### PR TITLE
2015.5.3 LXC module fixes

### DIFF
--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -2907,7 +2907,7 @@ def running_systemd(name, cache=True):
             '''\
             #!/usr/bin/env bash
             set -x
-            if ! which systemctl 1>/dev/nulll 2>/dev/null;then exit 2;fi
+            if ! which systemctl 1>/dev/null 2>/dev/null;then exit 2;fi
             for i in \\
                 /run/systemd/journal/dev-log\\
                 /run/systemd/journal/flushed\\

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -3191,9 +3191,14 @@ def bootstrap(name,
             if install:
                 rstr = __salt__['test.rand_str']()
                 configdir = '/tmp/.c_{0}'.format(rstr)
-                run(name,
+
+                if run(name,
                     'install -m 0700 -d {0}'.format(configdir),
-                    python_shell=False)
+                    python_shell=False):
+                    log.error('tmpdir {0} creation failed ({1}'
+                              .format(configdir, cmd))
+                    return False
+
                 bs_ = __salt__['config.gather_bootstrap_script'](
                     bootstrap=bootstrap_url)
                 dest_dir = os.path.join('/tmp', rstr)

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -2870,7 +2870,7 @@ def set_dns(name, dnsservers=None, searchdomains=None):
             name, 'sh -c "chmod +x {0};{0}"'.format(script), python_shell=True)
     # blindly delete the setter file
     run_all(name,
-            'if [ -f "{0}" ];then rm -f "{0}";fi'.format(script),
+            'sh -c \'if [ -f "{0}" ];then rm -f "{0}";fi\''.format(script),
             python_shell=True)
     if result['retcode'] != 0:
         error = ('Unable to write to /etc/resolv.conf in container \'{0}\''

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -3192,9 +3192,8 @@ def bootstrap(name,
                 rstr = __salt__['test.rand_str']()
                 configdir = '/tmp/.c_{0}'.format(rstr)
 
-                if run(name,
-                    'install -m 0700 -d {0}'.format(configdir),
-                    python_shell=False):
+                cmd = 'install -m 0700 -d {0}'.format(configdir)
+                if run(name, cmd, python_shell=False):
                     log.error('tmpdir {0} creation failed ({1}'
                               .format(configdir, cmd))
                     return False


### PR DESCRIPTION
I have been trying to use the salt-could with LXC for the past few months and this is the result of last release changes I had to apply to get things to start to work the way they should.

It includes two pretty obvious fixes and DNS and systemd scripts and a more debatable change to the way bootstrap script is installed into the container.
