### PR TITLE
Bugfix: Reactor missing import.

### DIFF
--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -10,6 +10,7 @@ import multiprocessing
 import yaml
 
 # Import salt libs
+import salt.runner
 import salt.state
 import salt.utils
 import salt.utils.cache


### PR DESCRIPTION
This missing import causes the Reactor not to fire in certain cases. This could be related with issue #21651.
