### PR TITLE
Tweak network address comparisons

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -160,12 +160,14 @@ def _sort_hostnames(hostname_list):
         third = e.count(':')
 
         # punish ipv4
+        # punish ipv4 addresses that start with '127.' more
         e_is_ipv4 = e.count('.') == 3 and not any(c.isalpha() for c in e)
-        if e_is_ipv4 and e.startswith('127.'):
-            fourth = 1
         if e_is_ipv4:
-            fourth = 1
-        if not e_is_ipv4:
+            if e.startswith('127.'):
+                fourth = 1
+            else:
+                fourth = 0
+        else:
             fourth = -1
 
         # favor hosts with more dots


### PR DESCRIPTION
Punish ipv4 addresses that start with '127.' more than other ipv4
addresses to follow original logic before refactor.

Related to Pull Request #23481

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
