### PR TITLE
[2015.5] Fix highstate outputter for jobs.lookup_jid

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -446,11 +446,6 @@ class AsyncClientMixin(object):
         except AttributeError:
             outputter = None
 
-        try:
-            if event.get('return').get('outputter'):
-                event['return'].pop('outputter')
-        except AttributeError:
-            pass
         # if this is a ret, we have our own set of rules
         if suffix == 'ret':
             # Check if ouputter was passed in the return data. If this is the case,

--- a/salt/runners/state.py
+++ b/salt/runners/state.py
@@ -112,7 +112,7 @@ def orchestrate(mods, saltenv='base', test=None, exclude=None, pillar=None):
             test,
             exclude,
             pillar=pillar)
-    ret = {minion.opts['id']: running, 'outputter': 'highstate'}
+    ret = {'data': {minion.opts['id']: running}, 'outputter': 'highstate'}
     return ret
 
 # Aliases for orchestrate runner


### PR DESCRIPTION
Don't pop 'outputter', we expect it further down

Also correctly wrap the output of orchestrate with 'data' key

This pop was put in as a fix for the orchestrate runner in #25521. However,
we just needed to wrap the return in 'data' to get it to be stripped
automatically. The lack of 'outputter' was causing us to not properly
strip the 'data' further down, and the highstate outputter would
subsequently barf for correctly-wrapped return data.

Fixes #27831 

@cachedout FYI

Tested state.orch to make sure it's outputting correctly as well.
