### PR TITLE
Set a fallback HWM

### DIFF
--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -297,10 +297,10 @@ class SaltEvent(object):
         '''
         self.sub = self.context.socket(zmq.SUB)
         try:
-            self.sub.setsockopt(zmq.HWM, self.opts.get('salt_event_pub_hwm'))
+            self.sub.setsockopt(zmq.HWM, self.opts.get('salt_event_pub_hwm', 0))
         except AttributeError:
-            self.sub.setsockopt(zmq.SNDHWM, self.opts.get('salt_event_pub_hwm'))
-            self.sub.setsockopt(zmq.RCVHWM, self.opts.get('salt_event_pub_hwm'))
+            self.sub.setsockopt(zmq.SNDHWM, self.opts.get('salt_event_pub_hwm', 0))
+            self.sub.setsockopt(zmq.RCVHWM, self.opts.get('salt_event_pub_hwm', 0))
         self.sub.connect(self.puburi)
         self.poller.register(self.sub, zmq.POLLIN)
         self.sub.setsockopt_string(zmq.SUBSCRIBE, u'')
@@ -877,10 +877,10 @@ class EventPublisher(multiprocessing.Process):
         # Prepare the master event publisher
         self.epub_sock = self.context.socket(zmq.PUB)
         try:
-            self.epub_sock.setsockopt(zmq.HWM, self.opts.get('event_publisher_pub_hwm'))
+            self.epub_sock.setsockopt(zmq.HWM, self.opts.get('event_publisher_pub_hwm', 0))
         except AttributeError:
-            self.epub_sock.setsockopt(zmq.SNDHWM, self.opts.get('event_publisher_pub_hwm'))
-            self.epub_sock.setsockopt(zmq.RCVHWM, self.opts.get('event_publisher_pub_hwm'))
+            self.epub_sock.setsockopt(zmq.SNDHWM, self.opts.get('event_publisher_pub_hwm', 0))
+            self.epub_sock.setsockopt(zmq.RCVHWM, self.opts.get('event_publisher_pub_hwm', 0))
         # Prepare master event pull socket
         self.epull_sock = self.context.socket(zmq.PULL)
         if self.opts.get('ipc_mode', '') == 'tcp':


### PR DESCRIPTION
This mostly happens in the test suite when opts are setup by hand, but a safe default is a good idea regardless.
