### PR TITLE
Add salt.loader.grain_funcs

### DIFF
--- a/doc/ref/clients/index.rst
+++ b/doc/ref/clients/index.rst
@@ -67,6 +67,8 @@ Each module type has a corresponding loader function.
 
 .. autofunction:: salt.loader.grains
 
+.. autofunction:: salt.loader.grain_funcs
+
 Salt's Client Interfaces
 ========================
 

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -438,6 +438,27 @@ def render(opts, functions, states=None):
     return rend
 
 
+def grain_funcs(opts):
+    '''
+    Returns the grain functions
+
+      .. code-block:: python
+
+          import salt.config
+          import salt.loader
+
+          __opts__ = salt.config.minion_config('/etc/salt/minion')
+          grainfuncs = salt.loader.grain_funcs(__opts__)
+    '''
+    return LazyLoader(_module_dirs(opts,
+                                   'grains',
+                                   'grain',
+                                   ext_type_dirs='grains_dirs'),
+                      opts,
+                      tag='grains',
+                      )
+
+
 def grains(opts, force_refresh=False):
     '''
     Return the functions for the dynamic grains and the values for the static
@@ -510,10 +531,7 @@ def grains(opts, force_refresh=False):
         opts['grains'] = {}
 
     grains_data = {}
-    funcs = LazyLoader(_module_dirs(opts, 'grains', 'grain', ext_type_dirs='grains_dirs'),
-                     opts,
-                     tag='grains',
-                     )
+    funcs = grain_funcs(opts)
     if force_refresh:  # if we refresh, lets reload grain modules
         funcs.clear()
     # Run core grains


### PR DESCRIPTION
Exposes all of the functions that make up all of the grains. This
allows a user to call individual grain functions without collecting
all of them.
