### PR TITLE
Reduce digital_ocean API call frequency

### DIFF
--- a/doc/topics/releases/beryllium.rst
+++ b/doc/topics/releases/beryllium.rst
@@ -19,6 +19,9 @@ Salt Cloud Changes
 
 - Modified the Linode Salt Cloud driver to use Linode's native API instead of
   depending on apache-libcloud or linode-python.
+- When querying for VMs in ``ditigal_ocean.py``, the number of VMs to include in
+  a page was changed from 20 (default) to 200 to reduce the number of API calls
+  to Digital Ocean.
 
 JBoss 7 State
 =============

--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -122,7 +122,7 @@ def avail_images(call=None):
     ret = {}
 
     while fetch:
-        items = query(method='images', command='?page=' + str(page))
+        items = query(method='images', command='?page=' + str(page) + '&per_page=200')
 
         for image in items['images']:
             ret[image['id']] = {}
@@ -172,7 +172,7 @@ def list_nodes(call=None):
     ret = {}
 
     while fetch:
-        items = query(method='droplets', command='?page=' + str(page))
+        items = query(method='droplets', command='?page=' + str(page) + '&per_page=200')
         for node in items['droplets']:
             ret[node['name']] = {
                 'id': node['id'],
@@ -204,7 +204,7 @@ def list_nodes_full(call=None, forOutput=True):
     ret = {}
 
     while fetch:
-        items = query(method='droplets', command='?page=' + str(page))
+        items = query(method='droplets', command='?page=' + str(page) + '&per_page=200')
         for node in items['droplets']:
             ret[node['name']] = {}
             for item in six.iterkeys(node):


### PR DESCRIPTION
Fixes #25431 

This is the same change as in #25438, but since the module names have been changed as `digital_ocean_v2.py` doesn't exist in 2015.8 and onwards, the change wouldn't have merged forward.
