### PR TITLE
useradd.py: Use contextmanager to prevent leaked filehandles

### DIFF
--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -152,10 +152,9 @@ def _changes(name,
             change['homephone'] = homephone
     # OpenBSD login class
     if __grains__['kernel'] == 'OpenBSD':
-        if not loginclass:
-            loginclass = '""'
-        if __salt__['user.get_loginclass'](name)['loginclass'] != loginclass:
-            change['loginclass'] = loginclass
+        if loginclass:
+            if __salt__['user.get_loginclass'](name) != loginclass:
+                change['loginclass'] = loginclass
 
     return change
 
@@ -443,8 +442,8 @@ def present(name,
                 if lshad[key] != spost[key]:
                     ret['changes'][key] = spost[key]
         if __grains__['kernel'] == 'OpenBSD':
-            if lcpost['loginclass'] != lcpre['loginclass']:
-                ret['changes']['loginclass'] = lcpost['loginclass']
+            if lcpre != lcpost:
+                ret['changes']['loginclass'] = lcpost
         if ret['changes']:
             ret['comment'] = 'Updated user {0}'.format(name)
         changes = _changes(name,


### PR DESCRIPTION
This also makes some optimizations by not assigning the output of
functions to variables when unnecessary, and changes this module to pass
arguments to the cmd.run functions as list instead of a string.

It also changes some weird behavior for the loginclass functions.
There's no reason to return a dictionary that will only have one
element, and there is no reason to return a string that is literally
just two quotes (i.e. `'""'`) when there is no login class found. An empty
string is sufficient, and has the benefit of also evaluating as False as
a boolean.
