### PR TITLE
Improve state_output documentation

### DIFF
--- a/doc/man/salt.1
+++ b/doc/man/salt.1
@@ -97,9 +97,10 @@ the started execution and complete.
 New in version 0.17.
 
 .sp
-Override the configured state_output value for minion output.  Default:
-full
-.UNINDENT
+Override the configured \fBstate_output\fP value for minion output. One of
+\fBfull\fP, \fBterse\fP, \fBmixed\fP, \fBchanges\fP or \fBfilter\fP\&.
+Default: \fBfull\fB\&.
+
 .INDENT 0.0
 .TP
 .B \-\-subset=SUBSET

--- a/doc/ref/cli/salt.rst
+++ b/doc/ref/cli/salt.rst
@@ -45,9 +45,10 @@ Options
 .. option:: --state-output=STATE_OUTPUT
 
     .. versionadded:: 0.17
-    
-    Override the configured state_output value for minion output.  Default: 
-    full
+
+    Override the configured ``state_output`` value for minion output. One of
+    ``full``, ``terse``, ``mixed``, ``changes`` or ``filter``.  Default:
+    ``full``.
 
 .. option:: --subset=SUBSET
 

--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -16,20 +16,24 @@ state_verbose:
     instruct the highstate outputter to omit displaying anything in green, this
     means that nothing with a result of True and no changes will not be printed
 state_output:
-    The highstate outputter has five output modes, `full`, `terse`, `mixed`,
-    `changes` and `filter`. The default is set to full, which will display many
-    lines of detailed information for each executed chunk. If the `state_output`
-    option is set to `terse` then the output is greatly simplified and shown in
-    only one line.  If `mixed` is used, then terse output will be used unless a
-    state failed, in which case full output will be used.  If `changes` is used,
-    then terse output will be used if there was no error and no changes,
-    otherwise full output will be used. If `filter` is used, then either or both
-    of two different filters can be used: `exclude` or `terse`. These can be set
-    as such from the command line, or in the Salt config as
-    `state_output_exclude` or `state_output_terse`, respectively. The values to
-    exclude must be a comma-separated list of `True`, `False` and/or `None`.
-    Because of parsing nuances, if only one of these is used, it must still
-    contain a comma. For instance: `exclude=True,`.
+    The highstate outputter has five output modes, ``full``, ``terse``,
+    ``mixed``, ``changes`` and ``filter``.
+
+    * The default is set to ``full``, which will display many lines of detailed
+      information for each executed chunk.
+    * If ``terse`` is used, then the output is greatly simplified and shown in
+      only one line.
+    * If ``mixed`` is used, then terse output will be used unless a state
+      failed, in which case full output will be used.
+    * If ``changes`` is used, then terse output will be used if there was no
+      error and no changes, otherwise full output will be used.
+    * If ``filter`` is used, then either or both of two different filters can be
+      used: ``exclude`` or ``terse``.
+      These can be set as such from the command line, or in the Salt config as
+      `state_output_exclude` or `state_output_terse`, respectively. The values to
+      exclude must be a comma-separated list of `True`, `False` and/or `None`.
+      Because of parsing nuances, if only one of these is used, it must still
+      contain a comma. For instance: `exclude=True,`.
 state_tabular:
     If `state_output` uses the terse output, set this to `True` for an aligned
     output format.  If you wish to use a custom format, this can be set to a

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1004,8 +1004,9 @@ class OutputOptionsMixIn(object):
         group.add_option(
             '--state-output', '--state_output',
             default='full',
-            help=('Override the configured state_output value for minion output'
-                  '. Default: full')
+            help=('Override the configured state_output value for minion '
+                  'output. One of full, terse, mixed, changes or filter. '
+                  'Default: full.')
         )
 
         for option in self.output_options_group.option_list:


### PR DESCRIPTION
List all the available settings in the documentation and on the command line.
Also, make the documentation clearer about the different possibilities.

I especially find it difficult to remember which options are available, which one does what and the fact that you constantly have to return to the website to lookup the documentation is a bit cumbersome. Especially since the rendering wasn't exactly great.

Hopefully, this pull request makes things slightly better.
