### PR TITLE
Fixes win_path module, migrates from reg.(set|get)_key to reg.(set|get)_value

### DIFF
--- a/salt/modules/win_path.py
+++ b/salt/modules/win_path.py
@@ -201,4 +201,3 @@ def remove(path):
         return rehash()
     else:
         return False
-

--- a/salt/modules/win_path.py
+++ b/salt/modules/win_path.py
@@ -75,7 +75,7 @@ def get_path():
     '''
     ret = __salt__['reg.read_key']('HKEY_LOCAL_MACHINE',
                                    'SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
-                                   'PATH').split(';')
+                                   'PATH')['vdata'].split(';')
 
     # Trim ending backslash
     return list(map(_normalize_dir, ret))
@@ -148,11 +148,11 @@ def add(path, index=0):
 
     # Add it to the Path
     sysPath.insert(index, path)
-    regedit = __salt__['reg.set_key'](
+    regedit = __salt__['reg.set_value'](
         'HKEY_LOCAL_MACHINE',
         'SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
-        'PATH',
         ';'.join(sysPath),
+        'PATH',
         'REG_EXPAND_SZ'
     )
 
@@ -190,14 +190,15 @@ def remove(path):
     except ValueError:
         return True
 
-    regedit = __salt__['reg.set_key'](
+    regedit = __salt__['reg.set_value'](
         'HKEY_LOCAL_MACHINE',
         'SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
-        'PATH',
         ';'.join(sysPath),
+        'PATH',
         'REG_EXPAND_SZ'
     )
     if regedit:
         return rehash()
     else:
         return False
+

--- a/tests/unit/modules/win_path_test.py
+++ b/tests/unit/modules/win_path_test.py
@@ -69,7 +69,7 @@ class WinPathTestCase(TestCase):
         '''
             Test to Returns the system path
         '''
-        mock = MagicMock(return_value='c:\\salt')
+        mock = MagicMock(return_value={'vdata': 'c:\\salt'})
         with patch.dict(win_path.__salt__, {'reg.read_key': mock}):
             self.assertListEqual(win_path.get_path(), ['c:\\salt'])
 
@@ -85,12 +85,12 @@ class WinPathTestCase(TestCase):
         '''
             Test to add the directory to the SYSTEM path
         '''
-        mock = MagicMock(return_value=['c:\\salt'])
-        with patch.object(win_path, 'get_path', mock):
-            mock = MagicMock(return_value=True)
-            with patch.dict(win_path.__salt__, {'reg.set_key': mock}):
-                mock = MagicMock(side_effect=[True, False])
-                with patch.object(win_path, 'rehash', mock):
+        mock_get = MagicMock(return_value=['c:\\salt'])
+        with patch.object(win_path, 'get_path', mock_get):
+            mock_set = MagicMock(return_value=True)
+            with patch.dict(win_path.__salt__, {'reg.set_value': mock_set}):
+                mock_rehash = MagicMock(side_effect=[True, False])
+                with patch.object(win_path, 'rehash', mock_rehash):
                     self.assertTrue(win_path.add("c:\\salt", 1))
 
                     self.assertFalse(win_path.add("c:\\salt", 1))
@@ -99,14 +99,14 @@ class WinPathTestCase(TestCase):
         '''
             Test to remove the directory from the SYSTEM path
         '''
-        mock = MagicMock(side_effect=[[1], ['c:\\salt'], ['c:\\salt']])
-        with patch.object(win_path, 'get_path', mock):
+        mock_get = MagicMock(side_effect=[[1], ['c:\\salt'], ['c:\\salt']])
+        with patch.object(win_path, 'get_path', mock_get):
             self.assertTrue(win_path.remove("c:\\salt"))
 
-            mock = MagicMock(side_effect=[True, False])
-            with patch.dict(win_path.__salt__, {'reg.set_key': mock}):
-                mock = MagicMock(return_value="Salt")
-                with patch.object(win_path, 'rehash', mock):
+            mock_set = MagicMock(side_effect=[True, False])
+            with patch.dict(win_path.__salt__, {'reg.set_value': mock_set}):
+                mock_rehash = MagicMock(return_value="Salt")
+                with patch.object(win_path, 'rehash', mock_rehash):
                     self.assertEqual(win_path.remove("c:\\salt"), "Salt")
 
                 self.assertFalse(win_path.remove("c:\\salt"))


### PR DESCRIPTION
win_path is broken for me, as reg.get_key returns a dictionary with the required values inside.
Accessing the value with the key 'vdata' solves the problem.
