### PR TITLE
Add SyntaxError to get_error exception

### DIFF
--- a/salt/utils/boto.py
+++ b/salt/utils/boto.py
@@ -233,7 +233,7 @@ def get_error(e):
         error = ET.fromstring(body).find('Errors').find('Error')
         error = {'code': error.find('Code').text,
                  'message': error.find('Message').text}
-    except (AttributeError, ET.ParseError):
+    except (AttributeError, SyntaxError, ET.ParseError):
         error = None
 
     if error:


### PR DESCRIPTION
Python2.6 throws a SyntaxError here instead of an AttributeError like Python 2.7 does
