### PR TITLE
Fixes to ipset module for 2015.8

### DIFF
--- a/salt/states/ipset.py
+++ b/salt/states/ipset.py
@@ -221,8 +221,8 @@ def present(name, entry=None, family='ipv4', **kwargs):
                     ret['changes'] = {'locale': name}
                     ret['result'] = True
                     ret['comment'] += 'entry {0} added to set {1} for family {2}\n'.format(
-                        kwargs['set_name'],
                         _entry,
+                        kwargs['set_name'],
                         family)
                 else:
                     ret['result'] = False

--- a/tests/unit/modules/ipset_test.py
+++ b/tests/unit/modules/ipset_test.py
@@ -185,13 +185,13 @@ comment support')
             self.assertEqual(ipset.check('set', 'entry'),
                              'Error: Set set does not exist')
 
-        with patch.object(ipset, '_find_set_type', return_value=True):
+        with patch.object(ipset, '_find_set_type', return_value='hash:ip'):
             with patch.object(ipset, '_find_set_members',
                               side_effect=['entry', '',
-                                           ["192.168.0.4", "192.168.0.5"],
-                                           ["192.168.0.3"], ["192.168.0.6"],
-                                           ["192.168.0.4", "192.168.0.5"],
-                                           ["192.168.0.3"], ["192.168.0.6"],
+                                           ['192.168.0.4', '192.168.0.5'],
+                                           ['192.168.0.3'], ['192.168.0.6'],
+                                           ['192.168.0.4', '192.168.0.5'],
+                                           ['192.168.0.3'], ['192.168.0.6'],
                                            ]):
                 self.assertTrue(ipset.check('set', 'entry'))
                 self.assertFalse(ipset.check('set', 'entry'))
@@ -200,6 +200,19 @@ comment support')
                 self.assertFalse(ipset.check('set', '192.168.0.4/31'))
                 self.assertTrue(ipset.check('set', '192.168.0.4-192.168.0.5'))
                 self.assertFalse(ipset.check('set', '192.168.0.4-192.168.0.5'))
+                self.assertFalse(ipset.check('set', '192.168.0.4-192.168.0.5'))
+
+        with patch.object(ipset, '_find_set_type', return_value='hash:net'):
+            with patch.object(ipset, '_find_set_members',
+                              side_effect=['entry', '',
+                                           '192.168.0.4/31', '192.168.0.4/30',
+                                           '192.168.0.4/31', '192.168.0.4/30',
+                                           ]):
+                self.assertTrue(ipset.check('set', 'entry'))
+                self.assertFalse(ipset.check('set', 'entry'))
+                self.assertTrue(ipset.check('set', '192.168.0.4/31'))
+                self.assertFalse(ipset.check('set', '192.168.0.4/31'))
+                self.assertTrue(ipset.check('set', '192.168.0.4-192.168.0.5'))
                 self.assertFalse(ipset.check('set', '192.168.0.4-192.168.0.5'))
 
     def test_test(self):


### PR DESCRIPTION
Fixes to ipset module when using hash:net set types for both IP ranges, networks with prefix length and single hosts with prefix length
