### PR TITLE
only look at basename of file path for glob match

### DIFF
--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -761,7 +761,7 @@ def push_dir(path, glob=None, upload_path=None):
         for root, dirs, files in os.walk(path):
             filelist += [os.path.join(root, tmpfile) for tmpfile in files]
         if glob is not None:
-            filelist = [fi for fi in filelist if fnmatch.fnmatch(fi, glob)]
+            filelist = [fi for fi in filelist if fnmatch.fnmatch(os.path.basename(fi), glob)]
         for tmpfile in filelist:
             if upload_path and tmpfile.startswith(path):
                 tmpupload_path = os.path.join(os.path.sep,


### PR DESCRIPTION
I couldn't find an issue, but there is a google group post talking about the issue.
