### PR TITLE
Leave salt.utils.s3 location fallback to salt.utils.aws

### DIFF
--- a/salt/utils/s3.py
+++ b/salt/utils/s3.py
@@ -20,11 +20,9 @@ except ImportError:
 import salt.utils
 import salt.utils.aws
 import salt.utils.xmlutil as xml
-import salt.utils.iam as iam
 from salt._compat import ElementTree as ET
 
 log = logging.getLogger(__name__)
-DEFAULT_LOCATION = 'us-east-1'
 
 
 def query(key, keyid, method='GET', params=None, headers=None,
@@ -90,11 +88,6 @@ def query(key, keyid, method='GET', params=None, headers=None,
     if not key or not keyid:
         key = salt.utils.aws.IROLE_CODE
         keyid = salt.utils.aws.IROLE_CODE
-
-    if not location:
-        location = iam.get_iam_region()
-    if not location:
-        location = DEFAULT_LOCATION
 
     data = ''
     if method == 'PUT':


### PR DESCRIPTION
Requires #26446
## Why?

salt.utils.aws is a more feature complete and more often used lib. This reduces code duplication, gives us one less place with a hard coded us-east-1 location.

salt.utils.aws.get_region_from_metadata() has neater error handling and a caching feature to avoid unnecessary calls to network stack.
## Details

If no location is configured, let salt.utils.s3.query() pass location=None to salt.utils.aws.sig4() so that salt.utils.aws.get_region_from_metadata() can be used.
## Deprecation

In this codebase, salt.utils.s3 is the only module that imports salt.utils.iam. This change deprecates salt.utils.iam, but I didn't dare remove the file. I would like advice on how to handle deprecation.
