### PR TITLE
Improvement: add pillar PCRE (RFC - do not merge)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -52,7 +52,8 @@ disable=W0142,
   C0330,
   I0011,
   I0012,
-  E8402
+  E8402,
+  E8731
 #  E8121,
 #  E8122,
 #  E8123,
@@ -68,6 +69,7 @@ disable=W0142,
 # E812* All PEP8 E12*
 # E8402 module level import not at top of file
 # E8501 PEP8 line too long
+# E8731 do not assign a lambda expression, use a def
 # C0330 (bad-continuation)
 # I0011 (locally-disabling)
 # I0012 (locally-enabling)

--- a/.pylintrc
+++ b/.pylintrc
@@ -52,6 +52,7 @@ disable=W0142,
   C0330,
   I0011,
   I0012,
+  W1202,
   E8402,
   E8731
 #  E8121,
@@ -66,6 +67,7 @@ disable=W0142,
 # Disabled Checks
 #
 # W0142 (star-args)
+# W1202 (logging-format-interpolation) Use % formatting in logging functions but pass the % parameters as arguments
 # E812* All PEP8 E12*
 # E8402 module level import not at top of file
 # E8501 PEP8 line too long

--- a/.testing.pylintrc
+++ b/.testing.pylintrc
@@ -81,7 +81,8 @@ disable=R,
   E8129,
   E8131,
   E8265,
-  E8402
+  E8402,
+  E8731
 
 # Disabled:
 # R* [refactoring suggestions & reports]
@@ -119,6 +120,7 @@ disable=R,
 # E8265 PEP8 E265 - block comment should start with "# "
 # E8501 PEP8 line too long
 # E8402 module level import not at top of file
+# E8731 do not assign a lambda expression, use a def
 
 [REPORTS]
 

--- a/.testing.pylintrc
+++ b/.testing.pylintrc
@@ -67,6 +67,7 @@ disable=R,
   W0622,
   W0631,
   W0704,
+  W1202,
   F0220,
   F0401,
   E8501,
@@ -115,6 +116,7 @@ disable=R,
 # W0704 (pointless-except) [misnomer; "ignores the exception" rather than "pointless"]
 # F0220 (unresolved-interface)
 # F0401 (import-error)
+# W1202 (logging-format-interpolation) Use % formatting in logging functions but pass the % parameters as arguments
 #
 # E812* All PEP8 E12*
 # E8265 PEP8 E265 - block comment should start with "# "

--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -229,7 +229,18 @@ FunctionEnd
 
 Function .onInit
 
+MessageBox MB_OK "$INSTDIR"
+
+  confFind:
   IfFileExists "$INSTDIR\conf\minion" confFound confNotFound
+
+  confNotFound:
+    ${If} $INSTDIR == "c:\salt\bin\Scripts"
+      StrCpy $INSTDIR "C:\salt"
+      goto confFind
+    ${Else}
+      goto confReallyNotFound
+    ${EndIf}
 
   confFound:
     FileOpen $0 "$INSTDIR\conf\minion" r
@@ -256,7 +267,7 @@ Function .onInit
     EndOfFile:
       FileClose $0
 
-  confNotFound:
+  confReallyNotFound:
     Push $R0
     Push $R1
     Push $R2

--- a/salt/auth/yubico.py
+++ b/salt/auth/yubico.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 
 '''
-Provide authentication using YubiKey
+Provide authentication using YubiKey.
+
+.. versionadded:: 2015.2.0
+
+:depends: yubico-client Python module
 
 To get your YubiKey API key you will need to visit the website below.
 
@@ -32,12 +36,11 @@ two values in your /etc/salt/master configuration.
 Please wait five to ten minutes after generating the key before testing so that
 the API key will be updated on all the YubiCloud servers.
 
-:depends:   - yubico-client Python module
 '''
 
-from __future__ import print_function
-
+# Import Python Libs
 from __future__ import absolute_import
+from __future__ import print_function
 import logging
 
 log = logging.getLogger(__name__)

--- a/salt/auth/yubico.py
+++ b/salt/auth/yubico.py
@@ -86,8 +86,6 @@ def auth(username, password):
         log.info('Unable to verify YubiKey `{0}`'.format(e))
         return False
 
-    return False
-
 
 if __name__ == '__main__':
     __opts__ = {'yubico_users': {'damian': {'id': '12345', 'key': 'ABC123'}}}

--- a/salt/beacons/load.py
+++ b/salt/beacons/load.py
@@ -31,7 +31,7 @@ def beacon(config):
     and only emit a beacon if any of them are
     exceeded.
 
-    code-block:: yaml
+    .. code-block:: yaml
 
         beacons:
           - load:

