### PR TITLE
Avoid IndexError when listing mounts if mount output ends in newline

### DIFF
--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -41,7 +41,8 @@ def _list_mounts():
 
     for line in mounts.split('\n'):
         comps = re.sub(r"\s+", " ", line).split()
-        ret[comps[2]] = comps[0]
+        if len(comps) >= 3:
+            ret[comps[2]] = comps[0]
     return ret
 
 


### PR DESCRIPTION
When attempting to list mounts (eg via `mount.active` module or `mount.mounted` state), if the underlying `mount` command's stdout ends with a tailing newline char, this produces `IndexError out of range` because no elements are present in an empty line.

The raw output from my `mount -l` (retrieved by `salt-ssh '*' cmd.runstdout 'mount -l' --out=raw`) is (noting the traiilng newline):

```
'/dev/mapper/vg0-root on / type ext3 (rw)\nproc on /proc type proc (rw)\nsysfs on /sys type sysfs (rw)\ndevpts on /dev/pts type devpts (rw,gid=5,mode=620)\ntmpfs on /dev/shm type tmpfs (rw)\n/dev/sda1 on /boot type ext3 (rw)\nnone on /proc/sys/fs/binfmt_misc type binfmt_misc (rw)\nsunrpc on /var/lib/nfs/rpc_pipefs type rpc_pipefs (rw)\ndmf:/home/TDH on /mnt/tdh type nfs (rw,bg,tcp,soft,timeo=5,retrans=3,intr,nfsvers=3,addr=137.219.15.32)\n'
```

This, when passed to the existing code inside `salt/modules/mount.py` (as the variable `mounts`):

```
     for line in mounts.split('\n'):
         comps = re.sub(r"\s+", " ", line).split()
         ret[comps[2]] = comps[0]
```

 errors when this string is split by newline character, because it produces an array with a final element of `''` (empty string).  On the `comps =` line above, the empty string is attempted to be `split()` on whitespace, and thus produces an empty-length list as `comps`. This then errors on the following line because there are no indexes available:

```
        Traceback (most recent call last):
          File "/tmp/.root_826f28__salt/salt-call", line 4, in <module>
            salt_call()
          File "/tmp/.root_826f28__salt/salt/scripts.py", line 227, in salt_call
            client.run()
          File "/tmp/.root_826f28__salt/salt/cli/call.py", line 69, in run
            caller.run()
          File "/tmp/.root_826f28__salt/salt/cli/caller.py", line 236, in run
            ret = self.call()
          File "/tmp/.root_826f28__salt/salt/cli/caller.py", line 138, in call
            ret['return'] = func(*args, **kwargs)
          File "/tmp/.root_826f28__salt/salt/modules/mount.py", line 190, in active
            _active_mounts(ret)
          File "/tmp/.root_826f28__salt/salt/modules/mount.py", line 93, in _active_mounts
            _list = _list_mounts()
          File "/tmp/.root_826f28__salt/salt/modules/mount.py", line 44, in _list_mounts
            ret[comps[2]] = comps[0]
        IndexError: list index out of range
```

This PR checks there's sufficient elements in the output, and if not, the line is ignored.

Tested with current 2015.5 Salt (from Git, the commit this PR is based on) and RHEL 6.7.  I'm unsure if it's a change in output from RHEL's mount command that's caused this or Salt's internals changing with running but I hadn't experienced this until today.
