### PR TITLE
Defaults to current saltenv in state.sls

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -354,7 +354,7 @@ def highstate(test=None,
 
 
 def sls(mods,
-        saltenv='base',
+        saltenv=None,
         test=None,
         exclude=None,
         queue=False,
@@ -410,6 +410,9 @@ def sls(mods,
         )
         # Backwards compatibility
         saltenv = env
+
+    if saltenv is None:
+        saltenv = __opts__['environment'] or 'base'
 
     if queue:
         _wait(kwargs.get('__pub_jid'))


### PR DESCRIPTION
Hi,

I hit a bug when running `salt-call state.sls my-state` with `environment` other than `base`. Here is a setup to reproduce :

``` console
$ salt --versions
           Salt: 2014.7.0
         Python: 2.7.3 (default, Mar 13 2014, 11:03:55)
         Jinja2: 2.6
       M2Crypto: 0.21.1
 msgpack-python: 0.4.6
   msgpack-pure: Not Installed
       pycrypto: 2.6.1
        libnacl: Not Installed
         PyYAML: 3.10
          ioflo: Not Installed
          PyZMQ: 14.7.0
           RAET: Not Installed
            ZMQ: 2.2.0
           Mako: 0.7.0
$ tree
.
├── config
│   └── minion
└── states
    └── my.sls

2 directories, 2 files
$ cat config/minion 
environment: dev
log_level: debug
file_client: local
file_roots:
  dev:
    - /usr/local/src/salt-bug/states/
$ cat states/my.sls 
dumb:
  test.succeed_without_changes
$ sudo salt-call --config config/ state.sls my
[DEBUG   ] Configuration file path: /usr/local/src/salt-bug/config/minion
[DEBUG   ] Reading configuration from /usr/local/src/salt-bug/config/minion
[DEBUG   ] The `lspci` binary is not available on the system. GPU grains will not be available.
[DEBUG   ] The `dmidecode` binary is not available on the system. GPU grains will not be available.
[DEBUG   ] SMBIOS: neither dmidecode nor smbios found!
[DEBUG   ] SMBIOS: neither dmidecode nor smbios found!
[DEBUG   ] Registered VCS backend: git
[DEBUG   ] Registered VCS backend: hg
[DEBUG   ] Registered VCS backend: svn
[DEBUG   ] Registered VCS backend: bzr
[DEBUG   ] Reading configuration from /usr/local/src/salt-bug/config/minion
[DEBUG   ] The `lspci` binary is not available on the system. GPU grains will not be available.
[DEBUG   ] The `dmidecode` binary is not available on the system. GPU grains will not be available.
[DEBUG   ] SMBIOS: neither dmidecode nor smbios found!
[INFO    ] Loading fresh modules for state activity
[DEBUG   ] SMBIOS: neither dmidecode nor smbios found!
[DEBUG   ] Updating roots fileserver cache
[DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://my.sls'
[DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://my/init.sls'
local:
    Data failed to compile:
----------
    No matching sls found for 'my' in env 'base'
$
```

With this patch :

``` console
$ sudo salt-call --config config/ state.sls my
[DEBUG   ] Configuration file path: /usr/local/src/salt-bug/config/minion
[DEBUG   ] Reading configuration from /usr/local/src/salt-bug/config/minion
[DEBUG   ] The `lspci` binary is not available on the system. GPU grains will not be availab
le.
[DEBUG   ] The `dmidecode` binary is not available on the system. GPU grains will not be ava
ilable.
[DEBUG   ] SMBIOS: neither dmidecode nor smbios found!
[DEBUG   ] SMBIOS: neither dmidecode nor smbios found!
[DEBUG   ] Registered VCS backend: git
[DEBUG   ] Registered VCS backend: hg
[DEBUG   ] Registered VCS backend: svn
[DEBUG   ] Registered VCS backend: bzr
[DEBUG   ] Reading configuration from /usr/local/src/salt-bug/config/minion
[DEBUG   ] The `lspci` binary is not available on the system. GPU grains will not be availab
le.
[DEBUG   ] The `dmidecode` binary is not available on the system. GPU grains will not be ava
ilable.
[DEBUG   ] SMBIOS: neither dmidecode nor smbios found!
[INFO    ] Loading fresh modules for state activity
[DEBUG   ] SMBIOS: neither dmidecode nor smbios found!
[DEBUG   ] Updating roots fileserver cache
[INFO    ] Fetching file from saltenv 'dev', ** skipped ** latest already in cache 'salt://m
y.sls'
[DEBUG   ] Jinja search path: ['/var/cache/salt/minion/files/dev']
[DEBUG   ] Rendered data from file: /var/cache/salt/minion/files/dev/my.sls:
dumb:
  test.succeed_without_changes

[DEBUG   ] Results of YAML rendering: 
OrderedDict([('dumb', 'test.succeed_without_changes')])
[INFO    ] Running state [dumb] at time 16:59:08.384951
[INFO    ] Executing state test.succeed_without_changes for dumb
[INFO    ] Success!
[INFO    ] Completed state [dumb] at time 16:59:08.385382
[DEBUG   ] File /var/cache/salt/minion/accumulator/51763920 does not exist, no need to clean
up.
local:
----------
          ID: dumb
    Function: test.succeed_without_changes
      Result: True
     Comment: Success!
     Started: 16:59:08.384951
    Duration: 0.431 ms
     Changes:   

Summary
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1
```
