### PR TITLE
Merge pillar includes correctly

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -534,8 +534,8 @@ class Pillar(object):
                                         self.merge_strategy,
                                         self.opts.get('renderer', 'yaml'))
 
-                            if err:
-                                errors += err
+                                if err:
+                                    errors += err
         return state, mods, errors
 
     def render_pillar(self, matches):

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -522,17 +522,17 @@ class Pillar(object):
                                         mods,
                                         defaults
                                         )
-                            if nstate:
-                                if key:
-                                    nstate = {
-                                        key: nstate
-                                    }
+                                if nstate:
+                                    if key:
+                                        nstate = {
+                                            key: nstate
+                                        }
 
-                                state = merge(
-                                    state,
-                                    nstate,
-                                    self.merge_strategy,
-                                    self.opts.get('renderer', 'yaml'))
+                                    state = merge(
+                                        state,
+                                        nstate,
+                                        self.merge_strategy,
+                                        self.opts.get('renderer', 'yaml'))
 
                             if err:
                                 errors += err


### PR DESCRIPTION
When a pillar is included multiple times (e.g. in some `init.sls` or the top file), the rendering checks for duplicates and skips merging pillar modules that have been merged before. However, this causes the preceding module to be merged again if there is any. In the `recurse` merge strategy this goes mostly unnoticed, but when using `recurse_list` leads to strange behavior. The following setup can reproduce the problem:

top.sls

``` yaml
base:
  '*':
   - order: 1
   - test.sub2
  minion1:
   - order: 2
   - test
```

test/init.sls

``` yaml
include:
 - test.sub1
 - test.sub2
```

test/sub1.sls

``` yaml
p1:
 - value1_1
 - value1_2
```

test/sub2.sls

``` yaml
p2:
 - value2_1
 - value2_2
```

Output of `salt minion1 pillar.get p1`:

```
minion1:
    - value1_1
    - value1_2
    - value1_1
    - value1_2
```

Output of `salt minion1 pillar.get p2`:

```
minion1:
    - value2_1
    - value2_2
```

First `test.sub2` is read from the top file and merged. The include statement in `test` lists it once more; the rendering ignores it, and instead merges `test.sub1` again.

This PR fixes the aforementioned issue, caused by a re-used variable in a for-loop. It also includes a test similar to the setup above.
