### PR TITLE
Transport leak [RFC]

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1291,7 +1291,12 @@ class Minion(MinionBase):
                 os.makedirs(jdir)
             salt.utils.fopen(fn_, 'w+b').write(self.serial.dumps(ret))
         try:
+            import gc
+            gc.set_debug(gc.DEBUG_COLLECTABLE | gc.DEBUG_UNCOLLECTABLE | gc.DEBUG_OBJECTS)
             ret_val = channel.send(load, timeout=timeout)
+            gc.collect()
+            print(gc.garbage)
+            print('\n\n')
         except SaltReqTimeoutError:
             msg = ('The minion failed to return the job information for job '
                    '{0}. This is often due to the master being shut down or '

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1291,12 +1291,7 @@ class Minion(MinionBase):
                 os.makedirs(jdir)
             salt.utils.fopen(fn_, 'w+b').write(self.serial.dumps(ret))
         try:
-            import gc
-            gc.set_debug(gc.DEBUG_COLLECTABLE | gc.DEBUG_UNCOLLECTABLE | gc.DEBUG_OBJECTS)
             ret_val = channel.send(load, timeout=timeout)
-            gc.collect()
-            print(gc.garbage)
-            print('\n\n')
         except SaltReqTimeoutError:
             msg = ('The minion failed to return the job information for job '
                    '{0}. This is often due to the master being shut down or '

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -736,9 +736,6 @@ class AsyncReqMessageClient(object):
             self.socket.close()
         self.context.term()
 
-#    def __del__(self):
-#        self.destroy()
-
     def _init_socket(self):
         if hasattr(self, 'stream'):
             self.stream.close()  # pylint: disable=E0203

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -320,6 +320,7 @@ class AsyncZeroMQPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.t
             self._stream.socket.close(0)
         if hasattr(self, 'context'):
             self.context.term()
+        self.message_client.destory()
 
     def __del__(self):
         self.destroy()
@@ -735,8 +736,8 @@ class AsyncReqMessageClient(object):
             self.socket.close()
         self.context.term()
 
-    def __del__(self):
-        self.destroy()
+#    def __del__(self):
+#        self.destroy()
 
     def _init_socket(self):
         if hasattr(self, 'stream'):
@@ -808,6 +809,7 @@ class AsyncReqMessageClient(object):
                 self._init_socket()  # re-init the zmq socket (no other way in zmq)
                 continue
             self.remove_message_timeout(message)
+            self.send_future_map.pop(message)
 
     def remove_message_timeout(self, message):
         if message not in self.send_timeout_map:


### PR DESCRIPTION
This corrects a serious memory leak in the salt-minion, whereby memory is leaked on every return.

To illustrate the issue:

``` python
#!/usr/bin/python2

import salt.config
import salt.minion

from pympler import tracker, asizeof, refbrowser

tracker = tracker.SummaryTracker()

opts = salt.config.minion_config('/etc/salt/minion')
opts['master_uri'] = 'tcp://localhost:4506'
minion = salt.minion.Minion(opts)

for x in range(0, 100):
    minion._return_pub({'ret': True})
    tracker.print_diff()
    print(asizeof.asizeof(minion))
```

One will see that memory is clearly being allocated which is not released. The same results can be observed by tracking the memory usage of a running minion as returns are sent to the master.

This patch addresses the problem in two ways.

First, it removes the future from the future map after it's been successfully sent. This is likely a minor problem and does not appear to be the main cause of the leak, in my testing.

Of more concern is the second fix, which removes the `__del__` and instead requires that the consumer of the class do cleanup manually by calling the `destroy()` method. The reason appears to be that having the two `__del__` has created a reference cycle in which the Python garbage collector does not know in which order to clean up the instances which are bound to each other. While this does mean that `destroy()` will need to be called manually for consumers of the internal sending class in the ZMQ transport, this shouldn't much of an issue since it really isn't "public facing", per-se. :]

@jacksontj Would you mind having a look and telling me what you think before we merge this? You have have had a good reason for not cleaning up the future map, because I found that curious so I'd like very much to get your feedback. Thanks!
