### PR TITLE
Replace "command -v" with "which" and get rid of spurious log messages

### DIFF
--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -2635,17 +2635,17 @@ def set_dns(name, dnsservers=None, searchdomains=None):
 
 def _need_install(name):
     ret = 0
-    has_minion = retcode(name, "command -v salt-minion")
+    has_minion = retcode(name, 'which salt-minion')
     # we assume that installing is when no minion is running
     # but testing the executable presence is not enougth for custom
     # installs where the bootstrap can do much more than installing
     # the bare salt binaries.
     if has_minion:
-        processes = run_stdout(name, "ps aux")
+        processes = run_stdout(name, 'ps aux')
         if 'salt-minion' not in processes:
             ret = 1
         else:
-            retcode(name, "salt-call --local service.stop salt-minion")
+            retcode(name, 'salt-call --local service.stop salt-minion')
     else:
         ret = 1
     return ret

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -2838,8 +2838,12 @@ def attachable(name):
         _ensure_exists(name)
         # Can't use run() here because it uses attachable() and would
         # endlessly recurse, resulting in a traceback
+        log.debug('Checking if LXC container {0} is attachable'.format(name))
         cmd = 'lxc-attach --clear-env -n {0} -- /usr/bin/env'.format(name)
-        result = __salt__['cmd.retcode'](cmd, python_shell=False) == 0
+        result = __salt__['cmd.retcode'](cmd,
+                                         python_shell=False,
+                                         output_loglevel='quiet',
+                                         ignore_retcode=True) == 0
         __context__['lxc.attachable'] = result
     return __context__['lxc.attachable']
 

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -2635,7 +2635,9 @@ def set_dns(name, dnsservers=None, searchdomains=None):
 
 def _need_install(name):
     ret = 0
-    has_minion = retcode(name, 'which salt-minion')
+    has_minion = retcode(name,
+                         'which salt-minion',
+                         ignore_retcode=True)
     # we assume that installing is when no minion is running
     # but testing the executable presence is not enougth for custom
     # installs where the bootstrap can do much more than installing
@@ -2748,7 +2750,9 @@ def bootstrap(name,
         needs_install = _need_install(name)
     else:
         needs_install = True
-    seeded = retcode(name, 'test -e \'{0}\''.format(SEED_MARKER)) == 0
+    seeded = retcode(name,
+                     'test -e \'{0}\''.format(SEED_MARKER),
+                     ignore_retcode=True) == 0
     tmp = tempfile.mkdtemp()
     if seeded and not unconditional_install:
         ret = True
@@ -3405,8 +3409,8 @@ def cp(name, source, dest, makedirs=False):
     if not os.path.isabs(dest):
         raise SaltInvocationError('Destination path must be absolute')
     if retcode(name,
-                   'test -d \'{0}\''.format(dest),
-                   ignore_retcode=True) == 0:
+               'test -d \'{0}\''.format(dest),
+               ignore_retcode=True) == 0:
         # Destination is a directory, full path to dest file will include the
         # basename of the source file.
         dest = os.path.join(dest, source_name)
@@ -3416,8 +3420,8 @@ def cp(name, source, dest, makedirs=False):
         # parent directory.
         dest_dir, dest_name = os.path.split(dest)
         if retcode(name,
-                       'test -d \'{0}\''.format(dest_dir),
-                       ignore_retcode=True) != 0:
+                   'test -d \'{0}\''.format(dest_dir),
+                   ignore_retcode=True) != 0:
             if makedirs:
                 result = run_all(name, 'mkdir -p \'{0}\''.format(dest_dir))
                 if result['retcode'] != 0:


### PR DESCRIPTION
The former does not work in lxc-attach, while the latter does.
