### PR TITLE
allow to delete grains which value is False

### DIFF
--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -220,8 +220,7 @@ def absent(name, destructive=False):
            'changes': {},
            'result': True,
            'comment': ''}
-    grain = __grains__.get(name)
-    if grain:
+    if name in __grains__:
         if __opts__['test']:
             ret['result'] = None
             if destructive is True:


### PR DESCRIPTION
without this patch `grains.absent` was not able to remove a grain which value was `False`
