### PR TITLE
Fixes #19673

### DIFF
--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -470,7 +470,7 @@ def mkpart(device, part_type, fs_type=None, start=None, end=None):
     '''
     _validate_device(device)
 
-    if not start or not end:
+    if start in [None, ''] or end in [None, '']:
         raise CommandExecutionError(
             'partition.mkpart requires a start and an end'
         )


### PR DESCRIPTION
It was checking if start or end was False. None, 0, and '' evaluate to False so
0 was being evaluated as an invalid parameter for start and end. Changed it to
specifically check for None and ''. 0 is a valid value for start and end.

Fixes #19673
