### PR TITLE
Ensure VM name is valid before trying to create Linode VM

### DIFF
--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -1028,18 +1028,20 @@ def _validate_name(name):
     '''
     Checks if the provided name fits Linode's labeling parameters.
 
+    .. versionadded:: 2015.5.6
+
     name
         The VM name to validate
     '''
-    ret = True
     name_length = len(name)
     regex = re.compile(r'^[a-zA-Z0-9][A-Za-z0-9_-]*[a-zA-Z0-9]$')
 
     if name_length < 3 or name_length > 48:
         ret = False
-
-    if not re.match(regex, name):
+    elif not re.match(regex, name):
         ret = False
+    else:
+        ret = True
 
     if ret is False:
         log.warning(

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -1033,15 +1033,12 @@ def _validate_name(name):
     '''
     ret = True
     name_length = len(name)
-    regex = re.compile(r'^\w+$')
+    regex = re.compile(r'^[a-zA-Z0-9][A-Za-z0-9_-]*[a-zA-Z0-9]$')
 
     if name_length < 3 or name_length > 48:
         ret = False
 
     if not re.match(regex, name):
-        ret = False
-
-    if name.startswith(('-', '_',)) or name.endswith(('-', '_',)):
         ret = False
 
     if ret is False:

--- a/tests/unit/cloud/clouds/linode_test.py
+++ b/tests/unit/cloud/clouds/linode_test.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Nicole Thomas <nicole@saltstack.com>`
+'''
+
+# Import Salt Libs
+from __future__ import absolute_import
+
+# Import Salt Testing Libs
+from salttesting import TestCase, skipIf
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../../')
+
+# Import Salt Libs
+from salt.cloud.clouds import linode
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class LinodeTestCase(TestCase):
+    '''
+    Unit TestCase for the salt.cloud.clouds.linode module.
+    '''
+
+    # _validate_name tests
+
+    def test_validate_name_first_character_invalid(self):
+        '''
+        Tests when name starts with an invalid character.
+        '''
+        # Test when name begins with a hyphen
+        self.assertFalse(linode._validate_name('-foo'))
+        
+        # Test when name begins with an underscore
+        self.assertFalse(linode._validate_name('_foo'))
+
+    def test_validate_name_last_character_invalid(self):
+        '''
+        Tests when name ends with an invalid character.
+        '''
+        # Test when name ends with a hyphen
+        self.assertFalse(linode._validate_name('foo-'))
+
+        # Test when name ends with an underscore
+        self.assertFalse(linode._validate_name('foo_'))
+
+    def test_validate_name_too_short(self):
+        '''
+        Tests when name has less than three letters.
+        '''
+        # Test when name is an empty string
+        self.assertFalse(linode._validate_name(''))
+
+        # Test when name is two letters long
+        self.assertFalse(linode._validate_name('ab'))
+
+        # Test when name is three letters long (valid)
+        self.assertTrue(linode._validate_name('abc'))
+
+    def test_validate_name_too_long(self):
+        '''
+        Tests when name has more than 48 letters.
+        '''
+        long_name = '1111-2222-3333-4444-5555-6666-7777-8888-9999-111'
+        # Test when name is 48 letters long (valid)
+        self.assertEqual(len(long_name), 48)
+        self.assertTrue(linode._validate_name(long_name))
+
+        # Test when name is more than 48 letters long
+        long_name += '1'
+        self.assertEqual(len(long_name), 49)
+        self.assertFalse(linode._validate_name(long_name))
+
+    def test_validate_name_invalid_characters(self):
+        '''
+        Tests when name contains invalid characters.
+        '''
+        # Test when name contains an invalid character
+        self.assertFalse(linode._validate_name('foo;bar'))
+
+        # Test when name contains non-ascii letters
+        self.assertFalse(linode._validate_name('fooàààààbar'))
+
+        # Test when name contains spaces
+        self.assertFalse(linode._validate_name('foo bar'))
+
+    def test_validate_name_valid_characters(self):
+        '''
+        Tests when name contains valid characters.
+        '''
+        # Test when name contains letters and numbers
+        self.assertTrue(linode._validate_name('foo123bar'))
+
+        # Test when name contains hyphens
+        self.assertTrue(linode._validate_name('foo-bar'))
+
+        # Test when name contains underscores
+        self.assertTrue(linode._validate_name('foo_bar'))
+
+        # Test when name start and end with numbers
+        self.assertTrue(linode._validate_name('1foo'))
+        self.assertTrue(linode._validate_name('foo0'))
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(LinodeTestCase, needs_daemon=False)

--- a/tests/unit/cloud/clouds/linode_test.py
+++ b/tests/unit/cloud/clouds/linode_test.py
@@ -31,7 +31,7 @@ class LinodeTestCase(TestCase):
         '''
         # Test when name begins with a hyphen
         self.assertFalse(linode._validate_name('-foo'))
-        
+
         # Test when name begins with an underscore
         self.assertFalse(linode._validate_name('_foo'))
 


### PR DESCRIPTION
Fixes #14612

In 2015.5, an error is caught when the vm name doesn't match Linode's label parameters. The side effect of this is that a `linode1234567` vm is created and left in the "Brand New" state. Another caveat of this bug is that in 2015.8 and onwards, the vm is created and bootstrapped with a minion, but since the label name is invalid (and an error isn't thrown by Linode's API), the minion id is never set as the Linode label so you can't reach the minion via salt.

I have fixed this by implementing a check at the beginning of the `create` function to ensure the vm name is a valid Linode label before firing off the create event.

I also wrote tests to ensure valid/invalid label names are caught appropriately.
