### PR TITLE
[DO NOT MERGE] RFC -- Runner return code of 1 if not ret true

### DIFF
--- a/salt/runner.py
+++ b/salt/runner.py
@@ -170,4 +170,7 @@ class Runner(RunnerClient):
                     salt.output.display_output(ret, 'nested', self.opts)
                 return ret
             log.debug('Runner return: {0}'.format(ret))
-            return ret
+            if not ret:
+                raise salt.exceptions.SaltClientError
+            else:
+                return ret


### PR DESCRIPTION
This is a Request for Comment. It is not meant to represent a final fix, but rather a point to begin discussion.

This PR refs #21764

The problem at hand is how to get salt-run to return exit codes representing runner "failures".

There has been a long-running discussion around exit codes and I won't rehash that here. This PR takes a very naieve approach and simply returns 1 on the CLI if ret doesn't evaluate to python truthiness. Clearly, that only solves a subset of issues as their might be other reasons for a runner to return an error that should be represented by a 1 error code and those aren't handled here.

One thing we could do would be to have runners that wish to raise an error simply raise the a SaltClientException and we could handle those as we do here. Alternatively, we could discuss a way to emebed return codes in the actual returns from the runner functions, though I think this approach may be difficult.

Or, we could simply stick with this naieve approach, perhaps config-gated?

Thoughts?

cc: @basepi, @kiorky, @jacksontj, @thatch45, @s0undt3ch 
