### PR TITLE
Fix salt.state.file._unify_sources_and_hashes when sources is used without sources_hashes

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -243,6 +243,7 @@ import pprint
 import shutil
 import traceback
 import yaml
+from itertools import izip_longest
 
 # Import salt libs
 import salt.payload
@@ -255,7 +256,6 @@ from salt.utils.serializers import json as json_serializer
 
 # Import 3rd-party libs
 import salt.ext.six as six
-from salt.ext.six.moves import map  # pylint: disable=import-error,redefined-builtin
 
 log = logging.getLogger(__name__)
 
@@ -634,7 +634,7 @@ def _unify_sources_and_hashes(source=None, source_hash=None,
         return (True, '', [(source, source_hash)])
 
     # Make a nice neat list of tuples exactly len(sources) long..
-    return True, '', list(map(None, sources, source_hashes[:len(sources)]))
+    return True, '', list(izip_longest(sources, source_hashes[:len(sources)]))
 
 
 def _get_template_texts(source_list=None,

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -243,7 +243,6 @@ import pprint
 import shutil
 import traceback
 import yaml
-from itertools import izip_longest
 
 # Import salt libs
 import salt.payload

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -256,6 +256,7 @@ from salt.utils.serializers import json as json_serializer
 
 # Import 3rd-party libs
 import salt.ext.six as six
+from salt.ext.six.moves import zip_longest
 
 log = logging.getLogger(__name__)
 
@@ -634,7 +635,7 @@ def _unify_sources_and_hashes(source=None, source_hash=None,
         return (True, '', [(source, source_hash)])
 
     # Make a nice neat list of tuples exactly len(sources) long..
-    return True, '', list(izip_longest(sources, source_hashes[:len(sources)]))
+    return True, '', list(zip_longest(sources, source_hashes[:len(sources)]))
 
 
 def _get_template_texts(source_list=None,


### PR DESCRIPTION
Following this commit (https://github.com/saltstack/salt/commit/ebea0cf05ea2eaf37916a71d42b112978ca9383d#diff-3b447dc835943beb1326f98f684fe783L489), method _unify_sources_and_hashes now uses itertools.imap instead of the traditional python2.X map.

It's used here (https://github.com/saltstack/salt/blob/v2015.5.0/salt/states/file.py#L661) when sources is used.

The issue occurred when sources is used and when sources_hashes is empty.

The problem is that python 2.X map and imap + python 3.X map doesn't expose the same behavior with None function.

In python 2.X:

```
x = [1, 2]
y = []
list(map(None, x, y))
```

Output:

```
[(1, None), (2, None)]
```

In python 3.X or with itertools.imap:

```
x = [1, 2]
y = []
list(imap(None, x, y))
```

Output:

```
[]
```

It looks like it's a known issue in python (http://bugs.python.org/issue2186) so my proposition is to use izip_longest instead which seems to do what we want to is moreover more explicit.

A possible workaround is to set some random sources_hashes (I set WORKAROUND_QUICK_FIX_SALT_2015.5.0 for example) as the hash of sources is not used when we get the templates (https://github.com/saltstack/salt/blob/v2015.5.0/salt/states/file.py#L686).
