### PR TITLE
Make elasticsearch work as master job cache

### DIFF
--- a/salt/modules/elasticsearch.py
+++ b/salt/modules/elasticsearch.py
@@ -174,7 +174,7 @@ def alias_get(indices=None, aliases=None, hosts=None, profile=None):
     return None
 
 
-def document_create(index, doc_type, body=None, hosts=None, profile=None):
+def document_create(index, doc_type, body=None, id=None, hosts=None, profile=None):
     '''
     Create a document in a specified index
 
@@ -184,7 +184,7 @@ def document_create(index, doc_type, body=None, hosts=None, profile=None):
     '''
     es = _get_instance(hosts, profile)
     try:
-        result = es.index(index=index, doc_type=doc_type, body=body)  # TODO error handling
+        result = es.index(index=index, doc_type=doc_type, body=body, id=id)  # TODO error handling
         return True
     except elasticsearch.exceptions.NotFoundError:
         return None

--- a/salt/returners/elasticsearch_return.py
+++ b/salt/returners/elasticsearch_return.py
@@ -123,7 +123,7 @@ def save_load(jid, load):
     '''
     Save the load to the specified jid id
     '''
-    index = 'salt-master-job-cache'
+    index = __salt__['config.option']('elasticsearch:master_job_cache_index', 'salt-master-job-cache')
     doc_type = __salt__['config.option']('elasticsearch:master_job_cache_doc_type', 'default')
 
     index_exists = __salt__['elasticsearch.index_exists'](index)
@@ -147,7 +147,7 @@ def get_load(jid):
     '''
     Return the load data that marks a specified jid
     '''
-    index = 'salt-master_job_cache'
+    index = __salt__['config.option']('elasticsearch:master_job_cache_index', 'salt-master-job-cache')
     doc_type = __salt__['config.option']('elasticsearch:master_job_cache_doc_type', 'default')
 
     data = __salt__['elasticsearch.document_get'](index=index, id=jid, doc_type=doc_type)

--- a/salt/returners/elasticsearch_return.py
+++ b/salt/returners/elasticsearch_return.py
@@ -122,6 +122,8 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
 def save_load(jid, load):
     '''
     Save the load to the specified jid id
+
+    .. versionadded:: 2015.8.1
     '''
     index = __salt__['config.option']('elasticsearch:master_job_cache_index', 'salt-master-job-cache')
     doc_type = __salt__['config.option']('elasticsearch:master_job_cache_doc_type', 'default')
@@ -146,6 +148,8 @@ def save_load(jid, load):
 def get_load(jid):
     '''
     Return the load data that marks a specified jid
+
+    .. versionadded:: 2015.8.1
     '''
     index = __salt__['config.option']('elasticsearch:master_job_cache_index', 'salt-master-job-cache')
     doc_type = __salt__['config.option']('elasticsearch:master_job_cache_doc_type', 'default')


### PR DESCRIPTION
Add `save_load()` and `get_load()` to `elasticsearch_return.py` so it can serve as a master job cache. Refs #23125.
