### PR TITLE
Fix httpasswd result false positive in test mode

### DIFF
--- a/salt/states/htpasswd.py
+++ b/salt/states/htpasswd.py
@@ -81,9 +81,6 @@ def user_exists(name, password=None, htpasswd_file=None, options='',
             ret['comment'] = useradd_ret['stderr']
             return ret
 
-    if __opts__['test']:
-        ret['result'] = None
-    else:
-        ret['result'] = True
+    ret['result'] = True
     ret['comment'] = 'User already known'
     return ret


### PR DESCRIPTION
`httpasswd.user_exists` currently always shows up as having changed something if ran with `test=True`.

```
          ID: phpmyadmin-htpasswd
    Function: webutil.user_exists
        Name: admin
      Result: None
     Comment: User already known
     Started: 15:16:10.324431
    Duration: 4.742 ms
     Changes:
```
