### PR TITLE
Changing the way links look on the index page

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,17 +17,17 @@ Download
 
 Salt source releases are available for download via the following PyPI link:
 
-    https://pypi.python.org/pypi/salt
+* https://pypi.python.org/pypi/salt
 
 The installation document, found in the following link,  outlines where to
 obtain packages and installation specifics for platforms:
 
-    :doc:`Installation </topics/installation/index>`
+* :doc:`Installation </topics/installation/index>`
 
 The Salt Bootstrap project, found in the following repository, is a single
 shell script, which automates the install correctly on  multiple platforms:
 
-    https://github.com/saltstack/salt-bootstrap
+* https://github.com/saltstack/salt-bootstrap
 
 Get Started
 ===============


### PR DESCRIPTION
Earlier they looked like this:
<img width="864" alt="screen shot 2015-07-08 at 2 55 33 am" src="https://cloud.githubusercontent.com/assets/3374962/8564743/ffe87ae2-251c-11e5-91b6-0684fb539798.png">

Now they look like this:
<img width="866" alt="screen shot 2015-07-08 at 2 57 18 am" src="https://cloud.githubusercontent.com/assets/3374962/8564750/13ff3f16-251d-11e5-860e-a858fb1df364.png">
