### PR TITLE
Consider each pillar match only once.

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -446,10 +446,12 @@ class Pillar(object):
                         self.opts.get('nodegroups', {}),
                         ):
                     if saltenv not in matches:
-                        matches[saltenv] = []
+                        matches[saltenv] = env_matches = []
+                    else:
+                        env_matches = matches[saltenv]
                     for item in data:
-                        if isinstance(item, six.string_types):
-                            matches[saltenv].append(item)
+                        if isinstance(item, six.string_types) and item not in env_matches:
+                            env_matches.append(item)
         return matches
 
     def render_pstate(self, sls, saltenv, mods, defaults=None):


### PR DESCRIPTION
As reported in #25954, a minion receives a pillar .sls multiple times in case it matches multiple targets in the top file. This has been fixed by making lists override by default (#27891). However, it might be intended to merge lists from multiple sls sources. This complementary PR loads each sls module only once, avoiding unintentional list item duplicates.
