### PR TITLE
extend rest_tornado to accept additional urls

### DIFF
--- a/tests/unit/netapi/rest_tornado/__init__.py
+++ b/tests/unit/netapi/rest_tornado/__init__.py
@@ -1,1 +1,44 @@
 # encoding: utf-8
+import logging
+import salt.client.netapi
+from .test_handlers import SaltnadoTestCase
+
+import salttesting.mock as mock
+
+logger = logging.getLogger(__name__)
+
+class StubHandler(object):
+    pass
+
+
+class TestNetapiStartup(SaltnadoTestCase):
+
+    def get_app(self):
+        return self.build_tornado_app([])
+
+    @mock.patch("tornado.web.Application")
+    @mock.patch("tornado.httpserver.HTTPServer")
+    @mock.patch("tornado.ioloop.IOLoop.instance")
+    def test_url_extensions_start(self, mock_ioloop, mock_http_server, mock_application):
+        '''
+        Test that url extensions are properly imported and included in paths
+        '''
+        opts = self.opts
+        opts['rest_tornado'] = {
+                "port": "55555",
+                "disable_ssl": True,
+                "extension_urls": {
+                    "/foo": {
+                        "module": "unit.netapi.rest_tornado",
+                        "class": "StubHandler"
+                    }
+                }
+            }
+        client = salt.client.netapi.NetapiClient(opts)
+        client.netapi['rest_tornado.start']()
+        app_args, app_kwargs = mock_application.call_args
+        paths = app_args[0]
+        added_url = paths[-1]
+        self.assertEqual(added_url[0], "/foo")
+        self.assertTrue(mock_http_server.called)
+        self.assertTrue(mock_ioloop.called)

--- a/tests/unit/netapi/rest_tornado/__init__.py
+++ b/tests/unit/netapi/rest_tornado/__init__.py
@@ -7,14 +7,14 @@ import salttesting.mock as mock
 
 logger = logging.getLogger(__name__)
 
+
 class StubHandler(object):
-    pass
+    """
+    Stub Handler to test the import module below
+    """
 
 
-class TestNetapiStartup(SaltnadoTestCase):
-
-    def get_app(self):
-        return self.build_tornado_app([])
+class TestNetapiStartup(object):
 
     @mock.patch("tornado.web.Application")
     @mock.patch("tornado.httpserver.HTTPServer")
@@ -40,5 +40,6 @@ class TestNetapiStartup(SaltnadoTestCase):
         paths = app_args[0]
         added_url = paths[-1]
         self.assertEqual(added_url[0], "/foo")
+        self.assertEqual(added_url[1], StubHandler)
         self.assertTrue(mock_http_server.called)
         self.assertTrue(mock_ioloop.called)

--- a/tests/unit/netapi/rest_tornado/test_handlers.py
+++ b/tests/unit/netapi/rest_tornado/test_handlers.py
@@ -7,6 +7,7 @@ import yaml
 import os
 
 # Import Salt Testing Libs
+from salttesting.mock import MagicMock, patch
 from salttesting.unit import skipIf
 from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../..')
@@ -19,6 +20,7 @@ try:
 except ImportError:
     HAS_TORNADO = False
 import salt.auth
+import salt.client.netapi
 
 
 # Import 3rd-party libs
@@ -63,10 +65,6 @@ class SaltnadoTestCase(integration.ModuleCase, AsyncHTTPTestCase):
         return self.get_config('master', from_scratch=True)
 
     @property
-    def mod_opts(self):
-        return self.get_config('minion', from_scratch=True)
-
-    @property
     def auth(self):
         if not hasattr(self, '__auth'):
             self.__auth = salt.auth.LoadAuth(self.opts)
@@ -94,7 +92,7 @@ class SaltnadoTestCase(integration.ModuleCase, AsyncHTTPTestCase):
 
         application.auth = self.auth
         application.opts = self.opts
-        application.mod_opts = self.mod_opts
+        application.mod_opts = {}
 
         return application
 

--- a/tests/unit/netapi/rest_tornado/test_handlers.py
+++ b/tests/unit/netapi/rest_tornado/test_handlers.py
@@ -7,7 +7,6 @@ import yaml
 import os
 
 # Import Salt Testing Libs
-from salttesting.mock import MagicMock, patch
 from salttesting.unit import skipIf
 from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../..')
@@ -20,7 +19,6 @@ try:
 except ImportError:
     HAS_TORNADO = False
 import salt.auth
-import salt.client.netapi
 
 
 # Import 3rd-party libs


### PR DESCRIPTION
Do we want this upstream?

If so, where should I put documentation about the feature?

The TLDR is that this lets you specify a new url path and a module and class that will handle requests to it, so that people can add custom endpoints for the salt-api.
