### PR TITLE
fix #20841: add sls name from reactor

### DIFF
--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -602,10 +602,17 @@ class Reactor(multiprocessing.Process, salt.state.Compiler):
 
         for fn_ in glob.glob(glob_ref):
             try:
-                react.update(self.render_template(
+                res = self.render_template(
                     fn_,
                     tag=tag,
-                    data=data))
+                    data=data)
+
+                # for #20841, inject the sls name here since verify_high()
+                # assumes it exists in case there are any errors
+                for name in res:
+                    res[name]['__sls__'] = fn_
+
+                react.update(res)
             except Exception:
                 log.error('Failed to render "{0}"'.format(fn_))
         return react
@@ -656,15 +663,19 @@ class Reactor(multiprocessing.Process, salt.state.Compiler):
         log.debug('Compiling reactions for tag {0}'.format(tag))
         high = {}
         chunks = []
-        for fn_ in reactors:
-            high.update(self.render_reaction(fn_, tag, data))
-        if high:
-            errors = self.verify_high(high)
-            if errors:
-                log.error(('Unable to render reactions for event {0} due to '
-                           'errors ({1}) in one or more of the sls files ({2})').format(tag, errors, reactors))
-                return []  # We'll return nothing since there was an error
-            chunks = self.order_chunks(self.compile_high_data(high))
+        try:
+            for fn_ in reactors:
+                high.update(self.render_reaction(fn_, tag, data))
+            if high:
+                errors = self.verify_high(high)
+                if errors:
+                    log.error(('Unable to render reactions for event {0} due to '
+                               'errors ({1}) in one or more of the sls files ({2})').format(tag, errors, reactors))
+                    return []  # We'll return nothing since there was an error
+                chunks = self.order_chunks(self.compile_high_data(high))
+        except Exception as exc:
+            log.error('Exception trying to compile reactions: {0}'.format(exc), exc_info=True)
+
         return chunks
 
     def call_reactions(self, chunks):


### PR DESCRIPTION
This addresses #20841.  The verify_high() function in state.py assumes there are **sls** attributes in the body when it is generating error messages.  When the data is originally created from a reactor, that does not exist, so we inject the name of the reactor sls files so that verify_high() can properly generate error messages if it fails to compile.
