### PR TITLE
Fix issue #22306

### DIFF
--- a/salt/pillar/s3.py
+++ b/salt/pillar/s3.py
@@ -128,7 +128,10 @@ def ext_pillar(minion_id,
         log.info('Sync local pillar cache from S3 completed.')
 
     opts = deepcopy(__opts__)
-    opts['pillar_roots'][environment] = [pillar_dir]
+    opts['pillar_roots'][environment] = [os.path.join(pillar_dir, environment)] if multiple_env else [pillar_dir]
+
+    # Avoid recursively re-adding this same pillar
+    opts['ext_pillar'] = [x for x in opts['ext_pillar'] if 's3' not in x]
 
     pil = Pillar(opts, __grains__, minion_id, environment)
 


### PR DESCRIPTION
Be aware of when we download files from S3 that have an environment
prefix. For example, if the S3 bucket contains /base/top.sls then the
file will be downloaded as {pillar_dir}/base/top.sls rather than
{pillar_dir}/top.sls which will mean that we are building our pillar
with the wrong root and won't actually ingest any pillar data.

Now we take into account whether or not we are in multiple_env mode and
correct the pillar root accordingly.

We also need to avoid recursively recreating the pillar when we compile
the pillar. There may be a more canonical way to do this, I'm not
familiar enough with salt internals to know, but by ripping out the s3
config from the ext_pillar config we avoid the infinite recursion.

May be related to #18355
