### PR TITLE
fix #20420: using other state's comment makes comment grow fast

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1866,7 +1866,7 @@ class State(object):
             else:
                 # determine what the requisite failures where, and return
                 # a nice error message
-                comment_dict = {}
+                failed_requisites = set()
                 # look at all requisite types for a failure
                 for req_type, req_lows in reqs.iteritems():
                     for req_low in req_lows:
@@ -1881,13 +1881,18 @@ class State(object):
                             # use SLS.ID for the key-- so its easier to find
                             key = '{sls}.{_id}'.format(sls=req_low['__sls__'],
                                                        _id=req_low['__id__'])
-                            comment_dict[key] = req_ret['comment']
+                            failed_requisites.add(key)
 
-                running[tag] = {'changes': {},
-                                'result': False,
-                                'comment': 'One or more requisite failed: {0}'.format(comment_dict),
-                                '__run_num__': self.__run_num,
-                                '__sls__': low['__sls__']}
+                _cmt = 'One or more requisite failed: {0}'.format(
+                    ', '.join(str(i) for i in failed_requisites)
+                )
+                running[tag] = {
+                    'changes': {},
+                    'result': False,
+                    'comment': _cmt,
+                    '__run_num__': self.__run_num,
+                    '__sls__': low['__sls__']
+                }
             self.__run_num += 1
         elif status == 'change' and not low.get('__prereq__'):
             ret = self.call(low, chunks, running)


### PR DESCRIPTION
so just mention SLS.ID of that state to help user indicate
where the requisite failed.

Before:

```
         ID: nginx
    Function: service.running
      Result: False
     Comment: One or more requisite failed: {'nginx./etc/nginx/conf.d/example_ssl.conf': 'One or more requisite failed: {\'nginx.nginx\': \'One or more requisite failed: {\\\'web.web\\\': "These values could not be changed: {\\\'homeDoesNotExist\\\': \\\'/var/www\\\'}"}\'}', 'nginx./etc/nginx/conf.d/default.conf': 'One or more requisite failed: {\'nginx.nginx\': \'One or more requisite failed: {\\\'web.web\\\': "These values could not be changed: {\\\'homeDoesNotExist\\\': \\\'/var/www\\\'}"}\'}', 'nginx./var/www/robots.txt': 'One or more requisite failed: {\'web./var/www\': \'One or more requisite failed: {\\\'web.web\\\': "These values could not be changed: {\\\'homeDoesNotExist\\\': \\\'/var/www\\\'}"}\', \'nginx.nginx\': \'One or more requisite failed: {\\\'web.web\\\': "These values could not be changed: {\\\'homeDoesNotExist\\\': \\\'/var/www\\\'}"}\', \'web.web\': "These values could not be changed: {\'homeDoesNotExist\': \'/var/www\'}"}', 'nginx.nginx': 'One or more requisite failed: {\'nginx.nginx\': \'One or more requisite failed: {\\\'web.web\\\': "These values could not be changed: {\\\'homeDoesNotExist\\\': \\\'/var/www\\\'}"}\'}', 'etherpad./etc/nginx/conf.d/etherpad.conf': 'One or more requisite failed: {\'etherpad.etherpad\': \'One or more requisite failed: {\\\'etherpad.etherpad\\\': \\\'One or more requisite failed: {\\\\\\\'etherpad.etherpad\\\\\\\': \\\\\\\'One or more requisite failed: {\\\\\\\\\\\\\\\'web.web\\\\\\\\\\\\\\\': "These values could not be changed: {\\\\\\\\\\\\\\\'homeDoesNotExist\\\\\\\\\\\\\\\': \\\\\\\\\\\\\\\'/var/www\\\\\\\\\\\\\\\'}"}\\\\\\\'}\\\', \\\'etherpad./usr/local/etherpad-lite-1.3.0/src/package.json\\\': \\\'One or more requisite failed: {\\\\\\\'etherpad./usr/local/etherpad-lite-1.3.0/src\\\\\\\': \\\\\\\'One or more requisite failed: {\\\\\\\\\\\\\\\'etherpad./usr/local/etherpad-lite-1.3.0\\\\\\\\\\\\\\\': \\\\\\\\\\\\\\\'One or more requisite failed: {\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'etherpad./usr/local/etherpad-lite-1.3.0\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\': \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'One or more requisite failed: {\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'web.web\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\': "These values could not be changed: {\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'homeDoesNotExist\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\': \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'/var/www\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'}"}\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'}\\\\\\\\\\\\\\\'}\\\\\\\'}\\\', \\\'etherpad./usr/local/etherpad-lite-1.3.0/node_modules\\\': \\\'One or more requisite failed: {\\\\\\\'etherpad./usr/local/etherpad-lite-1.3.0\\\\\\\': \\\\\\\'One or more requisite failed: {\\\\\\\\\\\\\\\'etherpad./usr/local/etherpad-lite-1.3.0\\\\\\\\\\\\\\\': \\\\\\\\\\\\\\\'One or more requisite failed: {\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'web.web\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\': "These values could not be changed: {\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'homeDoesNotExist\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\': \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'/var/www\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'}"}\\\\\\\\\\\\\\\'}\\\\\\\'}\\\', \\\'etherpad./usr/local/etherpad-lite-1.3.0/var\\\': \\\'One or more requisite failed: {\\\\\\\'etherpad./usr/local/etherpad-lite-1.3.0\\\\\\\': \\\\\\\'One or more requisite failed: {\\\\\\\\\\\\\\\'etherpad./usr/local/etherpad-lite-1.3.0\\\\\\\\\\\\\\\': \\\\\\\\\\\\\\\'One or more requisite failed: {\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'web.web\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\': "These values could not be changed: {\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'homeDoesNotExist\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\': \\\\\\\\\\
.... and more longer
```

After:

```
          ID: nginx
    Function: service.running
      Result: False
     Comment: One or more requisite failed: nginx./etc/nginx/conf.d/example_ssl.conf, nginx./etc/nginx/conf.d/defa
ult.conf, nginx./var/www/robots.txt, nginx.nginx, etherpad./etc/nginx/conf.d/etherpad.conf, nginx./etc/nginx/mime.
types, web.web, nginx.nginx.conf
     Started:
    Duration:
     Changes:
```

The thing caused many backslash probably State.call function, but this fix eliminated the use of comment field, so that can be fixed in another MR.