--- a/salt/beacons/load.py
+++ b/salt/beacons/load.py
@@ -31,19 +31,19 @@ def beacon(config):
     and only emit a beacon if any of them are
     exceeded.
 
-    code_block:: yaml
+    code-block:: yaml
 
         beacons:
-            - load:
-              - 1m:
-                - 0.0
-                - 2.0
-              - 5m:
-                - 0.0
-                - 1.5
-              - 15m:
-                - 0.1
-                - 1.0
+          - load:
+            - 1m:
+              - 0.0
+              - 2.0
+            - 5m:
+              - 0.0
+              - 1.5
+            - 15m:
+              - 0.1
+              - 1.0
 
     '''
     log.trace('load beacon starting')

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -496,6 +496,7 @@ class LocalClient(object):
             * ``grain`` - Match based on a grain comparison
             * ``grain_pcre`` - Grain comparison with a regex
             * ``pillar`` - Pillar data comparison
+            * ``pillar_pcre`` - Pillar data comparison with a regex
             * ``nodegroup`` - Match on nodegroup
             * ``range`` - Use a Range server for matching
             * ``compound`` - Pass a compound match string

--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -34,7 +34,7 @@ ARGS = None
 # The below line is where OPTIONS can be redefined with internal options
 # (rather than cli arguments) when the shim is bundled by
 # client.ssh.Single._cmd_str()
-# pylint: disable=block-comment-should-start-with-'# '
+# pylint: disable=block-comment-should-start-with-cardinal-space
 #%%OPTS
 
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1022,7 +1022,7 @@ class Minion(MinionBase):
                                  '{0}_match'.format(data['tgt_type']), None)
             if match_func is None:
                 return
-            if data['tgt_type'] in ('grain', 'grain_pcre', 'pillar'):
+            if data['tgt_type'] in ('grain', 'grain_pcre', 'pillar', 'pillar_pcre'):
                 delimiter = data.get('delimiter', DEFAULT_TARGET_DELIM)
                 if not match_func(data['tgt'], delimiter=delimiter):
                     return
@@ -2729,9 +2729,22 @@ class Matcher(object):
             self.opts['pillar'], tgt, delimiter=delimiter
         )
 
+    def pillar_pcre_match(self, tgt, delimiter=DEFAULT_TARGET_DELIM):
+        '''
+        Reads in the pillar pcre match
+        '''
+        log.debug('pillar PCRE target: {0}'.format(tgt))
+        if delimiter not in tgt:
+            log.error('Got insufficient arguments for pillar PCRE match '
+                      'statement from master')
+            return False
+        return salt.utils.subdict_match(
+            self.opts['pillar'], tgt, delimiter=delimiter, regex_match=True
+        )
+
     def pillar_exact_match(self, tgt, delimiter=':'):
         '''
-        Reads in the pillar match, no globbing
+        Reads in the pillar match, no globbing, no PCRE
         '''
         log.debug('pillar target: {0}'.format(tgt))
         if delimiter not in tgt:
@@ -2791,6 +2804,7 @@ class Matcher(object):
         ref = {'G': 'grain',
                'P': 'grain_pcre',
                'I': 'pillar',
+               'J': 'pillar_pcre',
                'L': 'list',
                'S': 'ipcidr',
                'E': 'pcre'}

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -361,7 +361,10 @@ def _run(cmd,
         )
 
     if python_shell is not True and not isinstance(cmd, list):
-        cmd = shlex.split(cmd)
+        posix = True
+        if salt.utils.is_windows():
+            posix = False
+        cmd = shlex.split(cmd, posix=posix)
     if not use_vt:
         # This is where the magic happens
         try:

--- a/salt/modules/match.py
+++ b/salt/modules/match.py
@@ -70,6 +70,46 @@ def ipcidr(tgt):
         return False
 
 
+def pillar_pcre(tgt, delimiter=DEFAULT_TARGET_DELIM, delim=None):
+    '''
+    Return True if the minion matches the given pillar_pcre target. The
+    ``delimiter`` argument can be used to specify a different delimiter.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' match.pillar_pcre 'cheese:(swiss|american)'
+        salt '*' match.pillar_pcre 'clone_url|https://github\.com/.*\.git' delimiter='|'
+
+    delimiter
+        Specify an alternate delimiter to use when traversing a nested dict
+
+        .. versionadded:: 2014.7.0
+
+    delim
+        Specify an alternate delimiter to use when traversing a nested dict
+
+        .. versionadded:: 0.16.4
+        .. deprecated:: 2014.7.0
+    '''
+    if delim is not None:
+        salt.utils.warn_until(
+            'Beryllium',
+            'The \'delim\' argument to match.pillar_pcre has been deprecated '
+            'and will be removed in a future release. Please use '
+            '\'delimiter\' instead.'
+        )
+        delimiter = delim
+
+    matcher = salt.minion.Matcher({'pillar': __pillar__}, __salt__)
+    try:
+        return matcher.pillar_pcre_match(tgt, delimiter=delimiter)
+    except Exception as exc:
+        log.exception(exc)
+        return False
+
+
 def pillar(tgt, delimiter=DEFAULT_TARGET_DELIM, delim=None):
     '''
     Return True if the minion matches the given pillar target. The

