### PR TITLE
Boto ElastiCache support for subnet_groups

### DIFF
--- a/salt/states/boto_elasticache.py
+++ b/salt/states/boto_elasticache.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
 Manage Elasticache
+==================
 
 .. versionadded:: 2014.7.0
 
@@ -247,13 +248,68 @@ def present(
     return ret
 
 
-def absent(
-        name,
-        wait=True,
-        region=None,
-        key=None,
-        keyid=None,
-        profile=None):
+def subnet_group_present(name, subnet_ids, description, tags=None, region=None,
+                         key=None, keyid=None, profile=None):
+    '''
+    Ensure ElastiCache subnet group exists.
+
+    .. versionadded:: Beryllium
+
+    name
+        The name for the ElastiCache subnet group. This value is stored as a lowercase string.
+
+    subnet_ids
+        A list of VPC subnet IDs for the cache subnet group.
+
+    description
+        Subnet group description.
+
+    tags
+        A list of tags.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+    '''
+    ret = {'name': name,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    exists = __salt__['boto_elasticache.subnet_group_exists'](name=name, tags=tags, region=region, key=key,
+                                                              keyid=keyid, profile=profile)
+    if not exists:
+        if __opts__['test']:
+            ret['comment'] = 'Subnet group {0} is set to be created.'.format(name)
+            ret['result'] = None
+            return ret
+        created = __salt__['boto_elasticache.create_subnet_group'](name=name, subnet_ids=subnet_ids,
+                                                                   description=description, tags=tags,
+                                                                   region=region, key=key, keyid=keyid,
+                                                                   profile=profile)
+        if not created:
+            ret['result'] = False
+            ret['comment'] = 'Failed to create {0} subnet group.'.format(name)
+            return ret
+        ret['changes']['old'] = None
+        ret['changes']['new'] = name
+        ret['comment'] = 'Subnet group {0} created.'.format(name)
+        return ret
+    ret['comment'] = 'Subnet group present.'
+    return ret
+
+
+def absent(name, wait=True, region=None, key=None, keyid=None, profile=None):
     '''
     Ensure the named elasticache cluster is deleted.
 
@@ -279,13 +335,11 @@ def absent(
     '''
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
-    is_present = __salt__['boto_elasticache.exists'](name, region, key, keyid,
-                                                     profile)
+    is_present = __salt__['boto_elasticache.exists'](name, region, key, keyid, profile)
 
     if is_present:
         if __opts__['test']:
-            ret['comment'] = 'Cache cluster {0} is set to be removed.'.format(
-                name)
+            ret['comment'] = 'Cache cluster {0} is set to be removed.'.format(name)
             ret['result'] = None
             return ret
         deleted = __salt__['boto_elasticache.delete'](name, wait, region, key,
@@ -298,17 +352,11 @@ def absent(
             ret['comment'] = 'Failed to delete {0} cache cluster.'.format(name)
     else:
         ret['comment'] = '{0} does not exist in {1}.'.format(name, region)
-
     return ret
 
 
-def creategroup(name, primary_cluster_id, replication_group_description,
-                wait=None,
-                region=None,
-                key=None,
-                keyid=None,
-                profile=None):
-
+def creategroup(name, primary_cluster_id, replication_group_description, wait=None,
+                region=None, key=None, keyid=None, profile=None):
     '''
     Ensure the a replication group is create.
 
@@ -322,7 +370,7 @@ def creategroup(name, primary_cluster_id, replication_group_description,
         Name of the master cache node
 
     replication_group_description
-        Description for the group
+        Description for the group 
 
     region
         Region to connect to.
@@ -338,7 +386,7 @@ def creategroup(name, primary_cluster_id, replication_group_description,
         that contains a dict with region, key and keyid.
     '''
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
-
+    
     is_present = __salt__['boto_elasticache.group_exists'](name, region, key, keyid,
                                                                  profile)
     if not is_present:
@@ -346,19 +394,12 @@ def creategroup(name, primary_cluster_id, replication_group_description,
             ret['comment'] = 'Replication {0} is set to be created.'.format(
                 name)
             ret['result'] = None
-        created = __salt__['boto_elasticache.create_replication_group'](name,
-                                                                        primary_cluster_id,
+        created = __salt__['boto_elasticache.create_replication_group'](name, primary_cluster_id,
                                                                         replication_group_description,
-                                                                        wait,
-                                                                        region,
-                                                                        key,
-                                                                        keyid,
-                                                                        profile
-                                                                        )
-
+                                                                        wait, region, key, keyid, profile)
+        
         if created:
-            config = __salt__['boto_elasticache.describe_replication_group'](name, region, key,
-                                                             keyid, profile)
+            config = __salt__['boto_elasticache.describe_replication_group'](name, region, key, keyid, profile)
             ret['changes']['old'] = None
             ret['changes']['new'] = config
             ret['result'] = True
@@ -368,5 +409,33 @@ def creategroup(name, primary_cluster_id, replication_group_description,
     else:
         ret['comment'] = '{0} replication group exists .'.format(name)
         ret['result'] = True
+    return ret
 
+
+def subnet_group_absent(name, tags=None, region=None, key=None, keyid=None, profile=None):
+    ret = {'name': name,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    exists = __salt__['boto_elasticache.subnet_group_exists'](name=name, tags=tags, region=region, key=key,
+                                                              keyid=keyid, profile=profile)
+    if not exists:
+        ret['result'] = True
+        ret['comment'] = '{0} ElastiCache subnet group does not exist.'.format(name)
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'ElastiCache subnet group {0} is set to be removed.'.format(name)
+        ret['result'] = None
+        return ret
+    deleted = __salt__['boto_elasticache.delete_subnet_group'](name, region, key, keyid, profile)
+    if not deleted:
+        ret['result'] = False
+        ret['comment'] = 'Failed to delete {0} ElastiCache subnet group.'.format(name)
+        return ret
+    ret['changes']['old'] = name
+    ret['changes']['new'] = None
+    ret['comment'] = 'ElastiCache subnet group {0} deleted.'.format(name)
     return ret

--- a/salt/states/boto_elasticache.py
+++ b/salt/states/boto_elasticache.py
@@ -2,7 +2,7 @@
 '''
 Manage Elasticache
 ==================
-
+replication_group_description
 .. versionadded:: 2014.7.0
 
 Create, destroy and update Elasticache clusters. Be aware that this interacts
@@ -370,7 +370,7 @@ def creategroup(name, primary_cluster_id, replication_group_description, wait=No
         Name of the master cache node
 
     replication_group_description
-        Description for the group 
+        Description for the group
 
     region
         Region to connect to.
@@ -386,7 +386,6 @@ def creategroup(name, primary_cluster_id, replication_group_description, wait=No
         that contains a dict with region, key and keyid.
     '''
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
-    
     is_present = __salt__['boto_elasticache.group_exists'](name, region, key, keyid,
                                                                  profile)
     if not is_present:
@@ -397,7 +396,6 @@ def creategroup(name, primary_cluster_id, replication_group_description, wait=No
         created = __salt__['boto_elasticache.create_replication_group'](name, primary_cluster_id,
                                                                         replication_group_description,
                                                                         wait, region, key, keyid, profile)
-        
         if created:
             config = __salt__['boto_elasticache.describe_replication_group'](name, region, key, keyid, profile)
             ret['changes']['old'] = None


### PR DESCRIPTION
**Changes:**
- Adds module functions: `subnet_group_exists, create_subnet_group, delete_subnet_group`.
- Adds state functions: `subnet_group_present, subnet_group_absent`.
- Minor syntax changes.
