### PR TITLE
Make iptables module build_rules accept protocol as an alias for proto

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -159,14 +159,20 @@ def build_rule(table=None, chain=None, command=None, position='', full=None, fam
         rule += '-o {0} '.format(kwargs['of'])
         del kwargs['of']
 
-    if 'proto' in kwargs:
-        if kwargs['proto'].startswith('!') or kwargs['proto'].startswith('not'):
-            kwargs['proto'] = re.sub(bang_not_pat, '', kwargs['proto'])
+    if 'protocol' in kwargs:
+        proto = kwargs['protocol']
+        del kwargs['protocol']
+    elif 'proto' in kwargs:
+        proto = kwargs['proto']
+        del kwargs['proto']
+
+    if proto:
+        if proto.startswith('!') or proto.startswith('not'):
+            proto = re.sub(bang_not_pat, '', proto)
             rule += '! '
 
-        rule += '-p {0} '.format(kwargs['proto'])
+        rule += '-p {0} '.format(proto)
         proto = True
-        del kwargs['proto']
 
     if 'match' in kwargs:
         if not isinstance(kwargs['match'], list):


### PR DESCRIPTION
The salt documentation mentions that **kwargs passed to an iptables state such as iptables.append are passed to the iptables command as a long command line option ([here](https://github.com/saltstack/salt/blob/a60579bcf5a3bbb6c94191d1e4aebe7da1242959/salt/states/iptables.py#L309-L312), for example). This is not the case, as `--proto` is not an iptables option, whereas `--protocol` is.

As far as I can tell, the option is `--proto` for some other iptables commands, but not the main one. I think the most flexible solution here is to just make them both work, which is what this change does.
