### PR TITLE
fix infinite loop introduced by #20124 when init (/proc/1/cmdline) is not in the supported_inits list

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1063,14 +1063,16 @@ def os_data():
                     with open(init_bin, 'rb') as fp_:
                         buf = True
                         edge = ''
+                        buf = fp_.read(buf_size).lower()
                         while buf:
-                            buf = edge + fp_.read(buf_size).lower()
+                            buf = edge + buf
                             for item in supported_inits:
                                 if item in buf:
                                     grains['init'] = item
                                     buf = ''
                                     break
                             edge = buf[-edge_len:]
+                            buf = fp_.read(buf_size).lower()
                 except (IOError, OSError) as exc:
                     log.error(
                         'Unable to read from init_bin ({0}): {1}'


### PR DESCRIPTION
How to verify: install interactively salt using salt-bootstrap on a docker container (i.e. _saltstack/centos6-minimal_).
In this case init is set to bash:

```
#cat /proc/1/cmdline
/bin/bash
```
