### PR TITLE
add dockercompose module to manage docker containers via docker-compose

### DIFF
--- a/salt/modules/dockercompose.py
+++ b/salt/modules/dockercompose.py
@@ -161,10 +161,10 @@ def __write_docker_compose(path, docker_compose):
         f.close()
     else:
         return __standardize_result(False,
-                                    "Could not write docker-compose filein %s"
-                                    % path, None, None)
+                                    "Could not write docker-compose file in {0}".format(path),
+                                    None, None)
     project = __load_project(path)
-    if type(project) is dict:
+    if isinstance(project, dict):
         os.remove(os.path.join(path, dc_filename))
         return project
     return path
@@ -191,8 +191,10 @@ def __handle_except(inst):
     :param inst:
     :return:
     """
-    return __standardize_result(False, "Docker-compose command %s failed"
-                                % (inspect.stack()[1][3]), "%s" % (inst), None)
+    return __standardize_result(False,
+                                "Docker-compose command {0} failed".
+                                format(inspect.stack()[1][3]),
+                                "{0}".format(inst), None)
 
 
 def _get_convergence_plans(project, service_names):
@@ -237,7 +239,7 @@ def create(path, docker_compose):
     """
     if docker_compose:
         ret = __write_docker_compose(path, docker_compose)
-        if type(ret) is dict:
+        if isinstance(ret, dict):
             return ret
     else:
         return __standardize_result(False,
@@ -268,7 +270,7 @@ def restart(path, service_names=None):
     project = __load_project(path)
     debug_ret = {}
     result = {}
-    if type(project) is dict:
+    if isinstance(project, dict):
         return project
     else:
         try:
@@ -305,7 +307,7 @@ def stop(path, service_names=None):
     project = __load_project(path)
     debug_ret = {}
     result = {}
-    if type(project) is dict:
+    if isinstance(project, dict):
         return project
     else:
         try:
@@ -342,7 +344,7 @@ def pause(path, service_names=None, **kwargs):
     project = __load_project(path)
     debug_ret = {}
     result = {}
-    if type(project) is dict:
+    if isinstance(project, dict):
         return project
     else:
         try:
@@ -379,7 +381,7 @@ def unpause(path, service_names=None, **kwargs):
     project = __load_project(path)
     debug_ret = {}
     result = {}
-    if type(project) is dict:
+    if isinstance(project, dict):
         return project
     else:
         try:
@@ -416,7 +418,7 @@ def start(path, service_names=None, **kwargs):
     project = __load_project(path)
     debug_ret = {}
     result = {}
-    if type(project) is dict:
+    if isinstance(project, dict):
         return project
     else:
         try:
@@ -453,7 +455,7 @@ def kill(path, service_names=None, **kwargs):
     project = __load_project(path)
     debug_ret = {}
     result = {}
-    if type(project) is dict:
+    if isinstance(project, dict):
         return project
     else:
         try:
@@ -488,7 +490,7 @@ def rm(path, service_names=None, **kwargs):
     """
 
     project = __load_project(path)
-    if type(project) is dict:
+    if isinstance(project, dict):
         return project
     else:
         try:
@@ -514,7 +516,7 @@ def ps(path, **kwargs):
 
     project = __load_project(path)
     result = {}
-    if type(project) is dict:
+    if isinstance(project, dict):
         return project
     else:
         containers = sorted(
@@ -524,7 +526,7 @@ def ps(path, **kwargs):
         for container in containers:
             command = container.human_readable_command
             if len(command) > 30:
-                command = '%s ...' % command[:26]
+                command = '{0} ...'.format(command[:26])
             result[container.name] = {
                 'id': container.id,
                 'name': container.name,
@@ -556,7 +558,7 @@ def up(path, service_names=None):
 
     debug_ret = {}
     project = __load_project(path)
-    if type(project) is dict:
+    if isinstance(project, dict):
         return project
     else:
         try:

--- a/salt/modules/dockercompose.py
+++ b/salt/modules/dockercompose.py
@@ -80,6 +80,8 @@ Detailed Function Documentation
 -------------------------------
 """
 
+from __future__ import absolute_import
+
 import inspect
 import logging
 import os
@@ -323,7 +325,7 @@ def stop(path, service_names=None):
     return __standardize_result(True, 'Stopping containers via docker-compose', result, debug_ret)
 
 
-def pause(path, service_names=None, **kwargs):
+def pause(path, service_names=None):
     """
     Pause running containers in the docker-compose file, service_names is a python
     list, if omitted pause all containers
@@ -360,7 +362,7 @@ def pause(path, service_names=None, **kwargs):
     return __standardize_result(True, 'Pausing containers via docker-compose', result, debug_ret)
 
 
-def unpause(path, service_names=None, **kwargs):
+def unpause(path, service_names=None):
     """
     Un-Pause containers in the docker-compose file, service_names is a python
     list, if omitted unpause all containers
@@ -397,7 +399,7 @@ def unpause(path, service_names=None, **kwargs):
     return __standardize_result(True, 'Un-Pausing containers via docker-compose', result, debug_ret)
 
 
-def start(path, service_names=None, **kwargs):
+def start(path, service_names=None):
     """
     Start containers in the docker-compose file, service_names is a python
     list, if omitted start all containers
@@ -434,7 +436,7 @@ def start(path, service_names=None, **kwargs):
     return __standardize_result(True, 'Starting containers via docker-compose', result, debug_ret)
 
 
-def kill(path, service_names=None, **kwargs):
+def kill(path, service_names=None):
     """
     Kill containers in the docker-compose file, service_names is a python
     list, if omitted kill all containers
@@ -471,7 +473,7 @@ def kill(path, service_names=None, **kwargs):
     return __standardize_result(True, 'Killing containers via docker-compose', result, debug_ret)
 
 
-def rm(path, service_names=None, **kwargs):
+def rm(path, service_names=None):
     """
     Remove stopped containers in the docker-compose file, service_names is a python
     list, if omitted remove all stopped containers
@@ -500,7 +502,7 @@ def rm(path, service_names=None, **kwargs):
     return __standardize_result(True, 'Removing stopped containers via docker-compose', None, None)
 
 
-def ps(path, **kwargs):
+def ps(path):
     """
     List all running containers and report some information about them
 

--- a/salt/modules/dockercompose.py
+++ b/salt/modules/dockercompose.py
@@ -1,21 +1,83 @@
 
 # -*- coding: utf-8 -*-
 """
+Module to import docker-compose via saltstack
+
+.. versionadded:: Boron
+
 :maintainer: Jean Praloran <jeanpralo@gmail.com>
 :maturity: new
 :depends: docker-compose>=1.5
 :platform: all
 
-Module to import docker-compose via saltstack
-Author: Jean Praloran (jeanpralo@gmail.com)
-All commands are not implemented yet (feel free to extend or PR):
+Introduction
+------------
+This module allows to deal with docker-compose file in a directory.
+
+This is  a first version only, the following commands are missing at the moment
+but will be built later on if the community is interested in this module:
   - build
   - run
-
   - logs
   - port
   - pull
   - scale
+
+
+How to use this module?
+-----------------------
+In order to use the module if you have no docker-compose file on the server you
+can issue the command create, it takes two arguments the path where the
+docker-compose.yml will be stored and the content of this latter:
+
+.. code-block:: bash
+    # salt-call -l debug dockercompose.create /tmp/toto '
+     database:
+     image: mongo:3.0
+     command: mongod --smallfiles --quiet --logpath=/dev/null
+     '
+
+Then you can execute a list of method defined at the bottom with at least one
+argument (the path where the docker-compose.yml will be read) and an optional
+python list which corresponds to the services names:
+
+.. code-block:: bash
+    # salt-call -l debug dockercompose.up /tmp/toto
+    # salt-call -l debug dockercompose.restart /tmp/toto '[database]'
+    # salt-call -l debug dockercompose.stop /tmp/toto
+    # salt-call -l debug dockercompose.rm /tmp/toto
+
+
+Docker-compose method supported
+-------------------------------
+ - up
+ - restart
+ - stop
+ - start
+ - pause
+ - unpause
+ - kill
+ - rm
+ - ps
+
+Functions
+---------
+- docker-compose.yml management
+    - :py:func:`dockercompose.create <salt.modules.dockercompose.create>`
+- Manage containers
+    - :py:func:`dockercompose.restart <salt.modules.dockercompose.restart>`
+    - :py:func:`dockercompose.stop <salt.modules.dockercompose.stop>`
+    - :py:func:`dockercompose.pause <salt.modules.dockercompose.pause>`
+    - :py:func:`dockercompose.unpause <salt.modules.dockercompose.unpause>`
+    - :py:func:`dockercompose.start <salt.modules.dockercompose.start>`
+    - :py:func:`dockercompose.kill <salt.modules.dockercompose.kill>`
+    - :py:func:`dockercompose.rm <salt.modules.dockercompose.rm>`
+    - :py:func:`dockercompose.up <salt.modules.dockercompose.up>`
+- Gather informations about containers:
+    - :py:func:`dockercompose.ps <salt.modules.dockercompose.ps>`
+
+Detailed Function Documentation
+-------------------------------
 """
 
 import inspect
@@ -25,12 +87,12 @@ import re
 
 from operator import attrgetter
 try:
-	import compose
-	from compose.cli.command import get_project
-	from compose.service import ConvergenceStrategy
-	HAS_DOCKERCOMPOSE = True
+    import compose
+    from compose.cli.command import get_project
+    from compose.service import ConvergenceStrategy
+    HAS_DOCKERCOMPOSE = True
 except ImportError:
-	HAS_DOCKERCOMPOSE = False
+    HAS_DOCKERCOMPOSE = False
 
 MIN_DOCKERCOMPOSE = (1, 5, 0)
 VERSION_RE = r'([\d.]+)'
@@ -43,396 +105,468 @@ dc_filename = "docker-compose.yml"
 
 
 def __virtual__():
-	if HAS_DOCKERCOMPOSE:
-		match = re.match(VERSION_RE, str(compose.__version__))
-		if match:
-			version = tuple([int(x) for x in match.group(1).split('.')])
-			if MIN_DOCKERCOMPOSE >= version:
-				return __virtualname__
-		else:
-			log.critical("Minimum version of docker-compose>=1.5.0")
-	return False
+    if HAS_DOCKERCOMPOSE:
+        match = re.match(VERSION_RE, str(compose.__version__))
+        if match:
+            version = tuple([int(x) for x in match.group(1).split('.')])
+            if MIN_DOCKERCOMPOSE >= version:
+                return __virtualname__
+        else:
+            log.critical("Minimum version of docker-compose>=1.5.0")
+    return False
 
 
 def __standardize_result(status, message, data=None, debug_msg=None):
-	"""
-	Standardizes all responses
+    """
+    Standardizes all responses
 
-	:param status:
-	:param message:
-	:param data:
-	:param debug_msg:
-	:return:
-	"""
-	result = {
-		'status': status,
-		'message': message
-	}
+    :param status:
+    :param message:
+    :param data:
+    :param debug_msg:
+    :return:
+    """
+    result = {
+        'status': status,
+        'message': message
+    }
 
-	if data is not None:
-		result['return'] = data
+    if data is not None:
+        result['return'] = data
 
-	if debug_msg is not None and debug:
-		result['debug'] = debug_msg
+    if debug_msg is not None and debug:
+        result['debug'] = debug_msg
 
-	return result
+    return result
 
 
 def __write_docker_compose(path, docker_compose):
-	"""
-	Write docker-compose to a temp directory
-	in order to use it with docker-compose ( config check )
+    """
+    Write docker-compose to a temp directory
+    in order to use it with docker-compose ( config check )
 
-	:param path:
+    :param path:
 
-	docker_compose
-		contains the docker-compose file
+    docker_compose
+        contains the docker-compose file
 
-	:return:
-	"""
+    :return:
+    """
 
-	if os.path.isdir(path) is False:
-		os.mkdir(path)
-	f = open(os.path.join(path, dc_filename), 'w')
-	if f:
-		f.write(docker_compose)
-		f.close()
-	else:
-		return __standardize_result(False, "Could not write docker-compose file in %s" % path, None, None)
-	project = __load_project(path)
-	if type(project) is dict:
-		os.remove(os.path.join(path, dc_filename))
-		return project
-	return path
+    if os.path.isdir(path) is False:
+        os.mkdir(path)
+    f = open(os.path.join(path, dc_filename), 'w')
+    if f:
+        f.write(docker_compose)
+        f.close()
+    else:
+        return __standardize_result(False,
+                                    "Could not write docker-compose filein %s"
+                                    % path, None, None)
+    project = __load_project(path)
+    if type(project) is dict:
+        os.remove(os.path.join(path, dc_filename))
+        return project
+    return path
 
 
 def __load_project(path):
-	"""
-	Load a docker-compose project from path
+    """
+    Load a docker-compose project from path
 
-	:param path:
-	:return:
-	"""
-	try:
-		project = get_project(path)
-	except Exception as inst:
-		return __handle_except(inst)
-	return project
+    :param path:
+    :return:
+    """
+    try:
+        project = get_project(path)
+    except Exception as inst:
+        return __handle_except(inst)
+    return project
 
 
 def __handle_except(inst):
-	"""
-	Handle exception and return a standart result
+    """
+    Handle exception and return a standart result
 
-	:param inst:
-	:return:
-	"""
-	return __standardize_result(False, "Docker-compose command %s failed" % (inspect.stack()[1][3]), "%s" % (inst), None)
+    :param inst:
+    :return:
+    """
+    return __standardize_result(False, "Docker-compose command %s failed"
+                                % (inspect.stack()[1][3]), "%s" % (inst), None)
 
 
 def _get_convergence_plans(project, service_names):
-	"""
-	Get action executed for each container
+    """
+    Get action executed for each container
 
-	:param project:
-	:param service_names:
-	:return:
-	"""
-	ret = {}
-	plans = project._get_convergence_plans(project.get_services(service_names), ConvergenceStrategy.changed)
-	for cont in plans:
-		(action, container) = plans[cont]
-		if action == 'create':
-			ret[cont] = "Creating container"
-		elif action == 'recreate':
-			ret[cont] = "Re-creating container"
-		elif action == 'start':
-			ret[cont] = "Starting container"
-		elif action == 'noop':
-			ret[cont] = "Container is up to date"
-	return ret
-
-
-def create(path, docker_compose, **kwargs):
-	"""
-	Create and validate a docker-compose file into a directory
-
-	path
-		Path where the docker-compose file will be stored on the server
-
-	docker_compose
-		docker_compose file
-
-	:param kwargs:
-	:return:
-	"""
-	if docker_compose:
-		ret = __write_docker_compose(path, docker_compose)
-		if type(ret) is dict:
-			return ret
-	else:
-		return __standardize_result(False, "Creating a docker-compose project failed, you must send a valid docker-compose file", None, None)
-	return __standardize_result(True, "Successfully created the docker-compose file", {'compose.base_dir': path}, None)
+    :param project:
+    :param service_names:
+    :return:
+    """
+    ret = {}
+    plans = project._get_convergence_plans(project.get_services(service_names),
+                                           ConvergenceStrategy.changed)
+    for cont in plans:
+        (action, container) = plans[cont]
+        if action == 'create':
+            ret[cont] = "Creating container"
+        elif action == 'recreate':
+            ret[cont] = "Re-creating container"
+        elif action == 'start':
+            ret[cont] = "Starting container"
+        elif action == 'noop':
+            ret[cont] = "Container is up to date"
+    return ret
 
 
-def restart(path, service_names=None, **kwargs):
-	"""
-	Restart a docker-compose application
+def create(path, docker_compose):
+    """
+    Create and validate a docker-compose file into a directory
 
-	path
-		Path where the docker-compose file is stored on the server
+    path
+        Path where the docker-compose file will be stored on the server
 
-	service_names
-		If specified will restart only the specified services
-	:return:
-	"""
+    docker_compose
+        docker_compose file
 
-	project = __load_project(path)
-	debug_ret = {}
-	result = {}
-	if type(project) is dict:
-		return project
-	else:
-		try:
-			project.restart(service_names)
-			if debug:
-				for container in project.containers():
-					if service_names is None or container.get('Name')[1:] in service_names:
-						container.inspect_if_not_inspected()
-						debug_ret[container.get('Name')] = container.inspect()
-						result[container.get('Name')] = 'restarted'
-		except Exception as inst:
-			return __handle_except(inst)
-	return __standardize_result(True, 'Restarting containers via docker-compose', result, debug_ret)
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion dockercompose.create /path/to/docker-compose.yml content
+    """
+    if docker_compose:
+        ret = __write_docker_compose(path, docker_compose)
+        if type(ret) is dict:
+            return ret
+    else:
+        return __standardize_result(False,
+                                    "Creating a docker-compose project failed, you must send a valid docker-compose file",
+                                    None, None)
+    return __standardize_result(True, "Successfully created the docker-compose file", {'compose.base_dir': path}, None)
 
 
-def stop(path, service_names=None, **kwargs):
-	"""
-	Stop running containers
+def restart(path, service_names=None):
+    """
+    Restart container(s) in the docker-compose file, service_names is a python
+    list, if omitted restart all containers
 
-	path
-		Path where the docker-compose file is stored on the server
-	service_names
-		If specified will restart only the specified services
-	:return:
-	"""
+    path
+        Path where the docker-compose file is stored on the server
 
-	project = __load_project(path)
-	debug_ret = {}
-	result = {}
-	if type(project) is dict:
-		return project
-	else:
-		try:
-			project.stop(service_names)
-			if debug:
-				for container in project.containers(stopped=True):
-					if service_names is None or container.get('Name')[1:] in service_names:
-						container.inspect_if_not_inspected()
-						debug_ret[container.get('Name')] = container.inspect()
-						result[container.get('Name')] = 'stopped'
-		except Exception as inst:
-			return __handle_except(inst)
-	return __standardize_result(True, 'Stopping containers via docker-compose', result, debug_ret)
+    service_names
+        If specified will restart only the specified services
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion dockercompose.restart /path/to/docker-compose.yml
+        salt myminion dockercompose.restart /path/to/docker-compose.yml '[janus]'
+    """
+
+    project = __load_project(path)
+    debug_ret = {}
+    result = {}
+    if type(project) is dict:
+        return project
+    else:
+        try:
+            project.restart(service_names)
+            if debug:
+                for container in project.containers():
+                    if service_names is None or container.get('Name')[1:] in service_names:
+                        container.inspect_if_not_inspected()
+                        debug_ret[container.get('Name')] = container.inspect()
+                        result[container.get('Name')] = 'restarted'
+        except Exception as inst:
+            return __handle_except(inst)
+    return __standardize_result(True, 'Restarting containers via docker-compose', result, debug_ret)
+
+
+def stop(path, service_names=None):
+    """
+    Stop running containers in the docker-compose file, service_names is a python
+    list, if omitted stop all containers
+
+    path
+        Path where the docker-compose file is stored on the server
+    service_names
+        If specified will stop only the specified services
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion dockercompose.stop /path/to/docker-compose.yml
+        salt myminion dockercompose.stop  /path/to/docker-compose.yml '[janus]'
+    """
+
+    project = __load_project(path)
+    debug_ret = {}
+    result = {}
+    if type(project) is dict:
+        return project
+    else:
+        try:
+            project.stop(service_names)
+            if debug:
+                for container in project.containers(stopped=True):
+                    if service_names is None or container.get('Name')[1:] in service_names:
+                        container.inspect_if_not_inspected()
+                        debug_ret[container.get('Name')] = container.inspect()
+                        result[container.get('Name')] = 'stopped'
+        except Exception as inst:
+            return __handle_except(inst)
+    return __standardize_result(True, 'Stopping containers via docker-compose', result, debug_ret)
 
 
 def pause(path, service_names=None, **kwargs):
-	"""
-	Pause running containers
+    """
+    Pause running containers in the docker-compose file, service_names is a python
+    list, if omitted pause all containers
 
-	path
-		Path where the docker-compose file is stored on the server
-	service_names
-		If specified will restart only the specified services
-	:return:
-	"""
+    path
+        Path where the docker-compose file is stored on the server
+    service_names
+        If specified will pause only the specified services
 
-	project = __load_project(path)
-	debug_ret = {}
-	result = {}
-	if type(project) is dict:
-		return project
-	else:
-		try:
-			project.pause(service_names)
-			if debug:
-				for container in project.containers():
-					if service_names is None or container.get('Name')[1:] in service_names:
-						container.inspect_if_not_inspected()
-						debug_ret[container.get('Name')] = container.inspect()
-						result[container.get('Name')] = 'paused'
-		except Exception as inst:
-			return __handle_except(inst)
-	return __standardize_result(True, 'Pausing containers via docker-compose', result, debug_ret)
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion dockercompose.pause /path/to/docker-compose.yml
+        salt myminion dockercompose.pause /path/to/docker-compose.yml '[janus]'
+    """
+
+    project = __load_project(path)
+    debug_ret = {}
+    result = {}
+    if type(project) is dict:
+        return project
+    else:
+        try:
+            project.pause(service_names)
+            if debug:
+                for container in project.containers():
+                    if service_names is None or container.get('Name')[1:] in service_names:
+                        container.inspect_if_not_inspected()
+                        debug_ret[container.get('Name')] = container.inspect()
+                        result[container.get('Name')] = 'paused'
+        except Exception as inst:
+            return __handle_except(inst)
+    return __standardize_result(True, 'Pausing containers via docker-compose', result, debug_ret)
 
 
 def unpause(path, service_names=None, **kwargs):
-	"""
-	Un-Pause paused containers
+    """
+    Un-Pause containers in the docker-compose file, service_names is a python
+    list, if omitted unpause all containers
 
-	path
-		Path where the docker-compose file is stored on the server
-	service_names
-		If specified will restart only the specified services
-	:return:
-	"""
+    path
+        Path where the docker-compose file is stored on the server
+    service_names
+        If specified will un-pause only the specified services
 
-	project = __load_project(path)
-	debug_ret = {}
-	result = {}
-	if type(project) is dict:
-		return project
-	else:
-		try:
-			project.unpause(service_names)
-			if debug:
-				for container in project.containers():
-					if service_names is None or container.get('Name')[1:] in service_names:
-						container.inspect_if_not_inspected()
-						debug_ret[container.get('Name')] = container.inspect()
-						result[container.get('Name')] = 'unpaused'
-		except Exception as inst:
-			return __handle_except(inst)
-	return __standardize_result(True, 'Un-Pausing containers via docker-compose', result, debug_ret)
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion dockercompose.pause /path/to/docker-compose.yml
+        salt myminion dockercompose.pause /path/to/docker-compose.yml '[janus]'
+    """
+
+    project = __load_project(path)
+    debug_ret = {}
+    result = {}
+    if type(project) is dict:
+        return project
+    else:
+        try:
+            project.unpause(service_names)
+            if debug:
+                for container in project.containers():
+                    if service_names is None or container.get('Name')[1:] in service_names:
+                        container.inspect_if_not_inspected()
+                        debug_ret[container.get('Name')] = container.inspect()
+                        result[container.get('Name')] = 'unpaused'
+        except Exception as inst:
+            return __handle_except(inst)
+    return __standardize_result(True, 'Un-Pausing containers via docker-compose', result, debug_ret)
 
 
 def start(path, service_names=None, **kwargs):
-	"""
-	Start stopped containers
+    """
+    Start containers in the docker-compose file, service_names is a python
+    list, if omitted start all containers
 
-	path
-		Path where the docker-compose file is stored on the server
-	service_names
-		If specified will restart only the specified services
-	:return:
-	"""
+    path
+        Path where the docker-compose file is stored on the server
+    service_names
+        If specified will start only the specified services
 
-	project = __load_project(path)
-	debug_ret = {}
-	result = {}
-	if type(project) is dict:
-		return project
-	else:
-		try:
-			project.start(service_names)
-			if debug:
-				for container in project.containers():
-					if service_names is None or container.get('Name')[1:] in service_names:
-						container.inspect_if_not_inspected()
-						debug_ret[container.get('Name')] = container.inspect()
-						result[container.get('Name')] = 'started'
-		except Exception as inst:
-			return __handle_except(inst)
-	return __standardize_result(True, 'Starting containers via docker-compose', result, debug_ret)
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion dockercompose.start /path/to/docker-compose.yml
+        salt myminion dockercompose.start /path/to/docker-compose.yml '[janus]'
+    """
+
+    project = __load_project(path)
+    debug_ret = {}
+    result = {}
+    if type(project) is dict:
+        return project
+    else:
+        try:
+            project.start(service_names)
+            if debug:
+                for container in project.containers():
+                    if service_names is None or container.get('Name')[1:] in service_names:
+                        container.inspect_if_not_inspected()
+                        debug_ret[container.get('Name')] = container.inspect()
+                        result[container.get('Name')] = 'started'
+        except Exception as inst:
+            return __handle_except(inst)
+    return __standardize_result(True, 'Starting containers via docker-compose', result, debug_ret)
 
 
 def kill(path, service_names=None, **kwargs):
-	"""
-	Kill running containers
+    """
+    Kill containers in the docker-compose file, service_names is a python
+    list, if omitted kill all containers
 
-	path
-		Path where the docker-compose file is stored on the server
-	service_names
-		If specified will restart only the specified services
-	:return:
-	"""
+    path
+        Path where the docker-compose file is stored on the server
+    service_names
+        If specified will kill only the specified services
 
-	project = __load_project(path)
-	debug_ret = {}
-	result = {}
-	if type(project) is dict:
-		return project
-	else:
-		try:
-			project.kill(service_names)
-			if debug:
-				for container in project.containers(stopped=True):
-					if service_names is None or container.get('Name')[1:] in service_names:
-						container.inspect_if_not_inspected()
-						debug_ret[container.get('Name')] = container.inspect()
-						result[container.get('Name')] = 'killed'
-		except Exception as inst:
-			return __handle_except(inst)
-	return __standardize_result(True, 'Killing containers via docker-compose', result, debug_ret)
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion dockercompose.kill /path/to/docker-compose.yml
+        salt myminion dockercompose.kill /path/to/docker-compose.yml '[janus]'
+    """
+
+    project = __load_project(path)
+    debug_ret = {}
+    result = {}
+    if type(project) is dict:
+        return project
+    else:
+        try:
+            project.kill(service_names)
+            if debug:
+                for container in project.containers(stopped=True):
+                    if service_names is None or container.get('Name')[1:] in service_names:
+                        container.inspect_if_not_inspected()
+                        debug_ret[container.get('Name')] = container.inspect()
+                        result[container.get('Name')] = 'killed'
+        except Exception as inst:
+            return __handle_except(inst)
+    return __standardize_result(True, 'Killing containers via docker-compose', result, debug_ret)
 
 
 def rm(path, service_names=None, **kwargs):
-	"""
-	Remove stopped containers
+    """
+    Remove stopped containers in the docker-compose file, service_names is a python
+    list, if omitted remove all stopped containers
 
-	path
-		Path where the docker-compose file is stored on the server
-	service_names
-		If specified will restart only the specified services
-	:return:
-	"""
+    path
+        Path where the docker-compose file is stored on the server
+    service_names
+        If specified will remove only the specified stopped services
 
-	project = __load_project(path)
-	if type(project) is dict:
-		return project
-	else:
-		try:
-			project.remove_stopped(service_names)
-		except Exception as inst:
-			return __handle_except(inst)
-	return __standardize_result(True, 'Removing stopped containers via docker-compose', None, None)
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion dockercompose.rm /path/to/docker-compose.yml
+        salt myminion dockercompose.rm /path/to/docker-compose.yml '[janus]'
+    """
+
+    project = __load_project(path)
+    if type(project) is dict:
+        return project
+    else:
+        try:
+            project.remove_stopped(service_names)
+        except Exception as inst:
+            return __handle_except(inst)
+    return __standardize_result(True, 'Removing stopped containers via docker-compose', None, None)
 
 
 def ps(path, **kwargs):
-	"""
-	Return a list of the running containers for the docker-compose app
+    """
+    List all running containers and report some information about them
 
-	path
-		Path where the docker-compose file is stored on the server
-	:return:
-	"""
-	project = __load_project(path)
-	result = {}
-	if type(project) is dict:
-		return project
-	else:
-		containers = sorted(
-			project.containers(None, stopped=True) +
-			project.containers(None, one_off=True),
-			key=attrgetter('name'))
-		for container in containers:
-			command = container.human_readable_command
-			if len(command) > 30:
-				command = '%s ...' % command[:26]
-			result[container.name] = {
-				'id': container.id,
-				'name': container.name,
-				'command': command,
-				'state': container.human_readable_state,
-				'ports': container.human_readable_ports,
-			}
-	return __standardize_result(True, "Listing docker-compose containers", result, None)
+    path
+        Path where the docker-compose file is stored on the server
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion dockercompose.ps /path/to/docker-compose.yml
+    """
+
+    project = __load_project(path)
+    result = {}
+    if type(project) is dict:
+        return project
+    else:
+        containers = sorted(
+            project.containers(None, stopped=True) +
+            project.containers(None, one_off=True),
+            key=attrgetter('name'))
+        for container in containers:
+            command = container.human_readable_command
+            if len(command) > 30:
+                command = '%s ...' % command[:26]
+            result[container.name] = {
+                'id': container.id,
+                'name': container.name,
+                'command': command,
+                'state': container.human_readable_state,
+                'ports': container.human_readable_ports,
+            }
+    return __standardize_result(True, "Listing docker-compose containers", result, None)
 
 
-def up(path, service_names=None, **kwargs):
-	"""
-	Create and start containers
+def up(path, service_names=None):
+    """
+    Create and start containers defined in the the docker-compose.yml file
+    located in path, service_names is a python list, if omitted create and
+    start all containers
 
-	path
-		Path where the docker-compose file is  stored on the server
-	service_names
-		If specified will restart only the specified services
-	:return:
-	"""
+    path
+        Path where the docker-compose file is stored on the server
+    service_names
+        If specified will create and start only the specified services
 
-	debug_ret = {}
-	project = __load_project(path)
-	if type(project) is dict:
-		return project
-	else:
-		try:
-			result = _get_convergence_plans(project, service_names)
-			ret = project.up(service_names)
-			if debug:
-				for container in ret:
-					if service_names is None or container.get('Name')[1:] in service_names:
-						container.inspect_if_not_inspected()
-						debug_ret[container.get('Name')] = container.inspect()
-		except Exception as inst:
-			return __handle_except(inst)
-	return __standardize_result(True, 'Adding containers via docker-compose', result, debug_ret)
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion dockercompose.up /path/to/docker-compose.yml
+        salt myminion dockercompose.up /path/to/docker-compose.yml '[janus]'
+    """
+
+    debug_ret = {}
+    project = __load_project(path)
+    if type(project) is dict:
+        return project
+    else:
+        try:
+            result = _get_convergence_plans(project, service_names)
+            ret = project.up(service_names)
+            if debug:
+                for container in ret:
+                    if service_names is None or container.get('Name')[1:] in service_names:
+                        container.inspect_if_not_inspected()
+                        debug_ret[container.get('Name')] = container.inspect()
+        except Exception as inst:
+            return __handle_except(inst)
+    return __standardize_result(True, 'Adding containers via docker-compose', result, debug_ret)

--- a/salt/modules/dockercompose.py
+++ b/salt/modules/dockercompose.py
@@ -251,7 +251,7 @@ def create(path, docker_compose):
 
     .. code-block:: bash
 
-        salt myminion dockercompose.create /path/to/docker-compose.yml content
+        salt myminion dockercompose.create /path/where/docker-compose/stored content
     '''
     if docker_compose:
         ret = __write_docker_compose(path, docker_compose)
@@ -279,8 +279,8 @@ def restart(path, service_names=None):
 
     .. code-block:: bash
 
-        salt myminion dockercompose.restart /path/to/docker-compose.yml
-        salt myminion dockercompose.restart /path/to/docker-compose.yml '[janus]'
+        salt myminion dockercompose.restart /path/where/docker-compose/stored
+        salt myminion dockercompose.restart /path/where/docker-compose/stored '[janus]'
     '''
 
     project = __load_project(path)
@@ -316,8 +316,8 @@ def stop(path, service_names=None):
 
     .. code-block:: bash
 
-        salt myminion dockercompose.stop /path/to/docker-compose.yml
-        salt myminion dockercompose.stop  /path/to/docker-compose.yml '[janus]'
+        salt myminion dockercompose.stop /path/where/docker-compose/stored
+        salt myminion dockercompose.stop  /path/where/docker-compose/stored '[janus]'
     '''
 
     project = __load_project(path)
@@ -353,8 +353,8 @@ def pause(path, service_names=None):
 
     .. code-block:: bash
 
-        salt myminion dockercompose.pause /path/to/docker-compose.yml
-        salt myminion dockercompose.pause /path/to/docker-compose.yml '[janus]'
+        salt myminion dockercompose.pause /path/where/docker-compose/stored
+        salt myminion dockercompose.pause /path/where/docker-compose/stored '[janus]'
     '''
 
     project = __load_project(path)
@@ -390,8 +390,8 @@ def unpause(path, service_names=None):
 
     .. code-block:: bash
 
-        salt myminion dockercompose.pause /path/to/docker-compose.yml
-        salt myminion dockercompose.pause /path/to/docker-compose.yml '[janus]'
+        salt myminion dockercompose.pause /path/where/docker-compose/stored
+        salt myminion dockercompose.pause /path/where/docker-compose/stored '[janus]'
     '''
 
     project = __load_project(path)
@@ -427,8 +427,8 @@ def start(path, service_names=None):
 
     .. code-block:: bash
 
-        salt myminion dockercompose.start /path/to/docker-compose.yml
-        salt myminion dockercompose.start /path/to/docker-compose.yml '[janus]'
+        salt myminion dockercompose.start /path/where/docker-compose/stored
+        salt myminion dockercompose.start /path/where/docker-compose/stored '[janus]'
     '''
 
     project = __load_project(path)
@@ -464,8 +464,8 @@ def kill(path, service_names=None):
 
     .. code-block:: bash
 
-        salt myminion dockercompose.kill /path/to/docker-compose.yml
-        salt myminion dockercompose.kill /path/to/docker-compose.yml '[janus]'
+        salt myminion dockercompose.kill /path/where/docker-compose/stored
+        salt myminion dockercompose.kill /path/where/docker-compose/stored '[janus]'
     '''
 
     project = __load_project(path)
@@ -501,8 +501,8 @@ def rm(path, service_names=None):
 
     .. code-block:: bash
 
-        salt myminion dockercompose.rm /path/to/docker-compose.yml
-        salt myminion dockercompose.rm /path/to/docker-compose.yml '[janus]'
+        salt myminion dockercompose.rm /path/where/docker-compose/stored
+        salt myminion dockercompose.rm /path/where/docker-compose/stored '[janus]'
     '''
 
     project = __load_project(path)
@@ -527,7 +527,7 @@ def ps(path):
 
     .. code-block:: bash
 
-        salt myminion dockercompose.ps /path/to/docker-compose.yml
+        salt myminion dockercompose.ps /path/where/docker-compose/stored
     '''
 
     project = __load_project(path)
@@ -568,8 +568,8 @@ def up(path, service_names=None):
 
     .. code-block:: bash
 
-        salt myminion dockercompose.up /path/to/docker-compose.yml
-        salt myminion dockercompose.up /path/to/docker-compose.yml '[janus]'
+        salt myminion dockercompose.up /path/where/docker-compose/stored
+        salt myminion dockercompose.up /path/where/docker-compose/stored '[janus]'
     '''
 
     debug_ret = {}

--- a/salt/modules/dockercompose.py
+++ b/salt/modules/dockercompose.py
@@ -16,11 +16,9 @@ This module allows to deal with docker-compose file in a directory.
 
 This is  a first version only, the following commands are missing at the moment
 but will be built later on if the community is interested in this module:
-  - build
   - run
   - logs
   - port
-  - pull
   - scale
 
 Installation Prerequisites
@@ -73,6 +71,8 @@ Docker-compose method supported
  - kill
  - rm
  - ps
+ - pull
+ - build
 
 Functions
 ---------
@@ -88,6 +88,9 @@ Functions
     - :py:func:`dockercompose.kill <salt.modules.dockercompose.kill>`
     - :py:func:`dockercompose.rm <salt.modules.dockercompose.rm>`
     - :py:func:`dockercompose.up <salt.modules.dockercompose.up>`
+- Manage containers image:
+    - :py:func:`dockercompose.pull <salt.modules.dockercompose.pull>`
+    - :py:func:`dockercompose.build <salt.modules.dockercompose.build>`
 - Gather informations about containers:
     - :py:func:`dockercompose.ps <salt.modules.dockercompose.ps>`
 
@@ -303,6 +306,70 @@ def create(path, docker_compose):
                                     'Creating a docker-compose project failed, you must send a valid docker-compose file',
                                     None, None)
     return __standardize_result(True, 'Successfully created the docker-compose file', {'compose.base_dir': path}, None)
