### PR TITLE
Fix salt-call using RAET on Windows

### DIFF
--- a/salt/transport/raet.py
+++ b/salt/transport/raet.py
@@ -99,7 +99,7 @@ class RAETReqChannel(ReqChannel):
         if kind in [kinds.APPL_KIND_NAMES[kinds.applKinds.master],
                     kinds.APPL_KIND_NAMES[kinds.applKinds.syndic]]:
             lanename = 'master'
-        elif kind == [kinds.APPL_KIND_NAMES[kinds.applKinds.minion],
+        elif kind in [kinds.APPL_KIND_NAMES[kinds.applKinds.minion],
                       kinds.APPL_KIND_NAMES[kinds.applKinds.caller]]:
             lanename = "{0}_{1}".format(role, kind)
         else:
@@ -112,7 +112,7 @@ class RAETReqChannel(ReqChannel):
                           lanename=lanename,
                           sockdirpath=self.opts['sock_dir'])
 
-        stack.Pk = raeting.packKinds.pack
+        stack.Pk = raeting.PackKind.pack
         stack.addRemote(RemoteYard(stack=stack,
                                    name=ryn,
                                    lanename=lanename,


### PR DESCRIPTION
salt/cli/caller.py:
- Avoid picking RAETCaller on Windows. Since no state from RAETCaller
  is needed in the spawned child process, simply moved the child process
  entry function outside of RAETCaller.
- Added Windows specific logic to detect if the lane is set up. We need
  to use win32file.CreateFile for detection since Windows lanes don't use
  regular files.

salt/transport/raet.py:
- Fixed obvious bugs that would cause this functionality to not work in
  any OS.

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
