### PR TITLE
Support for Devuan

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -969,7 +969,8 @@ _OS_FAMILY_MAP = {
     'Linaro': 'Debian',
     'elementary OS': 'Debian',
     'ScientificLinux': 'RedHat',
-    'Raspbian': 'Debian'
+    'Raspbian': 'Debian',
+    'Devuan': 'Debian'
 }
 
 


### PR DESCRIPTION
With that change, Devuan (http://devuan.org/) is detected as part of the Debian OS family so that APT/PKGREPO Modules are working too.

I'm not sure if this is the only needed change, but as far as I tested this made Salt working for me.
