### PR TITLE
salt-ssh state: fix including all salt:// references

### DIFF
--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -99,11 +99,13 @@ def lowstate_file_refs(chunks, extras=''):
     return refs
 
 
-def salt_refs(data, ret=[]):
+def salt_refs(data, ret=None):
     '''
     Pull salt file references out of the states
     '''
     proto = 'salt://'
+    if ret is None:
+        ret = []
     if isinstance(data, str):
         if data.startswith(proto) and data not in ret:
             ret.append(data)

--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -99,20 +99,20 @@ def lowstate_file_refs(chunks, extras=''):
     return refs
 
 
-def salt_refs(data):
+def salt_refs(data, ret=[]):
     '''
     Pull salt file references out of the states
     '''
     proto = 'salt://'
-    ret = []
     if isinstance(data, str):
-        if data.startswith(proto):
-            return [data]
+        if data.startswith(proto) and data not in ret:
+            ret.append(data)
     if isinstance(data, list):
         for comp in data:
-            if isinstance(comp, str):
-                if comp.startswith(proto):
-                    ret.append(comp)
+            salt_refs(comp, ret)
+    if isinstance(data, dict):
+        for comp in data:
+            salt_refs(data[comp], ret)
     return ret
 
 
@@ -154,7 +154,7 @@ def prep_trans_tar(file_client, chunks, file_refs, pillar=None):
                     if not os.path.isdir(tgt_dir):
                         os.makedirs(tgt_dir)
                     shutil.copy(path, tgt)
-                    break
+                    continue
                 files = file_client.cache_dir(name, saltenv)
                 if files:
                     for filename in files:
@@ -170,7 +170,7 @@ def prep_trans_tar(file_client, chunks, file_refs, pillar=None):
                         if not os.path.isdir(tgt_dir):
                             os.makedirs(tgt_dir)
                         shutil.copy(filename, tgt)
-                    break
+                    continue
     cwd = os.getcwd()
     os.chdir(gendir)
     with closing(tarfile.open(trans_tar, 'w:gz')) as tfp:


### PR DESCRIPTION
Proposed patch to fix #23355. It needs review, of course, and testing. I think it should have some unit / integration tests too. It seems there is no test written for the SSH client yet, or I didn't find it, and I don't know enough to initialize one.

I didn't understand why the function `prep_trans_tar` make a loop into the given list, then break after the first entry is done. There may be a good reason, it that case, my change may break it.
