### PR TITLE
bad logic in checking for x509 extensions

### DIFF
--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -1129,7 +1129,7 @@ def create_certificate(path=None, text=False, ca_server=None, **kwargs):
     cert.set_issuer(signing_cert.get_subject())
 
     for extname, extlongname in EXT_NAME_MAPPINGS.iteritems():
-        if extname not in kwargs or extlongname not in kwargs or extname not in csrexts or extlongname not in csrexts:
+        if (extname in kwargs or extlongname in kwargs or extname in csrexts or extlongname in csrexts) is False:
             continue
 
         # Use explicitly set values first, fall back to CSR values.


### PR DESCRIPTION
Bad logic in checking for extensions resulted in extensions not being added to the generated certificate.
