### PR TITLE
Allow 'salt' command metadata to be a dict

### DIFF
--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -9,6 +9,7 @@ import sys
 import salt.utils.job
 from salt.ext.six import string_types
 from salt.utils import parsers, print_cli
+from salt.utils.args import yamlify_arg
 from salt.exceptions import (
         SaltClientError,
         SaltInvocationError,
@@ -134,7 +135,8 @@ class SaltCMD(parsers.SaltCMDOptionParser):
                 kwargs['ret_config'] = getattr(self.options, 'return_config')
 
             if getattr(self.options, 'metadata'):
-                kwargs['metadata'] = getattr(self.options, 'metadata')
+                kwargs['metadata'] = yamlify_arg(
+                        getattr(self.options, 'metadata'))
 
             # If using eauth and a token hasn't already been loaded into
             # kwargs, prompt the user to enter auth credentials


### PR DESCRIPTION
When invoking 'salt' on the command line, using the '--metadata'
option will not allow you to pass in data that will be represented
in Python as a dict. This data will be represented as a string.
There are situations where using a dict for metadata is desirable.
For instance, if one would want to pass a number of named options as
metadata.

To accomplish this, the metadata is simply fed through the function:
'salt.utils.args.yamlify_arg'. This function is versatile: if the
original input is not a string, it will return the original input. If
it fails to parse the input into the dict or other such object, it
will return the original input.

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
