### PR TITLE
Provide a user option for authentication using salt-ssh

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2349,6 +2349,13 @@ class SaltSSHOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                  'ask for approval'
         )
         auth_group.add_option(
+            '--user',
+            dest='ssh_user',
+            default='root',
+            help='Set the default user to attempt to use when '
+                 'authenticating'
+        )
+        auth_group.add_option(
             '--passwd',
             dest='ssh_passwd',
             default='',


### PR DESCRIPTION
Fixing this issue: https://github.com/saltstack/salt/issues/7911

Wondering if the default user should be the root or $USER?
