### PR TITLE
Set up salt-ssh file logging

### DIFF
--- a/salt/cli/ssh.py
+++ b/salt/cli/ssh.py
@@ -13,6 +13,7 @@ class SaltSSH(parsers.SaltSSHOptionParser):
 
     def run(self):
         self.parse_args()
+        self.setup_logfile_logger()
 
         ssh = salt.client.ssh.SSH(self.config)
         ssh.run()


### PR DESCRIPTION
Currently, `--log-file` has no effect because logging is never set up.
