### PR TITLE
Node inspector module(s)

### DIFF
--- a/salt/modules/inspectlib/__init__.py
+++ b/salt/modules/inspectlib/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2015 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -119,6 +119,28 @@ class Inspector(object):
 
         self.db.connection.commit()
 
+    def _get_managed_files(self):
+        '''
+        Build a in-memory data of all managed files.
+        '''
+        dirs = set()
+        links = set()
+        files = set()
+
+        for line in os.popen("rpm -qlav").xreadlines():
+            line = line.strip()
+            if not line:
+                continue
+            line = line.replace("\t", " ").split(" ")
+            if line[0][0] == "d":
+                dirs.add(line[-1])
+            elif line[0][0] == "l":
+                links.add(line[-1])
+            elif line[0][0] == "-":
+                files.add(line[-1])
+
+        return sorted(files), sorted(dirs), sorted(links)
+
     def snapshot(self, mode):
         '''
         Take a snapshot of the system.

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -18,7 +18,7 @@ import os
 import sys
 from subprocess import Popen, PIPE, STDOUT
 from salt.modules.inspectlib.dbhandle import DBHandle
-
+from salt.modules.inspectlib.exceptions import (InspectorSnapshotException)
 
 class Inspector(object):
 
@@ -30,7 +30,7 @@ class Inspector(object):
             db_path = globals().get('__salt__')['config.get']('inspector.db', '')
 
         if not db_path:
-            raise Inspector.InspectorSnapshotException("Inspector database location is not configured yet in minion.")
+            raise InspectorSnapshotException("Inspector database location is not configured yet in minion.")
         self.dbfile = db_path
 
         self.db = DBHandle(self.dbfile)
@@ -40,7 +40,7 @@ class Inspector(object):
             pid_file = globals().get('__salt__')['config.get']('inspector.pid', '')
 
         if not pid_file:
-            raise Inspector.InspectorSnapshotException("Inspector PID file location is not configured yet in minion.")
+            raise InspectorSnapshotException("Inspector PID file location is not configured yet in minion.")
         self.pidfile = pid_file
 
     def _syscall(self, command, input=None, env=None, *params):
@@ -109,7 +109,7 @@ class Inspector(object):
         Take a snapshot of the system.
         '''
         if mode not in self.MODE:
-            raise Inspector.InspectorSnapshotException("Unknown mode: '{0}'".format(mode))
+            raise InspectorSnapshotException("Unknown mode: '{0}'".format(mode))
 
         os.system("nice -{0} python {1} {2} {3} {4} & > /dev/null".format(
             priority, __file__, self.pidfile, self.dbfile, mode))

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2014 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+from subprocess import Popen, PIPE, STDOUT
+from salt.modules.inspectlib.dbhandle import DBHandle
+
+
+class Inspector(object):
+    class InspectorSnapshotException(Exception):
+        '''
+        Snapshot exception.
+        '''
+
+    MODE = ['configuration', 'payload', 'all']
+
+    def __init__(self, db_path=None, pid_file=None):
+        # Configured path
+        if not db_path and '__salt__' in globals():
+            db_path = globals().get('__salt__')['config.get']('inspector.db', '')
+
+        if not db_path:
+            raise Inspector.InspectorSnapshotException("Inspector database location is not configured yet in minion.")
+        self.dbfile = db_path
+
+        self.db = DBHandle(self.dbfile)
+        self.db.open()
+
+        if not pid_file and '__salt__' in globals():
+            pid_file = globals().get('__salt__')['config.get']('inspector.pid', '')
+
+        if not pid_file:
+            raise Inspector.InspectorSnapshotException("Inspector PID file location is not configured yet in minion.")
+        self.pidfile = pid_file
+
+    def _syscall(self, command, input=None, env=None, *params):
+        '''
+        Call an external system command.
+        '''
+        return Popen([command] + list(params), stdout=PIPE, stdin=PIPE, stderr=STDOUT,
+                     env=env or os.environ).communicate(input=input)
+
+    def _get_cfg_pkgs(self):
+        '''
+        Get packages with configuration files.
+        '''
+        out, err = self._syscall('rpm', None, None, '-qa', '--configfiles',
+                                 '--queryformat', '%{name}-%{version}-%{release}\\n')
+        data = dict()
+        pkg_name = None
+        pkg_configs = []
+
+        for line in out.split(os.linesep):
+            line = line.strip()
+            if not line:
+                continue
+            if not line.startswith("/"):
+                if pkg_name and pkg_configs:
+                    data[pkg_name] = pkg_configs
+                pkg_name = line
+                pkg_configs = []
+            else:
+                pkg_configs.append(line)
+
+        if pkg_name and pkg_configs:
+            data[pkg_name] = pkg_configs
+
+        return data
+
+    def _save_cfg_pkgs(self, data):
+        '''
+        Save configuration packages.
+        '''
+        for table in ["inspector_pkg", "inspector_pkg_cfg_files"]:
+            self.db.flush(table)
+
+        pkg_id = 0
+        pkg_cfg_id = 0
+        for pkg_name, pkg_configs in data.items():
+            self.db.cursor.execute("INSERT INTO inspector_pkg (id, name) VALUES (?, ?)",
+                                   (pkg_id, pkg_name))
+            for pkg_config in pkg_configs:
+                self.db.cursor.execute("INSERT INTO inspector_pkg_cfg_files (id, pkgid, path) VALUES (?, ?, ?)",
+                                       (pkg_cfg_id, pkg_id, pkg_config))
+                pkg_cfg_id += 1
+            pkg_id += 1
+
+        self.db.connection.commit()
+
+    def snapshot(self, mode):
+        '''
+        Take a snapshot of the system.
+        '''
+        data = self._get_cfg_pkgs()
+        self._save_cfg_pkgs(data)
+
+    def request_snapshot(self, mode, priority=19):
+        '''
+        Take a snapshot of the system.
+        '''
+        if mode not in self.MODE:
+            raise Inspector.InspectorSnapshotException("Unknown mode: '{0}'".format(mode))
+
+        os.system("nice -{0} python {1} {2} {3} {4} & > /dev/null".format(
+            priority, __file__, self.pidfile, self.dbfile, mode))
+
+
+def is_alive(pidfile):
+    '''
+    Check if PID is still alive.
+    '''
+    # Just silencing os.kill exception if no such PID, therefore try/pass.
+    try:
+        os.kill(int(open(pidfile).read().strip()), 0)
+        sys.exit(1)
+    except Exception as ex:
+        pass
+
+
+def main(dbfile, pidfile, mode):
+    '''
+    Main analyzer routine.
+    '''
+    Inspector(dbfile, pidfile).snapshot(mode)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 4:
+        print >> sys.stderr, "This module is not intended to use directly!"
+        sys.exit(1)
+
+    pidfile, dbfile, mode = sys.argv[1:]
+    is_alive(pidfile)
+
+    # Double-fork stuff
+    try:
+        if os.fork() > 0:
+            sys.exit(0)
+    except OSError as ex:
+        sys.exit(1)
+
+    os.setsid()
+    os.umask(0)
+
+    try:
+        pid = os.fork()
+        if pid > 0:
+            fpid = open(pidfile, "w")
+            fpid.write("{0}\n".format(pid))
+            fpid.close()
+            sys.exit(0)
+    except OSError as ex:
+        sys.exit(1)
+
+    main(dbfile, pidfile, mode)

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -23,6 +23,9 @@ from salt.modules.inspectlib.exceptions import (InspectorSnapshotException)
 class Inspector(object):
 
     MODE = ['configuration', 'payload', 'all']
