### PR TITLE
boto_cfn: allow for optional keys in describe

### DIFF
--- a/salt/modules/boto_cfn.py
+++ b/salt/modules/boto_cfn.py
@@ -109,7 +109,7 @@ def describe(name, region=None, key=None, keyid=None, profile=None):
             log.debug('Found VPC: {0}'.format(stack.stack_id))
             keys = ('stack_id', 'description', 'stack_status', 'stack_status_reason')
 
-            ret = dict([(k, getattr(stack, k)) for k in keys])
+            ret = dict([(k, getattr(stack, k)) for k in keys if hasattr(stack, k)])
             o = getattr(stack, 'outputs')
             outputs = {}
             for i in o:


### PR DESCRIPTION
``` pytb
  File "/home/ubuntu/salt/salt/modules/boto_cfn.py", line 112, in describe
    ret = dict([(k, getattr(stack, k)) for k in keys])
AttributeError: 'Stack' object has no attribute 'stack_status_reason'
```

Alternatively, default to `None`:

``` python
ret = dict([(k, getattr(stack, k, None)) for k in keys])
```

@thatch45, @ryan-lane: any preference?
