### PR TITLE
Fix extraneous quote in loader error

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -699,11 +699,11 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             return '{0!r} is not available.'.format(function_name)
         else:
             if self.missing_modules.get(mod_name) is not None:
-                return '{0!r}\' __virtual__ returned False: {1}'.format(mod_name, self.missing_modules[mod_name])
+                return '\'{0}\' __virtual__ returned False: {1}'.format(mod_name, self.missing_modules[mod_name])
             elif self.missing_modules.get(mod_name) is None:
-                return '{0!r}\' __virtual__ returned False'.format(mod_name)
+                return '\'{0}\' __virtual__ returned False'.format(mod_name)
             else:
-                return '{0!r} is not available.'.format(function_name)
+                return '\'{0}\' is not available.'.format(function_name)
 
     def refresh_file_mapping(self):
         '''


### PR DESCRIPTION
Also got rid of raw string formatting, it should not be used as a means of
quoting a substring as it causes unicode errors in Python 3.
