### PR TITLE
Don't pass `ex_config_drive` to libcloud unless it's explicitly enabled

### DIFF
--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -599,9 +599,9 @@ def request_instance(vm_=None, call=None):
             kwargs['ex_userdata'] = fp.read()
 
     config_drive = config.get_cloud_config_value(
-        'config_drive', vm_, __opts__, default=False, search_global=False
+        'config_drive', vm_, __opts__, default=None, search_global=False
     )
-    if config_drive:
+    if config_drive is not None:
         kwargs['ex_config_drive'] = config_drive
 
     salt.utils.cloud.fire_event(

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -598,9 +598,11 @@ def request_instance(vm_=None, call=None):
         with salt.utils.fopen(userdata_file, 'r') as fp:
             kwargs['ex_userdata'] = fp.read()
 
-    kwargs['ex_config_drive'] = config.get_cloud_config_value(
-        'config_drive', vm_, __opts__, search_global=False
+    config_drive = config.get_cloud_config_value(
+        'config_drive', vm_, __opts__, default=False, search_global=False
     )
+    if config_drive:
+        kwargs['ex_config_drive'] = config_drive
 
     salt.utils.cloud.fire_event(
         'event',


### PR DESCRIPTION
Fixes #19923
