### PR TITLE
removed tuple index error

### DIFF
--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -625,5 +625,5 @@ def mod_watch(name, user=None, **kwargs):
             ret['result'] = False
             ret['comment'] = '{0} failed to remount: {1}'.format(name, out)
     else:
-        ret['comment'] = 'Watch not supported in {1} at this time'.format(kwargs['sfun'])
+        ret['comment'] = 'Watch not supported in {0} at this time'.format(kwargs['sfun'])
     return ret


### PR DESCRIPTION
@jfindlay , there was some typo in states/mount.py file.

File "/testing/salt/states/mount.py", line 628, in mod_watch
    ret['comment'] = 'Watch not supported in {1} at this time'.format(kwargs['sfun'])

So, this is the fix for the error.
