### PR TITLE
Check for existence of 'subnetId' key in subnet dict

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1182,7 +1182,7 @@ def _create_eni_if_necessary(interface):
                         break
             else:
                 for subnet in subnet_query_result['item']:
-                    if subnet['subnetId'] == interface['SubnetId']:
+                    if 'subnetId' in subnet and subnet['subnetId'] == interface['SubnetId']:
                         found = True
                         break
 


### PR DESCRIPTION
Prevents a backtrace like this:

```
[ERROR   ] Failed to create VM web-exp-0001. Configuration value 'SubnetId' needs to be set
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/cloud/__init__.py", line 1241, in create
    output = self.clouds[func](vm_)
  File "/usr/lib/python2.7/site-packages/salt/cloud/clouds/ec2.py", line 2169, in create
    data, vm_ = request_instance(vm_, location)
  File "/usr/lib/python2.7/site-packages/salt/cloud/clouds/ec2.py", line 1561, in request_instance
    _new_eni = _create_eni(interface)
  File "/usr/lib/python2.7/site-packages/salt/cloud/clouds/ec2.py", line 1159, in _create_eni
    if subnet['subnetId'] == interface['SubnetId']:
KeyError: 'SubnetId'
Error: There was a profile error: Failed to deploy VM
```
