### PR TITLE
Egress rule support for boto_secgroup

### DIFF
--- a/salt/modules/boto_secgroup.py
+++ b/salt/modules/boto_secgroup.py
@@ -166,40 +166,42 @@ def _get_group(conn, name=None, vpc_id=None, group_id=None, region=None):  # pyl
     else:
         return None
 
+
 def _parse_rules(sg, rules):
     _rules = []
     for rule in rules:
-            log.debug('examining rule {0} for group {1}'.format(rule, sg.id))
-            attrs = ['ip_protocol', 'from_port', 'to_port', 'grants']
-            _rule = odict.OrderedDict()
-            for attr in attrs:
-                val = getattr(rule, attr)
-                if not val:
-                    continue
-                if attr == 'grants':
-                    _grants = []
-                    for grant in val:
-                        log.debug('examining grant {0} for'.format(grant))
-                        g_attrs = {'name': 'source_group_name',
-                                   'owner_id': 'source_group_owner_id',
-                                   'group_id': 'source_group_group_id',
-                                   'cidr_ip': 'cidr_ip'}
-                        _grant = odict.OrderedDict()
-                        for g_attr, g_attr_map in six.iteritems(g_attrs):
-                            g_val = getattr(grant, g_attr)
-                            if not g_val:
-                                continue
-                            _grant[g_attr_map] = g_val
-                        _grants.append(_grant)
-                    _rule['grants'] = _grants
-                elif attr == 'from_port':
-                    _rule[attr] = int(val)
-                elif attr == 'to_port':
-                    _rule[attr] = int(val)
-                else:
-                    _rule[attr] = val
-            _rules.append(_rule)
+        log.debug('examining rule {0} for group {1}'.format(rule, sg.id))
+        attrs = ['ip_protocol', 'from_port', 'to_port', 'grants']
+        _rule = odict.OrderedDict()
+        for attr in attrs:
+            val = getattr(rule, attr)
+            if not val:
+                continue
+            if attr == 'grants':
+                _grants = []
+                for grant in val:
+                    log.debug('examining grant {0} for'.format(grant))
+                    g_attrs = {'name': 'source_group_name',
+                               'owner_id': 'source_group_owner_id',
+                               'group_id': 'source_group_group_id',
+                               'cidr_ip': 'cidr_ip'}
+                    _grant = odict.OrderedDict()
+                    for g_attr, g_attr_map in six.iteritems(g_attrs):
+                        g_val = getattr(grant, g_attr)
+                        if not g_val:
+                            continue
+                        _grant[g_attr_map] = g_val
+                    _grants.append(_grant)
+                _rule['grants'] = _grants
+            elif attr == 'from_port':
+                _rule[attr] = int(val)
+            elif attr == 'to_port':
+                _rule[attr] = int(val)
+            else:
+                _rule[attr] = val
+        _rules.append(_rule)
     return _rules
