### PR TITLE
Adding a couple tests for the mysql.grant_exists

### DIFF
--- a/tests/unit/modules/mysql_test.py
+++ b/tests/unit/modules/mysql_test.py
@@ -198,12 +198,44 @@ class MySQLTestCase(TestCase):
                        'testuser'
         )
 
-    @skipIf(True, 'TODO: Mock up user_grants()')
-    def test_grant_exists(self):
+    def test_grant_exists_true(self):
         '''
-        Test to ensure a basic query for grants works in the mysql exec module
+        Test to ensure that we can find a grant that exists
         '''
-        self._test_call(mysql.grant_exists, '', 'SELECT,INSERT,UPDATE', 'database.*', 'frank')
+        mock_grants = [
+            "GRANT USAGE ON *.* TO 'testuser'@'%'",
+            "GRANT SELECT, INSERT, UPDATE ON `testdb`.`testtableone` TO 'testuser'@'%'",
+            "GRANT SELECT ON `testdb`.`testtabletwo` TO 'testuer'@'%'",
+            "GRANT SELECT ON `testdb`.`testtablethree` TO 'testuser'@'%'",
+        ]
+        mock = MagicMock(return_value=mock_grants)
+        with patch.object(mysql, 'user_grants', return_value=mock_grants) as mock_user_grants:
+            ret = mysql.grant_exists(
+                'SELECT, INSERT, UPDATE',
+                'testdb.testtableone',
+                'testuser',
+                '%'
+            )
+            self.assertEqual(ret, True)
+
+    def test_grant_exists_false(self):
+        '''
+        Test to ensure that we don't find a grant that doesn't exist
+        '''
+        mock_grants = [
+            "GRANT USAGE ON *.* TO 'testuser'@'%'",
+            "GRANT SELECT, INSERT, UPDATE ON `testdb`.`testtableone` TO 'testuser'@'%'",
+            "GRANT SELECT ON `testdb`.`testtablethree` TO 'testuser'@'%'",
+        ]
+        mock = MagicMock(return_value=mock_grants)
+        with patch.object(mysql, 'user_grants', return_value=mock_grants) as mock_user_grants:
+            ret = mysql.grant_exists(
+                'SELECT',
+                'testdb.testtabletwo',
+                'testuser',
+                '%'
+            )
+            self.assertEqual(ret, False)
 
     @skipIf(True, 'TODO: Mock up user_grants()')
     def test_grant_add(self):


### PR DESCRIPTION
I found that this was broken in the version of salt that we are using (2014.1.13) but fixed in the latest. So I thought I would add a couple of tests to ensure that it stays fixed.
