### PR TITLE
Improves example illustrating SLS-to-Python mapping

### DIFF
--- a/doc/ref/states/writing.rst
+++ b/doc/ref/states/writing.rst
@@ -17,8 +17,7 @@ illustrate:
 .. code-block:: yaml
 
     /etc/salt/master: # maps to "name"
-      file: # maps to State module filename e.g. https://github.com/saltstack/salt/tree/develop/salt/states/file.py
-        - managed # maps to the managed function in the file State module
+      file.managed: # maps to <filename>.<function> - e.g. "managed" in https://github.com/saltstack/salt/tree/develop/salt/states/file.py
         - user: root # one of many options passed to the manage function
         - group: root
         - mode: 644


### PR DESCRIPTION
The example worked, but was confusing, because the options passed to "file.managed" were indented so they line up with the function itself, "managed". This makes it look like "file.managed" is being called, then "file.user", then "file.group", etc.
