### PR TITLE
Fix for double output with static  salt cli/v2015.2

### DIFF
--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -163,12 +163,7 @@ class SaltCMD(parsers.SaltCMDOptionParser):
                         kwargs['cli'] = True
                     else:
                         cmd_func = local.cmd_cli
-                    if self.options.static:
-                        if self.options.verbose:
-                            kwargs['verbose'] = True
-                        full_ret = local.cmd_full_return(**kwargs)
-                        ret, out, retcode = self._format_ret(full_ret)
-                        self._output_ret(ret, out)
+
                     if self.options.progress:
                         kwargs['progress'] = True
                         self.config['progress'] = True

--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -53,7 +53,7 @@ class SaltCMD(parsers.SaltCMDOptionParser):
             self.exit(2, '{0}\n'.format(exc))
             return
 
-        if self.options.batch:
+        if self.options.batch or self.options.static:
             import salt.cli.batch
             eauth = {}
             if 'token' in self.config:
@@ -77,6 +77,9 @@ class SaltCMD(parsers.SaltCMDOptionParser):
                 eauth['eauth'] = self.options.eauth
 
             if self.options.static:
+
+                if not self.options.batch:
+                    self.config['batch'] = '100%'
 
                 batch = salt.cli.batch.Batch(self.config, eauth=eauth, quiet=True)
 


### PR DESCRIPTION
resubmitted to the correct branch

Fix for incorrect output with salt CLI --static option

When the `static` option was used outside the context of the `batch` option
the output would appear thusly:

``` bash
salt -s 'seed*ord' test.ping --out json
```

``` json
{
    "seed-02.pgsql.revsys.000.lab.rackspace.ord": true,
    "seed-01.pgsql.revsys.000.lab.rackspace.ord": true,
    "seed-03.pgsql.revsys.000.lab.rackspace.ord": true
}
{
    "seed-03.pgsql.revsys.000.lab.rackspace.ord": true
}
{
    "seed-02.pgsql.revsys.000.lab.rackspace.ord": true
}
{
    "seed-01.pgsql.revsys.000.lab.rackspace.ord": true
}
```

Using the default outputter results in minion responses being displayed twice.

If it is used with the `batch` option, it Does The Right Thing. Since  `batch` needs logic to take care of the presense of `static`, it made sense to me to remove the `if options.static:` bits from the else half of the`if options.batch:`, extending it to `if options.batch or options.static:` and adding `if not options.batch: self.config['batch'] = '100%'` to make cli.batch.Batch() happy.
