### PR TITLE
Update minimum version for pycrypto

### DIFF
--- a/requirements/zeromq.txt
+++ b/requirements/zeromq.txt
@@ -1,4 +1,4 @@
 -r base.txt
 
-pycrypto >= 2.1.0
+pycrypto >= 2.6.1
 pyzmq >= 2.2.0


### PR DESCRIPTION
After debugging some issues with the test suite, @msteed and I have determined that pycrypto>=2.6.1 will be necessary in Beryllium.

Refs #23695
