### PR TITLE
Provide all git pillar dirs in `opts[pillar_roots]`

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -251,7 +251,7 @@ def ext_pillar(minion_id, repo, pillar_dirs):
             'smart'
         )
         for pillar_dir, env in six.iteritems(pillar.pillar_dirs):
-            opts['pillar_roots'] = {env: [pillar_dir]}
+            opts['pillar_roots'] = {env: [d for (d, e) in six.iteritems(pillar.pillar_dirs) if env == e]}
             local_pillar = Pillar(opts, __grains__, minion_id, env)
             ret = salt.utils.dictupdate.merge(
                 ret,


### PR DESCRIPTION
Do not only provide the `pillar_roots` directory of the currently
evaluated pillar SLS.
This makes it impossible to use `include` for pillar SLS located in
another git repository.

Fixes #27932
