### PR TITLE
[dockerng] Migrate salt.mine to dockerng

### DIFF
--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -685,12 +685,12 @@ def create_container(image,
             'info': _get_container_infos(container),
             'out': container_info
         }
-        __salt__['mine.send']('docker.get_containers', host=True)
+        __salt__['mine.send']('dockerng.ps', verbose=True, all=True, host=True)
         return callback(status, id_=container, comment=comment, out=out)
     except Exception as e:
         _invalid(status, id_=image, out=traceback.format_exc())
         raise e
-    __salt__['mine.send']('docker.get_containers', host=True)
+    __salt__['mine.send']('dockerng.ps', verbose=True, all=True, host=True)
     return status
 
 
@@ -804,7 +804,7 @@ def stop(container, timeout=10):
                  comment=(
                      'An exception occurred while stopping '
                      'your container {0}').format(container))
-    __salt__['mine.send']('docker.get_containers', host=True)
+    __salt__['mine.send']('dockerng.ps', verbose=True, all=True, host=True)
     return status
 
 
@@ -859,7 +859,7 @@ def kill(container, signal=None):
                  comment=(
                      'An exception occurred while killing '
                      'your container {0}').format(container))
-    __salt__['mine.send']('docker.get_containers', host=True)
+    __salt__['mine.send']('dockerng.ps', verbose=True, all=True, host=True)
     return status
 
 
@@ -895,7 +895,7 @@ def restart(container, timeout=10):
                  comment=(
                      'An exception occurred while restarting '
                      'your container {0}').format(container))
-    __salt__['mine.send']('docker.get_containers', host=True)
+    __salt__['mine.send']('dockerng.ps', verbose=True, all=True, host=True)
     return status
 
 
@@ -975,7 +975,7 @@ def start(container,
                  comment=(
                      'An exception occurred while starting '
                      'your container {0}').format(container))
-    __salt__['mine.send']('docker.get_containers', host=True)
+    __salt__['mine.send']('dockerng.ps', verbose=True, all=True, host=True)
     return status
 
 
@@ -1013,7 +1013,7 @@ def wait(container):
                  comment=(
                      'An exception occurred while waiting '
                      'your container {0}').format(container))
-    __salt__['mine.send']('docker.get_containers', host=True)
+    __salt__['mine.send']('dockerng.ps', verbose=True, all=True, host=True)
     return status
 
 
@@ -1093,7 +1093,7 @@ def remove_container(container, force=False, v=False):
                          comment=(
                              'Container {0} is running, '
                              'won\'t remove it').format(container))
-                __salt__['mine.send']('docker.get_containers', host=True)
+                __salt__['mine.send']('dockerng.ps', verbose=True, all=True, host=True)
                 return status
             else:
                 kill(dcontainer)
@@ -1107,7 +1107,7 @@ def remove_container(container, force=False, v=False):
             status['comment'] = 'Container {0} was removed'.format(container)
     except Exception:
         _invalid(status, id_=container, out=traceback.format_exc())
-    __salt__['mine.send']('docker.get_containers', host=True)
+    __salt__['mine.send']('dockerng.ps', verbose=True, all=True, host=True)
     return status
 
 

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -572,6 +572,21 @@ def _ensure_exists(wrapped):
     return wrapper
 
 
