### PR TITLE
EC2 cloud: Fix another availability zone mismatch

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -994,7 +994,7 @@ def get_availability_zone(vm_):
     if avz is None:
         return None
 
-    zones = _list_availability_zones()
+    zones = _list_availability_zones(vm_)
 
     # Validate user-specified AZ
     if avz not in zones:
@@ -1084,7 +1084,7 @@ def get_provider(vm_=None):
     return provider
 
 
-def _list_availability_zones():
+def _list_availability_zones(vm_=None):
     '''
     List all availability zones in the current region
     '''
@@ -1092,9 +1092,9 @@ def _list_availability_zones():
 
     params = {'Action': 'DescribeAvailabilityZones',
               'Filter.0.Name': 'region-name',
-              'Filter.0.Value.0': get_location()}
+              'Filter.0.Value.0': get_location(vm_)}
     result = aws.query(params,
-                       location=get_location(),
+                       location=get_location(vm_),
                        provider=get_provider(),
                        opts=__opts__,
                        sigver='4')


### PR DESCRIPTION
Another instance where ec2 drops/forgets the location parameter. I'm pretty sure there are more.

This is not an issue when salt-cloud calls are being made from command line, but when trying to deploy with salt.cloud sls states, things break. 
