### PR TITLE
set systemd service killMode to process for minion

### DIFF
--- a/pkg/salt-minion.service
+++ b/pkg/salt-minion.service
@@ -5,6 +5,7 @@ After=syslog.target network.target
 [Service]
 Type=simple
 ExecStart=/usr/bin/salt-minion
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fixes #22993.

The change is only made for the minion process because, theoretically,
only the minion could create the problem described.  salt-master and
salt-syndic do not theoretically spawn non-salt processes during the
lifetime of their processes, whereas salt-minion does this by design.

The default behavior for systemd `killMode` seems to be `control-group`,
which means all processes that share the same control group as the
minion process will also be killed by systemd when the minion service is
stopped (killed).

It is reasonable to expect that activity done on a system by a salt
minion should persist beyond the lifetime of the minion process, so
let's not kill procs that the minion starts even when the minion exits.
