### PR TITLE
Ignore the first element of kern.disks split, which is the sysctl name

### DIFF
--- a/salt/grains/ssds.py
+++ b/salt/grains/ssds.py
@@ -50,7 +50,7 @@ def _freebsd_ssds():
     camcontrol = salt.utils.which('camcontrol')
 
     devices = __salt__['cmd.run']('{0} kern.disks'.format(sysctl))
-    for device in devices.split(' '):
+    for device in devices.split(' ')[1:]:
         identify = __salt__['cmd.run']('{0} identify {1}'.format(camcontrol,
                                        device))
         if SSD_TOKEN in identify:


### PR DESCRIPTION
Thanks to @dneades for pointing this out.  It shouldn't have a functional impact but removes an unnecessary shell call for a nonexistent device.

This may just be for 2015.5, I rewrote a lot of the SSD grain as the new disk grain.  I'm not sure how cleanly that will upmerge so I'll send another PR that can be used or closed for 2015.8 at your call.
