### PR TITLE
[2014.7] Log salt-ssh roster render errors more assertively and verbosely

### DIFF
--- a/salt/renderers/yaml.py
+++ b/salt/renderers/yaml.py
@@ -47,7 +47,7 @@ def render(yaml_data, saltenv='base', sls='', argline='', **kws):
         try:
             data = load(yaml_data, Loader=get_yaml_loader(argline))
         except ScannerError as exc:
-            err_type = _ERROR_MAP.get(exc.problem, 'Unknown yaml render error')
+            err_type = _ERROR_MAP.get(exc.problem, exc.problem)
             line_num = exc.problem_mark.line + 1
             raise SaltRenderError(err_type, line_num, exc.problem_mark.buffer)
         except ConstructorError as exc:

--- a/salt/roster/__init__.py
+++ b/salt/roster/__init__.py
@@ -67,7 +67,7 @@ class Roster(object):
             try:
                 targets.update(self.rosters[f_str](tgt, tgt_type))
             except salt.exceptions.SaltRenderError as exc:
-                log.error('Unable to render roster file: {0}'.format(exc.error))
+                log.error('Unable to render roster file: {0}'.format(exc))
             except IOError as exc:
                 pass
 

--- a/salt/roster/__init__.py
+++ b/salt/roster/__init__.py
@@ -67,7 +67,7 @@ class Roster(object):
             try:
                 targets.update(self.rosters[f_str](tgt, tgt_type))
             except salt.exceptions.SaltRenderError as exc:
-                log.debug('Unable to render roster file: {0}'.format(exc.error))
+                log.error('Unable to render roster file: {0}'.format(exc.error))
             except IOError as exc:
                 pass
 


### PR DESCRIPTION
Fixes #22332 

Now, for a roster file like this:

```
basepi01:
  host:45.79.196.79
  user: root
```

We get something like this, rather than an "Unknown error" at debug log level:

```
root@li1305-77:~# salt-ssh '*' test.ping
[ERROR   ] Unable to render roster file: mapping values are not allowed here; line 3

---
basepi02:
  host:45.79.196.79
  user: root    <======================

---
No hosts found with target * of type glob
```
