### PR TITLE
add os build version grain to OS X minions

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1313,6 +1313,7 @@ def os_data():
         grains['os'] = 'ESXi'
     elif grains['kernel'] == 'Darwin':
         osrelease = __salt__['cmd.run']('sw_vers -productVersion')
+        grains['os_build_version'] = __salt__['cmd.run']('sw_vers -buildVersion')
         grains['os'] = 'MacOS'
         grains['os_family'] = 'MacOS'
         grains['osrelease'] = osrelease


### PR DESCRIPTION
use `sw_vers -buildVersion` to return the OSX BuildVersion details in salt grains.
