### PR TITLE
RequestContext

### DIFF
--- a/salt/cli/run.py
+++ b/salt/cli/run.py
@@ -39,13 +39,13 @@ class SaltRun(parsers.SaltRunOptionParser):
                 pr = activate_profile(profiling_enabled)
                 try:
                     ret = runner.run()
+                    if isinstance(ret, dict) and 'retcode' in ret:
+                        self.exit(ret['retcode'])
                 finally:
                     output_profile(
                         pr,
                         stats_path=self.options.profiling_path,
                         stop=True)
-                    if isinstance(ret, dict) and 'retcode' in ret:
-                        self.exit(ret['retcode'])
 
         except SaltClientError as exc:
             raise SystemExit(str(exc))

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -10,6 +10,7 @@ import weakref
 import traceback
 import collections
 import multiprocessing
+import tornado.stack_context
 
 # Import Salt libs
 import salt.exceptions
@@ -333,8 +334,10 @@ class SyncClientMixin(object):
             else:
                 kwargs = low['kwargs']
 
-            data['return'] = self.functions[fun](*args, **kwargs)
-            data['success'] = True
+            # Initialize a context for executing the method.
+            with tornado.stack_context.StackContext(self.functions.context_dict.clone):
+                data['return'] = self.functions[fun](*args, **kwargs)
+                data['success'] = True
         except (Exception, SystemExit) as ex:
             if isinstance(ex, salt.exceptions.NotImplemented):
                 data['return'] = str(ex)

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -84,13 +84,13 @@ class ClientFuncsDict(collections.MutableMapping):
 
             user = salt.utils.get_specific_user()
             return self.client._proc_function(
-                   key,
-                   low,
-                   user,
-                   async_pub['tag'],  # TODO: fix
-                   async_pub['jid'],  # TODO: fix
-                   False,  # Don't daemonize
-                   )
+                key,
+                low,
+                user,
+                async_pub['tag'],  # TODO: fix
+                async_pub['jid'],  # TODO: fix
+                False,  # Don't daemonize
+            )
         return wrapper
 
     def __len__(self):

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -90,17 +90,20 @@ def static_loader(
         base_path=None,
         filter_name=None,
         ):
-    funcs = LazyLoader(_module_dirs(opts,
-                                  ext_type,
-                                  tag,
-                                  int_type,
-                                  ext_dirs,
-                                  ext_type_dirs,
-                                  base_path),
-                     opts,
-                     tag=tag,
-                     pack=pack,
-                     )
+    funcs = LazyLoader(
+        _module_dirs(
+            opts,
+            ext_type,
+            tag,
+            int_type,
+            ext_dirs,
+            ext_type_dirs,
+            base_path,
+        ),
+        opts,
+        tag=tag,
+        pack=pack,
+    )
     ret = {}
     funcs._load_all()
     if filter_name:
