### PR TITLE
Replace "s3" with "s3fs" in the s3fs documentation

### DIFF
--- a/doc/man/salt.7
+++ b/doc/man/salt.7
@@ -42133,7 +42133,7 @@ Master config file.
 .nf
 .ft C
 fileserver_backend:
-  \- s3
+  \- s3fs
 .ft P
 .fi
 .UNINDENT

--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -3,13 +3,13 @@
 Amazon S3 Fileserver Backend
 
 This backend exposes directories in S3 buckets as Salt environments. To enable
-this backend, add ``s3`` to the :conf_master:`fileserver_backend` option in the
-Master config file.
+this backend, add ``s3fs`` to the :conf_master:`fileserver_backend` option in
+the Master config file.
 
 .. code-block:: yaml
 
     fileserver_backend:
-      - s3
+      - s3fs
 
 S3 credentials must also be set in the master config file:
 


### PR DESCRIPTION
Fixes #23085.  One must add `s3fs` to `fileserver_roots` in order to
activate the S3 file server back end, not `s3`.
