### PR TITLE
Add lxml dependency to opennebula docs

### DIFF
--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -6,6 +6,8 @@ OpenNebula Cloud Module
 The OpenNebula cloud module is used to control access to an OpenNebula
 cloud.
 
+:depends: lxml
+
 Use of this module requires the ``xml_rpc``, ``user`` and
 ``password`` parameter to be set. Set up the cloud configuration
 at ``/etc/salt/cloud.providers`` or


### PR DESCRIPTION
Sometimes `lxml` comes with your python installation. And sometimes it doesn't. Add a note to the OpenNebula docs to indicate that `lxml` is required.
