### PR TITLE
Cleanup jinja attribute access for loader

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -270,8 +270,6 @@ class SyncClientMixin(object):
             # namespace only once per module-- not per func
             completed_funcs = []
             for mod_name in self.functions:
-                if '.' not in mod_name:
-                    continue
                 mod, _ = mod_name.split('.', 1)
                 if mod in completed_funcs:
                     continue

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -512,8 +512,6 @@ def grains(opts, force_refresh=False):
 
     # Run the rest of the grains
     for key, fun in six.iteritems(funcs):
-        if '.' not in key:
-            continue
         if key.startswith('core.') or key == '_errors':
             continue
         try:
@@ -727,7 +725,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
 
         # names of modules that we don't have (errors, __virtual__, etc.)
         self.missing_modules = {}  # mapping of name -> error
-        self.loaded_modules = set()  # list of all modules that we have loaded
+        self.loaded_modules = {}  # mapping of module_name -> dict_of_functions
         self.loaded_files = set()  # TODO: just remove them from file_mapping?
 
         self.disabled = set(self.opts.get('disable_{0}s'.format(self.tag), []))
@@ -739,6 +737,23 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         _generate_module('{0}.int.{1}'.format(self.loaded_base_name, tag))
         _generate_module('{0}.ext'.format(self.loaded_base_name))
         _generate_module('{0}.ext.{1}'.format(self.loaded_base_name, tag))
+
+    def __getattr__(self, mod_name):
+        '''
+        Allow for "direct" attribute access-- this allows jinja templates to
+        access things like `salt.test.ping()`
+        '''
+        if mod_name not in self.loaded_modules and not self.loaded:
+            for name in self._iter_files(mod_name):
+                if name in self.loaded_files:
+                    continue
+                # if we got what we wanted, we are done
+                if self._load_module(name) and mod_name in self.loaded_modules:
+                    break
+        if mod_name in self.loaded_modules:
+            return self.loaded_modules[mod_name]
+        else:
+            raise AttributeError(mod_name)
 
     def missing_fun_string(self, function_name):
         '''
@@ -833,7 +848,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         super(LazyLoader, self).clear()  # clear the lazy loader
         self.loaded_files = set()
         self.missing_modules = {}
-        self.loaded_modules = set()
+        self.loaded_modules = {}
         # if we have been loaded before, lets clear the file mapping since
         # we obviously want a re-do
         if hasattr(self, 'opts'):
@@ -1014,7 +1029,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                     module_name
                 )
             )
-        self._dict[module_name] = salt.utils.odict.OrderedDict()
+        mod_dict = salt.utils.odict.OrderedDict()
         for attr in getattr(mod, '__load__', dir(mod)):
             if attr.startswith('_'):
                 # private functions are skipped
@@ -1033,13 +1048,13 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             funcname = getattr(mod, '__func_alias__', {}).get(attr, attr)
             # Save many references for lookups
             self._dict['{0}.{1}'.format(module_name, funcname)] = func
-            setattr(self._dict[module_name], funcname, func)
-            self._dict[module_name][funcname] = func
+            setattr(mod_dict, funcname, func)
+            mod_dict[funcname] = func
             self._apply_outputter(func, mod)
 
         # enforce depends
         Depends.enforce_dependencies(self._dict, self.tag)
-        self.loaded_modules.add(module_name)
+        self.loaded_modules[module_name] = mod_dict
         return True
 
     def _load(self, key):
@@ -1047,12 +1062,9 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         Load a single item if you have it
         '''
         # if the key doesn't have a '.' then it isn't valid for this mod dict
-        if not isinstance(key, six.string_types):
+        if not isinstance(key, six.string_types) or '.' not in key:
             raise KeyError
-        if '.' not in key:
-            mod_name = key
-        else:
-            mod_name, _ = key.split('.', 1)
+        mod_name, _ = key.split('.', 1)
         if mod_name in self.missing_modules:
             return True
         # if the modulename isn't in the whitelist, don't bother

--- a/salt/renderers/pyobjects.py
+++ b/salt/renderers/pyobjects.py
@@ -306,8 +306,6 @@ def load_states():
 
     # TODO: some way to lazily do this? This requires loading *all* state modules
     for key, func in lazy_states.iteritems():
-        if '.' not in key:
-            continue
         mod_name, func_name = key.split('.', 1)
         if mod_name not in states:
             states[mod_name] = {}

--- a/salt/utils/lazy.py
+++ b/salt/utils/lazy.py
@@ -91,22 +91,6 @@ class LazyDict(collections.MutableMapping):
         else:
             return self._dict[key]
 
-    def __getattr__(self, name):
-        '''
-        Check if the name is in the dict and return it if it is
-        '''
-        if name not in self._dict and not self.loaded:
-            # load the item
-            if self._load(name):
-                log.debug('LazyLoaded {0}'.format(name))
-                return self._dict[name]
-            else:
-                log.debug('Could not LazyLoad {0}'.format(name))
-                raise KeyError(name)
-        elif name in self:
-            return self[name]
-        raise AttributeError(name)
-
     def __len__(self):
         # if not loaded,
         if not self.loaded:

--- a/tests/integration/loader/loader.py
+++ b/tests/integration/loader/loader.py
@@ -106,8 +106,7 @@ class LazyLoaderVirtualEnabledTest(TestCase):
         self.assertEqual(func_globals['__pillar__'], self.opts.get('pillar', {}))
         # the opts passed into modules is at least a subset of the whole opts
         for key, val in six.iteritems(func_globals['__opts__']):
-            if key in self.opts:
-                self.assertEqual(self.opts[key], val)
+            self.assertEqual(self.opts[key], val)
 
     def test_pack(self):
         self.loader.pack['__foo__'] = 'bar'

--- a/tests/integration/modules/sysmod.py
+++ b/tests/integration/modules/sysmod.py
@@ -68,8 +68,6 @@ class SysModuleTest(integration.ModuleCase):
         )
 
         for fun in docs:
-            if '.' not in fun:
-                continue
             if fun.startswith('runtests_helpers'):
                 continue
             if fun in allow_failure:


### PR DESCRIPTION
Refactor of #22723 
@thatch45 I think I like this better, since the attribute access is not available in the dict interface-- meaning that you don't need those `if '.' not in key` checks all over creation ;)
