### PR TITLE
Fixed win_path.py

### DIFF
--- a/salt/modules/win_path.py
+++ b/salt/modules/win_path.py
@@ -74,11 +74,7 @@ def get_path():
     '''
     ret = __salt__['reg.read_value']('HKEY_LOCAL_MACHINE',
                                    'SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
-                                   'PATH')
-    if isinstance(ret, dict):
-        ret = ret['vdata'].split(';')
-    if isinstance(ret, str):
-        ret = ret.split(';')
+                                   'PATH')['vdata'].split(';')
 
     # Trim ending backslash
     return list(map(_normalize_dir, ret))


### PR DESCRIPTION
Moved vdata and split to the same line
No need to check for string types
