### PR TITLE
Fix minion failover, document same

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -22,6 +22,18 @@
 # If only one master is listed, this setting is ignored and a warning will be logged.
 #random_master: False
 
+# Minions can connect to multiple masters simultaneously (all masters
+# are "hot"), or can be configured to failover if a master becomes
+# unavailable.  Multiple hot masters are configured by setting this
+# value to "standard".  Failover masters can be requested by setting
+# to "failover".  MAKE SURE TO SET master_alive_interval if you are
+# using failover.
+# master_type: standard
+
+# Poll interval in seconds for checking if the master is still there.  Only
+# respected if master_type above is "failover".
+# master_alive_interval: 30
+
 # Set whether the minion should connect to the master via IPv6:
 #ipv6: False
 

--- a/doc/contents-2.rst
+++ b/doc/contents-2.rst
@@ -9,6 +9,7 @@ Salt Table of Contents
     topics/jobs/index
     topics/event/index
     topics/topology/index
+    topics/highavailability/index
     topics/windows/index
     topics/cloud/index
     topics/netapi/index

--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -21,6 +21,7 @@ Salt Table of Contents
     topics/event/index
     topics/beacons/index
     topics/ext_processes/index
+    topics/highavailability/index
     topics/topology/index
     topics/transports/raet/index
     topics/windows/index

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -82,10 +82,24 @@ The option can can also be set to a list of masters, enabling
 
 .. versionadded:: 2014.7.0
 
-Default: ``str``
+Default: ``standard``
 
-The type of the :conf_minion:`master` variable. Can be either ``func`` or
-``failover``.
+The type of the :conf_minion:`master` variable. Can be ``standard``, ``failover`` or
+``func``.
+
+.. code-block:: yaml
+
+    master_type: failover
+
+If this option is set to ``failover``, :conf_minion:`master` must be a list of
+master addresses. The minion will then try each master in the order specified
+in the list until it successfully connects.  :conf_minion:`master_alive_interval`
+must also be set, this determines how often the minion will verify the presence
+of the master.
+
+.. code-block:: yaml
+
+    master_type: func
 
 If the master needs to be dynamically assigned by executing a function instead
 of reading in the static master value, set this to ``func``. This can be used
@@ -93,19 +107,16 @@ to manage the minion's master setting from an execution module. By simply
 changing the algorithm in the module to return a new master ip/fqdn, restart
 the minion and it will connect to the new master.
 
+``master_alive_interval``
+-------------------------
 
 .. code-block:: yaml
 
-    master_type: func
+    master_alive_interval: 30
 
-If this option is set to ``failover``, :conf_minion:`master` must be a list of
-master addresses. The minion will then try each master in the order specified
-in the list until it successfully connects.
-
-
-.. code-block:: yaml
-
-    master_type: failover
+Configures how often, in seconds, the minion will verify that the current
+master is alive and responding.  The minion will try to establish a connection
+to the next master in the list if it finds the existing one is dead.
 
 ``master_shuffle``
 ------------------

