### PR TITLE
Fix error detection when salt-cloud config is missing a master's address

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -76,7 +76,8 @@ def enter_mainloop(target,
                    pool_size=None,
                    callback=None,
                    queue=None):
-    '''Manage a multiprocessing pool
+    '''
+    Manage a multiprocessing pool
 
     - If the queue does not output anything, the pool runs indefinitely
 
@@ -1172,12 +1173,11 @@ class Cloud(object):
         )
 
         if deploy:
-            if make_master is False and 'master' not in minion_dict:
+            if make_master is not True and 'master' not in minion_dict:
                 raise SaltCloudConfigError(
-                    (
-                        'There\'s no master defined on the '
-                        '{0!r} VM settings'
-                    ).format(vm_['name'])
+                    'There\'s no master defined on the {0!r} VM settings'.format(
+                        vm_['name']
+                    )
                 )
 
             if 'pub_key' not in vm_ and 'priv_key' not in vm_:

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1173,9 +1173,9 @@ class Cloud(object):
         )
 
         if deploy:
-            if make_master is not True and 'master' not in minion_dict:
+            if not make_master and 'master' not in minion_dict:
                 raise SaltCloudConfigError(
-                    'There\'s no master defined on the {0!r} VM settings'.format(
+                    'There\'s no master defined on the {0!r} VM settings.'.format(
                         vm_['name']
                     )
                 )

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1174,7 +1174,7 @@ class Cloud(object):
 
         if deploy:
             if not make_master and 'master' not in minion_dict:
-                raise SaltCloudConfigError(
+                log.warn(
                     'There\'s no master defined on the {0!r} VM settings.'.format(
                         vm_['name']
                     )


### PR DESCRIPTION
Fixes #20169

The error checking to raise a SaltCloudConfigError was in place to provide a warning if a user forgets to define where the master is in the provider/profile configs, but the logic was incorrect. The error would not be shown unless `make_master` was set to `False`. However, `make_master` defaults to `None`.
