### PR TITLE
Fix wrong number of arguments

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -85,7 +85,7 @@ def __virtual__():
     return False
 
 
-def __init__():
+def __init__(opts):
     '''
     For Debian and derivative systems, set up
     a few env variables to keep apt happy and


### PR DESCRIPTION
```
2015-04-29 11:19:49,377 [salt.loader      ][ERROR   ][2747] __init__() takes no arguments (1 given)
```

`salt.modules.aptpkg.__init__` is called from with 1 argument from [`salt.loader`](https://github.com/saltstack/salt/blob/develop/salt/loader.py#L1018).
