### PR TITLE
smartos_imgadm cleanup

### DIFF
--- a/salt/modules/smartos_imgadm.py
+++ b/salt/modules/smartos_imgadm.py
@@ -262,6 +262,9 @@ def delete(uuid=None):
     '''
     Remove an installed image
 
+    uuid : string
+        Specifies uuid to import
+
     CLI Example:
 
     .. code-block:: bash
@@ -279,8 +282,13 @@ def delete(uuid=None):
     if retcode != 0:
         ret['Error'] = _exit_status(retcode)
         return ret
-    ret[uuid] = res['stdout'].splitlines()
-    return ret
+    # output: Deleted image d5b3865c-0804-11e5-be21-dbc4ce844ddc
+    result = []
+    for image in res['stdout'].splitlines():
+        image = [var for var in image.split(" ") if var]
+        result.append(image[2])
+
+    return result
 
 
 def vacuum(verbose=False):

--- a/salt/modules/smartos_imgadm.py
+++ b/salt/modules/smartos_imgadm.py
@@ -16,6 +16,8 @@ log = logging.getLogger(__name__)
 
 # Function aliases
 __func_alias__ = {
+    'list_installed': 'list',
+    'update_installed': update,
     'import_image': 'import'
 }
 
@@ -90,7 +92,7 @@ def version():
     return ret[-1]
 
 
-def update(uuid=''):
+def update_installed(uuid=''):
     '''
     Gather info on unknown image(s) (locally installed)
 
@@ -147,7 +149,7 @@ def avail(search=None, verbose=False):
     return result
 
 
-def list(verbose=False):
+def list_installed(verbose=False):
     '''
     Return a list of installed images
 

--- a/salt/modules/smartos_imgadm.py
+++ b/salt/modules/smartos_imgadm.py
@@ -192,7 +192,7 @@ def show(uuid=None):
     if retcode != 0:
         ret['Error'] = _exit_status(retcode)
         return ret
-    ret[uuid] = res['stdout'].splitlines()
+    ret = json.loads(res['stdout'])
     return ret
 
 

--- a/salt/modules/smartos_imgadm.py
+++ b/salt/modules/smartos_imgadm.py
@@ -63,19 +63,22 @@ def version():
     return ret[-1]
 
 
-def update_installed():
+def update(uuid=''):
     '''
-    Gather info on unknown images (locally installed)
+    Gather info on unknown image(s) (locally installed)
+
+    uuid : string
+        Specifies uuid of image
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' imgadm.update_installed
+        salt '*' imgadm.update [uuid]
     '''
     imgadm = _check_imgadm()
     if imgadm:
-        cmd = '{0} update'.format(imgadm)
+        cmd = '{0} update {1}'.format(imgadm, uuid).rstrip()
         __salt__['cmd.run'](cmd)
     return {}
 

--- a/salt/modules/smartos_imgadm.py
+++ b/salt/modules/smartos_imgadm.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 # Function aliases
 __func_alias__ = {
     'list_installed': 'list',
-    'update_installed': update,
+    'update_installed': 'update',
     'import_image': 'import'
 }
 

--- a/salt/modules/smartos_imgadm.py
+++ b/salt/modules/smartos_imgadm.py
@@ -71,7 +71,7 @@ def update_installed():
 
     .. code-block:: bash
 
-        salt '*' imgadm.update_installed()
+        salt '*' imgadm.update_installed
     '''
     imgadm = _check_imgadm()
     if imgadm:

--- a/salt/modules/smartos_imgadm.py
+++ b/salt/modules/smartos_imgadm.py
@@ -253,7 +253,7 @@ def import_image(uuid=None, verbose=False):
         ret['Error'] = _exit_status(retcode)
         return ret
 
-    return _parse_image_meta(get(uuid), verbose)
+    return {uuid: _parse_image_meta(get(uuid), verbose)}
 
 
 def delete(uuid=None):

--- a/salt/modules/smartos_imgadm.py
+++ b/salt/modules/smartos_imgadm.py
@@ -230,4 +230,33 @@ def delete(uuid=None):
     return ret
 
 
