### PR TITLE
Fix state.apply for salt-ssh

### DIFF
--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -22,6 +22,9 @@ import salt.minion
 import salt.log
 from salt.ext.six import string_types
 
+__func_alias__ = {
+    'apply_': 'apply'
+}
 log = logging.getLogger(__name__)
 
 
@@ -257,6 +260,28 @@ def high(data, **kwargs):
 
     # If for some reason the json load fails, return the stdout
     return stdout
+
+
+def apply_(mods=None,
+          **kwargs):
+    '''
+    .. versionadded:: 2015.5.3
+
+    Apply states! This function will call highstate or state.sls based on the
+    arguments passed in, state.apply is intended to be the main gateway for
+    all state executions.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' state.apply
+        salt '*' state.apply test
+        salt '*' state.apply test,pkgs
+    '''
+    if mods:
+        return sls(mods, **kwargs)
+    return highstate(**kwargs)
 
 
 def highstate(test=None, **kwargs):


### PR DESCRIPTION
Simply copy-pasting the module function seemed to do the trick. This seems like a really bad way to "solve" this problem, but I doubt I am the right person to solve whatever underlying issue causes this to be necessary.

See issue #24746
