### PR TITLE
Standardize return values in EC2 pricing

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -4197,4 +4197,4 @@ def show_pricing(kwargs=None, call=None):
     ret['per_month'] = ret['per_day'] * 30
     ret['per_year'] = ret['per_week'] * 52
 
-    return ret
+    return {profile['profile']: ret}


### PR DESCRIPTION
This produces an output that matches the Softlayer pricing output:

```
my-ec2:
    ----------
    ec2:
        ----------
        centos65:
            ----------
            per_day:
                0.624
            per_hour:
                0.026
            per_month:
                18.720
            per_week:
                4.368
            per_year:
                227.136
```
