### PR TITLE
add initial support for WinRM in Windows cloud deployment

### DIFF
--- a/doc/topics/cloud/windows.rst
+++ b/doc/topics/cloud/windows.rst
@@ -32,6 +32,14 @@ channels:
 
 .. __: http://software.opensuse.org/package/winexe
 
+Optionally WinRM can be used instead of `winexe` if the python module `pywinrm`
+is available and WinRM is supported on the target Windows version. Information
+on pywinrm can be found at the project home:
+
+* `pywinrm project home`__
+
+.. __: https://github.com/diyan/pywinrm
+
 Additionally, a copy of the Salt Minion Windows installer must be present on
 the system on which Salt Cloud is running. This installer may be downloaded
 from saltstack.com:
@@ -68,6 +76,7 @@ profile configuration as `userdata_file`. For instance:
     userdata_file: /etc/salt/windows-firewall.ps1
 
 
+
 Configuration
 =============
 Configuration is set as usual, with some extra configuration settings. The
@@ -92,6 +101,8 @@ Setting the installer in ``/etc/salt/cloud.providers``:
 
 The default Windows user is `Administrator`, and the default Windows password
 is blank.
+
+If WinRM is to be used ``use_winrm`` needs to be set to `True`.
 
 
 Auto-Generated Passwords on EC2

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -752,6 +752,7 @@ def wait_for_winexesvc(host, port, username, password, timeout=900):
                 )
             )
 
+
 def wait_for_winrm(host, port, username, password, timeout=900):
     '''
     Wait until WinRM connection can be established.
@@ -786,6 +787,7 @@ def wait_for_winrm(host, port, username, password, timeout=900):
                     host, port, trycount
                 )
             )
+
 
 def validate_windows_cred(host, username='Administrator', password=None, retries=10,
                           retry_delay=1):
@@ -1855,6 +1857,7 @@ def win_cmd(command, **kwargs):
     # Signal an error
     return 1
 
+
 def winrm_cmd(session, command, flags, **kwargs):
     '''
     Wrapper for commands to be run against Windows boxes using WinRM.
@@ -1864,6 +1867,7 @@ def winrm_cmd(session, command, flags, **kwargs):
     ))
     r = session.run_cmd(command, flags)
     return r.status_code
+
 
 def root_cmd(command, tty, sudo, allow_failure=False, **kwargs):
     '''

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -42,6 +42,14 @@ try:
 except ImportError:
     HAS_SMB = False
 
+try:
+    import winrm
+    from winrm.exceptions import WinRMTransportError
+
+    HAS_WINRM = True
+except ImportError:
+    HAS_WINRM = False
+
 # Import salt libs
 import salt.crypt
 import salt.client
@@ -435,6 +443,9 @@ def bootstrap(vm_, opts):
         )
         if win_pass:
             deploy_kwargs['password'] = win_pass
+        deploy_kwargs['use_winrm'] = salt.config.get_cloud_config_value(
+            'use_winrm', vm_, opts, default=False
+        )
 
     # Store what was used to the deploy the VM
     event_kwargs = copy.deepcopy(deploy_kwargs)
@@ -741,6 +752,40 @@ def wait_for_winexesvc(host, port, username, password, timeout=900):
                 )
             )
 
+def wait_for_winrm(host, port, username, password, timeout=900):
+    '''
+    Wait until WinRM connection can be established.
+    '''
+    start = time.time()
+    log.debug(
+        'Attempting WinRM connection to host {0} on port {1}'.format(
+            host, port
+        )
+    )
+    trycount = 0
+    while True:
+        trycount += 1
+        try:
+            s = winrm.Session(host, auth=(username, password), transport='ssl')
+            s.protocol.set_timeout(15)
+            log.trace('WinRM endpoint url: {0}'.format(s.url))
+            r = s.run_cmd('sc query winrm')
+            if r.status_code == 0:
+                log.debug('WinRM session connected...')
+                return s
+            log.debug('Return code was {0}'.format(r.status_code))
+            time.sleep(1)
+        except WinRMTransportError as exc:
+            log.debug('Caught exception in wait_for_winrm: {0}'.format(exc))
+            if time.time() - start > timeout:
+                log.error('WinRM connection timed out: {0}'.format(timeout))
+                return None
+            log.debug(
+                'Retrying WinRM connection to host {0} on port {1} '
+                '(try {2})'.format(
+                    host, port, trycount
+                )
+            )
 
 def validate_windows_cred(host, username='Administrator', password=None, retries=10,
                           retry_delay=1):
@@ -847,6 +892,7 @@ def deploy_windows(host,
                    tmp_dir='C:\\salttmp',
                    opts=None,
                    master_sign_pub_file=None,
+                   use_winrm=False,
                    **kwargs):
     '''
     Copy the install files to a remote Windows box, and execute them
