### PR TITLE
Survey runner now uses compound target - fully compatible with previous glob targeting.

### DIFF
--- a/salt/runners/survey.py
+++ b/salt/runners/survey.py
@@ -165,7 +165,7 @@ def _get_pool_results(*args, **kwargs):
 
     client = salt.client.get_local_client(__opts__['conf_file'])
     try:
-        minions = client.cmd(tgt, cmd, args[2:], timeout=__opts__['timeout'])
+        minions = client.cmd(tgt, cmd, args[2:], timeout=__opts__['timeout'], expr_form='compound')
     except SaltClientError as client_error:
         print(client_error)
         return ret


### PR DESCRIPTION
It surprises me that all target patterns don't default to compound - but that might be a hasty thought.
