### PR TITLE
Fix failing event tests and modify event init

### DIFF
--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -186,11 +186,10 @@ class SaltEvent(object):
         if salt.utils.is_windows() and not hasattr(opts, 'ipc_mode'):
             opts['ipc_mode'] = 'tcp'
         self.puburi, self.pulluri = self.__load_uri(sock_dir, node)
-        if listen:
+        if listen and not self.cpub:
             self.connect_pub()
         self.pending_tags = []
         self.pending_events = []
-        self.connect_pub()
         self.__load_cache_regex()
 
     @classmethod
@@ -420,7 +419,7 @@ class SaltEvent(object):
 
             log.trace('get_event() received = {0}'.format(ret))
             return ret
-
+       log.trace('_get_event() waited {0} seconds and received nothing'.format(wait * 1000))
         return None
 
     def get_event(self, wait=5, tag='', full=False, match_type=None):

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -419,7 +419,7 @@ class SaltEvent(object):
 
             log.trace('get_event() received = {0}'.format(ret))
             return ret
-       log.trace('_get_event() waited {0} seconds and received nothing'.format(wait * 1000))
+        log.trace('_get_event() waited {0} seconds and received nothing'.format(wait * 1000))
         return None
 
     def get_event(self, wait=5, tag='', full=False, match_type=None):

--- a/tests/unit/utils/event_test.py
+++ b/tests/unit/utils/event_test.py
@@ -249,8 +249,12 @@ class TestSaltEvent(TestCase):
     def test_event_multiple_clients(self):
         '''Test event is received by multiple clients'''
         with eventpublisher_process():
-            me1 = event.MasterEvent(SOCK_DIR)
-            me2 = event.MasterEvent(SOCK_DIR)
+            me1 = event.MasterEvent(SOCK_DIR, listen=True)
+            me2 = event.MasterEvent(SOCK_DIR, listen=True)
+           # We need to sleep here to avoid a race condition wherein
+           # the second socket may not be connected by the time the first socket
+           # sends the event.
+            time.sleep(0.5)
             me1.fire_event({'data': 'foo1'}, 'evt1')
             evt1 = me1.get_event(tag='evt1')
             self.assertGotEvent(evt1, {'data': 'foo1'})

--- a/tests/unit/utils/event_test.py
+++ b/tests/unit/utils/event_test.py
@@ -251,9 +251,9 @@ class TestSaltEvent(TestCase):
         with eventpublisher_process():
             me1 = event.MasterEvent(SOCK_DIR, listen=True)
             me2 = event.MasterEvent(SOCK_DIR, listen=True)
-           # We need to sleep here to avoid a race condition wherein
-           # the second socket may not be connected by the time the first socket
-           # sends the event.
+            # We need to sleep here to avoid a race condition wherein
+            # the second socket may not be connected by the time the first socket
+            # sends the event.
             time.sleep(0.5)
             me1.fire_event({'data': 'foo1'}, 'evt1')
             evt1 = me1.get_event(tag='evt1')


### PR DESCRIPTION
There was a problem wherein two sockets would race to see which was connected first,
causing unit.utils.event_test.TestSaltEvent.test_event_multiple_clients to fail from
time to time. This gives a little breathing room to the second socket.

This also only does the pub connect if necessary on SaltEvent instantation.
