### PR TITLE
Fix error handling in salt.modules.file.statvfs

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2965,7 +2965,7 @@ def statvfs(path):
             'f_blocks', 'f_bsize', 'f_favail', 'f_ffree', 'f_files', 'f_flag',
             'f_frsize', 'f_namemax'))
     except (OSError, IOError):
-        raise CommandExecutionError('Could not create {0!r}'.format(link))
+        raise CommandExecutionError('Could not statvfs {0!r}'.format(path))
     return False
 
 


### PR DESCRIPTION
The old error messaged printed the wrong variable and was also
misleading as statvfs does not create any files.

With current salt versions the following happens:
$ salt-call file.statvfs /does/not/exist
Error running 'file.statvfs': Could not create <function link at 0x7fe0d77a7f50>
