### PR TITLE
DRY: Let's only write the code to check keypaths and modes once

### DIFF
--- a/salt/cloud/clouds/botocore_aws.py
+++ b/salt/cloud/clouds/botocore_aws.py
@@ -32,15 +32,12 @@ If this driver is still needed, set up the cloud configuration at
 
 # Import python libs
 from __future__ import absolute_import
-import os
-import stat
 import logging
 
 # Import salt.cloud libs
 import salt.utils.cloud
 import salt.config as config
 from salt.utils import namespaced_function
-from salt.exceptions import SaltCloudException, SaltCloudSystemExit
 import salt.ext.six as six
 
 # Import libcloudfuncs and libcloud_aws, required to latter patch __opts__

--- a/salt/cloud/clouds/botocore_aws.py
+++ b/salt/cloud/clouds/botocore_aws.py
@@ -37,6 +37,7 @@ import stat
 import logging
 
 # Import salt.cloud libs
+import salt.utils.cloud
 import salt.config as config
 from salt.utils import namespaced_function
 from salt.exceptions import SaltCloudException, SaltCloudSystemExit
@@ -87,29 +88,14 @@ def __virtual__():
         return False
 
     for provider, details in six.iteritems(__opts__['providers']):
-        if 'provider' not in details or details['provider'] != 'aws':
+        if 'aws' not in details:
             continue
 
-        if not os.path.exists(details['private_key']):
-            raise SaltCloudException(
-                'The AWS key file \'{0}\' used in the \'{1}\' provider '
-                'configuration does not exist\n'.format(
-                    details['private_key'],
-                    provider
-                )
-            )
-
-        keymode = str(
-            oct(stat.S_IMODE(os.stat(details['private_key']).st_mode))
-        )
-        if keymode not in ('0400', '0600'):
-            raise SaltCloudException(
-                'The AWS key file \'{0}\' used in the \'{1}\' provider '
-                'configuration needs to be set to mode 0400 or 0600\n'.format(
-                    details['private_key'],
-                    provider
-                )
-            )
+        parameters = details['aws']
+        if salt.utils.cloud.check_key_path_and_mode(
+                provider, parameters['private_key']
+        ) is False:
+            return False
 
     # Let's bring the functions imported from libcloud_aws to the current
     # namespace.

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -195,27 +195,10 @@ def __virtual__():
             continue
 
         parameters = details['ec2']
-
-        if not os.path.exists(parameters['private_key']):
-            raise SaltCloudException(
-                'The EC2 key file \'{0}\' used in the \'{1}\' provider '
-                'configuration does not exist\n'.format(
-                    parameters['private_key'],
-                    provider
-                )
-            )
-
-        key_mode = str(
-            oct(stat.S_IMODE(os.stat(parameters['private_key']).st_mode))
-        )
-        if key_mode not in ('0400', '0600'):
-            raise SaltCloudException(
-                'The EC2 key file \'{0}\' used in the \'{1}\' provider '
-                'configuration needs to be set to mode 0400 or 0600\n'.format(
-                    parameters['private_key'],
-                    provider
-                )
-            )
+        if salt.utils.cloud.check_key_path_and_mode(
+                provider, parameters['private_key']
+        ) is False:
+            return False
 
     return __virtualname__
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -71,7 +71,6 @@ To use the EC2 cloud module, set up the cloud configuration at
 from __future__ import absolute_import
 import os
 import sys
-import stat
 import time
 import uuid
 import pprint

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -49,7 +49,6 @@ Example Provider Configuration
 from __future__ import absolute_import
 import os
 import re
-import stat
 import pprint
 import logging
 import msgpack

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -120,30 +120,9 @@ def __virtual__():
 
         parameters = details['gce']
         pathname = os.path.expanduser(parameters['service_account_private_key'])
