### PR TITLE
Make the testing ioloop the current one

### DIFF
--- a/tests/unit/transport/tcp_test.py
+++ b/tests/unit/transport/tcp_test.py
@@ -58,6 +58,7 @@ class BaseTCPReqCase(TestCase):
         cls.server_channel.pre_fork(cls.process_manager)
 
         cls.io_loop = tornado.ioloop.IOLoop()
+        cls.io_loop.make_current()
         cls.server_channel.post_fork(cls._handle_payload, io_loop=cls.io_loop)
 
         cls.server_thread = threading.Thread(target=cls.io_loop.start)

--- a/tests/unit/transport/zeromq_test.py
+++ b/tests/unit/transport/zeromq_test.py
@@ -66,6 +66,7 @@ class BaseZMQReqCase(TestCase):
         cls.server_channel.pre_fork(cls.process_manager)
 
         cls.io_loop = zmq.eventloop.ioloop.ZMQIOLoop()
+        cls.io_loop.make_current()
         cls.server_channel.post_fork(cls._handle_payload, io_loop=cls.io_loop)
 
         cls.server_thread = threading.Thread(target=cls.io_loop.start)


### PR DESCRIPTION
Otherwise, loops from previous intefere and cause stacktraces on ioloop init
