### PR TITLE
Changed %cd% to %~dp0

### DIFF
--- a/pkg/windows/buildenv/salt-call.bat
+++ b/pkg/windows/buildenv/salt-call.bat
@@ -3,7 +3,7 @@
 :: Accepts all parameters that Salt-Minion Accepts
 
 :: Define Variables
-Set Python="%cd%\bin\python.exe"
-Set Script="%cd%\bin\Scripts\salt-call"
+Set Python="%~dp0\bin\python.exe"
+Set Script="%~dp0\bin\Scripts\salt-call"
 
 "%Python%" "%Script%" %*

--- a/pkg/windows/buildenv/salt-cp.bat
+++ b/pkg/windows/buildenv/salt-cp.bat
@@ -3,7 +3,7 @@
 :: Accepts all parameters that Salt-Minion Accepts
 
 :: Define Variables
-Set Python="%cd%\bin\python.exe"
-Set Script="%cd%\bin\Scripts\salt-cp"
+Set Python="%~dp0\bin\python.exe"
+Set Script="%~dp0\bin\Scripts\salt-cp"
 
 "%Python%" "%Script%" %*

--- a/pkg/windows/buildenv/salt-minion-debug.bat
+++ b/pkg/windows/buildenv/salt-minion-debug.bat
@@ -1,2 +1,11 @@
+@ echo off
+:: Script for starting the Salt-Minion
+:: Accepts all parameters that Salt-Minion Accepts
+
+:: Define Variables
+Set Python="%~dp0\bin\python.exe"
+Set Script="%~dp0\bin\Scripts\salt-minion"
+
 net stop salt-minion
-.\bin\python.exe .\bin\Scripts\salt-minion -l debug -c C:\salt\conf
+
+"%Python%" "%Script%" -l debug

--- a/pkg/windows/buildenv/salt-minion.bat
+++ b/pkg/windows/buildenv/salt-minion.bat
@@ -3,7 +3,7 @@
 :: Accepts all parameters that Salt-Minion Accepts
 
 :: Define Variables
-Set Python="%cd%\bin\python.exe"
-Set Script="%cd%\bin\Scripts\salt-minion"
+Set Python="%~dp0\bin\python.exe"
+Set Script="%~dp0\bin\Scripts\salt-minion"
 
 "%Python%" "%Script%" %*

--- a/pkg/windows/buildenv/salt-unity.bat
+++ b/pkg/windows/buildenv/salt-unity.bat
@@ -3,7 +3,7 @@
 :: Accepts all parameters that Salt-Minion Accepts
 
 :: Define Variables
-Set Python="%cd%\bin\python.exe"
-Set Script="%cd%\bin\Scripts\salt-unity"
+Set Python="%~dp0\bin\python.exe"
+Set Script="%~dp0\bin\Scripts\salt-unity"
 
 "%Python%" "%Script%" %*


### PR DESCRIPTION
%~dp0 uses the directory of the batch file not the working directory
This allows the batch files to be called from anywhere
Fixes issue: #22740
