### PR TITLE
Make system.reboot use `shutdown -r` when available

### DIFF
--- a/salt/modules/system.py
+++ b/salt/modules/system.py
@@ -61,9 +61,12 @@ def poweroff():
     return ret
 
 
-def reboot():
+def reboot(at_time=None):
     '''
-    Reboot the system using the 'reboot' command
+    Reboot the system
+
+    at_time
+        The wait time in minutes before the system will be shutdown.
 
     CLI Example:
 
@@ -71,7 +74,7 @@ def reboot():
 
         salt '*' system.reboot
     '''
-    cmd = ['reboot']
+    cmd = ['shutdown', '-r', ('{0}'.format(at_time) if at_time else 'now')]
     ret = __salt__['cmd.run'](cmd, python_shell=False)
     return ret
 
@@ -89,10 +92,6 @@ def shutdown(at_time=None):
 
         salt '*' system.shutdown 5
     '''
-
-    if at_time:
-        cmd = ['shutdown', '-h', '{0}'.format(at_time)]
-    else:
-        cmd = ['shutdown', '-h', 'now']
+    cmd = ['shutdown', '-h', ('{0}'.format(at_time) if at_time else 'now')]
     ret = __salt__['cmd.run'](cmd, python_shell=False)
     return ret

--- a/tests/unit/modules/system_test.py
+++ b/tests/unit/modules/system_test.py
@@ -53,13 +53,23 @@ class SystemTestCase(TestCase):
                         {'cmd.run': MagicMock(return_value='A')}):
             self.assertEqual(system.poweroff(), 'A')
 
+    @patch.dict(system.__salt__, {'cmd.run': MagicMock(return_value='A')})
     def test_reboot(self):
         '''
-        Test to reboot the system using the 'reboot' command
+        Test to reboot the system with shutdown -r
         '''
-        with patch.dict(system.__salt__,
-                        {'cmd.run': MagicMock(return_value='A')}):
-            self.assertEqual(system.reboot(), 'A')
+        self.assertEqual(system.reboot(), 'A')
+        system.__salt__['cmd.run'].assert_called_with(
+            ['shutdown', '-r', 'now'], python_shell=False)
+
+    @patch.dict(system.__salt__, {'cmd.run': MagicMock(return_value='A')})
+    def test_reboot_with_delay(self):
+        '''
+        Test to reboot the system using shutdown -r with a delay
+        '''
+        self.assertEqual(system.reboot(at_time=5), 'A')
+        system.__salt__['cmd.run'].assert_called_with(
+            ['shutdown', '-r', '5'], python_shell=False)
 
     def test_shutdown(self):
         '''


### PR DESCRIPTION
see issue #27710
