### PR TITLE
[2015.8] Only expand nodegroups to lists if there is a nested nodegroup

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -103,6 +103,10 @@ def get_minion_data(minion, opts):
 def nodegroup_comp(nodegroup, nodegroups, skip=None, first_call=True):
     '''
     Recursively expand ``nodegroup`` from ``nodegroups``; ignore nodegroups in ``skip``
+
+    If a top-level (non-recursive) call finds no nodegroups, return the original
+    nodegroup definition (for backwards compatibility). Keep track of recursive
+    calls via `first_call` argument
     '''
     expanded_nodegroup = False
     if skip is None:

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -100,7 +100,7 @@ def get_minion_data(minion, opts):
     return minion if minion else None, None, None
 
 
-def nodegroup_comp(nodegroup, nodegroups, skip=None):
+def nodegroup_comp(nodegroup, nodegroups, skip=None, first_call=True):
     '''
     Recursively expand ``nodegroup`` from ``nodegroups``; ignore nodegroups in ``skip``
     '''
@@ -135,7 +135,7 @@ def nodegroup_comp(nodegroup, nodegroups, skip=None):
             ret.append(word)
         elif len(word) >= 3 and word.startswith('N@'):
             expanded_nodegroup = True
-            ret.extend(nodegroup_comp(word[2:], nodegroups, skip=skip))
+            ret.extend(nodegroup_comp(word[2:], nodegroups, skip=skip, first_call=False))
         else:
             ret.append(word)
 
@@ -148,9 +148,12 @@ def nodegroup_comp(nodegroup, nodegroups, skip=None):
     log.debug('nodegroup_comp({0}) => {1}'.format(nodegroup, ret))
     # Only return list form if a nodegroup was expanded. Otherwise return
     # the original string to conserve backwards compat
-    if expanded_nodegroup:
+    if expanded_nodegroup or not first_call:
         return ret
     else:
+        log.debug('No nested nodegroups detected. '
+                  'Using original nodegroup definition: {0}'
+                  .format(nodegroups[nodegroup]))
         return nodegroups[nodegroup]
 
 

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -147,7 +147,7 @@ def nodegroup_comp(nodegroup, nodegroups, skip=None):
 
     log.debug('nodegroup_comp({0}) => {1}'.format(nodegroup, ret))
     # Only return list form if a nodegroup was expanded. Otherwise return
-    # the original string to conserve 
+    # the original string to conserve backwards compat
     if expanded_nodegroup:
         return ret
     else:

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -104,7 +104,7 @@ def nodegroup_comp(nodegroup, nodegroups, skip=None):
     '''
     Recursively expand ``nodegroup`` from ``nodegroups``; ignore nodegroups in ``skip``
     '''
-
+    expanded_nodegroup = False
     if skip is None:
         skip = set()
     elif nodegroup in skip:
@@ -134,6 +134,7 @@ def nodegroup_comp(nodegroup, nodegroups, skip=None):
         if word in opers:
             ret.append(word)
         elif len(word) >= 3 and word.startswith('N@'):
+            expanded_nodegroup = True
             ret.extend(nodegroup_comp(word[2:], nodegroups, skip=skip))
         else:
             ret.append(word)
@@ -145,7 +146,12 @@ def nodegroup_comp(nodegroup, nodegroups, skip=None):
     skip.remove(nodegroup)
 
     log.debug('nodegroup_comp({0}) => {1}'.format(nodegroup, ret))
-    return ret
+    # Only return list form if a nodegroup was expanded. Otherwise return
+    # the original string to conserve 
+    if expanded_nodegroup:
+        return ret
+    else:
+        return nodegroups[nodegroup]
 
 
 class CkMinions(object):


### PR DESCRIPTION
Fixes #24660 
Fixes #26107

By keeping nodegroup matches as strings if there are no nested nodegroups, we can continue to communicate with 2015.5 and 2014.7 minions via nodegroup matches.

@plastikos FYI