-
-        if not os.path.exists(pathname):
-            log.error(
-                'The GCE service account private key \'{0}\' used in '
-                'the \'{1}\' provider configuration does not exist\n'.format(
-                    parameters['service_account_private_key'],
-                    provider
-                )
-            )
-            return False
-
-        key_mode = str(
-            oct(stat.S_IMODE(os.stat(pathname).st_mode))
-        )
-
-        if key_mode not in ('0400', '0600'):
-            log.error(
-                'The GCE service account private key \'{0}\' used in '
-                'the \'{1}\' provider configuration needs to be set to '
-                'mode 0400 or 0600\n'.format(
-                    parameters['service_account_private_key'],
-                    provider
-                )
-            )
+        if salt.utils.cloud.check_key_path_and_mode(
+                provider, pathname
+        ) is False:
             return False
 
     return __virtualname__

--- a/salt/cloud/clouds/libcloud_aws.py
+++ b/salt/cloud/clouds/libcloud_aws.py
@@ -34,7 +34,6 @@ from __future__ import absolute_import
 
 # Import python libs
 import os
-import stat
 import uuid
 import pprint
 import logging

--- a/salt/cloud/clouds/libcloud_aws.py
+++ b/salt/cloud/clouds/libcloud_aws.py
@@ -101,29 +101,14 @@ def __virtual__():
         return False
 
     for provider, details in six.iteritems(__opts__['providers']):
-        if 'provider' not in details or details['provider'] != 'aws':
+        if 'aws' not in details:
             continue
 
-        if not os.path.exists(details['private_key']):
-            raise SaltCloudException(
-                'The AWS key file \'{0}\' used in the \'{1}\' provider '
-                'configuration does not exist\n'.format(
-                    details['private_key'],
-                    provider
-                )
-            )
-
-        keymode = str(
-            oct(stat.S_IMODE(os.stat(details['private_key']).st_mode))
-        )
-        if keymode not in ('0400', '0600'):
-            raise SaltCloudException(
-                'The AWS key file \'{0}\' used in the \'{1}\' provider '
-                'configuration needs to be set to mode 0400 or 0600\n'.format(
-                    details['private_key'],
-                    provider
-                )
-            )
+        parameters = details['aws']
+        if salt.utils.cloud.check_key_path_and_mode(
+            provider, parameters['private_key']
+        ) is False:
+            return False
 
     global avail_images, avail_sizes, script, list_nodes
     global avail_locations, list_nodes_full, list_nodes_select, get_image

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -3005,6 +3005,15 @@ def check_key_path_and_mode(provider, key_path):
     Checks that the key_path exists and the key_mode is either 0400 or 0600.
 
     Returns True or False.
+
+    .. versionadded:: Boron
+
+    provider
+        The provider name that the key_path to check belongs to.
+
+    key_path
+        The key_path to ensure that it exists and to check adequate permissions
+        against.
     '''
     if not os.path.exists(key_path):
         log.error(

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -2998,3 +2998,33 @@ def get_salt_interface(vm_, opts):
         )
 
     return salt_host
+
+
+def check_key_path_and_mode(provider, key_path):
+    '''
+    Checks that the key_path exists and the key_mode is either 0400 or 0600.
+
+    Returns True or False.
+    '''
+    if not os.path.exists(key_path):
+        log.error(
+            'The key file \'{0}\' used in the \'{1}\' provider configuration '
+            'does not exist.\n'.format(
+                key_path,
+                provider
+            )
+        )
+        return False
+
+    key_mode = str(oct(stat.S_IMODE(os.stat(key_path).st_mode)))
+    if key_mode not in ('0400', '0600'):
+        log.error(
+            'The key file \'{0}\' used in the \'{1}\' provider configuration '
+            'needs to be set to mode 0400 or 0600.\n'.format(
+                key_path,
+                provider
+            )
+        )
+        return False
+
+    return True


### PR DESCRIPTION
Also brings the aws-related drivers inline with the gce and ec2 drivers to make sure we're not "continue-ing" out of the loop.
