### PR TITLE
Don't append role to hash_cachedir

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -1508,7 +1508,7 @@ class GitBase(object):
             self.cache_root = os.path.join(self.opts['cachedir'], self.role)
         self.env_cache = os.path.join(self.cache_root, 'envs.p')
         self.hash_cachedir = os.path.join(
-            self.cache_root, self.role, 'hash')
+            self.cache_root, 'hash')
         self.file_list_cachedir = os.path.join(
             self.opts['cachedir'], 'file_lists', self.role)
 


### PR DESCRIPTION
Fixes #27217.

Thanks to @nasenbaer13 for figuring this out and providing the commit to fix it.
