### PR TITLE
Fix init_bin being None from #20124 + #24531

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1069,27 +1069,33 @@ def os_data():
             with salt.utils.fopen('/proc/1/cmdline') as fhr:
                 init_cmdline = fhr.read().replace('\x00', ' ').split()
                 init_bin = salt.utils.which(init_cmdline[0])
-                supported_inits = ('upstart', 'sysvinit', 'systemd')
-                edge_len = max(len(x) for x in supported_inits) - 1
-                buf_size = __opts__['file_buffer_size']
-                try:
-                    with open(init_bin, 'rb') as fp_:
-                        buf = True
-                        edge = ''
-                        buf = fp_.read(buf_size).lower()
-                        while buf:
-                            buf = edge + buf
-                            for item in supported_inits:
-                                if item in buf:
-                                    grains['init'] = item
-                                    buf = ''
-                                    break
-                            edge = buf[-edge_len:]
+                if init_bin is not None:
+                    supported_inits = ('upstart', 'sysvinit', 'systemd')
+                    edge_len = max(len(x) for x in supported_inits) - 1
+                    buf_size = __opts__['file_buffer_size']
+                    try:
+                        with open(init_bin, 'rb') as fp_:
+                            buf = True
+                            edge = ''
                             buf = fp_.read(buf_size).lower()
-                except (IOError, OSError) as exc:
+                            while buf:
+                                buf = edge + buf
+                                for item in supported_inits:
+                                    if item in buf:
+                                        grains['init'] = item
+                                        buf = ''
+                                        break
+                                edge = buf[-edge_len:]
+                                buf = fp_.read(buf_size).lower()
+                    except (IOError, OSError) as exc:
+                        log.error(
+                            'Unable to read from init_bin ({0}): {1}'
+                            .format(init_bin, exc)
+                        )
+                else:
                     log.error(
-                        'Unable to read from init_bin ({0}): {1}'
-                        .format(init_bin, exc)
+                        'Could not determine init location from command line: ({0})'
+                        .format(' '.join(init_cmdline))
                     )
 
         # Add lsb grains on any distro with lsb-release


### PR DESCRIPTION
When the minion is run as a user without privelidge to see the init
binary the minion will not start. i.e. normal user and init is in /sbin/.
#24531 removed some paths from $PATH which caused this to error in

 develop, if #24531 is backported this should be as well.
