### PR TITLE
add glusterfs' direct-io-mode to mount_invisible_keys

### DIFF
--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -226,6 +226,7 @@ def mounted(name,
                 mount_invisible_keys = [
                     'actimeo',
                     'comment',
+                    'direct-io-mode',
                     'password',
                     'retry',
                     'port',


### PR DESCRIPTION
When mounting a glusterfs volume, the "direct-io-mode" is an invisible option, causing the volume to be remounted on every highstate run. This adds the option to the mount_invisible_keys list.
