### PR TITLE
Call action on instance-id

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1454,10 +1454,13 @@ class Cloud(object):
                     if not names:
                         break
                     if vm_name not in names:
-                        log.debug('vm:{0} in provider:{1} is not in name list:{2!r}'.format(
-                            vm_name, driver, names
-                        ))
-                        continue
+                        if 'id' in vm_details and vm_details['id'] in names:
+                            vm_name = vm_details['id']
+                        else:
+                            log.debug('vm:{0} in provider:{1} is not in name list:{2!r}'.format(
+                                vm_name, driver, names
+                            ))
+                            continue
                     with context.func_globals_inject(
                         self.clouds[fun],
                         __active_provider_name__=':'.join([alias, driver])

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -3141,11 +3141,13 @@ def list_nodes_min(location=None, call=None):
             for item in instance['instancesSet']['item']:
                 state = item['instanceState']['name']
                 name = _extract_name_tag(item)
+                id = item['instanceId']
         else:
             item = instance['instancesSet']['item']
             state = item['instanceState']['name']
             name = _extract_name_tag(item)
-        ret[name] = {'state': state}
+            id = item['instanceId']
+        ret[name] = {'state': state, 'id': id}
     return ret
 
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2428,7 +2428,7 @@ def create_attach_volumes(name, kwargs, call=None, wait_to_finish=True):
         )
 
     if 'instance_id' not in kwargs:
-        kwargs['instance_id'] = _get_node(name)[name]['instanceId']
+        kwargs['instance_id'] = _get_node(name)['instanceId']
 
     if isinstance(kwargs['volumes'], str):
         volumes = yaml.safe_load(kwargs['volumes'])
@@ -2505,7 +2505,7 @@ def stop(name, call=None):
 
     log.info('Stopping node {0}'.format(name))
 
-    instance_id = _get_node(name)[name]['instanceId']
+    instance_id = _get_node(name)['instanceId']
 
     params = {'Action': 'StopInstances',
               'InstanceId.1': instance_id}
@@ -2529,7 +2529,7 @@ def start(name, call=None):
 
     log.info('Starting node {0}'.format(name))
 
-    instance_id = _get_node(name)[name]['instanceId']
+    instance_id = _get_node(name)['instanceId']
 
     params = {'Action': 'StartInstances',
               'InstanceId.1': instance_id}
