### PR TITLE
Update win_dns_client.py

### DIFF
--- a/salt/modules/win_dns_client.py
+++ b/salt/modules/win_dns_client.py
@@ -45,10 +45,10 @@ def get_dns_servers(interface='Local Area Connection'):
         for iface in c.Win32_NetworkAdapter(NetEnabled=True):
             if interface == iface.NetConnectionID:
                 iface_config = c.Win32_NetworkAdapterConfiguration(Index=iface.Index).pop()
-+                try:
-+                    return list(iface_config.DNSServerSearchOrder)
-+                except:
-+                    return []                
+                try:
+                    return list(iface_config.DNSServerSearchOrder)
+                except TypeError:
+                    return []                
     log.debug('Interface "{0}" not found'.format(interface))
     return False
 

--- a/salt/modules/win_dns_client.py
+++ b/salt/modules/win_dns_client.py
@@ -45,7 +45,10 @@ def get_dns_servers(interface='Local Area Connection'):
         for iface in c.Win32_NetworkAdapter(NetEnabled=True):
             if interface == iface.NetConnectionID:
                 iface_config = c.Win32_NetworkAdapterConfiguration(Index=iface.Index).pop()
-                return list(iface_config.DNSServerSearchOrder)
++                try:
++                    return list(iface_config.DNSServerSearchOrder)
++                except:
++                    return []                
     log.debug('Interface "{0}" not found'.format(interface))
     return False
 

--- a/salt/modules/win_dns_client.py
+++ b/salt/modules/win_dns_client.py
@@ -48,7 +48,7 @@ def get_dns_servers(interface='Local Area Connection'):
                 try:
                     return list(iface_config.DNSServerSearchOrder)
                 except TypeError:
-                    return []                
+                    return []
     log.debug('Interface "{0}" not found'.format(interface))
     return False
 


### PR DESCRIPTION
If there is no dns address setted in the windows client, the iface_config.DNSServerSearchOrder method will return None, therefore this module will generate TypeError,  'NoneType' object is not iterable.
