### PR TITLE
cleanup of python requirements

### DIFF
--- a/pkg/smartos/esky/requirements.txt
+++ b/pkg/smartos/esky/requirements.txt
@@ -1,4 +1,2 @@
 GitPython==0.3.2.RC1
-halite
 -r ../../../requirements/opt.txt
--r ../../../requirements/cloud.txt


### PR DESCRIPTION
halite is deprecated, could requirements file got removed so importing it fails in the until loops. esky packages now builds on smartos base-64-lts 14.4.0 - version salt-2015.8.0rc2
