### PR TITLE
Ensure GCE and EC2 configuration checks are correct

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -188,26 +188,28 @@ def __virtual__():
         return False
 
     for provider, details in six.iteritems(__opts__['providers']):
-        if 'provider' not in details or details['provider'] != 'ec2':
+        if 'ec2' not in details:
             continue
 
-        if not os.path.exists(details['private_key']):
+        parameters = details['ec2']
+
+        if not os.path.exists(parameters['private_key']):
             raise SaltCloudException(
                 'The EC2 key file {0!r} used in the {1!r} provider '
                 'configuration does not exist\n'.format(
-                    details['private_key'],
+                    parameters['private_key'],
                     provider
                 )
             )
 
         keymode = str(
-            oct(stat.S_IMODE(os.stat(details['private_key']).st_mode))
+            oct(stat.S_IMODE(os.stat(parameters['private_key']).st_mode))
         )
         if keymode not in ('0400', '0600'):
             raise SaltCloudException(
                 'The EC2 key file {0!r} used in the {1!r} provider '
                 'configuration needs to be set to mode 0400 or 0600\n'.format(
-                    details['private_key'],
+                    parameters['private_key'],
                     provider
                 )
             )

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -131,26 +131,32 @@ def __virtual__():
         return False
 
     for provider, details in __opts__['providers'].iteritems():
-        if 'provider' not in details or details['provider'] != 'gce':
+        if 'gce' not in details:
             continue
 
-        pathname = os.path.expanduser(details['service_account_private_key'])
+        parameters = details['gce']
+        pathname = os.path.expanduser(parameters['service_account_private_key'])
+
         if not os.path.exists(pathname):
             raise SaltCloudException(
                 'The GCE service account private key {0!r} used in '
                 'the {1!r} provider configuration does not exist\n'.format(
-                    details['service_account_private_key'], provider
+                    parameters['service_account_private_key'],
+                    provider
                 )
             )
+
         keymode = str(
             oct(stat.S_IMODE(os.stat(pathname).st_mode))
         )
+
         if keymode not in ('0400', '0600'):
             raise SaltCloudException(
                 'The GCE service account private key {0!r} used in '
                 'the {1!r} provider configuration needs to be set to '
                 'mode 0400 or 0600\n'.format(
-                    details['service_account_private_key'], provider
+                    parameters['service_account_private_key'],
+                    provider
                 )
             )
 


### PR DESCRIPTION
Fixes #15590

Previously, the extra configuration checks for key file permissions weren't getting hit in the EC2 and GCE drivers. This fixes that. 
