### PR TITLE
Fixing spacing typo

### DIFF
--- a/doc/topics/best_practices.rst
+++ b/doc/topics/best_practices.rst
@@ -320,7 +320,7 @@ modification of static values:
         'Debian': {
             'server': 'apache2',
             'service': 'apache2',
-             'conf': '/etc/apache2/apache.conf',
+            'conf': '/etc/apache2/apache.conf',
         },
         'RedHat': {
             'server': 'httpd',
@@ -376,7 +376,7 @@ to be broken into two states.
         'Debian': {
             'server': 'apache2',
             'service': 'apache2',
-             'conf': '/etc/apache2/apache.conf',
+            'conf': '/etc/apache2/apache.conf',
         },
         'RedHat': {
             'server': 'httpd',


### PR DESCRIPTION
The best practices guide has a small typo in the example. 
