### PR TITLE
SmartOS SMF minion startup fix

### DIFF
--- a/pkg/smartos/salt-minion.xml
+++ b/pkg/smartos/salt-minion.xml
@@ -14,7 +14,7 @@
                   grouping="require_all"
                   restart_on="none"
                   type="path">
-          <service_fmri value='file:///opt/local/etc/salt/minion'/>
+          <service_fmri value="file:///opt/local/etc/salt/minion"/>
       </dependency>
 
       <dependency name="network"
@@ -31,17 +31,17 @@
         <service_fmri value="svc:/system/filesystem/local"/>
       </dependency>
 
-      <method_context>
-       <method_environment>
-        <envvar name='PATH'
-                value='/usr/local/sbin:/usr/local/bin:/opt/local/sbin:/opt/local/bin:/usr/sbin:/usr/bin:/sbin'/>
-       </method_environment>
-      </method_context>
-
       <exec_method type="method"
                    name="start"
                    exec="/opt/local/bin/salt-minion -c %{config_dir}"
-                   timeout_seconds="60"/>
+                   timeout_seconds="60">
+        <method_context>
+          <method_environment>
+            <envvar name="PATH"
+                    value="/usr/local/sbin:/usr/local/bin:/opt/local/sbin:/opt/local/bin:/usr/sbin:/usr/bin:/sbin"/>
+          </method_environment>
+        </method_context>
+      </exec_method>
 
       <exec_method type="method"
                    name="stop"


### PR DESCRIPTION
Per my own testing on dozens of SmartOS VM's and others saltstack/salt-bootstrap#473 "Problem 3", the salt-minion service manifest definition doesn't work. Minion won't start because of missing path. This change fixes that. I think it may have broke in 2014.7 so back-porting to that version, which is I think is the correct process (then you all merge forward to develop right?).
