### PR TITLE
Fix for high cpu usage by salt-ssh

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -431,7 +431,6 @@ class SSH(object):
             if len(running) >= self.opts.get('ssh_max_procs', 25) or len(self.targets) >= len(running):
                 time.sleep(0.1)
 
-
     def run_iter(self, mine=False):
         '''
         Execute and yield returns as they come in, do not print to the display

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -427,6 +427,10 @@ class SSH(object):
                     running.pop(host)
             if len(rets) >= len(self.targets):
                 break
+            # Sleep when limit or all threads started
+            if len(running) >= self.opts.get('ssh_max_procs', 25) or len(self.targets) >= len(running):
+                time.sleep(0.1)
+
 
     def run_iter(self, mine=False):
         '''


### PR DESCRIPTION
When i use salt-ssh i always have 100% usage on one cpu core.
This patch add sleep when all threads are run or limit is reached, it is very simple solution to fix this problem and work for me :)
