### PR TITLE
--state-output and overriding defaults

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -108,7 +108,7 @@ class CustomOption(optparse.Option, object):
     def take_action(self, action, dest, *args, **kwargs):
         # see https://github.com/python/cpython/blob/master/Lib/optparse.py#L786
         self.explicit = True
-        return optparse.Option.take_action(self, *args, **kwargs)
+        return optparse.Option.take_action(self, action, dest, *args, **kwargs)
 
 
 class OptionParser(optparse.OptionParser, object):

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -104,6 +104,13 @@ class OptionParserMeta(MixInMeta):
         return instance
 
 
+class CustomOption(optparse.Option, object):
+    def take_action(self, action, dest, *args, **kwargs):
+        # see https://github.com/python/cpython/blob/master/Lib/optparse.py#L786
+        self.explicit = True
+        return optparse.Option.take_action(self, *args, **kwargs)
+
+
 class OptionParser(optparse.OptionParser, object):
     VERSION = version.__saltstack_version__.formatted_version
 
@@ -129,6 +136,13 @@ class OptionParser(optparse.OptionParser, object):
 
         if self.epilog and '%prog' in self.epilog:
             self.epilog = self.epilog.replace('%prog', self.get_prog_name())
+
+    option_class = CustomOption
+
+    def add_option_group(self, *args, **kwargs):
+        option_group = optparse.OptionParser.add_option_group(self, *args, **kwargs)
+        option_group.option_class = CustomOption
+        return option_group
 
     def parse_args(self, args=None, values=None):
         options, args = optparse.OptionParser.parse_args(self, args, values)
@@ -252,10 +266,11 @@ class MergeConfigMixIn(six.with_metaclass(MixInMeta, object)):
                 if value is not None:
                     # There's an actual value, add it to the config
                     self.config[option.dest] = value
-            elif value is not None and value != default:
-                # Only set the value in the config file IF it's not the default
-                # value, this makes it possible to tweak settings on the
-                # configuration files bypassing the shell option flags
+            elif value is not None and getattr(option, "explicit", False):
+                # Only set the value in the config file IF it was explicitly
+                # specified by the user, this makes it possible to tweak settings
+                # on the configuration files bypassing the shell option flags'
+                # defaults
                 self.config[option.dest] = value
             elif option.dest in self.config:
                 # Let's update the option value with the one from the
@@ -276,11 +291,11 @@ class MergeConfigMixIn(six.with_metaclass(MixInMeta, object)):
                     if value is not None:
                         # There's an actual value, add it to the config
                         self.config[option.dest] = value
-                elif value is not None and value != default:
-                    # Only set the value in the config file IF it's not the
-                    # default value, this makes it possible to tweak settings
-                    # on the configuration files bypassing the shell option
-                    # flags
+                elif value is not None and getattr(option, "explicit", False):
+                    # Only set the value in the config file IF it was explicitly
+                    # specified by the user, this makes it possible to tweak
+                    # settings on the configuration files bypassing the shell
+                    # option flags' defaults
                     self.config[option.dest] = value
                 elif option.dest in self.config:
                     # Let's update the option value with the one from the


### PR DESCRIPTION
It seems like there's an issue with the way salt treats command-line arguments in general, i only run into this with --salt-output however. I believe it's not the intended behaviour – that would be odd if true.
### Specific issue

I set "state_output: mixed" in /etc/salt/master so i expect state_output to be "mixed" unless i pass --state-output with a different value. It works as expected if i pass "--state-output terse" like this:

```
salt '*' state.sls somestate --state-output terse -l debug
```

However it does not work as expected if i pass "--state-output full":

```
salt '*' state.sls somestate --state-output full -l debug
```
### General issue

As far as i understand the code, salt loads default options from several configuration files, reads command line arguments and then merges the options giving preference to command-line arguments; it looks reasonable so far. The problem is that as it turns out it is not always the case. A special clause [here](https://github.com/saltstack/salt/blob/develop/salt/utils/parsers.py#L279) prefers the option from the configuration file if the option from the command line wasn't set (supposedly), this is necessary to prevent command-line defaults from overriding options explicitly set in the configuration file. What makes this code broken is that it does not really check if the command-line argument was really passed, only that its value should be equal to the command-line default as if it was the same thing.
