### PR TITLE
SmartOS grain fixes

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1668,24 +1668,25 @@ def _hw_data(osdata):
         return {}
 
     grains = {}
-    if salt.utils.which_bin(['dmidecode', 'smbios']) is not None:
-        if not salt.utils.is_smartos() or salt.utils.is_smartos_globalzone():
-            grains = {
-                'biosversion': __salt__['smbios.get']('bios-version'),
-                'productname': __salt__['smbios.get']('system-product-name'),
-                'manufacturer': __salt__['smbios.get']('system-manufacturer'),
-                'biosreleasedate': __salt__['smbios.get']('bios-release-date'),
-                'uuid': __salt__['smbios.get']('system-uuid')
-            }
-            grains = dict([(key, val) for key, val in grains.items() if val is not None])
-            uuid = __salt__['smbios.get']('system-uuid')
-            if uuid is not None:
-                grains['uuid'] = uuid.lower()
-            for serial in ('system-serial-number', 'chassis-serial-number', 'baseboard-serial-number'):
-                serial = __salt__['smbios.get'](serial)
-                if serial is not None:
-                    grains['serial'] = serial
-                    break
+    # On SmartOS (possibly SunOS also) smbios only works in the global zone
+    # smbios is also not compatible with linux's smbios (smbios -s = print summarized)
+    if salt.utils.which_bin(['dmidecode', 'smbios']) is not None and not salt.utils.is_smartos():
+        grains = {
+            'biosversion': __salt__['smbios.get']('bios-version'),
+            'productname': __salt__['smbios.get']('system-product-name'),
+            'manufacturer': __salt__['smbios.get']('system-manufacturer'),
+            'biosreleasedate': __salt__['smbios.get']('bios-release-date'),
+            'uuid': __salt__['smbios.get']('system-uuid')
+        }
+        grains = dict([(key, val) for key, val in grains.items() if val is not None])
+        uuid = __salt__['smbios.get']('system-uuid')
+        if uuid is not None:
+            grains['uuid'] = uuid.lower()
+        for serial in ('system-serial-number', 'chassis-serial-number', 'baseboard-serial-number'):
+            serial = __salt__['smbios.get'](serial)
+            if serial is not None:
+                grains['serial'] = serial
+                break
     elif osdata['kernel'] == 'FreeBSD':
         # On FreeBSD /bin/kenv (already in base system)
         # can be used instead of dmidecode

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1240,11 +1240,11 @@ def os_data():
         grains.update(_linux_gpu_data())
     elif grains['kernel'] == 'SunOS':
         grains['os_family'] = 'Solaris'
-        uname_v = __salt__['cmd.run']('uname -v')
-        if 'joyent_' in uname_v:
+        if salt.utils.is_smartos():
             # See https://github.com/joyent/smartos-live/issues/224
+            uname_v = __salt__['cmd.run']('uname -v')
             grains['os'] = grains['osfullname'] = 'SmartOS'
-            grains['osrelease'] = uname_v
+            grains['osrelease'] = uname_v[uname_v.index('_')+1:]
         elif os.path.isfile('/etc/release'):
             with salt.utils.fopen('/etc/release', 'r') as fp_:
                 rel_data = fp_.read()

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -351,7 +351,7 @@ def _sunos_cpudata():
     grains = {}
     grains['cpu_flags'] = []
 
-    grains['cpuarch'] = __salt__['cmd.run']('uname -p')
+    grains['cpuarch'] = __salt__['cmd.run']('isainfo -k')
     psrinfo = '/usr/sbin/psrinfo 2>/dev/null'
     grains['num_cpus'] = len(__salt__['cmd.run'](psrinfo, python_shell=True).splitlines())
     kstat_info = 'kstat -p cpu_info:0:*:brand'

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1669,22 +1669,23 @@ def _hw_data(osdata):
 
     grains = {}
     if salt.utils.which_bin(['dmidecode', 'smbios']) is not None:
-        grains = {
-            'biosversion': __salt__['smbios.get']('bios-version'),
-            'productname': __salt__['smbios.get']('system-product-name'),
-            'manufacturer': __salt__['smbios.get']('system-manufacturer'),
-            'biosreleasedate': __salt__['smbios.get']('bios-release-date'),
-            'uuid': __salt__['smbios.get']('system-uuid')
-        }
-        grains = dict([(key, val) for key, val in grains.items() if val is not None])
-        uuid = __salt__['smbios.get']('system-uuid')
-        if uuid is not None:
-            grains['uuid'] = uuid.lower()
-        for serial in ('system-serial-number', 'chassis-serial-number', 'baseboard-serial-number'):
-            serial = __salt__['smbios.get'](serial)
-            if serial is not None:
-                grains['serial'] = serial
-                break
+        if not salt.utils.is_smartos() or salt.utils.is_smartos_globalzone():
+            grains = {
+                'biosversion': __salt__['smbios.get']('bios-version'),
+                'productname': __salt__['smbios.get']('system-product-name'),
+                'manufacturer': __salt__['smbios.get']('system-manufacturer'),
+                'biosreleasedate': __salt__['smbios.get']('bios-release-date'),
+                'uuid': __salt__['smbios.get']('system-uuid')
+            }
+            grains = dict([(key, val) for key, val in grains.items() if val is not None])
+            uuid = __salt__['smbios.get']('system-uuid')
+            if uuid is not None:
+                grains['uuid'] = uuid.lower()
+            for serial in ('system-serial-number', 'chassis-serial-number', 'baseboard-serial-number'):
+                serial = __salt__['smbios.get'](serial)
+                if serial is not None:
+                    grains['serial'] = serial
+                    break
     elif osdata['kernel'] == 'FreeBSD':
         # On FreeBSD /bin/kenv (already in base system)
         # can be used instead of dmidecode

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -618,7 +618,12 @@ def _interfaces_ifconfig(out):
             # status determines global interface status.
             #
             # merge items with higher priority for older values
+            # after that merge the inet and inet6 sub items for both
             ret[iface] = dict(list(data.items()) + list(ret[iface].items()))
+            if 'inet' in data:
+                ret[iface]['inet'].extend(x for x in data['inet'] if x not in ret[iface]['inet'])
+            if 'inet6' in data:
+                ret[iface]['inet6'].extend(x for x in data['inet6'] if x not in ret[iface]['inet6'])
         else:
             ret[iface] = data
         del data


### PR DESCRIPTION
- don't include joyent_ in release version (as per only timestamp is used - http://us-east.manta.joyent.com/Joyent_Dev/public/SmartOS/smartos.html)
- use isainfo -k instead of uname -p to get system architecture. (correctly report i368 and amd64), applies to SunOS in general
- Skip smbios grains on SmartOS as smbios is not compatible
- Correctly parse aditional inet/inet6 addresses on SmartOS/SunOS (fixes grains part of issue #26139)
