### PR TITLE
Removed --silent flag from npm install calls.

### DIFF
--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -106,7 +106,7 @@ def install(pkg=None,
 
     '''
 
-    cmd = 'npm install --silent --json'
+    cmd = 'npm install --json'
 
     if dir is None:
         cmd += ' --global'
@@ -250,7 +250,7 @@ def list_(pkg=None,
         if uid:
             env.update({'SUDO_UID': uid, 'SUDO_USER': ''})
 
-    cmd = 'npm list --silent --json'
+    cmd = 'npm list --json'
 
     if dir is None:
         cmd += ' --global'


### PR DESCRIPTION
I found it quite annoying trying to debug issues with npm bootstrapping because of the `--silent` flag being set.

Salt's output seems very verbose, and for good reason in my opinion, thus I don't see a reason for this flag to be set.
