### PR TITLE
Better error messages when virtualenv creation fails

### DIFF
--- a/salt/states/virtualenv_mod.py
+++ b/salt/states/virtualenv_mod.py
@@ -162,7 +162,12 @@ def managed(name,
             use_vt=use_vt,
         )
 
-        ret['result'] = _ret['retcode'] == 0
+        if _ret['retcode'] != 0:
+            ret['result'] = False
+            ret['comment'] = _ret['stdout'] + _ret['stderr']
+            return ret
+
+        ret['result'] = True
         ret['changes']['new'] = __salt__['cmd.run_stderr'](
             '{0} -V'.format(venv_py)).strip('\n')
 


### PR DESCRIPTION
The virtualenv state doesn't return early enough if virtualenv creation fails, creating cryptic error messages.

Is there a better way to format the comment than simply concatenating stdout and stderr?

Before:

```
          ID: /var/www/qdb/.virtualenv
    Function: virtualenv.managed
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/tmp/.root_3cd8c3_salt/salt/state.py", line 1591, in call
                  **cdata['kwargs'])
                File "/tmp/.root_3cd8c3_salt/salt/states/virtualenv_mod.py", line 167, in managed
                  '{0} -V'.format(venv_py)).strip('\n')
                File "/tmp/.root_3cd8c3_salt/salt/modules/cmdmod.py", line 1334, in run_stderr
                  pillar_override=kwargs.get('pillar'))
                File "/tmp/.root_3cd8c3_salt/salt/modules/cmdmod.py", line 419, in _run
                  .format(cmd, kwargs, exc)
              CommandExecutionError: Unable to run command ['/var/www/qdb/.virtualenv/bin/python', '-V'] with the context {'with_communicate': True, 'shell': False, 'env': {'LANG': 'en_US.UTF8', 'LC_ALL': 'C', 'SHELL': '/bin/bash', 'MAIL': '/var/mail/root', 'SHLVL': '1', 'DEBIAN_FRONTEND': 'noninteractive', 'SSH_CLIENT': '51.174.74.144 54797 22', 'PWD': '/root', 'LOGNAME': 'root', 'USER': 'root', 'HOME': '/root', 'PATH': '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', 'SSH_CONNECTION': '51.174.74.144 54797 212.71.237.159 22', 'UCF_FORCE_CONFFOLD': '1', 'APT_LISTBUGS_FRONTEND': 'none', 'APT_LISTCHANGES_FRONTEND': 'none', '_': '/bin/sh'}, 'stdout': -1, 'close_fds': True, 'stdin': None, 'stderr': -1, 'cwd': '/root'}, reason: [Errno 2] No such file or directory
     Started: 21:48:56.176156
    Duration: 358.574 ms
```

After:

```
          ID: /var/www/qdb/.virtualenv
    Function: virtualenv.managed
      Result: False
     Comment: Already using interpreter /usr/bin/python3
              Using base prefix '/usr'Traceback (most recent call last):
                File "/usr/bin/virtualenv", line 9, in <module>
                  load_entry_point('virtualenv==1.11.6', 'console_scripts', 'virtualenv')()
                File "/usr/lib/python3/dist-packages/virtualenv.py", line 830, in main
                  symlink=options.symlink)
                File "/usr/lib/python3/dist-packages/virtualenv.py", line 999, in create_environment
                  site_packages=site_packages, clear=clear, symlink=symlink))
                File "/usr/lib/python3/dist-packages/virtualenv.py", line 1198, in install_python
                  mkdir(lib_dir)
                File "/usr/lib/python3/dist-packages/virtualenv.py", line 451, in mkdir
                  os.makedirs(path)
                File "/usr/lib/python3.4/os.py", line 227, in makedirs
                  makedirs(head, mode, exist_ok)
                File "/usr/lib/python3.4/os.py", line 227, in makedirs
                  makedirs(head, mode, exist_ok)
                File "/usr/lib/python3.4/os.py", line 237, in makedirs
                  mkdir(name, mode)
              PermissionError: [Errno 13] Permission denied: '/var/www/qdb/.virtualenv'
```
