### PR TITLE
Returner Documention Fixes

### DIFF
--- a/salt/returners/hipchat_return.py
+++ b/salt/returners/hipchat_return.py
@@ -40,9 +40,9 @@ Hipchat settings may also be configured as:
       from_name: user@email.com
 
     hipchat_profile:
-      api_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-      api_version: v1
-      from_name: user@email.com
+      hipchat.api_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      hipchat.api_version: v1
+      hipchat.from_name: user@email.com
 
     hipchat:
       profile: hipchat_profile

--- a/salt/returners/pushover_returner.py
+++ b/salt/returners/pushover_returner.py
@@ -48,7 +48,7 @@ PushOver settings may also be configured as::
         retry: 2
 
     pushover_profile:
-        token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        pushover.token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
     pushover:
         user: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/salt/returners/slack_returner.py
+++ b/salt/returners/slack_returner.py
@@ -40,8 +40,8 @@ Slack settings may also be configured as::
         from_name: user@email.com
 
     slack_profile:
-        api_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-        from_name: user@email.com
+        slack.api_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        slack.from_name: user@email.com
 
     slack:
         profile: slack_profile

--- a/salt/returners/xmpp_return.py
+++ b/salt/returners/xmpp_return.py
@@ -31,8 +31,8 @@ XMPP settings may also be configured as::
         recipient: someone@xmpp.example.com
 
     xmpp_profile:
-        jid: user@xmpp.domain.com/resource
-        password: password
+        xmpp.jid: user@xmpp.domain.com/resource
+        xmpp.password: password
 
     xmpp:
         profile: xmpp_profile


### PR DESCRIPTION
Fixing the documentation for the returners that mention using profiles, items in the profile need to include the virtualname of the returner to be found.
