### PR TITLE
Update windows-package-manager.rst Firefox pkg name was changed to lo…

### DIFF
--- a/doc/topics/windows/windows-package-manager.rst
+++ b/doc/topics/windows/windows-package-manager.rst
@@ -61,7 +61,7 @@ The package definition file should look similar to this example for Firefox:
 
 .. code-block:: yaml
 
-    Firefox:
+    firefox:
       17.0.1:
         installer: 'salt://win/repo/firefox/English/Firefox Setup 17.0.1.exe'
         full_name: Mozilla Firefox 17.0.1 (x86 en-US)


### PR DESCRIPTION
…wercase

The salt winrepo firefox.sls pkg name for 'Firefox' has changed to lowercase 'firefox' in salt-winrepo commit SHA: c821f53
saltstack/salt-winrepo@SHA: saltstack/salt-winrepo@c821f53
https://github.com/saltstack/salt-winrepo/commit/c821f539b00dcff865a3e4144406df0a6d8430df#diff-e4cafcf2dc2edcf281c42447df0fdfa5
