### PR TITLE
fix deprecated pymongo usage causing errors in latest pymongo

### DIFF
--- a/salt/tops/mongo.py
+++ b/salt/tops/mongo.py
@@ -102,7 +102,7 @@ def top(**kwargs):
     environment_field = __opts__['master_tops']['mongo'].get('environment_field', 'environment')
 
     log.info('connecting to {0}:{1} for mongo ext_tops'.format(host, port))
-    conn = pymongo.Connection(host, port)
+    conn = pymongo.MongoClient(host, port)
 
     log.debug('using database \'{0}\''.format(__opts__['mongo.db']))
     mdb = conn[__opts__['mongo.db']]
@@ -126,7 +126,7 @@ def top(**kwargs):
         )
     )
 
-    result = mdb[collection].find_one({id_field: minion_id}, fields=[states_field, environment_field])
+    result = mdb[collection].find_one({id_field: minion_id}, projection=[states_field, environment_field])
     if result and states_field in result:
         if environment_field in result:
             environment = result[environment_field]


### PR DESCRIPTION
This minor fix just updates deprecated usage no longer available in pymongo > 3.0. The related open issue is https://github.com/saltstack/salt/issues/24174.

*Created against 2014.1
