### PR TITLE
fix bug in sysrc to allow for empty rc variables

### DIFF
--- a/salt/modules/sysrc.py
+++ b/salt/modules/sysrc.py
@@ -60,9 +60,14 @@ def get(**kwargs):
 
     ret = {}
     for sysrc in sysrcs.split("\n"):
-        rcfile = sysrc.split(': ')[0]
-        var = sysrc.split(': ')[1]
-        val = sysrc.split(': ')[2]
+        line_components = sysrc.split(': ')
+        rcfile = line_components[0]
+        if len(line_components) > 2:
+            var = line_components[1]
+            val = line_components[2]
+        else:
+            var = line_components[1].rstrip(':')
+            val = ''
         if rcfile not in ret:
             ret[rcfile] = {}
         ret[rcfile][var] = val


### PR DESCRIPTION
/etc/defaults/rc.conf contains some empty variables, e.g. cloned_interfaces.
sysrc will return something like
'cloned_interfaces: '
when trying to set such an empty variables, an exception was raised.
Fixed by checking for empty variables.
