### PR TITLE
Add fake pymongo version attribute for the docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -123,8 +123,9 @@ MOCK_MODULES = [
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = Mock()
 
-# Define a fake version attribute for libcloud so docs build as supposed
+# Define a fake version attribute for the following libs.
 sys.modules['libcloud'].__version__ = '0.0.0'
+sys.modules['pymongo'].version = '0.0.0'
 
 
 # -- Add paths to PYTHONPATH ---------------------------------------------------


### PR DESCRIPTION
This bypasses the following traceback when building the docs.

``` python
File "/Users/shouse/src/salt/salt/salt/returners/mongo_future_return.py", line 72, in <module>
    version = '.'.join(version.split('.')[:2])
TypeError: 'Mock' object has no attribute '__getitem__'
```
