### PR TITLE
Missing provider to driver change

### DIFF
--- a/salt/cloud/clouds/lxc.py
+++ b/salt/cloud/clouds/lxc.py
@@ -431,7 +431,7 @@ def create(vm_, call=None):
         'event', 'starting create',
         'salt/cloud/{0}/creating'.format(vm_['name']),
         {'name': vm_['name'], 'profile': profile,
-         'provider': vm_['provider'], },
+         'provider': vm_['driver'], },
         transport=__opts__['transport'])
     ret = {'name': vm_['name'], 'changes': {}, 'result': True, 'comment': ''}
     if 'pub_key' not in vm_ and 'priv_key' not in vm_:


### PR DESCRIPTION
Without this change I get:

```
2015-09-02 14:53:32,932 [salt.cloud       ][ERROR   ][354] Failed to create VM mylxc-machine. Configuration value 'provider' needs to be set
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/cloud/__init__.py", line 1257, in create
    output = self.clouds[func](vm_)
  File "/usr/lib/python2.7/dist-packages/salt/cloud/clouds/lxc.py", line 434, in create 
    'provider': vm_['provider'], },
KeyError: 'provider'
2015-09-02 14:53:32,934 [salt.state       ][ERROR   ][354] An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1591, in call
    **cdata['kwargs'])
  File "/usr/lib/python2.7/dist-packages/salt/states/cloud.py", line 273, in profile
    info = __salt__['cloud.profile'](profile, name, vm_overrides=kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/modules/cloud.py", line 196, in profile_
    info = client.profile(profile, names, vm_overrides=vm_overrides, **kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/cloud/__init__.py", line 341, in profile
    mapper.run_profile(profile, names, vm_overrides=vm_overrides)
  File "/usr/lib/python2.7/dist-packages/salt/cloud/__init__.py", line 1417, in run_profile
    raise SaltCloudSystemExit('Failed to deploy VM')
SaltCloudSystemExit: Failed to deploy VM ret={'mylxc-machine': {'Error': 'Failed to deploy VM'}}
```

When provisioning an lxc container from a cloud.profile state.

Here is also a print out of vm_:

```
{
'profile':  'lxc-dhcp',
'priv_key': '-----BEGIN RSA PRIVATE KEY-----......obfuscated......-----END RSA PRIVATE KEY-----',
'target': 'my_minion_id_here',
'minion': {
    'master': 'my_master_ip_here',
    'master_port': 4506
    },
'image': 'ubuntu',
'driver': 'lxc-provider1:lxc',
'name': 'mylxc-machine',
'state_output': 'mixed',
'pub_key': '-----BEGIN PUBLIC KEY-----......obfuscated......-----END PUBLIC KEY-----',
'os': 'bootstrap-salt',
'inline_script': None,
'size': '3g'
}
```
