### PR TITLE
Fixing ImportError in salt 2014.7.0 version causing VMware salt-cloud driver to fail

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -92,7 +92,14 @@ except Exception:
     pass
 
 # Import third party libs
-import salt.ext.six as six
+try:
+    import salt.ext.six as six
+except ImportError:
+    # Salt version <= 2014.7.0
+    try:
+        import six
+    except ImportError:
+        HAS_LIBS = False
 
 # Get logging started
 log = logging.getLogger(__name__)


### PR DESCRIPTION
Fixes #23953 
