### PR TITLE
Avoid starting minion starting if already running

### DIFF
--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -238,6 +238,12 @@ class Minion(parsers.MinionOptionParser):  # pylint: disable=no-init
             )
         )
         migrations.migrate_paths(self.config)
+
+        # Bail out if we find a process running and it matches out pidfile
+        if self.check_running():
+            logger.exception('Salt minion is already running. Exiting.')
+            self.shutdown(err.errno)
+
         # TODO: AIO core is separate from transport
         if self.config['transport'].lower() in ('zeromq', 'tcp'):
             # Late import so logging works correctly

--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -242,7 +242,7 @@ class Minion(parsers.MinionOptionParser):  # pylint: disable=no-init
         # Bail out if we find a process running and it matches out pidfile
         if self.check_running():
             logger.exception('Salt minion is already running. Exiting.')
-            self.shutdown(err.errno)
+            self.shutdown(1)
 
         # TODO: AIO core is separate from transport
         if self.config['transport'].lower() in ('zeromq', 'tcp'):

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -843,6 +843,10 @@ class DaemonMixIn(six.with_metaclass(MixInMeta, object)):
             import salt.utils
             salt.utils.daemonize()
 
+    def is_daemonized(self):
+        import salt.utils.process
+        return salt.utils.process.os_is_running()
+
 
 class PidfileMixin(six.with_metaclass(MixInMeta, object)):
     _mixin_prio_ = 40
@@ -859,6 +863,13 @@ class PidfileMixin(six.with_metaclass(MixInMeta, object)):
     def set_pidfile(self):
         from salt.utils.process import set_pidfile
         set_pidfile(self.config['pidfile'], self.config['user'])
+
+    def check_pidfile(self):
+        '''
+        Report whether a pidfile exists
+        '''
+        from salt.utils.process import get_pidfile
+        get_pidfile(self.config['pidfile'])
 
 
 class TargetOptionsMixIn(six.with_metaclass(MixInMeta, object)):
@@ -1515,6 +1526,13 @@ class MasterOptionParser(six.with_metaclass(OptionParserMeta,
 
     def setup_config(self):
         return config.master_config(self.get_config_file_path())
+
+    def check_running(self):
+        '''
+        Check if a pid file exists and if it is associated with 
+        a running process.
+        '''
+        return self.check_pidfile() and self.is_daemonized()
 
 
 class MinionOptionParser(six.with_metaclass(OptionParserMeta, MasterOptionParser)):  # pylint: disable=no-init

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -843,9 +843,9 @@ class DaemonMixIn(six.with_metaclass(MixInMeta, object)):
             import salt.utils
             salt.utils.daemonize()
 
-    def is_daemonized(self):
+    def is_daemonized(self, pid):
         import salt.utils.process
-        return salt.utils.process.os_is_running()
+        return salt.utils.process.os_is_running(pid)
 
 
 class PidfileMixin(six.with_metaclass(MixInMeta, object)):
@@ -868,8 +868,15 @@ class PidfileMixin(six.with_metaclass(MixInMeta, object)):
         '''
         Report whether a pidfile exists
         '''
+        from salt.utils.process import check_pidfile
+        return check_pidfile(self.config['pidfile'])
+
+    def get_pidfile(self):
+        '''
+        Return a pid contained in a pidfile
+        '''
         from salt.utils.process import get_pidfile
-        get_pidfile(self.config['pidfile'])
+        return get_pidfile(self.config['pidfile'])
 
 
 class TargetOptionsMixIn(six.with_metaclass(MixInMeta, object)):
@@ -1529,10 +1536,11 @@ class MasterOptionParser(six.with_metaclass(OptionParserMeta,
 
     def check_running(self):
         '''
-        Check if a pid file exists and if it is associated with 
+        Check if a pid file exists and if it is associated with
         a running process.
         '''
-        return self.check_pidfile() and self.is_daemonized()
+        if self.check_pidfile():
+            return self.is_daemonized(self.get_pidfile())
 
 
 class MinionOptionParser(six.with_metaclass(OptionParserMeta, MasterOptionParser)):  # pylint: disable=no-init

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -102,6 +102,13 @@ def set_pidfile(pidfile, user):
     log.debug('Chowned pidfile: {0} to user: {1}'.format(pidfile, user))
 
 
+def get_pidfile(pidfile):
+    '''
+    Determine if a pidfile has been written out
+    '''
+    return os.path.isfile(pidfile)
+
+
 def clean_proc(proc, wait_for_kill=10):
     '''
     Generic method for cleaning up multiprocessing procs

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -102,11 +102,21 @@ def set_pidfile(pidfile, user):
     log.debug('Chowned pidfile: {0} to user: {1}'.format(pidfile, user))
 
 
-def get_pidfile(pidfile):
+def check_pidfile(pidfile):
     '''
     Determine if a pidfile has been written out
     '''
     return os.path.isfile(pidfile)
+
+
+def get_pidfile(pidfile):
+    '''
+    Return the pid from a pidfile as an integer
+    '''
+    with salt.utils.fopen(pidfile) as pdf:
+        pid = pdf.read()
+
+    return int(pid)
 
 
 def clean_proc(proc, wait_for_kill=10):
@@ -140,6 +150,8 @@ def os_is_running(pid):
     '''
     Use OS facilities to determine if a process is running
     '''
+    if isinstance(pid, six.string_types):
+        pid = int(pid)
     if HAS_PSUTIL:
         return psutil.pid_exists(pid)
     else:


### PR DESCRIPTION
Here, we check both the pid and compare the pid to the process list to try and make a decision about whether or not we're about to startup a minion which will produce duplicate returns.

Closes #25013 
