### PR TITLE
Allow users to create snapshots of their virtual machines

### DIFF
--- a/salt/cloud/clouds/vsphere.py
+++ b/salt/cloud/clouds/vsphere.py
@@ -81,7 +81,7 @@ import salt.config as config
 # Attempt to import pysphere lib
 HAS_LIBS = False
 try:
-    from pysphere import VIServer, MORTypes
+    from pysphere import VIServer, MORTypes, VIException
     HAS_LIBS = True
 except Exception:  # pylint: disable=W0703
     pass
@@ -917,7 +917,7 @@ def create_snapshot(kwargs=None, call=None):
         ret['snapshot'] = kwargs['snapshot']
         ret['comment'] = 'Snapshot created'
         ret['result'] = True
-    except:
+    except VIException:
         log.error('Unable to create snapshot')
 
         ret['name'] = kwargs['name']

--- a/salt/cloud/clouds/vsphere.py
+++ b/salt/cloud/clouds/vsphere.py
@@ -867,3 +867,60 @@ def snapshot_list(kwargs=None, call=None):
             ret[vm]['snapshots'].append(snap.get_name())
 
     return ret
+
+
+def create_snapshot(kwargs=None, call=None):
+    '''
+    Create a snapshot
+
+    @name: Name of the virtual machine to snapshot
+    @snapshot: Name of the snapshot
+    @description: Description of the snapshot (optional)
+    @memory: Dump of the internal state of the virtual machine (optional)
+
+    CLI Example:
+
+    .. code-block:: bash
+
+       salt-cloud -f create_snapshot [PROVIDER] name=myvm.example.com snapshot=mysnapshot
+       salt-cloud -f create_snapshot [PROVIDER] name=myvm.example.com snapshot=mysnapshot description='My Snapshot' memory=True
+    '''
+    if call != 'function':
+        log.error(
+            'The show_keypair function must be called with -f or --function.'
+        )
+        return False
+
+    if not kwargs:
+        kwargs = {}
+
+    if 'name' not in kwargs or 'snapshot' not in kwargs:
+        log.error('name and snapshot are required arguments')
+        return False
+
+    ret = {}
+    conn = get_conn()
+
+    vm = conn.get_vm_by_name(kwargs['name'])
+
+    try:
+        log.info('Creating snapshot')
+        vm.create_snapshot(
+            kwargs['snapshot'],
+            kwargs.get('description', None),
+            kwargs.get('memory', False)
+        )
+
+        ret['name'] = kwargs['name']
+        ret['snapshot'] = kwargs['snapshot']
+        ret['comment'] = 'Snapshot created'
+        ret['result'] = True
+    except:
+        log.error('Unable to create snapshot')
+
+        ret['name'] = kwargs['name']
+        ret['snapshot'] = kwargs['snapshot']
+        ret['comment'] = 'Failed to create snapshot'
+        ret['result'] = False
+
+    return ret

--- a/salt/cloud/clouds/vsphere.py
+++ b/salt/cloud/clouds/vsphere.py
@@ -878,6 +878,8 @@ def create_snapshot(kwargs=None, call=None):
     @description: Description of the snapshot (optional)
     @memory: Dump of the internal state of the virtual machine (optional)
 
+    .. versionadded:: Beryllium
+
     CLI Example:
 
     .. code-block:: bash


### PR DESCRIPTION
``` bash
$ salt-cloud -f create_snapshot cs name=myvm snapshot=mysnapshot description='Testing Snapshot'
[INFO    ] salt-cloud starting
[INFO    ] Creating snapshot
cs:
    ----------
    vsphere:
        ----------
        comment:
            Snapshot created
        name:
            myvm
        result:
            True
        snapshot:
            mysnapshot
```
