### PR TITLE
make the redis-returner use a pipeline

### DIFF
--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -98,10 +98,12 @@ def returner(ret):
     Return data to a redis data store
     '''
     serv = _get_serv(ret)
-    serv.set('{0}:{1}'.format(ret['id'], ret['jid']), json.dumps(ret))
-    serv.lpush('{0}:{1}'.format(ret['id'], ret['fun']), ret['jid'])
-    serv.sadd('minions', ret['id'])
-    serv.sadd('jids', ret['jid'])
+    pipe = serv.pipeline()
+    pipe.set('{0}:{1}'.format(ret['id'], ret['jid']), json.dumps(ret))
+    pipe.lpush('{0}:{1}'.format(ret['id'], ret['fun']), ret['jid'])
+    pipe.sadd('minions', ret['id'])
+    pipe.sadd('jids', ret['jid'])
+    pipe.execute()
 
 
 def save_load(jid, load):


### PR DESCRIPTION
This feature is documented here: http://redis.io/topics/pipelining
In general, this commit makes redis_return 4 times faster, which is
especially noticable when using a remote redis server with higher RTTs.

When using `master_job_cache`, this can be a major speedup when many
minions are returning at the same time, as the salt master does not
write return data once per job, but once for each minion. The saved time
is 3*RTT*n, with n being the number of minions participating in a job.

When using `ext_job_cache`, or when redis is connected via a loopback
interface the gain by using a pipeline is neglectable.
