### PR TITLE
Use getattr to fetch psutil.version_info

### DIFF
--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -22,7 +22,7 @@ try:
     import salt.utils.psutil_compat as psutil
 
     HAS_PSUTIL = True
-    PSUTIL2 = psutil.version_info >= (2, 0)
+    PSUTIL2 = getattr(psutil, 'version_info', ()) >= (2, 0)
 except ImportError:
     HAS_PSUTIL = False
 # pylint: enable=import-error


### PR DESCRIPTION
This was preventing the docs for this module from getting built. I'm not sure how or if that can be mocked using our normal docs Mock() system.

It may be better to use Salt's loader to build the docs rather than mocking imports. Needs experimentation...

Closes #25441.
