### PR TITLE
[Saltnado] - Add the support of login payload in JSON and YAML.

### DIFF
--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -706,12 +706,18 @@ class SaltAuthHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
             }}
         '''
         try:
-            creds = {'username': self.get_arguments('username')[0],
-                     'password': self.get_arguments('password')[0],
-                     'eauth': self.get_arguments('eauth')[0],
+            request_payload = self.deserialize(self.request.body)
+
+            if not isinstance(request_payload, dict):
+                self.send_error(400)
+                return
+
+            creds = {'username': request_payload['username'],
+                     'password': request_payload['password'],
+                     'eauth': request_payload['eauth'],
                      }
         # if any of the args are missing, its a bad request
-        except IndexError:
+        except KeyError:
             self.send_error(400)
             return
 


### PR DESCRIPTION
Login endpoint supported only application/x-www-form-urlencoded which may
be an useless limitation. This PR add support for more content-type,
JSON and YAML and every content-type supported by saltnado in general
as it uses the same deserialisation method than the lowstate deserialisation.
