### PR TITLE
Check for required parameters in salt-cloud provider and profile configs

### DIFF
--- a/salt/cloud/clouds/aliyun.py
+++ b/salt/cloud/clouds/aliyun.py
@@ -566,6 +566,11 @@ def create(vm_):
     '''
     Create a single VM from a data dict
     '''
+    # Check for required profile parameters before sending any API calls.
+    if config.is_profile_configured(__opts__,
+                                    __active_provider_name__ or 'aliyun',
+                                    vm_['profile']) is False:
+        return False
 
     # Since using "provider: <provider-engine>" is deprecated, alias provider
     # to use driver: "driver: <provider-engine>"

--- a/salt/cloud/clouds/cloudstack.py
+++ b/salt/cloud/clouds/cloudstack.py
@@ -220,6 +220,12 @@ def create(vm_):
     '''
     Create a single VM from a data dict
     '''
+    # Check for required profile parameters before sending any API calls.
+    if config.is_profile_configured(__opts__,
+                                    __active_provider_name__ or 'cloudstack',
+                                    vm_['profile']) is False:
+        return False
+
     salt.utils.cloud.fire_event(
         'event',
         'starting create',

--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -303,6 +303,11 @@ def create(vm_):
     '''
     Create a single VM from a data dict
     '''
+    # Check for required profile parameters before sending any API calls.
+    if config.is_profile_configured(__opts__,
+                                    __active_provider_name__ or 'digital_ocean',
+                                    vm_['profile']) is False:
+        return False
 
     # Since using "provider: <provider-engine>" is deprecated, alias provider
     # to use driver: "driver: <provider-engine>"

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2100,6 +2100,12 @@ def create(vm_=None, call=None):
             'You cannot create an instance with -a or -f.'
         )
 
+    # Check for required profile parameters before sending any API calls.
+    if config.is_profile_configured(__opts__,
+                                    __active_provider_name__ or 'ec2',
+                                    vm_['profile']) is False:
+        return False
+
     # Since using "provider: <provider-engine>" is deprecated, alias provider
     # to use driver: "driver: <provider-engine>"
     if 'provider' in vm_:

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -561,6 +561,12 @@ def create_network(kwargs=None, call=None):
         log.error(
             'A network CIDR range must be specified when creating a network.'
         )
+        return
+
+    # Check for required profile parameters before sending any API calls.
+    if config.is_profile_configured(__opts__,
+                                    __active_provider_name__ or 'gce',
+                                    vm_['profile']) is False:
         return False
 
     name = kwargs['name']

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -563,12 +563,6 @@ def create_network(kwargs=None, call=None):
         )
         return
 
-    # Check for required profile parameters before sending any API calls.
-    if config.is_profile_configured(__opts__,
-                                    __active_provider_name__ or 'gce',
-                                    vm_['profile']) is False:
-        return False
-
     name = kwargs['name']
     cidr = kwargs['cidr']
     conn = get_conn()
@@ -2033,6 +2027,12 @@ def create(vm_=None, call=None):
                 GCE_VM_NAME_REGEX.pattern
             )
         )
+
+    # Check for required profile parameters before sending any API calls.
+    if config.is_profile_configured(__opts__,
+                                    __active_provider_name__ or 'gce',
+                                    vm_['profile']) is False:
+        return False
 
     conn = get_conn()
 

--- a/salt/cloud/clouds/gogrid.py
+++ b/salt/cloud/clouds/gogrid.py
@@ -82,6 +82,11 @@ def create(vm_):
     '''
     Create a single VM from a data dict
     '''
+    # Check for required profile parameters before sending any API calls.
+    if config.is_profile_configured(__opts__,
+                                    __active_provider_name__ or 'gogrid',
+                                    vm_['profile']) is False:
+        return False
 
     # Since using "provider: <provider-engine>" is deprecated, alias provider
     # to use driver: "driver: <provider-engine>"

