### PR TITLE
handle all exceptions gitpython can raise

### DIFF
--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -388,13 +388,12 @@ def _get_tree_gitpython(repo, tgt_env):
     # Branch or tag not matched, check if 'tgt_env' is a commit
     if not _env_is_exposed(tgt_env):
         return None
+
     try:
         commit = repo['repo'].rev_parse(tgt_env)
-    except gitdb.exc.BadObject:
-        pass
-    else:
         return commit.tree
-    return None
+    except gitdb.exc.ODBError:
+        return None
 
 
 def _get_tree_pygit2(repo, tgt_env):


### PR DESCRIPTION
and make the code cleaner.

initially, I handle the exception by:

```
except (gitdb.exc.BadObject, gitdb.exc.BadName):
```

but it will fail if user use old version of gitdb, because gitdb.exc.BadName only added since https://github.com/gitpython-developers/gitdb/commit/7bde7b098b07291227fcbc4eb900ebf13c9191a2 , only available in `0.6.4+`.
