### PR TITLE
Adding ability to vmware cloud create() so extra_config can be specified

### DIFF
--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -95,6 +95,8 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
       host: c4212n-002.domain.com
       template: False
       power_on: True
+      extra_config:
+        guestinfo.SaltMaster: 10.20.30.140
 
 
 provider
@@ -206,3 +208,9 @@ template
 power_on
     Specifies whether the new virtual machine should be powered on or not. If
     ``template: True`` is set, this field is ignored. Default is ``power_on: True``.
+
+extra_config
+    Specifies the additional configuration information for the virtual machine. This
+    describes a set of modifications to the additional options. If the key is already
+    present, it will be reset with the new value provided. Otherwise, a new option is
+    added. Keys with empty values will be removed.

--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -97,6 +97,8 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
       power_on: True
       extra_config:
         guestinfo.SaltMaster: 10.20.30.140
+        guestinfo.Domain: foobar.com
+        randomKey: randomValue
 
 
 provider

--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -96,8 +96,10 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
       template: False
       power_on: True
       extra_config:
-        guestinfo.SaltMaster: 10.20.30.140
-        guestinfo.Domain: foobar.com
+        mem.hotadd: 'yes'
+        guestinfo.saltMaster: 10.20.30.140
+        guestinfo.domain: foobar.com
+        contactGroup: 'Core Infrastructure' 
         randomKey: randomValue
 
 

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -954,6 +954,9 @@ def create(vm_):
     devices = config.get_cloud_config_value(
         'devices', vm_, __opts__, default=None
     )
+    extra_config = config.get_cloud_config_value(
+        'extra_config', vm_, __opts__, default=None
+    )
     power = config.get_cloud_config_value(
         'power_on', vm_, __opts__, default=False
     )
@@ -1017,6 +1020,11 @@ def create(vm_):
         if devices:
             device_specs = _manage_devices(devices, object_ref)
             config_spec.deviceChange = device_specs
+
+        if extra_config:
+            for key, value in extra_config.iteritems():
+                option = vim.option.OptionValue(key=key, value=value)
+                config_spec.extraConfig.append(option)
 
         # Create the clone specs
         clone_spec = vim.vm.CloneSpec(


### PR DESCRIPTION
If you have scripts that need a guest environment variable to be set, you can now set them by specifying under `extra_config`. The idea has been taken from the powershell script written by Ralph Goodberlet rgoodbe@clemson.edu of Clemson University which requires specifies guest environment variables to be set in order to run a script upon boot and configure the networking and hostname. 
