### PR TITLE
2015.5 backport tls changes from develop

### DIFF
--- a/doc/ref/states/all/salt.states.tls.rst
+++ b/doc/ref/states/all/salt.states.tls.rst
@@ -3,8 +3,4 @@ salt.states.tls
 ===============
 
 .. automodule:: salt.states.tls
-<<<<<<< HEAD
     :members:
-=======
-    :members:
->>>>>>> develop

--- a/doc/ref/states/all/salt.states.tls.rst
+++ b/doc/ref/states/all/salt.states.tls.rst
@@ -3,4 +3,8 @@ salt.states.tls
 ===============
 
 .. automodule:: salt.states.tls
+<<<<<<< HEAD
     :members:
+=======
+    :members:
+>>>>>>> develop

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -316,6 +316,9 @@ def maybe_fix_ssl_version(ca_name, cacert_path=None, ca_filename=None):
     ca_filename
         alternative filename for the CA
 
+        .. versionadded:: 2015.5.3
+
+
     CLI Example:
 
     .. code-block:: bash
@@ -379,6 +382,9 @@ def ca_exists(ca_name, cacert_path=None, ca_filename=None):
         absolute path to ca certificates root directory
     ca_filename
         alternative filename for the CA
+
+        .. versionadded:: 2015.5.3
+
 
     CLI Example:
 
@@ -456,6 +462,9 @@ def get_ca_signed_cert(ca_name,
     cert_filename
         alternative filename for the certificate, useful when using special characters in the CN
 
+        .. versionadded:: 2015.5.3
+
+
     CLI Example:
 
     .. code-block:: bash
@@ -497,6 +506,9 @@ def get_ca_signed_key(ca_name,
         absolute path to certificates root directory
     key_filename
         alternative filename for the key, useful when using special characters
+
+        .. versionadded:: 2015.5.3
+
         in the CN
 
     CLI Example:
@@ -591,6 +603,9 @@ def create_ca(ca_name,
         absolute path to ca certificates root directory
     ca_filename
         alternative filename for the CA
+
+        .. versionadded:: 2015.5.3
+
     digest
         The message digest algorithm. Must be a string describing a digest
         algorithm supported by OpenSSL (by EVP_get_digestbyname, specifically).
@@ -1191,6 +1206,9 @@ def create_ca_signed_cert(ca_name,
     ca_filename
         alternative filename for the CA
 
+        .. versionadded:: 2015.5.3
+
+
     cert_path
         full path to the certificates directory
 
@@ -1199,6 +1217,9 @@ def create_ca_signed_cert(ca_name,
         characters in the CN. If this option is set it will override
         the certificate filename output effects of ``cert_type``.
         ``type_ext`` will be completely overridden.
+
+        .. versionadded:: 2015.5.3
+
 
     digest
         The message digest algorithm. Must be a string describing a digest
@@ -1553,6 +1574,9 @@ def create_empty_crl(
         absolute path to ca certificates root directory
     ca_filename
         alternative filename for the CA
+
+        .. versionadded:: 2015.5.3
+
     crl_file
         full path to the CRL file
 

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -215,14 +215,14 @@ def _new_serial(ca_name, CN):
     opts_hash_type = __opts__.get('hash_type', 'md5')
     hashtype = getattr(hashlib, opts_hash_type)
     hashnum = int(
-            hashtype(
-                '{0}_{1}_{2}'.format(
-                    ca_name,
-                    CN,
-                    int(time.time()))
-                ).hexdigest(),
-            16
-            )
+        hashtype(
+            '{0}_{1}_{2}'.format(
+                ca_name,
+                CN,
+                int(time.time()))
+        ).hexdigest(),
+        16
+    )
     log.debug('Hashnum: {0}'.format(hashnum))
 
     # record the hash somewhere
@@ -255,10 +255,10 @@ def _get_basic_info(ca_name, cert, ca_dir=None):
     index_file = "{0}/index.txt".format(ca_dir)
 
     expire_date = _four_digit_year_to_two_digit(
-            datetime.strptime(
-                cert.get_notAfter(),
-                four_digit_year_fmt)
-            )
+        datetime.strptime(
+            cert.get_notAfter(),
+            four_digit_year_fmt)
+    )
     serial_number = format(cert.get_serial_number(), 'X')
 
     # gotta prepend a /
@@ -266,10 +266,10 @@ def _get_basic_info(ca_name, cert, ca_dir=None):
 
     # then we can add the rest of the subject
     subject += '/'.join(
-            ['{0}={1}'.format(
-                x, y
-                ) for x, y in cert.get_subject().get_components()]
-            )
+        ['{0}={1}'.format(
+            x, y
+        ) for x, y in cert.get_subject().get_components()]
+    )
     subject += '\n'
 
     return (index_file, expire_date, serial_number, subject)
@@ -288,16 +288,16 @@ def _write_cert_to_database(ca_name, cert, cacert_path=None, status='V'):
     set_ca_path(cacert_path)
     ca_dir = '{0}/{1}'.format(cert_base_path(), ca_name)
     index_file, expire_date, serial_number, subject = _get_basic_info(
-            ca_name,
-            cert,
-            ca_dir)
+        ca_name,
+        cert,
+        ca_dir)
 
     index_data = '{0}\t{1}\t\t{2}\tunknown\t{3}'.format(
-            status,
-            expire_date,
-            serial_number,
-            subject
-            )
+        status,
+        expire_date,
+        serial_number,
+        subject
+    )
 
     with salt.utils.fopen(index_file, 'a+') as ofile:
         ofile.write(index_data)
@@ -333,9 +333,9 @@ def maybe_fix_ssl_version(ca_name, cacert_path=None, ca_filename=None):
             ca_name,
             ca_filename)
     ca_keyp = '{0}/{1}/{2}.key'.format(
-            cert_base_path(),
-            ca_name,
-            ca_filename)
+        cert_base_path(),
+        ca_name,
+        ca_filename)
     with salt.utils.fopen(certp) as fic:
         cert = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM,
                                                fic.read())
@@ -525,9 +525,9 @@ def get_ca_signed_key(ca_name,
         key_filename = CN
 
     keyp = '{0}/{1}/certs/{2}.key'.format(
-            cert_base_path(),
-            ca_name,
-            key_filename)
+        cert_base_path(),
+        ca_name,
+        key_filename)
     if not os.path.exists(keyp):
         raise ValueError('Certificate does not exists for {0}'.format(CN))
     else:
@@ -999,26 +999,26 @@ def create_csr(ca_name,
     with salt.utils.fopen('{0}/{1}.key'.format(csr_path,
                                                csr_filename), 'w+') as priv_key:
         priv_key.write(
-                OpenSSL.crypto.dump_privatekey(OpenSSL.crypto.FILETYPE_PEM, key)
-                )
+            OpenSSL.crypto.dump_privatekey(OpenSSL.crypto.FILETYPE_PEM, key)
+        )
 
     with salt.utils.fopen(csr_f, 'w+') as csr:
         csr.write(
-                OpenSSL.crypto.dump_certificate_request(
-                    OpenSSL.crypto.FILETYPE_PEM,
-                    req
-                    )
-                )
+            OpenSSL.crypto.dump_certificate_request(
+                OpenSSL.crypto.FILETYPE_PEM,
+                req
+            )
+        )
 
     ret = 'Created Private Key: "{0}{1}.key." '.format(
-                    csr_path,
-                    csr_filename
-                    )
+        csr_path,
+        csr_filename
+    )
     ret += 'Created CSR for "{0}": "{1}{2}.csr."'.format(
-                    CN,
-                    csr_path,
-                    csr_filename
-                    )
+        CN,
+        csr_path,
+        csr_filename
+    )
 
     return ret
 
@@ -1109,7 +1109,7 @@ def create_self_signed_cert(tls_dir='tls',
     if not replace and os.path.exists(
             '{0}/{1}/certs/{2}.crt'.format(cert_base_path(),
                                            tls_dir, cert_filename)
-            ):
+    ):
         return 'Certificate "{0}" already exists'.format(cert_filename)
 
     key = OpenSSL.crypto.PKey()
@@ -1138,37 +1138,37 @@ def create_self_signed_cert(tls_dir='tls',
 
     # Write private key and cert
     with salt.utils.fopen(
-                '{0}/{1}/certs/{2}.key'.format(cert_base_path(),
-                                               tls_dir, cert_filename),
-                'w+'
-                ) as priv_key:
+        '{0}/{1}/certs/{2}.key'.format(cert_base_path(),
+                                       tls_dir, cert_filename),
+        'w+'
+    ) as priv_key:
         priv_key.write(
-                OpenSSL.crypto.dump_privatekey(OpenSSL.crypto.FILETYPE_PEM, key)
-                )
+            OpenSSL.crypto.dump_privatekey(OpenSSL.crypto.FILETYPE_PEM, key)
+        )
 
     with salt.utils.fopen('{0}/{1}/certs/{2}.crt'.format(cert_base_path(),
                                                          tls_dir,
                                                          cert_filename
                                                          ), 'w+') as crt:
         crt.write(
-                OpenSSL.crypto.dump_certificate(
-                    OpenSSL.crypto.FILETYPE_PEM,
-                    cert
-                    )
-                )
+            OpenSSL.crypto.dump_certificate(
+                OpenSSL.crypto.FILETYPE_PEM,
+                cert
+            )
+        )
 
     _write_cert_to_database(tls_dir, cert)
 
     ret = 'Created Private Key: "{0}/{1}/certs/{2}.key." '.format(
-                    cert_base_path(),
-                    tls_dir,
-                    cert_filename
-                    )
+        cert_base_path(),
+        tls_dir,
+        cert_filename
+    )
     ret += 'Created Certificate: "{0}/{1}/certs/{2}.crt."'.format(
-                    cert_base_path(),
-                    tls_dir,
-                    cert_filename
-                    )
+        cert_base_path(),
+        tls_dir,
+        cert_filename
+    )
 
     return ret
 
@@ -1318,15 +1318,15 @@ def create_ca_signed_cert(ca_name,
                                                        ca_name,
                                                        ca_filename)) as fhr:
             ca_cert = OpenSSL.crypto.load_certificate(
-                    OpenSSL.crypto.FILETYPE_PEM, fhr.read()
-                )
+                OpenSSL.crypto.FILETYPE_PEM, fhr.read()
+            )
         with salt.utils.fopen('{0}/{1}/{2}.key'.format(cert_base_path(),
                                                        ca_name,
                                                        ca_filename)) as fhr:
             ca_key = OpenSSL.crypto.load_privatekey(
-                    OpenSSL.crypto.FILETYPE_PEM,
-                    fhr.read()
-                )
+                OpenSSL.crypto.FILETYPE_PEM,
+                fhr.read()
+            )
     except IOError:
         ret['retcode'] = 1
         ret['comment'] = 'There is no CA named "{0}"'.format(ca_name)
@@ -1336,19 +1336,19 @@ def create_ca_signed_cert(ca_name,
         csr_path = '{0}/{1}.csr'.format(cert_path, csr_filename)
         with salt.utils.fopen(csr_path) as fhr:
             req = OpenSSL.crypto.load_certificate_request(
-                    OpenSSL.crypto.FILETYPE_PEM,
-                    fhr.read())
+                OpenSSL.crypto.FILETYPE_PEM,
+                fhr.read())
     except IOError:
         ret['retcode'] = 1
         ret['comment'] = 'There is no CSR that matches the CN "{0}"'.format(
-                cert_filename)
+            cert_filename)
         return ret
 
     exts = []
     try:
         exts.extend(req.get_extensions())
         log.debug('req.get_extensions() supported in pyOpenSSL {0}'.format(
-                        OpenSSL.__dict__.get('__version__', '')))
+            OpenSSL.__dict__.get('__version__', '')))
     except AttributeError:
         try:
             # see: http://bazaar.launchpad.net/~exarkun/pyopenssl/master/revision/189
