### PR TITLE
Support pillarenv cmdline in state.sls

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1118,7 +1118,8 @@ class AESFuncs(object):
             load['id'],
             load.get('saltenv', load.get('env')),
             ext=load.get('ext'),
-            pillar=load.get('pillar_override', {}))
+            pillar=load.get('pillar_override', {}),
+            pillarenv=load.get('pillarenv', None))
         data = pillar.compile_pillar(pillar_dirs=pillar_dirs)
         self.fs_.update_opts()
         if self.opts.get('minion_data_cache', False):

--- a/salt/master.py
+++ b/salt/master.py
@@ -1119,7 +1119,7 @@ class AESFuncs(object):
             load.get('saltenv', load.get('env')),
             ext=load.get('ext'),
             pillar=load.get('pillar_override', {}),
-            pillarenv=load.get('pillarenv', None))
+            pillarenv=load.get('pillarenv'))
         data = pillar.compile_pillar(pillar_dirs=pillar_dirs)
         self.fs_.update_opts()
         if self.opts.get('minion_data_cache', False):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -355,7 +355,8 @@ class SMinion(object):
             self.opts,
             self.opts['grains'],
             self.opts['id'],
-            self.opts['environment']
+            self.opts['environment'],
+            pillarenv=self.opts['pillarenv']
         ).compile_pillar()
         self.utils = salt.loader.utils(self.opts)
         self.functions = salt.loader.minion_mods(self.opts, utils=self.utils,
@@ -1308,6 +1309,7 @@ class Minion(MinionBase):
                 self.opts['grains'],
                 self.opts['id'],
                 self.opts['environment'],
+                pillarenv=self.opts['pillarenvv']
             ).compile_pillar()
         except SaltClientError:
             # Do not exit if a pillar refresh fails.
@@ -2455,7 +2457,8 @@ class ProxyMinion(Minion):
             opts,
             opts['grains'],
             opts['id'],
-            opts['environment']
+            opts['environment'],
+            pillarenv=opts['pillarenv']
         ).compile_pillar()
         self.functions, self.returners, self.function_errors = self._load_modules()
         self.serial = salt.payload.Serial(self.opts)

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -356,7 +356,7 @@ class SMinion(object):
             self.opts['grains'],
             self.opts['id'],
             self.opts['environment'],
-            pillarenv=self.opts['pillarenv']
+            pillarenv=self.opts.get('pillarenv')
         ).compile_pillar()
         self.utils = salt.loader.utils(self.opts)
         self.functions = salt.loader.minion_mods(self.opts, utils=self.utils,
@@ -602,7 +602,8 @@ class Minion(MinionBase):
             self.opts,
             self.opts['grains'],
             self.opts['id'],
-            self.opts['environment']
+            self.opts['environment'],
+            self.opts.get('pillarenv')
         ).compile_pillar()
         self.functions, self.returners, self.function_errors = self._load_modules()
         self.serial = salt.payload.Serial(self.opts)
@@ -1309,7 +1310,7 @@ class Minion(MinionBase):
                 self.opts['grains'],
                 self.opts['id'],
                 self.opts['environment'],
-                pillarenv=self.opts['pillarenvv']
+                pillarenv=self.opts.get('pillarenv')
             ).compile_pillar()
         except SaltClientError:
             # Do not exit if a pillar refresh fails.
@@ -2458,7 +2459,7 @@ class ProxyMinion(Minion):
             opts['grains'],
             opts['id'],
             opts['environment'],
