### PR TITLE
Check for VOLUME lines in image

### DIFF
--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -1391,12 +1391,10 @@ def running(name,
         if runtime_kwargs.get('binds') is not None:
             if 'volumes' not in create_kwargs:
                 # Check if there are preconfigured volumes in the image
-                preconfigured_volumes = False
                 for step in __salt__['dockerng.history'](image, quiet=True):
                     if step.lstrip().startswith('VOLUME'):
-                        preconfigured_volumes = True
                         break
-                if not preconfigured_volumes:
+                else:
                     # No preconfigured volumes, we need to make our own. Use
                     # the ones from the "binds" configuration.
                     create_kwargs['volumes'] = [

--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -1389,11 +1389,20 @@ def running(name,
         # Add any needed container creation arguments based on the validated
         # runtime arguments.
         if runtime_kwargs.get('binds') is not None:
-            # Using bind mounts requries mountpoints to be specified at the
-            # time the container is created, so we need to add them to the
-            # create_kwargs.
-            create_kwargs['volumes'] = [bind_conf['bind'] for bind_conf in
-                                        runtime_kwargs['binds'].values()]
+            if 'volumes' not in create_kwargs:
+                # Check if there are preconfigured volumes in the image
+                preconfigured_volumes = False
+                for step in __salt__['dockerng.history'](image, quiet=True):
+                    if step.lstrip().startswith('VOLUME'):
+                        preconfigured_volumes = True
+                        break
+                if not preconfigured_volumes:
+                    # No preconfigured volumes, we need to make our own. Use
+                    # the ones from the "binds" configuration.
+                    create_kwargs['volumes'] = [
+                        x['bind']
+                        for x in six.itervalues(runtime_kwargs['binds'])
+                    ]
         if runtime_kwargs.get('port_bindings') is not None \
                 and create_kwargs.get('ports') is None:
             create_kwargs['ports'] = ','.join(

--- a/tests/unit/states/dockerng_test.py
+++ b/tests/unit/states/dockerng_test.py
@@ -39,14 +39,17 @@ class DockerngTestCase(TestCase):
         '''
         Test dockerng.running function
         '''
+        mock_volume = '/container-0'
         dockerng_create = Mock()
         dockerng_start = Mock()
+        dockerng_history = MagicMock(return_value=mock_volume)
         __salt__ = {'dockerng.list_containers': MagicMock(),
                     'dockerng.list_tags': MagicMock(),
                     'dockerng.pull': MagicMock(),
                     'dockerng.state': MagicMock(),
                     'dockerng.create': dockerng_create,
                     'dockerng.start': dockerng_start,
+                    'dockerng.history': dockerng_history,
                     }
         with patch.dict(dockerng_state.__dict__,
                         {'__salt__': __salt__}):
@@ -58,7 +61,7 @@ class DockerngTestCase(TestCase):
             'image:latest',
             validate_input=False,
             name='cont',
-            volumes=['/container-0'],
+            volumes=[mock_volume],
             client_timeout=60)
         dockerng_start.assert_called_with(
             'cont',


### PR DESCRIPTION
Only add volumes to the container creation arguments if there are binds, but
no volumes, and even then only when there are no preconfigured volumes in the
image.

This fixes cases where preconfigured (but unbound) volumes result in the
dockerng.running state thinking that the container configuration does not
match.

NOTE: This is a better solution for the pull request @ticosax opened in #23912.
Once this is merged, I'd like @ticosax to open a new pull request to include
his wonderfully-written tests.
