### PR TITLE
Some fixes for nova driver for Rackspace

### DIFF
--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -645,7 +645,7 @@ def create(vm_):
             return
 
         rackconnectv3 = config.get_cloud_config_value(
-            'rackconnectv3', vm_, __opts__, default='False',
+            'rackconnectv3', vm_, __opts__, default=False,
             search_global=False
         )
 
@@ -721,19 +721,27 @@ def create(vm_):
             data.public_ips = access_ip
             return data
 
+        # populate return data with private_ips
+        # when ssh_interface is set to private_ips and public_ips exist
+        if not result and ssh_interface(vm_) == 'private_ips':
+            for private_ip in private:
+                ignore_ip = ignore_cidr(vm_, private_ip)
+                if private_ip not in data.private_ips and not ignore_ip:
+                    result.append(private_ip)
+
         if cloudnetwork(vm_) is True:
             data.public_ips = access_ip
             return data
+
+        if public:
+            data.public_ips = public
+            if ssh_interface(vm_) != 'private_ips':
+                return data
 
         if result:
             log.debug('result = {0}'.format(result))
             data.private_ips = result
             if ssh_interface(vm_) == 'private_ips':
-                return data
-
-        if public:
-            data.public_ips = public
-            if ssh_interface(vm_) != 'private_ips':
                 return data
 
     try:

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -681,17 +681,20 @@ class SaltNova(OpenStackComputeShell):
         nt_ks = self.compute_conn
         ret = {}
         for item in nt_ks.servers.list():
-            ret[item.name] = {
-                'id': item.id,
-                'name': item.name,
-                'state': item.status,
-                'accessIPv4': item.accessIPv4,
-                'accessIPv6': item.accessIPv6,
-                'flavor': {'id': item.flavor['id'],
-                           'links': item.flavor['links']},
-                'image': {'id': item.image['id'],
-                          'links': item.image['links']},
-                }
+            try:
+                ret[item.name] = {
+                    'id': item.id,
+                    'name': item.name,
+                    'state': item.status,
+                    'accessIPv4': item.accessIPv4,
+                    'accessIPv6': item.accessIPv6,
+                    'flavor': {'id': item.flavor['id'],
+                               'links': item.flavor['links']},
+                    'image': {'id': item.image['id'],
+                              'links': item.image['links']},
+                    }
+            except TypeError:
+                pass
         return ret
 
     def server_list_detailed(self):
@@ -701,28 +704,31 @@ class SaltNova(OpenStackComputeShell):
         nt_ks = self.compute_conn
         ret = {}
         for item in nt_ks.servers.list():
-            ret[item.name] = {
-                'OS-EXT-SRV-ATTR': {},
-                'OS-EXT-STS': {},
-                'accessIPv4': item.accessIPv4,
-                'accessIPv6': item.accessIPv6,
-                'addresses': item.addresses,
-                'created': item.created,
-                'flavor': {'id': item.flavor['id'],
-                           'links': item.flavor['links']},
-                'hostId': item.hostId,
-                'id': item.id,
-                'image': {'id': item.image['id'],
-                          'links': item.image['links']},
-                'key_name': item.key_name,
-                'links': item.links,
-                'metadata': item.metadata,
-                'name': item.name,
-                'state': item.status,
-                'tenant_id': item.tenant_id,
-                'updated': item.updated,
-                'user_id': item.user_id,
-            }
+            try:
+                ret[item.name] = {
+                    'OS-EXT-SRV-ATTR': {},
+                    'OS-EXT-STS': {},
+                    'accessIPv4': item.accessIPv4,
+                    'accessIPv6': item.accessIPv6,
+                    'addresses': item.addresses,
+                    'created': item.created,
+                    'flavor': {'id': item.flavor['id'],
+                               'links': item.flavor['links']},
+                    'hostId': item.hostId,
+                    'id': item.id,
+                    'image': {'id': item.image['id'],
+                              'links': item.image['links']},
+                    'key_name': item.key_name,
+                    'links': item.links,
+                    'metadata': item.metadata,
+                    'name': item.name,
+                    'state': item.status,
+                    'tenant_id': item.tenant_id,
+                    'updated': item.updated,
+                    'user_id': item.user_id,
+                }
+            except TypeError:
+                continue
 
             ret[item.name]['progress'] = getattr(item, 'progress', '0')
 


### PR DESCRIPTION
This PR fixes a typo (which causes a logic issue later) in commit b7f8487, that commit also adds in some logic from the openstack driver I committed many moons ago.  Also, preserve the public_ips for final output, instead of returning early if `ssh_interface(_vm) == 'private_ips'`.

The second commit adds some error handling for servers returned by the novaclient driver that are missing details, due to in-flight deletion or otherwise broken metadata.

I PR'd this against 2015.8 because the # of changes compared to 2015.5 was quite a bit higher, and I didn't think it'd merge very cleanly.
