### PR TITLE
Change pub test to return global ioloop instance

### DIFF
--- a/tests/unit/transport/zeromq_test.py
+++ b/tests/unit/transport/zeromq_test.py
@@ -187,7 +187,7 @@ class AsyncPubChannelTest(BaseZMQPubCase, PubChannelMixin):
     Tests around the publish system
     '''
     def get_new_ioloop(self):
-        return zmq.eventloop.ioloop.ZMQIOLoop()
+        return zmq.eventloop.ioloop.ZMQIOLoop().instance()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This _could_ be causing the intermetent failures on
unit.transport.zeromq_test.AsyncPubChannelTest.test_basic but it
is a bit of a shot in the dark.
