### PR TITLE
Port 'TCP' transport to work on Windows

### DIFF
--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -53,13 +53,25 @@ class IPCServer(object):
 
         Blocks until socket is established
 
-        :param str socket_path: Path on the filesystem for the socket to bind to.
-                                This socket does not need to exist prior to calling
-                                this method, but parent directories should.
+        :param str/int socket_path: Path on the filesystem for the
+                                    socket to bind to. This socket does
+                                    not need to exist prior to calling
+                                    this method, but parent directories
+                                    should.
+                                    It may also be of type 'int', in
+                                    which case it is used as the port
+                                    for a tcp localhost connection.
         '''
         # Start up the ioloop
         log.trace('IPCServer: binding to socket: {0}'.format(self.socket_path))
-        self.sock = tornado.netutil.bind_unix_socket(self.socket_path)
+        if isinstance(self.socket_path, int):
+            self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            self.sock.setblocking(0)
+            self.sock.bind(('127.0.0.1', self.socket_path))
+            self.sock.listen(128)
+        else:
+            self.sock = tornado.netutil.bind_unix_socket(self.socket_path)
 
         tornado.netutil.add_accept_handler(
             self.sock,
@@ -143,9 +155,12 @@ class IPCClient(object):
     server/client implementation.
 
     :param IOLoop io_loop: A Tornado ioloop to handle scheduling
-    :param str socket_path: A path on the filesystem where a socket
-                            belonging to a running IPCServer can be
-                            found.
+    :param str/int socket_path: A path on the filesystem where a socket
+                                belonging to a running IPCServer can be
+                                found.
+                                It may also be of type 'int', in which
+                                case it is used as the port for a tcp
+                                localhost connection.
     '''
 
     # Create singleton map between two sockets
@@ -158,7 +173,7 @@ class IPCClient(object):
         loop_instance_map = IPCClient.instance_map[io_loop]
 
         # FIXME
-        key = socket_path
+        key = str(socket_path)
 
         if key not in loop_instance_map:
             log.debug('Initializing new IPCClient for path: {0}'.format(key))
@@ -213,8 +228,15 @@ class IPCClient(object):
         '''
         Connect to a running IPCServer
         '''
+        if isinstance(self.socket_path, int):
+            sock_type = socket.AF_INET
+            sock_addr = ('127.0.0.1', self.socket_path)
+        else:
+            sock_type = socket.AF_UNIX
+            sock_addr = self.socket_path
+
         self.stream = IOStream(
-            socket.socket(socket.AF_UNIX, socket.SOCK_STREAM),
+            socket.socket(sock_type, socket.SOCK_STREAM),
             io_loop=self.io_loop,
         )
         while True:
@@ -222,7 +244,7 @@ class IPCClient(object):
                 break
             try:
                 log.trace('IPCClient: Connecting to socket: {0}'.format(self.socket_path))
-                yield self.stream.connect(self.socket_path)
+                yield self.stream.connect(sock_addr)
                 self._connecting_future.set_result(True)
                 break
             except Exception as e:

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -234,13 +234,19 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
     # TODO: opts!
     backlog = 5
 
+    def __init__(self, opts):
+        salt.transport.server.ReqServerChannel.__init__(self, opts)
+        self._socket = None
+
     @property
     def socket(self):
         return self._socket
 
     def close(self):
-        self.socket.shutdown(socket.SHUT_RDWR)
-        self.socket.close()
+        if self._socket is not None:
+            self._socket.shutdown(socket.SHUT_RDWR)
+            self._socket.close()
+            self._socket = None
 
     def __del__(self):
         self.close()
@@ -250,10 +256,6 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
         Pre-fork we need to create the zmq router device
         '''
         salt.transport.mixins.auth.AESReqServerMixin.pre_fork(self, process_manager)
-        self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self._socket.setblocking(0)
-        self._socket.bind((self.opts['interface'], int(self.opts['ret_port'])))
 
     def post_fork(self, payload_handler, io_loop):
         '''