@@ -2669,9 +2669,7 @@ def get_tags(name=None,
     if instance_id is None:
         if resource_id is None:
             if name:
-                instances = list_nodes_full(location)
-                if name in instances:
-                    instance_id = instances[name]['instanceId']
+                instance_id = _get_node(name)['instanceId']
             elif 'instance_id' in kwargs:
                 instance_id = kwargs['instance_id']
             elif 'resource_id' in kwargs:
@@ -2722,7 +2720,7 @@ def del_tags(name=None,
         del kwargs['resource_id']
 
     if not instance_id:
-        instance_id = _get_node(name)[name]['instanceId']
+        instance_id = _get_node(name)['instanceId']
 
     params = {'Action': 'DeleteTags',
               'ResourceId.1': instance_id}
@@ -2784,7 +2782,7 @@ def destroy(name, call=None):
         )
 
     node_metadata = _get_node(name)
-    instance_id = node_metadata[name]['instanceId']
+    instance_id = node_metadata['instanceId']
     sir_id = node_metadata.get('spotInstanceRequestId')
     protected = show_term_protect(
         name=name,
@@ -2878,7 +2876,7 @@ def reboot(name, call=None):
 
         salt-cloud -a reboot mymachine
     '''
-    instance_id = _get_node(name)[name]['instanceId']
+    instance_id = _get_node(name)['instanceId']
     params = {'Action': 'RebootInstances',
               'InstanceId.1': instance_id}
 
@@ -2981,7 +2979,7 @@ def _get_node(name=None, instance_id=None, location=None):
                                   provider=provider,
                                   opts=__opts__,
                                   sigver='4')
-            return _extract_instance_info(instances)
+            return _extract_instance_info(instances).values()[0]
         except KeyError:
             attempts -= 1
             log.debug(
@@ -3199,8 +3197,7 @@ def show_term_protect(name=None, instance_id=None, call=None, quiet=False):
         )
 
     if not instance_id:
-        instances = list_nodes_full(get_location())
-        instance_id = instances[name]['instanceId']
+        instance_id = _get_node(name)['instanceId']
     params = {'Action': 'DescribeInstanceAttribute',
               'InstanceId': instance_id,
               'Attribute': 'disableApiTermination'}
@@ -3276,8 +3273,7 @@ def _toggle_term_protect(name, value):
 
         salt-cloud -a disable_term_protect mymachine
     '''
-    instances = list_nodes_full(get_location())
-    instance_id = instances[name]['instanceId']
+    instance_id = _get_node(name)['instanceId']
     params = {'Action': 'ModifyInstanceAttribute',
               'InstanceId': instance_id,
               'DisableApiTermination.Value': value}
@@ -3317,8 +3313,7 @@ def show_delvol_on_destroy(name, kwargs=None, call=None):
     volume_id = kwargs.get('volume_id', None)
 
     if instance_id is None:
-        instances = list_nodes_full()
-        instance_id = instances[name]['instanceId']
+        instance_id = _get_node(name)['instanceId']
 
     params = {'Action': 'DescribeInstances',
               'InstanceId.1': instance_id}
@@ -3410,8 +3405,7 @@ def _toggle_delvol(name=None, instance_id=None, device=None, volume_id=None,
                    value=None, requesturl=None):
 
     if not instance_id:
-        instances = list_nodes_full(get_location())
-        instance_id = instances[name]['instanceId']
+        instance_id = _get_node(name)['instanceId']
 
     if requesturl:
         data = aws.query(requesturl=requesturl,
@@ -3561,8 +3555,7 @@ def attach_volume(name=None, kwargs=None, instance_id=None, call=None):
         instance_id = kwargs['instance_id']
 
     if name and not instance_id:
-        instances = list_nodes_full(get_location())
-        instance_id = instances[name]['instanceId']
+        instance_id = _get_node(name)['instanceId']
 
     if not name and not instance_id:
         log.error('Either a name or an instance_id is required.')
@@ -3987,7 +3980,7 @@ def get_console_output(
         location = get_location()
 
     if not instance_id:
-        instance_id = _get_node(name)[name]['instanceId']
+        instance_id = _get_node(name)['instanceId']
 
     if kwargs is None:
         kwargs = {}
@@ -4049,7 +4042,7 @@ def get_password_data(
         )
 
     if not instance_id:
-        instance_id = _get_node(name)[name]['instanceId']
+        instance_id = _get_node(name)['instanceId']
 
     if kwargs is None:
         kwargs = {}


### PR DESCRIPTION
Back in my misguided pull request https://github.com/saltstack/salt/pull/24485 @techhat and @rallytime commented that calling an action on instance-id should be possible. The design of ec2.py driver shows this in some places. For example, the _get_node function explicitly checks for something formatted like instance-id and returns the correct instance. But salt currently stops short of actually supporting it.

This pull request attempts to make the changes necessary to support calling action on instance-id. I'm not an experienced programmer nor am I very familiar with the salt code, so please review carefully before merging.

This pull request makes the following changes:
1. In salt/cloud/__init__.py: Pass instance-id on to the ec2 driver.
   
   Consider two instances with the same name tag but different IDs, i-12345678 and i-98765432. The user passes in i-12345678. We should _never_, under any circumstance, operate on i-98765432 if the user explicitly passed i-12345678. So we shouldn't resolve instance-id to name and then pass the name to the driver, but rather pass the instance-id on to the driver.
2. Pass instance-id as name rather than separate parameter.
   
   Some actions and functions already accept an instance-id as parameter, but most actions/functions in ec2.py call _get_node(name) to obtain the instance information. Since _get_node already supports resolving an instance-id, it seems easiest to just pass in the instance-id as name, everything will just work.
   
   Unfortunately, _get_node returns returns a dict with ret[name] = instance_info. Calling _get_node(name)[name], with name an instance ID, for example: _get_node("i-12345678")["i-12345678"] doesn't work, because the dict key would be the instance name, not the instance-id. So...
3. Make _get_node return an instance directly, rather than a dict of instances.
   
   _get_node seems to be designed to return information about a single instance only. So it is not necessary to return a dict {name : instance_info}, we can return instance_info directly. Then calls can be changed from _get_node(name)[name] to just _get_node(name) which will still work if name is an instance-id.
   
   There are two other functions that call _get_node and then pass the returning object on to another function outside ec2.py. One is queue_instances, which calls
   
   ```
   node = _get_node(instance_id=instance_id)
   salt.utils.cloud.cache_node(node, __active_provider_name__, __opts__)
   ```
   
   Correct me if I'm wrong, but here cache_node expects instance_info directly, not {name : instance_info}. There is another function, cache_node_list, which expects a dict {name1: info1, name2: info2} etc. So the _get_node change here is not a problem (even a fix?). Although I'm not sure I understand how the cache works.
   
   The other function is show_instance. This is more problematic because it is an **api breaking change**.
   
   Consider this test program:
   
   ```
   import salt.cloud
   import json
   
   client = salt.cloud.CloudClient(path='/etc/salt/cloud')
   ret = client.action(fun="show_instance",names=["instancename"])
   print(json.dumps(ret, indent=4))
   ```
   
   Currently, it returns:
   
   ```
   {
       "ec2-ireland-test": {
           "ec2": {
               "instancename": {
                   "instancename": {
                        INSTANCE_INFO
                   }
                }
           }
       }
   }
   ```
   
   After the _get_node change in this pull request, it returns:
   
   ```
   {
       "ec2-ireland-test": {
           "ec2": {
               "instancename": {
                   INSTANCE_INFO
                }
            }
       }
   }
   ```
   
   I would argue that the bottom one is better, there is no need for the double instancename nesting. But this is still an API breaking change.
4. Turn list_nodes_full calls into _get_node calls.
   
   There are still some actions and functions in ec2.py, that figure out a node's instance-id as follows:
   
   ```
   instances = list_nodes_full(get_location())
   instance_id = instances[name]['instanceId']
   ```
   
   I have turned these into:
   
   ```
   instance_id = _get_node(name)['instanceId']
   ```
   
   So they too can benefit from _get_node's ability to handle the name-is-an-instance-id condition.

Feedback appreciated. Thanks!
