### PR TITLE
Boto dynamodb module should be using layer 2 abstractions

### DIFF
--- a/salt/modules/boto_dynamodb.py
+++ b/salt/modules/boto_dynamodb.py
@@ -74,7 +74,7 @@ def __virtual__():
     '''
     if not HAS_BOTO:
         return False
-    __utils__['boto.assign_funcs'](__name__, 'dynamodb')
+    __utils__['boto.assign_funcs'](__name__, 'dynamodb2')
     return True
 
 


### PR DESCRIPTION
The `boto_dynamodb` module was using the layer1 abstractions after the refactor to `utils.boto`. It originally was using the layer2 abstractions: https://github.com/saltstack/salt/commit/5f7bd4840a37a3e0e9901eb6f37bd1ec5beb13f0

Noticed this after trying to run:

``` bash
salt 'salt-master' boto_dynamodb.exists salt-master-store
```

This returned:

``` bash
salt-master:
    Passed invalid arguments to boto_dynamodb.exists: list indices must be integers, not str

        Check to see if a table exists.

        CLI Example:

        .. code-block:: bash

            salt myminion boto_dynamodb.exists table_name region=us-east-1
```

This was due to the layer1 abstractions that return a list of tables instead of a dictionary (which the salt module was expecting). With the layer2 abstraction change was tested successfully against `create_table`, `exist` and `delete` in the `boto_dynamodb` module:

``` bash
~# salt salt-master boto_dynamodb.create_table salt-master-store1 hash_key=id hash_key_data_type=N range_key=created_at range_key_data_type=N read_capacity_units=1 write_capacity_units=1
salt-master:
    True

~# salt salt-master boto_dynamodb.exists salt-master-store1
salt-master:
    True

~# salt salt-master boto_dynamodb.delete salt-master-store1                                                                                                                                     
salt-master:
    True
```

Salt versions:

``` bash
Salt Version:
           Salt: 2015.8.0rc3-174-g35a5fad

Dependency Versions:
         Jinja2: 2.7.2
       M2Crypto: 0.21.1
           Mako: Not Installed
         PyYAML: 3.10
          PyZMQ: 14.0.1
         Python: 2.7.6 (default, Jun 22 2015, 17:58:13)
           RAET: Not Installed
        Tornado: 4.2.1
            ZMQ: 4.0.4
           cffi: Not Installed
       cherrypy: Not Installed
       dateutil: Not Installed
          gitdb: Not Installed
      gitpython: Not Installed
          ioflo: Not Installed
        libnacl: Not Installed
   msgpack-pure: Not Installed
 msgpack-python: 0.3.0
   mysql-python: Not Installed
      pycparser: Not Installed
       pycrypto: 2.6.1
         pygit2: Not Installed
   python-gnupg: Not Installed
          smmap: Not Installed
        timelib: Not Installed

System Versions:
           dist: Ubuntu 14.04 trusty
        machine: x86_64
        release: 3.13.0-52-generic
         system: Ubuntu 14.04 trusty
```
