### PR TITLE
Ignore the first element of kern.disks split, which is the sysctl name (new disks grain)

### DIFF
--- a/salt/grains/disks.py
+++ b/salt/grains/disks.py
@@ -72,7 +72,7 @@ def _freebsd_disks():
     devices = __salt__['cmd.run']('{0} -n kern.disks'.format(sysctl))
     SSD_TOKEN = 'non-rotating'
 
-    for device in devices.split(' '):
+    for device in devices.split(' ')[1:]:
         if device.startswith('cd'):
             log.debug('Disk grain skipping cd')
         elif _freebsd_vbox():


### PR DESCRIPTION
Same as https://github.com/saltstack/salt/pull/26700 just not sure if upmerge will handle the move from SSDs->disks grain new in 2015.8.  Feel free to close if it does :+1: 
