### PR TITLE
Cloud tests should use an image that is LTS

### DIFF
--- a/tests/integration/files/conf/cloud.profiles.d/digital_ocean.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/digital_ocean.conf
@@ -1,4 +1,4 @@
 digitalocean-test:
   provider: digitalocean-config
-  image: 14.10 x64
+  image: 14.04 x64
   size: 2GB


### PR DESCRIPTION
Changes the test image to create for digital ocean cloud tests to be on Ubuntu 14.04, not 14.10
