### PR TITLE
[docs] return will not work in the context in which it is shown

### DIFF
--- a/doc/ref/states/requisites.rst
+++ b/doc/ref/states/requisites.rst
@@ -600,7 +600,7 @@ same privileges as the salt-minion.
         - pattern: ^enabled=0
         - repl: enabled=1
         - check_cmd:
-          - grep 'enabled=0' /etc/yum.repos.d/fedora.repo && return 1 || return 0
+          - grep 'enabled=0' /etc/yum.repos.d/fedora.repo && exit 1 || exit 0
 
 This will attempt to do a replace on all enabled=0 in the .repo file, and
 replace them with enabled=1. The check_cmd is just a bash command. It will do


### PR DESCRIPTION
return will always throw an error when called in the context it's being used in the example - should be exit.

root@master:/etc/salt# salt minion1 cmd.retcode 'echo && return 2 || return 3' python_shell=True
minion1:
    1
