### PR TITLE
Backwards compat fixes for pecl module

### DIFF
--- a/salt/modules/pecl.py
+++ b/salt/modules/pecl.py
@@ -16,6 +16,9 @@ except ImportError:
 # Import salt libs
 import salt.utils
 
+# Import 3rd-party libs
+import salt.ext.six as six
+
 __func_alias__ = {
     'list_': 'list'
 }
@@ -67,6 +70,8 @@ def install(pecls, defaults=False, force=False, preferred_state='stable'):
 
         salt '*' pecl.install fuse
     '''
+    if isinstance(pecls, six.string_types):
+        pecls = [pecls]
     preferred_state = '-d preferred_state={0}'.format(_cmd_quote(preferred_state))
     if force:
         return _pecl('{0} install -f {1}'.format(preferred_state, _cmd_quote(' '.join(pecls))),
@@ -108,6 +113,8 @@ def uninstall(pecls):
 
         salt '*' pecl.uninstall fuse
     '''
+    if isinstance(pecls, six.string_types):
+        pecls = [pecls]
     return _pecl('uninstall {0}'.format(_cmd_quote(' '.join(pecls))))
 
 
@@ -124,6 +131,8 @@ def update(pecls):
 
         salt '*' pecl.update fuse
     '''
+    if isinstance(pecls, six.string_types):
+        pecls = [pecls]
     return _pecl('install -U {0}'.format(_cmd_quote(' '.join(pecls))))
 
 


### PR DESCRIPTION
The pecl module used to work with strings from the states. Now it's broken with the pecl state for old state definitions (and may even current ones).
