### PR TITLE
dockerng: fix image_present for forced, non-existent image

### DIFF
--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -446,17 +446,18 @@ def image_present(name,
     image = ':'.join(_get_repo_tag(name))
     all_tags = __salt__['dockerng.list_tags']()
 
-    if image in all_tags and not force:
-        ret['result'] = True
-        ret['comment'] = 'Image \'{0}\' already present'.format(name)
-        return ret
-    elif force:
-        try:
-            image_info = __salt__['dockerng.inspect_image'](name)
-        except Exception as exc:
-            ret['comment'] = \
-                'Unable to get info for image \'{0}\': {1}'.format(name, exc)
+    if image in all_tags:
+        if not force:
+            ret['result'] = True
+            ret['comment'] = 'Image \'{0}\' already present'.format(name)
             return ret
+        else:
+            try:
+                image_info = __salt__['dockerng.inspect_image'](name)
+            except Exception as exc:
+                ret['comment'] = \
+                    'Unable to get info for image \'{0}\': {1}'.format(name, exc)
+                return ret
     else:
         image_info = None
 


### PR DESCRIPTION
With a non-existent image, which is forced, the call to `inspect_image`
will raise a `CommandExecutionError`: "Unable to get info for image".

This commit changes it to only call `inspect_image` for existing images.
