### PR TITLE
allow vpc_name instead of vpc_id for boto_secgroup

### DIFF
--- a/salt/modules/boto_secgroup.py
+++ b/salt/modules/boto_secgroup.py
@@ -51,7 +51,6 @@ import logging
 import re
 from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
 import salt.ext.six as six
-from salt.exceptions import SaltInvocationError, CommandExecutionError
 
 log = logging.getLogger(__name__)
 

--- a/salt/modules/boto_secgroup.py
+++ b/salt/modules/boto_secgroup.py
@@ -535,7 +535,6 @@ def _check_vpc(vpc_id, vpc_name, region, key, keyid, profile):
     '''
 
     if not _exactly_one((vpc_name, vpc_id)):
-        log.debug('EXISTS: {} , {}'.format(vpc_id, vpc_name))
         raise SaltInvocationError('One (but not both) of vpc_id or vpc_name '
                                   'must be provided.')
     if vpc_name:

--- a/salt/modules/boto_secgroup.py
+++ b/salt/modules/boto_secgroup.py
@@ -141,7 +141,8 @@ def _get_group(conn, name=None, vpc_id=None, group_id=None, region=None,
     return None.
     '''
     if name:
-        vpc_id = _check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
+        if vpc_name:
+            vpc_id = _check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
         if vpc_id is None:
             log.debug('getting group for {0}'.format(name))
             group_filter = {'group-name': name}
@@ -306,7 +307,8 @@ def create(name, description, vpc_id=None, region=None, key=None, keyid=None,
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
-    vpc_id = _check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
+    if vpc_name:
+        vpc_id = _check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
     created = conn.create_security_group(name, description, vpc_id)
     if created:
         log.info('Created security group {0}.'.format(name))

--- a/salt/modules/boto_secgroup.py
+++ b/salt/modules/boto_secgroup.py
@@ -51,6 +51,7 @@ import logging
 import re
 from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
 import salt.ext.six as six
+from salt.exceptions import SaltInvocationError, CommandExecutionError
 
 log = logging.getLogger(__name__)
 
@@ -89,7 +90,7 @@ def __virtual__():
 
 
 def exists(name=None, region=None, key=None, keyid=None, profile=None,
-           vpc_id=None, group_id=None):
+           vpc_id=None, group_id=None, vpc_name=None):
     '''
     Check to see if an security group exists.
 
@@ -99,7 +100,8 @@ def exists(name=None, region=None, key=None, keyid=None, profile=None,
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
-    group = _get_group(conn, name, vpc_id, group_id, region)
+    group = _get_group(conn, name, vpc_id, group_id, region, vpc_name,
+                       key, keyid, profile)
     if group:
         return True
     else:
@@ -131,13 +133,15 @@ def _split_rules(rules):
     return split
 
 
-def _get_group(conn, name=None, vpc_id=None, group_id=None, region=None):  # pylint: disable=W0613
+def _get_group(conn, name=None, vpc_id=None, group_id=None, region=None,
+               vpc_name=None, key=None, keyid=None, profile=None):  # pylint: disable=W0613
     '''
     Get a group object given a name, name and vpc_id or group_id. Return a
     boto.ec2.securitygroup.SecurityGroup object if the group is found, else
     return None.
     '''
     if name:
+        vpc_id = _check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
         if vpc_id is None:
             log.debug('getting group for {0}'.format(name))
             group_filter = {'group-name': name}
@@ -211,7 +215,8 @@ def _parse_rules(sg, rules):
     return _rules
 
 
-def get_group_id(name, vpc_id=None, region=None, key=None, keyid=None, profile=None):
+def get_group_id(name, vpc_id=None, region=None, key=None, keyid=None,
+                 profile=None, vpc_name=None):
     '''
     Get a Group ID given a Group Name or Group Name and VPC ID
 
