### PR TITLE
Fix grains.get_or_set_hash to work with multiple entries under same key

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -514,9 +514,12 @@ def get_or_set_hash(name,
         val = ''.join([random.SystemRandom().choice(chars) for _ in range(length)])
 
         if ':' in name:
-            name, rest = name.split(':', 1)
+            root, rest = name.split(':', 1)
+            curr = get(root, _infinitedict())
             val = _dict_from_path(rest, val)
-
-        setval(name, val)
+            curr.update(val)
+            setval(root, curr)
+        else:
+            setval(name, val)
 
     return get(name)


### PR DESCRIPTION
Addressing issue #14888 and related.
