### PR TITLE
Allow use of rst header links by separating options out from yaml example

### DIFF
--- a/doc/topics/cloud/gce.rst
+++ b/doc/topics/cloud/gce.rst
@@ -258,6 +258,8 @@ GCE supports two different disk types, ``pd-standard`` and ``pd-ssd``.
 The default disk type setting is ``pd-standard``. To specify using an SSD
 disk, set ``pd-ssd`` as the value.
 
+.. versionadded:: 2014.7.0
+
 
 SSH Remote Access
 =================

--- a/doc/topics/cloud/gce.rst
+++ b/doc/topics/cloud/gce.rst
@@ -152,80 +152,115 @@ it can be verified with Salt:
 GCE Specific Settings
 =====================
 Consult the sample profile below for more information about GCE specific
-settings.  Some of them are mandatory and are properly labeled below but
+settings. Some of them are mandatory and are properly labeled below but
 typically also include a hard-coded default.
+
+Initial Profile
+---------------
+Set up an initial profile at ``/etc/salt/cloud.profiles`` or
+``/etc/salt/cloud.profiles.d/gce.conf``:
 
 .. code-block:: yaml
 
     my-gce-profile:
-
-      # Image is used to define what Operating System image should be used
-      # to for the instance.  Examples are Debian 7 (wheezy) and CentOS 6.
-      #
-      # MANDATORY
-      #
       image: centos-6
-
-      # A 'size', in GCE terms, refers to the instance's 'machine type'.  See
-      # the on-line documentation for a complete list of GCE machine types.
-      #
-      # MANDATORY
-      #
       size: n1-standard-1
-
-      # A 'location', in GCE terms, refers to the instance's 'zone'.  GCE
-      # has the notion of both Regions (e.g. us-central1, europe-west1, etc)
-      # and Zones (e.g. us-central1-a, us-central1-b, etc).
-      #
-      # MANDATORY
-      #
       location: europe-west1-b
-
-      # Use this setting to define the network resource for the instance.
-      # All GCE projects contain a network named 'default' but it's possible
-      # to use this setting to create instances belonging to a different
-      # network resource.
-      #
       network: default
-
-      # GCE supports instance/network tags and this setting allows you to
-      # set custom tags.  It should be a list of strings and must be
-      # parse-able by the python ast.literal_eval() function to convert it
-      # to a python list.
-      #
       tags: '["one", "two", "three"]'
-
-      # GCE supports instance metadata and this setting allows you to
-      # set custom metadata.  It should be a hash of key/value strings and
-      # parse-able by the python ast.literal_eval() function to convert it
-      # to a python dictionary.
-      #
       metadata: '{"one": "1", "2": "two"}'
-
-      # Use this setting to ensure that when new instances are created,
-      # they will use a persistent disk to preserve data between instance
-      # terminations and re-creations.
-      #
       use_persistent_disk: True
-
-      # In the event that you wish the boot persistent disk to be permanently
-      # deleted when you destroy an instance, set delete_boot_pd to True.
-      #
       delete_boot_pd: False
-
-      # Specify whether to use public or private IP for deploy script.
-      # Valid options are:
-      #     private_ips - The salt-master is also hosted with GCE
-      #     public_ips - The salt-master is hosted outside of GCE
       ssh_interface: public_ips
-
-      # Per instance setting: Used a named fixed IP address to this host.
-      # Valid options are:
-      #     ephemeral - The host will use a GCE ephemeral IP
-      #     None - No external IP will be configured on this host.
-      # Optionally, pass the name of a GCE address to use a fixed IP address.
-      # If the address does not already exist, it will be created.
       external_ip: "ephemeral"
+
+image
+-----
+
+Image is used to define what Operating System image should be used
+to for the instance. Examples are Debian 7 (wheezy) and CentOS 6. Required.
+
+size
+----
+
+A 'size', in GCE terms, refers to the instance's 'machine type'. See
+the on-line documentation for a complete list of GCE machine types. Required.
+
+location
+--------
+
+A 'location', in GCE terms, refers to the instance's 'zone'. GCE
+has the notion of both Regions (e.g. us-central1, europe-west1, etc)
+and Zones (e.g. us-central1-a, us-central1-b, etc). Required.
+
+network
+-------
+
+Use this setting to define the network resource for the instance.
+All GCE projects contain a network named 'default' but it's possible
+to use this setting to create instances belonging to a different
+network resource.
+
+tags
+----
+
+GCE supports instance/network tags and this setting allows you to
+set custom tags. It should be a list of strings and must be
+parse-able by the python ast.literal_eval() function to convert it
+to a python list.
+
+metadata
+--------
+
+GCE supports instance metadata and this setting allows you to
+set custom metadata. It should be a hash of key/value strings and
+parse-able by the python ast.literal_eval() function to convert it
+to a python dictionary.
+
+use_persistent_disk
+-------------------
+
+Use this setting to ensure that when new instances are created,
+they will use a persistent disk to preserve data between instance
+terminations and re-creations.
+
+delete_boot_pd
+--------------
+
+In the event that you wish the boot persistent disk to be permanently
+deleted when you destroy an instance, set delete_boot_pd to True.
+
+ssh_interface
+-------------
+
+Specify whether to use public or private IP for deploy script.
+
+Valid options are:
+* private_ips: The salt-master is also hosted with GCE
+* public_ips: The salt-master is hosted outside of GCE
+
+external_ip
+-----------
+
+Per instance setting: Used a named fixed IP address to this host.
+
+Valid options are:
+* ephemeral - The host will use a GCE ephemeral IP
+* None - No external IP will be configured on this host.
+
+Optionally, pass the name of a GCE address to use a fixed IP address.
+If the address does not already exist, it will be created.
+
+ex_disk_type
+------------
+
+GCE supports two different disk types, ``pd-standard`` and ``pd-ssd``.
+The default disk type setting is ``pd-standard``. To specify using an SSD
+disk, set ``pd-ssd`` as the value.
+
+
+SSH Remote Access
+=================
 
 GCE instances do not allow remote access to the root user by default.
 Instead, another user must be used to run the deploy script using sudo.


### PR DESCRIPTION
Also added docs to use the ex_disk_type option

Refs #19236
