### PR TITLE
Detect Apache CloudStack KVM Hypervisor in core grain

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -453,6 +453,10 @@ def _windows_virtual(osdata):
     # Manufacturer: Parallels Software International Inc.
     elif 'Parallels Software' in osdata.get('manufacturer'):
         grains['virtual'] = 'Parallels'
+    # Apache CloudStack
+    elif 'CloudStack KVM Hypervisor' in osdata.get('productname', ''):
+        grains['virtual'] = 'kvm'
+        grains['virtual_subtype'] = 'cloudstack'
     return grains
 
 


### PR DESCRIPTION
In the next Apache CloudStack release the KVM Hypervisor will provide
additional information via smbios to the guest.

This allows SaltStack to detect that the machine is running inside
KVM on Apache CloudStack.
