### PR TITLE
Add optional job end time to the local_cache returner

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -517,7 +517,7 @@ VALID_OPTS = {
     'master_job_cache': str,
 
     # Specify whether the master should store end times for jobs as returns come in
-    'jos_cache_store_endtime': False,
+    'jos_cache_store_endtime': bool,
 
     # The minion data cache is a cache of information about the minions stored on the master.
     # This information is primarily the pillar and grains data. The data is cached in the master

--- a/salt/config.py
+++ b/salt/config.py
@@ -517,7 +517,7 @@ VALID_OPTS = {
     'master_job_cache': str,
 
     # Specify whether the master should store end times for jobs as returns come in
-    'jos_cache_store_endtime': bool,
+    'job_cache_store_endtime': bool,
 
     # The minion data cache is a cache of information about the minions stored on the master.
     # This information is primarily the pillar and grains data. The data is cached in the master
@@ -951,7 +951,7 @@ DEFAULT_MASTER_OPTS = {
     'job_cache': True,
     'ext_job_cache': '',
     'master_job_cache': 'local_cache',
-    'jos_cache_store_endtime': False,
+    'job_cache_store_endtime': False,
     'minion_data_cache': True,
     'enforce_mine_cache': False,
     'ipc_mode': _DFLT_IPC_MODE,

--- a/salt/config.py
+++ b/salt/config.py
@@ -516,6 +516,9 @@ VALID_OPTS = {
     # that it receives
     'master_job_cache': str,
 
+    # Specify whether the master should store end times for jobs as returns come in
+    'jos_cache_store_endtime': False,
+
     # The minion data cache is a cache of information about the minions stored on the master.
     # This information is primarily the pillar and grains data. The data is cached in the master
     # cachedir under the name of the minion and used to predetermine what minions are expected to
@@ -948,6 +951,7 @@ DEFAULT_MASTER_OPTS = {
     'job_cache': True,
     'ext_job_cache': '',
     'master_job_cache': 'local_cache',
+    'jos_cache_store_endtime': False,
     'minion_data_cache': True,
     'enforce_mine_cache': False,
     'ipc_mode': _DFLT_IPC_MODE,

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -762,7 +762,7 @@ class RemoteFuncs(object):
         fstr = '{0}.update_endtime'.format(self.opts['master_job_cache'])
         if (self.opts.get['job_cache_store_endtime']
                 and fstr in self.mminion.returners):
-            self.mminion.returners[fstr](endtime)
+            self.mminion.returners[fstr](load['jid'], endtime)
 
         fstr = '{0}.returner'.format(self.opts['master_job_cache'])
         self.mminion.returners[fstr](load)

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -760,7 +760,7 @@ class RemoteFuncs(object):
             return
 
         fstr = '{0}.update_endtime'.format(self.opts['master_job_cache'])
-        if (self.opts.get['job_cache_store_endtime']
+        if (self.opts.get('job_cache_store_endtime')
                 and fstr in self.mminion.returners):
             self.mminion.returners[fstr](load['jid'], endtime)
 

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -757,6 +757,8 @@ class RemoteFuncs(object):
         if not self.opts['job_cache'] or self.opts.get('ext_job_cache'):
             return
 
+        load['starttime'] = salt.utils.jid_to_time(load['jid'])
+        load['endtime'] = salt.utils.jid_to_time(salt.utils.jid.gen_jid())
         fstr = '{0}.returner'.format(self.opts['master_job_cache'])
         self.mminion.returners[fstr](load)
 

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -739,6 +739,8 @@ class RemoteFuncs(object):
         '''
         Handle the return data sent from the minions
         '''
+        # Generate EndTime
+        endtime = salt.utils.jid.jid_to_time(salt.utils.jid.gen_jid())
         # If the return data is invalid, just ignore it
         if any(key not in load for key in ('return', 'jid', 'id')):
             return False
@@ -757,8 +759,11 @@ class RemoteFuncs(object):
         if not self.opts['job_cache'] or self.opts.get('ext_job_cache'):
             return
 
-        load['starttime'] = salt.utils.jid_to_time(load['jid'])
-        load['endtime'] = salt.utils.jid_to_time(salt.utils.jid.gen_jid())
+        fstr = '{0}.update_endtime'.format(self.opts['master_job_cache'])
+        if (self.opts.get['job_cache_store_endtime']
+                and fstr in self.mminion.returners):
+            self.mminion.returners[fstr](endtime)
+
         fstr = '{0}.returner'.format(self.opts['master_job_cache'])
         self.mminion.returners[fstr](load)
 

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -256,9 +256,10 @@ def get_jids():
     for jid, job, _, _ in _walk_through(_job_dir()):
         ret[jid] = salt.utils.jid.format_jid_instance(jid, job)
 
-        endtime = get_endtime(jid)
-        if endtime:
-            ret[jid]['EndTime'] = endtime
+        if __opts__.get('job_cache_store_endtime'):
+            endtime = get_endtime(jid)
+            if endtime:
+                ret[jid]['EndTime'] = endtime
 
     return ret
 

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -28,6 +28,8 @@ MINIONS_P = '.minions.p'
 RETURN_P = 'return.p'
 # out is the "out" from the minion data
 OUT_P = 'out.p'
+# endtime is the end time for a job, not stored as msgpack
+ENDTIME = 'endtime'
 
 
 def _job_dir():
@@ -280,3 +282,34 @@ def clean_old_jobs():
                     hours_difference = (cur - jid_ctime) / 3600.0
                     if hours_difference > __opts__['keep_jobs']:
                         shutil.rmtree(f_path)
+
+
+def update_endtime(jid, time):
+    '''
+    Update (or store) the end time for a given job
+
+    Endtime is stored as a plain text string
+    '''
+    jid_dir = _jid_dir(jid)
+    try:
+        if not os.path.exists(jid_dir):
+            os.makedirs(jid_dir)
+        with salt.utils.fopen(os.path.join(jid_dir, ENDTIME), 'w') as etfile:
+            etfile.write(time)
+    except IOError as exc:
+        log.warning('Could not write job invocation cache file: {0}'.format(exc))
+
+
+def get_endtime(jid):
+    '''
+    Retrieve the stored endtime for a given job
+
+    Returns False if no endtime is present
+    '''
+    jid_dir = _jid_dir(jid)
+    etpath = os.path.join(jid_dir, ENDTIME)
+    if not os.path.exists(etpath):
+        return False
+    with salt.utils.fopen(etpath, 'r') as etfile:
+        endtime = etfile.read().strip('\n')
+    return endtime

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -255,6 +255,12 @@ def get_jids():
     ret = {}
     for jid, job, _, _ in _walk_through(_job_dir()):
         ret[jid] = salt.utils.jid.format_jid_instance(jid, job)
+
+        if __opts__.get['job_cache_store_endtime']:
+            endtime = get_endtime(jid)
+            if endtime:
+                ret[jid]['EndTime'] = endtime
+
     return ret
 
 

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -256,10 +256,9 @@ def get_jids():
     for jid, job, _, _ in _walk_through(_job_dir()):
         ret[jid] = salt.utils.jid.format_jid_instance(jid, job)
 
-        if __opts__.get['job_cache_store_endtime']:
-            endtime = get_endtime(jid)
-            if endtime:
-                ret[jid]['EndTime'] = endtime
+        endtime = get_endtime(jid)
+        if endtime:
+            ret[jid]['EndTime'] = endtime
 
     return ret
 

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -191,8 +191,8 @@ def list_job(jid, ext_source=None, outputter=None):
     ret.update(_format_jid_instance(jid, job))
     ret['Result'] = mminion.returners['{0}.get_jid'.format(returner)](jid)
 
-    fstr = '{0}.get_endtime'.format(self.opts['master_job_cache'])
-    if (self.opts.get['job_cache_store_endtime']
+    fstr = '{0}.get_endtime'.format(__opts__['master_job_cache'])
+    if (__opts__.get['job_cache_store_endtime']
             and fstr in self.mminion.returners):
         endtime = mminion.returners[fstr](jid)
         if endtime:
@@ -353,8 +353,8 @@ def print_job(jid, ext_source=None, outputter=None):
         return ret
     ret[jid]['Result'] = mminion.returners['{0}.get_jid'.format(returner)](jid)
 
-    fstr = '{0}.get_endtime'.format(self.opts['master_job_cache'])
-    if (self.opts.get['job_cache_store_endtime']
+    fstr = '{0}.get_endtime'.format(__opts__['master_job_cache'])
+    if (__opts__.get['job_cache_store_endtime']
             and fstr in self.mminion.returners):
         endtime = mminion.returners[fstr](jid)
         if endtime:

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -192,8 +192,8 @@ def list_job(jid, ext_source=None, outputter=None):
     ret['Result'] = mminion.returners['{0}.get_jid'.format(returner)](jid)
 
     fstr = '{0}.get_endtime'.format(__opts__['master_job_cache'])
-    if (__opts__.get['job_cache_store_endtime']
-            and fstr in self.mminion.returners):
+    if (__opts__.get('job_cache_store_endtime')
+            and fstr in mminion.returners):
         endtime = mminion.returners[fstr](jid)
         if endtime:
             ret['EndTime'] = endtime
@@ -354,11 +354,11 @@ def print_job(jid, ext_source=None, outputter=None):
     ret[jid]['Result'] = mminion.returners['{0}.get_jid'.format(returner)](jid)
 
     fstr = '{0}.get_endtime'.format(__opts__['master_job_cache'])
-    if (__opts__.get['job_cache_store_endtime']
-            and fstr in self.mminion.returners):
+    if (__opts__.get('job_cache_store_endtime')
+            and fstr in mminion.returners):
         endtime = mminion.returners[fstr](jid)
         if endtime:
-            ret['EndTime'] = endtime
+            ret[jid]['EndTime'] = endtime
 
     if outputter:
         salt.utils.warn_until(

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -190,6 +190,14 @@ def list_job(jid, ext_source=None, outputter=None):
     job = mminion.returners['{0}.get_load'.format(returner)](jid)
     ret.update(_format_jid_instance(jid, job))
     ret['Result'] = mminion.returners['{0}.get_jid'.format(returner)](jid)
+
+    fstr = '{0}.get_endtime'.format(self.opts['master_job_cache'])
+    if (self.opts.get['job_cache_store_endtime']
+            and fstr in self.mminion.returners):
+        endtime = mminion.returners[fstr](jid)
+        if endtime:
+            ret['EndTime'] = endtime
+
     if outputter:
         salt.utils.warn_until(
             'Boron',
@@ -344,6 +352,14 @@ def print_job(jid, ext_source=None, outputter=None):
             'Check master log for details.'.format(returner))
         return ret
     ret[jid]['Result'] = mminion.returners['{0}.get_jid'.format(returner)](jid)
+
+    fstr = '{0}.get_endtime'.format(self.opts['master_job_cache'])
+    if (self.opts.get['job_cache_store_endtime']
+            and fstr in self.mminion.returners):
+        endtime = mminion.returners[fstr](jid)
+        if endtime:
+            ret['EndTime'] = endtime
+
     if outputter:
         salt.utils.warn_until(
             'Boron',

--- a/salt/utils/job.py
+++ b/salt/utils/job.py
@@ -18,6 +18,8 @@ def store_job(opts, load, event=None, mminion=None):
     '''
     Store job information using the configured master_job_cache
     '''
+    # Generate EndTime
+    endtime = salt.utils.jid.jid_to_time(salt.utils.jid.gen_jid())
     # If the return data is invalid, just ignore it
     if any(key not in load for key in ('return', 'jid', 'id')):
         return False
@@ -84,6 +86,12 @@ def store_job(opts, load, event=None, mminion=None):
         if 'jid' in load and 'get_load' in mminion.returners and not mminion.returners[getfstr](load.get('jid', '')):
             mminion.returners[savefstr](load['jid'], load)
         mminion.returners[fstr](load)
+
+        updateetfstr = '{0}.update_endtime'.format(job_cache)
+        if (opts.get('job_cache_store_endtime')
+                and updateetfstr in mminion.returners):
+            mminion.returners[updateetfstr](load['jid'], endtime)
+
     except KeyError:
         emsg = "Returner '{0}' does not support function returner".format(job_cache)
         log.error(emsg)


### PR DESCRIPTION
Other returners can implement this by implementing the functions `update_endtime` and `get_endtime`.

Fixes #23563 

Only stores endtime if `job_cach_store_endtime: True` is set in master config.
