### PR TITLE
salt-call custom states

### DIFF
--- a/salt/cli/call.py
+++ b/salt/cli/call.py
@@ -29,6 +29,11 @@ class SaltCall(parsers.SaltCallOptionParser):
             pillar_root = os.path.abspath(self.options.pillar_root)
             self.config['pillar_roots'] = {'base': _expand_glob_path([pillar_root])}
 
+        if self.options.states_dir:
+            # check if the argument is pointing to a file on disk
+            states_dir = os.path.abspath(self.options.states_dir)
+            self.config['states_dirs'] = [states_dir]
+
         if self.options.local:
             self.config['file_client'] = 'local'
         if self.options.master:

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2247,6 +2247,11 @@ class SaltCallOptionParser(six.with_metaclass(OptionParserMeta,
             help='Set this directory as the base pillar root.'
         )
         self.add_option(
+            '--states-dir',
+            default=None,
+            help='Set this directory to search for additional states'
+        )
+        self.add_option(
             '--retcode-passthrough',
             default=False,
             action='store_true',


### PR DESCRIPTION
When running `salt-call` the user should be able to specify where additional states live.

```
salt-call --local --file-root=/home/damian/salt --states-dir=/home/damian/salt/states state.sls mystate
```
