### PR TITLE
fix for glance state trace error on import failure

### DIFF
--- a/salt/states/glance.py
+++ b/salt/states/glance.py
@@ -12,12 +12,23 @@ import time
 from salt.utils import warn_until
 
 # Import OpenStack libs
-from keystoneclient.apiclient.exceptions import \
-    Unauthorized as kstone_Unauthorized
-from glanceclient.exc import \
-    HTTPUnauthorized as glance_Unauthorized
+try:
+    from keystoneclient.apiclient.exceptions import \
+        Unauthorized as kstone_Unauthorized
+    from glanceclient.exc import \
+        HTTPUnauthorized as glance_Unauthorized
+    HAS_DEPENDENCIES = True
+except ImportError:
+    HAS_DEPENDENCIES = False
 
 log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Only load if dependencies are loaded
+    '''
+    return HAS_DEPENDENCIES
 
 
 def _find_image(name):


### PR DESCRIPTION
```
[DEBUG   ] Failed to import states glance:
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1130, in _load_module
    ), fn_, fpath, desc)
  File "/usr/lib/python2.7/dist-packages/salt/states/glance.py", line 15, in <module>
    from keystoneclient.apiclient.exceptions import \
ImportError: No module named keystoneclient.apiclient.exceptions
```
