### PR TITLE
Boto secgroup improvements

### DIFF
--- a/salt/states/boto_secgroup.py
+++ b/salt/states/boto_secgroup.py
@@ -241,6 +241,17 @@ def _check_rule(rule, _rule):
     from boto, since they may not completely match rules defined in sls files
     but may be functionally equivalent.
     '''
+
+    # We need to alter what Boto returns if no ports are specified
+    # so that we can compare rules fairly.
+    #
+    # Boto returns None for from_port and to_port where we're required
+    # to pass in "-1" instead.
+    if _rule.get('from_port') is None:
+        _rule['from_port'] = -1
+    if _rule.get('to_port') is None:
+        _rule['to_port'] = -1
+
     if (rule['ip_protocol'] == _rule['ip_protocol'] and
             str(rule['from_port']) == str(_rule['from_port']) and
             str(rule['to_port']) == str(_rule['to_port'])):

--- a/salt/states/boto_secgroup.py
+++ b/salt/states/boto_secgroup.py
@@ -152,6 +152,8 @@ def present(
             return ret
     if not rules:
         rules = []
+    if not rules_egress:
+        rules_egress = []
     _ret = _rules_present(name, rules, rules_egress, vpc_id, region, key, keyid, profile)
     ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])


### PR DESCRIPTION
Minor changes - removing requirement to specify egress rules (even if empty). Fixing change detection when a rule is for all ports - boto expects input of -1 to -1 as port range, but seems to return None, which breaks the comparison in _check_rule.
