### PR TITLE
Move invocation routine up

### DIFF
--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -197,7 +197,6 @@ def save_load(jid, clear_load):
             log.debug('Job cache write failure: {0}'.format(exc))
 
 
-
 def get_load(jid):
     '''
     Return the load data that marks a specified jid

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -167,6 +167,17 @@ def save_load(jid, clear_load):
 
     serial = salt.payload.Serial(__opts__)
 
+    # Save the invocation information
+    try:
+        if not os.path.exists(jid_dir):
+            os.makedirs(jid_dir)
+        serial.dump(
+            clear_load,
+            salt.utils.fopen(os.path.join(jid_dir, LOAD_P), 'w+b')
+            )
+    except IOError as exc:
+        log.warning('Could not write job invocation cache file: {0}'.format(exc))
+
     # if you have a tgt, save that for the UI etc
     if 'tgt' in clear_load:
         ckminions = salt.utils.minions.CkMinions(__opts__)
@@ -181,19 +192,10 @@ def save_load(jid, clear_load):
                 minions,
                 salt.utils.fopen(os.path.join(jid_dir, MINIONS_P), 'w+b')
                 )
-        except IOError:
+        except IOError as exc:
             log.warning('Could not write job cache file for minions: {0}'.format(minions))
+            log.debug('Job cache write failure: {0}'.format(exc))
 
-    # Save the invocation information
-    try:
-        if not os.path.exists(jid_dir):
-            os.makedirs(jid_dir)
-        serial.dump(
-            clear_load,
-            salt.utils.fopen(os.path.join(jid_dir, LOAD_P), 'w+b')
-            )
-    except IOError as exc:
-        log.warning('Could not write job invocation cache file: {0}'.format(exc))
 
 
 def get_load(jid):


### PR DESCRIPTION
We should be checking for the existence of the job dir and saving the invocation before we do anything else.
