### PR TITLE
[2015.2] Alias `cmd.run` to `cmd.shell` in templates (python_shell=True)

### DIFF
--- a/salt/client/ssh/wrapper/__init__.py
+++ b/salt/client/ssh/wrapper/__init__.py
@@ -144,3 +144,12 @@ class FunctionWrapper(object):
         # We save it as an alias and then can return it when referenced
         # later in __getitem__
         self.aliases[cmd] = value
+
+    def get(self, cmd, default):
+        '''
+        Mirrors behavior of dict.get
+        '''
+        if cmd in self:
+            return self[cmd]
+        else:
+            return default

--- a/salt/client/ssh/wrapper/__init__.py
+++ b/salt/client/ssh/wrapper/__init__.py
@@ -43,7 +43,7 @@ class FunctionWrapper(object):
         self.fsclient = fsclient
         self.kwargs.update(kwargs)
         self.aliases = aliases
-        if self.alises is None:
+        if self.aliases is None:
             self.aliases = {}
 
     def __contains__(self, key):

--- a/salt/client/ssh/wrapper/__init__.py
+++ b/salt/client/ssh/wrapper/__init__.py
@@ -31,6 +31,7 @@ class FunctionWrapper(object):
             mods=None,
             fsclient=None,
             cmd_prefix=None,
+            aliases=None,
             **kwargs):
         super(FunctionWrapper, self).__init__()
         self.cmd_prefix = cmd_prefix
@@ -41,7 +42,9 @@ class FunctionWrapper(object):
                        'host': host}
         self.fsclient = fsclient
         self.kwargs.update(kwargs)
-        self.aliases = {}
+        self.aliases = aliases
+        if self.alises is None:
+            self.aliases = {}
 
     def __contains__(self, key):
         '''
@@ -74,6 +77,7 @@ class FunctionWrapper(object):
                                    mods=self.mods,
                                    fsclient=self.fsclient,
                                    cmd_prefix=cmd,
+                                   aliases=self.aliases,
                                    **kwargs)
 
         if self.cmd_prefix:

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -737,7 +737,7 @@ def shell(cmd,
 
         salt '*' cmd.shell cmd='sed -e s/=/:/g'
     '''
-    if python_shell in kwargs:
+    if 'python_shell' in kwargs:
         python_shell = kwargs.pop('python_shell')
     else:
         python_shell = True

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -737,6 +737,10 @@ def shell(cmd,
 
         salt '*' cmd.shell cmd='sed -e s/=/:/g'
     '''
+    if python_shell in kwargs:
+        python_shell = kwargs.pop('python_shell')
+    else:
+        python_shell = True
     return run(cmd,
         cwd=cwd,
         stdin=stdin,
@@ -754,7 +758,7 @@ def shell(cmd,
         ignore_retcode=ignore_retcode,
         saltenv=saltenv,
         use_vt=use_vt,
-        python_shell=True,
+        python_shell=python_shell,
         **kwargs)
 
 

--- a/salt/renderers/jinja.py
+++ b/salt/renderers/jinja.py
@@ -291,6 +291,11 @@ def _split_module_dicts():
     if not isinstance(__salt__, dict):
         return __salt__
     mod_dict = dict(__salt__)
+
+    # Alias cmd.run to cmd.shell to make python_shell=True the default for
+    # jinja calls
+    mod_dict['cmd.run'] = mod_dict['cmd.shell']
+
     for module_func_name, mod_fun in mod_dict.items():
         mod, fun = module_func_name.split('.', 1)
         if mod not in mod_dict:

--- a/salt/renderers/jinja.py
+++ b/salt/renderers/jinja.py
@@ -291,7 +291,6 @@ def _split_module_dicts():
     if not isinstance(__salt__, dict):
         return __salt__
     mod_dict = dict(__salt__)
-
     for module_func_name, mod_fun in mod_dict.items():
         mod, fun = module_func_name.split('.', 1)
         if mod not in mod_dict:

--- a/salt/renderers/jinja.py
+++ b/salt/renderers/jinja.py
@@ -292,10 +292,6 @@ def _split_module_dicts():
         return __salt__
     mod_dict = dict(__salt__)
 
-    # Alias cmd.run to cmd.shell to make python_shell=True the default for
-    # jinja calls
-    mod_dict['cmd.run'] = mod_dict['cmd.shell']
-
     for module_func_name, mod_fun in mod_dict.items():
         mod, fun = module_func_name.split('.', 1)
         if mod not in mod_dict:

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -54,6 +54,15 @@ def wrap_tmpl_func(render_str):
         if context is None:
             context = {}
 
+        # Alias cmd.run to cmd.shell to make python_shell=True the default for
+        # templated calls
+        if 'salt' in kws:
+            if 'cmd.run' in kws['salt'] and 'cmd.shell' in kws['salt']:
+                kws['salt']['cmd.run'] = kws['salt']['cmd.shell']
+            if 'run' in kws['salt'].get('cmd', {}) \
+                    and 'shell' in kws['salt'].get('cmd', {}):
+                kws['salt']['cmd']['run'] = kws['salt']['cmd']['shell']
+
         # We want explicit context to overwrite the **kws
         kws.update(context)
         context = kws

--- a/tests/integration/cli/custom_module.py
+++ b/tests/integration/cli/custom_module.py
@@ -69,7 +69,10 @@ class SSHCustomModuleTest(integration.SSHCase):
             "module_|-custom-module_|-test.recho_|-run": 'olleh'}
         cmd = self.run_function('state.sls', arg=['custom_module'])
         for key in cmd:
-            if not cmd[key]['result']:
+            if not isinstance(cmd, dict) or not isinstance(cmd[key], dict):
+                raise AssertionError('{0} is not a proper state return'
+                                     .format(cmd))
+            elif not cmd[key]['result']:
                 raise AssertionError(cmd[key]['comment'])
             cmd_ret = cmd[key]['changes'].get('ret', None)
             self.assertEqual(cmd_ret, expected[key])


### PR DESCRIPTION
Includes some new functionality to FunctionWrapper in salt-ssh to make this possible.
