### PR TITLE
[2015.8] Revert loader changes from #26645

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -450,10 +450,6 @@ def log_handlers(opts):
 
     :param dict opts: The Salt options dictionary
     '''
-    pack = {
-        '__grains__': grains(opts),
-        '__salt__': minion_mods(opts)
-    }
     ret = LazyLoader(_module_dirs(opts,
                                   'log_handlers',
                                   'log_handlers',
@@ -461,7 +457,6 @@ def log_handlers(opts):
                                   base_path=os.path.join(SALT_BASE_PATH, 'log')),
                      opts,
                      tag='log_handlers',
-                     pack=pack
                      )
     return FilterDictWrapper(ret, '.setup_handlers')
 

--- a/salt/log/handlers/sentry_mod.py
+++ b/salt/log/handlers/sentry_mod.py
@@ -81,6 +81,7 @@ from __future__ import absolute_import
 import logging
 
 # Import salt libs
+import salt.loader
 from salt.log import LOG_LEVELS
 
 # Import 3rd party libs
@@ -92,6 +93,8 @@ except ImportError:
     HAS_RAVEN = False
 
 log = logging.getLogger(__name__)
+__grains__ = salt.loader.grains(__opts__)
+__salt__ = salt.loader.minion_mods(__opts__)
 
 # Define the module's virtual name
 __virtualname__ = 'sentry'


### PR DESCRIPTION
Also change sentry handler to work without that code.

@s0undt3ch Look good? I couldn't find the original version of the sentry handler and wanted to make sure I didn't do anything stupid.

Fixes #26669 
