### PR TITLE
Increase frequency of ssh terminal output checking

### DIFF
--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -351,7 +351,7 @@ class Shell(object):
                 elif stdout and stdout.endswith('_||ext_mods||_'):
                     mods_raw = json.dumps(self.mods, separators=(',', ':')) + '|_E|0|'
                     term.sendline(mods_raw)
-                time.sleep(0.5)
+                time.sleep(0.01)
             return ret_stdout, ret_stderr, term.exitstatus
         finally:
             term.close(terminate=True, kill=True)


### PR DESCRIPTION
Now salt-ssh wait 0.5 between every terminal reading, it is problem when i try to apply bigger number of states.

For example i have system with 440 states, when i try to apply them with standard sleep this takes ~132s, with patch it takes ~17s.

sleep 0.5:
## Summary

Succeeded: 440 (unchanged=3)
## Failed:      0

Total states run:     440

real    2m12.738s
user    2m0.710s
sys 0m13.273s

sleep 0.01:
## Summary

Succeeded: 440 (unchanged=3)
## Failed:      0

Total states run:     440

real    0m17.649s
user    0m16.851s
sys 0m2.104s
