### PR TITLE
refactor gpg renderer; removing dependency on python-gnupg

### DIFF
--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -2,8 +2,8 @@
 '''
 Renderer that will decrypt GPG ciphers
 
-Any key in the SLS file can be a GPG cipher, and this renderer will decrypt
-it before passing it off to Salt. This allows you to safely store secrets in
+Any key in the SLS file can be a GPG cipher, and this renderer will decrypt it
+before passing it off to Salt. This allows you to safely store secrets in
 source control, in such a way that only your Salt master can decrypt them and
 distribute them only to the minions that need them.
 
@@ -11,14 +11,17 @@ The typical use-case would be to use ciphers in your pillar data, and keep a
 secret key on your master. You can put the public key in source control so that
 developers can add new secrets quickly and easily.
 
-This renderer requires the python-gnupg package. Be careful to install the
-``python-gnupg`` package, not the ``gnupg`` package, or you will get errors.
+This renderer requires the gpg binary.
+
+**No python libraries are required as of the Beryllium release.**
 
 To set things up, you will first need to generate a keypair. On your master,
 run:
 
-.. code-block:: bash
+.. code-block:: shell
 
+    # mkdir -p /etc/salt/gpgkeys
+    # chmod 0700 /etc/salt/gpgkeys
     # gpg --gen-key --homedir /etc/salt/gpgkeys
 
 Do not supply a password for your keypair, and use a name that makes sense
@@ -26,45 +29,35 @@ for your application. Be sure to back up your gpg directory someplace safe!
 
 To retrieve the public key:
 
-.. code-block:: bash
+.. code-block:: shell
 
-    # gpg --armor --homedir /etc/salt/gpgkeys --armor --export <KEY-NAME> \
-          > exported_pubkey.gpg
+    # gpg --homedir /etc/salt/gpgkeys --armor --export <KEY-NAME> \
+        > exported_pubkey.gpg
 
 Now, to encrypt secrets, copy the public key to your local machine and run:
 
-.. code-block:: bash
+.. code-block:: shell
 
     $ gpg --import exported_pubkey.gpg
 
 To generate a cipher from a secret:
 
-.. code-block:: bash
+.. code-block:: shell
 
-   $ echo -n "supersecret" | gpg --homedir ~/.gnupg --armor --encrypt -r <KEY-name>
+   $ echo -n "supersecret" | gpg --armor --encrypt -r <KEY-name>
 
-There are two ways to configure salt for the usage of this renderer:
-
-1. Set up the renderer on your master by adding something like this line to your
-    config:
-
-        .. code-block:: yaml
-
-            renderer: jinja | yaml | gpg
-
-    This will apply the renderers to all pillars and states while requiring
-    ``python-gnupg`` to be installed on all minions since the decryption
-    will happen on the minions.
-
-2. To apply the renderer on a file-by-file basis add the following line to the top of any pillar with gpg data in it:
+To apply the renderer on a file-by-file basis add the following line to the
+top of any pillar with gpg data in it:
 
     .. code-block:: yaml
 
         #!yaml|gpg
 
-Now with your renderers configured, you can include your ciphers in your pillar data like so:
+Now with your renderer configured, you can include your ciphers in your pillar data like so:
 
 .. code-block:: yaml
+
+    #!yaml|gpg
 
     a-secret: |
       -----BEGIN PGP MESSAGE-----
@@ -87,6 +80,7 @@ from __future__ import absolute_import
 import os
 import re
 import logging
+from subprocess import Popen, PIPE
 
 # Import salt libs
 import salt.utils
@@ -96,43 +90,36 @@ from salt.exceptions import SaltRenderError
 # Import 3rd-party libs
 import salt.ext.six as six
 # pylint: disable=import-error
-try:
-    import gnupg
+
+if salt.utils.which('gpg'):
     HAS_GPG = True
-    if salt.utils.which('gpg') is None:
-        HAS_GPG = False
-except ImportError:
+else:
     HAS_GPG = False
-# pylint: enable=import-error
+    raise SaltRenderError('GPG unavailable')
 
-log = logging.getLogger(__name__)
+LOG = logging.getLogger(__name__)
 
+GPG_BINARY = salt.utils.which('gpg')
 GPG_HEADER = re.compile(r'-----BEGIN PGP MESSAGE-----')
 DEFAULT_GPG_KEYDIR = os.path.join(salt.syspaths.CONFIG_DIR, 'gpgkeys')
 
 
-def decrypt_ciphertext(cypher, gpg, safe=False):
+def _decrypt_ciphertext(cipher):
     '''
     Given a block of ciphertext as a string, and a gpg object, try to decrypt
     the cipher and return the decrypted string. If the cipher cannot be
     decrypted, log the error, and return the ciphertext back out.