+def _refresh_mine_cache(wrapped):
+    '''
+    Decorator to trig a refresh of salt mine data.
+    '''
+    @functools.wraps(wrapped)
+    def wrapper(*args, **kwargs):
+        '''
+        refresh salt mine on exit.
+        '''
+        returned = wrapped(*args, **salt.utils.clean_kwargs(**kwargs))
+        __salt__['mine.send']('dockerng.ps', verbose=True, all=True, host=True)
+        return returned
+    return wrapper
+
+
 # Helper functions
 def _change_state(name, action, expected, *args, **kwargs):
     '''
@@ -2228,6 +2243,9 @@ def ps_(**kwargs):
     all : False
         If ``True``, stopped containers will also be returned
 
+    host: False
+        If ``True``, local host's network topology will be included
+
     verbose : False
         If ``True``, a ``docker inspect`` will be run on each container
         returned.
@@ -2280,6 +2298,10 @@ def ps_(**kwargs):
         for c_id in ret:
             ret[c_id]['Info'] = inspect_container(c_id)
 
+    if kwargs.get('host', False):
+        ret.setdefault(
+            'host', {}).setdefault(
+                'interfaces', {}).update(__salt__['network.interfaces']())
     return ret
 
 
@@ -2457,6 +2479,7 @@ def version():
 
 
 # Functions to manage containers
+@_refresh_mine_cache
 def create(image,
            name=None,
            client_timeout=CLIENT_TIMEOUT,
@@ -2995,6 +3018,7 @@ def export(name,
     return ret
 
 
+@_refresh_mine_cache
 @_ensure_exists
 def rm_(name, force=False, volumes=False):
     '''
@@ -3974,6 +3998,7 @@ def tag_(name, image, force=False):
 
 
 # Functions to manage container state
+@_refresh_mine_cache
 @_ensure_exists
 def kill(name):
     '''
@@ -4002,6 +4027,7 @@ def kill(name):
     return _change_state(name, 'kill', 'stopped')
 
 
+@_refresh_mine_cache
 @_api_version(1.12)
 @_ensure_exists
 def pause(name):
@@ -4076,6 +4102,7 @@ def restart(name, timeout=10):
     return ret
 
 
+@_refresh_mine_cache
 @_ensure_exists
 def signal_(name, signal):
     '''
@@ -4104,6 +4131,7 @@ def signal_(name, signal):
     return True
 
 
+@_refresh_mine_cache
 @_ensure_exists
 def start(name, validate_ip_addrs=True, **kwargs):
     '''
@@ -4318,6 +4346,7 @@ def start(name, validate_ip_addrs=True, **kwargs):
     return _change_state(name, 'start', 'running', **runtime_kwargs)
 
 
+@_refresh_mine_cache
 @_ensure_exists
 def stop(name, timeout=STOP_TIMEOUT, **kwargs):
     '''
@@ -4373,6 +4402,7 @@ def stop(name, timeout=STOP_TIMEOUT, **kwargs):
     return ret
 
 
+@_refresh_mine_cache
 @_api_version(1.12)
 @_ensure_exists
 def unpause(name):
@@ -4443,6 +4473,7 @@ def wait(name):
 
 
 # Functions to run commands inside containers
