### PR TITLE
Add netaddress module for getting info about IP networks

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -174,6 +174,7 @@ Full list of builtin execution modules
     nacl
     nagios
     nagios_rpc
+    netaddress
     netbsd_sysctl
     netbsdservice
     netscaler

--- a/doc/ref/modules/all/salt.modules.netaddress.rst
+++ b/doc/ref/modules/all/salt.modules.netaddress.rst
@@ -1,0 +1,6 @@
+=======================
+salt.modules.netaddress
+=======================
+
+.. automodule:: salt.modules.netaddress
+    :members:

--- a/salt/modules/netaddress.py
+++ b/salt/modules/netaddress.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+'''
+Module for getting information about network addresses.
+
+.. versionadded:: TBD
+
+:depends: netaddr
+'''
+
+__virtualname__ = 'netaddress'
+
+# Import third party libs
+try:
+    import netaddr
+    HAS_NETADDR = True
+except ImportError as e:
+    print e
+    HAS_NETADDR = False
+
+
+def __virtual__():
+    '''
+    Only load if netaddr library exist.
+    '''
+    if not HAS_NETADDR:
+        return False
+    return __virtualname__
+
+
+def list_cidr_ips(cidr):
+    '''
+    Get a list of IP addresses from a CIDR.
+
+    CLI example::
+
+        salt myminion netaddress.list_cidr_ips 192.168.0.0/20
+    '''
+    ips = netaddr.IPNetwork(cidr)
+    return [str(ip) for ip in list(ips)]
+
+
+def list_cidr_ips_ipv6(cidr):
+    '''
+    Get a list of IPv6 addresses from a CIDR.
+
+    CLI example::
+
+        salt myminion netaddress.list_cidr_ips_ipv6 192.168.0.0/20
+    '''
+    ips = netaddr.IPNetwork(cidr)
+    return [str(ip.ipv6()) for ip in list(ips)]
+
+
+def cidr_netmask(cidr):
+    '''
+    Get the netmask address associated with a CIDR address.
+
+    CLI example::
+
+        salt myminion netaddress.cidr_netmask 192.168.0.0/20
+    '''
+    ips = netaddr.IPNetwork(cidr)
+    return str(ips.netmask)
+
+
+def cidr_broadcast(cidr):
+    '''
+    Get the broadcast address associated with a CIDR address.
+
+    CLI example::
+
+        salt myminion netaddress.cidr_netmask 192.168.0.0/20
+    '''
+    ips = netaddr.IPNetwork(cidr)
+    return str(ips.broadcast)

--- a/salt/modules/netaddress.py
+++ b/salt/modules/netaddress.py
@@ -2,7 +2,7 @@
 '''
 Module for getting information about network addresses.
 
-.. versionadded:: TBD
+.. versionadded:: Boron
 
 :depends: netaddr
 '''

--- a/salt/modules/netaddress.py
+++ b/salt/modules/netaddress.py
@@ -6,6 +6,7 @@ Module for getting information about network addresses.
 
 :depends: netaddr
 '''
+from __future__ import absolute_import
 
 __virtualname__ = 'netaddress'
 

--- a/salt/modules/netaddress.py
+++ b/salt/modules/netaddress.py
@@ -14,7 +14,6 @@ try:
     import netaddr
     HAS_NETADDR = True
 except ImportError as e:
-    print e
     HAS_NETADDR = False
 
 


### PR DESCRIPTION
Ability to get some basic info back about network ranges via CIDR addresses. For instance, get a list of IP addresses within a CIDR range, or get the netmask or broadcast address of the CIDR range.
