### PR TITLE
Allow parent relative includes in state files

### DIFF
--- a/doc/ref/renderers/all/salt.renderers.stateconf.rst
+++ b/doc/ref/renderers/all/salt.renderers.stateconf.rst
@@ -172,20 +172,22 @@ Here's a list of features enabled by this renderer.
       include:
         - .apache
         - .db.mysql
+        - ..app.django
 
       exclude:
         - sls: .users
 
   If the above is written in a salt file at `salt://some/where.sls` then
-  it will include `salt://some/apache.sls` and `salt://some/db/mysql.sls`,
-  and exclude `salt://some/users.ssl`. Actually, it does that by rewriting
-  the above ``include`` and ``exclude`` into:
+  it will include `salt://some/apache.sls`, `salt://some/db/mysql.sls` and
+  `salt://app/django.sls`, and exclude `salt://some/users.ssl`. Actually,
+  it does that by rewriting the above ``include`` and ``exclude`` into:
 
   .. code-block:: yaml
 
       include:
         - some.apache
         - some.db.mysql
+        - app.django
 
       exclude:
         - sls: some.users

--- a/doc/ref/states/include.rst
+++ b/doc/ref/states/include.rst
@@ -49,6 +49,23 @@ the running sls formula was added, simply precede the formula name with a
       - .virt
       - .virt.hyper
 
+In Salt 2015.8, the ability to include sls formulas which are relative to the
+the parents of the running sls forumla was added.  In order to achieve this,
+prece the formula name with more than one `.`. Much like Python's relative
+import abilities, two or more leading dots give a relative import to the
+parent or parents of the current package, with each `.` representing one level
+after the first.
+
+Within a sls fomula at ``example.dev.virtual``, the following:
+
+.. code-block:: yaml
+
+    include:
+      - ..http
+      - ...base
+
+would result in ``example.http`` and ``base`` being included.
+
 Exclude
 =======
 
@@ -58,7 +75,7 @@ high data has been compiled, so nothing should be able to override an
 exclude.
 
 Since the exclude can remove an id or an sls the type of component to
-exclude needs to be defined. an exclude statement that verifies that the
+exclude needs to be defined. An exclude statement that verifies that the
 running highstate does not contain the `http` sls and the `/etc/vimrc` id
 would look like this:
 

--- a/salt/renderers/stateconf.py
+++ b/salt/renderers/stateconf.py
@@ -264,15 +264,9 @@ def rewrite_single_shorthand_state_decl(data):  # pylint: disable=C0103
             data[sid] = {states: []}
 
 
-def _parent_sls(sls):
-    i = sls.rfind('.')
-    return sls[:i] + '.' if i != -1 else ''
-
-
 def rewrite_sls_includes_excludes(data, sls, saltenv):
     # if the path of the included/excluded sls starts with a leading dot(.)
     # then it's taken to be relative to the including/excluding sls.
-    sls = _parent_sls(sls)
     for sid in data:
         if sid == 'include':
             includes = data[sid]
@@ -283,15 +277,32 @@ def rewrite_sls_includes_excludes(data, sls, saltenv):
                     slsenv = saltenv
                     incl = each
                 if incl.startswith('.'):
-                    includes[i] = {slsenv: (sls + incl[1:])}
+                    includes[i] = {slsenv: _relative_to_abs_sls(incl, sls)}
         elif sid == 'exclude':
             for sdata in data[sid]:
                 if 'sls' in sdata and sdata['sls'].startswith('.'):
-                    sdata['sls'] = sls + sdata['sls'][1:]
+                    sdata['sls'] = _relative_to_abs_sls(sdata['sls'], sls)
 
 
 def _local_to_abs_sid(sid, sls):  # id must starts with '.'
-    return _parent_sls(sls) + sid[1:] if '::' in sid else sls + '::' + sid[1:]
+    if '::' in sid:
+        return _relative_to_abs_sls(sid, sls)
+    else:
+        abs_sls = _relative_to_abs_sls(sid, sls + '.')
+        return '::'.join(abs_sls.rsplit('.', 1))
+
+
+def _relative_to_abs_sls(relative, sls):
+    """ Convert ``relative`` sls reference into absolute, relative to ``sls``.
+    """
+    levels, suffix = re.match('^(\.+)(.*)$', relative).groups()
+    level_count = len(levels)
+    p_comps = sls.split('.')
+    if level_count > len(p_comps):
+        raise SaltRenderError(
+            'Attempted relative include goes beyond top level package'
+        )
+    return '.'.join(p_comps[:-level_count] + [suffix])
 
 
 def nvlist(thelist, names=None):

--- a/salt/state.py
+++ b/salt/state.py
@@ -22,6 +22,7 @@ import fnmatch
 import logging
 import datetime
 import traceback
+import re
 
 # Import salt libs
 import salt.utils
@@ -2633,11 +2634,21 @@ class BaseHighState(object):
                         continue
 
                     if inc_sls.startswith('.'):
+                        levels, include = \
+                            re.match('^(\.+)(.*)$', inc_sls).groups()
+                        level_count = len(levels)
                         p_comps = sls.split('.')
                         if state_data.get('source', '').endswith('/init.sls'):
-                            inc_sls = sls + inc_sls
-                        else:
-                            inc_sls = '.'.join(p_comps[:-1]) + inc_sls
+                            p_comps.append('init')
+                        if level_count > len(p_comps):
+                            msg = ('Attempted relative include of {0!r} '
+                                   'within SLS \'{1}:{2}\' '
+                                   'goes beyond top level package '
+                                   .format(inc_sls, saltenv, sls))
+                            log.error(msg)
+                            errors.append(msg)
+                            continue
+                        inc_sls = '.'.join(p_comps[:-level_count] + [include])
 
                     if env_key != xenv_key:
                         # Resolve inc_sls in the specified environment


### PR DESCRIPTION
This implements a solution to #25477.  Any `include` directives within state files can use multiple dot notation (influenced by Python relative imports) to refer to a parent state, eg:

```
include:
  - ..utils
  - ...app.django
```

inside a statefile located at `salt://my/example/state.sls` to include `salt://my/utils.sls` and `salt://app/djano.sls` respectively.  Attempts to include higher that the top level will be detected and reported accordingly.

This also implements the same functionality inside the stateconf renderer (http://docs.saltstack.com/en/latest/ref/renderers/all/salt.renderers.stateconf.html), which supported relative includes, excludes, and prefixed states.  This PR expands on existing tests for stateconf for these changes.

This also updates the documentation accordingly.

Notes:
- There is some slight duplication of functionality between `salt.state` for include directives and `salt.renderers.stateconf`.  Fwiw, there was duplication already around the relative-to-absolute code.  Happy to look at refactoring into a common function if someone tells me where it should go.
- No tests appear to exist for `salt.state.BaseHighState.render_state` (this method mocked out), hence why I've not attempted to create new tests for testing the highstate render