--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -213,6 +213,7 @@ def get(tgt, fun, expr_form='glob'):
         grain_pcre
         compound
         pillar
+        pillar_pcre
 
     Note that all pillar matches, whether using the compound matching system or
     the pillar matching system, will be exact matches, with globbing disabled.
@@ -235,6 +236,7 @@ def get(tgt, fun, expr_form='glob'):
                      'ipcidr': __salt__['match.ipcidr'],
                      'compound': __salt__['match.compound'],
                      'pillar': __salt__['match.pillar'],
+                     'pillar_pcre': __salt__['match.pillar_pcre'],
                      }[expr_form](tgt)
         if is_target:
             data = __salt__['data.getval']('mine_cache')

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -504,9 +504,14 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
         # they would survive the previous line (in the pip.installed state).
         # Put the commas back in while making sure the names are contained in
         # quotes, this allows for proper version spec passing salt>=0.17.0
-        cmd.extend(
-            ['{0!r}'.format(p.replace(';', ',')) for p in pkgs]
-        )
+        if salt.utils.is_windows():
+            cmd.extend(
+                ['{0}'.format(p.replace(';', ',')) for p in pkgs]
+            )
+        else:
+            cmd.extend(
+                ['{0!r}'.format(p.replace(';', ',')) for p in pkgs]
+            )
 
     if editable:
         egg_match = re.compile(r'(?:#|#.*?&)egg=([^&]*)')

--- a/salt/modules/publish.py
+++ b/salt/modules/publish.py
@@ -160,6 +160,7 @@ def publish(tgt, fun, arg=None, expr_form='glob', returner='', timeout=5):
     - grain
     - grain_pcre
     - pillar
+    - pillar_pcre
     - ipcidr
     - range
     - compound

--- a/salt/modules/puppet.py
+++ b/salt/modules/puppet.py
@@ -124,8 +124,7 @@ class _Puppet(object):
         if self.subcmd == 'agent':
             # no arguments are required
             args.extend([
-                'onetime', 'verbose', 'ignorecache', 'no-daemonize',
-                'no-usecacheonfailure', 'no-splay', 'show_diff'
+                'test'
             ])
 
         # finally do this after subcmd has been matched for all remaining args
@@ -167,7 +166,10 @@ def run(*args, **kwargs):
 
     puppet.kwargs.update(salt.utils.clean_kwargs(**kwargs))
 
-    return __salt__['cmd.run_all'](repr(puppet), python_shell=False)
+    if __salt__['cmd.run_all'](repr(puppet), python_shell=False) in [0, 2]:
+        return 0
+    else:
+        return 1
 
 
 def noop(*args, **kwargs):

--- a/salt/modules/raet_publish.py
+++ b/salt/modules/raet_publish.py
@@ -120,6 +120,7 @@ def publish(tgt, fun, arg=None, expr_form='glob', returner='', timeout=5):
     - grain
     - grain_pcre
     - pillar
+    - pillar_pcre
     - ipcidr
     - range
     - compound

--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -37,7 +37,7 @@ def __virtual__():
     '''
     Set the virtual pkg module if the os is Solaris 11
     '''
-    if __grains__['os'] == 'Solaris' and float(__grains__['kernelrelease']) == 5.10:
+    if __grains__['os'] == 'Solaris' and float(__grains__['kernelrelease']) > 5.10:
         return __virtualname__
     return False
 

--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -29,7 +29,7 @@ import logging
 import salt.utils
 
 # Define the module's virtual name
-__virtualname__ = 'solarisips'
+__virtualname__ = 'pkg'
 log = logging.getLogger(__name__)
 
 
@@ -37,7 +37,7 @@ def __virtual__():
     '''
     Set the virtual pkg module if the os is Solaris 11
     '''
-    if __grains__['os'] == 'Solaris' and __grains__['kernelrelease'] == '5.11':
+    if __grains__['os'] == 'Solaris' and float(__grains__['kernelrelease']) == 5.10:
         return __virtualname__
     return False
 
@@ -129,8 +129,7 @@ def list_upgrades(refresh=False):
         refresh_db(full=True)
     upgrades = {}
     # awk is in core-os package so we can use it without checking
