### PR TITLE
dockerng: handle None in container.Names

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -2130,7 +2130,7 @@ def list_containers(**kwargs):
     '''
     ret = set()
     for item in six.itervalues(ps_(all=kwargs.get('all', False))):
-        for c_name in [x.lstrip('/') for x in item.get('Names', [])]:
+        for c_name in [x.lstrip('/') for x in item.get('Names', []) or []]:
             ret.add(c_name)
     return sorted(ret)
 


### PR DESCRIPTION
`Names` might be `None`, and would cause this error:

```
[ERROR   ] An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1591, in call
    **cdata['kwargs'])
  File "/usr/lib/python2.7/dist-packages/salt/states/dockerng.py", line 1386, in running
    if name not in __salt__['dockerng.list_containers'](all=True):
  File "/usr/lib/python2.7/dist-packages/salt/modules/dockerng.py", line 2136, in list_containers
    for c_name in [x.lstrip('/') for x in item.get('Names', []) or []]:
TypeError: 'NoneType' object is not iterable

> /usr/lib/python2.7/dist-packages/salt/modules/dockerng.py(2136)list_containers()
   2135     for item in six.itervalues(ps_(all=kwargs.get('all', False))):
-> 2136         for c_name in [x.lstrip('/') for x in item.get('Names', [])]:
   2137             ret.add(c_name)

ipdb> item.get('Names') is None
True
ipdb> item
{u'Status': u'Dead', u'Image': u'gliderlabs/logspout:v2', …
u'Names': None, … }
```
