### PR TITLE
Don't stacktrace if invalid credentials are passed to boto_route53 state

### DIFF
--- a/salt/states/boto_route53.py
+++ b/salt/states/boto_route53.py
@@ -71,8 +71,12 @@ passed in as a dict, or as a string to pull from pillars or minion config:
                 key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
 '''
 
+# Import Python Libs
+from __future__ import absolute_import
+
 # Import Salt Libs
 from salt.utils import SaltInvocationError
+
 
 def __virtual__():
     '''

--- a/salt/states/boto_route53.py
+++ b/salt/states/boto_route53.py
@@ -71,6 +71,8 @@ passed in as a dict, or as a string to pull from pillars or minion config:
                 key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
 '''
 
+# Import Salt Libs
+from salt.utils import SaltInvocationError
 
 def __virtual__():
     '''
@@ -144,10 +146,15 @@ def present(
     if isinstance(value, list):
         value = ','.join(value)
 
-    record = __salt__['boto_route53.get_record'](name, zone, record_type,
-                                                 False, region, key, keyid,
-                                                 profile, split_dns,
-                                                 private_zone)
+    try:
+        record = __salt__['boto_route53.get_record'](name, zone, record_type,
+                                                     False, region, key, keyid,
+                                                     profile, split_dns,
+                                                     private_zone)
+    except SaltInvocationError as err:
+        ret['comment'] = 'Error: {0}'.format(err)
+        ret['result'] = False
+        return ret
 
     if isinstance(record, dict) and not record:
         if __opts__['test']:


### PR DESCRIPTION
Refs #27374 and #28213.

This cleans up the stacktrace thrown by `salt.utils.boto.py` when invalid credentials are passed to the boto state. Instead of this:

```
local:
----------
          ID: dns-record
    Function: boto_route53.present
        Name: rallytime.example.com.
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/root/SaltStack/salt/salt/state.py", line 1592, in call
                  **cdata['kwargs'])
                File "/root/SaltStack/salt/salt/loader.py", line 1494, in wrapper
                  return f(*args, **kwargs)
                File "/root/SaltStack/salt/salt/states/boto_route53.py", line 150, in present
                  private_zone)
                File "/root/SaltStack/salt/salt/modules/boto_route53.py", line 190, in get_record
                  conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
                File "/root/SaltStack/salt/salt/utils/boto.py", line 206, in get_connection
                  'region "{1}".'.format(service, region))
              SaltInvocationError: No authentication credentials found when attempting to make boto route53 connection to region "us-east-1".
     Started: 17:27:00.114536
    Duration: 1005.694 ms
     Changes:

Summary for local
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:   1.006 s
```

We get this:

```
local:
----------
          ID: dns-record
    Function: boto_route53.present
        Name: rallytime.example.com.
      Result: False
     Comment: Error: No authentication credentials found when attempting to make boto route53 connection to region "us-east-1".
     Started: 16:59:34.908723
    Duration: 1005.152 ms
     Changes:
Summary for local
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:   1.005 s
```

@basepi This file will probably conflict on the merge-forward from 2015.5. Please take the 2015.8 version  (this one).
