### PR TITLE
Unmask a runtime masked services too

### DIFF
--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -389,7 +389,8 @@ def unmask(name):
     '''
     if _untracked_custom_unit_found(name) or _unit_file_changed(name):
         systemctl_reload()
-    return not __salt__['cmd.retcode'](_systemctl_cmd('unmask', name))
+    return not (__salt__['cmd.retcode'](_systemctl_cmd('unmask', name))
+                or __salt__['cmd.retcode'](_systemctl_cmd('unmask --runtime', name)))
 
 
 def mask(name):


### PR DESCRIPTION
**Environment**:

``` shell
$ lsb_release -rd
Description:    Ubuntu 15.04
Release:    15.04

$ systemd --version
systemd 219
+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT -GNUTLS +ACL +XZ -LZ4 -SECCOMP +BLKID -ELFUTILS +KMOD -IDN

$ salt-call --version
salt-call 2015.8.0rc3-92-g103651d (Beryllium)
```

**Bug:**

``` shell
$ systemctl stop cron
$ systemctl mask --runtime cron
Created symlink from /run/systemd/system/cron.service to /dev/null.

$ salt-call service.start cron
[INFO    ] Executing command 'systemctl unmask cron.service' in directory '/home/vagrant'
[INFO    ] Executing command 'systemctl start cron.service' in directory '/home/vagrant'
[ERROR   ] Command 'systemctl start cron.service' failed with return code: 1
[ERROR   ] output: Failed to start cron.service: Unit cron.service is masked.
local:
    False
```
