### PR TITLE
Improve error logging for pygit2 SSH-based remotes

### DIFF
--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -59,9 +59,12 @@ be used to install it:
 If pygit2_ is not packaged for the platform on which the Master is running, the
 pygit2_ website has installation instructions here__. Keep in mind however that
 following these instructions will install libgit2 and pygit2_ without system
-packages.
+packages. Additionally, keep in mind that :ref:`SSH authentication in pygit2
+<pygit2-authentication-ssh>` requires libssh2_ (*not* libssh) development
+libraries to be present before libgit2 is built.
 
 .. __: http://www.pygit2.org/install.html
+.. _libssh2: http://www.libssh2.org/
 
 GitPython
 ---------
@@ -186,7 +189,7 @@ master:
        ``git+ssh://``.
 
 3. Restart the master to load the new configuration.
-   
+
 
 .. note::
 
@@ -539,6 +542,8 @@ an ``insecure_auth`` parameter:
         - password: mypassword
         - insecure_auth: True
 
+.. _pygit2-authentication-ssh:
+
 SSH
 ~~~
 
@@ -647,7 +652,7 @@ server via SSH:
 .. code-block:: bash
 
     $ su
-    Password: 
+    Password:
     # ssh github.com
     The authenticity of host 'github.com (192.30.252.128)' can't be established.
     RSA key fingerprint is 16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48.

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -572,7 +572,7 @@ def _verify_auth(repo):
         '''
         Helper function to log errors about missing auth parameters
         '''
-        log.error(
+        log.critical(
             'Incomplete authentication information for remote {0}. Missing '
             'parameters: {1}'.format(remote_url, ', '.join(missing))
         )
@@ -595,7 +595,7 @@ def _verify_auth(repo):
         user = address.split('@')[0]
         if user == address:
             # No '@' sign == no user. This is a problem.
-            log.error(
+            log.critical(
                 'Password / keypair specified for remote {0}, but remote '
                 'URL is missing a username'.format(repo['url'])
             )
@@ -620,7 +620,7 @@ def _verify_auth(repo):
             return True
         if password_ok:
             if transport == 'http' and not repo['insecure_auth']:
-                log.error(
+                log.critical(
                     'Invalid configuration for gitfs remote {0}. '
                     'Authentication is disabled by default on http remotes. '
                     'Either set gitfs_insecure_auth to True in the master '
@@ -636,7 +636,7 @@ def _verify_auth(repo):
             missing_auth = [x for x in required_params if not bool(repo[x])]
             _incomplete_auth(repo['url'], missing_auth)
     else:
-        log.error(
+        log.critical(
             'Invalid configuration for remote {0}. Unsupported transport '
             '{1!r}.'.format(repo['url'], transport)
         )
@@ -700,7 +700,7 @@ def init():
                  salt.utils.repack_dictlist(remote[repo_url]).items()]
             )
             if not per_remote_conf:
-                log.error(
+                log.critical(
                     'Invalid per-remote configuration for gitfs remote {0}. '
                     'If no per-remote parameters are being specified, there '
                     'may be a trailing colon after the URL, which should be '
@@ -811,7 +811,7 @@ def init():
                    '{0}'.format(exc))
             if provider == 'gitpython':
                 msg += ' Perhaps git is not available.'
-            log.error(msg, exc_info_on_loglevel=logging.DEBUG)
+            log.critical(msg, exc_info_on_loglevel=logging.DEBUG)
             _failhard()
 
     if new_remote:
@@ -1189,14 +1189,14 @@ def update():
                 try:
                     refs_post = client.fetch(path, repo['repo'])
                 except dulwich.errors.NotGitRepository:
-                    log.critical(
+                    log.error(
                         'Dulwich does not recognize remote {0} as a valid '
                         'remote URL. Perhaps it is missing \'.git\' at the '
                         'end.'.format(repo['url'])
                     )
                     continue
                 except KeyError:
-                    log.critical(
+                    log.error(
                         'Local repository cachedir {0!r} (corresponding '
                         'remote: {1}) has been corrupted. Salt will now '
                         'attempt to remove the local checkout to allow it to '
@@ -1207,7 +1207,7 @@ def update():
                     try:
                         salt.utils.rm_rf(repo['cachedir'])
                     except OSError as exc:
-                        log.critical(
+                        log.error(
                             'Unable to remove {0!r}: {1}'
                             .format(repo['cachedir'], exc)
                         )
@@ -1635,7 +1635,7 @@ def _file_lists(load, form):
         try:
             os.makedirs(list_cachedir)
         except os.error:
-            log.critical('Unable to make cachedir {0}'.format(list_cachedir))
+            log.error('Unable to make cachedir {0}'.format(list_cachedir))
             return []
     list_cache = os.path.join(
         list_cachedir,

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -596,8 +596,8 @@ def _verify_auth(repo):
         if user == address:
             # No '@' sign == no user. This is a problem.
             log.critical(
-                'Password / keypair specified for remote {0}, but remote '
-                'URL is missing a username'.format(repo['url'])
+                'Keypair specified for remote {0}, but remote URL is missing '
+                'a username'.format(repo['url'])
             )
             _failhard()
 

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -1169,10 +1169,16 @@ def update():
                     # pygit2.Remote.fetch() returns a class instance in
                     # pygit2 >= 0.21.0
                     received_objects = fetch.received_objects
-                log.debug(
-                    'gitfs received {0} objects for remote {1}'
-                    .format(received_objects, repo['url'])
-                )
+                if received_objects != 0:
+                    log.debug(
+                        'gitfs received {0} objects for remote {1}'
+                        .format(received_objects, repo['url'])
+                    )
+                else:
+                    log.debug(
+                        'gitfs remote {0} is up-to-date'
+                        .format(repo['url'])
+                    )
                 # Clean up any stale refs
                 refs_post = repo['repo'].listall_references()
                 cleaned = _clean_stale(repo['repo'], refs_post)


### PR DESCRIPTION
If libgit2 is compiled without libssh2, an "Unsupported URL protocol" GitError
exception is raised. This pull request catches this exception and, if the
credentials are a keypair (which means SSH auth), logs an meaningful error
message that will let the user know that libgit2 was probably not compiled with
libssh2.

Additionally, some loglevels have been adjusted for some gitfs errors, and the
gitfs walkthrough has been updated to include information about the libssh2
requirement.

Fixes #21979.
