### PR TITLE
pkg.installed: Check binary pkg metadata to determine action

### DIFF
--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -7,6 +7,7 @@ Resources needed by pkg providers
 from __future__ import absolute_import
 import fnmatch
 import logging
+import os
 import pprint
 
 # Import third party libs
@@ -15,17 +16,21 @@ import salt.ext.six as six
 
 # Import salt libs
 import salt.utils
+from salt.exceptions import SaltInvocationError
 
 log = logging.getLogger(__name__)
 __SUFFIX_NOT_NEEDED = ('x86_64', 'noarch')
 
 
-def _repack_pkgs(pkgs):
+def _repack_pkgs(pkgs, normalize=True):
     '''
     Repack packages specified using "pkgs" argument to pkg states into a single
     dictionary
     '''
-    _normalize_name = __salt__.get('pkg.normalize_name', lambda pkgname: pkgname)
+    if normalize and 'pkg.normalize_name' in __salt__:
+        _normalize_name = __salt__['pkg.normalize_name']
+    else:
+        _normalize_name = lambda pkgname: pkgname
     return dict(
         [
             (_normalize_name(str(x)), str(y) if y is not None else y)
@@ -34,7 +39,7 @@ def _repack_pkgs(pkgs):
     )
 
 
-def pack_sources(sources):
+def pack_sources(sources, normalize=True):
     '''
     Accepts list of dicts (or a string representing a list of dicts) and packs
     the key/value pairs into a single dict.
@@ -42,13 +47,27 @@ def pack_sources(sources):
     ``'[{"foo": "salt://foo.rpm"}, {"bar": "salt://bar.rpm"}]'`` would become
     ``{"foo": "salt://foo.rpm", "bar": "salt://bar.rpm"}``
 
+    normalize : True
+        Normalize the package name by removing the architecture, if the
+        architecture of the package is different from the architecture of the
+        operating system. The ability to disable this behavior is useful for
+        poorly-created packages which include the architecture as an actual
+        part of the name, such as kernel modules which match a specific kernel
+        version.
+
+        .. versionadded:: Beryllium
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' pkg_resource.pack_sources '[{"foo": "salt://foo.rpm"}, {"bar": "salt://bar.rpm"}]'
     '''
-    _normalize_name = __salt__.get('pkg.normalize_name', lambda pkgname: pkgname)
+    if normalize and 'pkg.normalize_name' in __salt__:
+        _normalize_name = __salt__['pkg.normalize_name']
+    else:
+        _normalize_name = lambda pkgname: pkgname
+
     if isinstance(sources, six.string_types):
         try:
             sources = yaml.safe_load(sources)
@@ -102,32 +121,38 @@ def parse_targets(name=None,
         return None, None
 
     elif pkgs:
-        pkgs = _repack_pkgs(pkgs)
+        pkgs = _repack_pkgs(pkgs, normalize=normalize)
         if not pkgs:
             return None, None
         else:
             return pkgs, 'repository'
 
     elif sources and __grains__['os'] != 'MacOS':
-        sources = pack_sources(sources)
+        sources = pack_sources(sources, normalize=normalize)
         if not sources:
             return None, None
 
         srcinfo = []
         for pkg_name, pkg_src in six.iteritems(sources):
             if __salt__['config.valid_fileproto'](pkg_src):
-                # Cache package from remote source (salt master, HTTP, FTP)
-                srcinfo.append((pkg_name,
-                                pkg_src,
-                               __salt__['cp.cache_file'](pkg_src, saltenv),
-                               'remote'))
+                # Cache package from remote source (salt master, HTTP, FTP) and
+                # append a tuple containing the cached path along with the
+                # specified version.
+                srcinfo.append((
+                    __salt__['cp.cache_file'](pkg_src[0], saltenv),
+                    pkg_src[1]
+                ))
             else:
-                # Package file local to the minion
-                srcinfo.append((pkg_name, pkg_src, pkg_src, 'local'))
+                # Package file local to the minion, just append the tuple from
+                # the pack_sources() return data.
+                if not os.path.isabs(pkg_src[0]):
+                    raise SaltInvocationError(
+                        'Path {0} for package {1} is either not absolute or '
+                        'an invalid protocol'.format(pkg_src[0], pkg_name)
+                    )
+                srcinfo.append(pkg_src)
 
-        # srcinfo is a 4-tuple (pkg_name,pkg_uri,pkg_path,pkg_type), so grab
-        # the package path (3rd element of tuple).
-        return [x[2] for x in srcinfo], 'file'
+        return srcinfo, 'file'
 
     elif name:
         if normalize:
@@ -180,7 +205,7 @@ def version(*names, **kwargs):
     return ret
 
 
-def add_pkg(pkgs, name, version):
+def add_pkg(pkgs, name, pkgver):
     '''
     Add a package to a dict of installed packages.
 
@@ -191,7 +216,7 @@ def add_pkg(pkgs, name, version):
         salt '*' pkg_resource.add_pkg '{}' bind 9
     '''
     try:
-        pkgs.setdefault(name, []).append(version)
+        pkgs.setdefault(name, []).append(pkgver)
     except AttributeError as exc:
         log.exception(exc)
 
@@ -237,7 +262,7 @@ def stringify(pkgs):
         log.exception(exc)
 
 
-def version_clean(version):
+def version_clean(verstr):
     '''
     Clean the version string removing extra data.
     This function will simply try to call ``pkg.version_clean``.
@@ -248,16 +273,16 @@ def version_clean(version):
 
         salt '*' pkg_resource.version_clean <version_string>
     '''
-    if version and 'pkg.version_clean' in __salt__:
-        return __salt__['pkg.version_clean'](version)
-
-    return version
+    if verstr and 'pkg.version_clean' in __salt__:
+        return __salt__['pkg.version_clean'](verstr)
+    return verstr
 
 
 def check_extra_requirements(pkgname, pkgver):
     '''
     Check if the installed package already has the given requirements.
-    This function will simply try to call "pkg.check_extra_requirements".
+    This function will return the result of ``pkg.check_extra_requirements`` if
+    this function exists for the minion, otherwise it will return True.
 
     CLI Example:
 

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -6,12 +6,20 @@ Support for rpm
 # Import python libs
 from __future__ import absolute_import
 import logging
+import os
 import re
 
 # Import Salt libs
 import salt.utils
 import salt.utils.decorators as decorators
-from salt.ext.six.moves import zip  # pylint: disable=import-error,redefined-builtin
+import salt.utils.pkg.rpm
+# pylint: disable=import-error,redefined-builtin
+from salt.ext.six.moves import (
+    zip,
+    shlex_quote as _cmd_quote
+)
+# pylint: enable=import-error,redefined-builtin
+from salt.exceptions import CommandExecutionError, SaltInvocationError
 
 log = logging.getLogger(__name__)
 
@@ -36,6 +44,60 @@ def __virtual__():
     if os_family in ['redhat', 'suse'] or os_grain in enabled:
         return __virtualname__
     return False
+
+
+def bin_pkg_info(path, saltenv='base'):
+    '''
+    .. versionadded:: Beryllium
+
+    Parses RPM metadata and returns a dictionary of information about the
+    package (name, version, etc.).
+
+    path
+        Path to the file. Can either be an absolute path to a file on the
+        minion, or a salt fileserver URL (e.g. ``salt://path/to/file.rpm``).
+        If a salt fileserver URL is passed, the file will be cached to the
+        minion so that it can be examined.
+
+    saltenv : base
+        Salt fileserver envrionment from which to retrieve the package. Ignored
+        if ``path`` is a local file path on the minion.
+    '''
+    # If the path is a valid protocol, pull it down using cp.cache_file
+    if __salt__['config.valid_fileproto'](path):
+        newpath = __salt__['cp.cache_file'](path, saltenv)
+        if not newpath:
+            raise CommandExecutionError(
+                'Unable to retrieve {0} from saltenv \'{1}'
+                .format(path, saltenv)
+            )
+        path = newpath
+    else:
+        if not os.path.exists(path):
+            raise CommandExecutionError(
+                '{0} does not exist on minion'.format(path)
+            )
+        elif not os.path.isabs(path):
+            raise SaltInvocationError(
+                '{0} does not exist on minion'.format(path)
+            )
+
+    # REPOID is not a valid tag for the rpm command. Remove it and replace it
+    # with 'none'
+    queryformat = salt.utils.pkg.rpm.QUERYFORMAT.replace('%{REPOID}', 'none')
+    output = __salt__['cmd.run_stdout'](
+        'rpm -qp --queryformat {0} {1}'.format(_cmd_quote(queryformat), path),
+        output_loglevel='trace',
+        ignore_retcode=True
+    )
+    ret = {}
+    pkginfo = salt.utils.pkg.rpm.parse_pkginfo(
+        output,
+        osarch=__grains__['osarch']
+    )
+    for field in pkginfo._fields:
+        ret[field] = getattr(pkginfo, field)
+    return ret
 
 
 def list_pkgs(*packages):

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -38,31 +38,12 @@ except ImportError:
 # Import salt libs
 import salt.utils
 import salt.utils.decorators as decorators
+import salt.utils.pkg.rpm
 from salt.exceptions import (
     CommandExecutionError, MinionError, SaltInvocationError
 )
 
 log = logging.getLogger(__name__)
-
-__QUERYFORMAT = '%{NAME}_|-%{VERSION}_|-%{RELEASE}_|-%{ARCH}_|-%{REPOID}'
-
-# These arches compiled from the rpmUtils.arch python module source
-__ARCHES_64 = ('x86_64', 'athlon', 'amd64', 'ia32e', 'ia64', 'geode')
-__ARCHES_32 = ('i386', 'i486', 'i586', 'i686')
-__ARCHES_PPC = ('ppc', 'ppc64', 'ppc64iseries', 'ppc64pseries')
-__ARCHES_S390 = ('s390', 's390x')
-__ARCHES_SPARC = (
-    'sparc', 'sparcv8', 'sparcv9', 'sparcv9v', 'sparc64', 'sparc64v'
-)
-__ARCHES_ALPHA = (
-    'alpha', 'alphaev4', 'alphaev45', 'alphaev5', 'alphaev56',
-    'alphapca56', 'alphaev6', 'alphaev67', 'alphaev68', 'alphaev7'
-)
-__ARCHES_ARM = ('armv5tel', 'armv5tejl', 'armv6l', 'armv7l')
-__ARCHES_SH = ('sh3', 'sh4', 'sh4a')
-
-__ARCHES = __ARCHES_64 + __ARCHES_32 + __ARCHES_PPC + __ARCHES_S390 + \
-    __ARCHES_ALPHA + __ARCHES_ARM + __ARCHES_SH
 
 # Define the module's virtual name
 __virtualname__ = 'pkg'
@@ -87,41 +68,16 @@ def __virtual__():
     return False
 
 
-def _parse_pkginfo(line):
-    '''
-    A small helper to parse a repoquery; returns a namedtuple
-    '''
-    # Importing `collections` here since this function is re-namespaced into
-    # another module
-    import collections
-    pkginfo = collections.namedtuple(
-        'PkgInfo',
-        ('name', 'version', 'arch', 'repoid')
-    )
-
-    try:
-        name, pkg_version, release, arch, repoid = line.split('_|-')
-    # Handle unpack errors (should never happen with the queryformat we are
-    # using, but can't hurt to be careful).
-    except ValueError:
-        return None
-
-    if not _check_32(arch):
-        if arch not in (__grains__['osarch'], 'noarch'):
-            name += '.{0}'.format(arch)
-    if release:
-        pkg_version += '-{0}'.format(release)
-
-    return pkginfo(name, pkg_version, arch, repoid)
-
-
 def _repoquery_pkginfo(repoquery_args):
     '''
     Wrapper to call repoquery and parse out all the tuples
     '''
     ret = []
     for line in _repoquery(repoquery_args, ignore_stderr=True):
-        pkginfo = _parse_pkginfo(line)
+        pkginfo = salt.utils.pkg.rpm.parse_pkginfo(
+            line,
+            osarch=__grains__['osarch']
+        )
         if pkginfo is not None:
             ret.append(pkginfo)
     return ret
@@ -143,7 +99,9 @@ def _check_repoquery():
             raise CommandExecutionError('Unable to install yum-utils')
 
 
-def _repoquery(repoquery_args, query_format=__QUERYFORMAT, ignore_stderr=False):
+def _repoquery(repoquery_args,
+               query_format=salt.utils.pkg.rpm.QUERYFORMAT,
+               ignore_stderr=False):
     '''
     Runs a repoquery command and returns a list of namedtuples
     '''
@@ -154,8 +112,8 @@ def _repoquery(repoquery_args, query_format=__QUERYFORMAT, ignore_stderr=False):
     call = __salt__['cmd.run_all'](cmd, output_loglevel='trace')
     if call['retcode'] != 0:
         comment = ''
-        # when checking for packages some yum modules return data via
-        # stderr that don't cause non-zero return codes.  A perfect
+        # When checking for packages some yum modules return data via
+        # stderr that don't cause non-zero return codes. j perfect
         # example of this is when spacewalk is installed but not yet
         # registered. We should ignore those when getting pkginfo.
         if 'stderr' in call and not salt.utils.is_true(ignore_stderr):
@@ -239,40 +197,6 @@ def _get_branch_option(**kwargs):
         log.info('Adding branch {0!r}'.format(branch))
         branch_arg = ('--branch={0!r}'.format(branch))
     return branch_arg
-
-
-def _check_32(arch):
-    '''
-    Returns True if both the OS arch and the passed arch are 32-bit
-    '''
-    return all(x in __ARCHES_32 for x in (__grains__['osarch'], arch))
-
-
-def _rpm_pkginfo(name):
-    '''
-    Parses RPM metadata and returns a pkginfo namedtuple
-    '''
-    # REPOID is not a valid tag for the rpm command. Remove it and replace it
-    # with 'none'
-    queryformat = __QUERYFORMAT.replace('%{REPOID}', 'none')
-    output = __salt__['cmd.run_stdout'](
-        'rpm -qp --queryformat {0!r} {1}'.format(_cmd_quote(queryformat), name),
-        output_loglevel='trace',
-        ignore_retcode=True
-    )
-    return _parse_pkginfo(output)
-
-
-def _rpm_installed(name):
-    '''
-    Parses RPM metadata to determine if the RPM target is already installed.
-    Returns the name of the installed package if found, otherwise None.
-    '''
-    pkg = _rpm_pkginfo(name)
-    try:
-        return pkg.name if pkg.name in list_pkgs() else None
-    except AttributeError:
-        return None
 
 
 def _get_yum_config():
@@ -391,11 +315,12 @@ def normalize_name(name):
     '''
     try:
         arch = name.rsplit('.', 1)[-1]
-        if arch not in __ARCHES + ('noarch',):
+        if arch not in salt.utils.pkg.rpm.ARCHES + ('noarch',):
             return name
     except ValueError:
         return name
-    if arch in (__grains__['osarch'], 'noarch') or _check_32(arch):
+    if arch in (__grains__['osarch'], 'noarch') \
+            or salt.utils.pkg.rpm.check_32(arch, osarch=__grains__['osarch']):
         return name[:-(len(arch) + 1)]
     return name
 
@@ -449,7 +374,7 @@ def latest_version(*names, **kwargs):
         ret[name] = ''
         try:
             arch = name.rsplit('.', 1)[-1]
-            if arch not in __ARCHES:
+            if arch not in salt.utils.pkg.rpm.ARCHES:
                 arch = __grains__['osarch']
         except ValueError:
             arch = __grains__['osarch']
@@ -476,7 +401,7 @@ def latest_version(*names, **kwargs):
     for name in names:
         for pkg in (x for x in updates if x.name == name):
             if pkg.arch == 'noarch' or pkg.arch == namearch_map[name] \
-                    or _check_32(pkg.arch):
+                    or salt.utils.pkg.rpm.check_32(pkg.arch):
                 ret[name] = pkg.version
                 # no need to check another match, if there was one
                 break
@@ -898,13 +823,11 @@ def install(name=None,
         architecture as an actual part of the name such as kernel modules
         which match a specific kernel version.
 
+        .. code-block:: bash
+
+            salt -G role:nsd pkg.install gpfs.gplbin-2.6.32-279.31.1.el6.x86_64 normalize=False
+
         .. versionadded:: 2014.7.0
-
-    Example:
-
-    .. code-block:: bash
-
-        salt -G role:nsd pkg.install gpfs.gplbin-2.6.32-279.31.1.el6.x86_64 normalize=False
 
 
     Returns a dict containing the new package names and versions::
@@ -948,36 +871,63 @@ def install(name=None,
     else:
         pkg_params_items = []
         for pkg_source in pkg_params:
-            rpm_info = _rpm_pkginfo(pkg_source)
-            if rpm_info is not None:
-                pkg_params_items.append([rpm_info.name, rpm_info.version, pkg_source])
+            if 'lowpkg.bin_pkg_info' in __salt__:
+                rpm_info = __salt__['lowpkg.bin_pkg_info'](pkg_source)
             else:
-                pkg_params_items.append([pkg_source, None, pkg_source])
+                rpm_info = None
+            if rpm_info is None:
+                log.error(
+                    'pkg.install: Unable to get rpm information for {0}. '
+                    'Version comparisons will be unavailable, and return '
+                    'data may be inaccurate if reinstall=True.'
+                    .format(pkg_source)
+                )
+                pkg_params_items.append([pkg_source])
+            else:
+                pkg_params_items.append(
+                    [rpm_info['name'], pkg_source, rpm_info['version']]
+                )
 
     for pkg_item_list in pkg_params_items:
-        pkgname = pkg_item_list[0]
-        version_num = pkg_item_list[1]
-        if version_num is None:
-            if reinstall and pkg_type == 'repository' and pkgname in old:
-                to_reinstall[pkgname] = pkgname
-            else:
-                targets.append(pkgname)
+        if pkg_type == 'repository':
+            pkgname, version_num = pkg_item_list
         else:
-            cver = old.get(pkgname, '')
-            arch = ''
             try:
-                namepart, archpart = pkgname.rsplit('.', 1)
+                pkgname, pkgpath, version_num = pkg_item_list
             except ValueError:
-                pass
-            else:
-                if archpart in __ARCHES:
-                    arch = '.' + archpart
-                    pkgname = namepart
+                pkgname = None
+                pkgpath = pkg_item_list[0]
+                version_num = None
 
+        if version_num is None:
             if pkg_type == 'repository':
+                if reinstall and pkgname in old:
+                    to_reinstall[pkgname] = pkgname
+                else:
+                    targets.append(pkgname)
+            else:
+                targets.append(pkgpath)
+        else:
+            # If we are installing a package file and not one from the repo,
+            # and version_num is not None, then we can assume that pkgname is
+            # not None, since the only way version_num is not None is if RPM
+            # metadata parsing was successful.
+            if pkg_type == 'repository':
+                arch = ''
+                try:
+                    namepart, archpart = pkgname.rsplit('.', 1)
+                except ValueError:
+                    pass
+                else:
+                    if archpart in salt.utils.pkg.rpm.ARCHES:
+                        arch = '.' + archpart
+                        pkgname = namepart
+
                 pkgstr = '"{0}-{1}{2}"'.format(pkgname, version_num, arch)
             else:
-                pkgstr = pkg_item_list[2]
+                pkgstr = pkgpath
+
+            cver = old.get(pkgname, '')
             if reinstall and cver \
                     and salt.utils.compare_versions(ver1=version_num,
                                                     oper='==',
@@ -1023,25 +973,14 @@ def install(name=None,
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
 
-    versionName = pkgname
     ret = salt.utils.compare_dicts(old, new)
 
-    if sources is not None:
-        versionName = pkgname + '-' + new.get(pkgname, '')
-        if pkgname in ret:
-            ret[versionName] = ret.pop(pkgname)
     for pkgname in to_reinstall:
-        if not versionName not in old:
-            ret.update({versionName: {'old': old.get(pkgname, ''),
+        if pkgname not in ret or pkgname in old:
+            ret.update({pkgname: {'old': old.get(pkgname, ''),
                                   'new': new.get(pkgname, '')}})
-        else:
-            if versionName not in ret:
-                ret.update({versionName: {'old': old.get(pkgname, ''),
-                                      'new': new.get(pkgname, '')}})
     if ret:
         __context__.pop('pkg._avail', None)
-    elif sources is not None:
-        ret = {versionName: {}}
     return ret
 
 

--- a/salt/utils/pkg/__init__.py
+++ b/salt/utils/pkg/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+'''
+Helper modules used by lowpkg modules
+'''

--- a/salt/utils/pkg/rpm.py
+++ b/salt/utils/pkg/rpm.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+'''
+Common
+'''
+
+# Import python libs
+from __future__ import absolute_import
+import logging
+
+# Import salt libs
+from salt._compat import subprocess
+
+log = logging.getLogger(__name__)
+
+# These arches compiled from the rpmUtils.arch python module source
+ARCHES_64 = ('x86_64', 'athlon', 'amd64', 'ia32e', 'ia64', 'geode')
+ARCHES_32 = ('i386', 'i486', 'i586', 'i686')
+ARCHES_PPC = ('ppc', 'ppc64', 'ppc64iseries', 'ppc64pseries')
+ARCHES_S390 = ('s390', 's390x')
+ARCHES_SPARC = (
+    'sparc', 'sparcv8', 'sparcv9', 'sparcv9v', 'sparc64', 'sparc64v'
+)
+ARCHES_ALPHA = (
+    'alpha', 'alphaev4', 'alphaev45', 'alphaev5', 'alphaev56',
+    'alphapca56', 'alphaev6', 'alphaev67', 'alphaev68', 'alphaev7'
+)
+ARCHES_ARM = ('armv5tel', 'armv5tejl', 'armv6l', 'armv7l')
+ARCHES_SH = ('sh3', 'sh4', 'sh4a')
+
+ARCHES = ARCHES_64 + ARCHES_32 + ARCHES_PPC + ARCHES_S390 + \
+    ARCHES_ALPHA + ARCHES_ARM + ARCHES_SH
+
+QUERYFORMAT = '%{NAME}_|-%{VERSION}_|-%{RELEASE}_|-%{ARCH}_|-%{REPOID}'
+
+
+def _osarch():
+    '''
+    Get the os architecture using rpm --eval
+    '''
+    ret = subprocess.Popen(
+        'rpm --eval "%{_host_cpu}"',
+        shell=True,
+        close_fds=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE).communicate()[0]
+    return ret or 'unknown'
+
+
+def check_32(arch, osarch=None):
+    '''
+    Returns True if both the OS arch and the passed arch are 32-bit
+    '''
+    if osarch is None:
+        osarch = _osarch()
+    return all(x in ARCHES_32 for x in (osarch, arch))
+
+
+def parse_pkginfo(line, osarch=None):
+    '''
+    A small helper to parse an rpm/repoquery command's output. Returns a
+    namedtuple
+    '''
+    # Importing `collections` here since this function is re-namespaced into
+    # another module
+    import collections
+    pkginfo = collections.namedtuple(
+        'PkgInfo',
+        ('name', 'version', 'arch', 'repoid')
+    )
+
+    try:
+        name, pkg_version, release, arch, repoid = line.split('_|-')
+    # Handle unpack errors (should never happen with the queryformat we are
+    # using, but can't hurt to be careful).
+    except ValueError:
+        return None
+
+    if osarch is None:
+        osarch = _osarch()
+
+    if not check_32(arch):
+        if arch not in (osarch, 'noarch'):
+            name += '.{0}'.format(arch)
+    if release:
+        pkg_version += '-{0}'.format(release)
+
+    return pkginfo(name, pkg_version, arch, repoid)


### PR DESCRIPTION
This implements #7772 for yumpkg.py. Future pull requests will fill out support
for the other providers.

QA: We need to test binary package installs on other platforms, as well as all
manner of repository installs (with and without "pkgs", with and without
versions being specified, etc.). Our test coverage for repository packages is
good, but there may be edge cases for which I did not account.
