### PR TITLE
Allow git_pillar to properly stack.

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -580,6 +580,7 @@ class Pillar(object):
         elif isinstance(val, list):
             if key == 'git':
                 ext = self.ext_pillars[key](self.opts['id'],
+                                            pillar,
                                             val,
                                             pillar_dirs)
             else:
@@ -589,6 +590,7 @@ class Pillar(object):
         else:
             if key == 'git':
                 ext = self.ext_pillars[key](self.opts['id'],
+                                            pillar,
                                             val,
                                             pillar_dirs)
             else:

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -207,12 +207,12 @@ def __virtual__():
     return False
 
 
-def ext_pillar(minion_id, repo, pillar_dirs):
+def ext_pillar(minion_id, pillar, repo, pillar_dirs):
     '''
     Execute a command and read the output as YAML
     '''
     if isinstance(repo, six.string_types):
-        return _legacy_git_pillar(minion_id, repo, pillar_dirs)
+        return _legacy_git_pillar(minion_id, pillar, repo, pillar_dirs)
     else:
         opts = copy.deepcopy(__opts__)
         opts['pillar_roots'] = {}
@@ -222,7 +222,7 @@ def ext_pillar(minion_id, repo, pillar_dirs):
         ret = {}
         for pillar_dir, env in six.iteritems(pillar.pillar_dirs):
             opts['pillar_roots'] = {env: [pillar_dir]}
-            local_pillar = Pillar(opts, __grains__, minion_id, env)
+            local_pillar = Pillar(opts, __grains__, minion_id, env, pillar=pillar)
             ret.update(local_pillar.compile_pillar(ext=False))
         return ret
 
@@ -391,7 +391,7 @@ def _legacy_git_pillar(minion_id, repo_string, pillar_dirs):
 
     opts['pillar_roots'][environment] = [pillar_dir]
 
-    pil = Pillar(opts, __grains__, minion_id, branch)
+    pil = Pillar(opts, __grains__, minion_id, branch, pillar=pillar)
 
     return pil.compile_pillar()
 


### PR DESCRIPTION
This commit plumbs the pillar data from previous ext_pillars into the
git_pillar so that it can use that data when setting pillars. My use
case for this is that I have a custom ext_pillar that sets some pillar
data that affects the pillar data generated by the git_pillar.

Signed-off-by: Warren Turkal wt@signalfx.com
