### PR TITLE
extended documentation about dependencies for dig module

### DIFF
--- a/salt/modules/dig.py
+++ b/salt/modules/dig.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 '''
-Compendium of generic DNS utilities
+Compendium of generic DNS utilities. 
+You'll need to have the `dig` command line tool installed in order 
+to use this module.
 '''
 from __future__ import absolute_import
 

--- a/salt/modules/dig.py
+++ b/salt/modules/dig.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Compendium of generic DNS utilities. 
-You'll need to have the `dig` command line tool installed in order 
-to use this module.
+Compendium of generic DNS utilities.
+The 'dig' command line tool must be installed in order to use this module.
 '''
 from __future__ import absolute_import
 


### PR DESCRIPTION
`dig` command line tool is required for this module to be loaded (see `__virtual__()`)
