### PR TITLE
Module executors initial implementation

### DIFF
--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -134,6 +134,9 @@ class SaltCMD(parsers.SaltCMDOptionParser):
             if getattr(self.options, 'return_config'):
                 kwargs['ret_config'] = getattr(self.options, 'return_config')
 
+            if getattr(self.options, 'module_executors'):
+                kwargs['module_executors'] = yamlify_arg(getattr(self.options, 'module_executors'))
+
             if getattr(self.options, 'metadata'):
                 kwargs['metadata'] = yamlify_arg(
                         getattr(self.options, 'metadata'))

--- a/salt/executors/__init__.py
+++ b/salt/executors/__init__.py
@@ -2,11 +2,9 @@
 '''
 Executors Directory
 '''
-from __builtin__ import isinstance
-from salt.exceptions import SaltInvocationError
 
 
-class ModuleExecutorBase():
+class ModuleExecutorBase(object):
     '''
     Base class for module executors.
     Each executor implementation have to override this class and have corresponding get function that creates the
@@ -19,10 +17,10 @@ class ModuleExecutorBase():
         All external data including  have to be passed to the constructor.
         '''
         pass
-    
+
     def execute(self):
         '''
-        Execute the function or another executor in a specific way or in 
-        a specific environment. 
+        Execute the function or another executor in a specific way or in
+        a specific environment.
         '''
         pass

--- a/salt/executors/__init__.py
+++ b/salt/executors/__init__.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+'''
+Executors Directory
+'''
+from __builtin__ import isinstance
+from salt.exceptions import SaltInvocationError
+
+
+class ModuleExecutorBase():
+    '''
+    Base class for module executors.
+    Each executor implementation have to override this class and have corresponding get function that creates the
+    executor object.
+    '''
+
+    def __init__(self):
+        '''
+        Constructor shall perform all pre-exec steps needed by executor.
+        All external data including  have to be passed to the constructor.
+        '''
+        pass
+    
+    def execute(self):
+        '''
+        Execute the function or another executor in a specific way or in 
+        a specific environment. 
+        '''
+        pass

--- a/salt/executors/direct_call.py
+++ b/salt/executors/direct_call.py
@@ -4,6 +4,7 @@ Direct call executor module
 
 @author: Dmitry Kuzmenko <dmitry.kuzmenko@dsr-company.com>
 '''
+from __future__ import absolute_import
 from salt.executors import ModuleExecutorBase
 
 
@@ -20,6 +21,7 @@ class DirectCallExecutor(ModuleExecutorBase):
         '''
         Constructor
         '''
+        super(DirectCallExecutor, self).__init__()
         self.func, self.args, self.kwargs = func, args, kwargs
 
     def execute(self):

--- a/salt/executors/direct_call.py
+++ b/salt/executors/direct_call.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+'''
+Direct call executor module
+
+@author: Dmitry Kuzmenko <dmitry.kuzmenko@dsr-company.com>
+'''
+from salt.executors import ModuleExecutorBase
+
+
+def get(*args, **kwargs):
+    return DirectCallExecutor(*args, **kwargs)
+
+
+class DirectCallExecutor(ModuleExecutorBase):
+    '''
+    Directly calls the given function with arguments
+    '''
+
+    def __init__(self, opts, data, func, *args, **kwargs):
+        '''
+        Constructor
+        '''
+        self.func, self.args, self.kwargs = func, args, kwargs
+
+    def execute(self):
+        return self.func(*self.args, **self.kwargs)

--- a/salt/executors/splay.py
+++ b/salt/executors/splay.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 '''
 Splay function calls across targeted minions
 
@@ -29,12 +30,13 @@ class SplayExecutor(ModuleExecutorBase):
         '''
         Constructor
         '''
+        super(SplayExecutor, self).__init__()
         self.splaytime = data.get('splaytime') or opts.get('splaytime', _DEFAULT_SPLAYTIME)
         if self.splaytime <= 0:
             raise ValueError('splaytime must be a positive integer')
         self.executor = executor
         self.fun_name = data.get('fun')
-    
+
     def _get_hash(self, hashable, size):
         '''
         Jenkins One-At-A-Time Hash Function
@@ -58,27 +60,27 @@ class SplayExecutor(ModuleExecutorBase):
     def _calc_splay(self, hashable, splaytime=_DEFAULT_SPLAYTIME, size=_DEFAULT_SIZE):
         hash_val = self._get_hash(hashable, size)
         return int(splaytime * hash_val / float(size))
-    
+
     def execute(self):
         '''
         Splay a salt function call execution time across minions over
         a number of seconds (default: 600)
