### PR TITLE
fix sysctl truncating newline on os x

### DIFF
--- a/salt/modules/darwin_sysctl.py
+++ b/salt/modules/darwin_sysctl.py
@@ -176,9 +176,11 @@ def persist(name, value, config='/etc/sysctl.conf', apply_change=False):
                     return 'Already set'
                 new_line = '{0}={1}'.format(name, value)
                 nlines.append(new_line)
+                nlines.append('\n')
                 edited = True
     if not edited:
         nlines.append('{0}={1}'.format(name, value))
+        nlines.append('\n')
     with salt.utils.fopen(config, 'w+') as ofile:
         ofile.writelines(nlines)
     # If apply_change=True, apply edits to system


### PR DESCRIPTION
sysctl.present does not persist across reboots in OS X and running a state to apply will only set the values for the current session (does not persist across reboots).
