### PR TITLE
Added check for PyMySQL if MySQLdb import fails

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -49,13 +49,25 @@ import salt.utils
 
 # Import third party libs
 try:
+    # Try to import MySQLdb
     import MySQLdb
     import MySQLdb.cursors
     import MySQLdb.converters
     from MySQLdb.constants import FIELD_TYPE, FLAG
     HAS_MYSQLDB = True
 except ImportError:
-    HAS_MYSQLDB = False
+    try:
+        # MySQLdb import failed, try to import PyMySQL
+        import pymysql
+        pymysql.install_as_MySQLdb()
+        import MySQLdb
+        import MySQLdb.cursors
+        import MySQLdb.converters
+        from MySQLdb.constants import FIELD_TYPE, FLAG
+        HAS_MYSQLDB = True
+    except ImportError:
+        # No MySQL Connector installed, return False
+        HAS_MYSQLDB = False
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
- Added PyMySQL to dependencies for windows so that it will be bundled with Salt. See the following PRs:
  https://github.com/saltstack/salt-windows-dev/pull/24
  https://github.com/saltstack/salt-windows-dev/pull/25

Fixes #26754
