### PR TITLE
Fix reference before assignment in sqs engine

### DIFF
--- a/salt/engines/sqs_events.py
+++ b/salt/engines/sqs_events.py
@@ -72,7 +72,7 @@ def __virtual__():
 log = logging.getLogger(__name__)
 
 
-def _get_sqs_conn(profile):
+def _get_sqs_conn(profile, region=None, key=None, keyid=None):
     '''
     Get a boto connection to SQS.
     '''
@@ -85,17 +85,12 @@ def _get_sqs_conn(profile):
         keyid = _profile.get('keyid', None)
         region = _profile.get('region', None)
 
-    if not region and __opts__.get('sqs.region'):
-        region = __opts__.get('sqs.region')
-
     if not region:
-        region = 'us-east-1'
-
-    if not key and __opts__.get('sqs.key'):
-        key = __opts__.get('sqs.key')
-    if not keyid and __opts__.get('sqs.keyid'):
-        keyid = __opts__.get('sqs.keyid')
-
+        region = __opts__.get('sqs.region', 'us-east-1')
+    if not key:
+        key = __opts__.get('sqs.key', None)
+    if not keyid:
+        keyid = __opts__.get('sqs.keyid', None)
     try:
         conn = boto.sqs.connect_to_region(region, aws_access_key_id=keyid,
                                           aws_secret_access_key=key)


### PR DESCRIPTION
I'm using a `~/.aws/credentials` config file for testing locally. I was getting the following error while attempting to enable the `sqs_events` engine:

``` bash
~# tail -f -n 50 /var/log/salt/master
2015-09-02 03:21:56,471 [salt.transport.zeromq][INFO    ][23010] Worker binding to socket ipc:///var/run/salt/master/workers.ipc
2015-09-02 03:21:56,480 [salt.transport.zeromq][INFO    ][22986] Worker binding to socket ipc:///var/run/salt/master/workers.ipc
2015-09-02 03:21:56,637 [salt.engines     ][CRITICAL][23675] Engine <salt.loader.LazyLoader object at 0x278b5d0> could not be started! Error: local v
ariable 'keyid' referenced before assignment
2015-09-02 03:21:56,666 [salt.utils.process][INFO    ][22921] Process <class 'salt.engines.Engine'> (23675) died with exit status None, restarting...
2015-09-02 03:21:57,681 [salt.engines     ][CRITICAL][23679] Engine <salt.loader.LazyLoader object at 0x278b5d0> could not be started! Error: local v
ariable 'keyid' referenced before assignment
```

I made the changes to fix the assignment and sqs messages fired on the event bus as expected! I also tested various master config settings (sqs.*, profiles, etc.) which still work as expect.  

Worth noting that it could be beneficial to eventually remove `_get_sqs_conn` to leverage `_get_conn` in `__utils__` .

``` bash
~# salt --versions
Salt Version:
           Salt: 2015.8.0rc3-2278-gb23d0d8

Dependency Versions:
         Jinja2: 2.6
       M2Crypto: 0.21.1
           Mako: Not Installed
         PyYAML: 3.10
          PyZMQ: 14.0.1
         Python: 2.7.3 (default, Jun 22 2015, 19:33:41)
           RAET: Not Installed
        Tornado: 4.2.1
            ZMQ: 4.0.4
           cffi: Not Installed
       cherrypy: 3.2.2
       dateutil: 2.4.2
          gitdb: Not Installed
      gitpython: Not Installed
          ioflo: Not Installed
        libnacl: Not Installed
   msgpack-pure: Not Installed
 msgpack-python: 0.1.10
   mysql-python: Not Installed
      pycparser: Not Installed
       pycrypto: 2.6.1
         pygit2: Not Installed
   python-gnupg: Not Installed
          smmap: Not Installed
        timelib: Not Installed

System Versions:
           dist: Ubuntu 12.04 precise
        machine: x86_64
        release: 3.2.0-23-generic
         system: Ubuntu 12.04 precise
```
