### PR TITLE
Add option to read additional arguments from stdin

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -127,6 +127,17 @@ class OptionParser(optparse.OptionParser, object):
 
     def parse_args(self, args=None, values=None):
         options, args = optparse.OptionParser.parse_args(self, args, values)
+        if 'args_stdin' in options.__dict__ and options.args_stdin is True:
+            # Read additional options and/or arguments from stdin and combine
+            # them with the options and arguments from the command line.
+            new_inargs = sys.stdin.readlines()
+            new_inargs = [arg.rstrip('\r\n') for arg in new_inargs]
+            new_options, new_args = optparse.OptionParser.parse_args(
+                    self,
+                    new_inargs)
+            options.__dict__.update(new_options.__dict__)
+            args.extend(new_args)
+
         if options.versions_report:
             self.print_versions_report()
 
@@ -965,6 +976,20 @@ class TimeoutMixIn(six.with_metaclass(MixInMeta, object)):
         )
 
 
+class ArgsStdinMixIn(six.with_metaclass(MixInMeta, object)):
+    _mixin_prio_ = 10
+
+    def _mixin_setup(self):
+        self.add_option(
+            '--args-stdin',
+            default=False,
+            dest='args_stdin',
+            action='store_true',
+            help=('Read additional options and/or arguments from stdin. '
+                  'Each entry is newline separated.')
+        )
+
+
 class OutputOptionsMixIn(six.with_metaclass(MixInMeta, object)):
 
     _mixin_prio_ = 40
@@ -1447,7 +1472,8 @@ class SaltCMDOptionParser(six.with_metaclass(OptionParserMeta,
                                              OutputOptionsMixIn,
                                              LogLevelMixIn,
                                              HardCrashMixin,
-                                             SaltfileMixIn)):
+                                             SaltfileMixIn,
+                                             ArgsStdinMixIn)):
 
     default_timeout = 5
 
@@ -2018,7 +2044,8 @@ class SaltCallOptionParser(six.with_metaclass(OptionParserMeta,
                                               LogLevelMixIn,
                                               OutputOptionsMixIn,
                                               HardCrashMixin,
-                                              SaltfileMixIn)):
+                                              SaltfileMixIn,
+                                              ArgsStdinMixIn)):
 
     description = ('Salt call is used to execute module functions locally '
                    'on a minion')
@@ -2220,7 +2247,8 @@ class SaltRunOptionParser(six.with_metaclass(OptionParserMeta,
                                              LogLevelMixIn,
                                              HardCrashMixin,
                                              SaltfileMixIn,
-                                             OutputOptionsMixIn)):
+                                             OutputOptionsMixIn,
+                                             ArgsStdinMixIn)):
 
     default_timeout = 1
 


### PR DESCRIPTION
Added a boolean command line option called '--args-stdin'.
When this is used, it will read addional options and/or arguments from
stdin.

Why is this needed?

On Windows, the maximum command line length for CreateProcess is 32K
and for 'cmd.exe' is 8K. Reference:
http://blogs.msdn.com/b/oldnewthing/archive/2003/12/10/56028.aspx

On Linux, the limitation is generally much higher and isn't an issue.
I have run into this limitation in 2 different ways:

1) When invoking the 'salt' command and explicitly listing each minion.
When the minion list gets close to 1000, this limitation will be hit.

2) When invoking the 'salt' or 'salt-call' command and passing a large
job argument. We have our own plug-in modules that implement more job
functions. Some of these functions take a configuration for a minion.
That configuration routinely exceeds 32K.

By passing options and/or arguments through stdin, I can avoid the
problems outlined above.

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
