### PR TITLE
Add support for presence change of a locally connected minion

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -534,6 +534,11 @@ class CkMinions(object):
             if not os.path.isdir(cdir):
                 return minions
             addrs = salt.utils.network.local_port_tcp(int(self.opts['publish_port']))
+            if '127.0.0.1' in addrs or '0.0.0.0' in addrs:
+                # Add in possible ip addresses of a locally connected minion
+                addrs.discard('127.0.0.1')
+                addrs.discard('0.0.0.0')
+                addrs.update(set(salt.utils.network.ip_addrs()))
             if subset:
                 search = subset
             else:


### PR DESCRIPTION
If a local minion is connected, then: salt.utils.network.local_port_tcp()
will return a set that includes '127.0.0.1'. However, '127.0.0.1' is
excluded from the matching algorithm (rightfully so). So add in the
possible ipv4 addresses that could be used the same way the grains data
that we are trying to match calculates it on the minion, which is using:
salt.utils.network.ip_addrs().

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
