### PR TITLE
pass along kwargs data so gather_job_info so find_job will use eauth

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -195,7 +195,7 @@ class LocalClient(object):
         # Looks like the timeout is invalid, use config
         return self.opts['timeout']
 
-    def gather_job_info(self, jid, tgt, tgt_type):
+    def gather_job_info(self, jid, tgt, tgt_type, **kwargs):
         '''
         Return the information about a given job
         '''
@@ -207,6 +207,7 @@ class LocalClient(object):
                                 arg=[jid],
                                 expr_form=tgt_type,
                                 timeout=timeout,
+                                **kwargs
                                )
 
         if 'jid' in pub_data:
@@ -934,7 +935,7 @@ class LocalClient(object):
             # re-do the ping
             if time.time() > timeout_at and minions_running:
                 # since this is a new ping, no one has responded yet
-                jinfo = self.gather_job_info(jid, tgt, tgt_type)
+                jinfo = self.gather_job_info(jid, tgt, tgt_type, **kwargs)
                 minions_running = False
                 # if we weren't assigned any jid that means the master thinks
                 # we have nothing to send
@@ -1252,7 +1253,8 @@ class LocalClient(object):
                                          timeout=timeout,
                                          tgt=tgt,
                                          tgt_type=tgt_type,
-                                         expect_minions=(verbose or show_timeout)
+                                         expect_minions=(verbose or show_timeout),
+                                         **kwargs
                                          ):
             return_count = return_count + 1
             if progress:


### PR DESCRIPTION
When executing a long running job, like highstate, the client throws an authentication error when using eauth (pam in my case). This happens after the job is successfully submitted.  The root cause is when the client tries to run saltutil.find_job in gather_job_info the eauth details in kwargs are not passed along so the master throws an authentication error of type "user".
