### PR TITLE
#22080 part 1: Addition of Python 3 compatible ipaddress module

### DIFF
--- a/salt/ext/ipaddress.py
+++ b/salt/ext/ipaddress.py
@@ -1,0 +1,2222 @@
+# Python 2.7 port of Python 3.4's ipaddress module.
+
+# List of compatibility changes:
+
+# Python 3 uses only new-style classes.
+# s/class \(\w\+\):/class \1(object):/
+
+# Use iterator versions of map and range:
+from itertools import imap as map
+range = xrange
+
+# This backport uses bytearray instead of bytes, as bytes is the same
+# as str in Python 2.7.
+bytes = bytearray
+
+# Python 2 does not support exception chaining.
+# s/ from None$//
+
+# When checking for instances of int, also allow Python 2's long.
+_builtin_isinstance = isinstance
+
+def isinstance(val, types):
+    if types is int:
+        types = (int, long)
+    elif type(types) is tuple and int in types:
+        types += (long,)
+    return _builtin_isinstance(val, types)
+
+# functools.lru_cache is Python 3.2+ only.
+# /@functools.lru_cache()/d
+
+# int().to_bytes is Python 3.2+ only.
+# s/\(\w+\)\.to_bytes(/_int_to_bytes(\1, /
+def _int_to_bytes(self, length, byteorder, signed=False):
+    assert byteorder == 'big' and signed is False
+    if self < 0 or self >= 256**length:
+        raise OverflowError()
+    return bytearray(('%0*x' % (length * 2, self)).decode('hex'))
+
+# int.from_bytes is Python 3.2+ only.
+# s/int\.from_bytes(/_int_from_bytes(/g
+def _int_from_bytes(what, byteorder, signed=False):
+    assert byteorder == 'big' and signed is False
+    return int(str(bytearray(what)).encode('hex'), 16)
+
+# Python 2.6 has no int.bit_length()
+if hasattr(int, 'bit_length'):
+    _int_bit_length = lambda i: i.bit_length()
+else:
+    _int_bit_length = lambda i: len(bin(abs(i))) - 2
+
+# ----------------------------------------------------------------------------
+
+
+# Copyright 2007 Google Inc.
+#  Licensed to PSF under a Contributor Agreement.
+
+"""A fast, lightweight IPv4/IPv6 manipulation library in Python.
+
+This library is used to create/poke/manipulate IPv4 and IPv6 addresses
+and networks.
+
+"""
+
+__version__ = '1.0'
+
+
+import functools
+
+IPV4LENGTH = 32
+IPV6LENGTH = 128
+
+class AddressValueError(ValueError):
+    """A Value Error related to the address."""
+
+
+class NetmaskValueError(ValueError):
+    """A Value Error related to the netmask."""
+
+
+def ip_address(address):
+    """Take an IP string/int and return an object of the correct type.
+
+    Args:
+        address: A string or integer, the IP address.  Either IPv4 or
+          IPv6 addresses may be supplied; integers less than 2**32 will
+          be considered to be IPv4 by default.
+
+    Returns:
+        An IPv4Address or IPv6Address object.
+
+    Raises:
+        ValueError: if the *address* passed isn't either a v4 or a v6
+          address
+
+    """
+    try:
+        return IPv4Address(address)
+    except (AddressValueError, NetmaskValueError):
+        pass
+
+    try:
+        return IPv6Address(address)
+    except (AddressValueError, NetmaskValueError):
+        pass
+
+    raise ValueError('%r does not appear to be an IPv4 or IPv6 address' %
+                     address)
+
+
+def ip_network(address, strict=True):
+    """Take an IP string/int and return an object of the correct type.
+
+    Args:
+        address: A string or integer, the IP network.  Either IPv4 or
+          IPv6 networks may be supplied; integers less than 2**32 will
+          be considered to be IPv4 by default.
+
+    Returns:
+        An IPv4Network or IPv6Network object.
+
+    Raises:
+        ValueError: if the string passed isn't either a v4 or a v6
+          address. Or if the network has host bits set.
+
+    """
+    try:
+        return IPv4Network(address, strict)
+    except (AddressValueError, NetmaskValueError):
+        pass
+
+    try:
+        return IPv6Network(address, strict)
+    except (AddressValueError, NetmaskValueError):
+        pass
+
+    raise ValueError('%r does not appear to be an IPv4 or IPv6 network' %
+                     address)
+
+
+def ip_interface(address):
+    """Take an IP string/int and return an object of the correct type.
+
+    Args:
+        address: A string or integer, the IP address.  Either IPv4 or
+          IPv6 addresses may be supplied; integers less than 2**32 will
+          be considered to be IPv4 by default.
+
+    Returns:
+        An IPv4Interface or IPv6Interface object.
+
+    Raises:
+        ValueError: if the string passed isn't either a v4 or a v6
+          address.
+
+    Notes:
+        The IPv?Interface classes describe an Address on a particular
+        Network, so they're basically a combination of both the Address
+        and Network classes.
+
+    """
+    try:
+        return IPv4Interface(address)
+    except (AddressValueError, NetmaskValueError):
+        pass
+
+    try:
+        return IPv6Interface(address)
+    except (AddressValueError, NetmaskValueError):
+        pass
+
+    raise ValueError('%r does not appear to be an IPv4 or IPv6 interface' %
+                     address)
+
+
+def v4_int_to_packed(address):
+    """Represent an address as 4 packed bytes in network (big-endian) order.
+
+    Args:
+        address: An integer representation of an IPv4 IP address.
+
+    Returns:
+        The integer address packed as 4 bytes in network (big-endian) order.
+
+    Raises:
+        ValueError: If the integer is negative or too large to be an
+          IPv4 IP address.
+
+    """
+    try:
+        return _int_to_bytes(address, 4, 'big')
+    except:
+        raise ValueError("Address negative or too large for IPv4")
+
+
+def v6_int_to_packed(address):
+    """Represent an address as 16 packed bytes in network (big-endian) order.
+
+    Args:
+        address: An integer representation of an IPv6 IP address.
+
+    Returns:
+        The integer address packed as 16 bytes in network (big-endian) order.
+
+    """
+    try:
+        return _int_to_bytes(address, 16, 'big')
+    except:
+        raise ValueError("Address negative or too large for IPv6")
+
+
+def _split_optional_netmask(address):
+    """Helper to split the netmask and raise AddressValueError if needed"""
+    addr = str(address).split('/')
+    if len(addr) > 2:
+        raise AddressValueError("Only one '/' permitted in %r" % address)
+    return addr
+
+
+def _find_address_range(addresses):
+    """Find a sequence of IPv#Address.
+
+    Args:
+        addresses: a list of IPv#Address objects.
+
+    Returns:
+        A tuple containing the first and last IP addresses in the sequence.
+
+    """
+    first = last = addresses[0]
+    for ip in addresses[1:]:
+        if ip._ip == last._ip + 1:
+            last = ip
+        else:
+            break
+    return (first, last)
+
+
+def _count_righthand_zero_bits(number, bits):
+    """Count the number of zero bits on the right hand side.
+
+    Args:
+        number: an integer.
+        bits: maximum number of bits to count.
+
+    Returns:
+        The number of zero bits on the right hand side of the number.
+
+    """
+    if number == 0:
+        return bits
+    for i in range(bits):
+        if (number >> i) & 1:
+            return i
+    # All bits of interest were zero, even if there are more in the number
+    return bits
+
+
+def summarize_address_range(first, last):
+    """Summarize a network range given the first and last IP addresses.
+
+    Example:
+        >>> list(summarize_address_range(IPv4Address('192.0.2.0'),
+        ...                              IPv4Address('192.0.2.130')))
+        ...                                #doctest: +NORMALIZE_WHITESPACE
+        [IPv4Network('192.0.2.0/25'), IPv4Network('192.0.2.128/31'),
+         IPv4Network('192.0.2.130/32')]
+
+    Args:
+        first: the first IPv4Address or IPv6Address in the range.
+        last: the last IPv4Address or IPv6Address in the range.
+
+    Returns:
+        An iterator of the summarized IPv(4|6) network objects.
+
+    Raise:
+        TypeError:
+            If the first and last objects are not IP addresses.
+            If the first and last objects are not the same version.
+        ValueError:
+            If the last object is not greater than the first.
+            If the version of the first address is not 4 or 6.
+
+    """
+    if (not (isinstance(first, _BaseAddress) and
+             isinstance(last, _BaseAddress))):
+        raise TypeError('first and last must be IP addresses, not networks')
+    if first.version != last.version:
+        raise TypeError("%s and %s are not of the same version" % (
+                         first, last))
+    if first > last:
+        raise ValueError('last IP address must be greater than first')
+
+    if first.version == 4:
+        ip = IPv4Network
+    elif first.version == 6:
+        ip = IPv6Network
+    else:
+        raise ValueError('unknown IP version')
+
+    ip_bits = first._max_prefixlen
+    first_int = first._ip
+    last_int = last._ip
+    while first_int <= last_int:
+        nbits = min(_count_righthand_zero_bits(first_int, ip_bits),
+                    _int_bit_length(last_int - first_int + 1) - 1)
+        net = ip('%s/%d' % (first, ip_bits - nbits))
+        yield net
+        first_int += 1 << nbits
+        if first_int - 1 == ip._ALL_ONES:
+            break
+        first = first.__class__(first_int)
+
+
+def _collapse_addresses_recursive(addresses):
+    """Loops through the addresses, collapsing concurrent netblocks.
+
+    Example:
+
+        ip1 = IPv4Network('192.0.2.0/26')
+        ip2 = IPv4Network('192.0.2.64/26')
+        ip3 = IPv4Network('192.0.2.128/26')
+        ip4 = IPv4Network('192.0.2.192/26')
+
+        _collapse_addresses_recursive([ip1, ip2, ip3, ip4]) ->
+          [IPv4Network('192.0.2.0/24')]
+
+        This shouldn't be called directly; it is called via
+          collapse_addresses([]).
+
+    Args:
+        addresses: A list of IPv4Network's or IPv6Network's
+
+    Returns:
+        A list of IPv4Network's or IPv6Network's depending on what we were
+        passed.
+
+    """
+    while True:
+        last_addr = None
+        ret_array = []
+        optimized = False
+
+        for cur_addr in addresses:
+            if not ret_array:
+                last_addr = cur_addr
+                ret_array.append(cur_addr)
+            elif (cur_addr.network_address >= last_addr.network_address and
+                cur_addr.broadcast_address <= last_addr.broadcast_address):
+                optimized = True
+            elif cur_addr == list(last_addr.supernet().subnets())[1]:
+                ret_array[-1] = last_addr = last_addr.supernet()
+                optimized = True
+            else:
+                last_addr = cur_addr
+                ret_array.append(cur_addr)
+
+        addresses = ret_array
+        if not optimized:
+            return addresses
+
+
+def collapse_addresses(addresses):
+    """Collapse a list of IP objects.
+
+    Example:
+        collapse_addresses([IPv4Network('192.0.2.0/25'),
+                            IPv4Network('192.0.2.128/25')]) ->
+                           [IPv4Network('192.0.2.0/24')]
+
+    Args:
+        addresses: An iterator of IPv4Network or IPv6Network objects.
+
+    Returns:
+        An iterator of the collapsed IPv(4|6)Network objects.
+
+    Raises:
+        TypeError: If passed a list of mixed version objects.
+
+    """
+    i = 0
+    addrs = []
+    ips = []
+    nets = []
+
+    # split IP addresses and networks
+    for ip in addresses:
+        if isinstance(ip, _BaseAddress):
+            if ips and ips[-1]._version != ip._version:
+                raise TypeError("%s and %s are not of the same version" % (
+                                 ip, ips[-1]))
+            ips.append(ip)
+        elif ip._prefixlen == ip._max_prefixlen:
+            if ips and ips[-1]._version != ip._version:
+                raise TypeError("%s and %s are not of the same version" % (
+                                 ip, ips[-1]))
+            try:
+                ips.append(ip.ip)
+            except AttributeError:
+                ips.append(ip.network_address)
+        else:
+            if nets and nets[-1]._version != ip._version:
+                raise TypeError("%s and %s are not of the same version" % (
+                                 ip, nets[-1]))
+            nets.append(ip)
+
+    # sort and dedup
+    ips = sorted(set(ips))
+    nets = sorted(set(nets))
+
+    while i < len(ips):
+        (first, last) = _find_address_range(ips[i:])
+        i = ips.index(last) + 1
+        addrs.extend(summarize_address_range(first, last))
+
+    return iter(_collapse_addresses_recursive(sorted(
+        addrs + nets, key=_BaseNetwork._get_networks_key)))
+
+
+def get_mixed_type_key(obj):
+    """Return a key suitable for sorting between networks and addresses.
+
+    Address and Network objects are not sortable by default; they're
+    fundamentally different so the expression
+
+        IPv4Address('192.0.2.0') <= IPv4Network('192.0.2.0/24')
+
+    doesn't make any sense.  There are some times however, where you may wish
+    to have ipaddress sort these for you anyway. If you need to do this, you
+    can use this function as the key= argument to sorted().
+
+    Args:
+      obj: either a Network or Address object.
+    Returns:
+      appropriate key.
+
+    """
+    if isinstance(obj, _BaseNetwork):
+        return obj._get_networks_key()
+    elif isinstance(obj, _BaseAddress):
+        return obj._get_address_key()
+    return NotImplemented
+
+
+class _TotalOrderingMixin(object):
+    # Helper that derives the other comparison operations from
+    # __lt__ and __eq__
+    # We avoid functools.total_ordering because it doesn't handle
+    # NotImplemented correctly yet (http://bugs.python.org/issue10042)
+    def __eq__(self, other):
+        raise NotImplementedError
+    def __ne__(self, other):
+        equal = self.__eq__(other)
+        if equal is NotImplemented:
+            return NotImplemented
+        return not equal
+    def __lt__(self, other):
+        raise NotImplementedError
+    def __le__(self, other):
+        less = self.__lt__(other)
+        if less is NotImplemented or not less:
+            return self.__eq__(other)
+        return less
+    def __gt__(self, other):
+        less = self.__lt__(other)
+        if less is NotImplemented:
+            return NotImplemented
+        equal = self.__eq__(other)
+        if equal is NotImplemented:
+            return NotImplemented
+        return not (less or equal)
+    def __ge__(self, other):
+        less = self.__lt__(other)
+        if less is NotImplemented:
+            return NotImplemented
+        return not less
+
+class _IPAddressBase(_TotalOrderingMixin):
+
+    """The mother class."""
+
+    @property
+    def exploded(self):
+        """Return the longhand version of the IP address as a string."""
+        return self._explode_shorthand_ip_string()
+
+    @property
+    def compressed(self):
+        """Return the shorthand version of the IP address as a string."""
+        return str(self)
+
+    @property
+    def version(self):
+        msg = '%200s has no version specified' % (type(self),)
+        raise NotImplementedError(msg)
+
+    def _check_int_address(self, address):
+        if address < 0:
+            msg = "%d (< 0) is not permitted as an IPv%d address"
+            raise AddressValueError(msg % (address, self._version))
+        if address > self._ALL_ONES:
+            msg = "%d (>= 2**%d) is not permitted as an IPv%d address"
+            raise AddressValueError(msg % (address, self._max_prefixlen,
+                                           self._version))
+
+    def _check_packed_address(self, address, expected_len):
+        address_len = len(address)
+        if address_len != expected_len:
+            msg = "%r (len %d != %d) is not permitted as an IPv%d address"
+            raise AddressValueError(msg % (address, address_len,
+                                           expected_len, self._version))
+
+    def _ip_int_from_prefix(self, prefixlen):
+        """Turn the prefix length into a bitwise netmask
+
+        Args:
+            prefixlen: An integer, the prefix length.
+
+        Returns:
+            An integer.
+
+        """
+        return self._ALL_ONES ^ (self._ALL_ONES >> prefixlen)
+
+    def _prefix_from_ip_int(self, ip_int):
+        """Return prefix length from the bitwise netmask.
+
+        Args:
+            ip_int: An integer, the netmask in axpanded bitwise format
+
+        Returns:
+            An integer, the prefix length.
+
+        Raises:
+            ValueError: If the input intermingles zeroes & ones
+        """
+        trailing_zeroes = _count_righthand_zero_bits(ip_int,
+                                                     self._max_prefixlen)
+        prefixlen = self._max_prefixlen - trailing_zeroes
+        leading_ones = ip_int >> trailing_zeroes
+        all_ones = (1 << prefixlen) - 1
+        if leading_ones != all_ones:
+            byteslen = self._max_prefixlen // 8
+            details = _int_to_bytes(ip_int, byteslen, 'big')
+            msg = 'Netmask pattern %r mixes zeroes & ones'
+            raise ValueError(msg % details)
+        return prefixlen
+
+    def _report_invalid_netmask(self, netmask_str):
+        msg = '%r is not a valid netmask' % netmask_str
+        raise NetmaskValueError(msg)
+
+    def _prefix_from_prefix_string(self, prefixlen_str):
+        """Return prefix length from a numeric string
+
+        Args:
+            prefixlen_str: The string to be converted
+
+        Returns:
+            An integer, the prefix length.
+
+        Raises:
+            NetmaskValueError: If the input is not a valid netmask
+        """
+        # int allows a leading +/- as well as surrounding whitespace,
+        # so we ensure that isn't the case
+        if not _BaseV4._DECIMAL_DIGITS.issuperset(prefixlen_str):
+            self._report_invalid_netmask(prefixlen_str)
+        try:
+            prefixlen = int(prefixlen_str)
+        except ValueError:
+            self._report_invalid_netmask(prefixlen_str)
+        if not (0 <= prefixlen <= self._max_prefixlen):
+            self._report_invalid_netmask(prefixlen_str)
+        return prefixlen
+
+    def _prefix_from_ip_string(self, ip_str):
+        """Turn a netmask/hostmask string into a prefix length
+
+        Args:
+            ip_str: The netmask/hostmask to be converted
+
+        Returns:
+            An integer, the prefix length.
+
+        Raises:
+            NetmaskValueError: If the input is not a valid netmask/hostmask
+        """
+        # Parse the netmask/hostmask like an IP address.
+        try:
+            ip_int = self._ip_int_from_string(ip_str)
+        except AddressValueError:
+            self._report_invalid_netmask(ip_str)
+
+        # Try matching a netmask (this would be /1*0*/ as a bitwise regexp).
+        # Note that the two ambiguous cases (all-ones and all-zeroes) are
+        # treated as netmasks.
+        try:
+            return self._prefix_from_ip_int(ip_int)
+        except ValueError:
+            pass
+
+        # Invert the bits, and try matching a /0+1+/ hostmask instead.
+        ip_int ^= self._ALL_ONES
+        try:
+            return self._prefix_from_ip_int(ip_int)
+        except ValueError:
+            self._report_invalid_netmask(ip_str)
+
+
+class _BaseAddress(_IPAddressBase):
+
+    """A generic IP object.
+
+    This IP class contains the version independent methods which are
+    used by single IP addresses.
+    """
+
+    def __init__(self, address):
+        if (not isinstance(address, bytes)
+            and '/' in str(address)):
+            raise AddressValueError("Unexpected '/' in %r" % address)
+
+    def __int__(self):
+        return self._ip
+
+    def __eq__(self, other):
+        try:
+            return (self._ip == other._ip
+                    and self._version == other._version)
+        except AttributeError:
+            return NotImplemented
+
+    def __lt__(self, other):
+        if self._version != other._version:
+            raise TypeError('%s and %s are not of the same version' % (
+                             self, other))
+        if not isinstance(other, _BaseAddress):
+            raise TypeError('%s and %s are not of the same type' % (
+                             self, other))
+        if self._ip != other._ip:
+            return self._ip < other._ip
+        return False
+
+    # Shorthand for Integer addition and subtraction. This is not
+    # meant to ever support addition/subtraction of addresses.
+    def __add__(self, other):
+        if not isinstance(other, int):
+            return NotImplemented
+        return self.__class__(int(self) + other)
+
+    def __sub__(self, other):
+        if not isinstance(other, int):
+            return NotImplemented
+        return self.__class__(int(self) - other)
+
+    def __repr__(self):
+        return '%s(%r)' % (self.__class__.__name__, str(self))
+
+    def __str__(self):
+        return str(self._string_from_ip_int(self._ip))
+
+    def __hash__(self):
+        return hash(hex(int(self._ip)))
+
+    def _get_address_key(self):
+        return (self._version, self)
+
+
+class _BaseNetwork(_IPAddressBase):
+
+    """A generic IP network object.
+
+    This IP class contains the version independent methods which are
+    used by networks.
+
+    """
+    def __init__(self, address):
+        self._cache = {}
+
+    def __repr__(self):
+        return '%s(%r)' % (self.__class__.__name__, str(self))
+
+    def __str__(self):
+        return '%s/%d' % (self.network_address, self.prefixlen)
+
+    def hosts(self):
+        """Generate Iterator over usable hosts in a network.
+
+        This is like __iter__ except it doesn't return the network
+        or broadcast addresses.
+
+        """
+        network = int(self.network_address)
+        broadcast = int(self.broadcast_address)
+        for x in range(network + 1, broadcast):
+            yield self._address_class(x)
+
+    def __iter__(self):
+        network = int(self.network_address)
+        broadcast = int(self.broadcast_address)
+        for x in range(network, broadcast + 1):
+            yield self._address_class(x)
+
+    def __getitem__(self, n):
+        network = int(self.network_address)
+        broadcast = int(self.broadcast_address)
+        if n >= 0:
+            if network + n > broadcast:
+                raise IndexError
+            return self._address_class(network + n)
+        else:
+            n += 1
+            if broadcast + n < network:
+                raise IndexError
+            return self._address_class(broadcast + n)
+
+    def __lt__(self, other):
+        if self._version != other._version:
+            raise TypeError('%s and %s are not of the same version' % (
+                             self, other))
+        if not isinstance(other, _BaseNetwork):
+            raise TypeError('%s and %s are not of the same type' % (
+                             self, other))
+        if self.network_address != other.network_address:
+            return self.network_address < other.network_address
+        if self.netmask != other.netmask:
+            return self.netmask < other.netmask
+        return False
+
+    def __eq__(self, other):
+        try:
+            return (self._version == other._version and
+                    self.network_address == other.network_address and
+                    int(self.netmask) == int(other.netmask))
+        except AttributeError:
+            return NotImplemented
+
+    def __hash__(self):
+        return hash(int(self.network_address) ^ int(self.netmask))
+
+    def __contains__(self, other):
+        # always false if one is v4 and the other is v6.
+        if self._version != other._version:
+            return False
+        # dealing with another network.
+        if isinstance(other, _BaseNetwork):
+            return False
+        # dealing with another address
+        else:
+            # address
+            return (int(self.network_address) <= int(other._ip) <=
+                    int(self.broadcast_address))
+
+    def overlaps(self, other):
+        """Tell if self is partly contained in other."""
+        return self.network_address in other or (
+            self.broadcast_address in other or (
+                other.network_address in self or (
+                    other.broadcast_address in self)))
+
+    @property
+    def broadcast_address(self):
+        x = self._cache.get('broadcast_address')
+        if x is None:
+            x = self._address_class(int(self.network_address) |
+                                    int(self.hostmask))
+            self._cache['broadcast_address'] = x
+        return x
+
+    @property
+    def hostmask(self):
+        x = self._cache.get('hostmask')
+        if x is None:
+            x = self._address_class(int(self.netmask) ^ self._ALL_ONES)
+            self._cache['hostmask'] = x
+        return x
+
+    @property
+    def with_prefixlen(self):
+        return '%s/%d' % (self.network_address, self._prefixlen)
+
+    @property
+    def with_netmask(self):
+        return '%s/%s' % (self.network_address, self.netmask)
+
+    @property
+    def with_hostmask(self):
+        return '%s/%s' % (self.network_address, self.hostmask)
+
+    @property
+    def num_addresses(self):
+        """Number of hosts in the current subnet."""
+        return int(self.broadcast_address) - int(self.network_address) + 1
+
+    @property
+    def _address_class(self):
+        # Returning bare address objects (rather than interfaces) allows for
+        # more consistent behaviour across the network address, broadcast
+        # address and individual host addresses.
+        msg = '%200s has no associated address class' % (type(self),)
+        raise NotImplementedError(msg)
+
+    @property
+    def prefixlen(self):
+        return self._prefixlen
+
+    def address_exclude(self, other):
+        """Remove an address from a larger block.
+
+        For example:
+
+            addr1 = ip_network('192.0.2.0/28')
+            addr2 = ip_network('192.0.2.1/32')
+            addr1.address_exclude(addr2) =
+                [IPv4Network('192.0.2.0/32'), IPv4Network('192.0.2.2/31'),
+                IPv4Network('192.0.2.4/30'), IPv4Network('192.0.2.8/29')]
+
+        or IPv6:
+
+            addr1 = ip_network('2001:db8::1/32')
+            addr2 = ip_network('2001:db8::1/128')
+            addr1.address_exclude(addr2) =
+                [ip_network('2001:db8::1/128'),
+                ip_network('2001:db8::2/127'),
+                ip_network('2001:db8::4/126'),
+                ip_network('2001:db8::8/125'),
+                ...
+                ip_network('2001:db8:8000::/33')]
+
+        Args:
+            other: An IPv4Network or IPv6Network object of the same type.
+
+        Returns:
+            An iterator of the IPv(4|6)Network objects which is self
+            minus other.
+
+        Raises:
+            TypeError: If self and other are of differing address
+              versions, or if other is not a network object.
+            ValueError: If other is not completely contained by self.
+
+        """
+        if not self._version == other._version:
+            raise TypeError("%s and %s are not of the same version" % (
+                             self, other))
+
+        if not isinstance(other, _BaseNetwork):
+            raise TypeError("%s is not a network object" % other)
+
+        if not (other.network_address >= self.network_address and
+                other.broadcast_address <= self.broadcast_address):
+            raise ValueError('%s not contained in %s' % (other, self))
+        if other == self:
+            raise StopIteration
+
+        # Make sure we're comparing the network of other.
+        other = other.__class__('%s/%s' % (other.network_address,
+                                           other.prefixlen))
+
+        s1, s2 = self.subnets()
+        while s1 != other and s2 != other:
+            if (other.network_address >= s1.network_address and
+                other.broadcast_address <= s1.broadcast_address):
+                yield s2
+                s1, s2 = s1.subnets()
+            elif (other.network_address >= s2.network_address and
+                  other.broadcast_address <= s2.broadcast_address):
+                yield s1
+                s1, s2 = s2.subnets()
+            else:
+                # If we got here, there's a bug somewhere.
+                raise AssertionError('Error performing exclusion: '
+                                     's1: %s s2: %s other: %s' %
+                                     (s1, s2, other))
+        if s1 == other:
+            yield s2
+        elif s2 == other:
+            yield s1
+        else:
+            # If we got here, there's a bug somewhere.
+            raise AssertionError('Error performing exclusion: '
+                                 's1: %s s2: %s other: %s' %
+                                 (s1, s2, other))
+
+    def compare_networks(self, other):
+        """Compare two IP objects.
+
+        This is only concerned about the comparison of the integer
+        representation of the network addresses.  This means that the
+        host bits aren't considered at all in this method.  If you want
+        to compare host bits, you can easily enough do a
+        'HostA._ip < HostB._ip'
+
+        Args:
+            other: An IP object.
+
+        Returns:
+            If the IP versions of self and other are the same, returns:
+
+            -1 if self < other:
+              eg: IPv4Network('192.0.2.0/25') < IPv4Network('192.0.2.128/25')
+              IPv6Network('2001:db8::1000/124') <
+                  IPv6Network('2001:db8::2000/124')
+            0 if self == other
+              eg: IPv4Network('192.0.2.0/24') == IPv4Network('192.0.2.0/24')
+              IPv6Network('2001:db8::1000/124') ==
+                  IPv6Network('2001:db8::1000/124')
+            1 if self > other
+              eg: IPv4Network('192.0.2.128/25') > IPv4Network('192.0.2.0/25')
+                  IPv6Network('2001:db8::2000/124') >
+                      IPv6Network('2001:db8::1000/124')
+
+          Raises:
+              TypeError if the IP versions are different.
+
+        """
+        # does this need to raise a ValueError?
+        if self._version != other._version:
+            raise TypeError('%s and %s are not of the same type' % (
+                             self, other))
+        # self._version == other._version below here:
+        if self.network_address < other.network_address:
+            return -1
+        if self.network_address > other.network_address:
+            return 1
+        # self.network_address == other.network_address below here:
+        if self.netmask < other.netmask:
+            return -1
+        if self.netmask > other.netmask:
+            return 1
+        return 0
+
+    def _get_networks_key(self):
+        """Network-only key function.
+
+        Returns an object that identifies this address' network and
+        netmask. This function is a suitable "key" argument for sorted()
+        and list.sort().
+
+        """
+        return (self._version, self.network_address, self.netmask)
+
+    def subnets(self, prefixlen_diff=1, new_prefix=None):
+        """The subnets which join to make the current subnet.
+
+        In the case that self contains only one IP
+        (self._prefixlen == 32 for IPv4 or self._prefixlen == 128
+        for IPv6), yield an iterator with just ourself.
+
+        Args:
+            prefixlen_diff: An integer, the amount the prefix length
+              should be increased by. This should not be set if
+              new_prefix is also set.
+            new_prefix: The desired new prefix length. This must be a
+              larger number (smaller prefix) than the existing prefix.
+              This should not be set if prefixlen_diff is also set.
+
+        Returns:
+            An iterator of IPv(4|6) objects.
+
+        Raises:
+            ValueError: The prefixlen_diff is too small or too large.
+                OR
+            prefixlen_diff and new_prefix are both set or new_prefix
+              is a smaller number than the current prefix (smaller
+              number means a larger network)
+
+        """
+        if self._prefixlen == self._max_prefixlen:
+            yield self
+            return
+
+        if new_prefix is not None:
+            if new_prefix < self._prefixlen:
+                raise ValueError('new prefix must be longer')
+            if prefixlen_diff != 1:
+                raise ValueError('cannot set prefixlen_diff and new_prefix')
+            prefixlen_diff = new_prefix - self._prefixlen
+
+        if prefixlen_diff < 0:
+            raise ValueError('prefix length diff must be > 0')
+        new_prefixlen = self._prefixlen + prefixlen_diff
+
+        if new_prefixlen > self._max_prefixlen:
+            raise ValueError(
+                'prefix length diff %d is invalid for netblock %s' % (
+                    new_prefixlen, self))
+
+        first = self.__class__('%s/%s' %
+                                 (self.network_address,
+                                  self._prefixlen + prefixlen_diff))
+
+        yield first
+        current = first
+        while True:
+            broadcast = current.broadcast_address
+            if broadcast == self.broadcast_address:
+                return
+            new_addr = self._address_class(int(broadcast) + 1)
+            current = self.__class__('%s/%s' % (new_addr,
+                                                new_prefixlen))
+
+            yield current
+
+    def supernet(self, prefixlen_diff=1, new_prefix=None):
+        """The supernet containing the current network.
+
+        Args:
+            prefixlen_diff: An integer, the amount the prefix length of
+              the network should be decreased by.  For example, given a
+              /24 network and a prefixlen_diff of 3, a supernet with a
+              /21 netmask is returned.
+
+        Returns:
+            An IPv4 network object.
+
+        Raises:
+            ValueError: If self.prefixlen - prefixlen_diff < 0. I.e., you have
+              a negative prefix length.
+                OR
+            If prefixlen_diff and new_prefix are both set or new_prefix is a
+              larger number than the current prefix (larger number means a
+              smaller network)
+
+        """
+        if self._prefixlen == 0:
+            return self
+
+        if new_prefix is not None:
+            if new_prefix > self._prefixlen:
+                raise ValueError('new prefix must be shorter')
+            if prefixlen_diff != 1:
+                raise ValueError('cannot set prefixlen_diff and new_prefix')
+            prefixlen_diff = self._prefixlen - new_prefix
+
+        if self.prefixlen - prefixlen_diff < 0:
+            raise ValueError(
+                'current prefixlen is %d, cannot have a prefixlen_diff of %d' %
+                (self.prefixlen, prefixlen_diff))
+        # TODO (pmoody): optimize this.
+        t = self.__class__('%s/%d' % (self.network_address,
+                                      self.prefixlen - prefixlen_diff),
+                                     strict=False)
+        return t.__class__('%s/%d' % (t.network_address, t.prefixlen))
+
+    @property
+    def is_multicast(self):
+        """Test if the address is reserved for multicast use.
+
+        Returns:
+            A boolean, True if the address is a multicast address.
+            See RFC 2373 2.7 for details.
+
+        """
+        return (self.network_address.is_multicast and
+                self.broadcast_address.is_multicast)
+
+    @property
+    def is_reserved(self):
+        """Test if the address is otherwise IETF reserved.
+
+        Returns:
+            A boolean, True if the address is within one of the
+            reserved IPv6 Network ranges.
+
+        """
+        return (self.network_address.is_reserved and
+                self.broadcast_address.is_reserved)
+
+    @property
+    def is_link_local(self):
+        """Test if the address is reserved for link-local.
+
+        Returns:
+            A boolean, True if the address is reserved per RFC 4291.
+
+        """
+        return (self.network_address.is_link_local and
+                self.broadcast_address.is_link_local)
+
+    @property
+    def is_private(self):
+        """Test if this address is allocated for private networks.
+
+        Returns:
+            A boolean, True if the address is reserved per
+            iana-ipv4-special-registry or iana-ipv6-special-registry.
+
+        """
+        return (self.network_address.is_private and
+                self.broadcast_address.is_private)
+
+    @property
+    def is_global(self):
+        """Test if this address is allocated for public networks.
+
+        Returns:
+            A boolean, True if the address is not reserved per
+            iana-ipv4-special-registry or iana-ipv6-special-registry.
+
+        """
+        return not self.is_private
+
+    @property
+    def is_unspecified(self):
+        """Test if the address is unspecified.
+
+        Returns:
+            A boolean, True if this is the unspecified address as defined in
+            RFC 2373 2.5.2.
+
+        """
+        return (self.network_address.is_unspecified and
+                self.broadcast_address.is_unspecified)
+
+    @property
+    def is_loopback(self):
+        """Test if the address is a loopback address.
+
+        Returns:
+            A boolean, True if the address is a loopback address as defined in
+            RFC 2373 2.5.3.
+
+        """
+        return (self.network_address.is_loopback and
+                self.broadcast_address.is_loopback)
+
+
+class _BaseV4(object):
+
+    """Base IPv4 object.
+
+    The following methods are used by IPv4 objects in both single IP
+    addresses and networks.
+
+    """
+
+    # Equivalent to 255.255.255.255 or 32 bits of 1's.
+    _ALL_ONES = (2**IPV4LENGTH) - 1
+    _DECIMAL_DIGITS = frozenset('0123456789')
+
+    # the valid octets for host and netmasks. only useful for IPv4.
+    _valid_mask_octets = frozenset((255, 254, 252, 248, 240, 224, 192, 128, 0))
+
+    def __init__(self, address):
+        self._version = 4
+        self._max_prefixlen = IPV4LENGTH
+
+    def _explode_shorthand_ip_string(self):
+        return str(self)
+
+    def _ip_int_from_string(self, ip_str):
+        """Turn the given IP string into an integer for comparison.
+
+        Args:
+            ip_str: A string, the IP ip_str.
+
+        Returns:
+            The IP ip_str as an integer.
+
+        Raises:
+            AddressValueError: if ip_str isn't a valid IPv4 Address.
+
+        """
+        if not ip_str:
+            raise AddressValueError('Address cannot be empty')
+
+        octets = ip_str.split('.')
+        if len(octets) != 4:
+            raise AddressValueError("Expected 4 octets in %r" % ip_str)
+
+        try:
+            return _int_from_bytes(map(self._parse_octet, octets), 'big')
+        except ValueError as exc:
+            raise AddressValueError("%s in %r" % (exc, ip_str))
+
+    def _parse_octet(self, octet_str):
+        """Convert a decimal octet into an integer.
+
+        Args:
+            octet_str: A string, the number to parse.
+
+        Returns:
+            The octet as an integer.
+
+        Raises:
+            ValueError: if the octet isn't strictly a decimal from [0..255].
+
+        """
+        if not octet_str:
+            raise ValueError("Empty octet not permitted")
+        # Whitelist the characters, since int() allows a lot of bizarre stuff.
+        if not self._DECIMAL_DIGITS.issuperset(octet_str):
+            msg = "Only decimal digits permitted in %r"
+            raise ValueError(msg % octet_str)
+        # We do the length check second, since the invalid character error
+        # is likely to be more informative for the user
+        if len(octet_str) > 3:
+            msg = "At most 3 characters permitted in %r"
+            raise ValueError(msg % octet_str)
+        # Convert to integer (we know digits are legal)
+        octet_int = int(octet_str, 10)
+        # Any octets that look like they *might* be written in octal,
+        # and which don't look exactly the same in both octal and
+        # decimal are rejected as ambiguous
+        if octet_int > 7 and octet_str[0] == '0':
+            msg = "Ambiguous (octal/decimal) value in %r not permitted"
+            raise ValueError(msg % octet_str)
+        if octet_int > 255:
+            raise ValueError("Octet %d (> 255) not permitted" % octet_int)
+        return octet_int
+
+    def _string_from_ip_int(self, ip_int):
+        """Turns a 32-bit integer into dotted decimal notation.
+
+        Args:
+            ip_int: An integer, the IP address.
+
+        Returns:
+            The IP address as a string in dotted decimal notation.
+
+        """
+        return '.'.join(map(str, _int_to_bytes(ip_int, 4, 'big')))
+
+    def _is_valid_netmask(self, netmask):
+        """Verify that the netmask is valid.
+
+        Args:
+            netmask: A string, either a prefix or dotted decimal
+              netmask.
+
+        Returns:
+            A boolean, True if the prefix represents a valid IPv4
+            netmask.
+
+        """
+        mask = netmask.split('.')
+        if len(mask) == 4:
+            try:
+                for x in mask:
+                    if int(x) not in self._valid_mask_octets:
+                        return False
+            except ValueError:
+                # Found something that isn't an integer or isn't valid
+                return False
+            for idx, y in enumerate(mask):
+                if idx > 0 and y > mask[idx - 1]:
+                    return False
+            return True
+        try:
+            netmask = int(netmask)
+        except ValueError:
+            return False
+        return 0 <= netmask <= self._max_prefixlen
+
+    def _is_hostmask(self, ip_str):
+        """Test if the IP string is a hostmask (rather than a netmask).
+
+        Args:
+            ip_str: A string, the potential hostmask.
+
+        Returns:
+            A boolean, True if the IP string is a hostmask.
+
+        """
+        bits = ip_str.split('.')
+        try:
+            parts = [x for x in map(int, bits) if x in self._valid_mask_octets]
+        except ValueError:
+            return False
+        if len(parts) != len(bits):
+            return False
+        if parts[0] < parts[-1]:
+            return True
+        return False
+
+    @property
+    def max_prefixlen(self):
+        return self._max_prefixlen
+
+    @property
+    def version(self):
+        return self._version
+
+
+class IPv4Address(_BaseV4, _BaseAddress):
+
+    """Represent and manipulate single IPv4 Addresses."""
+
+    def __init__(self, address):
+
+        """
+        Args:
+            address: A string or integer representing the IP
+
+              Additionally, an integer can be passed, so
+              IPv4Address('192.0.2.1') == IPv4Address(3221225985).
+              or, more generally
+              IPv4Address(int(IPv4Address('192.0.2.1'))) ==
+                IPv4Address('192.0.2.1')
+
+        Raises:
+            AddressValueError: If ipaddress isn't a valid IPv4 address.
+
+        """
+        _BaseAddress.__init__(self, address)
+        _BaseV4.__init__(self, address)
+
+        # Efficient constructor from integer.
+        if isinstance(address, int):
+            self._check_int_address(address)
+            self._ip = address
+            return
+
+        # Constructing from a packed address
+        if isinstance(address, bytes):
+            self._check_packed_address(address, 4)
+            self._ip = _int_from_bytes(address, 'big')
+            return
+
+        # Assume input argument to be string or any object representation
+        # which converts into a formatted IP string.
+        addr_str = str(address)
+        self._ip = self._ip_int_from_string(addr_str)
+
+    @property
+    def packed(self):
+        """The binary representation of this address."""
+        return v4_int_to_packed(self._ip)
+
+    @property
+    def is_reserved(self):
+        """Test if the address is otherwise IETF reserved.
+
+         Returns:
+             A boolean, True if the address is within the
+             reserved IPv4 Network range.
+
+        """
+        reserved_network = IPv4Network('240.0.0.0/4')
+        return self in reserved_network
+
+    @property
+    def is_private(self):
+        """Test if this address is allocated for private networks.
+
+        Returns:
+            A boolean, True if the address is reserved per
+            iana-ipv4-special-registry.
+
+        """
+        return (self in IPv4Network('0.0.0.0/8') or
+                self in IPv4Network('10.0.0.0/8') or
+                self in IPv4Network('127.0.0.0/8') or
+                self in IPv4Network('169.254.0.0/16') or
+                self in IPv4Network('172.16.0.0/12') or
+                self in IPv4Network('192.0.0.0/29') or
+                self in IPv4Network('192.0.0.170/31') or
+                self in IPv4Network('192.0.2.0/24') or
+                self in IPv4Network('192.168.0.0/16') or
+                self in IPv4Network('198.18.0.0/15') or
+                self in IPv4Network('198.51.100.0/24') or
+                self in IPv4Network('203.0.113.0/24') or
+                self in IPv4Network('240.0.0.0/4') or
+                self in IPv4Network('255.255.255.255/32'))
+
+
+    @property
+    def is_multicast(self):
+        """Test if the address is reserved for multicast use.
+
+        Returns:
+            A boolean, True if the address is multicast.
+            See RFC 3171 for details.
+
+        """
+        multicast_network = IPv4Network('224.0.0.0/4')
+        return self in multicast_network
+
+    @property
+    def is_unspecified(self):
+        """Test if the address is unspecified.
+
+        Returns:
+            A boolean, True if this is the unspecified address as defined in
+            RFC 5735 3.
+
+        """
+        unspecified_address = IPv4Address('0.0.0.0')
+        return self == unspecified_address
+
+    @property
+    def is_loopback(self):
+        """Test if the address is a loopback address.
+
+        Returns:
+            A boolean, True if the address is a loopback per RFC 3330.
+
+        """
+        loopback_network = IPv4Network('127.0.0.0/8')
+        return self in loopback_network
+
+    @property
+    def is_link_local(self):
+        """Test if the address is reserved for link-local.
+
+        Returns:
+            A boolean, True if the address is link-local per RFC 3927.
+
+        """
+        linklocal_network = IPv4Network('169.254.0.0/16')
+        return self in linklocal_network
+
+
+class IPv4Interface(IPv4Address):
+
+    def __init__(self, address):
+        if isinstance(address, (bytes, int)):
+            IPv4Address.__init__(self, address)
+            self.network = IPv4Network(self._ip)
+            self._prefixlen = self._max_prefixlen
+            return
+
+        addr = _split_optional_netmask(address)
+        IPv4Address.__init__(self, addr[0])
+
+        self.network = IPv4Network(address, strict=False)
+        self._prefixlen = self.network._prefixlen
+
+        self.netmask = self.network.netmask
+        self.hostmask = self.network.hostmask
+
+    def __str__(self):
+        return '%s/%d' % (self._string_from_ip_int(self._ip),
+                          self.network.prefixlen)
+
+    def __eq__(self, other):
+        address_equal = IPv4Address.__eq__(self, other)
+        if not address_equal or address_equal is NotImplemented:
+            return address_equal
+        try:
+            return self.network == other.network
+        except AttributeError:
+            # An interface with an associated network is NOT the
+            # same as an unassociated address. That's why the hash
+            # takes the extra info into account.
+            return False
+
+    def __lt__(self, other):
+        address_less = IPv4Address.__lt__(self, other)
+        if address_less is NotImplemented:
+            return NotImplemented
+        try:
+            return self.network < other.network
+        except AttributeError:
+            # We *do* allow addresses and interfaces to be sorted. The
+            # unassociated address is considered less than all interfaces.
+            return False
+
+    def __hash__(self):
+        return self._ip ^ self._prefixlen ^ int(self.network.network_address)
+
+    @property
+    def ip(self):
+        return IPv4Address(self._ip)
+
+    @property
+    def with_prefixlen(self):
+        return '%s/%s' % (self._string_from_ip_int(self._ip),
+                          self._prefixlen)
+
+    @property
+    def with_netmask(self):
+        return '%s/%s' % (self._string_from_ip_int(self._ip),
+                          self.netmask)
+
+    @property
+    def with_hostmask(self):
+        return '%s/%s' % (self._string_from_ip_int(self._ip),
+                          self.hostmask)
+
+
+class IPv4Network(_BaseV4, _BaseNetwork):
+
+    """This class represents and manipulates 32-bit IPv4 network + addresses..
+
+    Attributes: [examples for IPv4Network('192.0.2.0/27')]
+        .network_address: IPv4Address('192.0.2.0')
+        .hostmask: IPv4Address('0.0.0.31')
+        .broadcast_address: IPv4Address('192.0.2.32')
+        .netmask: IPv4Address('255.255.255.224')
+        .prefixlen: 27
+
+    """
+    # Class to use when creating address objects
+    _address_class = IPv4Address
+
+    def __init__(self, address, strict=True):
+
+        """Instantiate a new IPv4 network object.
+
+        Args:
+            address: A string or integer representing the IP [& network].
+              '192.0.2.0/24'
+              '192.0.2.0/255.255.255.0'
+              '192.0.0.2/0.0.0.255'
+              are all functionally the same in IPv4. Similarly,
+              '192.0.2.1'
+              '192.0.2.1/255.255.255.255'
+              '192.0.2.1/32'
+              are also functionally equivalent. That is to say, failing to
+              provide a subnetmask will create an object with a mask of /32.
+
+              If the mask (portion after the / in the argument) is given in
+              dotted quad form, it is treated as a netmask if it starts with a
+              non-zero field (e.g. /255.0.0.0 == /8) and as a hostmask if it
+              starts with a zero field (e.g. 0.255.255.255 == /8), with the
+              single exception of an all-zero mask which is treated as a
+              netmask == /0. If no mask is given, a default of /32 is used.
+
+              Additionally, an integer can be passed, so
+              IPv4Network('192.0.2.1') == IPv4Network(3221225985)
+              or, more generally
+              IPv4Interface(int(IPv4Interface('192.0.2.1'))) ==
+                IPv4Interface('192.0.2.1')
+
+        Raises:
+            AddressValueError: If ipaddress isn't a valid IPv4 address.
+            NetmaskValueError: If the netmask isn't valid for
+              an IPv4 address.
+            ValueError: If strict is True and a network address is not
+              supplied.
+
+        """
+
+        _BaseV4.__init__(self, address)
+        _BaseNetwork.__init__(self, address)
+
+        # Constructing from a packed address
+        if isinstance(address, bytes):
+            self.network_address = IPv4Address(address)
+            self._prefixlen = self._max_prefixlen
+            self.netmask = IPv4Address(self._ALL_ONES)
+            #fixme: address/network test here
+            return
+
+        # Efficient constructor from integer.
+        if isinstance(address, int):
+            self.network_address = IPv4Address(address)
+            self._prefixlen = self._max_prefixlen
+            self.netmask = IPv4Address(self._ALL_ONES)
+            #fixme: address/network test here.
+            return
+
+        # Assume input argument to be string or any object representation
+        # which converts into a formatted IP prefix string.
+        addr = _split_optional_netmask(address)
+        self.network_address = IPv4Address(self._ip_int_from_string(addr[0]))
+
+        if len(addr) == 2:
+            try:
+                # Check for a netmask in prefix length form
+                self._prefixlen = self._prefix_from_prefix_string(addr[1])
+            except NetmaskValueError:
+                # Check for a netmask or hostmask in dotted-quad form.
+                # This may raise NetmaskValueError.
+                self._prefixlen = self._prefix_from_ip_string(addr[1])
+        else:
+            self._prefixlen = self._max_prefixlen
+        self.netmask = IPv4Address(self._ip_int_from_prefix(self._prefixlen))
+
+        if strict:
+            if (IPv4Address(int(self.network_address) & int(self.netmask)) !=
+                self.network_address):
+                raise ValueError('%s has host bits set' % self)
+        self.network_address = IPv4Address(int(self.network_address) &
+                                           int(self.netmask))
+
+        if self._prefixlen == (self._max_prefixlen - 1):
+            self.hosts = self.__iter__
+
+    @property
+    def is_global(self):
+        """Test if this address is allocated for public networks.
+
+        Returns:
+            A boolean, True if the address is not reserved per
+            iana-ipv4-special-registry.
+
+        """
+        return (not (self.network_address in IPv4Network('100.64.0.0/10') and
+                    self.broadcast_address in IPv4Network('100.64.0.0/10')) and
+                not self.is_private)
+
+
+
+class _BaseV6(object):
+
+    """Base IPv6 object.
+
+    The following methods are used by IPv6 objects in both single IP
+    addresses and networks.
+
+    """
+
+    _ALL_ONES = (2**IPV6LENGTH) - 1
+    _HEXTET_COUNT = 8
+    _HEX_DIGITS = frozenset('0123456789ABCDEFabcdef')
+
+    def __init__(self, address):
+        self._version = 6
+        self._max_prefixlen = IPV6LENGTH
+
+    def _ip_int_from_string(self, ip_str):
+        """Turn an IPv6 ip_str into an integer.
+
+        Args:
+            ip_str: A string, the IPv6 ip_str.
+
+        Returns:
+            An int, the IPv6 address
+
+        Raises:
+            AddressValueError: if ip_str isn't a valid IPv6 Address.
+
+        """
+        if not ip_str:
+            raise AddressValueError('Address cannot be empty')
+
+        parts = ip_str.split(':')
+
+        # An IPv6 address needs at least 2 colons (3 parts).
+        _min_parts = 3
+        if len(parts) < _min_parts:
+            msg = "At least %d parts expected in %r" % (_min_parts, ip_str)
+            raise AddressValueError(msg)
+
+        # If the address has an IPv4-style suffix, convert it to hexadecimal.
+        if '.' in parts[-1]:
+            try:
+                ipv4_int = IPv4Address(parts.pop())._ip
+            except AddressValueError as exc:
+                raise AddressValueError("%s in %r" % (exc, ip_str))
+            parts.append('%x' % ((ipv4_int >> 16) & 0xFFFF))
+            parts.append('%x' % (ipv4_int & 0xFFFF))
+
+        # An IPv6 address can't have more than 8 colons (9 parts).
+        # The extra colon comes from using the "::" notation for a single
+        # leading or trailing zero part.
+        _max_parts = self._HEXTET_COUNT + 1
+        if len(parts) > _max_parts:
+            msg = "At most %d colons permitted in %r" % (_max_parts-1, ip_str)
+            raise AddressValueError(msg)
+
+        # Disregarding the endpoints, find '::' with nothing in between.
+        # This indicates that a run of zeroes has been skipped.
+        skip_index = None
+        for i in range(1, len(parts) - 1):
+            if not parts[i]:
+                if skip_index is not None:
+                    # Can't have more than one '::'
+                    msg = "At most one '::' permitted in %r" % ip_str
+                    raise AddressValueError(msg)
+                skip_index = i
+
+        # parts_hi is the number of parts to copy from above/before the '::'
+        # parts_lo is the number of parts to copy from below/after the '::'
+        if skip_index is not None:
+            # If we found a '::', then check if it also covers the endpoints.
+            parts_hi = skip_index
+            parts_lo = len(parts) - skip_index - 1
+            if not parts[0]:
+                parts_hi -= 1
+                if parts_hi:
+                    msg = "Leading ':' only permitted as part of '::' in %r"
+                    raise AddressValueError(msg % ip_str)  # ^: requires ^::
+            if not parts[-1]:
+                parts_lo -= 1
+                if parts_lo:
+                    msg = "Trailing ':' only permitted as part of '::' in %r"
+                    raise AddressValueError(msg % ip_str)  # :$ requires ::$
+            parts_skipped = self._HEXTET_COUNT - (parts_hi + parts_lo)
+            if parts_skipped < 1:
+                msg = "Expected at most %d other parts with '::' in %r"
+                raise AddressValueError(msg % (self._HEXTET_COUNT-1, ip_str))
+        else:
+            # Otherwise, allocate the entire address to parts_hi.  The
+            # endpoints could still be empty, but _parse_hextet() will check
+            # for that.
+            if len(parts) != self._HEXTET_COUNT:
+                msg = "Exactly %d parts expected without '::' in %r"
+                raise AddressValueError(msg % (self._HEXTET_COUNT, ip_str))
+            if not parts[0]:
+                msg = "Leading ':' only permitted as part of '::' in %r"
+                raise AddressValueError(msg % ip_str)  # ^: requires ^::
+            if not parts[-1]:
+                msg = "Trailing ':' only permitted as part of '::' in %r"
+                raise AddressValueError(msg % ip_str)  # :$ requires ::$
+            parts_hi = len(parts)
+            parts_lo = 0
+            parts_skipped = 0
+
+        try:
+            # Now, parse the hextets into a 128-bit integer.
+            ip_int = 0
+            for i in range(parts_hi):
+                ip_int <<= 16
+                ip_int |= self._parse_hextet(parts[i])
+            ip_int <<= 16 * parts_skipped
+            for i in range(-parts_lo, 0):
+                ip_int <<= 16
+                ip_int |= self._parse_hextet(parts[i])
+            return ip_int
+        except ValueError as exc:
+            raise AddressValueError("%s in %r" % (exc, ip_str))
+
+    def _parse_hextet(self, hextet_str):
+        """Convert an IPv6 hextet string into an integer.
+
+        Args:
+            hextet_str: A string, the number to parse.
+
+        Returns:
+            The hextet as an integer.
+
+        Raises:
+            ValueError: if the input isn't strictly a hex number from
+              [0..FFFF].
+
+        """
+        # Whitelist the characters, since int() allows a lot of bizarre stuff.
+        if not self._HEX_DIGITS.issuperset(hextet_str):
+            raise ValueError("Only hex digits permitted in %r" % hextet_str)
+        # We do the length check second, since the invalid character error
+        # is likely to be more informative for the user
+        if len(hextet_str) > 4:
+            msg = "At most 4 characters permitted in %r"
+            raise ValueError(msg % hextet_str)
+        # Length check means we can skip checking the integer value
+        return int(hextet_str, 16)
+
+    def _compress_hextets(self, hextets):
+        """Compresses a list of hextets.
+
+        Compresses a list of strings, replacing the longest continuous
+        sequence of "0" in the list with "" and adding empty strings at
+        the beginning or at the end of the string such that subsequently
+        calling ":".join(hextets) will produce the compressed version of
+        the IPv6 address.
+
+        Args:
+            hextets: A list of strings, the hextets to compress.
+
+        Returns:
+            A list of strings.
+
+        """
+        best_doublecolon_start = -1
+        best_doublecolon_len = 0
+        doublecolon_start = -1
+        doublecolon_len = 0
+        for index, hextet in enumerate(hextets):
+            if hextet == '0':
+                doublecolon_len += 1
+                if doublecolon_start == -1:
+                    # Start of a sequence of zeros.
+                    doublecolon_start = index
+                if doublecolon_len > best_doublecolon_len:
+                    # This is the longest sequence of zeros so far.
+                    best_doublecolon_len = doublecolon_len
+                    best_doublecolon_start = doublecolon_start
+            else:
+                doublecolon_len = 0
+                doublecolon_start = -1
+
+        if best_doublecolon_len > 1:
+            best_doublecolon_end = (best_doublecolon_start +
+                                    best_doublecolon_len)
+            # For zeros at the end of the address.
+            if best_doublecolon_end == len(hextets):
+                hextets += ['']
+            hextets[best_doublecolon_start:best_doublecolon_end] = ['']
+            # For zeros at the beginning of the address.
+            if best_doublecolon_start == 0:
+                hextets = [''] + hextets
+
+        return hextets
+
+    def _string_from_ip_int(self, ip_int=None):
+        """Turns a 128-bit integer into hexadecimal notation.
+
+        Args:
+            ip_int: An integer, the IP address.
+
+        Returns:
+            A string, the hexadecimal representation of the address.
+
+        Raises:
+            ValueError: The address is bigger than 128 bits of all ones.
+
+        """
+        if ip_int is None:
+            ip_int = int(self._ip)
+
+        if ip_int > self._ALL_ONES:
+            raise ValueError('IPv6 address is too large')
+
+        hex_str = '%032x' % ip_int
+        hextets = ['%x' % int(hex_str[x:x+4], 16) for x in range(0, 32, 4)]
+
+        hextets = self._compress_hextets(hextets)
+        return ':'.join(hextets)
+
+    def _explode_shorthand_ip_string(self):
+        """Expand a shortened IPv6 address.
+
+        Args:
+            ip_str: A string, the IPv6 address.
+
+        Returns:
+            A string, the expanded IPv6 address.
+
+        """
+        if isinstance(self, IPv6Network):
+            ip_str = str(self.network_address)
+        elif isinstance(self, IPv6Interface):
+            ip_str = str(self.ip)
+        else:
+            ip_str = str(self)
+
+        ip_int = self._ip_int_from_string(ip_str)
+        hex_str = '%032x' % ip_int
+        parts = [hex_str[x:x+4] for x in range(0, 32, 4)]
+        if isinstance(self, (_BaseNetwork, IPv6Interface)):
+            return '%s/%d' % (':'.join(parts), self._prefixlen)
+        return ':'.join(parts)
+
+    @property
+    def max_prefixlen(self):
+        return self._max_prefixlen
+
+    @property
+    def version(self):
+        return self._version
+
+
+class IPv6Address(_BaseV6, _BaseAddress):
+
+    """Represent and manipulate single IPv6 Addresses."""
+
+    def __init__(self, address):
+        """Instantiate a new IPv6 address object.
+
+        Args:
+            address: A string or integer representing the IP
+
+              Additionally, an integer can be passed, so
+              IPv6Address('2001:db8::') ==
+                IPv6Address(42540766411282592856903984951653826560)
+              or, more generally
+              IPv6Address(int(IPv6Address('2001:db8::'))) ==
+                IPv6Address('2001:db8::')
+
+        Raises:
+            AddressValueError: If address isn't a valid IPv6 address.
+
+        """
+        _BaseAddress.__init__(self, address)
+        _BaseV6.__init__(self, address)
+
+        # Efficient constructor from integer.
+        if isinstance(address, int):
+            self._check_int_address(address)
+            self._ip = address
+            return
+
+        # Constructing from a packed address
+        if isinstance(address, bytes):
+            self._check_packed_address(address, 16)
+            self._ip = _int_from_bytes(address, 'big')
+            return
+
+        # Assume input argument to be string or any object representation
+        # which converts into a formatted IP string.
+        addr_str = str(address)
+        self._ip = self._ip_int_from_string(addr_str)
+
+    @property
+    def packed(self):
+        """The binary representation of this address."""
+        return v6_int_to_packed(self._ip)
+
+    @property
+    def is_multicast(self):
+        """Test if the address is reserved for multicast use.
+
+        Returns:
+            A boolean, True if the address is a multicast address.
+            See RFC 2373 2.7 for details.
+
+        """
+        multicast_network = IPv6Network('ff00::/8')
+        return self in multicast_network
+
+    @property
+    def is_reserved(self):
+        """Test if the address is otherwise IETF reserved.
+
+        Returns:
+            A boolean, True if the address is within one of the
+            reserved IPv6 Network ranges.
+
+        """
+        reserved_networks = [IPv6Network('::/8'), IPv6Network('100::/8'),
+                             IPv6Network('200::/7'), IPv6Network('400::/6'),
+                             IPv6Network('800::/5'), IPv6Network('1000::/4'),
+                             IPv6Network('4000::/3'), IPv6Network('6000::/3'),
+                             IPv6Network('8000::/3'), IPv6Network('A000::/3'),
+                             IPv6Network('C000::/3'), IPv6Network('E000::/4'),
+                             IPv6Network('F000::/5'), IPv6Network('F800::/6'),
+                             IPv6Network('FE00::/9')]
+
+        return any(self in x for x in reserved_networks)
+
+    @property
+    def is_link_local(self):
+        """Test if the address is reserved for link-local.
+
+        Returns:
+            A boolean, True if the address is reserved per RFC 4291.
+
+        """
+        linklocal_network = IPv6Network('fe80::/10')
+        return self in linklocal_network
+
+    @property
+    def is_site_local(self):
+        """Test if the address is reserved for site-local.
+
+        Note that the site-local address space has been deprecated by RFC 3879.
+        Use is_private to test if this address is in the space of unique local
+        addresses as defined by RFC 4193.
+
+        Returns:
+            A boolean, True if the address is reserved per RFC 3513 2.5.6.
+
+        """
+        sitelocal_network = IPv6Network('fec0::/10')
+        return self in sitelocal_network
+
+    @property
+    def is_private(self):
+        """Test if this address is allocated for private networks.
+
+        Returns:
+            A boolean, True if the address is reserved per
+            iana-ipv6-special-registry.
+
+        """
+        return (self in IPv6Network('::1/128') or
+                self in IPv6Network('::/128') or
+                self in IPv6Network('::ffff:0:0/96') or
+                self in IPv6Network('100::/64') or
+                self in IPv6Network('2001::/23') or
+                self in IPv6Network('2001:2::/48') or
+                self in IPv6Network('2001:db8::/32') or
+                self in IPv6Network('2001:10::/28') or
+                self in IPv6Network('fc00::/7') or
+                self in IPv6Network('fe80::/10'))
+
+    @property
+    def is_global(self):
+        """Test if this address is allocated for public networks.
+
+        Returns:
+            A boolean, true if the address is not reserved per
+            iana-ipv6-special-registry.
+
+        """
+        return not self.is_private
+
+    @property
+    def is_unspecified(self):
+        """Test if the address is unspecified.
+
+        Returns:
+            A boolean, True if this is the unspecified address as defined in
+            RFC 2373 2.5.2.
+
+        """
+        return self._ip == 0
+
+    @property
+    def is_loopback(self):
+        """Test if the address is a loopback address.
+
+        Returns:
+            A boolean, True if the address is a loopback address as defined in
+            RFC 2373 2.5.3.
+
+        """
+        return self._ip == 1
+
+    @property
+    def ipv4_mapped(self):
+        """Return the IPv4 mapped address.
+
+        Returns:
+            If the IPv6 address is a v4 mapped address, return the
+            IPv4 mapped address. Return None otherwise.
+
+        """
+        if (self._ip >> 32) != 0xFFFF:
+            return None
+        return IPv4Address(self._ip & 0xFFFFFFFF)
+
+    @property
+    def teredo(self):
+        """Tuple of embedded teredo IPs.
+
+        Returns:
+            Tuple of the (server, client) IPs or None if the address
+            doesn't appear to be a teredo address (doesn't start with
+            2001::/32)
+
+        """
+        if (self._ip >> 96) != 0x20010000:
+            return None
+        return (IPv4Address((self._ip >> 64) & 0xFFFFFFFF),
+                IPv4Address(~self._ip & 0xFFFFFFFF))
+
+    @property
+    def sixtofour(self):
+        """Return the IPv4 6to4 embedded address.
+
+        Returns:
+            The IPv4 6to4-embedded address if present or None if the
+            address doesn't appear to contain a 6to4 embedded address.
+
+        """
+        if (self._ip >> 112) != 0x2002:
+            return None
+        return IPv4Address((self._ip >> 80) & 0xFFFFFFFF)
+
+
+class IPv6Interface(IPv6Address):
+
+    def __init__(self, address):
+        if isinstance(address, (bytes, int)):
+            IPv6Address.__init__(self, address)
+            self.network = IPv6Network(self._ip)
+            self._prefixlen = self._max_prefixlen
+            return
+
+        addr = _split_optional_netmask(address)
+        IPv6Address.__init__(self, addr[0])
+        self.network = IPv6Network(address, strict=False)
+        self.netmask = self.network.netmask
+        self._prefixlen = self.network._prefixlen
+        self.hostmask = self.network.hostmask
+
+    def __str__(self):
+        return '%s/%d' % (self._string_from_ip_int(self._ip),
+                          self.network.prefixlen)
+
+    def __eq__(self, other):
+        address_equal = IPv6Address.__eq__(self, other)
+        if not address_equal or address_equal is NotImplemented:
+            return address_equal
+        try:
+            return self.network == other.network
+        except AttributeError:
+            # An interface with an associated network is NOT the
+            # same as an unassociated address. That's why the hash
+            # takes the extra info into account.
+            return False
+
+    def __lt__(self, other):
+        address_less = IPv6Address.__lt__(self, other)
+        if address_less is NotImplemented:
+            return NotImplemented
+        try:
+            return self.network < other.network
+        except AttributeError:
+            # We *do* allow addresses and interfaces to be sorted. The
+            # unassociated address is considered less than all interfaces.
+            return False
+
+    def __hash__(self):
+        return self._ip ^ self._prefixlen ^ int(self.network.network_address)
+
+    @property
+    def ip(self):
+        return IPv6Address(self._ip)
+
+    @property
+    def with_prefixlen(self):
+        return '%s/%s' % (self._string_from_ip_int(self._ip),
+                          self._prefixlen)
+
+    @property
+    def with_netmask(self):
+        return '%s/%s' % (self._string_from_ip_int(self._ip),
+                          self.netmask)
+
+    @property
+    def with_hostmask(self):
+        return '%s/%s' % (self._string_from_ip_int(self._ip),
+                          self.hostmask)
+
+    @property
+    def is_unspecified(self):
+        return self._ip == 0 and self.network.is_unspecified
+
+    @property
+    def is_loopback(self):
+        return self._ip == 1 and self.network.is_loopback
+
+
+class IPv6Network(_BaseV6, _BaseNetwork):
+
+    """This class represents and manipulates 128-bit IPv6 networks.
+
+    Attributes: [examples for IPv6('2001:db8::1000/124')]
+        .network_address: IPv6Address('2001:db8::1000')
+        .hostmask: IPv6Address('::f')
+        .broadcast_address: IPv6Address('2001:db8::100f')
+        .netmask: IPv6Address('ffff:ffff:ffff:ffff:ffff:ffff:ffff:fff0')
+        .prefixlen: 124
+
+    """
+
+    # Class to use when creating address objects
+    _address_class = IPv6Address
+
+    def __init__(self, address, strict=True):
+        """Instantiate a new IPv6 Network object.
+
+        Args:
+            address: A string or integer representing the IPv6 network or the
+              IP and prefix/netmask.
+              '2001:db8::/128'
+              '2001:db8:0000:0000:0000:0000:0000:0000/128'
+              '2001:db8::'
+              are all functionally the same in IPv6.  That is to say,
+              failing to provide a subnetmask will create an object with
+              a mask of /128.
+
+              Additionally, an integer can be passed, so
+              IPv6Network('2001:db8::') ==
+                IPv6Network(42540766411282592856903984951653826560)
+              or, more generally
+              IPv6Network(int(IPv6Network('2001:db8::'))) ==
+                IPv6Network('2001:db8::')
+
+            strict: A boolean. If true, ensure that we have been passed
+              A true network address, eg, 2001:db8::1000/124 and not an
+              IP address on a network, eg, 2001:db8::1/124.
+
+        Raises:
+            AddressValueError: If address isn't a valid IPv6 address.
+            NetmaskValueError: If the netmask isn't valid for
+              an IPv6 address.
+            ValueError: If strict was True and a network address was not
+              supplied.
+
+        """
+        _BaseV6.__init__(self, address)
+        _BaseNetwork.__init__(self, address)
+
+        # Efficient constructor from integer.
+        if isinstance(address, int):
+            self.network_address = IPv6Address(address)
+            self._prefixlen = self._max_prefixlen
+            self.netmask = IPv6Address(self._ALL_ONES)
+            return
+
+        # Constructing from a packed address
+        if isinstance(address, bytes):
+            self.network_address = IPv6Address(address)
+            self._prefixlen = self._max_prefixlen
+            self.netmask = IPv6Address(self._ALL_ONES)
+            return
+
+        # Assume input argument to be string or any object representation
+        # which converts into a formatted IP prefix string.
+        addr = _split_optional_netmask(address)
+
+        self.network_address = IPv6Address(self._ip_int_from_string(addr[0]))
+
+        if len(addr) == 2:
+            # This may raise NetmaskValueError
+            self._prefixlen = self._prefix_from_prefix_string(addr[1])
+        else:
+            self._prefixlen = self._max_prefixlen
+
+        self.netmask = IPv6Address(self._ip_int_from_prefix(self._prefixlen))
+        if strict:
+            if (IPv6Address(int(self.network_address) & int(self.netmask)) !=
+                self.network_address):
+                raise ValueError('%s has host bits set' % self)
+        self.network_address = IPv6Address(int(self.network_address) &
+                                           int(self.netmask))
+
+        if self._prefixlen == (self._max_prefixlen - 1):
+            self.hosts = self.__iter__
+
+    @property
+    def is_site_local(self):
+        """Test if the address is reserved for site-local.
+
+        Note that the site-local address space has been deprecated by RFC 3879.
+        Use is_private to test if this address is in the space of unique local
+        addresses as defined by RFC 4193.
+
+        Returns:
+            A boolean, True if the address is reserved per RFC 3513 2.5.6.
+
+        """
+        return (self.network_address.is_site_local and
+                self.broadcast_address.is_site_local)

