### PR TITLE
Add execution module to generate JSON Schema from the argspec of state functions

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -13,14 +13,14 @@ states themselves.
 
 # Import python libs
 from __future__ import absolute_import
-import os
-import json
 import copy
-import shutil
-import time
+import json
 import logging
+import os
+import shutil
 import tarfile
 import tempfile
+import time
 
 # Import salt libs
 import salt.config

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -5,9 +5,10 @@ Control the state system on the minion.
 State Caching
 -------------
 
-When a highstate is called, the minion automatically caches a copy of the last high data.
-If you then run a highstate with cache=True it will use that cached highdata and won't hit the fileserver
-except for ``salt://`` links in the states themselves.
+When a highstate is called, the minion automatically caches a copy of the last
+high data. If you then run a highstate with cache=True it will use that cached
+highdata and won't hit the fileserver except for ``salt://`` links in the
+states themselves.
 '''
 
 # Import python libs

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -24,11 +24,11 @@ import tempfile
 
 # Import salt libs
 import salt.config
+import salt.payload
+import salt.state
 import salt.utils
 import salt.utils.jid
 import salt.utils.url
-import salt.state
-import salt.payload
 from salt.exceptions import SaltInvocationError
 
 # Import 3rd-party libs

--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -10,9 +10,9 @@ import logging
 
 # Import salt libs
 import salt.loader
-import salt.utils
-import salt.state
 import salt.runner
+import salt.state
+import salt.utils
 from salt.utils.doc import strip_rst as _strip_rst
 
 # Import 3rd-party libs

--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -13,6 +13,7 @@ import salt.loader
 import salt.runner
 import salt.state
 import salt.utils
+import salt.utils.schema as S
 from salt.utils.doc import strip_rst as _strip_rst
 
 # Import 3rd-party libs
@@ -837,3 +838,62 @@ def list_renderers(*args):
         for func in fnmatch.filter(ren_, module):
             ren.add(func)
     return sorted(ren)
+
+
+def _argspec_to_schema(mod, spec):
+    args = spec['args']
+    defaults = spec['defaults'] or []
+
+    args_req = args[:len(args) - len(defaults)]
+    args_defaults = zip(args[-len(defaults):], defaults)
+
+    types = {
+        'title': mod,
+        'description': mod,
+    }
+
+    for i in args_req:
+        types[i] = S.OneOfItem(items=(
+            S.BooleanItem(title=i, description=i, required=True),
+            S.IntegerItem(title=i, description=i, required=True),
+            S.NumberItem(title=i, description=i, required=True),
+            S.StringItem(title=i, description=i, required=True),
+
+            # S.ArrayItem(title=i, description=i, required=True),
+            # S.DictItem(title=i, description=i, required=True),
+        ))
+
+    for i, j in args_defaults:
+        types[i] = S.OneOfItem(items=(
+            S.BooleanItem(title=i, description=i, default=j),
+            S.IntegerItem(title=i, description=i, default=j),
+            S.NumberItem(title=i, description=i, default=j),
+            S.StringItem(title=i, description=i, default=j),
+
+            # S.ArrayItem(title=i, description=i, default=j),
+            # S.DictItem(title=i, description=i, default=j),
+        ))
+
+    return type(mod, (S.Schema,), types).serialize()
+
+
+def state_schema(module=''):
+    '''
+    Return a JSON Schema for the given state function(s)
+
+    .. versionadded:: Boron
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' sys.state_schema
+        salt '*' sys.state_schema pkg.installed
+    '''
+    specs = state_argspec(module)
+
+    schemas = []
+    for state_mod, state_spec in specs.items():
+        schemas.append(_argspec_to_schema(state_mod, state_spec))
+
+    return schemas

--- a/salt/utils/schema.py
+++ b/salt/utils/schema.py
@@ -8,14 +8,16 @@
 
     Object Oriented Configuration - JSON Schema compatible generator
 
-    This code was inspired by `jsl`__, "A Python DSL for describing JSON schemas".
+    This code was inspired by `jsl`__, "A Python DSL for describing JSON
+    schemas".
 
     .. __: http://jsl.readthedocs.org/
 
 
-    A configuration document or configuration document section is defined using the
-    py:class:`Schema`, the configuration items are defined by any of the subclasses
-    of py:class:`BaseSchemaItem` as attributes of a subclass of py:class:`Schema` class.
+    A configuration document or configuration document section is defined using
+    the py:class:`Schema`, the configuration items are defined by any of the
+    subclasses of py:class:`BaseSchemaItem` as attributes of a subclass of
+    py:class:`Schema` class.
 
     As an example:
 
@@ -100,8 +102,8 @@
         }
 
 
-    The serialized version of the configuration block can be used to validate a configuration dictionary using
-    the `python jsonschema library`__.
+    The serialized version of the configuration block can be used to validate a
+    configuration dictionary using the `python jsonschema library`__.
 
     .. __: https://pypi.python.org/pypi/jsonschema
 
@@ -252,9 +254,10 @@
             -1
         >>>
 
-    If however, you just want to use the configuration blocks for readability and do not desire the nested
-    dictionaries serialization, you can pass ``flatten=True`` when defining a configuration section as a
-    configuration subclass attribute:
+    If however, you just want to use the configuration blocks for readability
+    and do not desire the nested dictionaries serialization, you can pass
+    ``flatten=True`` when defining a configuration section as a configuration
+    subclass attribute:
 
     .. code-block:: python
 


### PR DESCRIPTION
This is the first step in being able to perform a pre-flight validation of a state run. It checks that the given functions and the arguments to those functions are valid. This opens the door to being able to annotate (via parsing structured docstrings) argument types as well. This allows validating a state run before it is run by checking the resulting data structure against a schema. Another future use is to provide autocomplete hinting within text editors for state functions -- this could be done by tying into the master-side state compilation process in salt-ssh. Stay tuned...
