### PR TITLE
debug rest_tornado test error

### DIFF
--- a/tests/integration/netapi/rest_tornado/test_app.py
+++ b/tests/integration/netapi/rest_tornado/test_app.py
@@ -414,13 +414,17 @@ class TestJobsSaltAPIHandler(SaltnadoTestCase):
                                )
         response = self.wait(timeout=10)
         response_obj = json.loads(response.body)['return'][0]
-        for jid, ret in response_obj.iteritems():
-            self.assertIn('Function', ret)
-            self.assertIn('Target', ret)
-            self.assertIn('Target-type', ret)
-            self.assertIn('User', ret)
-            self.assertIn('StartTime', ret)
-            self.assertIn('Arguments', ret)
+        try:
+            for jid, ret in response_obj.iteritems():
+                self.assertIn('Function', ret)
+                self.assertIn('Target', ret)
+                self.assertIn('Target-type', ret)
+                self.assertIn('User', ret)
+                self.assertIn('StartTime', ret)
+                self.assertIn('Arguments', ret)
+        except AttributeError as attribute_error:
+            print json.loads(response.body)
+            raise
 
         # test with a specific JID passed in
         jid = response_obj.iterkeys().next()


### PR DESCRIPTION
``` python
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/tornado/testing.py", line 120, in __call__
    result = self.orig_method(*args, **kwargs)
  File "/testing/tests/integration/netapi/rest_tornado/test_app.py", line 402, in test_get
    for jid, ret in six.iteritems(response_obj):
  File "/testing/salt/ext/six.py", line 572, in iteritems
    return iter(d.iteritems(**kw))
AttributeError: 'unicode' object has no attribute 'iteritems'
```
