### PR TITLE
Make LocalClient.cmd_iter_no_block() not block

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -42,18 +42,13 @@ class Batch(object):
         else:
             args.append(self.opts.get('expr_form', 'glob'))
 
-        ping_gen = self.local.cmd_iter_no_block(*args, **self.eauth)
-        wait_until = time.time() + self.opts['timeout']
+        ping_gen = self.local.cmd_iter(*args, **self.eauth)
 
         fret = set()
         for ret in ping_gen:
             m = next(ret.iterkeys())
             if m is not None:
                 fret.add(m)
-            if time.time() > wait_until:
-                break
-            if m is None:
-                time.sleep(0.1)
         return (list(fret), ping_gen)
 
     def get_bnum(self):

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -385,8 +385,8 @@ class LocalClient(object):
         .. code-block:: python
 
             >>> returns = local.cmd_batch('*', 'state.highstate', bat='10%')
-            >>> for return in returns:
-            ...     print return
+            >>> for ret in returns:
+            ...     print(ret)
             {'jerry': {...}}
             {'dave': {...}}
             {'stewart': {...}}
@@ -617,7 +617,7 @@ class LocalClient(object):
 
             >>> ret = local.cmd_iter('*', 'test.ping')
             >>> for i in ret:
-            ...     print i
+            ...     print(i)
             {'jerry': {'ret': True}}
             {'dave': {'ret': True}}
             {'stewart': {'ret': True}}
@@ -668,9 +668,9 @@ class LocalClient(object):
 
         .. code-block:: python
 
-            >>> ret = local.cmd_iter('*', 'test.ping')
+            >>> ret = local.cmd_iter_no_block('*', 'test.ping')
             >>> for i in ret:
-            ...     print i
+            ...     print(i)
             None
             {'jerry': {'ret': True}}
             {'dave': {'ret': True}}


### PR DESCRIPTION
Add an optional `block` parameter to `LocalClient.get_iter_returns()`. Pass `block=False` in `cmd_iter_no_block()` so it can yield when no returns are available. Fixes #23464,
