### PR TITLE
Fixed problem with add/remove path

### DIFF
--- a/salt/modules/win_path.py
+++ b/salt/modules/win_path.py
@@ -72,7 +72,7 @@ def get_path():
 
         salt '*' win_path.get_path
     '''
-    ret = __salt__['reg.read_key']('HKEY_LOCAL_MACHINE',
+    ret = __salt__['reg.read_value']('HKEY_LOCAL_MACHINE',
                                    'SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
                                    'PATH')
     if isinstance(ret, dict):
@@ -149,8 +149,8 @@ def add(path, index=0):
     regedit = __salt__['reg.set_value'](
         'HKEY_LOCAL_MACHINE',
         'SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
-        ';'.join(sysPath),
         'PATH',
+        ';'.join(sysPath),
         'REG_EXPAND_SZ'
     )
 
@@ -186,8 +186,8 @@ def remove(path):
     regedit = __salt__['reg.set_value'](
         'HKEY_LOCAL_MACHINE',
         'SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
-        ';'.join(sysPath),
         'PATH',
+        ';'.join(sysPath),
         'REG_EXPAND_SZ'
     )
     if regedit:

--- a/tests/unit/modules/win_path_test.py
+++ b/tests/unit/modules/win_path_test.py
@@ -70,7 +70,7 @@ class WinPathTestCase(TestCase):
             Test to Returns the system path
         '''
         mock = MagicMock(return_value={'vdata': 'c:\\salt'})
-        with patch.dict(win_path.__salt__, {'reg.read_key': mock}):
+        with patch.dict(win_path.__salt__, {'reg.read_value': mock}):
             self.assertListEqual(win_path.get_path(), ['c:\\salt'])
 
     def test_exists(self):


### PR DESCRIPTION
Use `reg.read_value` instead of `reg.read_key`
Someone changed to `reg.set_value` but failed to change the order of the arguments to match the new function.
Tested add/remove path

Fixes: #27133 
