### PR TITLE
Feature state grains support nested and dict

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -342,7 +342,7 @@ def remove(key, val, delimiter=DEFAULT_TARGET_DELIM):
         specify the delimiter you use.
         You can now append values to a list in nested dictionnary grains. If the
         list doesn't exist at this level, it will be created.
-        .. versionadded:: FIXME
+        .. versionadded:: Boron
 
     CLI Example:
 

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -15,6 +15,7 @@ import collections
 from functools import reduce
 
 # Import 3rd-party libs
+from salt.utils.odict import OrderedDict
 import yaml
 import salt.ext.six as six
 from salt.ext.six.moves import range  # pylint: disable=import-error,no-name-in-module,redefined-builtin
@@ -238,6 +239,8 @@ def setvals(grains, destructive=False):
             __grains__[key] = val
     # Cast defaultdict to dict; is there a more central place to put this?
     yaml.representer.SafeRepresenter.add_representer(collections.defaultdict,
+            yaml.representer.SafeRepresenter.represent_dict)
+    yaml.representer.SafeRepresenter.add_representer(OrderedDict,
             yaml.representer.SafeRepresenter.represent_dict)
     cstr = yaml.safe_dump(grains, default_flow_style=False)
     try:

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -329,11 +329,17 @@ def append(key, val, convert=False, delimiter=DEFAULT_TARGET_DELIM):
     return setval(key, grains)
 
 
-def remove(key, val):
+def remove(key, val, delimiter=DEFAULT_TARGET_DELIM):
     '''
     .. versionadded:: 0.17.0
 
     Remove a value from a list in the grains config file
+
+    :param delimiter: The key can be a nested dict key. Use this parameter to
+        specify the delimiter you use.
+        You can now append values to a list in nested dictionnary grains. If the
+        list doesn't exist at this level, it will be created.
+        .. versionadded:: FIXME
 
     CLI Example:
 
@@ -341,12 +347,20 @@ def remove(key, val):
 
         salt '*' grains.remove key val
     '''
-    grains = get(key, [])
+    grains = get(key, [], delimiter)
     if not isinstance(grains, list):
         return 'The key {0} is not a valid list'.format(key)
     if val not in grains:
         return 'The val {0} was not in the list {1}'.format(val, key)
     grains.remove(val)
