### PR TITLE
Close io loop before deleting attribute

### DIFF
--- a/salt/utils/async.py
+++ b/salt/utils/async.py
@@ -86,6 +86,6 @@ class SyncWrapper(object):
         '''
         On deletion of the async wrapper, make sure to clean up the async stuff
         '''
+        self.io_loop.close()
         if hasattr(self, 'async'):
             del self.async
-        self.io_loop.close()


### PR DESCRIPTION
Fixes #26889 

I also tested this for file-handle leaks and did not observe any.