-    lines = __salt__['cmd.run_stdout'](
-        "/bin/pkg list -Hu | /bin/awk '{print $1}' | /bin/xargs pkg list -Hnv").splitlines()
+    lines = __salt__['cmd.run_stdout']("/bin/pkg list -Huv").splitlines()
     for line in lines:
         upgrades[_ips_get_pkgname(line)] = _ips_get_pkgversion(line)
     return upgrades

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -23,7 +23,7 @@ def __virtual__():
     '''
     Set the virtual pkg module if the os is Solaris
     '''
-    if __grains__['os'] == 'Solaris':
+    if __grains__['os'] == 'Solaris' and float(__grains__['kernelrelease']) <= 5.10:
         return __virtualname__
     return False
 

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -20,10 +20,10 @@ from __future__ import absolute_import
 # Import python libs
 import os
 import time
-import datetime
 import logging
 import hashlib
 from salt.ext.six.moves import range
+from datetime import datetime
 
 HAS_SSL = False
 try:
@@ -201,9 +201,9 @@ def maybe_fix_ssl_version(ca_name, cacert_path=None):
                 except Exception:
                     bits = 2048
                 try:
-                    days = (datetime.datetime.strptime(cert.get_notAfter(),
+                    days = (datetime.strptime(cert.get_notAfter(),
                                                        '%Y%m%d%H%M%SZ') -
-                            datetime.datetime.now()).days
+                            datetime.now()).days
                 except (ValueError, TypeError):
                     days = 365
                 subj = cert.get_subject()
@@ -418,7 +418,7 @@ def create_ca(ca_name,
                                                 key)
     write_key = True
     if os.path.exists(ca_keyp):
-        bck = "{0}.{1}".format(ca_keyp, datetime.datetime.now().strftime(
+        bck = "{0}.{1}".format(ca_keyp, datetime.now().strftime(
             "%Y%m%d%H%M%S"))
         with salt.utils.fopen(ca_keyp) as fic:
             old_key = fic.read().strip()
@@ -967,6 +967,61 @@ def create_pkcs12(ca_name, CN, passphrase='', cacert_path=None):
                     ca_name,
                     CN
                     )
+
+
+def cert_info(cert_path, digest='sha256'):
+    '''
+    Return information for a particular certificate
+
+    cert_path
+        path to the cert file
+    digest
+        what digest to use for fingerprinting
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' tls.cert_info /dir/for/certs/cert.pem
+    '''
+    # format that OpenSSL returns dates in
+    date_fmt = '%Y%m%d%H%M%SZ'
+
+    with salt.utils.fopen(cert_path) as cert_file:
+        cert = OpenSSL.crypto.load_certificate(
+                OpenSSL.crypto.FILETYPE_PEM,
+                cert_file.read()
+            )
+    ret = {
+        'fingerprint': cert.digest(digest),
+        'subject': dict(cert.get_subject().get_components()),
+        'issuer': dict(cert.get_issuer().get_components()),
+        'serial_number': cert.get_serial_number(),
+        'not_before': time.mktime(datetime.strptime(cert.get_notBefore(), date_fmt).timetuple()),
+        'not_after': time.mktime(datetime.strptime(cert.get_notAfter(), date_fmt).timetuple()),
+    }
+
+    # add additional info if your version of pyOpenSSL supports it
+    if hasattr(cert, 'get_extension_count'):
+        ret['extensions'] = {}
+        for i in range(cert.get_extension_count()):
+            ext = cert.get_extension(i)
+            ret['extensions'][ext.get_short_name()] = ext
+
+    if 'subjectAltName' in ret.get('extensions', {}):
+        valid_names = set()
+        for name in ret['extensions']['subjectAltName']._subjectAltNameString().split(", "):
+            if not name.startswith('DNS:'):
+                log.error('Cert {0} has an entry ({1}) which does not start with DNS:'.format(cert_path, name))
+            else:
+                valid_names.add(name[4:])
+        ret['subject_alt_names'] = valid_names
+
+    if hasattr(cert, 'get_signature_algorithm'):
+        ret['signature_algorithm'] = cert.get_signature_algorithm()
+
+    return ret
+
 
 if __name__ == '__main__':
     #create_ca('koji', days=365, **cert_sample_meta)

--- a/salt/states/alias.py
+++ b/salt/states/alias.py
@@ -53,7 +53,7 @@ def present(name, target):
         return ret
     else:
         ret['result'] = False
-        ret['comment'] = 'Failed to set alias'
+        ret['comment'] = 'Failed to set alias {0} -> {1}'.format(name, target)
         return ret
 
 
@@ -83,5 +83,5 @@ def absent(name):
         return ret
     else:
         ret['result'] = False
-        ret['comment'] = 'Failed to remove alias'
+        ret['comment'] = 'Failed to remove alias {0}'.format(name)
         return ret

--- a/salt/states/tls.py
+++ b/salt/states/tls.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+'''
+Enforce state for SSL/TLS.
+=========================================================================
+
+'''
+
+import time
+import datetime
+
+__virtualname__ = 'tls'
+
+
+def __virtual__():
+    if 'tls.cert_info' not in __salt__:
+        return False
+
+    return __virtualname__
+
+
+def valid_certificate(
+        name,
+        weeks=0,
+        days=0,
+        hours=0,
+        minutes=0,
+        seconds=0,
+    ):
+    '''
+    Verify that a TLS certificate is valid now and (optionally) will be valid
+    for the time specified through weeks, days, hours, minutes, and seconds.
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    now = time.time()
+    cert_info = __salt__['tls.cert_info'](name)
+
+    # verify that the cert is valid *now*
+    if now < cert_info['not_before']:
+        ret['comment'] = 'Certificate is not yet valid'
+        return ret
+    if now > cert_info['not_after']:
+        ret['comment'] = 'Certificate is expired'
+        return ret
+
+    # verify the cert will be valid for defined time
+    delta_remaining = datetime.timedelta(seconds=cert_info['not_after']-now)
+    delta_kind_map = {
+        'weeks': weeks,
+        'days': days,
+        'hours': hours,
+        'minutes': minutes,
+        'seconds': seconds,
+    }
+
+    delta_min = datetime.timedelta(**delta_kind_map)
+    # if ther eisn't enough time remaining, we consider it a failure
+    if delta_remaining < delta_min:
+        ret['comment'] = 'Certificate will expire in {0}, which is less than {1}'.format(delta_remaining, delta_min)
+        return ret
+
+    ret['result'] = True
+    ret['comment'] = 'Certificate is valid for {0}'.format(delta_remaining)
+    return ret

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -102,7 +102,7 @@ try:
     libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("c"))
     res_init = libc.__res_init
     HAS_RESINIT = True
-except:
+except (ImportError, OSError, AttributeError):
     HAS_RESINIT = False
 
 # Import salt libs

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -527,9 +527,9 @@ def dns_check(addr, safe=False, ipv6=False):
     '''
     error = False
     try:
-	# issue #21397: force glibc to re-read resolv.conf
-	if HAS_RESINIT:
-	    res_init()
+        # issue #21397: force glibc to re-read resolv.conf
+        if HAS_RESINIT:
+            res_init()
         hostnames = socket.getaddrinfo(
             addr, None, socket.AF_UNSPEC, socket.SOCK_STREAM
         )

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -96,6 +96,15 @@ try:
 except ImportError:
     HAS_SETPROCTITLE = False
 
+try:
+    import ctypes
+    import ctypes.util
+    libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("c"))
+    res_init = libc.__res_init
+    HAS_RESINIT = True
+except:
+    HAS_RESINIT = False
+
 # Import salt libs
 import salt._compat
 import salt.exitcodes
@@ -518,6 +527,9 @@ def dns_check(addr, safe=False, ipv6=False):
     '''
     error = False
     try:
+	# issue #21397: force glibc to re-read resolv.conf
+	if HAS_RESINIT:
+	    res_init()
         hostnames = socket.getaddrinfo(
             addr, None, socket.AF_UNSPEC, socket.SOCK_STREAM
         )

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -219,6 +219,16 @@ class CkMinions(object):
         '''
         return self._check_cache_minions(expr, delimiter, greedy, 'pillar')
 
+    def _check_pillar_pcre_minions(self, expr, delimiter, greedy):
+        '''
+        Return the minions found by looking via pillar with PCRE
+        '''
+        return self._check_cache_minions(expr,
+                                         delimiter,
+                                         greedy,
+                                         'pillar',
+                                         regex_match=True)
+
     def _check_pillar_exact_minions(self, expr, delimiter, greedy):
         '''
         Return the minions found by looking via pillar
@@ -360,6 +370,7 @@ class CkMinions(object):
             ref = {'G': self._check_grain_minions,
                    'P': self._check_grain_pcre_minions,
                    'I': self._check_pillar_minions,
+                   'J': self._check_pillar_pcre_minions,
                    'L': self._check_list_minions,
                    'S': self._check_ipcidr_minions,
                    'E': self._check_pcre_minions,
@@ -372,13 +383,13 @@ class CkMinions(object):
             tokens = expr.split()
             for match in tokens:
                 # Try to match tokens from the compound target, first by using
-                # the 'G, X, I, L, S, E' matcher types, then by hostname glob.
+                # the 'G, X, I, J, L, S, E' matcher types, then by hostname glob.
                 if '@' in match and match[1] == '@':
                     comps = match.split('@')
                     matcher = ref.get(comps[0])
 
                     matcher_args = ['@'.join(comps[1:])]
-                    if comps[0] in ('G', 'P', 'I'):
+                    if comps[0] in ('G', 'P', 'I', 'J'):
                         matcher_args.append(delimiter)
                     matcher_args.append(True)
 
@@ -532,6 +543,7 @@ class CkMinions(object):
         ref = {'G': 'grain',
                'P': 'grain_pcre',
                'I': 'pillar',
+               'J': 'pillar_pcre',
                'L': 'list',
                'S': 'ipcidr',
                'E': 'pcre',
@@ -539,7 +551,8 @@ class CkMinions(object):
         infinite = [
                 'node',
                 'ipcidr',
-                'pillar']
+                'pillar',
+                'pillar_pcre']
         if not self.opts.get('minion_data_cache', False):
             infinite.append('grain')
             infinite.append('grain_pcre')
@@ -612,7 +625,7 @@ class CkMinions(object):
         '''
         if publish_validate:
             v_tgt_type = tgt_type
-            if tgt_type.lower() == 'pillar':
+            if tgt_type.lower() in ('pillar', 'pillar_pcre'):
                 v_tgt_type = 'pillar_exact'
             elif tgt_type.lower() == 'compound':
                 v_tgt_type = 'compound_pillar_exact'
@@ -620,7 +633,8 @@ class CkMinions(object):
             minions = set(self.check_minions(tgt, tgt_type))
             mismatch = bool(minions.difference(v_minions))
             # If the non-exact match gets more minions than the exact match
-            # then pillar globbing is being used, and we have a problem
+            # then pillar globbing or PCRE is being used, and we have a
+            # problem
             if mismatch:
                 return False
         # compound commands will come in a list so treat everything as a list

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -939,6 +939,15 @@ class ExtendedTargetOptionsMixIn(TargetOptionsMixIn):
                   'expression:\n"role:production*"')
         )
         group.add_option(
+            '-J', '--pillar-pcre',
+            default=False,
+            action='store_true',
+            help=('Instead of using shell globs to evaluate the target '
+                  'use a pillar value to identify targets, the syntax '
+                  'for the target is the pillar key followed by a pcre'
+                  'regular expression:\n"role:prod.*"')
+        )
+        group.add_option(
             '-S', '--ipcidr',
             default=False,
             action='store_true',

--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -47,10 +47,17 @@ class Reactor(multiprocessing.Process, salt.state.Compiler):
 
         for fn_ in glob.glob(glob_ref):
             try:
-                react.update(self.render_template(
+                res = self.render_template(
                     fn_,
                     tag=tag,
-                    data=data))
+                    data=data)
+
+                # for #20841, inject the sls name here since verify_high()
+                # assumes it exists in case there are any errors
+                for name in res:
+                    res[name]['__sls__'] = fn_
+
+                react.update(res)
             except Exception:
                 log.error('Failed to render "{0}": '.format(fn_), exc_info=True)
         return react
@@ -101,15 +108,19 @@ class Reactor(multiprocessing.Process, salt.state.Compiler):
         log.debug('Compiling reactions for tag {0}'.format(tag))
         high = {}
         chunks = []
-        for fn_ in reactors:
-            high.update(self.render_reaction(fn_, tag, data))
-        if high:
-            errors = self.verify_high(high)
-            if errors:
-                log.error(('Unable to render reactions for event {0} due to '
-                           'errors ({1}) in one or more of the sls files ({2})').format(tag, errors, reactors))
-                return []  # We'll return nothing since there was an error
-            chunks = self.order_chunks(self.compile_high_data(high))
+        try:
+            for fn_ in reactors:
+                high.update(self.render_reaction(fn_, tag, data))
+            if high:
+                errors = self.verify_high(high)
+                if errors:
+                    log.error(('Unable to render reactions for event {0} due to '
+                               'errors ({1}) in one or more of the sls files ({2})').format(tag, errors, reactors))
+                    return []  # We'll return nothing since there was an error
+                chunks = self.order_chunks(self.compile_high_data(high))
+        except Exception as exc:
+            log.error('Exception trying to compile reactions: {0}'.format(exc), exc_info=True)
+
         return chunks
 
     def call_reactions(self, chunks):

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -379,6 +379,11 @@ class Schedule(object):
             jobcount = 0
             for basefilename in os.listdir(salt.minion.get_proc_dir(self.opts['cachedir'])):
                 fn_ = os.path.join(salt.minion.get_proc_dir(self.opts['cachedir']), basefilename)
+                if not os.path.exists(fn_):
+                    log.debug('schedule.handle_func: {0} was processed '
+                              'in another thread, skipping.'.format(
+                                  basefilename))
+                    continue
                 with salt.utils.fopen(fn_, 'r') as fp_:
                     job = salt.payload.Serial(self.opts).load(fp_)
                     if job:

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -303,6 +303,18 @@ def check_user(user):
             os.setgid(pwuser.pw_gid)
             os.setuid(pwuser.pw_uid)
 
+            # We could just reset the whole environment but let's just override
+            # the variables we can get from pwuser
+            if 'HOME' in os.environ:
+                os.environ['HOME'] = pwuser.pw_dir
+
+            if 'SHELL' in os.environ:
+                os.environ['SHELL'] = pwuser.pw_shell
+
+            for envvar in ('USER', 'LOGNAME'):
+                if envvar in os.environ:
+                    os.environ[envvar] = pwuser.pw_name
+
         except OSError:
             msg = 'Salt configured to run as user "{0}" but unable to switch.'
             msg = msg.format(user)

--- a/tests/integration/netapi/rest_tornado/test_app.py
+++ b/tests/integration/netapi/rest_tornado/test_app.py
@@ -414,13 +414,17 @@ class TestJobsSaltAPIHandler(SaltnadoTestCase):
                                )
         response = self.wait(timeout=10)
         response_obj = json.loads(response.body)['return'][0]
