### PR TITLE
Adjust dockerng/dockerio docstrings

### DIFF
--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -5,7 +5,7 @@ Management of Docker Containers
 .. versionadded:: 2014.1.0
 
 .. deprecated:: 2015.8.0
-    Future feature development will be done only in :mod:`docker-ng
+    Future feature development will be done only in :mod:`dockerng
     <salt.modules.dockerng>`. See the documentation for this module for
     information on the deprecation path.
 

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5,8 +5,8 @@ Management of Docker Containers
 .. versionadded:: 2015.8.0
 
 
-Why Make a Second Docker Module?
---------------------------------
+Why Make a Second Docker Execution Module?
+------------------------------------------
 
 We have received a lot of feedback on our Docker support. In the process of
 implementing recommended improvements, it became obvious that major changes
@@ -19,7 +19,7 @@ option. This will give users a couple release cycles to modify their scripts,
 SLS files, etc. to use the new functionality, rather than forcing users to
 change everything immediately.
 
-In the **Carbon** release of Salt (due early 2016), this execution module will
+In the **Carbon** release of Salt (due in 2016), this execution module will
 take the place of the default Docker execution module, and backwards-compatible
 naming will be maintained for a couple releases after that to allow users time
 to replace references to ``dockerng`` with ``docker``.

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -3,6 +3,11 @@
 Manage Docker containers
 ========================
 
+.. deprecated:: 2015.8.0
+    Future feature development will be done only in :mod:`dockerng
+    <salt.states.dockerng>`. See the documentation for this module for
+    information on the deprecation path.
+
 `Docker <https://www.docker.io>`_
 is a lightweight, portable, self-sufficient software container
 wrapper. The base supported wrapper type is

--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -8,6 +8,27 @@ Management of Docker containers
 This is the state module to accompany the :mod:`dockerng
 <salt.modules.dockerng>` execution module.
 
+
+Why Make a Second Docker State Module?
+--------------------------------------
+
+We have received a lot of feedback on our Docker support. In the process of
+implementing recommended improvements, it became obvious that major changes
+needed to be made to the functions and return data. In the end, a complete
+rewrite was done.
+
+The changes being too significant, it was decided that making a separate
+execution module and state module (called ``dockerng``) would be the best
+option. This will give users a couple release cycles to modify their scripts,
+SLS files, etc. to use the new functionality, rather than forcing users to
+change everything immediately.
+
+In the **Carbon** release of Salt (due in 2016), this execution module will
+take the place of the default Docker execution module, and backwards-compatible
+naming will be maintained for a couple releases after that to allow users time
+to replace references to ``dockerng`` with ``docker``.
+
+
 .. note::
 
     To pull from a Docker registry, authentication must be configured. See


### PR DESCRIPTION
This adds a similar documentation section to the top of the state module to
match the one in the execution module. It also updates the expected release
date of the Carbon release to reflect the new release cadence.

It also adds a deprecation notice to the dockerio state module, and corrects
the name of the dockerng module in the deprecation notice from the dockerio
execution module docstring. It was changed from docker-ng to dockerng early on
and this change was never reflected in the deprecation notice.
