### PR TITLE
[2015.8] Fix global provider overrides

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -196,7 +196,7 @@ def minion_mods(
             # sometimes providers opts is not to diverge modules but
             # for other configuration
             try:
-                funcs = raw_mod(opts, providers[mod], ret.items())
+                funcs = raw_mod(opts, providers[mod], ret)
             except TypeError:
                 break
             else:

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -185,6 +185,8 @@ def minion_mods(
                      whitelist=whitelist,
                      loaded_base_name=loaded_base_name)
 
+    ret.pack['__salt__'] = ret
+
     # Load any provider overrides from the configuration file providers option
     #  Note: Providers can be pkg, service, user or group - not to be confused
     #        with cloud providers.
@@ -203,7 +205,6 @@ def minion_mods(
                         f_key = '{0}{1}'.format(mod, func[func.rindex('.'):])
                         ret[f_key] = funcs[func]
 
-    ret.pack['__salt__'] = ret
     if notify:
         evt = salt.utils.event.get_event('minion', opts=opts, listen=False)
         evt.fire_event({'complete': True}, tag='/salt/minion/minion_mod_complete')


### PR DESCRIPTION
I think either of the commits in this pull request would fix the issue alone. But `ret.items()` was forcing all modules to load (inefficient, kills usefulness of lazyloader), and I think we do want the pack before we load anything.

Fixes #27209 
