### PR TITLE
Batch mode sometimes improperly builds lists of minions to process

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -111,7 +111,11 @@ class Batch(object):
             else:
                 for i in range(bnum - len(active)):
                     if to_run:
-                        next_.append(to_run.pop())
+                        minion_id = to_run.pop()
+                        if isinstance(minion_id, dict):
+                            next_.append(minion_id.keys()[0])
+                        else:
+                            next_.append(minion_id)
 
             active += next_
             args[0] = next_


### PR DESCRIPTION
Ran into a rare error using batch mode. Regardless of the size of the batch, the second batch tracebacks. For instance, with `salt -b 5 '*' test.ping`:

```
No minions matched the target. No command was sent, no jid was assigned.
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
TypeError: unhashable type: 'dict'
Traceback (most recent call last):
  File "/usr/bin/salt", line 10, in <module>
    salt_main()
  File "/usr/lib/python2.6/site-packages/salt/scripts.py", line 349, in salt_main
    client.run()
  File "/usr/lib/python2.6/site-packages/salt/cli/salt.py", line 95, in run
    for res in batch.run():
  File "/usr/lib/python2.6/site-packages/salt/cli/batch.py", line 175, in run
    if minion not in parts:
TypeError: unhashable type: 'dict'
Traceback (most recent call last):
  File "/usr/bin/salt", line 10, in <module>
    salt_main()
  File "/usr/lib/python2.6/site-packages/salt/scripts.py", line 349, in salt_main
    client.run()
  File "/usr/lib/python2.6/site-packages/salt/cli/salt.py", line 95, in run
    for res in batch.run():
  File "/usr/lib/python2.6/site-packages/salt/cli/batch.py", line 175, in run
    if minion not in parts:
TypeError: unhashable type: 'dict'
```

This patch catches the minion ID at the point where the name seems to get messed up. Rather than the list of minion IDs being nothing but strings, they show up as a list of dicts, where the only key is the ID of a minion.

This feels like I'm addressing a symptom instead of the cause, but I'm pretty sure this change is at least innocuous not to cause problems for anybody else.
