### PR TITLE
Deprecate using "provider" in favor of "driver" in cloud provider files

### DIFF
--- a/doc/topics/cloud/aliyun.rst
+++ b/doc/topics/cloud/aliyun.rst
@@ -1,6 +1,6 @@
-==================================
+===============================
 Getting Started With Aliyun ECS
-==================================
+===============================
 
 The Aliyun ECS (Elastic Computer Service) is one of the most popular public
 cloud providers in China. This cloud provider can be used to manage aliyun
@@ -32,7 +32,7 @@ under "My Service" tab.
       # aliyun Access Key Secret
       key: GDd45t43RDBTrkkkg43934t34qT43t4dgegerGEgg
       location: cn-qingdao
-      provider: aliyun
+      driver: aliyun
 
 
 Profiles
@@ -46,7 +46,7 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or in the
 .. code-block:: yaml
 
     aliyun_centos:
-        provider: my-aliyun-config
+        driver: my-aliyun-config
         size: ecs.t1.small
         location: cn-qingdao
         securitygroup: G1989096784427999

--- a/doc/topics/cloud/aws.rst
+++ b/doc/topics/cloud/aws.rst
@@ -84,7 +84,7 @@ parameters are discussed in more detail below.
       # Optionally add an IAM profile
       iam_profile: 'arn:aws:iam::123456789012:instance-profile/ExampleInstanceProfile'
 
-      provider: ec2
+      driver: ec2
 
 
     my-ec2-southeast-private-ips:
@@ -144,7 +144,7 @@ parameters are discussed in more detail below.
       # Optionally add an IAM profile
       iam_profile: 'my other profile name'
 
-      provider: ec2
+      driver: ec2
 
 
 Access Credentials
@@ -340,7 +340,7 @@ The following settings are always required for EC2:
       keyname: test
       securitygroup: quick-start
       private_key: /root/test.pem
-      provider: ec2
+      driver: ec2
 
 
 Optional Settings

--- a/doc/topics/cloud/azure.rst
+++ b/doc/topics/cloud/azure.rst
@@ -30,7 +30,7 @@ Set up the provider config at ``/etc/salt/cloud.providers.d/azure.conf``:
     # Note: This example is for /etc/salt/cloud.providers.d/azure.conf
 
     my-azure-config:
-      provider: azure
+      driver: azure
       subscription_id: 3287abc8-f98a-c678-3bde-326766fd3617
       certificate_path: /etc/salt/azure.pem
 

--- a/doc/topics/cloud/config.rst
+++ b/doc/topics/cloud/config.rst
@@ -58,7 +58,7 @@ Cloud provider configuration syntax can live in several places. The first is in
         keyname: test
         securitygroup: quick-start
         private_key: /root/test.pem
