### PR TITLE
Revert "Update __init__.py"

### DIFF
--- a/salt/wheel/__init__.py
+++ b/salt/wheel/__init__.py
@@ -121,6 +121,6 @@ class WheelClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
             >>> wheel.cmd('key.finger', ['jerry'])
             {'minions': {'jerry': '5d:f6:79:43:5e:d4:42:3f:57:b8:45:a8:7e:a4:6e:ca'}}
         '''
-        return self.low(fun, kwarg)
+
 
 Wheel = WheelClient  # for backward-compat


### PR DESCRIPTION
This reverts commit 5664de6610de024e09b35d919a10c715370bd539.

The commit introduced a specific implementation of WheelClient.cmd()
that calls low(fun, low) method passing args as low argument that's
wrong, args and kwargs should be packed into low that should be a dict.

Fix for #26415 
