### PR TITLE
Use localectl for locale setting/getting on Debian if available

### DIFF
--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -103,6 +103,9 @@ def get_locale():
     elif 'RedHat' in __grains__['os_family']:
         cmd = 'grep "^LANG=" /etc/sysconfig/i18n'
     elif 'Debian' in __grains__['os_family']:
+        if salt.utils.which('localectl'):
+            return _localectl_get()
+
         cmd = 'grep "^LANG=" /etc/default/locale'
     elif 'Gentoo' in __grains__['os_family']:
         cmd = 'eselect --brief locale show'
@@ -136,6 +139,9 @@ def set_locale(locale):
             append_if_not_found=True
         )
     elif 'Debian' in __grains__['os_family']:
+        if salt.utils.which('localectl'):
+            return _localectl_set(locale)
+
         update_locale = salt.utils.which('update-locale')
         if update_locale is None:
             raise CommandExecutionError(


### PR DESCRIPTION
There is a problem:

``` bash
$ lsb_release -rd
Description:    Debian GNU/Linux 8.1 (jessie)
Release:    8.1

$ localectl
   System Locale: LANG=en_GB.UTF-8
       VC Keymap: n/a
      X11 Layout: us
       X11 Model: pc105

$ salt-call -c ~/conf locale.set_locale en_US.UTF-8
local:
    True

$ localectl
   System Locale: LANG=en_GB.UTF-8
       VC Keymap: n/a
      X11 Layout: us
       X11 Model: pc105
```
