### PR TITLE
Fix for ext_pillar being compiled twice in legacy git_pillar code (2015.5 branch)

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -322,4 +322,4 @@ def ext_pillar(minion_id,
 
     pil = Pillar(opts, __grains__, minion_id, branch)
 
-    return pil.compile_pillar()
+    return pil.compile_pillar(ext=False)

--- a/tests/integration/modules/pillar.py
+++ b/tests/integration/modules/pillar.py
@@ -114,20 +114,6 @@ class PillarModuleTest(integration.ModuleCase):
 
         self.assertEqual(grepo.rp_location, repo.remotes.origin.url)
 
-    @skipIf(HAS_GIT_PYTHON is False,
-            'GitPython must be installed and >= version {0}'.format(GIT_PYTHON))
-    def test_ext_pillar_env_mapping(self):
-        import os
-        from salt.pillar import git_pillar
-
-        repo_url = 'https://github.com/saltstack/pillar1.git'
-        pillar = self.run_function('pillar.data')
-
-        for branch, env in [('dev', 'testing')]:
-            repo = git_pillar.GitPillar(branch, repo_url, self.master_opts)
-
-            self.assertIn(repo.working_dir,
-                    pillar['test_ext_pillar_opts']['pillar_roots'][env])
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
This is #28210, opened against the 2015.5 branch. This will conflict
when merged forward (into 2015.8) because of the git_pillar rewrite, and
the 2015.8 side of the conflict should be kept in all conflicts.
