### PR TITLE
Fix python 2.6 syntax error in salt/grains/core.py

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1661,7 +1661,7 @@ def _hw_data(osdata):
             'biosreleasedate': __salt__['smbios.get']('bios-release-date'),
             'uuid': __salt__['smbios.get']('system-uuid')
         }
-        grains = {key: val for key, val in grains.items() if val is not None}
+        grains = dict([(key, val) for key, val in grains.items() if val is not None])
         uuid = __salt__['smbios.get']('system-uuid')
         if uuid is not None:
             grains['uuid'] = uuid.lower()


### PR DESCRIPTION
Fixes #22327

This should also clear up some of the test failures for Ubuntu 10 and CentOS 6 on the develop branch.
