### PR TITLE
replace bad value for master_type in example minion config

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -28,7 +28,7 @@
 # value to "standard".  Failover masters can be requested by setting
 # to "failover".  MAKE SURE TO SET master_alive_interval if you are
 # using failover.
-# master_type: standard
+# master_type: str
 
 # Poll interval in seconds for checking if the master is still there.  Only
 # respected if master_type above is "failover".


### PR DESCRIPTION
At some point, `standard` became an invalid argument for the master_type
minion config bit wrt Minion.eval_master().  'str' is what is reflected in https://github.com/saltstack/salt/blob/develop/salt/config.py#L74.  I haven't tracked down what changed elsewhere to make this a problem but have found that setting this in the opts.cloud.minion dict alleviates the problem of a newly minted minion soiling itself when trying to activate at the end of the bootstrap run.

Perhaps whatever code bit is laying down this squint-worthy minion config should probably just drop an empty /etc/salt/minion file letting it get updated with non-default values rather than trying to set every available minion opt.
- mad props to the creators/maintainers of the bootstrap script.  BASH makes
  me want to cut myself, so I appreciate complex scripts that are so
  very functional that I don't have to be responsible for
