### PR TITLE
Fix pacman.list_upgrades for new python_shell default.

### DIFF
--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -143,7 +143,7 @@ def list_upgrades(refresh=False):
         out = call['stdout']
 
     output = iter(out.splitlines())
-    output.next() # Skip informational output line
+    output.next()  # Skip informational output line
     for line in output:
         comps = line.split(' ')
         if len(comps) < 2:

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -126,10 +126,7 @@ def list_upgrades(refresh=False):
     if refresh:
         options.append('-y')
 
-    cmd = (
-        'pacman {0} | egrep -v '
-        r'"^\s|^:"'
-    ).format(' '.join(options))
+    cmd = ('pacman {0}').format(' '.join(options))
 
     call = __salt__['cmd.run_all'](cmd, output_loglevel='trace')
 
@@ -145,7 +142,9 @@ def list_upgrades(refresh=False):
     else:
         out = call['stdout']
 
-    for line in out.splitlines():
+    output = iter(out.splitlines())
+    output.next() # Skip informational output line
+    for line in output:
         comps = line.split(' ')
         if len(comps) < 2:
             continue


### PR DESCRIPTION
2015.5 sets the default for python_shell to False, so the pipe used in
pacman.list_upgrades no longer works. The egrep invocation after the
pipe has the effect of skipping the first output line, which is an
informational message. Instead of piping to egrep, we simply skip the
first line of output when parsing for the available upgrades.
