### PR TITLE
Keep track of SyncWrapper's IOLoop usage

### DIFF
--- a/salt/utils/async.py
+++ b/salt/utils/async.py
@@ -7,11 +7,14 @@ from __future__ import absolute_import
 
 import tornado.ioloop
 import tornado.concurrent
+LOOP_CLASS = tornado.ioloop.IOLoop
+# attempt to use zmq-- if we have it otherwise fallback to tornado loop
 try:
     import zmq.eventloop.ioloop
     # support pyzmq 13.0.x, TODO: remove once we force people to 14.0.x
     if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
         zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
+    LOOP_CLASS = zmq.eventloop.ioloop.ZMQIOLoop
 except ImportError:
     pass  # salt-ssh doesn't dep zmq
 
@@ -47,6 +50,7 @@ class SyncWrapper(object):
     ret = sync.async_method()
     '''
     loop_map = weakref.WeakKeyDictionary()  # keep a mapping of parent io_loop -> sync_loop
+    loops_in_use = weakref.WeakSet()  # set of sync_loops in use
 
     def __init__(self, method, args=tuple(), kwargs=None):
         if kwargs is None:
@@ -54,13 +58,24 @@ class SyncWrapper(object):
 
         parent_io_loop = tornado.ioloop.IOLoop.current()
         if parent_io_loop not in SyncWrapper.loop_map:
-            SyncWrapper.loop_map[parent_io_loop] = zmq.eventloop.ioloop.ZMQIOLoop()
+            SyncWrapper.loop_map[parent_io_loop] = LOOP_CLASS()
 
-        self.io_loop = SyncWrapper.loop_map[parent_io_loop]
+        io_loop = SyncWrapper.loop_map[parent_io_loop]
+        if io_loop in self.loops_in_use:
+            io_loop = LOOP_CLASS()
+        self.io_loop = io_loop
+        self.loops_in_use.add(self.io_loop)
         kwargs['io_loop'] = self.io_loop
 
         with current_ioloop(self.io_loop):
             self.async = method(*args, **kwargs)
+
+    def __del__(self):
+        '''
+        Once the async wrapper is complete, remove our loop from the in use set
+        so someone else can use it without making another one
+        '''
+        self.loops_in_use.remove(self.io_loop)
 
     def __getattribute__(self, key):
         try:

--- a/tests/unit/utils/async_test.py
+++ b/tests/unit/utils/async_test.py
@@ -1,0 +1,78 @@
+# coding: utf-8
+
+# Import Python Libs
+from __future__ import absolute_import
+
+# Import 3rd-party libs
+import tornado.testing
+import tornado.gen
+from tornado.testing import AsyncTestCase
+
+from salt.utils import async
+
+
+class HelperA(object):
+    def __init__(self, io_loop=None):
+        pass
+
+    @tornado.gen.coroutine
+    def sleep(self):
+        yield tornado.gen.sleep(0.5)
+        raise tornado.gen.Return(True)
+
+
+class HelperB(object):
+    def __init__(self, a=None, io_loop=None):
+        if a is None:
+            a = async.SyncWrapper(HelperA)
+        self.a = a
+
+    @tornado.gen.coroutine
+    def sleep(self):
+        yield tornado.gen.sleep(0.5)
+        self.a.sleep()
+        raise tornado.gen.Return(False)
+
+
+class TestSyncWrapper(AsyncTestCase):
+    @tornado.testing.gen_test
+    def test_helpers(self):
+        '''
+        Test that the helper classes do what we expect within a regular async env
+        '''
+        ha = HelperA()
+        ret = yield ha.sleep()
+        self.assertTrue(ret)
+
+        hb = HelperB()
+        ret = yield hb.sleep()
+        self.assertFalse(ret)
+
+    def test_basic_wrap(self):
+        '''
+        Test that we can wrap an async caller.
+        '''
+        sync = async.SyncWrapper(HelperA)
+        ret = sync.sleep()
+        self.assertTrue(ret)
+
+    def test_double(self):
+        '''
+        Test when the async wrapper object itself creates a wrap of another thing
+
+        This works fine since the second wrap is based on the first's IOLoop so we
+        don't have to worry about complex start/stop mechanics
+        '''
+        sync = async.SyncWrapper(HelperB)
+        ret = sync.sleep()
+        self.assertFalse(ret)
+
+    def test_double_sameloop(self):
+        '''
+        Test async wrappers initiated from the same IOLoop, to ensure that
+        we don't wire up both to the same IOLoop (since it causes MANY problems).
+        '''
+        a = async.SyncWrapper(HelperA)
+        sync = async.SyncWrapper(HelperB, (a,))
+        ret = sync.sleep()
+        self.assertFalse(ret)


### PR DESCRIPTION
While thinking through issues that might cause #25718 I ran into this case-- where you can create 2 sync wrappers with the same parent IOLoop and run into problems because you can't start/stop the loop multiple times like that and have the call tree work correctly. To solve this (since it _should_ be the exceptional case) I'm making SyncWrapper keep track of which loops are in use-- then if someone attempts this situation it will simply make another one.

This error previously resulted in the following exception:

```
RuntimeError: IOLoop is already running
```
