### PR TITLE
[2015.2] Merge forward from 2014.7 to 2015.2

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -916,6 +916,13 @@ class RemoteClient(Client):
             return self.channel
         return salt.transport.Channel.factory(self.opts)
 
+    def _refresh_channel(self):
+        '''
+        Reset the channel, in the event of an interruption
+        '''
+        self.channel = salt.transport.Channel.factory(self.opts)
+        return self.channel
+
     def get_file(self,
                  path,
                  dest='',
@@ -990,6 +997,7 @@ class RemoteClient(Client):
             data = self.channel.send(load)
             if 'data' not in data:
                 log.error('Data is {0}'.format(data))
+                self._refresh_channel()
             if not data['data']:
                 if not fn_ and data['dest']:
                     # This is a 0 byte file on the master

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -501,7 +501,7 @@ def install(name=None,
                                                         ver2=cver,
                                                         cmp_func=version_cmp):
                     downgrade = True
-                targets.append('{0}={1}'.format(param, version_num.lstrip('=')))
+                targets.append('{0}={1}'.format(param, str(version_num).lstrip('=')))
         if fromrepo:
             log.info('Targeting repo {0!r}'.format(fromrepo))
         cmd = ['apt-get', '-q', '-y']

--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -154,7 +154,7 @@ def list_(device, unit=None):
     else:
         cmd = 'parted -m -s {0} print'.format(device)
 
-    out = __salt__['cmd.run'](cmd).splitlines()
+    out = __salt__['cmd.run_stdout'](cmd).splitlines()
     ret = {'info': {}, 'partitions': {}}
     mode = 'info'
     for line in out:

--- a/salt/utils/serializers/yaml.py
+++ b/salt/utils/serializers/yaml.py
@@ -17,6 +17,7 @@ from yaml.constructor import ConstructorError
 from yaml.scanner import ScannerError
 
 from salt.utils.serializers import DeserializationError, SerializationError
+from salt.utils.odict import OrderedDict
 
 __all__ = ['deserialize', 'serialize', 'available']
 
@@ -40,7 +41,7 @@ def deserialize(stream_or_string, **options):
     :param options: options given to lower yaml module.
     """
 
-    options.setdefault('Loader', BaseLoader)
+    options.setdefault('Loader', Loader)
     try:
         return yaml.load(stream_or_string, **options)
     except ScannerError as error:
@@ -63,7 +64,7 @@ def serialize(obj, **options):
     :param options: options given to lower yaml module.
     """
 
-    options.setdefault('Dumper', BaseDumper)
+    options.setdefault('Dumper', Dumper)
     try:
         response = yaml.dump(obj, **options)
         if response.endswith('\n...\n'):
@@ -112,3 +113,4 @@ Dumper.add_multi_representer(set, Dumper.represent_set)
 Dumper.add_multi_representer(datetime.date, Dumper.represent_date)
 Dumper.add_multi_representer(datetime.datetime, Dumper.represent_datetime)
 Dumper.add_multi_representer(None, Dumper.represent_undefined)
+Dumper.add_multi_representer(OrderedDict, Dumper.represent_dict)

--- a/salt/utils/serializers/yaml.py
+++ b/salt/utils/serializers/yaml.py
@@ -41,7 +41,7 @@ def deserialize(stream_or_string, **options):
     :param options: options given to lower yaml module.
     """
 
-    options.setdefault('Loader', Loader)
+    options.setdefault('Loader', BaseLoader)
     try:
         return yaml.load(stream_or_string, **options)
     except ScannerError as error:

--- a/tests/unit/utils/serializers_test.py
+++ b/tests/unit/utils/serializers_test.py
@@ -128,7 +128,7 @@ class TestSerializers(TestCase):
         assert obj == final_obj
 
         # BLAAM! yml_src is not valid !
-        final_obj = yaml.deserialize(yml_src)
+        final_obj = OrderedDict(yaml.deserialize(yml_src))
         assert obj != final_obj
 
     @skipIf(not yamlex.available, SKIP_MESSAGE % 'sls')


### PR DESCRIPTION
[2015.2] Merge forward from 2014.7 to 2015.2

```
Conflicts:
    salt/fileclient.py
    salt/utils/serializers/yaml.py
```
