### PR TITLE
Don't try to read init binary if it wasn't found

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1042,28 +1042,29 @@ def os_data():
             with salt.utils.fopen('/proc/1/cmdline') as fhr:
                 init_cmdline = fhr.read().replace('\x00', ' ').split()
                 init_bin = salt.utils.which(init_cmdline[0])
-                supported_inits = ('upstart', 'sysvinit', 'systemd')
-                edge_len = max(len(x) for x in supported_inits) - 1
-                buf_size = __opts__['file_buffer_size']
-                try:
-                    with open(init_bin, 'rb') as fp_:
-                        buf = True
-                        edge = ''
-                        buf = fp_.read(buf_size).lower()
-                        while buf:
-                            buf = edge + buf
-                            for item in supported_inits:
-                                if item in buf:
-                                    grains['init'] = item
-                                    buf = ''
-                                    break
-                            edge = buf[-edge_len:]
+                if init_bin:
+                    supported_inits = ('upstart', 'sysvinit', 'systemd')
+                    edge_len = max(len(x) for x in supported_inits) - 1
+                    buf_size = __opts__['file_buffer_size']
+                    try:
+                        with open(init_bin, 'rb') as fp_:
+                            buf = True
+                            edge = ''
                             buf = fp_.read(buf_size).lower()
-                except (IOError, OSError) as exc:
-                    log.error(
-                        'Unable to read from init_bin ({0}): {1}'
-                        .format(init_bin, exc)
-                    )
+                            while buf:
+                                buf = edge + buf
+                                for item in supported_inits:
+                                    if item in buf:
+                                        grains['init'] = item
+                                        buf = ''
+                                        break
+                                edge = buf[-edge_len:]
+                                buf = fp_.read(buf_size).lower()
+                    except (IOError, OSError) as exc:
+                        log.error(
+                            'Unable to read from init_bin ({0}): {1}'
+                            .format(init_bin, exc)
+                        )
 
         # Add lsb grains on any distro with lsb-release
         try:


### PR DESCRIPTION
This fixes an edge case where init_bin is None in certain environments
(such as the Fedora Buildsystem).
