### PR TITLE
supports skip_verify option for zypper during package installation/update

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -511,6 +511,7 @@ def refresh_db():
 def install(name=None,
             refresh=False,
             fromrepo=None,
+            skip_verify=False,
             pkgs=None,
             sources=None,
             downloadonly=None,
@@ -540,6 +541,9 @@ def install(name=None,
 
     downloadonly
         Only download the packages, do not install.
+
+    skip_verify
+        Skip the GPG verification check (e.g., ``--no-gpg-checks``)
 
     version
         Can be either a version number, or the combination of a comparison
@@ -637,6 +641,8 @@ def install(name=None,
     cmd_install = ['zypper', '--non-interactive']
     if not refresh:
         cmd_install.append('--no-refresh')
+    if skip_verify:
+        cmd_install.append('--no-gpg-checks')
     cmd_install += ['install', '--name', '--auto-agree-with-licenses']
     if downloadonly:
         cmd_install.append('--download-only')
@@ -671,7 +677,7 @@ def install(name=None,
     return salt.utils.compare_dicts(old, new)
 
 
-def upgrade(refresh=True):
+def upgrade(refresh=True, skip_verify=False):
     '''
     Run a full system upgrade, a zypper upgrade
 
@@ -685,6 +691,13 @@ def upgrade(refresh=True):
     .. code-block:: bash
 
         salt '*' pkg.upgrade
+
+
+    Options:
+
+    skip_verify
+        Skip the GPG verification check (e.g., ``--no-gpg-checks``)
+
     '''
     ret = {'changes': {},
            'result': True,
@@ -694,7 +707,10 @@ def upgrade(refresh=True):
     if salt.utils.is_true(refresh):
         refresh_db()
     old = list_pkgs()
-    cmd = 'zypper --non-interactive update --auto-agree-with-licenses'
+    cmd = 'zypper --non-interactive'
+    if skip_verify:
+       cmd +=' --no-gpg-checks'
+    cmd += ' update --auto-agree-with-licenses'
     call = __salt__['cmd.run_all'](cmd, output_loglevel='trace')
     if call['retcode'] != 0:
         ret['result'] = False

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -511,10 +511,10 @@ def refresh_db():
 def install(name=None,
             refresh=False,
             fromrepo=None,
-            skip_verify=False,
             pkgs=None,
             sources=None,
             downloadonly=None,
+            skip_verify=False,
             **kwargs):
     '''
     Install the passed package(s), add refresh=True to run 'zypper refresh'

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -709,7 +709,7 @@ def upgrade(refresh=True, skip_verify=False):
     old = list_pkgs()
     cmd = 'zypper --non-interactive'
     if skip_verify:
-       cmd +=' --no-gpg-checks'
+        cmd += ' --no-gpg-checks'
     cmd += ' update --auto-agree-with-licenses'
     call = __salt__['cmd.run_all'](cmd, output_loglevel='trace')
     if call['retcode'] != 0:


### PR DESCRIPTION
zypper pkg module supports skip_verify only for repositories.
This patch adds skip_verify handling also for rpms, making non-repository package installation (e.g. custom rpms) possible.
