### PR TITLE
loader uses a deep dictionary merge for the grains (core and customs)

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -244,6 +244,12 @@
 # often lower this value
 #loop_interval: 60
 
+# The grains can be merged, instead of overridden, using this option.
+# This allows custom grains to defined different subvalues of a dictionary
+# grain. By default this feature is disabled, to enable set grains_deep_merge
+# to ``True``.
+#grains_deep_merge: False
+
 # The grains_refresh_every setting allows for a minion to periodically check
 # its grains to see if they have changed and, if so, to inform the master
 # of the new grains. This operation is moderately expensive, therefore

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -355,6 +355,50 @@ to enable set grains_cache to ``True``.
     grains_cache: False
 
 
+.. conf_minion:: grains_deep_merge
+
+``grains_deep_merge``
+---------------------
+
+.. versionadded:: Boron
+
+Default: ``False``
+
+The grains can be merged, instead of overridden, using this option.
+This allows custom grains to defined different subvalues of a dictionary
+grain. By default this feature is disabled, to enable set grains_deep_merge
+to ``True``.
+
+.. code-block:: yaml
+
+    grains_deep_merge: False
+
+For example, with these custom grains functions:
+
+.. code-block:: python
+
+    def custom1_k1():
+        return {'custom1': {'k1': 'v1'}}
+
+    def custom1_k2():
+        return {'custom1': {'k2': 'v2'}}
+
+Without ``grains_deep_merge``, the result would be:
+
+.. code-block:: yaml
+
+    custom1:
+      k1: v1
+
+With ``grains_deep_merge``, the result will be:
+
+.. code-block:: yaml
+
+    custom1:
+      k1: v1
+      k2: v2
+
+
 .. conf_minion:: sock_dir
 
 ``sock_dir``

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -798,6 +798,7 @@ DEFAULT_MINION_OPTS = {
     'cache_jobs': False,
     'grains_cache': False,
     'grains_cache_expiration': 300,
+    'grains_deep_merge': False,
     'conf_file': os.path.join(salt.syspaths.CONFIG_DIR, 'minion'),
     'sock_dir': os.path.join(salt.syspaths.SOCK_DIR, 'minion'),
     'backup_mode': '',

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -28,7 +28,6 @@ import salt.utils.context
 import salt.utils.lazy
 import salt.utils.event
 import salt.utils.odict
-import salt.utils.dictupdate
 
 # Solve the Chicken and egg problem where grains need to run before any
 # of the modules are loaded and are generally available for any usage.
@@ -631,6 +630,7 @@ def grains(opts, force_refresh=False, proxy=None):
 
     if opts.get('skip_grains', False):
         return {}
+    grains_deep_merge = opts.get('grains_deep_merge', False) is True
     if 'conf_file' in opts:
         pre_opts = {}
         pre_opts.update(salt.config.load_config(
@@ -666,7 +666,10 @@ def grains(opts, force_refresh=False, proxy=None):
         ret = fun()
         if not isinstance(ret, dict):
             continue
-        salt.utils.dictupdate.update(grains_data, ret)
+        if grains_deep_merge:
+            salt.utils.dictupdate.update(grains_data, ret)
+        else:
+            grains_data.update(ret)
 
     # Run the rest of the grains
     for key, fun in six.iteritems(funcs):
@@ -685,7 +688,10 @@ def grains(opts, force_refresh=False, proxy=None):
             continue
         if not isinstance(ret, dict):
             continue
-        salt.utils.dictupdate.update(grains_data, ret)
+        if grains_deep_merge:
+            salt.utils.dictupdate.update(grains_data, ret)
+        else:
+            grains_data.update(ret)
 
     # Write cache if enabled
     if opts.get('grains_cache', False):
@@ -706,7 +712,10 @@ def grains(opts, force_refresh=False, proxy=None):
             log.error(msg.format(cfn))
         os.umask(cumask)
 
-    salt.utils.dictupdate.update(grains_data, opts['grains'])
+    if grains_deep_merge:
+        salt.utils.dictupdate.update(grains_data, opts['grains'])
+    else:
+        grains_data.update(opts['grains'])
     return grains_data
 
 

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -28,6 +28,7 @@ import salt.utils.context
 import salt.utils.lazy
 import salt.utils.event
 import salt.utils.odict
+import salt.utils.dictupdate
 
 # Solve the Chicken and egg problem where grains need to run before any
 # of the modules are loaded and are generally available for any usage.
@@ -665,7 +666,7 @@ def grains(opts, force_refresh=False, proxy=None):
         ret = fun()
         if not isinstance(ret, dict):
             continue
-        grains_data.update(ret)
+        salt.utils.dictupdate.update(grains_data, ret)
 
     # Run the rest of the grains
     for key, fun in six.iteritems(funcs):
@@ -684,7 +685,7 @@ def grains(opts, force_refresh=False, proxy=None):
             continue
         if not isinstance(ret, dict):
             continue
-        grains_data.update(ret)
+        salt.utils.dictupdate.update(grains_data, ret)
 
     # Write cache if enabled
     if opts.get('grains_cache', False):
@@ -705,7 +706,7 @@ def grains(opts, force_refresh=False, proxy=None):
             log.error(msg.format(cfn))
         os.umask(cumask)
 
-    grains_data.update(opts['grains'])
+    salt.utils.dictupdate.update(grains_data, opts['grains'])
     return grains_data
 
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -765,7 +765,8 @@ class TestDaemon(object):
         if sync_needed:
             # Wait for minions to "sync_all"
             for target in [self.sync_minion_modules,
-                           self.sync_minion_states]:
+                           self.sync_minion_states,
+                           self.sync_minion_grains]:
                 sync_minions = MultiprocessingProcess(
                     target=target,
                     args=(self.minion_targets, self.MINIONS_SYNC_TIMEOUT)
@@ -1020,6 +1021,9 @@ class TestDaemon(object):
     def sync_minion_modules(self, targets, timeout=None):
         salt.utils.appendproctitle('SyncMinionModules')
         self.sync_minion_modules_('modules', targets, timeout=timeout)
+
+    def sync_minion_grains(self, targets, timeout=None):
+        self.sync_minion_modules_('grains', targets, timeout=timeout)
 
 
 class AdaptedConfigurationTestCaseMixIn(object):

--- a/tests/integration/files/file/base/_grains/test_custom_grain1.py
+++ b/tests/integration/files/file/base/_grains/test_custom_grain1.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+def myfunction():
+     grains = {}
+     grains['a_custom'] = {'k1': 'v1'}
+     return grains

--- a/tests/integration/files/file/base/_grains/test_custom_grain2.py
+++ b/tests/integration/files/file/base/_grains/test_custom_grain2.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+def myfunction():
+     grains = {}
+     grains['a_custom'] = {'k2': 'v2'}
+     return grains

--- a/tests/integration/loader/ext_grains.py
+++ b/tests/integration/loader/ext_grains.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+'''
+    integration.loader.ext_grains
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Test Salt's loader regarding external grains
+'''
+
+# Import Python libs
+from __future__ import absolute_import
+
+# Import Salt Testing libs
+from salttesting.helpers import ensure_in_syspath
+ensure_in_syspath('../')
+
+# Import salt libs
+import integration
+from salt.config import minion_config
+
+from salt.loader import grains
+
+
+class LoaderGrainsTest(integration.ModuleCase):
+    '''
+    Test the loader standard behavior with external grains
+    '''
+
+    def setUp(self):
+        self.opts = minion_config(None)
+        self.opts['disable_modules'] = ['pillar']
+        self.opts['grains'] = grains(self.opts)
+
+    def test_grains_overwrite(self):
+        grains = self.run_function('grains.items')
+
+        # Check that custom grains are overwritten
+        self.assertEqual({'k2': 'v2'}, grains['a_custom'])
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(LoaderGrainsTest)

--- a/tests/integration/loader/ext_grains.py
+++ b/tests/integration/loader/ext_grains.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import
 
 # Import Salt Testing libs
 from salttesting.helpers import ensure_in_syspath
+from salttesting.unit import skipIf
 ensure_in_syspath('../')
 
 # Import salt libs
@@ -37,6 +38,29 @@ class LoaderGrainsTest(integration.ModuleCase):
         self.assertEqual({'k2': 'v2'}, grains['a_custom'])
 
 
+@skipIf(True, "needs a way to reload minion after config change")
+class LoaderGrainsMergeTest(integration.ModuleCase):
+    '''
+    Test the loader deep merge behavior with external grains
+    '''
+
+    def setUp(self):
+        self.opts = minion_config(None)
+        self.opts['grains_deep_merge'] = True
+        self.assertTrue(self.opts['grains_deep_merge'])
+        self.opts['disable_modules'] = ['pillar']
+        __grains__ = grains(self.opts)
+
+    def test_grains_merge(self):
+        __grain__ = self.run_function('grains.item', ['a_custom'])
+
+        # Check that the grain is present
+        self.assertIn('a_custom', __grain__)
+        # Check that the grains are merged
+        self.assertEqual({'k1': 'v1', 'k2': 'v2'}, __grain__['a_custom'])
+
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(LoaderGrainsTest)
+    run_tests(LoaderGrainsMergeTest)


### PR DESCRIPTION
This is a fix for #27881
I must say that I didn't write any unit or integration test for this change, and I don't know about the performance impact.
