### PR TITLE
fix #23695

### DIFF
--- a/requirements/zeromq.txt
+++ b/requirements/zeromq.txt
@@ -1,4 +1,4 @@
 -r base.txt
 
-pycrypto
+pycrypto >= 2.1.0
 pyzmq >= 2.2.0

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -36,7 +36,10 @@ from salt.ext.six import string_types
 from salt.template import compile_template
 
 # Import third party libs
-import Crypto.Random
+try:
+    import Crypto.Random
+except ImportError:
+    pass  # pycrypto < 2.1
 import yaml
 import salt.ext.six as six
 from salt.ext.six.moves import input  # pylint: disable=import-error,redefined-builtin
@@ -2232,7 +2235,8 @@ def run_parallel_map_providers_query(data, queue=None):
     This function will be called from another process when building the
     providers map.
     '''
-    Crypto.Random.atfork()
+    if 'Crypto.Random' in sys.modules:
+        Crypto.Random.atfork()
 
     cloud = Cloud(data['opts'])
     try:

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -14,6 +14,7 @@ import signal
 import logging
 import traceback
 import multiprocessing
+import sys
 from itertools import groupby
 
 # Import salt.cloud libs

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -36,6 +36,7 @@ from salt.ext.six import string_types
 from salt.template import compile_template
 
 # Import third party libs
+import Crypto.Random
 import yaml
 import salt.ext.six as six
 from salt.ext.six.moves import input  # pylint: disable=import-error,redefined-builtin
@@ -2231,12 +2232,7 @@ def run_parallel_map_providers_query(data, queue=None):
     This function will be called from another process when building the
     providers map.
     '''
-    try:
-        import Crypto.Random  # pylint: disable=E0611
-        Crypto.Random.atfork()
-    except ImportError:
-        # PyCrypto version < 2.1
-        pass
+    Crypto.Random.atfork()
 
     cloud = Cloud(data['opts'])
     try:

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -361,7 +361,8 @@ class AsyncAuth(object):
 
         self.io_loop = io_loop or tornado.ioloop.IOLoop.current()
 
-        Crypto.Random.atfork()
+        if 'Crypto.Random' in sys.modules:
+            Crypto.Random.atfork()
         key = self.__key(self.opts)
         # TODO: if we already have creds for this key, lets just re-use
         if key in AsyncAuth.creds_map:

--- a/salt/master.py
+++ b/salt/master.py
@@ -18,7 +18,10 @@ import multiprocessing
 # Import third party libs
 import zmq
 from Crypto.PublicKey import RSA
-import Crypto.Random
+try:
+    import Crypto.Random
+except ImportError:
+    pass
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 import salt.ext.six as six
 from salt.ext.six.moves import range
@@ -746,7 +749,8 @@ class MWorker(multiprocessing.Process):
             self.key,
             )
         self.aes_funcs = AESFuncs(self.opts)
-        Crypto.Random.atfork()
+        if 'Crypto.Random' in sys.modules:
+            Crypto.Random.atfork()
         self.__bind()
 
 


### PR DESCRIPTION
- require pycrypto >= 2.1.0 in requirements/zeromq.txt
- remove old workaround for pycrypto < 2.1 from salt/cloud/**init**.py
