### PR TITLE
bugfix: fix service.enable for missing rc.conf

### DIFF
--- a/salt/modules/freebsdservice.py
+++ b/salt/modules/freebsdservice.py
@@ -162,7 +162,7 @@ def _switch(name,                   # pylint: disable=C0103
                 edited = True
     if not edited:
         # Ensure that the file ends in a \n
-        if nlines[-1][-1] != '\n':
+        if len(nlines) > 1 and nlines[-1][-1] != '\n':
             nlines[-1] = '{0}\n'.format(nlines[-1])
         nlines.append('{0}="{1}"\n'.format(rcvar, val))
 


### PR DESCRIPTION
The code assumed rc.conf to be existing and non-empty. Added a length
check to ensure it works even if rc.conf is missing, such as in a newly
created jail.
