### PR TITLE
Systemd not recognized properly on Oracle Linux 7

### DIFF
--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -69,7 +69,7 @@ def __virtual__():
         if __grains__['os'] == 'Fedora':
             if osrelease > 15:
                 return False
-        if __grains__['os'] in ('RedHat', 'CentOS', 'ScientificLinux'):
+        if __grains__['os'] in ('RedHat', 'CentOS', 'ScientificLinux', 'OEL'):
             if osrelease >= 7:
                 return False
         return __virtualname__


### PR DESCRIPTION
Both systemd and rh_service modules were enabled which led to a strange situation where:
- state.sls or state.highstate were failing on service state
- state.sls_id was passing on the called service

Probably fixes Issue #21446.
Trivial change that can be merged to all live branches.
