### PR TITLE
RedHat IPv6 static routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,9 +24,8 @@ lib64
 pip/
 share/
 tests/integration/tmp/
-
-# tox - ignore any tox-created virtualenv dirs
-.tox
+tests/cachedir/
+tests/unit/templates/roots/
 
 # setuptools stuff
 *.egg-info
@@ -52,8 +51,8 @@ htmlcov/
 tags
 
 # ignore Vagrant file
-Vagrantfile
-.vagrant
+**/Vagrantfile
+**/.vagrant
 
 # Compiled translation files should not be VCS'ed
 # locale/zh_CN/LC_MESSAGES/topics/virt/nic.mo
@@ -65,6 +64,10 @@ _version.py
 
 # Ignore grains file written out during tests
 tests/integration/files/conf/grains
+/salt/_syspaths.py
+
+# ignore the local root
+/root/**
 
 # Ignore file cache created by jinja tests
 tests/unit/templates/roots

--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,9 @@ lib64
 pip/
 share/
 tests/integration/tmp/
-tests/cachedir/
-tests/unit/templates/roots/
+
+# tox - ignore any tox-created virtualenv dirs
+.tox
 
 # setuptools stuff
 *.egg-info
@@ -36,6 +37,7 @@ coverage.xml
 htmlcov/
 
 # IDE files
+/.settings
 /.project
 /.pydevproject
 /.idea
@@ -50,8 +52,8 @@ htmlcov/
 tags
 
 # ignore Vagrant file
-**/Vagrantfile
-**/.vagrant
+Vagrantfile
+.vagrant
 
 # Compiled translation files should not be VCS'ed
 # locale/zh_CN/LC_MESSAGES/topics/virt/nic.mo
@@ -63,10 +65,6 @@ _version.py
 
 # Ignore grains file written out during tests
 tests/integration/files/conf/grains
