### PR TITLE
Don't merge: Add missing jump arguments to iptables module

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -105,9 +105,8 @@ def version(family='ipv4'):
 def build_rule(table='filter', chain=None, command=None, position='', full=None, family='ipv4',
                **kwargs):
     '''
-    Build a well-formatted iptables rule based on kwargs. Long options must be
-    used (`--jump` instead of `-j`) because they will have the `--` added to
-    them. A `table` and `chain` are not required, unless `full` is True.
+    Build a well-formatted iptables rule based on kwargs. A `table` and `chain`
+    are not required, unless `full` is True.
 
     If `full` is `True`, then `table`, `chain` and `command` are required.
     `command` may be specified as either a short option ('I') or a long option
@@ -118,6 +117,9 @@ def build_rule(table='filter', chain=None, command=None, position='', full=None,
     `position`. This will only be useful if `full` is True.
 
     If `connstate` is passed in, it will automatically be changed to `state`.
+
+    To pass in jump options that doesn't take arguments, pass in an empty
+    string.
 
     CLI Examples:
 
@@ -266,21 +268,53 @@ def build_rule(table='filter', chain=None, command=None, position='', full=None,
     # Jumps should appear last, except for any arguments that are passed to
     # jumps, which of course need to follow.
     after_jump = []
+    # List of options fetched from http://www.iptables.info/en/iptables-targets-and-jumps.html
     after_jump_arguments = (
+        'j',  # j and jump needs to be first
         'jump',
-        'j',
-        'to-port',
-        'to-ports',
-        'to-destination',
-        'to-source',
+        'clamp-mss-to-pmtu',
+        'ecn-tcp-remove',  # no arg
+        'mask',  # only used with either save-mark or restore-mark
+        'nodst',
+        'queue-num',
         'reject-with',
-        'set-mark',
-        'set-xmark',
-        'log-level',
+        'restore',  # no arg
+        'restore-mark',  # no arg
+        #'save',  # no arg, problematic name: How do we avoid collision with this?
+        'save-mark',  # no arg
+        'selctx',
+        'set-dscp',
+        'set-dscp-class',
+        'set-mss',
+        'set-tos',
+        'ttl-dec',
+        'ttl-inc',
+        'ttl-set',
+        'ulog-cprange',
+        'ulog-nlgroup',
+        'ulog-prefix',
+        'ulog-qthreshold',
+        'clustermac',
+        'hash-init,'
+        'hashmode',
+        'local-node',
         'log-ip-options',
+        'log-level',
         'log-prefix',
         'log-tcp-options',
         'log-tcp-sequence',
+        'new',  # no arg
+        'reject-with',
+        'set-class',
+        'set-mark',
+        'set-xmark',
+        'to',
+        'to-destination',
+        'to-port',
+        'to-ports',
+        'to-source',
+        'total-nodes,'
+        'total-nodes',
     )
     for after_jump_argument in after_jump_arguments:
         if after_jump_argument in kwargs:

--- a/salt/states/iptables.py
+++ b/salt/states/iptables.py
@@ -330,6 +330,9 @@ def append(name, table='filter', family='ipv4', **kwargs):
     that would normally be used for iptables, with one exception: ``--state`` is
     specified as `connstate` instead of `state` (not to be confused with
     `ctstate`).
+
+    Jump options that doesn't take arguments should be passed in with an empty
+    string.
     '''
     ret = {'name': name,
            'changes': {},
@@ -454,6 +457,9 @@ def insert(name, table='filter', family='ipv4', **kwargs):
     that would normally be used for iptables, with one exception: ``--state`` is
     specified as `connstate` instead of `state` (not to be confused with
     `ctstate`).
+
+    Jump options that doesn't take arguments should be passed in with an empty
+    string.
     '''
     ret = {'name': name,
            'changes': {},
@@ -574,6 +580,9 @@ def delete(name, table='filter', family='ipv4', **kwargs):
     that would normally be used for iptables, with one exception: ``--state`` is
     specified as `connstate` instead of `state` (not to be confused with
     `ctstate`).
+
+    Jump options that doesn't take arguments should be passed in with an empty
+    string.
     '''
     ret = {'name': name,
            'changes': {},

--- a/tests/unit/modules/iptables_test.py
+++ b/tests/unit/modules/iptables_test.py
@@ -125,6 +125,16 @@ class IptablesTestCase(TestCase):
                                              **{'log-prefix': 'spam: '}),
                          '--jump LOG --log-prefix "spam: "')
 
+        # Should allow no-arg jump options
+        self.assertEqual(iptables.build_rule(jump='CLUSTERIP',
+                                             **{'new': ''}),
+                         '--jump CLUSTERIP --new ')
+
+        # Should allow the --save jump option to CONNSECMARK
+        #self.assertEqual(iptables.build_rule(jump='CONNSECMARK',
+        #                                     **{'save': ''}),
+        #                 '--jump CONNSECMARK --save ')
+
         ret = '/sbin/iptables --wait -t salt -I INPUT 3 -m state --jump ACCEPT'
         with patch.object(iptables, '_iptables_cmd',
                           MagicMock(return_value='/sbin/iptables')):


### PR DESCRIPTION
I think these are all the arguments supported.

Points to discuss:
- Probably no rush since no one seems to have complained yet, but some of these options doesn't take any arguments, like most other iptables options do, which I don't think we have documented or implemented support for. How should we handle this?
  `- save-mark: ~` (if we want to have only dicts in the kwargs)
  `- save-mark: ''` (Same as above, but empty string instead of null. Will not require any changes)
  `- save-mark` (clean, mixes strings and dicts in the kwargs)
  I'm not sure if I've seen any of these somewhere else in the codebase, is there some precedent for doing this?
- The `--save` option crashes with our defined `--save` option. Also probably
  no rush since no one's complained so far, but this should be fixed.
  Maybe we can rename this one to connsecmark-save, since it only appears
  as an option to the CONNSECMARK jump target? Maybe also rename restore
  to connsecmark-restore too, for consistency, even though restore
  doesn't collide with anything?
