### PR TITLE
Tls add cert type option

### DIFF
--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -699,7 +699,9 @@ def create_csr(ca_name,
                ca_filename=None,
                csr_path=None,
                csr_filename=None,
-               digest='sha256'):
+               digest='sha256',
+               type_ext=False,
+               cert_type='server'):
     '''
     Create a Certificate Signing Request (CSR) for a
     particular Certificate Authority (CA)
@@ -742,18 +744,32 @@ def create_csr(ca_name,
                 requests to https://1.2.3.4 will fail from python's
                 requests library w/out the second entry in the above list
 
-    cacert_path
-        absolute path to ca certificates root directory
-    ca_filename
-        alternative filename for the CA
-    csr_path
-        full path to the CSR directory
-    csr_filename
-        alternative filename for the csr, useful when using special characters in the CN
-    digest
-        The message digest algorithm. Must be a string describing a digest
-        algorithm supported by OpenSSL (by EVP_get_digestbyname, specifically).
-        For example, "md5" or "sha1". Default: 'sha256'
+    .. versionadded:: Beryllium
+
+    cert_type
+        Specify the general certificate type. Can be either `server` or
+        `client`. Indicates the set of common extensions added to the CSR.
+
+        server: {
+           'basicConstraints': 'CA:FALSE',
+           'extendedKeyUsage': 'serverAuth',
+           'keyUsage': 'digitalSignature, keyEncipherment'
+        }
+
+        client: {
+           'basicConstraints': 'CA:FALSE',
+           'extendedKeyUsage': 'clientAuth',
+           'keyUsage': 'nonRepudiation, digitalSignature, keyEncipherment'
+        }
+
+    type_ext
+        boolean.  Whether or not to extend the filename with CN_[cert_type]
+        This can be useful if a server and client certificate are needed for
+        the same CN. Defaults to False to avoid introducing an unexpected file
+        naming pattern
+
+        The files normally named some_subject_CN.csr and some_subject_CN.key
+        will then be saved
 
     Writes out a Certificate Signing Request (CSR) If the file already
     exists, the function just returns assuming the CSR already exists.
@@ -791,8 +807,10 @@ def create_csr(ca_name,
     if not os.path.exists(csr_path):
         os.makedirs(csr_path)
 
+    CN_ext = '_{0}'.format(cert_type) if type_ext else ''
+
     if not csr_filename:
-        csr_filename = CN
+        csr_filename = '{0}{1}'.format(CN, CN_ext)
 
     csr_f = '{0}/{1}.csr'.format(csr_path, csr_filename)
 

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -103,6 +103,8 @@ import os
 import time
 import logging
 import hashlib
+import salt.utils
+from salt._compat import string_types
 from salt.ext.six.moves import range
 from datetime import datetime
 from distutils.version import LooseVersion
@@ -118,8 +120,6 @@ except ImportError:
     pass
 
 # Import salt libs
-import salt.utils
-from salt._compat import string_types
 
 
 log = logging.getLogger(__name__)
@@ -243,7 +243,7 @@ def _get_basic_info(ca_name, cert, ca_dir=None):
             )
     serial_number = format(cert.get_serial_number(), 'X')
 
-    #gotta prepend a /
+    # gotta prepend a /
     subject = '/'
 
     # then we can add the rest of the subject
@@ -331,9 +331,9 @@ def maybe_fix_ssl_version(ca_name, cacert_path=None, ca_filename=None):
                 except Exception:
                     bits = 2048
                 try:
-                    days = (datetime.strptime(cert.get_notAfter(),
-                                                       '%Y%m%d%H%M%SZ') -
-                            datetime.now()).days
+                    days = (datetime.strptime(
+                        cert.get_notAfter(),
+                        '%Y%m%d%H%M%SZ') - datetime.now()).days
                 except (ValueError, TypeError):
                     days = 365
                 subj = cert.get_subject()
@@ -499,22 +499,18 @@ def _check_onlyif_unless(onlyif, unless):
     if onlyif is not None:
         if not isinstance(onlyif, string_types):
             if not onlyif:
-                ret = {'comment': 'onlyif execution failed',
-                        'result': True}
+                ret = {'comment': 'onlyif execution failed', 'result': True}
         elif isinstance(onlyif, string_types):
             if retcode(onlyif) != 0:
-                ret = {'comment': 'onlyif execution failed',
-                        'result': True}
+                ret = {'comment': 'onlyif execution failed', 'result': True}
                 log.debug('onlyif execution failed')
     if unless is not None:
         if not isinstance(unless, string_types):
             if unless:
-                ret = {'comment': 'unless execution succeeded',
-                        'result': True}
+                ret = {'comment': 'unless execution succeeded', 'result': True}
         elif isinstance(unless, string_types):
             if retcode(unless) == 0:
-                ret = {'comment': 'unless execution succeeded',
-                        'result': True}
+                ret = {'comment': 'unless execution succeeded', 'result': True}
                 log.debug('unless execution succeeded')
     return ret
 
@@ -1204,7 +1200,6 @@ def create_ca_signed_cert(ca_name,
 
     set_ca_path(cacert_path)
 
-
     ca_filename = '{0}_ca_cert'.format(ca_name)
 
     if not cert_path:
@@ -1257,12 +1252,11 @@ def create_ca_signed_cert(ca_name,
         return ret
 
     try:
-        with salt.utils.fopen(
-            '{0}/{1}.csr'.format(cert_path, csr_filename)) as fhr:
+        csr_path = '{0}/{1}.csr'.format(cert_path, csr_filename)
+        with salt.utils.fopen(csr_path) as fhr:
             req = OpenSSL.crypto.load_certificate_request(
                     OpenSSL.crypto.FILETYPE_PEM,
-                    fhr.read()
-                    )
+                    fhr.read())
     except IOError:
         ret['retcode'] = 1
         ret['comment'] = 'There is no CSR that matches the CN "{0}"'.format(cert_filename)
@@ -1280,9 +1274,9 @@ def create_ca_signed_cert(ca_name,
             # so we mimic the newly get_extensions method present in ultra
             # recent pyopenssl distros
             log.info('req.get_extensions() not supported in pyOpenSSL versions '
-                    'prior to 0.15. Switching to Dark Magic(tm) '
-                    ' Your version: {0}'.format(
-                            OpenSSL.__dict__.get('__version__', 'pre-2014')))
+                     'prior to 0.15. Switching to Dark Magic(tm) '
+                     ' Your version: {0}'.format(
+                         OpenSSL.__dict__.get('__version__', 'pre-2014')))
 
             native_exts_obj = OpenSSL._util.lib.X509_REQ_get_extensions(req._req)
             for i in range(OpenSSL._util.lib.sk_X509_EXTENSION_num(native_exts_obj)):
@@ -1312,14 +1306,11 @@ def create_ca_signed_cert(ca_name,
 
     cert.sign(ca_key, digest)
 
-    with salt.utils.fopen(
-        '{0}/{1}.crt'.format(cert_path, cert_filename), 'w+') as crt:
+    cert_full_path = '{0}/{1}.crt'.format(cert_path, cert_filename)
+
+    with salt.utils.fopen(cert_full_path, 'w+') as crt:
         crt.write(
-            OpenSSL.crypto.dump_certificate(
-                OpenSSL.crypto.FILETYPE_PEM,
-                cert
-                )
-            )
+            OpenSSL.crypto.dump_certificate(OpenSSL.crypto.FILETYPE_PEM, cert))
 
     _write_cert_to_database(ca_name, cert)
 
@@ -1661,9 +1652,9 @@ def revoke_cert(
                 except ValueError:
                     ret['retcode'] = 1
                     ret['comment'] = ("Revocation date '{0}' does not match"
-                                     "format '{1}'").format(
-                                             revoke_date,
-                                             two_digit_year_fmt)
+                                      "format '{1}'".format(
+                                          revoke_date,
+                                          two_digit_year_fmt))
                     return ret
             elif index_serial_subject in line:
                 __salt__['file.replace'](
@@ -1710,7 +1701,7 @@ def revoke_cert(
 
 
 if __name__ == '__main__':
-    #create_ca('koji', days=365, **cert_sample_meta)
+    # create_ca('koji', days=365, **cert_sample_meta)
     create_csr(
             'koji',
             CN='test_system',

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -4,11 +4,96 @@ A salt module for SSL/TLS.
 Can create a Certificate Authority (CA)
 or use Self-Signed certificates.
 
-:depends:   - PyOpenSSL Python module
+:depends:   - PyOpenSSL Python module (0.14 or later)
 :configuration: Add the following values in /etc/salt/minion for the CA module
     to function properly::
 
         ca.cert_base_path: '/etc/pki'
+
+
+CLI Example #1
+Creating a CA, a server request and its signed certificate:
+
+    .. code-block:: bash
+
+    # salt-call tls.create_ca my_little \
+      days=5 \
+      CN='My Little CA' \
+      C=US \
+      ST=Utah \
+      L=Salt Lake City \
+      O=Saltstack \
+      emailAddress=pleasedontemail@thisisnot.coms
+
+    Created Private Key: "/etc/pki/my_little/my_little_ca_cert.key"
+    Created CA "my_little_ca": "/etc/pki/my_little_ca/my_little_ca_cert.crt"
+
+    # salt-call tls.create_csr my_little CN=www.thisisnot.coms
+    Created Private Key: "/etc/pki/my_little/certs/www.thisisnot.coms.key
+    Created CSR for "www.thisisnot.coms": "/etc/pki/my_little/certs/www.thisisnot.coms.csr"
+
+    # salt-call tls.create_ca_signed_cert my_little CN=www.thisisnot.coms
+    Created Certificate for "www.thisisnot.coms": /etc/pki/my_little/certs/www.thisisnot.coms.crt"
+
+CLI Example #2:
+Creating a client request and its signed certificate
+
+    .. code-block:: bash
+
+    # salt-call tls.create_csr my_little CN=DBReplica_No.1 cert_type=client
+    Created Private Key: "/etc/pki/my_little/certs//DBReplica_No.1.key."
+    Created CSR for "DBReplica_No.1": "/etc/pki/my_little/certs/DBReplica_No.1.csr."
+
+    # salt-call tls.create_ca_signed_cert my_little CN=DBReplica_No.1
+    Created Certificate for "DBReplica_No.1": "/etc/pki/my_little/certs/DBReplica_No.1.crt"
+
+CLI Example #3:
+Creating both a server and client req + cert for the same CN
+
+    .. code-block:: bash
+    # salt-call tls.create_csr my_little CN=MasterDBReplica_No.2  \
+        cert_type=client
+    Created Private Key: "/etc/pki/my_little/certs/MasterDBReplica_No.2.key."
+    Created CSR for "DBReplica_No.1": "/etc/pki/my_little/certs/MasterDBReplica_No.2.csr."
+
+    # salt-call tls.create_ca_signed_cert my_little CN=MasterDBReplica_No.2
+    Created Certificate for "DBReplica_No.1": "/etc/pki/my_little/certs/DBReplica_No.1.crt"
+
+    # salt-call tls.create_csr my_little CN=MasterDBReplica_No.2 \
+        cert_type=server
+    Certificate "MasterDBReplica_No.2" already exists
+
+    (doh!)
+
+    # salt-call tls.create_csr my_little CN=MasterDBReplica_No.2 \
+        cert_type=server type_ext=True
+    Created Private Key: "/etc/pki/my_little/certs/DBReplica_No.1_client.key."
+    Created CSR for "DBReplica_No.1": "/etc/pki/my_little/certs/DBReplica_No.1_client.csr."
+
+    # salt-call tls.create_ca_signed_cert my_little CN=MasterDBReplica_No.2
+    Certificate "MasterDBReplica_No.2" already exists
+
+    (DOH!)
+
+    # salt-call tls.create_ca_signed_cert my_little CN=MasterDBReplica_No.2 \
+        cert_type=server type_ext=True
+    Created Certificate for "MasterDBReplica_No.2": "/etc/pki/my_little/certs/MasterDBReplica_No.2_server.crt"
+
+
+CLI Example #4:
+Create a server req + cert with non-CN filename for the cert
+
+    .. code-block:: bash
+
+    # salt-call tls.create_csr my_little CN=www.anothersometh.ing \
+        cert_type=server type_ext=True
+    Created Private Key: "/etc/pki/my_little/certs/www.anothersometh.ing_server.key."
+    Created CSR for "DBReplica_No.1": "/etc/pki/my_little/certs/www.anothersometh.ing_server.csr."
+
+    # salt-call tls_create_ca_signed_cert my_little CN=www.anothersometh.ing \
+        cert_type=server cert_filename="something_completely_different"
+    Created Certificate for "www.anothersometh.ing": /etc/pki/my_little/certs/something_completely_different.crt
+
 '''
 from __future__ import absolute_import
 # pylint: disable=C0103
