### PR TITLE
Connected - CacheWorker addition

### DIFF
--- a/salt/utils/cache.py
+++ b/salt/utils/cache.py
@@ -67,7 +67,6 @@ class CacheCli(object):
         '''
         Sets up the zmq-connection to the ConCache
         '''
-        super(CacheCli, self).__init__()
         self.opts = opts
         self.serial = salt.payload.Serial(self.opts.get('serial', ''))
         self.cache_sock = os.path.join(self.opts['sock_dir'], 'con_cache.ipc')

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -506,17 +506,6 @@ class ConnectedCache(multiprocessing.Process):
         '''
         self.stop()
 
-    def renew(self):
-        '''
-        compares the current minion list against the ips
-        connected on the master publisher port and updates
-        the minion list accordingly
-        '''
-        log.debug('ConCache renewing minion cache')
-        new_mins = list(salt.utils.minions.CkMinions(self.opts).connected_ids())
-        self.minions = new_mins
-        log.debug('ConCache received {0} minion ids'.format(len(new_mins)))
-
     def cleanup(self):
         '''
         remove sockets on shutdown
@@ -614,10 +603,6 @@ class ConnectedCache(multiprocessing.Process):
                         # Send reply back to client
                         reply = serial.dumps(self.minions)
                         creq_in.send(reply)
-
-                else:
-                    reply = serial.dumps(False)
-                    creq_in.send(reply)
 
             # check for next cache-update from workers
             elif socks.get(cupd_in) == zmq.POLLIN:

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -461,7 +461,7 @@ class CacheWorker(multiprocessing.Process):
         '''
         new_mins = list(salt.utils.minions.CkMinions(self.opts).connected_ids())
         cc = cache_cli(self.opts)
-
+        cc.get_cached()
         cc.put_cache(new_mins)
         log.debug('ConCache CacheWorker update finished')
 

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -626,6 +626,9 @@ class ConnectedCache(multiprocessing.Process):
                     if new_c_data[0] not in self.minions:
                         log.trace('ConCache Adding minion {0} to cache'.format(new_c_data[0]))
                         self.minions.append(new_c_data[0])
+                elif len(new_c_data) > 1:
+                    log.debug('ConCache Replacing minion list from worker')
+                    self.minions = new_c_data
                 else:
                     log.debug('ConCache Got malformed result dict from worker')
                     del new_c_data

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -443,7 +443,7 @@ class CacheTimer(Thread):
 
 class CacheWorker(multiprocessing.Process):
     '''
-    Worker for ConnectedCache updates which run in its
+    Worker for ConnectedCache which runs in its
     own process to prevent blocking of ConnectedCache
     main-loop when refreshing minion-list
     '''

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -595,7 +595,7 @@ class ConnectedCache(multiprocessing.Process):
             # check for next cache-request
             if socks.get(creq_in) == zmq.POLLIN:
                 msg = serial.loads(creq_in.recv())
-                log.trace('ConCache Received request: {0}'.format(msg))
+                log.debug('ConCache Received request: {0}'.format(msg))
 
                 # requests to the minion list are send as str's
                 if isinstance(msg, str):

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -640,8 +640,9 @@ class ConnectedCache(multiprocessing.Process):
                 sec_event = serial.loads(timer_in.recv())
 
                 # update the list every 30 seconds
-                if (sec_event == 31) or (sec_event == 1):
-                    self.renew()
+                if int(sec_event % 30) == 0:
+                    cw = CacheWorker(self.opts)
+                    cw.start()
 
         self.stop()
         creq_in.close()

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -441,6 +441,7 @@ class CacheTimer(Thread):
             if count >= 60:
                 count = 0
 
+
 class CacheWorker(multiprocessing.Process):
     '''
     Worker for ConnectedCache which runs in its

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -605,7 +605,7 @@ class ConnectedCache(multiprocessing.Process):
                         creq_in.send(reply)
 
             # check for next cache-update from workers
-            elif socks.get(cupd_in) == zmq.POLLIN:
+            if socks.get(cupd_in) == zmq.POLLIN:
                 new_c_data = serial.loads(cupd_in.recv())
                 # tell the worker to exit
                 #cupd_in.send(serial.dumps('ACK'))
@@ -636,7 +636,7 @@ class ConnectedCache(multiprocessing.Process):
                 log.info('ConCache {0} entries in cache'.format(len(self.minions)))
 
             # check for next timer-event to start new jobs
-            elif socks.get(timer_in) == zmq.POLLIN:
+            if socks.get(timer_in) == zmq.POLLIN:
                 sec_event = serial.loads(timer_in.recv())
 
                 # update the list every 30 seconds


### PR DESCRIPTION
The ConnectedCache runs CkMinions.connected_ids() in 30 second intervals to build a list of currently connected minions. Running connected_ids() can take quite a while on larger installations and the ConnectedCaches mainloop. in its current implementation, blocks while running it. This leads to MWorkers blocking during authentication of minions while waiting for the ConnectedCache.

The CacheWorker added with this PR runs connected_ids() in its own process and feeds the result back to the ConnectedCache using the CacheCli which fully removes the blockage described above.
