### PR TITLE
Adding return_kwargs

### DIFF
--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -85,6 +85,10 @@ class SaltCMD(parsers.SaltCMDOptionParser):
             if getattr(self.options, 'return_config'):
                 kwargs['ret_config'] = getattr(self.options, 'return_config')
 
+            if getattr(self.options, 'return_kwargs'):
+                kwargs['ret_kwargs'] = yamlify_arg(
+                        getattr(self.options, 'return_kwargs'))
+
             if getattr(self.options, 'module_executors'):
                 kwargs['module_executors'] = yamlify_arg(getattr(self.options, 'module_executors'))
 

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -1611,6 +1611,9 @@ class LocalFuncs(object):
             if 'metadata' in load['kwargs']:
                 pub_load['metadata'] = load['kwargs'].get('metadata')
 
+            if 'ret_kwargs' in load['kwargs']:
+                pub_load['ret_kwargs'] = load['kwargs'].get('ret_kwargs')
+
         if 'user' in load:
             log.info(
                 'User {user} Published command {fun} with jid {jid}'.format(

--- a/salt/master.py
+++ b/salt/master.py
@@ -2179,6 +2179,9 @@ class ClearFuncs(object):
             if 'module_executors' in clear_load['kwargs']:
                 load['module_executors'] = clear_load['kwargs'].get('module_executors')
 
+            if 'ret_kwargs' in clear_load['kwargs']:
+                load['ret_kwargs'] = clear_load['kwargs'].get('ret_kwargs')
+
         if 'user' in clear_load:
             log.info(
                 'User {user} Published command {fun} with jid {jid}'.format(

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1149,6 +1149,8 @@ class Minion(MinionBase):
         if data['ret']:
             if 'ret_config' in data:
                 ret['ret_config'] = data['ret_config']
+            if 'ret_kwargs' in data:
+                ret['ret_kwargs'] = data['ret_kwargs']
             ret['id'] = opts['id']
             for returner in set(data['ret'].split(',')):
                 try:
@@ -1209,6 +1211,8 @@ class Minion(MinionBase):
         if data['ret']:
             if 'ret_config' in data:
                 ret['ret_config'] = data['ret_config']
+            if 'ret_kwargs' in data:
+                ret['ret_kwargs'] = data['ret_kwargs']
             for returner in set(data['ret'].split(',')):
                 ret['id'] = opts['id']
                 try:

--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -54,6 +54,8 @@ SCHEDULE_CONF = [
         'cron',
         'until',
         'after',
+        'return_config',
+        'return_kwargs'
 ]
 
 
@@ -348,7 +350,7 @@ def build_schedule_item(name, **kwargs):
             schedule[name]['splay'] = kwargs['splay']
 
     for item in ['range', 'when', 'once', 'once_fmt', 'cron', 'returner',
-            'return_config', 'until']:
+                 'return_config', 'return_kwargs', 'until']:
         if item in kwargs:
             schedule[name][item] = kwargs[item]
 

--- a/salt/returners/__init__.py
+++ b/salt/returners/__init__.py
@@ -98,6 +98,11 @@ def get_returner_options(virtualname=None,
         )
     )
 
+    # override some values with relevant options from
+    # keyword arguments passed via return_kwargs
+    if 'ret_kwargs' in ret:
+        _options.update(ret['ret_kwargs'])
+
     return _options
 
 

--- a/salt/returners/carbon_return.py
+++ b/salt/returners/carbon_return.py
@@ -70,6 +70,15 @@ To use the alternative configuration, append '--return_config alternative' to th
 .. code-block:: bash
 
     salt '*' test.ping --return carbon --return_config alternative
+
+To override individual configuration items, append --return_kwargs '{"key:": "value"}' to the salt command.
+
+.. versionadded:: Boron
+
+.. code-block:: bash
+
+    salt '*' test.ping --return carbon --return_kwargs '{"skip_on_error": False}'
+
 '''
 
 # Import python libs

--- a/salt/returners/couchdb_return.py
+++ b/salt/returners/couchdb_return.py
@@ -31,6 +31,14 @@ To use the alternative configuration, append ``--return_config alternative`` to 
 
     salt '*' test.ping --return couchdb --return_config alternative
 
+To override individual configuration items, append --return_kwargs '{"key:": "value"}' to the salt command.
+
+.. versionadded:: Boron
+
+.. code-block:: bash
+
+    salt '*' test.ping --return couchdb --return_kwargs '{"db": "another-salt"}'
+
 On concurrent database access
 ==============================
 

--- a/salt/returners/hipchat_return.py
+++ b/salt/returners/hipchat_return.py
@@ -65,6 +65,15 @@ To use the alternative configuration, append '--return_config alternative' to th
 .. code-block:: bash
 
     salt '*' test.ping --return hipchat --return_config alternative
+
+To override individual configuration items, append --return_kwargs '{"key:": "value"}' to the salt command.
+
+.. versionadded:: Boron
+
+.. code-block:: bash
+
+    salt '*' test.ping --return hipchat --return_kwargs '{"room_id": "another-room"}'
+
 '''
 from __future__ import absolute_import
 

--- a/salt/returners/influxdb_return.py
+++ b/salt/returners/influxdb_return.py
@@ -40,6 +40,15 @@ To use the alternative configuration, append '--return_config alternative' to th
 .. code-block:: bash
 
     salt '*' test.ping --return influxdb --return_config alternative
+
+To override individual configuration items, append --return_kwargs '{"key:": "value"}' to the salt command.
+
+.. versionadded:: Boron
+
+.. code-block:: bash
+
+    salt '*' test.ping --return influxdb --return_kwargs '{"db": "another-salt"}'
+
 '''
 from __future__ import absolute_import
 

--- a/salt/returners/memcache_return.py
+++ b/salt/returners/memcache_return.py
@@ -35,6 +35,15 @@ To use the alternative configuration, append '--return_config alternative' to th
 .. code-block:: bash
 
     salt '*' test.ping --return memcache --return_config alternative
+
+To override individual configuration items, append --return_kwargs '{"key:": "value"}' to the salt command.
+
+.. versionadded:: Boron
+
+.. code-block:: bash
+
+    salt '*' test.ping --return memcache --return_kwargs '{"host": "hostname.domain.com"}'
+
 '''
 from __future__ import absolute_import
 

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -53,6 +53,15 @@ To use the alternative configuration, append '--return_config alternative' to th
 .. code-block:: bash
 
     salt '*' test.ping --return mongo --return_config alternative
+
+To override individual configuration items, append --return_kwargs '{"key:": "value"}' to the salt command.
+
+.. versionadded:: Boron
+
+.. code-block:: bash
+
+    salt '*' test.ping --return mongo --return_kwargs '{"db": "another-salt"}'
+
 '''
 from __future__ import absolute_import
 

--- a/salt/returners/mongo_return.py
+++ b/salt/returners/mongo_return.py
@@ -42,6 +42,23 @@ To use the alternative configuration, append '--return_config alternative' to th
 .. code-block:: bash
 
     salt '*' test.ping --return mongo_return --return_config alternative
+
+To override individual configuration items, append --return_kwargs '{"key:": "value"}' to the salt command.
+
+.. versionadded:: Boron
+
+.. code-block:: bash
+
+    salt '*' test.ping --return mongo --return_kwargs '{"db": "another-salt"}'
+
+To override individual configuration items, append --return_kwargs '{"key:": "value"}' to the salt command.
+
+.. versionadded:: Boron
+
+.. code-block:: bash
+
+    salt '*' test.ping --return mongo --return_kwargs '{"db": "another-salt"}'
+
 '''
 from __future__ import absolute_import
 

--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -114,6 +114,15 @@ To use the alternative configuration, append '--return_config alternative' to th
 .. code-block:: bash
 
     salt '*' test.ping --return mysql --return_config alternative
+
+To override individual configuration items, append --return_kwargs '{"key:": "value"}' to the salt command.
+
+.. versionadded:: Boron
+
+.. code-block:: bash
+
+    salt '*' test.ping --return mysql --return_kwargs '{"db": "another-salt"}'
+
 '''
 from __future__ import absolute_import
 # Let's not allow PyLint complain about string substitution

--- a/salt/returners/nagios_return.py
+++ b/salt/returners/nagios_return.py
@@ -38,6 +38,15 @@ Nagios settings may also be configured as::
   To use the alternative configuration, append '--return_config alternative' to the salt command. ex:
 
     salt '*' test.ping --return nagios --return_config alternative
+
+To override individual configuration items, append --return_kwargs '{"key:": "value"}' to the salt command.
+
+.. versionadded:: Boron
+
+.. code-block:: bash
+
+    salt '*' test.ping --return nagios --return_kwargs '{"service": "service-name"}'
+
 '''
 from __future__ import absolute_import
 

--- a/salt/returners/odbc.py
+++ b/salt/returners/odbc.py
@@ -113,6 +113,15 @@ correctly.  Replace with equivalent SQL for other ODBC-compliant servers
   .. code-block:: bash
 
     salt '*' test.ping --return odbc --return_config alternative
+
+To override individual configuration items, append --return_kwargs '{"key:": "value"}' to the salt command.
+
+.. versionadded:: Boron
+
+.. code-block:: bash
+
+    salt '*' test.ping --return odbc --return_kwargs '{"dsn": "dsn-name"}'
+
 '''
 from __future__ import absolute_import
 # Let's not allow PyLint complain about string substitution

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -119,6 +119,15 @@ To use the alternative configuration, append '--return_config alternative' to th
 .. code-block:: bash
 
     salt '*' test.ping --return pgjsonb --return_config alternative
+
+To override individual configuration items, append --return_kwargs '{"key:": "value"}' to the salt command.
+
+.. versionadded:: Boron
+
+.. code-block:: bash
+
+    salt '*' test.ping --return pgjsonb --return_kwargs '{"db": "another-salt"}'
+
 '''
 from __future__ import absolute_import
 # Let's not allow PyLint complain about string substitution

--- a/salt/returners/postgres.py
+++ b/salt/returners/postgres.py
@@ -85,6 +85,15 @@ To use the alternative configuration, append '--return_config alternative' to th
 .. code-block:: bash
 
     salt '*' test.ping --return postgres --return_config alternative
+
+To override individual configuration items, append --return_kwargs '{"key:": "value"}' to the salt command.
+
+.. versionadded:: Boron
+
+.. code-block:: bash
+
+    salt '*' test.ping --return postgres --return_kwargs '{"db": "another-salt"}'
+
 '''
 from __future__ import absolute_import
 # Let's not allow PyLint complain about string substitution

--- a/salt/returners/pushover_returner.py
+++ b/salt/returners/pushover_returner.py
@@ -67,6 +67,15 @@ PushOver settings may also be configured as::
   To use the alternative configuration, append '--return_config alternative' to the salt command. ex:
 
     salt '*' test.ping --return pushover --return_config alternative
+
+To override individual configuration items, append --return_kwargs '{"key:": "value"}' to the salt command.
+
+.. versionadded:: Boron
+
+.. code-block:: bash
+
+    salt '*' test.ping --return pushover --return_kwargs '{"title": "Salt is awesome!"}'
+
 '''
 from __future__ import absolute_import
 

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -35,6 +35,15 @@ To use the alternative configuration, append '--return_config alternative' to th
 .. code-block:: bash
 
     salt '*' test.ping --return redis --return_config alternative
+
+To override individual configuration items, append --return_kwargs '{"key:": "value"}' to the salt command.
+
+.. versionadded:: Boron
+
+.. code-block:: bash
+
+    salt '*' test.ping --return redis --return_kwargs '{"db": "another-salt"}'
+
 '''
 from __future__ import absolute_import
 

--- a/salt/returners/slack_returner.py
+++ b/salt/returners/slack_returner.py
@@ -62,6 +62,15 @@ To use the alternative configuration, append '--return_config alternative' to th
 .. code-block:: bash
 
     salt '*' test.ping --return slack --return_config alternative
+
+To override individual configuration items, append --return_kwargs '{"key:": "value"}' to the salt command.
+
+.. versionadded:: Boron
+
+.. code-block:: bash
+
+    salt '*' test.ping --return slack --return_kwargs '{"channel": "#random"}'
+
 '''
 from __future__ import absolute_import
 

--- a/salt/returners/smtp_return.py
+++ b/salt/returners/smtp_return.py
@@ -69,6 +69,14 @@ To use the alternative configuration, append '--return_config alternative' to th
 
     salt '*' test.ping --return smtp --return_config alternative
 
+To override individual configuration items, append --return_kwargs '{"key:": "value"}' to the salt command.
+
+.. versionadded:: Boron
+
+.. code-block:: bash
+
+    salt '*' test.ping --return smtp --return_kwargs '{"to": "user@domain.com"}'
+
 '''
 from __future__ import absolute_import
 

--- a/salt/returners/sqlite3_return.py
+++ b/salt/returners/sqlite3_return.py
@@ -71,6 +71,14 @@ To use the alternative configuration, append '--return_config alternative' to th
 
     salt '*' test.ping --return sqlite3 --return_config alternative
 
+To override individual configuration items, append --return_kwargs '{"key:": "value"}' to the salt command.
+
+.. versionadded:: Boron
+
+.. code-block:: bash
+
+    salt '*' test.ping --return sqlite3 --return_kwargs '{"db": "/var/lib/salt/another-salt.db"}'
+
 '''
 from __future__ import absolute_import
 

--- a/salt/returners/xmpp_return.py
+++ b/salt/returners/xmpp_return.py
@@ -55,6 +55,15 @@ To use the alternative configuration, append '--return_config alternative' to th
 .. code-block:: bash
 
     salt '*' test.ping --return xmpp --return_config alternative
+
+To override individual configuration items, append --return_kwargs '{"key:": "value"}' to the salt command.
+
+.. versionadded:: Boron
+
+.. code-block:: bash
+
+    salt '*' test.ping --return xmpp --return_kwargs '{"recipient": "someone-else@xmpp.example.com"}'
+
 '''
 from __future__ import absolute_import
 

--- a/salt/states/schedule.py
+++ b/salt/states/schedule.py
@@ -71,6 +71,8 @@ Management of the Salt scheduler
             - Friday 5:00pm
         - returner: xmpp
         - return_config: xmpp_state_run
+        - return_kwargs:
+            recipient: user@domain.com
 
     This will schedule the command: state.sls httpd test=True at 5pm on Monday,
     Wednesday and Friday, and 3pm on Tuesday and Thursday.  Using the xmpp returner
@@ -165,6 +167,10 @@ def present(name,
 
     return_config
         The alternative configuration to use for returner configuration options.
+
+    return_kwargs
+        Any individual returner configuration items to override.  Should be passed
+        as a dictionary.
 
     persist
         Whether the job should persist between minion restarts, defaults to True.

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1750,6 +1750,12 @@ class SaltCMDOptionParser(six.with_metaclass(OptionParserMeta,
                   'systems, databases or applications.')
         )
         self.add_option(
+            '--return_kwargs',
+            default={},
+            metavar='RETURNER_KWARGS',
+            help=('Set any returner options at the command line.')
+        )
+        self.add_option(
             '--module-executors',
             dest='module_executors',
             default=None,

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -682,6 +682,8 @@ class Schedule(object):
             if data_returner or self.schedule_returner:
                 if 'returner_config' in data:
                     ret['ret_config'] = data['returner_config']
+                if 'returner_kwargs' in data:
+                    ret['ret_kwargs'] = data['returner_kwargs']
                 rets = []
                 for returner in [data_returner, self.schedule_returner]:
                     if isinstance(returner, str):


### PR DESCRIPTION
Adding the ability from both the Salt CLI and in the Salt schedule to pass a new argument, return_kwargs.  Using this option will override any returner options already set in the minion configuration or inside an alternative configuration.
