### PR TITLE
only read /proc/1/cmdline if it exists

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1039,32 +1039,33 @@ def os_data():
             os.stat('/run/systemd/system')
             grains['init'] = 'systemd'
         except OSError:
-            with salt.utils.fopen('/proc/1/cmdline') as fhr:
-                init_cmdline = fhr.read().replace('\x00', ' ').split()
-                init_bin = salt.utils.which(init_cmdline[0])
-                if init_bin:
-                    supported_inits = ('upstart', 'sysvinit', 'systemd')
-                    edge_len = max(len(x) for x in supported_inits) - 1
-                    buf_size = __opts__['file_buffer_size']
-                    try:
-                        with open(init_bin, 'rb') as fp_:
-                            buf = True
-                            edge = ''
-                            buf = fp_.read(buf_size).lower()
-                            while buf:
-                                buf = edge + buf
-                                for item in supported_inits:
-                                    if item in buf:
-                                        grains['init'] = item
-                                        buf = ''
-                                        break
-                                edge = buf[-edge_len:]
+            if os.path.exists('/proc/1/cmdline'):
+                with salt.utils.fopen('/proc/1/cmdline') as fhr:
+                    init_cmdline = fhr.read().replace('\x00', ' ').split()
+                    init_bin = salt.utils.which(init_cmdline[0])
+                    if init_bin:
+                        supported_inits = ('upstart', 'sysvinit', 'systemd')
+                        edge_len = max(len(x) for x in supported_inits) - 1
+                        buf_size = __opts__['file_buffer_size']
+                        try:
+                            with open(init_bin, 'rb') as fp_:
+                                buf = True
+                                edge = ''
                                 buf = fp_.read(buf_size).lower()
-                    except (IOError, OSError) as exc:
-                        log.error(
-                            'Unable to read from init_bin ({0}): {1}'
-                            .format(init_bin, exc)
-                        )
+                                while buf:
+                                    buf = edge + buf
+                                    for item in supported_inits:
+                                        if item in buf:
+                                            grains['init'] = item
+                                            buf = ''
+                                            break
+                                    edge = buf[-edge_len:]
+                                    buf = fp_.read(buf_size).lower()
+                        except (IOError, OSError) as exc:
+                            log.error(
+                                'Unable to read from init_bin ({0}): {1}'
+                                .format(init_bin, exc)
+                            )
 
         # Add lsb grains on any distro with lsb-release
         try:


### PR DESCRIPTION
Jailed environments may not have access to this file; fixes #25454.

The diff is difficult to read.  All I did was prepend an if statement.
