### PR TITLE
Improvement module package collision

### DIFF
--- a/tests/integration/loader/loader.py
+++ b/tests/integration/loader/loader.py
@@ -435,6 +435,94 @@ class LazyLoaderSubmodReloadingTest(TestCase):
         self.assertNotIn(self.module_key, self.loader)
 
 
+mod_template = '''
+def test():
+    return ({val})
+'''
+
+
+class LazyLoaderModulePackageTest(TestCase):
+    '''
+    Test the loader of salt with changing modules
+    '''
+    module_name = 'loadertestmodpkg'
+    module_key = 'loadertestmodpkg.test'
+
+    def setUp(self):
+        self.opts = _config = minion_config(None)
+        self.opts['grains'] = grains(self.opts)
+        self.tmp_dir = tempfile.mkdtemp(dir=tests.integration.TMP)
+
+        dirs = _module_dirs(self.opts, 'modules', 'module')
+        dirs.append(self.tmp_dir)
+        self.loader = LazyLoader(dirs,
+                                 self.opts,
+                                 tag='module')
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir)
+
+    def update_pyfile(self, pyfile, contents):
+        dirname = os.path.dirname(pyfile)
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
+        with open(pyfile, 'wb') as fh:
+            fh.write(contents)
+            fh.flush()
+            os.fsync(fh.fileno())  # flush to disk
+
+        # pyc files don't like it when we change the original quickly
+        # since the header bytes only contain the timestamp (granularity of seconds)
+        # TODO: don't write them? Is *much* slower on re-load (~3x)
+        # https://docs.python.org/2/library/sys.html#sys.dont_write_bytecode
+        try:
+            os.unlink(pyfile + 'c')
+        except OSError:
+            pass
+
+    def rm_pyfile(self, pyfile):
+        os.unlink(pyfile)
+        os.unlink(pyfile + 'c')
+
+    def update_module(self, relative_path, contents):
+        self.update_pyfile(os.path.join(self.tmp_dir, relative_path), contents)
+
+    def rm_module(self, relative_path):
+        self.rm_pyfile(os.path.join(self.tmp_dir, relative_path))
+
+    def test_module(self):
+        # ensure it doesn't exist
+        self.assertNotIn('foo', self.loader)
+        self.assertNotIn('foo.test', self.loader)
+        self.update_module('foo.py', mod_template.format(val=1))
+        self.loader.clear()
+        self.assertIn('foo.test', self.loader)
+        self.assertEqual(self.loader['foo.test'](), 1)
+
+    def test_package(self):
+        # ensure it doesn't exist
+        self.assertNotIn('foo', self.loader)
+        self.assertNotIn('foo.test', self.loader)
+        self.update_module('foo/__init__.py', mod_template.format(val=2))
+        self.loader.clear()
+        self.assertIn('foo.test', self.loader)
+        self.assertEqual(self.loader['foo.test'](), 2)
+
+    def test_module_package_collision(self):
+        # ensure it doesn't exist
+        self.assertNotIn('foo', self.loader)
+        self.assertNotIn('foo.test', self.loader)
+        self.update_module('foo.py', mod_template.format(val=3))
+        self.loader.clear()
+        self.assertIn('foo.test', self.loader)
+        self.assertEqual(self.loader['foo.test'](), 3)
+
+        self.update_module('foo/__init__.py', mod_template.format(val=4))
+        self.loader.clear()
+        self.assertIn('foo.test', self.loader)
+        self.assertEqual(self.loader['foo.test'](), 4)
+
+
 deep_init_base = '''
 import top_lib
 import top_lib.mid_lib


### PR DESCRIPTION
There was an exception in the loader with the following layout:

  foo.py
  foo/**init**.py

It appears this was fixed yesterday (or the day before) before I submitted this.  I'm still submitting this for these reasons:
- this adds a unit test for this case (ensures that foo/**init**.py has priority)
- this removes cruft code with `sub_path`
- this (IMHO) has a cleaner logic flow with a single location for mapping the file into the loader
