### PR TITLE
Merge kwargs into opts for tcp client

### DIFF
--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -82,6 +82,7 @@ class AsyncTCPReqChannel(salt.transport.client.ReqChannel):
 
     @classmethod
     def __key(cls, opts, **kwargs):
+        opts.update(kwargs)
         return (opts['pki_dir'],     # where the keys are stored
                 opts['id'],          # minion ID
                 opts['master_uri'],  # master ID

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -82,7 +82,8 @@ class AsyncTCPReqChannel(salt.transport.client.ReqChannel):
 
     @classmethod
     def __key(cls, opts, **kwargs):
-        opts.update(kwargs)
+        if 'master_uri' in kwargs:
+            opts['master_uri'] = kwargs['master_uri']
         return (opts['pki_dir'],     # where the keys are stored
                 opts['id'],          # minion ID
                 opts['master_uri'],  # master ID


### PR DESCRIPTION
This is what prevented the TCP tests from running in the test suite. We were passing in `master_uri` via kwargs but then only searching for it in opts.

@jacksontj Please have a look here and let me know what you think. We may want to trim this down so we're only overriding certain keys. Thanks!
