### PR TITLE
Add a note to the git_pillar docs stating that GitPython is the only currently supported provider

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -2,6 +2,8 @@
 '''
 Clone a remote git repository and use the filesystem as a Pillar source
 
+Currently GitPython is the only supported provider for git Pillars
+
 This external Pillar source can be configured in the master config file like
 so:
 


### PR DESCRIPTION
Thanks @jfindlay for the heads up on the proper location.
