### PR TITLE
Fix broken batch results

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -157,8 +157,11 @@ class Batch(object):
                             continue
                         if self.opts.get('raw'):
                             parts.update({part['id']: part})
+                            minion_tracker[queue]['minions'].remove(part['id'])
                         else:
                             parts.update(part)
+                            for id in part.keys():
+                                minion_tracker[queue]['minions'].remove(id)
                 except StopIteration:
                     # if a iterator is done:
                     # - set it to inactive


### PR DESCRIPTION
Fixes #24875

a34b74a70c8ebcabdf5096b0af02ae5d5770b531 fixed the ValueError but caused results to be overwritten as if a minion did not return, when actually it did.

The problem originates from the `StopIterator`:

```
                        # add all minions that belong to this iterator and
                        # that have not responded to parts{} with an empty response
                        for minion in minion_tracker[queue]['minions']:
                            if minion not in parts:
                                parts[minion] = {}
                                parts[minion]['ret'] = {}
```

Because the minions list is never reduced, it will populate parts with empty results for all minions that have not responded within the _last iteration_ as opposed to minions that have not responded within _any iteration_

Before a34b74a70c8ebcabdf5096b0af02ae5d5770b531 this meant a `ValueError` because the result set on the last iteration would contain empty responses for minions that weren't in the active queue anymore, because they responded in a previous iteration.

The fix, however, just skipped removing from active and carried on anyway, meaning the responses for minions that responded in earlier iterations were overwritten by the empty response generated in the last iteration.

This PR clears back the queue minion list as each minion responds, so only those that did not respond _at all_ are set to an empty response.

An alternative fix could be to check if the minion is in active and _skip_ so that the result is not overwritten. Not sure which is preferred - so I followed my own logical approach, which is to ensure `parts` only ever contains new information (it's weird that it contains empty responses for something that had already responded previously). Alternative smaller fix is at line 187 to do this instead, but I think it's more a bodge since `parts` would still be confusing:

```
                if minion not in active:
                    continue
                active.remove(minion)
```
