### PR TITLE
Use __states__ for calls to other boto states

### DIFF
--- a/salt/states/boto_asg.py
+++ b/salt/states/boto_asg.py
@@ -408,7 +408,7 @@ def present(
         for cfg in launch_config:
             args.update(cfg)
         if not __opts__['test']:
-            lc_ret = __salt__['state.single']('boto_lc.present', **args)
+            lc_ret = __states__['boto_lc.present'](**args)
             lc_ret = next(six.itervalues(lc_ret))
             if lc_ret['result'] is True and lc_ret['changes']:
                 if 'launch_config' not in ret['changes']:
@@ -612,7 +612,7 @@ def _alarms_present(name, alarms, alarms_from_pillar, region, key, keyid, profil
             'keyid': keyid,
             'profile': profile,
         }
-        ret = __salt__['state.single']('boto_cloudwatch_alarm.present', **kwargs)
+        ret = __states__['boto_cloudwatch_alarm.present'](**kwargs)
         results = next(six.itervalues(ret))
         if not results['result']:
             merged_return_value['result'] = False

--- a/salt/states/boto_asg.py
+++ b/salt/states/boto_asg.py
@@ -409,7 +409,6 @@ def present(
             args.update(cfg)
         if not __opts__['test']:
             lc_ret = __states__['boto_lc.present'](**args)
-            lc_ret = next(six.itervalues(lc_ret))
             if lc_ret['result'] is True and lc_ret['changes']:
                 if 'launch_config' not in ret['changes']:
                     ret['changes']['launch_config'] = {}
@@ -612,8 +611,7 @@ def _alarms_present(name, alarms, alarms_from_pillar, region, key, keyid, profil
             'keyid': keyid,
             'profile': profile,
         }
-        ret = __states__['boto_cloudwatch_alarm.present'](**kwargs)
-        results = next(six.itervalues(ret))
+        results = __states__['boto_cloudwatch_alarm.present'](**kwargs)
         if not results['result']:
             merged_return_value['result'] = False
         if results.get('changes', {}) != {}:

--- a/salt/states/boto_elb.py
+++ b/salt/states/boto_elb.py
@@ -335,8 +335,7 @@ def present(
             name, region, key, keyid, profile
         )
         for cname in cnames:
-            _ret = __salt__['state.single'](
-                'boto_route53.present',
+            _ret = __states__['boto_route53.present'](
                 name=cname.get('name'),
                 value=lb['dns_name'],
                 zone=cname.get('zone'),
@@ -912,7 +911,7 @@ def _alarms_present(name, alarms, alarms_from_pillar, region, key, keyid, profil
             "keyid": keyid,
             "profile": profile,
         }
-        ret = __salt__["state.single"]('boto_cloudwatch_alarm.present', **kwargs)
+        ret = __states__['boto_cloudwatch_alarm.present'](**kwargs)
         results = next(six.itervalues(ret))
         if not results["result"]:
             merged_return_value["result"] = results["result"]

--- a/salt/states/boto_elb.py
+++ b/salt/states/boto_elb.py
@@ -347,7 +347,6 @@ def present(
                 keyid=keyid,
                 profile=profile
             )
-            _ret = _ret.values()[0]
             ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
             ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
             if not _ret['result']:
@@ -911,8 +910,7 @@ def _alarms_present(name, alarms, alarms_from_pillar, region, key, keyid, profil
             "keyid": keyid,
             "profile": profile,
         }
-        ret = __states__['boto_cloudwatch_alarm.present'](**kwargs)
-        results = next(six.itervalues(ret))
+        results = __states__['boto_cloudwatch_alarm.present'](**kwargs)
         if not results["result"]:
             merged_return_value["result"] = results["result"]
         if results.get("changes", {}) != {}:


### PR DESCRIPTION
This change uses __states__ rather than __salt__['state.single'] in boto state module calls to other modules. Using __states__ means we won't need to reload modules on every call out to another state. If you have a lot of states and use calls out to other states (like an ASG or ELB that manages its alarms or route53 entries) this can save a considerable amount of time.