+
+
+def pull(path, service_names=None):
+    '''
+    Pull image for containers in the docker-compose file, service_names is a
+    python list, if omitted pull all images
+
+    path
+        Path where the docker-compose file is stored on the server
+    service_names
+        If specified will pull only the image for the specified services
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion dockercompose.pull /path/where/docker-compose/stored
+        salt myminion dockercompose.pull /path/where/docker-compose/stored '[janus]'
+    '''
+
+    project = __load_project(path)
+    if isinstance(project, dict):
+        return project
+    else:
+        try:
+            project.pull(service_names)
+        except Exception as inst:
+            return __handle_except(inst)
+    return __standardize_result(True, 'Pulling containers images via docker-compose succeeded',
+                                None, None)
+
+
+def build(path, service_names=None):
+    '''
+    Build image for containers in the docker-compose file, service_names is a
+    python list, if omitted build images for all containers. Please note
+    that at the moment the module does not allow you to upload your Dockerfile,
+    nor any other file you could need with your docker-compose.yml, you will
+    have to make sure the files you need are actually in the directory sepcified
+    in the `build` keyword
+
+    path
+        Path where the docker-compose file is stored on the server
+    service_names
+        If specified will pull only the image for the specified services
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion dockercompose.build /path/where/docker-compose/stored
+        salt myminion dockercompose.build /path/where/docker-compose/stored '[janus]'
+    '''
+
+    project = __load_project(path)
+    if isinstance(project, dict):
+        return project
+    else:
+        try:
+            project.build(service_names)
+        except Exception as inst:
+            return __handle_except(inst)
+    return __standardize_result(True, 'Building containers images via docker-compose succeeded',
+                                None, None)
 
 
 def restart(path, service_names=None):

