### PR TITLE
Remove doc references to obsolete minion opt

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -431,21 +431,6 @@ behavior is to have time-frame within all minions try to reconnect.
 
     recon_randomize: True
 
-.. conf_minion:: dns_check
-
-``dns_check``
--------------
-
-Default: ``True``
-
-When healing, a dns_check is run. This is to make sure that the originally
-resolved dns has not changed. If this is something that does not happen in your
-environment, set this value to ``False``.
-
-.. code-block:: yaml
-
-    dns_check: True
-
 .. conf_minion:: cache_sreqs
 
 ``cache_sreqs``


### PR DESCRIPTION
The `dns_check` minion config option was removed in 2015.5.0 but was still in the minion docs
