### PR TITLE
Add boothook support for cloud_init

### DIFF
--- a/salt/modules/boto_asg.py
+++ b/salt/modules/boto_asg.py
@@ -382,6 +382,10 @@ def get_cloud_init_mime(cloud_init):
     if isinstance(cloud_init, six.string_types):
         cloud_init = json.loads(cloud_init)
     _cloud_init = email.mime.multipart.MIMEMultipart()
+    if 'boothooks' in cloud_init:
+        for script_name, script in six.iteritems(cloud_init['boothooks']):
+            _script = email.mime.text.MIMEText(script, 'cloud-boothook')
+            _cloud_init.attach(_script)
     if 'scripts' in cloud_init:
         for script_name, script in six.iteritems(cloud_init['scripts']):
             _script = email.mime.text.MIMEText(script, 'x-shellscript')

--- a/salt/states/boto_lc.py
+++ b/salt/states/boto_lc.py
@@ -62,6 +62,10 @@ and autoscale groups are completely dependent on each other.
             - '/dev/sda1':
                 size: 20
         - cloud_init:
+            boothooks:
+              'disable-master.sh': |
+                #!/bin/bash
+                echo "manual" > /etc/init/salt-master.override
             scripts:
               'run_salt.sh': |
                 #!/bin/bash


### PR DESCRIPTION
This commit adds support for boothook scripts to cloud_init. These are executed early in the boot order, and can be used for e.g. disabling startup jobs.
