### PR TITLE
Revert "Deep merge of pillar lists"

### DIFF
--- a/salt/utils/dictupdate.py
+++ b/salt/utils/dictupdate.py
@@ -42,9 +42,6 @@ def update(dest, upd, recursive_update=True):
                     and isinstance(val, collections.Mapping):
                 ret = update(dest_subkey, val)
                 dest[key] = ret
-            elif isinstance(dest_subkey, list) \
-                     and isinstance(val, list):
-                dest[key] = dest.get(key, []) + val
             else:
                 dest[key] = upd[key]
         return dest


### PR DESCRIPTION
This reverts commit d030e289b323732c573be5c5a7f93d93ea267187.

I will re-apply this commit to 2015.8 after merging forward.

Refs #25358
