### PR TITLE
On Windows, don't use IsUserAnAdmin() because it is deprecated

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -325,6 +325,59 @@ def get_gid(group=None):
     return result
 
 
+def _win_user_token_is_admin(user_token):
+    '''
+    Using the win32 api, determine if the user with token 'user_token' has
+    administrator rights.
+
+    See MSDN entry here:
+        http://msdn.microsoft.com/en-us/library/aa376389(VS.85).aspx
+    '''
+    class SID_IDENTIFIER_AUTHORITY(ctypes.Structure):
+        _fields_ = [
+            ("byte0", ctypes.c_byte),
+            ("byte1", ctypes.c_byte),
+            ("byte2", ctypes.c_byte),
+            ("byte3", ctypes.c_byte),
+            ("byte4", ctypes.c_byte),
+            ("byte5", ctypes.c_byte),
+        ]
+    nt_authority = SID_IDENTIFIER_AUTHORITY()
+    nt_authority.byte5 = 5
+
+    SECURITY_BUILTIN_DOMAIN_RID = 0x20
+    DOMAIN_ALIAS_RID_ADMINS = 0x220
+    administrators_group = ctypes.c_void_p()
+    if ctypes.windll.advapi32.AllocateAndInitializeSid(
+            ctypes.byref(nt_authority),
+            2,
+            SECURITY_BUILTIN_DOMAIN_RID,
+            DOMAIN_ALIAS_RID_ADMINS,
+            0, 0, 0, 0, 0, 0,
+            ctypes.byref(administrators_group)) == 0:
+        raise Exception("AllocateAndInitializeSid failed")
+
+    try:
+        is_admin = ctypes.wintypes.BOOL()
+        if ctypes.windll.advapi32.CheckTokenMembership(
+                user_token,
+                administrators_group,
+                ctypes.byref(is_admin)) == 0:
+            raise Exception("CheckTokenMembership failed")
+        return is_admin.value != 0
+
+    finally:
+        ctypes.windll.advapi32.FreeSid(administrators_group)
+
+
+def _win_current_user_is_admin():
+    '''
+    ctypes.windll.shell32.IsUserAnAdmin() is intentionally avoided due to this
+    function being deprecated.
+    '''
+    return _win_user_token_is_admin(0)
+
+
 def get_specific_user():
     '''
     Get a user name for publishing. If you find the user is "root" attempt to be
@@ -332,7 +385,7 @@ def get_specific_user():
     '''
     user = get_user()
     if is_windows():
-        if ctypes.windll.shell32.IsUserAnAdmin() != 0:
+        if _win_current_user_is_admin():
             return 'sudo_{0}'.format(user)
     else:
         env_vars = ('SUDO_USER',)


### PR DESCRIPTION
According to this, IsUserAnAdmin() is deprecated and is not
official supported after Vista:
https://msdn.microsoft.com/en-us/library/windows/desktop/bb776463%28v=vs.85%29.aspx
Unofficially, it seems to work in Windows 7 and 8, but it is risky
to use something that the documentation says:
"It may be altered or unavailable in subsequent versions."

In order to avoid using IsUserAnAdmin(), the solution was based off of
this:
https://skippylovesmalorie.wordpress.com/tag/python-windows/

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
