### PR TITLE
Templatize winrepo on the minion

### DIFF
--- a/doc/topics/windows/windows-package-manager.rst
+++ b/doc/topics/windows/windows-package-manager.rst
@@ -50,9 +50,10 @@ Usage
 
 By default, the Windows software repository is found at ``/srv/salt/win/repo``
 This can be changed in the master config file (default location is
-``/etc/salt/master``) by modifying the  ``win_repo`` variable.  Each piece of
-software should have its own directory which contains the installers and a
-package definition file. This package definition file is a YAML file named
+``/etc/salt/master``) by modifying the  ``win_repo`` variable, but this must
+reside somewhere inside the master's `file_roots`.  Each piece of software
+should have its own directory which contains the installers and a package
+definition file. This package definition file is a YAML file named
 ``init.sls``.
 
 The package definition file should look similar to this example for Firefox:
@@ -178,7 +179,7 @@ Only applies to salt: installer URLs.
         reboot: False
         install_flags: ' /ACTION=install /IACCEPTSQLSERVERLICENSETERMS /Q'
         cache_dir: True
-       
+
 Generate Repo Cache File
 ========================
 
@@ -188,7 +189,15 @@ Once the sls file has been created, generate the repository cache file with the 
 
     salt-run winrepo.genrepo
 
-Then update the repository cache file on your minions, exactly how it's done for the Linux package managers:
+Beginning with the Beryllium Salt release the repository cache is compiled on
+the Salt Minion. This allows for easy templating on the minion which allows for
+pillar, grains and other things to be available during compilation time. From
+Beryllium forward the above `salt-run winrepo.genrepo` is only required for
+older minions. New minions should execute `salt \* pkg.refresh_db` to update
+from the latest from the master's repo.
+
+Then update the repository cache file on your minions, exactly how it's done
+for the Linux package managers:
 
 .. code-block:: bash
 

--- a/salt/config.py
+++ b/salt/config.py
@@ -370,8 +370,8 @@ VALID_OPTS = {
     # Events matching a tag in this list should never be sent to an event returner.
     'event_return_blacklist': list,
 
-    # The file cache for the win_pkg module
-    'win_repo_cachefile': str,
+    # The source location for the winrepo sls files
+    'win_repo_source_dir': str,
 
     # This pidfile to write out to when a deamon starts
     'pidfile': str,
@@ -800,7 +800,7 @@ DEFAULT_MINION_OPTS = {
     'syndic_log_file': os.path.join(salt.syspaths.LOGS_DIR, 'syndic'),
     'syndic_pidfile': os.path.join(salt.syspaths.PIDFILE_DIR, 'salt-syndic.pid'),
     'random_reauth_delay': 10,
-    'win_repo_cachefile': 'salt://win/repo/winrepo.p',
+    'win_repo_source_dir': 'salt://win/repo/',
     'pidfile': os.path.join(salt.syspaths.PIDFILE_DIR, 'salt-minion.pid'),
     'range_server': 'range:80',
     'tcp_keepalive': True,

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -412,7 +412,8 @@ def genrepo(saltenv='base'):
                             renderers,
                             __opts__['renderer'])
                 except SaltRenderError as exc:
-                    log.debug('Failed to compile {0}. Error: {1}.'.format(os.path.join(root, name), exc))
+                    log.debug('Failed to compile {0}.'.format(os.path.join(root, name)))
+                    log.debug('Error: {0}.'.format(exc))
                     continue
 
                 if config:

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -412,8 +412,7 @@ def genrepo(saltenv='base'):
                             renderers,
                             __opts__['renderer'])
                 except SaltRenderError as exc:
-                    log.debug('Failed to compile {0}.'
-                              'Error: {1}.'.format(os.path.join(root, name), exc))
+                    log.debug('Failed to compile {0}. Error: {1}.'.format(os.path.join(root, name), exc))
                     continue
 
                 if config:

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -372,6 +372,7 @@ def refresh_db(saltenv='base'):
     __context__.pop('winrepo.data', None)
     repo = __opts__['win_repo_source_dir']
     cached_files = __salt__['cp.cache_dir'](repo, saltenv, include_pat='*.sls')
+    genrepo(saltenv=saltenv)
     return cached_files
 
 

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -32,6 +32,7 @@ except ImportError:
 
 # Import salt libs
 import salt.utils
+import salt.syspaths
 
 log = logging.getLogger(__name__)
 
@@ -385,7 +386,8 @@ def genrepo():
         salt-run winrepo.genrepo
     '''
     ret = {}
-    repo = __opts__['win_repo']
+    repo = salt.syspaths.CACHE_DIR
+    return repo
     if not os.path.exists(repo):
         os.makedirs(repo)
     winrepo = __opts__['win_repo_mastercachefile']

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -370,7 +370,7 @@ def refresh_db(saltenv='base'):
     '''
     __context__.pop('winrepo.data', None)
     repo = __opts__['win_repo_source_dir']
