### PR TITLE
Resolve ensure_index deprecation warnings, change get_options usernam…

### DIFF
--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -104,7 +104,7 @@ def _get_options(ret=None):
     attrs = {'host': 'host',
              'port': 'port',
              'db': 'db',
-             'username': 'username',
+             'user': 'user',
              'password': 'password',
              'indexes': 'indexes'}
 
@@ -139,10 +139,10 @@ def _get_conn(ret):
         mdb.authenticate(user, password)
 
     if indexes:
-        mdb.saltReturns.ensure_index('minion')
-        mdb.saltReturns.ensure_index('jid')
+        mdb.saltReturns.create_index('minion')
+        mdb.saltReturns.create_index('jid')
 
-        mdb.jobs.ensure_index('jid')
+        mdb.jobs.create_index('jid')
 
     return conn, mdb
 

--- a/salt/returners/mongo_return.py
+++ b/salt/returners/mongo_return.py
@@ -94,7 +94,7 @@ def _get_options(ret):
     attrs = {'host': 'host',
              'port': 'port',
              'db': 'db',
-             'username': 'username',
+             'user': 'user',
              'password': 'password'}
 
     _options = salt.returners.get_returner_options(__virtualname__,


### PR DESCRIPTION
…e attribute to user

Resolve warnings from mongo regarding deprecated method ensure_index
Fix issue where returner never logs in as configured user because the
code attempts to grab username attribute instead of user, as documented
everwhere.

Issue #25973
