### PR TITLE
template: jinja2 -> jinja

### DIFF
--- a/salt/states/debconfmod.py
+++ b/salt/states/debconfmod.py
@@ -76,7 +76,7 @@ def set_file(name, source, template=None, context=None, defaults=None, **kwargs)
         <state_id>:
           debconf.set_file:
             - source: salt://pathto/pkg.selections.jinja2
-            - template: jinja2
+            - template: jinja
             - context:
                 some_value: "false"
 


### PR DESCRIPTION
Silly typo. Docs and man pages probably need to be regenerated after this.
