### PR TITLE
Change state example to use proper kwarg

### DIFF
--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -90,7 +90,7 @@ Available Functions
 
       /finish-install.sh:
         docker.run:
-          - container: mysuperdocker
+          - cid: mysuperdocker
           - unless: grep -q something /var/log/foo
           - docker_unless: grep -q done /install_log
 


### PR DESCRIPTION
Refs #12003

docker.run takes `cid` as a kwarg, not `container`.
