### PR TITLE
Instead of raising the exception() instance, raise from exc_info()

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -577,6 +577,9 @@ class Minion(MinionBase):
         # finish connecting to master
         self._connect_master_future.add_done_callback(lambda f: self.io_loop.stop())
         self.io_loop.start()
+        # I made the following 3 line oddity to preserve traceback.
+        # Please read PR #23978 before changing, hopefully avoiding regressions.
+        # Good luck, we're all counting on you.  Thanks.
         future_exception = self._connect_master_future.exc_info()
         if future_exception:
             raise six.reraise(*future_exception)

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -579,7 +579,7 @@ class Minion(MinionBase):
         self.io_loop.start()
         future_exception = self._connect_master_future.exc_info()
         if future_exception:
-            raise future_exception[0], future_exception[1], future_exception[2]
+            raise six.reraise(*future_exception)
 
     @tornado.gen.coroutine
     def connect_master(self):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -577,8 +577,9 @@ class Minion(MinionBase):
         # finish connecting to master
         self._connect_master_future.add_done_callback(lambda f: self.io_loop.stop())
         self.io_loop.start()
-        if self._connect_master_future.exception():
-            raise self._connect_master_future.exception()
+        future_exception = self._connect_master_future.exc_info()
+        if future_exception:
+            raise future_exception[0], future_exception[1], future_exception[2]
 
     @tornado.gen.coroutine
     def connect_master(self):


### PR DESCRIPTION
Since this is probably non-obvious as to why I've applied this change, I'll provide some better context.

I've got an unrelated issue with my minion dev version, but the exception was getting mangled.

The problem is that `sync_connect_master` is trying to re-raise the exception instance it gets back from the `Future` instance.  Why this is a problem is that the exception doesn't actually originate in that context, so raise is nuking the traceback by raising a new exception with the same value.

The proper way to handle this is to specify the traceback when raising a new exception, but how to do that is different in python 2 vs python 3.
In Python 2 you would call raise with 3 parameters, like I did in 5580eab.
Python 3 does away with this because exceptions now have the traceback stored internally, you'd raise something like `E(V).with_traceback(T)` instead.

Thankfully, there is a nice compatibility function available in `six`, and we bundle that so it's a safe thing to rely on.  As such, I changed the PR to use that function.
That actually leaves us with syntax far nicer than either: `raise six.reraise(*future_exception)` ... very tidy.

An unhelpful exception from before:

```
Traceback (most recent call last):
  File "/home/redacted/salt-dev/salt/salt/scripts.py", line 81, in minion_process
    minion.start()
  File "/home/redacted/salt-dev/salt/salt/cli/daemons.py", line 269, in start
    self.minion.tune_in()
  File "/home/redacted/salt-dev/salt/salt/minion.py", line 1580, in tune_in
    self.sync_connect_master()
  File "/home/redacted/salt-dev/salt/salt/minion.py", line 581, in sync_connect_master
    raise self._connect_master_future.exception()
TypeError: cannot concatenate 'str' and 'int' objects
```

A much better traceback from after:

```
Traceback (most recent call last):
  File "/home/redacted/salt-dev/salt/salt/scripts.py", line 81, in minion_process
    minion.start()
  File "/home/redacted/salt-dev/salt/salt/cli/daemons.py", line 269, in start
    self.minion.tune_in()
  File "/home/redacted/salt-dev/salt/salt/minion.py", line 1581, in tune_in
    self.sync_connect_master()
  File "/home/redacted/salt-dev/salt/salt/minion.py", line 582, in sync_connect_master
    six.reraise(*e)
  File "/home/redacted/salt-dev/local/lib/python2.7/site-packages/tornado/gen.py", line 810, in run
    yielded = self.gen.throw(*sys.exc_info())
  File "/home/redacted/salt-dev/salt/salt/minion.py", line 590, in connect_master
    yield self._post_master_init(master)
  File "/home/redacted/salt-dev/local/lib/python2.7/site-packages/tornado/gen.py", line 807, in run
    value = future.result()
  File "/home/redacted/salt-dev/local/lib/python2.7/site-packages/tornado/concurrent.py", line 209, in result
    raise_exc_info(self._exc_info)
  File "/home/redacted/salt-dev/local/lib/python2.7/site-packages/tornado/gen.py", line 812, in run
    yielded = self.gen.send(value)
  File "/home/redacted/salt-dev/salt/salt/minion.py", line 631, in _post_master_init
    'maxrunning': 2
  File "/home/redacted/salt-dev/salt/salt/utils/schedule.py", line 401, in add_job
    tag='/salt/minion/minion_schedule_add_complete')
  File "/home/redacted/salt-dev/salt/salt/utils/event.py", line 496, in fire_event
    log.debug('mes @ event: '+self.opts.get('max_event_size', 'missing'))
TypeError: cannot concatenate 'str' and 'int' objects
```

As we can see, I failed miserably at remembering to shove a `str()` around my debugging statement's `self.opts.get()` call.  Oops.

I'll add a note to the code (should be the third commit) directing anyone seeing is oddity to read this PR before changing it.  Just in case someone has the thought to simplify the code heh.
