### PR TITLE
Prevent stacktrace on os.path.exists in hosts module

### DIFF
--- a/salt/modules/hosts.py
+++ b/salt/modules/hosts.py
@@ -29,6 +29,8 @@ def _get_or_create_hostfile():
     does not exist.
     '''
     hfn = __get_hosts_filename()
+    if hfn is None:
+        hfn = ''
     if not os.path.exists(hfn):
         salt.utils.fopen(hfn, 'w').close()
     return hfn


### PR DESCRIPTION
If hfn is None, it will stacktrace in os.path.exists. Change it to an empty string.
