### PR TITLE
Fix memory leak in saltnado

### DIFF
--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -267,7 +267,8 @@ class EventListener(object):
         # request_obj -> list of (tag, future)
         self.request_map = defaultdict(list)
 
-        self.timeout_map = {}  # map of future -> timeout_callback
+        # map of future -> timeout_callback
+        self.timeout_map = {}
 
         self.stream = zmqstream.ZMQStream(self.event.sub,
                                           io_loop=tornado.ioloop.IOLoop.current())
@@ -280,7 +281,15 @@ class EventListener(object):
         if request not in self.request_map:
             return
         for tag, future in self.request_map[request]:
+            # timeout the future
             self._timeout_future(tag, future)
+            # remove the timeout
+            if future in self.timeout_map:
+                tornado.ioloop.IOLoop.current().remove_timeout(self.timeout_map[future])
+                del self.timeout_map[future]
+
+        del self.request_map[request]
+
 
     def get_event(self,
                   request,
@@ -291,6 +300,13 @@ class EventListener(object):
         '''
         Get an event (async of course) return a future that will get it later
         '''
+        # if the request finished, no reason to allow event fetching, since we
+        # can't send back to the client
+        if request._finished:
+            future = Future()
+            future.set_exception(TimeoutException())
+            return future
+
         future = Future()
         if callback is not None:
             def handle_future(future):

--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -290,7 +290,6 @@ class EventListener(object):
 
         del self.request_map[request]
 
-
     def get_event(self,
                   request,
                   tag='',

--- a/tests/integration/netapi/rest_tornado/test_app.py
+++ b/tests/integration/netapi/rest_tornado/test_app.py
@@ -581,6 +581,7 @@ class TestWebhookSaltAPIHandler(SaltnadoTestCase):
             self.assertIn('headers', event['data'])
             self.assertEqual(event['data']['post'], {'foo': 'bar'})
         # get an event future
+        self._finished = False  # TODO: remove after some cleanup of the event listener
         event = self.application.event_listener.get_event(self,
                                                           tag='salt/netapi/hook',
                                                           callback=verify_event,


### PR DESCRIPTION
Fixes #24846

If an event was checked after the request was closed out it was possible for requests to get into the event_listener's mapping and never be cleaned out. This fixes the leak by checking if the request is open or not before adding it to the mappings.

As discussed in the issue the preferred way would be to move the mappings into the request object itself, but that turns out to be a decent amount of work to get working completely. This fixes our leak, so we should get it in :)
