### PR TITLE
[WIP] More IPC!

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,6 +3,6 @@ msgpack-python > 0.3
 PyYAML
 MarkupSafe
 requests >= 1.0.0
-tornado >= 4.0
+tornado >= 4.2
 # Required by Tornado to handle threads stuff.
 futures >= 2.0

--- a/salt/transport/frame.py
+++ b/salt/transport/frame.py
@@ -25,7 +25,7 @@ def frame_msg(body, header=None, raw_body=False):
 
     framed_msg['head'] = header
     framed_msg['body'] = body
-    framed_msg_packed = msgpack.packb(framed_msg, encoding='utf-8')
+    framed_msg_packed = msgpack.packb(framed_msg)
     msg = six.b('{0} '.format(len(framed_msg_packed)))
     msg += framed_msg_packed
     return msg

--- a/salt/transport/frame.py
+++ b/salt/transport/frame.py
@@ -4,7 +4,10 @@ Helper functions for transport components to handle message framing
 '''
 # Import python libs
 from __future__ import absolute_import
+
+# Import 3rd-party libs
 import msgpack
+import salt.ext.six as six
 
 
 # TODO: remove raw_body??
@@ -22,5 +25,7 @@ def frame_msg(body, header=None, raw_body=False):
 
     framed_msg['head'] = header
     framed_msg['body'] = body
-    framed_msg_packed = msgpack.dumps(framed_msg)
-    return '{0} {1}'.format(len(framed_msg_packed), framed_msg_packed)
+    framed_msg_packed = msgpack.packb(framed_msg)
+    msg = six.b('{0} '.format(len(framed_msg_packed)))
+    msg += framed_msg_packed
+    return msg

--- a/salt/transport/frame.py
+++ b/salt/transport/frame.py
@@ -25,7 +25,7 @@ def frame_msg(body, header=None, raw_body=False):
 
     framed_msg['head'] = header
     framed_msg['body'] = body
-    framed_msg_packed = msgpack.packb(framed_msg)
+    framed_msg_packed = msgpack.packb(framed_msg, encoding='utf-8')
     msg = six.b('{0} '.format(len(framed_msg_packed)))
     msg += framed_msg_packed
     return msg

--- a/salt/transport/frame.py
+++ b/salt/transport/frame.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 import msgpack
 
 
+# TODO: remove raw_body??
 def frame_msg(body, header=None, raw_body=False):
     '''
     Frame the given message with our wire protocol

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -28,6 +28,15 @@ from salt.exceptions import SaltReqTimeoutError
 # Import 3rd-party libs
 import salt.ext.six as six
 
+try:
+    MAXSIZE = sys.maxint
+except AttributeError:
+    if not six.PY3:
+        raise
+    # sys.maxint does not exist under Python 3 its integer type has no limits aside from memory.
+    # Let's default to sys.maxsize which in Python 2 equals sys.maxint
+    MAXSIZE = sys.maxsize
+
 log = logging.getLogger(__name__)
 
 
@@ -198,7 +207,7 @@ class IPCClient(object):
         self.subscribe_handlers = []
         self._mid = 1
         # TODO: move to config
-        self._max_messages = sys.maxint - 1  # number of IDs before we wrap
+        self._max_messages = MAXSIZE - 1  # number of IDs before we wrap
 
         # Maximum number of inflight messages
         self.maxflight = 5  # TODO: config

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -369,7 +369,6 @@ class IPCClient(object):
         '''
         timeout a given message_id
         '''
-        log.trace('Timing out message_id {0} on {1}'.format(message_id, self.socket_path))
         del self.timeout_map[message_future]
         if message_future in self.send_queue:
             log.trace('Timing out future from send queue')

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -116,7 +116,6 @@ class IPCServer(object):
                                             body,
                                             write_callback(stream, framed_msg['head']))
             except Exception as exc:
