### PR TITLE
bugfix use of 'iteritem' in 2014.7 branch

### DIFF
--- a/salt/states/rabbitmq_vhost.py
+++ b/salt/states/rabbitmq_vhost.py
@@ -98,7 +98,7 @@ def present(name,
 
     if vhost_exists:
         owner_perms = __salt__['rabbitmq.list_permissions'](name, runas=runas)
-        for eowner, eperms in owner_perms.iteritem():
+        for eowner, eperms in owner_perms.iteritems():
             if eowner == owner and eperms == [conf, write, read]:
                 ret['comment'] = 'Nothing to do'
                 return ret


### PR DESCRIPTION
improper use of dict type 'iteritem', should be 'iteritems'.

This was discovered when combined with bugfix #24511, where previously such code could not have been exercised with more than 1 vhost.
