### PR TITLE
Escape search replacement text, fixes #27356

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1441,7 +1441,7 @@ def replace(path,
                     if prepend_if_not_found or append_if_not_found:
                         # Search for content, so we don't continue pre/appending
                         # the content if it's been pre/appended in a previous run.
-                        if re.search('^{0}$'.format(content), line):
+                        if re.search('^{0}$'.format(re.escape(content)), line):
                             # Content was found, so set found.
                             found = True
 


### PR DESCRIPTION
Escape `content` so that re.search does not throw an error if `content` contains special regex characters.