+    IGNORE_MOUNTS = ["proc", "sysfs", "devtmpfs", "tmpfs", "fuse.gvfs-fuse-daemon"]
+    IGNORE_FS_TYPES = ["autofs", "cifs", "nfs", "nfs4"]
+    IGNORE_PATHS = ["/tmp", "/var/tmp", "/lost+found", "/var/run", "/var/lib/rpm", "/.snapshots", "/.zfs", "/etc/ssh"]
 
     def __init__(self, db_path=None, pid_file=None):
         # Configured path

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -240,7 +240,6 @@ class Inspector(object):
         '''
         Take a snapshot of the system.
         '''
-        self.db.purge()
         self._save_cfg_pkgs(self._get_changed_cfg_pkgs(self._get_cfg_pkgs()))
 
     def request_snapshot(self, mode, priority=19):

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -126,6 +126,23 @@ class Inspector(object):
 
         self.db.connection.commit()
 
+    def _save_payload(self, files, directories, links):
+        '''
+        Save payload (unmanaged files)
+        '''
+        idx = 0
+        for p_type, p_list in (('f', files), ('d', directories), ('l', links,),):
+            for p_obj in p_list:
+                stats = os.stat(p_obj)
+                self.db.cursor.execute("INSERT INTO inspector_payload "
+                                       "(id, path, p_type, mode, uid, gid, p_size, atime, mtime, ctime)"
+                                       "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                                       (id, p_obj, p_type, stats.st_mode, stats.st_uid, stats.st_gid, stats.st_size,
+                                        stats.st_atime, stats.st_mtime, stats.st_ctime))
+                idx += 1
+
+        self.db.connection.commit()
+
     def _get_managed_files(self):
         '''
         Build a in-memory data of all managed files.

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -230,7 +230,10 @@ class Inspector(object):
         all_dirs = list()
         all_links = list()
         for entry_path in os.listdir("/"):
-            e_files, e_dirs, e_links = self._get_all_files("/{0}".format(entry_path), *ignored)
+            entry_path = "/{0}".format(entry_path)
+            if entry_path in ignored:
+                continue
+            e_files, e_dirs, e_links = self._get_all_files(entry_path, *ignored)
             all_files.extend(e_files)
             all_dirs.extend(e_dirs)
             all_links.extend(e_links)

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -137,7 +137,7 @@ class Inspector(object):
                 self.db.cursor.execute("INSERT INTO inspector_payload "
                                        "(id, path, p_type, mode, uid, gid, p_size, atime, mtime, ctime)"
                                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                                       (id, p_obj, p_type, stats.st_mode, stats.st_uid, stats.st_gid, stats.st_size,
+                                       (idx, p_obj, p_type, stats.st_mode, stats.st_uid, stats.st_gid, stats.st_size,
                                         stats.st_atime, stats.st_mtime, stats.st_ctime))
                 idx += 1
 

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -250,6 +250,7 @@ class Inspector(object):
         if mode not in self.MODE:
             raise InspectorSnapshotException("Unknown mode: '{0}'".format(mode))
 
+        self._prepare_full_scan()
         os.system("nice -{0} python {1} {2} {3} {4} & > /dev/null".format(
             priority, __file__, self.pidfile, self.dbfile, mode))
 

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -281,7 +281,9 @@ class Inspector(object):
         Take a snapshot of the system.
         '''
         # TODO: Mode
+
         self._save_cfg_pkgs(self._get_changed_cfg_pkgs(self._get_cfg_pkgs()))
+        self._save_payload(*self._scan_payload())
 
     def request_snapshot(self, mode, priority=19):
         '''
@@ -291,6 +293,7 @@ class Inspector(object):
             raise InspectorSnapshotException("Unknown mode: '{0}'".format(mode))
 
         self._prepare_full_scan()
+
         os.system("nice -{0} python {1} {2} {3} {4} & > /dev/null".format(
             priority, __file__, self.pidfile, self.dbfile, mode))
 

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -101,8 +101,7 @@ class Inspector(object):
         '''
         Take a snapshot of the system.
         '''
-        data = self._get_cfg_pkgs()
-        self._save_cfg_pkgs(data)
+        self._save_cfg_pkgs(self._get_changed_cfg_pkgs(self._get_cfg_pkgs()))
 
     def request_snapshot(self, mode, priority=19):
         '''

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -77,6 +77,28 @@ class Inspector(object):
 
         return data
 
+    def _get_changed_cfg_pkgs(self, data):
+        '''
+        Filter out unchanged packages.
+        '''
+        f_data = dict()
+        for pkg_name, pkg_files in data.items():
+            cfgs = list()
+            out, err = self._syscall("rpm", None, None, '-V', '--nodeps', '--nodigest',
+                                     '--nosignature', '--nomtime', '--nolinkto', pkg_name)
+            for line in out.split(os.linesep):
+                line = line.strip()
+                if not line or line.find(" c ") < 0 or line.split(" ")[0].find("5") < 0:
+                    continue
+
+                cfg_file = line.split(" ")[-1]
+                if cfg_file in pkg_files:
+                    cfgs.append(cfg_file)
+            if cfgs:
+                f_data[pkg_name] = cfgs
+
+        return f_data
+
     def _save_cfg_pkgs(self, data):
         '''
         Save configuration packages.

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -29,7 +29,9 @@ class Inspector(object):
     MODE = ['configuration', 'payload', 'all']
     IGNORE_MOUNTS = ["proc", "sysfs", "devtmpfs", "tmpfs", "fuse.gvfs-fuse-daemon"]
     IGNORE_FS_TYPES = ["autofs", "cifs", "nfs", "nfs4"]
-    IGNORE_PATHS = ["/tmp", "/var/tmp", "/lost+found", "/var/run", "/var/lib/rpm", "/.snapshots", "/.zfs", "/etc/ssh"]
+    IGNORE_PATHS = ["/tmp", "/var/tmp", "/lost+found", "/var/run",
+                    "/var/lib/rpm", "/.snapshots", "/.zfs", "/etc/ssh",
+                    "/root", "/home"]
 
     def __init__(self, db_path=None, pid_file=None):
         # Configured path

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -197,6 +197,29 @@ class Inspector(object):
         s_files, s_dirs, s_links = system_all
 
         return sorted(intr(m_files, s_files)), sorted(intr(m_dirs, s_dirs)), sorted(intr(m_links, s_links))
+
+    def _scan_payload(self):
+        '''
+        Scan the system.
+        '''
+        # Get ignored points
+        ignored = list()
+        self.db.cursor.execute("SELECT path FROM inspector_ignored")
+        for ign_path in self.db.cursor.fetchall():
+            ign_path = ign_path[0]
+            ignored.append(ign_path)
+
+        all_files = list()
+        all_dirs = list()
+        all_links = list()
+        for entry_path in os.listdir("/"):
+            e_files, e_dirs, e_links = self._get_all_files("/{0}".format(entry_path), *ignored)
+            all_files.extend(e_files)
+            all_dirs.extend(e_dirs)
+            all_links.extend(e_links)
+
+        return self._get_unmanaged_files(self._get_managed_files(), (all_files, all_dirs, all_links,))
+
     def _prepare_full_scan(self):
         '''
 

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -183,7 +183,7 @@ class Inspector(object):
                         continue
                 except Exception as ex:
                     continue
