### PR TITLE
Update chocolatey.py 'install' and 'uninstall' states renamed

### DIFF
--- a/salt/states/chocolatey.py
+++ b/salt/states/chocolatey.py
@@ -5,6 +5,9 @@ Manage Chocolatey package installs
 .. versionadded:: Boron
 '''
 
+# Import salt libs
+import salt.utils
+
 
 def __virtual__():
     '''
@@ -13,9 +16,19 @@ def __virtual__():
     return 'chocolatey' if 'chocolatey.install' in __salt__ else False
 
 
+def install(*args, **kwargs):
+    '''
+    Deprecated, please use 'installed'. This function will be removed in Salt
+    Nitrogen.
+    '''
+    salt.utils.warn_until('Nitrogen',
+                          'Please use chocolatey.installed. '
+                          'chocolatey.install will be removed in Salt Nitrogen.')
+    installed(*args, **kwargs)
+
+
 def installed(name, version=None, source=None, force=False, install_args=None,
             override_args=False, force_x86=False):
-
     '''
     Installs a package if not already installed
 
@@ -93,6 +106,17 @@ def installed(name, version=None, source=None, force=False, install_args=None,
         ret['comment'] = 'Failed to install the package {0}'.format(name)
 
     return ret
+
+
+def uninstall(*args, **kwargs):
+    '''
+    Deprecated, please use 'uninstalled'. This function will be removed in Salt
+    Nitrogen.
+    '''
+    salt.utils.warn_until('Nitrogen',
+                          'Please use chocolatey.uninstalled. '
+                          'chocolatey.uninstall will be removed in Salt Nitrogen.')
+    uninstalled(*args, **kwargs)
 
 
 def uninstalled(name, version=None, uninstall_args=None, override_args=False):

--- a/salt/states/chocolatey.py
+++ b/salt/states/chocolatey.py
@@ -13,7 +13,7 @@ def __virtual__():
     return 'chocolatey' if 'chocolatey.install' in __salt__ else False
 
 
-def install(name, version=None, source=None, force=False, install_args=None,
+def installed(name, version=None, source=None, force=False, install_args=None,
             override_args=False, force_x86=False):
 
     '''
@@ -48,7 +48,7 @@ def install(name, version=None, source=None, force=False, install_args=None,
     .. code-block:: yaml
 
         Installsomepackage:
-          chocolatey.install:
+          chocolatey.installed:
             - name: packagename
             - version: '12.04'
             - source: 'mychocolatey/source'
@@ -95,7 +95,7 @@ def install(name, version=None, source=None, force=False, install_args=None,
     return ret
 
 
-def uninstall(name, version=None, uninstall_args=None, override_args=False):
+def uninstalled(name, version=None, uninstall_args=None, override_args=False):
     '''
     Uninstalls a package
 
@@ -119,7 +119,7 @@ def uninstall(name, version=None, uninstall_args=None, override_args=False):
     .. code-block: yaml
 
       Removemypackage:
-        chocolatey.uninstall:
+        chocolatey.uninstalled:
           - name: mypackage
           - version: '21.5'
 

--- a/salt/states/chocolatey.py
+++ b/salt/states/chocolatey.py
@@ -5,6 +5,9 @@ Manage Chocolatey package installs
 .. versionadded:: Boron
 '''
 
+# Import Python libs
+from __future__ import absolute_import
+
 # Import salt libs
 import salt.utils
 


### PR DESCRIPTION
Change 'install' and 'uninstall' state names to the more state-full naming convention 'installed' and 'uninstalled'.
