### PR TITLE
Module blacklist broken in 2015.8 and develop

### DIFF
--- a/salt/acl/__init__.py
+++ b/salt/acl/__init__.py
@@ -40,6 +40,6 @@ class ClientACL(object):
             else:
                 funs_to_check = cmd
             for fun in funs_to_check:
-                if re.match(cmd, fun):
+                if re.match(blacklisted_module, fun):
                     return True
         return False


### PR DESCRIPTION
The `cmd_is_blacklisted` method of `ClientACL` is supposed to check if the function(s) passed match anything in the blacklist.  Instead, it current checks if the function matches itself...which is always True.  The end result is that having any entries in the module blacklist effectively blacklists all commands for every user.

I know y'all are cutting 2015.8.0 real soon, but I'd love to see this make it in as a bugfix if at all possible.  Thanks!
