### PR TITLE
boolean option `bare` for modules.gpg.(en|de)crypt()

### DIFF
--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -977,7 +977,8 @@ def encrypt(user=None,
             output=None,
             sign=None,
             use_passphrase=False,
-            gnupghome=None):
+            gnupghome=None
+            bare=False):
     '''
     Encrypt a message or file
 
@@ -1006,6 +1007,10 @@ def encrypt(user=None,
 
     gnupghome
         Specify the location where GPG related files are stored.
+
+    bare
+        If True, return the (armored) encrypted block as a string without the
+        standard comment/res dict
 
     CLI Example:
 
@@ -1052,13 +1057,19 @@ def encrypt(user=None,
         raise SaltInvocationError('filename or text must be passed.')
 
     if result.ok:
-        if output:
-            ret['comment'] = 'Encrypted data has been written to {0}'.format(output)
+        if not bare:
+            if output:
+                ret['comment'] = 'Encrypted data has been written to {0}'.format(output)
+            else:
+                ret['comment'] = result.data
         else:
-            ret['comment'] = result.data
+            ret = result.data
     else:
-        ret['res'] = False
-        ret['comment'] = '{0}.\nPlease check the salt-minion log.'.format(result.status)
+        if not bare:
+            ret['res'] = False
+            ret['comment'] = '{0}.\nPlease check the salt-minion log.'.format(result.status)
+        else:
+            ret = False
         log.error(result.stderr)
     return ret
 
@@ -1068,7 +1079,8 @@ def decrypt(user=None,
             filename=None,
             output=None,
             use_passphrase=False,
-            gnupghome=None):
+            gnupghome=None
+            bare=False):
     '''
     Decrypt a message or file
 
@@ -1090,6 +1102,10 @@ def decrypt(user=None,
 
     gnupghome
         Specify the location where GPG related files are stored.
+
+    bare
+        If True, return the (armored) decrypted block as a string without the
+        standard comment/res dict
 
     CLI Example:
 
@@ -1126,12 +1142,20 @@ def decrypt(user=None,
         raise SaltInvocationError('filename or text must be passed.')
 
     if result.ok:
-        if output:
-            ret['comment'] = 'Decrypted data has been written to {0}'.format(output)
+        if not bare:
+            if output:
+                ret['comment'] = 'Decrypted data has been written to {0}'.format(output)
+            else:
+                ret['comment'] = result.data
         else:
-            ret['comment'] = result.data
+            ret = result.data
     else:
-        ret['res'] = False
-        ret['comment'] = '{0}.\nPlease check the salt-minion log.'.format(result.status)
+        if not bare:
+            ret['res'] = False
+            ret['comment'] = '{0}.\nPlease check the salt-minion log.'.format(result.status)
+        else:
+            ret = False
+
         log.error(result.stderr)
+
     return ret

--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -977,7 +977,7 @@ def encrypt(user=None,
             output=None,
             sign=None,
             use_passphrase=False,
-            gnupghome=None
+            gnupghome=None,
             bare=False):
     '''
     Encrypt a message or file
@@ -1079,7 +1079,7 @@ def decrypt(user=None,
             filename=None,
             output=None,
             use_passphrase=False,
-            gnupghome=None
+            gnupghome=None,
             bare=False):
     '''
     Decrypt a message or file


### PR DESCRIPTION
Changes made to the return values of modules.gpg in support of gpg 
states resulted in dictionary-structured return values for gpg.encrypt
and gpg.decrypt. For modules that use gpg.*() programmatically, a
consistent gpg.(en|un)crypt()['comment'] is required to deal with the
new structure.

This commit adds `bare` (boolean) to give (prettier) access to the
pre-11/14 gpg function signatures which returned a string value or
False.

Default is False as to not mess with the new state modules
functionality.
