### PR TITLE
Allow cloud roster to use sudo

### DIFF
--- a/salt/roster/cloud.py
+++ b/salt/roster/cloud.py
@@ -8,6 +8,13 @@ maintains an index of minions that it creates and deletes. This index tracks the
 provider and profile configuration used to provision the minion, including
 authentication information. So long as this configuration remains current, it can
 be used by Salt SSH to log into any minion in the index.
+
+To connect as a user other than root, modify the cloud configuration file
+usually located at /etc/salt/cloud. For example, add the following:
+
+.. code-block:: yaml
+    ssh_username: my_user
+    sudo: True
 '''
 
 # Import python libs
@@ -99,7 +106,7 @@ def targets(tgt, tgt_type='glob', **kwargs):  # pylint: disable=W0613
     )
     if key_filename:
         ret['tgt']['priv'] = key_filename
-        
+
     sudo = salt.config.get_cloud_config_value(
         'sudo', vm_, cloud_opts, search_global=False, default=None
     )

--- a/salt/roster/cloud.py
+++ b/salt/roster/cloud.py
@@ -99,6 +99,12 @@ def targets(tgt, tgt_type='glob', **kwargs):  # pylint: disable=W0613
     )
     if key_filename:
         ret['tgt']['priv'] = key_filename
+        
+    sudo = salt.config.get_cloud_config_value(
+        'sudo', vm_, cloud_opts, search_global=False, default=None
+    )
+    if sudo:
+        ret['tgt']['sudo'] = sudo
 
     return ret
 


### PR DESCRIPTION
Similar to issue #26689, but I am using the cloud roster file to get the IP targets generated from running salt-cloud.
