### PR TITLE
TCP keepalives on the ret side, Revisited.

### DIFF
--- a/salt/transport/__init__.py
+++ b/salt/transport/__init__.py
@@ -217,7 +217,7 @@ class ZeroMQChannel(Channel):
                         log.debug('Removed obsolete sreq-object from '
                                   'sreq_cache for master {0}'.format(check_key[0]))
 
-            ZeroMQChannel.sreq_cache[key] = salt.payload.SREQ(self.master_uri)
+            ZeroMQChannel.sreq_cache[key] = salt.payload.SREQ(self.master_uri, opts=self.opts)
 
         return ZeroMQChannel.sreq_cache[key]
 


### PR DESCRIPTION
The fixes by cachedout (https://github.com/cachedout/salt/commit/56ca41cc8e988ca5f094254eb2e6326494600920) which were backported into 2015.2 (https://github.com/saltstack/salt/pull/21465) were also merged into 2014.7 but missing a single parameter (salt.payload.SREQ didn't get self.opts) thus still not setting up the TCP keepalive for the ZeroMQ Channel by default.

Without this minions whom's TCP connection to the master had died but hadn't noticed yet would still hang when doing a pillar_refesh() for example.
