### PR TITLE
Improve error message when module does not exist

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -776,14 +776,15 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         '''
         mod_name = function_name.split('.')[0]
         if mod_name in self.loaded_modules:
-            return '{0!r} is not available.'.format(function_name)
+            return '\'{0}\' is not available.'.format(function_name)
         else:
             if self.missing_modules.get(mod_name) is not None:
-                return '\'{0}\' __virtual__ returned False: {1}'.format(mod_name, self.missing_modules[mod_name])
-            elif self.missing_modules.get(mod_name) is None:
-                return '\'{0}\' __virtual__ returned False'.format(mod_name)
+                # Error in the __virtual__ function of an existing module
+                return '\'{0}\' __virtual__ returned False: {1}'.format(
+                    mod_name, self.missing_modules[mod_name]
+                )
             else:
-                return '\'{0}\' is not available.'.format(function_name)
+                return 'Module \'{0}\' is not available.'.format(mod_name)
 
     def refresh_file_mapping(self):
         '''


### PR DESCRIPTION
This also simplifies the if/elif/else logic when the module does not exist.
The else would never be reached anyway since we are doing an
`if X is not None` followed by an `if X is None`.

This gives different and meaninful errors when a non-existant module is used,
as well as when a nonexistant function in an existing module is used.

```
[root@cent6 ~]# salt cent6 salt_util.sync_modules
cent6:
    Module 'salt_util' is not available.
[root@cent6 ~]# salt cent6 saltutil.sync_modulessss
cent6:
    'saltutil.sync_modulessss' is not available.
```

Fixes #22958
