### PR TITLE
Handle includes in `include_config` recursively

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -1491,7 +1491,14 @@ def include_config(include, orig_path, verbose):
 
         for fn_ in sorted(glob.glob(path)):
             log.debug('Including configuration from {0!r}'.format(fn_))
-            salt.utils.dictupdate.update(configuration, _read_conf_file(fn_))
+            opts = _read_conf_file(fn_)
+
+            include = opts.get('include', [])
+            if include:
+                opts.update(include_config(include, fn_, verbose))
+
+            salt.utils.dictupdate.update(configuration, opts)
+
     return configuration
 
 


### PR DESCRIPTION
This allows for using `include` in an included file, which was
previously ignored.
