### PR TITLE
Strip extraneous newline character added in last environment variable

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -294,8 +294,8 @@ def _run(cmd,
             # Getting the environment for the runas user
             # There must be a better way to do this.
             py_code = (
-                'import os, itertools; '
-                'print \"\\0\".join(itertools.chain(*os.environ.items()))'
+                'import sys, os, itertools; '
+                'sys.stdout.write(\"\\0\".join(itertools.chain(*os.environ.items())))'
             )
             if __grains__['os'] in ['MacOS', 'Darwin']:
                 env_cmd = ('sudo', '-i', '-u', runas, '--',


### PR DESCRIPTION
The print statement used to dump the environment associated to the 'runas'
user adds a trailing newline at the end of the string. This newline is
kept and injected in the value of the last environment variable. Most of
the time, it is innocuous but in some cases it can have serious
consequences.

In my case, the last variable was HOME and the trailing newline broke the
command that salt was executing because it was not able to create a file
in the home directory (which was non-existing).

NOTE: This commit should really be included in the 2015.05 branch too.
I have been bitten by this issue when I upgraded from 2014.07 to 2015.05
so it's a regression for me.
