### PR TITLE
Introduce standard error output when cli exits with non-zero status

### DIFF
--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -74,6 +74,7 @@ class SaltCMD(parsers.SaltCMDOptionParser):
                     if tok:
                         eauth['token'] = tok.get('token', '')
                 if not res:
+                    sys.stderr.write('ERROR: Authentication failed\n')
                     sys.exit(2)
                 eauth.update(res)
                 eauth['eauth'] = self.options.eauth
@@ -100,6 +101,7 @@ class SaltCMD(parsers.SaltCMDOptionParser):
                         for ret in res.itervalues():
                             retcode = salt.utils.job.get_retcode(ret)
                             if retcode != 0:
+                                sys.stderr.write('ERROR: Minions returned with non-zero exit code\n')
                                 sys.exit(retcode)
 
         else:
@@ -150,6 +152,7 @@ class SaltCMD(parsers.SaltCMDOptionParser):
                     if tok:
                         kwargs['token'] = tok.get('token', '')
                 if not res:
+                    sys.stderr.write('ERROR: Authentication failed\n')
                     sys.exit(2)
                 kwargs.update(res)
                 kwargs['eauth'] = self.options.eauth
@@ -213,6 +216,7 @@ class SaltCMD(parsers.SaltCMDOptionParser):
                     # This is the final point before the 'salt' cmd returns,
                     # which is why we set the retcode here.
                     if retcodes.count(0) < len(retcodes):
+                        sys.stderr.write('ERROR: Minions returned with non-zero exit code\n')
                         sys.exit(11)
 
             except (SaltInvocationError, EauthAuthenticationError, SaltClientError) as exc:
@@ -283,6 +287,7 @@ class SaltCMD(parsers.SaltCMDOptionParser):
             # Determine the proper output method and run it
             salt.output.display_output(ret, out, self.config)
         if not ret:
+            sys.stderr.write('ERROR: No return received\n')
             sys.exit(2)
 
     def _format_ret(self, full_ret):


### PR DESCRIPTION
I've noticed that salt 2015.5 now returns exit codes based on what minions returns. That's great!

Unfortunately, it wasn't clear to me that's the reason my salt commands were exiting with non-zero exit codes. To me it looked like the salt process was crashing with no output.

With this change I propose salt outputs a message to standard error to hint at why it's exiting with non-zero exit code.

Do you agree?
