### PR TITLE
Fix fileserver backends __opts__ overwritten by _pillar

### DIFF
--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -306,6 +306,12 @@ class Fileserver(object):
         '''
         return self.opts
 
+    def update_opts(self):
+        # This fix func monkey patching by pillar
+        for name, func in self.servers.items():
+            if '__opts__' in func.func_globals:
+                func.func_globals['__opts__'].update(self.opts)
+
     def clear_cache(self, back=None):
         '''
         Clear the cache of all of the fileserver backends that support the

--- a/salt/master.py
+++ b/salt/master.py
@@ -768,14 +768,14 @@ class AESFuncs(object):
         '''
         Set the local file objects from the file server interface
         '''
-        fs_ = salt.fileserver.Fileserver(self.opts)
-        self._serve_file = fs_.serve_file
-        self._file_hash = fs_.file_hash
-        self._file_list = fs_.file_list
-        self._file_list_emptydirs = fs_.file_list_emptydirs
-        self._dir_list = fs_.dir_list
-        self._symlink_list = fs_.symlink_list
-        self._file_envs = fs_.envs
+        self.fs_ = salt.fileserver.Fileserver(self.opts)
+        self._serve_file = self.fs_.serve_file
+        self._file_hash = self.fs_.file_hash
+        self._file_list = self.fs_.file_list
+        self._file_list_emptydirs = self.fs_.file_list_emptydirs
+        self._dir_list = self.fs_.dir_list
+        self._symlink_list = self.fs_.symlink_list
+        self._file_envs = self.fs_.envs
 
     def __verify_minion(self, id_, token):
         '''
@@ -1104,6 +1104,7 @@ class AESFuncs(object):
             load.get('ext'),
             self.mminion.functions)
         data = pillar.compile_pillar(pillar_dirs=pillar_dirs)
+        self.fs_.update_opts()
         if self.opts.get('minion_data_cache', False):
             cdir = os.path.join(self.opts['cachedir'], 'minions', load['id'])
             if not os.path.isdir(cdir):


### PR DESCRIPTION
Refs #22941 
Supersedes #22942 

This time, I only override `__opts__` globals so that `file_roots` is not `pillar_roots`.

What do you think of it ? :)
