### PR TITLE
Fix pacman.list_upgrades when refresh=True.

### DIFF
--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -142,11 +142,9 @@ def list_upgrades(refresh=False):
     else:
         out = call['stdout']
 
-    output = iter(out.splitlines())
-    output.next()  # Skip informational output line
-    for line in output:
+    for line in iter(out.splitlines()):
         comps = line.split(' ')
-        if len(comps) < 2:
+        if len(comps) != 2:
             continue
         upgrades[comps[0]] = comps[1]
     return upgrades


### PR DESCRIPTION
When refresh=True, there more than 1 informational line.
Only use lines that match the specified print format,
which has one space (all other lines have more than one space).
