### PR TITLE
Use smaller number for upper limit of mac_user's _first_avail_uid helper function

### DIFF
--- a/salt/modules/mac_user.py
+++ b/salt/modules/mac_user.py
@@ -63,7 +63,7 @@ def _dscl(cmd, ctype='create'):
 
 def _first_avail_uid():
     uids = set(x.pw_uid for x in pwd.getpwall())
-    for idx in range(501, 2 ** 32):
+    for idx in range(501, 2 ** 24):
         if idx not in uids:
             return idx
 


### PR DESCRIPTION
Using 2^32 as the upper limit causes an OverflowError when unit tests are run
on a 32-bit host. If your OS X host has over 4 billion users, I tip my hat to
you.