@@ -1361,7 +1361,7 @@ def create_ca_signed_cert(ca_name,
                          OpenSSL.__dict__.get('__version__', 'pre-2014')))
 
             native_exts_obj = OpenSSL._util.lib.X509_REQ_get_extensions(
-                    req._req)
+                req._req)
             for i in _range(OpenSSL._util.lib.sk_X509_EXTENSION_num(
                     native_exts_obj)):
                 ext = OpenSSL.crypto.X509Extension.__new__(
@@ -1400,10 +1400,10 @@ def create_ca_signed_cert(ca_name,
 
     return ('Created Certificate for "{0}": '
             '"{1}/{2}.crt"').format(
-                    CN,
-                    cert_path,
-                    cert_filename
-                    )
+        CN,
+        cert_path,
+        cert_filename
+    )
 
 
 def create_pkcs12(ca_name, CN, passphrase='', cacert_path=None, replace=False):
@@ -1446,7 +1446,7 @@ def create_pkcs12(ca_name, CN, passphrase='', cacert_path=None, replace=False):
                 cert_base_path(),
                 ca_name,
                 CN)
-            ):
+    ):
         return 'Certificate "{0}" already exists'.format(CN)
 
     try:
@@ -1454,9 +1454,9 @@ def create_pkcs12(ca_name, CN, passphrase='', cacert_path=None, replace=False):
                                                                ca_name,
                                                                ca_name)) as fhr:
             ca_cert = OpenSSL.crypto.load_certificate(
-                    OpenSSL.crypto.FILETYPE_PEM,
-                    fhr.read()
-                )
+                OpenSSL.crypto.FILETYPE_PEM,
+                fhr.read()
+            )
     except IOError:
         return 'There is no CA named "{0}"'.format(ca_name)
 
@@ -1465,16 +1465,16 @@ def create_pkcs12(ca_name, CN, passphrase='', cacert_path=None, replace=False):
                                                              ca_name,
                                                              CN)) as fhr:
             cert = OpenSSL.crypto.load_certificate(
-                    OpenSSL.crypto.FILETYPE_PEM,
-                    fhr.read()
-                )
+                OpenSSL.crypto.FILETYPE_PEM,
+                fhr.read()
+            )
         with salt.utils.fopen('{0}/{1}/certs/{2}.key'.format(cert_base_path(),
                                                              ca_name,
                                                              CN)) as fhr:
             key = OpenSSL.crypto.load_privatekey(
-                    OpenSSL.crypto.FILETYPE_PEM,
-                    fhr.read()
-                    )
+                OpenSSL.crypto.FILETYPE_PEM,
+                fhr.read()
+            )
     except IOError:
         return 'There is no certificate that matches the CN "{0}"'.format(CN)
 
@@ -1491,11 +1491,11 @@ def create_pkcs12(ca_name, CN, passphrase='', cacert_path=None, replace=False):
 
     return ('Created PKCS#12 Certificate for "{0}": '
             '"{1}/{2}/certs/{3}.p12"').format(
-                    CN,
-                    cert_base_path(),
-                    ca_name,
-                    CN
-                    )
+        CN,
+        cert_base_path(),
+        ca_name,
+        CN
+    )
 
 
 def cert_info(cert_path, digest='sha256'):
@@ -1518,9 +1518,9 @@ def cert_info(cert_path, digest='sha256'):
 
     with salt.utils.fopen(cert_path) as cert_file:
         cert = OpenSSL.crypto.load_certificate(
-                OpenSSL.crypto.FILETYPE_PEM,
-                cert_file.read()
-            )
+            OpenSSL.crypto.FILETYPE_PEM,
+            cert_file.read()
+        )
     ret = {
         'fingerprint': cert.digest(digest),
         'subject': dict(cert.get_subject().get_components()),
@@ -1596,29 +1596,29 @@ def create_empty_crl(
 
     if not crl_file:
         crl_file = '{0}/{1}/crl.pem'.format(
-                _cert_base_path(),
-                ca_name
-                )
+            _cert_base_path(),
+            ca_name
+        )
 
     if os.path.exists('{0}'.format(crl_file)):
         return 'CRL "{0}" already exists'.format(crl_file)
 
     try:
         ca_cert = OpenSSL.crypto.load_certificate(
-                OpenSSL.crypto.FILETYPE_PEM,
-                salt.utils.fopen('{0}/{1}/{2}.crt'.format(
-                    cert_base_path(),
-                    ca_name,
-                    ca_filename
-                    )).read()
-                )
+            OpenSSL.crypto.FILETYPE_PEM,
+            salt.utils.fopen('{0}/{1}/{2}.crt'.format(
+                cert_base_path(),
+                ca_name,
+                ca_filename
+            )).read()
+        )
         ca_key = OpenSSL.crypto.load_privatekey(
-                OpenSSL.crypto.FILETYPE_PEM,
-                salt.utils.fopen('{0}/{1}/{2}.key'.format(
-                    cert_base_path(),
-                    ca_name,
-                    ca_filename)).read()
-                )
+            OpenSSL.crypto.FILETYPE_PEM,
+            salt.utils.fopen('{0}/{1}/{2}.key'.format(
+                cert_base_path(),
+                ca_name,
+                ca_filename)).read()
+        )
     except IOError:
         return 'There is no CA named "{0}"'.format(ca_name)
 
@@ -1690,53 +1690,53 @@ def revoke_cert(
 
     try:
         ca_cert = OpenSSL.crypto.load_certificate(
-                OpenSSL.crypto.FILETYPE_PEM,
-                salt.utils.fopen('{0}/{1}/{2}.crt'.format(
-                    cert_base_path(),
-                    ca_name,
-                    ca_filename
-                    )).read()
-                )
+            OpenSSL.crypto.FILETYPE_PEM,
+            salt.utils.fopen('{0}/{1}/{2}.crt'.format(
+                cert_base_path(),
+                ca_name,
+                ca_filename
+            )).read()
+        )
         ca_key = OpenSSL.crypto.load_privatekey(
-                OpenSSL.crypto.FILETYPE_PEM,
-                salt.utils.fopen('{0}/{1}/{2}.key'.format(
-                    cert_base_path(),
-                    ca_name,
-                    ca_filename)).read()
-                )
+            OpenSSL.crypto.FILETYPE_PEM,
+            salt.utils.fopen('{0}/{1}/{2}.key'.format(
+                cert_base_path(),
+                ca_name,
+                ca_filename)).read()
+        )
     except IOError:
         return 'There is no CA named "{0}"'.format(ca_name)
 
     try:
         client_cert = OpenSSL.crypto.load_certificate(
-                OpenSSL.crypto.FILETYPE_PEM,
-                salt.utils.fopen('{0}/{1}.crt'.format(
-                    cert_path,
-                    cert_filename)).read()
-                )
+            OpenSSL.crypto.FILETYPE_PEM,
+            salt.utils.fopen('{0}/{1}.crt'.format(
+                cert_path,
+                cert_filename)).read()
+        )
     except IOError:
         return 'There is no client certificate named "{0}"'.format(CN)
 
     index_file, expire_date, serial_number, subject = _get_basic_info(
-            ca_name,
-            client_cert,
-            ca_dir)
+        ca_name,
+        client_cert,
+        ca_dir)
 
     index_serial_subject = '{0}\tunknown\t{1}'.format(
-            serial_number,
-            subject)
+        serial_number,
+        subject)
     index_v_data = 'V\t{0}\t\t{1}'.format(
-            expire_date,
-            index_serial_subject)
+        expire_date,
+        index_serial_subject)
     index_r_data_pattern = re.compile(
-            r"R\t" +
-            expire_date +
-            r"\t\d{12}Z\t" +
-            re.escape(index_serial_subject))
+        r"R\t" +
+        expire_date +
+        r"\t\d{12}Z\t" +
+        re.escape(index_serial_subject))
     index_r_data = 'R\t{0}\t{1}\t{2}'.format(
-            expire_date,
-            _four_digit_year_to_two_digit(datetime.now()),
-            index_serial_subject)
+        expire_date,
+        _four_digit_year_to_two_digit(datetime.now()),
+        index_serial_subject)
 
     ret = {}
     with salt.utils.fopen(index_file) as f:
@@ -1747,10 +1747,10 @@ def revoke_cert(
                     datetime.strptime(revoke_date, two_digit_year_fmt)
                     return ('"{0}/{1}.crt" was already revoked, '
                             'serial number: {2}').format(
-                                    cert_path,
-                                    cert_filename,
-                                    serial_number
-                                    )
+                        cert_path,
+                        cert_filename,
+                        serial_number
+                    )
                 except ValueError:
                     ret['retcode'] = 1
                     ret['comment'] = ("Revocation date '{0}' does not match"
@@ -1760,10 +1760,10 @@ def revoke_cert(
                     return ret
             elif index_serial_subject in line:
                 __salt__['file.replace'](
-                        index_file,
-                        index_v_data,
-                        index_r_data,
-                        backup=False)
+                    index_file,
+                    index_v_data,
+                    index_r_data,
+                    backup=False)
                 break
 
     crl = OpenSSL.crypto.CRL()
@@ -1784,14 +1784,14 @@ def revoke_cert(
 
     if crl_file is None:
         crl_file = '{0}/{1}/crl.pem'.format(
-                _cert_base_path(),
-                ca_name
-                )
+            _cert_base_path(),
+            ca_name
+        )
 
     if os.path.isdir(crl_file):
         ret['retcode'] = 1
         ret['comment'] = 'crl_file "{0}" is an existing directory'.format(
-                crl_file)
+            crl_file)
         return ret
 
     with salt.utils.fopen(crl_file, 'w') as f:
@@ -1799,23 +1799,23 @@ def revoke_cert(
 
     return ('Revoked Certificate: "{0}/{1}.crt", '
             'serial number: {2}').format(
-                    cert_path,
-                    cert_filename,
-                    serial_number
-                    )
+        cert_path,
+        cert_filename,
+        serial_number
+    )
 
 
 if __name__ == '__main__':
     # create_ca('koji', days=365, **cert_sample_meta)
     create_csr(
-            'koji',
-            CN='test_system',
-            C="US",
-            ST="Utah",
-            L="Centerville",
-            O="SaltStack",
-            OU=None,
-            emailAddress='test_system@saltstack.org'
-            )
+        'koji',
+        CN='test_system',
+        C="US",
+        ST="Utah",
+        L="Centerville",
+        O="SaltStack",
+        OU=None,
+        emailAddress='test_system@saltstack.org'
+    )
     create_ca_signed_cert('koji', 'test_system')
     create_pkcs12('koji', 'test_system', passphrase='test')

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -4,17 +4,98 @@ A salt module for SSL/TLS.
 Can create a Certificate Authority (CA)
 or use Self-Signed certificates.
 
-:depends:   - PyOpenSSL Python module
-:configuration: Add the following values in ``/etc/salt/minion`` for the CA module
-    to function properly:
-
-    .. code-block:: text
+:depends:   - PyOpenSSL Python module (0.14 or later)
+:configuration: Add the following values in /etc/salt/minion for the CA module
+    to function properly::
 
         ca.cert_base_path: '/etc/pki'
