### PR TITLE
Empty string is falsy

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1340,7 +1340,7 @@ def managed(name,
 
     # If no source is specified, set replace to False, as there is nothing
     # to replace the file with.
-    src_defined = source or contents or contents_pillar or contents_grains
+    src_defined = source or contents is not None or contents_pillar or contents_grains
     if not src_defined and replace:
         replace = False
         log.warning(


### PR DESCRIPTION
Resolves #26538

Just ran into this issue myself, felt compelled to fix it.

As per @jfindlay's point,

> I also wonder if the file.touch state should use file.managed internally in this way to reduce code duplication and complexity.

Were you suggesting simply calling `managed` with arguments to replicate `touch`'s behavior, or refactoring out common code so we can have different `ret` messages? One would be significantly easier than the other, but I could see advantages to both; breaking up `managed` into components would improve readability, imho.
