### PR TITLE
ssh: AuthorizedKeysFile expands defined tokens

### DIFF
--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -29,6 +29,7 @@ to use a YAML 'explicit key', as demonstrated in the second example below.
       ssh_auth.present:
         - user: root
         - source: salt://ssh_keys/thatch.id_rsa.pub
+        - config: %h/.ssh/authorized_keys
 
     sshkeys:
       ssh_auth.present:
@@ -239,7 +240,8 @@ def present(
 
     config
         The location of the authorized keys file relative to the user's home
-        directory, defaults to ".ssh/authorized_keys"
+        directory, defaults to ".ssh/authorized_keys". Token expansion %u and
+        %h for username and home path supported.
     '''
     ret = {'name': name,
            'changes': {},
@@ -382,7 +384,9 @@ def absent(name,
 
     config
         The location of the authorized keys file relative to the user's home
-        directory, defaults to ".ssh/authorized_keys"
+        directory, defaults to ".ssh/authorized_keys". Token expansion %u and
+        %h for username and home path supported.
+
     '''
     ret = {'name': name,
            'changes': {},

--- a/tests/unit/modules/ssh_test.py
+++ b/tests/unit/modules/ssh_test.py
@@ -29,6 +29,6 @@ class SSHAuthKeyPathTestCase(TestCase):
                 '/home/user')
         self.assertEqual(output, '/home//home/user')
 
-        output = ssh._expand_authorized_keys_path('/srv/%h/aaa/%u%%', 'user', 
+        output = ssh._expand_authorized_keys_path('/srv/%h/aaa/%u%%', 'user',
                 '/home/user')
         self.assertEqual(output, '/srv//home/user/aaa/user%')

--- a/tests/unit/modules/ssh_test.py
+++ b/tests/unit/modules/ssh_test.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+# import Python Libs
+from __future__ import absolute_import
+
+# Import Salt Testing Libs
+from salttesting import TestCase
+from salttesting.helpers import ensure_in_syspath
+
+# Import Salt Libs
+ensure_in_syspath('../../')
+from salt.modules import ssh
+
+
+class SSHAuthKeyPathTestCase(TestCase):
+    '''
+    TestCase for salt.modules.ssh module's ssh AuthorizedKeysFile path
+    expansion
+    '''
+    def test_expand_user_token(self):
+        '''
+        Test if the %u token is correctly expanded
+        '''
+        output = ssh._expand_authorized_keys_path('/home/%u', 'user',
+                '/home/user')
+        self.assertEqual(output, '/home/user')
+
+        output = ssh._expand_authorized_keys_path('/home/%h', 'user',
+                '/home/user')
+        self.assertEqual(output, '/home//home/user')
+
+        output = ssh._expand_authorized_keys_path('/srv/%h/aaa/%u%%', 'user', 
+                '/home/user')
+        self.assertEqual(output, '/srv//home/user/aaa/user%')


### PR DESCRIPTION
The idea is that ssh supports %h and %u tokens, and it is a pain in the ass to make this from anywhere else, seen that ssh_auth state exists here.
