### PR TITLE
Deep merge of pillar lists

### DIFF
--- a/salt/utils/dictupdate.py
+++ b/salt/utils/dictupdate.py
@@ -42,6 +42,9 @@ def update(dest, upd, recursive_update=True):
                     and isinstance(val, collections.Mapping):
                 ret = update(dest_subkey, val)
                 dest[key] = ret
+            elif isinstance(dest_subkey, list) \
+                     and isinstance(val, list):
+                dest[key] = dest.get(key, []) + val
             else:
                 dest[key] = upd[key]
         return dest


### PR DESCRIPTION
Pillar deep merge of lists
## Problem

When using recurse merge pillar mode (default), if a list is inside of a dict 
to be merged, that list is not merged, and the last seen list of the same name
is used wholesale.  This PR will merge lists.

This also possibly fixes #22241.
## Example Setup of Pillars 
- top.sls 

```
base:
    '*':
     - test
     - test2
```
- test.sls

```
dict_with_list:
     foo: bar
     list_foo:
         - list_entry_1
         - list_etnry_2
```
- test2.sls 

```
dict_with_list:
     foo2: bar2
     list_foo:
         - list_entry_3
```
## 2015.5.3 does not merge lists in recurse merge mode 

```
[root@35c7dac3f0a2 /]# salt --versions-report
           Salt: 2015.5.3
         Python: 2.7.5 (default, Jun 24 2015, 00:41:19)
         Jinja2: 2.7.3
       M2Crypto: 0.22
 msgpack-python: 0.4.6
   msgpack-pure: Not Installed
       pycrypto: 2.6.1
        libnacl: Not Installed
         PyYAML: 3.11
          ioflo: Not Installed
          PyZMQ: 14.7.0
           RAET: Not Installed
            ZMQ: 3.2.5
           Mako: Not Installed
        Tornado: Not Installed
```

```
[root@35c7dac3f0a2 /]# salt-call pillar.items
local:
    ----------
    dict_with_list:
        ----------
        foo:
            bar
        foo2:
            bar2
        list_foo:
            - list_entry_3
```
## Patch supports Merging Lists

```
[root@35c7dac3f0a2 /]# salt-call pillar.items
local:
    ----------
    dict_with_list:
        ----------
        foo:
            bar
        foo2:
            bar2
        list_foo:
            - list_entry_1
            - list_etnry_2
            - list_entry_3
```
