### PR TITLE
Saltnado runner client results in blocking call despite being set-up as Runner.async

### DIFF
--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -1023,14 +1023,7 @@ class SaltAPIHandler(BaseSaltAPIHandler, SaltClientsMixIn):  # pylint: disable=W
         '''
         f_call = {'args': [chunk['fun'], chunk]}
         pub_data = self.saltclients['runner'](chunk['fun'], chunk)
-        tag = pub_data['tag'] + '/ret'
-        try:
-            event = yield self.application.event_listener.get_event(self, tag=tag)
-
-            # only return the return data
-            raise tornado.gen.Return(event['data']['return'])
-        except TimeoutException:
-            raise tornado.gen.Return('Timeout waiting for runner to execute')
+        raise tornado.gen.Return(pub_data)
 
 
 class MinionSaltAPIHandler(SaltAPIHandler):  # pylint: disable=W0223


### PR DESCRIPTION
Despite [being set up as an asynchronous client](https://github.com/saltstack/salt/blob/develop/salt/netapi/rest_tornado/saltnado.py#L219), the saltnado call blocks until it returns. The expected behavior is immediately returning object containing a `jid`, the same response as using `client=local_async`.

Steps:
1. `POST` a command to `/` using `client=runner`, example `POST` body: 
`fun=state.orchestrate&client=runner&mods=orchestrate.my_orchestrate&pillar={}`

Salt master running on Linux CentOS6. Relevant output of `salt --versions-report`:

```
Salt: 2015.5.2
Python: 2.6.6 (r266:84292, Jan 22 2014, 09:42:36)
Jinja2: 2.7.2
```

A more desirable fix may be to add a new client, `runner_async`, and convert the current runner to a synchronous model, inline with `client=local`. For my use case, this fix is perfectly fine as we want everything running async.
