### PR TITLE
Fix new container initialization in LXC runner

### DIFF
--- a/salt/runners/lxc.py
+++ b/salt/runners/lxc.py
@@ -251,7 +251,7 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
                 expr_form='list', timeout=600).get(host, {})
         name = kw.pop('name', name)
         # be sure not to seed an alrady seeded host
-        kw['seed'] = seeds[name]
+        kw['seed'] = seeds.get(name, True)
         if not kw['seed']:
             kw.pop('seed_cmd', '')
         cmds.append(


### PR DESCRIPTION
When creating new LXC container with help of salt-cloud lxc.init crashes
with similar message:

```
[INFO    ] Creating container(s) '['test-host']' on host 'lxc-host'
[ERROR   ] Failed to create VM test-host. Configuration value 'test-host' needs to be set
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/cloud/__init__.py", line 1193, in create
    output = self.clouds[func](vm_)
  File "/usr/lib/python2.7/dist-packages/salt/cloud/clouds/lxc.py", line 424, in create
    cret = _runner().cmd('lxc.cloud_init', [vm_['name']], kwarg=kwarg)
  File "/usr/lib/python2.7/dist-packages/salt/runner.py", line 123, in cmd
    return self.functions[fun](*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/runners/lxc.py", line 355, in cloud_init
    saltcloud_mode=True, quiet=quiet, **kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/runners/lxc.py", line 257, in init
    kw['seed'] = seeds[name]
KeyError: 'test-host'
```

The reason is that salt-cloud always passes generated keys to lxc.init,
it skips seeds dictionary population and errors out trying to lookup
non-existent key.

Fix this by using fallback value of True because we always want to seed
minion in such case.
