### PR TITLE
[2014.7] Fix some salt-ssh issues with Fedora 21

### DIFF
--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -6,6 +6,7 @@ Manage transport commands via ssh
 # Import python libs
 import re
 import os
+import json
 import time
 import logging
 import subprocess
@@ -92,7 +93,7 @@ class Shell(object):
             options.append('PasswordAuthentication=yes')
         else:
             options.append('PasswordAuthentication=no')
-        if self.opts['_ssh_version'] > '4.9':
+        if self.opts.get('_ssh_version', '') > '4.9':
             options.append('GSSAPIAuthentication=no')
         options.append('ConnectTimeout={0}'.format(self.timeout))
         if self.opts.get('ignore_host_keys'):
@@ -153,7 +154,7 @@ class Shell(object):
         '''
         if self.passwd:
             # Using single quotes prevents shell expansion and
-            # passwords containig '$'
+            # passwords containing '$'
             return "{0} {1} '{2} -p {3} {4}@{5}'".format(
                     'ssh-copy-id',
                     '-i {0}.pub'.format(self.priv),
@@ -170,7 +171,7 @@ class Shell(object):
         '''
         if self.passwd:
             # Using single quotes prevents shell expansion and
-            # passwords containig '$'
+            # passwords containing '$'
             return "{0} {1} {2} -p {3} {4}@{5}".format(
                     'ssh-copy-id',
                     '-i {0}.pub'.format(self.priv),
@@ -197,6 +198,7 @@ class Shell(object):
         # TODO: if tty, then our SSH_SHIM cannot be supplied from STDIN Will
         # need to deliver the SHIM to the remote host and execute it there
 
+        opts = ''
         tty = self.tty
         if ssh != 'ssh':
             tty = False
@@ -317,52 +319,38 @@ class Shell(object):
         sent_passwd = 0
         ret_stdout = ''
         ret_stderr = ''
-        while True:
-            stdout, stderr = term.recv()
-            if stdout:
-                ret_stdout += stdout
-            if stderr:
-                ret_stderr += stderr
-            if stdout and SSH_PASSWORD_PROMPT_RE.search(stdout):
-                if len(stdout) > 256:
-                    pass
-                elif not self.passwd:
-                    try:
-                        term.close(terminate=True, kill=True)
-                    except salt.utils.vt.TerminalException:
-                        pass
-                    return '', 'Permission denied, no authentication information', 254
-                if sent_passwd < passwd_retries:
-                    term.sendline(self.passwd)
-                    sent_passwd += 1
-                    continue
-                else:
-                    # asking for a password, and we can't seem to send it
-                    try:
-                        term.close(terminate=True, kill=True)
-                    except salt.utils.vt.TerminalException:
-                        pass
-                    return '', 'Password authentication failed', 254
-            elif stdout and KEY_VALID_RE.search(stdout):
-                if key_accept:
-                    term.sendline('yes')
-                    continue
-                else:
-                    term.sendline('no')
-                    ret_stdout = ('The host key needs to be accepted, to '
-                                  'auto accept run salt-ssh with the -i '
-                                  'flag:\n{0}').format(stdout)
-                    return ret_stdout, '', 254
-            if not term.isalive():
-                while True:
-                    stdout, stderr = term.recv()
-                    if stdout:
-                        ret_stdout += stdout
-                    if stderr:
-                        ret_stderr += stderr
-                    if stdout is None and stderr is None:
-                        break
-                term.close(terminate=True, kill=True)
-                break
-            time.sleep(0.5)
-        return ret_stdout, ret_stderr, term.exitstatus
+
+        try:
+            while term.has_unread_data:
+                stdout, stderr = term.recv()
+                if stdout:
+                    ret_stdout += stdout
+                if stderr:
+                    ret_stderr += stderr
+                if stdout and SSH_PASSWORD_PROMPT_RE.search(stdout):
+                    if not self.passwd:
+                        return '', 'Permission denied, no authentication information', 254
+                    if sent_passwd < passwd_retries:
+                        term.sendline(self.passwd)
+                        sent_passwd += 1
+                        continue
+                    else:
+                        # asking for a password, and we can't seem to send it
+                        return '', 'Password authentication failed', 254
+                elif stdout and KEY_VALID_RE.search(stdout):
+                    if key_accept:
+                        term.sendline('yes')
+                        continue
+                    else:
+                        term.sendline('no')
+                        ret_stdout = ('The host key needs to be accepted, to '
+                                      'auto accept run salt-ssh with the -i '
+                                      'flag:\n{0}').format(stdout)
+                        return ret_stdout, '', 254
+                elif stdout and stdout.endswith('_||ext_mods||_'):
+                    mods_raw = json.dumps(self.mods, separators=(',', ':')) + '|_E|0|'
+                    term.sendline(mods_raw)
+                time.sleep(0.5)
+            return ret_stdout, ret_stderr, term.exitstatus
+        finally:
+            term.close(terminate=True, kill=True)

--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -182,7 +182,7 @@ def gen_thin(cachedir, extra_mods='', overwrite=False, so_mods=''):
             # top is a single file module
             tfp.add(base)
             continue
-        for root, dirs, files in os.walk(base):
+        for root, dirs, files in os.walk(base, followlinks=True):
             for name in files:
                 if not name.endswith(('.pyc', '.pyo')):
                     tfp.add(os.path.join(root, name))

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -522,13 +522,15 @@ class Terminal(object):
                     os.close(tty_fd)
 
                 # Verify we now have a controlling tty.
-                tty_fd = os.open('/dev/tty', os.O_WRONLY)
-                if tty_fd < 0:
-                    raise TerminalException(
-                        'Could not open controlling tty, /dev/tty'
-                    )
-                else:
-                    os.close(tty_fd)
+                if os.name != 'posix':
+                    # Only do this check in not BSD-like operating systems. BSD-like operating systems breaks at this point
+                    tty_fd = os.open('/dev/tty', os.O_WRONLY)
+                    if tty_fd < 0:
+                        raise TerminalException(
+                            'Could not open controlling tty, /dev/tty'
+                        )
+                    else:
+                        os.close(tty_fd)
                 # <---- Make STDOUT the controlling PTY ----------------------
 
                 # ----- Duplicate Descriptors ------------------------------->


### PR DESCRIPTION
`requests` is packaged with symlinks in `requests/packages`. Follow those symlinks. At least until 2015.2 when we can finally be rid of `requests` and its nonsense.

Also pull some salt-ssh code in from 2015.2 which fixes some issues interacting with vt.
