### PR TITLE
ensure {} output is not treated as change in module.py state, fixes #…

### DIFF
--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -209,7 +209,7 @@ def run(name, **kwargs):
         ret['result'] = False
         return ret
     else:
-        if mret is not None:
+        if mret is not None or mret is not {}:
             ret['changes']['ret'] = mret
 
     if 'returner' in kwargs:


### PR DESCRIPTION
https://github.com/saltstack/salt/pull/15220
https://github.com/saltstack/salt/issues/24233

Fixing an issue where module returned {} is reported as change in state run by module.py.
