### PR TITLE
Properly align highstate duration sum

### DIFF
--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -375,8 +375,9 @@ def _format_host(host, data):
         if sum_duration > 999:
             sum_duration /= 1000
             duration_unit = 's'
-        total_duration = u'Total run time: {0:>{1}} {2}'.format(
-            sum_duration, line_max_len - 7, duration_unit)
+        total_duration = u'Total run time: {0} {1}'.format(
+            '{:.3f}'.format(sum_duration).rjust(9 - len(duration_unit)),
+            duration_unit)
         hstrs.append(colorfmt.format(colors['CYAN'], total_duration, colors))
 
     if strip_colors:


### PR DESCRIPTION
Currently, the highstate duration is prone to be misaligned with the number of states ran. Normalizing to 3 decimals and using `rjust` seems to fix the problem.

Sample output after my changes:

```
$ salt-ssh vagrant-dev state.highstate
vagrant-dev:

Summary for vagrant-dev
------------
Succeeded: 2
Failed:    0
------------
Total states run:     2
Total run time:  57.090 ms

$ salt-ssh vagrant-dev state.highstate
vagrant-dev:

Summary for vagrant-dev
-------------
Succeeded: 18
Failed:     0
-------------
Total states run:     18
Total run time:    9.970 s

$ salt-ssh vagrant-dev state.highstate
vagrant-dev:

Summary for vagrant-dev
-------------
Succeeded: 70
Failed:     0
-------------
Total states run:     70
Total run time:   27.972 s
```
