### PR TITLE
[2014.7] Work around bug in salt-ssh in config.get for gpg renderer

### DIFF
--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -135,9 +135,10 @@ def render(gpg_data, saltenv='base', sls='', argline='', **kwargs):
     '''
     if not HAS_GPG:
         raise SaltRenderError('GPG unavailable')
+    homedir = None
     if 'config.get' in __salt__:
-        homedir = __salt__['config.get']('gpg_keydir', DEFAULT_GPG_KEYDIR)
-    else:
+        homedir = __salt__['config.get']('gpg_keydir', None)
+    if homedir is None:
         homedir = __opts__.get('gpg_keydir', DEFAULT_GPG_KEYDIR)
     log.debug('Reading GPG keys from: {0}'.format(homedir))
     try:


### PR DESCRIPTION
If config.get fails, try querying **opts** directly. Something is going on with config.get, I'll fix that next. Theoretically if we get into the first if statement we shouldn't need the second. In any case, this workaround won't break anything existing.

Refs #19114