@@ -193,14 +196,15 @@ def minion_mods(
     # TODO Publish documentation for module whitelisting
     if not whitelist:
         whitelist = opts.get('whitelist_modules', None)
-    ret = LazyLoader(_module_dirs(opts, 'modules', 'module'),
-                     opts,
-                     tag='module',
-                     pack={'__context__': context, '__utils__': utils,
-                           '__proxy__': proxy},
-                     whitelist=whitelist,
-                     loaded_base_name=loaded_base_name,
-                     static_modules=static_modules)
+    ret = LazyLoader(
+        _module_dirs(opts, 'modules', 'module'),
+        opts,
+        tag='module',
+        pack={'__context__': context, '__utils__': utils, '__proxy__': proxy},
+        whitelist=whitelist,
+        loaded_base_name=loaded_base_name,
+        static_modules=static_modules,
+    )
 
     ret.pack['__salt__'] = ret
 
@@ -242,11 +246,13 @@ def raw_mod(opts, name, functions, mod='modules'):
         testmod = salt.loader.raw_mod(__opts__, 'test', None)
         testmod['test.ping']()
     '''
-    loader = LazyLoader(_module_dirs(opts, mod, 'rawmodule'),
-                        opts,
-                        tag='rawmodule',
-                        virtual_enable=False,
-                        pack={'__salt__': functions})
+    loader = LazyLoader(
+        _module_dirs(opts, mod, 'rawmodule'),
+        opts,
+        tag='rawmodule',
+        virtual_enable=False,
+        pack={'__salt__': functions},
+    )
     # if we don't have the module, return an empty dict
     if name not in loader.file_mapping:
         return {}
@@ -261,21 +267,24 @@ def engines(opts, functions, runners):
     '''
     pack = {'__salt__': functions,
             '__runners__': runners}
-    return LazyLoader(_module_dirs(opts, 'engines', 'engines'),
-                      opts,
-                      tag='engines',
-                      pack=pack)
+    return LazyLoader(
+        _module_dirs(opts, 'engines', 'engines'),
+        opts,
+        tag='engines',
+        pack=pack,
+    )
 
 
 def proxy(opts, functions=None, returners=None, whitelist=None):
     '''
     Returns the proxy module for this salt-proxy-minion
     '''
-    ret = LazyLoader(_module_dirs(opts, 'proxy', 'proxy'),
-                     opts,
-                     tag='proxy',
-                     pack={'__salt__': functions,
-                           '__ret__': returners})
+    ret = LazyLoader(
+        _module_dirs(opts, 'proxy', 'proxy'),
+        opts,
+        tag='proxy',
+        pack={'__salt__': functions, '__ret__': returners},
+    )
 
     ret.pack['__proxy__'] = ret
 
@@ -286,34 +295,38 @@ def returners(opts, functions, whitelist=None, context=None):
     '''
     Returns the returner modules
     '''
-    return LazyLoader(_module_dirs(opts, 'returners', 'returner'),
-                      opts,
-                      tag='returner',
-                      whitelist=whitelist,
-                      pack={'__salt__': functions,
-                            '__context__': context})
+    return LazyLoader(
+        _module_dirs(opts, 'returners', 'returner'),
+        opts,
+        tag='returner',
+        whitelist=whitelist,
+        pack={'__salt__': functions, '__context__': context},
+    )
 
 
 def utils(opts, whitelist=None, context=None):
     '''
     Returns the utility modules
     '''
-    return LazyLoader(_module_dirs(opts, 'utils', 'utils', ext_type_dirs='utils_dirs'),
-                      opts,
-                      tag='utils',
-                      whitelist=whitelist,
-                      pack={'__context__': context})
+    return LazyLoader(
+        _module_dirs(opts, 'utils', 'utils', ext_type_dirs='utils_dirs'),
+        opts,
+        tag='utils',
+        whitelist=whitelist,
+        pack={'__context__': context},
+    )
 
 
 def pillars(opts, functions, context=None):
     '''
     Returns the pillars modules
     '''
-    ret = LazyLoader(_module_dirs(opts, 'pillar', 'pillar'),
-                     opts,
-                     tag='pillar',
-                     pack={'__salt__': functions,
-                           '__context__': context})
+    ret = LazyLoader(
+        _module_dirs(opts, 'pillar', 'pillar'),
+        opts,
+        tag='pillar',
+        pack={'__salt__': functions, '__context__': context},
+    )
     return FilterDictWrapper(ret, '.ext_pillar')
 
 
@@ -324,10 +337,12 @@ def tops(opts):
     if 'master_tops' not in opts:
         return {}
     whitelist = list(opts['master_tops'].keys())
-    ret = LazyLoader(_module_dirs(opts, 'tops', 'top'),
-                     opts,
-                     tag='top',
-                     whitelist=whitelist)
+    ret = LazyLoader(
+        _module_dirs(opts, 'tops', 'top'),
+        opts,
+        tag='top',
+        whitelist=whitelist,
+    )
     return FilterDictWrapper(ret, '.top')
 
 
@@ -335,10 +350,12 @@ def wheels(opts, whitelist=None):
     '''
     Returns the wheels modules
     '''
-    return LazyLoader(_module_dirs(opts, 'wheel', 'wheel'),
-                      opts,
-                      tag='wheel',
-                      whitelist=whitelist)
+    return LazyLoader(
+        _module_dirs(opts, 'wheel', 'wheel'),
+        opts,
+        tag='wheel',
+        whitelist=whitelist,
+    )
 
 
 def outputters(opts):
@@ -348,9 +365,11 @@ def outputters(opts):
     :param dict opts: The Salt options dictionary
     :returns: LazyLoader instance, with only outputters present in the keyspace
     '''
-    ret = LazyLoader(_module_dirs(opts, 'output', 'output', ext_type_dirs='outputter_dirs'),
-                     opts,
-                     tag='output')
+    ret = LazyLoader(
+        _module_dirs(opts, 'output', 'output', ext_type_dirs='outputter_dirs'),
+        opts,
+        tag='output',
+    )
     wrapped_ret = FilterDictWrapper(ret, '.output')
     # TODO: this name seems terrible... __salt__ should always be execution mods
     ret.pack['__salt__'] = wrapped_ret
@@ -363,9 +382,11 @@ def serializers(opts):
     :param dict opts: The Salt options dictionary
     :returns: LazyLoader instance, with only serializers present in the keyspace
     '''
-    return LazyLoader(_module_dirs(opts, 'serializers', 'serializers'),
-                      opts,
-                      tag='serializers')
+    return LazyLoader(
+        _module_dirs(opts, 'serializers', 'serializers'),
+        opts,
+        tag='serializers',
+    )
 
 
 def auth(opts, whitelist=None):
@@ -375,31 +396,37 @@ def auth(opts, whitelist=None):
     :param dict opts: The Salt options dictionary
     :returns: LazyLoader
     '''
-    return LazyLoader(_module_dirs(opts, 'auth', 'auth'),
-                      opts,
-                      tag='auth',
-                      whitelist=whitelist,
-                      pack={'__salt__': minion_mods(opts)})
+    return LazyLoader(
+        _module_dirs(opts, 'auth', 'auth'),
+        opts,
+        tag='auth',
+        whitelist=whitelist,
+        pack={'__salt__': minion_mods(opts)},
+    )
 
 
 def fileserver(opts, backends):
     '''
     Returns the file server modules
     '''
-    return LazyLoader(_module_dirs(opts, 'fileserver', 'fileserver'),
-                      opts,
-                      tag='fileserver',
-                      whitelist=backends)
+    return LazyLoader(
+        _module_dirs(opts, 'fileserver', 'fileserver'),
+        opts,
+        tag='fileserver',
+        whitelist=backends,
+    )
 
 
 def roster(opts, whitelist=None):
     '''
     Returns the roster modules
     '''
-    return LazyLoader(_module_dirs(opts, 'roster', 'roster'),
-                      opts,
-                      tag='roster',
-                      whitelist=whitelist)
+    return LazyLoader(
+        _module_dirs(opts, 'roster', 'roster'),
+        opts,
+        tag='roster',
+        whitelist=whitelist,
+    )
 
 
 def states(opts, functions, utils, whitelist=None):
@@ -418,11 +445,13 @@ def states(opts, functions, utils, whitelist=None):
         __opts__ = salt.config.minion_config('/etc/salt/minion')
         statemods = salt.loader.states(__opts__, None, None)
     '''
-    ret = LazyLoader(_module_dirs(opts, 'states', 'states'),
-                      opts,
-                      tag='states',
-                      pack={'__salt__': functions},
-                      whitelist=whitelist)
+    ret = LazyLoader(
+        _module_dirs(opts, 'states', 'states'),
+        opts,
+        tag='states',
+        pack={'__salt__': functions},
+        whitelist=whitelist,
+    )
     ret.pack['__states__'] = ret
     ret.pack['__utils__'] = utils
     return ret
@@ -436,11 +465,12 @@ def beacons(opts, functions, context=None):
     :param dict functions: A dictionary of minion modules, with module names as
                             keys and funcs as values.
     '''
-    return LazyLoader(_module_dirs(opts, 'beacons', 'beacons'),
-                      opts,
-                      tag='beacons',
-                      pack={'__context__': context,
-                            '__salt__': functions})
+    return LazyLoader(
+        _module_dirs(opts, 'beacons', 'beacons'),
+        opts,
+        tag='beacons',
+        pack={'__context__': context, '__salt__': functions},
+    )
 
 
 def search(opts, returners, whitelist=None):
@@ -453,11 +483,13 @@ def search(opts, returners, whitelist=None):
     '''
     # TODO Document returners arg
     # TODO Document whitelist arg
-    return LazyLoader(_module_dirs(opts, 'search', 'search'),
-                      opts,
-                      tag='search',
-                      whitelist=whitelist,
-                      pack={'__ret__': returners})
+    return LazyLoader(
+        _module_dirs(opts, 'search', 'search'),
+        opts,
+        tag='search',
+        whitelist=whitelist,
+        pack={'__ret__': returners},
+    )
 
 
 def log_handlers(opts):
@@ -466,14 +498,17 @@ def log_handlers(opts):
 
     :param dict opts: The Salt options dictionary
     '''
-    ret = LazyLoader(_module_dirs(opts,
-                                  'log_handlers',
-                                  'log_handlers',
-                                  int_type='handlers',
-                                  base_path=os.path.join(SALT_BASE_PATH, 'log')),
-                     opts,
-                     tag='log_handlers',
-                     )
+    ret = LazyLoader(
+        _module_dirs(
+            opts,
+            'log_handlers',
+            'log_handlers',
+            int_type='handlers',
+            base_path=os.path.join(SALT_BASE_PATH, 'log'),
+        ),
+        opts,
+        tag='log_handlers',
+    )
     return FilterDictWrapper(ret, '.setup_handlers')
 
 
@@ -481,14 +516,17 @@ def ssh_wrapper(opts, functions=None, context=None):
     '''
     Returns the custom logging handler modules
     '''
-    return LazyLoader(_module_dirs(opts,
-                                   'wrapper',
-                                   'wrapper',
-                                   base_path=os.path.join(SALT_BASE_PATH, os.path.join('client', 'ssh'))),
-                      opts,
-                      tag='wrapper',
-                      pack={'__salt__': functions, '__context__': context},
-                      )
+    return LazyLoader(
+        _module_dirs(
+            opts,
+            'wrapper',
+            'wrapper',
+            base_path=os.path.join(SALT_BASE_PATH, os.path.join('client', 'ssh')),
+        ),
+        opts,
+        tag='wrapper',
+        pack={'__salt__': functions, '__context__': context},
+    )
 
 
 def render(opts, functions, states=None):
@@ -498,14 +536,17 @@ def render(opts, functions, states=None):
     pack = {'__salt__': functions}
     if states:
         pack['__states__'] = states
-    ret = LazyLoader(_module_dirs(opts,
-                                  'renderers',
-                                  'render',
-                                  ext_type_dirs='render_dirs'),
-                     opts,
-                     tag='render',
-                     pack=pack,
-                     )
+    ret = LazyLoader(
+        _module_dirs(
+            opts,
+            'renderers',
+            'render',
+            ext_type_dirs='render_dirs',
+        ),
+        opts,
+        tag='render',
+        pack=pack,
+    )
     rend = FilterDictWrapper(ret, '.render')
 
     if not check_render_pipe_str(opts['renderer'], rend):
@@ -528,13 +569,16 @@ def grain_funcs(opts):
           __opts__ = salt.config.minion_config('/etc/salt/minion')
           grainfuncs = salt.loader.grain_funcs(__opts__)
     '''
-    return LazyLoader(_module_dirs(opts,
-                                   'grains',
-                                   'grain',
-                                   ext_type_dirs='grains_dirs'),
-                      opts,
-                      tag='grains',
-                      )
+    return LazyLoader(
+        _module_dirs(
+            opts,
+            'grains',
+            'grain',
+            ext_type_dirs='grains_dirs',
+        ),
+        opts,
+        tag='grains',
+    )
 
 
 def grains(opts, force_refresh=False):
@@ -672,11 +716,12 @@ def call(fun, **kwargs):
     args = kwargs.get('args', [])
     dirs = kwargs.get('dirs', [])
 
-    funcs = LazyLoader([os.path.join(SALT_BASE_PATH, 'modules')] + dirs,
-                          None,
-                          tag='modules',
-                          virtual_enable=False,
-                          )
+    funcs = LazyLoader(
+        [os.path.join(SALT_BASE_PATH, 'modules')] + dirs,
+        None,
+        tag='modules',
+        virtual_enable=False,
+    )
     return funcs[fun](*args)
 
 
@@ -684,10 +729,11 @@ def runner(opts):
     '''
     Directly call a function inside a loader directory
     '''
-    ret = LazyLoader(_module_dirs(opts, 'runners', 'runner', ext_type_dirs='runner_dirs'),
-                     opts,
-                     tag='runners',
-                     )
+    ret = LazyLoader(
+        _module_dirs(opts, 'runners', 'runner', ext_type_dirs='runner_dirs'),
+        opts,
+        tag='runners',
+    )
     # TODO: change from __salt__ to something else, we overload __salt__ too much
     ret.pack['__salt__'] = ret
     return ret
@@ -697,22 +743,24 @@ def queues(opts):
     '''
     Directly call a function inside a loader directory
     '''
-    return LazyLoader(_module_dirs(opts, 'queues', 'queue', ext_type_dirs='queue_dirs'),
-                     opts,
-                     tag='queues',
-                     )
+    return LazyLoader(
+        _module_dirs(opts, 'queues', 'queue', ext_type_dirs='queue_dirs'),
+        opts,
+        tag='queues',
+    )
 
 
 def sdb(opts, functions=None, whitelist=None):
     '''
     Make a very small database call
     '''
-    return LazyLoader(_module_dirs(opts, 'sdb', 'sdb'),
-                     opts,
-                     tag='sdb',
-                     pack={'__sdb__': functions},
-                     whitelist=whitelist,
-                     )
+    return LazyLoader(
+        _module_dirs(opts, 'sdb', 'sdb'),
+        opts,
+        tag='sdb',
+        pack={'__sdb__': functions},
+        whitelist=whitelist,
+    )
 
 
 def pkgdb(opts):
@@ -783,21 +831,23 @@ def netapi(opts):
     '''
     Return the network api functions
     '''
-    return LazyLoader(_module_dirs(opts, 'netapi', 'netapi'),
-                     opts,
-                     tag='netapi',
-                     )
+    return LazyLoader(
+        _module_dirs(opts, 'netapi', 'netapi'),
+        opts,
+        tag='netapi',
+    )
 
 
 def executors(opts, functions=None, context=None):
     '''
     Returns the executor modules
     '''
-    return LazyLoader(_module_dirs(opts, 'executors', 'executor'),
-                      opts,
-                      tag='executor',
-                      pack={'__salt__': functions, '__context__': context or {}},
-                      )
+    return LazyLoader(
+        _module_dirs(opts, 'executors', 'executor'),
+        opts,
+        tag='executor',
+        pack={'__salt__': functions, '__context__': context or {}},
+    )
 
 
 def _generate_module(name):

--- a/salt/utils/context.py
+++ b/salt/utils/context.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
+    :codeauthor: :email:`Thomas Jackson (jacksontj.89@gmail.com)`
 
 
     salt.utils.context
@@ -11,7 +12,12 @@
 from __future__ import absolute_import
 
 # Import python libs
+import copy
+import threading
+import collections
 from contextlib import contextmanager
+
+import salt.ext.six
 
 
 @contextmanager
@@ -49,3 +55,138 @@ def func_globals_inject(func, **overrides):
     # Remove any entry injected in the function globals
     for injected in injected_func_globals:
         del func_globals[injected]
+
+
+class ContextDict(collections.MutableMapping):
+    """A context manager that saves some per-thread state globally.
+    Intended for use with Tornado's StackContext.
+
+    Provide arbitrary data as kwargs upon creation,
+    then allow any children to override the values of the parent.
+    """
+
+    def __init__(self, **data):
+        # state should be thread local, so this object can be threadsafe
+        self._state = threading.local()
+        # variable for the overriden data
+        self._state.data = None
+        self.global_data = {}
+
+    @property
+    def active(self):
+        '''Determine if this ContextDict is currently overriden
+        Since the ContextDict can be overriden in each thread, we check whether
+        the _state.data is set or not.
+        '''
+        try:
+            return self._state.data is not None
+        except AttributeError:
+            return False
+
+    # TODO: rename?
+    def clone(self, **kwargs):
+        '''
+        Clone this context, and return the ChildContextDict
+        '''
+        child = ChildContextDict(parent=self, overrides=kwargs)
+        return child
+
+    def __setitem__(self, key, val):
+        if self.active:
+            self._state.data[key] = val
+        else:
+            self.global_data[key] = val
+
+    def __delitem__(self, key):
+        if self.active:
+            del self._state.data[key]
+        else:
+            del self.global_data[key]
+
+    def __getitem__(self, key):
+        if self.active:
+            return self._state.data[key]
+        else:
+            return self.global_data[key]
+
+    def __len__(self):
+        if self.active:
+            return len(self._state.data)
+        else:
+            return len(self.global_data)
+
+    def __iter__(self):
+        if self.active:
+            return iter(self._state.data)
+        else:
+            return iter(self.global_data)
+
+
+class ChildContextDict(collections.MutableMapping):
+    '''An overrideable child of ContextDict
+
+    '''
+    def __init__(self, parent, overrides=None):
+        self.parent = parent
+        self._data = {} if overrides is None else overrides
+
+        # merge self.global_data into self._data
+        for k, v in self.parent.global_data.iteritems():
+            if k not in self._data:
+                self._data[k] = copy.deepcopy(v)
+
+    def __setitem__(self, key, val):
+        self._data[key] = val
+
+    def __delitem__(self, key):
+        del self._data[key]
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def __len__(self):
+        return len(self._data)
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __enter__(self):
+        self.parent._state.data = self._data
+
+    def __exit__(self, *exc):
+        self.parent._state.data = None
+
+
+class NamespacedDictWrapper(collections.MutableMapping, dict):
+    '''
+    Create a dict which wraps another dict with a specific prefix of key(s)
+
+    MUST inherit from dict to serialize through msgpack correctly
+    '''
+    def __init__(self, d, pre_keys):
+        self.__dict = d
+        if isinstance(pre_keys, salt.ext.six.string_types):
+            self.pre_keys = (pre_keys,)
+        else:
+            self.pre_keys = pre_keys
+
+    def _dict(self):
+        r = self.__dict
+        for k in self.pre_keys:
+            r = r[k]
+        return r
+
+    def __setitem__(self, key, val):
+        self._dict()[key] = val
+
+    def __delitem__(self, key):
+        del self._dict()[key]
+
+    def __getitem__(self, key):
+        return self._dict()[key]
+
+    def __len__(self):
+        return len(self._dict())
+
+    def __iter__(self):
+        return iter(self._dict())

--- a/salt/utils/context.py
+++ b/salt/utils/context.py
@@ -163,7 +163,7 @@ class NamespacedDictWrapper(collections.MutableMapping, dict):
 
     MUST inherit from dict to serialize through msgpack correctly
     '''
-    def __init__(self, d, pre_keys):
+    def __init__(self, d, pre_keys):  # pylint: disable=W0231
         self.__dict = d
         if isinstance(pre_keys, salt.ext.six.string_types):
             self.pre_keys = (pre_keys,)

--- a/tests/unit/context_test.py
+++ b/tests/unit/context_test.py
@@ -104,7 +104,7 @@ class ContextDictTests(AsyncTestCase):
 
         wait_iterator = tornado.gen.WaitIterator(*futures)
         while not wait_iterator.done():
-            r = yield wait_iterator.next()
+            r = yield next(wait_iterator)
             self.assertEqual(r[0], r[1])  # verify that the global value remails
             self.assertEqual(r[2], r[3])  # verify that the override sticks locally
             self.assertEqual(r[3], r[4])  # verify that the override sticks across coroutines

--- a/tests/unit/context_test.py
+++ b/tests/unit/context_test.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+'''
+    tests.unit.context_test
+    ~~~~~~~~~~~~~~~~~~~~
+'''
+# Import python libs
+from __future__ import absolute_import
+import tornado.stack_context
+import threading
+import time
+
+# Import Salt Testing libs
+from salttesting import TestCase
+from salttesting.helpers import ensure_in_syspath
+ensure_in_syspath('../../')
+
+# Import Salt libs
+from salt.utils.context import ContextDict, NamespacedDictWrapper
+
+
+class ContextDictTests(TestCase):
+    def setUp(self):
+        self.cd = ContextDict()
+        # set a global value
+        self.cd['foo'] = 'global'
+
+    def test_threads(self):
+        rets = []
+
+        def tgt(x, s):
+            inner_ret = []
+            over = self.cd.clone()
+
+            inner_ret.append(self.cd.get('foo'))
+            with over:
+                inner_ret.append(over.get('foo'))
+                over['foo'] = x
+                inner_ret.append(over.get('foo'))
+                time.sleep(s)
+                inner_ret.append(over.get('foo'))
+                rets.append(inner_ret)
+
+        threads = []
+        NUM_JOBS = 5
+        for x in xrange(0, NUM_JOBS):
+            s = NUM_JOBS - x
+            t = threading.Thread(target=tgt, args=(x, s))
+            t.start()
+            threads.append(t)
+
+        for t in threads:
+            t.join()
+
+        for r in rets:
+            self.assertEqual(r[0], r[1])
+            self.assertEqual(r[2], r[3])
+
+    def test_basic(self):
+        '''Test that the contextDict is a dict
+        '''
+        # ensure we get the global value
+        self.assertEqual(
+            dict(self.cd),
+            {'foo': 'global'},
+        )
+
+    def test_override(self):
+        over = self.cd.clone()
+        over['bar'] = 'global'
+        self.assertEqual(
+            dict(over),
+            {'foo': 'global', 'bar': 'global'},
+        )
+        self.assertEqual(
+            dict(self.cd),
+            {'foo': 'global'},
+        )
+        with tornado.stack_context.StackContext(lambda: over):
+            self.assertEqual(
+                dict(over),
+                {'foo': 'global', 'bar': 'global'},
+            )
+            self.assertEqual(
+                dict(self.cd),
+                {'foo': 'global', 'bar': 'global'},
+            )
+            over['bar'] = 'baz'
+            self.assertEqual(
+                dict(over),
+                {'foo': 'global', 'bar': 'baz'},
+            )
+            self.assertEqual(
+                dict(self.cd),
+                {'foo': 'global', 'bar': 'baz'},
+            )
+        self.assertEqual(
+            dict(over),
+            {'foo': 'global', 'bar': 'baz'},
+        )
+        self.assertEqual(
+            dict(self.cd),
+            {'foo': 'global'},
+        )
+
+    def test_multiple_contexts(self):
+        cds = []
+        for x in xrange(0, 10):
+            cds.append(self.cd.clone(bar=x))
+        for x, cd in enumerate(cds):
+            self.assertNotIn('bar', self.cd)
+            with tornado.stack_context.StackContext(lambda: cd):
+                self.assertEqual(
+                    dict(self.cd),
+                    {'bar': x, 'foo': 'global'},
+                )
+        self.assertNotIn('bar', self.cd)
+
+
+class NamespacedDictWrapperTests(TestCase):
+    PREFIX = 'prefix'
+
+    def setUp(self):
+        self._dict = {}
+
+    def test_single_key(self):
+        self._dict['prefix'] = {'foo': 'bar'}
+        w = NamespacedDictWrapper(self._dict, 'prefix')
+        self.assertEqual(w['foo'], 'bar')
+
+    def test_multiple_key(self):
+        self._dict['prefix'] = {'foo': {'bar': 'baz'}}
+        w = NamespacedDictWrapper(self._dict, ('prefix', 'foo'))
+        self.assertEqual(w['bar'], 'baz')

--- a/tests/unit/context_test.py
+++ b/tests/unit/context_test.py
@@ -13,6 +13,7 @@ import time
 
 # Import Salt Testing libs
 from salttesting import TestCase
+from salt.ext.six.moves import range
 from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../')
 
@@ -47,7 +48,7 @@ class ContextDictTests(AsyncTestCase):
 
         threads = []
         NUM_JOBS = 5
-        for x in xrange(0, NUM_JOBS):
+        for x in range(0, NUM_JOBS):
             s = NUM_JOBS - x
             t = threading.Thread(target=tgt, args=(x, s))
             t.start()
@@ -89,7 +90,7 @@ class ContextDictTests(AsyncTestCase):
 
         futures = []
         NUM_JOBS = 5
-        for x in xrange(0, NUM_JOBS):
+        for x in range(0, NUM_JOBS):
             s = NUM_JOBS - x
             over = self.cd.clone()
             def run():
@@ -156,7 +157,7 @@ class ContextDictTests(AsyncTestCase):
 
     def test_multiple_contexts(self):
         cds = []
-        for x in xrange(0, 10):
+        for x in range(0, 10):
             cds.append(self.cd.clone(bar=x))
         for x, cd in enumerate(cds):
             self.assertNotIn('bar', self.cd)

--- a/tests/unit/context_test.py
+++ b/tests/unit/context_test.py
@@ -22,6 +22,9 @@ from salt.utils.context import ContextDict, NamespacedDictWrapper
 
 
 class ContextDictTests(AsyncTestCase):
+    # how many threads/coroutines to run at a time
+    num_concurrent_tasks = 5
+
     def setUp(self):
         super(ContextDictTests, self).setUp()
         self.cd = ContextDict()
@@ -47,9 +50,8 @@ class ContextDictTests(AsyncTestCase):
                 rets.append(inner_ret)
 
         threads = []
-        NUM_JOBS = 5
-        for x in range(0, NUM_JOBS):
-            s = NUM_JOBS - x
+        for x in range(0, self.num_concurrent_tasks):
+            s = self.num_concurrent_tasks - x
             t = threading.Thread(target=tgt, args=(x, s))
             t.start()
             threads.append(t)
@@ -89,9 +91,9 @@ class ContextDictTests(AsyncTestCase):
             raise tornado.gen.Return(inner_ret)
 
         futures = []
-        NUM_JOBS = 5
-        for x in range(0, NUM_JOBS):
-            s = NUM_JOBS - x
+
+        for x in range(0, self.num_concurrent_tasks):
+            s = self.num_concurrent_tasks - x
             over = self.cd.clone()
             def run():
                 return tgt(x, s/5.0, over)

--- a/tests/unit/context_test.py
+++ b/tests/unit/context_test.py
@@ -95,11 +95,10 @@ class ContextDictTests(AsyncTestCase):
         for x in range(0, self.num_concurrent_tasks):
             s = self.num_concurrent_tasks - x
             over = self.cd.clone()
-            def run():
-                return tgt(x, s/5.0, over)
+
             f = tornado.stack_context.run_with_stack_context(
-                tornado.stack_context.StackContext(lambda: over),
-                run,
+                tornado.stack_context.StackContext(lambda: over),  # pylint: disable=W0640
+                lambda: tgt(x, s/5.0, over),  # pylint: disable=W0640
             )
             futures.append(f)
 


### PR DESCRIPTION
**_Please DO NOT immediately merge**_

While investigating #23373 we realized that the reactor problems we were seeing were actually to do with the fact that the loader isn't threadsafe (due to globals injection). Since the direction we are going is _more_ concurrency-- we really need to have a robust solution for making injected variables thread/coroutine safe.

Another system that has something similar is flask's [request context](http://flask.pocoo.org/docs/0.10/reqcontext/)). In flask if you want access to the `request` object, you simply import the object and it will be your version (for your given context). This simple access makes the data storage concurrency a non-issue.

The implementation here is a RequestContext (based on tornado's [stack_context](http://tornadokevinlee.readthedocs.org/en/latest/stack_context.html)). This RequestContext will do all of the bookkeeping of which coroutine/thread is currently executing-- and will switch between the values for each one. 

To maintain compatibility with the globals injection (`__salt__`) I've also created NamespacedDictWrapper which simply looks like the global dict but under the hood calls the appropriate namespace within RequestContext.
