### PR TITLE
update code that changes log level of salt-ssh shim command

### DIFF
--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -292,7 +292,7 @@ class Shell(object):
         logmsg = 'Executing command: {0}'.format(cmd)
         if self.passwd:
             logmsg = logmsg.replace(self.passwd, ('*' * 6))
-        if 'decode("base64")' in logmsg:
+        if 'decode("base64")' in logmsg or 'base64.b64decode(' in logmsg:
             log.debug('Executed SHIM command. Command logged to TRACE')
             log.trace(logmsg)
         else:

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -219,7 +219,7 @@ class Terminal(object):
             '{2}'.format(self.pid, self.child_fd, self.child_fde)
         )
         terminal_command = ' '.join(self.args)
-        if 'decode("base64")' in terminal_command:
+        if 'decode("base64")' in terminal_command or 'base64.b64decode(' in terminal_command:
             log.debug('VT: Salt-SSH SHIM Terminal Command executed. Logged to TRACE')
             log.trace('Terminal Command: {0}'.format(terminal_command))
         else:


### PR DESCRIPTION
`str.decode("base64")` has been changed to `base64.b64decode`, but the code that checks for `decode("base64")` had not been updated accordingly.
