### PR TITLE
Highstate output: show duration in seconds instead of milliseconds when appropriate

### DIFF
--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -368,7 +368,15 @@ def _format_host(host, data):
                                                sum(six.itervalues(rcounts)) - rcounts.get('warnings', 0),
                                                line_max_len - 7)
         hstrs.append(colorfmt.format(colors['CYAN'], totals, colors))
-        total_duration = u'Total run time: {0:>{1}} ms'.format(sum(rdurations), line_max_len - 7)
+
+        sum_duration = sum(rdurations)
+        duration_unit = 'ms'
+        # convert to seconds if duration is 1000ms or more
+        if sum_duration > 999:
+            sum_duration /= 1000
+            duration_unit = 's'
+        total_duration = u'Total run time: {0:>{1}} {2}'.format(
+            sum_duration, line_max_len - 7, duration_unit)
         hstrs.append(colorfmt.format(colors['CYAN'], total_duration, colors))
 
     if strip_colors:


### PR DESCRIPTION
It's a bit tough for the brain to process `23623.628 ms` compared to `23.623628 s`.
