### PR TITLE
fix grains.append in nested dictionnary grains #23411

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -260,7 +260,7 @@ def setval(key, val, destructive=False):
     return setvals({key: val}, destructive)
 
 
-def append(key, val, convert=False):
+def append(key, val, convert=False, delimiter=':'):
     '''
     .. versionadded:: 0.17.0
 
@@ -278,13 +278,19 @@ def append(key, val, convert=False):
         If convert is False and the grain contains non-list contents, an error
         is given. Defaults to False.
 
+    :param delimiter: The key can be a nested dict key. Use this parameter to
+        specify the delimiter you use.
+        You can now append values to a list in nested dictionnary grains. If the
+        list doesn't exist at this level, it will be created.
+        .. versionadded:: FIXME
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' grains.append key val
     '''
-    grains = get(key, [])
+    grains = get(key, [], delimiter)
     if not isinstance(grains, list) and convert is True:
         grains = [grains]
     if not isinstance(grains, list):
@@ -292,6 +298,15 @@ def append(key, val, convert=False):
     if val in grains:
         return 'The val {0} was already in the list {1}'.format(val, key)
     grains.append(val)
+
+    while delimiter in key:
+        key, rest = key.rsplit(delimiter, 1)
+        _grain = get(key, _infinitedict(), delimiter)
+        print('key:', key, '\nrest:', rest, '\n_grain:', _grain, '\ngrains:', grains)
+        if isinstance(_grain, dict):
+            _grain.update({rest: grains})
+        grains = _grain
+
     return setval(key, grains)
 
 

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -302,7 +302,6 @@ def append(key, val, convert=False, delimiter=':'):
     while delimiter in key:
         key, rest = key.rsplit(delimiter, 1)
         _grain = get(key, _infinitedict(), delimiter)
-        print('key:', key, '\nrest:', rest, '\n_grain:', _grain, '\ngrains:', grains)
         if isinstance(_grain, dict):
             _grain.update({rest: grains})
         grains = _grain


### PR DESCRIPTION
I propose this change to fix #23411.
I added the `delimiter` parameter, with a `versionadded` tag to be updated.

Maybe I should add some test for future regression but I would need help.
