### PR TITLE
#25863 state.pkg.installed fix

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -346,7 +346,12 @@ def _find_install_targets(name=None,
         # enforced. Takes extra time. Disable for improved performance
         if not skip_suggestions:
             # Perform platform-specific pre-flight checks
-            problems = _preflight_check(desired, **kwargs)
+            not_installed = dict([
+                (name, version)
+                for name, version in desired.items()
+                if not (name in cur_pkgs and version in (None, cur_pkgs[name]))
+            ])
+            problems = _preflight_check(not_installed, **kwargs)
             comments = []
             if problems.get('no_suggest'):
                 comments.append(


### PR DESCRIPTION
First approach on #25863
state.pkg.installed: do preflight check only for non-installed packages.
