### PR TITLE
imgadm.avail should return multiple results

### DIFF
--- a/salt/modules/smartos_imgadm.py
+++ b/salt/modules/smartos_imgadm.py
@@ -95,16 +95,17 @@ def avail(search=None):
     cmd = '{0} avail'.format(imgadm)
     res = __salt__['cmd.run_all'](cmd)
     retcode = res['retcode']
+    result = []
     if retcode != 0:
         ret['Error'] = _exit_status(retcode)
         return ret
     if search:
         for line in res['stdout'].splitlines():
             if search in line:
-                ret = line
+                result.append(line)
     else:
-        ret = res['stdout'].splitlines()
-    return ret
+        result = res['stdout'].splitlines()
+    return result
 
 
 def list_installed():


### PR DESCRIPTION
Slowly thinking of items from issue #25986

Now imgadm.avail will return multiple results if found vs only the first.

```
[root@core /zones/c03b3c34-dab1-47d2-9a4c-3fa280e7bce1/root/salt_dev/salt]# salt-call --local imgadm.avail base-64-lts
[INFO    ] Executing command '/usr/sbin/imgadm avail' in directory '/root'
local:
    - c02a2044-c1bd-11e4-bd8c-dfc1db8b0182  base-64-lts             14.4.0                                            smartos  2015-03-03T15:55:44Z
    - 24648664-e50c-11e4-be23-0349d0a5f3cf  base-64-lts             14.4.1                                            smartos  2015-04-17T14:15:04Z
    - b67492c2-055c-11e5-85d8-8b039ac981ec  base-64-lts             14.4.2                                            smartos  2015-05-28T17:12:26Z
```
