### PR TITLE
Ensure git submodules are initialized when the submodules option is set to true

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -314,7 +314,7 @@ def latest(name,
                     __salt__['git.submodule'](target,
                                               user=user,
                                               identity=identity,
-                                              opts='--recursive')
+                                              opts='--recursive --init')
 
                 try:
                     new_rev = __salt__['git.revision'](cwd=target, user=user)
@@ -377,7 +377,7 @@ def latest(name,
                 __salt__['git.submodule'](target,
                                           user=user,
                                           identity=identity,
-                                          opts='--recursive')
+                                          opts='--recursive --init')
 
             new_rev = None
             if not bare:


### PR DESCRIPTION
The git.latest state does not initialize submodules when the submodules:True
option is specified. Hence, no submodules are fetched.
 Steps to reproduce: git.latest any repo with submodules
 Fix: add the --init
flag to the "git submodule update" call
