### PR TITLE
Psutil compat

### DIFF
--- a/salt/daemons/flo/core.py
+++ b/salt/daemons/flo/core.py
@@ -48,7 +48,7 @@ import salt.ext.six as six
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 HAS_PSUTIL = False
 try:
-    import psutil
+    import salt.utils.psutil_compat as psutil
     HAS_PSUTIL = True
 except ImportError:
     pass
@@ -520,7 +520,7 @@ class SaltLoadModules(ioflo.base.deeding.Deed):
                     )
             modules_max_memory = True
             old_mem_limit = resource.getrlimit(resource.RLIMIT_AS)
-            rss, vms = psutil.Process(os.getpid()).get_memory_info()
+            rss, vms = psutil.Process(os.getpid()).memory_info()
             mem_limit = rss + vms + self.opts.value['modules_max_memory']
             resource.setrlimit(resource.RLIMIT_AS, (mem_limit, mem_limit))
         elif self.opts.value.get('modules_max_memory', -1) > 0:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -42,7 +42,7 @@ except ImportError:
 
 HAS_PSUTIL = False
 try:
-    import psutil
+    import salt.utils.psutil_compat as psutil
     HAS_PSUTIL = True
 except ImportError:
     pass
@@ -920,7 +920,7 @@ class Minion(MinionBase):
             log.debug('modules_max_memory set, enforcing a maximum of {0}'.format(self.opts['modules_max_memory']))
             modules_max_memory = True
             old_mem_limit = resource.getrlimit(resource.RLIMIT_AS)
-            rss, vms = psutil.Process(os.getpid()).get_memory_info()
+            rss, vms = psutil.Process(os.getpid()).memory_info()
             mem_limit = rss + vms + self.opts['modules_max_memory']
             resource.setrlimit(resource.RLIMIT_AS, (mem_limit, mem_limit))
         elif self.opts.get('modules_max_memory', -1) > 0:

--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -126,10 +126,10 @@ def top(num_processes=5, interval=3):
     '''
     result = []
     start_usage = {}
-    for pid in psutil.get_pid_list():
+    for pid in psutil.pid_list():
         try:
             process = psutil.Process(pid)
-            user, system = process.get_cpu_times()
+            user, system = process.cpu_times()
         except psutil.NoSuchProcess:
             continue
         start_usage[process] = user + system
@@ -137,7 +137,7 @@ def top(num_processes=5, interval=3):
     usage = set()
     for process, start in start_usage.items():
         try:
-            user, system = process.get_cpu_times()
+            user, system = process.cpu_times()
         except psutil.NoSuchProcess:
             continue
         now = user + system
@@ -159,9 +159,9 @@ def top(num_processes=5, interval=3):
                 'cpu': {},
                 'mem': {},
         }
-        for key, value in process.get_cpu_times()._asdict().items():
+        for key, value in process.cpu_times()._asdict().items():
             info['cpu'][key] = value
-        for key, value in process.get_memory_info()._asdict().items():
+        for key, value in process.memory_info()._asdict().items():
             info['mem'][key] = value
         result.append(info)
 
@@ -178,7 +178,7 @@ def get_pid_list():
 
         salt '*' ps.get_pid_list
     '''
-    return psutil.get_pid_list()
+    return psutil.pid_list()
 
 
 def proc_info(pid, attrs=None):
@@ -538,7 +538,7 @@ def boot_time(time_format=None):
     except AttributeError:
         # get_boot_time() has been removed in newer psutil versions, and has
         # been replaced by boot_time() which provides the same information.
-        b_time = int(psutil.get_boot_time())
+        b_time = int(psutil.boot_time())
     if time_format:
         # Load epoch timestamp as a datetime.datetime object
         b_time = datetime.datetime.fromtimestamp(b_time)
