### PR TITLE
Fix regression of #21355 introduced by #21603

### DIFF
--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -163,7 +163,7 @@ def present(
         fullkey = sshre.search(name)
         # if it is {key} [comment]
         if not fullkey:
-            key_and_comment = name.split()
+            key_and_comment = name.split(None, 1)
             name = key_and_comment[0]
             if len(key_and_comment) == 2:
                 comment = key_and_comment[1]
@@ -172,7 +172,7 @@ def present(
             if fullkey.group(1):
                 options = fullkey.group(1).split(',')
             # key is of format: {enc} {key} [comment]
-            comps = fullkey.group(2).split()
+            comps = fullkey.group(2).split(None, 2)
             enc = comps[0]
             name = comps[1]
             if len(comps) == 3:


### PR DESCRIPTION
This fixes the regression introduced by #21603 failing to parse spaced key comments.

Since #21603 related to keys without comments, care should be taken with this; I've now tested it on my keys and it works in all cases, but IIRC that was already the case.
