### PR TITLE
Added a way to wait for a reboot to complete on Windows

### DIFF
--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 import logging
 import re
 import datetime
+import time
 try:
     from shlex import quote as _cmd_quote  # pylint: disable=E0611
 except ImportError:
@@ -102,7 +103,7 @@ def poweroff(timeout=5, in_seconds=False):
     return shutdown(timeout, in_seconds)
 
 
-def reboot(timeout=5, in_seconds=False):
+def reboot(timeout=5, in_seconds=False, wait_for_reboot=False):
     '''
     Reboot the system
 
@@ -114,15 +115,31 @@ def reboot(timeout=5, in_seconds=False):
 
         .. versionadded:: Beryllium
 
+        The amount of seconds to wait before rebooting
+
+    wait_for_reboot
+
+        .. versionadded:: Beryllium
+
+        Sleeps for timeout + 30 seconds after reboot has been initiated.
+        This is useful for use in a highstate for example where
+        you have many states that could be ran after this one. Which you don't want
+        to start until after the restart i.e You could end up with a half finished state.
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' system.reboot 5
+        salt '*' system.reboot 5 True
     '''
     seconds = _convert_minutes_seconds(timeout, in_seconds)
     cmd = ['shutdown', '/r', '/t', '{0}'.format(seconds)]
     ret = __salt__['cmd.run'](cmd, python_shell=False)
+
+    if wait_for_reboot:
+        time.sleep(seconds + 30)
+
     return ret
 
 

--- a/tests/unit/modules/win_system_test.py
+++ b/tests/unit/modules/win_system_test.py
@@ -58,6 +58,38 @@ class WinSystemTestCase(TestCase):
         mock = MagicMock(return_value='salt')
         with patch.dict(win_system.__salt__, {'cmd.run': mock}):
             self.assertEqual(win_system.reboot(), 'salt')
+            mock.assert_called_once_with(['shutdown', '/r', '/t', '300'], python_shell=False)
+
+    def test_reboot_with_timeout_in_minutes(self):
+        '''
+            Test to reboot the system with a timeout
+        '''
+        mock = MagicMock(return_value='salt')
+        with patch.dict(win_system.__salt__, {'cmd.run': mock}):
+            self.assertEqual(win_system.reboot(5, in_seconds=False), 'salt')
+            mock.assert_called_once_with(['shutdown', '/r', '/t', '300'], python_shell=False)
+
+    def test_reboot_with_timeout_in_seconds(self):
+        '''
+            Test to reboot the system with a timeout
+        '''
+        mock = MagicMock(return_value='salt')
+        with patch.dict(win_system.__salt__, {'cmd.run': mock}):
+            self.assertEqual(win_system.reboot(5, in_seconds=True), 'salt')
+            mock.assert_called_once_with(['shutdown', '/r', '/t', '5'], python_shell=False)
+
+    def test_reboot_with_wait(self):
+        '''
+            Test to reboot the system with a timeout and
+            wait for it to finish
+        '''
+        mock = MagicMock(return_value='salt')
+        sleep_mock = MagicMock(return_value='salt')
+        with patch.dict(win_system.__salt__, {'cmd.run': mock}):
+            with patch('time.sleep', sleep_mock):
+                self.assertEqual(win_system.reboot(wait_for_reboot=True), 'salt')
+                mock.assert_called_once_with(['shutdown', '/r', '/t', '300'], python_shell=False)
+                sleep_mock.assert_called_once_with(330)
 
     def test_shutdown(self):
         '''


### PR DESCRIPTION
- This is useful if you have many states that are being run in a highstate and you don't want the rest of the states, running just before a reboot as this could lead to half complete states i.e installing software
