### PR TITLE
Get rid of error in legacy git pillar when using branch mapping notation

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -316,6 +316,8 @@ class _LegacyGitPillar(object):
             branch = opts.get('environment') or 'base'
             if branch == 'base':
                 branch = opts.get('gitfs_base') or 'master'
+        elif ':' in branch:
+            branch = branch.split(':', 1)[0]
         return branch
 
     def update(self):


### PR DESCRIPTION
This doesn't fix the problem of the branch not being mapped to the specified
branch, and this code is not going to be maintained going forward (in favor of
the gitfs-backed git_pillar code), but this will at least prevent the branch
from failing to checkout.
