### PR TITLE
Fix #27655: handling of success in postgres_local_cache

### DIFF
--- a/salt/returners/postgres_local_cache.py
+++ b/salt/returners/postgres_local_cache.py
@@ -56,6 +56,8 @@ and then:
     --
     -- Table structure for table 'salt_returns'
     --
+    -- note that 'success' must not have NOT NULL constraint, since
+    -- some functions don't provide it.
 
     DROP TABLE IF EXISTS salt_returns;
     CREATE TABLE salt_returns (
@@ -203,12 +205,6 @@ def returner(load):
     '''
     Return data to a postgres server
     '''
-    # salt guarantees that there will be 'fun', 'jid', 'return' and 'id' but not
-    # 'success'
-    success = 'Unknown'
-    if 'success' in load:
-        success = load['success']
-
     conn = _get_conn()
     if conn is None:
         return None
@@ -222,7 +218,7 @@ def returner(load):
             load['jid'],
             json.dumps(six.text_type(str(load['return']), 'utf-8', 'replace')),
             load['id'],
-            success
+            load.get('success'),
         )
     )
     _close_conn(conn)


### PR DESCRIPTION
- using get() is anyway more pythonic
- psycopg2 translates None to NULL
- moving explanation to schema comment

(there's no existing unit test for this)
