### PR TITLE
Adding client_acl functionality to rest_cherrypy API.

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -333,7 +333,7 @@ def salt_token_tool():
 
 def salt_client_acl_tool(username, ip):
     '''
-    ..versionadded:: 2015.5.2
+    ..versionadded:: Boron
 
     Verifies user requests against the API whitelist (IP whitelisting)
     in order to provide whitelisting like the master has for users, but

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -1448,7 +1448,7 @@ class Login(LowDataAdapter):
                        "user {0} from IP {1}")
         success_str = ("[client_acl] Authentication sucessful for "
                        "user {0} from IP {1}")
-        user = creds['username']
+        user = creds.get('username', '')
         ip = cherrypy.request.remote.ip
         if not salt_client_acl_tool(user, ip):
             logger.debug(failure_str.format(user, ip))

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -331,7 +331,7 @@ def salt_token_tool():
         cherrypy.request.cookie['session_id'] = x_auth
 
 
-def salt_client_acl_tool(username, ip):
+def salt_api_acl_tool(username, ip):
     '''
     ..versionadded:: Boron
 
@@ -343,7 +343,7 @@ def salt_client_acl_tool(username, ip):
     if salt_config:
         cherrypy_conf = salt_config.get('rest_cherrypy', None)
         if cherrypy_conf:
-            acl = cherrypy_conf.get('client_acl', None)
+            acl = cherrypy_conf.get('api_acl', None)
             if acl:
                 if username in acl and ip in acl[username]:
                     return True
@@ -1443,14 +1443,14 @@ class Login(LowDataAdapter):
         else:
             creds = cherrypy.serving.request.lowstate
 
