### PR TITLE
If two ssh keynames are found in DigitalOcean, abort and warn the user.

### DIFF
--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -560,10 +560,20 @@ def list_keypairs(call=None):
 
     items = query(method='account/keys')
     ret = {}
-    for keypair in items['ssh_keys']:
-        ret[keypair['name']] = {}
-        for item in six.iterkeys(keypair):
-            ret[keypair['name']][item] = str(keypair[item])
+    for key_pair in items['ssh_keys']:
+        name = key_pair['name']
+        if name in ret:
+            raise SaltCloudSystemExit(
+                'A duplicate key pair name, \'{0}\', was found in DigitalOcean\'s '
+                'key pair list. Please change the key name stored by DigitalOcean. '
+                'Be sure to adjust the value of \'ssh_key_file\' in your cloud '
+                'profile or provider configuration, if necessary.'.format(
+                    name
+                )
+            )
+        ret[name] = {}
+        for item in six.iterkeys(key_pair):
+            ret[name][item] = str(key_pair[item])
 
     return ret
 


### PR DESCRIPTION
Fixes #25079

DigitalOcean allows multiple ssh keys to be stored with the same name (though the fingerprints must be different). This leads to authentication problems as the key named in a salt-cloud config matches, but the private key doesn't match the public key. If this situation is encountered, salt-cloud will now exit.

Exiting out of the process instead of just logging a warning was chosen to avoid confusion as when listing keypairs, the keyname is overwritten by the last key pair on the list, which makes it look like only one key is present, but there are in fact multiple keys. It will also reduce confusion in situations where a keypair might work at some point, but not in others. 
