### PR TITLE
Adding UserKnownHostsFile=/dev/null to ignore_host_key

### DIFF
--- a/doc/ref/cli/salt-ssh.rst
+++ b/doc/ref/cli/salt-ssh.rst
@@ -55,8 +55,15 @@ Options
 
 .. option:: -i, --ignore-host-keys
 
-    Ignore the ssh host keys which by default are honored and connections
-    would ask for approval.
+    Disables StrictHostKeyChecking to relax acceptance of new and unknown
+    host keys. 
+
+.. option:: --no-host-keys
+
+    Fully ignores ssh host keys which by default are honored and connections
+    would ask for approval. Useful if the host key of a remote server has 
+    changed and would still error with --ignore-host-keys.
+
 
 .. option:: --passwd
 

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -100,6 +100,8 @@ class Shell(object):
             options.append('GSSAPIAuthentication=no')
         options.append('ConnectTimeout={0}'.format(self.timeout))
         if self.opts.get('ignore_host_keys'):
+            options.append('StrictHostKeyChecking=no')
+        if self.opts.get('no_host_keys'):
             options.extend(['StrictHostKeyChecking=no',
                             'UserKnownHostsFile=/dev/null'])
         known_hosts = self.opts.get('known_hosts_file')
@@ -133,6 +135,8 @@ class Shell(object):
             options.append('GSSAPIAuthentication=no')
         options.append('ConnectTimeout={0}'.format(self.timeout))
         if self.opts.get('ignore_host_keys'):
+            options.append('StrictHostKeyChecking=no')
+        if self.opts.get('no_host_keys'):
             options.extend(['StrictHostKeyChecking=no',
                             'UserKnownHostsFile=/dev/null'])
 

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -100,7 +100,8 @@ class Shell(object):
             options.append('GSSAPIAuthentication=no')
         options.append('ConnectTimeout={0}'.format(self.timeout))
         if self.opts.get('ignore_host_keys'):
-            options.append('StrictHostKeyChecking=no')
+            options.extend(['StrictHostKeyChecking=no',
+                            'UserKnownHostsFile=/dev/null'])
         known_hosts = self.opts.get('known_hosts_file')
         if known_hosts and os.path.isfile(known_hosts):
             options.append('UserKnownHostsFile={0}'.format(known_hosts))
@@ -132,7 +133,8 @@ class Shell(object):
             options.append('GSSAPIAuthentication=no')
         options.append('ConnectTimeout={0}'.format(self.timeout))
         if self.opts.get('ignore_host_keys'):
-            options.append('StrictHostKeyChecking=no')
+            options.extend(['StrictHostKeyChecking=no',
+                            'UserKnownHostsFile=/dev/null'])
 
         if self.passwd:
             options.extend(['PasswordAuthentication=yes',

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2460,7 +2460,15 @@ class SaltSSHOptionParser(six.with_metaclass(OptionParserMeta,
             default=False,
             action='store_true',
             help='By default ssh host keys are honored and connections will '
-                 'ask for approval'
+                 'ask for approval. Use this option to disable '
+                 'StrictHostKeyChecking.'
+        )
+        auth_group.add_option(
+            '--no-host-keys',
+            dest='no_host_keys',
+            default=False,
+            action='store_true',
+            help='Removes all host key checking functionality from SSH session.'
         )
         auth_group.add_option(
             '--user',


### PR DESCRIPTION
In relation to https://github.com/saltstack/salt/issues/25366

Just adding StrictHostKeyChecking=no isn't sufficient to entirely ignore host keys as implied by the '--ignore-host-keys' flag, it will still check existing host keys, it's more in relation to accepting previously unseen keys.

Needs UserKnownHostsFile=/dev/null as an additional option to fully ignore host keys.

Tested and resolves above issue.
