### PR TITLE
prerequisite to fix the smartos libcrypto loading

### DIFF
--- a/doc/topics/cloud/openstack.rst
+++ b/doc/topics/cloud/openstack.rst
@@ -120,7 +120,8 @@ ssh_key_name
 ssh_interface
     This option allows you to create a VM without a public IP. If this option
     is omitted and the VM does not have a public IP, then the salt-cloud waits
-    for a certain period of time and then destroys the VM.
+    for a certain period of time and then destroys the VM. With the nova drive,
+    private cloud networks can be defined here.
 
 For more information concerning cloud profiles, see :doc:`here
 </topics/cloud/profiles>`.

--- a/pkg/smartos/esky/requirements.txt
+++ b/pkg/smartos/esky/requirements.txt
@@ -1,4 +1,2 @@
 GitPython==0.3.2.RC1
-halite
 -r ../../../requirements/opt.txt
--r ../../../requirements/cloud.txt

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -639,7 +639,7 @@ def create(vm_):
             networkname = rackconnectv3
             for network in node['addresses'].get(networkname, []):
                 if network['version'] is 4:
-                    node['extra']['access_ip'] = network['addr']
+                    access_ip = network['addr']
                     break
             vm_['rackconnect'] = True
 

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -86,7 +86,7 @@ Note: You must include the default net-ids when setting networks or the server
 will be created without the rest of the interfaces
 
 Note: For rackconnect v3, rackconnectv3 needs to be specified with the
-rackconnect v3 cloud network as it's variable.
+rackconnect v3 cloud network as its variable.
 '''
 from __future__ import absolute_import
 # pylint: disable=E0102

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -86,7 +86,7 @@ Note: You must include the default net-ids when setting networks or the server
 will be created without the rest of the interfaces
 
 Note: For rackconnect v3, rackconnectv3 needs to be specified with the
-rackconnect v3 cloud network as it's variable
+rackconnect v3 cloud network as it's variable.
 '''
 from __future__ import absolute_import
 # pylint: disable=E0102

--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -218,7 +218,7 @@ def build_rule(table='filter', chain=None, command=None, position='', full=None,
 
     if 'connstate' in kwargs:
         if '-m state' not in rule:
-            rule += '-m state '
+            rule.append('-m state')
 
         rule.append('{0}--state {1}'.format(maybe_add_negation('connstate'), kwargs['connstate']))
 

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -725,7 +725,7 @@ def install(name=None,
         opts += 'U'
     if salt.utils.is_true(dryrun):
         opts += 'n'
-    if not salt.utils.is_true(dryrun):
+    if not salt.utils.is_true(dryrun) and pkg_type != 'file':
         opts += 'y'
     if salt.utils.is_true(quiet):
         opts += 'q'
@@ -746,7 +746,7 @@ def install(name=None,
 
     if pkg_type == 'file':
         pkg_cmd = 'add'
-        targets = list(pkg_params.keys())
+        targets = pkg_params
     elif pkg_type == 'repository':
         pkg_cmd = 'install'
         if pkgs is None and kwargs.get('version') and len(pkg_params) == 1:

--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -376,7 +376,7 @@ def _format_host(host, data):
             sum_duration /= 1000
             duration_unit = 's'
         total_duration = u'Total run time: {0} {1}'.format(
-            '{:.3f}'.format(sum_duration).rjust(line_max_len - 5),
+            '{0:.3f}'.format(sum_duration).rjust(line_max_len - 5),
             duration_unit)
         hstrs.append(colorfmt.format(colors['CYAN'], total_duration, colors))
 

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1587,6 +1587,17 @@ def is_sunos():
 
 
 @real_memoize
+def is_smartos():
+    '''
+    Simple function to return if host is SmartOS (Illumos) or not
+    '''
+    if not is_sunos():
+        return False
+    else:
+      return os.uname()[3].startswith('joyent_')
+
+
+@real_memoize
 def is_freebsd():
     '''
     Simple function to return if host is FreeBSD or not

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1598,6 +1598,29 @@ def is_smartos():
 
 
 @real_memoize
+def is_smartos_globalzone():
+    '''
+    Function to return if host is SmartOS (Illumos) global zone or not
+    '''
+    if not is_smartos():
+        return False
+    else:
+        cmd = ['zonename']
+        try:
+            zonename = subprocess.Popen(
+                cmd, shell=False,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        except OSError:
+            return False
+        if zonename.returncode:
+            return False
+        if zonename.stdout.read().strip() == "global":
+            return True
+
+        return False
+
+
+@real_memoize
 def is_freebsd():
     '''
     Simple function to return if host is FreeBSD or not


### PR DESCRIPTION
Prerequisite to implement a fix for issue #25757

This implements `salt.utils.is_smartos()` and `salt.utils.is_smartos_globalzone()`
is_smartos() will check uname for joyent_ 
is_smartos_globalzone will use is_smartos + run zonename to make sure we are the global zone. 

This should end up in 2015.8 and devel branches.
