### PR TITLE
ubuntu systemd/legacy init support

### DIFF
--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -7,10 +7,12 @@ from __future__ import absolute_import
 import logging
 import os
 import re
+import glob
 
 # Import 3rd-party libs
 import salt.ext.six as six
 import salt.utils.systemd
+import salt.exceptions
 
 log = logging.getLogger(__name__)
 
@@ -158,6 +160,124 @@ def systemctl_reload():
     return retcode == 0
 
 
+def _default_runlevel():
+    '''
+    Try to figure out the default runlevel.  It is kept in
+    /etc/init/rc-sysinit.conf, but can be overridden with entries
+    in /etc/inittab, or via the kernel command-line at boot
+    '''
+    # Try to get the "main" default.  If this fails, throw up our
+    # hands and just guess "2", because things are horribly broken
+    try:
+        with salt.utils.fopen('/etc/init/rc-sysinit.conf') as fp_:
+            for line in fp_:
+                if line.startswith('env DEFAULT_RUNLEVEL'):
+                    runlevel = line.split('=')[-1].strip()
+    except Exception:
+        return '2'
+
+    # Look for an optional "legacy" override in /etc/inittab
+    try:
+        with salt.utils.fopen('/etc/inittab') as fp_:
+            for line in fp_:
+                if not line.startswith('#') and 'initdefault' in line:
+                    runlevel = line.split(':')[1]
+    except Exception:
+        pass
+
+    # The default runlevel can also be set via the kernel command-line.
+    # Kinky.
+    try:
+        valid_strings = set(
+            ('0', '1', '2', '3', '4', '5', '6', 's', 'S', '-s', 'single'))
+        with salt.utils.fopen('/proc/cmdline') as fp_:
+            for line in fp_:
+                for arg in line.strip().split():
+                    if arg in valid_strings:
+                        runlevel = arg
+                        break
+    except Exception:
+        pass
+
+    return runlevel
+
+
+def _runlevel():
+    '''
+    Return the current runlevel
+    '''
+    if 'systemd._runlevel' in __context__:
+        return __context__['systemd._runlevel']
+    out = __salt__['cmd.run']('runlevel', python_shell=False)
+    try:
+        ret = out.split()[1]
+    except IndexError:
+        # The runlevel is unknown, return the default
+        ret = _default_runlevel()
+    __context__['systemd._runlevel'] = ret
+    return ret
+
+
+def _get_service_exec():
+    '''
+    Debian uses update-rc.d to manage System-V style services.
+    http://www.debian.org/doc/debian-policy/ch-opersys.html#s9.3.3
+    '''
+    executable = 'update-rc.d'
+    salt.utils.check_or_die(executable)
+    return executable
+
+
+def _has_sysv_exec():
+    '''
+    Return the current runlevel
+    '''
+    if 'systemd._has_sysv_exec' not in __context__:
+        try:
+            __context__['systemd._has_sysv_exec'] = bool(_get_service_exec())
+        except(
+            salt.exceptions.CommandExecutionError,
+            salt.exceptions.CommandNotFoundError
+        ):
+            __context__['systemd._has_sysv_exec'] = False
+    return __context__['systemd._has_sysv_exec']
+
+
+def _sysv_exists(name):
+    script = '/etc/init.d/{0}'.format(name)
+    return os.access(script, os.X_OK)
+
+
+def _service_is_sysv(name):
+    '''
+    A System-V style service will have a control script in
+    /etc/init.d.
+    Return True only if the service doesnt also provide a systemd unit file.
+    '''
+    script = '/etc/init.d/{0}'.format(name)
+    return (_has_sysv_exec() and
+            name in _get_all_units() and
+            name not in _get_all_unit_files() and
+            _sysv_exists(name))
+
+
+def _sysv_is_disabled(name):
+    '''
+    A System-V style service is assumed disabled if there is no
+    start-up link (starts with "S") to its script in /etc/init.d in
+    the current runlevel.
+    '''
+    return not bool(glob.glob('/etc/rc{0}.d/S*{1}'.format(_runlevel(), name)))
+
+
+def _sysv_is_enabled(name):
+    '''
+    Assume that if a System-V style service is not disabled then it
+    must be enabled.
+    '''
+    return not _sysv_is_disabled(name)
+
+
 def get_enabled():
     '''
     Return a list of all enabled services
@@ -169,8 +289,19 @@ def get_enabled():
         salt '*' service.get_enabled
     '''
     ret = []
-    for name, state in six.iteritems(_get_all_unit_files()):
+    units = _get_all_unit_files()
+    services = _get_all_units()
+    for name, state in six.iteritems(units):
         if state == 'enabled':
