### PR TITLE
Remove unecessary debug statements

### DIFF
--- a/salt/modules/random_org.py
+++ b/salt/modules/random_org.py
@@ -120,9 +120,6 @@ def _query(api_version=None, data=None):
     elif result.status_code == 204:
         return True
     else:
-        log.debug('base_url {0}'.format(base_url))
-        log.debug('data {0}'.format(data))
-        log.debug('result {0}'.format(result.text))
         ret['message'] = result.text
         return ret
 


### PR DESCRIPTION
These were throwing errors on some platforms:

Traceback (most recent call last):
  File "/testing/tests/unit/modules/random_org_test.py", line 296, in test_generateblobs
    format='hex'), ret6)
  File "/testing/salt/modules/random_org.py", line 743, in generateBlobs
    result = _query(api_version=api_version, data=data)
  File "/testing/salt/modules/random_org.py", line 125, in _query
    log.debug('result {0}'.format(result.text))
AttributeError: 'dict' object has no attribute 'text'