-            if not valid:
+            if not valid or not os.path.exists(obj):
                 continue
             mode = os.lstat(obj).st_mode
             if stat.S_ISLNK(mode):

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -21,10 +21,6 @@ from salt.modules.inspectlib.dbhandle import DBHandle
 
 
 class Inspector(object):
-    class InspectorSnapshotException(Exception):
-        '''
-        Snapshot exception.
-        '''
 
     MODE = ['configuration', 'payload', 'all']
 

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -179,6 +179,22 @@ class Inspector(object):
                 files.append(obj)
 
         return sorted(files), sorted(dirs), sorted(links)
+
+    def _get_unmanaged_files(self, managed, system_all):
+        '''
+        Get the intersection between all files and managed files.
+        '''
+        def intr(src, data):
+            out = set()
+            for d_el in data:
+                if d_el not in src:
+                    out.add(d_el)
+            return out
+
+        m_files, m_dirs, m_links = managed
+        s_files, s_dirs, s_links = system_all
+
+        return sorted(intr(m_files, s_files)), sorted(intr(m_dirs, s_dirs)), sorted(intr(m_links, s_links))
     def snapshot(self, mode):
         '''
         Take a snapshot of the system.

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -219,17 +219,24 @@ class Inspector(object):
         Scan the system.
         '''
         # Get ignored points
+        allowed = list()
+        self.db.cursor.execute("SELECT path FROM inspector_allowed")
+        for alwd_path in self.db.cursor.fetchall():
+            if os.path.exists(alwd_path[0]):
+                allowed.append(alwd_path[0])
+
         ignored = list()
-        self.db.cursor.execute("SELECT path FROM inspector_ignored")
-        for ign_path in self.db.cursor.fetchall():
-            ign_path = ign_path[0]
-            ignored.append(ign_path)
+        if not allowed:
+            self.db.cursor.execute("SELECT path FROM inspector_ignored")
+            for ign_path in self.db.cursor.fetchall():
+                ignored.append(ign_path[0])
 
         all_files = list()
         all_dirs = list()
         all_links = list()
-        for entry_path in os.listdir("/"):
-            entry_path = "/{0}".format(entry_path)
+        for entry_path in [pth for pth in (allowed or os.listdir("/")) if pth]:
+            if entry_path[0] != "/":
+                entry_path = "/{0}".format(entry_path)
             if entry_path in ignored:
                 continue
             e_files, e_dirs, e_links = self._get_all_files(entry_path, *ignored)

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -240,6 +240,7 @@ class Inspector(object):
         '''
         Take a snapshot of the system.
         '''
+        # TODO: Mode
         self._save_cfg_pkgs(self._get_changed_cfg_pkgs(self._get_cfg_pkgs()))
 
     def request_snapshot(self, mode, priority=19):

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2014 SUSE LLC
+# Copyright 2015 SUSE LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -177,11 +177,8 @@ class Inspector(object):
             obj = os.path.join(path, obj)
             valid = True
             for ex_obj in exclude:
-                try:
-                    if obj.startswith(str(ex_obj)):
-                        valid = False
-                        continue
-                except Exception as ex:
+                if obj.startswith(str(ex_obj)):
+                    valid = False
                     continue
             if not valid or not os.path.exists(obj):
                 continue

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -248,7 +248,7 @@ class Inspector(object):
 
     def _prepare_full_scan(self, **kwargs):
         '''
-
+        Prepare full system scan by setting up the database etc.
         '''
         # TODO: Backup the SQLite database. Backup should be restored automatically if current db failed while queried.
         self.db.purge()
@@ -288,7 +288,6 @@ class Inspector(object):
         self.db.connection.commit()
 
         return ignored_all
-
 
     def snapshot(self, mode):
         '''

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -101,6 +101,7 @@ class Inspector(object):
         '''
         Take a snapshot of the system.
         '''
+        self.db.purge()
         self._save_cfg_pkgs(self._get_changed_cfg_pkgs(self._get_cfg_pkgs()))
 
     def request_snapshot(self, mode, priority=19):

--- a/salt/modules/inspectlib/dbhandle.py
+++ b/salt/modules/inspectlib/dbhandle.py
@@ -108,6 +108,14 @@ class DBHandle(DBHandleBase):
         '''
         DBHandleBase.__init__(self, path)
 
-        self.init_queries.append("CREATE TABLE inspector_pkg (id INTEGER PRIMARY KEY, name CHAR(255))")
-        self.init_queries.append("CREATE TABLE inspector_pkg_cfg_files (id INTEGER PRIMARY KEY, pkgid INTEGER, path CHAR(4096))")
-        self.init_queries.append("CREATE TABLE inspector_pkg_cfg_diffs (id INTEGER PRIMARY KEY, cfgid INTEGER, diff TEXT)")
+        self.init_queries.append("CREATE TABLE inspector_pkg "
+                                 "(id INTEGER PRIMARY KEY, name CHAR(255))")
+        self.init_queries.append("CREATE TABLE inspector_pkg_cfg_files "
+                                 "(id INTEGER PRIMARY KEY, pkgid INTEGER, path CHAR(4096))")
+        self.init_queries.append("CREATE TABLE inspector_pkg_cfg_diffs "
+                                 "(id INTEGER PRIMARY KEY, cfgid INTEGER, diff TEXT)")
+        self.init_queries.append("CREATE TABLE inspector_payload "
+                                 "(id INTEGER PRIMARY KEY, path CHAR(4096), "
+                                 "p_type char(1), mode INTEGER, uid INTEGER, gid INTEGER, p_size INTEGER, "
+                                 "atime FLOAT, mtime FLOAT, ctime FLOAT)")
+        self.init_queries.append("CREATE TABLE inspector_ignored (path CHAR(4096))")

--- a/salt/modules/inspectlib/dbhandle.py
+++ b/salt/modules/inspectlib/dbhandle.py
@@ -51,10 +51,15 @@ class DBHandleBase(object):
         if self.cursor.fetchall():
             return
 
+        self._run_init_queries()
+        self.connection.commit()
+
+    def _run_init_queries(self):
+        '''
+        Initialization queries
+        '''
         for query in self.init_queries:
             self.cursor.execute(query)
-
-        self.connection.commit()
 
     def purge(self):
         '''
@@ -63,8 +68,9 @@ class DBHandleBase(object):
         if self.connection and self.cursor:
             self.cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
             for table_name in self.cursor.fetchall():
-                self.cursor.execute("DROP TABLE ?", (table_name,))
+                self.cursor.execute("DROP TABLE {0}".format(table_name[0]))
             self.connection.commit()
+        self._run_init_queries()
 
     def flush(self, table):
         '''

--- a/salt/modules/inspectlib/dbhandle.py
+++ b/salt/modules/inspectlib/dbhandle.py
@@ -45,6 +45,7 @@ class DBHandleBase(object):
             os.unlink(self._path)  # As simple as that
 
         self.connection = sqlite3.connect(self._path)
+        self.connection.text_factory = str
         self.cursor = self.connection.cursor()
 
         self.cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")

--- a/salt/modules/inspectlib/dbhandle.py
+++ b/salt/modules/inspectlib/dbhandle.py
@@ -80,3 +80,28 @@ class DBHandleBase(object):
         if self.cursor is not None and self.connection is not None:
             self.connection.close()
             self.cursor = self.connection = None
