### PR TITLE
Allow URL specification of NPM packages

### DIFF
--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -128,9 +128,12 @@ def installed(name,
         # Check to see if we are trying to install from a URI
         elif '://' in pkg_name:  # TODO Better way?
             for pkg_details in installed_pkgs.values():
-                pkg_from = pkg_details.get('from', '').split('://')[1]
-                if pkg_name.split('://')[1] == pkg_from:
-                    return True
+                try:
+                    pkg_from = pkg_details.get('from', '').split('://')[1]
+                    if pkg_name.split('://')[1] == pkg_from:
+                        return True
+                except IndexError:
+                     pass
         return False
 
     for pkg in pkg_list:

--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -133,7 +133,7 @@ def installed(name,
                     if pkg_name.split('://')[1] == pkg_from:
                         return True
                 except IndexError:
-                     pass
+                    pass
         return False
 
     for pkg in pkg_list:

--- a/tests/integration/states/npm.py
+++ b/tests/integration/states/npm.py
@@ -32,6 +32,16 @@ class NpmStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
         self.assertSaltTrueReturn(ret)
 
     @destructiveTest
+    def test_npm_install_url_referenced_package(self):
+        '''
+        Determine if URL-referenced NPM module can be successfully installed.
+        '''
+        ret = self.run_state('npm.installed', name='git://github.com/Unitech/pm2')
+        self.assertSaltTrueReturn(ret)
+        ret = self.run_state('npm.removed', name='git://github.com/Unitech/pm2')
+        self.assertSaltTrueReturn(ret)
+
+    @destructiveTest
     def test_npm_installed_pkgs(self):
         '''
         Basic test to determine if NPM module successfully installs multiple


### PR DESCRIPTION
If an NPM package was specified as a url (i.e. git://github.com/Unitech/pm2), the state would crash with an IndexError.  Assume that not every package installed globally is specified with a URL.

Example failing state:

```
kvsio:
  npm.installed:
      - name: git+ssh://github.com/dougluce/kvs.io.git
```

Should fix #24151.
