### PR TITLE
Removed check for no package name

### DIFF
--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -133,8 +133,6 @@ def install(pkg=None,
         cmd.append(pkg)
     elif pkgs:
         cmd.extend(pkgs)
-    else:
-        return 'No package name specified'
 
     if env is None:
         env = {}


### PR DESCRIPTION
When a pkg name is not specified, this should just run `npm install --json`. The check that was removed prevented this from happening and also prevented the 'npm.bootstrap' state from working correctly.
