### PR TITLE
Allow checking for non-normalized systemd units.

### DIFF
--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -234,6 +234,8 @@ def available(name):
         salt '*' service.available sshd
     '''
     name = _canonical_template_unit_name(name)
+    if name.endswith('.service'):
+        name = name[:-8]  # len('.service') is 8
     units = get_all()
     if name in units:
         return True


### PR DESCRIPTION
When using service.available with the systemd provider, allow appending
the .service suffix for service files, so that service.available('sshd')
and service.available('sshd.service') both are True.

I was a bit confused after salt couldn't find a service file, even though I was able to start it by hand.
