### PR TITLE
Boto RDS bug fixes and adds support for subnet_group

### DIFF
--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -382,7 +382,7 @@ def create_subnet_group(name, db_subnet_group_description, subnet_ids,
     try:
         rds = conn.create_db_subnet_group(name, db_subnet_group_description,
                                           subnet_ids, tags)
-        if rds:
+        if not rds:
             msg = 'Failed to create RDS subnet group {0}'.format(name)
             log.error(msg)
             return False

--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -361,9 +361,7 @@ def create_parameter_group(name, db_parameter_group_family, description,
         return False
 
 
-def create_subnet_group(name, db_subnet_group_description, subnet_ids,
-                        tags=None, region=None, key=None, keyid=None,
-                        profile=None):
+def create_subnet_group(name, description, subnet_ids, tags=None, region=None, key=None, keyid=None, profile=None):
     '''
     Create an RDS subnet group
 

--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -378,8 +378,7 @@ def create_subnet_group(name, description, subnet_ids, tags=None, region=None, k
                                                 profile):
         return True
     try:
-        rds = conn.create_db_subnet_group(name, db_subnet_group_description,
-                                          subnet_ids, tags)
+        rds = conn.create_db_subnet_group(name, description, subnet_ids, tags)
         if not rds:
             msg = 'Failed to create RDS subnet group {0}'.format(name)
             log.error(msg)

--- a/salt/states/boto_rds.py
+++ b/salt/states/boto_rds.py
@@ -351,9 +351,8 @@ def subnet_group_present(name, subnet_ids, description, tags=None, region=None,
             ret['result'] = None
             return ret
         created = __salt__['boto_rds.create_subnet_group'](name=name, subnet_ids=subnet_ids,
-                                                           db_subnet_group_description=description,
-                                                           tags=tags, region=region, key=key, keyid=keyid,
-                                                           profile=profile)
+                                                           description=description, tags=tags, region=region,
+                                                           key=key, keyid=keyid, profile=profile)
         if not created:
             ret['result'] = False
             ret['comment'] = 'Failed to create {0} subnet group.'.format(name)

--- a/salt/states/boto_rds.py
+++ b/salt/states/boto_rds.py
@@ -391,7 +391,38 @@ def absent(name, skip_final_snapshot=None, final_db_snapshot_identifier=None,
         ret['result'] = False
         ret['comment'] = 'Failed to delete {0} RDS.'.format(name)
         return ret
-    ret['changes']['old'] = {'rds': name}
-    ret['changes']['new'] = {'rds': None}
+    ret['changes']['old'] = name
+    ret['changes']['new'] = None
     ret['comment'] = 'RDS {0} deleted.'.format(name)
+    return ret
+
+
+def subnet_group_absent(name, tags=None, region=None, key=None, keyid=None, profile=None):
+    ret = {'name': name,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    exists = __salt__['boto_rds.subnet_group_exists'](name=name, tags=tags, region=region, key=key,
+                                                      keyid=keyid, profile=profile)
+    if not exists:
+        ret['result'] = True
+        ret['comment'] = '{0} RDS subnet group does not exist.'.format(name)
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'RDS subnet group {0} is set to be removed.'.format(name)
+        ret['result'] = None
+        return ret
+    deleted = __salt__['boto_rds.delete_subnet_group'](name, skip_final_snapshot,
+                                                       final_db_snapshot_identifier,
+                                                       region, key, keyid, profile)
+    if not deleted:
+        ret['result'] = False
+        ret['comment'] = 'Failed to delete {0} RDS subnet group.'.format(name)
+        return ret
+    ret['changes']['old'] = name
+    ret['changes']['new'] = None
+    ret['comment'] = 'RDS subnet group {0} deleted.'.format(name)
     return ret

--- a/salt/states/boto_rds.py
+++ b/salt/states/boto_rds.py
@@ -415,9 +415,7 @@ def subnet_group_absent(name, tags=None, region=None, key=None, keyid=None, prof
         ret['comment'] = 'RDS subnet group {0} is set to be removed.'.format(name)
         ret['result'] = None
         return ret
-    deleted = __salt__['boto_rds.delete_subnet_group'](name, skip_final_snapshot,
-                                                       final_db_snapshot_identifier,
-                                                       region, key, keyid, profile)
+    deleted = __salt__['boto_rds.delete_subnet_group'](name, region, key, keyid, profile)
     if not deleted:
         ret['result'] = False
         ret['comment'] = 'Failed to delete {0} RDS subnet group.'.format(name)


### PR DESCRIPTION
**Changes:**
- Adds subnet_group_present which is needed for proper deployment using a different VPC than the default one.
- Fixes yaml documentation indentation.
- Fixes create_db_subnet_group in module.
- Renames create_replica to replica_present.
