### PR TITLE
Correct warning logging when update lock is present for git_pillar/winrepo, add runner function for clearing git_pillar/winrepo locks

### DIFF
--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -291,7 +291,7 @@ def clear_lock(clear_func, lock_type, remote=None):
         that a subset of remotes can be targeted.
 
 
-    Returns a tuple containing two lists: One with messages
+    Returns the return data from ``clear_func``.
     '''
     msg = 'Clearing update lock for {0} remotes'.format(lock_type)
     if remote:

--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -12,6 +12,11 @@ import salt.utils
 import salt.utils.master
 import salt.payload
 from salt.ext.six import string_types
+from salt.fileserver import clear_lock as _clear_lock
+from salt.fileserver.gitfs import PER_REMOTE_OVERRIDES as __GITFS_OVERRIDES
+from salt.pillar.git_pillar \
+    import PER_REMOTE_OVERRIDES as __GIT_PILLAR_OVERRIDES
+from salt.runners.winrepo import PER_REMOTE_OVERRIDES as __WINREPO_OVERRIDES
 
 log = logging.getLogger(__name__)
 
@@ -230,3 +235,50 @@ def clear_all(tgt=None, expr_form='glob'):
                         clear_pillar_flag=True,
                         clear_grains_flag=True,
                         clear_mine_flag=True)
+
+
+def clear_git_lock(role, remote=None):
+    '''
+    .. versionadded:: 2015.8.2
+
+    Remove the update locks for Salt components (gitfs, git_pillar, winrepo)
+    which use gitfs backend code from salt.utils.gitfs.
+
+    role
+        Which type of lock to remove (``gitfs``, ``git_pillar``, or
+        ``winrepo``)
+
+    remote
+        If specified, then any remotes which contain the passed string will
+        have their lock cleared. For example, a ``remote`` value of **github**
+        will remove the lock from all github.com remotes.
+    '''
+    if role == 'gitfs':
+        git_objects = [salt.utils.gitfs.GitFS(__opts__)]
+        git_objects[0].init_remotes(__opts__['gitfs_remotes'], __GITFS_OVERRIDES)
+    elif role == 'git_pillar':
+        git_objects = []
+        for ext_pillar in __opts__['ext_pillar']:
+            key = next(iter(ext_pillar))
+            if key == 'git':
+                if not isinstance(ext_pillar['git'], list):
+                    continue
+                obj = salt.utils.gitfs.GitPillar(__opts__)
+                obj.init_remotes(ext_pillar['git'], __GIT_PILLAR_OVERRIDES)
+                git_objects.append(obj)
+    elif role == 'winrepo':
+        git_objects = [salt.utils.gitfs.WinRepo(__opts__)]
+        git_objects[0].init_remotes(__opts__['winrepo_remotes'], __WINREPO_OVERRIDES)
+    else:
+        raise SaltInvocationError('Invalid role \'{0}\''.format(role))
+
+    ret = {}
+    for obj in git_objects:
+        cleared, errors = _clear_lock(obj.clear_lock, role, remote)
+        if cleared:
+            ret.setdefault('cleared', []).extend(cleared)
+        if errors:
+            ret.setdefault('errors', []).extend(errors)
+    if not ret:
+        ret = 'No locks were removed'
+    salt.output.display_output(ret, 'nested', opts=__opts__)

--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -244,6 +244,13 @@ def clear_git_lock(role, remote=None):
     Remove the update locks for Salt components (gitfs, git_pillar, winrepo)
     which use gitfs backend code from salt.utils.gitfs.
 
+    .. note::
+        Running :py:func:`cache.clear_all <salt.runners.cache.clear_all>` will
+        not include this function as it does for pillar, grains, and mine.
+
+        Additionally, executing this function with a ``role`` of ``gitfs`` is
+        equivalent to running ``salt-run fileserver.clear_lock backend=git``.
+
     role
         Which type of lock to remove (``gitfs``, ``git_pillar``, or
         ``winrepo``)
@@ -252,6 +259,12 @@ def clear_git_lock(role, remote=None):
         If specified, then any remotes which contain the passed string will
         have their lock cleared. For example, a ``remote`` value of **github**
         will remove the lock from all github.com remotes.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run cache.clear_git_lock git_pillar
     '''
     if role == 'gitfs':
         git_objects = [salt.utils.gitfs.GitFS(__opts__)]

--- a/salt/runners/fileserver.py
+++ b/salt/runners/fileserver.py
@@ -313,9 +313,9 @@ def clear_lock(backend=None, remote=None):
         Only clear the update lock for the specified backend(s).
 
     remote
-        If not None, then any remotes which contain the passed string will have
-        their lock cleared. For example, a ``remote`` value of **github** will
-        remove the lock from all github.com remotes.
+        If specified, then any remotes which contain the passed string will
+        have their lock cleared. For example, a ``remote`` value of **github**
+        will remove the lock from all github.com remotes.
 
     CLI Example:
 

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -1685,7 +1685,7 @@ class GitBase(object):
                     'Update lockfile is present for {0} remote \'{1}\', '
                     'skipping. If this warning persists, it is possible that '
                     'the update process was interrupted. Removing {2} or '
-                    'running \'salt-run fileserver.clear_lock {0}\' will '
+                    'running \'salt-run cache.clear_git_lock {0}\' will '
                     'allow updates to continue for this remote.'
                     .format(self.role, repo.id, repo.lockfile)
                 )


### PR DESCRIPTION
Fixes #27738.
