### PR TITLE
Prevent attribute error during finding files in GitFS

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -578,7 +578,7 @@ class GitPython(GitProvider):
             except KeyError:
                 # File not found or repo_path points to a directory
                 break
-        return blob, blob.hexsha
+        return blob, blob.hexsha if blob else None
 
     def get_tree(self, tgt_env):
         '''
@@ -933,7 +933,7 @@ class Pygit2(GitProvider):
                     blob = self.repo[oid]
             except KeyError:
                 break
-        return blob, blob.hex
+        return blob, blob.hex if blob else None
 
     def get_tree(self, tgt_env):
         '''
@@ -1271,7 +1271,7 @@ class Dulwich(GitProvider):  # pylint: disable=abstract-method
                     break
             except KeyError:
                 break
-        return blob, blob.sha().hexdigest()
+        return blob, blob.sha().hexdigest() if blob else None
 
     def get_conf(self):
         '''


### PR DESCRIPTION
Fixes #26149. Not sure if all those `None` checks are needed, but I thought I'd rather get them all than only do the pygit2 one.
