### PR TITLE
Correctly report disk usage on Windows

### DIFF
--- a/salt/modules/win_disk.py
+++ b/salt/modules/win_disk.py
@@ -50,24 +50,19 @@ def usage():
         drive_bitmask >>= 1
     for drive in drives:
         try:
-            (sectorspercluster,
-             bytespersector,
-             freeclusters,
-             totalclusters) = win32api.GetDiskFreeSpace(
+            (available_bytes,
+             total_bytes,
+             total_free_bytes) = win32api.GetDiskFreeSpaceEx(
                  '{0}:\\'.format(drive)
-             )
-            totalsize = sectorspercluster * bytespersector * totalclusters
-            available_space = (
-                sectorspercluster * bytespersector * freeclusters
             )
-            used = totalsize - available_space
-            capacity = int(used / float(totalsize) * 100)
+            used = total_bytes - total_free_bytes
+            capacity = used / float(total_bytes) * 100
             ret['{0}:\\'.format(drive)] = {
                 'filesystem': '{0}:\\'.format(drive),
-                '1K-blocks': totalsize / 1024,
+                '1K-blocks': total_bytes / 1024,
                 'used': used / 1024,
-                'available': available_space / 1024,
-                'capacity': '{0}%'.format(capacity),
+                'available': total_free_bytes / 1024,
+                'capacity': '{0:.0f}%'.format(capacity),
             }
         except Exception:
             ret['{0}:\\'.format(drive)] = {


### PR DESCRIPTION
This fixes #16508.

The GetDiskFreeSpace API call uses 32-bit unsigned ints, which causes it
to fail for large disks.  The GetDiskFreeSpaceEx method uses long
integers and avoids the need for several manual calcuations.

This also ensures the capacity reported rounds correct.  The previous
implementation was to convert the percentage directly to an int, slicing
off the decimal portion.
