### PR TITLE
Remove script func from OpenNebula driver - it's obsolete b/c of salt.utils.bootstrap

### DIFF
--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -1687,24 +1687,6 @@ def image_update(call=None, kwargs=None):
     return ret
 
 
-def script(vm_):
-    '''
-    Return the script deployment object.
-
-    vm_
-        The VM for which to deploy a script.
-    '''
-    deploy_script = salt.utils.cloud.os_script(
-        config.get_cloud_config_value('script', vm_, __opts__),
-        vm_,
-        __opts__,
-        salt.utils.cloud.salt_config_to_yaml(
-            salt.utils.cloud.minion_config(__opts__, vm_)
-        )
-    )
-    return deploy_script
-
-
 def show_instance(name, call=None):
     '''
     Show the details from OpenNebula concerning a named VM.


### PR DESCRIPTION
The `script` function used to be called by `create`. However, when the `salt.utils.bootstrap` function was used instead of duplicating vm-creation efforts, the `script` function became obsolete.
