### PR TITLE
Fixes to sysmod.py

### DIFF
--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -12,6 +12,7 @@ import logging
 import salt.loader
 import salt.utils
 import salt.state
+import salt.runner
 from salt.utils.doc import strip_rst as _strip_rst
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
runner_doc in sysmod requires salt.runner to be imported.
