### PR TITLE
Fix version reporting of gitpython

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -559,7 +559,7 @@ def dependency_information(include_salt_cloud=False):
         ('cffi', 'cffi', '__version__'),
         ('pycparser', 'pycparser', '__version__'),
         ('gitdb', 'gitdb', '__version__'),
-        ('gitpython', 'gitpython', '__version__'),
+        ('gitpython', 'git', '__version__'),
         ('python-gnupg', 'gnupg', '__version__'),
         ('mysql-python', 'MySQLdb', '__version__'),
         ('cherrypy', 'cherrypy', '__version__'),


### PR DESCRIPTION
The module is called `git`, not `gitpython`.

Without this, the version for `gitpython` will not show up with
`salt-call --versions-report`.
