### PR TITLE
Properly handle getting local config values in older git versions

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -1922,9 +1922,9 @@ def config_set(name,
     pre = __salt__['git.config_get'](
         cwd='global' if global_ else repo,
         key=name,
-        all=True,
         user=user,
-        ignore_retcode=True
+        ignore_retcode=True,
+        **{'all': True}
     )
 
     if desired == pre:
@@ -1947,7 +1947,7 @@ def config_set(name,
 
     try:
         # Set/update config value
-        __salt__['git.config_set'](
+        post = __salt__['git.config_set'](
             cwd='global' if global_ else repo,
             key=name,
             value=value,
@@ -1964,15 +1964,6 @@ def config_set(name,
                 _strip_exc(exc)
             )
         )
-
-    # Check value to make sure that it now matches the value we set
-    post = __salt__['git.config_get'](
-        cwd='global' if global_ else repo,
-        key=name,
-        all=True,
-        user=user,
-        ignore_retcode=True
-    )
 
     if pre != post:
         ret['changes'][name] = {'old': pre, 'new': post}

--- a/tests/integration/modules/git.py
+++ b/tests/integration/modules/git.py
@@ -350,7 +350,9 @@ class GitModuleTest(integration.ModuleCase):
         }
         _clear_config()
         try:
-            # Try to specify both single and multivar (error raised)
+            log.debug(
+                'Try to specify both single and multivar (should raise error)'
+            )
             self.assertTrue(
                 'Only one of \'value\' and \'multivar\' is permitted' in
                 self.run_function(
@@ -361,7 +363,10 @@ class GitModuleTest(integration.ModuleCase):
                     cwd=self.repo
                 )
             )
-            # Set single local value without cwd (error raised)
+            log.debug(
+                'Try to set single local value without cwd (should raise '
+                'error)'
+            )
             self.assertTrue(
                 '\'cwd\' argument required unless global=True' in
                 self.run_function(
@@ -370,7 +375,7 @@ class GitModuleTest(integration.ModuleCase):
                     value=cfg_local['foo.single'][0],
                 )
             )
-            # Set single local value
+            log.debug('Set single local value')
             self.assertEqual(
                 self.run_function(
                     'git.config_set',
@@ -380,7 +385,7 @@ class GitModuleTest(integration.ModuleCase):
                 ),
                 cfg_local['foo.single']
             )
-            # Set single global value
+            log.debug('Set single global value')
             self.assertEqual(
                 self.run_function(
                     'git.config_set',
@@ -390,7 +395,7 @@ class GitModuleTest(integration.ModuleCase):
                 ),
                 cfg_global['foo.single']
             )
-            # Set local multivar
+            log.debug('Set local multivar')
             self.assertEqual(
                 self.run_function(
                     'git.config_set',
@@ -400,7 +405,7 @@ class GitModuleTest(integration.ModuleCase):
                 ),
                 cfg_local['foo.multi']
             )
-            # Set global multivar
+            log.debug('Set global multivar')
             self.assertEqual(
                 self.run_function(
                     'git.config_set',
@@ -410,7 +415,7 @@ class GitModuleTest(integration.ModuleCase):
                 ),
                 cfg_global['foo.multi']
             )
-            # Get single local value
+            log.debug('Get single local value')
             self.assertEqual(
                 self.run_function(
                     'git.config_get',
@@ -419,7 +424,7 @@ class GitModuleTest(integration.ModuleCase):
                 ),
                 cfg_local['foo.single'][0]
             )
-            # Get single value from local multivar
+            log.debug('Get single value from local multivar')
             self.assertEqual(
                 self.run_function(
                     'git.config_get',
@@ -428,7 +433,7 @@ class GitModuleTest(integration.ModuleCase):
                 ),
                 cfg_local['foo.multi'][-1]
             )
-            # Get all values from multivar (includes globals)
+            log.debug('Get all values from multivar (includes globals)')
             self.assertEqual(
                 self.run_function(
                     'git.config_get',
@@ -438,7 +443,7 @@ class GitModuleTest(integration.ModuleCase):
                 ),
                 cfg_local['foo.multi']
             )
-            # Get single global value
+            log.debug('Get single global value')
             self.assertEqual(
                 self.run_function(
                     'git.config_get',
@@ -447,7 +452,7 @@ class GitModuleTest(integration.ModuleCase):
                 ),
                 cfg_global['foo.single'][0]
             )
-            # Get single value from global multivar
+            log.debug('Get single value from global multivar')
             self.assertEqual(
                 self.run_function(
                     'git.config_get',
@@ -456,7 +461,7 @@ class GitModuleTest(integration.ModuleCase):
                 ),
                 cfg_global['foo.multi'][-1]
             )
-            # Get all values from global multivar
+            log.debug('Get all values from global multivar')
             self.assertEqual(
                 self.run_function(
                     'git.config_get',
@@ -465,7 +470,7 @@ class GitModuleTest(integration.ModuleCase):
                 ),
                 cfg_global['foo.multi']
             )
-            # Get all local keys/values using regex
+            log.debug('Get all local keys/values using regex')
             self.assertEqual(
                 self.run_function(
                     'git.config_get_regexp',
@@ -474,7 +479,7 @@ class GitModuleTest(integration.ModuleCase):
                 ),
                 cfg_local
             )
-            # Get all global keys/values using regex
+            log.debug('Get all global keys/values using regex')
             self.assertEqual(
                 self.run_function(
                     'git.config_get_regexp',
@@ -484,7 +489,7 @@ class GitModuleTest(integration.ModuleCase):
                 ),
                 cfg_global
             )
-            # Get just the local foo.multi values containing 'a'
+            log.debug('Get just the local foo.multi values containing \'a\'')
             self.assertEqual(
                 self.run_function(
                     'git.config_get_regexp',
@@ -494,7 +499,7 @@ class GitModuleTest(integration.ModuleCase):
                 ),
                 {'foo.multi': [x for x in cfg_local['foo.multi'] if 'a' in x]}
             )
-            # Get just the global foo.multi values containing 'a'
+            log.debug('Get just the global foo.multi values containing \'a\'')
             self.assertEqual(
                 self.run_function(
                     'git.config_get_regexp',
@@ -509,7 +514,7 @@ class GitModuleTest(integration.ModuleCase):
             # TODO: More robust unset testing, try to trigger all the
             # exceptions raised.
 
-            # Unset a single local value
+            log.debug('Unset a single local value')
             self.assertTrue(
                 self.run_function(
                     'git.config_unset',
@@ -517,7 +522,7 @@ class GitModuleTest(integration.ModuleCase):
                     cwd=self.repo,
                 )
             )
-            # Unset an entire local multivar
+            log.debug('Unset an entire local multivar')
             self.assertTrue(
                 self.run_function(
                     'git.config_unset',
@@ -526,7 +531,7 @@ class GitModuleTest(integration.ModuleCase):
                     **{'all': True}
                 )
             )
-            # Unset a single global value
+            log.debug('Unset a single global value')
             self.assertTrue(
                 self.run_function(
                     'git.config_unset',
@@ -534,7 +539,7 @@ class GitModuleTest(integration.ModuleCase):
                     **{'global': True}
                 )
             )
-            # Unset an entire local multivar
+            log.debug('Unset an entire local multivar')
             self.assertTrue(
                 self.run_function(
                     'git.config_unset',

--- a/tests/integration/states/git.py
+++ b/tests/integration/states/git.py
@@ -216,15 +216,12 @@ class GitTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
         self.addCleanup(shutil.rmtree, name, ignore_errors=True)
         subprocess.check_call(['git', 'init', '--quiet', name])
 
-        config_key = 'user.name'
-        config_value = 'foo bar'
-
         ret = self.run_state(
-            'git.config',
-            name=config_key,
-            value=config_value,
+            'git.config_set',
+            name='user.name',
+            value='foo bar',
             repo=name,
-            is_global=False)
+            **{'global': False})
         self.assertSaltTrueReturn(ret)
 
 


### PR DESCRIPTION
This PR also makes an optimization to the git.config_set state and adds some
helpful debug logging for one of the larger git module integration tests.