--- a/salt/modules/dockercompose.py
+++ b/salt/modules/dockercompose.py
@@ -78,6 +78,7 @@ Functions
 ---------
 - docker-compose.yml management
     - :py:func:`dockercompose.create <salt.modules.dockercompose.create>`
+    - :py:func:`dockercompose.get <salt.modules.dockercompose.get>`
 - Manage containers
     - :py:func:`dockercompose.restart <salt.modules.dockercompose.restart>`
     - :py:func:`dockercompose.stop <salt.modules.dockercompose.stop>`
@@ -154,6 +155,30 @@ def __standardize_result(status, message, data=None, debug_msg=None):
         result['debug'] = debug_msg
 
     return result
+
+
+def __read_docker_compose(path):
+    '''
+    Read the docker-compose.yml file if it exists in the directory
+
+    :param path:
+    :return:
+    '''
+    if os.path.isfile(os.path.join(path, dc_filename)) is False:
+        return __standardize_result(False,
+                                    'Path does not exist or docker-compose.yml is not present',
+                                    None, None)
+    f = open(os.path.join(path, dc_filename), 'r')
+    result = {'docker-compose.yml': ''}
+    if f:
+        for line in f:
+            result['docker-compose.yml'] += line
+        f.close()
+    else:
+        return __standardize_result(False, 'Could not read docker-compose.yml file.',
+                                    None, None)
+    return __standardize_result(True, 'Reading content of docker-compose.yml file',
+                                result, None)
 
 
 def __write_docker_compose(path, docker_compose):
