### PR TITLE
Add log error if we run salt-api w/ no config

### DIFF
--- a/salt/client/netapi.py
+++ b/salt/client/netapi.py
@@ -26,6 +26,9 @@ class NetapiClient(object):
         '''
         Load and start all available api modules
         '''
+        if not len(self.netapi):
+            logger.error("Did not find any netapi configurations, nothing to start")
+
         for fun in self.netapi:
             if fun.endswith('.start'):
                 logger.info('Starting {0} netapi module'.format(fun))


### PR DESCRIPTION
Currently, the salt-api script will exit with no error or hint of why it
failed if there is no netapi module configured.  Added a short line if
we find no api modules to start, warning the user that the config may be
missing.

Fixes #28240
