### PR TITLE
Overflow errors on 32bit armv7l (#27812)

### DIFF
--- a/salt/ext/ipaddress.py
+++ b/salt/ext/ipaddress.py
@@ -15,6 +15,12 @@ Source: https://bitbucket.org/kwi/py2-ipaddress/
 from itertools import imap as map
 range = xrange
 
+# Except that xrange only supports machine integers, not longs, so...
+def long_range(start, end):
+    while start < end:
+        yield start
+        start += 1
+
 # This backport uses bytearray instead of bytes, as bytes is the same
 # as str in Python 2.7.
 bytes = bytearray
@@ -713,13 +719,13 @@ class _BaseNetwork(_IPAddressBase):
         """
         network = int(self.network_address)
         broadcast = int(self.broadcast_address)
-        for x in range(network + 1, broadcast):
+        for x in long_range(network + 1, broadcast):
             yield self._address_class(x)
 
     def __iter__(self):
         network = int(self.network_address)
         broadcast = int(self.broadcast_address)
-        for x in range(network, broadcast + 1):
+        for x in long_range(network, broadcast + 1):
             yield self._address_class(x)
 
     def __getitem__(self, n):

--- a/salt/modules/ipset.py
+++ b/salt/modules/ipset.py
@@ -15,6 +15,13 @@ else:
     import salt.ext.ipaddress as ipaddress
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 
+# Fix included in py2-ipaddress for 32bit architectures
+# Except that xrange only supports machine integers, not longs, so...
+def long_range(start, end):
+    while start < end:
+        yield start
+        start += 1
+
 # Import salt libs
 import salt.utils
 
@@ -427,7 +434,7 @@ def check(set=None, entry=None, family='ipv4'):
             start, end = entry.split('-')
 
             if settype == 'hash:ip':
-                entries = [str(ipaddress.ip_address(ip)) for ip in range(
+                entries = [str(ipaddress.ip_address(ip)) for ip in long_range(
                     ipaddress.ip_address(start),
                     ipaddress.ip_address(end) + 1
                 )]

--- a/salt/modules/ipset.py
+++ b/salt/modules/ipset.py
@@ -15,6 +15,7 @@ else:
     import salt.ext.ipaddress as ipaddress
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 
+
 # Fix included in py2-ipaddress for 32bit architectures
 # Except that xrange only supports machine integers, not longs, so...
 def long_range(start, end):

--- a/salt/modules/ipset.py
+++ b/salt/modules/ipset.py
@@ -13,7 +13,6 @@ if six.PY3:
     import ipaddress
 else:
     import salt.ext.ipaddress as ipaddress
-from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 
 
 # Fix included in py2-ipaddress for 32bit architectures


### PR DESCRIPTION
Trying to build on armv7l generates overflow errors in ipaddress.py and ipset.py during testing. These patches incorporate changes made in upstream ipaddress.py and fixing code patterns that were in ipset.py that looked like they had been taken from ipaddress.py.

Full details in issue #27812
