### PR TITLE
Returning an error if you can't reload a config

### DIFF
--- a/pkg/rpm/salt-master
+++ b/pkg/rpm/salt-master
@@ -132,7 +132,7 @@ case "$1" in
         ;;
     reload)
         echo "can't reload configuration, you have to restart it"
-        RETVAL=$?
+        RETVAL=1
         ;;
     *)
         echo $"Usage: $0 {start|stop|status|restart|condrestart|reload}"


### PR DESCRIPTION
It seems like failing to reload and then returning success (which should always be the exit code of an 'echo') is incorrect.  This could also be cleaned up by removing reload as an option altogether, forcing users to start|stop|status|condrestart|restart instead.
