### PR TITLE
add jboss domain mode to jboss7 python modules

### DIFF
--- a/salt/modules/jboss7.py
+++ b/salt/modules/jboss7.py
@@ -48,10 +48,10 @@ def status(jboss_config, host=None, server_config=None):
     jboss_config
         Configuration dictionary with properties specified above.
     host
-        The name of the host. JBoss domain mode only - and required if running in domain mode. 
+        The name of the host. JBoss domain mode only - and required if running in domain mode.
         The host name is the "name" attribute of the "host" element in host.xml
     server_config
-        The name of the Server Configuration. JBoss Domain mode only - and required 
+        The name of the Server Configuration. JBoss Domain mode only - and required
         if running in domain mode.
 
     CLI Example:
@@ -62,14 +62,14 @@ def status(jboss_config, host=None, server_config=None):
 
        '''
     log.debug("======================== MODULE FUNCTION: jboss7.status")
-    if (host is None and server_config is None):
-      operation = ':read-attribute(name=server-state)'
-    elif (host is not None and server_config is not None):
-      operation = '/host="{host}"/server-config="{server_config}"/:read-attribute(name=status)'.format(
-              host=host, 
+    if host is None and server_config is None:
+        operation = ':read-attribute(name=server-state)'
+    elif host is not None and server_config is not None:
+        operation = '/host="{host}"/server-config="{server_config}"/:read-attribute(name=status)'.format(
+              host=host,
               server_config=server_config)
     else:
-      raise SaltInvocationError('Invalid parameters. Must either pass both host and server_config or neither')
+        raise SaltInvocationError('Invalid parameters. Must either pass both host and server_config or neither')
     return __salt__['jboss7_cli.run_operation'](jboss_config, operation, fail_on_error=False, retries=0)
 
 
@@ -80,7 +80,7 @@ def stop_server(jboss_config, host=None):
     jboss_config
         Configuration dictionary with properties specified above.
     host
-        The name of the host. JBoss domain mode only - and required if running in domain mode. 
+        The name of the host. JBoss domain mode only - and required if running in domain mode.
         The host name is the "name" attribute of the "host" element in host.xml
 
     CLI Example:
@@ -92,9 +92,9 @@ def stop_server(jboss_config, host=None):
        '''
     log.debug("======================== MODULE FUNCTION: jboss7.stop_server")
     if host is None:
-      operation = ':shutdown'
+        operation = ':shutdown'
     else:
-      operation = '/host="{host}"/:shutdown'.format(host=host)
+        operation = '/host="{host}"/:shutdown'.format(host=host)
     shutdown_result = __salt__['jboss7_cli.run_operation'](jboss_config, operation, fail_on_error=False)
     # JBoss seems to occasionaly close the channel immediately when :shutdown is sent
     if shutdown_result['success'] or (not shutdown_result['success'] and 'Operation failed: Channel closed' in shutdown_result['stdout']):
@@ -110,7 +110,7 @@ def reload_(jboss_config, host=None):
     jboss_config
         Configuration dictionary with properties specified above.
     host
-        The name of the host. JBoss domain mode only - and required if running in domain mode. 
+        The name of the host. JBoss domain mode only - and required if running in domain mode.
         The host name is the "name" attribute of the "host" element in host.xml
 
     CLI Example:
@@ -122,9 +122,9 @@ def reload_(jboss_config, host=None):
        '''
     log.debug("======================== MODULE FUNCTION: jboss7.reload")
     if host is None:
-      operation = ':reload'
+        operation = ':reload'
     else:
-      operation = '/host="{host}"/:reload'.format(host=host)
+        operation = '/host="{host}"/:reload'.format(host=host)
     reload_result = __salt__['jboss7_cli.run_operation'](jboss_config, operation, fail_on_error=False)
     # JBoss seems to occasionaly close the channel immediately when :reload is sent
     if reload_result['success'] or (not reload_result['success'] and
@@ -165,12 +165,12 @@ def create_datasource(jboss_config, name, datasource_properties, profile=None):
     ds_resource_description = __get_datasource_resource_description(jboss_config, name, profile)
 
     if profile is None:
-      operation = '/subsystem=datasources/data-source="{name}":add({properties})'.format(
+        operation = '/subsystem=datasources/data-source="{name}":add({properties})'.format(
                 name=name,
                 properties=__get_properties_assignment_string(datasource_properties, ds_resource_description)
       )
     else:
-      operation = '/profile="{profile}"/subsystem=datasources/data-source="{name}":add({properties})'.format(
+        operation = '/profile="{profile}"/subsystem=datasources/data-source="{name}":add({properties})'.format(
                 name=name,
                 profile=profile,
                 properties=__get_properties_assignment_string(datasource_properties, ds_resource_description)
@@ -267,9 +267,9 @@ def __get_datasource_resource_description(jboss_config, name, profile=None):
     log.debug("======================== MODULE FUNCTION: jboss7.__get_datasource_resource_description, name=%s, profile=%s", name, profile)
 
     if profile is None:
-      operation = '/subsystem=datasources/data-source="{name}":read-resource-description'.format(name=name)
+        operation = '/subsystem=datasources/data-source="{name}":read-resource-description'.format(name=name)
     else:
-      operation = '/profile="{profile}"/subsystem=datasources/data-source="{name}":read-resource-description'.format(name=name, profile=profile)
+        operation = '/profile="{profile}"/subsystem=datasources/data-source="{name}":read-resource-description'.format(name=name, profile=profile)
 
     operation_result = __salt__['jboss7_cli.run_operation'](jboss_config, operation)
     if operation_result['outcome']:
@@ -285,7 +285,7 @@ def read_datasource(jboss_config, name, profile=None):
     name
         Datasource name
     profile
-        Profile name (JBoss domain mode only) 
+        Profile name (JBoss domain mode only)
 
     CLI Example:
 
@@ -318,12 +318,12 @@ def create_simple_binding(jboss_config, binding_name, value, profile=None):
        '''
     log.debug("======================== MODULE FUNCTION: jboss7.create_simple_binding, binding_name=%s, value=%s, profile=%s", binding_name, value, profile)
     if profile is None:
