### PR TITLE
Expand glob patterns in the path argument of file.find

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -686,7 +686,7 @@ def find(path, *args, **kwargs):
     except ValueError as ex:
         return 'error: {0}'.format(ex)
 
-    ret = [p for p in finder.find(os.path.expanduser(path))]
+    ret = [item for i in [finder.find(os.path.expanduser(p)) for p in glob.glob(path)] for item in i]
     ret.sort()
     return ret
 

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -686,7 +686,7 @@ def find(path, *args, **kwargs):
     except ValueError as ex:
         return 'error: {0}'.format(ex)
 
-    ret = [item for i in [finder.find(os.path.expanduser(p)) for p in glob.glob(path)] for item in i]
+    ret = [item for i in [finder.find(p) for p in glob.glob(os.path.expanduser(path))] for item in i]
     ret.sort()
     return ret
 


### PR DESCRIPTION
This change addresses #16711.
The issue was that `file.find` was expanding only a leading `~` in the path via `os.path.expanduser`. With this change, paths containing glob patterns (e.g. `/home/*/data`) are correctly expanded with `glob.glob` before searching.
