### PR TITLE
Improve docs for modules.localemod & states.locale

### DIFF
--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -234,7 +234,9 @@ def gen_locale(locale, **kwargs):
     .. versionadded:: 2014.7.0
 
     :param locale: Any locale listed in /usr/share/i18n/locales or
-        /usr/share/i18n/SUPPORTED for debian and gentoo based distros
+        /usr/share/i18n/SUPPORTED for Debian and Gentoo based distributions,
+        which require the charmap to be specified as part of the locale
+        when generating it.
 
     verbose
         Show extra warnings about errors that are normally ignored.
@@ -244,7 +246,7 @@ def gen_locale(locale, **kwargs):
     .. code-block:: bash
 
         salt '*' locale.gen_locale en_US.UTF-8
-        salt '*' locale.gen_locale 'en_IE@euro ISO-8859-15'
+        salt '*' locale.gen_locale 'en_IE.UTF-8 UTF-8'    # Debian/Gentoo only
     '''
     on_debian = __grains__.get('os') == 'Debian'
     on_ubuntu = __grains__.get('os') == 'Ubuntu'

--- a/salt/states/locale.py
+++ b/salt/states/locale.py
@@ -62,7 +62,8 @@ def present(name):
     .. versionadded:: 2014.7.0
 
     name
-        The name of the locale to be present
+        The name of the locale to be present. Some distributions require the
+        charmap to be specified as part of the locale at this point.
     '''
     ret = {'name': name,
            'changes': {},

--- a/salt/states/locale.py
+++ b/salt/states/locale.py
@@ -3,12 +3,19 @@
 Management of languages/locales
 ===============================
 
-The locale can be managed for the system:
+Manage the available locales and the system default:
 
 .. code-block:: yaml
 
-    en_US.UTF-8:
-      locale.system
+    us_locale:
+      locale.present:
+        - name: en_US.UTF-8
+
+    default_locale:
+      locale.system:
+        - name: en_US.UTF-8
+        - require:
+          - locale: us_locale
 '''
 
 


### PR DESCRIPTION
This adds an example for the `locale.present` state and documents the fact that the charmap must be specified when generating locales on Debian or Gentoo.

The latter is something that I suppose new users might run into quite easily (at least I did), despite the list in `/usr/share/i18n/SUPPORTED` already being documented. Something similar to it had been part of @4be92ed, but has been removed again in @8565d7e.
