### PR TITLE
Fix issue wiith --match-set option. #23643

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -1234,7 +1234,7 @@ def _parser():
     ## sctp
     add_arg('--chunk-types', dest='chunk-types', action='append')
     ## set
-    add_arg('--match-set', dest='match-set', action='append', nargs=2)
+    add_arg('--match-set', dest='match-set', action='append')
     add_arg('--return-nomatch', dest='return-nomatch', action='append')
     add_arg('--update-counters', dest='update-counters', action='append')
     add_arg('--update-subcounters', dest='update-subcounters', action='append')


### PR DESCRIPTION
https://github.com/saltstack/salt/issues/23643
Function is expecting two arguments. But after processing state only one parameter (it contain two words) is pushed into list of options.
