### PR TITLE
--annotate and --message aren't valid options in older versions of git.

### DIFF
--- a/tests/integration/modules/git.py
+++ b/tests/integration/modules/git.py
@@ -87,7 +87,7 @@ class GitModuleTest(integration.ModuleCase):
         )
         # Add a tag
         subprocess.check_call(
-            ['git', 'tag', '--annotate', self.tags[0], '--message', 'Add tag']
+            ['git', 'tag', '-a', self.tags[0], '-m', 'Add tag']
         )
         # Checkout a second branch
         subprocess.check_call(


### PR DESCRIPTION
The default version on CentOS 6 is 1.7.1, which does not have the --annotate and --message options. They are -a and -m respectively. This shouldn't break forward compatibility as new versions of Git use -a or --append and -m or --message.
