### PR TITLE
Add /usr/local/bin to $PATH in salt-minion plist

### DIFF
--- a/pkg/darwin/com.saltstack.salt.minion.plist
+++ b/pkg/darwin/com.saltstack.salt.minion.plist
@@ -8,6 +8,11 @@
     <true/>
     <key>KeepAlive</key>
     <true/>
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>PATH</key>
+      <string>/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin</string>
+    </dict>
     <key>ProgramArguments</key>
     <array>
         <string>/usr/local/bin/salt-minion</string>


### PR DESCRIPTION
Running salt-minion as root when installed by default homebrew results in `$PATH` not containing `/usr/local/bin`, which is the default installation directory. This results in states such as `pkg.installed` failing because the brew module bootstraps its runas user with `brew --prefix`, which is not in the path.

This is not as ideal as perhaps, the homebrew formula installing a templated plist though.
