### PR TITLE
Added option parameters to make_repo to allow for configuration settings

### DIFF
--- a/salt/modules/debbuild.py
+++ b/salt/modules/debbuild.py
@@ -35,9 +35,9 @@ def __virtual__():
     return False
 
 
-def _get_env(env):
+def _get_build_env(env):
     '''
-    Get environment overrides dictionary to use in build process
+    Get build environment overrides dictionary to use in build process
     '''
     env_override = ""
     if env is None:
@@ -50,6 +50,22 @@ def _get_env(env):
         env_override += '{0}={1}\n'.format(key, value)
         env_override += 'export {0}\n'.format(key)
     return env_override
+
+
+def _get_repo_env(env):
+    '''
+    Get repo environment overrides dictionary to use in repo process
+    '''
+    env_options = ""
+    if env is None:
+        return env_options
+    if not isinstance(env, dict):
+        raise SaltInvocationError(
+            '\'env\' must be a Python dictionary'
+        )
+    for key, value in env.items():
+        env_options += '{0}\n'.format(value)
+    return env_options
 
 
 def _create_pbuilders(env):
@@ -138,7 +154,7 @@ OTHERMIRROR="deb http://ftp.us.debian.org/debian/ testing main contrib non-free 
     with open(pbuilderrc, "w") as fow:
         fow.write('{0}'.format(pbldrc_text))
 
-    env_overrides = _get_env(env)
+    env_overrides = _get_build_env(env)
     if env_overrides and not env_overrides.isspace():
         with open(pbuilderrc, "a") as fow:
             fow.write('{0}'.format(env_overrides))
