### PR TITLE
remove extra call to time_auth from ClearFuncs

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1715,12 +1715,14 @@ class ClearFuncs(object):
                 if not found:
                     log.warning('Authentication failure of type "eauth" occurred.')
                     return ''
-            if not self.loadauth.time_auth(clear_load):
-                log.warning('Authentication failure of type "eauth" occurred.')
-                return ''
 
             clear_load['groups'] = groups
-            return self.loadauth.mk_token(clear_load)
+            token = self.loadauth.mk_token(clear_load)
+            if not token:
+                log.warning('Authentication failure of type "eauth" occurred.')
+                return ''
+            else:
+                return token
         except Exception as exc:
             type_, value_, traceback_ = sys.exc_info()
             log.error(


### PR DESCRIPTION
In `ClearFuncs`, the `mk_token` method makes a call to `LoadAuth.time_auth` and then, if successful makes a call to `LoadAuth.mk_token`.  However, `LoadAuth.mk_token` _also_ calls `LoadAuth.time_auth` and the end result is duplicate authentication events.

This causes a problem for eauth modules that use one-time-use tokens (e.g. yubikey) as the token will be invalid after the first (superfluous) call to `time_auth` directly from `ClearFuncs.mk_token` and the call from `LoadAuth.mk_token` will fail.
