### PR TITLE
fix for: https://github.com/saltstack/salt/issues/27373

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -401,7 +401,7 @@ class DownloadWindowsDlls(Command):
                         from contextlib import closing
                         with closing(requests.get(furl, stream=True)) as req:
                             if req.status_code == 200:
-                                with open(fdest, 'w') as wfh:
+                                with open(fdest, 'wb') as wfh:
                                     for chunk in req.iter_content(chunk_size=4096):
                                         if chunk:  # filter out keep-alive new chunks
                                             wfh.write(chunk)
@@ -416,7 +416,7 @@ class DownloadWindowsDlls(Command):
                         req = urlopen(furl)
 
                         if req.getcode() == 200:
-                            with open(fdest, 'w') as wfh:
+                            with open(fdest, 'wb') as wfh:
                                 while True:
                                     for chunk in req.read(4096):
                                         if not chunk:


### PR DESCRIPTION
Setup::DownloadWindowsDlls is downloading and writing the file as
a text not a binary file.

When creating the file handle to write the binary after being download from salt's
dependency repo, the file handle was being created with just the 'write' attribute,
however it also needs the 'binary' attribute.

Change-Id: I2f67d27ee847cd7808a78cd5ec0b2151d6a0c0e7
