### PR TITLE
Only clean context if it exists

### DIFF
--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -312,7 +312,8 @@ class AsyncZeroMQPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.t
             # TODO: Optionally call stream.close() on newer pyzmq? Its broken on some
             self._stream.io_loop.remove_handler(self._stream.socket)
             self._stream.socket.close(0)
-        self.context.term()
+        if hasattr(self, 'context'):
+            self.context.term()
 
     def __del__(self):
         self.destroy()


### PR DESCRIPTION
Prevents an attribute error
