### PR TITLE
raise appropriate AttributeEror for certain collectionmapping attributes

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1076,6 +1076,14 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         '''
         Load a single item if you have it
         '''
+        # We must limit ourselves here to only exceptions which are technically
+        # needed and not to prevent certain modules from loading.
+        # Indeed, for now, the only case we need to filter out is the
+        # is the mapping.copy method which is normal to be absent from the
+        # loader but from which other code will test and rely on the
+        # raised AttributeError to perform their own duty
+        if key in ['copy']:
+            raise AttributeError(key)
         # if the key doesn't have a '.' then it isn't valid for this mod dict
         if not isinstance(key, six.string_types) or '.' not in key:
             raise KeyError


### PR DESCRIPTION
cc @jacksontj @thatch45 

This allow mock to work in unit tests.

Otherwise, it does

```
bin/nosetests --exe -e mc_test  -s  --xcoverage-file=.coverage.xml --with-doctest mc_states.tests.unit.modules.pillare_tests
E
======================================================================
ERROR: test_get_whitel (mc_states.tests.unit.modules.pillare_tests.TestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/srv/salt/makina-states/mc_states/tests/unit/modules/pillare_tests.py", line 287, in test_get_whitel
    'mc_pillar.loaddb_do': _load,
  File "/salt-venv/salt/local/lib/python2.7/site-packages/mock.py", line 1638, in __enter__
    self._patch_dict()
  File "/salt-venv/salt/local/lib/python2.7/site-packages/mock.py", line 1647, in _patch_dict
    original = in_dict.copy()
  File "/salt-venv/salt/src/salt/salt/utils/lazy.py", line 113, in __getattr__
    raise KeyError(name)
KeyError: 'copy'

```

See https://github.com/calvinchengx/python-mock/blob/master/mock.py#L1634
