### PR TITLE
'str' object has no attribute 'capitalized'

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -4041,7 +4041,7 @@ def serialize(name,
             else:
                 return {'changes': {},
                         'comment': ('{0} format is not supported for merging'
-                                    .format(formatter.capitalized())),
+                                    .format(formatter.capitalize())),
                         'name': name,
                         'result': False}
 
@@ -4076,7 +4076,7 @@ def serialize(name,
     else:
         return {'changes': {},
                 'comment': '{0} format is not supported'.format(
-                    formatter.capitalized()),
+                    formatter.capitalize()),
                 'name': name,
                 'result': False
                 }


### PR DESCRIPTION
Change in code:
As AttributeError raised fue to capitalized() function.
Error :
 AttributeError: 'str' object has no attribute 'capitalized'

It shoud be capitalize() and not capitalized().
