### PR TITLE
Boto ec2 enis unbound var

### DIFF
--- a/salt/modules/boto_ec2.py
+++ b/salt/modules/boto_ec2.py
@@ -996,7 +996,6 @@ def get_network_interface_id(name, region=None, key=None, keyid=None,
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     r = {}
-    enis = None
     try:
         enis = conn.get_all_network_interfaces(filters={'tag:Name': name})
         if not enis:
@@ -1039,7 +1038,6 @@ def get_network_interface(name=None, network_interface_id=None, region=None,
 
 def _get_network_interface(conn, name=None, network_interface_id=None):
     r = {}
-    enis = None
     if not (name or network_interface_id):
         raise SaltInvocationError(
             'Either name or network_interface_id must be provided.'

--- a/salt/modules/boto_ec2.py
+++ b/salt/modules/boto_ec2.py
@@ -996,6 +996,7 @@ def get_network_interface_id(name, region=None, key=None, keyid=None,
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     r = {}
+    enis = None
     try:
         enis = conn.get_all_network_interfaces(filters={'tag:Name': name})
     except boto.exception.EC2ResponseError as e:
@@ -1039,6 +1040,7 @@ def get_network_interface(name=None, network_interface_id=None, region=None,
 
 def _get_network_interface(conn, name=None, network_interface_id=None):
     r = {}
+    enis = None
     if not (name or network_interface_id):
         raise SaltInvocationError(
             'Either name or network_interface_id must be provided.'

--- a/salt/modules/boto_ec2.py
+++ b/salt/modules/boto_ec2.py
@@ -999,16 +999,15 @@ def get_network_interface_id(name, region=None, key=None, keyid=None,
     enis = None
     try:
         enis = conn.get_all_network_interfaces(filters={'tag:Name': name})
+        if not enis:
+            r['error'] = {'message': 'No ENIs found.'}
+        elif len(enis) > 1:
+            r['error'] = {'message': 'Name specified is tagged on multiple ENIs.'}
+        else:
+            eni = enis[0]
+            r['result'] = eni.id
     except boto.exception.EC2ResponseError as e:
         r['error'] = __utils__['boto.get_error'](e)
-    if not enis:
-        r['error'] = {'message': 'No ENIs found.'}
-    elif len(enis) > 1:
-        r['error'] = {'message': 'Name specified is tagged on multiple ENIs.'}
-    if 'error' in r:
-        return r
-    eni = enis[0]
-    r['result'] = eni.id
     return r
 
 
@@ -1050,16 +1049,16 @@ def _get_network_interface(conn, name=None, network_interface_id=None):
             enis = conn.get_all_network_interfaces([network_interface_id])
         else:
             enis = conn.get_all_network_interfaces(filters={'tag:Name': name})
+
+        if not enis:
+            r['error'] = {'message': 'No ENIs found.'}
+        elif len(enis) > 1:
+            r['error'] = {'message': 'Name specified is tagged on multiple ENIs.'}
+        else:
+            eni = enis[0]
+            r['result'] = eni
     except boto.exception.EC2ResponseError as e:
         r['error'] = __utils__['boto.get_error'](e)
-    if not enis:
-        r['error'] = {'message': 'No ENIs found.'}
-    elif len(enis) > 1:
-        r['error'] = {'message': 'Name specified is tagged on multiple ENIs.'}
-    if 'error' in r:
-        return r
-    eni = enis[0]
-    r['result'] = eni
     return r
 
 


### PR DESCRIPTION
If an exception occurs in the try block of _get_network_interface or get_network_interface_id (for example a user not having the DescribeNetworkInterfaces right, which caused this issue for me), enis variable will not be defined and a unbound variable exception will be thrown

If enis was defined before the try block, the exception message would be overwritten in the return object and the user would not get the exception error message returned to them, but instead a "no ENIs found" message.
