### PR TITLE
Changed t1 -> t2 micro

### DIFF
--- a/doc/topics/cloud/aws.rst
+++ b/doc/topics/cloud/aws.rst
@@ -265,13 +265,13 @@ Set up an initial profile at ``/etc/salt/cloud.profiles``:
     base_ec2_private:
       provider: my-ec2-southeast-private-ips
       image: ami-e565ba8c
-      size: t1.micro
+      size: t2.micro
       ssh_username: ec2-user
 
     base_ec2_public:
       provider: my-ec2-southeast-public-ips
       image: ami-e565ba8c
-      size: t1.micro
+      size: t2.micro
       ssh_username: ec2-user
 
     base_ec2_db:


### PR DESCRIPTION
t1.micro no longer supports HVM AMIs.  Attempted launch with a t1.micro results in:

[ERROR   ] AWS Response Status Code and Error: [400 400 Client Error: Bad Request] {'Errors': {'Error': {'Message': "Non-Windows instances with a virtualization type of 'hvm' are currently not supported for this instance type.", 'Code': 'InvalidParameterCombination'}}, 'RequestID': 'd8d20595-0a17-42ad-9f9a-41cbd009098d'}
