### PR TITLE
Prerequisite to fix the smartos libcrypto loading

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1587,6 +1587,17 @@ def is_sunos():
 
 
 @real_memoize
+def is_smartos():
+    '''
+    Simple function to return if host is SmartOS (Illumos) or not
+    '''
+    if not is_sunos():
+        return False
+    else:
+      return os.uname()[3].startswith('joyent_')
+
+
+@real_memoize
 def is_freebsd():
     '''
     Simple function to return if host is FreeBSD or not

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1614,7 +1614,7 @@ def is_smartos_globalzone():
             return False
         if zonename.returncode:
             return False
-        if zonename.stdout.read().strip() == "global":
+        if zonename.stdout.read().strip() == 'global':
             return True
 
         return False

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1598,6 +1598,29 @@ def is_smartos():
 
 
 @real_memoize
+def is_smartos_globalzone():
+    '''
+    Function to return if host is SmartOS (Illumos) global zone or not
+    '''
+    if not is_smartos():
+        return False
+    else:
+        cmd = ['zonename']
+        try:
+            zonename = subprocess.Popen(
+                cmd, shell=False,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        except OSError:
+            return False
+        if zonename.returncode:
+            return False
+        if zonename.stdout.read().strip() == "global":
+            return True
+
+        return False
+
+
+@real_memoize
 def is_freebsd():
     '''
     Simple function to return if host is FreeBSD or not

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1594,7 +1594,7 @@ def is_smartos():
     if not is_sunos():
         return False
     else:
-      return os.uname()[3].startswith('joyent_')
+        return os.uname()[3].startswith('joyent_')
 
 
 @real_memoize


### PR DESCRIPTION
Prerequisite to implement a fix for issue #25757

This implements salt.utils.is_smartos() and salt.utils.is_smartos_globalzone()
is_smartos() will check uname for joyent_
is_smartos_globalzone will use is_smartos + run zonename to make sure we are the global zone.

This should end up in 2015.8 and devel branches.

Edit: against the proper branch this time.
