### PR TITLE
correct a bad default value in http utility

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -187,10 +187,11 @@ def query(url,
         # Make sure no secret fields show up in logs
         if isinstance(data, dict):
             log_data = data.copy()
-            for item in data:
-                for field in hide_fields:
-                    if item == field:
-                        log_data[item] = 'XXXXXXXXXX'
+            if isinstance(hide_fields, list):
+                for item in data:
+                    for field in hide_fields:
+                        if item == field:
+                            log_data[item] = 'XXXXXXXXXX'
             log.trace('Request POST Data: {0}'.format(pprint.pformat(log_data)))
         else:
             log.trace('Request POST Data: {0}'.format(pprint.pformat(data)))


### PR DESCRIPTION
- caused by #25668 
- seems to need test cases!
- please backport!

```
----------
          ID: haste_server_started
    Function: module.run
        Name: http.query
      Result: False
     Comment: Module function http.query threw an exception. Exception: 'NoneType' object is not iterable
     Started: 12:20:14.064283
    Duration: 2.227 ms
     Changes:
```
