### PR TITLE
Fix cloud LXC container destruction

### DIFF
--- a/salt/cloud/clouds/lxc.py
+++ b/salt/cloud/clouds/lxc.py
@@ -377,7 +377,7 @@ def destroy(vm_, call=None):
             transport=__opts__['transport']
         )
         cret = _salt('lxc.destroy', vm_, stop=True)
-        ret['result'] = cret['change']
+        ret['result'] = cret['result']
         if ret['result']:
             ret['comment'] = '{0} was destroyed'.format(vm_)
             salt.utils.cloud.fire_event(


### PR DESCRIPTION
`salt.modules.lxc.destroy` return value was changed during LXC refactoring between 2014.7 and 2015.5 but `salt.cloud.clouds.lxc.destroy` did not follow it. As result `salt-cloud` was always thinking that LXC failed to destroy container and didn't remove minion keys from master.
