### PR TITLE
Boto VPC subnet state

### DIFF
--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -339,9 +339,9 @@ def create_subnet(vpc_id, cidr_block, availability_zone=None, subnet_name=None, 
         return False
 
 
-def delete_subnet(subnet_id, region=None, key=None, keyid=None, profile=None):
+def delete_subnet(name=None, subnet_id=None, region=None, key=None, keyid=None, profile=None):
     '''
-    Given a subnet ID, delete the subnet.
+    Given a subnet ID or name, delete the subnet.
 
     Returns True if the subnet was deleted and returns False if the subnet was not deleted.
 
@@ -356,6 +356,16 @@ def delete_subnet(subnet_id, region=None, key=None, keyid=None, profile=None):
     conn = _get_conn(region, key, keyid, profile)
     if not conn:
         return False
+
+    if not any((name, subnet_id)):
+        raise SaltInvocationError("Either name or subnet ID needs to be specified.")
+
+    if name:
+        subnets = describe_subnets(region=region, key=key, keyid=keyid, profile=profile)
+        for subnet in subnets:
+            if 'Name' in subnet['tags']:
+                if subnet['tags']['Name'] == name:
+                    subnet_id = subnet['id']
 
     try:
         if conn.delete_subnet(subnet_id):

--- a/salt/states/boto_vpc.py
+++ b/salt/states/boto_vpc.py
@@ -125,14 +125,81 @@ def present(name, cidr_block, instance_tenancy=None, dns_support=None,
     return ret
 
 
+def subnet_present(name, vpc_id, cidr_block, availability_zone=None, tags=None, region=None,
+                   key=None, keyid=None, profile=None):
+    '''
+    Ensure subnet exists.
+    .. versionadded:: 2014.7.3
+
+    name
+        Name of the subnet.
+
+    vpc_id
+        The ID of the VPC where you want to create the subnet.
+
+    cidr_block
+        The range of IPs in CIDR format, for example: 10.0.0.0/24. Block
+        size must be between /16 and /28 netmask.
+
+
+    availability_zone
+        The AZ you want the subnet in.
+
+    tags
+        A list of tags.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+    '''
+    ret = {'name': name,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    exists = __salt__['boto_vpc.subnet_exists'](name=name, cidr=cidr_block, zones=availability_zone,
+                                                tags=tags, region=region, key=key, keyid=keyid, profile=profile)
+    if not exists:
+        if __opts__['test']:
+            ret['comment'] = 'Subnet {0} is set to be created.'.format(name)
+            ret['result'] = None
+            return ret
+        created = __salt__['boto_vpc.create_subnet'](vpc_id, cidr_block, availability_zone, name,
+                                                     tags, region, key, keyid, profile)
+        if not created:
+            ret['result'] = False
+            ret['comment'] = 'Failed to create {0} subnet.'.format(name)
+            return ret
+        _describe = __salt__['boto_vpc.describe_subnets'](subnet_ids=[created], region=region, key=key, keyid=keyid,
+                                                          profile=profile)
+        ret['changes']['old'] = {'subnet': None}
+        ret['changes']['new'] = {'subnet': _describe}
+        ret['comment'] = 'Subnet {0} created.'.format(name)
+        return ret
+    ret['comment'] = 'Subnet present.'
+    return ret
+
+
 def absent(name, tags=None, region=None, key=None, keyid=None, profile=None):
     '''
     Ensure VPC with passed properties is absent.
 
     name
         Name of the VPC.
+
     tags
         A list of tags. All tags must match.
+
     region
         Region to connect to.
 
@@ -173,4 +240,54 @@ def absent(name, tags=None, region=None, key=None, keyid=None, profile=None):
     ret['changes']['old'] = {'vpc': name}
     ret['changes']['new'] = {'vpc': None}
     ret['comment'] = 'VPC {0} deleted.'.format(name)
+    return ret
+
+
+def subnet_absent(name=None, subnet_id=None, region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure subnet with passed properties is absent.
+    .. versionadded:: 2014.7.3
+
+    name
+        Name of the subnet.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+    '''
+
+    ret = {'name': name,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    exists = __salt__['boto_vpc.subnet_exists'](name=name, region=region, key=key, keyid=keyid, profile=profile)
+    if not exists:
+        ret['comment'] = '{0} subnet does not exist.'.format(name)
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'Subnet {0} is set to be removed.'.format(name)
+        ret['result'] = None
+        return ret
+
+    deleted = __salt__['boto_vpc.delete_subnet'](name=name, subnet_id=subnet_id, region=region, key=key, keyid=keyid,
+                                                 profile=profile)
+    if not deleted:
+        ret['result'] = False
+        ret['comment'] = 'Failed to delete {0} subnet.'.format(name)
+        return ret
+    ret['changes']['old'] = {'subnet': name}
+    ret['changes']['new'] = {'subnet': None}
+    ret['comment'] = 'Subnet {0} deleted.'.format(name)
     return ret

--- a/salt/states/boto_vpc.py
+++ b/salt/states/boto_vpc.py
@@ -129,7 +129,7 @@ def subnet_present(name, vpc_id, cidr_block, availability_zone=None, tags=None, 
                    key=None, keyid=None, profile=None):
     '''
     Ensure subnet exists.
-    .. versionadded:: 2014.7.3
+    .. versionadded:: Beryllium
 
     name
         Name of the subnet.
@@ -246,7 +246,7 @@ def absent(name, tags=None, region=None, key=None, keyid=None, profile=None):
 def subnet_absent(name=None, subnet_id=None, region=None, key=None, keyid=None, profile=None):
     '''
     Ensure subnet with passed properties is absent.
-    .. versionadded:: 2014.7.3
+    .. versionadded:: Beryllium
 
     name
         Name of the subnet.

--- a/tests/unit/modules/boto_vpc_test.py
+++ b/tests/unit/modules/boto_vpc_test.py
@@ -595,7 +595,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase):
         '''
         Tests deleting a subnet that doesn't exist
         '''
-        subnet_deletion_result = boto_vpc.delete_subnet('1234', **conn_parameters)
+        subnet_deletion_result = boto_vpc.delete_subnet(subnet_id='1234', **conn_parameters)
 
         self.assertFalse(subnet_deletion_result)
 

--- a/tests/unit/modules/boto_vpc_test.py
+++ b/tests/unit/modules/boto_vpc_test.py
@@ -586,7 +586,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase):
         vpc = self._create_vpc()
         subnet = self._create_subnet(vpc.id)
 
-        subnet_deletion_result = boto_vpc.delete_subnet(subnet.id, **conn_parameters)
+        subnet_deletion_result = boto_vpc.delete_subnet(subnet_id=subnet.id, **conn_parameters)
 
         self.assertTrue(subnet_deletion_result)
 


### PR DESCRIPTION
`boto_vpc.subnet_present` - ensure subnet is present, for now checks only the name
`boto_vpc.subnet_absent` - ensure subnet is absent, accepts name or ID
`boto_vpc.delete_subnet` - has been updated to accept a subnet name and not only an ID
