### PR TITLE
Fix Issue #11727: Got a bad pillar from master

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -978,7 +978,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                 ),
                 exc_info=True
             )
-            return mod
+            return False
         except Exception as error:
             log.error(
                 'Failed to import {0} {1}, this is due most likely to a '
@@ -987,7 +987,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                 ),
                 exc_info=True
             )
-            return mod
+            return False
         except SystemExit:
             log.error(
                 'Failed to import {0} {1} as the module called exit()\n'.format(
@@ -995,7 +995,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                 ),
                 exc_info=True
             )
-            return mod
+            return False
         finally:
             sys.path.pop()
 
@@ -1011,6 +1011,8 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         for p_name, p_value in six.iteritems(self.pack):
             setattr(mod, p_name, p_value)
 
+        module_name = mod.__name__.rsplit('.', 1)[-1]
+
         # Call a module's initialization method if it exists
         module_init = getattr(mod, '__init__', None)
         if inspect.isfunction(module_init):
@@ -1018,7 +1020,17 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                 module_init(self.opts)
             except TypeError as e:
                 log.error(e)
-        module_name = mod.__name__.rsplit('.', 1)[-1]
+            except Exception:
+                err_string = '__init__ failed'
+                log.debug(
+                    'Error loading {0}.{1}: {2}'.format(
+                        self.tag,
+                        module_name,
+                        err_string),
+                    exc_info=True)
+                self.missing_modules[module_name] = err_string
+                self.missing_modules[name] = err_string
+                return False
 
         # if virtual modules are enabled, we need to look for the
         # __virtual__() function inside that module and run it.


### PR DESCRIPTION
I was able to reproduce this issue consistently in my environment.

The minion would receive an empty string '' as pillar data instead of
the expected pillar data. The reason for this is that in
salt/master.py: _pillar()
it would invoke:
for func in six.itervalues(self.mminion.functions):

Which would cause a _load_all() in salt/loader.py

This would eventually cause an exception when loading:
salt/modules/boto_vpc.py (at line 113):
**utils**['boto.assign_funcs'](__name__,)

With: KeyError('boto.assign_funcs',)
Which probably means that 'boto.assign_funcs' isn't in **utils** at the
time of invocation.

However, this commit will not fix the problem in boto_vpc.py. I will
leave this up to a domain expert.

The focus of this commit is to make the loader capable of cleanly
handling errors while invoking '**init**' in loaded modules.

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
