### PR TITLE
Quick note on usability of 'include' statement.

### DIFF
--- a/doc/ref/states/include.rst
+++ b/doc/ref/states/include.rst
@@ -30,6 +30,10 @@ the following syntax is used:
     include:
       - dev: http
 
+**NOTE**: `include` does not simply inject the states where you place it
+in the sls file. If you need to guarantee order of execution, consider using 
+requisites.
+
 .. include:: ../../_incl/_incl/sls_filename_cant_contain_period.rst
 
 Relative Include


### PR DESCRIPTION
Users (myself included) often confuse how to use the `include` statement, thinking that they can drop it into the middle of an sls file and it will inject the included states into the middle of the sls file. This leads to confusion and repeat conversations in the chat room.

Just a quick note to remind people that `include` won't inject states into the sls file.
