### PR TITLE
Dont assume source_hash exists

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3201,7 +3201,7 @@ def get_managed(
     if template and source:
         # check if we have the template cached
         template_dest = __salt__['cp.is_cached'](source, saltenv)
-        if template_dest:
+        if template_dest and source_hash:
             comps = source_hash.split('=')
             cached_template_sum = get_hash(template_dest, form=source_sum['hash_type'])
             if cached_template_sum == source_sum['hsum']:


### PR DESCRIPTION
When using file.managed with a source of `file://` and no `source_hash`, this code block can be entered which assumes `source_hash` exists. Here, I add `source_hash` to the `if` statement as a temporary fix. Ideally, we could check for a cached templated file without the need for `source_hash`.
