### PR TITLE
Fix documentation on mod_random.seed module

### DIFF
--- a/salt/modules/mod_random.py
+++ b/salt/modules/mod_random.py
@@ -163,7 +163,7 @@ def seed(range=10, hash=None):
 
     .. code-block:: bash
 
-        salt '*' random.rand_seed 'none' '10'
+        salt '*' random.seed 10 hash=None
     '''
     if hash is None:
         hash = __grains__['id']


### PR DESCRIPTION
Fixed wrong example bash block for random.seed module
