### PR TITLE
Make the GoGrid Cloud Provider Tests work

### DIFF
--- a/tests/integration/cloud/providers/gogrid.py
+++ b/tests/integration/cloud/providers/gogrid.py
@@ -17,6 +17,7 @@ ensure_in_syspath('../../../')
 # Import Salt Libs
 import integration
 from salt.config import cloud_providers_config
+from salt.ext.six.moves import range
 
 
 def __random_name(size=6):

--- a/tests/integration/cloud/providers/gogrid.py
+++ b/tests/integration/cloud/providers/gogrid.py
@@ -6,9 +6,10 @@
 # Import Python Libs
 from __future__ import absolute_import
 import os
+import random
+import string
 
 # Import Salt Testing Libs
-from salttesting import skipIf
 from salttesting.helpers import ensure_in_syspath, expensiveTest
 
 ensure_in_syspath('../../../')
@@ -18,7 +19,20 @@ import integration
 from salt.config import cloud_providers_config
 
 
-@skipIf(True, 'waiting on bug report fixes from #13365')
+def __random_name(size=6):
+    '''
+    Generates a random cloud instance name
+    '''
+    return 'CLOUD-TEST-' + ''.join(
+        random.choice(string.ascii_uppercase + string.digits)
+        for x in range(size)
+    )
+
+# Create the cloud instance name to be used throughout the tests
+INSTANCE_NAME = __random_name()
+PROVIDER_NAME = 'gogrid'
+
+
 class GoGridTest(integration.ShellCase):
     '''
     Integration tests for the GoGrid cloud provider in Salt-Cloud
@@ -32,53 +46,55 @@ class GoGridTest(integration.ShellCase):
         super(GoGridTest, self).setUp()
 
         # check if appropriate cloud provider and profile files are present
-        profile_str = 'gogrid-config:'
-        provider = 'gogrid'
+        profile_str = 'gogrid-config'
         providers = self.run_cloud('--list-providers')
-        if profile_str not in providers:
+        if profile_str + ':' not in providers:
             self.skipTest(
                 'Configuration file for {0} was not found. Check {0}.conf files '
                 'in tests/integration/files/conf/cloud.*.d/ to run these tests.'
-                .format(provider)
+                .format(PROVIDER_NAME)
             )
 
         # check if client_key and api_key are present
-        path = os.path.join(integration.FILES,
-                            'conf',
-                            'cloud.providers.d',
-                            provider + '.conf')
-        config = cloud_providers_config(path)
-        api = config['gogrid-config']['gogrid']['apikey']
-        shared_secret = config['gogrid-config']['gogrid']['sharedsecret']
+        config = cloud_providers_config(
+            os.path.join(
+                integration.FILES,
+                'conf',
+                'cloud.providers.d',
+                PROVIDER_NAME + '.conf'
+            )
+        )
+
+        api = config[profile_str][PROVIDER_NAME]['apikey']
+        shared_secret = config[profile_str][PROVIDER_NAME]['sharedsecret']
+
         if api == '' or shared_secret == '':
             self.skipTest(
                 'An api key and shared secret must be provided to run these tests. '
                 'Check tests/integration/files/conf/cloud.providers.d/{0}.conf'
-                .format(provider)
+                .format(PROVIDER_NAME)
             )
 
     def test_instance(self):
         '''
         Test creating an instance on GoGrid
         '''
-        name = 'gogrid-testing'
-
-        # create the instance
-        instance = self.run_cloud('-p gogrid-test {0}'.format(name))
-        ret_str = '        {0}'.format(name)
-
         # check if instance with salt installed returned
         try:
-            self.assertIn(ret_str, instance)
+            self.assertIn(
+                INSTANCE_NAME,
+                [i.strip() for i in self.run_cloud('-p gogrid-test {0}'.format(INSTANCE_NAME))]
+            )
         except AssertionError:
-            self.run_cloud('-d {0} --assume-yes'.format(name))
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
             raise
 
         # delete the instance
-        delete = self.run_cloud('-d {0} --assume-yes'.format(name))
-        ret_str = '            True'
         try:
-            self.assertIn(ret_str, delete)
+            self.assertIn(
+                'True',
+                [i.strip() for i in self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))]
+            )
         except AssertionError:
             raise
 


### PR DESCRIPTION
The GoGrid driver was broken for a long time, so these tests were disabled. This PR enables the GoGrid Cloud Provider tests to run again on the nightly cloud test builds for Jenkins.
