### PR TITLE
Returners broken in 2015.5 

### DIFF
--- a/salt/returners/__init__.py
+++ b/salt/returners/__init__.py
@@ -208,9 +208,9 @@ def _fetch_profile_opts(
     log.info('Using profile %s', profile)
 
     if 'config.option' in __salt__:
-        creds = cfg.get(profile)
-    else:
         creds = cfg(profile)
+    else:
+        creds = cfg.get(profile)
 
     if not creds:
         return {}


### PR DESCRIPTION
The code calling cfg as a function vs treating it as a dictionary and using get is currently backwards causing returners to fail when used from the CLI and in scheduled jobs.
