### PR TITLE
s3fs breaks when fetching files from s3

### DIFF
--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -618,17 +618,17 @@ def _get_file_from_s3(metadata, saltenv, bucket_name, path, cached_file_path):
                         service_url=service_url,
                         verify_ssl=verify_ssl,
                         path=_quote(path),
-                        local_file=cached_file_path
+                        local_file=cached_file_path,
+                        full_headers=True
                     )
                     if ret is not None:
-                        for header in ret['headers']:
-                            name, value = header.split(':', 1)
-                            name = name.strip()
-                            value = value.strip()
-                            if name == 'Last-Modified':
+                        for header_name, header_value in ret['headers'].items():
+                            name = header_name.strip()
+                            value = header_value.strip()
+                            if name == 'Last-Modified'.lower():
                                 s3_file_mtime = datetime.datetime.strptime(
                                     value, '%a, %d %b %Y %H:%M:%S %Z')
-                            elif name == 'Content-Length':
+                            elif name == 'Content-Length'.lower():
                                 s3_file_size = int(value)
                         if (cached_file_size == s3_file_size and
                                 cached_file_mtime > s3_file_mtime):


### PR DESCRIPTION
Per https://github.com/saltstack/salt/issues/23567 there is an exception
when trying to parse headers.  The values in the returned ret['headers']
now defaults to just being a list of strings containing the keys, but no
values are included.  It seems that in the past a list of strings of
key:value pairs was returned.

This patch requests full_headers, which instead returns a dictionary of
header keys and values.  The keys are lowercased, but otherwise they
seem to be the same.

So this patch requests the full_headers and deals with lowercasing the
desired headers.  This works for me as long as both
https://github.com/saltstack/salt/commit/8999148da0a96145f289d1049802e49c5d862339
and
https://github.com/saltstack/salt/commit/80c7a697ae10b63e807d1b44755ae1338b306cd1
are applied.
