### PR TITLE
Updates to cloud docs for the provider > driver change

### DIFF
--- a/conf/cloud.providers
+++ b/conf/cloud.providers
@@ -3,13 +3,13 @@
 # directory is identical.
 
 #my-digitalocean-config:
-#  provider: digital_ocean
+#  driver: digital_ocean
 #  client_key: wFGEwgregeqw3435gDger
 #  api_key: GDE43t43REGTrkilg43934t34qT43t4dgegerGEgg
 #  location: New York 1
 
 #my-aws-quick-start:
-#  provider: ec2
+#  driver: ec2
 #  id: HJGRYCILJLKJYG
 #  key: 'kdjgfsgm;woormgl/aserigjksjdhasdfgn'
 #  keyname: test
@@ -17,7 +17,7 @@
 #  private_key: /root/test.pem
 
 #my-aws-default:
-#  provider: ec2
+#  driver: ec2
 #  id: HJGRYCILJLKJYG
 #  key: 'kdjgfsgm;woormgl/aserigjksjdhasdfgn'
 #  keyname: test
@@ -25,12 +25,12 @@
 #  private_key: /root/test.pem
 
 #my-gogrid-config:
-#  provider: gogrid
+#  driver: gogrid
 #  apikey: asdff7896asdh789
 #  sharedsecret: saltybacon
 
 #my-openstack-hp-config:
-#  provider: openstack
+#  driver: openstack
 #  identity_url: 'https://region-a.geo-1.identity.hpcloudsvc.com:35357/v2.0/'
 #  compute_name: Compute
 #  compute_region: 'az-1.region-a.geo-1'
@@ -41,7 +41,7 @@
 #  password: mypass
 
 #my-ibmsce-config:
-#  provider: ibmsce
+#  driver: ibmsce
 #  user: myuser@mycorp.com
 #  password: mypass
 #  ssh_key_name: mykey
@@ -49,30 +49,30 @@
 #  location: Raleigh
 
 #my-joyent-config:
-#    provider: joyent
+#    driver: joyent
 #    user: fred
 #    password: saltybacon
 #    private_key: /root/joyent.pem
 
 #my-linode-config:
-#  provider: linode
+#  driver: linode
 #  apikey: asldkgfakl;sdfjsjaslfjaklsdjf;askldjfaaklsjdfhasldsadfghdkf
 #  password: F00barbaz
 
 #my-parallels-config:
-#  provider: parallels
+#  driver: parallels
 #  user: myuser
 #  password: xyzzy
 #  url: https://api.cloud.xmission.com:4465/paci/v1.0/
 
 #my-proxmox-config:
-#  provider: proxmox
+#  driver: proxmox
 #  user: saltcloud@pve
 #  password: xyzzy
 #  url: your.proxmox.host
 
 #my-openstack-rackspace-config:
-#  provider: openstack
+#  driver: openstack
 #  identity_url: 'https://identity.api.rackspacecloud.com/v2.0/tokens'
 #  compute_name: cloudServersOpenStack
 #  protocol: ipv4
@@ -83,4 +83,4 @@
 #  apikey: 901d3f579h23c8v73q9
 
 #my-saltify-config:
-#  provider: saltify
+#  driver: saltify

--- a/conf/cloud.providers.d/digitalocean.conf
+++ b/conf/cloud.providers.d/digitalocean.conf
@@ -1,5 +1,5 @@
 #my-digitalocean-config:
-#  provider: digital_ocean
+#  driver: digital_ocean
 #  client_key: wFGEwgregeqw3435gDger
 #  api_key: GDE43t43REGTrkilg43934t34qT43t4dgegerGEgg
 #  location: New York 1

--- a/conf/cloud.providers.d/ec2.conf
+++ b/conf/cloud.providers.d/ec2.conf
@@ -1,5 +1,5 @@
 #my-aws-quick-start:
-#  provider: ec2
+#  driver: ec2
 #  id: HJGRYCILJLKJYG
 #  key: 'kdjgfsgm;woormgl/aserigjksjdhasdfgn'
 #  keyname: test
@@ -7,7 +7,7 @@
 #  private_key: /root/test.pem
 
 #my-aws-default:
-#  provider: ec2
+#  driver: ec2
 #  id: HJGRYCILJLKJYG
 #  key: 'kdjgfsgm;woormgl/aserigjksjdhasdfgn'
 #  keyname: test

--- a/conf/cloud.providers.d/gogrid.conf
+++ b/conf/cloud.providers.d/gogrid.conf
@@ -1,4 +1,4 @@
 #my-gogrid-config:
-#  provider: gogrid
+#  driver: gogrid
 #  apikey: asdff7896asdh789
 #  sharedsecret: saltybacon

--- a/conf/cloud.providers.d/hpcloud-openstack.conf
+++ b/conf/cloud.providers.d/hpcloud-openstack.conf
@@ -1,5 +1,5 @@
 #my-openstack-hp-config:
-#  provider: openstack
+#  driver: openstack
 #  identity_url: 'https://region-a.geo-1.identity.hpcloudsvc.com:35357/v2.0/'
 #  compute_name: Compute
 #  compute_region: 'az-1.region-a.geo-1'

--- a/conf/cloud.providers.d/ibmsce.conf
+++ b/conf/cloud.providers.d/ibmsce.conf
@@ -1,5 +1,5 @@
 #my-ibmsce-config:
-#  provider: ibmsce
+#  driver: ibmsce
 #  user: myuser@mycorp.com
 #  password: mypass
 #  ssh_key_name: mykey

--- a/conf/cloud.providers.d/joyent.conf
+++ b/conf/cloud.providers.d/joyent.conf
@@ -1,5 +1,5 @@
 #my-joyent-config:
-#    provider: joyent
+#    driver: joyent
 #    user: fred
 #    password: saltybacon
 #    private_key: /root/joyent.pem

--- a/conf/cloud.providers.d/linode.conf
+++ b/conf/cloud.providers.d/linode.conf
@@ -1,4 +1,4 @@
 #my-linode-config:
-#  provider: linode
+#  driver: linode
 #  apikey: asldkgfakl;sdfjsjaslfjaklsdjf;askldjfaaklsjdfhasldsadfghdkf
 #  password: F00barbaz

--- a/conf/cloud.providers.d/parallels.conf
+++ b/conf/cloud.providers.d/parallels.conf
@@ -1,5 +1,5 @@
 #my-parallels-config:
-#  provider: parallels
+#  driver: parallels
 #  user: myuser
 #  password: xyzzy
 #  url: https://api.cloud.xmission.com:4465/paci/v1.0/

--- a/conf/cloud.providers.d/proxmox.conf
+++ b/conf/cloud.providers.d/proxmox.conf
@@ -1,6 +1,5 @@
 #my-proxmox-config:
-#  provider: proxmox
+#  driver: proxmox
 #  user: saltcloud@pve
 #  password: xyzzy
 #  url: your.proxmox.host
-  

--- a/conf/cloud.providers.d/rackspace-openstack.conf
+++ b/conf/cloud.providers.d/rackspace-openstack.conf
@@ -1,5 +1,5 @@
 #my-openstack-rackspace-config:
