### PR TITLE
Add `defaults` and `context` parameters to cmd.script state

### DIFF
--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -1017,12 +1017,21 @@ def script(name,
                           'documentation.')
         return ret
 
-    if HAS_GRP:
-        pgid = os.getegid()
+    if context and not isinstance(context, dict):
+        ret['comment'] = ('Invalidly-formatted \'context\' parameter. Must '
+                          'be formed as a dict.')
+        return ret
+    if defaults and not isinstance(defaults, dict):
+        ret['comment'] = ('Invalidly-formatted \'defaults\' parameter. Must '
+                          'be formed as a dict.')
+        return ret
 
     tmpctx = defaults if defaults else {}
     if context:
         tmpctx.update(context)
+
+    if HAS_GRP:
+        pgid = os.getegid()
 
     cmd_kwargs = copy.deepcopy(kwargs)
     cmd_kwargs.update({'runas': user,

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -865,6 +865,8 @@ def script(name,
            timeout=None,
            use_vt=False,
            output_loglevel='debug',
+           defaults=None,
+           context=None,
            **kwargs):
     '''
     Download a script and execute it with specified arguments.
@@ -972,6 +974,16 @@ def script(name,
         interactively to the console and the logs.
         This is experimental.
 
+    context
+        .. version_added:: Boron
+
+        Overrides default context variables passed to the template.
+
+    defaults
+        .. version_added:: Boron
+
+        Default context passed to the template.
+
     output_loglevel
         Control the loglevel at which the output from the command is logged.
         Note that the command being run will still be logged (loglevel: DEBUG)
@@ -1008,6 +1020,10 @@ def script(name,
     if HAS_GRP:
         pgid = os.getegid()
 
+    tmpctx = defaults if defaults else {}
+    if context:
+        tmpctx.update(context)
+
     cmd_kwargs = copy.deepcopy(kwargs)
     cmd_kwargs.update({'runas': user,
                        'shell': shell or __grains__['shell'],
@@ -1022,6 +1038,7 @@ def script(name,
                        'timeout': timeout,
                        'output_loglevel': output_loglevel,
                        'use_vt': use_vt,
+                       'context': tmpctx,
                        'saltenv': __env__})
 
     run_check_cmd_kwargs = {


### PR DESCRIPTION
This PR adds support for `defaults` and `context` parameters in the `cmd.script` state. The implementation is intended to work exactly as the same-named parameters in various `file` states.

Fixes #9153 
