### PR TITLE
Add details to first line of top docs

### DIFF
--- a/doc/ref/states/top.rst
+++ b/doc/ref/states/top.rst
@@ -4,10 +4,10 @@
 The Top File
 ============
 
-The top file is used to map what SLS modules get loaded onto what minions via
-the state system. The top file creates a few general abstractions. First it
-maps what nodes should pull from which environments, next it defines which
-matches systems should draw from.
+The top file (top.sls) is used to map what SLS modules get loaded onto what 
+minions via the state system. The top file creates a few general abstractions.
+First it maps what nodes should pull from which environments, next it defines
+which matches systems should draw from.
 
 .. _states-top-environments:
 


### PR DESCRIPTION
We don't specify the top.sls in the first sentence which can be mildly confusing.