@@ -854,12 +900,34 @@ def deploy_windows(host,
     if not isinstance(opts, dict):
         opts = {}
 
+    if use_winrm and not HAS_WINRM:
+        log.error('WinRM requested but module winrm could not be imported')
+        return False
+
     starttime = time.mktime(time.localtime())
     log.debug('Deploying {0} at {1} (Windows)'.format(host, starttime))
-    if wait_for_port(host=host, port=port, timeout=port_timeout * 60) and \
-            wait_for_winexesvc(host=host, port=port,
-                               username=username, password=password,
-                               timeout=port_timeout * 60):
+    log.trace('HAS_WINRM: {0}, use_winrm: {1}'.format(HAS_WINRM, use_winrm))
+
+    port_available = wait_for_port(host=host, port=port, timeout=port_timeout * 60)
+
+    if not port_available:
+        return False
+
+    service_available = False
+    winrm_session = None
+
+    if HAS_WINRM and use_winrm:
+        winrm_session = wait_for_winrm(host=host, port=5986,
+                                           username=username, password=password,
+                                           timeout=port_timeout * 60)
+        if winrm_session is not None:
+            service_available = True
+    else:
+        service_available = wait_for_winexesvc(host=host, port=port,
+                                               username=username, password=password,
+                                               timeout=port_timeout * 60)
+
+    if port_available and service_available:
         log.debug('SMB port {0} on {1} is available'.format(port, host))
         log.debug(
             'Logging into {0}:{1} as {2}'.format(
@@ -903,12 +971,18 @@ def deploy_windows(host,
         installer = comps[-1]
         with salt.utils.fopen(win_installer, 'rb') as inst_fh:
             smb_conn.putFile('C$', 'salttemp/{0}'.format(installer), inst_fh.read)
-        # Shell out to winexe to execute win_installer
-        #  We don't actually need to set the master and the minion here since
-        #  the minion config file will be set next via impacket
-        win_cmd('winexe {0} "c:\\salttemp\\{1} /S /master={2} /minion-name={3}"'.format(
-            creds, installer, master, name
-        ))
+
+        if use_winrm:
+            winrm_cmd(winrm_session, 'c:\\salttemp\\{0}'.format(installer), ['/S', '/master={0}'.format(master),
+                                                                             '/minion-name={0}'.format(name)]
+            )
+        else:
+            # Shell out to winexe to execute win_installer
+            #  We don't actually need to set the master and the minion here since
+            #  the minion config file will be set next via impacket
+            win_cmd('winexe {0} "c:\\salttemp\\{1} /S /master={2} /minion-name={3}"'.format(
+                creds, installer, master, name
+            ))
 
         # Copy over minion_conf
         if minion_conf:
@@ -947,13 +1021,18 @@ def deploy_windows(host,
             smb_conn.deleteFile('C$', 'salttemp/{0}'.format(installer))
             smb_conn.deleteDirectory('C$', 'salttemp')
         # Shell out to winexe to ensure salt-minion service started
-        win_cmd('winexe {0} "sc stop salt-minion"'.format(
-            creds,
-        ))
-        time.sleep(5)
-        win_cmd('winexe {0} "sc start salt-minion"'.format(
-            creds,
-        ))
+        if use_winrm:
+            winrm_cmd(winrm_session, 'sc', ['stop', 'salt-minion'])
+            time.sleep(5)
+            winrm_cmd(winrm_session, 'sc', ['start', 'salt-minion'])
+        else:
+            win_cmd('winexe {0} "sc stop salt-minion"'.format(
+                creds,
+            ))
+            time.sleep(5)
+            win_cmd('winexe {0} "sc start salt-minion"'.format(
+                creds,
+            ))
 
         # Fire deploy action
         fire_event(
@@ -1776,6 +1855,15 @@ def win_cmd(command, **kwargs):
     # Signal an error
     return 1
 
+def winrm_cmd(session, command, flags, **kwargs):
+    '''
+    Wrapper for commands to be run against Windows boxes using WinRM.
+    '''
+    log.debug('Executing WinRM command: {0} {1}'.format(
+        command, flags
+    ))
+    r = session.run_cmd(command, flags)
+    return r.status_code
 
 def root_cmd(command, tty, sudo, allow_failure=False, **kwargs):
     '''


### PR DESCRIPTION
This adds simple support for WinRM using pywinrm. Unless the key use_winrm is set to True in a cloud profile the old behaviour using winexe is still used. WinRM is only used for executing the SaltStack installer, SMB support is still needed to transfer it.

This has only been tested with the openstack provider and Windows Server 2012 R2.

fixes saltstack/salt#15984 and is based on code by @trevor-h referenced in that issue.
