### PR TITLE
fix target rule, remove unneeded quotation mark

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -10,7 +10,6 @@ import re
 import sys
 import uuid
 import shlex
-import string
 
 # Import salt libs
 import salt.utils
@@ -345,10 +344,7 @@ def build_rule(table=None, chain=None, command=None, position='', full=None, fam
     for after_jump_argument in after_jump_arguments:
         if after_jump_argument in kwargs:
             value = kwargs[after_jump_argument]
-            if any(ws_char in str(value) for ws_char in string.whitespace):
-                after_jump.append('--{0} "{1}"'.format(after_jump_argument, value))
-            else:
-                after_jump.append('--{0} {1}'.format(after_jump_argument, value))
+            after_jump.append('--{0} {1}'.format(after_jump_argument, value))
             del kwargs[after_jump_argument]
 
     if 'log' in kwargs:


### PR DESCRIPTION
Salt version:

```
$ salt-call --version
salt-call 2015.5.2 (Lithium)
```

It is not valid to add quotation mark when target with argument, such as:

```
--jump CT --notrack
--jump DNAT --to-destination 192.168.0.1:8888
```

fix for this commit: aeb91b000cde8a5a3eda9e59a743ae47732d7952

this is the error log in my env:

```
$ salt-call state.sls common.service.iptables saltenv=base test=true
[ERROR   ] Command '/sbin/iptables -t raw -C PREROUTING --in-interface lo --jump "CT --notrack"' failed with return code: 2
[ERROR   ] output: iptables v1.4.21: Invalid target name `CT --notrack'
Try `iptables -h' or 'iptables --help' for more information.
[ERROR   ] Command '/sbin/iptables -t raw -C OUTPUT --out-interface lo --jump "CT --notrack"' failed with return code: 2
[ERROR   ] output: iptables v1.4.21: Invalid target name `CT --notrack'
Try `iptables -h' or 'iptables --help' for more information.

local:
----------
          ID: notrack_on_lo_in
    Function: iptables.append
      Result: None
     Comment: iptables rule for notrack_on_lo_in needs to be set (/sbin/iptables --wait -t raw -A PREROUTING  --in-interface lo --jump "CT --notrack") for ipv4
     Changes:
----------
          ID: notrack_on_lo_out
    Function: iptables.append
      Result: None
     Comment: iptables rule for notrack_on_lo_out needs to be set (/sbin/iptables --wait -t raw -A OUTPUT  --out-interface lo --jump "CT --notrack") for ipv4
     Changes:
```
