### PR TITLE
reinit crypto like in #23825

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -85,6 +85,7 @@ def gen_keys(keydir, keyname, keysize, user=None):
     priv = '{0}.pem'.format(base)
     pub = '{0}.pub'.format(base)
 
+    salt.utils.reinit_crypto()
     gen = RSA.generate(bits=keysize, e=65537)
     if os.path.isfile(priv):
         # Between first checking and the generation another process has made


### PR DESCRIPTION
Without this, salt-cloud fails when running using cloud.profile in a
reactor. so does runnerclient.cmd('cloud.profile').
