### PR TITLE
fix wrong package name for rng-tools

### DIFF
--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -306,9 +306,11 @@ def create_key(key_type='RSA',
     .. note::
 
         GPG key generation requires *a lot* of entropy and randomness.
-        Difficult to do over a remote connection, consider having another
-        process available which is generating randomness for the machine.
-        Also especially difficult on virtual machines, consider the rpg-tools
+        Difficult to do over a remote connection, consider having
+        another process available which is generating randomness for
+        the machine.  Also especially difficult on virtual machines,
+        consider the `rng-tools
+        <http://www.gnu.org/software/hurd/user/tlecarrour/rng-tools.html>`_
         package.
 
         The create_key process takes awhile so increasing the timeout


### PR DESCRIPTION
I loved RPG games, but they can't be used to help generate GPG key. :disappointed: 
