### PR TITLE
Fix service.{start,restart,reload,force-reload} for masked services

### DIFF
--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -437,6 +437,7 @@ def start(name):
     '''
     if _untracked_custom_unit_found(name) or _unit_file_changed(name):
         systemctl_reload()
+    unmask(name)
     return not __salt__['cmd.retcode'](_systemctl_cmd('start', name))
 
 
@@ -467,6 +468,7 @@ def restart(name):
     '''
     if _untracked_custom_unit_found(name) or _unit_file_changed(name):
         systemctl_reload()
+    unmask(name)
     return not __salt__['cmd.retcode'](_systemctl_cmd('restart', name))
 
 
@@ -482,6 +484,7 @@ def reload_(name):
     '''
     if _untracked_custom_unit_found(name) or _unit_file_changed(name):
         systemctl_reload()
+    unmask(name)
     return not __salt__['cmd.retcode'](_systemctl_cmd('reload', name))
 
 
@@ -497,6 +500,7 @@ def force_reload(name):
     '''
     if _untracked_custom_unit_found(name) or _unit_file_changed(name):
         systemctl_reload()
+    unmask(name)
     return not __salt__['cmd.retcode'](_systemctl_cmd('force-reload', name))
 
 
@@ -531,8 +535,7 @@ def enable(name, **kwargs):
     '''
     if _untracked_custom_unit_found(name) or _unit_file_changed(name):
         systemctl_reload()
-    if masked(name):
-        unmask(name)
+    unmask(name)
     if _service_is_sysv(name):
         executable = _get_service_exec()
         cmd = '{0} -f {1} defaults 99'.format(executable, name)

--- a/tests/unit/modules/systemd_test.py
+++ b/tests/unit/modules/systemd_test.py
@@ -196,20 +196,13 @@ class SystemdTestCase(TestCase):
         exe = MagicMock(return_value='foo')
         tmock = MagicMock(return_value=True)
         mock = MagicMock(return_value=False)
-        disabled_mock = MagicMock(return_value={'retcode': 1, 'stdout': 'disabled', 'stderr': ''})
-        masked_mock = MagicMock(return_value={'retcode': 1, 'stdout': 'masked', 'stderr': ''})
         with patch.object(systemd, '_untracked_custom_unit_found', mock):
             with patch.object(systemd, '_unit_file_changed', mock):
                 with patch.dict(systemd.__salt__, {'cmd.retcode': mock}):
-                    with patch.dict(systemd.__salt__, {'cmd.run_all': disabled_mock}):
-                        with patch.object(systemd, "_service_is_sysv", mock):
-                            self.assertTrue(systemd.enable("sshd"))
-                        with patch.object(systemd, "_get_service_exec", exe):
-                            with patch.object(systemd, "_service_is_sysv", tmock):
-                                self.assertTrue(systemd.enable("sshd"))
-
-                    with patch.dict(systemd.__salt__, {'cmd.run_all': masked_mock}):
-                        with patch.object(systemd, "_service_is_sysv", mock):
+                    with patch.object(systemd, "_service_is_sysv", mock):
+                        self.assertTrue(systemd.enable("sshd"))
+                    with patch.object(systemd, "_get_service_exec", exe):
+                        with patch.object(systemd, "_service_is_sysv", tmock):
                             self.assertTrue(systemd.enable("sshd"))
 
     def test_disable(self):


### PR DESCRIPTION
> `masked` is a stronger version of disable, since it prohibits all kinds of activation of the unit, including enablement and manual activation

The same problem with the `enable` action fixed [here](https://github.com/saltstack/salt/pull/26318).
