### PR TITLE
Added skip test_ext_pillar_env_mapping if git module does not exist.

### DIFF
--- a/tests/integration/modules/pillar.py
+++ b/tests/integration/modules/pillar.py
@@ -98,7 +98,6 @@ class PillarModuleTest(integration.ModuleCase):
     def no_test_issue_10408_ext_pillar_gitfs_url_update(self):
         import os
         from salt.pillar import git_pillar
-        import git
         original_url = 'git+ssh://original@example.com/home/git/test'
         changed_url = 'git+ssh://changed@example.com/home/git/test'
         rp_location = os.path.join(self.master_opts['cachedir'], 'pillar_gitfs/0/.git')
@@ -114,10 +113,11 @@ class PillarModuleTest(integration.ModuleCase):
 
         self.assertEqual(grepo.rp_location, repo.remotes.origin.url)
 
+    @skipIf(HAS_GIT_PYTHON is False,
+            'GitPython must be installed and >= version {0}'.format(GIT_PYTHON))
     def test_ext_pillar_env_mapping(self):
         import os
         from salt.pillar import git_pillar
-        import git
 
         repo_url = 'https://github.com/saltstack/pillar1.git'
         pillar = self.run_function('pillar.data')


### PR DESCRIPTION
If module named git does not exist, test test_ext_pillar_env_mapping
fail:

``` ======================================================================
ERROR: test_ext_pillar_env_mapping
(integration.modules.pillar.PillarModuleTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/git/salt/tests/integration/modules/pillar.py", line 120, in
test_ext_pillar_env_mapping
    import git
ImportError: No module named git
```

Added skip test_ext_pillar_env_mapping test.
