### PR TITLE
Fixed bug report link. Old link was 404

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,4 +65,4 @@ Reporting Issues
 
 To report an issue with Salt, please follow the guidelines for filing bug reports:
 
-* http://docs.saltstack.com/en/latest/topics/development/reporting_bugs.html
+* http://docs.saltstack.com/en/develop/topics/development/reporting_bugs.html


### PR DESCRIPTION
Bug reporting link was linking to a 404 not found page, updated link to develop instead of latest documentation.
