### PR TITLE
Fix exessive escaping in fluent log handler

### DIFF
--- a/salt/log/handlers/fluent_mod.py
+++ b/salt/log/handlers/fluent_mod.py
@@ -62,10 +62,6 @@ import salt.utils.network
 
 # Import Third party libs
 import salt.ext.six as six
-try:
-    import simplejson as json
-except ImportError:
-    import json
 
 log = logging.getLogger(__name__)
 
@@ -218,7 +214,7 @@ class LogstashFormatter(logging.Formatter, NewStyleClassMixIn):
                 continue
 
             message_dict['@fields'][key] = repr(value)
-        return json.dumps(message_dict)
+        return message_dict
 
     def format_v1(self, record):
         message_dict = {
@@ -262,7 +258,7 @@ class LogstashFormatter(logging.Formatter, NewStyleClassMixIn):
                 continue
 
             message_dict[key] = repr(value)
-        return json.dumps(message_dict)
+        return message_dict
 
 
 class FluentHandler(logging.Handler):


### PR DESCRIPTION
Fix exessive escaping produced by sending the dict though a JSON processor and instead relies on msgpack.

Old message:

```
2015-07-09 15:50:06 -0400 salt: "{\"tags\": [\"salt\"], \"process\": 11156, \"@timestamp\": \"2015-07-09T19:50:06.115Z\", \"funcName\": \"tune_in\", \"host\": \"devlogstash200.athenahealth.com\", \"message\": \"Minion is ready to receive requests!\", \"type\": \"logstash\", \"threadName\": \"MainThread\", \"processName\": \"MainProcess\", \"exc_info_on_loglevel\": null, \"pathname\": \"/usr/lib/python2.6/site-packages/salt/minion.py\", \"lineno\": 1529, \"logger\": \"salt.minion\", \"@version\": 1, \"levelname\": \"INFO\"}"
```

New message:

```
2015-07-09 18:36:32 -0400 salt: {"tags":["salt"],"process":18867,"@timestamp":"2015-07-09T22:36:32.431Z","funcName":"setup_extended_logging","host":"devlogstash200.athenahealth.com","message":"Processing `log_handlers.fluent`","type":"logstash","threadName":"MainThread","processName":"MainProcess","exc_info_on_loglevel":null,"pathname":"/usr/lib/python2.6/site-packages/salt/log/setup.py","lineno":545,"logger":"salt.log.setup","@version":1,"levelname":"INFO"}
```
