### PR TITLE
How to still use existing $PATH in "cmd" modules

### DIFF
--- a/doc/man/salt.7
+++ b/doc/man/salt.7
@@ -139505,6 +139505,22 @@ bar-script:
     - env: "PATH=/some/path:$PATH"
 .UNINDENT
 .UNINDENT
+.sp
+One can still use the existing $PATH with the help of some Jinja code:
+.INDENT 7.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+% set current_path = salt['environ.get']('PATH', '/bin:/usr/bin') %}
+
+mycommand:
+  cmd.run:
+    - name: ls -l /
+    - env:
+      - PATH: {{ [current_path, '/my/special/bin']|join(':') }}
+.UNINDENT
+.UNINDENT
 .TP
 .B stateful
 The command being executed is expected to return data about executing
@@ -139649,6 +139665,22 @@ literal '$PATH':
     - env: "PATH=/some/path:$PATH"
 .UNINDENT
 .UNINDENT
+.sp
+One can still use the existing $PATH with the help of some Jinja code:
+.INDENT 7.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+% set current_path = salt['environ.get']('PATH', '/bin:/usr/bin') %}
+
+mycommand:
+  cmd.run:
+    - name: ls -l /
+    - env:
+      - PATH: {{ [current_path, '/my/special/bin']|join(':') }}
+.UNINDENT
+.UNINDENT
 .TP
 .B umask
 The umask (in octal) to use when running the command.
@@ -139753,6 +139785,22 @@ literal '$PATH':
 script-bar:
   cmd.wait:
     - env: "PATH=/some/path:$PATH"
+.UNINDENT
+.UNINDENT
+.sp
+One can still use the existing $PATH with the help of some Jinja code:
+.INDENT 7.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+% set current_path = salt['environ.get']('PATH', '/bin:/usr/bin') %}
+
+mycommand:
+  cmd.run:
+    - name: ls -l /
+    - env:
+      - PATH: {{ [current_path, '/my/special/bin']|join(':') }}
 .UNINDENT
 .UNINDENT
 .TP
@@ -139865,6 +139913,22 @@ literal '$PATH':
  salt://scripts/bar.sh:
   cmd.wait_script:
     - env: "PATH=/some/path:$PATH"
+.UNINDENT
+.UNINDENT
+.sp
+One can still use the existing $PATH with the help of some Jinja code:
+.INDENT 7.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+% set current_path = salt['environ.get']('PATH', '/bin:/usr/bin') %}
+
+mycommand:
+  cmd.run:
+    - name: ls -l /
+    - env:
+      - PATH: {{ [current_path, '/my/special/bin']|join(':') }}
 .UNINDENT
 .UNINDENT
 .TP

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -451,6 +451,18 @@ def wait(name,
               cmd.wait:
                 - env: "PATH=/some/path:$PATH"
 
+        One can still use the existing $PATH by using a bit of Jinja:
+
+        .. code-block:: yaml
+
+            {% set current_path = salt['environ.get']('PATH', '/bin:/usr/bin') %}
+
+            mycommand:
+              cmd.run:
+                - name: ls -l /
+                - env:
+                  - PATH: {{ [current_path, '/my/special/bin']|join(':') }}
+
     umask
          The umask (in octal) to use when running the command.
 
@@ -568,6 +580,18 @@ def wait_script(name,
               cmd.wait_script:
                 - env: "PATH=/some/path:$PATH"
 
+        One can still use the existing $PATH by using a bit of Jinja:
+
+        .. code-block:: yaml
+
+            {% set current_path = salt['environ.get']('PATH', '/bin:/usr/bin') %}
+
+            mycommand:
+              cmd.run:
+                - name: ls -l /
+                - env:
+                  - PATH: {{ [current_path, '/my/special/bin']|join(':') }}
+
     umask
          The umask (in octal) to use when running the command.
 
@@ -666,6 +690,18 @@ def run(name,
             script-bar:
               cmd.run:
                 - env: "PATH=/some/path:$PATH"
+
+        One can still use the existing $PATH by using a bit of Jinja:
+
+        .. code-block:: yaml
+
+            {% set current_path = salt['environ.get']('PATH', '/bin:/usr/bin') %}
+
+            mycommand:
+              cmd.run:
+                - name: ls -l /
+                - env:
+                  - PATH: {{ [current_path, '/my/special/bin']|join(':') }}
 
     stateful
         The command being executed is expected to return data about executing
@@ -880,6 +916,18 @@ def script(name,
             salt://scripts/bar.sh:
               cmd.script:
                 - env: "PATH=/some/path:$PATH"
+
+        One can still use the existing $PATH by using a bit of Jinja:
+
+        .. code-block:: yaml
+
+            {% set current_path = salt['environ.get']('PATH', '/bin:/usr/bin') %}
+
+            mycommand:
+              cmd.run:
+                - name: ls -l /
+                - env:
+                  - PATH: {{ [current_path, '/my/special/bin']|join(':') }}
 
     umask
          The umask (in octal) to use when running the command.


### PR DESCRIPTION
Enhances #21840

Added a code example on how to still use the existing $PATH environment
variables in cmd modules. The code was taken from a mail from Ethan
Erchinger to the salt-users list.
