### PR TITLE
Fixes to debian_ip.py

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -591,7 +591,11 @@ def _parse_interfaces(interface_files=None):
                         iface_dict['ethtool'][attr] = valuestr
 
                     elif attr.startswith('bond'):
-                        opt = attr.split('_', 1)[1]
+                        if '-' in attr:
+                            opt = attr.split('-', 1)[1]
+                        elif '_' in attr:
+                            # Just in case configuration still has bond_
+                            opt = attr.split('_', 1)[1]
                         if 'bonding' not in iface_dict:
                             iface_dict['bonding'] = salt.utils.odict.OrderedDict()
                         iface_dict['bonding'][opt] = valuestr


### PR DESCRIPTION
Fixing issue reported when using bonded interfaces on Ubuntu.  Attributes should be bond-, but the code was attempting to split just on bond_.  Fix accounts for both, but the debian_ip.py module will write out bond attributes with bond- #23900 
