### PR TITLE
Pass actual renderers to the Reactor's Compiler

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -245,9 +245,9 @@ class Compiler(object):
     '''
     Class used to compile and manage the High Data structure
     '''
-    def __init__(self, opts):
+    def __init__(self, opts, renderers):
         self.opts = opts
-        self.rend = salt.loader.render(self.opts, {})
+        self.rend = renderers
 
     def render_template(self, template, **kwargs):
         '''

--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -29,11 +29,10 @@ class Reactor(multiprocessing.Process, salt.state.Compiler):
     '''
     def __init__(self, opts):
         multiprocessing.Process.__init__(self)
-        salt.state.Compiler.__init__(self, opts)
-
-        local_minion_opts = self.opts.copy()
+        local_minion_opts = opts.copy()
         local_minion_opts['file_client'] = 'local'
         self.minion = salt.minion.MasterMinion(local_minion_opts)
+        salt.state.Compiler.__init__(self, opts, self.minion.rend)
 
     def render_reaction(self, glob_ref, tag, data):
         '''


### PR DESCRIPTION
Weird issue, from looking at the old versions of the code it looks like it was also broken (at least on class init) but something afterwards came in and changed the pointer (SCARY!). This removes the need to load the renderers twice (bonus!) in addition to fixing the reported issue.

Fixes #25852
