### PR TITLE
Fixed 'defulats' typo in verify.py

### DIFF
--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -203,7 +203,7 @@ def verify_env(dirs, user, permissive=False, pki_dir=''):
         err = ('Failed to prepare the Salt environment for user '
                '{0}. The user is not available.\n').format(user)
         sys.stderr.write(err)
-        sys.exit(salt.defulats.exitcodes.EX_NOUSER)
+        sys.exit(salt.defaults.exitcodes.EX_NOUSER)
     for dir_ in dirs:
         if not dir_:
             continue


### PR DESCRIPTION
``` python-traceback
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
AttributeError: 'module' object has no attribute 'defulats'
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    salt_call()
  File "/usr/lib/python2.6/site-packages/salt/scripts.py", line 227, in salt_call
    client.run()
  File "/usr/lib/python2.6/site-packages/salt/cli/call.py", line 30, in run
    pki_dir=self.config['pki_dir'],
  File "/usr/lib/python2.6/site-packages/salt/utils/verify.py", line 206, in verify_env
    sys.exit(salt.defulats.exitcodes.EX_NOUSER)
AttributeError: 'module' object has no attribute 'defulats'
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    salt_call()
  File "/usr/lib/python2.6/site-packages/salt/scripts.py", line 227, in salt_call
    client.run()
  File "/usr/lib/python2.6/site-packages/salt/cli/call.py", line 30, in run
    pki_dir=self.config['pki_dir'],
  File "/usr/lib/python2.6/site-packages/salt/utils/verify.py", line 206, in verify_env
    sys.exit(salt.defulats.exitcodes.EX_NOUSER)
AttributeError: 'module' object has no attribute 'defulats'
```
