### PR TITLE
Philips HUE lamps Proxy Minion

### DIFF
--- a/salt/grains/philips_hue.py
+++ b/salt/grains/philips_hue.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 '''
-Generate baseline proxy minion grains
+Static grains for the Philips HUE lamps
 '''
+
 __proxyenabled__ = ['philips_hue']
 
 __virtualname__ = 'hue'

--- a/salt/grains/philips_hue.py
+++ b/salt/grains/philips_hue.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+'''
+Generate baseline proxy minion grains
+'''
+__proxyenabled__ = ['philips_hue']
+
+__virtualname__ = 'hue'
+
+
+def __virtual__():
+    if 'proxy' not in __opts__:
+        return False
+    else:
+        return __virtualname__
+
+
+def kernel():
+    return {'kernel': 'RTOS'}
+
+
+def os():
+    return {'os': 'FreeRTOS'}
+
+
+def os_family():
+    return {'os_family': 'RTOS'}
+
+
+def vendor():
+    return {'vendor': 'Philips'}
+
+
+def product():
+    return {'product': 'HUE'}

--- a/salt/grains/philips_hue.py
+++ b/salt/grains/philips_hue.py
@@ -1,4 +1,19 @@
 # -*- coding: utf-8 -*-
+#
+# Copyright 2015 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 '''
 Static grains for the Philips HUE lamps
 '''

--- a/salt/modules/philips_hue.py
+++ b/salt/modules/philips_hue.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+'''
+Philips HUE lamps module for proxy.
+'''
+
+from __future__ import absolute_import
+import sys
+
+__virtualname__ = 'hue'
+__proxyenabled__ = ['philips_hue']
+
+
+def _proxy():
+    '''
+    Get proxy.
+    '''
+    return __opts__['proxymodule']
+
+
+def __virtual__():
+    '''
+    Start the Philips HUE only for proxies.
+    '''
+
+    def _mkf(cmd_name, doc):
+        def _cmd(*args, **kw):
+            return _proxy()[_proxy().loaded_base_name + "." + cmd_name](*args, **kw)
+        return _cmd
+
+    import salt.proxy.philips_hue as hue
+    for method in dir(hue):
+        if method.startswith('call_'):
+            setattr(sys.modules[__name__], method[5:], _mkf(method, getattr(hue, method).__doc__))
+    del hue
+
+    return _proxy() and __virtualname__ or False

--- a/salt/modules/philips_hue.py
+++ b/salt/modules/philips_hue.py
@@ -1,4 +1,19 @@
 # -*- coding: utf-8 -*-
+#
+# Copyright 2015 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 '''
 Philips HUE lamps module for proxy.
 '''

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -163,7 +163,6 @@ def call_switch(*args, **kwargs):
     '''
     out = dict()
     devices = call_lights()
-    print devices
     for dev_id in ('id' not in kwargs and devices.keys() or _get_devices(kwargs)):
         if 'on' in kwargs:
             state = kwargs['on'] and Const.LAMP_ON or Const.LAMP_OFF

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -34,7 +34,7 @@ CONFIG = {}
 log = logging.getLogger(__file__)
 
 
-class Const:
+class Const(object):
     '''
     Constants for the lamp operations.
     '''
@@ -46,11 +46,10 @@ class Const:
     COLOR_RED = {"hue": 0, "sat": 254}
     COLOR_GREEN = {"hue": 25500, "sat": 254}
     COLOR_ORANGE = {"hue": 12000, "sat": 254}
-    COLOR_PINK = {"xy": [0.3688,0.2095]}
+    COLOR_PINK = {"xy": [0.3688, 0.2095]}
     COLOR_BLUE = {"hue": 46920, "sat": 254}
     COLOR_YELLOW = {"xy": [0.4432, 0.5154]}
-    COLOR_PURPLE = {"xy": [0.3787,0.1724]}
-
+    COLOR_PURPLE = {"xy": [0.3787, 0.1724]}
 
 
 def __virtual__():
@@ -103,7 +102,7 @@ def _set(lamp_id, state, method="state"):
     res = None
     try:
         res = json.loads(requests.put(url, json=state).content)
-    except Exception, err:
+    except Exception as err:
         raise CommandExecutionError(err)
 
     res = len(res) > 1 and res[-1] or res[0]
@@ -139,7 +138,7 @@ def _get_lights():
     '''
     try:
         return json.loads(requests.get(CONFIG['url'] + "/lights").content)
-    except Exception, exc:
+    except Exception as exc:
         raise CommandExecutionError(exc)
 
 
@@ -150,7 +149,7 @@ def call_lights(*args, **kwargs):
     '''
     res = dict()
     lights = _get_lights()
-    for dev_id in ('id' in kwargs and _get_devices(kwargs) or sorted(lights.keys())):
+    for dev_id in 'id' in kwargs and _get_devices(kwargs) or sorted(lights.keys()):
         if lights.get(str(dev_id)):
             res[dev_id] = lights[str(dev_id)]
 
