### PR TITLE
Salt runner to manager Reactors

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -2691,9 +2691,6 @@ def apply_master_config(overrides=None, defaults=None):
 
     opts.setdefault('pillar_source_merging_strategy', 'smart')
 
-    # if there is no reactors option yet, add an empty reactor list
-    if 'reactors' not in opts:
-        opts['reactors'] = []
     return opts
 
 

--- a/salt/config.py
+++ b/salt/config.py
@@ -2691,6 +2691,9 @@ def apply_master_config(overrides=None, defaults=None):
 
     opts.setdefault('pillar_source_merging_strategy', 'smart')
 
+    # if there is no reactors option yet, add an empty reactor list
+    if 'reactors' not in opts:
+        opts['reactors'] = []
     return opts
 
 

--- a/salt/master.py
+++ b/salt/master.py
@@ -459,7 +459,7 @@ class Master(SMaster):
         process_manager.add_process(Maintenance, args=(self.opts,))
         log.info('Creating master publisher process')
 
-        if self.opts.get('reactor'):
+        if 'reactor' in self.opts:
             log.info('Creating master reactor process')
             process_manager.add_process(salt.utils.reactor.Reactor, args=(self.opts,))
 

--- a/salt/runners/reactor.py
+++ b/salt/runners/reactor.py
@@ -1,0 +1,70 @@
+# Import pytohn libs
+from __future__ import absolute_import, print_function
+import logging
+
+# Import salt libs
+import salt.utils.reactor
+import salt.syspaths
+import salt.utils.event
+import salt.utils.process
+from salt.ext.six import string_types
+
+log = logging.getLogger(__name__)
+
+__func_alias__ = {
+    'list_': 'list',
+}
+
+
+def list_(saltenv='base', test=None):
+    '''
+
+    '''
+    sevent = salt.utils.event.get_event(
+            'master',
+            __opts__['sock_dir'],
+            __opts__['transport'],
+            opts=__opts__)
+
+    __jid_event__.fire_event({}, 'salt/reactors/manage/list')
+
+    results = sevent.get_event(wait=30, tag='salt/reactors/manage/list-results')
+    reactors = results['reactors']
+    return reactors
+
+
+def add(event, reactors, saltenv='base', test=None):
+    '''
+
+    '''
+    if isinstance(reactors, string_types):
+        reactors = [reactors]
+
+    sevent = salt.utils.event.get_event(
+            'master',
+            __opts__['sock_dir'],
+            __opts__['transport'],
+            opts=__opts__)
+
+    __jid_event__.fire_event({'event': event,
+                              'reactors': reactors},
+                             'salt/reactors/manage/add')
+
+    res = sevent.get_event(wait=30, tag='salt/reactors/manage/add-complete')
+    return res['result']
+
+
+def delete(event, saltenv='base', test=None):
+    '''
+
+    '''
+    sevent = salt.utils.event.get_event(
+            'master',
+            __opts__['sock_dir'],
+            __opts__['transport'],
+            opts=__opts__)
+
+    __jid_event__.fire_event({'event': event}, 'salt/reactors/manage/delete')
+
+    res = sevent.get_event(wait=30, tag='salt/reactors/manage/delete-complete')
+    return res['result']

--- a/salt/runners/reactor.py
+++ b/salt/runners/reactor.py
@@ -1,4 +1,8 @@
-# Import pytohn libs
+# -*- coding: utf-8 -*-
+'''
+A convenience system to manage reactors
+'''
+# Import python libs
 from __future__ import absolute_import, print_function
 import logging
 

