### PR TITLE
Wait for sync is not passed to boto_route53 state

### DIFF
--- a/salt/states/boto_elb.py
+++ b/salt/states/boto_elb.py
@@ -345,7 +345,8 @@ def present(
                 region=region,
                 key=key,
                 keyid=keyid,
-                profile=profile
+                profile=profile,
+                wait_for_sync=wait_for_sync
             )
             ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
             ret['comment'] = ' '.join([ret['comment'], _ret['comment']])


### PR DESCRIPTION
This is either a bug in documentation or in code. This fixes the code to correctly pass wait_for_sync to the route_53 state
