### PR TITLE
Don't try to cache a template when it's not a file

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2799,8 +2799,9 @@ def get_managed(
                             ' source file {0}').format(source)
 
     # if the file is a template we need to actually template the file to get
-    # a checksum, but we can cache the template itselt
-    if template:
+    # a checksum, but we can cache the template itself, but only if there is
+    # a template source (it could be a templated contents)
+    if template and source:
         # check if we have the template cached
         template_dest = __salt__['cp.is_cached'](source, saltenv)
         if template_dest:


### PR DESCRIPTION
When trying to use `file.managed` without a source file, just `contents`, with templating, `modules/file.py` tries to cache the template itself, but in this case it's not a file, so an Exception is raised when it tries to do string stuff to a `None`, which gets caught and turned into a confusing string error, shown to the user.

This PR fixes this issue by avoiding trying to cache a nonexistent file.
