### PR TITLE
Correct reST formatting for states.cmd documentation

### DIFF
--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -132,9 +132,8 @@ it can also watch a git state for changes
           - git: my-project
 
 
-Should I use :mod:`cmd.run <salt.states.cmd.run>` or :mod:`cmd.wait
-<salt.states.cmd.wait>`?
--------------------------------------------------------------------------------
+Should I use :mod:`cmd.run <salt.states.cmd.run>` or :mod:`cmd.wait <salt.states.cmd.wait>`?
+--------------------------------------------------------------------------------------------
 
 These two states are often confused. The important thing to remember about them
 is that :mod:`cmd.run <salt.states.cmd.run>` states are run each time the SLS
@@ -159,7 +158,7 @@ executed when the state it is watching changes. Example:
           - file: /usr/local/bin/postinstall.sh
 
 How do I create an environment from a pillar map?
--------------------------------------------------------------------------------
+-------------------------------------------------
 
 The map that comes from a pillar cannot be directly consumed by the env option.
 To use it one must convert it to a list. Example:


### PR DESCRIPTION
The previous fix of PEP8 in b7d74884a415312d948bd56d7d9ff419d91d6152 caused one of the headings in the documentation to fail to render (search for "Should I use" on http://docs.saltstack.com/en/latest/ref/states/all/salt.states.cmd.html).  The problem is that headings in reST should be on one line and the PEP8 fix wrapped the lines.

The 2nd change is just a best practice change for reST -- having the heading line the same length as the text.
