### PR TITLE
Remove grains outputter from grains modules

### DIFF
--- a/salt/client/ssh/wrapper/grains.py
+++ b/salt/client/ssh/wrapper/grains.py
@@ -16,13 +16,6 @@ from salt.exceptions import SaltException
 # Seed the grains dict so cython will build
 __grains__ = {}
 
-# Change the default outputter to make it more readable
-__outputter__ = {
-    'items': 'grains',
-    'item': 'grains',
-    'setval': 'grains',
-}
-
 
 def _serial_sanitizer(instr):
     '''Replaces the last 1/4 of a string with X's'''

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -28,13 +28,6 @@ __proxyenabled__ = ['*']
 # Seed the grains dict so cython will build
 __grains__ = {}
 
-# Change the default outputter to make it more readable
-__outputter__ = {
-    'items': 'grains',
-    'item': 'grains',
-    'setval': 'grains',
-}
-
 # http://stackoverflow.com/a/12414913/127816
 _infinitedict = lambda: collections.defaultdict(_infinitedict)
 


### PR DESCRIPTION
Since we have removed the grains outputter (#20172) we should stop trying to talk to it
