### PR TITLE
Backport #23367 to 2015.2

### DIFF
--- a/salt/modules/makeconf.py
+++ b/salt/modules/makeconf.py
@@ -43,8 +43,10 @@ def _add_var(var, value):
     fullvar = '{0}="{1}"'.format(var, value)
     if __salt__['file.contains'](makeconf, layman):
         # TODO perhaps make this a function in the file module?
-        cmd = ['sed', '-i', '/{0}/'.format(layman.replace('/', '\\/')),
-               fullvar, makeconf]
+        cmd = ['sed', '-i', '/{0}/ i\{1}'.format(
+                    layman.replace('/', '\\/'),
+                    fullvar),
+               makeconf]
         __salt__['cmd.run'](cmd)
     else:
         __salt__['file.append'](makeconf, fullvar)

--- a/salt/modules/makeconf.py
+++ b/salt/modules/makeconf.py
@@ -43,7 +43,7 @@ def _add_var(var, value):
     fullvar = '{0}="{1}"'.format(var, value)
     if __salt__['file.contains'](makeconf, layman):
         # TODO perhaps make this a function in the file module?
-        cmd = ['sed', '-i', '/{0}/ i\{1}'.format(
+        cmd = ['sed', '-i', r'/{0}/ i\{1}'.format(
                     layman.replace('/', '\\/'),
                     fullvar),
                makeconf]


### PR DESCRIPTION
Backport for #23367 to 2015.2 branch.  Feel free to close/reject if I've not done this right.

Original PR message:
Turns out that commit a369c883 (merged in PR #18368) make a bad change to modules/makeconf.py where it removed the insertion part of a '/regex/ i\text' construction.

Since this bug's pretty old, Nov 2014, I'll be sending backport PRs momentarily for 2014.7 and 2015.2 branches.
