### PR TITLE
Compare Keys ignores all newlines and carriage returns

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -593,7 +593,8 @@ class SAuth(object):
         if os.path.isfile(m_pub_fn) and not self.opts['open_mode']:
             local_master_pub = salt.utils.fopen(m_pub_fn).read()
 
-            if payload['pub_key'] != local_master_pub:
+            if payload['pub_key'].replace('\n', '').replace('\r', '') != \
+                    local_master_pub.replace('\n', '').replace('\r', ''):
                 if not self.check_auth_deps(payload):
                     return ''
 


### PR DESCRIPTION
Fixes #24052 
Bug was introduced by PR #23740 which forces binary for files in Windows. This fixed previous bugs for downloading files in windows (#23566 for example) but it broke the master_minion.pub file comparison that takes place on a minion upgrade.

This fix ignores /n /r when it does the key comparison.
