### PR TITLE
philips_hue fails during unit tests.

### DIFF
--- a/salt/modules/philips_hue.py
+++ b/salt/modules/philips_hue.py
@@ -29,13 +29,16 @@ def _proxy():
     '''
     Get proxy.
     '''
-    return __opts__['proxymodule']
+    return __opts__.get('proxymodule')
 
 
 def __virtual__():
     '''
     Start the Philips HUE only for proxies.
     '''
+
+    if not _proxy():
+        return False
 
     def _mkf(cmd_name, doc):
         def _cmd(*args, **kw):


### PR DESCRIPTION
It appears that it cannot index 'proxymodule' and doesn't properly handle the
exception.  This may not be the best way, but it will properly skip
initialization if settings are unavailable.
