### PR TITLE
Fixing key error

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1823,7 +1823,7 @@ class Map(Cloud):
                                 ret['existing'] = {}
                             ret['existing'][name] = ret['create'].pop(name)
 
-        if self.opts['hard']:
+        if 'hard' in self.opts and self.opts['hard']:
             if self.opts['enable_hard_maps'] is False:
                 raise SaltCloudSystemExit(
                     'The --hard map can be extremely dangerous to use, '


### PR DESCRIPTION
``` python
In [1]: from salt.cloud import CloudClient
In [2]: client = CloudClient(path='/etc/salt/cloud')
In [3]: client = CloudClient(path='/etc/salt/cloud')
KeyboardInterrupt

In [4]: systems = client.map_run('/root/MiruLabs/gitolite.map')
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-5-99953ee6ffc6> in <module>()
----> 1 systems = client.map_run('/root/MiruLabs/gitolite.map')

/usr/lib/python2.6/site-packages/salt/cloud/__init__.pyc in map_run(self, path, **kwargs)
    346         kwarg.update(kwargs)
    347         mapper = salt.cloud.Map(self._opts_defaults(**kwarg))
--> 348         dmap = mapper.map_data()
    349         return salt.utils.cloud.simple_types_filter(
    350             mapper.run_map(dmap)

/usr/lib/python2.6/site-packages/salt/cloud/__init__.pyc in map_data(self, cached)
   1824                             ret['existing'][name] = ret['create'].pop(name)
   1825 
-> 1826         if self.opts['hard']:
   1827             if self.opts['enable_hard_maps'] is False:
   1828                 raise SaltCloudSystemExit(

KeyError: 'hard'
```
