### PR TITLE
Add note about dockerng.inspect_image usage

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -2134,6 +2134,11 @@ def inspect_image(name):
     Retrieves image information. Equivalent to running the ``docker inspect``
     Docker CLI command, but will only look for image information.
 
+    .. note::
+        To inspect an image, it must have been pulled from a registry or built
+        locally. Images on a Docker registry which have not been pulled cannot
+        be inspected.
+
     name
         Image name or ID
 


### PR DESCRIPTION
Should clear up apparent confusion raised in https://github.com/saltstack/salt/issues/27976
