### PR TITLE
Fixed symlinks for windows (don't use user root)

### DIFF
--- a/salt/modules/win_useradd.py
+++ b/salt/modules/win_useradd.py
@@ -509,6 +509,8 @@ def current(sam=False):
     running from a command prompt it should return the username that started the
     command prompt.
 
+    .. versionadded:: 2015.5.6
+
     :param bool sam:
         False returns just the username without any domain notation. True
         returns the domain with the username in the SAM format. Ie:

--- a/salt/modules/win_useradd.py
+++ b/salt/modules/win_useradd.py
@@ -22,6 +22,9 @@ log = logging.getLogger(__name__)
 try:
     import wmi
     import pythoncom
+    import pywintypes
+    import win32api
+    import win32con
     import win32net
     import win32netcon
     import win32security
@@ -497,3 +500,46 @@ def rename(name, new_name):
         return post_info['name'] == new_name
 
     return False
+
+
+def current(sam=False):
+    '''
+    Get the username that salt-minion is running under. If salt-minion is
+    running as a service it should return the Local System account. If salt is
+    running from a command prompt it should return the username that started the
+    command prompt.
+
+    :param bool sam:
+        False returns just the username without any domain notation. True
+        returns the domain with the username in the SAM format. Ie:
+
+        ``domain\\username``
+
+    :return:
+        Returns False if the username cannot be returned. Otherwise returns the
+        username.
+    :rtype: bool str
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' user.current
+    '''
+    try:
+        if sam:
+            user_name = win32api.GetUserNameEx(win32con.NameSamCompatible)
+        else:
+            user_name = win32api.GetUserName()
+    except pywintypes.error as exc:
+        (number, context, message) = exc
+        log.error('Failed to get current user')
+        log.error('nbr: {0}'.format(number))
+        log.error('ctx: {0}'.format(context))
+        log.error('msg: {0}'.format(message))
+        return False
+
+    if not user_name:
+        return False
+
+    return user_name

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -835,6 +835,16 @@ def symlink(
         user = __opts__['user']
 
     if salt.utils.is_windows():
+
+        # Make sure the user exists in Windows
+        # Salt default is 'root'
+        if not __salt__['user.info'](user):
+            # User not found, use the account salt is running under
+            # If username not found, use System
+            user = __salt__['user.current']()
+            if not user:
+                user = 'SYSTEM'
+
         if group is not None:
             log.warning(
                 'The group argument for {0} has been ignored as this '


### PR DESCRIPTION
Added function to win_useradd to get the current user
If root is passed, verifies that it exists
If not, gets salt-minion user
Failing that, falls back to SYSTEM

Fixes: #26730
Fixes: #26899 (reverted)