-      operation = '/subsystem=naming/binding="{binding_name}":add(binding-type=simple, value="{value}")'.format(
+        operation = '/subsystem=naming/binding="{binding_name}":add(binding-type=simple, value="{value}")'.format(
             binding_name=binding_name,
             value=__escape_binding_value(value)
       )
     else:
-      operation = '/profile="{profile}"/subsystem=naming/binding="{binding_name}":add(binding-type=simple, value="{value}")'.format(
+        operation = '/profile="{profile}"/subsystem=naming/binding="{binding_name}":add(binding-type=simple, value="{value}")'.format(
             profile=profile,
             binding_name=binding_name,
             value=__escape_binding_value(value)
@@ -352,15 +352,15 @@ def update_simple_binding(jboss_config, binding_name, value, profile=None):
        '''
     log.debug("======================== MODULE FUNCTION: jboss7.update_simple_binding, binding_name=%s, value=%s, profile=%s", binding_name, value, profile)
     if profile is None:
-      operation = '/subsystem=naming/binding="{binding_name}":write-attribute(name=value, value="{value}")'.format(
-          binding_name=binding_name,
-          value=__escape_binding_value(value)
+        operation = '/subsystem=naming/binding="{binding_name}":write-attribute(name=value, value="{value}")'.format(
+            binding_name=binding_name,
+            value=__escape_binding_value(value)
       )
     else:
-      operation = '/profile="{profile}"/subsystem=naming/binding="{binding_name}":write-attribute(name=value, value="{value}")'.format(
-          profile=profile,
-          binding_name=binding_name,
-          value=__escape_binding_value(value)
+        operation = '/profile="{profile}"/subsystem=naming/binding="{binding_name}":write-attribute(name=value, value="{value}")'.format(
+            profile=profile,
+            binding_name=binding_name,
+            value=__escape_binding_value(value)
       )
     return __salt__['jboss7_cli.run_operation'](jboss_config, operation)
 
@@ -417,9 +417,9 @@ def __update_datasource_property(jboss_config, datasource_name, name, value, ds_
 def __read_datasource(jboss_config, name, profile=None):
 
     if profile is None:
-      operation = '/subsystem=datasources/data-source="{name}":read-resource'.format(name=name)
+        operation = '/subsystem=datasources/data-source="{name}":read-resource'.format(name=name)
     else:
-      operation = '/profile="{profile}"/subsystem=datasources/data-source="{name}":read-resource'.format(profile=profile, name=name)
+        operation = '/profile="{profile}"/subsystem=datasources/data-source="{name}":read-resource'.format(profile=profile, name=name)
 
     operation_result = __salt__['jboss7_cli.run_operation'](jboss_config, operation)
 

--- a/salt/modules/jboss7.py
+++ b/salt/modules/jboss7.py
@@ -28,6 +28,7 @@ import re
 import logging
 
 # Import Salt libs
+from salt.exceptions import SaltInvocationError
 from salt.utils import dictdiffer
 
 # Import 3rd-party libs
@@ -40,12 +41,18 @@ __func_alias__ = {
 }
 
 
-def status(jboss_config):
+def status(jboss_config, host=None, server_config=None):
     '''
     Get status of running jboss instance.
 
     jboss_config
         Configuration dictionary with properties specified above.
+    host
+        The name of the host. JBoss domain mode only - and required if running in domain mode. 
+        The host name is the "name" attribute of the "host" element in host.xml
+    server_config
+        The name of the Server Configuration. JBoss Domain mode only - and required 
+        if running in domain mode.
 
     CLI Example:
 
@@ -55,16 +62,26 @@ def status(jboss_config):
 
        '''
     log.debug("======================== MODULE FUNCTION: jboss7.status")
-    operation = ':read-attribute(name=server-state)'
+    if (host is None and server_config is None):
+      operation = ':read-attribute(name=server-state)'
+    elif (host is not None and server_config is not None):
+      operation = '/host="{host}"/server-config="{server_config}"/:read-attribute(name=status)'.format(
+              host=host, 
+              server_config=server_config)
+    else:
+      raise SaltInvocationError('Invalid parameters. Must either pass both host and server_config or neither')
     return __salt__['jboss7_cli.run_operation'](jboss_config, operation, fail_on_error=False, retries=0)
 
 
-def stop_server(jboss_config):
+def stop_server(jboss_config, host=None):
     '''
     Stop running jboss instance
 
     jboss_config
         Configuration dictionary with properties specified above.
+    host
+        The name of the host. JBoss domain mode only - and required if running in domain mode. 
+        The host name is the "name" attribute of the "host" element in host.xml
 
     CLI Example:
 
@@ -74,7 +91,10 @@ def stop_server(jboss_config):
 
        '''
     log.debug("======================== MODULE FUNCTION: jboss7.stop_server")
-    operation = ':shutdown'
+    if host is None:
+      operation = ':shutdown'
+    else:
+      operation = '/host="{host}"/:shutdown'.format(host=host)
     shutdown_result = __salt__['jboss7_cli.run_operation'](jboss_config, operation, fail_on_error=False)
     # JBoss seems to occasionaly close the channel immediately when :shutdown is sent
     if shutdown_result['success'] or (not shutdown_result['success'] and 'Operation failed: Channel closed' in shutdown_result['stdout']):
@@ -83,12 +103,15 @@ def stop_server(jboss_config):
         raise Exception('''Cannot handle error, return code={retcode}, stdout='{stdout}', stderr='{stderr}' '''.format(**shutdown_result))
 
 
-def reload_(jboss_config):
+def reload_(jboss_config, host=None):
     '''
     Reload running jboss instance
 
     jboss_config
         Configuration dictionary with properties specified above.
+    host
+        The name of the host. JBoss domain mode only - and required if running in domain mode. 
+        The host name is the "name" attribute of the "host" element in host.xml
 
     CLI Example:
 
@@ -98,7 +121,10 @@ def reload_(jboss_config):
 
        '''
     log.debug("======================== MODULE FUNCTION: jboss7.reload")
-    operation = ':reload'
+    if host is None:
+      operation = ':reload'
+    else:
+      operation = '/host="{host}"/:reload'.format(host=host)
     reload_result = __salt__['jboss7_cli.run_operation'](jboss_config, operation, fail_on_error=False)
     # JBoss seems to occasionaly close the channel immediately when :reload is sent
     if reload_result['success'] or (not reload_result['success'] and
@@ -109,7 +135,7 @@ def reload_(jboss_config):
         raise Exception('''Cannot handle error, return code={retcode}, stdout='{stdout}', stderr='{stderr}' '''.format(**reload_result))
 
 
-def create_datasource(jboss_config, name, datasource_properties):
+def create_datasource(jboss_config, name, datasource_properties, profile=None):
     '''
     Create datasource in running jboss instance
 
@@ -126,6 +152,8 @@ def create_datasource(jboss_config, name, datasource_properties):
           - password: secret
           - min-pool-size: 3
           - use-java-context: True
+    profile
+        The profile name (JBoss domain mode only)
 
     CLI Example:
 
@@ -133,13 +161,20 @@ def create_datasource(jboss_config, name, datasource_properties):
 
         salt '*' jboss7.create_datasource '{"cli_path": "integration.modules.sysmod.SysModuleTest.test_valid_docs", "controller": "10.11.12.13:9999", "cli_user": "jbossadm", "cli_password": "jbossadm"}' 'my_datasource' '{"driver-name": "mysql", "connection-url": "jdbc:mysql://localhost:3306/sampleDatabase", "jndi-name": "java:jboss/datasources/sampleDS", "user-name": "sampleuser", "password": "secret", "min-pool-size": 3, "use-java-context": True}'
     '''
-    log.debug("======================== MODULE FUNCTION: jboss7.create_datasource, name=%s", name)
-    ds_resource_description = __get_datasource_resource_description(jboss_config, name)
+    log.debug("======================== MODULE FUNCTION: jboss7.create_datasource, name=%s, profile=%s", name, profile)
+    ds_resource_description = __get_datasource_resource_description(jboss_config, name, profile)
 
-    operation = '/subsystem=datasources/data-source="{name}":add({properties})'.format(
+    if profile is None:
+      operation = '/subsystem=datasources/data-source="{name}":add({properties})'.format(
                 name=name,
                 properties=__get_properties_assignment_string(datasource_properties, ds_resource_description)
-    )
+      )
+    else:
+      operation = '/profile="{profile}"/subsystem=datasources/data-source="{name}":add({properties})'.format(
+                name=name,
+                profile=profile,
+                properties=__get_properties_assignment_string(datasource_properties, ds_resource_description)
+      )
 
     return __salt__['jboss7_cli.run_operation'](jboss_config, operation, fail_on_error=False)
 
@@ -178,7 +213,7 @@ def __format_value(key, value, ds_attributes):
         raise Exception("Don't know how to format value {0} of type {1}".format(value, type_))
 
 
-def update_datasource(jboss_config, name, new_properties):
+def update_datasource(jboss_config, name, new_properties, profile=None):
     '''
     Update an existing datasource in running jboss instance.
     If the property doesn't exist if will be created, if it does, it will be updated with the new value
@@ -196,6 +231,8 @@ def update_datasource(jboss_config, name, new_properties):
           - password: secret
           - min-pool-size: 3
           - use-java-context: True
+    profile
+        The profile name (JBoss domain mode only)
 
     CLI Example:
 
@@ -204,8 +241,8 @@ def update_datasource(jboss_config, name, new_properties):
         salt '*' jboss7.update_datasource '{"cli_path": "integration.modules.sysmod.SysModuleTest.test_valid_docs", "controller": "10.11.12.13:9999", "cli_user": "jbossadm", "cli_password": "jbossadm"}' 'my_datasource' '{"driver-name": "mysql", "connection-url": "jdbc:mysql://localhost:3306/sampleDatabase", "jndi-name": "java:jboss/datasources/sampleDS", "user-name": "sampleuser", "password": "secret", "min-pool-size": 3, "use-java-context": True}'
 
     '''
-    log.debug("======================== MODULE FUNCTION: jboss7.update_datasource, name=%s", name)
-    ds_result = __read_datasource(jboss_config, name)
+    log.debug("======================== MODULE FUNCTION: jboss7.update_datasource, name=%s, profile=%s", name, profile)
+    ds_result = __read_datasource(jboss_config, name, profile)
     current_properties = ds_result['result']
     diff = dictdiffer.DictDiffer(new_properties, current_properties)
     changed_properties = diff.changed()
@@ -215,10 +252,10 @@ def update_datasource(jboss_config, name, new_properties):
         'comment': ''
     }
     if len(changed_properties) > 0:
-        ds_resource_description = __get_datasource_resource_description(jboss_config, name)
+        ds_resource_description = __get_datasource_resource_description(jboss_config, name, profile)
         ds_attributes = ds_resource_description['attributes']
         for key in changed_properties:
-            update_result = __update_datasource_property(jboss_config, name, key, new_properties[key], ds_attributes)
+            update_result = __update_datasource_property(jboss_config, name, key, new_properties[key], ds_attributes, profile)
             if not update_result['success']:
                 ret['result'] = False
                 ret['comment'] = ret['comment'] + ('Could not update datasource property {0} with value {1},\n stdout: {2}\n'.format(key, new_properties[key], update_result['stdout']))
@@ -226,15 +263,20 @@ def update_datasource(jboss_config, name, new_properties):
     return ret
 
 
-def __get_datasource_resource_description(jboss_config, name):
-    log.debug("======================== MODULE FUNCTION: jboss7.__get_datasource_resource_description, name=%s", name)
-    operation = '/subsystem=datasources/data-source="{name}":read-resource-description'.format(name=name)
+def __get_datasource_resource_description(jboss_config, name, profile=None):
+    log.debug("======================== MODULE FUNCTION: jboss7.__get_datasource_resource_description, name=%s, profile=%s", name, profile)
+
+    if profile is None:
+      operation = '/subsystem=datasources/data-source="{name}":read-resource-description'.format(name=name)
+    else:
+      operation = '/profile="{profile}"/subsystem=datasources/data-source="{name}":read-resource-description'.format(name=name, profile=profile)
+
     operation_result = __salt__['jboss7_cli.run_operation'](jboss_config, operation)
     if operation_result['outcome']:
         return operation_result['result']
 
 
-def read_datasource(jboss_config, name):
+def read_datasource(jboss_config, name, profile=None):
     '''
     Read datasource properties in the running jboss instance.
 
@@ -242,6 +284,8 @@ def read_datasource(jboss_config, name):
         Configuration dictionary with properties specified above.
     name
         Datasource name
+    profile
+        Profile name (JBoss domain mode only) 
 
     CLI Example:
 
@@ -250,10 +294,10 @@ def read_datasource(jboss_config, name):
         salt '*' jboss7.read_datasource '{"cli_path": "integration.modules.sysmod.SysModuleTest.test_valid_docs", "controller": "10.11.12.13:9999", "cli_user": "jbossadm", "cli_password": "jbossadm"}'
        '''
     log.debug("======================== MODULE FUNCTION: jboss7.read_datasource, name=%s", name)
-    return __read_datasource(jboss_config, name)
+    return __read_datasource(jboss_config, name, profile)
 
 
-def create_simple_binding(jboss_config, binding_name, value):
+def create_simple_binding(jboss_config, binding_name, value, profile=None):
     '''
     Create a simple jndi binding in the running jboss instance
 
@@ -263,6 +307,8 @@ def create_simple_binding(jboss_config, binding_name, value):
         Binding name to be created
     value
         Binding value
+    profile
+        The profile name (JBoss domain mode only)
 
     CLI Example:
 
@@ -270,15 +316,22 @@ def create_simple_binding(jboss_config, binding_name, value):
 
         salt '*' jboss7.create_simple_binding '{"cli_path": "integration.modules.sysmod.SysModuleTest.test_valid_docs", "controller": "10.11.12.13:9999", "cli_user": "jbossadm", "cli_password": "jbossadm"}' my_binding_name my_binding_value
        '''
-    log.debug("======================== MODULE FUNCTION: jboss7.create_simple_binding, binding_name=%s, value=%s", binding_name, value)
-    operation = '/subsystem=naming/binding="{binding_name}":add(binding-type=simple, value="{value}")'.format(
-          binding_name=binding_name,
-          value=__escape_binding_value(value)
-    )
+    log.debug("======================== MODULE FUNCTION: jboss7.create_simple_binding, binding_name=%s, value=%s, profile=%s", binding_name, value, profile)
+    if profile is None:
+      operation = '/subsystem=naming/binding="{binding_name}":add(binding-type=simple, value="{value}")'.format(
+            binding_name=binding_name,
+            value=__escape_binding_value(value)
+      )
+    else:
+      operation = '/profile="{profile}"/subsystem=naming/binding="{binding_name}":add(binding-type=simple, value="{value}")'.format(
+            profile=profile,
+            binding_name=binding_name,
+            value=__escape_binding_value(value)
+      )
     return __salt__['jboss7_cli.run_operation'](jboss_config, operation)
 
 
-def update_simple_binding(jboss_config, binding_name, value):
+def update_simple_binding(jboss_config, binding_name, value, profile=None):
     '''
     Update the simple jndi binding in the running jboss instance
 
@@ -288,6 +341,8 @@ def update_simple_binding(jboss_config, binding_name, value):
         Binding name to be updated
     value
         New binding value
+    profile
+        The profile name (JBoss domain mode only)
 
     CLI Example:
 
@@ -295,15 +350,22 @@ def update_simple_binding(jboss_config, binding_name, value):
 
         salt '*' jboss7.update_simple_binding '{"cli_path": "integration.modules.sysmod.SysModuleTest.test_valid_docs", "controller": "10.11.12.13:9999", "cli_user": "jbossadm", "cli_password": "jbossadm"}' my_binding_name my_binding_value
        '''
-    log.debug("======================== MODULE FUNCTION: jboss7.update_simple_binding, binding_name=%s, value=%s", binding_name, value)
-    operation = '/subsystem=naming/binding="{binding_name}":write-attribute(name=value, value="{value}")'.format(
-        binding_name=binding_name,
-        value=__escape_binding_value(value)
-    )
+    log.debug("======================== MODULE FUNCTION: jboss7.update_simple_binding, binding_name=%s, value=%s, profile=%s", binding_name, value, profile)
+    if profile is None:
+      operation = '/subsystem=naming/binding="{binding_name}":write-attribute(name=value, value="{value}")'.format(
+          binding_name=binding_name,
+          value=__escape_binding_value(value)
+      )
+    else:
+      operation = '/profile="{profile}"/subsystem=naming/binding="{binding_name}":write-attribute(name=value, value="{value}")'.format(
+          profile=profile,
+          binding_name=binding_name,
+          value=__escape_binding_value(value)
+      )
     return __salt__['jboss7_cli.run_operation'](jboss_config, operation)
 
 
-def read_simple_binding(jboss_config, binding_name):
+def read_simple_binding(jboss_config, binding_name, profile=None):
     '''
     Read jndi binding in the running jboss instance
 
@@ -311,6 +373,8 @@ def read_simple_binding(jboss_config, binding_name):
         Configuration dictionary with properties specified above.
     binding_name
         Binding name to be created
+    profile
+        The profile name (JBoss domain mode only)
 
     CLI Example:
 
@@ -319,26 +383,44 @@ def read_simple_binding(jboss_config, binding_name):
         salt '*' jboss7.read_simple_binding '{"cli_path": "integration.modules.sysmod.SysModuleTest.test_valid_docs", "controller": "10.11.12.13:9999", "cli_user": "jbossadm", "cli_password": "jbossadm"}' my_binding_name
        '''
     log.debug("======================== MODULE FUNCTION: jboss7.read_simple_binding, %s", binding_name)
-    return __read_simple_binding(jboss_config, binding_name)
+    return __read_simple_binding(jboss_config, binding_name, profile=profile)
 
 
-def __read_simple_binding(jboss_config, binding_name):
-    operation = '/subsystem=naming/binding="{binding_name}":read-resource'.format(binding_name=binding_name)
+def __read_simple_binding(jboss_config, binding_name, profile=None):
+    if profile is None:
+        operation = '/subsystem=naming/binding="{binding_name}":read-resource'.format(binding_name=binding_name)
+    else:
+        operation = '/profile="{profile}"/subsystem=naming/binding="{binding_name}":read-resource'.format(binding_name=binding_name, profile=profile)
     return __salt__['jboss7_cli.run_operation'](jboss_config, operation)
 
 
-def __update_datasource_property(jboss_config, datasource_name, name, value, ds_attributes):
-    log.debug("======================== MODULE FUNCTION: jboss7.__update_datasource_property, datasource_name=%s, name=%s, value=%s", datasource_name, name, value)
-    operation = '/subsystem=datasources/data-source="{datasource_name}":write-attribute(name="{name}",value={value})'.format(
-                  datasource_name=datasource_name,
-                  name=name,
-                  value=__format_value(name, value, ds_attributes)
-            )
+def __update_datasource_property(jboss_config, datasource_name, name, value, ds_attributes, profile=None):
+    log.debug("======================== MODULE FUNCTION: jboss7.__update_datasource_property, datasource_name=%s, name=%s, value=%s, profile=%s", datasource_name, name, value, profile)
+
+    if profile is None:
+        operation = '/subsystem=datasources/data-source="{datasource_name}":write-attribute(name="{name}",value={value})'.format(
+                      datasource_name=datasource_name,
+                      name=name,
+                      value=__format_value(name, value, ds_attributes)
+        )
+    else:
+        operation = '/profile="{profile}"/subsystem=datasources/data-source="{datasource_name}":write-attribute(name="{name}",value={value})'.format(
+                      datasource_name=datasource_name,
+                      name=name,
+                      value=__format_value(name, value, ds_attributes),
+                      profile=profile
+        )
+
     return __salt__['jboss7_cli.run_operation'](jboss_config, operation, fail_on_error=False)
 
 
-def __read_datasource(jboss_config, name):
-    operation = '/subsystem=datasources/data-source="{name}":read-resource'.format(name=name)
+def __read_datasource(jboss_config, name, profile=None):
+
+    if profile is None:
+      operation = '/subsystem=datasources/data-source="{name}":read-resource'.format(name=name)
+    else:
+      operation = '/profile="{profile}"/subsystem=datasources/data-source="{name}":read-resource'.format(profile=profile, name=name)
+
     operation_result = __salt__['jboss7_cli.run_operation'](jboss_config, operation)
 
     return operation_result
@@ -350,7 +432,7 @@ def __escape_binding_value(binding_name):
     return result
 
 
-def remove_datasource(jboss_config, name):
+def remove_datasource(jboss_config, name, profile=None):
     '''
     Remove an existing datasource from the running jboss instance.
 
@@ -358,6 +440,8 @@ def remove_datasource(jboss_config, name):
         Configuration dictionary with properties specified above.
     name
         Datasource name
+    profile
+        The profile (JBoss domain mode only)
 
     CLI Example:
 
@@ -365,8 +449,11 @@ def remove_datasource(jboss_config, name):
 
         salt '*' jboss7.remove_datasource '{"cli_path": "integration.modules.sysmod.SysModuleTest.test_valid_docs", "controller": "10.11.12.13:9999", "cli_user": "jbossadm", "cli_password": "jbossadm"}' my_datasource_name
        '''
-    log.debug("======================== MODULE FUNCTION: jboss7.remove_datasource, name=%s", name)
-    operation = '/subsystem=datasources/data-source={name}:remove'.format(name=name)
+    log.debug("======================== MODULE FUNCTION: jboss7.remove_datasource, name=%s, profile=%s", name, profile)
+    if profile is None:
+        operation = '/subsystem=datasources/data-source={name}:remove'.format(name=name)
+    else:
+        operation = '/profile="{profile}"/subsystem=datasources/data-source={name}:remove'.format(name=name, profile=profile)
     return __salt__['jboss7_cli.run_operation'](jboss_config, operation, fail_on_error=False)
 
 

--- a/tests/unit/states/jboss7_test.py
+++ b/tests/unit/states/jboss7_test.py
@@ -64,7 +64,7 @@ class JBoss7StateTestCase(TestCase):
             else:
                 return {'success': False, 'err_code': 'JBAS014807'}
 
-        def create_func(jboss_config, name, datasource_properties):
+        def create_func(jboss_config, name, datasource_properties, profile):
             ds_status['created'] = True
             return {'success': True}
 
@@ -88,7 +88,7 @@ class JBoss7StateTestCase(TestCase):
             else:
                 return {'success': True, 'result': {'connection-url': 'jdbc:/old-connection-url'}}
 
-        def update_func(jboss_config, name, new_properties):
+        def update_func(jboss_config, name, new_properties, profile):
             ds_status['updated'] = True
             return {'success': True}
 
@@ -145,7 +145,7 @@ class JBoss7StateTestCase(TestCase):
             else:
                 return {'success': False, 'err_code': 'JBAS014807'}
 
-        def create_func(jboss_config, binding_name, value):
+        def create_func(jboss_config, binding_name, value, profile):
             binding_status['created'] = True
             return {'success': True}
 
@@ -171,7 +171,7 @@ class JBoss7StateTestCase(TestCase):
             else:
                 return {'success': True, 'result': {'value': 'DEV'}}
 
-        def update_func(jboss_config, binding_name, value):
+        def update_func(jboss_config, binding_name, value, profile):
             binding_status['updated'] = True
             return {'success': True}
 
@@ -204,7 +204,7 @@ class JBoss7StateTestCase(TestCase):
         def read_func(jboss_config, binding_name, profile):
             return {'success': False, 'err_code': 'JBAS014807'}
 
-        def create_func(jboss_config, binding_name, value):
+        def create_func(jboss_config, binding_name, value, profile):
             return {'success': False, 'failure-description': 'Incorrect binding name.'}
 
         __salt__['jboss7.read_simple_binding'] = MagicMock(side_effect=read_func)
@@ -221,7 +221,7 @@ class JBoss7StateTestCase(TestCase):
         def read_func(jboss_config, binding_name, profile):
             return {'success': True, 'result': {'value': 'DEV'}}
 
-        def update_func(jboss_config, binding_name, value):
+        def update_func(jboss_config, binding_name, value, profile):
             return {'success': False, 'failure-description': 'Incorrect binding name.'}
 
         __salt__['jboss7.read_simple_binding'] = MagicMock(side_effect=read_func)

--- a/tests/unit/states/jboss7_test.py
+++ b/tests/unit/states/jboss7_test.py
@@ -58,7 +58,7 @@ class JBoss7StateTestCase(TestCase):
         datasource_properties = {'connection-url': 'jdbc:/old-connection-url'}
         ds_status = {'created': False}
 
-        def read_func(jboss_config, name):
+        def read_func(jboss_config, name, profile):
             if ds_status['created']:
                 return {'success': True, 'result': datasource_properties}
             else:
@@ -82,7 +82,7 @@ class JBoss7StateTestCase(TestCase):
     def test_should_update_the_datasource_if_exists(self):
         ds_status = {'updated': False}
 
-        def read_func(jboss_config, name):
+        def read_func(jboss_config, name, profile):
             if ds_status['updated']:
                 return {'success': True, 'result': {'connection-url': 'jdbc:/new-connection-url'}}
             else:
@@ -116,7 +116,7 @@ class JBoss7StateTestCase(TestCase):
         result = jboss7.datasource_exists(name='appDS', jboss_config={}, datasource_properties={'connection-url': 'jdbc:/same-connection-url'}, recreate=True)
 
         __salt__['jboss7.remove_datasource'].assert_called_with(name='appDS', jboss_config={}, profile=None)
-        __salt__['jboss7.create_datasource'].assert_called_with(name='appDS', jboss_config={}, datasource_properties={'connection-url': 'jdbc:/same-connection-url'})
+        __salt__['jboss7.create_datasource'].assert_called_with(name='appDS', jboss_config={}, datasource_properties={'connection-url': 'jdbc:/same-connection-url'}, profile=None)
         self.assertEqual(result['changes']['removed'], 'appDS')
         self.assertEqual(result['changes']['created'], 'appDS')
 
@@ -139,7 +139,7 @@ class JBoss7StateTestCase(TestCase):
         # given
         binding_status = {'created': False}
 
-        def read_func(jboss_config, binding_name):
+        def read_func(jboss_config, binding_name, profile):
             if binding_status['created']:
                 return {'success': True, 'result': {'value': 'DEV'}}
             else:
@@ -165,7 +165,7 @@ class JBoss7StateTestCase(TestCase):
         # given
         binding_status = {'updated': False}
 
-        def read_func(jboss_config, binding_name):
+        def read_func(jboss_config, binding_name, profile):
             if binding_status['updated']:
                 return {'success': True, 'result': {'value': 'DEV2'}}
             else:
@@ -201,7 +201,7 @@ class JBoss7StateTestCase(TestCase):
         self.assertEqual(result['comment'], 'Bindings not changed.')
 
     def test_should_raise_exception_if_cannot_create_binding(self):
-        def read_func(jboss_config, binding_name):
+        def read_func(jboss_config, binding_name, profile):
             return {'success': False, 'err_code': 'JBAS014807'}
 
         def create_func(jboss_config, binding_name, value):
@@ -218,7 +218,7 @@ class JBoss7StateTestCase(TestCase):
             self.assertEqual(str(e), 'Incorrect binding name.')
 
     def test_should_raise_exception_if_cannot_update_binding(self):
-        def read_func(jboss_config, binding_name):
+        def read_func(jboss_config, binding_name, profile):
             return {'success': True, 'result': {'value': 'DEV'}}
 
         def update_func(jboss_config, binding_name, value):

--- a/tests/unit/states/jboss7_test.py
+++ b/tests/unit/states/jboss7_test.py
@@ -72,7 +72,7 @@ class JBoss7StateTestCase(TestCase):
         __salt__['jboss7.create_datasource'] = MagicMock(side_effect=create_func)
 
         # when
-        result = jboss7.datasource_exists(name='appDS', jboss_config={}, datasource_properties=datasource_properties)
+        result = jboss7.datasource_exists(name='appDS', jboss_config={}, datasource_properties=datasource_properties, profile=None)
 
         # then
         __salt__['jboss7.create_datasource'].assert_called_with(name='appDS', jboss_config={}, datasource_properties=datasource_properties)
@@ -95,7 +95,7 @@ class JBoss7StateTestCase(TestCase):
         __salt__['jboss7.read_datasource'] = MagicMock(side_effect=read_func)
         __salt__['jboss7.update_datasource'] = MagicMock(side_effect=update_func)
 
-        result = jboss7.datasource_exists(name='appDS', jboss_config={}, datasource_properties={'connection-url': 'jdbc:/new-connection-url'})
+        result = jboss7.datasource_exists(name='appDS', jboss_config={}, datasource_properties={'connection-url': 'jdbc:/new-connection-url'}, profile=None)
 
         __salt__['jboss7.update_datasource'].assert_called_with(name='appDS', jboss_config={}, new_properties={'connection-url': 'jdbc:/new-connection-url'})
         self.assertFalse(__salt__['jboss7.create_datasource'].called)
@@ -115,7 +115,7 @@ class JBoss7StateTestCase(TestCase):
 
         result = jboss7.datasource_exists(name='appDS', jboss_config={}, datasource_properties={'connection-url': 'jdbc:/same-connection-url'}, recreate=True)
 
-        __salt__['jboss7.remove_datasource'].assert_called_with(name='appDS', jboss_config={})
+        __salt__['jboss7.remove_datasource'].assert_called_with(name='appDS', jboss_config={}, profile=None)
         __salt__['jboss7.create_datasource'].assert_called_with(name='appDS', jboss_config={}, datasource_properties={'connection-url': 'jdbc:/same-connection-url'})
         self.assertEqual(result['changes']['removed'], 'appDS')
         self.assertEqual(result['changes']['created'], 'appDS')
@@ -131,7 +131,7 @@ class JBoss7StateTestCase(TestCase):
 
         result = jboss7.datasource_exists(name='appDS', jboss_config={}, datasource_properties={'connection-url': 'jdbc:/old-connection-url'})
 
-        __salt__['jboss7.update_datasource'].assert_called_with(name='appDS', jboss_config={}, new_properties={'connection-url': 'jdbc:/old-connection-url'})
+        __salt__['jboss7.update_datasource'].assert_called_with(name='appDS', jboss_config={}, new_properties={'connection-url': 'jdbc:/old-connection-url'}, profile=None)
         self.assertFalse(__salt__['jboss7.create_datasource'].called)
         self.assertEqual(result['comment'], 'Datasource not changed.')
 
@@ -153,7 +153,7 @@ class JBoss7StateTestCase(TestCase):
         __salt__['jboss7.create_simple_binding'] = MagicMock(side_effect=create_func)
 
         # when
-        result = jboss7.bindings_exist(name='bindings', jboss_config={}, bindings={'env': 'DEV'})
+        result = jboss7.bindings_exist(name='bindings', jboss_config={}, bindings={'env': 'DEV'}, profile=None)
 
         # then
         __salt__['jboss7.create_simple_binding'].assert_called_with(jboss_config={}, binding_name='env', value='DEV')
@@ -179,7 +179,7 @@ class JBoss7StateTestCase(TestCase):
         __salt__['jboss7.update_simple_binding'] = MagicMock(side_effect=update_func)
 
         # when
-        result = jboss7.bindings_exist(name='bindings', jboss_config={}, bindings={'env': 'DEV2'})
+        result = jboss7.bindings_exist(name='bindings', jboss_config={}, bindings={'env': 'DEV2'}, profile=None)
 
         # then
         __salt__['jboss7.update_simple_binding'].assert_called_with(jboss_config={}, binding_name='env', value='DEV2')
@@ -212,7 +212,7 @@ class JBoss7StateTestCase(TestCase):
 
         # when
         try:
-            jboss7.bindings_exist(name='bindings', jboss_config={}, bindings={'env': 'DEV2'})
+            jboss7.bindings_exist(name='bindings', jboss_config={}, bindings={'env': 'DEV2'}, profile=None)
             self.fail('An exception should be thrown')
         except CommandExecutionError as e:
             self.assertEqual(str(e), 'Incorrect binding name.')
@@ -229,7 +229,7 @@ class JBoss7StateTestCase(TestCase):
 
         # when
         try:
-            jboss7.bindings_exist(name='bindings', jboss_config={}, bindings={'env': '!@#!///some weird value'})
+            jboss7.bindings_exist(name='bindings', jboss_config={}, bindings={'env': '!@#!///some weird value'}, profile=None)
             self.fail('An exception should be thrown')
         except CommandExecutionError as e:
             self.assertEqual(str(e), 'Incorrect binding name.')

--- a/tests/unit/states/jboss7_test.py
+++ b/tests/unit/states/jboss7_test.py
@@ -75,7 +75,7 @@ class JBoss7StateTestCase(TestCase):
         result = jboss7.datasource_exists(name='appDS', jboss_config={}, datasource_properties=datasource_properties, profile=None)
 
         # then
-        __salt__['jboss7.create_datasource'].assert_called_with(name='appDS', jboss_config={}, datasource_properties=datasource_properties)
+        __salt__['jboss7.create_datasource'].assert_called_with(name='appDS', jboss_config={}, datasource_properties=datasource_properties, profile=None)
         self.assertFalse(__salt__['jboss7.update_datasource'].called)
         self.assertEqual(result['comment'], 'Datasource created.')
 
@@ -97,7 +97,7 @@ class JBoss7StateTestCase(TestCase):
 
         result = jboss7.datasource_exists(name='appDS', jboss_config={}, datasource_properties={'connection-url': 'jdbc:/new-connection-url'}, profile=None)
 
-        __salt__['jboss7.update_datasource'].assert_called_with(name='appDS', jboss_config={}, new_properties={'connection-url': 'jdbc:/new-connection-url'})
+        __salt__['jboss7.update_datasource'].assert_called_with(name='appDS', jboss_config={}, new_properties={'connection-url': 'jdbc:/new-connection-url'}, profile=None)
         self.assertFalse(__salt__['jboss7.create_datasource'].called)
         self.assertEqual(result['comment'], 'Datasource updated.')
 
@@ -156,7 +156,7 @@ class JBoss7StateTestCase(TestCase):
         result = jboss7.bindings_exist(name='bindings', jboss_config={}, bindings={'env': 'DEV'}, profile=None)
 
         # then
-        __salt__['jboss7.create_simple_binding'].assert_called_with(jboss_config={}, binding_name='env', value='DEV')
+        __salt__['jboss7.create_simple_binding'].assert_called_with(jboss_config={}, binding_name='env', value='DEV', profile=None)
         self.assertEqual(__salt__['jboss7.update_simple_binding'].call_count, 0)
         self.assertEqual(result['changes'], {'added': 'env:DEV\n'})
         self.assertEqual(result['comment'], 'Bindings changed.')
@@ -182,7 +182,7 @@ class JBoss7StateTestCase(TestCase):
         result = jboss7.bindings_exist(name='bindings', jboss_config={}, bindings={'env': 'DEV2'}, profile=None)
 
         # then
-        __salt__['jboss7.update_simple_binding'].assert_called_with(jboss_config={}, binding_name='env', value='DEV2')
+        __salt__['jboss7.update_simple_binding'].assert_called_with(jboss_config={}, binding_name='env', value='DEV2', profile=None)
         self.assertEqual(__salt__['jboss7.create_simple_binding'].call_count, 0)
         self.assertEqual(result['changes'], {'changed': 'env:DEV->DEV2\n'})
         self.assertEqual(result['comment'], 'Bindings changed.')


### PR DESCRIPTION
The existing jboss7 python state/exec modules only worked for JBoss "standalone" mode; however, JBoss also has a "domain" mode - and generally operations are slightly different. In particular:
- For subsystem operations, "domain" mode requires a top-level hierarchy called "profile" for each subsystem.
- For server, operations, a "host" - and possibly a "server_config" need to be specified.

This PR adds all of these as optional parameters so that "domain" mode users can utilize the jboss7 modules.

:hand: Extra scrutiny please - this is my first reasonably significant python module contribution
