### PR TITLE
Modify the Cassandra management and returner modules

### DIFF
--- a/salt/modules/cassandra_cql.py
+++ b/salt/modules/cassandra_cql.py
@@ -59,6 +59,7 @@ try:
 except ImportError:
     pass
 
+
 def __virtual__():
     '''
     Return virtual name of the module only if the python driver can be loaded.
@@ -135,9 +136,9 @@ def _connect(contact_points=None, port=None, cql_user=None, cql_pass=None):
     # function, or something similar for each loaded module, connection pools
     # and the like can be gracefully reclaimed/shutdown.
     if (__context__
-       and 'cassandra_cql_returner_cluster' in __context__
-       and 'cassandra_cql_returner_session' in __context__):
-       return __context__['cassandra_cql_returner_cluster'], __context__['cassandra_cql_returner_session']
+        and 'cassandra_cql_returner_cluster' in __context__
+        and 'cassandra_cql_returner_session' in __context__):
+        return __context__['cassandra_cql_returner_cluster'], __context__['cassandra_cql_returner_session']
     else:
         contact_points = _load_properties(property_name=contact_points, config_option='cluster')
         contact_points = contact_points if isinstance(contact_points, list) else contact_points.split(',')

--- a/salt/returners/cassandra_cql_return.py
+++ b/salt/returners/cassandra_cql_return.py
@@ -146,6 +146,7 @@ def __virtual__():
 
     return True
 
+
 def returner(ret):
     '''
     Return data to one of potentially many clustered cassandra nodes


### PR DESCRIPTION
Use context dunder (`__context__`) to store a cassandra Cluster
(connection pool). This will allow each worker thread have a
connection pool from which to create sessions (lease connections.)

Refactor the Salt Cassandra schema to use "minion_id" insted of
"id".