-        for jid, ret in response_obj.iteritems():
-            self.assertIn('Function', ret)
-            self.assertIn('Target', ret)
-            self.assertIn('Target-type', ret)
-            self.assertIn('User', ret)
-            self.assertIn('StartTime', ret)
-            self.assertIn('Arguments', ret)
+        try:
+            for jid, ret in response_obj.iteritems():
+                self.assertIn('Function', ret)
+                self.assertIn('Target', ret)
+                self.assertIn('Target-type', ret)
+                self.assertIn('User', ret)
+                self.assertIn('StartTime', ret)
+                self.assertIn('Arguments', ret)
+        except AttributeError as attribute_error:
+            print json.loads(response.body)
+            raise
 
         # test with a specific JID passed in
         jid = response_obj.iterkeys().next()

--- a/tests/integration/shell/matcher.py
+++ b/tests/integration/shell/matcher.py
@@ -191,6 +191,21 @@ class MatchTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
         self.assertIn('minion', data)
         self.assertIn('sub_minion', data)
 
+    def test_repillar(self):
+        '''
+        test salt pillar PCRE matcher
+        '''
+        data = self.run_salt(
+            '-t 1 --pillar-pcre "monty:^(python|hall)$" test.ping'
+        )
+        data = '\n'.join(data)
+        self.assertIn('minion', data)
+        self.assertNotIn('sub_minion', data)
+        data = self.run_salt('--pillar-pcre "knights:^(Robin|Lancelot)$" test.ping')
+        data = '\n'.join(data)
+        self.assertIn('sub_minion', data)
+        self.assertNotIn('minion', data.replace('sub_minion', 'stub'))
+
     def test_ipcidr(self):
         subnets_data = self.run_salt('--out yaml \'*\' network.subnets')
         yaml_data = yaml.load('\n'.join(subnets_data))