-    cached_files = __salt__['cp.cache_dir'](repo, saltenv, include_path='*.sls')
+    cached_files = __salt__['cp.cache_dir'](repo, saltenv, include_pat='*.sls')
     return cached_files
 
 

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -675,15 +675,12 @@ def get_repo_data(saltenv='base'):
     '''
     #if 'winrepo.data' in __context__:
     #    return __context__['winrepo.data']
-    repocache = __opts__['win_repo_cachefile']
-    cached_repo = __salt__['cp.is_cached'](repocache, saltenv)
-    if not cached_repo:
-        __salt__['pkg.refresh_db']()
+    repocache_dir = _get_local_repo_dir(saltenv=saltenv)
+    winrepo = 'winrepo.p'
     try:
-        with salt.utils.fopen(cached_repo, 'rb') as repofile:
+        with salt.utils.fopen(os.path.join(repocache_dir, winrepo), 'rb') as repofile:
             try:
                 repodata = msgpack.loads(repofile.read()) or {}
-                #__context__['winrepo.data'] = repodata
                 return repodata
             except Exception as exc:
                 log.exception(exc)

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -31,6 +31,7 @@ except ImportError:
 # pylint: enable=import-error
 
 # Import salt libs
+from salt.exceptions import SaltRenderError
 import salt.utils
 import salt.syspaths
 

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -376,6 +376,16 @@ def refresh_db(saltenv='base'):
     return cached_files
 
 
+def _get_local_repo_dir(saltenv='base'):
+    master_repo_src = __opts__['win_repo_source_dir']
+    dirs = []
+    dirs.append(salt.syspaths.CACHE_DIR)
+    dirs.extend(['minion', 'files'])
+    dirs.append(saltenv)
+    dirs.extend(master_repo_src[7:].strip('/').split('/'))
+    return os.sep.join(dirs)
+
+
 def genrepo(saltenv='base'):
     '''
     Generate win_repo_cachefile based on sls files in the win_repo
@@ -387,13 +397,7 @@ def genrepo(saltenv='base'):
         salt-run winrepo.genrepo
     '''
     ret = {}
-    master_repo_src = __opts__['win_repo_source_dir']
-    dirs = []
-    dirs.append(salt.syspaths.CACHE_DIR)
-    dirs.extend(['minion', 'files'])
-    dirs.append(saltenv)
-    dirs.extend(master_repo_src[7:].strip('/').split('/'))
-    repo = os.sep.join(dirs)
+    repo = _get_local_repo_dir(saltenv)
     if not os.path.exists(repo):
         os.makedirs(repo)
     winrepo = 'winrepo.p'

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -375,7 +375,7 @@ def refresh_db(saltenv='base'):
     return cached_files
 
 
-def genrepo():
+def genrepo(saltenv='base'):
     '''
     Generate win_repo_cachefile based on sls files in the win_repo
 
@@ -386,11 +386,16 @@ def genrepo():
         salt-run winrepo.genrepo
     '''
     ret = {}
-    repo = salt.syspaths.CACHE_DIR
-    return repo
+    master_repo_src = __opts__['win_repo_source_dir']
+    dirs = []
+    dirs.append(salt.syspaths.CACHE_DIR)
+    dirs.extend(['minion', 'files'])
+    dirs.append(saltenv)
+    dirs.extend(master_repo_src[7:].strip('/').split('/'))
+    repo = os.sep.join(dirs)
     if not os.path.exists(repo):
         os.makedirs(repo)
-    winrepo = __opts__['win_repo_mastercachefile']
+    winrepo = 'winrepo.p'
     renderers = salt.loader.render(__opts__, __salt__)
     for root, _, files in os.walk(repo):
         for name in files:
@@ -414,8 +419,8 @@ def genrepo():
                             revmap[repodata['full_name']] = pkgname
                     ret.setdefault('repo', {}).update(config)
                     ret.setdefault('name_map', {}).update(revmap)
-    with salt.utils.fopen(os.path.join(repo, winrepo), 'w+b') as repo:
-        repo.write(msgpack.dumps(ret))
+    with salt.utils.fopen(os.path.join(repo, winrepo), 'w+b') as repo_cache:
+        repo_cache.write(msgpack.dumps(ret))
     return ret
 
 

--- a/salt/runners/winrepo.py
+++ b/salt/runners/winrepo.py
@@ -15,6 +15,7 @@ except ImportError:
     import msgpack_pure as msgpack  # pylint: disable=import-error
 
 # Import salt libs
+from salt.exceptions import SaltRenderError
 import salt.utils
 import logging
 import salt.minion
@@ -43,10 +44,15 @@ def genrepo():
     for root, _, files in os.walk(repo):
         for name in files:
             if name.endswith('.sls'):
-                config = salt.template.compile_template(
-                        os.path.join(root, name),
-                        renderers,
-                        __opts__['renderer'])
+                try:
+                    config = salt.template.compile_template(
+                            os.path.join(root, name),
+                            renderers,
+                            __opts__['renderer'])
+                except SaltRenderError as exc:
+                    log.debug('Failed to render {0}.'.format(os.path.join(root, name)))
+                    log.debug('Error: {0}.'.format(exc))
+                    continue
                 if config:
                     revmap = {}
                     for pkgname, versions in six.iteritems(config):


### PR DESCRIPTION
Templatize the winrepo package definitions on the Minion. This allows for pillar and grains data to properly reflect that info in the winrepo package definitions

Fixes #6859

Also added some exception handling.
