### PR TITLE
Fix firewalld.get_masquerade

### DIFF
--- a/salt/modules/firewalld.py
+++ b/salt/modules/firewalld.py
@@ -403,7 +403,7 @@ def get_masquerade(zone):
     '''
     zone_info = list_all(zone)
 
-    if [zone_info[i]['masquerade'][0] for i in zone_info.keys()] == 'no':
+    if 'no' in [zone_info[i]['masquerade'][0] for i in zone_info.keys()]:
         return False
 
     return True


### PR DESCRIPTION
['no'] == 'no' is never true. It must be checked if the list contains the
string 'no'.
