### PR TITLE
Improve Upstart enable/disable handling

### DIFF
--- a/salt/modules/upstart.py
+++ b/salt/modules/upstart.py
@@ -44,6 +44,7 @@ from __future__ import absolute_import
 import glob
 import os
 import re
+import itertools
 
 # Import salt libs
 import salt.utils

--- a/salt/modules/upstart.py
+++ b/salt/modules/upstart.py
@@ -172,11 +172,12 @@ def _upstart_is_disabled(name):
     in /etc/init/[name].conf.
     '''
     files = ['/etc/init/{0}.conf'.format(name), '/etc/init/{0}.override'.format(name)]
-    for file_name in filter(os.path.isfile, files):
+    for file_name in itertools.ifilter(os.path.isfile, files):
         with salt.utils.fopen(file_name) as fp_:
-            if re.search('^\s*manual', fp_.read(), re.MULTILINE):
+            if re.search(r'^\s*manual', fp_.read(), re.MULTILINE):
                 return True
     return False
+
 
 def _upstart_is_enabled(name):
     '''
@@ -457,9 +458,9 @@ def _upstart_enable(name):
         return _upstart_is_enabled(name)
     override = '/etc/init/{0}.override'.format(name)
     files = ['/etc/init/{0}.conf'.format(name), override]
-    for file_name in filter(os.path.isfile, files):
+    for file_name in itertools.ifilter(os.path.isfile, files):
         with salt.utils.fopen(file_name, 'r+') as fp_:
-            new_text = re.sub('^\s*manual\n?', '', fp_.read(), 0, re.MULTILINE)
+            new_text = re.sub(r'^\s*manual\n?', '', fp_.read(), 0, re.MULTILINE)
             fp_.seek(0)
             fp_.write(new_text)
             fp_.truncate()


### PR DESCRIPTION
- Properly search for manual stanza instead of just existence of override files
- Handle "manual" stanzas in both override and regular conf files
- Do not try to disable/enable already disabled/enabled services
- Do not overwrite override files (use append) on disable
- Only delete empty override files on enable
