### PR TITLE
[dockerng] Introduce "start" argument to dockerng.running

### DIFF
--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -1665,8 +1665,13 @@ def running(name,
                         'Sent signal {0} to container'.format(watch_action)
                     )
             elif ret['changes']:
-                # comments are already provided where the change was detected
-                assert comments
+                if not comments:
+                    log.warning(
+                        'dockerng.running: we detected changes without '
+                        'a specific comment for container \'{0}\'.'.format(
+                            name)
+                    )
+                    comments.append('Container \'{0}\' changed.'.format(name))
             else:
                 # Container was not replaced, no necessary changes detected
                 # in pre-flight check, and no signal sent to container

--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -653,7 +653,7 @@ def running(name,
             validate_ip_addrs=True,
             watch_action='force',
             client_timeout=CLIENT_TIMEOUT,
-            check_is_running=True,
+            start=True,
             **kwargs):
     '''
     Ensure that a container with a specific configuration is present and
@@ -1308,12 +1308,13 @@ def running(name,
 
             This option requires Docker 1.5.0 or newer.
 
-    check_is_running : True
-        Skip running checks if set to False.
-        Useful for data only container, or for non daemonized container
-        processes.
-        Think one time commands like ``django commands`` ``migrate``
-        or ``collectstatic``.
+    start : True
+        Set to ``False`` to suppress starting of the container if it exists,
+        matches the desired configuration, but is not running. This is useful
+        for data-only containers, or for non-daemonized container processes,
+        such as the django ``migrate`` and ``collectstatic`` commands. In
+        instances such as this, the container only needs to be started the
+        first time.
     '''
     ret = {'name': name,
            'changes': {},
@@ -1565,7 +1566,7 @@ def running(name,
         # changes dict.
         ret['changes']['added'] = create_result
 
-    if new_container or (pre_state != 'running' and check_is_running):
+    if new_container or (pre_state != 'running' and start):
         try:
             # Start container
             __salt__['dockerng.start'](

--- a/tests/unit/states/dockerng_test.py
+++ b/tests/unit/states/dockerng_test.py
@@ -272,6 +272,80 @@ class DockerngTestCase(TestCase):
                               'name': 'image:latest',
                               })
 
+    def test_check_is_running_false(self):
+        '''
+        If check_is_running is False, then dockerng.running will not try
+        to start a container that is stopped.
+        '''
+        image_id = 'abcdefg'
+        dockerng_create = Mock()
+        dockerng_start = Mock()
+        dockerng_list_containers = Mock(return_value=['cont'])
+        dockerng_inspect_container = Mock(
+            return_value={'Config': {'Image': 'image:latest'},
+                          'Image': image_id})
+        __salt__ = {'dockerng.list_containers': dockerng_list_containers,
+                    'dockerng.inspect_container': dockerng_inspect_container,
+                    'dockerng.inspect_image': MagicMock(
+                        return_value={'Id': image_id}),
+                    'dockerng.list_tags': MagicMock(),
+                    'dockerng.pull': MagicMock(),
+                    'dockerng.state': MagicMock(side_effect=['stopped',
+                                                             'running']),
+                    'dockerng.create': dockerng_create,
+                    'dockerng.start': dockerng_start,
+                    }
+        with patch.dict(dockerng_state.__dict__,
+                        {'__salt__': __salt__}):
+            ret = dockerng_state.running(
+                'cont',
+                image='image:latest',
+                check_is_running=False,
+                )
+        self.assertEqual(ret, {'name': 'cont',
+                               'comment': "Container 'cont' is already "
+                               "configured as specified",
+                               'changes': {},
+                               'result': True,
+                               })
+
+    def test_check_is_running_true(self):
+        '''
+        If check_is_running is True, then dockerng.running will try
+        to start a container that is stopped.
+        '''
+        image_id = 'abcdefg'
+        dockerng_create = Mock()
+        dockerng_start = Mock()
+        dockerng_list_containers = Mock(return_value=['cont'])
+        dockerng_inspect_container = Mock(
+            return_value={'Config': {'Image': 'image:latest'},
+                          'Image': image_id})
+        __salt__ = {'dockerng.list_containers': dockerng_list_containers,
+                    'dockerng.inspect_container': dockerng_inspect_container,
+                    'dockerng.inspect_image': MagicMock(
+                        return_value={'Id': image_id}),
+                    'dockerng.list_tags': MagicMock(),
+                    'dockerng.pull': MagicMock(),
+                    'dockerng.state': MagicMock(side_effect=['stopped',
+                                                             'running']),
+                    'dockerng.create': dockerng_create,
+                    'dockerng.start': dockerng_start,
+                    }
+        with patch.dict(dockerng_state.__dict__,
+                        {'__salt__': __salt__}):
+            ret = dockerng_state.running(
+                'cont',
+                image='image:latest',
+                check_is_running=True,
+                )
+        self.assertEqual(ret, {'name': 'cont',
+                               'comment': "Container 'cont' changed state.",
+                               'changes': {'state': {'new': 'running',
+                                                     'old': 'stopped'}},
+                               'result': True,
+                               })
+
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/unit/states/dockerng_test.py
+++ b/tests/unit/states/dockerng_test.py
@@ -272,9 +272,9 @@ class DockerngTestCase(TestCase):
                               'name': 'image:latest',
                               })
 
-    def test_check_is_running_false(self):
+    def test_check_start_false(self):
         '''
-        If check_is_running is False, then dockerng.running will not try
+        If start is False, then dockerng.running will not try
         to start a container that is stopped.
         '''
         image_id = 'abcdefg'
@@ -300,7 +300,7 @@ class DockerngTestCase(TestCase):
             ret = dockerng_state.running(
                 'cont',
                 image='image:latest',
-                check_is_running=False,
+                start=False,
                 )
         self.assertEqual(ret, {'name': 'cont',
                                'comment': "Container 'cont' is already "
@@ -309,9 +309,9 @@ class DockerngTestCase(TestCase):
                                'result': True,
                                })
 
-    def test_check_is_running_true(self):
+    def test_check_start_true(self):
         '''
-        If check_is_running is True, then dockerng.running will try
+        If start is True, then dockerng.running will try
         to start a container that is stopped.
         '''
         image_id = 'abcdefg'
@@ -337,7 +337,7 @@ class DockerngTestCase(TestCase):
             ret = dockerng_state.running(
                 'cont',
                 image='image:latest',
-                check_is_running=True,
+                start=True,
                 )
         self.assertEqual(ret, {'name': 'cont',
                                'comment': "Container 'cont' changed state.",


### PR DESCRIPTION
Skip running checks if set to False.
Useful for data only container, or for non daemonized container processes.

Think one time commands like `django commands` `migrate` or `collectstatic`.

this feature already exists in `states.dockerio.running`

/cc @terminalmage 
