### PR TITLE
Various fixes for boto_route53 and boto_elb

### DIFF
--- a/salt/modules/boto_route53.py
+++ b/salt/modules/boto_route53.py
@@ -71,6 +71,14 @@ def _is_valid_resource(_type):
         return False
 
 
+def _encode_name(name):
+    return name.replace('*', r'\052')
+
+
+def _decode_name(name):
+    return name.replace(r'\052', '*')
+
+
 def get_record(name, zone, record_type, fetch_all=False, region=None, key=None,
                keyid=None, profile=None):
     '''
@@ -94,6 +102,7 @@ def get_record(name, zone, record_type, fetch_all=False, region=None, key=None,
     if not _is_valid_resource(_type):
         return None
 
+    name = _encode_name(name)
     if _type == 'A':
         _record = _zone.get_a(name, fetch_all)
     elif _type == 'CNAME':
@@ -102,7 +111,7 @@ def get_record(name, zone, record_type, fetch_all=False, region=None, key=None,
         _record = _zone.get_mx(name, fetch_all)
 
     if _record:
-        ret['name'] = _record.name
+        ret['name'] = _decode_name(_record.name)
         ret['value'] = _record.to_print()
         ret['record_type'] = _record.type
         ret['ttl'] = _record.ttl

--- a/salt/states/boto_elb.py
+++ b/salt/states/boto_elb.py
@@ -322,7 +322,7 @@ def present(
             name, region, key, keyid, profile
         )
         for cname in cnames:
-            _ret  = __salt__['state.single'](
+            _ret = __salt__['state.single'](
                 'boto_route53.present',
                 name=cname.get('name'),
                 value=lb['dns_name'],

--- a/tests/unit/states/boto_elb_test.py
+++ b/tests/unit/states/boto_elb_test.py
@@ -39,70 +39,100 @@ class BotoElbTestCase(TestCase):
         name = 'myelb'
         listeners = [{'elb_port': 'ELBPORT', 'instance_port': 'PORT',
                       'elb_protocol': 'HTTPS', 'certificate': 'A'}]
-        attributes = {'alarm_actions': ['arn:aws:sns:us-east-1:12345:myalarm'],
-                      'insufficient_data_actions': [],
-                      'ok_actions': ['arn:aws:sns:us-east-1:12345:myalarm']}
+        alarms = {'MyAlarm': {'name': name,
+                              'attributes': {'description': 'A'}}}
+        attrs = {'alarm_actions': ['arn:aws:sns:us-east-1:12345:myalarm'],
+                 'insufficient_data_actions': [],
+                 'ok_actions': ['arn:aws:sns:us-east-1:12345:myalarm']}
+        health_check = {'target:': 'HTTP:80/'}
         avail_zones = ['us-east-1a', 'us-east-1c', 'us-east-1d']
-        alarms = {'alarm_actions': {'name': name,
-                                    'attributes': {'description': 'A'}}}
+        cnames = [{'name': 'www.test.com', 'zone': 'test.com', 'ttl': 60}]
 
         ret = {'name': name,
-               'result': False,
+               'result': True,
                'changes': {},
                'comment': ''}
         ret1 = copy.deepcopy(ret)
 
         mock = MagicMock(return_value={})
-        mock_bool = MagicMock(return_value=False)
-        with patch.dict(boto_elb.__salt__,
-                        {'config.option': mock,
-                         'boto_elb.exists': mock_bool,
-                         'boto_elb.create': mock_bool,
-                         'boto_elb.get_attributes': mock}):
-            with patch.dict(boto_elb.__opts__, {'test': False}):
-                comt = (' Failed to create myelb ELB.')
-                ret.update({'comment': comt})
-                self.assertDictEqual(boto_elb.present
-                                     (name, listeners, attributes=attributes,
-                                      availability_zones=avail_zones), ret)
+        mock_false_bool = MagicMock(return_value=False)
+        mock_true_bool = MagicMock(return_value=True)
+        mock_attributes = MagicMock(return_value=attrs)
+        mock_health_check = MagicMock(return_value=health_check)
+        mock_ret = MagicMock(return_value={'myelb': ret1})
 
         mock = MagicMock(return_value={})
-        mock_ret = MagicMock(return_value={'result': {'result': False}})
-        comt1 = ('   Failed to retrieve health_check for ELB myelb.')
         with patch.dict(boto_elb.__salt__,
                         {'config.option': mock,
-                         'boto_elb.get_attributes': mock,
-                         'boto_elb.get_health_check': mock,
+                         'boto_elb.exists': mock_false_bool,
+                         'boto_elb.create': mock_false_bool}):
+            with patch.dict(boto_elb.__opts__, {'test': False}):
+                ret = boto_elb.present(
+                    name,
+                    listeners,
+                    availability_zones=avail_zones
+                )
+                self.assertTrue(boto_elb.__salt__['boto_elb.exists'].called)
+                self.assertTrue(boto_elb.__salt__['boto_elb.create'].called)
+                self.assertIn('Failed to create myelb ELB.', ret['comment'])
+                self.assertFalse(ret['result'])
+
+        mock = MagicMock(return_value={})
+        mock_ret = MagicMock(return_value={'myelb': ret1})
+        with patch.dict(boto_elb.__salt__,
+                        {'config.option': mock,
+                         'boto_elb.exists': mock_false_bool,
+                         'boto_elb.create': mock_true_bool,
+                         'boto_elb.get_attributes': mock_attributes,
+                         'boto_elb.get_health_check': mock_health_check,
                          'boto_elb.get_elb_config': mock,
                          'state.single': mock_ret}):
             with patch.dict(boto_elb.__opts__, {'test': False}):
-                ret1.update({'result': True})
-                mock_elb_present = MagicMock(return_value=ret1)
-                with patch.object(boto_elb, '_elb_present', mock_elb_present):
-                    comt = ('  Failed to retrieve attributes for ELB myelb.')
-                    ret.update({'comment': comt})
-                    self.assertDictEqual(boto_elb.present
-                                         (name, listeners), ret)
+                ret = boto_elb.present(
+                    name,
+                    listeners,
+                    availability_zones=avail_zones,
+                    health_check=health_check,
+                    alarms=alarms
+                )
+                self.assertTrue(boto_elb.__salt__['boto_elb.exists'].called)
+                self.assertTrue(boto_elb.__salt__['boto_elb.create'].called)
+                self.assertTrue(boto_elb.__salt__['state.single'].called)
+                self.assertTrue(
+                    boto_elb.__salt__['boto_elb.get_attributes'].called
+                )
+                self.assertTrue(
+                    boto_elb.__salt__['boto_elb.get_health_check'].called
+                )
+                self.assertIn('ELB myelb created.', ret['comment'])
+                self.assertTrue(ret['result'])
 
-                    with patch.object(boto_elb, '_attributes_present',
-                                      mock_elb_present):
-                        ret.update({'comment': comt1})
-                        self.assertDictEqual(boto_elb.present
-                                             (name, listeners), ret)
-
-                        with patch.object(boto_elb, '_health_check_present',
-                                          mock_elb_present):
-                            comt = ('    Failed to retrieve ELB myelb.')
-                            ret.update({'comment': comt})
-                            self.assertDictEqual(boto_elb.present
-                                                 (name, listeners), ret)
-
-                            with patch.object(boto_elb, '_alarms_present',
-                                              mock_elb_present):
-                                ret.update({'result': True})
-                                self.assertDictEqual(boto_elb.present
-                                                     (name, listeners,
-                                                      alarms=alarms), ret)
+        mock = MagicMock(return_value={})
+        mock_elb = MagicMock(return_value={'dns_name': 'myelb.amazon.com'})
+        mock_ret = MagicMock(return_value={'myelb': ret1})
+        with patch.dict(boto_elb.__salt__,
+                        {'config.option': mock,
+                         'boto_elb.exists': mock_false_bool,
+                         'boto_elb.create': mock_true_bool,
+                         'boto_elb.get_attributes': mock_attributes,
+                         'boto_elb.get_health_check': mock_health_check,
+                         'boto_elb.get_elb_config': mock_elb,
+                         'state.single': mock_ret}):
+            with patch.dict(boto_elb.__opts__, {'test': False}):
+                ret = boto_elb.present(
+                    name,
+                    listeners,
+                    availability_zones=avail_zones,
+                    health_check=health_check,
+                    cnames=cnames
+                )
+                self.assertTrue(boto_elb.__salt__['state.single'].called)
+                cname_call = boto_elb.__salt__['state.single'].mock_calls[0]
+                self.assertEqual(
+                    cname_call[1][0],
+                    'boto_route53.present'
+                )
+                self.assertTrue(ret['result'])
 
     # 'absent' function tests: 1
 

--- a/tests/unit/states/boto_elb_test.py
+++ b/tests/unit/states/boto_elb_test.py
@@ -97,20 +97,12 @@ class BotoElbTestCase(TestCase):
                             self.assertDictEqual(boto_elb.present
                                                  (name, listeners), ret)
 
-                            with patch.object(boto_elb, '_cnames_present',
+                            with patch.object(boto_elb, '_alarms_present',
                                               mock_elb_present):
-                                comt = ('     ')
-                                ret.update({'comment': comt})
+                                ret.update({'result': True})
                                 self.assertDictEqual(boto_elb.present
                                                      (name, listeners,
                                                       alarms=alarms), ret)
-
-                                with patch.object(boto_elb, '_alarms_present',
-                                                  mock_elb_present):
-                                    ret.update({'result': True})
-                                    self.assertDictEqual(boto_elb.present
-                                                         (name, listeners,
-                                                          alarms=alarms), ret)
 
     # 'absent' function tests: 1
 


### PR DESCRIPTION
- Fix for route53 entries with \* in their names
- Have boto_elb use boto_route53's state module directly
- Fix for boto_elb alarms
