### PR TITLE
Fix compatibility with pkgin > 0.7

### DIFF
--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -45,7 +45,7 @@ def _check_pkgin():
 
 
 @decorators.memoize
-def _supports_regex():
+def _get_version():
     '''
     Get the pkgin version
     '''
@@ -61,7 +61,25 @@ def _supports_regex():
     if not version_match:
         return False
 
-    return tuple([int(i) for i in version_match.group(1).split('.')]) > (0, 5)
+    return version_match.group(1).split('.')
+
+
+@decorators.memoize
+def _supports_regex():
+    '''
+    Check support of regexp
+    '''
+
+    return tuple([int(i) for i in _get_version()]) > (0, 5)
+
+
+@decorators.memoize
+def _supports_parsing():
+    '''
+    Check support of parsing
+    '''
+
+    return tuple([int(i) for i in _get_version()]) > (0, 7)
 
 
 def __virtual__():
@@ -78,7 +96,7 @@ def __virtual__():
 def _splitpkg(name):
     # name is in the format foobar-1.0nb1, already space-splitted
     if name[0].isalnum() and name != 'No':  # avoid < > = and 'No result'
-        return name.rsplit('-', 1)
+        return name.split(';', 1)[0].rsplit('-', 1)
 
 
 def search(pkg_name):
@@ -243,7 +261,10 @@ def list_pkgs(versions_as_list=False, **kwargs):
     out = __salt__['cmd.run'](pkg_command, output_loglevel='trace')
     for line in out.splitlines():
         try:
-            pkg, ver = line.split(' ')[0].rsplit('-', 1)
+            if _supports_parsing():
+                pkg, ver = line.split(';', 1)[0].rsplit('-', 1)
+            else:
+                pkg, ver = line.split(' ', 1)[0].rsplit('-', 1)
         except ValueError:
             continue
         __salt__['pkg_resource.add_pkg'](ret, pkg, ver)


### PR DESCRIPTION
- Add testing for parsing ability
- Fix broken parser for :
  - pkg.list_pkgs
  - pkg.search

Sample of bad parsing :

``` shell
[INFO    ] Executing command '/usr/sbin/zfs help || :' in directory '/root'
[INFO    ] Executing command '/opt/local/bin/pkgin -v' in directory '/root'
[INFO    ] Executing command '/opt/local/bin/pkgin se ^memcached$' in directory '/root'

local:
     ----------
     memcached-1.4.21;=;High:
         performance
```

Tested on pkgsrc 2014Q4.1 LTS (Joyent) 
