### PR TITLE
Fixed regex to account for comment character followed by whitespace

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1087,7 +1087,7 @@ def comment_line(path,
                 regex.lstrip('^').rstrip('$'),
                 '$' if regex.endswith('$') else '')
     else:
-        regex = '^{0}({1}){2}'.format(
+        regex = r'^{0}\s*({1}){2}'.format(
                 char,
                 regex.lstrip('^').rstrip('$'),
                 '$' if regex.endswith('$') else '')


### PR DESCRIPTION
Fixes: #25948
