### PR TITLE
Making vmware cloud driver Python3 compatible and other additions

### DIFF
--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -92,6 +92,15 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
             gateway: [10.40.50.110]
             subnet_mask: 255.255.255.128
             domain: mycompany.com
+        scsi:
+          SCSI controller 1:
+            type: lsilogic
+          SCSI controller 2:
+            type: lsilogic_sas
+            bus_sharing: virtual
+          SCSI controller 3:
+            type: paravirtual
+            bus_sharing: physical
 
       domain: mycompany.com
       dns_servers:
@@ -127,21 +136,21 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
         /srv/salt/yum/epel.repo: /etc/yum.repos.d/epel.repo
 
 
-provider
+``provider``
     Enter the name that was specified when the cloud provider config was created.
 
-clonefrom
+``clonefrom``
     Enter the name of the VM/template to clone from.
 
-num_cpus
+``num_cpus``
     Enter the number of vCPUS you want the VM/template to have. If not specified,
     the current VM/template\'s vCPU count is used.
 
-memory
+``memory``
     Enter memory (in MB) you want the VM/template to have. If not specified, the
     current VM/template\'s memory size is used.
 
-devices
+``devices``
     Enter the device specifications here. Currently, the following devices can be
     created or reconfigured:
 
@@ -164,7 +173,7 @@ devices
             Enter the network name you want the network adapter to be mapped to.
 
         type
-            Enter the network adapter type you wante to create. Currently supported
+            Enter the network adapter type you want to create. Currently supported
             types are vmxnet, vmxnet2, vmxnet3, e1000 and e1000e. If no type is
             specified, by default vmxnet3 will be used.
 
@@ -184,13 +193,38 @@ devices
             Enter the domain to be used with the network adapter. If the network
             specified is DHCP enabled, you do not have to specify this.
 
-domain
+    scsi
+        Enter the SCSI adapter specification here. If the SCSI adapter doesn\'t exist,
+        a new SCSI adapter will be created of the specified type. If the SCSI adapter
+        already exists, it will be reconfigured with the specifications. Currently, only
+        SCSI adapters of type lsilogic, lsilogic_sas and paravirtual can be created. The
+        following additional options can be specified per SCSI adapter:
+
+        type
+            Enter the SCSI adapter type you want to create. Currently supported
+            types are lsilogic, lsilogic_sas and paravirtual. Type must be specified
+            when creating a new SCSI adapter.
+
+        bus_sharing
+            Specify this if sharing of virtual disks between virtual machines is desired.
+            The following can be specified:
+
+            virtual
+                Virtual disks can be shared between virtual machines on the same server.
+
+            physical
+                Virtual disks can be shared between virtual machines on any server.
+
+            no
+                Virtual disks cannot be shared between virtual machines.
+
+``domain``
     Enter the global domain name to be used for DNS.
 
-dns_servers
+``dns_servers``
     Enter the list of DNS servers to use in order of priority.
 
-resourcepool
+``resourcepool``
     Enter the name of the resourcepool to which the new virtual machine should be
     attached. This determines what compute resources will be available to the clone.
 
@@ -203,7 +237,7 @@ resourcepool
           value will be used.
         - For a clone operation to a template, this argument is ignored.
 
-cluster
+``cluster``
     Enter the name of the cluster whose resource pool the new virtual machine should
     be attached to.
 
@@ -216,7 +250,7 @@ cluster
           value will be used.
         - For a clone operation to a template, this argument is ignored.
 
-datastore
+``datastore``
     Enter the name of the datastore or the datastore cluster where the virtual machine
     should be located on physical storage. If not specified, the current datastore is
     used.
@@ -227,7 +261,7 @@ datastore
           automatically applied.
         - If you specify a datastore name, DRS Storage recommendation is disabled.
 
-folder
+``folder``
     Enter the name of the folder that will contain the new virtual machine.
 
     .. note::