-                log.exception(exc)
                 log.error('Exception occurred while handling stream: {0}'.format(exc),
                           exc_info_on_loglevel=logging.DEBUG)
 

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -421,6 +421,9 @@ class IPCClient(object):
         self.send_queue.append(future)
         return future
 
+    # TODO: don't go through the regular queue. Right now if maxflight messages
+    # are out and we do a publish it won't go until one of those other messages
+    # completes
     def publish(self, msg, timeout=None, callback=None):
         '''
         Publish a message (send without expecting a response. Return a future

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -23,7 +23,7 @@ from tornado.iostream import IOStream
 import salt.transport.client
 import salt.transport.frame
 import salt.utils.async
-from salt.exceptions import SaltReqTimeoutError, SaltClientError
+from salt.exceptions import SaltReqTimeoutError
 
 log = logging.getLogger(__name__)
 
@@ -85,7 +85,7 @@ class IPCServer(object):
                 f = client.write(payload)
                 self.io_loop.add_future(f, lambda f: True)
             except tornado.iostream.StreamClosedError:
-                to_remove.append(item)
+                to_remove.append(client)
         for client in to_remove:
             client.close()
             self.clients.remove(client)
@@ -222,7 +222,6 @@ class IPCClient(object):
                 self._mid += 2
 
         return self._mid
-
 
     def __init__(self, socket_path, io_loop=None):
         # Handled by singleton __new__

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -228,9 +228,9 @@ class IPCClient(object):
         self.maxflight = 5  # TODO: config
 
         # queue of messages to send
-        self.send_queue = []
+        self.send_queue = []  # TODO: HWM
         # queue of messages we recieved (published remotely)
-        self.recv_queue = tornado.queues.Queue()  # TODO: HWM
+        self.recv_queue = tornado.queues.Queue(maxsize=500)  # TODO: configurable HWM
 
         # mapping of message_id -> future
         self.inflight_messages = {}
@@ -522,6 +522,7 @@ class IPCClient(object):
             timeout = time.time() + timeout
 
         msg = yield self.recv_queue.get(timeout=timeout)
+        self.recv_queue.task_done()
         raise tornado.gen.Return(msg)
 
     def subscribe(self):

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -299,7 +299,7 @@ class IPCClient(object):
                 self._connecting_future.set_result(True)
                 break
             except Exception as exc:
-                log.critical('foo', exc_info=True)
+                log.error('Exception connecting to {0}'.format(self.ipc_url), exc_info_on_loglevel=logging.DEBUG)
                 yield tornado.gen.sleep(1)  # TODO: backoff
                 #self._connecting_future.set_exception(exc)
 

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -119,7 +119,7 @@ class IPCServer(object):
             try:
                 framed_msg_len = yield stream.read_until(six.b(' '))
                 framed_msg_raw = yield stream.read_bytes(int(framed_msg_len.strip()))
-                framed_msg = msgpack.loads(framed_msg_raw, encoding='utf-8')
+                framed_msg = msgpack.loads(framed_msg_raw)
                 body = framed_msg['body']
                 self.io_loop.spawn_callback(self.payload_handler,
                                             body,
@@ -305,7 +305,7 @@ class IPCClient(object):
             try:
                 framed_msg_len = yield self.stream.read_until(six.b(' '))
                 framed_msg_raw = yield self.stream.read_bytes(int(framed_msg_len.strip()))
-                framed_msg = msgpack.loads(framed_msg_raw, encoding='utf-8')
+                framed_msg = msgpack.loads(framed_msg_raw)
                 header = framed_msg['head']
                 message_id = header.get('mid')
                 body = framed_msg['body']

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -120,13 +120,16 @@ class IPCServer(object):
                 framed_msg_len = yield stream.read_until(six.b(' '))
                 framed_msg_raw = yield stream.read_bytes(int(framed_msg_len.strip()))
                 framed_msg = msgpack.loads(framed_msg_raw)
-                body = framed_msg['body']
-                self.io_loop.spawn_callback(self.payload_handler,
-                                            body,
-                                            write_callback(stream, framed_msg['head']))
+                self.io_loop.spawn_callback(
+                    self.payload_handler,
+                    framed_msg['body'],
+                    write_callback(stream, framed_msg['head']),
+                )
             except Exception as exc:
-                log.error('Exception occurred while handling stream: {0}'.format(exc),
-                          exc_info_on_loglevel=logging.DEBUG)
+                log.error(
+                    'Exception occurred while handling stream: {0}'.format(exc),
+                     exc_info_on_loglevel=logging.DEBUG,
+                 )
 
         self.clients.remove(stream)
 

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -110,11 +110,11 @@ class IPCServer(object):
             try:
                 framed_msg_len = yield stream.read_until(six.b(' '))
                 framed_msg_raw = yield stream.read_bytes(int(framed_msg_len.strip()))
-                framed_msg = msgpack.loads(framed_msg_raw)
-                body = framed_msg[six.b('body')]
+                framed_msg = msgpack.loads(framed_msg_raw, encoding='utf-8')
+                body = framed_msg['body']
                 self.io_loop.spawn_callback(self.payload_handler,
                                             body,
-                                            write_callback(stream, framed_msg[six.b('head')]))
+                                            write_callback(stream, framed_msg['head']))
             except Exception as exc:
                 log.exception(exc)
                 log.error('Exception occurred while handling stream: {0}'.format(exc),

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -303,22 +303,22 @@ class IPCClient(object):
 
         while not self._closing:
             try:
-                framed_msg_len = yield self.stream.read_until(' ')
+                framed_msg_len = yield self.stream.read_until(six.b(' '))
                 framed_msg_raw = yield self.stream.read_bytes(int(framed_msg_len.strip()))
-                framed_msg = msgpack.loads(framed_msg_raw)
+                framed_msg = msgpack.loads(framed_msg_raw, encoding='utf-8')
                 header = framed_msg['head']
                 message_id = header.get('mid')
                 body = framed_msg['body']
 
                 if message_id is None:
-                    log.trace('Recieved subcribed message on {0}'.format(self.socket_path))
+                    log.trace('Received subscribed message on {0}'.format(self.socket_path))
                     for handler in self.subscribe_handlers:
                         self.io_loop.spawn_callback(handler, body)
                 # otherwise we have a message ID, lets handle it
                 else:
                     # if its odd, then we are getting a return for something we requested
                     if message_id % 2 == 1:
-                        log.trace('Recieved return for message_id {0} on {1}'.format(message_id, self.socket_path))
+                        log.trace('Received return for message_id {0} on {1}'.format(message_id, self.socket_path))
                         message_future = self.inflight_messages.pop(message_id)
                         self.remove_message_timeout(message_future)
                         message_future.set_result(body)

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -663,4 +663,4 @@ class TCPPubServerChannel(salt.transport.server.PubServerChannel):
         if load['tgt_type'] == 'list':
             int_payload['topic_lst'] = load['tgt']
         # Send it over IPC!
-        pub_sock.send(int_payload)
+        pub_sock.publish(int_payload)

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -609,7 +609,7 @@ class TCPPubServerChannel(salt.transport.server.PubServerChannel):
         pub_server.listen(int(self.opts['publish_port']), address=self.opts['interface'])
 
         # Set up Salt IPC server
-        pull_uri = os.path.join(self.opts['sock_dir'], 'publish_pull.ipc')
+        pull_uri = 'ipc://{0}'.format(os.path.join(self.opts['sock_dir'], 'publish_pull.ipc'))
         pull_sock = salt.transport.ipc.IPCMessageServer(
             pull_uri,
             io_loop=self.io_loop,
@@ -648,7 +648,7 @@ class TCPPubServerChannel(salt.transport.server.PubServerChannel):
             log.debug("Signing data packet")
             payload['sig'] = salt.crypt.sign_message(master_pem_path, payload['load'])
         # Use the Salt IPC server
-        pull_uri = os.path.join(self.opts['sock_dir'], 'publish_pull.ipc')
+        pull_uri = 'ipc://{0}'.format(os.path.join(self.opts['sock_dir'], 'publish_pull.ipc'))
         # TODO: switch to the actual async interface
         #pub_sock = salt.transport.ipc.IPCMessageClient(self.opts, io_loop=self.io_loop)
         pub_sock = salt.utils.async.SyncWrapper(

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -650,7 +650,6 @@ class TCPPubServerChannel(salt.transport.server.PubServerChannel):
         # Use the Salt IPC server
         pull_uri = 'ipc://{0}'.format(os.path.join(self.opts['sock_dir'], 'publish_pull.ipc'))
         # TODO: switch to the actual async interface
-        #pub_sock = salt.transport.ipc.IPCMessageClient(self.opts, io_loop=self.io_loop)
         pub_sock = salt.utils.async.SyncWrapper(
             salt.transport.ipc.IPCMessageClient,
             (pull_uri,)

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -438,7 +438,6 @@ class SaltMessageClient(object):
                 break
             except Exception as e:
                 yield tornado.gen.sleep(1)  # TODO: backoff
-                #self._connecting_future.set_exception(e)
 
     @tornado.gen.coroutine
     def _stream_return(self):

--- a/salt/utils/async.py
+++ b/salt/utils/async.py
@@ -18,6 +18,7 @@ except ImportError:
 import contextlib
 import weakref
 
+
 class Any(tornado.concurrent.Future):
     '''
     Future that wraps other futures to "block" until one is done

