### PR TITLE
Add version_cmp function to yumpkg.py

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -33,6 +33,12 @@ try:
 except ImportError:
     from salt.ext.six.moves import configparser
     HAS_YUM = False
+
+try:
+    import rpmUtils.miscutils
+    HAS_RPMUTILS = True
+except ImportError:
+    HAS_RPMUTILS = False
 # pylint: enable=import-error
 
 # Import salt libs
@@ -498,6 +504,40 @@ def version(*names, **kwargs):
         salt '*' pkg.version <package1> <package2> <package3> ...
     '''
     return __salt__['pkg_resource.version'](*names, **kwargs)
+
+
+def version_cmp(pkg1, pkg2):
+    '''
+    Do a cmp-style comparison on two packages. Return -1 if pkg1 < pkg2, 0 if
+    pkg1 == pkg2, and 1 if pkg1 > pkg2. Return None if there was a problem
+    making the comparison.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.version_cmp '0.2-001' '0.2.0.1-002'
+    '''
+    if HAS_RPMUTILS:
+        try:
+            cmp_result = rpmUtils.miscutils.compareEVR(
+                rpmUtils.miscutils.stringToVersion(pkg1),
+                rpmUtils.miscutils.stringToVersion(pkg2)
+            )
+            if cmp_result not in (-1, 0, 1):
+                raise Exception(
+                    'cmp result \'{0}\' is invalid'.format(cmp_result)
+                )
+            return cmp_result
+        except Exception as exc:
+            log.warning(
+                'Failed to compare version \'{0}\' to \'{1}\' using '
+                'rpmUtils: {2}'.format(pkg1, pkg2, exc)
+            )
+    # Fall back to distutils.version.LooseVersion (should only need to do
+    # this for RHEL5, or if an exception is raised when attempting to compare
+    # using rpmUtils)
+    return salt.utils.version_cmp(pkg1, pkg2)
 
 
 def list_pkgs(versions_as_list=False, **kwargs):
@@ -1086,11 +1126,13 @@ def install(name=None,
             if reinstall and cver \
                     and salt.utils.compare_versions(ver1=version_num,
                                                     oper='==',
-                                                    ver2=cver):
+                                                    ver2=cver,
+                                                    cmp_func=version_cmp):
                 to_reinstall[pkgname] = pkgstr
             elif not cver or salt.utils.compare_versions(ver1=version_num,
                                                          oper='>=',
-                                                         ver2=cver):
+                                                         ver2=cver,
+                                                         cmp_func=version_cmp):
                 targets.append(pkgstr)
             else:
                 downgrade.append(pkgstr)

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -508,6 +508,8 @@ def version(*names, **kwargs):
 
 def version_cmp(pkg1, pkg2):
     '''
+    .. versionadded:: 2015.5.4
+
     Do a cmp-style comparison on two packages. Return -1 if pkg1 < pkg2, 0 if
     pkg1 == pkg2, and 1 if pkg1 > pkg2. Return None if there was a problem
     making the comparison.

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -98,11 +98,12 @@ def _fulfills_version_spec(versions, oper, desired_version):
     Returns True if any of the installed versions match the specified version,
     otherwise returns False
     '''
+    cmp_func = __salt__.get('pkg.version_cmp')
     for ver in versions:
         if salt.utils.compare_versions(ver1=ver,
                                        oper=oper,
                                        ver2=desired_version,
-                                       cmp_func=__salt__.get('version_cmp')):
+                                       cmp_func=cmp_func):
             return True
     return False
 
@@ -1263,7 +1264,7 @@ def latest(
 
     targets = {}
     problems = []
-    cmp_func = __salt__.get('pkg.version_cmp', __salt__.get('version_cmp'))
+    cmp_func = __salt__.get('pkg.version_cmp')
     for pkg in desired_pkgs:
         if not avail[pkg]:
             if not cur[pkg]:

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1996,8 +1996,8 @@ def version_cmp(pkg1, pkg2):
         elif distutils.version.LooseVersion(pkg1) > \
                 distutils.version.LooseVersion(pkg2):
             return 1
-    except Exception as e:
-        log.exception(e)
+    except Exception as exc:
+        log.exception(exc)
     return None
 
 


### PR DESCRIPTION
This uses rpmUtils to more accurately compare version numbers, as
distutils.version.LooseVersion fails to successfully compare some
version numbers.

Fixes #21912.
