### PR TITLE
Windows: Pre-flight check fails when user is 'SYSTEM'

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -384,7 +384,7 @@ class Master(SMaster):
         if salt.utils.is_windows() and self.opts['user'] == 'root':
             # 'root' doesn't typically exist on Windows. Use the current user
             # home directory instead.
-            home = os.path.expanduser('~' + salt.utils.get_user())
+            home = os.path.expanduser('~')
         else:
             home = os.path.expanduser('~' + self.opts['user'])
         try:


### PR DESCRIPTION
When `salt.utils.get_user()` returns `SYSTEM`, as is the case when
salt-master is running as a Windows service:

`os.path.expanduser('~' + salt.utils.get_user())`
returns something like: `C:\Windows\system32\config\SYSTEM`
Unfortunately, this is a file (not a folder) that already exists on the
system, causing the pre-flight checks to fail.

`os.path.expanduser('~')` returns something like:
`C:\WINDOWS\system32\config\systemprofile`
which is correct for the `SYSTEM` user.

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
