### PR TITLE
openbsd-rcctl: use new syntax to speed up listing services

### DIFF
--- a/salt/modules/openbsdrcctl.py
+++ b/salt/modules/openbsdrcctl.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import
 
 # Import python libs
 import os
-import re
 
 # Import salt libs
 import salt.utils
@@ -94,7 +93,7 @@ def get_all():
     ret = []
     service = _cmd()
     for svc in __salt__['cmd.run']('{0} ls all'.format(service)).splitlines():
-            ret.append(svc)
+        ret.append(svc)
     return sorted(ret)
 
 
@@ -111,7 +110,7 @@ def get_disabled():
     ret = []
     service = _cmd()
     for svc in __salt__['cmd.run']('{0} ls off'.format(service)).splitlines():
-            ret.append(svc)
+        ret.append(svc)
     return sorted(ret)
 
 
@@ -128,7 +127,7 @@ def get_enabled():
     ret = []
     service = _cmd()
     for svc in __salt__['cmd.run']('{0} ls on'.format(service)).splitlines():
-            ret.append(svc)
+        ret.append(svc)
     return sorted(ret)
 
 

--- a/salt/modules/openbsdrcctl.py
+++ b/salt/modules/openbsdrcctl.py
@@ -91,12 +91,9 @@ def get_all():
 
         salt '*' service.get_all
     '''
-    badvar = ("_timeout", "_user")
     ret = []
     service = _cmd()
-    for svc in __salt__['cmd.run']('{0} getall'.format(service)).splitlines():
-        svc = re.sub('(_flags|)=.*$', '', svc)
-        if not svc.endswith(badvar):
+    for svc in __salt__['cmd.run']('{0} ls all'.format(service)).splitlines():
             ret.append(svc)
     return sorted(ret)
 
@@ -111,14 +108,10 @@ def get_disabled():
 
         salt '*' service.get_disabled
     '''
-    badvar = ("_timeout", "_user")
     ret = []
     service = _cmd()
-    for svc in __salt__['cmd.run']('{0} getall'.format(service)).splitlines():
-        if svc.endswith("=NO"):
-            svc = re.sub('(_flags|)=.*$', '', svc)
-            if not svc.endswith(badvar):
-                ret.append(svc)
+    for svc in __salt__['cmd.run']('{0} ls off'.format(service)).splitlines():
+            ret.append(svc)
     return sorted(ret)
 
 
@@ -132,14 +125,10 @@ def get_enabled():
 
         salt '*' service.get_enabled
     '''
-    badvar = ("_timeout", "_user")
     ret = []
     service = _cmd()
-    for svc in __salt__['cmd.run']('{0} getall'.format(service)).splitlines():
-        if not svc.endswith("=NO"):
-            svc = re.sub('(_flags|)=.*$', '', svc)
-            if not svc.endswith(badvar):
-                ret.append(svc)
+    for svc in __salt__['cmd.run']('{0} ls on'.format(service)).splitlines():
+            ret.append(svc)
     return sorted(ret)
 
 


### PR DESCRIPTION
I just introduced a new subcommand to rcctl(8) in OpenBSD that allows
querying for services (all, enabled, disabled, ...) so make salt use it.
