### PR TITLE
Fix salt.modules.dockerio.start method

### DIFF
--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -873,11 +873,9 @@ def start(container,
 
         salt '*' docker.start <container id>
     '''
-    if not binds:
-        binds = {}
-
-    if not isinstance(binds, dict):
-        raise SaltInvocationError('binds must be formatted as a dictionary')
+    if binds:
+        if not isinstance(binds, dict):
+            raise SaltInvocationError('binds must be formatted as a dictionary')
 
     client = _get_client()
     status = base_status.copy()


### PR DESCRIPTION
An empty dict is create if binds parameter is set to None.

This should not be the case as docker-py will treat the binds parameter and will create a new config for the host, loosing all the config for this host ( volumes, port bindings, ...)
