### PR TITLE
Skip tests that don't work with older mock

### DIFF
--- a/tests/unit/modules/artifactory_test.py
+++ b/tests/unit/modules/artifactory_test.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 from salt.modules import artifactory
-from salttesting import TestCase
-from salttesting.mock import MagicMock
+from salttesting import TestCase, skipIf
+from salttesting.mock import MagicMock, NO_MOCK, NO_MOCK_REASON
 
 
+@skipIf(NO_MOCK, NO_MOCK_REASON)
 class ArtifactoryTestCase(TestCase):
 
     org_module_functions = {}

--- a/tests/unit/modules/gpg_test.py
+++ b/tests/unit/modules/gpg_test.py
@@ -10,13 +10,13 @@ from __future__ import absolute_import
 from salttesting import TestCase, skipIf
 from salttesting.mock import (
     MagicMock,
+    mock_open,
     patch,
     NO_MOCK,
     NO_MOCK_REASON
 )
 
 from salttesting.helpers import ensure_in_syspath
-from mock import mock_open
 
 ensure_in_syspath('../../')
 

--- a/tests/unit/modules/groupadd_test.py
+++ b/tests/unit/modules/groupadd_test.py
@@ -4,8 +4,8 @@
 '''
 
 # Import Salt Testing Libs
-from salttesting import TestCase
-from salttesting.mock import MagicMock, patch
+from salttesting import TestCase, skipIf
+from salttesting.mock import MagicMock, patch, NO_MOCK, NO_MOCK_REASON
 #-------- from salt.exceptions import SaltInvocationError, CommandExecutionError
 
 # Import Salt Libs
@@ -15,6 +15,7 @@ from salt.modules import groupadd
 import grp
 
 
+@skipIf(NO_MOCK, NO_MOCK_REASON)
 class GroupAddTestCase(TestCase):
     '''
     TestCase for salt.modules.groupadd

--- a/tests/unit/modules/jboss7_test.py
+++ b/tests/unit/modules/jboss7_test.py
@@ -4,8 +4,8 @@ from salt.utils.odict import OrderedDict
 
 from salt.modules import jboss7
 
-from salttesting import TestCase
-from salttesting.mock import MagicMock
+from salttesting import TestCase, skipIf
+from salttesting.mock import MagicMock, NO_MOCK, NO_MOCK_REASON
 
 try:
     # will pass if executed along with other tests
@@ -15,6 +15,7 @@ except NameError:
     __builtin__.__salt__ = {}
 
 
+@skipIf(NO_MOCK, NO_MOCK_REASON)
 class JBoss7TestCase(TestCase):
     jboss_config = {}
     org_run_operation = None

--- a/tests/unit/modules/win_network_test.py
+++ b/tests/unit/modules/win_network_test.py
@@ -213,22 +213,6 @@ class WinNetworkTestCase(TestCase):
                           MagicMock(return_value=True)):
             self.assertTrue(win_network.in_subnet('10.1.1.0/16'))
 
-    # 'ip_addrs' function tests: 1
-
-    def test_ip_addrs(self):
-        '''
-        Test if it returns a list of IPv4 addresses assigned to the host.
-        '''
-        self.assertTrue(win_network.ip_addrs())
-
-    # 'ip_addrs6' function tests: 1
-
-    def test_ip_addrs6(self):
-        '''
-        Test if it returns a list of IPv6 addresses assigned to the host.
-        '''
-        self.assertTrue(win_network.ip_addrs6())
-
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/unit/states/archive_test.py
+++ b/tests/unit/states/archive_test.py
@@ -72,15 +72,9 @@ class ArchiveTest(TestCase):
                                                    'file.file_exists': mock_false,
                                                    'file.makedirs': mock_true,
                                                    'cmd.run_all': mock_run}):
-                    if HAS_PWD:
-                        running_as = pwd.getpwuid(os.getuid()).pw_name
-                    else:
-                        running_as = 'root'
                     filename = os.path.join(
                         tmp_dir,
-                        'files/test/_tmp{0}_test_archive_.tar'.format(
-                            '' if running_as == 'root' else '_{0}'.format(running_as)
-                        )
+                        'files/test/_tmp_test_archive_.tar'
                     )
                     for test_opts, ret_opts in zip(test_tar_opts, ret_tar_opts):
                         ret = archive.extracted(tmp_dir,

--- a/tests/unit/states/archive_test.py
+++ b/tests/unit/states/archive_test.py
@@ -6,11 +6,6 @@ unit tests for the archive state
 # Import Python Libs
 import os
 import tempfile
-try:
-    import pwd
-    HAS_PWD = True
-except ImportError:
-    HAS_PWD = False
 
 # Import Salt Libs
 from salt.states import archive

--- a/tests/unit/states/file_test.py
+++ b/tests/unit/states/file_test.py
@@ -253,7 +253,6 @@ class FileTestCase(TestCase):
                                                   group=group), ret)
 
     # 'absent' function tests: 1
