### PR TITLE
adding win_dns_client unit test case

### DIFF
--- a/tests/unit/modules/win_dns_client_test.py
+++ b/tests/unit/modules/win_dns_client_test.py
@@ -64,6 +64,22 @@ class Mockwmi(object):
         self.ipenabled = IPEnabled
         return [Mockwmi()]
 
+
+class Mockwinapi(object):
+    '''
+    Mock winapi class
+    '''
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def Com():
+        '''
+        Mock Com method
+        '''
+        return True
+
+win_dns_client.salt.utils.winapi = Mockwinapi
 win_dns_client.wmi = Mockwmi
 
 


### PR DESCRIPTION
Implemented win_dns_client unit test case.
Removed mocking of salt.utils = Mockwinapi.
Tried to mock salt.utils.winapi = Mockwinapi
