### PR TITLE
Add force argument to service to trigger force_reload

### DIFF
--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -388,7 +388,12 @@ def disabled(name, **kwargs):
     return ret
 
 
-def mod_watch(name, sfun=None, sig=None, reload=False, full_restart=False):
+def mod_watch(name,
+              sfun=None,
+              sig=None,
+              reload=False,
+              full_restart=False,
+              force=False):
     '''
     The service watcher, called to invoke the watch command.
 
@@ -406,6 +411,7 @@ def mod_watch(name, sfun=None, sig=None, reload=False, full_restart=False):
            'changes': {},
            'result': True,
            'comment': ''}
+    past_participle = None
 
     if sfun == 'dead':
         verb = 'stop'
@@ -419,20 +425,22 @@ def mod_watch(name, sfun=None, sig=None, reload=False, full_restart=False):
     elif sfun == 'running':
         if __salt__['service.status'](name, sig):
             if 'service.reload' in __salt__ and reload:
-                func = __salt__['service.reload']
-                verb = 'reload'
-                past_participle = verb + 'ed'
+                if 'service.force_reload' in __salt__ and force:
+                    func = __salt__['service.force_reload']
+                    verb = 'forcefully reload'
+                else:
+                    func = __salt__['service.reload']
+                    verb = 'reload'
             elif 'service.full_restart' in __salt__ and full_restart:
                 func = __salt__['service.full_restart']
                 verb = 'fully restart'
-                past_participle = verb + 'ed'
             else:
                 func = __salt__['service.restart']
                 verb = 'restart'
-                past_participle = verb + 'ed'
         else:
             func = __salt__['service.start']
             verb = 'start'
+        if not past_participle:
             past_participle = verb + 'ed'
     else:
         ret['comment'] = 'Unable to trigger watch for service.{0}'.format(sfun)


### PR DESCRIPTION
Systemd's service module has a force_reload function that I'd like to see exposed in service states.

I reduced some code duplication with the past_principle stuff while I was at it.
