### PR TITLE
Rh_ip fix

### DIFF
--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -957,7 +957,7 @@ def build_routes(iface, **settings):
     '''
 
     template = 'rh6_route_eth.jinja'
-    if __grains__['osmajorrelease'] < 6:
+    if __grains__['osrelease'][0] < 6:
         template = 'route_eth.jinja'
     log.debug('Template name: ' + template)
 

--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -957,7 +957,7 @@ def build_routes(iface, **settings):
     '''
 
     template = 'rh6_route_eth.jinja'
-    if float(__grains__['osrelease']) < 6:
+    if __grains__['osmajorrelease'] < 6:
         template = 'route_eth.jinja'
     log.debug('Template name: ' + template)
 


### PR DESCRIPTION
On 2015.8 running the state network.routes causes the ValueError below. This makes network.routes and ip.build_routes to work correctly without erroring. 

``` bash
 An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/site-packages/salt/state.py", line 1591, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/site-packages/salt/states/network.py", line 426, in routes
                  new = __salt__['ip.build_routes'](name, **kwargs)
                File "/usr/lib/python2.7/site-packages/salt/modules/rh_ip.py", line 960, in build_routes
                  if float(__grains__['osrelease']) < 6:
              ValueError: invalid literal for float(): 7.0.1406
```
