### PR TITLE
Fix typos in execution module docs

### DIFF
--- a/doc/ref/modules/index.rst
+++ b/doc/ref/modules/index.rst
@@ -21,10 +21,10 @@ Modules Are Easy to Write!
 
 Writing Salt execution modules is straightforward.
 
-A Salt execution modules is a Python or `Cython`_ module
+A Salt execution module is a Python or `Cython`_ module
 placed in a directory called ``_modules/``
 within the :conf_master:`file_roots` as specified by the master config file. By
-default this is `/srv/salt/_modules` on Linux systems.
+default this is ``/srv/salt/_modules`` on Linux systems.
 
 
 Modules placed in ``_modules/`` will be synced to the minions when any of the following


### PR DESCRIPTION
Fixes a pluralization error and a path formatting typo.
