### PR TITLE
Do not use runas when user is correct

### DIFF
--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -45,7 +45,7 @@ def _tap(tap, runas=None):
         return True
 
     cmd = 'brew tap {0}'.format(tap)
-    if __salt__['cmd.retcode'](cmd, python_shell=False, runas=runas):
+    if _call_brew(cmd)['retcode']:
         log.error('Failed to tap "{0}"'.format(tap))
         return False
 

--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -63,7 +63,7 @@ def _homebrew_bin():
 
 def _call_brew(cmd):
     '''
-    Calls the brew command with the user user account of brew
+    Calls the brew command with the user account of brew
     '''
     user = __salt__['file.get_user'](_homebrew_bin())
     runas = user if user != __opts__['user'] else None

--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -66,8 +66,9 @@ def _call_brew(cmd):
     Calls the brew command with the user user account of brew
     '''
     user = __salt__['file.get_user'](_homebrew_bin())
+    runas = user if user != __opts__['user'] else None
     return __salt__['cmd.run_all'](cmd,
-                                   runas=user,
+                                   runas=runas,
                                    output_loglevel='trace',
                                    python_shell=False)
 

--- a/tests/unit/modules/brew_test.py
+++ b/tests/unit/modules/brew_test.py
@@ -40,10 +40,10 @@ class BrewTestCase(TestCase):
         '''
         mock_taps = MagicMock(return_value={'stdout': TAPS_STRING})
         mock_user = MagicMock(return_value='foo')
-        moca_cmd = MagicMock(return_value='')
+        mock_cmd = MagicMock(return_value='')
         with patch.dict(brew.__salt__, {'file.get_user': mock_user,
                                         'cmd.run_all': mock_taps,
-                                        'cmd.run': moca_cmd}):
+                                        'cmd.run': mock_cmd}):
             self.assertEqual(brew._list_taps(), TAPS_LIST)
 
     # '_tap' function tests: 3

--- a/tests/unit/modules/brew_test.py
+++ b/tests/unit/modules/brew_test.py
@@ -19,6 +19,7 @@ from salt.modules import brew
 # Global Variables
 brew.__context__ = {}
 brew.__salt__ = {}
+brew.__opts__ = {'user': MagicMock(return_value='bar')}
 
 TAPS_STRING = 'homebrew/dupes\nhomebrew/science\nhomebrew/x11'
 TAPS_LIST = ['homebrew/dupes', 'homebrew/science', 'homebrew/x11']
@@ -64,8 +65,7 @@ class BrewTestCase(TestCase):
         mock_cmd = MagicMock(return_value='')
         with patch.dict(brew.__salt__, {'cmd.run_all': mock_failure,
                                         'file.get_user': mock_user,
-                                        'cmd.run': mock_cmd,
-                                        'cmd.retcode': mock_failure}):
+                                        'cmd.run': mock_cmd}):
             self.assertFalse(brew._tap('homebrew/test'))
 
     @patch('salt.modules.brew._list_taps', MagicMock(return_value=TAPS_LIST))
@@ -73,7 +73,12 @@ class BrewTestCase(TestCase):
         '''
         Tests adding unofficial GitHub repos to the list of brew taps
         '''
-        with patch.dict(brew.__salt__, {'cmd.retcode': MagicMock(return_value=0)}):
+        mock_failure = MagicMock(return_value={'retcode': 0})
+        mock_user = MagicMock(return_value='foo')
+        mock_cmd = MagicMock(return_value='')
+        with patch.dict(brew.__salt__, {'cmd.run_all': mock_failure,
+                                        'file.get_user': mock_user,
+                                        'cmd.run': mock_cmd}):
             self.assertTrue(brew._tap('homebrew/test'))
 
     # '_homebrew_bin' function tests: 1


### PR DESCRIPTION
_call_brew should not use runas when user is the same user as the user account of brew.
