### PR TITLE
Free 'fun' from the function signature namespace

### DIFF
--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -888,7 +888,7 @@ def cmd_iter(tgt,
         yield ret
 
 
-def runner(fun, **kwargs):
+def runner(_fun, **kwargs):
     '''
     Execute a runner module (this function must be run on the master)
 
@@ -915,10 +915,10 @@ def runner(fun, **kwargs):
     else:
         rclient = salt.runner.RunnerClient(__opts__)
 
-    return rclient.cmd(fun, [], kwarg=kwargs)
+    return rclient.cmd(_fun, kwarg=kwargs)
 
 
-def wheel(fun, **kwargs):
+def wheel(_fun, **kwargs):
     '''
     Execute a wheel module (this function must be run on the master)
 
@@ -936,7 +936,7 @@ def wheel(fun, **kwargs):
         salt '*' saltutil.wheel key.accept match=jerry
     '''
     wclient = salt.wheel.WheelClient(__opts__)
-    return wclient.cmd(fun, kwarg=kwargs)
+    return wclient.cmd(_fun, kwarg=kwargs)
 
 
 # this is the only way I could figure out how to get the REAL file_roots


### PR DESCRIPTION
'fun' is a common argument in Salt. format_call will choke if you attempt to call a function that uses this argment. I.e.,:

``` python
>>> __salt__.saltutil.runner('mine.get', tgt='*', fun='network.ip_addrs', tgt_type='glob')
Traceback (most recent call last):
  File "<console>", line 1, in <module>
TypeError: runner() got multiple values for keyword argument 'fun'
```