-#  provider: openstack
+#  driver: openstack
 #  identity_url: 'https://identity.api.rackspacecloud.com/v2.0/tokens'
 #  compute_name: cloudServersOpenStack
 #  protocol: ipv4

--- a/conf/cloud.providers.d/saltify.conf
+++ b/conf/cloud.providers.d/saltify.conf
@@ -1,2 +1,2 @@
 #my-saltify-config:
-#  provider: saltify
+#  driver: saltify

--- a/conf/cloud.providers.d/vsphere.conf
+++ b/conf/cloud.providers.d/vsphere.conf
@@ -1,5 +1,5 @@
 #my-vsphere-config:
-#  provider: vsphere
+#  driver: vsphere
 #  user: myuser
 #  password: verybadpass
 #  url: 'https://10.1.1.1:443'

--- a/doc/topics/cloud/aliyun.rst
+++ b/doc/topics/cloud/aliyun.rst
@@ -3,7 +3,7 @@ Getting Started With Aliyun ECS
 ===============================
 
 The Aliyun ECS (Elastic Computer Service) is one of the most popular public
-cloud providers in China. This cloud provider can be used to manage aliyun
+cloud hosts in China. This cloud host can be used to manage aliyun
 instance using salt-cloud.
 
 http://www.aliyun.com/
@@ -34,6 +34,14 @@ under "My Service" tab.
       location: cn-qingdao
       driver: aliyun
 
+.. note::
+    .. versionchanged:: 2015.8.0
+
+    The ``provider`` parameter in cloud provider definitions was renamed to ``driver``. This
+    change was made to avoid confusion with the ``provider`` parameter that is used in cloud profile
+    definitions. Cloud provider definitions now use ``driver`` to refer to the Salt cloud module that
+    provides the underlying functionality to connect to a cloud host, while cloud profiles continue
+    to use ``provider`` to refer to provider configurations that you define.
 
 Profiles
 ========
@@ -46,7 +54,7 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or in the
 .. code-block:: yaml
 
     aliyun_centos:
-        driver: my-aliyun-config
+        provider: my-aliyun-config
         size: ecs.t1.small
         location: cn-qingdao
         securitygroup: G1989096784427999

--- a/doc/topics/cloud/aws.rst
+++ b/doc/topics/cloud/aws.rst
@@ -5,9 +5,9 @@ Getting Started With AWS EC2
 Amazon EC2 is a very widely used public cloud platform and one of the core
 platforms Salt Cloud has been built to support.
 
-Previously, the suggested provider for AWS EC2 was the ``aws`` provider. This
-has been deprecated in favor of the ``ec2`` provider. Configuration using the
-old ``aws`` provider will still function, but that driver is no longer in
+Previously, the suggested driver for AWS EC2 was the ``aws`` driver. This
+has been deprecated in favor of the ``ec2`` driver. Configuration using the
+old ``aws`` driver will still function, but that driver is no longer in
 active development.
 
 
@@ -146,6 +146,14 @@ parameters are discussed in more detail below.
 
       driver: ec2
 
+.. note::
+    .. versionchanged:: 2015.8.0
+
+    The ``provider`` parameter in cloud provider definitions was renamed to ``driver``. This
+    change was made to avoid confusion with the ``provider`` parameter that is used in cloud profile
+    definitions. Cloud provider definitions now use ``driver`` to refer to the Salt cloud module that
+    provides the underlying functionality to connect to a cloud host, while cloud profiles continue
+    to use ``provider`` to refer to provider configurations that you define.
 
 Access Credentials
 ==================

--- a/doc/topics/cloud/azure.rst
+++ b/doc/topics/cloud/azure.rst
@@ -65,6 +65,14 @@ tab within the "Settings" section of the management portal.
 
 Optionally, a ``management_host`` may be configured, if necessary for the region.
 
+.. note::
+    .. versionchanged:: 2015.8.0
+
+    The ``provider`` parameter in cloud provider definitions was renamed to ``driver``. This
+    change was made to avoid confusion with the ``provider`` parameter that is used in cloud profile
+    definitions. Cloud provider definitions now use ``driver`` to refer to the Salt cloud module that
+    provides the underlying functionality to connect to a cloud host, while cloud profiles continue
+    to use ``provider`` to refer to provider configurations that you define.
 
 Cloud Profiles
 ==============

--- a/doc/topics/cloud/basic.rst
+++ b/doc/topics/cloud/basic.rst
@@ -19,7 +19,7 @@ Assuming there is a profile configured as following:
 .. code-block:: bash
 
     fedora_rackspace:
-        provider: rackspace
+        provider: my-rackspace-config
         image: Fedora 17
         size: 256 server
         script: bootstrap-salt

--- a/doc/topics/cloud/cloud.rst
+++ b/doc/topics/cloud/cloud.rst
@@ -1,24 +1,24 @@
-==============================
-Writing Cloud Provider Modules
-==============================
+============================
+Writing Cloud Driver Modules
+============================
 
 Salt Cloud runs on a module system similar to the main Salt project. The
 modules inside saltcloud exist in the ``salt/cloud/clouds`` directory of the
 salt source.
 
-There are two basic types of cloud modules. If a cloud provider is supported by
+There are two basic types of cloud modules. If a cloud host is supported by
 libcloud, then using it is the fastest route to getting a module written. The
 Apache Libcloud project is located at:
 
 http://libcloud.apache.org/
 
-Not every cloud provider is supported by libcloud. Additionally, not every
-feature in a supported cloud provider is necessary supported by libcloud. In
+Not every cloud host is supported by libcloud. Additionally, not every
+feature in a supported cloud host is necessarily supported by libcloud. In
 either of these cases, a module can be created which does not rely on libcloud.
 
-All Modules
-===========
-The following functions are required by all modules, whether or not they are
+All Driver Modules
+==================
+The following functions are required by all driver modules, whether or not they are
 based on libcloud.
 
 The __virtual__() Function
@@ -51,17 +51,17 @@ The create() Function
 ---------------------
 The most important function that does need to be manually written is the
 ``create()`` function. This is what is used to request a virtual machine to be
-created by the cloud provider, wait for it to become available, and then
+created by the cloud host, wait for it to become available, and then
 (optionally) log in and install Salt on it.
 
-A good example to follow for writing a cloud provider module based on libcloud
+A good example to follow for writing a cloud driver module based on libcloud
 is the module provided for Linode:
 
 https://github.com/saltstack/salt/tree/develop/salt/cloud/clouds/linode.py
 
 The basic flow of a ``create()`` function is as follows:
 
-* Send a request to the cloud provider to create a virtual machine.
+* Send a request to the cloud host to create a virtual machine.
 * Wait for the virtual machine to become available.
 * Generate kwargs to be used to deploy Salt.
 * Log into the virtual machine and deploy Salt.
@@ -80,20 +80,20 @@ configuration and environment variables.
 The first thing the ``create()`` function must do is fire an event stating that
 it has started the create process. This event is tagged
 ``salt/cloud/<vm name>/creating``. The payload contains the names of the VM,
