### PR TITLE
add windows specfic default for multiprocessing

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -52,8 +52,10 @@ if salt.utils.is_windows():
     # support in ZeroMQ, we want the default to be something that has a
     # chance of working.
     _DFLT_IPC_MODE = 'tcp'
+    _DFLT_MULTIPROCESSING_MODE = False
 else:
     _DFLT_IPC_MODE = 'ipc'
+    _DFLT_MULTIPROCESSING_MODE = True
 
 FLO_DIR = os.path.join(
         os.path.dirname(__file__),
@@ -754,7 +756,7 @@ DEFAULT_MINION_OPTS = {
     'open_mode': False,
     'auto_accept': True,
     'autosign_timeout': 120,
-    'multiprocessing': True,
+    'multiprocessing': _DFLT_MULTIPROCESSING_MODE,
     'mine_interval': 60,
     'ipc_mode': _DFLT_IPC_MODE,
     'ipv6': False,


### PR DESCRIPTION
multiprocessing has to be set to false on windows and should be done automatically like it is done with ipc_mode

see comment by @lorengordon [here](https://github.com/saltstack/salt/issues/23854#issuecomment-112411332)
