### PR TITLE
lxc: path support

### DIFF
--- a/salt/modules/container_resource.py
+++ b/salt/modules/container_resource.py
@@ -13,6 +13,7 @@ common logic to be re-used for common actions.
 # Import python libs
 from __future__ import absolute_import
 import functools
+import copy
 import logging
 import os
 import pipes
@@ -123,10 +124,17 @@ def run(name,
         python_shell=True,
         output_loglevel='debug',
         ignore_retcode=False,
+        path=None,
         use_vt=False,
         keep_env=None):
     '''
     Common logic for running shell commands in containers
+
+    path
+        path to the container parent (for LXC only)
+        default: /var/lib/lxc (system default)
+
+        .. versionadded:: Beryllium
 
     CLI Example:
 
@@ -158,6 +166,8 @@ def run(name,
 
     if exec_driver == 'lxc-attach':
         full_cmd = 'lxc-attach '
+        if path:
+            full_cmd += '-P {0} '.format(pipes.quote(path))
         if keep_env is not True:
             full_cmd += '--clear-env '
             if 'PATH' not in to_keep:
@@ -262,11 +272,18 @@ def copy_to(name,
             source,
             dest,
             container_type=None,
+            path=None,
             exec_driver=None,
             overwrite=False,
             makedirs=False):
     '''
     Common logic for copying files to containers
+
+    path
+        path to the container parent (for LXC only)
+        default: /var/lib/lxc (system default)
+
+        .. versionadded:: Beryllium
 
     CLI Example:
 
