### PR TITLE
Fixes yaml block indentation for GlusterFS state

### DIFF
--- a/salt/states/glusterfs.py
+++ b/salt/states/glusterfs.py
@@ -217,18 +217,18 @@ def add_volume_bricks(name, bricks):
 
     .. code-block:: yaml
 
-    myvolume:
-      glusterfs.add_volume_bricks:
-        - bricks:
-            - host1:/srv/gluster/drive1
-            - host2:/srv/gluster/drive2
+        myvolume:
+          glusterfs.add_volume_bricks:
+            - bricks:
+                - host1:/srv/gluster/drive1
+                - host2:/srv/gluster/drive2
 
-    Replicated Volume:
-      glusterfs.add_volume_bricks:
-        - name: volume2
-        - bricks:
-          - host1:/srv/gluster/drive2
-          - host2:/srv/gluster/drive3
+        Replicated Volume:
+          glusterfs.add_volume_bricks:
+            - name: volume2
+            - bricks:
+              - host1:/srv/gluster/drive2
+              - host2:/srv/gluster/drive3
     '''
     ret = {'name': name,
        'changes': {},


### PR DESCRIPTION
This is for documentation at: http://docs.saltstack.com/en/latest/ref/states/all/salt.states.glusterfs.html#module-salt.states.glusterfs

A very minor change.
