### PR TITLE
Remove requirements/cloud.txt

### DIFF
--- a/requirements/cloud.txt
+++ b/requirements/cloud.txt
@@ -1,1 +1,0 @@
-apache-libcloud >= 0.14.0


### PR DESCRIPTION
apache-libcloud is not longer a hard-dep for salt-cloud, so this
file isn't needed.
