### PR TITLE
Added exception handler to trap the RuntimeError raised when

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1162,7 +1162,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             Depends.enforce_dependencies(self._dict, self.tag)
         except RuntimeError as e:
             log.info('Depends.enforce_dependencies() failed '
-                     'for reasons: '.format(e))
+                     'for reasons: {0}'.format(e))
 
         self.loaded_modules[module_name] = mod_dict
         return True

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1158,7 +1158,12 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             self._apply_outputter(func, mod)
 
         # enforce depends
-        Depends.enforce_dependencies(self._dict, self.tag)
+        try:
+            Depends.enforce_dependencies(self._dict, self.tag)
+        except RuntimeError as e:
+            log.info('Depends.enforce_dependencies() failed '
+                     'for reasons: '.format(e))
+
         self.loaded_modules[module_name] = mod_dict
         return True
 


### PR DESCRIPTION
Depends.enforce_dependency() class method fires unsuccessfully. There appears
to be no synchronization within the Depends decorator class wrt the
class global dependency_dict which results in incomplete population of any
loader instantiation occuring at the time of one of these exceptions.

This would mitigate the immediate affects of #23839 and #23373.
