### PR TITLE
[improvement] compound match as list

### DIFF
--- a/doc/topics/targeting/compound.rst
+++ b/doc/topics/targeting/compound.rst
@@ -10,17 +10,19 @@ with CLI and :term:`top file` matching. To match using anything other than a
 glob, prefix the match string with the appropriate letter from the table below,
 followed by an ``@`` sign.
 
-====== ==================== ===============================================================
-Letter Match Type           Example
-====== ==================== ===============================================================
-G      Grains glob          ``G@os:Ubuntu``
-E      PCRE Minion ID       ``E@web\d+\.(dev|qa|prod)\.loc``
-P      Grains PCRE          ``P@os:(RedHat|Fedora|CentOS)``
-L      List of minions      ``L@minion1.example.com,minion3.domain.com or bl*.domain.com``
-I      Pillar glob          ``I@pdata:foobar``
-S      Subnet/IP address    ``S@192.168.1.0/24`` or ``S@192.168.1.100``
-R      Range cluster        ``R@%foo.bar``
-====== ==================== ===============================================================
+====== ========= ==================== ==============================================================
+Letter Delimiter Match Type           Example
+====== ========= ==================== ==============================================================
+G      x         Grains glob          ``G@os:Ubuntu``
+E                PCRE Minion ID       ``E@web\d+\.(dev|qa|prod)\.loc``
+P      x         Grains PCRE          ``P@os:(RedHat|Fedora|CentOS)``
+L                List of minions      ``L@minion1.example.com,minion3.domain.com or bl*.domain.com``
+I      x         Pillar glob          ``I@pdata:foobar``
+J      x         Pillar PCRE          ``J@pdata:^(foo|bar)$``
+S                Subnet/IP address    ``S@192.168.1.0/24`` or ``S@192.168.1.100``
+R                Range cluster        ``R@%foo.bar``
+====== ========= ==================== ==============================================================
+
 
 Matchers can be joined using boolean ``and``, ``or``, and ``not`` operators.
 
@@ -60,3 +62,18 @@ Matches can be grouped together with parentheses to explicitly declare precedenc
 
     Be certain to note that spaces are required between the parentheses and targets. Failing to obey this
     rule may result in incorrect targeting!
+
+Alternate Delimiters
+--------------------
+
+.. versionadded:: Beryllium
+
+Some matchers allow an optional delimiter character specified between the
+leading matcher character and the ``@`` pattern separator character.  This
+can be essential when the globbing or PCRE pattern may use the default
+delimiter character ``:``.  This avoids incorrect interpretation of the
+pattern as part of the grain or pillar data structure traversal.
+
+.. code-block:: bash
+
+    salt -C 'J|@foo|bar|^foo:bar$ or J!@gitrepo!https://github.com:example/project.git' test.ping

--- a/doc/topics/targeting/nodegroups.rst
+++ b/doc/topics/targeting/nodegroups.rst
@@ -17,6 +17,10 @@ nodegroups. Here's an example nodegroup configuration within
       group1: 'L@foo.domain.com,bar.domain.com,baz.domain.com or bl*.domain.com'
       group2: 'G@os:Debian and foo.domain.com'
       group3: 'G@os:Debian and N@group1'
+      group4:
+        - 'G@foo:bar'
+        - 'or'
+        - 'G@foo:baz'
 
 .. note::
 
@@ -24,11 +28,21 @@ nodegroups. Here's an example nodegroup configuration within
     group2 is matching specific grains. See the :doc:`compound matchers
     <compound>` documentation for more details.
 
+.. versionadded:: Beryllium
+
 .. note::
 
     Nodgroups can reference other nodegroups as seen in ``group3``.  Ensure
     that you do not have circular references.  Circular references will be
     detected and cause partial expansion with a logged error message.
