### PR TITLE
Don't incur a "_load_all" of the lazy_loader while looking for mod_init.

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -609,7 +609,7 @@ class State(object):
         mod_init function in the state module.
         '''
         # ensure that the module is loaded
-        self.states['{0}.{1}'.format(low['state'], low['fun'])]
+        self.states['{0}.{1}'.format(low['state'], low['fun'])]  # pylint: disable=W0106
         minit = '{0}.mod_init'.format(low['state'])
         if low['state'] not in self.mod_init:
             if minit in self.states._dict:

--- a/salt/state.py
+++ b/salt/state.py
@@ -608,9 +608,11 @@ class State(object):
         of a state package that has a mod_init function, then execute the
         mod_init function in the state module.
         '''
+        # ensure that the module is loaded
+        self.states['{0}.{1}'.format(low['state'], low['fun'])]
         minit = '{0}.mod_init'.format(low['state'])
         if low['state'] not in self.mod_init:
-            if minit in self.states:
+            if minit in self.states._dict:
                 mret = self.states[minit](low)
                 if not mret:
                     return


### PR DESCRIPTION
Since we were checking if mod_init is in the loader dict-- and we still allow for module merging (#20540) we will do a load_all for every module without mod_init. This patch makes it so we load w/e module the function is in, then check if we have loaded a mod_init. This cuts out ~600ms on my local simple state.sls runs
