### PR TITLE
Adding vm_tools_upgrade() action to vmware salt cloud driver

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -1568,7 +1568,7 @@ def create_cluster(kwargs=None, call=None):
     return False
 
 
-def vm_tools_upgrade(name, reboot=False, call=None):
+def upgrade_tools(name, reboot=False, call=None):
     '''
     To upgrade VMware Tools on a specified virtual machine.
 
@@ -1582,12 +1582,12 @@ def vm_tools_upgrade(name, reboot=False, call=None):
 
     .. code-block:: bash
 
-        salt-cloud -a vm_tools_upgrade vmname
-        salt-cloud -a vm_tools_upgrade vmname reboot=True
+        salt-cloud -a upgrade_tools vmname
+        salt-cloud -a upgrade_tools vmname reboot=True
     '''
     if call != 'action':
         raise SaltCloudSystemExit(
-            'The vm_tools_upgrade action must be called with -a or --action.'
+            'The upgrade_tools action must be called with -a or --action.'
         )
 
     vm = _get_mor_by_property(vim.VirtualMachine, name)

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -1598,7 +1598,7 @@ def upgrade_tools(name, reboot=False, call=None):
     if tools_status == "toolsOk":
         return 'VMware tools is already up to date'
 
-    # Exit if VM is not powered on 
+    # Exit if VM is not powered on
     if vm.summary.runtime.powerState != "poweredOn":
         return 'Tools cannot be upgraded if the VM is not powered on'
 

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -1601,7 +1601,7 @@ def vm_tools_upgrade(name, reboot=False, call=None):
     # Exit if VM is not powered on 
     if vm.summary.runtime.powerState != "poweredOn":
         return 'Tools cannot be upgraded if the VM is not powered on'
-        
+
     # If vmware tools is out of date, check major OS family
     # Upgrade tools on Linux and Windows guests
     if tools_status == "toolsOld":

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -1566,3 +1566,83 @@ def create_cluster(kwargs=None, call=None):
         return {cluster_name: 'created'}
 
     return False
+
+
+def vm_tools_upgrade(vm_name, reboot=False, call=None):
+    
+    '''
+    To check status and upgrade VMware Tools on a VM using vm name.
+    Default is ``reboot=False``  which attempts to suppress the reboot
+    on Windows VMs.  Use ``reboot=True`` to override.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-cloud -a vm_tools_upgrade vmname
+        salt-cloud -a vm_tools_upgrade vmname reboot=True
+    '''
+
+    if call != 'action':
+        raise SaltCloudSystemExit(
+            'The start action must be called with -a or --action.'
+        )
+
+    vm = _get_mor_by_property(vim.VirtualMachine, vm_name)
+
+    # Check if VM is powered on and vmware tools is up to date. 
+    if vm.summary.runtime.powerState == "poweredOn":
+        if vm.guest.toolsStatus == "toolsOk":
+            ret = 'VMware tools is up to date.'
+            log.info('VM {0} {1}'.format(vm_name, ret))
+
+            return ret
+        
+    # If vmware tools is out of date, check major OS family.
+    # Upgrade tools on Linux guests.
+        elif vm.guest.toolsStatus == "toolsOld":
+            if vm.guest.guestFamily == "linuxGuest":
+                try:
+                    log.info('Upgrading VMware tools on {0}'.format(vm_name))
+                    task = vm.UpgradeTools()
+                    _wait_for_task(task, vm_name, "Upgrade tools", 5, "info")
+
+                except Exception as exc:
+                    log.error('Could not upgrade VMware tools on VM {0}: {1}'.format(vm_name, exc))
+
+                    return 'failed to upgrade VMware tools'
+                
+    # If Windows, check if reboot is true.
+            elif vm.guest.guestFamily == "windowsGuest":
+                if reboot:
+                    try:
+                        log.info('Upgrading VMware tools on {0}'.format(vm_name))
+                        task = vm.UpgradeTools()
+                        _wait_for_task(task, vm_name, "Upgrade tools", 5, "info")
+
+                    except Exception as exc:
+                        log.error('Could not upgrade VMware tools on VM {0}: {1}'.format(vm_name, exc))
+
+                        return 'failed to upgrade VMware tools'
+
+    # If reboot is false, upgrade tools while supressing the reboot.
+                else:
+                    try:
+                        log.info('Upgrading VMware tools on {0}'.format(vm_name))
+                        task = vm.UpgradeTools('/S /v"/qn REBOOT=R"')
+                        _wait_for_task(task, vm_name, "Upgrade tools", 5, "info")
+
+                    except Exception as exc:
+                        log.error('Could not upgrade VMware tools on VM {0}: {1}'.format(vm_name, exc))
+
+                        return 'failed to upgrade VMware tools'
+
+            return 'VMware tools upgraded'
+        
+    # If vm is powered off, exit.
+    elif vm.summary.runtime.powerState == "poweredOff":
+        ret = 'Tools cannot be upgraded on powered off VMs.'
+        log.info('VM {0} {1}'.format(vm_name, ret))
+
+    return ret
+

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -1569,7 +1569,6 @@ def create_cluster(kwargs=None, call=None):
 
 
 def vm_tools_upgrade(vm_name, reboot=False, call=None):
