### PR TITLE
Expose container_id in mine.get_docker

### DIFF
--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -304,6 +304,8 @@ def get_docker(interfaces=None, cidrs=None, with_container_id=False):
     with_container_id
         Boolean, to expose container_id in the list of results
 
+        .. versionadded:: 2015.8.2
+
 
     CLI Example:
 

--- a/tests/unit/modules/mine_test.py
+++ b/tests/unit/modules/mine_test.py
@@ -190,14 +190,62 @@ class MineTestCase(TestCase):
                                 'PrivatePort': 80,
                                 'PublicPort': 80,
                                 'Type': 'tcp'}],
-                     'Image': 'image:latest'
+                     'Image': 'image:latest',
+                     'Info': {'Id': 'abcdefhjhi1234567899'},
                 },
             }}
         with patch.object(mine, 'get', return_value=ps_response):
             self.assertEqual(mine.get_docker(),
                              {'image:latest': {
-                                 'ipv4': {80: ['192.168.0.1:80',
-                                               '172.17.42.1:80']}}})
+                                 'ipv4': {80: [
+                                     '172.17.42.1:80',
+                                     '192.168.0.1:80',
+                                 ]}}})
+
+    def test_get_docker_with_container_id(self):
+        '''
+        Test for Get all mine data for 'dockerng.ps' and run an
+        aggregation.
+        '''
+        ps_response = {
+            'localhost': {
+                'host': {
+                    'interfaces': {
+                        'docker0': {
+                            'hwaddr': '88:99:00:00:99:99',
+                            'inet': [{'address': '172.17.42.1',
+                                      'broadcast': None,
+                                      'label': 'docker0',
+                                      'netmask': '255.255.0.0'}],
+                            'inet6': [{'address': 'ffff::eeee:aaaa:bbbb:8888',
+                                       'prefixlen': '64'}],
+                            'up': True},
+                        'eth0': {'hwaddr': '88:99:00:99:99:99',
+                                 'inet': [{'address': '192.168.0.1',
+                                           'broadcast': '192.168.0.255',
+                                           'label': 'eth0',
+                                           'netmask': '255.255.255.0'}],
+                                 'inet6': [{'address':
+                                            'ffff::aaaa:aaaa:bbbb:8888',
+                                            'prefixlen': '64'}],
+                                 'up': True},
+                    }},
+                'abcdefhjhi1234567899': {  # container Id
+                                         'Ports': [{'IP': '0.0.0.0',  # we bind on every interfaces
+                                                    'PrivatePort': 80,
+                                                    'PublicPort': 80,
+                                                    'Type': 'tcp'}],
+                                         'Image': 'image:latest',
+                                         'Info': {'Id': 'abcdefhjhi1234567899'},
+                                         },
+            }}
+        with patch.object(mine, 'get', return_value=ps_response):
+            self.assertEqual(mine.get_docker(with_container_id=True),
+                             {'image:latest': {
+                                 'ipv4': {80: [
+                                     ('172.17.42.1:80', 'abcdefhjhi1234567899'),
+                                     ('192.168.0.1:80', 'abcdefhjhi1234567899'),
+                                 ]}}})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Because sometimes we need to be able to perform additional introspection.

`Note` I did it in a way that is backward compatible, but I believe the result is unpleasant to use. I think `mine.get_docker` deserve a new interface.
