### PR TITLE
Fixes to salt.utils.http related to cp.get_file_str bug.

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -208,7 +208,7 @@ def query(url,
             auth = None
     else:
         if not username and not password and isinstance(auth, tuple):
-            (username, password) = auth # pylint: disable=W0633
+            (username, password) = auth  # pylint: disable=W0633
 
     if requests_lib is True:
         sess = requests.Session()

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -207,7 +207,8 @@ def query(url,
         else:
             auth = None
     else:
-        (username, password) = auth
+        if not username and not password and isinstance(auth, tuple):
+            (username, password) = auth
 
     if requests_lib is True:
         sess = requests.Session()

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -208,7 +208,7 @@ def query(url,
             auth = None
     else:
         if not username and not password and isinstance(auth, tuple):
-            (username, password) = auth
+            (username, password) = auth # pylint: disable=W0633
 
     if requests_lib is True:
         sess = requests.Session()

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -201,10 +201,13 @@ def query(url,
             continue
         header_dict[comps[0].strip()] = comps[1].strip()
 
-    if username and password:
-        auth = (username, password)
+    if not auth:
+        if username and password:
+            auth = (username, password)
+        else:
+            auth = None
     else:
-        auth = None
+        (username, password) = auth
 
     if requests_lib is True:
         sess = requests.Session()
@@ -214,6 +217,11 @@ def query(url,
         sess_cookies = sess.cookies
         sess.verify = verify_ssl
     else:
+        if auth:
+            password_mgr = urllib_request.HTTPPasswordMgrWithDefaultRealm()
+            password_mgr.add_password(None, url, username, password)
+        else:
+            password_mgr = None
         sess_cookies = None
 
     if cookies is not None:
@@ -275,6 +283,8 @@ def query(url,
             urllib_request.HTTPHandler,
             urllib_request.HTTPCookieProcessor(sess_cookies)
         ]
+        if password_mgr:
+            handlers.append(urllib_request.HTTPBasicAuthHandler(password_mgr))
 
         if url.startswith('https') or port == 443:
             if not HAS_MATCHHOSTNAME:


### PR DESCRIPTION
Fixing a bug where cp.get_file_str would not work if using http(s) URLs with authentication.  The salt.utils.http library in 2015.5 defaults to using urllib instead of requests and there was no authenitication support available.  This PR adds authentication support. #24106
