### PR TITLE
Changed the now deprecated .postinitio to ._prepare

### DIFF
--- a/salt/daemons/flo/core.py
+++ b/salt/daemons/flo/core.py
@@ -1731,7 +1731,7 @@ class SaltRaetMasterEvents(ioflo.base.deeding.Deed):
                'road_stack': '.salt.road.manor.stack',
                'master_events': '.salt.var.master_events'}
 
-    def postinitio(self):
+    def _prepare(self):
         self.master_events.value = deque()
 
     def action(self):


### PR DESCRIPTION
ioflo dropped deprecated Actor.postinitio() support starting from version 1.2.0. It was renamed to ._prepare(). Most of related changes have already applied in salt. But this one was missed.

Related to #21640 
