### PR TITLE
Append/prepend: search for full line

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1152,7 +1152,7 @@ def replace(path,
                 if prepend_if_not_found or append_if_not_found:
                     # Search for content, so we don't continue pre/appending
                     # the content if it's been pre/appended in a previous run.
-                    if re.search(content, line):
+                    if re.search('^{0}$'.format(content), line):
                         # Content was found, so set found.
                         found = True
 


### PR DESCRIPTION
When `append_if_not_found` or `prepend_if_not_found`
are true, assume the `content` to search for should
match a full line in the file. The rationale is that
if the content is not found, then it will be added as
a full line. Hence, it should be safe to assume that
it should exist as a full line in the file.

Fixes #23294
