### PR TITLE
localemod.gen_locale now always returns a boolean

### DIFF
--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -274,4 +274,4 @@ def gen_locale(locale):
         cmd.append('--generate')
     cmd.append(locale)
 
-    return __salt__['cmd.retcode'](cmd, python_shell=False)
+    return __salt__['cmd.retcode'](cmd, python_shell=False) == 0


### PR DESCRIPTION
Related to #22829, also fixes #21140.
