### PR TITLE
Add support for 'vpc_name' tag in boto_secgroup module and state

### DIFF
--- a/salt/modules/boto_secgroup.py
+++ b/salt/modules/boto_secgroup.py
@@ -51,6 +51,7 @@ import logging
 import re
 from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
 import salt.ext.six as six
+from salt.exceptions import SaltInvocationError
 
 log = logging.getLogger(__name__)
 

--- a/salt/modules/boto_secgroup.py
+++ b/salt/modules/boto_secgroup.py
@@ -51,6 +51,8 @@ import logging
 import re
 from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
 import salt.ext.six as six
+import salt.utils.boto
+from salt.exceptions import SaltInvocationError, CommandExecutionError
 
 log = logging.getLogger(__name__)
 
@@ -89,9 +91,9 @@ def __virtual__():
 
 
 def exists(name=None, region=None, key=None, keyid=None, profile=None,
-           vpc_id=None, group_id=None):
+           vpc_id=None, vpc_name=None, group_id=None):
     '''
-    Check to see if an security group exists.
+    Check to see if a security group exists.
 
     CLI example::
 
@@ -99,11 +101,114 @@ def exists(name=None, region=None, key=None, keyid=None, profile=None,
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
-    group = _get_group(conn, name, vpc_id, group_id, region)
+    if not vpc_id and vpc_name:
+        try:
+            vpc_id = _check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
+        except boto.exception.BotoServerError as e:
+            log.debug(e)
+            return False
+
+    group = _get_group(conn, name, vpc_id, vpc_name, group_id, region)
     if group:
         return True
     else:
         return False
+
+def _check_vpc(vpc_id, vpc_name, region, key, keyid, profile):
+    '''
+    Check whether a VPC with the given name or id exists.
+    Returns the vpc_id or None. Raises SaltInvocationError if
+    both vpc_id and vpc_name are None. Optionally raise a
+    CommandExecutionError if the VPC does not exist.
+    '''
+
+    if not _exactly_one((vpc_name, vpc_id)):
+        raise SaltInvocationError('One (but not both) of vpc_id or vpc_name '
+                                  'must be provided.')
+    if vpc_name:
+        vpc_id = _get_id(vpc_name=vpc_name, region=region, key=key, keyid=keyid,
+                         profile=profile)
+    elif not _find_vpcs(vpc_id=vpc_id, region=region, key=key, keyid=keyid,
+                        profile=profile):
+        log.info('VPC {0} does not exist.'.format(vpc_id))
+        return None
+    return vpc_id
+
+
+
+def _get_id(vpc_name=None, cidr=None, tags=None, region=None, key=None,
+            keyid=None, profile=None):
+    '''
+    Given VPC properties, return the VPC id if a match is found.
+    '''
+
+    if vpc_name and not any((cidr, tags)):
+        vpc_id = _cache_id(vpc_name, region=region,
+                           key=key, keyid=keyid,
+                           profile=profile)
+        if vpc_id:
+            return vpc_id
+
+    vpc_ids = _find_vpcs(vpc_name=vpc_name, cidr=cidr, tags=tags, region=region,
+                         key=key, keyid=keyid, profile=profile)
+    if vpc_ids:
+        log.info("Matching VPC: {0}".format(" ".join(vpc_ids)))
+        if len(vpc_ids) == 1:
+            vpc_id = vpc_ids[0]
+            if vpc_name:
+                _cache_id(vpc_name, vpc_id,
+                          region=region, key=key,
+                          keyid=keyid, profile=profile)
+            return vpc_id
+        else:
+            raise CommandExecutionError('Found more than one VPC matching the criteria.')
+    else:
+        log.info('No VPC found.')
+        return None
+
+
+def _find_vpcs(vpc_id=None, vpc_name=None, cidr=None, tags=None,
+               region=None, key=None, keyid=None, profile=None):
+
+    '''
+    Given VPC properties, find and return matching VPC ids.
+    '''
+
+    if all((vpc_id, vpc_name)):
+        raise SaltInvocationError('Only one of vpc_name or vpc_id may be '
+                                  'provided.')
+
+    if not any((vpc_id, vpc_name, tags, cidr)):
+        raise SaltInvocationError('At least one of the following must be '
+                                  'provided: vpc_id, vpc_name, cidr or tags.')
+
+    # Special connection to 'vpc' since 'ec2' connex don't provide get_all_vpcs()
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    conn = __utils__['boto.get_connection']('vpc', module=None, region=region,
+                       key=key, keyid=keyid, profile=profile)
+
+    filter_parameters = {'filters': {}}
+
+    if vpc_id:
+        filter_parameters['vpc_ids'] = [vpc_id]
+
+    if cidr:
+        filter_parameters['filters']['cidr'] = cidr
+
+    if vpc_name:
+        filter_parameters['filters']['tag:Name'] = vpc_name
+
+    if tags:
+        for tag_name, tag_value in six.iteritems(tags):
+            filter_parameters['filters']['tag:{0}'.format(tag_name)] = tag_value
+
+    vpcs = conn.get_all_vpcs(**filter_parameters)
+    log.debug('The filters criteria {0} matched the following VPCs:{1}'.format(filter_parameters, vpcs))
+
+    if vpcs:
+        return [vpc.id for vpc in vpcs]
+    else:
+        return []
 
 
 def _split_rules(rules):
@@ -131,12 +236,20 @@ def _split_rules(rules):
     return split
 
 
-def _get_group(conn, name=None, vpc_id=None, group_id=None, region=None):  # pylint: disable=W0613
+def _get_group(conn, name=None, vpc_id=None, vpc_name=None, group_id=None, region=None):  # pylint: disable=W0613
     '''
