### PR TITLE
[NetAPI] SaltNado - Improve support for Content-Type parsing. Ref #26505

### DIFF
--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -161,6 +161,7 @@ from copy import copy
 from collections import defaultdict
 
 # pylint: disable=import-error
+import cgi
 import yaml
 import tornado.httpserver
 import tornado.ioloop
@@ -503,7 +504,10 @@ class BaseSaltAPIHandler(tornado.web.RequestHandler, SaltClientsMixIn):  # pylin
         }
 
         try:
-            return ct_in_map[self.request.headers['Content-Type']](data)
+            # Use cgi.parse_header to correctly separate parameters from value
+            header = cgi.parse_header(self.request.headers['Content-Type'])
+            value, parameters = header
+            return ct_in_map[value](data)
         except KeyError:
             self.send_error(406)
         except ValueError:

--- a/tests/unit/netapi/rest_tornado/test_handlers.py
+++ b/tests/unit/netapi/rest_tornado/test_handlers.py
@@ -46,6 +46,7 @@ class SaltnadoTestCase(integration.ModuleCase, AsyncHTTPTestCase):
     Mixin to hold some shared things
     '''
     content_type_map = {'json': 'application/json',
+                        'json-utf8': 'application/json; charset=utf-8',
                         'yaml': 'application/x-yaml',
                         'text': 'text/plain',
                         'form': 'application/x-www-form-urlencoded'}
@@ -238,6 +239,13 @@ class TestBaseSaltAPIHandler(SaltnadoTestCase):
         self.assertEqual(returned_lowstate['tgt'], '*')
         self.assertEqual(returned_lowstate['fun'], 'test.fib')
         self.assertEqual(returned_lowstate['arg'], ['10', 'foo'])
+
+        # Send json with utf8 charset
+        response = self.fetch('/',
+                              method='POST',
+                              body=json.dumps(valid_lowstate),
+                              headers={'Content-Type': self.content_type_map['json-utf8']})
+        self.assertEqual(valid_lowstate, json.loads(response.body)['lowstate'])
 
 
 class TestSaltAuthHandler(SaltnadoTestCase):


### PR DESCRIPTION
It currently supports 'simple' values like application/json, but Content-Type
header could also includes parameter. See RFC http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17.

When sending JSON from a browser for example, the Content-Type is
`application/json; charset=utf-8` and salt-api failed to detect JSON content.

The proposition is to use cgi.parse_header method (https://docs.python.org/2.7/library/cgi.html?highlight=cgi#cgi.parse_header)
to correctly parse the Content-Type value but ignore parameters, JSON should
always be UTF-8 but I don't know about other supported Content-Type.
