### PR TITLE
pam_tally counter was not reset to 0 after a succesfull login

### DIFF
--- a/salt/auth/pam.py
+++ b/salt/auth/pam.py
@@ -17,19 +17,16 @@ Implemented using ctypes, so no compilation is necessary.
     The Python interface to PAM does not support authenticating as ``root``.
 
 '''
-from __future__ import absolute_import
 
-# Import python libs
+# Import Salt libs
+from salt.utils import get_group_list
+
 from ctypes import CDLL, POINTER, Structure, CFUNCTYPE, cast, pointer, sizeof
 from ctypes import c_void_p, c_uint, c_char_p, c_char, c_int
 from ctypes.util import find_library
 
-# Import Salt libs
-from salt.utils import get_group_list
-from salt.ext.six.moves import range
-
-LIBPAM = CDLL(find_library('pam'))
-LIBC = CDLL(find_library('c'))
+LIBPAM = CDLL(find_library("pam"))
+LIBC = CDLL(find_library("c"))
 
 CALLOC = LIBC.calloc
 CALLOC.restype = c_void_p
@@ -37,7 +34,7 @@ CALLOC.argtypes = [c_uint, c_uint]
 
 STRDUP = LIBC.strdup
 STRDUP.argstypes = [c_char_p]
-STRDUP.restype = POINTER(c_char)  # NOT c_char_p !!!!
+STRDUP.restype = POINTER(c_char) # NOT c_char_p !!!!
 
 # Various constants
 PAM_PROMPT_ECHO_OFF = 1
@@ -45,74 +42,72 @@ PAM_PROMPT_ECHO_ON = 2
 PAM_ERROR_MSG = 3
 PAM_TEXT_INFO = 4
 
-
 class PamHandle(Structure):
-    '''
-    Wrapper class for pam_handle_t
-    '''
+    """wrapper class for pam_handle_t"""
     _fields_ = [
-            ('handle', c_void_p)
+            ("handle", c_void_p)
             ]
 
     def __init__(self):
         Structure.__init__(self)
         self.handle = 0
 
-
 class PamMessage(Structure):
-    '''
-    Wrapper class for pam_message structure
-    '''
+    """wrapper class for pam_message structure"""
     _fields_ = [
             ("msg_style", c_int),
-            ("msg", c_char_p),
+            ("msg", POINTER(c_char)),
             ]
 
     def __repr__(self):
-        return '<PamMessage {0} {1!r}>'.format(self.msg_style, self.msg)
-
+        return "<PamMessage %i '%s'>" % (self.msg_style, self.msg)
 
 class PamResponse(Structure):
-    '''
-    Wrapper class for pam_response structure
-    '''
+    """wrapper class for pam_response structure"""
     _fields_ = [
-            ('resp', c_char_p),
-            ('resp_retcode', c_int),
+            ("resp", POINTER(c_char)),
+            ("resp_retcode", c_int),
             ]
 
     def __repr__(self):
-        return '<PamResponse {0} {1!r}>'.format(self.resp_retcode, self.resp)
-
+        return "<PamResponse %i '%s'>" % (self.resp_retcode, self.resp)
 
 CONV_FUNC = CFUNCTYPE(c_int,
         c_int, POINTER(POINTER(PamMessage)),
                POINTER(POINTER(PamResponse)), c_void_p)
 
-
 class PamConv(Structure):
-    '''
-    Wrapper class for pam_conv structure
-    '''
+    """wrapper class for pam_conv structure"""
     _fields_ = [
-            ('conv', CONV_FUNC),
-            ('appdata_ptr', c_void_p)
+            ("conv", CONV_FUNC),
+            ("appdata_ptr", c_void_p)
             ]
-
 
 try:
     PAM_START = LIBPAM.pam_start
     PAM_START.restype = c_int
     PAM_START.argtypes = [c_char_p, c_char_p, POINTER(PamConv),
-            POINTER(PamHandle)]
+        POINTER(PamHandle)]
+
+    PAM_END = LIBPAM.pam_end
+    PAM_END.restpe = c_int
+    PAM_END.argtypes = [PamHandle, c_int]
 
     PAM_AUTHENTICATE = LIBPAM.pam_authenticate
     PAM_AUTHENTICATE.restype = c_int
     PAM_AUTHENTICATE.argtypes = [PamHandle, c_int]
 
-    PAM_END = LIBPAM.pam_end
-    PAM_END.restype = c_int
-    PAM_END.argtypes = [PamHandle, c_int]
+    PAM_SETCRED = LIBPAM.pam_setcred
+    PAM_SETCRED.restype = c_int
+    PAM_SETCRED.argtypes = [PamHandle, c_int]
+ 
+    PAM_OPEN_SESSION = LIBPAM.pam_open_session
+    PAM_OPEN_SESSION.restype = c_int
+    PAM_OPEN_SESSION.argtypes = [PamHandle, c_int]
+
+    PAM_CLOSE_SESSION = LIBPAM.pam_close_session
+    PAM_CLOSE_SESSION.restype = c_int
+    PAM_CLOSE_SESSION.argtypes = [PamHandle, c_int]
 except Exception:
     HAS_PAM = False
 else:
@@ -125,32 +120,27 @@ def __virtual__():
     '''
     return HAS_PAM
 
