### PR TITLE
Using .zip archives as self-contained Salt modules

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -661,6 +661,23 @@ This setting requires that ``gcc`` and ``cython`` are installed on the minion
 
     cython_enable: False
 
+.. conf_minion:: enable_zip_modules
+
+``enable_zip_modules``
+----------------------
+
+.. versionadded:: 2015.8.0
+
+Default: ``False``
+
+Set this value to true to enable loading of zip archives as extension modules.
+This allows for packing module code with specific dependencies to avoid conflicts
+and/or having to install specific modules' dependencies in system libraries.
+
+.. code-block:: yaml
+
+    enable_zip_modules: False
+
 .. conf_minion:: providers
 
 ``providers``

--- a/doc/ref/modules/index.rst
+++ b/doc/ref/modules/index.rst
@@ -48,6 +48,86 @@ starts, so only the ``*.pyx`` file is required.
 
 .. _`Cython`: http://cython.org/
 
+Zip Archives as Modules
+=======================
+Python 2.3 and higher allows developers to directly import zip archives containing Python code.
+By setting :conf_minion:`enable_zip_modules` to ``True`` in the minion config, the Salt loader
+will be able to import ``.zip`` files in this fashion.  This allows Salt module developers to
+package dependencies with their modules for ease of deployment, isolation, etc.
+
+For a user, Zip Archive modules behave just like other modules.  When executing a function from a
+module provided as the file ``my_module.zip``, a user would call a function within that module
+as ``my_module.<function>``.
+
+Creating a Zip Archive Module
+-----------------------------
+A Zip Archive module is structured similarly to a simple `Python package`_.  The ``.zip`` file contains
+a single directory with the same name as the module.  The module code traditionally in ``<module_name>.py``
+goes in ``<module_name>/__init__.py``.  The dependency packages are subdirectories of ``<module_name>/``.
+
+Here is an example directory structure for the ``lumberjack`` module, which has two library dependencies
+(``sleep`` and ``work``) to be included.
+
+.. code-block:: bash
+
+    modules $ ls -R lumberjack
+    __init__.py     sleep           work
+
+    lumberjack/sleep:
+    __init__.py
+
+    lumberjack/work:
+    __init__.py
+
+The contents of ``lumberjack/__init__.py`` show how to import and use these included libraries.
+
+.. code-block:: python
+
+    # Libraries included in lumberjack.zip
+    from lumberjack import sleep, work
+
+
+    def is_ok(person):
+        ''' Checks whether a person is really a lumberjack '''
+        return sleep.all_night(person) and work.all_day(person)
+
+Then, create the zip:
+
+.. code-block:: bash
+
+    modules $ zip -r lumberjack lumberjack
+      adding: lumberjack/ (stored 0%)
+      adding: lumberjack/__init__.py (deflated 39%)
+      adding: lumberjack/sleep/ (stored 0%)
+      adding: lumberjack/sleep/__init__.py (deflated 7%)
+      adding: lumberjack/work/ (stored 0%)
+      adding: lumberjack/work/__init__.py (deflated 7%)
+    modules $ unzip -l lumberjack.zip
+    Archive:  lumberjack.zip
+      Length     Date   Time    Name
+     --------    ----   ----    ----
+            0  08-21-15 20:08   lumberjack/
+          348  08-21-15 20:08   lumberjack/__init__.py
+            0  08-21-15 19:53   lumberjack/sleep/
+           83  08-21-15 19:53   lumberjack/sleep/__init__.py
+            0  08-21-15 19:53   lumberjack/work/
+           81  08-21-15 19:21   lumberjack/work/__init__.py
+     --------                   -------
+          512                   6 files
+
+Once placed in :conf_master:`file_roots`, Salt users can distribute and use ``lumberjack.zip`` like any other module.
+
+.. code-block:: bash
+
+    $ sudo salt minion1 saltutil.sync_modules
+    minion1:
+      - modules.lumberjack
+    $ sudo salt minion1 lumberjack.is_ok 'Michael Palin'
+    minion1:
+      True
+
+.. _`Python package`: https://docs.python.org/2/tutorial/modules.html#packages
+
 Cross-Calling Modules
 =====================
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -297,6 +297,9 @@ VALID_OPTS = {
     # Tell the loader to attempt to import *.pyx cython files if cython is available
     'cython_enable': bool,
 
+    # Tell the loader to attempt to import *.zip archives
+    'enable_zip_modules': bool,
+
     # Tell the client to show minions that have timed out
     'show_timeout': bool,
 
@@ -851,6 +854,7 @@ DEFAULT_MINION_OPTS = {
     'test': False,
     'ext_job_cache': '',
     'cython_enable': False,
+    'enable_zip_modules': False,
     'state_verbose': True,
     'state_output': 'full',
     'state_output_diff': False,

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -17,6 +17,7 @@ import logging
 import inspect
 import tempfile
 from collections import MutableMapping
+from zipimport import zipimporter
 
 # Import salt libs
 from salt.exceptions import LoaderError
@@ -943,6 +944,9 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             except ImportError:
                 log.info('Cython is enabled in the options but not present '
                     'in the system path. Skipping Cython modules.')
+        # Allow for zipimport of modules
+        if self.opts.get('enable_zipmodules', True) is True:
+            self.suffix_map['.zip'] = tuple()
         # allow for module dirs
         self.suffix_map[''] = ('', '', imp.PKG_DIRECTORY)
 
@@ -1070,6 +1074,8 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             sys.path.append(os.path.dirname(fpath))
             if suffix == '.pyx':
                 mod = self.pyximport.load_module(name, fpath, tempfile.gettempdir())
+            if suffix == '.zip':
+                mod = zipimporter(fpath).load_module(name)
             else:
                 desc = self.suffix_map[suffix]
                 # if it is a directory, we dont open a file

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -949,7 +949,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                 log.info('Cython is enabled in the options but not present '
                     'in the system path. Skipping Cython modules.')
         # Allow for zipimport of modules
-        if self.opts.get('enable_zipmodules', True) is True:
+        if self.opts.get('enable_zip_modules', True) is True:
             self.suffix_map['.zip'] = tuple()
         # allow for module dirs
         self.suffix_map[''] = ('', '', imp.PKG_DIRECTORY)

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -945,7 +945,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                 log.info('Cython is enabled in the options but not present '
                     'in the system path. Skipping Cython modules.')
         # Allow for zipimport of modules
-        if self.opts.get('enable_zipmodules', True) is True:
+        if self.opts.get('enable_zip_modules', True) is True:
             self.suffix_map['.zip'] = tuple()
         # allow for module dirs
         self.suffix_map[''] = ('', '', imp.PKG_DIRECTORY)

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -108,7 +108,7 @@ def _sync(form, saltenv=None):
         # Grab only the desired files (.py, .pyx, .so)
         cache.extend(
             __salt__['cp.cache_dir'](
-                source, sub_env, include_pat=r'E@\.(pyx?|so)$'
+                source, sub_env, include_pat=r'E@\.(pyx?|so|zip)$'
             )
         )
         local_cache_dir = os.path.join(


### PR DESCRIPTION
I need a way to distribute Salt modules with their dependencies packaged up and potentially isolated from one another (e.g. module `foo` needs version 1.0 of library `bar`, but module `baz` needs version 2.0 of `bar`).  @sixninetynine gave me the idea of using Python's built-in zip archive import capabilities and it works great.  The code changes involved to allow this are minimal.  This PR is 90% documentation on how to make use of the feature :laughing: 

This should work for any type of extension module that's picked up by the LazyLoader (execution modules, state modules, custom grains, etc.)

I put `versionadded:: 2015.8.0` in the docs for the minion config option, since I figure this is probably a pretty easy backport.  Thanks!
