### PR TITLE
fix to returners configuration

### DIFF
--- a/salt/returners/__init__.py
+++ b/salt/returners/__init__.py
@@ -131,9 +131,9 @@ def _fetch_option(cfg, ret_config, virtualname, attr_name):
     if not ret_config:
         # Using the default configuration key
         if isinstance(cfg, dict):
-            return c_cfg.get(default_cfg_key, cfg.get(default_cfg_key))
+            return c_cfg.get(attr_name, cfg.get(default_cfg_key))
         else:
-            return c_cfg.get(default_cfg_key, cfg(default_cfg_key))
+            return c_cfg.get(attr_name, cfg(default_cfg_key))
 
     # Using ret_config to override the default configuration key
     ret_cfg = cfg('{0}.{1}'.format(ret_config, virtualname), {})


### PR DESCRIPTION
Fixing an issue when configuring returners and specifing the configuration as a dictionary.
