### PR TITLE
salt.modules.disk.percent() throws KeyError when partition doesn't exist

### DIFF
--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -58,9 +58,9 @@ def usage(args=None):
     '''
     flags = _clean_flags(args, 'disk.usage')
     if not os.path.isfile('/etc/mtab') and __grains__['kernel'] == 'Linux':
-        log.warn('df cannot run without /etc/mtab')
+        log.error('df cannot run without /etc/mtab')
         if __grains__.get('virtual_subtype') == 'LXC':
-            log.warn('df command failed and LXC detected. If you are running '
+            log.error('df command failed and LXC detected. If you are running '
                      'a Docker container, consider linking /proc/mounts to '
                      '/etc/mtab or consider running Docker with -privileged')
         return {}
@@ -112,7 +112,7 @@ def usage(args=None):
                         'capacity': comps[4],
                 }
         except IndexError:
-            log.warn('Problem parsing disk usage information')
+            log.error('Problem parsing disk usage information')
             ret = {}
     return ret
 
@@ -159,7 +159,7 @@ def inodeusage(args=None):
                     'filesystem': comps[0],
                 }
         except (IndexError, ValueError):
-            log.warn('Problem parsing inode usage information')
+            log.error('Problem parsing inode usage information')
             ret = {}
     return ret
 
@@ -197,18 +197,21 @@ def percent(args=None):
             else:
                 ret[comps[5]] = comps[4]
         except IndexError:
-            log.warn('Problem parsing disk usage information')
+            log.error('Problem parsing disk usage information')
             ret = {}
-    if args:
+    if args and args not in ret:
+        log.error('Problem parsing disk usage information: Partition \'{0}\' does not exist!'.format(args))
+        ret = {}
+    elif args:
         return ret[args]
-    else:
-        return ret
+
+    return ret
 
 
 @decorators.which('blkid')
 def blkid(device=None):
     '''
-    Return block device attributes: UUID, LABEL, etc.  This function only works
+    Return block device attributes: UUID, LABEL, etc. This function only works
     on systems where blkid is available.
 
     CLI Example:


### PR DESCRIPTION
Thanks to @iigorr for reporting the issue!

Before:

```
# salt-call -l info disk.percent foo
[INFO    ] Executing command 'df -P' in directory '/root'
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
KeyError: 'foo'
Traceback (most recent call last):
  File "/bin/salt-call", line 11, in <module>
    salt_call()
  File "/usr/lib/python2.7/site-packages/salt/scripts.py", line 331, in salt_call
    client.run()
  File "/usr/lib/python2.7/site-packages/salt/cli/call.py", line 51, in run
    caller.run()
  File "/usr/lib/python2.7/site-packages/salt/cli/caller.py", line 133, in run
    ret = self.call()
  File "/usr/lib/python2.7/site-packages/salt/cli/caller.py", line 196, in call
    ret['return'] = func(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/salt/modules/disk.py", line 203, in percent
    return ret[args]
KeyError: 'foo'
Traceback (most recent call last):
  File "/bin/salt-call", line 11, in <module>
    salt_call()
  File "/usr/lib/python2.7/site-packages/salt/scripts.py", line 331, in salt_call
    client.run()
  File "/usr/lib/python2.7/site-packages/salt/cli/call.py", line 51, in run
    caller.run()
  File "/usr/lib/python2.7/site-packages/salt/cli/caller.py", line 133, in run
    ret = self.call()
  File "/usr/lib/python2.7/site-packages/salt/cli/caller.py", line 196, in call
    ret['return'] = func(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/salt/modules/disk.py", line 203, in percent
    return ret[args]
KeyError: 'foo'
```

After:

```
# salt-call -l info disk.percent foo
[INFO    ] Executing command 'df -P' in directory '/root'
[ERROR   ] Problem parsing disk usage information: Partition 'foo' does not exist!
local:
    ----------
```
#27239 should be a working test for this case.
