### PR TITLE
Fix erroneous virtual:physical core grain detection

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -559,6 +559,8 @@ def _virtual(osdata):
                 grains['virtual'] = 'kvm'
             if 'Vendor: Bochs' in output:
                 grains['virtual'] = 'kvm'
+            if 'Manufacturer: Bochs' in output:
+                grains['virtual'] = 'kvm'
             if 'BHYVE  BVXSDT' in output:
                 grains['virtual'] = 'bhyve'
             # Product Name: (oVirt) www.ovirt.org


### PR DESCRIPTION
DMIdecode output:

```
Handle 0x0100, DMI type 1, 27 bytes
System Information
        Manufacturer: Red Hat
        Product Name: KVM
        Version: RHEL 7.0.0 PC (i440FX + PIIX, 1996)
        Serial Number: Not Specified
        UUID: 863720D8-04A3-4046-85F4-89BA01C11728
        Wake-up Type: Power Switch
        SKU Number: Not Specified
        Family: Red Hat Enterprise Linux

Handle 0x0300, DMI type 3, 20 bytes
Chassis Information
        Manufacturer: Bochs
        Type: Other
        Lock: Not Present
        Version: Not Specified
        Serial Number: Not Specified
        Asset Tag: Not Specified
        Boot-up State: Safe
        Power Supply State: Safe
        Thermal State: Safe
        Security Status: Unknown
        OEM Information: 0x00000000
        Height: Unspecified
        Number Of Power Cords: Unspecified
```

Currently results in `virtual:physical`, which is obviously wrong.