--- a/salt/utils/async.py
+++ b/salt/utils/async.py
@@ -18,6 +18,20 @@ except ImportError:
 import contextlib
 import weakref
 
+class Any(tornado.concurrent.Future):
+    '''
+    Future that wraps other futures to "block" until one is done
+    '''
+    def __init__(self, futures):  # pylint: disable=E1002
+        super(Any, self).__init__()
+        for future in futures:
+            future.add_done_callback(self.done_callback)
+
+    def done_callback(self, future):
+        # Any is completed once one is done, we don't set for the rest
+        if not self.done():
+            self.set_result(future)
+
 
 @contextlib.contextmanager
 def current_ioloop(io_loop):

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -65,6 +65,7 @@ from collections import MutableMapping
 
 # Import third party libs
 import salt.ext.six as six
+import tornado.ioloop
 try:
     import zmq
     import zmq.eventloop.ioloop
@@ -84,6 +85,7 @@ import salt.utils.cache
 import salt.utils.dicttrim
 import salt.utils.process
 import salt.utils.zeromq
+import salt.transport.ipc
 
 log = logging.getLogger(__name__)
 
@@ -174,8 +176,6 @@ class SaltEvent(object):
     '''
     def __init__(self, node, sock_dir=None, opts=None):
         self.serial = salt.payload.Serial({'serial': 'msgpack'})
-        self.context = zmq.Context()
-        self.poller = zmq.Poller()
         self.cpub = False
         self.cpush = False
         if opts is None:
@@ -274,11 +274,12 @@ class SaltEvent(object):
         '''
         Establish the publish connection
         '''
-        self.sub = self.context.socket(zmq.SUB)
-        self.sub.connect(self.puburi)
-        self.poller.register(self.sub, zmq.POLLIN)
-        self.sub.setsockopt_string(zmq.SUBSCRIBE, u'')
-        self.sub.setsockopt(zmq.LINGER, 5000)
+        self.sub = salt.utils.async.SyncWrapper(
+            salt.transport.ipc.IPCMessageClient,
+            (self.puburi,)
+        )
+        self.sub.subscribe()
+        self.sub.connect_async()
         self.cpub = True
 
     def connect_pull(self, timeout=1000):
@@ -287,9 +288,11 @@ class SaltEvent(object):
         Set the linger timeout of the socket options to timeout (in milliseconds)
         Default timeout is 1000 ms
         '''
