### PR TITLE
Revert "Add file as supported protocol for file source_hash. Fixes #23764"

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2933,7 +2933,7 @@ def get_managed(
         elif source.startswith('/'):
             source_sum = get_hash(source)
         elif source_hash:
-            protos = ('salt', 'http', 'https', 'ftp', 'swift', 's3', 'file')
+            protos = ('salt', 'http', 'https', 'ftp', 'swift', 's3')
             if _urlparse(source_hash).scheme in protos:
                 # The source_hash is a file on a server
                 hash_fn = __salt__['cp.cache_file'](source_hash, saltenv)


### PR DESCRIPTION
Upon further analysis, c03a6fa implements the same feature that 4b9d742 does.

4b9d742 is backport/conflict resolution of 1a6fb80.  c03a6fa was authored two days before 1a6fb80 was.  Additionally, 4b9d742 introduces logic that will never be executed due to c03a6fa.

Revert 4b9d742 in favor of c03a6fa.
