### PR TITLE
Update README to point to working 'Reporting Bugs' page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,4 +65,4 @@ Reporting Issues
 
 To report an issue with Salt, please follow the guidelines for filing bug reports:
 
-* http://docs.saltstack.com/en/latest/topics/development/reporting_bugs.html
+* https://docs.saltstack.com/en/develop/topics/development/reporting_bugs.html


### PR DESCRIPTION
The existing URL for reporting issues to Salt returns a 404.

Should this be updated to point to the development docs (which displays the pesky "You are viewing docs from the develop branch" message), or should the site be updated?
