### PR TITLE
Adding support for dnf to yumpkg.py

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1198,7 +1198,7 @@ def upgrade(refresh=True, fromrepo=None, skip_verify=False, name=None, pkgs=None
         pkgname, version_num = pkg_item_list
         targets.append(pkgname)
 
-    cmd = '{yum_command}-q -y {repo} {exclude} {branch} {gpgcheck} upgrade {pkgs}'.format(
+    cmd = '{yum_command} -q -y {repo} {exclude} {branch} {gpgcheck} upgrade {pkgs}'.format(
         yum_command=_yum(),
         repo=repo_arg,
         exclude=exclude_arg,

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -136,9 +136,9 @@ def _repoquery(repoquery_args,
     _check_repoquery()
 
     if _yum() == 'dnf':
-      _query_format = query_format.replace('-%{VERSION}_', '-%{EPOCH}:%{VERSION}_')
+        _query_format = query_format.replace('-%{VERSION}_', '-%{EPOCH}:%{VERSION}_')
     else:
-      _query_format = query_format
+        _query_format = query_format
 
     cmd = 'repoquery --plugins --queryformat {0} {1}'.format(
         _cmd_quote(_query_format), repoquery_args
@@ -159,11 +159,11 @@ def _repoquery(repoquery_args,
         )
     else:
         if _yum() == 'dnf':
-          # Remove the epoch when it is zero to maintain backward compatibility
-          remove_zero_epoch = call['stdout'].replace('-0:', '-')
-          out = remove_zero_epoch
+            # Remove the epoch when it is zero to maintain backward compatibility
+            remove_zero_epoch = call['stdout'].replace('-0:', '-')
+            out = remove_zero_epoch
         else:
-          out = call['stdout']
+            out = call['stdout']
         return out.splitlines()
 
 

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1068,7 +1068,7 @@ def install(name=None,
         __salt__['cmd.run'](cmd, output_loglevel='trace')
 
     if to_reinstall:
-        cmd = '{yum_command} {repo} {exclude} {branch} {gpgcheck} reinstall {pkg}'.format(
+        cmd = '{yum_command} -y {repo} {exclude} {branch} {gpgcheck} reinstall {pkg}'.format(
             yum_command=_yum(),
             repo=repo_arg,
             exclude=exclude_arg,

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -74,6 +74,28 @@ def __virtual__():
     return False
 
 
+def _yum():
+    '''
+    return yum or dnf depending on version
+    '''
+    contextkey = 'yum_bin'
+    if contextkey not in __context__:
+        try:
+            osrelease = int(__grains__['osrelease'])
+        except ValueError:
+            log.warning(
+                'Unexpected osrelease grain \'{0}\', please report this'
+                .format(__grains__['osrelease'])
+            )
+            __context__[contextkey] = 'yum'
+        else:
+            if 'fedora' in __grains__['os'].lower() and osrelease >= 22:
+                __context__[contextkey] = 'dnf'
+            else:
+                __context__[contextkey] = 'yum'
+    return __context__[contextkey]
+
+
 def _repoquery_pkginfo(repoquery_args):
     '''
     Wrapper to call repoquery and parse out all the tuples
@@ -96,7 +118,7 @@ def _check_repoquery():
     '''
     if not salt.utils.which('repoquery'):
         __salt__['cmd.run'](
-            ['yum', '-y', 'install', 'yum-utils'],
+            [_yum(), '-y', 'install', 'yum-utils'],
             python_shell=False,
             output_loglevel='trace'
         )
@@ -112,8 +134,14 @@ def _repoquery(repoquery_args,
     Runs a repoquery command and returns a list of namedtuples
     '''
     _check_repoquery()
+
+    if _yum() == 'dnf':
+      _query_format = query_format.replace('-%{VERSION}_', '-%{EPOCH}:%{VERSION}_')
+    else:
+      _query_format = query_format
+
     cmd = 'repoquery --plugins --queryformat {0} {1}'.format(
-        _cmd_quote(query_format), repoquery_args
+        _cmd_quote(_query_format), repoquery_args
     )
     call = __salt__['cmd.run_all'](cmd, output_loglevel='trace')
     if call['retcode'] != 0:
@@ -130,7 +158,12 @@ def _repoquery(repoquery_args,
             '{0}'.format(comment)
         )
     else:
-        out = call['stdout']
+        if _yum() == 'dnf':
+          # Remove the epoch when it is zero to maintain backward compatibility
+          remove_zero_epoch = call['stdout'].replace('-0:', '-')
+          out = remove_zero_epoch
+        else:
+          out = call['stdout']
         return out.splitlines()
 
 
@@ -747,8 +780,8 @@ def refresh_db(branch_arg=None, repo_arg=None, exclude_arg=None, branch=None, re
         1: False,
     }
 
-    clean_cmd = ['yum', '-q', 'clean', 'expire-cache']
-    update_cmd = ['yum', '-q', 'check-update']
+    clean_cmd = [_yum(), '-q', 'clean', 'expire-cache']
+    update_cmd = [_yum(), '-q', 'check-update']
 
     if repo:
         clean_cmd.append(repo)
@@ -1013,7 +1046,8 @@ def install(name=None,
                 downgrade.append(pkgstr)
 
     if targets:
-        cmd = 'yum -y {repo} {exclude} {branch} {gpgcheck} install {pkg}'.format(
+        cmd = '{yum_command} -y {repo} {exclude} {branch} {gpgcheck} install {pkg}'.format(
+            yum_command=_yum(),
             repo=repo_arg,
             exclude=exclude_arg,
             branch=branch_arg,
@@ -1023,7 +1057,8 @@ def install(name=None,
         __salt__['cmd.run'](cmd, output_loglevel='trace')
 
     if downgrade:
-        cmd = 'yum -y {repo} {exclude} {branch} {gpgcheck} downgrade {pkg}'.format(
+        cmd = '{yum_command} -y {repo} {exclude} {branch} {gpgcheck} downgrade {pkg}'.format(
+            yum_command=_yum(),
             repo=repo_arg,
             exclude=exclude_arg,
             branch=branch_arg,
@@ -1033,7 +1068,8 @@ def install(name=None,
         __salt__['cmd.run'](cmd, output_loglevel='trace')
 
     if to_reinstall:
-        cmd = 'yum -y {repo} {exclude} {branch} {gpgcheck} reinstall {pkg}'.format(
+        cmd = '{yum_command} {repo} {exclude} {branch} {gpgcheck} reinstall {pkg}'.format(
+            yum_command=_yum(),
             repo=repo_arg,
             exclude=exclude_arg,
             branch=branch_arg,
@@ -1162,7 +1198,8 @@ def upgrade(refresh=True, fromrepo=None, skip_verify=False, name=None, pkgs=None
         pkgname, version_num = pkg_item_list
         targets.append(pkgname)
 
-    cmd = 'yum -q -y {repo} {exclude} {branch} {gpgcheck} upgrade {pkgs}'.format(
+    cmd = '{yum_command}-q -y {repo} {exclude} {branch} {gpgcheck} upgrade {pkgs}'.format(
+        yum_command=_yum(),
         repo=repo_arg,
         exclude=exclude_arg,
         branch=branch_arg,
@@ -1216,7 +1253,9 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=W0613
     if not targets:
         return {}
     quoted_targets = [_cmd_quote(target) for target in targets]
-    cmd = 'yum -q -y remove {0}'.format(' '.join(quoted_targets))
+    cmd = '{yum_command} -q -y remove {0}'.format(
+        ' '.join(quoted_targets),
+        yum_command=_yum())
     __salt__['cmd.run'](cmd, output_loglevel='trace')
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
@@ -1334,7 +1373,9 @@ def hold(name=None, pkgs=None, sources=None, **kwargs):  # pylint: disable=W0613
                 ret[target]['comment'] = ('Package {0} is set to be held.'
                                           .format(target))
             else:
-                cmd = 'yum -q versionlock {0}'.format(target)
+                cmd = '{yum_command} -q versionlock {0}'.format(
+                    target,
+                    yum_command=_yum())
                 out = __salt__['cmd.run_all'](cmd)
 
                 if out['retcode'] == 0:
@@ -1423,8 +1464,9 @@ def unhold(name=None, pkgs=None, sources=None, **kwargs):  # pylint: disable=W06
                                           .format(target))
             else:
                 quoted_targets = [_cmd_quote(item) for item in search_locks]
-                cmd = 'yum -q versionlock delete {0}'.format(
-                        ' '.join(quoted_targets)
+                cmd = '{yum_command} -q versionlock delete {0}'.format(
+                        ' '.join(quoted_targets),
+                        yum_command=_yum()
                         )
                 out = __salt__['cmd.run_all'](cmd)
 
@@ -1455,7 +1497,7 @@ def get_locked_packages(pattern=None, full=True):
 
         salt '*' pkg.get_locked_packages
     '''
-    cmd = 'yum -q versionlock list'
+    cmd = '{yum_command} -q versionlock list'.format(yum_command=_yum())
     ret = __salt__['cmd.run'](cmd).split('\n')
 
     if pattern:
@@ -1519,7 +1561,7 @@ def group_list():
         salt '*' pkg.group_list
     '''
     ret = {'installed': [], 'available': [], 'installed environments': [], 'available environments': [], 'available languages': {}}
-    cmd = 'yum grouplist'
+    cmd = '{yum_command} grouplist'.format(yum_command=_yum())
     out = __salt__['cmd.run_stdout'](cmd, output_loglevel='trace').splitlines()
     key = None
     for idx in range(len(out)):


### PR DESCRIPTION
Used by Fedora 22 and beyond in place of yum.

Adding support for dnf's requirement of epoch when not zero. Format is `%{name}-%{epoch}:%{version}-%{release}`.

Strip the epoch when it is zero for dnf to preserve backward compatibility.
