### PR TITLE
fix unicode pillar values #3436

### DIFF
--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -290,6 +290,20 @@ def _get_jinja_error(trace, context=None):
     return line, out
 
 
+def _decode_recursively(object_):
+    if isinstance(object_, list):
+        return [_decode_recursively(o) for o in object_]
+    if isinstance(object_, tuple):
+        return tuple([_decode_recursively(o) for o in object_])
+    if isinstance(object_, dict):
+        return dict([(_decode_recursively(key), _decode_recursively(value))
+                     for key, value in six.iteritems(object_)])
+    elif isinstance(object_, string_types):
+        return salt.utils.locales.sdecode(object_)
+    else:
+        return object_
+
+
 def render_jinja_tmpl(tmplstr, context, tmplpath=None):
     opts = context['opts']
     saltenv = context['saltenv']
@@ -354,13 +368,7 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
 
     jinja_env.tests['list'] = salt.utils.is_list
 
-    decoded_context = {}
-    for key, value in six.iteritems(context):
-        if not isinstance(value, string_types):
-            decoded_context[key] = value
-            continue
-
-        decoded_context[key] = salt.utils.locales.sdecode(value)
+    decoded_context = _decode_recursively(context)
 
     try:
         template = jinja_env.from_string(tmplstr)


### PR DESCRIPTION
Only string values of the context were being decoded.

But 'pillar' is just a key in the context, with the pillar dictionary (possibly nested) as the value.

I've changed it so the decoding is done recursively, following dictionaries, tuples and lists.
