### PR TITLE
docfix: "cache_jobs: False" => grains_cache: False"

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -352,7 +352,7 @@ to enable set grains_cache to ``True``.
 
 .. code-block:: yaml
 
-    cache_jobs: False
+    grains_cache: False
 
 
 .. conf_minion:: sock_dir


### PR DESCRIPTION
At the currently rendered anchor link: http://docs.saltstack.com/en/latest/ref/configuration/minion.html#grains-cache

We see the use of "cache_jobs" in the yaml example for the section describing "grains_cache"
