### PR TITLE
Fixed win_useradd.py

### DIFF
--- a/salt/modules/win_useradd.py
+++ b/salt/modules/win_useradd.py
@@ -659,7 +659,7 @@ def info(name):
         ret['logonscript'] = items['script_path']
         ret['profile'] = items['profile']
         if not ret['profile']:
-            ret['profile'] = _get_userprofile_from_registry(name, ret['uid'])['vdata']
+            ret['profile'] = _get_userprofile_from_registry(name, ret['uid'])
         ret['home'] = items['home_dir']
         ret['homedrive'] = items['home_dir_drive']
         if not ret['home']:
@@ -679,7 +679,7 @@ def _get_userprofile_from_registry(user, sid):
         'HKEY_LOCAL_MACHINE',
         u'SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\ProfileList\\{0}'.format(sid),
         'ProfileImagePath'
-    )
+    )['vdata']
     log.debug(u'user {0} with sid={2} profile is located at "{1}"'.format(user, profile_dir, sid))
     return profile_dir
 


### PR DESCRIPTION
The real fix. Instead of getting vdata in the calling function,
_get_userprofile_from_registry should return just the profile and not a dict
full of a bunch of crap. This also fixes the debug log for the
_get_userprofile_from_registry function.
