### PR TITLE
iptables state generates a 0 position which is invalid in iptables cli #23950

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -732,6 +732,8 @@ def insert(table='filter', chain=None, position=None, rule=None, family='ipv4'):
         rules = get_rules(family='ipv4')
         size = len(rules[table][chain]['rules'])
         position = (size + position) + 1
+        if position is 0:
+            position = 1
 
     wait = '--wait' if _has_option('--wait', family) else ''
     cmd = '{0} {1} -t {2} -I {3} {4} {5}'.format(


### PR DESCRIPTION
2015.5 branch fix for #23950 - iptables state generates a 0 position which is invalid in iptables cli
