### PR TITLE
Fixes #26024

### DIFF
--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -866,7 +866,7 @@ def _network_conf(conf_tuples=None, **kwargs):
     # (lxc.network.ipv4.gateway: auto)
     if (
         distutils.version.LooseVersion(version()) <= '1.0.7' and
-        True not in ['ipv4.gateway' in a for a in ret]
+        True not in ['lxc.network.ipv4.gateway' in a for a in ret]
     ):
         ret.append({'lxc.network.ipv4.gateway': 'auto'})
     return ret


### PR DESCRIPTION
Fix for detection of previous gateways set.

[a for a in ret] iterates over OrderedDicts. To match (i.e. result in True), the key must be exactly the same. Thus a lxc.network is missing.
