### PR TITLE
use port 445 instead of port 22 when bootstrapping windows

### DIFF
--- a/doc/topics/cloud/windows.rst
+++ b/doc/topics/cloud/windows.rst
@@ -88,6 +88,7 @@ Setting the installer in ``/etc/salt/cloud.providers``:
       win_installer: /root/Salt-Minion-2014.7.0-AMD64-Setup.exe
       win_username: Administrator
       win_password: letmein
+      smb_port: 445
 
 The default Windows user is `Administrator`, and the default Windows password
 is blank.

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -421,6 +421,9 @@ def bootstrap(vm_, opts):
         'win_installer', vm_, opts
     )
     if win_installer:
+        deploy_kwargs['port'] = salt.config.get_cloud_config_value(
+            'smb_port', vm_, opts, default=445
+        )
         deploy_kwargs['win_installer'] = win_installer
         minion = salt.utils.cloud.minion_config(opts, vm_)
         deploy_kwargs['master'] = minion['master']


### PR DESCRIPTION
deploy_kwargs get default port 22 or ssh_port there for cloud bootstrapping fails without ssh_port=445 in the profile
make sense to use default port 445 and allow profile override with 'smb_port' parameter (following ssh_port convention)
