### PR TITLE
Issue #20850 puppet run should return actual code

### DIFF
--- a/salt/modules/puppet.py
+++ b/salt/modules/puppet.py
@@ -166,10 +166,8 @@ def run(*args, **kwargs):
 
     puppet.kwargs.update(salt.utils.clean_kwargs(**kwargs))
 
-    if __salt__['cmd.run_all'](repr(puppet), python_shell=False) in [0, 2]:
-        return 0
-    else:
-        return 1
+    return __salt__['cmd.run_all'](repr(puppet), python_shell=False)
+
 
 
 def noop(*args, **kwargs):

--- a/salt/modules/puppet.py
+++ b/salt/modules/puppet.py
@@ -169,7 +169,6 @@ def run(*args, **kwargs):
     return __salt__['cmd.run_all'](repr(puppet), python_shell=False)
 
 
-
 def noop(*args, **kwargs):
     '''
     Execute a puppet noop run and return a dict with the stderr, stdout,


### PR DESCRIPTION
Per the thread in https://github.com/saltstack/salt/issues/20850, I believe the proper retcode should be used rather than an obscured one.
