### PR TITLE
improvement: Support nested nodegroups

### DIFF
--- a/doc/ref/cli/index.rst
+++ b/doc/ref/cli/index.rst
@@ -136,8 +136,8 @@ shorthand for having to type out complicated compound expressions.
     nodegroups:
       group1: 'L@foo.domain.com,bar.domain.com,baz.domain.com and bl*.domain.com'
       group2: 'G@os:Debian and foo.domain.com'
+      group3: 'G@os:Debian and N@group1'
 
-More info on using nodegroups can be found :ref:`here <targeting-nodegroups>`.
 
 Calling the Function
 --------------------

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -2286,6 +2286,9 @@ A group consists of a group name and a compound target.
     nodegroups:
       group1: 'L@foo.domain.com,bar.domain.com,baz.domain.com or bl*.domain.com'
       group2: 'G@os:Debian and foo.domain.com'
+      group3: 'G@os:Debian and N@group1'
+
+More information on using nodegroups can be found :ref:`here <targeting-nodegroups>`.
 
 
 Range Cluster Settings

--- a/doc/topics/targeting/nodegroups.rst
+++ b/doc/topics/targeting/nodegroups.rst
@@ -16,12 +16,19 @@ nodegroups. Here's an example nodegroup configuration within
     nodegroups:
       group1: 'L@foo.domain.com,bar.domain.com,baz.domain.com or bl*.domain.com'
       group2: 'G@os:Debian and foo.domain.com'
+      group3: 'G@os:Debian and N@group1'
 
 .. note::
 
     The ``L`` within group1 is matching a list of minions, while the ``G`` in
     group2 is matching specific grains. See the :doc:`compound matchers
     <compound>` documentation for more details.
+
+.. note::
+
+    Nodgroups can reference other nodegroups as seen in ``group3``.  Ensure
+    that you do not have circular references.  Circular references will be
+    detected and cause partial expansion with a logged error message.
 
 To match a nodegroup on the CLI, use the ``-N`` command-line option:
 

--- a/tests/integration/files/conf/master
+++ b/tests/integration/files/conf/master
@@ -58,3 +58,8 @@ external_auth:
 
 master_tops:
   master_tops_test: True
+
+nodegroups:
+  min: minion
+  sub_min: sub_minion
+  mins: N@min or N@sub_min

--- a/tests/integration/shell/matcher.py
+++ b/tests/integration/shell/matcher.py
@@ -65,6 +65,29 @@ class MatchTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
         self.assertIn('sub_minion', data)
         self.assertNotIn('minion', data.replace('sub_minion', 'stub'))
 
+    def test_nodegroup(self):
+        '''
+        test salt nodegroup matcher
+        '''
+        def minion_in_target(minion, lines):
+            return sum([line == '{0}:'.format(minion) for line in lines])
+
+        data = self.run_salt('-N min test.ping')
+        self.assertTrue(minion_in_target('minion', data))
+        self.assertFalse(minion_in_target('sub_minion', data))
+        time.sleep(2)
+        data = self.run_salt('-N sub_min test.ping')
+        self.assertFalse(minion_in_target('minion', data))
+        self.assertTrue(minion_in_target('sub_minion', data))
+        time.sleep(2)
+        data = self.run_salt('-N mins test.ping')
+        self.assertTrue(minion_in_target('minion', data))
+        self.assertTrue(minion_in_target('sub_minion', data))
+        time.sleep(2)
+        data = self.run_salt('-N unknown_nodegroup test.ping')
+        self.assertFalse(minion_in_target('minion', data))
+        self.assertFalse(minion_in_target('sub_minion', data))
+
     def test_glob(self):
         '''
         test salt glob matcher


### PR DESCRIPTION
Nodegroups can be recursively expanded without worrying about other
compound matcher expansions.  Once the nodegroups are expanded on the
master the remaining flattened compound match can be expanded without the
nodegroup information.

---

It's unclear if this is an improvement or a bug fix.  It is unclear to me if `salt.utils.minions.nodegroup_comp()` is horribly broken (maybe it didn't get updated to match a previous change?) or if it doesn't work or if I just don't understand how it is supposed to work and I'm off in left field.  If someone can help me understand how `nodegroup_comp()` is supposed to work (why is it splitting on ','?) I would appreciate it.
