### PR TITLE
[Saltnado] - The CORS implementation was a bit naive about headers allowance.

### DIFF
--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -585,7 +585,13 @@ class BaseSaltAPIHandler(tornado.web.RequestHandler, SaltClientsMixIn):  # pylin
         Return CORS headers for preflight requests
         '''
         # Allow X-Auth-Token in requests
-        self.set_header('Access-Control-Allow-Headers', 'X-Auth-Token')
+        request_headers = self.request.headers.get('Access-Control-Request-Headers')
+        allowed_headers = request_headers.split(',')
+
+        # Filter allowed header here if needed.
+
+        # Allow request headers
+        self.set_header('Access-Control-Allow-Headers', ','.join(allowed_headers))
 
         # Allow X-Auth-Token in responses
         self.set_header('Access-Control-Expose-Headers', 'X-Auth-Token')

--- a/tests/unit/netapi/rest_tornado/test_handlers.py
+++ b/tests/unit/netapi/rest_tornado/test_handlers.py
@@ -295,10 +295,15 @@ class TestBaseSaltAPIHandler(SaltnadoTestCase):
         '''
         self._app.mod_opts['cors_origin'] = '*'
 
-        response = self.fetch('/', method='OPTIONS')
+        request_headers = 'X-Auth-Token, accept, content-type'
+        preflight_headers = {'Access-Control-Request-Headers': request_headers,
+                             'Access-Control-Request-Method': 'GET'}
+
+        response = self.fetch('/', method='OPTIONS', headers=preflight_headers)
         headers = response.headers
 
-        self.assertEqual(headers['Access-Control-Allow-Headers'], 'X-Auth-Token')
+        self.assertEqual(response.code, 204)
+        self.assertEqual(headers['Access-Control-Allow-Headers'], request_headers)
         self.assertEqual(headers['Access-Control-Expose-Headers'], 'X-Auth-Token')
         self.assertEqual(headers['Access-Control-Allow-Methods'], 'OPTIONS, GET, POST')
 


### PR DESCRIPTION
A preflight request send the list of headers of the final request
in a special header `Access-Control-Request-Headers`.
The server must returns the list of allowed header in the special header
`Access-Control-Allow-Headers` .

This PR just returns the whole list of headers but may allow filtering of some
of them quite easily. I'm not sure to see how filtering how headers may
impact security, if anyone has some leads.
