### PR TITLE
develop.pillar ldap doc fixes

### DIFF
--- a/salt/pillar/pillar_ldap.py
+++ b/salt/pillar/pillar_ldap.py
@@ -17,6 +17,7 @@ Configuring the LDAP ext_pillar
 
 The basic configuration is part of the `master configuration
 <master-configuration-ext-pillar>`_.
+
 .. code-block:: yaml
 
     ext_pillar:

--- a/salt/pillar/pillar_ldap.py
+++ b/salt/pillar/pillar_ldap.py
@@ -74,9 +74,9 @@ The ``it-admins`` configuration below returns the Pillar ``it-admins`` by:
         bindpw:    bi7ieBai5Ano
         referrals: false
         anonymous: false
-        mode: map
-        dn: 'ou=users,dc=company,dc=tld'
-        filter: '(&(memberof=cn=it-admins,ou=groups,dc=company,dc=tld)(objectclass=user))'
+        mode:      map
+        dn:        'ou=users,dc=company,dc=tld'
+        filter:    '(&(memberof=cn=it-admins,ou=groups,dc=company,dc=tld)(objectclass=user))'
         attrs:
             - cn
             - displayName


### PR DESCRIPTION
Some minor doc fixes (see commits).

I didn't understand, how the broken link in _The basic configuration is part of the [master configuration](http://docs.saltstack.com/en/latest/ref/pillar/all/master-configuration-ext-pillar)._ needs to be fixed.
Maybe someone with a bit more RST knowledge can have a look at this.
