### PR TITLE
Ensure object is type basestring and not only string for gpg render

### DIFF
--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -98,6 +98,7 @@ import salt.ext.six as six
 # pylint: disable=import-error
 try:
     import gnupg
+
     HAS_GPG = True
     if salt.utils.which('gpg') is None:
         HAS_GPG = False
@@ -122,7 +123,7 @@ def decrypt_ciphertext(cypher, gpg, safe=False):
     decrypted_data = gpg.decrypt(cypher)
     if not decrypted_data.ok:
         decrypt_err = "Could not decrypt cipher {0}, received {1}".format(
-                cypher, decrypted_data.stderr)
+            cypher, decrypted_data.stderr)
         log.error(decrypt_err)
         if safe:
             raise SaltRenderError(decrypt_err)
@@ -134,11 +135,11 @@ def decrypt_ciphertext(cypher, gpg, safe=False):
 
 def decrypt_object(obj, gpg):
     '''
-    Recursively try to decrypt any object. If the object is a string, and
+    Recursively try to decrypt any object. If the object is a basestring (string or unicode), and
     it contains a valid GPG header, decrypt it, otherwise keep going until
     a string is found.
     '''
-    if isinstance(obj, str):
+    if isinstance(obj, basestring):
         if GPG_HEADER.search(obj):
             return decrypt_ciphertext(obj, gpg)
         else:

--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -95,6 +95,7 @@ from salt.exceptions import SaltRenderError
 
 # Import 3rd-party libs
 import salt.ext.six as six
+
 # pylint: disable=import-error
 try:
     import gnupg
@@ -135,11 +136,11 @@ def decrypt_ciphertext(cypher, gpg, safe=False):
 
 def decrypt_object(obj, gpg):
     '''
-    Recursively try to decrypt any object. If the object is a basestring (string or unicode), and
+    Recursively try to decrypt any object. If the object is a six.string_types (string or unicode), and
     it contains a valid GPG header, decrypt it, otherwise keep going until
     a string is found.
     '''
-    if isinstance(obj, basestring):
+    if isinstance(obj, six.string_types):
         if GPG_HEADER.search(obj):
             return decrypt_ciphertext(obj, gpg)
         else:


### PR DESCRIPTION
Hi,

I use an elasticsearch external pillar plugins. This external pillar returns unicode instead of string. Due to this the gpg render currently doesn't work.
Changing the check from str to basestring make it work.

Nicolas
