### PR TITLE
Added option keyalgorithm for DDNS updates

### DIFF
--- a/salt/modules/ddns.py
+++ b/salt/modules/ddns.py
@@ -174,8 +174,9 @@ def update(zone, name, ttl, rdtype, data, nameserver='127.0.0.1', replace=False,
 
     keyring = _get_keyring(_config('keyfile', **kwargs))
     keyname = _config('keyname', **kwargs)
+    keyalgorithm = _config('keyalgorithm', **kwargs) or 'HMAC-MD5.SIG-ALG.REG.INT'
 
-    dns_update = dns.update.Update(zone, keyring=keyring, keyname=keyname)
+    dns_update = dns.update.Update(zone, keyring=keyring, keyname=keyname, keyalgorithm=keyalgorithm)
     if is_update:
         dns_update.replace(name, ttl, rdata)
     else:
@@ -206,8 +207,9 @@ def delete(zone, name, rdtype=None, data=None, nameserver='127.0.0.1', **kwargs)
 
     keyring = _get_keyring(_config('keyfile', **kwargs))
     keyname = _config('keyname', **kwargs)
+    keyalgorithm = _config('keyalgorithm', **kwargs) or 'HMAC-MD5.SIG-ALG.REG.INT'
 
-    dns_update = dns.update.Update(zone, keyring=keyring, keyname=keyname)
+    dns_update = dns.update.Update(zone, keyring=keyring, keyname=keyname, keyalgorithm=keyalgorithm)
 
     if rdtype:
         rdtype = dns.rdatatype.from_text(rdtype)


### PR DESCRIPTION
TSIG keys might not always be hmac-md5 and dnspython allows other algorithms to be used this should be configurable.

from: dns.tsig:

``` python
HMAC_MD5 = dns.name.from_text("HMAC-MD5.SIG-ALG.REG.INT")
HMAC_SHA1 = dns.name.from_text("hmac-sha1")
HMAC_SHA224 = dns.name.from_text("hmac-sha224")
HMAC_SHA256 = dns.name.from_text("hmac-sha256")
HMAC_SHA384 = dns.name.from_text("hmac-sha384")
HMAC_SHA512 = dns.name.from_text("hmac-sha512")
```

defaults to: HMAC-MD5.SIG-ALG.REG.INT
