### PR TITLE
Add log_handlers syncing to saltutil module

### DIFF
--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -423,6 +423,8 @@ def sync_utils(saltenv=None, refresh=True):
 
 def sync_log_handlers(saltenv=None, refresh=True):
     '''
+    .. versionadded:: Beryllium
+
     Sync utility source files from the _log_handlers directory on the salt master file
     server. This function is environment aware, pass the desired environment
     to grab the contents of the _log_handlers directory, base is the default

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -421,6 +421,25 @@ def sync_utils(saltenv=None, refresh=True):
     return ret
 
 
+def sync_log_handlers(saltenv=None, refresh=True):
+    '''
+    Sync utility source files from the _log_handlers directory on the salt master file
+    server. This function is environment aware, pass the desired environment
+    to grab the contents of the _log_handlers directory, base is the default
+    environment.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' saltutil.sync_log_handlers
+    '''
+    ret = _sync('log_handlers', saltenv)
+    if refresh:
+        refresh_modules()
+    return ret
+
+
 def sync_all(saltenv=None, refresh=True):
     '''
     Sync down all of the dynamic modules from the file server for a specific
@@ -463,6 +482,7 @@ def sync_all(saltenv=None, refresh=True):
     ret['returners'] = sync_returners(saltenv, False)
     ret['outputters'] = sync_outputters(saltenv, False)
     ret['utils'] = sync_utils(saltenv, False)
+    ret['log_handlers'] = sync_log_handlers(saltenv, False)
     if refresh:
         refresh_modules()
     return ret
@@ -510,7 +530,7 @@ def refresh_modules(async=True):
     '''
     Signal the minion to refresh the module and grain data
 
-    The default is to refresh module asyncrhonously. To block
+    The default is to refresh module asynchronously. To block
     until the module refresh is complete, set the 'async' flag
     to False.
 


### PR DESCRIPTION
Right now, it doesn't look like there's any non-manual way to set up external logging handlers on minions.  This allows syncing log_handlers to minions the same way as any other extension module and includes any external logging handlers in `saltutil.sync_all`

Also, minor typo fix in docstring of `refresh_modules`
