### PR TITLE
Test with a more recent pip version to avoid a traceback

### DIFF
--- a/tests/integration/states/pip.py
+++ b/tests/integration/states/pip.py
@@ -341,7 +341,7 @@ class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
             # Let's install a fixed version pip over whatever pip was
             # previously installed
             ret = self.run_function(
-                'pip.install', ['pip==1.3.1'], upgrade=True,
+                'pip.install', ['pip==6.0'], upgrade=True,
                 ignore_installed=True,
                 bin_env=venv_dir
             )
@@ -356,15 +356,15 @@ class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
                 pprint.pprint(ret)
                 raise
 
-            # Le't make sure we have pip 1.3.1 installed
+            # Le't make sure we have pip 6.0 installed
             self.assertEqual(
                 self.run_function('pip.list', ['pip'], bin_env=venv_dir),
-                {'pip': '1.3.1'}
+                {'pip': '6.0'}
             )
 
             # Now the actual pip upgrade pip test
             ret = self.run_state(
-                'pip.installed', name='pip==1.4.1', upgrade=True,
+                'pip.installed', name='pip==6.0.7', upgrade=True,
                 bin_env=venv_dir
             )
             try:
@@ -372,7 +372,7 @@ class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
                 self.assertInSaltReturn(
                     'Installed',
                     ret,
-                    ['changes', 'pip==1.4.1']
+                    ['changes', 'pip==6.0.7']
                 )
             except AssertionError:
                 import pprint


### PR DESCRIPTION
```
07:39:05,449 [salt.minion                                :1178][ERROR   ] A command in 'pip.list' had a problem: Traceback (most recent call last):
  File "/tmp/salt-tests-tmpdir/6833-pip-upgrade-pip/bin/pip", line 9, in <module>
    load_entry_point('pip==1.3.1', 'console_scripts', 'pip')()
  File "/tmp/salt-tests-tmpdir/6833-pip-upgrade-pip/lib/python2.6/site-packages/pkg_resources/__init__.py", line 546, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/tmp/salt-tests-tmpdir/6833-pip-upgrade-pip/lib/python2.6/site-packages/pkg_resources/__init__.py", line 2666, in load_entry_point
    return ep.load()
  File "/tmp/salt-tests-tmpdir/6833-pip-upgrade-pip/lib/python2.6/site-packages/pkg_resources/__init__.py", line 2339, in load
    return self.resolve()
  File "/tmp/salt-tests-tmpdir/6833-pip-upgrade-pip/lib/python2.6/site-packages/pkg_resources/__init__.py", line 2345, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/tmp/salt-tests-tmpdir/6833-pip-upgrade-pip/lib/python2.6/site-packages/pip/__init__.py", line 13, in <module>
    from pip.commands import commands, get_similar_commands, get_summaries
  File "/tmp/salt-tests-tmpdir/6833-pip-upgrade-pip/lib/python2.6/site-packages/pip/commands/__init__.py", line 6, in <module>
    from pip.commands.bundle import BundleCommand
  File "/tmp/salt-tests-tmpdir/6833-pip-upgrade-pip/lib/python2.6/site-packages/pip/commands/bundle.py", line 5, in <module>
    from pip.commands.install import InstallCommand
  File "/tmp/salt-tests-tmpdir/6833-pip-upgrade-pip/lib/python2.6/site-packages/pip/commands/install.py", line 5, in <module>
    from pip.req import InstallRequirement, RequirementSet, parse_requirements
  File "/tmp/salt-tests-tmpdir/6833-pip-upgrade-pip/lib/python2.6/site-packages/pip/req/__init__.py", line 3, in <module>
    from .req_install import InstallRequirement
  File "/tmp/salt-tests-tmpdir/6833-pip-upgrade-pip/lib/python2.6/site-packages/pip/req/req_install.py", line 20, in <module>
    import pip.wheel
  File "/tmp/salt-tests-tmpdir/6833-pip-upgrade-pip/lib/python2.6/site-packages/pip/wheel.py", line 23, in <module>
    from pip.exceptions import InvalidWheelFilename, UnsupportedWheel
ImportError: cannot import name InvalidWheelFilename
```
