### PR TITLE
new URL for windows salt downloads

### DIFF
--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -675,7 +675,7 @@ def bootstrap_psexec(hosts='', master=None, version=None, arch='win32',
 
     installer_url
         URL of minion installer executable. Defaults to the latest version from
-        http://docs.saltstack.com/downloads
+        https://repo.saltstack.com/windows/
 
     username
         Optional user name for login on remote computer.
@@ -694,7 +694,7 @@ def bootstrap_psexec(hosts='', master=None, version=None, arch='win32',
     '''
 
     if not installer_url:
-        base_url = 'http://docs.saltstack.com/downloads/'
+        base_url = 'https://repo.saltstack.com/windows/'
         source = _urlopen(base_url).read()
         salty_rx = re.compile('>(Salt-Minion-(.+?)-(.+)-Setup.exe)</a></td><td align="right">(.*?)\\s*<')
         source_list = sorted([[path, ver, plat, time.strptime(date, "%d-%b-%Y %H:%M")]


### PR DESCRIPTION
the old site stil exists, and looks almost up to date but am pretty sure all the really up to date and relevant stuff is (or should be!) now at https://repo.saltstack.com/windows/

I am also chanigng this from http to https, hope this has not undesireable side-effects?

Shouldn't the old docs.saltstack.com/windows directory be removed now?
