### PR TITLE
don't repeat the "if ret['changes']" condition

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1354,14 +1354,12 @@ def managed(name,
                 contents,
                 **kwargs
             )
-            if not ret['changes']:
-                ret['result'] = True
-            else:
-                ret['result'] = None
 
             if ret['changes']:
+                ret['result'] = None
                 ret['comment'] = 'The file {0} is set to be changed'.format(name)
             else:
+                ret['result'] = True
                 ret['comment'] = 'The file {0} is in the correct state'.format(name)
 
             return ret


### PR DESCRIPTION
I was having a look at the code since I thought https://github.com/saltstack/salt/issues/21422 was still not fixed.
Turns out https://github.com/saltstack/salt/commit/8e0a9e27156ee67f6633184db06427ef7583d4ef#diff-3b447dc835943beb1326f98f684fe783 had fixed it, but the code read strange to me (why have `if not changes` followed by `if changes`?)

This seems more straight forward to me.
