### PR TITLE
fix restart_on_error

### DIFF
--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -270,12 +270,6 @@ class Minion(parsers.MinionOptionParser):  # pylint: disable=no-init
             if check_user(self.config['user']):
                 logger.info('The salt minion is starting up')
                 self.minion.tune_in()
-        except (KeyboardInterrupt, SaltSystemExit) as exc:
-            logger.warn('Stopping the Salt Minion')
-            if isinstance(exc, KeyboardInterrupt):
-                logger.warn('Exiting on Ctrl-c')
-            else:
-                logger.error(str(exc))
         finally:
             self.shutdown()
 

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -38,7 +38,7 @@ import salt.utils.rsax931
 import salt.utils.verify
 import salt.version
 from salt.exceptions import (
-    AuthenticationError, SaltClientError, SaltReqTimeoutError
+    AuthenticationError, SaltClientError, SaltReqTimeoutError, SaltSystemExit
 )
 
 import tornado.gen
@@ -550,7 +550,7 @@ class AsyncAuth(object):
                 'Salt Minion.\nThe master public key can be found '
                 'at:\n{1}'.format(salt.version.__version__, m_pub_fn)
             )
-            sys.exit(42)
+            raise SaltSystemExit('Invalid master key')
         if self.opts.get('syndic_master', False):  # Is syndic
             syndic_finger = self.opts.get('syndic_finger', self.opts.get('master_finger', False))
             if syndic_finger:

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -108,10 +108,14 @@ class AsyncRemotePillar(object):
                 'cmd': '_pillar'}
         if self.ext:
             load['ext'] = self.ext
-        ret_pillar = yield self.channel.crypted_transfer_decode_dictentry(
-            load,
-            dictkey='pillar',
-        )
+        try:
+            ret_pillar = yield self.channel.crypted_transfer_decode_dictentry(
+                load,
+                dictkey='pillar',
+            )
+        except:
+            log.exception('Exception getting pillar:')
+            raise SaltClientError('Exception getting pillar.')
 
         if not isinstance(ret_pillar, dict):
             msg = ('Got a bad pillar from master, type {0}, expecting dict: '


### PR DESCRIPTION
Removing the exception handling from salt/cli/daemons.py:Minion.start since it prevents these exceptions from triggering a restart in salt/scripts.py:minion_process

Replacing sys.exit(42) in salt/crypt.py:AsyncAuth.sign_in with raising a SaltSystemExit, so the daemon can get restarted by the same logic.

Reraising exceptions triggered by a failed pillar load as SaltClientError so the daemon doesn't die when a failed refresh_pillar occurs.

Ticket: https://github.com/saltstack/salt/issues/27127
