### PR TITLE
reworked smartos_virt to reuse most of the new smartos_vmadm

### DIFF
--- a/salt/modules/smartos_virt.py
+++ b/salt/modules/smartos_virt.py
@@ -252,9 +252,7 @@ def stop(uuid):
     if uuid in list_inactive_vms():
         raise CommandExecutionError('The specified vm is stopped')
 
-    __salt__['vmadm.delete'](uuid)
-
-    return uuid in list_inactive_vms()
+    return __salt__['vmadm.delete'](uuid)
 
 
 def vm_virt_type(uuid):

--- a/salt/modules/smartos_virt.py
+++ b/salt/modules/smartos_virt.py
@@ -309,13 +309,14 @@ def get_macs(uuid):
 
         salt '*' virt.get_macs <uuid>
     '''
-    dladm = _check_dladm()
-    cmd = '{0} show-vnic -o MACADDRESS -p -z {1}'.format(dladm, uuid)
-    res = __salt__['cmd.run_all'](cmd)
-    ret = res['stdout']
-    if ret != '':
-        return ret
-    raise CommandExecutionError('We can\'t find the MAC address of this VM')
+    macs = []
+    ret = __salt__['vmadm.lookup'](search="uuid={uuid}".format(uuid=uuid), order='nics')
+    if len(ret) < 1:
+        raise CommandExecutionError('We can\'t find the MAC address of this VM')
+    else:
+        for nic in ret[0]['nics']:
+            macs.append(nic['mac'])
+        return macs
 
 
 # Deprecated aliases

--- a/salt/modules/smartos_virt.py
+++ b/salt/modules/smartos_virt.py
@@ -184,17 +184,7 @@ def list_active_vms():
 
         salt '*' virt.list_active_vms
     '''
-    vmadm = _check_vmadm()
-    cmd = '{0} lookup state=running'.format(vmadm)
-    vms = []
-    res = __salt__['cmd.run_all'](cmd)
-    retcode = res['retcode']
-    if retcode != 0:
-        raise CommandExecutionError(_exit_status(retcode))
-    for key, uuid in six.iteritems(res):
-        if key == "stdout":
-            vms.append(uuid)
-    return vms
+    return __salt__['vmadm.list'](search="state='running'", order='uuid')
 
 
 def list_inactive_vms():

--- a/salt/modules/smartos_virt.py
+++ b/salt/modules/smartos_virt.py
@@ -266,7 +266,7 @@ def reboot(uuid):
     if uuid in list_inactive_vms():
         raise CommandExecutionError('The specified vm is stopped')
 
-    _call_vmadm('reboot {0}'.format(uuid))
+    __salt__['vmadm.reboot'](uuid)
 
     return uuid in list_active_vms()
 

--- a/salt/modules/smartos_virt.py
+++ b/salt/modules/smartos_virt.py
@@ -89,7 +89,7 @@ def list_inactive_vms():
     return __salt__['vmadm.list'](search="state='stopped'", order='uuid')
 
 
-def vm_info(uuid):
+def vm_info(domain):
     '''
     Return a dict with information about the specified VM on this CN
 
@@ -97,12 +97,12 @@ def vm_info(uuid):
 
     .. code-block:: bash
 
-        salt '*' virt.vm_info <uuid>
+        salt '*' virt.vm_info <domain>
     '''
-    return __salt__['vmadm.get'](uuid)
+    return __salt__['vmadm.get'](domain)
 
 
-def start(uuid):
+def start(domain):
     '''
     Start a defined domain
 
@@ -110,17 +110,17 @@ def start(uuid):
 
     .. code-block:: bash
 
-        salt '*' virt.start <uuid>
+        salt '*' virt.start <domain>
     '''
-    if uuid in list_active_vms():
+    if domain in list_active_vms():
         raise CommandExecutionError('The specified vm is already running')
 
-    __salt__['vmadm.start'](uuid)
+    __salt__['vmadm.start'](domain)
 
-    return uuid in list_active_vms()
+    return domain in list_active_vms()
 
 
-def shutdown(uuid):
+def shutdown(domain):
     '''
     Send a soft shutdown signal to the named vm
 
@@ -128,17 +128,17 @@ def shutdown(uuid):
 
     .. code-block:: bash
 
-        salt '*' virt.shutdown <uuid>
+        salt '*' virt.shutdown <domain>
     '''
-    if uuid in list_inactive_vms():
+    if domain in list_inactive_vms():
         raise CommandExecutionError('The specified vm is already stopped')
 
