### PR TITLE
s3.head: return useful data

### DIFF
--- a/salt/modules/s3.py
+++ b/salt/modules/s3.py
@@ -176,7 +176,8 @@ def head(bucket, path=None, key=None, keyid=None, service_url=None,
                                key=key,
                                keyid=keyid,
                                service_url=service_url,
-                               verify_ssl=verify_ssl)
+                               verify_ssl=verify_ssl,
+                               full_headers=True)
 
 
 def put(bucket, path=None, return_bin=False, action=None, local_file=None,

--- a/salt/utils/s3.py
+++ b/salt/utils/s3.py
@@ -33,7 +33,7 @@ log = logging.getLogger(__name__)
 def query(key, keyid, method='GET', params=None, headers=None,
           requesturl=None, return_url=False, bucket=None, service_url=None,
           path=None, return_bin=False, action=None, local_file=None,
-          verify_ssl=True):
+          verify_ssl=True, full_headers=False):
     '''
     Perform a query against an S3-like API. This function requires that a
     secret key and the id for that key are passed in. For instance:
@@ -231,7 +231,10 @@ def query(key, keyid, method='GET', params=None, headers=None,
         if result.status_code != requests.codes.ok:
             return
         ret = {'headers': []}
-        for header in result.headers:
-            ret['headers'].append(header.strip())
+        if full_headers:
+            ret['headers'] = dict(result.headers)
+        else:
+            for header in result.headers:
+                ret['headers'].append(header.strip())
 
     return ret


### PR DESCRIPTION
Currently, `s3.head` returns a list of the header names. With this update, the values are returned as well.

I'm not sure what value there is in returning only the header names.... so perhaps returning values too should be the default (and only) behavior.