-/salt/_syspaths.py
-
-# ignore the local root
-/root/**
 
 # Ignore file cache created by jinja tests
 tests/unit/templates/roots

--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -955,12 +955,12 @@ def build_routes(iface, **settings):
 
         salt '*' ip.build_routes eth0 <settings>
     '''
-    
+
     template = 'rh6_route_eth.jinja'
     if __grains__['osrelease'][:1] < 6:
         template = 'route_eth.jinja'
     log.debug('Template name: ' + template)
-    
+
     iface = iface.lower()
     opts = _parse_routes(iface, settings)
     log.debug("Opts: \n {0}".format(opts))
@@ -974,7 +974,7 @@ def build_routes(iface, **settings):
     opts6 = []
     opts4 = []
     for route in opts['routes']:
-        ipaddr = route['ipaddr'] 
+        ipaddr = route['ipaddr']
         if salt.utils.validate.net.ipv6_addr(ipaddr):
             opts6.append(route)
         else:
@@ -984,7 +984,7 @@ def build_routes(iface, **settings):
 
     routecfg = template.render(routes=opts4)
     routecfg6 = template.render(routes=opts6)
-    
+
     if settings['test']:
         return _read_temp("\n".join([routecfg, routecfg6]))
 

--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -986,16 +986,19 @@ def build_routes(iface, **settings):
     routecfg6 = template.render(routes=opts6)
 
     if settings['test']:
-        return _read_temp("\n".join([routecfg, routecfg6]))
+        routes = _read_temp(routecfg)
+        routes.extend(_read_temp(routecfg6))
+        return routes
 
-    if opts4:
-        _write_file_iface(iface, routecfg, _RH_NETWORK_SCRIPT_DIR, 'route-{0}')
-        path = os.path.join(_RH_NETWORK_SCRIPT_DIR, 'route-{0}'.format(iface))
-    if opts6:
-        _write_file_iface(iface, routecfg6, _RH_NETWORK_SCRIPT_DIR, 'route6-{0}')
-        path6 = os.path.join(_RH_NETWORK_SCRIPT_DIR, 'route6-{0}'.format(iface))
+    _write_file_iface(iface, routecfg, _RH_NETWORK_SCRIPT_DIR, 'route-{0}')
+    _write_file_iface(iface, routecfg6, _RH_NETWORK_SCRIPT_DIR, 'route6-{0}')
 
-    return _read_file(path).extend(_read_file(path6))
+    path = os.path.join(_RH_NETWORK_SCRIPT_DIR, 'route-{0}'.format(iface))
+    path6 = os.path.join(_RH_NETWORK_SCRIPT_DIR, 'route6-{0}'.format(iface))
+
+    routes = _read_file(path)
+    routes.extend(_read_file(path6))
+    return routes
 
 
 def down(iface, iface_type):
@@ -1069,7 +1072,10 @@ def get_routes(iface):
         salt '*' ip.get_routes eth0
     '''
     path = os.path.join(_RH_NETWORK_SCRIPT_DIR, 'route-{0}'.format(iface))
-    return _read_file(path)
+    path6 = os.path.join(_RH_NETWORK_SCRIPT_DIR, 'route6-{0}'.format(iface))
+    routes = _read_file(path)
+    routes.extend(_read_file(path6))
+    return routes
 
 
 def get_network_settings():

--- a/salt/templates/rh_ip/rh6_route_eth.jinja
+++ b/salt/templates/rh_ip/rh6_route_eth.jinja
@@ -1,0 +1,6 @@
+{% for route in routes %}{% if route.name %}# {{route.name}}
+{{route.ipaddr}}
+{%- if route.netmask%}/{{route.netmask}}
+{%-endif%}{% if route.gateway %} via {{route.gateway}}
+{%endif%}
+{% endfor %}

--- a/tests/unit/modules/rh_ip_test.py
+++ b/tests/unit/modules/rh_ip_test.py
@@ -99,24 +99,25 @@ class RhipTestCase(TestCase):
         '''
         Test to build a route script for a network interface.
         '''
-        with patch.object(rh_ip, '_parse_routes', MagicMock()):
-            mock = jinja2.exceptions.TemplateNotFound('foo')
-            with patch.object(jinja2.Environment,
-                              'get_template', MagicMock(side_effect=mock)):
-                self.assertEqual(rh_ip.build_routes('iface'), '')
-
-            with patch.object(jinja2.Environment,
-                              'get_template', MagicMock()):
-                with patch.object(rh_ip, '_read_temp', return_value='A'):
-                    self.assertEqual(rh_ip.build_routes('i', test='t'), 'A')
-
-                with patch.object(rh_ip, '_read_file', return_value='A'):
-                    with patch.object(os.path, 'join', return_value='A'):
-                        with patch.object(rh_ip, '_write_file_iface',
-                                          return_value=None):
-                            self.assertEqual(rh_ip.build_routes('i',
-                                                                test=None),
-                                             'A')
+        with patch.dict(rh_ip.__grains__, {'osrelease': 'osrelease'}):
+            with patch.object(rh_ip, '_parse_routes', MagicMock()):
+                mock = jinja2.exceptions.TemplateNotFound('foo')
+                with patch.object(jinja2.Environment,
+                                  'get_template', MagicMock(side_effect=mock)):
+                    self.assertEqual(rh_ip.build_routes('iface'), '')
+        
+                with patch.object(jinja2.Environment,
+                                  'get_template', MagicMock()):
+                    with patch.object(rh_ip, '_read_temp', return_value='A'):
+                        self.assertEqual(rh_ip.build_routes('i', test='t'), 'A')
+        
+                    with patch.object(rh_ip, '_read_file', return_value='A'):
+                        with patch.object(os.path, 'join', return_value='A'):
+                            with patch.object(rh_ip, '_write_file_iface',
+                                              return_value=None):
+                                self.assertEqual(rh_ip.build_routes('i',
+                                                                    test=None),
+                                                 'A')
 
     def test_down(self):
         '''

--- a/tests/unit/modules/rh_ip_test.py
+++ b/tests/unit/modules/rh_ip_test.py
@@ -105,12 +105,12 @@ class RhipTestCase(TestCase):
                 with patch.object(jinja2.Environment,
                                   'get_template', MagicMock(side_effect=mock)):
                     self.assertEqual(rh_ip.build_routes('iface'), '')
-        
+
                 with patch.object(jinja2.Environment,
                                   'get_template', MagicMock()):
                     with patch.object(rh_ip, '_read_temp', return_value=['A']):
                         self.assertEqual(rh_ip.build_routes('i', test='t'), ['A', 'A'])
-        
+
                     with patch.object(rh_ip, '_read_file', return_value=['A']):
                         with patch.object(os.path, 'join', return_value='A'):
                             with patch.object(rh_ip, '_write_file_iface',

--- a/tests/unit/modules/rh_ip_test.py
+++ b/tests/unit/modules/rh_ip_test.py
@@ -108,16 +108,16 @@ class RhipTestCase(TestCase):
         
                 with patch.object(jinja2.Environment,
                                   'get_template', MagicMock()):
-                    with patch.object(rh_ip, '_read_temp', return_value='A'):
-                        self.assertEqual(rh_ip.build_routes('i', test='t'), 'A')
+                    with patch.object(rh_ip, '_read_temp', return_value=['A']):
+                        self.assertEqual(rh_ip.build_routes('i', test='t'), ['A', 'A'])
         
-                    with patch.object(rh_ip, '_read_file', return_value='A'):
+                    with patch.object(rh_ip, '_read_file', return_value=['A']):
                         with patch.object(os.path, 'join', return_value='A'):
                             with patch.object(rh_ip, '_write_file_iface',
                                               return_value=None):
                                 self.assertEqual(rh_ip.build_routes('i',
                                                                     test=None),
-                                                 'A')
+                                                 ['A', 'A'])
 
     def test_down(self):
         '''
@@ -160,8 +160,8 @@ class RhipTestCase(TestCase):
         Test to return the contents of the interface routes script.
         '''
         with patch.object(os.path, 'join', return_value='A'):
-            with patch.object(rh_ip, '_read_file', return_value='A'):
-                self.assertEqual(rh_ip.get_routes('iface'), 'A')
+            with patch.object(rh_ip, '_read_file', return_value=['A']):
+                self.assertEqual(rh_ip.get_routes('iface'), ['A', 'A'])
 
     def test_get_network_settings(self):
         '''


### PR DESCRIPTION
1. Added support for setting IPv6 static routes in RedHat systems.
2. New template for static routes file in Redhat systems 6+
