### PR TITLE
use the same quotes as the join

### DIFF
--- a/salt/queues/sqlite_queue.py
+++ b/salt/queues/sqlite_queue.py
@@ -212,7 +212,7 @@ def pop(queue, quantity=1):
             items = [item[0] for item in result]
             itemlist = '","'.join(items)
             _quote_escape(itemlist)
-            del_cmd = '''DELETE FROM {0} WHERE name IN ('{1}')'''.format(
+            del_cmd = '''DELETE FROM {0} WHERE name IN ("{1}")'''.format(
                 queue, itemlist)
 
             log.debug('SQL Query: {0}'.format(del_cmd))


### PR DESCRIPTION
fixes #26351

broken here https://github.com/saltstack/salt/commit/d2629c138f05b186dded6f8f3b2f09b135800f57 so it needs to be backported to 2015.8 as well

accidentally force pushed over the old one, so I am recreating it.