-    
-    
+
+
         NOTE: You *probably* want to use --async here and look up the job results later.
               If you're dead set on getting the output from the CLI command, then make
               sure to set the timeout (with the -t flag) to something greater than the
               splaytime (max splaytime + time to execute job).
               Otherwise, it's very likely that the cli will time out before the job returns.
-    
-    
+
+
         CLI Example:
         # With default splaytime
           salt --async '*' splay.splay pkg.install cowsay version=3.03-8.el6
-    
+
         # With specified splaytime (5 minutes) and timeout with 10 second buffer
           salt -t 310 '*' splay.splay 300 pkg.version cowsay
-        '''    
+        '''
         my_delay = self._calc_splay(__grains__['id'], splaytime=self.splaytime)
         log.debug("Splay is sleeping {0} secs on {1}".format(my_delay, self.fun_name))
         time.sleep(my_delay)

--- a/salt/executors/splay.py
+++ b/salt/executors/splay.py
@@ -1,0 +1,89 @@
+'''
+Splay function calls across targeted minions
+
+@author: Dmitry Kuzmenko <dmitry.kuzmenko@dsr-company.com>
+'''
+# Import Python Libs
+from __future__ import absolute_import
+import time
+import logging
+
+from salt.executors import ModuleExecutorBase
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_SPLAYTIME = 300
+_DEFAULT_SIZE = 8192
+
+
+def get(*args, **kwargs):
+    return SplayExecutor(*args, **kwargs)
+
+
+class SplayExecutor(ModuleExecutorBase):
+    '''
+    classdocs
+    '''
+
+    def __init__(self, opts, data, executor):
+        '''
+        Constructor
+        '''
+        self.splaytime = data.get('splaytime') or opts.get('splaytime', _DEFAULT_SPLAYTIME)
+        if self.splaytime <= 0:
+            raise ValueError('splaytime must be a positive integer')
+        self.executor = executor
+        self.fun_name = data.get('fun')
+    
+    def _get_hash(self, hashable, size):
+        '''
+        Jenkins One-At-A-Time Hash Function
+        More Info: http://en.wikipedia.org/wiki/Jenkins_hash_function#one-at-a-time
+        '''
+        # Using bitmask to emulate rollover behavior of C unsigned 32 bit int
+        bitmask = 0xffffffff
+        h = 0
+
+        for i in bytearray(hashable):
+            h = (h + i) & bitmask
+            h = (h + (h << 10)) & bitmask
+            h = (h ^ (h >> 6)) & bitmask
+
+        h = (h + (h << 3)) & bitmask
+        h = (h ^ (h >> 11)) & bitmask
+        h = (h + (h << 15)) & bitmask
+
+        return (h & (size - 1)) & bitmask
+
+    def _calc_splay(self, hashable, splaytime=_DEFAULT_SPLAYTIME, size=_DEFAULT_SIZE):
+        hash_val = self._get_hash(hashable, size)
+        return int(splaytime * hash_val / float(size))
+    
+    def execute(self):
+        '''
+        Splay a salt function call execution time across minions over
+        a number of seconds (default: 600)
+    
+    
+        NOTE: You *probably* want to use --async here and look up the job results later.
+              If you're dead set on getting the output from the CLI command, then make
+              sure to set the timeout (with the -t flag) to something greater than the
+              splaytime (max splaytime + time to execute job).
+              Otherwise, it's very likely that the cli will time out before the job returns.
+    
+    
+        CLI Example:
+        # With default splaytime
+          salt --async '*' splay.splay pkg.install cowsay version=3.03-8.el6
+    
+        # With specified splaytime (5 minutes) and timeout with 10 second buffer
+          salt -t 310 '*' splay.splay 300 pkg.version cowsay
+        '''    
+        my_delay = self._calc_splay(__grains__['id'], splaytime=self.splaytime)
+        log.debug("Splay is sleeping {0} secs on {1}".format(my_delay, self.fun_name))
+        time.sleep(my_delay)
+        result = self.executor.execute()
+        if not isinstance(result, dict):
+            result = {'result': result}
+        result['splaytime'] = str(my_delay)
+        return result

--- a/salt/executors/sudo.py
+++ b/salt/executors/sudo.py
@@ -64,6 +64,7 @@ class SudoExecutor(ModuleExecutorBase):
         '''
         Constructor
         '''
