### PR TITLE
boto utils module

### DIFF
--- a/salt/utils/boto.py
+++ b/salt/utils/boto.py
@@ -160,3 +160,30 @@ def get_connection(service, module=None, region=None, key=None, keyid=None,
         raise CommandExecutionError(exc.reason)
     __context__[cxkey] = conn
     return conn
+
+def get_exception(e):
+    '''
+    Extract the message from a boto exception and return a
+    CommandExecutionError with the original reason and message.
+
+    .. code-block:: python
+
+        raise __utils__['boto.get_exception'](e)
+    '''
+
+    status = e.status or ''
+    reason = e.reason or ''
+    body = e.body or ''
+
+    try:
+        message = ET.fromstring(body).find('Errors').find('Error').find('Message').text
+    except (AttributeError, ET.ParseError):
+        message = ''
+    
+
+    if message:
+        message = '{0} {1}: {2}'.format(status, reason, message)
+    else:
+        message = '{0} {1}'.format(status, reason)
+
+    return CommandExecutionError(message)

--- a/salt/utils/boto.py
+++ b/salt/utils/boto.py
@@ -100,6 +100,12 @@ def cache_id(service, name, sub_resource=None, resource_id=None,
              profile=None):
     '''
     Cache, invalidate, or retrieve an AWS resource id keyed by name.
+
+    .. code-block:: python
+
+        __utils__['boto.cache_id']('ec2', 'myinstance',
+                                   'i-a1b2c3',
+                                   profile='custom_profile')
     '''
 
     cxkey, _, _, _ = _get_profile(service, region, key,
@@ -123,7 +129,7 @@ def cache_id(service, name, sub_resource=None, resource_id=None,
 
 
 def get_connection(service, module=None, region=None, key=None, keyid=None,
-             profile=None):
+                   profile=None):
     '''
     Return a boto connection for the service.
 

--- a/salt/utils/boto.py
+++ b/salt/utils/boto.py
@@ -158,7 +158,7 @@ def get_connection(service, module=None, region=None, key=None, keyid=None,
                                   'attempting to make boto {0} connection to '
                                   'region "{1}".'.format(service, region))
     except BotoServerError as exc:
-        raise CommandExecutionError(exc.reason)
+        raise get_exception(exc)
     __context__[cxkey] = conn
     return conn
 

--- a/salt/utils/boto.py
+++ b/salt/utils/boto.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+'''
+Boto Common Utils
+=================
+
+Note: This module depends on the __context__ dict and, therefore, must
+be accessed via the loader or from the __utils__ dict.
+
+.. versionadded:: Beryllium
+'''
+
+# Import Python libs
+from __future__ import absolute_import
+import hashlib
+import logging
+
+# Import salt libs
+from salt._compat import ElementTree as ET
+
+# Import third party libs
+# pylint: disable=import-error
+try:
+    # pylint: disable=import-error
+    import boto
+    # pylint: enable=import-error
+    logging.getLogger('boto').setLevel(logging.CRITICAL)
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+# pylint: enable=import-error
+
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Only load if boto libraries exist and if boto libraries are greater than
+    a given version.
+    '''
+    # TODO: Determine minimal version we want to support. VPC requires > 2.8.0.
+    required_boto_version = '2.0.0' 
+    if not HAS_BOTO:
+        return False
+    elif _LooseVersion(boto.__version__) < _LooseVersion(required_boto_version):
+        return False
+    else:
+        return True
+
+
+def _get_profile(service, region, key, keyid, profile):
+    if profile:
+        if isinstance(profile, six.string_types):
+            _profile = __salt__['config.option'](profile)
+        elif isinstance(profile, dict):
+            _profile = profile
+        key = _profile.get('key', None)
+        keyid = _profile.get('keyid', None)
+        region = _profile.get('region', None)
+
+    if not region and __salt__['config.option'](service + '.region'):
+        region = __salt__['config.option'](service + '.region')
+
+    if not region:
+        region = 'us-east-1'
+
+    if not key and __salt__['config.option'](service + '.key'):
+        key = __salt__['config.option'](service + '.key')
+    if not keyid and __salt__['config.option'](service + '.keyid'):
+        keyid = __salt__['config.option'](service + '.keyid')
+
+    label = 'boto_{0}:'.format(service)
+    if keyid:
+        cxkey = label + hashlib.md5(region + keyid + key).hexdigest()
+    else:
+        cxkey = label + region
+
+    return (cxkey, region, key, keyid)
+
+
+def cache_id(name, sub_resource=None, resource_id=None,
+             invalidate=False, region=None, key=None, keyid=None,
+             profile=None):
+    '''
+    Cache, invalidate, or retrieve an AWS resource id keyed by name.
+    '''
+
+    cxkey, _, _, _ = _get_profile(service, region, key,
+                                  keyid, profile)
+    if sub_resource:
+        cxkey = '{0}:{1}:{2}:id'.format(cxkey, sub_resource, name)
+    else:
+        cxkey = '{0}:{1}:id'.format(cxkey, name)
+
+    if invalidate:
+        if cxkey in __context__:
+            del __context__[cxkey]
+            return True
+        else:
+            return False
+    if resource_id:
+        __context__[cxkey] = resource_id
+        return True
+
+    return __context__.get(cxkey)

--- a/salt/utils/boto.py
+++ b/salt/utils/boto.py
@@ -16,6 +16,7 @@ import logging
 from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
 
 # Import salt libs
+import salt.ext.six as six
 from salt.exceptions import SaltInvocationError, CommandExecutionError
 from salt._compat import ElementTree as ET
 
@@ -161,6 +162,7 @@ def get_connection(service, module=None, region=None, key=None, keyid=None,
     __context__[cxkey] = conn
     return conn
 
+
 def get_exception(e):
     '''
     Extract the message from a boto exception and return a
@@ -179,7 +181,7 @@ def get_exception(e):
         message = ET.fromstring(body).find('Errors').find('Error').find('Message').text
     except (AttributeError, ET.ParseError):
         message = ''
-    
+
     if message:
         message = '{0} {1}: {2}'.format(status, reason, message)
     else:

--- a/salt/utils/boto.py
+++ b/salt/utils/boto.py
@@ -180,7 +180,6 @@ def get_exception(e):
     except (AttributeError, ET.ParseError):
         message = ''
     
-
     if message:
         message = '{0} {1}: {2}'.format(status, reason, message)
     else:

--- a/tests/unit/utils/boto_test.py
+++ b/tests/unit/utils/boto_test.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Import python libs
 from __future__ import absolute_import
 from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module

--- a/tests/unit/utils/boto_test.py
+++ b/tests/unit/utils/boto_test.py
@@ -144,6 +144,11 @@ class BotoUtilsGetConnTestCase(BotoUtilsTestCaseBase):
         self.assertTrue(conn in salt.utils.boto.__context__.values())
 
     @mock_ec2
+    def test_conn_is_cache_with_profile(self):
+        conn = salt.utils.boto.get_connection(service, profile=conn_parameters)
+        self.assertTrue(conn in salt.utils.boto.__context__.values())
+
+    @mock_ec2
     def test_get_conn_with_no_auth_params_raises_invocation_error(self):
         with patch('boto.{0}.connect_to_region'.format(service),
                    side_effect=boto.exception.NoAuthHandlerFound()):
@@ -183,4 +188,4 @@ class BotoUtilsGetExceptionTestCase(BotoUtilsTestCaseBase):
 
 if __name__ == '__main__':
     from integration import run_tests
-    run_tests(BotoUtilsGetExceptionTestCase, needs_daemon=False)
+    run_tests(BotoUtilsGetConnTestCase, needs_daemon=False)

--- a/tests/unit/utils/boto_test.py
+++ b/tests/unit/utils/boto_test.py
@@ -1,0 +1,157 @@
+# Import python libs
+from __future__ import absolute_import
+from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module
+
+# Import Salt Testing libs
+from salttesting.unit import skipIf, TestCase
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, patch
+from salttesting.helpers import ensure_in_syspath
+ensure_in_syspath('../../')
+
+# Import Salt libs
+from salt.exceptions import SaltInvocationError, CommandExecutionError
+import salt.utils.boto
+
+# Import 3rd-party libs
+# pylint: disable=import-error
+try:
+    import boto
+    import boto.exception
+
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+
+try:
+    from moto import mock_ec2
+
+    HAS_MOTO = True
+except ImportError:
+    HAS_MOTO = False
+
+    def mock_ec2(self):
+        '''
+        if the mock_ec2 function is not available due to import failure
+        this replaces the decorated function with stub_function.
+        Allows unit tests to use the @mock_ec2 decorator
+        without a "NameError: name 'mock_ec2' is not defined" error.
+        '''
+
+        def stub_function(self):
+            pass
+
+        return stub_function
+
+
+required_boto_version = '2.0.0'
+region = 'us-east-1'
+access_key = 'GKTADJGHEIQSXMKKRBJ08H'
+secret_key = 'askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs'
+conn_parameters = {'region': region, 'key': access_key, 'keyid': secret_key, 'profile': {}}
+
+service = 'ec2'
+resource_name = 'test-instance'
+resource_id = 'i-a1b2c3'
+
+
+error_body = '''
+<Response>
+    <Errors>
+         <Error>
+           <Code>Error code text</Code>
+           <Message>Error message</Message>
+         </Error>
+    </Errors>
+    <RequestID>request ID</RequestID>
+</Response>
+'''
+
+def _has_required_boto():
+    '''
+    Returns True/False boolean depending on if Boto is installed and correct
+    version.
+    '''
+    if not HAS_BOTO:
+        return False
+    elif LooseVersion(boto.__version__) < LooseVersion(required_boto_version):
+        return False
+    else:
+        return True
+
+
+def _has_required_moto():
+    '''
+    Returns True/False boolean depending on if Moto is installed and correct
+    version.
+    '''
+    if not HAS_MOTO:
+        return False
+    else:
+        import pkg_resources
+
+        if LooseVersion(pkg_resources.get_distribution('moto').version) < LooseVersion('0.3.7'):
+            return False
+        return True
+
+
+class BotoUtilsTestCaseBase(TestCase):
+
+    def setUp(self):
+        salt.utils.boto.__context__ = {}
+        salt.utils.boto.__opts__ = {}
+        salt.utils.boto.__pillar__ = {}
+
+
+class BotoUtilsCacheIdTestCase(BotoUtilsTestCaseBase):
+    def setUp(self):
+        super(BotoUtilsCacheIdTestCase, self).setUp()
+
+    def test_set_and_get_with_no_auth_params(self):
+        salt.utils.boto.cache_id(service, resource_name, resource_id=resource_id)
+        self.assertEqual(salt.utils.boto.cache_id(service, resource_name), resource_id)
+
+    def test_set_and_get_with_explicit_auth_params(self):
+        salt.utils.boto.cache_id(service, resource_name, resource_id=resource_id, **conn_parameters)
+        self.assertEqual(salt.utils.boto.cache_id(service, resource_name, **conn_parameters), resource_id)
+
+    def test_set_and_get_with_different_region_returns_none(self):
+        salt.utils.boto.cache_id(service, resource_name, resource_id=resource_id, region='us-east-1')
+        self.assertEqual(salt.utils.boto.cache_id(service, resource_name, region='us-west-2'), None)
+
+    def test_set_and_get_after_invalidation_returns_none(self):
+        salt.utils.boto.cache_id(service, resource_name, resource_id=resource_id)
+        salt.utils.boto.cache_id(service, resource_name, resource_id=resource_id, invalidate=True)
+        self.assertEqual(salt.utils.boto.cache_id(service, resource_name), None)
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(HAS_BOTO is False, 'The boto module must be installed.')
+@skipIf(HAS_MOTO is False, 'The moto module must be installed.')
+@skipIf(_has_required_boto() is False, 'The boto module must be greater than'
+                                       ' or equal to version {0}'
+        .format(required_boto_version))
+class BotoUtilsGetConnTestCase(BotoUtilsTestCaseBase):
+
+    @mock_ec2
+    def test_conn_is_cached(self):
+        conn = salt.utils.boto.get_connection(service, **conn_parameters)
+        self.assertTrue(conn in salt.utils.boto.__context__.values())
+
+    @mock_ec2
+    def test_get_conn_with_no_auth_params_raises_invocation_error(self):
+        with patch('boto.{0}.connect_to_region'.format(service),
+                   side_effect=boto.exception.NoAuthHandlerFound()):
+            with self.assertRaises(SaltInvocationError):
+                salt.utils.boto.get_connection(service)
+
+    @mock_ec2
+    def test_get_conn_error_raises_command_execution_error(self):
+        with patch('boto.{0}.connect_to_region'.format(service),
+                   side_effect=boto.exception.BotoServerError(400, 'Mocked error', body=error_body)):
+            with self.assertRaises(CommandExecutionError):
+                salt.utils.boto.get_connection(service)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(BotoUtilsGetConnTestCase, needs_daemon=False)


### PR DESCRIPTION
This is a boto utils module which provides common code for creating and caching connections. It also provides a general caching function and a helper function for mapping `BotoServerErrors` to `CommandExecutionErrors`, preserving the XML error message. It is intended to be utilized from the boto execution modules via the `__utils__` dict.

@ryan-lane, @tsaridas, and @claudiupopescu
