### PR TITLE
Correct state pkg.updtodate to succeed when packages are up-to-date

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1808,7 +1808,7 @@ def uptodate(name, refresh=False, **kwargs):
 
     if updated.get('result') is False:
         ret.update(updated)
-    elif updated:
+    else updated or {} == updated:
         ret['changes'] = updated
         ret['comment'] = 'Upgrade successful.'
         ret['result'] = True


### PR DESCRIPTION
When there are no packages to upgrade pkg.upgrade returns an empty dictionary
indicating that there were no changes - this should result in state
pkg.uptodate succeeding.
