### PR TITLE
Fix suicide_when_without_parent

### DIFF
--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -70,7 +70,9 @@ def minion_process(queue):
                 # check pid alive (Unix only trick!)
                 os.kill(parent_pid, 0)
             except OSError:
-                sys.exit(999)
+                # forcibly exit, regular sys.exit raises an exception-- which
+                # isn't sufficient in a thread
+                os._exit(999)
     if not salt.utils.is_windows():
         thread = threading.Thread(target=suicide_when_without_parent, args=(os.getppid(),))
         thread.start()


### PR DESCRIPTION
If you call sys.exit within a thread it raises SystemExit-- which inside of a thread just exits the thread. This os._exit() will _actually_ allow the thread to cause the process to exit

IMO this "keepalive minion" feature using a separate process is a bit of a hack and we shouldn't have it. If all you want to do is have a minion process always running there are many options out there today (runit, init, systemd, upstart, sysvinit, nosh, finit, watchdogd, etc.) so there is no reason for us to have the same code in salt-- especially when our implementation is _very_ platform specific (*nix only). 

I propose we just have the minion re-try on SaltClientError (the only exception tune_in can raise) using the acceptance_wait_time-- but do nothing in the case where the minion is killed (kill -9 or anything similar).

cc: @steverweber