@@ -319,7 +335,7 @@ def build(runas, tgt, dest_dir, spec, sources, deps, env, template, saltenv='bas
     return ret
 
 
-def make_repo(repodir):
+def make_repo(repodir, keyid=None, env=None):
     '''
     Given the repodir, create a Debian repository out of the dsc therein
 
@@ -343,6 +359,15 @@ Pull: jessie
     repoconfdist = os.path.join(repoconf, 'distributions')
     with open(repoconfdist, "w") as fow:
         fow.write('{0}'.format(repocfg_text))
+
+    if keyid is not None:
+        with open(repoconfdist, "a") as fow:
+            fow.write('Signwith: {0}\n'.format(keyid))
+
+    repocfg_opts = _get_repo_env(env)
+    repoconfopts = os.path.join(repoconf, 'options')
+    with open(repoconfopts, "w") as fow:
+        fow.write('{0}'.format(repocfg_opts))
 
     for debfile in os.listdir(repodir):
         if debfile.endswith('.changes'):

--- a/salt/modules/debbuild.py
+++ b/salt/modules/debbuild.py
@@ -39,7 +39,7 @@ def _get_build_env(env):
     '''
     Get build environment overrides dictionary to use in build process
     '''
-    env_override = ""
+    env_override = ''
     if env is None:
         return env_override
     if not isinstance(env, dict):
@@ -56,7 +56,7 @@ def _get_repo_env(env):
     '''
     Get repo environment overrides dictionary to use in repo process
     '''
-    env_options = ""
+    env_options = ''
     if env is None:
         return env_options
     if not isinstance(env, dict):
@@ -147,16 +147,16 @@ OTHERMIRROR="deb http://ftp.us.debian.org/debian/ testing main contrib non-free 
         os.makedirs(pbuilder_hooksdir)
 
     d05hook = os.path.join(pbuilder_hooksdir, 'D05apt-preferences')
-    with open(d05hook, "w") as fow:
+    with salt.utils.fopen(d05hook, 'w') as fow:
         fow.write('{0}'.format(hook_text))
 
     pbuilderrc = os.path.join(home, '.pbuilderrc')
-    with open(pbuilderrc, "w") as fow:
+    with salt.utils.fopen(pbuilderrc, 'w') as fow:
         fow.write('{0}'.format(pbldrc_text))
 
     env_overrides = _get_build_env(env)
     if env_overrides and not env_overrides.isspace():
-        with open(pbuilderrc, "a") as fow:
+        with salt.utils.fopen(pbuilderrc, 'a') as fow:
             fow.write('{0}'.format(env_overrides))
 
 
@@ -357,16 +357,16 @@ Pull: jessie
         os.makedirs(repoconf)
 
     repoconfdist = os.path.join(repoconf, 'distributions')
-    with open(repoconfdist, "w") as fow:
+    with salt.utils.fopen(repoconfdist, 'w') as fow:
         fow.write('{0}'.format(repocfg_text))
 
     if keyid is not None:
-        with open(repoconfdist, "a") as fow:
+        with salt.utils.fopen(repoconfdist, 'a') as fow:
             fow.write('Signwith: {0}\n'.format(keyid))
 
     repocfg_opts = _get_repo_env(env)
     repoconfopts = os.path.join(repoconf, 'options')
-    with open(repoconfopts, "w") as fow:
+    with salt.utils.fopen(repoconfopts, 'w') as fow:
         fow.write('{0}'.format(repocfg_opts))
 
     for debfile in os.listdir(repodir):

--- a/salt/modules/rpmbuild.py
+++ b/salt/modules/rpmbuild.py
@@ -231,7 +231,7 @@ def build(runas, tgt, dest_dir, spec, sources, deps, env, template, saltenv='bas
     return ret
 
 
-def make_repo(repodir):
+def make_repo(repodir, keyid=None, env=None):
     '''
     Given the repodir, create a yum repository out of the rpms therein
 

--- a/salt/modules/rpmbuild.py
+++ b/salt/modules/rpmbuild.py
@@ -47,7 +47,7 @@ def _create_rpmmacros():
         os.makedirs(mockdir)
 
     rpmmacros = os.path.join(home, '.rpmmacros')
-    with open(rpmmacros, "w") as afile:
+    with salt.utils.fopen(rpmmacros, 'w') as afile:
         afile.write('%_topdir {0}\n'.format(rpmbuilddir))
         afile.write('%signature gpg\n')
         afile.write('%_gpg_name packaging@saltstack.com\n')
@@ -100,7 +100,7 @@ def _get_distset(tgt):
     if tgtattrs[1] in ['5', '6', '7']:
         distset = '--define "dist .el{0}"'.format(tgtattrs[1])
     else:
-        distset = ""
+        distset = ''
 
     return distset
 
@@ -109,7 +109,7 @@ def _get_deps(deps, tree_base, saltenv='base'):
     '''
     Get include string for list of dependent rpms to build package
     '''
-    deps_list = ""
+    deps_list = ''
     if deps is None:
         return deps_list
     if not isinstance(deps, list):
@@ -174,7 +174,7 @@ def build(runas, tgt, dest_dir, spec, sources, deps, env, template, saltenv='bas
         salt '*' pkgbuild.build mock epel-7-x86_64 /var/www/html/ https://raw.githubusercontent.com/saltstack/libnacl/master/pkg/rpm/python-libnacl.spec https://pypi.python.org/packages/source/l/libnacl/libnacl-1.3.5.tar.gz
 
     This example command should build the libnacl package for rhel 7 using user
-    "mock" and place it in /var/www/html/ on the minion
+    mock and place it in /var/www/html/ on the minion
     '''
     ret = {}
     if not os.path.isdir(dest_dir):
@@ -187,13 +187,13 @@ def build(runas, tgt, dest_dir, spec, sources, deps, env, template, saltenv='bas
 
     distset = _get_distset(tgt)
 
-    noclean = ""
+    noclean = ''
     deps_dir = tempfile.mkdtemp()
     deps_list = _get_deps(deps, deps_dir, saltenv)
     if deps_list and not deps_list.isspace():
         cmd = 'mock --root={0} {1}'.format(tgt, deps_list)
         __salt__['cmd.run'](cmd, runas=runas)
-        noclean += " --no-clean"
+        noclean += ' --no-clean'
 
     for srpm in srpms:
         dbase = os.path.dirname(srpm)

--- a/salt/states/pkgbuild.py
+++ b/salt/states/pkgbuild.py
@@ -161,7 +161,7 @@ def built(
     return ret
 
 
-def repo(name):
+def repo(name, keyid=None, env=None):
     '''
     Make a package repository, the name is directoty to turn into a repo.
     This state is best used with onchanges linked to your package building
@@ -169,6 +169,30 @@ def repo(name):
 
     name
         The directory to find packages that will be in the repository
+
+    keyid
+        Optional Key ID to use in signing repository
+
+    env
+        A dictionary of environment variables to be utlilized in creating the repository.
+        Example:
+
+        .. code-block:: yaml
+
+                - env:
+                    OPTIONS: 'ask-passphrase'
+
+        .. warning::
+
+            The above illustrates a common PyYAML pitfall, that **yes**,
+            **no**, **on**, **off**, **true**, and **false** are all loaded as
+            boolean ``True`` and ``False`` values, and must be enclosed in
+            quotes to be used as strings. More info on this (and other) PyYAML
+            idiosyncrasies can be found :doc:`here
+            </topics/troubleshooting/yaml_idiosyncrasies>`.
+
+            Use of OPTIONS on some platforms, for example: ask-passphrase, will
+            require gpg-agent or similar to cache passphrases.
     '''
     ret = {'name': name,
            'changes': {},
@@ -178,6 +202,14 @@ def repo(name):
         ret['result'] = None
         ret['comment'] = 'Package repo at {0} will be rebuilt'.format(name)
         return ret
-    __salt__['pkgbuild.make_repo'](name)
+
+    # Need the check for None here, if env is not provided then it falls back
+    # to None and it is assumed that the environment is not being overridden.
+    if env is not None and not isinstance(env, dict):
+        ret['comment'] = ('Invalidly-formatted \'env\' parameter. See '
+                          'documentation.')
+        return ret
+
+    __salt__['pkgbuild.make_repo'](name, keyid, env)
     ret['changes'] = {'refresh': True}
     return ret


### PR DESCRIPTION
Added optional partameters to allow for key and option setting when
creating a repo, esp. Debian.  Note use of passphrases in options
requires the use of gpg-agent or similar with previously cached
passphrase
