### PR TITLE
Gate the new zmq.eventloop.ioloop imports for salt-ssh

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -28,6 +28,11 @@ from salt.ext.six.moves import range
 # Import third party libs
 try:
     import zmq
+    # TODO: cleanup
+    import zmq.eventloop.ioloop
+    # support pyzmq 13.0.x, TODO: remove once we force people to 14.0.x
+    if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
+        zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
     HAS_ZMQ = True
 except ImportError:
     # Running in local, zmq not needed
@@ -92,11 +97,6 @@ from salt.exceptions import (
 )
 
 
-# TODO: cleanup
-import zmq.eventloop.ioloop
-# support pyzmq 13.0.x, TODO: remove once we force people to 14.0.x
-if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
-    zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
 import tornado.gen  # pylint: disable=F0401
 import tornado.ioloop  # pylint: disable=F0401
 

--- a/salt/utils/async.py
+++ b/salt/utils/async.py
@@ -7,10 +7,13 @@ from __future__ import absolute_import
 
 import tornado.ioloop
 import tornado.concurrent
-import zmq.eventloop.ioloop
-# support pyzmq 13.0.x, TODO: remove once we force people to 14.0.x
-if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
-    zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
+try:
+    import zmq.eventloop.ioloop
+    # support pyzmq 13.0.x, TODO: remove once we force people to 14.0.x
+    if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
+        zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
+except ImportError:
+    pass # salt-ssh doesn't dep zmq
 
 import contextlib
 import weakref

--- a/salt/utils/async.py
+++ b/salt/utils/async.py
@@ -13,7 +13,7 @@ try:
     if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
         zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
 except ImportError:
-    pass # salt-ssh doesn't dep zmq
+    pass  # salt-ssh doesn't dep zmq
 
 import contextlib
 import weakref


### PR DESCRIPTION
Fixes #23340 
