### PR TITLE
Fix bug introduced in a428023d89155e10f71f80d56d7b46ab0ab2a140

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -287,14 +287,15 @@ def ext_pillar(minion_id,
 
     # environment is "different" from the branch
     branch, _, environment = branch_env.partition(':')
+
+    gitpil = GitPillar(branch, repo_location, __opts__)
+    branch = gitpil.branch
+
     if environment == '':
         if branch == 'master':
             environment = 'base'
         else:
             environment = branch
-
-    gitpil = GitPillar(branch, repo_location, __opts__)
-    branch = gitpil.branch
 
     # normpath is needed to remove appended '/' if root is empty string.
     pillar_dir = os.path.normpath(os.path.join(gitpil.working_dir, root))


### PR DESCRIPTION
The branch must be used _after_ possibly modified in GitPillar()
