### PR TITLE
Fix git module to work in windows

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -203,7 +203,10 @@ def clone(cwd, repository, opts=None, user=None, identity=None,
 
     if not opts:
         opts = ''
-    cmd = 'git clone {0} {1!r} {2}'.format(repository, cwd, opts)
+    if salt.utils.is_windows():
+        cmd = 'git clone {0} {1} {2}'.format(repository, cwd, opts)
+    else:
+        cmd = 'git clone {0} {1!r} {2}'.format(repository, cwd, opts)
 
     return _git_run(cmd, runas=user, identity=identity)
 
@@ -952,5 +955,5 @@ def ls_remote(cwd, repository="origin", branch="master", user=None,
     '''
     _check_git()
     repository = _add_http_basic_auth(repository, https_user, https_pass)
-    cmd = "git ls-remote -h " + repository + " " + branch + " | cut -f 1"
+    cmd = ' '.join(["git", "ls-remote", "-h", str(repository), str(branch), "| cut -f 1"])
     return _git_run(cmd, cwd=cwd, runas=user, identity=identity)

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -203,7 +203,7 @@ def clone(cwd, repository, opts=None, user=None, identity=None,
 
     if not opts:
         opts = ''
-    if salt.utils.is_windows():
+    if utils.is_windows():
         cmd = 'git clone {0} {1} {2}'.format(repository, cwd, opts)
     else:
         cmd = 'git clone {0} {1!r} {2}'.format(repository, cwd, opts)


### PR DESCRIPTION
There were two problems here.
1st it was wrapping the target directory with single quotes which fails in windows
2nd it wasn't concatenating the command correctly when using a git branch that resembled a float (ie: 2014.7)
