### PR TITLE
Simple fix for locale.present on Ubuntu.

### DIFF
--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -252,8 +252,7 @@ def gen_locale(locale, **kwargs):
         cmd = ['locale-gen']
         if on_gentoo:
             cmd.append('--generate')
-        if not on_ubuntu:
-            cmd.append(locale)
+        cmd.append(locale)
     elif salt.utils.which("localedef") is not None:
         cmd = ['localedef', '--force',
                '-i', "{0}_{1}".format(locale_info['language'], locale_info['territory']),


### PR DESCRIPTION
Without this fix locale.present doesn't generate any locales on my ubuntu 14.04.2 installation.

Maybe refs issue #24433
@jfindlay maybe?

Thanks,
Rene´ Jochum aka pcdummy
