### PR TITLE
dockerng: use docker.version=auto by default

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -658,7 +658,7 @@ def _get_client(timeout=None):
     Set those keys in your configuration tree somehow:
 
         - docker.url: URL to the docker service
-        - docker.version: API version to use
+        - docker.version: API version to use (default: "auto")
     '''
     if 'docker.client' not in __context__:
         client_kwargs = {}
@@ -671,6 +671,9 @@ def _get_client(timeout=None):
         if 'base_url' not in client_kwargs and 'DOCKER_HOST' in os.environ:
             # Check if the DOCKER_HOST environment variable has been set
             client_kwargs['base_url'] = os.environ.get('DOCKER_HOST')
+
+        if 'version' not in client_kwargs:
+            client_kwargs['version'] = 'auto'
 
         __context__['docker.client'] = docker.Client(**client_kwargs)
 


### PR DESCRIPTION
Although there is a version check for docker-py, it still can fail in
the case of downgrading docker-py (e.g. when going to `prod` from
`dev`):

```
[DEBUG   ] "GET /v1.19/images/json?only_ids=0&all=0 HTTP/1.1" 404 72
[ERROR   ] An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1591, in call
    **cdata['kwargs'])
  File "/usr/lib/python2.7/dist-packages/salt/states/dockerng.py", line 447, in image_present
    all_tags = __salt__['dockerng.list_tags']()
  File "/usr/lib/python2.7/dist-packages/salt/modules/dockerng.py", line 2161, in list_tags
    for item in six.itervalues(images()):
  File "/usr/lib/python2.7/dist-packages/salt/modules/dockerng.py", line 1976, in images
    response = _client_wrapper('images', all=kwargs.get('all', False))
  File "/usr/lib/python2.7/dist-packages/salt/modules/dockerng.py", line 577, in wrapper
    return wrapped(*args, **salt.utils.clean_kwargs(**kwargs))
  File "/usr/lib/python2.7/dist-packages/salt/modules/dockerng.py", line 844, in _client_wrapper
    exc.explanation)
CommandExecutionError: Error 404: client and server don't have same version (client : 1.19, server: 1.18)
```

TEST CASE:
- Install docker-py 1.4.0
- Have a state to downgrade it

```
    docker-py:
      pip.installed:
        - name: docker-py==1.2.2
        - require:
          - pkg: python-pip
        - reload_modules: true
```

dockerng will be loaded, but then cause the above 404 errors.

This can be fixed by using `version=auto` for the `docker.Client`, which
could also be provided in the Salt config (`docker.version`).

The support for `version=auto` has been added in docker-py 1.1.0.
