### PR TITLE
Fix HipChat v2 API returner

### DIFF
--- a/salt/returners/hipchat_return.py
+++ b/salt/returners/hipchat_return.py
@@ -205,6 +205,7 @@ def _query(function,
                 data['notify'] = 0
             data = _urlencode(data)
     elif api_version == 'v2':
+        headers['Content-Type'] = 'application/json'
         headers['Authorization'] = 'Bearer {0}'.format(api_key)
         if data:
             data = json.dumps(data)


### PR DESCRIPTION
Add 'Content-Type' to v2 POST headers to comply with API documentation and remove Bad Request error noted in Issue #27777
