### PR TITLE
Fix doc around Include/Exclude for states

### DIFF
--- a/doc/ref/states/include.rst
+++ b/doc/ref/states/include.rst
@@ -2,15 +2,15 @@
 Include and Exclude
 ===================
 
-Salt sls files can include other sls files and exclude sls files that have been
-otherwise included. This allows for an sls file to easily extend or manipulate
-other sls files.
+Salt SLS files can include other SLS files and exclude SLS files that have been
+otherwise included. This allows for an SLS file to easily extend or manipulate
+other SLS files.
 
 Include
 =======
 
-When other sls files are included, everything defined in the included sls file
-will be added to the state run. When including define a list of sls formulas
+When other SLS files are included, everything defined in the included SLS file
+will be added to the state run. When including define a list of SLS formulas
 to include:
 
 .. code-block:: yaml
@@ -19,10 +19,10 @@ to include:
       - http
       - libvirt
 
-The include statement will include sls formulas from the same environment
-that the including sls formula is in. But the environment can be explicitly
+The include statement will include SLS formulas from the same environment
+that the including SLS formula is in. But the environment can be explicitly
 defined in the configuration to override the running environment, therefore
-if an sls formula needs to be included from an external environment named "dev"
+if an SLS formula needs to be included from an external environment named "dev"
 the following syntax is used:
 
 .. code-block:: yaml
@@ -30,8 +30,8 @@ the following syntax is used:
     include:
       - dev: http
 
-**NOTE**: `include` does not simply inject the states where you place it
-in the sls file. If you need to guarantee order of execution, consider using 
+**NOTE**: ``include`` does not simply inject the states where you place it
+in the SLS file. If you need to guarantee order of execution, consider using 
 requisites.
 
 .. include:: ../../_incl/_incl/sls_filename_cant_contain_period.rst
@@ -39,9 +39,9 @@ requisites.
 Relative Include
 ================
 
-In Salt 0.16.0 the capability to include sls formulas which are relative to
-the running sls formula was added, simply precede the formula name with a
-`.`:
+In Salt 0.16.0, the capability to include SLS formulas which are relative to
+the running SLS formula was added.  Simply precede the formula name with a
+``.``:
 
 .. code-block:: yaml
 
@@ -49,14 +49,15 @@ the running sls formula was added, simply precede the formula name with a
       - .virt
       - .virt.hyper
 
-In Salt 2015.8, the ability to include sls formulas which are relative to the
-the parents of the running sls forumla was added.  In order to achieve this,
-prece the formula name with more than one `.`. Much like Python's relative
-import abilities, two or more leading dots give a relative import to the
-parent or parents of the current package, with each `.` representing one level
-after the first.
+In Salt 2015.8, the ability to include SLS formulas which are relative to the
+parents of the running SLS formula was added.  In order to achieve this,
+precede the formula name with more than one ``.`` (dot). Much like Python's
+relative import abilities, two or more leading dots represent a relative
+include of the parent or parents of the current package, with each ``.``
+representing one level after the first.
 
-Within a sls fomula at ``example.dev.virtual``, the following:
+The following SLS configuration, if placed within ``example.dev.virtual``,
+would result in ``example.http`` and ``base`` being included respectively:
 
 .. code-block:: yaml
 
@@ -64,20 +65,19 @@ Within a sls fomula at ``example.dev.virtual``, the following:
       - ..http
       - ...base
 
-would result in ``example.http`` and ``base`` being included.
 
 Exclude
 =======
 
-The exclude statement, added in Salt 0.10.3 allows an sls to hard exclude
-another sls file or a specific id. The component is excluded after the
+The exclude statement, added in Salt 0.10.3, allows an SLS to hard exclude
+another SLS file or a specific id. The component is excluded after the
 high data has been compiled, so nothing should be able to override an
 exclude.
 
-Since the exclude can remove an id or an sls the type of component to
-exclude needs to be defined. An exclude statement that verifies that the
-running highstate does not contain the `http` sls and the `/etc/vimrc` id
-would look like this:
+Since the exclude can remove an id or an SLS the type of component to exclude
+needs to be defined. An exclude statement that verifies that the running
+highstate does not contain the ``http`` SLS and the ``/etc/vimrc`` id would
+look like this:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Fixes a number of my own spelling mistakes, and cleans up the documentation around including/excluding within SLS files, especially making sure `.` characters can be read clearly.
