### PR TITLE
New ldap state module and accompanying execution module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,18 +17,18 @@ MANIFEST
 #   top of salt such as
 # - /some/path$ git clone https://github.com/thatch45/salt.git
 # - /some/path$ virtualenv --python=/usr/bin/python2.6 salt
-bin/
-etc/
-include/
-lib/
-lib64
-local/
-pip/
-share/
-tests/integration/tmp/
-tests/cachedir/
-tests/unit/templates/roots/
-var/
+/bin/
+/etc/
+/include/
+/lib/
+/lib64/
+/local/
+/pip/
+/share/
+/tests/integration/tmp/
+/tests/cachedir/
+/tests/unit/templates/roots/
+/var/
 
 # setuptools stuff
 *.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -18,14 +18,17 @@ MANIFEST
 # - /some/path$ git clone https://github.com/thatch45/salt.git
 # - /some/path$ virtualenv --python=/usr/bin/python2.6 salt
 bin/
+etc/
 include/
 lib/
 lib64
+local/
 pip/
 share/
 tests/integration/tmp/
 tests/cachedir/
 tests/unit/templates/roots/
+var/
 
 # setuptools stuff
 *.egg-info

--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -147,6 +147,7 @@ Full list of builtin execution modules
     kmod
     launchctl
     layman
+    ldap3
     ldapmod
     linux_acl
     linux_lvm

--- a/doc/ref/modules/all/salt.modules.ldap3.rst
+++ b/doc/ref/modules/all/salt.modules.ldap3.rst
@@ -1,0 +1,6 @@
+==================
+salt.modules.ldap3
+==================
+
+.. automodule:: salt.modules.ldap3
+    :members:

--- a/doc/ref/states/all/index.rst
+++ b/doc/ref/states/all/index.rst
@@ -87,6 +87,7 @@ Full list of builtin state modules
     keystone
     kmod
     layman
+    ldap
     libvirt
     linux_acl
     locale

--- a/doc/ref/states/all/salt.states.ldap.rst
+++ b/doc/ref/states/all/salt.states.ldap.rst
@@ -1,0 +1,6 @@
+================
+salt.states.ldap
+================
+
+.. automodule:: salt.states.ldap
+    :members:

