### PR TITLE
#22080 part 4: Make the related functions fully IP-agnostic

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -754,11 +754,13 @@ def ip_addrs(interface=None, include_loopback=False, cidr=None):
 ipaddrs = ip_addrs
 
 
-def ip_addrs6(interface=None, include_loopback=False):
+def ip_addrs6(interface=None, include_loopback=False, cidr=None):
     '''
     Returns a list of IPv6 addresses assigned to the host. ::1 is ignored,
     unless 'include_loopback=True' is indicated. If 'interface' is provided,
     then only IP addresses from that interface will be returned.
+    Providing a CIDR via 'cidr="2000::/3"' will return only the addresses
+    which are within that subnet.
 
     CLI Example:
 
@@ -766,8 +768,12 @@ def ip_addrs6(interface=None, include_loopback=False):
 
         salt '*' network.ip_addrs6
     '''
-    return salt.utils.network.ip_addrs6(interface=interface,
+    addrs = salt.utils.network.ip_addrs(interface=interface,
                                         include_loopback=include_loopback)
+    if cidr:
+        return [i for i in addrs if salt.utils.network.ip_in_subnet(cidr, [i])]
+    else:
+        return addrs
 
 ipaddrs6 = ip_addrs6
 

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -768,7 +768,7 @@ def ip_addrs6(interface=None, include_loopback=False, cidr=None):
 
         salt '*' network.ip_addrs6
     '''
-    addrs = salt.utils.network.ip_addrs(interface=interface,
+    addrs = salt.utils.network.ip_addrs6(interface=interface,
                                         include_loopback=include_loopback)
     if cidr:
         return [i for i in addrs if salt.utils.network.ip_in_subnet(cidr, [i])]

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -779,8 +779,7 @@ def calculate_subnet(ipaddr, netmask):
     Takes IP and netmask and returns the network in CIDR-notation.
     (The IP can be any IP inside this subnet.)
     '''
-    return '{0}/{1}'.format(get_net_start(ipaddr, netmask),
-                            get_net_size(netmask))
+    return ipaddress.ip_interface('{0}/{1}'.format(ipaddr, netmask), strict=False)
 
 
 def _ipv4_to_bits(ipaddr):
@@ -864,32 +863,17 @@ def in_subnet(cidr, addrs=None):
     Returns True if host is within specified subnet, otherwise False
     '''
     try:
-        netstart, netsize = cidr.split('/')
-        netsize = int(netsize)
+        cidr = ipaddress.ip_network(cidr)
     except ValueError:
         log.error('Invalid CIDR \'{0}\''.format(cidr))
         return False
-
-    netstart_bin = _ipv4_to_bits(netstart)
-
-    if netsize < 32 and len(netstart_bin.rstrip('0')) > netsize:
-        log.error('Invalid network starting IP \'{0}\' in CIDR '
-                  '\'{1}\''.format(netstart, cidr))
-        return False
-
-    netstart_leftbits = netstart_bin[0:netsize]
 
     if addrs is None:
         addrs = ip_addrs()
 
     for ip_addr in addrs:
-        if netsize == 32:
-            if netstart == ip_addr:
-                return True
-        else:
-            ip_leftbits = _ipv4_to_bits(ip_addr)[0:netsize]
-            if netstart_leftbits == ip_leftbits:
-                return True
+        if ipaddress.ip_address(ip_addr) in cidr:
+            return True
     return False
 
 
@@ -897,12 +881,7 @@ def ip_in_subnet(ip_addr, cidr):
     '''
     Returns True if given IP is within specified subnet, otherwise False
     '''
-    ipaddr = int(''.join(['%02x' % int(x) for x in ip_addr.split('.')]), 16)  # pylint: disable=E1321
-    netstr, bits = cidr.split('/')
-    netaddr = int(''.join(['%02x' % int(x) for x in netstr.split('.')]), 16)  # pylint: disable=E1321
-    mask = (0xffffffff << (32 - int(bits))) & 0xffffffff
-    return (ipaddr & mask) == (netaddr & mask)
-
+    return in_subnet(cidr, [ip_addr])
 
 def ip_addrs(interface=None, include_loopback=False, interface_data=None):
     '''

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -883,6 +883,7 @@ def ip_in_subnet(ip_addr, cidr):
     '''
     return in_subnet(cidr, [ip_addr])
 
+
 def ip_addrs(interface=None, include_loopback=False, interface_data=None):
     '''
     Returns a list of IPv4 addresses assigned to the host. 127.0.0.1 is

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -779,7 +779,7 @@ def calculate_subnet(ipaddr, netmask):
     Takes IP and netmask and returns the network in CIDR-notation.
     (The IP can be any IP inside this subnet.)
     '''
-    return ipaddress.ip_interface('{0}/{1}'.format(ipaddr, netmask), strict=False)
+    return str(ipaddress.ip_network('{0}/{1}'.format(ipaddr, netmask), strict=False))
 
 
 def _ipv4_to_bits(ipaddr):


### PR DESCRIPTION
Another part of #22080, the functions controlling the matcher are now IP agnostic and based on the `ipaddress` module
- `utils.network.in_subnet` IP-agnostic
- `utils.network.ip_in_subnet` IP-agnostic
- `utils.network.calculate_subnet` IP-agnostic
- add `cidr` to `modules.network.ip_addrs6`
