### PR TITLE
Add gem source server

### DIFF
--- a/salt/modules/gem.py
+++ b/salt/modules/gem.py
@@ -54,7 +54,8 @@ def install(gems,           # pylint: disable=C0103
             rdoc=False,
             ri=False,
             pre_releases=False,
-            proxy=None):      # pylint: disable=C0103
+            proxy=None,
+            source=None):      # pylint: disable=C0103
     '''
     Installs one or several gems.
 
@@ -79,6 +80,9 @@ def install(gems,           # pylint: disable=C0103
     proxy : None
         Use the specified HTTP proxy server for all outgoing traffic.
         Format: http://hostname[:port]
+    source : None
+        Use the specified HTTP gem source server to download gem.
+        Format: http://hostname[:port]
 
     CLI Example:
 
@@ -99,6 +103,8 @@ def install(gems,           # pylint: disable=C0103
         options.append('--pre')
     if proxy:
         options.append('-p {0}'.format(proxy))
+    if source:
+        options.append('--source {0}'.format(source))
 
     cmdline_args = ' '.join(options)
     return _gem('install {gems} {options}'.format(gems=gems,

--- a/salt/states/gem.py
+++ b/salt/states/gem.py
@@ -35,7 +35,8 @@ def installed(name,          # pylint: disable=C0103
               rdoc=False,
               ri=False,
               pre_releases=False,
-              proxy=None):     # pylint: disable=C0103
+              proxy=None,
+              source=None):     # pylint: disable=C0103
     '''
     Make sure that a gem is installed.
 
@@ -72,6 +73,10 @@ def installed(name,          # pylint: disable=C0103
     proxy : None
         Use the specified HTTP proxy server for all outgoing traffic.
         Format: http://hostname[:port]
+
+    source : None
+        Use the specified HTTP gem source server to download gem.
+        Format: http://hostname[:port]
     '''
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
     if ruby is not None and (__salt__['rvm.is_installed'](runas=user) or __salt__['rbenv.is_installed'](runas=user)):
@@ -99,7 +104,8 @@ def installed(name,          # pylint: disable=C0103
                                rdoc=rdoc,
                                ri=ri,
                                pre_releases=pre_releases,
-                               proxy=proxy):
+                               proxy=proxy,
+                               source=source):
         ret['result'] = True
         ret['changes'][name] = 'Installed'
         ret['comment'] = 'Gem was successfully installed'


### PR DESCRIPTION
Permits to define a gem "proxy" server like geminabox instance for servers that doesn't have direct access to internet.
