### PR TITLE
On Windows running salt with admin privileges now authenticates

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -338,11 +338,15 @@ def get_specific_user():
     more specific
     '''
     user = get_user()
-    env_vars = ('SUDO_USER',)
-    if user == 'root':
-        for evar in env_vars:
-            if evar in os.environ:
-                return 'sudo_{0}'.format(os.environ[evar])
+    if is_windows():
+        if ctypes.windll.shell32.IsUserAnAdmin() != 0:
+            return 'sudo_{0}'.format(user)
+    else:
+        env_vars = ('SUDO_USER',)
+        if user == 'root':
+            for evar in env_vars:
+                if evar in os.environ:
+                    return 'sudo_{0}'.format(os.environ[evar])
     return user
 
 


### PR DESCRIPTION
On Windows, salt.utils.get_specific_user will now return
'sudo_<username>' when the the client process has administrator
privileges (eg used "Run as administrator" option).

This enables communication with the master if the client and
salt-master processes are run as different users (which is a
common use case when salt-master is run as a service and the
'salt' command is run in an administrator cmd.exe under the
logged in user).

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
