### PR TITLE
Be more careful about stripping away root_dir from directory options

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -911,11 +911,11 @@ def prepend_root_dir(opts, path_options):
     'root_dir' option.
     '''
     root_dir = os.path.abspath(opts['root_dir'])
-    root_opt = opts['root_dir'].rstrip(os.pathsep)
+    root_opt = opts['root_dir'].rstrip(os.sep)
     for path_option in path_options:
         if path_option in opts:
             path = opts[path_option]
-            if path == root_opt or path.startswith(root_opt + os.pathsep):
+            if path == root_opt or path.startswith(root_opt + os.sep):
                 path = path[len(root_opt):]
             opts[path_option] = salt.utils.path_join(root_dir, path)
 

--- a/salt/config.py
+++ b/salt/config.py
@@ -911,14 +911,13 @@ def prepend_root_dir(opts, path_options):
     'root_dir' option.
     '''
     root_dir = os.path.abspath(opts['root_dir'])
+    root_opt = opts['root_dir'].rstrip(os.pathsep)
     for path_option in path_options:
         if path_option in opts:
-            if opts[path_option].startswith(opts['root_dir']):
-                opts[path_option] = opts[path_option][len(opts['root_dir']):]
-            opts[path_option] = salt.utils.path_join(
-                root_dir,
-                opts[path_option]
-            )
+            path = opts[path_option]
+            if path == root_opt or path.startswith(root_opt + os.pathsep):
+                path = path[len(root_opt):]
+            opts[path_option] = salt.utils.path_join(root_dir, path)
 
 
 def insert_system_path(opts, paths):


### PR DESCRIPTION
Given the following config:

``` yml
root_dir: .
cachedir: .cache
```

`".cache".startswith(".")` will return true, but the `.` definitely should not be stripped from the string.

Closes #24885
