### PR TITLE
Fix #27108: TypeError in direct_call executor if kwargs include "opts"

### DIFF
--- a/salt/executors/direct_call.py
+++ b/salt/executors/direct_call.py
@@ -17,7 +17,7 @@ class DirectCallExecutor(ModuleExecutorBase):
     Directly calls the given function with arguments
     '''
 
-    def __init__(self, opts, data, func, *args, **kwargs):
+    def __init__(self, opts, data, func, args, kwargs):
         '''
         Constructor
         '''

--- a/salt/executors/sudo.py
+++ b/salt/executors/sudo.py
@@ -60,7 +60,7 @@ class SudoExecutor(ModuleExecutorBase):
     being run on ``sudo_minion``.
     '''
 
-    def __init__(self, opts, data, func, *args, **kwargs):
+    def __init__(self, opts, data, func, args, kwargs):
         '''
         Constructor
         '''

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1007,7 +1007,7 @@ class Minion(MinionBase):
                     executors[-1] = 'sudo.get'
                 # Get the last one that is function executor
                 executor = minion_instance.executors[
-                    "{0}".format(executors.pop())](opts, data, func, *args, **kwargs)
+                    "{0}".format(executors.pop())](opts, data, func, args, kwargs)
                 # Instantiate others from bottom to the top
                 for executor_name in reversed(executors):
                     executor = minion_instance.executors["{0}".format(executor_name)](opts, data, executor)


### PR DESCRIPTION
Pass function arguments to executor as a collections not as executor args.
#27108
