### PR TITLE
In CentOS 5 the .split() causes a stacktrace.

### DIFF
--- a/salt/modules/blockdev.py
+++ b/salt/modules/blockdev.py
@@ -223,7 +223,7 @@ def fstype(device):
         # itself for its type
         df_out = __salt__['cmd.run']('df -T {0}'.format(device)).splitlines()
         if len(df_out) > 1:
-            fs_type = df_out[1].split()[1]
+            fs_type = df_out[1]
             if fs_type:
                 return fs_type
 


### PR DESCRIPTION
Confirmed that .split() is unneeded in other OS's.
