### PR TITLE
cli: don't report syndics as unresponsive minions

### DIFF
--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -87,6 +87,7 @@ class Master(parsers.MasterOptionParser):
                         os.path.join(self.config['cachedir'], 'proc'),
                         self.config['sock_dir'],
                         self.config['token_dir'],
+                        self.config['syndic_dir'],
                         self.config['sqlite_queue_dir'],
                     ]
                 if self.config.get('transport') == 'raet':
@@ -106,6 +107,9 @@ class Master(parsers.MasterOptionParser):
                                                                    'file://')):
                     # Logfile is not using Syslog, verify
                     verify_files([logfile], self.config['user'])
+                # Clear out syndics from cachedir
+                for syndic_file in os.listdir(self.config['syndic_dir']):
+                    os.remove(os.path.join(self.config['syndic_dir'], syndic_file))
         except OSError as err:
             logger.exception('Failed to prepare salt environment')
             sys.exit(err.errno)

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -956,8 +956,8 @@ class LocalClient(object):
                     # if additional lower-level masters deliver their lists of expected
                     # minions.
                     break
-           # If we get here we may not have gathered the minion list yet. Keep waiting
-           # for all lower-level masters to respond with their minion lists
+            # If we get here we may not have gathered the minion list yet. Keep waiting
+            # for all lower-level masters to respond with their minion lists
 
             # let start the timeouts for all remaining minions
 
@@ -1309,14 +1309,12 @@ class LocalClient(object):
                         connected_minions = salt.utils.minions.CkMinions(self.opts).connected_ids()
                     if connected_minions and id_ not in connected_minions:
                         yield {id_: {'out': 'no_return',
-                                        'ret': 'Minion did not return. [Not connected]'}}
+                                     'ret': 'Minion did not return. [Not connected]'}}
                     else:
-                        yield({
-                            id_: {
-                                'out': 'no_return',
-                                'ret': 'Minion did not return. [No response]'
-                            }
-                        })
+                        # don't report syndics as unresponsive minions
+                        if not os.path.exists(os.path.join(self.opts['syndic_dir'], id_)):
+                            yield {id_: {'out': 'no_return',
+                                         'ret': 'Minion did not return. [No response]'}}
                 else:
                     yield {id_: min_ret}
 

--- a/salt/config.py
+++ b/salt/config.py
@@ -2466,6 +2466,7 @@ def apply_master_config(overrides=None, defaults=None):
         os.path.join(opts['cachedir'], 'extmods')
     )
     opts['token_dir'] = os.path.join(opts['cachedir'], 'tokens')
+    opts['syndic_dir'] = os.path.join(opts['cachedir'], 'syndics')
 
     using_ip_for_id = False
     append_master = False
@@ -2484,7 +2485,8 @@ def apply_master_config(overrides=None, defaults=None):
     # Prepend root_dir to other paths
     prepend_root_dirs = [
         'pki_dir', 'cachedir', 'pidfile', 'sock_dir', 'extension_modules',
-        'autosign_file', 'autoreject_file', 'token_dir', 'sqlite_queue_dir'
+        'autosign_file', 'autoreject_file', 'token_dir', 'syndic_dir',
+        'sqlite_queue_dir'
     ]
 
     # These can be set to syslog, so, not actual paths on the system

--- a/salt/master.py
+++ b/salt/master.py
@@ -1187,6 +1187,12 @@ class AESFuncs(object):
             fstr = '{0}.save_load'.format(self.opts['master_job_cache'])
             self.mminion.returners[fstr](load['jid'], load['load'])
 
+        # Register the syndic
+        syndic_cache_path = os.path.join(self.opts['cachedir'], 'syndics', load['id'])
+        if not os.path.exists(syndic_cache_path):
+            with salt.utils.fopen(syndic_cache_path, 'w') as f:
+                f.write('')
+
         # Format individual return loads
         for key, item in six.iteritems(load['return']):
             ret = {'jid': load['jid'],


### PR DESCRIPTION
Record syndic ids in the cachedir as they return. In the cli, don't
report known syndics as unresponsive minions. Issue #21615
