### PR TITLE
Fix version reporting of python-gnupg and mysql-python

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -560,7 +560,7 @@ def dependency_information(include_salt_cloud=False):
         ('pycparser', 'pycparser', '__version__'),
         ('gitdb', 'gitdb', '__version__'),
         ('gitpython', 'gitpython', '__version__'),
-        ('python-gnupg', 'python-gnupg', '__version__'),
+        ('python-gnupg', 'gnupg', '__version__'),
         ('mysql-python', 'mysql-python', '__version__'),
         ('cherrypy', 'cherrypy', '__version__'),
     ]

--- a/salt/version.py
+++ b/salt/version.py
@@ -561,7 +561,7 @@ def dependency_information(include_salt_cloud=False):
         ('gitdb', 'gitdb', '__version__'),
         ('gitpython', 'gitpython', '__version__'),
         ('python-gnupg', 'gnupg', '__version__'),
-        ('mysql-python', 'mysql-python', '__version__'),
+        ('mysql-python', 'MySQLdb', '__version__'),
         ('cherrypy', 'cherrypy', '__version__'),
     ]
 


### PR DESCRIPTION
The module is called `gnupg`, not `python-gnupg`.

Without this, the version for `python-gnupg` will not show up with
`salt-call --versions-report`.

While looking at it, I've found the `('mysql-python', 'mysql-python', '__version__')` to look suspicious, too.  I have not tested it, but it should be fixed now, too.
