### PR TITLE
Changing user and group only possible for existing ids.

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -145,7 +145,8 @@ def gid_to_group(gid):
     try:
         return grp.getgrgid(gid).gr_name
     except (KeyError, NameError):
-        return ''
+        # If group is not present, fall back to the gid.
+        return gid
 
 
 def group_to_gid(group):
@@ -211,7 +212,8 @@ def uid_to_user(uid):
     try:
         return pwd.getpwuid(uid).pw_name
     except (KeyError, NameError):
-        return ''
+        # If user is not present, fall back to the uid.
+        return uid
 
 
 def user_to_uid(user):


### PR DESCRIPTION
Setting `user` and `group` attributes in the `file` module (e.g. via states `file.manage` and `file.directory`) only works, if the users and groups are present on the system. However, using ids for users and groups is valid in chown / lchown, even if they do not exist. Unix systems fall back to the id numbers for example in directory listings.

The `file` module ignores anonymous ids and does not perform the assignment. The problem can be reproduced with a simple state sls using a nonexistent GID / UID:

```
test_dir:
  file.directory:
  - name: /_testdir
  - user: 2015
  - group: 2015

test_file:
  file.managed:
  - name: /_testfile
  - user: 2015
  - group: 2015
  - content: test
```

For `file.directory`, a repeated `state.sls` run with `test=True` even suggests that the user and group will be changed. However, without the `test` option, the assignment is ignored.

This PR falls back to using the UID / GID for cases where they cannot be resolved for a name, avoiding a comparison on two empty strings in `check_perms`.
