### PR TITLE
Don't assume package installation order.

### DIFF
--- a/tests/integration/modules/pip.py
+++ b/tests/integration/modules/pip.py
@@ -181,10 +181,11 @@ class PipModuleTest(integration.ModuleCase):
         )
         try:
             self.assertEqual(ret['retcode'], 0)
-            self.assertIn(
-                'Successfully installed pep8 Blinker SaltTesting',
-                ret['stdout']
-            )
+            for package in ('Blinker', 'SaltTesting', 'pep8'):
+                self.assertRegexpMatches(
+                    ret['stdout'],
+                    r'(?:.*)(Successfully installed)(?:.*)({0})(?:.*)'.format(package)
+                )
         except AssertionError:
             import pprint
             pprint.pprint(ret)


### PR DESCRIPTION
Additionally pep8 when installed using wheel, reports the version
together with the name.

```
Collecting pep8
  Using cached pep8-1.6.2-py2.py3-none-any.whl
Obtaining Blinker from git+https://github.com/jek/blinker.git#egg=Blinker
  Cloning https://github.com/jek/blinker.git to /tmp/tmpmWlmv7/venv/src/blinker
Obtaining SaltTesting from git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting
  Cloning https://github.com/saltstack/salt-testing.git to /tmp/tmpmWlmv7/venv/src/salttesting
Installing collected packages: pep8, Blinker, SaltTesting
  Running setup.py develop for Blinker
  Running setup.py develop for SaltTesting
Successfully installed Blinker SaltTesting pep8-1.6.2
```
