### PR TITLE
Fix highstate duration alignment (again)

### DIFF
--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -376,7 +376,7 @@ def _format_host(host, data):
             sum_duration /= 1000
             duration_unit = 's'
         total_duration = u'Total run time: {0} {1}'.format(
-            '{:.3f}'.format(sum_duration).rjust(9 - len(duration_unit)),
+            '{:.3f}'.format(sum_duration).rjust(line_max_len - 5),
             duration_unit)
         hstrs.append(colorfmt.format(colors['CYAN'], total_duration, colors))
 


### PR DESCRIPTION
Followup to https://github.com/saltstack/salt/pull/25653 - correcting my mistakes.

Honestly, I'm not sure why it worked previously.

Sample output:

```
$ salt-ssh '*' state.highstate
Summary for vagrant-dev
-------------
Succeeded: 75
Failed:     0
-------------
Total states run:     75
Total run time:  627.733 ms

Summary for vagrant-test
--------------
Succeeded: 115
Failed:      0
--------------
Total states run:     115
Total run time:     2.153 s

Summary for vagrant-test2
--------------
Succeeded: 116
Failed:      0
--------------
Total states run:     116
Total run time:    12.137 s
```
