### PR TITLE
Beacon for reporting failed logins

### DIFF
--- a/salt/beacons/btmp.py
+++ b/salt/beacons/btmp.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+'''
+Beacon to fire events at failed login of users
+
+.. code-block:: yaml
+
+    beacons:
+      btmp: {}
+'''
+# Import python libs
+import os
+import struct
+
+__virtualname__ = 'btmp'
+BTMP = '/var/log/btmp'
+FMT = '<hI32s4s32s256siili4l20s'
+FIELDS = [
+          'type',
+          'PID',
+          'line',
+          'inittab',
+          'user',
+          'hostname',
+          'exit_status',
+          'session',
+          'time',
+          'addr'
+          ]
+SIZE = struct.calcsize(FMT)
+LOC_KEY = 'btmp.loc'
+
+
+def __virtual__():
+    if os.path.isfile(BTMP):
+        return __virtualname__
+    return False
+
+
+def _get_loc():
+    '''
+    return the active file location
+    '''
+    if LOC_KEY in __context__:
+        return __context__[LOC_KEY]
+
+
+# TODO: add support for only firing events for specific users and login times
+def beacon(config):
+    '''
+    Read the last btmp file and return information on the failed logins
+
+    .. code-block:: yaml
+
+        beacons:
+          btmp: {}
+    '''
+    ret = []
+    with open(BTMP, 'rb') as fp_:
+        loc = __context__.get(LOC_KEY, 0)
+        if loc == 0:
+            fp_.seek(0, 2)
+            __context__[LOC_KEY] = fp_.tell()
+            return ret
+        else:
+            fp_.seek(loc)
+        while True:
+            raw = fp_.read(SIZE)
+            if len(raw) != SIZE:
+                return ret
+            __context__[LOC_KEY] = fp_.tell()
+            pack = struct.unpack(FMT, raw)
+            event = {}
+            for ind in range(len(FIELDS)):
+                event[FIELDS[ind]] = pack[ind]
+                if isinstance(event[FIELDS[ind]], str):
+                    event[FIELDS[ind]] = event[FIELDS[ind]].strip('\x00')
+            ret.append(event)
+    return ret


### PR DESCRIPTION
This was originally the 'faillog' beacon but that required that log tallying be setup via PAM.  This beacon essentially exposes the same thing that 'lastb' does, analogous to the wtmp beacon's relationship to 'last'.