-profile and provider.
+profile, and provider.
 
 A set of kwargs is then usually created, to describe the parameters required
-by the cloud provider to request the virtual machine.
+by the cloud host to request the virtual machine.
 
 An event is then fired to state that a virtual machine is about to be requested.
 It is tagged as ``salt/cloud/<vm name>/requesting``. The payload contains most
-or all of the parameters that will be sent to the cloud provider. Any private
+or all of the parameters that will be sent to the cloud host. Any private
 information (such as passwords) should not be sent in the event.
 
 After a request is made, a set of deploy kwargs will be generated. These will
 be used to install Salt on the target machine. Windows options are supported
-at this point, and should be generated, even if the cloud provider does not
-currently support Windows. This will save time in the future if the provider
+at this point, and should be generated, even if the cloud host does not
+currently support Windows. This will save time in the future if the host
 does eventually decide to support Windows.
 
 An event is then fired to state that the deploy process is about to begin. This
@@ -118,12 +118,12 @@ manager. These do not need to be handled by the developer in the cloud module.
 
 The ``salt.utils.cloud.validate_windows_cred()`` function has been extended to
 take the number of retries and retry_delay parameters in case a specific cloud
-provider has a delay between providing the Windows credentials and the
+host has a delay between providing the Windows credentials and the
 credentials being available for use.  In their ``create()`` function, or as a
 a sub-function called during the creation process, developers should use the
 ``win_deploy_auth_retries`` and ``win_deploy_auth_retry_delay`` parameters from
 the provider configuration to allow the end-user the ability to customize the
-number of tries and delay between tries for their particular provider.
+number of tries and delay between tries for their particular host.
 
 After the appropriate deploy function completes, a final event is fired
 which describes the virtual machine that has just been created. This event is
@@ -133,13 +133,13 @@ VM, profile, and provider.
 Finally, a dict (queried from the provider) which describes the new virtual
 machine is returned to the user. Because this data is not fired on the event
 bus it can, and should, return any passwords that were returned by the cloud
-provider. In some cases (for example, Rackspace), this is the only time that
+host. In some cases (for example, Rackspace), this is the only time that
 the password can be queried by the user; post-creation queries may not contain
-password information (depending upon the provider).
+password information (depending upon the host).
 
 The libcloudfuncs Functions
 ---------------------------
-A number of other functions are required for all cloud providers. However, with
+A number of other functions are required for all cloud hosts. However, with
 libcloud-based modules, these are all provided for free by the libcloudfuncs
 library. The following two lines set up the imports:
 
@@ -181,7 +181,7 @@ required by the developer. When this is the case, some or all of the functions
 in ``libcloudfuncs`` may be replaced. If they are all replaced, the libcloud
 imports should be absent from the Salt Cloud module.
 
-A good example of a non-libcloud provider is the DigitalOcean module:
+A good example of a non-libcloud driver is the DigitalOcean driver:
 
 https://github.com/saltstack/salt/tree/develop/salt/cloud/clouds/digital_ocean.py
 
@@ -202,8 +202,8 @@ to exist otherwise.
 
 The avail_locations() Function
 ------------------------------
-This function returns a list of locations available, if the cloud provider uses
-multiple data centers. It is not necessary if the cloud provider only uses one
+This function returns a list of locations available, if the cloud host uses
+multiple data centers. It is not necessary if the cloud host uses only one
 data center. It is normally called using the ``--list-locations`` option.
 
 .. code-block:: bash

--- a/doc/topics/cloud/config.rst
+++ b/doc/topics/cloud/config.rst
@@ -45,7 +45,7 @@ Cloud Configuration Syntax
 
 The data specific to interacting with public clouds is set up here.
 
-Cloud provider configuration syntax can live in several places. The first is in
+Cloud provider configuration settings can live in several places. The first is in
 ``/etc/salt/cloud``:
 
 .. code-block:: yaml
@@ -171,13 +171,13 @@ minion. In your pillar file, you would use something like this:
 
       profiles:
         ubuntu-nova:
-          driver: my-nova
+          provider: my-nova
           size: performance1-8
           image: bb02b1a3-bc77-4d17-ab5b-421d89850fca
           script_args: git develop
 
         ubuntu-openstack:
-          driver: my-openstack
+          provider: my-openstack
           size: performance1-8
           image: bb02b1a3-bc77-4d17-ab5b-421d89850fca
           script_args: git develop
@@ -217,7 +217,7 @@ Rackspace cloud requires two configuration options; a ``user`` and an ``apikey``
     my-rackspace-config:
       user: example_user
       apikey: 123984bjjas87034
-      driver: rackspace-config
+      driver: rackspace
 
 .. note::
 
@@ -444,7 +444,7 @@ Proxmox
 -------
 
 Using Salt with Proxmox requires a ``user``, ``password``, and ``URL``. These can be
-obtained from your cloud provider. Both PAM and PVE users can be used.
+obtained from your cloud host. Both PAM and PVE users can be used.
 
 .. code-block:: yaml
 
@@ -478,7 +478,7 @@ And in the map file:
 .. code-block:: yaml
 
     devhost10-lxc:
-      driver: devhost10-lxc
+      provider: devhost10-lxc
       from_container: ubuntu
       backing: lvm
       sudo: True

--- a/doc/topics/cloud/deploy.rst
+++ b/doc/topics/cloud/deploy.rst
@@ -75,7 +75,7 @@ test.ping. This is configured in the main cloud config file:
 
 
 This is currently considered to be experimental functionality, and may not work
-well with all providers. If you experience problems with Salt Cloud hanging
+well with all cloud hosts. If you experience problems with Salt Cloud hanging
 after Salt is deployed, consider using Startup States instead:
 
 http://docs.saltstack.com/ref/states/startup.html
@@ -114,7 +114,7 @@ Or even on the VM's profile settings:
 .. code-block:: yaml
 
     ubuntu_aws:
-      provider: ec2
+      provider: my-ec2-config
       image: ami-7e2da54e
       size: t1.micro
       deploy: False
@@ -174,7 +174,7 @@ to pass arguments to the deploy script:
 .. code-block:: yaml
 
     aws-amazon:
-      provider: ec2
+      provider: my-ec2-config
       image: ami-1624987f
       size: t1.micro
       ssh_username: ec2-user

--- a/doc/topics/cloud/digitalocean.rst
+++ b/doc/topics/cloud/digitalocean.rst
@@ -2,7 +2,7 @@
 Getting Started With DigitalOcean
 =================================
 
-DigitalOcean is a public cloud provider that specializes in Linux instances.
+DigitalOcean is a public cloud host that specializes in Linux instances.
 
 
 Configuration
@@ -25,6 +25,14 @@ under the "SSH Keys" section.
       ssh_key_names: my-key-name,my-key-name-2
       location: New York 1
 