-    __salt__['vmadm.stop'](uuid)
+    __salt__['vmadm.stop'](domain)
 
-    return uuid in list_inactive_vms()
+    return domain in list_inactive_vms()
 
 
-def reboot(uuid):
+def reboot(domain):
     '''
     Reboot a domain via ACPI request
 
@@ -146,17 +146,17 @@ def reboot(uuid):
 
     .. code-block:: bash
 
-        salt '*' virt.reboot <uuid>
+        salt '*' virt.reboot <domain>
     '''
-    if uuid in list_inactive_vms():
+    if domain in list_inactive_vms():
         raise CommandExecutionError('The specified vm is stopped')
 
-    __salt__['vmadm.reboot'](uuid)
+    __salt__['vmadm.reboot'](domain)
 
-    return uuid in list_active_vms()
+    return domain in list_active_vms()
 
 
-def stop(uuid):
+def stop(domain):
     '''
     Hard power down the virtual machine, this is equivalent to powering off the hardware.
 
@@ -164,15 +164,15 @@ def stop(uuid):
 
     .. code-block:: bash
 
-        salt '*' virt.destroy <uuid>
+        salt '*' virt.destroy <domain>
     '''
-    if uuid in list_inactive_vms():
+    if domain in list_inactive_vms():
         raise CommandExecutionError('The specified vm is stopped')
 
-    return __salt__['vmadm.delete'](uuid)
+    return __salt__['vmadm.delete'](domain)
 
 
-def vm_virt_type(uuid):
+def vm_virt_type(domain):
     '''
     Return VM virtualization type : OS or KVM
 
@@ -180,16 +180,16 @@ def vm_virt_type(uuid):
 
     .. code-block:: bash
 
-        salt '*' virt.vm_virt_type <uuid>
+        salt '*' virt.vm_virt_type <domain>
     '''
-    ret = __salt__['vmadm.lookup'](search="uuid={uuid}".format(uuid=uuid), order='type')
+    ret = __salt__['vmadm.lookup'](search="uuid={uuid}".format(uuid=domain), order='type')
     if len(ret) < 1:
         raise CommandExecutionError("We can't determine the type of this VM")
 
     return ret[0]['type']
 
 
-def setmem(uuid, memory):
+def setmem(domain, memory):
     '''
     Change the amount of memory allocated to VM.
     <memory> is to be specified in MB.
@@ -200,23 +200,23 @@ def setmem(uuid, memory):
 
     .. code-block:: bash
 
-        salt '*' virt.setmem <uuid> 512
+        salt '*' virt.setmem <domain> 512
     '''
-    vmtype = vm_virt_type(uuid)
+    vmtype = vm_virt_type(domain)
     if vmtype == 'OS':
-        return __salt__['vmadm.update'](vm=uuid, max_physical_memory=memory)
+        return __salt__['vmadm.update'](vm=domain, max_physical_memory=memory)
     elif vmtype == 'LX':
-        return __salt__['vmadm.update'](vm=uuid, max_physical_memory=memory)
+        return __salt__['vmadm.update'](vm=domain, max_physical_memory=memory)
     elif vmtype == 'KVM':
         log.warning('Changes will be applied after the VM restart.')
-        return __salt__['vmadm.update'](vm=uuid, ram=memory)
+        return __salt__['vmadm.update'](vm=domain, ram=memory)
     else:
         raise CommandExecutionError('Unknown VM type')
 
     return False
 
 
-def get_macs(uuid):
+def get_macs(domain):
     '''
     Return a list off MAC addresses from the named VM
 
@@ -224,10 +224,10 @@ def get_macs(uuid):
 
     .. code-block:: bash
 
-        salt '*' virt.get_macs <uuid>
+        salt '*' virt.get_macs <domain>
     '''
     macs = []
-    ret = __salt__['vmadm.lookup'](search="uuid={uuid}".format(uuid=uuid), order='nics')
+    ret = __salt__['vmadm.lookup'](search="uuid={uuid}".format(uuid=domain), order='nics')
     if len(ret) < 1:
         raise CommandExecutionError('We can\'t find the MAC address of this VM')
     else:

--- a/salt/modules/smartos_virt.py
+++ b/salt/modules/smartos_virt.py
@@ -212,11 +212,7 @@ def vm_info(uuid):
 
         salt '*' virt.vm_info <uuid>
     '''
-    res = __salt__['cmd.run_all']('{0} get {1}'.format(_check_vmadm(), uuid))
-    if res['retcode'] != 0:
-        raise CommandExecutionError(_exit_status(res['retcode']))
-
-    return res['stdout']
+    return __salt__['vmadm.get'](uuid)
 
 
 def start(uuid):
@@ -301,10 +297,11 @@ def vm_virt_type(uuid):
 
         salt '*' virt.vm_virt_type <uuid>
     '''
