### PR TITLE
Remove temporary file after file.managed with checkcmd

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1503,6 +1503,7 @@ def managed(name,
         except Exception as exc:
             ret['changes'] = {}
             log.debug(traceback.format_exc())
+            os.remove(tmp_filename)
             return _error(ret, 'Unable to check_cmd file: {0}'.format(exc))
 
         # file being updated to verify using check_cmd
@@ -1520,6 +1521,7 @@ def managed(name,
             cret = mod_run_check_cmd(check_cmd, tmp_filename, **check_cmd_opts)
             if isinstance(cret, dict):
                 ret.update(cret)
+                os.remove(tmp_filename)
                 return ret
             # Since we generated a new tempfile and we are not returning here
             # lets change the original sfn to the new tempfile or else we will
@@ -1556,6 +1558,8 @@ def managed(name,
             ret['changes'] = {}
             log.debug(traceback.format_exc())
             return _error(ret, 'Unable to manage file: {0}'.format(exc))
+        finally:
+            os.remove(tmp_filename)
 
 
 def directory(name,

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1472,6 +1472,8 @@ def managed(name,
         log.debug(traceback.format_exc())
         return _error(ret, 'Unable to manage file: {0}'.format(exc))
 
+    tmp_filename = None
+
     if check_cmd:
         tmp_filename = salt.utils.mkstemp()
 
@@ -1559,7 +1561,8 @@ def managed(name,
             log.debug(traceback.format_exc())
             return _error(ret, 'Unable to manage file: {0}'.format(exc))
         finally:
-            os.remove(tmp_filename)
+            if tmp_filename:
+                os.remove(tmp_filename)
 
 
 def directory(name,


### PR DESCRIPTION
Currently, if a `check_cmd` argument is passed to `file.managed`, the temporary file is not being removed.
