### PR TITLE
Always return a boolean in gen_locale()

### DIFF
--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -312,4 +312,4 @@ def gen_locale(locale, **kwargs):
     if kwargs.get('verbose'):
         return res
     else:
-        return res['retcode']
+        return res['retcode'] == 0

--- a/tests/unit/modules/localemod_test.py
+++ b/tests/unit/modules/localemod_test.py
@@ -101,13 +101,13 @@ class LocalemodTestCase(TestCase):
         '''
         Tests the return of successful gen_locale on Debian system
         '''
-        ret = {'stdout': 'saltines', 'stderr': 'biscuits', 'retcode': '31337', 'pid': '1337'}
+        ret = {'stdout': 'saltines', 'stderr': 'biscuits', 'retcode': 0, 'pid': 1337}
         with patch.dict(localemod.__grains__, {'os': 'Debian'}):
             with patch.dict(localemod.__salt__,
                             {'file.search': MagicMock(return_value=True),
                              'file.replace': MagicMock(return_value=True),
                              'cmd.run_all': MagicMock(return_value=ret)}):
-                self.assertEqual(localemod.gen_locale('en_US.UTF-8 UTF-8'), ret['retcode'])
+                self.assertTrue(localemod.gen_locale('en_US.UTF-8 UTF-8'))
 
     @patch('salt.utils.which', MagicMock(return_value='/some/dir/path'))
     @patch('os.listdir', MagicMock(return_value=['en_US']))
@@ -115,14 +115,14 @@ class LocalemodTestCase(TestCase):
         '''
         Test the return of successful gen_locale on Ubuntu system
         '''
-        ret = {'stdout': 'saltines', 'stderr': 'biscuits', 'retcode': '31337', 'pid': '1337'}
+        ret = {'stdout': 'saltines', 'stderr': 'biscuits', 'retcode': 0, 'pid': 1337}
         with patch.dict(localemod.__salt__,
                         {'file.replace': MagicMock(return_value=True),
                          'file.touch': MagicMock(return_value=None),
                          'file.append': MagicMock(return_value=None),
                          'cmd.run_all': MagicMock(return_value=ret)}):
             with patch.dict(localemod.__grains__, {'os': 'Ubuntu'}):
-                self.assertEqual(localemod.gen_locale('en_US.UTF-8'), ret['retcode'])
+                self.assertTrue(localemod.gen_locale('en_US.UTF-8'))
 
     @patch('salt.utils.which', MagicMock(return_value='/some/dir/path'))
     @patch('os.listdir', MagicMock(return_value=['en_US.UTF-8']))
@@ -130,13 +130,13 @@ class LocalemodTestCase(TestCase):
         '''
         Tests the return of successful gen_locale on Gentoo system
         '''
-        ret = {'stdout': 'saltines', 'stderr': 'biscuits', 'retcode': '31337', 'pid': '1337'}
+        ret = {'stdout': 'saltines', 'stderr': 'biscuits', 'retcode': 0, 'pid': 1337}
         with patch.dict(localemod.__grains__, {'os_family': 'Gentoo'}):
             with patch.dict(localemod.__salt__,
                             {'file.search': MagicMock(return_value=True),
                              'file.replace': MagicMock(return_value=True),
                              'cmd.run_all': MagicMock(return_value=ret)}):
-                self.assertEqual(localemod.gen_locale('en_US.UTF-8 UTF-8'), ret['retcode'])
+                self.assertTrue(localemod.gen_locale('en_US.UTF-8 UTF-8'))
 
     @patch('salt.utils.which', MagicMock(return_value='/some/dir/path'))
     @patch('os.listdir', MagicMock(return_value=['en_US']))
@@ -144,10 +144,10 @@ class LocalemodTestCase(TestCase):
         '''
         Tests the return of successful gen_locale
         '''
-        ret = {'stdout': 'saltines', 'stderr': 'biscuits', 'retcode': '31337', 'pid': '1337'}
+        ret = {'stdout': 'saltines', 'stderr': 'biscuits', 'retcode': 0, 'pid': 1337}
         with patch.dict(localemod.__salt__,
                         {'cmd.run_all': MagicMock(return_value=ret)}):
-            self.assertEqual(localemod.gen_locale('en_US.UTF-8'), ret['retcode'])
+            self.assertTrue(localemod.gen_locale('en_US.UTF-8'))
 
     @patch('salt.utils.which', MagicMock(return_value='/some/dir/path'))
     @patch('os.listdir', MagicMock(return_value=['en_US']))
@@ -155,7 +155,7 @@ class LocalemodTestCase(TestCase):
         '''
         Tests the return of successful gen_locale
         '''
-        ret = {'stdout': 'saltines', 'stderr': 'biscuits', 'retcode': '31337', 'pid': '1337'}
+        ret = {'stdout': 'saltines', 'stderr': 'biscuits', 'retcode': 0, 'pid': 1337}
         with patch.dict(localemod.__salt__,
                         {'cmd.run_all': MagicMock(return_value=ret)}):
             self.assertEqual(localemod.gen_locale('en_US.UTF-8', verbose=True), ret)


### PR DESCRIPTION
`states.locale.present()` already expects a boolean return value, which is probably the cause of #21140.
Judging from #2417, there is no consensus on what modules should return. So I decided to adjust the module rather than the state and make it conistent within itself (`set_locale()` returns a boolean as well) and with the behavior an error (`False` is returned).

I'm not very familiar with your release process, but from my understanding this should also get backported.
