### PR TITLE
additional logging in state.py module

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -473,6 +473,7 @@ def highstate(test=None,
         salt '*' state.highstate pillar="{foo: 'Foo!', bar: 'Bar!'}"
     '''
     if _disabled(['highstate']):
+        log.debug('Salt highstate run is disabled. To re-enable, run state.enable highstate')
         ret = {
             'name': 'Salt highstate run is disabled. To re-enable, run state.enable highstate',
             'result': 'False',
@@ -619,6 +620,8 @@ def sls(mods,
         disabled = _disabled([mods])
 
     if disabled:
+        for state in disabled:
+            log.debug('Salt state {0} run is disabled. To re-enable, run state.enable {0}'.format(state))
         __context__['retcode'] = 1
         return disabled
 


### PR DESCRIPTION
Adding some logging statement to give feedback when states, including highstate, are disabled.  Useful when running from scheduler.
