### PR TITLE
Salt ssh identities only

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -225,6 +225,10 @@ class SSH(object):
                 'ssh_sudo',
                 salt.config.DEFAULT_MASTER_OPTS['ssh_sudo']
             ),
+            'identities_only': self.opts.get(
+                'ssh_identities_only',
+                salt.config.DEFAULT_MASTER_OPTS['ssh_identities_only']
+            ),
         }
         if self.opts.get('rand_thin_dir'):
             self.defaults['thin_dir'] = os.path.join(
@@ -582,6 +586,7 @@ class Single(object):
             thin=None,
             mine=False,
             minion_opts=None,
+            identities_only=False,
             **kwargs):
         # Get mine setting and mine_functions if defined in kwargs (from roster)
         self.mine = mine
@@ -627,7 +632,8 @@ class Single(object):
                 'timeout': timeout,
                 'sudo': sudo,
                 'tty': tty,
-                'mods': self.mods}
+                'mods': self.mods,
+                'identities_only': identities_only}
         self.minion_opts = opts.get('ssh_minion_opts', {})
         if minion_opts is not None:
             self.minion_opts.update(minion_opts)

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -57,7 +57,8 @@ class Shell(object):
             timeout=None,
             sudo=False,
             tty=False,
-            mods=None):
+            mods=None,
+            identities_only=False):
         self.opts = opts
         self.host = host
         self.user = user
@@ -68,6 +69,7 @@ class Shell(object):
         self.sudo = sudo
         self.tty = tty
         self.mods = mods
+        self.identities_only = identities_only
 
     def get_error(self, errstr):
         '''
@@ -108,6 +110,8 @@ class Shell(object):
             options.append('IdentityFile={0}'.format(self.priv))
         if self.user:
             options.append('User={0}'.format(self.user))
+        if self.identities_only:
+            options.append('IdentitiesOnly=yes')
 
         ret = []
         for option in options:
@@ -143,6 +147,8 @@ class Shell(object):
             options.append('Port={0}'.format(self.port))
         if self.user:
             options.append('User={0}'.format(self.user))
+        if self.identities_only:
+            options.append('IdentitiesOnly=yes')
 
         ret = []
         for option in options:

--- a/salt/config.py
+++ b/salt/config.py
@@ -616,6 +616,7 @@ VALID_OPTS = {
     'ssh_user': str,
     'ssh_scan_ports': str,
     'ssh_scan_timeout': float,
+    'ssh_identities_only': bool,
 
     # Enable ioflo verbose logging. Warning! Very verbose!
     'ioflo_verbose': int,

--- a/salt/config.py
+++ b/salt/config.py
@@ -999,6 +999,7 @@ DEFAULT_MASTER_OPTS = {
     'ssh_user': 'root',
     'ssh_scan_ports': '22',
     'ssh_scan_timeout': 0.01,
+    'ssh_identities_only': False,
     'master_floscript': os.path.join(FLO_DIR, 'master.flo'),
     'worker_floscript': os.path.join(FLO_DIR, 'worker.flo'),
     'maintenance_floscript': os.path.join(FLO_DIR, 'maint.flo'),

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2493,6 +2493,14 @@ class SaltSSHOptionParser(six.with_metaclass(OptionParserMeta,
                  'with all minions. This combined with --passwd can make '
                  'initial deployment of keys very fast and easy'
         )
+        auth_group.add_option(
+            '--identities-only',
+            dest='ssh_identities_only',
+            default=False,
+            action='store_true',
+            help='Use the only authentication identity files configured in the '
+                 'ssh_config files. See IdentitiesOnly flag in man ssh_config'
+        )
         self.add_option_group(auth_group)
 
         scan_group = optparse.OptionGroup(


### PR DESCRIPTION
Add an ability to run ssh with -o IdentitiesOnly=yes. This option is intended for situations where ssh-agent offers many different identities and allow ssh to ignore those identities and use the only one specified in options.

Related to #24096 
