### PR TITLE
Gracefully handle package comparison not in (-1, 0, 1)

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -2302,6 +2302,12 @@ def compare_versions(ver1='', oper='==', ver2='', cmp_func=None):
     if oper == '!=':
         return cmp_result not in cmp_map['==']
     else:
+        # Gracefully handle cmp_result not in (-1, 0, 1).
+        if cmp_result < -1:
+            cmp_result = -1
+        elif cmp_result > 1:
+            cmp_result = 1
+
         return cmp_result in cmp_map[oper]
 
 

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -16,6 +16,7 @@ import hashlib
 import imp
 import json
 import logging
+import numbers
 import os
 import pprint
 import random
@@ -2297,6 +2298,12 @@ def compare_versions(ver1='', oper='==', ver2='', cmp_func=None):
 
     cmp_result = cmp_func(ver1, ver2)
     if cmp_result is None:
+        return False
+
+    # Check if integer/long
+    if not isinstance(cmp_result, numbers.Integral):
+        log.error('The version comparison function did not return an '
+                  'integer/long.')
         return False
 
     if oper == '!=':


### PR DESCRIPTION
This would have avoided #25369 alltogether. This came out of work I did related to https://github.com/saltstack/salt/issues/18652#issuecomment-133067853 until I realized the bug was already fixed.
