### PR TITLE
Fetch a key ID from a fingerprint

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1597,7 +1597,7 @@ def del_repo_key(name=None, **kwargs):
             owner_name, ppa_name = name[4:].split('/')
             ppa_info = _get_ppa_info_from_launchpad(
                 owner_name, ppa_name)
-            keyid = ppa_info['signing_key_fingerprint']
+            keyid = ppa_info['signing_key_fingerprint'][-8:]
         else:
             raise SaltInvocationError(
                 'keyid_ppa requires that a PPA be passed'


### PR DESCRIPTION
**Bug**:
`keyid_ppa: True` doesn't remove a GPG key

[Documentation](https://github.com/saltstack/salt/blob/662962c196509a208ac686146c7700864fcb4097/salt/states/pkgrepo.py#L387) says:

> keyid_ppa : False
>         If set to `True`, the GPG key's ID will be looked up from
>         ppa.launchpad.net and removed, and the `keyid` argument will be
>         ignored.

**How to reproduce**:

`lsb_release -a`:

```
Distributor ID: Ubuntu
Description:    Ubuntu 14.04.3 LTS
Release:    14.04
Codename:   trusty
```

`remove-ppa-repo.sls`:

``` yaml
remove_salt_ppa:
  pkgrepo.absent:
    - ppa: saltstack/salt
    - keyid_ppa: True
```

``` shell
add-apt-repository -y ppa:saltstack/salt
salt-call state.apply remove-ppa-repo
apt-key export 0E27C0A6 # key is here
```

`apt-key del` works with IDs on Trusty, `signing_key_fingerprint` contains a fingerprit. Fix: extract an ID from a fingerprint and pass it to `apt-key del`
