### PR TITLE
Run repoquery less

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -745,13 +745,13 @@ def check_db(*names, **kwargs):
         __context__['pkg._avail'] = avail
 
     ret = {}
+    repoquery_cmd = repoquery_base + ' {0}'.format(" ".join(names))
+    provides = sorted(
+        set(x.name for x in _repoquery_pkginfo(repoquery_cmd))
+    )
     for name in names:
         ret.setdefault(name, {})['found'] = name in avail
         if not ret[name]['found']:
-            repoquery_cmd = repoquery_base + ' {0}'.format(name)
-            provides = sorted(
-                set(x.name for x in _repoquery_pkginfo(repoquery_cmd))
-            )
             if name in provides:
                 # Package was not in avail but was found by the repoquery_cmd
                 ret[name]['found'] = True


### PR DESCRIPTION
Currently, if you're installing multiple packages using `pkgs` option to `pkg.installed`, repoquery is run once per package to find available versions. On my systems, this takes around 500ms to run, so can be very slow when you have a large list of packages.

This PR changes the behaviour so that repoquery is only run once for the entire list of packages.
