### PR TITLE
Making sure there is a new line after the Deprecation Warnings under salt-cloud

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -2044,7 +2044,7 @@ def warn_until(version,
             Replacement for warnings.formatwarning that disables the echoing of
             the 'line' parameter.
             '''
-            return '{0}:{1}: {2}: {3}'.format(
+            return '{0}:{1}: {2}: {3}\n'.format(
                 filename, lineno, category.__name__, message
             )
         saved = warnings.formatwarning


### PR DESCRIPTION
Otherwise the next line get's printed on the same line:

```
root@nitin-salt-develop:~/salt$ salt-cloud -d salt-oel-1
[INFO    ] salt-cloud starting
/usr/lib/python2.6/site-packages/salt/cloud/clouds/digital_ocean.py:85: DeprecationWarning: The digital_ocean driver is deprecated and will be removed in Salt Beryllium. Please convert your digital ocean provider configs to use the digital_ocean_v2 driver.No machines were found to be destroyed
```
