### PR TITLE
Add some support pyzmq 13.0.x

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -24,6 +24,9 @@ from salt.ext.six.moves import range
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
 
 import zmq.eventloop.ioloop
+# support pyzmq 13.0.x, TODO: remove once we force people to 14.0.x
+if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
+    zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
 import tornado.gen  # pylint: disable=F0401
 
 # Import salt libs

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -94,6 +94,9 @@ from salt.exceptions import (
 
 # TODO: cleanup
 import zmq.eventloop.ioloop
+# support pyzmq 13.0.x, TODO: remove once we force people to 14.0.x
+if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
+    zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
 import tornado.gen  # pylint: disable=F0401
 import tornado.ioloop  # pylint: disable=F0401
 

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -32,6 +32,9 @@ from salt.exceptions import SaltReqTimeoutError, SaltClientError
 # for IPC (for now)
 import zmq
 import zmq.eventloop.ioloop
+# support pyzmq 13.0.x, TODO: remove once we force people to 14.0.x
+if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
+    zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
 import zmq.eventloop.zmqstream
 
 # tornado imports

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -26,6 +26,9 @@ from salt.exceptions import SaltReqTimeoutError
 
 import zmq
 import zmq.eventloop.ioloop
+# support pyzmq 13.0.x, TODO: remove once we force people to 14.0.x
+if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
+    zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
 import zmq.eventloop.zmqstream
 
 # tornado imports

--- a/salt/utils/async.py
+++ b/salt/utils/async.py
@@ -8,6 +8,9 @@ from __future__ import absolute_import
 import tornado.ioloop
 import tornado.concurrent
 import zmq.eventloop.ioloop
+# support pyzmq 13.0.x, TODO: remove once we force people to 14.0.x
+if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
+    zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
 
 import contextlib
 

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -67,6 +67,9 @@ import salt.ext.six as six
 try:
     import zmq
     import zmq.eventloop.ioloop
+    # support pyzmq 13.0.x, TODO: remove once we force people to 14.0.x
+    if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
+        zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
     import zmq.eventloop.zmqstream
 except ImportError:
     # Local mode does not need zmq

--- a/tests/unit/transport/zeromq_test.py
+++ b/tests/unit/transport/zeromq_test.py
@@ -9,6 +9,9 @@ import os
 import threading
 
 import zmq.eventloop.ioloop
+# support pyzmq 13.0.x, TODO: remove once we force people to 14.0.x
+if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
+    zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
 from tornado.testing import AsyncTestCase
 
 import tornado.gen

--- a/tests/unit/utils/event_test.py
+++ b/tests/unit/utils/event_test.py
@@ -14,6 +14,10 @@ import hashlib
 import time
 from tornado.testing import AsyncTestCase
 import zmq
+import zmq.eventloop.ioloop
+# support pyzmq 13.0.x, TODO: remove once we force people to 14.0.x
+if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
+    zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
 from contextlib import contextmanager
 from multiprocessing import Process
 


### PR DESCRIPTION
pyzmq 13.0.x was the first version to support _any_ tornado in pyzmq, and since 14.0.x they have changed the API (IMO into a more sensible one). This conditionally changes the name to match the new API's naming.

Related to #22453
