### PR TITLE
On Python 3 `os.stat()` might raise FileNotFoundError.

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1071,7 +1071,7 @@ def os_data():
         try:
             os.stat('/run/systemd/system')
             grains['init'] = 'systemd'
-        except OSError:
+        except (OSError, IOError):
             if os.path.exists('/proc/1/cmdline'):
                 with salt.utils.fopen('/proc/1/cmdline') as fhr:
                     init_cmdline = fhr.read().replace('\x00', ' ').split()


### PR DESCRIPTION
FileNotFoundError is apparently a subclass of OSError but it wasn't
getting caught in Python 3. Adding IOError made it work.
