### PR TITLE
new salt.states.host.only() function to limit names associated with an IP

### DIFF
--- a/salt/modules/hosts.py
+++ b/salt/modules/hosts.py
@@ -108,6 +108,10 @@ def get_alias(ip):
     '''
     Return the list of aliases associated with an ip
 
+    Aliases (host names) are returned in the order in which they
+    appear in the hosts file.  If there are no aliases associated with
+    the IP, an empty list is returned.
+
     CLI Example:
 
     .. code-block:: bash

--- a/salt/modules/hosts.py
+++ b/salt/modules/hosts.py
@@ -143,6 +143,11 @@ def set_host(ip, alias):
     Set the host entry in the hosts file for the given ip, this will overwrite
     any previous entry for the given ip
 
+    .. versionchanged:: XXXX.X.X
+        If ``alias`` does not include any host names (it is the empty
+        string or contains only whitespace), all entries for the given
+        IP address are removed.
+
     CLI Example:
 
     .. code-block:: bash
@@ -153,6 +158,12 @@ def set_host(ip, alias):
     ovr = False
     if not os.path.isfile(hfn):
         return False
+
+    line_to_add = ip + '\t\t' + alias + '\n'
+    # support removing a host entry by providing an empty string
+    if not alias.strip():
+        line_to_add = ''
+
     lines = salt.utils.fopen(hfn).readlines()
     for ind, line in enumerate(lines):
         tmpline = line.strip()
@@ -163,7 +174,7 @@ def set_host(ip, alias):
         comps = tmpline.split()
         if comps[0] == ip:
             if not ovr:
-                lines[ind] = ip + '\t\t' + alias + '\n'
+                lines[ind] = line_to_add
                 ovr = True
             else:  # remove other entries
                 lines[ind] = ''
@@ -171,7 +182,7 @@ def set_host(ip, alias):
         # make sure there is a newline
         if lines and not lines[-1].endswith(('\n', '\r')):
             lines[-1] = '{0}\n'.format(lines[-1])
-        line = ip + '\t\t' + alias + '\n'
+        line = line_to_add
         lines.append(line)
     with salt.utils.fopen(hfn, 'w+') as ofile:
         ofile.writelines(lines)

--- a/salt/states/host.py
+++ b/salt/states/host.py
@@ -39,10 +39,29 @@ Or using the ``names`` directive, you can put several names for the same IP.
         - names:
           - server1
 
+You can replace all existing names for a particular IP address:
+
+.. code-block:: yaml
+
+    127.0.1.1:
+      host.only:
+        - hostnames:
+          - foo.example.com
+          - foo
+
+Or delete all existing names for an address:
+
+.. code-block:: yaml
+
+    203.0.113.25:
+        host.only:
+          - hostnames: []
+
 '''
 from __future__ import absolute_import
 
 import salt.utils.validate.net
+import salt.ext.six as six
 
 
 def present(name, ip):  # pylint: disable=C0103
@@ -125,4 +144,55 @@ def absent(name, ip):  # pylint: disable=C0103
                     ret['result'] = False
                     comments.append('Failed to remove host')
     ret['comment'] = '\n'.join(comments)
