### PR TITLE
don't show diff for test run if show_diff=False

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1468,6 +1468,8 @@ def managed(name,
             if ret['changes']:
                 ret['result'] = None
                 ret['comment'] = 'The file {0} is set to be changed'.format(name)
+                if not show_diff:
+                    ret['changes']['diff'] = '<show_diff=False>'
             else:
                 ret['result'] = True
                 ret['comment'] = 'The file {0} is in the correct state'.format(name)


### PR DESCRIPTION
if the idea behind `show_diff` is security, test run should not print diff either
