### PR TITLE
LXC gateway provisioned only when IP is provided

### DIFF
--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -840,7 +840,8 @@ def _network_conf(conf_tuples=None, **kwargs):
     # (lxc.network.ipv4.gateway: auto)
     if (
         distutils.version.LooseVersion(version()) <= '1.0.7' and
-        True not in ['lxc.network.ipv4.gateway' in a for a in ret]
+        True not in ['lxc.network.ipv4.gateway' in a for a in ret] and
+        True in ['lxc.network.ipv4' in a for a in ret]
     ):
         ret.append({'lxc.network.ipv4.gateway': 'auto'})
     return ret


### PR DESCRIPTION
The directive `lxc.network.ipv4.gateway = auto` should not be added to an LXC configuration file when no IP address is specified. It results in the following error: 

```
lxc-start 1441227080.264 ERROR    lxc_conf - conf.c:setup_netdev:2724 - Cannot add ipv4 gateway for eth0 when not assigning an address
```