@@ -236,7 +270,7 @@ folder
           to the same folder that the original VM/template belongs to unless specified.
         - If both folder and datacenter are specified, the folder value will be used.
 
-datacenter
+``datacenter``
     Enter the name of the datacenter that will contain the new virtual machine.
 
     .. note::
@@ -245,7 +279,7 @@ datacenter
           to the same folder that the original VM/template belongs to unless specified.
         - If both folder and datacenter are specified, the folder value will be used.
 
-host
+``host``
     Enter the name of the target host where the virtual machine should be registered.
 
     If not specified:
@@ -260,40 +294,40 @@ host
         - If resource pool is specified and the target pool represents a cluster without
           DRS enabled, an InvalidArgument exception be thrown.
 
-template
+``template``
     Specifies whether the new virtual machine should be marked as a template or not.
     Default is ``template: False``.
 
-power_on
+``power_on``
     Specifies whether the new virtual machine should be powered on or not. If
     ``template: True`` is set, this field is ignored. Default is ``power_on: True``.
 
-extra_config
+``extra_config``
     Specifies the additional configuration information for the virtual machine. This
     describes a set of modifications to the additional options. If the key is already
     present, it will be reset with the new value provided. Otherwise, a new option is
     added. Keys with empty values will be removed.
 
-deploy
+``deploy``
     Specifies if salt should be installed on the newly created VM. Default is ``True``
     so salt will be installed using the bootstrap script. If ``template: True`` or
     ``power_on: False`` is set, this field is ignored and salt will not be installed.
 
-private_key
+``private_key``
     Specify the path to the private key to use to be able to ssh to the VM.
 
-ssh_username
+``ssh_username``
     Specify the username to use in order to ssh to the VM. Default is ``root``
 
-password
+``password``
     Specify a password to use in order to ssh to the VM. If ``private_key`` is
     specified, you do not need to specify this.
 
-minion
+``minion``
     Specify custom minion configuration you want the salt minion to have. A good example
     would be to specify the ``master`` as the IP/DNS name of the master.
 
-file_map
+``file_map``
     Specify file/files you want to copy to the VM before the bootstrap script is run
     and salt is installed. A good example of using this would be if you need to put
     custom repo files on the server in case your server will be in a private network

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -70,6 +70,9 @@ try:
 except Exception:
     pass
 
+# Import third party libs
+import salt.ext.six as six
+
 # Get logging started
 log = logging.getLogger(__name__)
 
@@ -372,13 +375,13 @@ def _set_network_adapter_mapping_helper(adapter_specs):
     adapter_mapping = vim.vm.customization.AdapterMapping()
     adapter_mapping.adapter = vim.vm.customization.IPSettings()
 
-    if 'domain' in adapter_specs.keys():
+    if 'domain' in list(adapter_specs.keys()):
         domain = adapter_specs['domain']
         adapter_mapping.adapter.dnsDomain = domain
-    if 'gateway' in adapter_specs.keys():
+    if 'gateway' in list(adapter_specs.keys()):
         gateway = adapter_specs['gateway']
         adapter_mapping.adapter.gateway = gateway
-    if 'ip' in adapter_specs.keys():
+    if 'ip' in list(adapter_specs.keys()):
         ip = str(adapter_specs['ip'])
         subnet_mask = str(adapter_specs['subnet_mask'])
         adapter_mapping.adapter.ip = vim.vm.customization.FixedIp(ipAddress=ip)
@@ -403,11 +406,11 @@ def _manage_devices(devices, vm):
     for device in vm.config.hardware.device:
         if hasattr(device.backing, 'fileName'):
             # this is a hard disk
-            if 'disk' in devices.keys():
+            if 'disk' in list(devices.keys()):
                 # there is atleast one disk specified to be created/configured
                 unit_number += 1
                 existing_disks_label.append(device.deviceInfo.label)