@@ -604,7 +604,7 @@ def get_users():
         salt '*' ps.get_users
     '''
     try:
-        recs = psutil.get_users()
+        recs = psutil.users()
         return [dict(x._asdict()) for x in recs]
     except AttributeError:
         # get_users is only present in psutil > v0.5.0

--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -17,7 +17,7 @@ from salt.exceptions import SaltInvocationError, CommandExecutionError
 
 # Import third party libs
 try:
-    import psutil
+    import salt.utils.psutil_compat as psutil
 
     HAS_PSUTIL = True
     PSUTIL2 = psutil.version_info >= (2, 0)

--- a/salt/utils/psutil_compat.py
+++ b/salt/utils/psutil_compat.py
@@ -29,16 +29,16 @@ else:
     # Alias new module functions
     def boot_time():
         return psutil.BOOT_TIME
-    
+
     def cpu_count():
         return psutil.NUM_CPUS
-    
+
     # Alias renamed module functions
     pids = psutil.get_pid_list
     users = psutil.get_users
 
     # Alias renamed Process functions
-    _PROCESS_FUNCTION_MAP = { 
+    _PROCESS_FUNCTION_MAP = {
         "children": "get_children",
         "connections": "get_connections",
         "cpu_affinity": "get_cpu_affinity",
@@ -70,4 +70,3 @@ else:
             setattr(Process, new, psutil.Process.__dict__[old])
         except KeyError:
             pass
-

--- a/salt/utils/psutil_compat.py
+++ b/salt/utils/psutil_compat.py
@@ -10,12 +10,10 @@ Built off of http://grodola.blogspot.com/2014/01/psutil-20-porting.html
 
 from __future__ import absolute_import
 
-#log = logging.getLogger(__name__)
-
 # No exception handling, as we want ImportError if psutil doesn't exist
 import psutil
 
-if psutil.__version__ >= (2, 0):
+if psutil.version_info >= (2, 0):
     from psutil import *
 else:
     # Import hack to work around bugs in old psutil's

--- a/salt/utils/psutil_compat.py
+++ b/salt/utils/psutil_compat.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+'''
+Version agnostic psutil hack to fully support both old (<2.0) and new (>=2.0) psutil versions.
+The old <1.0 psutil API is dropped in psutil 3.0
+
+Should be removed once support for psutil <2.0 is dropped. (eg RHEL 6)
+
+Built off of http://grodola.blogspot.com/2014/01/psutil-20-porting.html
+'''
+
+from __future__ import absolute_import
+
+#log = logging.getLogger(__name__)
+
+# No exception handling, as we want ImportError if psutil doesn't exist
+import psutil
+
+if psutil.__version__ >= (2, 0):
+    from psutil import *
+else:
+    # Import hack to work around bugs in old psutil's
+    # Psuedo "from psutil import *"
+    _globals = globals()
+    for attr in psutil.__all__:
+        _temp = __import__('psutil', globals(), locals(), [attr], -1)
+        try:
+            _globals[attr] = getattr(_temp, attr)
+        except AttributeError:
+            pass
+
+    # Alias new module functions
+    def boot_time():
+        return psutil.BOOT_TIME
+    
+    def cpu_count():
+        return psutil.NUM_CPUS
+    
+    # Alias renamed module functions
+    pids = psutil.get_pid_list
+    users = psutil.get_users
+
+    # Alias renamed Process functions
+    _PROCESS_FUNCTION_MAP = { 
+        "children": "get_children",
+        "connections": "get_connections",
+        "cpu_affinity": "get_cpu_affinity",
+        "cpu_percent": "get_cpu_percent",
+        "cpu_times": "get_cpu_times",
+        "io_counters": "get_io_counters",
+        "ionice": "get_ionice",
+        "memory_info": "get_memory_info",
+        "memory_info_ex": "get_ext_memory_info",
+        "memory_maps": "get_memory_maps",
+        "memory_percent": "get_memory_percent",
+        "nice": "get_nice",
+        "num_ctx_switches": "get_num_ctx_switches",
+        "num_fds": "get_num_fds",
+        "num_threads": "get_num_threads",
+        "open_files": "get_open_files",
+        "rlimit": "get_rlimit",
+        "threads": "get_threads",
+        "cwd": "getcwd",
+
+        "cpu_affinity": "set_cpu_affinity",
+        "ionice": "set_ionice",
+        "nice": "set_nice",
+        "rlimit": "set_rlimit",
+    }
+
+    for new, old in _PROCESS_FUNCTION_MAP.iteritems():
+        try:
+            setattr(Process, new, psutil.Process.__dict__[old])
+        except KeyError:
+            pass
+

--- a/salt/utils/psutil_compat.py
+++ b/salt/utils/psutil_compat.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 '''
-Version agnostic psutil hack to fully support both old (<2.0) and new (>=2.0) psutil versions.
+Version agnostic psutil hack to fully support both old (<2.0) and new (>=2.0)
+psutil versions.
+
 The old <1.0 psutil API is dropped in psutil 3.0
 
 Should be removed once support for psutil <2.0 is dropped. (eg RHEL 6)