@@ -262,11 +264,15 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
 
         payload_handler: function to call with your payloads
         '''
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._socket.setblocking(0)
+        self._socket.bind((self.opts['interface'], int(self.opts['ret_port'])))
         self.payload_handler = payload_handler
         self.io_loop = io_loop
         self.req_server = SaltMessageServer(self.handle_message, io_loop=self.io_loop)
-        self.req_server.add_socket(self.socket)
-        self.socket.listen(self.backlog)
+        self.req_server.add_socket(self._socket)
+        self._socket.listen(self.backlog)
 
         self.serial = salt.payload.Serial(self.opts)
         salt.transport.mixins.auth.AESReqServerMixin.post_fork(self, payload_handler, io_loop)
@@ -392,6 +398,7 @@ class SaltMessageClient(object):
         self.send_timeout_map = {}  # request_id -> timeout_callback
 
         self._connecting_future = self.connect()
+        self._read_until_future = None
         self.io_loop.spawn_callback(self._stream_return)
 
         self._on_recv = None
@@ -402,6 +409,14 @@ class SaltMessageClient(object):
         self._closing = True
         if hasattr(self, '_stream') and not self._stream.closed():
             self._stream.close()
+            if self._read_until_future is not None:
+                # This will prevent this message from showing up:
+                # '[ERROR   ] Future exception was never retrieved:
+                # StreamClosedError'
+                # This happens because the logic is always waiting to read
+                # the next message and the associated read future is marked
+                # 'StreamClosedError' when the stream is closed.
+                self._read_until_future.exc_info()
 
     def __del__(self):
         self.destroy()
@@ -448,7 +463,8 @@ class SaltMessageClient(object):
             yield self._connecting_future
         while True:
             try:
-                framed_msg_len = yield self._stream.read_until(' ')
+                self._read_until_future = self._stream.read_until(' ')
+                framed_msg_len = yield self._read_until_future
                 framed_msg_raw = yield self._stream.read_bytes(int(framed_msg_len.strip()))
                 framed_msg = msgpack.loads(framed_msg_raw)
                 header = framed_msg['head']
@@ -602,6 +618,12 @@ class TCPPubServerChannel(salt.transport.server.PubServerChannel):
         self.serial = salt.payload.Serial(self.opts)  # TODO: in init?
         self.io_loop = io_loop or tornado.ioloop.IOLoop.current()
 
+    def __setstate__(self, state):
+        self.__init__(state['opts'])
+
+    def __getstate__(self):
+        return {'opts': self.opts}
+
     def _publish_daemon(self):
         '''
         Bind to the interface specified in the configuration file
@@ -613,7 +635,11 @@ class TCPPubServerChannel(salt.transport.server.PubServerChannel):
         pub_server.listen(int(self.opts['publish_port']), address=self.opts['interface'])
 
         # Set up Salt IPC server
-        pull_uri = os.path.join(self.opts['sock_dir'], 'publish_pull.ipc')
+        if self.opts.get('ipc_mode', '') == 'tcp':
+            pull_uri = int(self.opts.get('tcp_master_publish_pull', 4514))
+        else:
+            pull_uri = os.path.join(self.opts['sock_dir'], 'publish_pull.ipc')
+
         pull_sock = salt.transport.ipc.IPCMessageServer(
             pull_uri,
             io_loop=self.io_loop,
@@ -652,7 +678,10 @@ class TCPPubServerChannel(salt.transport.server.PubServerChannel):
             log.debug("Signing data packet")
             payload['sig'] = salt.crypt.sign_message(master_pem_path, payload['load'])
         # Use the Salt IPC server
-        pull_uri = os.path.join(self.opts['sock_dir'], 'publish_pull.ipc')
+        if self.opts.get('ipc_mode', '') == 'tcp':
+            pull_uri = int(self.opts.get('tcp_master_publish_pull', 4514))
+        else:
+            pull_uri = os.path.join(self.opts['sock_dir'], 'publish_pull.ipc')
         # TODO: switch to the actual async interface
         #pub_sock = salt.transport.ipc.IPCMessageClient(self.opts, io_loop=self.io_loop)
         pub_sock = salt.utils.async.SyncWrapper(


### PR DESCRIPTION
salt/transport/ipc.py:
- The 'socket_path' parameter may also be of type 'int'. If this is the
  case, it will be used as the port for a tcp localhost connection.

salt/transport/tcp.py
- If opt['ipc_mode'] is 'tcp', then using
  opts['tcp_master_publish_pull'] to get the port number to be used for
  the tcp localhost connection. This is similar to the zeromq logic.
- In TCPReqServerChannel, moving socket creation from pre_fork to
  post_fork. It isn't needed in pre_fork (the parent process doesn't
  need to access it), and on Windows, then spawning a process, the
  'socket' is not picklable. Making sure close() will still work in
  both parent and child processes by initializing '_socket' to None and
  closing only if it isn't None.
- Avoiding this error message that seems to always occur when
  SaltMessageClient is destroyed:
  '[ERROR   ] Future exception was never retrieved: StreamClosedError'
  This may be related with issue #25718.
  This happens because the logic is always waiting to read the next
  message and the associated read future is marked 'StreamClosedError'
  when the stream is closed.

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
