### PR TITLE
Avoid VBOX storage emulation bugs in FreeBSD disks grain

### DIFF
--- a/salt/grains/disks.py
+++ b/salt/grains/disks.py
@@ -11,6 +11,7 @@ import re
 
 # Import salt libs
 import salt.utils
+import salt.utils.decorators as decorators
 
 # Solve the Chicken and egg problem where grains need to run before any
 # of the modules are loaded and are generally available for any usage.
@@ -55,6 +56,7 @@ _identify_attribs = [_camconsts.__dict__[key] for key in
                      _camconsts.__dict__ if not key.startswith('__')]
 
 
+@decorators.memoize
 def _freebsd_vbox():
     # Don't tickle VirtualBox storage emulation bugs
     camcontrol = salt.utils.which('camcontrol')

--- a/salt/grains/disks.py
+++ b/salt/grains/disks.py
@@ -55,6 +55,15 @@ _identify_attribs = [_camconsts.__dict__[key] for key in
                      _camconsts.__dict__ if not key.startswith('__')]
 
 
+def _freebsd_vbox():
+    # Don't tickle VirtualBox storage emulation bugs
+    camcontrol = salt.utils.which('camcontrol')
+    devlist = __salt__['cmd.run']('{0} devlist'.format(camcontrol))
+    if 'VBOX' in devlist:
+        return True
+    return False
+
+
 def _freebsd_disks():
     ret = {'disks': {}, 'SSDs': []}
     sysctl = salt.utils.which('sysctl')
@@ -62,10 +71,16 @@ def _freebsd_disks():
     SSD_TOKEN = 'non-rotating'
 
     for device in devices.split(' '):
-        cam = _freebsd_camcontrol(device)
-        ret['disks'][device] = cam
-        if cam.get(_clean_keys(_camconsts.MEDIA_RPM)) == SSD_TOKEN:
-            ret['SSDs'].append(device)
+        if device.startswith('cd'):
+            log.debug('Disk grain skipping cd')
+        elif _freebsd_vbox():
+            log.debug('Disk grain skipping CAM identify/inquirty on VBOX')
+            ret['disks'][device] = {}
+        else:
+            cam = _freebsd_camcontrol(device)
+            ret['disks'][device] = cam
+            if cam.get(_clean_keys(_camconsts.MEDIA_RPM)) == SSD_TOKEN:
+                ret['SSDs'].append(device)
 
     return ret
 


### PR DESCRIPTION
Sending an ATA identify to an emulated AHCI device leads to an eventual but fairly quick lockup of a FreeBSD VirtualBox VM.

Also universally filter out cdroms as identify triggers log spam.
