### PR TITLE
Fixed Mine example for jinja code block

### DIFF
--- a/doc/topics/mine/index.rst
+++ b/doc/topics/mine/index.rst
@@ -107,7 +107,7 @@ to add them to the pool of load balanced servers.
 
     <...file contents snipped...>
 
-    {% for server, addrs in salt['mine.get']('roles:web', 'network.ip_addrs', expr_form='grain').items() %}
+    {% for server, addrs in salt['mine.get']('roles:web', 'network.ip_addrs', expr_form='pillar').items() %}
     server {{ server }} {{ addrs[0] }}:80 check
     {% endfor %}
 


### PR DESCRIPTION
In the Mine example, it has the `mine_functions:` deployed via a pillar file, but in the examples `/srv/salt/haproxy_config` snipit for the jinja code block, it used `expr_form='grain'` to access that mine function, which I couldn't get to work, until I changed it to `expr_form='pillar'`. Hopefully this is the right fix.  I found this example went back to `2014.7` branch, so PR is for that.
