### PR TITLE
Add party controls to zk_concurrency

### DIFF
--- a/doc/ref/cli/salt-cp.rst
+++ b/doc/ref/cli/salt-cp.rst
@@ -21,6 +21,11 @@ Description
 Salt copy copies a local file out to all of the Salt minions matched by the
 given target.
 
+Note: salt-cp uses salt's publishing mechanism. This means the privacy of the
+contents of the file on the wire are completely dependant upon the transport
+in use. In addition, if the salt-master is running with debug logging it is
+possible that the contents of the file will be logged to disk.
+
 Options
 =======
 

--- a/salt/modules/zk_concurrency.py
+++ b/salt/modules/zk_concurrency.py
@@ -18,6 +18,7 @@ try:
         ForceRetryError
     )
     import kazoo.recipe.lock
+    import kazoo.recipe.party
     from kazoo.exceptions import CancelledError
     from kazoo.exceptions import NoNodeError
 
@@ -271,3 +272,26 @@ def unlock(path,
     else:
         logging.error('Unable to find lease for path {0}'.format(path))
         return False
+
+
+def party_members(path,
+                  zk_hosts,
+                  ):
+    '''
+    Get the List of identifiers in a particular party
+
+    path
+        The path in zookeeper where the lock is
+
+    zk_hosts
+        zookeeper connect string
+
+    Example:
+
+    ... code-block: bash
+
+        salt minion zk_concurrency.party_members /lock/path host1:1234,host2:1234
+    '''
+    zk = _get_zk_conn(zk_hosts)
+    party = kazoo.recipe.party.ShallowParty(zk, path)
+    return list(party)

--- a/salt/state.py
+++ b/salt/state.py
@@ -66,6 +66,7 @@ STATE_REQUISITE_IN_KEYWORDS = frozenset([
     'listen_in',
     ])
 STATE_RUNTIME_KEYWORDS = frozenset([
+    'name',  # name of the highstate running
     'fun',
     'state',
     'check_cmd',


### PR DESCRIPTION
In addition to simple locking, sometimes you want to check that there are sufficient hosts working (in the party) before doing your state change.
