### PR TITLE
salt/master: chdir to root not homedir

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -387,22 +387,11 @@ class Master(SMaster):
         errors = []
         critical_errors = []
 
-        if salt.utils.is_windows() and self.opts['user'] == 'root':
-            # 'root' doesn't typically exist on Windows. Use the current user
-            # home directory instead.
-            home = os.path.expanduser('~' + salt.utils.get_user())
-        else:
-            home = os.path.expanduser('~' + self.opts['user'])
         try:
-            if salt.utils.is_windows() and not os.path.isdir(home):
-                # On Windows, Service account home directories may not
-                # initially exist. If this is the case, make sure the
-                # directory exists before continuing.
-                os.mkdir(home, 0o755)
-            os.chdir(home)
+            os.chdir('/')
         except OSError as err:
             errors.append(
-                'Cannot change to home directory {0} ({1})'.format(home, err)
+                'Cannot change to root directory ({1})'.format(err)
             )
 
         fileserver = salt.fileserver.Fileserver(self.opts)


### PR DESCRIPTION
This is a backport of https://github.com/saltstack/salt/pull/27091 to the stable branch since there are minor changes so the same patch does not automatically apply to both.

The pre-flight checks try to change to $HOME, this can fail for multiple
reasons. One such case is that /root is a protected dir under SELinux
which the master should not have access to. The daemon should instead
change to the root dir which is the only dir that is always guaranteed
to be there. The limited testing I have managed to do shows that windows
accepts the '/' path too just fine so the os-specific case is not
required either.

Changing to $HOME was added in https://github.com/saltstack/salt/pull/21279

Gentoo-Bug: https://bugs.gentoo.org/560300
