### PR TITLE
Add notes to map and gogrid docs -- don't use -P with map files

### DIFF
--- a/doc/topics/cloud/gogrid.rst
+++ b/doc/topics/cloud/gogrid.rst
@@ -24,6 +24,14 @@ in the configuration file to enable interfacing with GoGrid:
       apikey: asdff7896asdh789
       sharedsecret: saltybacon
 
+.. note::
+
+    A Note about using Map files with GoGrid:
+
+    Due to limitations in the GoGrid API, instances cannot be provisioned in parallel
+    with the GoGrid driver. Map files will work with GoGrid, but the ``-P``
+    argument should not be used on maps referencing GoGrid instances.
+
 
 Profiles
 ========

--- a/doc/topics/cloud/map.rst
+++ b/doc/topics/cloud/map.rst
@@ -39,6 +39,12 @@ to create the virtual machines in parallel:
 
     $ salt-cloud -m /path/to/mapfile -P
 
+.. note::
+
+    Due to limitations in the GoGrid API, instances cannot be provisioned in parallel
+    with the GoGrid driver. Map files will work with GoGrid, but the ``-P``
+    argument should not be used on maps referencing GoGrid instances.
+
 A map file can also be enforced to represent the total state of a cloud
 deployment by using the ``--hard`` option. When using the hard option any vms
 that exist but are not specified in the map file will be destroyed:

--- a/salt/cloud/clouds/gogrid.py
+++ b/salt/cloud/clouds/gogrid.py
@@ -20,6 +20,14 @@ Set up the cloud configuration at ``/etc/salt/cloud.providers`` or
       sharedsecret: saltybacon
       provider: gogrid
 
+.. note::
+
+    A Note about using Map files with GoGrid:
+
+    Due to limitations in the GoGrid API, instances cannot be provisioned in parallel
+    with the GoGrid driver. Map files will work with GoGrid, but the ``-P``
+    argument should not be used on maps referencing GoGrid instances.
+
 '''
 from __future__ import absolute_import
 


### PR DESCRIPTION
GoGrid's API doesn't like asynchronous calls, which gives trouble when trying to use map files in parallel. Let's warn users about that.

Refs #14666
