### PR TITLE
Fix `pylint: disable` with SaltStackVersion

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -76,10 +76,10 @@ class SaltStackVersion(object):
         # latest release so we can map deprecation warnings to versions.
 
 
-        # pylint: disable=E8203,E8265
-        # ----- Please refrain from fixing PEP-8 E203 and E265------------------------------------------------------->
-        # The idea is keep this readable
-        # ------------------------------------------------------------------------------------------------------------
+        # pylint: disable=E8203
+        # ----- Please refrain from fixing PEP-8 E203 and E265 ----->
+        # The idea is to keep this readable.
+        # -----------------------------------------------------------
         'Hydrogen'      : (2014, 1),
         'Helium'        : (2014, 7),
         'Lithium'       : (2015, 5),
@@ -87,6 +87,7 @@ class SaltStackVersion(object):
         'Boron'         : (MAX_SIZE - 104, 0),
         'Carbon'        : (MAX_SIZE - 103, 0),
         'Nitrogen'      : (MAX_SIZE - 102, 0),
+        # pylint: disable=E8265
         #'Oxygen'       : (MAX_SIZE - 101, 0),
         #'Fluorine'     : (MAX_SIZE - 100, 0),
         #'Neon'         : (MAX_SIZE - 99 , 0),
@@ -189,7 +190,7 @@ class SaltStackVersion(object):
         #'Bohrium'      : (MAX_SIZE - 2  , 0),
         #'Hassium'      : (MAX_SIZE - 1  , 0),
         #'Meitnerium'   : (MAX_SIZE - 0  , 0),
-        # <---- Please refrain from fixing PEP-8 E203 and E265 -------------------------------------------------------
+        # <---- Please refrain from fixing PEP-8 E203 and E265 ------
         # pylint: enable=E8203,E8265
     }
 


### PR DESCRIPTION
The `pylint: disable=E8265` was not working for where it was meant to be.
