### PR TITLE
gracefully handle when salt-minion cannot decrypt key

### DIFF
--- a/salt/transport/__init__.py
+++ b/salt/transport/__init__.py
@@ -242,9 +242,13 @@ class ZeroMQChannel(Channel):
     def crypted_transfer_decode_dictentry(self, load, dictkey=None, tries=3, timeout=60):
         ret = self.sreq.send('aes', self.auth.crypticle.dumps(load), tries, timeout)
         key = self.auth.get_keys()
-        aes = key.private_decrypt(ret['key'], 4)
-        pcrypt = salt.crypt.Crypticle(self.opts, aes)
-        return pcrypt.loads(ret[dictkey])
+        try:
+            aes = key.private_decrypt(ret['key'], 4)
+        except (TypeError, KeyError):
+            return None
+        else:
+            pcrypt = salt.crypt.Crypticle(self.opts, aes)
+            return pcrypt.loads(ret[dictkey])
 
     def _crypted_transfer(self, load, tries=3, timeout=60):
         '''


### PR DESCRIPTION
or salt-minion will die. Returns None to deligate
this job to compile_pillar function handle it,
as it is the only caller of this function for now.
