### PR TITLE
Strip whitespace characters using strip() for pub key check

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1953,7 +1953,7 @@ class ClearFuncs(object):
 
         elif os.path.isfile(pubfn):
             # The key has been accepted, check it
-            if salt.utils.fopen(pubfn, 'r').read() != load['pub']:
+            if salt.utils.fopen(pubfn, 'r').read().strip() != load['pub'].strip():
                 log.error(
                     'Authentication attempt from {id} failed, the public '
                     'keys did not match. This may be an attempt to compromise '


### PR DESCRIPTION
Fixes #21910 

As per the issue thread discussion, I've verified that the performance of strip() (http://svn.python.org/view/python/trunk/Objects/stringobject.c?view=markup  line 1852) should not be a hindrance.
