### PR TITLE
Support for IPv6 addresses scopes in network.interfaces

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -402,6 +402,7 @@ def _interfaces_ip(out):
         based on the current set of cols
         '''
         brd = None
+        scope = None
         if '/' in value:  # we have a CIDR in this address
             ip, cidr = value.split('/')  # pylint: disable=C0103
         else:
@@ -414,7 +415,8 @@ def _interfaces_ip(out):
                 brd = cols[cols.index('brd') + 1]
         elif type_ == 'inet6':
             mask = cidr
-        return (ip, mask, brd)
+            scope = cols[cols.index('scope') + 1]
+        return (ip, mask, brd, scope)
 
     groups = re.compile('\r?\n\\d').split(out)
     for group in groups:
@@ -441,7 +443,7 @@ def _interfaces_ip(out):
                 iflabel = cols[-1:][0]
                 if type_ in ('inet', 'inet6'):
                     if 'secondary' not in cols:
-                        ipaddr, netmask, broadcast = parse_network(value, cols)
+                        ipaddr, netmask, broadcast, scope = parse_network(value, cols)
                         if type_ == 'inet':
                             if 'inet' not in data:
                                 data['inet'] = list()
@@ -457,11 +459,12 @@ def _interfaces_ip(out):
                             addr_obj = dict()
                             addr_obj['address'] = ipaddr
                             addr_obj['prefixlen'] = netmask
+                            addr_obj['scope'] = scope
                             data['inet6'].append(addr_obj)
                     else:
                         if 'secondary' not in data:
                             data['secondary'] = list()
-                        ip_, mask, brd = parse_network(value, cols)
+                        ip_, mask, brd, scp = parse_network(value, cols)
                         data['secondary'].append({
                             'type': type_,
                             'address': ip_,
@@ -469,7 +472,7 @@ def _interfaces_ip(out):
                             'broadcast': brd,
                             'label': iflabel,
                         })
-                        del ip_, mask, brd
+                        del ip_, mask, brd, scp
                 elif type_.startswith('link'):
                     data['hwaddr'] = value
         if iface:


### PR DESCRIPTION
This pull request show IPv6 addresses scopes in network.interfaces modules.

Example output for `salt 'server' network.interfaces`: 

```
    eth0:
        ----------
        hwaddr:
            00:16:3e:54:12:76
        inet:
            |_
              ----------
              address:
                  176.31.222.181
              broadcast:
                  176.31.222.191
              label:
                  eth0
              netmask:
                  255.255.255.240
        inet6:
            |_
              ----------
              address:
                  2001:41d0:9b:fc01::1
              prefixlen:
                  56
              scope:
                  global
            |_
              ----------
              address:
                  fe80::216:3eff:fe54:1276
              prefixlen:
                  64
              scope:
                  link
        up:
            True
```
