### PR TITLE
[cloud:EC2] Move SourceDest logic to _update_enis and add  alias for delete_interface_on_terminate

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1266,11 +1266,16 @@ def _list_interface_private_addresses(eni_desc):
     return addresses
 
 
-def _modify_eni_properties(eni_id, properties={}):
+def _modify_eni_properties(eni_id, properties=None):
     '''
     Change properties of the interface
     with id eni_id to the values in properties dict
     '''
+    if type(subnet_query_result['item']) is not dict:
+        raise SaltCloudException(
+            'ENI properties must be a dictionary'
+        )
+
     params = {'Action': 'ModifyNetworkInterfaceAttribute',
               'NetworkInterfaceId': eni_id}
     for k, v in properties.iteritems():

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1204,9 +1204,6 @@ def _create_eni_if_necessary(interface):
         )
     )
 
-    if 'SourceDestCheck' in interface:
-        _modify_interface_source_dest_check(eni_id, interface['SourceDestCheck'])
-
     associate_public_ip = interface.get('AssociatePublicIpAddress', False)
     if type(associate_public_ip) is str:
         # Assume id of EIP as value
@@ -1266,14 +1263,15 @@ def _list_interface_private_addresses(eni_desc):
     return addresses
 
 
-def _modify_interface_source_dest_check(eni_id, source_dest_check=True):
+def _modify_eni_properties(eni_id, properties={}):
     '''
-    Change the state of SourceDestCheck Flag in the interface
-    with id eni_id to the value of source_dest_check
+    Change properties of the interface
+    with id eni_id to the values in properties dict
     '''
     params = {'Action': 'ModifyNetworkInterfaceAttribute',
-              'NetworkInterfaceId': eni_id,
-              'SourceDestCheck.Value': source_dest_check}
+              'NetworkInterfaceId': eni_id}
+    for k, v in properties.iteritems():
+        params[k] = v
 
     retries = 5
     while retries > 0:
@@ -1284,12 +1282,12 @@ def _modify_interface_source_dest_check(eni_id, source_dest_check=True):
             time.sleep(1)
             continue
 
-        return None
+        return result
 
     raise SaltCloudException(
-        'Could not change SourceDestCheck attribute '
-        'interface=<{0}> SourceDestCheck=<{1}>'.format(
-            eni_id, source_dest_check
+        'Could not change interface <{0}> attributes '
+        '<{1!r}> after 5 retries'.format(
+            eni_id, properties
         )
     )
 
@@ -1363,16 +1361,19 @@ def _update_enis(interfaces, instance):
         instance_enis.append((query_enis['networkInterfaceId'], query_enis['attachment']))
 
     for eni_id, eni_data in instance_enis:
-        params = {'Action': 'ModifyNetworkInterfaceAttribute',
-                  'NetworkInterfaceId': eni_id,
-                  'Attachment.AttachmentId': eni_data['attachmentId'],
-                  'Attachment.DeleteOnTermination': config_enis[eni_data['deviceIndex']].setdefault('delete_interface_on_terminate', True)}
-        set_eni_attributes = aws.query(params,
-                                       return_root=True,
-                                       location=get_location(),
-                                       provider=get_provider(),
-                                       opts=__opts__,
-                                       sigver='4')
+        delete_on_terminate = True
+        if 'DeleteOnTermination' in config_enis[eni_data['deviceIndex']]:
+            delete_on_terminate = config_enis[eni_data['deviceIndex']]['DeleteOnTermination']
+        elif 'delete_interface_on_terminate' in config_enis[eni_data['deviceIndex']]:
+            delete_on_terminate = config_enis[eni_data['deviceIndex']]['delete_interface_on_terminate']
+
+        params_attachment = {'Attachment.AttachmentId': eni_data['attachmentId'],
+                             'Attachment.DeleteOnTermination': delete_on_terminate}
+        set_eni_attachment_attributes = _modify_eni_properties(eni_id, params_attachment)
+
+        if 'SourceDestCheck' in config_enis[eni_data['deviceIndex']]:
+            params_sourcedest = {'SourceDestCheck.Value': config_enis[eni_data['deviceIndex']]['SourceDestCheck']}
+            set_eni_sourcedest_property = _modify_eni_properties(eni_id, params_sourcedest)
 
     return None
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1255,7 +1255,7 @@ def _modify_eni_properties(eni_id, properties=None):
     Change properties of the interface
     with id eni_id to the values in properties dict
     '''
-    if type(subnet_query_result['item']) is not dict:
+    if type(properties) is not dict:
         raise SaltCloudException(
             'ENI properties must be a dictionary'
         )

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1204,9 +1204,6 @@ def _create_eni_if_necessary(interface):
         )
     )
 
-    if 'SourceDestCheck' in interface:
-        _modify_interface_source_dest_check(eni_id, interface['SourceDestCheck'])
-
     associate_public_ip = interface.get('AssociatePublicIpAddress', False)
     if type(associate_public_ip) is str:
         # Assume id of EIP as value

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1263,11 +1263,16 @@ def _list_interface_private_addresses(eni_desc):
     return addresses
 
 
-def _modify_eni_properties(eni_id, properties={}):
+def _modify_eni_properties(eni_id, properties=None):
     '''
     Change properties of the interface
     with id eni_id to the values in properties dict
     '''
+    if type(subnet_query_result['item']) is not dict:
+        raise SaltCloudException(
+            'ENI properties must be a dictionary'
+        )
+
     params = {'Action': 'ModifyNetworkInterfaceAttribute',
               'NetworkInterfaceId': eni_id}
     for k, v in properties.iteritems():

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1268,7 +1268,7 @@ def _modify_eni_properties(eni_id, properties=None):
     Change properties of the interface
     with id eni_id to the values in properties dict
     '''
-    if type(subnet_query_result['item']) is not dict:
+    if type(properties) is not dict:
         raise SaltCloudException(
             'ENI properties must be a dictionary'
         )

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1209,9 +1209,6 @@ def _create_eni_if_necessary(interface):
         )
     )
 