-
-    :param safe: Raise an exception on failure instead of returning the ciphertext
     '''
-    decrypted_data = gpg.decrypt(cypher)
-    if not decrypted_data.ok:
-        decrypt_err = "Could not decrypt cipher {0}, received {1}".format(
-                cypher, decrypted_data.stderr)
-        log.error(decrypt_err)
-        if safe:
-            raise SaltRenderError(decrypt_err)
-        else:
-            return cypher
+    cmd = [GPG_BINARY, '--homedir', DEFAULT_GPG_KEYDIR, '-d']
+    proc = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, shell=False)
+    decrypted_data = proc.communicate(input=cipher)[0]
+    if not decrypted_data:
+        LOG.error('Could not decrypt cipher %s, received: %s', cipher, decrypted_data)
     else:
         return str(decrypted_data)
 
 
-def decrypt_object(obj, gpg):
+def _decrypt_object(obj):
     '''
     Recursively try to decrypt any object. If the object is a string, and
     it contains a valid GPG header, decrypt it, otherwise keep going until
@@ -140,16 +127,16 @@ def decrypt_object(obj, gpg):
     '''
     if isinstance(obj, str):
         if GPG_HEADER.search(obj):
-            return decrypt_ciphertext(obj, gpg)
+            return _decrypt_ciphertext(obj)
         else:
             return obj
     elif isinstance(obj, dict):
         for key, val in six.iteritems(obj):
-            obj[key] = decrypt_object(val, gpg)
+            obj[key] = _decrypt_object(val)
         return obj
     elif isinstance(obj, list):
-        for n, v in enumerate(obj):
-            obj[n] = decrypt_object(v, gpg)
+        for key, value in enumerate(obj):
+            obj[key] = _decrypt_object(value)
         return obj
     else:
         return obj
@@ -162,15 +149,6 @@ def render(gpg_data, saltenv='base', sls='', argline='', **kwargs):
     '''
     if not HAS_GPG:
         raise SaltRenderError('GPG unavailable')
-    if 'config.get' in __salt__:
-        homedir = __salt__['config.get']('gpg_keydir', DEFAULT_GPG_KEYDIR)
-    else:
-        homedir = __opts__.get('gpg_keydir', DEFAULT_GPG_KEYDIR)
-    log.debug('Reading GPG keys from: {0}'.format(homedir))
-    try:
-        gpg = gnupg.GPG(gnupghome=homedir)
-    except TypeError:
-        gpg = gnupg.GPG()
-    except OSError:
-        raise SaltRenderError('Cannot initialize gnupg')
-    return decrypt_object(gpg_data, gpg)
+    LOG.debug('Reading GPG keys from: %s', DEFAULT_GPG_KEYDIR)
+
+    return _decrypt_object(gpg_data)

--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -101,7 +101,11 @@ LOG = logging.getLogger(__name__)
 
 GPG_BINARY = salt.utils.which('gpg')
 GPG_HEADER = re.compile(r'-----BEGIN PGP MESSAGE-----')
-DEFAULT_GPG_KEYDIR = os.path.join(salt.syspaths.CONFIG_DIR, 'gpgkeys')
+
+if __salt__['config.get']('gpg_keydir'):
+    DEFAULT_GPG_KEYDIR = __salt__['config.get']('gpg_keydir')
+else:
+    DEFAULT_GPG_KEYDIR = os.path.join(salt.syspaths.CONFIG_DIR, 'gpgkeys')
 
 
 def _decrypt_ciphertext(cipher):


### PR DESCRIPTION
This patch updates the gpg renderer to avoid the dependency on python-gnupg. I feel this patch is useful for two reasons:
1. fewer package dependencies are always better.
2. python-gnupg essentially calls out to the GPG binary anyway, so this just cuts out the middle man.
