### PR TITLE
Skip libvirt tests if not running as root

### DIFF
--- a/tests/unit/states/libvirt_test.py
+++ b/tests/unit/states/libvirt_test.py
@@ -4,6 +4,7 @@
 '''
 # Import Python libs
 from __future__ import absolute_import
+import os
 
 # Import Salt Testing Libs
 from salttesting import skipIf, TestCase
@@ -33,6 +34,7 @@ class LibvirtTestCase(TestCase):
     '''
     # 'keys' function tests: 1
 
+    @skipIf(os.geteuid() != 0, 'you must be root to run this test')
     @patch('os.path.isfile', MagicMock(return_value=False))
     def test_keys(self):
         '''


### PR DESCRIPTION
Running salt.states.libvirt.keys() results in an OSError if the pki dir needs
to be created.
