### PR TITLE
Fixes an issue where Pagerduty states/modules couldn't find their profile in the Pillar

### DIFF
--- a/salt/utils/pagerduty.py
+++ b/salt/utils/pagerduty.py
@@ -39,7 +39,7 @@ def query(method='GET', profile=None, url=None, path='api/v1',
         opts = {}
 
     if profile is not None:
-        creds = opts.get(profile, {})
+        creds = opts.get(profile, {}) or opts.get('pillar').get(profile,{})
     else:
         creds = {}
 

--- a/salt/utils/pagerduty.py
+++ b/salt/utils/pagerduty.py
@@ -39,7 +39,7 @@ def query(method='GET', profile=None, url=None, path='api/v1',
         opts = {}
 
     if profile is not None:
-        creds = opts.get(profile, {}) or opts.get('pillar').get(profile,{})
+        creds = opts.get(profile, {}) or opts.get('pillar').get(profile, {})
     else:
         creds = {}
 


### PR DESCRIPTION
### Fixsplanation:

In the Pagerduty Saltstack integration guide under "In Saltstack"-->"Pillar configuration", the [how-to](https://www.pagerduty.com/docs/guides/saltstack-integration-guide/)  states that you can configure pagerduty's profile:
- in the minion config
- in the pillar (**currently broken**)
- in the master config (for reactors/runners)

The patch just makes it so that you can _also_ put the Pagerduty profile in the pillar data.
#### The current behavior:

The pagerduty state currently only works if the pagerduty profile is set:
- in the minion config (for states/modules)
  OR
- in the master config (for runner/reactors)
  This just makes it so it will also look in the pillar for the
  specified profile name.
#### Other stuff

It's not a big change, so I doubt it will break anything, but it will at least make Pagerduty events work properly from the pagerduty state.

I haven't tried it with any of the other pagerduty features, but my guess is that if they worked with the minion config file info, then they should also work with this patch.

Well, it doesn't work on the minions if you just put it in the pillar, either in v2014.7 or later.
I've tested this problem in git tag versions:
- v2014.7.1
- v2015.5.0
- v2015.5.1
#### Testing

I can only say for sure that I've tested the change in v2015.5.0 and v2015.5.1. Before that I just assumed that I wasn't putting things in the right places, and then I wasn't sure if it was a minor or a major problem.