@@ -235,6 +260,22 @@ def _get_convergence_plans(project, service_names):
         elif action == 'noop':
             ret[cont] = 'Container is up to date'
     return ret
+
+
+def get(path):
+    '''
+    Get the content of the docker-compose file into a directory
+
+    path
+        Path where the docker-compose file is stored on the server
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion dockercompose.get /path/where/docker-compose/stored
+    '''
+    return __read_docker_compose(path)
 
 
 def create(path, docker_compose):

--- a/salt/modules/dockercompose.py
+++ b/salt/modules/dockercompose.py
@@ -1,0 +1,438 @@
+
+# -*- coding: utf-8 -*-
+"""
+:maintainer: Jean Praloran <jeanpralo@gmail.com>
+:maturity: new
+:depends: docker-compose>=1.5
+:platform: all
+
+Module to import docker-compose via saltstack
+Author: Jean Praloran (jeanpralo@gmail.com)
+All commands are not implemented yet (feel free to extend or PR):
+  - build
+  - run
+
+  - logs
+  - port
+  - pull
+  - scale
+"""
+
+import inspect
+import logging
+import os
+import re
+
+from operator import attrgetter
+try:
+	import compose
+	from compose.cli.command import get_project
+	from compose.service import ConvergenceStrategy
+	HAS_DOCKERCOMPOSE = True
+except ImportError:
+	HAS_DOCKERCOMPOSE = False
+
+MIN_DOCKERCOMPOSE = (1, 5, 0)
+VERSION_RE = r'([\d.]+)'
+
+log = logging.getLogger(__name__)
+debug = True
+
+__virtualname__ = 'dockercompose'
+dc_filename = "docker-compose.yml"
+
+
+def __virtual__():
+	if HAS_DOCKERCOMPOSE:
+		match = re.match(VERSION_RE, str(compose.__version__))
+		if match:
+			version = tuple([int(x) for x in match.group(1).split('.')])
+			if MIN_DOCKERCOMPOSE >= version:
+				return __virtualname__
+		else:
+			log.critical("Minimum version of docker-compose>=1.5.0")
+	return False
+
+
+def __standardize_result(status, message, data=None, debug_msg=None):
+	"""
+	Standardizes all responses
+
+	:param status:
+	:param message:
+	:param data:
+	:param debug_msg:
+	:return:
+	"""
+	result = {
+		'status': status,
+		'message': message
+	}
+
+	if data is not None:
+		result['return'] = data
+
+	if debug_msg is not None and debug:
+		result['debug'] = debug_msg
+
+	return result
+
+
+def __write_docker_compose(path, docker_compose):
+	"""
+	Write docker-compose to a temp directory
+	in order to use it with docker-compose ( config check )
+
+	:param path:
+
+	docker_compose
+		contains the docker-compose file
+
+	:return:
+	"""
+
+	if os.path.isdir(path) is False:
+		os.mkdir(path)
+	f = open(os.path.join(path, dc_filename), 'w')
+	if f:
+		f.write(docker_compose)
+		f.close()
+	else:
+		return __standardize_result(False, "Could not write docker-compose file in %s" % path, None, None)
+	project = __load_project(path)
+	if type(project) is dict:
+		os.remove(os.path.join(path, dc_filename))
+		return project
+	return path
+
+
+def __load_project(path):
+	"""
+	Load a docker-compose project from path
+
+	:param path:
+	:return:
+	"""
+	try:
+		project = get_project(path)
+	except Exception as inst:
+		return __handle_except(inst)
+	return project
+
+
+def __handle_except(inst):
+	"""
+	Handle exception and return a standart result
+
+	:param inst:
+	:return:
+	"""
+	return __standardize_result(False, "Docker-compose command %s failed" % (inspect.stack()[1][3]), "%s" % (inst), None)
+
+
+def _get_convergence_plans(project, service_names):
+	"""
+	Get action executed for each container
+
+	:param project:
+	:param service_names:
+	:return:
+	"""
+	ret = {}
+	plans = project._get_convergence_plans(project.get_services(service_names), ConvergenceStrategy.changed)
+	for cont in plans:
+		(action, container) = plans[cont]
+		if action == 'create':
+			ret[cont] = "Creating container"
+		elif action == 'recreate':
+			ret[cont] = "Re-creating container"
+		elif action == 'start':
+			ret[cont] = "Starting container"
+		elif action == 'noop':
+			ret[cont] = "Container is up to date"
+	return ret
+
+
+def create(path, docker_compose, **kwargs):
+	"""
+	Create and validate a docker-compose file into a directory
+
+	path
+		Path where the docker-compose file will be stored on the server
+
+	docker_compose
+		docker_compose file
+
+	:param kwargs:
+	:return:
+	"""
+	if docker_compose:
+		ret = __write_docker_compose(path, docker_compose)
+		if type(ret) is dict:
+			return ret
+	else:
+		return __standardize_result(False, "Creating a docker-compose project failed, you must send a valid docker-compose file", None, None)
+	return __standardize_result(True, "Successfully created the docker-compose file", {'compose.base_dir': path}, None)
+
+
+def restart(path, service_names=None, **kwargs):
+	"""
+	Restart a docker-compose application
+
+	path
+		Path where the docker-compose file is stored on the server
+
+	service_names
+		If specified will restart only the specified services
+	:return:
+	"""
+
+	project = __load_project(path)
+	debug_ret = {}
+	result = {}
+	if type(project) is dict:
+		return project
+	else:
+		try:
+			project.restart(service_names)
+			if debug:
+				for container in project.containers():
+					if service_names is None or container.get('Name')[1:] in service_names:
+						container.inspect_if_not_inspected()
+						debug_ret[container.get('Name')] = container.inspect()
+						result[container.get('Name')] = 'restarted'
+		except Exception as inst:
+			return __handle_except(inst)
+	return __standardize_result(True, 'Restarting containers via docker-compose', result, debug_ret)
+
+
+def stop(path, service_names=None, **kwargs):
+	"""
+	Stop running containers
+
+	path
+		Path where the docker-compose file is stored on the server
+	service_names
+		If specified will restart only the specified services
+	:return:
+	"""
+
+	project = __load_project(path)
+	debug_ret = {}
+	result = {}
+	if type(project) is dict:
+		return project
+	else:
+		try:
+			project.stop(service_names)
+			if debug:
+				for container in project.containers(stopped=True):
+					if service_names is None or container.get('Name')[1:] in service_names:
+						container.inspect_if_not_inspected()
+						debug_ret[container.get('Name')] = container.inspect()
+						result[container.get('Name')] = 'stopped'
+		except Exception as inst:
+			return __handle_except(inst)
+	return __standardize_result(True, 'Stopping containers via docker-compose', result, debug_ret)
+
+
+def pause(path, service_names=None, **kwargs):
+	"""
+	Pause running containers
+
+	path
+		Path where the docker-compose file is stored on the server
+	service_names
+		If specified will restart only the specified services
+	:return:
+	"""
+
+	project = __load_project(path)
+	debug_ret = {}
+	result = {}
+	if type(project) is dict:
+		return project
+	else:
+		try:
+			project.pause(service_names)
+			if debug:
+				for container in project.containers():
+					if service_names is None or container.get('Name')[1:] in service_names:
+						container.inspect_if_not_inspected()
+						debug_ret[container.get('Name')] = container.inspect()
+						result[container.get('Name')] = 'paused'
+		except Exception as inst:
+			return __handle_except(inst)
+	return __standardize_result(True, 'Pausing containers via docker-compose', result, debug_ret)
+
+
+def unpause(path, service_names=None, **kwargs):
+	"""
+	Un-Pause paused containers
+
+	path
+		Path where the docker-compose file is stored on the server
+	service_names
+		If specified will restart only the specified services
+	:return:
+	"""
+
+	project = __load_project(path)
+	debug_ret = {}
+	result = {}
+	if type(project) is dict:
+		return project
+	else:
+		try:
+			project.unpause(service_names)
+			if debug:
+				for container in project.containers():
+					if service_names is None or container.get('Name')[1:] in service_names:
+						container.inspect_if_not_inspected()
+						debug_ret[container.get('Name')] = container.inspect()
+						result[container.get('Name')] = 'unpaused'
+		except Exception as inst:
+			return __handle_except(inst)
+	return __standardize_result(True, 'Un-Pausing containers via docker-compose', result, debug_ret)
+
+
+def start(path, service_names=None, **kwargs):
+	"""
+	Start stopped containers
+
+	path
+		Path where the docker-compose file is stored on the server
+	service_names
+		If specified will restart only the specified services
+	:return:
+	"""
+
+	project = __load_project(path)
+	debug_ret = {}
+	result = {}
+	if type(project) is dict:
+		return project
+	else:
+		try:
+			project.start(service_names)
+			if debug:
+				for container in project.containers():
+					if service_names is None or container.get('Name')[1:] in service_names:
+						container.inspect_if_not_inspected()
+						debug_ret[container.get('Name')] = container.inspect()
+						result[container.get('Name')] = 'started'
+		except Exception as inst:
+			return __handle_except(inst)
+	return __standardize_result(True, 'Starting containers via docker-compose', result, debug_ret)
+
+
+def kill(path, service_names=None, **kwargs):
+	"""
+	Kill running containers
+
+	path
+		Path where the docker-compose file is stored on the server
+	service_names
+		If specified will restart only the specified services
+	:return:
+	"""
+
+	project = __load_project(path)
+	debug_ret = {}
+	result = {}
+	if type(project) is dict:
+		return project
+	else:
+		try:
+			project.kill(service_names)
+			if debug:
+				for container in project.containers(stopped=True):
+					if service_names is None or container.get('Name')[1:] in service_names:
+						container.inspect_if_not_inspected()
+						debug_ret[container.get('Name')] = container.inspect()
+						result[container.get('Name')] = 'killed'
+		except Exception as inst:
+			return __handle_except(inst)
+	return __standardize_result(True, 'Killing containers via docker-compose', result, debug_ret)
+
+
+def rm(path, service_names=None, **kwargs):
+	"""
+	Remove stopped containers
+
+	path
+		Path where the docker-compose file is stored on the server
+	service_names
+		If specified will restart only the specified services
+	:return:
+	"""
+
+	project = __load_project(path)
+	if type(project) is dict:
+		return project
+	else:
+		try:
+			project.remove_stopped(service_names)
+		except Exception as inst:
+			return __handle_except(inst)
+	return __standardize_result(True, 'Removing stopped containers via docker-compose', None, None)
+
+
+def ps(path, **kwargs):
+	"""
+	Return a list of the running containers for the docker-compose app
+
+	path
+		Path where the docker-compose file is stored on the server
+	:return:
+	"""
+	project = __load_project(path)
+	result = {}
+	if type(project) is dict:
+		return project
+	else:
+		containers = sorted(
+			project.containers(None, stopped=True) +
+			project.containers(None, one_off=True),
+			key=attrgetter('name'))
+		for container in containers:
+			command = container.human_readable_command
+			if len(command) > 30:
+				command = '%s ...' % command[:26]
+			result[container.name] = {
+				'id': container.id,
+				'name': container.name,
+				'command': command,
+				'state': container.human_readable_state,
+				'ports': container.human_readable_ports,
+			}
+	return __standardize_result(True, "Listing docker-compose containers", result, None)
+
+
+def up(path, service_names=None, **kwargs):
+	"""
+	Create and start containers
+
+	path
+		Path where the docker-compose file is  stored on the server
+	service_names
+		If specified will restart only the specified services
+	:return:
+	"""
+
+	debug_ret = {}
+	project = __load_project(path)
+	if type(project) is dict:
+		return project
+	else:
+		try:
+			result = _get_convergence_plans(project, service_names)
+			ret = project.up(service_names)
+			if debug:
+				for container in ret:
+					if service_names is None or container.get('Name')[1:] in service_names:
+						container.inspect_if_not_inspected()
+						debug_ret[container.get('Name')] = container.inspect()
+		except Exception as inst:
+			return __handle_except(inst)
+	return __standardize_result(True, 'Adding containers via docker-compose', result, debug_ret)

