### PR TITLE
Fixed problem with pip not working on portable install

### DIFF
--- a/pkg/windows/BuildSalt.bat
+++ b/pkg/windows/BuildSalt.bat
@@ -69,7 +69,7 @@ If Exist "%BinDir%\README.txt" del /q "%BinDir%\README.txt"
 
 @ echo Building the installer...
 @ echo -------------------------
-makensis.exe "%InsDir%\Salt-Minion-Setup.nsi"
+makensis.exe /DSaltVersion="%Version%" "%InsDir%\Salt-Minion-Setup.nsi"
 @ echo.
 
 @ echo.

--- a/pkg/windows/BuildSalt.bat
+++ b/pkg/windows/BuildSalt.bat
@@ -9,7 +9,6 @@ Set "CurrDir=%cd%"
 Set "BinDir=%cd%\buildenv\bin"
 Set "InsDir=%cd%\installer"
 Set "PyDir=C:\Python27"
-Set "Version=%1"
 
 :: Find the NSIS Installer
 If Exist "C:\Program Files\NSIS\" (
@@ -29,6 +28,14 @@ If Exist "%BinDir%\" rd /S /Q "%BinDir%"
 @echo xcopy /S /E "%PyDir%" "%BinDir%\"
 xcopy /S /E "%PyDir%" "%BinDir%\"
 @ echo.
+
+:: Remove the fixed path in .exe files
+@echo Removing fixed path from .exe files
+python "%CurrDir%\portable.py" -f "%BinDir%\Scripts\easy_install.exe"
+python "%CurrDir%\portable.py" -f "%BinDir%\Scripts\easy_install-2.7.exe"
+python "%CurrDir%\portable.py" -f "%BinDir%\Scripts\pip.exe"
+python "%CurrDir%\portable.py" -f "%BinDir%\Scripts\pip2.7.exe"
+python "%CurrDir%\portable.py" -f "%BinDir%\Scripts\pip2.exe"
 
 @ echo Cleaning up unused files and directories...
 @ echo -------------------------------------------
@@ -61,7 +68,7 @@ If Exist "%BinDir%\README.txt" del /q "%BinDir%\README.txt"
 
 @ echo Building the installer...
 @ echo -------------------------
-makensis.exe /DSaltVersion="%Version%" "%InsDir%\Salt-Minion-Setup.nsi"
+makensis.exe "%InsDir%\Salt-Minion-Setup.nsi"
 @ echo.
 
 @ echo.
@@ -70,7 +77,5 @@ makensis.exe /DSaltVersion="%Version%" "%InsDir%\Salt-Minion-Setup.nsi"
 @ echo -------------------
 @ echo Installation file can be found in the following directory:
 @ echo %InsDir%
-
-done:
-if [%Version%] == [] pause
+pause
 cls

--- a/pkg/windows/BuildSalt.bat
+++ b/pkg/windows/BuildSalt.bat
@@ -9,6 +9,7 @@ Set "CurrDir=%cd%"
 Set "BinDir=%cd%\buildenv\bin"
 Set "InsDir=%cd%\installer"
 Set "PyDir=C:\Python27"
+Set "Version=%1"
 
 :: Find the NSIS Installer
 If Exist "C:\Program Files\NSIS\" (

--- a/pkg/windows/BuildSalt.bat
+++ b/pkg/windows/BuildSalt.bat
@@ -80,5 +80,5 @@ makensis.exe /DSaltVersion="%Version%" "%InsDir%\Salt-Minion-Setup.nsi"
 @ echo %InsDir%
 
 done:
--if [%Version%] == [] pause
+if [%Version%] == [] pause
 cls

--- a/pkg/windows/BuildSalt.bat
+++ b/pkg/windows/BuildSalt.bat
@@ -78,5 +78,7 @@ makensis.exe /DSaltVersion="%Version%" "%InsDir%\Salt-Minion-Setup.nsi"
 @ echo -------------------
 @ echo Installation file can be found in the following directory:
 @ echo %InsDir%
-pause
+
+done:
+-if [%Version%] == [] pause
 cls

--- a/pkg/windows/portable.py
+++ b/pkg/windows/portable.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python
+
+import sys, getopt
+
+def display_help():
+    print '####################################################################'
+    print '#                                                                  #'
+    print '# File: portable.py                                                #'
+    print '# Description:                                                     #'
+    print '#   - search and replace within a binary file                      #'
+    print '#                                                                  #'
+    print '# Parameters:                                                      #'
+    print '#   -f, --file    :  target file                                   #'
+    print '#   -s, --search  :  term to search for                            #'
+    print '#                    default is "C:\Python"                        #'
+    print '#   -r, --replace :  replace with this                             #'
+    print '#                    default is ".."                               #'
+    print '#                                                                  #'
+    print '# example:                                                         #'
+    print '#  portable.py -f <target_file> -s <search_term> -r <replace_term> #'
+    print '#                                                                  #'
+    print '####################################################################'
+    sys.exit(2)
+
+def main(argv):
+    target = ''
+    search = 'C:\Python27'
+    replace = '..'
+    try:
+        opts, args = getopt.getopt(argv,"hf:s:r:",["file=","search=", "replace="])
+    except getopt.GetoptError:
+        display_help()
+    for opt, arg in opts:
+        if opt == '-h':
+            display_help()
+        elif opt in ("-f", "--file"):
+            target = arg
+        elif opt in ("-s", "--search"):
+            search = arg
+        elif opt in ("-r", "--replace"):
+            replace = arg
+    if target == '':
+        display_help()
+    f = open( target, 'rb' ).read()
+    f = f.replace( search, replace )
+    open( target, 'wb' ).write(f)
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
Added portable.py that removes the hardcoded path to python in the .exe files for pip and easy_install
Updated BuildSalt.bat to use portable.py
Fixes issue: https://github.com/saltstack/salt/issues/21149
