### PR TITLE
Added line to give more descriptive error

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -595,6 +595,8 @@ class Client(object):
                 stream=True,
                 **get_kwargs
             )
+            if 'handle' not in query:
+                raise MinionError('Error: {0}'.format(query['error']))
             response = query['handle']
             chunk_size = 32 * 1024
             if not no_cache:


### PR DESCRIPTION
Problem when trying to download https from docs.saltstack.com since the new move to wpengine. The cp.get_url would just stacktrace. Now it includes a reason why.
Fixes: #24154
