### PR TITLE
fix for issue #24799

### DIFF
--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -220,6 +220,7 @@ def mounted(name,
                     'nonempty',
                     'transform_symlinks',
                     'port',
+                    'backup-volfile-servers',
                 ]
                 # options which are provided as key=value (e.g. password=Zohp5ohb)
                 mount_invisible_keys = [


### PR DESCRIPTION
added option backup-volfile-servers to mount.py state, needed when using glusterfs, otherwise remount is forced every time
