### PR TITLE
Backport b27c176

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1448,6 +1448,10 @@ def managed(name,
             if isinstance(cret, dict):
                 ret.update(cret)
                 return ret
+            # Since we generated a new tempfile and we are not returning here
+            # lets change the original sfn to the new tempfile or else we will
+            # get file not found
+            sfn = tmp_filename
         else:
             ret = {'changes': {},
                    'comment': '',


### PR DESCRIPTION
Backport the b27c176 to 2014.07.

check_cmd does not work without it.
