### PR TITLE
Add additional command line pillar example

### DIFF
--- a/doc/topics/tutorials/pillar.rst
+++ b/doc/topics/tutorials/pillar.rst
@@ -309,6 +309,12 @@ line:
 
     salt '*' state.sls my_sls_file pillar='{"hello": "world"}'
 
+Nested pillar values can also be set vai the command line:
+
+.. code-block:: bash
+
+   salt '*' state.sls my_sls_file pillar='{"foo": {"bar": "baz"}}'
+
 .. note::
 
     If a key is passed on the command line that already exists on the minion,

--- a/doc/topics/tutorials/pillar.rst
+++ b/doc/topics/tutorials/pillar.rst
@@ -309,7 +309,7 @@ line:
 
     salt '*' state.sls my_sls_file pillar='{"hello": "world"}'
 
-Nested pillar values can also be set vai the command line:
+Nested pillar values can also be set via the command line:
 
 .. code-block:: bash
 


### PR DESCRIPTION
This simply adds another example that shows how a user can updated a nested pillar value such as:

```
foo:
  bar: baz
```
