### PR TITLE
[2015.5] Add test.nop state

### DIFF
--- a/salt/states/test.py
+++ b/salt/states/test.py
@@ -8,6 +8,12 @@ Provide test case states that enable easy testing of things to do with
 
 .. code-block:: yaml
 
+    always-passes-with-any-kwarg:
+      test.nop:
+        - name: foo
+        - something: else
+        - foo: bar
+
     always-passes:
       test.succeed_without_changes:
         - name: foo

--- a/salt/states/test.py
+++ b/salt/states/test.py
@@ -43,6 +43,17 @@ from salt.exceptions import SaltInvocationError
 log = logging.getLogger(__name__)
 
 
+def nop(name, **kwargs):
+    '''
+    A no-op state that does nothing. Useful in conjunction with the `use`
+    requisite, or in templates which could otherwise be empty due to jinja
+    rendering
+
+    .. versionadded:: 2015.5.6
+    '''
+    return succeed_without_changes(name)
+
+
 def succeed_without_changes(name):
     '''
     Returns successful.
@@ -58,9 +69,6 @@ def succeed_without_changes(name):
         'result': True,
         'comment': 'Success!'
     }
-    if __opts__['test']:
-        ret['result'] = True
-        ret['comment'] = 'If we weren\'t testing, this would be a success!'
     return ret
 
 


### PR DESCRIPTION
A no-op state that does nothing. Useful in conjunction with the `use`
requisite, or in templates which could otherwise be empty due to jinja
rendering

Unlike test.succeed_without_changes, takes **kwargs to be more flexible.

Also removed the test stuff from succeed_without_changes. If a state
doesn't make changes, its behavior should be identical whether in test
mode or not.

Fixes #25423 
