### PR TITLE
Allow you to view the build arguments

### DIFF
--- a/salt/modules/nginx.py
+++ b/salt/modules/nginx.py
@@ -11,6 +11,8 @@ from salt.ext.six.moves.urllib.request import urlopen as _urlopen  # pylint: dis
 import salt.utils
 import salt.utils.decorators as decorators
 
+import re
+
 
 # Cache the output of running which('nginx') so this module
 # doesn't needlessly walk $PATH looking for the same binary
@@ -60,7 +62,7 @@ def build_info():
 
     for i in out.splitlines():
         if i.startswith('configure argument'):
-            ret['build arguments'] = i.split()[2:]
+            ret['build arguments'] = re.findall(r"(?:[^\s]*'.*')|(?:[^\s]+)", i)[2:]
             continue
 
         ret['info'].append(i)

--- a/salt/modules/nginx.py
+++ b/salt/modules/nginx.py
@@ -45,6 +45,29 @@ def version():
     return ret[-1]
 
 
+def build_info():
+    '''
+    Return server and build arguments
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' nginx.build_info
+    '''
+    ret = {'info': []}
+    out = __salt__['cmd.run']('{0} -V'.format(__detect_os()))
+
+    for i in out.splitlines():
+        if i.startswith('configure argument'):
+            ret['build arguments'] = i.split()[2:]
+            continue
+
+        ret['info'].append(i)
+
+    return ret
+
+
 def configtest():
     '''
     test configuration and exit


### PR DESCRIPTION
View the arguments used during the build of Nginx

``` bash
local:
    ----------
    build arguments:
        - --prefix=/usr/share/nginx
        - --sbin-path=/usr/sbin/nginx
        - --conf-path=/etc/nginx/nginx.conf
        - --error-log-path=/var/log/nginx/error.log
        - --http-log-path=/var/log/nginx/access.log
        - --http-client-body-temp-path=/var/lib/nginx/tmp/client_body
        - --http-proxy-temp-path=/var/lib/nginx/tmp/proxy
        - --http-fastcgi-temp-path=/var/lib/nginx/tmp/fastcgi
        - --http-uwsgi-temp-path=/var/lib/nginx/tmp/uwsgi
        - --http-scgi-temp-path=/var/lib/nginx/tmp/scgi
        - --pid-path=/var/run/nginx.pid
        - --lock-path=/var/lock/subsys/nginx
        - --user=nginx
        - --group=nginx
        - --with-file-aio
        - --with-ipv6
        - --with-http_ssl_module
        - --with-http_realip_module
        - --with-http_addition_module
        - --with-http_xslt_module
        - --with-http_image_filter_module
        - --with-http_geoip_module
        - --with-http_sub_module
        - --with-http_dav_module
        - --with-http_flv_module
        - --with-http_mp4_module
        - --with-http_gzip_static_module
        - --with-http_random_index_module
        - --with-http_secure_link_module
        - --with-http_degradation_module
        - --with-http_stub_status_module
        - --with-http_perl_module
        - --with-mail
        - --with-mail_ssl_module
        - --with-debug
        - --with-cc-opt='-O2
        - -g
        - -pipe
        - -Wall
        - -Wp,-D_FORTIFY_SOURCE=2
        - -fexceptions
        - -fstack-protector
        - --param=ssp-buffer-size=4
        - -m64
        - -mtune=generic'
        - --with-ld-opt=-Wl,-E
    info:
        - nginx version: nginx/1.0.15
        - built by gcc 4.4.7 20120313 (Red Hat 4.4.7-11) (GCC) 
        - TLS SNI support enabled
```