--- a/salt/cloud/clouds/joyent.py
+++ b/salt/cloud/clouds/joyent.py
@@ -242,6 +242,11 @@ def create(vm_):
 
         salt-cloud -p profile_name vm_name
     '''
+    # Check for required profile parameters before sending any API calls.
+    if config.is_profile_configured(__opts__,
+                                    __active_provider_name__ or 'joyent',
+                                    vm_['profile']) is False:
+        return False
 
     # Since using "provider: <provider-engine>" is deprecated, alias provider
     # to use driver: "driver: <provider-engine>"

--- a/salt/cloud/clouds/libcloud_aws.py
+++ b/salt/cloud/clouds/libcloud_aws.py
@@ -310,6 +310,12 @@ def create(vm_):
     '''
     Create a single VM from a data dict
     '''
+    # Check for required profile parameters before sending any API calls.
+    if config.is_profile_configured(__opts__,
+                                    __active_provider_name__ or 'aws',
+                                    vm_['profile']) is False:
+        return False
+
     key_filename = config.get_cloud_config_value(
         'private_key', vm_, __opts__, search_global=False, default=None
     )

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -171,6 +171,11 @@ def create(vm_):
     '''
     Create a single Linode VM.
     '''
+    # Check for required profile parameters before sending any API calls.
+    if config.is_profile_configured(__opts__,
+                                    __active_provider_name__ or 'linode',
+                                    vm_['profile']) is False:
+        return False
 
     # Since using "provider: <provider-engine>" is deprecated, alias provider
     # to use driver: "driver: <provider-engine>"

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -83,7 +83,7 @@ def get_configured_provider():
     return config.is_provider_configured(
         __opts__,
         __active_provider_name__ or 'linode',
-        ('apikey',)
+        ('apikey', 'password',)
     )
 
 

--- a/salt/cloud/clouds/msazure.py
+++ b/salt/cloud/clouds/msazure.py
@@ -399,6 +399,11 @@ def create(vm_):
     '''
     Create a single VM from a data dict
     '''
+    # Check for required profile parameters before sending any API calls.
+    if config.is_profile_configured(__opts__,
+                                    __active_provider_name__ or 'azure',
+                                    vm_['profile']) is False:
+        return False
 
     # Since using "provider: <provider-engine>" is deprecated, alias provider
     # to use driver: "driver: <provider-engine>"

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -530,6 +530,12 @@ def create(vm_):
     '''
     Create a single VM from a data dict
     '''
+    # Check for required profile parameters before sending any API calls.
+    if config.is_profile_configured(__opts__,
+                                    __active_provider_name__ or 'nova',
+                                    vm_['profile']) is False:
+        return False
+
     deploy = config.get_cloud_config_value('deploy', vm_, __opts__)
     key_filename = config.get_cloud_config_value(
         'ssh_key_file', vm_, __opts__, search_global=False, default=None

--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -284,6 +284,11 @@ def create(vm_):
     '''
     Create a single VM from a data dict
     '''
+    # Check for required profile parameters before sending any API calls.
+    if config.is_profile_configured(__opts__,
+                                    __active_provider_name__ or 'opennebula',
+                                    vm_['profile']) is False:
+        return False
 
     # Since using "provider: <provider-engine>" is deprecated, alias provider
     # to use driver: "driver: <provider-engine>"

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -593,6 +593,11 @@ def create(vm_):
     '''
     Create a single VM from a data dict
     '''
+    # Check for required profile parameters before sending any API calls.
+    if config.is_profile_configured(__opts__,
+                                    __active_provider_name__ or 'openstack',
+                                    vm_['profile']) is False:
+        return False
 
     # Since using "provider: <provider-engine>" is deprecated, alias provider
     # to use driver: "driver: <provider-engine>"

--- a/salt/cloud/clouds/parallels.py
+++ b/salt/cloud/clouds/parallels.py
@@ -270,6 +270,11 @@ def create(vm_):
     '''
     Create a single VM from a data dict
     '''
+    # Check for required profile parameters before sending any API calls.
+    if config.is_profile_configured(__opts__,
+                                    __active_provider_name__ or 'parallels',
+                                    vm_['profile']) is False:
+        return False
 
     # Since using "provider: <provider-engine>" is deprecated, alias provider
     # to use driver: "driver: <provider-engine>"

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -480,6 +480,11 @@ def create(vm_):
 
         salt-cloud -p proxmox-ubuntu vmhostname
     '''
