### PR TITLE
[2014.7] Allow salt-ssh minion config overrides via master config and roster

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -259,6 +259,17 @@
 # will cause minion to throw an exception and drop the message.
 # sign_pub_messages: False
 
+#####     Salt-SSH Configuration     #####
+##########################################
+
+# Pass in an alternative location for the salt-ssh roster file
+#roster_file: /etc/salt/roster
+
+# Pass in minion option overrides that will be inserted into the SHIM for
+# salt-ssh calls. The local minion config is not used for salt-ssh. Can be
+# overridden on a per-minion basis in the roster (`minion_opts`)
+#ssh_minion_opts:
+#  gpg_keydir: /root/gpg
 
 #####    Master Module Management    #####
 ##########################################

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -430,8 +430,8 @@ that connect to a master via localhost.
     presence_events: False
 
 
-Salt-SSH Settings
-=================
+Salt-SSH Configuration
+======================
 
 .. conf_master:: roster_file
 
@@ -454,7 +454,8 @@ Pass in an alternative location for the salt-ssh roster file
 Default: None
 
 Pass in minion option overrides that will be inserted into the SHIM for
-salt-ssh calls. The local minion config is not used for salt-ssh.
+salt-ssh calls. The local minion config is not used for salt-ssh. Can be
+overridden on a per-minion basis in the roster (``minion_opts``)
 
 .. code-block:: yaml
 

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -429,6 +429,10 @@ that connect to a master via localhost.
 
     presence_events: False
 
+
+Salt-SSH Settings
+=================
+
 .. conf_master:: roster_file
 
 ``roster_file``
@@ -441,6 +445,22 @@ Pass in an alternative location for the salt-ssh roster file
 .. code-block:: yaml
 
     roster_file: /root/roster
+
+.. conf_master:: ssh_minion_opts
+
+``ssh_minion_opts``
+-------------------
+
+Default: None
+
+Pass in minion option overrides that will be inserted into the SHIM for
+salt-ssh calls. The local minion config is not used for salt-ssh.
+
+.. code-block:: yaml
+
+    minion_opts:
+      gpg_keydir: /root/gpg
+
 
 Master Security Settings
 ========================

--- a/doc/topics/ssh/index.rst
+++ b/doc/topics/ssh/index.rst
@@ -126,6 +126,13 @@ file is in ``/etc/salt/master``. If one wishes to use a customized configuration
 the ``-c`` option to Salt SSH facilitates passing in a directory to look inside for a 
 configuration file named ``master``.
 
+Minion Config
+---------------
+
+Minion config options can be defined globally using the master configuration
+option ``ssh_minion_opts``. It can also be defined on a per-minion basis with
+the ``minion_opts`` entry in the roster.
+
 Running Salt SSH as non-root user
 =================================
 

--- a/doc/topics/ssh/index.rst
+++ b/doc/topics/ssh/index.rst
@@ -129,6 +129,8 @@ configuration file named ``master``.
 Minion Config
 ---------------
 
+.. versionadded:: 2015.2.1
+
 Minion config options can be defined globally using the master configuration
 option ``ssh_minion_opts``. It can also be defined on a per-minion basis with
 the ``minion_opts`` entry in the roster.

--- a/doc/topics/ssh/roster.rst
+++ b/doc/topics/ssh/roster.rst
@@ -34,13 +34,14 @@ The information which can be stored in a roster `target` is the following:
 
 .. code-block:: yaml
 
-    <Salt ID>:   # The id to reference the target system with
-        host:    # The IP address or DNS name of the remote host
-        user:    # The user to log in as
-        passwd:  # The password to log in with
+    <Salt ID>:       # The id to reference the target system with
+        host:        # The IP address or DNS name of the remote host
+        user:        # The user to log in as
+        passwd:      # The password to log in with
 
         # Optional parameters
-        port:    # The target system's ssh port number
-        sudo:    # Boolean to run command via sudo
-        priv:    # File path to ssh private key, defaults to salt-ssh.rsa
-        timeout: # Number of seconds to wait for response
+        port:        # The target system's ssh port number
+        sudo:        # Boolean to run command via sudo
+        priv:        # File path to ssh private key, defaults to salt-ssh.rsa
+        timeout:     # Number of seconds to wait for response
+        minion_opts: # Dictionary of minion opts

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -570,7 +570,7 @@ class Single(object):
                     'id': self.id,
                     'sock_dir': '/',
                 })
-        self.minion_config = yaml.dump(minion_opts).strip()
+        self.minion_config = yaml.dump(minion_opts)
         self.target = kwargs
         self.target.update(args)
         self.serial = salt.payload.Serial(opts)

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -519,6 +519,7 @@ class Single(object):
             mods=None,
             fsclient=None,
             thin=None,
+            minion_opts=None,
             **kwargs):
         self.opts = opts
         self.tty = tty
@@ -561,13 +562,15 @@ class Single(object):
                 'sudo': sudo,
                 'tty': tty,
                 'mods': self.mods}
-        minion_opts = opts.get('ssh_minion_opts', {})
-        minion_opts.update({
+        self.minion_opts = opts.get('ssh_minion_opts', {})
+        if minion_opts is not None:
+            self.minion_opts.update(minion_opts)
+        self.minion_opts.update({
                     'root_dir': os.path.join(self.thin_dir, 'running_data'),
                     'id': self.id,
                     'sock_dir': '/',
                 })
-        self.minion_config = yaml.dump(minion_opts)
+        self.minion_config = yaml.dump(self.minion_opts)
         self.target = kwargs
         self.target.update(args)
         self.serial = salt.payload.Serial(opts)

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -570,7 +570,7 @@ class Single(object):
                     'id': self.id,
                     'sock_dir': '/',
                 })
