### PR TITLE
Add __cli opt

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -1979,6 +1979,8 @@ def apply_minion_config(overrides=None,
     if overrides:
         opts.update(overrides)
 
+    opts['__cli'] = os.path.basename(sys.argv[0])
+
     if len(opts['sock_dir']) > len(opts['cachedir']) + 10:
         opts['sock_dir'] = os.path.join(opts['cachedir'], '.salt-unix')
 


### PR DESCRIPTION
Allows us to know what CLI command we are operating under. Especially useful for detecting uses of salt-call