--- a/doc/topics/highavailability/index.rst
+++ b/doc/topics/highavailability/index.rst
@@ -1,0 +1,65 @@
+.. _highavailability:
+
+==================================
+High Availability Features in Salt
+==================================
+
+Salt supports several features for high availability and fault tolerance.
+Brief documentation for these features is listed alongside their configuration
+parameters in :ref:`Configuration file examples <configuration/examples>`.
+
+Multimaster
+===========
+
+Salt minions can connect to multiple masters at one time by configuring the
+`master` configuration paramter as a YAML list of all the available masters.  By
+default, all masters are "hot", meaning that any master can direct commands to
+the Salt infrastructure.
+
+In a multimaster configuration, each master must have the same cryptographic
+keys, and minion keys must be accepted on all masters separately.  The contents
+of file_roots and pillar_roots need to be kept in sync with processes external
+to Salt as well
+
+A tutorial on setting up multimaster with "hot" masters is here:
+
+:doc:`Multimaster Tutorial </topics/tutorials/multimaster>`
+
+Multimaster with Failover
+=========================
+
+Changing the ``master_type`` parameter from ``standard`` to ``failover`` will
+cause minions to connect to the first responding master in the list of masters.
+Every ``master_alive_check`` seconds the minions will check to make sure
+the current master is still responding.  If the master does not respond,
+the minion will attempt to connect to the next master in the list.  If the
+minion runs out of masters, the list will be recycled in case dead masters
+have been restored.  Note that ``master_alive_check`` must be present in the
+minion configuration, or else the recurring job to check master status
+will not get scheduled.
+
+Failover can be combined with PKI-style encrypted keys, but PKI is NOT
+REQUIRED to use failover.
+
+Multimaster with PKI and Failover is discussed in 
+:doc:`this tutorial </topics/tutorials/multimaster_pki>`
+
+``master_type: failover`` can be combined with ``shuffle_masters: True``
+to spread minion connections across all masters (one master per
+minion, not each minion connecting to all masters).  Adding Salt Syndics
+into the mix makes it possible to create a load-balanced Salt infrastructure.
+If a master fails, minions will notice and select another master from the
+available list.
+
+Syndic
+======
+
+Salt's Syndic feature is a way to create differing infrastructure
+topologies.  It is not strictly an HA feature, but can be treated as such.
+
+With the syndic, a Salt infrastructure can be partitioned in such a way that
+certain masters control certain segments of the infrastructure, and "Master
+of Masters" nodes can control multiple segments underneath them.
+
+Syndics are covered in depth in :doc:`Salt Syndic </topics/topology/syndic>`.
+

--- a/doc/topics/highavailability/index.rst
+++ b/doc/topics/highavailability/index.rst
@@ -44,7 +44,7 @@ REQUIRED to use failover.
 Multimaster with PKI and Failover is discussed in 
 :doc:`this tutorial </topics/tutorials/multimaster_pki>`
 
-``master_type: failover`` can be combined with ``shuffle_masters: True``
+``master_type: failover`` can be combined with ``master_shuffle: True``
 to spread minion connections across all masters (one master per
 minion, not each minion connecting to all masters).  Adding Salt Syndics
 into the mix makes it possible to create a load-balanced Salt infrastructure.

--- a/salt/config.py
+++ b/salt/config.py
@@ -296,7 +296,7 @@ VALID_OPTS = {
 DEFAULT_MINION_OPTS = {
     'interface': '0.0.0.0',
     'master': 'salt',
-    'master_type': 'str',
+    'master_type': 'standard',
     'master_port': '4506',
     'master_finger': '',
     'master_shuffle': False,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -793,6 +793,10 @@ class Minion(MinionBase):
 
             # if failover is set, the first time through, opts['master'] is a list.
             elif opts['master_type'] == 'failover':
+                # if failed=True, the minion was previously connected
+                # we're probably called from the minions main-event-loop
+                # because a master connection loss was detected. remove
+                # the possibly failed master from the list of masters.
                 if failed:
                     log.info('Removing possibly failed master {0} from list of'
                              ' masters'.format(opts['master']))
@@ -811,10 +815,6 @@ class Minion(MinionBase):
                     opts['master'] = [opts['master']]
                     opts['master_list'] = opts['master']
                     opts['master_active_list'] = opts['master']
-                # if failed=True, the minion was previously connected
-                # we're probably called from the minions main-event-loop
-                # because a master connection loss was detected. remove
-                # the possibly failed master from the list of masters.
                 else:
                     msg = ('master_type set to \'failover\' but \'master\' '
                            'is not of type list but of type '


### PR DESCRIPTION
This PR fixes minion failover and documents same.  This ostensibly worked in previous versions and was enabled first by the addition of "Multimaster-PKI Failover" but it wasn't clearly documented that you could do failover without PKI.
