### PR TITLE
Display documention when the CLI gets bad function args

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -185,6 +185,7 @@ class BaseCaller(object):
                 active_level = LOG_LEVELS.get(
                     self.opts['log_level'].lower(), logging.ERROR)
                 if active_level <= logging.DEBUG:
+                    trace = traceback.format_exc()
                     sys.stderr.write(trace)
                 sys.exit(salt.defaults.exitcodes.EX_GENERIC)
             try:

--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -180,8 +180,8 @@ class BaseCaller(object):
             try:
                 ret['return'] = func(*args, **kwargs)
             except TypeError as exc:
-                trace = traceback.format_exc()
-                sys.stderr.write('Passed invalid arguments: {0}\n'.format(exc))
+                sys.stderr.write('\nPassed invalid arguments: {0}.\n\nUsage:\n'.format(exc))
+                print_cli(func.__doc__)
                 active_level = LOG_LEVELS.get(
                     self.opts['log_level'].lower(), logging.ERROR)
                 if active_level <= logging.DEBUG:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1200,8 +1200,7 @@ class Minion(MinionBase):
                 )
                 ret['out'] = 'nested'
             except TypeError as exc:
-                msg = ('TypeError encountered executing {0}: {1}. See '
-                       'debug log for more info.').format(function_name, exc)
+                msg = 'Passed invalid arguments: {0}\n{1}'.format(exc, func.__doc__)
                 log.warning(msg, exc_info_on_loglevel=logging.DEBUG)
                 ret['return'] = msg
                 ret['out'] = 'nested'


### PR DESCRIPTION
Now looks like this:

```
mp@silver ...devel/salt/salt % sudo salt-call test.echo                                                                                                                                                                                             (git)-[develop] 

Passed invalid arguments: echo() takes exactly 1 argument (0 given).

Usage:

    Return a string - used for testing the connection

    CLI Example:

    .. code-block:: bash

        salt '*' test.echo 'foo bar baz quo qux'

mp@silver ...devel/salt/salt % sudo salt-call test.ping invalid_arg                                                                                                                                                                                 (git)-[develop] 

Passed invalid arguments: ping() takes no arguments (1 given).

Usage:

    Used to make sure the minion is up and responding. Not an ICMP ping.

    Returns ``True``.

    CLI Example:

    .. code-block:: bash

        salt '*' test.ping


mp@silver ...devel/salt/salt % sudo salt silver test.ping invalid_arg                                            (git)-[develop] 
silver:
    Passed invalid arguments: ping() takes no arguments (1 given)

        Used to make sure the minion is up and responding. Not an ICMP ping.

        Returns ``True``.

        CLI Example:

        .. code-block:: bash

            salt '*' test.ping
```
