### PR TITLE
Minor fix on clean

### DIFF
--- a/salt/modules/smbios.py
+++ b/salt/modules/smbios.py
@@ -296,7 +296,7 @@ def _dmi_isclean(key, val):
                 continue
         log.trace('DMI {0} value {1} is an invalid UUID'.format(key, val.replace('\n', ' ')))
         return False
-    elif re.match('serial|part|version', key):
+    elif re.search('serial|part|version', key):
         # 'To be filled by O.E.M.
         # 'Not specified' etc.
         # 0000000, 1234667 etc.
@@ -304,7 +304,7 @@ def _dmi_isclean(key, val):
         return not re.match(r'^[0]+$', val) \
                 and not re.match(r'[0]?1234567[8]?[9]?[0]?', val) \
                 and not re.search(r'sernum|part[_-]?number|specified|filled', val, flags=re.IGNORECASE)
-    elif 'asset' in key or 'manufacturer' in key:
+    elif re.search('asset|manufacturer', key):
         # AssetTag0. Manufacturer04. Begone.
         return not re.search(r'manufacturer|to be filled|available|asset|^no(ne|t)', val, flags=re.IGNORECASE)
     else:


### PR DESCRIPTION
`re.match` matches from the start of the line, while we are actually looking for anywhere in the key ('system-serial' won't match on `match`, but will on `search`)
