### PR TITLE
m_names variable added to module.run

### DIFF
--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -62,6 +62,24 @@ arguments. For example:
         - func: network.ip_addrs
         - kwargs:
             interface: eth0
+
+.. code-block:: yaml
+
+cloud.create:
+  module.run:
+  - func: cloud.create
+  - provider: test-provider
+  - m_names:
+    - test-vlad
+  - kwargs: {
+        ssh_username: 'ubuntu',
+        image: 'ami-8d6d9daa',
+        securitygroup: 'default',
+        size: 'c3.large',
+        location: 'ap-northeast-1',
+        delvol_on_destroy: 'True'
+    }
+
 '''
 from __future__ import absolute_import
 

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -160,6 +160,8 @@ def run(name, **kwargs):
             rarg = 'm_name'
         elif arg == 'fun':
             rarg = 'm_fun'
+        elif arg == 'names':
+            rarg = 'm_names'
         else:
             rarg = arg
         if rarg not in kwargs and arg not in defaults:


### PR DESCRIPTION
m_names variable added to module.run state
so now it is possible to run cloud.create module and others who use the names var instead of name, example is in header of module.py
