### PR TITLE
[2015.5] Fix schedule.present always diffing

### DIFF
--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -293,7 +293,7 @@ def build_schedule_item(name, **kwargs):
             schedule[name]['splay'] = kwargs['splay']
 
     for item in ['range', 'when', 'once', 'once_fmt', 'cron', 'returner',
-            'return_config']:
+            'return_config', 'enabled']:
         if item in kwargs:
             schedule[name][item] = kwargs[item]
 

--- a/salt/states/schedule.py
+++ b/salt/states/schedule.py
@@ -185,11 +185,11 @@ def present(name,
                 ret['comment'] = new_item['comment']
                 return ret
 
-        # The schedule.list gives us an item that is guaranteed to have an
-        # 'enabled' argument. Before comparing, add 'enabled' if it's not
-        # available (assume True, like schedule.list does)
-        if 'enabled' not in new_item:
-            new_item['enabled'] = True
+            # The schedule.list gives us an item that is guaranteed to have an
+            # 'enabled' argument. Before comparing, add 'enabled' if it's not
+            # available (assume True, like schedule.list does)
+            if 'enabled' not in new_item:
+                new_item['enabled'] = True
 
         if new_item == current_schedule[name]:
             ret['comment'].append('Job {0} in correct state'.format(name))

--- a/salt/states/schedule.py
+++ b/salt/states/schedule.py
@@ -185,6 +185,12 @@ def present(name,
                 ret['comment'] = new_item['comment']
                 return ret
 
+        # The schedule.list gives us an item that is guaranteed to have an
+        # 'enabled' argument. Before comparing, add 'enabled' if it's not
+        # available (assume True, like schedule.list does)
+        if 'enabled' not in new_item:
+            new_item['enabled'] = True
+
         if new_item == current_schedule[name]:
             ret['comment'].append('Job {0} in correct state'.format(name))
         else:


### PR DESCRIPTION
Fixes #28217 

This was caused by this addition: https://github.com/saltstack/salt/blob/bdd48c92de143de5ae3fbe8635fd8b4147f4f44c/salt/modules/schedule.py#L82-L85

Basically, if we didn't define 'enabled', schedule.list would add it for us. However, just adding `enabled: True` wasn't enough, because schedule.build_schedule_item wouldn't add 'enabled' to the finished product, even if it was available.

Now, build_schedule_item adds 'enabled' to the dictionary if it's passed in, and if 'enabled' isn't a kwarg, we add it to the new_item before comparing to the existing schedule. (Assuming True, just like the schedule.list does)
