### PR TITLE
Fix pkgng provider to work with a sources list and the underlying pkg…

### DIFF
--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -746,7 +746,9 @@ def install(name=None,
 
     if pkg_type == 'file':
         pkg_cmd = 'add'
-        targets = list(pkg_params.keys())
+        # pkg add has smaller set of options (i.e. no -y or -n), filter below
+        opts = ''.join([opt for opt in opts if opt in 'AfIMq'])
+        targets = pkg_params
     elif pkg_type == 'repository':
         pkg_cmd = 'install'
         if pkgs is None and kwargs.get('version') and len(pkg_params) == 1:
@@ -763,6 +765,11 @@ def install(name=None,
     cmd = '{0} {1} {2} {3} {4}'.format(
         _pkg(jail, chroot), pkg_cmd, repo_opts, opts, ' '.join(targets)
     )
+
+    if pkg_cmd == 'add' and salt.utils.is_true(dryrun):
+        # pkg add doesn't have a dryrun mode, so echo out what will be run
+        return cmd
+
     __salt__['cmd.run'](cmd, python_shell=False, output_loglevel='trace')
     __context__.pop(_contextkey(jail, chroot), None)
     __context__.pop(_contextkey(jail, chroot, prefix='pkg.origin'), None)


### PR DESCRIPTION
Dryrun:

```
root@salt-freebsd-kev009 # salt-call pkg.install sources='[{"iocage":"http://pkg.freebsd.org/freebsd:10:x86:64/latest/All/iocage-1.6.2.txz"},{"zfs-stats-lite":"http://pkg.freebsd.org/freebsd:10:x86:64/latest/All/zfs-stats-lite-1.1.txz"}]' dryrun=True
[INFO    ] Executing command '/sbin/zfs help' in directory '/root'
[INFO    ] Starting new HTTP connection (1): pkg.freebsd.org
[INFO    ] Starting new HTTP connection (1): pkg.freebsd.org
[INFO    ] Executing command 'pkg info -ao' in directory '/root'
local:
    pkg add   /var/cache/salt/minion/extrn_files/base/pkg.freebsd.org/freebsd:10:x86:64/latest/All/zfs-stats-lite-1.1.txz /var/cache/salt/minion/extrn_files/base/pkg.freebsd.org/freebsd:10:x86:64/latest/All/iocage-1.6.2.txz
```

Installation:

```
root@salt-freebsd-kev009 # salt-call pkg.install sources='[{"iocage":"http://pkg.freebsd.org/freebsd:10:x86:64/latest/All/iocage-1.6.2.txz"},{"zfs-stats-lite":"http://pkg.freebsd.org/freebsd:10:x86:64/latest/All/zfs-stats-lite-1.1.txz"}]'~
[INFO    ] Executing command '/sbin/zfs help' in directory '/root'
[INFO    ] Starting new HTTP connection (1): pkg.freebsd.org
[INFO    ] Starting new HTTP connection (1): pkg.freebsd.org
[INFO    ] Executing command 'pkg info -ao' in directory '/root'
[INFO    ] Executing command 'pkg add   /var/cache/salt/minion/extrn_files/base/pkg.freebsd.org/freebsd:10:x86:64/latest/All/zfs-stats-lite-1.1.txz /var/cache/salt/minion/extrn_files/base/pkg.freebsd.org/freebsd:10:x86:64/latest/All/iocage-1.6.2.txz' in directory '/root'
[INFO    ] Executing command 'pkg info -ao' in directory '/root'
local:
    ----------
    iocage:
        ----------
        new:
            1.6.2
        old:

    zfs-stats-lite:
        ----------
        new:
            1.1
        old:

```

Already installed:

```
root@salt-freebsd-kev009 #
salt-call pkg.install
sources='[{"iocage":"http://pkg.freebsd.org/freebsd:10:x86:64/latest/All/iocage-1.6.2.txz"},{"zfs-stats-lite":"http://pkg.freebsd.org/freebsd:10:x86:64/latest/All/zfs-stats-lite-1.1.txz"}]'
[INFO    ] Executing command '/sbin/zfs help' in directory '/root'
[INFO    ] Starting new HTTP connection (1): pkg.freebsd.org
[INFO    ] Starting new HTTP connection (1): pkg.freebsd.org
[INFO    ] Executing command 'pkg info -ao' in directory '/root'
[INFO    ] Executing command 'pkg add
/var/cache/salt/minion/extrn_files/base/pkg.freebsd.org/freebsd:10:x86:64/latest/All/zfs-stats-lite-1.1.txz
/var/cache/salt/minion/extrn_files/base/pkg.freebsd.org/freebsd:10:x86:64/latest/All/iocage-1.6.2.txz'
in directory '/root'
[INFO    ] Executing command 'pkg info -ao' in directory '/root'
local:
    ----------
```
