### PR TITLE
Fix for issue #22880, this should be **kwarg, not kwarg=None.

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -148,7 +148,7 @@ class SyncClientMixin(object):
 
         return ret['data']['return']
 
-    def cmd(self, fun, arg=None, pub_data=None, kwarg=None):
+    def cmd(self, fun, arg=None, pub_data=None, **kwarg):
         '''
         Execute a function
 


### PR DESCRIPTION
Without this fix, and kwargs passed results in a TypeError
