### PR TITLE
Added a `cmd` method to the Caller() class for consistency with *Clients

### DIFF
--- a/doc/ref/clients/index.rst
+++ b/doc/ref/clients/index.rst
@@ -81,7 +81,7 @@ Salt Caller
 -----------
 
 .. autoclass:: salt.client.Caller
-    :members: function
+    :members: cmd
 
 RunnerClient
 ------------


### PR DESCRIPTION
This adds a new method to the Caller() class which is intended for use
from the Python API. The existing CLI behavior is untouched.

Whether to use `Caller().function()` or `Caller().sminion.functions`
causes the occasional confusion. Also using `function` parses args and
kwargs in a way intended for use from the CLI (I think) which can cause
unexpected behavior at the Python level.

@thatch45 thoughts?
