### PR TITLE
salt.modules.smartos_* limit to global zone only

### DIFF
--- a/salt/modules/smartos_imgadm.py
+++ b/salt/modules/smartos_imgadm.py
@@ -40,7 +40,7 @@ def __virtual__():
     '''
     Provides imgadm only on SmartOS
     '''
-    if __grains__['os'] == "SmartOS" and _check_imgadm():
+    if salt.utils.is_smartos_globalzone() and _check_imgadm():
         return __virtualname__
     return False
 

--- a/salt/modules/smartos_vmadm.py
+++ b/salt/modules/smartos_vmadm.py
@@ -41,7 +41,7 @@ def __virtual__():
     '''
     Provides virt on SmartOS
     '''
-    if __grains__['os'] == "SmartOS" and _check_vmadm():
+    if salt.utils.is_smartos_globalzone() and _check_vmadm():
         return __virtualname__
     return False
 


### PR DESCRIPTION
smartos_vmadm and smartos_imgadm does not make sense if we are not inside a smartos global zone.

using recently added is_smartos_global zone to check if we are good to go.
