### PR TITLE
Update 7-zip msi un-installer instructions

### DIFF
--- a/doc/topics/windows/windows-package-manager.rst
+++ b/doc/topics/windows/windows-package-manager.rst
@@ -161,10 +161,10 @@ project's wiki_:
         installer: salt://win/repo/7zip/7z920-x64.msi
         full_name: 7-Zip 9.20 (x64 edition)
         reboot: False
-        install_flags: ' /q '
+        install_flags: '/qn /norestart'
         msiexec: True
-        uninstaller: salt://win/repo/7zip/7z920-x64.msi
-        uninstall_flags: ' /qn'
+        uninstaller: '{23170F69-40C1-2702-0920-000001000000}'
+        uninstall_flags: '/qn /norestart'
 
 Add ``cache_dir: True`` when the installer requires multiple source files. The
 directory containing the installer file will be recursively cached on the minion.
@@ -177,7 +177,7 @@ Only applies to salt: installer URLs.
         installer: 'salt://win/repo/sqlexpress/setup.exe'
         full_name: Microsoft SQL Server 2014 Setup (English)
         reboot: False
-        install_flags: ' /ACTION=install /IACCEPTSQLSERVERLICENSETERMS /Q'
+        install_flags: '/ACTION=install /IACCEPTSQLSERVERLICENSETERMS /Q'
         cache_dir: True
 
 Generate Repo Cache File


### PR DESCRIPTION
The instructions as-are do not actually work. The uninstaller flag takes the windows GUID of the msi product code. And the various `install_flags` and `uninstall_flags` do NOT need leading, or trailing spaces.

@twangboy can confirm this is a better example (also see salt issue  https://github.com/saltstack/salt/issues/25778)
