### PR TITLE
Initial TLS state

### DIFF
--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -20,10 +20,10 @@ from __future__ import absolute_import
 # Import python libs
 import os
 import time
-import datetime
 import logging
 import hashlib
 from salt.ext.six.moves import range
+from datetime import datetime
 
 HAS_SSL = False
 try:
@@ -201,9 +201,9 @@ def maybe_fix_ssl_version(ca_name, cacert_path=None):
                 except Exception:
                     bits = 2048
                 try:
-                    days = (datetime.datetime.strptime(cert.get_notAfter(),
+                    days = (datetime.strptime(cert.get_notAfter(),
                                                        '%Y%m%d%H%M%SZ') -
-                            datetime.datetime.now()).days
+                            datetime.now()).days
                 except (ValueError, TypeError):
                     days = 365
                 subj = cert.get_subject()
@@ -418,7 +418,7 @@ def create_ca(ca_name,
                                                 key)
     write_key = True
     if os.path.exists(ca_keyp):
-        bck = "{0}.{1}".format(ca_keyp, datetime.datetime.now().strftime(
+        bck = "{0}.{1}".format(ca_keyp, datetime.now().strftime(
             "%Y%m%d%H%M%S"))
         with salt.utils.fopen(ca_keyp) as fic:
             old_key = fic.read().strip()
@@ -967,6 +967,61 @@ def create_pkcs12(ca_name, CN, passphrase='', cacert_path=None):
                     ca_name,
                     CN
                     )
+
+
+def cert_info(cert_path, digest='sha256'):
+    '''
+    Return information for a particular certificate
+
+    cert_path
+        path to the cert file
+    digest
+        what digest to use for fingerprinting
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' tls.cert_info /dir/for/certs/cert.pem
+    '''
+    # format that OpenSSL returns dates in
+    date_fmt = '%Y%m%d%H%M%SZ'
+
+    with salt.utils.fopen(cert_path) as cert_file:
+        cert = OpenSSL.crypto.load_certificate(
+                OpenSSL.crypto.FILETYPE_PEM,
+                cert_file.read()
+            )
+    ret = {
+        'fingerprint': cert.digest(digest),
+        'subject': dict(cert.get_subject().get_components()),
+        'issuer': dict(cert.get_issuer().get_components()),
+        'serial_number': cert.get_serial_number(),
+        'not_before': time.mktime(datetime.strptime(cert.get_notBefore(), date_fmt).timetuple()),
+        'not_after': time.mktime(datetime.strptime(cert.get_notAfter(), date_fmt).timetuple()),
+    }
+
+    # add additional info if your version of pyOpenSSL supports it
+    if hasattr(cert, 'get_extension_count'):
+        ret['extensions'] = {}
+        for i in range(cert.get_extension_count()):
+            ext = cert.get_extension(i)
+            ret['extensions'][ext.get_short_name()] = ext
+
+    if 'subjectAltName' in ret.get('extensions', {}):
+        valid_names = set()
+        for name in ret['extensions']['subjectAltName']._subjectAltNameString().split(", "):
+            if not name.startswith('DNS:'):
+                log.error('Cert {0} has an entry ({1}) which does not start with DNS:'.format(cert_path, name))
+            else:
+                valid_names.add(name[4:])
+        ret['subject_alt_names'] = valid_names
+
+    if hasattr(cert, 'get_signature_algorithm'):
+        ret['signature_algorithm'] = cert.get_signature_algorithm()
+
+    return ret
+
 
 if __name__ == '__main__':
     #create_ca('koji', days=365, **cert_sample_meta)

--- a/salt/states/tls.py
+++ b/salt/states/tls.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+'''
+Enforce state for SSL/TLS.
+=========================================================================
+
+'''
+
+import time
+import datetime
+
+__virtualname__ = 'tls'
+
+
+def __virtual__():
+    if 'tls.cert_info' not in __salt__:
+        return False
+
+    return __virtualname__
+
+
+def valid_certificate(
+        name,
+        weeks=0,
+        days=0,
+        hours=0,
+        minutes=0,
+        seconds=0,
+    ):
+    '''
+    Verify that a TLS certificate is valid now and (optionally) will be valid
+    for the time specified through weeks, days, hours, minutes, and seconds.
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    now = time.time()
+    cert_info = __salt__['tls.cert_info'](name)
+
+    # verify that the cert is valid *now*
+    if now < cert_info['not_before']:
+        ret['comment'] = 'Certificate is not yet valid'
+        return ret
+    if now > cert_info['not_after']:
+        ret['comment'] = 'Certificate is expired'
+        return ret
+
+    # verify the cert will be valid for defined time
+    delta_remaining = datetime.timedelta(seconds=cert_info['not_after']-now)
+    delta_kind_map = {
+        'weeks': weeks,
+        'days': days,
+        'hours': hours,
+        'minutes': minutes,
+        'seconds': seconds,
+    }
+
+    delta_min = datetime.timedelta(**delta_kind_map)
+    # if ther eisn't enough time remaining, we consider it a failure
+    if delta_remaining < delta_min:
+        ret['comment'] = 'Certificate will expire in {0}, which is less than {1}'.format(delta_remaining, delta_min)
+        return ret
+
+    ret['result'] = True
+    ret['comment'] = 'Certificate is valid for {0}'.format(delta_remaining)
+    return ret


### PR DESCRIPTION
This state will allow you to enforce that a certificate is valid (optionally for some time in the future). To do this I've added "cert_info" to the tls execution module to return a structured dict of info regarding the certs