@@ -221,15 +226,16 @@ def get_group_id(name, vpc_id=None, region=None, key=None, keyid=None, profile=N
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
-    group = _get_group(conn, name, vpc_id, region)
+    group = _get_group(conn, name, vpc_id, region, vpc_name, key, keyid,
+                       profile)
     if group:
         return group.id
     else:
         return False
 
 
-def convert_to_group_ids(groups, vpc_id, region=None, key=None, keyid=None,
-                         profile=None):
+def convert_to_group_ids(groups, vpc_id=None, region=None, key=None, keyid=None,
+                         profile=None, vpc_name=None):
     '''
     Given a list of security groups and a vpc_id, convert_to_group_ids will
     convert all list items in the given list to security group ids.
@@ -248,7 +254,8 @@ def convert_to_group_ids(groups, vpc_id, region=None, key=None, keyid=None,
         else:
             log.debug('calling boto_secgroup.get_group_id for'
                       ' group name {0}'.format(group))
-            group_id = get_group_id(group, vpc_id, region, key, keyid, profile)
+            group_id = get_group_id(group, vpc_id, region, key, keyid,
+                                    profile, vpc_name)
             log.debug('group name {0} has group id {1}'.format(
                 group, group_id)
             )
@@ -258,7 +265,7 @@ def convert_to_group_ids(groups, vpc_id, region=None, key=None, keyid=None,
 
 
 def get_config(name=None, group_id=None, region=None, key=None, keyid=None,
-               profile=None, vpc_id=None):
+               profile=None, vpc_id=None, vpc_name=None):
     '''
     Get the configuration for a security group.
 
@@ -268,7 +275,8 @@ def get_config(name=None, group_id=None, region=None, key=None, keyid=None,
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
-    sg = _get_group(conn, name, vpc_id, group_id, region)
+    sg = _get_group(conn, name, vpc_id, group_id, region, vpc_name, key,
+                    keyid, profile)
     if sg:
         ret = odict.OrderedDict()
         ret['name'] = sg.name
@@ -288,7 +296,7 @@ def get_config(name=None, group_id=None, region=None, key=None, keyid=None,
 
 
 def create(name, description, vpc_id=None, region=None, key=None, keyid=None,
-           profile=None):
+           profile=None, vpc_name=None):
     '''
     Create a security group.
 
@@ -298,6 +306,7 @@ def create(name, description, vpc_id=None, region=None, key=None, keyid=None,
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
+    vpc_id = _check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
     created = conn.create_security_group(name, description, vpc_id)
     if created:
         log.info('Created security group {0}.'.format(name))
@@ -309,7 +318,7 @@ def create(name, description, vpc_id=None, region=None, key=None, keyid=None,
 
 
 def delete(name=None, group_id=None, region=None, key=None, keyid=None,
-           profile=None, vpc_id=None):
+           profile=None, vpc_id=None, vpc_name=None):
     '''
     Delete a security group.
 
@@ -319,7 +328,8 @@ def delete(name=None, group_id=None, region=None, key=None, keyid=None,
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
-    group = _get_group(conn, name, vpc_id, group_id, region)
+    group = _get_group(conn, name, vpc_id, group_id, region, vpc_name,
+                       key, keyid, profile)
     if group:
         deleted = conn.delete_security_group(group_id=group.id)
         if deleted:
@@ -339,7 +349,8 @@ def authorize(name=None, source_group_name=None,
               source_group_owner_id=None, ip_protocol=None,
               from_port=None, to_port=None, cidr_ip=None, group_id=None,
               source_group_group_id=None, region=None, key=None,
-              keyid=None, profile=None, vpc_id=None, egress=False):
+              keyid=None, profile=None, vpc_id=None, egress=False,
+              vpc_name=None):
     '''
     Add a new rule to an existing security group.
 
@@ -349,7 +360,8 @@ def authorize(name=None, source_group_name=None,
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
-    group = _get_group(conn, name, vpc_id, group_id, region)
+    group = _get_group(conn, name, vpc_id, group_id, region, vpc_name,
+                       key, keyid, profile)
     if group:
         try:
             added = None
@@ -389,7 +401,8 @@ def revoke(name=None, source_group_name=None,
            source_group_owner_id=None, ip_protocol=None,
            from_port=None, to_port=None, cidr_ip=None, group_id=None,
            source_group_group_id=None, region=None, key=None,
-           keyid=None, profile=None, vpc_id=None, egress=False):
+           keyid=None, profile=None, vpc_id=None, egress=False,
+           vpc_name=None):
     '''
     Remove a rule from an existing security group.
 
@@ -399,7 +412,8 @@ def revoke(name=None, source_group_name=None,
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
-    group = _get_group(conn, name, vpc_id, group_id, region)
+    group = _get_group(conn, name, vpc_id, group_id, region, vpc_name,
+                       key, keyid, profile)
     if group:
         try:
             revoked = None
@@ -434,3 +448,101 @@ def revoke(name=None, source_group_name=None,
     else:
         log.debug('Failed to remove rule from security group.')
         return False
+
+
+def _find_vpcs(vpc_id=None, vpc_name=None, cidr=None, tags=None,
+               region=None, key=None, keyid=None, profile=None):
+
+    '''
+    Given VPC properties, find and return matching VPC ids.
+    Borrowed from boto_vpc; these could be refactored into a common library
+    '''
+
+    if all((vpc_id, vpc_name)):
+        raise SaltInvocationError('Only one of vpc_name or vpc_id may be '
+                                  'provided.')
+
+    if not any((vpc_id, vpc_name, tags, cidr)):
+        raise SaltInvocationError('At least one of the following must be '
+                                  'provided: vpc_id, vpc_name, cidr or tags.')
+
+    local_get_conn = __utils__['boto.get_connection_func']('vpc')
+    conn = local_get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    filter_parameters = {'filters': {}}
+
+    if vpc_id:
+        filter_parameters['vpc_ids'] = [vpc_id]
+
+    if cidr:
+        filter_parameters['filters']['cidr'] = cidr
+
+    if vpc_name:
+        filter_parameters['filters']['tag:Name'] = vpc_name
+
+    if tags:
+        for tag_name, tag_value in six.iteritems(tags):
+            filter_parameters['filters']['tag:{0}'.format(tag_name)] = tag_value
+
+    vpcs = conn.get_all_vpcs(**filter_parameters)
+    log.debug('The filters criteria {0} matched the following VPCs:{1}'.format(filter_parameters, vpcs))
+
+    if vpcs:
+        return [vpc.id for vpc in vpcs]
+    else:
+        return []
+
+
+def _get_id(vpc_name=None, cidr=None, tags=None, region=None, key=None,
+            keyid=None, profile=None):
+    '''
+    Given VPC properties, return the VPC id if a match is found.
+    Borrowed from boto_vpc; these could be refactored into a common library
+    '''
+
+    if vpc_name and not any((cidr, tags)):
+        vpc_id = _cache_id(vpc_name, region=region,
+                           key=key, keyid=keyid,
+                           profile=profile)
+        if vpc_id:
+            return vpc_id
+
+    vpc_ids = _find_vpcs(vpc_name=vpc_name, cidr=cidr, tags=tags, region=region,
+                         key=key, keyid=keyid, profile=profile)
+    if vpc_ids:
+        log.info("Matching VPC: {0}".format(" ".join(vpc_ids)))
+        if len(vpc_ids) == 1:
+            vpc_id = vpc_ids[0]
+            if vpc_name:
+                _cache_id(vpc_name, vpc_id,
+                          region=region, key=key,
+                          keyid=keyid, profile=profile)
+            return vpc_id
+        else:
+            raise CommandExecutionError('Found more than one VPC matching the criteria.')
+    else:
+        log.info('No VPC found.')
+        return None
+
+
+def _check_vpc(vpc_id, vpc_name, region, key, keyid, profile):
+    '''
+    Check whether a VPC with the given name or id exists.
+    Returns the vpc_id or None. Raises SaltInvocationError if
+    both vpc_id and vpc_name are None. Optionally raise a
+    CommandExecutionError if the VPC does not exist.
+
+    Borrowed from boto_vpc; these could be refactored into a common library
+    '''
+
+    if not _exactly_one((vpc_name, vpc_id)):
+        log.debug('EXISTS: {} , {}'.format(vpc_id, vpc_name))
+        raise SaltInvocationError('One (but not both) of vpc_id or vpc_name '
+                                  'must be provided.')
+    if vpc_name:
+        vpc_id = _get_id(vpc_name=vpc_name, region=region, key=key, keyid=keyid,
+                         profile=profile)
+    elif not _find_vpcs(vpc_id=vpc_id, region=region, key=key, keyid=keyid,
+                        profile=profile):
+        log.info('VPC {0} does not exist.'.format(vpc_id))
+        return None
+    return vpc_id

--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -131,7 +131,8 @@ def __init__(opts):
         __utils__['boto.assign_funcs'](__name__, 'vpc')
 
 
-def check_vpc(vpc_id, vpc_name, region, key, keyid, profile):
+def check_vpc(vpc_id=None, vpc_name=None, region=None, key=None, keyid=None,
+              profile=None):
     '''
     Check whether a VPC with the given name or id exists.
     Returns the vpc_id or None. Raises SaltInvocationError if

--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -138,6 +138,12 @@ def check_vpc(vpc_id=None, vpc_name=None, region=None, key=None, keyid=None,
     Returns the vpc_id or None. Raises SaltInvocationError if
     both vpc_id and vpc_name are None. Optionally raise a
     CommandExecutionError if the VPC does not exist.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_vpc.check_vpc vpc_name=myvpc profile=awsprofile
     '''
 
     if not _exactly_one((vpc_name, vpc_id)):

--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -131,7 +131,7 @@ def __init__(opts):
         __utils__['boto.assign_funcs'](__name__, 'vpc')
 
 
-def _check_vpc(vpc_id, vpc_name, region, key, keyid, profile):
+def check_vpc(vpc_id, vpc_name, region, key, keyid, profile):
     '''
     Check whether a VPC with the given name or id exists.
     Returns the vpc_id or None. Raises SaltInvocationError if
@@ -633,7 +633,7 @@ def describe(vpc_id=None, vpc_name=None, region=None, key=None,
 
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-        vpc_id = _check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
+        vpc_id = check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
         if not vpc_id:
             return {'vpc': None}
 
@@ -768,7 +768,7 @@ def create_subnet(vpc_id=None, cidr_block=None, vpc_name=None,
     '''
 
     try:
-        vpc_id = _check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
+        vpc_id = check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
         if not vpc_id:
             return {'created': False, 'error': {'message': 'VPC {0} does not exist.'.format(vpc_name or vpc_id)}}
     except BotoServerError as e:
@@ -1026,7 +1026,7 @@ def create_internet_gateway(internet_gateway_name=None, vpc_id=None,
 
     try:
         if vpc_id or vpc_name:
-            vpc_id = _check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
+            vpc_id = check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
             if not vpc_id:
                 return {'created': False,
                         'error': {'message': 'VPC {0} does not exist.'.format(vpc_name or vpc_id)}}
@@ -1196,7 +1196,7 @@ def create_dhcp_options(domain_name=None, domain_name_servers=None, ntp_servers=
 
     try:
         if vpc_id or vpc_name:
-            vpc_id = _check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
+            vpc_id = check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
             if not vpc_id:
                 return {'created': False,
                         'error': {'message': 'VPC {0} does not exist.'.format(vpc_name or vpc_id)}}
@@ -1254,7 +1254,7 @@ def associate_dhcp_options_to_vpc(dhcp_options_id, vpc_id=None, vpc_name=None,
 
     '''
     try:
-        vpc_id = _check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
+        vpc_id = check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
         if not vpc_id:
             return {'associated': False,
                     'error': {'message': 'VPC {0} does not exist.'.format(vpc_name or vpc_id)}}
@@ -1352,7 +1352,7 @@ def create_network_acl(vpc_id=None, vpc_name=None, network_acl_name=None,
     _id = vpc_name or vpc_id
 
     try:
-        vpc_id = _check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
+        vpc_id = check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
     except BotoServerError as e:
         return {'created': False, 'error': salt.utils.boto.get_error(e)}
 
@@ -1563,7 +1563,7 @@ def disassociate_network_acl(subnet_id=None, vpc_id=None, subnet_name=None, vpc_
                         'error': {'message': 'Subnet {0} does not exist.'.format(subnet_name)}}
 
         if vpc_name or vpc_id:
-            vpc_id = _check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
+            vpc_id = check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
 
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         association_id = conn.disassociate_network_acl(subnet_id, vpc_id=vpc_id)
@@ -1725,7 +1725,7 @@ def create_route_table(vpc_id=None, vpc_name=None, route_table_name=None,
         salt myminion boto_vpc.create_route_table vpc_name='myvpc' \\
                 route_table_name='myroutetable'
     '''
-    vpc_id = _check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
+    vpc_id = check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
     if not vpc_id:
         return {'created': False, 'error': {'message': 'VPC {0} does not exist.'.format(vpc_name or vpc_id)}}
 

--- a/salt/states/boto_secgroup.py
+++ b/salt/states/boto_secgroup.py
@@ -109,7 +109,8 @@ def present(
         region=None,
         key=None,
         keyid=None,
-        profile=None):
+        profile=None,
+        vpc_name=None):
     '''
     Ensure the security group exists with the specified rules.
 
@@ -121,6 +122,9 @@ def present(
 
     vpc_id
         The ID of the VPC to create the security group in, if any.
+
+    vpc_name
+        The name of the VPC to create the security group in, if any.
 
     rules
         A list of ingress rule dicts.
@@ -143,7 +147,7 @@ def present(
     '''
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     _ret = _security_group_present(name, description, vpc_id, region, key,
-                                   keyid, profile)
+                                   keyid, profile, vpc_name)
     ret['changes'] = _ret['changes']
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
     if not _ret['result']:
@@ -154,7 +158,8 @@ def present(
         rules = []
     if not rules_egress:
         rules_egress = []
-    _ret = _rules_present(name, rules, rules_egress, vpc_id, region, key, keyid, profile)
+    _ret = _rules_present(name, rules, rules_egress, vpc_id, region, key,
+                          keyid, profile, vpc_name)
     ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
     if not _ret['result']:
@@ -165,20 +170,22 @@ def present(
 def _security_group_present(
         name,
         description,
-        vpc_id,
-        region,
-        key,
-        keyid,
-        profile):
+        vpc_id=None,
+        region=None,
+        key=None,
+        keyid=None,
+        profile=None,
+        vpc_name=None):
     '''
-    given a group name or a group name and vpc id:
+    given a group name or a group name and vpc id (or vpc name):
     1. determine if the group exists
     2. if the group does not exist, creates the group
     3. return the group's configuration and any changes made
     '''
     ret = {'result': True, 'comment': '', 'changes': {}}
     exists = __salt__['boto_secgroup.exists'](name, region, key, keyid,
-                                              profile, vpc_id)
+                                              profile, vpc_id,
+                                              vpc_name=vpc_name)
     if not exists:
         if __opts__['test']:
             msg = 'Security group {0} is set to be created.'.format(name)
@@ -186,11 +193,13 @@ def _security_group_present(
             ret['result'] = None
             return ret
         created = __salt__['boto_secgroup.create'](name, description, vpc_id,
-                                                   region, key, keyid, profile)
+                                                   region, key, keyid, profile,
+                                                   vpc_name)
         if created:
             ret['changes']['old'] = {'secgroup': None}
             sg = __salt__['boto_secgroup.get_config'](name, None, region, key,
-                                                      keyid, profile, vpc_id)
+                                                      keyid, profile, vpc_id,
+                                                      vpc_name)
             ret['changes']['new'] = {'secgroup': sg}
             ret['comment'] = 'Security group {0} created.'.format(name)
         else:
@@ -339,13 +348,14 @@ def _rules_present(
         name,
         rules,
         rules_egress,
-        vpc_id,
-        region,
-        key,
-        keyid,
-        profile):
+        vpc_id=None,
+        region=None,
+        key=None,
+        keyid=None,
+        profile=None,
+        vpc_name=None):
     '''
-    given a group name or group name and vpc_id:
+    given a group name or group name and vpc_id (or vpc name):
     1. get lists of desired rule changes (using _get_rule_changes)
     2. delete/revoke or authorize/create rules
     3. return 'old' and 'new' group rules
@@ -354,7 +364,7 @@ def _rules_present(
 
     ret = {'result': True, 'comment': '', 'changes': {}}
     sg = __salt__['boto_secgroup.get_config'](name, None, region, key, keyid,
-                                              profile, vpc_id)
+                                              profile, vpc_id, vpc_name)
     if not sg:
         msg = '{0} security group configuration could not be retrieved.'
         ret['comment'] = msg.format(name)
@@ -362,12 +372,13 @@ def _rules_present(
         return ret
     rules = _split_rules(rules)
     rules_egress = _split_rules(rules_egress)
-    if vpc_id:
+    if vpc_id or vpc_name:
         for rule in itertools.chain(rules, rules_egress):
             _source_group_name = rule.get('source_group_name', None)
             if _source_group_name:
                 _group_id = __salt__['boto_secgroup.get_group_id'](
-                    _source_group_name, vpc_id, region, key, keyid, profile
+                    _source_group_name, vpc_id, region, key, keyid, profile,
+                    vpc_name
                 )
                 if not _group_id:
                     msg = ('source_group_name {0} does not map to a valid'
@@ -390,7 +401,7 @@ def _rules_present(
             for rule in to_delete:
                 _deleted = __salt__['boto_secgroup.revoke'](
                     name, vpc_id=vpc_id, region=region, key=key, keyid=keyid,
-                    profile=profile, **rule)
+                    profile=profile, vpc_name=vpc_name, **rule)
                 if not _deleted:
                     deleted = False
             if deleted:
@@ -405,7 +416,7 @@ def _rules_present(
             for rule in to_create:
                 _created = __salt__['boto_secgroup.authorize'](
                     name, vpc_id=vpc_id, region=region, key=key, keyid=keyid,
-                    profile=profile, **rule)
+                    profile=profile, vpc_name=vpc_name, **rule)
                 if not _created:
                     created = False
             if created:
@@ -421,7 +432,7 @@ def _rules_present(
             for rule in to_delete_egress:
                 _deleted = __salt__['boto_secgroup.revoke'](
                     name, vpc_id=vpc_id, region=region, key=key, keyid=keyid,
-                    profile=profile, egress=True, **rule)
+                    profile=profile, egress=True, vpc_name=vpc_name, **rule)
                 if not _deleted:
                     deleted = False
             if deleted:
@@ -437,7 +448,7 @@ def _rules_present(
             for rule in to_create_egress:
                 _created = __salt__['boto_secgroup.authorize'](
                     name, vpc_id=vpc_id, region=region, key=key, keyid=keyid,
-                    profile=profile, egress=True, **rule)
+                    profile=profile, egress=True, vpc_name=vpc_name, **rule)
                 if not _created:
                     created = False
             if created:
@@ -450,7 +461,8 @@ def _rules_present(
 
         ret['changes']['old'] = {'rules': sg['rules'], 'rules_egress': sg['rules_egress']}
         sg = __salt__['boto_secgroup.get_config'](name, None, region, key,
-                                                  keyid, profile, vpc_id)
+                                                  keyid, profile, vpc_id,
+                                                  vpc_name)
         ret['changes']['new'] = {'rules': sg['rules'], 'rules_egress': sg['rules_egress']}
     return ret
 
@@ -461,7 +473,8 @@ def absent(
         region=None,
         key=None,
         keyid=None,
-        profile=None):
+        profile=None,
+        vpc_name=None):
     '''
     Ensure a security group with the specified name does not exist.
 
@@ -470,6 +483,9 @@ def absent(
 
     vpc_id
         The ID of the VPC to create the security group in, if any.
+
+    vpc_name
+        The name of the VPC to create the security group in, if any.
 
     region
         Region to connect to.
@@ -487,7 +503,7 @@ def absent(
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
 
     sg = __salt__['boto_secgroup.get_config'](name, True, region, key, keyid,
-                                              profile, vpc_id)
+                                              profile, vpc_id, vpc_name)
     if sg:
         if __opts__['test']:
             msg = 'Security group {0} is set to be removed.'.format(name)
@@ -495,7 +511,8 @@ def absent(
             ret['result'] = None
             return ret
         deleted = __salt__['boto_secgroup.delete'](name, None, region, key,
-                                                   keyid, profile, vpc_id)
+                                                   keyid, profile, vpc_id,
+                                                   vpc_name)
         if deleted:
             ret['changes']['old'] = {'secgroup': sg}
             ret['changes']['new'] = {'secgroup': None}


### PR DESCRIPTION
When creating a VPC with `boto_vpc.present`, the remote end (the AWS API) determines the `vpc_id`. To make further additions in `boto_vpc`, you can use the `vpc_name` instead of the `vpc_id` because the `vpc_id` is not known (declaratively).

Unfortunately, this functionality was missing from `boto_secgroup`, which expected `vpc_id` only. Since we create VPCs with `boto_vpc`, it's not possible to know the `vpc_id` in our salt states (when writing declarative states). Thus, we need to be able to provide the `vpc_name`.

This patch allows for `vpc_name`.
