### PR TITLE
Keep $HOME from being interpretted by Master shell

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -926,10 +926,10 @@ ARGS = {9}\n'''.format(self.minion_config,
             pass
 
         # Execute shim
-        ret = self.shell.exec_cmd('/bin/sh $HOME/{0}'.format(target_shim_file))
+        ret = self.shell.exec_cmd('/bin/sh \'$HOME/{0}\''.format(target_shim_file))
 
         # Remove shim from target system
-        self.shell.exec_cmd('rm $HOME/{0}'.format(target_shim_file))
+        self.shell.exec_cmd('rm \'$HOME/{0}\''.format(target_shim_file))
 
         return ret
 


### PR DESCRIPTION
The command is being sent to a shelled ssh call which allows $HOME to get interpreted by the local shell. This is usually different than the remote user when using sudo (ie, /root vs /home/user) and causes it to fail to find the shim script.

Should fix bugs: https://github.com/saltstack/salt/issues/25134 and https://github.com/saltstack/salt/issues/24863

This may need to backout if we change shell._run_cmd()'s call to salt.utils.vt.Terminal with shell=False. Which may be a better fix, but would require a LOT more testing.
