### PR TITLE
[2015.2] Default to python_shell=True for cmd.run direct remote execution calls

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -611,6 +611,9 @@ def run(cmd,
         salt '*' cmd.run cmd='sed -e s/=/:/g'
     '''
     try:
+        if '__pub_jid' in kwargs and kwargs['__pub_jid'] \
+                                 and python_shell is None:
+            python_shell = True
         if __opts__.get('cmd_safe', True) is False and python_shell is None:
             # Override-switch for python_shell
             python_shell = True
@@ -805,6 +808,9 @@ def run_stdout(cmd,
         salt '*' cmd.run_stdout "grep f" stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
     try:
+        if '__pub_jid' in kwargs and kwargs['__pub_jid'] \
+                                 and python_shell is None:
+            python_shell = True
         if __opts__.get('cmd_safe', True) is False and python_shell is None:
             # Override-switch for python_shell
             python_shell = True
@@ -893,6 +899,9 @@ def run_stderr(cmd,
         salt '*' cmd.run_stderr "grep f" stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
     try:
+        if '__pub_jid' in kwargs and kwargs['__pub_jid'] \
+                                 and python_shell is None:
+            python_shell = True
         if __opts__.get('cmd_safe', True) is False and python_shell is None:
             # Override-switch for python_shell
             python_shell = True
@@ -981,6 +990,9 @@ def run_all(cmd,
         salt '*' cmd.run_all "grep f" stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
     try:
+        if '__pub_jid' in kwargs and kwargs['__pub_jid'] \
+                                 and python_shell is None:
+            python_shell = True
         if __opts__.get('cmd_safe', True) is False and python_shell is None:
             # Override-switch for python_shell
             python_shell = True
@@ -1188,6 +1200,9 @@ def script(source,
         salt '*' cmd.script salt://scripts/runme.sh stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
     try:
+        if '__pub_jid' in kwargs and kwargs['__pub_jid'] \
+                                 and python_shell is None:
+            python_shell = True
         if __opts__.get('cmd_safe', True) is False and python_shell is None:
             # Override-switch for python_shell
             python_shell = True
@@ -1301,6 +1316,9 @@ def script_retcode(source,
         salt '*' cmd.script_retcode salt://scripts/runme.sh stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
     try:
+        if '__pub_jid' in kwargs and kwargs['__pub_jid'] \
+                                 and python_shell is None:
+            python_shell = True
         if __opts__.get('cmd_safe', True) is False and python_shell is None:
             # Override-switch for python_shell
             python_shell = True

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -611,6 +611,8 @@ def run(cmd,
         salt '*' cmd.run cmd='sed -e s/=/:/g'
     '''
     try:
+        # Default to python_shell=True when run directly from remote execution
+        # system. Cross-module calls won't have a jid.
         if '__pub_jid' in kwargs and kwargs['__pub_jid'] \
                                  and python_shell is None:
             python_shell = True
@@ -808,6 +810,8 @@ def run_stdout(cmd,
         salt '*' cmd.run_stdout "grep f" stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
     try:
+        # Default to python_shell=True when run directly from remote execution
+        # system. Cross-module calls won't have a jid.
         if '__pub_jid' in kwargs and kwargs['__pub_jid'] \
                                  and python_shell is None:
             python_shell = True
@@ -899,6 +903,8 @@ def run_stderr(cmd,
         salt '*' cmd.run_stderr "grep f" stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
     try:
+        # Default to python_shell=True when run directly from remote execution
+        # system. Cross-module calls won't have a jid.
         if '__pub_jid' in kwargs and kwargs['__pub_jid'] \
                                  and python_shell is None:
             python_shell = True
@@ -990,6 +996,8 @@ def run_all(cmd,
         salt '*' cmd.run_all "grep f" stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
     try:
+        # Default to python_shell=True when run directly from remote execution
+        # system. Cross-module calls won't have a jid.
         if '__pub_jid' in kwargs and kwargs['__pub_jid'] \
                                  and python_shell is None:
             python_shell = True
@@ -1200,6 +1208,8 @@ def script(source,
         salt '*' cmd.script salt://scripts/runme.sh stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
     try:
+        # Default to python_shell=True when run directly from remote execution
+        # system. Cross-module calls won't have a jid.
         if '__pub_jid' in kwargs and kwargs['__pub_jid'] \
                                  and python_shell is None:
             python_shell = True
@@ -1316,6 +1326,8 @@ def script_retcode(source,
         salt '*' cmd.script_retcode salt://scripts/runme.sh stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
     try:
+        # Default to python_shell=True when run directly from remote execution
+        # system. Cross-module calls won't have a jid.
         if '__pub_jid' in kwargs and kwargs['__pub_jid'] \
                                  and python_shell is None:
             python_shell = True

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -54,6 +54,23 @@ def __virtual__():
     return __virtualname__
 
 
+def _python_shell_default(python_shell, __pub_jid):
+    '''
+    Set python_shell default based on remote execution and __opts__['cmd_safe']
+    '''
+    try:
+        # Default to python_shell=True when run directly from remote execution
+        # system. Cross-module calls won't have a jid.
+        if __pub_jid and python_shell is None:
+            return True
+        elif __opts__.get('cmd_safe', True) is False and python_shell is None:
+            # Override-switch for python_shell
+            return True
+    except NameError:
+        pass
+    return python_shell
+
+
 def _chroot_pids(chroot):
     pids = []
     for root in glob.glob('/proc/[0-9]*/root'):
@@ -610,17 +627,8 @@ def run(cmd,
 
         salt '*' cmd.run cmd='sed -e s/=/:/g'
     '''
-    try:
-        # Default to python_shell=True when run directly from remote execution
-        # system. Cross-module calls won't have a jid.
-        if '__pub_jid' in kwargs and kwargs['__pub_jid'] \
-                                 and python_shell is None:
-            python_shell = True
-        if __opts__.get('cmd_safe', True) is False and python_shell is None:
-            # Override-switch for python_shell
-            python_shell = True
-    except NameError:
-        pass
+    python_shell = _python_shell_default(python_shell,
+                                         kwargs.get('__pub_jid', ''))
     ret = _run(cmd,
                runas=runas,
                shell=shell,
@@ -809,17 +817,8 @@ def run_stdout(cmd,
 
         salt '*' cmd.run_stdout "grep f" stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
-    try:
-        # Default to python_shell=True when run directly from remote execution
-        # system. Cross-module calls won't have a jid.
-        if '__pub_jid' in kwargs and kwargs['__pub_jid'] \
-                                 and python_shell is None:
-            python_shell = True
-        if __opts__.get('cmd_safe', True) is False and python_shell is None:
-            # Override-switch for python_shell
-            python_shell = True
-    except NameError:
-        pass
+    python_shell = _python_shell_default(python_shell,
+                                         kwargs.get('__pub_jid', ''))
     ret = _run(cmd,
                runas=runas,
                cwd=cwd,
@@ -902,17 +901,8 @@ def run_stderr(cmd,
 
         salt '*' cmd.run_stderr "grep f" stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
-    try:
-        # Default to python_shell=True when run directly from remote execution
-        # system. Cross-module calls won't have a jid.
-        if '__pub_jid' in kwargs and kwargs['__pub_jid'] \
-                                 and python_shell is None:
-            python_shell = True
-        if __opts__.get('cmd_safe', True) is False and python_shell is None:
-            # Override-switch for python_shell
-            python_shell = True
-    except NameError:
-        pass
+    python_shell = _python_shell_default(python_shell,
+                                         kwargs.get('__pub_jid', ''))
     ret = _run(cmd,
                runas=runas,
                cwd=cwd,
@@ -995,17 +985,8 @@ def run_all(cmd,
 
         salt '*' cmd.run_all "grep f" stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
-    try:
-        # Default to python_shell=True when run directly from remote execution
-        # system. Cross-module calls won't have a jid.
-        if '__pub_jid' in kwargs and kwargs['__pub_jid'] \
-                                 and python_shell is None:
-            python_shell = True
-        if __opts__.get('cmd_safe', True) is False and python_shell is None:
-            # Override-switch for python_shell
-            python_shell = True
-    except NameError:
-        pass
+    python_shell = _python_shell_default(python_shell,
+                                         kwargs.get('__pub_jid', ''))
     ret = _run(cmd,
                runas=runas,
                cwd=cwd,
@@ -1207,17 +1188,8 @@ def script(source,
 
         salt '*' cmd.script salt://scripts/runme.sh stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
-    try:
-        # Default to python_shell=True when run directly from remote execution
-        # system. Cross-module calls won't have a jid.
-        if '__pub_jid' in kwargs and kwargs['__pub_jid'] \
-                                 and python_shell is None:
-            python_shell = True
-        if __opts__.get('cmd_safe', True) is False and python_shell is None:
-            # Override-switch for python_shell
-            python_shell = True
-    except NameError:
-        pass
+    python_shell = _python_shell_default(python_shell,
+                                         kwargs.get('__pub_jid', ''))
 
     def _cleanup_tempfile(path):
         try:
@@ -1325,17 +1297,8 @@ def script_retcode(source,
 
         salt '*' cmd.script_retcode salt://scripts/runme.sh stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
-    try:
-        # Default to python_shell=True when run directly from remote execution
-        # system. Cross-module calls won't have a jid.
-        if '__pub_jid' in kwargs and kwargs['__pub_jid'] \
-                                 and python_shell is None:
-            python_shell = True
-        if __opts__.get('cmd_safe', True) is False and python_shell is None:
-            # Override-switch for python_shell
-            python_shell = True
-    except NameError:
-        pass
+    python_shell = _python_shell_default(python_shell,
+                                         kwargs.get('__pub_jid', ''))
     if isinstance(__env__, string_types):
         salt.utils.warn_until(
             'Boron',


### PR DESCRIPTION
Cross-module calls won't have a jid, so this will allow shellisms with cmd.run on the command line.
