### PR TITLE
Fixed return status of boto_secgroup.absent()

### DIFF
--- a/salt/states/boto_secgroup.py
+++ b/salt/states/boto_secgroup.py
@@ -508,7 +508,7 @@ def absent(
 
         .. versionadded:: Boron
     '''
-    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
     sg = __salt__['boto_secgroup.get_config'](name, True, region, key, keyid,
                                               profile, vpc_id, vpc_name)


### PR DESCRIPTION
All other boto "thing.absent()" type functions return True if the object happens to already not exist when called.  This one function was returning None instead, which threw the colors off in an ugly way in the state run output :)  Grrrr.
