### PR TITLE
Purge iam user attributes before deleting iam user

### DIFF
--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -367,7 +367,8 @@ def create_group(group_name, path=None, region=None, key=None, keyid=None,
     '''
     if not path:
         path = '/'
-    if get_group(group_name, region=region, key=key, keyid=keyid, profile=profile):
+    if get_group(group_name, region=region, key=key, keyid=keyid,
+                 profile=profile):
         return True
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     try:
@@ -381,8 +382,7 @@ def create_group(group_name, path=None, region=None, key=None, keyid=None,
         return False
 
 
-def get_group(group_name, marker=None, max_items=None, region=None, key=None,
-              keyid=None, profile=None):
+def get_group(group_name, region=None, key=None, keyid=None, profile=None):
     '''
     Get group information.
 
@@ -396,13 +396,49 @@ def get_group(group_name, marker=None, max_items=None, region=None, key=None,
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     try:
-        info = conn.get_group(group_name, marker, max_items)
+        info = conn.get_group(group_name, max_items=1)
         if not info:
             return False
-        return info
+        return info['get_group_response']['get_group_result']['group']
     except boto.exception.BotoServerError as e:
         log.debug(e)
         msg = 'Failed to get group {0} info.'
+        log.error(msg.format(group_name))
+        return False
+
+
+def get_group_members(group_name, region=None, key=None, keyid=None, profile=None):
+    '''
+    Get group information.
+
+    .. versionadded:: Boron
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iam.get_group mygroup
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        marker = None
+        truncated = True
+        users = []
+        while truncated:
+            info = conn.get_group(group_name, marker=marker, max_items=1000)
+            if not info:
+                return False
+            truncated = bool(info['get_group_response']['get_group_result']['is_truncated'])
+            if truncated and 'marker' in info['get_group_response']['get_group_result']:
+                marker = info['get_group_response']['get_group_result']['marker']
+            else:
+                marker = None
+                truncated = False
+            users += info['get_group_response']['get_group_result']['users']
+        return users
+    except boto.exception.BotoServerError as e:
+        log.debug(e)
+        msg = 'Failed to get group {0} members.'
         log.error(msg.format(group_name))
         return False
 
@@ -425,8 +461,8 @@ def add_user_to_group(user_name, group_name, region=None, key=None, keyid=None,
         msg = 'Username : {0} does not exist.'
         log.error(msg.format(user_name, group_name))
         return False
-    if user_exists_in_group(user_name, group_name, region=region, key=key, keyid=keyid,
-                            profile=profile):
+    if user_exists_in_group(user_name, group_name, region=region, key=key,
+                            keyid=keyid, profile=profile):
         return True
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     try:
@@ -454,11 +490,14 @@ def user_exists_in_group(user_name, group_name, region=None, key=None, keyid=Non
 
         salt myminion boto_iam.user_exists_in_group myuser mygroup
     '''
-    group = get_group(group_name, region=region, key=key, keyid=keyid,
-                      profile=profile)
-    if group:
-        for _users in group['get_group_response']['get_group_result']['users']:
-            if user_name == _users['user_name']:
+    # TODO this should probably use boto.iam.get_groups_for_user
+    users = get_group_members(
+        group_name=group_name, region=region, key=key, keyid=keyid,
+        profile=profile
+    )
+    if users:
+        for _user in users:
+            if user_name == _user['user_name']:
                 msg = 'Username : {0} is already in group {1}.'
                 log.info(msg.format(user_name, group_name))
                 return True
@@ -512,7 +551,8 @@ def put_group_policy(group_name, policy_name, policy_json, region=None, key=None
 
         salt myminion boto_iam.put_group_policy mygroup policyname policyrules
     '''
-    group = get_group(group_name, region=region, key=key, keyid=keyid, profile=profile)
+    group = get_group(group_name, region=region, key=key, keyid=keyid,
+                      profile=profile)
     if not group:
         log.error('Group {0} does not exist'.format(group_name))
         return False
@@ -649,6 +689,106 @@ def create_login_profile(user_name, password, region=None, key=None,
             return 'Conflict'
         msg = 'Failed to update profile for user {0}.'
         log.error(msg.format(user_name))
+        return False
+
+
+def delete_login_profile(user_name, region=None, key=None, keyid=None,
+                         profile=None):
+    '''
+    Deletes a login profile for the specified user.
+
+    .. versionadded::
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iam.delete_login_profile user_name
+    '''
+    user = get_user(user_name, region, key, keyid, profile)
+    if not user:
+        msg = 'Username {0} does not exist'
+        log.error(msg.format(user_name))
+        return False
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        info = conn.delete_login_profile(user_name)
+        log.info('Deleted login profile for user {0}.'.format(user_name))
+        return True
+    except boto.exception.BotoServerError as e:
+        log.debug(e)
+        if 'Not Found' in e:
+            log.info('Login profile already deleted for user {0}.'.format(user_name))
+            return True
+        msg = 'Failed to delete login profile for user {0}.'
+        log.error(msg.format(user_name))
+        return False
+
+
+def get_all_mfa_devices(user_name, region=None, key=None, keyid=None,
+                        profile=None):
+    '''
+    Get all MFA devices associated with an IAM user.
+
+    .. versionadded::
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iam.get_all_mfa_devices user_name
+    '''
+    user = get_user(user_name, region, key, keyid, profile)
+    if not user:
+        msg = 'Username {0} does not exist'
+        log.error(msg.format(user_name))
+        return False
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        result = conn.get_all_mfa_devices(user_name)
+        devices = result['list_mfa_devices_response']['list_mfa_devices_result']['mfa_devices']
+        return devices
+    except boto.exception.BotoServerError as e:
+        log.debug(e)
+        if 'Not Found' in e:
+            log.info('Could not find user {0}.'.format(user_name))
+            return []
+        msg = 'Failed to get all MFA devices for user {0}.'
+        log.error(msg.format(user_name, serial))
+        return False
+
+
+def deactivate_mfa_device(user_name, serial, region=None, key=None, keyid=None,
+                          profile=None):
+    '''
+    Deactivates the specified MFA device and removes it from association with
+    the user.
+
+    .. versionadded::
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iam.deactivate_mfa_device user_name serial_num
+    '''
+    user = get_user(user_name, region, key, keyid, profile)
+    if not user:
+        msg = 'Username {0} does not exist'
+        log.error(msg.format(user_name))
+        return False
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        conn.deactivate_mfa_device(user_name, serial)
+        log.info('Deactivated MFA device {1} for user {0}.'.format(user_name, serial))
+        return True
+    except boto.exception.BotoServerError as e:
+        log.debug(e)
+        if 'Not Found' in e:
+            log.info('MFA device {1} not associated with user {0}.'.format(user_name, serial))
+            return True
+        msg = 'Failed to deactivate MFA device {1} for user {0}.'
+        log.error(msg.format(user_name, serial))
         return False
 
 
@@ -1343,6 +1483,5 @@ def export_users(path_prefix='/', region=None, key=None, keyid=None,
         user_sls.append({"name": name})
         user_sls.append({"policies": policies})
         user_sls.append({"path": user.path})
-        results["manage user " + name] = {"boto_iam.user_present":
-                                          user_sls}
+        results["manage user " + name] = {"boto_iam.user_present": user_sls}
     return _safe_dump(results)

--- a/salt/states/boto_iam.py
+++ b/salt/states/boto_iam.py
@@ -136,8 +136,11 @@ def __virtual__():
     return 'boto_iam.get_user' in __salt__
 
 
-def user_absent(name, delete_keys=None, region=None, key=None, keyid=None, profile=None):
+def user_absent(name, delete_keys=True, delete_mfa_devices=True, delete_profile=True, region=None, key=None, keyid=None, profile=None):
     '''
+
+    .. versionadded:: 2015.8
+
     Ensure the IAM user is absent. User cannot be deleted if it has keys.
 
     name (string)
@@ -145,6 +148,16 @@ def user_absent(name, delete_keys=None, region=None, key=None, keyid=None, profi
 
     delete_keys (bool)
         Delete all keys from user.
+
+    delete_mfa_devices (bool)
+        Delete all mfa devices from user.
+
+        .. versionadded:: Boron
+
+    delete_profile (bool)
+        Delete profile from user.
+
+        .. versionadded:: Boron
 
     region (string)
         Region to connect to.
@@ -164,7 +177,8 @@ def user_absent(name, delete_keys=None, region=None, key=None, keyid=None, profi
         ret['result'] = True
         ret['comment'] = 'IAM User {0} does not exist.'.format(name)
         return ret
-    if 'true' == str(delete_keys).lower:
+    # delete the user's access keys
+    if delete_keys:
         keys = __salt__['boto_iam.get_all_access_keys'](user_name=name, region=region, key=key,
                                                         keyid=keyid, profile=profile)
         log.debug('Keys for user {0} are {1}.'.format(name, keys))
@@ -172,14 +186,36 @@ def user_absent(name, delete_keys=None, region=None, key=None, keyid=None, profi
             keys = keys['list_access_keys_response']['list_access_keys_result']['access_key_metadata']
             for k in keys:
                 if __opts__['test']:
-                    ret['comment'] = 'Access key {0} is set to be deleted.'.format(k['access_key_id'])
+                    ret['comment'] = os.linesep.join([ret['comment'], 'Key {0} is set to be deleted.'.format(k['access_key_id'])])
                     ret['result'] = None
-                    return ret
-                if _delete_key(k['access_key_id'], name, region, key, keyid, profile):
-                    ret['comment'] = os.linesep.join([ret['comment'], 'Key {0} has been deleted.'.format(k['access_key_id'])])
-                    ret['changes'][k['access_key_id']] = 'deleted'
+                else:
+                    if _delete_key(ret, k['access_key_id'], name, region, key, keyid, profile):
+                        ret['comment'] = os.linesep.join([ret['comment'], 'Key {0} has been deleted.'.format(k['access_key_id'])])
+                        ret['changes'][k['access_key_id']] = 'deleted'
+    # delete the user's MFA tokens
+    if delete_mfa_devices:
+        devices = __salt__['boto_iam.get_all_mfa_devices'](user_name=name, region=region, key=key, keyid=keyid, profile=profile)
+        for d in devices:
+            serial = d['serial_number']
+            if __opts__['test']:
+                ret['comment'] = os.linesep.join([ret['comment'], 'IAM user {0} MFA device {1} is set to be deleted.'.format(name, serial)])
+                ret['result'] = None
+            else:
+                mfa_deleted = __salt__['boto_iam.deactivate_mfa_device'](user_name=name, serial=serial, region=region, key=key, keyid=keyid, profile=profile)
+                if mfa_deleted:
+                    ret['comment'] = os.linesep.join([ret['comment'], 'IAM user {0} MFA device {1} are deleted.'.format(name, serial)])
+    # delete the user's login profile
+    if delete_profile:
+        if __opts__['test']:
+            ret['comment'] = os.linesep.join([ret['comment'], 'IAM user {0} login profile is set to be deleted.'.format(name)])
+            ret['result'] = None
+        else:
+            profile_deleted = __salt__['boto_iam.delete_login_profile'](name, region, key, keyid, profile)
+            if profile_deleted:
+                ret['comment'] = os.linesep.join([ret['comment'], 'IAM user {0} login profile is deleted.'.format(name)])
+    # finally, actually delete the user
     if __opts__['test']:
-        ret['comment'] = 'IAM user {0} is set to be deleted.'.format(name)
+        ret['comment'] = os.linesep.join([ret['comment'], 'IAM user {0} is set to be deleted.'.format(name)])
         ret['result'] = None
         return ret
     deleted = __salt__['boto_iam.delete_user'](name, region, key, keyid, profile)
@@ -195,6 +231,9 @@ def user_absent(name, delete_keys=None, region=None, key=None, keyid=None, profi
 
 def keys_present(name, number, save_dir, region=None, key=None, keyid=None, profile=None):
     '''
+
+    .. versionadded:: 2015.8
+
     Ensure the IAM access keys are present.
 
     name (string)
@@ -280,6 +319,9 @@ def keys_present(name, number, save_dir, region=None, key=None, keyid=None, prof
 
 def keys_absent(access_keys, user_name, region=None, key=None, keyid=None, profile=None):
     '''
+
+    .. versionadded:: 2015.8
+
     Ensure the IAM user access_key_id is absent.
 
     access_key_id (list)
@@ -342,6 +384,9 @@ def _delete_key(ret, access_key_id, user_name, region=None, key=None, keyid=None
 def user_present(name, policies=None, policies_from_pillars=None, password=None, path=None, region=None, key=None,
                  keyid=None, profile=None):
     '''
+
+    .. versionadded:: 2015.8
+
     Ensure the IAM user is present
 
     name (string)
@@ -493,15 +538,18 @@ def _case_password(ret, name, password, region=None, key=None, keyid=None, profi
             ret['comment'] = os.linesep.join([ret['comment'], 'Login profile for user {0} exists.'.format(name)])
         else:
             ret['comment'] = os.linesep.join([ret['comment'], 'Password has been added to User {0}.'.format(name)])
-            ret['changes']['password'] = password
+            ret['changes']['password'] = 'REDACTED'
     else:
         ret['result'] = False
         ret['comment'] = os.linesep.join([ret['comment'], 'Password for user {0} could not be set.\nPlease check your password policy.'.format(name)])
     return ret
 
 
-def group_present(name, policies=None, policies_from_pillars=None, users=None, region=None, key=None, keyid=None, profile=None, path='/'):
+def group_present(name, policies=None, policies_from_pillars=None, users=None, path='/', region=None, key=None, keyid=None, profile=None):
     '''
+
+    .. versionadded:: 2015.8
+
     Ensure the IAM group is present
 
     name (string)
@@ -574,14 +622,14 @@ def group_present(name, policies=None, policies_from_pillars=None, users=None, r
         return ret
     if users:
         log.debug('Users are : {0}.'.format(users))
-        group_result = __salt__['boto_iam.get_group'](group_name=name, region=region, key=key, keyid=keyid, profile=profile)
-        ret = _case_group(ret, users, name, group_result, region, key, keyid, profile)
+        existing_users = __salt__['boto_iam.get_group_members'](group_name=name, region=region, key=key, keyid=keyid, profile=profile)
+        ret = _case_group(ret, users, name, existing_users, region, key, keyid, profile)
     return ret
 
 
-def _case_group(ret, users, group_name, group_result, region, key, keyid, profile):
+def _case_group(ret, users, group_name, existing_users, region, key, keyid, profile):
     _users = []
-    for user in group_result['get_group_response']['get_group_result']['users']:
+    for user in existing_users:
         _users.append(user['user_name'])
     log.debug('upstream users are {0}'.format(_users))
     for user in users:
@@ -596,7 +644,7 @@ def _case_group(ret, users, group_name, group_result, region, key, keyid, profil
                 ret['comment'] = 'User {0} is set to be added to group {1}.'.format(user, group_name)
                 ret['result'] = None
             else:
-                addret = __salt__['boto_iam.add_user_to_group'](user, group_name, region=region, key=key, keyid=keyid, profile=profile)
+                __salt__['boto_iam.add_user_to_group'](user, group_name, region, key, keyid, profile)
                 ret['comment'] = os.linesep.join([ret['comment'], 'User {0} has been added to group {1}.'.format(user, group_name)])
                 ret['changes'][user] = group_name
     for user in _users:
@@ -605,8 +653,8 @@ def _case_group(ret, users, group_name, group_result, region, key, keyid, profil
                 ret['comment'] = os.linesep.join([ret['comment'], 'User {0} is set to be removed from group {1}.'.format(user, group_name)])
                 ret['result'] = None
             else:
-                remret = __salt__['boto_iam.remove_user_from_group'](group_name=group_name, user_name=user, region=region,
-                                                                     key=key, keyid=keyid, profile=profile)
+                __salt__['boto_iam.remove_user_from_group'](group_name=group_name, user_name=user, region=region,
+                                                            key=key, keyid=keyid, profile=profile)
                 ret['comment'] = os.linesep.join([ret['comment'], 'User {0} has been removed from group {1}.'.format(user, group_name)])
                 ret['changes'][user] = 'Removed from group {0}.'.format(group_name)
     return ret
@@ -695,6 +743,8 @@ def account_policy(allow_users_to_change_password=None, hard_expiry=None, max_pa
     '''
     Change account policy.
 
+    .. versionadded:: 2015.8
+
     allow_users_to_change_password (bool)
         Allows all IAM users in your account to
         use the AWS Management Console to change their own passwords.
@@ -782,6 +832,8 @@ def server_cert_absent(name, region=None, key=None, keyid=None, profile=None):
     '''
     Deletes a server certificate.
 
+    .. versionadded:: 2015.8
+
     name (string)
         The name for the server certificate. Do not include the path in this value.
 
@@ -820,6 +872,8 @@ def server_cert_present(name, public_key, private_key, cert_chain=None, path=Non
                         region=None, key=None, keyid=None, profile=None):
     '''
     Crete server certificate.
+
+    .. versionadded:: 2015.8
 
     name (string)
         The name for the server certificate. Do not include the path in this value.


### PR DESCRIPTION
It's necessary to remove a number of iam user attributes before
deleting the user, or the user can't be deleted. This change
purges those attributes by default.
