### PR TITLE
remove default prefix of '-' in archive.tar and archive.cmd_unzip

### DIFF
--- a/doc/topics/releases/beryllium.rst
+++ b/doc/topics/releases/beryllium.rst
@@ -12,4 +12,17 @@ Core Changes
 JBoss 7 State
 =============
 
-- Remove unused argument ``timeout`` in jboss7.status
+Remove unused argument ``timeout`` in jboss7.status.
+
+Archive Module
+==============
+
+In the ``archive.tar`` and ``archive.cmd_unzip`` module functions, remove the
+arbitrary prefixing of the options string with ``-``.  An options string
+beginning with a ``--long-option``, would have uncharacteristically needed its
+first ``-`` removed under the former scheme.
+
+Also, tar will parse its options differently if short options are used with or
+without a preceding ``-``, so it is better to not confuse the user into
+thinking they're using the non- ``-`` format, when really they are using the
+with- ``-`` format.

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -56,6 +56,17 @@ def tar(options, tarfile, sources=None, dest=None,
     options
         Options to pass to the tar command
 
+        .. versionchanged:: Beryllium
+
+            The mandatory `-` prefixing has been removed.  An options string
+            beginning with a `--long-option`, would have uncharacteristically
+            needed its first `-` removed under the former scheme.
+
+            Also, tar will parse its options differently if short options are
+            used with or without a preceding `-`, so it is better to not
+            confuse the user into thinking they're using the non-`-` format,
+            when really they are using the with-`-` format.
+
     tarfile
         The filename of the tar archive to pack/unpack
 
@@ -77,14 +88,14 @@ def tar(options, tarfile, sources=None, dest=None,
 
         .. code-block:: bash
 
-            salt '*' archive.tar cjvf /tmp/salt.tar.bz2 {{grains.saltpath}} template=jinja
+            salt '*' archive.tar -cjvf /tmp/salt.tar.bz2 {{grains.saltpath}} template=jinja
 
     CLI Examples:
 
     .. code-block:: bash
 
         # Create a tarfile
-        salt '*' archive.tar cjvf /tmp/tarfile.tar.bz2 /tmp/file_1,/tmp/file_2
+        salt '*' archive.tar -cjvf /tmp/tarfile.tar.bz2 /tmp/file_1,/tmp/file_2
         # Unpack a tarfile
         salt '*' archive.tar xf foo.tar dest=/target/directory
     '''
@@ -101,10 +112,9 @@ def tar(options, tarfile, sources=None, dest=None,
     if dest:
         cmd.extend(['-C', '{0}'.format(dest)])
 
-    if not options.startswith('-'):
-        options = '-{0}'.format(options)
+    if options:
+        cmd.extend(options.split())
 
-    cmd.extend(options.split(" "))
     cmd.extend(['{0}'.format(tarfile)])
 
     if sources is not None:
@@ -409,15 +419,17 @@ def cmd_unzip(zip_file, dest, excludes=None,
     options : None
         Additional command-line options to pass to the ``unzip`` binary.
 
+        .. versionchanged:: Beryllium
+
+            The mandatory `-` prefixing has been removed.  An options string
+            beginning with a `--long-option`, would have uncharacteristically
+            needed its first `-` removed under the former scheme.
+
     runas : None
         Unpack the zip file as the specified user. Defaults to the user under
         which the minion is running.
 
         .. versionadded:: 2015.2.0
-
-    options : None
-        Additional command-line options to pass to the ``unzip`` binary.
-
 
     CLI Example:
 
@@ -432,14 +444,7 @@ def cmd_unzip(zip_file, dest, excludes=None,
 
     cmd = ['unzip']
     if options:
-        try:
-            if not options.startswith('-'):
-                options = '-{0}'.format(options)
-        except AttributeError:
-            raise SaltInvocationError(
-                'Invalid option(s): {0}'.format(options)
-            )
-        cmd.append(options)
+        cmd.extend(options.split())
     cmd.extend(['{0}'.format(zip_file), '-d', '{0}'.format(dest)])
 
     if excludes is not None:

--- a/tests/unit/modules/archive_test.py
+++ b/tests/unit/modules/archive_test.py
@@ -47,7 +47,7 @@ class ArchiveTestCase(TestCase):
         mock = MagicMock(return_value='salt')
         with patch.dict(archive.__salt__, {'cmd.run': mock}):
             ret = archive.tar(
-                'zcvf', 'foo.tar',
+                '-zcvf', 'foo.tar',
                 ['/tmp/something-to-compress-1',
                  '/tmp/something-to-compress-2'],
                 template=None
@@ -62,7 +62,7 @@ class ArchiveTestCase(TestCase):
         mock = MagicMock(return_value='salt')
         with patch.dict(archive.__salt__, {'cmd.run': mock}):
             ret = archive.tar(
-                'zcvf', 'foo.tar',
+                '-zcvf', 'foo.tar',
                 '/tmp/something-to-compress-1,/tmp/something-to-compress-2',
                 template=None
             )
@@ -222,7 +222,7 @@ class ArchiveTestCase(TestCase):
                 '/tmp/dest',
                 excludes='/tmp/tmpePe8yO,/tmp/tmpLeSw1A',
                 template='jinja',
-                options='fo'
+                options='-fo'
             )
             self.assertEqual(['salt'], ret)
             mock.assert_called_once_with(
@@ -238,7 +238,7 @@ class ArchiveTestCase(TestCase):
                 '/tmp/dest',
                 excludes=['/tmp/tmpePe8yO', '/tmp/tmpLeSw1A'],
                 template='jinja',
-                options='fo'
+                options='-fo'
             )
             self.assertEqual(['salt'], ret)
             mock.assert_called_once_with(


### PR DESCRIPTION
Related to #21995.  An options string beginning with a `--long-option`,
would have uncharacteristically needed its first `-` removed under the
former scheme.

Also, tar will parse its options differently if short options are used
with or without a preceding `-`, so it is better to not confuse the user
into thinking they're using the non-`-` format, when really they are
using the with-`-` format.
