### PR TITLE
DigitalOcean allow users to upload public keys

### DIFF
--- a/salt/cloud/clouds/digital_ocean_v2.py
+++ b/salt/cloud/clouds/digital_ocean_v2.py
@@ -703,6 +703,30 @@ def show_keypair(kwargs=None, call=None):
     return details
 
 
+def create_key(kwargs=None, call=None):
+    '''
+    Upload a public key
+    '''
+    if call != 'function':
+        log.error(
+            'The create_key function must be called with -f or --function.'
+        )
+        return False
+
+    try:
+        result = query(
+            method='account',
+            command='keys',
+            args={'name': kwargs['name'], 'public_key': kwargs['public_key']},
+            http_method='post'
+        )
+    except KeyError:
+        log.info('`name` and `public_key` arguments must be specified')
+        return False
+
+    return result
+
+
 def get_keyid(keyname):
     '''
     Return the ID of the keyname


### PR DESCRIPTION
When users provision minions on Digital Ocean, you need to ensure your public key is available for Salt-cloud to bootstrap a minion. 

``` bash
salt-cloud -f create_key my-digitalocean-config name='My Key' public_key='ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAQQDDHr/jh2Jy4yALcK4JyWbVkPRaWmhck3IgCoeOO3z1e2dBowLh64QAM+Qb72pxekALga2oi4GvT+TlWNhzPH4V example'
[INFO    ] salt-cloud starting
my-digitalocean-config:
    ----------
    digital_ocean:
        ----------
        ssh_key:
            ----------
            fingerprint:
                3b:16:bf:e4:8b:00:8b:b8:59:8c:a9:d3:f0:19:45:fa
            id:
                760383
            name:
                My Key
            public_key:
                ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAQQDDHr/jh2Jy4yALcK4JyWbVkPRaWmhck3IgCoeOO3z1e2dBowLh64QAM+Qb72pxekALga2oi4GvT+TlWNhzPH4V example
```
