### PR TITLE
2015.2: Fix batching

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -141,12 +141,12 @@ class CkMinions(object):
         '''
         Return the minions found by looking via regular expressions
         '''
-        cwd = os.getcwd()
-        os.chdir(os.path.join(self.opts['pki_dir'], self.acc))
-        reg = re.compile(expr)
-        ret = [fn_ for fn_ in os.listdir('.') if reg.match(fn_)]
-        os.chdir(cwd)
-        return ret
+        try:
+            minions = os.listdir(os.path.join(self.opts['pki_dir'], self.acc))
+            reg = re.compile(expr)
+            return [m for m in minions if reg.match(m)]
+        except OSError:
+            return []
 
     def _check_cache_minions(self,
                              expr,

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -124,7 +124,6 @@ class CkMinions(object):
         except OSError:
             return []
 
-
     def _check_list_minions(self, expr, greedy):  # pylint: disable=unused-argument
         '''
         Return the minions found by looking via a list
@@ -287,8 +286,10 @@ class CkMinions(object):
                 'Range matcher unavailable (unable to import seco.range, '
                 'module most likely not installed)'
             )
+        if not hasattr(self, '_range'):
+            self._range = seco.range.Range(self.opts['range_server'])
         try:
-            return range_.expand(expr)
+            return self._range.expand(expr)
         except seco.range.RangeException as exc:
             log.error(
                 'Range exception in compound match: {0}'.format(exc)

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -99,6 +99,11 @@ def nodegroup_comp(group, nodegroups, skip=None):
 class CkMinions(object):
     '''
     Used to check what minions should respond from a target
+
+    Note: This is a best-effort set of the minions that would match a target.
+    Depending on master configuration (grains caching, etc.) and topology (syndics)
+    the list may be a subset-- but we err on the side of too-many minions in this
+    class.
     '''
     def __init__(self, opts):
         self.opts = opts

--- a/tests/unit/cli/batch_test.py
+++ b/tests/unit/cli/batch_test.py
@@ -21,7 +21,7 @@ class BatchTestCase(TestCase):
     '''
 
     def setUp(self):
-        opts = {'batch': '', 'conf_file': {}, 'tgt': '', 'transport': ''}
+        opts = {'batch': '', 'conf_file': {}, 'tgt': '', 'transport': '', 'timeout': 5}
         mock_client = MagicMock()
         with patch('salt.client.get_local_client', MagicMock(return_value=mock_client)):
             with patch('salt.client.LocalClient.cmd_iter', MagicMock(return_value=[])):
@@ -33,7 +33,7 @@ class BatchTestCase(TestCase):
         '''
         Tests passing batch value as a number
         '''
-        self.batch.opts = {'batch': '2'}
+        self.batch.opts = {'batch': '2', 'timeout': 5}
         self.batch.minions = ['foo', 'bar']
         self.assertEqual(Batch.get_bnum(self.batch), 2)
 
@@ -41,7 +41,7 @@ class BatchTestCase(TestCase):
         '''
         Tests passing batch value as percentage
         '''
-        self.batch.opts = {'batch': '50%'}
+        self.batch.opts = {'batch': '50%', 'timeout': 5}
         self.batch.minions = ['foo']
         self.assertEqual(Batch.get_bnum(self.batch), 1)
 
@@ -49,7 +49,7 @@ class BatchTestCase(TestCase):
         '''
         Tests passing batch value as percentage over 100%
         '''
-        self.batch.opts = {'batch': '160%'}
+        self.batch.opts = {'batch': '160%', 'timeout': 5}
         self.batch.minions = ['foo', 'bar', 'baz']
         self.assertEqual(Batch.get_bnum(self.batch), 4)
 


### PR DESCRIPTION
The attempt to fix #18358 actually introduced a fairly large bug. The CKMinions class is intended to return (best effort) a super-set of the minions that would match the targeting criteria for a job-- _not_ the actual ones. This means that in a variety of situations (grains caching disabled, etc.) CKMinions will return a list of _all_ minions. Batching will then take that response and dutifully batch over _all_ minions in a cluster-- which isn't good.

This PR attempts to strike a balance between getting all the minions intended and not getting _all_ minions to more closely match the regular CLI behavior. In the regular CLI we consider a job as completed once all minions aren't running the job anymore. In this batching implementation we will ping all minions, wait up to timeout, then start the batching. In the event of minions returning during the batching we'll add them to the list of targets.

Also, while I was looking around in there I noticed a few things in CKMinions that were doing way more than necessary (especially range!).
