### PR TITLE
Ensure we pass on the enable setting if present, or use the default of True if not in build_schedule_item()

### DIFF
--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -275,6 +275,11 @@ def build_schedule_item(name, **kwargs):
     else:
         schedule[name]['name'] = name
 
+    if 'enabled' in kwargs:
+        schedule[name]['enabled'] = kwargs['enabled']
+    else:
+        schedule[name]['enabled'] = True
+
     if 'jid_include' not in kwargs or kwargs['jid_include']:
         schedule[name]['jid_include'] = True
 


### PR DESCRIPTION
Prior to this, when schedule.present compares the existing schedule to the one crafted by this function, enabled will actually be removed at each run.  schedule.present sees a modification needs to be made, and invokes schedule.modify, which does so with enabled: True, creating and endless loop of an 'enabled' removal and addition.
