### PR TITLE
Remove Mockwinapi mocking class from win_dns_client_test

### DIFF
--- a/tests/unit/modules/win_dns_client_test.py
+++ b/tests/unit/modules/win_dns_client_test.py
@@ -64,29 +64,6 @@ class Mockwmi(object):
         self.ipenabled = IPEnabled
         return [Mockwmi()]
 
-
-class Mockwinapi(object):
-    '''
-    Mock winapi class
-    '''
-    def __init__(self):
-        pass
-
-    class winapi(object):
-        '''
-        Mock winapi class
-        '''
-        def __init__(self):
-            pass
-
-        @staticmethod
-        def Com():
-            '''
-            Mock Com method
-            '''
-            pass
-
-win_dns_client.salt.utils = Mockwinapi
 win_dns_client.wmi = Mockwmi
 
 


### PR DESCRIPTION
The tests run on the same process, the Mockwinapi class is squashing
salt.utils and causing problems in the test suite.

Refs #22582
