### PR TITLE
Fixes #24586

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -894,11 +894,10 @@ class LocalClient(object):
         # iterator for this job's return
         if self.opts['order_masters']:
             # If we are a MoM, we need to gather expected minions from downstreams masters.
-            ret_iter = self.get_returns_no_block(jid, gather_errors=gather_errors, tags_regex='^syndic/.*/{0}'.format(jid))
+            jinfo_iter = self.get_returns_no_block(jid, gather_errors=gather_errors, tags_regex='^syndic/.*/{0}'.format(jid))
         else:
-            ret_iter = self.get_returns_no_block(jid, gather_errors=gather_errors)
-        # iterator for the info of this job
-        jinfo_iter = []
+            jinfo_iter = self.get_returns_no_block(jid, gather_errors=gather_errors)
+
         timeout_at = time.time() + timeout
         gather_syndic_wait = time.time() + self.opts['syndic_wait']
         # are there still minions running the job out there
@@ -911,7 +910,7 @@ class LocalClient(object):
         )
         while True:
             # Process events until timeout is reached or all minions have returned
-            for raw in ret_iter:
+            for raw in jinfo_iter:
                 # if we got None, then there were no events
                 if raw is None:
                     break


### PR DESCRIPTION
As described in #24586 calling cmd.script results in an infinite loop.
This behaviour was reproducible both using the api and the cli. It seems
to be caused by a job iterator (ret_iter) not being updated as part of a
loop. Thus, the associated opt out functionality was never executed.
This change-set fixes this issue for me, but it seems to also introduce
some new behaviour. In my particular case a salt.client.LocalClient.cmd
call with the module 'puppet_win.fact' only seems to return correct
values after having increased its time-out.
Therefore I ask for people to thoroughly review this fix before
introducing it into the code base. I am not able to correctly foresee or
understand the side effects it might have, since I am not familiar with
the salt implementation.
