### PR TITLE
Print the host name with the highstate summary.

### DIFF
--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -287,7 +287,7 @@ def _format_host(host, data):
         hstrs.append(
             colorfmt.format(
                 colors['CYAN'],
-                u'\nSummary\n{0}'.format('-' * line_max_len),
+                u'\nSummary for {0}\n{1}'.format(host, '-' * line_max_len),
                 colors
             )
         )


### PR DESCRIPTION
If there are failed states or unexpected results, this saves having to scroll all the way to the top of the highstate output to see which host encountered errors.
