### PR TITLE
Runner retcodes [WIP]

### DIFF
--- a/salt/cli/run.py
+++ b/salt/cli/run.py
@@ -37,11 +37,14 @@ class SaltRun(parsers.SaltRunOptionParser):
             if check_user(self.config['user']):
                 pr = activate_profile(profiling_enabled)
                 try:
-                    runner.run()
+                    ret = runner.run()
                 finally:
                     output_profile(
                         pr,
                         stats_path=self.options.profiling_path,
                         stop=True)
+                    if isinstance(ret, dict) and 'retcode' in ret:
+                        self.exit(ret['retcode'])
+
         except SaltClientError as exc:
             raise SystemExit(str(exc))

--- a/salt/runners/state.py
+++ b/salt/runners/state.py
@@ -54,6 +54,11 @@ def orchestrate(mods, saltenv='base', test=None, exclude=None, pillar=None):
             exclude,
             pillar=pillar)
     ret = {minion.opts['id']: running, 'outputter': 'highstate'}
+    res = salt.utils.check_state_result(ret)
+    if salt.utils.check_state_result(ret):
+        ret['retcode'] = 0
+    else:
+        ret['retcode'] = 1
     return ret
 
 # Aliases for orchestrate runner


### PR DESCRIPTION
This illustrates one possible, very simple way of delivering retcodes with runners.

I tried to avoid any magic and more or less mirror the way we deliver retcodes in other places. The major difference here is that we can't really reach into the module execution to pull out `__context__`, so we have to do a little dance up in the runner to re-evaluate it and inject it into the return.

This potentially means that the same retcode logic could exist at multiple layers, but this might not be all bad, since runners are very free-form and would often require that multiple module execution returns be evaluated in order to determine a retcode. I'm curious to hear feedback here.

Please give folks a few days to respond with thoughts before we get this in. Thanks!

cc: @jacksontj, @basepi, @terminalmage 

Refs #26499 
