### PR TITLE
Revert "Use the generic `text` attribute, not .body of the handler"

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -599,19 +599,19 @@ class Client(object):
         try:
             query = salt.utils.http.query(
                 fixed_url,
-                stream=True,
+                text=True,
                 username=url_data.username,
                 password=url_data.password,
                 **get_kwargs
             )
-            if 'handle' not in query:
+            if 'text' not in query:
                 raise MinionError('Error: {0}'.format(query['error']))
             if no_cache:
-                return query['handle'].body
+                return query['text']
             else:
                 dest_tmp = "{0}.part".format(dest)
                 with salt.utils.fopen(dest_tmp, 'wb') as destfp:
-                    destfp.write(query['handle'].body)
+                    destfp.write(query['text'])
                 salt.utils.files.rename(dest_tmp, dest)
                 return dest
         except HTTPError as exc:

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -607,11 +607,11 @@ class Client(object):
             if 'handle' not in query:
                 raise MinionError('Error: {0}'.format(query['error']))
             if no_cache:
-                return query['text']
+                return query['handle'].body
             else:
                 dest_tmp = "{0}.part".format(dest)
                 with salt.utils.fopen(dest_tmp, 'wb') as destfp:
-                    destfp.write(query['text'])
+                    destfp.write(query['handle'].body)
                 salt.utils.files.rename(dest_tmp, dest)
                 return dest
         except HTTPError as exc:

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -304,7 +304,7 @@ def query(url,
 
         result_status_code = result.status_code
         result_headers = result.headers
-        result_text = result.text
+        result_text = result.content
         result_cookies = result.cookies
     elif backend == 'urllib2':
         request = urllib_request.Request(url_full, data)


### PR DESCRIPTION
This reverts commit b1bf79821d2d9ae3fb1a02abfa859445f335bb49.

Apparently this is a bigger mess than we thought :/ 
