### PR TITLE
add option to allow slack returner to show changes

### DIFF
--- a/salt/returners/slack_returner.py
+++ b/salt/returners/slack_returner.py
@@ -14,6 +14,7 @@ The following fields can be set in the minion conf file::
     slack.as_user (required to see the profile picture of your bot)
     slack.profile (optional)
     slack.changes(optional, only show changes and failed states)
+    slack.yaml_format(optional, format the json in yaml format)
 
 
 Alternative configuration values can be used by prefacing the configuration.
@@ -76,6 +77,7 @@ To override individual configuration items, append --return_kwargs '{"key:": "va
 from __future__ import absolute_import
 
 # Import Python libs
+import yaml
 import pprint
 import logging
 import urllib
@@ -106,6 +108,7 @@ def _get_options(ret=None):
              'as_user': 'as_user',
              'api_key': 'api_key',
              'changes': 'changes',
+             'yaml_format': 'yaml_format',
              }
 
     profile_attr = 'slack_profile'
@@ -183,6 +186,7 @@ def returner(ret):
     as_user = _options.get('as_user')
     api_key = _options.get('api_key')
     changes = _options.get('changes')
+    yaml_format = _options.get('yaml_format')
 
     if not channel:
         log.error('slack.channel not defined in salt config')
@@ -201,8 +205,13 @@ def returner(ret):
         return
 
     returns = ret.get('return')
-    if changes:
+    if changes is True:
         returns = dict((key, value) for key, value in returns.items if value['result'] is not True or value['changes'])
+
+    if yaml_format is True:
+        returns = yaml.dump(returns)
+    else:
+        returns = pprint.pformat(returns)
 
     message = ('id: {0}\r\n'
                'function: {1}\r\n'
@@ -213,7 +222,7 @@ def returner(ret):
                     ret.get('fun'),
                     ret.get('fun_args'),
                     ret.get('jid'),
-                    pprint.pformat(returns)
+                    returns)
 
     slack = _post_message(channel,
                           message,


### PR DESCRIPTION
I don't need all the extra information in slack, I only need to know
what changes or what failed.
