### PR TITLE
Fix issue #22782

### DIFF
--- a/salt/states/keystone.py
+++ b/salt/states/keystone.py
@@ -173,11 +173,11 @@ def user_present(name,
             ret['comment'] = 'User "{0}" has been updated'.format(name)
             ret['changes']['Password'] = 'Updated'
         if roles:
-            for tenant_role in roles:
+            for tenant in roles.keys():
                 args = dict({'user_name': name, 'tenant_name':
-                             tenant_role, 'profile': profile}, **connection_args)
+                             tenant, 'profile': profile}, **connection_args)
                 tenant_roles = __salt__['keystone.user_role_list'](**args)
-                for role in roles[tenant_role]:
+                for role in roles[tenant]:
                     if role not in tenant_roles:
                         if __opts__['test']:
                             ret['result'] = None
@@ -187,7 +187,7 @@ def user_present(name,
                                 ret['changes']['roles'] = [role]
                             continue
                         addargs = dict({'user': name, 'role': role,
-                                        'tenant': tenant_role,
+                                        'tenant': tenant,
                                         'profile': profile},
                                        **connection_args)
                         newrole = __salt__['keystone.user_role_add'](**addargs)
@@ -195,7 +195,7 @@ def user_present(name,
                             ret['changes']['roles'].append(newrole)
                         else:
                             ret['changes']['roles'] = [newrole]
-                roles_to_remove = list(set(tenant_roles) - set(roles[tenant_role]))
+                roles_to_remove = list(set(tenant_roles) - set(roles[tenant]))
                 for role in roles_to_remove:
                     if __opts__['test']:
                         ret['result'] = None
@@ -205,7 +205,7 @@ def user_present(name,
                             ret['changes']['roles'] = [role]
                         continue
                     addargs = dict({'user': name, 'role': role,
-                                    'tenant': tenant_role,
+                                    'tenant': tenant,
                                     'profile': profile},
                                    **connection_args)
                     oldrole = __salt__['keystone.user_role_remove'](**addargs)
@@ -228,11 +228,11 @@ def user_present(name,
                                          profile=profile,
                                          **connection_args)
         if roles:
-            for tenant_role in roles:
-                for role in roles[tenant_role]:
+            for tenant in roles.keys():
+                for role in roles[tenant]:
                     __salt__['keystone.user_role_add'](user=name,
                                                        role=role,
-                                                       tenant=tenant_role,
+                                                       tenant=tenant,
                                                        profile=profile,
                                                        **connection_args)
         ret['comment'] = 'Keystone user {0} has been added'.format(name)

--- a/salt/states/keystone.py
+++ b/salt/states/keystone.py
@@ -102,7 +102,16 @@ def user_present(name,
         Availability state for this user
 
     roles
-        The roles the user should have under tenants
+        The roles the user should have under given tenants.
+        Passed as a dictionary mapping tenant names to a list
+        of roles in this tenant, i.e.::
+
+            roles:
+                admin:   # tenant
+                  - admin  # role
+                service:
+                  - admin
+                  - Member
     '''
     ret = {'name': name,
            'changes': {},


### PR DESCRIPTION
Actually the behavior of keystone.user_present() just changed slightly but the code's lacking 
readability made figuring this out difficult.
Now instead of the strange `TypeError: list indices must be integers, not OrderedDict` one
gets this:

```
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1548, in call
                  **cdata['kwargs'])
                File "/var/cache/salt/minion/extmods/states/keystone.py", line 185, in user_present
                  for tenant in roles.keys():
              AttributeError: 'list' object has no attribute 'keys'
```

The docstring for `user_present()` now emphasizes that the kwarg `roles` has to be dict:

```
% sudo salt controller sys.state_doc keystone.user_present
[...]
            roles
                The roles the user should have under given tenants.
                Passed as a dictionary mapping tenant names to a list
                of roles in this tenant, i.e.::

                    roles:
                        admin:   # tenant
                          - admin  # role
                        service:
                          - admin
                          - Member


```
