### PR TITLE
virtual returning none warning fixed in dev but missed in 2015.5

### DIFF
--- a/salt/modules/serverdensity_device.py
+++ b/salt/modules/serverdensity_device.py
@@ -30,7 +30,7 @@ def __virtual__():
     '''
     if not HAS_REQUESTS:
         return False
-
+    return "serverdensity_device"
 
 def get_sd_auth(val, sd_auth_pillar_name='serverdensity'):
     '''


### PR DESCRIPTION
didn't open issue because this is already fixed in dev but was missed back in 2015.5 so its blowing warning chunks all over in 2015.5
[WARNING ] salt.loaded.int.module.serverdensity_device.**virtual**() is wrongly returning `None`. It should either return `True`, `False` or a new name. If you're the developer of the module 'serverdensity_device', please fix this.
