### PR TITLE
[2015.2] Fix ssh orchestration

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2214,7 +2214,7 @@ class BaseHighState(object):
         Gather the lists of available sls data from the master
         '''
         avail = {}
-        for saltenv in self.client.envs():
+        for saltenv in self._get_envs():
             avail[saltenv] = self.client.list_states(saltenv)
         return avail
 
@@ -2258,6 +2258,15 @@ class BaseHighState(object):
             opts['jinja_trim_blocks'] = mopts.get('jinja_trim_blocks', False)
         return opts
 
+    def _get_envs(self):
+        '''
+        Pull the file server environments out of the master options
+        '''
+        envs = set(['base'])
+        if 'file_roots' in self.opts:
+            envs.update(list(self.opts['file_roots']))
+        return envs
+
     def get_tops(self):
         '''
         Gather the top files
@@ -2279,7 +2288,7 @@ class BaseHighState(object):
                         )
                     ]
         else:
-            for saltenv in self.client.envs():
+            for saltenv in self._get_envs():
                 tops[saltenv].append(
                         compile_template(
                             self.client.cache_file(

--- a/salt/state.py
+++ b/salt/state.py
@@ -2265,7 +2265,7 @@ class BaseHighState(object):
         envs = set(['base'])
         if 'file_roots' in self.opts:
             envs.update(list(self.opts['file_roots']))
-        return envs
+        return envs.union(set(self.client.envs()))
 
     def get_tops(self):
         '''

--- a/salt/state.py
+++ b/salt/state.py
@@ -2214,7 +2214,7 @@ class BaseHighState(object):
         Gather the lists of available sls data from the master
         '''
         avail = {}
-        for saltenv in self._get_envs():
+        for saltenv in self.client.envs():
             avail[saltenv] = self.client.list_states(saltenv)
         return avail
 
@@ -2258,15 +2258,6 @@ class BaseHighState(object):
             opts['jinja_trim_blocks'] = mopts.get('jinja_trim_blocks', False)
         return opts
 
-    def _get_envs(self):
-        '''
-        Pull the file server environments out of the master options
-        '''
-        envs = set(['base'])
-        if 'file_roots' in self.opts:
-            envs.update(list(self.opts['file_roots']))
-        return envs
-
     def get_tops(self):
         '''
         Gather the top files
@@ -2288,7 +2279,7 @@ class BaseHighState(object):
                         )
                     ]
         else:
-            for saltenv in self._get_envs():
+            for saltenv in self.client.envs():
                 tops[saltenv].append(
                         compile_template(
                             self.client.cache_file(

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -245,6 +245,9 @@ def state(
 
         m_ret = False
 
+        if 'return' in mdata and 'ret' not in mdata:
+            mdata['ret'] = mdata.pop('return')
+
         if mdata.get('failed', False):
             m_state = False
         else:


### PR DESCRIPTION
- Get the environments from the file client. This allows for proper population of environments including those generated through gitfs mapping branches.
- Salt SSH orchestration returns `ret` as `return`. Adapt.
