### PR TITLE
Pylint cleanup

### DIFF
--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -360,7 +360,7 @@ def get_batch_size(batch, num_minions):
                'of %10, 10% or 3').format(batch))
 
 
-class BaseSaltAPIHandler(tornado.web.RequestHandler, SaltClientsMixIn):
+class BaseSaltAPIHandler(tornado.web.RequestHandler, SaltClientsMixIn):  # pylint: disable=W0223
     ct_out_map = (
         ('application/json', json.dumps),
         ('application/x-yaml', yaml.safe_dump),
@@ -507,7 +507,7 @@ class BaseSaltAPIHandler(tornado.web.RequestHandler, SaltClientsMixIn):
         return lowstate
 
 
-class SaltAuthHandler(BaseSaltAPIHandler):
+class SaltAuthHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
     '''
     Handler for login requests
     '''
@@ -662,7 +662,7 @@ class SaltAuthHandler(BaseSaltAPIHandler):
         self.write(self.serialize(ret))
 
 
-class SaltAPIHandler(BaseSaltAPIHandler, SaltClientsMixIn):
+class SaltAPIHandler(BaseSaltAPIHandler, SaltClientsMixIn):  # pylint: disable=W0223
     '''
     Main API handler for base "/"
     '''
@@ -1013,7 +1013,7 @@ class SaltAPIHandler(BaseSaltAPIHandler, SaltClientsMixIn):
             raise tornado.gen.Return('Timeout waiting for runner to execute')
 
 
-class MinionSaltAPIHandler(SaltAPIHandler):
+class MinionSaltAPIHandler(SaltAPIHandler):  # pylint: disable=W0223
     '''
     A convenience endpoint for minion related functions
     '''
@@ -1142,7 +1142,7 @@ class MinionSaltAPIHandler(SaltAPIHandler):
         self.disbatch()
 
 
-class JobsSaltAPIHandler(SaltAPIHandler):
+class JobsSaltAPIHandler(SaltAPIHandler):  # pylint: disable=W0223
     '''
     A convenience endpoint for job cache data
     '''
@@ -1248,7 +1248,7 @@ class JobsSaltAPIHandler(SaltAPIHandler):
         self.disbatch()
 
 
-class RunSaltAPIHandler(SaltAPIHandler):
+class RunSaltAPIHandler(SaltAPIHandler):  # pylint: disable=W0223
     '''
     Endpoint to run commands without normal session handling
     '''
@@ -1312,7 +1312,7 @@ class RunSaltAPIHandler(SaltAPIHandler):
         self.disbatch()
 
 
-class EventsSaltAPIHandler(SaltAPIHandler):
+class EventsSaltAPIHandler(SaltAPIHandler):  # pylint: disable=W0223
     '''
     Expose the Salt event bus
 
@@ -1440,7 +1440,7 @@ class EventsSaltAPIHandler(SaltAPIHandler):
                 break
 
 
-class WebhookSaltAPIHandler(SaltAPIHandler):
+class WebhookSaltAPIHandler(SaltAPIHandler):  # pylint: disable=W0223
     '''
     A generic web hook entry point that fires an event on Salt's event bus
 

--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -366,16 +366,6 @@ class BaseSaltAPIHandler(tornado.web.RequestHandler, SaltClientsMixIn):  # pylin
         ('application/x-yaml', yaml.safe_dump),
     )
 
-    def min_syndic_wait_done(self):
-        '''
-        Ensure that the request has been open for a minimum of syndic_wait time
-        '''
-        if not self.application.opts['order_masters']:
-            return True
-        elif time.time() > self.start + self.application.opts['syndic_wait']:
-            return True
-        return False
-
     def _verify_client(self, client):
         '''
         Verify that the client is in fact one we have

--- a/tests/unit/netapi/rest_tornado/test_handlers.py
+++ b/tests/unit/netapi/rest_tornado/test_handlers.py
@@ -73,7 +73,7 @@ class SaltnadoTestCase(integration.ModuleCase, AsyncHTTPTestCase):
 
 class TestBaseSaltAPIHandler(SaltnadoTestCase):
     def get_app(self):
-        class StubHandler(saltnado.BaseSaltAPIHandler):
+        class StubHandler(saltnado.BaseSaltAPIHandler):  # pylint: disable=W0223
             def get(self):
                 return self.echo_stuff()
 

--- a/tests/unit/netapi/rest_tornado/test_handlers.py
+++ b/tests/unit/netapi/rest_tornado/test_handlers.py
@@ -38,7 +38,7 @@ from salt.ext.six.moves.urllib.parse import urlencode  # pylint: disable=no-name
 
 
 @skipIf(HAS_TORNADO is False, 'The tornado package needs to be installed')
-class SaltnadoTestCase(integration.ModuleCase, AsyncHTTPTestCase):
+class SaltnadoTestCase(integration.ModuleCase, AsyncHTTPTestCase):  # pylint: disable=W0223
     '''
     Mixin to hold some shared things
     '''


### PR DESCRIPTION
Something changed in the pylint tests and now its been complaining. That method in the abstract class it not implemented intentionally (we don't handle streaming requests), so this includes an override. In addition, there was some code that is no longer in use-- so I removed it.
