### PR TITLE
Allow usage of generators in Salt cloud config values

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -2318,7 +2318,7 @@ def get_cloud_config_value(name, vm_, opts, default=None, search_global=True):
     if name and vm_ and name in vm_:
         # The setting name exists in VM configuration.
         if isinstance(vm_[name], types.GeneratorType):
-            value = vm_[name].next()
+            value = next(vm_[name], '')
         else:
             if isinstance(value, dict):
                 value.update(vm_[name].copy())

--- a/salt/config.py
+++ b/salt/config.py
@@ -14,6 +14,7 @@ import time
 import codecs
 import logging
 from copy import deepcopy
+import types
 
 # Import third party libs
 import yaml
@@ -2316,10 +2317,13 @@ def get_cloud_config_value(name, vm_, opts, default=None, search_global=True):
 
     if name and vm_ and name in vm_:
         # The setting name exists in VM configuration.
-        if isinstance(value, dict):
-            value.update(vm_[name].copy())
+        if isinstance(vm_[name], types.GeneratorType):
+            value = vm_[name].next()
         else:
-            value = deepcopy(vm_[name])
+            if isinstance(value, dict):
+                value.update(vm_[name].copy())
+            else:
+                value = deepcopy(vm_[name])
 
     return value
 


### PR DESCRIPTION
This makes code much more readable if one needs to create multiple VMs with different parameters.

Instead of calling multiple times client.create() with different values, a single call can be used with generators as values.

client.create() takes "names" parameter as a list, to spin up multiple instances, this will allow usage of different values for other parameters.
