### PR TITLE
Support for environment overrides building packages

### DIFF
--- a/salt/modules/debbuild.py
+++ b/salt/modules/debbuild.py
@@ -19,6 +19,7 @@ from salt.ext.six.moves.urllib.parse import urlparse as _urlparse  # pylint: dis
 
 # Import salt libs
 import salt.utils
+from salt.exceptions import SaltInvocationError
 
 # pylint: disable=import-error
 
@@ -34,9 +35,46 @@ def __virtual__():
     return False
 
 
-def _create_pbuilders():
+def _get_env(env):
+    '''
+    Get environment overrides dictionary to use in build process
+    '''
+    env_override = ""
+    if env is None:
+        return env_override
+    if not isinstance(env, dict):
+        raise SaltInvocationError(
+            '\'env\' must be a Python dictionary'
+        )
+    for key, value in env.items():
+        env_override += '{0}={1}\n'.format(key, value)
+        env_override += 'export {0}\n'.format(key)
+    return env_override
+
+
+def _create_pbuilders(env):
     '''
     Create the .pbuilder family of files in user's home directory
+
+    env
+        A list  or dictionary of environment variables to be set prior to execution.
+        Example:
+
+        .. code-block:: yaml
+
+                - env:
+                  - DEB_BUILD_OPTIONS: 'nocheck'
+
+        .. warning::
+
+            The above illustrates a common PyYAML pitfall, that **yes**,
+            **no**, **on**, **off**, **true**, and **false** are all loaded as
+            boolean ``True`` and ``False`` values, and must be enclosed in
+            quotes to be used as strings. More info on this (and other) PyYAML
+            idiosyncrasies can be found :doc:`here
+            </topics/troubleshooting/yaml_idiosyncrasies>`.
+
+
     '''
     hook_text = '''#!/bin/sh
 set -e
@@ -100,6 +138,11 @@ OTHERMIRROR="deb http://ftp.us.debian.org/debian/ testing main contrib non-free 
     with open(pbuilderrc, "w") as fow:
         fow.write('{0}'.format(pbldrc_text))
 
+    env_overrides = _get_env(env)
+    if env_overrides and not env_overrides.isspace():
+        with open(pbuilderrc, "a") as fow:
+            fow.write('{0}'.format(env_overrides))
+
 
 def _mk_tree():
     '''
@@ -133,7 +176,7 @@ def _get_src(tree_base, source, saltenv='base'):
         shutil.copy(source, dest)
 
 
-def make_src_pkg(dest_dir, spec, sources, template=None, saltenv='base'):
+def make_src_pkg(dest_dir, spec, sources, env=None, template=None, saltenv='base'):
     '''
     Create a platform specific source package from the given platform spec/control file and sources
 
@@ -145,7 +188,7 @@ def make_src_pkg(dest_dir, spec, sources, template=None, saltenv='base'):
     This example command should build the libnacl SOURCE package and place it in
     /var/www/html/ on the minion
     '''
-    _create_pbuilders()
+    _create_pbuilders(env)
     tree_base = _mk_tree()
     ret = []
     if not os.path.isdir(dest_dir):
@@ -221,7 +264,7 @@ def make_src_pkg(dest_dir, spec, sources, template=None, saltenv='base'):
     return ret
 
 
-def build(runas, tgt, dest_dir, spec, sources, deps, template, saltenv='base'):
+def build(runas, tgt, dest_dir, spec, sources, deps, env, template, saltenv='base'):
     '''
     Given the package destination directory, the tarball containing debian files (e.g. control)
     and package sources, use pbuilder to safely build the platform package
@@ -241,7 +284,7 @@ def build(runas, tgt, dest_dir, spec, sources, deps, template, saltenv='base'):
         except (IOError, OSError):
             pass
     dsc_dir = tempfile.mkdtemp()
-    dscs = make_src_pkg(dsc_dir, spec, sources, template, saltenv)
+    dscs = make_src_pkg(dsc_dir, spec, sources, env, template, saltenv)
 
     # dscs should only contain salt orig and debian tarballs and dsc file
     for dsc in dscs:

--- a/salt/modules/rpmbuild.py
+++ b/salt/modules/rpmbuild.py
@@ -130,7 +130,7 @@ def _get_deps(deps, tree_base, saltenv='base'):
     return deps_list
 
 
-def make_src_pkg(dest_dir, spec, sources, template=None, saltenv='base'):
+def make_src_pkg(dest_dir, spec, sources, env=None, template=None, saltenv='base'):
     '''
     Create a source rpm from the given spec file and sources
 