-    @patch.object(os.path, 'islink', MagicMock(return_value=False))
     def test_absent(self):
         '''
         Test to make sure that the named file or directory is absent.
@@ -272,61 +271,69 @@ class FileTestCase(TestCase):
 
         comt = ('Must provide name to file.absent')
         ret.update({'comment': comt, 'name': ''})
-        self.assertDictEqual(filestate.absent(''), ret)
 
-        with patch.object(os.path, 'isabs', mock_f):
-            comt = ('Specified file {0} is not an absolute path'
-                    .format(name))
-            ret.update({'comment': comt, 'name': name})
-            self.assertDictEqual(filestate.absent(name), ret)
+        with patch.object(os.path, 'islink', MagicMock(return_value=False)):
+            self.assertDictEqual(filestate.absent(''), ret)
 
-        with patch.object(os.path, 'isabs', mock_t):
-            comt = ('Refusing to make "/" absent')
-            ret.update({'comment': comt, 'name': '/'})
-            self.assertDictEqual(filestate.absent('/'), ret)
-
-        with patch.object(os.path, 'isfile', mock_t):
-            with patch.dict(filestate.__opts__, {'test': True}):
-                comt = ('File {0} is set for removal'.format(name))
-                ret.update({'comment': comt, 'name': name, 'result': None})
+            with patch.object(os.path, 'isabs', mock_f):
+                comt = ('Specified file {0} is not an absolute path'
+                        .format(name))
+                ret.update({'comment': comt, 'name': name})
                 self.assertDictEqual(filestate.absent(name), ret)
 
-            with patch.dict(filestate.__opts__, {'test': False}):
-                with patch.dict(filestate.__salt__,
-                                {'file.remove': mock_file}):
-                    comt = ('Removed file {0}'.format(name))
-                    ret.update({'comment': comt, 'result': True,
-                                'changes': {'removed': name}})
-                    self.assertDictEqual(filestate.absent(name), ret)
+            with patch.object(os.path, 'isabs', mock_t):
+                comt = ('Refusing to make "/" absent')
+                ret.update({'comment': comt, 'name': '/'})
+                self.assertDictEqual(filestate.absent('/'), ret)
 
-                    comt = ('Removed file {0}'.format(name))
-                    ret.update({'comment': '', 'result': False, 'changes': {}})
-                    self.assertDictEqual(filestate.absent(name), ret)
-
-        with patch.object(os.path, 'isfile', mock_f):
-            with patch.object(os.path, 'isdir', mock_t):
+            with patch.object(os.path, 'isfile', mock_t):
                 with patch.dict(filestate.__opts__, {'test': True}):
-                    comt = ('Directory {0} is set for removal'.format(name))
-                    ret.update({'comment': comt, 'result': None})
+                    comt = ('File {0} is set for removal'.format(name))
+                    ret.update({'comment': comt,
+                                'name': name,
+                                'result': None})
                     self.assertDictEqual(filestate.absent(name), ret)
 
                 with patch.dict(filestate.__opts__, {'test': False}):
-                    with patch.object(shutil, 'rmtree', mock_tree):
-                        comt = ('Removed directory {0}'.format(name))
+                    with patch.dict(filestate.__salt__,
+                                    {'file.remove': mock_file}):
+                        comt = ('Removed file {0}'.format(name))
                         ret.update({'comment': comt, 'result': True,
                                     'changes': {'removed': name}})
                         self.assertDictEqual(filestate.absent(name), ret)
 
-                        comt = ('Failed to remove directory {0}'.format(name))
-                        ret.update({'comment': comt, 'result': False,
+                        comt = ('Removed file {0}'.format(name))
+                        ret.update({'comment': '',
+                                    'result': False,
                                     'changes': {}})
                         self.assertDictEqual(filestate.absent(name), ret)
 
-            with patch.object(os.path, 'isdir', mock_f):
-                with patch.dict(filestate.__opts__, {'test': True}):
-                    comt = ('File {0} is not present'.format(name))
-                    ret.update({'comment': comt, 'result': True})
-                    self.assertDictEqual(filestate.absent(name), ret)
+            with patch.object(os.path, 'isfile', mock_f):
+                with patch.object(os.path, 'isdir', mock_t):
+                    with patch.dict(filestate.__opts__, {'test': True}):
+                        comt = \
+                            'Directory {0} is set for removal'.format(name)
+                        ret.update({'comment': comt, 'result': None})
+                        self.assertDictEqual(filestate.absent(name), ret)
+
+                    with patch.dict(filestate.__opts__, {'test': False}):
+                        with patch.object(shutil, 'rmtree', mock_tree):
+                            comt = ('Removed directory {0}'.format(name))
+                            ret.update({'comment': comt, 'result': True,
+                                        'changes': {'removed': name}})
+                            self.assertDictEqual(filestate.absent(name), ret)
+
+                            comt = \
+                                'Failed to remove directory {0}'.format(name)
+                            ret.update({'comment': comt, 'result': False,
+                                        'changes': {}})
+                            self.assertDictEqual(filestate.absent(name), ret)
+
+                with patch.object(os.path, 'isdir', mock_f):
+                    with patch.dict(filestate.__opts__, {'test': True}):
+                        comt = ('File {0} is not present'.format(name))
+                        ret.update({'comment': comt, 'result': True})
+                        self.assertDictEqual(filestate.absent(name), ret)
 
     # 'exists' function tests: 1
 

--- a/tests/unit/states/jboss7_test.py
+++ b/tests/unit/states/jboss7_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from salttesting import TestCase
-from salttesting.mock import MagicMock
+from salttesting import TestCase, skipIf
+from salttesting.mock import MagicMock, NO_MOCK, NO_MOCK_REASON
 from salt.states import jboss7
 from salt.exceptions import CommandExecutionError
 import __builtin__
@@ -13,6 +13,7 @@ except NameError:
     __builtin__.__salt__ = {}
 
 
+@skipIf(NO_MOCK, NO_MOCK_REASON)
 class JBoss7StateTestCase(TestCase):
 
     org_module_functions = {}


### PR DESCRIPTION
This fixes test failures on RHEL6 builds in the Fedora Buildsystem.

This also removes two win_network tests which were clearly made to pass only
in Jenkins, and not in a chrooted build environment.
