### PR TITLE
Add back functions to client loader

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -134,8 +134,8 @@ class LocalClient(object):
                 self.opts['transport'],
                 opts=self.opts,
                 listen=not self.opts.get('__worker', False))
-
-        self.returners = salt.loader.returners(self.opts, {})
+        self.functions = salt.loader.minion_mods(self.opts)
+        self.returners = salt.loader.returners(self.opts, self.functions)
 
     def __read_master_key(self):
         '''


### PR DESCRIPTION
Since it is all lazy loaded now this should be safe, should fix bugs with cassandra returner.
merge only with approval from @ckochenower 