@@ -276,9 +293,27 @@ def copy_to(name,
     '''
     # Get the appropriate functions
     state = __salt__['{0}.state'.format(container_type)]
-    run_all = __salt__['{0}.run_all'.format(container_type)]
 
-    c_state = state(name)
+    def run_all(*args, **akwargs):
+        akwargs = copy.deepcopy(akwargs)
+        if container_type in ['lxc'] and 'path' not in akwargs:
+            akwargs['path'] = path
+        return __salt__['{0}.run_all'.format(container_type)](
+            *args, **akwargs)
+
+    state_kwargs = {}
+    cmd_kwargs = {'ignore_retcode': True}
+    if container_type in ['lxc']:
+        cmd_kwargs['path'] = path
+        state_kwargs['path'] = path
+
+    def _state(name):
+        if state_kwargs:
+            return state(name, **state_kwargs)
+        else:
+            return state(name)
+
+    c_state = _state(name)
     if c_state != 'running':
         raise CommandExecutionError(
             'Container \'{0}\' is not running'.format(name)
@@ -302,7 +337,7 @@ def copy_to(name,
         raise SaltInvocationError('Destination path must be absolute')
     if run_all(name,
                'test -d {0}'.format(pipes.quote(dest)),
-               ignore_retcode=True)['retcode'] == 0:
+               **cmd_kwargs)['retcode'] == 0:
         # Destination is a directory, full path to dest file will include the
         # basename of the source file.
         dest = os.path.join(dest, source_name)
@@ -313,10 +348,11 @@ def copy_to(name,
         dest_dir, dest_name = os.path.split(dest)
         if run_all(name,
                    'test -d {0}'.format(pipes.quote(dest_dir)),
-                   ignore_retcode=True)['retcode'] != 0:
+                   **cmd_kwargs)['retcode'] != 0:
             if makedirs:
                 result = run_all(name,
-                                 'mkdir -p {0}'.format(pipes.quote(dest_dir)))
+                                 'mkdir -p {0}'.format(pipes.quote(dest_dir)),
+                                 **cmd_kwargs)
                 if result['retcode'] != 0:
                     error = ('Unable to create destination directory {0} in '
                              'container \'{1}\''.format(dest_dir, name))
@@ -330,7 +366,7 @@ def copy_to(name,
                 )
     if not overwrite and run_all(name,
                                  'test -e {0}'.format(pipes.quote(dest)),
-                                 ignore_retcode=True)['retcode'] == 0:
+                                 **cmd_kwargs)['retcode'] == 0:
         raise CommandExecutionError(
             'Destination path {0} already exists. Use overwrite=True to '
             'overwrite it'.format(dest)
@@ -350,9 +386,12 @@ def copy_to(name,
     # and passing it as stdin to run(). This will keep down memory
     # usage for the minion and make the operation run quicker.
     if exec_driver == 'lxc-attach':
+        lxcattach = 'lxc-attach'
+        if path:
+            lxcattach += ' -P {0}'.format(pipes.quote(path))
         copy_cmd = (
-            'cat "{0}" | lxc-attach --clear-env --set-var {1} -n {2} -- '
-            'tee "{3}"'.format(local_file, PATH, name, dest)
+            'cat "{0}" | {4} --clear-env --set-var {1} -n {2} -- '
+            'tee "{3}"'.format(local_file, PATH, name, dest, lxcattach)
         )
     elif exec_driver == 'nsenter':
         pid = __salt__['{0}.pid'.format(container_type)](name)

--- a/salt/runners/lxc.py
+++ b/salt/runners/lxc.py
@@ -31,11 +31,17 @@ __func_alias__ = {
 }
 
 
-def _do(name, fun):
+def _do(name, fun, path=None):
     '''
     Invoke a function in the lxc module with no args
+
+    path
+        path to the container parent
+        default: /var/lib/lxc (system default)
+
+        .. versionadded:: Beryllium
     '''
-    host = find_guest(name, quiet=True)
+    host = find_guest(name, quiet=True, path=path)
     if not host:
         return False
 
@@ -44,6 +50,7 @@ def _do(name, fun):
             host,
             'lxc.{0}'.format(fun),
             [name],
+            kwarg={'path': path},
             timeout=60)
     data = next(cmd_ret)
     data = data.get(host, {}).get('ret', None)
@@ -52,12 +59,18 @@ def _do(name, fun):
     return data
 
 
-def _do_names(names, fun):
+def _do_names(names, fun, path=None):
     '''
     Invoke a function in the lxc module with no args
+
+    path
+        path to the container parent
+        default: /var/lib/lxc (system default)
+
+        .. versionadded:: Beryllium
     '''
     ret = {}
-    hosts = find_guests(names)
+    hosts = find_guests(names, path=path)
     if not hosts:
         return False
 
@@ -69,6 +82,7 @@ def _do_names(names, fun):
                     host,
                     'lxc.{0}'.format(fun),
                     [name],
+                    kwarg={'path': path},
                     timeout=60))
         for cmd in cmds:
             data = next(cmd)
@@ -78,33 +92,51 @@ def _do_names(names, fun):
     return ret
 
 
-def find_guest(name, quiet=False):
+def find_guest(name, quiet=False, path=None):
     '''
     Returns the host for a container.
+
+    path
+        path to the container parent
+        default: /var/lib/lxc (system default)
+
+        .. versionadded:: Beryllium
+
 
     .. code-block:: bash
 
         salt-run lxc.find_guest name
     '''
     if quiet:
-        log.warn('\'quiet\' argument is being deprecated. Please migrate to --quiet')
-    for data in _list_iter():
+        log.warn('\'quiet\' argument is being deprecated.'
+                 ' Please migrate to --quiet')
+    for data in _list_iter(path=path):
         host, l = next(six.iteritems(data))
         for x in 'running', 'frozen', 'stopped':
             if name in l[x]:
                 if not quiet:
-                    __jid_event__.fire_event({'data': host, 'outputter': 'lxc_find_host'}, 'progress')
+                    __jid_event__.fire_event(
+                        {'data': host,
+                         'outputter': 'lxc_find_host'},
+                        'progress')
                 return host
     return None
 
 
-def find_guests(names):
+def find_guests(names, path=None):
     '''
     Return a dict of hosts and named guests
+
+    path
+        path to the container parent
+        default: /var/lib/lxc (system default)
+
+        .. versionadded:: Beryllium
+
     '''
     ret = {}
     names = names.split(',')
-    for data in _list_iter():
+    for data in _list_iter(path=path):
         host, stat = next(six.iteritems(data))
         for state in stat:
             for name in stat[state]:
@@ -139,6 +171,12 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
     host
         Minion on which to initialize the container **(required)**
 
+    path
+        path to the container parent
+        default: /var/lib/lxc (system default)
+
+        .. versionadded:: Beryllium
+
     saltcloud_mode
         init the container with the saltcloud opts format instead
         See lxc.init_interface module documentation
@@ -169,7 +207,7 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
     network_profile
         Network profile to use for the container
 
-        .. versionadded:: 2015.5.0
+        .. versionadded:: 2015.5.2
 
     nic
         .. deprecated:: 2015.5.0
@@ -194,8 +232,10 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
         Optional config parameters. By default, the id is set to
         the name of the container.
     '''
+    path = kwargs.get('path', None)
     if quiet:
-        log.warn('\'quiet\' argument is being deprecated. Please migrate to --quiet')
+        log.warn('\'quiet\' argument is being deprecated.'
+                 ' Please migrate to --quiet')
     ret = {'comment': '', 'result': True}
     if host is None:
         # TODO: Support selection of host based on available memory/cpu/etc.
@@ -222,7 +262,7 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
         return ret
 
     log.info('Searching for LXC Hosts')
-    data = __salt__['lxc.list'](host, quiet=True)
+    data = __salt__['lxc.list'](host, quiet=True, path=path)
     for host, containers in six.iteritems(data):
         for name in names:
             if name in sum(six.itervalues(containers), []):
@@ -372,6 +412,12 @@ def cloud_init(names, host=None, quiet=False, **kwargs):
     host
         Minion to start the container on. Required.
 
+    path
+        path to the container parent
+        default: /var/lib/lxc (system default)
+
+        .. versionadded:: Beryllium
+
     saltcloud_mode
         init the container with the saltcloud opts format instead
     '''
@@ -381,13 +427,21 @@ def cloud_init(names, host=None, quiet=False, **kwargs):
                                 saltcloud_mode=True, quiet=quiet, **kwargs)
 
 
-def _list_iter(host=None):
+def _list_iter(host=None, path=None):
     '''
     Return a generator iterating over hosts
+
+    path
+        path to the container parent
+        default: /var/lib/lxc (system default)
+
+        .. versionadded:: Beryllium
     '''
     tgt = host or '*'
     client = salt.client.get_local_client(__opts__['conf_file'])
-    for container_info in client.cmd_iter(tgt, 'lxc.list'):
+    for container_info in client.cmd_iter(
+        tgt, 'lxc.list', kwarg={'path': path}
+    ):
         if not container_info:
             continue
         if not isinstance(container_info, dict):
@@ -406,34 +460,47 @@ def _list_iter(host=None):
         yield chunk
 
 
-def list_(host=None, quiet=False):
+def list_(host=None, quiet=False, path=None):
     '''
     List defined containers (running, stopped, and frozen) for the named
     (or all) host(s).
+
+    path
+        path to the container parent
+        default: /var/lib/lxc (system default)
+
+        .. versionadded:: Beryllium
 
     .. code-block:: bash
 
         salt-run lxc.list [host=minion_id]
     '''
-    it = _list_iter(host)
+    it = _list_iter(host, path=path)
     ret = {}
     for chunk in it:
         ret.update(chunk)
         if not quiet:
-            __jid_event__.fire_event({'data': chunk, 'outputter': 'lxc_list'}, 'progress')
+            __jid_event__.fire_event(
+                {'data': chunk, 'outputter': 'lxc_list'}, 'progress')
     return ret
 
 
-def purge(name, delete_key=True, quiet=False):
+def purge(name, delete_key=True, quiet=False, path=None):
     '''
     Purge the named container and delete its minion key if present.
     WARNING: Destroys all data associated with the container.
+
+    path
+        path to the container parent
+        default: /var/lib/lxc (system default)
+
+        .. versionadded:: Beryllium
 
     .. code-block:: bash
 
         salt-run lxc.purge name
     '''
-    data = _do_names(name, 'destroy')
+    data = _do_names(name, 'destroy', path=path)
     if data is False:
         return data
 
@@ -445,41 +512,62 @@ def purge(name, delete_key=True, quiet=False):
         return
 
     if not quiet:
-        __jid_event__.fire_event({'data': data, 'outputter': 'lxc_purge'}, 'progress')
+        __jid_event__.fire_event(
+            {'data': data, 'outputter': 'lxc_purge'}, 'progress')
     return data
 
 
-def start(name, quiet=False):
+def start(name, quiet=False, path=None):
     '''
     Start the named container.
+
+    path
+        path to the container parent
+        default: /var/lib/lxc (system default)
+
+        .. versionadded:: Beryllium
 
     .. code-block:: bash
 
         salt-run lxc.start name
     '''
-    data = _do_names(name, 'start')
+    data = _do_names(name, 'start', path=path)
     if data and not quiet:
-        __jid_event__.fire_event({'data': data, 'outputter': 'lxc_start'}, 'progress')
+        __jid_event__.fire_event(
+            {'data': data, 'outputter': 'lxc_start'}, 'progress')
     return data
 
 
-def stop(name, quiet=False):
+def stop(name, quiet=False, path=None):
     '''
     Stop the named container.
+
+    path
+        path to the container parent
+        default: /var/lib/lxc (system default)
+
+        .. versionadded:: Beryllium
 
     .. code-block:: bash
 
         salt-run lxc.stop name
     '''
-    data = _do_names(name, 'stop')
+    data = _do_names(name, 'stop', path=path)
     if data and not quiet:
-        __jid_event__.fire_event({'data': data, 'outputter': 'lxc_force_off'}, 'progress')
+        __jid_event__.fire_event(
+            {'data': data, 'outputter': 'lxc_force_off'}, 'progress')
     return data
 
 
-def freeze(name, quiet=False):
+def freeze(name, quiet=False, path=None):
     '''
     Freeze the named container
+
+    path
+        path to the container parent
+        default: /var/lib/lxc (system default)
+
+        .. versionadded:: Beryllium
 
     .. code-block:: bash
 
@@ -487,33 +575,48 @@ def freeze(name, quiet=False):
     '''
     data = _do_names(name, 'freeze')
     if data and not quiet:
-        __jid_event__.fire_event({'data': data, 'outputter': 'lxc_pause'}, 'progress')
+        __jid_event__.fire_event(
+            {'data': data, 'outputter': 'lxc_pause'}, 'progress')
     return data
 
 
-def unfreeze(name, quiet=False):
+def unfreeze(name, quiet=False, path=None):
     '''
     Unfreeze the named container
+
+    path
+        path to the container parent
+        default: /var/lib/lxc (system default)
+
+        .. versionadded:: Beryllium
 
     .. code-block:: bash
 
         salt-run lxc.unfreeze name
     '''
-    data = _do_names(name, 'unfreeze')
+    data = _do_names(name, 'unfreeze', path=path)
     if data and not quiet:
-        __jid_event__.fire_event({'data': data, 'outputter': 'lxc_resume'}, 'progress')
+        __jid_event__.fire_event(
+            {'data': data, 'outputter': 'lxc_resume'}, 'progress')
     return data
 
 
-def info(name, quiet=False):
+def info(name, quiet=False, path=None):
     '''
     Returns information about a container.
+
+    path
+        path to the container parent
+        default: /var/lib/lxc (system default)
+
+        .. versionadded:: Beryllium
 
     .. code-block:: bash
 
         salt-run lxc.info name
     '''
-    data = _do_names(name, 'info')
+    data = _do_names(name, 'info', path=path)
     if data and not quiet:
-        __jid_event__.fire_event({'data': data, 'outputter': 'lxc_info'}, 'progress')
+        __jid_event__.fire_event(
+            {'data': data, 'outputter': 'lxc_info'}, 'progress')
     return data

--- a/salt/states/lxc.py
+++ b/salt/states/lxc.py
@@ -27,9 +27,11 @@ def present(name,
             size=None,
             backing=None,
             vgname=None,
-            lvname=None):
+            lvname=None,
+            path=None):
     '''
-    .. versionchanged:: 2015.5.0
+    .. versionchanged:: Beryllium
+
         The :mod:`lxc.created <salt.states.lxc.created>` state has been renamed
         to ``lxc.present``, and the :mod:`lxc.cloned <salt.states.lxc.cloned>`
         state has been merged into this state.
@@ -39,13 +41,20 @@ def present(name,
     name
         The name of the container to be created
 
+    path
+        path to the container parent
+        default: /var/lib/lxc (system default)
+
+        .. versionadded:: Beryllium
+
+
     running : False
         * If ``True``, ensure that the container is running
         * If ``False``, ensure that the container is stopped
         * If ``None``, do nothing with regards to the running state of the
           container
 
-        .. versionadded:: 2015.5.0
+        .. versionadded:: Beryllium
 
     clone_from
         Create named container as a clone of the specified container
@@ -85,6 +94,7 @@ def present(name,
             <salt.modules.lxc.images>` function.
 
     options
+
         .. versionadded:: 2015.5.0
 
         Template-specific options to pass to the lxc-create command. These
@@ -153,7 +163,7 @@ def present(name,
                 pass
 
     # Sanity check(s)
-    if clone_from and not __salt__['lxc.exists'](clone_from):
+    if clone_from and not __salt__['lxc.exists'](clone_from, path=path):
         ret['result'] = False
         ret['comment'] = ('Clone source \'{0}\' does not exist'
                           .format(clone_from))
@@ -162,7 +172,7 @@ def present(name,
 
     action = 'cloned from {0}'.format(clone_from) if clone_from else 'created'
 
-    state = {'old': __salt__['lxc.state'](name)}
+    state = {'old': __salt__['lxc.state'](name, path=path)}
     if __opts__['test']:
         if state['old'] is None:
             ret['comment'] = (
@@ -213,6 +223,7 @@ def present(name,
                                                network_profile=network_profile,
                                                snapshot=snapshot,
                                                size=size,
+                                               path=path,
                                                backing=backing)
             else:
                 result = __salt__['lxc.create'](
@@ -227,6 +238,7 @@ def present(name,
                     size=size,
                     backing=backing,
                     vgname=vgname,
+                    path=path,
                     lvname=lvname)
         except (CommandExecutionError, SaltInvocationError) as exc:
             ret['result'] = False
@@ -245,7 +257,7 @@ def present(name,
             # Don't do anything
             pass
         elif running:
-            c_state = __salt__['lxc.state'](name)
+            c_state = __salt__['lxc.state'](name, path=path)
             if c_state == 'running':
                 ret['comment'] += ' and is running'
             else:
@@ -253,7 +265,9 @@ def present(name,
                 try:
                     start_func = 'lxc.unfreeze' if c_state == 'frozen' \
                         else 'lxc.start'
-                    state['new'] = __salt__[start_func](name)['state']['new']
+                    state['new'] = __salt__[start_func](
+                        name, path=path
+                    )['state']['new']
                     if state['new'] != 'running':
                         ret['result'] = False
                         ret['comment'] += error
@@ -273,14 +287,16 @@ def present(name,
                         )
 
         else:
-            c_state = __salt__['lxc.state'](name)
+            c_state = __salt__['lxc.state'](name, path=path)
             if c_state == 'stopped':
                 if state['old'] is not None:
                     ret['comment'] += ' and is stopped'
             else:
                 error = ', but it could not be stopped'
                 try:
-                    state['new'] = __salt__['lxc.stop'](name)['state']['new']
+                    state['new'] = __salt__['lxc.stop'](
+                        name, path=path
+                    )['state']['new']
                     if state['new'] != 'stopped':
                         ret['result'] = False
                         ret['comment'] += error
@@ -296,13 +312,13 @@ def present(name,
 
     if 'new' not in state:
         # Make sure we know the final state of the container before we return
-        state['new'] = __salt__['lxc.state'](name)
+        state['new'] = __salt__['lxc.state'](name, path=path)
     if state['old'] != state['new']:
         ret['changes']['state'] = state
     return ret
 
 
-def absent(name, stop=False):
+def absent(name, stop=False, path=None):
     '''
     Ensure a container is not present, destroying it if present
 
@@ -315,6 +331,13 @@ def absent(name, stop=False):
 
         .. versionadded:: 2015.5.2
 
+    path
+        path to the container parent
+        default: /var/lib/lxc (system default)
+
+        .. versionadded:: Beryllium
+
+
     .. code-block:: yaml
 
         web01:
@@ -325,7 +348,7 @@ def absent(name, stop=False):
            'result': True,
            'comment': 'Container \'{0}\' does not exist'.format(name)}
 
-    if not __salt__['lxc.exists'](name):
+    if not __salt__['lxc.exists'](name, path=path):
         return ret
 
     if __opts__['test']:
@@ -334,7 +357,7 @@ def absent(name, stop=False):
         return ret
 
     try:
-        result = __salt__['lxc.destroy'](name, stop=stop)
+        result = __salt__['lxc.destroy'](name, stop=stop, path=path)
     except (SaltInvocationError, CommandExecutionError) as exc:
         ret['result'] = False
         ret['comment'] = 'Failed to destroy container: {0}'.format(exc)
@@ -345,7 +368,7 @@ def absent(name, stop=False):
 
 
 # Container state (running/frozen/stopped)
-def running(name, restart=False):
+def running(name, restart=False, path=None):
     '''
     .. versionchanged:: 2015.5.0
         The :mod:`lxc.started <salt.states.lxc.started>` state has been renamed
@@ -362,6 +385,12 @@ def running(name, restart=False):
 
     name
         The name of the container
+
+    path
+        path to the container parent
+        default: /var/lib/lxc (system default)
+
+        .. versionadded:: Beryllium
 
     restart : False
         Restart container if it is already running
@@ -380,7 +409,7 @@ def running(name, restart=False):
            'comment': 'Container \'{0}\' is already running'.format(name),
            'changes': {}}
 
-    state = {'old': __salt__['lxc.state'](name)}
+    state = {'old': __salt__['lxc.state'](name, path=path)}
     if state['old'] is None:
         ret['result'] = False
         ret['comment'] = 'Container \'{0}\' does not exist'.format(name)
@@ -410,16 +439,16 @@ def running(name, restart=False):
 
     try:
         if state['old'] == 'frozen' and not restart:
-            result = __salt__['lxc.unfreeze'](name)
+            result = __salt__['lxc.unfreeze'](name, path=path)
         else:
             if restart:
-                result = __salt__['lxc.restart'](name)
+                result = __salt__['lxc.restart'](name, path=path)
             else:
-                result = __salt__['lxc.start'](name)
+                result = __salt__['lxc.start'](name, path=path)
     except (CommandExecutionError, SaltInvocationError) as exc:
         ret['result'] = False
         ret['comment'] = exc.strerror
-        state['new'] = __salt__['lxc.state'](name)
+        state['new'] = __salt__['lxc.state'](name, path=path)
     else:
         state['new'] = result['state']['new']
         if state['new'] != 'running':
@@ -439,7 +468,7 @@ def running(name, restart=False):
     return ret
 
 
-def frozen(name, start=True):
+def frozen(name, start=True, path=None):
     '''
     .. versionadded:: 2015.5.0
 
@@ -453,6 +482,13 @@ def frozen(name, start=True):
 
     name
         The name of the container
+
+    path
+        path to the container parent
+        default: /var/lib/lxc (system default)
+
+        .. versionadded:: Beryllium
+
 
     start : True
         Start container first, if necessary. If ``False``, then this state will
@@ -472,7 +508,7 @@ def frozen(name, start=True):
            'comment': 'Container \'{0}\' is already frozen'.format(name),
            'changes': {}}
 
-    state = {'old': __salt__['lxc.state'](name)}
+    state = {'old': __salt__['lxc.state'](name, path=path)}
     if state['old'] is None:
         ret['result'] = False
         ret['comment'] = 'Container \'{0}\' does not exist'.format(name)
@@ -495,11 +531,11 @@ def frozen(name, start=True):
         return ret
 
     try:
-        result = __salt__['lxc.freeze'](name, start=start)
+        result = __salt__['lxc.freeze'](name, start=start, path=path)
     except (CommandExecutionError, SaltInvocationError) as exc:
         ret['result'] = False
         ret['comment'] = exc.strerror
-        state['new'] = __salt__['lxc.state'](name)
+        state['new'] = __salt__['lxc.state'](name, path=path)
     else:
         state['new'] = result['state']['new']
         if state['new'] != 'frozen':
@@ -519,7 +555,7 @@ def frozen(name, start=True):
     return ret
 
 
-def stopped(name, kill=False):
+def stopped(name, kill=False, path=None):
     '''
     Ensure that a container is stopped
 
@@ -534,6 +570,12 @@ def stopped(name, kill=False):
 
     name
         The name of the container
+
+    path
+        path to the container parent
+        default: /var/lib/lxc (system default)
+
+        .. versionadded:: Beryllium
 
     kill : False
         Do not wait for the container to stop, kill all tasks in the container.
@@ -552,7 +594,7 @@ def stopped(name, kill=False):
            'comment': 'Container \'{0}\' is already stopped'.format(name),
            'changes': {}}
 
-    state = {'old': __salt__['lxc.state'](name)}
+    state = {'old': __salt__['lxc.state'](name, path=path)}
     if state['old'] is None:
         ret['result'] = False
         ret['comment'] = 'Container \'{0}\' does not exist'.format(name)
@@ -572,11 +614,11 @@ def stopped(name, kill=False):
         return ret
 
     try:
-        result = __salt__['lxc.stop'](name, kill=kill)
+        result = __salt__['lxc.stop'](name, kill=kill, path=path)
     except (CommandExecutionError, SaltInvocationError) as exc:
         ret['result'] = False
         ret['comment'] = exc.strerror
-        state['new'] = __salt__['lxc.state'](name)
+        state['new'] = __salt__['lxc.state'](name, path=path)
     else:
         state['new'] = result['state']['new']
         if state['new'] != 'stopped':
@@ -606,7 +648,7 @@ def created(name, **kwargs):
     return present(name, **kwargs)
 
 
-def started(name, restart=False):
+def started(name, path=None, restart=False):
     '''
     .. deprecated:: 2015.5.0
         Use :mod:`lxc.running <salt.states.lxc.running>`
@@ -616,7 +658,7 @@ def started(name, restart=False):
         'The lxc.started state has been renamed to lxc.running, please use '
         'lxc.running'
     )
-    return running(name, restart=restart)
+    return running(name, restart=restart, path=path)
 
 
 def cloned(name,
@@ -624,6 +666,7 @@ def cloned(name,
            snapshot=True,
            size=None,
            vgname=None,
+           path=None,
            profile=None):
     '''
     .. deprecated:: 2015.5.0
@@ -640,6 +683,7 @@ def cloned(name,
                    snapshot=snapshot,
                    size=size,
                    vgname=vgname,
+                   path=path,
                    profile=profile)
 
 
@@ -681,6 +725,13 @@ def edited_conf(name, lxc_conf=None, lxc_conf_unset=None):
         is deprecated.
 
     Edit LXC configuration options
+
+    path
+        path to the container parent
+        default: /var/lib/lxc (system default)
+
+        .. versionadded:: Beryllium
+
 
     .. code-block:: bash
 


### PR DESCRIPTION
This adds the support for custom path for containers managment, freeing us from the hardcoded /var/lib/lxc.

this will also help to support user containers, as `-P` switch wasnt supported

depends on #24066 (merged) #24080 
refs #23657
