### PR TITLE
Fix for https://github.com/saltstack/salt/issues/23221

### DIFF
--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -208,7 +208,7 @@ def gen_locale(locale, **kwargs):
 
     if on_debian or on_gentoo:  # file-based search
         search = '/usr/share/i18n/SUPPORTED'
-        valid = __salt__['file.search'](search, '^{0}$'.format(locale))
+        valid = __salt__['file.search'](search, '^{0}( (UTF-8|ISO-8859-.).?)?$'.format(locale))
     else:  # directory-based search
         if on_suse:
             search = '/usr/share/locale'


### PR DESCRIPTION
This should fix the locale generation. This fix will work for both types of declarations:

``` yaml
de_DE.UTF-8:
    locale.present
```

or

``` yaml
de_DE.UTF-8 UTF-8:
    locale.present
```

Tested with all locales in both format declaration
