### PR TITLE
Pass ca_bundle for windows (fixes SSL Error)

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -404,6 +404,9 @@ def query(url,
                 log.error('The client-side certificate path that was passed is '
                           'not valid: {0}'.format(cert))
 
+        if salt.utils.is_windows():
+            req_kwargs['ca_certs'] = ca_bundle
+
         max_body = opts.get('http_max_body', salt.config.DEFAULT_MINION_OPTS['http_max_body'])
         timeout = opts.get('http_request_timeout', salt.config.DEFAULT_MINION_OPTS['http_request_timeout'])
 

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -404,7 +404,7 @@ def query(url,
                 log.error('The client-side certificate path that was passed is '
                           'not valid: {0}'.format(cert))
 
-        if salt.utils.is_windows():
+        if verify_ssl:
             req_kwargs['ca_certs'] = ca_bundle
 
         max_body = opts.get('http_max_body', salt.config.DEFAULT_MINION_OPTS['http_max_body'])


### PR DESCRIPTION
Fixes: #27081 

Pass ca_bundle to tornado HTTPClient function
Otherwise causes CERTIFICATE_VERIFY_FAILED error in windows
Python 2.7.8 and below don't verify certs, essentially trusting all certs. 2.7.9 and above do. This error only occurs with Python 2.7.9 and above.
