### PR TITLE
Use human-readable cachedirs for gitfs-backed winrepo

### DIFF
--- a/doc/topics/windows/windows-package-manager.rst
+++ b/doc/topics/windows/windows-package-manager.rst
@@ -473,14 +473,6 @@ installed, then Salt will use it instead of the old method (which invokes the
 .. _pygit2: https://github.com/libgit2/pygit2
 .. _GitPython: https://github.com/gitpython-developers/GitPython
 
-One important change this brings is the the fact that each repo configured
-under the :conf_master:`winrepo_remotes` option (``win_gitrepos`` in Salt
-versions prior to 2015.8.0) will have its URL hashed and and the files will be
-checked out into a subdirectory containing that hashed name (for example,
-``/srv/salt/win/repo/f42c3382aeeaa8733908e5c256dba1ca/myprogram.sls``). There
-is no functional reason for the hashed name, it just comes from using the same
-back-end code that gitfs and git_pillar are using.
-
 To minimize potential issues, it is a good idea to remove any winrepo git
 repositories that were checked out by the old (pre-2015.8.0) winrepo code when
 upgrading the master to 2015.8.0 or later, and run

--- a/doc/topics/windows/windows-package-manager.rst
+++ b/doc/topics/windows/windows-package-manager.rst
@@ -508,7 +508,7 @@ An example of this would be the following:
     explanation of how per-remote configuration works in gitfs, the same
     principles apply to winrepo.
 
-There are a couple other changes in now Salt manages git repos using
+There are a couple other changes in how Salt manages git repos using
 pygit2_/GitPython_. First of all, a ``clean`` argument has been added to the
 :py:func:`winrepo.update_git_repos <salt.runners.winrepo.update_git_repos>`
 runner, which (if set to ``True``) will tell the runner to dispose of

--- a/doc/topics/windows/windows-package-manager.rst
+++ b/doc/topics/windows/windows-package-manager.rst
@@ -526,8 +526,9 @@ used, then this should *not* be used, as it will remove the directories
 containing non-git definitions.
 
 The other major change is that collisions between repo names are now detected,
-and the winrepo runner will not proceed if any are detected. Consider the
-following configuration:
+and the :py:func:`winrepo.update_git_repos
+<salt.runners.winrepo.update_git_repos>` runner will not proceed if any are
+detected. Consider the following configuration:
 
 .. code-block:: yaml
 

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -89,7 +89,7 @@ def init_git_pillar(opts):
                 pillar = salt.utils.gitfs.GitPillar(opts)
                 pillar.init_remotes(
                     opts_dict['git'],
-                    git_pillar.PER_REMOTE_PARAMS
+                    git_pillar.PER_REMOTE_OVERRIDES
                 )
                 ret.append(pillar)
     return ret

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -50,7 +50,7 @@ Walkthrough <tutorial-gitfs>`.
 from __future__ import absolute_import
 import logging
 
-PER_REMOTE_PARAMS = ('base', 'mountpoint', 'root', 'ssl_verify')
+PER_REMOTE_OVERRIDES = ('base', 'mountpoint', 'root', 'ssl_verify')
 SYMLINK_RECURSE_DEPTH = 100
 
 # Auth support (auth params can be global or per-remote, too)
@@ -98,7 +98,7 @@ def clear_lock(remote=None):
     Clear update.lk
     '''
     gitfs = salt.utils.gitfs.GitFS(__opts__)
-    gitfs.init_remotes(__opts__['gitfs_remotes'], PER_REMOTE_PARAMS)
+    gitfs.init_remotes(__opts__['gitfs_remotes'], PER_REMOTE_OVERRIDES)
     return gitfs.clear_lock(remote=remote)
 
 
@@ -111,7 +111,7 @@ def lock(remote=None):
     matches the pattern will be locked.
     '''
     gitfs = salt.utils.gitfs.GitFS(__opts__)
-    gitfs.init_remotes(__opts__['gitfs_remotes'], PER_REMOTE_PARAMS)
+    gitfs.init_remotes(__opts__['gitfs_remotes'], PER_REMOTE_OVERRIDES)
     return gitfs.lock(remote=remote)
 
 
@@ -120,7 +120,7 @@ def update():
     Execute a git fetch on all of the repos
     '''
     gitfs = salt.utils.gitfs.GitFS(__opts__)
-    gitfs.init_remotes(__opts__['gitfs_remotes'], PER_REMOTE_PARAMS)
+    gitfs.init_remotes(__opts__['gitfs_remotes'], PER_REMOTE_OVERRIDES)
     gitfs.update()
 
 
@@ -129,7 +129,7 @@ def envs(ignore_cache=False):
     Return a list of refs that can be used as environments
     '''
     gitfs = salt.utils.gitfs.GitFS(__opts__)
-    gitfs.init_remotes(__opts__['gitfs_remotes'], PER_REMOTE_PARAMS)
+    gitfs.init_remotes(__opts__['gitfs_remotes'], PER_REMOTE_OVERRIDES)
     return gitfs.envs(ignore_cache=ignore_cache)
 
 
@@ -139,7 +139,7 @@ def find_file(path, tgt_env='base', **kwargs):  # pylint: disable=W0613
     and send the path to the newly cached file
     '''
     gitfs = salt.utils.gitfs.GitFS(__opts__)
-    gitfs.init_remotes(__opts__['gitfs_remotes'], PER_REMOTE_PARAMS)
+    gitfs.init_remotes(__opts__['gitfs_remotes'], PER_REMOTE_OVERRIDES)
     return gitfs.find_file(path, tgt_env=tgt_env, **kwargs)
 
 
@@ -149,7 +149,7 @@ def init():
     and is not invoked by GitFS.
     '''
     gitfs = salt.utils.gitfs.GitFS(__opts__)
-    gitfs.init_remotes(__opts__['gitfs_remotes'], PER_REMOTE_PARAMS)
+    gitfs.init_remotes(__opts__['gitfs_remotes'], PER_REMOTE_OVERRIDES)
 
 
 def serve_file(load, fnd):
@@ -157,7 +157,7 @@ def serve_file(load, fnd):
     Return a chunk from a file based on the data received
     '''
     gitfs = salt.utils.gitfs.GitFS(__opts__)
-    gitfs.init_remotes(__opts__['gitfs_remotes'], PER_REMOTE_PARAMS)
+    gitfs.init_remotes(__opts__['gitfs_remotes'], PER_REMOTE_OVERRIDES)
     return gitfs.serve_file(load, fnd)
 
 
@@ -166,7 +166,7 @@ def file_hash(load, fnd):
     Return a file hash, the hash type is set in the master config file
     '''
     gitfs = salt.utils.gitfs.GitFS(__opts__)
-    gitfs.init_remotes(__opts__['gitfs_remotes'], PER_REMOTE_PARAMS)
+    gitfs.init_remotes(__opts__['gitfs_remotes'], PER_REMOTE_OVERRIDES)
     return gitfs.file_hash(load, fnd)
 
 
@@ -176,7 +176,7 @@ def file_list(load):
     environment (specified as a key within the load dict).
     '''
     gitfs = salt.utils.gitfs.GitFS(__opts__)
-    gitfs.init_remotes(__opts__['gitfs_remotes'], PER_REMOTE_PARAMS)
+    gitfs.init_remotes(__opts__['gitfs_remotes'], PER_REMOTE_OVERRIDES)
     return gitfs.file_list(load)
 
 
@@ -193,7 +193,7 @@ def dir_list(load):
     Return a list of all directories on the master
     '''
     gitfs = salt.utils.gitfs.GitFS(__opts__)
-    gitfs.init_remotes(__opts__['gitfs_remotes'], PER_REMOTE_PARAMS)
+    gitfs.init_remotes(__opts__['gitfs_remotes'], PER_REMOTE_OVERRIDES)
     return gitfs.dir_list(load)
 
 
@@ -202,5 +202,5 @@ def symlink_list(load):
     Return a dict of all symlinks based on a given path in the repo
     '''
     gitfs = salt.utils.gitfs.GitFS(__opts__)
-    gitfs.init_remotes(__opts__['gitfs_remotes'], PER_REMOTE_PARAMS)
+    gitfs.init_remotes(__opts__['gitfs_remotes'], PER_REMOTE_OVERRIDES)
     return gitfs.symlink_list(load)

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -46,7 +46,7 @@ from datetime import datetime
 from salt.exceptions import FileserverConfigError
 
 VALID_BRANCH_METHODS = ('branches', 'bookmarks', 'mixed')
-PER_REMOTE_PARAMS = ('base', 'branch_method', 'mountpoint', 'root')
+PER_REMOTE_OVERRIDES = ('base', 'branch_method', 'mountpoint', 'root')
 
 # Import third party libs
 import salt.ext.six as six
@@ -190,7 +190,7 @@ def init():
     repos = []
 
     per_remote_defaults = {}
-    for param in PER_REMOTE_PARAMS:
+    for param in PER_REMOTE_OVERRIDES:
         per_remote_defaults[param] = \
             six.text_type(__opts__['hgfs_{0}'.format(param)])
 
@@ -226,12 +226,12 @@ def init():
 
             per_remote_errors = False
             for param in (x for x in per_remote_conf
-                          if x not in PER_REMOTE_PARAMS):
+                          if x not in PER_REMOTE_OVERRIDES):
                 log.error(
                     'Invalid configuration parameter {0!r} for remote {1}. '
                     'Valid parameters are: {2}. See the documentation for '
                     'further information.'.format(
-                        param, repo_url, ', '.join(PER_REMOTE_PARAMS)
+                        param, repo_url, ', '.join(PER_REMOTE_OVERRIDES)
                     )
                 )
                 per_remote_errors = True

--- a/salt/fileserver/svnfs.py
+++ b/salt/fileserver/svnfs.py
@@ -39,7 +39,7 @@ import shutil
 from datetime import datetime
 from salt.exceptions import FileserverConfigError
 
-PER_REMOTE_PARAMS = ('mountpoint', 'root', 'trunk', 'branches', 'tags')
+PER_REMOTE_OVERRIDES = ('mountpoint', 'root', 'trunk', 'branches', 'tags')
 
 # Import third party libs
 import salt.ext.six as six
@@ -126,7 +126,7 @@ def init():
     repos = []
 
     per_remote_defaults = {}
-    for param in PER_REMOTE_PARAMS:
+    for param in PER_REMOTE_OVERRIDES:
         per_remote_defaults[param] = \
             six.text_type(__opts__['svnfs_{0}'.format(param)])
 
@@ -149,12 +149,12 @@ def init():
 
             per_remote_errors = False
             for param in (x for x in per_remote_conf
-                          if x not in PER_REMOTE_PARAMS):
+                          if x not in PER_REMOTE_OVERRIDES):
                 log.error(
                     'Invalid configuration parameter {0!r} for remote {1}. '
                     'Valid parameters are: {2}. See the documentation for '
                     'further information.'.format(
-                        param, repo_url, ', '.join(PER_REMOTE_PARAMS)
+                        param, repo_url, ', '.join(PER_REMOTE_OVERRIDES)
                     )
                 )
                 per_remote_errors = True

--- a/salt/modules/win_repo.py
+++ b/salt/modules/win_repo.py
@@ -25,7 +25,7 @@ from salt.exceptions import CommandExecutionError, SaltRenderError
 from salt.runners.winrepo import (
     genrepo as _genrepo,
     update_git_repos as _update_git_repos,
-    PER_REMOTE_PARAMS
+    PER_REMOTE_OVERRIDES
 )
 from salt.ext import six
 try:

--- a/salt/modules/win_repo.py
+++ b/salt/modules/win_repo.py
@@ -86,7 +86,7 @@ def genrepo():
     return _genrepo(opts=__opts__, fire_event=False)
 
 
-def update_git_repos():
+def update_git_repos(clean=False):
     '''
     Checkout git repos containing :ref:`Windows Software Package Definitions
     <windows-package-manager>`
@@ -97,6 +97,24 @@ def update_git_repos():
         permits the git executable to be run from the Command Prompt.
 
     .. _`Git for Windows`: https://git-for-windows.github.io/
+
+    clean : False
+        Clean repo cachedirs which are not configured under
+        :conf_minion:`winrepo_remotes`.
+
+        .. note::
+            This option only applies if either pygit2_ or GitPython_ is
+            installed into Salt's bundled Python.
+
+        .. warning::
+            This argument should not be set to ``True`` if a mix of git and
+            non-git repo definitions are being used, as it will result in the
+            non-git repo definitions being removed.
+
+        .. versionadded:: 2015.8.0
+
+        .. _GitPython: https://github.com/gitpython-developers/GitPython
+        .. _pygit2: https://github.com/libgit2/pygit2
 
     CLI Example:
 
@@ -109,7 +127,7 @@ def update_git_repos():
             'Git for Windows is not installed, or not configured to be '
             'accessible from the Command Prompt'
         )
-    return _update_git_repos(opts=__opts__, masterless=True)
+    return _update_git_repos(opts=__opts__, clean=clean, masterless=True)
 
 
 def show_sls(name, saltenv='base'):

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -189,7 +189,7 @@ except ImportError:
     HAS_GITPYTHON = False
 # pylint: enable=import-error
 
-PER_REMOTE_PARAMS = ('env', 'root', 'ssl_verify')
+PER_REMOTE_OVERRIDES = ('env', 'root', 'ssl_verify')
 
 # Set up logging
 log = logging.getLogger(__name__)
@@ -242,7 +242,7 @@ def ext_pillar(minion_id, repo, pillar_dirs):
         opts = copy.deepcopy(__opts__)
         opts['pillar_roots'] = {}
         pillar = salt.utils.gitfs.GitPillar(opts)
-        pillar.init_remotes(repo, PER_REMOTE_PARAMS)
+        pillar.init_remotes(repo, PER_REMOTE_OVERRIDES)
         pillar.checkout()
         ret = {}
         for pillar_dir, env in six.iteritems(pillar.pillar_dirs):

--- a/salt/runners/winrepo.py
+++ b/salt/runners/winrepo.py
@@ -139,7 +139,7 @@ def genrepo(opts=None, fire_event=True):
     return ret
 
 
-def update_git_repos(opts=None, masterless=False):
+def update_git_repos(opts=None, clean=False, masterless=False):
     '''
     Checkout git repos containing Windows Software Package Definitions
 
@@ -147,12 +147,23 @@ def update_git_repos(opts=None, masterless=False):
         Specify an alternate opts dict. Should not be used unless this function
         is imported into an execution module.
 
+    clean : False
+        Clean repo cachedirs which are not configured under
+        :conf_master:`winrepo_remotes`.
 
-    CLI Example:
+        .. warning::
+            This argument should not be set to ``True`` if a mix of git and
+            non-git repo definitions are being used, as it will result in the
+            non-git repo definitions being removed.
+
+        .. versionadded:: 2015.8.0
+
+    CLI Examples:
 
     .. code-block:: bash
 
         salt-run winrepo.update_git_repos
+        salt-run winrepo.update_git_repos clean=True
     '''
     if opts is None:
         opts = __opts__
@@ -251,7 +262,8 @@ def update_git_repos(opts=None, masterless=False):
                 # Since we're not running update(), we need to manually call
                 # clear_old_remotes() to remove directories from remotes that
                 # have been removed from configuration.
-                winrepo.clear_old_remotes()
+                if clean:
+                    winrepo.clear_old_remotes()
                 winrepo.checkout()
             except Exception as exc:
                 msg = 'Failed to update winrepo_remotes: {0}'.format(exc)

--- a/salt/runners/winrepo.py
+++ b/salt/runners/winrepo.py
@@ -248,6 +248,10 @@ def update_git_repos(opts=None, masterless=False):
                 winrepo = salt.utils.gitfs.WinRepo(opts, base_dir)
                 winrepo.init_remotes(remotes, PER_REMOTE_OVERRIDES)
                 winrepo.fetch_remotes()
+                # Since we're not running update(), we need to manually call
+                # clear_old_remotes() to remove directories from remotes that
+                # have been removed from configuration.
+                winrepo.clear_old_remotes()
                 winrepo.checkout()
             except Exception as exc:
                 msg = 'Failed to update winrepo_remotes: {0}'.format(exc)

--- a/salt/runners/winrepo.py
+++ b/salt/runners/winrepo.py
@@ -28,7 +28,8 @@ import salt.template
 
 log = logging.getLogger(__name__)
 
-PER_REMOTE_PARAMS = ('ssl_verify',)
+# Global parameters which can be overridden on a per-remote basis
+PER_REMOTE_OVERRIDES = ('ssl_verify',)
 
 
 def genrepo(opts=None, fire_event=True):
@@ -245,7 +246,7 @@ def update_git_repos(opts=None, masterless=False):
             # New winrepo code utilizing salt.utils.gitfs
             try:
                 winrepo = salt.utils.gitfs.WinRepo(opts, base_dir)
-                winrepo.init_remotes(remotes, PER_REMOTE_PARAMS)
+                winrepo.init_remotes(remotes, PER_REMOTE_OVERRIDES)
                 winrepo.fetch_remotes()
                 winrepo.checkout()
             except Exception as exc:


### PR DESCRIPTION
This pull request also adds support for gitfs params which are applied on a
per-remote-only basis, so that a "name" parameter can be used to resolve naming
conflicts for winrepo git repos.

Fixes #26979.
