### PR TITLE
Fix EC2 credentials from IAM roles for s3fs and s3 ext_pillar in 2015.5

### DIFF
--- a/salt/pillar/s3.py
+++ b/salt/pillar/s3.py
@@ -21,10 +21,11 @@ options
 The ``bucket`` parameter specifies the target S3 bucket. It is required.
 
 The ``keyid`` parameter specifies the key id to use when access the S3 bucket.
-It is required.
+If it is not provided, an attempt to fetch it from EC2 instance meta-data will
+be made.
 
-The ``key`` parameter specifies the key to use when access the S3 bucket. It
-is required.
+The ``key`` parameter specifies the key to use when access the S3 bucket. If it
+is not provided, an attempt to fetch it from EC2 instance meta-data will be made.
 
 The ``multiple_env`` defaults to False. It specifies whether the pillar should
 interpret top level folders as pillar environments (see mode section below).
@@ -109,8 +110,8 @@ class S3Credentials(object):
 def ext_pillar(minion_id,
                pillar,  # pylint: disable=W0613
                bucket,
-               key,
-               keyid,
+               key=None,
+               keyid=None,
                verify_ssl=True,
                location=None,
                multiple_env=False,

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -169,7 +169,12 @@ def sig4(method, endpoint, params, prov_dict,
         endpoint,
         amzdate,
     )
+
     signed_headers = 'host;x-amz-date'
+
+    if token != '':
+        canonical_headers += 'x-amz-security-token:{0}\n'.format(token)
+        signed_headers += ';x-amz-security-token'
 
     algorithm = 'AWS4-HMAC-SHA256'
 

--- a/salt/utils/s3.py
+++ b/salt/utils/s3.py
@@ -88,9 +88,8 @@ def query(key, keyid, method='GET', params=None, headers=None,
 
     # Try grabbing the credentials from the EC2 instance IAM metadata if available
     if not key or not keyid:
-        iam_creds = iam.get_iam_metadata()
-        key = iam_creds['secret_key']
-        keyid = iam_creds['access_key']
+        key = salt.utils.aws.IROLE_CODE
+        keyid = salt.utils.aws.IROLE_CODE
 
     if not location:
         location = iam.get_iam_region()


### PR DESCRIPTION
# Let utils.aws query instance metadata
## Why?

Because there was duplication of code in utils.iam and the more feature complete utils.aws. Because fetching temporary credentials from meta-data service did not actually work. Once I could get utils.aws.sig4() to fetch credentials, turns out the X-Amz-Security-Token header was not being signed, causing errors from Amazon's API.
## Summary

s3fs fileserver and s3 pillar backend both use utils.aws to query Amazon S3 API. This change avoids setting hard-coded fallback values and rather forwards None values of key and keyid so that utils.aws can make the fallback decision.
## Fallback features:
- pillar.s3.ext_pillar() allows key and keyid to be empty
- utils.s3.query() does not use utils.iam anymore to retrieve credentials from EC2 instance meta-data
- utils.s3.query() falls back on setting empty key & keyid to magical value from utils.aws.IROLE_CODE to let utils.aws.sig4() fill in credentials from EC2 meta-data.
## utils.aws features:

X-Amz-Security-Token header, which is necessary when using temporary credentials from IAM roles, now properly signed.
## Tested

Tested in eu-west-1 availability zone on Amazon Linux using IAM roles for S3 permissions. S3 backend for states and pillars worked with this minimal master config:

```
fileserver_backend:
  - s3fs
s3.buckets:
  base:
    - salt-states-bucket-name

ext_pillar:
  - s3:
      bucket: salt-pillars-bucket-name
```
