### PR TITLE
Rsync state

### DIFF
--- a/salt/states/rsync.py
+++ b/salt/states/rsync.py
@@ -29,9 +29,19 @@ def __virtual__():
     return salt.utils.which('rsync') and 'rsync' or False
 
 
+def _get_summary(rsync_out):
 def synchronized(name, source, delete=False, force=False, update=False,
                  passwordfile=None, exclude=None, excludefrom=None):
     '''
+    Get summary from the rsync successfull output.
+
+    :param rsync_out:
+    :return:
+    '''
+
+    return "- " + "\n- ".join([elm for elm in rsync_out.split("\n\n")[-1].replace("  ", "\n").split("\n") if elm])
+
+
     Synchronizing directories:
 
     .. code-block:: yaml

--- a/salt/states/rsync.py
+++ b/salt/states/rsync.py
@@ -42,6 +42,26 @@ def synchronized(name, source, delete=False, force=False, update=False,
     return "- " + "\n- ".join([elm for elm in rsync_out.split("\n\n")[-1].replace("  ", "\n").split("\n") if elm])
 
 
+def _get_changes(rsync_out):
+    '''
+    Get changes from the rsync successfull output.
+
+    :param rsync_out:
+    :return:
+    '''
+    copied = list()
+    deleted = list()
+
+    for line in rsync_out.split("\n\n")[0].split("\n")[1:]:
+        if line.startswith("deleting "):
+            deleted.append(line.split(" ", 1)[-1])
+        else:
+            copied.append(line)
+
+    return {
+        'copied': os.linesep.join(sorted(copied)) or "N/A",
+        'deleted': os.linesep.join(sorted(deleted)) or "N/A",
+    }
     Synchronizing directories:
 
     .. code-block:: yaml

--- a/salt/states/rsync.py
+++ b/salt/states/rsync.py
@@ -19,6 +19,7 @@ Rsync state.
 .. versionadded:: Boron
 '''
 
+from __future__ import absolute_import
 import salt.utils
 import os
 

--- a/salt/states/rsync.py
+++ b/salt/states/rsync.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 '''
 Rsync state.
+
+.. versionadded:: Boron
 '''
 
 import salt.utils

--- a/salt/states/rsync.py
+++ b/salt/states/rsync.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+'''
+Operations with Rsync.
+'''
+
+import salt.utils
+
+
+def __virtual__():
+    '''
+    Only if Rsync is available.
+
+    :return:
+    '''
+    return salt.utils.which('rsync') and 'rsync' or False
+
+
+def synchronized(name, source, delete=False, force=False, update=False,
+                 passwordfile=None, exclude=None, excludefrom=None):
+    '''
+    Synchronizing directories:
+
+    .. code-block:: yaml
+
+        /opt/user-backups:
+          rsync.synchronized:
+            - source: /home
+    '''
+    ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
+    result = __salt__['rsync.rsync'](source, name, delete=delete, force=force, update=update,
+                                     passwordfile=passwordfile, exclude=exclude, excludefrom=excludefrom)
+
+    return ret

--- a/salt/states/rsync.py
+++ b/salt/states/rsync.py
@@ -1,4 +1,18 @@
 # -*- coding: utf-8 -*-
+#
+# Copyright 2015 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 '''
 Operations with Rsync.
 '''

--- a/salt/states/rsync.py
+++ b/salt/states/rsync.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 '''
-Operations with Rsync.
+Rsync state.
 '''
 
 import salt.utils

--- a/salt/states/rsync.py
+++ b/salt/states/rsync.py
@@ -62,13 +62,36 @@ def _get_changes(rsync_out):
         'copied': os.linesep.join(sorted(copied)) or "N/A",
         'deleted': os.linesep.join(sorted(deleted)) or "N/A",
     }
-    Synchronizing directories:
+
+
+def synchronized(name, source,
+                 delete=False,
+                 force=False,
+                 update=False,
+                 passwordfile=None,
+                 exclude=None,
+                 excludefrom=None,
+                 prepare=False):
+    '''
+    Guarantees that the source directory is always copied to the target.
+
+    :param name: Name of the target directory.
+    :param source: Source directory.
+    :param prepare: Create destination directory if it does not exists.
+    :param delete: Delete extraneous files from the destination dirs (True or False)
+    :param force: Force deletion of dirs even if not empty
+    :param update: Skip files that are newer on the receiver (True or False)
+    :param passwordfile: Read daemon-access password from the file (path)
+    :param exclude: Exclude files, that matches pattern.
+    :param excludefrom: Read exclude patterns from the file (path)
+    :return:
 
     .. code-block:: yaml
 
         /opt/user-backups:
           rsync.synchronized:
             - source: /home
+            - force: True
     '''
     ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
     result = __salt__['rsync.rsync'](source, name, delete=delete, force=force, update=update,


### PR DESCRIPTION
We found out that Rsync state is nice to have, in order to avoid `cmd.run rsync.....` workaround.

Usage:

```
/opt/backups:
  rsync.synchronized:
    - source: /home/test
    - prepare: True
    - delete: True
```

The argument `prepare` is new and is not in the Rsync module. It just makes sure than `/opt/backups` is always there. If you run that state from the command line, you should get something like:

```
          ID: /opt/backups
    Function: rsync.synchronized
      Result: True
     Comment: - sent 13,365 bytes
              - received 112 bytes
              - 26,954.00 bytes/sec
              - total size is 6,136,588
              - speedup is 455.34
     Started: 20:35:53.170829
    Duration: 56.859 ms
     Changes:   
              ----------
              copied:
                  test/
                  test/foo.txt
              deleted:
                  N/A
```
