### PR TITLE
use cmd.run_all instead of cmd.run_stdout

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -974,9 +974,9 @@ def _linux_bin_exists(binary):
             pass
 
     try:
-        return len(__salt__['cmd.run_stdout'](
+        return len(__salt__['cmd.run_all'](
             'whereis -b {0}'.format(binary)
-        ).split()) > 1
+        )['stdout'].split()) > 1
     except salt.exceptions.CommandExecutionError:
         return False
 


### PR DESCRIPTION
Fixes #22574.