+
+
+CLI Example #1
+Creating a CA, a server request and its signed certificate:
+
+    .. code-block:: bash
+
+    # salt-call tls.create_ca my_little \
+      days=5 \
+      CN='My Little CA' \
+      C=US \
+      ST=Utah \
+      L=Salt Lake City \
+      O=Saltstack \
+      emailAddress=pleasedontemail@thisisnot.coms
+
+    Created Private Key: "/etc/pki/my_little/my_little_ca_cert.key"
+    Created CA "my_little_ca": "/etc/pki/my_little_ca/my_little_ca_cert.crt"
+
+    # salt-call tls.create_csr my_little CN=www.thisisnot.coms
+    Created Private Key: "/etc/pki/my_little/certs/www.thisisnot.coms.key
+    Created CSR for "www.thisisnot.coms": "/etc/pki/my_little/certs/www.thisisnot.coms.csr"
+
+    # salt-call tls.create_ca_signed_cert my_little CN=www.thisisnot.coms
+    Created Certificate for "www.thisisnot.coms": /etc/pki/my_little/certs/www.thisisnot.coms.crt"
+
+CLI Example #2:
+Creating a client request and its signed certificate
+
+    .. code-block:: bash
+
+    # salt-call tls.create_csr my_little CN=DBReplica_No.1 cert_type=client
+    Created Private Key: "/etc/pki/my_little/certs//DBReplica_No.1.key."
+    Created CSR for "DBReplica_No.1": "/etc/pki/my_little/certs/DBReplica_No.1.csr."
+
+    # salt-call tls.create_ca_signed_cert my_little CN=DBReplica_No.1
+    Created Certificate for "DBReplica_No.1": "/etc/pki/my_little/certs/DBReplica_No.1.crt"
+
+CLI Example #3:
+Creating both a server and client req + cert for the same CN
+
+    .. code-block:: bash
+    # salt-call tls.create_csr my_little CN=MasterDBReplica_No.2  \
+        cert_type=client
+    Created Private Key: "/etc/pki/my_little/certs/MasterDBReplica_No.2.key."
+    Created CSR for "DBReplica_No.1": "/etc/pki/my_little/certs/MasterDBReplica_No.2.csr."
+
+    # salt-call tls.create_ca_signed_cert my_little CN=MasterDBReplica_No.2
+    Created Certificate for "DBReplica_No.1": "/etc/pki/my_little/certs/DBReplica_No.1.crt"
+
+    # salt-call tls.create_csr my_little CN=MasterDBReplica_No.2 \
+        cert_type=server
+    Certificate "MasterDBReplica_No.2" already exists
+
+    (doh!)
+
+    # salt-call tls.create_csr my_little CN=MasterDBReplica_No.2 \
+        cert_type=server type_ext=True
+    Created Private Key: "/etc/pki/my_little/certs/DBReplica_No.1_client.key."
+    Created CSR for "DBReplica_No.1": "/etc/pki/my_little/certs/DBReplica_No.1_client.csr."
+
+    # salt-call tls.create_ca_signed_cert my_little CN=MasterDBReplica_No.2
+    Certificate "MasterDBReplica_No.2" already exists
+
+    (DOH!)
+
+    # salt-call tls.create_ca_signed_cert my_little CN=MasterDBReplica_No.2 \
+        cert_type=server type_ext=True
+    Created Certificate for "MasterDBReplica_No.2": "/etc/pki/my_little/certs/MasterDBReplica_No.2_server.crt"
+
+
+CLI Example #4:
+Create a server req + cert with non-CN filename for the cert
+
+    .. code-block:: bash
+
+    # salt-call tls.create_csr my_little CN=www.anothersometh.ing \
+        cert_type=server type_ext=True
+    Created Private Key: "/etc/pki/my_little/certs/www.anothersometh.ing_server.key."
+    Created CSR for "DBReplica_No.1": "/etc/pki/my_little/certs/www.anothersometh.ing_server.csr."
+
+    # salt-call tls_create_ca_signed_cert my_little CN=www.anothersometh.ing \
+        cert_type=server cert_filename="something_completely_different"
+    Created Certificate for "www.anothersometh.ing": /etc/pki/my_little/certs/something_completely_different.crt
+
 '''
-
 from __future__ import absolute_import
-
 # pylint: disable=C0103
 
 # Import python libs
@@ -22,22 +103,29 @@ import os
 import time
 import logging
 import hashlib
-from salt.ext import six
+import salt.utils
+from salt._compat import string_types
 from salt.ext.six.moves import range as _range
 from datetime import datetime
+from distutils.version import LooseVersion
+
+import re
 
 HAS_SSL = False
 try:
     import OpenSSL
     HAS_SSL = True
+    OpenSSL_version = LooseVersion(OpenSSL.__dict__.get('__version__', '0.0'))
 except ImportError:
     pass
 
 # Import salt libs
-import salt.utils
 
 
 log = logging.getLogger(__name__)
+
+two_digit_year_fmt = "%y%m%d%H%M%SZ"
+four_digit_year_fmt = "%Y%m%d%H%M%SZ"
 
 # Always use UTC for certificate info
 os.environ['TZ'] = 'UTC'
@@ -48,14 +136,31 @@ def __virtual__():
     '''
     Only load this module if the ca config options are set
     '''
-    if HAS_SSL:
+    if HAS_SSL and OpenSSL_version >= LooseVersion('0.14'):
+        if OpenSSL_version <= LooseVersion('0.15'):
+            log.warn('You should upgrade pyOpenSSL to at least 0.15.1')
+        # never EVER reactivate this code, this has been done too many times.
+        # not having configured a cert path in the configuration does not
+        # mean that users cant use this module as we provide methods
+        # to configure it afterwards.
+        # if __opts__.get('ca.cert_base_path', None):
+        #     return True
+        # else:
+        #     log.error('tls module not loaded: ca.cert_base_path not set')
+        #     return False
         return True
-    return False, ['PyOpenSSL must be installed before this module can be used.']
+    else:
+        return False, ['PyOpenSSL version 0.14 or later'
+                       ' must be installed before '
+                       ' this module can be used.']
 
 
 def cert_base_path(cacert_path=None):
     '''
     Return the base path for certs from CLI or from options
+
+    cacert_path
+        absolute path to ca certificates root directory
 
     CLI Example:
 
@@ -64,9 +169,13 @@ def cert_base_path(cacert_path=None):
         salt '*' tls.cert_base_path
     '''
     if not cacert_path:
-        cacert_path = __salt__['config.option']('ca.contextual_cert_base_path')
+        cacert_path = __context__.get(
+            'ca.contextual_cert_base_path',
+            __salt__['config.option']('ca.contextual_cert_base_path'))
     if not cacert_path:
-        cacert_path = __salt__['config.option']('ca.cert_base_path')
+        cacert_path = __context__.get(
+            'ca.cert_base_path',
+            __salt__['config.option']('ca.cert_base_path'))
     return cacert_path
 
 
@@ -89,7 +198,7 @@ def set_ca_path(cacert_path):
         salt '*' tls.set_ca_path /etc/certs
     '''
     if cacert_path:
-        __opts__['ca.contextual_cert_base_path'] = cacert_path
+        __context__['ca.contextual_cert_base_path'] = cacert_path
     return cert_base_path()
 
 
@@ -120,32 +229,39 @@ def _new_serial(ca_name, CN):
     cachedir = __opts__['cachedir']
     log.debug('cachedir: {0}'.format(cachedir))
     serial_file = '{0}/{1}.serial'.format(cachedir, ca_name)
-    with salt.utils.fopen(serial_file, 'a+') as ofile:
+    if not os.path.exists(cachedir):
+        os.makedirs(cachedir)
+    if not os.path.exists(serial_file):
+        fd = salt.utils.fopen(serial_file, 'w')
+    else:
+        fd = salt.utils.fopen(serial_file, 'a+')
+    with fd as ofile:
         ofile.write(str(hashnum))
 
     return hashnum
 
 
-def _write_cert_to_database(ca_name, cert, cacert_path=None):
+def _four_digit_year_to_two_digit(datetimeObj):
+    return datetimeObj.strftime(two_digit_year_fmt)
+
+
+def _get_basic_info(ca_name, cert, ca_dir=None):
     '''
-    write out the index.txt database file in the appropriate directory to
-    track certificates
-
-    ca_name
-        name of the CA
-    cert
-        certificate to be recorded
-    cacert_path
-        absolute path to ca certificates root directory
+    Get basic info to write out to the index.txt
     '''
-    set_ca_path(cacert_path)
-    index_file = "{0}/{1}/index.txt".format(cert_base_path(),
-                                            ca_name)
+    if ca_dir is None:
+        ca_dir = '{0}/{1}'.format(_cert_base_path(), ca_name)
 
-    expire_date = cert.get_notAfter()
-    serial_number = cert.get_serial_number()
+    index_file = "{0}/index.txt".format(ca_dir)
 
-    #gotta prepend a /
+    expire_date = _four_digit_year_to_two_digit(
+            datetime.strptime(
+                cert.get_notAfter(),
+                four_digit_year_fmt)
+            )
+    serial_number = format(cert.get_serial_number(), 'X')
+
+    # gotta prepend a /
     subject = '/'
 
     # then we can add the rest of the subject
@@ -156,7 +272,28 @@ def _write_cert_to_database(ca_name, cert, cacert_path=None):
             )
     subject += '\n'
 
-    index_data = 'V\t{0}\t\t{1}\tunknown\t{2}'.format(
+    return (index_file, expire_date, serial_number, subject)
+
+
+def _write_cert_to_database(ca_name, cert, cacert_path=None, status='V'):
+    '''
+    write out the index.txt database file in the appropriate directory to
+    track certificates
+
+    ca_name
+        name of the CA
+    cert
+        certificate to be recorded
+    '''
+    set_ca_path(cacert_path)
+    ca_dir = '{0}/{1}'.format(cert_base_path(), ca_name)
+    index_file, expire_date, serial_number, subject = _get_basic_info(
+            ca_name,
+            cert,
+            ca_dir)
+
+    index_data = '{0}\t{1}\t\t{2}\tunknown\t{3}'.format(
+            status,
             expire_date,
             serial_number,
             subject
@@ -166,7 +303,7 @@ def _write_cert_to_database(ca_name, cert, cacert_path=None):
         ofile.write(index_data)
 
 
-def maybe_fix_ssl_version(ca_name, cacert_path=None):
+def maybe_fix_ssl_version(ca_name, cacert_path=None, ca_filename=None):
     '''
     Check that the X509 version is correct
     (was incorrectly set in previous salt versions).
@@ -176,6 +313,8 @@ def maybe_fix_ssl_version(ca_name, cacert_path=None):
         ca authority name
     cacert_path
         absolute path to ca certificates root directory
+    ca_filename
+        alternative filename for the CA
 
     CLI Example:
 
@@ -184,12 +323,16 @@ def maybe_fix_ssl_version(ca_name, cacert_path=None):
         salt '*' tls.maybe_fix_ssl_version test_ca /etc/certs
     '''
     set_ca_path(cacert_path)
-    certp = '{0}/{1}/{2}_ca_cert.crt'.format(
-        cert_base_path(),
+    if not ca_filename:
+        ca_filename = '{0}_ca_cert'.format(ca_name)
+    certp = '{0}/{1}/{2}.crt'.format(
+            cert_base_path(),
             ca_name,
-            ca_name)
-    ca_keyp = '{0}/{1}/{2}_ca_cert.key'.format(
-        cert_base_path(), ca_name, ca_name)
+            ca_filename)
+    ca_keyp = '{0}/{1}/{2}.key'.format(
+            cert_base_path(),
+            ca_name,
+            ca_filename)
     with salt.utils.fopen(certp) as fic:
         cert = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM,
                                                fic.read())
@@ -206,9 +349,9 @@ def maybe_fix_ssl_version(ca_name, cacert_path=None):
                 except Exception:
                     bits = 2048
                 try:
-                    days = (datetime.strptime(cert.get_notAfter(),
-                                                       '%Y%m%d%H%M%SZ') -
-                            datetime.now()).days
+                    days = (datetime.strptime(
+                        cert.get_notAfter(),
+                        '%Y%m%d%H%M%SZ') - datetime.now()).days
                 except (ValueError, TypeError):
                     days = 365
                 subj = cert.get_subject()
@@ -226,7 +369,7 @@ def maybe_fix_ssl_version(ca_name, cacert_path=None):
                     fixmode=True)
 
 