+.. note::
+    .. versionchanged:: 2015.8.0
+
+    The ``provider`` parameter in cloud provider definitions was renamed to ``driver``. This
+    change was made to avoid confusion with the ``provider`` parameter that is used in cloud profile
+    definitions. Cloud provider definitions now use ``driver`` to refer to the Salt cloud module that
+    provides the underlying functionality to connect to a cloud host, while cloud profiles continue
+    to use ``provider`` to refer to provider configurations that you define.
 
 Profiles
 ========

--- a/doc/topics/cloud/features.rst
+++ b/doc/topics/cloud/features.rst
@@ -4,23 +4,23 @@
 Feature Matrix
 ==============
 
-A number of features are available in most cloud providers, but not all are
+A number of features are available in most cloud hosts, but not all are
 available everywhere. This may be because the feature isn't supported by the
-cloud provider itself, or it may only be that the feature has not yet been
+cloud host itself, or it may only be that the feature has not yet been
 added to Salt Cloud. In a handful of cases, it is because the feature does not
 make sense for a particular cloud provider (Saltify, for instance).
 
-This matrix shows which features are available in which cloud providers, as far
+This matrix shows which features are available in which cloud hosts, as far
 as Salt Cloud is concerned. This is not a comprehensive list of all features
-available in all cloud providers, and should not be used to make business
-decisions concerning choosing a cloud provider. In most cases, adding support
+available in all cloud hosts, and should not be used to make business
+decisions concerning choosing a cloud host. In most cases, adding support
 for a feature to Salt Cloud requires only a little effort.
 
 Legacy Drivers
 ==============
 Both AWS and Rackspace are listed as "Legacy". This is because those drivers
 have been replaced by other drivers, which are generally the preferred method
-for working with those providers.
+for working with those hosts.
 
 The EC2 driver should be used instead of the AWS driver, when possible. The
 OpenStack driver should be used instead of the Rackspace driver, unless the user
@@ -28,13 +28,13 @@ is dealing with instances in "the old cloud" in Rackspace.
 
 Note for Developers
 ===================
-When adding new features to a particular cloud provider, please make sure to
+When adding new features to a particular cloud host, please make sure to
 add the feature to this table. Additionally, if you notice a feature that is not
 properly listed here, pull requests to fix them is appreciated.
 
 Standard Features
 =================
-These are features that are available for almost every provider.
+These are features that are available for almost every cloud host.
 
 .. container:: scrollable
 

--- a/doc/topics/cloud/gce.rst
+++ b/doc/topics/cloud/gce.rst
@@ -113,6 +113,14 @@ Set up the cloud config at ``/etc/salt/cloud``:
     The value provided for ``project`` must not contain underscores or spaces and
     is labeled as "Project ID" on the Google Developers Console.
 
+.. note::
+    .. versionchanged:: 2015.8.0
+
+    The ``provider`` parameter in cloud provider definitions was renamed to ``driver``. This
+    change was made to avoid confusion with the ``provider`` parameter that is used in cloud profile
+    definitions. Cloud provider definitions now use ``driver`` to refer to the Salt cloud module that
+    provides the underlying functionality to connect to a cloud host, while cloud profiles continue
+    to use ``provider`` to refer to provider configurations that you define.
 
 Cloud Profiles
 ==============

--- a/doc/topics/cloud/gogrid.rst
+++ b/doc/topics/cloud/gogrid.rst
@@ -2,7 +2,7 @@
 Getting Started With GoGrid
 ===========================
 
-GoGrid is a public cloud provider supporting Linux and Windows.
+GoGrid is a public cloud host that supports Linux and Windows.
 
 
 Configuration
@@ -32,6 +32,14 @@ in the configuration file to enable interfacing with GoGrid:
     with the GoGrid driver. Map files will work with GoGrid, but the ``-P``
     argument should not be used on maps referencing GoGrid instances.
 
+.. note::
+    .. versionchanged:: 2015.8.0
+
+    The ``provider`` parameter in cloud provider definitions was renamed to ``driver``. This
+    change was made to avoid confusion with the ``provider`` parameter that is used in cloud profile
+    definitions. Cloud provider definitions now use ``driver`` to refer to the Salt cloud module that
+    provides the underlying functionality to connect to a cloud host, while cloud profiles continue
+    to use ``provider`` to refer to provider configurations that you define.
 
 Profiles
 ========

--- a/doc/topics/cloud/hpcloud.rst
+++ b/doc/topics/cloud/hpcloud.rst
@@ -50,6 +50,14 @@ provider configuration file as in the example shown below:
 
 The subsequent example that follows is using the openstack driver.
 
+.. note::
+    .. versionchanged:: 2015.8.0
+
+    The ``provider`` parameter in cloud provider definitions was renamed to ``driver``. This
+    change was made to avoid confusion with the ``provider`` parameter that is used in cloud profile
+    definitions. Cloud provider definitions now use ``driver`` to refer to the Salt cloud module that
+    provides the underlying functionality to connect to a cloud host, while cloud profiles continue
+    to use ``provider`` to refer to provider configurations that you define.
 
 Compute Region
 ==============

--- a/doc/topics/cloud/index.html
+++ b/doc/topics/cloud/index.html
@@ -1,7 +1,7 @@
 
 <row class="intro-row">
     <div class="col-sm-4">
-        <div class="intro-text">Provision systems on cloud providers / hypervisors and immediately bring them under management.</div>
+        <div class="intro-text">Provision systems on cloud hosts / hypervisors and immediately bring them under management.</div>
     </div>
 
     <div class="col-sm-8">

--- a/doc/topics/cloud/index.rst
+++ b/doc/topics/cloud/index.rst
@@ -15,9 +15,9 @@ Salt Cloud is built-in to Salt and is configured on and executed from your Salt 
 Define a Provider
 -----------------
 
-The first step is to add the credentials for your cloud provider. Credentials
-and provider settings are stored in provider configuration files.
-Provider configurations contain the details needed to connect to a cloud provider such as EC2, GCE, Rackspace, etc.,
+The first step is to add the credentials for your cloud host. Credentials
+and other settings provided by the cloud host are stored in provider configuration files.
+Provider configurations contain the details needed to connect to a cloud host such as EC2, GCE, Rackspace, etc.,
 and any global options that you want set on your cloud minions (such as the location of your Salt Master).
 
 On your Salt Master, browse to ``/etc/salt/cloud.providers.d/`` and create a file called ``<provider>.provider.conf``,
@@ -25,7 +25,7 @@ replacing ``<provider>`` with ``ec2``, ``softlayer``, and so on. The name helps 
 important as long as the file ends in ``.conf``.
 
 Next, browse to the :ref:`Provider specifics <cloud-provider-specifics>` and add any required settings for your
-provider to this file. Here is an example for Amazon EC2:
+cloud host to this file. Here is an example for Amazon EC2:
 
 .. code-block:: yaml
 
@@ -45,7 +45,7 @@ provider to this file. Here is an example for Amazon EC2:
       minion:
         master: saltmaster.example.com
 
-The required configuration varies between providers so make sure you read the provider specifics.
+The required configuration varies between cloud hosts so make sure you read the provider specifics.
 
 List Cloud Provider Options
 ---------------------------

