### PR TITLE
win_firewall: Report correct result in test mode

### DIFF
--- a/salt/states/win_firewall.py
+++ b/salt/states/win_firewall.py
@@ -30,7 +30,7 @@ def disabled(name):
             break
 
     if __opts__['test']:
-        ret['result'] = None
+        ret['result'] = not action or None
         return ret
 
     # Disable it
@@ -61,7 +61,7 @@ def add_rule(name, localport, protocol="tcp", action="allow", dir="in"):
         ret['changes'] = {'new rule': name}
 
     if __opts__['test']:
-        ret['result'] = None
+        ret['result'] = not commit or None
         return ret
 
     # Add rule


### PR DESCRIPTION
win_firewall always returns `None` when run in test mode, rather than returning if a change would be made
