### PR TITLE
Updated some beacon-specific documentation formatting

### DIFF
--- a/salt/beacons/diskusage.py
+++ b/salt/beacons/diskusage.py
@@ -41,17 +41,15 @@ def beacon(config):
     '''
     Monitor the disk usage of the minion
 
-    Specify thresholds for for each load average
-    and only emit a beacon if any of them are
+    Specify thresholds for each disk and only emit a beacon if any of them are
     exceeded.
 
     .. code-block:: yaml
 
         beacons:
-            diskusage:
-              - /: 63%
-              - /mnt/nfs: 50%
-
+          diskusage:
+            - /: 63%
+            - /mnt/nfs: 50%
     '''
     ret = []
     for diskusage in config:

--- a/salt/beacons/inotify.py
+++ b/salt/beacons/inotify.py
@@ -5,8 +5,8 @@ Watch files and translate the changes into salt events
 :depends:   - pyinotify Python module >= 0.9.5
 
 :Caution:   Using generic mask options like open, access, ignored, and
-:           closed_nowrite with reactors can easily cause the reactor
-:           to loop on itself.
+            closed_nowrite with reactors can easily cause the reactor
+            to loop on itself.
 
 '''
 # Import Python libs

--- a/salt/beacons/journald.py
+++ b/salt/beacons/journald.py
@@ -70,10 +70,10 @@ def beacon(config):
     .. code-block:: yaml
 
         beacons:
-            journald:
-                sshd:
-                    SYSLOG_IDENTIFIER: sshd
-                    PRIORITY: 6
+          journald:
+            sshd:
+              SYSLOG_IDENTIFIER: sshd
+              PRIORITY: 6
     '''
     ret = []
     journal = _get_journal()

--- a/salt/beacons/load.py
+++ b/salt/beacons/load.py
@@ -66,7 +66,7 @@ def beacon(config):
     '''
     Emit the load averages of this host.
 
-    Specify thresholds for for each load average
+    Specify thresholds for each load average
     and only emit a beacon if any of them are
     exceeded.
 

--- a/salt/beacons/network_info.py
+++ b/salt/beacons/network_info.py
@@ -68,7 +68,7 @@ def beacon(config):
     '''
     Emit the network statistics of this host.
 
-    Specify thresholds for for each network stat
+    Specify thresholds for each network stat
     and only emit a beacon if any of them are
     exceeded.
 
@@ -78,17 +78,17 @@ def beacon(config):
     .. code-block:: yaml
 
         beacons:
-            network_info:
-                eth0:
-                    - type: equal
-                    - bytes_sent: 100000
-                    - bytes_recv: 100000
-                    - packets_sent: 100000
-                    - packets_recv: 100000
-                    - errin: 100
-                    - errout: 100
-                    - dropin: 100
-                    - dropout: 100
+          network_info:
+            eth0:
+                - type: equal
+                - bytes_sent: 100000
+                - bytes_recv: 100000
+                - packets_sent: 100000
+                - packets_recv: 100000
+                - errin: 100
+                - errout: 100
+                - dropin: 100
+                - dropout: 100
 
     Emit beacon when any values are greater
     than to configured values.
@@ -96,17 +96,17 @@ def beacon(config):
     .. code-block:: yaml
 
         beacons:
-            network_info:
-                eth0:
-                    - type: greater
-                    - bytes_sent: 100000
-                    - bytes_recv: 100000
-                    - packets_sent: 100000
-                    - packets_recv: 100000
-                    - errin: 100
-                    - errout: 100
-                    - dropin: 100
-                    - dropout: 100
+          network_info:
+            eth0:
+                - type: greater
+                - bytes_sent: 100000
+                - bytes_recv: 100000
+                - packets_sent: 100000
+                - packets_recv: 100000
+                - errin: 100
+                - errout: 100
+                - dropin: 100
+                - dropout: 100
 
 
     '''

--- a/salt/beacons/ps.py
+++ b/salt/beacons/ps.py
@@ -36,7 +36,6 @@ def beacon(config):
             salt-master: running
             mysql: stopped
 
-
     The config above sets up beacons to check that
     processes are running or stopped.
     '''

--- a/salt/beacons/service.py
+++ b/salt/beacons/service.py
@@ -38,7 +38,6 @@ def beacon(config):
             salt-master:
             mysql:
 
-
     The config above sets up beacons to check for
     the salt-master and mysql services.
 
@@ -67,8 +66,6 @@ def beacon(config):
             nginx:
               onchangeonly: True
               uncleanshutdown: /run/nginx.pid
-
-
     '''
     ret = []
     for service in config:


### PR DESCRIPTION
I noticed not all the current beacon docs were rendering properly so this patch addresses some grammar, spacing and formatting issues.
