### PR TITLE
Refactored win_pkg to get all installed software as well as remove the win32* 3rd party module dependencies

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -15,7 +15,7 @@ from distutils.version import LooseVersion  # pylint: disable=import-error,no-na
 import salt.ext.six as six
 # pylint: disable=import-error
 try:
-    import _winreg
+    from salt.ext.six.moves import winreg as _winreg  # pylint: disable=import-error,no-name-in-module
     HAS_DEPENDENCIES = True
 except ImportError:
     HAS_DEPENDENCIES = False
@@ -382,22 +382,6 @@ def _get_product_information(reg_hive, reg_key, reg_handle):
     except WindowsError:
         pass
 
-    return products
-
-def _get_machine_keys():
-    '''
-    This will return the hive 'const' value and some registry keys where
-    installed software information has been known to exist for the
-    HKEY_LOCAL_MACHINE hive
-    '''
-    machine_hive_and_keys = {}
-    machine_keys = [
-        "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
-        "Software\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall"
-    ]
-    machine_hive = _winreg.HKEY_LOCAL_MACHINE
-    machine_hive_and_keys[machine_hive] = machine_keys
-    return machine_hive_and_keys
 
 def refresh_db(saltenv='base'):
     '''

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -384,6 +384,7 @@ def _get_product_information(reg_hive, reg_key, reg_handle):
 
     return products
 
+
 def refresh_db(saltenv='base'):
     '''
     Just recheck the repository and return a dict::

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1,11 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
 A module to manage software on Windows
-
-:depends:   - win32com
-            - win32con
-            - win32api
-            - pywintypes
 '''
 
 # Import python libs
@@ -20,8 +15,7 @@ from distutils.version import LooseVersion  # pylint: disable=import-error,no-na
 import salt.ext.six as six
 # pylint: disable=import-error
 try:
-    import win32api
-    import win32con
+    import _winreg
     HAS_DEPENDENCIES = True
 except ImportError:
     HAS_DEPENDENCIES = False
@@ -268,6 +262,74 @@ def _get_reg_software():
     display name as the key and the version as the value
     '''
     reg_software = {}
+
+    #attempt to corral the wild west of the multiple ways to install
+    #software in windows
+    reg_entries = dict(_get_machine_keys().items())
+    for reg_hive, reg_keys in six.iteritems(reg_entries):
+        for reg_key in reg_keys:
+
+            reg_handle = _open_registry_key(reg_hive, reg_key)
+            if reg_handle is None:
+                continue
+
+            products = _get_product_information(reg_hive, reg_key, reg_handle)
+            reg_software.update(products)
+
+            _winreg.CloseKey(reg_handle)
+
+    return reg_software
+
+
+def _get_machine_keys():
+    '''
+    This will return the hive 'const' value and some registry keys where
+    installed software information has been known to exist for the
+    HKEY_LOCAL_MACHINE hive
+    '''
+    machine_hive_and_keys = {}
+    machine_keys = [
+        "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
+        "Software\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall"
+    ]
+    machine_hive = _winreg.HKEY_LOCAL_MACHINE
+    machine_hive_and_keys[machine_hive] = machine_keys
+    return machine_hive_and_keys
+
+
+def _open_registry_key(reg_hive, reg_key):
+    reg_handle = None
+    try:
+        flags = _get_flags(reg_hive)
+
+        reg_handle = _winreg.OpenKeyEx(
+            reg_hive,
+            reg_key,
+            0,
+            flags)
+    # Unsinstall key may not exist for all users
+    except Exception:
+        pass
+
+    return reg_handle
+
+
+def _get_flags(reg_hive):
+    try:
+        reflect = _winreg.QueryReflectionKey(reg_hive)
+    except NotImplemented:
+        flags = reg_hive
+    else:
+        if reflect:
+            flags = _winreg.KEY_READ | _winreg.KEY_WOW64_64KEY
+        else:
+            flags = _winreg.KEY_READ | _winreg.KEY_WOW64_32KEY
+
+    return flags
+
+
+def _get_product_information(reg_hive, reg_key, reg_handle):
+
     # This is a list of default OS reg entries that don't seem to be installed
     # software and no version information exists on any of these items
     # Also, some MS Office updates don't register a product name which means
@@ -286,45 +348,41 @@ def _get_reg_software():
                    'Not Found']
     encoding = locale.getpreferredencoding()
 
-    #attempt to corral the wild west of the multiple ways to install
-    #software in windows
-    reg_entries = dict(_get_machine_keys().items())
-    for reg_hive, reg_keys in six.iteritems(reg_entries):
-        for reg_key in reg_keys:
+    products = {}
+    try:
+        i = 0
+        while True:
+            product_key = None
+            asubkey = _winreg.EnumKey(reg_handle, i)
+            rd_uninst_key = "\\".join([reg_key, asubkey])
+            displayName = ''
+            displayVersion = ''
             try:
-                reg_handle = win32api.RegOpenKeyEx(
-                    reg_hive,
-                    reg_key,
-                    0,
-                    win32con.KEY_READ)
-            except Exception:
-                pass
-                # Uninstall key may not exist for all users
-            for name, num, blank, time in win32api.RegEnumKeyEx(reg_handle):
-                prd_uninst_key = "\\".join([reg_key, name])
-                # These reg values aren't guaranteed to exist
-                windows_installer = _get_reg_value(
-                    reg_hive,
-                    prd_uninst_key,
-                    'WindowsInstaller')
-
-                prd_name = _get_reg_value(
-                    reg_hive,
-                    prd_uninst_key,
-                    "DisplayName")
+                # these are not garuanteed to exist
+                product_key = _open_registry_key(reg_hive, rd_uninst_key)
+                displayName, value_type = _winreg.QueryValueEx(product_key, "DisplayName")
                 try:
-                    prd_name = prd_name.decode(encoding)
+                    displayName = displayName.decode(encoding)
                 except Exception:
                     pass
-                prd_ver = _get_reg_value(
-                    reg_hive,
-                    prd_uninst_key,
-                    "DisplayVersion")
-                if name not in ignore_list:
-                    if prd_name != '':
-                        reg_software[prd_name] = prd_ver
-    return reg_software
+                displayVersion, value_type = _winreg.QueryValueEx(product_key, "DisplayVersion")
+            except Exception:
+                pass
 
+            if product_key is not None:
+                _winreg.CloseKey(product_key)
+            i += 1
+
+            if displayName not in ignore_list:
+                # some MS Office updates don't register a product name which means
+                # their information is useless
+                if displayName != '':
+                    products[displayName] = displayVersion
+
+    except WindowsError:
+        pass
+
+    return products
 
 def _get_machine_keys():
     '''
@@ -337,26 +395,9 @@ def _get_machine_keys():
         "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
         "Software\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall"
     ]
-    machine_hive = win32con.HKEY_LOCAL_MACHINE
+    machine_hive = _winreg.HKEY_LOCAL_MACHINE
     machine_hive_and_keys[machine_hive] = machine_keys
     return machine_hive_and_keys
-
-
-def _get_reg_value(reg_hive, reg_key, value_name=''):
-    '''
-    Read one value from Windows registry.
-    If 'name' is empty map, reads default value.
-    '''
-    try:
-        key_handle = win32api.RegOpenKeyEx(
-            reg_hive, reg_key, 0, win32con.KEY_ALL_ACCESS)
-        value_data, value_type = win32api.RegQueryValueEx(key_handle,
-                                                          value_name)
-        win32api.RegCloseKey(key_handle)
-    except Exception:
-        value_data = 'Not Found'
-    return value_data
-
 
 def refresh_db(saltenv='base'):
     '''

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -382,6 +382,7 @@ def _get_product_information(reg_hive, reg_key, reg_handle):
     except WindowsError:
         pass
 
+    return products
 
 def refresh_db(saltenv='base'):
     '''

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -379,10 +379,11 @@ def _get_product_information(reg_hive, reg_key, reg_handle):
                 if displayName != '':
                     products[displayName] = displayVersion
 
-    except WindowsError:
+    except WindowsError:  # pylint: disable=E0602
         pass
 
     return products
+
 
 def refresh_db(saltenv='base'):
     '''

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -269,6 +269,8 @@ def _get_reg_software():
     reg_software = {}
     # This is a list of default OS reg entries that don't seem to be installed
     # software and no version information exists on any of these items
+    # Also, some MS Office updates don't register a product name which means
+    # their information is useless.
     ignore_list = ['AddressBook',
                    'Connection Manager',
                    'DirectDrawEx',
@@ -279,8 +281,8 @@ def _get_reg_software():
                    'IEData',
                    'MobileOptionPack',
                    'SchedulingAgent',
-                   'WIC'
-                   ]
+                   'WIC',
+                   'Not Found']
     encoding = locale.getpreferredencoding()
 
     #attempt to corral the wild west of the multiple ways to install
@@ -318,11 +320,8 @@ def _get_reg_software():
                     prd_uninst_key,
                     "DisplayVersion")
                 if name not in ignore_list:
-                    if prd_name != 'Not Found':
-                        # some MS Office updates don't register a product name which means
-                        # their information is useless
-                        if prd_name != '':
-                            reg_software[prd_name] = prd_ver
+                    if prd_name != '':
+                        reg_software[prd_name] = prd_ver
     return reg_software
 
 

--- a/setup.py
+++ b/setup.py
@@ -401,7 +401,7 @@ class DownloadWindowsDlls(Command):
                         from contextlib import closing
                         with closing(requests.get(furl, stream=True)) as req:
                             if req.status_code == 200:
-                                with open(fdest, 'w') as wfh:
+                                with open(fdest, 'wb') as wfh:
                                     for chunk in req.iter_content(chunk_size=4096):
                                         if chunk:  # filter out keep-alive new chunks
                                             wfh.write(chunk)
@@ -416,7 +416,7 @@ class DownloadWindowsDlls(Command):
                         req = urlopen(furl)
 
                         if req.getcode() == 200:
-                            with open(fdest, 'w') as wfh:
+                            with open(fdest, 'wb') as wfh:
                                 while True:
                                     for chunk in req.read(4096):
                                         if not chunk:


### PR DESCRIPTION
Refactored win_pkg to get all installed software as well as remove the win32\* 3rd party module dependencies

Motivation:
I was not be able to get all installed software on both the 32bit and Wow64 registries. The problem is that the win32api module automatically redirects to the registry hive of the platform being run (Wow64 or 32 bit).
There was no way that I was able to find a way to prevent this from happening.

More information can be found here:
https://msdn.microsoft.com/en-us/library/windows/desktop/aa384232(v=vs.85).aspx

Furthermore, depending on if a program is 64 bit or 32 bit, when it is installed the program will be entered
in the appropriate registry hive. Thus, the win32api module will not get all installed software.

Implemantation/Fix:
The built in _winreg module allows for opening either the 64 or 32 bit hive, thus allowing for all installed software to be reported.
Furtheremore, using _winreg allows for the removal of third party dependencies as it is a built-in module for python.
