### PR TITLE
git.latest with no rev: fix concatenation error (NoneType and str)

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -416,7 +416,9 @@ def latest(name,
     if bare:
         remote_rev = None
     else:
-        if remote_rev_matches:
+        if rev is None:
+            remote_rev = None
+        elif remote_rev_matches:
             ref_name = 'refs/heads/' + rev
             if 'refs/heads/' + rev in remote_rev_matches:
                 remote_rev = remote_rev_matches['refs/heads/' + rev]
@@ -427,19 +429,16 @@ def latest(name,
                 desired_upstream = False
                 remote_rev_type = 'tag'
         else:
-            if rev is None:
-                remote_rev = None
+            if len(rev) <= 40 \
+                    and all(x in string.hexdigits for x in rev):
+                # git ls-remote did not find the rev, and because it's a
+                # hex string <= 40 chars we're going to assume that the
+                # desired rev is a SHA1
+                remote_rev = rev
+                desired_upstream = False
+                remote_rev_type = 'sha1'
             else:
-                if len(rev) <= 40 \
-                        and all(x in string.hexdigits for x in rev):
-                    # git ls-remote did not find the rev, and because it's a
-                    # hex string <= 40 chars we're going to assume that the
-                    # desired rev is a SHA1
-                    remote_rev = rev
-                    desired_upstream = False
-                    remote_rev_type = 'sha1'
-                else:
-                    remote_rev = None
+                remote_rev = None
 
     if rev and remote_rev is None:
         # A specific rev is desired, but that rev doesn't exist on the

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -417,7 +417,8 @@ def latest(name,
         remote_rev = None
     else:
         if rev is None:
-            remote_rev = None
+            remote_rev = 'HEAD'
+            remote_rev_type = 'sha1'
         elif remote_rev_matches:
             ref_name = 'refs/heads/' + rev
             if 'refs/heads/' + rev in remote_rev_matches:

--- a/tests/integration/states/git.py
+++ b/tests/integration/states/git.py
@@ -46,6 +46,22 @@ class GitTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
             ret = self.run_state(
                 'git.latest',
                 name='https://{0}/saltstack/salt-test-repo.git'.format(self.__domain),
+                target=name
+            )
+            self.assertSaltTrueReturn(ret)
+            self.assertTrue(os.path.isdir(os.path.join(name, '.git')))
+        finally:
+            shutil.rmtree(name, ignore_errors=True)
+
+    def test_latest_with_rev_and_submodules(self):
+        '''
+        git.latest
+        '''
+        name = os.path.join(integration.TMP, 'salt_repo')
+        try:
+            ret = self.run_state(
+                'git.latest',
+                name='https://{0}/saltstack/salt-test-repo.git'.format(self.__domain),
                 rev='develop',
                 target=name,
                 submodules=True


### PR DESCRIPTION
This error cropped up in 2015.8 just now. Probably due to the recent git rewrite.

```
          ID: /var/www/satis
    Function: git.latest
        Name: https://github.com/composer/satis
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/tmp/.root_740f1b_salt/salt/state.py", line 1591, in call
                  **cdata['kwargs'])
                File "/tmp/.root_740f1b_salt/salt/states/git.py", line 420, in latest
                  ref_name = 'refs/heads/' + rev
              TypeError: cannot concatenate 'str' and 'NoneType' objects
     Started: 16:29:02.804563
    Duration: 887.482 ms
     Changes:
```
