### PR TITLE
[salt.mine.get_docker] Discard containers that doesn't expose their internal ports.

### DIFF
--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -356,14 +356,17 @@ def get_docker(interfaces=None, cidrs=None):
                 if container['Image'] not in proxy_lists:
                     proxy_lists[container['Image']] = {}
                 for dock_port in container['Ports']:
+                    # IP exists only if port is exposed
+                    ip_address = dock_port.get('IP')
                     # If port is 0.0.0.0, then we must get the docker host IP
-                    if dock_port['IP'] == '0.0.0.0':
+                    if ip_address == '0.0.0.0':
                         for ip_ in host_ips:
                             proxy_lists[container['Image']].setdefault('ipv4', {}).setdefault(dock_port['PrivatePort'], []).append(
                                 '{0}:{1}'.format(ip_, dock_port['PublicPort']))
                             proxy_lists[container['Image']]['ipv4'][dock_port['PrivatePort']] = list(set(proxy_lists[container['Image']]['ipv4'][dock_port['PrivatePort']]))
-                    elif dock_port['IP']:
+                    elif ip_address:
                         proxy_lists[container['Image']].setdefault('ipv4', {}).setdefault(dock_port['PrivatePort'], []).append(
                             '{0}:{1}'.format(dock_port['IP'], dock_port['PublicPort']))
                         proxy_lists[container['Image']]['ipv4'][dock_port['PrivatePort']] = list(set(proxy_lists[container['Image']]['ipv4'][dock_port['PrivatePort']]))
+
     return proxy_lists


### PR DESCRIPTION
@UtahDave please can you have a look ?
I think it is safe to discard such containers because they are not reachable from the outside.
