### PR TITLE
Added seed option to mod_random

### DIFF
--- a/salt/modules/mod_random.py
+++ b/salt/modules/mod_random.py
@@ -147,26 +147,26 @@ def rand_int(start=1, end=10):
 
 
 def seed(range=10, hash=None):
-     '''
-     Returns a random number within a range. Optional hash argument can
-     be any hashable object. If hash is omitted or None, the id of the minion is used.
+    '''
+    Returns a random number within a range. Optional hash argument can
+    be any hashable object. If hash is omitted or None, the id of the minion is used.
 
-     .. versionadded: 2015.5.3
+    .. versionadded: 2015.5.3
 
-     hash: None
-         Any hashable object.
+    hash: None
+        Any hashable object.
 
-     range: 10
-         Any valid integer number
+    range: 10
+        Any valid integer number
 
-     CLI Example:
+    CLI Example:
 
-     .. code-block:: bash
+    .. code-block:: bash
 
-         salt '*' random.rand_seed 'none' '10'
-     '''
-     if hash is None:
-         hash = __grains__['id']
+        salt '*' random.rand_seed 'none' '10'
+    '''
+    if hash is None:
+        hash = __grains__['id']
 
-     random.seed(hash)
-     return random.randrange(range)
+    random.seed(hash)
+    return random.randrange(range)

--- a/salt/modules/mod_random.py
+++ b/salt/modules/mod_random.py
@@ -144,3 +144,29 @@ def rand_int(start=1, end=10):
         salt '*' random.rand_int 1 10
     '''
     return random.randint(start, end)
+
+
+def seed(range=10, hash=None):
+     '''
+     Returns a random number within a range. Optional hash argument can
+     be any hashable object. If hash is omitted or None, the id of the minion is used.
+
+     .. versionadded: 2015.5.3
+
+     hash: None
+         Any hashable object.
+
+     range: 10
+         Any valid integer number
+
+     CLI Example:
+
+     .. code-block:: bash
+
+         salt '*' random.rand_seed 'none' '10'
+     '''
+     if hash is None:
+         hash = __grains__['id']
+
+     random.seed(hash)
+     return random.randrange(range)


### PR DESCRIPTION
This will give salt the ability to use python random.seed as a basic
random number generator with a salt minion as hash object.

Reason for the hash object is to have a reproducable random number
between minions, but not between highstate runs on the same minion.

This is usefull for example to generate random crontab timings between
minions without the fear of regerating the crontab file on each run.
