### PR TITLE
Review defaults.get

### DIFF
--- a/salt/modules/defaults.py
+++ b/salt/modules/defaults.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import inspect
+from __future__ import absolute_import
 import json
 import logging
 import os
@@ -81,13 +81,13 @@ def get(key, default=''):
 
         salt '*' defaults.get core:users:root
 
-    The defaults is computed from pillar name. The first entry is considered as
-    the formula namespace. ``defaults.yaml`` and ``defaults.json`` are possible
-    filename for formula defaults.
+    The defaults is computed from pillar key. The first entry is considered as
+    the formula namespace.
 
-    For example, ``core:users:root`` will try to load
+    For example, querying ``core:users:root`` will try to load
     ``salt://core/defaults.yaml`` and ``salt://core/defaults.json``.
     '''
+
     if ':' in key:
         namespace, key = key.split(':', 1)
     else:

--- a/salt/modules/defaults.py
+++ b/salt/modules/defaults.py
@@ -35,7 +35,6 @@ def _get_files(pillar_name):
 
     for ext in ('yaml', 'json'):
         source_url = 'salt://{0}/{1}'.format(pillar_name, 'defaults.' + ext)
-        log.debug("Catching %r", source_url)
         paths.append(source_url)
 
     return __context__['cp.fileclient'].cache_files(paths)

--- a/salt/modules/defaults.py
+++ b/salt/modules/defaults.py
@@ -72,8 +72,6 @@ def get(key, default=''):
     a default value for a pillar from defaults.json or defaults.yaml
     files that are stored in the root of a salt formula.
 
-    When called from the CLI it works exactly like pillar.get.
-
     CLI Example:
 
     .. code-block:: bash


### PR DESCRIPTION
Hi,

The use case we hit was a good candidate for `defaults.get` module. We want to provide full settings in pillar identicall to `map.jinja` output.

Say we have two formulas : foo and bar. We want to reuse `foo.user` as `bar.user` without duplicating values. We also want to allow minion to override any settings.

``` saltstack
# pillars/foo.sls
{% set defaults = salt['defaults.get']('foo') -%}
{% load_yaml as pillars -%}
user: root
{% endload -%}
{% set pillars = salt['grains.filter_by']({
    'default': defaults,
}, merge=pillars) -%}
foo:
  {{ pillars|yaml(False)|indent(2) }}
```

This way, you can reuse settings in other pillars to avoid copying pillars. Like this.

``` yaml
# pillars/bar.sls
{% import_yaml 'foo.sls' as foo -%}
{% set foo = foo['foo'] -%}

bar:
  user: {{ foo.user }}
```

We have then consistent pillar deduplication.

But `defaults.get` has some oddities:
- it determines formula name from template name. This reduce reusability.
- it fallbacks to pillar in command line. Directly depends on above point.
- no logging
- does not load cached files but recompute files from pillar template file. This is a bug.

This PR fixes this.
