### PR TITLE
[salt-cloud] Fix creating droplet from snapshot in digital_ocean provider 

### DIFF
--- a/salt/cloud/clouds/digital_ocean_v2.py
+++ b/salt/cloud/clouds/digital_ocean_v2.py
@@ -117,7 +117,7 @@ def avail_images(call=None):
         for image in items['images']:
             ret[image['id']] = {}
             for item in image.keys():
-                ret[image['id']][item] = str(image[item])
+                ret[image['id']][item] = image[item]
 
         page += 1
         try:
@@ -224,12 +224,13 @@ def get_image(vm_):
     Return the image object to use
     '''
     images = avail_images()
-    vm_image = str(config.get_cloud_config_value(
+    vm_image = config.get_cloud_config_value(
         'image', vm_, __opts__, search_global=False
-    ))
+    )
     for image in images:
+        log.info(images[image])
         if vm_image in (images[image]['name'], images[image]['slug'], images[image]['id']):
-            if images[image]['slug'] != 'None':
+            if images[image]['slug'] is not None:
                 return images[image]['slug']
             return int(images[image]['id'])
     raise SaltCloudNotFound(

--- a/salt/cloud/clouds/digital_ocean_v2.py
+++ b/salt/cloud/clouds/digital_ocean_v2.py
@@ -229,7 +229,7 @@ def get_image(vm_):
     ))
     for image in images:
         if vm_image in (images[image]['name'], images[image]['slug'], images[image]['id']):
-            if images[image]['slug'] is not None:
+            if images[image]['slug'] != 'None':
                 return images[image]['slug']
             return int(images[image]['id'])
     raise SaltCloudNotFound(

--- a/salt/cloud/clouds/digital_ocean_v2.py
+++ b/salt/cloud/clouds/digital_ocean_v2.py
@@ -228,7 +228,6 @@ def get_image(vm_):
         'image', vm_, __opts__, search_global=False
     )
     for image in images:
-        log.info(images[image])
         if vm_image in (images[image]['name'], images[image]['slug'], images[image]['id']):
             if images[image]['slug'] is not None:
                 return images[image]['slug']


### PR DESCRIPTION
**Problem**
 Digital Ocean's API returns `'None'` instead of `None` for a non-existent image `slug`, rendering the conditional in `get_image` useless:

```
[DEBUG   ] Sending event - data = {'_stamp': '2015-09-01T19:22:48.162645', 'event': 'requesting instance', 'kwargs': {'ssh_keys': ['XXXXXXX], 'region': 'nyc3', 'ipv6': True, 'private_networking': True, 'backups': False, 'size': '1gb', 'image': 'None', 'name': 'test1'}}
[ERROR   ] Error creating salt-test1 on DIGITAL_OCEAN

The following exception was thrown when trying to run the initial deployment: An error occurred while querying DigitalOcean. HTTP Code: 422  Error: u'{"id":"unprocessable_entity","message":"You specified an invalid image for Droplet creation."}'
```

**Solution**
`if image['slug'] != 'None'`. Fixes #22724.
