### PR TITLE
Python 3.5 support.

### DIFF
--- a/salt/utils/nb_popen.py
+++ b/salt/utils/nb_popen.py
@@ -25,7 +25,9 @@ import logging
 import tempfile
 import subprocess
 
-if subprocess.mswindows:
+mswindows = (sys.platform == "win32")
+
+if mswindows:
     from win32file import ReadFile, WriteFile
     from win32pipe import PeekNamedPipe
     import msvcrt
@@ -123,7 +125,7 @@ class NonBlockingPopen(subprocess.Popen):
         getattr(self, which).close()
         setattr(self, which, None)
 
-    if subprocess.mswindows:
+    if mswindows:
         def send(self, input):
             if not self.stdin:
                 return None

--- a/salt/utils/odict.py
+++ b/salt/utils/odict.py
@@ -28,10 +28,15 @@ from collections import Callable
 import salt.ext.six as six
 
 try:
-    from collections import OrderedDict  # pylint: disable=E0611,minimum-python-version
+    # pylint: disable=E0611,minimum-python-versioin
+    import collections
+    class OrderedDict(collections.OrderedDict):
+        __hash__ = None
 except ImportError:
     try:
-        from ordereddict import OrderedDict
+        import ordereddict
+        class OrderedDict(ordereddict.OrderedDict):
+            __hash_ = None
     except ImportError:
         # {{{ http://code.activestate.com/recipes/576693/ (r9)
         # Backport of OrderedDict() class that runs on Python 2.4, 2.5, 2.6, 2.7 and pypy.
@@ -60,6 +65,7 @@ except ImportError:
             # The circular doubly linked list starts and ends with a sentinel element.
             # The sentinel element never gets deleted (this simplifies the algorithm).
             # Each link is stored as a list of length three:  [PREV, NEXT, KEY].
+            __hash_ = None
 
             def __init__(self, *args, **kwds):  # pylint: disable=E1003
                 '''Initialize an ordered dictionary.  Signature is the same as for

--- a/salt/utils/odict.py
+++ b/salt/utils/odict.py
@@ -28,7 +28,7 @@ from collections import Callable
 import salt.ext.six as six
 
 try:
-    # pylint: disable=E0611,minimum-python-versioin
+    # pylint: disable=E0611,minimum-python-version
     import collections
 
     class OrderedDict(collections.OrderedDict):

--- a/salt/utils/odict.py
+++ b/salt/utils/odict.py
@@ -30,11 +30,13 @@ import salt.ext.six as six
 try:
     # pylint: disable=E0611,minimum-python-versioin
     import collections
+
     class OrderedDict(collections.OrderedDict):
         __hash__ = None
 except ImportError:
     try:
         import ordereddict
+
         class OrderedDict(ordereddict.OrderedDict):
             __hash_ = None
     except ImportError:

--- a/salt/utils/odict.py
+++ b/salt/utils/odict.py
@@ -37,7 +37,7 @@ except ImportError:
     try:
         import ordereddict
 
-        class OrderedDict(ordereddict.OrderedDict): # pylint: disable=W0232
+        class OrderedDict(ordereddict.OrderedDict):  # pylint: disable=W0232
             __hash_ = None
     except ImportError:
         # {{{ http://code.activestate.com/recipes/576693/ (r9)

--- a/salt/utils/odict.py
+++ b/salt/utils/odict.py
@@ -37,7 +37,7 @@ except ImportError:
     try:
         import ordereddict
 
-        class OrderedDict(ordereddict.OrderedDict):
+        class OrderedDict(ordereddict.OrderedDict): # pylint: disable=W0232
             __hash_ = None
     except ImportError:
         # {{{ http://code.activestate.com/recipes/576693/ (r9)

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -31,7 +31,9 @@ import select
 import logging
 import subprocess
 
-if subprocess.mswindows:
+mswindows = (sys.platform == "win32")
+
+if mswindows:
     # pylint: disable=F0401,W0611
     from win32file import ReadFile, WriteFile
     from win32pipe import PeekNamedPipe
@@ -349,7 +351,7 @@ class Terminal(object):
     # <---- Context Manager Methods ------------------------------------------
 
 # ----- Platform Specific Methods ------------------------------------------->
-    if subprocess.mswindows:
+    if mswindows:
         # ----- Windows Methods --------------------------------------------->
         def _execute(self):
             raise NotImplementedError

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -29,7 +29,6 @@ import errno
 import signal
 import select
 import logging
-import subprocess
 
 mswindows = (sys.platform == "win32")
 


### PR DESCRIPTION
Some fixes for python 3.5:
1) Fix subprocess.mswindows check for Python 3.5. 
2) Added **hash** variable to the OrderedDict classes. 
