### PR TITLE
Adding entropy note for gpg renderer

### DIFF
--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -24,6 +24,13 @@ run:
 Do not supply a password for your keypair, and use a name that makes sense
 for your application. Be sure to back up your gpg directory someplace safe!
 
+.. note::
+    Unfortunately, there are some scenarios - for example, on virtual machines
+    which don’t have real hardware - where insufficient entropy causes key
+    generation to be extremely slow. If you come across this problem, you should
+    investigate means of increasing the system entropy. On virtualised Linux
+    systems, this can often be achieved by installing the rng-tools package.
+
 To retrieve the public key:
 
 .. code-block:: bash


### PR DESCRIPTION
Figured its worth adding a note to the `gpg` renderer. The snippet is a sample from `python-gpg`: https://pythonhosted.org/python-gnupg/#performance-issues

Also noticed there was a similar note already in the gpg module: http://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.gpg.html but I think its worth noting it in the renderer as well.
