### PR TITLE
salt.module.pkgin's __virtual__() should not return None if pkg_info is not present

### DIFF
--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -41,7 +41,7 @@ def _check_pkgin():
                 ppath = '{0}/bin/pkgin'.format(localbase)
                 if not os.path.exists(ppath):
                     return None
-        except:
+        except CommandExecutionError:
             return None
     return ppath
 

--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -32,15 +32,17 @@ def _check_pkgin():
     ppath = salt.utils.which('pkgin')
     if ppath is None:
         # pkgin was not found in $PATH, try to find it via LOCALBASE
-        localbase = __salt__['cmd.run'](
-            'pkg_info -Q LOCALBASE pkgin',
-            output_loglevel='trace'
-        )
-        if localbase is not None:
-            ppath = '{0}/bin/pkgin'.format(localbase)
-            if not os.path.exists(ppath):
-                return None
-
+        try:
+            localbase = __salt__['cmd.run'](
+               'pkg_info -Q LOCALBASE pkgin',
+                output_loglevel='trace'
+            )
+            if localbase is not None:
+                ppath = '{0}/bin/pkgin'.format(localbase)
+                if not os.path.exists(ppath):
+                    return None
+        except:
+            return None
     return ppath
 
 


### PR DESCRIPTION
salt.module.pkgin was throwing exceptions in `_check_pkgin()`, which in turn cause an exception in `__virtual__()`making it return None instead of True or False.

```
[INFO    ] Executing command 'pkg_info -Q LOCALBASE pkgin' in directory '/root'
[ERROR   ] Exception raised when processing __virtual__ function for pkgin. Module will not be loaded Unable to run command ['pkg_info', '-Q', 'LOCALBASE', 'pkgin'] with the context {'with_communicate': True, 'shell': False, 'env': {'LANG': 'en_US.UTF-8', 'TERM': 'xterm', 'SHELL': '/usr/bin/bash', 'TZ': 'UTC', 'MANPATH': '/usr/share/man:/smartdc/man:/opt/smartdc/man:/opt/local/man', 'MAIL': '/var/mail/root', 'SHLVL': '1', 'SSH_TTY': '/dev/pts/2', 'SSH_CLIENT': '2001:6f8:1480:30::1 2845 22', 'PWD': '/root', 'LOGNAME': 'root', 'USER': 'root', 'PROMPT_COMMAND': 'echo -ne "\\033]0;${HOSTNAME} \\007" && history -a', 'PATH': '/opt/local/salt/bin/appdata/salt-2015.8.0rc2-13-gf001d7e.solaris-2_11-i86pc_64bit:/usr/bin:/usr/sbin:/smartdc/bin:/opt/smartdc/bin:/opt/local/bin:/opt/local/sbin:/opt/smartdc/agents/bin', 'HOME': '/root', 'SSH_CONNECTION': '2001:6f8:1480:30::1 2845 2001:6f8:1480:30::91 22', 'PAGER': 'less', 'LC_ALL': 'C', '_': '/opt/local/salt/bin/salt-call'}, 'stdout': -1, 'close_fds': True, 'stdin': None, 'stderr': -2, 'cwd': '/root'}, reason: [Errno 2] No such file or directory
[WARNING ] salt.loaded.int.module.pkgin.__virtual__() is wrongly returning `None`. It should either return `True`, `False` or a new name. If you're the developer of the module 'pkgin', please fix this.
```

This PR adds a try, except around the pkg_info call to handle this correctly.

I noticed this when mopping up the 2015.8 failures on smartos
