### PR TITLE
Fix encoding issue

### DIFF
--- a/salt/output/json_out.py
+++ b/salt/output/json_out.py
@@ -54,7 +54,7 @@ def output(data):
     '''
     try:
         if 'output_indent' not in __opts__:
-            return json.dumps(data, default=repr, indent=4)
+            return json.dumps(data, default=repr, indent=4, encoding='latin1')
 
         indent = __opts__.get('output_indent')
         sort_keys = False


### PR DESCRIPTION
Occurs on: salt '*' pkg.list_pkgs --out=json --static -b 100%
Error Message: [ERROR   ] An un-handled exception was caught by salt's global exception handler:
UnicodeDecodeError: 'utf8' codec can't decode byte 0x82 in position 12: invalid start byte
Traceback (most recent call last):
