### PR TITLE
Patch for issue #25994

### DIFF
--- a/salt/modules/ilo.py
+++ b/salt/modules/ilo.py
@@ -37,8 +37,8 @@ def __execute_cmd(name, xml):
     if not os.path.isdir(tmp_dir):
         os.mkdir(tmp_dir)
     with tempfile.NamedTemporaryFile(dir=tmp_dir,
-                                     prefix=name,
-                                     suffix=os.getpid(),
+                                     prefix=name+str(os.getpid()),
+                                     suffix='.xml',
                                      delete=False) as fh:
         tmpfilename = fh.name
         fh.write(xml)


### PR DESCRIPTION
When the NamedTemporaryFile function is called it will throw a
TypeError exception. This converts the pid to a string before
concatenating it to the ‘name’.
