### PR TITLE
Fix broken link to git-config(1) docs

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -3342,6 +3342,7 @@ def worktree_prune(cwd,
         .. versionadded:: 2015.8.0
 
     .. _`git-worktree(1)`: http://git-scm.com/docs/git-worktree
+    .. _`git-config(1)`: http://git-scm.com/docs/git-config/2.5.1
 
 
     CLI Examples:


### PR DESCRIPTION
Note that I am linking directly to the documentation for Git 2.5.1 because of
a bug on git-scm.com, reported upstream as https://github.com/git/git-scm.com/issues/591.
