### PR TITLE
Feature add: Encrypted CLI pillar data

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -223,11 +223,15 @@ def high(data, test=False, queue=False, **kwargs):
         opts['test'] = __opts__.get('test', None)
 
     pillar = kwargs.get('pillar')
-    if pillar is not None and not isinstance(pillar, dict):
+    pillar_enc = kwargs.get('pillar_enc')
+    if pillar_enc is None \
+            and pillar is not None \
+            and not isinstance(pillar, dict):
         raise SaltInvocationError(
-            'Pillar data must be formatted as a dictionary'
+            'Pillar data must be formatted as a dictionary, unless pillar_enc '
+            'is specified.'
         )
-    st_ = salt.state.State(__opts__, pillar)
+    st_ = salt.state.State(__opts__, pillar, pillar_enc=pillar_enc)
     ret = st_.call_high(data)
     _set_retcode(ret)
     return ret
@@ -462,16 +466,29 @@ def highstate(test=None,
 
         Sets the ``test`` variable in the minion ``opts`` for the duration of
         the state run.
+
     pillar
-        Custom Pillar data can be passed with the ``pillar`` kwarg. Values
-        passed here will override hard-coded Pillar values.
-    queue : ``False``
+        Additional pillar data to use for this function. Any pillar keys
+        specified here will overwrite matching keys in the Pillar data.
+
+        .. versionchanged:: Boron
+            GPG-encrypted CLI Pillar data is now supported via the GPG
+            renderer. See :ref:`here <encrypted-cli-pillar-data>` for details.
+
+    pillar_enc
+        Specify which renderer to use to decrypt encrypted data located within
+        the ``pillar`` value. Currently, only ``gpg`` is supported.
+
+        .. versionadded:: Boron
+
+    queue : False
         Instead of failing immediately when another state run is in progress,
         queue the new state run to begin running once the other has finished.
 
         This option starts a new thread for each queued state run so use this
         option sparingly.
-    localconfig:
+
+    localconfig
         Instead of using running minion opts, load ``localconfig`` and merge that
         with the running minion opts. This functionality is intended for using
         "roots" of salt directories (with their own minion config, pillars,
@@ -524,15 +541,22 @@ def highstate(test=None,
         opts['environment'] = kwargs['saltenv']
 
     pillar = kwargs.get('pillar')
-    if pillar is not None and not isinstance(pillar, dict):
+    pillar_enc = kwargs.get('pillar_enc')
+    if pillar_enc is None \
+            and pillar is not None \
+            and not isinstance(pillar, dict):
         raise SaltInvocationError(
-            'Pillar data must be formatted as a dictionary'
+            'Pillar data must be formatted as a dictionary, unless pillar_enc '
+            'is specified.'
         )
 
     if 'pillarenv' in kwargs:
         opts['pillarenv'] = kwargs['pillarenv']
 
-    st_ = salt.state.HighState(opts, pillar, kwargs.get('__pub_jid'))
+    st_ = salt.state.HighState(opts,
+                               pillar,
+                               kwargs.get('__pub_jid'),
+                               pillar_enc=pillar_enc)
     st_.push_active()
     try:
         ret = st_.call_highstate(
@@ -575,15 +599,28 @@ def sls(mods,
 
         Sets the ``test`` variable in the minion ``opts`` for the duration of
         the state run.
+
     pillar
-        Custom Pillar data can be passed with the ``pillar`` kwarg. Values
-        passed here will override hard-coded Pillar values.
+        Additional pillar data to use for this function. Any pillar keys
+        specified here will overwrite matching keys in the Pillar data.
+
+        .. versionchanged:: Boron
+            GPG-encrypted CLI Pillar data is now supported via the GPG
+            renderer. See :ref:`here <encrypted-cli-pillar-data>` for details.
+
+    pillar_enc
+        Specify which renderer to use to decrypt encrypted data located within
+        the ``pillar`` value. Currently, only ``gpg`` is supported.
+
+        .. versionadded:: Boron
+
     queue : ``False``
         Instead of failing immediately when another state run is in progress,
         queue the new state run to begin running once the other has finished.
 
         This option starts a new thread for each queued state run so use this
         option sparingly.
+
     saltenv : None
         Specify a ``file_roots`` environment.
 
@@ -593,13 +630,16 @@ def sls(mods,
             Defaults to None. If no saltenv is specified, the minion config will
             be checked for a saltenv and if found, it will be used. If none is found,
             base will be used.
+
     pillarenv : None
         Specify a ``pillar_roots`` environment. By default all pillar environments
         merged together will be used.
+
     concurrent:
         WARNING: This flag is potentially dangerous. It is designed
         for use when multiple state runs can safely be run at the same
         Do not use this flag for performance optimization.
+
     localconfig:
         Instead of using running minion opts, load ``localconfig`` and merge that
         with the running minion opts. This functionality is intended for using
@@ -673,9 +713,13 @@ def sls(mods,
         opts['test'] = __opts__.get('test', None)
 
     pillar = kwargs.get('pillar')
-    if pillar is not None and not isinstance(pillar, dict):
+    pillar_enc = kwargs.get('pillar_enc')
+    if pillar_enc is None \
+            and pillar is not None \
+            and not isinstance(pillar, dict):
         raise SaltInvocationError(
-            'Pillar data must be formatted as a dictionary'
+            'Pillar data must be formatted as a dictionary, unless pillar_enc '
+            'is specified.'
         )
 
     serial = salt.payload.Serial(__opts__)
@@ -684,7 +728,10 @@ def sls(mods,
             '{0}.cache.p'.format(kwargs.get('cache_name', 'highstate'))
             )
 
-    st_ = salt.state.HighState(opts, pillar, kwargs.get('__pub_jid'))
+    st_ = salt.state.HighState(opts,
+                               pillar,
+                               kwargs.get('__pub_jid'),
+                               pillar_enc=pillar_enc)
 
     if kwargs.get('cache'):
         if os.path.isfile(cfn):
@@ -777,12 +824,16 @@ def top(topfn,
         opts['test'] = __opts__.get('test', None)
 
     pillar = kwargs.get('pillar')
-    if pillar is not None and not isinstance(pillar, dict):
+    pillar_enc = kwargs.get('pillar_enc')
+    if pillar_enc is None \
+            and pillar is not None \
+            and not isinstance(pillar, dict):
         raise SaltInvocationError(
-            'Pillar data must be formatted as a dictionary'
+            'Pillar data must be formatted as a dictionary, unless pillar_enc '
+            'is specified.'
         )
 
-    st_ = salt.state.HighState(opts, pillar)
+    st_ = salt.state.HighState(opts, pillar, pillar_enc=pillar_enc)
     st_.push_active()
     st_.opts['state_top'] = salt.utils.url.create(topfn)
     if saltenv:
@@ -818,12 +869,16 @@ def show_highstate(queue=False, **kwargs):
     if conflict is not None:
         return conflict
     pillar = kwargs.get('pillar')
-    if pillar is not None and not isinstance(pillar, dict):
+    pillar_enc = kwargs.get('pillar_enc')
+    if pillar_enc is None \
+            and pillar is not None \
+            and not isinstance(pillar, dict):
         raise SaltInvocationError(
-            'Pillar data must be formatted as a dictionary'
+            'Pillar data must be formatted as a dictionary, unless pillar_enc '
+            'is specified.'
         )
 
-    st_ = salt.state.HighState(__opts__, pillar)
+    st_ = salt.state.HighState(__opts__, pillar, pillar_enc=pillar_enc)
     st_.push_active()
     try:
         ret = st_.compile_highstate()
@@ -1006,15 +1061,19 @@ def show_sls(mods, saltenv='base', test=None, queue=False, env=None, **kwargs):
         opts['test'] = __opts__.get('test', None)
 
     pillar = kwargs.get('pillar')
-    if pillar is not None and not isinstance(pillar, dict):
+    pillar_enc = kwargs.get('pillar_enc')
+    if pillar_enc is None \
+            and pillar is not None \
+            and not isinstance(pillar, dict):
         raise SaltInvocationError(
-            'Pillar data must be formatted as a dictionary'
+            'Pillar data must be formatted as a dictionary, unless pillar_enc '
+            'is specified.'
         )
 
     if 'pillarenv' in kwargs:
         opts['pillarenv'] = kwargs['pillarenv']
 
-    st_ = salt.state.HighState(opts, pillar)
+    st_ = salt.state.HighState(opts, pillar, pillar_enc=pillar_enc)
     if isinstance(mods, six.string_types):
         mods = mods.split(',')
     st_.push_active()
@@ -1102,12 +1161,16 @@ def single(fun, name, test=None, queue=False, **kwargs):
         opts['test'] = __opts__.get('test', None)
 
     pillar = kwargs.get('pillar')
-    if pillar is not None and not isinstance(pillar, dict):
+    pillar_enc = kwargs.get('pillar_enc')
+    if pillar_enc is None \
+            and pillar is not None \
+            and not isinstance(pillar, dict):
         raise SaltInvocationError(
-            'Pillar data must be formatted as a dictionary'
+            'Pillar data must be formatted as a dictionary, unless pillar_enc '
+            'is specified.'
         )
 
-    st_ = salt.state.State(opts, pillar)
+    st_ = salt.state.State(opts, pillar, pillar_enc=pillar_enc)
     err = st_.verify_data(kwargs)
     if err:
         __context__['retcode'] = 1

--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-'''
+r'''
 Renderer that will decrypt GPG ciphers
 
 Any key in the SLS file can be a GPG cipher, and this renderer will decrypt it
@@ -11,56 +11,65 @@ The typical use-case would be to use ciphers in your pillar data, and keep a
 secret key on your master. You can put the public key in source control so that
 developers can add new secrets quickly and easily.
 
-This renderer requires the gpg binary.
+This renderer requires the gpg_ binary. No python libraries are required as of
+the 2015.8.0 release.
 
-**No python libraries are required as of the Beryllium release.**
+.. _gpg: https://gnupg.org
 
-To set things up, you will first need to generate a keypair. On your master,
-run:
+Setup
+-----
 
-.. code-block:: shell
+To set things up, first generate a keypair. On the master, run the following:
+
+.. code-block:: bash
 
     # mkdir -p /etc/salt/gpgkeys
     # chmod 0700 /etc/salt/gpgkeys
     # gpg --gen-key --homedir /etc/salt/gpgkeys
 
-Do not supply a password for your keypair, and use a name that makes sense
-for your application. Be sure to back up your gpg directory someplace safe!
+Do not supply a password for the keypair, and use a name that makes sense for
+your application. Be sure to back up the ``gpgkeys`` directory someplace safe!
 
 .. note::
     Unfortunately, there are some scenarios - for example, on virtual machines
     which don’t have real hardware - where insufficient entropy causes key
-    generation to be extremely slow. If you come across this problem, you should
-    investigate means of increasing the system entropy. On virtualised Linux
-    systems, this can often be achieved by installing the rng-tools package.
+    generation to be extremely slow. In these cases, there are usually means of
+    increasing the system entropy. On virtualised Linux systems, this can often
+    be achieved by installing the ``rng-tools`` package.
 
-To retrieve the public key:
 
-.. code-block:: shell
+Export the Public Key
+---------------------
 
-    # gpg --homedir /etc/salt/gpgkeys --armor --export <KEY-NAME> \
-        > exported_pubkey.gpg
+.. code-block:: bash
 
-Now, to encrypt secrets, copy the public key to your local machine and run:
+    # gpg --homedir /etc/salt/gpgkeys --armor --export <KEY-NAME> > exported_pubkey.gpg
 
-.. code-block:: shell
+
+Import the Public Key
+---------------------
+
+To encrypt secrets, copy the public key to your local machine and run:
+
+.. code-block:: bash
 
     $ gpg --import exported_pubkey.gpg
 
 To generate a cipher from a secret:
 
-.. code-block:: shell
+.. code-block:: bash
 
-   $ echo -n "supersecret" | gpg --armor --encrypt -r <KEY-name>
+   $ echo -n "supersecret" | gpg --armor --batch --trust-model always --encrypt -r <KEY-name>
 
 To apply the renderer on a file-by-file basis add the following line to the
 top of any pillar with gpg data in it:
 
-    .. code-block:: yaml
+.. code-block:: yaml
 
-        #!yaml|gpg
+    #!yaml|gpg
 
-Now with your renderer configured, you can include your ciphers in your pillar data like so:
+Now with your renderer configured, you can include your ciphers in your pillar
+data like so:
 
 .. code-block:: yaml
 
@@ -77,9 +86,126 @@ Now with your renderer configured, you can include your ciphers in your pillar d
       m4wBkfCAd8Eyo2jEnWQcM4TcXiF01XPL4z4g1/9AAxh+Q4d8RIRP4fbw7ct4nCJv
       Gr9v2DTF7HNigIMl4ivMIn9fp+EZurJNiQskLgNbktJGAeEKYkqX5iCuB1b693hJ
       FKlwHiJt5yA8X2dDtfk8/Ph1Jx2TwGS+lGjlZaNqp3R1xuAZzXzZMLyZDe5+i3RJ
-      skqmFTbOiA==
-      =Eqsm
+      skqmFTbOiA===Eqsm
       -----END PGP MESSAGE-----
+
+
+.. _encrypted-cli-pillar-data
+
+Encrypted CLI Pillar Data
+-------------------------
+
+.. versionadded:: Boron
+
+Functions like :py:func:`state.highstate <salt.modules.state.highstate>` and
+:py:func:`state.sls <salt.modules.state.sls>` allow for pillar data to be
+passed on the CLI.
+
+.. code-block:: bash
+
+    salt myminion state.highstate pillar="{'mypillar': 'foo'}"
+
+Starting with the Boron release of Salt, it is now possible for this pillar
+data to be GPG-encrypted, and to use the GPG renderer to decrypt it.
+
+
+Replacing Newlines
+******************
+
+To pass encrypted pillar data on the CLI, the ciphertext must have its newlines
+replaced with a literal backslash-n (``\n``), as newlines are not supported
+within Salt CLI arguments. There are a number of ways to do this:
+
+With awk or Perl:
+
+.. code-block:: bash
+
+    # awk
+    ciphertext=`echo -n "supersecret" | gpg --armor --batch --trust-model always --encrypt -r user@domain.com | awk '{printf "%s\\n",$0} END {print ""}'`
+    # Perl
+    ciphertext=`echo -n "supersecret" | gpg --armor --batch --trust-model always --encrypt -r user@domain.com | perl -pe 's/\n/\\n/g'`
+
+With Python:
+
+.. code-block:: python
+
+    import subprocess
+
+    secret, stderr = subprocess.Popen(
+        ['gpg', '--armor', '--batch', '--trust-model', 'always', '--encrypt',
+         '-r', 'user@domain.com'],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE).communicate(input='supersecret')
+
+    if secret:
+        print(secret.replace('\n', r'\n'))
+    else:
+        raise ValueError('No ciphertext found: {0}'.format(stderr))
+
+.. code-block:: bash
+
+    ciphertext=`python /path/to/script.py`
+
+
+The ciphertext can be included in the CLI pillar data like so:
+
+.. code-block:: bash
+
+    salt myminion state.sls secretstuff pillar_enc=gpg pillar="{secret_pillar: '$ciphertext'}"
+
+The ``pillar_enc=gpg`` argument tells Salt that there is GPG-encrypted pillar
+data, so that the CLI pillar data is passed through the GPG renderer, which
+will iterate recursively though the CLI pillar dictionary to decrypt any
+encrypted values.
+
+
+Encrypting the Entire CLI Pillar Dictionary
+*******************************************
+
+If several values need to be encrypted, it may be more convenient to encrypt
+the entire CLI pillar dictionary. Again, this can be done in several ways:
+
+With awk or Perl:
+
+.. code-block:: bash
+
+    # awk
+    ciphertext=`echo -n "{'secret_a': 'CorrectHorseBatteryStaple', 'secret_b': 'GPG is fun!'}" | gpg --armor --batch --trust-model always --encrypt -r user@domain.com | awk '{printf "%s\\n",$0} END {print ""}'`
+    # Perl
+    ciphertext=`echo -n "{'secret_a': 'CorrectHorseBatteryStaple', 'secret_b': 'GPG is fun!'}" | gpg --armor --batch --trust-model always --encrypt -r user@domain.com | perl -pe 's/\n/\\n/g'`
+
+With Python:
+
+.. code-block:: python
+
+    import subprocess
+
+    pillar_data = {'secret_a': 'CorrectHorseBatteryStaple',
+                   'secret_b': 'GPG is fun!'}
+
+    secret, stderr = subprocess.Popen(
+        ['gpg', '--armor', '--batch', '--trust-model', 'always', '--encrypt',
+         '-r', 'user@domain.com'],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE).communicate(input=repr(pillar_data))
+
+    if secret:
+        print(secret.replace('\n', r'\n'))
+    else:
+        raise ValueError('No ciphertext found: {0}'.format(stderr))
+
+.. code-block:: bash
+
+    ciphertext=`python /path/to/script.py`
+
+With the entire pillar dictionary now encrypted, it can be included in the CLI
+pillar data like so:
+
+.. code-block:: bash
+
+    salt myminion state.sls secretstuff pillar_enc=gpg pillar="$ciphertext"
 '''
 
 # Import python libs

--- a/tests/unit/modules/state_test.py
+++ b/tests/unit/modules/state_test.py
@@ -45,7 +45,7 @@ class MockState(object):
         '''
         flag = None
 
-        def __init__(self, opts, pillar=False):
+        def __init__(self, opts, pillar=False, pillar_enc=None):
             pass
 
         def verify_data(self, data):
@@ -133,10 +133,10 @@ class MockState(object):
         flag = False
         opts = {'state_top': ""}
 
-        def __init__(self, opts, pillar=None, kwargs=None):
-            pillar = pillar
-            kwargs = kwargs
-            self.state = MockState.State(opts)
+        def __init__(self, opts, pillar=None, jid=None, pillar_enc=None):
+            self.state = MockState.State(opts,
+                                         pillar=pillar,
+                                         pillar_enc=pillar_enc)
 
         def render_state(self, sls, saltenv, mods, matches, local=False):
             '''


### PR DESCRIPTION
Assume the following SLS:

``` bash
# cat srv/salt/test.sls
test:
  cmd.run:
    - name: echo {{ salt['pillar.get']('gpg_pillar', 'Crap! No worky.') }}
```

The pillar variable is not defined, so it will not be found by pillar.get:

``` bash
# salt-call -l quiet pillar.get gpg_pillar, 'not defined'
local:
    not defined
# salt-call -l quiet state.sls test
local:
----------
          ID: test
    Function: cmd.run
        Name: echo Crap! No worky.
      Result: True
     Comment: Command "echo Crap! No worky." run
     Started: 22:14:00.575690
    Duration: 7.347 ms
     Changes:
              ----------
              pid:
                  13523
              retcode:
                  0
              stderr:
              stdout:
                  Crap! No worky.

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time:   7.347 ms
```

Now, let's encrypt some text and encrypt it, then replace all newlines with "\n" to keep newline characters from the ciphertext from ending up on the CLI (which would mess with our arg parsing).

``` bash
# echo -n foo | gpg --armor --encrypt -r AAAAA | awk '{printf "%s\\n",$0} END {print ""}' >/tmp/cipher.txt
gpg: C789DCD1: There is no assurance this key belongs to the named user
sub  rsa2048/C789DCD1 2015-09-17 AAAAA <A@B.C>
 Primary key fingerprint: B178 8700 CC2A F28D 2458  86E7 825A 22B1 1C6A ABEE
      Subkey fingerprint: 1DED 717A 3108 633A C6CE  586C 28FE CB31 C789 DCD1

It is NOT certain that the key belongs to the person named
in the user ID.  If you *really* know what you are doing,
you may answer the next question with yes.

Use this key anyway? (y/N) y
```

Now, re-run the state.sls with the new `pillar_enc` argument, and include the ciphertext we created earlier as the value for the `gpg_pillar` key, and voila!

``` bash
# salt-call -l quiet state.sls test pillar_enc=gpg pillar="{gpg_pillar: '`cat /tmp/cipher.txt`'}"
local:
----------
          ID: test
    Function: cmd.run
        Name: echo foo
      Result: True
     Comment: Command "echo foo" run
     Started: 22:11:40.456325
    Duration: 7.66 ms
     Changes:
              ----------
              pid:
                  12734
              retcode:
                  0
              stderr:
              stdout:
                  foo

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time:   7.660 ms
```

This even works if you were to encrypt some YAML:

``` bash
# echo "gpg_pillar: bar" | gpg --armor --encrypt -r AAAAA | awk '{printf "%s\\n",$0} END {print ""}' >/tmp/cipher.txt
gpg: C789DCD1: There is no assurance this key belongs to the named user
sub  rsa2048/C789DCD1 2015-09-17 AAAAA <A@B.C>
 Primary key fingerprint: B178 8700 CC2A F28D 2458  86E7 825A 22B1 1C6A ABEE
      Subkey fingerprint: 1DED 717A 3108 633A C6CE  586C 28FE CB31 C789 DCD1

It is NOT certain that the key belongs to the person named
in the user ID.  If you *really* know what you are doing,
you may answer the next question with yes.

Use this key anyway? (y/N) y
# salt-call -l quiet state.sls test pillar_enc=gpg pillar="`cat /tmp/cipher.txt`"
local:
----------
          ID: test
    Function: cmd.run
        Name: echo bar
      Result: True
     Comment: Command "echo bar" run
     Started: 22:24:07.835792
    Duration: 11.336 ms
     Changes:
              ----------
              pid:
                  16455
              retcode:
                  0
              stderr:
              stdout:
                  bar

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time:  11.336 ms
```
