### PR TITLE
update novaclient to use the new v2 if available

### DIFF
--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -14,7 +14,10 @@ import salt.ext.six as six
 HAS_NOVA = False
 # pylint: disable=import-error
 try:
-    from novaclient.v1_1 import client
+    try:
+        from novaclient.v2 import client
+    except ImportError:
+        from novaclient.v1_1 import client
     from novaclient.shell import OpenStackComputeShell
     import novaclient.utils
     import novaclient.auth_plugin


### PR DESCRIPTION
@techhat 

Also, do we have a hold on 2015.8 until the ssh_interfaces regression is fixed in nova since we are making that the recommended way soon?
