### PR TITLE
Don't remove grains from opts

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -983,7 +983,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
 
         mod_opts = {}
         for key, val in list(opts.items()):
-            if key in ('logger', 'grains'):
+            if key == 'logger':
                 continue
             mod_opts[key] = val
         return mod_opts


### PR DESCRIPTION
Alternative fix for #24073.
Don't remove grains from module opts in loader. In this way salt will use the same grains instance in all modules instead of a number of copies.
