### PR TITLE
Boto VPC routes support

### DIFF
--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -1465,9 +1465,9 @@ def delete_route_table(route_table_id=None, route_table_name=None,
 
     '''
     try:
-        if _delete_resource('route_table', route_table_name,
-                            route_table_id, region, key,
-                            keyid, profile):
+        if _delete_resource(resource='route_table', name=route_table_name,
+                            resource_id=route_table_id, region=region, key=key,
+                            keyid=keyid, profile=profile):
             return True
     except boto.exception.BotoServerError as exc:
         log.error(exc)
@@ -1685,8 +1685,8 @@ def create_route(route_table_id, destination_cidr_block, gateway_id=None, instan
         return False
 
     try:
-        if conn.create_route(route_table_id, destination_cidr_block, gateway_id=gateway_id, instance_id=instance_id,
-                             interface_id=interface_id):
+        if conn.create_route(route_table_id=route_table_id, destination_cidr_block=destination_cidr_block,
+                             gateway_id=gateway_id, instance_id=instance_id, interface_id=interface_id):
             log.info('Route with cider block {0} on route table {1} was created'.format(route_table_id,
                                                                                         destination_cidr_block))
 

--- a/salt/states/boto_vpc.py
+++ b/salt/states/boto_vpc.py
@@ -529,10 +529,10 @@ def _routes_present(route_table_name, routes, tags=None, region=None, key=None, 
     route_table = __salt__['boto_vpc.describe_route_table'](route_table_name=route_table_name, tags=tags, region=region,
                                                             key=key, keyid=keyid, profile=profile)
     if not route_table:
-            msg = 'Could not retrieve configuration for route table {0}.'.format(route_table_name)
-            ret['comment'] = msg
-            ret['result'] = False
-            return ret
+        msg = 'Could not retrieve configuration for route table {0}.'.format(route_table_name)
+        ret['comment'] = msg
+        ret['result'] = False
+        return ret
     if not routes:
         routes = []
     else:


### PR DESCRIPTION
This allows one to keep routes in a desired state for routing tables.

Example usage:

```
my_route_table:
  boto_vpc.route_table_present:
    - name: some_name
    - vpc_id: vpc-123456
    - routes:
      - destination_cidr_block: 0.0.0.0/0
        instance_id: i-123456
        interface_id: eni-123456
```

I think the documentation needs some corrections, suggestions?
Ping @mgwilliams
