### PR TITLE
Load 'pkgng' as 'pkg' on FreeBSD 9 when `providers:pkg` == 'pkgng'

### DIFF
--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -95,7 +95,7 @@ def __virtual__():
         if 'providers' in __opts__:
             providers = __opts__['providers']
         if providers and 'pkg' in providers and providers['pkg'] == 'pkgng':
-            log.debug('Configuration option \'providers:pkg\' is set to '\
+            log.debug('Configuration option \'providers:pkg\' is set to '
                     '\'pkgng\', won\'t load old provider \'freebsdpkg\'.')
             return False
         return __virtualname__

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -86,9 +86,18 @@ __virtualname__ = 'pkg'
 
 def __virtual__():
     '''
-    Load as 'pkg' on FreeBSD versions less than 10
+    Load as 'pkg' on FreeBSD versions less than 10.
+    Don't load on FreeBSD 9 when the config option
+    ``providers:pkg`` is set to 'pkgng'.
     '''
     if __grains__['os'] == 'FreeBSD' and float(__grains__['osrelease']) < 10:
+        providers = {}
+        if 'providers' in __opts__:
+            providers = __opts__['providers']
+        if providers and 'pkg' in providers and providers['pkg'] == 'pkgng':
+            log.debug('Configuration option \'providers:pkg\' is set to '\
+                    '\'pkgng\', won\'t load old provider \'freebsdpkg\'.')
+            return False
         return __virtualname__
     return False
 

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -50,10 +50,22 @@ __virtualname__ = 'pkg'
 
 def __virtual__():
     '''
-    Load as 'pkg' on FreeBSD 10 and greater
+    Load as 'pkg' on FreeBSD 10 and greater.
+    Load as 'pkg' on FreeBSD 9 when config option
+    ``providers:pkg`` is set to 'pkgng'.
     '''
     if __grains__['os'] == 'FreeBSD' and float(__grains__['osrelease']) >= 10:
         return __virtualname__
+    if __grains__['os'] == 'FreeBSD' and \
+            float(__grains__['osmajorrelease']) == 9:
+        providers = {}
+        if 'providers' in __opts__:
+            providers = __opts__['providers']
+        log.debug('__opts__.providers: {0}'.format(providers))
+        if providers and 'pkg' in providers and providers['pkg'] == 'pkgng':
+            log.debug('Configuration option \'providers:pkg\' is set to ' \
+                '\'pkgng\', using \'pkgng\' in favor of \'freebsdpkg\'.')
+            return __virtualname__
     return False
 
 

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -63,7 +63,7 @@ def __virtual__():
             providers = __opts__['providers']
         log.debug('__opts__.providers: {0}'.format(providers))
         if providers and 'pkg' in providers and providers['pkg'] == 'pkgng':
-            log.debug('Configuration option \'providers:pkg\' is set to ' \
+            log.debug('Configuration option \'providers:pkg\' is set to '
                 '\'pkgng\', using \'pkgng\' in favor of \'freebsdpkg\'.')
             return __virtualname__
     return False


### PR DESCRIPTION
Both the docs of `freebsdpkg` and `pkgng` state adding the following 
would enable the `pkgng` provider for `pkg` on FreeBSD < 10:

``` yaml
providers:
  pkg: pkgng
```

I've added code actually doing this and tested it on FreeBSD 9 and 10.

Test-VMs:
- freebsd9: fresh FreeBSD 9 VM, salt installed from ports
- beasty3: outdated FreeBSD 9 VM, salt installed via pkg
- freebsd-server: up-to-date FreeBSD 10 VM, salt installed via pkg

Simple test based on the fact that `freebsdpkg` provides no `pkg.audit`:

```
floh@fuji-cyber200:~/:1818% sudo salt -G os:FreeBSD pkg.audit
freebsd9:
    'pkg.audit' is not available.
beasty3:
    vulnxml file up-to-date
    [...]    
    pcre-8.35_2 is vulnerable:
    pcre -- Heap Overflow Vulnerability in find_fixedlength()
    CVE: CVE-2015-5073
    WWW: https://vuxml.FreeBSD.org/freebsd/8a1d0e63-1e07-11e5-[...]

    1 problem(s) in the installed packages found.
freebsd-server:
    vulnxml file up-to-date
    0 problem(s) in the installed packages found.
user@master:~:1820% sudo salt freebsd9 cmd.run \
 "echo -e 'providers:\n    pkg: pkgng' | tee -a /usr/local/etc/salt/minion"
freebsd9:
    providers:
        pkg: pkgng
```

And after restarting the minion:

```
user@master:~:1832% sudo salt freebsd9 pkg.install tmux        
freebsd9:
    ----------
    libevent2:
        ----------
        new:
            2.0.22_1
        old:
    tmux:
        ----------
        new:
            2.0
        old:
user@master:~:1833% sudo salt freebsd9 pkg.audit
freebsd9:
    Fetching vuln.xml.bz2: .......... done
    0 problem(s) in the installed packages found.

```
