### PR TITLE
Fixes to schedule module

### DIFF
--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -105,11 +105,6 @@ def list_(show_all=False,
             del schedule[job]
             continue
 
-        # if enabled is not included in the job,
-        # assume job is enabled.
-        if 'enabled' not in schedule[job]:
-            schedule[job]['enabled'] = True
-
         for item in pycopy.copy(schedule[job]):
             if item not in SCHEDULE_CONF:
                 del schedule[job][item]
@@ -346,6 +341,11 @@ def build_schedule_item(name, **kwargs):
             'return_config', 'until']:
         if item in kwargs:
             schedule[name][item] = kwargs[item]
+
+    # if enabled is not included in the job,
+    # assume job is enabled.
+    if 'enabled' not in kwargs:
+        schedule[name]['enabled'] = True
 
     return schedule[name]
 

--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -57,7 +57,10 @@ SCHEDULE_CONF = [
 ]
 
 
-def list_(show_all=False, where=None, return_yaml=True):
+def list_(show_all=False,
+          show_disabled=True,
+          where=None,
+          return_yaml=True):
     '''
     List the jobs currently scheduled on the minion
 
@@ -67,7 +70,12 @@ def list_(show_all=False, where=None, return_yaml=True):
 
         salt '*' schedule.list
 
+        # Show all jobs including hidden internal jobs
         salt '*' schedule.list show_all=True
+
+        # Hide disabled jobs from list of jobs
+        salt '*' schedule.list show_disabled=False
+
     '''
 
     schedule = {}
@@ -97,6 +105,11 @@ def list_(show_all=False, where=None, return_yaml=True):
             del schedule[job]
             continue
 
+        # if enabled is not included in the job,
+        # assume job is enabled.
+        if 'enabled' not in schedule[job]:
+            schedule[job]['enabled'] = True
+
         for item in pycopy.copy(schedule[job]):
             if item not in SCHEDULE_CONF:
                 del schedule[job][item]
@@ -105,6 +118,11 @@ def list_(show_all=False, where=None, return_yaml=True):
                 schedule[job][item] = True
             if schedule[job][item] == 'false':
                 schedule[job][item] = False
+
+        # if the job is disabled and show_disabled is False, skip job
+        if not show_disabled and not schedule[job]['enabled']:
+            del schedule[job]
+            continue
 
         if '_seconds' in schedule[job]:
             schedule[job]['seconds'] = schedule[job]['_seconds']

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -387,6 +387,12 @@ class Schedule(object):
         if not len(data) == 1:
             raise ValueError('You can only schedule one new job at a time.')
 
+        # if enabled is not included in the job,
+        # assume job is enabled.
+        for job in data.keys():
+            if 'enabled' not in data[job]:
+                data[job]['enabled'] = True
+
         new_job = next(six.iterkeys(data))
 
         if new_job in self.opts['schedule']:

--- a/tests/unit/modules/schedule_test.py
+++ b/tests/unit/modules/schedule_test.py
@@ -33,7 +33,7 @@ schedule.__opts__ = {}
 schedule.__pillar__ = {}
 
 JOB1 = {'function': 'test.ping', 'maxrunning': 1, 'name': 'job1',
-        'jid_include': True}
+        'jid_include': True, 'enabled': True}
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)

--- a/tests/unit/modules/schedule_test.py
+++ b/tests/unit/modules/schedule_test.py
@@ -109,7 +109,8 @@ class ScheduleTestCase(TestCase):
             self.assertDictEqual(schedule.build_schedule_item
                                  ('job1', function='test.ping'),
                                  {'function': 'test.ping', 'maxrunning': 1,
-                                  'name': 'job1', 'jid_include': True})
+                                  'name': 'job1', 'jid_include': True,
+                                  'enabled': True})
 
             self.assertDictEqual(schedule.build_schedule_item
                                  ('job1', function='test.ping', seconds=3600,

--- a/tests/unit/modules/schedule_test.py
+++ b/tests/unit/modules/schedule_test.py
@@ -47,13 +47,13 @@ class ScheduleTestCase(TestCase):
         '''
         Test if it list the jobs currently scheduled on the minion.
         '''
-        with patch.dict(schedule.__opts__, {'schedule': {'_seconds': []}, 'sock_dir': SOCK_DIR}):
+        with patch.dict(schedule.__opts__, {'schedule': {'_seconds': {'enabled': True}}, 'sock_dir': SOCK_DIR}):
             mock = MagicMock(return_value=True)
             with patch.dict(schedule.__salt__, {'event.fire': mock}):
-                _ret_value = {'complete': True, 'schedule': {'_seconds': []}}
+                _ret_value = {'complete': True, 'schedule': {'_seconds': {'enabled': True}}}
                 with patch.object(SaltEvent, 'get_event', return_value=_ret_value):
-                    self.assertEqual(schedule.list_(), 'schedule:\n  _seconds: []\n')
-                    self.assertDictEqual(schedule.list_(show_all=True, return_yaml=False), {'_seconds': []})
+                    self.assertEqual(schedule.list_(), "schedule:\n  _seconds:\n    enabled: true\n")
+                    self.assertDictEqual(schedule.list_(show_all=True, return_yaml=False), {'_seconds': {'enabled': True}})
 
         with patch.dict(schedule.__opts__, {'schedule': {}, 'sock_dir': SOCK_DIR}):
             mock = MagicMock(return_value=True)

--- a/tests/unit/utils/schedule_test.py
+++ b/tests/unit/utils/schedule_test.py
@@ -81,9 +81,10 @@ class ScheduleTestCase(TestCase):
         '''
         Tests adding a job to the schedule
         '''
-        data = {'foo': 'bar'}
-        ret = {'schedule': {'foo': 'bar', 'hello': 'world'}}
-        self.schedule.opts = {'schedule': {'hello': 'world'},
+        data = {'foo': {'bar': 'baz'}}
+        ret = {'schedule': {'foo': {'bar': 'baz', 'enabled': True},
+                            'hello': {'world': 'peace', 'enabled': True}}}
+        self.schedule.opts = {'schedule': {'hello': {'world': 'peace', 'enabled': True}},
                               'sock_dir': SOCK_DIR}
         Schedule.add_job(self.schedule, data)
         del self.schedule.opts['sock_dir']


### PR DESCRIPTION
Jobs are enabled by default but schedule.list does not show an enabled jobs as being enabled by default.  This change fixes that.  Also allows schedule.list to be able to filter out disabled jobs.