--- a/salt/modules/dockercompose.py
+++ b/salt/modules/dockercompose.py
@@ -1,6 +1,6 @@
 
 # -*- coding: utf-8 -*-
-"""
+'''
 Module to import docker-compose via saltstack
 
 .. versionadded:: Boron
@@ -22,6 +22,20 @@ but will be built later on if the community is interested in this module:
   - port
   - pull
   - scale
+
+Installation Prerequisites
+--------------------------
+
+This execution module requires at least version 1.4.0 of both docker-compose_ and
+Docker_. docker-compose can easily be installed using :py:func:`pip.install
+<salt.modules.pip.install>`:
+
+.. code-block:: bash
+
+    salt myminion pip.install docker-compose>=1.5.0
+
+.. _docker-compose: https://pypi.python.org/pypi/docker-compose
+.. _Docker: https://www.docker.com/
 
 
 How to use this module?
@@ -78,7 +92,7 @@ Functions
 
 Detailed Function Documentation
 -------------------------------
-"""
+'''
 
 from __future__ import absolute_import
 
@@ -100,10 +114,10 @@ MIN_DOCKERCOMPOSE = (1, 5, 0)
 VERSION_RE = r'([\d.]+)'
 
 log = logging.getLogger(__name__)
-debug = True
+debug = False
 
 __virtualname__ = 'dockercompose'
-dc_filename = "docker-compose.yml"
+dc_filename = 'docker-compose.yml'
 
 
 def __virtual__():
@@ -114,12 +128,12 @@ def __virtual__():
             if MIN_DOCKERCOMPOSE >= version:
                 return __virtualname__
         else:
-            log.critical("Minimum version of docker-compose>=1.5.0")
+            log.critical('Minimum version of docker-compose>=1.5.0')
     return False
 
 
 def __standardize_result(status, message, data=None, debug_msg=None):
-    """
+    '''
     Standardizes all responses
 
     :param status:
