### PR TITLE
Log traceback on 'Function in mine_functions failed to execute' exceptions in mine.update

### DIFF
--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 import copy
 import logging
 import time
+import traceback
 
 # Import salt libs
 import salt.crypt
@@ -124,8 +125,9 @@ def update(clear=False):
                     continue
                 data[func] = __salt__[func]()
         except Exception:
-            log.error('Function {0} in mine_functions failed to execute'
-                      .format(func))
+            trace = traceback.format_exc()
+            log.error('Function {0} in mine_functions failed to execute. Error: {1}'
+                      .format(func, trace))
             continue
     if __opts__['file_client'] == 'local':
         if not clear:

--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -126,8 +126,9 @@ def update(clear=False):
                 data[func] = __salt__[func]()
         except Exception:
             trace = traceback.format_exc()
-            log.error('Function {0} in mine_functions failed to execute. Error: {1}'
-                      .format(func, trace))
+            log.error('Function {0} in mine_functions failed to execute'
+                      .format(func))
+            log.debug('Error: {0}'.format(trace))
             continue
     if __opts__['file_client'] == 'local':
         if not clear:


### PR DESCRIPTION
Hi,

As you can see, when salt fails to run a mine function it does nothing about it apart from stating the fact in the logs:
https://github.com/saltstack/salt/blob/9f24ec2d8d02fe75f32721e9e084be32dbece08c/salt/modules/mine.py#L126

I'm not sure if there is a higher reason for this exception to be suppressed silently, but I found that having full traceback in the logs helped my debugging a great deal.
