### PR TITLE
file.symlink gets windows account instead of root

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -835,6 +835,14 @@ def symlink(
         user = __opts__['user']
 
     if salt.utils.is_windows():
+
+        # Make sure the user exists in Windows
+        # Salt default is 'root'
+        if not __salt__['user.info'](user):
+            # User not found, use the account salt is running under
+            # If username not found, use System
+            user = os.getenv('username', 'System')
+
         if group is not None:
             log.warning(
                 'The group argument for {0} has been ignored as this '


### PR DESCRIPTION
root is default user for salt. In windows file.symlink state now checks to see if the passed user exists before continuing. If it does not, it gets the account that is running salt. If that fails, it uses 'System'.

Fixes: #26730 
