### PR TITLE
Add 'm_state' to 'm_'-prefixed arguments of 'module.run'

### DIFF
--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -50,6 +50,7 @@ with ``m_``:
 * fun
 * name
 * names
+* state
 
 For example:
 
@@ -178,6 +179,9 @@ def run(name, **kwargs):
         elif arg == 'fun':
             if 'm_fun' in kwargs:
                 defaults[arg] = kwargs.pop('m_fun')
+        elif arg == 'state':
+            if 'm_state' in kwargs:
+                defaults[arg] = kwargs.pop('m_state')
         if arg in kwargs:
             defaults[arg] = kwargs.pop(arg)
     missing = set()
@@ -188,6 +192,8 @@ def run(name, **kwargs):
             rarg = 'm_fun'
         elif arg == 'names':
             rarg = 'm_names'
+        elif arg == 'state':
+            rarg = 'm_state'
         else:
             rarg = arg
         if rarg not in kwargs and arg not in defaults:

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -43,7 +43,15 @@ the execution module function being executed:
 
 Due to how the state system works, if a module function accepts an
 argument called, ``name``, then ``m_name`` must be used to specify that
-argument, to avoid a collision with the ``name`` argument. For example:
+argument, to avoid a collision with the ``name`` argument.
+
+Here is a list of keywords hidden by the state system, which must be prefixed
+with ``m_``:
+* fun
+* name
+* names
+
+For example:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
I wanted to call the module `partition.set` from a state, which has a argument called `state`.
However, this argument is replaced by the state name in the internals of state.py.
Therefore, we need a mechanism for `state` similar to the one documented for `name` and enable `m_state`.

Besides, I was missing an exhaustive list of these arguments, so I propose to add it to the documentation.