+@_refresh_mine_cache
 @_ensure_exists
 def _run(name,
          cmd,
@@ -4478,6 +4509,7 @@ def _run(name,
         return ret[output]
 
 
+@_refresh_mine_cache
 def _script(name,
             source,
             saltenv='base',

--- a/tests/unit/modules/dockerng_test.py
+++ b/tests/unit/modules/dockerng_test.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+'''
+Unit tests for the dockerng module
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+
+# Import Salt Testing Libs
+from salttesting import skipIf, TestCase
+from salttesting.helpers import ensure_in_syspath
+from salttesting.mock import (
+    MagicMock,
+    Mock,
+    NO_MOCK,
+    NO_MOCK_REASON,
+    patch
+)
+
+ensure_in_syspath('../../')
+
+# Import Salt Libs
+from salt.modules import dockerng as dockerng_mod
+
+dockerng_mod.__context__ = {'docker.docker_version': ''}
+dockerng_mod.__salt__ = {}
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class DockerngTestCase(TestCase):
+    '''
+    Validate dockerng module
+    '''
+
+    def test_ps_with_host_true(self):
+        '''
+        Check that dockerng.ps called with host is ``True``,
+        include resutlt of ``network.interfaces`` command in returned result.
+        '''
+        network_interfaces = Mock(return_value={'mocked': None})
+        with patch.dict(dockerng_mod.__salt__,
+                        {'network.interfaces': network_interfaces}):
+            with patch.dict(dockerng_mod.__context__,
+                            {'docker.client': MagicMock()}):
+                ret = dockerng_mod.ps_(host=True)
+                self.assertEqual(ret,
+                                 {'host': {'interfaces': {'mocked': None}}})
+
+    @patch.object(dockerng_mod, '_get_exec_driver')
+    def test_check_mine_cache_is_refreshed_on_container_change_event(self, _):
+        '''
+        Every command that might modify docker containers state.
+        Should trig an update on ``mine.send``
+        '''
+
+        for command_name, args in (('create', ()),
+                                   ('rm_', ()),
+                                   ('kill', ()),
+                                   ('pause', ()),
+                                   ('signal_', ('KILL',)),
+                                   ('start', ()),
+                                   ('stop', ()),
+                                   ('unpause', ()),
+                                   ('_run', ('command',)),
+                                   ('_script', ('command',)),
+                                   ):
+            mine_send = Mock()
+            command = getattr(dockerng_mod, command_name)
+            docker_client = MagicMock()
+            docker_client.api_version = '1.12'
+            with patch.dict(dockerng_mod.__salt__,
+                            {'mine.send': mine_send,
+                             'container_resource.run': MagicMock(),
+                             'cp.cache_file': MagicMock(return_value=False)}):
+                with patch.dict(dockerng_mod.__context__,
+                                {'docker.client': docker_client}):
+                    command('container', *args)
+            mine_send.assert_called_with('dockerng.ps', verbose=True, all=True,
+                                         host=True)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(DockerngTestCase, needs_daemon=False)

--- a/tests/unit/modules/mine_test.py
+++ b/tests/unit/modules/mine_test.py
@@ -158,11 +158,45 @@ class MineTestCase(TestCase):
 
     def test_get_docker(self):
         '''
-        Test for Get all mine data for 'docker.get_containers' and run an
+        Test for Get all mine data for 'dockerng.ps' and run an
         aggregation.
         '''
-        with patch.object(mine, 'get', return_value={}):
-            self.assertEqual(mine.get_docker(), {})
+        ps_response = {
+            'localhost': {
+                'host': {
+                    'interfaces': {
+                        'docker0': {
+                            'hwaddr': '88:99:00:00:99:99',
+                            'inet': [{'address': '172.17.42.1',
+                                     'broadcast': None,
+                                     'label': 'docker0',
+                                     'netmask': '255.255.0.0'}],
+                            'inet6': [{'address': 'ffff::eeee:aaaa:bbbb:8888',
+                                       'prefixlen': '64'}],
+                            'up': True},
+                        'eth0': {'hwaddr': '88:99:00:99:99:99',
+                                'inet': [{'address': '192.168.0.1',
+                                          'broadcast': '192.168.0.255',
+                                          'label': 'eth0',
+                                          'netmask': '255.255.255.0'}],
+                                 'inet6': [{'address':
+                                            'ffff::aaaa:aaaa:bbbb:8888',
+                                            'prefixlen': '64'}],
+                                 'up': True},
+                }},
+                'abcdefhjhi1234567899': {  # container Id
+                    'Ports': [{'IP': '0.0.0.0',  # we bind on every interfaces
+                                'PrivatePort': 80,
+                                'PublicPort': 80,
+                                'Type': 'tcp'}],
+                     'Image': 'image:latest'
+                },
+            }}
+        with patch.object(mine, 'get', return_value=ps_response):
+            self.assertEqual(mine.get_docker(),
+                             {'image:latest': {
+                                 'ipv4': {80: ['192.168.0.1:80',
+                                               '172.17.42.1:80']}}})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Take advantage of the new wonderful dockerng module for mining feature.

This pull request consist into bringing back `host`argument from `docker.get_containers` to `dockerng.ps`. And, to trig a mine refresh on every salt function that might trig a state change.

/cc @terminalmage