+
+
+class DBHandle(DBHandleBase):
+    __instance = None
+
+    def __new__(cls, *args, **kwargs):
+        '''
+        Keep singleton.
+        '''
+        if not cls.__instance:
+            cls.__instance = super(DBHandle, cls).__new__(cls, *args, **kwargs)
+        return cls.__instance
+
+    def __init__(self, path):
+        '''
+        Database handle for the specific
+
+        :param path:
+        :return:
+        '''
+        DBHandleBase.__init__(self, path)
+
+        self.init_queries.append("CREATE TABLE inspector_pkg (id INTEGER PRIMARY KEY, name CHAR(255))")
+        self.init_queries.append("CREATE TABLE inspector_pkg_cfg_files (id INTEGER PRIMARY KEY, pkgid INTEGER, path CHAR(4096))")
+        self.init_queries.append("CREATE TABLE inspector_pkg_cfg_diffs (id INTEGER PRIMARY KEY, cfgid INTEGER, diff TEXT)")

--- a/salt/modules/inspectlib/dbhandle.py
+++ b/salt/modules/inspectlib/dbhandle.py
@@ -119,4 +119,8 @@ class DBHandle(DBHandleBase):
                                  "(id INTEGER PRIMARY KEY, path CHAR(4096), "
                                  "p_type char(1), mode INTEGER, uid INTEGER, gid INTEGER, p_size INTEGER, "
                                  "atime FLOAT, mtime FLOAT, ctime FLOAT)")
+
+        # inspector_allowed overrides inspector_ignored.
+        # I.e. if allowed is not empty, then inspector_ignored is completely omitted.
         self.init_queries.append("CREATE TABLE inspector_ignored (path CHAR(4096))")
+        self.init_queries.append("CREATE TABLE inspector_allowed (path CHAR(4096))")

--- a/salt/modules/inspectlib/dbhandle.py
+++ b/salt/modules/inspectlib/dbhandle.py
@@ -56,6 +56,16 @@ class DBHandleBase(object):
 
         self.connection.commit()
 
+    def purge(self):
+        '''
+        Purge whole database.
+        '''
+        if self.connection and self.cursor:
+            self.cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
+            for table_name in self.cursor.fetchall():
+                self.cursor.execute("DROP TABLE ?", (table_name,))
+            self.connection.commit()
+
     def flush(self, table):
         '''
         Flush the table.

--- a/salt/modules/inspectlib/dbhandle.py
+++ b/salt/modules/inspectlib/dbhandle.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2014 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sqlite3
+import os
+
+
+class DBHandle(object):
+    '''
+    Handle for the *volatile* database, which serves the purpose of caching
+    the inspected data. This database can be destroyed or corrupted, so it should
+    be simply re-created from scratch.
+    '''
+    __instance = None
+
+    def __new__(cls, *args, **kwargs):
+        '''
+        Keep singleton.
+        '''
+        if not cls.__instance:
+            cls.__instance = super(DBHandle, cls).__new__(cls, *args, **kwargs)
+        return cls.__instance
+
+    def __init__(self, path):
+        '''
+        Constructor.
+        '''
+        self._path = path
+        self.connection = None
+        self.cursor = None
+
+    def open(self, new=False):
+        '''
+        Init the database, if required.
+        '''
+        if self.connection and self.cursor:
+            return
+
+        if new and os.path.exists(self._path):
+            os.unlink(self._path)  # As simple as that
+
+        self.connection = sqlite3.connect(self._path)
+        self.cursor = self.connection.cursor()
+
+        self.cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        if self.cursor.fetchall():
+            return
+
+        self.cursor.execute("CREATE TABLE inspector_pkg (id INTEGER PRIMARY KEY, name CHAR(255))")
+        self.cursor.execute("CREATE TABLE inspector_pkg_cfg_files (id INTEGER PRIMARY KEY, pkgid INTEGER, path CHAR(4096))")
+        self.cursor.execute("CREATE TABLE inspector_pkg_cfg_diffs (id INTEGER PRIMARY KEY, cfgid INTEGER, diff TEXT)")
+        self.connection.commit()
+
+    def flush(self, table):
+        '''
+        Flush the table.
+        '''
+        self.cursor.execute("DELETE FROM " + table)
+        self.connection.commit()
+
+    def close(self):
+        '''
+        Close the database connection.
+        '''
+        if self.cursor is not None and self.connection is not None:
+            self.connection.close()
+            self.cursor = self.connection = None

--- a/salt/modules/inspectlib/dbhandle.py
+++ b/salt/modules/inspectlib/dbhandle.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2014 SUSE LLC
+# Copyright 2015 SUSE LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/salt/modules/inspectlib/exceptions.py
+++ b/salt/modules/inspectlib/exceptions.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2014 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class InspectorSnapshotException(Exception):
+    '''
+    Snapshot exception.
+    '''
+
+
+class InspectorQueryException(Exception):
+    '''
+    Exception that is only for the inspector query.
+    '''
+
+
+class SIException(Exception):
+    '''
+    System information exception.
+    '''

--- a/salt/modules/inspectlib/exceptions.py
+++ b/salt/modules/inspectlib/exceptions.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2014 SUSE LLC
+# Copyright 2015 SUSE LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -365,5 +365,13 @@ class Query(object):
         return data
 
     def _all(self, *args, **kwargs):
-        return "This is all"
+        '''
+        Return all the summary of the particular system.
+        '''
+        data = dict()
+        data['software'] = self._software(**kwargs)
+        data['system'] = self._system(**kwargs)
+        data['services'] = self._services(**kwargs)
+
+        return data
 

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -357,7 +357,11 @@ class Query(object):
         }
 
     def _payload(self, *args, **kwargs):
-        return "This is payload"
+        '''
+        Find all unmanaged files.
+        '''
+        data = dict()
+        return data
 
     def _all(self, *args, **kwargs):
         return "This is all"

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -137,7 +137,6 @@ class SysInfo(object):
         }
 
 
-
 class Query(object):
     '''
     Query the system.
@@ -249,7 +248,6 @@ class Query(object):
                 groups[name]['users'] = users.split(',')
 
         return groups
-
 
     def _get_external_accounts(self, locals):
         '''
@@ -521,4 +519,3 @@ class Query(object):
         data['payload'] = self._payload(**kwargs) or 'N/A'
 
         return data
-

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -290,6 +290,7 @@ class Query(object):
         data = dict()
         data['cpu'] = sysinfo._get_cpu()
         data['disks'] = sysinfo._get_fs()
+        data['mounts'] = sysinfo._get_mounts()
         data['memory'] = sysinfo._get_mem()
         data['network'] = sysinfo._get_network()
         data['os'] = sysinfo._get_os()

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -33,7 +33,7 @@ class SysInfo(object):
 
     def __init__(self, systype):
         if systype.lower() == "solaris":
-            raise SysInfo.SIException("Platform {0} not (yet) supported.".format(systype))
+            raise SIException("Platform {0} not (yet) supported.".format(systype))
 
     def _grain(self, grain):
         '''

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -202,6 +202,7 @@ class Query(object):
         data['disks'] = sysinfo._get_fs()
         data['memory'] = sysinfo._get_mem()
         data['network'] = sysinfo._get_network()
