### PR TITLE
Backport #23124 to 2014.7 

### DIFF
--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -154,7 +154,7 @@ def list_(device, unit=None):
     else:
         cmd = 'parted -m -s {0} print'.format(device)
 
-    out = __salt__['cmd.run'](cmd).splitlines()
+    out = __salt__['cmd.run_stdout'](cmd).splitlines()
     ret = {'info': {}, 'partitions': {}}
     mode = 'info'
     for line in out:


### PR DESCRIPTION
Backport #23124 to 2014.7 

The test file included in the original pull request doesn't exist on this branch. I'm only backporting the specific change to the module, instead of the whole test file as well.