+    # Check for required profile parameters before sending any API calls.
+    if config.is_profile_configured(__opts__,
+                                    __active_provider_name__ or 'proxmox',
+                                    vm_['profile']) is False:
+        return False
 
     # Since using "provider: <provider-engine>" is deprecated, alias provider
     # to use driver: "driver: <provider-engine>"

--- a/salt/cloud/clouds/qingcloud.py
+++ b/salt/cloud/clouds/qingcloud.py
@@ -638,6 +638,11 @@ def create(vm_):
         salt-cloud -p qingcloud-ubuntu-c1m1 hostname1
         salt-cloud -m /path/to/mymap.sls -P
     '''
+    # Check for required profile parameters before sending any API calls.
+    if config.is_profile_configured(__opts__,
+                                    __active_provider_name__ or 'qingcloud',
+                                    vm_['profile']) is False:
+        return False
 
     # Since using "provider: <provider-engine>" is deprecated, alias provider
     # to use driver: "driver: <provider-engine>"

--- a/salt/cloud/clouds/rackspace.py
+++ b/salt/cloud/clouds/rackspace.py
@@ -181,6 +181,12 @@ def create(vm_):
     '''
     Create a single VM from a data dict
     '''
+    # Check for required profile parameters before sending any API calls.
+    if config.is_profile_configured(__opts__,
+                                    __active_provider_name__ or 'rackspace',
+                                    vm_['profile']) is False:
+        return False
+
     deploy = config.get_cloud_config_value('deploy', vm_, __opts__)
     salt.utils.cloud.fire_event(
         'event',

--- a/salt/cloud/clouds/scaleway.py
+++ b/salt/cloud/clouds/scaleway.py
@@ -187,8 +187,15 @@ def create_node(args):
 
 
 def create(server_):
-    ''' Create a single BareMetal server from a data dict.
     '''
+    Create a single BareMetal server from a data dict.
+    '''
+    # Check for required profile parameters before sending any API calls.
+    if config.is_profile_configured(__opts__,
+                                    __active_provider_name__ or 'scaleway',
+                                    server_['profile']) is False:
+        return False
+
     salt.utils.cloud.fire_event(
         'event',
         'starting create',

--- a/salt/cloud/clouds/softlayer.py
+++ b/salt/cloud/clouds/softlayer.py
@@ -234,6 +234,12 @@ def create(vm_):
     '''
     Create a single VM from a data dict
     '''
+    # Check for required profile parameters before sending any API calls.
+    if config.is_profile_configured(__opts__,
+                                    __active_provider_name__ or 'softlayer',
+                                    vm_['profile']) is False:
+        return False
+
     salt.utils.cloud.fire_event(
         'event',
         'starting create',

--- a/salt/cloud/clouds/softlayer_hw.py
+++ b/salt/cloud/clouds/softlayer_hw.py
@@ -207,6 +207,12 @@ def create(vm_):
     '''
     Create a single VM from a data dict
     '''
+    # Check for required profile parameters before sending any API calls.
+    if config.is_profile_configured(__opts__,
+                                    __active_provider_name__ or 'softlayer_hw',
+                                    vm_['profile']) is False:
+        return False
+
     salt.utils.cloud.fire_event(
         'event',
         'starting create',

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2038,6 +2038,11 @@ def create(vm_):
 
         salt-cloud -p vmware-centos6.5 vmname
     '''
+    # Check for required profile parameters before sending any API calls.
+    if config.is_profile_configured(__opts__,
+                                    __active_provider_name__ or 'vmware',
+                                    vm_['profile']) is False:
+        return False
 
     # Since using "provider: <provider-engine>" is deprecated, alias provider
     # to use driver: "driver: <provider-engine>"

--- a/salt/cloud/clouds/vsphere.py
+++ b/salt/cloud/clouds/vsphere.py
@@ -228,6 +228,11 @@ def create(vm_):
     '''
     Create a single VM from a data dict
     '''
+    # Check for required profile parameters before sending any API calls.
+    if config.is_profile_configured(__opts__,
+                                    __active_provider_name__ or 'vsphere',
+                                    vm_['profile']) is False:
+        return False
 
     # Since using "provider: <provider-engine>" is deprecated, alias provider
     # to use driver: "driver: <provider-engine>"

--- a/salt/config.py
+++ b/salt/config.py
@@ -2316,17 +2316,16 @@ def is_provider_configured(opts, provider, required_keys=()):
             return False
         for key in required_keys:
             if opts['providers'][alias][driver].get(key, None) is None:
-                # There's at least one require configuration key which is not
-                # set.
-                log.trace(
-                    'The required {0!r} configuration setting is missing on '
-                    'the {1!r} driver(under the {2!r} alias)'.format(
+                # There's at least one require configuration key which is not set.
+                log.warning(
+                    'The required {0!r} configuration setting is missing from '
+                    'the {1!r} driver, which is configured under the {2!r} '
+                    'alias.'.format(
                         key, provider, alias
                     )
                 )
                 return False
-        # If we reached this far, there's a properly configured provider,
-        # return it!
+        # If we reached this far, there's a properly configured provider. Return it!
         return opts['providers'][alias][driver]
 
     for alias, drivers in six.iteritems(opts['providers']):
@@ -2335,15 +2334,16 @@ def is_provider_configured(opts, provider, required_keys=()):
                 continue
 
             # If we reached this far, we have a matching provider, let's see if
-            # all required configuration keys are present and not None
+            # all required configuration keys are present and not None.
             skip_provider = False
             for key in required_keys:
                 if provider_details.get(key, None) is None:
                     # This provider does not include all necessary keys,
-                    # continue to next one
-                    log.trace(
+                    # continue to next one.
+                    log.warning(
                         'The required {0!r} configuration setting is missing '
-                        'on the {1!r} driver(under the {2!r} alias)'.format(
+                        'from the {1!r} driver, which is configured under the '
+                        '{2!r} alias.'.format(
                             key, provider, alias
                         )
                     )

--- a/salt/config.py
+++ b/salt/config.py
@@ -2358,6 +2358,35 @@ def is_provider_configured(opts, provider, required_keys=()):
 
     # If we reached this point, the provider is not configured.
     return False
+
+
+def is_profile_configured(opts, provider, profile_name):
+    '''
+    Check if the requested profile contains the minimum required parameters for
+    a profile.
+
+    Required parameters include image, provider, and size keys.
+
+    .. versionadded:: Beryllium
+    '''
+    required_keys = ['image', 'provider', 'size']
+
+    alias, driver = provider.split(':')
+    profile_key = opts['providers'][alias][driver]['profiles'][profile_name]
+
+    for item in required_keys:
+        if profile_key.get(item, None) is None:
+            # There's at least one required configuration item which is not set.
+            log.error(
+                'The required {0!r} configuration setting is missing from the '
+                '{1!r} profile, which is configured '
+                'under the {2!r} alias.'.format(
+                    item, profile_name, alias
+                )
+            )
+            return False
+
+    return True
 # <---- Salt Cloud Configuration Functions -----------------------------------
 
 

--- a/salt/config.py
+++ b/salt/config.py
@@ -2370,10 +2370,17 @@ def is_profile_configured(opts, provider, profile_name):
     .. versionadded:: Beryllium
     '''
     required_keys = ['image', 'provider', 'size']
-
     alias, driver = provider.split(':')
+    provider_key = opts['providers'][alias][driver]
     profile_key = opts['providers'][alias][driver]['profiles'][profile_name]
 
+    # Check if image and/or size are supplied in the provider config. If either
+    # one is present, remove it from the required_keys list.
+    for item in required_keys:
+        if item in provider_key:
+            required_keys.remove(item)
+
+    # Check for remaining required parameters in the profile config.
     for item in required_keys:
         if profile_key.get(item, None) is None:
             # There's at least one required configuration item which is not set.


### PR DESCRIPTION
- We're already checking for missing provider parameters, but it was logging at the trace level. This moves them back up to warning.
- If you're provisioning a machine and you don't have image, provider, or size configured in your profile config, return False and display a helpful error message to the user. No need to continue making API calls if the necessary parameters are missing.
- Check provider files for image and size as well, before checking the profile configuration.
- Added the `is_profile_configured` to the `create` functions in all applicable salt-cloud drivers.

Refs #14231
