### PR TITLE
Allow virtual grains to be generated even if virt-what is not available

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -473,30 +473,29 @@ def _virtual(osdata):
     skip_cmds = ('AIX',)
 
     # list of commands to be executed to determine the 'virtual' grain
-    _cmds = set()
-
+    _cmds = []
     # test first for virt-what, which covers most of the desired functionality
     # on most platforms
     if not salt.utils.is_windows() and osdata['kernel'] not in skip_cmds:
         if salt.utils.which('virt-what'):
-            _cmds = (['virt-what'])
+            _cmds = ['virt-what']
         else:
             log.debug(
                 'Please install \'virt-what\' to improve results of the '
                 '\'virtual\' grain.'
             )
     # Check if enable_lspci is True or False
-    elif __opts__.get('enable_lspci', True) is False:
-        _cmds = (['dmidecode', 'dmesg'])
+    if __opts__.get('enable_lspci', True) is False:
+        _cmds += ['dmidecode', 'dmesg']
     elif osdata['kernel'] in skip_cmds:
         _cmds = ()
     else:
         # /proc/bus/pci does not exists, lspci will fail
         if not os.path.exists('/proc/bus/pci'):
-            _cmds = ('systemd-detect-virt', 'virt-what', 'dmidecode', 'dmesg')
+            _cmds = ['systemd-detect-virt', 'virt-what', 'dmidecode', 'dmesg']
         else:
-            _cmds = ('systemd-detect-virt', 'virt-what', 'dmidecode', 'lspci',
-                     'dmesg')
+            _cmds = ['systemd-detect-virt', 'virt-what', 'dmidecode', 'lspci',
+                     'dmesg']
 
     failed_commands = set()
     for command in _cmds:


### PR DESCRIPTION
Also normalized _cmds to be a list. The set() functionality wasn't
actually being used, we were just overwriting it with a list. Sets are
also unordered, which is a problem for a list of commands we want to run
in order.

Oh, and I left the `_cmds = ()` on line 499 as a tuple because that way if we try to append to it it will error out.

Fixes #26121
