### PR TITLE
Fix osx sysctl notruncate

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -368,7 +368,7 @@ local job cache on the master
 ``master_job_cache``
 --------------------
 
-.. versionadded:: 2014.7
+.. versionadded:: 2014.7.0
 
 Default: 'local_cache'
 

--- a/doc/topics/mine/index.rst
+++ b/doc/topics/mine/index.rst
@@ -37,7 +37,7 @@ Mine Functions Aliases
 Function aliases can be used to provide usage intentions or to allow multiple
 calls of the same function with different arguments.
 
-.. versionadded:: 2014.7
+.. versionadded:: 2014.7.0
 
 .. code-block:: yaml
 

--- a/salt/modules/darwin_sysctl.py
+++ b/salt/modules/darwin_sysctl.py
@@ -175,9 +175,11 @@ def persist(name, value, config='/etc/sysctl.conf', apply_change=False):
                     return 'Already set'
                 new_line = '{0}={1}'.format(name, value)
                 nlines.append(new_line)
+                nlines.append('\n')
                 edited = True
     if not edited:
         nlines.append('{0}={1}'.format(name, value))
+        nlines.append('\n')
     with salt.utils.fopen(config, 'w+') as ofile:
         ofile.writelines(nlines)
     # If apply_change=True, apply edits to system

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -456,7 +456,7 @@ def interface(iface):
     '''
     Return the inet address for a given interface
 
-    .. versionadded:: 2014.7
+    .. versionadded:: 2014.7.0
 
     CLI Example:
 
@@ -471,7 +471,7 @@ def interface_ip(iface):
     '''
     Return the inet address for a given interface
 
-    .. versionadded:: 2014.7
+    .. versionadded:: 2014.7.0
 
     CLI Example:
 
@@ -623,7 +623,7 @@ def connect(host, port=None, **kwargs):
     Test connectivity to a host using a particular
     port from the minion.
 
-    .. versionadded:: 2014.7
+    .. versionadded:: 2014.7.0
 
     CLI Example:
 

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -742,7 +742,7 @@ def runner(fun, **kwargs):
     '''
     Execute a runner module (this function must be run on the master)
 
-    .. versionadded:: 2014.7
+    .. versionadded:: 2014.7.0
 
     name
         The name of the function to run
@@ -772,7 +772,7 @@ def wheel(fun, **kwargs):
     '''
     Execute a wheel module (this function must be run on the master)
 
-    .. versionadded:: 2014.7
+    .. versionadded:: 2014.7.0
 
     name
         The name of the function to run

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -430,7 +430,7 @@ def wait_for_event(
     '''
     Watch Salt's event bus and block until a condition is met
 
-    .. versionadded:: 2014.7
+    .. versionadded:: 2014.7.0
 
     name
         An event tag to watch for; supports Reactor-style globbing.
@@ -531,7 +531,7 @@ def runner(name, **kwargs):
     '''
     Execute a runner module on the master
 
-    .. versionadded:: 2014.7
+    .. versionadded:: 2014.7.0
 
     name
         The name of the function to run
@@ -554,7 +554,7 @@ def wheel(name, **kwargs):
     '''
     Execute a wheel module on the master
 
-    .. versionadded:: 2014.7
+    .. versionadded:: 2014.7.0
 
     name
         The name of the function to run


### PR DESCRIPTION
sysctl.present does not persist across reboots in OS X and running a state to apply will only set the values for the current session (does not persist across reboots).
