### PR TITLE
Windows: use install dir instead of the current working dir

### DIFF
--- a/pkg/windows/buildenv/salt-call.bat
+++ b/pkg/windows/buildenv/salt-call.bat
@@ -3,7 +3,8 @@
 :: Accepts all parameters that Salt-Minion Accepts
 
 :: Define Variables
-Set Python="%cd%\bin\python.exe"
-Set Script="%cd%\bin\Scripts\salt-call"
+Set SaltInstallDir=%~dp0
+Set Python="%SaltInstallDir%bin\python.exe"
+Set Script="%SaltInstallDir%bin\Scripts\salt-call"
 
-"%Python%" "%Script%" %*
+%Python% %Script% %*

--- a/pkg/windows/buildenv/salt-cp.bat
+++ b/pkg/windows/buildenv/salt-cp.bat
@@ -3,7 +3,8 @@
 :: Accepts all parameters that Salt-Minion Accepts
 
 :: Define Variables
-Set Python="%cd%\bin\python.exe"
-Set Script="%cd%\bin\Scripts\salt-cp"
+Set SaltInstallDir=%~dp0
+Set Python="%SaltInstallDir%bin\python.exe"
+Set Script="%SaltInstallDir%bin\Scripts\salt-cp"
 
-"%Python%" "%Script%" %*
+%Python% %Script% %*

--- a/pkg/windows/buildenv/salt-minion-debug.bat
+++ b/pkg/windows/buildenv/salt-minion-debug.bat
@@ -1,2 +1,7 @@
 net stop salt-minion
-.\bin\python.exe .\bin\Scripts\salt-minion -l debug -c C:\salt\conf
+
+Set SaltInstallDir=%~dp0
+Set Python="%SaltInstallDir%bin\python.exe"
+Set Script="%SaltInstallDir%bin\Scripts\salt-minion"
+
+%Python% %Script% -l debug -c "%SaltInstallDir%conf"

--- a/pkg/windows/buildenv/salt-minion.bat
+++ b/pkg/windows/buildenv/salt-minion.bat
@@ -3,7 +3,8 @@
 :: Accepts all parameters that Salt-Minion Accepts
 
 :: Define Variables
-Set Python="%cd%\bin\python.exe"
-Set Script="%cd%\bin\Scripts\salt-minion"
+Set SaltInstallDir=%~dp0
+Set Python="%SaltInstallDir%bin\python.exe"
+Set Script="%SaltInstallDir%bin\Scripts\salt-minion"
 
-"%Python%" "%Script%" %*
+%Python% %Script% %*

--- a/pkg/windows/buildenv/salt-unity.bat
+++ b/pkg/windows/buildenv/salt-unity.bat
@@ -3,7 +3,8 @@
 :: Accepts all parameters that Salt-Minion Accepts
 
 :: Define Variables
-Set Python="%cd%\bin\python.exe"
-Set Script="%cd%\bin\Scripts\salt-unity"
+Set SaltInstallDir=%~dp0
+Set Python="%SaltInstallDir%bin\python.exe"
+Set Script="%SaltInstallDir%bin\Scripts\salt-unity"
 
-"%Python%" "%Script%" %*
+%Python% %Script% %*


### PR DESCRIPTION
salt-[...].bat files are now executable from anywhere, like the .exe files before.

Fixes #22740

I removed the redundant quotes around the paths while I was at it - I hope this does not break anything I don't understand (I am not a windows guy and feel very lucky that I hardly ever have to write batch files ;) ).
