### PR TITLE
[2014.7] Salt-SSH Backport FunctionWrapper.__contains__

### DIFF
--- a/salt/client/ssh/wrapper/__init__.py
+++ b/salt/client/ssh/wrapper/__init__.py
@@ -40,6 +40,18 @@ class FunctionWrapper(object):
         self.fsclient = fsclient
         self.kwargs.update(kwargs)
 
+    def __contains__(self, key):
+        '''
+        We need to implement a __contains__ method, othwerwise when someone
+        does a contains comparison python assumes this is a sequence, and does
+        __getitem__ keys 0 and up until IndexError
+        '''
+        try:
+            self[key]  # pylint: disable=W0104
+            return True
+        except KeyError:
+            return False
+
     def __getitem__(self, cmd):
         '''
         Return the function call to simulate the salt local lookup system


### PR DESCRIPTION
Otherwise `if 'config.get' in __salt__` fails becaues it tries to
iterate over a list (starting with 0, 1, 2, etc)

Along with #23272, fixes #19114 
