### PR TITLE
Add private IP functionality to the Linode driver

### DIFF
--- a/doc/topics/cloud/linode.rst
+++ b/doc/topics/cloud/linode.rst
@@ -203,18 +203,20 @@ are:
 * private_ips: The salt-master is also hosted within Linode.
 
 If specifying ``private_ips``, the Linodes must be hosted within the same data
-center and have the Network Helper enabled. The instance that is running the
-Salt-Cloud provisioning command must also have a private IP assigned to it.
+center and have the Network Helper enabled on your entire account. The instance
+that is running the Salt-Cloud provisioning command must also have a private IP
+assigned to it.
 
 Newer accounts created on Linode have the Network Helper setting enabled by default,
-account-wide. If you're running into problems, be sure to restart the instance that
-is running Salt Cloud after adding its own private IP address or enabling the Network
-Helper. Best results are found when the Network Helper is enabled across your entire
-Linode account. Please see `Linode's Network Helper`_ or `Static IP Configuration`_
-documentation for more information.
+account-wide. Legacy accounts do not have this setting enabled by default. To enable
+the Network Helper on your Linode account, please see `Linode's Network Helper`_
+documentation.
+
+If you're running into problems, be sure to restart the instance that is running
+Salt Cloud after adding its own private IP address or enabling the Network
+Helper.
 
 .. _Linode's Network Helper: https://www.linode.com/docs/platform/network-helper
-.. _Static IP Configuration: https://www.linode.com/docs/networking/linux-static-ip-configuration
 
 clonefrom
 ---------

--- a/doc/topics/cloud/linode.rst
+++ b/doc/topics/cloud/linode.rst
@@ -6,27 +6,24 @@ Linode is a public cloud host with a focus on Linux instances.
 
 Starting with the 2015.8.0 release of Salt, the Linode driver uses Linode's
 native REST API. There are no external dependencies required to use the
-Linode driver.
+Linode driver, other than a Linode account.
 
-Configuration
-=============
+
+Provider Configuration
+======================
 Linode requires a single API key, but the default root password for new
