### PR TITLE
gitfs: fix UnboundLocalError for 'msg'

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -189,7 +189,7 @@ class GitProvider(object):
                         )
                     log.critical(msg)
                 else:
-                    log.critical(
+                    msg = (
                         'Invalid {0} configuration parameter \'{1}\' in '
                         'remote {2}. Valid parameters are: {3}.'.format(
                             self.role,
@@ -203,6 +203,7 @@ class GitProvider(object):
                             ' See the GitFS Walkthrough in the Salt '
                             'documentation for further information.'
                         )
+                    log.critical(msg)
 
                 per_remote_errors = True
             if per_remote_errors:


### PR DESCRIPTION
When using an invalid gitfs configuration parameter, the following error
happened:

```
[CRITICAL] Invalid gitfs configuration parameter 'foo' in remote https://example.com/. Valid parameters are: base, mountpoint, root, ssl_verify, name.
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
UnboundLocalError: local variable 'msg' referenced before assignment
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    salt_call()
  …
  File "/usr/lib/python2.7/dist-packages/salt/utils/gitfs.py", line 202, in __init__
    msg += (
UnboundLocalError: local variable 'msg' referenced before assignment
```
