### PR TITLE
URL has changed

### DIFF
--- a/doc/topics/cloud/windows.rst
+++ b/doc/topics/cloud/windows.rst
@@ -46,7 +46,7 @@ from saltstack.com:
 
 * `SaltStack Download Area`__
 
-.. __: http://docs.saltstack.com/downloads/
+.. __: https://repo.saltstack.com/windows/
 
 
 Firewall Settings


### PR DESCRIPTION
the saltstack windows download area has moved over to https on https://repo.saltstack.com/windows/
