### PR TITLE
Fix get_managed() in file.py module for local files

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3164,9 +3164,11 @@ def get_managed(
                 return '', {}, 'Source file {0} not found'.format(source)
         # if its a local file
         elif urlparsed_source.scheme == 'file':
-            source_sum = get_hash(urlparsed_source.path)
+            file_sum = get_hash(urlparsed_source.path, form='sha256')
+            source_sum = {'hsum': file_sum, 'hash_type': 'sha256'}
         elif source.startswith('/'):
-            source_sum = get_hash(source)
+            file_sum = get_hash(source, form='sha256')
+            source_sum = {'hsum': file_sum, 'hash_type': 'sha256'}
         elif source_hash:
             protos = ('salt', 'http', 'https', 'ftp', 'swift', 's3')
             if _urlparse(source_hash).scheme in protos:


### PR DESCRIPTION
This fixes the 'Unable to manage file: string indices must be integers, not str'
error message problem.

source_sum must be a dictionary not a string.

The regression has been introduced by c03a6fa9d18c145419451cf899525d462a33fb4b when adding the file:// support.