+        data['os'] = sysinfo._get_os()
 
         return data
 

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -142,12 +142,6 @@ class Query(object):
     so there would be no need to pick it from various places.
     '''
 
-    class InspectorQueryException(Exception):
-        '''
-        Exception that is only for the inspector query.
-        '''
-        pass
-
     # Configuration: config files
     # Identity: users/groups
     # Software: packages, patterns, repositories

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -48,6 +48,7 @@ class SysInfo(object):
         out = __salt__['cmd.run_all']("df {0}".format(device))
         if out['retcode']:
             msg = "Disk size info error: {0}".format(out['stderr'])
+            log.error(msg)
             raise SIException(msg)
 
         devpath, blocks, used, available, used_p, mountpoint = [elm for elm in out['stdout'].split(os.linesep)[-1].split(" ") if elm]

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -392,7 +392,10 @@ class Query(object):
         data['software'] = self._software(**kwargs)
         data['system'] = self._system(**kwargs)
         data['services'] = self._services(**kwargs)
-        data['configuration'] = self._configuration(**kwargs)
+        try:
+            data['configuration'] = self._configuration(**kwargs)
+        except InspectorQueryException as ex:
+            log.error(ex)
 
         return data
 

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -232,6 +232,28 @@ class Query(object):
         return groups
 
 
+    def _get_external_accounts(self, locals):
+        '''
+        Return all known accounts, excluding local accounts.
+        '''
+        users = dict()
+        out = __salt__['cmd.run_all']("passwd -S -a")
+        if out['retcode']:
+            # System does not supports all accounts descriptions, just skipping.
+            return users
+        status = {'L': 'Locked', 'NP': 'No password', 'P': 'Usable password', 'LK': 'Locked'}
+        for data in [elm.strip().split(" ") for elm in out['stdout'].split(os.linesep) if elm.strip()]:
+            if len(data) < 2:
+                continue
+            name, login = data[:2]
+            if name not in locals:
+                users[name] = {
+                    'login': login,
+                    'status': status.get(login, 'N/A')
+                }
+
+        return users
+
     def _identity(self, *args, **kwargs):
         return "This is identity"
 

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -396,6 +396,7 @@ class Query(object):
             data['configuration'] = self._configuration(**kwargs)
         except InspectorQueryException as ex:
             log.error(ex)
+        data['payload'] = self._payload(**kwargs) or 'N/A'
 
         return data
 

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -167,7 +167,7 @@ class Query(object):
         :return:
         '''
         if scope not in self.SCOPES:
