### PR TITLE
Making sure that the key exists in dict and doesn't fail if devices have not been specified

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -1798,7 +1798,7 @@ def create(vm_):
             config=config_spec
         )
 
-        if specs['nics_map']:
+        if devices and 'nics_map' in specs.keys():
             if "Windows" not in object_ref.config.guestFullName:
                 global_ip = vim.vm.customization.GlobalIPSettings()
                 if vm_['dns_servers']:


### PR DESCRIPTION
 Fixes #23247 
