### PR TITLE
Fixing KeyError when there are no additional pages

### DIFF
--- a/salt/cloud/clouds/digital_ocean_v2.py
+++ b/salt/cloud/clouds/digital_ocean_v2.py
@@ -195,7 +195,10 @@ def list_nodes_full(call=None, forOutput=True):
                     value = str(value)
                 ret[node['name']][item] = value
         page += 1
-        fetch = 'next' in items['links']['pages']
+        try:
+            fetch = 'next' in items['links']['pages']
+        except KeyError:
+            fetch = False
     return ret
 
 

--- a/salt/cloud/clouds/digital_ocean_v2.py
+++ b/salt/cloud/clouds/digital_ocean_v2.py
@@ -115,7 +115,10 @@ def avail_images(call=None):
                 ret[image['id']][item] = str(image[item])
 
         page += 1
-        fetch = 'next' in items['links']['pages']
+        try:
+            fetch = 'next' in items['links']['pages']
+        except KeyError:
+            fetch = False
 
     return ret
 

--- a/salt/cloud/clouds/digital_ocean_v2.py
+++ b/salt/cloud/clouds/digital_ocean_v2.py
@@ -164,7 +164,11 @@ def list_nodes(call=None):
                 'state': str(node['status']),
             }
         page += 1
-        fetch = 'next' in items['links']['pages']
+        try:
+            fetch = 'next' in items['links']['pages']
+        except KeyError:
+            fetch = False
+
     return ret
 
 

--- a/salt/cloud/clouds/digital_ocean_v2.py
+++ b/salt/cloud/clouds/digital_ocean_v2.py
@@ -582,7 +582,7 @@ def query(method='droplets', droplet_id=None, command=None, args=None, http_meth
             'An error occurred while querying DigitalOcean. HTTP Code: {0}  '
             'Error: {1!r}'.format(
                 request.status_code,
-                #request.read()
+                # request.read()
                 request.text
             )
         )


### PR DESCRIPTION
When you have only one page you will get a KeyError

``` python
[ERROR   ] There was an error running the function: 'pages'
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/salt/cloud/cli.py", line 245, in run
    self.function_provider, self.function_name, kwargs
  File "/usr/lib/python2.6/site-packages/salt/cloud/__init__.py", line 1492, in do_function
    driver: self.clouds[fun](call='function')
  File "/usr/lib64/python2.6/contextlib.py", line 34, in __exit__
    self.gen.throw(type, value, traceback)
  File "/usr/lib/python2.6/site-packages/salt/utils/context.py", line 42, in func_globals_inject
    yield
  File "/usr/lib/python2.6/site-packages/salt/cloud/__init__.py", line 1492, in do_function
    driver: self.clouds[fun](call='function')
  File "/usr/lib/python2.6/site-packages/salt/cloud/clouds/digital_ocean_v2.py", line 167, in list_nodes
    fetch = 'next' in items['links']['pages']
KeyError: 'pages'
```
