### PR TITLE
Adding hostname to highstate summary output

### DIFF
--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -287,7 +287,7 @@ def _format_host(host, data):
         hstrs.append(
             colorfmt.format(
                 colors['CYAN'],
-                u'\nSummary for '+host+u'\n{0}'.format('-' * line_max_len),
+                u'\nSummary for {0}\n{1}'.format(host, '-' * line_max_len),
                 colors
             )
         )

--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -54,7 +54,7 @@ Example output:
                   ret:
                       True
 
-    Summary
+    Summary for myminion
     ------------
     Succeeded: 1
     Failed:    0
@@ -287,7 +287,7 @@ def _format_host(host, data):
         hstrs.append(
             colorfmt.format(
                 colors['CYAN'],
-                u'\nSummary\n{0}'.format('-' * line_max_len),
+                u'\nSummary for '+host+u'\n{0}'.format('-' * line_max_len),
                 colors
             )
         )


### PR DESCRIPTION
Many times I find myself targeting a highstate on several minions. I generally will look at the summary of the output to see if I am getting the expected results. I've often thought it would be nice to know which host the summary is for, without having to scroll back through many dozens of states. Hopefully others will find this change useful as well.