+            ret.append(name)
+    for name, state in six.iteritems(services):
+        if name in units:
+            continue
+        # performance; if the legacy initscript doesnt exists,
+        # dont contiue up with systemd query
+        if not _service_is_sysv(name):
+            continue
+        if _sysv_is_enabled(name):
             ret.append(name)
     return sorted(ret)
 
@@ -380,6 +511,10 @@ def enable(name, **kwargs):
     '''
     if _untracked_custom_unit_found(name) or _unit_file_changed(name):
         systemctl_reload()
+    if _service_is_sysv(name):
+        executable = _get_service_exec()
+        cmd = '{0} -f {1} defaults 99'.format(executable, name)
+        return not __salt__['cmd.retcode'](cmd, python_shell=False)
     return not __salt__['cmd.retcode'](_systemctl_cmd('enable', name))
 
 
@@ -395,6 +530,10 @@ def disable(name, **kwargs):
     '''
     if _untracked_custom_unit_found(name) or _unit_file_changed(name):
         systemctl_reload()
+    if _service_is_sysv(name):
+        executable = _get_service_exec()
+        cmd = [executable, '-f', name, 'remove']
+        return not __salt__['cmd.retcode'](cmd, python_shell=False)
     return not __salt__['cmd.retcode'](_systemctl_cmd('disable', name))
 
 
@@ -417,7 +556,7 @@ def _enabled(name):
     is_enabled = \
         not __salt__['cmd.retcode'](_systemctl_cmd('is-enabled', name),
                                     ignore_retcode=True)
-    return is_enabled or _templated_instance_enabled(name)
+    return is_enabled or _templated_instance_enabled(name) or _sysv_is_enabled(name)
 
 
 def enabled(name, **kwargs):
@@ -443,7 +582,7 @@ def disabled(name):
 
         salt '*' service.disabled <service name>
     '''
-    return not _enabled(name)
+    return not _enabled(name) and not _sysv_is_enabled(name)
 
 
 def show(name):

--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -254,7 +254,6 @@ def _service_is_sysv(name):
     /etc/init.d.
     Return True only if the service doesnt also provide a systemd unit file.
     '''
