### PR TITLE
mark repo not enabled when pkgrepo state passes in disable: True

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1857,7 +1857,12 @@ def mod_repo(repo, basedir=None, **kwargs):
             'Only one of \'mirrorlist\' and \'baseurl\' can be specified'
         )
 
+    # Build a list of keys to be deleted
     todelete = []
+    for key in repo_opts:
+        if repo_opts[key] != 0 and not repo_opts[key]:
+            del repo_opts[key]
+            todelete.append(key)
 
     # convert disabled=True to enabled=0 from pkgrepo state
     if 'disabled' in repo_opts:
@@ -1866,12 +1871,6 @@ def mod_repo(repo, basedir=None, **kwargs):
             repo_opts['enabled'] = 0
         del repo_opts['disabled']
         todelete.append('disabled')
-
-    # Build a list of keys to be deleted
-    for key in repo_opts:
-        if repo_opts[key] != 0 and not repo_opts[key]:
-            del repo_opts[key]
-            todelete.append(key)
 
     # Add baseurl or mirrorlist to the 'todelete' list if the other was
     # specified in the repo_opts

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1861,6 +1861,8 @@ def mod_repo(repo, basedir=None, **kwargs):
         kw_disabled = repo_opts['disabled']
         if kw_disabled is True or str(kw_disabled).lower() == 'true':
             repo_opts['enabled'] = 0
+        del repo_opts['disabled']
+        todelete.append('disabled')
 
     # Build a list of keys to be deleted
     todelete = []

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1857,6 +1857,11 @@ def mod_repo(repo, basedir=None, **kwargs):
             'Only one of \'mirrorlist\' and \'baseurl\' can be specified'
         )
 
+    if 'disabled' in repo_opts:
+        kw_disabled = repo_opts['disabled']
+        if kw_disabled is True or str(kw_disabled).lower() == 'true':
+            repo_opts['enabled'] = 0
+
     # Build a list of keys to be deleted
     todelete = []
     for key in repo_opts:

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1857,6 +1857,9 @@ def mod_repo(repo, basedir=None, **kwargs):
             'Only one of \'mirrorlist\' and \'baseurl\' can be specified'
         )
 
+    todelete = []
+
+    # convert disabled=True to enabled=0 from pkgrepo state
     if 'disabled' in repo_opts:
         kw_disabled = repo_opts['disabled']
         if kw_disabled is True or str(kw_disabled).lower() == 'true':
@@ -1865,7 +1868,6 @@ def mod_repo(repo, basedir=None, **kwargs):
         todelete.append('disabled')
 
     # Build a list of keys to be deleted
-    todelete = []
     for key in repo_opts:
         if repo_opts[key] != 0 and not repo_opts[key]:
             del repo_opts[key]


### PR DESCRIPTION
The pkgrepo state's new default is to use `disabled: True` when wanting to disable a repository.  Unfortunately the yumpkg.py execution module doesn't recognize this and falsely puts `disabled=True` in the yum.conf file, which is a no-op to Yum.  This will set `enabled: 0` if `disabled=True` is passed in to mod_repo.
