### PR TITLE
Requests to AWS instance metadata should never be proxied

### DIFF
--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -71,14 +71,18 @@ def creds(provider):
                 return __AccessKeyId__, __SecretAccessKey__, __Token__
         # We don't have any cached credentials, or they are expired, get them
         # TODO: Wrap this with a try and handle exceptions gracefully
+
+        # Connections to instance meta-data must never be proxied
         result = requests.get(
-            "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
+            "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+            proxies={'http': ''},
         )
         result.raise_for_status()
         role = result.text
         # TODO: Wrap this with a try and handle exceptions gracefully
         result = requests.get(
-            "http://169.254.169.254/latest/meta-data/iam/security-credentials/{0}".format(role)
+            "http://169.254.169.254/latest/meta-data/iam/security-credentials/{0}".format(role),
+            proxies={'http': ''},
         )
         result.raise_for_status()
         data = result.json()

--- a/salt/utils/iam.py
+++ b/salt/utils/iam.py
@@ -25,7 +25,7 @@ def _retry_get_url(url, num_retries=10, timeout=5):
     '''
     for i in range(0, num_retries):
         try:
-            result = requests.get(url, timeout=timeout)
+            result = requests.get(url, timeout=timeout, proxies={'http': ''})
             if hasattr(result, 'text'):
                 return result.text
             elif hasattr(result, 'content'):


### PR DESCRIPTION
Enforce usage of no proxies for requests that query instance metadata service in AWS. Trying to access this URI via proxy always returns 404.

This caters for the case when proxy settings are picked up from environment, but NO_PROXY is not correctly set.
