### PR TITLE
On Windows, use win32api.GetUserName instead of getpass.getuser

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -51,19 +51,12 @@ try:
 except ImportError:
     HAS_CPROFILE = False
 
-# Try to load pwd, fallback to getpass if unsuccessful
 # Import 3rd-party libs
 try:
     import Crypto.Random
     HAS_CRYPTO = True
 except ImportError:
     HAS_CRYPTO = False
-
-try:
-    import pwd
-except ImportError:
-    import getpass
-    pwd = None
 
 try:
     import timelib
@@ -276,10 +269,10 @@ def get_user():
     '''
     Get the current user
     '''
-    if pwd is not None:
+    if HAS_PWD:
         return pwd.getpwuid(os.geteuid()).pw_name
     else:
-        return getpass.getuser()
+        return win32api.GetUserName()
 
 
 def get_uid(user=None):
@@ -290,7 +283,7 @@ def get_uid(user=None):
     systems which do not support pwd or os.geteuid
     it will return None.
     """
-    if pwd is None:
+    if not HAS_PWD:
         result = None
     elif user is None:
         try:


### PR DESCRIPTION
getpass.getuser() should not be used for authentication because a
malicious user may simply change an environment variable (eg LOGNAME)
and impersonate any user. Due to this, use win32api.GetUserName()
which is a more secure way of obtaining the user name on Windows.

'pwd' was imported twice. Removed one instance. Use 'HAS_PWD' as
the presence check.

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