@@ -179,7 +178,7 @@ def call_switch(*args, **kwargs):
     '''
     out = dict()
     devices = _get_lights()
-    for dev_id in ('id' not in kwargs and sorted(devices.keys()) or _get_devices(kwargs)):
+    for dev_id in 'id' not in kwargs and sorted(devices.keys()) or _get_devices(kwargs):
         if 'on' in kwargs:
             state = kwargs['on'] and Const.LAMP_ON or Const.LAMP_OFF
         else:
@@ -209,7 +208,7 @@ def call_blink(*args, **kwargs):
     devices = _get_lights()
     pause = kwargs.get('pause', 0)
     res = dict()
-    for dev_id in ('id' not in kwargs and sorted(devices.keys()) or _get_devices(kwargs)):
+    for dev_id in 'id' not in kwargs and sorted(devices.keys()) or _get_devices(kwargs):
         state = devices[str(dev_id)]['state']['on']
         _set(dev_id, state and Const.LAMP_OFF or Const.LAMP_ON)
         if pause:
@@ -291,7 +290,7 @@ def call_alert(*args, **kwargs):
     res = dict()
 
     devices = _get_lights()
-    for dev_id in ('id' not in kwargs and sorted(devices.keys()) or _get_devices(kwargs)):
+    for dev_id in 'id' not in kwargs and sorted(devices.keys()) or _get_devices(kwargs):
         res[dev_id] = _set(dev_id, {"alert": kwargs.get("on", True) and "lselect" or "none"})
 
     return res
@@ -317,7 +316,7 @@ def call_effect(*args, **kwargs):
     res = dict()
 
     devices = _get_lights()
-    for dev_id in ('id' not in kwargs and sorted(devices.keys()) or _get_devices(kwargs)):
+    for dev_id in 'id' not in kwargs and sorted(devices.keys()) or _get_devices(kwargs):
         res[dev_id] = _set(dev_id, {"effect": kwargs.get("type", "none")})
 
     return res
@@ -369,7 +368,7 @@ def call_color(*args, **kwargs):
         if len(color) == 2:
             try:
                 color = {"xy": [float(color[0]), float(color[1])]}
-            except Exception, ex:
+            except Exception as ex:
                 color = None
         else:
             color = None
@@ -378,7 +377,7 @@ def call_color(*args, **kwargs):
         color = colormap.get(kwargs.get("color", 'white'), Const.COLOR_WHITE)
     color.update({"transitiontime": max(min(kwargs.get("transition", 0), 200), 0)})
 
-    for dev_id in ('id' not in kwargs and sorted(devices.keys()) or _get_devices(kwargs)):
+    for dev_id in 'id' not in kwargs and sorted(devices.keys()) or _get_devices(kwargs):
         res[dev_id] = _set(dev_id, color)
 
     return res
@@ -412,16 +411,16 @@ def call_brightness(*args, **kwargs):
 
     try:
         brightness = max(min(int(kwargs['value']), 244), 1)
-    except Exception, err:
+    except Exception as err:
         raise CommandExecutionError("Parameter 'value' does not contains an integer")
 
     try:
         transition = max(min(int(kwargs['transition']), 200), 0)
-    except Exception, err:
+    except Exception as err:
         transition = 0
 
     devices = _get_lights()
-    for dev_id in ('id' not in kwargs and sorted(devices.keys()) or _get_devices(kwargs)):
+    for dev_id in 'id' not in kwargs and sorted(devices.keys()) or _get_devices(kwargs):
         res[dev_id] = _set(dev_id, {"bri": brightness, "transitiontime": transition})
 
     return res
@@ -453,11 +452,11 @@ def call_temperature(*args, **kwargs):
         raise CommandExecutionError("Parameter 'value' (150~500) is missing")
     try:
         value = max(min(int(kwargs['value']), 500), 150)
-    except Exception, err:
+    except Exception as err:
         raise CommandExecutionError("Parameter 'value' does not contains an integer")
 
     devices = _get_lights()
-    for dev_id in ('id' not in kwargs and sorted(devices.keys()) or _get_devices(kwargs)):
+    for dev_id in 'id' not in kwargs and sorted(devices.keys()) or _get_devices(kwargs):
         res[dev_id] = _set(dev_id, {"ct": value})
 
     return res

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -30,7 +30,6 @@ from salt.exceptions import (CommandExecutionError, MinionError)
 
 __proxyenabled__ = ['philips_hue']
 
-GRAINS_CACHE = {}
 CONFIG = {}
 log = logging.getLogger(__file__)
 
@@ -74,24 +73,6 @@ def init(cnf):
         raise MinionError(message="Cannot find 'user' parameter in the proxy configuration")
 
     CONFIG['url'] = "http://{0}/api/{1}".format(host, user)
-
-
-def grains():
-    '''
-    Get the grains from the proxied device
-    '''
-    return grains_refresh()
-
-
-def grains_refresh():
-    '''
-    Refresh the grains from the proxied device
-    '''
-    if not GRAINS_CACHE:
-        GRAINS_CACHE['vendor'] = 'Philips'
-        GRAINS_CACHE['product'] = 'Hue Lamps'
-        
-    return GRAINS_CACHE
 
 
 def ping(*args, **kw):

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -151,21 +151,26 @@ def call_switch(*args, **kwargs):
     Options:
 
     * **id**: Specifies a device ID. Can be a comma-separated values. All, if omitted.
-    * **on**: True or False
+    * **on**: True or False. Inverted current, if omitted
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' hue.switch id=1 on=True
+        salt '*' hue.switch
+        salt '*' hue.switch id=1
         salt '*' hue.switch id=1,2,3 on=True
     '''
