### PR TITLE
Removed salt-master role requirement

### DIFF
--- a/salt/states/winrepo.py
+++ b/salt/states/winrepo.py
@@ -20,15 +20,7 @@ import salt.config
 
 
 def __virtual__():
-    '''
-    Load this state if this is the salt-master
-    '''
-    try:
-        return ('winrepo'
-                if 'salt-master' in __grains__.get('roles', [])
-                else False)
-    except TypeError:
-        return False
+    return 'winrepo'
 
 
 def genrepo(name, force=False, allow_empty=False):


### PR DESCRIPTION
Needs to be able to run on masterless minion.
Fixes: #25562
Fixes: #25801
