### PR TITLE
Backport 22036 to 2015.2 (remove aes & token_dir from def values() fn)

### DIFF
--- a/salt/wheel/config.py
+++ b/salt/wheel/config.py
@@ -22,8 +22,6 @@ def values():
     Return the raw values of the config file
     '''
     data = salt.config.master_config(__opts__['conf_file'])
-    data.pop('aes')
-    data.pop('token_dir')
     return data
 
 


### PR DESCRIPTION
Backport #22036.
