### PR TITLE
states.file: allow prepending to non-existent file (#27401)

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3290,11 +3290,9 @@ def append(name,
             if not check_res:
                 return _error(ret, check_msg)
 
-        # Make sure that we have a file
-        __salt__['file.touch'](name)
-
     check_res, check_msg = _check_file(name)
     if not check_res:
+        # Try to create the file
         touch(name, makedirs=makedirs)
         retry_res, retry_msg = _check_file(name)
         if not retry_res:
@@ -3464,12 +3462,13 @@ def prepend(name,
             if not check_res:
                 return _error(ret, check_msg)
 
-        # Make sure that we have a file
-        __salt__['file.touch'](name)
-
     check_res, check_msg = _check_file(name)
     if not check_res:
-        return _error(ret, check_msg)
+        # Try to create the file
+        touch(name, makedirs=makedirs)
+        retry_res, retry_msg = _check_file(name)
+        if not retry_res:
+            return _error(ret, check_msg)
 
     # Follow the original logic and re-assign 'text' if using source(s)...
     if sl_:


### PR DESCRIPTION
Remove the redundant file.touch invocation also from file.append, to simplify the flow.

---

The test is largely a copy of the one for #1864. I verified that it fails without this change and passes with it.