@@ -127,7 +141,7 @@ def __standardize_result(status, message, data=None, debug_msg=None):
     :param data:
     :param debug_msg:
     :return:
-    """
+    '''
     result = {
         'status': status,
         'message': message
@@ -143,7 +157,7 @@ def __standardize_result(status, message, data=None, debug_msg=None):
 
 
 def __write_docker_compose(path, docker_compose):
-    """
+    '''
     Write docker-compose to a temp directory
     in order to use it with docker-compose ( config check )
 
@@ -153,7 +167,7 @@ def __write_docker_compose(path, docker_compose):
         contains the docker-compose file
 
     :return:
-    """
+    '''
 
     if os.path.isdir(path) is False:
         os.mkdir(path)
@@ -163,7 +177,7 @@ def __write_docker_compose(path, docker_compose):
         f.close()
     else:
         return __standardize_result(False,
-                                    "Could not write docker-compose file in {0}".format(path),
+                                    'Could not write docker-compose file in {0}'.format(path),
                                     None, None)
     project = __load_project(path)
     if isinstance(project, dict):
@@ -173,12 +187,12 @@ def __write_docker_compose(path, docker_compose):
 
 
 def __load_project(path):
-    """
+    '''
     Load a docker-compose project from path
 
     :param path:
     :return:
-    """
+    '''
     try:
         project = get_project(path)
     except Exception as inst:
@@ -187,44 +201,44 @@ def __load_project(path):
 
 
 def __handle_except(inst):
-    """
+    '''
     Handle exception and return a standart result
 
     :param inst:
     :return:
