### PR TITLE
returners.local_cache: fix endless loop on OSError

### DIFF
--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -98,8 +98,7 @@ def prep_jid(nocache=False, passed_jid=None, recurse_count=0):
     except OSError:
         time.sleep(0.1)
         if passed_jid is None:
-            recurse_count += recurse_count
-            return prep_jid(nocache=nocache)
+            return prep_jid(nocache=nocache, recurse_count=recurse_count+1)
 
     try:
         with salt.utils.fopen(os.path.join(jid_dir_, 'jid'), 'wb+') as fn_:
@@ -110,8 +109,8 @@ def prep_jid(nocache=False, passed_jid=None, recurse_count=0):
     except IOError:
         log.warn('Could not write out jid file for job {0}. Retrying.'.format(jid))
         time.sleep(0.1)
-        recurse_count += recurse_count
-        return prep_jid(passed_jid=jid, nocache=nocache)
+        return prep_jid(passed_jid=jid, nocache=nocache,
+                        recurse_count=recurse_count+1)
 
     return jid
 

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -76,23 +76,25 @@ def _walk_through(job_dir):
 #TODO: add to returner docs-- this is a new one
 def prep_jid(nocache=False, passed_jid=None, recurse_count=0):
     '''
-    Return a job id and prepare the job id directory
-    This is the function responsible for making sure jids don't collide (unless its passed a jid)
+    Return a job id and prepare the job id directory.
+
+    This is the function responsible for making sure jids don't collide (unless
+    it is passed a jid).
     So do what you have to do to make sure that stays the case
     '''
     if recurse_count >= 5:
         err = 'prep_jid could not store a jid after {0} tries.'.format(recurse_count)
         log.error(err)
         raise salt.exceptions.SaltCacheError(err)
-    if passed_jid is None:  # this can be a None of an empty string
+    if passed_jid is None:  # this can be a None or an empty string.
         jid = salt.utils.jid.gen_jid()
     else:
         jid = passed_jid
 
     jid_dir_ = _jid_dir(jid)
 
-    # make sure we create the jid dir, otherwise someone else is using it,
-    # meaning we need a new jid
+    # Make sure we create the jid dir, otherwise someone else is using it,
+    # meaning we need a new jid.
     try:
         os.makedirs(jid_dir_)
     except OSError:


### PR DESCRIPTION
I was getting a "Permission denied" OSError when running as a non-root
user, from the example provided at
https://docs.saltstack.com/en/latest/ref/runners/all/salt.runners.pillar.html#salt.runners.pillar.show_pillar:

```
import salt.config
import salt.runner
opts = salt.config.master_config('/etc/salt/master')
runner = salt.runner.RunnerClient(opts)
pillar = runner.cmd('pillar.show_pillar')
print(pillar)
```

This patch passes on the increased `recurse_count` argument, so it will
eventually abort after 5 retries.
