### PR TITLE
Add initial support for floating IP in nova cloud driver.

### DIFF
--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -1115,6 +1115,7 @@ def floating_ip_delete(kwargs, call=None):
     conn = get_conn()
     return conn.floating_ip_delete(kwargs['floating_ip'])
 
+
 def floating_ip_associate(name, kwargs, call=None):
     '''
     Associate a floating IP address to a server

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -1054,3 +1054,98 @@ def virtual_interface_create(name, net_name, **kwargs):
     '''
     conn = get_conn()
     return conn.virtual_interface_create(name, net_name)
+
+
+def floating_ip_pool_list(call=None):
+    '''
+    List all floating IP pools
+    '''
+    if call != 'function':
+        raise SaltCloudSystemExit(
+            'The floating_ip_pool_list action must be called with -f or --function'
+        )
+
+    conn = get_conn()
+    return conn.floating_ip_pool_list()
+
+
+def floating_ip_list(call=None):
+    '''
+    List floating IPs
+    '''
+    if call != 'function':
+        raise SaltCloudSystemExit(
+            'The floating_ip_list action must be called with -f or --function'
+        )
+
+    conn = get_conn()
+    return conn.floating_ip_list()
+
+
+def floating_ip_create(kwargs, call=None):
+    '''
+    Allocate a floating IP
+    '''
+    if call != 'function':
+        raise SaltCloudSystemExit(
+            'The floating_ip_create action must be called with -f or --function'
+        )
+
+    if 'pool' not in kwargs:
+        log.error('pool is required')
+        return False
+
+    conn = get_conn()
+    return conn.floating_ip_create(kwargs['pool'])
+
+
+def floating_ip_delete(kwargs, call=None):
+    '''
+    De-allocate floating IP
+    '''
+    if call != 'function':
+        raise SaltCloudSystemExit(
+            'The floating_ip_delete action must be called with -f or --function'
+        )
+
+    if 'floating_ip' not in kwargs:
+        log.error('floating_ip is required')
+        return False
+
+    conn = get_conn()
+    return conn.floating_ip_delete(kwargs['floating_ip'])
+
+def floating_ip_associate(name, kwargs, call=None):
+    '''
+    Associate a floating IP address to a server
+    '''
+    if call != 'action':
+        raise SaltCloudSystemExit(
+            'The floating_ip_associate action must be called with -a of --action.'
+        )
+
+    if 'floating_ip' not in kwargs:
+        log.error('floating_ip is required')
+        return False
+
+    conn = get_conn()
+    conn.floating_ip_associate(name, kwargs['floating_ip'])
+    return list_nodes()[name]
+
+
+def floating_ip_disassociate(name, kwargs, call=None):
+    '''
+    Disassociate a floating IP from a server
+    '''
+    if call != 'action':
+        raise SaltCloudSystemExit(
+            'The floating_ip_disassociate action must be called with -a of --action.'
+        )
+
+    if 'floating_ip' not in kwargs:
+        log.error('floating_ip is required')
+        return False
+
+    conn = get_conn()
+    conn.floating_ip_disassociate(name, kwargs['floating_ip'])
+    return list_nodes()[name]

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -1059,6 +1059,8 @@ def virtual_interface_create(name, net_name, **kwargs):
 def floating_ip_pool_list(call=None):
     '''
     List all floating IP pools
+
+    .. versionadded:: Boron
     '''
     if call != 'function':
         raise SaltCloudSystemExit(
@@ -1072,6 +1074,8 @@ def floating_ip_pool_list(call=None):
 def floating_ip_list(call=None):
     '''
     List floating IPs
+
+    .. versionadded:: Boron
     '''
     if call != 'function':
         raise SaltCloudSystemExit(
@@ -1085,6 +1089,8 @@ def floating_ip_list(call=None):
 def floating_ip_create(kwargs, call=None):
     '''
     Allocate a floating IP
+
+    .. versionadded:: Boron
     '''
     if call != 'function':
         raise SaltCloudSystemExit(
@@ -1102,6 +1108,8 @@ def floating_ip_create(kwargs, call=None):
 def floating_ip_delete(kwargs, call=None):
     '''
     De-allocate floating IP
+
+    .. versionadded:: Boron
     '''
     if call != 'function':
         raise SaltCloudSystemExit(
@@ -1119,6 +1127,8 @@ def floating_ip_delete(kwargs, call=None):
 def floating_ip_associate(name, kwargs, call=None):
     '''
     Associate a floating IP address to a server
+
+    .. versionadded:: Boron
     '''
     if call != 'action':
         raise SaltCloudSystemExit(
@@ -1137,6 +1147,8 @@ def floating_ip_associate(name, kwargs, call=None):
 def floating_ip_disassociate(name, kwargs, call=None):
     '''
     Disassociate a floating IP from a server
+
+    .. versionadded:: Boron
     '''
     if call != 'action':
         raise SaltCloudSystemExit(

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -887,13 +887,93 @@ class SaltNova(OpenStackComputeShell):
         nets = nt_ks.virtual_interfaces.create(networkid, serverid)
         return nets
 
+    def floating_ip_pool_list(self):
+        '''
+        List all floating IP pools
+        '''
+        nt_ks = self.compute_conn
+        pools = nt_ks.floating_ip_pools.list()
+        response = {}
+        for pool in pools:
+            response[pool.name] = {
+                'name': pool.name,
+            }
+        return response
+
+    def floating_ip_list(self):
+        '''
+        List floating IPs
+        '''
+        nt_ks = self.compute_conn
+        floating_ips = nt_ks.floating_ips.list()
+        response = {}
+        for floating_ip in floating_ips:
+            response[floating_ip.ip] = {
+                'ip': floating_ip.ip,
+                'fixed_ip': floating_ip.fixed_ip,
+                'id': floating_ip.id,
+                'instance_id': floating_ip.instance_id,
+                'pool': floating_ip.pool
+            }
+        return response
+
+    def floating_ip_show(self, ip):
+        nt_ks = self.compute_conn
+        floating_ips = nt_ks.floating_ips.list()
+        for floating_ip in floating_ips:
+            if floating_ip.ip == ip:
+                return floating_ip
+        return {}
+
+    def floating_ip_create(self, pool=None):
+        '''
+        Allocate a floating IP
+        '''
+        nt_ks = self.compute_conn
+        floating_ip = nt_ks.floating_ips.create(pool)
+        response = {
+            'ip': floating_ip.ip,
+            'fixed_ip': floating_ip.fixed_ip,
+            'id': floating_ip.id,
+            'instance_id': floating_ip.instance_id,
+            'pool': floating_ip.pool
+        }
+        return response
+
+    def floating_ip_delete(self, floating_ip):
+        '''
+        De-allocate a floating IP
+        '''
+        ip = self.floating_ip_show(floating_ip)
+        nt_ks = self.compute_conn
+        return nt_ks.floating_ips.delete(ip)
+
+    def floating_ip_associate(self, server_name, floating_ip):
+        '''
+        Associate floating IP address to server
+        '''
+        nt_ks = self.compute_conn
+        server_ = self.server_by_name(server_name)
+        server = nt_ks.servers.get(server_.__dict__['id'])
+        server.add_floating_ip(floating_ip)
+        return self.floating_ip_list()[floating_ip]
+
+    def floating_ip_disassociate(self, server_name, floating_ip):
+        '''
+        Disassociate a floating IP from server
+        '''
+        nt_ks = self.compute_conn
+        server_ = self.server_by_name(server_name)
+        server = nt_ks.servers.get(server_.__dict__['id'])
+        server.remove_floating_ip(floating_ip)
+        return self.floating_ip_list()[floating_ip]
+
 # The following is a list of functions that need to be incorporated in the
 # nova module. This list should be updated as functions are added.
 #
 # absolute-limits     Print a list of absolute limits for a user
 # actions             Retrieve server actions.
 # add-fixed-ip        Add new IP address to network.
-# add-floating-ip     Add a floating IP address to a server.
 # aggregate-add-host  Add the host to the specified aggregate.
 # aggregate-create    Create a new aggregate with the specified details.
 # aggregate-delete    Delete the aggregate by its id.
@@ -923,11 +1003,6 @@ class SaltNova(OpenStackComputeShell):
 #                     and name.
 # endpoints           Discover endpoints that get returned from the
 #                     authenticate services
-# floating-ip-create  Allocate a floating IP for the current tenant.
-# floating-ip-delete  De-allocate a floating IP.
-# floating-ip-list    List floating ips for this tenant.
-# floating-ip-pool-list
-#                     List all floating ip pools.
 # get-vnc-console     Get a vnc console to a server.
 # host-action         Perform a power action on a host.
 # host-update         Update host settings.
@@ -942,7 +1017,6 @@ class SaltNova(OpenStackComputeShell):
 # reboot              Reboot a server.
 # rebuild             Shutdown, re-image, and re-boot a server.
 # remove-fixed-ip     Remove an IP address from a server.
-# remove-floating-ip  Remove a floating IP address from a server.
 # rename              Rename a server.
 # rescue              Rescue a server.
 # resize              Resize a server.

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -890,6 +890,8 @@ class SaltNova(OpenStackComputeShell):
     def floating_ip_pool_list(self):
         '''
         List all floating IP pools
+
+        .. versionadded:: Boron
         '''
         nt_ks = self.compute_conn
         pools = nt_ks.floating_ip_pools.list()
@@ -903,6 +905,8 @@ class SaltNova(OpenStackComputeShell):
     def floating_ip_list(self):
         '''
         List floating IPs
+
+        .. versionadded:: Boron
         '''
         nt_ks = self.compute_conn
         floating_ips = nt_ks.floating_ips.list()
@@ -918,6 +922,11 @@ class SaltNova(OpenStackComputeShell):
         return response
 
     def floating_ip_show(self, ip):
+        '''
+        Show info on specific floating IP
+
+        .. versionadded:: Boron
+        '''
         nt_ks = self.compute_conn
         floating_ips = nt_ks.floating_ips.list()
         for floating_ip in floating_ips:
@@ -928,6 +937,8 @@ class SaltNova(OpenStackComputeShell):
     def floating_ip_create(self, pool=None):
         '''
         Allocate a floating IP
+
+        .. versionadded:: Boron
         '''
         nt_ks = self.compute_conn
         floating_ip = nt_ks.floating_ips.create(pool)
@@ -943,6 +954,8 @@ class SaltNova(OpenStackComputeShell):
     def floating_ip_delete(self, floating_ip):
         '''
         De-allocate a floating IP
+
+        .. versionadded:: Boron
         '''
         ip = self.floating_ip_show(floating_ip)
         nt_ks = self.compute_conn
@@ -951,6 +964,8 @@ class SaltNova(OpenStackComputeShell):
     def floating_ip_associate(self, server_name, floating_ip):
         '''
         Associate floating IP address to server
+
+        .. versionadded:: Boron
         '''
         nt_ks = self.compute_conn
         server_ = self.server_by_name(server_name)
@@ -961,6 +976,8 @@ class SaltNova(OpenStackComputeShell):
     def floating_ip_disassociate(self, server_name, floating_ip):
         '''
         Disassociate a floating IP from server
+
+        .. versionadded:: Boron
         '''
         nt_ks = self.compute_conn
         server_ = self.server_by_name(server_name)


### PR DESCRIPTION
This adds initial support for floating IP in the nova cloud driver. Four functions and two actions are added to the driver for working with floating IPs. Keeping with how the nova driver works requisite functions are added to the nova openstack utils.

Fixes #26370
