### PR TITLE
the nova driver does not require libcloud

### DIFF
--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -174,9 +174,8 @@ def get_dependencies():
     Warn if dependencies aren't met.
     '''
     deps = {
-        'libcloud': HAS_LIBCLOUD,
         'netaddr': HAS_NETADDR,
-        'nova': HAS_NOVA,
+        'python-novaclient': HAS_NOVA,
     }
     return config.check_driver_dependencies(
         __virtualname__,


### PR DESCRIPTION
The only thing used from libcloudfuncs is the script and reboot, which
both hook through the regular connection, and are namespaced down to the
nova driver.  they use the regular conn, which hooks to the SaltNova
library in order to reboot the server.
