### PR TITLE
Mongo returners patch 1

### DIFF
--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -130,7 +130,7 @@ def _get_conn(ret):
     password = _options.get('password')
     indexes = _options.get('indexes', False)
 
-    # at some point we should remove support for 
+    # at some point we should remove support for
     # pymongo versions < 2.3 until then there are
     # a bunch of these sections that need to be supported
 

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -180,7 +180,7 @@ def returner(ret):
     # save returns in the saltReturns collection in the json format:
     # { 'minion': <minion_name>, 'jid': <job_id>, 'return': <return info with dots removed>,
     #   'fun': <function>, 'full_ret': <unformatted return with dots removed>}
-    #   
+    #
     # again we run into the issue with deprecated code from previous versions
 
     if float(version) > 2.3:

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -129,13 +129,11 @@ def _get_conn(ret):
     user = _options.get('user')
     password = _options.get('password')
     indexes = _options.get('indexes', False)
-    
     '''
     at some point we should remove support for 
     pymongo versions < 2.3 until then there are
     a bunch of these sections that need to be supported
     '''
-
     if float(version) > 2.3:
         conn = pymongo.MongoClient(host, port)
     else:
@@ -149,14 +147,12 @@ def _get_conn(ret):
         if float(version) > 2.3:
             mdb.saltReturns.create_index('minion')
             mdb.saltReturns.create_index('jid')
-            
             mdb.jobs.create_index('jid')
         else:
             mdb.saltReturns.ensure_index('minion')
             mdb.saltReturns.ensure_index('jid')
-            
             mdb.jobs.ensure_index('jid')
-
+            
     return conn, mdb
 
 

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -129,6 +129,12 @@ def _get_conn(ret):
     user = _options.get('user')
     password = _options.get('password')
     indexes = _options.get('indexes', False)
+    
+    '''
+    at some point we should remove support for 
+    pymongo versions < 2.3 until then there are
+    a bunch of these sections that need to be supported
+    '''
 
     if float(version) > 2.3:
         conn = pymongo.MongoClient(host, port)
@@ -140,10 +146,16 @@ def _get_conn(ret):
         mdb.authenticate(user, password)
 
     if indexes:
-        mdb.saltReturns.create_index('minion')
-        mdb.saltReturns.create_index('jid')
-
-        mdb.jobs.create_index('jid')
+        if float(version) > 2.3:
+            mdb.saltReturns.create_index('minion')
+            mdb.saltReturns.create_index('jid')
+            
+            mdb.jobs.create_index('jid')
+        else:
+            mdb.saltReturns.ensure_index('minion')
+            mdb.saltReturns.ensure_index('jid')
+            
+            mdb.jobs.ensure_index('jid')
 
     return conn, mdb
 
@@ -168,10 +180,18 @@ def returner(ret):
     sdata = {'minion': ret['id'], 'jid': ret['jid'], 'return': back, 'fun': ret['fun'], 'full_ret': full_ret}
     if 'out' in ret:
         sdata['out'] = ret['out']
-    # save returns in the saltReturns collection in the json format:
-    # { 'minion': <minion_name>, 'jid': <job_id>, 'return': <return info with dots removed>,
-    #   'fun': <function>, 'full_ret': <unformatted return with dots removed>}
-    mdb.saltReturns.insert(sdata)
+    '''
+    save returns in the saltReturns collection in the json format:
+     { 'minion': <minion_name>, 'jid': <job_id>, 'return': <return info with dots removed>,
+       'fun': <function>, 'full_ret': <unformatted return with dots removed>}
+       
+    again we run into the issue with deprecated code from previous versions
+    '''
+    if float(version) > 2.3:
+        #using .copy() to ensure that the original data is not changed, raising issue with pymongo team
+        mdb.saltReturns.insert_one(sdata.copy())
+    else:
+        mdb.saltReturns.insert(sdata.copy())
 
 
 def save_load(jid, load):
@@ -179,7 +199,11 @@ def save_load(jid, load):
     Save the load for a given job id
     '''
     conn, mdb = _get_conn(ret=None)
-    mdb.jobs.insert(load)
+    if float(version) > 2.3:
+        #using .copy() to ensure original data for load is unchanged
+        mdb.jobs.insert_one(load.copy())
+    else:
+        mdb.jobs.insert(load.copy())
 
 
 def get_load(jid):
@@ -187,7 +211,7 @@ def get_load(jid):
     Return the load associated with a given job id
     '''
     conn, mdb = _get_conn(ret=None)
-    ret = mdb.jobs.find_one({'jid': jid})
+    ret = mdb.jobs.find_one({'jid': jid}, {'_id': 0})
     return ret['load']
 
 
@@ -197,7 +221,7 @@ def get_jid(jid):
     '''
     conn, mdb = _get_conn(ret=None)
     ret = {}
-    rdata = mdb.saltReturns.find({'jid': jid})
+    rdata = mdb.saltReturns.find({'jid': jid}, {'_id': 0})
     if rdata:
         for data in rdata:
             minion = data['minion']
@@ -212,7 +236,7 @@ def get_fun(fun):
     '''
     conn, mdb = _get_conn(ret=None)
     ret = {}
