### PR TITLE
Have a nice error message if running as the wrong user.

### DIFF
--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -154,12 +154,12 @@ def verify_files(files, user):
     try:
         pwnam = pwd.getpwnam(user)
         uid = pwnam[2]
-
     except KeyError:
         err = ('Failed to prepare the Salt environment for user '
                '{0}. The user is not available.\n').format(user)
         sys.stderr.write(err)
         sys.exit(salt.defaults.exitcodes.EX_NOUSER)
+
     for fn_ in files:
         dirname = os.path.dirname(fn_)
         try:
@@ -171,6 +171,14 @@ def verify_files(files, user):
             if not os.path.isfile(fn_):
                 with salt.utils.fopen(fn_, 'w+') as fp_:
                     fp_.write('')
+
+        except IOError as err:
+            if err.errno != errno.EACCES:
+                raise
+            msg = 'No permissions to access "{0}", are you running as the correct user?\n'
+            sys.stderr.write(msg.format(fn_))
+            sys.exit(err.errno)
+
         except OSError as err:
             msg = 'Failed to create path "{0}" - {1}\n'
             sys.stderr.write(msg.format(fn_, err))


### PR DESCRIPTION
This is a nice-to-have to avoid exception tracebacks in the output if running Salt as the wrong user, which I tend to do by accident a lot.

The actual exception message is no longer shown because it is redundant.
