### PR TITLE
short-circuit auto-failure of iptables.delete state 

### DIFF
--- a/salt/states/iptables.py
+++ b/salt/states/iptables.py
@@ -601,16 +601,18 @@ def delete(name, family='ipv4', **kwargs):
     kwargs['name'] = name
     rule = __salt__['iptables.build_rule'](family=family, **kwargs)
     command = __salt__['iptables.build_rule'](full=True, family=family, command='D', **kwargs)
+
     if not __salt__['iptables.check'](kwargs['table'],
                                       kwargs['chain'],
                                       rule,
                                       family) is True:
-        ret['result'] = True
-        ret['comment'] = 'iptables rule for {0} already absent for {1} ({2})'.format(
-            name,
-            family,
-            command.strip())
-        return ret
+        if 'position' not in kwargs:
+            ret['result'] = True
+            ret['comment'] = 'iptables rule for {0} already absent for {1} ({2})'.format(
+                name,
+                family,
+                command.strip())
+            return ret
     if __opts__['test']:
         ret['comment'] = 'iptables rule for {0} needs to be deleted for {1} ({2})'.format(
             name,


### PR DESCRIPTION
Currently all states.iptables.delete dicts are passed through modules.iptables.check().  I understand the purpose of ..check(), but in this case it is overriding what should be a valid state definition:

``` bash
Chain ACCESS (1 references)
num  target     prot opt source               destination
1    ACCEPT     tcp  --  10.129.0.0/16        0.0.0.0/0            ctstate NEW /* saltstack 2015.2.0rc2 */
2    ACCEPT     tcp  --  1.1.1.1              0.0.0.0/0            ctstate NEW /* saltstack 2015.2.0rc2 */
3    ACCEPT     tcp  --  24.124.26.25         0.0.0.0/0            ctstate NEW /* saltstack 2015.2.0rc2 */
4    ACCEPT     tcp  --  192.168.73.0/24      0.0.0.0/0            ctstate NEW /* saltstack 2015.2.0rc2 */
5    ACCEPT     tcp  --  1.1.1.2              0.0.0.0/0            ctstate NEW /* saltstack 2015.2.0rc2 */
6    ACCEPT     tcp  --  24.124.89.19         0.0.0.0/0            ctstate NEW /* saltstack 2015.2.0rc2 */
7    RETURN     all  --  0.0.0.0/0            0.0.0.0/0

```

Given the output of the following execution module:

``` json
# salt-call ext_iptables.ipt_validate_targets chain=ACCESS --out=json
{
    "local": {
        "ACCESS": {
            "valid": {
                "24.124.26.25": {
                    "line": "3"
                },
                "10.129.0.0/16": {
                    "line": "1"
                },
                "192.168.73.0/24": {
                    "line": "4"
                },
                "24.124.89.19": {
                    "line": "6"
                }
            },
            "invalid": {
                "1.1.1.1": {
                    "line": "2"
                },
                "1.1.1.2": {
                    "line": "5"
                }
            }
        }
    }
}

```

Though modules.iptables.delete() supports `position` with `rule` = None, the early m..iptables.check() call  causes an automatic failure event though a positional delete call is valid.  I think it would be adequate to make the logic change in the iptables.delete state function since any other use-case for `position` actually would an accompanying, valid rule.

``` yaml
{% set ssh_revoked = salt['ext_iptables.ipt_validate_targets'](chain='ACCESS', family=inet_ver)['ACCESS']['invalid'] -%}

{% for target, line_no in ssh_revoked.items() -%}

sshd_iptables_noaccess_for_{{target}}:
  iptables.delete:
    - table: filter
    - family: {{inet_ver}}
    - chain: ACCESS
    - position: {{line_no}}
{% endfor %}
```
