### PR TITLE
Fixes for saltmod.function for salt-ssh

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -942,7 +942,7 @@ ARGS = {9}\n'''.format(self.minion_config,
         # 4. re-execute SHIM + command
         # 5. split SHIM results from command results
         # 6. return command results
-
+        self.argv = _convert_args(self.argv)
         log.debug('Performing shimmed, blocking command as follows:\n{0}'.format(' '.join(self.argv)))
         cmd_str = self._cmd_str()
         stdout, stderr, retcode = self.shim_cmd(cmd_str)
@@ -1207,3 +1207,18 @@ def ssh_version():
         return ret[1].split(',')[0].split('_')[1]
     except IndexError:
         return '2.0'
+
+
+def _convert_args(args):
+    '''
+    Take a list of args, and convert any dicts inside the list to keyword
+    args in the form of `key=value`, ready to be passed to salt-ssh
+    '''
+    converted = []
+    for arg in args:
+        if isinstance(arg, dict):
+            for key in list(arg.keys()):
+                converted.append('{0}={1}'.format(key, arg[key]))
+        else:
+            converted.append(arg)
+    return converted

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -935,13 +935,14 @@ ARGS = {9}\n'''.format(self.minion_config,
     def cmd_block(self, is_retry=False):
         '''
         Prepare the pre-check command to send to the subsystem
+
+        1. execute SHIM + command
+        2. check if SHIM returns a master request or if it completed
+        3. handle any master request
+        4. re-execute SHIM + command
+        5. split SHIM results from command results
+        6. return command results
         '''
-        # 1. execute SHIM + command
-        # 2. check if SHIM returns a master request or if it completed
-        # 3. handle any master request
-        # 4. re-execute SHIM + command
-        # 5. split SHIM results from command results
-        # 6. return command results
         self.argv = _convert_args(self.argv)
         log.debug('Performing shimmed, blocking command as follows:\n{0}'.format(' '.join(self.argv)))
         cmd_str = self._cmd_str()

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -404,6 +404,8 @@ def function(
         if mdata.get('failed', False):
             m_func = False
         else:
+            if 'return' in mdata and 'ret' not in mdata:
+                mdata['ret'] = mdata.pop('return')
             m_ret = mdata['ret']
             m_func = (not fail_function and True) or __salt__[fail_function](m_ret)
 


### PR DESCRIPTION
Salt-ssh needs its kwargs in the form `'key=value'`. We also need to use `return` as `ret` in the return structure as necessary.

Fixes #20615 
