### PR TITLE
Fix detection of powershell in win_service module.

### DIFF
--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -54,6 +54,7 @@ def has_powershell():
             return True
     return False
 
+
 def get_enabled():
     '''
     Return the enabled services

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 import salt.utils
 import time
 import logging
+import os
 from subprocess import list2cmdline
 from salt.ext.six.moves import zip
 from salt.ext.six.moves import range
@@ -45,10 +46,13 @@ def has_powershell():
 
         salt '*' service.has_powershell
     '''
-    return 'powershell' in __salt__['cmd.run'](
-            ['where', 'powershell'], python_shell=False
-        )
-
+    for path in os.environ["PATH"].split(os.pathsep):
+        path = path.strip('"')
+        fullpath = os.path.join(path, "powershell.exe")
+        fullpath = os.path.normpath(fullpath)
+        if os.path.isfile(fullpath) and os.access(fullpath, os.X_OK):
+            return True
+    return False
 
 def get_enabled():
     '''


### PR DESCRIPTION
Fix fo issue #26630 
win_service has_powershell function does not works on Windows XP because it uses the "where" command which is unavalaible on Windows XP.
I've change the method to check PATH environment variable.
