### PR TITLE
Add `fetch_tags` option to state git.latest. See #10141

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -48,6 +48,7 @@ def latest(name,
            bare=False,
            remote_name='origin',
            always_fetch=False,
+           fetch_tags=True,
            depth=None,
            identity=None,
            https_user=None,
@@ -229,6 +230,9 @@ def latest(name,
                     fetch_opts = remote_name
                 else:
                     fetch_opts = ''
+
+                if fetch_tags:
+                    fetch_opts += ' --tags'
 
                 # check remote if fetch_url not == name set it
                 remote = __salt__['git.remote_get'](target,


### PR DESCRIPTION
A starting point for #10141 

Other options include adding a config option after the clone:

`git config --add remote.origin.fetch +refs/tags/*:refs/tags/*`

This can be done with `salt.states.git.config`, but without the `--add`, which is necessary in some situations. Perhaps a better fix would be to add that feature?
