### PR TITLE
Another Fix to gpg.py in 2015.5

### DIFF
--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -614,9 +614,6 @@ def import_key(user=None,
     # include another check for Salt unit tests
     gnupg_version = distutils.version.LooseVersion(gnupg.__version__)
     if gnupg_version >= '1.3.1':
-        GPG_1_3_1 = True
-
-    if GPG_1_3_1:
         counts = imported_data.counts
         if counts.get('imported') or counts.get('imported_rsa'):
             ret['message'] = 'Successfully imported key(s).'


### PR DESCRIPTION
variable was referenced before assignment.  Just removing the variable and checking the return from distutils.version.LooseVersion directly.  #24862 