-        driver: aws
+        driver: ec2
 
 Cloud provider configuration data can also be housed in ``/etc/salt/cloud.providers``
 or any file matching ``/etc/salt/cloud.providers.d/*.conf``. All files in any of these
@@ -76,7 +76,7 @@ Using the example configuration above:
       keyname: test
       securitygroup: quick-start
       private_key: /root/test.pem
-      driver: aws
+      driver: ec2
 
 .. note::
 
@@ -122,7 +122,7 @@ The provider alias needs to have the provider key value appended as in the follo
       size: 256 server
 
 Notice that because of the multiple entries, one has to be explicit about the provider alias and
-name, from the above example, ``production-config: aws``.
+name, from the above example, ``production-config: ec2``.
 
 This data interactions with the ``salt-cloud`` binary regarding its ``--list-location``,
 ``--list-images``, and ``--list-sizes`` which needs a cloud provider as an argument. The argument
@@ -239,7 +239,7 @@ A number of configuration options are required for Amazon AWS including ``id``,
       keyname: test
       securitygroup: quick-start
       private_key: /root/test.pem
-      driver: aws
+      driver: ec2
 
     my-aws-default:
       id: HJGRYCILJLKJYG
@@ -247,7 +247,7 @@ A number of configuration options are required for Amazon AWS including ``id``,
       keyname: test
       securitygroup: default
       private_key: /root/test.pem
-      driver: aws
+      driver: ec2
 
 .. note::
 
@@ -637,7 +637,7 @@ configuration.  Consider ``/etc/salt/salt/cloud.providers`` containing:
         private_key: /root/test.pem
         location: ap-southeast-1
         availability_zone: ap-southeast-1b
-        driver: aws
+        driver: ec2
 
       - user: myuser@mycorp.com
         password: mypass

--- a/doc/topics/cloud/config.rst
+++ b/doc/topics/cloud/config.rst
@@ -94,7 +94,7 @@ For example:
         keyname: test
         securitygroup: quick-start
         private_key: /root/test.pem
-        driver: aws
+        driver: ec2
 
       - user: example_user
         apikey: 123984bjjas87034
@@ -107,12 +107,12 @@ The provider alias needs to have the provider key value appended as in the follo
 .. code-block:: yaml
 
     rhel_aws_dev:
-      provider: production-config:aws
+      provider: production-config:ec2
       image: ami-e565ba8c
       size: t1.micro
 
     rhel_aws_prod:
-      provider: production-config:aws
+      provider: production-config:ec2
       image: ami-e565ba8c
       size: High-CPU Extra Large Instance
 

--- a/doc/topics/cloud/config.rst
+++ b/doc/topics/cloud/config.rst
@@ -58,7 +58,7 @@ Cloud provider configuration syntax can live in several places. The first is in
         keyname: test
         securitygroup: quick-start
         private_key: /root/test.pem
-        provider: aws
+        driver: aws
 
 Cloud provider configuration data can also be housed in ``/etc/salt/cloud.providers``
 or any file matching ``/etc/salt/cloud.providers.d/*.conf``. All files in any of these
@@ -76,7 +76,7 @@ Using the example configuration above:
       keyname: test
       securitygroup: quick-start
       private_key: /root/test.pem
-      provider: aws
+      driver: aws
 
 .. note::
 
@@ -94,11 +94,11 @@ For example:
         keyname: test
         securitygroup: quick-start
         private_key: /root/test.pem
-        provider: aws
+        driver: aws
 
       - user: example_user
         apikey: 123984bjjas87034
-        provider: rackspace
+        driver: rackspace
 
 
 However, using this configuration method requires a change with profile configuration blocks.
@@ -158,7 +158,7 @@ minion. In your pillar file, you would use something like this:
           user: myuser
           api_key: apikey
           tenant: 123456
-          provider: nova
+          driver: nova
 
         my-openstack:
           identity_url: https://identity.api.rackspacecloud.com/v2.0/tokens
@@ -166,18 +166,18 @@ minion. In your pillar file, you would use something like this:
           apikey: apikey2
           tenant: 654321
           compute_region: DFW
-          provider: openstack
+          driver: openstack
           compute_name: cloudServersOpenStack
 
       profiles:
         ubuntu-nova:
-          provider: my-nova
+          driver: my-nova
           size: performance1-8
           image: bb02b1a3-bc77-4d17-ab5b-421d89850fca
           script_args: git develop
 
         ubuntu-openstack:
-          provider: my-openstack
+          driver: my-openstack
           size: performance1-8
           image: bb02b1a3-bc77-4d17-ab5b-421d89850fca
           script_args: git develop
@@ -199,7 +199,7 @@ If you do not have ``API token`` you can create one by clicking the "Create New 
     my-scaleway-config:
       access_key: 15cf404d-4560-41b1-9a0c-21c3d5c4ff1f
       token: a7347ec8-5de1-4024-a5e3-24b77d1ba91d
-      provider: scaleway
+      driver: scaleway
 
 .. note::
 
@@ -217,7 +217,7 @@ Rackspace cloud requires two configuration options; a ``user`` and an ``apikey``
     my-rackspace-config:
       user: example_user
       apikey: 123984bjjas87034
-      provider: rackspace-config
+      driver: rackspace-config
 
 .. note::
 
@@ -239,7 +239,7 @@ A number of configuration options are required for Amazon AWS including ``id``,
       keyname: test
       securitygroup: quick-start
       private_key: /root/test.pem
-      provider: aws
+      driver: aws
 
     my-aws-default:
       id: HJGRYCILJLKJYG
@@ -247,7 +247,7 @@ A number of configuration options are required for Amazon AWS including ``id``,
       keyname: test
       securitygroup: default
       private_key: /root/test.pem
-      provider: aws
+      driver: aws
 
 .. note::
 
@@ -269,7 +269,7 @@ be set:
       password: F00barbaz
       ssh_pubkey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKHEOLLbeXgaqRQT9NBAopVz366SdYc0KKX33vAnq+2R user@host
       ssh_key_file: ~/.ssh/id_ed25519
-      provider: linode
+      driver: linode
 
 The password needs to be 8 characters and contain lowercase, uppercase, and
 numbers.
@@ -294,7 +294,7 @@ to send the provisioning commands up to the freshly created virtual machine.
       user: fred
       password: saltybacon
       private_key: /root/joyent.pem
-      provider: joyent
+      driver: joyent
 
 .. note::
 
@@ -317,7 +317,7 @@ be set in the configuration file to enable interfacing with GoGrid:
     my-gogrid-config:
       apikey: asdff7896asdh789
       sharedsecret: saltybacon
-      provider: gogrid
+      driver: gogrid
 
 .. note::
 
@@ -346,7 +346,7 @@ both.
       ssh_key_name: mykey
       ssh_key_file: '/etc/salt/hpcloud/mykey.pem'
       password: mypass
-      provider: openstack
+      driver: openstack
 
     # For Rackspace
     my-openstack-rackspace-config:
@@ -358,7 +358,7 @@ both.
       user: myuser
       tenant: 5555555
       password: mypass
-      provider: openstack
+      driver: openstack
 
 
 If you have an API key for your provider, it may be specified instead of a
@@ -410,7 +410,7 @@ under the API Access tab.
 .. code-block:: yaml
 
     my-digitalocean-config:
-      provider: digital_ocean
+      driver: digital_ocean
       personal_access_token: xxx
       location: New York 1
 
@@ -432,7 +432,7 @@ can be obtained from your cloud provider.
       user: myuser
       password: xyzzy
       url: https://api.cloud.xmission.com:4465/paci/v1.0/
-      provider: parallels
+      driver: parallels
 
 .. note::
 
@@ -449,7 +449,7 @@ obtained from your cloud provider. Both PAM and PVE users can be used.
 .. code-block:: yaml
 
     my-proxmox-config:
-      provider: proxmox
+      driver: proxmox
       user: saltcloud@pve
       password: xyzzy
       url: your.proxmox.host
@@ -471,14 +471,14 @@ those containers via this driver.
 
     devhost10-lxc:
       target: devhost10
-      provider: lxc
+      driver: lxc
 
 And in the map file:
 
 .. code-block:: yaml
 
     devhost10-lxc:
-      provider: devhost10-lxc
+      driver: devhost10-lxc
       from_container: ubuntu
       backing: lvm
       sudo: True
@@ -512,7 +512,7 @@ following in cloud.profiles:
 .. code-block:: yaml
 
     make_salty:
-      provider: saltify
+      driver: saltify
 
 And in the map file:
 
@@ -637,14 +637,14 @@ configuration.  Consider ``/etc/salt/salt/cloud.providers`` containing:
         private_key: /root/test.pem
         location: ap-southeast-1
         availability_zone: ap-southeast-1b
-        provider: aws
+        driver: aws
 
       - user: myuser@mycorp.com
         password: mypass
         ssh_key_name: mykey
         ssh_key_file: '/etc/salt/ibm/mykey.pem'
         location: Raleigh
-        provider: ibmsce
+        driver: ibmsce
 
 
     my-productions-envs:
@@ -667,12 +667,12 @@ data:
              'keyname': 'test',
              'location': 'ap-southeast-1',
              'private_key': '/root/test.pem',
-             'provider': 'aws',
+             'driver': 'aws',
              'securitygroup': 'quick-start'
             },
             {'location': 'Raleigh',
              'password': 'mypass',
-             'provider': 'ibmsce',
+             'driver': 'ibmsce',
              'ssh_key_file': '/etc/salt/ibm/mykey.pem',
              'ssh_key_name': 'mykey',
              'user': 'myuser@mycorp.com'
@@ -682,7 +682,7 @@ data:
             {'availability_zone': 'us-east-1',
              'location': 'us-east-1',
              'password': 'mypass',
-             'provider': 'ibmsce',
+             'driver': 'ibmsce',
              'ssh_key_file': '/etc/salt/ibm/mykey.pem',
              'ssh_key_name': 'mykey',
              'user': 'my-production-user@mycorp.com'

--- a/doc/topics/cloud/deploy.rst
+++ b/doc/topics/cloud/deploy.rst
@@ -114,7 +114,7 @@ Or even on the VM's profile settings:
 .. code-block:: yaml
 
     ubuntu_aws:
-      provider: aws
+      provider: ec2
       image: ami-7e2da54e
       size: t1.micro
       deploy: False
@@ -174,7 +174,7 @@ to pass arguments to the deploy script:
 .. code-block:: yaml
 
     aws-amazon:
-      provider: aws
+      provider: ec2
       image: ami-1624987f
       size: t1.micro
       ssh_username: ec2-user

--- a/doc/topics/cloud/deploy.rst
+++ b/doc/topics/cloud/deploy.rst
@@ -174,12 +174,12 @@ to pass arguments to the deploy script:
 .. code-block:: yaml
 
     aws-amazon:
-        provider: aws
-        image: ami-1624987f
-        size: t1.micro
-        ssh_username: ec2-user
-        script: bootstrap-salt
-        script_args: -c /tmp/
+      provider: aws
+      image: ami-1624987f
+      size: t1.micro
+      ssh_username: ec2-user
+      script: bootstrap-salt
+      script_args: -c /tmp/
 
 
 This has also been tested to work with pipes, if needed:

--- a/doc/topics/cloud/digitalocean.rst
+++ b/doc/topics/cloud/digitalocean.rst
@@ -19,7 +19,7 @@ under the "SSH Keys" section.
     # /etc/salt/cloud.providers.d/ directory.
 
     my-digitalocean-config:
-      provider: digital_ocean
+      driver: digital_ocean
       personal_access_token: xxx
       ssh_key_file: /path/to/ssh/key/file
       ssh_key_names: my-key-name,my-key-name-2

--- a/doc/topics/cloud/gce.rst
+++ b/doc/topics/cloud/gce.rst
@@ -99,7 +99,7 @@ Set up the cloud config at ``/etc/salt/cloud``:
           node_type: broker
           release: 1.0.1
 
-        provider: gce
+        driver: gce
 
 .. note::
 

--- a/doc/topics/cloud/gogrid.rst
+++ b/doc/topics/cloud/gogrid.rst
@@ -20,7 +20,7 @@ in the configuration file to enable interfacing with GoGrid:
     # /etc/salt/cloud.providers.d/ directory.
 
     my-gogrid-config:
-      provider: gogrid
+      driver: gogrid
       apikey: asdff7896asdh789
       sharedsecret: saltybacon
 

--- a/doc/topics/cloud/hpcloud.rst
+++ b/doc/topics/cloud/hpcloud.rst
@@ -1,6 +1,6 @@
-==============================
+=============================
 Getting Started With HP Cloud
-==============================
+=============================
 
 HP Cloud is a major public cloud platform and uses the libcloud
 `openstack` driver. The current version of OpenStack that HP Cloud
@@ -45,7 +45,7 @@ provider configuration file as in the example shown below:
       ssh_key_name: yourkey
       ssh_key_file: /path/to/key/yourkey.priv
 
-      provider: openstack
+      driver: openstack
 
 
 The subsequent example that follows is using the openstack driver.

--- a/doc/topics/cloud/index.rst
+++ b/doc/topics/cloud/index.rst
@@ -12,13 +12,13 @@ Getting Started
 
 Salt Cloud is built-in to Salt and is configured on and executed from your Salt Master.
 
-Define a Profile
-----------------
+Define a Provider
+-----------------
 
 The first step is to add the credentials for your cloud provider. Credentials
 and provider settings are stored in provider configuration files.
-Provider configurations contain the details needed to connect, and any global options that you want set on
-your cloud minions (such as the location of your Salt Master).
+Provider configurations contain the details needed to connect to a cloud provider such as EC2, GCE, Rackspace, etc.,
+and any global options that you want set on your cloud minions (such as the location of your Salt Master).
 
 On your Salt Master, browse to ``/etc/salt/cloud.providers.d/`` and create a file called ``<provider>.provider.conf``,
 replacing ``<provider>`` with ``ec2``, ``softlayer``, and so on. The name helps you identify the contents, and is not

--- a/doc/topics/cloud/index.rst
+++ b/doc/topics/cloud/index.rst
@@ -30,7 +30,7 @@ provider to this file. Here is an example for Amazon EC2:
 .. code-block:: yaml
 
     my-ec2:
-      provider: ec2
+      driver: ec2
       # Set the EC2 access credentials (see below)
       #
       id: 'HJGRYCILJLKJYG'

--- a/doc/topics/cloud/joyent.rst
+++ b/doc/topics/cloud/joyent.rst
@@ -24,11 +24,11 @@ send the provisioning commands up to the freshly created virtual machine.
     # /etc/salt/cloud.providers.d/ directory.
 
     my-joyent-config:
-        provider: joyent
-        user: fred
-        password: saltybacon
-        private_key: /root/mykey.pem
-        keyname: mykey
+      driver: joyent
+      user: fred
+      password: saltybacon
+      private_key: /root/mykey.pem
+      keyname: mykey
 
 
 Profiles

--- a/doc/topics/cloud/linode.rst
+++ b/doc/topics/cloud/linode.rst
@@ -42,7 +42,7 @@ instances also needs to be set:
       password: F00barbaz
       ssh_pubkey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKHEOLLbeXgaqRQT9NBAopVz366SdYc0KKX33vAnq+2R user@host
       ssh_key_file: ~/.ssh/id_ed25519
-      provider: linode
+      driver: linode
 
 The password needs to be 8 characters and contain lowercase, uppercase, and
 numbers.
@@ -138,7 +138,7 @@ cloud profile that looks like this:
 .. code-block:: yaml
 
     li-clone:
-      provider: linode
+      provider: my-linode-config
       clonefrom: machine_to_clone
       script_args: -C
 

--- a/doc/topics/cloud/lxc.rst
+++ b/doc/topics/cloud/lxc.rst
@@ -17,7 +17,7 @@ In other words, Salt will connect to a minion, then from that minion:
     - :mod:`seed <salt.modules.config>` 
 
 Limitations
-------------
+-----------
 
 - You can only act on one minion and one provider at a time.
 - Listing images must be targeted to a particular LXC provider (nothing will be
@@ -60,7 +60,7 @@ Here is a simple provider configuration:
     # /etc/salt/cloud.providers.d/ directory.
     devhost10-lxc:
       target: devhost10
-      provider: lxc
+      driver: lxc
 
 Profile configuration
 ---------------------

--- a/doc/topics/cloud/openstack.rst
+++ b/doc/topics/cloud/openstack.rst
@@ -41,7 +41,7 @@ Configuration
       # tenant is the project name
       tenant: myproject
 
-      provider: openstack
+      driver: openstack
 
       # skip SSL certificate validation (default false)
       insecure: false

--- a/doc/topics/cloud/parallels.rst
+++ b/doc/topics/cloud/parallels.rst
@@ -47,7 +47,7 @@ http://www.parallels.com/products/pcs/
       # Set the access URL for your PARALLELS provider
       #
       url: https://api.cloud.xmission.com:4465/paci/v1.0/
-      provider: parallels
+      driver: parallels
 
 
 
@@ -124,7 +124,7 @@ The following settings are always required for PARALLELS:
       user: myuser
       password: badpass
       url: https://api.cloud.xmission.com:4465/paci/v1.0/
-      provider: parallels
+      driver: parallels
 
 
 Optional Settings

--- a/doc/topics/cloud/profiles.rst
+++ b/doc/topics/cloud/profiles.rst
@@ -23,14 +23,14 @@ public cloud provider. A number of additional parameters can also be inserted:
 .. code-block:: yaml
 
     centos_rackspace:
-        provider: rackspace
-        image: CentOS 6.2
-        size: 1024 server
-        minion:
-            master: salt.example.com
-            append_domain: webs.example.com
-            grains:
-                role: webserver
+      driver: rackspace
+      image: CentOS 6.2
+      size: 1024 server
+      minion:
+        master: salt.example.com
+        append_domain: webs.example.com
+        grains:
+          role: webserver
 
 
 The image must be selected from available images. Similarly, sizes must be
@@ -66,44 +66,44 @@ Larger Example
 .. code-block:: yaml
 
     rhel_ec2:
-        provider: ec2
-        image: ami-e565ba8c
-        size: t1.micro
-        minion:
-            cheese: edam
+      provider: ec2
+      image: ami-e565ba8c
+      size: t1.micro
+      minion:
+        cheese: edam
 
     ubuntu_ec2:
-        provider: ec2
-        image: ami-7e2da54e
-        size: t1.micro
-        minion:
-            cheese: edam
+      provider: ec2
+      image: ami-7e2da54e
+      size: t1.micro
+      minion:
+        cheese: edam
 
     ubuntu_rackspace:
-        provider: rackspace
-        image: Ubuntu 12.04 LTS
-        size: 256 server
-        minion:
-            cheese: edam
+      provider: rackspace
+      image: Ubuntu 12.04 LTS
+      size: 256 server
+      minion:
+        cheese: edam
 
     fedora_rackspace:
-        provider: rackspace
-        image: Fedora 17
-        size: 256 server
-        minion:
-            cheese: edam
+      provider: rackspace
+      image: Fedora 17
+      size: 256 server
+      minion:
+        cheese: edam
 
     cent_linode:
-        provider: linode
-        image: CentOS 6.2 64bit
-        size: Linode 512
+      provider: linode
+      image: CentOS 6.2 64bit
+      size: Linode 512
 
     cent_gogrid:
-        provider: gogrid
-        image: 12834
-        size: 512MB
+      provider: gogrid
+      image: 12834
+      size: 512MB
 
     cent_joyent:
-        provider: joyent
-        image: centos-6
-        size: Small 1GB
+      provider: joyent
+      image: centos-6
+      size: Small 1GB

--- a/doc/topics/cloud/proxmox.rst
+++ b/doc/topics/cloud/proxmox.rst
@@ -37,7 +37,7 @@ done when the VM is an OpenVZ container rather than a KVM virtual machine.
       # Set the access URL for your PROXMOX provider
       #
       url: your.proxmox.host
-      provider: proxmox
+      driver: proxmox
 
 
 
@@ -93,7 +93,7 @@ The following settings are always required for PROXMOX:
 .. code-block:: yaml
 
     my-proxmox-config:
-      provider: proxmox
+      driver: proxmox
       user: saltcloud@pve
       password: xyzzy
       url: your.proxmox.host

--- a/doc/topics/cloud/rackspace.rst
+++ b/doc/topics/cloud/rackspace.rst
@@ -47,7 +47,7 @@ To use the `openstack` driver (recommended), set up the cloud configuration at
       tenant: 123456
       apikey: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
-      provider: openstack
+      driver: openstack
 
 
 To use the `rackspace` driver, set up the cloud configuration at
@@ -57,7 +57,7 @@ To use the `rackspace` driver, set up the cloud configuration at
 .. code-block:: yaml
 
     my-rackspace-config:
-      provider: rackspace
+      driver: rackspace
       # The Rackspace login user
       user: fred
       # The Rackspace user's apikey
@@ -119,7 +119,7 @@ it can be verified with Salt:
     # salt myinstance test.ping
 
 RackConnect Environments
---------------------------------
+------------------------
 
 Rackspace offers a hybrid hosting configuration option called RackConnect that
 allows you to use a physical firewall appliance with your cloud servers. When
@@ -137,7 +137,7 @@ capability by adding this to your profiles:
         rackconnect: True
 
 Managed Cloud Environments
---------------------------------
+--------------------------
 
 Rackspace offers a managed service level of hosting. As part of the managed
 service level you have the ability to choose from base of lamp installations on

--- a/doc/topics/cloud/reactor.rst
+++ b/doc/topics/cloud/reactor.rst
@@ -109,7 +109,7 @@ related to the profile or provider config, and any default values that could
 have been changed in the profile or provider, but weren't.
 
 salt/cloud/<minion_id>/created
--------------------------------
+------------------------------
 
 The deploy sequence has completed, and the instance is now available, Salted,
 and ready for use. This event is the final task for Salt Cloud, before returning

--- a/doc/topics/cloud/salt.rst
+++ b/doc/topics/cloud/salt.rst
@@ -238,7 +238,7 @@ presence of the instance will be managed statefully.
 
     my-instance-name:
       cloud.present:
-        - provider: my-ec2-config
+        - driver: my-ec2-config
         - image: ami-1624987f
         - size: 't1.micro'
         - ssh_username: ec2-user

--- a/doc/topics/cloud/scaleway.rst
+++ b/doc/topics/cloud/scaleway.rst
@@ -19,7 +19,7 @@ If you do not have API token you can create one by clicking the "Create New Toke
     my-scaleway-config:
       access_key: 15cf404d-4560-41b1-9a0c-21c3d5c4ff1f
       token: a7347ec8-5de1-4024-a5e3-24b77d1ba91d
-      provider: scaleway
+      driver: scaleway
 
 Profiles
 ========
@@ -32,8 +32,8 @@ Set up an initial profile at /etc/salt/cloud.profiles or in the /etc/salt/cloud.
 .. code-block:: yaml
 
     scalewa-ubuntu:
-        provider: my-scaleway-config
-        image: Ubuntu Trusty (14.04 LTS)
+      provider: my-scaleway-config
+      image: Ubuntu Trusty (14.04 LTS)
 
 
 Images can be obtained using the ``--list-images`` option for the ``salt-cloud`` command:

--- a/doc/topics/cloud/softlayer.rst
+++ b/doc/topics/cloud/softlayer.rst
@@ -36,7 +36,7 @@ Set up the cloud config at ``/etc/salt/cloud.providers``:
       user: MYUSER1138
       apikey: 'e3b68aa711e6deadc62d5b76355674beef7cc3116062ddbacafe5f7e465bfdc9'
 
-      provider: softlayer
+      driver: softlayer
 
 
     my-softlayer-hw:
@@ -48,7 +48,7 @@ Set up the cloud config at ``/etc/salt/cloud.providers``:
       user: MYUSER1138
       apikey: 'e3b68aa711e6deadc62d5b76355674beef7cc3116062ddbacafe5f7e465bfdc9'
 
-      provider: softlayer_hw
+      driver: softlayer_hw
 
 
 Access Credentials

--- a/doc/topics/cloud/vexxhost.rst
+++ b/doc/topics/cloud/vexxhost.rst
@@ -50,7 +50,7 @@ driver.
       ssh_key_name: yourkey
       ssh_key_file: /path/to/key/yourkey.priv
 
-      provider: openstack
+      driver: openstack
 
 
 Authentication
@@ -80,9 +80,9 @@ profile will build an Ubuntu 12.04 LTS `nb.2G` instance.
 .. code-block:: yaml
 
     vh_ubuntu1204_2G:
-        provider: vexxhost
-        image: 4051139f-750d-4d72-8ef0-074f2ccc7e5a
-        size: nb.2G
+      provider: vexxhost
+      image: 4051139f-750d-4d72-8ef0-074f2ccc7e5a
+      size: nb.2G
 
 Provision an instance
 =====================

--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -33,19 +33,19 @@ set up in the cloud configuration at
 .. code-block:: yaml
 
     my-vmware-config:
-      provider: vmware
+      driver: vmware
       user: "DOMAIN\user"
       password: "verybadpass"
       url: "vcenter01.domain.com"
 
     vmware-vcenter02:
-      provider: vmware
+      driver: vmware
       user: "DOMAIN\user"
       password: "verybadpass"
       url: "vcenter02.domain.com"
 
     vmware-vcenter03:
-      provider: vmware
+      driver: vmware
       user: "DOMAIN\user"
       password: "verybadpass"
       url: "vcenter03.domain.com"

--- a/doc/topics/cloud/vsphere.rst
+++ b/doc/topics/cloud/vsphere.rst
@@ -39,7 +39,7 @@ Set up the cloud config at ``/etc/salt/cloud.providers`` or in the
 .. code-block:: yaml
 
     my-vsphere-config:
-      provider: vsphere
+      driver: vsphere
       # Set the vSphere access credentials
       user: marco
       password: polo

--- a/doc/topics/cloud/windows.rst
+++ b/doc/topics/cloud/windows.rst
@@ -89,7 +89,7 @@ Setting the installer in ``/etc/salt/cloud.providers``:
 .. code-block:: yaml
 
     my-softlayer:
-      provider: softlayer
+      driver: softlayer
       user: MYUSER1138
       apikey: 'e3b68aa711e6deadc62d5b76355674beef7cc3116062ddbacafe5f7e465bfdc9'
       minion:

--- a/doc/topics/releases/beryllium.rst
+++ b/doc/topics/releases/beryllium.rst
@@ -49,9 +49,27 @@ seconds by specifying ``in_seconds=True``.
 Deprecations
 ============
 
-The ``digital_ocean.py`` Salt Cloud driver was removed in favor of the
+- The ``digital_ocean.py`` Salt Cloud driver was removed in favor of the
 ``digital_ocean_v2.py`` driver as DigitalOcean has removed support for APIv1.
 The ``digital_ocean_v2.py`` was renamed to ``digital_ocean.py`` and supports
 DigitalOcean's APIv2.
-The ``vsphere.py`` Salt Cloud driver has been deprecated in favor of the
+
+- The ``vsphere.py`` Salt Cloud driver has been deprecated in favor of the
 ``vmware.py`` driver.
+
+- The ``openstack.py`` Salt Cloud driver has been deprecated in favor of the
+``nova.py`` driver.
+
+- The use of ``provider`` in Salt Cloud provider files to define cloud drivers
+has been deprecated in favor of useing ``driver``. Both terms will work until
+the Nitrogen release of Salt. Example provider file:
+
+.. code-block:: yaml
+
+    my-ec2-cloud-config:
+      id: 'HJGRYCILJLKJYG'
+      key: 'kdjgfsgm;woormgl/aserigjksjdhasdfgn'
+      private_key: /etc/salt/my_test_key.pem
+      keyname: my_test_key
+      securitygroup: default
+      driver: ec2

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1153,7 +1153,7 @@ class Cloud(object):
             'minion', vm_, self.opts, default={}
         )
 
-        # Since using "provider: <provider-engine>" is deprecated, alias provider 
+        # Since using "provider: <provider-engine>" is deprecated, alias provider
         # to use driver: "driver: <provider-engine>"
         if 'provider' in vm_:
             vm_['driver'] = vm_.pop('provider')

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -387,8 +387,14 @@ class CloudClient(object):
         ret = {}
         for name in names:
             vm_ = kwargs.copy()
+
+            # Since using "provider: <provider-engine>" is deprecated, alias provider
+            # to use driver: "driver: <provider-engine>"
+            if 'provider' in vm_:
+                vm_['driver'] = vm_.pop('provider')
+
             vm_['name'] = name
-            vm_['provider'] = provider
+            vm_['driver'] = provider
             vm_['profile'] = None
             ret[name] = salt.utils.cloud.simple_types_filter(
                 mapper.create(vm_))

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1157,7 +1157,12 @@ class Cloud(object):
             'minion', vm_, self.opts, default={}
         )
 
-        alias, driver = vm_['provider'].split(':')
+        # Since using "provider: <provider-engine>" is deprecated, alias provider 
+        # to use driver: "driver: <provider-engine>"
+        if 'provider' in vm_:
+            vm_['driver'] = vm_.pop('provider')
+
+        alias, driver = vm_['driver'].split(':')
         fun = '{0}.create'.format(driver)
         if fun not in self.clouds:
             log.error(
@@ -1246,7 +1251,7 @@ class Cloud(object):
             pass
 
         try:
-            alias, driver = vm_['provider'].split(':')
+            alias, driver = vm_['driver'].split(':')
             func = '{0}.create'.format(driver)
             with context.func_globals_inject(
                 self.clouds[fun],

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -470,14 +470,6 @@ class CloudClient(object):
                 'Either an instance or a provider must be specified.'
             )
 
-        return salt.utils.cloud.simple_types_filter(
-            mapper.run_profile(fun, names)
-        )
-
-    # map
-    # create
-    # destroy
-
 
 class Cloud(object):
     '''
@@ -530,8 +522,6 @@ class Cloud(object):
                         lookup, ', '.join(self.get_configured_providers())
                     )
                 )
-
-            return set((alias, driver))
 
         providers = set()
         for alias, drivers in six.iteritems(self.opts['providers']):

--- a/salt/cloud/clouds/aliyun.py
+++ b/salt/cloud/clouds/aliyun.py
@@ -20,7 +20,7 @@ Set up the cloud configuration at ``/etc/salt/cloud.providers`` or
       # aliyun Access Key Secret
       key: GDE43t43REGTrkilg43934t34qT43t4dgegerGEgg
       location: cn-qingdao
-      provider: aliyun
+      driver: aliyun
 
 :depends: requests
 '''

--- a/salt/cloud/clouds/aliyun.py
+++ b/salt/cloud/clouds/aliyun.py
@@ -566,6 +566,12 @@ def create(vm_):
     '''
     Create a single VM from a data dict
     '''
+
+    # Since using "provider: <provider-engine>" is deprecated, alias provider
+    # to use driver: "driver: <provider-engine>"
+    if 'provider' in vm_:
+        vm_['driver'] = vm_.pop('provider')
+
     salt.utils.cloud.fire_event(
         'event',
         'starting create',
@@ -573,7 +579,7 @@ def create(vm_):
         {
             'name': vm_['name'],
             'profile': vm_['profile'],
-            'provider': vm_['provider'],
+            'provider': vm_['driver'],
         },
         transport=__opts__['transport']
     )
@@ -658,7 +664,7 @@ def create(vm_):
         {
             'name': vm_['name'],
             'profile': vm_['profile'],
-            'provider': vm_['provider'],
+            'provider': vm_['driver'],
         },
         transport=__opts__['transport']
     )

--- a/salt/cloud/clouds/botocore_aws.py
+++ b/salt/cloud/clouds/botocore_aws.py
@@ -25,7 +25,7 @@ If this driver is still needed, set up the cloud configuration at
       securitygroup: ssh_open
       # The location of the private key which corresponds to the keyname
       private_key: /root/default.pem
-      provider: aws
+      driver: aws
 
 '''
 from __future__ import absolute_import

--- a/salt/cloud/clouds/cloudstack.py
+++ b/salt/cloud/clouds/cloudstack.py
@@ -18,7 +18,7 @@ Use of this module requires the ``apikey``, ``secretkey``, ``host`` and
       secretkey: <your secret key >
       host: localhost
       path: /client/api
-      provider: cloudstack
+      driver: cloudstack
 
 '''
 # pylint: disable=invalid-name,function-redefined

--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -20,7 +20,7 @@ under the "SSH Keys" section.
       personal_access_token: xxx
       ssh_key_file: /path/to/ssh/key/file
       ssh_key_names: my-key-name,my-key-name-2
-      provider: digital_ocean
+      driver: digital_ocean
 
 :depends: requests
 '''

--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -303,6 +303,12 @@ def create(vm_):
     '''
     Create a single VM from a data dict
     '''
+
+    # Since using "provider: <provider-engine>" is deprecated, alias provider
+    # to use driver: "driver: <provider-engine>"
+    if 'provider' in vm_:
+        vm_['driver'] = vm_.pop('provider')
+
     salt.utils.cloud.fire_event(
         'event',
         'starting create',
@@ -310,7 +316,7 @@ def create(vm_):
         {
             'name': vm_['name'],
             'profile': vm_['profile'],
-            'provider': vm_['provider'],
+            'provider': vm_['driver'],
         },
         transport=__opts__['transport']
     )
@@ -459,7 +465,7 @@ def create(vm_):
         {
             'name': vm_['name'],
             'profile': vm_['profile'],
-            'provider': vm_['provider'],
+            'provider': vm_['driver'],
         },
         transport=__opts__['transport']
     )

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -61,7 +61,7 @@ To use the EC2 cloud module, set up the cloud configuration at
       # Password defaults to None
       ssh_gateway_password: ExamplePasswordHere
 
-      provider: ec2
+      driver: ec2
 
 :depends: requests
 '''

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2100,6 +2100,11 @@ def create(vm_=None, call=None):
             'You cannot create an instance with -a or -f.'
         )
 
+    # Since using "provider: <provider-engine>" is deprecated, alias provider
+    # to use driver: "driver: <provider-engine>"
+    if 'provider' in vm_:
+        vm_['driver'] = vm_.pop('provider')
+
     salt.utils.cloud.fire_event(
         'event',
         'starting create',
@@ -2107,12 +2112,12 @@ def create(vm_=None, call=None):
         {
             'name': vm_['name'],
             'profile': vm_['profile'],
-            'provider': vm_['provider'],
+            'provider': vm_['driver'],
         },
         transport=__opts__['transport']
     )
     salt.utils.cloud.cachedir_index_add(
-        vm_['name'], vm_['profile'], 'ec2', vm_['provider']
+        vm_['name'], vm_['profile'], 'ec2', vm_['driver']
     )
 
     key_filename = config.get_cloud_config_value(
@@ -2306,7 +2311,7 @@ def create(vm_=None, call=None):
     event_data = {
         'name': vm_['name'],
         'profile': vm_['profile'],
-        'provider': vm_['provider'],
+        'provider': vm_['driver'],
         'instance_id': vm_['instance_id'],
     }
     if volumes:
@@ -2942,7 +2947,12 @@ def list_nodes_full(location=None, call=None):
 
 
 def _vm_provider_driver(vm_):
-    alias, driver = vm_['provider'].split(':')
+    # Since using "provider: <provider-engine>" is deprecated, alias provider
+    # to use driver: "driver: <provider-engine>"
+    if 'provider' in vm_:
+        vm_['driver'] = vm_.pop('provider')
+
+    alias, driver = vm_['driver'].split(':')
     if alias not in __opts__['providers']:
         return None
 

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -51,7 +51,7 @@ Setting up Service Account Authentication:
       service_account_email_address: 1234567890@developer.gserviceaccount.com
       # The location of the private key (PEM format)
       service_account_private_key: /home/erjohnso/PRIVKEY.pem
-      provider: gce
+      driver: gce
       # Specify whether to use public or private IP for deploy script.
       # Valid options are:
       #     private_ips - The salt-master is also hosted with GCE

--- a/salt/cloud/clouds/gogrid.py
+++ b/salt/cloud/clouds/gogrid.py
@@ -18,7 +18,7 @@ Set up the cloud configuration at ``/etc/salt/cloud.providers`` or
       apikey: asdff7896asdh789
       # The apikey's shared secret
       sharedsecret: saltybacon
-      provider: gogrid
+      driver: gogrid
 
 '''
 from __future__ import absolute_import

--- a/salt/cloud/clouds/joyent.py
+++ b/salt/cloud/clouds/joyent.py
@@ -11,7 +11,7 @@ Set up the cloud configuration at ``/etc/salt/cloud.providers`` or
 .. code-block:: yaml
 
     my-joyent-config:
-      provider: joyent
+      driver: joyent
       # The Joyent login user
       user: fred
       # The Joyent user's password

--- a/salt/cloud/clouds/joyent.py
+++ b/salt/cloud/clouds/joyent.py
@@ -242,6 +242,12 @@ def create(vm_):
 
         salt-cloud -p profile_name vm_name
     '''
+
+    # Since using "provider: <provider-engine>" is deprecated, alias provider
+    # to use driver: "driver: <provider-engine>"
+    if 'provider' in vm_:
+        vm_['driver'] = vm_.pop('provider')
+
     key_filename = config.get_cloud_config_value(
         'private_key', vm_, __opts__, search_global=False, default=None
     )
@@ -253,7 +259,7 @@ def create(vm_):
         {
             'name': vm_['name'],
             'profile': vm_['profile'],
-            'provider': vm_['provider'],
+            'provider': vm_['driver'],
         },
         transport=__opts__['transport']
     )
@@ -312,7 +318,7 @@ def create(vm_):
         {
             'name': vm_['name'],
             'profile': vm_['profile'],
-            'provider': vm_['provider'],
+            'provider': vm_['driver'],
         },
         transport=__opts__['transport']
     )

--- a/salt/cloud/clouds/libcloud_aws.py
+++ b/salt/cloud/clouds/libcloud_aws.py
@@ -26,7 +26,7 @@ If this driver is still needed, set up the cloud configuration at
       # The location of the private key which corresponds to the keyname
       private_key: /root/default.pem
 
-      provider: aws
+      driver: aws
 
 '''
 from __future__ import absolute_import

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -16,7 +16,7 @@ Set up the cloud configuration at ``/etc/salt/cloud.providers`` or ``/etc/salt/c
       # Linode account api key
       apikey: JVkbSJDGHSDKUKSDJfhsdklfjgsjdkflhjlsdfffhgdgjkenrtuinv
       password: F00barbaz
-      provider: linode
+      driver: linode
 
 When used with linode-python, this provider supports cloning existing Linodes. To clone, add a profile with a
 ``clonefrom`` key, and a ``script_args: -C``.

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -171,6 +171,12 @@ def create(vm_):
     '''
     Create a single Linode VM.
     '''
+
+    # Since using "provider: <provider-engine>" is deprecated, alias provider
+    # to use driver: "driver: <provider-engine>"
+    if 'provider' in vm_:
+        vm_['driver'] = vm_.pop('provider')
+
     salt.utils.cloud.fire_event(
         'event',
         'starting create',
@@ -178,7 +184,7 @@ def create(vm_):
         {
             'name': vm_['name'],
             'profile': vm_['profile'],
-            'provider': vm_['provider'],
+            'provider': vm_['driver'],
         },
         transport=__opts__['transport']
     )
@@ -312,7 +318,7 @@ def create(vm_):
         {
             'name': vm_['name'],
             'profile': vm_['profile'],
-            'provider': vm_['provider'],
+            'provider': vm_['driver'],
         },
         transport=__opts__['transport']
     )

--- a/salt/cloud/clouds/msazure.py
+++ b/salt/cloud/clouds/msazure.py
@@ -399,6 +399,12 @@ def create(vm_):
     '''
     Create a single VM from a data dict
     '''
+
+    # Since using "provider: <provider-engine>" is deprecated, alias provider
+    # to use driver: "driver: <provider-engine>"
+    if 'provider' in vm_:
+        vm_['driver'] = vm_.pop('provider')
+
     salt.utils.cloud.fire_event(
         'event',
         'starting create',
@@ -406,7 +412,7 @@ def create(vm_):
         {
             'name': vm_['name'],
             'profile': vm_['profile'],
-            'provider': vm_['provider'],
+            'provider': vm_['driver'],
         },
         transport=__opts__['transport']
     )
@@ -654,7 +660,7 @@ def create(vm_):
         {
             'name': vm_['name'],
             'profile': vm_['profile'],
-            'provider': vm_['provider'],
+            'provider': vm_['driver'],
         },
         transport=__opts__['transport']
     )

--- a/salt/cloud/clouds/msazure.py
+++ b/salt/cloud/clouds/msazure.py
@@ -31,7 +31,7 @@ Example ``/etc/salt/cloud.providers`` or
 .. code-block:: yaml
 
     my-azure-config:
-      provider: azure
+      driver: azure
       subscription_id: 3287abc8-f98a-c678-3bde-326766fd3617
       certificate_path: /etc/salt/azure.pem
       management_host: management.core.windows.net

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -543,6 +543,11 @@ def create(vm_):
 
     vm_['key_filename'] = key_filename
 
+    # Since using "provider: <provider-engine>" is deprecated, alias provider
+    # to use driver: "driver: <provider-engine>"
+    if 'provider' in vm_:
+        vm_['driver'] = vm_.pop('provider')
+
     salt.utils.cloud.fire_event(
         'event',
         'starting create',
@@ -550,7 +555,7 @@ def create(vm_):
         {
             'name': vm_['name'],
             'profile': vm_['profile'],
-            'provider': vm_['provider'],
+            'provider': vm_['driver'],
         },
         transport=__opts__['transport']
     )
@@ -750,7 +755,7 @@ def create(vm_):
         {
             'name': vm_['name'],
             'profile': vm_['profile'],
-            'provider': vm_['provider'],
+            'provider': vm_['driver'],
         },
         transport=__opts__['transport']
     )

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -45,7 +45,7 @@ examples could be set up in the cloud configuration at
 
       ssh_key_name: mykey
 
-      provider: nova
+      driver: nova
       userdata_file: /tmp/userdata.txt
 
 For local installations that only use private IP address ranges, the
@@ -67,7 +67,7 @@ accept them
       user: myusername
       password: mypassword
       tenant: <userid>
-      provider: nova
+      driver: nova
 
     my-api:
       identity_url: 'https://identity.api.rackspacecloud.com/v2.0/'
@@ -76,7 +76,7 @@ accept them
       api_key: <api_key>
       os_auth_plugin: rackspace
       tenant: <userid>
-      provider: nova
+      driver: nova
       networks:
         - net-id: 47a38ff2-fe21-4800-8604-42bd1848e743
         - net-id: 00000000-0000-0000-0000-000000000000

--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -17,7 +17,7 @@ at ``/etc/salt/cloud.providers`` or
       xml_rpc: http://localhost:2633/RPC2
       user: oneadmin
       password: JHGhgsayu32jsa
-      provider: opennebula
+      driver: opennebula
 
 '''
 from __future__ import absolute_import

--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -284,6 +284,12 @@ def create(vm_):
     '''
     Create a single VM from a data dict
     '''
+
+    # Since using "provider: <provider-engine>" is deprecated, alias provider
+    # to use driver: "driver: <provider-engine>"
+    if 'provider' in vm_:
+        vm_['driver'] = vm_.pop('provider')
+
     salt.utils.cloud.fire_event(
         'event',
         'starting create',
@@ -291,7 +297,7 @@ def create(vm_):
         {
             'name': vm_['name'],
             'profile': vm_['profile'],
-            'provider': vm_['provider'],
+            'provider': vm_['driver'],
         },
     )
 
@@ -493,7 +499,7 @@ def create(vm_):
         {
             'name': vm_['name'],
             'profile': vm_['profile'],
-            'provider': vm_['provider'],
+            'provider': vm_['driver'],
         },
     )
 

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -53,7 +53,7 @@ Set up in the cloud configuration at ``/etc/salt/cloud.providers`` or
               /local/path/to/src.txt
       # Skips the service catalog API endpoint, and uses the following
       base_url: http://192.168.1.101:3000/v2/12345
-      provider: openstack
+      driver: openstack
       userdata_file: /tmp/userdata.txt
       # config_drive is required for userdata at rackspace
       config_drive: True

--- a/salt/cloud/clouds/parallels.py
+++ b/salt/cloud/clouds/parallels.py
@@ -270,6 +270,12 @@ def create(vm_):
     '''
     Create a single VM from a data dict
     '''
+
+    # Since using "provider: <provider-engine>" is deprecated, alias provider
+    # to use driver: "driver: <provider-engine>"
+    if 'provider' in vm_:
+        vm_['driver'] = vm_.pop('provider')
+
     salt.utils.cloud.fire_event(
         'event',
         'starting create',
@@ -277,7 +283,7 @@ def create(vm_):
         {
             'name': vm_['name'],
             'profile': vm_['profile'],
-            'provider': vm_['provider'],
+            'provider': vm_['driver'],
         },
         transport=__opts__['transport']
     )
@@ -456,7 +462,7 @@ def create(vm_):
         {
             'name': vm_['name'],
             'profile': vm_['profile'],
-            'provider': vm_['provider'],
+            'provider': vm_['driver'],
         },
         transport=__opts__['transport']
     )

--- a/salt/cloud/clouds/parallels.py
+++ b/salt/cloud/clouds/parallels.py
@@ -16,7 +16,7 @@ Set up the cloud configuration at ``/etc/salt/cloud.providers`` or
       user: myuser
       password: mypassword
       url: https://api.cloud.xmission.com:4465/paci/v1.0/
-      provider: parallels
+      driver: parallels
 
 '''
 

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -480,6 +480,12 @@ def create(vm_):
 
         salt-cloud -p proxmox-ubuntu vmhostname
     '''
+
+    # Since using "provider: <provider-engine>" is deprecated, alias provider
+    # to use driver: "driver: <provider-engine>"
+    if 'provider' in vm_:
+        vm_['driver'] = vm_.pop('provider')
+
     ret = {}
 
     salt.utils.cloud.fire_event(
@@ -489,7 +495,7 @@ def create(vm_):
         {
             'name': vm_['name'],
             'profile': vm_['profile'],
-            'provider': vm_['provider'],
+            'provider': vm_['driver'],
         },
         transport=__opts__['transport']
     )
@@ -675,7 +681,7 @@ def create(vm_):
         {
             'name': vm_['name'],
             'profile': vm_['profile'],
-            'provider': vm_['provider'],
+            'provider': vm_['driver'],
         },
     )
 

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -18,7 +18,7 @@ Set up the cloud configuration at ``/etc/salt/cloud.providers`` or
       user: myuser@pam or myuser@pve
       password: mypassword
       url: hypervisor.domain.tld
-      provider: proxmox
+      driver: proxmox
 
 :maintainer: Frank Klaassen <frank@cloudright.nl>
 :maturity: new

--- a/salt/cloud/clouds/qingcloud.py
+++ b/salt/cloud/clouds/qingcloud.py
@@ -638,6 +638,12 @@ def create(vm_):
         salt-cloud -p qingcloud-ubuntu-c1m1 hostname1
         salt-cloud -m /path/to/mymap.sls -P
     '''
+
+    # Since using "provider: <provider-engine>" is deprecated, alias provider
+    # to use driver: "driver: <provider-engine>"
+    if 'provider' in vm_:
+        vm_['driver'] = vm_.pop('provider')
+
     salt.utils.cloud.fire_event(
         'event',
         'starting create',
@@ -645,7 +651,7 @@ def create(vm_):
         {
             'name': vm_['name'],
             'profile': vm_['profile'],
-            'provider': vm_['provider'],
+            'provider': vm_['driver'],
         },
         transport=__opts__['transport']
     )
@@ -719,7 +725,7 @@ def create(vm_):
         {
             'name': vm_['name'],
             'profile': vm_['profile'],
-            'provider': vm_['provider'],
+            'provider': vm_['driver'],
         },
         transport=__opts__['transport']
     )

--- a/salt/cloud/clouds/qingcloud.py
+++ b/salt/cloud/clouds/qingcloud.py
@@ -17,7 +17,7 @@ Set up the cloud configuration at ``/etc/salt/cloud.providers`` or
 .. code-block:: yaml
 
     my-qingcloud:
-      provider: qingcloud
+      driver: qingcloud
       access_key_id: AKIDMRTGYONNLTFFRBQJ
       secret_access_key: clYwH21U5UOmcov4aNV2V2XocaHCG3JZGcxEczFu
       zone: pek2

--- a/salt/cloud/clouds/rackspace.py
+++ b/salt/cloud/clouds/rackspace.py
@@ -25,7 +25,7 @@ Set up the cloud configuration at ``/etc/salt/cloud.providers`` or
 .. code-block:: yaml
 
     my-rackspace-config:
-      provider: rackspace
+      driver: rackspace
       # The Rackspace login user
       user: fred
       # The Rackspace user's apikey

--- a/salt/cloud/clouds/scaleway.py
+++ b/salt/cloud/clouds/scaleway.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
 Scaleway Cloud Module
-==========================
+=====================
 
 .. versionadded:: Beryllium
 
@@ -17,7 +17,7 @@ the cloud configuration at ``/etc/salt/cloud.providers`` or
       # Scaleway organization and token
       access_key: 0e604a2c-aea6-4081-acb2-e1d1258ef95c
       token: be8fd96b-04eb-4d39-b6ba-a9edbcf17f12
-      provider: scaleway
+      driver: scaleway
 
 :depends: requests
 '''

--- a/salt/cloud/clouds/softlayer.py
+++ b/salt/cloud/clouds/softlayer.py
@@ -17,7 +17,7 @@ configuration at:
       # SoftLayer account api key
       user: MYLOGIN
       apikey: JVkbSJDGHSDKUKSDJfhsdklfjgsjdkflhjlsdfffhgdgjkenrtuinv
-      provider: softlayer
+      driver: softlayer
 
 The SoftLayer Python Library needs to be installed in order to use the
 SoftLayer salt.cloud modules. See: https://pypi.python.org/pypi/SoftLayer

--- a/salt/cloud/clouds/softlayer_hw.py
+++ b/salt/cloud/clouds/softlayer_hw.py
@@ -17,7 +17,7 @@ configuration at:
       # SoftLayer account api key
       user: MYLOGIN
       apikey: JVkbSJDGHSDKUKSDJfhsdklfjgsjdkflhjlsdfffhgdgjkenrtuinv
-      provider: softlayer_hw
+      driver: softlayer_hw
 
 The SoftLayer Python Library needs to be installed in order to use the
 SoftLayer salt.cloud modules. See: https://pypi.python.org/pypi/SoftLayer

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -27,19 +27,19 @@ cloud configuration at
 .. code-block:: yaml
 
     my-vmware-config:
-      provider: vmware
+      driver: vmware
       user: "DOMAIN\\user"
       password: "verybadpass"
       url: "vcenter01.domain.com"
 
     vmware-vcenter02:
-      provider: vmware
+      driver: vmware
       user: "DOMAIN\\user"
       password: "verybadpass"
       url: "vcenter02.domain.com"
 
     vmware-vcenter03:
-      provider: vmware
+      driver: vmware
       user: "DOMAIN\\user"
       password: "verybadpass"
       url: "vcenter03.domain.com"

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2038,6 +2038,12 @@ def create(vm_):
 
         salt-cloud -p vmware-centos6.5 vmname
     '''
+
+    # Since using "provider: <provider-engine>" is deprecated, alias provider
+    # to use driver: "driver: <provider-engine>"
+    if 'provider' in vm_:
+        vm_['driver'] = vm_.pop('provider')
+
     salt.utils.cloud.fire_event(
         'event',
         'starting create',
@@ -2045,7 +2051,7 @@ def create(vm_):
         {
             'name': vm_['name'],
             'profile': vm_['profile'],
-            'provider': vm_['provider'],
+            'provider': vm_['driver'],
         },
         transport=__opts__['transport']
     )
@@ -2313,7 +2319,7 @@ def create(vm_):
             {
                 'name': vm_['name'],
                 'profile': vm_['profile'],
-                'provider': vm_['provider'],
+                'provider': vm_['driver'],
             },
             transport=__opts__['transport']
         )

--- a/salt/cloud/clouds/vsphere.py
+++ b/salt/cloud/clouds/vsphere.py
@@ -204,6 +204,12 @@ def create(vm_):
     '''
     Create a single VM from a data dict
     '''
+
+    # Since using "provider: <provider-engine>" is deprecated, alias provider
+    # to use driver: "driver: <provider-engine>"
+    if 'provider' in vm_:
+        vm_['driver'] = vm_.pop('provider')
+
     salt.utils.cloud.fire_event(
         'event',
         'starting create',
@@ -211,7 +217,7 @@ def create(vm_):
         {
             'name': vm_['name'],
             'profile': vm_['profile'],
-            'provider': vm_['provider'],
+            'provider': vm_['driver'],
         },
         transport=__opts__['transport']
     )
@@ -296,7 +302,7 @@ def create(vm_):
         {
             'name': vm_['name'],
             'profile': vm_['profile'],
-            'provider': vm_['provider'],
+            'provider': vm_['driver'],
         },
         transport=__opts__['transport']
     )

--- a/salt/cloud/clouds/vsphere.py
+++ b/salt/cloud/clouds/vsphere.py
@@ -34,7 +34,7 @@ configuration at:
 .. code-block:: yaml
 
     my-vsphere-config:
-      provider: vsphere
+      driver: vsphere
       user: myuser
       password: verybadpass
       url: 'https://10.1.1.1:443'

--- a/salt/config.py
+++ b/salt/config.py
@@ -2229,11 +2229,11 @@ def get_cloud_config_value(name, vm_, opts, default=None, search_global=True):
                 else:
                     value = deepcopy(opts['profiles'][vm_['profile']][name])
 
-        # Since using "provider: <provider-engine>" is deprecated, alias provider 
+        # Since using "provider: <provider-engine>" is deprecated, alias provider
         # to use driver: "driver: <provider-engine>"
         if 'provider' in vm_:
             vm_['driver'] = vm_.pop('provider')
-            
+
         # Let's get the value from the provider, if present.
         if ':' in vm_['driver']:
             # The provider is defined as <provider-alias>:<driver-name>

--- a/salt/config.py
+++ b/salt/config.py
@@ -52,10 +52,8 @@ if salt.utils.is_windows():
     # support in ZeroMQ, we want the default to be something that has a
     # chance of working.
     _DFLT_IPC_MODE = 'tcp'
-    _DFLT_MULTIPROCESSING_MODE = False
 else:
     _DFLT_IPC_MODE = 'ipc'
-    _DFLT_MULTIPROCESSING_MODE = True
 
 FLO_DIR = os.path.join(
         os.path.dirname(__file__),
@@ -756,7 +754,7 @@ DEFAULT_MINION_OPTS = {
     'open_mode': False,
     'auto_accept': True,
     'autosign_timeout': 120,
-    'multiprocessing': _DFLT_MULTIPROCESSING_MODE,
+    'multiprocessing': True,
     'mine_interval': 60,
     'ipc_mode': _DFLT_IPC_MODE,
     'ipv6': False,
@@ -1568,7 +1566,7 @@ def cloud_config(path, env_var='SALT_CLOUD_CONFIG', defaults=None,
     # entries.
     for idx, entry in enumerate(deploy_scripts_search_path[:]):
         if not os.path.isabs(entry):
-            # Let's try if adding the provided path's directory name turns the
+            # Let's try adding the provided path's directory name turns the
             # entry into a proper directory
             entry = os.path.join(os.path.dirname(path), entry)
 
@@ -1723,15 +1721,25 @@ def apply_cloud_config(overrides, defaults=None):
         for alias, details in six.iteritems(providers):
             if isinstance(details, list):
                 for detail in details:
-                    if 'provider' not in detail:
+                    if 'provider' not in detail and 'driver' not in detail:
                         raise salt.exceptions.SaltCloudConfigError(
-                            'The cloud provider alias {0!r} has an entry '
-                            'missing the required setting \'provider\''.format(
+                            'The cloud provider alias {0!r} has an entry missing the required setting of either'
+                            '\'provider\' or \'driver\'. Note that \'provider\' has been deprecated, so you should '
+                            'use the \'driver\' notation.'.format(
                                 alias
                             )
                         )
+                    elif 'provider' in detail:
+                        salt.utils.warn_until(
+                            'Nitrogen',
+                            'The term \'provider\' is being deprecated in favor of \'driver\'. Support for '
+                            '\'provider\' will be removed in Salt Nitrogen. Please convert your cloud provider '
+                            'configuration files to use \'driver\'.'
+                        )
+                        driver = detail['provider']
+                    elif 'driver' in detail:
+                        driver = detail['driver']
 
-                    driver = detail['provider']
                     if ':' in driver:
                         # Weird, but...
                         alias, driver = driver.split(':')
@@ -1742,14 +1750,23 @@ def apply_cloud_config(overrides, defaults=None):
                     detail['provider'] = '{0}:{1}'.format(alias, driver)
                     config['providers'][alias][driver] = detail
             elif isinstance(details, dict):
-                if 'provider' not in details:
+                if 'provider' not in details and 'driver' not in details:
                     raise salt.exceptions.SaltCloudConfigError(
-                        'The cloud provider alias {0!r} has an entry '
-                        'missing the required setting \'provider\''.format(
+                        'The cloud provider alias {0!r} has an entry missing the required setting of either'
+                        '\'provider\' or \'driver\''.format(
                             alias
                         )
                     )
-                driver = details['provider']
+                elif 'provider' in detail:
+                    salt.utils.warn_until(
+                        'Nitrogen',
+                        'The term \'provider\' is being deprecated in favor of \'driver\' and support for '
+                        '\'provider\' will be removed in Salt Nitrogen. Please convert your cloud provider'
+                        'configuration files to use \'driver\'.'
+                    )
+                    driver = detail['provider']
+                elif 'driver' in detail:
+                    driver = detail['driver']
                 if ':' in driver:
                     # Weird, but...
                     alias, driver = driver.split(':')
@@ -2008,15 +2025,15 @@ def apply_cloud_providers_config(overrides, defaults=None):
             # we won't be able to properly reference it.
             handled_providers = set()
             for details in val:
-                if 'provider' not in details:
+                if 'provider' not in details and 'driver' not in details:
                     if 'extends' not in details:
                         log.error(
                             'Please check your cloud providers configuration. '
-                            'There\'s no \'provider\' nor \'extends\' '
-                            'definition. So it\'s pretty useless.'
+                            'There\'s no \'driver\', \'provider\', nor \'extends\' '
+                            'definition referenced.'
                         )
                     continue
-                if details['provider'] in handled_providers:
+                if details['driver'] in handled_providers or details['provider'] in handled_providers:
                     log.error(
                         'You can only have one entry per cloud provider. For '
                         'example, if you have a cloud provider configuration '
@@ -2031,14 +2048,25 @@ def apply_cloud_providers_config(overrides, defaults=None):
                 handled_providers.add(details['provider'])
 
         for entry in val:
-            if 'provider' not in entry:
-                entry['provider'] = '-only-extendable-{0}'.format(ext_count)
+            # Since using "provider: <provider-engine>" is deprecated, alias provider
+            # to use driver: "driver: <provider-engine>"
+            if 'provider' in entry:
+                salt.utils.warn_until(
+                    'Nitrogen',
+                    'The term \'provider\' is being deprecated in favor of \'driver\'. Support for '
+                    '\'provider\' will be removed in Salt Nitrogen. Please convert your cloud provider '
+                    'configuration files to use \'driver\'.'
+                )
+                entry['driver'] = entry.pop('provider')
+
+            if 'driver' not in entry:
+                entry['driver'] = '-only-extendable-{0}'.format(ext_count)
                 ext_count += 1
 
             if key not in providers:
                 providers[key] = {}
 
-            provider = entry['provider']
+            provider = entry['driver']
             if provider not in providers[key]:
                 providers[key][provider] = entry
 
@@ -2159,11 +2187,10 @@ def apply_cloud_providers_config(overrides, defaults=None):
                 continue
 
             log.info(
-                'There\'s at least one cloud driver details under the {0!r} '
+                'There\'s at least one cloud driver under the {0!r} '
                 'cloud provider alias which does not have the required '
-                '\'provider\' setting. Was probably just used as a holder '
-                'for additional data. Removing it from the available '
-                'providers listing'.format(
+                '\'driver\' setting. Removing it from the available '
+                'providers listing.'.format(
                     provider_alias
                 )
             )
@@ -2202,10 +2229,15 @@ def get_cloud_config_value(name, vm_, opts, default=None, search_global=True):
                 else:
                     value = deepcopy(opts['profiles'][vm_['profile']][name])
 
-        # Let's get the value from the provider, if present
-        if ':' in vm_['provider']:
-            # The provider is defined as <provider-alias>:<provider-name>
-            alias, driver = vm_['provider'].split(':')
+        # Since using "provider: <provider-engine>" is deprecated, alias provider 
+        # to use driver: "driver: <provider-engine>"
+        if 'provider' in vm_:
+            vm_['driver'] = vm_.pop('provider')
+            
+        # Let's get the value from the provider, if present.
+        if ':' in vm_['driver']:
+            # The provider is defined as <provider-alias>:<driver-name>
+            alias, driver = vm_['driver'].split(':')
             if alias in opts['providers'] and \
                     driver in opts['providers'][alias]:
                 details = opts['providers'][alias][driver]
@@ -2214,23 +2246,23 @@ def get_cloud_config_value(name, vm_, opts, default=None, search_global=True):
                         value.update(details[name].copy())
                     else:
                         value = deepcopy(details[name])
-        elif len(opts['providers'].get(vm_['provider'], ())) > 1:
-            # The provider is NOT defined as <provider-alias>:<provider-name>
+        elif len(opts['providers'].get(vm_['driver'], ())) > 1:
+            # The provider is NOT defined as <provider-alias>:<driver-name>
             # and there's more than one entry under the alias.
             # WARN the user!!!!
             log.error(
                 'The {0!r} cloud provider definition has more than one '
                 'entry. Your VM configuration should be specifying the '
-                'provider as \'provider: {0}:<provider-engine>\'. Since '
+                'provider as \'driver: {0}:<driver-engine>\'. Since '
                 'it\'s not, we\'re returning the first definition which '
                 'might not be what you intended.'.format(
-                    vm_['provider']
+                    vm_['driver']
                 )
             )
 
-        if vm_['provider'] in opts['providers']:
+        if vm_['driver'] in opts['providers']:
             # There's only one driver defined for this provider. This is safe.
-            alias_defs = opts['providers'].get(vm_['provider'])
+            alias_defs = opts['providers'].get(vm_['driver'])
             provider_driver_defs = alias_defs[next(iter(list(alias_defs.keys())))]
             if name in provider_driver_defs:
                 # The setting name exists in the VM's provider configuration.

--- a/salt/config.py
+++ b/salt/config.py
@@ -2244,11 +2244,11 @@ def get_cloud_config_value(name, vm_, opts, default=None, search_global=True):
                 else:
                     value = deepcopy(opts['profiles'][vm_['profile']][name])
 
-        # Since using "provider: <provider-engine>" is deprecated, alias provider 
+        # Since using "provider: <provider-engine>" is deprecated, alias provider
         # to use driver: "driver: <provider-engine>"
         if 'provider' in vm_:
             vm_['driver'] = vm_.pop('provider')
-            
+
         # Let's get the value from the provider, if present.
         if ':' in vm_['driver']:
             # The provider is defined as <provider-alias>:<driver-name>

--- a/salt/version.py
+++ b/salt/version.py
@@ -86,7 +86,7 @@ class SaltStackVersion(object):
         'Beryllium'     : (MAX_SIZE - 105, 0),
         'Boron'         : (MAX_SIZE - 104, 0),
         'Carbon'        : (MAX_SIZE - 103, 0),
-        #'Nitrogen'     : (MAX_SIZE - 102, 0),
+        'Nitrogen'      : (MAX_SIZE - 102, 0),
         #'Oxygen'       : (MAX_SIZE - 101, 0),
         #'Fluorine'     : (MAX_SIZE - 100, 0),
         #'Neon'         : (MAX_SIZE - 99 , 0),

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -486,27 +486,27 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
     @patch('salt.config.old_to_new',
            MagicMock(return_value={'default_include': 'path/to/some/cloud/conf/file',
                                    'providers': {'foo': {'bar': {
-                                       'provider': 'foo:bar'}}}}))
+                                       'driver': 'foo:bar'}}}}))
     def test_apply_cloud_config_success_list(self):
         '''
         Tests success when valid data is passed into the function as a list
         '''
-        overrides = {'providers': {'foo': [{'provider': 'bar'}]}}
+        overrides = {'providers': {'foo': [{'driver': 'bar'}]}}
         ret = {'default_include': 'path/to/some/cloud/conf/file',
-               'providers': {'foo': {'bar': {'provider': 'foo:bar'}}}}
+               'providers': {'foo': {'bar': {'driver': 'foo:bar'}}}}
         self.assertEqual(sconfig.apply_cloud_config(overrides, defaults=DEFAULT), ret)
 
     @patch('salt.config.old_to_new',
            MagicMock(return_value={'default_include': 'path/to/some/cloud/conf/file',
                                    'providers': {'foo': {'bar': {
-                                       'provider': 'foo:bar'}}}}))
+                                       'driver': 'foo:bar'}}}}))
     def test_apply_cloud_config_success_dict(self):
         '''
         Tests success when valid data is passed into function as a dictionary
         '''
-        overrides = {'providers': {'foo': {'provider': 'bar'}}}
+        overrides = {'providers': {'foo': {'driver': 'bar'}}}
         ret = {'default_include': 'path/to/some/cloud/conf/file',
-               'providers': {'foo': {'bar': {'provider': 'foo:bar'}}}}
+               'providers': {'foo': {'bar': {'driver': 'foo:bar'}}}}
         self.assertEqual(sconfig.apply_cloud_config(overrides, defaults=DEFAULT), ret)
 
     # apply_vm_profiles_config tests
@@ -525,7 +525,7 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
         '''
         providers = {'test-provider':
                          {'digital_ocean':
-                              {'provider': 'digital_ocean', 'profiles': {}}}}
+                              {'driver': 'digital_ocean', 'profiles': {}}}}
         overrides = {'test-profile':
                          {'provider': 'test-provider',
                           'image': 'Ubuntu 12.10 x64',
@@ -544,7 +544,7 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
         '''
         Tests profile extends functionality with valid provider and profile configs
         '''
-        providers = {'test-config': {'ec2': {'profiles': {}, 'provider': 'ec2'}}}
+        providers = {'test-config': {'ec2': {'profiles': {}, 'driver': 'ec2'}}}
         overrides = {'Amazon': {'image': 'test-image-1',
                                 'extends': 'dev-instances'},
                      'Fedora': {'image': 'test-image-2',
@@ -576,10 +576,10 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
         overrides = {'my-dev-envs':
                          [{'id': 'ABCDEFGHIJKLMNOP',
                            'key': 'supersecretkeysupersecretkey',
-                           'provider': 'ec2'},
+                           'driver': 'ec2'},
                           {'apikey': 'abcdefghijklmnopqrstuvwxyz',
                            'password': 'supersecret',
-                           'provider': 'ec2'}],
+                           'driver': 'ec2'}],
                      'conf_file': PATH}
         self.assertRaises(SaltCloudConfigError,
                           sconfig.apply_cloud_providers_config,
@@ -600,11 +600,11 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
                            'user': 'user@mycorp.com',
                            'location': 'ap-southeast-1',
                            'key': 'supersecretkeysupersecretkey',
-                           'provider': 'ec2'
+                           'driver': 'ec2'
                           },
                           {'apikey': 'abcdefghijklmnopqrstuvwxyz',
                            'password': 'supersecret',
-                           'provider': 'linode'
+                           'driver': 'linode'
                           }],
                      'conf_file': PATH}
         ret = {'my-production-envs':
@@ -612,7 +612,7 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
                         {'profiles': {},
                          'location': 'us-east-1',
                          'key': 'supersecretkeysupersecretkey',
-                         'provider': 'ec2',
+                         'driver': 'ec2',
                          'id': 'ABCDEFGHIJKLMNOP',
                          'user': 'ec2-user@mycorp.com'}},
                'my-dev-envs':
@@ -620,12 +620,12 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
                         {'apikey': 'abcdefghijklmnopqrstuvwxyz',
                          'password': 'supersecret',
                          'profiles': {},
-                         'provider': 'linode'},
+                         'driver': 'linode'},
                     'ec2':
                         {'profiles': {},
                          'location': 'ap-southeast-1',
                          'key': 'supersecretkeysupersecretkey',
-                         'provider': 'ec2',
+                         'driver': 'ec2',
                          'id': 'ABCDEFGHIJKLMNOP',
                          'user': 'user@mycorp.com'}}}
         self.assertEqual(ret,
@@ -650,22 +650,22 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
                            'user': 'user@mycorp.com',
                            'location': 'ap-southeast-1',
                            'key': 'supersecretkeysupersecretkey',
-                           'provider': 'ec2'},
+                           'driver': 'ec2'},
                           {'apikey': 'abcdefghijklmnopqrstuvwxyz',
                            'password': 'supersecret',
-                           'provider': 'linode'}],
+                           'driver': 'linode'}],
                      'conf_file': PATH}
         ret = {'my-production-envs':
                    {'linode':
                         {'apikey': 'abcdefghijklmnopqrstuvwxyz',
                          'profiles': {},
                          'location': 'Salt Lake City',
-                         'provider': 'linode',
+                         'driver': 'linode',
                          'password': 'new-password'},
                     'ec2':
                         {'user': 'ec2-user@mycorp.com',
                          'key': 'supersecretkeysupersecretkey',
-                         'provider': 'ec2',
+                         'driver': 'ec2',
                          'id': 'ABCDEFGHIJKLMNOP',
                          'profiles': {},
                          'location': 'us-east-1'}},
@@ -674,12 +674,12 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
                         {'apikey': 'abcdefghijklmnopqrstuvwxyz',
                          'password': 'supersecret',
                          'profiles': {},
-                         'provider': 'linode'},
+                         'driver': 'linode'},
                     'ec2':
                         {'profiles': {},
                          'user': 'user@mycorp.com',
                          'key': 'supersecretkeysupersecretkey',
-                         'provider': 'ec2',
+                         'driver': 'ec2',
                          'id': 'ABCDEFGHIJKLMNOP',
                          'location': 'ap-southeast-1'}}}
         self.assertEqual(ret, sconfig.apply_cloud_providers_config(
@@ -699,7 +699,7 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
                            'user': 'user@mycorp.com',
                            'location': 'ap-southeast-1',
                            'key': 'supersecretkeysupersecretkey',
-                           'provider': 'ec2'}],
+                           'driver': 'ec2'}],
                      'conf_file': PATH}
         self.assertRaises(SaltCloudConfigError,
                           sconfig.apply_cloud_providers_config,
@@ -719,7 +719,7 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
                            'user': 'user@mycorp.com',
                            'location': 'ap-southeast-1',
                            'key': 'supersecretkeysupersecretkey',
-                           'provider': 'ec2'}],
+                           'driver': 'ec2'}],
                      'conf_file': PATH}
         self.assertRaises(SaltCloudConfigError,
                           sconfig.apply_cloud_providers_config,
@@ -739,7 +739,7 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
                            'user': 'user@mycorp.com',
                            'location': 'ap-southeast-1',
                            'key': 'supersecretkeysupersecretkey',
-                           'provider': 'linode'}],
+                           'driver': 'linode'}],
                      'conf_file': PATH}
         self.assertRaises(SaltCloudConfigError,
                           sconfig.apply_cloud_providers_config,
@@ -759,7 +759,7 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
                            'user': 'user@mycorp.com',
                            'location': 'ap-southeast-1',
                            'key': 'supersecretkeysupersecretkey',
-                           'provider': 'linode'}],
+                           'driver': 'linode'}],
                      'conf_file': PATH}
         self.assertRaises(SaltCloudConfigError,
                           sconfig.apply_cloud_providers_config,


### PR DESCRIPTION
The use of `provider: <provider-engine>` has been deprecated in favor of `driver: <engine-provider>` to help reduce confusion in defining `provider: my-ec2-config` in the profile file, and then `provider: ec2` in the provider file. This can get confusing pretty quickly. Replacing `provider` with `driver` in provider files should help clear up this confusion. 

Here's an example provider file with the change:

```
my-ec2-cloud-config:
  id: 'HJGRYCILJLKJYG'
  key: 'kdjgfsgm;woormgl/aserigjksjdhasdfgn'
  private_key: /etc/salt/my_test_key.pem
  keyname: my_test_key
  securitygroup: default
  driver: ec2
```

Both options will work until the Nitrogen release of Salt.
