### PR TITLE
Refactor cloud provider tests to be more accurate

### DIFF
--- a/tests/integration/cloud/providers/digital_ocean.py
+++ b/tests/integration/cloud/providers/digital_ocean.py
@@ -78,61 +78,59 @@ class DigitalOceanTest(integration.ShellCase):
         '''
         Tests the return of running the --list-images command for digital ocean
         '''
-        image_name = '14.10 x64'
-        ret_str = '                {0}'.format(image_name)
-        list_images = self.run_cloud('--list-images {0}'.format(PROVIDER_NAME))
-        self.assertIn(ret_str, list_images)
+        image_list = self.run_cloud('--list-images {0}'.format(PROVIDER_NAME))
+        self.assertIn(
+            '14.04 x64',
+            [i.strip() for i in image_list]
+        )
 
     def test_list_locations(self):
         '''
         Tests the return of running the --list-locations command for digital ocean
         '''
-        location_name = 'San Francisco 1'
-        ret_str = '                {0}'.format(location_name)
-        list_locations = self.run_cloud('--list-locations {0}'.format(PROVIDER_NAME))
-        self.assertIn(ret_str, list_locations)
+        _list_locations = self.run_cloud('--list-locations {0}'.format(PROVIDER_NAME))
+        self.assertIn(
+            'San Francisco 1',
+            [i.strip() for i in _list_locations]
+        )
 
     def test_list_sizes(self):
         '''
         Tests the return of running the --list-sizes command for digital ocean
         '''
-        size_name = '16GB'
-        ret_str = '                {0}'.format(size_name)
-        list_sizes = self.run_cloud('--list-sizes {0}'.format(PROVIDER_NAME))
-        self.assertIn(ret_str, list_sizes)
+        _list_sizes = self.run_cloud('--list-sizes {0}'.format(PROVIDER_NAME))
+        self.assertIn(
+            '16gb',
+            [i.strip() for i in _list_sizes]
+        )
 
     def test_instance(self):
         '''
         Test creating an instance on DigitalOcean
         '''
-
-        # create the instance
-        instance = self.run_cloud('-p digitalocean-test {0}'.format(INSTANCE_NAME))
-        ret_str = '        {0}'.format(INSTANCE_NAME)
-
         # check if instance with salt installed returned
         try:
-            self.assertIn(ret_str, instance)
+            self.assertIn(
+                INSTANCE_NAME,
+                [i.strip() for i in self.run_cloud('-p digitalocean-test {0}'.format(INSTANCE_NAME))]
+            )
         except AssertionError:
             self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
             raise
 
         # delete the instance
-        delete = self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
-        ret_str = '                OK'
         try:
-            self.assertIn(ret_str, delete)
+            self.assertIn(
+                'True',
+                [i.strip() for i in self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))]
+            )
         except AssertionError:
             raise
 
         # Final clean-up of created instance, in case something went wrong.
         # This was originally in a tearDown function, but that didn't make sense
         # To run this for each test when not all tests create instances.
-        query = self.run_cloud('--query')
-        ret_str = '        {0}:'.format(INSTANCE_NAME)
-
-        # if test instance is still present, delete it
-        if ret_str in query:
+        if INSTANCE_NAME in [i.strip() for i in self.run_cloud('--query')]:
             self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
 
 

--- a/tests/integration/cloud/providers/digital_ocean.py
+++ b/tests/integration/cloud/providers/digital_ocean.py
@@ -9,6 +9,7 @@ import random
 import string
 
 # Import Salt Testing Libs
+from salttesting import skipIf
 from salttesting.helpers import ensure_in_syspath, expensiveTest
 
 ensure_in_syspath('../../../')
@@ -32,6 +33,8 @@ INSTANCE_NAME = __random_name()
 PROVIDER_NAME = 'digital_ocean'
 
 
