### PR TITLE
Update chocolatey.py allow passing package_args

### DIFF
--- a/salt/states/chocolatey.py
+++ b/salt/states/chocolatey.py
@@ -14,7 +14,7 @@ def __virtual__():
 
 
 def install(name, version=None, source=None, force=False, install_args=None,
-            override_args=False, force_x86=False):
+            override_args=False, force_x86=False, package_args=None):
 
     '''
     Installs a package if not already installed
@@ -44,6 +44,9 @@ def install(name, version=None, source=None, force=False, install_args=None,
 
     force_x86
       Force x86 (32bit) installation on 64 bit systems. Defaults to false.
+
+    package_args
+        A list of arguments you want to pass to the package
 
     .. code-block:: yaml
 
@@ -82,7 +85,8 @@ def install(name, version=None, source=None, force=False, install_args=None,
                                                              force,
                                                              install_args,
                                                              override_args,
-                                                             force_x86)}
+                                                             force_x86,
+                                                             package_args)}
 
     if 'Running chocolatey failed' not in ret['changes']:
         ret['result'] = True


### PR DESCRIPTION
Allow passing 'package_args' to the chocolatey install state.