--- a/salt/ext/ipaddress.py
+++ b/salt/ext/ipaddress.py
@@ -1,4 +1,10 @@
-# Python 2.7 port of Python 3.4's ipaddress module.
+'''
+Python 2.[67] port of Python 3.4's ipaddress module
+
+Almost verbatim copy of the core lib, with compatibility changes
+Source: https://bitbucket.org/kwi/py2-ipaddress/
+'''
+# pylint: skip-file
 
 # List of compatibility changes:
 

--- a/tests/utils/test_ipaddress.py
+++ b/tests/utils/test_ipaddress.py
@@ -1,4 +1,9 @@
-# Python 2.7 port of Python 3.4's test_ipaddress.
+'''
+Python 2.[67] port of Python 3.4's test_ipaddress.
+
+Almost verbatim copy of core lib w/compatibility fixes
+'''
+# pylint: skip-file
 
 # List of compatibility changes:
 

--- a/tests/utils/test_ipaddress.py
+++ b/tests/utils/test_ipaddress.py
@@ -1,0 +1,1723 @@
+# Python 2.7 port of Python 3.4's test_ipaddress.
+
+# List of compatibility changes:
+
+# This backport uses bytearray instead of bytes, as bytes is the same
+# as str in Python 2.7.
+bytes = bytearray
+# s/\(b'[^']\+'\)/bytearray(\1)/g
+# plus manual fixes for implicit string concatenation.
+
+# Python 3.4 has assertRaisesRegex where Python 2.7 only has assertRaisesRegexp.
+# s/\.assertRaisesRegexp(/.assertRaisesRegexp(/
+
+# Python 2.6 carries assertRaisesRegexp and others in unittest2
+
+# Python 2.6 wants unicode into bytes.fromhex
+# s/bytes.fromhex\("/bytes.fromhex(u"/g
+
+# Further compatibility changes are marked "Compatibility", below.
+
+# ----------------------------------------------------------------------------
+
+
+# Copyright 2007 Google Inc.
+#  Licensed to PSF under a Contributor Agreement.
+
+"""Unittest for ipaddress module."""
+
+
+import re
+import contextlib
+import operator
+import ipaddress
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+class BaseTestCase(unittest.TestCase):
+    # One big change in ipaddress over the original ipaddr module is
+    # error reporting that tries to assume users *don't know the rules*
+    # for what constitutes an RFC compliant IP address
+
+    # Ensuring these errors are emitted correctly in all relevant cases
+    # meant moving to a more systematic test structure that allows the
+    # test structure to map more directly to the module structure
+
+    # Note that if the constructors are refactored so that addresses with
+    # multiple problems get classified differently, that's OK - just
+    # move the affected examples to the newly appropriate test case.
+
+    # There is some duplication between the original relatively ad hoc
+    # test suite and the new systematic tests. While some redundancy in
+    # testing is considered preferable to accidentally deleting a valid
+    # test, the original test suite will likely be reduced over time as
+    # redundant tests are identified.
+
+    @property
+    def factory(self):
+        raise NotImplementedError
+
+    @contextlib.contextmanager
+    def assertCleanError(self, exc_type, details, *args):
+        """
+        Ensure exception does not display a context by default
+
+        Wraps unittest.TestCase.assertRaisesRegex
+        """
+        if args:
+            details = details % args
+        cm = self.assertRaisesRegexp(exc_type, details)
+        with cm as exc:
+            yield exc
+
+        # Compatibility: Python 2.7 does not support exception chaining
+        ## Ensure we produce clean tracebacks on failure
+        #if exc.exception.__context__ is not None:
+        #    self.assertTrue(exc.exception.__suppress_context__)
+
+    def assertAddressError(self, details, *args):
+        """Ensure a clean AddressValueError"""
+        return self.assertCleanError(ipaddress.AddressValueError,
+                                       details, *args)
+
+    def assertNetmaskError(self, details, *args):
+        """Ensure a clean NetmaskValueError"""
+        return self.assertCleanError(ipaddress.NetmaskValueError,
+                                details, *args)
+
+    def assertInstancesEqual(self, lhs, rhs):
+        """Check constructor arguments produce equivalent instances"""
+        self.assertEqual(self.factory(lhs), self.factory(rhs))
+
+
+class CommonTestMixin:
+
+    def test_empty_address(self):
+        with self.assertAddressError("Address cannot be empty"):
+            self.factory("")
+
+    def test_floats_rejected(self):
+        with self.assertAddressError(re.escape(repr("1.0"))):
+            self.factory(1.0)
+
+    def test_not_an_index_issue15559(self):
+        # Implementing __index__ makes for a very nasty interaction with the
+        # bytes constructor. Thus, we disallow implicit use as an integer
+        self.assertRaises(TypeError, operator.index, self.factory(1))
+        self.assertRaises(TypeError, hex, self.factory(1))
+        self.assertRaises(TypeError, bytes, self.factory(1))
+
+
+class CommonTestMixin_v4(CommonTestMixin):
+
+    def test_leading_zeros(self):
+        self.assertInstancesEqual("000.000.000.000", "0.0.0.0")
+        self.assertInstancesEqual("192.168.000.001", "192.168.0.1")
+
+    def test_int(self):
+        self.assertInstancesEqual(0, "0.0.0.0")
+        self.assertInstancesEqual(3232235521, "192.168.0.1")
+
+    def test_packed(self):
+        self.assertInstancesEqual(bytes.fromhex(u"00000000"), "0.0.0.0")
+        self.assertInstancesEqual(bytes.fromhex(u"c0a80001"), "192.168.0.1")
+
+    def test_negative_ints_rejected(self):
+        msg = "-1 (< 0) is not permitted as an IPv4 address"
+        with self.assertAddressError(re.escape(msg)):
+            self.factory(-1)
+
+    def test_large_ints_rejected(self):
+        msg = "%d (>= 2**32) is not permitted as an IPv4 address"
+        with self.assertAddressError(re.escape(msg % 2**32)):
+            self.factory(2**32)
+
+    def test_bad_packed_length(self):
+        def assertBadLength(length):
+            addr = bytes(length)
+            msg = "%r (len %d != 4) is not permitted as an IPv4 address"
+            with self.assertAddressError(re.escape(msg % (addr, length))):
+                self.factory(addr)
+
+        assertBadLength(3)
+        assertBadLength(5)
+
+class CommonTestMixin_v6(CommonTestMixin):
+
+    def test_leading_zeros(self):
+        self.assertInstancesEqual("0000::0000", "::")
+        self.assertInstancesEqual("000::c0a8:0001", "::c0a8:1")
+
+    def test_int(self):
+        self.assertInstancesEqual(0, "::")
+        self.assertInstancesEqual(3232235521, "::c0a8:1")
+
+    def test_packed(self):
+        addr = bytes(12) + bytes.fromhex(u"00000000")
+        self.assertInstancesEqual(addr, "::")
+        addr = bytes(12) + bytes.fromhex(u"c0a80001")
+        self.assertInstancesEqual(addr, "::c0a8:1")
+        addr = bytes.fromhex(u"c0a80001") + bytes(12)
+        self.assertInstancesEqual(addr, "c0a8:1::")
+
+    def test_negative_ints_rejected(self):
+        msg = "-1 (< 0) is not permitted as an IPv6 address"
+        with self.assertAddressError(re.escape(msg)):
+            self.factory(-1)
+
+    def test_large_ints_rejected(self):
+        msg = "%d (>= 2**128) is not permitted as an IPv6 address"
+        with self.assertAddressError(re.escape(msg % 2**128)):
+            self.factory(2**128)
+
+    def test_bad_packed_length(self):
+        def assertBadLength(length):
+            addr = bytes(length)
+            msg = "%r (len %d != 16) is not permitted as an IPv6 address"
+            with self.assertAddressError(re.escape(msg % (addr, length))):
+                self.factory(addr)
+                self.factory(addr)
+
+        assertBadLength(15)
+        assertBadLength(17)
+
+
+class AddressTestCase_v4(BaseTestCase, CommonTestMixin_v4):
+    factory = ipaddress.IPv4Address
+
+    def test_network_passed_as_address(self):
+        addr = "127.0.0.1/24"
+        with self.assertAddressError("Unexpected '/' in %r", addr):
+            ipaddress.IPv4Address(addr)
+
+    def test_bad_address_split(self):
+        def assertBadSplit(addr):
+            with self.assertAddressError("Expected 4 octets in %r", addr):
+                ipaddress.IPv4Address(addr)
+
+        assertBadSplit("127.0.1")
+        assertBadSplit("42.42.42.42.42")
+        assertBadSplit("42.42.42")
+        assertBadSplit("42.42")
+        assertBadSplit("42")
+        assertBadSplit("42..42.42.42")
+        assertBadSplit("42.42.42.42.")
+        assertBadSplit("42.42.42.42...")
+        assertBadSplit(".42.42.42.42")
+        assertBadSplit("...42.42.42.42")
+        assertBadSplit("016.016.016")
+        assertBadSplit("016.016")
+        assertBadSplit("016")
+        assertBadSplit("000")
+        assertBadSplit("0x0a.0x0a.0x0a")
+        assertBadSplit("0x0a.0x0a")
+        assertBadSplit("0x0a")
+        assertBadSplit(".")
+        assertBadSplit("bogus")
+        assertBadSplit("bogus.com")
+        assertBadSplit("1000")
+        assertBadSplit("1000000000000000")
+        assertBadSplit("192.168.0.1.com")
+
+    def test_empty_octet(self):
+        def assertBadOctet(addr):
+            with self.assertAddressError("Empty octet not permitted in %r",
+                                          addr):
+                ipaddress.IPv4Address(addr)
+
+        assertBadOctet("42..42.42")
+        assertBadOctet("...")
+
+    def test_invalid_characters(self):
+        def assertBadOctet(addr, octet):
+            msg = "Only decimal digits permitted in %r in %r" % (octet, addr)
+            with self.assertAddressError(re.escape(msg)):
+                ipaddress.IPv4Address(addr)
+
+        assertBadOctet("0x0a.0x0a.0x0a.0x0a", "0x0a")
+        assertBadOctet("0xa.0x0a.0x0a.0x0a", "0xa")
+        assertBadOctet("42.42.42.-0", "-0")
+        assertBadOctet("42.42.42.+0", "+0")
+        assertBadOctet("42.42.42.-42", "-42")
+        assertBadOctet("+1.+2.+3.4", "+1")
+        assertBadOctet("1.2.3.4e0", "4e0")
+        assertBadOctet("1.2.3.4::", "4::")
+        assertBadOctet("1.a.2.3", "a")
+
+    def test_octal_decimal_ambiguity(self):
+        def assertBadOctet(addr, octet):
+            msg = "Ambiguous (octal/decimal) value in %r not permitted in %r"
+            with self.assertAddressError(re.escape(msg % (octet, addr))):
+                ipaddress.IPv4Address(addr)
+
+        assertBadOctet("016.016.016.016", "016")
+        assertBadOctet("001.000.008.016", "008")
+
+    def test_octet_length(self):
+        def assertBadOctet(addr, octet):
+            msg = "At most 3 characters permitted in %r in %r"
+            with self.assertAddressError(re.escape(msg % (octet, addr))):
+                ipaddress.IPv4Address(addr)
+
+        assertBadOctet("0000.000.000.000", "0000")
+        assertBadOctet("12345.67899.-54321.-98765", "12345")
+
+    def test_octet_limit(self):
+        def assertBadOctet(addr, octet):
+            msg = "Octet %d (> 255) not permitted in %r" % (octet, addr)
+            with self.assertAddressError(re.escape(msg)):
+                ipaddress.IPv4Address(addr)
+
+        assertBadOctet("257.0.0.0", 257)
+        assertBadOctet("192.168.0.999", 999)
+
+
+class AddressTestCase_v6(BaseTestCase, CommonTestMixin_v6):
+    factory = ipaddress.IPv6Address
+
+    def test_network_passed_as_address(self):
+        addr = "::1/24"
+        with self.assertAddressError("Unexpected '/' in %r", addr):
+            ipaddress.IPv6Address(addr)
+
+    def test_bad_address_split_v6_not_enough_parts(self):
+        def assertBadSplit(addr):
+            msg = "At least 3 parts expected in %r"
+            with self.assertAddressError(msg, addr):
+                ipaddress.IPv6Address(addr)
+
+        assertBadSplit(":")
+        assertBadSplit(":1")
+        assertBadSplit("FEDC:9878")
+
+    def test_bad_address_split_v6_too_many_colons(self):
+        def assertBadSplit(addr):
+            msg = "At most 8 colons permitted in %r"
+            with self.assertAddressError(msg, addr):
+                ipaddress.IPv6Address(addr)
+
+        assertBadSplit("9:8:7:6:5:4:3::2:1")
+        assertBadSplit("10:9:8:7:6:5:4:3:2:1")
+        assertBadSplit("::8:7:6:5:4:3:2:1")
+        assertBadSplit("8:7:6:5:4:3:2:1::")
+        # A trailing IPv4 address is two parts
+        assertBadSplit("10:9:8:7:6:5:4:3:42.42.42.42")
+
+    def test_bad_address_split_v6_too_many_parts(self):
+        def assertBadSplit(addr):
+            msg = "Exactly 8 parts expected without '::' in %r"
+            with self.assertAddressError(msg, addr):
+                ipaddress.IPv6Address(addr)
+
+        assertBadSplit("3ffe:0:0:0:0:0:0:0:1")
+        assertBadSplit("9:8:7:6:5:4:3:2:1")
+        assertBadSplit("7:6:5:4:3:2:1")
+        # A trailing IPv4 address is two parts
+        assertBadSplit("9:8:7:6:5:4:3:42.42.42.42")
+        assertBadSplit("7:6:5:4:3:42.42.42.42")
+
+    def test_bad_address_split_v6_too_many_parts_with_double_colon(self):
+        def assertBadSplit(addr):
+            msg = "Expected at most 7 other parts with '::' in %r"
+            with self.assertAddressError(msg, addr):
+                ipaddress.IPv6Address(addr)
+
+        assertBadSplit("1:2:3:4::5:6:7:8")
+
+    def test_bad_address_split_v6_repeated_double_colon(self):
+        def assertBadSplit(addr):
+            msg = "At most one '::' permitted in %r"
+            with self.assertAddressError(msg, addr):
+                ipaddress.IPv6Address(addr)
+
+        assertBadSplit("3ffe::1::1")
+        assertBadSplit("1::2::3::4:5")
+        assertBadSplit("2001::db:::1")
+        assertBadSplit("3ffe::1::")
+        assertBadSplit("::3ffe::1")
+        assertBadSplit(":3ffe::1::1")
+        assertBadSplit("3ffe::1::1:")
+        assertBadSplit(":3ffe::1::1:")
+        assertBadSplit(":::")
+        assertBadSplit('2001:db8:::1')
+
+    def test_bad_address_split_v6_leading_colon(self):
+        def assertBadSplit(addr):
+            msg = "Leading ':' only permitted as part of '::' in %r"
+            with self.assertAddressError(msg, addr):
+                ipaddress.IPv6Address(addr)
+
+        assertBadSplit(":2001:db8::1")
+        assertBadSplit(":1:2:3:4:5:6:7")
+        assertBadSplit(":1:2:3:4:5:6:")
+        assertBadSplit(":6:5:4:3:2:1::")
+
+    def test_bad_address_split_v6_trailing_colon(self):
+        def assertBadSplit(addr):
+            msg = "Trailing ':' only permitted as part of '::' in %r"
+            with self.assertAddressError(msg, addr):
+                ipaddress.IPv6Address(addr)
+
+        assertBadSplit("2001:db8::1:")
+        assertBadSplit("1:2:3:4:5:6:7:")
+        assertBadSplit("::1.2.3.4:")
+        assertBadSplit("::7:6:5:4:3:2:")
+
+    def test_bad_v4_part_in(self):
+        def assertBadAddressPart(addr, v4_error):
+            with self.assertAddressError("%s in %r", v4_error, addr):
+                ipaddress.IPv6Address(addr)
+
+        assertBadAddressPart("3ffe::1.net", "Expected 4 octets in '1.net'")
+        assertBadAddressPart("3ffe::127.0.1",
+                             "Expected 4 octets in '127.0.1'")
+        assertBadAddressPart("::1.2.3",
+                             "Expected 4 octets in '1.2.3'")
+        assertBadAddressPart("::1.2.3.4.5",
+                             "Expected 4 octets in '1.2.3.4.5'")
+        assertBadAddressPart("3ffe::1.1.1.net",
+                             "Only decimal digits permitted in 'net' "
+                             "in '1.1.1.net'")
+
+    def test_invalid_characters(self):
+        def assertBadPart(addr, part):
+            msg = "Only hex digits permitted in %r in %r" % (part, addr)
+            with self.assertAddressError(re.escape(msg)):
+                ipaddress.IPv6Address(addr)
+
+        assertBadPart("3ffe::goog", "goog")
+        assertBadPart("3ffe::-0", "-0")
+        assertBadPart("3ffe::+0", "+0")
+        assertBadPart("3ffe::-1", "-1")
+        assertBadPart("1.2.3.4::", "1.2.3.4")
+        assertBadPart('1234:axy::b', "axy")
+
+    def test_part_length(self):
+        def assertBadPart(addr, part):
+            msg = "At most 4 characters permitted in %r in %r"
+            with self.assertAddressError(msg, part, addr):
+                ipaddress.IPv6Address(addr)
+
+        assertBadPart("::00000", "00000")
+        assertBadPart("3ffe::10000", "10000")
+        assertBadPart("02001:db8::", "02001")
+        assertBadPart('2001:888888::1', "888888")
+
+
+class NetmaskTestMixin_v4(CommonTestMixin_v4):
+    """Input validation on interfaces and networks is very similar"""
+
+    def test_split_netmask(self):
+        addr = "1.2.3.4/32/24"
+        with self.assertAddressError("Only one '/' permitted in %r" % addr):
+            self.factory(addr)
+
+    def test_address_errors(self):
+        def assertBadAddress(addr, details):
+            with self.assertAddressError(details):
+                self.factory(addr)
+
+        assertBadAddress("/", "Address cannot be empty")
+        assertBadAddress("/8", "Address cannot be empty")
+        assertBadAddress("bogus", "Expected 4 octets")
+        assertBadAddress("google.com", "Expected 4 octets")
+        assertBadAddress("10/8", "Expected 4 octets")
+        assertBadAddress("::1.2.3.4", "Only decimal digits")
+        assertBadAddress("1.2.3.256", re.escape("256 (> 255)"))
+
+    def test_valid_netmask(self):
+        self.assertEqual(str(self.factory('192.0.2.0/255.255.255.0')),
+                         '192.0.2.0/24')
+        for i in range(0, 33):
+            # Generate and re-parse the CIDR format (trivial).
+            net_str = '0.0.0.0/%d' % i
+            net = self.factory(net_str)
+            self.assertEqual(str(net), net_str)
+            # Generate and re-parse the expanded netmask.
+            self.assertEqual(
+                str(self.factory('0.0.0.0/%s' % net.netmask)), net_str)
+            # Zero prefix is treated as decimal.
+            self.assertEqual(str(self.factory('0.0.0.0/0%d' % i)), net_str)
+            # Generate and re-parse the expanded hostmask.  The ambiguous
+            # cases (/0 and /32) are treated as netmasks.
+            if i in (32, 0):
+                net_str = '0.0.0.0/%d' % (32 - i)
+            self.assertEqual(
+                str(self.factory('0.0.0.0/%s' % net.hostmask)), net_str)
+
+    def test_netmask_errors(self):
+        def assertBadNetmask(addr, netmask):
+            msg = "%r is not a valid netmask" % netmask
+            with self.assertNetmaskError(re.escape(msg)):
+                self.factory("%s/%s" % (addr, netmask))
+
+        assertBadNetmask("1.2.3.4", "")
+        assertBadNetmask("1.2.3.4", "-1")
+        assertBadNetmask("1.2.3.4", "+1")
+        assertBadNetmask("1.2.3.4", " 1 ")
+        assertBadNetmask("1.2.3.4", "0x1")
+        assertBadNetmask("1.2.3.4", "33")
+        assertBadNetmask("1.2.3.4", "254.254.255.256")
+        assertBadNetmask("1.2.3.4", "1.a.2.3")
+        assertBadNetmask("1.1.1.1", "254.xyz.2.3")
+        assertBadNetmask("1.1.1.1", "240.255.0.0")
+        assertBadNetmask("1.1.1.1", "255.254.128.0")
+        assertBadNetmask("1.1.1.1", "0.1.127.255")
+        assertBadNetmask("1.1.1.1", "pudding")
+        assertBadNetmask("1.1.1.1", "::")
+
+
+class InterfaceTestCase_v4(BaseTestCase, NetmaskTestMixin_v4):
+    factory = ipaddress.IPv4Interface
+
+class NetworkTestCase_v4(BaseTestCase, NetmaskTestMixin_v4):
+    factory = ipaddress.IPv4Network
+
+
+class NetmaskTestMixin_v6(CommonTestMixin_v6):
+    """Input validation on interfaces and networks is very similar"""
+
+    def test_split_netmask(self):
+        addr = "cafe:cafe::/128/190"
+        with self.assertAddressError("Only one '/' permitted in %r" % addr):
+            self.factory(addr)
+
+    def test_address_errors(self):
+        def assertBadAddress(addr, details):
+            with self.assertAddressError(details):
+                self.factory(addr)
+
+        assertBadAddress("/", "Address cannot be empty")
+        assertBadAddress("/8", "Address cannot be empty")
+        assertBadAddress("google.com", "At least 3 parts")
+        assertBadAddress("1.2.3.4", "At least 3 parts")
+        assertBadAddress("10/8", "At least 3 parts")
+        assertBadAddress("1234:axy::b", "Only hex digits")
+
+    def test_valid_netmask(self):
+        # We only support CIDR for IPv6, because expanded netmasks are not
+        # standard notation.
+        self.assertEqual(str(self.factory('2001:db8::/32')), '2001:db8::/32')
+        for i in range(0, 129):
+            # Generate and re-parse the CIDR format (trivial).
+            net_str = '::/%d' % i
+            self.assertEqual(str(self.factory(net_str)), net_str)
+            # Zero prefix is treated as decimal.
+            self.assertEqual(str(self.factory('::/0%d' % i)), net_str)
+
+    def test_netmask_errors(self):
+        def assertBadNetmask(addr, netmask):
+            msg = "%r is not a valid netmask" % netmask
+            with self.assertNetmaskError(re.escape(msg)):
+                self.factory("%s/%s" % (addr, netmask))
+
+        assertBadNetmask("::1", "")
+        assertBadNetmask("::1", "::1")
+        assertBadNetmask("::1", "1::")
+        assertBadNetmask("::1", "-1")
+        assertBadNetmask("::1", "+1")
+        assertBadNetmask("::1", " 1 ")
+        assertBadNetmask("::1", "0x1")
+        assertBadNetmask("::1", "129")
+        assertBadNetmask("::1", "1.2.3.4")
+        assertBadNetmask("::1", "pudding")
+        assertBadNetmask("::", "::")
+
+class InterfaceTestCase_v6(BaseTestCase, NetmaskTestMixin_v6):
+    factory = ipaddress.IPv6Interface
+
+class NetworkTestCase_v6(BaseTestCase, NetmaskTestMixin_v6):
+    factory = ipaddress.IPv6Network
+
+
+class FactoryFunctionErrors(BaseTestCase):
+
+    def assertFactoryError(self, factory, kind):
+        """Ensure a clean ValueError with the expected message"""
+        addr = "camelot"
+        msg = '%r does not appear to be an IPv4 or IPv6 %s'
+        with self.assertCleanError(ValueError, msg, addr, kind):
+            factory(addr)
+
+    def test_ip_address(self):
+        self.assertFactoryError(ipaddress.ip_address, "address")
+
+    def test_ip_interface(self):
+        self.assertFactoryError(ipaddress.ip_interface, "interface")
+
+    def test_ip_network(self):
+        self.assertFactoryError(ipaddress.ip_network, "network")
+
+
+class ComparisonTests(unittest.TestCase):
+
+    v4addr = ipaddress.IPv4Address(1)
+    v4net = ipaddress.IPv4Network(1)
+    v4intf = ipaddress.IPv4Interface(1)
+    v6addr = ipaddress.IPv6Address(1)
+    v6net = ipaddress.IPv6Network(1)
+    v6intf = ipaddress.IPv6Interface(1)
+
+    v4_addresses = [v4addr, v4intf]
+    v4_objects = v4_addresses + [v4net]
+    v6_addresses = [v6addr, v6intf]
+    v6_objects = v6_addresses + [v6net]
+    objects = v4_objects + v6_objects
+
+    def test_foreign_type_equality(self):
+        # __eq__ should never raise TypeError directly
+        other = object()
+        for obj in self.objects:
+            self.assertNotEqual(obj, other)
+            self.assertFalse(obj == other)
+            self.assertEqual(obj.__eq__(other), NotImplemented)
+            self.assertEqual(obj.__ne__(other), NotImplemented)
+
+    def test_mixed_type_equality(self):
+        # Ensure none of the internal objects accidentally
+        # expose the right set of attributes to become "equal"
+        for lhs in self.objects:
+            for rhs in self.objects:
+                if lhs is rhs:
+                    continue
+                self.assertNotEqual(lhs, rhs)
+
+    def test_containment(self):
+        for obj in self.v4_addresses:
+            self.assertIn(obj, self.v4net)
+        for obj in self.v6_addresses:
+            self.assertIn(obj, self.v6net)
+        for obj in self.v4_objects + [self.v6net]:
+            self.assertNotIn(obj, self.v6net)
+        for obj in self.v6_objects + [self.v4net]:
+            self.assertNotIn(obj, self.v4net)
+
+    def test_mixed_type_ordering(self):
+        for lhs in self.objects:
+            for rhs in self.objects:
+                if isinstance(lhs, type(rhs)) or isinstance(rhs, type(lhs)):
+                    continue
+                self.assertRaises(TypeError, lambda: lhs < rhs)
+                self.assertRaises(TypeError, lambda: lhs > rhs)
+                self.assertRaises(TypeError, lambda: lhs <= rhs)
+                self.assertRaises(TypeError, lambda: lhs >= rhs)
+
+    def test_mixed_type_key(self):
+        # with get_mixed_type_key, you can sort addresses and network.
+        v4_ordered = [self.v4addr, self.v4net, self.v4intf]
+        v6_ordered = [self.v6addr, self.v6net, self.v6intf]
+        self.assertEqual(v4_ordered,
+                         sorted(self.v4_objects,
+                                key=ipaddress.get_mixed_type_key))
+        self.assertEqual(v6_ordered,
+                         sorted(self.v6_objects,
+                                key=ipaddress.get_mixed_type_key))
+        self.assertEqual(v4_ordered + v6_ordered,
+                         sorted(self.objects,
+                                key=ipaddress.get_mixed_type_key))
+        self.assertEqual(NotImplemented, ipaddress.get_mixed_type_key(object))
+
+    def test_incompatible_versions(self):
+        # These should always raise TypeError
+        v4addr = ipaddress.ip_address('1.1.1.1')
+        v4net = ipaddress.ip_network('1.1.1.1')
+        v6addr = ipaddress.ip_address('::1')
+        v6net = ipaddress.ip_address('::1')
+
+        self.assertRaises(TypeError, v4addr.__lt__, v6addr)
+        self.assertRaises(TypeError, v4addr.__gt__, v6addr)
+        self.assertRaises(TypeError, v4net.__lt__, v6net)
+        self.assertRaises(TypeError, v4net.__gt__, v6net)
+
+        self.assertRaises(TypeError, v6addr.__lt__, v4addr)
+        self.assertRaises(TypeError, v6addr.__gt__, v4addr)
+        self.assertRaises(TypeError, v6net.__lt__, v4net)
+        self.assertRaises(TypeError, v6net.__gt__, v4net)
+
+
+
+class IpaddrUnitTest(unittest.TestCase):
+
+    def setUp(self):
+        self.ipv4_address = ipaddress.IPv4Address('1.2.3.4')
+        self.ipv4_interface = ipaddress.IPv4Interface('1.2.3.4/24')
+        self.ipv4_network = ipaddress.IPv4Network('1.2.3.0/24')
+        #self.ipv4_hostmask = ipaddress.IPv4Interface('10.0.0.1/0.255.255.255')
+        self.ipv6_address = ipaddress.IPv6Interface(
+            '2001:658:22a:cafe:200:0:0:1')
+        self.ipv6_interface = ipaddress.IPv6Interface(
+            '2001:658:22a:cafe:200:0:0:1/64')
+        self.ipv6_network = ipaddress.IPv6Network('2001:658:22a:cafe::/64')
+
+    def testRepr(self):
+        self.assertEqual("IPv4Interface('1.2.3.4/32')",
+                         repr(ipaddress.IPv4Interface('1.2.3.4')))
+        self.assertEqual("IPv6Interface('::1/128')",
+                         repr(ipaddress.IPv6Interface('::1')))
+
+    # issue57
+    def testAddressIntMath(self):
+        self.assertEqual(ipaddress.IPv4Address('1.1.1.1') + 255,
+                         ipaddress.IPv4Address('1.1.2.0'))
+        self.assertEqual(ipaddress.IPv4Address('1.1.1.1') - 256,
+                         ipaddress.IPv4Address('1.1.0.1'))
+        self.assertEqual(ipaddress.IPv6Address('::1') + (2**16 - 2),
+                         ipaddress.IPv6Address('::ffff'))
+        self.assertEqual(ipaddress.IPv6Address('::ffff') - (2**16 - 2),
+                         ipaddress.IPv6Address('::1'))
+
+    def testInvalidIntToBytes(self):
+        self.assertRaises(ValueError, ipaddress.v4_int_to_packed, -1)
+        self.assertRaises(ValueError, ipaddress.v4_int_to_packed,
+                          2 ** ipaddress.IPV4LENGTH)
+        self.assertRaises(ValueError, ipaddress.v6_int_to_packed, -1)
+        self.assertRaises(ValueError, ipaddress.v6_int_to_packed,
+                          2 ** ipaddress.IPV6LENGTH)
+
+    def testInternals(self):
+        first, last = ipaddress._find_address_range([
+            ipaddress.IPv4Address('10.10.10.10'),
+            ipaddress.IPv4Address('10.10.10.12')])
+        self.assertEqual(first, last)
+        self.assertEqual(128, ipaddress._count_righthand_zero_bits(0, 128))
+        self.assertEqual("IPv4Network('1.2.3.0/24')", repr(self.ipv4_network))
+
+    def testMissingAddressVersion(self):
+        class Broken(ipaddress._BaseAddress):
+            pass
+        broken = Broken('127.0.0.1')
+        with self.assertRaisesRegexp(NotImplementedError, "Broken.*version"):
+            broken.version
+
+    def testMissingNetworkVersion(self):
+        class Broken(ipaddress._BaseNetwork):
+            pass
+        broken = Broken('127.0.0.1')
+        with self.assertRaisesRegexp(NotImplementedError, "Broken.*version"):
+            broken.version
+
+    def testMissingAddressClass(self):
+        class Broken(ipaddress._BaseNetwork):
+            pass
+        broken = Broken('127.0.0.1')
+        with self.assertRaisesRegexp(NotImplementedError, "Broken.*address"):
+            broken._address_class
+
+    def testGetNetwork(self):
+        self.assertEqual(int(self.ipv4_network.network_address), 16909056)
+        self.assertEqual(str(self.ipv4_network.network_address), '1.2.3.0')
+
+        self.assertEqual(int(self.ipv6_network.network_address),
+                         42540616829182469433403647294022090752)
+        self.assertEqual(str(self.ipv6_network.network_address),
+                         '2001:658:22a:cafe::')
+        self.assertEqual(str(self.ipv6_network.hostmask),
+                         '::ffff:ffff:ffff:ffff')
+
+    def testIpFromInt(self):
+        self.assertEqual(self.ipv4_interface._ip,
+                         ipaddress.IPv4Interface(16909060)._ip)
+
+        ipv4 = ipaddress.ip_network('1.2.3.4')
+        ipv6 = ipaddress.ip_network('2001:658:22a:cafe:200:0:0:1')
+        self.assertEqual(ipv4, ipaddress.ip_network(int(ipv4.network_address)))
+        self.assertEqual(ipv6, ipaddress.ip_network(int(ipv6.network_address)))
+
+        v6_int = 42540616829182469433547762482097946625
+        self.assertEqual(self.ipv6_interface._ip,
+                         ipaddress.IPv6Interface(v6_int)._ip)
+
+        self.assertEqual(ipaddress.ip_network(self.ipv4_address._ip).version,
+                         4)
+        self.assertEqual(ipaddress.ip_network(self.ipv6_address._ip).version,
+                         6)
+
+    def testIpFromPacked(self):
+        address = ipaddress.ip_address
+        self.assertEqual(self.ipv4_interface._ip,
+                         ipaddress.ip_interface(bytearray(b'\x01\x02\x03\x04'))._ip)
+        self.assertEqual(address('255.254.253.252'),
+                         address(bytearray(b'\xff\xfe\xfd\xfc')))
+        self.assertEqual(self.ipv6_interface.ip,
+                         ipaddress.ip_interface(
+                    bytearray(b'\x20\x01\x06\x58\x02\x2a\xca\xfe'
+                    b'\x02\x00\x00\x00\x00\x00\x00\x01')).ip)
+        self.assertEqual(address('ffff:2:3:4:ffff::'),
+                         address(bytearray(b'\xff\xff\x00\x02\x00\x03\x00\x04') +
+                            bytearray(b'\xff\xff') + bytearray(b'\x00') * 6))
+        self.assertEqual(address('::'),
+                         address(bytearray(b'\x00') * 16))
+
+    def testGetIp(self):
+        self.assertEqual(int(self.ipv4_interface.ip), 16909060)
+        self.assertEqual(str(self.ipv4_interface.ip), '1.2.3.4')
+
+        self.assertEqual(int(self.ipv6_interface.ip),
+                         42540616829182469433547762482097946625)
+        self.assertEqual(str(self.ipv6_interface.ip),
+                         '2001:658:22a:cafe:200::1')
+
+    def testGetNetmask(self):
+        self.assertEqual(int(self.ipv4_network.netmask), 4294967040)
+        self.assertEqual(str(self.ipv4_network.netmask), '255.255.255.0')
+        self.assertEqual(int(self.ipv6_network.netmask),
+                         340282366920938463444927863358058659840)
+        self.assertEqual(self.ipv6_network.prefixlen, 64)
+
+    def testZeroNetmask(self):
+        ipv4_zero_netmask = ipaddress.IPv4Interface('1.2.3.4/0')
+        self.assertEqual(int(ipv4_zero_netmask.network.netmask), 0)
+        self.assertEqual(ipv4_zero_netmask._prefix_from_prefix_string('0'), 0)
+        self.assertTrue(ipv4_zero_netmask._is_valid_netmask('0'))
+        self.assertTrue(ipv4_zero_netmask._is_valid_netmask('0.0.0.0'))
+        self.assertFalse(ipv4_zero_netmask._is_valid_netmask('invalid'))
+
+        ipv6_zero_netmask = ipaddress.IPv6Interface('::1/0')
+        self.assertEqual(int(ipv6_zero_netmask.network.netmask), 0)
+        self.assertEqual(ipv6_zero_netmask._prefix_from_prefix_string('0'), 0)
+
+    def testIPv4NetAndHostmasks(self):
+        net = self.ipv4_network
+        self.assertFalse(net._is_valid_netmask('invalid'))
+        self.assertTrue(net._is_valid_netmask('128.128.128.128'))
+        self.assertFalse(net._is_valid_netmask('128.128.128.127'))
+        self.assertFalse(net._is_valid_netmask('128.128.128.255'))
+        self.assertTrue(net._is_valid_netmask('255.128.128.128'))
+
+        self.assertFalse(net._is_hostmask('invalid'))
+        self.assertTrue(net._is_hostmask('128.255.255.255'))
+        self.assertFalse(net._is_hostmask('255.255.255.255'))
+        self.assertFalse(net._is_hostmask('1.2.3.4'))
+
+        net = ipaddress.IPv4Network('127.0.0.0/0.0.0.255')
+        self.assertEqual(net.prefixlen, 24)
+
+    def testGetBroadcast(self):
+        self.assertEqual(int(self.ipv4_network.broadcast_address), 16909311)
+        self.assertEqual(str(self.ipv4_network.broadcast_address), '1.2.3.255')
+
+        self.assertEqual(int(self.ipv6_network.broadcast_address),
+                         42540616829182469451850391367731642367)
+        self.assertEqual(str(self.ipv6_network.broadcast_address),
+                         '2001:658:22a:cafe:ffff:ffff:ffff:ffff')
+
+    def testGetPrefixlen(self):
+        self.assertEqual(self.ipv4_interface.network.prefixlen, 24)
+        self.assertEqual(self.ipv6_interface.network.prefixlen, 64)
+
+    def testGetSupernet(self):
+        self.assertEqual(self.ipv4_network.supernet().prefixlen, 23)
+        self.assertEqual(str(self.ipv4_network.supernet().network_address),
+                         '1.2.2.0')
+        self.assertEqual(
+            ipaddress.IPv4Interface('0.0.0.0/0').network.supernet(),
+            ipaddress.IPv4Network('0.0.0.0/0'))
+
+        self.assertEqual(self.ipv6_network.supernet().prefixlen, 63)
+        self.assertEqual(str(self.ipv6_network.supernet().network_address),
+                         '2001:658:22a:cafe::')
+        self.assertEqual(ipaddress.IPv6Interface('::0/0').network.supernet(),
+                         ipaddress.IPv6Network('::0/0'))
+
+    def testGetSupernet3(self):
+        self.assertEqual(self.ipv4_network.supernet(3).prefixlen, 21)
+        self.assertEqual(str(self.ipv4_network.supernet(3).network_address),
+                         '1.2.0.0')
+
+        self.assertEqual(self.ipv6_network.supernet(3).prefixlen, 61)
+        self.assertEqual(str(self.ipv6_network.supernet(3).network_address),
+                         '2001:658:22a:caf8::')
+
+    def testGetSupernet4(self):
+        self.assertRaises(ValueError, self.ipv4_network.supernet,
+                          prefixlen_diff=2, new_prefix=1)
+        self.assertRaises(ValueError, self.ipv4_network.supernet,
+                          new_prefix=25)
+        self.assertEqual(self.ipv4_network.supernet(prefixlen_diff=2),
+                         self.ipv4_network.supernet(new_prefix=22))
+
+        self.assertRaises(ValueError, self.ipv6_network.supernet,
+                          prefixlen_diff=2, new_prefix=1)
+        self.assertRaises(ValueError, self.ipv6_network.supernet,
+                          new_prefix=65)
+        self.assertEqual(self.ipv6_network.supernet(prefixlen_diff=2),
+                         self.ipv6_network.supernet(new_prefix=62))
+
+    def testHosts(self):
+        hosts = list(self.ipv4_network.hosts())
+        self.assertEqual(254, len(hosts))
+        self.assertEqual(ipaddress.IPv4Address('1.2.3.1'), hosts[0])
+        self.assertEqual(ipaddress.IPv4Address('1.2.3.254'), hosts[-1])
+
+        # special case where only 1 bit is left for address
+        self.assertEqual([ipaddress.IPv4Address('2.0.0.0'),
+                          ipaddress.IPv4Address('2.0.0.1')],
+                         list(ipaddress.ip_network('2.0.0.0/31').hosts()))
+
+    def testFancySubnetting(self):
+        self.assertEqual(sorted(self.ipv4_network.subnets(prefixlen_diff=3)),
+                         sorted(self.ipv4_network.subnets(new_prefix=27)))
+        self.assertRaises(ValueError, list,
+                          self.ipv4_network.subnets(new_prefix=23))
+        self.assertRaises(ValueError, list,
+                          self.ipv4_network.subnets(prefixlen_diff=3,
+                                                   new_prefix=27))
+        self.assertEqual(sorted(self.ipv6_network.subnets(prefixlen_diff=4)),
+                         sorted(self.ipv6_network.subnets(new_prefix=68)))
+        self.assertRaises(ValueError, list,
+                          self.ipv6_network.subnets(new_prefix=63))
+        self.assertRaises(ValueError, list,
+                          self.ipv6_network.subnets(prefixlen_diff=4,
+                                                   new_prefix=68))
+
+    def testGetSubnets(self):
+        self.assertEqual(list(self.ipv4_network.subnets())[0].prefixlen, 25)
+        self.assertEqual(str(list(
+                    self.ipv4_network.subnets())[0].network_address),
+                         '1.2.3.0')
+        self.assertEqual(str(list(
+                    self.ipv4_network.subnets())[1].network_address),
+                         '1.2.3.128')
+
+        self.assertEqual(list(self.ipv6_network.subnets())[0].prefixlen, 65)
+
+    def testGetSubnetForSingle32(self):
+        ip = ipaddress.IPv4Network('1.2.3.4/32')
+        subnets1 = [str(x) for x in ip.subnets()]
+        subnets2 = [str(x) for x in ip.subnets(2)]
+        self.assertEqual(subnets1, ['1.2.3.4/32'])
+        self.assertEqual(subnets1, subnets2)
+
+    def testGetSubnetForSingle128(self):
+        ip = ipaddress.IPv6Network('::1/128')
+        subnets1 = [str(x) for x in ip.subnets()]
+        subnets2 = [str(x) for x in ip.subnets(2)]
+        self.assertEqual(subnets1, ['::1/128'])
+        self.assertEqual(subnets1, subnets2)
+
+    def testSubnet2(self):
+        ips = [str(x) for x in self.ipv4_network.subnets(2)]
+        self.assertEqual(
+            ips,
+            ['1.2.3.0/26', '1.2.3.64/26', '1.2.3.128/26', '1.2.3.192/26'])
+
+        ipsv6 = [str(x) for x in self.ipv6_network.subnets(2)]
+        self.assertEqual(
+            ipsv6,
+            ['2001:658:22a:cafe::/66',
+             '2001:658:22a:cafe:4000::/66',
+             '2001:658:22a:cafe:8000::/66',
+             '2001:658:22a:cafe:c000::/66'])
+
+    def testSubnetFailsForLargeCidrDiff(self):
+        self.assertRaises(ValueError, list,
+                          self.ipv4_interface.network.subnets(9))
+        self.assertRaises(ValueError, list,
+                          self.ipv4_network.subnets(9))
+        self.assertRaises(ValueError, list,
+                          self.ipv6_interface.network.subnets(65))
+        self.assertRaises(ValueError, list,
+                          self.ipv6_network.subnets(65))
+
+    def testSupernetFailsForLargeCidrDiff(self):
+        self.assertRaises(ValueError,
+                          self.ipv4_interface.network.supernet, 25)
+        self.assertRaises(ValueError,
+                          self.ipv6_interface.network.supernet, 65)
+
+    def testSubnetFailsForNegativeCidrDiff(self):
+        self.assertRaises(ValueError, list,
+                          self.ipv4_interface.network.subnets(-1))
+        self.assertRaises(ValueError, list,
+                          self.ipv4_network.subnets(-1))
+        self.assertRaises(ValueError, list,
+                          self.ipv6_interface.network.subnets(-1))
+        self.assertRaises(ValueError, list,
+                          self.ipv6_network.subnets(-1))
+
+    def testGetNum_Addresses(self):
+        self.assertEqual(self.ipv4_network.num_addresses, 256)
+        self.assertEqual(list(self.ipv4_network.subnets())[0].num_addresses,
+                         128)
+        self.assertEqual(self.ipv4_network.supernet().num_addresses, 512)
+
+        self.assertEqual(self.ipv6_network.num_addresses, 18446744073709551616)
+        self.assertEqual(list(self.ipv6_network.subnets())[0].num_addresses,
+                         9223372036854775808)
+        self.assertEqual(self.ipv6_network.supernet().num_addresses,
+                         36893488147419103232)
+
+    def testContains(self):
+        self.assertIn(ipaddress.IPv4Interface('1.2.3.128/25'),
+                      self.ipv4_network)
+        self.assertNotIn(ipaddress.IPv4Interface('1.2.4.1/24'),
+                         self.ipv4_network)
+        # We can test addresses and string as well.
+        addr1 = ipaddress.IPv4Address('1.2.3.37')
+        self.assertIn(addr1, self.ipv4_network)
+        # issue 61, bad network comparison on like-ip'd network objects
+        # with identical broadcast addresses.
+        self.assertFalse(ipaddress.IPv4Network('1.1.0.0/16').__contains__(
+                ipaddress.IPv4Network('1.0.0.0/15')))
+
+    def testNth(self):
+        self.assertEqual(str(self.ipv4_network[5]), '1.2.3.5')
+        self.assertRaises(IndexError, self.ipv4_network.__getitem__, 256)
+
+        self.assertEqual(str(self.ipv6_network[5]),
+                         '2001:658:22a:cafe::5')
+
+    def testGetitem(self):
+        # http://code.google.com/p/ipaddr-py/issues/detail?id=15
+        addr = ipaddress.IPv4Network('172.31.255.128/255.255.255.240')
+        self.assertEqual(28, addr.prefixlen)
+        addr_list = list(addr)
+        self.assertEqual('172.31.255.128', str(addr_list[0]))
+        self.assertEqual('172.31.255.128', str(addr[0]))
+        self.assertEqual('172.31.255.143', str(addr_list[-1]))
+        self.assertEqual('172.31.255.143', str(addr[-1]))
+        self.assertEqual(addr_list[-1], addr[-1])
+
+    def testEqual(self):
+        self.assertTrue(self.ipv4_interface ==
+                        ipaddress.IPv4Interface('1.2.3.4/24'))
+        self.assertFalse(self.ipv4_interface ==
+                         ipaddress.IPv4Interface('1.2.3.4/23'))
+        self.assertFalse(self.ipv4_interface ==
+                         ipaddress.IPv6Interface('::1.2.3.4/24'))
+        self.assertFalse(self.ipv4_interface == '')
+        self.assertFalse(self.ipv4_interface == [])
+        self.assertFalse(self.ipv4_interface == 2)
+
+        self.assertTrue(self.ipv6_interface ==
+            ipaddress.IPv6Interface('2001:658:22a:cafe:200::1/64'))
+        self.assertFalse(self.ipv6_interface ==
+            ipaddress.IPv6Interface('2001:658:22a:cafe:200::1/63'))
+        self.assertFalse(self.ipv6_interface ==
+                         ipaddress.IPv4Interface('1.2.3.4/23'))
+        self.assertFalse(self.ipv6_interface == '')
+        self.assertFalse(self.ipv6_interface == [])
+        self.assertFalse(self.ipv6_interface == 2)
+
+    def testNotEqual(self):
+        self.assertFalse(self.ipv4_interface !=
+                         ipaddress.IPv4Interface('1.2.3.4/24'))
+        self.assertTrue(self.ipv4_interface !=
+                        ipaddress.IPv4Interface('1.2.3.4/23'))
+        self.assertTrue(self.ipv4_interface !=
+                        ipaddress.IPv6Interface('::1.2.3.4/24'))
+        self.assertTrue(self.ipv4_interface != '')
+        self.assertTrue(self.ipv4_interface != [])
+        self.assertTrue(self.ipv4_interface != 2)
+
+        self.assertTrue(self.ipv4_address !=
+                         ipaddress.IPv4Address('1.2.3.5'))
+        self.assertTrue(self.ipv4_address != '')
+        self.assertTrue(self.ipv4_address != [])
+        self.assertTrue(self.ipv4_address != 2)
+
+        self.assertFalse(self.ipv6_interface !=
+            ipaddress.IPv6Interface('2001:658:22a:cafe:200::1/64'))
+        self.assertTrue(self.ipv6_interface !=
+            ipaddress.IPv6Interface('2001:658:22a:cafe:200::1/63'))
+        self.assertTrue(self.ipv6_interface !=
+                        ipaddress.IPv4Interface('1.2.3.4/23'))
+        self.assertTrue(self.ipv6_interface != '')
+        self.assertTrue(self.ipv6_interface != [])
+        self.assertTrue(self.ipv6_interface != 2)
+
+        self.assertTrue(self.ipv6_address !=
+                        ipaddress.IPv4Address('1.2.3.4'))
+        self.assertTrue(self.ipv6_address != '')
+        self.assertTrue(self.ipv6_address != [])
+        self.assertTrue(self.ipv6_address != 2)
+
+    def testSlash32Constructor(self):
+        self.assertEqual(str(ipaddress.IPv4Interface(
+                    '1.2.3.4/255.255.255.255')), '1.2.3.4/32')
+
+    def testSlash128Constructor(self):
+        self.assertEqual(str(ipaddress.IPv6Interface('::1/128')),
+                                  '::1/128')
+
+    def testSlash0Constructor(self):
+        self.assertEqual(str(ipaddress.IPv4Interface('1.2.3.4/0.0.0.0')),
+                          '1.2.3.4/0')
+
+    def testCollapsing(self):
+        # test only IP addresses including some duplicates
+        ip1 = ipaddress.IPv4Address('1.1.1.0')
+        ip2 = ipaddress.IPv4Address('1.1.1.1')
+        ip3 = ipaddress.IPv4Address('1.1.1.2')
+        ip4 = ipaddress.IPv4Address('1.1.1.3')
+        ip5 = ipaddress.IPv4Address('1.1.1.4')
+        ip6 = ipaddress.IPv4Address('1.1.1.0')
+        # check that addreses are subsumed properly.
+        collapsed = ipaddress.collapse_addresses(
+            [ip1, ip2, ip3, ip4, ip5, ip6])
+        self.assertEqual(list(collapsed),
+                [ipaddress.IPv4Network('1.1.1.0/30'),
+                 ipaddress.IPv4Network('1.1.1.4/32')])
+
+        # test a mix of IP addresses and networks including some duplicates
+        ip1 = ipaddress.IPv4Address('1.1.1.0')
+        ip2 = ipaddress.IPv4Address('1.1.1.1')
+        ip3 = ipaddress.IPv4Address('1.1.1.2')
+        ip4 = ipaddress.IPv4Address('1.1.1.3')
+        #ip5 = ipaddress.IPv4Interface('1.1.1.4/30')
+        #ip6 = ipaddress.IPv4Interface('1.1.1.4/30')
+        # check that addreses are subsumed properly.
+        collapsed = ipaddress.collapse_addresses([ip1, ip2, ip3, ip4])
+        self.assertEqual(list(collapsed),
+                         [ipaddress.IPv4Network('1.1.1.0/30')])
+
+        # test only IP networks
+        ip1 = ipaddress.IPv4Network('1.1.0.0/24')
+        ip2 = ipaddress.IPv4Network('1.1.1.0/24')
+        ip3 = ipaddress.IPv4Network('1.1.2.0/24')
+        ip4 = ipaddress.IPv4Network('1.1.3.0/24')
+        ip5 = ipaddress.IPv4Network('1.1.4.0/24')
+        # stored in no particular order b/c we want CollapseAddr to call
+        # [].sort
+        ip6 = ipaddress.IPv4Network('1.1.0.0/22')
+        # check that addreses are subsumed properly.
+        collapsed = ipaddress.collapse_addresses([ip1, ip2, ip3, ip4, ip5,
+                                                     ip6])
+        self.assertEqual(list(collapsed),
+                         [ipaddress.IPv4Network('1.1.0.0/22'),
+                          ipaddress.IPv4Network('1.1.4.0/24')])
+
+        # test that two addresses are supernet'ed properly
+        collapsed = ipaddress.collapse_addresses([ip1, ip2])
+        self.assertEqual(list(collapsed),
+                         [ipaddress.IPv4Network('1.1.0.0/23')])
+
+        # test same IP networks
+        ip_same1 = ip_same2 = ipaddress.IPv4Network('1.1.1.1/32')
+        self.assertEqual(list(ipaddress.collapse_addresses(
+                    [ip_same1, ip_same2])),
+                         [ip_same1])
+
+        # test same IP addresses
+        ip_same1 = ip_same2 = ipaddress.IPv4Address('1.1.1.1')
+        self.assertEqual(list(ipaddress.collapse_addresses(
+                    [ip_same1, ip_same2])),
+                         [ipaddress.ip_network('1.1.1.1/32')])
+        ip1 = ipaddress.IPv6Network('2001::/100')
+        ip2 = ipaddress.IPv6Network('2001::/120')
+        ip3 = ipaddress.IPv6Network('2001::/96')
+        # test that ipv6 addresses are subsumed properly.
+        collapsed = ipaddress.collapse_addresses([ip1, ip2, ip3])
+        self.assertEqual(list(collapsed), [ip3])
+
+        # the toejam test
+        addr_tuples = [
+                (ipaddress.ip_address('1.1.1.1'),
+                 ipaddress.ip_address('::1')),
+                (ipaddress.IPv4Network('1.1.0.0/24'),
+                 ipaddress.IPv6Network('2001::/120')),
+                (ipaddress.IPv4Network('1.1.0.0/32'),
+                 ipaddress.IPv6Network('2001::/128')),
+        ]
+        for ip1, ip2 in addr_tuples:
+            self.assertRaises(TypeError, ipaddress.collapse_addresses,
+                              [ip1, ip2])
+
+    def testSummarizing(self):
+        #ip = ipaddress.ip_address
+        #ipnet = ipaddress.ip_network
+        summarize = ipaddress.summarize_address_range
+        ip1 = ipaddress.ip_address('1.1.1.0')
+        ip2 = ipaddress.ip_address('1.1.1.255')
+
+        # summarize works only for IPv4 & IPv6
+        class IPv7Address(ipaddress.IPv6Address):
+            @property
+            def version(self):
+                return 7
+        ip_invalid1 = IPv7Address('::1')
+        ip_invalid2 = IPv7Address('::1')
+        self.assertRaises(ValueError, list,
+                          summarize(ip_invalid1, ip_invalid2))
+        # test that a summary over ip4 & ip6 fails
+        self.assertRaises(TypeError, list,
+                          summarize(ip1, ipaddress.IPv6Address('::1')))
+        # test a /24 is summarized properly
+        self.assertEqual(list(summarize(ip1, ip2))[0],
+                         ipaddress.ip_network('1.1.1.0/24'))
+        # test an  IPv4 range that isn't on a network byte boundary
+        ip2 = ipaddress.ip_address('1.1.1.8')
+        self.assertEqual(list(summarize(ip1, ip2)),
+                         [ipaddress.ip_network('1.1.1.0/29'),
+                          ipaddress.ip_network('1.1.1.8')])
+        # all!
+        ip1 = ipaddress.IPv4Address(0)
+        ip2 = ipaddress.IPv4Address(ipaddress.IPv4Address._ALL_ONES)
+        self.assertEqual([ipaddress.IPv4Network('0.0.0.0/0')],
+                         list(summarize(ip1, ip2)))
+
+        ip1 = ipaddress.ip_address('1::')
+        ip2 = ipaddress.ip_address('1:ffff:ffff:ffff:ffff:ffff:ffff:ffff')
+        # test a IPv6 is sumamrized properly
+        self.assertEqual(list(summarize(ip1, ip2))[0],
+                         ipaddress.ip_network('1::/16'))
+        # test an IPv6 range that isn't on a network byte boundary
+        ip2 = ipaddress.ip_address('2::')
+        self.assertEqual(list(summarize(ip1, ip2)),
+                         [ipaddress.ip_network('1::/16'),
+                          ipaddress.ip_network('2::/128')])
+
+        # test exception raised when first is greater than last
+        self.assertRaises(ValueError, list,
+                          summarize(ipaddress.ip_address('1.1.1.0'),
+                                    ipaddress.ip_address('1.1.0.0')))
+        # test exception raised when first and last aren't IP addresses
+        self.assertRaises(TypeError, list,
+                          summarize(ipaddress.ip_network('1.1.1.0'),
+                                    ipaddress.ip_network('1.1.0.0')))
+        self.assertRaises(TypeError, list,
+                          summarize(ipaddress.ip_network('1.1.1.0'),
+                                    ipaddress.ip_network('1.1.0.0')))
+        # test exception raised when first and last are not same version
+        self.assertRaises(TypeError, list,
+                          summarize(ipaddress.ip_address('::'),
+                                    ipaddress.ip_network('1.1.0.0')))
+
+    def testAddressComparison(self):
+        self.assertTrue(ipaddress.ip_address('1.1.1.1') <=
+                        ipaddress.ip_address('1.1.1.1'))
+        self.assertTrue(ipaddress.ip_address('1.1.1.1') <=
+                        ipaddress.ip_address('1.1.1.2'))
+        self.assertTrue(ipaddress.ip_address('::1') <=
+                        ipaddress.ip_address('::1'))
+        self.assertTrue(ipaddress.ip_address('::1') <=
+                        ipaddress.ip_address('::2'))
+
+    def testInterfaceComparison(self):
+        self.assertTrue(ipaddress.ip_interface('1.1.1.1') <=
+                        ipaddress.ip_interface('1.1.1.1'))
+        self.assertTrue(ipaddress.ip_interface('1.1.1.1') <=
+                        ipaddress.ip_interface('1.1.1.2'))
+        self.assertTrue(ipaddress.ip_interface('::1') <=
+                        ipaddress.ip_interface('::1'))
+        self.assertTrue(ipaddress.ip_interface('::1') <=
+                        ipaddress.ip_interface('::2'))
+
+    def testNetworkComparison(self):
+        # ip1 and ip2 have the same network address
+        ip1 = ipaddress.IPv4Network('1.1.1.0/24')
+        ip2 = ipaddress.IPv4Network('1.1.1.0/32')
+        ip3 = ipaddress.IPv4Network('1.1.2.0/24')
+
+        self.assertTrue(ip1 < ip3)
+        self.assertTrue(ip3 > ip2)
+
+        self.assertEqual(ip1.compare_networks(ip1), 0)
+
+        # if addresses are the same, sort by netmask
+        self.assertEqual(ip1.compare_networks(ip2), -1)
+        self.assertEqual(ip2.compare_networks(ip1), 1)
+
+        self.assertEqual(ip1.compare_networks(ip3), -1)
+        self.assertEqual(ip3.compare_networks(ip1), 1)
+        self.assertTrue(ip1._get_networks_key() < ip3._get_networks_key())
+
+        ip1 = ipaddress.IPv6Network('2001:2000::/96')
+        ip2 = ipaddress.IPv6Network('2001:2001::/96')
+        ip3 = ipaddress.IPv6Network('2001:ffff:2000::/96')
+
+        self.assertTrue(ip1 < ip3)
+        self.assertTrue(ip3 > ip2)
+        self.assertEqual(ip1.compare_networks(ip3), -1)
+        self.assertTrue(ip1._get_networks_key() < ip3._get_networks_key())
+
+        # Test comparing different protocols.
+        # Should always raise a TypeError.
+        self.assertRaises(TypeError,
+                          self.ipv4_network.compare_networks,
+                          self.ipv6_network)
+        ipv6 = ipaddress.IPv6Interface('::/0')
+        ipv4 = ipaddress.IPv4Interface('0.0.0.0/0')
+        self.assertRaises(TypeError, ipv4.__lt__, ipv6)
+        self.assertRaises(TypeError, ipv4.__gt__, ipv6)
+        self.assertRaises(TypeError, ipv6.__lt__, ipv4)
+        self.assertRaises(TypeError, ipv6.__gt__, ipv4)
+
+        # Regression test for issue 19.
+        ip1 = ipaddress.ip_network('10.1.2.128/25')
+        self.assertFalse(ip1 < ip1)
+        self.assertFalse(ip1 > ip1)
+        ip2 = ipaddress.ip_network('10.1.3.0/24')
+        self.assertTrue(ip1 < ip2)
+        self.assertFalse(ip2 < ip1)
+        self.assertFalse(ip1 > ip2)
+        self.assertTrue(ip2 > ip1)
+        ip3 = ipaddress.ip_network('10.1.3.0/25')
+        self.assertTrue(ip2 < ip3)
+        self.assertFalse(ip3 < ip2)
+        self.assertFalse(ip2 > ip3)
+        self.assertTrue(ip3 > ip2)
+
+        # Regression test for issue 28.
+        ip1 = ipaddress.ip_network('10.10.10.0/31')
+        ip2 = ipaddress.ip_network('10.10.10.0')
+        ip3 = ipaddress.ip_network('10.10.10.2/31')
+        ip4 = ipaddress.ip_network('10.10.10.2')
+        sorted = [ip1, ip2, ip3, ip4]
+        unsorted = [ip2, ip4, ip1, ip3]
+        unsorted.sort()
+        self.assertEqual(sorted, unsorted)
+        unsorted = [ip4, ip1, ip3, ip2]
+        unsorted.sort()
+        self.assertEqual(sorted, unsorted)
+        self.assertRaises(TypeError, ip1.__lt__,
+                          ipaddress.ip_address('10.10.10.0'))
+        self.assertRaises(TypeError, ip2.__lt__,
+                          ipaddress.ip_address('10.10.10.0'))
+
+        # <=, >=
+        self.assertTrue(ipaddress.ip_network('1.1.1.1') <=
+                        ipaddress.ip_network('1.1.1.1'))
+        self.assertTrue(ipaddress.ip_network('1.1.1.1') <=
+                        ipaddress.ip_network('1.1.1.2'))
+        self.assertFalse(ipaddress.ip_network('1.1.1.2') <=
+                        ipaddress.ip_network('1.1.1.1'))
+        self.assertTrue(ipaddress.ip_network('::1') <=
+                        ipaddress.ip_network('::1'))
+        self.assertTrue(ipaddress.ip_network('::1') <=
+                        ipaddress.ip_network('::2'))
+        self.assertFalse(ipaddress.ip_network('::2') <=
+                         ipaddress.ip_network('::1'))
+
+    def testStrictNetworks(self):
+        self.assertRaises(ValueError, ipaddress.ip_network, '192.168.1.1/24')
+        self.assertRaises(ValueError, ipaddress.ip_network, '::1/120')
+
+    def testOverlaps(self):
+        other = ipaddress.IPv4Network('1.2.3.0/30')
+        other2 = ipaddress.IPv4Network('1.2.2.0/24')
+        other3 = ipaddress.IPv4Network('1.2.2.64/26')
+        self.assertTrue(self.ipv4_network.overlaps(other))
+        self.assertFalse(self.ipv4_network.overlaps(other2))
+        self.assertTrue(other2.overlaps(other3))
+
+    def testEmbeddedIpv4(self):
+        ipv4_string = '192.168.0.1'
+        ipv4 = ipaddress.IPv4Interface(ipv4_string)
+        v4compat_ipv6 = ipaddress.IPv6Interface('::%s' % ipv4_string)
+        self.assertEqual(int(v4compat_ipv6.ip), int(ipv4.ip))
+        v4mapped_ipv6 = ipaddress.IPv6Interface('::ffff:%s' % ipv4_string)
+        self.assertNotEqual(v4mapped_ipv6.ip, ipv4.ip)
+        self.assertRaises(ipaddress.AddressValueError, ipaddress.IPv6Interface,
+                          '2001:1.1.1.1:1.1.1.1')
+
+    # Issue 67: IPv6 with embedded IPv4 address not recognized.
+    def testIPv6AddressTooLarge(self):
+        # RFC4291 2.5.5.2
+        self.assertEqual(ipaddress.ip_address('::FFFF:192.0.2.1'),
+                          ipaddress.ip_address('::FFFF:c000:201'))
+        # RFC4291 2.2 (part 3) x::d.d.d.d
+        self.assertEqual(ipaddress.ip_address('FFFF::192.0.2.1'),
+                          ipaddress.ip_address('FFFF::c000:201'))
+
+    def testIPVersion(self):
+        self.assertEqual(self.ipv4_address.version, 4)
+        self.assertEqual(self.ipv6_address.version, 6)
+
+    def testMaxPrefixLength(self):
+        self.assertEqual(self.ipv4_interface.max_prefixlen, 32)
+        self.assertEqual(self.ipv6_interface.max_prefixlen, 128)
+
+    def testPacked(self):
+        self.assertEqual(self.ipv4_address.packed,
+                         bytearray(b'\x01\x02\x03\x04'))
+        self.assertEqual(ipaddress.IPv4Interface('255.254.253.252').packed,
+                         bytearray(b'\xff\xfe\xfd\xfc'))
+        self.assertEqual(self.ipv6_address.packed,
+                         bytearray(b'\x20\x01\x06\x58\x02\x2a\xca\xfe'
+                         b'\x02\x00\x00\x00\x00\x00\x00\x01'))
+        self.assertEqual(ipaddress.IPv6Interface('ffff:2:3:4:ffff::').packed,
+                         bytearray(b'\xff\xff\x00\x02\x00\x03\x00\x04\xff\xff')
+                            + bytearray(b'\x00') * 6)
+        self.assertEqual(ipaddress.IPv6Interface('::1:0:0:0:0').packed,
+                         bytearray(b'\x00') * 6 + bytearray(b'\x00\x01') + bytearray(b'\x00') * 8)
+
+    def testIpType(self):
+        ipv4net = ipaddress.ip_network('1.2.3.4')
+        ipv4addr = ipaddress.ip_address('1.2.3.4')
+        ipv6net = ipaddress.ip_network('::1.2.3.4')
+        ipv6addr = ipaddress.ip_address('::1.2.3.4')
+        self.assertEqual(ipaddress.IPv4Network, type(ipv4net))
+        self.assertEqual(ipaddress.IPv4Address, type(ipv4addr))
+        self.assertEqual(ipaddress.IPv6Network, type(ipv6net))
+        self.assertEqual(ipaddress.IPv6Address, type(ipv6addr))
+
+    def testReservedIpv4(self):
+        # test networks
+        self.assertEqual(True, ipaddress.ip_interface(
+                '224.1.1.1/31').is_multicast)
+        self.assertEqual(False, ipaddress.ip_network('240.0.0.0').is_multicast)
+        self.assertEqual(True, ipaddress.ip_network('240.0.0.0').is_reserved)
+
+        self.assertEqual(True, ipaddress.ip_interface(
+                '192.168.1.1/17').is_private)
+        self.assertEqual(False, ipaddress.ip_network('192.169.0.0').is_private)
+        self.assertEqual(True, ipaddress.ip_network(
+                '10.255.255.255').is_private)
+        self.assertEqual(False, ipaddress.ip_network('11.0.0.0').is_private)
+        self.assertEqual(False, ipaddress.ip_network('11.0.0.0').is_reserved)
+        self.assertEqual(True, ipaddress.ip_network(
+                '172.31.255.255').is_private)
+        self.assertEqual(False, ipaddress.ip_network('172.32.0.0').is_private)
+        self.assertEqual(True,
+                         ipaddress.ip_network('169.254.1.0/24').is_link_local)
+
+        self.assertEqual(True,
+                          ipaddress.ip_interface(
+                              '169.254.100.200/24').is_link_local)
+        self.assertEqual(False,
+                          ipaddress.ip_interface(
+                              '169.255.100.200/24').is_link_local)
+
+        self.assertEqual(True,
+                          ipaddress.ip_network(
+                              '127.100.200.254/32').is_loopback)
+        self.assertEqual(True, ipaddress.ip_network(
+                '127.42.0.0/16').is_loopback)
+        self.assertEqual(False, ipaddress.ip_network('128.0.0.0').is_loopback)
+        self.assertEqual(False,
+                         ipaddress.ip_network('100.64.0.0/10').is_private)
+        self.assertEqual(False, ipaddress.ip_network('100.64.0.0/10').is_global)
+
+        self.assertEqual(True,
+                         ipaddress.ip_network('192.0.2.128/25').is_private)
+        self.assertEqual(True,
+                         ipaddress.ip_network('192.0.3.0/24').is_global)
+
+        # test addresses
+        self.assertEqual(True, ipaddress.ip_address('0.0.0.0').is_unspecified)
+        self.assertEqual(True, ipaddress.ip_address('224.1.1.1').is_multicast)
+        self.assertEqual(False, ipaddress.ip_address('240.0.0.0').is_multicast)
+        self.assertEqual(True, ipaddress.ip_address('240.0.0.1').is_reserved)
+        self.assertEqual(False,
+                         ipaddress.ip_address('239.255.255.255').is_reserved)
+
+        self.assertEqual(True, ipaddress.ip_address('192.168.1.1').is_private)
+        self.assertEqual(False, ipaddress.ip_address('192.169.0.0').is_private)
+        self.assertEqual(True, ipaddress.ip_address(
+                '10.255.255.255').is_private)
+        self.assertEqual(False, ipaddress.ip_address('11.0.0.0').is_private)
+        self.assertEqual(True, ipaddress.ip_address(
+                '172.31.255.255').is_private)
+        self.assertEqual(False, ipaddress.ip_address('172.32.0.0').is_private)
+
+        self.assertEqual(True,
+                         ipaddress.ip_address('169.254.100.200').is_link_local)
+        self.assertEqual(False,
+                         ipaddress.ip_address('169.255.100.200').is_link_local)
+
+        self.assertEqual(True,
+                          ipaddress.ip_address('127.100.200.254').is_loopback)
+        self.assertEqual(True, ipaddress.ip_address('127.42.0.0').is_loopback)
+        self.assertEqual(False, ipaddress.ip_address('128.0.0.0').is_loopback)
+        self.assertEqual(True, ipaddress.ip_network('0.0.0.0').is_unspecified)
+
+    def testReservedIpv6(self):
+
+        self.assertEqual(True, ipaddress.ip_network('ffff::').is_multicast)
+        self.assertEqual(True, ipaddress.ip_network(2**128 - 1).is_multicast)
+        self.assertEqual(True, ipaddress.ip_network('ff00::').is_multicast)
+        self.assertEqual(False, ipaddress.ip_network('fdff::').is_multicast)
+
+        self.assertEqual(True, ipaddress.ip_network('fecf::').is_site_local)
+        self.assertEqual(True, ipaddress.ip_network(
+                'feff:ffff:ffff:ffff::').is_site_local)
+        self.assertEqual(False, ipaddress.ip_network(
+                'fbf:ffff::').is_site_local)
+        self.assertEqual(False, ipaddress.ip_network('ff00::').is_site_local)
+
+        self.assertEqual(True, ipaddress.ip_network('fc00::').is_private)
+        self.assertEqual(True, ipaddress.ip_network(
+                'fc00:ffff:ffff:ffff::').is_private)
+        self.assertEqual(False, ipaddress.ip_network('fbff:ffff::').is_private)
+        self.assertEqual(False, ipaddress.ip_network('fe00::').is_private)
+
+        self.assertEqual(True, ipaddress.ip_network('fea0::').is_link_local)
+        self.assertEqual(True, ipaddress.ip_network(
+                'febf:ffff::').is_link_local)
+        self.assertEqual(False, ipaddress.ip_network(
+                'fe7f:ffff::').is_link_local)
+        self.assertEqual(False, ipaddress.ip_network('fec0::').is_link_local)
+
+        self.assertEqual(True, ipaddress.ip_interface('0:0::0:01').is_loopback)
+        self.assertEqual(False, ipaddress.ip_interface('::1/127').is_loopback)
+        self.assertEqual(False, ipaddress.ip_network('::').is_loopback)
+        self.assertEqual(False, ipaddress.ip_network('::2').is_loopback)
+
+        self.assertEqual(True, ipaddress.ip_network('0::0').is_unspecified)
+        self.assertEqual(False, ipaddress.ip_network('::1').is_unspecified)
+        self.assertEqual(False, ipaddress.ip_network('::/127').is_unspecified)
+
+        self.assertEqual(True,
+                         ipaddress.ip_network('2001::1/128').is_private)
+        self.assertEqual(True,
+                         ipaddress.ip_network('200::1/128').is_global)
+        # test addresses
+        self.assertEqual(True, ipaddress.ip_address('ffff::').is_multicast)
+        self.assertEqual(True, ipaddress.ip_address(2**128 - 1).is_multicast)
+        self.assertEqual(True, ipaddress.ip_address('ff00::').is_multicast)
+        self.assertEqual(False, ipaddress.ip_address('fdff::').is_multicast)
+
+        self.assertEqual(True, ipaddress.ip_address('fecf::').is_site_local)
+        self.assertEqual(True, ipaddress.ip_address(
+                'feff:ffff:ffff:ffff::').is_site_local)
+        self.assertEqual(False, ipaddress.ip_address(
+                'fbf:ffff::').is_site_local)
+        self.assertEqual(False, ipaddress.ip_address('ff00::').is_site_local)
+
+        self.assertEqual(True, ipaddress.ip_address('fc00::').is_private)
+        self.assertEqual(True, ipaddress.ip_address(
+                'fc00:ffff:ffff:ffff::').is_private)
+        self.assertEqual(False, ipaddress.ip_address('fbff:ffff::').is_private)
+        self.assertEqual(False, ipaddress.ip_address('fe00::').is_private)
+
+        self.assertEqual(True, ipaddress.ip_address('fea0::').is_link_local)
+        self.assertEqual(True, ipaddress.ip_address(
+                'febf:ffff::').is_link_local)
+        self.assertEqual(False, ipaddress.ip_address(
+                'fe7f:ffff::').is_link_local)
+        self.assertEqual(False, ipaddress.ip_address('fec0::').is_link_local)
+
+        self.assertEqual(True, ipaddress.ip_address('0:0::0:01').is_loopback)
+        self.assertEqual(True, ipaddress.ip_address('::1').is_loopback)
+        self.assertEqual(False, ipaddress.ip_address('::2').is_loopback)
+
+        self.assertEqual(True, ipaddress.ip_address('0::0').is_unspecified)
+        self.assertEqual(False, ipaddress.ip_address('::1').is_unspecified)
+
+        # some generic IETF reserved addresses
+        self.assertEqual(True, ipaddress.ip_address('100::').is_reserved)
+        self.assertEqual(True, ipaddress.ip_network('4000::1/128').is_reserved)
+
+    def testIpv4Mapped(self):
+        self.assertEqual(
+                ipaddress.ip_address('::ffff:192.168.1.1').ipv4_mapped,
+                ipaddress.ip_address('192.168.1.1'))
+        self.assertEqual(ipaddress.ip_address('::c0a8:101').ipv4_mapped, None)
+        self.assertEqual(ipaddress.ip_address('::ffff:c0a8:101').ipv4_mapped,
+                         ipaddress.ip_address('192.168.1.1'))
+
+    def testAddrExclude(self):
+        addr1 = ipaddress.ip_network('10.1.1.0/24')
+        addr2 = ipaddress.ip_network('10.1.1.0/26')
+        addr3 = ipaddress.ip_network('10.2.1.0/24')
+        addr4 = ipaddress.ip_address('10.1.1.0')
+        addr5 = ipaddress.ip_network('2001:db8::0/32')
+        self.assertEqual(sorted(list(addr1.address_exclude(addr2))),
+                         [ipaddress.ip_network('10.1.1.64/26'),
+                          ipaddress.ip_network('10.1.1.128/25')])
+        self.assertRaises(ValueError, list, addr1.address_exclude(addr3))
+        self.assertRaises(TypeError, list, addr1.address_exclude(addr4))
+        self.assertRaises(TypeError, list, addr1.address_exclude(addr5))
+        self.assertEqual(list(addr1.address_exclude(addr1)), [])
+
+    def testHash(self):
+        self.assertEqual(hash(ipaddress.ip_interface('10.1.1.0/24')),
+                         hash(ipaddress.ip_interface('10.1.1.0/24')))
+        self.assertEqual(hash(ipaddress.ip_network('10.1.1.0/24')),
+                         hash(ipaddress.ip_network('10.1.1.0/24')))
+        self.assertEqual(hash(ipaddress.ip_address('10.1.1.0')),
+                         hash(ipaddress.ip_address('10.1.1.0')))
+        # i70
+        self.assertEqual(hash(ipaddress.ip_address('1.2.3.4')),
+                         hash(ipaddress.ip_address(
+                    int(ipaddress.ip_address('1.2.3.4')._ip))))
+        ip1 = ipaddress.ip_address('10.1.1.0')
+        ip2 = ipaddress.ip_address('1::')
+        dummy = {}
+        dummy[self.ipv4_address] = None
+        dummy[self.ipv6_address] = None
+        dummy[ip1] = None
+        dummy[ip2] = None
+        self.assertIn(self.ipv4_address, dummy)
+        self.assertIn(ip2, dummy)
+
+    def testIPBases(self):
+        net = self.ipv4_network
+        self.assertEqual('1.2.3.0/24', net.compressed)
+        net = self.ipv6_network
+        self.assertRaises(ValueError, net._string_from_ip_int, 2**128 + 1)
+
+    def testIPv6NetworkHelpers(self):
+        net = self.ipv6_network
+        self.assertEqual('2001:658:22a:cafe::/64', net.with_prefixlen)
+        self.assertEqual('2001:658:22a:cafe::/ffff:ffff:ffff:ffff::',
+                         net.with_netmask)
+        self.assertEqual('2001:658:22a:cafe::/::ffff:ffff:ffff:ffff',
+                         net.with_hostmask)
+        self.assertEqual('2001:658:22a:cafe::/64', str(net))
+
+    def testIPv4NetworkHelpers(self):
+        net = self.ipv4_network
+        self.assertEqual('1.2.3.0/24', net.with_prefixlen)
+        self.assertEqual('1.2.3.0/255.255.255.0', net.with_netmask)
+        self.assertEqual('1.2.3.0/0.0.0.255', net.with_hostmask)
+        self.assertEqual('1.2.3.0/24', str(net))
+
+    def testCopyConstructor(self):
+        addr1 = ipaddress.ip_network('10.1.1.0/24')
+        addr2 = ipaddress.ip_network(addr1)
+        addr3 = ipaddress.ip_interface('2001:658:22a:cafe:200::1/64')
+        addr4 = ipaddress.ip_interface(addr3)
+        addr5 = ipaddress.IPv4Address('1.1.1.1')
+        addr6 = ipaddress.IPv6Address('2001:658:22a:cafe:200::1')
+
+        self.assertEqual(addr1, addr2)
+        self.assertEqual(addr3, addr4)
+        self.assertEqual(addr5, ipaddress.IPv4Address(addr5))
+        self.assertEqual(addr6, ipaddress.IPv6Address(addr6))
+
+    def testCompressIPv6Address(self):
+        test_addresses = {
+            '1:2:3:4:5:6:7:8': '1:2:3:4:5:6:7:8/128',
+            '2001:0:0:4:0:0:0:8': '2001:0:0:4::8/128',
+            '2001:0:0:4:5:6:7:8': '2001::4:5:6:7:8/128',
+            '2001:0:3:4:5:6:7:8': '2001:0:3:4:5:6:7:8/128',
+            '2001:0:3:4:5:6:7:8': '2001:0:3:4:5:6:7:8/128',
+            '0:0:3:0:0:0:0:ffff': '0:0:3::ffff/128',
+            '0:0:0:4:0:0:0:ffff': '::4:0:0:0:ffff/128',
+            '0:0:0:0:5:0:0:ffff': '::5:0:0:ffff/128',
+            '1:0:0:4:0:0:7:8': '1::4:0:0:7:8/128',
+            '0:0:0:0:0:0:0:0': '::/128',
+            '0:0:0:0:0:0:0:0/0': '::/0',
+            '0:0:0:0:0:0:0:1': '::1/128',
+            '2001:0658:022a:cafe:0000:0000:0000:0000/66':
+            '2001:658:22a:cafe::/66',
+            '::1.2.3.4': '::102:304/128',
+            '1:2:3:4:5:ffff:1.2.3.4': '1:2:3:4:5:ffff:102:304/128',
+            '::7:6:5:4:3:2:1': '0:7:6:5:4:3:2:1/128',
+            '::7:6:5:4:3:2:0': '0:7:6:5:4:3:2:0/128',
+            '7:6:5:4:3:2:1::': '7:6:5:4:3:2:1:0/128',
+            '0:6:5:4:3:2:1::': '0:6:5:4:3:2:1:0/128',
+            }
+        for uncompressed, compressed in list(test_addresses.items()):
+            self.assertEqual(compressed, str(ipaddress.IPv6Interface(
+                uncompressed)))
+
+    def testExplodeShortHandIpStr(self):
+        addr1 = ipaddress.IPv6Interface('2001::1')
+        addr2 = ipaddress.IPv6Address('2001:0:5ef5:79fd:0:59d:a0e5:ba1')
+        addr3 = ipaddress.IPv6Network('2001::/96')
+        addr4 = ipaddress.IPv4Address('192.168.178.1')
+        self.assertEqual('2001:0000:0000:0000:0000:0000:0000:0001/128',
+                         addr1.exploded)
+        self.assertEqual('0000:0000:0000:0000:0000:0000:0000:0001/128',
+                         ipaddress.IPv6Interface('::1/128').exploded)
+        # issue 77
+        self.assertEqual('2001:0000:5ef5:79fd:0000:059d:a0e5:0ba1',
+                         addr2.exploded)
+        self.assertEqual('2001:0000:0000:0000:0000:0000:0000:0000/96',
+                         addr3.exploded)
+        self.assertEqual('192.168.178.1', addr4.exploded)
+
+    def testIntRepresentation(self):
+        self.assertEqual(16909060, int(self.ipv4_address))
+        self.assertEqual(42540616829182469433547762482097946625,
+                         int(self.ipv6_address))
+
+    def testForceVersion(self):
+        self.assertEqual(ipaddress.ip_network(1).version, 4)
+        self.assertEqual(ipaddress.IPv6Network(1).version, 6)
+
+    def testWithStar(self):
+        self.assertEqual(self.ipv4_interface.with_prefixlen, "1.2.3.4/24")
+        self.assertEqual(self.ipv4_interface.with_netmask,
+                         "1.2.3.4/255.255.255.0")
+        self.assertEqual(self.ipv4_interface.with_hostmask,
+                         "1.2.3.4/0.0.0.255")
+
+        self.assertEqual(self.ipv6_interface.with_prefixlen,
+                         '2001:658:22a:cafe:200::1/64')
+        self.assertEqual(self.ipv6_interface.with_netmask,
+                         '2001:658:22a:cafe:200::1/ffff:ffff:ffff:ffff::')
+        # this probably don't make much sense, but it's included for
+        # compatibility with ipv4
+        self.assertEqual(self.ipv6_interface.with_hostmask,
+                         '2001:658:22a:cafe:200::1/::ffff:ffff:ffff:ffff')
+
+    def testNetworkElementCaching(self):
+        # V4 - make sure we're empty
+        self.assertNotIn('network_address', self.ipv4_network._cache)
+        self.assertNotIn('broadcast_address', self.ipv4_network._cache)
+        self.assertNotIn('hostmask', self.ipv4_network._cache)
+
+        # V4 - populate and test
+        self.assertEqual(self.ipv4_network.network_address,
+                         ipaddress.IPv4Address('1.2.3.0'))
+        self.assertEqual(self.ipv4_network.broadcast_address,
+                         ipaddress.IPv4Address('1.2.3.255'))
+        self.assertEqual(self.ipv4_network.hostmask,
+                         ipaddress.IPv4Address('0.0.0.255'))
+
+        # V4 - check we're cached
+        self.assertIn('broadcast_address', self.ipv4_network._cache)
+        self.assertIn('hostmask', self.ipv4_network._cache)
+
+        # V6 - make sure we're empty
+        self.assertNotIn('broadcast_address', self.ipv6_network._cache)
+        self.assertNotIn('hostmask', self.ipv6_network._cache)
+
+        # V6 - populate and test
+        self.assertEqual(self.ipv6_network.network_address,
+                         ipaddress.IPv6Address('2001:658:22a:cafe::'))
+        self.assertEqual(self.ipv6_interface.network.network_address,
+                         ipaddress.IPv6Address('2001:658:22a:cafe::'))
+
+        self.assertEqual(
+            self.ipv6_network.broadcast_address,
+            ipaddress.IPv6Address('2001:658:22a:cafe:ffff:ffff:ffff:ffff'))
+        self.assertEqual(self.ipv6_network.hostmask,
+                         ipaddress.IPv6Address('::ffff:ffff:ffff:ffff'))
+        self.assertEqual(
+            self.ipv6_interface.network.broadcast_address,
+            ipaddress.IPv6Address('2001:658:22a:cafe:ffff:ffff:ffff:ffff'))
+        self.assertEqual(self.ipv6_interface.network.hostmask,
+                         ipaddress.IPv6Address('::ffff:ffff:ffff:ffff'))
+
+        # V6 - check we're cached
+        self.assertIn('broadcast_address', self.ipv6_network._cache)
+        self.assertIn('hostmask', self.ipv6_network._cache)
+        self.assertIn('broadcast_address', self.ipv6_interface.network._cache)
+        self.assertIn('hostmask', self.ipv6_interface.network._cache)
+
+    def testTeredo(self):
+        # stolen from wikipedia
+        server = ipaddress.IPv4Address('65.54.227.120')
+        client = ipaddress.IPv4Address('192.0.2.45')
+        teredo_addr = '2001:0000:4136:e378:8000:63bf:3fff:fdd2'
+        self.assertEqual((server, client),
+                         ipaddress.ip_address(teredo_addr).teredo)
+        bad_addr = '2000::4136:e378:8000:63bf:3fff:fdd2'
+        self.assertFalse(ipaddress.ip_address(bad_addr).teredo)
+        bad_addr = '2001:0001:4136:e378:8000:63bf:3fff:fdd2'
+        self.assertFalse(ipaddress.ip_address(bad_addr).teredo)
+
+        # i77
+        teredo_addr = ipaddress.IPv6Address('2001:0:5ef5:79fd:0:59d:a0e5:ba1')
+        self.assertEqual((ipaddress.IPv4Address('94.245.121.253'),
+                          ipaddress.IPv4Address('95.26.244.94')),
+                         teredo_addr.teredo)
+
+    def testsixtofour(self):
+        sixtofouraddr = ipaddress.ip_address('2002:ac1d:2d64::1')
+        bad_addr = ipaddress.ip_address('2000:ac1d:2d64::1')
+        self.assertEqual(ipaddress.IPv4Address('172.29.45.100'),
+                         sixtofouraddr.sixtofour)
+        self.assertFalse(bad_addr.sixtofour)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
First drop of #22080 solution
See how 
https://bitbucket.org/kwi/py2-ipaddress/
works out
(the code in `py2-ipaddress` is in much better shape than `ipaddress`)
