### PR TITLE
Minor docs changes to emphasize JSON output problems without `--static` option

### DIFF
--- a/doc/man/salt-call.1
+++ b/doc/man/salt-call.1
@@ -206,7 +206,8 @@ using the Python \fBpprint\fP standard library module.
 .INDENT 7.0
 .INDENT 3.5
 If using \fB\-\-out=json\fP, you will probably want \fB\-\-static\fP as well.
-Without the static option, you will get a JSON string for each minion.
+Without the static option, you will get a separate JSON string per minion
+which makes JSON output invalid as a whole.
 This is due to using an iterative outputter. So if you want to feed it
 to a JSON parser, use \fB\-\-static\fP as well.
 .UNINDENT

--- a/doc/man/salt-cloud.1
+++ b/doc/man/salt-cloud.1
@@ -255,7 +255,8 @@ using the Python \fBpprint\fP standard library module.
 .INDENT 7.0
 .INDENT 3.5
 If using \fB\-\-out=json\fP, you will probably want \fB\-\-static\fP as well.
-Without the static option, you will get a JSON string for each minion.
+Without the static option, you will get a separate JSON string per minion
+which makes JSON output invalid as a whole.
 This is due to using an iterative outputter. So if you want to feed it
 to a JSON parser, use \fB\-\-static\fP as well.
 .UNINDENT

--- a/doc/man/salt-key.1
+++ b/doc/man/salt-key.1
@@ -135,7 +135,8 @@ using the Python \fBpprint\fP standard library module.
 .INDENT 7.0
 .INDENT 3.5
 If using \fB\-\-out=json\fP, you will probably want \fB\-\-static\fP as well.
-Without the static option, you will get a JSON string for each minion.
+Without the static option, you will get a separate JSON string per minion
+which makes JSON output invalid as a whole.
 This is due to using an iterative outputter. So if you want to feed it
 to a JSON parser, use \fB\-\-static\fP as well.
 .UNINDENT

--- a/doc/man/salt-ssh.1
+++ b/doc/man/salt-ssh.1
@@ -221,7 +221,8 @@ using the Python \fBpprint\fP standard library module.
 .INDENT 7.0
 .INDENT 3.5
 If using \fB\-\-out=json\fP, you will probably want \fB\-\-static\fP as well.
-Without the static option, you will get a JSON string for each minion.
+Without the static option, you will get a separate JSON string per minion
+which makes JSON output invalid as a whole.
 This is due to using an iterative outputter. So if you want to feed it
 to a JSON parser, use \fB\-\-static\fP as well.
 .UNINDENT

--- a/doc/man/salt.1
+++ b/doc/man/salt.1
@@ -280,7 +280,8 @@ using the Python \fBpprint\fP standard library module.
 .INDENT 7.0
 .INDENT 3.5
 If using \fB\-\-out=json\fP, you will probably want \fB\-\-static\fP as well.
-Without the static option, you will get a JSON string for each minion.
+Without the static option, you will get a separate JSON string per minion
+which makes JSON output invalid as a whole.
 This is due to using an iterative outputter. So if you want to feed it
 to a JSON parser, use \fB\-\-static\fP as well.
 .UNINDENT

--- a/doc/man/salt.1
+++ b/doc/man/salt.1
@@ -82,8 +82,10 @@ query the minions and check on running jobs. Default: 5
 .B \-s, \-\-static
 By default as of version 0.9.8 the salt command returns data to the
 console as it is received from minions, but previous releases would return
-data only after all data was received. To only return the data with a hard
-timeout and after all minions have returned then use the static option.
+data only after all data was received. Use the static option to only return
+the data with a hard timeout and after all minions have returned.
+Without the static option, you will get a separate JSON string per minion
+which makes JSON output invalid as a whole.
 .UNINDENT
 .INDENT 0.0
 .TP

--- a/doc/ref/cli/_includes/output-options.rst
+++ b/doc/ref/cli/_includes/output-options.rst
@@ -18,7 +18,8 @@ Output Options
 
     .. note::
         If using ``--out=json``, you will probably want ``--static`` as well.
-        Without the static option, you will get a JSON string for each minion.
+        Without the static option, you will get a separate JSON string per minion
+        which makes JSON output invalid as a whole.
         This is due to using an iterative outputter. So if you want to feed it
         to a JSON parser, use ``--static`` as well.
 

--- a/doc/ref/cli/salt.rst
+++ b/doc/ref/cli/salt.rst
@@ -34,8 +34,10 @@ Options
 
     By default as of version 0.9.8 the salt command returns data to the
     console as it is received from minions, but previous releases would return
-    data only after all data was received. To only return the data with a hard
-    timeout and after all minions have returned then use the static option.
+    data only after all data was received. Use the static option to only return
+    the data with a hard timeout and after all minions have returned.
+    Without the static option, you will get a separate JSON string per minion
+    which makes JSON output invalid as a whole.
 
 .. option:: --async
 


### PR DESCRIPTION
This is supposed to be a follow up for issues #25154 and #25153 to close them.

The docs are simply clearer now for the cases when JSON output is used without `--static` option.
