### PR TITLE
Inspector: enable Ubuntu/Debian!

### DIFF
--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -30,6 +30,7 @@ from salt.utils import reinit_crypto
 
 
 class Inspector(object):
+    DEFAULT_MINION_CONFIG_PATH = '/etc/salt/minion'
 
     MODE = ['configuration', 'payload', 'all']
     IGNORE_MOUNTS = ["proc", "sysfs", "devtmpfs", "tmpfs", "fuse.gvfs-fuse-daemon"]

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -18,7 +18,6 @@
 from __future__ import absolute_import
 import os
 import sys
-import stat
 from subprocess import Popen, PIPE, STDOUT
 
 # Import Salt Libs

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -324,6 +324,8 @@ class Inspector(object):
         Take a snapshot of the system.
         '''
         # TODO: Mode
+        self._init_env()
+
 
         self._save_cfg_pkgs(self._get_changed_cfg_pkgs(self._get_cfg_pkgs()))
         self._save_payload(*self._scan_payload())

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -108,6 +108,10 @@ class Inspector(object):
                 data.pop(pkg_name)
 
         return data
+
+    def __get_cfg_pkgs_rpm(self):
+        '''
+        Get packages with configuration files on RPM systems.
         '''
         out, err = self._syscall('rpm', None, None, '-qa', '--configfiles',
                                  '--queryformat', '%{name}-%{version}-%{release}\\n')

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -297,7 +297,7 @@ class Inspector(object):
         for entry_path in [pth for pth in (allowed or os.listdir("/")) if pth]:
             if entry_path[0] != "/":
                 entry_path = "/{0}".format(entry_path)
-            if entry_path in ignored:
+            if entry_path in ignored or os.path.islink(entry_path):
                 continue
             e_files, e_dirs, e_links = self._get_all_files(entry_path, *ignored)
             all_files.extend(e_files)

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -245,16 +245,15 @@ class Inspector(object):
                     continue
             if not valid or not os.path.exists(obj):
                 continue
-            mode = os.lstat(obj).st_mode
-            if stat.S_ISLNK(mode):
+            if os.path.islink(obj):
                 links.append(obj)
-            elif stat.S_ISDIR(mode):
+            elif os.path.isdir(obj):
                 dirs.append(obj)
                 f_obj, d_obj, l_obj = self._get_all_files(obj, *exclude)
                 files.extend(f_obj)
                 dirs.extend(d_obj)
                 links.extend(l_obj)
-            elif stat.S_ISREG(mode):
+            elif os.path.isfile(obj):
                 files.append(obj)
 
         return sorted(files), sorted(dirs), sorted(links)

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -45,7 +45,8 @@ class Inspector(object):
             db_path = globals().get('__salt__')['config.get']('inspector.db', '')
 
         if not db_path:
-            raise InspectorSnapshotException("Inspector database location is not configured yet in minion.")
+            raise InspectorSnapshotException('Inspector database location is not configured yet in minion.\n'
+                                             'Add "inspector.db: /path/to/cache" in "/etc/salt/minion".')
         self.dbfile = db_path
 
         self.db = DBHandle(self.dbfile)

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -310,6 +310,15 @@ class Inspector(object):
 
         return ignored_all
 
+    def _init_env(self):
+        '''
+        Initialize some Salt environment.
+        '''
+        from salt.config import minion_config
+        from salt.grains import core as g_core
+        g_core.__opts__ = minion_config(self.DEFAULT_MINION_CONFIG_PATH)
+        self.grains_core = g_core
+
     def snapshot(self, mode):
         '''
         Take a snapshot of the system.

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -56,7 +56,8 @@ class Inspector(object):
             pid_file = globals().get('__salt__')['config.get']('inspector.pid', '')
 
         if not pid_file:
-            raise InspectorSnapshotException("Inspector PID file location is not configured yet in minion.")
+            raise InspectorSnapshotException("Inspector PID file location is not configured yet in minion.\n"
+                                             'Add "inspector.pid: /path/to/pids in "/etc/salt/minion".')
         self.pidfile = pid_file
 
     def _syscall(self, command, input=None, env=None, *params):

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -69,7 +69,16 @@ class Inspector(object):
 
     def _get_cfg_pkgs(self):
         '''
-        Get packages with configuration files.
+        Package scanner switcher between the platforms.
+
+        :return:
+        '''
+        if self.grains_core.os_data().get('os_family') == 'Debian':
+            return self.__get_cfg_pkgs_dpkg()
+        elif self.grains_core.os_data().get('os_family') in ['Suse', 'redhat']:
+            return self.__get_cfg_pkgs_rpm()
+        else:
+            return dict()
         '''
         out, err = self._syscall('rpm', None, None, '-qa', '--configfiles',
                                  '--queryformat', '%{name}-%{version}-%{release}\\n')

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -65,11 +65,8 @@ class SysInfo(object):
         Get available file systems and their types.
         '''
 
