### PR TITLE
updates to beacons module

### DIFF
--- a/salt/beacons/__init__.py
+++ b/salt/beacons/__init__.py
@@ -96,6 +96,17 @@ class Beacon(object):
             self.interval_map[mod] = 1
         return False
 
+    def list_beacons(self):
+        '''
+        List the beacon items
+        '''
+        # Fire the complete event back along with the list of beacons
+        evt = salt.utils.event.get_event('minion', opts=self.opts)
+        evt.fire_event({'complete': True, 'beacons': self.opts['beacons']},
+                       tag='/salt/minion/minion_beacons_list_complete')
+
+        return True
+
     def add_beacon(self, name, beacon_data):
         '''
         Add a beacon item

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1371,6 +1371,8 @@ class Minion(MinionBase):
             self.beacons.enable_beacon(name)
         elif func == 'disable_beacon':
             self.beacons.disable_beacon(name)
+        elif func == 'list':
+            self.beacons.list_beacons()
 
     def environ_setenv(self, package):
         '''


### PR DESCRIPTION
Switching the list function in the beacon execution module to use an event to retrieve the list of beacons to ensure consistency when using salt vs salt-call
