### PR TITLE
Improve output when using iptables.save

### DIFF
--- a/salt/states/iptables.py
+++ b/salt/states/iptables.py
@@ -348,9 +348,9 @@ def append(name, family='ipv4', **kwargs):
                     __saved_rules.append(saved_rules[table][chain].get('rules'))
             # Only save if rules in memory are different than saved rules
             if __rules != __saved_rules:
-                __salt__['iptables.save'](filename, family=family)
-                ret['comment'] += ('\nSaved iptables rule for {0} to: '
-                                   '{1} for {2}'.format(name, filename, family))
+                out = __salt__['iptables.save'](filename, family=family)
+                ret['comment'] += ('\nSaved iptables rule {0} for {1}\n'
+                                   '{2}\n{3}').format(name, family, command.strip(), out)
         return ret
     if __opts__['test']:
         ret['comment'] = 'iptables rule for {0} needs to be set ({1}) for {2}'.format(
@@ -371,9 +371,9 @@ def append(name, family='ipv4', **kwargs):
                     filename = kwargs['save']
                 else:
                     filename = None
-                __salt__['iptables.save'](filename, family=family)
-                ret['comment'] = ('Set and Saved iptables rule for {0} to: '
-                                  '{1} for {2}'.format(name, command.strip(), family))
+                out = __salt__['iptables.save'](filename, family=family)
+                ret['comment'] = ('Set and saved iptables rule {0} for {1}\n'
+                                  '{2}\n{3}').format(name, family, command.strip(), out)
         return ret
     else:
         ret['result'] = False
@@ -439,9 +439,9 @@ def insert(name, family='ipv4', **kwargs):
                     __saved_rules.append(saved_rules[table][chain].get('rules'))
             # Only save if rules in memory are different than saved rules
             if __rules != __saved_rules:
-                __salt__['iptables.save'](filename, family=family)
-                ret['comment'] += ('\nSaved iptables rule for {0} to: '
-                                   '{1} for {2}').format(name, command.strip(), family)
+                out = __salt__['iptables.save'](filename, family=family)
+                ret['comment'] += ('\nSaved iptables rule {0} for {1}\n'
+                                   '{2}\n{3}').format(name, family, command.strip(), out)
         return ret
     if __opts__['test']:
         ret['comment'] = 'iptables rule for {0} needs to be set for {1} ({2})'.format(
@@ -458,9 +458,9 @@ def insert(name, family='ipv4', **kwargs):
             family)
         if 'save' in kwargs:
             if kwargs['save']:
-                __salt__['iptables.save'](filename=None, family=family)
-                ret['comment'] = ('Set and Saved iptables rule for {0} to: '
-                                  '{1} for {2}').format(name, command.strip(), family)
+                out = __salt__['iptables.save'](filename=None, family=family)
+                ret['comment'] = ('Set and saved iptables rule {0} for {1}\n'
+                                  '{2}\n{3}').format(name, family, command.strip(), out)
         return ret
     else:
         ret['result'] = False
@@ -538,9 +538,9 @@ def delete(name, family='ipv4', **kwargs):
             command.strip())
         if 'save' in kwargs:
             if kwargs['save']:
-                __salt__['iptables.save'](filename=None, family=family)
-                ret['comment'] = ('Deleted and Saved iptables rule for {0} for {1}'
-                                  '{2}'.format(name, command.strip(), family))
+                out = __salt__['iptables.save'](filename=None, family=family)
+                ret['comment'] = ('Deleted and saved iptables rule {0} for {1}\n'
+                                  '{2}\n{3}').format(name, family, command.strip(), out)
         return ret
     else:
         ret['result'] = False
@@ -601,7 +601,7 @@ def set_policy(name, family='ipv4', **kwargs):
         if 'save' in kwargs:
             if kwargs['save']:
                 __salt__['iptables.save'](filename=None, family=family)
-                ret['comment'] = 'Set and Saved default policy for {0} to {1} family {2}'.format(
+                ret['comment'] = 'Set and saved default policy for {0} to {1} family {2}'.format(
                     kwargs['chain'],
                     kwargs['policy'],
                     family


### PR DESCRIPTION
This is a followup/improvement of https://github.com/saltstack/salt/pull/22374.

This change will append "Wrote X lines to filename" to the comments when iptables.save is used, instead of repeating the iptables command that was ran or rendering the filename as "None" (because that's what the filename variable is when it's passed to the iptables.save function).

New output:

```
          ID: iptables-rule-irc--ipv4-tcp-ircd-outgoing
    Function: iptables.append
        Name: irc--ipv4-tcp-ircd-outgoing
      Result: True
     Comment: Set and saved iptables rule irc--ipv4-tcp-ircd-outgoing for ipv4
              /sbin/iptables --wait -t filter -A OUTPUT  -p tcp -m state --state NEW,ESTABLISHED --dport ircd --jump ACCEPT
              Wrote 1 lines to "/etc/iptables/rules.v4"
     Started: 08:41:26.227690
    Duration: 239.094 ms
     Changes:   
              ----------
              locale:
                  irc--ipv4-tcp-ircd-outgoing
```

Old output:

```
     Comment: Set and saved iptables rule for irc--ipv4-tcp-ircd-outgoing to: /sbin/iptables --wait -t filter -A OUTPUT  -p tcp -m state --state NEW,ESTABLISHED --dport ircd --jump ACCEPT for ipv4
```

I'd like some feedback on this. Maybe the command should be appended to the changes dictionary instead? I didn't do this as it seemed like a bigger change than to append it to the comment, and the existing changes data (what does locale have to do with iptables?) was cryptic.