--- a/doc/topics/cloud/joyent.rst
+++ b/doc/topics/cloud/joyent.rst
@@ -2,7 +2,7 @@
 Getting Started With Joyent
 ===========================
 
-Joyent is a public cloud provider supporting SmartOS, Linux, FreeBSD, and
+Joyent is a public cloud host that supports SmartOS, Linux, FreeBSD, and
 Windows.
 
 
@@ -30,6 +30,14 @@ send the provisioning commands up to the freshly created virtual machine.
       private_key: /root/mykey.pem
       keyname: mykey
 
+.. note::
+    .. versionchanged:: 2015.8.0
+
+    The ``provider`` parameter in cloud provider definitions was renamed to ``driver``. This
+    change was made to avoid confusion with the ``provider`` parameter that is used in cloud profile
+    definitions. Cloud provider definitions now use ``driver`` to refer to the Salt cloud module that
+    provides the underlying functionality to connect to a cloud host, while cloud profiles continue
+    to use ``provider`` to refer to provider configurations that you define.
 
 Profiles
 ========

--- a/doc/topics/cloud/linode.rst
+++ b/doc/topics/cloud/linode.rst
@@ -2,7 +2,7 @@
 Getting Started With Linode
 ===========================
 
-Linode is a public cloud provider with a focus on Linux instances.
+Linode is a public cloud host with a focus on Linux instances.
 
 Starting with the 2015.8.0 release of Salt, the Linode driver uses Linode's
 native REST API. There are no external dependencies required to use the
@@ -27,6 +27,15 @@ instances also needs to be set:
 
 The password needs to be 8 characters and contain lowercase, uppercase, and
 numbers.
+
+.. note::
+    .. versionchanged:: 2015.8.0
+
+    The ``provider`` parameter in cloud provider definitions was renamed to ``driver``. This
+    change was made to avoid confusion with the ``provider`` parameter that is used in cloud profile
+    definitions. Cloud provider definitions now use ``driver`` to refer to the Salt cloud module that
+    provides the underlying functionality to connect to a cloud host, while cloud profiles continue
+    to use ``provider`` to refer to provider configurations that you define.
 
 Profiles
 ========

--- a/doc/topics/cloud/lxc.rst
+++ b/doc/topics/cloud/lxc.rst
@@ -23,10 +23,6 @@ Limitations
 - Listing images must be targeted to a particular LXC provider (nothing will be
   outputted with ``all``)
 
-.. warning::
-
-   On pre **2015.5.2**, you need to specify explitly the network bridge
-
 Operation
 ---------
 
@@ -61,6 +57,15 @@ Here is a simple provider configuration:
     devhost10-lxc:
       target: devhost10
       driver: lxc
+
+.. note::
+    .. versionchanged:: 2015.8.0
+
+    The ``provider`` parameter in cloud provider definitions was renamed to ``driver``. This
+    change was made to avoid confusion with the ``provider`` parameter that is used in cloud profile
+    definitions. Cloud provider definitions now use ``driver`` to refer to the Salt cloud module that
+    provides the underlying functionality to connect to a cloud host, while cloud profiles continue
+    to use ``provider`` to refer to provider configurations that you define.
 
 Profile configuration
 ---------------------

--- a/doc/topics/cloud/misc.rst
+++ b/doc/topics/cloud/misc.rst
@@ -14,7 +14,7 @@ to pass arguments to the deploy script:
 .. code-block:: yaml
 
     ec2-amazon:
-        provider: ec2
+        provider: my-ec2-config
         image: ami-1624987f
         size: t1.micro
         ssh_username: ec2-user
@@ -95,7 +95,7 @@ Delete SSH Keys
 ===============
 When Salt Cloud deploys an instance, the SSH pub key for the instance is added
 to the known_hosts file for the user that ran the salt-cloud command. When an
-instance is deployed, a cloud provider generally recycles the IP address for
+instance is deployed, a cloud host generally recycles the IP address for
 the instance.  When Salt Cloud attempts to deploy an instance using a recycled
 IP address that has previously been accessed from the same machine, the old key
 in the known_hosts file will cause a conflict.
@@ -161,7 +161,7 @@ wait_for_ip_timeout
 ~~~~~~~~~~~~~~~~~~~
 
 The amount of time Salt Cloud should wait for a VM to start and get an IP back
-from the cloud provider. 
+from the cloud host.
 Default: varies by cloud provider ( between 5 and 25 minutes)
 
 
@@ -232,7 +232,7 @@ diff_cache_events
 ~~~~~~~~~~~~~~~~~
 
 When the cloud cachedir is being managed, if differences are encountered
-between the data that is returned live from the cloud provider and the data in
+between the data that is returned live from the cloud host and the data in
 the cache, fire events which describe the changes. This setting can be True or
 False.
 
@@ -251,20 +251,20 @@ The following are events that can be fired based on this data.
 
 salt/cloud/minionid/cache_node_new
 **********************************
-A new node was found on the cloud provider which was not listed in the cloud
+A new node was found on the cloud host which was not listed in the cloud
 cachedir. A dict describing the new node will be contained in the event.
 
 
 salt/cloud/minionid/cache_node_missing
 **************************************
 A node that was previously listed in the cloud cachedir is no longer available
-on the cloud provider.
+on the cloud host.
 
 
 salt/cloud/minionid/cache_node_diff
 ***********************************
 One or more pieces of data in the cloud cachedir has changed on the cloud
-provider. A dict containing both the old and the new data will be contained in
+host. A dict containing both the old and the new data will be contained in
 the event.
 
 

--- a/doc/topics/cloud/openstack.rst
+++ b/doc/topics/cloud/openstack.rst
@@ -46,6 +46,14 @@ Configuration
       # skip SSL certificate validation (default false)
       insecure: false
 
+.. note::
+    .. versionchanged:: 2015.8.0
+
+    The ``provider`` parameter in cloud provider definitions was renamed to ``driver``. This
+    change was made to avoid confusion with the ``provider`` parameter that is used in cloud profile
+    definitions. Cloud provider definitions now use ``driver`` to refer to the Salt cloud module that
+    provides the underlying functionality to connect to a cloud host, while cloud profiles continue
+    to use ``provider`` to refer to provider configurations that you define.
 
 Using nova client to get information from OpenStack
 ===================================================

--- a/doc/topics/cloud/parallels.rst
+++ b/doc/topics/cloud/parallels.rst
@@ -4,7 +4,7 @@ Getting Started With Parallels
 
 Parallels Cloud Server is a product by Parallels that delivers a cloud hosting
 solution. The PARALLELS module for Salt Cloud enables you to manage instances
-hosted by a provider using PCS. Further information can be found at:
+hosted using PCS. Further information can be found at:
 
 http://www.parallels.com/products/pcs/
 
@@ -22,7 +22,7 @@ http://www.parallels.com/products/pcs/
     PARALLELS.user: myuser
     PARALLELS.password: badpass
 
