### PR TITLE
Lxc seed and prof ports

### DIFF
--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -4093,7 +4093,7 @@ def reconfigure(name,
             return profile_match
         return kw_overrides_match
     if nic_opts is not None and not network_profile:
-        network_profile = 'eth0'
+        network_profile = DEFAULT_NIC
 
     if autostart is not None:
         autostart = select('autostart', autostart)


### PR DESCRIPTION
reopening of #23808 
refs #23772 #23833 #23847 #23658 #23657
should be applied after  #23898  (and rebased, of course.)
