### PR TITLE
Remove m2crypto

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -168,7 +168,7 @@ def private_encrypt(key, message):
     :rtype: str
     :return: The signature, or an empty string if the signature operation failed
     '''
-    signer = salt.utils.rsax931.RSAX931(key.exportKey('PEM'))
+    signer = salt.utils.rsax931.RSAX931Signer(key.exportKey('PEM'))
     return signer.sign(message)
 
 
@@ -182,7 +182,7 @@ def public_decrypt(pub, message):
     :return: The message (or digest) recovered from the signature, or an
         empty string if the verification failed
     '''
-    verifier = salt.utils.rsax931.RSAX931(pub.exportKey('PEM'))
+    verifier = salt.utils.rsax931.RSAX931Verifier(pub.exportKey('PEM'))
     return verifier.verify(message)
 
 

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -22,6 +22,7 @@ try:
     from Crypto.Cipher import AES, PKCS1_OAEP
     from Crypto.Hash import SHA
     from Crypto.PublicKey import RSA
+    import Crypto.Random
 except ImportError:
     # No need for crypt in local mode
     pass
@@ -359,6 +360,7 @@ class AsyncAuth(object):
 
         self.io_loop = io_loop or tornado.ioloop.IOLoop.current()
 
+        Crypto.Random.atfork()
         key = self.__key(self.opts)
         # TODO: if we already have creds for this key, lets just re-use
         if key in AsyncAuth.creds_map:

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -22,6 +22,7 @@ try:
     from Crypto.Cipher import AES, PKCS1_OAEP
     from Crypto.Hash import SHA
     from Crypto.PublicKey import RSA
+    from Crypto.Signature import PKCS1_v1_5
     import Crypto.Random
 except ImportError:
     # No need for crypt in local mode
@@ -122,7 +123,7 @@ def sign_message(privkey_path, message):
 
 def verify_signature(pubkey_path, message, signature):
     '''
-    Use Crypto.Signature to verify the signature on a message.
+    Use Crypto.Signature.PKCS1_v1_5 to verify the signature on a message.
     Returns True for valid signature.
     '''
     log.debug('salt.crypt.verify_signature: Loading public key')
@@ -130,7 +131,7 @@ def verify_signature(pubkey_path, message, signature):
         pubkey = RSA.importKey(f.read())
     log.debug('salt.crypt.verify_signature: Verifying signature')
     verifier = PKCS1_v1_5.new(pubkey)
-    return verifier.verify(SHA.new(message))
+    return verifier.verify(SHA.new(message), signature)
 
 
 def gen_signature(priv_path, pub_path, sign_path):

--- a/salt/master.py
+++ b/salt/master.py
@@ -18,6 +18,7 @@ import multiprocessing
 # Import third party libs
 import zmq
 from Crypto.PublicKey import RSA
+import Crypto.Random
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 import salt.ext.six as six
 from salt.ext.six.moves import range
@@ -751,6 +752,7 @@ class MWorker(multiprocessing.Process):
             self.key,
             )
         self.aes_funcs = AESFuncs(self.opts)
+        Crypto.Random.atfork()
         self.__bind()
 
 

--- a/salt/master.py
+++ b/salt/master.py
@@ -17,7 +17,7 @@ import multiprocessing
 
 # Import third party libs
 import zmq
-from M2Crypto import RSA
+from Crypto.PublicKey import RSA
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 import salt.ext.six as six
 from salt.ext.six.moves import range
@@ -819,15 +819,16 @@ class AESFuncs(object):
 
         pub = None
         try:
-            pub = RSA.load_pub_key(tmp_pub)
-        except RSA.RSAError as err:
+            with salt.utils.fopen(tmp_pub) as fp_:
+                pub = RSA.importKey(fp_.read())
+        except (ValueError, IndexError, TypeError) as err:
             log.error('Unable to load temporary public key "{0}": {1}'
                       .format(tmp_pub, err))
         try:
             os.remove(tmp_pub)
