### PR TITLE
Fixes the boto_vpc_test failure on CentOS 5 tests

### DIFF
--- a/tests/unit/modules/boto_vpc_test.py
+++ b/tests/unit/modules/boto_vpc_test.py
@@ -6,14 +6,12 @@ from salttesting.mock import patch
 try:
     import boto
     from boto.exception import BotoServerError
-
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
 
 try:
     from moto import mock_ec2
-
     HAS_MOTO = True
 except ImportError:
     HAS_MOTO = False
@@ -51,6 +49,8 @@ ensure_in_syspath('../../')
 # which was added in boto 2.8.0
 # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
 required_boto_version = '2.8.0'
+required_moto_version = '0.3.7'
+
 region = 'us-east-1'
 access_key = 'GKTADJGHEIQSXMKKRBJ08H'
 secret_key = 'askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs'
@@ -84,8 +84,11 @@ def _has_required_moto():
         return False
     else:
         import pkg_resources
-
-        if LooseVersion(pkg_resources.get_distribution('moto').version) < LooseVersion('0.3.7'):
+        from pkg_resources import DistributionNotFound
+        try:
+            if LooseVersion(pkg_resources.get_distribution('moto').version) < LooseVersion(required_moto_version):
+                return False
+        except DistributionNotFound:
             return False
         return True
 


### PR DESCRIPTION
`pkg_resources.get_distribution` doesn't work on CentOS 5 since it looks for moto in site-packages and not pip (which is how we're installing it in the salt-jenkins states).

This catches the exception through by get_distribution so we can run the rest of the tests in this file.

`pkg_resources.get_distribution` was used instead of `moto.__version__` because the moto package doesn't contain the `__version__` dict. I've submitted an issue to moto [here](https://github.com/spulec/moto/issues/353).
