### PR TITLE
Don't acquire lock if there is no formatter

### DIFF
--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -208,13 +208,13 @@ class SaltLoggingClass(six.with_metaclass(LoggingMixInMeta, LOGGING_LOGGER_CLASS
                                LOGGING_TEMP_HANDLER):
                     continue
 
-                if not handler.lock:
-                    handler.createLock()
-                handler.acquire()
-
                 formatter = handler.formatter
                 if not formatter:
                     continue
+
+                if not handler.lock:
+                    handler.createLock()
+                handler.acquire()
 
                 fmt = formatter._fmt.replace('%', '%%')
 


### PR DESCRIPTION
this cause locking when a log handler don't have a formatter.
Sometimes, log handler don't need one
