### PR TITLE
Fix to pkg state module

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -933,6 +933,10 @@ def installed(
 
     if version is not None and version == 'latest':
         version = __salt__['pkg.latest_version'](name)
+        # If version is empty, it means the latest version is installed
+        # so we grab that version to avoid passing an empty string
+        if not version:
+            version = __salt__['pkg.version'](name)
 
     kwargs['allow_updates'] = allow_updates
     result = _find_install_targets(name, version, pkgs, sources,


### PR DESCRIPTION
When latest is passed in the state as the version to install, once the package is installed the state runs will fail.  pkg.latest_version returned an empty string once the package is installed so we need to grab the installed version in that case to avoid passing an empty string to the pkg module in question. #19291 
