### PR TITLE
Possible fix for 'puppet.run always returns 0 #20850'

### DIFF
--- a/salt/modules/puppet.py
+++ b/salt/modules/puppet.py
@@ -124,8 +124,7 @@ class _Puppet(object):
         if self.subcmd == 'agent':
             # no arguments are required
             args.extend([
-                'onetime', 'verbose', 'ignorecache', 'no-daemonize',
-                'no-usecacheonfailure', 'no-splay', 'show_diff'
+                'test'
             ])
 
         # finally do this after subcmd has been matched for all remaining args
@@ -167,7 +166,10 @@ def run(*args, **kwargs):
 
     puppet.kwargs.update(salt.utils.clean_kwargs(**kwargs))
 
-    return __salt__['cmd.run_all'](repr(puppet), python_shell=False)
+    if __salt__['cmd.run_all'](repr(puppet), python_shell=False) in [0, 2]:
+        return 0
+    else:
+        return 1
 
 
 def noop(*args, **kwargs):


### PR DESCRIPTION
- Change default Puppet agent args to just 'test', which includes the former ones plus 'detailed-exitcodes'.
- Exit properly depending on those detailed exit codes.
#20850
