### PR TITLE
Prevent any arbitrary folder being created on minion by accident

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -939,6 +939,18 @@ class RemoteClient(Client):
         dest is omitted, then the downloaded file will be placed in the minion
         cache
         '''
+
+        # Check if file exists on server, before creating files and
+        # directories
+        hash_server = self.hash_file(path, saltenv)
+        if hash_server == '':
+            log.debug(
+                'Could not find file from saltenv {0!r}, {1!r}'.format(
+                    saltenv, path
+                )
+            )
+            return False
+
         if env is not None:
             salt.utils.warn_until(
                 'Boron',
@@ -959,7 +971,6 @@ class RemoteClient(Client):
 
         if dest2check and os.path.isfile(dest2check):
             hash_local = self.hash_file(dest2check, saltenv)
-            hash_server = self.hash_file(path, saltenv)
             if hash_local == hash_server:
                 log.info(
                     'Fetching file from saltenv {0!r}, ** skipped ** '

--- a/tests/unit/states/group_test.py
+++ b/tests/unit/states/group_test.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Rahul Handay <rahulha@saltstack.com>`
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+
+# Import Salt Testing Libs
+from salttesting import TestCase, skipIf
+from salttesting.helpers import ensure_in_syspath
+from salttesting.mock import (
+    MagicMock,
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+ensure_in_syspath('../../')
+
+# Import Salt Libs
+from salt.states import group
+
+# Globals
+group.__salt__ = {}
+group.__opts__ = {}
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class GroupTestCase(TestCase):
+    '''
+        Validate the group state
+    '''
+    def test_present(self):
+        '''
+            Test to ensure that a group is present
+        '''
+        ret = {'name': 'salt',
+               'changes': {},
+               'result': True,
+               'comment': {}
+               }
+
+        ret.update({'comment': 'Error: Conflicting options "members" with'
+                    ' "addusers" and/or "delusers" can not be used together. ',
+                    'result': None})
+        self.assertDictEqual(group.present("salt", delusers=True,
+                                           members=True), ret)
+
+        ret.update({'comment': 'Error. Same user(s) can not be'
+                    ' added and deleted simultaneously'})
+        self.assertDictEqual(group.present("salt", addusers=['a'],
+                                           delusers=['a']), ret)
+
+        ret.update({'comment': 'The following group attributes are set'
+                    ' to be changed:\nkey1: value1\nkey0: value0\n'})
+        mock = MagicMock(side_effect=[{'key0': 'value0',
+                                       'key1': 'value1'}, False, False, False])
+        with patch.object(group, '_changes', mock):
+            with patch.dict(group.__opts__, {"test": True}):
+                self.assertDictEqual(group.present("salt"), ret)
+
+                ret.update({'comment': 'Group salt set to be added'})
+                self.assertDictEqual(group.present("salt"), ret)
+
+            with patch.dict(group.__opts__, {"test": False}):
+                mock = MagicMock(return_value=[{'gid': 1, 'name': 'stack'}])
+                with patch.dict(group.__salt__, {'group.getent': mock}):
+                    ret.update({'result': False,
+                                'comment': 'Group salt is not present but'
+                                ' gid 1 is already taken by group stack'})
+                    self.assertDictEqual(group.present("salt", 1), ret)
+
+                    mock = MagicMock(return_value=False)
+                    with patch.dict(group.__salt__, {'group.add': mock}):
+                        ret.update({'comment':
+                                    'Failed to create new group salt'})
+                        self.assertDictEqual(group.present("salt"), ret)
+
+    def test_absent(self):
+        '''
+            Test to ensure that the named group is absent
+        '''
+        ret = {'name': 'salt',
+               'changes': {},
+               'result': True,
+               'comment': {}
+               }
+        mock = MagicMock(side_effect=[True, True, True, False])
+        with patch.dict(group.__salt__, {'group.info': mock}):
+            with patch.dict(group.__opts__, {"test": True}):
+                ret.update({'result': None,
+                            'comment': 'Group salt is set for removal'})
+                self.assertDictEqual(group.absent("salt"), ret)
+
+            with patch.dict(group.__opts__, {"test": False}):
+                mock = MagicMock(side_effect=[True, False])
+                with patch.dict(group.__salt__, {'group.delete': mock}):
+                    ret.update({'result': True, 'changes': {'salt': ''},
+                                'comment': 'Removed group salt'})
+                    self.assertDictEqual(group.absent('salt'), ret)
+
+                    ret.update({'changes': {}, 'result': False,
+                                'comment': 'Failed to remove group salt'})
+                    self.assertDictEqual(group.absent('salt'), ret)
+
+            ret.update({'result': True,
+                        'comment': 'Group not present'})
+            self.assertDictEqual(group.absent('salt'), ret)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(GroupTestCase, needs_daemon=False)


### PR DESCRIPTION
We discovered interesting behavior from salt when confusing state.sls with state.sls_id.

An engineer accidentally ran (he meant to use state.sls_id):

```
salt 'some_machine' state.sls /some/directory/with/file utils/prod test=True
```

Expecting to test if the state "/some/directory/with/file" within our "utils/prod.sls" file can be run safely. It (correctly) exited with the message:

```
Data failed to compile:
----------
No matching salt environment for environment 'utils/prod' found
----------
No matching sls found for '/some/directory/with/file' in env 'utils/prod'
```

But, the problem is, is that after running this once he spotted that the folder '/some/directory/with/file' has been created on the minion. This raised two issues:
1) This prevented the correct version of the salt run to succeed:

```
salt 'some_machine' state.sls_id /some/directory/with/file utils/prod test=True
some_machine
----------
          ID:  /some/directory/with/file
    Function: file.managed
      Result: False
     Comment: Specified target  /some/directory/with/file is a directory
     Started: 13:51:22.636077
    Duration: 3.996 ms
     Changes:   

Summary
------------
Succeeded: 0
Failed:    1
------------
```

2) The salt-minion just modified the file system in an arbitrary location despite using "test=True".

It turns out by having used "state.sls" the salt-minion attempted to fetch the .sls file /some/directory/with/file.sls from the salt-env utils/prod. This does not exist on the salt master, but the salt-minion went ahead and created directories as if it did.

This pull request changes the salt-minion behavior to check if the .sls file exists on the salt master before creating files and directories on the minion. This should prevent the above behavior and prevent people from accidentally creating arbitrary folders on the minion.  
