### PR TITLE
Fix file_roots CA lookup in salt.utils.http.get_ca_bundle

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -443,14 +443,17 @@ def get_ca_bundle(opts=None):
         return opts_bundle
 
     file_roots = opts.get('file_roots', {'base': [syspaths.SRV_ROOT_DIR]})
-    salt_root = file_roots['base'][0]
-    log.debug('file_roots is {0}'.format(salt_root))
 
     # Please do not change the order without good reason
-    for path in (
-        # Check Salt first
-        os.path.join(salt_root, 'cacert.pem'),
-        os.path.join(salt_root, 'ca-bundle.crt'),
+
+    # Check Salt first
+    for salt_root in file_roots.get('base', []):
+        log.debug('file_roots is {0}'.format(salt_root))
+        for path in ('cacert.pem', 'ca-bundle.crt'):
+            if os.path.exists(path):
+                return path
+
+    locations = (
         # Debian has paths that often exist on other distros
         '/etc/ssl/certs/ca-certificates.crt',
         # RedHat is also very common
@@ -460,7 +463,8 @@ def get_ca_bundle(opts=None):
         '/etc/ssl/certs/ca-bundle.crt',
         # Suse has an unusual path
         '/var/lib/ca-certificates/ca-bundle.pem',
-    ):
+    )
+    for path in locations:
         if os.path.exists(path):
             return path
 


### PR DESCRIPTION
When trying to apply any `http.query` state to minion via highstate salt
would crash with similar backtrace:

```
  Traceback (most recent call last):
    File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1563, in call
      **cdata['kwargs'])
    File "/usr/lib/python2.7/dist-packages/salt/states/http.py", line 47, in query
      data = __salt__['http.query'](name, **kwargs)
    File "/usr/lib/python2.7/dist-packages/salt/modules/http.py", line 30, in query
      return salt.utils.http.query(url=url, opts=__opts__, **kwargs)
    File "/usr/lib/python2.7/dist-packages/salt/utils/http.py", line 151, in query
      ca_bundle = get_ca_bundle(opts)
    File "/usr/lib/python2.7/dist-packages/salt/utils/http.py", line 449, in get_ca_bundle
      salt_root = file_roots['base'][0]
  IndexError: list index out of range
```

Master was returning to minion dictionary of environments with empty
lists as values (via `salt.master.AESFuncs._master_opts`) and
`get_ca_bundle` was way too optimistically assuming that list of file
roots can't be empty.

With this fix `get_ca_bundle` tries to walk over list of `file_roots` and
fallback to standard locations if CA bundle is not found.

I believe that proper logic would be to look up CA bundle using file
server but I'm not sure how to implement that. This change at least
allows to properly use `http.query` state in all other cases except of CA
bundle stored in `file_roots` and required.