-    if 'on' not in kwargs:
-        raise CommandExecutionError("Parameter 'on' is missing and should be True or False")
-
     out = dict()
-    for dev_id in ('id' not in kwargs and call_lights().keys() or _get_devices(kwargs)):
-        out[dev_id] = _set(dev_id, kwargs['on'] and Const.LAMP_ON or Const.LAMP_OFF)
+    devices = call_lights()
+    print devices
+    for dev_id in ('id' not in kwargs and devices.keys() or _get_devices(kwargs)):
+        if 'on' in kwargs:
+            state = kwargs['on'] and Const.LAMP_ON or Const.LAMP_OFF
+        else:
+            # Invert the current state
+            state = devices[str(dev_id)]['state']['on'] and Const.LAMP_OFF or Const.LAMP_ON
+        out[dev_id] = _set(dev_id, state)
 
     return out
 

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -181,13 +181,17 @@ def call_ping(*args, **kwargs):
 
 def call_status(*args, **kwargs):
     '''
-    Return lamps status.
+    Return the status of the lamps.
     '''
-    return {
-        1: True,
-        2: True,
-        3: False,
+    res = dict()
+    devices = call_lights()
+    for dev_id in devices:
+        res[dev_id] = {
+            'on': devices[dev_id]['state']['on'],
+            'reachable': devices[dev_id]['state']['reachable']
         }
+
+    return res
 
 
 def call_alert(*args, **kwargs):

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -118,6 +118,7 @@ def _set(lamp_id, state):
 
     return res
 
+
 def _get_devices(params):
     '''
     Parse device(s) ID(s) from the common params.

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -235,8 +235,8 @@ def call_status(*args, **kwargs):
     Return the status of the lamps.
     '''
     res = dict()
-    devices = _get_devices()
-    for dev_id in devices:
+    devices = _get_lights()
+    for dev_id in 'id' not in kwargs and sorted(devices.keys()) or _get_devices(kwargs):
         res[dev_id] = {
             'on': devices[dev_id]['state']['on'],
             'reachable': devices[dev_id]['state']['reachable']

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -148,12 +148,9 @@ def call_switch(*args, **kwargs):
     If no particular state is passed,
     then lamp will be switched to the opposite state.
 
-    Required parameters:
-
-    * **id**: Specifies a device ID. Can be a comma-separated values.
-
     Options:
 
+    * **id**: Specifies a device ID. Can be a comma-separated values. All, if omitted.
     * **on**: True or False
 
     CLI Example:
@@ -167,7 +164,7 @@ def call_switch(*args, **kwargs):
         raise CommandExecutionError("Parameter 'on' is missing and should be True or False")
 
     out = dict()
-    for dev_id in _get_devices(kwargs):
+    for dev_id in ('id' not in kwargs and call_lights().keys() or _get_devices(kwargs)):
         out[dev_id] = _set(dev_id, kwargs['on'] and Const.LAMP_ON or Const.LAMP_OFF)
 
     return out

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -103,6 +103,13 @@ def _get_devices(params):
 
 
 # Callers
+def call_lights(*args, **kwargs):
+    '''
+    Get info about available lamps.
+    '''
+    return json.loads(requests.get(CONFIG['url'] + "/lights").content)
+
+
 def call_ping(*args, **kwargs):
     '''
     Ping the lamps

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -445,3 +445,39 @@ def call_brightness(*args, **kwargs):
         res[dev_id] = _set(dev_id, {"bri": brightness, "transitiontime": transition})
 
     return res
+
+
+def call_temperature(*args, **kwargs):
+    '''
+    Set the mired color temperature. More: http://en.wikipedia.org/wiki/Mired
+
+    Arguments:
+
+    * **value**: 150~500.
+
+    Options:
+
+    * **id**: Specifies a device ID. Can be comma-separated ids or all, if omitted.
+
+    CLE Example:
+
+    .. code-block:: bash
+
+        salt '*' hue.temperature value=150
+        salt '*' hue.temperature value=150 id=1
+        salt '*' hue.temperature value=150 id=1,2,3
+    '''
+    res = dict()
+
+    if 'value' not in kwargs:
+        raise CommandExecutionError("Parameter 'value' (150~500) is missing")
+    try:
+        value = max(min(int(kwargs['value']), 500), 150)
+    except Exception, err:
+        raise CommandExecutionError("Parameter 'value' does not contains an integer")
+
+    devices = _get_lights()
+    for dev_id in ('id' not in kwargs and sorted(devices.keys()) or _get_devices(kwargs)):
+        res[dev_id] = _set(dev_id, {"ct": value})
+
+    return res

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -99,7 +99,7 @@ def shutdown(opts, *args, **kw):
     return True
 
 
-def _set(lamp_id, state):
+def _set(lamp_id, state, method="state"):
     '''
     Set state to the device by ID.
 
@@ -107,8 +107,8 @@ def _set(lamp_id, state):
     :param state:
     :return:
     '''
-    res = json.loads(requests.put(CONFIG['url']+"/lights/"
-                                   + str(lamp_id) + "/state", json=state).content)
+    url = "{0}/lights/{1}".format(CONFIG['url'], lamp_id) + (method and "/{0}".format(method) or '')
+    res = json.loads(requests.put(url, json=state).content)
     res = len(res) > 1 and res[-1] or res[0]
     if res.get('success'):
         res = {'result': True}

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -274,10 +274,25 @@ def call_rename(*args, **kwargs):
 
 def call_alert(*args, **kwargs):
     '''
-    Blink the alert.
+    Lamp alert
+
+    Options:
+
+    * **id**: Specifies a device ID. Can be comma-separated ids or all, if omitted.
+    * **on**: Turns on or off an alert. Default is True.
+
+    CLE Example:
+
+    .. code-block:: bash
+
+        salt '*' hue.alert
+        salt '*' hue.alert id=1
+        salt '*' hue.alert id=1,2,3 on=false
     '''
-    return {
-        1: 'Alerted',
-        2: 'Alerted',
-        3: 'Skipped',
-    }
+    res = dict()
+
+    devices = _get_lights()
+    for dev_id in ('id' not in kwargs and sorted(devices.keys()) or _get_devices(kwargs)):
+        res[dev_id] = _set(dev_id, {"alert": kwargs.get("on", True) and "lselect" or "none"})
+
+    return res

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -342,8 +342,14 @@ def call_color(*args, **kwargs):
     Options:
 
     * **id**: Specifies a device ID. Can be comma-separated ids or all, if omitted.
-    * **color**: Fixed color. Values are: red, green, blue, orange, pink, white. Default white.
+    * **color**: Fixed color. Values are: red, green, blue, orange, pink, white,
+                 yellow, daylight, purple. Default white.
     * **transition**: Transition 0~200.
+
+    Advanced:
+
+    * **gamut**: XY coordinates. Use gamut according to the Philips HUE devices documentation.
+                 More: http://www.developers.meethue.com/documentation/hue-xy-values
 
     CLE Example:
 

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -14,6 +14,14 @@ GRAINS_CACHE = {}
 log = logging.getLogger(__file__)
 
 
+class Const:
+    '''
+    Constants for the lamp operations.
+    '''
+    LAMP_ON = {"on": True, "transitiontime": 0}
+    LAMP_OFF = {"on": False, "transitiontime": 0}
+
+
 def __virtual__():
     '''
     Validate the module.

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -178,7 +178,7 @@ def call_ping(*args, **kwargs):
     '''
     Ping the lamps
     '''
-    ping(*args, **kw)
+    call_blink(*args, **kwargs)
 
 
 def call_status(*args, **kwargs):

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -129,7 +129,8 @@ def _get_devices(params):
     if 'id' not in params:
         raise CommandExecutionError("Parameter ID is required.")
 
-    return [int(dev) for dev in params['id'].split(",")]
+    return type(params['id']) == int and [params['id']] \
+           or [int(dev) for dev in params['id'].split(",")]
 
 
 # Callers

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -193,20 +193,27 @@ def call_blink(*args, **kwargs):
     '''
     devices = call_lights()
     pause = kwargs.get('pause', 0)
+    res = dict()
     for dev_id in ('id' not in kwargs and sorted(devices.keys()) or _get_devices(kwargs)):
         state = devices[str(dev_id)]['state']['on']
         _set(dev_id, state and Const.LAMP_OFF or Const.LAMP_ON)
         if pause:
             time.sleep(pause)
-        _set(dev_id, not state and Const.LAMP_OFF or Const.LAMP_ON)
+        res[dev_id] = _set(dev_id, not state and Const.LAMP_OFF or Const.LAMP_ON)
+
+    return res
 
 
 def call_ping(*args, **kwargs):
     '''
     Ping the lamps
     '''
-    call_blink(*args, **kwargs)
+    errors = dict()
+    for dev_id, dev_status in call_blink().items():
+        if not dev_status['result']:
+            errors[dev_id] = False
 
+    return errors or True
 
 def call_status(*args, **kwargs):
     '''

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -145,7 +145,19 @@ def _get_lights():
 # Callers
 def call_lights(*args, **kwargs):
     '''
-    Get info about available lamps.
+    Get info about all available lamps.
+
+    Options:
+
+    * **id**: Specifies a device ID. Can be a comma-separated values. All, if omitted.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' hue.lights
+        salt '*' hue.lights id=1
+        salt '*' hue.lights id=1,2,3
     '''
     res = dict()
     lights = _get_lights()
@@ -198,7 +210,7 @@ def call_blink(*args, **kwargs):
     * **id**: Specifies a device ID. Can be a comma-separated values. All, if omitted.
     * **pause**: Time in seconds. Can be less than 1, i.e. 0.7, 0.5 sec.
 
-    CLE Example:
+    CLI Example:
 
     .. code-block:: bash
 
@@ -220,7 +232,13 @@ def call_blink(*args, **kwargs):
 
 def call_ping(*args, **kwargs):
     '''
-    Ping the lamps
+    Ping the lamps by issuing a short inversion blink to all available devices.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' hue.ping
     '''
     errors = dict()
     for dev_id, dev_status in call_blink().items():
@@ -233,6 +251,18 @@ def call_ping(*args, **kwargs):
 def call_status(*args, **kwargs):
     '''
     Return the status of the lamps.
+
+    Options:
+
+    * **id**: Specifies a device ID. Can be a comma-separated values. All, if omitted.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' hue.status
+        salt '*' hue.status id=1
+        salt '*' hue.status id=1,2,3
     '''
     res = dict()
     devices = _get_lights()
@@ -254,7 +284,7 @@ def call_rename(*args, **kwargs):
     * **id**: Specifies a device ID. Only one device at a time.
     * **title**: Title of the device.
 
-    CLE Example:
+    CLI Example:
 
     .. code-block:: bash
 
@@ -276,10 +306,10 @@ def call_alert(*args, **kwargs):
 
     Options:
 
-    * **id**: Specifies a device ID. Can be comma-separated ids or all, if omitted.
+    * **id**: Specifies a device ID. Can be a comma-separated values. All, if omitted.
     * **on**: Turns on or off an alert. Default is True.
 
-    CLE Example:
+    CLI Example:
 
     .. code-block:: bash
 
@@ -302,10 +332,10 @@ def call_effect(*args, **kwargs):
 
     Options:
 
-    * **id**: Specifies a device ID. Can be comma-separated ids or all, if omitted.
+    * **id**: Specifies a device ID. Can be a comma-separated values. All, if omitted.
     * **type**: Type of the effect. Possible values are "none" or "colorloop". Default "none".
 
-    CLE Example:
+    CLI Example:
 
     .. code-block:: bash
 
@@ -328,7 +358,7 @@ def call_color(*args, **kwargs):
 
     Options:
 
-    * **id**: Specifies a device ID. Can be comma-separated ids or all, if omitted.
+    * **id**: Specifies a device ID. Can be a comma-separated values. All, if omitted.
     * **color**: Fixed color. Values are: red, green, blue, orange, pink, white,
                  yellow, daylight, purple. Default white.
     * **transition**: Transition 0~200.
@@ -338,7 +368,7 @@ def call_color(*args, **kwargs):
     * **gamut**: XY coordinates. Use gamut according to the Philips HUE devices documentation.
                  More: http://www.developers.meethue.com/documentation/hue-xy-values
 
-    CLE Example:
+    CLI Example:
 
     .. code-block:: bash
 
@@ -393,10 +423,10 @@ def call_brightness(*args, **kwargs):
 
     Options:
 
-    * **id**: Specifies a device ID. Can be comma-separated ids or all, if omitted.
+    * **id**: Specifies a device ID. Can be a comma-separated values. All, if omitted.
     * **transition**: Transition 0~200. Default 0.
 
-    CLE Example:
+    CLI Example:
 
     .. code-block:: bash
 
@@ -436,9 +466,9 @@ def call_temperature(*args, **kwargs):
 
     Options:
 
-    * **id**: Specifies a device ID. Can be comma-separated ids or all, if omitted.
+    * **id**: Specifies a device ID. Can be a comma-separated values. All, if omitted.
 
-    CLE Example:
+    CLI Example:
 
     .. code-block:: bash
 

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -1,4 +1,19 @@
 # -*- coding: utf-8 -*-
+#
+# Copyright 2015 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 '''
 Philips HUE lamps module for proxy.
 '''

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -44,6 +44,7 @@ def grains_refresh():
         
     return GRAINS_CACHE
 
+
 def ping(*args, **kw):
     '''
     Ping the lamps.
@@ -59,6 +60,26 @@ def shutdown(opts, *args, **kw):
     # This is no-op method, which is required but makes nothing at this point.
     return True
 
+
+def _set(lamp_id, state):
+    '''
+    Set state to the device by ID.
+
+    :param lamp_id:
+    :param state:
+    :return:
+    '''
+    res = json.loads(requests.put(CONFIG['url']+"/lights/"
+                                   + str(lamp_id) + "/state", json=state).content)
+    res = len(res) > 1 and res[-1] or res[0]
+    if res.get('success'):
+        res = {'result': True}
+    elif res.get('error'):
+        res = {'result': False,
+               'description': res['error']['description'],
+               'type': res['error']['type']}
+
+    return res
 
 def _get_devices(params):
     '''

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -119,7 +119,12 @@ def _set(lamp_id, state, method="state"):
     :return:
     '''
     url = "{0}/lights/{1}".format(CONFIG['url'], lamp_id) + (method and "/{0}".format(method) or '')
-    res = json.loads(requests.put(url, json=state).content)
+    res = None
+    try:
+        res = json.loads(requests.put(url, json=state).content)
+    except Exception, err:
+        raise CommandExecutionError(err)
+
     res = len(res) > 1 and res[-1] or res[0]
     if res.get('success'):
         res = {'result': True}
@@ -151,7 +156,10 @@ def _get_lights():
 
     :return:
     '''
-    return json.loads(requests.get(CONFIG['url'] + "/lights").content)
+    try:
+        return json.loads(requests.get(CONFIG['url'] + "/lights").content)
+    except Exception, exc:
+        raise CommandExecutionError(exc)
 
 
 # Callers

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -330,9 +330,9 @@ def call_effect(*args, **kwargs):
 
     .. code-block:: bash
 
-        salt '*' hue.alert
-        salt '*' hue.alert id=1
-        salt '*' hue.alert id=1,2,3 on=false
+        salt '*' hue.effect
+        salt '*' hue.effect id=1
+        salt '*' hue.effect id=1,2,3 type=colorloop
     '''
     res = dict()
 

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 # Import python libs
 import logging
 import requests
+import time
 import json
 from salt.exceptions import (CommandExecutionError, MinionError)
 
@@ -172,6 +173,32 @@ def call_switch(*args, **kwargs):
         out[dev_id] = _set(dev_id, state)
 
     return out
+
+
+def call_blink(*args, **kwargs):
+    '''
+    Blink a lamp. If lamp is ON, then blink ON-OFF-ON, otherwise OFF-ON-OFF.
+
+    Options:
+
+    * **id**: Specifies a device ID. Can be a comma-separated values. All, if omitted.
+    * **pause**: Time in seconds. Can be less than 1, i.e. 0.7, 0.5 sec.
+
+    CLE Example:
+
+    .. code-block:: bash
+
+        salt '*' hue.blink id=1
+        salt '*' hue.blink id=1,2,3
+    '''
+    devices = call_lights()
+    pause = kwargs.get('pause', 0)
+    for dev_id in ('id' not in kwargs and sorted(devices.keys()) or _get_devices(kwargs)):
+        state = devices[str(dev_id)]['state']['on']
+        _set(dev_id, state and Const.LAMP_OFF or Const.LAMP_ON)
+        if pause:
+            time.sleep(pause)
+        _set(dev_id, not state and Const.LAMP_OFF or Const.LAMP_ON)
 
 
 def call_ping(*args, **kwargs):

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -296,3 +296,29 @@ def call_alert(*args, **kwargs):
         res[dev_id] = _set(dev_id, {"alert": kwargs.get("on", True) and "lselect" or "none"})
 
     return res
+
+
+def call_effect(*args, **kwargs):
+    '''
+    Set an effect to the lamp.
+
+    Options:
+
+    * **id**: Specifies a device ID. Can be comma-separated ids or all, if omitted.
+    * **type**: Type of the effect. Possible values are "none" or "colorloop". Default "none".
+
+    CLE Example:
+
+    .. code-block:: bash
+
+        salt '*' hue.alert
+        salt '*' hue.alert id=1
+        salt '*' hue.alert id=1,2,3 on=false
+    '''
+    res = dict()
+
+    devices = _get_lights()
+    for dev_id in ('id' not in kwargs and sorted(devices.keys()) or _get_devices(kwargs)):
+        res[dev_id] = _set(dev_id, {"effect": kwargs.get("type", "none")})
+
+    return res

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -42,6 +42,13 @@ class Const:
     LAMP_ON = {"on": True, "transitiontime": 0}
     LAMP_OFF = {"on": False, "transitiontime": 0}
 
+    COLOR_WHITE = {"sat": 0}
+    COLOR_RED = {"hue": 0, "sat": 254}
+    COLOR_GREEN = {"hue": 25500, "sat": 254}
+    COLOR_ORANGE = {"hue": 12000, "sat": 254}
+    COLOR_PINK = {"hue": 12000, "sat": 254}
+    COLOR_BLUE = {"hue": 46920, "sat": 254}
+
 
 def __virtual__():
     '''
@@ -320,5 +327,43 @@ def call_effect(*args, **kwargs):
     devices = _get_lights()
     for dev_id in ('id' not in kwargs and sorted(devices.keys()) or _get_devices(kwargs)):
         res[dev_id] = _set(dev_id, {"effect": kwargs.get("type", "none")})
+
+    return res
+
+
+def call_color(*args, **kwargs):
+    '''
+    Set a color to the lamp.
+
+    Options:
+
+    * **id**: Specifies a device ID. Can be comma-separated ids or all, if omitted.
+    * **color**: Fixed color. Values are: red, green, blue, orange, pink, white. Default white.
+    * **transition**: Transition 0~200.
+
+    CLE Example:
+
+    .. code-block:: bash
+
+        salt '*' hue.color
+        salt '*' hue.color id=1
+        salt '*' hue.color id=1,2,3 oolor=red transition=30
+    '''
+    res = dict()
+
+    colormap = {
+        'red': Const.COLOR_RED,
+        'green': Const.COLOR_GREEN,
+        'blue': Const.COLOR_BLUE,
+        'orange': Const.COLOR_ORANGE,
+        'pink': Const.COLOR_PINK,
+        'white': Const.COLOR_WHITE,
+    }
+
+    devices = _get_lights()
+    for dev_id in ('id' not in kwargs and sorted(devices.keys()) or _get_devices(kwargs)):
+        color = colormap.get(kwargs.get("color", 'white'), Const.COLOR_WHITE)
+        color.update({"transitiontime": max(min(kwargs.get("transition", 0), 200), 0)})
+        res[dev_id] = _set(dev_id, color)
 
     return res

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -165,7 +165,7 @@ def call_status(*args, **kwargs):
         }
 
 
-def call_alert(*args, **kw):
+def call_alert(*args, **kwargs):
     '''
     Blink the alert.
     '''

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -402,3 +402,46 @@ def call_color(*args, **kwargs):
         res[dev_id] = _set(dev_id, color)
 
     return res
+
+
+def call_brightness(*args, **kwargs):
+    '''
+    Set an effect to the lamp.
+
+    Arguments:
+
+    * **value**: 0~255 brightness of the lamp.
+
+    Options:
+
+    * **id**: Specifies a device ID. Can be comma-separated ids or all, if omitted.
+    * **transition**: Transition 0~200. Default 0.
+
+    CLE Example:
+
+    .. code-block:: bash
+
+        salt '*' hue.brightness value=100
+        salt '*' hue.brightness id=1 value=150
+        salt '*' hue.brightness id=1,2,3 value=255
+    '''
+    res = dict()
+
+    if 'value' not in kwargs:
+        raise CommandExecutionError("Parameter 'value' is missing")
+
+    try:
+        brightness = max(min(int(kwargs['value']), 244), 1)
+    except Exception, err:
+        raise CommandExecutionError("Parameter 'value' does not contains an integer")
+
+    try:
+        transition = max(min(int(kwargs['transition']), 200), 0)
+    except Exception, err:
+        transition = 0
+
+    devices = _get_lights()
+    for dev_id in ('id' not in kwargs and sorted(devices.keys()) or _get_devices(kwargs)):
+        res[dev_id] = _set(dev_id, {"bri": brightness, "transitiontime": transition})
+
+    return res

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -169,10 +169,9 @@ def call_lights(*args, **kwargs):
     '''
     res = dict()
     lights = _get_lights()
-    if 'id' in kwargs:
-        for dev_id in _get_devices(kwargs):
-            if lights.get(str(dev_id)):
-                res[dev_id] = lights[str(dev_id)]
+    for dev_id in ('id' in kwargs and _get_devices(kwargs) or sorted(lights.keys())):
+        if lights.get(str(dev_id)):
+            res[dev_id] = lights[str(dev_id)]
 
     return res or False
 

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -163,7 +163,7 @@ def call_switch(*args, **kwargs):
     '''
     out = dict()
     devices = call_lights()
-    for dev_id in ('id' not in kwargs and devices.keys() or _get_devices(kwargs)):
+    for dev_id in ('id' not in kwargs and sorted(devices.keys()) or _get_devices(kwargs)):
         if 'on' in kwargs:
             state = kwargs['on'] and Const.LAMP_ON or Const.LAMP_OFF
         else:

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -230,6 +230,31 @@ def call_status(*args, **kwargs):
     return res
 
 
+def call_rename(*args, **kwargs):
+    '''
+    Rename a device.
+
+    Options:
+
+    * **id**: Specifies a device ID. Only one device at a time.
+    * **title**: Title of the device.
+
+    CLE Example:
+
+    .. code-block:: bash
+
+        salt '*' hue.rename id=1 title='WC for cats'
+    '''
+    dev_id = _get_devices(kwargs)
+    if len(dev_id) > 1:
+        raise CommandExecutionError("Only one device can be renamed at a time")
+
+    if 'title' not in kwargs:
+        raise CommandExecutionError("Title is missing")
+
+    return _set(dev_id[0], {"name": kwargs['title']}, method="")
+
+
 def call_alert(*args, **kwargs):
     '''
     Blink the alert.

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import
 import logging
 import requests
 import json
-from salt.exceptions import CommandExecutionError
+from salt.exceptions import (CommandExecutionError, MinionError)
 
 
 __proxyenabled__ = ['philips_hue']
@@ -34,10 +34,19 @@ def __virtual__():
     return True
 
 
-def init(opts):
+def init(cnf):
     '''
     Initialize the module.
     '''
+    host = cnf.get('proxy', {}).get('host')
+    if not host:
+        raise MinionError(message="Cannot find 'host' parameter in the proxy configuration")
+
+    user = cnf.get('proxy', {}).get('user')
+    if not user:
+        raise MinionError(message="Cannot find 'user' parameter in the proxy configuration")
+
+    CONFIG['url'] = "http://{0}/api/{1}".format(host, user)
 
 
 def grains():

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -60,6 +60,19 @@ def shutdown(opts, *args, **kw):
     return True
 
 
+def _get_devices(params):
+    '''
+    Parse device(s) ID(s) from the common params.
+
+    :param params:
+    :return:
+    '''
+    if 'id' not in params:
+        raise CommandExecutionError("Parameter ID is required.")
+
+    return [int(dev) for dev in params['id'].split(",")]
+
+
 # Callers
 def call_ping(*args, **kwargs):
     '''
@@ -79,7 +92,7 @@ def call_status(*args, **kwargs):
         }
 
 
-def call_alert(*args, **kwargs):
+def call_alert(*args, **kw):
     '''
     Blink the alert.
     '''

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -7,12 +7,10 @@ from __future__ import absolute_import
 
 # Import python libs
 import logging
-import salt.utils.http
 
 __proxyenabled__ = ['philips_hue']
 
 GRAINS_CACHE = {}
-DETAILS = {}
 log = logging.getLogger(__file__)
 
 
@@ -63,14 +61,14 @@ def shutdown(opts, *args, **kw):
 
 
 # Callers
-def call_ping(*args, **kw):
+def call_ping(*args, **kwargs):
     '''
     Ping the lamps
     '''
     ping(*args, **kw)
 
 
-def call_status(*args, **kw):
+def call_status(*args, **kwargs):
     '''
     Return lamps status.
     '''
@@ -81,7 +79,7 @@ def call_status(*args, **kw):
         }
 
 
-def call_alert(*args, **kw):
+def call_alert(*args, **kwargs):
     '''
     Blink the alert.
     '''

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+'''
+Philips HUE lamps module for proxy.
+'''
+
+from __future__ import absolute_import
+
+# Import python libs
+import logging
+import salt.utils.http
+
+__proxyenabled__ = ['philips_hue']
+
+GRAINS_CACHE = {}
+DETAILS = {}
+log = logging.getLogger(__file__)
+
+
+def __virtual__():
+    '''
+    Validate the module.
+    '''
+    return True
+
+
+def init(opts):
+    '''
+    Initialize the module.
+    '''
+
+
+def grains():
+    '''
+    Get the grains from the proxied device
+    '''
+    return grains_refresh()
+
+
+def grains_refresh():
+    '''
+    Refresh the grains from the proxied device
+    '''
+    if not GRAINS_CACHE:
+        GRAINS_CACHE['vendor'] = 'Philips'
+        GRAINS_CACHE['product'] = 'Hue Lamps'
+        
+    return GRAINS_CACHE
+
+def ping(*args, **kw):
+    '''
+    Ping the lamps.
+    '''
+    # Here blink them
+    return True
+
+
+def shutdown(opts, *args, **kw):
+    '''
+    Shuts down the service.
+    '''
+    # This is no-op method, which is required but makes nothing at this point.
+    return True
+
+
+# Callers
+def call_ping(*args, **kw):
+    '''
+    Ping the lamps
+    '''
+    ping(*args, **kw)
+
+
+def call_status(*args, **kw):
+    '''
+    Return lamps status.
+    '''
+    return {
+        1: True,
+        2: True,
+        3: False,
+        }
+
+
+def call_alert(*args, **kw):
+    '''
+    Blink the alert.
+    '''
+    return {
+        1: 'Alerted',
+        2: 'Alerted',
+        3: 'Skipped',
+    }

--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -22,7 +22,14 @@ from __future__ import absolute_import
 
 # Import python libs
 import logging
-import requests
+
+# INFO: This is going to be removed anytime soon in favor of salt.utils.http
+#       But it needs a separate PR!
+try:
+    import requests
+except ImportError as err:
+    requests = None
+
 import time
 import json
 from salt.exceptions import (CommandExecutionError, MinionError)
@@ -56,7 +63,7 @@ def __virtual__():
     '''
     Validate the module.
     '''
-    return True
+    return requests is not None
 
 
 def init(cnf):


### PR DESCRIPTION
During our [SUSECon 2015](http://www.susecon.com/) in Amsterdam this November, we will be performing various SaltStack and SUSE Manager demonstrations. One of those demos will be controlling a set of [Philips HUE lamps](http://www2.meethue.com/).

This is a _really_ working Proxy Minion. :wink: 

Setup in pillars:

```
top.sls

base:
  'philips':
    - philips


philips.sls

proxy:
  proxytype: philips_hue
  host: [hostname or IP address]
  user: [username]
```

Example usage:

To see all information about available lamps:

```
salt philips hue.lights
```

To switch (toggle) their status (those ON goes OFF and vice versa):

```
salt philips hue.switch
```

Or bring specific lamp to a specific status:

```
salt philips hue.switch id=1 on=true
```

It supports color setting (presets colors or your own custom, gamut/XY based), alerting, color wheel effect, configurable blinking, lamp naming/renaming, brightness and temperature. Now you can make your NOC room glowing red and blinking, when your servers goes down. :wink: 
