### PR TITLE
Fix issue with eauth when perms are specified for both users and groups

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1696,21 +1696,21 @@ class ClearFuncs(object):
         try:
             name = self.loadauth.load_name(clear_load)
             groups = self.loadauth.get_groups(clear_load)
-            if not ((name in self.opts['external_auth'][clear_load['eauth']]) |
-                    ('*' in self.opts['external_auth'][clear_load['eauth']])):
+            eauth_config = self.opts['external_auth'][clear_load['eauth']]
+            if '*' not in eauth_config and name not in eauth_config:
                 found = False
                 for group in groups:
-                    if "{0}%".format(group) in self.opts['external_auth'][clear_load['eauth']]:
+                    if "{0}%".format(group) in eauth_config:
                         found = True
                         break
                 if not found:
                     log.warning('Authentication failure of type "eauth" occurred.')
                     return ''
-                else:
-                    clear_load['groups'] = groups
             if not self.loadauth.time_auth(clear_load):
                 log.warning('Authentication failure of type "eauth" occurred.')
                 return ''
+
+            clear_load['groups'] = groups
             return self.loadauth.mk_token(clear_load)
         except Exception as exc:
             log.error(
@@ -1759,40 +1759,46 @@ class ClearFuncs(object):
                     )
                 )
                 return ''
+
+            # Bail if the token is empty or if the eauth type specified is not allowed
             if not token or token['eauth'] not in self.opts['external_auth']:
                 log.warning('Authentication failure of type "token" occurred.')
                 return ''
-            if not ((token['name'] in self.opts['external_auth'][token['eauth']]) |
-                    ('*' in self.opts['external_auth'][token['eauth']])):
-                found = False
+
+            # Fetch eauth config and collect users and groups configured for access
+            eauth_config = self.opts['external_auth'][token['eauth']]
+            eauth_users = []
+            eauth_groups = []
+            for entry in eauth_config:
+                if entry.endswith('%'):
+                    eauth_groups.append(entry.rstrip('%'))
+                else:
+                    eauth_users.append(entry)
+
+            # If there are groups in the token, check if any of them are listed in the eauth config
+            group_auth_match = False
+            try:
                 for group in token['groups']:
-                    if "{0}%".format(group) in self.opts['external_auth'][token['eauth']]:
-                        found = True
+                    if group in eauth_groups:
+                        group_auth_match = True
                         break
-                if not found:
+            except KeyError:
+                pass
+            finally:
+                if '*' not in eauth_users and token['name'] not in eauth_users and not group_auth_match:
                     log.warning('Authentication failure of type "token" occurred.')
                     return ''
 
-            group_perm_keys = [item for item in self.opts['external_auth'][token['eauth']] if item.endswith('%')]  # The configured auth groups
-
-            # First we need to know if the user is allowed to proceed via any of their group memberships.
-            group_auth_match = False
-            for group_config in group_perm_keys:
-                group_config = group_config.rstrip('%')
-                for group in token['groups']:
-                    if group == group_config:
-                        group_auth_match = True
-
+            # Compile list of authorized actions for the user
             auth_list = []
-
-            if '*' in self.opts['external_auth'][token['eauth']]:
-                auth_list.extend(self.opts['external_auth'][token['eauth']]['*'])
-            if token['name'] in self.opts['external_auth'][token['eauth']]:
-                auth_list.extend(self.opts['external_auth'][token['eauth']][token['name']])
+            # Add permissions for '*' or user-specific to the auth list
+            for user_key in ('*', token['name']):
+                auth_list.extend(eauth_config.get(user_key, []))
+            # Add any add'l permissions allowed by group membership
             if group_auth_match:
-                auth_list = self.ckminions.fill_auth_list_from_groups(self.opts['external_auth'][token['eauth']], token['groups'], auth_list)
+                auth_list = self.ckminions.fill_auth_list_from_groups(eauth_config, token['groups'], auth_list)
 
-            log.trace("compiled auth_list: {0}".format(auth_list))
+            log.trace("Compiled auth_list: {0}".format(auth_list))
 
             good = self.ckminions.auth_check(
                 auth_list,

--- a/salt/master.py
+++ b/salt/master.py
@@ -1784,10 +1784,9 @@ class ClearFuncs(object):
                         break
             except KeyError:
                 pass
-            finally:
-                if '*' not in eauth_users and token['name'] not in eauth_users and not group_auth_match:
-                    log.warning('Authentication failure of type "token" occurred.')
-                    return ''
+            if '*' not in eauth_users and token['name'] not in eauth_users and not group_auth_match:
+                log.warning('Authentication failure of type "token" occurred.')
+                return ''
 
             # Compile list of authorized actions for the user
             auth_list = []

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -1521,19 +1521,18 @@ class Login(LowDataAdapter):
         try:
             eauth = self.opts.get('external_auth', {}).get(token['eauth'], {})
 
+            # Get sum of '*' perms, user-specific perms, and group-specific perms
+            perms = eauth.get(token['name'], [])
+            perms.extend(eauth.get('*', []))
+
             if 'groups' in token:
                 user_groups = set(token['groups'])
                 eauth_groups = set([i.rstrip('%') for i in eauth.keys() if i.endswith('%')])
 
-                perms = []
                 for group in user_groups & eauth_groups:
                     perms.extend(eauth['{0}%'.format(group)])
 
-                perms = perms or None
-            else:
-                perms = eauth.get(token['name'], eauth.get('*'))
-
-            if perms is None:
+            if not perms:
                 raise ValueError("Eauth permission list not found.")
         except (AttributeError, IndexError, KeyError, ValueError):
             logger.debug("Configuration for external_auth malformed for "


### PR DESCRIPTION
There is currently a bug in the way eauth permissions are handled if permissions are defined for both individual users and groups.  In this scenario, if a user has permissions specified in the eauth config but is not a member of any group that has permissions defined, valid requests from that user will fail with the following stacktrace

```
# Output is from v2015.5.2, so line numbers may differ from develop
2015-08-05 00:10:46,355 [salt.master      ][CRITICAL][14009] Unexpected Error in Mworker
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/salt/master.py", line 736, in __bind
    ret = self.serial.dumps(self._handle_payload(payload))
  File "/usr/lib/python2.6/site-packages/salt/master.py", line 794, in _handle_payload
    'clear': self._handle_clear}[key](load)
  File "/usr/lib/python2.6/site-packages/salt/master.py", line 807, in _handle_clear
    return getattr(self.clear_funcs, load['cmd'])(load)
  File "/usr/lib/python2.6/site-packages/salt/master.py", line 2233, in publish
    for group in token['groups']:
KeyError: 'groups'
```

This is because the validation logic assumes that if groups are configured for eauth, any valid token will contain groups info, but the token creation logic only inserts this information if the user matches one or more groups specified in the eauth config.  

`mk_token` always gathers the user's group memberships so that it can check if any of them match groups in the eauth config, so I don't see why we shouldn't store them in the token either way.  I also cleaned up the logic in `ClearFuncs.publish` to avoid iterating over the same data or re-fetching the same dictionary values unnecessarily, so hopefully that will be a minor performance improvement.

While working on this, I also noticed that the logic in the cherrypy netapi module to respond to a POST to `/login` is determining permissions incorrectly.  If the requesting user is in a group specified in the eauth config, then the return will only have the permissions allowed by their group memberships, even if there are specific permissions for that user or permissions for `'*'`.  A user without any group permissions, but with user-specific permissions will also not see the permissions for `'*'` in the return.  The updated version ensures that all relevant permissions for the user will be in the return.
