### PR TITLE
updating boto_ec2 module to get the vpc_id key out of the vpc_id dict…

### DIFF
--- a/salt/modules/boto_ec2.py
+++ b/salt/modules/boto_ec2.py
@@ -723,6 +723,7 @@ def create_network_interface(
     vpc_id = __salt__['boto_vpc.get_subnet_association'](
         [subnet_id], region=region, key=key, keyid=keyid, profile=profile
     )
+    vpc_id = vpc_id.get('vpc_id')
     if not vpc_id:
         msg = 'subnet_id {0} does not map to a valid vpc id.'.format(subnet_id)
         r['error'] = {'message': msg}


### PR DESCRIPTION
… returned from boto_vpc.get_subnet_association

fixes #27571 
