### PR TITLE
Change versionadded/changed references from Beryllium to 2015.8.0

### DIFF
--- a/doc/ref/states/requisites.rst
+++ b/doc/ref/states/requisites.rst
@@ -7,7 +7,7 @@ Requisites and Other Global State Arguments
 Fire Event Notifications
 ========================
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 The `fire_event` option in a state will cause the minion to send an event to
 the Salt Master upon completion of that individual state.

--- a/doc/topics/cloud/azure.rst
+++ b/doc/topics/cloud/azure.rst
@@ -196,7 +196,7 @@ behavior when a VM is destroyed.
 
 cleanup_disks
 -------------
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 Default is ``False``. When set to ``True``, Salt Cloud will wait for the VM to
 be destroyed, then attempt to destroy the main disk that is associated with the
@@ -204,7 +204,7 @@ VM.
 
 cleanup_vhds
 ------------
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 Default is ``False``. Requires ``cleanup_disks`` to be set to ``True``. When
 also set to ``True``, Salt Cloud will ask Azure to delete the VHD associated
@@ -212,7 +212,7 @@ with the disk that is also destroyed.
 
 cleanup_services
 ----------------
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 Default is ``False``. Requires ``cleanup_disks`` to be set to ``True``. When
 also set to ``True``, Salt Cloud will wait for the disk to be destroyed, then
@@ -222,7 +222,7 @@ belongs to the service, the disk must be destroyed before the service can be.
 
 Managing Hosted Services
 ========================
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 An account can have one or more hosted services. A hosted service is required
 in order to create a VM. However, as mentioned above, if a hosted service is not
@@ -302,7 +302,7 @@ Delete a specific hosted service.
 
 Managing Storage Accounts
 =========================
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 Salt Cloud can manage storage accounts associated with the account. The
 following functions are available. Deprecated marked as deprecated are marked
@@ -422,7 +422,7 @@ to be specified.
 
 Managing Disks
 ==============
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 When a VM is created, a disk will also be created for it. The following
 functions are available for managing disks. Deprecated marked as deprecated are
@@ -493,7 +493,7 @@ Delete a specific disk.
 
 Managing Service Certificates
 =============================
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 Stored at the cloud service level, these certificates are used by your deployed
 services. For more information on service certificates, see the following link:
@@ -571,7 +571,7 @@ and ``thumbalgorithm`` can be obtained from ``list_service_certificates``.
 
 Managing Management Certificates
 ================================
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 A Azure management certificate is an X.509 v3 certificate used to authenticate
 an agent, such as Visual Studio Tools for Windows Azure or a client application
@@ -653,7 +653,7 @@ obtained from ``list_management_certificates``.
 
 Virtual Network Management
 ==========================
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 The following are functions for managing virtual networks.
 
@@ -668,7 +668,7 @@ List input endpoints associated with the deployment.
 
 Managing Input Endpoints
 ========================
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 Input endpoints are used to manage port access for roles. Because endpoints
 cannot be managed by the Azure Python SDK, Salt Cloud uses the API directly.
@@ -815,7 +815,7 @@ endpoint is set to. For instance, port 22 would be called SSH.
 
 Managing Affinity Groups
 ========================
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 Affinity groups allow you to group your Azure services to optimize performance.
 All services and VMs within an affinity group will be located in the same
@@ -888,7 +888,7 @@ Delete a specific affinity group associated with the account
 
 Managing Blob Storage
 =====================
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 Azure storage containers and their contents can be managed with Salt Cloud. This
 is not as elegant as using one of the other available clients in Windows, but it

--- a/doc/topics/cloud/gogrid.rst
+++ b/doc/topics/cloud/gogrid.rst
@@ -106,7 +106,7 @@ command:
 Assigning IPs
 =============
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 The GoGrid API allows IP addresses to be manually assigned. Salt Cloud supports
 this functionality by allowing an IP address to be specified using the

--- a/doc/topics/cloud/linode.rst
+++ b/doc/topics/cloud/linode.rst
@@ -4,7 +4,7 @@ Getting Started With Linode
 
 Linode is a public cloud provider with a focus on Linux instances.
 
-Starting with the Beryllium release of Salt, the Linode driver uses Linode's
+Starting with the 2015.8.0 release of Salt, the Linode driver uses Linode's
 native REST API. There are no external dependencies required to use the
 Linode driver.
 

--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -2,7 +2,7 @@
 Getting Started With VMware
 ===========================
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 **Author**: Nitin Madhok <nmadhok@clemson.edu>
 

--- a/doc/topics/releases/version_numbers.rst
+++ b/doc/topics/releases/version_numbers.rst
@@ -24,8 +24,9 @@ Assigned codenames:
 - Hydrogen: ``2014.1.0``
 - Helium: ``2014.7.0``
 - Lithium: ``2015.5.0``
-- Beryllium: ``TBD``
+- Beryllium: ``2015.8.0``
 - Boron: ``TBD``
+- Carbon: ``TBD``
 
 Example
 -------

--- a/doc/topics/targeting/compound.rst
+++ b/doc/topics/targeting/compound.rst
@@ -43,7 +43,7 @@ That same example expressed in a :term:`top file` looks like the following:
         - match: compound
         - webserver
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 Excluding a minion based on its ID is also possible:
 
@@ -51,7 +51,7 @@ Excluding a minion based on its ID is also possible:
 
     salt -C 'not web-dc1-srv' test.ping
 
-Versions prior to Beryllium a leading ``not`` was not supported in compound
+Versions prior to 2015.8.0 a leading ``not`` was not supported in compound
 matches. Instead, something like the following was required:
 
 .. code-block:: bash
@@ -81,7 +81,7 @@ Matches can be grouped together with parentheses to explicitly declare precedenc
 Alternate Delimiters
 --------------------
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 Some matchers allow an optional delimiter character specified between the
 leading matcher character and the ``@`` pattern separator character.  This

--- a/doc/topics/targeting/nodegroups.rst
+++ b/doc/topics/targeting/nodegroups.rst
@@ -28,7 +28,7 @@ nodegroups. Here's an example nodegroup configuration within
     group2 is matching specific grains. See the :doc:`compound matchers
     <compound>` documentation for more details.
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 .. note::
 
@@ -36,7 +36,7 @@ nodegroups. Here's an example nodegroup configuration within
     that you do not have circular references.  Circular references will be
     detected and cause partial expansion with a logged error message.
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 Compound nodegroups can be either string values or lists of string values.
 When the nodegroup is A string value will be tokenized by splitting on

--- a/doc/topics/windows/windows-package-manager.rst
+++ b/doc/topics/windows/windows-package-manager.rst
@@ -189,10 +189,10 @@ Once the sls file has been created, generate the repository cache file with the 
 
     salt-run winrepo.genrepo
 
-Beginning with the Beryllium Salt release the repository cache is compiled on
+Beginning with the 2015.8.0 Salt release the repository cache is compiled on
 the Salt Minion. This allows for easy templating on the minion which allows for
 pillar, grains and other things to be available during compilation time. From
-Beryllium forward the above `salt-run winrepo.genrepo` is only required for
+2015.8.0 forward the above `salt-run winrepo.genrepo` is only required for
 older minions. New minions should execute `salt \* pkg.refresh_db` to update
 from the latest from the master's repo.
 

--- a/salt/auth/stormpath.py
+++ b/salt/auth/stormpath.py
@@ -16,7 +16,7 @@ normally requires.
     directory: 3456789012
     # But not both
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 '''
 
 from __future__ import absolute_import

--- a/salt/cli/spm.py
+++ b/salt/cli/spm.py
@@ -5,7 +5,7 @@
 
     Salt's spm cli parser.
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 '''
 
 # Import Python libs

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1578,7 +1578,7 @@ class Caller(object):
     ``Caller`` is the same interface used by the :command:`salt-call`
     command-line tool on the Salt Minion.
 
-    .. versionchanged:: Beryllium
+    .. versionchanged:: 2015.8.0
         Added the ``cmd`` method for consistency with the other Salt clients.
         The existing ``function`` and ``sminion.functions`` interfaces still
         exist but have been removed from the docs.
