### PR TITLE
Give MacOS an 'os_family' grain

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1299,6 +1299,7 @@ def os_data():
     elif grains['kernel'] == 'Darwin':
         osrelease = __salt__['cmd.run']('sw_vers -productVersion')
         grains['os'] = 'MacOS'
+        grains['os_family'] = 'MacOS'
         grains['osrelease'] = osrelease
         grains['osmajorrelease'] = osrelease.rsplit('.', 1)[0]
         grains.update(_bsd_cpudata(grains))


### PR DESCRIPTION
- MacOS seemed to be the only OS without an os_family named.
- Formulas based on os_family for cross platform were unnecessarily difficult because of this.
