### PR TITLE
Fix fileclient.is_cached

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -25,6 +25,7 @@ import salt.utils
 import salt.utils.templates
 import salt.utils.gzip_util
 import salt.utils.http
+import salt.utils.url
 from salt.utils.openstack.swift import SaltSwift
 
 # pylint: disable=no-name-in-module,import-error

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -352,18 +352,23 @@ class Client(object):
             # Backwards compatibility
             saltenv = env
 
+        if path.startswith('salt://'):
+            path, senv = salt.utils.url.parse(path)
+            if senv:
+                saltenv = senv
+
+        escaped = True if salt.utils.url.is_escaped(path) else False
+
+        # also strip escape character '|'
         localsfilesdest = os.path.join(
-            self.opts['cachedir'], 'localfiles', path.lstrip('/'))
+            self.opts['cachedir'], 'localfiles', path.lstrip('|/'))
         filesdest = os.path.join(
-            self.opts['cachedir'], 'files', saltenv, path.lstrip('salt://'))
-        extrndest = self._extrn_path(path, saltenv)
+            self.opts['cachedir'], 'files', saltenv, path.lstrip('|'))
 
         if os.path.exists(filesdest):
-            return filesdest
+            return salt.utils.url.escape(filesdest) if escaped else filesdest
         elif os.path.exists(localsfilesdest):
-            return localsfilesdest
-        elif os.path.exists(extrndest):
-            return extrndest
+            return salt.utils.url.escape(localsfilesdest) if escaped else localsfilesdest
 
         return ''
 

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -364,7 +364,7 @@ class Client(object):
         localsfilesdest = os.path.join(
             self.opts['cachedir'], 'localfiles', path.lstrip('|/'))
         filesdest = os.path.join(
-            self.opts['cachedir'], 'files', saltenv, path.lstrip('|'))
+            self.opts['cachedir'], 'files', saltenv, path.lstrip('|/'))
 
         if os.path.exists(filesdest):
             return salt.utils.url.escape(filesdest) if escaped else filesdest

--- a/salt/utils/url.py
+++ b/salt/utils/url.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+'''
+URL utils
+'''
+
+# Import python libs
+from __future__ import absolute_import
+import re
+
+# Import salt libs
+from salt.ext.six.moves.urllib.parse import urlparse, urlunparse  # pylint: disable=import-error,no-name-in-module
+import salt.utils
+
+
+def parse(url):
+    '''
+    Parse a salt:// URL; return the path and a possible saltenv query.
+    '''
+    if not url.startswith('salt://'):
+        return url, None
+
+    # urlparse will split on valid filename chars such as '?' and '&'
+    resource = url.split('salt://', 1)[-1]
+
+    if '?env=' in resource:
+        salt.utils.warn_until(
+            'Boron',
+            'Passing a salt environment should be done using \'saltenv\' '
+            'not \'env\'. This functionality will be removed in Salt Boron.'
+        )
+        path, saltenv = resource.split('?env=', 1)
+    elif '?saltenv=' in resource:
+        path, saltenv = resource.split('?saltenv=', 1)
+    else:
+        path, saltenv = resource, None
+
+    if salt.utils.is_windows():
+        path = salt.utils.sanitize_win_path_string(path)
+
+    return path, saltenv
+
+
+def create(path, saltenv=None):
+    '''
+    join `path` and `saltenv` into a 'salt://' URL.
+    '''
+    if salt.utils.is_windows():
+        path = salt.utils.sanitize_win_path_string(path)
+
+    query = u'saltenv={0}'.format(saltenv) if saltenv else ''
+    url = urlunparse(('file', '', path, '', query, ''))
+    return u'salt://{0}'.format(url[len('file:///'):])
+
+
+def is_escaped(url):
+    '''
+    test whether `url` is escaped with `|`
+    '''
+    if salt.utils.is_windows():
+        return False
+
+    scheme = urlparse(url).scheme
+    if not scheme:
+        return url.startswith('|')
+    elif scheme == 'salt':
+        path, saltenv = parse(url)
+        return path.startswith('|')
+    else:
+        return False
+
+
+def escape(url):
+    '''
+    add escape character `|` to `url`
+    '''
+    if salt.utils.is_windows():
+        return url
+
+    scheme = urlparse(url).scheme
+    if not scheme:
+        if url.startswith('|'):
+            return url
+        else:
+            return u'|{0}'.format(url)
+    elif scheme == 'salt':
+        path, saltenv = parse(url)
+        if path.startswith('|'):
+            return create(path, saltenv)
+        else:
+            return create(u'|{0}'.format(path), saltenv)
+    else:
+        return url
+
+
+def unescape(url):
+    '''
+    remove escape character `|` from `url`
+    '''
+    if salt.utils.is_windows():
+        return url
+
+    scheme = urlparse(url).scheme
+    if not scheme:
+        return url.lstrip('|')
+    elif scheme == 'salt':
+        path, saltenv = parse(url)
+        return create(path.lstrip('|'), saltenv)
+    else:
+        return url
+
+
+def add_env(url, saltenv):
+    '''
+    append `saltenv` to `url` as a query parameter to a 'salt://' url
+    '''
+    if not url.startswith('salt://'):
+        return url
+
+    path, senv = parse(url)
+    return create(path, saltenv)
+
+
+def split_env(url):
+    '''
+    remove the saltenv query parameter from a 'salt://' url
+    '''
+    if not url.startswith('salt://'):
+        return url, None
+
+    path, senv = parse(url)
+    return create(path), senv
+
+
+def validate(url, protos):
+    '''
+    Return true if the passed URL scheme is in the list of accepted protos
+    '''
+    if urlparse(url).scheme in protos:
+        return True
+    return False
+
+
+def strip_proto(url):
+    '''
+    Return a copy of the string with the protocol designation stripped, if one
+    was present.
+    '''
+    return re.sub('^[^:/]+://', '', url)


### PR DESCRIPTION
Whoever wrote this code misunderstood how `string.lsplit()` works.

```
>>> 'salt://slah/slah'.lstrip('salt://')
'h/slah'
```

This backports the develop version of this function, and `salt.utils.url` to support it.
