### PR TITLE
Revert "fixes #27217 clear_old_remotes clears wrong directory (gitfs)"

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -1609,7 +1609,7 @@ class GitBase(object):
                 pass
         to_remove = []
         for item in cachedir_ls:
-            if item in ('gitfs', 'refs'):
+            if item in ('hash', 'refs'):
                 continue
             path = os.path.join(self.cache_root, item)
             if os.path.isdir(path):


### PR DESCRIPTION
This reverts commit cccdeee18aa9dade43a0e78c5081524f8156ce03, as it was
correct in the first place.
