### PR TITLE
HTTP Return Code Cleanup

### DIFF
--- a/salt/modules/hipchat.py
+++ b/salt/modules/hipchat.py
@@ -22,9 +22,10 @@ import json
 import logging
 
 # Import 3rd-party Libs
-# pylint: disable=import-error,no-name-in-module
+# pylint: disable=import-error,no-name-in-module,redefined-builtin
 from salt.ext.six.moves.urllib.parse import urljoin as _urljoin
 from salt.ext.six.moves import range
+import salt.ext.six.moves.http_client
 # pylint: enable=import-error,no-name-in-module
 
 try:
@@ -150,11 +151,11 @@ def _query(function, api_key=None, api_version=None, method='GET', data=None):
         log.error(e)
         return False
 
-    if result.status_code == 200:
+    if result.status_code == salt.ext.six.moves.http_client.OK:
         result = result.json()
         response = hipchat_functions.get(api_version).get(function).get('response')
         return result.get(response)
-    elif result.status_code == 204:
+    elif result.status_code == salt.ext.six.moves.http_client.NO_CONTENT:
         return True
     else:
         log.debug(url)

--- a/salt/modules/pushover_notify.py
+++ b/salt/modules/pushover_notify.py
@@ -23,7 +23,8 @@ import logging
 # Import 3rd-party libs
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 from salt.ext.six.moves.urllib.parse import urljoin as _urljoin
-# pylint: enable=import-error,no-name-in-module
+import salt.ext.six.moves.http_client
+# pylint: enable=import-error,no-name-in-module,redefined-builtin
 
 try:
     import requests
@@ -119,7 +120,7 @@ def _query(function,
         ret['res'] = False
         return ret
 
-    if result.status_code == 200:
+    if result.status_code == salt.ext.six.moves.http_client.OK:
         result = result.json()
         response = pushover_functions.get(function).get('response')
         if response in result and result[response] == 0:

--- a/salt/modules/random_org.py
+++ b/salt/modules/random_org.py
@@ -25,6 +25,7 @@ import logging
 import json
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 from salt.ext.six.moves.urllib.parse import urljoin as _urljoin
+import salt.ext.six.moves.http_client
 # pylint: enable=import-error,no-name-in-module
 
 try:
@@ -109,14 +110,14 @@ def _query(api_version=None, data=None):
         ret['res'] = False
         return ret
 
-    if result.status_code == 200:
+    if result.status_code == salt.ext.six.moves.http_client.OK:
         result = result.json()
         if result.get('result'):
             return result.get('result')
         if result.get('error'):
             return result.get('error')
         return ret
-    elif result.status_code == 204:
+    elif result.status_code == salt.ext.six.moves.http_client.NO_CONTENT:
         return True
     else:
         log.debug('base_url {0}'.format(base_url))

--- a/salt/modules/slack_notify.py
+++ b/salt/modules/slack_notify.py
@@ -24,6 +24,7 @@ import logging
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 from salt.ext.six.moves.urllib.parse import urljoin as _urljoin
 from salt.ext.six.moves import range
+import salt.ext.six.moves.http_client
 # pylint: enable=import-error,no-name-in-module
 
 try:
@@ -113,7 +114,7 @@ def _query(function, api_key=None, method='GET', data=None):
         ret['res'] = False
         return ret
 
-    if result.status_code == 200:
+    if result.status_code == salt.ext.six.moves.http_client.OK:
         result = result.json()
         response = slack_functions.get(function).get('response')
         if 'error' in result:
@@ -122,7 +123,7 @@ def _query(function, api_key=None, method='GET', data=None):
             return ret
         ret['message'] = result.get(response)
         return ret
-    elif result.status_code == 204:
+    elif result.status_code == salt.ext.six.moves.http_client.NO_CONTENT:
         return True
     else:
         log.debug(url)

--- a/salt/returners/hipchat_return.py
+++ b/salt/returners/hipchat_return.py
@@ -76,8 +76,9 @@ import logging
 # Import 3rd-party libs
 import requests
 from requests.exceptions import ConnectionError
-# pylint: disable=import-error
-from salt.ext.six.moves.urllib.parse import urljoin as _urljoin  # pylint: disable=import-error,no-name-in-module
+# pylint: disable=import-error,no-name-in-module
+from salt.ext.six.moves.urllib.parse import urljoin as _urljoin
+import salt.ext.six.moves.http_client
 # pylint: enable=import-error
 
 # Import Salt Libs
@@ -221,11 +222,11 @@ def _query(function, api_key=None, api_version=None, method='GET', data=None):
         log.error(e)
         return False
 
-    if result.status_code == 200:
+    if result.status_code == salt.ext.six.moves.http_client.OK:
         result = result.json()
         response = hipchat_functions.get(api_version).get(function).get('response')
         return result.get(response)
-    elif result.status_code == 204:
+    elif result.status_code == salt.ext.six.moves.http_client.NO_CONTENT:
         return True
     else:
         log.debug(url)

--- a/salt/returners/nagios_return.py
+++ b/salt/returners/nagios_return.py
@@ -49,6 +49,9 @@ import requests
 from xml.dom.minidom import parseString
 
 import salt.returners
+# pylint: disable=import-error,no-name-in-module,redefined-builtin
+import salt.ext.six.moves.http_client
+# pylint: enable=import-error,no-name-in-module,redefined-builtin
 
 log = logging.getLogger(__name__)
 
@@ -145,7 +148,7 @@ def _post_data(options=None, xml=None):
         verify=True,
     )
 
