### PR TITLE
Remove parted deprecations and fix failing tests

### DIFF
--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -97,7 +97,7 @@ def _validate_partition_boundary(boundary):
         )
 
 
-def probe(*devices, **kwargs):
+def probe(*devices):
     '''
     Ask the kernel to update its local partition data. When no args are
     specified all block devices are tried.
@@ -113,39 +113,12 @@ def probe(*devices, **kwargs):
         salt '*' partition.probe /dev/sda
         salt '*' partition.probe /dev/sda /dev/sdb
     '''
-    salt.utils.kwargs_warn_until(kwargs, 'Beryllium')
-    if 'device' in kwargs:
-        devices = tuple([kwargs['device']] + list(devices))
-        del kwargs['device']
-    if kwargs:
-        raise TypeError("probe() takes no keyword arguments")
-
     for device in devices:
         _validate_device(device)
 
     cmd = 'partprobe -- {0}'.format(" ".join(devices))
     out = __salt__['cmd.run'](cmd).splitlines()
     return out
-
-
-def part_list(device, unit=None):
-    '''
-    Deprecated. Calls partition.list.
-
-    CLI Examples:
-
-    .. code-block:: bash
-
-        salt '*' partition.part_list /dev/sda
-        salt '*' partition.part_list /dev/sda unit=s
-        salt '*' partition.part_list /dev/sda unit=kB
-    '''
-    salt.utils.warn_until(
-        'Beryllium',
-        '''The \'part_list\' function has been deprecated in favor of
-        \'list_\'. Please update your code and configs to reflect this.''')
-
-    return list_(device, unit)
 
 
 def list_(device, unit=None):

--- a/tests/unit/modules/parted_test.py
+++ b/tests/unit/modules/parted_test.py
@@ -84,57 +84,13 @@ class PartedTestCase(TestCase):
 
     @patch('salt.modules.parted._validate_device', MagicMock())
     def test_probe_w_single_arg(self):
-        parted.probe("/dev/sda")
+        parted.probe('/dev/sda')
         self.cmdrun.assert_called_once_with('partprobe -- /dev/sda')
 
     @patch('salt.modules.parted._validate_device', MagicMock())
     def test_probe_w_multiple_args(self):
         parted.probe('/dev/sda', '/dev/sdb')
         self.cmdrun.assert_called_once_with('partprobe -- /dev/sda /dev/sdb')
-
-    @staticmethod
-    def check_kwargs_warn_until_devices(device_kwargs):
-        def check_args(kwargs, version):
-            assert kwargs == device_kwargs
-            assert version == 'Beryllium'
-        parted.salt.utils.kwargs_warn_until.side_effect = check_args
-
-    @patch('salt.utils.kwargs_warn_until')
-    @patch('salt.modules.parted._validate_device', MagicMock())
-    def test_probe_w_device_kwarg(self, *args, **kwargs):
-        device_kwargs = {'device': '/dev/sda'}
-        parted.probe(**device_kwargs)
-        self.check_kwargs_warn_until_devices(device_kwargs)
-        self.cmdrun.assert_called_once_with('partprobe -- /dev/sda')
-
-    @patch('salt.utils.kwargs_warn_until')
-    @patch('salt.modules.parted._validate_device', MagicMock())
-    def test_probe_w_device_kwarg_and_arg(self, *args, **kwargs):
-        '''device arg is concatenated with positional args'''
-        device_kwargs = {'device': '/dev/sda'}
-        parted.probe("/dev/sdb", **device_kwargs)
-        self.check_kwargs_warn_until_devices(device_kwargs)
-        self.cmdrun.assert_called_once_with('partprobe -- /dev/sda /dev/sdb')
-
-    @patch('salt.utils.kwargs_warn_until')
-    def test_probe_w_extra_kwarg(self, *args, **kwargs):
-        device_kwargs = {'foo': 'bar'}
-        self.assertRaises(TypeError, parted.probe, **device_kwargs)
-        self.check_kwargs_warn_until_devices(device_kwargs)
-        self.assertFalse(self.cmdrun.called)
-
-    # Test part_list function
-
-    @patch('salt.modules.parted.list_')
-    @patch('salt.utils.warn_until')
-    def test_part_list(self, *args, **kwargs):
-        '''Function should call new function and raise deprecation warning'''
-        parted.part_list("foo", "bar")
-        parted.list_.assert_called_once_with("foo", "bar")
-        parted.salt.utils.warn_until.assert_called_once_with(
-            'Beryllium',
-            '''The \'part_list\' function has been deprecated in favor of
-        \'list_\'. Please update your code and configs to reflect this.''')
 
     # Test _list function
 


### PR DESCRIPTION
The tests that were removed here are used to test deprecated/removed functionality or an entire function that is removed.
