### PR TITLE
Add SSHClient to the Python API docs

### DIFF
--- a/doc/ref/clients/index.rst
+++ b/doc/ref/clients/index.rst
@@ -100,3 +100,9 @@ CloudClient
 
 .. autoclass:: salt.cloud.CloudClient
     :members:
+
+SSHClient
+---------
+
+.. autoclass:: salt.client.ssh.client.SSHClient
+    :members: cmd, cmd_iter


### PR DESCRIPTION
I'm leaving cmd_sync out on purpose for now until we get eauth support
sorted.
