### PR TITLE
grains: Remove dmesg path and add additional detection path for virtu…

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -725,15 +725,16 @@ def _virtual(osdata):
         if os.path.isfile('/sys/devices/virtual/dmi/id/product_name'):
             try:
                 with salt.utils.fopen('/sys/devices/virtual/dmi/id/product_name', 'r') as fhr:
-                    if 'VirtualBox' in fhr.read():
+                    output = fhr.read()
+                    if 'VirtualBox' in output:
                         grains['virtual'] = 'VirtualBox'
-                    if 'RHEV Hypervisor' in fhr.read():
+                    elif 'RHEV Hypervisor' in output:
                         grains['virtual'] = 'kvm'
                         grains['virtual_subtype'] = 'rhev'
-                    if 'oVirt Node' in fhr.read():
+                    elif 'oVirt Node' in output:
                         grains['virtual'] = 'kvm'
                         grains['virtual_subtype'] = 'ovirt'
-                    if 'Google' in fhr.read():
+                    elif 'Google' in output:
                         grains['virtual'] = 'gce'
             except IOError:
                 pass


### PR DESCRIPTION
…albox, rhev, ovirt, and gce

Improves behavior mentioned in #25101 

dmesg has a limited buffer size and will eventually drop the lines we are trying to match against. This patch removes calling dmesg and adds an additional detection path.
