### PR TITLE
Correct service state changes in test mode

### DIFF
--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -299,7 +299,7 @@ def running(name, enable=None, sig=None, init_delay=None, **kwargs):
     if before_toggle_status:
         ret['comment'] = 'The service {0} is already running'.format(name)
         if __opts__['test']:
-            ret['result'] = None
+            ret['result'] = True
             return ret
         if enable is True and not before_toggle_enable_status:
             ret.update(_enable(name, None, **kwargs))
@@ -392,7 +392,7 @@ def dead(name, enable=None, sig=None, **kwargs):
                 ret.update(_disable(name, None, **kwargs))
             return ret
         else:
-            ret['result'] = None
+            ret['result'] = True
         return ret
 
     if __opts__['test']:


### PR DESCRIPTION
Currently, when running in test mode, you get a ton of false positives for changes when running service states:

```
$ salt-ssh odin state.apply cron test=True
odin:
----------
          ID: cron-service
    Function: service.running
        Name: cron
      Result: None
     Comment: The service cron is already running
     Started: 22:37:36.634773
    Duration: 169.388 ms
     Changes:   

Summary for odin
------------
Succeeded: 7 (unchanged=1)
Failed:    0
------------
Total states run:     7
Total run time: 627.736 ms
```

As far as I can tell, this is because "no change" should be represented with `True`, not `None`.

The current behaviour was introduced in this commit: https://github.com/saltstack/salt/commit/bde7867c9862e2872c1fca0062b22e2f4493d39e
