### PR TITLE
2015.5 branch: Fix traceback when 2015.8 git ext_pillar config schema used

### DIFF
--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -61,7 +61,15 @@ def init_git_pillar(opts):
                 import git
             except ImportError:
                 return pillargitfs
-            parts = opts_dict['git'].strip().split()
+            try:
+                parts = opts_dict['git'].strip().split()
+            except AttributeError:
+                log.error(
+                    'Invalid git ext_pillar configuration found, please check '
+                    'the master config file. Each git ext_pillar specified '
+                    'must be a string.'
+                )
+                continue
             try:
                 br = parts[0]
                 loc = parts[1]


### PR DESCRIPTION
If the new gitfs-backed git_pillar configuration schema is used, the
Maintenance process will endlessly crash and restart itself because of a
traceback raised when parsing the ext_pillar configuration. This commit
fixes that by catching the AttributeError and logging an error to the
master log.
