### PR TITLE
Fixed problem trying to load file with name of boolean type

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -625,7 +625,7 @@ def get_repo_data(saltenv='base'):
     if not cached_repo:
         __salt__['pkg.refresh_db']()
     try:
-        with salt.utils.fopen(cached_repo, 'rb') as repofile:
+        with salt.utils.fopen(repocache, 'rb') as repofile:
             try:
                 repodata = msgpack.loads(repofile.read()) or {}
                 #__context__['winrepo.data'] = repodata


### PR DESCRIPTION
It was trying to load a file with the variable `cached_repo` which is a boolean value indicating whether or not the repo is cached
Changed to use the `repocache` variable which loads the repo filename from the `win_repo_cachefile` setting in the minion config
Fixes: #25437 
