### PR TITLE
[2014.7] Reduce salt-ssh debug log verbosity

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -850,8 +850,8 @@ ARGS = {9}\n'''.format(self.minion_config,
         cmd_str = self._cmd_str()
         stdout, stderr, retcode = self.shim_cmd(cmd_str)
 
-        log.debug('STDOUT {1}\n{0}'.format(stdout, self.target['host']))
-        log.debug('STDERR {1}\n{0}'.format(stderr, self.target['host']))
+        log.trace('STDOUT {1}\n{0}'.format(stdout, self.target['host']))
+        log.trace('STDERR {1}\n{0}'.format(stderr, self.target['host']))
         log.debug('RETCODE {1}: {0}'.format(retcode, self.target['host']))
 
         error = self.categorize_shim_errors(stdout, stderr, retcode)

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -317,7 +317,9 @@ class Shell(object):
                 cmd,
                 shell=True,
                 log_stdout=True,
+                log_stdout_level='trace',
                 log_stderr=True,
+                log_stderr_level='trace',
                 stream_stdout=False,
                 stream_stderr=False)
         sent_passwd = 0

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -285,7 +285,11 @@ class Shell(object):
         logmsg = 'Executing command: {0}'.format(cmd)
         if self.passwd:
             logmsg = logmsg.replace(self.passwd, ('*' * 6))
-        log.debug(logmsg)
+        if 'decode("base64")' in logmsg:
+            log.debug('Executed SHIM command. Command logged to TRACE')
+            log.trace(logmsg)
+        else:
+            log.debug(logmsg)
 
         ret = self._run_cmd(cmd)
         return ret

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -216,7 +216,12 @@ class Terminal(object):
             'Child Forked! PID: {0}  STDOUT_FD: {1}  STDERR_FD: '
             '{2}'.format(self.pid, self.child_fd, self.child_fde)
         )
-        log.debug('Terminal Command: {0}'.format(' '.join(self.args)))
+        terminal_command = ' '.join(self.args)
+        if 'decode("base64")' in terminal_command:
+            log.debug('VT: Salt-SSH SHIM Terminal Command executed. Logged to TRACE')
+            log.trace('Terminal Command: {0}'.format(terminal_command))
+        else:
+            log.debug('Terminal Command: {0}'.format(terminal_command))
         # <---- Spawn our terminal -------------------------------------------
 
         # ----- Setup Logging ----------------------------------------------->


### PR DESCRIPTION
Anything that involves the SHIM should be logged to TRACE