-        self.minion_config = yaml.dump(minion_opts, width=1000).strip()
+        self.minion_config = yaml.dump(minion_opts).strip()
         self.target = kwargs
         self.target.update(args)
         self.serial = salt.payload.Serial(opts)
@@ -771,7 +771,10 @@ class Single(object):
             debug = '1'
         arg_str = '''
 OPTIONS = OBJ()
-OPTIONS.config = '{0}'
+OPTIONS.config = \
+"""
+{0}
+"""
 OPTIONS.delimiter = '{1}'
 OPTIONS.saltdir = '{2}'
 OPTIONS.checksum = '{3}'

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -561,12 +561,16 @@ class Single(object):
                 'sudo': sudo,
                 'tty': tty,
                 'mods': self.mods}
-        self.minion_config = yaml.dump(
-                {
+        minion_config_file = os.path.join(opts.get('config_dir', '/etc/salt'),
+                                          'minion')
+        minion_opts = salt.config.load_config(minion_config_file,
+                                              'SALT_MINION_CONFIG')
+        minion_opts.update({
                     'root_dir': os.path.join(self.thin_dir, 'running_data'),
                     'id': self.id,
                     'sock_dir': '/',
-                }, width=1000).strip()
+                })
+        self.minion_config = yaml.dump(minion_opts, width=1000).strip()
         self.target = kwargs
         self.target.update(args)
         self.serial = salt.payload.Serial(opts)

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -561,10 +561,7 @@ class Single(object):
                 'sudo': sudo,
                 'tty': tty,
                 'mods': self.mods}
-        minion_config_file = os.path.join(opts.get('config_dir', '/etc/salt'),
-                                          'minion')
-        minion_opts = salt.config.load_config(minion_config_file,
-                                              'SALT_MINION_CONFIG')
+        minion_opts = opts.get('ssh_minion_opts', {})
         minion_opts.update({
                     'root_dir': os.path.join(self.thin_dir, 'running_data'),
                     'id': self.id,

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -683,6 +683,7 @@ class Single(object):
                 self.opts,
                 self.id,
                 fsclient=self.fsclient,
+                minion_opts=self.minion_opts,
                 **self.target)
             opts_pkg = pre_wrapper['test.opts_pkg']()
             opts_pkg['file_roots'] = self.opts['file_roots']
@@ -739,6 +740,7 @@ class Single(object):
             opts,
             self.id,
             fsclient=self.fsclient,
+            minion_opts=self.minion_opts,
             **self.target)
         self.wfuncs = salt.loader.ssh_wrapper(opts, wrapper, self.context)
         wrapper.wfuncs = self.wfuncs

--- a/salt/client/ssh/wrapper/__init__.py
+++ b/salt/client/ssh/wrapper/__init__.py
@@ -86,7 +86,7 @@ class FunctionWrapper(object):
                     mods=self.mods,
                     wipe=True,
                     fsclient=self.fsclient,
-                    minion_opts = self.minion_opts
+                    minion_opts = self.minion_opts,
                     **self.kwargs
             )
             stdout, stderr, _ = single.cmd_block()

--- a/salt/client/ssh/wrapper/__init__.py
+++ b/salt/client/ssh/wrapper/__init__.py
@@ -86,7 +86,7 @@ class FunctionWrapper(object):
                     mods=self.mods,
                     wipe=True,
                     fsclient=self.fsclient,
-                    minion_opts = self.minion_opts,
+                    minion_opts=self.minion_opts,
                     **self.kwargs
             )
             stdout, stderr, _ = single.cmd_block()

--- a/salt/client/ssh/wrapper/__init__.py
+++ b/salt/client/ssh/wrapper/__init__.py
@@ -29,6 +29,7 @@ class FunctionWrapper(object):
             mods=None,
             fsclient=None,
             cmd_prefix=None,
+            minion_opts=None,
             **kwargs):
         super(FunctionWrapper, self).__init__()
         self.cmd_prefix = cmd_prefix
@@ -39,6 +40,7 @@ class FunctionWrapper(object):
                        'host': host}
         self.fsclient = fsclient
         self.kwargs.update(kwargs)
+        self.minion_opts = minion_opts
 
     def __getitem__(self, cmd):
         '''
@@ -59,6 +61,7 @@ class FunctionWrapper(object):
                                    mods=self.mods,
                                    fsclient=self.fsclient,
                                    cmd_prefix=cmd,
+                                   minion_opts=self.minion_opts
                                    **kwargs)
 
         if self.cmd_prefix:
@@ -83,6 +86,7 @@ class FunctionWrapper(object):
                     mods=self.mods,
                     wipe=True,
                     fsclient=self.fsclient,
+                    minion_opts = self.minion_opts
                     **self.kwargs
             )
             stdout, stderr, _ = single.cmd_block()

--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -135,10 +135,9 @@ def render(gpg_data, saltenv='base', sls='', argline='', **kwargs):
     '''
     if not HAS_GPG:
         raise SaltRenderError('GPG unavailable')
-    homedir = None
     if 'config.get' in __salt__:
-        homedir = __salt__['config.get']('gpg_keydir', None)
-    if homedir is None:
+        homedir = __salt__['config.get']('gpg_keydir', DEFAULT_GPG_KEYDIR)
+    else:
         homedir = __opts__.get('gpg_keydir', DEFAULT_GPG_KEYDIR)
     log.debug('Reading GPG keys from: {0}'.format(homedir))
     try:


### PR DESCRIPTION
There was no way to override minion config options previously, now there are two methods:

1) Set `ssh_minion_opts` in the master config (should be formed as a dictionary)
2) Set `minion_opts` in the roster for a given target (again, formed as a dictionary)

2 overrides 1.

Also reverts #23188, don't need the workaround anymore.

Refs #19114 
