### PR TITLE
Vmware cloud driver additions/refactors

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -1026,7 +1026,14 @@ def _upg_tools_helper(vm, reboot=False):
                 return status
             _wait_for_task(task, vm.name, "tools upgrade", 5, "info")
         except Exception as exc:
-            log.error('Could not upgrade VMware tools on VM {0}: {1}'.format(vm.name, exc))
+            log.error(
+                'Error while upgrading VMware tools on VM {0}: {1}'.format(
+                    vm.name,
+                    exc
+                ),
+                # Show the traceback if the debug logging level is enabled
+                exc_info_on_loglevel=logging.DEBUG
+            )
             status = 'VMware tools upgrade failed'
             return status
         status = 'VMware tools upgrade succeeded'
@@ -1644,7 +1651,14 @@ def start(name, call=None):
                 task = vm["object"].PowerOn()
                 _wait_for_task(task, name, "power on")
             except Exception as exc:
-                log.error('Could not power on VM {0}: {1}'.format(name, exc))
+                log.error(
+                    'Error while powering on VM {0}: {1}'.format(
+                        name,
+                        exc
+                    ),
+                    # Show the traceback if the debug logging level is enabled
+                    exc_info_on_loglevel=logging.DEBUG
+                )
                 return 'failed to power on'
 
     return 'powered on'
@@ -1683,7 +1697,14 @@ def stop(name, call=None):
                 task = vm["object"].PowerOff()
                 _wait_for_task(task, name, "power off")
             except Exception as exc:
-                log.error('Could not power off VM {0}: {1}'.format(name, exc))
+                log.error(
+                    'Error while powering off VM {0}: {1}'.format(
+                        name,
+                        exc
+                    ),
+                    # Show the traceback if the debug logging level is enabled
+                    exc_info_on_loglevel=logging.DEBUG
+                )
                 return 'failed to power off'
 
     return 'powered off'
@@ -1726,7 +1747,14 @@ def suspend(name, call=None):
                 task = vm["object"].Suspend()
                 _wait_for_task(task, name, "suspend")
             except Exception as exc:
-                log.error('Could not suspend VM {0}: {1}'.format(name, exc))
+                log.error(
+                    'Error while suspending VM {0}: {1}'.format(
+                        name,
+                        exc
+                    ),
+                    # Show the traceback if the debug logging level is enabled
+                    exc_info_on_loglevel=logging.DEBUG
+                )
                 return 'failed to suspend'
 
     return 'suspended'
@@ -1765,7 +1793,14 @@ def reset(name, call=None):
                 task = vm["object"].Reset()
                 _wait_for_task(task, name, "reset")
             except Exception as exc:
-                log.error('Could not reset VM {0}: {1}'.format(name, exc))
+                log.error(
+                    'Error while resetting VM {0}: {1}'.format(
+                        name,
+                        exc
+                    ),
+                    # Show the traceback if the debug logging level is enabled
+                    exc_info_on_loglevel=logging.DEBUG
+                )
                 return 'failed to reset'
 
     return 'reset'
@@ -1804,7 +1839,14 @@ def terminate(name, call=None):
                 log.info('Terminating VM {0}'.format(name))
                 vm["object"].Terminate()
             except Exception as exc:
-                log.error('Could not terminate VM {0}: {1}'.format(name, exc))
+                log.error(
+                    'Error while terminating VM {0}: {1}'.format(
+                        name,
+                        exc
+                    ),
+                    # Show the traceback if the debug logging level is enabled
+                    exc_info_on_loglevel=logging.DEBUG
+                )
                 return 'failed to terminate'
 
     return 'terminated'
@@ -1852,10 +1894,28 @@ def destroy(name, call=None):
                     task = vm["object"].PowerOff()
                     _wait_for_task(task, name, "power off")
                 except Exception as exc:
-                    log.error('Could not destroy VM {0}: {1}'.format(name, exc))
+                    log.error(
+                        'Error while powering off VM {0}: {1}'.format(
+                            name,
+                            exc
+                        ),
+                        # Show the traceback if the debug logging level is enabled
+                        exc_info_on_loglevel=logging.DEBUG
+                    )
                     return 'failed to destroy'
