### PR TITLE
LDAP auth: Escape filter value for group membership search

### DIFF
--- a/salt/auth/ldap.py
+++ b/salt/auth/ldap.py
@@ -269,8 +269,9 @@ def groups(username, **kwargs):
                 log.error('Could not get distinguished name for user {0}'.format(username))
                 return group_list
             # LDAP results are always tuples.  First entry in the tuple is the DN
-            dn = user_dn_results[0][0]
+            dn = ldap.filter.escape_filter_chars(user_dn_results[0][0])
             ldap_search_string = '(&(member={0})(objectClass={1}))'.format(dn, _config('groupclass'))
+            log.debug('Running LDAP group membership search: {0}'.format(ldap_search_string))
             try:
                 search_results = bind.search_s(_config('basedn'),
                                                ldap.SCOPE_SUBTREE,


### PR DESCRIPTION
The result from a user search need to be escaped when put to the group membership search. Otherwise the search will result with:

```
[ERROR   ] Exception thrown while retrieving group membership in AD: {'desc': 'Bad search filter'}
```

**Example:**
Before:
`(&(member=CN=Rambo\, John,OU=Prague,OU=Users,DC=salt,DC=com)(objectClass=group))`
After:
`(&(member=CN=Rambo\5c, John,OU=Prague,OU=Users,DC=salt,DC=com)(objectClass=group))`

Tested with Active Directory. Can be backported to 2014.7 and develop branches.
