### PR TITLE
Fixed #22547 using sources in file.append stacktraces

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -658,6 +658,10 @@ def _unify_sources_and_hashes(source=None, source_hash=None,
     if source:
         return (True, '', [(source, source_hash)])
 
+    # map is actually imap so both lists need to be equal length to iterate
+    # over all sources:
+    source_hashes.extend([None] * (len(sources) - len(source_hashes)))
+
     # Make a nice neat list of tuples exactly len(sources) long..
     return True, '', list(zip_longest(sources, source_hashes[:len(sources)]))
 


### PR DESCRIPTION
References: #22547 

The use of map here assumed the Python2 `map`, whereas in fact `six` pulls in `itertools.imap`.

`imap` won't iterate any further than the shortest iterable, so if `source_hashes` is an empty list, `_unify_sources_and_hashes()` will return empty list.

This seemed the shortest fix and presumably fixes a similar problem in `salt.states.prepend`.
