### PR TITLE
adding vm_name to ip resolving and using ip for vm creation

### DIFF
--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -516,6 +516,17 @@ def create(vm_):
 
     log.info('Creating Cloud VM {0}'.format(vm_['name']))
 
+    if 'use_dns' in vm_ and not 'ip_address' in vm_:
+        use_dns = vm_['use_dns']
+        if use_dns:
+            from socket import gethostbyname, gaierror
+            try:
+                ip_address = gethostbyname(str(vm_['name']))
+            except gaierror:
+                log.debug('Resolving of {hostname} failed'.format(hostname=str(vm_['name'])))
+            else:
+                vm_['ip_address'] = str(ip_address)
+
     try:
         data = create_node(vm_)
     except Exception as exc:

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -516,7 +516,7 @@ def create(vm_):
 
     log.info('Creating Cloud VM {0}'.format(vm_['name']))
 
-    if 'use_dns' in vm_ and not 'ip_address' in vm_:
+    if 'use_dns' in vm_ and 'ip_address' not in vm_:
         use_dns = vm_['use_dns']
         if use_dns:
             from socket import gethostbyname, gaierror


### PR DESCRIPTION
It is now possible to precreate a lot of pairs fqdn<->ip_address in dns
and then use these ip addresses for vms.
This allows us to use one cloud profile to many vms relation instead of
using one profile to one vm if ip address is set explicitly
