### PR TITLE
[2015.2] Add missing args to cp.get_file in salt-ssh

### DIFF
--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -291,10 +291,13 @@ class Shell(object):
         ret = self._run_cmd(cmd)
         return ret
 
-    def send(self, local, remote):
+    def send(self, local, remote, makedirs=False):
         '''
         scp a file or files to a remote system
         '''
+        if makedirs:
+            self.exec_cmd('mkdir -p {0}'.format(os.path.dirname(remote)))
+
         cmd = '{0} {1}:{2}'.format(local, self.host, remote)
         cmd = self._cmd_str(cmd, ssh='scp')
 

--- a/salt/client/ssh/wrapper/cp.py
+++ b/salt/client/ssh/wrapper/cp.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 # Import salt libs
 import salt.client.ssh
 import logging
+from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 

--- a/salt/client/ssh/wrapper/cp.py
+++ b/salt/client/ssh/wrapper/cp.py
@@ -6,18 +6,38 @@ from __future__ import absolute_import
 
 # Import salt libs
 import salt.client.ssh
+import logging
+
+log = logging.getLogger(__name__)
 
 
-def get_file(path, dest, saltenv='base'):
+def get_file(path,
+             dest,
+             saltenv='base',
+             makedirs=False,
+             template=None,
+             gzip=None):
     '''
     Send a file from the master to the location in specified
+
+    .. note::
+
+        gzip compression is not supported in the salt-ssh version of
+        cp.get_file. The argument is only accepted for interface compatibility.
     '''
+    if gzip is not None:
+        log.warning('The gzip argument to cp.get_file in salt-ssh is '
+                    'unsupported')
+
+    if template is not None:
+        (path, dest) = _render_filenames(path, dest, saltenv, template)
+
     src = __context__['fileclient'].cache_file(path, saltenv)
     single = salt.client.ssh.Single(
             __opts__,
             '',
             **__salt__.kwargs)
-    ret = single.shell.send(src, dest)
+    ret = single.shell.send(src, dest, makedirs)
     return not ret[2]
 
 
@@ -74,3 +94,56 @@ def list_master_symlinks(saltenv='base', prefix=''):
     List all of the symlinks stored on the master
     '''
     return __context__['fileclient'].symlink_list(saltenv, prefix)
+
+
+def _render_filenames(path, dest, saltenv, template):
+    '''
+    Process markup in the :param:`path` and :param:`dest` variables (NOT the
+    files under the paths they ultimately point to) according to the markup
+    format provided by :param:`template`.
+    '''
+    if not template:
+        return (path, dest)
+
+    # render the path as a template using path_template_engine as the engine
+    if template not in salt.utils.templates.TEMPLATE_REGISTRY:
+        raise CommandExecutionError(
+            'Attempted to render file paths with unavailable engine '
+            '{0}'.format(template)
+        )
+
+    kwargs = {}
+    kwargs['salt'] = __salt__
+    kwargs['pillar'] = __pillar__
+    kwargs['grains'] = __grains__
+    kwargs['opts'] = __opts__
+    kwargs['saltenv'] = saltenv
+
+    def _render(contents):
+        '''
+        Render :param:`contents` into a literal pathname by writing it to a
+        temp file, rendering that file, and returning the result.
+        '''
+        # write out path to temp file
+        tmp_path_fn = salt.utils.mkstemp()
+        with salt.utils.fopen(tmp_path_fn, 'w+') as fp_:
+            fp_.write(contents)
+        data = salt.utils.templates.TEMPLATE_REGISTRY[template](
+            tmp_path_fn,
+            to_str=True,
+            **kwargs
+        )
+        salt.utils.safe_rm(tmp_path_fn)
+        if not data['result']:
+            # Failed to render the template
+            raise CommandExecutionError(
+                'Failed to render file path with error: {0}'.format(
+                    data['data']
+                )
+            )
+        else:
+            return data['data']
+
+    path = _render(path)
+    dest = _render(dest)
+    return (path, dest)


### PR DESCRIPTION
Fixes #22751 

Add `makedirs` and `template` as working args for `cp.get_file` in salt-ssh, and add a placeholder for `gzip` argument, to make the interface match the non-salt-ssh function

```
root@li1039-215:~/salt# salt-ssh basepi02 cp.get_file salt://test.txt '/tmp/{{ grains["os"] }}/test.txt' makedirs=True template=jinja
basepi02:
    True
root@li1039-215:~/salt# salt-ssh -r basepi02 'find /tmp/Ubuntu'
basepi02:
    ----------
    retcode:
        0
    stderr:
    stdout:
        /tmp/Ubuntu
        /tmp/Ubuntu/test.txt
```
