### PR TITLE
Debian: Hostname always updated

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1808,7 +1808,8 @@ def build_network_settings(**settings):
 
     # Write hostname to /etc/hostname
     sline = opts['hostname'].split('.', 1)
-    hostname = '{0}\n' . format(sline[0])
+    opts['hostname'] = sline[0]
+    hostname = '{0}\n' . format(opts['hostname'])
     current_domainname = current_network_settings['domainname']
 
     # Only write the hostname if it has changed


### PR DESCRIPTION
On Debian, the file `/etc/hostname` is always updated, even when the hostname doesn't change.
Also, the value shown for `HOSTNAME` is incorrect:

```
server.example.tld:
----------
          ID: hostname
    Function: network.system
      Result: True
     Comment: Global network settings are up to date.
     Started: 21:06:09.238698
    Duration: 13.059 ms
     Changes:   
              ----------
              network_settings:
                  --- 
                  +++ 
                  @@ -1,3 +1,3 @@
                   NETWORKING=yes

                  -HOSTNAME=server

                  +HOSTNAME=server.example.tld

                   DOMAIN=example.tld
```

This pull request fixes that.
