### PR TITLE
Fix PEP8 complaints & functional testing

### DIFF
--- a/salt/states/test.py
+++ b/salt/states/test.py
@@ -210,8 +210,8 @@ def configurable_test_state(name, changes=True, result=True, comment=''):
         ret['changes'] = {}
     else:
         err = ('You have specified the state option \'Changes\' with'
-            ' invalid arguments. It must be either '
-            ' \'True\', \'False\', or \'Random\'')
+               ' invalid arguments. It must be either '
+               ' \'True\', \'False\', or \'Random\'')
         raise SaltInvocationError(err)
 
     if result == 'Random':
@@ -340,13 +340,13 @@ def _if_str_then_list(listing):
 
 
 def check_pillar(name,
-        present=None,
-        boolean=None,
-        integer=None,
-        string=None,
-        listing=None,
-        dictionary=None,
-        verbose=False):
+                 present=None,
+                 boolean=None,
+                 integer=None,
+                 string=None,
+                 listing=None,
+                 dictionary=None,
+                 verbose=False):
     '''
     Checks the presence and, optionally, the type of
     given keys in Pillar.
@@ -434,5 +434,51 @@ def check_pillar(name,
         for key, key_type in fine.items():
             comment += '- {0} ({1})\n'.format(key, key_type)
         ret['comment'] += comment
+
+    return ret
+
+
+def file(name, **kwargs):
+    '''
+    Check a file exists and ensure the attributes are what are expected.
+
+    .. versionadded:: Beryllium
+
+    name
+        The filename to check exists
+
+    .. code-block:: yaml
+
+        check_passwd_file
+          test.file:
+            - name: /etc/passwd
+            - mode: '0644'
+            - gid: 0
+            - type: file
+    '''
+    ret = {
+        'name': name,
+        'result': True,
+        'comment': 'No difference',
+        'changes': ''
+    }
+
+    if not __salt__['file.file_exists'](name):
+        ret['result'] = False
+        ret['comment'] = 'file does not exist'
+
+        return ret
+
+    _perms = __salt__['file.stats'](name)
+
+    diff = set(kwargs.items()) - set(_perms.items())
+
+    if diff:
+        ret['result'] = False
+        ret['comment'] = 'File mismatch'
+        ret['changes'] = {
+            'actual': {i: _perms[i] for i in dict(diff).keys()},
+            'expected': dict(diff),
+        }
 
     return ret


### PR DESCRIPTION
I would like to perform easy functional testing of my states by writing simple sls definitions that actually validate state runs. For example, when I have a state that manages the `/etc/passwd`, we should be able to run a separate test state that validates everything worked as expected.

Example:-

/srv/salt/service/accounts/init.sls

``` yaml
configure_passwd:
  file.managed:
    - name: /etc/passwd
    - mode: '0644'
    - user: root
    - group: root
```

The test for this state could be the following:-

/srv/salt/service/accounts/testing/test_passwd.sls

``` yaml
check_passwd:
  test.file:
    - name: /etc/passwd
    - mode: '0644'
    - gid: 0
```

This test can be manually run or via our CI environment.

``` bash
# salt-call --local state.sls service.accounts.testing.test_passwd
local:
----------
          ID: check_passwd
    Function: test.file
        Name: /etc/passwd
      Result: False
     Comment: File mismatch
     Started: 22:00:35.301009
    Duration: 4.51 ms
     Changes:   
              ----------
              actual:
                  ----------
                  gid:
                      10
                  mode:
                      1644
              expected:
                  ----------
                  gid:
                      0
                  mode:
                      0644

Summary
------------
Succeeded: 0 (changed=1)
Failed:    1
------------
Total states run:     1
```

What are your thoughts around this?  @cachedout @thatch45 @whiteinge @rallytime
