### PR TITLE
Fix salt cli runs with batch-size set

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -143,9 +143,10 @@ class Batch(object):
             for ping_ret in self.ping_gen:
                 if ping_ret is None:
                     break
-                if ping_ret not in self.minions:
-                    self.minions.append(ping_ret)
-                    to_run.append(ping_ret)
+                m = next(ping_ret.iterkeys())
+                if m not in self.minions:
+                    self.minions.append(m)
+                    to_run.append(m)
 
             for queue in iters:
                 try:


### PR DESCRIPTION
Because of lacking key extraction in ping response, the response dict is being put into minion list. Extract the key use that instead.

This Patch is originally from @apergos, taken form https://github.com/saltstack/salt/issues/23047
