### PR TITLE
Fixing return code to be "1" instead of 0 when the return code of a run is something other than 0

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -528,7 +528,7 @@ class SSH(object):
         final_exit = 0
         for ret in self.handle_ssh():
             host = next(six.iterkeys(ret))
-            host_ret = ret[host].get('retcode')
+            host_ret = ret[host].get('retcode', 0)
             if host_ret != 0:
                 final_exit = 1
 

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -525,9 +525,9 @@ class SSH(object):
             print('')
         sret = {}
         outputter = self.opts.get('output', 'nested')
+        final_exit = 0
         for ret in self.handle_ssh():
             host = next(six.iterkeys(ret))
-            final_exit = 0
             host_ret = ret[host].get('retcode')
             if host_ret != 0:
                 final_exit = 1

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -20,6 +20,7 @@ import yaml
 import uuid
 import tempfile
 import binascii
+import sys
 
 # Import salt libs
 import salt.client.ssh.shell
@@ -526,6 +527,11 @@ class SSH(object):
         outputter = self.opts.get('output', 'nested')
         for ret in self.handle_ssh():
             host = next(six.iterkeys(ret))
+            final_exit = 0
+            host_ret = ret[host].get('retcode')
+            if host_ret != 0:
+                final_exit = 1
+
             self.cache_job(jid, host, ret[host], fun)
             ret = self.key_deploy(host, ret)
             if not isinstance(ret[host], dict):
@@ -554,6 +560,7 @@ class SSH(object):
                     outputter,
                     self.opts)
 
+        sys.exit(final_exit)
 
 class Single(object):
     '''

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -561,6 +561,7 @@ class SSH(object):
                     self.opts)
 
         sys.exit(final_exit)
+        
 
 class Single(object):
     '''

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -766,11 +766,11 @@ class Single(object):
                 opts_pkg['_caller_cachedir'] = self.opts['cachedir']
             # Use the ID defined in the roster file
             opts_pkg['id'] = self.id
+            retcode = opts_pkg['retcode']
 
             if '_error' in opts_pkg:
                 # Refresh failed
                 ret = json.dumps({'local': opts_pkg})
-                retcode = opts_pkg['retcode']
                 return ret, retcode
 
             pillar = salt.pillar.Pillar(
@@ -848,7 +848,7 @@ class Single(object):
             ret = json.dumps({'local': result['local']})
         else:
             ret = json.dumps({'local': {'return': result}})
-        return ret
+        return ret, retcode
 
     def _cmd_str(self):
         '''

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -707,7 +707,7 @@ class Single(object):
             stdout, stderr, retcode = self.shell.exec_cmd(cmd_str)
 
         elif self.fun in self.wfuncs or self.mine:
-            stdout = self.run_wfunc()
+            stdout, retcode = self.run_wfunc()
 
         else:
             stdout, stderr, retcode = self.cmd_block()
@@ -769,7 +769,8 @@ class Single(object):
             if '_error' in opts_pkg:
                 # Refresh failed
                 ret = json.dumps({'local': opts_pkg})
-                return ret
+                retcode = opts_pkg['retcode']
+                return ret, retcode
 
             pillar = salt.pillar.Pillar(
                     opts_pkg,

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -559,8 +559,8 @@ class SSH(object):
                     sret,
                     outputter,
                     self.opts)
-
-        sys.exit(final_exit)
+        if final_exit:
+            sys.exit(salt.defaults.exitcodes.EX_AGGREGATE)
 
 
 class Single(object):

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -561,7 +561,7 @@ class SSH(object):
                     self.opts)
 
         sys.exit(final_exit)
-        
+
 
 class Single(object):
     '''

--- a/salt/client/ssh/wrapper/__init__.py
+++ b/salt/client/ssh/wrapper/__init__.py
@@ -114,12 +114,14 @@ class FunctionWrapper(object):
             if stderr.count('Permission Denied'):
                 return {'_error': 'Permission Denied',
                         'stdout': stdout,
-                        'stderr': stderr}
+                        'stderr': stderr
+                        'retcode': retcode}
             try:
                 ret = json.loads(stdout, object_hook=salt.utils.decode_dict)
                 if len(ret) < 2 and 'local' in ret:
                     ret = ret['local']
                 ret = ret.get('return', {})
+                ret.update({'retcode': retcode})
             except ValueError:
                 ret = {'_error': 'Failed to return clean data',
                        'stderr': stderr,

--- a/salt/client/ssh/wrapper/__init__.py
+++ b/salt/client/ssh/wrapper/__init__.py
@@ -110,7 +110,7 @@ class FunctionWrapper(object):
                     fsclient=self.fsclient,
                     **self.kwargs
             )
-            stdout, stderr, _ = single.cmd_block()
+            stdout, stderr, retcode = single.cmd_block()
             if stderr.count('Permission Denied'):
                 return {'_error': 'Permission Denied',
                         'stdout': stdout,
@@ -123,7 +123,8 @@ class FunctionWrapper(object):
             except ValueError:
                 ret = {'_error': 'Failed to return clean data',
                        'stderr': stderr,
-                       'stdout': stdout}
+                       'stdout': stdout,
+                       'retcode': retcode}
             return ret
         return caller
 

--- a/salt/defaults/exitcodes.py
+++ b/salt/defaults/exitcodes.py
@@ -15,6 +15,9 @@ EX_THIN_DEPLOY = 11
 EX_THIN_CHECKSUM = 12
 EX_MOD_DEPLOY = 13
 
+# One of a collection failed
+EX_AGGREGATE = 20
+
 # The os.EX_* exit codes are Unix only so in the interest of cross-platform
 # compatiblility define them explicitly here.
 #


### PR DESCRIPTION
This relates to issue #23102. 
