### PR TITLE
Fixed zmq monitor for pyzmq < 14.0.0

### DIFF
--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -30,8 +30,12 @@ import zmq.eventloop.ioloop
 if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
     zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
 import zmq.eventloop.zmqstream
-import zmq.utils.monitor
-EVENT_MAP = None
+try:
+    import zmq.utils.monitor
+    HAS_ZMQ_MONITOR = True
+    EVENT_MAP = None
+except ImportError:
+    HAS_ZMQ_MONITOR = False
 
 # Import Tornado Libs
 import tornado
@@ -288,7 +292,7 @@ class AsyncZeroMQPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.t
         More information:
             http://api.zeromq.org/4-0:zmq-socket-monitor
         '''
-        if not self.opts['zmq_monitor']:
+        if not HAS_ZMQ_MONITOR or not self.opts['zmq_monitor']:
             return
 
         global EVENT_MAP
@@ -310,7 +314,7 @@ class AsyncZeroMQPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.t
         self._monitor_stream.on_recv(monitor_callback)
 
     def _stop_monitor(self):
-        if not hasattr(self, '_monitor_socket') or self._monitor_socket is None:
+        if not HAS_ZMQ_MONITOR or not hasattr(self, '_monitor_socket') or self._monitor_socket is None:
             return
         self._socket.disable_monitor()
         self._monitor_stream.close()


### PR DESCRIPTION
Fix for #23240: old zmq versions have no socket monitor.
