### PR TITLE
Update salt/auth/pki.py

### DIFF
--- a/salt/auth/pki.py
+++ b/salt/auth/pki.py
@@ -22,7 +22,7 @@ import logging
 # Import third party libs
 # pylint: disable=import-error
 try:
-    import Crypto.Util
+    from Crypto.Util import asn1
     import OpenSSL
     HAS_DEPS = True
 except ImportError:
@@ -44,12 +44,17 @@ def __virtual__():
     return False
 
 
-def auth(pem, **kwargs):
+def auth(username, password, **kwargs):
     '''
-    Returns True if the given user cert was issued by the CA.
+    Returns True if the given user cert (password is the cert contents) 
+    was issued by the CA and if cert's Common Name is equal to username.
+    
     Returns False otherwise.
 
-    ``pem``: a pem-encoded user public key (certificate)
+    ``username``: we need it to run the auth function from CLI/API;
+                  it should be in master config auth/acl
+    ``password``: contents of user certificate (pem-encoded user public key);
+                  why "password"? For CLI, it's the only available name
 
     Configure the CA cert in the master config file:
 
@@ -58,10 +63,11 @@ def auth(pem, **kwargs):
         external_auth:
           pki:
             ca_file: /etc/pki/tls/ca_certs/trusted-ca.crt
-
+            your_user:
+              - .*
     '''
     c = OpenSSL.crypto
-
+    pem = password
     cert = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, pem)
 
     cacert_file = __salt__['config.get']('external_auth:pki:ca_file')
@@ -79,7 +85,7 @@ def auth(pem, **kwargs):
     cert_asn1 = c.dump_certificate(c.FILETYPE_ASN1, cert)
 
     # Decode the certificate
-    der = Crypto.Util.asn1.DerSequence()
+    der = asn1.DerSequence()
     der.decode(cert_asn1)
 
     # The certificate has three parts:
@@ -93,7 +99,7 @@ def auth(pem, **kwargs):
 
     # The signature is a BIT STRING (Type 3)
     # Decode that as well
-    der_sig_in = Crypto.Util.asn1.DerObject()
+    der_sig_in = asn1.DerObject()
     der_sig_in.decode(der_sig)
 
     # Get the payload
@@ -112,8 +118,9 @@ def auth(pem, **kwargs):
     # And verify the certificate
     try:
         c.verify(cacert, sig, der_cert, algo)
+        assert dict(cert.get_subject().get_components())['CN'] == username, "Certificate's CN should match the username"
         log.info('Successfully authenticated certificate: {0}'.format(pem))
         return True
-    except OpenSSL.crypto.Error:
+    except (OpenSSL.crypto.Error, AssertionError):
         log.info('Failed to authenticate certificate: {0}'.format(pem))
     return False

--- a/salt/auth/pki.py
+++ b/salt/auth/pki.py
@@ -46,9 +46,9 @@ def __virtual__():
 
 def auth(username, password, **kwargs):
     '''
-    Returns True if the given user cert (password is the cert contents) 
+    Returns True if the given user cert (password is the cert contents)
     was issued by the CA and if cert's Common Name is equal to username.
-    
+
     Returns False otherwise.
 
     ``username``: we need it to run the auth function from CLI/API;


### PR DESCRIPTION
- fix `asn1` import (should be explicitly imported from `Crypto.Util`)
- changed `auth(...)` method arguments: `pem` replaced with `username` and `password` because these two can be passed via `salt` CLI
  - `username` is required by salt auth core in order to trigger `auth.pki` (and only in case when `username` is mentioned in master conf `external_auth:pki` i.e. when it passes ACL)
  - `password` is the user certificate contents (why not `pem`? Because it's the only way to pass the certificate contents in `salt` CLI without prompt)
- additional security check added: we check that `username` is equal to cert's Common Name (CN)

Now it's possible to use PKI auth in `salt` CLI (as well as in `salt-api`).
## How to use it

I believe that currently it's not well explained how to use this PKI Salt external auth so here is an example
### Create certificates

I'm not an SSL guru, the example is taken [from here](http://datacenteroverlords.com/2012/03/01/creating-your-own-ssl-certificate-authority/):

``` bash
openssl genrsa -out root-ca.key 2048
openssl req -x509 -new -nodes -key root-ca.key -days 1024 -out root-ca.pem
openssl genrsa -out johns.key 2048
openssl req -new -key johns.key -out johns.csr # set Common Name: johns (i.e. desired username)
openssl x509 -req -in johns.csr -CA root-ca.pem -CAkey root-ca.key -CAcreateserial -out johns.crt -days 365
```
### Enable root certificate

Edit your master config:

``` yaml
external_auth:
  pki:
    ca_file: /path/to/root-ca.pem
    johns:
      - .*
```
### Run Salt CLI

``` bash
salt -a pki --username=johns --password="`cat /path/to/johns.crt`" '*' test.ping
```
### Run Salt API

Assuming that you have set it up:

``` bash
curl https://your-salt-api:12345/login -c cookies -d eauth=pki -d username=johns --data-urlencode password="`cat /path/to/johns.crt`" # should return Token
curl https://your-salt-api:12345 -b cookies -d client=local -d fun=test.ping -d tgt='*'
```
