### PR TITLE
softlayer provider also requires libcloud

### DIFF
--- a/salt/cloud/clouds/softlayer.py
+++ b/salt/cloud/clouds/softlayer.py
@@ -47,6 +47,13 @@ try:
 except ImportError:
     HAS_SLLIBS = False
 
+# Attempt to import libcloud
+try:
+    import libcloud
+    HAS_LIBCLOUD = True
+except ImportError:
+    HAS_LIBCLOUD = False
+
 # Get logging started
 log = logging.getLogger(__name__)
 
@@ -60,6 +67,9 @@ def __virtual__():
     Set up the libcloud functions and check for SoftLayer configurations.
     '''
     if not HAS_SLLIBS:
+        return False
+
+    if not HAS_LIBCLOUD:
         return False
 
     if get_configured_provider() is False:


### PR DESCRIPTION
Without this, and without libcloud installed, you get a very ambiguous:

```
> [ERROR   ] There was a profile error: global name 'ScriptDeployment' is not defined
```

when trying to provision.

Technically, we could use `HAS_LIBCLOUD` from L39, but that's an implicit `import *`, so if the behavior of that changes, this would break unexpectedly.

So instead of relying on the global `HAS_LIBCLOUD` from `libcloudfuncs.py`, I chose to just re-detect in this module.