-    ret = _call_vmadm('list -p -o type uuid={0}'.format(uuid))['stdout']
-    if not ret:
-        raise CommandExecutionError('We can\'t determine the type of this VM')
-    return ret
+    ret = __salt__['vmadm.lookup'](search="uuid={uuid}".format(uuid=uuid), order='type')
+    if len(ret) < 1:
+        raise CommandExecutionError("We can't determine the type of this VM")
+
+    return ret[0]['type']
 
 
 def setmem(uuid, memory):

--- a/salt/modules/smartos_virt.py
+++ b/salt/modules/smartos_virt.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-Module for managing VMs on SmartOS
+virst compatibility module for managing VMs on SmartOS
 '''
 from __future__ import absolute_import
 
@@ -11,7 +11,6 @@ import json
 from salt.exceptions import CommandExecutionError
 import salt.utils
 import salt.utils.decorators as decorators
-import salt.ext.six as six
 try:
     from shlex import quote as _cmd_quote  # pylint: disable=E0611
 except ImportError:
@@ -161,16 +160,17 @@ def list_domains():
 
         salt '*' virt.list_domains
     '''
-    vmadm = _check_vmadm()
-    cmd = '{0} list'.format(vmadm)
+    data = __salt__['vmadm.list'](keyed=True)
     vms = []
-    res = __salt__['cmd.run_all'](cmd)
-    retcode = res['retcode']
-    if retcode != 0:
-        raise CommandExecutionError(_exit_status(retcode))
-    for key, uuid in six.iteritems(res):
-        if key == "stdout":
-            vms.append(uuid)
+    vms.append("UUID                                  TYPE  RAM      STATE             ALIAS")
+    for vm in data:
+        vms.append("{vmuuid}{vmtype}{vmram}{vmstate}{vmalias}".format(
+            vmuuid=vm.ljust(38),
+            vmtype=data[vm]['type'].ljust(6),
+            vmram=data[vm]['ram'].ljust(9),
+            vmstate=data[vm]['state'].ljust(18),
+            vmalias=data[vm]['alias'],
+        ))
     return vms
 
 

--- a/salt/modules/smartos_virt.py
+++ b/salt/modules/smartos_virt.py
@@ -232,7 +232,7 @@ def start(uuid):
     if uuid in list_active_vms():
         raise CommandExecutionError('The specified vm is already running')
 
-    _call_vmadm('start {0}'.format(uuid))
+    __salt__['vmadm.start'](uuid)
 
     return uuid in list_active_vms()
 
@@ -250,7 +250,7 @@ def shutdown(uuid):
     if uuid in list_inactive_vms():
         raise CommandExecutionError('The specified vm is already stopped')
 
-    _call_vmadm('stop {0}'.format(uuid))
+    __salt__['vmadm.stop'](uuid)
 
     return uuid in list_inactive_vms()
 
@@ -286,7 +286,7 @@ def stop(uuid):
     if uuid in list_inactive_vms():
         raise CommandExecutionError('The specified vm is stopped')
 
-    _call_vmadm('delete {0}'.format(uuid))
+    __salt__['vmadm.delete'](uuid)
 
     return uuid in list_inactive_vms()
 

--- a/salt/modules/smartos_virt.py
+++ b/salt/modules/smartos_virt.py
@@ -197,17 +197,7 @@ def list_inactive_vms():
 
         salt '*' virt.list_inactive_vms
     '''
-    vmadm = _check_vmadm()
-    cmd = '{0} lookup state=stopped'.format(vmadm)
-    vms = []
-    res = __salt__['cmd.run_all'](cmd)
-    retcode = res['retcode']
-    if retcode != 0:
-        raise CommandExecutionError(_exit_status(retcode))
-    for key, uuid in six.iteritems(res):
-        if key == "stdout":
-            vms.append(uuid)
-    return vms
+    return __salt__['vmadm.list'](search="state='stopped'", order='uuid')
 
 
 def vm_info(uuid):


### PR DESCRIPTION
This is the last bit to close #26507
- smartos_virt (virt) now used smartos_vmadm internally instead of calling vmadm directly
- get_macs now also works for vms that are not running (as a side effect of the above)
- swapped out uuid for domain to be consistent

Opened against develop as suggested in #26507, no functionally has changed so it could be a backport candidate for 2015.8 branch also.
