### PR TITLE
file.serialize needs to add a final newline to serialized files

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -4310,6 +4310,8 @@ def serialize(name,
                 'result': False
                 }
 
+    contents += '\n'
+
     if __opts__['test']:
         ret['changes'] = __salt__['file.check_managed_changes'](
             name=name,

--- a/tests/unit/states/file_test.py
+++ b/tests/unit/states/file_test.py
@@ -63,7 +63,7 @@ class TestFileState(TestCase):
         self.assertEqual(json.loads(returner.returned), dataset)
 
         filestate.serialize('/tmp', dataset, formatter="python")
-        self.assertEqual(returner.returned, pprint.pformat(dataset))
+        self.assertEqual(returner.returned, pprint.pformat(dataset) + '\n')
 
     def test_contents_and_contents_pillar(self):
         def returner(contents, *args, **kwargs):


### PR DESCRIPTION
It's only proper and nice to do. 
It shouldn't have any impact other than `cat` playing nice ;)
