### PR TITLE
salt.utils.which() don't lookup outside sys.path

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -488,19 +488,6 @@ def which(exe=None):
             return False
 
         search_path = search_path.split(os.pathsep)
-        if not is_windows():
-            # Add any dirs in the default_path which are not in search_path. If
-            # there was no PATH variable found in os.environ, then this will be
-            # a no-op. This ensures that all dirs in the default_path are
-            # searched, which lets salt.utils.which() work well when invoked by
-            # salt-call running from cron (which, depending on platform, may
-            # have a severely limited PATH).
-            search_path.extend(
-                [
-                    x for x in default_path.split(os.pathsep)
-                    if x not in search_path
-                ]
-            )
         for path in search_path:
             full_path = os.path.join(path, exe)
             if _is_executable_file_or_link(full_path):


### PR DESCRIPTION
Salt utils which shouldn't lookup a binary outside the PATH environment variable. If somebody needs to add/remove a path it should be done by environment, not by salt business logic.
Related to #24085, #7990
