### PR TITLE
Fixes for git.latest, git module integration tests, etc.

### DIFF
--- a/doc/topics/releases/beryllium.rst
+++ b/doc/topics/releases/beryllium.rst
@@ -45,21 +45,27 @@ The git state and execution modules have gone through an extensive overhaul.
 Changes in the :py:func:`git.latest <salt.states.git.latest>` State
 -------------------------------------------------------------------
 
-- The ``branch`` parameter has been added, allowing for a custom branch name to
+- The ``branch`` argument has been added, allowing for a custom branch name to
   be used in the local checkout maintained by the :py:func:`git.latest
   <salt.states.git.latest>` state. This can be helpful in avoiding ambiguous
-  refs in the local checkout when a tag is used as the ``rev`` parameter. If no
+  refs in the local checkout when a tag is used as the ``rev`` argument. If no
   ``branch`` is specified, then the state uses the value of ``rev`` as the
   branch name.
-- The ``remote_name`` parameter has been deprecated and renamed to ``remote``.
-- The ``force`` parameter has been deprecated and renamed to ``force_clone`` to
-  reduce ambiguity with the other "force" parameters.
-- Using SHA1 hashes (full or shortened) in the ``rev`` parameter is now
+- The ``always_fetch`` argument no longer has any effect, and will be removed
+  in a future release. The state now detects whether or not a fetch is needed
+  based on comparisons made between the local and remote repositories.
+- The ``force_fetch`` argument has been added to force a fetch if the fetch is
+  not a fast-forward (for instance, if someone has done a reset and
+  force-pushed to the remote repository).
+- The ``remote_name`` argument has been deprecated and renamed to ``remote``.
+- The ``force`` argument has been deprecated and renamed to ``force_clone`` to
+  reduce ambiguity with the other "force" arguments.
+- Using SHA1 hashes (full or shortened) in the ``rev`` argument is now
   properly supported.
 - Non-fast-forward merges are now detected before the repository is updated,
   and the state will not update the repository if the change is not a
   fast-forward. Non-fast-forward updates must be overridden with the
-  ``force_reset`` parameter. If ``force_reset`` is set to ``True``, the state
+  ``force_reset`` argument. If ``force_reset`` is set to ``True``, the state
   will only reset the repository if it cannot be fast-forwarded. This is in
   contrast to the earlier behavior, in which a hard-reset would be performed
   every time the state was run if ``force_reset`` was set to ``True``.
@@ -126,9 +132,9 @@ Changes to Functions in Git Execution Module
 
 - Now returns ``True`` when the ``git archive`` command was successful, and
   otherwise raises an error.
-- ``overwrite`` argument added to prevent an exixting archive from being
-  overwritten by this function.
-- ``fmt`` argument deprecated and renamed to ``format``
+- The ``overwrite`` argument has been added to prevent an existing archive from
+  being overwritten by this function.
+- The ``fmt`` argument has been deprecated and renamed to ``format``.
 - Trailing slash no longer implied in ``prefix`` argument, must be included if
   this argument is passed.
 
@@ -146,24 +152,24 @@ Changes to Functions in Git Execution Module
   which to clone the repository. If this option is specified, then the clone
   will be made within the directory specified by the ``cwd``, instead of at
   that location.
-- ``repository`` argument deprecated and renamed to ``url``
+- The ``repository`` argument has been deprecated and renamed to ``url``.
 
 :py:func:`git.config_get <salt.modules.git.config_get>`
 *******************************************************
 
-- ``setting_name`` argument deprecated and renamed to ``key``
+- The ``setting_name`` argument has been deprecated and renamed to ``key``.
 - The ``global`` argument has been added, to query the global git configuration
 - The ``all`` argument has been added to return a list of all values for the
   specified key, allowing for all values in a multivar to be returned.
-- ``cwd`` argument is now optional if ``global`` is set to ``True``
+- The ``cwd`` argument is now optional if ``global`` is set to ``True``
 
 :py:func:`git.config_set <salt.modules.git.config_set>`
 *******************************************************
 
 - The value(s) of the key being set are now returned
-- ``setting_name`` argument deprecated and renamed to ``key``
-- ``setting_value`` argument deprecated and renamed to ``value``
-- ``is_global`` argument deprecated and renamed to ``global``
+- The ``setting_name`` argument has been deprecated and renamed to ``key``.
+- The ``setting_value`` argument has been deprecated and renamed to ``value``.
+- The ``is_global`` argument has been deprecated and renamed to ``global``.
 - The ``multivar`` argument has been added to specify a list of values to set
   for the specified key. The ``value`` argument is not compatible with
   ``multivar``.
@@ -171,18 +177,30 @@ Changes to Functions in Git Execution Module
   just adds an ``--add`` to the ``git config`` command that is run to set the
   value).
 
+:py:func:`git.fetch <salt.modules.git.fetch>`
+*********************************************
+
+- The ``force`` argument has been added to force the fetch when it is not a
+  fast-forward. This could have been achieved in previous Salt versions by
+  including ``--force`` in the ``opts`` argument, this argument is just for
+  convenience and to match the usage of other functions with ``force``
+  arguments.
+- The ``refspecs`` argument has been added to allow for one or more refspecs to
+  be provided which overide the one(s) specified by the
+  **remote.remote_name.fetch** git configuration option.
+
 :py:func:`git.ls_remote <salt.modules.git.ls_remote>`
 *****************************************************
 
