### PR TITLE
Update openbsdpkg.py

### DIFF
--- a/salt/modules/openbsdpkg.py
+++ b/salt/modules/openbsdpkg.py
@@ -105,9 +105,9 @@ def latest_version(*names, **kwargs):
             continue
         pkgname += '--{0}'.format(flavor) if flavor else ''
         cur = pkgs.get(pkgname, '')
-        if not cur or __salt__['pkg_resource.compare'](pkg1=cur,
-                                                       oper='<',
-                                                       pkg2=pkgver):
+        if not cur or salt.utils.compare_versions(ver1=cur,
+                                                  oper='<',
+                                                  ver2=pkgver):
             ret[pkgname] = pkgver
 
     # Return a string if only one package name passed


### PR DESCRIPTION
- It looks like function 'pkg_resource.compare' used in orig. file is obsolete, 
- change correcting following exception, when comparing currently installed and latest available package versions: 

```
   The minion function caused an exception: Traceback (most recent call last):
      File "/usr/local/lib/python2.7/site-packages/salt/minion.py", line 1161, in _thread_return
        return_data = func(*args, **kwargs)
      File "/usr/local/lib/python2.7/site-packages/salt/modules/openbsdpkg.py", line 108, in latest_version
        if not cur or __salt__['pkg_resource.compare'](pkg1=cur,
      File "/usr/local/lib/python2.7/site-packages/salt/utils/lazy.py", line 90, in __getitem__
        raise KeyError(key)
    KeyError: 'pkg_resource.compare'
~~
```
