### PR TITLE
Fix .bak file overload on gentoo and some wildcard support for portage_config

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -140,6 +140,10 @@ M2Crypto installed using apt::
 
     virtualenv --system-site-packages /path/to/your/virtualenv
 
+On Gentoo systems you should use ``--system-site-packages`` when creating
+the virtualenv to enable pkg and portage_config functionality as the
+portage package is not available via pip
+
 .. note:: Using your system Python modules in the virtualenv
 
     If you have the required python modules installed on your system already

--- a/doc/topics/development/hacking.rst
+++ b/doc/topics/development/hacking.rst
@@ -35,8 +35,12 @@ Create a new `virtualenv`_:
 .. _`virtualenv`: https://pypi.python.org/pypi/virtualenv
 
 Avoid making your :ref:`virtualenv path too long <too_long_socket_path>`.
+
 On Arch Linux, where Python 3 is the default installation of Python, use
 the ``virtualenv2`` command instead of ``virtualenv``.
+
+On Gentoo you must use ``--system-site-packages`` to enable pkg and portage_config
+functionality
 
 .. note:: Using system Python modules in the virtualenv
 

--- a/salt/modules/portage_config.py
+++ b/salt/modules/portage_config.py
@@ -70,7 +70,8 @@ def _get_config_file(conf, atom):
         if not parts:
             return
         if parts.cp == '*/*':
-            relative_path = parts.repo
+            # parts.repo will be empty if there is no repo part
+            relative_path = parts.repo or "gentoo"
         else:
             relative_path = os.path.join(*[x for x in os.path.split(parts.cp) if x != '*'])
     else:

--- a/tests/unit/modules/portage_config.py
+++ b/tests/unit/modules/portage_config.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Ryan Lewis (ryansname@gmail.com)`
+
+    tests.unit.modules.portage_flags
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+'''
+
+
+# Import Python libs
+from __future__ import absolute_import
+
+# Import Salt Testing libs
+from salttesting import skipIf, TestCase
+from salttesting.helpers import ensure_in_syspath
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
+ensure_in_syspath('../../')
+
+# Import salt libs
+from salt.modules import portage_config
+from salt.exceptions import CommandNotFoundError
+from salt.utils import which_bin
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class PortageConfigTestCase(TestCase):
+    def test_get_config_file_wildcards(self):
+        pairs = [
+            ('*/*::repo', '/etc/portage/package.mask/repo'),
+            ('*/pkg::repo', '/etc/portage/package.mask/pkg'),
+            ('cat/*', '/etc/portage/package.mask/cat'),
+            ('cat/pkg', '/etc/portage/package.mask/cat/pkg'),
+            ('cat/pkg::repo', '/etc/portage/package.mask/cat/pkg'),
+        ]
+
+        for (atom, expected) in pairs:
+            self.assertEqual(portage_config._get_config_file('mask', atom), expected)
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(PortageConfigTestCase, needs_daemon=False)

--- a/tests/unit/modules/portage_config.py
+++ b/tests/unit/modules/portage_config.py
@@ -5,21 +5,17 @@
     tests.unit.modules.portage_flags
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 '''
-
-
 # Import Python libs
 from __future__ import absolute_import
 
 # Import Salt Testing libs
 from salttesting import skipIf, TestCase
 from salttesting.helpers import ensure_in_syspath
-from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON
 ensure_in_syspath('../../')
 
 # Import salt libs
 from salt.modules import portage_config
-from salt.exceptions import CommandNotFoundError
-from salt.utils import which_bin
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)


### PR DESCRIPTION
The first change here is to fix hundreds of .bak files being generated on my machine when there is a wildcard atom in one for the configuration sections. This was done by creating a portage.dep.Atom instance to validate the atom instead of searching the portage cache.
If there are wildcards are present the 'correct' file for the config is whichever part of the atom that does not have a wildcard. i.e. `*/gtk2 -> /etc/portage/package.mask/gtk2`, if both are wildcards the repo name becomes the file: `*/*::reponame -> /etc/portage/package.mask/reponame`.

This is useful for masking off overlays or applying use flags to categories of packages.

Although technically valid there is still no support for wildcards being part of the atom -> `sys-lib/gtk*`.

I've also added some documentation changes for a gotcha that had me stuck for the longest time when I was setting up the development environment.

If you need anything moved to a separate pull reqeust or squashed, or if there are more things I should do then please let me know.
