### PR TITLE
Don't allow VMs with duplicate names to be created in EC2/AWS

### DIFF
--- a/doc/topics/releases/beryllium.rst
+++ b/doc/topics/releases/beryllium.rst
@@ -17,6 +17,12 @@ Core Changes
 Salt Cloud Changes
 ==================
 
+- Changed the default behavior of ``rename_on_destroy`` to be set to ``True``
+  in the EC2 and AWS drivers.
+- Changed the default behavior of the EC2 and AWS drivers to always check for
+  duplicate names of VMs before trying to create a new VM. Will now throw an
+  error similarly to other salt-cloud drivers when trying to create a VM of the
+  same name, even if the VM is in the ``terminated`` state.
 - Modified the Linode Salt Cloud driver to use Linode's native API instead of
   depending on apache-libcloud or linode-python.
 - When querying for VMs in ``ditigal_ocean.py``, the number of VMs to include in

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1878,32 +1878,17 @@ class Map(Cloud):
                         continue
 
                     # A machine by the same name exists
-                    for mdriver, state in six.iteritems(matching):
+                    for item in matching:
                         if name not in ret['create']:
                             # Machine already removed
                             break
 
-                        if mdriver not in ('aws', 'ec2') and \
-                                state.lower() != 'terminated':
-                            # Regarding other providers, simply remove
-                            # them for the create map.
-                            log.warn(
-                                '{0!r} already exists, removing from '
-                                'the create map'.format(name)
-                            )
-                            if 'existing' not in ret:
-                                ret['existing'] = {}
-                            ret['existing'][name] = ret['create'].pop(name)
-                            continue
-
-                        if state.lower() != 'terminated':
-                            log.info(
-                                '{0!r} already exists, removing '
-                                'from the create map'.format(name)
-                            )
-                            if 'existing' not in ret:
-                                ret['existing'] = {}
-                            ret['existing'][name] = ret['create'].pop(name)
+                        log.warn('{0!r} already exists, removing from '
+                                 'the create map.'.format(name))
+                        
+                        if 'existing' not in ret:
+                            ret['existing'] = {}
+                        ret['existing'][name] = ret['create'].pop(name)
 
         if 'hard' in self.opts and self.opts['hard']:
             if self.opts['enable_hard_maps'] is False:

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1378,14 +1378,7 @@ class Cloud(object):
         del provider_details['profiles']
 
         for name in names:
-            name_exists = False
             if name in vms:
-                if 'state' in vms[name]:
-                    if vms[name]['state'].lower() != 'terminated':
-                        name_exists = True
-                else:
-                    name_exists = True
-            if name_exists:
                 msg = '{0} already exists under {1}:{2}'.format(
                     name, alias, driver
                 )

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1885,7 +1885,7 @@ class Map(Cloud):
 
                         log.warn('{0!r} already exists, removing from '
                                  'the create map.'.format(name))
-                        
+
                         if 'existing' not in ret:
                             ret['existing'] = {}
                         ret['existing'][name] = ret['create'].pop(name)

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2810,10 +2810,13 @@ def destroy(name, call=None):
 
     ret = {}
 
-    if config.get_cloud_config_value('rename_on_destroy',
-                                     get_configured_provider(),
-                                     __opts__,
-                                     search_global=False) is True:
+    # Default behavior is to rename EC2 VMs when destroyed
+    # via salt-cloud, unless explicitly set to False.
+    rename_on_destroy = config.get_cloud_config_value('rename_on_destroy',
+                                                      get_configured_provider(),
+                                                      __opts__,
+                                                      search_global=False)
+    if rename_on_destroy is not False:
         newname = '{0}-DEL{1}'.format(name, uuid.uuid4().hex)
         rename(name, kwargs={'newname': newname}, call='action')
         log.info(

--- a/salt/cloud/clouds/libcloud_aws.py
+++ b/salt/cloud/clouds/libcloud_aws.py
@@ -783,9 +783,14 @@ def destroy(name):
     ret = {}
 
     newname = name
-    if config.get_cloud_config_value('rename_on_destroy',
-                               get_configured_provider(),
-                               __opts__, search_global=False) is True:
+
+    # Default behavior is to rename AWS VMs when destroyed
+    # via salt-cloud, unless explicitly set to False.
+    rename_on_destroy = config.get_cloud_config_value('rename_on_destroy',
+                                                      get_configured_provider(),
+                                                      __opts__,
+                                                      search_global=False)
+    if rename_on_destroy is not False:
         newname = '{0}-DEL{1}'.format(name, uuid.uuid4().hex)
         rename(name, kwargs={'newname': newname}, call='action')
         log.info(


### PR DESCRIPTION
Even if the VM is in the terminated state, from salt-cloud's perspective,
there should never be duplicately named instances.

This PR also changes the `rename_on_destroy` config default to True to
avoid errors and move the old ones out of the way if you forget to set it
in your cloud config.

Tested this both with creating individual VMs as well as using mapfiles, and it works:

```
# salt-cloud -m ~/mapfile
[INFO    ] salt-cloud starting
[INFO    ] Applying map from '/root/mapfile'.
[INFO    ] 'nt-testing-3' already exists, removing from the create map
[INFO    ] 'nt-map-test' already exists, removing from the create map
The following virtual machines already exist:
  nt-map-test
  nt-testing-3
The following virtual machines are set to be created:
  nt-testing-0

Proceed? [N/y] n
[INFO    ] Complete
nt-map-test:
    ----------
    Message:
        Already running
nt-testing-3:
    ----------
    Message:
        Already running
```

pinrg @techhat 
