### PR TITLE
Document availability of arguments to file states

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -31,14 +31,16 @@ the jinja templating system would look like this:
     {% endif %}
 
 It is also possible to use the :mod:`py renderer <salt.renderers.py>` as a
-templating option. The template would be a python script which would need to
-contain a function called ``run()``, which returns a string. The returned
-string will be the contents of the managed file. For example:
+templating option. The template would be a Python script which would need to
+contain a function called ``run()``, which returns a string. All arguments
+to the state will be made available to the Python script as globals. The
+returned string will be the contents of the managed file. For example:
 
 .. code-block:: python
 
     def run():
-        lines = ('foo', 'bar', 'baz')
+        lines = ['foo', 'bar', 'baz']
+        lines.extend([source, name, user, context])  # Arguments as globals
         return '\\n\\n'.join(lines)
 
 .. note::


### PR DESCRIPTION
Mention in the documentation that all arguments to a Python-rendered templated file will be made available as globals to the Python script.

I was previously unsure where or if the context for a rendered file (`file.managed` with `template: py` configured) would be available to the Python script renderer.  This PR explains this point.
