### PR TITLE
Removed list_pkgs caching

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -17,7 +17,6 @@ except ImportError:
     HAS_DEPENDENCIES = False
 
 # Import python libs
-import copy
 import logging
 try:
     import msgpack

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -237,14 +237,6 @@ def list_pkgs(versions_as_list=False, **kwargs):
             for x in ('removed', 'purge_desired')]):
         return {}
 
-    if 'pkg.list_pkgs' in __context__:
-        if versions_as_list:
-            return __context__['pkg.list_pkgs']
-        else:
-            ret = copy.deepcopy(__context__['pkg.list_pkgs'])
-            __salt__['pkg_resource.stringify'](ret)
-            return ret
-
     ret = {}
     name_map = _get_name_map()
     with salt.utils.winapi.Com():
@@ -258,7 +250,6 @@ def list_pkgs(versions_as_list=False, **kwargs):
             __salt__['pkg_resource.add_pkg'](ret, key, val)
 
     __salt__['pkg_resource.sort_pkglist'](ret)
-    __context__['pkg.list_pkgs'] = copy.deepcopy(ret)
     if not versions_as_list:
         __salt__['pkg_resource.stringify'](ret)
     return ret
@@ -574,7 +565,6 @@ def install(name=None, refresh=False, pkgs=None, saltenv='base', **kwargs):
 
         __salt__['cmd.run'](cmd, output_loglevel='trace', python_shell=False)
 
-    __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
     return salt.utils.compare_dicts(old, new)
 
@@ -678,7 +668,6 @@ def remove(name=None, pkgs=None, version=None, extra_uninstall_flags=None, **kwa
 
         __salt__['cmd.run'](cmd, output_loglevel='trace', python_shell=False)
 
-    __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
     return salt.utils.compare_dicts(old, new)
 


### PR DESCRIPTION
This was causing a problem in windows where pkg.list_pkgs was returning a cached list of installed software instead of what was actually installed. The minion needed to be restarted to obtain the current list.
Possibly fixes: #17948 and #11341
