### PR TITLE
add utils/compat.py

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -22,6 +22,7 @@ from salt.exceptions import LoaderError
 from salt.template import check_render_pipe_str
 from salt.utils.decorators import Depends
 import salt.utils.lazy
+import salt.utils.odict
 
 # Solve the Chicken and egg problem where grains need to run before any
 # of the modules are loaded and are generally available for any usage.

--- a/salt/utils/compat.py
+++ b/salt/utils/compat.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+'''
+Compatibility functions for utils
+'''
+
+# Import python libs
+from __future__ import absolute_import
+import sys
+
+# Import salt libs
+import salt.loader
+
+
+def pack_dunder(name):
+    '''
+    Compatibility helper function to make __utils__ available on demand.
+    '''
+    # TODO: Deprecate starting with Beryllium
+
+    mod = sys.modules[name]
+    if not hasattr(mod, '__utils__'):
+        setattr(mod, '__utils__', salt.loader.utils(mod.__opts__))


### PR DESCRIPTION
`utils/compat.py` provides a function that can be used to make `__utils__` available to modules in versions of salt prior to Beryllium. `__utils__` is packed by the loader in Beryllium.

It is important to get this into 2015.2 if at all possible, so that users can backport the latest `boto_*` modules, which depend on `__utils__`.

ping @thatch45, @ryan-lane

ref: #22767
