### PR TITLE
Remove unused code

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -491,12 +491,6 @@ class Master(SMaster):
             log.debug('Sleeping for two seconds to let concache rest')
             time.sleep(2)
 
-        def run_reqserver():
-            reqserv = ReqServer(
-                self.opts,
-                self.key,
-                self.master_key)
-            reqserv.run()
         log.info('Creating master request server process')
         process_manager.add_process(self.run_reqserver)
         try:


### PR DESCRIPTION
salt/master.py:
- The run_reqserver() function was moved from being defined within a
  class method to being its own class method. This was to facilitate
  pickling on Windows. At that time, the old version was removed.
  However, the old version found its way back into the code, even
  though it is not used or referenced. Note that 'self.run_reqserver'
  references the new, class method version.

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