-                if device.deviceInfo.label in devices['disk'].keys():
+                if device.deviceInfo.label in list(devices['disk'].keys()):
                     size_gb = devices['disk'][device.deviceInfo.label]['size']
                     size_kb = int(size_gb) * 1024 * 1024
                     if device.capacityInKB < size_kb:
@@ -417,10 +420,10 @@ def _manage_devices(devices, vm):
 
         elif hasattr(device.backing, 'network'):
             # this is a network adapter
-            if 'network' in devices.keys():
+            if 'network' in list(devices.keys()):
                 # there is atleast one network adapter specified to be created/configured
                 existing_network_adapters_label.append(device.deviceInfo.label)
-                if device.deviceInfo.label in devices['network'].keys():
+                if device.deviceInfo.label in list(devices['network'].keys()):
                     network_name = devices['network'][device.deviceInfo.label]['name']
                     network_spec = _edit_existing_network_adapter_helper(device, network_name)
                     adapter_mapping = _set_network_adapter_mapping_helper(devices['network'][device.deviceInfo.label])
@@ -429,11 +432,11 @@ def _manage_devices(devices, vm):
 
         elif hasattr(device, 'scsiCtlrUnitNumber'):
             # this is a scsi adapter
-            if 'scsi' in devices.keys():
+            if 'scsi' in list(devices.keys()):
                 # there is atleast one scsi adapter specified to be created/configured
                 bus_number += 1
                 existing_scsi_adapters_label.append(device.deviceInfo.label)
-                if device.deviceInfo.label in devices['scsi'].keys():
+                if device.deviceInfo.label in list(devices['scsi'].keys()):
                     # Modify the existing SCSI adapter
                     scsi_adapter_properties = devices['scsi'][device.deviceInfo.label]
                     bus_sharing = scsi_adapter_properties['bus_sharing'].strip().lower() if 'bus_sharing' in scsi_adapter_properties else None
@@ -444,7 +447,7 @@ def _manage_devices(devices, vm):
                             scsi_spec = _edit_existing_scsi_adapter_helper(device, bus_sharing)
                             device_specs.append(scsi_spec)
 
-    if 'disk' in devices.keys():
+    if 'disk' in list(devices.keys()):
         disks_to_create = list(set(devices['disk'].keys()) - set(existing_disks_label))
         disks_to_create.sort()
         log.debug("Disks to create: {0}".format(disks_to_create))
@@ -455,7 +458,7 @@ def _manage_devices(devices, vm):
             device_specs.append(disk_spec)
             unit_number += 1
 
-    if 'network' in devices.keys():
+    if 'network' in list(devices.keys()):
         network_adapters_to_create = list(set(devices['network'].keys()) - set(existing_network_adapters_label))
         network_adapters_to_create.sort()
         log.debug("Networks to create: {0}".format(network_adapters_to_create))
@@ -468,7 +471,7 @@ def _manage_devices(devices, vm):
             device_specs.append(network_spec)
             nics_map.append(adapter_mapping)
 
-    if 'scsi' in devices.keys():
+    if 'scsi' in list(devices.keys()):
         scsi_adapters_to_create = list(set(devices['scsi'].keys()) - set(existing_scsi_adapters_label))
         scsi_adapters_to_create.sort()
         log.debug("SCSI adapters to create: {0}".format(scsi_adapters_to_create))
@@ -1673,7 +1676,7 @@ def create(vm_):
             config_spec.deviceChange = specs['device_specs']
 
         if extra_config:
-            for key, value in extra_config.iteritems():
+            for key, value in six.iteritems(extra_config):
                 option = vim.option.OptionValue(key=key, value=value)
                 config_spec.extraConfig.append(option)
 

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -312,10 +312,68 @@ def _add_new_network_adapter_helper(network_adapter_label, network_name, adapter
     return network_spec
 
 
+def _edit_existing_scsi_adapter_helper(scsi_adapter, bus_sharing):
+    scsi_adapter.sharedBus = bus_sharing
+    scsi_spec = vim.vm.device.VirtualDeviceSpec()
+    scsi_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
+    scsi_spec.device = scsi_adapter
+
+    return scsi_spec
+
+
+def _add_new_scsi_adapter_helper(scsi_adapter_label, properties, bus_number):
+    random_key = randint(-1050, -1000)
+    adapter_type = properties['type'].strip().lower() if 'type' in properties else None
+    bus_sharing = properties['bus_sharing'].strip().lower() if 'bus_sharing' in properties else None
+
+    scsi_spec = vim.vm.device.VirtualDeviceSpec()
+
+    if adapter_type == "lsilogic":
+        summary = "LSI Logic"
+        scsi_spec.device = vim.vm.device.VirtualLsiLogicController()
+    elif adapter_type == "lsilogic_sas":
+        summary = "LSI Logic Sas"
+        scsi_spec.device = vim.vm.device.VirtualLsiLogicSASController()
+    elif adapter_type == "paravirtual":
+        summary = "VMware paravirtual SCSI"
+        scsi_spec.device = vim.vm.device.ParaVirtualSCSIController()
+    else:
+        # If type not specified or does not match, show error and return
+        if not adapter_type:
+            err_msg = "The type of {0} has not been specified".format(scsi_adapter_label)
+        else:
+            err_msg = "Cannot create {0} of invalid/unsupported type {1}".format(scsi_adapter_label, adapter_type)
+        raise SaltCloudSystemExit(err_msg)
+
+    scsi_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
+
+    scsi_spec.device.key = random_key
+    scsi_spec.device.busNumber = bus_number
+    scsi_spec.device.deviceInfo = vim.Description()
+    scsi_spec.device.deviceInfo.label = scsi_adapter_label
+    scsi_spec.device.deviceInfo.summary = summary
+
+    if bus_sharing == "virtual":
+        # Virtual disks can be shared between virtual machines on the same server
+        scsi_spec.device.sharedBus = vim.vm.device.VirtualSCSIController.Sharing.virtualSharing
+
+    elif bus_sharing == "physical":
+        # Virtual disks can be shared between virtual machines on any server
+        scsi_spec.device.sharedBus = vim.vm.device.VirtualSCSIController.Sharing.physicalSharing
+
+    else:
+        # Virtual disks cannot be shared between virtual machines
+        scsi_spec.device.sharedBus = vim.vm.device.VirtualSCSIController.Sharing.noSharing
+
+    return scsi_spec
+
+
 def _manage_devices(devices, vm):
     unit_number = 0
+    bus_number = 0
     device_specs = []
     existing_disks_label = []
+    existing_scsi_adapters_label = []
     existing_network_adapters_label = []
     nics_map = []
 
@@ -327,9 +385,6 @@ def _manage_devices(devices, vm):
             if 'disk' in devices.keys():
                 # there is atleast one disk specified to be created/configured
                 unit_number += 1
-                # check if scsi controller
-                if unit_number == 7:
-                    unit_number += 1
                 existing_disks_label.append(device.deviceInfo.label)
                 if device.deviceInfo.label in devices['disk'].keys():
                     size_gb = devices['disk'][device.deviceInfo.label]['size']
@@ -365,6 +420,22 @@ def _manage_devices(devices, vm):
                     else:
                         adapter_mapping.adapter.ip = vim.vm.customization.DhcpIpGenerator()
                     nics_map.append(adapter_mapping)
+        elif hasattr(device, 'scsiCtlrUnitNumber'):
+            # this is a scsi adapter
+            if 'scsi' in devices.keys():
+                # there is atleast one scsi adapter specified to be created/configured
+                bus_number += 1
+                existing_scsi_adapters_label.append(device.deviceInfo.label)
+                if device.deviceInfo.label in devices['scsi'].keys():
+                    # Modify the existing SCSI adapter
+                    scsi_adapter_properties = devices['scsi'][device.deviceInfo.label]
+                    bus_sharing = scsi_adapter_properties['bus_sharing'].strip().lower() if 'bus_sharing' in scsi_adapter_properties else None
+                    if bus_sharing and bus_sharing in ['virtual', 'physical', 'no']:
+                        bus_sharing = '{0}Sharing'.format(bus_sharing)
+                        if bus_sharing != device.sharedBus:
+                            # Only edit the SCSI adapter if bus_sharing is different
+                            scsi_spec = _edit_existing_scsi_adapter_helper(device, bus_sharing)
+                            device_specs.append(scsi_spec)
 
     if 'disk' in devices.keys():
         disks_to_create = list(set(devices['disk'].keys()) - set(existing_disks_label))
@@ -376,9 +447,6 @@ def _manage_devices(devices, vm):
             disk_spec = _add_new_hard_disk_helper(disk_label, size_gb, unit_number)
             device_specs.append(disk_spec)
             unit_number += 1
-            # check if scsi controller
-            if unit_number == 7:
-                unit_number += 1
 
     if 'network' in devices.keys():
         network_adapters_to_create = list(set(devices['network'].keys()) - set(existing_network_adapters_label))
@@ -408,6 +476,17 @@ def _manage_devices(devices, vm):
             else:
                 adapter_mapping.adapter.ip = vim.vm.customization.DhcpIpGenerator()
             nics_map.append(adapter_mapping)
+
+    if 'scsi' in devices.keys():
+        scsi_adapters_to_create = list(set(devices['scsi'].keys()) - set(existing_scsi_adapters_label))
+        scsi_adapters_to_create.sort()
+        log.debug("SCSI adapters to create: {0}".format(scsi_adapters_to_create))
+        for scsi_adapter_label in scsi_adapters_to_create:
+            # create the scsi adapter
+            scsi_adapter_properties = devices['scsi'][scsi_adapter_label]
+            scsi_spec = _add_new_scsi_adapter_helper(scsi_adapter_label, scsi_adapter_properties, bus_number)
+            device_specs.append(scsi_spec)
+            bus_number += 1
 
     ret = {
         'device_specs': device_specs,

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -368,7 +368,7 @@ def _add_new_scsi_adapter_helper(scsi_adapter_label, properties, bus_number):
     return scsi_spec
 
 
-def _set_network_adapter_mapping(adapter_specs):
+def _set_network_adapter_mapping_helper(adapter_specs):
     adapter_mapping = vim.vm.customization.AdapterMapping()
     adapter_mapping.adapter = vim.vm.customization.IPSettings()
 
@@ -423,7 +423,7 @@ def _manage_devices(devices, vm):
                 if device.deviceInfo.label in devices['network'].keys():
                     network_name = devices['network'][device.deviceInfo.label]['name']
                     network_spec = _edit_existing_network_adapter_helper(device, network_name)
-                    adapter_mapping = _set_network_adapter_mapping(devices['network'][device.deviceInfo.label])
+                    adapter_mapping = _set_network_adapter_mapping_helper(devices['network'][device.deviceInfo.label])
                     device_specs.append(network_spec)
                     nics_map.append(adapter_mapping)
 
@@ -464,7 +464,7 @@ def _manage_devices(devices, vm):
             adapter_type = devices['network'][network_adapter_label]['type']
             # create the network adapter
             network_spec = _add_new_network_adapter_helper(network_adapter_label, network_name, adapter_type)
-            adapter_mapping = _set_network_adapter_mapping(devices['network'][network_adapter_label])
+            adapter_mapping = _set_network_adapter_mapping_helper(devices['network'][network_adapter_label])
             device_specs.append(network_spec)
             nics_map.append(adapter_mapping)
 


### PR DESCRIPTION
Made vmware salt-cloud driver Python3 compatible.

Added ability to modify/create SCSI adapters in `create()` in vmware salt-cloud driver and also adding docs for it
Refs feature request #22364 filed by @angystardust

Combining duplicate code for network adapter mapping in a single helper function called `_set_network_adapter_mapping_helper()`

@techhat 
