### PR TITLE
Changes to various schedule related functions to ensure persistence.

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -637,7 +637,7 @@ class Minion(MinionBase):
                     'jid_include': True,
                     'maxrunning': 2
                 }
-            })
+            }, persist=True)
 
         # add master_alive job if enabled
         if self.opts['master_alive_interval'] > 0:
@@ -651,7 +651,7 @@ class Minion(MinionBase):
                     'kwargs': {'master': self.opts['master'],
                                'connected': True}
                 }
-            })
+            }, persist=True)
 
         self.grains_cache = self.opts['grains']
 
@@ -1339,27 +1339,30 @@ class Minion(MinionBase):
         name = data.get('name', None)
         schedule = data.get('schedule', None)
         where = data.get('where', None)
+        persist = data.get('persist', None)
 
         if func == 'delete':
-            self.schedule.delete_job(name)
+            self.schedule.delete_job(name, persist)
         elif func == 'add':
-            self.schedule.add_job(schedule)
+            self.schedule.add_job(schedule, persist)
         elif func == 'modify':
-            self.schedule.modify_job(name, schedule, where)
+            self.schedule.modify_job(name, schedule, persist, where)
         elif func == 'enable':
             self.schedule.enable_schedule()
         elif func == 'disable':
             self.schedule.disable_schedule()
         elif func == 'enable_job':
-            self.schedule.enable_job(name, where)
+            self.schedule.enable_job(name, persist, where)
         elif func == 'run_job':
             self.schedule.run_job(name)
         elif func == 'disable_job':
-            self.schedule.disable_job(name, where)
+            self.schedule.disable_job(name, persist, where)
         elif func == 'reload':
             self.schedule.reload(schedule)
         elif func == 'list':
             self.schedule.list(where)
