### PR TITLE
fixes #27217 clear_old_remotes clears wrong directory (gitfs)

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -1609,7 +1609,7 @@ class GitBase(object):
                 pass
         to_remove = []
         for item in cachedir_ls:
-            if item in ('hash', 'refs'):
+            if item in ('gitfs', 'refs'):
                 continue
             path = os.path.join(self.cache_root, item)
             if os.path.isdir(path):


### PR DESCRIPTION
The hash directory is in the gitfs directory and gitfs directory is not excluded from the purge.
