### PR TITLE
MySQL can go away, this seems the most reliable way of checking it's …

### DIFF
--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -198,7 +198,7 @@ def _get_serv(ret=None, commit=False):
             conn.ping()
             connect = False
         except MySQLdb.connections.OperationalError as exc:
-            log.debug('OperationalError on ping: {}'.format(exc))
+            log.debug('OperationalError on ping: {0}'.format(exc))
 
     if connect:
         log.debug('Generating new MySQL connection pool')

--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -190,10 +190,17 @@ def _get_serv(ret=None, commit=False):
     '''
     _options = _get_options(ret)
 
+    connect = True
     if __context__ and 'mysql_returner_conn' in __context__:
-        log.debug('Reusing MySQL connection pool')
-        conn = __context__['mysql_returner_conn']
-    else:
+        try:
+            log.debug('Trying to reuse MySQL connection pool')
+            conn = __context__['mysql_returner_conn']
+            conn.ping()
+            connect = False
+        except MySQLdb.connections.OperationalError as exc:
+            log.debug('OperationalError on ping: {}'.format(exc))
+
+    if connect:
         log.debug('Generating new MySQL connection pool')
         try:
             # An empty ssl_options dictionary passed to MySQLdb.connect will


### PR DESCRIPTION
…still alive.

Ok, that was exactly how github formatted it and I rather like it.

So what's happening is that the recent addition of caching the MySQL connection pool has an unfortunate side effect that it doesn't reattempt connection when the server goes away for some reason (such as when the connection time out expires).
If this were at a lower level, or I didn't mind kludging, there is a connection option that makes it automatically reconnect, but it looks like MySQLdb doesn't let you get at that.
For safety and sanity purposes I've implemented this as an attempt to call `conn.ping()` so that if the connection isn't available it will reconnect right there.  That feels like the best compromise and most portable solution.

The caching doesn't appear to be in any of the release branches, thus PR against dev.  Not sure if the pool caching is going to be back ported.
