### PR TITLE
[2015.5] Move cmd.run jinja aliasing to a wrapper class to prevent side effects

### DIFF
--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -72,7 +72,7 @@ class AliasedLoader:
     def __getitem__(self, name):
         if name in ALIASES:
             salt.utils.warn_until('Nitrogen', ALIAS_WARN)
-            return self.wrapped[ALIASES['name']]
+            return self.wrapped[ALIASES[name]]
         else:
             return self.wrapped[name]
 

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -54,7 +54,7 @@ ALIASES = {
 }
 
 
-class AliasedLoader:
+class AliasedLoader(object):
     '''
     Light wrapper around the LazyLoader to redirect 'cmd.run' calls to
     'cmd.shell', for easy use of shellisms during templating calls
@@ -84,7 +84,7 @@ class AliasedLoader:
             return getattr(self.wrapped, name)
 
 
-class AliasedModule:
+class AliasedModule(object):
     '''
     Light wrapper around module objects returned by the LazyLoader's getattr
     for the purposes of `salt.cmd.run()` syntax in templates

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -41,6 +41,68 @@ TEMPLATE_DIRNAME = os.path.join(saltpath[0], 'templates')
 SLS_ENCODING = 'utf-8'  # this one has no BOM.
 SLS_ENCODER = codecs.getencoder(SLS_ENCODING)
 
+ALIAS_WARN = (
+        'Starting in 2015.5, cmd.run uses python_shell=False by default, '
+        'which doesn\'t support shellisms (pipes, env variables, etc). '
+        'cmd.run is currently aliased to cmd.shell to prevent breakage. '
+        'Please switch to cmd.shell or set python_shell=True to avoid '
+        'breakage in the future, when this aliasing is removed.'
+)
+
+
+class AliasedLoader:
+    '''
+    Light wrapper around the LazyLoader to redirect 'cmd.run' calls to
+    'cmd.shell', for easy use of shellisms during templating calls
+
+    Dotted aliases ('cmd.run') must resolve to another dotted alias
+    (e.g. 'cmd.shell')
+
+    Non-dotted aliases ('cmd') must resolve to a dictionary of function
+    aliases for that module (e.g. {'run': 'shell'})
+    '''
+    aliases = {
+            'cmd.run': 'cmd.shell',
+            'cmd': {'run': 'shell'},
+    }
+
+    def __init__(self, wrapped):
+        self.wrapped = wrapped
+
+    def __getitem__(self, name):
+        if name in aliases:
+            salt.utils.warn_until('Nitrogen', ALIAS_WARN)
+            return self.wrapped[aliases['name']]
+        else:
+            return self.wrapped[name]
+
+    def __getattr__(self, name):
+        if name in aliases:
+            salt.utils.warn_until('Nitrogen', ALIAS_WARN)
+            return AliasedModule(getattr(self.wrapped, name), aliases[name])
+        else:
+            return getattr(self.wrapped, name)
+
+
+class AliasedModule:
+    '''
+    Light wrapper around module objects returned by the LazyLoader's getattr
+    for the purposes of `salt.cmd.run()` syntax in templates
+
+    Allows for aliasing specific functions, such as `run` to `shell` for easy
+    use of shellisms during templating calls
+    '''
+    def __init__(self, wrapped, aliases):
+        self.aliases = aliases
+        self.wrapped = wrapped
+
+    def __getattr__(self, name):
+        if name in aliases:
+            salt.utils.warn_until('Nitrogen', ALIAS_WARN)
+            return getattr(self.wrapped, aliases[name])
+        else:
+            return getattr(self.wrapped, name)
+
 
 def wrap_tmpl_func(render_str):
 
@@ -57,11 +119,7 @@ def wrap_tmpl_func(render_str):
         # Alias cmd.run to cmd.shell to make python_shell=True the default for
         # templated calls
         if 'salt' in kws:
-            if 'cmd.run' in kws['salt'] and 'cmd.shell' in kws['salt']:
-                kws['salt']['cmd.run'] = kws['salt']['cmd.shell']
-            if 'run' in kws['salt'].get('cmd', {}) \
-                    and 'shell' in kws['salt'].get('cmd', {}):
-                kws['salt']['cmd']['run'] = kws['salt']['cmd']['shell']
+            kws['salt'] = AliasedLoader(kws['salt'])
 
         # We want explicit context to overwrite the **kws
         kws.update(context)

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -97,9 +97,9 @@ class AliasedModule:
         self.wrapped = wrapped
 
     def __getattr__(self, name):
-        if name in aliases:
+        if name in self.aliases:
             salt.utils.warn_until('Nitrogen', ALIAS_WARN)
-            return getattr(self.wrapped, aliases[name])
+            return getattr(self.wrapped, self.aliases[name])
         else:
             return getattr(self.wrapped, name)
 

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -48,6 +48,10 @@ ALIAS_WARN = (
         'Please switch to cmd.shell or set python_shell=True to avoid '
         'breakage in the future, when this aliasing is removed.'
 )
+ALIASES = {
+        'cmd.run': 'cmd.shell',
+        'cmd': {'run': 'shell'},
+}
 
 
 class AliasedLoader:
@@ -61,25 +65,21 @@ class AliasedLoader:
     Non-dotted aliases ('cmd') must resolve to a dictionary of function
     aliases for that module (e.g. {'run': 'shell'})
     '''
-    aliases = {
-            'cmd.run': 'cmd.shell',
-            'cmd': {'run': 'shell'},
-    }
 
     def __init__(self, wrapped):
         self.wrapped = wrapped
 
     def __getitem__(self, name):
-        if name in aliases:
+        if name in ALIASES:
             salt.utils.warn_until('Nitrogen', ALIAS_WARN)
-            return self.wrapped[aliases['name']]
+            return self.wrapped[ALIASES['name']]
         else:
             return self.wrapped[name]
 
     def __getattr__(self, name):
-        if name in aliases:
+        if name in ALIASES:
             salt.utils.warn_until('Nitrogen', ALIAS_WARN)
-            return AliasedModule(getattr(self.wrapped, name), aliases[name])
+            return AliasedModule(getattr(self.wrapped, name), ALIASES[name])
         else:
             return getattr(self.wrapped, name)
 

--- a/salt/version.py
+++ b/salt/version.py
@@ -83,7 +83,7 @@ class SaltStackVersion(object):
         'Beryllium'     : (MAX_SIZE - 105, 0),
         'Boron'         : (MAX_SIZE - 104, 0),
         'Carbon'        : (MAX_SIZE - 103, 0),
-        #'Nitrogen'     : (MAX_SIZE - 102, 0),
+        'Nitrogen'      : (MAX_SIZE - 102, 0),
         #'Oxygen'       : (MAX_SIZE - 101, 0),
         #'Fluorine'     : (MAX_SIZE - 100, 0),
         #'Neon'         : (MAX_SIZE - 99 , 0),


### PR DESCRIPTION
Wrap the LazyLoader in the templating context to allow us to alias cmd.run to cmd.shell until Nitrogen.

Previous aliasing could cause side effects in other areas of salt, and copy.deepcopy was killing performance.

Refs #25049 

@terminalmage mind testing to make sure this alleviates the side effects you were seeing?

@cachedout would love a review
