### PR TITLE
[EXPERT REVIEW REQUIRED] Remove grains workaround from pillar generation

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1109,11 +1109,6 @@ class AESFuncs(object):
         if not salt.utils.verify.valid_id(self.opts, load['id']):
             return False
         load['grains']['id'] = load['id']
-        mods = set()
-        for func in six.itervalues(self.mminion.functions):
-            mods.add(func.__module__)
-        for mod in mods:
-            sys.modules[mod].__grains__ = load['grains']
 
         pillar_dirs = {}
         pillar = salt.pillar.Pillar(


### PR DESCRIPTION
Originally, we had implemented a fix for issue #11453 wherein we would
take a minion's grains from the load it presented and slam them into
salt modules directly during pillar generation.

This approach had serious performance impacts and also recently started
producing stacktraces as we hit attempts to import modules not present
on the host system.

In re-testing the issue reported in #11453 and without this workaround,
this issue is no longer present. I believe it has been fixed in the recent
work done in the LazyLoader.

Please do not merge this unless you are @thatch45 
