### PR TITLE
Support unicode in file.recurse

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -64,7 +64,7 @@ class Client(object):
         Make sure that this path is intended for the salt master and trim it
         '''
         if not path.startswith('salt://'):
-            raise MinionError('Unsupported path: {0}'.format(path))
+            raise MinionError(u'Unsupported path: {0}'.format(path))
         return path[7:]
 
     def _file_local_list(self, dest):

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -196,7 +196,7 @@ def file_hash(load, fnd):
     cache_path = os.path.join(__opts__['cachedir'],
                               'roots/hash',
                               load['saltenv'],
-                              '{0}.hash.{1}'.format(fnd['rel'],
+                              u'{0}.hash.{1}'.format(fnd['rel'],
                               __opts__['hash_type']))
     # if we have a cache, serve that if the mtime hasn't changed
     if os.path.exists(cache_path):

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -328,7 +328,7 @@ def cache_file(path, saltenv='base', env=None):
     _mk_client()
     if path.startswith('salt://|'):
         # Strip pipe. Windows doesn't allow pipes in filenames
-        path = 'salt://{0}'.format(path[8:])
+        path = u'salt://{0}'.format(path[8:])
     env_splitter = '?saltenv='
     if '?env=' in path:
         salt.utils.warn_until(

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3488,7 +3488,7 @@ def manage_file(name,
             ret['comment'] = 'File {0} updated'.format(name)
 
         elif not ret['changes'] and ret['result']:
-            ret['comment'] = 'File {0} is in the correct state'.format(name)
+            ret['comment'] = u'File {0} is in the correct state'.format(name)
         if sfn:
             __clean_tmp(sfn)
         return ret

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2148,7 +2148,7 @@ def recurse(name,
             ret['changes'][path] = _ret['changes']
 
     def manage_file(path, source):
-        source = '{0}|{1}'.format(source[:7], source[7:])
+        source = u'{0}|{1}'.format(source[:7], source[7:])
         if clean and os.path.exists(path) and os.path.isdir(path):
             _ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
             if __opts__['test']:
@@ -2303,7 +2303,7 @@ def recurse(name,
             manage_directory(dirname)
             vdir.add(dirname)
 
-        src = 'salt://{0}'.format(fn_)
+        src = u'salt://{0}'.format(fn_)
         manage_file(dest, src)
 
     if include_empty:
@@ -2343,7 +2343,7 @@ def recurse(name,
 
     # Flatten comments until salt command line client learns
     # to display structured comments in a readable fashion
-    ret['comment'] = '\n'.join('\n#### {0} ####\n{1}'.format(
+    ret['comment'] = '\n'.join(u'\n#### {0} ####\n{1}'.format(
         k, v if isinstance(v, string_types) else '\n'.join(v)
     ) for (k, v) in six.iteritems(ret['comment'])).strip()
 


### PR DESCRIPTION
This patch adds partial support for unicode file names in `file.recurse`.

**Warning:** I know you work hard on Python 3. This patch is incompatible with Python 3.0-3.2. It is tested on Python 2.7 and should be compatible with Python 3.3+.

**Test Scenario:**

```
mkdir /srv/salt/test
touch /srv/salt/test/☃
salt-call state.single file.recurse /tmp/test source=salt://test
```

**Expected:**

```
          ----------
          /tmp/test/☃:
              ----------
              diff:
                  New file
              mode:
                  0644
```

__Result: __

```
Function: file.recurse
  Result: False
 Comment: An exception occurred in this state: Traceback (most recent call last):
            File "/usr/local/lib/python2.7/site-packages/salt/state.py", line 1562, in call
              **cdata['kwargs'])
            File "/usr/local/lib/python2.7/site-packages/salt/states/file.py", line 2309, in recurse
              y = 'salt://{0}'.format(fn_)
          UnicodeEncodeError: 'ascii' codec can't encode characters in position 26-32: ordinal not in range(128)
```

---

> In Python 3.3, the u prefix has been reintroduced.

This patch should work for Python 3.3. But if Python 3.0-3.2 matters I could replace `u''` with `six.u('')`. What's your strategy on Python 3?
