### PR TITLE
Switch resolver to threaded variant

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,3 +4,5 @@ PyYAML
 MarkupSafe
 requests >= 1.0.0
 tornado >= 4.0
+# Required by Tornado to handle threads stuff.
+futures >= 2.0

--- a/salt/transport/client.py
+++ b/salt/transport/client.py
@@ -52,6 +52,7 @@ class AsyncChannel(object):
         cls._resolver = ThreadedResolver()
         cls._resolver.initialize(num_threads=num_threads)
 
+
 # TODO: better doc strings
 class AsyncReqChannel(AsyncChannel):
     '''

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -119,11 +119,13 @@ class AsyncTCPReqChannel(salt.transport.client.ReqChannel):
         if self.crypt != 'clear':
             self.auth = salt.crypt.AsyncAuth(self.opts, io_loop=self.io_loop)
 
+        resolver = kwargs.get('resolver')
+
         parse = urlparse.urlparse(self.opts['master_uri'])
         host, port = parse.netloc.rsplit(':', 1)
         self.master_addr = (host, int(port))
 
-        self.message_client = SaltMessageClient(host, int(port), io_loop=self.io_loop)
+        self.message_client = SaltMessageClient(host, int(port), io_loop=self.io_loop, resolver=resolver)
 
     def __del__(self):
         self.message_client.destroy()
@@ -379,17 +381,13 @@ class SaltMessageClient(object):
     '''
     Low-level message sending client
     '''
-    def __init__(self, host, port, io_loop=None):
+    def __init__(self, host, port, io_loop=None, resolver=None):
         self.host = host
         self.port = port
 
         self.io_loop = io_loop or tornado.ioloop.IOLoop.current()
 
-        # Configure the resolver to use a non-blocking one
-        # Not Threaded since we need to work on python2
-        tornado.netutil.Resolver.configure('tornado.netutil.ExecutorResolver')
-
-        self._tcp_client = tornado.tcpclient.TCPClient(io_loop=self.io_loop)
+        self._tcp_client = tornado.tcpclient.TCPClient(io_loop=self.io_loop, resolver=resolver)
 
         self._mid = 1
         self._max_messages = sys.maxint - 1  # number of IDs before we wrap


### PR DESCRIPTION
Hi, guys. 

We noticed that your developers tried to fix blocking DNS resolving in Tornado TCP client

https://github.com/saltstack/salt/commit/9c680514b454489bb7dfe962a473422fb444f04a

But actually this commit doesn't fix issue.  Fix configures tornado.netutil.ExecutorResolver for using as default DNS Resolver. But it is useful only when you provide own 'executor=' param to constructor. TCP Client creates resolver without additional params so ExecutorResolver uses dummy_executor (DummyExecutor) (see http://tornado.readthedocs.org/en/latest/_modules/tornado/concurrent.html) that simply calls function in synchronous blocking mode. It means that your Salt application still hangs in DNS resolving call and will be unresponsive to all events until resolving is finished.

Also there is a strange comment inside commit

> Configure the resolver to use a non-blocking one
>  Not Threaded since we need to work on python2

ThreadedResolver works fine with python2. You only need to add dependency on 'futures' package https://pypi.python.org/pypi/futures - it is backport of concurrent.futures package from python3. 
