### PR TITLE
Optimize dictupdate.update and add #24097 functionality

### DIFF
--- a/salt/utils/dictupdate.py
+++ b/salt/utils/dictupdate.py
@@ -66,7 +66,7 @@ def merge_list(obj_a, obj_b):
 
 
 def merge_recurse(obj_a, obj_b):
-    copied = copy.copy(obj_a)
+    copied = copy.deepcopy(obj_a)
     return update(copied, obj_b)
 
 

--- a/salt/utils/dictupdate.py
+++ b/salt/utils/dictupdate.py
@@ -26,6 +26,8 @@ def update(dest, upd, recursive_update=True):
     If recursive_update=False, will use the classic dict.update, or fall back
     on a manual merge (helpful for non-dict types like FunctionWrapper)
     '''
+    if dest is None:
+        return upd
     if recursive_update:
         for key, val in six.iteritems(upd):
             try:
@@ -40,7 +42,7 @@ def update(dest, upd, recursive_update=True):
                     and isinstance(val, collections.Mapping):
                 ret = update(dest_subkey, val)
                 dest[key] = ret
-            elif key:
+            else:
                 dest[key] = upd[key]
         return dest
     else:

--- a/salt/utils/dictupdate.py
+++ b/salt/utils/dictupdate.py
@@ -24,7 +24,7 @@ def update(dest, upd):
                 valtype = OrderedDict
             else:
                 valtype = dict
-            dest_subkey = dest.get(key, valtype())
+            dest_subkey = dest.get(key, None)
         except AttributeError:
             dest_subkey = None
         if isinstance(dest_subkey, collections.Mapping) \

--- a/salt/utils/dictupdate.py
+++ b/salt/utils/dictupdate.py
@@ -21,10 +21,10 @@ def update(dest, upd):
     for key, val in six.iteritems(upd):
         try:
             if isinstance(val, OrderedDict):
-                klass = OrderedDict
+                valtype = OrderedDict
             else:
-                klass = dict
-            dest_subkey = dest.get(key, klass())
+                valtype = dict
+            dest_subkey = dest.get(key, valtype())
         except AttributeError:
             dest_subkey = None
         if isinstance(dest_subkey, collections.Mapping) \

--- a/salt/utils/dictupdate.py
+++ b/salt/utils/dictupdate.py
@@ -18,6 +18,14 @@ log = logging.getLogger(__name__)
 
 
 def update(dest, upd, recursive_update=True):
+    '''
+    Recursive version of the default dict.update
+
+    Merges upd recursively into dest
+
+    If recursive_update=False, will use the classic dict.update, or fall back
+    on a manual merge (helpful for non-dict types like FunctionWrapper)
+    '''
     if recursive_update:
         for key, val in six.iteritems(upd):
             try:


### PR DESCRIPTION
Refs #24097 

https://github.com/saltstack/salt/commit/8599143200c09986769de9f4c8b87d28f6510b27 will be the biggest optimization. By defaulting to `None` we won't recurse if the key doesn't exist in `dest`.

Also pulled in the `recursive_update` argument from #24097.