-- ``repository`` argument deprecated and renamed to ``remote``
-- ``branch`` argument deprecated and renamed to ``ref``
+- The ``repository`` argument has been deprecated and renamed to ``remote``.
+- The ``branch`` argument has been deprecated and renamed to ``ref``.
 - The ``opts`` argument has been added to allow for additional CLI options to
   be passed to the ``git ls-remote`` command.
 
 :py:func:`git.merge <salt.modules.git.merge>`
 *********************************************
 
-- The ``branch`` argument deprecated and renamed to ``rev``
+- The ``branch`` argument has been deprecated and renamed to ``rev``.
 
 :py:func:`git.status <salt.modules.git.status>`
 ***********************************************

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -627,7 +627,7 @@ def latest(name,
                 elif fast_forward is True:
                     merge_action = 'fast-forwarded'
                 else:
-                    merge_action = None
+                    merge_action = 'updated'
 
                 if local_branch is None:
                     # No local branch, no upstream tracking branch

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -110,8 +110,8 @@ def _uptodate(ret, target, comments=None):
         # Shouldn't be making any changes if the repo was up to date, but
         # report on them so we are alerted to potential problems with our
         # logic.
-        msg += '\n\nChanges already made: '
-        msg += _format_comments(comments)
+        ret['comment'] += '\n\nChanges already made: '
+        ret['comment'] += _format_comments(comments)
     return ret
 
 

--- a/tests/integration/modules/git.py
+++ b/tests/integration/modules/git.py
@@ -46,8 +46,9 @@ def _worktrees_supported():
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE).communicate()[0]
     if not git_version:
-        # Git not installed
+        log.debug('Git not installed')
         return False
+    log.debug('Detected git version ' + git_version)
     try:
         return LooseVersion(git_version.split()[-1]) >= LooseVersion('2.5.0')
     except Exception:

--- a/tests/integration/modules/git.py
+++ b/tests/integration/modules/git.py
@@ -41,7 +41,7 @@ def _worktrees_supported():
     '''
     git_version = subprocess.Popen(
         ['git', '--version'],
-        shell=True,
+        shell=False,
         close_fds=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE).communicate()[0]

--- a/tests/integration/modules/git.py
+++ b/tests/integration/modules/git.py
@@ -1,4 +1,11 @@
 # -*- coding: utf-8 -*-
+'''
+Tests for git execution module
+
+NOTE: These tests may modify the global git config, and have been marked as
+destructive as a result. If no values are set for user.name or user.email in
+the user's global .gitconfig, then these tests will set one.
+'''
 
 # Import Python Libs
 from __future__ import absolute_import
@@ -33,7 +40,7 @@ def _worktrees_supported():
     Check if the git version is 2.5.0 or later
     '''
     git_version = subprocess.Popen(
-        'git --version',
+        ['git', '--version'],
         shell=True,
         close_fds=True,
         stdout=subprocess.PIPE,
@@ -56,6 +63,7 @@ def _makedirs(path):
             raise
 
 
+@destructiveTest
 @skip_if_binaries_missing('git')
 class GitModuleTest(integration.ModuleCase):
 
@@ -77,11 +85,22 @@ class GitModuleTest(integration.ModuleCase):
                     fp_.write('This is a test file named ' + filename + '.')
         # Navigate to the root of the repo to init, stage, and commit
         os.chdir(self.repo)
+        # Initialize a new git repository
         subprocess.check_call(['git', 'init', '--quiet', self.repo])
-        subprocess.check_call(
-            ['git', 'config', '--global', 'user.name', 'Jenkins'])
-        subprocess.check_call(
-            ['git', 'config', '--global', 'user.email', 'qa@saltstack.com'])
+
+        # Set user.name and user.email config attributes if not present
+        for key, value in (('user.name', 'Jenkins'),
+                           ('user.email', 'qa@saltstack.com')):
+            # Check if key is missing
+            keycheck = subprocess.Popen(
+                ['git', 'config', '--get', '--global', key],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE)
+            if keycheck.wait() != 0:
+                # Set the key if it is not present
+                subprocess.check_call(
+                    ['git', 'config', '--global', key, value])
+
         subprocess.check_call(['git', 'add', '.'])
         subprocess.check_call(
             ['git', 'commit', '--quiet', '--message', 'Initial commit']
@@ -300,7 +319,6 @@ class GitModuleTest(integration.ModuleCase):
         )
         self.assertTrue(bool(re.search(commit_re_prefix + commit_msg, ret)))
 
-    @destructiveTest
     def test_config(self):
         '''
         Test setting, getting, and unsetting config values


### PR DESCRIPTION
- Fix an oversight with the tests where the global user.name and user.email
  parameters were being set in the setUp routine even when they already exist,
  stomping on the ~/.gitconfig of whomever was running the test.
- Fix how git.latest handles non-fast-forward merges, as well as checking out a
  new branch when the current branch has uncommitted changes.
- Add 2 arguments to the git.fetch function.
- Deprecate the always_fetch argument from git.latest, as the logic for
  detecting when a fetch is necessary is now much more robust.
- Properly handle short-SHA1 revs
