### PR TITLE
Add file as supported protocol for file source_hash. Fixes #25701.

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3168,7 +3168,7 @@ def get_managed(
         elif source.startswith('/'):
             source_sum = get_hash(source)
         elif source_hash:
-            protos = ('salt', 'http', 'https', 'ftp', 'swift', 's3')
+            protos = ('salt', 'http', 'https', 'ftp', 'swift', 's3', 'file')
             if _urlparse(source_hash).scheme in protos:
                 # The source_hash is a file on a server
                 hash_fn = __salt__['cp.cache_file'](source_hash, saltenv)


### PR DESCRIPTION
This fixes the regression of #23764 introduced in 576f1b8.
Re-apply 1a6fb80 and resolve conflict.

Conflicts:
    salt/modules/file.py
