### PR TITLE
Fixes to debian_ip.py in 2015.5

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1529,6 +1529,9 @@ def build_interface(iface, iface_type, enabled, **settings):
     if iface_type not in _IFACE_TYPES:
         _raise_error_iface(iface, iface_type, _IFACE_TYPES)
 
+    if 'proto' not in settings:
+        settings['proto'] = 'static'
+
     if iface_type == 'slave':
         settings['slave'] = 'yes'
         if 'master' not in settings:


### PR DESCRIPTION
Having proto default to static if it's not specified since it's needed to build the template. #24521 