-        # Check client acl for the api.
-        failure_str = ("[client_acl] Authentication failed for "
+        # Check acl for the api.
+        failure_str = ("[api_acl] Authentication failed for "
                        "user {0} from IP {1}")
-        success_str = ("[client_acl] Authentication sucessful for "
+        success_str = ("[api_acl] Authentication sucessful for "
                        "user {0} from IP {1}")
         user = creds.get('username', '')
         ip = cherrypy.request.remote.ip
-        if not salt_client_acl_tool(user, ip):
+        if not salt_api_acl_tool(user, ip):
             logger.debug(failure_str.format(user, ip))
             raise cherrypy.HTTPError(401, failure_str.format(user, ip))
         else:

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -1490,7 +1490,7 @@ class Login(LowDataAdapter):
 
         # Validate against the whitelist.
         if not salt_api_acl_tool(creds['username'], cherrypy.request):
-            raise cherrypy.HTTPError(401, failure_str.format(user, ip))
+            raise cherrypy.HTTPError(401)
 
         # Mint token.
         token = self.auth.mk_token(creds)

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -331,26 +331,82 @@ def salt_token_tool():
         cherrypy.request.cookie['session_id'] = x_auth
 
 
-def salt_api_acl_tool(username, ip):
+def salt_api_acl_tool(username, request):
     '''
     ..versionadded:: Boron
 
     Verifies user requests against the API whitelist (IP whitelisting)
     in order to provide whitelisting like the master has for users, but
     over the API.
+
+    ..code-block:: yaml
+    
+        rest_cherrypy:
+            proxy_requests: True
+            proxy_header: 'X-Forwarded-For'
+            users:
+                '*':
+                    - 1.1.1.1
+                    - 1.1.1.2
+                foo:
+                    - 8.8.4.4
     '''
+    failure_str = ("[api_acl] Authentication failed for "
+                   "user {0} from IP {1}")
+    success_str = ("[api_acl] Authentication sucessful for "
+                   "user {0} from IP {1}")
+    # Salt Configuration
     salt_config = cherrypy.config.get('saltopts', None)
     if salt_config:
+        # Cherrypy Config.
         cherrypy_conf = salt_config.get('rest_cherrypy', None)
         if cherrypy_conf:
+            # ACL Config.
             acl = cherrypy_conf.get('api_acl', None)
             if acl:
-                if username in acl and ip in acl[username]:
-                    return True
-                elif username in acl and ip not in acl[username]:
-                    return False
+                # Check users first so we don't even bother with
+                # checking the ACL if the user isn't in the whitelist.
+                users = acl.get('users', {})
+                if username in users or '*' in users:
+                    check_user = username if username in users else '*'
+                    # Do we serve requests through a proxy?
+                    proxy = acl.get('proxy_requests', False)
+                    if proxy:
+                        # Do we have a special header?
+                        proxy_header = acl.get('proxy_header', 'X-Forwarded-For')
+                        ips = request.headers.get(proxy_header)
+                        if ips and isinstance(ips, list):
+                            for ip in ips:
+                                if ip in users[check_user]:
+                                     logger.info(success_str.format(username, ips))
+                                     return True
+                            else:
+                                logger.info(failure_str.format(username, ips))
+                                return False
+                        elif ips and isinstance(ips, str):
+                            if ip in users[check_user]:
+                                logger.info(success_str.format(username, ip))
+                                return True
+                            else:
+                                logger.info(failure_str.format(username, ip))
+                                return False
+                        else:
+                            ip = request.remote.ip
+                            if ip in users[check_user]:
+                                logger.info(success_str.format(username, ip))
+                                return True
+                            else:
+                                logger.info(failure_str.format(username, ip))
+                                return False
+                    else:
+                        ip = request.remote.ip
+                        if ip in users[check_user]:
+                            logger.info(success_str.format(username, ip))
+                            return True
+                        else:
+                            logger.info(failure_str.format(username, ip))
+                            return False
     return True
-
 
 def salt_ip_verify_tool():
     '''

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -344,10 +344,11 @@ def salt_client_acl_tool(username, ip):
         cherrypy_conf = salt_config.get('rest_cherrypy', None)
         if cherrypy_conf:
             acl = cherrypy_conf.get('client_acl', None)
-            if username in acl and ip in acl[username]:
-                return True
-            elif username in acl and not ip in acl[username]:
-                return False
+            if acl:
+                if username in acl and ip in acl[username]:
+                    return True
+                elif username in acl and not ip in acl[username]:
+                    return False
     return True
 
 

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -1501,7 +1501,7 @@ class Login(LowDataAdapter):
             creds = cherrypy.serving.request.lowstate
 
         # Validate against the whitelist.
-        if not salt_api_acl_tool(user, cherrypy.request):
+        if not salt_api_acl_tool(creds['username'], cherrypy.request):
             raise cherrypy.HTTPError(401, failure_str.format(user, ip))
 
         # Mint token.

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -347,7 +347,7 @@ def salt_client_acl_tool(username, ip):
             if acl:
                 if username in acl and ip in acl[username]:
                     return True
-                elif username in acl and not ip in acl[username]:
+                elif username in acl and ip not in acl[username]:
                     return False
     return True
 

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -1499,24 +1499,9 @@ class Login(LowDataAdapter):
         else:
             creds = cherrypy.serving.request.lowstate
 
-        # Check acl for the api.
-        failure_str = ("[api_acl] Authentication failed for "
-                       "user {0} from IP {1}")
-        success_str = ("[api_acl] Authentication sucessful for "
-                       "user {0} from IP {1}")
-        user = creds.get('username', '')
-
-        # Check if handling a request from a proxy.
-        ip = cherrypy.request.headers.get('X-Forwarded-For', None)
-        if not ip:
-            ip = cherrypy.request.remote.ip
-
         # Validate against the whitelist.
         if not salt_api_acl_tool(user, ip):
-            logger.debug(failure_str.format(user, ip))
             raise cherrypy.HTTPError(401, failure_str.format(user, ip))
-        else:
-            logger.debug(success_str.format(user, ip))
 
         # Mint token.
         token = self.auth.mk_token(creds)

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -342,14 +342,15 @@ def salt_api_acl_tool(username, request):
     ..code-block:: yaml
     
         rest_cherrypy:
-            proxy_requests: True
-            proxy_header: 'X-Forwarded-For'
-            users:
-                '*':
-                    - 1.1.1.1
-                    - 1.1.1.2
-                foo:
-                    - 8.8.4.4
+            api_acl:
+                proxy_requests: True
+                proxy_header: 'X-Forwarded-For'
+                users:
+                    '*':
+                        - 1.1.1.1
+                        - 1.1.1.2
+                    foo:
+                        - 8.8.4.4
     '''
     failure_str = ("[api_acl] Authentication failed for "
                    "user {0} from IP {1}")

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -1500,7 +1500,7 @@ class Login(LowDataAdapter):
             creds = cherrypy.serving.request.lowstate
 
         # Validate against the whitelist.
-        if not salt_api_acl_tool(user, ip):
+        if not salt_api_acl_tool(user, cherrypy.request):
             raise cherrypy.HTTPError(401, failure_str.format(user, ip))
 
         # Mint token.

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -1436,6 +1436,12 @@ class Login(LowDataAdapter):
             raise salt.exceptions.SaltDaemonNotRunning(
                 'Salt Master is not available.')
 
+        # the urlencoded_processor will wrap this in a list
+        if isinstance(cherrypy.serving.request.lowstate, list):
+            creds = cherrypy.serving.request.lowstate[0]
+        else:
+            creds = cherrypy.serving.request.lowstate
+
         # Check client acl for the api.
         failure_str = ("[client_acl] Authentication failed for "
                        "user {0} from IP {1}")
@@ -1448,12 +1454,6 @@ class Login(LowDataAdapter):
             raise cherrypy.HTTPError(401, failure_str.format(user, ip))
         else:
             logger.debug(success_str.format(user, ip))
-
-        # the urlencoded_processor will wrap this in a list
-        if isinstance(cherrypy.serving.request.lowstate, list):
-            creds = cherrypy.serving.request.lowstate[0]
-        else:
-            creds = cherrypy.serving.request.lowstate
 
         token = self.auth.mk_token(creds)
         if 'token' not in token:

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -371,7 +371,7 @@ def salt_api_acl_tool(username, request):
         if cherrypy_conf:
             # ACL Config.
             acl = cherrypy_conf.get('api_acl', None)
-    
+
     if acl:
         users = acl.get('users', {})
         if users:
@@ -396,6 +396,7 @@ def salt_api_acl_tool(username, request):
     else:
         logger.info(pass_str.format(username, ip))
         return True
+
 
 def salt_ip_verify_tool():
     '''

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -372,10 +372,10 @@ def salt_api_acl_tool(username, request):
             # ACL Config.
             acl = cherrypy_conf.get('api_acl', None)
 
+    ip = request.remote.ip
     if acl:
         users = acl.get('users', {})
         if users:
-            ip = request.remote.ip
             if username in users:
                 if ip in users[username]:
                     logger.info(success_str.format(username, ip))

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -1488,8 +1488,9 @@ class Login(LowDataAdapter):
         else:
             creds = cherrypy.serving.request.lowstate
 
+        username = creds.get('username', None)
         # Validate against the whitelist.
-        if not salt_api_acl_tool(creds['username'], cherrypy.request):
+        if not salt_api_acl_tool(username, cherrypy.request):
             raise cherrypy.HTTPError(401)
 
         # Mint token.


### PR DESCRIPTION
Hey Saltstack folks!

We have a business need for allowing certain users to access the API from certain hosts.  Because of this the normal whitelist IP wouldn't work, so I stole the idea from master and made a client_acl inside of the rest_cherrypy configuration.  It looks similar to the other one as well:

```
rest_cherrypy:
  port: 8888
  client_acl:
    user1:
      - 1.1.1.1
    user2:
      - 1.1.1.2
```

This has been tested and working using the following inputs:
- Valid user and valid IP
- Valid user and invalid IP
- Invalid user and valid IP
- Invalid user and invalid IP

All seem to work.  This also should work without the value being there, so nobody who is using the API should have to change anything, it's just a new feature they can get.

If there's a better place to put this, please let me know, but this was pretty easy to implement here.

Thanks.
