### PR TITLE
Remove redundant text from syslog returner

### DIFF
--- a/salt/returners/syslog_return.py
+++ b/salt/returners/syslog_return.py
@@ -41,7 +41,7 @@ def returner(ret):
     '''
     Return data to the local syslog
     '''
-    syslog.syslog(syslog.LOG_INFO, 'salt-minion: {0}'.format(json.dumps(ret)))
+    syslog.syslog(syslog.LOG_INFO, '{0}'.format(json.dumps(ret)))
 
 
 def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument


### PR DESCRIPTION
The implicit call to syslog.openlog will already add salt-minion (technically `sys.argv[0]`) to the syslog.syslog call. It's redundant (and not technically correct) to have salt-minion here.

Can also be applied to 2015.8 and develop without issue.

Fixes #27756
