### PR TITLE
Fix failing zmq tests

### DIFF
--- a/tests/unit/transport/zeromq_test.py
+++ b/tests/unit/transport/zeromq_test.py
@@ -7,6 +7,7 @@
 from __future__ import absolute_import
 import os
 import threading
+import time
 
 import zmq.eventloop.ioloop
 # support pyzmq 13.0.x, TODO: remove once we force people to 14.0.x
@@ -74,6 +75,7 @@ class BaseZMQReqCase(TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.process_manager.kill_children()
+        time.sleep(2)  # Give the procs a chance to fully close before we stop the io_loop
         cls.io_loop.stop()
         cls.server_channel.close()
 


### PR DESCRIPTION
This is just a stopgap to prevent the ioloop from shutting down before the procs die off.
