### PR TITLE
Prevent a load from being written if one already exists

### DIFF
--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -228,7 +228,8 @@ def get_load(jid):
     Return the load data that marks a specified jid
     '''
     jid_dir = _jid_dir(jid)
-    if not os.path.exists(jid_dir):
+    load_fn = os.path.join(jid_dir, LOAD_P)
+    if not os.path.exists(jid_dir) or not os.path.exists(load_fn):
         return {}
     serial = salt.payload.Serial(__opts__)
 

--- a/salt/utils/job.py
+++ b/salt/utils/job.py
@@ -72,6 +72,7 @@ def store_job(opts, load, event=None, mminion=None):
 
     # otherwise, write to the master cache
     savefstr = '{0}.save_load'.format(job_cache)
+    getfstr = '{0}.get_load'.format(job_cache)
     fstr = '{0}.returner'.format(job_cache)
     if 'fun' not in load and load.get('return', {}):
         ret_ = load.get('return', {})
@@ -80,7 +81,7 @@ def store_job(opts, load, event=None, mminion=None):
         if 'user' in ret_:
             load.update({'user': ret_['user']})
     try:
-        if 'jid' in load:
+        if 'jid' in load and not mminion.returners[getfstr](load.get('jid', '')):
             mminion.returners[savefstr](load['jid'], load)
         mminion.returners[fstr](load)
     except KeyError:


### PR DESCRIPTION
This is a workaround for a problem introduced when loads are being written on returns, which was originally introduced to ensure that a load is _always_ written, even if run in masterless mode or from lower-level masters in a syndic setup.

Ultimately, we'll want to re-address that strategy but this prevents the corrupted loads for the time being.