-    script = '/etc/init.d/{0}'.format(name)
     return (_has_sysv_exec() and
             name in _get_all_units() and
             name not in _get_all_unit_files() and

--- a/tests/unit/modules/systemd_test.py
+++ b/tests/unit/modules/systemd_test.py
@@ -193,6 +193,7 @@ class SystemdTestCase(TestCase):
         '''
             Test to enable the named service to start when the system boots
         '''
+        exe = MagicMock(return_value='foo')
         tmock = MagicMock(return_value=True)
         mock = MagicMock(return_value=False)
         with patch.object(systemd, '_untracked_custom_unit_found', mock):
@@ -200,14 +201,16 @@ class SystemdTestCase(TestCase):
                 with patch.dict(systemd.__salt__, {'cmd.retcode': mock}):
                     with patch.object(systemd, "_service_is_sysv", mock):
                         self.assertTrue(systemd.enable("sshd"))
-                    with patch.object(systemd, "_service_is_sysv", tmock):
-                        self.assertTrue(systemd.enable("sshd"))
+                    with patch.object(systemd, "_get_service_exec", exe):
+                        with patch.object(systemd, "_service_is_sysv", tmock):
+                            self.assertTrue(systemd.enable("sshd"))
 
     def test_disable(self):
         '''
             Test to disable the named service to not
             start when the system boots
         '''
+        exe = MagicMock(return_value='foo')
         tmock = MagicMock(return_value=True)
         mock = MagicMock(return_value=False)
         with patch.object(systemd, '_untracked_custom_unit_found', mock):
@@ -215,8 +218,9 @@ class SystemdTestCase(TestCase):
                 with patch.dict(systemd.__salt__, {'cmd.retcode': mock}):
                     with patch.object(systemd, "_service_is_sysv", mock):
                         self.assertTrue(systemd.disable("sshd"))
-                    with patch.object(systemd, "_service_is_sysv", tmock):
-                        self.assertTrue(systemd.disable("sshd"))
+                    with patch.object(systemd, "_get_service_exec", exe):
+                        with patch.object(systemd, "_service_is_sysv", tmock):
+                            self.assertTrue(systemd.disable("sshd"))
 
     def test_enabled(self):
         '''

--- a/tests/unit/modules/systemd_test.py
+++ b/tests/unit/modules/systemd_test.py
@@ -61,8 +61,8 @@ class SystemdTestCase(TestCase):
                                         "a": "disabled",
                                         "b": "disabled",
                                         "e": "disabled"})
-        with patch("salt.modules.systemd._sysv_is_disabled", sysve):
-            with patch("salt.modules.systemd._service_is_sysv", sysv):
+        with patch.object(systemd, "_sysv_is_disabled", sysve):
+            with patch.object(systemd, "_service_is_sysv", sysv):
                 with patch.object(systemd, '_get_all_unit_files', mock):
                     with patch.object(systemd, '_get_all_units', lmock):
                         self.assertListEqual(
@@ -198,9 +198,9 @@ class SystemdTestCase(TestCase):
         with patch.object(systemd, '_untracked_custom_unit_found', mock):
             with patch.object(systemd, '_unit_file_changed', mock):
                 with patch.dict(systemd.__salt__, {'cmd.retcode': mock}):
-                    with patch("salt.modules.systemd._service_is_sysv", mock):
+                    with patch.object(systemd, "_service_is_sysv", mock):
                         self.assertTrue(systemd.enable("sshd"))
-                    with patch("salt.modules.systemd._service_is_sysv", tmock):
+                    with patch.object(systemd, "_service_is_sysv", tmock):
                         self.assertTrue(systemd.enable("sshd"))
 
     def test_disable(self):
@@ -213,9 +213,9 @@ class SystemdTestCase(TestCase):
         with patch.object(systemd, '_untracked_custom_unit_found', mock):
             with patch.object(systemd, '_unit_file_changed', mock):
                 with patch.dict(systemd.__salt__, {'cmd.retcode': mock}):
-                    with patch("salt.modules.systemd._service_is_sysv", mock):
+                    with patch.object(systemd, "_service_is_sysv", mock):
                         self.assertTrue(systemd.disable("sshd"))
-                    with patch("salt.modules.systemd._service_is_sysv", tmock):
+                    with patch.object(systemd, "_service_is_sysv", tmock):
                         self.assertTrue(systemd.disable("sshd"))
 
     def test_enabled(self):

--- a/tests/unit/modules/systemd_test.py
+++ b/tests/unit/modules/systemd_test.py
@@ -23,6 +23,7 @@ from salt.modules import systemd
 
 # Globals
 systemd.__salt__ = {}
+systemd.__context__ = {}
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -44,10 +45,28 @@ class SystemdTestCase(TestCase):
         '''
             Test to return a list of all enabled services
         '''
+        def sysv(name):
+            if name in ['d', 'e']:
+                return True
+            return False
+
+        def sysve(name):
+            if name in ['e']:
+                return True
+            return False
+
         mock = MagicMock(return_value={"a": "enabled", "b": "enabled",
                                        "c": "disabled"})
-        with patch.object(systemd, '_get_all_unit_files', mock):
-            self.assertListEqual(systemd.get_enabled(), ["a", "b"])
+        lmock = MagicMock(return_value={"d": "disabled",
+                                        "a": "disabled",
+                                        "b": "disabled",
+                                        "e": "disabled"})
+        with patch("salt.modules.systemd._sysv_is_disabled", sysve):
+            with patch("salt.modules.systemd._service_is_sysv", sysv):
+                with patch.object(systemd, '_get_all_unit_files', mock):
+                    with patch.object(systemd, '_get_all_units', lmock):
+                        self.assertListEqual(
+                            systemd.get_enabled(), ["a", "b", "d"])
 
     def test_get_disabled(self):
         '''
@@ -174,22 +193,30 @@ class SystemdTestCase(TestCase):
         '''
             Test to enable the named service to start when the system boots
         '''
+        tmock = MagicMock(return_value=True)
         mock = MagicMock(return_value=False)
         with patch.object(systemd, '_untracked_custom_unit_found', mock):
             with patch.object(systemd, '_unit_file_changed', mock):
                 with patch.dict(systemd.__salt__, {'cmd.retcode': mock}):
-                    self.assertTrue(systemd.enable("sshd"))
+                    with patch("salt.modules.systemd._service_is_sysv", mock):
+                        self.assertTrue(systemd.enable("sshd"))
+                    with patch("salt.modules.systemd._service_is_sysv", tmock):
+                        self.assertTrue(systemd.enable("sshd"))
 
     def test_disable(self):
         '''
             Test to disable the named service to not
             start when the system boots
         '''
+        tmock = MagicMock(return_value=True)
         mock = MagicMock(return_value=False)
         with patch.object(systemd, '_untracked_custom_unit_found', mock):
             with patch.object(systemd, '_unit_file_changed', mock):
                 with patch.dict(systemd.__salt__, {'cmd.retcode': mock}):
-                    self.assertTrue(systemd.disable("sshd"))
+                    with patch("salt.modules.systemd._service_is_sysv", mock):
+                        self.assertTrue(systemd.disable("sshd"))
+                    with patch("salt.modules.systemd._service_is_sysv", tmock):
+                        self.assertTrue(systemd.disable("sshd"))
 
     def test_enabled(self):
         '''


### PR DESCRIPTION
This makes salt.service alike compatible with ubuntu>= 15.04

With the systemd switch, the modules are broken for now.

It seems good, im just reviewing it a bit more

cc @thatch45 
