### PR TITLE
Support for Isilon OneFS (based on FreeBSD).

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -25,11 +25,17 @@ from salt.utils import vt
 import salt.utils
 import salt.utils.timed_subprocess
 import salt.grains.extra
-from salt.ext.six import string_types
 from salt.exceptions import CommandExecutionError, TimedProcTimeoutError
 from salt.log import LOG_LEVELS
-import salt.ext.six as six
-from salt.ext.six.moves import range
+
+try:
+    from salt.ext.six import string_types
+    import salt.ext.six as six
+    from salt.ext.six.moves import range
+except ImportError:
+    from six import string_types
+    import six
+    from six.moves import range
 
 # Only available on POSIX systems, nonfatal on windows
 try:
@@ -260,7 +266,7 @@ def _run(cmd,
             if __grains__['os'] in ['MacOS', 'Darwin']:
                 env_cmd = ('sudo', '-i', '-u', runas, '--',
                            sys.executable)
-            elif __grains__['os'] in ['FreeBSD']:
+            elif __grains__['os'] in ['FreeBSD','Isilon OneFS']:
                 env_cmd = ('su', '-', runas, '-c',
                            "{0} -c {1}".format(shell, sys.executable))
             elif __grains__['os_family'] in ['Solaris']:

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -31,10 +31,17 @@ import glob
 import hashlib
 from functools import reduce  # pylint: disable=redefined-builtin
 
+try:
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
-import salt.ext.six as six
-from salt.ext.six.moves import range, zip
-from salt.ext.six.moves.urllib.parse import urlparse as _urlparse
+    import salt.ext.six as six
+    from salt.ext.six.moves import range, zip
+    from salt.ext.six.moves.urllib.parse import urlparse as _urlparse
+# pylint: enable=import-error,no-name-in-module,redefined-builtin
+except ImportError:
+# pylint: disable=import-error,no-name-in-module,redefined-builtin
+    import six
+    from six.moves import range, zip
+    from six.moves.urllib.parse import urlparse as _urlparse
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
 
 try:
@@ -2033,7 +2040,7 @@ def patch(originalfile, patchfile, options='', dry_run=False):
         salt '*' file.patch /opt/file.txt /tmp/file.txt.patch
     '''
     if dry_run:
-        if __grains__['kernel'] in ('FreeBSD', 'OpenBSD'):
+        if __grains__['kernel'] in ('FreeBSD', 'OpenBSD', 'Isilon OneFS'):
             dry_run_opt = ' -C'
         else:
             dry_run_opt = ' --dry-run'


### PR DESCRIPTION
Isilon OneFS 7.2 is based on FreeBSD 7.4.  It has proprietary configuration mangagement, but it is possible to use salt-ssh to manage files, directories, users and groups.

This patch set will allow Salt to execute the correct FreeBSD modules based on the OneFS kernel name.
