### PR TITLE
Fix st_ctime in local_cache returner update

### DIFF
--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -305,7 +305,7 @@ def clean_old_jobs():
                     # No jid file means corrupted cache entry, scrub it
                     shutil.rmtree(f_path)
                 else:
-                    jid_ctime = os.stat(jid_file).st_ctime()
+                    jid_ctime = os.stat(jid_file).st_ctime
                     hours_difference = (cur - jid_ctime) / 3600.0
                     if hours_difference > __opts__['keep_jobs']:
                         shutil.rmtree(f_path)


### PR DESCRIPTION
I made a typo in https://github.com/saltstack/salt/pull/23273 ... st_ctime is an attribute of the object returned by os.stat(), not a method.  Oops!
