### PR TITLE
Fixes to ipset in 2015.5 for #26628

### DIFF
--- a/salt/modules/ipset.py
+++ b/salt/modules/ipset.py
@@ -510,8 +510,10 @@ def _find_set_info(set):
     setinfo = {}
     _tmp = out['stdout'].split('\n')
     for item in _tmp:
-        key, value = item.split(':', 1)
-        setinfo[key] = value[1:]
+        # Only split if item has a colon
+        if ':' in item:
+            key, value = item.split(':', 1)
+            setinfo[key] = value[1:]
     return setinfo
 
 


### PR DESCRIPTION
Fixing issue when information returned from ipset isn't in the format we expect and it causes an exception. #26628
