### PR TITLE
Fix Doc in jinja template,

### DIFF
--- a/doc/topics/mine/index.rst
+++ b/doc/topics/mine/index.rst
@@ -160,7 +160,7 @@ to add them to the pool of load balanced servers.
 
     <...file contents snipped...>
 
-    {% for server, addrs in salt['mine.get']('roles:web', 'network.ip_addrs', expr_form='pillar').items() %}
+    {% for server, addrs in salt['mine.get']('roles:web', 'network.ip_addrs', expr_form='grain').items() %}
     server {{ server }} {{ addrs[0] }}:80 check
     {% endfor %}
 


### PR DESCRIPTION
In the example expr_form is using pillar instead of grain when in the doc is explained the use of a grain for the role
