### PR TITLE
Allow additional parameters for GCE cloud profile

### DIFF
--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -2047,7 +2047,11 @@ def create(vm_=None, call=None):
             'ex_disk_type': config.get_cloud_config_value(
                 'ex_disk_type', vm_, __opts__, default='pd-standard'),
             'ex_disk_auto_delete': config.get_cloud_config_value(
-                'ex_disk_auto_delete', vm_, __opts__, default=True)
+                'ex_disk_auto_delete', vm_, __opts__, default=True),
+            'ex_disks_gce_struct': config.get_cloud_config_value(
+                'ex_disks_gce_struct', vm_, __opts__, default=None),
+            'ex_service_accounts': config.get_cloud_config_value(
+                'ex_service_accounts', vm_, __opts__, default=None)
         })
         if kwargs.get('ex_disk_type') not in ('pd-standard', 'pd-ssd'):
             raise SaltCloudSystemExit(

--- a/tests/integration/files/conf/cloud.profiles.d/gce.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/gce.conf
@@ -1,10 +1,29 @@
 gce-test:
   provider: gce-config
-  image: ubuntu-1404-trusty-v20150128
-  size: g1-small
+  #image: ubuntu-1404-trusty-v20150128
+  size: n1-highcpu-2
   location: us-central1-a
   network: default
-  use_persistent_disk: True
+  #use_persistent_disk: True
   delete_boot_pd: True
   ssh_username: ubuntu
   deploy: True
+  ex_disks_gce_struct:
+      -
+        autoDelete: true
+        boot: true
+        initializeParams:
+          sourceImage: projects/ubuntu-os-cloud/global/images/ubuntu-1404-trusty-v20150128
+          diskType: projects/<your-project>/zones/us-central1-a/diskTypes/pd-ssd
+        type: PERSISTENT
+      -
+        autoDelete: true
+        initializeParams:
+          diskType: projects/<your-project>/zones/us-central1-a/diskTypes/local-ssd
+        type: SCRATCH
+  ex_service_accounts:
+    -
+      scopes:
+        - compute-rw
+        - datastore
+        - storage-full

--- a/tests/integration/files/conf/cloud.profiles.d/gce.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/gce.conf
@@ -1,11 +1,19 @@
 gce-test:
   provider: gce-config
-  #image: ubuntu-1404-trusty-v20150128
+  image: ubuntu-1404-trusty-v20150128
+  size: g1-small
+  location: us-central1-a
+  network: default
+  use_persistent_disk: True
+  delete_boot_pd: True
+  ssh_username: ubuntu
+  deploy: True
+
+gce-test-extra:
+  provider: gce-config
   size: n1-highcpu-2
   location: us-central1-a
   network: default
-  #use_persistent_disk: True
-  delete_boot_pd: True
   ssh_username: ubuntu
   deploy: True
   ex_disks_gce_struct:

--- a/tests/integration/files/conf/cloud.profiles.d/gce.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/gce.conf
@@ -22,12 +22,12 @@ gce-test-extra:
         boot: true
         initializeParams:
           sourceImage: projects/ubuntu-os-cloud/global/images/ubuntu-1404-trusty-v20150128
-          diskType: projects/<your-project>/zones/us-central1-a/diskTypes/pd-ssd
+          diskType: zones/us-central1-a/diskTypes/pd-ssd
         type: PERSISTENT
       -
         autoDelete: true
         initializeParams:
-          diskType: projects/<your-project>/zones/us-central1-a/diskTypes/local-ssd
+          diskType: zones/us-central1-a/diskTypes/local-ssd
         type: SCRATCH
   ex_service_accounts:
     -


### PR DESCRIPTION
Right now [libcloud](https://github.com/apache/libcloud/blob/trunk/libcloud/compute/drivers/gce.py#L2049) allows to pass more parameters for creating node, especially _ex_disks_gce_struct_ and _ex_service_accounts_, than salt  cloud profile. In this commit, they are at least not ignored. Question is whether it is better to pass them one by one, or all parameters from profile and let _libcloud_ check them.

Other question is if salt should provide shorter way for defining disks.

Possible base for solving #22346 
