### PR TITLE
Fix 26898

### DIFF
--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -40,6 +40,7 @@ try:
     import win32api
     import win32file
     import win32security
+    import win32con
     from pywintypes import error as pywinerror
     HAS_WINDOWS_MODULES = True
 except ImportError:
@@ -49,7 +50,7 @@ except ImportError:
 import salt.utils
 from salt.modules.file import (check_hash,  # pylint: disable=W0611
         directory_exists, get_managed, mkdir, makedirs_, makedirs_perms,
-        check_managed, check_managed_changes, check_perms, remove, source_list,
+        check_managed, check_managed_changes, check_perms, source_list,
         touch, append, contains, contains_regex, contains_regex_multiline,
         contains_glob, find, psed, get_sum, _get_bkroot, _mkstemp_copy,
         get_hash, manage_file, file_exists, get_diff, list_backups,
@@ -76,7 +77,7 @@ def __virtual__():
             global check_perms, get_managed, makedirs_perms, manage_file
             global source_list, mkdir, __clean_tmp, makedirs_, file_exists
             global check_managed, check_managed_changes, check_file_meta
-            global remove, append, _error, directory_exists, touch, contains
+            global append, _error, directory_exists, touch, contains
             global contains_regex, contains_regex_multiline, contains_glob
             global find, psed, get_sum, check_hash, get_hash, delete_backup
             global get_diff, _get_flags, extract_hash, comment_line
@@ -95,7 +96,6 @@ def __virtual__():
             restore_backup = _namespaced_function(restore_backup, globals())
             delete_backup = _namespaced_function(delete_backup, globals())
             extract_hash = _namespaced_function(extract_hash, globals())
-            remove = _namespaced_function(remove, globals())
             append = _namespaced_function(append, globals())
             check_perms = _namespaced_function(check_perms, globals())
             get_managed = _namespaced_function(get_managed, globals())
@@ -1033,6 +1033,58 @@ def set_mode(path, mode):
                  'always None.'.format(func_name))
 
     return get_mode(path)
+
+
+def remove(path, force=False):
+    '''
+    Remove the named file or directory
+
+    :param str path: The path to the file or directory to remove.
+
+    :param bool force: Remove even if marked Read-Only
+
+    :return: True if successful, False if unsuccessful
+    :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' file.remove C:\\Temp
+    '''
+    # This must be a recursive function in windows to properly deal with
+    # Symlinks. The shutil.rmtree function will remove the contents of
+    # the Symlink source in windows.
+    path = os.path.expanduser(path)
+
+    if not os.path.isabs(path):
+        raise SaltInvocationError('File path must be absolute.')
+
+    # Remove ReadOnly Attribute
+    if force:
+        win32api.SetFileAttributes(path, win32con.FILE_ATTRIBUTE_NORMAL)
+
+    try:
+        if os.path.isfile(path):
+            # A file and a symlinked file are removed the same way
+            os.remove(path)
+        elif is_link(path):
+            # If it's a symlink directory, use the rmdir command
+            os.rmdir(path)
+        else:
+            for name in os.listdir(path):
+                item = '{0}\\{1}'.format(path, name)
+                # If it's a normal directory, recurse to remove it's contents
+                remove(item)
+
+            # rmdir will work now because the directory is empty
+            os.rmdir(path)
+    except (OSError, IOError) as exc:
+        raise CommandExecutionError(
+            'Could not remove {0!r}: {1}'.format(path, exc)
+        )
+
+    return True
 
 
 def symlink(src, link):

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -427,7 +427,7 @@ def _clean_dir(root, keep, exclude_pat):
                 try:
                     os.remove(nfn)
                 except OSError:
-                    shutil.rmtree(nfn)
+                    __salt__['file.remove'](nfn)
 
     for roots, dirs, files in os.walk(root):
         for name in itertools.chain(dirs, files):