-        self.push = self.context.socket(zmq.PUSH)
-        self.push.setsockopt(zmq.LINGER, timeout)
-        self.push.connect(self.pulluri)
+        self.push = salt.utils.async.SyncWrapper(
+            salt.transport.ipc.IPCMessageClient,
+            (self.pulluri,)
+        )
+        self.push.connect_async()
         self.cpush = True
 
     @classmethod
@@ -370,19 +373,11 @@ class SaltEvent(object):
         timeout_at = start + wait
         while not wait or time.time() <= timeout_at:
             try:
-                # convert to milliseconds
-                socks = dict(self.poller.poll(wait * 1000))
-                if socks.get(self.sub) != zmq.POLLIN:
-                    continue
-
-                # Please do not use non-blocking mode here. Reliability is
-                # more important than pure speed on the event bus.
-                ret = self.get_event_block()
-            except zmq.ZMQError as ex:
-                if ex.errno == errno.EAGAIN or ex.errno == errno.EINTR:
-                    continue
-                else:
-                    raise
+                recv_timeout = (timeout_at - time.time()) if wait > 0 else None
+                raw = self.sub.recv(timeout=recv_timeout)
+                ret = self._deserialize_event(raw)
+            except Exception as ex:  # TODO: more specific exception
+                continue
 
             if not match_func(ret['tag'], tag):     # tag not match
                 if any(match_func(ret['tag'], ptag) for ptag in pending_tags):
