### PR TITLE
Fix handling of disabled apt repositories in pkgrepo.managed

### DIFF
--- a/doc/topics/releases/beryllium.rst
+++ b/doc/topics/releases/beryllium.rst
@@ -19,6 +19,11 @@ JBoss 7 State
 
 Remove unused argument ``timeout`` in jboss7.status.
 
+Pkgrepo State
+=============
+
+Deprecate ``enabled`` argument in ``pkgrepo.managed`` in favor of ``disabled``.
+
 Archive Module
 ==============
 

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1617,23 +1617,6 @@ def mod_repo(repo, saltenv='base', **kwargs):
             mod_source.comment = " ".join(str(c) for c in kwargs['comments'])
         sources.list.append(mod_source)
 
-    # if all comps aren't part of the disable
-    # match, it is important we keep the comps
-    # not destined to be disabled/enabled in
-    # the original state
-    if ('disabled' in kwargs and
-            mod_source.disabled != kwargs['disabled']):
-
-        s_comps = set(mod_source.comps)
-        r_comps = set(repo_comps)
-        if s_comps.symmetric_difference(r_comps):
-            new_source = sourceslist.SourceEntry(source.line)
-            new_source.file = source.file
-            new_source.comps = list(r_comps.difference(s_comps))
-            source.comps = list(s_comps.difference(r_comps))
-            sources.insert(sources.index(source), new_source)
-            sources.save()
-
     for key in kwargs:
         if key in _MODIFY_OK and hasattr(mod_source, key):
             setattr(mod_source, key, kwargs[key])


### PR DESCRIPTION
The main idea here is to fix the currently broken handling of disabled repositories and the removal of the ambiguous 'enabled' option from that state.

I would also appreciate it if this could be backported to 2014.7 or 2015.2. I have already tested it on those branch and the resulting behaviour constitutes a significant improvement over the status quo.

Please refer to the individual commit messages and referenced bugs for more information. 
