### PR TITLE
loader.proxy: call `_modules_dirs` only once

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -254,7 +254,6 @@ def proxy(opts, functions, whitelist=None, loaded_base_name=None):
     '''
     Returns the proxy module for this salt-proxy-minion
     '''
-    dirs = _module_dirs(opts, 'proxy', 'proxy')
     return LazyLoader(_module_dirs(opts, 'proxy', 'proxy'),
                       opts,
                       tag='proxy',


### PR DESCRIPTION
Instead of assigning it to an unused variable, pass the function's
return value to LazyLoader directly.