@@ -447,6 +442,10 @@ class SaltEvent(object):
         else:
             return ret['data']
 
+    def _deserialize_event(self, raw):
+        mtag, data = self.unpack(raw, self.serial)
+        return {'data': data, 'tag': mtag}
+
     def get_event_noblock(self):
         '''Get the raw event without blocking or any other niceties
         '''
@@ -502,7 +501,7 @@ class SaltEvent(object):
         log.debug('Sending event - data = {0}'.format(data))
         event = '{0}{1}{2}'.format(tag, tagend, serialized_data)
         try:
-            self.push.send(salt.utils.to_bytes(event, 'utf-8'))
+            self.push.publish(salt.utils.to_bytes(event, 'utf-8'))
         except Exception as ex:
             log.debug(ex)
             raise
@@ -531,31 +530,6 @@ class SaltEvent(object):
             self.sub.close()
         if self.cpush is True and self.push.closed is False:
             self.push.close()
-        # If sockets are not unregistered from a poller, nothing which touches
-        # that poller gets garbage collected. The Poller itself, its
-        # registered sockets and the Context
-        if isinstance(self.poller.sockets, dict):
-            for socket in six.iterkeys(self.poller.sockets):
-                if socket.closed is False:
-                    socket.setsockopt(zmq.LINGER, linger)
-                    socket.close()
-                self.poller.unregister(socket)
-        else:
-            for socket in self.poller.sockets:
-                if socket[0].closed is False:
-                    socket[0].setsockopt(zmq.LINGER, linger)
-                    socket[0].close()
-                self.poller.unregister(socket[0])
-        if self.context.closed is False:
-            self.context.term()
-
-        # Hardcore destruction
-        if hasattr(self.context, 'destroy'):
-            self.context.destroy(linger=1)
-
-        # https://github.com/zeromq/pyzmq/issues/173#issuecomment-4037083
-        # Assertion failed: get_load () == 0 (poller_base.cpp:32)
-        time.sleep(0.025)
 
     def fire_ret_load(self, load):
         '''
@@ -656,7 +630,6 @@ class AsyncEventPublisher(object):
         self.publish_handler = publish_handler
 
         self.io_loop = io_loop or zmq.eventloop.ioloop.ZMQIOLoop()
-        self.context = zmq.Context()
 
         hash_type = getattr(hashlib, self.opts.get('hash_type', 'md5'))
         # Only use the first 10 chars to keep longer hashes from exceeding the
@@ -674,8 +647,6 @@ class AsyncEventPublisher(object):
         )
         if os.path.exists(epull_sock_path):
             os.unlink(epull_sock_path)
-
-        self.epub_sock = self.context.socket(zmq.PUB)
 
         if self.opts.get('ipc_mode', '') == 'tcp':
             epub_uri = 'tcp://127.0.0.1:{0}'.format(
@@ -699,6 +670,17 @@ class AsyncEventPublisher(object):
             '{0} PULL socket URI: {1}'.format(
                 self.__class__.__name__, epull_uri
             )
+        )
+
+        self.epub_sock = salt.transport.ipc.IPCMessageServer(
+            epub_uri,
+            io_loop=self.io_loop,
+        )
+
+        self.epull_sock = salt.transport.ipc.IPCMessageServer(
+            epull_uri,
+            io_loop=self.io_loop,
+            payload_handler=self.handle_publish,
         )
 
         # Check to make sure the sock_dir is available, create if not
@@ -728,31 +710,24 @@ class AsyncEventPublisher(object):
                     # Let's stop at this stage
                     raise
 
-        # Create the pull socket
-        self.epull_sock = self.context.socket(zmq.PULL)
-
         # Securely bind the event sockets
         if self.opts.get('ipc_mode', '') != 'tcp':
             old_umask = os.umask(0o177)
         try:
             log.info('Starting pub socket on {0}'.format(epub_uri))
-            self.epub_sock.bind(epub_uri)
+            self.epub_sock.start()
             log.info('Starting pull socket on {0}'.format(epull_uri))
-            self.epull_sock.bind(epull_uri)
+            self.epull_sock.start()
         finally:
             if self.opts.get('ipc_mode', '') != 'tcp':
                 os.umask(old_umask)
 
-        self.stream = zmq.eventloop.zmqstream.ZMQStream(self.epull_sock, io_loop=self.io_loop)
-        self.stream.on_recv(self.handle_publish)
-
-    def handle_publish(self, package):
+    def handle_publish(self, package, _):
         '''
         Get something from epull, publish it out epub, and return the package (or None)
         '''
-        package = package[0]
         try:
-            self.epub_sock.send(package)
+            self.epub_sock.publish(package)
             self.io_loop.spawn_callback(self.publish_handler, package)
             return package
         # Add an extra fallback in case a forked process leeks through
@@ -795,13 +770,8 @@ class EventPublisher(multiprocessing.Process):
         Bind the pub and pull sockets for events
         '''
         salt.utils.appendproctitle(self.__class__.__name__)