-            pillarenv=opts['pillarenv']
+            pillarenv=opts.get('pillarenv')
         ).compile_pillar()
         self.functions, self.returners, self.function_errors = self._load_modules()
         self.serial = salt.payload.Serial(self.opts)

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -538,6 +538,7 @@ def sls(mods,
         exclude=None,
         queue=False,
         env=None,
+        pillarenv=None,
         **kwargs):
     '''
     Execute a set list of state files from an environment.
@@ -594,10 +595,18 @@ def sls(mods,
         # Backwards compatibility
         saltenv = env
     if not saltenv:
-        if __opts__.get('saltenv', None):
-            saltenv = __opts__['saltenv']
+        if __opts__.get('environment', None):
+            saltenv = __opts__['environment']
         else:
             saltenv = 'base'
+    else:
+        __opts__['environment'] = saltenv
+
+    if not pillarenv:
+        if __opts__.get('pillarenv', None):
+            pillarenv = __opts__['pillarenv']
+    else:
+        __opts__['pillarenv'] = pillarenv
 
     if queue:
         _wait(kwargs.get('__pub_jid'))

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -505,6 +505,9 @@ def highstate(test=None,
             'Pillar data must be formatted as a dictionary'
         )
 
+    if 'pillarenv' in kwargs:
+        opts['pillarenv'] = kwargs['pillarenv']
+
     st_ = salt.state.HighState(opts, pillar, kwargs.get('__pub_jid'))
     st_.push_active()
     try:
@@ -566,6 +569,9 @@ def sls(mods,
             Defaults to None. If no saltenv is specified, the minion config will
             be checked for a saltenv and if found, it will be used. If none is found,
             base will be used.
+    pillarenv : None
+        Specify a ``pillar_roots`` environment. By default all pillar environments
+        merged together will be used.
     concurrent:
         WARNING: This flag is potentially dangerous. It is designed
         for use when multiple state runs can safely be run at the same

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -855,6 +855,8 @@ def sls_id(
         opts['test'] = True
     else:
         opts['test'] = __opts__.get('test', None)
+    if 'pillarenv' in kwargs:
+        opts['pillarenv'] = kwargs['pillarenv']
     st_ = salt.state.HighState(opts)
     if isinstance(mods, six.string_types):
         split_mods = mods.split(',')
@@ -917,6 +919,8 @@ def show_low_sls(mods,
         opts['test'] = True
     else:
         opts['test'] = __opts__.get('test', None)
+    if 'pillarenv' in kwargs:
+        opts['pillarenv'] = kwargs['pillarenv']
     st_ = salt.state.HighState(opts)
     if isinstance(mods, six.string_types):
         mods = mods.split(',')
@@ -977,6 +981,9 @@ def show_sls(mods, saltenv='base', test=None, queue=False, env=None, **kwargs):
         raise SaltInvocationError(
             'Pillar data must be formatted as a dictionary'
         )
+
+    if 'pillarenv' in kwargs:
+        opts['pillarenv'] = kwargs['pillarenv']
 
     st_ = salt.state.HighState(opts, pillar)
     if isinstance(mods, six.string_types):

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -289,7 +289,7 @@ class Pillar(object):
                                 ),
                             self.rend,
                             self.opts['renderer'],
-                            self.opts['pillarenv']
+                            self.opts['pillarenv'],
                             _pillar_rend=True
                             )
                         ]

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -32,7 +32,7 @@ log = logging.getLogger(__name__)
 
 
 def get_pillar(opts, grains, id_, saltenv=None, ext=None, env=None, funcs=None,
-               pillar=None):
+               pillar=None, pillarenv=None):
     '''
     Return the correct pillar driver based on the file_client option
     '''
@@ -49,12 +49,12 @@ def get_pillar(opts, grains, id_, saltenv=None, ext=None, env=None, funcs=None,
         'local': Pillar
     }.get(opts['file_client'], Pillar)
     return ptype(opts, grains, id_, saltenv, ext, functions=funcs,
-                 pillar=pillar)
+                 pillar=pillar, pillarenv=pillarenv)
 
 
 # TODO: migrate everyone to this one!
 def get_async_pillar(opts, grains, id_, saltenv=None, ext=None, env=None, funcs=None,
-               pillar=None):
+               pillar=None, pillarenv=None):
     '''
     Return the correct pillar driver based on the file_client option
     '''
@@ -71,7 +71,7 @@ def get_async_pillar(opts, grains, id_, saltenv=None, ext=None, env=None, funcs=
         #'local': AsyncPillar  # TODO: implement
     }.get(opts['file_client'], Pillar)
     return ptype(opts, grains, id_, saltenv, ext, functions=funcs,
-                 pillar=pillar)
+                 pillar=pillar, pillarenv=pillarenv)
 
 
 class AsyncRemotePillar(object):
@@ -79,13 +79,14 @@ class AsyncRemotePillar(object):
     Get the pillar from the master
     '''
     def __init__(self, opts, grains, id_, saltenv, ext=None, functions=None,
-                 pillar=None):
+                 pillar=None, pillarenv=None):
         self.opts = opts
         self.opts['environment'] = saltenv
         self.ext = ext
         self.grains = grains
         self.id_ = id_
         self.channel = salt.transport.client.AsyncReqChannel.factory(opts)
+        self.opts['pillarenv'] = pillarenv
         self.pillar_override = {}
         if pillar is not None:
             if isinstance(pillar, dict):
@@ -101,6 +102,7 @@ class AsyncRemotePillar(object):
         load = {'id': self.id_,
                 'grains': self.grains,
                 'saltenv': self.opts['environment'],
+                'pillarenv': self.opts['pillarenv'],
                 'pillar_override': self.pillar_override,
                 'ver': '2',
                 'cmd': '_pillar'}
