### PR TITLE
Add a helper module function called list_enabled

### DIFF
--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -96,14 +96,14 @@ def list_(show_all=False, return_yaml=True):
 def is_enabled(name):
     '''
     List a Job only if its enabled
-    
+
     CLI Example:
-    
+
     .. code-block:: bash
-    
+
         salt '*' schedule.is_enabled name=job_name
     '''
-    
+
     current_schedule = __salt__['schedule.list'](show_all=False, return_yaml=False)
     if name in current_schedule:
         return current_schedule[name]

--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -92,6 +92,22 @@ def list_(show_all=False, return_yaml=True):
     else:
         return {'schedule': {}}
 
+def list_enabled(name):
+    '''
+    List a Job only if its enabled
+    
+    CLI Example:
+    
+    .. code-block:: bash
+    
+        salt '*' schedule.enabled name=job_name
+    '''
+    
+    current_schedule = __salt__['schedule.list'](show_all=False, return_yaml=False)
+    if name in current_schedule:
+        return current_schedule[name]
+    else:
+        return {}
 
 def purge(**kwargs):
     '''

--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -92,6 +92,7 @@ def list_(show_all=False, return_yaml=True):
     else:
         return {'schedule': {}}
 
+
 def list_enabled(name):
     '''
     List a Job only if its enabled
@@ -108,6 +109,7 @@ def list_enabled(name):
         return current_schedule[name]
     else:
         return {}
+
 
 def purge(**kwargs):
     '''

--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -97,6 +97,8 @@ def is_enabled(name):
     '''
     List a Job only if its enabled
 
+    .. versionadded:: 2015.5.3
+
     CLI Example:
 
     .. code-block:: bash

--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -93,7 +93,7 @@ def list_(show_all=False, return_yaml=True):
         return {'schedule': {}}
 
 
-def list_enabled(name):
+def is_enabled(name):
     '''
     List a Job only if its enabled
     
@@ -101,7 +101,7 @@ def list_enabled(name):
     
     .. code-block:: bash
     
-        salt '*' schedule.enabled name=job_name
+        salt '*' schedule.is_enabled name=job_name
     '''
     
     current_schedule = __salt__['schedule.list'](show_all=False, return_yaml=False)


### PR DESCRIPTION
The use case of this function is to allow jobs to be scheduled by pillars but enabled by states. This allows us to add jobs to a Minions Schedule but enable them only after the minion is ready for them. 

``` jinja
{% set status =  salt['pillar.get']('external_pillar:status,'') %}
{% if status in "valid statuses" %}
  {% if not salt['schedule.list_enabled']('formula-job-name') %}
job-name-schedule-enable:
  module.run:
    - name: schedule.enable_job
    - m_name: 'formula-job-name'
  {% endif %}
{% endif %}
```
