### PR TITLE
Correctly create single item list for failover master type with string value for master opt

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -802,7 +802,7 @@ class Minion(MinionBase):
                 elif isinstance(opts['master'], str) and ('master_list' not in opts):
                     # We have a string, but a list was what was intended. Convert.
                     # See issue 23611 for details
-                    opts['master'] = list(opts['master'])
+                    opts['master'] = [opts['master']]
                 elif opts['__role'] == 'syndic':
                     log.info('Syndic setting master_syndic to \'{0}\''.format(opts['master']))
 


### PR DESCRIPTION
This is in relation to the issue https://github.com/saltstack/salt/issues/24434

The fix in https://github.com/saltstack/salt/pull/23637 is intended to create a list with a single element that is the master name provided, however it actually creates a list of characters in the master string, which means the minion will think that each character is a potential master and try to resolve/connect to it.

```
>>> master = 'master.foo.org'
>>> [master] # what we want
['master.foo.org']
>>> list(master) # current behavior
['m', 'a', 's', 't', 'e', 'r', '.', 'f', 'o', 'o', '.', 'o', 'r', 'g']
```