-    # Set the access URL for your PARALLELS provider
+    # Set the access URL for your PARALLELS host
     #
     PARALLELS.url: https://api.cloud.xmission.com:4465/paci/v1.0/
 
@@ -49,12 +49,19 @@ http://www.parallels.com/products/pcs/
       url: https://api.cloud.xmission.com:4465/paci/v1.0/
       driver: parallels
 
+.. note::
+    .. versionchanged:: 2015.8.0
 
+    The ``provider`` parameter in cloud provider definitions was renamed to ``driver``. This
+    change was made to avoid confusion with the ``provider`` parameter that is used in cloud profile
+    definitions. Cloud provider definitions now use ``driver`` to refer to the Salt cloud module that
+    provides the underlying functionality to connect to a cloud host, while cloud profiles continue
+    to use ``provider`` to refer to provider configurations that you define.
 
 Access Credentials
 ==================
 The ``user``, ``password``, and ``url`` will be provided to you by your cloud
-provider. These are all required in order for the PARALLELS driver to work.
+host. These are all required in order for the PARALLELS driver to work.
 
 
 Cloud Profiles
@@ -62,26 +69,11 @@ Cloud Profiles
 Set up an initial profile at ``/etc/salt/cloud.profiles`` or
 ``/etc/salt/cloud.profiles.d/parallels.conf``:
 
-
-* Using the old cloud configuration format:
-
-.. code-block:: yaml
-
-    parallels-ubuntu:
-        provider: parallels
-        image: ubuntu-12.04-x86_64
-
-
-* Using the new cloud configuration format and the cloud configuration example
-  from above:
-
 .. code-block:: yaml
 
     parallels-ubuntu:
         provider: my-parallels-config
         image: ubuntu-12.04-x86_64
-
-
 
 The profile can be realized now with a salt command:
 
@@ -89,7 +81,7 @@ The profile can be realized now with a salt command:
 
     # salt-cloud -p parallels-ubuntu myubuntu
 
-This will create an instance named ``myubuntu`` on the cloud provider. The
+This will create an instance named ``myubuntu`` on the cloud host. The
 minion that is installed on this instance will have an ``id`` of ``myubuntu``.
 If the command was executed on the salt-master, its Salt key will automatically
 be signed on the master.
@@ -131,8 +123,8 @@ Optional Settings
 =================
 Unlike other cloud providers in Salt Cloud, Parallels does not utilize a
 ``size`` setting. This is because Parallels allows the end-user to specify a
-more detailed configuration for their instances, than is allowed by many other
-cloud providers. The following options are available to be used in a profile,
+more detailed configuration for their instances than is allowed by many other
+cloud hosts. The following options are available to be used in a profile,
 with their default settings listed.
 
 .. code-block:: yaml

--- a/doc/topics/cloud/profiles.rst
+++ b/doc/topics/cloud/profiles.rst
@@ -8,7 +8,7 @@ a yaml configuration. The syntax for declaring profiles is simple:
 .. code-block:: yaml
 
     fedora_rackspace:
-        provider: rackspace
+        provider: my-rackspace-config
         image: Fedora 17
         size: 256 server
         script: bootstrap-salt
@@ -18,12 +18,12 @@ and does not normally need to be specified. Further examples in this document
 will not show the ``script`` option.
 
 A few key pieces of information need to be declared and can change based on the
-public cloud provider. A number of additional parameters can also be inserted:
+cloud provider. A number of additional parameters can also be inserted:
 
 .. code-block:: yaml
 
     centos_rackspace:
-      driver: rackspace
+      provider: my-rackspace-config
       image: CentOS 6.2
       size: 1024 server
       minion:
@@ -66,44 +66,44 @@ Larger Example
 .. code-block:: yaml
 
     rhel_ec2:
-      provider: ec2
+      provider: my-ec2-config
       image: ami-e565ba8c
       size: t1.micro
       minion:
         cheese: edam
 
     ubuntu_ec2:
-      provider: ec2
+      provider: my-ec2-config
       image: ami-7e2da54e
       size: t1.micro
       minion:
         cheese: edam
 
     ubuntu_rackspace:
-      provider: rackspace
+      provider: my-rackspace-config
       image: Ubuntu 12.04 LTS
       size: 256 server
       minion:
         cheese: edam
 
     fedora_rackspace:
-      provider: rackspace
+      provider: my-rackspace-config
       image: Fedora 17
       size: 256 server
       minion:
         cheese: edam
 
     cent_linode:
-      provider: linode
+      provider: my-linode-config
       image: CentOS 6.2 64bit
       size: Linode 512
 
     cent_gogrid:
-      provider: gogrid
+      provider: my-gogrid-config
       image: 12834
       size: 512MB
 
     cent_joyent:
-      provider: joyent
+      provider: my-joyent-config
       image: centos-6
       size: Small 1GB

--- a/doc/topics/cloud/proxmox.rst
+++ b/doc/topics/cloud/proxmox.rst
@@ -34,17 +34,24 @@ done when the VM is an OpenVZ container rather than a KVM virtual machine.
       user: myuser@pve
       password: badpass
 
-      # Set the access URL for your PROXMOX provider
+      # Set the access URL for your PROXMOX host
       #
       url: your.proxmox.host
       driver: proxmox
 
+.. note::
+    .. versionchanged:: 2015.8.0
 
+    The ``provider`` parameter in cloud provider definitions was renamed to ``driver``. This
+    change was made to avoid confusion with the ``provider`` parameter that is used in cloud profile
+    definitions. Cloud provider definitions now use ``driver`` to refer to the Salt cloud module that
+    provides the underlying functionality to connect to a cloud host, while cloud profiles continue
+    to use ``provider`` to refer to provider configurations that you define.
 
 Access Credentials
 ==================
 The ``user``, ``password``, and ``url`` will be provided to you by your cloud
-provider. These are all required in order for the PROXMOX driver to work.
+host. These are all required in order for the PROXMOX driver to work.
 
 
 Cloud Profiles
@@ -57,7 +64,7 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
 .. code-block:: yaml
 
     proxmox-ubuntu:
-        provider: proxmox
+        provider: my-proxmox-config
         image: local:vztmpl/ubuntu-12.04-standard_12.04-1_amd64.tar.gz
         technology: openvz
         host: myvmhost
@@ -71,7 +78,7 @@ The profile can be realized now with a salt command:
 
     # salt-cloud -p proxmox-ubuntu myubuntu
 
-This will create an instance named ``myubuntu`` on the cloud provider. The
+This will create an instance named ``myubuntu`` on the cloud host. The
 minion that is installed on this instance will have a ``hostname`` of ``myubuntu``.
 If the command was executed on the salt-master, its Salt key will automatically
 be signed on the master.

--- a/doc/topics/cloud/rackspace.rst
+++ b/doc/topics/cloud/rackspace.rst
@@ -5,7 +5,7 @@ Getting Started With Rackspace
 Rackspace is a major public cloud platform which may be configured using either
 the `rackspace` or the `openstack` driver, depending on your needs.
 
