### PR TITLE
solve the issue of add_host. If the name had already one more recored…

### DIFF
--- a/salt/modules/ddns.py
+++ b/salt/modules/ddns.py
@@ -159,25 +159,12 @@ def update(zone, name, ttl, rdtype, data, nameserver='127.0.0.1', replace=False,
     rdtype = dns.rdatatype.from_text(rdtype)
     rdata = dns.rdata.from_text(dns.rdataclass.IN, rdtype, data)
 
-    is_update = False
-    for rrset in answer.answer:
-        if rdata in rrset.items:
-            rr = rrset.items
-            if ttl == rrset.ttl:
-                if replace and (len(answer.answer) > 1
-                        or len(rrset.items) > 1):
-                    is_update = True
-                    break
-                return None
-            is_update = True
-            break
-
     keyring = _get_keyring(_config('keyfile', **kwargs))
     keyname = _config('keyname', **kwargs)
     keyalgorithm = _config('keyalgorithm', **kwargs) or 'HMAC-MD5.SIG-ALG.REG.INT'
 
     dns_update = dns.update.Update(zone, keyring=keyring, keyname=keyname, keyalgorithm=keyalgorithm)
-    if is_update:
+    if replace:
         dns_update.replace(name, ttl, rdata)
     else:
         dns_update.add(name, ttl, rdata)

--- a/salt/modules/ddns.py
+++ b/salt/modules/ddns.py
@@ -167,7 +167,7 @@ def update(zone, name, ttl, rdtype, data, nameserver='127.0.0.1', replace=False,
     for rrset in answer.answer:
         if rdata in rrset.items:
             if ttl == rrset.ttl:
-                if (len(answer.answer) >= 1 or len(rrset.items) >= 1):
+                if len(answer.answer) >= 1 or len(rrset.items) >= 1:
                     is_exist = True
                     break
 

--- a/salt/modules/ddns.py
+++ b/salt/modules/ddns.py
@@ -163,10 +163,18 @@ def update(zone, name, ttl, rdtype, data, nameserver='127.0.0.1', replace=False,
     keyname = _config('keyname', **kwargs)
     keyalgorithm = _config('keyalgorithm', **kwargs) or 'HMAC-MD5.SIG-ALG.REG.INT'
 
+    is_exist = False
+    for rrset in answer.answer:
+        if rdata in rrset.items:
+            if ttl == rrset.ttl:
+                if (len(answer.answer) >= 1 or len(rrset.items) >= 1):
+                    is_exist = True
+                    break
+
     dns_update = dns.update.Update(zone, keyring=keyring, keyname=keyname, keyalgorithm=keyalgorithm)
     if replace:
         dns_update.replace(name, ttl, rdata)
-    else:
+    elif not is_exist:
         dns_update.add(name, ttl, rdata)
     answer = dns.query.udp(dns_update, nameserver)
     if answer.rcode() > 0:


### PR DESCRIPTION
solve the issue of add_host. 
If the name had already one more recored and the update data was not in the zone, we would need to execute one more time. 
The function of dns_update.replace() will deleting all rrset at the specific host name.
If we want to add_host, we don't need to check the data exist in dns server.
