### PR TITLE
If record returned None, don't continue with the state. Something went wrong

### DIFF
--- a/salt/states/boto_route53.py
+++ b/salt/states/boto_route53.py
@@ -134,6 +134,11 @@ def present(
     record = __salt__['boto_route53.get_record'](name, zone, record_type,
                                                  False, region, key, keyid,
                                                  profile)
+    if record is None:
+        ret['comment'] = 'Error: Something went wrong getting the record. ' \
+                         'Please check your credentials.'
+        ret['result'] = False
+        return ret
 
     if isinstance(record, dict) and not record:
         if __opts__['test']:


### PR DESCRIPTION
When this happens, something went wrong but no errors were thrown. In 2015.8 a SaltInvocationError gets thrown, but this has been heavily refactored to use `salt.utils.boto.py`, which doesn't exist on 2015.5.

Fixes #27374