--- a/salt/runners/reactor.py
+++ b/salt/runners/reactor.py
@@ -18,7 +18,13 @@ __func_alias__ = {
 
 def list_(saltenv='base', test=None):
     '''
+    List currently configured reactors
 
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run reactor.list
     '''
     sevent = salt.utils.event.get_event(
             'master',
@@ -35,7 +41,13 @@ def list_(saltenv='base', test=None):
 
 def add(event, reactors, saltenv='base', test=None):
     '''
+    Add a new reactor
 
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run reactor.add 'salt/cloud/*/destroyed' reactors='/srv/reactor/destroy/*.sls'
     '''
     if isinstance(reactors, string_types):
         reactors = [reactors]
@@ -56,7 +68,13 @@ def add(event, reactors, saltenv='base', test=None):
 
 def delete(event, saltenv='base', test=None):
     '''
+    Delete a reactor
 
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run reactor.delete 'salt/cloud/*/destroyed'
     '''
     sevent = salt.utils.event.get_event(
             'master',

--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -102,6 +102,58 @@ class Reactor(multiprocessing.Process, salt.state.Compiler):
                     reactors.extend(val)
         return reactors
 
+    def list_all(self):
+        '''
+        Return a list of the reactors
+        '''
+        if isinstance(self.minion.opts['reactor'], string_types):
+            log.debug('Reading reactors from yaml {0}'.format(self.opts['reactor']))
+            try:
+                with salt.utils.fopen(self.opts['reactor']) as fp_:
+                    react_map = yaml.safe_load(fp_.read())
+            except (OSError, IOError):
+                log.error(
+                    'Failed to read reactor map: "{0}"'.format(
+                        self.opts['reactor']
+                        )
+                    )
+            except Exception:
+                log.error(
+                    'Failed to parse YAML in reactor map: "{0}"'.format(
+                        self.opts['reactor']
+                        )
+                    )
+        else:
+            log.debug('Not reading reactors from yaml')
+            react_map = self.minion.opts['reactor']
+        return react_map
+
+    def add_reactor(self, tag, reaction):
+        '''
+        Add a reactor
+        '''
+        reactors = self.list_all()
+        for reactor in reactors:
+            _tag = next(iterkeys(reactor))
+            if _tag == tag:
+                return {'status': False, 'comment': 'Reactor already exists.'}
+
+        self.minion.opts['reactor'].append({tag: reaction})
+        return {'status': True, 'comment': 'Reactor added.'}
+
+    def delete_reactor(self, tag):
+        '''
+        Delete a reactor
+        '''
+        reactors = self.list_all()
+        for reactor in reactors:
+            _tag = next(iterkeys(reactor))
+            if _tag == tag:
+                self.minion.opts['reactor'].remove(reactor)
+                return {'status': True, 'comment': 'Reactor deleted.'}
+
+        return {'status': False, 'comment': 'Reactor does not exists.'}
+
     def reactions(self, tag, data, reactors):
         '''
         Render a list of reactor files and returns a reaction struct
@@ -128,6 +180,7 @@ class Reactor(multiprocessing.Process, salt.state.Compiler):
         '''
         Execute the reaction state
         '''
+        log.debug('=== running Reactor.call_reactions ===')
         for chunk in chunks:
             self.wrap.run(chunk)
 
@@ -150,15 +203,31 @@ class Reactor(multiprocessing.Process, salt.state.Compiler):
             # skip all events fired by ourselves
             if data['data'].get('user') == self.wrap.event_user:
                 continue
-            reactors = self.list_reactors(data['tag'])
-            if not reactors:
-                continue
-            chunks = self.reactions(data['tag'], data['data'], reactors)
-            if chunks:
-                try:
-                    self.call_reactions(chunks)
-                except SystemExit:
-                    log.warning('Exit ignored by reactor')
+            if data['tag'].endswith('salt/reactors/manage/add'):
+                _data = data['data']
+                res = self.add_reactor(_data['event'], _data['reactors'])
+                self.event.fire_event({'reactors': self.list_all(),
+                                       'result': res},
+                                      'salt/reactors/manage/add-complete')
+            elif data['tag'].endswith('salt/reactors/manage/delete'):
+                _data = data['data']
+                res = self.delete_reactor(_data['event'])
+                self.event.fire_event({'reactors': self.list_all(),
+                                       'result': res},
+                                      'salt/reactors/manage/delete-complete')
+            elif data['tag'].endswith('salt/reactors/manage/list'):
+                self.event.fire_event({'reactors': self.list_all()},
+                                      'salt/reactors/manage/list-results')
+            else:
+                reactors = self.list_reactors(data['tag'])
+                if not reactors:
+                    continue
+                chunks = self.reactions(data['tag'], data['data'], reactors)
+                if chunks:
+                    try:
+                        self.call_reactions(chunks)
+                    except SystemExit:
+                        log.warning('Exit ignored by reactor')
 
 
 class ReactWrap(object):

--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -180,7 +180,6 @@ class Reactor(multiprocessing.Process, salt.state.Compiler):
         '''
         Execute the reaction state
         '''
-        log.debug('=== running Reactor.call_reactions ===')
         for chunk in chunks:
             self.wrap.run(chunk)
 


### PR DESCRIPTION
Switching Salt master to start with an empty reactor list so that the process will start.  Adding a new runner to manage Reactors using reactor events.
