### PR TITLE
[2015.5] Remove __kwarg__ from salt-ssh keyword args

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1219,6 +1219,8 @@ def _convert_args(args):
     for arg in args:
         if isinstance(arg, dict):
             for key in list(arg.keys()):
+                if key == '__kwarg__':
+                    continue
                 converted.append('{0}={1}'.format(key, arg[key]))
         else:
             converted.append(arg)


### PR DESCRIPTION
Currently this keyword arg is actually being removed as a side effect
of salt.utils.args.parse_input. If that ever changed then this code
would break. Prevent that future breakage. (I considered removing that
side effect but wasn't sure what else it would break so I held off for
now)
