### PR TITLE
openbsd: add _openbsd_remotes_on

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1548,6 +1548,14 @@ def is_freebsd():
     return sys.platform.startswith('freebsd')
 
 
+@real_memoize
+def is_openbsd():
+    '''
+    Simple function to return if host is OpenBSD or not
+    '''
+    return sys.platform.startswith('openbsd')
+
+
 def is_fcntl_available(check_sunos=False):
     '''
     Simple function to check if the `fcntl` module is available or not.


### PR DESCRIPTION
Helper function to natively returns a set of ipv4 host addresses of both local
and remote established connections without needing to depend on lsof(8).
