### PR TITLE
salt.modules.network now supports SmartOS and SunOS < Solaris 11

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -921,7 +921,7 @@ def mod_hostname(hostname):
         return False
 
     hostname_cmd = salt.utils.which('hostnamectl') or salt.utils.which('hostname')
-    if __grains__['kernel'] == 'SunOS':
+    if salt.utils.is_sunos():
         uname_cmd = '/usr/bin/uname' if salt.utils.is_smartos() else salt.utils.which('uname')
         check_hostname_cmd = salt.utils.which('check-hostname')
 

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -907,7 +907,7 @@ def mod_hostname(hostname):
 
             try:
                 host[host.index(o_hostname)] = hostname
-                if  __grains__['kernel'] == 'SunOS':
+                if __grains__['kernel'] == 'SunOS':
                     # also set a copy of the hostname
                     host[host.index(o_hostname.split('.')[0])] = hostname.split('.')[0]
             except ValueError:

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -647,7 +647,11 @@ def arp():
         comps = line.split()
         if len(comps) < 4:
             continue
-        if not __grains__['kernel'] == 'OpenBSD':
+        if __grains__['kernel'] == 'SunOS':
+            if ':' not in comps[-1]:
+                continue
+            ret[comps[-1]] = comps[1]
+        elif not __grains__['kernel'] == 'OpenBSD':
             ret[comps[3]] = comps[1].strip('(').strip(')')
         else:
             if comps[0] == 'Host' or comps[1] == '(incomplete)':

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -562,7 +562,7 @@ def traceroute(host):
     out = __salt__['cmd.run'](cmd)
 
     # Parse version of traceroute
