### PR TITLE
salt.utils.is_smartos_zone, inverse of is_smartos_globalzone

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1621,6 +1621,29 @@ def is_smartos_globalzone():
 
 
 @real_memoize
+def is_smartos_zone():
+    '''
+    Function to return if host is SmartOS (Illumos) and not the gz
+    '''
+    if not is_smartos():
+        return False
+    else:
+        cmd = ['zonename']
+        try:
+            zonename = subprocess.Popen(
+                cmd, shell=False,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        except OSError:
+            return False
+        if zonename.returncode:
+            return False
+        if zonename.stdout.read().strip() == 'global':
+            return False
+
+        return True
+
+
+@real_memoize
 def is_freebsd():
     '''
     Simple function to return if host is FreeBSD or not


### PR DESCRIPTION
Simply using `if not salt.utils.is_smartos_globalzone()` can you incorrect results, it it will return True for example when running on SunOS or linux. This introduces a proper check to make sure we are running in a smartos zone.

salt.utils.is_smartos(): matches smartos, regardless if we are global or a non global zone
salt.utils.is_smartos_globalzone(): matches only if we are a smartos globalzone (aka compute node)
salt.utils.is_smartos_zone(): matches only if we are a non globalzone on smartos (aka a smart machine)
