### PR TITLE
Use yes $'\n' instead of printf '\n' for pecl commands

### DIFF
--- a/salt/modules/pecl.py
+++ b/salt/modules/pecl.py
@@ -33,7 +33,7 @@ def _pecl(command, defaults=False):
     '''
     cmdline = 'pecl {0}'.format(command)
     if salt.utils.is_true(defaults):
-        cmdline = "printf '\n' | " + cmdline
+        cmdline = 'yes ' + r"$'\n'" + ' | ' + cmdline
 
     ret = __salt__['cmd.run_all'](cmdline, python_shell=True)
 


### PR DESCRIPTION
This allows extensions with multiple questions to be installed without
hanging. See https://github.com/saltstack/salt/pull/5882#issuecomment-108442378

Note: this only affects pecl functions called with `defaults=True`.
