### PR TITLE
Outputters should sync to output, not outputters, on the minion.

### DIFF
--- a/doc/ref/file_server/dynamic-modules.rst
+++ b/doc/ref/file_server/dynamic-modules.rst
@@ -23,7 +23,7 @@ The directories are prepended with an underscore:
 - :file:`_renderers`
 - :file:`_returners`
 - :file:`_states`
-- :file:`_outputters`
+- :file:`_output`
 - :file:`_utils`
 
 The contents of these directories need to be synced over to the minions after

--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -134,7 +134,7 @@ def prep_trans_tar(file_client, chunks, file_refs, pillar=None):
             ['salt://_grains'],
             ['salt://_renderers'],
             ['salt://_returners'],
-            ['salt://_outputters'],
+            ['salt://_output'],
             ['salt://_utils'],
             ]
     with salt.utils.fopen(lowfn, 'w+') as fp_:

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -364,23 +364,25 @@ def sync_returners(saltenv=None, refresh=True):
     return ret
 
 
-def sync_outputters(saltenv=None, refresh=True):
+def sync_output(saltenv=None, refresh=True):
     '''
-    Sync the outputters from the _output directory on the salt master file
-    server. This function is environment aware, pass the desired environment
-    to grab the contents of the _output directory, base is the default
+    Sync the output modules from the _output directory on the salt master file
+    server. This function is environment aware. Pass the desired environment
+    to grab the contents of the _output directory. Base is the default
     environment.
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' saltutil.sync_outputters
+        salt '*' saltutil.sync_output
     '''
     ret = _sync('output', saltenv)
     if refresh:
         refresh_modules()
     return ret
+
+sync_outputters = sync_output
 
 
 def sync_utils(saltenv=None, refresh=True):
@@ -406,7 +408,7 @@ def sync_all(saltenv=None, refresh=True):
     '''
     Sync down all of the dynamic modules from the file server for a specific
     environment. This function synchronizes custom modules, states, beacons,
-    grains, returners, outputters, renderers, and utils.
+    grains, returners, output modules, renderers, and utils.
 
     refresh : True
         Also refresh the execution modules available to the minion.
@@ -425,7 +427,7 @@ def sync_all(saltenv=None, refresh=True):
     ret['grains'] = sync_grains(saltenv, False)
     ret['renderers'] = sync_renderers(saltenv, False)
     ret['returners'] = sync_returners(saltenv, False)
-    ret['output'] = sync_outputters(saltenv, False)
+    ret['output'] = sync_output(saltenv, False)
     ret['utils'] = sync_utils(saltenv, False)
     if refresh:
         refresh_modules()

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -366,9 +366,9 @@ def sync_returners(saltenv=None, refresh=True):
 
 def sync_outputters(saltenv=None, refresh=True):
     '''
-    Sync the outputters from the _outputters directory on the salt master file
+    Sync the outputters from the _output directory on the salt master file
     server. This function is environment aware, pass the desired environment
-    to grab the contents of the _outputters directory, base is the default
+    to grab the contents of the _output directory, base is the default
     environment.
 
     CLI Example:
@@ -377,7 +377,7 @@ def sync_outputters(saltenv=None, refresh=True):
 
         salt '*' saltutil.sync_outputters
     '''
-    ret = _sync('outputters', saltenv)
+    ret = _sync('output', saltenv)
     if refresh:
         refresh_modules()
     return ret
@@ -425,7 +425,7 @@ def sync_all(saltenv=None, refresh=True):
     ret['grains'] = sync_grains(saltenv, False)
     ret['renderers'] = sync_renderers(saltenv, False)
     ret['returners'] = sync_returners(saltenv, False)
-    ret['outputters'] = sync_outputters(saltenv, False)
+    ret['output'] = sync_outputters(saltenv, False)
     ret['utils'] = sync_utils(saltenv, False)
     if refresh:
         refresh_modules()


### PR DESCRIPTION
Otherwise, the loader won't pick them up.

Fixes #17103

All of the other custom dynamic modules map to their respective directories in the salt tree - outputters should, too. 