@@ -1623,7 +1623,7 @@ class Caller(object):
         '''
         Call an execution module with the given arguments and keword arguments
 
-        .. versionchanged:: Beryllium
+        .. versionchanged:: 2015.8.0
             Added the ``cmd`` method for consistency with the other Salt clients.
             The existing ``function`` and ``sminion.functions`` interfaces still
             exist but have been removed from the docs.

--- a/salt/client/spm.py
+++ b/salt/client/spm.py
@@ -2,7 +2,7 @@
 '''
 This module provides the point of entry to SPM, the Salt Package Manager
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 '''
 
 # Import Python libs

--- a/salt/client/ssh/wrapper/pillar.py
+++ b/salt/client/ssh/wrapper/pillar.py
@@ -110,7 +110,7 @@ def raw(key=None):
 
 def keys(key, delimiter=DEFAULT_TARGET_DELIM):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Attempt to retrieve a list of keys from the named value from the pillar.
 

--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -791,7 +791,7 @@ def show_pricing(kwargs=None, call=None):
     Show pricing for a particular profile. This is only an estimate, based on
     unofficial pricing sources.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Examples:
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -4053,7 +4053,7 @@ def update_pricing(kwargs=None, call=None):
         salt-cloud -f update_pricing my-ec2-config
         salt-cloud -f update_pricing my-ec2-config type=linux
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
     '''
     sources = {
         'linux': 'https://a0.awsstatic.com/pricing/1/ec2/linux-od.min.js',
@@ -4078,7 +4078,7 @@ def _parse_pricing(url, name):
     '''
     Download and parse an individual pricing file from AWS
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
     '''
     price_js = http.query(url, text=True)
 
@@ -4149,7 +4149,7 @@ def show_pricing(kwargs=None, call=None):
 
         salt-cloud -f update_pricing <provider>
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
     '''
     profile = __opts__['profiles'].get(kwargs['profile'], {})
     if not profile:

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -2244,7 +2244,7 @@ def update_pricing(kwargs=None, call=None):
 
         salt-cloud -f update_pricing my-gce-config
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
     '''
     url = 'https://cloudpricingcalculator.appspot.com/static/data/pricelist.json'
     price_json = http.query(url, decode=True, decode_type='json')
@@ -2263,7 +2263,7 @@ def show_pricing(kwargs=None, call=None):
     Show pricing for a particular profile. This is only an estimate, based on
     unofficial pricing sources.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Examples:
 

--- a/salt/cloud/clouds/gogrid.py
+++ b/salt/cloud/clouds/gogrid.py
@@ -313,7 +313,7 @@ def list_passwords(kwargs=None, call=None):
     '''
     List all password on the account
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
     '''
     response = _query('support', 'password/list')
 
@@ -343,7 +343,7 @@ def list_public_ips(kwargs=None, call=None):
 
         salt-cloud -f list_public_ips <provider> state=assigned
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
     '''
     if kwargs is None:
         kwargs = {}
@@ -373,7 +373,7 @@ def list_common_lookups(kwargs=None, call=None):
     '''
     List common lookups for a particular type of item
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
     '''
     if kwargs is None:
         kwargs = {}
@@ -437,7 +437,7 @@ def reboot(name, call=None):
 
         salt-cloud -a reboot vm_name
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
     '''
     return _query('grid', 'server/power', args={'name': name, 'power': 'restart'})
 
@@ -452,7 +452,7 @@ def stop(name, call=None):
 
         salt-cloud -a stop vm_name
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
     '''
     return _query('grid', 'server/power', args={'name': name, 'power': 'stop'})
 
@@ -467,7 +467,7 @@ def start(name, call=None):
 
         salt-cloud -a start vm_name
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
     '''
     return _query('grid', 'server/power', args={'name': name, 'power': 'start'})
 
@@ -482,7 +482,7 @@ def show_instance(name, call=None):
 
         salt-cloud -a show_instance vm_name
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
     '''
     response = _query('grid', 'server/get', args={'name': name})
     ret = {}
@@ -510,7 +510,7 @@ def _query(action=None,
     '''
     Make a web call to GoGrid
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
     '''
     vm_ = get_configured_provider()
     apikey = config.get_cloud_config_value(

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -781,7 +781,7 @@ def reboot(name=None, linode_id=None, call=None):
     '''
     Reboot a linode. Either a name or a linode_id must be provided.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     name
         The name of the VM to reboot.
@@ -827,7 +827,7 @@ def show_instance(name=None, linode_id=None, call=None):
     Displays details about a particular Linode VM. Either a name or a linode_id must
     be provided.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     name
         The name of the VM for which to display details.
@@ -881,7 +881,7 @@ def show_pricing(kwargs=None, call=None):
     Show pricing for a particular profile. This is only an estimate, based on
     unofficial pricing sources.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 

--- a/salt/cloud/clouds/msazure.py
+++ b/salt/cloud/clouds/msazure.py
@@ -1067,7 +1067,7 @@ def get_operation_status(kwargs=None, conn=None, call=None):
 
 def list_storage(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     List storage accounts associated with the account
 
@@ -1095,7 +1095,7 @@ def list_storage(kwargs=None, conn=None, call=None):
 
 def show_storage(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     List storage service properties
 
@@ -1131,7 +1131,7 @@ get_storage = show_storage
 
 def show_storage_keys(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Show storage account keys
 
@@ -1174,7 +1174,7 @@ get_storage_keys = show_storage_keys
 
 def create_storage(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Create a new storage account
 
@@ -1226,7 +1226,7 @@ def create_storage(kwargs=None, conn=None, call=None):
 
 def update_storage(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Update a storage account's properties
 
@@ -1263,7 +1263,7 @@ def update_storage(kwargs=None, conn=None, call=None):
 
 def regenerate_storage_keys(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Regenerate storage account keys. Requires a key_type ("primary" or
     "secondary") to be specified.
@@ -1303,7 +1303,7 @@ def regenerate_storage_keys(kwargs=None, conn=None, call=None):
 
 def delete_storage(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Delete a specific storage account
 
@@ -1336,7 +1336,7 @@ def delete_storage(kwargs=None, conn=None, call=None):
 
 def list_services(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     List hosted services associated with the account
 
@@ -1364,7 +1364,7 @@ def list_services(kwargs=None, conn=None, call=None):
 
 def show_service(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     List hosted service properties
 
@@ -1398,7 +1398,7 @@ def show_service(kwargs=None, conn=None, call=None):
 
 def create_service(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Create a new hosted service
 
@@ -1445,7 +1445,7 @@ def create_service(kwargs=None, conn=None, call=None):
 
 def delete_service(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Delete a specific service associated with the account
 
@@ -1478,7 +1478,7 @@ def delete_service(kwargs=None, conn=None, call=None):
 
 def list_disks(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     List disks associated with the account
 
@@ -1505,7 +1505,7 @@ def list_disks(kwargs=None, conn=None, call=None):
 
 def show_disk(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Return information about a disk
 
@@ -1539,7 +1539,7 @@ get_disk = show_disk
 
 def cleanup_unattached_disks(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Cleans up all disks associated with the account, which are not attached.
     *** CAUTION *** This is a destructive function with no undo button, and no
@@ -1574,7 +1574,7 @@ def cleanup_unattached_disks(kwargs=None, conn=None, call=None):
 
 def delete_disk(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Delete a specific disk associated with the account
 
@@ -1608,7 +1608,7 @@ def delete_disk(kwargs=None, conn=None, call=None):
 
 def update_disk(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Update a disk's properties
 
@@ -1647,7 +1647,7 @@ def update_disk(kwargs=None, conn=None, call=None):
 
 def list_service_certificates(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     List certificates associated with the service
 
@@ -1680,7 +1680,7 @@ def list_service_certificates(kwargs=None, conn=None, call=None):
 
 def show_service_certificate(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Return information about a service certificate
 
@@ -1725,7 +1725,7 @@ get_service_certificate = show_service_certificate
 
 def add_service_certificate(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Add a new service certificate
 
@@ -1773,7 +1773,7 @@ def add_service_certificate(kwargs=None, conn=None, call=None):
 
 def delete_service_certificate(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Delete a specific certificate associated with the service
 
@@ -1817,7 +1817,7 @@ def delete_service_certificate(kwargs=None, conn=None, call=None):
 
 def list_management_certificates(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     List management certificates associated with the subscription
 
@@ -1844,7 +1844,7 @@ def list_management_certificates(kwargs=None, conn=None, call=None):
 
 def show_management_certificate(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Return information about a management_certificate
 
@@ -1879,7 +1879,7 @@ get_management_certificate = show_management_certificate
 
 def add_management_certificate(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Add a new management certificate
 
@@ -1923,7 +1923,7 @@ def add_management_certificate(kwargs=None, conn=None, call=None):
 
 def delete_management_certificate(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Delete a specific certificate associated with the management
 
@@ -1957,7 +1957,7 @@ def delete_management_certificate(kwargs=None, conn=None, call=None):
 
 def list_virtual_networks(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     List input endpoints associated with the deployment
 
@@ -1979,7 +1979,7 @@ def list_virtual_networks(kwargs=None, conn=None, call=None):
 
 def list_input_endpoints(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     List input endpoints associated with the deployment
 
@@ -2023,7 +2023,7 @@ def list_input_endpoints(kwargs=None, conn=None, call=None):
 
 def show_input_endpoint(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Show an input endpoint associated with the deployment
 
@@ -2055,7 +2055,7 @@ get_input_endpoint = show_input_endpoint
 
 def update_input_endpoint(kwargs=None, conn=None, call=None, activity='update'):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Update an input endpoint associated with the deployment. Please note that
     there may be a delay before the changes show up.
@@ -2169,7 +2169,7 @@ xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 
 def add_input_endpoint(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Add an input endpoint to the deployment. Please note that
     there may be a delay before the changes show up.
@@ -2193,7 +2193,7 @@ def add_input_endpoint(kwargs=None, conn=None, call=None):
 
 def delete_input_endpoint(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Delete an input endpoint from the deployment. Please note that
     there may be a delay before the changes show up.
@@ -2215,7 +2215,7 @@ def delete_input_endpoint(kwargs=None, conn=None, call=None):
 
 def show_deployment(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Return information about a deployment
 
@@ -2255,7 +2255,7 @@ get_deployment = show_deployment
 
 def list_affinity_groups(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     List input endpoints associated with the deployment
 
@@ -2282,7 +2282,7 @@ def list_affinity_groups(kwargs=None, conn=None, call=None):
 
 def show_affinity_group(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Show an affinity group associated with the account
 
@@ -2317,7 +2317,7 @@ get_affinity_group = show_affinity_group
 
 def create_affinity_group(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Create a new affinity group
 
@@ -2361,7 +2361,7 @@ def create_affinity_group(kwargs=None, conn=None, call=None):
 
 def update_affinity_group(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Update an affinity group's properties
 
@@ -2398,7 +2398,7 @@ def update_affinity_group(kwargs=None, conn=None, call=None):
 
 def delete_affinity_group(kwargs=None, conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Delete a specific affinity group associated with the account
 
@@ -2431,7 +2431,7 @@ def delete_affinity_group(kwargs=None, conn=None, call=None):
 
 def get_storage_conn(storage_account=None, storage_key=None, conn_kwargs=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Return a storage_conn object for the storage account
     '''
@@ -2455,7 +2455,7 @@ def get_storage_conn(storage_account=None, storage_key=None, conn_kwargs=None):
 
 def make_blob_url(kwargs=None, storage_conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Creates the URL to access a blob
 
@@ -2511,7 +2511,7 @@ def make_blob_url(kwargs=None, storage_conn=None, call=None):
 
 def list_storage_containers(kwargs=None, storage_conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     List containers associated with the storage account
 
@@ -2538,7 +2538,7 @@ def list_storage_containers(kwargs=None, storage_conn=None, call=None):
 
 def create_storage_container(kwargs=None, storage_conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Create a storage container
 
@@ -2580,7 +2580,7 @@ def create_storage_container(kwargs=None, storage_conn=None, call=None):
 
 def show_storage_container(kwargs=None, storage_conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Show a container associated with the storage account
 
@@ -2620,7 +2620,7 @@ get_storage_container = show_storage_container
 
 def show_storage_container_metadata(kwargs=None, storage_conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Show a storage container's metadata
 
@@ -2663,7 +2663,7 @@ get_storage_container_metadata = show_storage_container_metadata
 
 def set_storage_container_metadata(kwargs=None, storage_conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Set a storage container's metadata
 
@@ -2714,7 +2714,7 @@ def set_storage_container_metadata(kwargs=None, storage_conn=None, call=None):
 
 def show_storage_container_acl(kwargs=None, storage_conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Show a storage container's acl
 
@@ -2757,7 +2757,7 @@ get_storage_container_acl = show_storage_container_acl
 
 def set_storage_container_acl(kwargs=None, storage_conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Set a storage container's acl
 
@@ -2799,7 +2799,7 @@ def set_storage_container_acl(kwargs=None, storage_conn=None, call=None):
 
 def delete_storage_container(kwargs=None, storage_conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Delete a container associated with the storage account
 
@@ -2841,7 +2841,7 @@ def delete_storage_container(kwargs=None, storage_conn=None, call=None):
 
 def lease_storage_container(kwargs=None, storage_conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Lease a container associated with the storage account
 
@@ -2920,7 +2920,7 @@ def lease_storage_container(kwargs=None, storage_conn=None, call=None):
 
 def list_blobs(kwargs=None, storage_conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     List blobs associated with the container
 
@@ -2993,7 +2993,7 @@ def list_blobs(kwargs=None, storage_conn=None, call=None):
 
 def show_blob_service_properties(kwargs=None, storage_conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Show a blob's service properties
 
@@ -3023,7 +3023,7 @@ get_blob_service_properties = show_blob_service_properties
 
 def set_blob_service_properties(kwargs=None, storage_conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Sets the properties of a storage account's Blob service, including
     Windows Azure Storage Analytics. You can also use this operation to
@@ -3064,7 +3064,7 @@ def set_blob_service_properties(kwargs=None, storage_conn=None, call=None):
 
 def show_blob_properties(kwargs=None, storage_conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Returns all user-defined metadata, standard HTTP properties, and
     system properties for the blob.
@@ -3117,7 +3117,7 @@ get_blob_properties = show_blob_properties
 
 def set_blob_properties(kwargs=None, storage_conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Set a blob's properties
 
@@ -3186,7 +3186,7 @@ def set_blob_properties(kwargs=None, storage_conn=None, call=None):
 
 def put_blob(kwargs=None, storage_conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Upload a blob
 
@@ -3261,7 +3261,7 @@ def put_blob(kwargs=None, storage_conn=None, call=None):
 
 def get_blob(kwargs=None, storage_conn=None, call=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Download a blob
 

--- a/salt/cloud/clouds/qingcloud.py
+++ b/salt/cloud/clouds/qingcloud.py
@@ -3,7 +3,7 @@
 QingCloud Cloud Module
 ======================
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 The QingCloud cloud module is used to control access to the QingCloud.
 http://www.qingcloud.com/

--- a/salt/cloud/clouds/scaleway.py
+++ b/salt/cloud/clouds/scaleway.py
@@ -3,7 +3,7 @@
 Scaleway Cloud Module
 =====================
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 The Scaleway cloud module is used to interact with your Scaleway BareMetal
 Servers.

--- a/salt/cloud/clouds/softlayer_hw.py
+++ b/salt/cloud/clouds/softlayer_hw.py
@@ -659,7 +659,7 @@ def show_pricing(kwargs=None, call=None):
 
         salt-cloud -f update_pricing <provider>
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
     '''
     profile = __opts__['profiles'].get(kwargs['profile'], {})
     if not profile:

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -3,7 +3,7 @@
 VMware Cloud Module
 ===================
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 The VMware cloud module allows you to manage VMware ESX, ESXi, and vCenter.
 

--- a/salt/cloud/clouds/vsphere.py
+++ b/salt/cloud/clouds/vsphere.py
@@ -884,7 +884,7 @@ def snapshot_list(kwargs=None, call=None):
     '''
     List virtual machines with snapshots
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -940,7 +940,7 @@ def create_snapshot(kwargs=None, call=None):
     @description: Description of the snapshot (optional)
     @memory: Dump of the internal state of the virtual machine (optional)
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -994,7 +994,7 @@ def delete_snapshot(kwargs=None, call=None):
     '''
     Delete snapshot
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 

--- a/salt/config.py
+++ b/salt/config.py
@@ -2388,7 +2388,7 @@ def is_profile_configured(opts, provider, profile_name):
 
     Required parameters include image, provider, and size keys.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
     '''
     required_keys = ['image', 'provider', 'size']
     alias, driver = provider.split(':')
@@ -2794,7 +2794,7 @@ def spm_config(path):
     Read in the salt master config file and add additional configs that
     need to be stubbed out for spm
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
     '''
     # Let's grab a copy of salt's master default opts
     defaults = DEFAULT_MASTER_OPTS

--- a/salt/engines/logstash.py
+++ b/salt/engines/logstash.py
@@ -3,7 +3,7 @@
 An engine that reads messages from the salt event bus and pushes
 them onto a logstash endpoint.
 
-.. versionadded: Beryllium
+.. versionadded: 2015.8.0
 
 :configuration:
 

--- a/salt/engines/sqs_events.py
+++ b/salt/engines/sqs_events.py
@@ -4,7 +4,7 @@ An engine that continuously reads messages from SQS and fires them as events.
 
 Note that long polling is utilized to avoid excessive CPU usage.
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 :configuration:
     This engine can be run on the master or on a minion.

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -421,7 +421,7 @@ def install(name=None,
         install --reinstall`` will only be used if the installed version
         matches the requested version.
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
 
     Multiple Package Installation Options:
@@ -474,7 +474,7 @@ def install(name=None,
    force_conf_new
         Always install the new version of any configuration files.
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     Returns a dict containing the new package names and versions::
 
@@ -733,7 +733,7 @@ def autoremove(list_only=False, purge=False):
     purge : False
         Also remove package config data when autoremoving packages.
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -851,7 +851,7 @@ def upgrade(refresh=True, dist_upgrade=False, **kwargs):
    force_conf_new
         Always install the new version of any configuration files.
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -1550,7 +1550,7 @@ def del_repo(repo, **kwargs):
 
 def del_repo_key(name=None, **kwargs):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Remove a repo key using ``apt-key del``
 

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -57,7 +57,7 @@ def tar(options, tarfile, sources=None, dest=None,
     options
         Options to pass to the tar command
 
-        .. versionchanged:: Beryllium
+        .. versionchanged:: 2015.8.0
 
             The mandatory `-` prefixing has been removed.  An options string
             beginning with a `--long-option`, would have uncharacteristically
@@ -420,7 +420,7 @@ def cmd_unzip(zip_file, dest, excludes=None,
     options : None
         Additional command-line options to pass to the ``unzip`` binary.
 
-        .. versionchanged:: Beryllium
+        .. versionchanged:: 2015.8.0
 
             The mandatory `-` prefixing has been removed.  An options string
             beginning with a `--long-option`, would have uncharacteristically

--- a/salt/modules/bamboohr.py
+++ b/salt/modules/bamboohr.py
@@ -2,7 +2,7 @@
 '''
 Support for BambooHR
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 Requires a ``subdomain`` and an ``apikey`` in ``/etc/salt/minion``:
 

--- a/salt/modules/beacons.py
+++ b/salt/modules/beacons.py
@@ -2,7 +2,7 @@
 '''
 Module for managing the Salt beacons on a minion
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 '''
 
@@ -26,8 +26,6 @@ __func_alias__ = {
 def list_(return_yaml=True):
     '''
     List the beacons currently configured on the minion
-
-    .. versionadded:: Beryllium
 
     :param return_yaml:     Whether to return YAML formatted output, default True
     :return:                List of currently configured Beacons.
@@ -69,8 +67,6 @@ def list_(return_yaml=True):
 def add(name, beacon_data, **kwargs):
     '''
     Add a beacon on the minion
-
-    .. versionadded:: Beryllium
 
     :param name:            Name of the beacon to configure
     :param beacon_data:     Dictionary or list containing configuration for beacon.
@@ -134,8 +130,6 @@ def add(name, beacon_data, **kwargs):
 def modify(name, beacon_data, **kwargs):
     '''
     Modify an existing beacon
-
-    .. versionadded:: Beryllium
 
     :param name:            Name of the beacon to configure
     :param beacon_data:     Dictionary or list containing updated configuration for beacon.
@@ -217,8 +211,6 @@ def delete(name, **kwargs):
     '''
     Delete a beacon item
 
-    .. versionadded:: Beryllium
-
     :param name:            Name of the beacon to delete
     :return:                Boolean and status message on success or failure of delete.
 
@@ -260,8 +252,6 @@ def save():
     '''
     Save all beacons on the minion
 
-    .. versionadded:: Beryllium
-
     :return:                Boolean and status message on success or failure of save.
 
     CLI Example:
@@ -298,8 +288,6 @@ def save():
 def enable(**kwargs):
     '''
     Enable all beacons on the minion
-
-    .. versionadded:: Beryllium
 
     :return:                Boolean and status message on success or failure of enable.
 
@@ -340,8 +328,6 @@ def disable(**kwargs):
     '''
     Disable all beaconsd jobs on the minion
 
-    .. versionadded:: Beryllium
-
     :return:                Boolean and status message on success or failure of disable.
 
     CLI Example:
@@ -381,8 +367,6 @@ def disable(**kwargs):
 def enable_beacon(name, **kwargs):
     '''
     Enable beacon on the minion
-
-    .. versionadded:: Beryllium
 
     :name:                  Name of the beacon to enable.
     :return:                Boolean and status message on success or failure of enable.
@@ -431,8 +415,6 @@ def enable_beacon(name, **kwargs):
 def disable_beacon(name, **kwargs):
     '''
     Disable beacon on the minion
-
-    .. versionadded:: Beryllium
 
     :name:                  Name of the beacon to enable.
     :return:                Boolean and status message on success or failure of disable.

--- a/salt/modules/boto_cfn.py
+++ b/salt/modules/boto_cfn.py
@@ -2,7 +2,7 @@
 '''
 Connection module for Amazon Cloud Formation
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.5.0
 
 :configuration: This module accepts explicit AWS credentials but can also utilize
     IAM roles assigned to the instance trough Instance Profiles. Dynamic
@@ -71,8 +71,6 @@ def exists(name, region=None, key=None, keyid=None, profile=None):
     '''
     Check to see if a stack exists.
 
-    .. versionadded:: Beryllium
-
     CLI example::
 
         salt myminion boto_cfn.exists mystack region=us-east-1
@@ -93,7 +91,7 @@ def describe(name, region=None, key=None, keyid=None, profile=None):
     '''
     Describe a stack.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI example::
 
@@ -131,8 +129,6 @@ def create(name, template_body=None, template_url=None, parameters=None, notific
     '''
     Create a CFN stack.
 
-    .. versionadded:: Beryllium
-
     CLI example to create a stack::
 
         salt myminion boto_cfn.create mystack template_url='https://s3.amazonaws.com/bucket/template.cft' \
@@ -157,7 +153,7 @@ def update_stack(name, template_body=None, template_url=None, parameters=None, n
     '''
     Update a CFN stack.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI example to update a stack::
 
@@ -184,8 +180,6 @@ def delete(name, region=None, key=None, keyid=None, profile=None):
     '''
     Delete a CFN stack.
 
-    .. versionadded:: Beryllium
-
     CLI example to delete a stack::
 
         salt myminion boto_cfn.delete mystack region=us-east-1
@@ -204,8 +198,6 @@ def delete(name, region=None, key=None, keyid=None, profile=None):
 def get_template(name, region=None, key=None, keyid=None, profile=None):
     '''
     Check to see if attributes are set on a CFN stack.
-
-    .. versionadded:: Beryllium
 
     CLI example::
 
@@ -228,7 +220,7 @@ def validate_template(template_body=None, template_url=None, region=None, key=No
     '''
     Validate cloudformation template
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI example::
 

--- a/salt/modules/boto_ec2.py
+++ b/salt/modules/boto_ec2.py
@@ -2,7 +2,7 @@
 '''
 Connection module for Amazon EC2
 
-.. versionadded:: TBD
+.. versionadded:: 2015.8.0
 
 :configuration: This module accepts explicit EC2 credentials but can also
     utilize IAM roles assigned to the instance trough Instance Profiles.

--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -205,7 +205,7 @@ def create_user(user_name, path=None, region=None, key=None, keyid=None,
     '''
     Create a user.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -234,7 +234,7 @@ def get_all_access_keys(user_name, marker=None, max_items=None,
     '''
     Get all access keys from a user.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -255,7 +255,7 @@ def create_access_key(user_name, region=None, key=None, keyid=None, profile=None
     '''
     Create access key id for a user.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -277,7 +277,7 @@ def delete_access_key(access_key_id, user_name=None, region=None, key=None,
     '''
     Delete access key id from a user.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -299,7 +299,7 @@ def delete_user(user_name, region=None, key=None, keyid=None,
     '''
     Delete a user.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -324,7 +324,7 @@ def get_user(user_name=None, region=None, key=None, keyid=None, profile=None):
     '''
     Get user information.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -350,7 +350,7 @@ def create_group(group_name, path=None, region=None, key=None, keyid=None,
     '''
     Create a group.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -379,7 +379,7 @@ def get_group(group_name, marker=None, max_items=None, region=None, key=None,
     '''
     Get group information.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -405,7 +405,7 @@ def add_user_to_group(user_name, group_name, region=None, key=None, keyid=None,
     '''
     Add user to group.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -439,7 +439,7 @@ def user_exists_in_group(user_name, group_name, region=None, key=None, keyid=Non
     '''
     Check if user exists in group.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -463,7 +463,7 @@ def remove_user_from_group(group_name, user_name, region=None, key=None, keyid=N
     '''
     Remove user from group.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -497,7 +497,7 @@ def put_group_policy(group_name, policy_name, policy_json, region=None, key=None
     '''
     Adds or updates the specified policy document for the specified group.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -563,7 +563,7 @@ def get_group_policy(group_name, policy_name, region=None, key=None,
     '''
     Retrieves the specified policy document for the specified group.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -617,7 +617,7 @@ def create_login_profile(user_name, password, region=None, key=None,
     Creates a login profile for the specified user, give the user the
     ability to access AWS services and the AWS Management Console.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -657,7 +657,7 @@ def update_account_password_policy(allow_users_to_change_password=None,
     '''
     Update the password policy for the AWS account.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -687,7 +687,7 @@ def get_account_policy(region=None, key=None, keyid=None, profile=None):
     '''
     Get account policy for the AWS account.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -973,7 +973,7 @@ def update_assume_role_policy(role_name, policy_document, region=None,
     '''
     Update an assume role policy for a role.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -1003,7 +1003,7 @@ def build_policy(region=None, key=None, keyid=None, profile=None):
     '''
     Build a default assume role policy.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -1077,7 +1077,7 @@ def get_all_user_policies(user_name, marker=None, max_items=None, region=None, k
     '''
     Get all user policies.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -1103,7 +1103,7 @@ def get_user_policy(user_name, policy_name, region=None, key=None, keyid=None, p
     '''
     Retrieves the specified policy document for the specified user.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -1132,7 +1132,7 @@ def put_user_policy(user_name, policy_name, policy_json, region=None, key=None, 
     '''
     Adds or updates the specified policy document for the specified user.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -1197,7 +1197,7 @@ def upload_server_cert(cert_name, cert_body, private_key, cert_chain=None, path=
     '''
     Upload a certificate to Amazon.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -1236,7 +1236,7 @@ def get_server_certificate(cert_name, region=None, key=None, keyid=None, profile
     '''
     Returns certificate information from Amazon
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -1261,7 +1261,7 @@ def delete_server_cert(cert_name, region=None, key=None, keyid=None, profile=Non
     '''
     Deletes a certificate from Amazon.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 

--- a/salt/modules/boto_kms.py
+++ b/salt/modules/boto_kms.py
@@ -2,7 +2,7 @@
 '''
 Connection module for Amazon KMS
 
-.. versionadded:: beryllium
+.. versionadded:: 2015.8.0
 
 :configuration: This module accepts explicit kms credentials but can also utilize
     IAM roles assigned to the instance trough Instance Profiles. Dynamic

--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -2,7 +2,7 @@
 '''
 Connection module for Amazon RDS
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 :configuration: This module accepts explicit rds credentials but can also
     utilize IAM roles assigned to the instance trough Instance Profiles.

--- a/salt/modules/boto_route53.py
+++ b/salt/modules/boto_route53.py
@@ -103,7 +103,7 @@ def zone_exists(zone, region=None, key=None, keyid=None, profile=None):
     '''
     Check for the existence of a Route53 hosted zone.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example::
 
@@ -119,7 +119,7 @@ def create_zone(zone, private=False, vpc_id=None, vpc_region=None, region=None,
     '''
     Create a Route53 hosted zone.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example::
 
@@ -141,7 +141,7 @@ def delete_zone(zone, region=None, key=None, keyid=None, profile=None):
     '''
     Delete a Route53 hosted zone.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example::
 

--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -39,7 +39,7 @@ Connection module for Amazon VPC
             key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
             region: us-east-1
 
-.. versionchanged:: Beryllium
+.. versionchanged:: 2015.8.0
     All methods now return a dictionary. Create and delete methods return:
 
     .. code-block:: yaml
@@ -357,7 +357,7 @@ def get_resource_id(resource, name=None, resource_id=None, region=None,
     '''
     Get an AWS id for a VPC resource by type and name.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -381,7 +381,7 @@ def resource_exists(resource, name=None, resource_id=None, tags=None,
     {exists: false} if it does not exist, or {error: {message: error text}
     on error.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -616,7 +616,7 @@ def describe(vpc_id=None, vpc_name=None, region=None, key=None,
 
     Returns a dictionary of interesting properties.
 
-    .. versionchanged:: Beryllium
+    .. versionchanged:: 2015.8.0
         Added vpc_name argument
 
     CLI Example:
@@ -662,7 +662,7 @@ def describe_vpcs(vpc_id=None, name=None, cidr=None, tags=None,
 
     Returns a a list of dictionaries with interesting properties.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -754,7 +754,7 @@ def create_subnet(vpc_id=None, cidr_block=None, vpc_name=None,
 
     Returns True if the VPC subnet was created and returns False if the VPC subnet was not created.
 
-    .. versionchanged:: Beryllium
+    .. versionchanged:: 2015.8.0
         Added vpc_name argument
 
     CLI Examples:
@@ -787,7 +787,7 @@ def delete_subnet(subnet_id=None, subnet_name=None, region=None, key=None,
 
     Returns True if the subnet was deleted and returns False if the subnet was not deleted.
 
-    .. versionchanged:: Beryllium
+    .. versionchanged:: 2015.8.0
         Added subnet_name argument
 
     CLI Example:
@@ -811,7 +811,7 @@ def subnet_exists(subnet_id=None, name=None, subnet_name=None, cidr=None,
 
     Returns True if the subnet exists, otherwise returns False.
 
-    .. versionchanged:: Beryllium
+    .. versionchanged:: 2015.8.0
         Added subnet_name argument
         Deprecated name argument
 
@@ -917,7 +917,7 @@ def describe_subnet(subnet_id=None, subnet_name=None, region=None,
 
     Returns a dictionary of interesting properties.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Examples:
 
@@ -949,7 +949,7 @@ def describe_subnets(subnet_ids=None, subnet_names=None, vpc_id=None, cidr=None,
     If a subnet id or CIDR is provided, only its associated subnet details will be
     returned.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Examples:
 
@@ -1014,7 +1014,7 @@ def create_internet_gateway(internet_gateway_name=None, vpc_id=None,
     Returns the internet gateway id if the internet gateway was created and
     returns False if the internet gateways was not created.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
     CLI Example:
 
     .. code-block:: bash
@@ -1053,7 +1053,7 @@ def delete_internet_gateway(internet_gateway_id=None,
 
     Returns True if the internet gateway was deleted and otherwise False.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Examples:
 
@@ -1131,7 +1131,7 @@ def delete_customer_gateway(customer_gateway_id=None, customer_gateway_name=None
 
     Returns True if the customer gateway was deleted and returns False if the customer gateway was not deleted.
 
-    .. versionchanged:: Beryllium
+    .. versionchanged:: 2015.8.0
         Added customer_gateway_name argument
 
     CLI Example:
@@ -1180,7 +1180,7 @@ def create_dhcp_options(domain_name=None, domain_name_servers=None, ntp_servers=
 
     Returns True if the DHCP options record was created and returns False if the DHCP options record was not deleted.
 
-    .. versionchanged:: Beryllium
+    .. versionchanged:: 2015.8.0
         Added vpc_name and vpc_id arguments
 
     CLI Example:
@@ -1222,7 +1222,7 @@ def delete_dhcp_options(dhcp_options_id=None, dhcp_options_name=None,
     '''
     Delete dhcp options by id or name.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -1333,7 +1333,7 @@ def create_network_acl(vpc_id=None, vpc_name=None, network_acl_name=None,
 
     Returns the network acl id if successful, otherwise returns False.
 
-    .. versionchanged:: Beryllium
+    .. versionchanged:: 2015.8.0
         Added vpc_name, subnet_id, and subnet_name arguments
 
     CLI Example:
@@ -1703,7 +1703,7 @@ def create_route_table(vpc_id=None, vpc_name=None, route_table_name=None,
     '''
     Creates a route table.
 
-    .. versionchanged:: Beryllium
+    .. versionchanged:: 2015.8.0
         Added vpc_name argument
 
     CLI Examples:
@@ -1771,7 +1771,7 @@ def route_exists(destination_cidr_block, route_table_name=None, route_table_id=N
     '''
     Checks if a route exists.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -2073,7 +2073,7 @@ def describe_route_table(route_table_id=None, route_table_name=None,
     '''
     Given route table properties, return route table details if matching table(s) exist.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 

--- a/salt/modules/cabal.py
+++ b/salt/modules/cabal.py
@@ -3,7 +3,7 @@
 Manage and query Cabal packages
 ===============================
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 '''
 from __future__ import absolute_import

--- a/salt/modules/container_resource.py
+++ b/salt/modules/container_resource.py
@@ -2,7 +2,7 @@
 '''
 Common resources for LXC and systemd-nspawn containers
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 These functions are not designed to be called directly, but instead from the
 :mod:`lxc <salt.modules.lxc>`, :mod:`nspawn <salt.modules.nspawn>`, and
@@ -133,8 +133,6 @@ def run(name,
     path
         path to the container parent (for LXC only)
         default: /var/lib/lxc (system default)
-
-        .. versionadded:: Beryllium
 
     CLI Example:
 
@@ -282,8 +280,6 @@ def copy_to(name,
     path
         path to the container parent (for LXC only)
         default: /var/lib/lxc (system default)
-
-        .. versionadded:: Beryllium
 
     CLI Example:
 

--- a/salt/modules/data.py
+++ b/salt/modules/data.py
@@ -106,7 +106,7 @@ def getval(key):
     '''
     Get a value from the minion datastore
 
-    .. deprecated:: Beryllium
+    .. deprecated:: 2015.8.0
          Use ``get`` instead
 
     CLI Example:
@@ -122,7 +122,7 @@ def getvals(*keylist):
     '''
     Get values from the minion datastore
 
-    .. deprecated:: Beryllium
+    .. deprecated:: 2015.8.0
          Use ``get`` instead
 
     CLI Example:
@@ -178,7 +178,7 @@ def get(key, default=None):
     '''
     Get a (list of) value(s) from the minion datastore
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -200,7 +200,7 @@ def keys():
     '''
     Get all keys from the minion datastore
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -216,7 +216,7 @@ def values():
     '''
     Get values from the minion datastore
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -232,7 +232,7 @@ def items():
     '''
     Get items from the minion datastore
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -248,7 +248,7 @@ def has_key(key):
     '''
     Check if key is in the minion datastore
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 

--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -817,7 +817,7 @@ def kill(container, signal=None):
     signal
         signal to send
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -2,7 +2,7 @@
 '''
 Management of Docker Containers
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 
 Why Make a Second Docker Module?

--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -27,7 +27,7 @@ def __virtual__():
 
 def bin_pkg_info(path, saltenv='base'):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Parses RPM metadata and returns a dictionary of information about the
     package (name, version, etc.).

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -304,7 +304,7 @@ def list_upgrades(refresh=True, backtrack=3):
         calculation fails due to a conflict or an unsatisfied dependency
         (default: ´3´).
 
-        .. versionadded: Beryllium
+        .. versionadded: 2015.8.0
 
     CLI Example:
 
@@ -740,7 +740,7 @@ def upgrade(refresh=True, binhost=None, backtrack=3):
         calculation fails due to a conflict or an unsatisfied dependency
         (default: ´3´).
 
-        .. versionadded: Beryllium
+        .. versionadded: 2015.8.0
 
     Return a dict containing the new package names and versions::
 

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1228,7 +1228,7 @@ def line(path, content, match=None, mode=None, location=None,
          before=None, after=None, show_changes=True, backup=False,
          quiet=False, indent=True):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Edit a line in the configuration file.
 
@@ -1547,14 +1547,14 @@ def replace(path,
             (the original version and the edited version) in order to generate the
             diff.
     ignore_if_missing
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
         When this parameter is ``True``, ``file.replace`` will return ``False`` if the
         file doesn't exist. When this parameter is ``False``, ``file.replace`` will
         throw an error if the file doesn't exist.
         Default is ``False`` (to maintain compatibility with prior behaviour).
     preserve_inode
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
         Preserve the inode of the file, so that any hard links continue to share the
         inode with the original filename. This works by *copying* the file, reading
@@ -2015,7 +2015,7 @@ def search(path,
         If true, inserts 'MULTILINE' into ``flags`` and sets ``bufsize`` to
         'file'.
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 

--- a/salt/modules/firewalld.py
+++ b/salt/modules/firewalld.py
@@ -413,7 +413,7 @@ def add_masquerade(zone):
     '''
     Enable masquerade on a zone.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -428,7 +428,7 @@ def remove_masquerade(zone):
     '''
     Remove masquerade on a zone.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -443,7 +443,7 @@ def add_port(zone, port):
     '''
     Allow specific ports in a zone.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -461,7 +461,7 @@ def remove_port(zone, port):
     '''
     Remove a specific port from a zone.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -476,7 +476,7 @@ def list_ports(zone):
     '''
     List all ports in a zone.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -491,7 +491,7 @@ def add_port_fwd(zone, src, dest, proto='tcp', dstaddr=''):
     '''
     Add port forwarding.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -517,7 +517,7 @@ def remove_port_fwd(zone, src, dest, proto='tcp'):
     '''
     Remove Port Forwarding.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -539,7 +539,7 @@ def list_port_fwd(zone):
     '''
     List port forwarding
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -566,7 +566,7 @@ def block_icmp(zone, icmp):
     '''
     Block a specific ICMP type on a zone
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -589,7 +589,7 @@ def allow_icmp(zone, icmp):
     '''
     Allow a specific ICMP type on a zone
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -612,7 +612,7 @@ def list_icmp_block(zone):
     '''
     List ICMP blocks on a zone
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 

--- a/salt/modules/gem.py
+++ b/salt/modules/gem.py
@@ -225,7 +225,7 @@ def list_upgrades(ruby=None,
                   runas=None,
                   gem_bin=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Check if an upgrade is available for installed gems
 

--- a/salt/modules/ifttt.py
+++ b/salt/modules/ifttt.py
@@ -2,7 +2,7 @@
 '''
 Support for IFTTT
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 Requires an ``api_key`` in ``/etc/salt/minion``:
 
@@ -40,9 +40,7 @@ def _query(event=None,
            header_dict=None,
            data=None):
     '''
-    Make a web call to IFTTT
-
-    .. versionadded:: Beryllium
+    Make a web call to IFTTT.
     '''
     secret_key = __salt__['config.get']('ifttt.secret_key') or \
         __salt__['config.get']('ifttt:secret_key')

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -88,7 +88,7 @@ def get_root_path(path):
     '''
     Get the configured lxc root for containers
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -106,7 +106,7 @@ def version():
     '''
     Return the actual lxc client version
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -261,7 +261,7 @@ def cloud_init_interface(name, vm_=None, **kwargs):
     path
         path to the container parent directory (default: /var/lib/lxc)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     profile
         :ref:`profile <tutorial-lxc-profiles-container>` selection
@@ -1261,7 +1261,7 @@ def init(name,
         path to the container parent directory
         default: /var/lib/lxc (system)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     clone
         .. deprecated:: 2015.5.0
@@ -1878,7 +1878,7 @@ def create(name,
     path
         parent path for the container creation (default: /var/lib/lxc)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
     '''
     # Required params for 'download' template
     download_template_deps = ('dist', 'release', 'arch')
@@ -2012,7 +2012,7 @@ def clone(name,
         path to the container parent directory
         default: /var/lib/lxc (system)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     **Container Cloning Arguments**
 
@@ -2029,12 +2029,12 @@ def clone(name,
     network_profile
         Network profile to use for container
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     nic_opts
         give extra opts overriding network profile values
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
 
     CLI Examples:
@@ -2110,7 +2110,7 @@ def ls_(active=None, cache=True, path=None):
         path to the container parent directory
         default: /var/lib/lxc (system)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     active
         If ``True``, return only active (i.e. running) containers
@@ -2157,7 +2157,7 @@ def list_(extra=False, limit=None, path=None):
         path to the container parent directory
         default: /var/lib/lxc (system)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     limit
         Return output matching a specific state (**frozen**, **running**, or
@@ -2314,7 +2314,7 @@ def _ensure_running(name, no_start=False, path=None):
         path to the container parent directory
         default: /var/lib/lxc (system)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
     '''
     _ensure_exists(name, path=path)
     pre = state(name, path=path)
@@ -2350,14 +2350,14 @@ def restart(name, path=None, lxc_config=None, force=False):
         path to the container parent directory
         default: /var/lib/lxc (system)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     lxc_config
 
         path to a lxc config file
         config file will be guessed from container name otherwise
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     force : False
         If ``True``, the container will be force-stopped instead of gracefully
@@ -2394,19 +2394,19 @@ def start(name, **kwargs):
         path to the container parent directory
         default: /var/lib/lxc (system)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     lxc_config
 
         path to a lxc config file
         config file will be guessed from container name otherwise
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     use_vt
         run the command through VT
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -2456,7 +2456,7 @@ def stop(name, kill=False, path=None, use_vt=None):
         path to the container parent directory
         default: /var/lib/lxc (system)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     kill: False
         Do not wait for the container to stop, kill all tasks in the container.
@@ -2469,7 +2469,7 @@ def stop(name, kill=False, path=None, use_vt=None):
     use_vt
         run the command through VT
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -2500,7 +2500,7 @@ def freeze(name, **kwargs):
         path to the container parent directory
         default: /var/lib/lxc (system)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     start : False
         If ``True`` and the container is stopped, the container will be started
@@ -2511,7 +2511,7 @@ def freeze(name, **kwargs):
     use_vt
         run the command through VT
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -2549,12 +2549,12 @@ def unfreeze(name, path=None, use_vt=None):
         path to the container parent directory
         default: /var/lib/lxc (system)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     use_vt
         run the command through VT
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -2584,7 +2584,7 @@ def destroy(name, stop=False, path=None):
     path
         path to the container parent directory (default: /var/lib/lxc)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     stop : False
         If ``True``, the container will be destroyed even if it is
@@ -2621,7 +2621,7 @@ def exists(name, path=None):
     path
         path to the container parent directory (default: /var/lib/lxc)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
 
     CLI Example:
@@ -2646,7 +2646,7 @@ def state(name, path=None):
     path
         path to the container parent directory (default: /var/lib/lxc)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -2692,7 +2692,7 @@ def get_parameter(name, parameter, path=None):
         path to the container parent directory
         default: /var/lib/lxc (system)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -2721,7 +2721,7 @@ def set_parameter(name, parameter, value, path=None):
         path to the container parent directory
         default: /var/lib/lxc (system)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -2751,7 +2751,7 @@ def info(name, path=None):
         path to the container parent directory
         default: /var/lib/lxc (system)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -2915,7 +2915,7 @@ def set_password(name, users, password, encrypted=True, path=None):
         path to the container parent directory
         default: /var/lib/lxc (system)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -2966,7 +2966,7 @@ def update_lxc_conf(name, lxc_conf, lxc_conf_unset, path=None):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -3074,7 +3074,7 @@ def set_dns(name, dnsservers=None, searchdomains=None, path=None):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -3164,7 +3164,7 @@ def running_systemd(name, cache=True, path=None):
     path
         path to the container parent
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -3242,7 +3242,7 @@ def systemd_running_state(name, path=None):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -3270,7 +3270,7 @@ def test_sd_started_state(name, path=None):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
 
     CLI Example:
@@ -3299,7 +3299,7 @@ def test_bare_started_state(name, path=None):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
 
     CLI Example:
@@ -3330,7 +3330,7 @@ def wait_started(name, path=None, timeout=300):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -3419,7 +3419,7 @@ def bootstrap(name,
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     pub_key
         Explicit public key to pressed the minion with (optional).
@@ -3598,7 +3598,7 @@ def attachable(name, path=None):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -3646,7 +3646,7 @@ def _run(name,
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     '''
     orig_state = state(name, path=path)
@@ -3717,7 +3717,7 @@ def run_cmd(name,
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     .. deprecated:: 2015.5.0
         Use :mod:`lxc.run <salt.modules.lxc.run>` instead
@@ -3763,7 +3763,7 @@ def run(name,
         chroot_fallback=False,
         keep_env='http_proxy,https_proxy,no_proxy'):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Run :mod:`cmd.run <salt.modules.cmdmod.run>` within a container
 
@@ -3791,7 +3791,7 @@ def run(name,
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     no_start : False
         If the container is not running, don't start it
@@ -3880,7 +3880,7 @@ def run_stdout(name,
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     no_start : False
         If the container is not running, don't start it
@@ -3967,7 +3967,7 @@ def run_stderr(name,
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     no_start : False
         If the container is not running, don't start it
@@ -4062,7 +4062,7 @@ def retcode(name,
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     stdin : None
         Standard input to be used for the command
@@ -4146,7 +4146,7 @@ def run_all(name,
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     cmd
         Command to run
@@ -4213,7 +4213,7 @@ def _get_md5(name, path):
 
 def copy_to(name, source, dest, overwrite=False, makedirs=False, path=None):
     '''
-    .. versionchanged:: Beryllium
+    .. versionchanged:: 2015.8.0
         Function renamed from ``lxc.cp`` to ``lxc.copy_to`` for consistency
         with other container types. ``lxc.cp`` will continue to work, however.
         For versions 2015.2.x and earlier, use ``lxc.cp``.
@@ -4230,7 +4230,7 @@ def copy_to(name, source, dest, overwrite=False, makedirs=False, path=None):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     dest
         Destination on the container. Must be an absolute path.
@@ -4243,7 +4243,7 @@ def copy_to(name, source, dest, overwrite=False, makedirs=False, path=None):
         Unless this option is set to ``True``, then if a file exists at the
         location specified by the ``dest`` argument, an error will be raised.
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     makedirs : False
 
@@ -4503,7 +4503,7 @@ def reboot(name, path=None):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Examples:
 
@@ -4587,7 +4587,7 @@ def reconfigure(name,
     path
         path to the container parent
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -4666,7 +4666,7 @@ def apply_network_profile(name, network_profile, nic_opts=None, path=None):
     path
         path to the container parent
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Examples:
 

--- a/salt/modules/mod_random.py
+++ b/salt/modules/mod_random.py
@@ -151,7 +151,7 @@ def seed(range=10, hash=None):
     Returns a random number within a range. Optional hash argument can
     be any hashable object. If hash is omitted or None, the id of the minion is used.
 
-    .. versionadded: Beryllium
+    .. versionadded: 2015.8.0
 
     hash: None
         Any hashable object.

--- a/salt/modules/nagios_rpc.py
+++ b/salt/modules/nagios_rpc.py
@@ -2,7 +2,7 @@
 '''
 Check Host & Service status from Nagios via JSON RPC.
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 '''
 

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -737,7 +737,7 @@ def calc_net(ip_addr, netmask=None):
         salt '*' network.calc_net 172.17.0.5 255.255.255.240
         salt '*' network.calc_net 2a02:f6e:a000:80:84d8:8332:7866:4e07/64
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
     '''
     return salt.utils.network.calc_net(ip_addr, netmask)
 
@@ -961,7 +961,7 @@ def is_private(ip_addr):
     Check if the given IP address is a private address
 
     .. versionadded:: 2014.7.0
-    .. versionchanged:: Beryllium
+    .. versionchanged:: 2015.8.0
         IPv6 support
 
     CLI Example:
@@ -978,7 +978,7 @@ def is_loopback(ip_addr):
     Check if the given IP address is a loopback address
 
     .. versionadded:: 2014.7.0
-    .. versionchanged:: Beryllium
+    .. versionchanged:: 2015.8.0
         IPv6 support
 
     CLI Example:
@@ -994,7 +994,7 @@ def reverse_ip(ip_addr):
     '''
     Returns the reversed IP address
 
-    .. versionchanged:: Beryllium
+    .. versionchanged:: 2015.8.0
         IPv6 support
 
     CLI Example:

--- a/salt/modules/nspawn.py
+++ b/salt/modules/nspawn.py
@@ -2,7 +2,7 @@
 '''
 Manage nspawn containers
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 `systemd-nspawn(1)`__ is a tool used to manage lightweight namespace
 containers. This execution module provides several functions to help manage

--- a/salt/modules/osquery.py
+++ b/salt/modules/osquery.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 '''
-Support for OSQuery - https://osquery.io
+Support for OSQuery - https://osquery.io.
+
+.. versionadded:: 2015.8.0
 '''
 from __future__ import absolute_import
 
@@ -106,8 +108,6 @@ def _osquery_cmd(table, attrs=None, where=None, format='json'):
 
 def version():
     '''
-    .. versionadded:: Beryllium
-
     Return version of osquery
 
     CLI Example:
@@ -123,8 +123,6 @@ def version():
 
 def rpm_packages(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return cpuid information from osquery
 
     CLI Example:
@@ -140,8 +138,6 @@ def rpm_packages(attrs=None, where=None):
 
 def kernel_integrity(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return kernel_integrity information from osquery
 
     CLI Example:
@@ -157,8 +153,6 @@ def kernel_integrity(attrs=None, where=None):
 
 def kernel_modules(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return kernel_modules information from osquery
 
     CLI Example:
@@ -174,8 +168,6 @@ def kernel_modules(attrs=None, where=None):
 
 def memory_map(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return memory_map information from osquery
 
     CLI Example:
@@ -191,8 +183,6 @@ def memory_map(attrs=None, where=None):
 
 def process_memory_map(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return process_memory_map information from osquery
 
     CLI Example:
@@ -208,8 +198,6 @@ def process_memory_map(attrs=None, where=None):
 
 def shared_memory(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return shared_memory information from osquery
 
     CLI Example:
@@ -225,8 +213,6 @@ def shared_memory(attrs=None, where=None):
 
 def apt_sources(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return apt_sources information from osquery
 
     CLI Example:
@@ -242,8 +228,6 @@ def apt_sources(attrs=None, where=None):
 
 def deb_packages(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return deb_packages information from osquery
 
     CLI Example:
@@ -259,8 +243,6 @@ def deb_packages(attrs=None, where=None):
 
 def acpi_tables(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return acpi_tables information from osquery
 
     CLI Example:
@@ -274,8 +256,6 @@ def acpi_tables(attrs=None, where=None):
 
 def arp_cache(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return arp_cache information from osquery
 
     CLI Example:
@@ -289,8 +269,6 @@ def arp_cache(attrs=None, where=None):
 
 def block_devices(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return block_devices information from osquery
 
     CLI Example:
@@ -304,8 +282,6 @@ def block_devices(attrs=None, where=None):
 
 def cpuid(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return cpuid information from osquery
 
     CLI Example:
@@ -319,8 +295,6 @@ def cpuid(attrs=None, where=None):
 
 def crontab(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return crontab information from osquery
 
     CLI Example:
@@ -334,8 +308,6 @@ def crontab(attrs=None, where=None):
 
 def etc_hosts(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return etc_hosts information from osquery
 
     CLI Example:
@@ -362,8 +334,6 @@ def etc_services(attrs=None, where=None):
 
 def file_changes(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return file_changes information from osquery
 
     CLI Example:
@@ -377,8 +347,6 @@ def file_changes(attrs=None, where=None):
 
 def groups(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return groups information from osquery
 
     CLI Example:
@@ -392,8 +360,6 @@ def groups(attrs=None, where=None):
 
 def hardware_events(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return hardware_events information from osquery
 
     CLI Example:
@@ -407,8 +373,6 @@ def hardware_events(attrs=None, where=None):
 
 def interface_addresses(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return interface_addresses information from osquery
 
     CLI Example:
@@ -422,8 +386,6 @@ def interface_addresses(attrs=None, where=None):
 
 def interface_details(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return interface_details information from osquery
 
     CLI Example:
@@ -437,8 +399,6 @@ def interface_details(attrs=None, where=None):
 
 def kernel_info(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return kernel_info information from osquery
 
     CLI Example:
@@ -452,8 +412,6 @@ def kernel_info(attrs=None, where=None):
 
 def last(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return last information from osquery
 
     CLI Example:
@@ -467,8 +425,6 @@ def last(attrs=None, where=None):
 
 def listening_ports(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return listening_ports_ information from osquery
 
     CLI Example:
@@ -482,8 +438,6 @@ def listening_ports(attrs=None, where=None):
 
 def logged_in_users(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return logged_in_users_ information from osquery
 
     CLI Example:
@@ -497,8 +451,6 @@ def logged_in_users(attrs=None, where=None):
 
 def mounts(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return mounts_ information from osquery
 
     CLI Example:
@@ -512,8 +464,6 @@ def mounts(attrs=None, where=None):
 
 def os_version(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return os_version information from osquery
 
     CLI Example:
@@ -527,8 +477,6 @@ def os_version(attrs=None, where=None):
 
 def passwd_changes(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return passwd_changes information from osquery
 
     CLI Example:
@@ -542,8 +490,6 @@ def passwd_changes(attrs=None, where=None):
 
 def pci_devices(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return pci_devices information from osquery
 
     CLI Example:
@@ -557,8 +503,6 @@ def pci_devices(attrs=None, where=None):
 
 def process_envs(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return process_envs information from osquery
 
     CLI Example:
@@ -572,8 +516,6 @@ def process_envs(attrs=None, where=None):
 
 def process_open_files(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return process_open_files information from osquery
 
     CLI Example:
@@ -587,8 +529,6 @@ def process_open_files(attrs=None, where=None):
 
 def process_open_sockets(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return process_open_sockets information from osquery
 
     CLI Example:
@@ -602,8 +542,6 @@ def process_open_sockets(attrs=None, where=None):
 
 def processes(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return processes information from osquery
 
     CLI Example:
@@ -617,8 +555,6 @@ def processes(attrs=None, where=None):
 
 def routes(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return routes information from osquery
 
     CLI Example:
@@ -632,8 +568,6 @@ def routes(attrs=None, where=None):
 
 def shell_history(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return shell_history information from osquery
 
     CLI Example:
@@ -647,8 +581,6 @@ def shell_history(attrs=None, where=None):
 
 def smbios_tables(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return smbios_tables information from osquery
 
     CLI Example:
@@ -662,8 +594,6 @@ def smbios_tables(attrs=None, where=None):
 
 def suid_bin(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return suid_bin information from osquery
 
     CLI Example:
@@ -677,8 +607,6 @@ def suid_bin(attrs=None, where=None):
 
 def system_controls(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return system_controls information from osquery
 
     CLI Example:
@@ -692,8 +620,6 @@ def system_controls(attrs=None, where=None):
 
 def usb_devices(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return usb_devices information from osquery
 
     CLI Example:
@@ -707,8 +633,6 @@ def usb_devices(attrs=None, where=None):
 
 def users(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return users information from osquery
 
     CLI Example:
@@ -722,8 +646,6 @@ def users(attrs=None, where=None):
 
 def alf(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return alf information from osquery
 
     CLI Example:
@@ -739,8 +661,6 @@ def alf(attrs=None, where=None):
 
 def alf_exceptions(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return alf_exceptions information from osquery
 
     CLI Example:
@@ -756,8 +676,6 @@ def alf_exceptions(attrs=None, where=None):
 
 def alf_explicit_auths(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return alf_explicit_auths information from osquery
 
     CLI Example:
@@ -773,8 +691,6 @@ def alf_explicit_auths(attrs=None, where=None):
 
 def alf_services(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return alf_services information from osquery
 
     CLI Example:
@@ -790,8 +706,6 @@ def alf_services(attrs=None, where=None):
 
 def apps(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return apps information from osquery
 
     CLI Example:
@@ -807,8 +721,6 @@ def apps(attrs=None, where=None):
 
 def certificates(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return certificates information from osquery
 
     CLI Example:
@@ -824,8 +736,6 @@ def certificates(attrs=None, where=None):
 
 def chrome_extensions(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return chrome_extensions information from osquery
 
     CLI Example:
@@ -841,8 +751,6 @@ def chrome_extensions(attrs=None, where=None):
 
 def firefox_addons(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return firefox_addons information from osquery
 
     CLI Example:
@@ -858,8 +766,6 @@ def firefox_addons(attrs=None, where=None):
 
 def homebrew_packages(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return homebrew_packages information from osquery
 
     CLI Example:
@@ -875,8 +781,6 @@ def homebrew_packages(attrs=None, where=None):
 
 def iokit_devicetree(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return iokit_devicetree information from osquery
 
     CLI Example:
@@ -892,8 +796,6 @@ def iokit_devicetree(attrs=None, where=None):
 
 def iokit_registry(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return iokit_registry information from osquery
 
     CLI Example:
@@ -909,8 +811,6 @@ def iokit_registry(attrs=None, where=None):
 
 def kernel_extensions(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return kernel_extensions information from osquery
 
     CLI Example:
@@ -926,8 +826,6 @@ def kernel_extensions(attrs=None, where=None):
 
 def keychain_items(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return keychain_items information from osquery
 
     CLI Example:
@@ -943,8 +841,6 @@ def keychain_items(attrs=None, where=None):
 
 def launchd(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return launchd information from osquery
 
     CLI Example:
@@ -960,8 +856,6 @@ def launchd(attrs=None, where=None):
 
 def nfs_shares(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return nfs_shares information from osquery
 
     CLI Example:
@@ -977,8 +871,6 @@ def nfs_shares(attrs=None, where=None):
 
 def nvram(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return nvram information from osquery
 
     CLI Example:
@@ -994,8 +886,6 @@ def nvram(attrs=None, where=None):
 
 def preferences(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return preferences information from osquery
 
     CLI Example:
@@ -1011,8 +901,6 @@ def preferences(attrs=None, where=None):
 
 def quarantine(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return quarantine information from osquery
 
     CLI Example:
@@ -1028,8 +916,6 @@ def quarantine(attrs=None, where=None):
 
 def safari_extensions(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return safari_extensions information from osquery
 
     CLI Example:
@@ -1045,8 +931,6 @@ def safari_extensions(attrs=None, where=None):
 
 def startup_items(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return startup_items information from osquery
 
     CLI Example:
@@ -1062,8 +946,6 @@ def startup_items(attrs=None, where=None):
 
 def xattr_where_from(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return xattr_where_from information from osquery
 
     CLI Example:
@@ -1079,8 +961,6 @@ def xattr_where_from(attrs=None, where=None):
 
 def xprotect_entries(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return xprotect_entries information from osquery
 
     CLI Example:
@@ -1096,8 +976,6 @@ def xprotect_entries(attrs=None, where=None):
 
 def xprotect_reports(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return xprotect_reports information from osquery
 
     CLI Example:
@@ -1113,8 +991,6 @@ def xprotect_reports(attrs=None, where=None):
 
 def file_(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return file information from osquery
 
     CLI Example:
@@ -1128,8 +1004,6 @@ def file_(attrs=None, where=None):
 
 def hash_(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return hash information from osquery
 
     CLI Example:
@@ -1143,8 +1017,6 @@ def hash_(attrs=None, where=None):
 
 def osquery_extensions(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return osquery_extensions information from osquery
 
     CLI Example:
@@ -1158,8 +1030,6 @@ def osquery_extensions(attrs=None, where=None):
 
 def osquery_flags(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return osquery_flags information from osquery
 
     CLI Example:
@@ -1173,8 +1043,6 @@ def osquery_flags(attrs=None, where=None):
 
 def osquery_info(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return osquery_info information from osquery
 
     CLI Example:
@@ -1188,8 +1056,6 @@ def osquery_info(attrs=None, where=None):
 
 def osquery_registry(attrs=None, where=None):
     '''
-    .. versionadded:: Beryllium
-
     Return osquery_registry information from osquery
 
     CLI Example:
@@ -1203,8 +1069,6 @@ def osquery_registry(attrs=None, where=None):
 
 def time_(attrs=None):
     '''
-    .. versionadded:: Beryllium
-
     Return time information from osquery
 
     CLI Example:
@@ -1218,8 +1082,6 @@ def time_(attrs=None):
 
 def query(sql=None):
     '''
-    .. versionadded:: Beryllium
-
     Return time information from osquery
 
     CLI Example:

--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -136,7 +136,7 @@ def _obfuscate_inner(var):
 
 def obfuscate(*args):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Same as :py:func:`items`, but replace pillar values with a simple type indication.
 
@@ -168,7 +168,7 @@ def obfuscate(*args):
 # identifier rule.
 def ls(*args):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Calls the master for a fresh pillar, generates the pillar data on the
     fly (same as :py:func:`items`), but only shows the available main keys.
@@ -281,7 +281,7 @@ def ext(external, pillar=None):
 
 def keys(key, delimiter=DEFAULT_TARGET_DELIM):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Attempt to retrieve a list of keys from the named value from the pillar.
 

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -55,7 +55,7 @@ def pack_sources(sources, normalize=True):
         part of the name, such as kernel modules which match a specific kernel
         version.
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 

--- a/salt/modules/portage_config.py
+++ b/salt/modules/portage_config.py
@@ -526,14 +526,16 @@ def is_present(conf, atom):
 
 
 def get_iuse(cp):
-    """
-    .. versionadded:: Beryllium
-    Gets the current IUSE flags from the tree
+    '''
+    .. versionadded:: 2015.8.0
+
+    Gets the current IUSE flags from the tree.
+
     @type: cpv: string
     @param cpv: cat/pkg
     @rtype list
     @returns [] or the list of IUSE flags
-    """
+    '''
     cpv = _get_cpv(cp)
     try:
         # aux_get might return dupes, so run them through set() to remove them
@@ -544,24 +546,27 @@ def get_iuse(cp):
 
 
 def get_installed_use(cp, use="USE"):
-    """
-    .. versionadded:: Beryllium
-    Gets the installed USE flags from the VARDB
+    '''
+    .. versionadded:: 2015.8.0
+
+    Gets the installed USE flags from the VARDB.
+
     @type: cp: string
     @param cp: cat/pkg
     @type use: string
     @param use: 1 of ["USE", "PKGUSE"]
     @rtype list
     @returns [] or the list of IUSE flags
-    """
+    '''
     portage = _get_portage()
     cpv = _get_cpv(cp)
     return portage.db[portage.root]["vartree"].dbapi.aux_get(cpv, [use])[0].split()
 
 
 def filter_flags(use, use_expand_hidden, usemasked, useforced):
-    """
-    .. versionadded:: Beryllium
+    '''
+    .. versionadded:: 2015.8.0
+
     Filter function to remove hidden or otherwise not normally
     visible USE flags from a list.
 
@@ -575,7 +580,7 @@ def filter_flags(use, use_expand_hidden, usemasked, useforced):
     @param useforced: the forced USE flags.
     @rtype: list
     @return the filtered USE flags.
-    """
+    '''
     portage = _get_portage()
     # clean out some environment flags, since they will most probably
     # be confusing for the user
@@ -598,15 +603,16 @@ def filter_flags(use, use_expand_hidden, usemasked, useforced):
 
 
 def get_all_cpv_use(cp):
-    """
-    .. versionadded:: Beryllium
-    Uses portage to determine final USE flags and settings for an emerge
+    '''
+    .. versionadded:: 2015.8.0
+
+    Uses portage to determine final USE flags and settings for an emerge.
 
     @type cp: string
     @param cp: eg cat/pkg
     @rtype: lists
     @return  use, use_expand_hidden, usemask, useforce
-    """
+    '''
     cpv = _get_cpv(cp)
     portage = _get_portage()
     use = None
@@ -629,9 +635,11 @@ def get_all_cpv_use(cp):
 
 def get_cleared_flags(cp):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
+
     Uses portage for compare use flags which is used for installing package
     and use flags which now exist int /etc/portage/package.use/
+
     @type cp: string
     @param cp: eg cat/pkg
     @rtype: tuple
@@ -649,9 +657,11 @@ def get_cleared_flags(cp):
 
 def is_changed_uses(cp):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
+
     Uses portage for determine if the use flags of installed package
-    is compatible with use flags in portage configs
+    is compatible with use flags in portage configs.
+
     @type cp: string
     @param cp: eg cat/pkg
     '''

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -473,10 +473,14 @@ def tablespace_list(user=None, host=None, port=None, maintenance_db=None,
                     password=None, runas=None):
     '''
     Return dictionary with information about tablespaces of a Postgres server.
+
     CLI Example:
+
     .. code-block:: bash
+
         salt '*' postgres.tablespace_list
-    .. versionadded:: Beryllium
+
+    .. versionadded:: 2015.8.0
     '''
 
     ret = {}
@@ -503,10 +507,14 @@ def tablespace_exists(name, user=None, host=None, port=None, maintenance_db=None
               password=None, runas=None):
     '''
     Checks if a tablespace exists on the Postgres server.
+
     CLI Example:
+
     .. code-block:: bash
+
         salt '*' postgres.tablespace_exists 'dbname'
-    .. versionadded:: Beryllium
+
+    .. versionadded:: 2015.8.0
     '''
 
     tablespaces = tablespace_list(user=user, host=host, port=port,
@@ -526,7 +534,8 @@ def tablespace_create(name, location, options=None, owner=None, user=None,
     .. code-block:: bash
 
         salt '*' postgres.tablespace_create tablespacename '/path/datadir'
-    .. versionadded:: Beryllium
+
+    .. versionadded:: 2015.8.0
     '''
     owner_query = ''
     options_query = ''
@@ -555,13 +564,17 @@ def tablespace_alter(name, user=None, host=None, port=None, maintenance_db=None,
                      set_option=None, reset_option=None, runas=None):
     '''
     Change tablespace name, owner, or options.
+
     CLI Example:
+
     .. code-block:: bash
+
         salt '*' postgres.tablespace_alter tsname new_owner=otheruser
         salt '*' postgres.tablespace_alter index_space new_name=fast_raid
         salt '*' postgres.tablespace_alter test set_option="{'seq_page_cost': '1.1'}"
         salt '*' postgres.tablespace_alter tsname reset_option=seq_page_cost
-    .. versionadded:: Beryllium
+
+    .. versionadded:: 2015.8.0
     '''
     if not any([new_name, new_owner, set_option, reset_option]):
         return True  # Nothing todo?
@@ -596,10 +609,14 @@ def tablespace_remove(name, user=None, host=None, port=None,
                       maintenance_db=None, password=None, runas=None):
     '''
     Removes a tablespace from the Postgres server.
+
     CLI Example:
+
     .. code-block:: bash
+
         salt '*' postgres.tablespace_remove tsname
-    .. versionadded:: Beryllium
+
+    .. versionadded:: 2015.8.0
     '''
     query = 'DROP TABLESPACE {0}'.format(name)
     ret = _psql_prepare_and_run(['-c', query],

--- a/salt/modules/rallydev.py
+++ b/salt/modules/rallydev.py
@@ -2,7 +2,7 @@
 '''
 Support for RallyDev
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 Requires a ``username`` and a ``password`` in ``/etc/salt/minion``:
 
@@ -68,9 +68,7 @@ def _query(action=None,
            header_dict=None,
            data=None):
     '''
-    Make a web call to Stormpath
-
-    .. versionadded:: Beryllium
+    Make a web call to RallyDev.
     '''
     token = _get_token()
     username = __opts__.get('rallydev', {}).get('username', None)

--- a/salt/modules/riak.py
+++ b/salt/modules/riak.py
@@ -53,7 +53,7 @@ def stop():
     '''
     Stop Riak
 
-    .. versionchanged:: Beryllium
+    .. versionchanged:: 2015.8.0
 
     CLI Example:
 
@@ -78,7 +78,7 @@ def cluster_join(username, hostname):
     '''
     Join a Riak cluster
 
-    .. versionchanged:: Beryllium
+    .. versionchanged:: 2015.8.0
 
     CLI Example:
 
@@ -108,7 +108,7 @@ def cluster_leave(username, hostname):
     '''
     Leave a Riak cluster
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -138,7 +138,7 @@ def cluster_plan():
     '''
     Review Cluster Plan
 
-    .. versionchanged:: Beryllium
+    .. versionchanged:: 2015.8.0
 
     CLI Example:
 
@@ -158,7 +158,7 @@ def cluster_commit():
     '''
     Commit Cluster Changes
 
-    .. versionchanged:: Beryllium
+    .. versionchanged:: 2015.8.0
 
     CLI Example:
 
@@ -183,7 +183,7 @@ def member_status():
     '''
     Get cluster member status
 
-    .. versionchanged:: Beryllium
+    .. versionchanged:: 2015.8.0
 
     CLI Example:
 
@@ -227,7 +227,7 @@ def status():
     '''
     Current node status
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -251,7 +251,7 @@ def test():
     '''
     Runs a test of a few standard Riak operations
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -276,7 +276,7 @@ def services():
     '''
     List available services on a node
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -46,7 +46,7 @@ def __virtual__():
 
 def bin_pkg_info(path, saltenv='base'):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Parses RPM metadata and returns a dictionary of information about the
     package (name, version, etc.).

--- a/salt/modules/rpmbuild.py
+++ b/salt/modules/rpmbuild.py
@@ -2,7 +2,7 @@
 '''
 RPM Package builder system
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 This system allows for all of the components to build rpms safely in chrooted
 environments. This also provides a function to generate yum repositories

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -423,7 +423,7 @@ def sync_utils(saltenv=None, refresh=True):
 
 def sync_log_handlers(saltenv=None, refresh=True):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Sync utility source files from the _log_handlers directory on the salt master file
     server. This function is environment aware, pass the desired environment

--- a/salt/modules/stormpath.py
+++ b/salt/modules/stormpath.py
@@ -2,7 +2,7 @@
 '''
 Support for Stormpath
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 '''
 
 # Import python libs
@@ -35,7 +35,6 @@ def create_account(directory_id, email, password, givenName, surname, **kwargs):
 
         salt myminion stormpath.create_account <directory_id> shemp@example.com letmein Shemp Howard
 
-    .. versionadded:: Beryllium
     '''
     items = {
         'email': email,
@@ -65,7 +64,6 @@ def list_accounts():
 
         salt myminion stormpath.list_accounts
 
-    .. versionadded:: Beryllium
     '''
     status, result = _query(action='accounts', command='current')
     return result
@@ -84,7 +82,6 @@ def show_account(account_id=None,
 
         salt myminion stormpath.show_account <account_id>
 
-    .. versionadded:: Beryllium
     '''
     if account_id:
         status, result = _query(
@@ -130,7 +127,6 @@ def update_account(account_id, key=None, value=None, items=None):
         salt myminion stormpath.update_account <account_id> items='{"givenName": "Shemp"}
         salt myminion stormpath.update_account <account_id> items='{"middlename": ""}
 
-    .. versionadded:: Beryllium
     '''
     if items is None:
         if key is None or value is None:
@@ -150,7 +146,7 @@ def update_account(account_id, key=None, value=None, items=None):
 
 def delete_account(account_id):
     '''
-    Delete an account
+    Delete an account.
 
     CLI Examples:
 
@@ -173,7 +169,6 @@ def list_directories():
 
         salt myminion stormpath.list_directories
 
-    .. versionadded:: Beryllium
     '''
     tenant = show_tenant()
     tenant_id = tenant.get('href', '').split('/')[-1]
@@ -183,7 +178,7 @@ def list_directories():
 
 def show_tenant():
     '''
-    Get the tenant for the login being used
+    Get the tenant for the login being used.
     '''
     status, result = _query(action='tenants', command='current')
     return result
@@ -196,9 +191,7 @@ def _query(action=None,
            header_dict=None,
            data=None):
     '''
-    Make a web call to Stormpath
-
-    .. versionadded:: Beryllium
+    Make a web call to Stormpath.
     '''
     apiid = __opts__.get('stormpath', {}).get('apiid', None)
     apikey = __opts__.get('stormpath', {}).get('apikey', None)

--- a/salt/modules/temp.py
+++ b/salt/modules/temp.py
@@ -4,7 +4,7 @@ Simple module for creating temporary directories and files
 
 This is a thin wrapper around Pythons tempfile module
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 '''
 from __future__ import absolute_import

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -741,7 +741,7 @@ def get_extensions(cert_type):
     Fetch X509 and CSR extension definitions from tls:extensions:
     (common|server|client) or set them to standard defaults.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     cert_type:
         The type of certificate such as ``server`` or ``client``.
@@ -882,7 +882,7 @@ def create_csr(ca_name,
                 requests to https://1.2.3.4 will fail from python's
                 requests library w/out the second entry in the above list
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     cert_type
         Specify the general certificate type. Can be either `server` or
@@ -1563,7 +1563,7 @@ def create_empty_crl(
     '''
     Create an empty Certificate Revocation List.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     ca_name
         name of the CA
@@ -1639,7 +1639,7 @@ def revoke_cert(
     '''
     Revoke a certificate.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     ca_name
         Name of the CA.

--- a/salt/modules/trafficserver.py
+++ b/salt/modules/trafficserver.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 '''
-Apache Traffic Server execution module
+Apache Traffic Server execution module.
+
+.. versionadded:: 2015.8.0
 
 ``traffic_line`` is used to execute individual Traffic Server commands and to
 script multiple commands in a shell.

--- a/salt/modules/udev.py
+++ b/salt/modules/udev.py
@@ -2,7 +2,7 @@
 '''
 Manage and query udev info
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 '''
 from __future__ import absolute_import

--- a/salt/modules/victorops.py
+++ b/salt/modules/victorops.py
@@ -2,7 +2,7 @@
 '''
 Support for VictorOps
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 Requires an ``api_key`` in ``/etc/salt/minion``:
 
@@ -47,8 +47,6 @@ def _query(action=None,
            data=None):
     '''
     Make a web call to VictorOps
-
-    .. versionadded:: Beryllium
     '''
     api_key = __salt__['config.get']('victorops.api_key') or \
         __salt__['config.get']('victorops:api_key')

--- a/salt/modules/win_powercfg.py
+++ b/salt/modules/win_powercfg.py
@@ -3,7 +3,7 @@
 This module allows you to control the power settings of a windows minion via
 powercfg.
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 .. code-block:: bash
 

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -393,7 +393,7 @@ def create(name,
     '''
     Create the named service.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Required parameters:
     name: Specifies the service name returned by the getkeyname operation

--- a/salt/modules/win_status.py
+++ b/salt/modules/win_status.py
@@ -56,7 +56,7 @@ def __virtual__():
 
 def cpuload():
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Return the processor load as a percentage
 
@@ -83,7 +83,7 @@ def cpuload():
 
 def diskusage(human_readable=False, path=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Return the disk usage for this minion
 
@@ -131,7 +131,7 @@ def procs(count=False):
     count : False
         If ``True``, this function will simply return the number of processes.
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -158,7 +158,7 @@ def procs(count=False):
 
 def saltmem(human_readable=False):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Returns the amount of memory that salt is using
 
@@ -186,7 +186,7 @@ def saltmem(human_readable=False):
 
 def uptime(human_readable=False):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Return the system uptime for this machine in seconds
 

--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -50,7 +50,7 @@ def halt(timeout=5, in_seconds=False):
     in_seconds
         Whether to treat timeout as seconds or minutes.
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -91,7 +91,7 @@ def poweroff(timeout=5, in_seconds=False):
     in_seconds
         Whether to treat timeout as seconds or minutes.
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -112,7 +112,7 @@ def reboot(timeout=5, in_seconds=False):
     in_seconds
         Whether to treat timeout as seconds or minutes.
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -136,7 +136,7 @@ def shutdown(timeout=5, in_seconds=False):
     in_seconds
         Whether to treat timeout as seconds or minutes.
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     CLI Example:
 

--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -2,7 +2,7 @@
 '''
 Manage X509 certificates
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 '''
 

--- a/salt/pillar/hg_pillar.py
+++ b/salt/pillar/hg_pillar.py
@@ -4,7 +4,7 @@
 '''
 Use remote Mercurial repository as a Pillar source.
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 The module depends on the ``hglib`` python module being available.
 This is the same requirement as for hgfs_ so should not pose any extra

--- a/salt/returners/influxdb_return.py
+++ b/salt/returners/influxdb_return.py
@@ -2,7 +2,7 @@
 '''
 Return data to an influxdb server.
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 To enable this returner the minion will need the python client for influxdb
 installed and the following values configured in the minion or master

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -103,7 +103,7 @@ def lookup_jid(jid,
         When set to `True`, adds the minions that did return from the command.
         Default: `True`.
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     missing
         When set to `True`, adds the minions that did NOT return from the command.
@@ -365,7 +365,7 @@ def last_run(ext_source=None,
     '''
     List all detectable jobs and associated functions
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 

--- a/salt/runners/lxc.py
+++ b/salt/runners/lxc.py
@@ -39,7 +39,7 @@ def _do(name, fun, path=None):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
     '''
     host = find_guest(name, quiet=True, path=path)
     if not host:
@@ -67,7 +67,7 @@ def _do_names(names, fun, path=None):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
     '''
     ret = {}
     hosts = find_guests(names, path=path)
@@ -100,7 +100,7 @@ def find_guest(name, quiet=False, path=None):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
 
     .. code-block:: bash
@@ -131,7 +131,7 @@ def find_guests(names, path=None):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     '''
     ret = {}
@@ -175,7 +175,7 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     saltcloud_mode
         init the container with the saltcloud opts format instead
@@ -416,7 +416,7 @@ def cloud_init(names, host=None, quiet=False, **kwargs):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     saltcloud_mode
         init the container with the saltcloud opts format instead
@@ -435,7 +435,7 @@ def _list_iter(host=None, path=None):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
     '''
     tgt = host or '*'
     client = salt.client.get_local_client(__opts__['conf_file'])
@@ -469,7 +469,7 @@ def list_(host=None, quiet=False, path=None):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     .. code-block:: bash
 
@@ -494,7 +494,7 @@ def purge(name, delete_key=True, quiet=False, path=None):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     .. code-block:: bash
 
@@ -525,7 +525,7 @@ def start(name, quiet=False, path=None):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     .. code-block:: bash
 
@@ -546,7 +546,7 @@ def stop(name, quiet=False, path=None):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     .. code-block:: bash
 
@@ -567,7 +567,7 @@ def freeze(name, quiet=False, path=None):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     .. code-block:: bash
 
@@ -588,7 +588,7 @@ def unfreeze(name, quiet=False, path=None):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     .. code-block:: bash
 
@@ -609,7 +609,7 @@ def info(name, quiet=False, path=None):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     .. code-block:: bash
 

--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -157,7 +157,7 @@ def list_state(subset=None, show_ipv4=False, state=None):
         Show minions being in specific state that is one of 'available', 'joined',
         'allowed', 'alived' or 'reaped'.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -203,7 +203,7 @@ def list_not_state(subset=None, show_ipv4=False, state=None):
         Show minions being in specific state that is one of 'available', 'joined',
         'allowed', 'alived' or 'reaped'.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -236,7 +236,7 @@ def present(subset=None, show_ipv4=False):
     Print a list of all minions that are up according to Salt's presence
     detection (no commands will be sent to minions)
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     subset : None
         Pass in a CIDR range to filter minions by IP address.
@@ -244,7 +244,7 @@ def present(subset=None, show_ipv4=False):
     show_ipv4 : False
         Also show the IP address each minion is connecting from.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -266,7 +266,7 @@ def not_present(subset=None, show_ipv4=False):
     show_ipv4 : False
         Also show the IP address each minion is connecting from.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -288,7 +288,7 @@ def joined(subset=None, show_ipv4=False):
     show_ipv4 : False
         Also show the IP address each minion is connecting from.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -310,7 +310,7 @@ def not_joined(subset=None, show_ipv4=False):
     show_ipv4 : False
         Also show the IP address each minion is connecting from.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -332,7 +332,7 @@ def allowed(subset=None, show_ipv4=False):
     show_ipv4 : False
         Also show the IP address each minion is connecting from.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -354,7 +354,7 @@ def not_allowed(subset=None, show_ipv4=False):
     show_ipv4 : False
         Also show the IP address each minion is connecting from.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -376,7 +376,7 @@ def alived(subset=None, show_ipv4=False):
     show_ipv4 : False
         Also show the IP address each minion is connecting from.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -398,7 +398,7 @@ def not_alived(subset=None, show_ipv4=False):
     show_ipv4 : False
         Also show the IP address each minion is connecting from.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -420,7 +420,7 @@ def reaped(subset=None, show_ipv4=False):
     show_ipv4 : False
         Also show the IP address each minion is connecting from.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 
@@ -442,7 +442,7 @@ def not_reaped(subset=None, show_ipv4=False):
     show_ipv4 : False
         Also show the IP address each minion is connecting from.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     CLI Example:
 

--- a/salt/runners/pkg.py
+++ b/salt/runners/pkg.py
@@ -2,7 +2,7 @@
 '''
 Package helper functions using ``salt.modules.pkg``
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 '''
 
 # Import python libs

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -361,7 +361,7 @@ def salt_spm():
     '''
     The main function for spm, the Salt Package Manager
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
     '''
     import salt.cli.spm
     spm = salt.cli.spm.SPM()  # pylint: disable=E1120

--- a/salt/sdb/rest.py
+++ b/salt/sdb/rest.py
@@ -6,7 +6,7 @@ Generic REST API SDB Module
 :maturity:      New
 :platform:      all
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 This module allows access to a REST interface using an ``sdb://`` URI.
 

--- a/salt/states/beacon.py
+++ b/salt/states/beacon.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 '''
 Management of the Salt beacons
-==============================================
+==============================
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 .. code-block:: yaml
 

--- a/salt/states/boto_cfn.py
+++ b/salt/states/boto_cfn.py
@@ -2,7 +2,7 @@
 '''
     Connection module for Amazon Cloud Formation
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     :configuration: This module accepts explicit AWS credentials but can also utilize
     IAM roles assigned to the instance trough Instance Profiles. Dynamic
@@ -60,8 +60,6 @@ def present(name, template_body=None, template_url=None, parameters=None, notifi
             stack_policy_during_update_url=None, region=None, key=None, keyid=None, profile=None):
     '''
     Ensure cloud formation stack is present.
-
-    .. versionadded:: Beryllium
 
     name (string) - Name of the stack.
 
@@ -183,8 +181,6 @@ def present(name, template_body=None, template_url=None, parameters=None, notifi
 def absent(name, region=None, key=None, keyid=None, profile=None):
     '''
     Ensure cloud formation stack is absent.
-
-    .. versionadded:: Beryllium
 
     name (string) – The name of the stack to delete.
 

--- a/salt/states/boto_ec2.py
+++ b/salt/states/boto_ec2.py
@@ -2,7 +2,7 @@
 '''
 Manage EC2
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 This module provides an interface to the Elastic Compute Cloud (EC2) service
 from AWS.

--- a/salt/states/boto_elasticache.py
+++ b/salt/states/boto_elasticache.py
@@ -253,7 +253,7 @@ def subnet_group_present(name, subnet_ids, description, tags=None, region=None,
     '''
     Ensure ElastiCache subnet group exists.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     name
         The name for the ElastiCache subnet group. This value is stored as a lowercase string.

--- a/salt/states/boto_elb.py
+++ b/salt/states/boto_elb.py
@@ -362,7 +362,7 @@ def register_instances(name, instances, region=None, key=None, keyid=None,
     '''
     Add instance/s to load balancer
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     .. code-block:: yaml
 

--- a/salt/states/boto_iam.py
+++ b/salt/states/boto_iam.py
@@ -3,7 +3,7 @@
 Manage IAM roles.
 =================
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 This module uses ``boto``, which can be installed via package, or pip.
 
@@ -138,9 +138,6 @@ def __virtual__():
 
 def user_absent(name, delete_keys=None, region=None, key=None, keyid=None, profile=None):
     '''
-
-    .. versionadded:: Beryllium
-
     Ensure the IAM user is absent. User cannot be deleted if it has keys.
 
     name (string)
@@ -198,9 +195,6 @@ def user_absent(name, delete_keys=None, region=None, key=None, keyid=None, profi
 
 def keys_present(name, number, save_dir, region=None, key=None, keyid=None, profile=None):
     '''
-
-    .. versionadded:: Beryllium
-
     Ensure the IAM access keys are present.
 
     name (string)
@@ -286,9 +280,6 @@ def keys_present(name, number, save_dir, region=None, key=None, keyid=None, prof
 
 def keys_absent(access_keys, user_name, region=None, key=None, keyid=None, profile=None):
     '''
-
-    .. versionadded:: Beryllium
-
     Ensure the IAM user access_key_id is absent.
 
     access_key_id (list)
@@ -351,9 +342,6 @@ def _delete_key(ret, access_key_id, user_name, region=None, key=None, keyid=None
 def user_present(name, policies=None, policies_from_pillars=None, password=None, path=None, region=None, key=None,
                  keyid=None, profile=None):
     '''
-
-    .. versionadded:: Beryllium
-
     Ensure the IAM user is present
 
     name (string)
@@ -512,9 +500,6 @@ def _case_password(ret, name, password, region=None, key=None, keyid=None, profi
 
 def group_present(name, policies=None, policies_from_pillars=None, users=None, region=None, key=None, keyid=None, profile=None):
     '''
-
-    .. versionadded:: Beryllium
-
     Ensure the IAM group is present
 
     name (string)
@@ -703,9 +688,7 @@ def account_policy(allow_users_to_change_password=None, hard_expiry=None, max_pa
                    region=None, key=None, keyid=None,
                    profile=None):
     '''
-    Change account policy
-
-    .. versionadded:: Beryllium
+    Change account policy.
 
     allow_users_to_change_password (bool)
         Allows all IAM users in your account to
@@ -792,9 +775,7 @@ def account_policy(allow_users_to_change_password=None, hard_expiry=None, max_pa
 
 def server_cert_absent(name, region=None, key=None, keyid=None, profile=None):
     '''
-    Deletes a server certificate
-
-    .. versionadded:: Beryllium
+    Deletes a server certificate.
 
     name (string)
         The name for the server certificate. Do not include the path in this value.
@@ -834,8 +815,6 @@ def server_cert_present(name, public_key, private_key, cert_chain=None, path=Non
                         region=None, key=None, keyid=None, profile=None):
     '''
     Crete server certificate.
-
-    .. versionadded:: Beryllium
 
     name (string)
         The name for the server certificate. Do not include the path in this value.

--- a/salt/states/boto_iam_role.py
+++ b/salt/states/boto_iam_role.py
@@ -75,7 +75,7 @@ with the role. This is the default behavior of the AWS console.
 
 If ``delete_policies: False`` is specified, existing policies that are not in
 the given list of policies will not be deleted. This allows manual modifications
-on the IAM role to be persistent. This functionality was added in Beryllium.
+on the IAM role to be persistent. This functionality was added in 2015.8.0.
 '''
 from __future__ import absolute_import
 import salt.utils.dictupdate as dictupdate
@@ -147,7 +147,7 @@ def present(
         value is ``True``. If ``False`` is specified, existing policies will not be deleted
         allowing manual modifications on the IAM role to be persistent.
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
     '''
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     _ret = _role_present(name, policy_document, path, region, key, keyid,

--- a/salt/states/boto_kms.py
+++ b/salt/states/boto_kms.py
@@ -2,7 +2,7 @@
 '''
 Manage KMS keys, key policies and grants.
 
-.. versionadded:: beryllium
+.. versionadded:: 2015.8.0
 
 Be aware that this interacts with Amazon's services, and so may incur charges.
 

--- a/salt/states/boto_rds.py
+++ b/salt/states/boto_rds.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 '''
 Manage RDSs
-=================
+===========
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 Create and destroy RDS instances. Be aware that this interacts with Amazon's
 services, and so may incur charges.
@@ -315,8 +315,6 @@ def subnet_group_present(name, subnet_ids, description, tags=None, region=None,
                          key=None, keyid=None, profile=None):
     '''
     Ensure DB subnet group exists.
-
-    .. versionadded:: Beryllium
 
     name
         The name for the DB subnet group. This value is stored as a lowercase string.

--- a/salt/states/boto_vpc.py
+++ b/salt/states/boto_vpc.py
@@ -3,7 +3,7 @@
 Manage VPCs
 =================
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 Create and destroy VPCs. Be aware that this interacts with Amazon's services,
 and so may incur charges.

--- a/salt/states/cabal.py
+++ b/salt/states/cabal.py
@@ -3,7 +3,7 @@
 Installation of Cabal Packages
 ==============================
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 These states manage the installed packages for Haskell using
 cabal. Note that cabal-install must be installed for these states to

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -731,7 +731,7 @@ def run(name,
         Ignore the timeout of commands, which is useful for running nohup
         processes.
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     creates
         Only run if the file specified by ``creates`` does not exist.

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -1095,7 +1095,7 @@ def running(name,
         This state will ask nginx to reload (instead of restart)
         each time the /etc/nginx/nginx.conf is modified.
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
 
     For other parameters, see salt.modules.dockerio execution module

--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -2,7 +2,7 @@
 '''
 Management of Docker containers
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 
 This is the state module to accompany the :mod:`dockerng

--- a/salt/states/etcd_mod.py
+++ b/salt/states/etcd_mod.py
@@ -4,7 +4,7 @@
 Manage etcd Keys
 ================
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 :depends:  - python-etcd
 

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2343,7 +2343,7 @@ def line(name, content, match=None, mode=None, location=None,
     '''
     Line-based editing of a file.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Params are identical to the remote execution function
     :mod:`file.line <salt.modules.file.line>`.

--- a/salt/states/firewalld.py
+++ b/salt/states/firewalld.py
@@ -2,7 +2,7 @@
 '''
 Management of firewalld
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 The following example applies changes to the public zone, blocks echo-reply
 and echo-request packets, does not set the zone to be the default, enables

--- a/salt/states/ifttt.py
+++ b/salt/states/ifttt.py
@@ -5,7 +5,7 @@ Trigger an event in IFTTT
 
 This state is useful for trigging events in IFTTT.
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 .. code-block:: yaml
 

--- a/salt/states/lxc.py
+++ b/salt/states/lxc.py
@@ -30,7 +30,7 @@ def present(name,
             lvname=None,
             path=None):
     '''
-    .. versionchanged:: Beryllium
+    .. versionchanged:: 2015.8.0
 
         The :mod:`lxc.created <salt.states.lxc.created>` state has been renamed
         to ``lxc.present``, and the :mod:`lxc.cloned <salt.states.lxc.cloned>`
@@ -45,7 +45,7 @@ def present(name,
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
 
     running : False
@@ -54,7 +54,7 @@ def present(name,
         * If ``None``, do nothing with regards to the running state of the
           container
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     clone_from
         Create named container as a clone of the specified container
@@ -335,7 +335,7 @@ def absent(name, stop=False, path=None):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
 
     .. code-block:: yaml
@@ -390,7 +390,7 @@ def running(name, restart=False, path=None):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     restart : False
         Restart container if it is already running
@@ -487,7 +487,7 @@ def frozen(name, start=True, path=None):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
 
     start : True
@@ -575,7 +575,7 @@ def stopped(name, kill=False, path=None):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     kill : False
         Do not wait for the container to stop, kill all tasks in the container.
@@ -730,7 +730,7 @@ def edited_conf(name, lxc_conf=None, lxc_conf_unset=None):
         path to the container parent
         default: /var/lib/lxc (system default)
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
 
     .. code-block:: bash

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1647,7 +1647,7 @@ def removed(name, version=None, pkgs=None, normalize=True, **kwargs):
         part of the name, such as kernel modules which match a specific kernel
         version.
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     Multiple Package Options:
 
@@ -1688,7 +1688,7 @@ def purged(name, version=None, pkgs=None, normalize=True, **kwargs):
         part of the name, such as kernel modules which match a specific kernel
         version.
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     Multiple Package Options:
 
@@ -1771,7 +1771,7 @@ def uptodate(name, refresh=False, **kwargs):
 
 def group_installed(name, skip=None, include=None, **kwargs):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Ensure that an entire package group is installed. This state is only
     supported for the :mod:`yum <salt.modules.yumpkg>` package manager.

--- a/salt/states/pkgbuild.py
+++ b/salt/states/pkgbuild.py
@@ -3,7 +3,7 @@
 The pkgbuild state is the front of Salt package building backend. It
 automatically
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 .. code-block:: yaml
 

--- a/salt/states/postgres_tablespace.py
+++ b/salt/states/postgres_tablespace.py
@@ -1,16 +1,20 @@
 # -*- coding: utf-8 -*-
 '''
 Management of PostgreSQL tablespace
-==================================
+===================================
 The postgres_tablespace module is used to create and manage Postgres
 tablespaces.
+
 Tablespaces can be set as either absent or present.
+
 .. code-block:: yaml
     ssd-tablespace:
       postgres_tablespace.present:
         - name: indexes
         - directory: /mnt/ssd-data
-.. versionadded:: Beryllium
+
+.. versionadded:: 2015.8.0
+
 '''
 from __future__ import absolute_import
 
@@ -34,7 +38,8 @@ def present(name,
             db_user=None):
     '''
     Ensure that the named tablespace is present with the specified properties.
-    For more information about all of these options see man create_tablespace(1)
+    For more information about all of these options see man create_tablespace(1).
+
     name
         The name of the tablespace to create/manage.
     directory
@@ -58,7 +63,6 @@ def present(name,
     user
         System user all operations should be performed on behalf of
 
-        .. versionadded:: Beryllium
     '''
     ret = {'name': name,
            'changes': {},
@@ -132,7 +136,8 @@ def absent(name,
            db_port=None,
            db_user=None):
     '''
-    Ensure that the named database is absent
+    Ensure that the named database is absent.
+
     name
         The name of the database to remove
     db_user
@@ -145,7 +150,6 @@ def absent(name,
         Database port if different from config or default
     user
         System user all operations should be performed on behalf of
-        .. versionadded:: Beryllium
     '''
     ret = {'name': name,
            'changes': {},

--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -381,7 +381,7 @@ def absent(name,
         in standard "authorized_keys" format. If this is set, comment, enc and
         options will be ignored.
 
-        .. versionadded:: Beryllium
+        .. versionadded:: 2015.8.0
 
     config
         The location of the authorized keys file relative to the user's home

--- a/salt/states/stormpath_account.py
+++ b/salt/states/stormpath_account.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 '''
-Support for Stormpath
+Support for Stormpath.
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 '''
 
 # Import python libs
@@ -52,8 +52,6 @@ def present(name, **kwargs):
 
     customData.
         Optional. Must be specified as a dict.
-
-    .. versionadded:: Beryllium
     '''
     # Because __opts__ is not available outside of functions
     if __opts__.get('requests_lib', False):
@@ -136,8 +134,6 @@ def absent(name, directory_id=None):
         each will be scanned for the account. Specifying a directory_id will
         therefore cut down on the number of requests to Stormpath, and increase
         performance of this state.
-
-    .. versionadded:: Beryllium
     '''
     # Because __opts__ is not available outside of functions
     if __opts__.get('requests_lib', False):

--- a/salt/states/test.py
+++ b/salt/states/test.py
@@ -238,7 +238,7 @@ def show_notification(name, text=None, **kwargs):
     '''
     Simple notification using text argument.
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     name
         A unique string.

--- a/salt/states/trafficserver.py
+++ b/salt/states/trafficserver.py
@@ -2,7 +2,7 @@
 '''
 Control Apache Traffic Server
 =============================
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 '''
 
 

--- a/salt/states/victorops.py
+++ b/salt/states/victorops.py
@@ -3,7 +3,7 @@
 Create an Event in VictorOps
 ============================
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 This state is useful for creating events on the
 VictorOps service during state runs.

--- a/salt/states/win_powercfg.py
+++ b/salt/states/win_powercfg.py
@@ -4,7 +4,7 @@
 This module allows you to control the power settings of a windows minion via
 powercfg.
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 .. code-block:: yaml
 

--- a/salt/states/x509.py
+++ b/salt/states/x509.py
@@ -2,7 +2,7 @@
 '''
 Manage X509 Certificates
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 This module can enable managing a complete PKI infrastructure including creating private keys, CA's,
 certificates and CRLs. It includes the ability to generate a private key on a server, and have the

--- a/salt/utils/boto.py
+++ b/salt/utils/boto.py
@@ -7,7 +7,7 @@ Note: This module depends on the dicts packed by the loader and,
 therefore, must be accessed via the loader or from the __utils__ dict.
 
 The __utils__ dict will not be automatically available to execution modules
-until Beryllium. The `salt.utils.compat.pack_dunder` helper function
+until 2015.8.0. The `salt.utils.compat.pack_dunder` helper function
 provides backwards compatibility.
 
 This module provides common functionality for the boto execution modules.
@@ -31,7 +31,7 @@ Example Usage:
             conn = _get_conn()
             vpc_id = _cache_id('test-vpc')
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 '''
 
 # Import Python libs

--- a/salt/utils/msazure.py
+++ b/salt/utils/msazure.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 
 Utilities for accessing storage container blogs on Azure
 '''
@@ -26,7 +26,7 @@ log = logging.getLogger(__name__)
 
 def get_storage_conn(storage_account=None, storage_key=None, opts=None):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Return a storage_conn object for the storage account
     '''
@@ -43,7 +43,7 @@ def get_storage_conn(storage_account=None, storage_key=None, opts=None):
 
 def list_blobs(storage_conn=None, **kwargs):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     List blobs associated with the container
     '''
@@ -73,7 +73,7 @@ def list_blobs(storage_conn=None, **kwargs):
 
 def put_blob(storage_conn=None, **kwargs):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Upload a blob
     '''
@@ -123,7 +123,7 @@ def put_blob(storage_conn=None, **kwargs):
 
 def get_blob(storage_conn=None, **kwargs):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Download a blob
     '''
@@ -170,7 +170,7 @@ def get_blob(storage_conn=None, **kwargs):
 
 def object_to_dict(obj):
     '''
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
 
     Convert an object to a dictionary
     '''

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -175,7 +175,7 @@ scheduler to skip this first run and wait until the next scheduled run.
 The scheduler also supports scheduling jobs using a cron like format.
 This requires the python-croniter library.
 
-    ... versionadded:: Beryllium
+    ... versionadded:: 2015.8.0
 
     schedule:
       job1:
@@ -193,7 +193,7 @@ will not run once the specified time has passed.  Time should be specified
 in a format support by the dateutil library.
 This requires the python-dateutil library.
 
-    ... versionadded:: Beryllium
+    ... versionadded:: 2015.8.0
 
     schedule:
       job1:

--- a/salt/utils/stormpath.py
+++ b/salt/utils/stormpath.py
@@ -2,7 +2,7 @@
 '''
 Support for Stormpath
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 '''
 
 # Import python libs
@@ -25,7 +25,7 @@ def query(action=None,
     '''
     Make a web call to Stormpath
 
-    .. versionadded:: Beryllium
+    .. versionadded:: 2015.8.0
     '''
     if opts is None:
         opts = {}

--- a/scripts/spm
+++ b/scripts/spm
@@ -2,7 +2,7 @@
 '''
 Publish commands to the salt system from the command line on the master.
 
-.. versionadded:: Beryllium
+.. versionadded:: 2015.8.0
 '''
 
 from salt.scripts import salt_spm


### PR DESCRIPTION
Note that some `versionadded` references are being removed because the entire module is new. I did this to reduce confusion where some functions have the tag and others do not, even though they were added for the same release.

In one case, the Beryllium tag was added to a module that was actually added in 2015._5_.0 and not Beryllium. I've fixed the reference to when the entire module was added and removed the `Beryllium` tags from the functions that were originally available. 
