### PR TITLE
always load pip execution module

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -601,11 +601,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
 
     if pre_releases:
         # Check the locally installed pip version
-        pip_version_cmd = '{0} --version'.format(pip_bin)
-        output = __salt__['cmd.run_all'](pip_version_cmd,
-                                         use_vt=use_vt,
-                                         python_shell=False).get('stdout', '')
-        pip_version = output.split()[1]
+        pip_version = version(pip_bin)
 
         # From pip v1.4 the --pre flag is available
         if salt.utils.compare_versions(ver1=pip_version, oper='>=', ver2='1.4'):
@@ -884,7 +880,6 @@ def list_(prefix=None,
 
     pip_bin = _get_pip_bin(bin_env)
 
-    pip_version_cmd = [pip_bin, '--version']
     cmd = [pip_bin, 'freeze']
 
     cmd_kwargs = dict(runas=user, cwd=cwd, python_shell=False)
@@ -892,11 +887,7 @@ def list_(prefix=None,
         cmd_kwargs['env'] = {'VIRTUAL_ENV': bin_env}
 
     if not prefix or prefix in ('p', 'pi', 'pip'):
-        pip_version_result = __salt__['cmd.run_all'](' '.join(pip_version_cmd),
-                                                     **cmd_kwargs)
-        if pip_version_result['retcode'] > 0:
-            raise CommandExecutionError(pip_version_result['stderr'])
-        packages['pip'] = pip_version_result['stdout'].split()[1]
+        packages['pip'] = version(bin_env)
 
     result = __salt__['cmd.run_all'](' '.join(cmd), **cmd_kwargs)
     if result['retcode'] > 0:

--- a/tests/integration/modules/pip.py
+++ b/tests/integration/modules/pip.py
@@ -54,10 +54,10 @@ class PipModuleTest(integration.ModuleCase):
         # Let's run a pip depending functions
         for func in ('pip.freeze', 'pip.list'):
             ret = self.run_function(func, bin_env=self.venv_dir)
-            self.assertEqual(
-                ret,
-                'Command required for \'{0}\' not found: Could not find '
-                'a `pip` binary'.format(func)
+            self.assertIn(
+                'Command required for \'{0}\' not found: '
+                'Could not find a `pip` binary in virtualenv'.format(func),
+                ret
             )
 
     @skipIf(os.geteuid() != 0, 'you must be root to run this test')

--- a/tests/unit/modules/pip_test.py
+++ b/tests/unit/modules/pip_test.py
@@ -944,38 +944,38 @@ class PipTestCase(TestCase):
             'bbfreeze-loader==1.1.0',
             'pycrypto==2.6'
         ]
-        mock = MagicMock(
-            side_effect=[
-                {'retcode': 0, 'stdout': 'pip MOCKED_VERSION'},
-                {'retcode': 0, 'stdout': '\n'.join(eggs)}
-            ]
-        )
+        mock_version = '6.1.1'
+        mock = MagicMock(return_value={'retcode': 0, 'stdout': '\n'.join(eggs)})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
-            ret = pip.list_()
-            mock.assert_called_with(
-                'pip freeze',
-                runas=None,
-                cwd=None,
-                python_shell=False,
-            )
-            self.assertEqual(
-                ret, {
-                    'SaltTesting-dev': 'git+git@github.com:s0undt3ch/salt-testing.git@9ed81aa2f918d59d3706e56b18f0782d1ea43bf8',
-                    'M2Crypto': '0.21.1',
-                    'bbfreeze-loader': '1.1.0',
-                    'bbfreeze': '1.1.0',
-                    'pip': 'MOCKED_VERSION',
-                    'pycrypto': '2.6'
-                }
-            )
+            with patch('salt.modules.pip.version',
+                       MagicMock(return_value=mock_version)):
+                ret = pip.list_()
+                mock.assert_called_with(
+                    'pip freeze',
+                    runas=None,
+                    cwd=None,
+                    python_shell=False,
+                )
+                self.assertEqual(
+                    ret, {
+                        'SaltTesting-dev': 'git+git@github.com:s0undt3ch/salt-testing.git@9ed81aa2f918d59d3706e56b18f0782d1ea43bf8',
+                        'M2Crypto': '0.21.1',
+                        'bbfreeze-loader': '1.1.0',
+                        'bbfreeze': '1.1.0',
+                        'pip': mock_version,
+                        'pycrypto': '2.6'
+                    }
+                )
 
         # Non zero returncode raises exception?
         mock = MagicMock(return_value={'retcode': 1, 'stderr': 'CABOOOOMMM!'})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
-            self.assertRaises(
-                CommandExecutionError,
-                pip.list_,
-            )
+            with patch('salt.modules.pip.version',
+                       MagicMock(return_value='6.1.1')):
+                self.assertRaises(
+                    CommandExecutionError,
+                    pip.list_,
+                )
 
     def test_list_command_with_prefix(self):
         eggs = [
@@ -1014,34 +1014,35 @@ class PipTestCase(TestCase):
             {'retcode': 0, 'stdout': ''}
         ])
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
-            pip.install(
-                'pep8', pre_releases=True
-            )
-            mock.assert_called_with(
-                'pip install \'pep8\'',
-                saltenv='base',
-                runas=None,
-                cwd=None,
-                use_vt=False,
-                python_shell=False,
-            )
+            with patch('salt.modules.pip.version',
+                       MagicMock(return_value='1.3')):
+                pip.install(
+                    'pep8', pre_releases=True
+                )
+                mock.assert_called_with(
+                    'pip install \'pep8\'',
+                    saltenv='base',
+                    runas=None,
+                    cwd=None,
+                    use_vt=False,
+                    python_shell=False,
+                )
 
-        mock = MagicMock(side_effect=[
-            {'retcode': 0, 'stdout': 'pip 1.4.0 /path/to/site-packages/pip'},
-            {'retcode': 0, 'stdout': ''}
-        ])
-        with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
-            pip.install(
-                'pep8', pre_releases=True
-            )
-            mock.assert_called_with(
-                'pip install --pre \'pep8\'',
-                saltenv='base',
-                runas=None,
-                cwd=None,
-                use_vt=False,
-                python_shell=False,
-            )
+        mock_run = MagicMock(return_value='pip 1.4.1 /path/to/site-packages/pip')
+        mock_run_all = MagicMock(return_value={'retcode': 0, 'stdout': ''})
+        with patch.dict(pip.__salt__, {'cmd.run': mock_run,
+                                       'cmd.run_all': mock_run_all}):
+            with patch('salt.modules.pip._get_pip_bin',
+                       MagicMock(return_value='pip')):
+                pip.install('pep8', pre_releases=True)
+                mock_run_all.assert_called_with(
+                    'pip install --pre \'pep8\'',
+                    saltenv='base',
+                    runas=None,
+                    cwd=None,
+                    use_vt=False,
+                    python_shell=False,
+                )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #23682.  Salt cannot know at load time whether pip is installed, but if a user has pip located in a virtualenv or some other obscure location, they should still be able to use the pip module and state by supplying an appropriate `bin_env` as necessary.
