### PR TITLE
rev defaults to HEAD

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -431,7 +431,7 @@ def latest(name,
         bare = True
 
     # Check to make sure rev and mirror/bare are not both in use
-    if rev and bare:
+    if rev != 'HEAD' and bare:
         return _fail(ret, ('\'rev\' is not compatible with the \'mirror\' and '
                            '\'bare\' arguments'))
 


### PR DESCRIPTION
If this isn't there, you can't do a git latest with bare or mirror

@terminalmage 