+
+    while delimiter in key:
+        key, rest = key.rsplit(delimiter, 1)
+        _grain = get(key, None, delimiter)
+        if isinstance(_grain, dict):
+            _grain.update({rest: grains})
+        grains = _grain
+
     return setval(key, grains)
 
 

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -628,7 +628,8 @@ def set(key,
     elif isinstance(_existing_value, list):
         _existing_value_type = 'complex'
 
-    if _existing_value_type is not None and _existing_value == val:
+    if _existing_value_type is not None and _existing_value == val \
+                   and (val is not None or destructive is not True):
         ret['comment'] = 'Grain is already set'
         return ret
 

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -612,7 +612,7 @@ def set(key,
         _existing_value_type = 'complex'
 
     if _existing_value_type is not None and _existing_value == val:
-        ret['comment'] = 'The value \'{0}\' was already set for key \'{1}\''.format(val, key)
+        ret['comment'] = 'Grain is already set'
         return ret
 
     if _existing_value is not None and not force:

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -589,7 +589,7 @@ def set(key,
         salt '*' grains.set 'apps:myApp' '{port: 2209}'
     '''
 
-    ret = {'comment': [],
+    ret = {'comment': '',
            'changes': {},
            'result': True}
 

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -298,7 +298,7 @@ def append(key, val, convert=False, delimiter=DEFAULT_TARGET_DELIM):
         is given. Defaults to False.
 
     :param delimiter: The key can be a nested dict key. Use this parameter to
-        specify the delimiter you use.
+        specify the delimiter you use, instead of the default ``:``.
         You can now append values to a list in nested dictionnary grains. If the
         list doesn't exist at this level, it will be created.
         .. versionadded:: 2014.7.6
@@ -339,7 +339,7 @@ def remove(key, val, delimiter=DEFAULT_TARGET_DELIM):
     Remove a value from a list in the grains config file
 
     :param delimiter: The key can be a nested dict key. Use this parameter to
-        specify the delimiter you use.
+        specify the delimiter you use, instead of the default ``:``.
         You can now append values to a list in nested dictionnary grains. If the
         list doesn't exist at this level, it will be created.
         .. versionadded:: Boron
@@ -555,7 +555,7 @@ def get_or_set_hash(name,
     .. warning::
 
         This function could return strings which may contain characters which are reserved
-        as directives by the YAML parser, such as strings beginning with `%`. To avoid
+        as directives by the YAML parser, such as strings beginning with ``%``. To avoid
         issues when using the output of this function in an SLS file containing YAML+Jinja,
         surround the call with single quotes.
     '''
@@ -586,7 +586,7 @@ def set(key,
     with nested keys.
 
     This function is conservative. It will only overwrite an entry if
-    its value and the given one are not a list or a dict. The `force`
+    its value and the given one are not a list or a dict. The ``force``
     parameter is used to allow overwriting in all cases.
 
     .. versionadded:: 2015.8.0
@@ -596,7 +596,8 @@ def set(key,
     :param destructive: If an operation results in a key being removed,
                   delete the key, too. Defaults to False.
     :param delimiter:
-        Specify an alternate delimiter to use when traversing a nested dict
+        Specify an alternate delimiter to use when traversing a nested dict,
+        the default being ``:``
 
     CLI Example:
 

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -618,11 +618,12 @@ def set(key,
     elif isinstance(val, list):
         _new_value_type = 'complex'
 
-    _existing_value = get(key, _non_existent_key, delimiter)
+    _non_existent = object()
+    _existing_value = get(key, _non_existent, delimiter)
     _value = _existing_value
 
     _existing_value_type = 'simple'
-    if _existing_value == _non_existent_key:
+    if _existing_value is _non_existent:
         _existing_value_type = None
     elif isinstance(_existing_value, dict):
         _existing_value_type = 'complex'

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -87,7 +87,7 @@ def get(key, default='', delimiter=DEFAULT_TARGET_DELIM):
         pkg:apache
 
 
-    delimiter
+    :param delimiter:
         Specify an alternate delimiter to use when traversing a nested dict
 
         .. versionadded:: 2014.7.0
@@ -301,6 +301,7 @@ def append(key, val, convert=False, delimiter=DEFAULT_TARGET_DELIM):
         specify the delimiter you use, instead of the default ``:``.
         You can now append values to a list in nested dictionnary grains. If the
         list doesn't exist at this level, it will be created.
+
         .. versionadded:: 2014.7.6
 
     CLI Example:
@@ -342,6 +343,7 @@ def remove(key, val, delimiter=DEFAULT_TARGET_DELIM):
         specify the delimiter you use, instead of the default ``:``.
         You can now append values to a list in nested dictionnary grains. If the
         list doesn't exist at this level, it will be created.
+
         .. versionadded:: Boron
 
     CLI Example:

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -19,7 +19,7 @@ def present(name, value, delimiter=DEFAULT_TARGET_DELIM, force=False):
     '''
     Ensure that a grain is set
 
-    .. versionchanged:: FIXME
+    .. versionchanged:: Boron
 
     name
         The grain name
@@ -29,10 +29,10 @@ def present(name, value, delimiter=DEFAULT_TARGET_DELIM, force=False):
 
     :param force: If force is True, the existing grain will be overwritten
         regardless of its existing or provided value type. Defaults to False
-        .. versionadded:: FIXME
+        .. versionadded:: Boron
 
     :param delimiter: A delimiter different from the default can be provided.
-        .. versionadded:: FIXME
+        .. versionadded:: Boron
 
     It is now capable to set a grain to a complex value (ie. lists and dicts)
     and supports nested grains as well.
@@ -97,7 +97,7 @@ def list_present(name, value, delimiter=DEFAULT_TARGET_DELIM):
         The value is present in the list type grain.
 
     :param delimiter: A delimiter different from the default can be provided.
-        .. versionadded:: FIXME
+        .. versionadded:: Boron
 
     The grain should be `list type <http://docs.python.org/2/tutorial/datastructures.html#data-structures>`_
 
@@ -179,7 +179,7 @@ def list_absent(name, value, delimiter=DEFAULT_TARGET_DELIM):
        The value to delete from the grain list.
 
     :param delimiter: A delimiter different from the default can be provided.
-        .. versionadded:: FIXME
+        .. versionadded:: Boron
 
     The grain should be `list type <http://docs.python.org/2/tutorial/datastructures.html#data-structures>`_
 
@@ -248,12 +248,12 @@ def absent(name,
 
     :param force: If force is True, the existing grain will be overwritten
         regardless of its existing or provided value type. Defaults to False
-        .. versionadded:: FIXME
+        .. versionadded:: Boron
 
     :param delimiter: A delimiter different from the default can be provided.
-        .. versionadded:: FIXME
+        .. versionadded:: Boron
 
-    .. versionchanged:: FIXME
+    .. versionchanged:: Boron
     This state now support nested grains and complex values. It is also more
     conservative: if a grain has a value that is a list or a dict, it will
     not be removed unless the `force` parameter is True.
@@ -339,7 +339,7 @@ def append(name, value, convert=False,
         is given. Defaults to False.
 
     :param delimiter: A delimiter different from the default can be provided.
-        .. versionadded:: FIXME
+        .. versionadded:: Boron
 
     .. code-block:: yaml
 

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -66,7 +66,7 @@ def present(name, value, delimiter=DEFAULT_TARGET_DELIM, force=False):
             ret['changes'] = {'new': name}
         else:
             ret['comment'] = 'Grain {0} is set to be changed'.format(name)
-            ret['changes'] = {'new': name}
+            ret['changes'] = {'changed': {name: value}}
         return ret
     ret = __salt__['grains.set'](name, value, force=force)
     if ret['result'] is True and ret['changes'] != {}:

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -301,7 +301,8 @@ def absent(name,
     return ret
 
 
-def append(name, value, convert=False):
+def append(name, value, convert=False,
+           delimiter=DEFAULT_TARGET_DELIM):
     '''
     .. versionadded:: 2014.7.0
 
@@ -317,17 +318,21 @@ def append(name, value, convert=False):
         If convert is False and the grain contains non-list contents, an error
         is given. Defaults to False.
 
+    :param delimiter: A delimiter different from the default can be provided.
+        .. versionadded:: FIXME
+
     .. code-block:: yaml
 
       grain_name:
         grains.append:
           - value: to_be_appended
     '''
+    name = re.sub(delimiter, DEFAULT_TARGET_DELIM, name)
     ret = {'name': name,
            'changes': {},
            'result': True,
            'comment': ''}
-    grain = __grains__.get(name)
+    grain = __salt__['grains.get'](name, None)
     if grain:
         if isinstance(grain, list):
             if value in grain:

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -205,7 +205,7 @@ def list_absent(name, value, delimiter=DEFAULT_TARGET_DELIM):
            'changes': {},
            'result': True,
            'comment': ''}
-    grain = __grains__.get(name)
+    grain = __salt__['grains.get'](name, None)
     if grain:
         if isinstance(grain, list):
             if value not in grain:

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -34,14 +34,16 @@ def present(name, value, delimiter=DEFAULT_TARGET_DELIM, force=False):
     :param delimiter: A delimiter different from the default can be provided.
         .. versionadded:: FIXME
 
-    It is now capable to set a grain to a dict and supports nested grains.
+    It is now capable to set a grain to a complex value (ie. lists and dicts)
+    and supports nested grains as well.
 
     If the grain does not yet exist, a new grain is set to the given value. For
-    the grain is nested, the necessary keys are created if they don't exist. If
-    a given is an existing value, it will be converted, but an existing value
+    a nested grain, the necessary keys are created if they don't exist. If
+    a given key is an existing value, it will be converted, but an existing value
     different from the given key will fail the state.
+
     If the grain with the given name exists, its value is updated to the new
-    value unless its existing or provided type is a list or a dict. Use
+    value unless its existing or provided value is complex (list or dict). Use
     `force: True` to overwrite.
 
     .. code-block:: yaml
@@ -49,6 +51,13 @@ def present(name, value, delimiter=DEFAULT_TARGET_DELIM, force=False):
       cheese:
         grains.present:
           - value: edam
+
+      nested_grain_with_complex_value:
+        grains.present:
+          - name: icinga:Apache SSL
+          - value:
+            - command: check_https
+            - params:  -H localhost -p 443 -S
     '''
     name = re.sub(delimiter, DEFAULT_TARGET_DELIM, name)
     ret = {'name': name,

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -15,7 +15,7 @@ from salt.defaults import DEFAULT_TARGET_DELIM
 import re
 
 
-def present(name, value, delimiter=':', force=False):
+def present(name, value, delimiter=DEFAULT_TARGET_DELIM, force=False):
     '''
     Ensure that a grain is set
 
@@ -50,7 +50,7 @@ def present(name, value, delimiter=':', force=False):
         grains.present:
           - value: edam
     '''
-    name = re.sub(delimiter, ':', name)
+    name = re.sub(delimiter, DEFAULT_TARGET_DELIM, name)
     ret = {'name': name,
            'changes': {},
            'result': True,
@@ -75,7 +75,7 @@ def present(name, value, delimiter=':', force=False):
     return ret
 
 
-def list_present(name, value):
+def list_present(name, value, delimiter=DEFAULT_TARGET_DELIM):
     '''
     .. versionadded:: 2014.1.0
 
@@ -86,6 +86,9 @@ def list_present(name, value):
 
     value
         The value is present in the list type grain.
+
+    :param delimiter: A delimiter different from the default can be provided.
+        .. versionadded:: FIXME
 
     The grain should be `list type <http://docs.python.org/2/tutorial/datastructures.html#data-structures>`_
 
@@ -105,6 +108,8 @@ def list_present(name, value):
               - web
               - dev
     '''
+
+    name = re.sub(delimiter, DEFAULT_TARGET_DELIM, name)
     ret = {'name': name,
            'changes': {},
            'result': True,
@@ -143,7 +148,7 @@ def list_present(name, value):
             ret['comment'] = 'Failed append value {1} to grain {0}'.format(name, value)
             return ret
     else:
-        if value not in __grains__.get(name):
+        if value not in __salt__['grains.get'](name, delimiter=DEFAULT_TARGET_DELIM):
             ret['result'] = False
             ret['comment'] = 'Failed append value {1} to grain {0}'.format(name, value)
             return ret
@@ -152,7 +157,7 @@ def list_present(name, value):
     return ret
 
 
-def list_absent(name, value):
+def list_absent(name, value, delimiter=DEFAULT_TARGET_DELIM):
     '''
     Delete a value from a grain formed as a list.
 
@@ -163,6 +168,9 @@ def list_absent(name, value):
 
     value
        The value to delete from the grain list.
+
+    :param delimiter: A delimiter different from the default can be provided.
+        .. versionadded:: FIXME
 
     The grain should be `list type <http://docs.python.org/2/tutorial/datastructures.html#data-structures>`_
 
@@ -182,6 +190,8 @@ def list_absent(name, value):
               - web
               - dev
     '''
+
+    name = re.sub(delimiter, DEFAULT_TARGET_DELIM, name)
     ret = {'name': name,
            'changes': {},
            'result': True,

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -264,13 +264,33 @@ def absent(name,
         grains.absent
     '''
 
+    _non_existent_key = 'NonExistentValueMagicNumberSpK3hnufdHfeBUXCfqVK'
+
     name = re.sub(delimiter, DEFAULT_TARGET_DELIM, name)
     ret = {'name': name,
            'changes': {},
            'result': True,
            'comment': ''}
-    grain = __salt__['grains.get'](name, None)
-    if grain:
+    grain = __salt__['grains.get'](name, _non_existent_key)
+    if grain is None:
+        if __opts__['test']:
+            ret['result'] = None
+            if destructive is True:
+                ret['comment'] = 'Grain {0} is set to be deleted'\
+                    .format(name)
+                ret['changes'] = {'deleted': name}
+            return ret
+        ret = __salt__['grains.set'](name,
+                                     None,
+                                     destructive=destructive,
+                                     force=force)
+        if ret['result']:
+            if destructive is True:
+                ret['comment'] = 'Grain {0} was deleted'\
+                    .format(name)
+                ret['changes'] = {'deleted': name}
+        ret['name'] = name
+    elif grain != _non_existent_key:
         if __opts__['test']:
             ret['result'] = None
             if destructive is True:

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -254,9 +254,9 @@ def absent(name,
         .. versionadded:: FIXME
 
     .. versionchanged:: FIXME
-    This state now support nested grains. It is also more conservative:
-    if a grain has a value that is a list or a dict, it will not be removed
-    unless the `force` parameter is True
+    This state now support nested grains and complex values. It is also more
+    conservative: if a grain has a value that is a list or a dict, it will
+    not be removed unless the `force` parameter is True.
 
     .. code-block:: yaml
 

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -64,13 +64,14 @@ def present(name, value, delimiter=DEFAULT_TARGET_DELIM, force=False):
            'changes': {},
            'result': True,
            'comment': ''}
-    existing = __salt__['grains.get'](name, 'nonexistingzniQSDpWy3ywmgFn66lL4PLG9oBrDi')
+    _non_existent = object()
+    existing = __salt__['grains.get'](name, _non_existent)
     if existing == value:
         ret['comment'] = 'Grain is already set'
         return ret
     if __opts__['test']:
         ret['result'] = None
-        if existing == 'nonexistingzniQSDpWy3ywmgFn66lL4PLG9oBrDi':
+        if existing is _non_existent:
             ret['comment'] = 'Grain {0} is set to be added'.format(name)
             ret['changes'] = {'new': name}
         else:
@@ -264,14 +265,14 @@ def absent(name,
         grains.absent
     '''
 
-    _non_existent_key = 'NonExistentValueMagicNumberSpK3hnufdHfeBUXCfqVK'
+    _non_existent = object()
 
     name = re.sub(delimiter, DEFAULT_TARGET_DELIM, name)
     ret = {'name': name,
            'changes': {},
            'result': True,
            'comment': ''}
-    grain = __salt__['grains.get'](name, _non_existent_key)
+    grain = __salt__['grains.get'](name, _non_existent)
     if grain is None:
         if __opts__['test']:
             ret['result'] = None
@@ -290,7 +291,7 @@ def absent(name,
                     .format(name)
                 ret['changes'] = {'deleted': name}
         ret['name'] = name
-    elif grain != _non_existent_key:
+    elif grain is not _non_existent:
         if __opts__['test']:
             ret['result'] = None
             if destructive is True:

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -29,9 +29,11 @@ def present(name, value, delimiter=DEFAULT_TARGET_DELIM, force=False):
 
     :param force: If force is True, the existing grain will be overwritten
         regardless of its existing or provided value type. Defaults to False
+
         .. versionadded:: Boron
 
     :param delimiter: A delimiter different from the default can be provided.
+
         .. versionadded:: Boron
 
     It is now capable to set a grain to a complex value (ie. lists and dicts)
@@ -58,6 +60,11 @@ def present(name, value, delimiter=DEFAULT_TARGET_DELIM, force=False):
           - value:
             - command: check_https
             - params:  -H localhost -p 443 -S
+
+      with,a,custom,delimiter:
+        grains.present:
+          - value:     yay
+          - delimiter: ,
     '''
     name = re.sub(delimiter, DEFAULT_TARGET_DELIM, name)
     ret = {'name': name,
@@ -97,7 +104,8 @@ def list_present(name, value, delimiter=DEFAULT_TARGET_DELIM):
     value
         The value is present in the list type grain.
 
-    :param delimiter: A delimiter different from the default can be provided.
+    :param delimiter: A delimiter different from the default ``:`` can be provided.
+
         .. versionadded:: Boron
 
     The grain should be `list type <http://docs.python.org/2/tutorial/datastructures.html#data-structures>`_
@@ -179,7 +187,8 @@ def list_absent(name, value, delimiter=DEFAULT_TARGET_DELIM):
     value
        The value to delete from the grain list.
 
-    :param delimiter: A delimiter different from the default can be provided.
+    :param delimiter: A delimiter different from the default ``:`` can be provided.
+
         .. versionadded:: Boron
 
     The grain should be `list type <http://docs.python.org/2/tutorial/datastructures.html#data-structures>`_
@@ -249,9 +258,11 @@ def absent(name,
 
     :param force: If force is True, the existing grain will be overwritten
         regardless of its existing or provided value type. Defaults to False
+
         .. versionadded:: Boron
 
     :param delimiter: A delimiter different from the default can be provided.
+
         .. versionadded:: Boron
 
     .. versionchanged:: Boron
@@ -262,7 +273,7 @@ def absent(name,
     .. code-block:: yaml
 
       grain_name:
-        grains.absent
+        grains.absent: []
     '''
 
     _non_existent = object()
@@ -340,6 +351,7 @@ def append(name, value, convert=False,
         is given. Defaults to False.
 
     :param delimiter: A delimiter different from the default can be provided.
+
         .. versionadded:: Boron
 
     .. code-block:: yaml

--- a/tests/unit/modules/grains_test.py
+++ b/tests/unit/modules/grains_test.py
@@ -292,23 +292,21 @@ class GrainsModuleTestCase(TestCase):
         grainsmod.__grains__ = {'a': 12, 'c': 8}
         res = grainsmod.set('a', 12)
         self.assertTrue(res['result'])
-        self.assertEqual(res['comment'], 'The value \'12\' was already set for key \'a\'')
+        self.assertEqual(res['comment'], 'Grain is already set')
         self.assertEqual(grainsmod.__grains__, {'a': 12, 'c': 8})
 
         # Set a grain to the same complex value
         grainsmod.__grains__ = {'a': ['item', 12], 'c': 8}
         res = grainsmod.set('a', ['item', 12])
         self.assertTrue(res['result'])
-        self.assertEqual(res['comment'], 'The value \'[\'item\', 12]\' was already set '
-                            + 'for key \'a\'')
+        self.assertEqual(res['comment'], 'Grain is already set')
         self.assertEqual(grainsmod.__grains__, {'a': ['item', 12], 'c': 8})
 
         # Set a key to the same simple value in a nested grain
         grainsmod.__grains__ = {'a': 'aval', 'b': {'nested': 'val'}, 'c': 8}
         res = grainsmod.set('b,nested', 'val', delimiter=',')
         self.assertTrue(res['result'])
-        self.assertEqual(res['comment'], 'The value \'val\' was already set for key '
-                            + '\'b,nested\'')
+        self.assertEqual(res['comment'], 'Grain is already set')
         self.assertEqual(grainsmod.__grains__, {'a': 'aval',
                                                 'b': {'nested': 'val'},
                                                 'c': 8})

--- a/tests/unit/states/grains_test.py
+++ b/tests/unit/states/grains_test.py
@@ -670,7 +670,7 @@ class GrainsTestCase(TestCase):
                                   + "- correct\n"
         )
 
-    # 'append' function tests: 5
+    # 'append' function tests: 6
 
     def test_append(self):
         # Append to an existing list
@@ -688,6 +688,26 @@ class GrainsTestCase(TestCase):
                                   + "foo:\n"
                                   + "- bar\n"
                                   + "- baz\n"
+        )
+
+    def test_append_nested(self):
+        # Append to an existing nested list
+        self.setGrains({'a': 'aval', 'foo': {'list': ['bar']}})
+        ret = grains.append(
+            name='foo,list',
+            value='baz',
+            delimiter=',')
+        self.assertEqual(ret['result'], True)
+        self.assertEqual(ret['comment'], 'Value baz was added to grain foo:list')
+        self.assertEqual(ret['changes'], {'added': 'baz'})
+        self.assertEqual(
+            grains.__grains__,
+            {'a': 'aval', 'foo': {'list': ['bar', 'baz']}})
+        self.assertGrainFileContent("a: aval\n"
+                                  + "foo:\n"
+                                  + "  list:\n"
+                                  + "  - bar\n"
+                                  + "  - baz\n"
         )
 
     def test_append_already(self):

--- a/tests/unit/states/grains_test.py
+++ b/tests/unit/states/grains_test.py
@@ -549,6 +549,20 @@ class GrainsTestCase(TestCase):
                                   + "foo: null\n"
         )
 
+        # Unset grain when its value is False
+        self.setGrains({'a': 'aval', 'foo': False})
+        ret = grains.absent(
+            name='foo')
+        self.assertEqual(ret['result'], True)
+        self.assertEqual(ret['comment'], 'Value for grain foo was set to None')
+        self.assertEqual(ret['changes'], {'grain': 'foo', 'value': None})
+        self.assertEqual(
+            grains.__grains__,
+            {'a': 'aval', 'foo': None})
+        self.assertGrainFileContent("a: aval\n"
+                                  + "foo: null\n"
+        )
+
         # Unset a nested grain
         self.setGrains({'a': 'aval', 'foo': ['order', {'is': {'nested': 'bar'}}, 'correct']})
         ret = grains.absent(
@@ -640,6 +654,19 @@ class GrainsTestCase(TestCase):
     def test_absent_delete(self):
         # Delete a grain
         self.setGrains({'a': 'aval', 'foo': 'bar'})
+        ret = grains.absent(
+            name='foo',
+            destructive=True)
+        self.assertEqual(ret['result'], True)
+        self.assertEqual(ret['comment'], 'Grain foo was deleted')
+        self.assertEqual(ret['changes'], {'deleted': 'foo'})
+        self.assertEqual(
+            grains.__grains__,
+            {'a': 'aval'})
+        self.assertGrainFileContent("a: aval\n")
+
+        # Delete a previously unset grain
+        self.setGrains({'a': 'aval', 'foo': None})
         ret = grains.absent(
             name='foo',
             destructive=True)

--- a/tests/unit/states/grains_test.py
+++ b/tests/unit/states/grains_test.py
@@ -325,7 +325,7 @@ class GrainsTestCase(TestCase):
             name='foo',
             value='newbar')
         self.assertEqual(ret['result'], None)
-        self.assertEqual(ret['changes'], {'new': 'foo'})
+        self.assertEqual(ret['changes'], {'changed': {'foo': 'newbar'}})
         self.assertEqual(
             grains.__grains__,
             {'a': 'aval', 'foo': 'bar'})


### PR DESCRIPTION
This pull request should fix #11870 and #15583
It's an implementation for the support of nested grains and complex values (list or dict) for the `grains` state.

I think this pull request needs a very good review, because it's a big change to the way grains are set from states. I wrote extended tests for this change, including checking the `grains` file content. The doc strings are also updated to explain the new behavior.

In theory, these changes won't badly break existing state definitions. There is one difference, though. While the old behavior allowed to remove a grain containing a complex value, the new one don't, unless specifying `force=True`.