@@ -597,9 +682,9 @@ def create_ca(ca_name,
 
     _write_cert_to_database(ca_name, ca)
 
-    ret = ('Created Private Key: "{0}/{1}/{2}.key." ').format(
+    ret = ('Created Private Key: "{0}/{1}{2}.key." ').format(
         cert_base_path(), ca_name, ca_filename)
-    ret += ('Created CA "{0}": "{1}/{2}/{3}.crt."').format(
+    ret += ('Created CA "{0}": "{1}/{2}{3}.crt."').format(
         ca_name, cert_base_path(), ca_name, ca_filename)
 
     return ret
@@ -1029,7 +1114,9 @@ def create_ca_signed_cert(ca_name,
                           ca_filename=None,
                           cert_path=None,
                           cert_filename=None,
-                          digest='sha256'):
+                          digest='sha256',
+                          cert_type=None,
+                          type_ext=False):
     '''
     Create a Certificate (CERT) signed by a named Certificate Authority (CA)
 
@@ -1059,12 +1146,38 @@ def create_ca_signed_cert(ca_name,
         full path to the certificates directory
 
     cert_filename
-        alternative filename for the certificate, useful when using special characters in the CN
+        alternative filename for the certificate, useful when using special
+        characters in the CN. If this option is set it will override
+        the certificate filename output effects of ``cert_type``.
+        ``type_ext`` will be completely overridden.
 
     digest
         The message digest algorithm. Must be a string describing a digest
         algorithm supported by OpenSSL (by EVP_get_digestbyname, specifically).
         For example, "md5" or "sha1". Default: 'sha256'
+
+    cert_type
+        string. Either 'server' or 'client' (see create_csr() for details).
+
+        If create_csr(type_ext=True) this function **must** be called with the
+        same cert_type so it can find the CSR file.
+
+    .. note::
+        create_csr() defaults to cert_type='server'; therefore, if it was also
+        called with type_ext, cert_type becomes a required argument for
+        create_ca_signed_cert()
+
+    type_ext
+        bool. If set True, use ``cert_type`` as an extension to the CN when
+        formatting the filename.
+
+        e.g.: some_subject_CN_server.crt or some_subject_CN_client.crt
+
+        This facilitates the context where both types are required for the same
+        subject
+
+        If ``cert_filename`` is `not None`, setting ``type_ext`` has no
+        effect
 
     If the following values were set:
 
@@ -1091,14 +1204,26 @@ def create_ca_signed_cert(ca_name,
 
     set_ca_path(cacert_path)
 
-    if not ca_filename:
-        ca_filename = '{0}_ca_cert'.format(ca_name)
+
+    ca_filename = '{0}_ca_cert'.format(ca_name)
 
     if not cert_path:
         cert_path = '{0}/{1}/certs'.format(cert_base_path(), ca_name)
 
+    if type_ext:
+        if not cert_type:
+            log.error('type_ext = True but cert_type is unset. '
+                      'Certificate not written.')
+            return ret
+        elif cert_type:
+            CN_ext = '_{0}'.format(cert_type)
+    else:
+        CN_ext = ''
+
+    csr_filename = '{0}{1}'.format(CN, CN_ext)
+
     if not cert_filename:
-        cert_filename = CN
+        cert_filename = '{0}{1}'.format(CN, CN_ext)
 
     if os.path.exists(
             os.path.join(
@@ -1132,8 +1257,8 @@ def create_ca_signed_cert(ca_name,
         return ret
 
     try:
-        with salt.utils.fopen('{0}/{1}.csr'.format(cert_path,
-                                                   cert_filename)) as fhr:
+        with salt.utils.fopen(
+            '{0}/{1}.csr'.format(cert_path, csr_filename)) as fhr:
             req = OpenSSL.crypto.load_certificate_request(
                     OpenSSL.crypto.FILETYPE_PEM,
                     fhr.read()
@@ -1187,8 +1312,8 @@ def create_ca_signed_cert(ca_name,
 
     cert.sign(ca_key, digest)
 
-    with salt.utils.fopen('{0}/{1}.crt'.format(cert_path,
-                                               cert_filename), 'w+') as crt:
+    with salt.utils.fopen(
+        '{0}/{1}.crt'.format(cert_path, cert_filename), 'w+') as crt:
         crt.write(
             OpenSSL.crypto.dump_certificate(
                 OpenSSL.crypto.FILETYPE_PEM,


### PR DESCRIPTION
From conversation w/ @quantonganh on the last series of commits, added cert_type and type_ext arguments to create_csr() and create_ca_signed_cert() to facilitate the ability to choose which set of common extensions to use.  Folded cert_type and type_ext into logic that @quantonganh committed wrt cert_filename.  If cert_filename is set it will override cert_type/type_ext

``` python
In create_csr():
  cert_type defaults to 'server'
  type_ext default to False
  if type_ext is True, append cert_type to the CN for the CSR filename format

In create_ca_signed_cert():
  cert_type defaults to None
  type_ext defaults to False
```

  If cert_type is set with create_csr(), it must be set for ccsc() to allow it to find the CSR
  If type_ext is True, cert_type is required to be set to reflect generated CSRs + appends cert_type to the CN for the filename format

  If cert_filename is set, it is used for the filename format.  In this context, type_ext is ignored.  cert_type must be set to reflect create_csr(cert_type) iaoi create_csr(type_ext) was set
