### PR TITLE
Allow file_map in salt-cloud to handle folders.

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1189,7 +1189,7 @@ def deploy_script(host,
                     continue
 
                 if os.path.isdir(local_file):
-                    dir_name = os.path.basename(local_file)
+                    dir_name  = os.path.basename(local_file)
                     remote_dir = os.path.join(os.path.dirname(remote_file),
                                               dir_name)
                 else:
@@ -1769,7 +1769,6 @@ def sftp_file(dest_path, contents=None, kwargs=None, local_file=None):
         tmppath = local_file
         if os.path.isdir(local_file):
             put_args = ['-r']
-
 
     log.debug('Uploading {0} to {1} (sfcp)'.format(dest_path, kwargs.get('hostname')))
 

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1189,11 +1189,11 @@ def deploy_script(host,
                     continue
 
                 if os.path.isdir(local_file):
-                    dir_name  = os.path.basename(local_file)
+                    dir_name = os.path.basename(local_file)
                     remote_dir = os.path.join(os.path.dirname(remote_file),
                                               dir_name)
                 else:
-                    remote_dir = s.path.dirname(remote_file)
+                    remote_dir = os.path.dirname(remote_file)
 
                 if remote_dir not in remote_dirs:
                     root_cmd('mkdir -p \'{0}\''.format(remote_dir), tty, sudo, **ssh_kwargs)

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1187,7 +1187,14 @@ def deploy_script(host,
                     )
                     file_map_fail.append({local_file: remote_file})
                     continue
-                remote_dir = os.path.dirname(remote_file)
+
+                if os.path.isdir(local_file):
+                    dir_name = os.path.basename(local_file)
+                    remote_dir = os.path.join(os.path.dirname(remote_file),
+                                              dir_name)
+                else:
+                    remote_dir = s.path.dirname(remote_file)
+
                 if remote_dir not in remote_dirs:
                     root_cmd('mkdir -p \'{0}\''.format(remote_dir), tty, sudo, **ssh_kwargs)
                     remote_dirs.append(remote_dir)
@@ -1748,6 +1755,8 @@ def sftp_file(dest_path, contents=None, kwargs=None, local_file=None):
     '''
     Use sftp to upload a file to a server
     '''
+    put_args = []
+
     if kwargs is None:
         kwargs = {}
 
@@ -1758,6 +1767,9 @@ def sftp_file(dest_path, contents=None, kwargs=None, local_file=None):
 
     if local_file is not None:
         tmppath = local_file
+        if os.path.isdir(local_file):
+            put_args = ['-r']
+
 
     log.debug('Uploading {0} to {1} (sfcp)'.format(dest_path, kwargs.get('hostname')))
 
@@ -1816,8 +1828,8 @@ def sftp_file(dest_path, contents=None, kwargs=None, local_file=None):
             )
         )
 
-    cmd = 'echo "put {0} {1}" | sftp {2} {3[username]}@{3[hostname]}'.format(
-        tmppath, dest_path, ' '.join(ssh_args), kwargs
+    cmd = 'echo "put {0} {1} {2}" | sftp {3} {4[username]}@{4[hostname]}'.format(
+        ' '.join(put_args), tmppath, dest_path, ' '.join(ssh_args), kwargs
     )
     log.debug('SFTP command: {0!r}'.format(cmd))
     retcode = _exec_ssh_cmd(cmd,


### PR DESCRIPTION
Logic has been added to sftp_file and the file_map decoder for salt-cloud allowing you to list folders as well as files in file_map.

The use case was seeding the /srv directory and /etc/salt directory on a salt master that is isolated.
