### PR TITLE
import salt.ext.six as six like main file.py

### DIFF
--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -30,6 +30,7 @@ import fileinput  # do not remove, used in imported file.py functions
 import fnmatch  # do not remove, used in imported file.py functions
 from salt.ext.six import string_types  # do not remove, used in imported file.py functions
 # do not remove, used in imported file.py functions
+import salt.ext.six as six  # pylint: disable=import-error,no-name-in-module
 from salt.ext.six.moves.urllib.parse import urlparse as _urlparse  # pylint: disable=import-error,no-name-in-module
 import salt.utils.atomicfile  # do not remove, used in imported file.py functions
 from salt.exceptions import CommandExecutionError, SaltInvocationError


### PR DESCRIPTION
The imported functions in win_file.py needs this. We must import
in win_file.py because importing it in the originating file.py
doesn't follow when we import the functions from file.py

Fixes #21884 