-def ca_exists(ca_name, cacert_path=None):
+def ca_exists(ca_name, cacert_path=None, ca_filename=None):
     '''
     Verify whether a Certificate Authority (CA) already exists
 
@@ -234,6 +377,8 @@ def ca_exists(ca_name, cacert_path=None):
         name of the CA
     cacert_path
         absolute path to ca certificates root directory
+    ca_filename
+        alternative filename for the CA
 
     CLI Example:
 
@@ -242,12 +387,16 @@ def ca_exists(ca_name, cacert_path=None):
         salt '*' tls.ca_exists test_ca /etc/certs
     '''
     set_ca_path(cacert_path)
-    certp = '{0}/{1}/{2}_ca_cert.crt'.format(
+    if not ca_filename:
+        ca_filename = '{0}_ca_cert'.format(ca_name)
+    certp = '{0}/{1}/{2}.crt'.format(
             cert_base_path(),
             ca_name,
-            ca_name)
+            ca_filename)
     if os.path.exists(certp):
-        maybe_fix_ssl_version(ca_name)
+        maybe_fix_ssl_version(ca_name,
+                              cacert_path=cacert_path,
+                              ca_filename=ca_filename)
         return True
     return False
 
@@ -288,6 +437,116 @@ def get_ca(ca_name, as_text=False, cacert_path=None):
     return certp
 
 
