### PR TITLE
Add s3 to protocols for remote source_hash (2014.7 backport)

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2556,7 +2556,7 @@ def get_managed(
                 if not source_sum:
                     return '', {}, 'Source file {0} not found'.format(source)
             elif source_hash:
-                protos = ['salt', 'http', 'https', 'ftp', 'swift']
+                protos = ['salt', 'http', 'https', 'ftp', 'swift', 's3']
                 if salt._compat.urlparse(source_hash).scheme in protos:
                     # The source_hash is a file on a server
                     hash_fn = __salt__['cp.cache_file'](source_hash, saltenv)


### PR DESCRIPTION
This is a backport of the fix for #15209 into 2014.7.
https://github.com/saltstack/salt/pull/19640

Without it, s3 urls broken in file states unless you include the hash via some non-S3 url. 
