### PR TITLE
fix parsing the output of parted in parted.list_()

### DIFF
--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -173,7 +173,7 @@ def list_(device, unit=None):
     else:
         cmd = 'parted -m -s {0} print'.format(device)
 
-    out = __salt__['cmd.run'](cmd).splitlines()
+    out = __salt__['cmd.run_stdout'](cmd).splitlines()
     ret = {'info': {}, 'partitions': {}}
     mode = 'info'
     for line in out:

--- a/tests/unit/modules/parted_test.py
+++ b/tests/unit/modules/parted_test.py
@@ -27,8 +27,12 @@ class PartedTestCase(TestCase):
     # Setup for each test function.
 
     def setUp(self):
-        parted.__salt__ = {'cmd.run': MagicMock()}
+        parted.__salt__ = {
+            'cmd.run': MagicMock(),
+            'cmd.run_stdout': MagicMock(),
+        }
         self.cmdrun = parted.__salt__['cmd.run']
+        self.cmdrun_stdout = parted.__salt__['cmd.run_stdout']
         self.maxDiff = None
 
     # Test __virtual__ function for module registration
@@ -176,17 +180,17 @@ class PartedTestCase(TestCase):
 
     @patch('salt.modules.parted._validate_device', MagicMock())
     def test_list__empty_cmd_output(self):
-        self.cmdrun.return_value = self.parted_print_output('empty')
+        self.cmdrun_stdout.return_value = self.parted_print_output('empty')
         output = parted.list_('/dev/sda')
-        self.cmdrun.assert_called_once_with('parted -m -s /dev/sda print')
+        self.cmdrun_stdout.assert_called_once_with('parted -m -s /dev/sda print')
         expected = {'info': {}, 'partitions': {}}
         self.assertEqual(output, expected)
 
     @patch('salt.modules.parted._validate_device', MagicMock())
     def test_list__valid_unit_empty_cmd_output(self):
-        self.cmdrun.return_value = self.parted_print_output('empty')
+        self.cmdrun_stdout.return_value = self.parted_print_output('empty')
         output = parted.list_('/dev/sda', unit='s')
-        self.cmdrun.assert_called_once_with('parted -m -s /dev/sda unit s print')
+        self.cmdrun_stdout.assert_called_once_with('parted -m -s /dev/sda unit s print')
         expected = {'info': {}, 'partitions': {}}
         self.assertEqual(output, expected)
 
@@ -197,27 +201,27 @@ class PartedTestCase(TestCase):
 
     @patch('salt.modules.parted._validate_device', MagicMock())
     def test_list__bad_header(self):
-        self.cmdrun.return_value = self.parted_print_output('bad_header')
+        self.cmdrun_stdout.return_value = self.parted_print_output('bad_header')
         self.assertRaises(CommandExecutionError, parted.list_, '/dev/sda')
-        self.cmdrun.assert_called_once_with('parted -m -s /dev/sda print')
+        self.cmdrun_stdout.assert_called_once_with('parted -m -s /dev/sda print')
 
     @patch('salt.modules.parted._validate_device', MagicMock())
     def test_list__bad_label_info(self):
-        self.cmdrun.return_value = self.parted_print_output('bad_label_info')
+        self.cmdrun_stdout.return_value = self.parted_print_output('bad_label_info')
         self.assertRaises(CommandExecutionError, parted.list_, '/dev/sda')
-        self.cmdrun.assert_called_once_with('parted -m -s /dev/sda print')
+        self.cmdrun_stdout.assert_called_once_with('parted -m -s /dev/sda print')
 
     @patch('salt.modules.parted._validate_device', MagicMock())
     def test_list__bad_partition(self):
-        self.cmdrun.return_value = self.parted_print_output('bad_partition')
+        self.cmdrun_stdout.return_value = self.parted_print_output('bad_partition')
         self.assertRaises(CommandExecutionError, parted.list_, '/dev/sda')
-        self.cmdrun.assert_called_once_with('parted -m -s /dev/sda print')
+        self.cmdrun_stdout.assert_called_once_with('parted -m -s /dev/sda print')
 
     @patch('salt.modules.parted._validate_device', MagicMock())
     def test_list__valid_cmd_output(self):
-        self.cmdrun.return_value = self.parted_print_output('valid')
+        self.cmdrun_stdout.return_value = self.parted_print_output('valid')
         output = parted.list_('/dev/sda')
