### PR TITLE
py3: fix arch failures

### DIFF
--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -306,9 +306,9 @@ def getsid(name):
     for line in lines:
         if 'SERVICE SID:' in line:
             comps = line.split(':', 1)
-            if comps[1] > 1:
+            try:
                 return comps[1].strip()
-            else:
+            except (AttributeError, IndexError):
                 return None
 
 

--- a/tests/unit/modules/cron_test.py
+++ b/tests/unit/modules/cron_test.py
@@ -15,7 +15,6 @@ ensure_in_syspath('../../')
 
 # Import Salt libs
 from salt.modules import cron
-import salt.ext.six as six
 from salt.ext.six.moves import StringIO
 
 STUB_USER = 'root'

--- a/tests/unit/modules/cron_test.py
+++ b/tests/unit/modules/cron_test.py
@@ -15,6 +15,7 @@ ensure_in_syspath('../../')
 
 # Import Salt libs
 from salt.modules import cron
+import salt.ext.six as six
 from salt.ext.six.moves import StringIO
 
 STUB_USER = 'root'
@@ -138,11 +139,14 @@ class CronTestCase(TestCase):
         )
 
     def test__unicode_match(self):
+        encoding = __builtins__.__salt_system_encoding__
+        __builtins__.__salt_system_encoding__ = 'utf-8'
         self.assertTrue(cron._cron_matched({'identifier': '1'}, 'foo', 1))
         self.assertTrue(cron._cron_matched({'identifier': 'é'}, 'foo', 'é'))
         self.assertTrue(cron._cron_matched({'identifier': u'é'}, 'foo', 'é'))
         self.assertTrue(cron._cron_matched({'identifier': 'é'}, 'foo', u'é'))
         self.assertTrue(cron._cron_matched({'identifier': u'é'}, 'foo', u'é'))
+        __builtins__.__salt_system_encoding__ = encoding
 
     @patch('salt.modules.cron._write_cron_lines',
            new=MagicMock(side_effect=write_crontab))

--- a/tests/unit/modules/cron_test.py
+++ b/tests/unit/modules/cron_test.py
@@ -15,7 +15,7 @@ ensure_in_syspath('../../')
 
 # Import Salt libs
 from salt.modules import cron
-from salt.ext.six.moves import StringIO
+from salt.ext.six.moves import builtins, StringIO
 
 STUB_USER = 'root'
 STUB_PATH = '/tmp'
@@ -138,14 +138,14 @@ class CronTestCase(TestCase):
         )
 
     def test__unicode_match(self):
-        encoding = __builtins__.__salt_system_encoding__
-        __builtins__.__salt_system_encoding__ = 'utf-8'
+        encoding = builtins.__salt_system_encoding__
+        builtins.__salt_system_encoding__ = 'utf-8'
         self.assertTrue(cron._cron_matched({'identifier': '1'}, 'foo', 1))
         self.assertTrue(cron._cron_matched({'identifier': 'é'}, 'foo', 'é'))
         self.assertTrue(cron._cron_matched({'identifier': u'é'}, 'foo', 'é'))
         self.assertTrue(cron._cron_matched({'identifier': 'é'}, 'foo', u'é'))
         self.assertTrue(cron._cron_matched({'identifier': u'é'}, 'foo', u'é'))
-        __builtins__.__salt_system_encoding__ = encoding
+        builtins.__salt_system_encoding__ = encoding
 
     @patch('salt.modules.cron._write_cron_lines',
            new=MagicMock(side_effect=write_crontab))

--- a/tests/unit/modules/network_test.py
+++ b/tests/unit/modules/network_test.py
@@ -23,9 +23,12 @@ from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../')
 
 # Import Salt Libs
+import salt.ext.six as six
 import salt.utils
 from salt.modules import network
 from salt.exceptions import CommandExecutionError
+if six.PY2:
+    import salt.ext.ipaddress
 
 # Globals
 network.__grains__ = {}
@@ -268,25 +271,27 @@ class NetworkTestCase(TestCase):
                 self.assertDictEqual(network.connect('host', 'port'),
                                      {'comment': ret, 'result': True})
 
