### PR TITLE
Fix psutil compat for psutil versions < 1.1.0

### DIFF
--- a/salt/utils/psutil_compat.py
+++ b/salt/utils/psutil_compat.py
@@ -68,10 +68,17 @@ else:
                 return self.get_nice()
 
         def rlimit(self, *args, **kwargs):
-            if args or kwargs:
-                return self.set_rlimit(*args, **kwargs)
+            '''
+            set_rlimit and get_limit were not introduced until psutil v1.1.0
+            '''
+            if psutil.version_info >= (1, 1, 0):
+                if args or kwargs:
+                    return self.set_rlimit(*args, **kwargs)
+                else:
+                    return self.get_rlimit()
             else:
-                return self.get_rlimit()
+                pass
+
 
     # Alias renamed Process functions
     _PROCESS_FUNCTION_MAP = {

--- a/salt/utils/psutil_compat.py
+++ b/salt/utils/psutil_compat.py
@@ -79,7 +79,6 @@ else:
             else:
                 pass
 
-
     # Alias renamed Process functions
     _PROCESS_FUNCTION_MAP = {
         "children": "get_children",


### PR DESCRIPTION
the `get_rlimit` and `set_rlimit` methods were not introduced until psutil 1.1.0 so trying to run those methods will cause an exception.  This, for instance, breaks `ps.proc_info`
