### PR TITLE
Add 2015.5 codename to version numbers docs

### DIFF
--- a/doc/topics/releases/version_numbers.rst
+++ b/doc/topics/releases/version_numbers.rst
@@ -23,6 +23,9 @@ Assigned codenames:
 
 - Hydrogen: ``2014.1.0``
 - Helium: ``2014.7.0``
+- Lithium: ``2015.5``
+- Beryllium: ``TBD``
+- Boron: ``TBD``
 
 Example
 -------


### PR DESCRIPTION
Added Lithium, Beryllium, Boron to version_numbers doc. Also added a trailing newline.
