### PR TITLE
Avoid deprecation warning from  portage.dep.strip_empty()

### DIFF
--- a/salt/modules/portage_config.py
+++ b/salt/modules/portage_config.py
@@ -277,7 +277,7 @@ def append_to_package_conf(conf, atom='', flags=None, string='', overwrite=False
             new_flags = list(flags)
         else:
             atom = string.strip().split()[0]
-            new_flags = portage.dep.strip_empty(string.strip().split(' '))[1:]
+            new_flags = filter(None,string.strip().split(' '))[1:]
             if '/' not in atom:
                 atom = _p_to_cp(atom)
                 string = '{0} {1}'.format(atom, ' '.join(new_flags))

--- a/salt/modules/portage_config.py
+++ b/salt/modules/portage_config.py
@@ -230,7 +230,7 @@ def _merge_flags(new_flags, old_flags=None, conf='any'):
         old_flags = []
     args = [old_flags, new_flags]
     if conf == 'accept_keywords':
-        tmp = new_flags+ \
+        tmp = new_flags + \
             [i for i in old_flags if _check_accept_keywords(new_flags, i)]
     else:
         tmp = portage.flatten(args)
@@ -277,7 +277,7 @@ def append_to_package_conf(conf, atom='', flags=None, string='', overwrite=False
             new_flags = list(flags)
         else:
             atom = string.strip().split()[0]
-            new_flags = filter(None,string.strip().split(' '))[1:]
+            new_flags = [flag for flag in string.strip().split(' ') if flag][1:]
             if '/' not in atom:
                 atom = _p_to_cp(atom)
                 string = '{0} {1}'.format(atom, ' '.join(new_flags))


### PR DESCRIPTION
Switch portage.dep.strip_empty(...) to list comprehension to avoid deprecation warning and do essentially the same according to docs:
- https://docs.python.org/2/tutorial/datastructures.html#list-comprehensions
- https://docs.python.org/3/tutorial/datastructures.html#list-comprehensions
- portage.dep

``` python
def strip_empty(myarr):
        """
        Strip all empty elements from an array

        @param myarr: The list of elements
        @type myarr: List
        @rtype: Array
        @return: The array with empty elements removed
        """
        warnings.warn(_("%s is deprecated and will be removed without replacement.") % \
                ('portage.dep.strip_empty',), DeprecationWarning, stacklevel=2)
        return [x for x in myarr if x]
```

Unfortunately I do not have the time at hand to write a test for this.

Regards,
