### PR TITLE
Update boto_elb.create docstring with correct syntax

### DIFF
--- a/salt/modules/boto_elb.py
+++ b/salt/modules/boto_elb.py
@@ -151,7 +151,7 @@ def create(name, availability_zones, listeners=None, subnets=None,
 
     CLI example to create an ELB::
 
-        salt myminion boto_elb.create myelb '["us-east-1a", "us-east-1e"]' listeners='[["HTTPS", "HTTP", 443, 80, "arn:aws:iam::1111111:server-certificate/mycert"]]' region=us-east-1
+        salt myminion boto_elb.create myelb '["us-east-1a", "us-east-1e"]' listeners='[[443, 80, "HTTPS", "HTTP", "arn:aws:iam::1111111:server-certificate/mycert"]]' region=us-east-1
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 


### PR DESCRIPTION
The format of the listeners example was incorrect/backwards. According
to the Boto documentation[1], the listeners should be in the format of:
LoadBalancerPortNumber, InstancePortNumber, Protocol, InstanceProtocol,
and an optional SSLCertificateId.

[1] http://boto.readthedocs.org/en/latest/ref/elb.html#boto.ec2.elb.ELBConnection.create_load_balancer
