### PR TITLE
Unset PYTHONHOME when starting the service

### DIFF
--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -249,6 +249,7 @@ Section -Post
   WriteRegStr HKLM "SYSTEM\CurrentControlSet\services\salt-minion" "DependOnService" "nsi"
 
   ExecWait "nssm.exe install salt-minion $INSTDIR\bin\python.exe $INSTDIR\bin\Scripts\salt-minion -c $INSTDIR\conf -l quiet"
+  ExecWait "nssm.exe set salt-minion AppEnvironmentExtra PYTHONHOME="
   RMDir /R "$INSTDIR\var\cache\salt" ; removing cache from old version
 
   Call updateMinionConfig


### PR DESCRIPTION
Means that installing Python on the system shouldn't break Salt

Issue https://github.com/saltstack/salt/issues/24238
