### PR TITLE
Add sqlite3 pillar

### DIFF
--- a/salt/pillar/mysql.py
+++ b/salt/pillar/mysql.py
@@ -87,7 +87,7 @@ class MySQLExtPillar(SqlBaseExtPillar):
     def _db_name(cls):
         return 'MySQL'
 
-    def _get_options():
+    def _get_options(self):
         '''
         Returns options used for the MySQL connection.
         '''
@@ -107,11 +107,11 @@ class MySQLExtPillar(SqlBaseExtPillar):
         return _options
 
     @contextmanager
-    def _get_cursor():
+    def _get_cursor(self):
         '''
         Yield a MySQL cursor
         '''
-        _options = _get_options()
+        _options = self._get_options()
         conn = MySQLdb.connect(host=_options['host'],
                                user=_options['user'],
                                passwd=_options['pass'],
@@ -141,6 +141,7 @@ class MySQLExtPillar(SqlBaseExtPillar):
 
         return super(MySQLExtPillar, self).extract_queries(args, kwargs)
 
+
 def ext_pillar(minion_id,
                pillar,
                *args,
@@ -148,4 +149,4 @@ def ext_pillar(minion_id,
     '''
     Execute queries against MySQL, merge and return as a dict
     '''
-    return  MySQLExtPillar().fetch(minion_id, pillar, *args, **kwargs)
+    return MySQLExtPillar().fetch(minion_id, pillar, *args, **kwargs)

--- a/salt/pillar/mysql.py
+++ b/salt/pillar/mysql.py
@@ -5,160 +5,34 @@ Retrieve Pillar data by doing a MySQL query
 MariaDB provides Python support through the MySQL Python package.
 Therefore, you may use this module with both MySQL or MariaDB.
 
+This module is a concrete implementation of the sql_base ext_pillar for MySQL.
+
 :maturity: new
 :depends: python-mysqldb
 :platform: all
 
-Theory of mysql ext_pillar
+Legacy compatibility
 =====================================
 
-Ok, here's the theory for how this works...
+This module has an extra addition for backward compatibility.
 
-- If there's a keyword arg of mysql_query, that'll go first.
-- Then any non-keyword args are processed in order.
-- Finally, remaining keywords are processed.
+If there's a keyword arg of mysql_query, that'll go first before other args.
+This legacy compatibility translates to depth 1.
 
 We do this so that it's backward compatible with older configs.
-Keyword arguments are sorted before being appended, so that they're predictable,
-but they will always be applied last so overall it's moot.
-
-For each of those items we process, it depends on the object type:
-
-- Strings are executed as is and the pillar depth is determined by the number
-  of fields returned.
-- A list has the first entry used as the query, the second as the pillar depth.
-- A mapping uses the keys "query" and "depth" as the tuple
-
-You can retrieve as many fields as you like, how they get used depends on the
-exact settings.
+This is deprecated and slated to be removed in Boron.
 
 Configuring the mysql ext_pillar
 =====================================
 
-First an example of how legacy queries were specified.
-
-.. code-block:: yaml
-
-  ext_pillar:
-    - mysql:
-        mysql_query: "SELECT pillar,value FROM pillars WHERE minion_id = %s"
-
-Alternatively, a list of queries can be passed in
-
-.. code-block:: yaml
-
-  ext_pillar:
-    - mysql:
-        - "SELECT pillar,value FROM pillars WHERE minion_id = %s"
-        - "SELECT pillar,value FROM more_pillars WHERE minion_id = %s"
-
-Or you can pass in a mapping
-
-.. code-block:: yaml
-
-  ext_pillar:
-    - mysql:
-        main: "SELECT pillar,value FROM pillars WHERE minion_id = %s"
-        extras: "SELECT pillar,value FROM more_pillars WHERE minion_id = %s"
-
-The query can be provided as a string as we have just shown, but they can be
-provided as lists
-
-.. code-block:: yaml
-
-  ext_pillar:
-    - mysql:
-        - "SELECT pillar,value FROM pillars WHERE minion_id = %s"
-          2
-
-Or as a mapping
-
-.. code-block:: yaml
-
-  ext_pillar:
-    - mysql:
-        - query: "SELECT pillar,value FROM pillars WHERE minion_id = %s"
-          depth: 2
-
-The depth defines how the dicts are constructed.
-Essentially if you query for fields a,b,c,d for each row you'll get:
-
-- With depth 1: {a: {"b": b, "c": c, "d": d}}
-- With depth 2: {a: {b: {"c": c, "d": d}}}
-- With depth 3: {a: {b: {c: d}}}
-
-Depth greater than 3 wouldn't be different from 3 itself.
-Depth of 0 translates to the largest depth needed, so 3 in this case.
-(max depth == key count - 1)
-
-The legacy compatibility translates to depth 1.
-
-Then they are merged in a similar way to plain pillar data, in the order
-returned by MySQL.
-
-Thus subsequent results overwrite previous ones when they collide.
-
-The ignore_null option can be used to change the overwrite behavior so that
-only non-NULL values in subsequent results will overwrite.  This can be used
-to selectively overwrite default values.
-
-.. code-block:: yaml
-
-  ext_pillar:
-    - mysql:
-        - query: "SELECT pillar,value FROM pillars WHERE minion_id = 'default' and minion_id != %s"
-          depth: 2
-        - query: "SELECT pillar,value FROM pillars WHERE minion_id = %s"
-          depth: 2
-          ignore_null: True
-
-If you specify `as_list: True` in the mapping expression it will convert
-collisions to lists.
-
-If you specify `with_lists: '...'` in the mapping expression it will
-convert the specified depths to list.  The string provided is a sequence
-numbers that are comma separated.  The string '1,3' will result in::
-
-    a,b,c,d,e,1  # field 1 same, field 3 differs
-    a,b,c,f,g,2  # ^^^^
-    a,z,h,y,j,3  # field 1 same, field 3 same
-    a,z,h,y,k,4  # ^^^^
-      ^   ^
-
-These columns define list grouping
-
-.. code-block:: python
-
-    {a: [
-          {c: [
-              {e: 1},
-              {g: 2}
-              ]
-          },
-          {h: [
-              {j: 3, k: 4 }
-              ]
-          }
-    ]}
-
-The range for with_lists is 1 to number_of_fields, inclusive.
-Numbers outside this range are ignored.
-
-Finally, if you pass the queries in via a mapping, the key will be the
-first level name where as passing them in as a list will place them in the
-root.  This isolates the query results into their own subtrees.
-This may be a help or hindrance to your aims and can be used as such.
-
-You can basically use any SELECT query that gets you the information, you
-could even do joins or subqueries in case your minion_id is stored elsewhere.
-It is capable of handling single rows or multiple rows per minion.
+Use the 'mysql' key under ext_pillar for configuration of queries.
 
 MySQL configuration of the MySQL returner is being used (mysql.db, mysql.user,
-mysql.pass, mysql.port, mysql.host)
+mysql.pass, mysql.port, mysql.host) for database connection info.
 
 Required python modules: MySQLdb
 
-More complete example
+Complete example
 =====================================
 
 .. code-block:: yaml
@@ -180,18 +54,13 @@ More complete example
 '''
 from __future__ import absolute_import
 
-# Please don't strip redundant parentheses from this file.
-# I have added some for clarity.
-
-# tests/unit/pillar/mysql_test.py may help understand this code.
-
 # Import python libs
 from contextlib import contextmanager
 import logging
 
 # Import Salt libs
-from salt.utils.odict import OrderedDict
-from salt.ext.six.moves import range
+import salt.utils
+from salt.pillar.sql_base import SqlBaseExtPillar
 
 # Set up logging
 log = logging.getLogger(__name__)
@@ -210,289 +79,73 @@ def __virtual__():
     return True
 
 
-def _get_options():
+class MySQLExtPillar(SqlBaseExtPillar):
     '''
-    Returns options used for the MySQL connection.
+    This class receives and processes the database rows from MySQL.
     '''
-    defaults = {'host': 'localhost',
-                'user': 'salt',
-                'pass': 'salt',
-                'db': 'salt',
-                'port': 3306}
-    _options = {}
-    _opts = __opts__.get('mysql', {})
-    for attr in defaults:
-        if attr not in _opts:
-            log.debug('Using default for MySQL {0}'.format(attr))
-            _options[attr] = defaults[attr]
-            continue
-        _options[attr] = _opts[attr]
-    return _options
+    @classmethod
+    def _db_name(cls):
+        return 'MySQL'
 
+    def _get_options():
+        '''
+        Returns options used for the MySQL connection.
+        '''
+        defaults = {'host': 'localhost',
+                    'user': 'salt',
+                    'pass': 'salt',
+                    'db': 'salt',
+                    'port': 3306}
+        _options = {}
+        _opts = __opts__.get('mysql', {})
+        for attr in defaults:
+            if attr not in _opts:
+                log.debug('Using default for MySQL {0}'.format(attr))
+                _options[attr] = defaults[attr]
+                continue
+            _options[attr] = _opts[attr]
+        return _options
 
-@contextmanager
-def _get_serv():
-    '''
-    Return a mysql cursor
-    '''
-    _options = _get_options()
-    conn = MySQLdb.connect(host=_options['host'],
-                           user=_options['user'],
-                           passwd=_options['pass'],
-                           db=_options['db'], port=_options['port'])
-    cursor = conn.cursor()
-    try:
-        yield cursor
-    except MySQLdb.DatabaseError as err:
-        log.exception('Error in ext_pillar MySQL: {0}'.format(err.args))
-    finally:
-        conn.close()
-
-
-class Merger(object):
-    '''
-        This class receives and processes the database rows in a database
-        agnostic way.
-    '''
-    result = None
-    focus = None
-    field_names = None
-    num_fields = 0
-    depth = 0
-    as_list = False
-    with_lists = None
-    ignore_null = False
-
-    def __init__(self):
-        self.result = self.focus = {}
+    @contextmanager
+    def _get_cursor():
+        '''
+        Yield a MySQL cursor
+        '''
+        _options = _get_options()
+        conn = MySQLdb.connect(host=_options['host'],
+                               user=_options['user'],
+                               passwd=_options['pass'],
+                               db=_options['db'], port=_options['port'])
+        cursor = conn.cursor()
+        try:
+            yield cursor
+        except MySQLdb.DatabaseError as err:
+            log.exception('Error in ext_pillar MySQL: {0}'.format(err.args))
+        finally:
+            conn.close()
 
     def extract_queries(self, args, kwargs):
         '''
             This function normalizes the config block into a set of queries we
             can use.  The return is a list of consistently laid out dicts.
         '''
-        # Please note the function signature is NOT an error.  Neither args, nor
-        # kwargs should have asterisks.  We are passing in a list and dict,
-        # rather than receiving variable args.  Adding asterisks WILL BREAK the
-        # function completely.
-
-        # First, this is the query buffer.  Contains lists of [base,sql]
-        qbuffer = []
-
-        # Is there an old style mysql_query?
+        # Handle legacy query specification
         if 'mysql_query' in kwargs:
-            qbuffer.append([None, kwargs.pop('mysql_query')])
+            salt.utils.warn_until(
+                'Boron',
+                'The legacy mysql_query configuration parameter is deprecated.'
+                'See the docs for the new styel of configuration.'
+                'This functionality will be removed in Salt Boron.'
+            )
+            args.insert(0, kwargs.pop('mysql_query'))
 
-        # Add on the non-keywords...
-        qbuffer.extend([[None, s] for s in args])
-
-        # And then the keywords...
-        # They aren't in definition order, but they can't conflict each other.
-        klist = list(kwargs.keys())
-        klist.sort()
-        qbuffer.extend([[k, kwargs[k]] for k in klist])
-
-        # Filter out values that don't have queries.
-        qbuffer = [x for x in qbuffer if (
-                (isinstance(x[1], str) and len(x[1]))
-                or
-                (isinstance(x[1], (list, tuple)) and (len(x[1]) > 0) and x[1][0])
-                or
-                (isinstance(x[1], dict) and 'query' in x[1] and len(x[1]['query']))
-            )]
-
-        # Next, turn the whole buffer into full dicts.
-        for qb in qbuffer:
-            defaults = {'query': '',
-                        'depth': 0,
-                        'as_list': False,
-                        'with_lists': None,
-                        'ignore_null': False
-                        }
-            if isinstance(qb[1], str):
-                defaults['query'] = qb[1]
-            elif isinstance(qb[1], (list, tuple)):
-                defaults['query'] = qb[1][0]
-                if len(qb[1]) > 1:
-                    defaults['depth'] = qb[1][1]
-                # May set 'as_list' from qb[1][2].
-            else:
-                defaults.update(qb[1])
-                if defaults['with_lists']:
-                    defaults['with_lists'] = [
-                        int(i) for i in defaults['with_lists'].split(',')
-                    ]
-            qb[1] = defaults
-
-        return qbuffer
-
-    def enter_root(self, root):
-        '''
-            Set self.focus for kwarg queries
-        '''
-        # There is no collision protection on root name isolation
-        if root:
-            self.result[root] = self.focus = {}
-        else:
-            self.focus = self.result
-
-    def process_fields(self, field_names, depth):
-        '''
-            The primary purpose of this function is to store the sql field list
-            and the depth to which we process.
-        '''
-        # List of field names in correct order.
-        self.field_names = field_names
-        # number of fields.
-        self.num_fields = len(field_names)
-        # Constrain depth.
-        if (depth == 0) or (depth >= self.num_fields):
-            self.depth = self.num_fields - 1
-        else:
-            self.depth = depth
-
-    def process_results(self, rows):
-        '''
-            This function takes a list of database results and iterates over,
-            merging them into a dict form.
-        '''
-        listify = OrderedDict()
-        listify_dicts = OrderedDict()
-        for ret in rows:
-            # crd is the Current Return Data level, to make this non-recursive.
-            crd = self.focus
-            # Walk and create dicts above the final layer
-            for i in range(0, self.depth-1):
-                # At the end we'll use listify to find values to make a list of
-                if i+1 in self.with_lists:
-                    if id(crd) not in listify:
-                        listify[id(crd)] = []
-                        listify_dicts[id(crd)] = crd
-                    if ret[i] not in listify[id(crd)]:
-                        listify[id(crd)].append(ret[i])
-                if ret[i] not in crd:
-                    # Key missing
-                    crd[ret[i]] = {}
-                    crd = crd[ret[i]]
-                else:
-                    # Check type of collision
-                    ty = type(crd[ret[i]])
-                    if ty is list:
-                        # Already made list
-                        temp = {}
-                        crd[ret[i]].append(temp)
-                        crd = temp
-                    elif ty is not dict:
-                        # Not a list, not a dict
-                        if self.as_list:
-                            # Make list
-                            temp = {}
-                            crd[ret[i]] = [crd[ret[i]], temp]
-                            crd = temp
-                        else:
-                            # Overwrite
-                            crd[ret[i]] = {}
-                            crd = crd[ret[i]]
-                    else:
-                        # dict, descend.
-                        crd = crd[ret[i]]
-
-            # If this test is true, the penultimate field is the key
-            if self.depth == self.num_fields - 1:
-                nk = self.num_fields-2  # Aka, self.depth-1
-                # Should we and will we have a list at the end?
-                if ((self.as_list and (ret[nk] in crd)) or
-                        (nk+1 in self.with_lists)):
-                    if ret[nk] in crd:
-                        if not isinstance(crd[ret[nk]], list):
-                            crd[ret[nk]] = [crd[ret[nk]]]
-                        # if it's already a list, do nothing
-                    else:
-                        crd[ret[nk]] = []
-                    crd[ret[nk]].append(ret[self.num_fields-1])
-                else:
-                    if not self.ignore_null or ret[self.num_fields-1] is not None:
-                        crd[ret[nk]] = ret[self.num_fields-1]
-            else:
-                # Otherwise, the field name is the key but we have a spare.
-                # The spare results because of {c: d} vs {c: {"d": d, "e": e }}
-                # So, make that last dict
-                if ret[self.depth-1] not in crd:
-                    crd[ret[self.depth-1]] = {}
-                # This bit doesn't escape listify
-                if self.depth in self.with_lists:
-                    if id(crd) not in listify:
-                        listify[id(crd)] = []
-                        listify_dicts[id(crd)] = crd
-                    if ret[self.depth-1] not in listify[id(crd)]:
-                        listify[id(crd)].append(ret[self.depth-1])
-                crd = crd[ret[self.depth-1]]
-                # Now for the remaining keys, we put them into the dict
-                for i in range(self.depth, self.num_fields):
-                    nk = self.field_names[i]
-                    # Listify
-                    if i+1 in self.with_lists:
-                        if id(crd) not in listify:
-                            listify[id(crd)] = []
-                            listify_dicts[id(crd)] = crd
-                        if nk not in listify[id(crd)]:
-                            listify[id(crd)].append(nk)
-                    # Collision detection
-                    if self.as_list and (nk in crd):
-                        # Same as before...
-                        if isinstance(crd[nk], list):
-                            crd[nk].append(ret[i])
-                        else:
-                            crd[nk] = [crd[nk], ret[i]]
-                    else:
-                        if not self.ignore_null or ret[i] is not None:
-                            crd[nk] = ret[i]
-        # Get key list and work backwards.  This is inner-out processing
-        ks = list(listify_dicts.keys())
-        ks.reverse()
-        for i in ks:
-            d = listify_dicts[i]
-            for k in listify[i]:
-                if isinstance(d[k], dict):
-                    d[k] = list(d[k].values())
-                elif isinstance(d[k], list):
-                    d[k] = [d[k]]
-
+        return super(MySQLExtPillar, self).extract_queries(args, kwargs)
 
 def ext_pillar(minion_id,
-               pillar,  # pylint: disable=W0613
+               pillar,
                *args,
                **kwargs):
     '''
-    Execute queries, merge and return as a dict
+    Execute queries against MySQL, merge and return as a dict
     '''
-    log.info('Querying MySQL for information for {0}'.format(minion_id, ))
-    #
-    #    log.debug('ext_pillar MySQL args: {0}'.format(args))
-    #    log.debug('ext_pillar MySQL kwargs: {0}'.format(kwargs))
-    #
-    # Most of the heavy lifting is in this class for ease of testing.
-    return_data = Merger()
-    qbuffer = return_data.extract_queries(args, kwargs)
-    with _get_serv() as cur:
-        for root, details in qbuffer:
-            # Run the query
-            cur.execute(details['query'], (minion_id,))
-
-            # Extract the field names MySQL has returned and process them
-            # All heavy lifting is done in the Merger class to decouple the
-            # logic from MySQL.  Makes it easier to test.
-            return_data.process_fields([row[0] for row in cur.description],
-                                       details['depth'])
-            return_data.enter_root(root)
-            return_data.as_list = details['as_list']
-            if details['with_lists']:
-                return_data.with_lists = details['with_lists']
-            else:
-                return_data.with_lists = []
-            return_data.ignore_null = details['ignore_null']
-            return_data.process_results(cur.fetchall())
-
-            log.debug('ext_pillar MySQL: Return data: {0}'.format(
-                      return_data))
-    return return_data.result
+    return  MySQLExtPillar().fetch(minion_id, pillar, *args, **kwargs)

--- a/salt/pillar/sql_base.py
+++ b/salt/pillar/sql_base.py
@@ -176,13 +176,13 @@ from __future__ import absolute_import
 # tests/unit/pillar/mysql_test.py may help understand this code.
 
 # Import python libs
-from contextlib import contextmanager
 import logging
-import abc # Added in python2.6 so always available
+import abc  # Added in python2.6 so always available
 
 # Import Salt libs
 from salt.utils.odict import OrderedDict
 from salt.ext.six.moves import range
+from salt.ext import six
 
 # Set up logging
 log = logging.getLogger(__name__)
@@ -193,12 +193,11 @@ def __virtual__():
     return False
 
 
-class SqlBaseExtPillar(object):
+class SqlBaseExtPillar(six.with_metaclass(abc.ABCMeta, object)):
     '''
     This class receives and processes the database rows in a database
     agnostic way.
     '''
-    __metaclass__ = abc.ABCMeta
 
     result = None
     focus = None
@@ -416,7 +415,6 @@ class SqlBaseExtPillar(object):
                 elif isinstance(d[k], list):
                     d[k] = [d[k]]
 
-
     def fetch(self,
               minion_id,
               pillar,  # pylint: disable=W0613
@@ -426,14 +424,14 @@ class SqlBaseExtPillar(object):
         Execute queries, merge and return as a dict.
         '''
         db_name = self._db_name()
-        log.info('Querying {0} for information for {1}'.format(db_name,  minion_id))
+        log.info('Querying {0} for information for {1}'.format(db_name, minion_id))
         #
         #    log.debug('ext_pillar {0} args: {1}'.format(db_name, args))
         #    log.debug('ext_pillar {0} kwargs: {1}'.format(db_name, kwargs))
         #
         # Most of the heavy lifting is in this class for ease of testing.
         qbuffer = self.extract_queries(args, kwargs)
-        with _get_cursor() as cursor:
+        with self._get_cursor() as cursor:
             for root, details in qbuffer:
                 # Run the query
                 cursor.execute(details['query'], (minion_id,))
@@ -450,8 +448,7 @@ class SqlBaseExtPillar(object):
                 self.ignore_null = details['ignore_null']
                 self.process_results(cursor.fetchall())
 
-                log.debug('ext_pillar {0}: Return data: {1}'.format(db_name,
-                      self))
+                log.debug('ext_pillar {0}: Return data: {1}'.format(db_name, self))
         return self.result
 
 

--- a/salt/pillar/sql_base.py
+++ b/salt/pillar/sql_base.py
@@ -1,0 +1,459 @@
+# -*- coding: utf-8 -*-
+'''
+Retrieve Pillar data by doing a SQL query
+
+This module is not meant to be used directly as an ext_pillar.
+It is a place to put code common to PEP 249 compliant SQL database adapters.
+It exposes a python ABC that can be subclassed for new database providers.
+
+:maturity: new
+:platform: all
+
+Theory of sql_base ext_pillar
+=====================================
+
+Ok, here's the theory for how this works...
+
+- First, any non-keyword args are processed in order.
+- Then, remaining keywords are processed.
+
+We do this so that it's backward compatible with older configs.
+Keyword arguments are sorted before being appended, so that they're predictable,
+but they will always be applied last so overall it's moot.
+
+For each of those items we process, it depends on the object type:
+
+- Strings are executed as is and the pillar depth is determined by the number
+  of fields returned.
+- A list has the first entry used as the query, the second as the pillar depth.
+- A mapping uses the keys "query" and "depth" as the tuple
+
+You can retrieve as many fields as you like, how they get used depends on the
+exact settings.
+
+Configuring a sql_base ext_pillar
+=====================================
+
+The sql_base ext_pillar cannot be used directly, but shares query configuration
+with its implementations. These examples use a fake 'sql_base' adapter, which
+should be replaced with the name of the adapter you are using.
+
+A list of queries can be passed in
+
+.. code-block:: yaml
+
+  ext_pillar:
+    - sql_base:
+        - "SELECT pillar,value FROM pillars WHERE minion_id = %s"
+        - "SELECT pillar,value FROM more_pillars WHERE minion_id = %s"
+
+Or you can pass in a mapping
+
+.. code-block:: yaml
+
+  ext_pillar:
+    - sql_base:
+        main: "SELECT pillar,value FROM pillars WHERE minion_id = %s"
+        extras: "SELECT pillar,value FROM more_pillars WHERE minion_id = %s"
+
+The query can be provided as a string as we have just shown, but they can be
+provided as lists
+
+.. code-block:: yaml
+
+  ext_pillar:
+    - sql_base:
+        - "SELECT pillar,value FROM pillars WHERE minion_id = %s"
+          2
+
+Or as a mapping
+
+.. code-block:: yaml
+
+  ext_pillar:
+    - sql_base:
+        - query: "SELECT pillar,value FROM pillars WHERE minion_id = %s"
+          depth: 2
+
+The depth defines how the dicts are constructed.
+Essentially if you query for fields a,b,c,d for each row you'll get:
+
+- With depth 1: {a: {"b": b, "c": c, "d": d}}
+- With depth 2: {a: {b: {"c": c, "d": d}}}
+- With depth 3: {a: {b: {c: d}}}
+
+Depth greater than 3 wouldn't be different from 3 itself.
+Depth of 0 translates to the largest depth needed, so 3 in this case.
+(max depth == key count - 1)
+
+Then they are merged in a similar way to plain pillar data, in the order
+returned by the SQL database.
+
+Thus subsequent results overwrite previous ones when they collide.
+
+The ignore_null option can be used to change the overwrite behavior so that
+only non-NULL values in subsequent results will overwrite.  This can be used
+to selectively overwrite default values.
+
+.. code-block:: yaml
+
+  ext_pillar:
+    - sql_base:
+        - query: "SELECT pillar,value FROM pillars WHERE minion_id = 'default' and minion_id != %s"
+          depth: 2
+        - query: "SELECT pillar,value FROM pillars WHERE minion_id = %s"
+          depth: 2
+          ignore_null: True
+
+If you specify `as_list: True` in the mapping expression it will convert
+collisions to lists.
+
+If you specify `with_lists: '...'` in the mapping expression it will
+convert the specified depths to list.  The string provided is a sequence
+numbers that are comma separated.  The string '1,3' will result in::
+
+    a,b,c,d,e,1  # field 1 same, field 3 differs
+    a,b,c,f,g,2  # ^^^^
+    a,z,h,y,j,3  # field 1 same, field 3 same
+    a,z,h,y,k,4  # ^^^^
+      ^   ^
+
+These columns define list grouping
+
+.. code-block:: python
+
+    {a: [
+          {c: [
+              {e: 1},
+              {g: 2}
+              ]
+          },
+          {h: [
+              {j: 3, k: 4 }
+              ]
+          }
+    ]}
+
+The range for with_lists is 1 to number_of_fields, inclusive.
+Numbers outside this range are ignored.
+
+Finally, if you pass the queries in via a mapping, the key will be the
+first level name where as passing them in as a list will place them in the
+root.  This isolates the query results into their own subtrees.
+This may be a help or hindrance to your aims and can be used as such.
+
+You can basically use any SELECT query that gets you the information, you
+could even do joins or subqueries in case your minion_id is stored elsewhere.
+It is capable of handling single rows or multiple rows per minion.
+
+Configuration of the connection depends on the adapter in use.
+
+More complete example for MySQL (to also show configuration)
+=====================================
+
+.. code-block:: yaml
+
+    mysql:
+      user: 'salt'
+      pass: 'super_secret_password'
+      db: 'salt_db'
+
+    ext_pillar:
+      - mysql:
+          fromdb:
+            query: 'SELECT col1,col2,col3,col4,col5,col6,col7
+                      FROM some_random_table
+                     WHERE minion_pattern LIKE %s'
+            depth: 5
+            as_list: True
+            with_lists: [1,3]
+'''
+from __future__ import absolute_import
+
+# Please don't strip redundant parentheses from this file.
+# I have added some for clarity.
+
+# tests/unit/pillar/mysql_test.py may help understand this code.
+
+# Import python libs
+from contextlib import contextmanager
+import logging
+import abc # Added in python2.6 so always available
+
+# Import Salt libs
+from salt.utils.odict import OrderedDict
+from salt.ext.six.moves import range
+
+# Set up logging
+log = logging.getLogger(__name__)
+
+
+# This ext_pillar is abstract and cannot be used directory
+def __virtual__():
+    return False
+
+
+class SqlBaseExtPillar(object):
+    '''
+    This class receives and processes the database rows in a database
+    agnostic way.
+    '''
+    __metaclass__ = abc.ABCMeta
+
+    result = None
+    focus = None
+    field_names = None
+    num_fields = 0
+    depth = 0
+    as_list = False
+    with_lists = None
+    ignore_null = False
+
+    def __init__(self):
+        self.result = self.focus = {}
+
+    @classmethod
+    @abc.abstractmethod
+    def _db_name(cls):
+        '''
+        Return a friendly name for the database, e.g. 'MySQL' or 'SQLite'.
+        Used in logging output.
+        '''
+        pass
+
+    @abc.abstractmethod
+    def _get_cursor(self):
+        '''
+        Yield a PEP 249 compliant Cursor as a context manager.
+        '''
+        pass
+
+    def extract_queries(self, args, kwargs):
+        '''
+        This function normalizes the config block into a set of queries we
+        can use.  The return is a list of consistently laid out dicts.
+        '''
+        # Please note the function signature is NOT an error.  Neither args, nor
+        # kwargs should have asterisks.  We are passing in a list and dict,
+        # rather than receiving variable args.  Adding asterisks WILL BREAK the
+        # function completely.
+
+        # First, this is the query buffer.  Contains lists of [base,sql]
+        qbuffer = []
+
+        # Add on the non-keywords...
+        qbuffer.extend([[None, s] for s in args])
+
+        # And then the keywords...
+        # They aren't in definition order, but they can't conflict each other.
+        klist = list(kwargs.keys())
+        klist.sort()
+        qbuffer.extend([[k, kwargs[k]] for k in klist])
+
+        # Filter out values that don't have queries.
+        qbuffer = [x for x in qbuffer if (
+                (isinstance(x[1], str) and len(x[1]))
+                or
+                (isinstance(x[1], (list, tuple)) and (len(x[1]) > 0) and x[1][0])
+                or
+                (isinstance(x[1], dict) and 'query' in x[1] and len(x[1]['query']))
+            )]
+
+        # Next, turn the whole buffer into full dicts.
+        for qb in qbuffer:
+            defaults = {'query': '',
+                        'depth': 0,
+                        'as_list': False,
+                        'with_lists': None,
+                        'ignore_null': False
+                        }
+            if isinstance(qb[1], str):
+                defaults['query'] = qb[1]
+            elif isinstance(qb[1], (list, tuple)):
+                defaults['query'] = qb[1][0]
+                if len(qb[1]) > 1:
+                    defaults['depth'] = qb[1][1]
+                # May set 'as_list' from qb[1][2].
+            else:
+                defaults.update(qb[1])
+                if defaults['with_lists']:
+                    defaults['with_lists'] = [
+                        int(i) for i in defaults['with_lists'].split(',')
+                    ]
+            qb[1] = defaults
+
+        return qbuffer
+
+    def enter_root(self, root):
+        '''
+        Set self.focus for kwarg queries
+        '''
+        # There is no collision protection on root name isolation
+        if root:
+            self.result[root] = self.focus = {}
+        else:
+            self.focus = self.result
+
+    def process_fields(self, field_names, depth):
+        '''
+        The primary purpose of this function is to store the sql field list
+        and the depth to which we process.
+        '''
+        # List of field names in correct order.
+        self.field_names = field_names
+        # number of fields.
+        self.num_fields = len(field_names)
+        # Constrain depth.
+        if (depth == 0) or (depth >= self.num_fields):
+            self.depth = self.num_fields - 1
+        else:
+            self.depth = depth
+
+    def process_results(self, rows):
+        '''
+        This function takes a list of database results and iterates over,
+        merging them into a dict form.
+        '''
+        listify = OrderedDict()
+        listify_dicts = OrderedDict()
+        for ret in rows:
+            # crd is the Current Return Data level, to make this non-recursive.
+            crd = self.focus
+            # Walk and create dicts above the final layer
+            for i in range(0, self.depth-1):
+                # At the end we'll use listify to find values to make a list of
+                if i+1 in self.with_lists:
+                    if id(crd) not in listify:
+                        listify[id(crd)] = []
+                        listify_dicts[id(crd)] = crd
+                    if ret[i] not in listify[id(crd)]:
+                        listify[id(crd)].append(ret[i])
+                if ret[i] not in crd:
+                    # Key missing
+                    crd[ret[i]] = {}
+                    crd = crd[ret[i]]
+                else:
+                    # Check type of collision
+                    ty = type(crd[ret[i]])
+                    if ty is list:
+                        # Already made list
+                        temp = {}
+                        crd[ret[i]].append(temp)
+                        crd = temp
+                    elif ty is not dict:
+                        # Not a list, not a dict
+                        if self.as_list:
+                            # Make list
+                            temp = {}
+                            crd[ret[i]] = [crd[ret[i]], temp]
+                            crd = temp
+                        else:
+                            # Overwrite
+                            crd[ret[i]] = {}
+                            crd = crd[ret[i]]
+                    else:
+                        # dict, descend.
+                        crd = crd[ret[i]]
+
+            # If this test is true, the penultimate field is the key
+            if self.depth == self.num_fields - 1:
+                nk = self.num_fields-2  # Aka, self.depth-1
+                # Should we and will we have a list at the end?
+                if ((self.as_list and (ret[nk] in crd)) or
+                        (nk+1 in self.with_lists)):
+                    if ret[nk] in crd:
+                        if not isinstance(crd[ret[nk]], list):
+                            crd[ret[nk]] = [crd[ret[nk]]]
+                        # if it's already a list, do nothing
+                    else:
+                        crd[ret[nk]] = []
+                    crd[ret[nk]].append(ret[self.num_fields-1])
+                else:
+                    if not self.ignore_null or ret[self.num_fields-1] is not None:
+                        crd[ret[nk]] = ret[self.num_fields-1]
+            else:
+                # Otherwise, the field name is the key but we have a spare.
+                # The spare results because of {c: d} vs {c: {"d": d, "e": e }}
+                # So, make that last dict
+                if ret[self.depth-1] not in crd:
+                    crd[ret[self.depth-1]] = {}
+                # This bit doesn't escape listify
+                if self.depth in self.with_lists:
+                    if id(crd) not in listify:
+                        listify[id(crd)] = []
+                        listify_dicts[id(crd)] = crd
+                    if ret[self.depth-1] not in listify[id(crd)]:
+                        listify[id(crd)].append(ret[self.depth-1])
+                crd = crd[ret[self.depth-1]]
+                # Now for the remaining keys, we put them into the dict
+                for i in range(self.depth, self.num_fields):
+                    nk = self.field_names[i]
+                    # Listify
+                    if i+1 in self.with_lists:
+                        if id(crd) not in listify:
+                            listify[id(crd)] = []
+                            listify_dicts[id(crd)] = crd
+                        if nk not in listify[id(crd)]:
+                            listify[id(crd)].append(nk)
+                    # Collision detection
+                    if self.as_list and (nk in crd):
+                        # Same as before...
+                        if isinstance(crd[nk], list):
+                            crd[nk].append(ret[i])
+                        else:
+                            crd[nk] = [crd[nk], ret[i]]
+                    else:
+                        if not self.ignore_null or ret[i] is not None:
+                            crd[nk] = ret[i]
+        # Get key list and work backwards.  This is inner-out processing
+        ks = list(listify_dicts.keys())
+        ks.reverse()
+        for i in ks:
+            d = listify_dicts[i]
+            for k in listify[i]:
+                if isinstance(d[k], dict):
+                    d[k] = list(d[k].values())
+                elif isinstance(d[k], list):
+                    d[k] = [d[k]]
+
+
+    def fetch(self,
+              minion_id,
+              pillar,  # pylint: disable=W0613
+              *args,
+              **kwargs):
+        '''
+        Execute queries, merge and return as a dict.
+        '''
+        db_name = self._db_name()
+        log.info('Querying {0} for information for {1}'.format(db_name,  minion_id))
+        #
+        #    log.debug('ext_pillar {0} args: {1}'.format(db_name, args))
+        #    log.debug('ext_pillar {0} kwargs: {1}'.format(db_name, kwargs))
+        #
+        # Most of the heavy lifting is in this class for ease of testing.
+        qbuffer = self.extract_queries(args, kwargs)
+        with _get_cursor() as cursor:
+            for root, details in qbuffer:
+                # Run the query
+                cursor.execute(details['query'], (minion_id,))
+
+                # Extract the field names the db has returned and process them
+                self.process_fields([row[0] for row in cursor.description],
+                                           details['depth'])
+                self.enter_root(root)
+                self.as_list = details['as_list']
+                if details['with_lists']:
+                    self.with_lists = details['with_lists']
+                else:
+                    self.with_lists = []
+                self.ignore_null = details['ignore_null']
+                self.process_results(cursor.fetchall())
+
+                log.debug('ext_pillar {0}: Return data: {1}'.format(db_name,
+                      self))
+        return self.result
+
+
+# To extend this module you must define a top level ext_pillar procedure
+# See mysql.py for an example

--- a/salt/pillar/sqlite3.py
+++ b/salt/pillar/sqlite3.py
@@ -53,7 +53,6 @@ import logging
 import sqlite3
 
 # Import Salt libs
-import salt.utils
 from salt.pillar.sql_base import SqlBaseExtPillar
 
 # Set up logging
@@ -72,7 +71,7 @@ class SQLite3ExtPillar(SqlBaseExtPillar):
     def _db_name(cls):
         return 'SQLite3'
 
-    def _get_options():
+    def _get_options(self):
         '''
         Returns options used for the SQLite3 connection.
         '''
@@ -89,11 +88,11 @@ class SQLite3ExtPillar(SqlBaseExtPillar):
         return _options
 
     @contextmanager
-    def _get_cursor():
+    def _get_cursor(self):
         '''
         Yield a SQLite3 cursor
         '''
-        _options = _get_options()
+        _options = self._get_options()
         conn = sqlite3.connect(_options.get('database'),
                                timeout=float(_options.get('timeout')))
         cursor = conn.cursor()
@@ -104,6 +103,7 @@ class SQLite3ExtPillar(SqlBaseExtPillar):
         finally:
             conn.close()
 
+
 def ext_pillar(minion_id,
                pillar,
                *args,
@@ -111,4 +111,4 @@ def ext_pillar(minion_id,
     '''
     Execute queries against SQLite3, merge and return as a dict
     '''
-    return  SQLite3ExtPillar().fetch(minion_id, pillar, *args, **kwargs)
+    return SQLite3ExtPillar().fetch(minion_id, pillar, *args, **kwargs)

--- a/salt/pillar/sqlite3.py
+++ b/salt/pillar/sqlite3.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+'''
+Retrieve Pillar data by doing a SQLite3 query
+
+sqlite3 is included in the stdlib since python2.5.
+
+This module is a concrete implementation of the sql_base ext_pillar for SQLite3.
+
+:maturity: new
+:platform: all
+
+Configuring the sqlite3 ext_pillar
+=====================================
+
+Use the 'sqlite3' key under ext_pillar for configuration of queries.
+
+SQLite3 database connection configuration requires the following values
+configured in the master config:
+
+Note, timeout is in seconds.
+
+.. code-block:: yaml
+
+    pillar.sqlite3.database: /var/lib/salt/pillar.db
+    pillar.sqlite3.timeout: 5.0
+
+
+Complete example
+=====================================
+
+.. code-block:: yaml
+
+    pillar:
+      sqlite3:
+        database: '/var/lib/salt/pillar.db'
+        timeout: 5.0
+
+    ext_pillar:
+      - sqlite3:
+          fromdb:
+            query: 'SELECT col1,col2,col3,col4,col5,col6,col7
+                      FROM some_random_table
+                     WHERE minion_pattern LIKE %s'
+            depth: 5
+            as_list: True
+            with_lists: [1,3]
+'''
+from __future__ import absolute_import
+
+# Import python libs
+from contextlib import contextmanager
+import logging
+import sqlite3
+
+# Import Salt libs
+import salt.utils
+from salt.pillar.sql_base import SqlBaseExtPillar
+
+# Set up logging
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    return True
+
+
+class SQLite3ExtPillar(SqlBaseExtPillar):
+    '''
+    This class receives and processes the database rows from SQLite3.
+    '''
+    @classmethod
+    def _db_name(cls):
+        return 'SQLite3'
+
+    def _get_options():
+        '''
+        Returns options used for the SQLite3 connection.
+        '''
+        defaults = {'database': '/var/lib/salt/pillar.db',
+                    'timeout': 5.0}
+        _options = {}
+        _opts = __opts__.get('pillar', {}).get('sqlite3', {})
+        for attr in defaults:
+            if attr not in _opts:
+                log.debug('Using default for SQLite3 pillar {0}'.format(attr))
+                _options[attr] = defaults[attr]
+                continue
+            _options[attr] = _opts[attr]
+        return _options
+
+    @contextmanager
+    def _get_cursor():
+        '''
+        Yield a SQLite3 cursor
+        '''
+        _options = _get_options()
+        conn = sqlite3.connect(_options.get('database'),
+                               timeout=float(_options.get('timeout')))
+        cursor = conn.cursor()
+        try:
+            yield cursor
+        except sqlite3.Error as err:
+            log.exception('Error in ext_pillar SQLite3: {0}'.format(err.args))
+        finally:
+            conn.close()
+
+def ext_pillar(minion_id,
+               pillar,
+               *args,
+               **kwargs):
+    '''
+    Execute queries against SQLite3, merge and return as a dict
+    '''
+    return  SQLite3ExtPillar().fetch(minion_id, pillar, *args, **kwargs)

--- a/tests/unit/pillar/mysql_test.py
+++ b/tests/unit/pillar/mysql_test.py
@@ -19,7 +19,7 @@ class MysqlPillarTestCase(TestCase):
     maxDiff = None
 
     def test_001_extract_queries_legacy(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         args, kwargs = [], {'mysql_query': 'SELECT blah'}
         qbuffer = return_data.extract_queries(args, kwargs)
         self.assertEqual([
@@ -28,7 +28,7 @@ class MysqlPillarTestCase(TestCase):
         ], qbuffer)
 
     def test_002_extract_queries_list(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         args, kwargs = [
             'SELECT blah',
             'SELECT blah2',
@@ -63,7 +63,7 @@ class MysqlPillarTestCase(TestCase):
         ], qbuffer)
 
     def test_003_extract_queries_kwarg(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         args, kwargs = [], {
             '1': 'SELECT blah',
             '2': 'SELECT blah2',
@@ -92,7 +92,7 @@ class MysqlPillarTestCase(TestCase):
         ], qbuffer)
 
     def test_004_extract_queries_mixed(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         args, kwargs = [
             'SELECT blah1',
             ('SELECT blah2', 2),
@@ -123,7 +123,7 @@ class MysqlPillarTestCase(TestCase):
 
     def test_005_extract_queries_bogus_list(self):
         # This test is specifically checking that empty queries are dropped
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         args, kwargs = [
             'SELECT blah',
             '',
@@ -161,7 +161,7 @@ class MysqlPillarTestCase(TestCase):
 
     def test_006_extract_queries_bogus_kwargs(self):
         # this test is cut down as most of the path matches test_*_bogus_list
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         args, kwargs = [], {
             '1': 'SELECT blah',
             '2': '',
@@ -176,14 +176,14 @@ class MysqlPillarTestCase(TestCase):
         ], qbuffer)
 
     def test_011_enter_root(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.enter_root("test")
         self.assertEqual(return_data.result["test"], return_data.focus)
         return_data.enter_root(None)
         self.assertEqual(return_data.result, return_data.focus)
 
     def test_021_process_fields(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.process_fields(['a', 'b'], 0)
         self.assertEqual(return_data.num_fields, 2)
         self.assertEqual(return_data.depth, 1)
@@ -207,7 +207,7 @@ class MysqlPillarTestCase(TestCase):
         self.assertEqual(return_data.depth, 3)
 
     def test_111_process_results_legacy(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.process_fields(['a', 'b'], 0)
         return_data.with_lists = []
         return_data.process_results([[1, 2]])
@@ -217,7 +217,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_112_process_results_legacy_multiple(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.process_fields(['a', 'b'], 0)
         return_data.with_lists = []
         return_data.process_results([[1, 2], [3, 4], [5, 6]])
@@ -227,7 +227,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_121_process_results_depth_0(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.process_fields(['a', 'b', 'c', 'd'], 0)
         return_data.with_lists = []
         return_data.enter_root(None)
@@ -238,7 +238,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_122_process_results_depth_1(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.process_fields(['a', 'b', 'c', 'd'], 1)
         return_data.with_lists = []
         return_data.enter_root(None)
@@ -249,7 +249,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_123_process_results_depth_2(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.process_fields(['a', 'b', 'c', 'd'], 2)
         return_data.with_lists = []
         return_data.enter_root(None)
@@ -260,7 +260,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_124_process_results_depth_3(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.process_fields(['a', 'b', 'c', 'd'], 3)
         return_data.with_lists = []
         return_data.enter_root(None)
@@ -271,7 +271,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_125_process_results_depth_4(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.process_fields(['a', 'b', 'c', 'd'], 4)
         return_data.with_lists = []
         return_data.enter_root(None)
@@ -282,7 +282,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_131_process_results_overwrite_legacy_multiple(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.process_fields(['a', 'b'], 0)
         return_data.with_lists = []
         return_data.process_results([[1, 2], [3, 4], [1, 6]])
@@ -292,7 +292,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_132_process_results_merge_depth_0(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.process_fields(['a', 'b', 'c', 'd'], 0)
         return_data.with_lists = []
         return_data.enter_root(None)
@@ -303,7 +303,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_133_process_results_overwrite_depth_0(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.process_fields(['a', 'b', 'c', 'd'], 0)
         return_data.with_lists = []
         return_data.enter_root(None)
@@ -314,7 +314,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_134_process_results_deepmerge_depth_0(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.process_fields(['a', 'b', 'c', 'd'], 0)
         return_data.with_lists = []
         return_data.enter_root(None)
@@ -325,7 +325,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_135_process_results_overwrite_depth_1(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.process_fields(['a', 'b', 'c', 'd'], 1)
         return_data.with_lists = []
         return_data.enter_root(None)
@@ -336,7 +336,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_136_process_results_merge_depth_2(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.process_fields(['a', 'b', 'c', 'd'], 2)
         return_data.with_lists = []
         return_data.enter_root(None)
@@ -347,7 +347,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_137_process_results_overwrite_depth_2(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.process_fields(['a', 'b', 'c', 'd'], 2)
         return_data.with_lists = []
         return_data.enter_root(None)
@@ -358,7 +358,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_201_process_results_complexity_multiresults(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.process_fields(['a', 'b', 'c', 'd'], 2)
         return_data.with_lists = []
         return_data.enter_root(None)
@@ -370,7 +370,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_202_process_results_complexity_as_list(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.process_fields(['a', 'b', 'c', 'd'], 2)
         return_data.with_lists = []
         return_data.enter_root(None)
@@ -383,7 +383,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_203_process_results_complexity_as_list_deeper(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.process_fields(['a', 'b', 'c', 'd'], 0)
         return_data.with_lists = []
         return_data.enter_root(None)
@@ -396,7 +396,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_204_process_results_complexity_as_list_mismatch_depth(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.as_list = True
         return_data.with_lists = []
         return_data.enter_root(None)
@@ -411,7 +411,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_205_process_results_complexity_as_list_mismatch_depth_reversed(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.as_list = True
         return_data.with_lists = []
         return_data.enter_root(None)
@@ -427,7 +427,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_206_process_results_complexity_as_list_mismatch_depth_weird_order(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.as_list = True
         return_data.with_lists = []
         return_data.enter_root(None)
@@ -445,7 +445,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_207_process_results_complexity_collision_mismatch_depth(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.as_list = False
         return_data.with_lists = []
         return_data.enter_root(None)
@@ -460,7 +460,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_208_process_results_complexity_collision_mismatch_depth_reversed(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.as_list = False
         return_data.with_lists = []
         return_data.enter_root(None)
@@ -476,7 +476,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_209_process_results_complexity_collision_mismatch_depth_weird_order(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.as_list = False
         return_data.with_lists = []
         return_data.enter_root(None)
@@ -494,7 +494,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_20A_process_results_complexity_as_list_vary(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.as_list = True
         return_data.with_lists = []
         return_data.enter_root(None)
@@ -511,7 +511,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_207_process_results_complexity_roots_collision(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.as_list = False
         return_data.with_lists = []
         return_data.enter_root(None)
@@ -525,7 +525,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_301_process_results_with_lists(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.as_list = False
         return_data.with_lists = [1, 3]
         return_data.enter_root(None)
@@ -550,7 +550,7 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_302_process_results_with_lists_consecutive(self):
-        return_data = mysql.Merger()
+        return_data = mysql.MySQLExtPillar()
         return_data.as_list = False
         return_data.with_lists = [1, 2, 3]
         return_data.enter_root(None)

--- a/tests/unit/pillar/sqlite3_test.py
+++ b/tests/unit/pillar/sqlite3_test.py
@@ -1,0 +1,568 @@
+# -*- coding: utf-8 -*-
+
+# Import python libs
+from __future__ import absolute_import
+
+# Import Salt Testing libs
+from salttesting import TestCase, skipIf
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+# Import Salt Libs
+from salt.pillar import sqlite3
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class SQLite3PillarTestCase(TestCase):
+    maxDiff = None
+
+    def test_001_extract_queries_list(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        args, kwargs = [
+            'SELECT blah',
+            'SELECT blah2',
+            ('SELECT blah3',),
+            ('SELECT blah4', 2),
+            {'query': 'SELECT blah5'},
+            {'query': 'SELECT blah6', 'depth': 2},
+            {'query': 'SELECT blah7', 'as_list': True},
+            {'query': 'SELECT blah8', 'with_lists': '1'},
+            {'query': 'SELECT blah9', 'with_lists': '1,2'}
+        ], {}
+        qbuffer = return_data.extract_queries(args, kwargs)
+        self.assertEqual([
+            [None, {'query': 'SELECT blah', 'depth': 0, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah2', 'depth': 0, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah3', 'depth': 0, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah4', 'depth': 2, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah5', 'depth': 0, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah6', 'depth': 2, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah7', 'depth': 0, 'as_list': True,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah8', 'depth': 0, 'as_list': False,
+                    'with_lists': [1], 'ignore_null': False}],
+            [None, {'query': 'SELECT blah9', 'depth': 0, 'as_list': False,
+                    'with_lists': [1, 2], 'ignore_null': False}]
+        ], qbuffer)
+
+    def test_002_extract_queries_kwarg(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        args, kwargs = [], {
+            '1': 'SELECT blah',
+            '2': 'SELECT blah2',
+            '3': ('SELECT blah3',),
+            '4': ('SELECT blah4', 2),
+            '5': {'query': 'SELECT blah5'},
+            '6': {'query': 'SELECT blah6', 'depth': 2},
+            '7': {'query': 'SELECT blah7', 'as_list': True},
+        }
+        qbuffer = return_data.extract_queries(args, kwargs)
+        self.assertEqual([
+            ['1', {'query': 'SELECT blah', 'depth': 0, 'as_list': False,
+                   'with_lists': None, 'ignore_null': False}],
+            ['2', {'query': 'SELECT blah2', 'depth': 0, 'as_list': False,
+                   'with_lists': None, 'ignore_null': False}],
+            ['3', {'query': 'SELECT blah3', 'depth': 0, 'as_list': False,
+                   'with_lists': None, 'ignore_null': False}],
+            ['4', {'query': 'SELECT blah4', 'depth': 2, 'as_list': False,
+                   'with_lists': None, 'ignore_null': False}],
+            ['5', {'query': 'SELECT blah5', 'depth': 0, 'as_list': False,
+                   'with_lists': None, 'ignore_null': False}],
+            ['6', {'query': 'SELECT blah6', 'depth': 2, 'as_list': False,
+                   'with_lists': None, 'ignore_null': False}],
+            ['7', {'query': 'SELECT blah7', 'depth': 0, 'as_list': True,
+                   'with_lists': None, 'ignore_null': False}]
+        ], qbuffer)
+
+    def test_003_extract_queries_mixed(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        args, kwargs = [
+            'SELECT blah1',
+            ('SELECT blah2', 2),
+            {'query': 'SELECT blah3', 'as_list': True},
+        ], {
+            '1': 'SELECT blah1',
+            '2': ('SELECT blah2', 2),
+            '3': {'query': 'SELECT blah3', 'as_list': True},
+        }
+        qbuffer = return_data.extract_queries(args, kwargs)
+        self.assertEqual([
+            [None, {'query': 'SELECT blah1', 'depth': 0, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah2', 'depth': 2, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah3', 'depth': 0, 'as_list': True,
+                    'with_lists': None, 'ignore_null': False}],
+            ['1', {'query': 'SELECT blah1', 'depth': 0, 'as_list': False,
+                   'with_lists': None, 'ignore_null': False}],
+            ['2', {'query': 'SELECT blah2', 'depth': 2, 'as_list': False,
+                   'with_lists': None, 'ignore_null': False}],
+            ['3', {'query': 'SELECT blah3', 'depth': 0, 'as_list': True,
+                   'with_lists': None, 'ignore_null': False}]
+        ], qbuffer)
+
+    def test_004_extract_queries_bogus_list(self):
+        # This test is specifically checking that empty queries are dropped
+        return_data = sqlite3.SQLite3ExtPillar()
+        args, kwargs = [
+            'SELECT blah',
+            '',
+            'SELECT blah2',
+            ('SELECT blah3',),
+            ('',),
+            ('SELECT blah4', 2),
+            tuple(),
+            ('SELECT blah5',),
+            {'query': 'SELECT blah6'},
+            {'query': ''},
+            {'query': 'SELECT blah7', 'depth': 2},
+            {'not_a_query': 'in sight!'},
+            {'query': 'SELECT blah8', 'as_list': True},
+        ], {}
+        qbuffer = return_data.extract_queries(args, kwargs)
+        self.assertEqual([
+            [None, {'query': 'SELECT blah', 'depth': 0, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah2', 'depth': 0, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah3', 'depth': 0, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah4', 'depth': 2, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah5', 'depth': 0, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah6', 'depth': 0, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah7', 'depth': 2, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah8', 'depth': 0, 'as_list': True,
+                    'with_lists': None, 'ignore_null': False}]
+        ], qbuffer)
+
+    def test_005_extract_queries_bogus_kwargs(self):
+        # this test is cut down as most of the path matches test_*_bogus_list
+        return_data = sqlite3.SQLite3ExtPillar()
+        args, kwargs = [], {
+            '1': 'SELECT blah',
+            '2': '',
+            '3': 'SELECT blah2'
+        }
+        qbuffer = return_data.extract_queries(args, kwargs)
+        self.assertEqual([
+            ['1', {'query': 'SELECT blah', 'depth': 0, 'as_list': False,
+                   'with_lists': None, 'ignore_null': False}],
+            ['3', {'query': 'SELECT blah2', 'depth': 0, 'as_list': False,
+                   'with_lists': None, 'ignore_null': False}]
+        ], qbuffer)
+
+    def test_011_enter_root(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.enter_root("test")
+        self.assertEqual(return_data.result["test"], return_data.focus)
+        return_data.enter_root(None)
+        self.assertEqual(return_data.result, return_data.focus)
+
+    def test_021_process_fields(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.process_fields(['a', 'b'], 0)
+        self.assertEqual(return_data.num_fields, 2)
+        self.assertEqual(return_data.depth, 1)
+        return_data.process_fields(['a', 'b'], 2)
+        self.assertEqual(return_data.num_fields, 2)
+        self.assertEqual(return_data.depth, 1)
+        return_data.process_fields(['a', 'b', 'c', 'd'], 0)
+        self.assertEqual(return_data.num_fields, 4)
+        self.assertEqual(return_data.depth, 3)
+        return_data.process_fields(['a', 'b', 'c', 'd'], 1)
+        self.assertEqual(return_data.num_fields, 4)
+        self.assertEqual(return_data.depth, 1)
+        return_data.process_fields(['a', 'b', 'c', 'd'], 2)
+        self.assertEqual(return_data.num_fields, 4)
+        self.assertEqual(return_data.depth, 2)
+        return_data.process_fields(['a', 'b', 'c', 'd'], 3)
+        self.assertEqual(return_data.num_fields, 4)
+        self.assertEqual(return_data.depth, 3)
+        return_data.process_fields(['a', 'b', 'c', 'd'], 4)
+        self.assertEqual(return_data.num_fields, 4)
+        self.assertEqual(return_data.depth, 3)
+
+    def test_111_process_results_legacy(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.process_fields(['a', 'b'], 0)
+        return_data.with_lists = []
+        return_data.process_results([[1, 2]])
+        self.assertEqual(
+             {1: 2},
+             return_data.result
+        )
+
+    def test_112_process_results_legacy_multiple(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.process_fields(['a', 'b'], 0)
+        return_data.with_lists = []
+        return_data.process_results([[1, 2], [3, 4], [5, 6]])
+        self.assertEqual(
+             {1: 2, 3: 4, 5: 6},
+             return_data.result
+        )
+
+    def test_121_process_results_depth_0(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.process_fields(['a', 'b', 'c', 'd'], 0)
+        return_data.with_lists = []
+        return_data.enter_root(None)
+        return_data.process_results([[1, 2, 3, 4], [5, 6, 7, 8]])
+        self.assertEqual(
+             {1: {2: {3: 4}}, 5: {6: {7: 8}}},
+             return_data.result
+        )
+
+    def test_122_process_results_depth_1(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.process_fields(['a', 'b', 'c', 'd'], 1)
+        return_data.with_lists = []
+        return_data.enter_root(None)
+        return_data.process_results([[1, 2, 3, 4], [5, 6, 7, 8]])
+        self.assertEqual(
+             {1: {'b': 2, 'c': 3, 'd': 4}, 5: {'b': 6, 'c': 7, 'd': 8}},
+             return_data.result
+        )
+
+    def test_123_process_results_depth_2(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.process_fields(['a', 'b', 'c', 'd'], 2)
+        return_data.with_lists = []
+        return_data.enter_root(None)
+        return_data.process_results([[1, 2, 3, 4], [5, 6, 7, 8]])
+        self.assertEqual(
+             {1: {2: {'c': 3, 'd': 4}}, 5: {6: {'c': 7, 'd': 8}}},
+             return_data.result
+        )
+
+    def test_124_process_results_depth_3(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.process_fields(['a', 'b', 'c', 'd'], 3)
+        return_data.with_lists = []
+        return_data.enter_root(None)
+        return_data.process_results([[1, 2, 3, 4], [5, 6, 7, 8]])
+        self.assertEqual(
+             {1: {2: {3: 4}}, 5: {6: {7: 8}}},
+             return_data.result
+        )
+
+    def test_125_process_results_depth_4(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.process_fields(['a', 'b', 'c', 'd'], 4)
+        return_data.with_lists = []
+        return_data.enter_root(None)
+        return_data.process_results([[1, 2, 3, 4], [5, 6, 7, 8]])
+        self.assertEqual(
+             {1: {2: {3: 4}}, 5: {6: {7: 8}}},
+             return_data.result
+        )
+
+    def test_131_process_results_overwrite_legacy_multiple(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.process_fields(['a', 'b'], 0)
+        return_data.with_lists = []
+        return_data.process_results([[1, 2], [3, 4], [1, 6]])
+        self.assertEqual(
+             {1: 6, 3: 4},
+             return_data.result
+        )
+
+    def test_132_process_results_merge_depth_0(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.process_fields(['a', 'b', 'c', 'd'], 0)
+        return_data.with_lists = []
+        return_data.enter_root(None)
+        return_data.process_results([[1, 2, 3, 4], [1, 6, 7, 8]])
+        self.assertEqual(
+             {1: {2: {3: 4}, 6: {7: 8}}},
+             return_data.result
+        )
+
+    def test_133_process_results_overwrite_depth_0(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.process_fields(['a', 'b', 'c', 'd'], 0)
+        return_data.with_lists = []
+        return_data.enter_root(None)
+        return_data.process_results([[1, 2, 3, 4], [1, 2, 3, 8]])
+        self.assertEqual(
+             {1: {2: {3: 8}}},
+             return_data.result
+        )
+
+    def test_134_process_results_deepmerge_depth_0(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.process_fields(['a', 'b', 'c', 'd'], 0)
+        return_data.with_lists = []
+        return_data.enter_root(None)
+        return_data.process_results([[1, 2, 3, 4], [1, 2, 7, 8]])
+        self.assertEqual(
+             {1: {2: {3: 4, 7: 8}}},
+             return_data.result
+        )
+
+    def test_135_process_results_overwrite_depth_1(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.process_fields(['a', 'b', 'c', 'd'], 1)
+        return_data.with_lists = []
+        return_data.enter_root(None)
+        return_data.process_results([[1, 2, 3, 4], [1, 6, 7, 8]])
+        self.assertEqual(
+             {1: {'b': 6, 'c': 7, 'd': 8}},
+             return_data.result
+        )
+
+    def test_136_process_results_merge_depth_2(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.process_fields(['a', 'b', 'c', 'd'], 2)
+        return_data.with_lists = []
+        return_data.enter_root(None)
+        return_data.process_results([[1, 2, 3, 4], [1, 6, 7, 8]])
+        self.assertEqual(
+             {1: {2: {'c': 3, 'd': 4}, 6: {'c': 7, 'd': 8}}},
+             return_data.result
+        )
+
+    def test_137_process_results_overwrite_depth_2(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.process_fields(['a', 'b', 'c', 'd'], 2)
+        return_data.with_lists = []
+        return_data.enter_root(None)
+        return_data.process_results([[1, 2, 3, 4], [1, 2, 7, 8]])
+        self.assertEqual(
+             {1: {2: {'c': 7, 'd': 8}}},
+             return_data.result
+        )
+
+    def test_201_process_results_complexity_multiresults(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.process_fields(['a', 'b', 'c', 'd'], 2)
+        return_data.with_lists = []
+        return_data.enter_root(None)
+        return_data.process_results([[1, 2, 3, 4]])
+        return_data.process_results([[1, 2, 7, 8]])
+        self.assertEqual(
+             {1: {2: {'c': 7, 'd': 8}}},
+             return_data.result
+        )
+
+    def test_202_process_results_complexity_as_list(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.process_fields(['a', 'b', 'c', 'd'], 2)
+        return_data.with_lists = []
+        return_data.enter_root(None)
+        return_data.as_list = True
+        return_data.process_results([[1, 2, 3, 4]])
+        return_data.process_results([[1, 2, 7, 8]])
+        self.assertEqual(
+             {1: {2: {'c': [3, 7], 'd': [4, 8]}}},
+             return_data.result
+        )
+
+    def test_203_process_results_complexity_as_list_deeper(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.process_fields(['a', 'b', 'c', 'd'], 0)
+        return_data.with_lists = []
+        return_data.enter_root(None)
+        return_data.as_list = True
+        return_data.process_results([[1, 2, 3, 4]])
+        return_data.process_results([[1, 2, 3, 8]])
+        self.assertEqual(
+             {1: {2: {3: [4, 8]}}},
+             return_data.result
+        )
+
+    def test_204_process_results_complexity_as_list_mismatch_depth(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.as_list = True
+        return_data.with_lists = []
+        return_data.enter_root(None)
+        return_data.process_fields(['a', 'b', 'c', 'd'], 0)
+        return_data.process_results([[1, 2, 3, 4]])
+        return_data.process_results([[1, 2, 3, 5]])
+        return_data.process_fields(['a', 'b', 'c', 'd', 'e'], 0)
+        return_data.process_results([[1, 2, 3, 6, 7]])
+        self.assertEqual(
+             {1: {2: {3: [4, 5, {6: 7}]}}},
+             return_data.result
+        )
+
+    def test_205_process_results_complexity_as_list_mismatch_depth_reversed(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.as_list = True
+        return_data.with_lists = []
+        return_data.enter_root(None)
+        return_data.process_fields(['a', 'b', 'c', 'd', 'e'], 0)
+        return_data.process_results([[1, 2, 3, 6, 7]])
+        return_data.process_results([[1, 2, 3, 8, 9]])
+        return_data.process_fields(['a', 'b', 'c', 'd'], 0)
+        return_data.process_results([[1, 2, 3, 4]])
+        return_data.process_results([[1, 2, 3, 5]])
+        self.assertEqual(
+             {1: {2: {3: [{6: 7, 8: 9}, 4, 5]}}},
+             return_data.result
+        )
+
+    def test_206_process_results_complexity_as_list_mismatch_depth_weird_order(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.as_list = True
+        return_data.with_lists = []
+        return_data.enter_root(None)
+        return_data.process_fields(['a', 'b', 'c', 'd', 'e'], 0)
+        return_data.process_results([[1, 2, 3, 6, 7]])
+        return_data.process_fields(['a', 'b', 'c', 'd'], 0)
+        return_data.process_results([[1, 2, 3, 4]])
+        return_data.process_fields(['a', 'b', 'c', 'd', 'e'], 0)
+        return_data.process_results([[1, 2, 3, 8, 9]])
+        return_data.process_fields(['a', 'b', 'c', 'd'], 0)
+        return_data.process_results([[1, 2, 3, 5]])
+        self.assertEqual(
+             {1: {2: {3: [{6: 7, }, 4, {8: 9}, 5]}}},
+             return_data.result
+        )
+
+    def test_207_process_results_complexity_collision_mismatch_depth(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.as_list = False
+        return_data.with_lists = []
+        return_data.enter_root(None)
+        return_data.process_fields(['a', 'b', 'c', 'd'], 0)
+        return_data.process_results([[1, 2, 3, 4]])
+        return_data.process_results([[1, 2, 3, 5]])
+        return_data.process_fields(['a', 'b', 'c', 'd', 'e'], 0)
+        return_data.process_results([[1, 2, 3, 6, 7]])
+        self.assertEqual(
+             {1: {2: {3: {6: 7}}}},
+             return_data.result
+        )
+
+    def test_208_process_results_complexity_collision_mismatch_depth_reversed(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.as_list = False
+        return_data.with_lists = []
+        return_data.enter_root(None)
+        return_data.process_fields(['a', 'b', 'c', 'd', 'e'], 0)
+        return_data.process_results([[1, 2, 3, 6, 7]])
+        return_data.process_results([[1, 2, 3, 8, 9]])
+        return_data.process_fields(['a', 'b', 'c', 'd'], 0)
+        return_data.process_results([[1, 2, 3, 4]])
+        return_data.process_results([[1, 2, 3, 5]])
+        self.assertEqual(
+             {1: {2: {3: 5}}},
+             return_data.result
+        )
+
+    def test_209_process_results_complexity_collision_mismatch_depth_weird_order(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.as_list = False
+        return_data.with_lists = []
+        return_data.enter_root(None)
+        return_data.process_fields(['a', 'b', 'c', 'd', 'e'], 0)
+        return_data.process_results([[1, 2, 3, 6, 7]])
+        return_data.process_fields(['a', 'b', 'c', 'd'], 0)
+        return_data.process_results([[1, 2, 3, 4]])
+        return_data.process_fields(['a', 'b', 'c', 'd', 'e'], 0)
+        return_data.process_results([[1, 2, 3, 8, 9]])
+        return_data.process_fields(['a', 'b', 'c', 'd'], 0)
+        return_data.process_results([[1, 2, 3, 5]])
+        self.assertEqual(
+             {1: {2: {3: 5}}},
+             return_data.result
+        )
+
+    def test_20A_process_results_complexity_as_list_vary(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.as_list = True
+        return_data.with_lists = []
+        return_data.enter_root(None)
+        return_data.process_fields(['a', 'b', 'c', 'd', 'e'], 0)
+        return_data.process_results([[1, 2, 3, 6, 7]])
+        return_data.process_results([[1, 2, 3, 8, 9]])
+        return_data.process_fields(['a', 'b', 'c', 'd'], 0)
+        return_data.process_results([[1, 2, 3, 4]])
+        return_data.as_list = False
+        return_data.process_results([[1, 2, 3, 5]])
+        self.assertEqual(
+             {1: {2: {3: 5}}},
+             return_data.result
+        )
+
+    def test_207_process_results_complexity_roots_collision(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.as_list = False
+        return_data.with_lists = []
+        return_data.enter_root(None)
+        return_data.process_fields(['a', 'b', 'c', 'd'], 0)
+        return_data.process_results([[1, 2, 3, 4]])
+        return_data.enter_root(1)
+        return_data.process_results([[5, 6, 7, 8]])
+        self.assertEqual(
+             {1: {5: {6: {7: 8}}}},
+             return_data.result
+        )
+
+    def test_301_process_results_with_lists(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.as_list = False
+        return_data.with_lists = [1, 3]
+        return_data.enter_root(None)
+        return_data.process_fields(['a', 'b', 'c', 'd', 'e', 'v'], 0)
+        return_data.process_results([['a', 'b', 'c', 'd', 'e', 1],
+                                     ['a', 'b', 'c', 'f', 'g', 2],
+                                     ['a', 'z', 'h', 'y', 'j', 3],
+                                     ['a', 'z', 'h', 'y', 'k', 4]])
+        self.assertEqual(
+            {'a': [
+                  {'c': [
+                      {'e': 1},
+                      {'g': 2}
+                      ]
+                  },
+                  {'h': [
+                      {'j': 3, 'k': 4}
+                      ]
+                  }
+            ]},
+             return_data.result
+        )
+
+    def test_302_process_results_with_lists_consecutive(self):
+        return_data = sqlite3.SQLite3ExtPillar()
+        return_data.as_list = False
+        return_data.with_lists = [1, 2, 3]
+        return_data.enter_root(None)
+        return_data.process_fields(['a', 'b', 'c', 'd', 'e', 'v'], 0)
+        return_data.process_results([['a', 'b', 'c', 'd', 'e', 1],
+                                     ['a', 'b', 'c', 'f', 'g', 2],
+                                     ['a', 'z', 'h', 'y', 'j', 3],
+                                     ['a', 'z', 'h', 'y', 'k', 4]])
+        self.assertEqual(
+            {'a': [
+                  [[
+                      {'e': 1},
+                      {'g': 2}
+                      ]
+                  ],
+                  [[
+                      {'j': 3, 'k': 4}
+                      ]
+                  ]
+            ]},
+             return_data.result
+        )
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(SQLite3PillarTestCase, needs_daemon=False)


### PR DESCRIPTION
Extract the PEP 249 generic parts of the mysql pillar into a new, abstract, ext_pillar: sql_base.

Add a new sqlite3 ext_pillar that extends the sql_base ext_pillar.

Origin story: I wanted to use SQLite3 as a CMDB backer to try out ext_pillars. I only have a few nodes, MySQL is overkill for me.
