### PR TITLE
Updated the Nodegroup docs to include how to target nodegroups in SLS Jinja

### DIFF
--- a/doc/topics/targeting/nodegroups.rst
+++ b/doc/topics/targeting/nodegroups.rst
@@ -84,6 +84,7 @@ To use Nodegroups in Jinja logic for SLS files, the :conf_master:'pillar_opts' o
 Once pillar_opts is enabled, you can find the nodegroups under the "master" pillar. To make sure that only the correct minions are targeted, you should use each matcher for the nodegroup definition.
 For example, to check if a minion is in the 'webserver' nodegroup:
 .. code-block:: yaml
+
     nodegroups:
       webserver: 'G@os:Debian and L@minion1,minion2'
 

--- a/doc/topics/targeting/nodegroups.rst
+++ b/doc/topics/targeting/nodegroups.rst
@@ -67,3 +67,33 @@ nodegroup`` on the line directly following the nodegroup name.
 
     A limited amount of functionality, such as targeting with -N from the command-line may be
     available without a restart.
+
+Using Nodegroups in SLS files
+=============================
+
+To use Nodegroups in Jinja logic for SLS files, the :conf_master:'pillar_opts' option in ``/etc/salt/master`` must be set to "True". This will pass the master's configuration as Pillar data to each minion.
+
+.. note::
+
+    If the master's configuration contains any sensitive data, this will be passed to each minion. Do not enable this
+    option if you have any configuration data that you do not want to get on your minions.
+
+    Also, if you make changes to your nodegroups, you might need to run ``salt '*' saltutil.refresh_pillar`` after
+    restarting the master.
+
+Once pillar_opts is enabled, you can find the nodegroups under the "master" pillar. To make sure that only the correct minions are targeted, you should use each matcher for the nodegroup definition.
+For example, to check if a minion is in the 'webserver' nodegroup:
+.. code-block:: yaml
+    nodegroups:
+      webserver: 'G@os:Debian and L@minion1,minion2'
+
+.. code-block:: yaml
+
+    {% if grains.id in salt['pillar.get']('master:nodegroups:webserver', []) and grains.os in salt['pillar.get']('master:nodegroups:webserver', []) %}
+    ...
+    {% endif %}
+
+.. note::
+
+    If you do not include all of the matchers used to define a nodegroup, Salt might incorrectly target minions
+    that meet some of the nodegroup requirements, but not all of them.

--- a/doc/topics/targeting/nodegroups.rst
+++ b/doc/topics/targeting/nodegroups.rst
@@ -71,17 +71,22 @@ nodegroup`` on the line directly following the nodegroup name.
 Using Nodegroups in SLS files
 =============================
 
-To use Nodegroups in Jinja logic for SLS files, the :conf_master:'pillar_opts' option in ``/etc/salt/master`` must be set to "True". This will pass the master's configuration as Pillar data to each minion.
+To use Nodegroups in Jinja logic for SLS files, the :conf_master:'pillar_opts' option in 
+``/etc/salt/master`` must be set to "True". This will pass the master's configuration as 
+Pillar data to each minion.
 
 .. note::
 
-    If the master's configuration contains any sensitive data, this will be passed to each minion. Do not enable this
-    option if you have any configuration data that you do not want to get on your minions.
+    If the master's configuration contains any sensitive data, this will be passed to each minion. 
+    Do not enable this option if you have any configuration data that you do not want to get
+    on your minions.
 
-    Also, if you make changes to your nodegroups, you might need to run ``salt '*' saltutil.refresh_pillar`` after
-    restarting the master.
+    Also, if you make changes to your nodegroups, you might need to run 
+    ``salt '*' saltutil.refresh_pillar`` after restarting the master.
 
-Once pillar_opts is enabled, you can find the nodegroups under the "master" pillar. To make sure that only the correct minions are targeted, you should use each matcher for the nodegroup definition.
+Once pillar_opts is enabled, you can find the nodegroups under the "master" pillar. 
+To make sure that only the correct minions are targeted, 
+you should use each matcher for the nodegroup definition.
 For example, to check if a minion is in the 'webserver' nodegroup:
 
 .. code-block:: yaml
@@ -91,11 +96,13 @@ For example, to check if a minion is in the 'webserver' nodegroup:
 
 .. code-block:: yaml
 
-    {% if grains.id in salt['pillar.get']('master:nodegroups:webserver', []) and grains.os in salt['pillar.get']('master:nodegroups:webserver', []) %}
+    {% if grains.id in salt['pillar.get']('master:nodegroups:webserver', []) 
+    and grains.os in salt['pillar.get']('master:nodegroups:webserver', []) %}
     ...
     {% endif %}
 
 .. note::
 
-    If you do not include all of the matchers used to define a nodegroup, Salt might incorrectly target minions
-    that meet some of the nodegroup requirements, but not all of them.
+    If you do not include all of the matchers used to define a nodegroup, 
+    Salt might incorrectly target minions that meet some of the nodegroup 
+    requirements, but not all of them.

--- a/doc/topics/targeting/nodegroups.rst
+++ b/doc/topics/targeting/nodegroups.rst
@@ -83,6 +83,7 @@ To use Nodegroups in Jinja logic for SLS files, the :conf_master:'pillar_opts' o
 
 Once pillar_opts is enabled, you can find the nodegroups under the "master" pillar. To make sure that only the correct minions are targeted, you should use each matcher for the nodegroup definition.
 For example, to check if a minion is in the 'webserver' nodegroup:
+
 .. code-block:: yaml
 
     nodegroups:


### PR DESCRIPTION
See issue #28268

This pull request will add a new section to the Nodegroup docs (doc/topics/targeting/nodegroups.rst) that explains how to target nodegroups in Jinja. To do this, pillar_opts needs to be set to "True" on the master. Then the minion can pull nodegroup configurations through pillar data.
