### PR TITLE
Package information

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2213,3 +2213,35 @@ def owner(*paths):
     if len(ret) == 1:
         return next(six.itervalues(ret))
     return ret
+
+
+def info_installed(*names):
+    '''
+    Return the information of the named package(s), installed on the system.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.info_installed <package1>
+        salt '*' pkg.info_installed <package1> <package2> <package3> ...
+    '''
+    ret = dict()
+    for pkg_name, pkg_nfo in __salt__['lowpkg.info'](*names).items():
+        t_nfo = dict()
+        # Translate dpkg-specific keys to a common structure
+        for key, value in pkg_nfo.items():
+            if key == 'package':
+                t_nfo['name'] = value
+            elif key == 'origin':
+                t_nfo['vendor'] = value
+            elif key == 'section':
+                t_nfo['group'] = value
+            elif key == 'maintainer':
+                t_nfo['packager'] = value
+            else:
+                t_nfo[key] = value
+
+        ret[pkg_name] = t_nfo
+
+    return ret

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2239,6 +2239,8 @@ def info_installed(*names):
                 t_nfo['group'] = value
             elif key == 'maintainer':
                 t_nfo['packager'] = value
+            elif key == 'homepage':
+                t_nfo['url'] = value
             else:
                 t_nfo[key] = value
 

--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 import logging
 import os
 import re
+import datetime
 
 # Import salt libs
 import salt.utils
@@ -280,8 +281,23 @@ def _get_pkg_info(*packages):
         for pkg_info_line in [el.strip() for el in pkg_info.split(os.linesep) if el.strip()]:
             key, value = pkg_info_line.split(":", 1)
             pkg_data[key] = value or "N/A"
+            pkg_data['install_date'] = _get_pkg_install_time(pkg_data.get('package'))
         pkg_data['description'] = pkg_descr.split(":", 1)[-1]
         ret.append(pkg_data)
 
     return ret
 
+
+def _get_pkg_install_time(pkg):
+    '''
+    Return package install time, based on the /var/lib/dpkg/info/<package>.list
+
+    :return:
+    '''
+    iso_time = "N/A"
+    if pkg is not None:
+        location = "/var/lib/dpkg/info/{0}.list".format(pkg)
+        if os.path.exists(location):
+            iso_time = datetime.datetime.fromtimestamp(os.path.getmtime(location)).isoformat()
+
+    return iso_time

--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -301,3 +301,25 @@ def _get_pkg_install_time(pkg):
             iso_time = datetime.datetime.fromtimestamp(os.path.getmtime(location)).isoformat()
 
     return iso_time
+
+
+def info(*packages):
+    '''
+    Return a detailed package(s) summary information.
+    If no packages specified, all packages will be returned.
+
+    :param packages:
+    :return:
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' lowpkg.info apache2 bash
+    '''
+
+    ret = dict()
+    for pkg in _get_pkg_info(*packages):
+        ret[pkg['package']] = pkg
+
+    return ret

--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -364,7 +364,8 @@ def info(*packages):
                 pkg[pkg_ext_k] = pkg_ext_v
         # Remove "technical" keys
         for t_key in ['installed_size', 'depends', 'recommends',
-                      'conflicts', 'bugs', 'description-md5']:
+                      'provides', 'replaces', 'conflicts', 'bugs',
+                      'description-md5', 'task']:
             if t_key in pkg:
                 del pkg[t_key]
         ret[pkg['package']] = pkg

--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -263,7 +263,8 @@ def _get_pkg_info(*packages):
           "source:${source:Package}\\n" \
           "version:${Version}\\n" \
           "section:${Section}\\n" \
-          "size:${Installed-size}\\n" \
+          "installed_size:${Installed-size}\\n" \
+          "size:${Size}\\n" \
           "origin:${Origin}\\n" \
           "homepage:${Homepage}\\n" \
           "======\\n" \

--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -294,6 +294,24 @@ def _get_pkg_info(*packages):
     return ret
 
 
