### PR TITLE
Allow the loader to embed standard python modules

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -998,8 +998,8 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                             self.file_mapping[f_noext] = (fpath, ext)
                 except OSError:
                     continue
-            for smod in self.static_modules:
-                self.file_mapping[smod] = (smod, '.o')
+        for smod in self.static_modules:
+            self.file_mapping[smod] = (smod, '.o')
 
     def clear(self):
         '''

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -844,6 +844,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                  pack=None,
                  whitelist=None,
                  virtual_enable=True,
+                 static_modules=None
                  ):  # pylint: disable=W0231
 
         self.opts = self.__prep_mod_opts(opts)
@@ -867,6 +868,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         self.missing_modules = {}  # mapping of name -> error
         self.loaded_modules = {}  # mapping of module_name -> dict_of_functions
         self.loaded_files = set()  # TODO: just remove them from file_mapping?
+        self.static_modules = static_modules if static_modules else []
 
         self.disabled = set(self.opts.get('disable_{0}s'.format(self.tag), []))
 
@@ -996,6 +998,8 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                             self.file_mapping[f_noext] = (fpath, ext)
                 except OSError:
                     continue
+            for smod in self.static_modules:
+                self.file_mapping[smod] = (smod, '.o')
 
     def clear(self):
         '''
@@ -1070,6 +1074,8 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             sys.path.append(os.path.dirname(fpath))
             if suffix == '.pyx':
                 mod = self.pyximport.load_module(name, fpath, tempfile.gettempdir())
+            if suffix == '.o':
+                mod = __import__(fpath, globals(), locals(), [], -1)
             else:
                 desc = self.suffix_map[suffix]
                 # if it is a directory, we dont open a file

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -999,7 +999,8 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                 except OSError:
                     continue
         for smod in self.static_modules:
-            self.file_mapping[smod] = (smod, '.o')
+            f_noext = smod.split('.')[-1]
+            self.file_mapping[f_noext] = (smod, '.o')
 
     def clear(self):
         '''
@@ -1075,7 +1076,13 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             if suffix == '.pyx':
                 mod = self.pyximport.load_module(name, fpath, tempfile.gettempdir())
             if suffix == '.o':
-                mod = __import__(fpath, globals(), locals(), [], -1)
+                top_mod = __import__(fpath, globals(), locals(), [], -1)
+                comps = fpath.split('.')
+                if len(comps) < 2:
+                    mod = top_mod
+                else:
+                    for subname in comps[1:]:
+                        mod = getattr(top_mod, subname)
             else:
                 desc = self.suffix_map[suffix]
                 # if it is a directory, we dont open a file

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1076,13 +1076,14 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             if suffix == '.pyx':
                 mod = self.pyximport.load_module(name, fpath, tempfile.gettempdir())
             if suffix == '.o':
-                top_mod = __import__(fpath, globals(), locals(), [], -1)
+                top_mod = __import__(fpath, globals(), locals(), [])
                 comps = fpath.split('.')
                 if len(comps) < 2:
                     mod = top_mod
                 else:
+                    mod = top_mod
                     for subname in comps[1:]:
-                        mod = getattr(top_mod, subname)
+                        mod = getattr(mod, subname)
             else:
                 desc = self.suffix_map[suffix]
                 # if it is a directory, we dont open a file


### PR DESCRIPTION
This is just a little addition to the loader so that arbitrary modules can be loaded without looking up the filesystem locations
