### PR TITLE
Icehouse Keystone may raise AuthorizationFailure instead of Unauthorized

### DIFF
--- a/salt/modules/keystone.py
+++ b/salt/modules/keystone.py
@@ -817,7 +817,8 @@ def user_verify_password(user_id=None, name=None, password=None,
               'auth_url': auth_url}
     try:
         userauth = client.Client(**kwargs)
-    except keystoneclient.exceptions.Unauthorized:
+    except (keystoneclient.exceptions.Unauthorized,
+            keystoneclient.exceptions.AuthorizationFailure):
         return False
     return True
 


### PR DESCRIPTION
Hi,

I'm seeing this exception on the OpenStack controller in my testbed:

```
2015-03-26 14:06:18,667 [salt.state       ][ERROR   ] An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1531, in call
    **cdata['kwargs'])
  File "/usr/lib/python2.7/dist-packages/salt/states/keystone.py", line 164, in user_present
    **connection_args):
  File "/usr/lib/python2.7/dist-packages/salt/modules/keystone.py", line 819, in user_verify_password
    userauth = client.Client(**kwargs)
  File "/usr/lib/python2.7/dist-packages/keystoneclient/v2_0/client.py", line 144, in __init__
    self.authenticate()
  File "/usr/lib/python2.7/dist-packages/keystoneclient/utils.py", line 318, in inner
    return func(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/keystoneclient/httpclient.py", line 392, in authenticate
    resp = self.get_raw_token_from_identity_service(**kwargs)
  File "/usr/lib/python2.7/dist-packages/keystoneclient/v2_0/client.py", line 179, in get_raw_token_from_identity_service
    "%s" % e)
AuthorizationFailure: Authorization Failed: A username and password or token is required.
```

I'm working with OpenStack Icehouse for months. At some minor update to Keystone in 
OpenStack Icehouse not too long ago they've changed the exception raised by the 
`keystoneclient` module. 
Thus my state for the service user for Nova started to fail on every consecutive run.
Making the function return `False` on AuthorizationFailure, too, fixes the issue.

Btw: The problem seems to be present in the "2015.2" and the "develop" branche, too.

Regards, Florian