+def vacuum():
+    '''
+    Remove unused images
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' imgadm.vacuum
+    '''
+    ret = {}
+    imgadm = _check_imgadm()
+    cmd = '{0} vacuum -f'.format(imgadm)
+    res = __salt__['cmd.run_all'](cmd)
+    retcode = res['retcode']
+    if retcode != 0:
+        ret['Error'] = _exit_status(retcode)
+        return ret
+    # output: Deleted image d5b3865c-0804-11e5-be21-dbc4ce844ddc (lx-centos-6@20150601)
+    result = {}
+    for image in res['stdout'].splitlines():
+        image = [var for var in image.split(" ") if var]
+        result[image[2]] = {
+            'name': image[3][1:image[3].index('@')],
+            'version': image[3][image[3].index('@')+1:-1]
+        }
+    return result
+
+
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/salt/modules/smartos_imgadm.py
+++ b/salt/modules/smartos_imgadm.py
@@ -14,6 +14,11 @@ import salt.utils.decorators as decorators
 
 log = logging.getLogger(__name__)
 
+# Function aliases
+__func_alias__ = {
+    'import_image': 'import'
+}
+
 # Define the module's virtual name
 __virtualname__ = 'imgadm'
 
@@ -217,19 +222,24 @@ def get(uuid=None):
     if retcode != 0:
         ret['Error'] = _exit_status(retcode)
         return ret
-    ret[uuid] = res['stdout'].splitlines()
+    ret = json.loads(res['stdout'])
     return ret
 
 
-def import_image(uuid=None):
+def import_image(uuid=None, verbose=False):
     '''
     Import an image from the repository
+
+    uuid : string
+        Specifies uuid to import
+    verbose : boolean (False)
+        Specifies verbose output
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' imgadm.import_image e42f8c84-bbea-11e2-b920-078fab2aab1f
+        salt '*' imgadm.import e42f8c84-bbea-11e2-b920-078fab2aab1f [verbose=True]
     '''
     ret = {}
     if not uuid:
@@ -242,8 +252,8 @@ def import_image(uuid=None):
     if retcode != 0:
         ret['Error'] = _exit_status(retcode)
         return ret
-    ret[uuid] = res['stdout'].splitlines()
-    return ret
+
+    return _parse_image_meta(get(uuid), verbose)
 
 
 def delete(uuid=None):

--- a/salt/modules/smartos_imgadm.py
+++ b/salt/modules/smartos_imgadm.py
@@ -217,7 +217,7 @@ def get(uuid=None):
     if retcode != 0:
         ret['Error'] = _exit_status(retcode)
         return ret
-    ret[uuid] = res['stdout'].splitlines()
+    ret = json.loads(res['stdout'])
     return ret
 
 

--- a/salt/modules/smartos_imgadm.py
+++ b/salt/modules/smartos_imgadm.py
@@ -142,26 +142,33 @@ def avail(search=None, verbose=False):
     return result
 
 
-def list_installed():
+def list(verbose=False):
     '''
     Return a list of installed images
+
+    verbose : boolean (False)
+        Specifies verbose output
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' imgadm.list_installed
+        salt '*' imgadm.list [verbose=True]
     '''
     ret = {}
     imgadm = _check_imgadm()
-    cmd = '{0} list'.format(imgadm)
+    cmd = '{0} list -j'.format(imgadm)
     res = __salt__['cmd.run_all'](cmd)
     retcode = res['retcode']
+    result = {}
     if retcode != 0:
         ret['Error'] = _exit_status(retcode)
         return ret
-    ret = res['stdout'].splitlines()
-    return ret
+
+    for image in json.loads(res['stdout']):
+        result[image['manifest']['uuid']] = _parse_image_meta(image, verbose)
+
+    return result
 
 
 def show(uuid=None):
@@ -275,7 +282,7 @@ def vacuum(verbose=False):
 
     .. code-block:: bash
 
-        salt '*' imgadm.vacuum [True]
+        salt '*' imgadm.vacuum [verbose=True]
     '''
     ret = {}
     imgadm = _check_imgadm()

--- a/salt/modules/smartos_imgadm.py
+++ b/salt/modules/smartos_imgadm.py
@@ -230,15 +230,18 @@ def delete(uuid=None):
     return ret
 
 
-def vacuum():
+def vacuum(verbose=False):
     '''
     Remove unused images