@@ -164,7 +164,7 @@ def make_src_pkg(dest_dir, spec, sources, template=None, saltenv='base'):
     return ret
 
 
-def build(runas, tgt, dest_dir, spec, sources, deps, template, saltenv='base'):
+def build(runas, tgt, dest_dir, spec, sources, deps, env, template, saltenv='base'):
     '''
     Given the package destination directory, the spec file source and package
     sources, use mock to safely build the rpm defined in the spec file
@@ -183,7 +183,7 @@ def build(runas, tgt, dest_dir, spec, sources, deps, template, saltenv='base'):
         except (IOError, OSError):
             pass
     srpm_dir = tempfile.mkdtemp()
-    srpms = make_src_pkg(srpm_dir, spec, sources, template, saltenv)
+    srpms = make_src_pkg(srpm_dir, spec, sources, env, template, saltenv)
 
     distset = _get_distset(tgt)
 

--- a/salt/states/pkgbuild.py
+++ b/salt/states/pkgbuild.py
@@ -21,6 +21,8 @@ automatically
         - dest_dir: /tmp/pkg
         - spec: salt://pkg/salt/spec/salt.spec
         - template: jinja
+        - deps:
+          - salt://pkg/salt/sources/required_dependency.rpm
         - tgt: epel-7-x86_64
         - sources:
           - salt://pkg/salt/sources/logrotate.salt
@@ -54,6 +56,7 @@ def built(
         template,
         tgt,
         deps=None,
+        env=None,
         results=None,
         always=False,
         saltenv='base'):
@@ -88,6 +91,24 @@ def built(
         downloading directly from Amazon S3 compatible URLs with both
         pre-configured and automatic IAM credentials
 
+    env
+        A dictionary of environment variables to be set prior to execution.
+        Example:
+
+        .. code-block:: yaml
+
+                - env:
+                    DEB_BUILD_OPTIONS: 'nocheck'
+
+        .. warning::
+
+            The above illustrates a common PyYAML pitfall, that **yes**,
+            **no**, **on**, **off**, **true**, and **false** are all loaded as
+            boolean ``True`` and ``False`` values, and must be enclosed in
+            quotes to be used as strings. More info on this (and other) PyYAML
+            idiosyncrasies can be found :doc:`here
+            </topics/troubleshooting/yaml_idiosyncrasies>`.
+
     results
         The names of the expected rpms that will be built
 
@@ -118,6 +139,14 @@ def built(
         ret['comment'] = 'Packages need to be built'
         ret['result'] = None
         return ret
+
+    # Need the check for None here, if env is not provided then it falls back
+    # to None and it is assumed that the environment is not being overridden.
+    if env is not None and not isinstance(env, dict):
+        ret['comment'] = ('Invalidly-formatted \'env\' parameter. See '
+                          'documentation.')
+        return ret
+
     ret['changes'] = __salt__['pkgbuild.build'](
         runas,
         tgt,
@@ -125,6 +154,7 @@ def built(
         spec,
         sources,
         deps,
+        env,
         template,
         saltenv)
     ret['comment'] = 'Packages Built'


### PR DESCRIPTION
Allow for environment overriding when building packages by passing in a dictionary of environment variables and their settings: for example DEB_BUILD_OPTIONS="nocheck" when building Debian packages by adding to an sls file used in building packages:
- env:
   DEB_BUILD_OPTIONS: 'nocheck'
