### PR TITLE
Solaris pkg modules - improve performance and correct os detection

### DIFF
--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -29,7 +29,7 @@ import logging
 import salt.utils
 
 # Define the module's virtual name
-__virtualname__ = 'solarisips'
+__virtualname__ = 'pkg'
 log = logging.getLogger(__name__)
 
 
@@ -37,7 +37,7 @@ def __virtual__():
     '''
     Set the virtual pkg module if the os is Solaris 11
     '''
-    if __grains__['os'] == 'Solaris' and __grains__['kernelrelease'] == '5.11':
+    if __grains__['os'] == 'Solaris' and float(__grains__['kernelrelease']) == 5.10:
         return __virtualname__
     return False
 
@@ -129,8 +129,7 @@ def list_upgrades(refresh=False):
         refresh_db(full=True)
     upgrades = {}
     # awk is in core-os package so we can use it without checking
-    lines = __salt__['cmd.run_stdout'](
-        "/bin/pkg list -Hu | /bin/awk '{print $1}' | /bin/xargs pkg list -Hnv").splitlines()
+    lines = __salt__['cmd.run_stdout']("/bin/pkg list -Huv").splitlines()
     for line in lines:
         upgrades[_ips_get_pkgname(line)] = _ips_get_pkgversion(line)
     return upgrades

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -23,7 +23,7 @@ def __virtual__():
     '''
     Set the virtual pkg module if the os is Solaris
     '''
-    if __grains__['os'] == 'Solaris':
+    if __grains__['os'] == 'Solaris' and float(__grains__['kernelrelease']) <= 5.10:
         return __virtualname__
     return False
 


### PR DESCRIPTION
Makes IPS packaging (solarisips.py) the default for Solaris 11 as SVR4 packaging (solarispkg.py) is deprecated, and fixes an inefficient function.  SVR4 packaging can still be enabled at a package level in the state definition or via the minion config 'providers' option .
