### PR TITLE
Remove deprecation warnings for Beryllium

### DIFF
--- a/doc/topics/releases/beryllium.rst
+++ b/doc/topics/releases/beryllium.rst
@@ -79,3 +79,18 @@ the Nitrogen release of Salt. Example provider file:
       keyname: my_test_key
       securitygroup: default
       driver: ec2
+
+- The use of ``lock`` has been deprecated and from ``salt.utils.fopen``.
+``salt.utils.flopen`` should be used instead.
+
+- The following args have been deprecated from the ``rabbitmq_vhost.present``
+state: ``user``, ``owner``, ``conf``, ``write``, ``read``, and ``runas``.
+
+- The use of ``runas`` has been deprecated from the ``rabbitmq_vhost.absent``
+state.
+
+- Support for ``output`` in ``mine.get`` was removed. ``--out`` should be used
+instead.
+
+- The use of ``delim`` was removed from the following functions in the ``match``
+execution module: ``pillar_pcre``, ``pillar``, ``grain_pcre``,

--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -1274,12 +1274,12 @@ def associate_new_dhcp_options_to_vpc(vpc_id, domain_name=None, domain_name_serv
                                       netbios_name_servers=None, netbios_node_type=None,
                                       region=None, key=None, keyid=None, profile=None):
     '''
-    ..deprecated:: Beryllium
+    ..deprecated:: Boron
         This function has been deprecated in favor of
         :py:func:`boto_vpc.create_dhcp_options <salt.modules.boto_vpc.create_dhcp_options>`,
         which now takes vpc_id or vpc_name as kwargs.
 
-        This function will be removed in a future release.
+        This function will be removed in the Salt Boron release.
 
     Given valid DHCP options and a valid VPC id, create and associate the DHCP options record with the VPC.
 
@@ -1290,6 +1290,11 @@ def associate_new_dhcp_options_to_vpc(vpc_id, domain_name=None, domain_name_serv
         salt myminion boto_vpc.associate_new_dhcp_options_to_vpc 'vpc-6b1fe402' domain_name='example.com' domain_name_servers='[1.2.3.4]' ntp_servers='[5.6.7.8]' netbios_name_servers='[10.0.0.1]' netbios_node_type=1
 
     '''
