### PR TITLE
ec2 network_interfaces fix

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1152,10 +1152,17 @@ def _create_eni_if_necessary(interface):
 
     for subnet_query_result in subnet_query:
         if 'item' in subnet_query_result:
-            for subnet in subnet_query_result['item']:
-                if subnet['subnetId'] == interface['SubnetId']:
-                    found = True
-                    break
+            if type(subnet_query_result['item']) is dict:
+                for key, value in subnet_query_result['item'].iteritems():
+                    if key == "subnetId":
+                        if value == interface['SubnetId']:
+                            found = True
+                            break
+            else:
+                for subnet in subnet_query_result['item']:
+                    if subnet['subnetId'] == interface['SubnetId']:
+                        found = True
+                        break
 
     if not found:
         raise SaltCloudConfigError(


### PR DESCRIPTION
Submitting this as a possible bug fix for error:

File "github/salt/salt/cloud/clouds/ec2.py", line 1105, in _create_eni
if subnet['subnetId'] == interface['SubnetId']:
TypeError: string indices must be integers, not str

This is when using salt-cloud to create a new ec2 server that has "network_interfaces:" within the profile.

I fully support the python code here to be refactored/more idiomatic/etc.

It appears that the original code's for loop attempts to act on the subnet object as a dictionary in all cases, but the subnet object will actually be an array of keys if the subnet_query_result['item'] is a dict.

Please see -- http://comments.gmane.org/gmane.comp.sysutils.salt.user/19248 for reference.

Thanks!
