### PR TITLE
add test for #18843

### DIFF
--- a/tests/integration/states/user.py
+++ b/tests/integration/states/user.py
@@ -63,6 +63,27 @@ class UserTest(integration.ModuleCase,
 
     @destructiveTest
     @skipIf(os.geteuid() != 0, 'you must be root to run this test')
+    def test_user_present_when_home_dir_does_not_18843(self):
+        '''
+        This is a DESTRUCTIVE TEST it creates a new user on the minion.
+        And then destroys that user.
+        Assume that it will break any system you run it on.
+        '''
+        HOMEDIR = '/tmp/home_of_salt_test'
+        ret = self.run_state('user.present', name='salt_test',
+                             home=HOMEDIR)
+        self.assertSaltTrueReturn(ret)
+
+        self.run_function('file.absent', name=HOMEDIR)
+        ret = self.run_state('user.present', name='salt_test',
+                             home=HOMEDIR)
+        self.assertSaltTrueReturn(ret)
+
+        ret = self.run_state('user.absent', name='salt_test')
+        self.assertSaltTrueReturn(ret)
+
+    @destructiveTest
+    @skipIf(os.geteuid() != 0, 'you must be root to run this test')
     def test_user_present_nondefault(self):
         '''
         This is a DESTRUCTIVE TEST it creates a new user on the on the minion.


### PR DESCRIPTION
This should fail before https://github.com/saltstack/salt/pull/22887/ get merged. 
My local setup cannot run test, I got these errors:

```
Traceback (most recent call last):
  File "tests/runtests.py", line 411, in <module>
    main()
  File "tests/runtests.py", line 396, in main
    status = parser.run_integration_tests()
  File "tests/runtests.py", line 316, in run_integration_tests
    with TestDaemon(self):
  File "/home/hvn/Github/salt/tests/integration/__init__.py", line 173, in __enter__
    self.start_zeromq_daemons()
  File "/home/hvn/Github/salt/tests/integration/__init__.py", line 230, in start_zeromq_daemons
    minion = salt.minion.Minion(self.minion_opts)
  File "/home/hvn/Github/salt/salt/minion.py", line 599, in __init__
    safe)
  File "/home/hvn/Github/salt/salt/minion.py", line 778, in eval_master
    if self.authenticate(timeout, safe) == 'full':
  File "/home/hvn/Github/salt/salt/minion.py", line 1380, in authenticate
    creds = auth.sign_in(timeout, safe, tries)
  File "/home/hvn/Github/salt/salt/crypt.py", line 649, in sign_in
    raise SaltClientError('Attempt to authenticate with the salt master failed')
salt.exceptions.SaltClientError: Attempt to authenticate with the salt master failed
```
