### PR TITLE
Don't error log missing IFTTT keys

### DIFF
--- a/salt/modules/ifttt.py
+++ b/salt/modules/ifttt.py
@@ -29,8 +29,7 @@ def __virtual__():
     '''
     if not __salt__['config.get']('ifttt.secret_key') and \
        not __salt__['config.get']('ifttt:secret_key'):
-        log.error('IFTTT Secret Key Unavailable, not loading.')
-        return False
+        return (False, 'IFTTT Secret Key Unavailable, not loading.')
     return True
 
 


### PR DESCRIPTION
Also uses the the tuple-variant of `__virtual__` by returning a tuple with the reason, which puts the reason in the debug log.
