### PR TITLE
Allow unless, onlyif, check_cmd to use python_shell=True

### DIFF
--- a/doc/ref/states/requisites.rst
+++ b/doc/ref/states/requisites.rst
@@ -414,6 +414,11 @@ the specified commands return ``False``. The ``unless`` requisite operates
 as NOR and is useful in giving more granular control over when a state should
 execute.
 
+**NOTE**: Under the hood ``unless`` calls ``cmd.retcode`` with 
+``python_shell=True``.  This means the commands referenced by unless will be
+parsed by a shell, so beware of side-effects as this shell will be run with the
+same privileges as the salt-minion.
+
 .. code-block:: yaml
 
     vim:
@@ -452,6 +457,11 @@ Onlyif
 ``onlyif`` is the opposite of ``unless``. If all of the commands in ``onlyif``
 return ``True``, then the state is run. If any of the specified commands
 return ``False``, the state will not run.
+
+**NOTE**: Under the hood ``onlyif`` calls ``cmd.retcode`` with 
+``python_shell=True``.  This means the commands referenced by unless will be
+parsed by a shell, so beware of side-effects as this shell will be run with the
+same privileges as the salt-minion.
 
 .. code-block:: yaml
 
@@ -526,6 +536,11 @@ check_cmd
 
 Check Command is used for determining that a state did or did not run as
 expected.
+
+**NOTE**: Under the hood ``check_cmd`` calls ``cmd.retcode`` with 
+``python_shell=True``.  This means the commands referenced by unless will be
+parsed by a shell, so beware of side-effects as this shell will be run with the
+same privileges as the salt-minion.
 
 .. code-block:: yaml
 

--- a/salt/state.py
+++ b/salt/state.py
@@ -650,7 +650,7 @@ class State(object):
             else:
                 low_data_onlyif = low_data['onlyif']
             for entry in low_data_onlyif:
-                cmd = self.functions['cmd.retcode'](entry, ignore_retcode=True, **cmd_opts)
+                cmd = self.functions['cmd.retcode'](entry, ignore_retcode=True, python_shell=True, **cmd_opts)
                 log.debug('Last command return code: {0}'.format(cmd))
                 if cmd != 0 and ret['result'] is False:
                     ret.update({'comment': 'onlyif execution failed',
@@ -667,7 +667,7 @@ class State(object):
             else:
                 low_data_unless = low_data['unless']
             for entry in low_data_unless:
-                cmd = self.functions['cmd.retcode'](entry, ignore_retcode=True, **cmd_opts)
+                cmd = self.functions['cmd.retcode'](entry, ignore_retcode=True, python_shell=True, **cmd_opts)
                 log.debug('Last command return code: {0}'.format(cmd))
                 if cmd == 0 and ret['result'] is False:
                     ret.update({'comment': 'unless execution succeeded',
@@ -689,7 +689,7 @@ class State(object):
         if 'shell' in self.opts['grains']:
             cmd_opts['shell'] = self.opts['grains'].get('shell')
         for entry in low_data['check_cmd']:
-            cmd = self.functions['cmd.retcode'](entry, ignore_retcode=True, **cmd_opts)
+            cmd = self.functions['cmd.retcode'](entry, ignore_retcode=True, python_shell=True, **cmd_opts)
             log.debug('Last command return code: {0}'.format(cmd))
             if cmd == 0 and ret['result'] is False:
                 ret.update({'comment': 'check_cmd determined the state succeeded', 'result': True})


### PR DESCRIPTION
The requisites `onlyif`, `check_cmd`, and `unless` run commands to help determine whether states should continue executing or not.  With the default of `python_shell=False` these commands were no longer being passed through a shell.  This PR changes python_shell to True for these requisites and documents the caveats to this change in the documentation for them.
