### PR TITLE
Corrected output for iptables rule saved to file

### DIFF
--- a/salt/states/iptables.py
+++ b/salt/states/iptables.py
@@ -350,7 +350,7 @@ def append(name, family='ipv4', **kwargs):
             if __rules != __saved_rules:
                 __salt__['iptables.save'](filename, family=family)
                 ret['comment'] += ('\nSaved iptables rule for {0} to: '
-                                   '{1} for {2}'.format(name, command.strip(), family))
+                                   '{1} for {2}'.format(name, filename, family))
         return ret
     if __opts__['test']:
         ret['comment'] = 'iptables rule for {0} needs to be set ({1}) for {2}'.format(


### PR DESCRIPTION
Output currently looks like this - the `iptables` invocation is displayed twice, which I believe is because of this wrong argument being passed to `str.format`.

```
          ID: iptables-rule-http-server-ipv6-tcp-80-incoming
    Function: iptables.append
        Name: http-server-ipv6-tcp-80-incoming
      Result: True
     Comment: iptables rule for http-server-ipv6-tcp-80-incoming already set (/sbin/ip6tables --wait -t filter -A INPUT  -p tcp -m state --state ESTABLISHED --sport 80 --jump ACCEPT) for ipv6
              Saved iptables rule for http-server-ipv6-tcp-80-incoming to: /sbin/ip6tables --wait -t filter -A INPUT  -p tcp -m state --state ESTABLISHED --sport 80 --jump ACCEPT for ipv6
     Started: 20:48:23.650130
    Duration: 349.021 ms
     Changes:
```
