### PR TITLE
Removed dependency on powershell to restart salt-minion

### DIFF
--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -8,14 +8,9 @@ from __future__ import absolute_import
 import salt.utils
 import time
 import logging
-import os
 from subprocess import list2cmdline
 from salt.ext.six.moves import zip
 from salt.ext.six.moves import range
-try:
-    from shlex import quote as _cmd_quote  # pylint: disable=E0611
-except ImportError:
-    from pipes import quote as _cmd_quote
 
 log = logging.getLogger(__name__)
 

--- a/tests/unit/modules/win_service_test.py
+++ b/tests/unit/modules/win_service_test.py
@@ -119,21 +119,16 @@ class WinServiceTestCase(TestCase):
         '''
             Test to restart the named service
         '''
-        mock = MagicMock(side_effect=[True, True, False])
-        with patch.object(win_service, 'has_powershell', mock):
-            mock_true = MagicMock(return_value=True)
-            with patch.object(win_service, 'create_win_salt_restart_task',
+        mock_true = MagicMock(return_value=True)
+        with patch.object(win_service, 'create_win_salt_restart_task',
+                          mock_true):
+            with patch.object(win_service, 'execute_salt_restart_task',
                               mock_true):
-                with patch.object(win_service, 'execute_salt_restart_task',
-                                  mock_true):
-                    self.assertTrue(win_service.restart("salt-minion"))
+                self.assertTrue(win_service.restart("salt-minion"))
 
-            with patch.dict(win_service.__salt__, {'cmd.retcode': mock_true}):
-                self.assertFalse(win_service.restart("salt"))
-
-            with patch.object(win_service, 'stop', mock_true):
-                with patch.object(win_service, 'start', mock_true):
-                    self.assertTrue(win_service.restart("salt"))
+        with patch.object(win_service, 'stop', mock_true):
+            with patch.object(win_service, 'start', mock_true):
+                self.assertTrue(win_service.restart("salt"))
 
     def test_createwin_saltrestart_task(self):
         '''


### PR DESCRIPTION
Fixes: #26629

Used `net stop && net start instead` of a powershell command to restart the
salt-minion service.

Removed function that checks for powershell on the machine as it's no longer needed.
