### PR TITLE
Implement full event caching for subscribed tags

### DIFF
--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -261,8 +261,6 @@ class EventListener(object):
             opts=opts,
         )
 
-        self.event.subscribe()  # start listening for events immediately
-
         # tag -> list of futures
         self.tag_map = defaultdict(list)
 


### PR DESCRIPTION
Require all multitasking contexts to subscribe to their events so one call to get_event for one tag does not discard events that should be saved for a subsequent call to get_event with another tag.
Use blocking get_event in batching with very small timeout.

Fixes #25998, where events were getting lost due to one iterator discarding events destined for another iterator, which breaks the following command:

```
salt -t 60 --batch 5 '*' cmd.run $'sleep $(( $(dd if=/dev/urandom count=1 bs=1 2>/dev/null | hexdump -e \'"%.1d"\') / 30 )); echo Hello world from $(hostname -f)'
```
