### PR TITLE
Fix #23289 Workaround for pyzmq's inability to unregister sockets sometimes

### DIFF
--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -702,8 +702,10 @@ class AsyncReqMessageClient(object):
     def destroy(self):
         if hasattr(self, 'stream'):
             # TODO: Optionally call stream.close() on newer pyzmq? It is broken on some.
-            self.stream.io_loop.remove_handler(self.stream.socket)
             self.stream.socket.close()
+            self.stream.io_loop.remove_handler(self.stream.socket)
+            # set this to None, more hacks for messed up pyzmq
+            self.stream.socket = None
             self.socket.close()
         self.context.term()
 


### PR DESCRIPTION
The stack trace @UtahDave was seeing was due to us trying to double unregister the socket from the ioloop. This code block exists soely to work with pyzmq 13.x (which does it wrong-- and doesn't work). To maintain compabitility the terribleness must continue-- so we'll magically set the socket to None after we close and unregister it.
