### PR TITLE
The first arg in a state should always be name, and unfreeze name from salt/state.py

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -66,7 +66,6 @@ STATE_REQUISITE_IN_KEYWORDS = frozenset([
     'listen_in',
     ])
 STATE_RUNTIME_KEYWORDS = frozenset([
-    'name',  # name of the highstate running
     'fun',
     'state',
     'check_cmd',


### PR DESCRIPTION
This should fix the problems with the CentOS\* test failures.

Refs #24332

@s0undt3ch 
