### PR TITLE
Update saltstack2 theme inheritance

### DIFF
--- a/doc/_themes/saltstack2/theme.conf
+++ b/doc/_themes/saltstack2/theme.conf
@@ -1,3 +1,3 @@
 [theme]
-inherit = classic
+inherit = default
 stylesheet = css/main.css


### PR DESCRIPTION
Inheriting from a native theme seems better for those who just want to assemble the installation packages with minimal requirements
