### PR TITLE
Added git version check to git module

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -11,10 +11,7 @@ import logging
 import os
 import re
 import shlex
-<<<<<<< 4790356e44d9f147b42e8d5cfc9a06fb815d28a3
 import sys
-=======
->>>>>>> removed subprocess import
 from distutils.version import LooseVersion as _LooseVersion
 
 # Import salt libs

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -11,7 +11,10 @@ import logging
 import os
 import re
 import shlex
+<<<<<<< 4790356e44d9f147b42e8d5cfc9a06fb815d28a3
 import sys
+=======
+>>>>>>> removed subprocess import
 from distutils.version import LooseVersion as _LooseVersion
 
 # Import salt libs


### PR DESCRIPTION
Older versions of git do not have some CLI flags, like --local. This allows for compatibility with old versions of git. 
