### PR TITLE
unset size parameter for lxc.create when backing=zfs

### DIFF
--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -1926,7 +1926,7 @@ def create(name,
     lvname = select('lvname')
     fstype = select('fstype')
     size = select('size', '1G')
-    if backing in ('dir', 'overlayfs', 'btrfs'):
+    if backing in ('dir', 'overlayfs', 'btrfs', 'zfs'):
         fstype = None
         size = None
     # some backends wont support some parameters


### PR DESCRIPTION
When using the lxc.create parameter backing=zfs the default 1G size parameter kicks in, which sadly makes the lxc-create call fail.

LXC backing store type zfs does not support setting the container storage size ATM.

This fixes this error message in the minion log:

2015-06-20 02:00:57,588 [salt.minion      ][ERROR   ][3694] A command in 'lxc.create' had a problem: Container could not be created with cmd 'lxc-create -n test-container -t download -B zfs --fssize 1G -- --release trusty --arch amd64 --dist ubuntu': filesystem type and size are only valid with block devices
