### PR TITLE
Fix s3 using IAM credentials

### DIFF
--- a/salt/utils/s3.py
+++ b/salt/utils/s3.py
@@ -88,9 +88,8 @@ def query(key, keyid, method='GET', params=None, headers=None,
 
     # Try grabbing the credentials from the EC2 instance IAM metadata if available
     if not key or not keyid:
-        iam_creds = iam.get_iam_metadata()
-        key = iam_creds['secret_key']
-        keyid = iam_creds['access_key']
+        key = salt.utils.aws.IROLE_CODE
+        keyid = salt.utils.aws.IROLE_CODE
 
     if not location:
         location = iam.get_iam_region()


### PR DESCRIPTION
Pass `salt.utils.aws.IROLE_CODE` as the access_key and secret_key to `salt.utils.aws.sig4` so that `sig4` grabs the full IAM credentials when it calls `salt.utils.aws.creds`.

Tested manually on my ec2 nodes. Fixes #26345.
