### PR TITLE
improve cmd.run env documentation

### DIFF
--- a/doc/man/salt.7
+++ b/doc/man/salt.7
@@ -138136,8 +138136,8 @@ Example:
 .sp
 .nf
 .ft C
-salt://scripts/foo.sh:
-  cmd.script:
+foo-script:
+  cmd.run:
     \- env:
       \- BATCH: \(aqyes\(aq
 .ft P
@@ -138153,6 +138153,19 @@ The above illustrates a common PyYAML pitfall, that \fByes\fP,
 boolean \fBTrue\fP and \fBFalse\fP values, and must be enclosed in
 quotes to be used as strings. More info on this (and other) PyYAML
 idiosyncrasies can be found \fBhere\fP\&.
+.UNINDENT
+.UNINDENT
+.sp
+Variables as values are not evaluated. So $PATH in the following example is a
+literal '$PATH':
+.INDENT 7.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+bar-script:
+  cmd.run:
+    - env: "PATH=/some/path:$PATH"
 .UNINDENT
 .UNINDENT
 .TP
@@ -138286,6 +138299,19 @@ quotes to be used as strings. More info on this (and other) PyYAML
 idiosyncrasies can be found \fBhere\fP\&.
 .UNINDENT
 .UNINDENT
+.sp
+Variables as values are not evaluated. So $PATH in the following example is a
+literal '$PATH':
+.INDENT 7.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+ salt://scripts/bar.sh:
+  cmd.script:
+    - env: "PATH=/some/path:$PATH"
+.UNINDENT
+.UNINDENT
 .TP
 .B umask
 The umask (in octal) to use when running the command.
@@ -138360,8 +138386,8 @@ Example:
 .sp
 .nf
 .ft C
-salt://scripts/foo.sh:
-  cmd.script:
+script-foo:
+  cmd.wait:
     \- env:
       \- BATCH: \(aqyes\(aq
 .ft P
@@ -138377,6 +138403,19 @@ The above illustrates a common PyYAML pitfall, that \fByes\fP,
 boolean \fBTrue\fP and \fBFalse\fP values, and must be enclosed in
 quotes to be used as strings. More info on this (and other) PyYAML
 idiosyncrasies can be found \fBhere\fP\&.
+.UNINDENT
+.UNINDENT
+.sp
+Variables as values are not evaluated. So $PATH in the following example is a
+literal '$PATH':
+.INDENT 7.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+script-bar:
+  cmd.wait:
+    - env: "PATH=/some/path:$PATH"
 .UNINDENT
 .UNINDENT
 .TP
@@ -138460,7 +138499,7 @@ Example:
 .nf
 .ft C
 salt://scripts/foo.sh:
-  cmd.script:
+  cmd.wait_script:
     \- env:
       \- BATCH: \(aqyes\(aq
 .ft P
@@ -138476,6 +138515,19 @@ The above illustrates a common PyYAML pitfall, that \fByes\fP,
 boolean \fBTrue\fP and \fBFalse\fP values, and must be enclosed in
 quotes to be used as strings. More info on this (and other) PyYAML
 idiosyncrasies can be found \fBhere\fP\&.
+.UNINDENT
+.UNINDENT
+.sp
+Variables as values are not evaluated. So $PATH in the following example is a
+literal '$PATH':
+.INDENT 7.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+ salt://scripts/bar.sh:
+  cmd.wait_script:
+    - env: "PATH=/some/path:$PATH"
 .UNINDENT
 .UNINDENT
 .TP

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -428,8 +428,8 @@ def wait(name,
 
         .. code-block:: yaml
 
-            salt://scripts/foo.sh:
-              cmd.script:
+            script-foo:
+              cmd.wait:
                 - env:
                   - BATCH: 'yes'
 
@@ -441,6 +441,15 @@ def wait(name,
             quotes to be used as strings. More info on this (and other) PyYAML
             idiosyncrasies can be found :doc:`here
             </topics/troubleshooting/yaml_idiosyncrasies>`.
+
+        Variables as values are not evaluated. So $PATH in the following
+        example is a literal '$PATH':
+
+        .. code-block:: yaml
+
+            script-bar:
+              cmd.wait:
+                - env: "PATH=/some/path:$PATH"
 
     umask
          The umask (in octal) to use when running the command.
@@ -537,7 +546,7 @@ def wait_script(name,
         .. code-block:: yaml
 
             salt://scripts/foo.sh:
-              cmd.script:
+              cmd.wait_script:
                 - env:
                   - BATCH: 'yes'
 
@@ -549,6 +558,15 @@ def wait_script(name,
             quotes to be used as strings. More info on this (and other) PyYAML
             idiosyncrasies can be found :doc:`here
             </topics/troubleshooting/yaml_idiosyncrasies>`.
+
+        Variables as values are not evaluated. So $PATH in the following
+        example is a literal '$PATH':
+
+        .. code-block:: yaml
+
+            salt://scripts/bar.sh:
+              cmd.wait_script:
+                - env: "PATH=/some/path:$PATH"
 
     umask
          The umask (in octal) to use when running the command.
@@ -626,8 +644,8 @@ def run(name,
 
         .. code-block:: yaml
 
-            salt://scripts/foo.sh:
-              cmd.script:
+            script-foo:
+              cmd.run:
                 - env:
                   - BATCH: 'yes'
 
@@ -639,6 +657,15 @@ def run(name,
             quotes to be used as strings. More info on this (and other) PyYAML
             idiosyncrasies can be found :doc:`here
             </topics/troubleshooting/yaml_idiosyncrasies>`.
+
+        Variables as values are not evaluated. So $PATH in the following
+        example is a literal '$PATH':
+
+        .. code-block:: yaml
+
+            script-bar:
+              cmd.run:
+                - env: "PATH=/some/path:$PATH"
 
     stateful
         The command being executed is expected to return data about executing
@@ -844,6 +871,15 @@ def script(name,
             quotes to be used as strings. More info on this (and other) PyYAML
             idiosyncrasies can be found :doc:`here
             </topics/troubleshooting/yaml_idiosyncrasies>`.
+
+        Variables as values are not evaluated. So $PATH in the following
+        example is a literal '$PATH':
+
+        .. code-block:: yaml
+
+            salt://scripts/bar.sh:
+              cmd.script:
+                - env: "PATH=/some/path:$PATH"
 
     umask
          The umask (in octal) to use when running the command.


### PR DESCRIPTION
Resolves #21840

Improved documentation to cmd.run(et.al.) env argument by mentioning
that variables as values will not be evaluated.
