### PR TITLE
Don't modify return results in splay.

### DIFF
--- a/salt/executors/splay.py
+++ b/salt/executors/splay.py
@@ -84,8 +84,4 @@ class SplayExecutor(ModuleExecutorBase):
         my_delay = self._calc_splay(__grains__['id'], splaytime=self.splaytime)
         log.debug("Splay is sleeping {0} secs on {1}".format(my_delay, self.fun_name))
         time.sleep(my_delay)
-        result = self.executor.execute()
-        if not isinstance(result, dict):
-            result = {'result': result}
-        result['splaytime'] = str(my_delay)
-        return result
+        return self.executor.execute()


### PR DESCRIPTION
Splay originally was converting return to dict and adding 'splay' key to
the return result. That breaks salt scripts.
If we need to provide executors a way to return something more than result it's better to either return a tuple (orig return, executor metadata dict) or declare functions always return dict with mandatory key 'result'.