-        linger = 5000
-        # Set up the context
-        self.context = zmq.Context(1)
-        # Prepare the master event publisher
-        self.epub_sock = self.context.socket(zmq.PUB)
-        # Prepare master event pull socket
-        self.epull_sock = self.context.socket(zmq.PULL)
+        self.io_loop = tornado.ioloop.IOLoop()
+
         if self.opts.get('ipc_mode', '') == 'tcp':
             epub_uri = 'tcp://127.0.0.1:{0}'.format(
                 self.opts.get('tcp_master_pub_port', 4512)
@@ -819,38 +789,42 @@ class EventPublisher(multiprocessing.Process):
                 )
             salt.utils.zeromq.check_ipc_path_max_len(epull_uri)
 
-        # Start the master event publisher
-        old_umask = os.umask(0o177)
+        self.epub_sock = salt.transport.ipc.IPCMessageServer(
+            epub_uri,
+            io_loop=self.io_loop,
+        )
+        self.epull_sock = salt.transport.ipc.IPCMessageServer(
+            epull_uri,
+            io_loop=self.io_loop,
+            payload_handler=self.handle_publish,
+        )
+
+        self.epub_sock.start()
+        self.epull_sock.start()
         try:
-            self.epull_sock.bind(epull_uri)
-            self.epub_sock.bind(epub_uri)
-            if (self.opts.get('ipc_mode', '') != 'tcp' and (
-                    self.opts.get('client_acl') or
-                    self.opts.get('external_auth'))):
-                os.chmod(os.path.join(
-                    self.opts['sock_dir'], 'master_event_pub.ipc'), 0o666)
-        finally:
-            os.umask(old_umask)
-        try:
-            while True:
-                # Catch and handle EINTR from when this process is sent
-                # SIGUSR1 gracefully so we don't choke and die horribly
-                try:
-                    package = self.epull_sock.recv()
-                    self.epub_sock.send(package)
-                except zmq.ZMQError as exc:
-                    if exc.errno == errno.EINTR:
-                        continue
-                    raise exc
+            self.io_loop.start()
         except KeyboardInterrupt:
-            if self.epub_sock.closed is False:
-                self.epub_sock.setsockopt(zmq.LINGER, linger)
-                self.epub_sock.close()
-            if self.epull_sock.closed is False:
-                self.epull_sock.setsockopt(zmq.LINGER, linger)
-                self.epull_sock.close()
-            if self.context.closed is False:
-                self.context.term()
+            self.epub_sock.close()
+            self.epull_sock.close()
+
+    def handle_publish(self, package, _):
+        '''
+        Get something from epull, publish it out epub, and return the package (or None)
+        '''
+        try:
+            self.epub_sock.publish(package)
+            return package
+        # Add an extra fallback in case a forked process leeks through
+        except zmq.ZMQError as exc:
+            # The interrupt caused by python handling the
+            # SIGCHLD. Throws this error with errno == EINTR.
+            # Nothing to receive on the zmq socket throws this error
+            # with EAGAIN.
+            # Both are safe to ignore
+            if exc.errno != errno.EAGAIN and exc.errno != errno.EINTR:
+                log.critical('Unexpected ZMQError while polling minion',
+                             exc_info=True)
+            return None
 
 
 class EventReturn(multiprocessing.Process):

--- a/tests/unit/transport/ipc_test.py
+++ b/tests/unit/transport/ipc_test.py
@@ -32,12 +32,12 @@ log = logging.getLogger(__name__)
 ensure_in_syspath('../')
 
 
-class BaseIPCReqCase(tornado.testing.AsyncTestCase):
+class BaseIPCCase(tornado.testing.AsyncTestCase):
     '''
     Test the req server/client pair
     '''
     def setUp(self):
-        super(BaseIPCReqCase, self).setUp()
+        super(BaseIPCCase, self).setUp()
         self._start_handlers = dict(self.io_loop._handlers)
         self.socket_path = os.path.join(integration.TMP, 'ipc_test.ipc')
 
@@ -51,7 +51,7 @@ class BaseIPCReqCase(tornado.testing.AsyncTestCase):
         self.payloads = []
 
     def tearDown(self):
-        super(BaseIPCReqCase, self).tearDown()
+        super(BaseIPCCase, self).tearDown()
         failures = []
         self.server_channel.close()
         os.unlink(self.socket_path)
@@ -68,7 +68,7 @@ class BaseIPCReqCase(tornado.testing.AsyncTestCase):
         if isinstance(payload, dict) and payload.get('stop'):
             self.stop()
 
-class IPCClientSendTests(BaseIPCReqCase):
+class IPCClientSendTests(BaseIPCCase):
     '''
     Test for the IPCClient
     '''
@@ -144,7 +144,7 @@ class IPCClientSendTests(BaseIPCReqCase):
         self.assertEqual(self.payloads[:-1], [None, None, 'foo', 'foo'])
 
 
-class IPCClientSubscribeTests(BaseIPCReqCase):
+class IPCClientSubscribeTests(BaseIPCCase):
     '''
     Test for the IPCClient
     '''
@@ -254,4 +254,5 @@ class IPCClientSubscribeTests(BaseIPCReqCase):
 
 if __name__ == '__main__':
     from integration import run_tests
-    run_tests(IPCMessageClient, needs_daemon=False)
+    run_tests(IPCClientSendTests, needs_daemon=False)
+    run_tests(IPCClientSubscribeTests, needs_daemon=False)

