### PR TITLE
fix connection function to mongo

### DIFF
--- a/salt/modules/mongodb.py
+++ b/salt/modules/mongodb.py
@@ -59,7 +59,7 @@ def _connect(user=None, password=None, host=None, port=None, database='admin'):
         port = __salt__['config.option']('mongodb.port')
 
     try:
-        conn = pymongo.connection.Connection(host=host, port=port)
+        conn = pymongo.MongoClient(host=host, port=port)
         mdb = pymongo.database.Database(conn, database)
         if user and password:
             mdb.authenticate(user, password)


### PR DESCRIPTION
connecting to mongo using "pymongo.connection.Connection" did not work on different versions of mongo.
this change fixes the connection issue.
