### PR TITLE
Don't stacktrace when trying to get the default locale.

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -39,7 +39,12 @@ def __define_global_system_encoding_variable__():
         # encoding. MS Windows has problems with this and reports the wrong
         # encoding
         import locale
-        encoding = locale.getdefaultlocale()[-1]
+        try:
+            encoding = locale.getdefaultlocale()[-1]
+        except ValueError:
+            # A bad locale setting was most likely found:
+            #   https://github.com/saltstack/salt/issues/26063
+            pass
 
         # This is now garbage collectable
         del locale


### PR DESCRIPTION
Fixes #26063