-    """
+    '''
     return __standardize_result(False,
-                                "Docker-compose command {0} failed".
+                                'Docker-compose command {0} failed'.
                                 format(inspect.stack()[1][3]),
-                                "{0}".format(inst), None)
+                                '{0}'.format(inst), None)
 
 
 def _get_convergence_plans(project, service_names):
-    """
+    '''
     Get action executed for each container
 
     :param project:
     :param service_names:
     :return:
-    """
+    '''
     ret = {}
     plans = project._get_convergence_plans(project.get_services(service_names),
                                            ConvergenceStrategy.changed)
     for cont in plans:
         (action, container) = plans[cont]
         if action == 'create':
-            ret[cont] = "Creating container"
+            ret[cont] = 'Creating container'
         elif action == 'recreate':
-            ret[cont] = "Re-creating container"
+            ret[cont] = 'Re-creating container'
         elif action == 'start':
-            ret[cont] = "Starting container"
+            ret[cont] = 'Starting container'
         elif action == 'noop':
-            ret[cont] = "Container is up to date"
+            ret[cont] = 'Container is up to date'
     return ret
 
 
 def create(path, docker_compose):
-    """
+    '''
     Create and validate a docker-compose file into a directory
 
     path
@@ -238,20 +252,20 @@ def create(path, docker_compose):
     .. code-block:: bash
 
         salt myminion dockercompose.create /path/to/docker-compose.yml content
-    """
+    '''
     if docker_compose:
         ret = __write_docker_compose(path, docker_compose)
         if isinstance(ret, dict):
             return ret
     else:
         return __standardize_result(False,
-                                    "Creating a docker-compose project failed, you must send a valid docker-compose file",
+                                    'Creating a docker-compose project failed, you must send a valid docker-compose file',
                                     None, None)
-    return __standardize_result(True, "Successfully created the docker-compose file", {'compose.base_dir': path}, None)
+    return __standardize_result(True, 'Successfully created the docker-compose file', {'compose.base_dir': path}, None)
 
 
 def restart(path, service_names=None):
-    """
+    '''
     Restart container(s) in the docker-compose file, service_names is a python
     list, if omitted restart all containers
 