-            task = vm["object"].Destroy_Task()
-            _wait_for_task(task, name, "destroy")
+            try:
+                task = vm["object"].Destroy_Task()
+                _wait_for_task(task, name, "destroy")
+            except Exception as exc:
+                log.error(
+                    'Error while destroying VM {0}: {1}'.format(
+                        name,
+                        exc
+                    ),
+                    # Show the traceback if the debug logging level is enabled
+                    exc_info_on_loglevel=logging.DEBUG
+                )
+                return 'failed to destroy'
 
     salt.utils.cloud.fire_event(
         'event',
@@ -2288,7 +2348,14 @@ def rescan_hba(kwargs=None, call=None):
             host_ref.configManager.storageSystem.RescanAllHba()
             ret = 'rescanned all HBAs'
     except Exception as exc:
-        log.error('Could not rescan HBA on host {0}: {1}'.format(host_name, exc))
+        log.error(
+            'Error while rescaning HBA on host {0}: {1}'.format(
+                host_name,
+                exc
+            ),
+            # Show the traceback if the debug logging level is enabled
+            exc_info_on_loglevel=logging.DEBUG
+        )
         return {host_name: 'failed to rescan HBA'}
 
     return {host_name: ret}
@@ -2860,7 +2927,14 @@ def create_snapshot(name, kwargs=None, call=None):
         task = vm_ref.CreateSnapshot(snapshot_name, desc, memdump, quiesce)
         _wait_for_task(task, name, "create snapshot", 5, 'info')
     except Exception as exc:
-        log.error('Error while creating snapshot of {0}: {1}'.format(name, exc))
+        log.error(
+            'Error while creating snapshot of {0}: {1}'.format(
+                name,
+                exc
+            ),
+            # Show the traceback if the debug logging level is enabled
+            exc_info_on_loglevel=logging.DEBUG
+        )
         return 'failed to create snapshot'
 
     return {'Snapshot created successfully': _get_snapshots(vm_ref.snapshot.rootSnapshotList, vm_ref.snapshot.currentSnapshot)}
@@ -2907,7 +2981,14 @@ def revert_to_snapshot(name, kwargs=None, call=None):
         _wait_for_task(task, name, "revert to snapshot", 5, 'info')
 
     except Exception as exc:
-        log.error('Error while reverting VM {0} to snapshot: {1}'.format(name, exc))
+        log.error(
+            'Error while reverting VM {0} to snapshot: {1}'.format(
+                name,
+                exc
+            ),
+            # Show the traceback if the debug logging level is enabled
+            exc_info_on_loglevel=logging.DEBUG
+        )
         return 'revert failed'
 
     return 'reverted to current snapshot'
@@ -2943,7 +3024,14 @@ def remove_all_snapshots(name, kwargs=None, call=None):
         task = vm_ref.RemoveAllSnapshots()
         _wait_for_task(task, name, "remove snapshots", 5, 'info')
     except Exception as exc:
-        log.error('Error while removing snapshots on VM {0}: {1}'.format(name, exc))
+        log.error(
+            'Error while removing snapshots on VM {0}: {1}'.format(
+                name,
+                exc
+            ),
+            # Show the traceback if the debug logging level is enabled
+            exc_info_on_loglevel=logging.DEBUG
+        )
         return 'failed to remove snapshots'
 
     return 'removed all snapshots'
@@ -3062,7 +3150,14 @@ def add_host(kwargs=None, call=None):
             log.debug('SSL thumbprint received from the host system: {0}'.format(ssl_thumbprint))
             spec.sslThumbprint = ssl_thumbprint
         except Exception as exc:
-            log.error('Error while trying to get SSL thumbprint of host {0}: {1}'.format(host_name, exc))
+            log.error(
+                'Error while trying to get SSL thumbprint of host {0}: {1}'.format(
+                    host_name,
+                    exc
+                ),
+                # Show the traceback if the debug logging level is enabled
+                exc_info_on_loglevel=logging.DEBUG
+            )
             return {host_name: 'failed to add host'}
 
     try:
@@ -3077,7 +3172,14 @@ def add_host(kwargs=None, call=None):
         if isinstance(exc, vim.fault.SSLVerifyFault):
             log.error('Authenticity of the host\'s SSL certificate is not verified')
             log.info('Try again after setting the esxi_host_ssl_thumbprint to {0} in provider configuration'.format(exc.thumbprint))
-        log.error('Error while adding host {0}: {1}'.format(host_name, exc))
+        log.error(
+            'Error while adding host {0}: {1}'.format(
+                host_name,
+                exc
+            ),
+            # Show the traceback if the debug logging level is enabled
+            exc_info_on_loglevel=logging.DEBUG
+        )
         return {host_name: 'failed to add host'}
 
     return {host_name: ret}
@@ -3121,7 +3223,14 @@ def remove_host(kwargs=None, call=None):
             task = host_ref.Destroy_Task()
         _wait_for_task(task, host_name, "remove host", 1, 'info')
     except Exception as exc:
-        log.error('Error while removing host {0}: {1}'.format(host_name, exc))
+        log.error(
+            'Error while removing host {0}: {1}'.format(
+                host_name,
+                exc
+            ),
+            # Show the traceback if the debug logging level is enabled
+            exc_info_on_loglevel=logging.DEBUG
+        )
         return {host_name: 'failed to remove host'}
 
     return {host_name: 'removed host from vcenter'}
@@ -3163,7 +3272,14 @@ def connect_host(kwargs=None, call=None):
         task = host_ref.ReconnectHost_Task()
         _wait_for_task(task, host_name, "connect host", 5, 'info')
     except Exception as exc:
-        log.error('Error while connecting host {0}: {1}'.format(host_name, exc))
+        log.error(
+            'Error while connecting host {0}: {1}'.format(
+                host_name,
+                exc
+            ),
+            # Show the traceback if the debug logging level is enabled
+            exc_info_on_loglevel=logging.DEBUG
+        )
         return {host_name: 'failed to connect host'}
 
     return {host_name: 'connected host'}
@@ -3205,7 +3321,14 @@ def disconnect_host(kwargs=None, call=None):
         task = host_ref.DisconnectHost_Task()
         _wait_for_task(task, host_name, "disconnect host", 1, 'info')
     except Exception as exc:
-        log.error('Error while disconnecting host {0}: {1}'.format(host_name, exc))
+        log.error(
+            'Error while disconnecting host {0}: {1}'.format(
+                host_name,
+                exc
+            ),
+            # Show the traceback if the debug logging level is enabled
+            exc_info_on_loglevel=logging.DEBUG
+        )
         return {host_name: 'failed to disconnect host'}
 
     return {host_name: 'disconnected host'}
@@ -3268,7 +3391,14 @@ def reboot_host(kwargs=None, call=None):
         host_ref.RebootHost_Task(force)
         _wait_for_host(host_ref, "reboot", 10, 'info')
     except Exception as exc:
-        log.error('Error while rebooting host {0}: {1}'.format(host_name, exc))
+        log.error(
+            'Error while rebooting host {0}: {1}'.format(
+                host_name,
+                exc
+            ),
+            # Show the traceback if the debug logging level is enabled
+            exc_info_on_loglevel=logging.DEBUG
+        )
         return {host_name: 'failed to reboot host'}
 
     return {host_name: 'rebooted host'}
@@ -3331,5 +3461,5 @@ def create_datastore_cluster(kwargs=None, call=None):
             exc_info_on_loglevel=logging.DEBUG
         )
         return False