+        super(SudoExecutor, self).__init__()
         self.cmd = ['sudo',
                     '-u', opts.get('sudo_user'),
                     'salt-call',

--- a/salt/executors/sudo.py
+++ b/salt/executors/sudo.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+'''
+Sudo executor module
+
+@author: Dmitry Kuzmenko <dmitry.kuzmenko@dsr-company.com>
+'''
+# Import python libs
+from __future__ import absolute_import
+import json
+try:
+    from shlex import quote as _cmd_quote  # pylint: disable=E0611
+except ImportError:
+    from pipes import quote as _cmd_quote
+
+# Import salt libs
+from salt.executors import ModuleExecutorBase
+import salt.utils
+import salt.syspaths
+
+__virtualname__ = 'sudo'
+
+
+def __virtual__():
+    if salt.utils.which('sudo') and __opts__.get('sudo_user'):
+        return __virtualname__
+    return False
+
+
+def get(*args, **kwargs):
+    return SudoExecutor(*args, **kwargs)
+
+
+class SudoExecutor(ModuleExecutorBase):
+    '''
+    Allow for the calling of execution modules via sudo.
+
+    This module is invoked by the minion if the ``sudo_user`` minion config is
+    present.
+
+    Example minion config:
+
+    .. code-block:: yaml
+
+        sudo_user: saltdev
+
+    Once this setting is made, any execution module call done by the minion will be
+    run under ``sudo -u <sudo_user> salt-call``.  For example, with the above
+    minion config,
+
+    .. code-block:: bash
+
+        salt sudo_minion cmd.run 'cat /etc/sudoers'
+
+    is equivalent to
+
+    .. code-block:: bash
+
+        sudo -u saltdev salt-call cmd.run 'cat /etc/sudoers'
+
+    being run on ``sudo_minion``.
+    '''
+
+    def __init__(self, opts, data, func, *args, **kwargs):
+        '''
+        Constructor
+        '''
+        self.cmd = ['sudo',
+                    '-u', opts.get('sudo_user'),
+                    'salt-call',
+                    '--out', 'json',
+                    '--metadata',
+                    '-c', salt.syspaths.CONFIG_DIR,
+                    '--',
+                    data.get('fun')]
+        for arg in args:
+            self.cmd.append(_cmd_quote(str(arg)))
+        for key in kwargs:
+            self.cmd.append(_cmd_quote('{0}={1}'.format(key, kwargs[key])))
+
+    def execute(self):
+        '''
+        Wrap a shell execution out to salt call with sudo
+
+        Example:
+
+        /etc/salt/minion
+
+        .. code-block:: yaml
+
+            sudo_user: saltdev
+
+        .. code-block:: bash
+
+            salt '*' test.ping  # is run as saltdev user
+        '''
+
+        cmd_ret = __salt__['cmd.run_all'](self.cmd, use_vt=True, python_shell=False)
+
+        if cmd_ret['retcode'] == 0:
+            cmd_meta = json.loads(cmd_ret['stdout'])['local']
+            ret = cmd_meta['return']
+            __context__['retcode'] = cmd_meta.get('retcode', 0)
+        else:
+            ret = cmd_ret['stderr']
+            __context__['retcode'] = cmd_ret['retcode']
+
+        return ret

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -781,6 +781,16 @@ def netapi(opts):
                      )
 
 
+def executors(opts):
+    '''
+    Returns the executor modules
+    '''
+    return LazyLoader(_module_dirs(opts, 'executors', 'executor'),
+                      opts,
+                      tag='executor',
+                      )
+
+
 def _generate_module(name):
     if name in sys.modules:
         return

--- a/salt/master.py
+++ b/salt/master.py
@@ -2157,6 +2157,9 @@ class ClearFuncs(object):
             if 'metadata' in clear_load['kwargs']:
                 load['metadata'] = clear_load['kwargs'].get('metadata')
 
