### PR TITLE
Reinstate minion config provider override as per doco

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -125,6 +125,19 @@ def minion_mods(
                      pack={'__context__': context},
                      whitelist=whitelist,
                      loaded_base_name=loaded_base_name)
+
+    # Load any provider overrides from the configuration file providers option
+    #  Note: Providers can be pkg, service, user or group - not to be confused
+    #        with cloud providers.
+    if opts.get('providers', False):
+        providers = opts.get('providers', False)
+        for mod in providers:
+            funcs = raw_mod(opts, providers[mod], ret.items())
+            if funcs:
+                for func in funcs:
+                    f_key = '{0}{1}'.format(mod, func[func.rindex('.'):])
+                    ret[f_key] = funcs[func]
+
     ret.pack['__salt__'] = ret
 
     return ret


### PR DESCRIPTION
I believe this resolves the second part of issue #22117 - provider override in minion config (as opposed to a provider override in the state definition)