+def _get_pkg_license(pkg):
+    '''
+    Try to get a license from the package.
+    Based on https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+
+    :param pkg:
+    :return:
+    '''
+    licenses = set()
+    cpr = "/usr/share/doc/{0}/copyright".format(pkg)
+    if os.path.exists(cpr):
+        for line in open(cpr).read().split(os.linesep):
+            if line.startswith("License:"):
+                licenses.add(line.split(":", 1)[1].strip())
+
+    return ", ".join(sorted(licenses))
+
+
 def _get_pkg_install_time(pkg):
     '''
     Return package install time, based on the /var/lib/dpkg/info/<package>.list
@@ -368,6 +386,10 @@ def info(*packages):
                       'description-md5', 'task']:
             if t_key in pkg:
                 del pkg[t_key]
+
+        lic = _get_pkg_license(pkg['package'])
+        if lic:
+            pkg['license'] = lic
         ret[pkg['package']] = pkg
 
     return ret

--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -346,7 +346,8 @@ def _get_pkg_ds_avail():
         nfo = dict()
         for line in (pkg_mrk + pkg_info).split(os.linesep):
             line = line.split(": ", 1)
-            if len(line) != 2: continue
+            if len(line) != 2:
+                continue
             key, value = line
             if value.strip():
                 nfo[key.lower()] = value

--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -265,6 +265,7 @@ def _get_pkg_info(*packages):
           "section:${Section}\\n" \
           "size:${Installed-size}\\n" \
           "origin:${Origin}\\n" \
+          "homepage:${Homepage}\\n" \
           "======\\n" \
           "description:${Description}\\n" \
           "------\\n'"

--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -280,7 +280,8 @@ def _get_pkg_info(*packages):
         pkg_info, pkg_descr = re.split(r"====*", pkg_info)
         for pkg_info_line in [el.strip() for el in pkg_info.split(os.linesep) if el.strip()]:
             key, value = pkg_info_line.split(":", 1)
-            pkg_data[key] = value or "N/A"
+            if value:
+                pkg_data[key] = value
             pkg_data['install_date'] = _get_pkg_install_time(pkg_data.get('package'))
         pkg_data['description'] = pkg_descr.split(":", 1)[-1]
         ret.append(pkg_data)

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -8,6 +8,8 @@ from __future__ import absolute_import
 import logging
 import os
 import re
+import time
+import datetime
 
 # Import Salt libs
 import salt.utils
@@ -397,6 +399,18 @@ def diff(package, path):
     return res
 
 
+def _pkg_time_to_iso(pkg_time):
+    '''
+    Convert package time to ISO 8601.
+
+    :param pkg_time:
+    :return:
+    '''
+    ptime = time.strptime(pkg_time)
+    return datetime.datetime(ptime.tm_year, ptime.tm_mon, ptime.tm_mday,
+                             ptime.tm_hour, ptime.tm_min, ptime.tm_sec).isoformat()
+
+
 def info(*packages):
     '''
     Return a detailed package(s) summary information.
@@ -441,6 +455,8 @@ def info(*packages):
             key = key.replace(' ', '_').lower()
             if key == 'name':
                 pkg_name = value
+            if key in ['build_date', 'install_date']:
+                value = _pkg_time_to_iso(value)
             if key != 'description' and value:
                 pkg_data[key] = value
         if pkg_name:

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -437,7 +437,7 @@ def info(*packages):
         out = call['stdout']
 
     ret = dict()
-    for pkg_info in re.split("----*", out):
+    for pkg_info in re.split(r"----*", out):
         pkg_info = pkg_info.strip()
         if not pkg_info:
             continue

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -447,18 +447,27 @@ def info(*packages):
 
         pkg_data = dict()
         pkg_name = None
-        for line in pkg_info[:]:
+        descr_marker = False
+        descr = list()
+        for line in pkg_info:
+            if descr_marker:
+                descr.append(line)
+                continue
             line = [item.strip() for item in line.split(':', 1)]
             if len(line) != 2:
                 continue
             key, value = line
             key = key.replace(' ', '_').lower()
+            if key == 'description':
+                descr_marker = True
+                continue
             if key == 'name':
                 pkg_name = value
             if key in ['build_date', 'install_date']:
                 value = _pkg_time_to_iso(value)
             if key != 'description' and value:
                 pkg_data[key] = value
+        pkg_data['decription'] = os.linesep.join(descr)
         if pkg_name:
             ret[pkg_name] = pkg_data
 

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -684,6 +684,32 @@ def list_upgrades(refresh=True, **kwargs):
     return dict([(x.name, x.version) for x in updates])
 
 
