### PR TITLE
salt.module.smartos_imgadm now supports vacuum

### DIFF
--- a/salt/modules/smartos_imgadm.py
+++ b/salt/modules/smartos_imgadm.py
@@ -230,4 +230,33 @@ def delete(uuid=None):
     return ret
 
 
+def vacuum():
+    '''
+    Remove unused images
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' imgadm.vacuum
+    '''
+    ret = {}
+    imgadm = _check_imgadm()
+    cmd = '{0} vacuum -f'.format(imgadm)
+    res = __salt__['cmd.run_all'](cmd)
+    retcode = res['retcode']
+    if retcode != 0:
+        ret['Error'] = _exit_status(retcode)
+        return ret
+    # output: Deleted image d5b3865c-0804-11e5-be21-dbc4ce844ddc (lx-centos-6@20150601)
+    result = {}
+    for image in res['stdout'].splitlines():
+        image = [var for var in image.split(" ") if var]
+        result[image[2]] = {
+            'name': image[3][1:image[3].index('@')],
+            'version': image[3][image[3].index('@')+1:-1]
+        }
+    return result
+
+
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/salt/modules/smartos_imgadm.py
+++ b/salt/modules/smartos_imgadm.py
@@ -230,15 +230,18 @@ def delete(uuid=None):
     return ret
 
 
-def vacuum():
+def vacuum(verbose=False):
     '''
     Remove unused images
+
+    verbose : boolean (False)
+        Specifies verbose output
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' imgadm.vacuum
+        salt '*' imgadm.vacuum [True]
     '''
     ret = {}
     imgadm = _check_imgadm()
@@ -256,7 +259,10 @@ def vacuum():
             'name': image[3][1:image[3].index('@')],
             'version': image[3][image[3].index('@')+1:-1]
         }
-    return result
+    if verbose:
+        return result
+    else:
+        return list(result.keys())
 
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
Working my way through issue #25986, added vacuum support to remove unused images.

_Slowly getting more familiar with salt modules, first time returning data in a nice dict.
Wouldn't hurt to give it a quick extra sanity check._

```
[root@core ~]# salt-call --local imgadm.vacuum True
[INFO    ] Executing command '/usr/sbin/imgadm vacuum -f' in directory '/root'
local:
    ----------
    a79dc83a-e3a7-11e4-bfe5-d3bb86399352:
        ----------
        name:
            lx-centos-6
        version:
            20150415
    d5b3865c-0804-11e5-be21-dbc4ce844ddc:
        ----------
        name:
            lx-centos-6
        version:
            20150601
```

```
[root@core ~]# salt-call --local imgadm.vacuum
[INFO    ] Executing command '/usr/sbin/imgadm vacuum -f' in directory '/root'
local:
    - d5b3865c-0804-11e5-be21-dbc4ce844ddc
```
