### PR TITLE
[Don't merge] Inject module __grains__ data into opts before create a state

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -158,6 +158,7 @@ def _get_opts(localconfig=None):
     opts = copy.deepcopy(__opts__)
     if localconfig:
         opts = salt.config.minion_config(localconfig, defaults=opts)
+    opts['grains'] = __grains__
     return opts
 
 

--- a/tests/unit/modules/state_test.py
+++ b/tests/unit/modules/state_test.py
@@ -30,6 +30,7 @@ state.__salt__ = {}
 state.__context__ = {}
 state.__opts__ = {}
 state.__pillar__ = {}
+state.__grains__ = {}
 
 
 class MockState(object):


### PR DESCRIPTION
Thus state will use actual grains data.
Related to #24073 
