### PR TITLE
Add missing newlines before param listing to fix doc rendering

### DIFF
--- a/salt/modules/slack_notify.py
+++ b/salt/modules/slack_notify.py
@@ -159,6 +159,7 @@ def list_rooms(api_key=None):
 def list_users(api_key=None):
     '''
     List all Slack users.
+
     :param api_key: The Slack admin api key.
     :return: The user list.
 
@@ -176,6 +177,7 @@ def list_users(api_key=None):
 def find_room(name, api_key=None):
     '''
     Find a room by name and return it.
+
     :param name:    The room name.
     :param api_key: The Slack admin api key.
     :return:        The room object.
@@ -207,6 +209,7 @@ def find_room(name, api_key=None):
 def find_user(name, api_key=None):
     '''
     Find a user by name and return it.
+
     :param name:        The user name.
     :param api_key:     The Slack admin api key.
     :return:            The user object.
@@ -235,6 +238,7 @@ def post_message(channel,
                  api_key=None):
     '''
     Send a message to a Slack channel.
+
     :param channel:     The channel name, either will work.
     :param message:     The message to send to the Slack channel.
     :param from_name:   Specify who the message is from.


### PR DESCRIPTION
This fixes the [rendering of the docs](https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.slack_notify.html) where the params are currently not properly rendered:

![slack-params](https://cloud.githubusercontent.com/assets/48491/10178934/161e1ce0-6703-11e5-867f-b96d8d4c5d54.png)
