### PR TITLE
fixing git fetch problem with None in command

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -1394,7 +1394,7 @@ def fetch(cwd,
     command.extend(
         [x for x in _format_opts(opts) if x not in ('-f', '--force')]
     )
-    if not isinstance(remote, six.string_types):
+    if remote and not isinstance(remote, six.string_types):
         remote = str(remote)
     if remote:
         command.append(remote)


### PR DESCRIPTION
If result is None is converted to string with value 'None' and added to command list.

Log from minion:
Module function git.fetch threw an exception. Exception: fatal: 'None' does not appear to be a git repository
