### PR TITLE
Correct issue with docker api 1.19

### DIFF
--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -660,7 +660,7 @@ def create_container(image,
                 volumes.remove(volume)
 
     try:
-        if float(client.version()['ApiVersion']) > 1.18:
+        if salt.utils.version_cmp(client.version()['ApiVersion'], '1.18') == 1:
             container_info = client.create_container(
                 image=image,
                 command=command,

--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -660,25 +660,47 @@ def create_container(image,
                 volumes.remove(volume)
 
     try:
-        container_info = client.create_container(
-            image=image,
-            command=command,
-            hostname=hostname,
-            user=user,
-            detach=detach,
-            stdin_open=stdin_open,
-            tty=tty,
-            mem_limit=mem_limit,
-            ports=ports,
-            environment=environment,
-            dns=dns,
-            volumes=volumes,
-            volumes_from=volumes_from,
-            name=name,
-            cpu_shares=cpu_shares,
-            cpuset=cpuset,
-            host_config=docker.utils.create_host_config(binds=binds)
-        )
+        if float(client.version()['ApiVersion']) > 1.18:
+            container_info = client.create_container(
+                image=image,
+                command=command,
+                hostname=hostname,
+                user=user,
+                detach=detach,
+                stdin_open=stdin_open,
+                tty=tty,
+                ports=ports,
+                environment=environment,
+                dns=dns,
+                volumes=volumes,
+                volumes_from=volumes_from,
+                name=name,
+                cpu_shares=cpu_shares,
+                cpuset=cpuset,
+                host_config=docker.utils.create_host_config(binds=binds,
+                                                            mem_limit=mem_limit)
+            )
+        else:
+            container_info = client.create_container(
+                image=image,
+                command=command,
+                hostname=hostname,
+                user=user,
+                detach=detach,
+                stdin_open=stdin_open,
+                tty=tty,
+                mem_limit=mem_limit,
+                ports=ports,
+                environment=environment,
+                dns=dns,
+                volumes=volumes,
+                volumes_from=volumes_from,
+                name=name,
+                cpu_shares=cpu_shares,
+                cpuset=cpuset,
+                host_config=docker.utils.create_host_config(binds=binds)
+            )
+
         log.trace("docker.client.create_container returned: " + str(container_info))
         container = container_info['Id']
         callback = _valid

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -2660,11 +2660,13 @@ def create(image,
 
     # Added to manage api change in 1.19.
     # mem_limit and memswap_limit must be provided in host_config object
-    if float(version()['ApiVersion']) > 1.18:
+    if salt.utils.version_cmp(version()['ApiVersion'], '1.18') == 1:
         create_kwargs['host_config'] = docker.utils.create_host_config(mem_limit=create_kwargs.get('mem_limit'),
                                                                        memswap_limit=create_kwargs.get('memswap_limit'))
-        if 'mem_limit' in create_kwargs: del create_kwargs['mem_limit']
-        if 'memswap_limit' in create_kwargs: del create_kwargs['memswap_limit']
+        if 'mem_limit' in create_kwargs:
+            del create_kwargs['mem_limit']
+        if 'memswap_limit' in create_kwargs:
+            del create_kwargs['memswap_limit']
 
     log.debug(
         'dockerng.create is using the following kwargs to create '

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -2658,6 +2658,14 @@ def create(image,
             if 'api_name' in val:
                 create_kwargs[val['api_name']] = create_kwargs.pop(key)
 
+    # Added to manage api change in 1.19.
+    # mem_limit and memswap_limit must be provided in host_config object
+    if float(version()['ApiVersion']) > 1.18:
+        create_kwargs['host_config'] = docker.utils.create_host_config(mem_limit=create_kwargs.get('mem_limit'),
+                                                                       memswap_limit=create_kwargs.get('memswap_limit'))
+        if 'mem_limit' in create_kwargs: del create_kwargs['mem_limit']
+        if 'memswap_limit' in create_kwargs: del create_kwargs['memswap_limit']
+
     log.debug(
         'dockerng.create is using the following kwargs to create '
         'container \'{0}\' from image \'{1}\': {2}'


### PR DESCRIPTION
Correct issue with docker api 1.19 due to move of mem parameters to host_config object

This PR has been created due to feedback from https://github.com/saltstack/salt/pull/26614 in order to correct the issue on dockerng also not available in salt 2015.5 which was the release patched for the previous PR.
