### PR TITLE
Add clone for qemu

### DIFF
--- a/doc/topics/cloud/proxmox.rst
+++ b/doc/topics/cloud/proxmox.rst
@@ -146,3 +146,92 @@ with their default settings listed.
 
     # The name of the image, from ``salt-cloud --list-images proxmox``
     image: local:vztmpl/ubuntu-12.04-standard_12.04-1_amd64.tar.gz
+
+QEMU
+====
+
+Some functionnalities works differently if you use 'qemu' as technology. In order to create a new VM with qemu, you need to specificy some more informations.
+You can also clone a qemu template which already is on your Proxmox server.
+
+QEMU profile file (for a new VM):
+
+.. code-bock:: yaml
+  proxmox-win7:
+    # Image of the new VM
+    image: image.iso # You can get all your available images using 'salt-cloud --list-images provider_name' (Ex: 'salt-cloud --list-images my-proxmox-config')
+
+    # Technology used to create the VM ('qemu' or 'openvz')
+    technology: qemu
+ 
+    # Proxmox node name
+    host: node_name
+
+    # Proxmox password
+    password: your_password
+
+    # Workaround https://github.com/saltstack/salt/issues/27821
+    size: ''
+
+    # RAM size (MB)
+    memory: 2048
+
+    # OS Type enum (other / wxp / w2k / w2k3 / w2k8 / wvista / win7 / win8 / l24 / l26 / solaris)
+    ostype: win7
+    
+    # Hard disk location
+    sata0: <location>:<size>, format=<qcow2/vmdk/raw>, size=<size>GB #Example: local:120,format=qcow2,size=120GB
+
+    #CD/DVD Drive
+    ide2: <content_location>,media=cdrom #Example: local:iso/name.iso,media=cdrom
+
+    # Network Device
+    net0:<model>,bridge=<bridge> #Example: e1000,bridge=vmbr0
+
+    # Enable QEMU Guest Agent (0 / 1)
+    agent: 1
+
+    # VM name
+    name: Test
+
+More informations about these parameters can be found on Proxmox API (http://pve.proxmox.com/pve2-api-doc/) under the 'POST' method of nodes/{node}/qemu
+
+
+QEMU profile file (for a clone):
+
+.. code-bock:: yaml
+  proxmox-win7:
+    # Enable Clone
+    clone: 1
+
+    # New VM description
+    clone_description: 'description'
+
+    # New VM name
+    clone_name: 'name'
+
+    # New VM format (qcow2 / raw / vmdk)
+    clone_format: qcow2
+
+    # Full clone (1) or Link clone (0)
+    clone_full: 0
+
+    # VMID of Template to clone
+    clone_from: ID
+
+    # Technology used to create the VM ('qemu' or 'openvz')
+    technology: qemu
+ 
+    # Proxmox node name
+    host: node_name
+
+    # Proxmox password
+    password: your_password
+
+    # Workaround https://github.com/saltstack/salt/issues/27821
+    size: ''
+
+More informations can be found on Proxmox API under the 'POST' method of /nodes/{node}/qemu/{vmid}/clone
+
+.. note::
+    The Proxmox API offers a lot more options and parameters, which are not yet supported by this salt-cloud 'overlay'. Feel free to add your contribution by forking the github repository and modifying  the following file : salt/salt/cloud/clouds/proxmox.py
+    An easy way to support more parameters for VM creation would be to add the names of the optionals parameters in the 'create_nodes(vm_)' function, under the 'qemu' technology. But it requires you to dig into the code ...

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -542,7 +542,8 @@ def create(vm_):
                 vm_['ip_address'] = str(ip_address)
 
     try:
-        data = create_node(vm_)
+        newid = _get_next_vmid()
+        data = create_node(vm_, newid)
     except Exception as exc:
         log.error(
             'Error creating {0} on PROXMOX\n\n'
@@ -557,7 +558,10 @@ def create(vm_):
 
     ret['creation_data'] = data
     name = vm_['name']        # hostname which we know
-    vmid = data['vmid']       # vmid which we have received
+    if (vm_['clone']) == True:
+        vmid = newid
+    else:
+        vmid = data['vmid']       # vmid which we have received
     host = data['node']       # host which we have received
     nodeType = data['technology']  # VM tech (Qemu / OpenVZ)
 
@@ -624,7 +628,7 @@ def create(vm_):
     return ret
 
 
-def create_node(vm_):
+def create_node(vm_, newid):
     '''
     Build and submit the requestdata to create a new node
     '''
@@ -650,7 +654,7 @@ def create_node(vm_):
 
     # Required by both OpenVZ and Qemu (KVM)
     vmhost = vm_['host']
-    newnode['vmid'] = _get_next_vmid()
+    newnode['vmid'] = newid
 
     for prop in 'cpuunits', 'description', 'memory', 'onboot':
         if prop in vm_:  # if the property is set, use it for the VM request
@@ -667,7 +671,7 @@ def create_node(vm_):
                 newnode[prop] = vm_[prop]
     elif vm_['technology'] == 'qemu':
         # optional Qemu settings
-        for prop in 'acpi', 'cores', 'cpu', 'pool', 'storage':
+        for prop in 'acpi', 'cores', 'cpu', 'pool', 'storage', 'sata0', 'ostype', 'ide2', 'net0':
             if prop in vm_:  # if the property is set, use it for the VM request
                 newnode[prop] = vm_[prop]
 
@@ -681,7 +685,17 @@ def create_node(vm_):
 
     log.debug('Preparing to generate a node using these parameters: {0} '.format(
               newnode))
-    node = query('post', 'nodes/{0}/{1}'.format(vmhost, vm_['technology']), newnode)
+    if vm_['clone'] == True and vm_['technology'] == 'qemu':
+        postParams = {}
+        postParams['newid'] = newnode['vmid']
+
+        for prop in 'description', 'format', 'full', 'name':
+            if 'clone_' + prop in vm_:  # if the property is set, use it for the VM request                                                                                                            
+                postParams[prop] = vm_['clone_' + prop]
+
+        node = query('post', 'nodes/{0}/qemu/{1}/clone'.format(vmhost, vm_['clone_from']), postParams)
+    else:
+        node = query('post', 'nodes/{0}/{1}'.format(vmhost, vm_['technology']), newnode)
     return _parse_proxmox_upid(node, vm_)
 
 

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -558,7 +558,7 @@ def create(vm_):
 
     ret['creation_data'] = data
     name = vm_['name']        # hostname which we know
-    if (vm_['clone']) == True:
+    if (vm_['clone']) is True:
         vmid = newid
     else:
         vmid = data['vmid']       # vmid which we have received
@@ -685,12 +685,12 @@ def create_node(vm_, newid):
 
     log.debug('Preparing to generate a node using these parameters: {0} '.format(
               newnode))
-    if vm_['clone'] == True and vm_['technology'] == 'qemu':
+    if vm_['clone'] is and vm_['technology'] == 'qemu':
         postParams = {}
         postParams['newid'] = newnode['vmid']
 
         for prop in 'description', 'format', 'full', 'name':
-            if 'clone_' + prop in vm_:  # if the property is set, use it for the VM request                                                                                                            
+            if 'clone_' + prop in vm_:  # if the property is set, use it for the VM request
                 postParams[prop] = vm_['clone_' + prop]
 
         node = query('post', 'nodes/{0}/qemu/{1}/clone'.format(vmhost, vm_['clone_from']), postParams)

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -685,7 +685,7 @@ def create_node(vm_, newid):
 
     log.debug('Preparing to generate a node using these parameters: {0} '.format(
               newnode))
-    if vm_['clone'] is and vm_['technology'] == 'qemu':
+    if vm_['clone'] is True and vm_['technology'] == 'qemu':
         postParams = {}
         postParams['newid'] = newnode['vmid']
 


### PR DESCRIPTION
We needed a way to clone VM on Proxmox.

Looking on the API (http://pve.proxmox.com/pve2-api-doc/), we found a way to clone.
You can now use 'qemu' as technology, it supports 'sata0', 'ide2', 'net0', and 'ostype'.

You can also clone an existing VM (or template) by providing 
'clone' : True
'clone_from' : VMID to clone

Optional for clone : 'clone_name', 'clone_description', 'clone_format' (raw, qcow2, vmdk), 'clone_full' (0 or 1 (linked clone or full clone))
