### PR TITLE
Properly check for ipset ranges, fixes #26453

### DIFF
--- a/tests/unit/modules/ipset_test.py
+++ b/tests/unit/modules/ipset_test.py
@@ -187,9 +187,20 @@ comment support')
 
         with patch.object(ipset, '_find_set_type', return_value=True):
             with patch.object(ipset, '_find_set_members',
-                              side_effect=['entry', '']):
+                              side_effect=['entry', '',
+                                           ["192.168.0.4", "192.168.0.5"],
+                                           ["192.168.0.3"], ["192.168.0.6"],
+                                           ["192.168.0.4", "192.168.0.5"],
+                                           ["192.168.0.3"], ["192.168.0.6"],
+                                           ]):
                 self.assertTrue(ipset.check('set', 'entry'))
                 self.assertFalse(ipset.check('set', 'entry'))
+                self.assertTrue(ipset.check('set', '192.168.0.4/31'))
+                self.assertFalse(ipset.check('set', '192.168.0.4/31'))
+                self.assertFalse(ipset.check('set', '192.168.0.4/31'))
+                self.assertTrue(ipset.check('set', '192.168.0.4-192.168.0.5'))
+                self.assertFalse(ipset.check('set', '192.168.0.4-192.168.0.5'))
+                self.assertFalse(ipset.check('set', '192.168.0.4-192.168.0.5'))
 
     def test_test(self):
         '''


### PR DESCRIPTION
This add support for idempotent runs of `ipset.present` state if ranges are used as entries. IP1-IP2 and IP/MASK variants are supported.

Not sure if the branch is correct, though. I'd like to see this in the next release (2015.8.0).
