### PR TITLE
smtp module: make multiple recipients work as expected

### DIFF
--- a/salt/modules/smtp.py
+++ b/salt/modules/smtp.py
@@ -100,6 +100,7 @@ def send_msg(recipient,
     msg['Subject'] = subject
     msg['From'] = sender
     msg['To'] = recipient
+    recipients = [r.strip() for r in recipient.split(',')]
 
     try:
         if use_ssl in ['True', 'true']:
@@ -137,7 +138,7 @@ def send_msg(recipient,
             return False
 
     try:
-        smtpconn.sendmail(sender, [recipient], msg.as_string())
+        smtpconn.sendmail(sender, recipients, msg.as_string())
     except smtplib.SMTPRecipientsRefused:
         log.debug("All recipients were refused.")
         return False


### PR DESCRIPTION
Until now, only the first address specified in `recipient` was sent an email, although they appeared in the emails `To` field. A simple split of the `recipient` value along the commas fixes this.
