### PR TITLE
aptpkg.mod_repo: Raise when key_url doesn't exist

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1802,6 +1802,10 @@ def mod_repo(repo, saltenv='base', **kwargs):
     elif 'key_url' in kwargs:
         key_url = kwargs['key_url']
         fn_ = __salt__['cp.cache_file'](key_url, saltenv)
+        if not fn_:
+            raise CommandExecutionError(
+                'Error: file not found: {0}'.format(key_url)
+            )
         cmd = 'apt-key add {0}'.format(_cmd_quote(fn_))
         out = __salt__['cmd.run_stdout'](cmd, **kwargs)
         if not out.upper().startswith('OK'):


### PR DESCRIPTION
pipes.quote would raise with unexplicit error if _fn = False

With the following state:

```
emdebian-repo:
  pkgrepo.managed:
    - humanname: EMDebian repository
    - name: deb http://www.emdebian.org/debian/ jessie main
    - file: /etc/apt/sources.list.d/emdebian.list
    - key_url: salt://raspberry-pi/emdebian.pgp.key
    - require_in:
      - gcc-4.7-arm-linux-gnueabihf
      - g++-4.7-arm-linux-gnueabihf
```

I got this error:

```
          ID: emdebian-repo
    Function: pkgrepo.managed
        Name: deb http://www.emdebian.org/debian/ jessie main
      Result: False
     Comment: Failed to configure repo 'deb http://www.emdebian.org/debian/ jessie main': 'bool' object is not iterable
     Started: 04:32:11.375845
    Duration: 93.689 ms
     Changes:   
```

With the patch, the error becomes:

```
          ID: emdebian-repo
    Function: pkgrepo.managed
        Name: deb http://www.emdebian.org/debian/ jessie main
      Result: False
     Comment: Failed to configure repo 'deb http://www.emdebian.org/debian/ jessie main': Error: file not found: salt://raspberry-pi/emdebian.pgp.key
     Started: 04:33:00.798934
    Duration: 93.026 ms
     Changes:   
```

I don't know if this should be also pushed on other branches, like 2015.5 and/or 2015.8. What do you think?
