### PR TITLE
Don't fail if pip package is already present and pip1 is installed

### DIFF
--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -677,7 +677,7 @@ def installed(name,
     # already present. Pip1 returns a retcode of 1 (instead of 0 for pip2) if you run
     # "pip install" without any arguments. See issue #21845.
     if pip_install_call and \
-            (pip_install_call.get('retcode', 1) == 0 or pip_install_call.get('stdout').startswith(
+            (pip_install_call.get('retcode', 1) == 0 or pip_install_call.get('stdout', '').startswith(
                 'You must give at least one requirement to install')):
         ret['result'] = True
 

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -673,7 +673,12 @@ def installed(name,
         use_vt=use_vt
     )
 
-    if pip_install_call and (pip_install_call.get('retcode', 1) == 0):
+    # Check the retcode for success, but don't fail if using pip1 and the package is
+    # already present. Pip1 returns a retcode of 1 (instead of 0 for pip2) if you run
+    # "pip install" without any arguments. See issue #21845.
+    if pip_install_call and \
+            (pip_install_call.get('retcode', 1) == 0 or pip_install_call.get('stdout').startswith(
+                'You must give at least one requirement to install')):
         ret['result'] = True
 
         if requirements or editable:


### PR DESCRIPTION
Refs #21845 

Checking the `stdout` here is a bit hacky, but it's the only way we can get pip1 and pip2 to play nicely together since pip changed the return code values between versions, and still support using `pkgs` in the pip state.