-
 def authenticate(username, password, service='login'):
-    '''
-    Returns True if the given username and password authenticate for the
+    """Returns True if the given username and password authenticate for the
     given service.  Returns False otherwise
-
+    
     ``username``: the username to authenticate
-
+    
     ``password``: the password in plain text
-
+    
     ``service``: the PAM service to authenticate against.
-                 Defaults to 'login'
-    '''
+                 Defaults to 'login'"""
     @CONV_FUNC
     def my_conv(n_messages, messages, p_response, app_data):
-        '''
-        Simple conversation function that responds to any
-        prompt where the echo is off with the supplied password
-        '''
+        """Simple conversation function that responds to any
+        prompt where the echo is off with the supplied password"""
         # Create an array of n_messages response objects
         addr = CALLOC(n_messages, sizeof(PamResponse))
         p_response[0] = cast(addr, POINTER(PamResponse))
         for i in range(n_messages):
             if messages[i].contents.msg_style == PAM_PROMPT_ECHO_OFF:
                 pw_copy = STRDUP(str(password))
-                p_response.contents[i].resp = cast(pw_copy, c_char_p)
+                p_response.contents[i].resp = pw_copy
                 p_response.contents[i].resp_retcode = 0
         return 0
 
@@ -165,7 +155,26 @@ def authenticate(username, password, service='login'):
         return False
 
     retval = PAM_AUTHENTICATE(handle, 0)
-    PAM_END(handle, 0)
+    if retval != 0:
+        PAM_END(handle, retval)
+        return False
+ 
+    retval = PAM_SETCRED(handle, 0)
+    if retval != 0:
+        PAM_END(handle, retval)
+        return False
+
+    retval = PAM_OPEN_SESSION(handle, 0)
+    if retval != 0:
+        PAM_END(handle, retval)
+        return False
+
+    retval = PAM_CLOSE_SESSION(handle, 0)
+    if retval != 0:
+        PAM_END(handle, retval)
+        return False
+
+    retval = PAM_END(handle, retval)
     return retval == 0
 
 
@@ -173,7 +182,7 @@ def auth(username, password, **kwargs):
     '''
     Authenticate via pam
     '''
-    return authenticate(username, password, kwargs.get('service', 'login'))
+    return authenticate(username, password, kwargs.get('service', 'system-auth'))
 
 
 def groups(username, *args, **kwargs):

--- a/salt/auth/pam.py
+++ b/salt/auth/pam.py
@@ -36,13 +36,14 @@ CALLOC.argtypes = [c_uint, c_uint]
 
 STRDUP = LIBC.strdup
 STRDUP.argstypes = [c_char_p]
-STRDUP.restype = POINTER(c_char) # NOT c_char_p !!!!
+STRDUP.restype = POINTER(c_char)  # NOT c_char_p !!!!
 
 # Various constants
 PAM_PROMPT_ECHO_OFF = 1
 PAM_PROMPT_ECHO_ON = 2
 PAM_ERROR_MSG = 3
 PAM_TEXT_INFO = 4
+
 
 class PamHandle(Structure):
     '''
@@ -56,6 +57,7 @@ class PamHandle(Structure):
         Structure.__init__(self)
         self.handle = 0
 
+
 class PamMessage(Structure):
     '''
     Wrapper class for pam_message structure
@@ -66,7 +68,8 @@ class PamMessage(Structure):
             ]
 
     def __repr__(self):
-        return "<PamMessage %i '%s'>" % (self.msg_style, self.msg)
+        return "<PamMessage {0:d} '{1}'>".format(self.msg_style, self.msg)
+
 
 class PamResponse(Structure):
     '''
@@ -78,11 +81,12 @@ class PamResponse(Structure):
             ]
 
     def __repr__(self):
-        return "<PamResponse %i '%s'>" % (self.resp_retcode, self.resp)
+        return "<PamResponse {0:d} '{1}'>".format(self.resp_retcode, self.resp)
 
 CONV_FUNC = CFUNCTYPE(c_int,
         c_int, POINTER(POINTER(PamMessage)),
                POINTER(POINTER(PamResponse)), c_void_p)
+
 
 class PamConv(Structure):
     '''
@@ -110,7 +114,7 @@ try:
     PAM_SETCRED = LIBPAM.pam_setcred
     PAM_SETCRED.restype = c_int
     PAM_SETCRED.argtypes = [PamHandle, c_int]
- 
+
     PAM_OPEN_SESSION = LIBPAM.pam_open_session
     PAM_OPEN_SESSION.restype = c_int
     PAM_OPEN_SESSION.argtypes = [PamHandle, c_int]
@@ -129,6 +133,7 @@ def __virtual__():
     Only load on Linux systems
     '''
     return HAS_PAM
+
 
 def authenticate(username, password, service='login'):
     '''
@@ -172,7 +177,7 @@ def authenticate(username, password, service='login'):
     if retval != 0:
         PAM_END(handle, retval)
         return False
- 
+
     retval = PAM_SETCRED(handle, 0)
     if retval != 0:
         PAM_END(handle, retval)

--- a/salt/auth/pam.py
+++ b/salt/auth/pam.py
@@ -17,10 +17,12 @@ Implemented using ctypes, so no compilation is necessary.
     The Python interface to PAM does not support authenticating as ``root``.
 
 '''
+from __future__ import absolute_import
 
 # Import Salt libs
 from salt.utils import get_group_list
 
+# Import python libs
 from ctypes import CDLL, POINTER, Structure, CFUNCTYPE, cast, pointer, sizeof
 from ctypes import c_void_p, c_uint, c_char_p, c_char, c_int
 from ctypes.util import find_library
@@ -43,7 +45,9 @@ PAM_ERROR_MSG = 3
 PAM_TEXT_INFO = 4
 
 class PamHandle(Structure):
-    """wrapper class for pam_handle_t"""
+    '''
+    Wrapper class for pam_handle_t
+    '''
     _fields_ = [
             ("handle", c_void_p)
             ]
@@ -53,7 +57,9 @@ class PamHandle(Structure):
         self.handle = 0
 
 class PamMessage(Structure):
-    """wrapper class for pam_message structure"""
+    '''
+    Wrapper class for pam_message structure
+    '''
     _fields_ = [
             ("msg_style", c_int),
             ("msg", POINTER(c_char)),
@@ -63,7 +69,9 @@ class PamMessage(Structure):
         return "<PamMessage %i '%s'>" % (self.msg_style, self.msg)
 
 class PamResponse(Structure):
-    """wrapper class for pam_response structure"""
+    '''
+    Wrapper class for pam_response structure
+    '''
     _fields_ = [
             ("resp", POINTER(c_char)),
             ("resp_retcode", c_int),
@@ -77,7 +85,9 @@ CONV_FUNC = CFUNCTYPE(c_int,
                POINTER(POINTER(PamResponse)), c_void_p)
 
 class PamConv(Structure):
-    """wrapper class for pam_conv structure"""
+    '''
+    Wrapper class for pam_conv structure
+    '''
     _fields_ = [
             ("conv", CONV_FUNC),
             ("appdata_ptr", c_void_p)
@@ -121,19 +131,23 @@ def __virtual__():
     return HAS_PAM
 
 def authenticate(username, password, service='login'):
-    """Returns True if the given username and password authenticate for the
+    '''
+    Returns True if the given username and password authenticate for the
     given service.  Returns False otherwise
-    
+
     ``username``: the username to authenticate
-    
+
     ``password``: the password in plain text
-    
+
     ``service``: the PAM service to authenticate against.
-                 Defaults to 'login'"""
+                 Defaults to 'login'
+    '''
     @CONV_FUNC
     def my_conv(n_messages, messages, p_response, app_data):
