### PR TITLE
convert exception e.message to just e

### DIFF
--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -87,9 +87,9 @@ def commit():
             conn.cu.commit(confirm=True)
             ret['out'] = True
             ret['message'] = 'Commit Successful.'
-        except Exception as e:
+        except Exception as exception:
             ret['out'] = False
-            ret['message'] = 'Pre-commit check succeeded but actual commit failed with "{0}"'.format(e.message)
+            ret['message'] = 'Pre-commit check succeeded but actual commit failed with "{0}"'.format(exception)
     else:
         ret['out'] = False
         ret['message'] = 'Pre-commit check failed.'


### PR DESCRIPTION
BaseException.message has been deprecated as of Python 2.6
