### PR TITLE
Fix custom Sphinx formatter for aliased functions

### DIFF
--- a/doc/_ext/saltautodoc.py
+++ b/doc/_ext/saltautodoc.py
@@ -40,4 +40,10 @@ class SaltFunctionDocumenter(FunctionDocumenter):
 
 
 def setup(app):
-    app.add_autodocumenter(SaltFunctionDocumenter)
+    def add_documenter(app, env, docnames):
+        app.add_autodocumenter(SaltFunctionDocumenter)
+
+    # add_autodocumenter() must be called after the initial setup and the
+    # 'builder-inited' event, as sphinx.ext.autosummary will restore the
+    # original documenter on 'builder-inited'
+    app.connect('env-before-read-docs', add_documenter)


### PR DESCRIPTION
As of today, aliased functions like `salt.states.alternatives.set()` [appear incorrectly](http://salt.readthedocs.org/en/v2014.7.0/ref/states/all/salt.states.alternatives.html#salt.states.alternatives.set_) in the docs, i.e. for example with the trailing underscore.

This is a regression of #7885: Since Sphinx 1.2.1 (commit sphinx-doc/sphinx@574a796), `sphinx.ext.autosummary` overwrites custom-set documenters.
It is not a particularly elegant solution, but still none of the events from `sphinx.ext.autodoc` allows editing a function's name. Subclassing other autodoc classes also appears to be quite challenging.