+def get_ca_signed_cert(ca_name,
+                       CN='localhost',
+                       as_text=False,
+                       cacert_path=None,
+                       cert_filename=None):
+    '''
+    Get the certificate path or content
+
+    ca_name
+        name of the CA
+    CN
+        common name of the certificate
+    as_text
+        if true, return the certificate content instead of the path
+    cacert_path
+        absolute path to certificates root directory
+    cert_filename
+        alternative filename for the certificate, useful when using special characters in the CN
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' tls.get_ca_signed_cert test_ca CN=localhost as_text=False cacert_path=/etc/certs
+    '''
+    set_ca_path(cacert_path)
+    if not cert_filename:
+        cert_filename = CN
+
+    certp = '{0}/{1}/certs/{2}.crt'.format(
+            cert_base_path(),
+            ca_name,
+            cert_filename)
+    if not os.path.exists(certp):
+        raise ValueError('Certificate does not exists for {0}'.format(CN))
+    else:
+        if as_text:
+            with salt.utils.fopen(certp) as fic:
+                certp = fic.read()
+    return certp
+
+
+def get_ca_signed_key(ca_name,
+                      CN='localhost',
+                      as_text=False,
+                      cacert_path=None,
+                      key_filename=None):
+    '''
+    Get the certificate path or content
+
+    ca_name
+        name of the CA
+    CN
+        common name of the certificate
+    as_text
+        if true, return the certificate content instead of the path
+    cacert_path
+        absolute path to certificates root directory
+    key_filename
+        alternative filename for the key, useful when using special characters
+        in the CN
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' tls.get_ca_signed_key \
+                test_ca CN=localhost \
+                as_text=False \
+                cacert_path=/etc/certs
+    '''
+    set_ca_path(cacert_path)
+    if not key_filename:
+        key_filename = CN
+
+    keyp = '{0}/{1}/certs/{2}.key'.format(
+            cert_base_path(),
+            ca_name,
+            key_filename)
+    if not os.path.exists(keyp):
+        raise ValueError('Certificate does not exists for {0}'.format(CN))
+    else:
+        if as_text:
+            with salt.utils.fopen(keyp) as fic:
+                keyp = fic.read()
+    return keyp
+
+
+def _check_onlyif_unless(onlyif, unless):
+    ret = None
+    retcode = __salt__['cmd.retcode']
+    if onlyif is not None:
+        if not isinstance(onlyif, string_types):
+            if not onlyif:
+                ret = {'comment': 'onlyif execution failed', 'result': True}
+        elif isinstance(onlyif, string_types):
+            if retcode(onlyif) != 0:
+                ret = {'comment': 'onlyif execution failed', 'result': True}
+                log.debug('onlyif execution failed')
+    if unless is not None:
+        if not isinstance(unless, string_types):
+            if unless:
+                ret = {'comment': 'unless execution succeeded', 'result': True}
+        elif isinstance(unless, string_types):
+            if retcode(unless) == 0:
+                ret = {'comment': 'unless execution succeeded', 'result': True}
+                log.debug('unless execution succeeded')
+    return ret
+
+
 def create_ca(ca_name,
               bits=2048,
               days=365,
@@ -300,7 +559,10 @@ def create_ca(ca_name,
               emailAddress='xyz@pdq.net',
               fixmode=False,
               cacert_path=None,
+              ca_filename=None,
               digest='sha256',
+              onlyif=None,
+              unless=None,
               replace=False):
     '''
     Create a Certificate Authority (CA)
@@ -308,25 +570,27 @@ def create_ca(ca_name,
     ca_name
         name of the CA
     bits
-        number of RSA key bits, Default is ``2048``
+        number of RSA key bits, default is 2048
     days
-        number of days the CA will be valid, Default is ``365``
+        number of days the CA will be valid, default is 365
     CN
-        common name in the request, Default is ``localhost``
+        common name in the request, default is "localhost"
     C
-        country, Default is ``US``
+        country, default is "US"
     ST
-        state, Default is ``Utah``
+        state, default is "Utah"
     L
-        locality, Default is ``Salt Lake City``
+        locality, default is "Centerville", the city where SaltStack originated
     O
-        organization, Default is ``SaltStack``
+        organization, default is "SaltStack"
     OU
-        organizational unit, Default is ``None``
+        organizational unit, default is None
     emailAddress
-        email address for the CA owner, Default is ``xyz@pdq.net``
+        email address for the CA owner, default is 'xyz@pdq.net'
     cacert_path
         absolute path to ca certificates root directory
+    ca_filename
+        alternative filename for the CA
     digest
         The message digest algorithm. Must be a string describing a digest
         algorithm supported by OpenSSL (by EVP_get_digestbyname, specifically).
@@ -340,16 +604,13 @@ def create_ca(ca_name,
     already exists, the function just returns assuming the CA certificate
     already exists.
 
-    If the following values were set:
-
-    .. code-block:: bash
+    If the following values were set::
 
         ca.cert_base_path='/etc/pki'
         ca_name='koji'
 
-    the resulting CA, and corresponding key, would be written in the following location:
-
-    .. code-block:: text
+    the resulting CA, and corresponding key, would be written in the following
+    location::
 
         /etc/pki/koji/koji_ca_cert.crt
         /etc/pki/koji/koji_ca_cert.key
@@ -360,15 +621,21 @@ def create_ca(ca_name,
 
         salt '*' tls.create_ca test_ca
     '''
+    status = _check_onlyif_unless(onlyif, unless)
+    if status is not None:
+        return None
+
     set_ca_path(cacert_path)
-    certp = '{0}/{1}/{2}_ca_cert.crt'.format(
-        cert_base_path(), ca_name, ca_name)
-    ca_keyp = '{0}/{1}/{2}_ca_cert.key'.format(
-        cert_base_path(), ca_name, ca_name)
-    if not replace and not fixmode and ca_exists(ca_name):
-        return (
-            'Certificate for CA named "{0}" '
-            'already exists').format(ca_name)
+
+    if not ca_filename:
+        ca_filename = '{0}_ca_cert'.format(ca_name)
+
+    certp = '{0}/{1}/{2}.crt'.format(
+        cert_base_path(), ca_name, ca_filename)
+    ca_keyp = '{0}/{1}/{2}.key'.format(
+        cert_base_path(), ca_name, ca_filename)
+    if not replace and not fixmode and ca_exists(ca_name, ca_filename=ca_filename):
+        return 'Certificate for CA named "{0}" already exists'.format(ca_name)
 
     if fixmode and not os.path.exists(certp):
         raise ValueError('{0} does not exists, can\'t fix'.format(certp))
@@ -449,12 +716,98 @@ def create_ca(ca_name,
 
     _write_cert_to_database(ca_name, ca)
 
-    ret = ('Created Private Key: "{0}/{1}/{1}_ca_cert.key." ').format(
-        cert_base_path(), ca_name)
-    ret += ('Created CA "{0}": "{1}/{0}/{0}_ca_cert.crt."').format(
-        ca_name, cert_base_path())
+    ret = ('Created Private Key: "{0}/{1}/{2}.key." ').format(
+        cert_base_path(), ca_name, ca_filename)
+    ret += ('Created CA "{0}": "{1}/{2}/{3}.crt."').format(
+        ca_name, cert_base_path(), ca_name, ca_filename)
 
     return ret
+
+
+def get_extensions(cert_type):
+    '''
+    Fetch X509 and CSR extension definitions from tls:extensions:
+    (common|server|client) or set them to standard defaults.
+
+    .. versionadded:: Beryllium
+
+    cert_type:
+        The type of certificate such as ``server`` or ``client``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' tls.get_extensions client
+
+    '''
+
+    ext = {}
+    if cert_type == '':
+        log.error('cert_type set to empty in tls_ca.get_extensions(); '
+                  'defaulting to ``server``')
+        cert_type = 'server'
+
+    try:
+        ext['common'] = __salt__['pillar.get']('tls.extensions:common', False)
+    except NameError as err:
+        log.debug(err)
+
+    if not ext['common'] or ext['common'] == '':
+        ext['common'] = {
+            'csr': {
+                'basicConstraints': 'CA:FALSE',
+            },
+            'cert': {
+                'authorityKeyIdentifier': 'keyid,issuer:always',
+                'subjectKeyIdentifier': 'hash',
+            },
+        }
+
+    try:
+        ext['server'] = __salt__['pillar.get']('tls.extensions:server', False)
+    except NameError as err:
+        log.debug(err)
+
+    if not ext['server'] or ext['server'] == '':
+        ext['server'] = {
+            'csr': {
+                'extendedKeyUsage': 'serverAuth',
+                'keyUsage': 'digitalSignature, keyEncipherment',
+            },
+            'cert': {},
+        }
+
+    try:
+        ext['client'] = __salt__['pillar.get']('tls.extensions:client', False)
+    except NameError as err:
+        log.debug(err)
+
+    if not ext['client'] or ext['client'] == '':
+        ext['client'] = {
+            'csr': {
+                'extendedKeyUsage': 'clientAuth',
+                'keyUsage': 'nonRepudiation, digitalSignature, keyEncipherment',
+            },
+            'cert': {},
+        }
+
+    # possible user-defined profile or a typo
+    if cert_type not in ext:
+        try:
+            ext[cert_type] = __salt__['pillar.get'](
+                'tls.extensions:{0}'.format(cert_type))
+        except NameError as e:
+            log.debug(
+                'pillar, tls:extensions:{0} not available or '
+                'not operating in a salt context\n{1}'.format(cert_type, e))
+
+    retval = ext['common']
+
+    for Use in retval:
+        retval[Use].update(ext[cert_type][Use])
+
+    return retval
 
 
 def create_csr(ca_name,
@@ -468,7 +821,12 @@ def create_csr(ca_name,
                emailAddress='xyz@pdq.net',
                subjectAltName=None,
                cacert_path=None,
+               ca_filename=None,
+               csr_path=None,
+               csr_filename=None,
                digest='sha256',
+               type_ext=False,
+               cert_type='server',
                replace=False):
     '''
     Create a Certificate Signing Request (CSR) for a
@@ -477,30 +835,68 @@ def create_csr(ca_name,
     ca_name
         name of the CA
     bits
-        number of RSA key bits, Default is ``2048``
+        number of RSA key bits, default is 2048
     CN
-        common name in the request, Default is ``localhost``
+        common name in the request, default is "localhost"
     C
-        country, Default is ``US``
+        country, default is "US"
     ST
-        state, Default is ``Utah``
+        state, default is "Utah"
     L
-        locality, Default is ``Salt Lake City``
+        locality, default is "Centerville", the city where SaltStack originated
     O
-        organization. Must the same as CA certificate or an error will be raised, Default is ``SaltStack``
+        organization, default is "SaltStack"
+        NOTE: Must the same as CA certificate or an error will be raised
     OU
-        organizational unit, Default is ``None``
+        organizational unit, default is None
     emailAddress
-        email address for the request, Default is ``xyz@pdq.net``
+        email address for the request, default is 'xyz@pdq.net'
     subjectAltName
         valid subjectAltNames in full form, e.g. to add DNS entry you would call
-        this function with this value:  **['DNS:myapp.foo.comm']**
-    cacert_path
-        absolute path to ca certificates root directory
-    digest
-        The message digest algorithm. Must be a string describing a digest
-        algorithm supported by OpenSSL (by EVP_get_digestbyname, specifically).
-        For example, "md5" or "sha1". Default: 'sha256'
+        this function with this value:
+
+        examples: ['DNS:somednsname.com',
+                'DNS:1.2.3.4',
+                'IP:1.2.3.4',
+                'IP:2001:4801:7821:77:be76:4eff:fe11:e51',
+                'email:me@i.like.pie.com']
+
+    .. note::
+        some libraries do not properly query IP: prefixes, instead looking
+        for the given req. source with a DNS: prefix. To be thorough, you
+        may want to include both DNS: and IP: entries if you are using
+        subjectAltNames for destinations for your TLS connections.
+            e.g.:
+                requests to https://1.2.3.4 will fail from python's
+                requests library w/out the second entry in the above list
+
+    .. versionadded:: Beryllium
+
+    cert_type
+        Specify the general certificate type. Can be either `server` or
+        `client`. Indicates the set of common extensions added to the CSR.
+
+        server: {
+           'basicConstraints': 'CA:FALSE',
+           'extendedKeyUsage': 'serverAuth',
+           'keyUsage': 'digitalSignature, keyEncipherment'
+        }
+
+        client: {
+           'basicConstraints': 'CA:FALSE',
+           'extendedKeyUsage': 'clientAuth',
+           'keyUsage': 'nonRepudiation, digitalSignature, keyEncipherment'
+        }
+
+    type_ext
+        boolean.  Whether or not to extend the filename with CN_[cert_type]
+        This can be useful if a server and client certificate are needed for
+        the same CN. Defaults to False to avoid introducing an unexpected file
+        naming pattern
+
+        The files normally named some_subject_CN.csr and some_subject_CN.key
+        will then be saved
+
     replace
         Replace this signing request even if it exists
 
@@ -509,18 +905,14 @@ def create_csr(ca_name,
     Writes out a Certificate Signing Request (CSR) If the file already
     exists, the function just returns assuming the CSR already exists.
 
-    If the following values were set:
-
-    .. code-block:: bash
+    If the following values were set::
 
         ca.cert_base_path='/etc/pki'
         ca_name='koji'
         CN='test.egavas.org'
 
     the resulting CSR, and corresponding key, would be written in the
-    following location:
-
-    .. code-block:: text
+    following location::
 
         /etc/pki/koji/certs/test.egavas.org.csr
         /etc/pki/koji/certs/test.egavas.org.key
@@ -533,19 +925,26 @@ def create_csr(ca_name,
     '''
     set_ca_path(cacert_path)
 
-    if not ca_exists(ca_name):
+    if not ca_filename:
+        ca_filename = '{0}_ca_cert'.format(ca_name)
+
+    if not ca_exists(ca_name, ca_filename=ca_filename):
         return ('Certificate for CA named "{0}" does not exist, please create '
                 'it first.').format(ca_name)
 
-    if not os.path.exists('{0}/{1}/certs/'.format(
-        cert_base_path(),
-        ca_name)
-    ):
-        os.makedirs("{0}/{1}/certs/".format(cert_base_path(),
-                                            ca_name))
+    if not csr_path:
+        csr_path = '{0}/{1}/certs/'.format(cert_base_path(), ca_name)
 
-    csr_f = '{0}/{1}/certs/{2}.csr'.format(cert_base_path(),
-                                           ca_name, CN)
+    if not os.path.exists(csr_path):
+        os.makedirs(csr_path)
+
+    CN_ext = '_{0}'.format(cert_type) if type_ext else ''
+
+    if not csr_filename:
+        csr_filename = '{0}{1}'.format(CN, CN_ext)
+
+    csr_f = '{0}/{1}.csr'.format(csr_path, csr_filename)
+
     if not replace and os.path.exists(csr_f):
         return 'Certificate Request "{0}" already exists'.format(csr_f)
 
@@ -563,17 +962,27 @@ def create_csr(ca_name,
     req.get_subject().CN = CN
     req.get_subject().emailAddress = emailAddress
 
+    extensions = get_extensions(cert_type)['csr']
+    extension_adds = []
+
+    for ext, value in extensions.items():
+        extension_adds.append(OpenSSL.crypto.X509Extension(ext, False, value))
+
     if subjectAltName:
-        req.add_extensions([
+        if isinstance(subjectAltName, str):
+            subjectAltName = [subjectAltName]
+
+        extension_adds.append(
             OpenSSL.crypto.X509Extension(
-                'subjectAltName', False, ", ".join(subjectAltName))])
+                'subjectAltName', False, ", ".join(subjectAltName)))
+
+    req.add_extensions(extension_adds)
     req.set_pubkey(key)
     req.sign(key, digest)
 
     # Write private key and request
-    with salt.utils.fopen('{0}/{1}/certs/{2}.key'.format(
-                                    cert_base_path(),
-                                    ca_name, CN), 'w+') as priv_key:
+    with salt.utils.fopen('{0}/{1}.key'.format(csr_path,
+                                               csr_filename), 'w+') as priv_key:
         priv_key.write(
                 OpenSSL.crypto.dump_privatekey(OpenSSL.crypto.FILETYPE_PEM, key)
                 )
@@ -586,16 +995,14 @@ def create_csr(ca_name,
                     )
                 )
 
-    ret = 'Created Private Key: "{0}/{1}/certs/{2}.key." '.format(
-                    cert_base_path(),
-                    ca_name,
-                    CN
+    ret = 'Created Private Key: "{0}{1}.key." '.format(
+                    csr_path,
+                    csr_filename
                     )
-    ret += 'Created CSR for "{0}": "{1}/{2}/certs/{3}.csr."'.format(
-                    ca_name,
-                    cert_base_path(),
-                    ca_name,
-                    CN
+    ret += 'Created CSR for "{0}": "{1}{2}.csr."'.format(
+                    CN,
+                    csr_path,
+                    csr_filename
                     )
 
     return ret
@@ -612,31 +1019,31 @@ def create_self_signed_cert(tls_dir='tls',
                             OU=None,
                             emailAddress='xyz@pdq.net',
                             cacert_path=None,
+                            cert_filename=None,
                             digest='sha256',
                             replace=False):
     '''
     Create a Self-Signed Certificate (CERT)
 
     tls_dir
-        location appended to the ca.cert_base_path, Default is ``tls``
+        location appended to the ca.cert_base_path, default is 'tls'
     bits
-        number of RSA key bits, Default is ``2048``
-    days
-        validity of certificate, Default is ``365``
+        number of RSA key bits, default is 2048
     CN
-        common name in the request, Default is ``localhost``
+        common name in the request, default is "localhost"
     C
-        country, Default is ``US``
+        country, default is "US"
     ST
-        state, Default is ``Utah``
+        state, default is "Utah"
     L
-        locality, Default is ``Salt Lake City``
+        locality, default is "Centerville", the city where SaltStack originated
     O
-        organization. Must the same as CA certificate or an error will be raised, Default is ``SaltStack``
+        organization, default is "SaltStack"
+        NOTE: Must the same as CA certificate or an error will be raised
     OU
-        organizational unit, Default is ``None``
+        organizational unit, default is None
     emailAddress
-        email address for the request, Default is ``xyz@pdq.net``
+        email address for the request, default is 'xyz@pdq.net'
     cacert_path
         absolute path to ca certificates root directory
     digest
@@ -651,27 +1058,28 @@ def create_self_signed_cert(tls_dir='tls',
     Writes out a Self-Signed Certificate (CERT). If the file already
     exists, the function just returns.
 
-    If the following values were set:
-
-    .. code-block:: bash
+    If the following values were set::
 
         ca.cert_base_path='/etc/pki'
         tls_dir='koji'
         CN='test.egavas.org'
 
     the resulting CERT, and corresponding key, would be written in the
-    following location:
-
-    .. code-block:: text
+    following location::
 
         /etc/pki/koji/certs/test.egavas.org.crt
         /etc/pki/koji/certs/test.egavas.org.key
 
-    CLI Examples:
+    CLI Example:
 
     .. code-block:: bash
 
         salt '*' tls.create_self_signed_cert
+
+    Passing options from the command line:
+
+    .. code-block:: bash
+
         salt 'minion' tls.create_self_signed_cert CN='test.mysite.org'
     '''
     set_ca_path(cacert_path)
@@ -680,11 +1088,14 @@ def create_self_signed_cert(tls_dir='tls',
         os.makedirs("{0}/{1}/certs/".format(cert_base_path(),
                                             tls_dir))
 
+    if not cert_filename:
+        cert_filename = CN
+
     if not replace and os.path.exists(
             '{0}/{1}/certs/{2}.crt'.format(cert_base_path(),
-                                           tls_dir, CN)
+                                           tls_dir, cert_filename)
             ):
-        return 'Certificate "{0}" already exists'.format(CN)
+        return 'Certificate "{0}" already exists'.format(cert_filename)
 
     key = OpenSSL.crypto.PKey()
     key.generate_key(OpenSSL.crypto.TYPE_RSA, bits)
@@ -713,7 +1124,7 @@ def create_self_signed_cert(tls_dir='tls',
     # Write private key and cert
     with salt.utils.fopen(
                 '{0}/{1}/certs/{2}.key'.format(cert_base_path(),
-                                               tls_dir, CN),
+                                               tls_dir, cert_filename),
                 'w+'
                 ) as priv_key:
         priv_key.write(
@@ -722,7 +1133,7 @@ def create_self_signed_cert(tls_dir='tls',
 
     with salt.utils.fopen('{0}/{1}/certs/{2}.crt'.format(cert_base_path(),
                                                          tls_dir,
-                                                         CN
+                                                         cert_filename
                                                          ), 'w+') as crt:
         crt.write(
                 OpenSSL.crypto.dump_certificate(
@@ -736,12 +1147,12 @@ def create_self_signed_cert(tls_dir='tls',
     ret = 'Created Private Key: "{0}/{1}/certs/{2}.key." '.format(
                     cert_base_path(),
                     tls_dir,
-                    CN
+                    cert_filename
                     )
     ret += 'Created Certificate: "{0}/{1}/certs/{2}.crt."'.format(
                     cert_base_path(),
                     tls_dir,
-                    CN
+                    cert_filename
                     )
 
     return ret
@@ -751,9 +1162,13 @@ def create_ca_signed_cert(ca_name,
                           CN,
                           days=365,
                           cacert_path=None,
+                          ca_filename=None,
+                          cert_path=None,
+                          cert_filename=None,
                           digest='sha256',
-                          replace=False,
-                          **extensions):
+                          cert_type=None,
+                          type_ext=False,
+                          replace=False):
     '''
     Create a Certificate (CERT) signed by a named Certificate Authority (CA)
 
@@ -768,9 +1183,23 @@ def create_ca_signed_cert(ca_name,
     CN
         common name matching the certificate signing request
     days
-        number of days certificate is valid, Default is ``365`` (1 year)
+        number of days certificate is valid, default is 365 (1 year)
+
     cacert_path
         absolute path to ca certificates root directory
+
+    ca_filename
+        alternative filename for the CA
+
+    cert_path
+        full path to the certificates directory
+
+    cert_filename
+        alternative filename for the certificate, useful when using special
+        characters in the CN. If this option is set it will override
+        the certificate filename output effects of ``cert_type``.
+        ``type_ext`` will be completely overridden.
+
     digest
         The message digest algorithm. Must be a string describing a digest
         algorithm supported by OpenSSL (by EVP_get_digestbyname, specifically).
@@ -780,25 +1209,39 @@ def create_ca_signed_cert(ca_name,
 
         .. versionadded:: 2015.5.1
 
-    extensions
-        X509 V3 certificate extension
+    cert_type
+        string. Either 'server' or 'client' (see create_csr() for details).
 
-    Writes out a Certificate (CERT). If the file already
-    exists, the function just returns assuming the CERT already exists.
+        If create_csr(type_ext=True) this function **must** be called with the
+        same cert_type so it can find the CSR file.
 
-    The CN *must* match an existing CSR generated by create_csr. If it
-    does not, this method does nothing.
+    .. note::
+        create_csr() defaults to cert_type='server'; therefore, if it was also
+        called with type_ext, cert_type becomes a required argument for
+        create_ca_signed_cert()
+
+    type_ext
+        bool. If set True, use ``cert_type`` as an extension to the CN when
+        formatting the filename.
+
+        e.g.: some_subject_CN_server.crt or some_subject_CN_client.crt
+
+        This facilitates the context where both types are required for the same
+        subject
+
+        If ``cert_filename`` is `not None`, setting ``type_ext`` has no
+        effect
 
     If the following values were set:
 
-    .. code-block:: bash
+    .. code-block:: text
 
         ca.cert_base_path='/etc/pki'
         ca_name='koji'
         CN='test.egavas.org'
 
-    the resulting signed certificate would be written in the
-    following location:
+    the resulting signed certificate would be written in the following
+    location:
 
     .. code-block:: text
 
@@ -810,99 +1253,135 @@ def create_ca_signed_cert(ca_name,
 
         salt '*' tls.create_ca_signed_cert test localhost
     '''
+    ret = {}
+
     set_ca_path(cacert_path)
 
-    crt_f = '{0}/{1}/certs/{2}.crt'.format(cert_base_path(),
-                                           ca_name, CN)
-    if not replace and os.path.exists(crt_f):
-        return 'Certificate "{0}" already exists'.format(CN)
+    if not ca_filename:
+        ca_filename = '{0}_ca_cert'.format(ca_name)
+
+    if not cert_path:
+        cert_path = '{0}/{1}/certs'.format(cert_base_path(), ca_name)
+
+    if type_ext:
+        if not cert_type:
+            log.error('type_ext = True but cert_type is unset. '
+                      'Certificate not written.')
+            return ret
+        elif cert_type:
+            CN_ext = '_{0}'.format(cert_type)
+    else:
+        CN_ext = ''
+
+    csr_filename = '{0}{1}'.format(CN, CN_ext)
+
+    if not cert_filename:
+        cert_filename = '{0}{1}'.format(CN, CN_ext)
+
+    if not replace and os.path.exists(
+            os.path.join(
+                os.path.sep.join('{0}/{1}/certs/{2}.crt'.format(
+                    cert_base_path(),
+                    ca_name,
+                    cert_filename).split('/')
+                )
+            )
+    ):
+        return 'Certificate "{0}" already exists'.format(cert_filename)
 
     try:
-        maybe_fix_ssl_version(ca_name)
-        with salt.utils.fopen('{0}/{1}/{2}_ca_cert.crt'.format(cert_base_path(),
-                                                               ca_name,
-                                                               ca_name)) as fhr:
+        maybe_fix_ssl_version(ca_name,
+                              cacert_path=cacert_path,
+                              ca_filename=ca_filename)
+        with salt.utils.fopen('{0}/{1}/{2}.crt'.format(cert_base_path(),
+                                                       ca_name,
+                                                       ca_filename)) as fhr:
             ca_cert = OpenSSL.crypto.load_certificate(
                     OpenSSL.crypto.FILETYPE_PEM, fhr.read()
                 )
-        with salt.utils.fopen('{0}/{1}/{2}_ca_cert.key'.format(cert_base_path(),
-                                                               ca_name,
-                                                               ca_name)) as fhr:
+        with salt.utils.fopen('{0}/{1}/{2}.key'.format(cert_base_path(),
+                                                       ca_name,
+                                                       ca_filename)) as fhr:
             ca_key = OpenSSL.crypto.load_privatekey(
                     OpenSSL.crypto.FILETYPE_PEM,
                     fhr.read()
                 )
     except IOError:
-        return 'There is no CA named "{0}"'.format(ca_name)
+        ret['retcode'] = 1
+        ret['comment'] = 'There is no CA named "{0}"'.format(ca_name)
+        return ret
 
     try:
-        with salt.utils.fopen('{0}/{1}/certs/{2}.csr'.format(cert_base_path(),
-                                                             ca_name,
-                                                             CN)) as fhr:
+        csr_path = '{0}/{1}.csr'.format(cert_path, csr_filename)
+        with salt.utils.fopen(csr_path) as fhr:
             req = OpenSSL.crypto.load_certificate_request(
                     OpenSSL.crypto.FILETYPE_PEM,
-                    fhr.read()
-                    )
+                    fhr.read())
     except IOError:
-        return 'There is no CSR that matches the CN "{0}"'.format(CN)
+        ret['retcode'] = 1
+        ret['comment'] = 'There is no CSR that matches the CN "{0}"'.format(
+                cert_filename)
+        return ret
 
     exts = []
     try:
-        # see: http://bazaar.launchpad.net/~exarkun/pyopenssl/master/revision/189
-        # support is there from quite a long time, but without API
-        # so we mimic the newly get_extensions method present in ultra
-        # recent pyopenssl distros
-        native_exts_obj = OpenSSL._util.lib.X509_REQ_get_extensions(req._req)
-        for i in _range(OpenSSL._util.lib.sk_X509_EXTENSION_num(native_exts_obj)):
-            ext = OpenSSL.crypto.X509Extension.__new__(OpenSSL.crypto.X509Extension)
-            ext._extension = OpenSSL._util.lib.sk_X509_EXTENSION_value(native_exts_obj, i)
-            exts.append(ext)
-    except Exception:
-        log.error('Support for extensions is not available, upgrade PyOpenSSL')
+        exts.extend(req.get_extensions())
+        log.debug('req.get_extensions() supported in pyOpenSSL {0}'.format(
+                        OpenSSL.__dict__.get('__version__', '')))
+    except AttributeError:
+        try:
+            # see: http://bazaar.launchpad.net/~exarkun/pyopenssl/master/revision/189
+            # support is there from quite a long time, but without API
+            # so we mimic the newly get_extensions method present in ultra
+            # recent pyopenssl distros
+            log.info('req.get_extensions() not supported in pyOpenSSL versions '
+                     'prior to 0.15. Switching to Dark Magic(tm) '
+                     ' Your version: {0}'.format(
+                         OpenSSL.__dict__.get('__version__', 'pre-2014')))
+
+            native_exts_obj = OpenSSL._util.lib.X509_REQ_get_extensions(
+                    req._req)
+            for i in _range(OpenSSL._util.lib.sk_X509_EXTENSION_num(
+                    native_exts_obj)):
+                ext = OpenSSL.crypto.X509Extension.__new__(
+                    OpenSSL.crypto.X509Extension)
+                ext._extension = OpenSSL._util.lib.sk_X509_EXTENSION_value(
+                    native_exts_obj,
+                    i)
+                exts.append(ext)
+        except Exception:
+            log.error('X509 extensions are unsupported in pyOpenSSL '
+                      'versions prior to 0.14. Upgrade required. Current '
+                      'version: {0}'.format(
+                          OpenSSL.__dict__.get('__version__', 'pre-2014'))
+                      )
 
     cert = OpenSSL.crypto.X509()
     cert.set_version(2)
     cert.set_subject(req.get_subject())
     cert.gmtime_adj_notBefore(0)
     cert.gmtime_adj_notAfter(int(days) * 24 * 60 * 60)
-    if exts:
-        cert.add_extensions(exts)
     cert.set_serial_number(_new_serial(ca_name, CN))
     cert.set_issuer(ca_cert.get_subject())
     cert.set_pubkey(req.get_pubkey())
-    extensions_list = []
-    for name, edata in six.iteritems(extensions):
-        if not isinstance(edata, dict):
-            continue
-        for opt in ['critical', 'options']:
-            if opt not in edata:
-                break
-        else:
-            extensions_list.append(OpenSSL.crypto.X509Extension(
-                                   name,
-                                   edata['critical'],
-                                   edata['options']))
-    cert.add_extensions(extensions_list)
+
+    cert.add_extensions(exts)
+
     cert.sign(ca_key, digest)
 
-    with salt.utils.fopen('{0}/{1}/certs/{2}.crt'.format(cert_base_path(),
-                                                         ca_name,
-                                                         CN), 'w+') as crt:
+    cert_full_path = '{0}/{1}.crt'.format(cert_path, cert_filename)
+
+    with salt.utils.fopen(cert_full_path, 'w+') as crt:
         crt.write(
-            OpenSSL.crypto.dump_certificate(
-                OpenSSL.crypto.FILETYPE_PEM,
-                cert
-                )
-            )
+            OpenSSL.crypto.dump_certificate(OpenSSL.crypto.FILETYPE_PEM, cert))
 
     _write_cert_to_database(ca_name, cert)
 
     return ('Created Certificate for "{0}": '
-            '"{1}/{2}/certs/{3}.crt"').format(
-                    ca_name,
-                    cert_base_path(),
-                    ca_name,
-                    CN
+            '"{1}/{2}.crt"').format(
+                    CN,
+                    cert_path,
+                    cert_filename
                     )
 
 
@@ -923,18 +1402,14 @@ def create_pkcs12(ca_name, CN, passphrase='', cacert_path=None, replace=False):
 
         .. versionadded:: 2015.5.1
 
-    If the following values were set:
-
-    .. code-block:: bash
+    If the following values were set::
 
         ca.cert_base_path='/etc/pki'
         ca_name='koji'
         CN='test.egavas.org'
 
     the resulting signed certificate would be written in the
-    following location:
-
-    .. code-block:: text
+    following location::
 
         /etc/pki/koji/certs/test.egavas.org.p12
 
@@ -1030,8 +1505,12 @@ def cert_info(cert_path, digest='sha256'):
         'subject': dict(cert.get_subject().get_components()),
         'issuer': dict(cert.get_issuer().get_components()),
         'serial_number': cert.get_serial_number(),
-        'not_before': time.mktime(datetime.strptime(cert.get_notBefore(), date_fmt).timetuple()),
-        'not_after': time.mktime(datetime.strptime(cert.get_notAfter(), date_fmt).timetuple()),
+        'not_before': time.mktime(datetime.strptime(
+            cert.get_notBefore(),
+            date_fmt).timetuple()),
+        'not_after': time.mktime(datetime.strptime(
+            cert.get_notAfter(),
+            date_fmt).timetuple()),
     }
 
     # add additional info if your version of pyOpenSSL supports it
@@ -1043,9 +1522,11 @@ def cert_info(cert_path, digest='sha256'):
 
     if 'subjectAltName' in ret.get('extensions', {}):
         valid_names = set()
-        for name in ret['extensions']['subjectAltName']._subjectAltNameString().split(", "):
+        for name in ret['extensions']['subjectAltName'] \
+                ._subjectAltNameString().split(", "):
             if not name.startswith('DNS:'):
-                log.error('Cert {0} has an entry ({1}) which does not start with DNS:'.format(cert_path, name))
+                log.error('Cert {0} has an entry ({1}) which does not start '
+                          'with DNS:'.format(cert_path, name))
             else:
                 valid_names.add(name[4:])
         ret['subject_alt_names'] = valid_names
@@ -1056,8 +1537,252 @@ def cert_info(cert_path, digest='sha256'):
     return ret
 
 
+def create_empty_crl(
+        ca_name,
+        cacert_path=None,
+        ca_filename=None,
+        crl_file=None):
+    '''
+    Create an empty Certificate Revocation List.
+
+    .. versionadded:: Beryllium
+
+    ca_name
+        name of the CA
+    cacert_path
+        absolute path to ca certificates root directory
+    ca_filename
+        alternative filename for the CA
+    crl_file
+        full path to the CRL file
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' tls.create_empty_crl ca_name='koji' \
+                ca_filename='ca' \
+                crl_file='/etc/openvpn/team1/crl.pem'
+    '''
+
+    set_ca_path(cacert_path)
+
+    if not ca_filename:
+        ca_filename = '{0}_ca_cert'.format(ca_name)
+
+    if not crl_file:
+        crl_file = '{0}/{1}/crl.pem'.format(
+                _cert_base_path(),
+                ca_name
+                )
+
+    if os.path.exists('{0}'.format(crl_file)):
+        return 'CRL "{0}" already exists'.format(crl_file)
+
+    try:
+        ca_cert = OpenSSL.crypto.load_certificate(
+                OpenSSL.crypto.FILETYPE_PEM,
+                salt.utils.fopen('{0}/{1}/{2}.crt'.format(
+                    cert_base_path(),
+                    ca_name,
+                    ca_filename
+                    )).read()
+                )
+        ca_key = OpenSSL.crypto.load_privatekey(
+                OpenSSL.crypto.FILETYPE_PEM,
+                salt.utils.fopen('{0}/{1}/{2}.key'.format(
+                    cert_base_path(),
+                    ca_name,
+                    ca_filename)).read()
+                )
+    except IOError:
+        return 'There is no CA named "{0}"'.format(ca_name)
+
+    crl = OpenSSL.crypto.CRL()
+    crl_text = crl.export(ca_cert, ca_key)
+
+    with salt.utils.fopen(crl_file, 'w') as f:
+        f.write(crl_text)
+
+    return 'Created an empty CRL: "{0}"'.format(crl_file)
+
+
+def revoke_cert(
+        ca_name,
+        CN,
+        cacert_path=None,
+        ca_filename=None,
+        cert_path=None,
+        cert_filename=None,
+        crl_file=None):
+    '''
+    Revoke a certificate.
+
+    .. versionadded:: Beryllium
+
+    ca_name
+        Name of the CA.
+
+    CN
+        Common name matching the certificate signing request.
+
+    cacert_path
+        Absolute path to ca certificates root directory.
+
+    ca_filename
+        Alternative filename for the CA.
+
+    cert_path
+        Path to the cert file.
+
+    cert_filename
+        Alternative filename for the certificate, useful when using special
+        characters in the CN.
+
+    crl_file
+        Full path to the CRL file.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' tls.revoke_cert ca_name='koji' \
+                ca_filename='ca' \
+                crl_file='/etc/openvpn/team1/crl.pem'
+
+    '''
+
+    set_ca_path(cacert_path)
+    ca_dir = '{0}/{1}'.format(cert_base_path(), ca_name)
+
+    if ca_filename is None:
+        ca_filename = '{0}_ca_cert'.format(ca_name)
+
+    if cert_path is None:
+        cert_path = '{0}/{1}/certs'.format(_cert_base_path(), ca_name)
+
+    if cert_filename is None:
+        cert_filename = '{0}'.format(CN)
+
+    try:
+        ca_cert = OpenSSL.crypto.load_certificate(
+                OpenSSL.crypto.FILETYPE_PEM,
+                salt.utils.fopen('{0}/{1}/{2}.crt'.format(
+                    cert_base_path(),
+                    ca_name,
+                    ca_filename
+                    )).read()
+                )
+        ca_key = OpenSSL.crypto.load_privatekey(
+                OpenSSL.crypto.FILETYPE_PEM,
+                salt.utils.fopen('{0}/{1}/{2}.key'.format(
+                    cert_base_path(),
+                    ca_name,
+                    ca_filename)).read()
+                )
+    except IOError:
+        return 'There is no CA named "{0}"'.format(ca_name)
+
+    try:
+        client_cert = OpenSSL.crypto.load_certificate(
+                OpenSSL.crypto.FILETYPE_PEM,
+                salt.utils.fopen('{0}/{1}.crt'.format(
+                    cert_path,
+                    cert_filename)).read()
+                )
+    except IOError:
+        return 'There is no client certificate named "{0}"'.format(CN)
+
+    index_file, expire_date, serial_number, subject = _get_basic_info(
+            ca_name,
+            client_cert,
+            ca_dir)
+
+    index_serial_subject = '{0}\tunknown\t{1}'.format(
+            serial_number,
+            subject)
+    index_v_data = 'V\t{0}\t\t{1}'.format(
+            expire_date,
+            index_serial_subject)
+    index_r_data_pattern = re.compile(
+            r"R\t" +
+            expire_date +
+            r"\t\d{12}Z\t" +
+            re.escape(index_serial_subject))
+    index_r_data = 'R\t{0}\t{1}\t{2}'.format(
+            expire_date,
+            _four_digit_year_to_two_digit(datetime.now()),
+            index_serial_subject)
+
+    ret = {}
+    with salt.utils.fopen(index_file) as f:
+        for line in f:
+            if index_r_data_pattern.match(line):
+                revoke_date = line.split('\t')[2]
+                try:
+                    datetime.strptime(revoke_date, two_digit_year_fmt)
+                    return ('"{0}/{1}.crt" was already revoked, '
+                            'serial number: {2}').format(
+                                    cert_path,
+                                    cert_filename,
+                                    serial_number
+                                    )
+                except ValueError:
+                    ret['retcode'] = 1
+                    ret['comment'] = ("Revocation date '{0}' does not match"
+                                      "format '{1}'".format(
+                                          revoke_date,
+                                          two_digit_year_fmt))
+                    return ret
+            elif index_serial_subject in line:
+                __salt__['file.replace'](
+                        index_file,
+                        index_v_data,
+                        index_r_data,
+                        backup=False)
+                break
+
+    crl = OpenSSL.crypto.CRL()
+
+    with salt.utils.fopen(index_file) as f:
+        for line in f:
+            if line.startswith('R'):
+                fields = line.split('\t')
+                revoked = OpenSSL.crypto.Revoked()
+                revoked.set_serial(fields[3])
+                revoke_date_2_digit = datetime.strptime(fields[2],
+                                                        two_digit_year_fmt)
+                revoked.set_rev_date(revoke_date_2_digit.strftime(
+                    four_digit_year_fmt))
+                crl.add_revoked(revoked)
+
+    crl_text = crl.export(ca_cert, ca_key)
+
+    if crl_file is None:
+        crl_file = '{0}/{1}/crl.pem'.format(
+                _cert_base_path(),
+                ca_name
+                )
+
+    if os.path.isdir(crl_file):
+        ret['retcode'] = 1
+        ret['comment'] = 'crl_file "{0}" is an existing directory'.format(
+                crl_file)
+        return ret
+
+    with salt.utils.fopen(crl_file, 'w') as f:
+        f.write(crl_text)
+
+    return ('Revoked Certificate: "{0}/{1}.crt", '
+            'serial number: {2}').format(
+                    cert_path,
+                    cert_filename,
+                    serial_number
+                    )
+
+
 if __name__ == '__main__':
-    #create_ca('koji', days=365, **cert_sample_meta)
+    # create_ca('koji', days=365, **cert_sample_meta)
     create_csr(
             'koji',
             CN='test_system',

--- a/salt/states/tls.py
+++ b/salt/states/tls.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
-Enforce state for SSL/TLS.
-=========================================================================
+Enforce state for SSL/TLS
+=========================
 
 '''
 
+# Import Python Libs
+from __future__ import absolute_import
 import time
 import datetime
 

--- a/tests/unit/modules/tls_test.py
+++ b/tests/unit/modules/tls_test.py
@@ -130,8 +130,8 @@ class TLSAddTestCase(TestCase):
         Test for retrieving cert base path
         '''
         ca_path = '/etc/tls'
-        mock = MagicMock(return_value=ca_path)
-        with patch.dict(tls.__salt__, {'config.option': mock}):
+        mock_opt = MagicMock(return_value=ca_path)
+        with patch.dict(tls.__salt__, {'config.option': mock_opt}):
             self.assertEqual(tls.cert_base_path(), ca_path)
 
     def test_set_ca_cert_path(self):
@@ -139,11 +139,11 @@ class TLSAddTestCase(TestCase):
         Test for setting the cert base path
         '''
         ca_path = '/tmp/ca_cert_test_path'
-        mock = MagicMock(return_value='/etc/tls')
+        mock_opt = MagicMock(return_value='/etc/tls')
         ret = {'ca.contextual_cert_base_path': '/tmp/ca_cert_test_path'}
-        with patch.dict(tls.__salt__, {'config.option': mock}):
+        with patch.dict(tls.__salt__, {'config.option': mock_opt}):
             tls.set_ca_path(ca_path)
-            self.assertDictEqual(tls.__opts__, ret)
+            self.assertEqual(tls.__context__, ret)
 
     @patch('os.path.exists', MagicMock(return_value=False))
     @patch('salt.modules.tls.maybe_fix_ssl_version',
@@ -154,8 +154,8 @@ class TLSAddTestCase(TestCase):
         '''
         ca_path = '/tmp/test_tls'
         ca_name = 'test_ca'
-        mock = MagicMock(return_value=ca_path)
-        with patch.dict(tls.__salt__, {'config.option': mock}):
+        mock_opt = MagicMock(return_value=ca_path)
+        with patch.dict(tls.__salt__, {'config.option': mock_opt}):
             self.assertFalse(tls.ca_exists(ca_name))
 
     @patch('os.path.exists', MagicMock(return_value=True))
@@ -167,8 +167,8 @@ class TLSAddTestCase(TestCase):
         '''
         ca_path = '/tmp/test_tls'
         ca_name = 'test_ca'
-        mock = MagicMock(return_value=ca_path)
-        with patch.dict(tls.__salt__, {'config.option': mock}):
+        mock_opt = MagicMock(return_value=ca_path)
+        with patch.dict(tls.__salt__, {'config.option': mock_opt}):
             self.assertTrue(tls.ca_exists(ca_name))
 
     @patch('os.path.exists', MagicMock(return_value=False))
@@ -180,8 +180,8 @@ class TLSAddTestCase(TestCase):
         '''
         ca_path = '/tmp/test_tls'
         ca_name = 'test_ca'
-        mock = MagicMock(return_value=ca_path)
-        with patch.dict(tls.__salt__, {'config.option': mock}):
+        mock_opt = MagicMock(return_value=ca_path)
+        with patch.dict(tls.__salt__, {'config.option': mock_opt}):
             self.assertRaises(ValueError, tls.get_ca, ca_name)
 
     @patch('os.path.exists', MagicMock(return_value=True))
@@ -194,8 +194,8 @@ class TLSAddTestCase(TestCase):
         '''
         ca_path = '/tmp/test_tls'
         ca_name = 'test_ca'
-        mock = MagicMock(return_value=ca_path)
-        with patch.dict(tls.__salt__, {'config.option': mock}):
+        mock_opt = MagicMock(return_value=ca_path)
+        with patch.dict(tls.__salt__, {'config.option': mock_opt}):
             self.assertEqual(tls.get_ca(ca_name, as_text=True),
                              _TLS_TEST_DATA['ca_cert'])
 
@@ -212,8 +212,8 @@ class TLSAddTestCase(TestCase):
             ca_path,
             ca_name,
             ca_name)
-        mock = MagicMock(return_value=ca_path)
-        with patch.dict(tls.__salt__, {'config.option': mock}):
+        mock_opt = MagicMock(return_value=ca_path)
+        with patch.dict(tls.__salt__, {'config.option': mock_opt}):
             self.assertEqual(tls.get_ca(ca_name), certp)
 
     @patch('os.path.exists', MagicMock(return_value=True))
@@ -236,7 +236,7 @@ class TLSAddTestCase(TestCase):
             'extensions': None,
             'fingerprint': ('96:72:B3:0A:1D:34:37:05:75:57:44:7E:08:81:A7:09:'
                             '0C:E1:8F:5F:4D:0C:49:CE:5B:D2:6B:45:D3:4D:FF:31'),
-            'serial_number': 284092004844685647925744086791559203700L,
+            'serial_number': 284092004844685647925744086791559203700,
             'subject': {
                 'C': 'US',
                 'CN': 'localhost',
@@ -294,8 +294,9 @@ class TLSAddTestCase(TestCase):
                 ca_name)
             ret = 'Created Private Key: "{0}." Created CA "{1}": "{2}."'.format(
                 certk, ca_name, certp)
-            mock = MagicMock(return_value=ca_path)
-            with patch.dict(tls.__salt__, {'config.option': mock}):
+            mock_opt = MagicMock(return_value=ca_path)
+            mock_ret = MagicMock(return_value=0)
+            with patch.dict(tls.__salt__, {'config.option': mock_opt, 'cmd.retcode': mock_ret}):
                 with patch.dict(tls.__opts__, {'hash_type': 'sha256',
                                                'cachedir': ca_path}):
                     self.assertEqual(
@@ -329,8 +330,9 @@ class TLSAddTestCase(TestCase):
                 ca_name)
             ret = 'Created Private Key: "{0}." Created CA "{1}": "{2}."'.format(
                 certk, ca_name, certp)
-            mock = MagicMock(return_value=ca_path)
-            with patch.dict(tls.__salt__, {'config.option': mock}):
+            mock_opt = MagicMock(return_value=ca_path)
+            mock_ret = MagicMock(return_value=0)
+            with patch.dict(tls.__salt__, {'config.option': mock_opt, 'cmd.retcode': mock_ret}):
                 with patch.dict(tls.__opts__, {'hash_type': 'sha256',
                                                'cachedir': ca_path}):
                     with patch.dict(_TLS_TEST_DATA['create_ca'],
@@ -367,9 +369,11 @@ class TLSAddTestCase(TestCase):
                 _TLS_TEST_DATA['create_ca']['CN'])
             ret = ('Created Private Key: "{0}." '
                    'Created CSR for "{1}": "{2}."').format(
-                       certk, ca_name, certp)
-            mock = MagicMock(return_value=ca_path)
-            with patch.dict(tls.__salt__, {'config.option': mock}):
+                       certk, _TLS_TEST_DATA['create_ca']['CN'], certp)
+            mock_opt = MagicMock(return_value=ca_path)
+            mock_ret = MagicMock(return_value=0)
+            mock_pgt = MagicMock(return_value=False)
+            with patch.dict(tls.__salt__, {'config.option': mock_opt, 'cmd.retcode': mock_ret, 'pillar.get': mock_pgt}):
                 with patch.dict(tls.__opts__, {'hash_type': 'sha256',
                                                'cachedir': ca_path}):
                     tls.create_ca(ca_name)
@@ -402,9 +406,11 @@ class TLSAddTestCase(TestCase):
                 _TLS_TEST_DATA['create_ca']['CN'])
             ret = ('Created Private Key: "{0}." '
                    'Created CSR for "{1}": "{2}."').format(
-                       certk, ca_name, certp)
-            mock = MagicMock(return_value=ca_path)
-            with patch.dict(tls.__salt__, {'config.option': mock}):
+                       certk, _TLS_TEST_DATA['create_ca']['CN'], certp)
+            mock_opt = MagicMock(return_value=ca_path)
+            mock_ret = MagicMock(return_value=0)
+            mock_pgt = MagicMock(return_value=False)
+            with patch.dict(tls.__salt__, {'config.option': mock_opt, 'cmd.retcode': mock_ret, 'pillar.get': mock_pgt}):
                 with patch.dict(tls.__opts__, {'hash_type': 'sha256',
                                                'cachedir': ca_path}):
                     with patch.dict(_TLS_TEST_DATA['create_ca'],
@@ -441,8 +447,8 @@ class TLSAddTestCase(TestCase):
             ret = ('Created Private Key: "{0}." '
                    'Created Certificate: "{1}."').format(
                        certk, certp)
-            mock = MagicMock(return_value=ca_path)
-            with patch.dict(tls.__salt__, {'config.option': mock}):
+            mock_opt = MagicMock(return_value=ca_path)
+            with patch.dict(tls.__salt__, {'config.option': mock_opt}):
                 with patch.dict(tls.__opts__, {'hash_type': 'sha256',
                                                'cachedir': ca_path}):
                     self.assertEqual(
@@ -476,8 +482,8 @@ class TLSAddTestCase(TestCase):
             ret = ('Created Private Key: "{0}." '
                    'Created Certificate: "{1}."').format(
                        certk, certp)
-            mock = MagicMock(return_value=ca_path)
-            with patch.dict(tls.__salt__, {'config.option': mock}):
+            mock_opt = MagicMock(return_value=ca_path)
+            with patch.dict(tls.__salt__, {'config.option': mock_opt}):
                 with patch.dict(tls.__opts__, {'hash_type': 'sha256',
                                                'cachedir': ca_path}):
                     self.assertEqual(
@@ -505,9 +511,11 @@ class TLSAddTestCase(TestCase):
                 ca_name,
                 _TLS_TEST_DATA['create_ca']['CN'])
             ret = 'Created Certificate for "{0}": "{1}"'.format(
-                ca_name, certp)
-            mock = MagicMock(return_value=ca_path)
-            with patch.dict(tls.__salt__, {'config.option': mock}):
+                _TLS_TEST_DATA['create_ca']['CN'], certp)
+            mock_opt = MagicMock(return_value=ca_path)
+            mock_ret = MagicMock(return_value=0)
+            mock_pgt = MagicMock(return_value=False)
+            with patch.dict(tls.__salt__, {'config.option': mock_opt, 'cmd.retcode': mock_ret, 'pillar.get': mock_pgt}):
                 with patch.dict(tls.__opts__, {'hash_type': 'sha256',
                                                'cachedir': ca_path}):
                     tls.create_ca(ca_name)
@@ -515,7 +523,7 @@ class TLSAddTestCase(TestCase):
                     self.assertEqual(
                         tls.create_ca_signed_cert(
                             ca_name,
-                            **_TLS_TEST_DATA['create_ca']),
+                            _TLS_TEST_DATA['create_ca']['CN']),
                         ret)
         finally:
             if os.path.isdir(ca_path):
@@ -536,22 +544,23 @@ class TLSAddTestCase(TestCase):
                 ca_name,
                 _TLS_TEST_DATA['create_ca']['CN'])
             ret = 'Created Certificate for "{0}": "{1}"'.format(
-                ca_name, certp)
-            mock = MagicMock(return_value=ca_path)
-            with patch.dict(tls.__salt__, {'config.option': mock}):
+                _TLS_TEST_DATA['create_ca']['CN'], certp)
+            mock_opt = MagicMock(return_value=ca_path)
+            mock_ret = MagicMock(return_value=0)
+            mock_pgt = MagicMock(return_value=False)
+            with patch.dict(tls.__salt__, {'config.option': mock_opt, 'cmd.retcode': mock_ret, 'pillar.get': mock_pgt}):
                 with patch.dict(tls.__opts__, {'hash_type': 'sha256',
                                                'cachedir': ca_path}):
-                    with patch.dict(_TLS_TEST_DATA['create_ca'],
-                                    {'replace': True}):
-                        tls.create_ca(ca_name)
-                        tls.create_csr(ca_name)
-                        tls.create_ca_signed_cert(ca_name,
-                                                  **_TLS_TEST_DATA['create_ca'])
-                        self.assertEqual(
-                            tls.create_ca_signed_cert(
-                                ca_name,
-                                **_TLS_TEST_DATA['create_ca']),
-                            ret)
+                    tls.create_ca(ca_name)
+                    tls.create_csr(ca_name)
+                    tls.create_ca_signed_cert(ca_name,
+                                              _TLS_TEST_DATA['create_ca']['CN'])
+                    self.assertEqual(
+                        tls.create_ca_signed_cert(
+                            ca_name,
+                            _TLS_TEST_DATA['create_ca']['CN'],
+                            replace=True),
+                        ret)
         finally:
             if os.path.isdir(ca_path):
                 shutil.rmtree(ca_path)
@@ -572,14 +581,16 @@ class TLSAddTestCase(TestCase):
                 _TLS_TEST_DATA['create_ca']['CN'])
             ret = 'Created PKCS#12 Certificate for "{0}": "{1}"'.format(
                 _TLS_TEST_DATA['create_ca']['CN'], certp)
-            mock = MagicMock(return_value=ca_path)
-            with patch.dict(tls.__salt__, {'config.option': mock}):
+            mock_opt = MagicMock(return_value=ca_path)
+            mock_ret = MagicMock(return_value=0)
+            mock_pgt = MagicMock(return_value=False)
+            with patch.dict(tls.__salt__, {'config.option': mock_opt, 'cmd.retcode': mock_ret, 'pillar.get': mock_pgt}):
                 with patch.dict(tls.__opts__, {'hash_type': 'sha256',
                                                'cachedir': ca_path}):
                     tls.create_ca(ca_name)
                     tls.create_csr(ca_name, **_TLS_TEST_DATA['create_ca'])
                     tls.create_ca_signed_cert(ca_name,
-                                              **_TLS_TEST_DATA['create_ca'])
+                                              _TLS_TEST_DATA['create_ca']['CN'])
                     self.assertEqual(
                         tls.create_pkcs12(ca_name,
                                           _TLS_TEST_DATA['create_ca']['CN'],
@@ -605,8 +616,10 @@ class TLSAddTestCase(TestCase):
                 _TLS_TEST_DATA['create_ca']['CN'])
             ret = 'Created PKCS#12 Certificate for "{0}": "{1}"'.format(
                 _TLS_TEST_DATA['create_ca']['CN'], certp)
-            mock = MagicMock(return_value=ca_path)
-            with patch.dict(tls.__salt__, {'config.option': mock}):
+            mock_opt = MagicMock(return_value=ca_path)
+            mock_ret = MagicMock(return_value=0)
+            mock_pgt = MagicMock(return_value=False)
+            with patch.dict(tls.__salt__, {'config.option': mock_opt, 'cmd.retcode': mock_ret, 'pillar.get': mock_pgt}):
                 with patch.dict(tls.__opts__, {'hash_type': 'sha256',
                                                'cachedir': ca_path}):
                     with patch.dict(_TLS_TEST_DATA['create_ca'],
@@ -614,7 +627,7 @@ class TLSAddTestCase(TestCase):
                         tls.create_ca(ca_name)
                         tls.create_csr(ca_name)
                         tls.create_ca_signed_cert(ca_name,
-                                                  **_TLS_TEST_DATA['create_ca'])
+                                                  _TLS_TEST_DATA['create_ca']['CN'])
                         tls.create_pkcs12(ca_name,
                                           _TLS_TEST_DATA['create_ca']['CN'],
                                           'password')


### PR DESCRIPTION
Merging in the develop bugfixes and the filename feature for inclusion in 2015.5.3

This also simplifies maintenance of tls_test as there's only one version that fits both branches.