@@ -125,13 +127,14 @@ class RemotePillar(object):
     Get the pillar from the master
     '''
     def __init__(self, opts, grains, id_, saltenv, ext=None, functions=None,
-                 pillar=None):
+                 pillar=None, pillarenv=None):
         self.opts = opts
         self.opts['environment'] = saltenv
         self.ext = ext
         self.grains = grains
         self.id_ = id_
         self.channel = salt.transport.Channel.factory(opts)
+        self.opts['pillarenv'] = pillarenv
         self.pillar_override = {}
         if pillar is not None:
             if isinstance(pillar, dict):
@@ -146,6 +149,7 @@ class RemotePillar(object):
         load = {'id': self.id_,
                 'grains': self.grains,
                 'saltenv': self.opts['environment'],
+                'pillarenv': self.opts['pillarenv'],
                 'pillar_override': self.pillar_override,
                 'ver': '2',
                 'cmd': '_pillar'}
@@ -169,11 +173,11 @@ class Pillar(object):
     Read over the pillar top files and render the pillar data
     '''
     def __init__(self, opts, grains, id_, saltenv, ext=None, functions=None,
-                 pillar=None):
+                 pillar=None, pillarenv=None):
         # Store the file_roots path so we can restore later. Issue 5449
         self.actual_file_roots = opts['file_roots']
         # use the local file client
-        self.opts = self.__gen_opts(opts, grains, id_, saltenv, ext)
+        self.opts = self.__gen_opts(opts, grains, id_, saltenv=saltenv, ext=ext, pillarenv=pillarenv)
         self.client = salt.fileclient.get_file_client(self.opts, True)
 
         if opts.get('file_client', '') == 'local':
@@ -219,7 +223,7 @@ class Pillar(object):
             return {}
         return ext
 
-    def __gen_opts(self, opts_in, grains, id_, saltenv=None, ext=None, env=None):
+    def __gen_opts(self, opts_in, grains, id_, saltenv=None, ext=None, env=None, pillarenv=None):
         '''
         The options need to be altered to conform to the file client
         '''
@@ -242,6 +246,8 @@ class Pillar(object):
         opts['id'] = id_
         if 'environment' not in opts:
             opts['environment'] = saltenv
+        if pillarenv not in opts:
+            opts['pillarenv'] = pillarenv
         if opts['state_top'].startswith('salt://'):
             opts['state_top'] = opts['state_top']
         elif opts['state_top'].startswith('/'):
@@ -274,16 +280,16 @@ class Pillar(object):
         errors = []
         # Gather initial top files
         try:
-            if self.opts['environment']:
-                tops[self.opts['environment']] = [
+            if self.opts['pillarenv']:
+                tops[self.opts['pillarenv']] = [
                         compile_template(
                             self.client.cache_file(
                                 self.opts['state_top'],
-                                self.opts['environment']
+                                self.opts['pillarenv']
                                 ),
                             self.rend,
                             self.opts['renderer'],
-                            self.opts['environment'],
+                            self.opts['pillarenv']
                             _pillar_rend=True
                             )
                         ]
@@ -426,8 +432,8 @@ class Pillar(object):
         '''
         matches = {}
         for saltenv, body in six.iteritems(top):
-            if self.opts['environment']:
-                if saltenv != self.opts['environment']:
+            if self.opts['pillarenv']:
+                if saltenv != self.opts['pillarenv']:
                     continue
             for match, data in six.iteritems(body):
                 if self.matcher.confirm_top(

--- a/salt/state.py
+++ b/salt/state.py
@@ -617,7 +617,7 @@ class State(object):
                 self.opts['id'],
                 self.opts['environment'],
                 pillar=self._pillar_override,
-                pillarenv=self.opts['pillarenv']
+                pillarenv=self.opts.get('pillarenv')
                 )
         ret = pillar.compile_pillar()
         if self._pillar_override and isinstance(self._pillar_override, dict):

--- a/salt/state.py
+++ b/salt/state.py
@@ -616,7 +616,8 @@ class State(object):
                 self.opts['grains'],
                 self.opts['id'],
                 self.opts['environment'],
-                pillar=self._pillar_override
+                pillar=self._pillar_override,
+                pillarenv=self.opts['pillarenv']
                 )
         ret = pillar.compile_pillar()
         if self._pillar_override and isinstance(self._pillar_override, dict):


### PR DESCRIPTION
Currently highstate is broken, I'd continue work on it. Pillarenv option works, for instance the following works: `salt '*' state.sls test saltenv=base pillarenv=pillar_dev`
This pull request is just for code review at this moment. I'd very appreciate if somebody will have a minute to take a look at the code just to confirm I'm in the right way.
