### PR TITLE
GlusterFS force volume creation

### DIFF
--- a/salt/modules/glusterfs.py
+++ b/salt/modules/glusterfs.py
@@ -104,7 +104,7 @@ def peer(name):
 
 
 def create(name, bricks, stripe=False, replica=False, device_vg=False,
-           transport='tcp', start=False):
+           transport='tcp', start=False, force=False):
     '''
     Create a glusterfs volume.
 
@@ -134,6 +134,9 @@ def create(name, bricks, stripe=False, replica=False, device_vg=False,
 
     start
         Start the volume after creation
+
+    force
+        Force volume creation, this works even if creating in root FS
 
     CLI Example:
 
@@ -173,6 +176,8 @@ def create(name, bricks, stripe=False, replica=False, device_vg=False,
     if transport != 'tcp':
         cmd += 'transport {0} '.format(transport)
     cmd += ' '.join(bricks)
+    if force:
+        cmd += ' force'
 
     log.debug('Clustering command:\n{0}'.format(cmd))
     ret = __salt__['cmd.run'](cmd)

--- a/salt/states/glusterfs.py
+++ b/salt/states/glusterfs.py
@@ -89,7 +89,7 @@ def peered(name):
 
 
 def created(name, bricks, stripe=False, replica=False, device_vg=False,
-            transport='tcp', start=False):
+            transport='tcp', start=False, force=False):
     '''
     Check if volume already exists
 
@@ -153,7 +153,7 @@ def created(name, bricks, stripe=False, replica=False, device_vg=False,
 
     ret['comment'] = __salt__['glusterfs.create'](name, bricks, stripe,
                                                   replica, device_vg,
-                                                  transport, start)
+                                                  transport, start, force)
 
     old_volumes = volumes
     volumes = __salt__['glusterfs.list_volumes']()


### PR DESCRIPTION
This allows one to force the volume creation.
This way if the volume resides on / (root) FS it will still be created.
Very handy for tests.
