### PR TITLE
Fix stacktrace in get_cli_returns()

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1282,8 +1282,12 @@ class LocalClient(object):
                 break
             if 'minions' in raw.get('data', {}):
                 continue
-            found.add(raw['id'])
-            ret = {raw['id']: {'ret': raw['return']}}
+            try:
+                found.add(raw['id'])
+                ret = {raw['id']: {'ret': raw['return']}}
+            except KeyError:
+                # Ignore other erroneous messages
+                continue
             if 'out' in raw:
                 ret[raw['id']]['out'] = raw['out']
             yield ret


### PR DESCRIPTION
Backport fix for #18994, present in 2015.5

Fixes #21318.