@@ -929,10 +929,10 @@ def symlink(
                     return _error(ret, ((
                                             'File exists where the backup target {0} should go'
                                         ).format(backupname)))
-                elif os.path.isfile(backupname):
-                    os.remove(backupname)
-                elif os.path.isdir(backupname):
-                    shutil.rmtree(backupname)
+                elif os.path.isfile(backupname)\
+                        or __salt__['file.is_link'](backupname)\
+                        or os.path.isdir(backupname):
+                    __salt__['file.remove'](backupname)
                 else:
                     return _error(ret, ((
                                             'Something exists where the backup target {0}'
@@ -941,11 +941,11 @@ def symlink(
             os.rename(name, backupname)
         elif force:
             # Remove whatever is in the way
-            if os.path.isfile(name):
-                os.remove(name)
+            if __salt__['file.is_link'](name):
+                __salt__['file.remove'](name)
                 ret['changes']['forced'] = 'Symlink was forcibly replaced'
             else:
-                shutil.rmtree(name)
+                __salt__['file.remove'](name)
         else:
             # Otherwise throw an error
             if os.path.isfile(name):
@@ -1021,7 +1021,7 @@ def absent(name):
             ret['comment'] = 'Directory {0} is set for removal'.format(name)
             return ret
         try:
-            shutil.rmtree(name)
+            __salt__['file.remove'](name)
             ret['comment'] = 'Removed directory {0}'.format(name)
             ret['changes']['removed'] = name
             return ret
@@ -1781,12 +1781,12 @@ def directory(name,
                     return _error(ret, ((
                                             'File exists where the backup target {0} should go'
                                         ).format(backupname)))
-                elif os.path.isfile(backupname):
-                    os.remove(backupname)
-                elif os.path.islink(backupname):
-                    os.remove(backupname)
-                elif os.path.isdir(backupname):
-                    shutil.rmtree(backupname)
+
+                elif os.path.isfile(backupname) \
+                        or __salt__['file.is_link'](backupname) \
+                        or os.path.isdir(backupname):
+                    __salt__['file.remove'](backupname)
+
                 else:
                     return _error(ret, ((
                                             'Something exists where the backup target {0}'
@@ -1798,11 +1798,11 @@ def directory(name,
             if os.path.isfile(name):
                 os.remove(name)
                 ret['changes']['forced'] = 'File was forcibly replaced'
-            elif os.path.islink(name):
-                os.remove(name)
+            elif __salt__['file.is_link'](name):
+                __salt__['file.remove'](name)
                 ret['changes']['forced'] = 'Symlink was forcibly replaced'
             else:
-                shutil.rmtree(name)
+                __salt__['file.remove'](name)
         else:
             if os.path.isfile(name):
                 return _error(
@@ -2227,7 +2227,7 @@ def recurse(name,
                 merge_ret(path, _ret)
                 return
             else:
-                shutil.rmtree(path)
+                __salt__['file.remove'](path)
                 _ret['changes'] = {'diff': 'Replaced directory with a '
                                            'new file'}
                 merge_ret(path, _ret)
@@ -3646,12 +3646,7 @@ def copy(
         elif not __opts__['test'] and changed:
             # Remove the destination to prevent problems later
             try:
-                if os.path.islink(name):
-                    os.unlink(name)
-                elif os.path.isfile(name):
-                    os.remove(name)
-                else:
-                    shutil.rmtree(name)
+                __salt__['file.remove'](name)
             except (IOError, OSError):
                 return _error(
                     ret,
@@ -3751,12 +3746,7 @@ def rename(name, source, force=False, makedirs=False):
         elif not __opts__['test']:
             # Remove the destination to prevent problems later
             try:
-                if os.path.islink(name):
-                    os.unlink(name)
-                elif os.path.isfile(name):
-                    os.remove(name)
-                else:
-                    shutil.rmtree(name)
+                __salt__['file.remove'](name)
             except (IOError, OSError):
                 return _error(
                     ret,

--- a/tests/unit/states/file_test.py
+++ b/tests/unit/states/file_test.py
@@ -621,7 +621,7 @@ class FileTestCase(TestCase):
                                                          False])):
                     with patch.object(os.path, 'lexists', mock_t):
                         with patch.object(filestate.__salt__,
-                                          {'file.is_link', mock_f}):
+                                          {'file.is_link': mock_f}):
                             with patch.object(os.path, 'isdir', mock_f):
                                 comt = ('File exists where the backup target'
                                         ' A should go')
@@ -1376,7 +1376,7 @@ class FileTestCase(TestCase):
                     comt = ('Failed to delete "{0}" in preparation for '
                             'forced move'.format(name))
                     with patch.object(filestate.__salt__,
-                                      {'file.remove', mock_f},
+                                      {'file.remove': mock_f},
                                       MagicMock(side_effect=[IOError, True])):
                         ret.update({'comment': comt, 'result': False})
                         self.assertDictEqual(filestate.rename(name, source,


### PR DESCRIPTION
## Please test on linux

Fixes #26898
Fix file.remove for windows …
The linux version used shutil.rmtree to remove directories. When this hits a
symlink directory in Windows, it removes actual files from the Source.

Created a recursive function to detect symlinks and remove them correctly in
Windows.

Replaced instances of shutil.rmtree in file state with `__salt__['file.remove']`
