### PR TITLE
Fix service.enable for masked services

### DIFF
--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -407,6 +407,22 @@ def mask(name):
     return not __salt__['cmd.retcode'](_systemctl_cmd('mask', name))
 
 
+def masked(name):
+    '''
+    Return if the named service is masked
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.masked <service name>
+    '''
+    if _untracked_custom_unit_found(name) or _unit_file_changed(name):
+        systemctl_reload()
+    out = __salt__['cmd.run_all'](_systemctl_cmd('is-enabled', name), ignore_retcode=True)
+    return out['retcode'] == 1 and 'masked' in out['stdout']
+
+
 def start(name):
     '''
     Start the specified service with systemd
@@ -513,6 +529,8 @@ def enable(name, **kwargs):
     '''
     if _untracked_custom_unit_found(name) or _unit_file_changed(name):
         systemctl_reload()
+    if masked(name):
+        unmask(name)
     if _service_is_sysv(name):
         executable = _get_service_exec()
         cmd = '{0} -f {1} defaults 99'.format(executable, name)

--- a/tests/unit/modules/systemd_test.py
+++ b/tests/unit/modules/systemd_test.py
@@ -196,13 +196,20 @@ class SystemdTestCase(TestCase):
         exe = MagicMock(return_value='foo')
         tmock = MagicMock(return_value=True)
         mock = MagicMock(return_value=False)
+        disabled_mock = MagicMock(return_value={'retcode': 1, 'stdout': 'disabled', 'stderr': ''})
+        masked_mock = MagicMock(return_value={'retcode': 1, 'stdout': 'masked', 'stderr': ''})
         with patch.object(systemd, '_untracked_custom_unit_found', mock):
             with patch.object(systemd, '_unit_file_changed', mock):
                 with patch.dict(systemd.__salt__, {'cmd.retcode': mock}):
-                    with patch.object(systemd, "_service_is_sysv", mock):
-                        self.assertTrue(systemd.enable("sshd"))
-                    with patch.object(systemd, "_get_service_exec", exe):
-                        with patch.object(systemd, "_service_is_sysv", tmock):
+                    with patch.dict(systemd.__salt__, {'cmd.run_all': disabled_mock}):
+                        with patch.object(systemd, "_service_is_sysv", mock):
+                            self.assertTrue(systemd.enable("sshd"))
+                        with patch.object(systemd, "_get_service_exec", exe):
+                            with patch.object(systemd, "_service_is_sysv", tmock):
+                                self.assertTrue(systemd.enable("sshd"))
+
+                    with patch.dict(systemd.__salt__, {'cmd.run_all': masked_mock}):
+                        with patch.object(systemd, "_service_is_sysv", mock):
                             self.assertTrue(systemd.enable("sshd"))
 
     def test_disable(self):


### PR DESCRIPTION
**Bug:** `service.enable` fails for masked services

**Steps to reproduce:**

``` sh
$ salt-call --version
salt-call 2015.8.0-260-g909556a (Beryllium)

$ lsb_release -rd
Description:    Ubuntu 15.04
Release:    15.04

$ apt-get install ntp
$ systemctl mask ntp
Created symlink from /etc/systemd/system/ntp.service to /dev/null.

$ salt-call service.enable ntp
[ERROR   ] output: Synchronizing state for ntp.service with sysvinit using update-rc.d...
Executing /usr/sbin/update-rc.d ntp defaults
insserv: warning: current start runlevel(s) (empty) of script `ntp' overrides LSB defaults (2 3 4 5).
insserv: warning: current stop runlevel(s) (1 2 3 4 5) of script `ntp' overrides LSB defaults (1).
Executing /usr/sbin/update-rc.d ntp enable
Failed to execute operation: Operation not supported
```
