### PR TITLE
make __utils__ available to execution modules

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -139,7 +139,8 @@ class LocalClient(object):
                 self.opts['transport'],
                 opts=self.opts,
                 listen=not self.opts.get('__worker', False))
-        self.functions = salt.loader.minion_mods(self.opts)
+        self.utils = salt.loader.utils(self.opts)
+        self.functions = salt.loader.minion_mods(self.opts, utils=self.utils)
         self.returners = salt.loader.returners(self.opts, self.functions)
 
     def __read_master_key(self):

--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -35,7 +35,8 @@ class SSHState(salt.state.State):
         Load up the modules for remote compilation via ssh
         '''
         self.functions = self.wrapper
-        locals_ = salt.loader.minion_mods(self.opts)
+        self.utils = salt.loader.utils(self.opts)
+        locals_ = salt.loader.minion_mods(self.opts, utils=self.utils)
         self.states = salt.loader.states(self.opts, locals_)
         self.rend = salt.loader.render(self.opts, self.functions)
 

--- a/salt/daemons/flo/core.py
+++ b/salt/daemons/flo/core.py
@@ -618,6 +618,7 @@ class SaltLoadModules(ioflo.base.deeding.Deed):
     '''
     Ioinits = {'opts': '.salt.opts',
                'grains': '.salt.grains',
+               'utils': '.salt.loader.utils',
                'modules': '.salt.loader.modules',
                'grain_time': '.salt.var.grain_time',
                'module_refresh': '.salt.var.module_refresh',
@@ -660,9 +661,11 @@ class SaltLoadModules(ioflo.base.deeding.Deed):
             self.opts.value['grains'] = salt.loader.grains(self.opts.value)
             self.grain_time.value = time.time()
             self.grains.value = self.opts.value['grains']
-        self.modules.value = salt.loader.minion_mods(self.opts.value)
+        self.utils.value = salt.loader.utils(self.opts.value)
+        self.modules.value = salt.loader.minion_mods(self.opts.value, utils=self.utils.value)
         self.returners.value = salt.loader.returners(self.opts.value, self.modules.value)
 
+        self.utils.value.clear()
         self.modules.value.clear()
         self.returners.value.clear()
 
@@ -739,6 +742,7 @@ class SaltSchedule(ioflo.base.deeding.Deed):
     '''
     Ioinits = {'opts': '.salt.opts',
                'grains': '.salt.grains',
+               'utils': '.salt.loader.utils',
                'modules': '.salt.loader.modules',
                'returners': '.salt.loader.returners'}
 
@@ -746,7 +750,8 @@ class SaltSchedule(ioflo.base.deeding.Deed):
         '''
         Map opts and make the schedule object
         '''
-        self.modules.value = salt.loader.minion_mods(self.opts.value)
+        self.utils.value = salt.loader.utils(self.opts.value)
+        self.modules.value = salt.loader.minion_mods(self.opts.value, utils=self.utils.value)
         self.returners.value = salt.loader.returners(self.opts.value, self.modules.value)
         self.schedule = salt.utils.schedule.Schedule(
                 self.opts.value,

--- a/salt/engines/__init__.py
+++ b/salt/engines/__init__.py
@@ -20,7 +20,8 @@ def start_engines(opts, proc_mgr):
         runners = salt.loader.runner(opts)
     else:
         runners = []
-    funcs = salt.loader.minion_mods(opts)
+    utils = salt.loader.utils(opts)
+    funcs = salt.loader.minion_mods(opts, utils=utils)
     engines = salt.loader.engines(opts, funcs, runners)
 
     engines_opt = opts.get('engines', [])

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -93,6 +93,7 @@ def _module_dirs(
 def minion_mods(
         opts,
         context=None,
+        utils=None,
         whitelist=None,
         include_errors=False,
         initial_load=False,
@@ -117,12 +118,14 @@ def minion_mods(
     '''
     if context is None:
         context = {}
+    if utils is None:
+        utils = {}
     if not whitelist:
         whitelist = opts.get('whitelist_modules', None)
     ret = LazyLoader(_module_dirs(opts, 'modules', 'module'),
                      opts,
                      tag='module',
-                     pack={'__context__': context},
+                     pack={'__context__': context, '__utils__': utils},
                      whitelist=whitelist,
                      loaded_base_name=loaded_base_name)
     ret.pack['__salt__'] = ret

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -110,10 +110,11 @@ class Pillar(object):
 
         # if we didn't pass in functions, lets load them
         if functions is None:
+            utils = salt.loader.utils(opts)
             if opts.get('file_client', '') == 'local':
-                self.functions = salt.loader.minion_mods(opts)
+                self.functions = salt.loader.minion_mods(opts, utils=utils)
             else:
-                self.functions = salt.loader.minion_mods(self.opts)
+                self.functions = salt.loader.minion_mods(self.opts, utils=utils)
         else:
             self.functions = functions
 

--- a/salt/state.py
+++ b/salt/state.py
@@ -723,7 +723,8 @@ class State(object):
         Load the modules into the state
         '''
         log.info('Loading fresh modules for state activity')
-        self.functions = salt.loader.minion_mods(self.opts, self.state_con)
+        self.utils = salt.loader.utils(self.opts)
+        self.functions = salt.loader.minion_mods(self.opts, self.state_con, utils=self.utils)
         if isinstance(data, dict):
             if data.get('provider', False):
                 if isinstance(data['provider'], str):


### PR DESCRIPTION
This pull request uses the utils loader to make utils dynamically available execution modules in the `__utils__` dict. This has (at least) two advantages over using `salt.utils`:

1) custom utils are now possible
2) utils loaded in this way have access to a `__context__`

This does not deprecate the use of `salt.utils` -- it just provides a more flexible way of accessing them.

This should in time be expanded to make `__utils__` available to all types of modules (states, returners, etc).
