### PR TITLE
Format /etc/locale.gen correctly in salt.modules.localemod.gen_locale

### DIFF
--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -234,7 +234,7 @@ def gen_locale(locale, **kwargs):
         __salt__['file.replace'](
             '/etc/locale.gen',
             r'^\s*#\s*{0}\s*$'.format(locale),
-            '{0}'.format(locale),
+            '{0}\\n'.format(locale),
             append_if_not_found=True
         )
     elif on_ubuntu:


### PR DESCRIPTION
Prior to this change, the `file.replace` call matches an end-of-line character, which changes a file (extract) from:

```
...
# en_US.UTF-8 UTF-8
# en_ZA ISO-8859-1
...
```

to

```
...
en_US.UTF-8 UTF-8# en_ZA ISO-8859-1
...
```

which is incorrectly formatted -- the newline char being removed means the whole section after the whitespace is considered the charset.  See http://www.man-online.org/page/5-locale.gen/.

As a result, running `locale-gen`has no effect because the entry in this file doesn't exist.

After this PR adds the newline character into the replacement text, the file format is correct:

```
...
en_US.UTF-8 UTF-8
# en_ZA ISO-8859-1
...
```

and calls to `locale-gen` (eg via Salt's locale state etc) can now succeed.

This may fix #24827.