-        self.cmdrun.assert_called_once_with('parted -m -s /dev/sda print')
+        self.cmdrun_stdout.assert_called_once_with('parted -m -s /dev/sda print')
         expected = {
             'info': {
                 'logical sector': '512',
@@ -253,9 +257,9 @@ class PartedTestCase(TestCase):
 
     @patch('salt.modules.parted._validate_device', MagicMock())
     def test_list__valid_unit_valid_cmd_output(self):
-        self.cmdrun.return_value = self.parted_print_output('valid')
+        self.cmdrun_stdout.return_value = self.parted_print_output('valid')
         output = parted.list_('/dev/sda', unit='s')
-        self.cmdrun.assert_called_once_with('parted -m -s /dev/sda unit s print')
+        self.cmdrun_stdout.assert_called_once_with('parted -m -s /dev/sda unit s print')
         expected = {
             'info': {
                 'logical sector': '512',
@@ -291,9 +295,9 @@ class PartedTestCase(TestCase):
 
     @patch('salt.modules.parted._validate_device', MagicMock())
     def test_list__valid_legacy_cmd_output(self):
-        self.cmdrun.return_value = self.parted_print_output('valid_legacy')
+        self.cmdrun_stdout.return_value = self.parted_print_output('valid_legacy')
         output = parted.list_('/dev/sda')
-        self.cmdrun.assert_called_once_with('parted -m -s /dev/sda print')
+        self.cmdrun_stdout.assert_called_once_with('parted -m -s /dev/sda print')
         expected = {
             'info': {
                 'logical sector': '512',
@@ -328,9 +332,9 @@ class PartedTestCase(TestCase):
 
     @patch('salt.modules.parted._validate_device', MagicMock())
     def test_list__valid_unit_valid_legacy_cmd_output(self):
-        self.cmdrun.return_value = self.parted_print_output('valid_legacy')
+        self.cmdrun_stdout.return_value = self.parted_print_output('valid_legacy')
         output = parted.list_('/dev/sda', unit='s')
-        self.cmdrun.assert_called_once_with('parted -m -s /dev/sda unit s print')
+        self.cmdrun_stdout.assert_called_once_with('parted -m -s /dev/sda unit s print')
         expected = {
             'info': {
                 'logical sector': '512',


### PR DESCRIPTION
Hi there,

Parsing the output of parted may fail in **partition.list** (in the code: **parted.list_**).
Here is an example of such a case:

```
[INFO    ] Executing command 'parted -m -s /dev/sdb print' in directory '/root'
[DEBUG   ] output: Warning: Not all of the space available to /dev/sdb appears to be used, you can fix the GPT to use all of the space (an extra 44662784 blocks) or continue with the current setting? 
BYT;
/dev/sdb:31.5GB:scsi:512:512:gpt:ATA VBOX HARDDISK:;
1:1049kB:8589MB:8588MB:btrfs:SRV:;
Traceback (most recent call last):
  File ".../eggs/salt-2014.7.0-py2.7.egg/salt/cli/caller.py", line 129, in call
    ret['return'] = func(*args, **kwargs)
  File ".../eggs/salt-2014.7.0-py2.7.egg/salt/modules/parted.py", line 148, in list_
    'Problem encountered while parsing output from parted')
CommandExecutionError: Problem encountered while parsing output from parted
Error running 'partition.list': Problem encountered while parsing output from parted
```

At https://github.com/saltstack/salt/blob/6560839d923493c59045b3a745b50f2c42d3be72/salt/modules/parted.py#L182, _cols_ is: _['Warning', ' Not all of the space available to /dev/sdb appears to be used, you can fix the GPT to use all of the space (an extra 44662784 blocks) or continue with the current setting? ']_

To correct this, I simply changed **cmd.run** to **cmd.run_stdout** since the message _Warning: Not all of the space available to /dev/sdb appears to be used, you can fix the GPT to use all of the space (an extra 44662784 blocks) or continue with the current setting?_ is written on stderr.

The log with the path of this pull request on a test virtual machine:

```
[INFO    ] Executing command 'parted -m -s /dev/sdb print' in directory '/root'
[DEBUG   ] stdout: BYT;
/dev/sdb:31.5GB:scsi:512:512:gpt:ATA VBOX HARDDISK:;
1:1049kB:8589MB:8588MB:btrfs:SRV:;
[DEBUG   ] stderr: Warning: Not all of the space available to /dev/sdb appears to be used, you can fix the GPT to use all of the space (an extra 44662784 blocks) or continue with the current setting?
['/dev/sdb', '31.5GB', 'scsi', '512', '512', 'gpt', 'ATA VBOX HARDDISK', '']
```

May be related to #16188 (some other things are bugging me, but I can not directly work around this one).