+
+    verbose : boolean (False)
+        Specifies verbose output
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' imgadm.vacuum
+        salt '*' imgadm.vacuum [True]
     '''
     ret = {}
     imgadm = _check_imgadm()
@@ -256,7 +259,10 @@ def vacuum():
             'name': image[3][1:image[3].index('@')],
             'version': image[3][image[3].index('@')+1:-1]
         }
-    return result
+    if verbose:
+        return result
+    else:
+        return list(result.keys())
 
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
Complete cleanup of smartos_imgadm.
Now returns proper output, vacuum support got added and naming is now on par with the actually imgadm command.

This PR super seeds PR #26142 

```
[root@core ~]# salt-call --local imgadm.avail base-64-lts verbose=True
[INFO    ] Executing command '/usr/sbin/imgadm avail -j' in directory '/root'
local:
    ----------
    24648664-e50c-11e4-be23-0349d0a5f3cf:
        ----------
        description:
            A 64-bit SmartOS image with just essential packages installed. Ideal for users who are comfortable with setting up their own environment and tools.
        name:
            base-64-lts
        os:
            smartos
        published:
            2015-04-17T14:15:04Z
        source:
            https://images.joyent.com
        version:
            14.4.1
    b67492c2-055c-11e5-85d8-8b039ac981ec:
        ----------
        description:
            A 64-bit SmartOS image with just essential packages installed. Ideal for users who are comfortable with setting up their own environment and tools.
        name:
            base-64-lts
        os:
            smartos
        published:
            2015-05-28T17:12:26Z
        source:
            https://images.joyent.com
        version:
            14.4.2
    c02a2044-c1bd-11e4-bd8c-dfc1db8b0182:
        ----------
        description:
            A 64-bit SmartOS image with just essential packages installed. Ideal for users who are comfortable with setting up their own environment and tools.
        name:
            base-64-lts
        os:
            smartos
        published:
            2015-03-03T15:55:44Z
        source:
            https://images.joyent.com
        version:
            14.4.0
```

```
[root@core ~]# salt-call --local imgadm.avail base-64-lts
[INFO    ] Executing command '/usr/sbin/imgadm avail -j' in directory '/root'
local:
    ----------
    24648664-e50c-11e4-be23-0349d0a5f3cf:
        base-64-lts@14.4.1 [2015-04-17T14:15:04Z]
    b67492c2-055c-11e5-85d8-8b039ac981ec:
        base-64-lts@14.4.2 [2015-05-28T17:12:26Z]
    c02a2044-c1bd-11e4-bd8c-dfc1db8b0182:
        base-64-lts@14.4.0 [2015-03-03T15:55:44Z]
```

```
[root@core ~]# salt-call --local imgadm.import d5b3865c-0804-11e5-be21-dbc4ce844ddc
[INFO    ] Executing command '/usr/sbin/imgadm import d5b3865c-0804-11e5-be21-dbc4ce844ddc' in directory '/root'
[INFO    ] Executing command '/usr/sbin/imgadm get d5b3865c-0804-11e5-be21-dbc4ce844ddc' in directory '/root'
local:
    lx-centos-6@20150601 [2015-06-01T02:20:56Z]
```

```
[root@core ~]# salt-call --local imgadm.vacuum True
[INFO    ] Executing command '/usr/sbin/imgadm vacuum -f' in directory '/root'
local:
    ----------
    a79dc83a-e3a7-11e4-bfe5-d3bb86399352:
        ----------
        name:
            lx-centos-6
        version:
            20150415
    d5b3865c-0804-11e5-be21-dbc4ce844ddc:
        ----------
        name:
            lx-centos-6
        version:
            20150601
```

```
[root@core ~]# salt-call --local imgadm.vacuum
[INFO    ] Executing command '/usr/sbin/imgadm vacuum -f' in directory '/root'
local:
    - d5b3865c-0804-11e5-be21-dbc4ce844ddc
```
