### PR TITLE
loader: do not overwrite errors in missing_modules with None

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1188,9 +1188,13 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             # if process_virtual returned a non-True value then we are
             # supposed to not process this module
             if virtual_ret is not True:
-                # If a module has information about why it could not be loaded, record it
-                self.missing_modules[module_name] = virtual_err
-                self.missing_modules[name] = virtual_err
+                # If a module has information about why it could not be loaded,
+                # record it.  But do not overwrite any information from an
+                # inner call (via `process_virtual`).
+                if module_name not in self.missing_modules:
+                    self.missing_modules[module_name] = virtual_err
+                if name not in self.missing_modules:
+                    self.missing_modules[name] = virtual_err
                 return False
 
         # If this is a proxy minion then MOST modules cannot work. Therefore, require that


### PR DESCRIPTION
In the case that `self.missing_modules` is filled already, do not
overwrite it with `None`.  Let us keep the first reported error.

In the case of `dockerng` (as of PR #27602) the error might come from
`modules.dockerng`, but then `states.dockerng` would return just
`False`, without any addtional `virtual_err`.

I think the first error is the most significant, otherwise we could
overwrite it in case a later error would not be `None`.
