### PR TITLE
sort integration test minion return lists

### DIFF
--- a/tests/integration/netapi/rest_tornado/test_app.py
+++ b/tests/integration/netapi/rest_tornado/test_app.py
@@ -193,11 +193,15 @@ class TestSaltAPIHandler(SaltnadoTestCase):
                               connect_timeout=10,
                               request_timeout=10,
                               )
+
         response_obj = json.loads(response.body)
+        ret = response_obj['return']
+        ret[0]['minions'] = sorted(ret[0]['minions'])
+
         # TODO: verify pub function? Maybe look at how we test the publisher
-        self.assertEqual(len(response_obj['return']), 1)
-        self.assertIn('jid', response_obj['return'][0])
-        self.assertEqual(response_obj['return'][0]['minions'], ['minion', 'sub_minion'])
+        self.assertEqual(len(ret), 1)
+        self.assertIn('jid', ret[0])
+        self.assertEqual(ret[0]['minions'], sorted(['minion', 'sub_minion']))
 
     def test_multi_local_async_post(self):
         low = [{'client': 'local_async',
@@ -216,12 +220,17 @@ class TestSaltAPIHandler(SaltnadoTestCase):
                               connect_timeout=10,
                               request_timeout=10,
                               )
+
         response_obj = json.loads(response.body)
-        self.assertEqual(len(response_obj['return']), 2)
-        self.assertIn('jid', response_obj['return'][0])
-        self.assertIn('jid', response_obj['return'][1])
-        self.assertEqual(response_obj['return'][0]['minions'], ['minion', 'sub_minion'])
-        self.assertEqual(response_obj['return'][1]['minions'], ['minion', 'sub_minion'])
+        ret = response_obj['return']
+        ret[0]['minions'] = sorted(ret[0]['minions'])
+        ret[1]['minions'] = sorted(ret[1]['minions'])
+
+        self.assertEqual(len(ret), 2)
+        self.assertIn('jid', ret[0])
+        self.assertIn('jid', ret[1])
+        self.assertEqual(ret[0]['minions'], sorted(['minion', 'sub_minion']))
+        self.assertEqual(ret[1]['minions'], sorted(['minion', 'sub_minion']))
 
     def test_multi_local_async_post_multitoken(self):
         low = [{'client': 'local_async',
@@ -247,13 +256,18 @@ class TestSaltAPIHandler(SaltnadoTestCase):
                               connect_timeout=10,
                               request_timeout=10,
                               )
+
         response_obj = json.loads(response.body)
-        self.assertEqual(len(response_obj['return']), 3)  # make sure we got 3 responses
-        self.assertIn('jid', response_obj['return'][0])  # the first 2 are regular returns
-        self.assertIn('jid', response_obj['return'][1])
-        self.assertIn('Failed to authenticate', response_obj['return'][2])  # bad auth
-        self.assertEqual(response_obj['return'][0]['minions'], ['minion', 'sub_minion'])
-        self.assertEqual(response_obj['return'][1]['minions'], ['minion', 'sub_minion'])
+        ret = response_obj['return']
+        ret[0]['minions'] = sorted(ret[0]['minions'])
+        ret[1]['minions'] = sorted(ret[1]['minions'])
+
+        self.assertEqual(len(ret), 3)  # make sure we got 3 responses
+        self.assertIn('jid', ret[0])  # the first 2 are regular returns
+        self.assertIn('jid', ret[1])
+        self.assertIn('Failed to authenticate', ret[2])  # bad auth
+        self.assertEqual(ret[0]['minions'], sorted(['minion', 'sub_minion']))
+        self.assertEqual(ret[1]['minions'], sorted(['minion', 'sub_minion']))
 
     def test_simple_local_async_post_no_tgt(self):
         low = [{'client': 'local_async',
@@ -342,11 +356,15 @@ class TestMinionSaltAPIHandler(SaltnadoTestCase):
                               connect_timeout=10,
                               request_timeout=10,
                               )
+
         response_obj = json.loads(response.body)
+        ret = response_obj['return']
+        ret[0]['minions'] = sorted(ret[0]['minions'])
+
         # TODO: verify pub function? Maybe look at how we test the publisher
-        self.assertEqual(len(response_obj['return']), 1)
-        self.assertIn('jid', response_obj['return'][0])
-        self.assertEqual(response_obj['return'][0]['minions'], ['minion', 'sub_minion'])
+        self.assertEqual(len(ret), 1)
+        self.assertIn('jid', ret[0])
+        self.assertEqual(ret[0]['minions'], sorted(['minion', 'sub_minion']))
 
     def test_post_with_client(self):
         # get a token for this test
@@ -362,11 +380,15 @@ class TestMinionSaltAPIHandler(SaltnadoTestCase):
                               connect_timeout=10,
                               request_timeout=10,
                               )
+
         response_obj = json.loads(response.body)
+        ret = response_obj['return']
+        ret[0]['minions'] = sorted(ret[0]['minions'])
+
         # TODO: verify pub function? Maybe look at how we test the publisher
-        self.assertEqual(len(response_obj['return']), 1)
-        self.assertIn('jid', response_obj['return'][0])
-        self.assertEqual(response_obj['return'][0]['minions'], ['minion', 'sub_minion'])
+        self.assertEqual(len(ret), 1)
+        self.assertIn('jid', ret[0])
+        self.assertEqual(ret[0]['minions'], sorted(['minion', 'sub_minion']))
 
     def test_post_with_incorrect_client(self):
         '''

--- a/tests/integration/netapi/test_client.py
+++ b/tests/integration/netapi/test_client.py
@@ -42,7 +42,8 @@ class NetapiClientTest(TestCase):
         # Remove all the volatile values before doing the compare.
         self.assertIn('jid', ret)
         ret.pop('jid', None)
-        self.assertEqual(ret, {'minions': ['minion', 'sub_minion']})
+        ret['minions'] = sorted(ret['minions'])
+        self.assertEqual(ret, {'minions': sorted(['minion', 'sub_minion'])})
 
     def test_jid(self):
         '''
@@ -54,9 +55,10 @@ class NetapiClientTest(TestCase):
         low.update(self.eauth_creds)
 
         ret = self.netapi.run(low)
+        ret['minions'] = sorted(ret['minions'])
 
         self.assertEqual(ret, {'jid': '123abc',
-                               'minions': ['minion', 'sub_minion']})
+                               'minions': sorted(['minion', 'sub_minion'])})
 
     def test_wheel(self):
         low = {'client': 'wheel', 'fun': 'key.list_all'}


### PR DESCRIPTION
unsorted lists were causing test failures.