-
+    
     return {datastore_cluster_name: 'created'}

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2170,8 +2170,8 @@ def create(vm_):
                     type='clone',
                     vm=object_ref,
                     podSelectionSpec=pod_spec,
-                    cloneSpec = clone_spec,
-                    cloneName = vm_name,
+                    cloneSpec=clone_spec,
+                    cloneName=vm_name,
                     folder=folder_ref
                 )
 
@@ -3514,5 +3514,5 @@ def create_datastore_cluster(kwargs=None, call=None):
             exc_info_on_loglevel=logging.DEBUG
         )
         return False
-    
+
     return {datastore_cluster_name: 'created'}

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -3163,7 +3163,7 @@ def add_datastore_cluster(kwargs=None, call=None):
 
     .. code-block:: bash
 
-        salt-cloud -f add_datastore_cluster my-vmware-config name="myDatastoreName" datacenter="myDatacenterName"
+        salt-cloud -f add_datastore_cluster my-vmware-config name="myDatastoreClusterName" datacenter="myDatacenterName"
     '''
     if call != 'function':
         raise SaltCloudSystemExit(
@@ -3175,7 +3175,7 @@ def add_datastore_cluster(kwargs=None, call=None):
 
     if not name:
         raise SaltCloudSystemExit(
-            'You must specify a name of the new datacenter cluster'
+            'You must specify a name of the new datastore cluster'
         )
 
     if not datacenter:

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -1065,7 +1065,8 @@ def get_vcenter_version(kwargs=None, call=None):
     '''
     if call != 'function':
         raise SaltCloudSystemExit(
-            'The get_vcenter_version function must be called with -f or --function.'
+            'The get_vcenter_version function must be called with '
+            '-f or --function.'
         )
 
     # Get the inventory
