### PR TITLE
`__pillar__` can be a boolean, don't assume it's a `dict`.

### DIFF
--- a/salt/grains/opts.py
+++ b/salt/grains/opts.py
@@ -9,6 +9,7 @@ def opts():
     '''
     Return the minion configuration settings
     '''
-    if __opts__.get('grain_opts', False) or __pillar__.get('grain_opts', False):
+    if __opts__.get('grain_opts', False) or \
+            (isinstance(__pillar__, dict) and __pillar__.get('grain_opts', False)):
         return __opts__
     return {}


### PR DESCRIPTION
Fixes #26559