--- a/salt/modules/ldap3.py
+++ b/salt/modules/ldap3.py
@@ -1,0 +1,494 @@
+# -*- coding: utf-8 -*-
+'''
+Query and modify an LDAP database (alternative interface)
+=========================================================
+
+.. versionadded:: Boron
+
+This is an alternative to the ``ldap`` interface provided by the
+:py:mod:`ldapmod <salt.modules.ldapmod>` execution module.
+
+:depends: - ``ldap`` Python module
+'''
+
+from __future__ import absolute_import
+
+available_backends = set()
+try:
+    import ldap
+    import ldap.ldapobject
+    import ldap.modlist
+    import ldap.sasl
+    available_backends.add('ldap')
+except ImportError:
+    pass
+import logging
+import salt.ext.six as six
+import sys
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''Only load this module if the Python ldap module is present'''
+    return bool(len(available_backends))
+
+
+class LDAPError(Exception):
+    '''Base class of all LDAP exceptions raised by backends.
+
+    This is only used for errors encountered while interacting with
+    the LDAP server; usage errors (e.g., invalid backend name) will
+    have a different type.
+
+    :ivar cause: backend exception object, if applicable
+    '''
+    def __init__(self, message, cause=None):
+        super(LDAPError, self).__init__(message)
+        self.cause = cause
+
+
+def _convert_exception(e):
+    '''Convert an ldap backend exception to an LDAPError and raise it.'''
+    args = ('exception in ldap backend: {0}'.format(repr(e)), e)
+    if six.PY2:
+        six.reraise(LDAPError, args, sys.exc_info()[2])
+    else:
+        six.raise_from(LDAPError(*args), e)
+
+
+def _bind(l, bind=None):
+    '''Bind helper.'''
+    if bind is None:
+        return
+    method = bind.get('method', 'simple')
+    if method is None:
+        return
+    elif method == 'simple':
+        l.simple_bind_s(bind.get('dn', ''), bind.get('password', ''))
+    elif method == 'sasl':
+        sasl_class = getattr(ldap.sasl,
+                             bind.get('mechanism', 'EXTERNAL').lower())
+        creds = bind.get('credentials', None)
+        if creds is None:
+            creds = {}
+        auth = sasl_class(*creds.get('args', []), **creds.get('kwargs', {}))
+        l.sasl_interactive_bind_s(bind.get('dn', ''), auth)
+    else:
+        raise ValueError('unsupported bind method "' + method
+                         + '"; supported bind methods: simple sasl')
+
+
+class _connect_ctx(object):
+    def __init__(self, c):
+        self.c = c
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        pass
+
+
+def connect(connect_spec=None):
+    '''Connect and optionally bind to an LDAP server.
+
+    :param connect_spec:
+        This can be an LDAP connection object returned by a previous
+        call to :py:func:`connect` (in which case the argument is
+        simply returned), ``None`` (in which case an empty dict is
+        used), or a dict with the following keys:
+
+        * ``'backend'``
+            Optional; default depends on which Python LDAP modules are
+            installed.  Name of the Python LDAP module to use.  Only
+            ``'ldap'`` is supported at the moment.
+
+        * ``'url'``
+            Optional; defaults to ``'ldapi:///'``.  URL to the LDAP
+            server.
+
+        * ``'bind'``
+            Optional; defaults to ``None``.  Describes how to bind an
+            identity to the LDAP connection.  If ``None``, an
+            anonymous connection is made.  Valid keys:
+
+            * ``'method'``
+                Optional; defaults to ``None``.  The authentication
+                method to use.  Valid values include but are not
+                necessarily limited to ``'simple'``, ``'sasl'``, and
+                ``None``.  If ``None``, an anonymous connection is
+                made.  Available methods depend on the chosen backend.
+
+            * ``'mechanism'``
+                Optional; defaults to ``'EXTERNAL'``.  The SASL
+                mechanism to use.  Ignored unless the method is
+                ``'sasl'``.  Available methods depend on the chosen
+                backend and the server's capabilities.
+
+            * ``'credentials'``
+                Optional; defaults to ``None``.  An object specific to
+                the chosen SASL mechanism and backend that represents
+                the authentication credentials.  Ignored unless the
+                method is ``'sasl'``.
+
+                For the ``'ldap'`` backend, this is a dictionary.  If
+                ``None``, an empty dict is used.  Keys:
+
+                * ``'args'``
+                    Optional; defaults to an empty list.  A list of
+                    arguments to pass to the SASL mechanism
+                    constructor.  See the SASL mechanism constructor
+                    documentation in the ``ldap.sasl`` Python module.
+
+                * ``'kwargs'``
+                    Optional; defaults to an empty dict.  A dict of
+                    keyword arguments to pass to the SASL mechanism
+                    constructor.  See the SASL mechanism constructor
+                    documentation in the ``ldap.sasl`` Python module.
+
+            * ``'dn'``
+                Optional; defaults to an empty string.  The
+                distinguished name to bind.
+
+            * ``'password'``
+                Optional; defaults to an empty string.  Password for
+                binding.  Ignored if the method is ``'sasl'``.
+
+        * ``'tls'``
+            Optional; defaults to ``None``.  A backend-specific object
+            containing settings to override default TLS behavior.
+
+            For the ``'ldap'`` backend, this is a dictionary.  Not all
+            settings in this dictionary are supported by all versions
+            of ``python-ldap`` or the underlying TLS library.  If
+            ``None``, an empty dict is used.  Possible keys:
+
+            * ``'starttls'``
+                If present, initiate a TLS connection using StartTLS.
+                (The value associated with this key is ignored.)
+
+            * ``'cacertdir'``
+                Set the path of the directory containing CA
+                certificates.
+
+            * ``'cacertfile'``
+                Set the pathname of the CA certificate file.
+
+            * ``'certfile'``
+                Set the pathname of the certificate file.
+
+            * ``'cipher_suite'``
+                Set the allowed cipher suite.
+
+            * ``'crlcheck'``
+                Set the CRL evaluation strategy.  Valid values are
+                ``'none'``, ``'peer'``, and ``'all'``.
+
+            * ``'crlfile'``
+                Set the pathname of the CRL file.
+
+            * ``'dhfile'``
+                Set the pathname of the file containing the parameters
+                for Diffie-Hellman ephemeral key exchange.
+
+            * ``'keyfile'``
+                Set the pathname of the certificate key file.
+
+            * ``'newctx'``
+                If present, instruct the underlying TLS library to
+                create a new TLS context.  (The value associated with
+                this key is ignored.)
+
+            * ``'protocol_min'``
+                Set the minimum protocol version.
+
+            * ``'random_file'``
+                Set the pathname of the random file when
+                ``/dev/random`` and ``/dev/urandom`` are not
+                available.
+
+            * ``'require_cert'``
+                Set the certificate validation policy.  Valid values
+                are ``'never'``, ``'hard'``, ``'demand'``,
+                ``'allow'``, and ``'try'``.
+
+        * ``'opts'``
+            Optional; defaults to ``None``.  A backend-specific object
+            containing options for the backend.
+
+            For the ``'ldap'`` backend, this is a dictionary of
+            OpenLDAP options to set.  If ``None``, an empty dict is
+            used.  Each key is a the name of an OpenLDAP option
+            constant without the ``'LDAP_OPT_'`` prefix, then
+            converted to lower case.
+
+    :returns:
+        an object representing an LDAP connection that can be used as
+        the ``connect_spec`` argument to any of the functions in this
+        module (to avoid the overhead of making and terminating
+        multiple connections).
+
+        This object should be used as a context manager.  It is safe
+        to nest ``with`` statements.
+    '''
+    if isinstance(connect_spec, _connect_ctx):
+        return connect_spec
+    if connect_spec is None:
+        connect_spec = {}
+    backend_name = connect_spec.get('backend', 'ldap')
+    if backend_name not in available_backends:
+        raise ValueError('unsupported backend or required Python module'
+                         + ' unavailable: {0}'.format(backend_name))
+    url = connect_spec.get('url', 'ldapi:///')
+    try:
+        l = ldap.initialize(url)
+        l.protocol_version = ldap.VERSION3
+
+        # set up tls
+        tls = connect_spec.get('tls', None)
+        if tls is None:
+            tls = {}
+        vars = {}
+        for k, v in six.iteritems(tls):
+            if k in ('starttls', 'newctx'):
+                vars[k] = True
+            elif k in ('crlcheck', 'require_cert'):
+                l.set_option(getattr(ldap, 'OPT_X_TLS_' + k.upper()),
+                             getattr(ldap, 'OPT_X_TLS_' + v.upper()))
+            else:
+                l.set_option(getattr(ldap, 'OPT_X_TLS_' + k.upper()), v)
+        if vars.get('starttls', False):
+            l.start_tls_s()
+        if vars.get('newctx', False):
+            l.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
+
+        # set up other options
+        l.set_option(ldap.OPT_REFERRALS, 0)
+        opts = connect_spec.get('opts', None)
+        if opts is None:
+            opts = {}
+        for k, v in six.iteritems(opts):
+            opt = getattr(ldap, 'OPT_' + k.upper())
+            l.set_option(opt, v)
+
+        _bind(l, connect_spec.get('bind', None))
+    except ldap.LDAPError as e:
+        _convert_exception(e)
+    return _connect_ctx(l)
+
+
+def search(connect_spec, base, scope='subtree', filterstr='(objectClass=*)',
+           attrlist=None, attrsonly=0):
+    '''Search an LDAP database.
+
+    :param connect_spec:
+        See the documentation for the ``connect_spec`` parameter for
+        :py:func:`connect`.
+
+    :param base:
+        Distinguished name of the entry at which to start the search.
+
+    :param scope:
+        One of the following:
+
+        * ``'subtree'``
+            Search the base and all of its descendants.
+
+        * ``'base'``
+            Search only the base itself.
+
+        * ``'onelevel'``
+            Search only the base's immediate children.
+
+    :param filterstr:
+        String representation of the filter to apply in the search.
+
+    :param attrlist:
+        Limit the returned attributes to those in the specified list.
+        If ``None``, all attributes of each entry are returned.
+
+    :param attrsonly:
+        If non-zero, don't return any attribute values.
+
+    :returns:
+        a dict of results.  The dict is empty if there are no results.
+        The dict maps each returned entry's distinguished name to a
+        dict that maps each of the matching attribute names to a list
+        of its values.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' ldap3.search "{
+            'url': 'ldaps://ldap.example.com/',
+            'bind': {
+                'method': 'simple',
+                'dn': 'cn=admin,dc=example,dc=com',
+                'password': 'secret',
+            },
+        }" "base='dc=example,dc=com'"
+    '''
+    l = connect(connect_spec)
+    scope = getattr(ldap, 'SCOPE_' + scope.upper())
+    try:
+        results = l.c.search_s(base, scope, filterstr, attrlist, attrsonly)
+    except ldap.NO_SUCH_OBJECT:
+        results = []
+    except ldap.LDAPError as e:
+        _convert_exception(e)
+    return dict(results)
+
+
+def add(connect_spec, dn, attributes):
+    '''Add an entry to an LDAP database.
+
+    :param connect_spec:
+        See the documentation for the ``connect_spec`` parameter for
+        :py:func:`connect`.
+
+    :param dn:
+        Distinguished name of the entry.
+
+    :param attributes:
+        Non-empty dict mapping each of the new entry's attributes to a
+        non-empty iterable of values.
+
+    :returns:
+        ``True`` if successful, raises an exception otherwise.
+    '''
+    l = connect(connect_spec)
+    # convert the "iterable of values" to lists in case that's what
+    # addModlist() expects (also to ensure that the caller's objects
+    # are not modified)
+    attributes = dict(((attr, list(vals))
+                       for attr, vals in six.iteritems(attributes)))
+    log.info('adding entry: dn: {0} attributes: {1}'.format(
+        repr(dn), repr(attributes)))
+    modlist = ldap.modlist.addModlist(attributes)
+    try:
+        l.c.add_s(dn, modlist)
+    except ldap.LDAPError as e:
+        _convert_exception(e)
+    return True
+
+
+def delete(connect_spec, dn):
+    '''Delete an entry from an LDAP database.
+
+    :param connect_spec:
+        See the documentation for the ``connect_spec`` parameter for
+        :py:func:`connect`.
+
+    :param dn:
+        Distinguished name of the entry.
+
+    :returns:
+        ``True`` if successful, raises an exception otherwise.
+    '''
+    l = connect(connect_spec)
+    log.info('deleting entry: dn: {0}'.format(repr(dn)))
+    try:
+        l.c.delete_s(dn)
+    except ldap.LDAPError as e:
+        _convert_exception(e)
+    return True
+
+
+def modify(connect_spec, dn, directives):
+    '''Modify an entry in an LDAP database.
+
+    :param connect_spec:
+        See the documentation for the ``connect_spec`` parameter for
+        :py:func:`connect`.
+
+    :param dn:
+        Distinguished name of the entry.
+
+    :param directives:
+        Iterable of directives that indicate how to modify the entry.
+        Each directive is a tuple of the form ``(op, attr, vals)``,
+        where:
+
+        * ``op`` identifies the modification operation to perform.
+          One of:
+
+          * ``'add'`` to add one or more values to the attribute
+
+          * ``'delete'`` to delete some or all of the values from the
+            attribute.  If no values are specified with this
+            operation, all of the attribute's values are deleted.
+            Otherwise, only the named values are deleted.
+
+          * ``'replace'`` to replace all of the attribute's values
+            with zero or more new values
+
+        * ``attr`` names the attribute to modify
+
+        * ``vals`` is an iterable of values to add or delete
+
+    :returns:
+        ``True`` if successful, raises an exception otherwise.
+    '''
+    l = connect(connect_spec)
+    # convert the "iterable of values" to lists in case that's what
+    # modify_s() expects (also to ensure that the caller's objects are
+    # not modified)
+    modlist = [(getattr(ldap, 'MOD_' + op.upper()), attr, list(vals))
+               for op, attr, vals in directives]
+    try:
+        l.c.modify_s(dn, modlist)
+    except ldap.LDAPError as e:
+        _convert_exception(e)
+    return True
+
+
+def change(connect_spec, dn, before, after):
+    '''Modify an entry in an LDAP database.
+
+    This does the same thing as :py:func:`modify`, but with a simpler
+    interface.  Instead of taking a list of directives, it takes a
+    before and after view of an entry, determines the differences
+    between the two, computes the directives, and executes them.
+
+    Any attribute value present in ``before`` but missing in ``after``
+    is deleted.  Any attribute value present in ``after`` but missing
+    in ``before`` is added.  Any attribute value in the database that
+    is not mentioned in either ``before`` or ``after`` is not altered.
+    Any attribute value that is present in both ``before`` and
+    ``after`` is ignored, regardless of whether that attribute value
+    exists in the database.
+
+    :param connect_spec:
+        See the documentation for the ``connect_spec`` parameter for
+        :py:func:`connect`.
+
+    :param dn:
+        Distinguished name of the entry.
+
+    :param before:
+        The expected state of the entry before modification.  This is
+        a dict mapping each attribute name to an iterable of values.
+
+    :param after:
+        The desired state of the entry after modification.  This is a
+        dict mapping each attribute name to an iterable of values.
+
+    :returns:
+        ``True`` if successful, raises an exception otherwise.
+    '''
+    l = connect(connect_spec)
+    # convert the "iterable of values" to lists in case that's what
+    # modifyModlist() expects (also to ensure that the caller's dicts
+    # are not modified)
+    before = dict(((attr, list(vals))
+                   for attr, vals in six.iteritems(before)))
+    after = dict(((attr, list(vals))
+                  for attr, vals in six.iteritems(after)))
+    modlist = ldap.modlist.modifyModlist(before, after)
+    try:
+        l.c.modify_s(dn, modlist)
+    except ldap.LDAPError as e:
+        _convert_exception(e)
+    return True

--- a/salt/states/ldap.py
+++ b/salt/states/ldap.py
@@ -1,0 +1,518 @@
+# -*- coding: utf-8 -*-
+'''
+Manage entries in an LDAP database
+==================================
+
+.. versionadded:: Boron
+
+The ``states.ldap`` state module allows you to manage LDAP entries and
+their attributes.
+'''
+
+from __future__ import absolute_import
+
+import copy
+import inspect
+import logging
+import salt.ext.six as six
+from salt.utils.odict import OrderedDict
+
+log = logging.getLogger(__name__)
+
+
+def managed(name, entries, connect_spec=None):
+    '''Ensure the existance (or not) of LDAP entries and their attributes
+
+    Example:
+
+    .. code-block:: yaml
+
+        ldapi:///:
+          ldap.managed:
+            - connect_spec:
+                bind:
+                  method: sasl
+
+            - entries:
+
+              # make sure the entry doesn't exist
+              - cn=foo,ou=users,dc=example,dc=com:
+                - delete_others: True
+
+              # make sure the entry exists with only the specified
+              # attribute values
+              - cn=admin,dc=example,dc=com:
+                - delete_others: True
+                - replace:
+                    cn:
+                      - admin
+                    description:
+                      - LDAP administrator
+                    objectClass:
+                      - simpleSecurityObject
+                      - organizationalRole
+                    userPassword:
+                      - {{pillar.ldap_admin_password}}
+
+              # make sure the entry exists, its olcRootDN attribute
+              # has only the specified value, the olcRootDN attribute
+              # doesn't exist, and all other attributes are ignored
+              - 'olcDatabase={1}hdb,cn=config':
+                - replace:
+                    olcRootDN:
+                      - cn=admin,dc=example,dc=com
+                    # the admin entry has its own password attribute
+                    olcRootPW: []
+
+              # note the use of 'default'.  also note how you don't
+              # have to use list syntax if there is only one attribute
+              # value
+              - cn=foo,ou=users,dc=example,dc=com:
+                - delete_others: True
+                - default:
+                    userPassword: changeme
+                    shadowLastChange: 0
+                    # keep sshPublicKey if present, but don't create
+                    # the attribute if it is missing
+                    sshPublicKey: []
+                - replace:
+                    cn: foo
+                    uid: foo
+                    uidNumber: 1000
+                    gidNumber: 1000
+                    gecos: Foo Bar
+                    givenName: Foo
+                    sn: Bar
+                    homeDirectory: /home/foo
+                    loginShell: /bin/bash
+                    objectClass:
+                      - inetOrgPerson
+                      - posixAccount
+                      - top
+                      - ldapPublicKey
+                      - shadowAccount
+
+    :param name:
+        The URL of the LDAP server.  This is ignored if
+        ``connect_spec`` is either a connection object or a dict with
+        a ``'url'`` entry.
+
+    :param entries:
+        A description of the desired state of zero or more LDAP
+        entries.
+
+        ``entries`` is an iterable of dicts.  Each of these dict's
+        keys are the distinguished names (DNs) of LDAP entries to
+        manage.  Each of these dicts is processed in order.  A later
+        dict can reference an LDAP entry that was already mentioned in
+        an earlier dict, which makes it possible for later dicts to
+        enhance or alter the desired state of an LDAP entry.
+
+        The DNs are mapped to a description of the LDAP entry's
+        desired state.  These LDAP entry descriptions are themselves
+        iterables of dicts.  Each dict in the iterable is processed in
+        order.  They contain directives controlling the entry's state.
+        The key names the directive type and the value is state
+        information for the directive.  The specific structure of the
+        state information depends on the directive type.
+
+        The structure of ``entries`` looks like this::
+
+            [{dn1: [{directive1: directive1_state,
+                     directive2: directive2_state},
+                    {directive3: directive3_state}],
+              dn2: [{directive4: directive4_state,
+                     directive5: directive5_state}]},
+             {dn3: [{directive6: directive6_state}]}]
+
+        These are the directives:
+
+        * ``'delete_others'``
+            Boolean indicating whether to delete attributes not
+            mentioned in this dict or any of the other directive
+            dicts for this DN.  Defaults to ``False``.
+
+            If you don't want to delete an attribute if present, but
+            you also don't want to add it if it is missing or modify
+            it if it is present, you can use either the ``'default'``
+            directive or the ``'add'`` directive with an empty value
+            list.
+
+        * ``'default'``
+            A dict mapping an attribute name to an iterable of default
+            values for that attribute.  If the attribute already
+            exists, it is left alone.  If not, it is created using the
+            given list of values.
+
+            An empty value list is useful when you don't want to
+            create an attribute if it is missing but you do want to
+            preserve it if the ``'delete_others'`` key is ``True``.
+
+        * ``'add'``
+            Attribute values to add to the entry.  This is a dict
+            mapping an attribute name to an iterable of values to add.
+
+            An empty value list is useful when you don't want to
+            create an attribute if it is missing but you do want to
+            preserve it if the ``'delete_others'`` key is ``True``.
+
+        * ``'delete'``
+            Attribute values to remove from the entry.  This is a dict
+            mapping an attribute name to an iterable of values to
+            delete from the attribute.  If the iterable is empty, all
+            of the attribute's values are deleted.
+
+        * ``'replace'``
+            Attributes to replace.  This is a dict mapping an
+            attribute name to an iterable of values.  Any existing
+            values for the attribute are deleted, then the given
+            values are added.  The iterable may be empty.
+
+        In the above directives, the iterables of attribute values may
+        instead be ``None``, in which case an empty list is used, or a
+        scalar such as a string or number, in which case a new list
+        containing the scalar is used.
+
+        Note that if all attribute values are removed from an entry,
+        the entire entry is deleted.
+
+    :param connect_spec:
+        See the description of the ``connect_spec`` parameter of the
+        :py:func:`ldap3.connect <salt.modules.ldap3.connect>` function
+        in the :py:mod:`ldap3 <salt.modules.ldap3>` execution module.
+        If this is a dict and the ``'url'`` entry is not specified,
+        the ``'url'`` entry is set to the value of the ``name``
+        parameter.
+
+    :returns:
+        A dict with the following keys:
+
+        * ``'name'``
+            This is the same object passed to the ``name`` parameter.
+
+        * ``'changes'``
+            This is a dict describing the changes made (or, in test
+            mode, the changes that would have been attempted).  If no
+            changes were made (or no changes would have been
+            attempted), then this dict is empty.  Only successful
+            changes are included.
+
+            Each key is a DN of an entry that was changed (or would
+            have been changed).  Entries that were not changed (or
+            would not have been changed) are not included.  The value
+            is a dict with two keys:
+
+            * ``'old'``
+                The state of the entry before modification.  If the
+                entry did not previously exist, this key maps to
+                ``None``.  Otherwise, the value is a dict mapping each
+                of the old entry's attributes to a list of its values
+                before any modifications were made.  Unchanged
+                attributes are excluded from this dict.
+
+            * ``'new'``
+                The state of the entry after modification.  If the
+                entry was deleted, this key maps to ``None``.
+                Otherwise, the value is a dict mapping each of the
+                entry's attributes to a list of its values after the
+                modifications were made.  Unchanged attributes are
+                excluded from this dict.
+
+            Example ``'changes'`` dict where a new entry was created
+            with a single attribute containing two values::
+
+                {'dn1': {'old': None,
+                         'new': {'attr1': ['val1', 'val2']}}}
+
+            Example ``'changes'`` dict where a new attribute was added
+            to an existing entry::
+
+                {'dn1': {'old': {},
+                         'new': {'attr2': ['val3']}}}
+
+        * ``'result'``
+            One of the following values:
+
+            * ``True`` if no changes were necessary or if all changes
+              were applied successfully.
+            * ``False`` if at least one change was unable to be applied.
+            * ``None`` if changes would be applied but it is in test
+              mode.
+    '''
+    if connect_spec is None:
+        connect_spec = {}
+    try:
+        connect_spec.setdefault('url', name)
+    except AttributeError:
+        # already a connection object
+        pass
+
+    connect = __salt__['ldap3.connect']
+
+    # hack to get at the ldap3 module to access the ldap3.LDAPError
+    # exception class.  https://github.com/saltstack/salt/issues/27578
+    ldap3 = inspect.getmodule(connect)
+
+    with connect(connect_spec) as l:
+
+        old, new = _process_entries(l, entries)
+
+        # collect all of the affected entries (only the key is
+        # important in this dict; would have used an OrderedSet if
+        # there was one)
+        dn_set = OrderedDict()
+        dn_set.update(old)
+        dn_set.update(new)
+
+        # do some cleanup
+        dn_to_delete = set()
+        for dn in dn_set:
+            o = old.get(dn, {})
+            n = new.get(dn, {})
+            for x in o, n:
+                to_delete = set()
+                for attr, vals in six.iteritems(x):
+                    if not len(vals):
+                        # clean out empty attribute lists
+                        to_delete.add(attr)
+                for attr in to_delete:
+                    del x[attr]
+            if o == n:
+                # clean out unchanged entries
+                dn_to_delete.add(dn)
+        for dn in dn_to_delete:
+            for x in old, new:
+                x.pop(dn, None)
+            del dn_set[dn]
+
+        ret = {
+            'name': name,
+            'changes': {},
+            'result': None,
+            'comment': '',
+        }
+
+        if old == new:
+            ret['comment'] = 'LDAP entries already set'
+            ret['result'] = True
+            return ret
+
+        if __opts__['test']:
+            ret['comment'] = 'Would change LDAP entries'
+            changed_old = old
+            changed_new = new
+            success_dn_set = dn_set
+        else:
+            # execute the changes
+            changed_old = OrderedDict()
+            changed_new = OrderedDict()
+            # assume success; these will be changed on error
+            ret['result'] = True
+            ret['comment'] = 'Successfully updated LDAP entries'
+            errs = []
+            success_dn_set = OrderedDict()
+            for dn in dn_set:
+                o = old.get(dn, {})
+                n = new.get(dn, {})
+
+                try:
+                    # perform the operation
+                    if len(o):
+                        if len(n):
+                            op = 'modify'
+                            assert o != n
+                            __salt__['ldap3.change'](l, dn, o, n)
+                        else:
+                            op = 'delete'
+                            __salt__['ldap3.delete'](l, dn)
+                    else:
+                        op = 'add'
+                        assert len(n)
+                        __salt__['ldap3.add'](l, dn, n)
+
+                    # update these after the op in case an exception
+                    # is raised
+                    changed_old[dn] = o
+                    changed_new[dn] = n
+                    success_dn_set[dn] = True
+                except ldap3.LDAPError:
+                    log.exception('failed to %s entry %s', op, dn)
+                    errs.append((op, dn))
+                    continue
+
+            if len(errs):
+                ret['result'] = False
+                ret['comment'] = 'failed to ' \
+                                 + ', '.join((op + ' entry ' + dn
+                                              for op, dn in errs))
+
+    # set ret['changes'].  filter out any unchanged attributes, and
+    # convert the value sets to lists before returning them to the
+    # user (sorted for easier comparisons)
+    for dn in success_dn_set:
+        o = changed_old.get(dn, {})
+        n = changed_new.get(dn, {})
+        changes = {}
+        ret['changes'][dn] = changes
+        for x, xn in ((o, 'old'), (n, 'new')):
+            if not len(x):
+                changes[xn] = None
+                continue
+            changes[xn] = dict(((attr, sorted(vals))
+                                for attr, vals in six.iteritems(x)
+                                if o.get(attr, ()) != n.get(attr, ())))
+
+    return ret
+
+
+def _process_entries(l, entries):
+    '''Helper for managed() to process entries and return before/after views
+
+    Collect the current database state and update it according to the
+    data in :py:func:`managed`'s ``entries`` parameter.  Return the
+    current database state and what it will look like after
+    modification.
+
+    :param l:
+        the LDAP connection object
+
+    :param entries:
+        the same object passed to the ``entries`` parameter of
+        :py:func:`manage`
+
+    :return:
+        an ``(old, new)`` tuple that describes the current state of
+        the entries and what they will look like after modification.
+        Each item in the tuple is an OrderedDict that maps an entry DN
+        to another dict that maps an attribute name to a set of its
+        values (it's a set because according to the LDAP spec,
+        attribute value ordering is unspecified and there can't be
+        duplicates).  The structure looks like this:
+
+            {dn1: {attr1: set([val1])},
+             dn2: {attr1: set([val2]), attr2: set([val3, val4])}}
+
+        All of an entry's attributes and values will be included, even
+        if they will not be modified.  If an entry mentioned in the
+        entries variable doesn't yet exist in the database, the DN in
+        ``old`` will be mapped to an empty dict.  If an entry in the
+        database will be deleted, the DN in ``new`` will be mapped to
+        an empty dict.  All value sets are non-empty:  An attribute
+        that will be added to an entry is not included in ``old``, and
+        an attribute that will be deleted frm an entry is not included
+        in ``new``.
+
+        These are OrderedDicts to ensure that the user-supplied
+        entries are processed in the user-specified order (in case
+        there are dependencies, such as ACL rules specified in an
+        early entry that make it possible to modify a later entry).
+    '''
+
+    old = OrderedDict()
+    new = OrderedDict()
+
+    for entries_dict in entries:
+        for dn, directives_seq in six.iteritems(entries_dict):
+            # get the old entry's state.  first check to see if we've
+            # previously processed the entry.
+            olde = new.get(dn, None)
+            if olde is None:
+                # next check the database
+                results = __salt__['ldap3.search'](l, dn, 'base')
+                if len(results) == 1:
+                    attrs = results[dn]
+                    olde = dict(((attr, set(attrs[attr]))
+                                 for attr in attrs
+                                 if len(attrs[attr])))
+                else:
+                    # nothing, so it must be a brand new entry
+                    assert len(results) == 0
+                    olde = {}
+                old[dn] = olde
+            # copy the old entry to create the new (don't do a simple
+            # assignment or else modifications to newe will affect
+            # olde)
+            newe = copy.deepcopy(olde)
+            new[dn] = newe
+
+            # process the directives
+            entry_status = {
+                'delete_others': False,
+                'mentioned_attributes': set(),
+            }
+            for directives in directives_seq:
+                _update_entry(newe, entry_status, directives)
+            if entry_status['delete_others']:
+                to_delete = set()
+                for attr in newe:
+                    if attr not in entry_status['mentioned_attributes']:
+                        to_delete.add(attr)
+                for attr in to_delete:
+                    del newe[attr]
+    return old, new
+
+
+def _update_entry(entry, status, directives):
+    '''Update an entry's attributes using the provided directives
+
+    :param entry:
+        A dict mapping each attribute name to a set of its values
+    :param status:
+        A dict holding cross-invocation status (whether delete_others
+        is True or not, and the set of mentioned attributes)
+    :param directives:
+        A dict mapping directive types to directive-specific state
+    '''
+    for directive, state in six.iteritems(directives):
+        if directive == 'delete_others':
+            status['delete_others'] = state
+            continue
+        for attr, vals in six.iteritems(state):
+            status['mentioned_attributes'].add(attr)
+            vals = _toset(vals)
+            if directive == 'default':
+                if len(vals) and (attr not in entry or not len(entry[attr])):
+                    entry[attr] = vals
+            elif directive == 'add':
+                vals.update(entry.get(attr, ()))
+                if len(vals):
+                    entry[attr] = vals
+            elif directive == 'delete':
+                existing_vals = entry.pop(attr, set())
+                if len(vals):
+                    existing_vals -= vals
+                    if len(existing_vals):
+                        entry[attr] = existing_vals
+            elif directive == 'replace':
+                entry.pop(attr, None)
+                if len(vals):
+                    entry[attr] = vals
+            else:
+                raise ValueError('unknown directive: ' + directive)
+
+
+def _toset(thing):
+    '''helper to convert various things to a set
+
+    This enables flexibility in what users provide as the list of LDAP
+    entry attribute values.  Note that the LDAP spec prohibits
+    duplicate values in an attribute and that the order is
+    unspecified, so a set is good for automatically removing
+    duplicates.
+
+    None becomes an empty set.  Iterables except for strings have
+    their elements added to a new set.  Non-None scalars (strings,
+    numbers, non-iterable objects, etc.) are added as the only member
+    of a new set.
+
+    '''
+    if thing is None:
+        return set()
+    if isinstance(thing, six.string_types):
+        return set((thing,))
+    # convert numbers to strings so that equality checks work
+    # (LDAP stores numbers as strings)
+    try:
+        return set((str(x) for x in thing))
+    except TypeError:
+        return set((str(thing),))

--- a/tests/unit/states/ldap_test.py
+++ b/tests/unit/states/ldap_test.py
@@ -1,0 +1,334 @@
+# -*- coding: utf-8 -*-
+'''Test cases for the ``ldap`` state module
+
+This code is gross.  I started out trying to remove some of the
+duplicate code in the test cases, and before I knew it the test code
+was an ugly second implementation.
+
+I'm leaving it for now, but this should really be gutted and replaced
+with something sensible.
+'''
+
+from __future__ import absolute_import
+
+import copy
+import salt.ext.six as six
+import salt.states.ldap
+
+from salttesting import skipIf, TestCase
+from salttesting.helpers import ensure_in_syspath
+from salttesting.mock import (
+    NO_MOCK,
+    NO_MOCK_REASON,
+    patch,
+)
+
+ensure_in_syspath('../../')
+
+
+# emulates the LDAP database.  each key is the DN of an entry and it
+# maps to a dict which maps attribute names to sets of values.
+db = {}
+
+
+def _init_db(newdb=None):
+    if newdb is None:
+        newdb = {}
+    global db
+    db = newdb
+
+
+def _complex_db():
+    return {
+        'dnfoo': {
+            'attrfoo1': set((
+                'valfoo1.1',
+                'valfoo1.2',
+            )),
+            'attrfoo2': set((
+                'valfoo2.1',
+            )),
+        },
+        'dnbar': {
+            'attrbar1': set((
+                'valbar1.1',
+                'valbar1.2',
+            )),
+            'attrbar2': set((
+                'valbar2.1',
+            )),
+        },
+    }
+
+
+class _dummy_ctx(object):
+    def __init__(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        pass
+
+
+def _dummy_connect(connect_spec):
+    return _dummy_ctx()
+
+
+def _dummy_search(connect_spec, base, scope):
+    if base not in db:
+        return {}
+    return {base: dict(((attr, sorted(db[base][attr]))
+                        for attr in db[base]
+                        if len(db[base][attr])))}
+
+
+def _dummy_add(connect_spec, dn, attributes):
+    assert dn not in db
+    assert len(attributes)
+    db[dn] = {}
+    for attr, vals in six.iteritems(attributes):
+        assert len(vals)
+        db[dn][attr] = set(vals)
+    return True
+
+
+def _dummy_delete(connect_spec, dn):
+    assert dn in db
+    del db[dn]
+    return True
+
+
+def _dummy_change(connect_spec, dn, before, after):
+    assert before != after
+    assert len(before)
+    assert len(after)
+    assert dn in db
+    e = db[dn]
+    assert e == before
+    all_attrs = set()
+    all_attrs.update(before)
+    all_attrs.update(after)
+    directives = []
+    for attr in all_attrs:
+        if attr not in before:
+            assert attr in after
+            assert len(after[attr])
+            directives.append(('add', attr, after[attr]))
+        elif attr not in after:
+            assert attr in before
+            assert len(before[attr])
+            directives.append(('delete', attr, ()))
+        else:
+            assert len(before[attr])
+            assert len(after[attr])
+            to_del = before[attr] - after[attr]
+            if len(to_del):
+                directives.append(('delete', attr, to_del))
+            to_add = after[attr] - before[attr]
+            if len(to_add):
+                directives.append(('add', attr, to_add))
+    return _dummy_modify(connect_spec, dn, directives)
+
+
+def _dummy_modify(connect_spec, dn, directives):
+    assert dn in db
+    e = db[dn]
+    for op, attr, vals in directives:
+        if op == 'add':
+            assert len(vals)
+            existing_vals = e.setdefault(attr, set())
+            for val in vals:
+                assert val not in existing_vals
+                existing_vals.add(val)
+        elif op == 'delete':
+            assert attr in e
+            existing_vals = e[attr]
+            assert len(existing_vals)
+            if not len(vals):
+                del e[attr]
+                continue
+            for val in vals:
+                assert val in existing_vals
+                existing_vals.remove(val)
+            if not len(existing_vals):
+                del e[attr]
+        elif op == 'replace':
+            e.pop(attr, None)
+            e[attr] = set(vals)
+        else:
+            raise ValueError()
+    return True
+
+
+def _dump_db(d=None):
+    if d is None:
+        d = db
+    return dict(((dn, dict(((attr, sorted(d[dn][attr]))
+                            for attr in d[dn])))
+                 for dn in d))
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class LDAPTestCase(TestCase):
+
+    def setUp(self):
+        __opts = getattr(salt.states.ldap, '__opts__', {})
+        salt.states.ldap.__opts__ = __opts
+        __salt = getattr(salt.states.ldap, '__salt__', {})
+        salt.states.ldap.__salt__ = __salt
+        self.patchers = [
+            patch.dict('salt.states.ldap.__opts__', {'test': False}),
+        ]
+        for f in ('connect', 'search', 'add', 'delete', 'change', 'modify'):
+            self.patchers.append(
+                patch.dict('salt.states.ldap.__salt__',
+                           {'ldap3.' + f: globals()['_dummy_' + f]}))
+        for p in self.patchers:
+            p.start()
+        self.maxDiff = None
+
+    def tearDown(self):
+        for p in reversed(self.patchers):
+            p.stop()
+
+    def _test_helper(self, init_db, expected_ret, replace,
+                     delete_others=False):
+        _init_db(copy.deepcopy(init_db))
+        old = _dump_db()
+        new = _dump_db()
+        expected_db = copy.deepcopy(init_db)
+        for dn, attrs in six.iteritems(replace):
+            for attr, vals in six.iteritems(attrs):
+                if len(vals):
+                    new.setdefault(dn, {})[attr] = sorted(set(vals))
+                    expected_db.setdefault(dn, {})[attr] = set(vals)
+                elif dn in expected_db:
+                    new[dn].pop(attr, None)
+                    expected_db[dn].pop(attr, None)
+            if not len(expected_db.get(dn, {})):
+                new.pop(dn, None)
+                expected_db.pop(dn, None)
+        if delete_others:
+            dn_to_delete = set()
+            for dn, attrs in six.iteritems(expected_db):
+                if dn in replace:
+                    to_delete = set()
+                    for attr, vals in six.iteritems(attrs):
+                        if attr not in replace[dn]:
+                            to_delete.add(attr)
+                    for attr in to_delete:
+                        del attrs[attr]
+                        del new[dn][attr]
+                    if not len(attrs):
+                        dn_to_delete.add(dn)
+            for dn in dn_to_delete:
+                del new[dn]
+                del expected_db[dn]
+        name = 'ldapi:///'
+        expected_ret['name'] = name
+        expected_ret.setdefault('result', True)
+        expected_ret.setdefault('comment', 'Successfully updated LDAP entries')
+        expected_ret.setdefault('changes', dict(
+            ((dn, {'old': dict((attr, vals)
+                               for attr, vals in six.iteritems(old[dn])
+                               if vals != new.get(dn, {}).get(attr, ()))
+                          if dn in old else None,
+                   'new': dict((attr, vals)
+                               for attr, vals in six.iteritems(new[dn])
+                               if vals != old.get(dn, {}).get(attr, ()))
+                          if dn in new else None})
+             for dn in replace
+             if old.get(dn, {}) != new.get(dn, {}))))
+        entries = [{dn: [{'replace': attrs},
+                         {'delete_others': delete_others}]}
+                   for dn, attrs in six.iteritems(replace)]
+        actual = salt.states.ldap.managed(name, entries)
+        self.assertDictEqual(expected_ret, actual)
+        self.assertDictEqual(expected_db, db)
+
+    def _test_helper_success(self, init_db, replace, delete_others=False):
+        self._test_helper(init_db, {}, replace, delete_others)
+
+    def _test_helper_nochange(self, init_db, replace, delete_others=False):
+        expected = {
+            'changes': {},
+            'comment': 'LDAP entries already set',
+        }
+        self._test_helper(init_db, expected, replace, delete_others)
+
+    def test_managed_empty(self):
+        _init_db()
+        name = 'ldapi:///'
+        expected = {
+            'name': name,
+            'changes': {},
+            'result': True,
+            'comment': 'LDAP entries already set',
+        }
+        actual = salt.states.ldap.managed(name, {})
+        self.assertDictEqual(expected, actual)
+
+    def test_managed_add_entry(self):
+        self._test_helper_success(
+            {},
+            {'dummydn': {'foo': ['bar', 'baz']}})
+
+    def test_managed_add_attr(self):
+        self._test_helper_success(
+            _complex_db(),
+            {'dnfoo': {'attrfoo3': ['valfoo3.1']}})
+
+    def test_managed_simplereplace(self):
+        self._test_helper_success(
+            _complex_db(),
+            {'dnfoo': {'attrfoo1': ['valfoo1.3']}})
+
+    def test_managed_deleteattr(self):
+        self._test_helper_success(
+            _complex_db(),
+            {'dnfoo': {'attrfoo1': []}})
+
+    def test_managed_deletenonexistattr(self):
+        self._test_helper_nochange(
+            _complex_db(),
+            {'dnfoo': {'dummyattr': []}})
+
+    def test_managed_deleteentry(self):
+        self._test_helper_success(
+            _complex_db(),
+            {'dnfoo': {}},
+            True)
+
+    def test_managed_deletenonexistentry(self):
+        self._test_helper_nochange(
+            _complex_db(),
+            {'dummydn': {}},
+            True)
+
+    def test_managed_deletenonexistattrinnonexistentry(self):
+        self._test_helper_nochange(
+            _complex_db(),
+            {'dummydn': {'dummyattr': []}})
+
+    def test_managed_add_attr_delete_others(self):
+        self._test_helper_success(
+            _complex_db(),
+            {'dnfoo': {'dummyattr': ['dummyval']}},
+            True)
+
+    def test_managed_no_net_change(self):
+        self._test_helper_nochange(
+            _complex_db(),
+            {'dnfoo': {'attrfoo1': ['valfoo1.2', 'valfoo1.1']}})
+
+    def test_managed_repeated_values(self):
+        self._test_helper_success(
+            {},
+            {'dummydn': {'dummyattr': ['dummyval', 'dummyval']}})
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(LDAPTestCase, needs_daemon=False)


### PR DESCRIPTION
This is a rough draft of a new `ldap` state module.  I also created a new `ldap2` execution module to support the state module.

There are a number of issues with these two new modules:
- I don't like the name `ldap2` for the execution module because it sounds like it's for the old LDAP protocol version 2.  The name `ldap` is already taken by the `ldapmod` execution module.  (I didn't use the existing `ldapmod` module because I don't like `search()`'s API.)
- I'm not sure the API is the best.  In particular, the depth of some of the structures is pretty extreme (lists of dicts containing lists of dicts containing lists).
- The code is not well tested (e.g., I haven't tested error conditions like permission denied due to ACL rules, and I have no idea how it will handle non-ASCII text).
- There are no test cases for the `ldap2` execution module.
- The unit test code for the `ldap` state module is gross.  Really gross.
- There aren't enough test cases for the `ldap` state module.
- I'm sure there's lots of lint issues.
- There should be more examples in the documentation, especially in the `ldap2` execution module function documentation.
- Other stuff I'm forgetting.

I would love some feedback, but would especially love patches.  I don't have much time to continue working on these modules, especially since they work well enough to solve the problem I wrote them to solve.

Addresses #10076, #25911
