### PR TITLE
Fix requisites missing from pyobjects that were introduced in 2014.7

### DIFF
--- a/salt/utils/pyobjects.py
+++ b/salt/utils/pyobjects.py
@@ -10,7 +10,7 @@ import logging
 
 from salt.utils.odict import OrderedDict
 
-REQUISITES = ('listen', 'require', 'watch', 'use', 'listen_in', 'require_in', 'watch_in', 'use_in')
+REQUISITES = ('listen', 'onchanges', 'onfail', 'require', 'watch', 'use', 'listen_in', 'onchanges_in', 'onfail_in', 'require_in', 'watch_in', 'use_in')
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
This fixes #20652, @tomashavlas added the fix to develop in 27868d6 but it wasn't ever backported to 2014.7.

This should definitely be added to the next 2014.7 & 2015.2 releases.  Do you need me to submit a PR for 2015.2?
