### PR TITLE
Implement 'map' mode in LDAP pillar module

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -1809,6 +1809,8 @@ configuration is the same as :conf_master:`file_roots`:
 ``ext_pillar``
 --------------
 
+.. _master-configuration-ext-pillar:
+
 The ext_pillar option allows for any number of external pillar interfaces to be
 called when populating pillar data. The configuration is based on ext_pillar
 functions. The available ext_pillar functions can be found herein:

--- a/salt/pillar/pillar_ldap.py
+++ b/salt/pillar/pillar_ldap.py
@@ -2,12 +2,58 @@
 '''
 Use LDAP data as a Pillar source
 
-This pillar module parses a config file (specified in the salt master config),
-and executes a series of LDAP searches based on that config.  Data returned by
-these searches is aggregated, with data items found later in the LDAP search
-order overriding data found earlier on.
+This pillar module executes a series of LDAP searches.
+Data returned by these searches are aggregated, whereby data returned by later
+searches override data by previous searches with the same key.
 
-The final result set is merged with the pillar data.
+The final result is merged with existing pillar data.
+
+The configuration of this external pillar module is done via an external
+file which provides the actual configuration for the LDAP searches.
+
+===============================
+Configuring the LDAP ext_pillar
+===============================
+
+The basic configuration is part of the `master configuration
+<master-configuration-ext-pillar>`_.
+.. code-block:: yaml
+
+    ext_pillar:
+      - pillar_ldap: /etc/salt/master.d/pillar_ldap.yaml
+
+.. note::
+
+    When placing the file in the ``master.d`` directory, make sure its name
+    doesn't end in ``.conf``, otherwise the salt-master process will attempt
+    to parse its content.
+
+.. warning::
+
+    Make sure this file has very restrictive permissions, as it will contain
+    possibly sensitive LDAP credentials!
+
+The only required key in the master configuration is ``pillar_ldap`` pointing
+to a file containing the actual configuration.
+
+Configuring the LDAP searches
+=============================
+
+The file is processed using `Salt's Renderers <renderers>` which makes it
+possible to reference grains within the configuration.
+
+.. note::
+
+    The following example uses YAML as format for the configuration which
+    allows to shorten the configuration significantly by re-using a pre-defined
+    ``defaults`` block for each search definition.
+
+.. code-block:: yaml
+
+    ldap: &defaults
+    server: 
+
+
 '''
 
 # Import python libs

--- a/salt/pillar/pillar_ldap.py
+++ b/salt/pillar/pillar_ldap.py
@@ -51,7 +51,15 @@ possible to reference grains within the configuration.
 .. code-block:: yaml
 
     ldap: &defaults
-    server: 
+    server:    ldap.company.tld
+    port:      389
+    tls:       true
+    dn:        'dc=company,dc=tld
+    binddn:    'cn=salt-pillars,ou=users,dc=company,dc=tld'
+    bindpw:    bi7ieBai5Ano
+    referrals: false
+    anonymous: false
+
 
 
 '''

--- a/salt/pillar/pillar_ldap.py
+++ b/salt/pillar/pillar_ldap.py
@@ -49,15 +49,22 @@ possible to reference grains within the configuration.
     to trick the master into returning secret data.
     Use only the 'id' grain which is verified through the minion's key/cert.
 
-.. note::
+Map Mode
+--------
 
-    The following example uses YAML as format for the configuration which
-    allows to shorten the configuration significantly by re-using a pre-defined
-    ``defaults`` block for each search definition.
+The ``it-admins`` configuration below returns the Pillar ``it-admins`` by:
+
+- filtering for:
+    - members of the group ``it-admins``
+    - objects with ``objectclass=user``
+- returning the data of users (``mode: map``), where each user is a dictionary
+  containing the configured string or list attributes.
+
+  **Configuration:**
 
 .. code-block:: yaml
 
-    ldap: &defaults
+    salt-users:
         server:    ldap.company.tld
         port:      389
         tls:       true
@@ -66,18 +73,22 @@ possible to reference grains within the configuration.
         bindpw:    bi7ieBai5Ano
         referrals: false
         anonymous: false
+        mode: map
+        dn: 'ou=users,dc=company,dc=tld'
+        filter: '(&(memberof=cn=it-admins,ou=groups,dc=company,dc=tld)(objectclass=user))'
+        attrs:
+            - cn
+            - displayName
+            - givenName
+            - sn
+        lists:
+            - memberOf
 
-The ``salt-users`` configuration below returns the Pillar ``salt-users`` by:
-
-- filtering for:
-    - members of the group ``it-admins``
-    - objects with ``objectclass=user``
-- returning a list of users (``mode: list``), where each user is a dictionary
-  containing the configured string or list attributes:
+  **Result:**
 
 .. code-block:: yaml
 
-    pct-staff:
+    salt-users:
         - cn: cn=johndoe,ou=users,dc=company,dc=tld
           displayName: John Doe
           givenName:   John
@@ -93,22 +104,11 @@ The ``salt-users`` configuration below returns the Pillar ``salt-users`` by:
               - cn=it-admins,ou=groups,dc=company,dc=tld
               - cn=team02,ou=groups,dc=company
 
-.. code-block:: yaml
 
-    salt-users:
-        <<: *defaults
-        dn: 'ou=users,dc=company,dc=tld'
-        filter: '(&(memberof=cn=it-admins,ou=groups,dc=company,dc=tld)(objectclass=user))'
-        attrs:
-            - cn
-            - displayName
-            - givenName
-            - sn
-        lists:
-            - memberOf
+List Mode
+---------
 
-.. TODO: document the more obscure default modes (!= 'mode: list') where specially crafted
-         LDAP records are parsed by splitting the records based on equal signs (or so...?)
+TODO: see also `_result_to_dict()` documentation
 '''
 
 # Import python libs


### PR DESCRIPTION
The current mode of operation applied by the LDAP pillar module is rather obscure and requires specially crafted records in LDAP to be used as external Pillar data.

This PR implements a more sane/straightforward approach which works with regular existing LDAP records and doesn't require any changes to the LDAP schema.

See the documentation changes in the diff for details.
