### PR TITLE
Fix salt.cloud.Cloud salt.client.get_local_client call

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1261,7 +1261,12 @@ class Cloud(object):
 
                 # a small pause makes the sync work reliably
                 time.sleep(3)
-                client = salt.client.get_local_client(mopts=self.opts)
+
+                minopts = salt.config.DEFAULT_MASTER_OPTS
+                minopts.update(salt.config.minion_config('/etc/salt/master'))
+
+                client = salt.client.get_local_client(mopts=minopts)
+
                 ret = client.cmd(vm_['name'], 'saltutil.sync_{0}'.format(
                     self.opts['sync_after_install']
                 ))

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1262,8 +1262,14 @@ class Cloud(object):
                 # a small pause makes the sync work reliably
                 time.sleep(3)
 
-                mopts_ = salt.config.DEFAULT_MASTER_OPTS
-                mopts_.update(salt.config.minion_config('/etc/salt/master'))
+                mopts_ = salt.config.DEFAULT_MINION_OPTS
+                conf_path = '/'.join(__opts__['conf_file'].split('/')[:-1])
+                mopts_.update(
+                    salt.config.minion_config(
+                        os.path.join(conf_path,
+                                     'minion')
+                    )
+                )
 
                 client = salt.client.get_local_client(mopts=mopts_)
 

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1262,10 +1262,10 @@ class Cloud(object):
                 # a small pause makes the sync work reliably
                 time.sleep(3)
 
-                minopts = salt.config.DEFAULT_MASTER_OPTS
-                minopts.update(salt.config.minion_config('/etc/salt/master'))
+                mopts_ = salt.config.DEFAULT_MASTER_OPTS
+                mopts_.update(salt.config.minion_config('/etc/salt/master'))
 
-                client = salt.client.get_local_client(mopts=minopts)
+                client = salt.client.get_local_client(mopts=mopts_)
 
                 ret = client.cmd(vm_['name'], 'saltutil.sync_{0}'.format(
                     self.opts['sync_after_install']

--- a/salt/cloud/libcloudfuncs.py
+++ b/salt/cloud/libcloudfuncs.py
@@ -362,9 +362,13 @@ def destroy(name, conn=None, call=None):
             flush_mine_on_destroy = profiles[profile]['flush_mine_on_destroy']
     if flush_mine_on_destroy:
         log.info('Clearing Salt Mine: {0}'.format(name))
-        mopts = config.DEFAULT_MASTER_OPTS
-        mopts.update(config.master_config('/etc/salt/master'))
-        client = salt.client.get_local_client(mopts)
+
+        mopts_ = salt.config.DEFAULT_MINION_OPTS
+        conf_path = '/'.join(__opts__['conf_file'].split('/')[:-1])
+        mopts_.update(
+            salt.config.minion_config(os.path.join(conf_path, 'minion'))
+        )
+        client = salt.client.get_local_client(mopts_)
         minions = client.cmd(name, 'mine.flush')
 
     log.info('Clearing Salt Mine: {0}, {1}'.format(name, flush_mine_on_destroy))

--- a/salt/cloud/libcloudfuncs.py
+++ b/salt/cloud/libcloudfuncs.py
@@ -362,7 +362,9 @@ def destroy(name, conn=None, call=None):
             flush_mine_on_destroy = profiles[profile]['flush_mine_on_destroy']
     if flush_mine_on_destroy:
         log.info('Clearing Salt Mine: {0}'.format(name))
-        client = salt.client.get_local_client(__opts__['conf_file'])
+        mopts = config.DEFAULT_MASTER_OPTS
+        mopts.update(config.master_config('/etc/salt/master'))
+        client = salt.client.get_local_client(mopts)
         minions = client.cmd(name, 'mine.flush')
 
     log.info('Clearing Salt Mine: {0}, {1}'.format(name, flush_mine_on_destroy))

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 '''
-Routines to set up a minion
+We wanna be free to ride our machines without being hassled by The Man!
+And we wanna get loaded!
+And we wanna have a good time!
+And that's what we are gonna do. We are gonna have a good time...
 '''
 
 # Import python libs


### PR DESCRIPTION
…uch as

sync_after_install

f8ae7503c566f615bf39b83ad16d5e6261dc2b7b introduced code in the local client
object that broke when fed salt-cloud **opts**.  This merely loads the local
master defaults + config to make loader happy again.

clarification: this does not modify or overwrite anything salt.cloud related-- just loads the config, feeds it to the loader and then its gc'd
