### PR TITLE
Introduce master_uri_format config

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -70,6 +70,11 @@ VALID_OPTS = {
     # or 'func'. If 'func' is specified, the 'master' option should be set to an exec
     # module function to run to determine the master hostname.
     'master_type': str,
+    
+    # Specify the format in which the master address will be specified. Can
+    # specify 'default' or 'ip_port'. If 'ip_port' is specified, then the
+    # master address can be specified as an IP:PORT string.
+    'master_uri_format': str,
 
     # The fingerprint of the master key may be specified to increase security. Generate
     # a master fingerprint with `salt-key -F master`
@@ -681,6 +686,7 @@ DEFAULT_MINION_OPTS = {
     'interface': '0.0.0.0',
     'master': 'salt',
     'master_type': 'str',
+    'master_uri_format': 'default',
     'master_port': '4506',
     'master_finger': '',
     'master_shuffle': False,


### PR DESCRIPTION
We've started playing with running multiple salt-masters to talk to our minions (using docker). This allows us to test new things in salt, but if anything goes bad, we can quickly switch back to the reliable salt-masters.

Because we have multiple salt-masters running on one machine we want to specify them on different ports.

Unfortunately I could not find a way in salt minion config to specify a different port per master, also the salt-minion DNS lookup doesn't support SRV records (which is also worth exploring in my opinion).

This patch introduces an optional "master_uri_format" option to salt-minion config. This allows different ports per salt master. This enables me to specify a configuration such as:

```
master_uri_format: ip_port
master:
  - saltmaster1:1235
  - saltmaster2:1236
```

This is also compatible with failover and the "master-type: func" options.

I was concerned about the master's publish_port because in http://docs.saltstack.com/en/latest/topics/tutorials/intro_scale.html it's mentioned that the minion connects to the master using the publish_port (not ret_port). Based on my testing this is not the case. Maybe I'm missing something?
