### PR TITLE
Fixes to gpg module

### DIFF
--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -163,7 +163,7 @@ def search_keys(text, keyserver=None, user=None):
 
     user
         Which user's keychain to access, defaults to user Salt is running as.  Passing
-        the user as 'salt' will set the GPG home directory to /etc/salt/gpg.
+        the user as 'salt' will set the GPG home directory to /etc/salt/gpgkeys.
 
     CLI Example:
 
@@ -207,7 +207,7 @@ def list_keys(user=None, gnupghome=None):
 
     user
         Which user's keychain to access, defaults to user Salt is running as.  Passing
-        the user as 'salt' will set the GPG home directory to /etc/salt/gpg.
+        the user as 'salt' will set the GPG home directory to /etc/salt/gpgkeys.
 
     gnupghome
         Specify the location where GPG related files are stored.
@@ -252,7 +252,7 @@ def list_secret_keys(user=None, gnupghome=None):
 
     user
         Which user's keychain to access, defaults to user Salt is running as.  Passing
-        the user as 'salt' will set the GPG home directory to /etc/salt/gpg.
+        the user as 'salt' will set the GPG home directory to /etc/salt/gpgkeys.
 
     gnupghome
         Specify the location where GPG related files are stored.
@@ -346,7 +346,7 @@ def create_key(key_type='RSA',
 
     user
         Which user's keychain to access, defaults to user Salt is running as.  Passing
-        the user as 'salt' will set the GPG home directory to /etc/salt/gpg.
+        the user as 'salt' will set the GPG home directory to /etc/salt/gpgkeys.
 
     gnupghome
         Specify the location where GPG related files are stored.
@@ -425,7 +425,7 @@ def delete_key(keyid=None,
 
     user
         Which user's keychain to access, defaults to user Salt is running as.  Passing
-        the user as 'salt' will set the GPG home directory to /etc/salt/gpg.
+        the user as 'salt' will set the GPG home directory to /etc/salt/gpgkeys.
 
     gnupghome
         Specify the location where GPG related files are stored.
@@ -494,7 +494,7 @@ def get_key(keyid=None, fingerprint=None, user=None, gnupghome=None):
 
     user
         Which user's keychain to access, defaults to user Salt is running as.  Passing
-        the user as 'salt' will set the GPG home directory to /etc/salt/gpg.
+        the user as 'salt' will set the GPG home directory to /etc/salt/gpgkeys.
 
     gnupghome
         Specify the location where GPG related files are stored.
@@ -550,7 +550,7 @@ def get_secret_key(keyid=None, fingerprint=None, user=None, gnupghome=None):
 
     user
         Which user's keychain to access, defaults to user Salt is running as.  Passing
-        the user as 'salt' will set the GPG home directory to /etc/salt/gpg.
+        the user as 'salt' will set the GPG home directory to /etc/salt/gpgkeys.
 
     gnupghome
         Specify the location where GPG related files are stored.
@@ -604,7 +604,7 @@ def import_key(user=None,
 
     user
         Which user's keychain to access, defaults to user Salt is running as.  Passing
-        the user as 'salt' will set the GPG home directory to /etc/salt/gpg.
+        the user as 'salt' will set the GPG home directory to /etc/salt/gpgkeys.
 
     text
         The text containing to import.
@@ -674,7 +674,7 @@ def export_key(keyids=None, secret=False, user=None, gnupghome=None):
 
     user
         Which user's keychain to access, defaults to user Salt is running as.  Passing
-        the user as 'salt' will set the GPG home directory to /etc/salt/gpg.
+        the user as 'salt' will set the GPG home directory to /etc/salt/gpgkeys.
 
     gnupghome
         Specify the location where GPG related files are stored.
@@ -710,7 +710,7 @@ def receive_keys(keyserver=None, keys=None, user=None, gnupghome=None):
 
     user
         Which user's keychain to access, defaults to user Salt is running as.  Passing
-        the user as 'salt' will set the GPG home directory to /etc/salt/gpg.
+        the user as 'salt' will set the GPG home directory to /etc/salt/gpgkeys.
 
     CLI Example:
 
@@ -768,7 +768,7 @@ def trust_key(keyid=None,
 
     user
         Which user's keychain to access, defaults to user Salt is running as.  Passing
-        the user as 'salt' will set the GPG home directory to /etc/salt/gpg.
+        the user as 'salt' will set the GPG home directory to /etc/salt/gpgkeys.
 
     CLI Example:
 
@@ -817,7 +817,12 @@ def trust_key(keyid=None,
     cmd = 'echo {0}:{1} | {2} --import-ownertrust'.format(fingerprint,
                                                           NUM_TRUST_DICT[trust_level],
                                                           _check_gpg())
-    res = __salt__['cmd.run_all'](cmd, runas=user)
+    _user = user
+    if user == 'salt':
+        homeDir = os.path.join(salt.syspaths.CONFIG_DIR, 'gpgkeys')
+        cmd = '{0} --homedir {1}'.format(cmd, homeDir)
+        _user = 'root'
+    res = __salt__['cmd.run_all'](cmd, runas=_user)
 
     if not res['retcode'] == 0:
         ret['res'] = False
@@ -851,7 +856,7 @@ def sign(user=None,
 
     user
         Which user's keychain to access, defaults to user Salt is running as.  Passing
-        the user as 'salt' will set the GPG home directory to /etc/salt/gpg.
+        the user as 'salt' will set the GPG home directory to /etc/salt/gpgkeys.
 
     keyid
         The keyid of the key to set the trust level for, defaults to
@@ -928,7 +933,7 @@ def verify(text=None,
 
     user
         Which user's keychain to access, defaults to user Salt is running as.  Passing
-        the user as 'salt' will set the GPG home directory to /etc/salt/gpg.
+        the user as 'salt' will set the GPG home directory to /etc/salt/gpgkeys.
 
     gnupghome
         Specify the location where GPG related files are stored.
@@ -980,7 +985,7 @@ def encrypt(user=None,
 
     user
         Which user's keychain to access, defaults to user Salt is running as.  Passing
-        the user as 'salt' will set the GPG home directory to /etc/salt/gpg.
+        the user as 'salt' will set the GPG home directory to /etc/salt/gpgkeys.
 
     recipients
         The fingerprints for those recipient whom the data is being encrypted for.
@@ -1071,7 +1076,7 @@ def decrypt(user=None,
 
     user
         Which user's keychain to access, defaults to user Salt is running as.  Passing
-        the user as 'salt' will set the GPG home directory to /etc/salt/gpg.
+        the user as 'salt' will set the GPG home directory to /etc/salt/gpgkeys.
 
     text
         The encrypted text to decrypt.


### PR DESCRIPTION
Fixing the case where user=salt and trust_key attempts to run the gpg binary as the user salt, which doesn't exist.  Instead we set the homeDir as config-location/gpgkeys and run the command as root.  Also updating documention to reflect location for default 'salt' controlled GPG keys as config-location/gpgkeys rather than config-location/gpg.  #22415 
