### PR TITLE
[25230] Change LXC version to come from lxc-info

### DIFF
--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -117,7 +117,7 @@ def version():
     '''
     k = 'lxc.version'
     if not __context__.get(k, None):
-        cversion = __salt__['cmd.run_all']('lxc-ls --version')
+        cversion = __salt__['cmd.run_all']('lxc-info --version')
         if not cversion['retcode']:
             ver = distutils.version.LooseVersion(cversion['stdout'])
             if ver < distutils.version.LooseVersion('1.0'):


### PR DESCRIPTION
Fix for:
https://github.com/saltstack/salt/issues/25230

Seems lxc-ls isn't reliable to get a version - seems to be blank in some circumstances (when there's no containers?), and returns response of native ls otherwise

Examples from LXC 1.0.7:
lxc-info --version
1.0.7

lxc-ls --version
ls (GNU coreutils) 8.4
Copyright (C) 2010 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later http://gnu.org/licenses/gpl.html.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

ls --version
ls (GNU coreutils) 8.4
Copyright (C) 2010 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later http://gnu.org/licenses/gpl.html.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
