### PR TITLE
Win_firewall fix

### DIFF
--- a/tests/unit/states/win_firewall_test.py
+++ b/tests/unit/states/win_firewall_test.py
@@ -54,10 +54,10 @@ class WinFirewallTestCase(TestCase):
             Test to add a new firewall rule (Windows only)
         '''
         ret = {'name': 'salt',
-               'changes': {},
+                'changes': {'new rule': 'salt'},
                'result': None,
                'comment': ''}
-        mock = MagicMock(return_value=True)
+        mock = MagicMock(return_value=False)
         with patch.dict(win_firewall.__salt__, {"firewall.get_rule": mock}):
             with patch.dict(win_firewall.__opts__, {"test": True}):
                 self.assertDictEqual(win_firewall.add_rule('salt', 'stack'),

--- a/tests/unit/states/win_firewall_test.py
+++ b/tests/unit/states/win_firewall_test.py
@@ -20,12 +20,21 @@ ensure_in_syspath('../../')
 
 # Import Salt Libs
 from salt.states import win_firewall
+import salt.utils
+
 
 # Globals
 win_firewall.__salt__ = {}
 win_firewall.__opts__ = {}
 
 
+if salt.utils.is_windows():
+    WINDOWS = True
+else:
+    WINDOWS = False
+
+
+@skipIf(not WINDOWS, 'Only run if Windows')
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class WinFirewallTestCase(TestCase):
     '''
@@ -54,7 +63,7 @@ class WinFirewallTestCase(TestCase):
             Test to add a new firewall rule (Windows only)
         '''
         ret = {'name': 'salt',
-                'changes': {'new rule': 'salt'},
+               'changes': {'new rule': 'salt'},
                'result': None,
                'comment': ''}
         mock = MagicMock(return_value=False)
@@ -65,7 +74,7 @@ class WinFirewallTestCase(TestCase):
             with patch.dict(win_firewall.__opts__, {"test": False}):
                 with patch.dict(win_firewall.__opts__, {"test": False}):
                     ret.update({'comment': 'A rule with that name already'
-                                ' exists', 'result': True})
+                                ' exists', 'result': True, 'changes': {}})
                     self.assertDictEqual(win_firewall.add_rule('salt',
                                                                'stack'), ret)
 


### PR DESCRIPTION
Brought Win_firewall_test more in line with the changes to win_firewall state changes. This also doesn't need to run on Linux. Skipped if not Windows.
