### PR TITLE
instance_id being set to location instead of None. Causes rename to fail when using name.

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2498,7 +2498,7 @@ def set_tags(name=None,
 
         if resource_id is None:
             if instance_id is None:
-                instance_id = _get_node(name, location)[name]['instanceId']
+                instance_id = _get_node(name=name, instance_id=None, location=location)[name]['instanceId']
         else:
             instance_id = resource_id
 


### PR DESCRIPTION
```
salt-cloud -a rename test newname=test2
```

Fails with:

``` python
[ERROR   ] There was an error actioning machines: string indices must be integers, not str
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/cloud/cli.py", line 223, in run
    ret = mapper.do_action(names, kwargs)
  File "/usr/lib/python2.7/site-packages/salt/cloud/__init__.py", line 1456, in do_action
    vm_name, kwargs, call='action'
  File "/usr/lib/python2.7/site-packages/salt/cloud/clouds/ec2.py", line 2683, in rename
    set_tags(name, {'Name': kwargs['newname']}, call='action')
  File "/usr/lib/python2.7/site-packages/salt/cloud/clouds/ec2.py", line 2501, in set_tags
    instance_id = _get_node(name, location)[name]['instanceId']
  File "/usr/lib/python2.7/site-packages/salt/cloud/clouds/ec2.py", line 2904, in _get_node
    return _extract_instance_info(instances)
  File "/usr/lib/python2.7/site-packages/salt/cloud/clouds/ec2.py", line 2971, in _extract_instance_info
    if isinstance(instance['instancesSet']['item'], list):
TypeError: string indices must be integers, not str
```
