### PR TITLE
Choose better partition ids and PRIMARY KEYs

### DIFF
--- a/salt/returners/cassandra_cql_return.py
+++ b/salt/returners/cassandra_cql_return.py
@@ -32,7 +32,7 @@ Return data to a cassandra server
 Use the following cassandra database schema::
 
     CREATE KEYSPACE IF NOT EXISTS salt
-               WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1};
+        WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1};
 
     CREATE USER IF NOT EXISTS salt WITH PASSWORD 'salt' NOSUPERUSER;
 
@@ -40,40 +40,41 @@ Use the following cassandra database schema::
 
     USE salt;
 
-    CREATE KEYSPACE IF NOT EXISTS salt WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};
-
-    CREATE TABLE IF NOT EXISTS salt.salt_returns (
-        jid text PRIMARY KEY,
+    CREATE TABLE salt.salt_returns (
+        jid text,
+        id text,
+        fun text,
         alter_time timestamp,
         full_ret text,
-        fun text,
-        id text,
         return text,
-        success boolean
-    );
-    CREATE INDEX IF NOT EXISTS fun ON salt.salt_returns (fun);
-    CREATE INDEX IF NOT EXISTS id ON salt.salt_returns (id);
-
-    CREATE TABLE IF NOT EXISTS salt.minions (
-        id text PRIMARY KEY,
-        last_fun text
-    );
-
-    CREATE TABLE IF NOT EXISTS salt.jids (
+        success boolean,
+        PRIMARY KEY (jid, id, fun)
+    ) WITH CLUSTERING ORDER BY (id ASC, fun ASC);
+    CREATE INDEX id ON salt.salt_returns (id);
+    CREATE INDEX fun ON salt.salt_returns (fun);
+    
+    CREATE TABLE salt.jids (
         jid text PRIMARY KEY,
         load text
     );
-
-    CREATE TABLE IF NOT EXISTS salt.salt_events (
-        id timeuuid PRIMARY KEY,
+    
+    CREATE TABLE salt.minions (
+        id text PRIMARY KEY,
+        last_fun text
+    );
+    CREATE INDEX last_fun ON salt.minions (last_fun);
+    
+    CREATE TABLE salt.salt_events (
+        id timeuuid,
+        tag text,
         alter_time timestamp,
         data text,
         master_id text,
-        tag text
-    );
-    CREATE INDEX IF NOT EXISTS tag ON salt.salt_events (tag);
-
-
+        PRIMARY KEY (id, tag)
+    ) WITH CLUSTERING ORDER BY (tag ASC);
+    CREATE INDEX tag ON salt.salt_events (tag);
+    
+    
 Required python modules: cassandra-driver
 
   To use the cassandra returner, append '--return cassandra' to the salt command. ex:


### PR DESCRIPTION
Cassandra does things a bit differently when keying/storying, sorting data. The changes in this pull request will optimize reads by essentially giving Cassandra hits as to best store the data based on how the data will be read/queried.
