### PR TITLE
Add a short argument (-P) for --grain-pcre

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -850,7 +850,7 @@ class TargetOptionsMixIn(six.with_metaclass(MixInMeta, object)):
                   'expression:\n"os:Arch*"')
         )
         group.add_option(
-            '--grain-pcre',
+            '-P', '--grain-pcre',
             default=False,
             action='store_true',
             help=('Instead of using shell globs to evaluate the target '


### PR DESCRIPTION
  The compound matcher uses P@ for grain-pcre matches.  Currently -P is
  only used for salt-key and salt cloud cli parsers so "-P" should not
  collide with another option.
