### PR TITLE
Fix iptables.build_rule

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -218,7 +218,7 @@ def build_rule(table='filter', chain=None, command=None, position='', full=None,
 
     if 'connstate' in kwargs:
         if '-m state' not in rule:
-            rule += '-m state '
+            rule.append('-m state')
 
         rule.append('{0}--state {1}'.format(maybe_add_negation('connstate'), kwargs['connstate']))
 


### PR DESCRIPTION
Iptables is broken at the moment because of this bug.

Before:

```
$ salt-ssh vagrant-test iptables.build_rule family=ipv4 connstate=ESTABLISHED
vagrant-test:
    - m   s t a t e   --state ESTABLISHED
```

After:

```
$ salt-ssh vagrant-test iptables.build_rule family=ipv4 connstate=ESTABLISHED
vagrant-test:
    -m state --state ESTABLISHED
```

This bug is not present in 2015.5.