+
 
 def get_group_id(name, vpc_id=None, region=None, key=None, keyid=None, profile=None):
     '''

--- a/salt/states/boto_secgroup.py
+++ b/salt/states/boto_secgroup.py
@@ -47,6 +47,17 @@ passed in as a dict, or as a string to pull from pillars or minion config:
                   cidr_ip:
                     - 10.0.0.0/0
                     - 192.168.0.0/0
+                - ip_protocol: icmp
+                  from_port: -1
+                  to_port: -1
+                  source_group_name: mysecgroup
+            - rules_egress:
+                - ip_protocol: all
+                  from_port: -1
+                  to_port: -1
+                  cidr_ip:
+                    - 10.0.0.0/0
+                    - 192.168.0.0/0
             - region: us-east-1
             - keyid: GKTADJGHEIQSXMKKRBJ08H
             - key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
@@ -94,6 +105,7 @@ def present(
         description,
         vpc_id=None,
         rules=None,
+        rules_egress=None,
         region=None,
         key=None,
         keyid=None,
@@ -112,6 +124,9 @@ def present(
 
     rules
         A list of ingress rule dicts.
+
+    rules_egress
+        A list of egress rule dicts.
 
     region
         Region to connect to.
@@ -137,7 +152,7 @@ def present(
             return ret
     if not rules:
         rules = []
-    _ret = _rules_present(name, rules, vpc_id, region, key, keyid, profile)
+    _ret = _rules_present(name, rules, rules_egress, vpc_id, region, key, keyid, profile)
     ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
     if not _ret['result']:

--- a/salt/states/boto_secgroup.py
+++ b/salt/states/boto_secgroup.py
@@ -274,10 +274,13 @@ def _get_rule_changes(rules, _rules):
             raise SaltInvocationError('ip_protocol, to_port, and from_port are'
                                       ' required arguments for security group'
                                       ' rules.')
-        supported_protocols = ['tcp', 'udp', 'icmp', 'all']
+        supported_protocols = ['tcp', 'udp', 'icmp', 'all', '-1']
         if ip_protocol not in supported_protocols:
             msg = ('Invalid ip_protocol {0} specified in security group rule.')
             raise SaltInvocationError(msg.format(ip_protocol))
+        # For the 'all' case, we need to change the protocol name to '-1'.
+        if ip_protocol == 'all':
+            rule['ip_protocol'] = '-1'
         cidr_ip = rule.get('cidr_ip', None)
         group_name = rule.get('source_group_name', None)
         group_id = rule.get('source_group_group_id', None)

--- a/tests/unit/modules/boto_secgroup_test.py
+++ b/tests/unit/modules/boto_secgroup_test.py
@@ -207,7 +207,7 @@ class BotoSecgroupTestCase(TestCase):
         expected_get_config_result = OrderedDict([('name', group.name), ('group_id', group.id), ('owner_id', u'111122223333'),
                                                  ('description', group.description),
                                                  ('rules', [{'to_port': to_port, 'from_port': from_port,
-                                                     'ip_protocol': ip_protocol, 'cidr_ip': cidr_ip}]), 
+                                                  'ip_protocol': ip_protocol, 'cidr_ip': cidr_ip}]),
                                                  ('rules_egress', [])])
         secgroup_get_config_result = boto_secgroup.get_config(group_id=group.id, **conn_parameters)
         self.assertEqual(expected_get_config_result, secgroup_get_config_result)

--- a/tests/unit/modules/boto_secgroup_test.py
+++ b/tests/unit/modules/boto_secgroup_test.py
@@ -207,7 +207,8 @@ class BotoSecgroupTestCase(TestCase):
         expected_get_config_result = OrderedDict([('name', group.name), ('group_id', group.id), ('owner_id', u'111122223333'),
                                                  ('description', group.description),
                                                  ('rules', [{'to_port': to_port, 'from_port': from_port,
-                                                  'ip_protocol': ip_protocol, 'cidr_ip': cidr_ip}])])
+                                                     'ip_protocol': ip_protocol, 'cidr_ip': cidr_ip}]), 
+                                                 ('rules_egress', [])])
         secgroup_get_config_result = boto_secgroup.get_config(group_id=group.id, **conn_parameters)
         self.assertEqual(expected_get_config_result, secgroup_get_config_result)
 


### PR DESCRIPTION
I've written a patch to add a new feature and a minor fix to modules.boto_secgroup and states.boto_secgroup. The changes are:
1. Egress rule support for boto_secgroup, both module and state.  
2. Fixed the 'all' target (boto 2.38 seems to require this to be passed as -1 rather than "all" - see lines 277-283 of the state boto_secgroup).
3. Fixed code documentation where it had "autoscale" rather than "security".
4. Updated documentation example YAML to match.

The tests unit.modules.boto_secgroup_test and unit.states.boto_secgroup pass, as well as creation tests of VPCs.

_Note_: There is a potential gotcha with this patch. Given that egress rules were not previously supported, if somebody has a security group where they use salt to manage the ingress rules, but manually manage the egress rules, on the next run of that state after applying this patch, any manually added egress rules would be removed. This is so that the way that the state handles egress rules is identical to how it handles ingress rules. I'd be very happy to take suggestions for changes here.

Also, the unit test coverage may require some work - it doesn't seem to currently have any tests defined for rules, just for the existence/creation/deletion of a security group.

Cheers!
