### PR TITLE
Check if the remote exists before casting to a string.

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -1375,10 +1375,8 @@ def fetch(cwd,
     command.extend(
         [x for x in _format_opts(opts) if x not in ('-f', '--force')]
     )
-    if not isinstance(remote, six.string_types):
-        remote = str(remote)
     if remote:
-        command.append(remote)
+        command.append(str(remote))
     if refspecs is not None:
         if isinstance(refspecs, (list, tuple)):
             refspec_list = []


### PR DESCRIPTION
The bug before was if the origin wasn't specified None would be cast to a string-- which would then be interpreted as True-- which would end up trying to run `git fetch None` which doesn't work :)
