### PR TITLE
add get_route function to network module

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -1122,7 +1122,7 @@ def get_route(ip):
     if __grains__['kernel'] == 'Linux':
         cmd = 'ip route get {0}'.format(ip)
         out = __salt__['cmd.run'](cmd, python_shell=True)
-        regexp = re.compile(r'(via\s+(?P<gateway>[\w\.:]+))?\s+dev\s+(?P<interface>[\w\W]+)\s+src\s+(?P<source>[\w\.:]+)')
+        regexp = re.compile(r'(via\s+(?P<gateway>[\w\.:]+))?\s+dev\s+(?P<interface>[\w\.\:]+)\s+.*src\s+(?P<source>[\w\.:]+)')
         m = regexp.search(out.splitlines()[0])
         ret = {
             'destination': ip,

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -1108,3 +1108,29 @@ def default_route(family=None):
                 ret.append(route)
 
     return ret
+
+
+def get_route(ip):
+    '''
+    Return routing information for given destination ip
+
+    CLI Example::
+
+        salt '*' network.get_route 10.10.10.10
+    '''
+
+    if __grains__['kernel'] == 'Linux':
+        cmd = 'ip route get {0}'.format(ip)
+        out = __salt__['cmd.run'](cmd, python_shell=True)
+        regexp = re.compile(r'(via\s+(?P<gateway>[\w\.:]+))?\s+dev\s+(?P<interface>[\w\W]+)\s+src\s+(?P<source>[\w\.:]+)')
+        m = regexp.search(out.splitlines()[0])
+        ret = {
+            'destination': ip,
+            'gateway': m.group('gateway'),
+            'interface': m.group('interface'),
+            'source': m.group('source')}
+
+        return ret
+    else:
+        raise CommandExecutionError('Not yet supported on this platform')
+

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -1133,4 +1133,3 @@ def get_route(ip):
         return ret
     else:
         raise CommandExecutionError('Not yet supported on this platform')
-


### PR DESCRIPTION
It would be nice to have a function which return routing information with help of 'ip route get <ip>' command.

Examples:

```
# salt-call network.get_route 127.0.0.1
local:
    ----------
    destination:
        127.0.0.1
    gateway:
        None
    interface:
        lo
    source:
        127.0.0.1

# salt-call network.get_route 10.10.10.10
local:
    ----------
    destination:
        10.10.10.10
    gateway:
        172.17.42.1
    interface:
        eth0
    source:
        172.17.0.115

# salt-call network.get_route 172.17.0.116
local:
    ----------
    destination:
        172.17.0.116
    gateway:
        None
    interface:
        eth0
    source:
        172.17.0.115

# salt-call network.get_route fe80::42:acff:fe11:73
local:
    ----------
    destination:
        fe80::42:acff:fe11:73
    gateway:
        None
    interface:
        lo
    source:
        fe80::42:acff:fe11:73
```