-instances also needs to be set:
+instances also needs to be set. The password needs to be eight characters
+and contain lowercase, uppercase, and numbers.
+
+Set up the provider cloud configuration file at ``/etc/salt/cloud.providers`` or
+``/etc/salt/cloud.providers.d/*.conf``.
 
 .. code-block:: yaml
 
-    # Note: This example is for /etc/salt/cloud.providers or any file in the
-    # /etc/salt/cloud.providers.d/ directory.
-
     my-linode-config:
-      apikey: asldkgfakl;sdfjsjaslfjaklsdjf;askldjfaaklsjdfhasldsadfghdkf
-      password: F00barbaz
-      ssh_pubkey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKHEOLLbeXgaqRQT9NBAopVz366SdYc0KKX33vAnq+2R user@host
-      ssh_key_file: ~/.ssh/id_ed25519
+      apikey: 'asldkgfakl;sdfjsjaslfjaklsdjf;askldjfaaklsjdfhasldsadfghdkf'
+      password: 'F00barbaz'
       driver: linode
-
-The password needs to be 8 characters and contain lowercase, uppercase, and
-numbers.
 
 .. note::
     .. versionchanged:: 2015.8.0
@@ -37,22 +34,39 @@ numbers.
     provides the underlying functionality to connect to a cloud host, while cloud profiles continue
     to use ``provider`` to refer to provider configurations that you define.
 
-Profiles
-========
 
-Cloud Profiles
-~~~~~~~~~~~~~~
-Set up an initial profile at ``/etc/salt/cloud.profiles`` or in the
-``/etc/salt/cloud.profiles.d/`` directory:
+Profile Configuration
+=====================
+Linode profiles require a ``provider``, ``size``, ``image``, and ``location``. Set up an initial profile
+at ``/etc/salt/cloud.profiles`` or in the ``/etc/salt/cloud.profiles.d/`` directory:
 
 .. code-block:: yaml
 
     linode_1024:
       provider: my-linode-config
       size: Linode 1024
-      image: Arch Linux 2013.06
-      location: london
+      image: Ubuntu 14.04 LTS
+      location: Atlanta, GA, USA
 
+The profile can be realized now with a salt command:
+
+.. code-block:: bash
+
+    salt-cloud -p linode_1024 linode-instance
+
+This will create an salt minion instance named ``linode-instance`` in Linode. If the command was
+executed on the salt-master, its Salt key will automatically be signed on the master.
+
+Once the instance has been created with a salt-minion installed, connectivity to
+it can be verified with Salt:
+
+.. code-block:: bash
+
+    salt linode-instance test.ping
+
+
+Listing Sizes
+-------------
 Sizes can be obtained using the ``--list-sizes`` option for the ``salt-cloud``
 command:
 
@@ -65,24 +79,37 @@ command:
             ----------
             Linode 1024:
                 ----------
-                bandwidth:
-                    2000
-                disk:
-                    49152
-                driver:
-                get_uuid:
-                id:
+                AVAIL:
+                    ----------
+                    10:
+                        500
+                    2:
+                        500
+                    3:
+                        500
+                    4:
+                        500
+                    6:
+                        500
+                    7:
+                        500
+                    8:
+                        500
+                    9:
+                        500
+                CORES:
                     1
-                name:
+                DISK:
+                    24
+                HOURLY:
+                    0.015
+                LABEL:
                     Linode 1024
-                price:
-                    20.0
-                ram:
-                    1024
-                uuid:
-                    03e18728ce4629e2ac07c9cbb48afffb8cb499c4
     ...SNIP...
 
+
+Listing Images
+--------------
 Images can be obtained using the ``--list-images`` option for the ``salt-cloud``
 command:
 
@@ -93,25 +120,25 @@ command:
         ----------
         linode:
             ----------
-            Arch Linux 2013.06:
+            Arch Linux 2015.02:
                 ----------
-                driver:
-                extra:
-                    ----------
-                    64bit:
-                        1
-                    pvops:
-                        1
-                get_uuid:
-                id:
-                    112
-                name:
-                    Arch Linux 2013.06
-                uuid:
-                    8457f92eaffc92b7666b6734a96ad7abe1a8a6dd
+                CREATE_DT:
+                    2015-02-20 14:17:16.0
+                DISTRIBUTIONID:
+                    138
+                IS64BIT:
+                    1
+                LABEL:
+                    Arch Linux 2015.02
+                MINIMAGESIZE:
+                    800
+                REQUIRESPVOPSKERNEL:
+                    1
     ...SNIP...
 
 
+Listing Locations
+-----------------
 Locations can be obtained using the ``--list-locations`` option for the ``salt-cloud``
 command:
 
@@ -124,23 +151,90 @@ command:
             ----------
             Atlanta, GA, USA:
                 ----------
-                abbreviation:
+                ABBR:
                     atlanta
-                id:
+                DATACENTERID:
                     4
-            Dallas, TX, USA:
-                ----------
-                abbreviation:
-                    dallas
-                id:
-                    2
+                LOCATION:
+                    Atlanta, GA, USA
     ...SNIP...
+
+
+Linode Specific Settings
+========================
+There are several options outlined below that can be added to either the Linode
+provider of profile configuration files. Some options are mandatory and are
+properly labeled below but typically also include a hard-coded default.
+
+image
+-----
+Image is used to define what Operating System image should be used for the
+instance. Examples are ``Ubuntu 14.04 LTS`` and ``CentOS 7``. This option should
+be specified in the profile config. Required.
+
+location
+--------
+Location is used to define which Linode data center the instance will reside in.
+Required.
+
+size
+----
+Size is used to define the instance's "plan type" which includes memory, storage,
+and price. Required.
+
+assign_private_ip
+-----------------
+.. versionadded:: Boron
+
+Assigns a private IP address to a Linode when set to True. Default is False.
+
+private_ip
+----------
+Deprecated in favor of `assign_private_ip`_ in Salt Boron.
+
+ssh_interface
+-------------
+.. versionadded:: Boron
+
+Specify whether to use a public or private IP for the deploy script. Valid options
+are:
+
+* public_ips: The salt-master is hosted outside of Linode. Default.
+* private_ips: The salt-master is also hosted within Linode.
+
+If specifying ``private_ips``, the Linodes must be hosted within the same data
+center and have the Network Helper enabled. The instance that is running the
+Salt-Cloud provisioning command must also have a private IP assigned to it.
+
+Newer accounts created on Linode have the Network Helper setting enabled by default,
+account-wide. If you're running into problems, be sure to restart the instance that
+is running Salt Cloud after adding its own private IP address or enabling the Network
+Helper. Best results are found when the Network Helper is enabled across your entire
+Linode account. Please see `Linode's Network Helper`_ or `Static IP Configuration`_
+documentation for more information.
+
+.. _Linode's Network Helper: https://www.linode.com/docs/platform/network-helper
+.. _Static IP Configuration: https://www.linode.com/docs/networking/linux-static-ip-configuration
+
+clonefrom
+---------
+Setting the clonefrom option to a specified instance enables the new instance to be
+cloned from the named instance instead of being created from scratch. If using the
+clonefrom option, it is likely a good idea to also specify ``script_args: -C`` if a
+minion is already installed on the to-be-cloned instance. See the `Cloning`_ section
+below for more information.
 
 
 Cloning
 =======
+To clone a Linode, add a profile with a ``clonefrom`` key, and a ``script_args: -C``.
+``clonefrom`` should be the name of the Linode that is the source for the clone.
+``script_args: -C`` passes a -C to the salt-bootstrap script, which only configures
+the minion and doesn't try to install a new copy of salt-minion. This way the minion
+gets new keys and the keys get pre-seeded on the master, and the ``/etc/salt/minion``
+file has the right minion 'id:' declaration.
 
-When salt-cloud accesses Linode via linode-python it can clone machines.
+Cloning requires a post 2015-02-01 salt-bootstrap.
 
 It is safest to clone a stopped machine. To stop a machine run
 
@@ -161,8 +255,7 @@ cloud profile that looks like this:
 Then run salt-cloud as normal, specifying `-p li-clone`. The profile name can
 be anything; It doesn't have to be `li-clone`.
 
-`Clonefrom:` is the name of an existing machine in Linode from which to clone.
-`Script_args: -C` is necessary to avoid re-deploying Salt via salt-bootstrap.
+`clonefrom:` is the name of an existing machine in Linode from which to clone.
+`script_args: -C` is necessary to avoid re-deploying Salt via salt-bootstrap.
 `-C` will just re-deploy keys so the new minion will not have a duplicate key
 or minion_id on the master.
-

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -16,23 +16,13 @@ Set up the cloud configuration at ``/etc/salt/cloud.providers`` or ``/etc/salt/c
       apikey: f4ZsmwtB1c7f85Jdu43RgXVDFlNjuJaeIYV8QMftTqKScEB2vSosFSr...
       password: F00barbaz
       driver: linode
-      ssh_key_file: /tmp/salt-cloud_pubkey
-      ssh_pubkey: ssh-rsa AAAAB3NzaC1yc2EA...
 
     linode-profile:
       provider: my-linode-provider
       size: Linode 1024
       image: CentOS 7
       location: London, England, UK
-      private_ip: true
 
-To clone, add a profile with a ``clonefrom`` key, and a ``script_args: -C``. ``clonefrom`` should be the name of
-the VM (*linode*) that is the source for the clone. ``script_args: -C`` passes a -C to the
-bootstrap script, which only configures the minion and doesn't try to install a new copy of salt-minion. This way the
-minion gets new keys and the keys get pre-seeded on the master, and the /etc/salt/minion file has the right
-'id:' declaration.
-
-Cloning requires a post 2015-02-01 salt-bootstrap.
 '''
 
 # Import Python Libs
@@ -51,6 +41,7 @@ from salt.exceptions import (
     SaltCloudNotFound,
     SaltCloudSystemExit
 )
+from salt.utils import warn_until
 
 # Import Salt-Cloud Libs
 import salt.utils.cloud
@@ -346,26 +337,27 @@ def create(vm_):
     if 'provider' in vm_:
         vm_['driver'] = vm_.pop('provider')
 
-    if _validate_name(vm_['name']) is False:
+    name = vm_['name']
+    if _validate_name(name) is False:
         return False
 
     salt.utils.cloud.fire_event(
         'event',
         'starting create',
-        'salt/cloud/{0}/creating'.format(vm_['name']),
+        'salt/cloud/{0}/creating'.format(name),
         {
-            'name': vm_['name'],
+            'name': name,
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
         transport=__opts__['transport']
     )
 
-    log.info('Creating Cloud VM {0}'.format(vm_['name']))
+    log.info('Creating Cloud VM {0}'.format(name))
 
     data = {}
     kwargs = {
-        'name': vm_['name'],
+        'name': name,
         'image': vm_['image'],
         'size': vm_['size'],
     }
@@ -411,7 +403,7 @@ def create(vm_):
                 'Error creating {0} on Linode\n\n'
                 'The following exception was thrown by Linode when trying to '
                 'run the initial deployment:\n'.format(
-                    vm_['name']
+                    name
                 ),
                 exc_info_on_loglevel=logging.DEBUG
             )
@@ -420,7 +412,7 @@ def create(vm_):
     salt.utils.cloud.fire_event(
         'event',
         'requesting instance',
-        'salt/cloud/{0}/requesting'.format(vm_['name']),
+        'salt/cloud/{0}/requesting'.format(name),
         {'kwargs': kwargs},
         transport=__opts__['transport']
     )
@@ -431,28 +423,39 @@ def create(vm_):
     if not _wait_for_status(node_id, status=(_get_status_id_by_name('brand_new'))):
         log.error(
             'Error creating {0} on LINODE\n\n'
-            'while waiting for initial ready status'.format(vm_['name']),
+            'while waiting for initial ready status'.format(name),
             exc_info_on_loglevel=logging.DEBUG
         )
 
     # Update the Linode's Label to reflect the given VM name
-    update_linode(node_id, update_args={'Label': vm_['name']})
-    log.debug('Set name for {0} - was linode{1}.'.format(vm_['name'], node_id))
+    update_linode(node_id, update_args={'Label': name})
+    log.debug('Set name for {0} - was linode{1}.'.format(name, node_id))
 
     # Create disks and get ids
-    log.debug('Creating disks for {0}'.format(vm_['name']))
+    log.debug('Creating disks for {0}'.format(name))
     root_disk_id = create_disk_from_distro(vm_, node_id)['DiskID']
     swap_disk_id = create_swap_disk(vm_, node_id)['DiskID']
 
     # Add private IP address if requested
-    if get_private_ip(vm_):
+    private_ip_assignment = get_private_ip()
+    if private_ip_assignment:
         create_private_ip(vm_, node_id)
 
+    # Define which ssh_interface to use
+    ssh_interface = _get_ssh_interface(vm_)
+    if ssh_interface == 'private_ips':
+        # If ssh_interface is set to use private_ips, but assign_private_ip
+        # wasn't set to True, let's help out and create a private ip.
+        if private_ip_assignment is False:
+            create_private_ip(vm_, node_id)
+            private_ip_assignment = True
+
     # Create a ConfigID using disk ids
-    config_id = create_config(kwargs={'name': vm_['name'],
+    config_id = create_config(kwargs={'name': name,
                                       'linode_id': node_id,
                                       'root_disk_id': root_disk_id,
-                                      'swap_disk_id': swap_disk_id})['ConfigID']
+                                      'swap_disk_id': swap_disk_id,
+                                      'helper_network': private_ip_assignment})['ConfigID']
     # Boot the Linode
     boot(kwargs={'linode_id': node_id,
                  'config_id': config_id,
@@ -469,7 +472,11 @@ def create(vm_):
     data['private_ips'] = ips['private_ips']
     data['public_ips'] = ips['public_ips']
 
-    vm_['ssh_host'] = data['public_ips'][0]
+    # Pass the correct IP address to the bootstrap ssh_host key
+    if ssh_interface == 'private_ips':
+        vm_['ssh_host'] = data['private_ips'][0]
+    else:
+        vm_['ssh_host'] = data['public_ips'][0]
 
     # If a password wasn't supplied in the profile or provider config, set it now.
     vm_['password'] = get_password(vm_)
@@ -489,9 +496,9 @@ def create(vm_):
     salt.utils.cloud.fire_event(
         'event',
         'created instance',
-        'salt/cloud/{0}/created'.format(vm_['name']),
+        'salt/cloud/{0}/created'.format(name),
         {
-            'name': vm_['name'],
+            'name': name,
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
@@ -629,12 +636,9 @@ def create_swap_disk(vm_, linode_id, swap_size=None):
     return _clean_data(result)
 
 
-def create_private_ip(vm_, linode_id):
+def create_private_ip(linode_id):
     r'''
     Creates a private IP for the specified Linode.
-
-    vm_
-        The VM profile to create the swap disk for.
 
     linode_id
         The ID of the Linode to create the IP address for.
@@ -940,8 +944,18 @@ def get_private_ip(vm_):
     '''
     Return True if a private ip address is requested
     '''
+    if 'private_ip' in vm_:
+        warn_until(
+            'Carbon',
+            'The \'private_ip\' option is being deprecated in favor of the '
+            '\'assign_private_ip\' option. Please convert your Linode configuration '
+            'files to use \'assign_private_ip\'.'
+        )
+        vm_['assign_private_ip'] = vm_['private_ip']
+        vm_.pop('private_ip')
+
     return config.get_cloud_config_value(
-        'private_ip', vm_, __opts__, default=False
+        'assign_private_ip', vm_, __opts__, default=False
     )
 
 
@@ -1537,3 +1551,14 @@ def _validate_name(name):
         )
 
     return ret
+
+
+def _get_ssh_interface(vm_):
+    '''
+    Return the ssh_interface type to connect to. Either 'public_ips' (default)
+    or 'private_ips'.
+    '''
+    return config.get_cloud_config_value(
+        'ssh_interface', vm_, __opts__, default='public_ips',
+        search_global=False
+    )

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -437,9 +437,9 @@ def create(vm_):
     swap_disk_id = create_swap_disk(vm_, node_id)['DiskID']
 
     # Add private IP address if requested
-    private_ip_assignment = get_private_ip()
+    private_ip_assignment = get_private_ip(vm_)
     if private_ip_assignment:
-        create_private_ip(vm_, node_id)
+        create_private_ip(node_id)
 
     # Define which ssh_interface to use
     ssh_interface = _get_ssh_interface(vm_)
@@ -447,7 +447,7 @@ def create(vm_):
         # If ssh_interface is set to use private_ips, but assign_private_ip
         # wasn't set to True, let's help out and create a private ip.
         if private_ip_assignment is False:
-            create_private_ip(vm_, node_id)
+            create_private_ip(node_id)
             private_ip_assignment = True
 
     # Create a ConfigID using disk ids


### PR DESCRIPTION
Refs #19400

Also updated the "Getting Started with Linode" docs to reflect this change, as well as document the known profile/provider config options more verbosely.

To use private IP functionality set the following options in your Linode configs:

```
my-linode-config:
  assign_private_ip: True
  ssh_interface: private_ips
```

Note: `private_ip` has been deprecated in this PR in favor of `assign_private_ip` to reduce ambiguity. The `assign_private_ip` config can be used on it's own to give the Linode a private IP, but still use the public IP as an ssh interface. If `ssh_interface: private_ips` is set, but `assign_private_ip` is not, we'll still create a private IP for the instance.

Also Note: You must have Linode's [Network Helper](https://www.linode.com/docs/platform/network-helper) enabled globally for your entire Linode account for `ssh_interface: private_ips` to function properly. The instance running Salt Cloud must also have a private IP added (may require a Linode restart) and be located in the same data center as the Linode to be created.
