### PR TITLE
Adding extra command line arguments only for dnf install to allow upgrades

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1046,8 +1046,14 @@ def install(name=None,
                 downgrade.append(pkgstr)
 
     if targets:
-        cmd = '{yum_command} -y {repo} {exclude} {branch} {gpgcheck} install {pkg}'.format(
+        if _yum() == 'dnf':
+            dnf_args='--best --allowerasing'
+        else:
+            dnf_args=''
+
+        cmd = '{yum_command} -y {dnf} {repo} {exclude} {branch} {gpgcheck} install {pkg}'.format(
             yum_command=_yum(),
+            dnf=dnf_args,
             repo=repo_arg,
             exclude=exclude_arg,
             branch=branch_arg,


### PR DESCRIPTION
yum install is used by salt for doing pkg.latest, but dnf requires extra command line arguments to get the same behavior. So we add them just for dnf.
