### PR TITLE
Fixed warning salt.loaded.int.module.rpmbuild.__virtual__() is wrongly returning `None`.

### DIFF
--- a/salt/modules/rpmbuild.py
+++ b/salt/modules/rpmbuild.py
@@ -29,7 +29,7 @@ def __virtual__():
     '''
     if salt.utils.which('mock'):
         return __virtualname__
-
+    return False
 
 def _mk_tree():
     '''

--- a/salt/modules/rpmbuild.py
+++ b/salt/modules/rpmbuild.py
@@ -31,6 +31,7 @@ def __virtual__():
         return __virtualname__
     return False
 
+
 def _mk_tree():
     '''
     Create the rpm build tree


### PR DESCRIPTION
Added return False to the `rmbuild.__virtual__()` to fix warning from the minion log file:

```
2015-06-13 03:59:59,764 [salt.loader                                ][WARNING ][5662] salt.loaded.int.module.rpmbuild.__virtual__() is wrongly returning `None`. It should either return `True`, `False` or a new name. If you're the developer of the module 'rpmbuild', please fix this.
```
