### PR TITLE
minion log_level default is 'info' not 'warning'

### DIFF
--- a/doc/ref/configuration/logging/index.rst
+++ b/doc/ref/configuration/logging/index.rst
@@ -56,7 +56,7 @@ Examples:
 ``log_level``
 -------------
 
-Default: ``warning``
+Default: ``info``
 
 The level of log record messages to send to the console.
 One of ``all``, ``garbage``, ``trace``, ``debug``, ``info``, ``warning``,
@@ -73,7 +73,7 @@ One of ``all``, ``garbage``, ``trace``, ``debug``, ``info``, ``warning``,
 ``log_level_logfile``
 ---------------------
 
-Default: ``warning``
+Default: ``info``
 
 The level of messages to send to the log file.
 One of ``all``, ``garbage``, ``trace``, ``debug``, ``info``, ``warning``,

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -1031,7 +1031,7 @@ Examples:
 ``log_level``
 -------------
 
-Default: ``warning``
+Default: ``info``
 
 The level of messages to send to the console. See also :conf_log:`log_level`.
 
@@ -1045,7 +1045,7 @@ The level of messages to send to the console. See also :conf_log:`log_level`.
 ``log_level_logfile``
 ---------------------
 
-Default: ``warning``
+Default: ``info``
 
 The level of messages to send to the log file. See also
 :conf_log:`log_level_logfile`. When it is not set explicitly


### PR DESCRIPTION
This is a minor documentation fix to indicate that the default setting for the minion's log_level is info, not warning.
