### PR TITLE
Bugfix: When writing MsgPack content to file, binary mode is required

### DIFF
--- a/salt/daemons/flo/jobber.py
+++ b/salt/daemons/flo/jobber.py
@@ -274,7 +274,7 @@ class SaltRaetNixJobber(ioflo.base.deeding.Deed):
 
         sdata = {'pid': os.getpid()}
         sdata.update(data)
-        with salt.utils.fopen(fn_, 'w+') as fp_:
+        with salt.utils.fopen(fn_, 'w+b') as fp_:
             fp_.write(self.serial.dumps(sdata))
         ret = {'success': False}
         function_name = data['fun']

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -574,7 +574,7 @@ class Schedule(object):
                               'in another thread, skipping.'.format(
                                   basefilename))
                     continue
-                with salt.utils.fopen(fn_, 'r') as fp_:
+                with salt.utils.fopen(fn_, 'rb') as fp_:
                     job = salt.payload.Serial(self.opts).load(fp_)
                     if job:
                         if 'schedule' in job:
@@ -607,7 +607,7 @@ class Schedule(object):
             log.debug('schedule.handle_func: adding this job to the jobcache '
                       'with data {0}'.format(ret))
             # write this to /var/cache/salt/minion/proc
-            with salt.utils.fopen(proc_fn, 'w+') as fp_:
+            with salt.utils.fopen(proc_fn, 'w+b') as fp_:
                 fp_.write(salt.payload.Serial(self.opts).dumps(ret))
 
         args = tuple()


### PR DESCRIPTION
Before this fix, failures happened when reading some (but not all) of
the jid-based files in get_proc_dir() while running under RAET.

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
