### PR TITLE
bugfix: trailing "...done" in rabbitmq output

### DIFF
--- a/tests/unit/modules/rabbitmq_test.py
+++ b/tests/unit/modules/rabbitmq_test.py
@@ -37,11 +37,11 @@ class RabbitmqTestCase(TestCase):
         '''
         Test if it return a list of users based off of rabbitmqctl user_list.
         '''
-        mock_run = MagicMock(return_value='saltstack')
+        mock_run = MagicMock(return_value='Listing users ...\nguest\t[administrator]\n')
         with patch.dict(rabbitmq.__salt__, {'cmd.run': mock_run}):
-            self.assertDictEqual(rabbitmq.list_users(), {})
+            self.assertDictEqual(rabbitmq.list_users(), {'guest': set(['administrator'])})
 
-    # 'list_vhosts' function tests: 1
+    # 'list_vhosts' function tests: 3
 
     def test_list_vhosts(self):
         '''
@@ -49,18 +49,43 @@ class RabbitmqTestCase(TestCase):
         '''
         mock_run = MagicMock(return_value='...\nsaltstack\n...')
         with patch.dict(rabbitmq.__salt__, {'cmd.run': mock_run}):
-            self.assertListEqual(rabbitmq.list_vhosts(), ['saltstack'])
+            self.assertListEqual(rabbitmq.list_vhosts(), ['...', 'saltstack', '...'])
 
-    # 'user_exists' function tests: 1
+    def test_list_vhosts_trailing_done(self):
+        '''
+        Ensure any trailing '...done' line is stripped from output.
+        '''
+        mock_run = MagicMock(return_value='...\nsaltstack\n...done')
+        with patch.dict(rabbitmq.__salt__, {'cmd.run': mock_run}):
+            self.assertListEqual(rabbitmq.list_vhosts(), ['...', 'saltstack'])
+
+    def test_list_vhosts_succeeding_listing(self):
+        '''
+        Ensure succeeding 'Listing ...' line is stripped from output
+        '''
+        mock_run = MagicMock(return_value='Listing vhosts ...\nsaltstack\n...')
+        with patch.dict(rabbitmq.__salt__, {'cmd.run': mock_run}):
+            self.assertListEqual(rabbitmq.list_vhosts(), ['saltstack', '...'])
+
+    # 'user_exists' function tests: 2
+
+    def test_user_exists_negative(self):
+        '''
+        Negative test of whether rabbitmq-internal user exists based
+        on rabbitmqctl list_users.
+        '''
+        mock_run = MagicMock(return_value='Listing users ...\nsaltstack\t[administrator]\n...done')
+        with patch.dict(rabbitmq.__salt__, {'cmd.run': mock_run}):
+            self.assertFalse(rabbitmq.user_exists('rabbit_user'))
 
     def test_user_exists(self):
         '''
-        Test if it return whether the user exists based
+        Test whether a given rabbitmq-internal user exists based
         on rabbitmqctl list_users.
         '''
-        mock_run = MagicMock(return_value='saltstack')
+        mock_run = MagicMock(return_value='Listing users ...\nsaltstack\t[administrator]\n...done')
         with patch.dict(rabbitmq.__salt__, {'cmd.run': mock_run}):
-            self.assertFalse(rabbitmq.user_exists('rabbit_user'))
+            self.assertTrue(rabbitmq.user_exists('saltstack'))
 
     # 'vhost_exists' function tests: 1
 
@@ -69,7 +94,7 @@ class RabbitmqTestCase(TestCase):
         Test if it return whether the vhost exists based
         on rabbitmqctl list_vhosts.
         '''
-        mock_run = MagicMock(return_value='...\nsaltstack\n...')
+        mock_run = MagicMock(return_value='Listing vhosts ...\nsaltstack')
         with patch.dict(rabbitmq.__salt__, {'cmd.run': mock_run}):
             self.assertTrue(rabbitmq.vhost_exists('saltstack'))
 
@@ -167,7 +192,7 @@ class RabbitmqTestCase(TestCase):
         Test if it list permissions for a user
         via rabbitmqctl list_user_permissions.
         '''
-        mock_run = MagicMock(return_value='...\nsaltstack\tsaltstack\n...')
+        mock_run = MagicMock(return_value='Listing stuff ...\nsaltstack\tsaltstack\n...done')
         with patch.dict(rabbitmq.__salt__, {'cmd.run': mock_run}):
             self.assertDictEqual(rabbitmq.list_user_permissions('myuser'),
                                  {'saltstack': ['saltstack']})


### PR DESCRIPTION
## Problem

Some versions of rabbitmq (v3.4.1) do not output any final "...done" line in output of listings, but the given salt code unconditionally removed the final line of output, which may often result in inconsistent behavior of dependent state functions, where the final line has a value that is significant.
## Solution

This bugfix changes this output manipulation to be conditional, matching only lines of `"Listing ..."` as the first, and `"...done"` as the last.
## Details

In my environment::

```
[rabbitmq@db01 ~]$ rabbitmqctl list_vhosts
Listing vhosts ...
/
```

This causes issues in, for example, a vhost is attempted to be created for '/' that already exists, if that vhost happens to be the last one listed in command output, it is thought non-existant, resulting in state failure::

```
Failure: rabbitmq_vhost_|-rabbitmq-vhost_|-/_|-present: Creating vhost "/" ...
Error: vhost_already_exists: /
```
