### PR TITLE
Added compare_versions to be used within jinja

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -977,3 +977,7 @@ def _get_latest_pkg_version(pkginfo):
     if len(pkginfo) == 1:
         return next(six.iterkeys(pkginfo))
     return sorted(pkginfo, cmp=_reverse_cmp_pkg_versions).pop()
+
+
+def compare_versions(ver1='', oper='==', ver2=''):
+    return salt.utils.compare_versions(ver1, oper, ver2)


### PR DESCRIPTION
So we can do version comparison from within winrepo sls files
Fixes #26131 