-    if __grains__['kernel'] == 'SunOS':
+    if salt.utils.is_sunos():
         traceroute_version = [0, 0, 0]
     else:
         cmd2 = 'traceroute --version'

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -86,7 +86,10 @@ def ping(host, timeout=False, return_boolean=False):
         salt '*' network.ping archlinux.org timeout=3
     '''
     if timeout:
-        cmd = 'ping -W {0} -c 4 {1}'.format(timeout, salt.utils.network.sanitize_host(host))
+        if salt.utils.is_sunos():
+            cmd = 'ping -c 4 {1} {0}'.format(timeout, salt.utils.network.sanitize_host(host))
+        else:
+            cmd = 'ping -W {0} -c 4 {1}'.format(timeout, salt.utils.network.sanitize_host(host))
     else:
         cmd = 'ping -c 4 {0}'.format(salt.utils.network.sanitize_host(host))
     if return_boolean:

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -1336,7 +1336,7 @@ def get_route(ip):
         # recvpipe  sendpipe  ssthresh    rtt,ms rttvar,ms  hopcount      mtu     expire
         #       0         0         0         0         0         0      1500         0
         cmd = '/usr/sbin/route -n get {0}'.format(ip)
-        out = __salt__['cmd.run'](cmd, python_shell=True)
+        out = __salt__['cmd.run'](cmd, python_shell=False)
 
         ret = {
             'destination': ip,
@@ -1370,7 +1370,7 @@ def get_route(ip):
         #     use       mtu    expire
         # 8352657         0         0
         cmd = 'route -n get {0}'.format(ip)
-        out = __salt__['cmd.run'](cmd, python_shell=True)
+        out = __salt__['cmd.run'](cmd, python_shell=False)
 
         ret = {
             'destination': ip,

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -931,13 +931,13 @@ def mod_hostname(hostname):
 
     # Grab the old hostname so we know which hostname to change and then
     # change the hostname using the hostname command
-    if not __grains__['kernel'] == 'SunOS':
+    if not salt.utils.is_sunos():
         o_hostname = __salt__['cmd.run']('{0} -f'.format(hostname_cmd))
     else:
         # output: Hostname core OK: fully qualified as core.acheron.be
         o_hostname = __salt__['cmd.run'](check_hostname_cmd).split(' ')[-1]
 
-    if not __grains__['kernel'] == 'SunOS':
+    if not salt.utils.is_sunos():
         __salt__['cmd.run']('{0} {1}'.format(hostname_cmd, hostname))
     else:
         __salt__['cmd.run']('{0} -S {1}'.format(uname_cmd, hostname.split('.')[0]))
@@ -952,7 +952,7 @@ def mod_hostname(hostname):
 
             try:
                 host[host.index(o_hostname)] = hostname
-                if __grains__['kernel'] == 'SunOS':
+                if salt.utils.is_sunos():
                     # also set a copy of the hostname
                     host[host.index(o_hostname.split('.')[0])] = hostname.split('.')[0]
             except ValueError:
@@ -979,7 +979,7 @@ def mod_hostname(hostname):
             fh_.write(hostname + '\n')
 
     # Update /etc/nodename and /etc/defaultdomain on SunOS
-    if __grains__['kernel'] == 'SunOS':
+    if salt.utils.is_sunos():
         with salt.utils.fopen('/etc/nodename', 'w') as fh_:
             fh_.write(hostname.split('.')[0] + '\n')
         with salt.utils.fopen('/etc/defaultdomain', 'w') as fh_:

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -693,12 +693,12 @@ def arp():
             if ':' not in comps[-1]:
                 continue
             ret[comps[-1]] = comps[1]
-        elif not __grains__['kernel'] == 'OpenBSD':
-            ret[comps[3]] = comps[1].strip('(').strip(')')
-        else:
+        elif __grains__['kernel'] == 'OpenBSD':
             if comps[0] == 'Host' or comps[1] == '(incomplete)':
                 continue
             ret[comps[1]] = comps[0]
+        else:
+            ret[comps[3]] = comps[1].strip('(').strip(')')
     return ret
 
 

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -331,7 +331,7 @@ def _netstat_sunos():
             ret.append({
                 'proto': 'udp6' if addr_family == 'inet6' else 'udp',
                 'local-address': comps[0],
-                'remote-address': comps[1]})
+                'remote-address': comps[1] if len(comps) > 2 else ''})
 
     return ret
 

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -210,6 +210,16 @@ def get_hostnames():
     except (IOError, OSError):
         pass
 
+    # try /etc/nodename (SunOS only)
+    if salt.utils.is_sunos():
+        try:
+            name = ''
+            with salt.utils.fopen('/etc/nodename') as hfl:
+                name = hfl.read()
+            h.append(name)
+        except (IOError, OSError):
+            pass
+
     # try /etc/hosts
     try:
         with salt.utils.fopen('/etc/hosts') as hfl:


### PR DESCRIPTION
Set of fixes for salt.module.network to make things work on SunOS/SmartOS.
Note: Solaris 11 is a bit different. I have no test system so some things like mod_hostname won't work on Solaris 11.
- get_hostname now uses /etc/nodename on SunOS
- ping now correctly works when timeout is provided on SunOS
- traceroute correctly parses the results on SunOS (same as BSD)
- netstat partially works on SunOS, missing program and user
- arp fixes parsing of output on SunOS
- mod_hostname now works on Solaris 10 (compatible -> SmartOS, OmniOS, ...)
  - split fqdn into host and domain name, set them in /etc/nodename, /etc/defaultdomain and update /etc/hosts.
  - uses uname -S to set host name part
  - uses check-hostname to get fqdn, can potentially fail with broken /etc/hosts file (still better than not working at all I)
- routes now supports SunOS
- default_route now supports SunOS
- get_route now supports SunOS (OpenBSD commit **may** follow once a friend confirms it works)

```
[root@core ~]# salt-call --local network.netstat
[WARNING ] User and program not (yet) supported on SunOS
[INFO    ] Executing command 'netstat -f inet -P tcp -an | tail -n+5' in directory '/root'
[INFO    ] Executing command 'netstat -f inet -P udp -an | tail -n+5' in directory '/root'
[INFO    ] Executing command 'netstat -f inet6 -P tcp -an | tail -n+5' in directory '/root'
[INFO    ] Executing command 'netstat -f inet6 -P udp -an | tail -n+5' in directory '/root'
local:
    |_
      ----------
      local-address:
          *.111
      proto:
          tcp
      recv-q:
          0
      remote-address:
          *.*
      send-q:
          1048576
      state:
          LISTEN
    |_
      ----------
      local-address:
          *.*
      proto:
          tcp
      recv-q:
          0
      remote-address:
          *.*
      send-q:
          1048576
      state:
          IDLE
    |_
      ----------
      local-address:
          *.111
      proto:
          tcp
      recv-q:
          0
      remote-address:
          *.*
      send-q:
          1048576
      state:
          LISTEN
    |_
      ----------
      local-address:
          *.*
      proto:
          tcp
      recv-q:
          0
      remote-address:
          *.*
      send-q:
          1048576
      state:
          IDLE
    |_
      ----------
      local-address:
          *.22
      proto:
          tcp
      recv-q:
          0
      remote-address:
          *.*
      send-q:
          1048576
      state:
          LISTEN
    |_
      ----------
      local-address:
          127.0.0.1.25
      proto:
          tcp
      recv-q:
          0
      remote-address:
          *.*
      send-q:
          1048576
      state:
          LISTEN
    |_
      ----------
      local-address:
          127.0.0.1.587
      proto:
          tcp
      recv-q:
          0
      remote-address:
          *.*
      send-q:
          1048576
      state:
          LISTEN
    |_
      ----------
      local-address:
          127.0.0.1.8080
      proto:
          tcp
      recv-q:
          0
      remote-address:
          *.*
      send-q:
          1048576
      state:
          LISTEN
    |_
      ----------
      local-address:
          *.*
      proto:
          udp
      remote-address:
          Unbound
    |_
      ----------
      local-address:
          *.111
      proto:
          udp
      remote-address:
          Idle
    |_
      ----------
      local-address:
          *.*
      proto:
          udp
      remote-address:
          Unbound
    |_
      ----------
      local-address:
          *.46090
      proto:
          udp
      remote-address:
          Idle
    |_
      ----------
      local-address:
          *.111
      proto:
          udp
      remote-address:
          Idle
    |_
      ----------
      local-address:
          *.*
      proto:
          udp
      remote-address:
          Unbound
    |_
      ----------
      local-address:
          *.46061
      proto:
          udp
      remote-address:
          Idle
    |_
      ----------
      local-address:
          *.123
      proto:
          udp
      remote-address:
          Idle
    |_
      ----------
      local-address:
          *.123
      proto:
          udp
      remote-address:
          Idle
    |_
      ----------
      local-address:
          127.0.0.1.123
      proto:
          udp
      remote-address:
          Idle
    |_
      ----------
      local-address:
          172.16.xx.yy:123
      proto:
          udp
      remote-address:
          Idle
    |_
      ----------
      local-address:
          *.61115
      proto:
          udp
      remote-address:
          Idle
    |_
      ----------
      local-address:
          *.54577
      proto:
          udp
      remote-address:
          Idle
    |_
      ----------
      local-address:
          *.5353
      proto:
          udp
      remote-address:
          Idle
    |_
      ----------
      local-address:
          *.5353
      proto:
          udp
      remote-address:
          Idle
    |_
      ----------
      local-address:
          2001:6f8:1480:xx::yy.22
      proto:
          tcp6
      recv-q:
          0
      remote-address:
          2001:6f8:1480:xx::yy.31228
      send-q:
          1049580
      state:
          ESTABLISHED
    |_
      ----------
      local-address:
          2001:6f8:1480:xx::yy.22
      proto:
          tcp6
      recv-q:
          0
      remote-address:
          2001:6f8:1480:xx::yy.52371
      send-q:
          1049580
      state:
          ESTABLISHED
    |_
      ----------
      local-address:
          *.111
      proto:
          tcp6
      recv-q:
          0
      remote-address:
          *.*
      send-q:
          1048576
      state:
          LISTEN
    |_
      ----------
      local-address:
          *.*
      proto:
          tcp6
      recv-q:
          0
      remote-address:
          *.*
      send-q:
          1048576
      state:
          IDLE
    |_
      ----------
      local-address:
          *.22
      proto:
          tcp6
      recv-q:
          0
      remote-address:
          *.*
      send-q:
          1048576
      state:
          LISTEN
    |_
      ----------
      local-address:
          ::1.25
      proto:
          tcp6
      recv-q:
          0
      remote-address:
          *.*
      send-q:
          1048576
      state:
          LISTEN
    |_
      ----------
      local-address:
          2001:6f8:1480:xx::yy.22
      proto:
          tcp6
      recv-q:
          0
      remote-address:
          2001:6f8:1480:xx::yy.46903
      send-q:
          1049580
      state:
          ESTABLISHED
    |_
      ----------
      local-address:
          *.*
      proto:
          udp6
      remote-address:
          Unbound
    |_
      ----------
      local-address:
          *.111
      proto:
          udp6
      remote-address:
          Idle
    |_
      ----------
      local-address:
          *.*
      proto:
          udp6
      remote-address:
          Unbound
    |_
      ----------
      local-address:
          *.46090
      proto:
          udp6
      remote-address:
          Idle
    |_
      ----------
      local-address:
          *.123
      proto:
          udp6
      remote-address:
          Idle
    |_
      ----------
      local-address:
          ::1.123
      proto:
          udp6
      remote-address:
          Idle
    |_
      ----------
      local-address:
          2001:6f8:1480:xx::yy.123
      proto:
          udp6
      remote-address:
          Idle
    |_
      ----------
      local-address:
          *.54577
      proto:
          udp6
      remote-address:
          Idle
    |_
      ----------
      local-address:
          *.5353
      proto:
          udp6
      remote-address:
          Idle
```

```
[root@nacl /salt_dev/salt]# /opt/local/salt/bin/salt-call --local network.traceroute blackdot.be
[INFO    ] Executing command 'traceroute blackdot.be' in directory '/root'
local:
    |_
      ----------
      count:
          1
      hostname:
          exosphere-vlan10
      ip:
          172.16.xx.yy
      ms1:
          1.039
      ms2:
          0.820
      ms3:
          0.815
    |_
      ----------
      count:
          2
      hostname:
          192.168.0.1
      ip:
          192.168.0.1
      ms1:
          2.080
      ms2:
          1.541
      ms3:
          2.177
    |_
      ----------
      count:
          3
      hostname:
          example.com
      ip:
          213.224.xx.yy
      ms1:
          20.073
      ms2:
          18.399
      ms3:
          13.644
    |_
      ----------
      count:
          4
      hostname:
          example.com
      ip:
          213.224.xx.yy
      ms1:
          25.949
      ms2:
          18.919
      ms3:
          17.320
    |_
      ----------
      count:
          5
      hostname:
          example.com
      ip:
          213.224.xx.yy
      ms1:
          20.966
      ms2:
          16.733
      ms3:
          16.717
    |_
      ----------
      count:
          6
      hostname:
          ovh.bnix.net
      ip:
          194.53.172.70
      ms1:
          123.920
      ms2:
          140.058
      ms3:
          23.487
    |_
      ----------
      count:
          7
      hostname:
          rbx-g1-a9.fr.eu
      ip:
          213.251.130.56
      ms1:
          17.218
      ms2:
          24.466
      ms3:
          26.317
    |_
      ----------
      count:
          8
      hostname:
          vss-4-6k.routers.ovh.net
      ip:
          94.23.122.160
      ms1:
          18.072
      ms2:
          245.771
      ms3:
          21.364
    |_
      ----------
      count:
          9
      hostname:
          www.blackdot.be
      ip:
          5.135.127.100
      ms1:
          23.358
      ms2:
          24.325
      ms3:
          27.236
```

```
[root@nacl /salt_dev/salt]# /opt/local/salt/bin/salt-call --local network.arp
[INFO    ] Executing command 'arp -an' in directory '/root'
local:
    ----------
    00:15:xx:xx:xx:xx:
        172.16.xx.yy
    00:15:xx:xx:xx:xx:
        172.16.xx.yy
```

```
[root@nacl /salt_dev/salt]# /usr/sbin/check-hostname
Hostname nacl OK: fully qualified as nacl.acheron.be
[root@nacl /salt_dev/salt]# /opt/local/salt/bin/salt-call --local network.mod_hostname test.acheron.be
[INFO    ] Executing command '/usr/sbin/check-hostname' in directory '/root'
[INFO    ] Executing command '/usr/bin/uname -S test' in directory '/root'
local:
    True
[root@nacl /salt_dev/salt]# /usr/sbin/check-hostname
Hostname test OK: fully qualified as test.acheron.be
```

```
root@nacl /salt_dev/salt]# /opt/local/salt/bin/salt-call --local network.routes
[INFO    ] Executing command 'netstat -f inet -rn | tail -n+5' in directory '/root'
[INFO    ] Executing command 'netstat -f inet6 -rn | tail -n+5' in directory '/root'
local:
    |_
      ----------
      addr_family:
          inet
      destination:
          default
      flags:
          UG
      gateway:
          172.16.xx.yy
      interface:
          net0
      netmask:
    |_
      ----------
      addr_family:
          inet
      destination:
          127.0.0.1
      flags:
          UH
      gateway:
          127.0.0.1
      interface:
          lo0
      netmask:
    |_
      ----------
      addr_family:
          inet
      destination:
          172.16.xx.yy
      flags:
          U
      gateway:
          172.16.xx.yy
      interface:
          net0
      netmask:
    |_
      ----------
      addr_family:
          inet6
      destination:
          ::1
      flags:
          UH
      gateway:
          ::1
      interface:
          lo0
      netmask:
```

```
[root@nacl /salt_dev/salt]# /opt/local/salt/bin/salt-call --local network.default_route
[INFO    ] Executing command 'netstat -f inet -rn | tail -n+5' in directory '/root'
[INFO    ] Executing command 'netstat -f inet6 -rn | tail -n+5' in directory '/root'
local:
    |_
      ----------
      addr_family:
          inet
      destination:
          default
      flags:
          UG
      gateway:
          172.16.xx.yy
      interface:
          net0
      netmask:
```

```
[root@core ~]# /opt/local/salt/bin/salt-call --local network.get_route blackdot.be[INFO    ] Executing command '/usr/sbin/route -n get blackdot.be' in directory '/root'
local:
    ----------
    destination:
        5.135.127.100
    gateway:
        172.16.xx.yy
    interface:
        igb0
    source:
        172.16.xx.yy
```
