### PR TITLE
Fix "No such file or directory" in grains/core.py

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -165,7 +165,7 @@ def _linux_gpu_data():
 
     devs = []
     try:
-        lspci_out = __salt__['cmd.run']('lspci -vmm')
+        lspci_out = __salt__['cmd.run']('{0} -vmm'.format(lspci))
 
         cur_dev = {}
         error = False
@@ -510,7 +510,7 @@ def _virtual(osdata):
         if not cmd:
             continue
 
-        cmd = '{0} {1}'.format(command, ' '.join(args))
+        cmd = '{0} {1}'.format(cmd, ' '.join(args))
 
         ret = __salt__['cmd.run_all'](cmd)
 


### PR DESCRIPTION
I ran into this problem running `salt-ssh '*' test.ping` with a
XenServer 6.5 node as the target. Even though the `lspci` and
`dmidecode` commands are found by `salt.utils.which`, `cmd.run`fails
("No such file or directory") because the commands are not actually in
the `$PATH` . By passing the full path of the command  to `cmd.run`,
the execution succeeds regardless of `$PATH`.
