### PR TITLE
Updated etcd_mod module to use __utils__

### DIFF
--- a/salt/modules/etcd_mod.py
+++ b/salt/modules/etcd_mod.py
@@ -70,7 +70,7 @@ def get_(key, recurse=False, profile=None):
         salt myminion etcd.get /path/to/key profile=my_etcd_config
         salt myminion etcd.get /path/to/key recurse=True profile=my_etcd_config
     '''
-    client = salt.utils.etcd_util.get_conn(__opts__, profile)
+    client = __utils__['etcd_util.get_conn'](__opts__, profile)
     try:
         result = client.get(key)
     except KeyError as err:
@@ -98,7 +98,8 @@ def set_(key, value, profile=None):
         salt myminion etcd.set /path/to/key value
         salt myminion etcd.set /path/to/key value profile=my_etcd_config
     '''
-    client = salt.utils.etcd_util.get_conn(__opts__, profile)
+
+    client = __utils__['etcd_util.get_conn'](__opts__, profile)
     try:
         result = client.write(key, value)
     except KeyError as err:
@@ -124,7 +125,7 @@ def ls_(path='/', profile=None):
         salt myminion etcd.ls /path/to/dir/
         salt myminion etcd.ls /path/to/dir/ profile=my_etcd_config
     '''
-    client = salt.utils.etcd_util.get_conn(__opts__, profile)
+    client = __utils__['etcd_util.get_conn'](__opts__, profile)
     try:
         items = client.get(path)
     except KeyError as err:
@@ -158,7 +159,7 @@ def rm_(key, recurse=False, profile=None):
         salt myminion etcd.rm /path/to/key profile=my_etcd_config
         salt myminion etcd.rm /path/to/dir recurse=True profile=my_etcd_config
     '''
-    client = salt.utils.etcd_util.get_conn(__opts__, profile)
+    client = __utils__['etcd_util.get_conn'](__opts__, profile)
     try:
         if client.delete(key, recursive=recurse):
             return True
@@ -186,7 +187,7 @@ def tree(path='/', profile=None):
         salt myminion etcd.tree profile=my_etcd_config
         salt myminion etcd.tree /path/to/keys profile=my_etcd_config
     '''
-    client = salt.utils.etcd_util.get_conn(__opts__, profile)
+    client = __utils__['etcd_util.get_conn'](__opts__, profile)
     try:
         return salt.utils.etcd_util.tree(client, path)
     except KeyError as err:


### PR DESCRIPTION
Updates the `etcd_mod` salt execution module to load the `etcd_util` module via the new `__utils__` variable which is coming in Beryllium.

Fixes some problems I'm seeing when installing `python-etcd` and then running an `etcd` it fails because it thinks `python-etcd` does not exist even though it does and the modules have been reloaded.
