### PR TITLE
fix bug in docker.loaded

### DIFF
--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -1874,7 +1874,7 @@ def load(imagepath):
     if os.path.isfile(imagepath):
         try:
             dockercmd = ['docker', 'load', '-i', imagepath]
-            ret = __salt__['cmd.run'](dockercmd)
+            ret = __salt__['cmd.run'](dockercmd, python_shell=False)
             if ((isinstance(ret, dict) and
                 ('retcode' in ret) and
                 (ret['retcode'] != 0))):


### PR DESCRIPTION
`cmd.run` only accepts a list if `python_shell` is `True`, so before this it was just running `docker`, rather than actually loading the image.
