### PR TITLE
Cherrypy timeout

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -151,7 +151,7 @@ class SyncClientMixin(object):
         ret_tag = salt.utils.event.tagify('ret', base=job['tag'])
 
         if timeout is None:
-            timeout = 300
+            timeout = self.opts.get('rest_timeout', 300)
         ret = event.get_event(tag=ret_tag, full=True, wait=timeout)
         if ret is None:
             raise salt.exceptions.SaltClientTimeout(

--- a/salt/config.py
+++ b/salt/config.py
@@ -676,6 +676,9 @@ VALID_OPTS = {
 
     # Used strictly for performance testing in RAET.
     'dummy_publisher': bool,
+
+    # Used by salt-api for master requests timeout
+    'rest_timeout': int,
 }
 
 # default configurations
@@ -1065,6 +1068,7 @@ DEFAULT_API_OPTS = {
     # ----- Salt master settings overridden by Salt-API --------------------->
     'pidfile': '/var/run/salt-api.pid',
     'logfile': '/var/log/salt/api',
+    'rest_timeout': 300,
     # <---- Salt master settings overridden by Salt-API ----------------------
 }
 

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -1069,18 +1069,21 @@ class Jobs(LowDataAdapter):
                 - 2
                 - 6.9141387939453125e-06
         '''
-        lowstate = [{
-            'client': 'runner',
-            'fun': 'jobs.lookup_jid' if jid else 'jobs.list_jobs',
-            'jid': jid,
-        }]
-
         if jid:
-            lowstate.append({
+            lowstate = [{
+                'client': 'runner',
+                'fun': 'jobs.lookup_jid',
+                'args': (jid,),
+            }, {
                 'client': 'runner',
                 'fun': 'jobs.list_job',
-                'jid': jid,
-            })
+                'args': (jid,),
+            }]
+        else:
+            lowstate = [{
+                'client': 'runner',
+                'fun': 'jobs.list_jobs',
+            }]
 
         cherrypy.request.lowstate = lowstate
         job_ret_info = list(self.exec_lowstate(

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -988,7 +988,7 @@ class Jobs(LowDataAdapter):
         'tools.salt_auth.on': True,
     })
 
-    def GET(self, jid=None):
+    def GET(self, jid=None, timeout=''):
         '''
         A convenience URL for getting lists of previously run jobs or getting
         the return from a single job
@@ -1069,20 +1069,24 @@ class Jobs(LowDataAdapter):
                 - 2
                 - 6.9141387939453125e-06
         '''
+        timeout = int(timeout) if timeout.isdigit() else None
         if jid:
             lowstate = [{
                 'client': 'runner',
                 'fun': 'jobs.lookup_jid',
                 'args': (jid,),
+                'timeout': timeout,
             }, {
                 'client': 'runner',
                 'fun': 'jobs.list_job',
                 'args': (jid,),
+                'timeout': timeout,
             }]
         else:
             lowstate = [{
                 'client': 'runner',
                 'fun': 'jobs.list_jobs',
+                'timeout': timeout,
             }]
 
         cherrypy.request.lowstate = lowstate

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -101,7 +101,7 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
             })
         '''
         reformatted_low = self._reformat_low(low)
-        return mixins.SyncClientMixin.cmd_sync(self, reformatted_low)
+        return mixins.SyncClientMixin.cmd_sync(self, reformatted_low, timeout)
 
 
 class Runner(RunnerClient):


### PR DESCRIPTION
Related to #23408
- Fixed jobs/<id> API request broken in develop.
- Added rest_timeout salt-api config option and ?timeout=<val> 'jobs' rest call param
