### PR TITLE
Update modules path for operating systems using systemd

### DIFF
--- a/salt/modules/kmod.py
+++ b/salt/modules/kmod.py
@@ -55,7 +55,7 @@ def _get_modules_conf():
     Return location of modules config file.
     Default: /etc/modules
     '''
-    if __grains__['os'] == 'Arch':
+    if  'systemd' in __grains__:
         return '/etc/modules-load.d/salt_managed.conf'
     return '/etc/modules'
 


### PR DESCRIPTION
Hi guys,

Just noticed salt.modules.kmod tries to write the persistent modules setting to /etc/modules, which does not exist when using systemd. This change checks for the systemd grain instead of the os=Arch grain so it should work for in every case. I've only tested it on CentOS 6/7.

Thanks,
Andrei
