### PR TITLE
allow disabling auth on webhook endpoint in rest_tornado

### DIFF
--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -30,6 +30,7 @@ add the following to the Salt master config file.
         ssl_key: /etc/pki/api/certs/server.key
         debug: False
         disable_ssl: False
+        webhook_disable_auth: False
 
 
 .. _rest_tornado-auth:
@@ -1563,7 +1564,8 @@ class WebhookSaltAPIHandler(SaltAPIHandler):
                       revision: {{ revision }}
             {% endif %}
         '''
-        if not self._verify_auth():
+        disable_auth = self.application.mod_opts.get('webhook_disable_auth')
+        if not disable_auth and self._verify_auth():
             self.redirect('/login')
             return
 

--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -1565,7 +1565,7 @@ class WebhookSaltAPIHandler(SaltAPIHandler):
             {% endif %}
         '''
         disable_auth = self.application.mod_opts.get('webhook_disable_auth')
-        if not disable_auth and self._verify_auth():
+        if not disable_auth and not self._verify_auth():
             self.redirect('/login')
             return
 

--- a/tests/integration/netapi/rest_tornado/test_app.py
+++ b/tests/integration/netapi/rest_tornado/test_app.py
@@ -17,11 +17,6 @@ from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../../')
 
 import salt.ext.six as six
-try:
-    import tornado
-    HAS_TORNADO = True
-except ImportError:
-    HAS_TORNADO = False
 
 try:
     import zmq
@@ -31,14 +26,13 @@ except ImportError:
     HAS_ZMQ_IOLOOP = False
 
 
-@skipIf(HAS_TORNADO is False, 'Tornado must be installed to run these tests')
 @skipIf(HAS_ZMQ_IOLOOP is False, 'PyZMQ version must be >= 14.0.1 to run these tests.')
 @skipIf(StrictVersion(zmq.__version__) < StrictVersion('14.0.1'), 'PyZMQ must be >= 14.0.1 to run these tests.')
 class TestSaltAPIHandler(SaltnadoTestCase):
     def get_app(self):
         urls = [('/', saltnado.SaltAPIHandler)]
 
-        application = super(TestSaltAPIHandler, self).get_app(urls)
+        application = self.build_tornado_app(urls)
 
         application.event_listener = saltnado.EventListener({}, self.opts)
         return application
@@ -281,14 +275,13 @@ class TestSaltAPIHandler(SaltnadoTestCase):
         self.assertEqual(response_obj['return'], [['minion', 'sub_minion']])
 
 
-@skipIf(HAS_TORNADO is False, 'Tornado must be installed to run these tests')
 @skipIf(HAS_ZMQ_IOLOOP is False, 'PyZMQ version must be >= 14.0.1 to run these tests.')
 class TestMinionSaltAPIHandler(SaltnadoTestCase):
     def get_app(self):
         urls = [(r"/minions/(.*)", saltnado.MinionSaltAPIHandler),
                 (r"/minions", saltnado.MinionSaltAPIHandler),
                 ]
-        application = super(TestMinionSaltAPIHandler, self).get_app(urls)
+        application = self.build_tornado_app(urls)
         application.event_listener = saltnado.EventListener({}, self.opts)
         return application
 
@@ -371,14 +364,13 @@ class TestMinionSaltAPIHandler(SaltnadoTestCase):
         self.assertEqual(response.code, 400)
 
 
-@skipIf(HAS_TORNADO is False, 'Tornado must be installed to run these tests')
 @skipIf(HAS_ZMQ_IOLOOP is False, 'PyZMQ version must be >= 14.0.1 to run these tests.')
 class TestJobsSaltAPIHandler(SaltnadoTestCase):
     def get_app(self):
         urls = [(r"/jobs/(.*)", saltnado.JobsSaltAPIHandler),
-                (r"/jobs", saltnado.JobsSaltAPIHandler), 
+                (r"/jobs", saltnado.JobsSaltAPIHandler),
                 ]
-        application = super(TestJobsSaltAPIHandler, self).get_app(urls)
+        application = self.build_tornado_app(urls)
         application.event_listener = saltnado.EventListener({}, self.opts)
         return application
 
@@ -421,13 +413,12 @@ class TestJobsSaltAPIHandler(SaltnadoTestCase):
 
 # TODO: run all the same tests from the root handler, but for now since they are
 # the same code, we'll just sanity check
