### PR TITLE
Fix: Boto SNS - Auth Basic Endpoint Compare

### DIFF
--- a/salt/states/boto_sns.py
+++ b/salt/states/boto_sns.py
@@ -151,7 +151,7 @@ def present(
         # Example: https://user:****@my.endpoiint.com/foo/bar
         _endpoint = subscription['endpoint']
         matches = re.search(
-            'https://(?P<user>\w+):(?P<pass>\w+)@',
+            r'https://(?P<user>\w+):(?P<pass>\w+)@',
             _endpoint)
 
         # We are using https and have auth creds - the password will be starred out,

--- a/salt/states/boto_sns.py
+++ b/salt/states/boto_sns.py
@@ -146,24 +146,24 @@ def present(
     ]
 
     for subscription in subscriptions:
-        # If the subscription contains inline digest auth AWS will * the
-        # password so we need to do the same with ours if we match the regex
-        # Exmaple: https://user:****@my.endpoiint.com/foo/bar
+        # If the subscription contains inline digest auth, AWS will *** the
+        # password. So we need to do the same with ours if the regex matches
+        # Example: https://user:****@my.endpoiint.com/foo/bar
         _endpoint = subscription['endpoint']
         matches = re.search(
             'https://(?P<user>\w+):(?P<pass>\w+)@',
             _endpoint)
 
-        # We are https and have auth creds, star out the pass so we can
-        # check if the sub exists since aws will star it out
+        # We are using https and have auth creds - the password will be starred out,
+        # so star out our password so we can still match it
         if matches is not None:
             subscription['endpoint'] = _endpoint.replace(
                 matches.groupdict()['pass'],
                 '****')
 
         if subscription not in _subscriptions:
-            # Just incase we stared out a password we always
-            # ensure the endpoint is the origional value
+            # Ensure the endpoint is set back to it's original value,
+            # incase we starred out a password
             subscription['endpoint'] = _endpoint
 
             if __opts__['test']:


### PR DESCRIPTION
When creating an AWS SNS Topic Subscription with Auth Basic credentials Amazon will star out the password in API responses.

For example: `https://foo:bar@foo.com` becomes `https://foo:****@foo.com`

This means when a `boto_sns.present` is called multiple times with this kind of subscription it will always run the `boto_sns.subscribe` function even though the subscription exists because  `https://foo:bar@foo.com` != `https://foo:****@foo.com`.

This PR fixes this be running a regex looking for a simple auth basic pattern in the endpoint. If one is found then the password is stared out so a correct comparison can be made and the original endpoint restored (with the password not stared out) if the subscription does not exist so it can be created correctly.
