### PR TITLE
Fix docker.running detection of running container

### DIFF
--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -1129,7 +1129,7 @@ def running(name,
         # then assume it already exists.
     )
 
-    is_running = __salt__['docker.is_running'](container)
+    is_running = __salt__['docker.is_running'](name)
 
     # if container exists but is not started, try to start it
     if already_exists_with_same_image and (is_running or not start):


### PR DESCRIPTION
Didn't find an open issue.  When `container` is not set explicitly, the early running check in `docker.running` fails even if the named container is running because `name` is not used for the check.
