### PR TITLE
Add --state-verbose command line option to salt cmd

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1157,9 +1157,9 @@ class OutputOptionsMixIn(six.with_metaclass(MixInMeta, object)):
                     )
 
     def process_state_verbose(self):
-        if (self.options.state_verbose == "True" or self.options.state_verbose == "true"):
+        if self.options.state_verbose == "True" or self.options.state_verbose == "true":
             self.options.state_verbose = True
-        elif (self.options.state_verbose == "False" or self.options.state_verbose == "false"):
+        elif self.options.state_verbose == "False" or self.options.state_verbose == "false":
             self.options.state_verbose = False
 
     def _mixin_after_parsed(self):

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1118,6 +1118,13 @@ class OutputOptionsMixIn(six.with_metaclass(MixInMeta, object)):
                   'output. One of full, terse, mixed, changes or filter. '
                   'Default: full.')
         )
+        group.add_option(
+            '--state-verbose', '--state_verbose',
+            default=True,
+            help=('Override the configured state_verbose value for minion '
+                  'output. Set to True or False'
+                  'Default: True')
+        )
 
         for option in self.output_options_group.option_list:
             def process(opt):
@@ -1148,6 +1155,12 @@ class OutputOptionsMixIn(six.with_metaclass(MixInMeta, object)):
                             exc
                         )
                     )
+
+    def process_state_verbose(self):
+        if (self.options.state_verbose == "True" or self.options.state_verbose == "true"):
+            self.options.state_verbose = True
+        elif (self.options.state_verbose == "False" or self.options.state_verbose == "false"):
+            self.options.state_verbose = False
 
     def _mixin_after_parsed(self):
         group_options_selected = [


### PR DESCRIPTION
This overrides the state_verbose setting that may be set in master config. 

Closes issue https://github.com/saltstack/salt/issues/13640

If master has state_verbose set to True

--state-verbose=False would suppress states that didn't change.

If master config has state_verbose set to False

--state-verbose=True would still show states that didn't have changes.

Below is test output with state_verbose=True in ./etc/salt/master:

```
$ salt -c ./etc/salt '*' --state-verbose=True  state.highstate
salt-dev:
----------
          ID: test_file.txt
    Function: file.managed
        Name: /tmp/test_file.txt
      Result: True
     Comment: File /tmp/test_file.txt exists with proper permissions. No changes made.
     Started: 13:51:15.798599
    Duration: 7.176 ms
     Changes:

Summary for salt-dev
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1
Total run time:   7.176 ms

$ salt -c ./etc/salt '*' --state-verbose=False  state.highstate
salt-dev:

Summary for salt-dev
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1
Total run time:   8.589 ms
```