+        elif func == 'save_schedule':
+            self.schedule.save_schedule()
 
     def manage_beacons(self, package):
         '''

--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -194,17 +194,17 @@ def delete(name, **kwargs):
         ret['comment'] = 'Job: {0} would be deleted from schedule.'.format(name)
         ret['result'] = True
     else:
+        persist = True
+        if 'persist' in kwargs:
+            persist = kwargs['persist']
+
         if name in list_(show_all=True, where='opts', return_yaml=False):
-            event_data = {'name': name, 'func': 'delete'}
+            event_data = {'name': name, 'func': 'delete', 'persist': persist}
         elif name in list_(show_all=True, where='pillar', return_yaml=False):
-            event_data = {'name': name, 'where': 'pillar', 'func': 'delete'}
+            event_data = {'name': name, 'where': 'pillar', 'func': 'delete', 'persist': False}
         else:
             ret['comment'] = 'Job {0} does not exist.'.format(name)
             return ret
-
-        event_data['persist'] = True
-        if 'persist' in kwargs:
-            event_data['persist'] = kwargs['persist']
 
         try:
             eventer = salt.utils.event.get_event('minion', opts=__opts__)
@@ -446,14 +446,20 @@ def modify(name, **kwargs):
     if 'test' in kwargs and kwargs['test']:
         ret['comment'] = 'Job: {0} would be modified in schedule.'.format(name)
     else:
-        if name in list_(show_all=True, where='opts', return_yaml=False):
-            event_data = {'name': name, 'schedule': _new, 'func': 'modify'}
-        elif name in list_(show_all=True, where='pillar', return_yaml=False):
-            event_data = {'name': name, 'schedule': _new, 'where': 'pillar', 'func': 'modify'}
-
-        event_data['persist'] = True
+        persist = True
         if 'persist' in kwargs:
-            event_data['persist'] = kwargs['persist']
+            persist = kwargs['persist']
+        if name in list_(show_all=True, where='opts', return_yaml=False):
+            event_data = {'name': name,
+                          'schedule': _new,
+                          'func': 'modify',
+                          'persist': persist}
+        elif name in list_(show_all=True, where='pillar', return_yaml=False):
+            event_data = {'name': name,
+                          'schedule': _new,
+                          'where': 'pillar',
+                          'func': 'modify',
+                          'persist': False}
 
         out = __salt__['event.fire'](event_data, 'manage_schedule')
         if out:
@@ -524,18 +530,18 @@ def enable_job(name, **kwargs):
     if 'test' in __opts__ and __opts__['test']:
         ret['comment'] = 'Job: {0} would be enabled in schedule.'.format(name)
     else:
+        persist = True
+        if 'persist' in kwargs:
+            persist = kwargs['persist']
+
         if name in list_(show_all=True, where='opts', return_yaml=False):
-            event_data = {'name': name, 'func': 'enable_job'}
+            event_data = {'name': name, 'func': 'enable_job', 'persist': persist}
         elif name in list_(show_all=True, where='pillar', return_yaml=False):
-            event_data = {'name': name, 'where': 'pillar', 'func': 'enable_job'}
+            event_data = {'name': name, 'where': 'pillar', 'func': 'enable_job', 'persist': False}
         else:
             ret['comment'] = 'Job {0} does not exist.'.format(name)
             ret['result'] = False
             return ret
-
-        event_data['persist'] = True
-        if 'persist' in kwargs:
-            event_data['persist'] = kwargs['persist']
 
         try:
             eventer = salt.utils.event.get_event('minion', opts=__opts__)
@@ -579,18 +585,18 @@ def disable_job(name, **kwargs):
     if 'test' in kwargs and kwargs['test']:
         ret['comment'] = 'Job: {0} would be disabled in schedule.'.format(name)
     else:
+        persist = True
+        if 'persist' in kwargs:
+            persist = kwargs['persist']
+
         if name in list_(show_all=True, where='opts', return_yaml=False):
-            event_data = {'name': name, 'func': 'disable_job'}
+            event_data = {'name': name, 'func': 'disable_job', 'persist': persist}
         elif name in list_(show_all=True, where='pillar'):
-            event_data = {'name': name, 'where': 'pillar', 'func': 'disable_job'}
+            event_data = {'name': name, 'where': 'pillar', 'func': 'disable_job', 'persist': False}
         else:
             ret['comment'] = 'Job {0} does not exist.'.format(name)
             ret['result'] = False
             return ret
-
-        event_data['persist'] = True
-        if 'persist' in kwargs:
-            event_data['persist'] = kwargs['persist']
 
         try:
             eventer = salt.utils.event.get_event('minion', opts=__opts__)

--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -637,13 +637,13 @@ def save(**kwargs):
                 event_ret = eventer.get_event(tag='/salt/minion/minion_schedule_saved', wait=30)
                 if event_ret and event_ret['complete']:
                     ret['result'] = True
-                    ret['comment'] = 'Schedule has be saved.'
+                    ret['comment'] = 'Schedule (non-pillar items) saved.'
                 else:
                     ret['result'] = False
-                    ret['comment'] = 'Failed to save schedule'
+                    ret['comment'] = 'Failed to save schedule.'
         except KeyError:
             # Effectively a no-op, since we can't really return without an event system
-            ret['comment'] = 'Event module not available. Schedule enable job failed.'
+            ret['comment'] = 'Event module not available. Schedule save failed.'
     return ret
 
 

--- a/salt/states/schedule.py
+++ b/salt/states/schedule.py
@@ -166,6 +166,8 @@ def present(name,
     return_config
         The alternative configuration to use for returner configuration options.
 
+    persist
+        Whether the job should persist between minion restarts, defaults to True.
     '''
 
     ret = {'name': name,
@@ -227,10 +229,9 @@ def absent(name, **kwargs):
     name
         The unique name that is given to the scheduled job.
 
+    persist
+        Whether the job should persist between minion restarts, defaults to True.
     '''
-    ### NOTE: The keyword arguments in **kwargs are ignored in this state, but
-    ###       cannot be removed from the function definition, otherwise the use
-    ###       of unsupported arguments will result in a traceback.
 
     ret = {'name': name,
            'result': True,
@@ -265,10 +266,10 @@ def enabled(name, **kwargs):
     name
         The unique name that is given to the scheduled job.
 
+    persist
+        Whether the job should persist between minion restarts, defaults to True.
+
     '''
-    ### NOTE: The keyword arguments in **kwargs are ignored in this state, but
-    ###       cannot be removed from the function definition, otherwise the use
-    ###       of unsupported arguments will result in a traceback.
 
     ret = {'name': name,
            'result': True,
@@ -303,10 +304,10 @@ def disabled(name, **kwargs):
     name
         The unique name that is given to the scheduled job.
 
+    persist
+        Whether the job should persist between minion restarts, defaults to True.
+
     '''
-    ### NOTE: The keyword arguments in **kwargs are ignored in this state, but
-    ###       cannot be removed from the function definition, otherwise the use
-    ###       of unsupported arguments will result in a traceback.
 
     ret = {'name': name,
            'result': True,

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -347,7 +347,7 @@ class Schedule(object):
         except (IOError, OSError):
             log.error('Failed to persist the updated schedule')
 
-    def delete_job(self, name, persist, where=None):
+    def delete_job(self, name, persist=True, where=None):
         '''
         Deletes a job from the scheduler.
         '''
@@ -375,7 +375,7 @@ class Schedule(object):
         if persist:
             self.persist()
 
-    def add_job(self, data, persist):
+    def add_job(self, data, persist=True):
         '''
         Adds a new job to the scheduler. The format is the same as required in
         the configuration file. See the docs on how YAML is interpreted into
@@ -407,7 +407,7 @@ class Schedule(object):
         if persist:
             self.persist()
 
-    def enable_job(self, name, persist, where=None):
+    def enable_job(self, name, persist=True, where=None):
         '''
         Enable a job in the scheduler.
         '''
@@ -428,7 +428,7 @@ class Schedule(object):
         if persist:
             self.persist()
 
-    def disable_job(self, name, persist, where=None):
+    def disable_job(self, name, persist=True, where=None):
         '''
         Disable a job in the scheduler.
         '''
@@ -449,7 +449,7 @@ class Schedule(object):
         if persist:
             self.persist()
 
-    def modify_job(self, name, schedule, persist, where=None):
+    def modify_job(self, name, schedule, persist=True, where=None):
         '''
         Modify a job in the scheduler.
         '''

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -340,13 +340,14 @@ class Schedule(object):
                 salt.syspaths.CONFIG_DIR,
                 'minion.d',
                 '_schedule.conf')
+        log.debug('Persisting schedule')
         try:
             with salt.utils.fopen(schedule_conf, 'wb+') as fp_:
                 fp_.write(yaml.dump({'schedule': self.opts['schedule']}))
         except (IOError, OSError):
             log.error('Failed to persist the updated schedule')
 
-    def delete_job(self, name, where=None):
+    def delete_job(self, name, persist, where=None):
         '''
         Deletes a job from the scheduler.
         '''
@@ -371,7 +372,10 @@ class Schedule(object):
         if name in self.intervals:
             del self.intervals[name]
 
-    def add_job(self, data):
+        if persist:
+            self.persist()
+
+    def add_job(self, data, persist):
         '''
         Adds a new job to the scheduler. The format is the same as required in
         the configuration file. See the docs on how YAML is interpreted into
@@ -400,9 +404,10 @@ class Schedule(object):
         evt.fire_event({'complete': True, 'schedule': self.opts['schedule']},
                        tag='/salt/minion/minion_schedule_add_complete')
 
-        self.persist()
+        if persist:
+            self.persist()
 
-    def enable_job(self, name, where=None):
+    def enable_job(self, name, persist, where=None):
         '''
         Enable a job in the scheduler.
         '''
@@ -420,7 +425,10 @@ class Schedule(object):
 
         log.info('Enabling job {0} in scheduler'.format(name))
 
-    def disable_job(self, name, where=None):
+        if persist:
+            self.persist()
+
+    def disable_job(self, name, persist, where=None):
         '''
         Disable a job in the scheduler.
         '''
@@ -438,18 +446,24 @@ class Schedule(object):
 
         log.info('Disabling job {0} in scheduler'.format(name))
 
-    def modify_job(self, name, schedule, where=None):
+        if persist:
+            self.persist()
+
+    def modify_job(self, name, schedule, persist, where=None):
         '''
         Modify a job in the scheduler.
         '''
         if where == 'pillar':
             if name in self.opts['pillar']['schedule']:
-                self.delete_job(name, where=where)
+                self.delete_job(name, persist, where=where)
             self.opts['pillar']['schedule'][name] = schedule
         else:
             if name in self.opts['schedule']:
-                self.delete_job(name, where=where)
+                self.delete_job(name, persist, where=where)
             self.opts['schedule'][name] = schedule
+
+        if persist:
+            self.persist()
 
     def run_job(self, name):
         '''
@@ -546,6 +560,17 @@ class Schedule(object):
         evt = salt.utils.event.get_event('minion', opts=self.opts)
         evt.fire_event({'complete': True, 'schedule': schedule},
                        tag='/salt/minion/minion_schedule_list_complete')
+
+    def save_schedule(self):
+        '''
+        Save the current schedule
+        '''
+        self.persist()
+
+        # Fire the complete event back along with the list of schedule
+        evt = salt.utils.event.get_event('minion', opts=self.opts)
+        evt.fire_event({'complete': True},
+                       tag='/salt/minion/minion_schedule_saved')
 
     def handle_func(self, func, data):
         '''

--- a/tests/unit/modules/schedule_test.py
+++ b/tests/unit/modules/schedule_test.py
@@ -252,7 +252,7 @@ class ScheduleTestCase(TestCase):
         '''
         Test if it save all scheduled jobs on the minion.
         '''
-        comm1 = 'Schedule (non-pillar items) saved to ///schedule.conf.'
+        comm1 = 'Schedule (non-pillar items) saved.'
         with patch.dict(schedule.__opts__, {'config_dir': '', 'schedule': {},
                                             'default_include': '/tmp',
                                             'sock_dir': SOCK_DIR}):

--- a/tests/unit/utils/schedule_test.py
+++ b/tests/unit/utils/schedule_test.py
@@ -107,7 +107,7 @@ class ScheduleTestCase(TestCase):
         '''
         self.schedule.opts = {'pillar': {'schedule': {'name': {'enabled': 'foo'}}},
                               'sock_dir': SOCK_DIR}
-        Schedule.enable_job(self.schedule, 'name', where='pillar')
+        Schedule.enable_job(self.schedule, 'name', persist=False, where='pillar')
         del self.schedule.opts['sock_dir']
         self.assertTrue(self.schedule.opts['pillar']['schedule']['name']['enabled'])
 
@@ -129,7 +129,7 @@ class ScheduleTestCase(TestCase):
         '''
         self.schedule.opts = {'pillar': {'schedule': {'name': {'enabled': 'foo'}}},
                               'sock_dir': SOCK_DIR}
-        Schedule.disable_job(self.schedule, 'name', where='pillar')
+        Schedule.disable_job(self.schedule, 'name', persist=False, where='pillar')
         del self.schedule.opts['sock_dir']
         self.assertFalse(self.schedule.opts['pillar']['schedule']['name']['enabled'])
 
@@ -153,7 +153,7 @@ class ScheduleTestCase(TestCase):
         ret = {'pillar': {'schedule': {'name': {'foo': 'bar'}}}}
         self.schedule.opts = {'pillar': {'schedule': {'name': {'foo': 'bar'}}},
                               'sock_dir': SOCK_DIR}
-        Schedule.modify_job(self.schedule, 'name', schedule, where='pillar')
+        Schedule.modify_job(self.schedule, 'name', schedule, persist=False, where='pillar')
         del self.schedule.opts['sock_dir']
         self.assertEqual(self.schedule.opts, ret)
 


### PR DESCRIPTION
Adding the default option to persist the configured schedule into /etc/salt/minion.d/_schedule.conf to all schedule related functions in the execution module.  
Adding documention to the state module showing how to control persistence.  
Reworked the save function in the schedule execution module to follow suit and save to /etc/salt/minion.d/_schedule.conf as well.
