### PR TITLE
doc: fix rendering of ref/states/top

### DIFF
--- a/doc/ref/states/top.rst
+++ b/doc/ref/states/top.rst
@@ -317,10 +317,10 @@ For the following discussion of top file compilation, assume the following
 configuration:
 
 
-``/etc/salt/master``
-
+``/etc/salt/master:``
 .. code-block:: yaml
-    <snip>
+    …
+
     file_roots:
       first_env:
         - /srv/salt/first


### PR DESCRIPTION
Use `…` instead of `<snip>` with "/etc/salt/master" example, and add a
colon as with "first/top.sls" below.

This is meant to fix the rendering issue you see on https://docs.saltstack.com/en/latest/ref/states/top.html#how-top-files-are-compiled.
