### PR TITLE
Bugfix for highstate return data handler.

### DIFF
--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -116,6 +116,7 @@ def _format_host(host, data):
                           .format(hcolor, err, colors)))
     if isinstance(data, dict):
         # Verify that the needed data is present
+        data_tmp = {}
         for tname, info in six.iteritems(data):
             if isinstance(info, dict) and '__run_num__' not in info:
                 err = (u'The State execution failed to record the order '
@@ -123,6 +124,9 @@ def _format_host(host, data):
                        'return missing data is:')
                 hstrs.insert(0, pprint.pformat(info))
                 hstrs.insert(0, err)
+            if isinstance(info, dict) and 'result' in info:
+                data_tmp[tname] = info
+        data = data_tmp
         # Everything rendered as it should display the output
         for tname in sorted(
                 data,


### PR DESCRIPTION
If highstate dict contatins mix of key to dict and key to any other
object outputter throws error.

This happens in the case described in #23373 return from the minion looks like the following:
`[INFO    ] {'ret': {'alpha': {'args': [], 'kwargs': {'__pub_user': 'dimm', '__pub_arg': [], '__pub_fun': 'test.arg', '__pub_jid': '20151014130645342887', '__pub_tgt': 'alpha', '__pub_tgt_type': 'glob', '__pub_ret': {}}}}, 'out': 'highstate'}`
And highstate outputter error is:

```
[DEBUG   ] Traceback (most recent call last):
  File "/home/dimm/projects/salt/git/salt/salt/output/__init__.py", line 39, in try_printout
    return get_printout(out, opts)(data).rstrip()
  File "/home/dimm/projects/salt/git/salt/salt/output/highstate.py", line 85, in output
    return _format_host(host, hostdata)[0]
  File "/home/dimm/projects/salt/git/salt/salt/output/highstate.py", line 137, in _format_host
    schanged, ctext = _format_changes(ret['changes'])
  File "/home/dimm/projects/salt/git/salt/salt/output/highstate.py", line 406, in _format_changes
    s, c = _format_host(host, hostdata)
  File "/home/dimm/projects/salt/git/salt/salt/output/highstate.py", line 129, in _format_host
    key=lambda k: data[k].get('__run_num__', 0)):
  File "/home/dimm/projects/salt/git/salt/salt/output/highstate.py", line 129, in <lambda>
    key=lambda k: data[k].get('__run_num__', 0)):
AttributeError: 'list' object has no attribute 'get'
```
