### PR TITLE
Update environment variables.

### DIFF
--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -303,6 +303,18 @@ def check_user(user):
             os.setgid(pwuser.pw_gid)
             os.setuid(pwuser.pw_uid)
 
+            # We could just reset the whole environment but let's just override
+            # the variables we can get from pwuser
+            if 'HOME' in os.environ:
+                os.environ['HOME'] = pwuser.pw_dir
+
+            if 'SHELL' in os.environ:
+                os.environ['SHELL'] = pwuser.pw_shell
+
+            for envvar in ('USER', 'LOGNAME'):
+                if envvar in os.environ:
+                    os.environ[envvar] = pwuser.pw_name
+
         except OSError:
             msg = 'Salt configured to run as user "{0}" but unable to switch.'
             msg = msg.format(user)


### PR DESCRIPTION
When running salt as a user which is not root, I've found out that, at
least pygit2, misbehaves.

Salt correctly changes to the desired user, but the environment is the
same as the root user. `libgit2` takes advantage of environment
variables to load `.gitconfig` and because the environ is kept as the
root user, it fails to load it.

```
[ERROR   ] Exception caught while initializing gitfs remote /var/cache/salt/master/gitfs/e3971c3f4ffa91eb057d362f6bfb3683: Error stat'ing config file '/root/.gitconfig': /var/cache/salt/master/gitfs/e3971c3f4ffa91eb057d362f6bfb3683: Error stat'ing config file '/root/.gitconfig'
```
