### PR TITLE
bugfix missing `runas=None' for rabbitmqctl cmds (backport to 2015.8)

### DIFF
--- a/salt/states/rabbitmq_user.py
+++ b/salt/states/rabbitmq_user.py
@@ -42,14 +42,14 @@ def __virtual__():
     return salt.utils.which('rabbitmqctl') is not None
 
 
-def _check_perms_changes(name, newperms):
+def _check_perms_changes(name, newperms, runas=None):
     '''
     Whether Rabbitmq user's permissions need to be changed
     '''
     if not newperms:
         return False
 
-    existing_perms = __salt__['rabbitmq.list_user_permissions'](name)
+    existing_perms = __salt__['rabbitmq.list_user_permissions'](name, runas=runas)
 
     perm_need_change = False
     for vhost_perms in newperms:
@@ -63,14 +63,14 @@ def _check_perms_changes(name, newperms):
     return perm_need_change
 
 
-def _check_tags_changes(name, newtags):
+def _check_tags_changes(name, newtags, runas=None):
     '''
     Whether Rabbitmq user's tags need to be changed
     '''
     if newtags:
         if isinstance(newtags, str):
             newtags = newtags.split()
-        return __salt__['rabbitmq.list_users']()[name] - set(newtags)
+        return __salt__['rabbitmq.list_users'](runas=runas)[name] - set(newtags)
     else:
         return []
 
@@ -147,7 +147,7 @@ def present(name,
                         name, runas=runas)
                     changes['old'] += 'Removed password.\n'
 
-        if _check_tags_changes(name, tags):
+        if _check_tags_changes(name, tags, runas=runas):
             if __opts__['test']:
                 ret['result'] = None
                 ret['comment'] += ('Tags for user {0} '
@@ -158,7 +158,7 @@ def present(name,
             )
             changes['new'] += 'Set tags: {0}\n'.format(tags)
 
-        if _check_perms_changes(name, perms):
+        if _check_perms_changes(name, perms, runas=runas):
             if __opts__['test']:
                 ret['result'] = None
                 ret['comment'] += ('Permissions for user {0} '
@@ -167,7 +167,7 @@ def present(name,
             for vhost_perm in perms:
                 for vhost, perm in six.iteritems(vhost_perm):
                     result.update(__salt__['rabbitmq.set_permissions'](
-                        vhost, name, perm[0], perm[1], perm[2], runas)
+                        vhost, name, perm[0], perm[1], perm[2], runas=runas)
                     )
                     changes['new'] += (
                         'Set permissions {0} for vhost {1}'


### PR DESCRIPTION
This PR duplicates #26295 as a request to backport the given fix to the 2015.8 branch.
# Problem

Some rabbitmqctl client commands were executed without
honoring the `runas` state keyword, resulting in
system commands executed as the minion. States that
previously succeeded are now failed by parser error
traceback when failing to split by expected tabstops
output, wheras the output likely contains some error.
# Solution

Forward the `runas=None` keyword parameter in the
standard pattern for supplementary functions that
were introduced by cd0212e8e, `_check_perms_changes`
and `_check_tags_changes`.

All calls to `__salt__['rabbtimq.(...)']` were
audited, no further bugs of this pattern found.
# Example Symptom

```
Failure: rabbitmq_user_|-rabbitmq-user-xxx_|-xxx_|-present: An exception occurred in this state: Traceback (most recent call last):
    File "/usr/lib/python2.7/site-packages/salt/state.py", line 1561, in call
      **cdata['kwargs'])
    File "/usr/lib/python2.7/site-packages/salt/states/rabbitmq_user.py", line 147, in present
      if _check_tags_changes(name, tags):
    File "/usr/lib/python2.7/site-packages/salt/states/rabbitmq_user.py", line 70, in _check_tags_changes
      return __salt__['rabbitmq.list_users']()[name] - set(newtags)
    File "/usr/lib/python2.7/site-packages/salt/modules/rabbitmq.py", line 116, in list_users
      return _output_to_dict(res, func)
    File "/usr/lib/python2.7/site-packages/salt/modules/rabbitmq.py", line 94, in _output_to_dict
      key, values = row.split('\t', 1)
  ValueError: need more than 1 value to unpack
```
