### PR TITLE
Fixing mysql list jobs

### DIFF
--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -69,35 +69,6 @@ def _walk_through(job_dir):
             yield jid, job, t_path, final
 
 
-def _format_job_instance(job):
-    '''
-    Format the job instance correctly
-    '''
-    ret = {'Function': job.get('fun', 'unknown-function'),
-           'Arguments': list(job.get('arg', [])),
-           # unlikely but safeguard from invalid returns
-           'Target': job.get('tgt', 'unknown-target'),
-           'Target-type': job.get('tgt_type', []),
-           'User': job.get('user', 'root')}
-
-    if 'metadata' in job:
-        ret['Metadata'] = job.get('metadata', {})
-    else:
-        if 'kwargs' in job:
-            if 'metadata' in job['kwargs']:
-                ret['Metadata'] = job['kwargs'].get('metadata', {})
-    return ret
-
-
-def _format_jid_instance(jid, job):
-    '''
-    Format the jid correctly
-    '''
-    ret = _format_job_instance(job)
-    ret.update({'StartTime': salt.utils.jid.jid_to_time(jid)})
-    return ret
-
-
 #TODO: add to returner docs-- this is a new one
 def prep_jid(nocache=False, passed_jid=None):
     '''
@@ -281,7 +252,7 @@ def get_jids():
     '''
     ret = {}
     for jid, job, _, _ in _walk_through(_job_dir()):
-        ret[jid] = _format_jid_instance(jid, job)
+        ret[jid] = salt.utils.jid.format_jid_instance(jid, job)
     return ret
 
 

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -277,7 +277,7 @@ def get_jid(jid):
 
 def get_jids():
     '''
-    Return a list of all job ids
+    Return a dict mapping all job ids to job information
     '''
     ret = {}
     for jid, job, _, _ in _walk_through(_job_dir()):

--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -359,14 +359,15 @@ def get_jids():
     '''
     with _get_serv(ret=None, commit=True) as cur:
 
-        sql = '''SELECT DISTINCT jid
+        sql = '''SELECT DISTINCT `jid`, `load`
                 FROM `jids`'''
 
         cur.execute(sql)
         data = cur.fetchall()
-        ret = []
+        ret = {}
         for jid in data:
-            ret.append(jid[0])
+            ret[jid[0]] = salt.utils.jid.format_jid_instance(jid[0],
+                                                             json.loads(jid[1]))
         return ret
 
 

--- a/salt/utils/jid.py
+++ b/salt/utils/jid.py
@@ -90,6 +90,7 @@ def jid_to_time(jid):
                                                 micro)
     return ret
 
+
 def format_job_instance(job):
     '''
     Format the job instance correctly

--- a/salt/utils/jid.py
+++ b/salt/utils/jid.py
@@ -89,3 +89,31 @@ def jid_to_time(jid):
                                                 second,
                                                 micro)
     return ret
+
+def format_job_instance(job):
+    '''
+    Format the job instance correctly
+    '''
+    ret = {'Function': job.get('fun', 'unknown-function'),
+           'Arguments': list(job.get('arg', [])),
+           # unlikely but safeguard from invalid returns
+           'Target': job.get('tgt', 'unknown-target'),
+           'Target-type': job.get('tgt_type', []),
+           'User': job.get('user', 'root')}
+
+    if 'metadata' in job:
+        ret['Metadata'] = job.get('metadata', {})
+    else:
+        if 'kwargs' in job:
+            if 'metadata' in job['kwargs']:
+                ret['Metadata'] = job['kwargs'].get('metadata', {})
+    return ret
+
+
+def format_jid_instance(jid, job):
+    '''
+    Format the jid correctly
+    '''
+    ret = format_job_instance(job)
+    ret.update({'StartTime': jid_to_time(jid)})
+    return ret


### PR DESCRIPTION
I'm doing three closely related things here:

1/ I've moved the `_format_jid_instance()` function from returners/local_cache.py to utils/jid.py so that it can be cleanly reused by other returners.  The clean formatting of the return dict seems a good thing to make consistent.

2/ I've changed the `get_jids()" function in returners/mysql.py to construct and return a dict of the jobs rather than a list of jids.  This brings it in line with the intended behaviour.

3/ I've updated the doc string on `get_jids()` in returners/local_cache.py to reflect the fact it returns a dict and not a list as it claimed.

This makes progress towards #22713
