### PR TITLE
Add an "is list" test to the jinja environment

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -2753,3 +2753,10 @@ def to_unicode(s, encoding=None):
         if isinstance(s, str):
             return s.decode(encoding or __salt_system_encoding__)
         return unicode(s)  # pylint: disable=incompatible-py3-code
+
+
+def is_list(value):
+    '''
+    Check if a variable is a list.
+    '''
+    return isinstance(value, list)

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -294,6 +294,8 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
     jinja_env.globals['odict'] = OrderedDict
     jinja_env.globals['show_full_context'] = show_full_context
 
+    jinja_env.tests['list'] = salt.utils.is_list
+
     decoded_context = {}
     for key, value in six.iteritems(context):
         if not isinstance(value, string_types):


### PR DESCRIPTION
This is a huge annoyance of mine - not being able to test if a variable is a list in jinja.

``` jinja
# currently, you have to do something like this...
{% if value is sequence and value is not string and value is not mapping %}
# after this change
{% if value is list %}
```

I wasn't sure if there was a feature freeze for 2015.8, but it is a very simple feature. Let me know if this should be targetted at the develop branch instead.