-    rdata = mdb.saltReturns.find_one({'fun': fun})
+    rdata = mdb.saltReturns.find_one({'fun': fun}, {'_id': 0})
     if rdata:
         ret = rdata
     return ret

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -129,11 +129,11 @@ def _get_conn(ret):
     user = _options.get('user')
     password = _options.get('password')
     indexes = _options.get('indexes', False)
-    '''
-    at some point we should remove support for 
-    pymongo versions < 2.3 until then there are
-    a bunch of these sections that need to be supported
-    '''
+
+    # at some point we should remove support for 
+    # pymongo versions < 2.3 until then there are
+    # a bunch of these sections that need to be supported
+
     if float(version) > 2.3:
         conn = pymongo.MongoClient(host, port)
     else:
@@ -152,7 +152,7 @@ def _get_conn(ret):
             mdb.saltReturns.ensure_index('minion')
             mdb.saltReturns.ensure_index('jid')
             mdb.jobs.ensure_index('jid')
-            
+
     return conn, mdb
 
 
@@ -176,13 +176,13 @@ def returner(ret):
     sdata = {'minion': ret['id'], 'jid': ret['jid'], 'return': back, 'fun': ret['fun'], 'full_ret': full_ret}
     if 'out' in ret:
         sdata['out'] = ret['out']
-    '''
-    save returns in the saltReturns collection in the json format:
-     { 'minion': <minion_name>, 'jid': <job_id>, 'return': <return info with dots removed>,
-       'fun': <function>, 'full_ret': <unformatted return with dots removed>}
-       
-    again we run into the issue with deprecated code from previous versions
-    '''
+
+    # save returns in the saltReturns collection in the json format:
+    # { 'minion': <minion_name>, 'jid': <job_id>, 'return': <return info with dots removed>,
+    #   'fun': <function>, 'full_ret': <unformatted return with dots removed>}
+    #   
+    # again we run into the issue with deprecated code from previous versions
+
     if float(version) > 2.3:
         #using .copy() to ensure that the original data is not changed, raising issue with pymongo team
         mdb.saltReturns.insert_one(sdata.copy())

--- a/salt/returners/mongo_return.py
+++ b/salt/returners/mongo_return.py
@@ -133,7 +133,7 @@ def _get_conn(ret):
     if user and password:
         mdb.authenticate(user, password)
     
-     if indexes:
+    if indexes:
         if float(version) > 2.3:
             mdb.saltReturns.create_index('minion')
             mdb.saltReturns.create_index('jid')

--- a/salt/returners/mongo_return.py
+++ b/salt/returners/mongo_return.py
@@ -120,7 +120,7 @@ def _get_conn(ret):
     password = _options.get('password')
     indexes = _options.get('indexes', False)
 
-    # at some point we should remove support for 
+    # at some point we should remove support for
     # pymongo versions < 2.3 until then there are
     # a bunch of these sections that need to be supported
 
@@ -132,7 +132,7 @@ def _get_conn(ret):
 
     if user and password:
         mdb.authenticate(user, password)
-    
+
     if indexes:
         if float(version) > 2.3:
             mdb.saltReturns.create_index('minion')

--- a/salt/returners/mongo_return.py
+++ b/salt/returners/mongo_return.py
@@ -119,13 +119,11 @@ def _get_conn(ret):
     user = _options.get('user')
     password = _options.get('password')
     indexes = _options.get('indexes', False)
-
     '''
     at some point we should remove support for 
     pymongo versions < 2.3 until then there are
     a bunch of these sections that need to be supported
     '''
-
     if float(version) > 2.3:
         conn = pymongo.MongoClient(host, port)
     else:

--- a/salt/returners/mongo_return.py
+++ b/salt/returners/mongo_return.py
@@ -96,7 +96,7 @@ def _get_options(ret):
              'port': 'port',
              'db': 'db',
              'user': 'user',
