### PR TITLE
2015.2: include doc in master config for module_dirs

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -74,6 +74,13 @@
 # "states", "returners", etc.
 #extension_modules: <no default>
 
+# Directory for custom modules. This directory can contain subdirectories for
+# each of Salt's module types such as "runners", "output", "wheel", "modules",
+# "states", "returners", etc.
+# Like 'extension_modules' but can take an array of paths
+#module_dirs: <no default>
+#   - /var/cache/salt/minion/extmods
+
 # Verify and set permissions on configuration directories at startup:
 #verify_env: True
 

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -224,6 +224,21 @@ each of Salt's module types such as "runners", "output", "wheel", "modules",
 
     extension_modules: srv/modules
 
+.. conf_minion:: module_dirs
+
+``module_dirs``
+---------------
+
+Default: ``[]``
+
+Like ``extension_modules``, but a list of extra directories to search
+for Salt modules.
+
+.. code-block:: yaml
+
+    module_dirs:
+      - /var/cache/salt/minion/extmods
+
 .. conf_master:: cachedir
 
 ``cachedir``

--- a/salt/cloud/clouds/vsphere.py
+++ b/salt/cloud/clouds/vsphere.py
@@ -7,7 +7,7 @@ vSphere Cloud Module
 
 The vSphere cloud module is used to control access to VMWare vSphere.
 
-:depends:   - PySphere Python module
+:depends:   - PySphere Python module >= 0.1.8
 
 Note: Ensure python pysphere module is installed by running following one-liner
 check. The output should be 0.
@@ -15,6 +15,8 @@ check. The output should be 0.
 .. code-block:: bash
 
    python -c "import pysphere" ; echo $?
+   # if this fails install using
+   pip install https://pysphere.googlecode.com/files/pysphere-0.1.8.zip
 
 Use of this module only requires a URL, username and password. Set up the cloud
 configuration at:


### PR DESCRIPTION
include doc in master config for module_dirs.
the loader checks module_dirs for both master and minion... so why not include it because it allows for a list of dirs where extension_modules only supports one dir.
