### PR TITLE
network module: import ipaddress the same way as in other modules

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -22,9 +22,9 @@ from salt.exceptions import CommandExecutionError
 # Import 3rd-party libs
 import salt.ext.six as six
 from salt.ext.six.moves import range  # pylint: disable=import-error,no-name-in-module,redefined-builtin
-try:
+if six.PY3:
     import ipaddress
-except ImportError:
+else:
     import salt.ext.ipaddress as ipaddress
 
 


### PR DESCRIPTION
Use `import ipaddress` only in python 3. In python 2, `import salt.ext.ipaddress` in order to avoid importing any third-party ipaddress module from `site-packages`.
