### PR TITLE
Fixes broken Salt Raet. master.flo file path broken

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -60,8 +60,8 @@ else:
     _DFLT_MULTIPROCESSING_MODE = True
 
 FLO_DIR = os.path.join(
-        os.path.dirname(__file__),
-        'daemons', 'flo')
+            os.path.dirname(os.path.dirname(__file__)),
+            'daemons', 'flo')
 
 VALID_OPTS = {
     # The address of the salt master. May be specified as IP address or hostname

--- a/salt/daemons/flo/core.py
+++ b/salt/daemons/flo/core.py
@@ -30,7 +30,7 @@ from salt.utils import kinds, is_windows
 from salt.utils.event import tagify
 
 # Import ioflo libs
-from ioflo.base.odicting import odict
+from ioflo.aid.odicting import odict
 import ioflo.base.deeding
 
 from ioflo.base.consoling import getConsole

--- a/salt/daemons/salting.py
+++ b/salt/daemons/salting.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import
 import os
 
 # Import ioflo libs
-from ioflo.base.odicting import odict
+from ioflo.aid.odicting import odict
 
 from ioflo.base.consoling import getConsole
 console = getConsole()

--- a/salt/daemons/test/plan/actors.py
+++ b/salt/daemons/test/plan/actors.py
@@ -12,7 +12,7 @@ from collections import deque
 
 # Import ioflo libs
 import ioflo.base.deeding
-from ioflo.base.odicting import odict
+from ioflo.aid.odicting import odict
 
 from ioflo.base.consoling import getConsole
 console = getConsole()

--- a/salt/daemons/test/test_master.py
+++ b/salt/daemons/test/test_master.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import
 import os
 import stat
 
-from ioflo.base.odicting import odict
+from ioflo.aid.odicting import odict
 from ioflo.base.consoling import getConsole
 console = getConsole()
 

--- a/salt/daemons/test/test_minion.py
+++ b/salt/daemons/test/test_minion.py
@@ -11,7 +11,7 @@ from __future__ import print_function
 import os
 import stat
 
-from ioflo.base.odicting import odict
+from ioflo.aid.odicting import odict
 from ioflo.base.consoling import getConsole
 console = getConsole()
 

--- a/salt/daemons/test/test_multimaster.py
+++ b/salt/daemons/test/test_multimaster.py
@@ -19,7 +19,7 @@ import time
 import tempfile
 import shutil
 
-from ioflo.base.odicting import odict
+from ioflo.aid.odicting import odict
 from ioflo.base.aiding import Timer, StoreTimer
 from ioflo.base import storing
 from ioflo.base.consoling import getConsole

--- a/salt/daemons/test/test_multimaster.py
+++ b/salt/daemons/test/test_multimaster.py
@@ -20,7 +20,7 @@ import tempfile
 import shutil
 
 from ioflo.aid.odicting import odict
-from ioflo.base.aiding import Timer, StoreTimer
+from ioflo.aid.timing import Timer, StoreTimer
 from ioflo.base import storing
 from ioflo.base.consoling import getConsole
 console = getConsole()

--- a/salt/daemons/test/test_presence.py
+++ b/salt/daemons/test/test_presence.py
@@ -13,7 +13,7 @@ else:
 
 from ioflo.base.consoling import getConsole
 console = getConsole()
-from ioflo.base.odicting import odict
+from ioflo.aid.odicting import odict
 from ioflo.test import testing
 
 from raet.lane.stacking import LaneStack

--- a/salt/daemons/test/test_raetkey.py
+++ b/salt/daemons/test/test_raetkey.py
@@ -19,7 +19,7 @@ import time
 import tempfile
 import shutil
 
-from ioflo.base.odicting import odict
+from ioflo.aid.odicting import odict
 from ioflo.base.aiding import Timer, StoreTimer
 from ioflo.base import storing
 from ioflo.base.consoling import getConsole

--- a/salt/daemons/test/test_raetkey.py
+++ b/salt/daemons/test/test_raetkey.py
@@ -20,7 +20,7 @@ import tempfile
 import shutil
 
 from ioflo.aid.odicting import odict
-from ioflo.base.aiding import Timer, StoreTimer
+from ioflo.aid.timing import Timer, StoreTimer
 from ioflo.base import storing
 from ioflo.base.consoling import getConsole
 console = getConsole()

--- a/salt/daemons/test/test_saltkeep.py
+++ b/salt/daemons/test/test_saltkeep.py
@@ -21,7 +21,7 @@ import time
 import tempfile
 import shutil
 
-from ioflo.base.odicting import odict
+from ioflo.aid.odicting import odict
 from ioflo.base.aiding import Timer, StoreTimer
 from ioflo.base import storing
 from ioflo.base.consoling import getConsole

--- a/salt/daemons/test/test_saltkeep.py
+++ b/salt/daemons/test/test_saltkeep.py
@@ -22,7 +22,7 @@ import tempfile
 import shutil
 
 from ioflo.aid.odicting import odict
-from ioflo.base.aiding import Timer, StoreTimer
+from ioflo.aid.timing import Timer, StoreTimer
 from ioflo.base import storing
 from ioflo.base.consoling import getConsole
 console = getConsole()

--- a/salt/daemons/test/test_stats.py
+++ b/salt/daemons/test/test_stats.py
@@ -14,7 +14,7 @@ import time
 
 from ioflo.base.consoling import getConsole
 console = getConsole()
-from ioflo.base.odicting import odict
+from ioflo.aid.odicting import odict
 from ioflo.test import testing
 
 from raet.abiding import ns2u

--- a/salt/daemons/test/test_stats.py
+++ b/salt/daemons/test/test_stats.py
@@ -10,6 +10,7 @@ if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
     import unittest
+import time
 
 from ioflo.base.consoling import getConsole
 console = getConsole()
@@ -101,7 +102,7 @@ class StatsEventerTestCase(testing.FrameIofloTestCase):
         testStack = self.store.fetch('.salt.test.lane.stack')
         if testStack:
             testStack.value.server.close()
-
+        act.actor.road_stack.value.server.close()
 
     def testMasterRoadStats(self):
         """
@@ -156,7 +157,7 @@ class StatsEventerTestCase(testing.FrameIofloTestCase):
         testStack = self.store.fetch('.salt.test.lane.stack')
         if testStack:
             testStack.value.server.close()
-
+        time.sleep(0.1)
 
     def testMasterLaneStats(self):
         """
@@ -212,7 +213,6 @@ class StatsEventerTestCase(testing.FrameIofloTestCase):
         if testStack:
             testStack.value.server.close()
 
-
     def testMasterStatsWrongMissingTag(self):
         """
         Test Master Stats requests with unknown and missing tag (A3, A4)
@@ -267,7 +267,6 @@ class StatsEventerTestCase(testing.FrameIofloTestCase):
         if testStack:
             testStack.value.server.close()
 
-
     def testMasterStatsUnknownRemote(self):
         """
         Test Master Stats request with unknown remote (B1)
@@ -318,7 +317,6 @@ class StatsEventerTestCase(testing.FrameIofloTestCase):
         if testStack:
             testStack.value.server.close()
 
-
     def testMasterStatsNoRequest(self):
         """
         Test Master Stats no requests (nothing to do) (B2)
@@ -364,7 +362,6 @@ class StatsEventerTestCase(testing.FrameIofloTestCase):
         testStack = self.store.fetch('.salt.test.lane.stack')
         if testStack:
             testStack.value.server.close()
-
 
     def testMinionContextSetup(self):
         """
@@ -412,7 +409,7 @@ class StatsEventerTestCase(testing.FrameIofloTestCase):
         testStack = self.store.fetch('.salt.test.road.stack')
         if testStack:
             testStack.value.server.close()
-
+        act.actor.road_stack.value.server.close()
 
     def testMinionRoadStats(self):
         """
@@ -471,7 +468,6 @@ class StatsEventerTestCase(testing.FrameIofloTestCase):
         if testStack:
             testStack.value.server.close()
 
-
     def testMinionLaneStats(self):
         """
         Test Minion Road Stats request (A2)
@@ -529,7 +525,6 @@ class StatsEventerTestCase(testing.FrameIofloTestCase):
         if testStack:
             testStack.value.server.close()
 
-
     def testMinionStatsWrongMissingTag(self):
         """
         Test Minion Stats requests with unknown and missing tag (A3, A4)
@@ -586,7 +581,6 @@ class StatsEventerTestCase(testing.FrameIofloTestCase):
         if testStack:
             testStack.value.server.close()
 
-
     def testMinionStatsUnknownRemote(self):
         """
         Test Minion Stats request with unknown remote (B1)
@@ -637,7 +631,6 @@ class StatsEventerTestCase(testing.FrameIofloTestCase):
         testStack = self.store.fetch('.salt.test.road.stack')
         if testStack:
             testStack.value.server.close()
-
 
     def testMinionStatsNoRequest(self):
         """
@@ -728,8 +721,8 @@ if __name__ == '__main__' and __package__ is None:
 
     # console.reinit(verbosity=console.Wordage.concise)
 
-    runAll()  # run all unittests
+    #runAll()  # run all unittests
 
-    # runSome()  #only run some
+    runSome()  #only run some
 
-    # runOne('testMasterContextSetup')
+    #runOne('testMasterLaneStats')

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1034,7 +1034,8 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                     # if we do, we want it if we have a higher precidence ext
                     else:
                         curr_ext = self.file_mapping[f_noext][1]
-                        if suffix_order.index(ext) < suffix_order.index(curr_ext):
+                        #log.debug("****** curr_ext={0} ext={1} suffix_order={2}".format(curr_ext, ext, suffix_order))
+                        if curr_ext and suffix_order.index(ext) < suffix_order.index(curr_ext):
                             self.file_mapping[f_noext] = (fpath, ext)
                 except OSError:
                     continue

--- a/salt/utils/yamldumper.py
+++ b/salt/utils/yamldumper.py
@@ -18,7 +18,7 @@ except ImportError:
 from salt.utils.odict import OrderedDict
 
 try:
-    from ioflo.base.odicting import odict
+    from ioflo.aid.odicting import odict
     HAS_IOFLO = True
 except ImportError:
     odict = None


### PR DESCRIPTION
Looks like moving the .config file to its own package directory broke the path for FLO_DIR.
This fixes it.
