### PR TITLE
more complete unit tests for state grains

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -231,8 +231,8 @@ def setvals(grains, destructive=False):
         if val is None and destructive is True:
             if key in grains:
                 del grains[key]
-                if key in __grains__:
-                    del __grains__[key]
+            if key in __grains__:
+                del __grains__[key]
         else:
             grains[key] = val
             __grains__[key] = val

--- a/tests/unit/states/grains_test.py
+++ b/tests/unit/states/grains_test.py
@@ -16,7 +16,7 @@ from salt.states import grains as grains
 
 grainsmod.__opts__ = grains.__opts__ = {
     'test': False,
-    'conf_file': '/tmp/__salt_test_state_grains',
+    'conf_file': '/tmp/__salt_test_state_grains_config/minion',
     'cachedir':  '/tmp/__salt_test_state_grains_cache_dir',
 }
 

--- a/tests/unit/states/grains_test.py
+++ b/tests/unit/states/grains_test.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 # Import Salt Testing libs
 from salttesting import TestCase, skipIf
 from salttesting.helpers import ensure_in_syspath
-from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock
 
 ensure_in_syspath('../../')
 
@@ -30,10 +30,10 @@ grainsmod.__salt__ = grains.__salt__ = {
     'grains.delval': grainsmod.delval,
     'grains.append': grainsmod.append,
     'grains.remove': grainsmod.remove,
+    'saltutil.sync_grains': MagicMock()
 }
 
 
-@patch.dict(grainsmod.__salt__, {'saltutil.sync_grains': MagicMock()})
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class GrainsTestCase(TestCase):
 


### PR DESCRIPTION
This is a proposal for different, more complete unit tests for the state grains. I wrote it some days ago, hadn't notice that the current one existed. When I noticed, I wanted to add some tests I think are necessary, but the implementation is so different that I abandoned.

Please don't take this pull request in a bad way. It is not my intention to hurt anybody.

My implementation may be of less quality, as I'm more a sysadmin than a developer, but I think it has some needed additional tests, and I have a concern about the current implementation. I may be wrong, but I think it would be better to test the state result using the actual module functions, not mocked ones. Am I wrong? I always fear that a change introduced in the module functions could break the state behavior without being noticed.
I tried to follow the [Writing Unit Tests](http://docs.saltstack.com/en/latest/topics/development/tests/unit.html) page, using one function for each `return`.

There is one thing that bother me, in this tests. It's that I was forced to specify system accessible (but unix specific) paths for `__opts__['conf_file']` and `__opts__['cachedir']`. Is there a way to mock a file or directory, or a better way?

Please correct me if anything is wrong in my thinking.
