### PR TITLE
Don't stacktrace if there are conflicting id errors in highstate

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2433,7 +2433,11 @@ class BaseHighState(object):
         '''
         Returns the high data derived from the top file
         '''
-        tops = self.get_tops()
+        try:
+            tops = self.get_tops()
+        except SaltRenderError as err:
+            log.error('Unable to render top file: ' + str(err.error))
+            return {}
         return self.merge_tops(tops)
 
     def top_matches(self, top):
@@ -2936,7 +2940,7 @@ class BaseHighState(object):
             top = self.get_top()
         except SaltRenderError as err:
             ret[tag_name]['comment'] = 'Unable to render top file: '
-            ret[tag_name]['comment'] += err.error
+            ret[tag_name]['comment'] += str(err.error)
             return ret
         except Exception:
             trb = traceback.format_exc()
@@ -2945,7 +2949,7 @@ class BaseHighState(object):
         err += self.verify_tops(top)
         matches = self.top_matches(top)
         if not matches:
-            msg = ('No Top file or external nodes data matches found')
+            msg = 'No Top file or external nodes data matches found.'
             ret[tag_name]['comment'] = msg
             return ret
         matches = self.matches_whitelist(matches, whitelist)


### PR DESCRIPTION
Fixes #16753

Given the following top file:

```
base:
  '*':
    - foo
  '*':
    - bar
```

This fix allows the error to come through cleanly, instead of nasty stacktraces stated in the bug report, when running either a `state.show_top` or `state.highstate` like so:

```
root@rallytime:~# salt-call --local state.highstate
[INFO    ] Loading fresh modules for state activity
[INFO    ] Fetching file from saltenv 'base', ** skipped ** latest already in cache 'salt://top.sls'
[ERROR   ] Unable to render top file: Conflicting ID '*'
local:
----------
          ID: states
    Function: no.None
      Result: False
     Comment: Unable to render top file: Conflicting ID '*'
     Started:
    Duration:
     Changes:

Summary
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
root@rallytime:~# salt-call --local state.show_top
[INFO    ] Loading fresh modules for state activity
[INFO    ] Fetching file from saltenv 'base', ** skipped ** latest already in cache 'salt://top.sls'
[ERROR   ] Unable to render top file: Conflicting ID '*'
local:
    ----------
```
