### PR TITLE
states.dockerio: Fix Bug introduced in cc1cd22471f39f9c3c56d105486feebd336a1fb9

### DIFF
--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -1024,6 +1024,7 @@ def running(name,
         remove_status = __salt__['docker.remove_container'](name)
         if not remove_status['status']:
             return _invalid(comment='Failed to remove outdated container {0!r}'.format(name))
+        already_exists = False
         # now it's clear, the name is available for the new container
 
     # parse input data


### PR DESCRIPTION
Once the container is destroyed, put the flag `already_exists` to `False`
to let the new container be created.
