### PR TITLE
Quiet noisy log entry in smbios execution module

### DIFF
--- a/salt/modules/smbios.py
+++ b/salt/modules/smbios.py
@@ -38,7 +38,7 @@ def __virtual__():
     Only work when dmidecode is installed.
     '''
     if DMIDECODER is None:
-        log.debug('SMBIOS: dmidecode nor smbios found!')
+        log.debug('SMBIOS: neither dmidecode nor smbios found!')
         return False
     else:
         return True

--- a/salt/modules/smbios.py
+++ b/salt/modules/smbios.py
@@ -38,7 +38,7 @@ def __virtual__():
     Only work when dmidecode is installed.
     '''
     if DMIDECODER is None:
-        log.warn('SMBIOS: dmidecode nor smbios found!')
+        log.debug('SMBIOS: dmidecode nor smbios found!')
         return False
     else:
         return True


### PR DESCRIPTION
This is noisy and most people won't care about this log message unless
something is going wrong (in which case they can run in debug mode to
troubleshoot). Lowered loglevel to debug.
