### PR TITLE
Catch the unset (empty/None) environment case

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -179,9 +179,9 @@ class GitPillar(object):
     def map_branch(self, branch, opts=None):
         opts = __opts__ if opts is None else opts
         if branch == '__env__':
-            branch = opts.get('environment', 'base')
+            branch = opts.get('environment') or 'base'
             if branch == 'base':
-                branch = opts.get('gitfs_base', 'master')
+                branch = opts.get('gitfs_base') or 'master'
         return branch
 
     def update(self):


### PR DESCRIPTION
See https://github.com/saltstack/salt/commit/7d8915945656074cc20cc41be98cd34024d61d2f#commitcomment-11014223

When the environment is not set in the grains and not given on command line, opts['environment'] exists, but the opts.get('environment', 'base') will render None. This causes git_pillar to checkout the branch 'None', which is not what's functionally desired.
