### PR TITLE
Add deprecation warning to Digital Ocean v1 Driver

### DIFF
--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -22,7 +22,7 @@ cloud configuration at ``/etc/salt/cloud.providers`` or
 '''
 from __future__ import absolute_import
 
-# Import python libs
+# Import Python Libs
 import os
 import copy
 import time
@@ -36,7 +36,10 @@ try:
 except ImportError:
     HAS_REQUESTS = False
 
-# Import salt cloud libs
+# Import Salt Libs
+from salt.utils import warn_until
+
+# Import Salt Cloud Libs
 import salt.utils.cloud
 import salt.config as config
 from salt.exceptions import (
@@ -69,6 +72,13 @@ def get_configured_provider():
     '''
     Return the first configured instance.
     '''
+    warn_until(
+        'Beryllium',
+        'The digital_ocean driver is deprecated and will be removed in Salt Beryllium. '
+        'Please convert your digital ocean provider configs to use the digital_ocean_v2 '
+        'driver.'
+    )
+
     return config.is_provider_configured(
         __opts__,
         __active_provider_name__ or 'digital_ocean',

--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -6,6 +6,15 @@ DigitalOcean Cloud Module
 The DigitalOcean cloud module is used to control access to the DigitalOcean
 VPS system.
 
+.. note::
+
+    Due to Digital Ocean deprecating its original API, this salt-cloud driver for
+    Digital Ocean will be deprecated in Salt Beryllium. The digital_ocean_v2 driver
+    that is currently available on all 2015.5.x releases will be used instead.
+    Starting in Beryllium, the digital_ocean_v2.py driver will be renamed to
+    digital_ocean.py and this driver will be removed. Please convert any original
+    digital_ocean provider configs to use the new digital_ocean_v2 provider configs.
+
 Use of this module only requires the ``api_key`` parameter to be set. Set up the
 cloud configuration at ``/etc/salt/cloud.providers`` or
 ``/etc/salt/cloud.providers.d/digital_ocean.conf``:


### PR DESCRIPTION
Digital Ocean's APIv1 is deprecated and will no longer be available starting Nov. 1, 2015.

In Salt Beryllium, the digital_ocean_v2.py driver, which uses Digital Ocean's AIPv2, will become digital_ocean.py. This adds any necessary warnings. 

Refs #22731
