### PR TITLE
Fixed error where file was evaluated as a symlink in test_absent

### DIFF
--- a/tests/unit/states/file_test.py
+++ b/tests/unit/states/file_test.py
@@ -252,12 +252,12 @@ class FileTestCase(TestCase):
                                                   group=group), ret)
 
     # 'absent' function tests: 1
-
+    @patch.object(os.path, 'islink', MagicMock(return_value=False))
     def test_absent(self):
         '''
         Test to make sure that the named file or directory is absent.
         '''
-        name = '/etc/grub.conf'
+        name = '/fake/file.conf'
 
         ret = {'name': name,
                'result': False,


### PR DESCRIPTION
Changed name from a potentially real file to non-existent file as well. 
