### PR TITLE
Binary write

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1015,7 +1015,7 @@ def fopen(*args, **kwargs):
     NB! We still have small race condition between open and fcntl.
 
     '''
-    # Remove lock, uid, gid and mode from kwargs if present
+    # Remove lock from kwargs if present
     lock = kwargs.pop('lock', False)
 
     if lock is True:

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1028,6 +1028,19 @@ def fopen(*args, **kwargs):
         )
         return flopen(*args, **kwargs)
 
+    # ensure 'binary' mode is always used on windows
+    if is_windows():
+        if len(args) > 1:
+            args = list(args)
+            if 'b' not in args[1]:
+                args[1] += 'b'
+        elif kwargs.get('mode', None):
+            if 'b' not in kwargs['mode']:
+                kwargs['mode'] += 'b'
+        else:
+            # the default is to read
+            kwargs['mode'] = 'rb'
+
     fhandle = open(*args, **kwargs)
     if is_fcntl_available():
         # modify the file descriptor on systems with fcntl


### PR DESCRIPTION
At the event of this commit there are, including tests, 626 uses of
salt.utils.fopen in the salt codebase, 477 of which do not set binary
mode.  Files should always be written in binary mode on windows, so
ensure it always there for windows.  It most likely would not be a
problem for other systems, but to be safe, only set it for windows.  As
it is required on windows, we can solve all occurrences and potential
occurrences of this problem (#23566 for example) in one place.

@thatch45, @UtahDave
