### PR TITLE
Pass osarch to check_32()

### DIFF
--- a/salt/utils/pkg/rpm.py
+++ b/salt/utils/pkg/rpm.py
@@ -78,7 +78,7 @@ def parse_pkginfo(line, osarch=None):
     if osarch is None:
         osarch = _osarch()
 
-    if not check_32(arch):
+    if not check_32(arch, osarch):
         if arch not in (osarch, 'noarch'):
             name += '.{0}'.format(arch)
     if release:


### PR DESCRIPTION
This prevents a bunch of unnecessary calls to `rpm --eval`.

Fixes #25776.

Thanks to @tbaker57 for the investigative work that led to this fix.
