### PR TITLE
use abspath, do not eliminating symlinks

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -326,8 +326,8 @@ def _gen_keep_files(name, require):
         '''
         Check whether ``path`` is child of ``directory``
         '''
-        path = os.path.realpath(path)
-        directory = os.path.realpath(directory)
+        path = os.path.abspath(path)
+        directory = os.path.abspath(directory)
 
         relative = os.path.relpath(path, directory)
 


### PR DESCRIPTION
realpath will eliminating symlinks, so following sls won't work as expected

``` yaml
/root/a:
  file.directory:
    - user: root
    - group: root
    - mode: 0755
    - clean: True
    - require:
      - file: /root/a/b

/root/a/b:
  file.symlink:
    - user: root
    - group: root
    - target: /etc
```