+            if 'module_executors' in clear_load['kwargs']:
+                load['module_executors'] = clear_load['kwargs'].get('module_executors')
+
         if 'user' in clear_load:
             log.info(
                 'User {user} Published command {fun} with jid {jid}'.format(

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -868,7 +868,7 @@ class Minion(MinionBase):
         # we're done, reset the limits!
         if modules_max_memory is True:
             resource.setrlimit(resource.RLIMIT_AS, old_mem_limit)
-            
+
         executors = salt.loader.executors(self.opts)
 
         return functions, returners, errors, executors
@@ -1305,7 +1305,7 @@ class Minion(MinionBase):
         Refresh the functions and returners.
         '''
         log.debug('Refreshing modules. Notify={0}'.format(notify))
-        self.functions, self.returners, _ = self._load_modules(force_refresh, notify=notify)
+        self.functions, self.returners, _, self.executors = self._load_modules(force_refresh, notify=notify)
         self.schedule.functions = self.functions
         self.schedule.returners = self.returners
 
@@ -1527,7 +1527,7 @@ class Minion(MinionBase):
                         del self.pub_channel
                         self._connect_master_future = self.connect_master()
                         self.block_until_connected()  # TODO: remove
-                        self.functions, self.returners, self.function_errors = self._load_modules()
+                        self.functions, self.returners, self.function_errors, self.executors = self._load_modules()
                         self._fire_master_minion_start()
                         log.info('Minion is ready to receive requests!')
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1000,9 +1000,11 @@ class Minion(MinionBase):
                 executors = data.get('module_executors') or opts.get('module_executors', ['direct_call.get'])
                 if isinstance(executors, six.string_types):
                     executors = [executors]
-                elif not isinstance(executors, list):
-                    raise SaltInvocationError("Wrong executors specification: {0}. String or list expected".format(
-                        executors))
+                elif not isinstance(executors, list) or not executors:
+                    raise SaltInvocationError("Wrong executors specification: {0}. String or non-empty list expected".
+                        format(executors))
+                if opts.get('sudo_user', ''):
+                    executors[-1] = 'sudo.get'
                 # Get the last one that is function executor
                 executor = minion_instance.executors[
                     "{0}".format(executors.pop())](opts, data, func, *args, **kwargs)

--- a/salt/modules/splay.py
+++ b/salt/modules/splay.py
@@ -11,7 +11,7 @@ import time
 import salt.ext.six as six
 
 # Import Salt Libs
-from salt.exceptions import CommandExecutionError
+from salt.exceptions import CommandExecutionError, SaltInvocationError
 
 _DEFAULT_SPLAYTIME = 600
 _DEFAULT_SIZE = 8192
@@ -52,7 +52,7 @@ def calc_splay(hashable, splaytime=_DEFAULT_SPLAYTIME, size=_DEFAULT_SIZE):
     return int(splaytime * hash_val / float(size))
 
 
-def splay(*args, **kwargs):
+def splay(fun, *args, **kwargs):
     '''
     Splay a salt function call execution time across minions over
     a number of seconds (default: 600)
@@ -72,6 +72,12 @@ def splay(*args, **kwargs):
     # With specified splaytime (5 minutes) and timeout with 10 second buffer
       salt -t 310 '*' splay.splay 300 pkg.version cowsay
     '''
+    if fun == 'sudo.salt_call':
+        __context__['retcode'] = 1
+        raise SaltInvocationError('sudo.salt_call is not designed to be run '
+                                  'directly, but is used by the minion when '
+                                  'the sudo_user config is set.')
+
     # Convert args tuple to a list so we can pop the splaytime and func out
     args = list(args)
 

--- a/salt/modules/sudo.py
+++ b/salt/modules/sudo.py
@@ -81,7 +81,7 @@ def salt_call(runas, fun, *args, **kwargs):
            '--',
            fun]
     for arg in args:
-        cmd.append(_cmd_quote(arg))
+        cmd.append(_cmd_quote(str(arg)))
     for key in kwargs:
         cmd.append(_cmd_quote('{0}={1}'.format(key, kwargs[key])))
 

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1705,6 +1705,14 @@ class SaltCMDOptionParser(six.with_metaclass(OptionParserMeta,
                   'systems, databases or applications.')
         )
         self.add_option(
+            '--module-executors',
+            dest='module_executors',
+            default=None,
+            metavar='EXECUTOR_LIST',
+            help=('Set an alternative list of executors to override the one '
+                  'set in minion config')
+        )
+        self.add_option(
             '-d', '--doc', '--documentation',
             dest='doc',
             default=False,


### PR DESCRIPTION
Provides "module executor" approach discussed in #23157. Use either via minion config:

```
module_executors:
  - splay.get
  - direct_call.get
```

Will execute any function with splay before actually call it.

```
salt '*' test.ping --module-executors="[splay.get, direct_call.get]"
```

Will execute test.ping with splay.
