### PR TITLE
Remove only the file extension when checking missing cached nodes.

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -2751,7 +2751,7 @@ def missing_node_cache(prov_dir, node_list, provider, opts):
     '''
     cached_nodes = []
     for node in os.listdir(prov_dir):
-        cached_nodes.append(node.replace('.p', ''))
+        cached_nodes.append(os.path.splitext(node)[0])
 
     log.debug(sorted(cached_nodes))
     log.debug(sorted(node_list))


### PR DESCRIPTION
With string.replace every substring of '.p' would be removed, causing incorrect minion IDs. For example, a minion ID of 'production.postgres' would be cached under the filename 'production.postgres.p' but would be loaded as 'productionostgres'.
