### PR TITLE
Use cmd_unzip to preserve permissions

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -206,18 +206,17 @@ def extracted(name,
 
     __salt__['file.makedirs'](name, user=user, group=group)
 
-    if archive_format in ('zip', 'rar'):
-        log.debug('Extract {0} in {1}'.format(filename, name))
-        files = __salt__['archive.un{0}'.format(archive_format)](filename,
-                                                                 name)
+    log.debug('Extract {0} in {1}'.format(filename, name))
+    if archive_format == 'zip':
+        files = __salt__['archive.cmd_unzip'](filename, name)
+    elif archive_format == 'rar':
+        files = __salt__['archive.unrar'](filename, name)
     else:
         if tar_options is None:
             with closing(tarfile.open(filename, 'r')) as tar:
                 files = tar.getnames()
                 tar.extractall(name)
         else:
-            log.debug('Untar {0} in {1}'.format(filename, name))
-
             tar_opts = tar_options.split(' ')
 
             tar_cmd = ['tar']


### PR DESCRIPTION
Solves #23822

Python's zip file extraction does not preserve permissions in archive, so we use cmd.run unzip instead.
