### PR TITLE
Pass file pointers to the serialize load functions.

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -4289,10 +4289,10 @@ def serialize(name,
         if os.path.isfile(name):
             if formatter == 'yaml':
                 with salt.utils.fopen(name, 'r') as fhr:
-                    existing_data = yaml.safe_load(fhr.read())
+                    existing_data = yaml.safe_load(fhr)
             elif formatter == 'json':
                 with salt.utils.fopen(name, 'r') as fhr:
-                    existing_data = json.load(fhr.read())
+                    existing_data = json.load(fhr)
             else:
                 return {'changes': {},
                         'comment': ('{0} format is not supported for merging'


### PR DESCRIPTION
When loading existing data for merging, the yaml/json load functions expect to receive an open file reference . Currently they are passed a string of the already read data, which results in an AttributeError.
