### PR TITLE
Support split_dns on route53

### DIFF
--- a/salt/states/boto_route53.py
+++ b/salt/states/boto_route53.py
@@ -90,7 +90,9 @@ def present(
         key=None,
         keyid=None,
         profile=None,
-        wait_for_sync=True):
+        wait_for_sync=True,
+        split_dns=False,
+        private_zone=False):
     '''
     Ensure the Route53 record is present.
 
@@ -127,12 +129,20 @@ def present(
 
     wait_for_sync
         Wait for an INSYNC change status from Route53.
+
+    split_dns
+        Route53 supports a public and private DNS zone with the same
+        names.
+
+    private_zone
+        If using split_dns, specify if this is the private zone.
     '''
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
     record = __salt__['boto_route53.get_record'](name, zone, record_type,
                                                  False, region, key, keyid,
-                                                 profile)
+                                                 profile, split_dns,
+                                                 private_zone)
 
     if isinstance(record, dict) and not record:
         if __opts__['test']:
@@ -142,7 +152,8 @@ def present(
         added = __salt__['boto_route53.add_record'](name, value, zone,
                                                     record_type, identifier,
                                                     ttl, region, key, keyid,
-                                                    profile, wait_for_sync)
+                                                    profile, wait_for_sync,
+                                                    split_dns, private_zone)
         if added:
             ret['changes']['old'] = None
             ret['changes']['new'] = {'name': name,
@@ -182,7 +193,9 @@ def present(
                                                              identifier, ttl,
                                                              region, key,
                                                              keyid, profile,
-                                                             wait_for_sync)
+                                                             wait_for_sync,
+                                                             split_dns,
+                                                             private_zone)
             if updated:
                 ret['changes']['old'] = record
                 ret['changes']['new'] = {'name': name,
@@ -208,7 +221,9 @@ def absent(
         key=None,
         keyid=None,
         profile=None,
-        wait_for_sync=True):
+        wait_for_sync=True,
+        split_dns=False,
+        private_zone=False):
     '''
     Ensure the Route53 record is deleted.
 
@@ -236,12 +251,20 @@ def absent(
 
     wait_for_sync
         Wait for an INSYNC change status from Route53.
+
+    split_dns
+        Route53 supports a public and private DNS zone with the same
+        names.
+
+    private_zone
+        If using split_dns, specify if this is the private zone.
     '''
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
     record = __salt__['boto_route53.get_record'](name, zone, record_type,
                                                  False, region, key, keyid,
-                                                 profile)
+                                                 profile, split_dns,
+                                                 private_zone)
     if record:
         if __opts__['test']:
             msg = 'Route53 record {0} set to be deleted.'.format(name)
@@ -253,7 +276,9 @@ def absent(
                                                          identifier, False,
                                                          region, key, keyid,
                                                          profile,
-                                                         wait_for_sync)
+                                                         wait_for_sync,
+                                                         split_dns,
+                                                         private_zone)
         if deleted:
             ret['changes']['old'] = record
             ret['changes']['new'] = None


### PR DESCRIPTION
In Amazon Route53 it is possible to have public and private DNS zones with the same name.  This state and module were previously matching by name only, which would only ever get the zone that was first in the list with no way to determine if you were creating records for the public or private zone.

To ensure backwards compatibility, I added a split_dns flag that then looks for the PrivateZone boolean in the route53 config to determine if we are modifying the proper zone. 

If we don't need to support functionality in a totally backwards-compatible way, we can remove the split_dns flag and then force the state to specify whether it is the public or private zone being modified, but that was not how I currently implemented the change.

Separately, I noticed this state reports that it returns successfully in many cases where it should not.  This added functionality does not change that behavior -- the return behavior remains the same.  I will have to look deeper to understand that issue better.
