### PR TITLE
Fix 'dict' object has no attribute split

### DIFF
--- a/salt/modules/win_path.py
+++ b/salt/modules/win_path.py
@@ -76,7 +76,8 @@ def get_path():
     ret = __salt__['reg.read_key']('HKEY_LOCAL_MACHINE',
                                    'SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
                                    'PATH')
-    ret = ret['vdata'].split(';')
+    if 'vdata' in ret.keys():
+        ret = ret['vdata'].split(';')
 
     # Trim ending backslash
     return list(map(_normalize_dir, ret))

--- a/salt/modules/win_path.py
+++ b/salt/modules/win_path.py
@@ -76,8 +76,10 @@ def get_path():
     ret = __salt__['reg.read_key']('HKEY_LOCAL_MACHINE',
                                    'SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
                                    'PATH')
-    if 'vdata' in ret.keys():
-        ret = ret['vdata'].split(';')
+    if isinstance(ret, dict):         
+        ret = ret['vdata'].split(';') 
+    if isinstance(ret, str):          
+        ret = ret.split(';')
 
     # Trim ending backslash
     return list(map(_normalize_dir, ret))

--- a/salt/modules/win_path.py
+++ b/salt/modules/win_path.py
@@ -76,9 +76,9 @@ def get_path():
     ret = __salt__['reg.read_key']('HKEY_LOCAL_MACHINE',
                                    'SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
                                    'PATH')
-    if isinstance(ret, dict):         
-        ret = ret['vdata'].split(';') 
-    if isinstance(ret, str):          
+    if isinstance(ret, dict):
+        ret = ret['vdata'].split(';')
+    if isinstance(ret, str):
         ret = ret.split(';')
 
     # Trim ending backslash

--- a/salt/modules/win_path.py
+++ b/salt/modules/win_path.py
@@ -75,7 +75,8 @@ def get_path():
     '''
     ret = __salt__['reg.read_key']('HKEY_LOCAL_MACHINE',
                                    'SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
-                                   'PATH').split(';')
+                                   'PATH')
+    ret = ret['vdata'].split(';')
 
     # Trim ending backslash
     return list(map(_normalize_dir, ret))


### PR DESCRIPTION
After updating to 2015.5.5 the state calls of win_path.exists suddenly were broken due to the change in the reg.py module.
This commit fixes the win_path.exists read_key implementation to fit the reg.read_value implementation that was discussed in https://github.com/saltstack/salt/issues/25618