+    return ret
+
+
+def only(name, hostnames):
+    '''
+    Ensure that only the given hostnames are associated with the
+    given IP address.
+
+    .. versionadded:: XXXX.X.X
+
+    name
+        The IP address to associate with the given hostnames.
+
+    hostnames
+        Either a single hostname or a list of hostnames to associate
+        with the given IP address in the given order.  Any other
+        hostname associated with the IP address is removed.  If no
+        hostnames are specified, all hostnames associated with the
+        given IP address are removed.
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': None,
+           'comment': ''}
+
+    if isinstance(hostnames, six.string_types):
+        hostnames = [hostnames]
+
+    old = ' '.join(__salt__['hosts.get_alias'](name))
+    new = ' '.join((x.strip() for x in hostnames))
+
+    if old == new:
+        ret['comment'] = 'IP address {0} already set to "{1}"'.format(
+            name, new)
+        ret['result'] = True
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'Would change {0} from "{1}" to "{2}"'.format(
+            name, old, new)
+        return ret
+
+    ret['result'] = __salt__['hosts.set_host'](name, new)
+    if not ret['result']:
+        ret['comment'] = ('hosts.set_host failed to change {0}'
+            + ' from "{1}" to "{2}"').format(name, old, new)
+        return ret
+
+    ret['comment'] = 'successfully changed {0} from "{1}" to "{2}"'.format(
+        name, old, new)
+    ret['changes'] = {name: {'old': old, 'new': new}}
     return ret

--- a/tests/unit/states/host_test.py
+++ b/tests/unit/states/host_test.py
@@ -21,6 +21,7 @@ from salttesting.mock import (
 ensure_in_syspath('../../')
 
 host.__salt__ = {}
+host.__opts__ = {}
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -51,6 +52,80 @@ class HostTestCase(TestCase):
         mock = MagicMock(return_value=False)
         with patch.dict(host.__salt__, {'hosts.has_pair': mock}):
             self.assertDictEqual(host.absent("salt", "127.0.0.1"), ret)
+
+    def test_only_already(self):
+        '''
+        Test only() when the state hasn't changed
+        '''
+        expected = {
+            'name': '127.0.1.1',
+            'changes': {},
+            'result': True,
+            'comment': 'IP address 127.0.1.1 already set to "foo.bar"'}
+        mock1 = MagicMock(return_value=['foo.bar'])
+        with patch.dict(host.__salt__, {'hosts.get_alias': mock1}):
+            mock2 = MagicMock(return_value=True)
+            with patch.dict(host.__salt__, {'hosts.set_host': mock2}):
+                with patch.dict(host.__opts__, {'test': False}):
+                    self.assertDictEqual(
+                        expected,
+                        host.only("127.0.1.1", 'foo.bar'))
+
+    def test_only_dryrun(self):
+        '''
+        Test only() when state would change, but it's a dry run
+        '''
+        expected = {
+            'name': '127.0.1.1',
+            'changes': {},
+            'result': None,
+            'comment': 'Would change 127.0.1.1 from "foo.bar" to "foo.bar foo"'}
+        mock1 = MagicMock(return_value=['foo.bar'])
+        with patch.dict(host.__salt__, {'hosts.get_alias': mock1}):
+            mock2 = MagicMock(return_value=True)
+            with patch.dict(host.__salt__, {'hosts.set_host': mock2}):
+                with patch.dict(host.__opts__, {'test': True}):
+                    self.assertDictEqual(
+                        expected,
+                        host.only("127.0.1.1", ['foo.bar', 'foo']))
+
+    def test_only_fail(self):
+        '''
+        Test only() when state change fails
+        '''
+        expected = {
+            'name': '127.0.1.1',
+            'changes': {},
+            'result': False,
+            'comment': 'hosts.set_host failed to change 127.0.1.1'
+                + ' from "foo.bar" to "foo.bar foo"'}
+        mock = MagicMock(return_value=['foo.bar'])
+        with patch.dict(host.__salt__, {'hosts.get_alias': mock}):
+            mock = MagicMock(return_value=False)
+            with patch.dict(host.__salt__, {'hosts.set_host': mock}):
+                with patch.dict(host.__opts__, {'test': False}):
+                    self.assertDictEqual(
+                        expected,
+                        host.only("127.0.1.1", ['foo.bar', 'foo']))
+
+    def test_only_success(self):
+        '''
+        Test only() when state successfully changes
+        '''
+        expected = {
+            'name': '127.0.1.1',
+            'changes': {'127.0.1.1': {'old': 'foo.bar', 'new': 'foo.bar foo'}},
+            'result': True,
+            'comment': 'successfully changed 127.0.1.1'
+                + ' from "foo.bar" to "foo.bar foo"'}
+        mock = MagicMock(return_value=['foo.bar'])
+        with patch.dict(host.__salt__, {'hosts.get_alias': mock}):
+            mock = MagicMock(return_value=True)
+            with patch.dict(host.__salt__, {'hosts.set_host': mock}):
+                with patch.dict(host.__opts__, {'test': False}):
+                    self.assertDictEqual(
+                        expected,
+                        host.only("127.0.1.1", ['foo.bar', 'foo']))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add a new function to the `host` state module named `only()` that sets the hostnames associated with an IP to a particular set of hostnames.  Any hostname already associated with the IP address that is not mentioned in the provided list is removed.  If no hostnames are provided, all hostnames associated with the IP address are removed.

Also extend `salt.modules.hosts.set_host()` to delete all entries if the provided aliases is the empty string.

The motivation for this is to set the hostnames for `127.0.1.1` on Debian-based systems.  See bug #26624.  (This is not a fix for that bug, but it's an alternative way to get the behavior I want.)
