### PR TITLE
Fix wrongly passed around 'location' in EC2 cloud, resulting in us-ea…

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1987,6 +1987,7 @@ def wait_for_instance(
                 console = get_console_output(
                     instance_id=vm_['instance_id'],
                     call='action',
+                    location=get_location(vm_)
                 )
                 pprint.pprint(console)
                 time.sleep(5)
@@ -2446,6 +2447,9 @@ def set_tags(name=None,
     if kwargs is None:
         kwargs = {}
 
+    if location is None:
+        location = get_location()
+
     if instance_id is None:
         if 'resource_id' in kwargs:
             resource_id = kwargs['resource_id']
@@ -2484,7 +2488,7 @@ def set_tags(name=None,
     while attempts >= 0:
         result = aws.query(params,
                            setname='tagSet',
-                           location=get_location(),
+                           location=location,
                            provider=get_provider(),
                            opts=__opts__,
                            sigver='4')
@@ -3840,6 +3844,7 @@ def describe_snapshots(kwargs=None, call=None):
 
 def get_console_output(
         name=None,
+        location=None,
         instance_id=None,
         call=None,
         kwargs=None,
@@ -3855,6 +3860,9 @@ def get_console_output(
             'The get_console_output action must be called with '
             '-a or --action.'
         )
+
+    if location is None:
+        location = get_location()
 
     if not instance_id:
         instance_id = _get_node(name)[name]['instanceId']
@@ -3872,7 +3880,7 @@ def get_console_output(
 
     ret = {}
     data = aws.query(params,
-                     location=get_location(),
+                     location=location,
                      provider=get_provider(),
                      opts=__opts__,
                      sigver='4')


### PR DESCRIPTION
location variable defaults to us-east-1 when creating VMs through map in ec2 driver, in at least these two codepaths
- set_tags 
- get_console_output, which is called when known_hosts was set

looking around in ec2.py, there might be other instances where this could happen. 

Also, aws.query might benefit from a wrapper function that does more consistent checking of returned errors, like in :
        data = aws.query( ... ) 
        if isinstance(data, dict) and 'error' in data:

I could not figure out why my get_console_ was failing.
