### PR TITLE
Call the windows specific function not the general one

### DIFF
--- a/salt/modules/win_network.py
+++ b/salt/modules/win_network.py
@@ -210,7 +210,7 @@ def interfaces():
 
         salt '*' network.interfaces
     '''
-    return salt.utils.network.interfaces()
+    return salt.utils.network.win_interfaces()
 
 
 def hw_addr(iface):


### PR DESCRIPTION
This will make the `unit.modules.win_network_test.WinNetworkTestCase.test_interfaces` test fail, as it should fail given that it worked because it was being "fed" the linux interfaces when executed from linux.