--- a/tests/unit/transport/ipc_test.py
+++ b/tests/unit/transport/ipc_test.py
@@ -25,7 +25,6 @@ from salt.ext.six.moves import range
 # Import Salt Testing libs
 import integration
 
-from salttesting.mock import MagicMock
 from salttesting.helpers import ensure_in_syspath
 
 log = logging.getLogger(__name__)
@@ -70,6 +69,7 @@ class BaseIPCCase(tornado.testing.AsyncTestCase):
         yield reply_func(payload)
         if isinstance(payload, dict) and payload.get('stop'):
             self.stop()
+
 
 class IPCClientSendTests(BaseIPCCase):
     '''

--- a/tests/unit/transport/ipc_test.py
+++ b/tests/unit/transport/ipc_test.py
@@ -40,9 +40,10 @@ class BaseIPCCase(tornado.testing.AsyncTestCase):
         super(BaseIPCCase, self).setUp()
         self._start_handlers = dict(self.io_loop._handlers)
         self.socket_path = os.path.join(integration.TMP, 'ipc_test.ipc')
+        self.ipc_url = 'ipc://{0}'.format(self.socket_path)
 
         self.server_channel = salt.transport.ipc.IPCMessageServer(
-            self.socket_path,
+            self.ipc_url,
             io_loop=self.io_loop,
             payload_handler=self._handle_payload,
         )
@@ -77,7 +78,7 @@ class IPCClientSendTests(BaseIPCCase):
     '''
     def _get_channel(self):
         channel = salt.transport.ipc.IPCClient(
-            socket_path=self.socket_path,
+            ipc_url=self.ipc_url,
             io_loop=self.io_loop,
         )
         channel.connect(callback=self.stop)
@@ -175,7 +176,7 @@ class IPCClientSubscribeTests(BaseIPCCase):
     '''
     def _get_channel(self):
         channel = salt.transport.ipc.IPCClient(
-            socket_path=self.socket_path,
+            ipc_url=self.ipc_url,
             io_loop=self.io_loop,
         )
         channel.connect(callback=self.stop)
@@ -283,7 +284,7 @@ class IPCClientPublishTests(BaseIPCCase):
     '''
     def _get_channel(self):
         channel = salt.transport.ipc.IPCClient(
-            socket_path=self.socket_path,
+            ipc_url=self.ipc_url,
             io_loop=self.io_loop,
         )
         channel.connect(callback=self.stop)

--- a/tests/unit/transport/ipc_test.py
+++ b/tests/unit/transport/ipc_test.py
@@ -154,7 +154,10 @@ class IPCClientSendTests(BaseIPCCase):
 
         self.channel.send({'stop': True})
         self.wait()
-        self.assertEqual(self.payloads[:-1], ['foo', 'foo'])
+        local_channel.send({'stop': True})
+        self.wait()
+
+        self.assertEqual(self.payloads.count('foo'), 2)
 
     def test_multistream_errors(self):
         local_channel = self._get_channel()
@@ -167,7 +170,10 @@ class IPCClientSendTests(BaseIPCCase):
 
         self.channel.send({'stop': True})
         self.wait()
-        self.assertEqual(self.payloads[:-1], [None, None, 'foo', 'foo'])
+        local_channel.send({'stop': True})
+        self.wait()
+        self.assertEqual(self.payloads.count('foo'), 2)
+        self.assertEqual(self.payloads.count(None), 2)
 
 
 class IPCClientSubscribeTests(BaseIPCCase):


### PR DESCRIPTION
In this PR I'm planning on replacing the zmq IPC completely within salt (unlike #23236 taking it out for just the publisher).

Note: this is currently a WIP, so feedback is welcome :)

Status: At this point pub/sub and push/pull have been implemented. I plan on implementing a req/rep pattern (even though nothing really uses that in the master as IPC today, except conncache which is zmq specific) similar to how the tcp transport does its message multiplexing. Once thats done I think I'll consolidate it down to a single class to do all the IPC (since I don't think the API will be confusing).

This objective here is to finish out #22694
