### PR TITLE
Adjust ZeroMQ 4 docs to reflect changes to Ubuntu 12 packages

### DIFF
--- a/doc/topics/installation/ubuntu.rst
+++ b/doc/topics/installation/ubuntu.rst
@@ -67,45 +67,9 @@ may be given at a time:
 ZeroMQ 4
 ========
 
-We recommend using ZeroMQ 4 where available. ZeroMQ 4 is already available for
-Ubuntu 14.04 and Ubuntu 14.10 and nothing additional needs to be done. However,
-the **chris-lea/zeromq** PPA can be used to provide ZeroMQ 4 on Ubuntu 12.04 LTS.
-Adding this PPA can be done with a :mod:`pkgrepo.managed <salt.states.pkgrepo.managed>`
-state.
-
-.. code-block:: yaml
-
-    zeromq-ppa:
-      pkgrepo.managed:
-        - ppa: chris-lea/zeromq
-
-The following states can be used to upgrade ZeroMQ and pyzmq, and then restart
-the minion:
-
-.. code-block:: yaml
-
-    update_zmq:
-      pkg.latest:
-        - pkgs:
-          - zeromq
-          - python-zmq
-        - order: last
-      cmd.wait:
-        - name: |
-            echo service salt-minion restart | at now + 1 minute
-        - watch:
-          - pkg: update_zmq
-
-.. note::
-
-    This example assumes that atd is installed and running, see here_ for a more
-    detailed explanation.
-
-.. _here: http://docs.saltstack.com/en/latest/faq.html#what-is-the-best-way-to-restart-a-salt-daemon-using-salt
-
-If this repo is added *before* Salt is installed, then installing either
-``salt-master`` or ``salt-minion`` will automatically pull in ZeroMQ 4.0.4, and
-additional states to upgrade ZeroMQ and pyzmq are unnecessary.
+ZeroMQ 4 is available by default for Ubuntu 14.04 and newer. However, for Ubuntu
+12.04 LTS, starting with Salt version ``2014.7.5``, ZeroMQ 4 is included with the
+Salt installation package and nothing additional needs to be done.
 
 
 Post-installation tasks


### PR DESCRIPTION
Removed the chrislea ppa third party installation information. This
shouldn't be needed anymore for any Ubuntu package after 2014.7.5.

Refs #18610 and #18476

ping @joehealy
