### PR TITLE
Provides tagging of Sentry LogHandler events.

### DIFF
--- a/salt/log/handlers/sentry_mod.py
+++ b/salt/log/handlers/sentry_mod.py
@@ -13,7 +13,8 @@
         logging handler to be available.
 
     Configuring the python `Sentry`_ client, `Raven`_, should be done under the
-    ``sentry_handler`` configuration key.
+    ``sentry_handler`` configuration key. Additional `context` may be provided
+    for coresponding grain item(s).
     At the bare minimum, you need to define the `DSN`_. As an example:
 
     .. code-block:: yaml
@@ -33,7 +34,12 @@
           project: app-id
           public_key: deadbeefdeadbeefdeadbeefdeadbeef
           secret_key: beefdeadbeefdeadbeefdeadbeefdead
-
+          context:
+            - os
+            - master
+            - saltversion
+            - cpuarch
+            - ec2.tags.environment
 
     All the client configuration keys are supported, please see the
     `Raven client documentation`_.
@@ -101,7 +107,6 @@ def setup_handlers():
     if 'sentry_handler' not in __opts__:
         log.debug('No \'sentry_handler\' key was found in the configuration')
         return False
-
     options = {}
     dsn = get_config_value('dsn')
     if dsn is not None:
@@ -178,7 +183,15 @@ def setup_handlers():
     })
 
     client = raven.Client(**options)
-
+    context = get_config_value('context')
+    context_dict = {}
+    if context is not None:
+        for tag in context:
+            tag_value = __salt__['grains.get'](tag)
+            if len(tag_value) > 0:
+                context_dict[tag] = tag_value
+        if len(context_dict) > 0:
+            client.context.merge({'tags': context_dict})
     try:
         handler = SentryHandler(client)
         handler.setLevel(LOG_LEVELS[get_config_value('log_level', 'error')])


### PR DESCRIPTION
By providing context within the logging events it becomes more effective
in multiple environments as well as addition details such as os, custom
grains, etc. This primarly shadow the functionality in the sentry
shipper with the exception of explicit introduction of the salt.loader
includes to enable the feature.

@basepi 
