### PR TITLE
Make test.fib much more naive

### DIFF
--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -269,6 +269,7 @@ def fib(num):
         return num, time.time() - start
     return _fib(num-1) + _fib(num-2), time.time() - start
 
+
 def _fib(num):
     '''
     Helper method for test.fib, doesn't calculate the time.

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -267,10 +267,15 @@ def fib(num):
     start = time.time()
     if num < 2:
         return num, time.time() - start
-    num1, _ = fib(num-1)
-    num2, _ = fib(num-2)
-    totaltime = time.time() - start
-    return num1 + num2, totaltime
+    return _fib(num-1) + _fib(num-2), time.time() - start
+
+def _fib(num):
+    '''
+    Helper method for test.fib, doesn't calculate the time.
+    '''
+    if num < 2:
+        return num
+    return _fib(num-1), _fib(num-2)
 
 
 def collatz(start):

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -264,6 +264,7 @@ def fib(num):
 
         salt '*' test.fib 3
     '''
+    num = int(num)
     start = time.time()
     if num < 2:
         return num, time.time() - start

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -253,8 +253,10 @@ def arg_repr(*args, **kwargs):
 
 def fib(num):
     '''
-    Return a Fibonacci sequence up to but not including the passed number,
-    and the time it took to compute in seconds. Used for performance tests.
+    Return the num-th Fibonacci number, and the time it took to compute in
+    seconds. Used for performance tests.
+
+    This function is designed to have terrible performance.
 
     CLI Example:
 
@@ -262,14 +264,13 @@ def fib(num):
 
         salt '*' test.fib 3
     '''
-    num = int(num)
     start = time.time()
-    fib_a, fib_b = 0, 1
-    ret = [0]
-    while fib_b < num:
-        ret.append(fib_b)
-        fib_a, fib_b = fib_b, fib_a + fib_b
-    return ret, time.time() - start
+    if num < 2:
+        return num, time.time() - start
+    num1, _ = fib(num-1)
+    num2, _ = fib(num-2)
+    totaltime = time.time() - start
+    return num1 + num2, totaltime
 
 
 def collatz(start):

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -275,7 +275,7 @@ def _fib(num):
     '''
     if num < 2:
         return num
-    return _fib(num-1), _fib(num-2)
+    return _fib(num-1) + _fib(num-2)
 
 
 def collatz(start):

--- a/tests/integration/client/syndic.py
+++ b/tests/integration/client/syndic.py
@@ -28,9 +28,9 @@ class TestSyndic(integration.SyndicCase):
         self.assertEqual(
                 self.run_function(
                     'test.fib',
-                    ['40'],
-                    )[0][-1],
-                34
+                    ['20'],
+                    )[0],
+                6765
                 )
 
 

--- a/tests/integration/modules/publish.py
+++ b/tests/integration/modules/publish.py
@@ -88,10 +88,10 @@ class PublishModuleTest(integration.ModuleCase,
         '''
         ret = self.run_function(
             'publish.full_data',
-            ['minion', 'test.fib', 40]
+            ['minion', 'test.fib', 20]
         )
         self.assertTrue(ret)
-        self.assertEqual(ret['minion']['ret'][0][-1], 34)
+        self.assertEqual(ret['minion']['ret'][0], 6765)
 
     def test_kwarg(self):
         '''

--- a/tests/integration/modules/test.py
+++ b/tests/integration/modules/test.py
@@ -73,9 +73,9 @@ class TestModuleTest(integration.ModuleCase,
         self.assertEqual(
                 self.run_function(
                     'test.fib',
-                    ['40'],
-                    )[0][-1],
-                34
+                    ['20'],
+                    )[0],
+                6765
                 )
 
     def test_collatz(self):

--- a/tests/integration/shell/call.py
+++ b/tests/integration/shell/call.py
@@ -35,7 +35,7 @@ class CallTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
 
         expect = ['local:',
                   '    - 2',
-                  '    - 3.09944152832e-06',]
+                  '    - 3.09944152832e-06']
         self.assertEqual(expect, out[:-1])
 
     def test_text_output(self):

--- a/tests/integration/shell/call.py
+++ b/tests/integration/shell/call.py
@@ -34,18 +34,15 @@ class CallTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
         out = self.run_call('-l quiet test.fib 3')
 
         expect = ['local:',
-                  '    |_',
-                  '      - 0',
-                  '      - 1',
-                  '      - 1',
-                  '      - 2']
+                  '    - 2',
+                  '    - 3.09944152832e-06',]
         self.assertEqual(expect, out[:-1])
 
     def test_text_output(self):
         out = self.run_call('-l quiet --out txt test.fib 3')
 
         expect = [
-            'local: ([0, 1, 1, 2]'
+            'local: (2,'
         ]
 
         self.assertEqual(''.join(expect), ''.join(out).rsplit(",", 1)[0])

--- a/tests/integration/shell/call.py
+++ b/tests/integration/shell/call.py
@@ -34,15 +34,14 @@ class CallTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
         out = self.run_call('-l quiet test.fib 3')
 
         expect = ['local:',
-                  '    - 2',
-                  '    - 3.09944152832e-06']
+                  '    - 2']
         self.assertEqual(expect, out[:-1])
 
     def test_text_output(self):
         out = self.run_call('-l quiet --out txt test.fib 3')
 
         expect = [
-            'local: (2,'
+            'local: (2'
         ]
 
         self.assertEqual(''.join(expect), ''.join(out).rsplit(",", 1)[0])


### PR DESCRIPTION
If we want to actually be able to use this to compare performance, we
need a much more naive implementation.

```
root@li1073-144:~/salt# salt '*' test.fib 35
basepi_minion2:
    - 9227465
    - 3.4365170002
basepi_minion_master:
    - 9227465
    - 3.56477189064
basepi_minion1:
    - 9227465
    - 3.7709748745
basepi_minion3:
    - 9227465
    - 4.7913069725
```

Much better. :+1: 
