### PR TITLE
[2015.5] Handle CommandExecutionError in grains commands, Fixes #23342

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -497,9 +497,16 @@ def _virtual(osdata):
 
         cmd = '{0} {1}'.format(command, ' '.join(args))
 
-        ret = __salt__['cmd.run_all'](cmd)
+        try:
+            ret = __salt__['cmd.run_all'](cmd)
 
-        if ret['retcode'] > 0:
+            if ret['retcode'] > 0:
+                if salt.log.is_logging_configured():
+                    if salt.utils.is_windows():
+                        continue
+                    failed_commands.add(command)
+                continue
+        except salt.exceptions.CommandExecutionError:
             if salt.log.is_logging_configured():
                 if salt.utils.is_windows():
                     continue


### PR DESCRIPTION
Since we switched to python_shell=False, commands throw exceptions
when not found, rather than just having a non-zero retcode (since
we're not using a shell). Catch these exceptions and handle them the
same way as non-zero retcodes.

Fixes #23342 
