### PR TITLE
Fix wrong namespaces

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -267,10 +267,10 @@ def query(url,
         result_text = result.text
         result_cookies = result.cookies
     else:
-        request = urllib.Request(url, data)
+        request = urllib.request.Request(url, data)
         handlers = [
-            urllib.HTTPHandler,
-            urllib.HTTPCookieProcessor(sess_cookies)
+            urllib.request.HTTPHandler,
+            urllib.request.HTTPCookieProcessor(sess_cookies)
         ]
 
         if url.startswith('https') or port == 443:
@@ -316,7 +316,7 @@ def query(url,
                     if hasattr(ssl, 'SSLContext'):
                         # Python >= 2.7.9
                         context = ssl.SSLContext.load_cert_chain(*cert_chain)
-                        handlers.append(urllib.HTTPSHandler(context=context))  # pylint: disable=E1123
+                        handlers.append(urllib.request.HTTPSHandler(context=context))  # pylint: disable=E1123
                     else:
                         # Python < 2.7.9
                         cert_kwargs = {
@@ -328,7 +328,7 @@ def query(url,
                             cert_kwargs['key_file'] = cert_chain[1]
                         handlers[0] = salt.ext.six.moves.http_client.HTTPSConnection(**cert_kwargs)
 
-        opener = urllib.build_opener(*handlers)
+        opener = urllib.request.build_opener(*handlers)
         for header in header_dict:
             request.add_header(header, header_dict[header])
         request.get_method = lambda: method


### PR DESCRIPTION
```
2015-04-30 21:34:29,549 [salt.state       ][ERROR   ][2218] Unable to manage file: 'Module_six_moves_urllib' object has no attribute 'Request'
```

Since saltstack/salt@94f9184f51301ceb5f981e67aef68d499f067c30 `http.py` use `urllib` with `six` instead of `urllib2`.
But `Request`, `HTTPHandler`, `HTTPCookieProcessor`, `HTTPSHandler` and `build_opener` are not in `urllib` but in [`urllib.request`](https://docs.python.org/3/library/urllib.request.html).
