### PR TITLE
Update aliases.py

### DIFF
--- a/salt/modules/aliases.py
+++ b/salt/modules/aliases.py
@@ -144,12 +144,14 @@ def has_target(alias, target):
     if target == '':
         raise SaltInvocationError('target can not be an empty string')
     aliases = list_aliases()
-    if alias in aliases and isinstance(target, list):
+    if alias not in aliases:
+        return False
+    if isinstance(target, list):
         for item in target:
             if item not in aliases[alias]:
                 return False
         target = ', '.join(target)
-    return alias in aliases and target in aliases[alias]
+    return target == aliases[alias]
 
 
 def set_target(alias, target):


### PR DESCRIPTION
Fixes #24537. Also note: the new behavior overwrites any prior superset targets with the current set. For example, given an /etc/aliases entry "a: b,c,d" and the salt state specified as "a: { alias.present: [ target: b ] }", the /etc/aliases entry is changed to "a: b". This seems okay to me, given that the documentation states "If the alias exists but the target differs from the previous entry, the target(s) will be overwritten."