@@ -267,7 +281,7 @@ def restart(path, service_names=None):
 
         salt myminion dockercompose.restart /path/to/docker-compose.yml
         salt myminion dockercompose.restart /path/to/docker-compose.yml '[janus]'
-    """
+    '''
 
     project = __load_project(path)
     debug_ret = {}
@@ -289,7 +303,7 @@ def restart(path, service_names=None):
 
 
 def stop(path, service_names=None):
-    """
+    '''
     Stop running containers in the docker-compose file, service_names is a python
     list, if omitted stop all containers
 
@@ -304,7 +318,7 @@ def stop(path, service_names=None):
 
         salt myminion dockercompose.stop /path/to/docker-compose.yml
         salt myminion dockercompose.stop  /path/to/docker-compose.yml '[janus]'
-    """
+    '''
 
     project = __load_project(path)
     debug_ret = {}
@@ -326,7 +340,7 @@ def stop(path, service_names=None):
 
 
 def pause(path, service_names=None):
-    """
+    '''
     Pause running containers in the docker-compose file, service_names is a python
     list, if omitted pause all containers
 
@@ -341,7 +355,7 @@ def pause(path, service_names=None):
 
         salt myminion dockercompose.pause /path/to/docker-compose.yml
         salt myminion dockercompose.pause /path/to/docker-compose.yml '[janus]'
-    """
+    '''
 
     project = __load_project(path)
     debug_ret = {}
@@ -363,7 +377,7 @@ def pause(path, service_names=None):
 
 
 def unpause(path, service_names=None):
-    """
+    '''
     Un-Pause containers in the docker-compose file, service_names is a python
     list, if omitted unpause all containers
 
@@ -378,7 +392,7 @@ def unpause(path, service_names=None):
 
         salt myminion dockercompose.pause /path/to/docker-compose.yml
         salt myminion dockercompose.pause /path/to/docker-compose.yml '[janus]'
-    """
+    '''
 
     project = __load_project(path)
     debug_ret = {}
@@ -400,7 +414,7 @@ def unpause(path, service_names=None):
 
 
 def start(path, service_names=None):
-    """
+    '''
     Start containers in the docker-compose file, service_names is a python
     list, if omitted start all containers
 
@@ -415,7 +429,7 @@ def start(path, service_names=None):
 
         salt myminion dockercompose.start /path/to/docker-compose.yml
         salt myminion dockercompose.start /path/to/docker-compose.yml '[janus]'
-    """
+    '''
 
     project = __load_project(path)
     debug_ret = {}
@@ -437,7 +451,7 @@ def start(path, service_names=None):
 
 
 def kill(path, service_names=None):
-    """
+    '''
     Kill containers in the docker-compose file, service_names is a python
     list, if omitted kill all containers
 
@@ -452,7 +466,7 @@ def kill(path, service_names=None):
 
         salt myminion dockercompose.kill /path/to/docker-compose.yml
         salt myminion dockercompose.kill /path/to/docker-compose.yml '[janus]'
-    """
+    '''
 
     project = __load_project(path)
     debug_ret = {}
@@ -474,7 +488,7 @@ def kill(path, service_names=None):
 
 
 def rm(path, service_names=None):
-    """
+    '''
     Remove stopped containers in the docker-compose file, service_names is a python
     list, if omitted remove all stopped containers
 
@@ -489,7 +503,7 @@ def rm(path, service_names=None):
 
         salt myminion dockercompose.rm /path/to/docker-compose.yml
         salt myminion dockercompose.rm /path/to/docker-compose.yml '[janus]'
-    """
+    '''
 
     project = __load_project(path)
     if isinstance(project, dict):
@@ -503,7 +517,7 @@ def rm(path, service_names=None):
 
 
 def ps(path):
-    """
+    '''
     List all running containers and report some information about them
 
     path
@@ -514,7 +528,7 @@ def ps(path):
     .. code-block:: bash
 
         salt myminion dockercompose.ps /path/to/docker-compose.yml
-    """
+    '''
 
     project = __load_project(path)
     result = {}
@@ -536,11 +550,11 @@ def ps(path):
                 'state': container.human_readable_state,
                 'ports': container.human_readable_ports,
             }
-    return __standardize_result(True, "Listing docker-compose containers", result, None)
+    return __standardize_result(True, 'Listing docker-compose containers', result, None)
 
 
 def up(path, service_names=None):
-    """
+    '''
     Create and start containers defined in the the docker-compose.yml file
     located in path, service_names is a python list, if omitted create and
     start all containers
@@ -556,7 +570,7 @@ def up(path, service_names=None):
 
         salt myminion dockercompose.up /path/to/docker-compose.yml
         salt myminion dockercompose.up /path/to/docker-compose.yml '[janus]'
-    """
+    '''
 
     debug_ret = {}
     project = __load_project(path)

--- a/salt/modules/dockercompose.py
+++ b/salt/modules/dockercompose.py
@@ -104,6 +104,7 @@ import inspect
 import logging
 import os
 import re
+import salt.utils
 
 from operator import attrgetter
 try:
@@ -171,7 +172,7 @@ def __read_docker_compose(path):
         return __standardize_result(False,
                                     'Path does not exist or docker-compose.yml is not present',
                                     None, None)
-    f = open(os.path.join(path, dc_filename), 'r')
+    f = salt.utils.fopen(os.path.join(path, dc_filename), 'r')
     result = {'docker-compose.yml': ''}
     if f:
         for line in f:
@@ -199,7 +200,7 @@ def __write_docker_compose(path, docker_compose):
 
     if os.path.isdir(path) is False:
         os.mkdir(path)
-    f = open(os.path.join(path, dc_filename), 'w')
+    f = salt.utils.fopen(os.path.join(path, dc_filename), 'w')
     if f:
         f.write(docker_compose)
         f.close()


### PR DESCRIPTION
This module allows to deal with docker-compose file in a directory.

This is  a first version only, the following commands are missing at the moment but will be built later on if the community is interested in this module:
- build
- run
- logs
- port
- pull
- scale

In order to use the module if you have no docker-compose file on the server you can issue the command create, it takes two arguments the path where the docker-compose.yml will be stored and the content of this latter:

  # salt-call -l debug dockercompose.create /tmp/toto '
database:
  image: mongo:3.0
  command: mongod --smallfiles --quiet --logpath=/dev/null
'

Then you can execute a list of method defined at the bottom with at least one argument (the path where the docker-compose.yml will be read) and an optional python list which corresponds to the services names:

 # salt-call -l debug dockercompose.up /tmp/toto
 # salt-call -l debug dockercompose.restart /tmp/toto '[database]'
 # salt-call -l debug dockercompose.stop /tmp/toto
 # salt-call -l debug dockercompose.rm /tmp/toto

Method supported:
- up
- restart
- stop
- start
- pause
- unpause
- kill
- rm
- ps

Code might be a bit redundant for some functions might want to use pointer to function at some places if you think thats a good idea, otherwise I find it pretty readable like that.

Cheers.
