### PR TITLE
Improved error reporting for failed states

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -831,6 +831,9 @@ class State(object):
                         data['__sls__']
                         )
                     )
+                reason = self.states.missing_fun_string(full)
+                if reason:
+                    errors.append('Reason: {0}'.format(reason))
             else:
                 errors.append(
                         'Specified state \'{0}\' was not found'.format(

--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -28,7 +28,7 @@ def __virtual__():
     '''
     Only load if the npm module is available in __salt__
     '''
-    return 'npm' if 'npm.list' in __salt__ else False
+    return 'npm' if 'npm.list' in __salt__ else False, '\'npm\' binary not found on system'
 
 
 def installed(name,


### PR DESCRIPTION
If a state module could not be loaded, show the user the reason why.

Closes #22385