-            if pub.public_decrypt(token, 5) == 'salt':
+            if salt.crypt.public_decrypt(pub, token) == 'salt':
                 return True
-        except RSA.RSAError as err:
+        except ValueError as err:
             log.error('Unable to decrypt token: {0}'.format(err))
 
         log.error('Salt minion claiming to be {0} has attempted to'

--- a/salt/transport/mixins/auth.py
+++ b/salt/transport/mixins/auth.py
@@ -19,7 +19,6 @@ from salt.utils.cache import CacheCli
 
 # Import Third Party Libs
 import tornado.gen
-import Crypto.Random
 from Crypto.Cipher import PKCS1_OAEP
 from Crypto.PublicKey import RSA
 
@@ -83,9 +82,6 @@ class AESReqServerMixin(object):
             self.ckminions = salt.utils.minions.CkMinions(self.opts)
 
         self.master_key = salt.crypt.MasterKeys(self.opts)
-
-        # Re-initialize the RNG after fork as required by PyCrypto
-        Crypto.Random.atfork()
 
     def _encrypt_private(self, ret, dictkey, target):
         '''

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -182,7 +182,8 @@ class AsyncTCPReqChannel(salt.transport.client.ReqChannel):
             yield self.auth.authenticate()
         ret = yield self.message_client.send(self._package_load(self.auth.crypticle.dumps(load)), timeout=timeout)
         key = self.auth.get_keys()
-        aes = key.private_decrypt(ret['key'], 4)
+        cipher = PKCS1_OAEP.new(key)
+        aes = cipher.decrypt(ret['key'])
         pcrypt = salt.crypt.Crypticle(self.opts, aes)
         raise tornado.gen.Return(pcrypt.loads(ret[dictkey]))
 

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -45,6 +45,9 @@ import tornado.concurrent
 import tornado.tcpclient
 import tornado.netutil
 
+# Import third party libs
+from Crypto.Cipher import PKCS1_OAEP
+
 log = logging.getLogger(__name__)
 
 

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -38,6 +38,9 @@ import tornado
 import tornado.gen
 import tornado.concurrent
 
+# Import third party libs
+from Crypto.Cipher import PKCS1_OAEP
+
 log = logging.getLogger(__name__)
 
 

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -132,7 +132,8 @@ class AsyncZeroMQReqChannel(salt.transport.client.ReqChannel):
         # Return control to the caller. When send() completes, resume by populating ret with the Future.result
         ret = yield self.message_client.send(self._package_load(self.auth.crypticle.dumps(load)), timeout=timeout)
         key = self.auth.get_keys()
-        aes = key.private_decrypt(ret['key'], 4)
+        cipher = PKCS1_OAEP.new(key)
+        aes = cipher.decrypt(ret['key'])
         pcrypt = salt.crypt.Crypticle(self.opts, aes)
         raise tornado.gen.Return(pcrypt.loads(ret[dictkey]))
 

--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 '''
 Create and verify ANSI X9.31 RSA signatures using OpenSSL libcrypto
 '''
@@ -28,7 +29,8 @@ libcrypto.OPENSSL_add_all_algorithms_noconf()
 # openssl/rsa.h:#define RSA_X931_PADDING 5
 RSA_X931_PADDING = 5
 
-class RSAX931Signer:
+
+class RSAX931Signer(object):
     '''
     Create ANSI X9.31 RSA signatures using OpenSSL libcrypto
     '''
@@ -63,7 +65,7 @@ class RSAX931Signer:
         return buf[0:size]
 
 
-class RSAX931Verifier:
+class RSAX931Verifier(object):
     '''
     Verify ANSI X9.31 RSA signatures using OpenSSL libcrypto
     '''

--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -58,7 +58,7 @@ class RSAX931Signer:
         # Allocate a buffer large enough for the signature. Freed by ctypes.
         buf = create_string_buffer(libcrypto.RSA_size(self.__rsa))
         size = libcrypto.RSA_private_encrypt(len(msg), msg, buf, self.__rsa, RSA_X931_PADDING)
-        if size == 0:
+        if size < 0:
             raise ValueError('Unable to encrypt message')
         return buf[0:size]
 
@@ -94,6 +94,6 @@ class RSAX931Verifier:
         # Allocate a buffer large enough for the signature. Freed by ctypes.
         buf = create_string_buffer(libcrypto.RSA_size(self.__rsa))
         size = libcrypto.RSA_public_decrypt(len(signed), signed, buf, self.__rsa, RSA_X931_PADDING)
-        if size == 0:
+        if size < 0:
             raise ValueError('Unable to decrypt message')
         return buf[0:size]

--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -1,0 +1,99 @@
+'''
+Create and verify ANSI X9.31 RSA signatures using OpenSSL libcrypto
+'''
+
+from __future__ import absolute_import
+
+from ctypes import CDLL, c_char_p, c_int, c_void_p, pointer, create_string_buffer
+
+libcrypto = CDLL('libcrypto.so')
+
+libcrypto.RSA_new.argtypes = ()
+libcrypto.RSA_new.restype = c_void_p
+libcrypto.RSA_free.argtypes = (c_void_p, )
+libcrypto.RSA_size.argtype = (c_void_p)
+libcrypto.BIO_new_mem_buf.argtypes = (c_char_p, c_int)
+libcrypto.BIO_new_mem_buf.restype = c_void_p
+libcrypto.BIO_free.argtypes = (c_void_p, )
+libcrypto.PEM_read_bio_RSAPrivateKey.argtypes = (c_void_p, c_void_p, c_void_p, c_void_p)
+libcrypto.PEM_read_bio_RSAPrivateKey.restype = c_void_p
+libcrypto.PEM_read_bio_RSA_PUBKEY.argtypes = (c_void_p, c_void_p, c_void_p, c_void_p)
+libcrypto.PEM_read_bio_RSA_PUBKEY.restype = c_void_p
+libcrypto.RSA_private_encrypt.argtypes = (c_int, c_char_p, c_char_p, c_void_p, c_int)
+libcrypto.RSA_public_decrypt.argtypes = (c_int, c_char_p, c_char_p, c_void_p, c_int)
+
+libcrypto.OPENSSL_no_config()
+libcrypto.OPENSSL_add_all_algorithms_noconf()
+
+# openssl/rsa.h:#define RSA_X931_PADDING 5
+RSA_X931_PADDING = 5
+
+class RSAX931Signer:
+    '''
+    Create ANSI X9.31 RSA signatures using OpenSSL libcrypto
+    '''
+    def __init__(self, keydata):
+        '''
+        Init an RSAX931Signer instance
+
+        :param str keydata: The RSA private key in PEM format
+        '''
+        self.__bio = libcrypto.BIO_new_mem_buf(keydata, len(keydata))
+        self.__rsa = c_void_p(libcrypto.RSA_new())
+        if not libcrypto.PEM_read_bio_RSAPrivateKey(self.__bio, pointer(self.__rsa), None, None):
+            raise ValueError('invalid RSA private key')
+
+    def __del__(self):
+        libcrypto.BIO_free(self.__bio)
+        libcrypto.RSA_free(self.__rsa)
+
+    def sign(self, msg):
+        '''
+        Sign a message (digest) using the private key
+
+        :param str msg: The message (digest) to sign
+        :rtype: str
+        :return: The signature, or an empty string if the encryption failed
+        '''
+        # Allocate a buffer large enough for the signature. Freed by ctypes.
+        buf = create_string_buffer(libcrypto.RSA_size(self.__rsa))
+        size = libcrypto.RSA_private_encrypt(len(msg), msg, buf, self.__rsa, RSA_X931_PADDING)
+        if size == 0:
+            raise ValueError('Unable to encrypt message')
+        return buf[0:size]
+
+
+class RSAX931Verifier:
+    '''
+    Verify ANSI X9.31 RSA signatures using OpenSSL libcrypto
+    '''
+    def __init__(self, pubdata):
+        '''
+        Init an RSAX931Verifier instance
+
+        :param str pubdata: The RSA public key in PEM format
+        '''
+        self.__bio = libcrypto.BIO_new_mem_buf(pubdata, len(pubdata))
+        self.__rsa = c_void_p(libcrypto.RSA_new())
+        if not libcrypto.PEM_read_bio_RSA_PUBKEY(self.__bio, pointer(self.__rsa), None, None):
+            raise ValueError('invalid RSA public key')
+
+    def __del__(self):
+        libcrypto.BIO_free(self.__bio)
+        libcrypto.RSA_free(self.__rsa)
+
+    def verify(self, signed):
+        '''
+        Recover the message (digest) from the signature using the public key
+
+        :param str signed: The signature created with the private key
+        :rtype: str
+        :return: The message (digest) recovered from the signature, or an empty
+            string if the decryption failed
+        '''
+        # Allocate a buffer large enough for the signature. Freed by ctypes.
+        buf = create_string_buffer(libcrypto.RSA_size(self.__rsa))
+        size = libcrypto.RSA_public_decrypt(len(signed), signed, buf, self.__rsa, RSA_X931_PADDING)
+        if size == 0:
+            raise ValueError('Unable to decrypt message')
+        return buf[0:size]

--- a/tests/unit/utils/rsax931_test.py
+++ b/tests/unit/utils/rsax931_test.py
@@ -16,6 +16,7 @@ ensure_in_syspath('../../')
 # salt libs
 from salt.utils.rsax931 import RSAX931Signer, RSAX931Verifier
 
+
 class RSAX931Test(TestCase):
 
     privkey_data = textwrap.dedent('''\
@@ -89,7 +90,7 @@ class RSAX931Test(TestCase):
 
         signer = RSAX931Signer(RSAX931Test.privkey_data)
         with self.assertRaises(ValueError):
-            signer.sign('x'*255) # message too long
+            signer.sign('x'*255)  # message too long
 
         sig = signer.sign(RSAX931Test.hello_world)
         self.assertEqual(RSAX931Test.hello_world_sig, sig)

--- a/tests/unit/utils/rsax931_test.py
+++ b/tests/unit/utils/rsax931_test.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+'''
+Test the RSA ANSI X9.31 signer and verifier
+'''
+
+# python libs
+from __future__ import absolute_import
+import textwrap
+
+# salt testing libs
+from salttesting import TestCase
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+# salt libs
+from salt.utils.rsax931 import RSAX931Signer, RSAX931Verifier
+
+class RSAX931Test(TestCase):
+
+    privkey_data = textwrap.dedent('''\
+        -----BEGIN RSA PRIVATE KEY-----
+        MIIEpAIBAAKCAQEA75GR6ZTv5JOv90Vq8tKhKC7YQnhDIo2hM0HVziTEk5R4UQBW
+        a0CKytFMbTONY2msEDwX9iA0x7F5Lgj0X8eD4ZMsYqLzqjWMekLC8bjhxc+EuPo9
+        Dygu3mJ2VgRC7XhlFpmdo5NN8J2E7B/CNB3R4hOcMMZNZdi0xLtFoTfwU61UPfFX
+        14mV2laqLbvDEfQLJhUTDeFFV8EN5Z4H1ttLP3sMXJvc3EvM0JiDVj4l1TWFUHHz
+        eFgCA1Im0lv8i7PFrgW7nyMfK9uDSsUmIp7k6ai4tVzwkTmV5PsriP1ju88Lo3MB
+        4/sUmDv/JmlZ9YyzTO3Po8Uz3Aeq9HJWyBWHAQIDAQABAoIBAGOzBzBYZUWRGOgl
+        IY8QjTT12dY/ymC05GM6gMobjxuD7FZ5d32HDLu/QrknfS3kKlFPUQGDAbQhbbb0
+        zw6VL5NO9mfOPO2W/3FaG1sRgBQcerWonoSSSn8OJwVBHMFLG3a+U1Zh1UvPoiPK
+        S734swIM+zFpNYivGPvOm/muF/waFf8tF/47t1cwt/JGXYQnkG/P7z0vp47Irpsb
+        Yjw7vPe4BnbY6SppSxscW3KoV7GtJLFKIxAXbxsuJMF/rYe3O3w2VKJ1Sug1VDJl
+        /GytwAkSUer84WwP2b07Wn4c5pCnmLslMgXCLkENgi1NnJMhYVOnckxGDZk54hqP
+        9RbLnkkCgYEA/yKuWEvgdzYRYkqpzB0l9ka7Y00CV4Dha9Of6GjQi9i4VCJ/UFVr
+        UlhTo5y0ZzpcDAPcoZf5CFZsD90a/BpQ3YTtdln2MMCL/Kr3QFmetkmDrt+3wYnX
+        sKESfsa2nZdOATRpl1antpwyD4RzsAeOPwBiACj4fkq5iZJBSI0bxrMCgYEA8GFi
+        qAjgKh81/Uai6KWTOW2kX02LEMVRrnZLQ9VPPLGid4KZDDk1/dEfxjjkcyOxX1Ux
+        Klu4W8ZEdZyzPcJrfk7PdopfGOfrhWzkREK9C40H7ou/1jUecq/STPfSOmxh3Y+D
+        ifMNO6z4sQAHx8VaHaxVsJ7SGR/spr0pkZL+NXsCgYEA84rIgBKWB1W+TGRXJzdf
+        yHIGaCjXpm2pQMN3LmP3RrcuZWm0vBt94dHcrR5l+u/zc6iwEDTAjJvqdU4rdyEr
+        tfkwr7v6TNlQB3WvpWanIPyVzfVSNFX/ZWSsAgZvxYjr9ixw6vzWBXOeOb/Gqu7b
+        cvpLkjmJ0wxDhbXtyXKhZA8CgYBZyvcQb+hUs732M4mtQBSD0kohc5TsGdlOQ1AQ
+        McFcmbpnzDghkclyW8jzwdLMk9uxEeDAwuxWE/UEvhlSi6qdzxC+Zifp5NBc0fVe
+        7lMx2mfJGxj5CnSqQLVdHQHB4zSXkAGB6XHbBd0MOUeuvzDPfs2voVQ4IG3FR0oc
+        3/znuwKBgQChZGH3McQcxmLA28aUwOVbWssfXKdDCsiJO+PEXXlL0maO3SbnFn+Q
+        Tyf8oHI5cdP7AbwDSx9bUfRPjg9dKKmATBFr2bn216pjGxK0OjYOCntFTVr0psRB
+        CrKg52Qrq71/2l4V2NLQZU40Dr1bN9V+Ftd9L0pvpCAEAWpIbLXGDw==
+        -----END RSA PRIVATE KEY-----''')
+
+    pubkey_data = textwrap.dedent('''\
+        -----BEGIN PUBLIC KEY-----
+        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA75GR6ZTv5JOv90Vq8tKh
+        KC7YQnhDIo2hM0HVziTEk5R4UQBWa0CKytFMbTONY2msEDwX9iA0x7F5Lgj0X8eD
+        4ZMsYqLzqjWMekLC8bjhxc+EuPo9Dygu3mJ2VgRC7XhlFpmdo5NN8J2E7B/CNB3R
+        4hOcMMZNZdi0xLtFoTfwU61UPfFX14mV2laqLbvDEfQLJhUTDeFFV8EN5Z4H1ttL
+        P3sMXJvc3EvM0JiDVj4l1TWFUHHzeFgCA1Im0lv8i7PFrgW7nyMfK9uDSsUmIp7k
+        6ai4tVzwkTmV5PsriP1ju88Lo3MB4/sUmDv/JmlZ9YyzTO3Po8Uz3Aeq9HJWyBWH
+        AQIDAQAB
+        -----END PUBLIC KEY-----''')
+
+    hello_world = 'hello, world'
+
+    hello_world_sig = \
+        '\x63\xa0\x70\xd2\xe4\xd4\x6b\x8a\xa2\x59\x27\x5f\x00\x69' \
+        '\x1e\x3c\x50\xed\x50\x13\x09\x80\xe3\x47\x4e\x14\xb5\x7c' \
+        '\x07\x26\x4e\x20\x74\xea\x0e\xf8\xda\xff\x1e\x57\x8c\x67' \
+        '\x76\x73\xaa\xea\x0f\x0a\xe7\xa2\xe3\x88\xfc\x09\x87\x36' \
+        '\x01\x3a\xb7\x4c\x40\xe0\xf4\x54\xc5\xf1\xaa\xb2\x1d\x7f' \
+        '\xb6\xd3\xa8\xdd\x28\x69\x8b\x88\xe4\x42\x1e\x48\x3e\x1f' \
+        '\xe2\x2b\x3c\x7c\x85\x11\xe9\x59\xd7\xf3\xc2\x21\xd3\x55' \
+        '\xcb\x9c\x3c\x93\xcc\x20\xdf\x64\x81\xd0\x0d\xbf\x8e\x8d' \
+        '\x47\xec\x1d\x9e\x27\xec\x12\xed\x8b\x5f\xd6\x1d\xec\x8d' \
+        '\x77\x5a\x58\x8a\x24\xb6\x0f\x12\xb7\x51\xef\x7d\x85\x0f' \
+        '\x49\x39\x02\x81\x15\x08\x70\xd6\xe0\x0b\x31\xff\x5f\xf9' \
+        '\xd1\x92\x38\x59\x8c\x22\x9c\xbb\xbf\xcf\x85\x34\xe2\x47' \
+        '\xf5\xe2\xaa\xb4\x62\x33\x3c\x13\x78\x33\x87\x08\x9e\xb5' \
+        '\xbc\x5d\xc1\xbf\x79\x7c\xfa\x5f\x06\x6a\x3b\x17\x40\x09' \
+        '\xb9\x09\xbf\x32\xc3\x00\xe2\xbc\x91\x77\x14\xa5\x23\xf5' \
+        '\xf5\xf1\x09\x12\x38\xda\x3b\x6a\x82\x81\x7b\x5e\x1c\xcb' \
+        '\xaa\x36\x9b\x08\x36\x03\x14\x96\xa3\x31\x39\x59\x16\x75' \
+        '\xc9\xb6\x66\x94\x1b\x97\xff\xc8\xa1\xe3\x21\x35\x23\x06' \
+        '\x4c\x9b\xf4\xee'
+
+    def test_signer(self):
+        with self.assertRaises(ValueError):
+            signer = RSAX931Signer('bogus key data')
+        with self.assertRaises(ValueError):
+            signer = RSAX931Signer(RSAX931Test.pubkey_data)
+
+        signer = RSAX931Signer(RSAX931Test.privkey_data)
+        with self.assertRaises(ValueError):
+            signer.sign('x'*255) # message too long
+
+        sig = signer.sign(RSAX931Test.hello_world)
+        self.assertEqual(RSAX931Test.hello_world_sig, sig)
+
+    def test_verifier(self):
+        with self.assertRaises(ValueError):
+            verifier = RSAX931Verifier('bogus key data')
+        with self.assertRaises(ValueError):
+            verifier = RSAX931Verifier(RSAX931Test.privkey_data)
+
+        verifier = RSAX931Verifier(RSAX931Test.pubkey_data)
+        with self.assertRaises(ValueError):
+            verifier.verify('')
+        with self.assertRaises(ValueError):
+            verifier.verify(RSAX931Test.hello_world_sig + 'junk')
+
+        msg = verifier.verify(RSAX931Test.hello_world_sig)
+        self.assertEqual(RSAX931Test.hello_world, msg)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(RSAX931Test, needs_daemon=False)


### PR DESCRIPTION
Remove M2Crypto as a dependency. Backward-compatible functionality is implemented using PyCrypto and calls into OpenSSL libcrypto.
