### PR TITLE
fixes to schedule.add documentation in develop

### DIFF
--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -342,7 +342,7 @@ def add(name, **kwargs):
 
         salt '*' schedule.add job1 function='test.ping' seconds=3600
         # If function have some arguments, use job_args
-        salt '*' schedule.add job2 function='cmd.run' job_args=['date >> /tmp/date.log'] seconds=60
+        salt '*' schedule.add job2 function='cmd.run' job_args="['date >> /tmp/date.log']" seconds=60
     '''
 
     ret = {'comment': 'Failed to add job {0} to schedule.'.format(name),


### PR DESCRIPTION
Fixing documentation for schedule.add when using the job_args parameter, value needs to be be in quotes for the value to be passed in as an array. #25493 
