### PR TITLE
Fix #18966: file.serialize supports test=True

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -4063,10 +4063,28 @@ def serialize(name,
                 }
 
     if __opts__['test']:
-        ret['comment'] = (
-            'Dataset will be serialized and stored into {0}'
-        ).format(name)
-        ret['result'] = None
+        ret['changes'] = __salt__['file.check_managed_changes'](
+            name=name,
+            source=None,
+            source_hash={},
+            user=user,
+            group=group,
+            mode=mode,
+            template=None,
+            context=None,
+            defaults=None,
+            saltenv=__env__,
+            contents=contents,
+            **kwargs
+        )
+
+        if ret['changes']:
+            ret['result'] = None
+            ret['comment'] = 'Dataset will be serialized and stored into {0}'.format(name)
+        else:
+            ret['result'] = True
+            ret['comment'] = 'The file {0} is in the correct state'.format(name)
+
         return ret
 
     return __salt__['file.manage_file'](name=name,

--- a/tests/unit/states/file_test.py
+++ b/tests/unit/states/file_test.py
@@ -126,6 +126,7 @@ class TestFileState(TestCase):
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class FileTestCase(TestCase):
+
     '''
     Test cases for salt.states.file
     '''
@@ -1501,13 +1502,30 @@ class FileTestCase(TestCase):
         ret.update({'comment': comt, 'result': False})
         self.assertDictEqual(filestate.serialize(name, dataset=True,
                                                  formatter='A'), ret)
+        mock_changes = MagicMock(return_value=True)
+        mock_no_changes = MagicMock(return_value=False)
 
-        with patch.dict(filestate.__opts__, {'test': True}):
-            comt = ('Dataset will be serialized and stored into {0}'
-                    .format(name))
-            ret.update({'comment': comt, 'result': None})
-            self.assertDictEqual(filestate.serialize(name, dataset=True,
-                                                     formatter='python'), ret)
+        # __opts__['test']=True with changes
+        with patch.dict(filestate.__salt__,
+                        {'file.check_managed_changes': mock_changes}):
+            with patch.dict(filestate.__opts__, {'test': True}):
+                comt = ('Dataset will be serialized and stored into {0}'
+                        .format(name))
+                ret.update({'comment': comt, 'result': None, 'changes': True})
+                self.assertDictEqual(
+                    filestate.serialize(name, dataset=True,
+                                        formatter='python'), ret)
+
+        # __opts__['test']=True without changes
+        with patch.dict(filestate.__salt__,
+                        {'file.check_managed_changes': mock_no_changes}):
+            with patch.dict(filestate.__opts__, {'test': True}):
+                comt = ('The file {0} is in the correct state'
+                        .format(name))
+                ret.update({'comment': comt, 'result': True, 'changes': False})
+                self.assertDictEqual(
+                    filestate.serialize(name,
+                                        dataset=True, formatter='python'), ret)
 
         mock = MagicMock(return_value=ret)
         with patch.dict(filestate.__opts__, {'test': False}):


### PR DESCRIPTION
- Use file.check_managed_changes to diff the file when test=True

The code is copied and (slightly) modified from the file.managed function