--- a/tests/unit/states/alias_test.py
+++ b/tests/unit/states/alias_test.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+'''
+unit tests for the alias state
+'''
+
+# Import Salt Libs
+from salt.states import alias
+
+# Import Salt Testing Libs
+from salttesting import skipIf, TestCase
+from salttesting.helpers import ensure_in_syspath
+from salttesting.mock import (
+    NO_MOCK,
+    NO_MOCK_REASON,
+    MagicMock,
+    patch
+)
+
+ensure_in_syspath('../../')
+
+alias.__opts__ = {}
+alias.__salt__ = {}
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class AliasTest(TestCase):
+    '''
+    Validate the alias state
+    '''
+    def test_present_has_target(self):
+        '''
+        test alias.present has target already
+        '''
+        name = 'saltdude'
+        target = 'dude@saltstack.com'
+        ret = {'comment': 'Alias {0} already present'.format(name),
+               'changes': {},
+               'name': name,
+               'result': True}
+
+        has_target = MagicMock(return_value=True)
+        with patch.dict(alias.__salt__, {'aliases.has_target': has_target}):
+            self.assertEqual(alias.present(name, target), ret)
+
+    def test_present_has_not_target_test(self):
+        '''
+        test alias.present has't got target yet test mode
+        '''
+        name = 'saltdude'
+        target = 'dude@saltstack.com'
+        ret = {'comment': 'Alias {0} -> {1} is set to be added'.format(name, target),
+               'changes': {},
+               'name': name,
+               'result': None}
+
+        has_target = MagicMock(return_value=False)
+        with patch.dict(alias.__salt__, {'aliases.has_target': has_target}):
+            with patch.dict(alias.__opts__, {'test': True}):
+                self.assertEqual(alias.present(name, target), ret)
+
+    def test_present_set_target(self):
+        '''
+        test alias.present set target
+        '''
+        name = 'saltdude'
+        target = 'dude@saltstack.com'
+        ret = {'comment': 'Set email alias {0} -> {1}'.format(name, target),
+               'changes': {'alias': name},
+               'name': name,
+               'result': True}
+
+        has_target = MagicMock(return_value=False)
+        set_target = MagicMock(return_value=True)
+        with patch.dict(alias.__salt__, {'aliases.has_target': has_target}):
+            with patch.dict(alias.__opts__, {'test': False}):
+                with patch.dict(alias.__salt__, {'aliases.set_target': set_target}):
+                    self.assertEqual(alias.present(name, target), ret)
+
+    def test_present_set_target_failed(self):
+        '''
+        test alias.present set target failure
+        '''
+        name = 'saltdude'
+        target = 'dude@saltstack.com'
+        ret = {'comment': 'Failed to set alias {0} -> {1}'.format(name, target),
+               'changes': {},
+               'name': name,
+               'result': False}
+
+        has_target = MagicMock(return_value=False)
+        set_target = MagicMock(return_value=False)
+        with patch.dict(alias.__salt__, {'aliases.has_target': has_target}):
+            with patch.dict(alias.__opts__, {'test': False}):
+                with patch.dict(alias.__salt__, {'aliases.set_target': set_target}):
+                    self.assertEqual(alias.present(name, target), ret)
+
+    def test_absent_already_gone(self):
+        '''
+        test alias.absent already gone
+        '''
+        name = 'saltdude'
+        target = 'dude@saltstack.com'
+        ret = {'comment': 'Alias {0} already absent'.format(name),
+               'changes': {},
+               'name': name,
+               'result': True}
+
+        get_target = MagicMock(return_value=False)
+        with patch.dict(alias.__salt__, {'aliases.get_target': get_target}):
+            self.assertEqual(alias.absent(name), ret)
+
+    def test_absent_not_gone_test(self):
+        '''
+        test alias.absent already gone test mode
+        '''
+        name = 'saltdude'
+        target = 'dude@saltstack.com'
+        ret = {'comment': 'Alias {0} is set to be removed'.format(name),
+               'changes': {},
+               'name': name,
+               'result': None}
+
+        get_target = MagicMock(return_value=True)
+        with patch.dict(alias.__salt__, {'aliases.get_target': get_target}):
+            with patch.dict(alias.__opts__, {'test': True}):
+                self.assertEqual(alias.absent(name), ret)
+
+    def test_absent_rm_alias(self):
+        '''
+        test alias.absent remove alias
+        '''
+        name = 'saltdude'
+        target = 'dude@saltstack.com'
+        ret = {'comment': 'Removed alias {0}'.format(name),
+               'changes': {'alias': name},
+               'name': name,
+               'result': True}
+
+        get_target = MagicMock(return_value=True)
+        rm_alias = MagicMock(return_value=True)
+        with patch.dict(alias.__salt__, {'aliases.get_target': get_target}):
+            with patch.dict(alias.__opts__, {'test': False}):
+                with patch.dict(alias.__salt__, {'aliases.rm_alias': rm_alias}):
+                    self.assertEqual(alias.absent(name), ret)
+
+    def test_absent_rm_alias_failed(self):
+        '''
+        test alias.absent remove alias failure
+        '''
+        name = 'saltdude'
+        target = 'dude@saltstack.com'
+        ret = {'comment': 'Failed to remove alias {0}'.format(name),
+               'changes': {},
+               'name': name,
+               'result': False}
+
+        get_target = MagicMock(return_value=True)
+        rm_alias = MagicMock(return_value=False)
+        with patch.dict(alias.__salt__, {'aliases.get_target': get_target}):
+            with patch.dict(alias.__opts__, {'test': False}):
+                with patch.dict(alias.__salt__, {'aliases.rm_alias': rm_alias}):
+                    self.assertEqual(alias.absent(name), ret)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(AliasTest, needs_daemon=False)


### PR DESCRIPTION
Add option `-J/--pillar-pcre` to match on pillar `PCRE`s.

Is there a particular reason why matching on pillar `PCRE` is absent?  This greatly simplifies things for me.

Any points of security should be scrutinized by someone who knows what is going on in `minions.py:CkMinions:auth_check()`.

This is only mildly tested.