-    if hasattr(res, 'status_code') and res.status_code == 200:
+    if hasattr(res, 'status_code') and res.status_code == salt.ext.six.moves.http_client.OK:
         if hasattr(res, '_content'):
             result = parseString(res._content)
             if _getText(result.getElementsByTagName("status")[0].childNodes) == "0":

--- a/salt/returners/pushover_returner.py
+++ b/salt/returners/pushover_returner.py
@@ -77,9 +77,10 @@ import logging
 # Import 3rd-party libs
 import requests
 from requests.exceptions import ConnectionError
-# pylint: disable=import-error
+# pylint: disable=import-error,no-name-in-module,redefined-builtin
 from salt.ext.six.moves.urllib.parse import urljoin as _urljoin  # pylint: disable=import-error,no-name-in-module
-# pylint: enable=import-error
+import salt.ext.six.moves.http_client
+# pylint: enable=import-error,no-name-in-module,redefined-builtin
 
 # Import Salt Libs
 import salt.returners
@@ -213,7 +214,7 @@ def _query(function,
         ret['res'] = False
         return ret
 
-    if result.status_code == 200:
+    if result.status_code == salt.ext.six.moves.http_client.OK:
         result = result.json()
         response = pushover_functions.get(function).get('response')
         if response in result and result[response] == 0:

--- a/salt/returners/slack_returner.py
+++ b/salt/returners/slack_returner.py
@@ -43,7 +43,7 @@ Hipchat settings may also be configured as::
         profile: slack_profile
         channel: RoomName
 
-To use the HipChat returner, append '--return slack' to the salt command.
+To use the Slack returner, append '--return slack' to the salt command.
 
 .. code-block:: bash
 
@@ -64,9 +64,10 @@ import logging
 # Import 3rd-party libs
 import requests
 from requests.exceptions import ConnectionError
-# pylint: disable=import-error
+# pylint: disable=import-error,no-name-in-module,redefined-builtin
 from salt.ext.six.moves.urllib.parse import urljoin as _urljoin  # pylint: disable=import-error,no-name-in-module
-# pylint: enable=import-error
+import salt.ext.six.moves.http_client
+# pylint: enable=import-error,no-name-in-module,redefined-builtin
 
 # Import Salt Libs
 import salt.returners
@@ -181,7 +182,7 @@ def _query(function, api_key=None, method='GET', data=None):
         ret['res'] = False
         return ret
 
-    if result.status_code == 200:
+    if result.status_code == salt.ext.six.moves.http_client.OK:
         result = result.json()
         response = slack_functions.get(function).get('response')
         if 'error' in result:
@@ -190,7 +191,7 @@ def _query(function, api_key=None, method='GET', data=None):
             return ret
         ret['message'] = result.get(response)
         return ret
-    elif result.status_code == 204:
+    elif result.status_code == salt.ext.six.moves.http_client.NO_CONTENT:
         return True
     else:
         log.debug(url)
@@ -210,12 +211,12 @@ def _post_message(channel,
                   from_name,
                   api_key=None):
     '''
-    Send a message to a HipChat room.
+    Send a message to a Slack room.
     :param room_id:     The room id or room name, either will work.
-    :param message:     The message to send to the HipChat room.
+    :param message:     The message to send to the Slack room.
     :param from_name:   Specify who the message is from.
-    :param api_key:     The HipChat api key, if not specified in the configuration.
-    :param api_version: The HipChat api version, if not specified in the configuration.
+    :param api_key:     The Slack api key, if not specified in the configuration.
+    :param api_version: The Slack api version, if not specified in the configuration.
     :param color:       The color for the message, default: yellow.
     :param notify:      Whether to notify the room, default: False.
     :return:            Boolean if message was sent successfully.


### PR DESCRIPTION
Swapping out hardcoded HTTP return code numbers for their values from salt.ext.six.moves.http_client. Some typos in some documention for returners.
