### PR TITLE
Fix: minion doesn't set tok property in masters list case.

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -807,6 +807,7 @@ class Minion(MinionBase):
                        'the minions connection attempt.')
                 log.error(msg)
             else:
+                self.tok = pub_channel.auth.gen_token('salt')
                 self.connected = True
                 raise tornado.gen.Return((opts['master'], pub_channel))
 


### PR DESCRIPTION
If master entry in minion config is a list of 1 or more items the following error appears and minion doesn't start:

```
[ERROR   ] Minion failed to start: 
Traceback (most recent call last):
  File "/home/dimm/projects/salt/git/salt/salt/scripts.py", line 81, in minion_process
    minion.start()
  File "/home/dimm/projects/salt/git/salt/salt/cli/daemons.py", line 269, in start
    self.minion.tune_in()
  File "/home/dimm/projects/salt/git/salt/salt/minion.py", line 1624, in tune_in
    self._fire_master_minion_start()
  File "/home/dimm/projects/salt/git/salt/salt/minion.py", line 1312, in _fire_master_minion_start
    'minion_start'
  File "/home/dimm/projects/salt/git/salt/salt/minion.py", line 913, in _fire_master
    'tok': self.tok}
AttributeError: 'Minion' object has no attribute 'tok'
```

It's because minion doesn't set tok field after connect to master succeed in master list case.

Related to #21082 