@@ -1086,7 +1087,8 @@ def list_datacenters(kwargs=None, call=None):
     '''
     if call != 'function':
         raise SaltCloudSystemExit(
-            'The list_datacenters function must be called with -f or --function.'
+            'The list_datacenters function must be called with '
+            '-f or --function.'
         )
 
     datacenters = []
@@ -1112,7 +1114,8 @@ def list_clusters(kwargs=None, call=None):
     '''
     if call != 'function':
         raise SaltCloudSystemExit(
-            'The list_clusters function must be called with -f or --function.'
+            'The list_clusters function must be called with '
+            '-f or --function.'
         )
 
     clusters = []
@@ -1138,7 +1141,8 @@ def list_datastore_clusters(kwargs=None, call=None):
     '''
     if call != 'function':
         raise SaltCloudSystemExit(
-            'The list_datastore_clusters function must be called with -f or --function.'
+            'The list_datastore_clusters function must be called with '
+            '-f or --function.'
         )
 
     datastore_clusters = []
@@ -1164,7 +1168,8 @@ def list_datastores(kwargs=None, call=None):
     '''
     if call != 'function':
         raise SaltCloudSystemExit(
-            'The list_datastores function must be called with -f or --function.'
+            'The list_datastores function must be called with '
+            '-f or --function.'
         )
 
     datastores = []
@@ -1190,7 +1195,8 @@ def list_hosts(kwargs=None, call=None):
     '''
     if call != 'function':
         raise SaltCloudSystemExit(
-            'The list_hosts function must be called with -f or --function.'
+            'The list_hosts function must be called with '
+            '-f or --function.'
         )
 
     hosts = []
@@ -1216,7 +1222,8 @@ def list_resourcepools(kwargs=None, call=None):
     '''
     if call != 'function':
         raise SaltCloudSystemExit(
-            'The list_resourcepools function must be called with -f or --function.'
+            'The list_resourcepools function must be called with '
+            '-f or --function.'
         )
 
     resource_pools = []
