### PR TITLE
Fix issue with event.send in salt-call

### DIFF
--- a/salt/modules/event.py
+++ b/salt/modules/event.py
@@ -51,9 +51,7 @@ def fire_master(data, tag, preload=None):
             pass
         return True
 
-    if preload:
-        # If preload is specified, we must send a raw event (this is
-        # slower because it has to independently authenticate)
+    elif preload:
         load = preload
         auth = salt.crypt.SAuth(__opts__)
         load.update({'id': __opts__['id'],
@@ -69,16 +67,12 @@ def fire_master(data, tag, preload=None):
             pass
         return True
     else:
-        # Usually, we can send the event via the minion, which is faster
-        # because it is already authenticated
+        channel = salt.transport.Channel.factory(__opts__)
         try:
-            return salt.utils.event.MinionEvent(__opts__).fire_event(
-                {'data': data, 'tag': tag, 'events': None, 'pretag': None}, 'fire_master')
+            channel.send(load)
         except Exception:
-            exc_type, exc_value, exc_traceback = sys.exc_info()
-            lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
-            log.debug(lines)
-            return False
+            pass
+        return True
 
 
 def fire(data, tag):


### PR DESCRIPTION
This resolves an issue wherein running salt-call without a minion running
could not send custom events.

Ideally, the solution would be to detect whether or not a minion is running
and then determine whether to route the event through the running minion or
whether to stand up a new channel. However, I don't think this makes much of
a true difference in performance, unless sreq caching kicks in. Until we can
reliably detect a running minion from salt-call's perspective, though, this
may have to suffice. Any ideas about how to attack this a different way would
certainly be welcome.

Closes #26411