-    if 'SourceDestCheck' in interface:
-        _modify_interface_source_dest_check(eni_id, interface['SourceDestCheck'])
-
     if interface.get('associate_eip'):
         _associate_eip_with_interface(eni_id, interface.get('associate_eip'))
     elif interface.get('allocate_new_eip'):
@@ -1253,14 +1250,15 @@ def _list_interface_private_addresses(eni_desc):
     return addresses
 
 
-def _modify_interface_source_dest_check(eni_id, source_dest_check=True):
+def _modify_eni_properties(eni_id, properties={}):
     '''
-    Change the state of SourceDestCheck Flag in the interface
-    with id eni_id to the value of source_dest_check
+    Change properties of the interface
+    with id eni_id to the values in properties dict
     '''
     params = {'Action': 'ModifyNetworkInterfaceAttribute',
-              'NetworkInterfaceId': eni_id,
-              'SourceDestCheck.Value': source_dest_check}
+              'NetworkInterfaceId': eni_id}
+    for k, v in properties.iteritems():
+        params[k] = v
 
     retries = 5
     while retries > 0:
@@ -1271,12 +1269,12 @@ def _modify_interface_source_dest_check(eni_id, source_dest_check=True):
             time.sleep(1)
             continue
 
-        return None
+        return result
 
     raise SaltCloudException(
-        'Could not change SourceDestCheck attribute '
-        'interface=<{0}> SourceDestCheck=<{1}>'.format(
-            eni_id, source_dest_check
+        'Could not change interface <{0}> attributes '
+        '<{1!r}> after 5 retries'.format(
+            eni_id, properties
         )
     )
 
@@ -1350,16 +1348,19 @@ def _update_enis(interfaces, instance):
         instance_enis.append((query_enis['networkInterfaceId'], query_enis['attachment']))
 
     for eni_id, eni_data in instance_enis:
-        params = {'Action': 'ModifyNetworkInterfaceAttribute',
-                  'NetworkInterfaceId': eni_id,
-                  'Attachment.AttachmentId': eni_data['attachmentId'],
-                  'Attachment.DeleteOnTermination': config_enis[eni_data['deviceIndex']].setdefault('delete_interface_on_terminate', True)}
-        set_eni_attributes = aws.query(params,
-                                       return_root=True,
-                                       location=get_location(),
-                                       provider=get_provider(),
-                                       opts=__opts__,
-                                       sigver='4')
+        delete_on_terminate = True
+        if 'DeleteOnTermination' in config_enis[eni_data['deviceIndex']]:
+            delete_on_terminate = config_enis[eni_data['deviceIndex']]['DeleteOnTermination']
+        elif 'delete_interface_on_terminate' in config_enis[eni_data['deviceIndex']]:
+            delete_on_terminate = config_enis[eni_data['deviceIndex']]['delete_interface_on_terminate']
+
+        params_attachment = {'Attachment.AttachmentId': eni_data['attachmentId'],
+                             'Attachment.DeleteOnTermination': delete_on_terminate}
+        set_eni_attachment_attributes = _modify_eni_properties(eni_id, params_attachment)
+
+        if 'SourceDestCheck' in config_enis[eni_data['deviceIndex']]:
+            params_sourcedest = {'SourceDestCheck.Value': config_enis[eni_data['deviceIndex']]['SourceDestCheck']}
+            set_eni_sourcedest_property = _modify_eni_properties(eni_id, params_sourcedest)
 
     return None
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1250,11 +1250,16 @@ def _list_interface_private_addresses(eni_desc):
     return addresses
 
 
-def _modify_eni_properties(eni_id, properties={}):
+def _modify_eni_properties(eni_id, properties=None):
     '''
     Change properties of the interface
     with id eni_id to the values in properties dict
     '''
+    if type(subnet_query_result['item']) is not dict:
+        raise SaltCloudException(
+            'ENI properties must be a dictionary'
+        )
+
     params = {'Action': 'ModifyNetworkInterfaceAttribute',
               'NetworkInterfaceId': eni_id}
     for k, v in properties.iteritems():

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1271,7 +1271,7 @@ def _modify_eni_properties(eni_id, properties=None):
     Change properties of the interface
     with id eni_id to the values in properties dict
     '''
-    if type(subnet_query_result['item']) is not dict:
+    if type(properties) is not dict:
         raise SaltCloudException(
             'ENI properties must be a dictionary'
         )

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -318,8 +318,11 @@ class Fileserver(object):
     def update_opts(self):
         # This fix func monkey patching by pillar
         for name, func in self.servers.items():
-            if '__opts__' in func.__globals__:
-                func.__globals__['__opts__'].update(self.opts)
+            try:
+                if '__opts__' in func.__globals__:
+                    func.__globals__['__opts__'].update(self.opts)
+            except AttributeError:
+                pass
 
     def clear_cache(self, back=None):
         '''


### PR DESCRIPTION
- SourceDest Flag is now also honored, when we attach an existing interface (_update_enis is a post-flight update)
- delete_interface_on_terminate is DeleteOnTermination at the EC2 Api, this alias makes it possible to keep the config consistent with api parameter
