### PR TITLE
Tweak documentation for saltutils.find_cached_job.

### DIFF
--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -574,7 +574,8 @@ def find_job(jid):
 
 def find_cached_job(jid):
     '''
-    Return the data for a specific cached job id
+    Return the data for a specific cached job id. Note this only works if
+    cache_jobs has previously been set to True on the minion.
 
     CLI Example:
 


### PR DESCRIPTION
This function only works if the minion is configured with cache_jobs set to
True. Explicitly documenting this will make it less likely that users will
be confused when it silently fails to work for them.

Fixes #27735.
