### PR TITLE
Make get_event compatible with salt/client

### DIFF
--- a/salt/utils/raetevent.py
+++ b/salt/utils/raetevent.py
@@ -148,7 +148,7 @@ class RAETEvent(object):
         '''
         return raw
 
-    def get_event(self, wait=5, tag='', full=False):
+    def get_event(self, wait=5, tag='', match_type=None, full=False, no_block=None):
         '''
         Get a single publication.
         IF no publication available THEN block for up to wait seconds


### PR DESCRIPTION
Fixes error unexpected keyword argument for get_event() 
 File "/usr/local/lib/python2.7/site-packages/salt-2015.8.0-py2.7.egg/salt/client/**init**.py", line 823, in get_returns_no_block
    raw = self.event.get_event(wait=0.01, tag=tag, match_type=match_type, full=True, no_block=True)
TypeError: get_event() got an unexpected keyword argument 'match_type'
