### PR TITLE
Bugfix: 'clean_proc_dir' is broken

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -1110,10 +1110,11 @@ def clean_proc_dir(opts):
         with salt.utils.fopen(fn_, 'rb') as fp_:
             job = None
             try:
-                job_data = fp_.read()
-                if job_data:
-                    job = salt.payload.Serial(opts).load(fp_)
+                job = salt.payload.Serial(opts).load(fp_)
             except Exception:  # It's corrupted
+                # Windows cannot delete an open file
+                if salt.utils.is_windows():
+                    fp_.close()
                 try:
                     os.unlink(fn_)
                     continue


### PR DESCRIPTION
Upon testing (in my Windows environment), I noticed that in
clean_proc_dir():
    job = salt.payload.Serial(opts).load(fp_)

The result would always be that 'job' is None. Upon further
investigation, this seems to be the case because of this line above:
    job_data = fp_.read()

If I remove that line, things work as expected. So it seems like the
'fp_.read()' will move the current file position of 'fp_' to the end,
and so 'salt.payload.Serial(opts).load(fp_)' would end up reading what
it thinks is an empty file.

Looking at the logic, it seems like 'job_data = fp_.read()' is an
unnecessary step in any case, so it has been removed.

I have noticed that this same incorrect logic also exists in the 2015.2
and 2014.7 branches.

Also, added a fix for deleting files on Windows which was already in
another part of the same function.

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