-Please note that the `rackspace` driver is only intended for 1st gen instances,
+Please note that the `rackspace` driver is intended only for 1st gen instances,
 aka, "the old cloud" at Rackspace. It is required for 1st gen instances, but
 will *not* work with OpenStack-based instances. Unless you explicitly have a
 reason to use it, it is highly recommended that you use the `openstack` driver
@@ -66,6 +66,14 @@ To use the `rackspace` driver, set up the cloud configuration at
 The settings that follow are for using Rackspace with the `openstack` driver,
 and will not work with the `rackspace` driver.
 
+.. note::
+    .. versionchanged:: 2015.8.0
+
+    The ``provider`` parameter in cloud provider definitions was renamed to ``driver``. This
+    change was made to avoid confusion with the ``provider`` parameter that is used in cloud profile
+    definitions. Cloud provider definitions now use ``driver`` to refer to the Salt cloud module that
+    provides the underlying functionality to connect to a cloud host, while cloud profiles continue
+    to use ``provider`` to refer to provider configurations that you define.
 
 Compute Region
 ==============
@@ -172,10 +180,10 @@ configuration please add:
       force_first_gen: True
 
 Private Subnets
---------------------------------
-By default salt-cloud will not add Rackspace private networks to new servers.   To enable 
+---------------
+By default salt-cloud will not add Rackspace private networks to new servers. To enable
 a private network to a server instantiated by salt cloud, add the following section 
-to the provider file (typically  ``/etc/salt/cloud.providers.d/rackspace.conf``)
+to the provider file (typically ``/etc/salt/cloud.providers.d/rackspace.conf``)
 
 .. code-block:: yaml
 

--- a/doc/topics/cloud/reactor.rst
+++ b/doc/topics/cloud/reactor.rst
@@ -34,8 +34,7 @@ using the ``ec2-config`` provider, the payload for this tag would look like:
 
     {'name': 'web1',
      'profile': 'ec2-centos',
-     'provider': 'ec2-config'}
-
+     'provider': 'ec2-config:ec2'}
 
 Available Events
 ================
@@ -206,11 +205,11 @@ options that can be specified is ``startup_states``, which is commonly set to
 ``highstate``. This will tell the minion to immediately apply a highstate, as
 soon as it is able to do so.
 
-This can present a problem with some system images on some cloud providers. For
+This can present a problem with some system images on some cloud hosts. For
 instance, Salt Cloud can be configured to log in as either the ``root`` user, or
-a user with ``sudo`` access. While some providers commonly use images that
+a user with ``sudo`` access. While some hosts commonly use images that
 lock out remote ``root`` access and require a user with ``sudo`` privileges to
-log in (notably EC2, with their ``ec2-user`` login), most cloud providers fall
+log in (notably EC2, with their ``ec2-user`` login), most cloud hosts fall
 back to ``root`` as the default login on all images, including for operating
 systems (such as Ubuntu) which normally disallow remote ``root`` login.
 

--- a/doc/topics/cloud/salt.rst
+++ b/doc/topics/cloud/salt.rst
@@ -238,7 +238,7 @@ presence of the instance will be managed statefully.
 
     my-instance-name:
       cloud.present:
-        - driver: my-ec2-config
+        - provider: my-ec2-config
         - image: ami-1624987f
         - size: 't1.micro'
         - ssh_username: ec2-user

--- a/doc/topics/cloud/scaleway.rst
+++ b/doc/topics/cloud/scaleway.rst
@@ -2,7 +2,7 @@
 Getting Started With Scaleway
 =============================
 
-Scaleway is the first IaaS provider worldwide to offer an ARM based cloud. It’s the ideal platform for horizontal scaling with BareMetal SSD servers. The solution provides on demand resources: it comes with on-demand SSD storage, movable IPs , images, security group and an Object Storage solution. https://scaleway.com
+Scaleway is the first IaaS host worldwide to offer an ARM based cloud. It’s the ideal platform for horizontal scaling with BareMetal SSD servers. The solution provides on demand resources: it comes with on-demand SSD storage, movable IPs , images, security group and an Object Storage solution. https://scaleway.com
 
 Configuration
 =============
@@ -20,6 +20,15 @@ If you do not have API token you can create one by clicking the "Create New Toke
       access_key: 15cf404d-4560-41b1-9a0c-21c3d5c4ff1f
       token: a7347ec8-5de1-4024-a5e3-24b77d1ba91d
       driver: scaleway
+
+.. note::
+    .. versionchanged:: 2015.8.0
+
+    The ``provider`` parameter in cloud provider definitions was renamed to ``driver``. This
+    change was made to avoid confusion with the ``provider`` parameter that is used in cloud profile
+    definitions. Cloud provider definitions now use ``driver`` to refer to the Salt cloud module that
+    provides the underlying functionality to connect to a cloud host, while cloud profiles continue
+    to use ``provider`` to refer to provider configurations that you define.
 
 Profiles
 ========

--- a/doc/topics/cloud/softlayer.rst
+++ b/doc/topics/cloud/softlayer.rst
@@ -2,7 +2,7 @@
 Getting Started With SoftLayer
 ==============================
 
-SoftLayer is a public cloud provider, and baremetal hardware hosting provider.
+SoftLayer is a public cloud host, and baremetal hardware hosting service.
 
 Dependencies
 ============
@@ -50,6 +50,14 @@ Set up the cloud config at ``/etc/salt/cloud.providers``:
 
       driver: softlayer_hw
 
+.. note::
+    .. versionchanged:: 2015.8.0
+
+    The ``provider`` parameter in cloud provider definitions was renamed to ``driver``. This
+    change was made to avoid confusion with the ``provider`` parameter that is used in cloud profile
+    definitions. Cloud provider definitions now use ``driver`` to refer to the Salt cloud module that
+    provides the underlying functionality to connect to a cloud host, while cloud profiles continue
+    to use ``provider`` to refer to provider configurations that you define.
 
 Access Credentials
 ==================
@@ -384,7 +392,7 @@ The `globalIdentifier` returned in this list is necessary for the
 
 Optional Products for SoftLayer HW
 ==================================
-The softlayer_hw provider supports the ability to add optional products, which
+The softlayer_hw driver supports the ability to add optional products, which
 are supported by SoftLayer's API. These products each have an ID associated with
 them, that can be passed into Salt Cloud with the `optional_products` option:
 

--- a/doc/topics/cloud/troubleshooting.rst
+++ b/doc/topics/cloud/troubleshooting.rst
@@ -83,7 +83,7 @@ By default, Salt Cloud will create a directory on the target instance called
 ``/tmp/.saltcloud/``. This directory should be owned by the user that is to
 execute the deploy script, and should have permissions of ``0700``.
 
-Most cloud providers are configured to use ``root`` as the default initial user
+Most cloud hosts are configured to use ``root`` as the default initial user
 for deployment, and as such, this directory and all files in it should be owned
 by the ``root`` user.
 
@@ -101,14 +101,14 @@ The ``/tmp/.saltcloud/`` directory should the following files:
 
 Unprivileged Primary Users
 --------------------------