-@skipIf(HAS_TORNADO is False, 'Tornado must be installed to run these tests')
 @skipIf(HAS_ZMQ_IOLOOP is False, 'PyZMQ version must be >= 14.0.1 to run these tests.')
 class TestRunSaltAPIHandler(SaltnadoTestCase):
     def get_app(self):
-        urls = [("/run", saltnado.RunSaltAPIHandler), 
+        urls = [("/run", saltnado.RunSaltAPIHandler),
                 ]
-        application = super(TestRunSaltAPIHandler, self).get_app(urls)
+        application = self.build_tornado_app(urls)
         application.event_listener = saltnado.EventListener({}, self.opts)
         return application
 
@@ -446,13 +437,12 @@ class TestRunSaltAPIHandler(SaltnadoTestCase):
         self.assertEqual(response_obj['return'], [{'minion': True, 'sub_minion': True}])
 
 
-@skipIf(HAS_TORNADO is False, 'Tornado must be installed to run these tests')
 @skipIf(HAS_ZMQ_IOLOOP is False, 'PyZMQ version must be >= 14.0.1 to run these tests.')
 class TestEventsSaltAPIHandler(SaltnadoTestCase):
     def get_app(self):
-        urls = [(r"/events", saltnado.EventsSaltAPIHandler), 
+        urls = [(r"/events", saltnado.EventsSaltAPIHandler),
                 ]
-        application = super(TestEventsSaltAPIHandler, self).get_app(urls)
+        application = self.build_tornado_app(urls)
         application.event_listener = saltnado.EventListener({}, self.opts)
 
         # store a reference, for magic later!
@@ -491,7 +481,6 @@ class TestEventsSaltAPIHandler(SaltnadoTestCase):
             self.assertTrue(data.startswith('data: '))
 
 
-@skipIf(HAS_TORNADO is False, 'Tornado must be installed to run these tests')
 @skipIf(HAS_ZMQ_IOLOOP is False, 'PyZMQ version must be >= 14.0.1 to run these tests.')
 class TestWebhookSaltAPIHandler(SaltnadoTestCase):
 
@@ -500,7 +489,7 @@ class TestWebhookSaltAPIHandler(SaltnadoTestCase):
         urls = [(r"/hook(/.*)?", saltnado.WebhookSaltAPIHandler),
                 ]
 
-        application = super(TestWebhookSaltAPIHandler, self).get_app(urls)
+        application = self.build_tornado_app(urls)
 
         self.application = application
 

--- a/tests/integration/netapi/rest_tornado/test_app.py
+++ b/tests/integration/netapi/rest_tornado/test_app.py
@@ -36,10 +36,9 @@ except ImportError:
 @skipIf(StrictVersion(zmq.__version__) < StrictVersion('14.0.1'), 'PyZMQ must be >= 14.0.1 to run these tests.')
 class TestSaltAPIHandler(SaltnadoTestCase):
     def get_app(self):
-        application = tornado.web.Application([('/', saltnado.SaltAPIHandler)], debug=True)
+        urls = [('/', saltnado.SaltAPIHandler)]
 
-        application.auth = self.auth
-        application.opts = self.opts
+        application = super(TestSaltAPIHandler, self).get_app(urls)
 
         application.event_listener = saltnado.EventListener({}, self.opts)
         return application
@@ -286,13 +285,10 @@ class TestSaltAPIHandler(SaltnadoTestCase):
 @skipIf(HAS_ZMQ_IOLOOP is False, 'PyZMQ version must be >= 14.0.1 to run these tests.')
 class TestMinionSaltAPIHandler(SaltnadoTestCase):
     def get_app(self):
-        application = tornado.web.Application([(r"/minions/(.*)", saltnado.MinionSaltAPIHandler),
-                                               (r"/minions", saltnado.MinionSaltAPIHandler),
-                                               ], debug=True)
-
-        application.auth = self.auth
-        application.opts = self.opts
-
+        urls = [(r"/minions/(.*)", saltnado.MinionSaltAPIHandler),
+                (r"/minions", saltnado.MinionSaltAPIHandler),
+                ]
+        application = super(TestMinionSaltAPIHandler, self).get_app(urls)
         application.event_listener = saltnado.EventListener({}, self.opts)
         return application
 
@@ -379,13 +375,10 @@ class TestMinionSaltAPIHandler(SaltnadoTestCase):
 @skipIf(HAS_ZMQ_IOLOOP is False, 'PyZMQ version must be >= 14.0.1 to run these tests.')
 class TestJobsSaltAPIHandler(SaltnadoTestCase):
     def get_app(self):
-        application = tornado.web.Application([(r"/jobs/(.*)", saltnado.JobsSaltAPIHandler),
-                                               (r"/jobs", saltnado.JobsSaltAPIHandler),
-                                               ], debug=True)
-
-        application.auth = self.auth
-        application.opts = self.opts
-
+        urls = [(r"/jobs/(.*)", saltnado.JobsSaltAPIHandler),
+                (r"/jobs", saltnado.JobsSaltAPIHandler), 
+                ]
+        application = super(TestJobsSaltAPIHandler, self).get_app(urls)
         application.event_listener = saltnado.EventListener({}, self.opts)
         return application
 
@@ -432,12 +425,9 @@ class TestJobsSaltAPIHandler(SaltnadoTestCase):
 @skipIf(HAS_ZMQ_IOLOOP is False, 'PyZMQ version must be >= 14.0.1 to run these tests.')
 class TestRunSaltAPIHandler(SaltnadoTestCase):
     def get_app(self):
-        application = tornado.web.Application([("/run", saltnado.RunSaltAPIHandler),
-                                               ], debug=True)
-
-        application.auth = self.auth
-        application.opts = self.opts
-
+        urls = [("/run", saltnado.RunSaltAPIHandler), 
+                ]
+        application = super(TestRunSaltAPIHandler, self).get_app(urls)
         application.event_listener = saltnado.EventListener({}, self.opts)
         return application
 
@@ -460,13 +450,11 @@ class TestRunSaltAPIHandler(SaltnadoTestCase):
 @skipIf(HAS_ZMQ_IOLOOP is False, 'PyZMQ version must be >= 14.0.1 to run these tests.')
 class TestEventsSaltAPIHandler(SaltnadoTestCase):
     def get_app(self):
-        application = tornado.web.Application([(r"/events", saltnado.EventsSaltAPIHandler),
-                                               ], debug=True)
-
-        application.auth = self.auth
-        application.opts = self.opts
-
+        urls = [(r"/events", saltnado.EventsSaltAPIHandler), 
+                ]
+        application = super(TestEventsSaltAPIHandler, self).get_app(urls)
         application.event_listener = saltnado.EventListener({}, self.opts)
+
         # store a reference, for magic later!
         self.application = application
         self.events_to_fire = 0
@@ -506,12 +494,13 @@ class TestEventsSaltAPIHandler(SaltnadoTestCase):
 @skipIf(HAS_TORNADO is False, 'Tornado must be installed to run these tests')
 @skipIf(HAS_ZMQ_IOLOOP is False, 'PyZMQ version must be >= 14.0.1 to run these tests.')
 class TestWebhookSaltAPIHandler(SaltnadoTestCase):
-    def get_app(self):
-        application = tornado.web.Application([(r"/hook(/.*)?", saltnado.WebhookSaltAPIHandler),
-                                               ], debug=True)
 
-        application.auth = self.auth
-        application.opts = self.opts
+    def get_app(self):
+
+        urls = [(r"/hook(/.*)?", saltnado.WebhookSaltAPIHandler),
+                ]
+
+        application = super(TestWebhookSaltAPIHandler, self).get_app(urls)
 
         self.application = application
 

--- a/tests/unit/netapi/rest_tornado/test_handlers.py
+++ b/tests/unit/netapi/rest_tornado/test_handlers.py
@@ -89,7 +89,7 @@ class SaltnadoTestCase(integration.ModuleCase, AsyncHTTPTestCase):
         else:
             os.environ['ASYNC_TEST_TIMEOUT'] = self.async_timeout_prev
 
-    def get_app(self, urls):
+    def build_tornado_app(self, urls):
         application = tornado.web.Application(urls, debug=True)
 
         application.auth = self.auth
@@ -97,7 +97,6 @@ class SaltnadoTestCase(integration.ModuleCase, AsyncHTTPTestCase):
         application.mod_opts = self.mod_opts
 
         return application
-
 
 
 class TestBaseSaltAPIHandler(SaltnadoTestCase):
@@ -120,8 +119,8 @@ class TestBaseSaltAPIHandler(SaltnadoTestCase):
                     ret_dict[attr] = getattr(self, attr)
 
                 self.write(self.serialize(ret_dict))
-
-        return super(TestBaseSaltAPIHandler, self).get_app([('/', StubHandler)])
+        urls = [('/', StubHandler)]
+        return super(TestBaseSaltAPIHandler, self).get_tornado_app(urls)
 
     def test_content_type(self):
         '''
@@ -245,7 +244,7 @@ class TestSaltAuthHandler(SaltnadoTestCase):
 
     def get_app(self):
         urls = [('/login', saltnado.SaltAuthHandler)]
-        return super(TestSaltAuthHandler, self).get_app(urls)
+        return self.build_tornado_app(urls)
 
     def test_get(self):
         '''

--- a/tests/unit/netapi/rest_tornado/test_handlers.py
+++ b/tests/unit/netapi/rest_tornado/test_handlers.py
@@ -120,7 +120,7 @@ class TestBaseSaltAPIHandler(SaltnadoTestCase):
 
                 self.write(self.serialize(ret_dict))
         urls = [('/', StubHandler)]
-        return super(TestBaseSaltAPIHandler, self).get_tornado_app(urls)
+        return self.build_tornado_app(urls)
 
     def test_content_type(self):
         '''

--- a/tests/unit/netapi/rest_tornado/test_handlers.py
+++ b/tests/unit/netapi/rest_tornado/test_handlers.py
@@ -63,6 +63,10 @@ class SaltnadoTestCase(integration.ModuleCase, AsyncHTTPTestCase):
         return self.get_config('master', from_scratch=True)
 
     @property
+    def mod_opts(self):
+        return self.get_config('minion', from_scratch=True)
+
+    @property
     def auth(self):
         if not hasattr(self, '__auth'):
             self.__auth = salt.auth.LoadAuth(self.opts)
@@ -75,11 +79,25 @@ class SaltnadoTestCase(integration.ModuleCase, AsyncHTTPTestCase):
 
     def setUp(self):
         super(SaltnadoTestCase, self).setUp()
+        self.async_timeout_prev = os.environ.pop('ASYNC_TEST_TIMEOUT', None)
         os.environ['ASYNC_TEST_TIMEOUT'] = str(30)
 
     def tearDown(self):
         super(SaltnadoTestCase, self).tearDown()
-        os.environ.pop('ASYNC_TEST_TIMEOUT', None)
+        if self.async_timeout_prev is None:
+            os.environ.pop('ASYNC_TEST_TIMEOUT', None)
+        else:
+            os.environ['ASYNC_TEST_TIMEOUT'] = self.async_timeout_prev
+
+    def get_app(self, urls):
+        application = tornado.web.Application(urls, debug=True)
+
+        application.auth = self.auth
+        application.opts = self.opts
+        application.mod_opts = self.mod_opts
+
+        return application
+
 
 
 class TestBaseSaltAPIHandler(SaltnadoTestCase):
@@ -103,7 +121,7 @@ class TestBaseSaltAPIHandler(SaltnadoTestCase):
 
                 self.write(self.serialize(ret_dict))
 
-        return tornado.web.Application([('/', StubHandler)], debug=True)
+        return super(TestBaseSaltAPIHandler, self).get_app([('/', StubHandler)])
 
     def test_content_type(self):
         '''
@@ -224,14 +242,10 @@ class TestBaseSaltAPIHandler(SaltnadoTestCase):
 
 
 class TestSaltAuthHandler(SaltnadoTestCase):
+
     def get_app(self):
-
-        # TODO: make a "GET APPPLICATION" func
-        application = tornado.web.Application([('/login', saltnado.SaltAuthHandler)], debug=True)
-
-        application.auth = self.auth
-        application.opts = self.opts
-        return application
+        urls = [('/login', saltnado.SaltAuthHandler)]
+        return super(TestSaltAuthHandler, self).get_app(urls)
 
     def test_get(self):
         '''


### PR DESCRIPTION
Trying to provide more parity between rest_tornado and rest_cherrypy
