### PR TITLE
Allow PPAs on Linux Mint

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1235,7 +1235,7 @@ def get_repo(repo, **kwargs):
     ppa_auth = kwargs.get('ppa_auth', None)
     # we have to be clever about this since the repo definition formats
     # are a bit more "loose" than in some other distributions
-    if repo.startswith('ppa:') and __grains__['os'] == 'Ubuntu':
+    if repo.startswith('ppa:') and __grains__['os'] in ('Ubuntu', 'Mint'):
         # This is a PPA definition meaning special handling is needed
         # to derive the name.
         dist = __grains__['lsb_distrib_codename']
@@ -1308,7 +1308,7 @@ def del_repo(repo, **kwargs):
     '''
     _check_apt()
     is_ppa = False
-    if repo.startswith('ppa:') and __grains__['os'] == 'Ubuntu':
+    if repo.startswith('ppa:') and __grains__['os'] in ('Ubuntu', 'Mint'):
         # This is a PPA definition meaning special handling is needed
         # to derive the name.
         is_ppa = True
@@ -1423,7 +1423,7 @@ def mod_repo(repo, saltenv='base', **kwargs):
     # to ensure no one sets some key values that _shouldn't_ be changed on the
     # object itself, this is just a white-list of "ok" to set properties
     if repo.startswith('ppa:'):
-        if __grains__['os'] == 'Ubuntu':
+        if __grains__['os'] in ('Ubuntu', 'Mint'):
             # secure PPAs cannot be supported as of the time of this code
             # implementation via apt-add-repository.  The code path for
             # secure PPAs should be the same as urllib method
@@ -1701,7 +1701,7 @@ def expand_repo_def(repokwargs):
 
     sanitized = {}
     repo = _strip_uri(repokwargs['repo'])
-    if repo.startswith('ppa:') and __grains__['os'] == 'Ubuntu':
+    if repo.startswith('ppa:') and __grains__['os'] in ('Ubuntu', 'Mint'):
         dist = __grains__['lsb_distrib_codename']
         owner_name, ppa_name = repo[4:].split('/', 1)
         if 'ppa_auth' in repokwargs:

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -220,7 +220,7 @@ def managed(name, **kwargs):
                              'and the "ppa" argument.'
             return ret
         kwargs['repo'] = kwargs['name']
-    if 'ppa' in kwargs and __grains__['os'] == 'Ubuntu':
+    if 'ppa' in kwargs and __grains__['os'] in ('Ubuntu', 'Mint'):
         # overload the name/repo value for PPAs cleanly
         # this allows us to have one code-path for PPAs
         repo_name = 'ppa:{0}'.format(kwargs['ppa'])
@@ -382,7 +382,7 @@ def absent(name, **kwargs):
            'result': None,
            'comment': ''}
     repo = {}
-    if 'ppa' in kwargs and __grains__['os'] == 'Ubuntu':
+    if 'ppa' in kwargs and __grains__['os'] in ('Ubuntu', 'Mint'):
         name = kwargs.pop('ppa')
         if not name.startswith('ppa:'):
             name = 'ppa:' + name


### PR DESCRIPTION
Linux Mint has no trouble adding Ubuntu PPAs, as it uses Ubuntu's packages for nearly everything except the desktop stack. Patch was tested on Mint 17 and successfully added a Trusty PPA. 

Without this, `pkgrepo.managed` will silently fall back to adding whatever is in the 'name' argument as a line to /etc/apt/sources.list. (For us it was a descriptive label, which helpfully broke `apt-get update`.)