-Some providers, most notably EC2, are configured with a different primary user.
+Some cloud hosts, most notably EC2, are configured with a different primary user.
 Some common examples are ``ec2-user``, ``ubuntu``, ``fedora``, and ``bitnami``.
 In these cases, the ``/tmp/.saltcloud/`` directory and all files in it should
 be owned by this user.
 
-Some providers, such as EC2, are configured to not require these users to
+Some cloud hosts, such as EC2, are configured to not require these users to
 provide a password when using the ``sudo`` command. Because it is more secure
-to require ``sudo`` users to provide a password, other providers are configured
+to require ``sudo`` users to provide a password, other hosts are configured
 that way.
 
 If this instance is required to provide a password, it needs to be configured
@@ -123,7 +123,7 @@ configuration or the profile configuration:
 ``/tmp/`` is Mounted as ``noexec``
 ----------------------------------
 It is more secure to mount the ``/tmp/`` directory with a ``noexec`` option.
-This is uncommon on most cloud providers, but very common in private
+This is uncommon on most cloud hosts, but very common in private
 environments. To see if the ``/tmp/`` directory is mounted this way, run the
 following command:
 

--- a/doc/topics/cloud/vexxhost.rst
+++ b/doc/topics/cloud/vexxhost.rst
@@ -2,13 +2,13 @@
 Getting Started with VEXXHOST
 =============================
 
-`VEXXHOST <http://vexxhost.com>`_ is an cloud computing provider which provides
+`VEXXHOST <http://vexxhost.com>`_ is a cloud computing host which provides
 `Canadian cloud computing <http://vexxhost.com/cloud-computing>`_ services
-which are based in Monteral and uses the libcloud OpenStack driver.  VEXXHOST
+which are based in Monteral and use the libcloud OpenStack driver.  VEXXHOST
 currently runs the Havana release of OpenStack.  When provisioning new
 instances, they automatically get a public IP and private IP address.
 Therefore, you do not need to assign a floating IP to access your instance
-once it's booted.
+after it's booted.
 
 
 Cloud Provider Configuration
@@ -24,7 +24,7 @@ driver.
 
 .. code-block:: yaml
 
-    vexxhost:
+    my-vexxhost-config:
       # Set the location of the salt-master
       #
       minion:
@@ -52,6 +52,14 @@ driver.
 
       driver: openstack
 
+.. note::
+    .. versionchanged:: 2015.8.0
+
+    The ``provider`` parameter in cloud provider definitions was renamed to ``driver``. This
+    change was made to avoid confusion with the ``provider`` parameter that is used in cloud profile
+    definitions. Cloud provider definitions now use ``driver`` to refer to the Salt cloud module that
+    provides the underlying functionality to connect to a cloud host, while cloud profiles continue
+    to use ``provider`` to refer to provider configurations that you define.
 
 Authentication
 ==============
@@ -80,7 +88,7 @@ profile will build an Ubuntu 12.04 LTS `nb.2G` instance.
 .. code-block:: yaml
 
     vh_ubuntu1204_2G:
-      provider: vexxhost
+      provider: my-vexxhost-config
       image: 4051139f-750d-4d72-8ef0-074f2ccc7e5a
       size: nb.2G
 

--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -58,6 +58,15 @@ set up in the cloud configuration at
     server is not using the defaults. Default is ``protocol: https`` and
     ``port: 443``.
 
+.. note::
+    .. versionchanged:: 2015.8.0
+
+    The ``provider`` parameter in cloud provider definitions was renamed to ``driver``. This
+    change was made to avoid confusion with the ``provider`` parameter that is used in cloud profile
+    definitions. Cloud provider definitions now use ``driver`` to refer to the Salt cloud module that
+    provides the underlying functionality to connect to a cloud host, while cloud profiles continue
+    to use ``provider`` to refer to provider configurations that you define.
+
 .. _vmware-cloud-profile:
 
 Profiles

--- a/doc/topics/cloud/vsphere.rst
+++ b/doc/topics/cloud/vsphere.rst
@@ -46,6 +46,14 @@ Set up the cloud config at ``/etc/salt/cloud.providers`` or in the
       # Set the URL of your vSphere server
       url: 'vsphere.example.com'
 
+.. note::
+    .. versionchanged:: 2015.8.0
+
+    The ``provider`` parameter in cloud provider definitions was renamed to ``driver``. This
+    change was made to avoid confusion with the ``provider`` parameter that is used in cloud profile
+    definitions. Cloud provider definitions now use ``driver`` to refer to the Salt cloud module that
+    provides the underlying functionality to connect to a cloud host, while cloud profiles continue
+    to use ``provider`` to refer to provider configurations that you define.
 
 Profiles
 ========

--- a/doc/topics/development/labels.rst
+++ b/doc/topics/development/labels.rst
@@ -261,7 +261,7 @@ the tests pass and the pull request can be merged.
 ``Tests Passed``
     The pull request has passed all tests even though some test results are negative.  Sometimes the automated testing
     infrastructure will encounter internal errors unrelated to the code change in the pull request that cause test runs
-    to fail.  These errors can be caused by cloud provider and network issues and also Jenkins issues like erroneously
+    to fail.  These errors can be caused by cloud host and network issues and also Jenkins issues like erroneously
     accumulating workspace artifacts, resource exhaustion, and bugs that arise from long running Jenkins processes.
 
 Other

--- a/doc/topics/development/tests/index.rst
+++ b/doc/topics/development/tests/index.rst
@@ -108,7 +108,7 @@ the default cloud provider configuration file for DigitalOcean looks like this:
 .. code-block:: yaml
 
     digitalocean-config:
-      provider: digital_ocean
+      driver: digital_ocean
       client_key: ''
       api_key: ''
       location: New York 1
@@ -119,7 +119,7 @@ must be provided:
 .. code-block:: yaml
 
     digitalocean-config:
-      provider: digital_ocean
+      driver: digital_ocean
       client_key: wFGEwgregeqw3435gDger
       api_key: GDE43t43REGTrkilg43934t34qT43t4dgegerGEgg
       location: New York 1

--- a/doc/topics/development/tests/integration.rst
+++ b/doc/topics/development/tests/integration.rst
@@ -318,7 +318,7 @@ Ocean, located at: ``tests/integration/files/conf/cloud.providers.d/digital_ocea
 .. code-block:: yaml
 
     digitalocean-config:
-      provider: digital_ocean
+      driver: digital_ocean
       client_key: ''
       api_key: ''
       location: New York 1


### PR DESCRIPTION
Refs #24797

@rallytime Most of these changes try to reduce ambiguity between the usage of provider and driver. 
- References to a cloud provider in general were changed to cloud host (for example, "GoGrid is a public cloud provider..." was changed to "GoGrid is a public cloud host..."). I've tried to use "provider" only when referring to the actual provider config or code.
- I changed the examples if the "provider" value in a profile matched the value for "driver" in the provider config. For example, "provider: ec2" was changed to "provider: my-ec2-config".
- I changed a few references from "provider" to "driver" in some examples.
- I added a version added note describing the parameter rename to each of the provider config sections.
