### PR TITLE
Fix locale detection in debian/gentoo

### DIFF
--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -259,13 +259,17 @@ def gen_locale(locale, **kwargs):
     locale_info = _split_locale(locale)
 
     if on_debian or on_gentoo:  # file-based search
-        search = '/usr/share/i18n/SUPPORTED'
-        valid = __salt__['file.search'](search, '^{0}$'.format(locale))
+        path = '/usr/share/i18n/SUPPORTED'
+        def search_locale():
+            return __salt__['file.search'](path,
+                                           '^{0}$'.format(locale),
+                                           flags=re.MULTILINE)
+        valid = search_locale()
         if not valid and not locale_info['charmap']:
             # charmap was not supplied, so try copying the codeset
             locale_info['charmap'] = locale_info['codeset']
             locale = _join_locale(locale_info)
-            valid = __salt__['file.search'](search, '^{0}$'.format(locale))
+            valid = search_locale()
     else:  # directory-based search
         if on_suse:
             search = '/usr/share/locale'

--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -260,10 +260,12 @@ def gen_locale(locale, **kwargs):
 
     if on_debian or on_gentoo:  # file-based search
         path = '/usr/share/i18n/SUPPORTED'
+
         def search_locale():
             return __salt__['file.search'](path,
                                            '^{0}$'.format(locale),
                                            flags=re.MULTILINE)
+
         valid = search_locale()
         if not valid and not locale_info['charmap']:
             # charmap was not supplied, so try copying the codeset

--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -259,10 +259,10 @@ def gen_locale(locale, **kwargs):
     locale_info = _split_locale(locale)
 
     if on_debian or on_gentoo:  # file-based search
-        path = '/usr/share/i18n/SUPPORTED'
+        search = '/usr/share/i18n/SUPPORTED'
 
         def search_locale():
-            return __salt__['file.search'](path,
+            return __salt__['file.search'](search,
                                            '^{0}$'.format(locale),
                                            flags=re.MULTILINE)
 

--- a/tests/unit/modules/localemod_test.py
+++ b/tests/unit/modules/localemod_test.py
@@ -114,7 +114,7 @@ class LocalemodTestCase(TestCase):
         '''
         Tests the return of successful gen_locale on Debian system without a charmap
         '''
-        def file_search(search, pattern):
+        def file_search(search, pattern, flags):
             '''
             mock file.search
             '''
@@ -164,7 +164,7 @@ class LocalemodTestCase(TestCase):
         '''
         Tests the return of successful gen_locale on Gentoo system without a charmap
         '''
-        def file_search(search, pattern):
+        def file_search(search, pattern, flags):
             '''
             mock file.search
             '''


### PR DESCRIPTION
Need to pass the `re.MULTILINE` flag for the search to work properly.

Wrote an inner function to reduce code duplication while at it.
