### PR TITLE
Remove cloud-requirements.txt

### DIFF
--- a/cloud-requirements.txt
+++ b/cloud-requirements.txt
@@ -1,1 +1,0 @@
-apache-libcloud >= 0.14.0


### PR DESCRIPTION
apache-libcloud is not longer a hard-dep for salt-cloud
