### PR TITLE
Adding delete_den to delete denied keys

### DIFF
--- a/salt/key.py
+++ b/salt/key.py
@@ -832,6 +832,20 @@ class Key(object):
             else self.dict_match(matches)
         )
 
+    def delete_den(self):
+        '''
+        Delete all denied keys
+        '''
+        keys = self.list_keys()
+        for key in keys[self.DEN]:
+            try:
+                os.remove(os.path.join(self.opts['pki_dir'], status, key))
+                self.event.fire_event(eload, tagify(prefix='key'))
+            except (OSError, IOError)
+                pass
+        self.check_minion_cache()
+        return self.list_keys()
+
     def delete_all(self):
         '''
         Delete all keys


### PR DESCRIPTION
Adding this function.  This cannot yet be called, I need to figure out how salt-key is being called, then I'll add the method to use this api.  This is for issue #24836
