### PR TITLE
Changes required for creating a py.test salt plugin

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -10,14 +10,16 @@ import os
 import sys
 import time
 import hmac
+import base64
 import hashlib
 import logging
 import traceback
 import binascii
 import weakref
-from salt.ext.six.moves import zip  # pylint: disable=import-error,redefined-builtin
 
 # Import third party libs
+import salt.ext.six as six
+from salt.ext.six.moves import zip  # pylint: disable=import-error,redefined-builtin
 try:
     from Crypto.Cipher import AES, PKCS1_OAEP
     from Crypto.Hash import SHA
@@ -1113,7 +1115,10 @@ class Crypticle(object):
     @classmethod
     def generate_key_string(cls, key_size=192):
         key = os.urandom(key_size // 8 + cls.SIG_SIZE)
-        return key.encode('base64').replace('\n', '')
+        b64key = base64.b64encode(key)
+        if six.PY3:
+            b64key = b64key.decode('utf-8')
+        return b64key.replace('\n', '')
 
     @classmethod
     def extract_keys(cls, key_string, key_size):

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -44,6 +44,20 @@ log = logging.getLogger(__name__)
 SALT_BASE_PATH = os.path.abspath(os.path.dirname(salt.__file__))
 LOADED_BASE_NAME = 'salt.loaded'
 
+if six.PY3:
+    # pylint: disable=no-member,no-name-in-module,import-error
+    import importlib.machinery
+    SUFFIXES = []
+    for suffix in importlib.machinery.EXTENSION_SUFFIXES:
+        SUFFIXES.append((suffix, 'rb', 3))
+    for suffix in importlib.machinery.BYTECODE_SUFFIXES:
+        SUFFIXES.append((suffix, 'rb', 2))
+    for suffix in importlib.machinery.SOURCE_SUFFIXES:
+        SUFFIXES.append((suffix, 'r', 1))
+    # pylint: enable=no-member,no-name-in-module,import-error
+else:
+    SUFFIXES = imp.get_suffixes()
+
 # Because on the cloud drivers we do `from salt.cloud.libcloudfuncs import *`
 # which simplifies code readability, it adds some unsupported functions into
 # the driver's module scope.
@@ -969,7 +983,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         # map of suffix to description for imp
         self.suffix_map = {}
         suffix_order = []  # local list to determine precedence of extensions
-        for (suffix, mode, kind) in imp.get_suffixes():
+        for (suffix, mode, kind) in SUFFIXES:
             self.suffix_map[suffix] = (suffix, mode, kind)
             suffix_order.append(suffix)
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -714,7 +714,6 @@ class Minion(MinionBase):
         if not salt.utils.is_proxy():
             self.opts['grains'] = salt.loader.grains(opts)
 
-    # TODO: remove?
     def sync_connect_master(self, timeout=None):
         '''
         Block until we are connected to a master

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -42,6 +42,7 @@ import tornado.gen
 import tornado.concurrent
 
 # Import third party libs
+import salt.ext.six as six
 from Crypto.Cipher import PKCS1_OAEP
 
 log = logging.getLogger(__name__)
@@ -243,7 +244,7 @@ class AsyncZeroMQPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.t
             zmq.eventloop.ioloop.install()
             self.io_loop = tornado.ioloop.IOLoop.current()
 
-        self.hexid = hashlib.sha1(self.opts['id']).hexdigest()
+        self.hexid = hashlib.sha1(six.b(self.opts['id'])).hexdigest()
 
         self.auth = salt.crypt.AsyncAuth(self.opts, io_loop=self.io_loop)
 

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -305,6 +305,7 @@ class ProcessManager(object):
                                           'args': args,
                                           'kwargs': kwargs,
                                           'Process': process}
+        return process
 
     def restart_process(self, pid):
         '''


### PR DESCRIPTION
- Allow providing a timeout to the minion's `sync_connect_master()` function
- Return the process instance after adding it to the process manager