+    @skipIf(not six.PY2, 'test applies only to python 2')
     def test_is_private(self):
         '''
         Test for Check if the given IP address is a private address
         '''
-        with patch.object(network.ipaddress.IPv4Address, 'is_private',
+        with patch.object(salt.ext.ipaddress.IPv4Address, 'is_private',
                           return_value=True):
             self.assertTrue(network.is_private('0.0.0.0'))
-        with patch.object(network.ipaddress.IPv6Address, 'is_private',
+        with patch.object(salt.ext.ipaddress.IPv6Address, 'is_private',
                           return_value=True):
             self.assertTrue(network.is_private('::1'))
 
+    @skipIf(not six.PY2, 'test applies only to python 2')
     def test_is_loopback(self):
         '''
         Test for Check if the given IP address is a loopback address
         '''
-        with patch.object(network.ipaddress.IPv4Address, 'is_loopback',
+        with patch.object(salt.ext.ipaddress.IPv4Address, 'is_loopback',
                           return_value=True):
             self.assertTrue(network.is_loopback('127.0.0.1'))
-        with patch.object(network.ipaddress.IPv6Address, 'is_loopback',
+        with patch.object(salt.ext.ipaddress.IPv6Address, 'is_loopback',
                           return_value=True):
             self.assertTrue(network.is_loopback('::1'))
 

--- a/tests/unit/modules/win_service_test.py
+++ b/tests/unit/modules/win_service_test.py
@@ -176,9 +176,9 @@ class WinServiceTestCase(TestCase):
         '''
             Test to return the sid for this windows service
         '''
-        mock = MagicMock(side_effect=["SERVICE SID:2", "SERVICE SID"])
+        mock = MagicMock(side_effect=["SERVICE SID:S-1-5-80-1956725871-603941828-2318551034-3950094706-3826225633", "SERVICE SID"])
         with patch.dict(win_service.__salt__, {'cmd.run': mock}):
-            self.assertEqual(win_service.getsid("salt"), '2')
+            self.assertEqual(win_service.getsid("salt"), 'S-1-5-80-1956725871-603941828-2318551034-3950094706-3826225633')
 
             self.assertEqual(win_service.getsid("salt"), None)
 

--- a/tests/unit/templates/jinja_test.py
+++ b/tests/unit/templates/jinja_test.py
@@ -384,6 +384,8 @@ class TestGetTemplate(TestCase):
         )
 
     def test_render_with_unicode_syntax_error(self):
+        encoding = __builtins__.__salt_system_encoding__
+        __builtins__.__salt_system_encoding__ = 'utf-8'
         template = u'hello\n\n{{ bad\n\nfoo\ud55c'
         expected = r'.*---\nhello\n\n{{ bad\n\nfoo\xed\x95\x9c    <======================\n---'
         self.assertRaisesRegexp(
@@ -393,6 +395,7 @@ class TestGetTemplate(TestCase):
             template,
             dict(opts=self.local_opts, saltenv='test')
         )
+        __builtins__.__salt_system_encoding__ = encoding
 
     def test_render_with_utf8_syntax_error(self):
         template = 'hello\n\n{{ bad\n\nfoo\xed\x95\x9c'

--- a/tests/unit/templates/jinja_test.py
+++ b/tests/unit/templates/jinja_test.py
@@ -19,6 +19,7 @@ ensure_in_syspath('../../')
 import salt.loader
 import salt.utils
 from salt.exceptions import SaltRenderError
+from salt.ext.six.moves import builtins
 from salt.utils import get_context
 from salt.utils.jinja import (
     SaltCacheLoader,
@@ -384,8 +385,8 @@ class TestGetTemplate(TestCase):
         )
 
     def test_render_with_unicode_syntax_error(self):
-        encoding = __builtins__.__salt_system_encoding__
-        __builtins__.__salt_system_encoding__ = 'utf-8'
+        encoding = builtins.__salt_system_encoding__
+        builtins.__salt_system_encoding__ = 'utf-8'
         template = u'hello\n\n{{ bad\n\nfoo\ud55c'
         expected = r'.*---\nhello\n\n{{ bad\n\nfoo\xed\x95\x9c    <======================\n---'
         self.assertRaisesRegexp(
@@ -395,11 +396,11 @@ class TestGetTemplate(TestCase):
             template,
             dict(opts=self.local_opts, saltenv='test')
         )
-        __builtins__.__salt_system_encoding__ = encoding
+        builtins.__salt_system_encoding__ = encoding
 
     def test_render_with_utf8_syntax_error(self):
-        encoding = __builtins__.__salt_system_encoding__
-        __builtins__.__salt_system_encoding__ = 'utf-8'
+        encoding = builtins.__salt_system_encoding__
+        builtins.__salt_system_encoding__ = 'utf-8'
         template = 'hello\n\n{{ bad\n\nfoo\xed\x95\x9c'
         expected = r'.*---\nhello\n\n{{ bad\n\nfoo\xed\x95\x9c    <======================\n---'
         self.assertRaisesRegexp(
@@ -409,7 +410,7 @@ class TestGetTemplate(TestCase):
             template,
             dict(opts=self.local_opts, saltenv='test')
         )
-        __builtins__.__salt_system_encoding__ = encoding
+        builtins.__salt_system_encoding__ = encoding
 
     def test_render_with_undefined_variable(self):
         template = "hello\n\n{{ foo }}\n\nfoo"

--- a/tests/unit/templates/jinja_test.py
+++ b/tests/unit/templates/jinja_test.py
@@ -398,6 +398,8 @@ class TestGetTemplate(TestCase):
         __builtins__.__salt_system_encoding__ = encoding
 
     def test_render_with_utf8_syntax_error(self):
+        encoding = __builtins__.__salt_system_encoding__
+        __builtins__.__salt_system_encoding__ = 'utf-8'
         template = 'hello\n\n{{ bad\n\nfoo\xed\x95\x9c'
         expected = r'.*---\nhello\n\n{{ bad\n\nfoo\xed\x95\x9c    <======================\n---'
         self.assertRaisesRegexp(
@@ -407,6 +409,7 @@ class TestGetTemplate(TestCase):
             template,
             dict(opts=self.local_opts, saltenv='test')
         )
+        __builtins__.__salt_system_encoding__ = encoding
 
     def test_render_with_undefined_variable(self):
         template = "hello\n\n{{ foo }}\n\nfoo"

--- a/tests/unit/utils/utils_test.py
+++ b/tests/unit/utils/utils_test.py
@@ -752,14 +752,14 @@ class UtilsTestCase(TestCase):
             self.assertRaises(TypeError, utils.to_str, x)
         if six.PY3:
             self.assertEqual(utils.to_str('plugh'), 'plugh')
-            self.assertEqual(utils.to_str('áéíóúý'), 'áéíóúý')
+            self.assertEqual(utils.to_str('áéíóúý', 'utf-8'), 'áéíóúý')
             un = '\u4e2d\u56fd\u8a9e (\u7e41\u4f53)'  # pylint: disable=anomalous-unicode-escape-in-string
             ut = bytes((0xe4, 0xb8, 0xad, 0xe5, 0x9b, 0xbd, 0xe8, 0xaa, 0x9e, 0x20, 0x28, 0xe7, 0xb9, 0x81, 0xe4, 0xbd, 0x93, 0x29))
             self.assertEqual(utils.to_str(ut, 'utf-8'), un)
             self.assertEqual(utils.to_str(bytearray(ut), 'utf-8'), un)
         else:
             self.assertEqual(utils.to_str('plugh'), 'plugh')
-            self.assertEqual(utils.to_str(u'áéíóúý'), 'áéíóúý')
+            self.assertEqual(utils.to_str(u'áéíóúý', 'utf-8'), 'áéíóúý')
             un = u'\u4e2d\u56fd\u8a9e (\u7e41\u4f53)'
             ut = '\xe4\xb8\xad\xe5\x9b\xbd\xe8\xaa\x9e (\xe7\xb9\x81\xe4\xbd\x93)'
             self.assertEqual(utils.to_str(un, 'utf-8'), ut)


### PR DESCRIPTION
Fixes to tests that are now failing on our Arch setup, where the default system encoding is ascii.
