### PR TITLE
Ensure git submodules are initialized when the submodules option is s…

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -1116,7 +1116,7 @@ def latest(name,
                 if submodules:
                     __salt__['git.submodule'](target,
                                               'update',
-                                              opts=['--recursive'],
+                                              opts=['--recursive', '--init'],
                                               user=user,
                                               identity=identity)
             elif bare:
@@ -1374,7 +1374,7 @@ def latest(name,
             if submodules and remote_rev:
                 __salt__['git.submodule'](target,
                                           'update',
-                                          opts=['--recursive'],
+                                          opts=['--recursive', '--init'],
                                           user=user,
                                           identity=identity)
 


### PR DESCRIPTION
…et to true

The git.latest state does not initialize submodules when the submodules:True option is specified. Hence, no submodules are fetched.

Steps to reproduce: git.latest any repo with submodules
Fix: add the --init flag to the "git submodule update" call
