### PR TITLE
ensure ret is always defined

### DIFF
--- a/salt/modules/win_useradd.py
+++ b/salt/modules/win_useradd.py
@@ -127,8 +127,7 @@ def add(name,
            profile=profile,
            fullname=fullname)
 
-    if groups:
-        ret = chgroups(name, groups)
+    ret = chgroups(name, groups) if groups else True
 
     return ret
 


### PR DESCRIPTION
```
  File "C:\salt\bin\lib\site-packages\salt\state.py", line 1587, in call
    **cdata['kwargs'])
  File "C:\salt\bin\lib\site-packages\salt\states\user.py", line 590, in present
    if __salt__['user.add'](**params):
  File "C:\salt\bin\lib\site-packages\salt\modules\win_useradd.py", line 133, in add
    return ret
UnboundLocalError: local variable 'ret' referenced before assignment
```