@@ -37,32 +39,50 @@ else:
     pids = psutil.get_pid_list
     users = psutil.get_users
 
+    class Process(psutil.Process):
+        # Reimplement overloaded getters/setters
+        def cpu_affinity(self, *args, **kwargs):
+            if args or kwargs:
+                return self.set_cpu_affinity(*args, **kwargs)
+            else:
+                return self.get_cpu_affinity()
+
+        def ionice(self, *args, **kwargs):
+            if args or kwargs:
+                return self.set_ionice(*args, **kwargs)
+            else:
+                return self.get_ionice()
+
+        def nice(self, *args, **kwargs):
+            if args or kwargs:
+                return self.set_nice(*args, **kwargs)
+            else:
+                return self.get_nice()
+
+        def rlimit(self, *args, **kwargs):
+            if args or kwargs:
+                return self.set_rlimit(*args, **kwargs)
+            else:
+                return self.get_rlimit()
+
     # Alias renamed Process functions
     _PROCESS_FUNCTION_MAP = {
         "children": "get_children",
         "connections": "get_connections",
-        "cpu_affinity": "get_cpu_affinity",
         "cpu_percent": "get_cpu_percent",
         "cpu_times": "get_cpu_times",
         "io_counters": "get_io_counters",
-        "ionice": "get_ionice",
         "memory_info": "get_memory_info",
         "memory_info_ex": "get_ext_memory_info",
         "memory_maps": "get_memory_maps",
         "memory_percent": "get_memory_percent",
-        "nice": "get_nice",
         "num_ctx_switches": "get_num_ctx_switches",
         "num_fds": "get_num_fds",
         "num_threads": "get_num_threads",
         "open_files": "get_open_files",
-        "rlimit": "get_rlimit",
         "threads": "get_threads",
         "cwd": "getcwd",
 
-        "cpu_affinity": "set_cpu_affinity",
-        "ionice": "set_ionice",
-        "nice": "set_nice",
-        "rlimit": "set_rlimit",
     }
 
     for new, old in _PROCESS_FUNCTION_MAP.iteritems():

--- a/tests/unit/modules/ps_test.py
+++ b/tests/unit/modules/ps_test.py
@@ -16,7 +16,7 @@ HAS_PSUTIL = ps.__virtual__()
 HAS_PSUTIL_VERSION = False
 
 if HAS_PSUTIL:
-    import psutil
+    import salt.utils.psutil_compat as psutil
     from collections import namedtuple
 
     PSUTIL2 = psutil.version_info >= (2, 0)


### PR DESCRIPTION
psutil 3.0 drops 1.0 API, which breaks salt. However we still support old psutil versions (eg RHEL6)
This creates a temporary compatibility layer between the two versions until support for <2.0 is dropped.
