### PR TITLE
Fix OS related grains on openSUSE and SUSE Linux Enterprise

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1138,7 +1138,7 @@ def os_data():
                             ] = match.groups()[1].rstrip()
             if 'lsb_distrib_id' not in grains:
                 if os.path.isfile('/etc/os-release'):
-                    # Arch ARM Linux
+                    # Arch ARM Linux - SUSE 12+ - openSUSE 13+
                     with salt.utils.fopen('/etc/os-release') as ifile:
                         # Imitate lsb-release
                         for line in ifile:
@@ -1159,6 +1159,10 @@ def os_data():
                                 name, value = match.groups()
                                 if name.lower() == 'name':
                                     grains['lsb_distrib_id'] = value.strip()
+                                elif name.lower() == 'version_id':
+                                    grains['lsb_distrib_release'] = value
+                                elif name.lower() == 'pretty_name':
+                                    grains['lsb_distrib_codename'] = value
                 elif os.path.isfile('/etc/SuSE-release'):
                     grains['lsb_distrib_id'] = 'SUSE'
                     with salt.utils.fopen('/etc/SuSE-release') as fhr:


### PR DESCRIPTION
Starting from openSUSE 13 and SUSE Linux Enterprise 12 the file
`/etc/os-release` is part of these distributions. Future releases are
also going to drop `/etc/SuSE-release`.

The presence of `/etc/os-release` prevents the execution of the code
parsing `/etc/SuSE-release`, leading to missing/wrong grains.

Without this code on a SLE12 SP1 machine salt would produce these
grains:
- osrelease: 12
- oselease_info: [12]
- oscodename: x86_64

With this commit the following new grains are set:
- lsb_distrib_codename: SUSE Linux Enterprise Server 12 SP1
- lsb_distrib_release: 12.1

Moreover the following grains are properly set:
- osrelease: 12.1
- oselease_info: [12, 1]
- os_codename: SUSE Linux Enterprise Server 12 SP1

Signed-off-by: Flavio Castelli fcastelli@suse.com