+def info_installed(*names):
+    '''
+    Return the information of the named package(s), installed on the system.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.info_installed <package1>
+        salt '*' pkg.info_installed <package1> <package2> <package3> ...
+    '''
+    ret = dict()
+    for pkg_name, pkg_nfo in __salt__['lowpkg.info'](*names).items():
+        t_nfo = dict()
+        # Translate dpkg-specific keys to a common structure
+        for key, value in pkg_nfo.items():
+            if key == 'source_rpm':
+                t_nfo['source'] = value
+            else:
+                t_nfo[key] = value
+
+        ret[pkg_name] = t_nfo
+
+    return ret
+
+
 def check_db(*names, **kwargs):
     '''
     .. versionadded:: 0.17.0

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -95,7 +95,6 @@ def list_upgrades(refresh=True):
 list_updates = list_upgrades
 
 
-def info(*names, **kwargs):
 def info_installed(*names):
     '''
     Return the information of the named package(s), installed on the system.
@@ -120,6 +119,9 @@ def info_installed(*names):
         ret[pkg_name] = t_nfo
 
     return ret
+
+
+def info_available(*names, **kwargs):
     '''
     Return the information of the named package available for the system.
 
@@ -127,8 +129,8 @@ def info_installed(*names):
 
     .. code-block:: bash
 
-        salt '*' pkg.info <package name>
-        salt '*' pkg.info <package1> <package2> <package3> ...
+        salt '*' pkg.info_available <package1>
+        salt '*' pkg.info_available <package1> <package2> <package3> ...
     '''
     ret = {}
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -166,6 +166,24 @@ def info_available(*names, **kwargs):
     return ret
 
 
+def info(*names, **kwargs):
+    '''
+    .. deprecated:: Nitrogen
+       Use :py:func:`~salt.modules.pkg.info_available` instead.
+
+    Return the information of the named package available for the system.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.info_available <package1>
+        salt '*' pkg.info_available <package1> <package2> <package3> ...
+    '''
+    salt.utils.warn_until('Nitrogen', "Please use 'pkg.info_available' instead")
+    return info_available(*names)
+
+
 def latest_version(*names, **kwargs):
     '''
     Return the latest version of the named package available for upgrade or

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -188,7 +188,7 @@ def latest_version(*names, **kwargs):
         return ret
 
     names = sorted(list(set(names)))
-    package_info = info(*names)
+    package_info = info_available(*names)
     for name in names:
         pkg_info = package_info.get(name)
         if pkg_info is not None and pkg_info.get('status', '').lower() in ['not installed', 'out-of-date']:

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -177,8 +177,8 @@ def info(*names, **kwargs):
 
     .. code-block:: bash
 
-        salt '*' pkg.info_available <package1>
-        salt '*' pkg.info_available <package1> <package2> <package3> ...
+        salt '*' pkg.info <package1>
+        salt '*' pkg.info <package1> <package2> <package3> ...
     '''
     salt.utils.warn_until('Nitrogen', "Please use 'pkg.info_available' instead")
     return info_available(*names)

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -124,7 +124,7 @@ def info(*names, **kwargs):
     # Run in batches
     while batch:
         cmd = 'zypper info -t package {0}'.format(' '.join(batch[:batch_size]))
-        pkg_info.extend(re.split("----*", __salt__['cmd.run_stdout'](cmd, output_loglevel='trace')))
+        pkg_info.extend(re.split(r"----*", __salt__['cmd.run_stdout'](cmd, output_loglevel='trace')))
         batch = batch[batch_size:]
 
     for pkg_data in pkg_info:

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -96,6 +96,30 @@ list_updates = list_upgrades
 
 
 def info(*names, **kwargs):
+def info_installed(*names):
+    '''
+    Return the information of the named package(s), installed on the system.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.info_installed <package1>
+        salt '*' pkg.info_installed <package1> <package2> <package3> ...
+    '''
+    ret = dict()
+    for pkg_name, pkg_nfo in __salt__['lowpkg.info'](*names).items():
+        t_nfo = dict()
+        # Translate dpkg-specific keys to a common structure
+        for key, value in pkg_nfo.items():
+            if key == 'source_rpm':
+                t_nfo['source'] = value
+            else:
+                t_nfo[key] = value
+
+        ret[pkg_name] = t_nfo
+
+    return ret
     '''
     Return the information of the named package available for the system.
 


### PR DESCRIPTION
This PR does the following:
- Drops `pkg.info` which was available only for Zypper (SUSE) at the moment and renamed it to the `pkg.info_available`.
- Adds `pkg.info_installed` which is now same on SUSE, RedHat and Debian-based distros.

The dpkg wasn't that easy as RPM though... :wink: 
