### PR TITLE
Fix regression introduced yesterday in dockerio module

### DIFF
--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -1741,7 +1741,7 @@ def _run_wrapper(status, container, func, cmd, *args, **kwargs):
                 return status
             full_cmd = (
                 'nsenter --target {pid} --mount --uts --ipc --net --pid'
-                ' {cmd}'.format(pid=container_pid, cmd=cmd)
+                ' -- {cmd}'.format(pid=container_pid, cmd=cmd)
             )
         else:
             raise CommandExecutionError(


### PR DESCRIPTION
This fixes a problem introduced in c375309, I left out the double-dash between
the nsenter arguments and the command to run via nsenter.
