### PR TITLE
use explicit utf-8 decoding (#25532)

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -646,7 +646,7 @@ def _get_name_map():
     u_name_map = {}
     name_map = get_repo_data().get('name_map', {})
     for k in name_map.keys():
-        u_name_map[salt.utils.sdecode(k)] = name_map[k]
+        u_name_map[k.decode('utf-8')] = name_map[k]
     return u_name_map
 
 


### PR DESCRIPTION
since salt.utils.sdecode() is bias toward system encoding(defaults to cp1252) and it differs from the strings returned from _get_reg_software() (utf-8)
(#25532)