-        """Simple conversation function that responds to any
-        prompt where the echo is off with the supplied password"""
+        '''
+        Simple conversation function that responds to any
+        prompt where the echo is off with the supplied password
+        '''
         # Create an array of n_messages response objects
         addr = CALLOC(n_messages, sizeof(PamResponse))
         p_response[0] = cast(addr, POINTER(PamResponse))
@@ -182,7 +196,7 @@ def auth(username, password, **kwargs):
     '''
     Authenticate via pam
     '''
-    return authenticate(username, password, kwargs.get('service', 'system-auth'))
+    return authenticate(username, password, kwargs.get('service', 'login'))
 
 
 def groups(username, *args, **kwargs):


### PR DESCRIPTION
## Before the patch
### After 5 successful logins (yes, the tally counter was not reset after successful logins either!)

```
[root@saltm01 pam.d]# pam_tally2 --user saltapi --reset 
Login           Failures Latest failure     From
saltapi            10    04/20/15 13:34:32  unknown
```
### After a successful login:

```
[root@saltm01 pam.d]# pam_tally2 --user saltapi
Login           Failures Latest failure     From
saltapi             2    04/20/15 17:34:10  unknown
```
## With the patch
### After bad credentials:

```
[root@saltm01 pam.d]# pam_tally2 --user saltapi
Login           Failures Latest failure     From
saltapi             1    04/21/15 09:58:54  unknown
```
### After a successful login:

```
[root@saltm01 pam.d]# pam_tally2 --user saltapi 
Login           Failures Latest failure     From
saltapi             0    
```
## Root Cause

pam_setcred() needs to be called after pam_authenticate()
## Note

This patch is also opening/closing a pam_session for good measures.
