### PR TITLE
fix #21397 - force glibc to re-read resolv.conf

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -102,7 +102,7 @@ try:
     libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("c"))
     res_init = libc.__res_init
     HAS_RESINIT = True
-except:
+except (ImportError, OSError, AttributeError):
     HAS_RESINIT = False
 
 # Import salt libs

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -527,9 +527,9 @@ def dns_check(addr, safe=False, ipv6=False):
     '''
     error = False
     try:
-	# issue #21397: force glibc to re-read resolv.conf
-	if HAS_RESINIT:
-	    res_init()
+        # issue #21397: force glibc to re-read resolv.conf
+        if HAS_RESINIT:
+            res_init()
         hostnames = socket.getaddrinfo(
             addr, None, socket.AF_UNSPEC, socket.SOCK_STREAM
         )

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -96,6 +96,15 @@ try:
 except ImportError:
     HAS_SETPROCTITLE = False
 
+try:
+    import ctypes
+    import ctypes.util
+    libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("c"))
+    res_init = libc.__res_init
+    HAS_RESINIT = True
+except:
+    HAS_RESINIT = False
+
 # Import salt libs
 import salt._compat
 import salt.exitcodes
@@ -518,6 +527,9 @@ def dns_check(addr, safe=False, ipv6=False):
     '''
     error = False
     try:
+	# issue #21397: force glibc to re-read resolv.conf
+	if HAS_RESINIT:
+	    res_init()
         hostnames = socket.getaddrinfo(
             addr, None, socket.AF_UNSPEC, socket.SOCK_STREAM
         )


### PR DESCRIPTION
This addresses #21397 by using res_init() to force glibc to re-read the resolv.conf and pick up any changes so that the minion can correctly resolve the IP of the master even if the resolv.conf was in a broken state when the minion was started.
