### PR TITLE
Chocolatey doesn't have a help command.

### DIFF
--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -102,7 +102,7 @@ def chocolatey_version():
     '''
     if 'chocolatey._version' in __context__:
         return __context__['chocolatey._version']
-    cmd = [_find_chocolatey(__context__, __salt__), 'help']
+    cmd = [_find_chocolatey(__context__, __salt__)]
     out = __salt__['cmd.run'](cmd, python_shell=False)
     for line in out.splitlines():
         line = line.lower()


### PR DESCRIPTION
Second attempt!

Chocolatey no longer prints the version string when you use a command that doesn't exist, you just get the error message.

This now just runs chocolatey with no flags which does give you the version number!