+@skipIf(True, 'Valid provider configs are not available for the DigitalOcean v1 API '
+              'in conjunction with the configs needed for v2 API.')
 class DigitalOceanTest(integration.ShellCase):
     '''
     Integration tests for the DigitalOcean cloud provider in Salt-Cloud

--- a/tests/integration/cloud/providers/ec2.py
+++ b/tests/integration/cloud/providers/ec2.py
@@ -29,6 +29,7 @@ def __random_name(size=6):
 
 # Create the cloud instance name to be used throughout the tests
 INSTANCE_NAME = __random_name()
+PROVIDER_NAME = 'ec2'
 
 
 class EC2Test(integration.ShellCase):
@@ -44,31 +45,33 @@ class EC2Test(integration.ShellCase):
         super(EC2Test, self).setUp()
 
         # check if appropriate cloud provider and profile files are present
-        profile_str = 'ec2-config:'
-        provider = 'ec2'
+        profile_str = 'ec2-config'
         providers = self.run_cloud('--list-providers')
 
-        if profile_str not in providers:
+        if profile_str + ':' not in providers:
             self.skipTest(
                 'Configuration file for {0} was not found. Check {0}.conf files '
                 'in tests/integration/files/conf/cloud.*.d/ to run these tests.'
-                .format(provider)
+                .format(PROVIDER_NAME)
             )
 
         # check if id, key, keyname, securitygroup, private_key, location,
         # and provider are present
-        path = os.path.join(integration.FILES,
-                            'conf',
-                            'cloud.providers.d',
-                            provider + '.conf')
-        config = cloud_providers_config(path)
+        config = cloud_providers_config(
+            os.path.join(
+                integration.FILES,
+                'conf',
+                'cloud.providers.d',
+                PROVIDER_NAME + '.conf'
+            )
+        )
 
-        id = config['ec2-config']['ec2']['id']
-        key = config['ec2-config']['ec2']['key']
-        keyname = config['ec2-config']['ec2']['keyname']
-        sec_group = config['ec2-config']['ec2']['securitygroup']
-        private_key = config['ec2-config']['ec2']['private_key']
-        location = config['ec2-config']['ec2']['location']
+        id = config[profile_str][PROVIDER_NAME]['id']
+        key = config[profile_str][PROVIDER_NAME]['key']
+        keyname = config[profile_str][PROVIDER_NAME]['keyname']
+        sec_group = config[profile_str][PROVIDER_NAME]['securitygroup']
+        private_key = config[profile_str][PROVIDER_NAME]['private_key']
+        location = config[profile_str][PROVIDER_NAME]['location']
 
         conf_items = [id, key, keyname, sec_group, private_key, location]
         missing_conf_item = []
@@ -82,32 +85,29 @@ class EC2Test(integration.ShellCase):
                 'An id, key, keyname, security group, private key, and location must '
                 'be provided to run these tests. One or more of these elements is '
                 'missing. Check tests/integration/files/conf/cloud.providers.d/{0}.conf'
-                .format(provider)
+                .format(PROVIDER_NAME)
             )
 
     def test_instance(self):
         '''
         Tests creating and deleting an instance on EC2 (classic)
         '''
-
-        # create the instance
-        instance = self.run_cloud('-p ec2-test {0}'.format(INSTANCE_NAME))
-        ret_str = '{0}:'.format(INSTANCE_NAME)
-
-        # check if instance returned with salt installed
+        # check if instance with salt installed returned
         try:
-            self.assertIn(ret_str, instance)
+            self.assertIn(
+                INSTANCE_NAME,
+                [i.strip() for i in self.run_cloud('-p ec2-test {0}'.format(INSTANCE_NAME))]
+            )
         except AssertionError:
             self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
             raise
 
         # delete the instance
-        delete = self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
-        ret_str = '                    shutting-down'
-
-        # check if deletion was performed appropriately
         try:
-            self.assertIn(ret_str, delete)
+            self.assertIn(
+                INSTANCE_NAME + ':',
+                [i.strip() for i in self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))]
+            )
         except AssertionError:
             raise
 

--- a/tests/integration/cloud/providers/ec2.py
+++ b/tests/integration/cloud/providers/ec2.py
@@ -66,14 +66,14 @@ class EC2Test(integration.ShellCase):
             )
         )
 
-        id = config[profile_str][PROVIDER_NAME]['id']
+        id_ = config[profile_str][PROVIDER_NAME]['id']
         key = config[profile_str][PROVIDER_NAME]['key']
-        keyname = config[profile_str][PROVIDER_NAME]['keyname']
+        key_name = config[profile_str][PROVIDER_NAME]['keyname']
         sec_group = config[profile_str][PROVIDER_NAME]['securitygroup']
         private_key = config[profile_str][PROVIDER_NAME]['private_key']
         location = config[profile_str][PROVIDER_NAME]['location']
 
-        conf_items = [id, key, keyname, sec_group, private_key, location]
+        conf_items = [id_, key, key_name, sec_group, private_key, location]
         missing_conf_item = []
 
         for item in conf_items:

--- a/tests/integration/cloud/providers/ec2.py
+++ b/tests/integration/cloud/providers/ec2.py
@@ -92,22 +92,24 @@ class EC2Test(integration.ShellCase):
         '''
         Tests creating and deleting an instance on EC2 (classic)
         '''
-        # check if instance with salt installed returned
+        # create the instance
+        instance = self.run_cloud('-p ec2-test {0}'.format(INSTANCE_NAME))
+        ret_str = '{0}:'.format(INSTANCE_NAME)
+
+        # check if instance returned with salt installed
         try:
-            self.assertIn(
-                INSTANCE_NAME,
-                [i.strip() for i in self.run_cloud('-p ec2-test {0}'.format(INSTANCE_NAME))]
-            )
+            self.assertIn(ret_str, instance)
         except AssertionError:
             self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
             raise
 
         # delete the instance
+        delete = self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
+        ret_str = '                    shutting-down'
+
+        # check if deletion was performed appropriately
         try:
-            self.assertIn(
-                INSTANCE_NAME + ':',
-                [i.strip() for i in self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))]
-            )
+            self.assertIn(ret_str, delete)
         except AssertionError:
             raise
 

--- a/tests/integration/cloud/providers/gogrid.py
+++ b/tests/integration/cloud/providers/gogrid.py
@@ -5,6 +5,8 @@
 
 # Import Python Libs
 import os
+import random
+import string
 
 # Import Salt Testing Libs
 from salttesting import skipIf
@@ -15,6 +17,20 @@ ensure_in_syspath('../../../')
 # Import Salt Libs
 import integration
 from salt.config import cloud_providers_config
+
+
+def __random_name(size=6):
+    '''
+    Generates a random cloud instance name
+    '''
+    return 'CLOUD-TEST-' + ''.join(
+        random.choice(string.ascii_uppercase + string.digits)
+        for x in range(size)
+    )
+
+# Create the cloud instance name to be used throughout the tests
+INSTANCE_NAME = __random_name()
+PROVIDER_NAME = 'gogrid'
 
 
 @skipIf(True, 'waiting on bug report fixes from #13365')
@@ -31,53 +47,53 @@ class GoGridTest(integration.ShellCase):
         super(GoGridTest, self).setUp()
 
         # check if appropriate cloud provider and profile files are present
-        profile_str = 'gogrid-config:'
-        provider = 'gogrid'
+        profile_str = 'gogrid-config'
         providers = self.run_cloud('--list-providers')
-        if profile_str not in providers:
+        if profile_str + ':' not in providers:
             self.skipTest(
                 'Configuration file for {0} was not found. Check {0}.conf files '
                 'in tests/integration/files/conf/cloud.*.d/ to run these tests.'
-                .format(provider)
+                .format(PROVIDER_NAME)
             )
 
         # check if client_key and api_key are present
-        path = os.path.join(integration.FILES,
-                            'conf',
-                            'cloud.providers.d',
-                            provider + '.conf')
-        config = cloud_providers_config(path)
-        api = config['gogrid-config']['gogrid']['apikey']
-        shared_secret = config['gogrid-config']['gogrid']['sharedsecret']
+        config = cloud_providers_config(
+            os.path.join(
+                integration.FILES,
+                'conf',
+                'cloud.providers.d',
+                PROVIDER_NAME + '.conf'
+            )
+        )
+        api = config[profile_str][PROVIDER_NAME]['apikey']
+        shared_secret = config[profile_str][PROVIDER_NAME]['sharedsecret']
         if api == '' or shared_secret == '':
             self.skipTest(
                 'An api key and shared secret must be provided to run these tests. '
                 'Check tests/integration/files/conf/cloud.providers.d/{0}.conf'
-                .format(provider)
+                .format(PROVIDER_NAME)
             )
 
     def test_instance(self):
         '''
         Test creating an instance on GoGrid
         '''
-        name = 'gogrid-testing'
-
-        # create the instance
-        instance = self.run_cloud('-p gogrid-test {0}'.format(name))
-        ret_str = '        {0}'.format(name)
-
         # check if instance with salt installed returned
         try:
-            self.assertIn(ret_str, instance)
+            self.assertIn(
+                INSTANCE_NAME,
+                [i.strip() for i in self.run_cloud('-p gogrid-test {0}'.format(INSTANCE_NAME))]
+            )
         except AssertionError:
-            self.run_cloud('-d {0} --assume-yes'.format(name))
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
             raise
 
         # delete the instance
-        delete = self.run_cloud('-d {0} --assume-yes'.format(name))
-        ret_str = '            True'
         try:
-            self.assertIn(ret_str, delete)
+            self.assertIn(
+                INSTANCE_NAME + ':',
+                [i.strip() for i in self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))]
+            )
         except AssertionError:
             raise
 
@@ -85,13 +101,12 @@ class GoGridTest(integration.ShellCase):
         '''
         Clean up after tests
         '''
-        name = 'gogrid-testing'
         query = self.run_cloud('--query')
-        ret_str = '        {0}:'.format(name)
+        ret_str = '        {0}:'.format(INSTANCE_NAME)
 
         # if test instance is still present, delete it
         if ret_str in query:
-            self.run_cloud('-d {0} --assume-yes'.format(name))
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
 
 
 if __name__ == '__main__':

--- a/tests/integration/cloud/providers/linode.py
+++ b/tests/integration/cloud/providers/linode.py
@@ -37,6 +37,7 @@ def __random_name(size=6):
 
 # Create the cloud instance name to be used throughout the tests
 INSTANCE_NAME = __random_name()
+PROVIDER_NAME = 'linode'
 
 
 @skipIf(HAS_LIBCLOUD is False, 'salt-cloud requires >= libcloud 0.13.2')
@@ -53,29 +54,31 @@ class LinodeTest(integration.ShellCase):
         super(LinodeTest, self).setUp()
 
         # check if appropriate cloud provider and profile files are present
-        profile_str = 'linode-config:'
-        provider = 'linode'
+        profile_str = 'linode-config'
         providers = self.run_cloud('--list-providers')
-        if profile_str not in providers:
+        if profile_str + ':' not in providers:
             self.skipTest(
                 'Configuration file for {0} was not found. Check {0}.conf files '
                 'in tests/integration/files/conf/cloud.*.d/ to run these tests.'
-                .format(provider)
+                .format(PROVIDER_NAME)
             )
 
         # check if apikey and password are present
-        path = os.path.join(integration.FILES,
-                            'conf',
-                            'cloud.providers.d',
-                            provider + '.conf')
-        config = cloud_providers_config(path)
-        api = config['linode-config']['linode']['apikey']
-        password = config['linode-config']['linode']['password']
+        config = cloud_providers_config(
+            os.path.join(
+                integration.FILES,
+                'conf',
+                'cloud.providers.d',
+                PROVIDER_NAME + '.conf'
+            )
+        )
+        api = config[profile_str][PROVIDER_NAME]['apikey']
+        password = config[profile_str][PROVIDER_NAME]['password']
         if api == '' or password == '':
             self.skipTest(
                 'An api key and password must be provided to run these tests. Check '
                 'tests/integration/files/conf/cloud.providers.d/{0}.conf'.format(
-                    provider
+                    PROVIDER_NAME
                 )
             )
 
@@ -83,22 +86,22 @@ class LinodeTest(integration.ShellCase):
         '''
         Test creating an instance on Linode
         '''
-        # create the instance
-        instance = self.run_cloud('-p linode-test {0}'.format(INSTANCE_NAME))
-        ret_str = '        {0}'.format(INSTANCE_NAME)
-
         # check if instance with salt installed returned
         try:
-            self.assertIn(ret_str, instance)
+            self.assertIn(
+                INSTANCE_NAME,
+                [i.strip() for i in self.run_cloud('-p linode-test {0}'.format(INSTANCE_NAME))]
+            )
         except AssertionError:
             self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
             raise
 
         # delete the instance
-        delete = self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
-        ret_str = '            True'
         try:
-            self.assertIn(ret_str, delete)
+            self.assertIn(
+                INSTANCE_NAME + ':',
+                [i.strip() for i in self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))]
+            )
         except AssertionError:
             raise
 


### PR DESCRIPTION
The original way these were written, some we not accurately catching errors as well as they should have been. This fixes that and brings them more in line with each other.

@jtand
