### PR TITLE
Fixes to schedule module in 2015.5

### DIFF
--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -79,6 +79,11 @@ def list_(show_all=False, return_yaml=True):
             del schedule[job]
             continue
 
+        # if enabled is not included in the job,
+        # assume job is enabled.
+        if 'enabled' not in schedule[job]:
+            schedule[job]['enabled'] = True
+
         for item in pycopy.copy(schedule[job]):
             if item not in SCHEDULE_CONF:
                 del schedule[job][item]


### PR DESCRIPTION
Jobs are enabled by default but schedule.list does not show an enabled jobs as being enabled by default.  This change fixes that.
