### PR TITLE
Only pop the key if the key exists otherwise do nothing

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -2203,7 +2203,7 @@ def create_multiprocessing(parallel_data, queue=None):
         )
         return {parallel_data['name']: {'Error': str(exc)}}
 
-    if parallel_data['opts'].get('show_deploy_args', False) is False and 'deploy_kwargs' in output:
+    if parallel_data['opts'].get('show_deploy_args', False) is False:
         output.pop('deploy_kwargs', None)
 
     return {

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -2114,7 +2114,7 @@ class Map(Cloud):
                 output[name] = self.create(
                     profile, local_master=local_master
                 )
-                if self.opts.get('show_deploy_args', False) is False:
+                if self.opts.get('show_deploy_args', False) is False and 'deploy_kwargs' in output:
                     output[name].pop('deploy_kwargs', None)
             except SaltCloudException as exc:
                 log.error(
@@ -2203,7 +2203,7 @@ def create_multiprocessing(parallel_data, queue=None):
         )
         return {parallel_data['name']: {'Error': str(exc)}}
 
-    if parallel_data['opts'].get('show_deploy_args', False) is False:
+    if parallel_data['opts'].get('show_deploy_args', False) is False and 'deploy_kwargs' in output:
         output.pop('deploy_kwargs', None)
 
     return {


### PR DESCRIPTION
If we pop the key when it doesn't exist, it gives the following error:

```
[ERROR   ] Caught Exception, terminating workers
TRACE: 'bool' object has no attribute 'pop'
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/salt/cloud/__init__.py", line 60, in _call
    ret = func(*args, **kwargs)
  File "/usr/lib/python2.6/site-packages/salt/cloud/__init__.py", line 2207, in create_multiprocessing
    output.pop('deploy_kwargs', None)
AttributeError: 'bool' object has no attribute 'pop'



Error: There was a query error: Exception caught
Caught Exception, terminating workers
TRACE: 'bool' object has no attribute 'pop'
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/salt/cloud/__init__.py", line 60, in _call
    ret = func(*args, **kwargs)
  File "/usr/lib/python2.6/site-packages/salt/cloud/__init__.py", line 2207, in create_multiprocessing
    output.pop('deploy_kwargs', None)
AttributeError: 'bool' object has no attribute 'pop'
```
