### PR TITLE
Fixes to scheduler

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -498,6 +498,11 @@ class Schedule(object):
             jobcount = 0
             for basefilename in os.listdir(salt.minion.get_proc_dir(self.opts['cachedir'])):
                 fn_ = os.path.join(salt.minion.get_proc_dir(self.opts['cachedir']), basefilename)
+                if not os.path.exists(fn_):
+                    log.debug('schedule.handle_func: {0} was processed '
+                              'in another thread, skipping.'.format(
+                                  basefilename))
+                    continue
                 with salt.utils.fopen(fn_, 'r') as fp_:
                     job = salt.payload.Serial(self.opts).load(fp_)
                     if job:
@@ -592,6 +597,7 @@ class Schedule(object):
             # where the thread will die silently, which is worse.
         finally:
             try:
+                log.debug('schedule.handle_func: Removing {0}'.format(proc_fn))
                 os.unlink(proc_fn)
             except OSError as exc:
                 if exc.errno == errno.EEXIST or exc.errno == errno.ENOENT:


### PR DESCRIPTION
Fixing a bug that pops up randomly if you have multiple jobs with multiple threads, jobs would be processed in one thread but an attempt to process in another thread would be attempted.  The cache file would be removed after the other thread had gotten the list of cache file.  Adding some code to bypass the processing if the file is already gone.  #20107 
