### PR TITLE
Set log_level properly

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -268,7 +268,7 @@ VALID_OPTS = {
     'log_file': str,
 
     # The level of verbosity at which to log
-    'log_level': bool,
+    'log_level': str,
 
     # The log level to log to a given file
     'log_level_logfile': bool,
@@ -833,7 +833,7 @@ DEFAULT_MINION_OPTS = {
     'tcp_pub_port': 4510,
     'tcp_pull_port': 4511,
     'log_file': os.path.join(salt.syspaths.LOGS_DIR, 'minion'),
-    'log_level': None,
+    'log_level': 'info',
     'log_level_logfile': None,
     'log_datefmt': _DFLT_LOG_DATEFMT,
     'log_datefmt_logfile': _DFLT_LOG_DATEFMT_LOGFILE,
@@ -1036,7 +1036,7 @@ DEFAULT_MASTER_OPTS = {
     'tcp_master_publish_pull': 4514,
     'tcp_master_workers': 4515,
     'log_file': os.path.join(salt.syspaths.LOGS_DIR, 'master'),
-    'log_level': None,
+    'log_level': 'info',
     'log_level_logfile': None,
     'log_datefmt': _DFLT_LOG_DATEFMT,
     'log_datefmt_logfile': _DFLT_LOG_DATEFMT_LOGFILE,
@@ -1151,7 +1151,7 @@ CLOUD_CONFIG_DEFAULTS = {
     'deploy_scripts_search_path': 'cloud.deploy.d',
     # Logging defaults
     'log_file': os.path.join(salt.syspaths.LOGS_DIR, 'cloud'),
-    'log_level': None,
+    'log_level': 'info',
     'log_level_logfile': None,
     'log_datefmt': _DFLT_LOG_DATEFMT,
     'log_datefmt_logfile': _DFLT_LOG_DATEFMT_LOGFILE,


### PR DESCRIPTION
This is now safe to do with the parser changes made by @s0undt3ch 

Prevents errors like this:

```
AttributeError: 'NoneType' object has no attribute 'lower'
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    salt_call()
  File "/home/mp/devel/salt/salt/scripts.py", line 224, in salt_call
    client.run()
  File "/home/mp/devel/salt/salt/cli/call.py", line 50, in run
    caller.run()
  File "/home/mp/devel/salt/salt/cli/caller.py", line 133, in run
    ret = self.call()
  File "/home/mp/devel/salt/salt/cli/caller.py", line 201, in call
    self.opts['log_level'].lower(), logging.ERROR)
AttributeError: 'NoneType' object has no attribute 'lower'
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    salt_call()
  File "/home/mp/devel/salt/salt/scripts.py", line 224, in salt_call
    client.run()
  File "/home/mp/devel/salt/salt/cli/call.py", line 50, in run
    caller.run()
  File "/home/mp/devel/salt/salt/cli/caller.py", line 133, in run
    ret = self.call()
  File "/home/mp/devel/salt/salt/cli/caller.py", line 201, in call
    self.opts['log_level'].lower(), logging.ERROR)
AttributeError: 'NoneType' object has no attribute 'lower'
```
