### PR TITLE
Extend salt.utils.istextfile() with detection of utf-8 content instead of binary

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1107,6 +1107,11 @@ def istextfile(fp_, blocksize=512):
     elif not block:
         # An empty file is considered a valid text file
         return True
+    try:
+        block.decode('utf-8')
+        return True
+    except UnicodeDecodeError:
+        pass
 
     nontext = block.translate(None, text_characters)
     return float(len(nontext)) / len(block) <= 0.30

--- a/tests/integration/states/file.py
+++ b/tests/integration/states/file.py
@@ -1555,7 +1555,8 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
                     'name': '{0}'.format(test_file),
                     '__run_num__': 1,
                     'comment': 'File {0} updated'.format(test_file),
-                    'diff': 'Replace binary file with text file'
+                    'diff': '--- \n+++ \n@@ -1 +1,3\n+{0}\n {1}\n+{2}\n'.format(
+                                korean_utf8_2, korean_utf8_1, korean_utf8_3),
                 },
                 ('file_|-some-utf8-file-exists_|-{0}'
                 '_|-exists').format(test_file): {


### PR DESCRIPTION
In case of use a lot of utf-8 content in text file (for example rich russian comments or any other non-english email-templates) saltstack determine these files as binary and do not display diff. This patch adding simple check for utf-8 content before heuristic analysys.
