### PR TITLE
Update tutorial documentation

### DIFF
--- a/doc/topics/tutorials/minionfs.rst
+++ b/doc/topics/tutorials/minionfs.rst
@@ -5,18 +5,18 @@ MinionFS Backend Walkthrough
 ============================
 
 Propagating Files
-============================
+=================
 
 .. versionadded:: 2014.1.0
 
 Sometimes, you might need to propagate files that are generated on a minion.
 Salt already has a feature to send files from a minion to the master.
 
-Enabling Feature
-====================
+Enabling File Propation
+=======================
 
-To use the propagate feature one configuration change is required on the
-master. The :conf_master:`file_recv` option needs to be set to true.
+To use the propagate, update the following in the master config.
+The :conf_master:`file_recv` option needs to be set to true.
 
 .. code-block:: yaml
 
@@ -42,7 +42,7 @@ This command will store the file, including its full path, under
     :doc:`walkthrough </topics/tutorials/walkthrough>`.
 
 MinionFS Backend
-====================
+================
 
 Since it is not a good idea to expose the whole :conf_master:`cachedir`, MinionFS
 should be used to send these files to other minions.

--- a/doc/topics/tutorials/minionfs.rst
+++ b/doc/topics/tutorials/minionfs.rst
@@ -1,13 +1,27 @@
 .. _tutorial-minionfs:
 
 ============================
-MinionFS Backend Walkthrough
+Propagating Files Walkthrough
 ============================
 
 .. versionadded:: 2014.1.0
 
 Sometimes, you might need to propagate files that are generated on a minion.
-Salt already has a feature to send files from a minion to the master:
+Salt already has a feature to send files from a minion to the master.
+
+Enabling Feature
+====================
+
+To use the propagate feature one configuration change is required on the
+master. The :conf_master:`file_recv` option needs to be set to true.
+
+.. code-block:: yaml
+
+    file_recv: True
+
+These changes require a restart of the master, then new requests for the
+``salt://minion-id/`` protocol will send files that are pushed by ``cp.push``
+from ``minion-id`` to the master.
 
 .. code-block:: bash
 
@@ -23,6 +37,10 @@ This command will store the file, including its full path, under
     This walkthrough assumes basic knowledge of Salt and :mod:`cp.push
     <salt.modules.cp.push>`. To get up to speed, check out the
     :doc:`walkthrough </topics/tutorials/walkthrough>`.
+
+============================
+MinionFS Backend Walkthrough
+============================
 
 Since it is not a good idea to expose the whole :conf_master:`cachedir`, MinionFS
 should be used to send these files to other minions.

--- a/doc/topics/tutorials/minionfs.rst
+++ b/doc/topics/tutorials/minionfs.rst
@@ -1,7 +1,10 @@
 .. _tutorial-minionfs:
 
 ============================
-Propagating Files Walkthrough
+MinionFS Backend Walkthrough
+============================
+
+Propagating Files
 ============================
 
 .. versionadded:: 2014.1.0
@@ -38,9 +41,8 @@ This command will store the file, including its full path, under
     <salt.modules.cp.push>`. To get up to speed, check out the
     :doc:`walkthrough </topics/tutorials/walkthrough>`.
 
-============================
-MinionFS Backend Walkthrough
-============================
+MinionFS Backend
+====================
 
 Since it is not a good idea to expose the whole :conf_master:`cachedir`, MinionFS
 should be used to send these files to other minions.


### PR DESCRIPTION
When following the tutorial documentation (https://docs.saltstack.com/en/latest/topics/tutorials/minionfs.html) I found that I couldnt run the cp.push command. So I wanted to update the docs to show what needed to be enabled first then running the command. I am very open to changing whatever doesnt look good. @gravyboat
