### PR TITLE
Bugfix: crash at getting non-existing repo

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -280,7 +280,7 @@ def _get_repo_info(alias, repos_cfg=None):
             elif val == 'NONE':
                 meta[key] = None
         return meta
-    except ValueError:
+    except (ValueError, configparser.NoSectionError) as error:
         return {}
 
 


### PR DESCRIPTION
This fixes:
- State for `pkgrepo` to add/remove the repo for SUSE zypper
- Command `pkg.get_repo nonexistingrepo`