+    salt.utils.warn_until(
+        'Boron',
+        'Support for \'associate_new_dhcp_options_to_vpc\' has been deprecated '
+        'and will be removed in Salt Boron. Please use \'create_dhcp_options\' instead.'
+    )
 
     return create_dhcp_options(vpc_id=vpc_id, domain_name=domain_name,
                                domain_name_servers=domain_name_servers,
@@ -1499,12 +1504,12 @@ def associate_network_acl_to_subnet(network_acl_id=None, subnet_id=None,
 def associate_new_network_acl_to_subnet(vpc_id, subnet_id, network_acl_name=None, tags=None,
                                         region=None, key=None, keyid=None, profile=None):
     '''
-    ..deprecated:: Beryllium
+    ..deprecated:: Boron
         This function has been deprecated in favor of
         :py:func:`boto_vpc.create_network_acl <salt.modules.boto_vpc.create_network_acl>`,
         which now takes subnet_id or subnet_name as kwargs.
 
-        This function will be removed in a future release.
+        This function will be removed in the Salt Boron release.
 
     Given a vpc ID and a subnet ID, associates a new network act to a subnet.
 
@@ -1517,6 +1522,11 @@ def associate_new_network_acl_to_subnet(vpc_id, subnet_id, network_acl_name=None
 
         salt myminion boto_vpc.associate_new_network_acl_to_subnet 'vpc-6b1fe402' 'subnet-6a1fe403'
     '''
+    salt.utils.warn_until(
+        'Boron',
+        'Support for \'associate_new_network_acl_to_subnet\' has been deprecated '
+        'and will be removed in Salt Boron. Please use \'create_network_acl\' instead.'
+    )
 
     return create_network_acl(vpc_id=vpc_id, subnet_id=subnet_id,
                               network_acl_name=network_acl_name, tags=tags,

--- a/salt/modules/data.py
+++ b/salt/modules/data.py
@@ -106,7 +106,7 @@ def getval(key):
     '''
     Get a value from the minion datastore
 
-    .. deprecated:: 2015.8.0
+    .. deprecated:: Boron
          Use ``get`` instead
 
     CLI Example:
@@ -115,6 +115,11 @@ def getval(key):
 
         salt '*' data.getval <key>
     '''
+    salt.utils.warn_until(
+        'Boron',
+        'Support for \'getval\' has been deprecated and will be removed '
+        'in Salt Boron. Please use \'get\' instead.'
+    )
     return get(key)
 
 
@@ -122,7 +127,7 @@ def getvals(*keylist):
     '''
     Get values from the minion datastore
 
-    .. deprecated:: 2015.8.0
+    .. deprecated:: Boron
          Use ``get`` instead
 
     CLI Example:
@@ -131,6 +136,11 @@ def getvals(*keylist):
 
         salt '*' data.getvals <key> [<key> ...]
     '''
+    salt.utils.warn_until(
+        'Boron',
+        'Support for \'getvals\' has been deprecated and will be removed '
+        'in Salt Boron. Please use \'get\' instead.'
+    )
     return get(keylist)
 
 

--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -4,7 +4,7 @@ Management of Docker Containers
 
 .. versionadded:: 2014.1.0
 
-.. deprecated:: Beryllium
+.. deprecated:: 2015.8.0
     Future feature development will be done only in :mod:`docker-ng
     <salt.modules.dockerng>`. See the documentation for this module for
     information on the deprecation path.

--- a/salt/modules/match.py
+++ b/salt/modules/match.py
@@ -80,7 +80,7 @@ def ipcidr(tgt):
         return False
 
 
-def pillar_pcre(tgt, delimiter=DEFAULT_TARGET_DELIM, delim=None):
+def pillar_pcre(tgt, delimiter=DEFAULT_TARGET_DELIM):
     '''
     Return True if the minion matches the given pillar_pcre target. The
     ``delimiter`` argument can be used to specify a different delimiter.
@@ -101,17 +101,8 @@ def pillar_pcre(tgt, delimiter=DEFAULT_TARGET_DELIM, delim=None):
         Specify an alternate delimiter to use when traversing a nested dict
 
         .. versionadded:: 0.16.4
-        .. deprecated:: 2014.7.0
+        .. deprecated:: 2015.8.0
     '''
-    if delim is not None:
-        salt.utils.warn_until(
-            'Beryllium',
-            'The \'delim\' argument to match.pillar_pcre has been deprecated '
-            'and will be removed in a future release. Please use '
-            '\'delimiter\' instead.'
-        )
-        delimiter = delim
-
     matcher = salt.minion.Matcher({'pillar': __pillar__}, __salt__)
     try:
         return matcher.pillar_pcre_match(tgt, delimiter=delimiter)
@@ -120,7 +111,7 @@ def pillar_pcre(tgt, delimiter=DEFAULT_TARGET_DELIM, delim=None):
         return False
 
 
-def pillar(tgt, delimiter=DEFAULT_TARGET_DELIM, delim=None):
+def pillar(tgt, delimiter=DEFAULT_TARGET_DELIM):
     '''
     Return True if the minion matches the given pillar target. The
     ``delimiter`` argument can be used to specify a different delimiter.
@@ -141,17 +132,8 @@ def pillar(tgt, delimiter=DEFAULT_TARGET_DELIM, delim=None):
         Specify an alternate delimiter to use when traversing a nested dict
 
         .. versionadded:: 0.16.4
-        .. deprecated:: 2014.7.0
+        .. deprecated:: 2015.8.0
     '''
-    if delim is not None:
-        salt.utils.warn_until(
-            'Beryllium',
-            'The \'delim\' argument to match.pillar has been deprecated and '
-            'will be removed in a future release. Please use \'delimiter\' '
-            'instead.'
-        )
-        delimiter = delim
-
     matcher = salt.minion.Matcher({'pillar': __pillar__}, __salt__)
     try:
         return matcher.pillar_match(tgt, delimiter=delimiter)
@@ -178,7 +160,7 @@ def data(tgt):
         return False
 
 
-def grain_pcre(tgt, delimiter=DEFAULT_TARGET_DELIM, delim=None):
+def grain_pcre(tgt, delimiter=DEFAULT_TARGET_DELIM):
     '''
     Return True if the minion matches the given grain_pcre target. The
     ``delimiter`` argument can be used to specify a different delimiter.
@@ -199,17 +181,8 @@ def grain_pcre(tgt, delimiter=DEFAULT_TARGET_DELIM, delim=None):
         Specify an alternate delimiter to use when traversing a nested dict
 
         .. versionadded:: 0.16.4
-        .. deprecated:: 2014.7.0
+        .. deprecated:: 2015.8.0
     '''
-    if delim is not None:
-        salt.utils.warn_until(
-            'Beryllium',
-            'The \'delim\' argument to match.grain_pcre has been deprecated '
-            'and will be removed in a future release. Please use '
-            '\'delimiter\' instead.'
-        )
-        delimiter = delim
-
     matcher = salt.minion.Matcher({'grains': __grains__}, __salt__)
     try:
         return matcher.grain_pcre_match(tgt, delimiter=delimiter)
@@ -218,7 +191,7 @@ def grain_pcre(tgt, delimiter=DEFAULT_TARGET_DELIM, delim=None):
         return False
 
 
-def grain(tgt, delimiter=DEFAULT_TARGET_DELIM, delim=None):
+def grain(tgt, delimiter=DEFAULT_TARGET_DELIM):
     '''
     Return True if the minion matches the given grain target. The ``delimiter``
     argument can be used to specify a different delimiter.
@@ -239,17 +212,8 @@ def grain(tgt, delimiter=DEFAULT_TARGET_DELIM, delim=None):
         Specify an alternate delimiter to use when traversing a nested dict
 
         .. versionadded:: 0.16.4
-        .. deprecated:: 2014.7.0
+        .. deprecated:: 2015.8.0
     '''
-    if delim is not None:
-        salt.utils.warn_until(
-            'Beryllium',
-            'The \'delim\' argument to match.grain has been deprecated and '
-            'will be removed in a future release. Please use \'delimiter\' '
-            'instead.'
-        )
-        delimiter = delim
-
     matcher = salt.minion.Matcher({'grains': __grains__}, __salt__)
     try:
         return matcher.grain_match(tgt, delimiter=delimiter)

--- a/salt/runners/mine.py
+++ b/salt/runners/mine.py
@@ -14,7 +14,7 @@ import salt.utils.minions
 log = logging.getLevelName(__name__)
 
 
-def get(tgt, fun, tgt_type='glob', output=None):
+def get(tgt, fun, tgt_type='glob'):
     '''
     Gathers the data from the specified minions' mine, pass in the target,
     function to look up and the target type
@@ -25,10 +25,5 @@ def get(tgt, fun, tgt_type='glob', output=None):
 
         salt-run mine.get '*' network.interfaces
     '''
-    if output is not None:
-        # Remove this logging warning in Beryllium
-        salt.utils.warn_until(
-                'Beryllium',
-                'Runners now supports --out. Please use --out instead.')
     ret = salt.utils.minions.mine_get(tgt, fun, tgt_type, __opts__)
     return ret

--- a/salt/states/rabbitmq_vhost.py
+++ b/salt/states/rabbitmq_vhost.py
@@ -32,65 +32,43 @@ def __virtual__():
     return salt.utils.which('rabbitmqctl') is not None
 
 
-def present(name,
-            user=None,
-            owner=None,
-            conf=None,
-            write=None,
-            read=None,
-            runas=None):
+def present(name):
     '''
     Ensure the RabbitMQ VHost exists.
 
     name
         VHost name
+
     user
         Initial user permission to set on the VHost, if present
 
-        .. deprecated:: Beryllium
+        .. deprecated:: 2015.8.0
     owner
         Initial owner permission to set on the VHost, if present
 
-        .. deprecated:: Beryllium
+        .. deprecated:: 2015.8.0
     conf
         Initial conf string to apply to the VHost and user. Defaults to .*
 
-        .. deprecated:: Beryllium
+        .. deprecated:: 2015.8.0
     write
         Initial write permissions to apply to the VHost and user.
         Defaults to .*
 
-        .. deprecated:: Beryllium
+        .. deprecated:: 2015.8.0
     read
         Initial read permissions to apply to the VHost and user.
         Defaults to .*
 
-        .. deprecated:: Beryllium
+        .. deprecated:: 2015.8.0
     runas
         Name of the user to run the command
 
-        .. deprecated:: Beryllium
+        .. deprecated:: 2015.8.0
     '''
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
-    if runas:
-        salt.utils.warn_until(
-            'Beryllium',
-            'The support for \'runas\' has been deprecated and will be '
-            'removed in Salt Beryllium. Ping s0undt3ch for additional '
-            'information or see #6961.'
-        )
-
-    if any((user, owner, conf, write, read)):
-        salt.utils.warn_until(
-            'Beryllium',
-            'Passed \'owner\', \'user\', \'conf\', \'write\' or \'read\' '
-            'arguments. These are being deprecated, and will be removed in '
-            'Salt Beryllium. Please update your state files, and set '
-            'permissions for user instead. See rabbitmq_user.present.'
-        )
-
-    vhost_exists = __salt__['rabbitmq.vhost_exists'](name, runas=runas)
+    vhost_exists = __salt__['rabbitmq.vhost_exists'](name)
 
     if __opts__['test']:
         ret['result'] = None
@@ -103,7 +81,7 @@ def present(name,
         if vhost_exists:
             ret['comment'] = 'VHost {0} already exists'.format(name)
         else:
-            result = __salt__['rabbitmq.add_vhost'](name, runas=runas)
+            result = __salt__['rabbitmq.add_vhost'](name)
             if 'Error' in result:
                 ret['result'] = False
                 ret['comment'] = result['Error']
@@ -114,8 +92,7 @@ def present(name,
     return ret
 
 
-def absent(name,
-           runas=None):
+def absent(name):
     '''
     Ensure the RabbitMQ Virtual Host is absent
 
@@ -124,17 +101,11 @@ def absent(name,
     runas
         User to run the command
 
-        .. deprecated:: Beryllium
+        .. deprecated:: 2015.8.0
     '''
-    if runas:
-        salt.utils.warn_until(
-            'Beryllium',
-            'The support for \'runas\' has been deprecated and will be '
-            'removed in Salt Beryllium.'
-        )
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
-    vhost_exists = __salt__['rabbitmq.vhost_exists'](name, runas=runas)
+    vhost_exists = __salt__['rabbitmq.vhost_exists'](name)
 
     if not vhost_exists:
         ret['comment'] = 'Virtual Host {0} is not present'.format(name)
@@ -146,7 +117,7 @@ def absent(name,
 
     else:
         if vhost_exists:
-            result = __salt__['rabbitmq.delete_vhost'](name, runas=runas)
+            result = __salt__['rabbitmq.delete_vhost'](name)
             if 'Error' in result:
                 ret['result'] = False
                 ret['comment'] = result['Error']

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1190,19 +1190,6 @@ def fopen(*args, **kwargs):
     NB! We still have small race condition between open and fcntl.
 
     '''
-    # Remove lock from kwargs if present
-    lock = kwargs.pop('lock', False)
-
-    if lock is True:
-        warn_until(
-            'Beryllium',
-            'The \'lock\' keyword argument is deprecated and will be '
-            'removed in Salt Beryllium. Please use '
-            '\'salt.utils.flopen()\' for file locking while calling '
-            '\'salt.utils.fopen()\'.'
-        )
-        return flopen(*args, **kwargs)
-
     # ensure 'binary' mode is always used on windows
     if kwargs.pop('binary', True):
         if is_windows():

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -10,7 +10,6 @@ import re
 import shlex
 import socket
 import logging
-import subprocess
 from string import ascii_letters, digits
 
 # Import 3rd-party libs
@@ -925,9 +924,15 @@ def ip_in_subnet(addr, cidr):
     '''
     Returns True if given IP is within specified subnet, otherwise False
 
-    .. deprecated:: Beryllium
+    .. deprecated:: Boron
        Use :py:func:`~salt.utils.network.in_subnet` instead
     '''
+    salt.utils.warn_until(
+        'Boron',
+        'Support for \'ip_in_subnet\' has been deprecated and will be removed '
+        'in Salt Boron. Please use \'in_subnet\' instead.'
+    )
+    
     return in_subnet(cidr, addr)
 
 

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -932,7 +932,7 @@ def ip_in_subnet(addr, cidr):
         'Support for \'ip_in_subnet\' has been deprecated and will be removed '
         'in Salt Boron. Please use \'in_subnet\' instead.'
     )
-    
+
     return in_subnet(cidr, addr)
 
 


### PR DESCRIPTION
Some Beryllium deprecations were only referenced in the docs, and didn't have a CLI `warn_until` function. In those cases, I move the deprecation doc notice to `Boron` and add a `warn_until` function.

Also added any changes of things that were removed to the release notes.