+
+.. versionadded:: Beryllium
+
+Compound nodegroups can be either string values or lists of string values.
+When the nodegroup is A string value will be tokenized by splitting on
+whitespace.  This may be a problem if whitespace is necessary as part of a
+pattern.  When a nodegroup is a list of strings then tokenization will
+happen for each list element as a whole.
 
 To match a nodegroup on the CLI, use the ``-N`` command-line option:
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2349,7 +2349,7 @@ class Matcher(object):
             elif target_info and target_info.get('engine'):
                 if 'N' == target_info['engine']:
                     # Nodegroups should already be expanded/resolved to other engines
-                    log.error('Detected nodegroup expansion failure of "{0}"'.format(match))
+                    log.error('Detected nodegroup expansion failure of "{0}"'.format(word))
                     return False
                 engine = ref.get(target_info['engine'])
                 if not engine:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2365,7 +2365,7 @@ class Matcher(object):
                 engine_args = [target_info['pattern']]
                 engine_kwargs = {}
                 if target_info.get('delimiter'):
-                    engine_kwargs['delimiter'] = target_info.get['delimiter']
+                    engine_kwargs['delimiter'] = target_info['delimiter']
 
                 results.append(
                     str(getattr(self, '{0}_match'.format(engine))(*engine_args, **engine_kwargs))

--- a/tests/integration/files/conf/master
+++ b/tests/integration/files/conf/master
@@ -63,6 +63,10 @@ nodegroups:
   min: minion
   sub_min: sub_minion
   mins: N@min or N@sub_min
+  multiline_nodegroup:
+    - 'minion'
+    - 'or'
+    - 'sub_minion'
   redundant_minions: N@min or N@mins
   nodegroup_loop_a: N@nodegroup_loop_b
   nodegroup_loop_b: N@nodegroup_loop_a

--- a/tests/integration/shell/matcher.py
+++ b/tests/integration/shell/matcher.py
@@ -72,6 +72,22 @@ class MatchTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
         data = self.run_salt("-C '* and ( not G@test_grain:cheese )' test.ping")
         self.assertFalse(minion_in_returns('minion', data))
         self.assertTrue(minion_in_returns('sub_minion', data))
+        time.sleep(2)
+        data = self.run_salt("-C 'G%@planets%merc*' test.ping")
+        self.assertTrue(minion_in_returns('minion', data))
+        self.assertFalse(minion_in_returns('sub_minion', data))
+        time.sleep(2)
+        data = self.run_salt("-C 'P%@planets%^(mercury|saturn)$' test.ping")
+        self.assertTrue(minion_in_returns('minion', data))
+        self.assertTrue(minion_in_returns('sub_minion', data))
+        time.sleep(2)
+        data = self.run_salt("-C 'I%@companions%three%sarah*' test.ping")
+        self.assertTrue(minion_in_returns('minion', data))
+        self.assertTrue(minion_in_returns('sub_minion', data))
+        time.sleep(2)
+        data = self.run_salt("-C 'J%@knights%^(Lancelot|Galahad)$' test.ping")
+        self.assertTrue(minion_in_returns('minion', data))
+        self.assertTrue(minion_in_returns('sub_minion', data))
 
     def test_nodegroup(self):
         '''

--- a/tests/integration/shell/matcher.py
+++ b/tests/integration/shell/matcher.py
@@ -115,6 +115,10 @@ class MatchTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
         time.sleep(2)
         data = '\n'.join(self.run_salt('-N nodegroup_loop_a test.ping'))
         self.assertIn('No minions matched', data)
+        time.sleep(2)
+        data = self.run_salt("-N multiline_nodegroup test.ping")
+        self.assertTrue(minion_in_returns('minion', data))
+        self.assertTrue(minion_in_returns('sub_minion', data))
 
     def test_glob(self):
         '''


### PR DESCRIPTION
Compound matches, such as nodegroups, can now be specified as lists.  This
avoids splitting on whitespace which may be part of a key or value.

Right now this only works for nodegroups.  Making the argument to "-C"
(compound list) a JSON argument is a future task.

This is based on the un-merged https://github.com/saltstack/salt/pull/23012
