### PR TITLE
Use shutil.rmtree instead of os.rmdir

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -30,6 +30,7 @@ import salt.syspaths
 import salt.utils.validate.path
 import salt.utils.xdg
 import salt.exceptions
+import salt.utils.sdb
 
 from salt.ext.six import string_types, text_type
 from salt.ext.six.moves.urllib.parse import urlparse  # pylint: disable=import-error,no-name-in-module

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -153,7 +153,7 @@ def _sync(form, saltenv=None):
                 break
             for emptydir in emptydirs:
                 touched = True
-                os.rmdir(emptydir)
+                shutil.rmtree(emptydir, ignore_errors=True)
     # Dest mod_dir is touched? trigger reload if requested
     if touched:
         mod_file = os.path.join(__opts__['cachedir'], 'module_refresh')


### PR DESCRIPTION
Use shutil.rmtree because it ignores errors and we already know the directory is empty. Saves a try/except.

Also add a missing import for sdb.
