### PR TITLE
Force arguments to aptpkg.version_cmp into strings

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1123,6 +1123,10 @@ def version_cmp(pkg1, pkg2):
 
         salt '*' pkg.version_cmp '0.2.4-0ubuntu1' '0.2.4.1-0ubuntu1'
     '''
+    # both apt_pkg.version_compare and _cmd_quote need string arguments.
+    pkg1 = str(pkg1)
+    pkg2 = str(pkg2)
+
     # if we have apt_pkg, this will be quickier this way
     # and also do not rely on shell.
     if HAS_APTPKG:


### PR DESCRIPTION
Followup to https://github.com/saltstack/salt/pull/25369

Very commonly a float like `2.4` will be passed to the function due to the way module execution and yaml parsing works. This will throw a TypeError in both `apt_pkg.version_compare` and `_cmd_quote`, which will cause the function to simply return `None`.

For example, this is 2015.5 after removing the try/except block around the `apt_pkg.version_compare` function call:

```
test_state:
  test.fail_without_changes:
    - name: "{{ salt.pkg.version_cmp('2.5', '2.4') }}"

          ID: test_state
    Function: test.fail_without_changes
        Name: {'_error': 'Failed to return clean data', 'stderr': 'Passed invalid arguments: must be string or read-only buffer, not float', 'stdout': ''}
```
