### PR TITLE
Fix list render in apache

### DIFF
--- a/salt/modules/apache.py
+++ b/salt/modules/apache.py
@@ -403,7 +403,8 @@ def _parse_config(conf, slot=None):
         else:
             print('{0}'.format(conf), file=ret, end='')
     elif isinstance(conf, list):
-        print('{0} {1}'.format(str(slot), ' '.join(conf)), file=ret, end='')
+        for value in conf:
+            print(_parse_config(value, str(slot)), file=ret)
     elif isinstance(conf, dict):
         print('<{0} {1}>'.format(
             slot,
@@ -415,7 +416,7 @@ def _parse_config(conf, slot=None):
             if isinstance(value, str):
                 print('{0} {1}'.format(key, value), file=ret)
             elif isinstance(value, list):
-                print('{0} {1}'.format(key, ' '.join(value)), file=ret)
+                print(_parse_config(value, key), file=ret)
             elif isinstance(value, dict):
                 print(_parse_config(value, key), file=ret)
         print('</{0}>'.format(slot), file=ret, end='')


### PR DESCRIPTION
Fix rendering list to lines in apache module.
Render 

```
RewriteRule:
        - '^/a(.*) https://domani_a.com [R]'
        - '^/b(.*) https://domain_b.com [R]'
```

as

```
RewriteRule ^/a(.*) https://domani_a.com [R]
RewriteRule ^/b(.*) https://domain_b.com
```

rather than

```
RewriteRule ^/a(.*) https://domani_a.com [R]  ^/b(.*) https://domain_b.com
```

join all list on single line, which I don't think have any use in apache conf
