### PR TITLE
The variable name must be last

### DIFF
--- a/salt/modules/sysrc.py
+++ b/salt/modules/sysrc.py
@@ -40,18 +40,18 @@ def get(**kwargs):
 
     cmd = 'sysrc -v'
 
+    if 'file' in kwargs:
+        cmd += ' -f '+kwargs['file']
+
+    if 'jail' in kwargs:
+        cmd += ' -j '+kwargs['jail']
+
     if 'name' in kwargs:
         cmd += ' '+kwargs['name']
     elif kwargs.get('includeDefaults', False):
         cmd += ' -A'
     else:
         cmd += ' -a'
-
-    if 'file' in kwargs:
-        cmd += ' -f '+kwargs['file']
-
-    if 'jail' in kwargs:
-        cmd += ' -j '+kwargs['jail']
 
     sysrcs = __salt__['cmd.run'](cmd)
     if "sysrc: unknown variable" in sysrcs:


### PR DESCRIPTION
From the sysrc manual page on FreeBSD 10.1:

```
sysrc [-cdDeFhinNqvx] [-f file] [-j jail | -R dir] name[=value] ...
sysrc [-cdDeFhinNqvx] [-f file] [-j jail | -R dir] -a | -A
```

Without this patch, when arguments `file` and `name` are specified, None is always returned.
The following is then logged in the minion:

```
[ERROR   ] Command 'sysrc -v autoboot_delay -f /boot/loader.conf' failed with return code: 1
[ERROR   ] output: sysrc: unknown variable 'autoboot_delay'
sysrc: unknown variable '-f'
sysrc: unknown variable '/boot/loader.conf'
```
