### PR TITLE
dockerng: use error from modules.dockerng in states' __virtual__

### DIFF
--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -75,7 +75,7 @@ def __virtual__():
             _validate_input, globals()
         )
         return __virtualname__
-    return False
+    return (False, __modules__.missing_fun_string('dockerng.version'))
 
 
 def _format_comments(comments):


### PR DESCRIPTION
This improves the return value for errors in `__virtual__` by using the
information from `modules.dockerng`.

Ref: https://github.com/saltstack/salt/issues/27643#issuecomment-148942821
