### PR TITLE
Augeas: Improve command parsery.

### DIFF
--- a/salt/modules/augeas_cfg.py
+++ b/salt/modules/augeas_cfg.py
@@ -31,6 +31,7 @@ import re
 import logging
 from salt.ext.six.moves import zip
 import salt.ext.six as six
+import shlex
 
 # Make sure augeas python interface is installed
 HAS_AUGEAS = False
@@ -113,6 +114,23 @@ def execute(context=None, lens=None, commands=()):
         'remove': 'remove',
     }
 
+    arg_map = {
+        'set':    (1, 2),
+        'setm':   (2, 3),
+        'move':   (2,),
+        'insert': (3,),
+        'remove': (1,),
+    }
+
+    def make_path(path):
+        if not context:
+            return path
+        path = path.lstrip('/')
+        if path:
+            return os.path.join(context, path)
+        else:
+            return context
+
     flags = _Augeas.NO_MODL_AUTOLOAD if lens else _Augeas.NONE
     aug = _Augeas(flags=flags)
 
@@ -128,36 +146,34 @@ def execute(context=None, lens=None, commands=()):
             return ret
 
         method = method_map[cmd]
+        nargs = arg_map[method]
 
         try:
+            parts = shlex.split(arg)
+            if len(parts) not in nargs:
+                err = '{0} takes {1} args: {2}'.format(method, nargs, parts)
+                raise ValueError(err)
             if method == 'set':
-                path, value, remainder = re.split('([^\'" ]+|"[^"]*"|\'[^\']*\')$', arg, 1)
-                path = path.rstrip()
-                if context:
-                    path = os.path.join(context.rstrip('/'), path.lstrip('/'))
-                value = value.strip('"').strip("'")
+                path = make_path(parts[0])
+                value = parts[1] if len(parts) == 2 else None
                 args = {'path': path, 'value': value}
             elif method == 'setm':
-                base, sub, value = re.findall('([^\'" ]+|"[^"]*"|\'[^\']*\')', arg)
-                base = base.rstrip()
-                if context:
-                    base = os.path.join(context.rstrip('/'), base.lstrip('/'))
-                value = value.strip('"').strip("'")
+                base = make_path(parts[0])
+                sub = parts[1]
+                value = parts[2] if len(parts) == 3 else None
                 args = {'base': base, 'sub': sub, 'value': value}
             elif method == 'move':
-                path, dst = arg.split(' ', 1)
-                if context:
-                    path = os.path.join(context.rstrip('/'), path.lstrip('/'))
+                path = make_path(parts[0])
+                dst = parts[1]
                 args = {'src': path, 'dst': dst}
             elif method == 'insert':
-                label, where, path = re.split(' (before|after) ', arg)
-                if context:
-                    path = os.path.join(context.rstrip('/'), path.lstrip('/'))
+                label, where, path = parts
+                if where not in ("before", "after"):
+                  raise ValueError("Expected 'before' or 'after', not %r" % (where,))
+                path = make_path(path)
                 args = {'path': path, 'label': label, 'before': where == 'before'}
             elif method == 'remove':
-                path = arg
-                if context:
-                    path = os.path.join(context.rstrip('/'), path.lstrip('/'))
+                path = make_path(parts[0])
                 args = {'path': path}
         except ValueError as err:
             log.error(str(err))

--- a/salt/modules/augeas_cfg.py
+++ b/salt/modules/augeas_cfg.py
@@ -168,8 +168,8 @@ def execute(context=None, lens=None, commands=()):
                 args = {'src': path, 'dst': dst}
             elif method == 'insert':
                 label, where, path = parts
-                if where not in ("before", "after"):
-                    raise ValueError("Expected 'before' or 'after', not %r" % (where,))
+                if where not in ('before', 'after'):
+                    raise ValueError('Expected "before" or "after", not {0}'.format(where))
                 path = make_path(path)
                 args = {'path': path, 'label': label, 'before': where == 'before'}
             elif method == 'remove':

--- a/salt/modules/augeas_cfg.py
+++ b/salt/modules/augeas_cfg.py
@@ -169,7 +169,7 @@ def execute(context=None, lens=None, commands=()):
             elif method == 'insert':
                 label, where, path = parts
                 if where not in ("before", "after"):
-                  raise ValueError("Expected 'before' or 'after', not %r" % (where,))
+                    raise ValueError("Expected 'before' or 'after', not %r" % (where,))
                 path = make_path(path)
                 args = {'path': path, 'label': label, 'before': where == 'before'}
             elif method == 'remove':


### PR DESCRIPTION
- Use shlex for shell quoting (e.g. `setm /foo "*[label() ~= 'bar']" baz`).
- Allow None values.
- Check argument count.
