### PR TITLE
[modules/service] Add run function to run services with custom arguments

### DIFF
--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -64,6 +64,32 @@ def __virtual__():
     return 'service'
 
 
+def run(name, action):
+    '''
+    Run the specified service with an action.
+
+    .. versionadded:: 2015.8.1
+
+    name
+        Service name.
+
+    action
+        Action name (like start,  stop,  reload,  restart).
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.run apache2 reload
+        salt '*' service.run postgresql initdb
+    '''
+    cmd = os.path.join(
+        _GRAINMAP.get(__grains__.get('os'), '/etc/init.d'),
+        name
+    ) + ' ' + action
+    return not __salt__['cmd.retcode'](cmd, python_shell=False)
+
+
 def start(name):
     '''
     Start the specified service
@@ -74,11 +100,7 @@ def start(name):
 
         salt '*' service.start <service name>
     '''
-    cmd = os.path.join(
-        _GRAINMAP.get(__grains__.get('os'), '/etc/init.d'),
-        name
-    ) + ' start'
-    return not __salt__['cmd.retcode'](cmd, python_shell=False)
+    return __salt__['service.run'](name, 'start')
 
 
 def stop(name):
@@ -91,11 +113,7 @@ def stop(name):
 
         salt '*' service.stop <service name>
     '''
-    cmd = os.path.join(
-        _GRAINMAP.get(__grains__.get('os'), '/etc/init.d'),
-        name
-    ) + ' stop'
-    return not __salt__['cmd.retcode'](cmd, python_shell=False)
+    return __salt__['service.run'](name, 'stop')
 
 
 def restart(name):
@@ -108,11 +126,7 @@ def restart(name):
 
         salt '*' service.restart <service name>
     '''
-    cmd = os.path.join(
-        _GRAINMAP.get(__grains__.get('os'), '/etc/init.d'),
-        name
-    ) + ' restart'
-    return not __salt__['cmd.retcode'](cmd, python_shell=False)
+    return __salt__['service.run'](name, 'restart')
 
 
 def status(name, sig=None):
@@ -141,11 +155,7 @@ def reload_(name):
 
         salt '*' service.reload <service name>
     '''
-    cmd = os.path.join(
-        _GRAINMAP.get(__grains__.get('os'), '/etc/init.d'),
-        name
-    ) + ' reload'
-    return not __salt__['cmd.retcode'](cmd, python_shell=False)
+    return __salt__['service.run'](name, 'reload')
 
 
 def available(name):

--- a/tests/unit/modules/service_test.py
+++ b/tests/unit/modules/service_test.py
@@ -36,7 +36,7 @@ class ServiceTestCase(TestCase):
         Test to start the specified service
         '''
         with patch.object(os.path, 'join', return_value='A'):
-            with patch.dict(service.__salt__, {'cmd.retcode':
+            with patch.dict(service.__salt__, {'service.run':
                                                MagicMock(return_value=False)}):
                 self.assertTrue(service.start('name'))
 
@@ -45,7 +45,7 @@ class ServiceTestCase(TestCase):
         Test to stop the specified service
         '''
         with patch.object(os.path, 'join', return_value='A'):
-            with patch.dict(service.__salt__, {'cmd.retcode':
+            with patch.dict(service.__salt__, {'service.run':
                                                MagicMock(return_value=False)}):
                 self.assertTrue(service.stop('name'))
 
@@ -54,7 +54,7 @@ class ServiceTestCase(TestCase):
         Test to restart the specified service
         '''
         with patch.object(os.path, 'join', return_value='A'):
-            with patch.dict(service.__salt__, {'cmd.retcode':
+            with patch.dict(service.__salt__, {'service.run':
                                                MagicMock(return_value=False)}):
                 self.assertTrue(service.restart('name'))
 
@@ -73,7 +73,7 @@ class ServiceTestCase(TestCase):
         Test to restart the specified service
         '''
         with patch.object(os.path, 'join', return_value='A'):
-            with patch.dict(service.__salt__, {'cmd.retcode':
+            with patch.dict(service.__salt__, {'service.run':
                                                MagicMock(return_value=False)}):
                 self.assertTrue(service.reload_('name'))
 

--- a/tests/unit/modules/service_test.py
+++ b/tests/unit/modules/service_test.py
@@ -37,7 +37,7 @@ class ServiceTestCase(TestCase):
         '''
         with patch.object(os.path, 'join', return_value='A'):
             with patch.dict(service.__salt__, {'service.run':
-                                               MagicMock(return_value=False)}):
+                                               MagicMock(return_value=True)}):
                 self.assertTrue(service.start('name'))
 
     def test_stop(self):
@@ -46,7 +46,7 @@ class ServiceTestCase(TestCase):
         '''
         with patch.object(os.path, 'join', return_value='A'):
             with patch.dict(service.__salt__, {'service.run':
-                                               MagicMock(return_value=False)}):
+                                               MagicMock(return_value=True)}):
                 self.assertTrue(service.stop('name'))
 
     def test_restart(self):
@@ -55,7 +55,7 @@ class ServiceTestCase(TestCase):
         '''
         with patch.object(os.path, 'join', return_value='A'):
             with patch.dict(service.__salt__, {'service.run':
-                                               MagicMock(return_value=False)}):
+                                               MagicMock(return_value=True)}):
                 self.assertTrue(service.restart('name'))
 
     def test_status(self):
@@ -74,8 +74,17 @@ class ServiceTestCase(TestCase):
         '''
         with patch.object(os.path, 'join', return_value='A'):
             with patch.dict(service.__salt__, {'service.run':
-                                               MagicMock(return_value=False)}):
+                                               MagicMock(return_value=True)}):
                 self.assertTrue(service.reload_('name'))
+
+    def test_run(self):
+        '''
+        Test to run the specified service
+        '''
+        with patch.object(os.path, 'join', return_value='A'):
+            with patch.dict(service.__salt__, {'cmd.retcode':
+                                               MagicMock(return_value=False)}):
+                self.assertTrue(service.run('name', 'action'))
 
     def test_available(self):
         '''


### PR DESCRIPTION
`service.run` function allows run services with custom argument:

```
salt '*' service.run postgresql initdb
```
