### PR TITLE
fix typo in default pillar path

### DIFF
--- a/doc/topics/best_practices.rst
+++ b/doc/topics/best_practices.rst
@@ -154,7 +154,7 @@ creates a consistent understanding throughout our Salt environment. Users can
 expect that pillar variables found in an Apache state will live inside of an
 Apache pillar:
 
-``/srv/salt/pillar/apache.sls``:
+``/srv/pillar/apache.sls``:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
I am a newb and this threw me off for a bit. Wanted to make it consistent with the rest of the doc.
