### PR TITLE
Rabbitmq 3.2.4 on Ubuntu has "...done.", not "...done"

### DIFF
--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -72,7 +72,7 @@ def _strip_listing_to_done(output_list):
     # some versions of rabbitmq have no trailing '...done' line,
     # which some versions do not output.
     l_line = ''.join(output_list[-1:])
-    if l_line == '...done':
+    if '...done' in l_line:
         output_list.pop()
 
     return output_list


### PR DESCRIPTION
Commit 3c3d99fd569fd7961ba64a0bd350303b2a4a7305 was backported to 2015.8, but not 2015.5. Merge of this pull request closes issue https://github.com/saltstack/salt/issues/25125
