### PR TITLE
Let docker-py auto detect version if not defined by user

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -657,6 +657,11 @@ def _get_client(timeout=None):
             # Check if the DOCKER_HOST environment variable has been set
             client_kwargs['base_url'] = os.environ.get('DOCKER_HOST')
 
+        if 'version' not in client_kwargs:
+            # Let docker-py auto detect docker version incase
+            # it's not defined by user.
+            client_kwargs['version'] = 'auto'
+
         __context__['docker.client'] = docker.Client(**client_kwargs)
 
     # Set a new timeout if one was passed


### PR DESCRIPTION
Docker-py will auto detect docker version incase version 'auto' is used.
Reference: docker/docker-py#673
