### PR TITLE
Fix arguments passed to chef-solo command

### DIFF
--- a/salt/modules/chef.py
+++ b/salt/modules/chef.py
@@ -189,13 +189,11 @@ def solo(whyrun=False,
         Enable whyrun mode when set to True
     '''
     if logfile is None:
-        logfile = _default_logfile('chef-client'),
+        logfile = _default_logfile('chef-solo'),
     args = ['chef-solo',
             '--no-color',
             '--logfile "{0}"'.format(logfile),
             '--format doc']
-
-    args = ['chef-solo', '--no-color', '--logfile {0}'.format(logfile)]
 
     if whyrun:
         args.append('--why-run')


### PR DESCRIPTION
The chef.solo function was producing a stack trace. This fix addresses #21997
