### PR TITLE
Fix get_load in postgres returner

### DIFF
--- a/salt/returners/postgres.py
+++ b/salt/returners/postgres.py
@@ -204,7 +204,7 @@ def get_load(jid):
     cur.execute(sql, (jid,))
     data = cur.fetchone()
     if data:
-        return json.loads(data)
+        return json.loads(data[0])
     _close_conn(conn)
     return {}
 


### PR DESCRIPTION
The function `fetchone` always return a tuple (or None):
http://initd.org/psycopg/docs/cursor.html?highlight=fetchone#cursor.fetchone
