### PR TITLE
#28069 with lint

### DIFF
--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -75,7 +75,7 @@ def __virtual__():
             _validate_input, globals()
         )
         return __virtualname__
-    return False
+    return (False, __modules__.missing_fun_string('dockerng.version'))
 
 
 def _format_comments(comments):

--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -75,7 +75,7 @@ def __virtual__():
             _validate_input, globals()
         )
         return __virtualname__
-    return (False, __modules__.missing_fun_string('dockerng.version'))
+    return (False, __modules__.missing_fun_string('dockerng.version'))  # pylint: disable=E0602
 
 
 def _format_comments(comments):


### PR DESCRIPTION
A copy of #28069 with lint included.
