### PR TITLE
Minor update to msi un-installer info

### DIFF
--- a/doc/topics/windows/windows-package-manager.rst
+++ b/doc/topics/windows/windows-package-manager.rst
@@ -165,6 +165,20 @@ project's wiki_:
         uninstaller: '{23170F69-40C1-2702-0920-000001000000}'
         uninstall_flags: '/qn /norestart'
 
+Alternatively the ``uninstaller`` can also simply repeat the URL of the msi file. 
+
+.. code-block:: yaml
+
+    7zip:
+      9.20.00.0:
+        installer: salt://win/repo/7zip/7z920-x64.msi
+        full_name: 7-Zip 9.20 (x64 edition)
+        reboot: False
+        install_flags: '/qn /norestart'
+        msiexec: True
+        uninstaller: salt://win/repo/7zip/7z920-x64.msi
+        uninstall_flags: '/qn /norestart'
+
 
 Generate Repo Cache File
 ========================


### PR DESCRIPTION
The ``uninstaller` string can be either the windows GUID (aka msi prodcut code) OR the URL to the msi file. Both options work to uninstall a msi installed software.
