### PR TITLE
Make a copy of the merge argument in grains.filter_by

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -507,7 +507,7 @@ def filter_by(lookup_dict, grain='os_family', merge=None, default='default', bas
         if ret is None:
             ret = merge
         else:
-            salt.utils.dictupdate.update(ret, merge)
+            salt.utils.dictupdate.update(ret, copy.deepcopy(merge))
 
     return ret
 


### PR DESCRIPTION
Multiple calls of grains.filter_by in the same session might change
the merge argument, which is sometimes **pillar**, resulting in
incorrect context in map.jinja.

This change make a copy of the merge argument before passing it to
dictupdate.update.

Closes: #28127