-             'password': 'password'
+             'password': 'password',
              'indexes': 'indexes'}
 
     _options = salt.returners.get_returner_options(__virtualname__,

--- a/salt/returners/mongo_return.py
+++ b/salt/returners/mongo_return.py
@@ -96,7 +96,8 @@ def _get_options(ret):
              'port': 'port',
              'db': 'db',
              'user': 'user',
-             'password': 'password'}
+             'password': 'password'
+             'indexes': 'indexes'}
 
     _options = salt.returners.get_returner_options(__virtualname__,
                                                    ret,
@@ -117,6 +118,13 @@ def _get_conn(ret):
     db_ = _options.get('db')
     user = _options.get('user')
     password = _options.get('password')
+    indexes = _options.get('indexes', False)
+
+    '''
+    at some point we should remove support for 
+    pymongo versions < 2.3 until then there are
+    a bunch of these sections that need to be supported
+    '''
 
     if float(version) > 2.3:
         conn = pymongo.MongoClient(host, port)
@@ -126,6 +134,19 @@ def _get_conn(ret):
 
     if user and password:
         mdb.authenticate(user, password)
+    
+     if indexes:
+        if float(version) > 2.3:
+            mdb.saltReturns.create_index('minion')
+            mdb.saltReturns.create_index('jid')
+
+            mdb.jobs.create_index('jid')
+        else:
+            mdb.saltReturns.ensure_index('minion')
+            mdb.saltReturns.ensure_index('jid')
+
+            mdb.jobs.ensure_index('jid')
+
     return conn, mdb
 
 
@@ -150,10 +171,18 @@ def returner(ret):
     sdata = {'minion': ret['id'], 'jid': ret['jid'], 'return': back, 'fun': ret['fun'], 'full_ret': full_ret}
     if 'out' in ret:
         sdata['out'] = ret['out']
-        # save returns in the saltReturns collection in the json format:
-    # { 'minion': <minion_name>, 'jid': <job_id>, 'return': <return info with dots removed>,
-    #   'fun': <function>, 'full_ret': <unformatted return with dots removed>}
-    mdb.saltReturns.insert(sdata)
+    '''
+    save returns in the saltReturns collection in the json format:
+     { 'minion': <minion_name>, 'jid': <job_id>, 'return': <return info with dots removed>,
+       'fun': <function>, 'full_ret': <unformatted return with dots removed>}
+       
+    again we run into the issue with deprecated code from previous versions
+    '''
+    if float(version) > 2.3:
+        #using .copy() to ensure original data for load is unchanged
+        mdb.saltReturns.insert_one(sdata.copy())
+    else:
+        mdb.saltReturns.insert(sdata.copy())
 
 
 def get_jid(jid):
@@ -162,7 +191,7 @@ def get_jid(jid):
     '''
     conn, mdb = _get_conn(ret=None)
     ret = {}
-    rdata = mdb.saltReturns.find({'jid': jid})
+    rdata = mdb.saltReturns.find({'jid': jid}, {'_id': 0})
     if rdata:
         for data in rdata:
             minion = data['minion']
@@ -177,7 +206,7 @@ def get_fun(fun):
     '''
     conn, mdb = _get_conn(ret=None)
     ret = {}
-    rdata = mdb.saltReturns.find_one({'fun': fun})
+    rdata = mdb.saltReturns.find_one({'fun': fun}, {'_id': 0})
     if rdata:
         ret = rdata
     return ret

--- a/salt/returners/mongo_return.py
+++ b/salt/returners/mongo_return.py
@@ -119,11 +119,11 @@ def _get_conn(ret):
     user = _options.get('user')
     password = _options.get('password')
     indexes = _options.get('indexes', False)
-    '''
-    at some point we should remove support for 
-    pymongo versions < 2.3 until then there are
-    a bunch of these sections that need to be supported
-    '''
+
+    # at some point we should remove support for 
+    # pymongo versions < 2.3 until then there are
+    # a bunch of these sections that need to be supported
+
     if float(version) > 2.3:
         conn = pymongo.MongoClient(host, port)
     else:
@@ -169,13 +169,13 @@ def returner(ret):
     sdata = {'minion': ret['id'], 'jid': ret['jid'], 'return': back, 'fun': ret['fun'], 'full_ret': full_ret}
     if 'out' in ret:
         sdata['out'] = ret['out']
-    '''
-    save returns in the saltReturns collection in the json format:
-     { 'minion': <minion_name>, 'jid': <job_id>, 'return': <return info with dots removed>,
-       'fun': <function>, 'full_ret': <unformatted return with dots removed>}
-       
-    again we run into the issue with deprecated code from previous versions
-    '''
+
+    # save returns in the saltReturns collection in the json format:
+    # { 'minion': <minion_name>, 'jid': <job_id>, 'return': <return info with dots removed>,
+    #  'fun': <function>, 'full_ret': <unformatted return with dots removed>}
+    #
+    # again we run into the issue with deprecated code from previous versions
+    
     if float(version) > 2.3:
         #using .copy() to ensure original data for load is unchanged
         mdb.saltReturns.insert_one(sdata.copy())

--- a/salt/returners/mongo_return.py
+++ b/salt/returners/mongo_return.py
@@ -173,9 +173,9 @@ def returner(ret):
     # save returns in the saltReturns collection in the json format:
     # { 'minion': <minion_name>, 'jid': <job_id>, 'return': <return info with dots removed>,
     #  'fun': <function>, 'full_ret': <unformatted return with dots removed>}
-    #
+
     # again we run into the issue with deprecated code from previous versions
-    
+
     if float(version) > 2.3:
         #using .copy() to ensure original data for load is unchanged
         mdb.saltReturns.insert_one(sdata.copy())


### PR DESCRIPTION
Cleaning up the rest of the bugfix from https://github.com/saltstack/salt/issues/27125 looks like there's an issue where pymongo changes what should be static data. I'll raise an issue with them on that point but for now this should fix all issues with the returners in the 2015.8 release
