### PR TITLE
Fixes to mount.mounted state module

### DIFF
--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -217,6 +217,9 @@ def mounted(name,
                     'auto',
                     'users',
                     'bind',
+                    'nonempty',
+                    'transform_symlinks',
+                    'port',
                 ]
                 # options which are provided as key=value (e.g. password=Zohp5ohb)
                 mount_invisible_keys = [
@@ -224,6 +227,7 @@ def mounted(name,
                     'comment',
                     'password',
                     'retry',
+                    'port',
                 ]
                 # Some filesystems have options which should not force a remount.
                 mount_ignore_fs_keys = {


### PR DESCRIPTION
Adding sshfs mount options to the invisible list.  These options force a reboot since they won't be listed in the currently mounted device listing. #22586 
