### PR TITLE
Fix hipchat.send_message when using API v2

### DIFF
--- a/salt/modules/hipchat.py
+++ b/salt/modules/hipchat.py
@@ -134,6 +134,9 @@ def _query(function, api_key=None, api_version=None, method='GET', data=None):
     elif api_version == 'v2':
         headers['Authorization'] = 'Bearer {0}'.format(api_key)
         data = json.dumps(data)
+
+        if method == 'POST':
+            headers['Content-Type'] = 'application/json'
     else:
         log.error('Unsupported HipChat API version')
         return False


### PR DESCRIPTION
hipchat.send_message fails with
`{u'error': {u'message': u'Invalid content type: None', u'code': 400, u'type': u'Bad Request'}}`
when using v2
