### PR TITLE
Fix a bug with the implicit list handling in pyobjects requisites

### DIFF
--- a/salt/utils/pyobjects.py
+++ b/salt/utils/pyobjects.py
@@ -204,6 +204,16 @@ class State(object):
         self.id_ = id_
         self.module = module
         self.func = func
+
+        # our requisites should all be lists, but when you only have a
+        # single item it's more convenient to provide it without
+        # wrapping it in a list. transform them into a list
+        for attr in REQUISITES:
+            if attr in kwargs:
+                try:
+                    iter(kwargs[attr])
+                except TypeError:
+                    kwargs[attr] = [kwargs[attr]]
         self.kwargs = kwargs
 
         if isinstance(self.id_, StateExtend):
@@ -221,12 +231,6 @@ class State(object):
         # handle our requisites
         for attr in REQUISITES:
             if attr in kwargs:
-                # our requisites should all be lists, but when you only have a
-                # single item it's more convenient to provide it without
-                # wrapping it in a list. transform them into a list
-                if not isinstance(kwargs[attr], list):
-                    kwargs[attr] = [kwargs[attr]]
-
                 # rebuild the requisite list transforming any of the actual
                 # StateRequisite objects into their representative dict
                 kwargs[attr] = [


### PR DESCRIPTION
When specifying a requisite and you only need to list a single item you can specify it without being wrapped in a list and we will handle it automatically.  This was being handled when we built our attrs to output the final data, but this failed when you extended a require requisite inside of a context manager.

This can be safely merged forward to 2015.2 as well.
