### PR TITLE
Added --trusted-host option to pip.installed.

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -269,7 +269,8 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
             __env__=None,
             saltenv='base',
             env_vars=None,
-            use_vt=False):
+            use_vt=False,
+            trusted_host=None):
     '''
     Install packages with pip
 
@@ -387,6 +388,9 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
         Set environment variables that some builds will depend on. For example,
         a Python C-module may have a Makefile that needs INCLUDE_PATH set to
         pick up a header file while compiling.
+    trusted_host
+        Mark this host as trusted, even though it does not have valid or any
+        HTTPS.
 
 
     CLI Example:
@@ -662,6 +666,9 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
 
     if env_vars:
         os.environ.update(env_vars)
+
+    if trusted_host:
+        cmd.append('--trusted-host {0}'.format(trusted_host))
 
     try:
         cmd_kwargs = dict(cwd=cwd, saltenv=saltenv, use_vt=use_vt, runas=user)

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -235,7 +235,8 @@ def installed(name,
               allow_unverified=None,
               process_dependency_links=False,
               env_vars=None,
-              use_vt=False):
+              use_vt=False,
+              trusted_host=None):
     '''
     Make sure the package is installed
 
@@ -383,6 +384,10 @@ def installed(name,
 
     use_vt
         Use VT terminal emulation (see ouptut while installing)
+
+    trusted_host
+        Mark this host as trusted, even though it does not have valid or any
+        HTTPS.
 
     Example:
 
@@ -663,7 +668,8 @@ def installed(name,
         process_dependency_links=process_dependency_links,
         saltenv=__env__,
         env_vars=env_vars,
-        use_vt=use_vt
+        use_vt=use_vt,
+        trusted_host=trusted_host
     )
 
     if pip_install_call and (pip_install_call.get('retcode', 1) == 0):


### PR DESCRIPTION
Example:

test:
  pip.installed:
    - name: https://192.168.122.50/a-0.1.tar.gz
    - trusted_host: 192.168.122.50