-    Get a group object given a name, name and vpc_id or group_id. Return a
-    boto.ec2.securitygroup.SecurityGroup object if the group is found, else
+    Get a group object given a name, name and vpc_id/vpc_name or group_id. Return
+    a boto.ec2.securitygroup.SecurityGroup object if the group is found, else
     return None.
     '''
+
+    if not vpc_id and vpc_name:
+        try:
+            vpc_id = _check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
+        except boto.exception.BotoServerError as e:
+            log.debug(e)
+            return None
+
     if name:
         if vpc_id is None:
             log.debug('getting group for {0}'.format(name))
@@ -211,7 +324,8 @@ def _parse_rules(sg, rules):
     return _rules
 
 
-def get_group_id(name, vpc_id=None, region=None, key=None, keyid=None, profile=None):
+def get_group_id(name, vpc_id=None, vpc_name=None, region=None, key=None,
+                 keyid=None, profile=None):
     '''
     Get a Group ID given a Group Name or Group Name and VPC ID
 
@@ -221,15 +335,22 @@ def get_group_id(name, vpc_id=None, region=None, key=None, keyid=None, profile=N
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
-    group = _get_group(conn, name, vpc_id, region)
+    if not vpc_id and vpc_name:
+        try:
+            vpc_id = _check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
+        except boto.exception.BotoServerError as e:
+            log.debug(e)
+            return False
+
+    group = _get_group(conn, name, vpc_id, vpc_name, region)
     if group:
         return group.id
     else:
         return False
 
 
-def convert_to_group_ids(groups, vpc_id, region=None, key=None, keyid=None,
-                         profile=None):
+def convert_to_group_ids(groups, vpc_id, vpc_name=None, region=None, key=None,
+                         keyid=None, profile=None):
     '''
     Given a list of security groups and a vpc_id, convert_to_group_ids will
     convert all list items in the given list to security group ids.
@@ -248,7 +369,7 @@ def convert_to_group_ids(groups, vpc_id, region=None, key=None, keyid=None,
         else:
             log.debug('calling boto_secgroup.get_group_id for'
                       ' group name {0}'.format(group))
-            group_id = get_group_id(group, vpc_id, region, key, keyid, profile)
+            group_id = get_group_id(group, vpc_id, vpc_name, region, key, keyid, profile)
             log.debug('group name {0} has group id {1}'.format(
                 group, group_id)
             )
@@ -258,7 +379,7 @@ def convert_to_group_ids(groups, vpc_id, region=None, key=None, keyid=None,
 
 
 def get_config(name=None, group_id=None, region=None, key=None, keyid=None,
-               profile=None, vpc_id=None):
+               profile=None, vpc_id=None, vpc_name=None):
     '''
     Get the configuration for a security group.
 
@@ -268,7 +389,14 @@ def get_config(name=None, group_id=None, region=None, key=None, keyid=None,
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
-    sg = _get_group(conn, name, vpc_id, group_id, region)
+    if not vpc_id and vpc_name:
+        try:
+            vpc_id = _check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
+        except boto.exception.BotoServerError as e:
+            log.debug(e)
+            return None
+
+    sg = _get_group(conn, name, vpc_id, vpc_name, group_id, region)
     if sg:
         ret = odict.OrderedDict()
         ret['name'] = sg.name
@@ -287,8 +415,8 @@ def get_config(name=None, group_id=None, region=None, key=None, keyid=None,
         return None
 
 
-def create(name, description, vpc_id=None, region=None, key=None, keyid=None,
-           profile=None):
+def create(name, description, vpc_id=None, vpc_name=None, region=None, key=None,
+           keyid=None, profile=None):
     '''
     Create a security group.
 
@@ -297,6 +425,13 @@ def create(name, description, vpc_id=None, region=None, key=None, keyid=None,
         salt myminion boto_secgroup.create mysecgroup 'My Security Group'
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    if not vpc_id and vpc_name:
+        try:
+            vpc_id = _check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
+        except boto.exception.BotoServerError as e:
+            log.debug(e)
+            return False
 
     created = conn.create_security_group(name, description, vpc_id)
     if created:
@@ -309,7 +444,7 @@ def create(name, description, vpc_id=None, region=None, key=None, keyid=None,
 
 
 def delete(name=None, group_id=None, region=None, key=None, keyid=None,
-           profile=None, vpc_id=None):
+           profile=None, vpc_id=None, vpc_name=None):
     '''
     Delete a security group.
 
@@ -319,7 +454,14 @@ def delete(name=None, group_id=None, region=None, key=None, keyid=None,
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
-    group = _get_group(conn, name, vpc_id, group_id, region)
+    if not vpc_id and vpc_name:
+        try:
+            vpc_id = _check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
+        except boto.exception.BotoServerError as e:
+            log.debug(e)
+            return False
+
+    group = _get_group(conn, name, vpc_id, vpc_name, group_id, region)
     if group:
         deleted = conn.delete_security_group(group_id=group.id)
         if deleted:
@@ -338,8 +480,8 @@ def delete(name=None, group_id=None, region=None, key=None, keyid=None,
 def authorize(name=None, source_group_name=None,
               source_group_owner_id=None, ip_protocol=None,
               from_port=None, to_port=None, cidr_ip=None, group_id=None,
-              source_group_group_id=None, region=None, key=None,
-              keyid=None, profile=None, vpc_id=None, egress=False):
+              source_group_group_id=None, region=None, key=None, keyid=None,
+              profile=None, vpc_id=None, vpc_name=None, egress=False):
     '''
     Add a new rule to an existing security group.
 
@@ -349,7 +491,14 @@ def authorize(name=None, source_group_name=None,
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
-    group = _get_group(conn, name, vpc_id, group_id, region)
+    if not vpc_id and vpc_name:
+        try:
+            vpc_id = _check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
+        except boto.exception.BotoServerError as e:
+            log.debug(e)
+            return False
+
+    group = _get_group(conn, name, vpc_id, vpc_name, group_id, region)
     if group:
         try:
             added = None
@@ -388,8 +537,8 @@ def authorize(name=None, source_group_name=None,
 def revoke(name=None, source_group_name=None,
            source_group_owner_id=None, ip_protocol=None,
            from_port=None, to_port=None, cidr_ip=None, group_id=None,
-           source_group_group_id=None, region=None, key=None,
-           keyid=None, profile=None, vpc_id=None, egress=False):
+           source_group_group_id=None, region=None, key=None, keyid=None,
+           profile=None, vpc_id=None, vpc_name=None, egress=False):
     '''
     Remove a rule from an existing security group.
 
@@ -399,7 +548,14 @@ def revoke(name=None, source_group_name=None,
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
-    group = _get_group(conn, name, vpc_id, group_id, region)
+    if not vpc_id and vpc_name:
+        try:
+            vpc_id = _check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
+        except boto.exception.BotoServerError as e:
+            log.debug(e)
+            return False
+
+    group = _get_group(conn, name, vpc_id, vpc_name, group_id, region)
     if group:
         try:
             revoked = None

--- a/salt/modules/boto_secgroup.py
+++ b/salt/modules/boto_secgroup.py
@@ -51,7 +51,6 @@ import logging
 import re
 from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
 import salt.ext.six as six
-import salt.utils.boto
 from salt.exceptions import SaltInvocationError, CommandExecutionError
 
 log = logging.getLogger(__name__)
@@ -114,6 +113,7 @@ def exists(name=None, region=None, key=None, keyid=None, profile=None,
     else:
         return False
 
+
 def _check_vpc(vpc_id, vpc_name, region, key, keyid, profile):
     '''
     Check whether a VPC with the given name or id exists.
@@ -133,7 +133,6 @@ def _check_vpc(vpc_id, vpc_name, region, key, keyid, profile):
         log.info('VPC {0} does not exist.'.format(vpc_id))
         return None
     return vpc_id
-
 
 
 def _get_id(vpc_name=None, cidr=None, tags=None, region=None, key=None,

--- a/salt/modules/boto_secgroup.py
+++ b/salt/modules/boto_secgroup.py
@@ -150,9 +150,9 @@ def _get_group(conn=None, name=None, vpc_id=None, vpc_name=None, group_id=None,
     a boto.ec2.securitygroup.SecurityGroup object if the group is found, else
     return None.
     '''
-    if not _exactly_one((vpc_name, vpc_id)):
-        raise SaltInvocationError('One (but not both) of vpc_id or vpc_name '
-                                  'must be provided.')
+    if vpc_name and vpc_id:
+        raise SaltInvocationError('The params \'vpc_id\' and \'vpc_name\' '
+                                  'are mutually exclusive.')
 
     if not vpc_id and vpc_name:
         try:

--- a/salt/states/boto_secgroup.py
+++ b/salt/states/boto_secgroup.py
@@ -87,6 +87,7 @@ import logging
 
 # Import salt libs
 import salt.utils.dictupdate as dictupdate
+import salt.utils.boto
 from salt.exceptions import SaltInvocationError
 from salt.ext.six import string_types
 
@@ -104,6 +105,7 @@ def present(
         name,
         description,
         vpc_id=None,
+        vpc_name=None,
         rules=None,
         rules_egress=None,
         region=None,
@@ -120,7 +122,10 @@ def present(
         A description of this security group.
 
     vpc_id
-        The ID of the VPC to create the security group in, if any.
+        The ID of the VPC to create the security group in, if any. Exclusive with vpc_name.
+
+    vpc_name
+        The name of the VPC wherein to create the security group, if any. Exclusive with vpc_id.
 
     rules
         A list of ingress rule dicts.
@@ -142,7 +147,7 @@ def present(
         that contains a dict with region, key and keyid.
     '''
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
-    _ret = _security_group_present(name, description, vpc_id, region, key,
+    _ret = _security_group_present(name, description, vpc_id, vpc_name, region, key,
                                    keyid, profile)
     ret['changes'] = _ret['changes']
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
@@ -154,7 +159,8 @@ def present(
         rules = []
     if not rules_egress:
         rules_egress = []
-    _ret = _rules_present(name, rules, rules_egress, vpc_id, region, key, keyid, profile)
+    _ret = _rules_present(name, rules, rules_egress, vpc_id, vpc_name, region, key,
+                          keyid, profile)
     ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
     if not _ret['result']:
@@ -166,6 +172,7 @@ def _security_group_present(
         name,
         description,
         vpc_id,
+        vpc_name,
         region,
         key,
         keyid,
@@ -178,7 +185,7 @@ def _security_group_present(
     '''
     ret = {'result': True, 'comment': '', 'changes': {}}
     exists = __salt__['boto_secgroup.exists'](name, region, key, keyid,
-                                              profile, vpc_id)
+                                              profile, vpc_id, vpc_name)
     if not exists:
         if __opts__['test']:
             msg = 'Security group {0} is set to be created.'.format(name)
@@ -186,11 +193,13 @@ def _security_group_present(
             ret['result'] = None
             return ret
         created = __salt__['boto_secgroup.create'](name, description, vpc_id,
-                                                   region, key, keyid, profile)
+                                                   vpc_name, region, key, keyid,
+                                                   profile)
         if created:
             ret['changes']['old'] = {'secgroup': None}
             sg = __salt__['boto_secgroup.get_config'](name, None, region, key,
-                                                      keyid, profile, vpc_id)
+                                                      keyid, profile, vpc_id,
+                                                      vpc_name)
             ret['changes']['new'] = {'secgroup': sg}
             ret['comment'] = 'Security group {0} created.'.format(name)
         else:
@@ -340,12 +349,13 @@ def _rules_present(
         rules,
         rules_egress,
         vpc_id,
+        vpc_name,
         region,
         key,
         keyid,
         profile):
     '''
-    given a group name or group name and vpc_id:
+    given a group name or group name and vpc_id/vpc_name:
     1. get lists of desired rule changes (using _get_rule_changes)
     2. delete/revoke or authorize/create rules
     3. return 'old' and 'new' group rules
@@ -354,7 +364,7 @@ def _rules_present(
 
     ret = {'result': True, 'comment': '', 'changes': {}}
     sg = __salt__['boto_secgroup.get_config'](name, None, region, key, keyid,
-                                              profile, vpc_id)
+                                              profile, vpc_id, vpc_name)
     if not sg:
         msg = '{0} security group configuration could not be retrieved.'
         ret['comment'] = msg.format(name)
@@ -362,12 +372,12 @@ def _rules_present(
         return ret
     rules = _split_rules(rules)
     rules_egress = _split_rules(rules_egress)
-    if vpc_id:
+    if vpc_id or vpc_name:
         for rule in itertools.chain(rules, rules_egress):
             _source_group_name = rule.get('source_group_name', None)
             if _source_group_name:
                 _group_id = __salt__['boto_secgroup.get_group_id'](
-                    _source_group_name, vpc_id, region, key, keyid, profile
+                    _source_group_name, vpc_id, vpc_id, region, key, keyid, profile
                 )
                 if not _group_id:
                     msg = ('source_group_name {0} does not map to a valid'
@@ -389,8 +399,8 @@ def _rules_present(
             deleted = True
             for rule in to_delete:
                 _deleted = __salt__['boto_secgroup.revoke'](
-                    name, vpc_id=vpc_id, region=region, key=key, keyid=keyid,
-                    profile=profile, **rule)
+                    name, vpc_id=vpc_id, vpc_name=vpc_name, region=region, key=key,
+                    keyid=keyid, profile=profile, **rule)
                 if not _deleted:
                     deleted = False
             if deleted:
@@ -404,8 +414,8 @@ def _rules_present(
             created = True
             for rule in to_create:
                 _created = __salt__['boto_secgroup.authorize'](
-                    name, vpc_id=vpc_id, region=region, key=key, keyid=keyid,
-                    profile=profile, **rule)
+                    name, vpc_id=vpc_id, vpc_name=vpc_name, region=region, key=key,
+                    keyid=keyid, profile=profile, **rule)
                 if not _created:
                     created = False
             if created:
@@ -420,8 +430,8 @@ def _rules_present(
             deleted = True
             for rule in to_delete_egress:
                 _deleted = __salt__['boto_secgroup.revoke'](
-                    name, vpc_id=vpc_id, region=region, key=key, keyid=keyid,
-                    profile=profile, egress=True, **rule)
+                    name, vpc_id=vpc_id, vpc_name=vpc_name, region=region, key=key,
+                    keyid=keyid, profile=profile, egress=True, **rule)
                 if not _deleted:
                     deleted = False
             if deleted:
@@ -436,8 +446,8 @@ def _rules_present(
             created = True
             for rule in to_create_egress:
                 _created = __salt__['boto_secgroup.authorize'](
-                    name, vpc_id=vpc_id, region=region, key=key, keyid=keyid,
-                    profile=profile, egress=True, **rule)
+                    name, vpc_id=vpc_id, vpc_name=vpc_name, region=region, key=key,
+                    keyid=keyid, profile=profile, egress=True, **rule)
                 if not _created:
                     created = False
             if created:
@@ -450,7 +460,7 @@ def _rules_present(
 
         ret['changes']['old'] = {'rules': sg['rules'], 'rules_egress': sg['rules_egress']}
         sg = __salt__['boto_secgroup.get_config'](name, None, region, key,
-                                                  keyid, profile, vpc_id)
+                                                  keyid, profile, vpc_id, vpc_name)
         ret['changes']['new'] = {'rules': sg['rules'], 'rules_egress': sg['rules_egress']}
     return ret
 
@@ -458,6 +468,7 @@ def _rules_present(
 def absent(
         name,
         vpc_id=None,
+        vpc_name=None,
         region=None,
         key=None,
         keyid=None,
@@ -469,7 +480,10 @@ def absent(
         Name of the security group.
 
     vpc_id
-        The ID of the VPC to create the security group in, if any.
+        The ID of the VPC to remove the security group from, if any. Exclusive with vpc_name.
+
+    vpc_name
+        The name of the VPC wherefrom to delete the security group, if any. Exclusive with vpc_id.
 
     region
         Region to connect to.
@@ -487,7 +501,7 @@ def absent(
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
 
     sg = __salt__['boto_secgroup.get_config'](name, True, region, key, keyid,
-                                              profile, vpc_id)
+                                              profile, vpc_id, vpc_name)
     if sg:
         if __opts__['test']:
             msg = 'Security group {0} is set to be removed.'.format(name)
@@ -495,7 +509,7 @@ def absent(
             ret['result'] = None
             return ret
         deleted = __salt__['boto_secgroup.delete'](name, None, region, key,
-                                                   keyid, profile, vpc_id)
+                                                   keyid, profile, vpc_id, vpc_name)
         if deleted:
             ret['changes']['old'] = {'secgroup': sg}
             ret['changes']['new'] = {'secgroup': None}

--- a/salt/states/boto_secgroup.py
+++ b/salt/states/boto_secgroup.py
@@ -87,7 +87,6 @@ import logging
 
 # Import salt libs
 import salt.utils.dictupdate as dictupdate
-import salt.utils.boto
 from salt.exceptions import SaltInvocationError
 from salt.ext.six import string_types
 

--- a/salt/states/boto_secgroup.py
+++ b/salt/states/boto_secgroup.py
@@ -376,7 +376,7 @@ def _rules_present(
             _source_group_name = rule.get('source_group_name', None)
             if _source_group_name:
                 _group_id = __salt__['boto_secgroup.get_group_id'](
-                    _source_group_name, vpc_id, vpc_id, region, key, keyid, profile
+                    _source_group_name, vpc_id, vpc_name, region, key, keyid, profile
                 )
                 if not _group_id:
                     msg = ('source_group_name {0} does not map to a valid'


### PR DESCRIPTION
Annoying to not be able to build out a whole VPC in one go because there's no way to get the vpc_id of our freshly created VPC and pump it into boto_secgroup, the way you can for all the boto_vpc functions...

Note that this DOES connect/bind temporarily to the vpc AWS endpoint in addition to the expect EC2 endpoint - this is needed because the EC2 boto module doesn't support get_all_vpcs().

If this is unacceptable then I really can't think of another way to get this info shared all inside one state run.
