### PR TITLE
stringify linode id before performing str actions

### DIFF
--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -1033,6 +1033,7 @@ def _validate_name(name):
     name
         The VM name to validate
     '''
+    name = str(name)
     name_length = len(name)
     regex = re.compile(r'^[a-zA-Z0-9][A-Za-z0-9_-]*[a-zA-Z0-9]$')
 


### PR DESCRIPTION
Fixes #26798.  At the start of the provisioning process, linode reports
VM names by their linode ID, which is represented by the driver as an
integer.

@rallytime
