### PR TITLE
Smartos libcrypto nonesky fix

### DIFF
--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -29,6 +29,12 @@ def _load_libcrypto():
             'libcrypto.so*'))[0])
     else:
         lib = find_library('crypto')
+        if not lib and salt.utils.is_smartos():
+            # smartos does not have libraries in std location
+            lib = glob.glob(os.path.join(
+                '/opt/local/lib',
+                'libcrypto.so*'))
+            lib = lib[0] if len(lib) > 0 else None
         if lib:
             return cdll.LoadLibrary(lib)
         raise OSError('Cannot locate OpenSSL libcrypto')


### PR DESCRIPTION
SmartOS has 2 libcrypto's, the system one in /usr/{amd64.}/lib which should not be used and one from pkgsrc in /opt/local/lib, we should use this one.

find_library will find neither of those, so lib is None and we are on smartos we try to glob for the library. 
If nothing is found we reset lib to None as would be expected from libcrypto.
