### PR TITLE
Encode spaces with %20 instead of plus sign in AWS request query strings

### DIFF
--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -146,7 +146,6 @@ def sig4(method, endpoint, params, prov_dict, aws_api_version, location,
     http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
     '''
     timenow = datetime.datetime.utcnow()
-    timestamp = timenow.strftime('%Y-%m-%dT%H:%M:%SZ')
 
     # Retrieve access credentials from meta-data, or use provided
     access_key_id, secret_access_key, token = creds(prov_dict)
@@ -159,18 +158,12 @@ def sig4(method, endpoint, params, prov_dict, aws_api_version, location,
 
     amzdate = timenow.strftime('%Y%m%dT%H%M%SZ')
     datestamp = timenow.strftime('%Y%m%d')
-    payload_hash = hashlib.sha256('').hexdigest()
 
     canonical_headers = 'host:{0}\nx-amz-date:{1}\n'.format(
         endpoint,
         amzdate,
     )
     signed_headers = 'host;x-amz-date'
-
-    request = '\n'.join((
-        method, endpoint, querystring, canonical_headers,
-        signed_headers, payload_hash
-    ))
 
     algorithm = 'AWS4-HMAC-SHA256'
 

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -155,7 +155,7 @@ def sig4(method, endpoint, params, prov_dict, aws_api_version, location,
     params_with_headers['Version'] = aws_api_version
     keys = sorted(params_with_headers.keys())
     values = list(map(params_with_headers.get, keys))
-    querystring = urlencode(list(zip(keys, values)))
+    querystring = urlencode(list(zip(keys, values))).replace('+', '%20')
 
     amzdate = timenow.strftime('%Y%m%dT%H%M%SZ')
     datestamp = timenow.strftime('%Y%m%d')


### PR DESCRIPTION
It is currently not possible to set tag values (or any other values in AWS query string) to strings that contain spaces.

urlencode function from urllib replaces spaces with '+' (plus sign) to produce application/x-www-form-urlencoded format, but AWS signing process document explicitly talks about encoding spaces with %20 rather than '+' (see http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html).

There is an exiting issue raised in python bug tracker to have an ability to modify this behaivour of urlencode (see https://bugs.python.org/issue13866). But until it is resolved, this looks like the best way to go.

Remove duplicate and unused code in aws utils package:
The code for canonical request and payload hash generation is duplicate. timestamp is not used at all.
