### PR TITLE
Redis engine import fix

### DIFF
--- a/salt/engines/redis_sentinel.py
+++ b/salt/engines/redis_sentinel.py
@@ -21,24 +21,31 @@ events based on the channels they are subscribed to.
 
 :depends: redis
 '''
+
+# Import python libs
 from __future__ import absolute_import
+import logging
+
+# Import salt libs
 import salt.client
 from salt.ext import six
 from salt.ext.six.moves import zip
 
+# Import third party libs
 try:
     import redis
     HAS_REDIS = True
 except ImportError:
     HAS_REDIS = False
 
-import logging
-log = logging.getLogger(__name__)
-log.debug('LOAD REDIS_SENTINEL')
-
 
 def __virtual__():
-    return HAS_REDIS
+    if not HAS_REDIS:
+        return False
+    else:
+        return True
+
+log = logging.getLogger(__name__)
 
 
 class Listener(object):

--- a/salt/engines/redis_sentinel.py
+++ b/salt/engines/redis_sentinel.py
@@ -22,7 +22,6 @@ events based on the channels they are subscribed to.
 :depends: redis
 '''
 from __future__ import absolute_import
-import redis
 import salt.client
 from salt.ext import six
 from salt.ext.six.moves import zip


### PR DESCRIPTION
Removed a double `import redis` in the `redis engine`. I also cleaned up the engine file to make it more uniform with other engine files.

With the following master config:

``` bash
engines:
    - redis_sentinel:
        hosts:
            matching: 'board*'
            port: 26379
            interface: eth2
        channels:
            - '+switch-master'
            - '+odown'
            - '-odown'
```

And without redis installed I was getting:

``` bash
[DEBUG   ] Failed to import engines redis_sentinel:
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1128, in _load_module
    ), fn_, fpath, desc)
  File "/usr/lib/python2.7/dist-packages/salt/engines/redis_sentinel.py", line 25, in <module>
    import redis
ImportError: No module named redis
[DEBUG   ] Could not LazyLoad redis_sentinel.start
```

After changes 

``` bash
[DEBUG   ] Could not LazyLoad redis_sentinel.start
```

Salt versions:

``` bash
~# salt --versions
Salt Version:
           Salt: 2015.8.0-386-gdaaf57a

Dependency Versions:
         Jinja2: 2.7.2
       M2Crypto: 0.21.1
           Mako: Not Installed
         PyYAML: 3.10
          PyZMQ: 14.0.1
         Python: 2.7.6 (default, Jun 22 2015, 17:58:13)
           RAET: Not Installed
        Tornado: 4.2.1
            ZMQ: 4.0.4
           cffi: Not Installed
       cherrypy: Not Installed
       dateutil: Not Installed
          gitdb: Not Installed
      gitpython: Not Installed
          ioflo: Not Installed
        libnacl: Not Installed
   msgpack-pure: Not Installed
 msgpack-python: 0.3.0
   mysql-python: Not Installed
      pycparser: Not Installed
       pycrypto: 2.6.1
         pygit2: Not Installed
   python-gnupg: Not Installed
          smmap: Not Installed
        timelib: Not Installed

System Versions:
           dist: Ubuntu 14.04 trusty
        machine: x86_64
        release: 3.13.0-52-generic
         system: Ubuntu 14.04 trusty
```
