### PR TITLE
Move SPM paths around

### DIFF
--- a/doc/topics/spm/index.rst
+++ b/doc/topics/spm/index.rst
@@ -166,7 +166,7 @@ Pillars
 =======
 Formula packages include a pillar.example file. Rather than being placed in the
 formula directory, this file is renamed to ``<formula name>.sls.orig`` and
-placed in the ``pillar_roots``, where it can be easily updated to meet the
+placed in the ``pillar_path``, where it can be easily updated to meet the
 user's needs.
 
 Loader Modules
@@ -275,14 +275,14 @@ treated as if they have a ``-formula`` name.
 
 formula
 -------
-By default, most files from this type of package live in the ``/srv/salt/``
+By default, most files from this type of package live in the ``/srv/spm/salt/``
 directory. The exception is the ``pillar.example`` file, which will be renamed
-to ``<package_name>.sls`` and placed in the pillar directory (``/srv/pillar/``
+to ``<package_name>.sls`` and placed in the pillar directory (``/srv/spm/pillar/``
 by default).
 
 reactor
 -------
-By default, files from this type of package live in the ``/srv/reactor/``
+By default, files from this type of package live in the ``/srv/spm/reactor/``
 directory.
 
 conf

--- a/salt/config.py
+++ b/salt/config.py
@@ -781,7 +781,8 @@ DEFAULT_MINION_OPTS = {
     'file_client': 'remote',
     'use_master_when_local': False,
     'file_roots': {
-        'base': [salt.syspaths.BASE_FILE_ROOTS_DIR],
+        'base': [salt.syspaths.BASE_FILE_ROOTS_DIR,
+                 salt.syspaths.SPM_FORMULA_PATH]
     },
     'top_file_merging_strategy': 'merge',
     'env_order': [],
@@ -795,7 +796,8 @@ DEFAULT_MINION_OPTS = {
     'fileserver_followsymlinks': True,
     'fileserver_ignoresymlinks': False,
     'pillar_roots': {
-        'base': [salt.syspaths.BASE_PILLAR_ROOTS_DIR],
+        'base': [salt.syspaths.BASE_PILLAR_ROOTS_DIR,
+                 salt.syspaths.SPM_PILLAR_PATH]
     },
     'git_pillar_base': 'master',
     'git_pillar_branch': 'master',
@@ -943,13 +945,15 @@ DEFAULT_MASTER_OPTS = {
     'pki_dir': os.path.join(salt.syspaths.CONFIG_DIR, 'pki', 'master'),
     'cachedir': os.path.join(salt.syspaths.CACHE_DIR, 'master'),
     'file_roots': {
-        'base': [salt.syspaths.BASE_FILE_ROOTS_DIR],
+        'base': [salt.syspaths.BASE_FILE_ROOTS_DIR,
+                 salt.syspaths.SPM_FORMULA_PATH]
     },
     'master_roots': {
         'base': [salt.syspaths.BASE_MASTER_ROOTS_DIR],
     },
     'pillar_roots': {
-        'base': [salt.syspaths.BASE_PILLAR_ROOTS_DIR],
+        'base': [salt.syspaths.BASE_PILLAR_ROOTS_DIR,
+                 salt.syspaths.SPM_PILLAR_PATH]
     },
     'top_file_merging_strategy': 'merge',
     'env_order': [],
@@ -1197,9 +1201,9 @@ DEFAULT_API_OPTS = {
 
 DEFAULT_SPM_OPTS = {
     # ----- Salt master settings overridden by SPM --------------------->
-    'reactor_path': '/srv/spm/reactor',
     'formula_path': '/srv/spm/salt',
     'pillar_path': '/srv/spm/pillar',
+    'reactor_path': '/srv/spm/reactor',
     'spm_logfile': '/var/log/salt/spm',
     # spm_repos_config also includes a .d/ directory
     'spm_repos_config': '/etc/salt/spm.repos',

--- a/salt/config.py
+++ b/salt/config.py
@@ -1197,13 +1197,15 @@ DEFAULT_API_OPTS = {
 
 DEFAULT_SPM_OPTS = {
     # ----- Salt master settings overridden by SPM --------------------->
-    'reactor_roots': '/srv/reactor',
+    'reactor_path': '/srv/spm/reactor',
+    'formula_path': '/srv/spm/salt',
+    'pillar_path': '/srv/spm/pillar',
     'spm_logfile': '/var/log/salt/spm',
     # spm_repos_config also includes a .d/ directory
     'spm_repos_config': '/etc/salt/spm.repos',
     'spm_cache_dir': os.path.join(salt.syspaths.CACHE_DIR, 'spm'),
-    'spm_build_dir': '/srv/spm',
-    'spm_build_exclude': ['.git'],
+    'spm_build_dir': '/srv/spm_build',
+    'spm_build_exclude': ['.git', '.svn'],
     'spm_db': os.path.join(salt.syspaths.CACHE_DIR, 'spm', 'packages.db'),
     # <---- Salt master settings overridden by SPM ----------------------
 }

--- a/salt/spm/__init__.py
+++ b/salt/spm/__init__.py
@@ -81,7 +81,7 @@ class SPMClient(object):
         self.pkgdb = salt.loader.pkgdb(self.opts)
         self.db_conn = self.pkgdb[db_fun]()
 
-        self.files_prov = opts.get('spm_files_provider', 'roots')
+        self.files_prov = opts.get('spm_files_provider', 'local')
         files_fun = '{0}.init'.format(self.files_prov)
 
         self.pkgfiles = salt.loader.pkgfiles(self.opts)

--- a/salt/spm/pkgfiles/local.py
+++ b/salt/spm/pkgfiles/local.py
@@ -48,7 +48,7 @@ def check_existing(package, pkg_files, conn=None):
             # Module files are distributed via _modules, _states, etc
             out_file = os.path.join(conn['formula_path'], new_name)
         elif member.name == '{0}/pillar.example'.format(package):
-            # Pillars are automatically put in the pillar_roots
+            # Pillars are automatically put in the pillar_path
             new_name = '{0}.sls.orig'.format(package)
             out_file = os.path.join(conn['pillar_path'], new_name)
         elif package.endswith('-conf'):
@@ -81,7 +81,7 @@ def install_file(package, formula_tar, member, conn=None):
         # Module files are distributed via _modules, _states, etc
         member.name = member.name.replace('{0}/'.format(package), '')
     elif member.name == '{0}/pillar.example'.format(package):
-        # Pillars are automatically put in the pillar_roots
+        # Pillars are automatically put in the pillar_path
         member.name = '{0}.sls.orig'.format(package)
         out_path = conn['pillar_path']
     elif package.endswith('-conf'):
@@ -90,7 +90,7 @@ def install_file(package, formula_tar, member, conn=None):
         out_path = salt.syspaths.CONFIG_DIR
     elif package.endswith('-reactor'):
         # Reactor files go into /srv/reactor/
-        out_path = __opts__['reactor_roots']
+        out_path = __opts__['reactor_path']
 
     log.debug('Installing package file {0} to {1}'.format(member.name, out_path))
     formula_tar.extract(member, out_path)

--- a/salt/spm/pkgfiles/local.py
+++ b/salt/spm/pkgfiles/local.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-This module allows SPM to use the local filesystem (``file_roots``) to install
-files for SPM.
+This module allows SPM to use the local filesystem to install files for SPM.
 
 .. versionadded:: 2015.8.0
 '''
@@ -20,14 +19,16 @@ def init(**kwargs):
     '''
     Initialize the directories for the files
     '''
-    roots_path = __opts__['file_roots']['base'][0]
-    pillar_path = __opts__['pillar_roots']['base'][0]
-    for dir_ in (roots_path, pillar_path):
+    formula_path = __opts__['formula_path']
+    pillar_path = __opts__['pillar_path']
+    reactor_path = __opts__['reactor_path']
+    for dir_ in (formula_path, pillar_path, reactor_path):
         if not os.path.exists(dir_):
             os.makedirs(dir_)
     return {
-        'roots_path': roots_path,
+        'formula_path': formula_path,
         'pillar_path': pillar_path,
+        'reactor_path': reactor_path,
     }
 
 
@@ -45,7 +46,7 @@ def check_existing(package, pkg_files, conn=None):
         new_name = member.name.replace('{0}/'.format(package), '')
         if member.name.startswith('{0}/_'.format(package)):
             # Module files are distributed via _modules, _states, etc
-            out_file = os.path.join(conn['roots_path'], new_name)
+            out_file = os.path.join(conn['formula_path'], new_name)
         elif member.name == '{0}/pillar.example'.format(package):
             # Pillars are automatically put in the pillar_roots
             new_name = '{0}.sls.orig'.format(package)
@@ -55,9 +56,9 @@ def check_existing(package, pkg_files, conn=None):
             out_file = os.path.join(salt.syspaths.CONFIG_DIR, new_name)
         elif package.endswith('-reactor'):
             # Reactor files go into /srv/reactor/
-            out_file = os.path.join(__opts__['reactor_roots'], member.name)
+            out_file = os.path.join(conn['reactor_path'], member.name)
         else:
-            out_file = os.path.join(conn['roots_path'], member.name)
+            out_file = os.path.join(conn['formula_path'], member.name)
 
         if os.path.exists(out_file):
             existing_files.append(out_file)
@@ -74,7 +75,7 @@ def install_file(package, formula_tar, member, conn=None):
     if conn is None:
         conn = init()
 
-    out_path = conn['roots_path']
+    out_path = conn['formula_path']
 
     if member.name.startswith('{0}/_'.format(package)):
         # Module files are distributed via _modules, _states, etc

--- a/salt/syspaths.py
+++ b/salt/syspaths.py
@@ -34,7 +34,8 @@ except ImportError:
     __generated_syspaths = imp.new_module('salt._syspaths')
     for key in ('ROOT_DIR', 'CONFIG_DIR', 'CACHE_DIR', 'SOCK_DIR',
                 'SRV_ROOT_DIR', 'BASE_FILE_ROOTS_DIR', 'BASE_PILLAR_ROOTS_DIR',
-                'BASE_MASTER_ROOTS_DIR', 'LOGS_DIR', 'PIDFILE_DIR'):
+                'BASE_MASTER_ROOTS_DIR', 'LOGS_DIR', 'PIDFILE_DIR',
+                'SPM_FORMULA_PATH', 'SPM_PILLAR_PATH', 'SPM_REACTOR_PATH'):
         setattr(__generated_syspaths, key, None)
 
 
@@ -104,6 +105,18 @@ PIDFILE_DIR = __generated_syspaths.PIDFILE_DIR
 if PIDFILE_DIR is None:
     PIDFILE_DIR = os.path.join(ROOT_DIR, 'var', 'run')
 
+SPM_FORMULA_PATH = __generated_syspaths.SPM_FORMULA_PATH
+if SPM_FORMULA_PATH is None:
+    SPM_FORMULA_PATH = os.path.join(SRV_ROOT_DIR, 'spm', 'salt')
+
+SPM_PILLAR_PATH = __generated_syspaths.SPM_PILLAR_PATH
+if SPM_PILLAR_PATH is None:
+    SPM_PILLAR_PATH = os.path.join(SRV_ROOT_DIR, 'spm', 'pillar')
+
+SPM_REACTOR_PATH = __generated_syspaths.SPM_REACTOR_PATH
+if SPM_REACTOR_PATH is None:
+    SPM_REACTOR_PATH = os.path.join(SRV_ROOT_DIR, 'spm', 'reactor')
+
 
 __all__ = [
     'ROOT_DIR',
@@ -118,5 +131,8 @@ __all__ = [
     'PIDFILE_DIR',
     'INSTALL_DIR',
     'CLOUD_DIR',
-    'BOOTSTRAP'
+    'BOOTSTRAP',
+    'SPM_FORMULA_PATH',
+    'SPM_PILLAR_PATH',
+    'SPM_REACTOR_PATH'
 ]


### PR DESCRIPTION
Files in `/srv/salt/` are often regularly edited by users or placed under version control (or both). Files provided by SPM are not frequently edited, and should be separated. This will alleviate confusion, and reduce redundancy by keeping package-provided files out of version control.
