### PR TITLE
Fix loader call in pyobjects

### DIFF
--- a/salt/renderers/pyobjects.py
+++ b/salt/renderers/pyobjects.py
@@ -291,16 +291,10 @@ def load_states():
     states = {}
 
     # the loader expects to find pillar & grain data
-    __opts__['grains'] = __grains__
+    __opts__['grains'] = salt.loader.grains(__opts__)
     __opts__['pillar'] = __pillar__
-
-    lazy_states = salt.loader.LazyLoader(
-        salt.loader._module_dirs(__opts__, 'states', 'states'),
-        __opts__,
-        tag='states',
-        pack={'__salt__': __salt__},
-        virtual_enable=True,
-    )
+    lazy_funcs = salt.loader.minion_mods(__opts__)
+    lazy_states = salt.loader.states(__opts__, lazy_funcs)
 
     # TODO: some way to lazily do this? This requires loading *all* state modules
     for key, func in six.iteritems(lazy_states):

--- a/tests/unit/pyobjects_test.py
+++ b/tests/unit/pyobjects_test.py
@@ -22,7 +22,6 @@ from salt.template import compile_template
 from salt.utils.odict import OrderedDict
 from salt.utils.pyobjects import (StateFactory, State, Registry,
                                   SaltObject, InvalidFunction, DuplicateState)
-
 File = StateFactory('file')
 Service = StateFactory('service')
 


### PR DESCRIPTION
Fixes bug introduced in #24668. We need a full grains listing if we're going to use `__virtual__` because otherwise we won't load certain modules and states.