-        out = __salt__['cmd.run_all']("blkid -o export")
-        salt.utils.fsutils._verify_run(out)
-
         data = dict()
-        for dev, dev_data in salt.utils.fsutils._blkid_output(out['stdout']).items():
+        for dev, dev_data in salt.utils.fsutils._blkid().items():
             dev = self._get_disk_size(dev)
             device = dev.pop('device')
             dev['type'] = dev_data['type']

--- a/salt/modules/node.py
+++ b/salt/modules/node.py
@@ -45,14 +45,16 @@ def _(module):
     :return:
     '''
 
-
     mod = None
+    # pylint: disable=E0598
     try:
+        # importlib is in Python 2.7+ and 3+
         import importlib
         mod = importlib.import_module("salt.modules.inspectlib.{0}".format(module))
     except ImportError as err:
         # No importlib around (2.6)
         mod = getattr(__import__("salt.modules.inspectlib", globals(), locals(), fromlist=[str(module)]), module)
+    # pylint: enable=E0598
 
     mod.__grains__ = __grains__
     mod.__pillar__ = __pillar__

--- a/salt/modules/node.py
+++ b/salt/modules/node.py
@@ -45,11 +45,14 @@ def _(module):
     :return:
     '''
 
-    # importlib is unavailable on python 2.6
-    if module == 'collector':
-        mod = salt.modules.inspectlib.collector
-    elif module == 'query':
-        mod = salt.modules.inspectlib.query
+
+    mod = None
+    try:
+        import importlib
+        mod = importlib.import_module("salt.modules.inspectlib.{0}".format(module))
+    except ImportError as err:
+        # No importlib around (2.6)
+        mod = getattr(__import__("salt.modules.inspectlib", globals(), locals(), fromlist=[str(module)]), module)
 
     mod.__grains__ = __grains__
     mod.__pillar__ = __pillar__

--- a/salt/utils/fsutils.py
+++ b/salt/utils/fsutils.py
@@ -9,6 +9,7 @@ Run-time utilities
 # Import Python libs
 from __future__ import absolute_import
 import re
+import os
 import logging
 
 # Import Salt libs
@@ -58,6 +59,7 @@ def _get_mounts(fs_type=None):
     return mounts
 
 
+# TODO: Due to "blkid -o export" strongly differs from system to system, this must go away in favor of _blkid() below!
 def _blkid_output(out, fs_type=None):
     '''
     Parse blkid output.
@@ -82,6 +84,33 @@ def _blkid_output(out, fs_type=None):
 
     return data
 
+
+def _blkid(fs_type=None):
+    '''
+    Return available media devices.
+
+    :param fs_type: Filter only devices that are formatted by that file system.
+    '''
+    flt = lambda data: [el for el in data if el.strip()]
+    data = dict()
+    for dev_meta in flt(os.popen("blkid -o full").read().split(os.linesep)):  # No __salt__ around at this point.
+        dev_meta = dev_meta.strip()
+        if not dev_meta:
+            continue
+        device = dev_meta.split(" ")
+        dev_name = device.pop(0)[:-1]
+        data[dev_name] = dict()
+        for k_set in device:
+            ks_key, ks_value = [elm.replace('"', '') for elm in k_set.split("=")]
+            data[dev_name][ks_key.lower()] = ks_value
+
+    if fs_type:
+        mounts = _get_mounts(fs_type)
+        for device in six.iterkeys(mounts):
+            if data.get(device):
+                data[device]['mounts'] = mounts[device]
+
+    return data
 
 def _is_device(path):
     '''

--- a/salt/utils/fsutils.py
+++ b/salt/utils/fsutils.py
@@ -112,6 +112,7 @@ def _blkid(fs_type=None):
 
     return data
 
+
 def _is_device(path):
     '''
     Return True if path is a physical device.


### PR DESCRIPTION
The [Salt Inspector](http://docs.saltstack.com/en/develop/ref/modules/all/salt.modules.node.html) is now working on Debian/Ubuntu!
- Brings all the functionality as on RPM distros
- Fixes many small cross-platform bugs
- Minor cleanups

P.S. Sometimes it is needed `os.popen(...)` instead of `__salt__['cmd.run](...)` as the latter is not needed and is even not there. 
