### PR TITLE
Add support for tablespaces to postgres module & postgres_tablespace states

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -476,6 +476,7 @@ def tablespace_list(user=None, host=None, port=None, maintenance_db=None,
     CLI Example:
     .. code-block:: bash
         salt '*' postgres.tablespace_list
+    .. versionadded:: Beryllium
     '''
 
     ret = {}
@@ -505,6 +506,7 @@ def tablespace_exists(name, user=None, host=None, port=None, maintenance_db=None
     CLI Example:
     .. code-block:: bash
         salt '*' postgres.tablespace_exists 'dbname'
+    .. versionadded:: Beryllium
     '''
 
     tablespaces = tablespace_list(user=user, host=host, port=port,
@@ -524,6 +526,7 @@ def tablespace_create(name, location, options=None, owner=None, user=None,
     .. code-block:: bash
 
         salt '*' postgres.tablespace_create tablespacename '/path/datadir'
+    .. versionadded:: Beryllium
     '''
     owner_query = ''
     options_query = ''
@@ -558,6 +561,7 @@ def tablespace_alter(name, user=None, host=None, port=None, maintenance_db=None,
         salt '*' postgres.tablespace_alter index_space new_name=fast_raid
         salt '*' postgres.tablespace_alter test set_option="{'seq_page_cost': '1.1'}"
         salt '*' postgres.tablespace_alter tsname reset_option=seq_page_cost
+    .. versionadded:: Beryllium
     '''
     if not any([new_name, new_owner, set_option, reset_option]):
         return True  # Nothing todo?
@@ -595,6 +599,7 @@ def tablespace_remove(name, user=None, host=None, port=None,
     CLI Example:
     .. code-block:: bash
         salt '*' postgres.tablespace_remove tsname
+    .. versionadded:: Beryllium
     '''
     query = 'DROP TABLESPACE {0}'.format(name)
     ret = _psql_prepare_and_run(['-c', query],

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -528,13 +528,13 @@ def tablespace_create(name, location, options=None, owner=None, user=None,
     owner_query = ''
     options_query = ''
     if owner:
-        owner_query = 'OWNER {}'.format(owner)
+        owner_query = 'OWNER {0}'.format(owner)
         # should come out looking like: 'OWNER postgres'
     if options:
-        optionstext = ['{} = {}'.format(k, v) for k, v in options.items()]
-        options_query = 'WITH ( {} )'.format(', '.join(optionstext))
+        optionstext = ['{0} = {1}'.format(k, v) for k, v in options.items()]
+        options_query = 'WITH ( {0} )'.format(', '.join(optionstext))
         # should come out looking like: 'WITH ( opt1 = 1.0, opt2 = 4.0 )'
-    query = 'CREATE TABLESPACE {} {} LOCATION \'{}\' {}'.format(name,
+    query = 'CREATE TABLESPACE {0} {1} LOCATION \'{2}\' {3}'.format(name,
                                                                 owner_query,
                                                                 location,
                                                                 options_query)
@@ -565,16 +565,16 @@ def tablespace_alter(name, user=None, host=None, port=None, maintenance_db=None,
     queries = []
 
     if new_name:
-        queries.append('ALTER TABLESPACE {} RENAME TO {}'.format(
+        queries.append('ALTER TABLESPACE {0} RENAME TO {1}'.format(
                        name, new_name))
     if new_owner:
-        queries.append('ALTER TABLESPACE {} OWNER TO {}'.format(
+        queries.append('ALTER TABLESPACE {0} OWNER TO {1}'.format(
                        name, new_owner))
     if set_option:
-        queries.append('ALTER TABLESPACE {} SET ({} = {})'.format(
+        queries.append('ALTER TABLESPACE {0} SET ({1} = {2})'.format(
                        name, set_option.keys()[0], set_option.values()[0]))
     if reset_option:
-        queries.append('ALTER TABLESPACE {} RESET ({})'.format(
+        queries.append('ALTER TABLESPACE {0} RESET ({1})'.format(
                        name, reset_option))
 
     for query in queries:
@@ -596,7 +596,7 @@ def tablespace_remove(name, user=None, host=None, port=None,
     .. code-block:: bash
         salt '*' postgres.tablespace_remove tsname
     '''
-    query = 'DROP TABLESPACE {}'.format(name)
+    query = 'DROP TABLESPACE {0}'.format(name)
     ret = _psql_prepare_and_run(['-c', query],
                                 user=user,
                                 host=host,

--- a/salt/states/postgres_tablespace.py
+++ b/salt/states/postgres_tablespace.py
@@ -9,7 +9,8 @@ Tablespaces can be set as either absent or present.
     ssd-tablespace:
       postgres_tablespace.present:
         - name: indexes
-        - path:
+        - directory: /mnt/ssd-data
+.. versionadded:: Beryllium
 '''
 from __future__ import absolute_import
 

--- a/salt/states/postgres_tablespace.py
+++ b/salt/states/postgres_tablespace.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 '''
 Management of PostgreSQL tablespace
 ==================================
@@ -18,6 +19,7 @@ def __virtual__():
     Only load if the postgres module is present and is new enough (has ts funcs)
     '''
     return 'postgres.tablespace_exists' in __salt__
+
 
 def present(name,
             directory,
@@ -106,7 +108,7 @@ def present(name,
         # {seq_page_cost=1.1,random_page_cost=3.9}
         # TODO remove options that exist if possible
         for k, v in options:
-            if '{}={}'.format(k, v) not in tblspaces[name]['Opts']:
+            if '{0}={1}'.format(k, v) not in tblspaces[name]['Opts']:
                 # if 'seq_page_cost=1.1' not in '{seq_page_cost=1.1,...}'
                 if __opts__['test']:
                     ret['result'] = None

--- a/salt/states/postgres_tablespace.py
+++ b/salt/states/postgres_tablespace.py
@@ -1,0 +1,174 @@
+'''
+Management of PostgreSQL tablespace
+==================================
+The postgres_tablespace module is used to create and manage Postgres
+tablespaces.
+Tablespaces can be set as either absent or present.
+.. code-block:: yaml
+    ssd-tablespace:
+      postgres_tablespace.present:
+        - name: indexes
+        - path:
+'''
+from __future__ import absolute_import
+
+
+def __virtual__():
+    '''
+    Only load if the postgres module is present and is new enough (has ts funcs)
+    '''
+    return 'postgres.tablespace_exists' in __salt__
+
+def present(name,
+            directory,
+            options=None,
+            owner=None,
+            user=None,
+            maintenance_db=None,
+            db_password=None,
+            db_host=None,
+            db_port=None,
+            db_user=None):
+    '''
+    Ensure that the named tablespace is present with the specified properties.
+    For more information about all of these options see man create_tablespace(1)
+    name
+        The name of the tablespace to create/manage.
+    directory
+        The directory where the tablespace will be located, must already exist.
+    options
+        A dictionary of options to specify for the table.
+        Currently, the only tablespace options supported are
+        seq_page_cost - float; default=1.0
+        random_page_cost - float; default=4.0
+    owner
+        The database user that will be the owner of the tablespace
+        Defaults to the user executing the command (i.e. the `user` option)
+    db_user
+        database username if different from config or default
+    db_password
+        user password if any password for a specified user
+    db_host
+        Database host if different from config or default
+    db_port
+        Database port if different from config or default
+    user
+        System user all operations should be performed on behalf of
+
+        .. versionadded:: Beryllium
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': 'Tablespace {0} is already present'.format(name)}
+    dbargs = {
+        'maintenance_db': maintenance_db,
+        'runas': user,
+        'host': db_host,
+        'user': db_user,
+        'port': db_port,
+        'password': db_password,
+    }
+    tblspaces = __salt__['postgres.tablespace_list'](**dbargs)
+    if name not in tblspaces:
+        # not there, create it
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'Tablespace {0} is set to be created'.format(name)
+            return ret
+        if __salt__['postgres.tablespace_create'](name, directory, options,
+                                                  owner, **dbargs):
+            ret['comment'] = 'The tablespace {0} has been created'.format(name)
+            ret['changes'][name] = 'Present'
+            return ret
+
+    # already exists, make sure it's got the right config
+    if tblspaces[name]['Location'] != directory and not __opts__['test']:
+        ret['comment'] = """Tablespace {0} is not at the right location. This is
+            unfixable without dropping and recreating the tablespace.""".format(
+                name)
+        ret['result'] = False
+        return ret
+
+    if owner and not tblspaces[name]['Owner'] == owner:
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'Tablespace {0} owner to be altered'.format(name)
+        if (__salt__['postgres.tablespace_alter'](name, new_owner=owner)
+            and not __opts__['test']):
+            ret['comment'] = 'Tablespace {0} owner changed'.format(name)
+            ret['result'] = True
+
+    if options:
+        # options comes from postgres as a sort of json(ish) string, but it
+        # can't really be parsed out, but it's in a fairly consistent format
+        # that we should be able to string check:
+        # {seq_page_cost=1.1,random_page_cost=3.9}
+        # TODO remove options that exist if possible
+        for k, v in options:
+            if '{}={}'.format(k, v) not in tblspaces[name]['Opts']:
+                # if 'seq_page_cost=1.1' not in '{seq_page_cost=1.1,...}'
+                if __opts__['test']:
+                    ret['result'] = None
+                    ret['comment'] = """Tablespace {0} options to be
+                        altered""".format(name)
+                    break  # we know it's going to be altered, no reason to cont
+                if __salt__['postgres.tablespace_alter'](name,
+                                                         set_options={k: v}):
+                    ret['comment'] = 'Tablespace {0} opts changed'.format(name)
+                    ret['result'] = True
+
+    return ret
+
+
+def absent(name,
+           user=None,
+           maintenance_db=None,
+           db_password=None,
+           db_host=None,
+           db_port=None,
+           db_user=None):
+    '''
+    Ensure that the named database is absent
+    name
+        The name of the database to remove
+    db_user
+        database username if different from config or defaul
+    db_password
+        user password if any password for a specified user
+    db_host
+        Database host if different from config or default
+    db_port
+        Database port if different from config or default
+    user
+        System user all operations should be performed on behalf of
+        .. versionadded:: Beryllium
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    db_args = {
+        'maintenance_db': maintenance_db,
+        'runas': user,
+        'host': db_host,
+        'user': db_user,
+        'port': db_port,
+        'password': db_password,
+    }
+    #check if tablespace exists and remove it
+    if __salt__['postgres.tablespace_exists'](name, **db_args):
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'Tablespace {0} is set to be removed'.format(name)
+            return ret
+        if __salt__['postgres.tablespace_remove'](name, **db_args):
+            ret['comment'] = 'Tablespace {0} has been removed'.format(name)
+            ret['changes'][name] = 'Absent'
+            return ret
+
+    # fallback
+    ret['comment'] = 'Tablespace {0} is not present, so it cannot ' \
+                     'be removed'.format(name)
+    return ret


### PR DESCRIPTION
I look forward to any feedback anyone would like to give me since this is my 
first SaltStack submission.

Add tablespace_\* functions to postgres module. Mostly the same kind of
functionality that exists for database managment.

Also add postgres_tablespace states that use the new module support.

This should bring tablespace support in SaltStack inline with Postgresql user
and database support.
