### PR TITLE
Fix for an issue caused by a previous pull request

### DIFF
--- a/salt/returners/__init__.py
+++ b/salt/returners/__init__.py
@@ -90,8 +90,8 @@ def get_returner_options(virtualname=None,
     _options.update(
         _fetch_profile_opts(
             cfg,
-            __salt__,
             virtualname,
+            __salt__,
             _options,
             profile_attr,
             profile_attrs


### PR DESCRIPTION
Passed argumentes in the call _fetch_profile_opts to were in the wrong order