-            raise Query.InspectorQueryException(
+            raise InspectorQueryException(
                 "Unknown scope: {0}. Must be one of: {1}".format(repr(scope), ", ".join(self.SCOPES)))
         self.scope = '_' + scope
         self.db = DBHandle(globals()['__salt__']['config.get']('inspector.db', ''))

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -207,6 +207,9 @@ class Query(object):
             data[pkg_name] = configs
         self.db.close()
 
+        if not data:
+            raise InspectorQueryException("No inspected configuration yet available.")
+
         return data
 
     def _get_local_users(self, disabled=None):

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -180,7 +180,10 @@ class Query(object):
         return getattr(self, self.scope)(*args, **kwargs)
 
     def _changes(self, *args, **kwargs):
-        return "This is changes"
+        '''
+        Returns all diffs to the configuration files.
+        '''
+        raise Exception("Not yet implemented")
 
     def _configuration(self, *args, **kwargs):
         '''

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -64,6 +64,18 @@ class SysInfo(object):
         salt.utils.fsutils._verify_run(out)
 
         return salt.utils.fsutils._blkid_output(out['stdout'])
+    def _get_cpu(self):
+        '''
+        Get available CPU information.
+        '''
+        # CPU data in grains is OK-ish, but lscpu is still better in this case
+        out = __salt__['cmd.run_all']("lscpu")
+        salt.utils.fsutils._verify_run(out)
+        data = dict()
+        for descr, value in [elm.split(":", 1) for elm in out['stdout'].split(os.linesep)]:
+            data[descr.strip()] = value.strip()
+
+        return data
 
     def _get_mem(self):
         '''

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -162,7 +162,8 @@ class Query(object):
         :return:
         '''
         if scope not in self.SCOPES:
-            raise Query.InspectorQueryException("Unknown scope: {0}".format(repr(scope)))
+            raise Query.InspectorQueryException(
+                "Unknown scope: {0}. Must be one of: {1}".format(repr(scope), ", ".join(self.SCOPES)))
         self.scope = '_' + scope
 
     def __call__(self, *args, **kwargs):

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 
-import salt
 import os
 
+import salt
 
 class SysInfo(object):
     '''

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -395,6 +395,7 @@ class Query(object):
         try:
             data['configuration'] = self._configuration(**kwargs)
         except InspectorQueryException as ex:
+            data['configuration'] = 'N/A'
             log.error(ex)
         data['payload'] = self._payload(**kwargs) or 'N/A'
 

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -90,9 +90,8 @@ class SysInfo(object):
         Get memory.
         '''
         out = __salt__['cmd.run_all']("vmstat -s")
-        print out.keys()
         if out['retcode']:
-            raise SysInfo.SIException("Error: {0}".format(out['stderr']))
+            raise SysInfo.SIException("Memory info error: {0}".format(out['stderr']))
 
         ret = dict()
         for line in out['stdout'].split(os.linesep):

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -40,6 +40,21 @@ class SysInfo(object):
         '''
         return __grains__.get(grain, 'N/A')
 
+    def _get_disk_size(self, device):
+        '''
+        Get a size of a disk.
+        '''
+        out = __salt__['cmd.run_all']("df {0}".format(device))
+        if out['retcode']:
+            raise SysInfo.SIException("Disk size info error: {0}".format(out['stderr']))
+
+        devpath, blocks, used, available, used_p, mountpoint = [elm for elm in out['stdout'].split(os.linesep)[-1].split(" ") if elm]
+
+        return {
+            'device': devpath, 'blocks': blocks, 'used': used,
+            'available': available, 'used (%)': used_p, 'mounted': mountpoint,
+        }
+
     def _get_fs(self):
         '''
         Get available file systems and their types.

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -194,13 +194,10 @@ class Query(object):
         :param kwargs:
         :return:
         '''
-        CPU = 'CPU'
-        data = {CPU: dict()}
-        for key, value in __grains__.items():
-            print "KEY:", key
-            if key.startswith("cpu_"):
-                data[CPU][key.replace("cpu_", "")] = value
         sysinfo = SysInfo(__grains__.get("kernel"))
+
+        data = dict()
+        data['cpu'] = sysinfo._get_cpu()
         data['disks'] = sysinfo._get_fs()
         data['memory'] = sysinfo._get_mem()
 

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -74,6 +74,12 @@ class SysInfo(object):
 
         return data
 
+    def _get_mounts(self):
+        '''
+        Get mounted FS on the system.
+        '''
+        return salt.utils.fsutils._get_mounts()
+
     def _get_cpu(self):
         '''
         Get available CPU information.

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -258,7 +258,13 @@ class Query(object):
         return data
 
     def _services(self, *args, **kwargs):
-        return "This is service"
+        '''
+        Get list of enabled and disabled services on the particular system.
+        '''
+        return {
+            'enabled': __salt__['service.get_enabled'](),
+            'disabled': __salt__['service.get_disabled'](),
+        }
 
     def _payload(self, *args, **kwargs):
         return "This is payload"

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -31,12 +31,6 @@ class SysInfo(object):
     System information.
     '''
 
-    class SIException(Exception):
-        '''
-        System information exception.
-        '''
-        pass
-
     def __init__(self, systype):
         if systype.lower() == "solaris":
             raise SysInfo.SIException("Platform {0} not (yet) supported.".format(systype))

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -34,6 +34,12 @@ class SysInfo(object):
         if systype.lower() == "solaris":
             raise SysInfo.SIException("Platform {0} not (yet) supported.".format(systype))
 
+    def _grain(self, grain):
+        '''
+        An alias for grains getter.
+        '''
+        return __grains__.get(grain, 'N/A')
+
     def _get_fs(self):
         '''
         Get available file systems and their types.

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -21,6 +21,7 @@ import logging
 import salt
 import salt.utils.network
 from salt.modules.inspectlib.dbhandle import DBHandle
+from salt.modules.inspectlib.exceptions import (InspectorQueryException, SIException)
 
 log = logging.getLogger(__name__)
 

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -18,6 +18,8 @@
 import os
 
 import salt
+import salt.utils.network
+
 
 class SysInfo(object):
     '''
@@ -104,6 +106,16 @@ class SysInfo(object):
                 size = size + "K"
             ret[descr] = size
         return ret
+
+    def _get_network(self):
+        '''
+        Get network configuration.
+        '''
+        data = dict()
+        data['interfaces'] = salt.utils.network.interfaces()
+        data['subnets'] = salt.utils.network.subnets()
+
+        return data
 
 
 class Query(object):

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -98,7 +98,7 @@ class SysInfo(object):
         '''
         out = __salt__['cmd.run_all']("vmstat -s")
         if out['retcode']:
-            raise SysInfo.SIException("Memory info error: {0}".format(out['stderr']))
+            raise SIException("Memory info error: {0}".format(out['stderr']))
 
         ret = dict()
         for line in out['stdout'].split(os.linesep):

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -255,7 +255,26 @@ class Query(object):
         return users
 
     def _identity(self, *args, **kwargs):
-        return "This is identity"
+        '''
+        Local users and groups.
+
+        accounts
+            Can be either 'local', 'remote' or 'all' (equal to "local,remote").
+            Remote accounts cannot be resolved on all systems, but only
+            those, which supports 'passwd -S -a'.
+
+        disabled
+            True (or False, default) to return only disabled accounts.
+        '''
+        LOCAL = 'local accounts'
+        EXT = 'external accounts'
+
+        data = dict()
+        data[LOCAL] = self._get_local_users(disabled=kwargs.get('disabled'))
+        data[EXT] = self._get_external_accounts(data[LOCAL].keys()) or 'N/A'
+        data['local groups'] = self._get_local_groups()
+
+        return data
 
     def _system(self, *args, **kwargs):
         '''

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -315,6 +315,9 @@ class Query(object):
         return data
 
     def _software(self, *args, **kwargs):
+        '''
+        Return installed software.
+        '''
         data = dict()
         if 'exclude' in kwargs:
             excludes = kwargs['exclude'].split(",")

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -16,11 +16,13 @@
 
 
 import os
+import logging
 
 import salt
 import salt.utils.network
 from salt.modules.inspectlib.dbhandle import DBHandle
 
+log = logging.getLogger(__name__)
 
 
 class SysInfo(object):

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -47,7 +47,8 @@ class SysInfo(object):
         '''
         out = __salt__['cmd.run_all']("df {0}".format(device))
         if out['retcode']:
-            raise SysInfo.SIException("Disk size info error: {0}".format(out['stderr']))
+            msg = "Disk size info error: {0}".format(out['stderr'])
+            raise SIException(msg)
 
         devpath, blocks, used, available, used_p, mountpoint = [elm for elm in out['stdout'].split(os.linesep)[-1].split(" ") if elm]
 

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2014 SUSE LLC
+# Copyright 2015 SUSE LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -212,6 +212,26 @@ class Query(object):
 
         return users
 
+    def _get_local_groups(self):
+        '''
+        Return all known local groups to the system.
+        '''
+        groups = dict()
+        for line in open("/etc/group").xreadlines():
+            line = line.strip()
+            if ":" not in line:
+                continue
+            name, password, gid, users = line.split(":")
+            groups[name] = {
+                'gid': gid,
+            }
+
+            if users:
+                groups[name]['users'] = users.split(',')
+
+        return groups
+
+
     def _identity(self, *args, **kwargs):
         return "This is identity"
 

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -189,6 +189,29 @@ class Query(object):
     def _configuration(self, *args, **kwargs):
         return "This is configuration"
 
+    def _get_local_users(self, disabled=None):
+        '''
+        Return all known local accounts to the system.
+        '''
+        users = dict()
+        for line in open("/etc/passwd").xreadlines():
+            line = line.strip()
+            if ":" not in line:
+                continue
+            name, password, uid, gid, gecos, directory, shell = line.split(":")
+            active = not (password == "*" or password.startswith("!"))
+            if (disabled is False and active) or (disabled is True and not active) or disabled is None:
+                users[name] = {
+                    'uid': uid,
+                    'git': gid,
+                    'info': gecos,
+                    'home': directory,
+                    'shell': shell,
+                    'disabled': not active
+                }
+
+        return users
+
     def _identity(self, *args, **kwargs):
         return "This is identity"
 

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2014 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import salt
+import os
+
+
+class SysInfo(object):
+    '''
+    System information.
+    '''
+
+    class SIException(Exception):
+        '''
+        System information exception.
+        '''
+        pass
+
+    def __init__(self, systype):
+        if systype.lower() == "solaris":
+            raise SysInfo.SIException("Platform {0} not (yet) supported.".format(systype))
+
+    def _get_fs(self):
+        '''
+        Get available file systems and their types.
+        '''
+
+        out = __salt__['cmd.run_all']("blkid -o export")
+        salt.utils.fsutils._verify_run(out)
+
+        return salt.utils.fsutils._blkid_output(out['stdout'])
+
+    def _get_mem(self):
+        '''
+        Get memory.
+        '''
+        out = __salt__['cmd.run_all']("vmstat -s")
+        print out.keys()
+        if out['retcode']:
+            raise SysInfo.SIException("Error: {0}".format(out['stderr']))
+
+        ret = dict()
+        for line in out['stdout'].split(os.linesep):
+            line = line.strip()
+            if not line:
+                continue
+            size, descr = line.split(" ", 1)
+            if descr.startswith("K "):
+                descr = descr[2:]
+                size = size + "K"
+            ret[descr] = size
+        return ret
+
+
+class Query(object):
+    '''
+    Query the system.
+    This class is actually puts all Salt features together,
+    so there would be no need to pick it from various places.
+    '''
+
+    class InspectorQueryException(Exception):
+        '''
+        Exception that is only for the inspector query.
+        '''
+        pass
+
+    # Configuration: config files
+    # Identity: users/groups
+    # Software: packages, patterns, repositories
+    # Services
+    # System: distro, RAM etc
+    # Changes: all files that are managed and were changed from the original
+    # all: include all scopes (scary!)
+    # payload: files that are not managed
+
+    SCOPES = ["changes", "configuration", "identity", "system", "software", "services", "payload", "all"]
+
+    def __init__(self, scope):
+        '''
+        Constructor.
+
+        :param scope:
+        :return:
+        '''
+        if scope not in self.SCOPES:
+            raise Query.InspectorQueryException("Unknown scope: {0}".format(repr(scope)))
+        self.scope = '_' + scope
+
+    def __call__(self, *args, **kwargs):
+        '''
+        Call the query with the defined scope.
+
+        :param args:
+        :param kwargs:
+        :return:
+        '''
+
+        return getattr(self, self.scope)(*args, **kwargs)
+
+    def _changes(self, *args, **kwargs):
+        return "This is changes"
+
+    def _configuration(self, *args, **kwargs):
+        return "This is configuration"
+
+    def _identity(self, *args, **kwargs):
+        return "This is identity"
+
+    def _system(self, *args, **kwargs):
+        '''
+        This basically calls grains items and picks out only
+        necessary information in a certain structure.
+
+        :param args:
+        :param kwargs:
+        :return:
+        '''
+        CPU = 'CPU'
+        data = {CPU: dict()}
+        for key, value in __grains__.items():
+            print "KEY:", key
+            if key.startswith("cpu_"):
+                data[CPU][key.replace("cpu_", "")] = value
+        sysinfo = SysInfo(__grains__.get("kernel"))
+        data['disks'] = sysinfo._get_fs()
+        data['memory'] = sysinfo._get_mem()
+
+        return data
+
+    def _software(self, *args, **kwargs):
+        return "This is software"
+
+    def _services(self, *args, **kwargs):
+        return "This is service"
+
+    def _payload(self, *args, **kwargs):
+        return "This is payload"
+
+    def _all(self, *args, **kwargs):
+        return "This is all"
+

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -201,6 +201,7 @@ class Query(object):
         data['cpu'] = sysinfo._get_cpu()
         data['disks'] = sysinfo._get_fs()
         data['memory'] = sysinfo._get_mem()
+        data['network'] = sysinfo._get_network()
 
         return data
 

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -63,7 +63,15 @@ class SysInfo(object):
         out = __salt__['cmd.run_all']("blkid -o export")
         salt.utils.fsutils._verify_run(out)
 
-        return salt.utils.fsutils._blkid_output(out['stdout'])
+        data = dict()
+        for dev, dev_data in salt.utils.fsutils._blkid_output(out['stdout']).items():
+            dev = self._get_disk_size(dev)
+            device = dev.pop('device')
+            dev['type'] = dev_data['type']
+            data[device] = dev
+
+        return data
+
     def _get_cpu(self):
         '''
         Get available CPU information.

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -117,6 +117,18 @@ class SysInfo(object):
 
         return data
 
+    def _get_os(self):
+        '''
+        Get operating system summary
+        '''
+        return {
+            'name': self._grain('os'),
+            'family': self._grain('os_family'),
+            'arch': self._grain('osarch'),
+            'release': self._grain('osrelease'),
+        }
+
+
 
 class Query(object):
     '''

--- a/salt/modules/node.py
+++ b/salt/modules/node.py
@@ -59,7 +59,7 @@ def _(module):
     return mod
 
 
-def query(scope):
+def query(scope, **kwargs):
     '''
     Query the node for specific information.
 

--- a/salt/modules/node.py
+++ b/salt/modules/node.py
@@ -76,6 +76,7 @@ def inspect(mode='all', priority=19):
     except InspectorSnapshotException as ex:
         raise CommandExecutionError(ex)
     except Exception as ex:
+        log.error(ex.message)
         raise Exception(ex)
 
 
@@ -99,4 +100,5 @@ def query(scope, **kwargs):
     except InspectorQueryException as ex:
         raise CommandExecutionError(ex)
     except Exception as ex:
+        log.error(ex.message)
         raise Exception(ex)

--- a/salt/modules/node.py
+++ b/salt/modules/node.py
@@ -96,7 +96,7 @@ def query(scope, **kwargs):
     query = _("query")
     try:
         return query.Query(scope)(**kwargs)
-    except query.Query.InspectorQueryException as ex:
+    except InspectorQueryException as ex:
         raise CommandExecutionError(ex)
     except Exception as ex:
         raise Exception(ex)

--- a/salt/modules/node.py
+++ b/salt/modules/node.py
@@ -73,7 +73,7 @@ def inspect(mode='all', priority=19):
     collector = _("collector")
     try:
         return collector.Inspector().request_snapshot(mode, priority=priority)
-    except collector.Inspector.InspectorSnapshotException as ex:
+    except InspectorSnapshotException as ex:
         raise CommandExecutionError(ex)
     except Exception as ex:
         raise Exception(ex)

--- a/salt/modules/node.py
+++ b/salt/modules/node.py
@@ -79,4 +79,4 @@ def query(scope, **kwargs):
     except query.Query.InspectorQueryException as ex:
         raise CommandExecutionError(ex)
     except Exception as ex:
-        raise ex
+        raise Exception(ex)

--- a/salt/modules/node.py
+++ b/salt/modules/node.py
@@ -20,6 +20,8 @@ Module for full system inspection.
 from __future__ import absolute_import
 import logging
 import importlib
+from salt.modules.inspectlib.exceptions import (InspectorQueryException,
+                                                InspectorSnapshotException)
 
 # Import Salt libs
 import salt.utils

--- a/salt/modules/node.py
+++ b/salt/modules/node.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2015 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+Module for full system inspection.
+'''
+from __future__ import absolute_import
+import os
+import re
+import uuid
+import logging
+import importlib
+
+# Import Salt libs
+import salt.utils
+import salt.utils.fsutils
+from salt.exceptions import CommandExecutionError
+
+
+log = logging.getLogger(__name__)
+
+# Import inspectlib
+from salt.modules.inspectlib import query as q
+
+
+def __virtual__():
+    '''
+    Only work on POSIX-like systems
+    '''
+    return not salt.utils.is_windows()
+
+
+def _(module):
+    '''
+    Get inspectlib module for the lazy loader.
+
+    :param module:
+    :return:
+    '''
+
+    mod = importlib.import_module("salt.modules.inspectlib.{0}".format(module))
+    mod.__grains__ = __grains__
+    mod.__pillar__ = __pillar__
+    mod.__salt__ = __salt__
+
+    return mod
+
+
+def query(scope):
+    '''
+    Query the node for specific information.
+
+    Parameters:
+
+    * **scope**: Specify scope of the query.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' node.query scope=os
+    '''
+
+    return _("query").Query(scope)()

--- a/salt/modules/node.py
+++ b/salt/modules/node.py
@@ -52,6 +52,31 @@ def _(module):
     return mod
 
 
+def inspect(mode='all', priority=19):
+    '''
+    Start node inspection and save the data to the database for further query.
+
+    Parameters:
+
+    * **mode**: Clarify inspection mode: configuration, payload, all (default)
+    * **priority**: (advanced) Set priority of the inspection. Default is low priority.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' node.inspect
+        salt '*' node.inspect configuration
+    '''
+    collector = _("collector")
+    try:
+        return collector.Inspector().request_snapshot(mode, priority=priority)
+    except collector.Inspector.InspectorSnapshotException as ex:
+        raise CommandExecutionError(ex)
+    except Exception as ex:
+        raise Exception(ex)
+
+
 def query(scope, **kwargs):
     '''
     Query the node for specific information.

--- a/salt/modules/node.py
+++ b/salt/modules/node.py
@@ -18,9 +18,6 @@
 Module for full system inspection.
 '''
 from __future__ import absolute_import
-import os
-import re
-import uuid
 import logging
 import importlib
 
@@ -29,11 +26,7 @@ import salt.utils
 import salt.utils.fsutils
 from salt.exceptions import CommandExecutionError
 
-
 log = logging.getLogger(__name__)
-
-# Import inspectlib
-from salt.modules.inspectlib import query as q
 
 
 def __virtual__():

--- a/salt/modules/node.py
+++ b/salt/modules/node.py
@@ -61,7 +61,13 @@ def inspect(mode='all', priority=19):
     Parameters:
 
     * **mode**: Clarify inspection mode: configuration, payload, all (default)
+
+      payload
+        * **filter**: Comma-separated directories to track payload.
+
     * **priority**: (advanced) Set priority of the inspection. Default is low priority.
+
+
 
     CLI Example:
 
@@ -69,6 +75,7 @@ def inspect(mode='all', priority=19):
 
         salt '*' node.inspect
         salt '*' node.inspect configuration
+        salt '*' node.inspect payload filter=/opt,/ext/oracle
     '''
     collector = _("collector")
     try:

--- a/salt/modules/node.py
+++ b/salt/modules/node.py
@@ -54,7 +54,7 @@ def _(module):
     return mod
 
 
-def inspect(mode='all', priority=19):
+def inspect(mode='all', priority=19, **kwargs):
     '''
     Start node inspection and save the data to the database for further query.
 
@@ -79,7 +79,7 @@ def inspect(mode='all', priority=19):
     '''
     collector = _("collector")
     try:
-        return collector.Inspector().request_snapshot(mode, priority=priority)
+        return collector.Inspector().request_snapshot(mode, priority=priority, **kwargs)
     except InspectorSnapshotException as ex:
         raise CommandExecutionError(ex)
     except Exception as ex:

--- a/salt/modules/node.py
+++ b/salt/modules/node.py
@@ -73,5 +73,10 @@ def query(scope, **kwargs):
 
         salt '*' node.query scope=os
     '''
-
-    return _("query").Query(scope)()
+    query = _("query")
+    try:
+        return query.Query(scope)(**kwargs)
+    except query.Query.InspectorQueryException as ex:
+        raise CommandExecutionError(ex)
+    except Exception as ex:
+        raise ex

--- a/salt/modules/node.py
+++ b/salt/modules/node.py
@@ -88,11 +88,52 @@ def query(scope, **kwargs):
 
     * **scope**: Specify scope of the query.
 
+       * **System**: Return system data.
+
+       * **Software**: Return software information.
+
+       * **Services**: Return known services.
+
+       * **Identity**: Return user accounts information for this system.
+          accounts
+            Can be either 'local', 'remote' or 'all' (equal to "local,remote").
+            Remote accounts cannot be resolved on all systems, but only
+            those, which supports 'passwd -S -a'.
+
+          disabled
+            True (or False, default) to return only disabled accounts.
+
+       * **payload**: Payload scope parameters:
+          filter
+            Include only results which path starts from the filter string.
+
+          time
+            Display time in Unix ticks or format according to the configured TZ (default)
+            Values: ticks, tz (default)
+
+          size
+            Format size. Values: B, KB, MB, GB
+
+          type
+            Include payload type.
+            Values (comma-separated): directory (or dir), link, file (default)
+            Example (returns everything): type=directory,link,file
+
+          owners
+            Resolve UID/GID to an actual names or leave them numeric (default).
+            Values: name (default), id
+
+          brief
+            Return just a list of payload elements, if True. Default: False.
+
+       * **all**: Return all information (default).
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' node.query scope=os
+        salt '*' node.query payload type=file,link filter=/etc size=Kb brief=False
     '''
     query = _("query")
     try:


### PR DESCRIPTION
## Description

A first attempt to come up with the module that would describe the machine and further do something with that data (provisioning, migration, cloning etc).

Well, to begin with, you would need to inspect the machine first, something like this:

```
salt '*' node.inspect
```

This operation is different from other modules, that it starts a child process (currently Unix only) that takes the information about the following things:
- All unmanaged files (they do not belong to any package) (payload scope)
- User accounts and groups (identity scope)
- Software (packages scope)
- Configuration. These are managed configuration files, that belong to some packages (configuration scope)
- Diffs between current files and vendor provided
- Known services (services scope)

Then it is possible to query a system with something like:

```
salt '*' node.query [scope] [options]
```

Basically, `node.query` puts together all "scattered" bits of Salt together. Something just reused, something a bit improved, something is made new. Think of it as CMDB data, like all disks how they are sliced, what kind of FS on them, mounts, network devices, their configuration, networking, software, licenses, configuration files, payload files (those, that you just `scp` as is, without any packaging), identity, remote mounts of AutoFS, CIFS, NFS etc.
## Implementation

The inspection command is a pretty heavy one, so the basic requirements would be as following:
- Run it at low priority (currently lowest)
- Run it in a background and return the data into a local small database (SQLite3 has been chosen for this)
- Query all the heavy results from the database, not a real time.
- Reuse Salt minion.

Currently it starts a fork daemon (once per run, i.e. if running already then won't start) and the daemon is scanning the whole system, inserting the data into a database, which is configured in `/etc/salt/minion` like this:

```
inspector.db: /tmp/salt-inspector.db
inspector.pid: /tmp/salt-inspector.pid
inspector.log: /tmp/salt-inspector.log
```

It has few advantages over threading from within the minion:
- You can run it "reniced" low, while minion can be high priority.
- You can stop minion at all, while the daemon still runs.
- It is not intrusive at all to the minion core, just yet another module.

Whole data is collected to the SQLite database and is queried from there. Every time you call "inspect", this database is purged and refreshed from the scratch, so it is OK to corrupt it or destroy. The database is not very big: full scan of relatively "standard" Linux installation is about 2-3 Mb, depending on amount of files. Typical minimal SUSE JeOS is less than 1 Mb.
## Examples

For example, to know all changed configuration files:

```
e166:/tmp # salt 'e162.suse.de' node.query configuration
e162.suse.de:
    ----------
    SuSEfirewall2-3.6.312-1.3:
        - /etc/sysconfig/SuSEfirewall2
    fonts-config-20140604-1.57:
        - /etc/fonts/conf.d/10-rendering-options.conf
        - /etc/fonts/conf.d/58-family-prefer-local.conf
    grub2-2.02~beta2-48.3:
        - /etc/default/grub
    oracle-config-1.1-0.15.37:
        - /etc/oratab
    plymouth-0.9.0-9.1:
        - /etc/plymouth/plymouthd.conf
    postfix-2.11.0-8.1:
        - /etc/postfix/main.cf
        - /etc/postfix/master.cf
    salt-minion-bloody-1.1:
        - /etc/salt/minion
    shadow-4.1.5.1-12.80:
        - /etc/default/useradd
    sudo-1.8.10p3-1.62:
        - /etc/sudoers
    suse-module-tools-12.3-14.14:
        - /etc/modprobe.d/10-unsupported-modules.conf
```

If you are interesting to track payload only at certain places, I created `test.txt` file in empty `/opt` and scanned payload only there as follows:

```
salt 'e162.suse.de' node.inspect filter=/opt
```

Then there should be only one file:

```
e166:/tmp # salt 'e162.suse.de' node.query payload
e162.suse.de:
    ----------
    /opt/test.txt:
        ----------
        accessed:
            Apr 20 2015 17:30:03
        created:
            Apr 20 2015 17:30:03
        gid:
            root
        mode:
            0100644
        modified:
            Apr 20 2015 17:30:03
        size:
            5
        uid:
            root
```

Of course, you can do the other way around: scan everything and just query with the certain filter. But this is a different use case and also different "weight" of the task.
## Suggestions

I would be really glad if there would be better suggestions where to place what, how to organize modules better etc. @thatch45 ?