@@ -1242,7 +1249,8 @@ def list_networks(kwargs=None, call=None):
     '''
     if call != 'function':
         raise SaltCloudSystemExit(
-            'The list_networks function must be called with -f or --function.'
+            'The list_networks function must be called with '
+            '-f or --function.'
         )
 
     networks = []
@@ -1485,7 +1493,8 @@ def show_instance(name, call=None):
     '''
     if call != 'action':
         raise SaltCloudSystemExit(
-            'The show_instance action must be called with -a or --action.'
+            'The show_instance action must be called with '
+            '-a or --action.'
         )
 
     vm_properties = [
@@ -1559,7 +1568,8 @@ def list_folders(kwargs=None, call=None):
     '''
     if call != 'function':
         raise SaltCloudSystemExit(
-            'The list_folders function must be called with -f or --function.'
+            'The list_folders function must be called with '
+            '-f or --function.'
         )
 
     folders = []
@@ -1596,7 +1606,8 @@ def list_snapshots(kwargs=None, call=None):
     '''
     if call != 'function':
         raise SaltCloudSystemExit(
-            'The list_snapshots function must be called with -f or --function.'
+            'The list_snapshots function must be called with '
+            '-f or --function.'
         )
 
     ret = {}
@@ -1630,7 +1641,8 @@ def start(name, call=None):
     '''
     if call != 'action':
         raise SaltCloudSystemExit(
-            'The start action must be called with -a or --action.'
+            'The start action must be called with '
+            '-a or --action.'
         )
 
     vm_properties = [
@@ -1676,7 +1688,8 @@ def stop(name, call=None):
     '''
     if call != 'action':
         raise SaltCloudSystemExit(
-            'The stop action must be called with -a or --action.'
+            'The stop action must be called with '
+            '-a or --action.'
         )
 
     vm_properties = [
@@ -1722,7 +1735,8 @@ def suspend(name, call=None):
     '''
     if call != 'action':
         raise SaltCloudSystemExit(
-            'The suspend action must be called with -a or --action.'
+            'The suspend action must be called with '
+            '-a or --action.'
         )
 
     vm_properties = [
@@ -1772,7 +1786,8 @@ def reset(name, call=None):
     '''
     if call != 'action':
         raise SaltCloudSystemExit(
-            'The reset action must be called with -a or --action.'
+            'The reset action must be called with '
+            '-a or --action.'
         )
 
     vm_properties = [
@@ -1819,7 +1834,8 @@ def terminate(name, call=None):
     '''
     if call != 'action':
         raise SaltCloudSystemExit(
-            'The terminate action must be called with -a or --action.'
+            'The terminate action must be called with '
+            '-a or --action.'
         )
 
     vm_properties = [
@@ -2202,7 +2218,8 @@ def create_datacenter(kwargs=None, call=None):
     '''
     if call != 'function':
         raise SaltCloudSystemExit(
-            'The create_datacenter function must be called with -f or --function.'
+            'The create_datacenter function must be called with '
+            '-f or --function.'
         )
 
     datacenter_name = kwargs.get('name') if kwargs and 'name' in kwargs else None
@@ -2260,7 +2277,8 @@ def create_cluster(kwargs=None, call=None):
     '''
     if call != 'function':
         raise SaltCloudSystemExit(
-            'The create_cluster function must be called with -f or --function.'
+            'The create_cluster function must be called with '
+            '-f or --function.'
         )
 
     cluster_name = kwargs.get('name') if kwargs and 'name' in kwargs else None
@@ -2325,7 +2343,8 @@ def rescan_hba(kwargs=None, call=None):
     '''
     if call != 'function':
         raise SaltCloudSystemExit(
-            'The rescan_hba function must be called with -f or --function.'
+            'The rescan_hba function must be called with '
+            '-f or --function.'
         )
 
     hba = kwargs.get('hba') if kwargs and 'hba' in kwargs else None
@@ -2414,7 +2433,8 @@ def upgrade_tools(name, reboot=False, call=None):
     '''
     if call != 'action':
         raise SaltCloudSystemExit(
-            'The upgrade_tools action must be called with -a or --action.'
+            'The upgrade_tools action must be called with '
+            '-a or --action.'
         )
 
     vm_ref = _get_mor_by_property(vim.VirtualMachine, name)
@@ -2601,7 +2621,8 @@ def list_hbas(kwargs=None, call=None):
     '''
     if call != 'function':
         raise SaltCloudSystemExit(
-            'The list_hbas function must be called with -f or --function.'
+            'The list_hbas function must be called with '
+            '-f or --function.'
         )
 
     ret = {}
@@ -2896,7 +2917,8 @@ def create_snapshot(name, kwargs=None, call=None):
     '''
     if call != 'action':
         raise SaltCloudSystemExit(
-            'The create_snapshot action must be called with -a or --action.'
+            'The create_snapshot action must be called with '
+            '-a or --action.'
         )
 
     snapshot_name = kwargs.get('snapshot_name') if kwargs and 'snapshot_name' in kwargs else None
@@ -2965,7 +2987,8 @@ def revert_to_snapshot(name, kwargs=None, call=None):
     '''
     if call != 'action':
         raise SaltCloudSystemExit(
-            'The revert_to_snapshot action must be called with -a or --action.'
+            'The revert_to_snapshot action must be called with '
+            '-a or --action.'
         )
 
     suppress_power_on = _str_to_bool(kwargs.get('power_off', False))
@@ -3013,7 +3036,8 @@ def remove_all_snapshots(name, kwargs=None, call=None):
     '''
     if call != 'action':
         raise SaltCloudSystemExit(
-            'The remove_all_snapshots action must be called with -a or --action.'
+            'The remove_all_snapshots action must be called with '
+            '-a or --action.'
         )
 
     consolidate = _str_to_bool(kwargs.get('merge_snapshots')) if kwargs and 'merge_snapshots' in kwargs else True

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -3153,3 +3153,48 @@ def reboot_host(kwargs=None, call=None):
         return {host_name: 'failed to reboot host'}
 
     return {host_name: 'rebooted host'}
+
+
+def add_datastore_cluster(kwargs=None, call=None):
+    '''
+    Add a new datastore cluster to a datacenter
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-cloud -f add_datastore_cluster my-vmware-config name="myDatastoreName" datacenter="myDatacenterName"
+    '''
+    if call != 'function':
+        raise SaltCloudSystemExit(
+            'The add_datastore_cluster function must be called with -f or --function'
+        )
+
+    name = kwargs.get('name') if kwargs else None
+    datacenter = kwargs.get('datacenter') if kwargs else None
+
+    if not name:
+        raise SaltCloudSystemExit(
+            'You must specify a name of the new datacenter cluster'
+        )
+
+    if not datacenter:
+        raise SaltCloudSystemExit(
+            'You must specify the datacenter to attach the new datastore cluster to'
+        )
+
+    datacenter_ref = _get_mor_by_property(vim.Datacenter, datacenter)
+
+    if not datacenter_ref:
+        raise SaltCloudSystemExit(
+            'The specified datacenter does not exist'
+        )
+
+    try:
+        datacenter_ref.datastoreFolder.CreateStoragePod(name=name)
+       ret = 'Created Datastore Cluster {0}'.format(name)
+    except Exception as exc:
+        log.error('Error creating datastore cluster {0}: {1}'.format(name, exc))
+        return 'Could not create datastore cluster {0}'.format(name)
+
+    return ret

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -175,7 +175,7 @@ def _get_si():
                 ssl._create_default_https_context = default_context
             except:
                 raise SaltCloudSystemExit(
-                    '\nCCould not connect to the vCenter server using the specified username and password'
+                    '\nCould not connect to the vCenter server using the specified username and password'
                 )
         else:
             raise SaltCloudSystemExit(
@@ -2027,7 +2027,7 @@ def create(vm_):
             clone_type = "template" if object_ref.config.template else "vm"
         else:
             raise SaltCloudSystemExit(
-                'The VM/template that you have specified under clonefrom does not exist'
+                'The VM/template that you have specified under clonefrom does not exist.'
             )
 
         # Either a cluster, or a resource pool must be specified when cloning from template.
@@ -2036,18 +2036,18 @@ def create(vm_):
             if not resourcepool_ref:
                 log.error('Specified resource pool: {0} does not exist'.format(resourcepool))
                 if clone_type == "template":
-                    raise SaltCloudSystemExit('You must specify a resource pool that exists')
+                    raise SaltCloudSystemExit('You must specify a resource pool that exists.')
         elif cluster:
             cluster_ref = _get_mor_by_property(vim.ClusterComputeResource, cluster)
             if not cluster_ref:
                 log.error('Specified cluster: {0} does not exist'.format(cluster))
                 if clone_type == "template":
-                    raise SaltCloudSystemExit('You must specify a cluster that exists')
+                    raise SaltCloudSystemExit('You must specify a cluster that exists.')
             else:
                 resourcepool_ref = cluster_ref.resourcePool
         elif clone_type == "template":
             raise SaltCloudSystemExit(
-                'You must either specify a cluster or a resource pool when cloning from a template'
+                'You must either specify a cluster or a resource pool when cloning from a template.'
             )
         else:
             log.debug('Using resource pool used by the {0} {1}'.format(clone_type, vm_['clonefrom']))
@@ -2226,7 +2226,7 @@ def create_datacenter(kwargs=None, call=None):
 
     if not datacenter_name:
         raise SaltCloudSystemExit(
-            'You must pass a name for the new datacenter to be created.'
+            'You must specify name of the new datacenter to be created.'
         )
 
     if len(datacenter_name) >= 80 or len(datacenter_name) <= 0:
@@ -2286,12 +2286,12 @@ def create_cluster(kwargs=None, call=None):
 
     if not cluster_name:
         raise SaltCloudSystemExit(
-            'You must pass a name for the new cluster to be created.'
+            'You must specify name of the new cluster to be created.'
         )
 
     if not datacenter:
         raise SaltCloudSystemExit(
-            'You must pass a name for the datacenter where the cluster should be created.'
+            'You must specify name of the datacenter where the cluster should be created.'
         )
 
     if not isinstance(datacenter, vim.Datacenter):
@@ -2352,7 +2352,7 @@ def rescan_hba(kwargs=None, call=None):
 
     if not host_name:
         raise SaltCloudSystemExit(
-            'You must pass a name of the host system'
+            'You must specify name of the host system.'
         )
 
     host_ref = _get_mor_by_property(vim.HostSystem, host_name)
@@ -2466,7 +2466,7 @@ def list_hosts_by_cluster(kwargs=None, call=None):
     if call != 'function':
         raise SaltCloudSystemExit(
             'The list_hosts_by_cluster function must be called with '
-            '-f or --function'
+            '-f or --function.'
         )
 
     ret = {}
@@ -2510,7 +2510,7 @@ def list_clusters_by_datacenter(kwargs=None, call=None):
     if call != 'function':
         raise SaltCloudSystemExit(
             'The list_clusters_by_datacenter function must be called with '
-            '-f or --function'
+            '-f or --function.'
         )
 
     ret = {}
@@ -2554,7 +2554,7 @@ def list_hosts_by_datacenter(kwargs=None, call=None):
     if call != 'function':
         raise SaltCloudSystemExit(
             'The list_hosts_by_datacenter function must be called with '
-            '-f or --function'
+            '-f or --function.'
         )
 
     ret = {}
@@ -2635,7 +2635,7 @@ def list_hbas(kwargs=None, call=None):
 
     if hba_type and hba_type not in ["parallel", "block", "iscsi", "fibre"]:
         raise SaltCloudSystemExit(
-            'Specified hba type {0} currently not supported'.format(hba_type)
+            'Specified hba type {0} currently not supported.'.format(hba_type)
         )
 
     host_list = _get_mors_with_properties(vim.HostSystem, host_properties)
@@ -2741,7 +2741,7 @@ def enter_maintenance_mode(kwargs=None, call=None):
 
     if not host_name or not host_ref:
         raise SaltCloudSystemExit(
-            'You must pass a valid name of the host system'
+            'You must specify a valid name of the host system.'
         )
 
     if host_ref.runtime.inMaintenanceMode:
@@ -2786,7 +2786,7 @@ def exit_maintenance_mode(kwargs=None, call=None):
 
     if not host_name or not host_ref:
         raise SaltCloudSystemExit(
-            'You must pass a valid name of the host system'
+            'You must specify a valid name of the host system.'
         )
 
     if not host_ref.runtime.inMaintenanceMode:
@@ -2850,7 +2850,7 @@ def create_folder(kwargs=None, call=None):
 
     if not folder_path:
         raise SaltCloudSystemExit(
-            'You must specify a non empty folder path'
+            'You must specify a non empty folder path.'
         )
 
     folder_refs = []
@@ -2925,7 +2925,7 @@ def create_snapshot(name, kwargs=None, call=None):
 
     if not snapshot_name:
         raise SaltCloudSystemExit(
-            'You must provide a snapshot name for the snapshot to be created.'
+            'You must specify snapshot name for the snapshot to be created.'
         )
 
     memdump = _str_to_bool(kwargs.get('memdump', True))
@@ -3123,36 +3123,36 @@ def add_host(kwargs=None, call=None):
 
     if not host_user:
         raise SaltCloudSystemExit(
-            'You must provide the ESXi host username in your providers config'
+            'You must specify the ESXi host username in your providers config.'
         )
 
     if not host_password:
         raise SaltCloudSystemExit(
-            'You must provide the ESXi host password in your providers config'
+            'You must specify the ESXi host password in your providers config.'
         )
 
     if not host_name:
         raise SaltCloudSystemExit(
-            'You must pass either an IP or DNS name for the Host system'
+            'You must specify either the IP or DNS name of the host system.'
         )
 
     if (cluster_name and datacenter_name) or not(cluster_name or datacenter_name):
         raise SaltCloudSystemExit(
-            'You must specify either the cluster name or the datacenter name'
+            'You must specify either the cluster name or the datacenter name.'
         )
 
     if cluster_name:
         cluster_ref = _get_mor_by_property(vim.ClusterComputeResource, cluster_name)
         if not cluster_ref:
             raise SaltCloudSystemExit(
-                'Specified cluster does not exist'
+                'Specified cluster does not exist.'
             )
 
     if datacenter_name:
         datacenter_ref = _get_mor_by_property(vim.Datacenter, datacenter_name)
         if not datacenter_ref:
             raise SaltCloudSystemExit(
-                'Specified datacenter does not exist'
+                'Specified datacenter does not exist.'
             )
 
     spec = vim.host.ConnectSpec(
@@ -3229,13 +3229,13 @@ def remove_host(kwargs=None, call=None):
 
     if not host_name:
         raise SaltCloudSystemExit(
-            'You must specify the name of the Host system'
+            'You must specify name of the host system.'
         )
 
     host_ref = _get_mor_by_property(vim.HostSystem, host_name)
     if not host_ref:
         raise SaltCloudSystemExit(
-            'Specified host system does not exist'
+            'Specified host system does not exist.'
         )
 
     try:
@@ -3280,13 +3280,13 @@ def connect_host(kwargs=None, call=None):
 
     if not host_name:
         raise SaltCloudSystemExit(
-            'You must specify the name of the Host system'
+            'You must specify name of the host system.'
         )
 
     host_ref = _get_mor_by_property(vim.HostSystem, host_name)
     if not host_ref:
         raise SaltCloudSystemExit(
-            'Specified host system does not exist'
+            'Specified host system does not exist.'
         )
 
     if host_ref.runtime.connectionState == 'connected':
@@ -3329,13 +3329,13 @@ def disconnect_host(kwargs=None, call=None):
 
     if not host_name:
         raise SaltCloudSystemExit(
-            'You must specify the name of the Host system'
+            'You must specify name of the host system.'
         )
 
     host_ref = _get_mor_by_property(vim.HostSystem, host_name)
     if not host_ref:
         raise SaltCloudSystemExit(
-            'Specified host system does not exist'
+            'Specified host system does not exist.'
         )
 
     if host_ref.runtime.connectionState == 'disconnected':
@@ -3385,30 +3385,30 @@ def reboot_host(kwargs=None, call=None):
 
     if not host_name:
         raise SaltCloudSystemExit(
-            'You must specify the name of the Host system'
+            'You must specify name of the host system.'
         )
 
     host_ref = _get_mor_by_property(vim.HostSystem, host_name)
     if not host_ref:
         raise SaltCloudSystemExit(
-            'Specified host system does not exist'
+            'Specified host system does not exist.'
         )
 
     if host_ref.runtime.connectionState == 'notResponding':
         raise SaltCloudSystemExit(
-            'Specified host system cannot be rebooted in its current state (not responding)'
+            'Specified host system cannot be rebooted in it\'s current state (not responding).'
         )
 
     if not host_ref.capability.rebootSupported:
         raise SaltCloudSystemExit(
-            'Specified host system does not support reboot'
+            'Specified host system does not support reboot.'
         )
 
     if not host_ref.runtime.inMaintenanceMode:
         raise SaltCloudSystemExit(
             'Specified host system is not in maintenance mode. Specify force=True to '
             'force reboot even if there are virtual machines running or other operations '
-            'in progress'
+            'in progress.'
         )
 
     try:
@@ -3441,7 +3441,7 @@ def create_datastore_cluster(kwargs=None, call=None):
     if call != 'function':
         raise SaltCloudSystemExit(
             'The create_datastore_cluster function must be called with '
-            '-f or --function'
+            '-f or --function.'
         )
 
     datastore_cluster_name = kwargs.get('name') if kwargs and 'name' in kwargs else None
@@ -3449,7 +3449,7 @@ def create_datastore_cluster(kwargs=None, call=None):
 
     if not datastore_cluster_name:
         raise SaltCloudSystemExit(
-            'You must pass a name for the new datastore cluster to be created.'
+            'You must specify name of the new datastore cluster to be created.'
         )
 
     if len(datastore_cluster_name) >= 80 or len(datastore_cluster_name) <= 0:
@@ -3459,7 +3459,7 @@ def create_datastore_cluster(kwargs=None, call=None):
 
     if not datacenter_name:
         raise SaltCloudSystemExit(
-            'You must pass a name for the datacenter where the datastore cluster should be created.'
+            'You must specify name of the datacenter where the datastore cluster should be created.'
         )
 
     # Check if datastore cluster already exists


### PR DESCRIPTION
Added `create_datastore_cluster()` to be able to create a new datastore cluster in the specified datacenter

Making sure to show the traceback if debug logging level is enabled and if an exception is thrown

Standardizing error messages, correcting grammar and spellings etc

Making sure that Storage DRS recommendations are applied if a datastore cluster is specified under `datastore` when creating a VM. Fixes #23486

@techhat @rallytime 
