### PR TITLE
Adding more features to vmware cloud driver

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -409,7 +409,6 @@ def _manage_devices(devices, vm):
                 adapter_mapping.adapter.ip = vim.vm.customization.DhcpIpGenerator()
             nics_map.append(adapter_mapping)
 
-
     ret = {
         'device_specs': device_specs,
         'nics_map': nics_map

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -366,8 +366,6 @@ def _manage_devices(devices, vm):
                         adapter_mapping.adapter.ip = vim.vm.customization.DhcpIpGenerator()
                     nics_map.append(adapter_mapping)
 
-                    
-
     if 'disk' in devices.keys():
         disks_to_create = list(set(devices['disk'].keys()) - set(existing_disks_label))
         disks_to_create.sort()

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -737,14 +737,26 @@ def show_instance(name, call=None):
         if hasattr(device.backing, 'fileName'):
             device_full_info[device.deviceInfo.label]['capacityInKB'] = device.capacityInKB
             device_full_info[device.deviceInfo.label]['diskMode'] = device.backing.diskMode
-            disk_full_info[device.deviceInfo.label] = device_full_info[device.deviceInfo.label]
-            disk_full_info[device.deviceInfo.label]['descriptor'] = device.backing.fileName
+            disk_full_info[device.deviceInfo.label] = device_full_info[device.deviceInfo.label].copy()
+            disk_full_info[device.deviceInfo.label]['fileName'] = device.backing.fileName
+            if device.backing.datastore:
+                disk_full_info[device.deviceInfo.label]['datastore'] = {
+                    'name': device.backing.datastore.name,
+                    'host': [host.key.name for host in device.backing.datastore.host],
+                    'summary': {
+                        'capacityInKB': device.backing.datastore.summary.capacity,
+                        'freeSpaceInKB': device.backing.datastore.summary.freeSpace,
+                        'fileSystem': device.backing.datastore.summary.type,
+                        'url': device.backing.datastore.summary.url
+                    }
+                }
 
-    storage_full_info = {}
-    storage_full_info['committed'] = vm.summary.storage.committed
-    storage_full_info['uncommitted'] = vm.summary.storage.uncommitted
-    storage_full_info['unshared'] = vm.summary.storage.unshared
-    storage_full_info['disks'] = disk_full_info
+    storage_full_info = {
+        'committed': vm.summary.storage.committed,
+        'uncommitted': vm.summary.storage.uncommitted,
+        'unshared': vm.summary.storage.unshared,
+        'disks': disk_full_info,
+    }
 
     file_full_info = {}
     for file in vm.layoutEx.file:

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -425,7 +425,7 @@ def _wait_for_ip(vm, max_wait_minute):
         for net in vm.guest.net:
             if net.ipConfig.ipAddress:
                 for current_ip in net.ipConfig.ipAddress:
-                    if match('\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}', current_ip.ipAddress) and current_ip.ipAddress != '127.0.0.1':
+                    if match('^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$', current_ip.ipAddress) and current_ip.ipAddress != '127.0.0.1':
                         ip = current_ip.ipAddress
                         return ip
         time.sleep(5)

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -425,7 +425,7 @@ def _wait_for_ip(vm, max_wait_minute):
         for net in vm.guest.net:
             if net.ipConfig.ipAddress:
                 for current_ip in net.ipConfig.ipAddress:
-                    if match('^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$', current_ip.ipAddress) and current_ip.ipAddress != '127.0.0.1':
+                    if match(r'^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$', current_ip.ipAddress) and current_ip.ipAddress != '127.0.0.1':
                         ip = current_ip.ipAddress
                         return ip
         time.sleep(5)

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -1145,7 +1145,7 @@ def destroy(name, call=None):
     )
     if __opts__.get('update_cachedir', False) is True:
         salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
-    return 'True'
+    return True
 
 
 def create(vm_):


### PR DESCRIPTION
#### READY TO BE MERGED
#### [salt.cloud.clouds.vsphere](http://docs.saltstack.com/en/latest/ref/clouds/all/salt.cloud.clouds.vsphere.html) can now be deprecated.

`create()` can now deploy and install salt on the VM using the bootstrap script. 

`file_map` can be specified with a list of files

`dns_servers` can be specified

`domain` can be specified per network adapter or global

`ip` can be specified per network adapter

`gateway` can be specified per network adapter

`subnet_mask` can be specified per network adapter

`private_key` or `password` can be specified which is used to ssh into the VM

`ssh_username` can be specified which is used to ssh into the VM

minion custom config can be specified under `minion`

`deploy` is set to `True` by default to install salt using the bootstrap script but can be set to `False`

Static IP can now be specified per network adapter. If not specified, IP will automatically be requested using DHCP. (Network must be DHCP enabled for DHCP to assign IP). Currently, static IP can only be assigned to Linux VM's and not Windows VM's. Both Windows and Linux VM's can be assigned ip using DHCP though on a DHCP enabled network

Also added `wait_for_ip()` which waits for the ip information to be available after cloning the VM. 

Also added `list_nodes_full`.

@techhat @rallytime 
