### PR TITLE
Fix access to ret parameter of _print_returns_summary() (reverts 54b33dd35948 #24732)

### DIFF
--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -250,7 +250,7 @@ class SaltCMD(parsers.SaltCMDOptionParser):
         not_response_minions = []
         not_connected_minions = []
         for each_minion in ret:
-            minion_ret = ret[each_minion]
+            minion_ret = ret[each_minion].get('ret')
             if (
                     isinstance(minion_ret, string_types)
                     and minion_ret.startswith("Minion did not return")


### PR DESCRIPTION
The attempt to fix `_print_returns_summary()` in 54b33dd35948 missed that
there were two callers of `_print_returns_summary()` with differing data
structure in the `ret` parameter.  While 54b33dd35948 fixed the results for
one caller it broke it for the other.  Commits 2de88e6 and 7c9f4ca fix the
consistency of the `ret` parameter for callers and now 54b33dd35948 needs to
be reverted.
