### PR TITLE
Fix file.managed absent source error

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2765,7 +2765,9 @@ def get_managed(
     source_sum = {}
     if template and source:
         sfn = __salt__['cp.cache_file'](source, saltenv)
-        if not os.path.exists(sfn):
+        # exists doesn't play nice with sfn as bool
+        # but if cache failed, sfn == False
+        if not sfn or not os.path.exists(sfn):
             return sfn, {}, 'Source file {0} not found'.format(source)
         if sfn == name:
             raise SaltInvocationError(


### PR DESCRIPTION
If a source is absent, now we have without the patch
(because of cp.patch returning False)

```
          ID: cpt-xxxx
    Function: file.managed
        Name: /etc/ssl/cloud/separate/xxx-full.crt
      Result: False
     Comment: Unable to manage file: coercing to Unicode: need string or buffer, bool found
     Started: 11:45:11.996986
    Duration: 1.913 ms
     Changes:

```
