### PR TITLE
add splay module

### DIFF
--- a/salt/modules/splay.py
+++ b/salt/modules/splay.py
@@ -1,3 +1,4 @@
+# -*- coding: UTF-8 -*-
 '''
 Splay function calls across targeted minions
 '''

--- a/salt/modules/splay.py
+++ b/salt/modules/splay.py
@@ -1,0 +1,100 @@
+'''
+Splay function calls across targeted minions
+'''
+import time
+from salt.exceptions import CommandExecutionError
+
+_DEFAULT_SPLAYTIME = 600
+_DEFAULT_SIZE = 8192
+
+
+def _get_hash(hashable, size):
+    '''
+    Jenkins One-At-A-Time Hash Function
+    More Info: http://en.wikipedia.org/wiki/Jenkins_hash_function#one-at-a-time
+    '''
+    # Using bitmask to emulate rollover behavior of C unsigned 32 bit int
+    bitmask = 0xffffffff
+    h = 0
+
+    for i in bytearray(hashable):
+        h = (h + i) & bitmask
+        h = (h + (h << 10)) & bitmask
+        h = (h ^ (h >> 6)) & bitmask
+
+    h = (h + (h << 3)) & bitmask
+    h = (h ^ (h >> 11)) & bitmask
+    h = (h + (h << 15)) & bitmask
+
+    return (h & (size - 1)) & bitmask
+
+
+def _calc_splay(hashable, splaytime=_DEFAULT_SPLAYTIME, size=_DEFAULT_SIZE):
+    hash_val = _get_hash(hashable, size)
+    return int(splaytime * hash_val / float(size))
+
+
+def splay(*args, **kwargs):
+    '''
+    Splay a salt function call execution time across minions over
+    a number of seconds (default: 600)
+
+
+    NOTE: You *probably* want to use --async here and look up the job results later.
+          If you're dead set on getting the output from the CLI command, then make
+          sure to set the timeout (with the -t flag) to something greater than the
+          splaytime (max splaytime + time to execute job). 
+          Otherwise, it's very likely that the cli will time out before the job returns.
+
+
+    CLI Example:
+    # With default splaytime
+      salt --async '*' splay.splay pkg.install cowsay version=3.03-8.el6
+
+    # With specified splaytime (5 minutes) and timeout with 10 second buffer
+      salt -t 310 '*' splay.splay 300 pkg.version cowsay
+    '''
+    # Convert args tuple to a list so we can pop the splaytime and func out
+    args = list(args)
+
+    # If the first argument passed is an integer, set it as the splaytime
+    try:
+        splaytime = int(args[0])
+        args.pop(0)
+    except ValueError:
+        splaytime = _DEFAULT_SPLAYTIME
+
+    if splaytime <= 0:
+        raise ValueError('splaytime must be a positive integer')
+
+    func = args.pop(0)
+    # Check if the func is valid before the sleep
+    if not func in __salt__:
+        raise CommandExecutionError('Unable to find module function {0}'.format(func))
+
+    my_delay = _calc_splay(__grains__['id'], splaytime=splaytime)
+    time.sleep(my_delay)
+    # Get rid of the hidden kwargs that salt injects
+    func_kwargs = dict((k,v) for k,v in kwargs.iteritems() if not k.startswith('__'))
+    result = __salt__[func](*args, **func_kwargs)
+    if type(result) != dict:
+        result = {'result': result}
+    result['splaytime'] = str(my_delay)
+    return result
+
+
+def show(splaytime=_DEFAULT_SPLAYTIME):
+    '''
+    Show calculated splaytime for this minion
+    Will use default value of 600 (seconds) if splaytime value not provided
+
+
+    CLI Example:
+        salt example-host splay.show
+        salt example-host splay.show 60
+    '''
+    # Coerce splaytime to int (passed arg from CLI will be a str)
+    if type(splaytime) != int:
+        splaytime = int(splaytime)
+
+    return str(_calc_splay(__grains__['id'], splaytime=splaytime))

--- a/salt/modules/splay.py
+++ b/salt/modules/splay.py
@@ -43,7 +43,7 @@ def splay(*args, **kwargs):
     NOTE: You *probably* want to use --async here and look up the job results later.
           If you're dead set on getting the output from the CLI command, then make
           sure to set the timeout (with the -t flag) to something greater than the
-          splaytime (max splaytime + time to execute job). 
+          splaytime (max splaytime + time to execute job).
           Otherwise, it's very likely that the cli will time out before the job returns.
 
 
@@ -69,13 +69,13 @@ def splay(*args, **kwargs):
 
     func = args.pop(0)
     # Check if the func is valid before the sleep
-    if not func in __salt__:
+    if func not in __salt__:
         raise CommandExecutionError('Unable to find module function {0}'.format(func))
 
     my_delay = _calc_splay(__grains__['id'], splaytime=splaytime)
     time.sleep(my_delay)
     # Get rid of the hidden kwargs that salt injects
-    func_kwargs = dict((k,v) for k,v in kwargs.iteritems() if not k.startswith('__'))
+    func_kwargs = dict((k, v) for k, v in kwargs.iteritems() if not k.startswith('__'))
     result = __salt__[func](*args, **func_kwargs)
     if type(result) != dict:
         result = {'result': result}


### PR DESCRIPTION
This is a wrapper module that uses a hash function to evenly splay out job execution and returns across a set of minions (vs. batch which will process minions in the sliding window as fast as possible).  This comes in handy for large environments where running a job against '*' can result in the master being overwhelmed by all the simultaneous job returns.

I had a mind to make this invokable as a CLI arg to salt for parity with batch, but realize that it would be a departure from current convention to invoke a module from a CLI arg, so I'm just putting in the module for now :stuck_out_tongue_winking_eye: 
