### PR TITLE
Remove unwanted debug statement

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -564,7 +564,6 @@ def get_ca_bundle(opts=None):
 
     # Check Salt first
     for salt_root in file_roots.get('base', []):
-        log.debug('file_roots is {0}'.format(salt_root))
         for path in ('cacert.pem', 'ca-bundle.crt'):
             if os.path.exists(path):
                 return path


### PR DESCRIPTION
This debug statement was added when creating spm related modules but it produces a lot of noise in the debug log which isn't needed anymore. Talked to @techhat and he mentioned it's safe to remove it. This should also be back ported to other branches. 
