### PR TITLE
deprecate setting user permission in rabbitmq_vhost.present

### DIFF
--- a/salt/states/rabbitmq_vhost.py
+++ b/salt/states/rabbitmq_vhost.py
@@ -50,14 +50,22 @@ def present(name,
         .. deprecated:: Beryllium
     owner
         Initial owner permission to set on the VHost, if present
+
+        .. deprecated:: Beryllium
     conf
         Initial conf string to apply to the VHost and user. Defaults to .*
+
+        .. deprecated:: Beryllium
     write
         Initial write permissions to apply to the VHost and user.
         Defaults to .*
+
+        .. deprecated:: Beryllium
     read
         Initial read permissions to apply to the VHost and user.
         Defaults to .*
+
+        .. deprecated:: Beryllium
     runas
         Name of the user to run the command
 
@@ -72,37 +80,17 @@ def present(name,
             'removed in Salt Beryllium. Ping s0undt3ch for additional '
             'information or see #6961.'
         )
-    if user:
-        # Warn users about the deprecation
+
+    if any(user, owner, conf, write, read):
         salt.utils.warn_until(
             'Beryllium',
-            'The \'user\' argument is being deprecated in favor of \'owner\', '
-            'and will be removed in Salt Beryllium. Please update your state '
-            'files.'
+            'Passed \'owner\', \'user\', \'conf\', \'write\' or \'read\' '
+            'arguments. These are being deprecated, and will be removed in '
+            'Salt Beryllium. Please update your state files, and set '
+            'permissions for user instead. See rabbitmq_user.present.'
         )
-    if user is not None and owner is not None:
-        # owner wins over user but let warn about the deprecation.
-        salt.utils.warn_until(
-            'Beryllium',
-            'Passed both the \'owner\' and \'user\' arguments. \'user\' is '
-            'being ignored in favor of \'owner\' as the \'user\' argument is '
-            'being deprecated in favor of \'owner\' and will be removed in '
-            'Salt Beryllium. Please update your state files.'
-        )
-        user = None
-    elif user is not None:
-        # Support old runas usage
-        owner = user
-        user = None
 
     vhost_exists = __salt__['rabbitmq.vhost_exists'](name, runas=runas)
-
-    if vhost_exists:
-        owner_perms = __salt__['rabbitmq.list_permissions'](name, runas=runas)
-        for eowner, eperms in owner_perms.iteritem():
-            if eowner == owner and eperms == [conf, write, read]:
-                ret['comment'] = 'Nothing to do'
-                return ret
 
     if __opts__['test']:
         ret['result'] = None
@@ -111,17 +99,10 @@ def present(name,
         else:
             ret['comment'] = 'Creating VHost {0}'.format(name)
 
-        if user is not None:
-            ret['comment'] += (
-                ' Setting permissions for {0} {1} {2} {3}'.format(
-                    owner,
-                    conf or '.*',
-                    write or '.*',
-                    read or '.*'
-                )
-            )
     else:
-        if not vhost_exists:
+        if vhost_exists:
+            ret['comment'] = 'VHost {0} already exists'.format(name)
+        else:
             result = __salt__['rabbitmq.add_vhost'](name, runas=runas)
             if 'Error' in result:
                 ret['result'] = False
@@ -129,21 +110,6 @@ def present(name,
             elif 'Added' in result:
                 ret['comment'] = result['Added']
                 ret['changes'] = {'old': '', 'new': name}
-        else:
-            ret['comment'] = 'VHost {0} already exists'.format(name)
-
-        if owner is not None:
-            conf = conf or '.*'
-            write = write or '.*'
-            read = read or '.*'
-            result = __salt__['rabbitmq.set_permissions'](
-                name, owner, conf, write, read, runas=runas)
-
-            if 'Error' in result:
-                ret['result'] = False
-                ret['comment'] = result['Error']
-            elif 'Permissions Set':
-                ret['comment'] += ' {0}'.format(result['Permissions Set'])
 
     return ret
 


### PR DESCRIPTION
permission for user on each vhost should be managed
by using rabbitmq_user.present instead.
That setting user permission feature was overlap between them and can cause contradict permissions 
as it can be set in 2 different places.

And, the keyword: `owner` is not correct due to rabbitmq doc (https://www.rabbitmq.com/man/rabbitmqctl.1.man.html):

> This command instructs the RabbitMQ broker to list all the users which have been granted access to the virtual host called /myvhost, and the permissions they have for operations on resources in that virtual host. Note that an empty string means no permissions granted. 

it has no concept of owner.