-    
     '''
     To check status and upgrade VMware Tools on a VM using vm name.
     Default is ``reboot=False``  which attempts to suppress the reboot
@@ -1582,7 +1581,6 @@ def vm_tools_upgrade(vm_name, reboot=False, call=None):
         salt-cloud -a vm_tools_upgrade vmname
         salt-cloud -a vm_tools_upgrade vmname reboot=True
     '''
-
     if call != 'action':
         raise SaltCloudSystemExit(
             'The start action must be called with -a or --action.'
@@ -1595,46 +1593,39 @@ def vm_tools_upgrade(vm_name, reboot=False, call=None):
         if vm.guest.toolsStatus == "toolsOk":
             ret = 'VMware tools is up to date.'
             log.info('VM {0} {1}'.format(vm_name, ret))
-
             return ret
         
-    # If vmware tools is out of date, check major OS family.
-    # Upgrade tools on Linux guests.
+        # If vmware tools is out of date, check major OS family.
+        # Upgrade tools on Linux guests.
         elif vm.guest.toolsStatus == "toolsOld":
             if vm.guest.guestFamily == "linuxGuest":
                 try:
                     log.info('Upgrading VMware tools on {0}'.format(vm_name))
                     task = vm.UpgradeTools()
                     _wait_for_task(task, vm_name, "Upgrade tools", 5, "info")
-
                 except Exception as exc:
                     log.error('Could not upgrade VMware tools on VM {0}: {1}'.format(vm_name, exc))
-
                     return 'failed to upgrade VMware tools'
                 
-    # If Windows, check if reboot is true.
+            # If Windows, check if reboot is true.
             elif vm.guest.guestFamily == "windowsGuest":
                 if reboot:
                     try:
                         log.info('Upgrading VMware tools on {0}'.format(vm_name))
                         task = vm.UpgradeTools()
                         _wait_for_task(task, vm_name, "Upgrade tools", 5, "info")
-
                     except Exception as exc:
                         log.error('Could not upgrade VMware tools on VM {0}: {1}'.format(vm_name, exc))
-
                         return 'failed to upgrade VMware tools'
 
-    # If reboot is false, upgrade tools while supressing the reboot.
+                # If reboot is false, upgrade tools while supressing the reboot.
                 else:
                     try:
                         log.info('Upgrading VMware tools on {0}'.format(vm_name))
                         task = vm.UpgradeTools('/S /v"/qn REBOOT=R"')
                         _wait_for_task(task, vm_name, "Upgrade tools", 5, "info")
-
                     except Exception as exc:
                         log.error('Could not upgrade VMware tools on VM {0}: {1}'.format(vm_name, exc))
-
                         return 'failed to upgrade VMware tools'
 
             return 'VMware tools upgraded'
@@ -1645,4 +1636,3 @@ def vm_tools_upgrade(vm_name, reboot=False, call=None):
         log.info('VM {0} {1}'.format(vm_name, ret))
 
     return ret
-


### PR DESCRIPTION
Adding `vm_tools_upgrade()` action to vmware salt cloud driver to be able to upgrade the vmware tools on single/multiple VM's when run in parallel mode.

The function was written by Ralph Goodberlet @rmgoodberlet
