### PR TITLE
Fix issue 24851: regular expression so it now matches packages with '.' or '-' at pkg name

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1487,9 +1487,9 @@ def get_locked_packages(pattern=None, full=True):
             _pat = r'\d\:({0}\-\S+)'.format(pattern)
     else:
         if full:
-            _pat = r'(\d\:\w+\-\S+)'
+            _pat = r'(\d\:\w+(?:[\.\-][^\-]+)*-\S+)'
         else:
-            _pat = r'\d\:(\w+\-\S+)'
+            _pat = r'\d\:(\w+(?:[\.\-][^\-]+)*-\S+)'
     pat = re.compile(_pat)
 
     current_locks = []


### PR DESCRIPTION
This pull-req fixes issue: https://github.com/saltstack/salt/issues/24851
