### PR TITLE
Fix stacktrace when `--summary` is used

### DIFF
--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -237,7 +237,7 @@ class SaltCMD(parsers.SaltCMDOptionParser):
         not_return_counter = 0
         not_return_minions = []
         for each_minion in ret:
-            minion_ret = ret[each_minion].get('ret')
+            minion_ret = ret[each_minion]
             if (
                     isinstance(minion_ret, string_types)
                     and minion_ret.startswith("Minion did not return")


### PR DESCRIPTION
Fix access of `ret[]` in `_print_returns_summary()`.

Fixes #24111.
