### PR TITLE
Pass opts in as pub_data to salt-run jobs

### DIFF
--- a/salt/runner.py
+++ b/salt/runner.py
@@ -139,6 +139,7 @@ class Runner(RunnerClient):
                 args, kwargs = salt.minion.load_args_and_kwargs(
                     self.functions[low['fun']],
                     salt.utils.args.parse_input(self.opts['arg']),
+                    self.opts,
                 )
                 low['args'] = args
                 low['kwargs'] = kwargs


### PR DESCRIPTION
Fixes regression in undocumented/untested feature of runners :)
