### PR TITLE
Move VM creation details dict to log.trace

### DIFF
--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -2191,7 +2191,7 @@ def create(vm_=None, call=None):
         )
 
     log.info('Created Cloud VM {0[name]!r}'.format(vm_))
-    log.debug(
+    log.trace(
         '{0[name]!r} VM creation details:\n{1}'.format(
             vm_, pprint.pformat(node_dict)
         )


### PR DESCRIPTION
Fixes #16179

The bootstrap script gets printed twice to the screen when the VM creation details dict is logged. Let's move this to trace and reduce the noise.
