### PR TITLE
fix parse of { on next line

### DIFF
--- a/salt/modules/logrotate.py
+++ b/salt/modules/logrotate.py
@@ -41,7 +41,7 @@ def _parse_conf(conf_file=default_conf):
     '''
     ret = {}
     mode = 'single'
-    multi_name = ''
+    multi_names = []
     multi = {}
     with salt.utils.fopen(conf_file, 'r') as ifile:
         for line in ifile:
@@ -54,12 +54,17 @@ def _parse_conf(conf_file=default_conf):
             comps = line.split()
             if '{' in line and '}' not in line:
                 mode = 'multi'
-                multi_name = comps[0]
+                if len(comps) == 1:
+                    multi_names=prev_comps
+                else:
+                    multi_names=comps
+                    multi_names.pop()
                 continue
             if '}' in line:
                 mode = 'single'
-                ret[multi_name] = multi
-                multi_name = ''
+                for multi_name in multi_names:
+                    ret[multi_name] = multi
+                multi_names=[]
                 multi = {}
                 continue
 
@@ -80,6 +85,7 @@ def _parse_conf(conf_file=default_conf):
                         ret[file_key] = include_conf[file_key]
                         ret['include files'][include].append(file_key)
 
+            prev_comps=comps
             if len(comps) > 1:
                 key[comps[0]] = ' '.join(comps[1:])
             else:

--- a/salt/modules/logrotate.py
+++ b/salt/modules/logrotate.py
@@ -43,6 +43,7 @@ def _parse_conf(conf_file=default_conf):
     mode = 'single'
     multi_names = []
     multi = {}
+    prev_comps = None
     with salt.utils.fopen(conf_file, 'r') as ifile:
         for line in ifile:
             line = line.strip()
@@ -54,17 +55,17 @@ def _parse_conf(conf_file=default_conf):
             comps = line.split()
             if '{' in line and '}' not in line:
                 mode = 'multi'
-                if len(comps) == 1:
-                    multi_names=prev_comps
+                if len(comps) == 1 and prev_comps:
+                    multi_names = prev_comps
                 else:
-                    multi_names=comps
+                    multi_names = comps
                     multi_names.pop()
                 continue
             if '}' in line:
                 mode = 'single'
                 for multi_name in multi_names:
                     ret[multi_name] = multi
-                multi_names=[]
+                multi_names = []
                 multi = {}
                 continue
 
@@ -85,7 +86,7 @@ def _parse_conf(conf_file=default_conf):
                         ret[file_key] = include_conf[file_key]
                         ret['include files'][include].append(file_key)
 
-            prev_comps=comps
+            prev_comps = comps
             if len(comps) > 1:
                 key[comps[0]] = ' '.join(comps[1:])
             else:


### PR DESCRIPTION
modules/logrotate.py was not properly processing some config files.  When the { is on the next line like 

```
/var/log/messaages
{
    rotate 4
}
```

it was parsing the { as just another configuration directive.   I've fixed this by having it pull in the previous line when it sees  { on a line by itself.

While I was in there, I also had it properly parse multiple log files applying to one '{}' stanza.  Liike this:

```
/var/log/syslog /var/log/message
{
rotate 5
}
```

See the /var/log/httpd/access.log from the logrotate.conf man page for another example of this.  
One possible bug.  If you logrotate.set  one of the values in the {} stanza that's shared it will change it for both of them.  It's not clear to me if this is the desired behavior or not.  Probably not.
