### PR TITLE
Remove update() in git pillar

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -312,8 +312,6 @@ def ext_pillar(minion_id,
     if __opts__['pillar_roots'].get(branch, []) == [pillar_dir]:
         return {}
 
-    gitpil.update()
-
     opts = deepcopy(__opts__)
 
     opts['pillar_roots'][environment] = [pillar_dir]

--- a/tests/unit/pillar/git_test.py
+++ b/tests/unit/pillar/git_test.py
@@ -58,6 +58,7 @@ class GitPillarTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn)
                 'pillar_opts': False
                 }
         git_pillar.__grains__ = {}
+        git_pillar.update('master', 'file://{0}'.format(self.repo_path))
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)


### PR DESCRIPTION
This causes workers to block when a large number of minions request pillar data. Full discussion in #19994.

Refs #18593 as well
