### PR TITLE
Don't stacktrace if "name" is specified as a minion id in a map file

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1696,7 +1696,15 @@ class Map(Cloud):
                             #   - bar1:
                             #   - bar2:
                             overrides = {}
-                        overrides.setdefault('name', name)
+                        try:
+                            overrides.setdefault('name', name)
+                        except AttributeError:
+                            log.error(
+                                'Cannot use \'name\' as a minion id in a cloud map as it '
+                                'is a reserved word. Please change \'name\' to a different '
+                                'minion id reference.'
+                            )
+                            return ''
                         entries[name] = overrides
                 map_[profile] = entries
                 continue


### PR DESCRIPTION
Fixes #24021 

Consider the following map file, where `name` is specified as the minion id:

```
# /etc/salt/mapfile

make_salty:
  - name:
      ssh_host: <my-host>
      ssh_username: <my-user>
      ssh_keyfile: <my-keyfile>
```

This configuration will produce the following stacktrace:

```
# salt-cloud -m /etc/salt/mapfile
[INFO    ] salt-cloud starting
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
AttributeError: 'str' object has no attribute 'setdefault'
Traceback (most recent call last):
  File "/usr/local/bin/salt-cloud", line 10, in <module>
    salt_cloud()
  File "/root/SaltStack/salt/salt/scripts.py", line 316, in salt_cloud
    client.run()
  File "/root/SaltStack/salt/salt/cloud/cli.py", line 87, in run
    mapper = salt.cloud.Map(self.config)
  File "/root/SaltStack/salt/salt/cloud/__init__.py", line 1565, in __init__
    self.rendered_map = self.read()
  File "/root/SaltStack/salt/salt/cloud/__init__.py", line 1699, in read
    overrides.setdefault('name', name)
AttributeError: 'str' object has no attribute 'setdefault'
Traceback (most recent call last):
  File "/usr/local/bin/salt-cloud", line 10, in <module>
    salt_cloud()
  File "/root/SaltStack/salt/salt/scripts.py", line 316, in salt_cloud
    client.run()
  File "/root/SaltStack/salt/salt/cloud/cli.py", line 87, in run
    mapper = salt.cloud.Map(self.config)
  File "/root/SaltStack/salt/salt/cloud/__init__.py", line 1565, in __init__
    self.rendered_map = self.read()
  File "/root/SaltStack/salt/salt/cloud/__init__.py", line 1699, in read
    overrides.setdefault('name', name)
AttributeError: 'str' object has no attribute 'setdefault'
```

This pull request fixes that and provides a helpful error log:

```
# salt-cloud -m ~/mapfile
[INFO    ] salt-cloud starting
[ERROR   ] Cannot use 'name' as a minion id in a cloud map as it is a reserved word. Please change 'name' to a different minion id reference.
```
