### PR TITLE
Clarify argument usage for runners in reactors

### DIFF
--- a/doc/topics/reactor/index.rst
+++ b/doc/topics/reactor/index.rst
@@ -290,8 +290,8 @@ For example:
     clear_the_grains_cache_for_all_minions:
       runner.cache.clear_grains
 
-If :py:func:`the runner takes arguments <salt.runners.cache.clear_grains>` then
-they can be specified as well:
+If the :py:func:`the runner takes arguments <salt.runners.cloud.profile>` then
+they must be specified as keyword arguments.
 
 .. code-block:: yaml
 
@@ -301,6 +301,9 @@ they can be specified as well:
         - instances:
           - web11       # These VM names would be generated via Jinja in a
           - web12       # real-world example.
+
+To determine the proper names for the arguments, check the documentation
+or source code for the runner function you wish to call.
 
 Passing event data to Minions or Orchestrate as Pillar
 ------------------------------------------------------


### PR DESCRIPTION
Clarified that positional arguments don't work in runners currently and
that you must use keyword args. Fixes #27770

Also, modified the link to point at the function the example shows,
rather than the previous example.
