### PR TITLE
Make it possible to run salt-cloud as current user

### DIFF
--- a/salt/cloud/cli.py
+++ b/salt/cloud/cli.py
@@ -44,8 +44,11 @@ class SaltCloud(parsers.SaltCloudParser):
         # Parse shell arguments
         self.parse_args()
 
-        salt_master_user = self.config.get('user', salt.utils.get_user())
-        if salt_master_user is not None and not check_user(salt_master_user):
+        salt_master_user = self.config.get('user')
+        if salt_master_user is None:
+            salt_master_user = salt.utils.get_user()
+
+        if not check_user(salt_master_user):
             self.error(
                 'If salt-cloud is running on a master machine, salt-cloud '
                 'needs to run as the same user as the salt-master, {0!r}. If '


### PR DESCRIPTION
Currently, [`self.config.get('user', salt.utils.get_user())`](https://github.com/saltstack/salt/blob/fd70187176bca85b6afd73e8086b5cb56404b9bf/salt/cloud/cli.py#L47) never triggers `salt.utils.get_user()` because the master config is merged into the cloud config, and the master config contains the default value `'user': 'root'`.

Furthermore, if you specify `user: null` in your cloud config, you get this error:

```
  File "/home/andreas/dev/python/salt/salt/utils/verify.py", line 205, in verify_env
    pwnam = pwd.getpwnam(user)
TypeError: must be string, not None
```

So I changed the behavior so that if the user config is specified as null, salt-cloud defaults to the current user.

As an alternative, the user key could be deleted from the dictionary [in this part of the config code](https://github.com/saltstack/salt/blob/7e58ee88dc5288e5974d99668f0d0e4b9c70fc8d/salt/config.py#L1714-L1717).
