### PR TITLE
Fix crash in boto_asg.get_instances if the requested attribute is None

### DIFF
--- a/salt/modules/boto_asg.py
+++ b/salt/modules/boto_asg.py
@@ -552,4 +552,5 @@ def get_instances(name, lifecycle_state="InService", health_status="Healthy", at
         instance_ids.append(i.instance_id)
     # get full instance info, so that we can return the attribute
     instances = ec2_conn.get_only_instances(instance_ids=instance_ids)
-    return [getattr(instance, attribute).encode("ascii") for instance in instances]
+    attributes = [getattr(instance, attribute) for instance in instances]
+    return [attribute.encode("ascii") if attribute is not None else None for attribute in attributes]


### PR DESCRIPTION
If you run get_instances, sometimes you have instances that have some attributes set to None, e.g. if an IP address is not yet assigned. Currently, this leads to an exception. This commit should fix it.
