### PR TITLE
Fix #13513 - Reflection

### DIFF
--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -35,6 +35,7 @@ Values/Entries are name/data pairs. There can be many values in a key. The
 # Import python libs
 from __future__ import absolute_import
 import logging
+import struct
 
 # Import third party libs
 try:
@@ -67,9 +68,9 @@ class Registry(object):
             "HKU": _winreg.HKEY_USERS,
             }
 
-        self.reflection_mask = {
-            True: _winreg.KEY_ALL_ACCESS,
-            False: _winreg.KEY_ALL_ACCESS | _winreg.KEY_WOW64_64KEY,
+        self.registry_32 = {
+            True: _winreg.KEY_ALL_ACCESS | _winreg.KEY_WOW64_32KEY,
+            False: _winreg.KEY_ALL_ACCESS,
             }
 
         self.vtype = {
@@ -106,7 +107,30 @@ def __virtual__():
     return False
 
 
-def read_key(hkey, path, key=None):
+def _key_exists(hive, key, use_32bit_registry=False):
+    '''
+    Check that the key is found in the registry
+
+    :param str hive: The hive to connect to.
+    :param str key: The key to check
+    :param bool use_32bit_registry: Look in the 32bit portion of the registry
+
+    :return: Returns True if found, False if not found
+    :rtype: bool
+    '''
+    registry = Registry()
+    hkey = registry.hkeys[hive]
+    access_mask = registry.registry_32[use_32bit_registry]
+
+    try:
+        handle = _winreg.OpenKey(hkey, key, 0, access_mask)
+        _winreg.CloseKey(handle)
+        return True
+    except WindowsError as exc:  # pylint: disable=E0602
+        return False
+
+
+def read_key(hkey, path, key=None, use_32bit_registry=False):
     '''
     .. important::
         The name of this function is misleading and will be changed to reflect
@@ -146,36 +170,41 @@ def read_key(hkey, path, key=None):
                                        'removed in Salt Boron')
         return read_value(hive=hkey,
                           key=path,
-                          vname=key)
+                          vname=key,
+                          use_32bit_registry=use_32bit_registry)
 
-    return read_value(hive=hkey, key=path)
+    return read_value(hive=hkey,
+                      key=path,
+                      use_32bit_registry=use_32bit_registry)
 
 
-def read_value(hive, key, vname=None):
+def read_value(hive, key, vname=None, use_32bit_registry=False):
     r'''
     Reads a registry value entry or the default value for a key.
 
-    :param str hive:
-        The name of the hive. Can be one of the following
-        - HKEY_LOCAL_MACHINE or HKLM
-        - HKEY_CURRENT_USER or HKCU
-        - HKEY_USER or HKU
+    :param str hive: The name of the hive. Can be one of the following
 
-    :param str key:
-        The key (looks like a path) to the value name.
+    - HKEY_LOCAL_MACHINE or HKLM
+    - HKEY_CURRENT_USER or HKCU
+    - HKEY_USER or HKU
 
-    :param str vname:
-        The value name. These are the individual name/data pairs under the key.
-        If not passed, the key (Default) value will be returned
+    :param str key: The key (looks like a path) to the value name.
 
-    :return:
-        A dictionary containing the passed settings as well as the value_data if
-        successful. If unsuccessful, sets success to False
+    :param str vname: The value name. These are the individual name/data pairs
+    under the key. If not passed, the key (Default) value will be returned
 
-        If vname is not passed:
-        - Returns the first unnamed value (Default) as a string.
-        - Returns none if first unnamed value is empty.
-        - Returns False if key not found.
+    :param bool use_32bit_registry: Accesses the 32bit portion of the registry
+    on 64 bit installations. On 32bit machines this is ignored.
+
+    :return: A dictionary containing the passed settings as well as the
+    value_data if successful. If unsuccessful, sets success to False
+
+    If vname is not passed:
+
+    - Returns the first unnamed value (Default) as a string.
+    - Returns none if first unnamed value is empty.
+    - Returns False if key not found.
+
     :rtype: dict
 
     CLI Example:
@@ -199,9 +228,10 @@ def read_value(hive, key, vname=None):
 
     registry = Registry()
     hkey = registry.hkeys[hive]
+    access_mask = registry.registry_32[use_32bit_registry]
 
     try:
-        handle = _winreg.OpenKey(hkey, key)
+        handle = _winreg.OpenKey(hkey, key, 0, access_mask)
         try:
             vdata, vtype = _winreg.QueryValueEx(handle, vname)
             if vdata or vdata in [0, '']:
@@ -212,7 +242,6 @@ def read_value(hive, key, vname=None):
         except WindowsError as exc:  # pylint: disable=E0602
             ret['vdata'] = ('(value not set)')
             ret['vtype'] = 'REG_SZ'
-            ret['success'] = True
     except WindowsError as exc:  # pylint: disable=E0602
         log.debug(exc)
         log.debug('Cannot find key: {0}\\{1}'.format(hive, key))
@@ -222,7 +251,13 @@ def read_value(hive, key, vname=None):
     return ret
 
 
-def set_key(hkey, path, value, key=None, vtype='REG_DWORD', reflection=True):
+def set_key(hkey,
+            path,
+            value,
+            key=None,
+            vtype='REG_DWORD',
+            reflection=True,
+            use_32bit_registry=False):
     '''
     .. important ::
         The name of this function is misleading and will be changed to reflect
@@ -257,46 +292,57 @@ def set_key(hkey, path, value, key=None, vtype='REG_DWORD', reflection=True):
                          key=path,
                          vname=key,
                          vdata=value,
-                         vtype=vtype)
+                         vtype=vtype,
+                         use_32bit_registry=use_32bit_registry)
 
-    return set_value(hive=hkey, key=path, vdata=value, vtype=vtype)
+    return set_value(hive=hkey,
+                     key=path,
+                     vdata=value,
+                     vtype=vtype,
+                     use_32bit_registry=use_32bit_registry)
 
 
-def set_value(hive, key, vname=None, vdata=None, vtype='REG_SZ', reflection=True):
+def set_value(hive,
+              key,
+              vname=None,
+              vdata=None,
+              vtype='REG_SZ',
+              reflection=True,
+              use_32bit_registry=False):
     '''
     Sets a registry value entry or the default value for a key.
 
-    :param str hive:
-        The name of the hive. Can be one of the following
-        - HKEY_LOCAL_MACHINE or HKLM
-        - HKEY_CURRENT_USER or HKCU
-        - HKEY_USER or HKU
+    :param str hive: The name of the hive. Can be one of the following
 
-    :param str key:
-        The key (looks like a path) to the value name.
+    - HKEY_LOCAL_MACHINE or HKLM
+    - HKEY_CURRENT_USER or HKCU
+    - HKEY_USER or HKU
 
-    :param str vname:
-        The value name. These are the individual name/data pairs under the key.
-        If not passed, the key (Default) value will be set.
+    :param str key: The key (looks like a path) to the value name.
 
-    :param str vdata:
-        The value data to be set.
+    :param str vname: The value name. These are the individual name/data pairs
+    under the key. If not passed, the key (Default) value will be set.
 
-    :param str vtype:
-        The value type. Can be one of the following:
-        - REG_BINARY
-        - REG_DWORD
-        - REG_EXPAND_SZ
-        - REG_MULTI_SZ
-        - REG_SZ
+    :param str vdata: The value data to be set.
 
-    :param bool reflection:
-        A boolean value indicating that the value should also be set in the
-        Wow6432Node portion of the registry. Only applies to 64 bit Windows.
-        This setting is ignored for 32 bit Windows.
+    :param str vtype: The value type. Can be one of the following:
 
-    :return:
-        Returns True if successful, False if not
+    - REG_BINARY
+    - REG_DWORD
+    - REG_EXPAND_SZ
+    - REG_MULTI_SZ
+    - REG_SZ
+
+    :param bool reflection: A boolean value indicating that the value should
+    also be set in the Wow6432Node portion of the registry. Only applies to 64
+    bit Windows. This setting is ignored for 32 bit Windows.
+
+    .. deprecated:: 2015.8.2
+       Use `use_32bit_registry` instead. The parameter seems to have no effect
+       since Windows 7 / Windows 2008R2 removed support for reflection. The
+       parameter will be removed in Boron.
+
+    :return: Returns True if successful, False if not
     :rtype: bool
 
     CLI Example:
@@ -306,21 +352,29 @@ def set_value(hive, key, vname=None, vdata=None, vtype='REG_SZ', reflection=True
         salt '*' reg.set_value HKEY_LOCAL_MACHINE 'SOFTWARE\\Salt' 'version' '2015.5.2'
     '''
     registry = Registry()
-    hive = registry.hkeys[hive]
+    hkey = registry.hkeys[hive]
     vtype = registry.vtype[vtype]
-    access_mask = registry.reflection_mask[reflection]
+    access_mask = registry.registry_32[use_32bit_registry]
 
     try:
-        handle = _winreg.CreateKeyEx(hive, key, 0, access_mask)
+        handle = _winreg.CreateKeyEx(hkey, key, 0, access_mask)
+        if vtype == registry.vtype['REG_SZ']\
+                or vtype == registry.vtype['REG_BINARY']:
+            vdata = str(vdata)
         _winreg.SetValueEx(handle, vname, 0, vtype, vdata)
         _winreg.CloseKey(handle)
         return True
-    except (WindowsError, ValueError) as exc:  # pylint: disable=E0602
+    except (WindowsError, ValueError, TypeError) as exc:  # pylint: disable=E0602
         log.error(exc, exc_info=True)
         return False
 
 
-def create_key(hkey, path, key=None, value=None, reflection=True):
+def create_key(hkey,
+               path,
+               key=None,
+               value=None,
+               reflection=True,
+               use_32bit_registry=False):
     '''
     .. important ::
         The name of this function is misleading and will be changed to reflect
@@ -353,12 +407,17 @@ def create_key(hkey, path, key=None, value=None, reflection=True):
                          key=path,
                          vname=key,
                          vdata=value,
-                         vtype='REG_SZ')
+                         use_32bit_registry=use_32bit_registry)
 
-    return set_value(hive=hkey, key=path)
+    return set_value(hive=hkey, key=path, use_32bit_registry=use_32bit_registry)
 
 
-def delete_key(hkey, path, key=None, reflection=True, force=False):
+def delete_key(hkey,
+               path,
+               key=None,
+               reflection=True,
+               force=False,
+               use_32bit_registry=False):
     '''
     .. important::
         The name of this function is misleading and will be changed to reflect
@@ -383,34 +442,31 @@ def delete_key(hkey, path, key=None, reflection=True, force=False):
 
         salt '*' reg.delete_key HKEY_CURRENT_USER 'SOFTWARE\\Salt'
 
-    :param str hkey: (will be changed to hive)
-        The name of the hive. Can be one of the following
-        - HKEY_LOCAL_MACHINE or HKLM
-        - HKEY_CURRENT_USER or HKCU
-        - HKEY_USER or HKU
+    :param str hkey: (will be changed to hive) The name of the hive. Can be one
+    of the following
 
-    :param str path: (will be changed to key)
-        The key (looks like a path) to remove.
+    - HKEY_LOCAL_MACHINE or HKLM
+    - HKEY_CURRENT_USER or HKCU
+    - HKEY_USER or HKU
 
-    :param str key: (used incorrectly)
-        Will be removed in Boron
+    :param str path: (will be changed to key) The key (looks like a path) to
+    remove.
 
-    :param bool reflection:
-        A boolean value indicating that the value should also be removed from
-        the Wow6432Node portion of the registry. Only applies to 64 bit Windows.
-        This setting is ignored for 32 bit Windows.
+    :param str key: (used incorrectly) Will be removed in Boron
 
-        Only applies to delete value. If the key parameter is passed, this
-        function calls delete_value instead. Will be changed in Boron.
+    :param bool reflection: A boolean value indicating that the value should
+    also be removed from the Wow6432Node portion of the registry. Only applies
+    to 64 bit Windows. This setting is ignored for 32 bit Windows.
 
-    :param bool force:
-        A boolean value indicating that all subkeys should be removed as well.
-        If this is set to False (default) and there are subkeys, the delete_key
-        function will fail.
+    Only applies to delete value. If the key parameter is passed, this function
+    calls delete_value instead. Will be changed in Boron.
 
-    :return:
-        Returns True if successful, False if not
-        If force=True, the results of delete_key_recursive are returned.
+    :param bool force: A boolean value indicating that all subkeys should be
+    removed as well. If this is set to False (default) and there are subkeys,
+    the delete_key function will fail.
+
+    :return: Returns True if successful, False if not. If force=True, the
+    results of delete_key_recursive are returned.
     :rtype: bool
     '''
 
@@ -422,42 +478,46 @@ def delete_key(hkey, path, key=None, reflection=True, force=False):
         return delete_value(hive=hkey,
                             key=path,
                             vname=key,
-                            reflection=reflection)
+                            reflection=reflection,
+                            use_32bit_registry=use_32bit_registry)
 
     if force:
-        return delete_key_recursive(hkey, path)
+        return delete_key_recursive(hkey,
+                                    path,
+                                    use_32bit_registry=use_32bit_registry)
 
     registry = Registry()
     hive = registry.hkeys[hkey]
     key = path
+    access_mask = registry.registry_32[use_32bit_registry]
 
     try:
         # Can't use delete_value to delete a key
-        _winreg.DeleteKey(hive, key)
+        key_handle = _winreg.OpenKey(hive, key, 0, access_mask)
+        _winreg.DeleteKey(key_handle, '')
+        _winreg.CloseKey(key_handle)
         return True
     except WindowsError as exc:  # pylint: disable=E0602
         log.error(exc, exc_info=True)
         return False
 
 
-def delete_key_recursive(hive, key):
+def delete_key_recursive(hive, key, use_32bit_registry=False):
     '''
     .. versionadded:: 2015.5.4
 
     Delete a registry key to include all subkeys.
 
-    :param hive:
-        The name of the hive. Can be one of the following
-        - HKEY_LOCAL_MACHINE or HKLM
-        - HKEY_CURRENT_USER or HKCU
-        - HKEY_USER or HKU
+    :param hive: The name of the hive. Can be one of the following
 
-    :param key:
-        The key to remove (looks like a path)
+    - HKEY_LOCAL_MACHINE or HKLM
+    - HKEY_CURRENT_USER or HKCU
+    - HKEY_USER or HKU
 
-    :return:
-        A dictionary listing the keys that deleted successfully as well as those
-        that failed to delete.
+    :param key: The key to remove (looks like a path)
+
+    :return: A dictionary listing the keys that deleted successfully as well as
+    those that failed to delete.
     :rtype: dict
 
     The following example will remove ``salt`` and all its subkeys from the
@@ -469,6 +529,15 @@ def delete_key_recursive(hive, key):
 
         salt '*' reg.delete_key_recursive HKLM SOFTWARE\\salt
     '''
+    # Instantiate the registry object
+    registry = Registry()
+    hkey = registry.hkeys[hive]
+    key_path = key
+    access_mask = registry.registry_32[use_32bit_registry]
+
+    if not _key_exists(hive, key, use_32bit_registry):
+        return False
+
     # Functions for traversing the registry tree
     def subkeys(key):
         i = 0
@@ -480,70 +549,61 @@ def delete_key_recursive(hive, key):
             except WindowsError:  # pylint: disable=E0602
                 break
 
-    def traverse_registry_tree(hkey, keypath, ret):
-        key = _winreg.OpenKey(hkey, keypath, 0, _winreg.KEY_READ)
+    def traverse_registry_tree(hkey, keypath, ret, access_mask):
+        key = _winreg.OpenKey(hkey, keypath, 0, access_mask)
         for subkeyname in subkeys(key):
             subkeypath = r'{0}\{1}'.format(keypath, subkeyname)
-            ret = traverse_registry_tree(hkey, subkeypath, ret)
+            ret = traverse_registry_tree(hkey, subkeypath, ret, access_mask)
             ret.append('{0}'.format(subkeypath))
         return ret
 
-    # Instantiate the registry object
-    registry = Registry()
-    hkey = registry.hkeys[hive]
-    keypath = key
-
     # Get a reverse list of registry keys to be deleted
     key_list = []
-    key_list = traverse_registry_tree(hkey, keypath, key_list)
+    key_list = traverse_registry_tree(hkey, key_path, key_list, access_mask)
+    # Add the top level key last, all subkeys must be deleted first
+    key_list.append(r'{0}'.format(key_path))
 
     ret = {'Deleted': [],
            'Failed': []}
 
-    # Delete all subkeys
-    for keypath in key_list:
+    # Delete all sub_keys
+    for sub_key_path in key_list:
         try:
-            _winreg.DeleteKey(hkey, keypath)
-            ret['Deleted'].append(r'{0}\{1}'.format(hive, keypath))
+            key_handle = _winreg.OpenKey(hkey, sub_key_path, 0, access_mask)
+            _winreg.DeleteKey(key_handle, '')
+            ret['Deleted'].append(r'{0}\{1}'.format(hive, sub_key_path))
         except WindowsError as exc:  # pylint: disable=E0602
             log.error(exc, exc_info=True)
-            ret['Failed'].append(r'{0}\{1} {2}'.format(hive, key, exc))
-
-    # Delete the key now that all the subkeys are deleted
-    try:
-        _winreg.DeleteKey(hkey, key)
-        ret['Deleted'].append(r'{0}\{1}'.format(hive, key))
-    except WindowsError as exc:  # pylint: disable=E0602
-        log.error(exc, exc_info=True)
-        ret['Failed'].append(r'{0}\{1} {2}'.format(hive, key, exc))
+            ret['Failed'].append(r'{0}\{1} {2}'.format(hive, sub_key_path, exc))
 
     return ret
 
 
-def delete_value(hive, key, vname=None, reflection=True):
+def delete_value(hive, key, vname=None, reflection=True, use_32bit_registry=False):
     '''
     Delete a registry value entry or the default value for a key.
 
-    :param str hive:
-        The name of the hive. Can be one of the following
-        - HKEY_LOCAL_MACHINE or HKLM
-        - HKEY_CURRENT_USER or HKCU
-        - HKEY_USER or HKU
+    :param str hive: The name of the hive. Can be one of the following
 
-    :param str key:
-        The key (looks like a path) to the value name.
+    - HKEY_LOCAL_MACHINE or HKLM
+    - HKEY_CURRENT_USER or HKCU
+    - HKEY_USER or HKU
 
-    :param str vname:
-        The value name. These are the individual name/data pairs under the key.
-        If not passed, the key (Default) value will be deleted.
+    :param str key: The key (looks like a path) to the value name.
 
-    :param bool reflection:
-        A boolean value indicating that the value should also be set in the
-        Wow6432Node portion of the registry. Only applies to 64 bit Windows.
-        This setting is ignored for 32 bit Windows.
+    :param str vname: The value name. These are the individual name/data pairs
+    under the key. If not passed, the key (Default) value will be deleted.
 
-    :return:
-        Returns True if successful, False if not
+    :param bool reflection: A boolean value indicating that the value should
+    also be set in the Wow6432Node portion of the registry. Only applies to 64
+    bit Windows. This setting is ignored for 32 bit Windows.
+
+    .. deprecated:: 2015.8.2
+       Use `use_32bit_registry` instead. The parameter seems to have no effect
+       since Windows 7 / Windows 2008R2 removed support for reflection. The
+       parameter will be removed in Boron.
+
+    :return: Returns True if successful, False if not
     :rtype: bool
 
     CLI Example:
@@ -554,7 +614,7 @@ def delete_value(hive, key, vname=None, reflection=True):
     '''
     registry = Registry()
     hive = registry.hkeys[hive]
-    access_mask = registry.reflection_mask[reflection]
+    access_mask = registry.registry_32[use_32bit_registry]
 
     try:
         handle = _winreg.OpenKey(hive, key, 0, access_mask)
@@ -562,6 +622,5 @@ def delete_value(hive, key, vname=None, reflection=True):
         _winreg.CloseKey(handle)
         return True
     except WindowsError as exc:  # pylint: disable=E0602
-        _winreg.CloseKey(handle)
         log.error(exc, exc_info=True)
         return False

--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -35,7 +35,6 @@ Values/Entries are name/data pairs. There can be many values in a key. The
 # Import python libs
 from __future__ import absolute_import
 import logging
-import struct
 
 # Import third party libs
 try:

--- a/salt/states/reg.py
+++ b/salt/states/reg.py
@@ -94,56 +94,65 @@ def _parse_key(key):
     return hive, key
 
 
-def present(name, value=None, vname=None, vdata=None, vtype='REG_SZ', reflection=True):
+def present(name,
+            value=None,
+            vname=None,
+            vdata=None,
+            vtype='REG_SZ',
+            reflection=True,
+            use_32bit_registry=False):
     '''
     Ensure a registry key or value is present.
 
-    :param str name:
-        A string value representing the full path of the key to include the
-        HIVE, Key, and all Subkeys. For example:
+    :param str name: A string value representing the full path of the key to
+    include the HIVE, Key, and all Subkeys. For example:
 
-        ``HKEY_LOCAL_MACHINE\\SOFTWARE\\Salt``
+    ``HKEY_LOCAL_MACHINE\\SOFTWARE\\Salt``
 
-        Valid hive values include:
-            - HKEY_CURRENT_USER or HKCU
-            - HKEY_LOCAL_MACHINE or HKLM
-            - HKEY_USERS or HKU
+    Valid hive values include:
+    - HKEY_CURRENT_USER or HKCU
+    - HKEY_LOCAL_MACHINE or HKLM
+    - HKEY_USERS or HKU
 
-    :param str value:
-        Deprecated. Use vname and vdata instead. Included here for backwards
-        compatability.
+    :param str value: Deprecated. Use vname and vdata instead. Included here for
+    backwards compatability.
 
-    :param str vname:
-        The name of the value you'd like to create beneath the Key. If this
-        parameter is not passed it will assume you want to set the (Default)
-        value
+    :param str vname: The name of the value you'd like to create beneath the
+    Key. If this parameter is not passed it will assume you want to set the
+    (Default) value
 
-    :param str vdata:
-        The value you'd like to set for the Key. If a value name (vname) is
-        passed, this will be the data for that value name. If not, this will be
-        the (Default) value for the key.
+    :param str vdata: The value you'd like to set for the Key. If a value name
+    (vname) is passed, this will be the data for that value name. If not, this
+    will be the (Default) value for the key.
 
-        The type for the (Default) value is always REG_SZ and cannot be changed.
-        This parameter is optional. If not passed, the Key will be created with.
+    The type for the (Default) value is always REG_SZ and cannot be changed.
+    This parameter is optional. If not passed, the Key will be created with no
+    associated item/value pairs.
 
-    :param str vtype:
-        The value type for the data you wish to store in the registry. Valid
-        values are:
+    :param str vtype: The value type for the data you wish to store in the
+    registry. Valid values are:
 
-            - REG_BINARY
-            - REG_DWORD
-            - REG_EXPAND_SZ
-            - REG_MULTI_SZ
-            - REG_SZ (Default)
+    - REG_BINARY
+    - REG_DWORD
+    - REG_EXPAND_SZ
+    - REG_MULTI_SZ
+    - REG_SZ (Default)
 
-    :param bool reflection:
-        On 64 bit machines a duplicate value will be created in the
-        ``Wow6432Node`` for 32bit programs. This only applies to the SOFTWARE
-        key. This option is ignored on 32bit operating systems. This value
-        defaults to True. Set it to False to disable reflection.
+    :param bool reflection: On 64 bit machines a duplicate value will be created
+    in the ``Wow6432Node`` for 32bit programs. This only applies to the SOFTWARE
+    key. This option is ignored on 32bit operating systems. This value defaults
+    to True. Set it to False to disable reflection.
 
-    :return:
-        Returns a dictionary showing the results of the registry operation.
+    .. deprecated:: 2015.8.2
+       Use `use_32bit_registry` instead.
+       The parameter seems to have no effect since Windows 7 / Windows 2008R2
+       removed support for reflection. The parameter will be removed in Boron.
+
+    :param bool use_32bit_registry: Use the 32bit portion of the registry.
+    Applies only to 64bit windows. 32bit Windows will ignore this parameter.
+    Default if False.
+
+    :return: Returns a dictionary showing the results of the registry operation.
     :rtype: dict
 
     The following example will set the ``(Default)`` value for the
@@ -199,7 +208,10 @@ def present(name, value=None, vname=None, vdata=None, vtype='REG_SZ', reflection
         hive, key = _parse_key(name)
 
     # Determine what to do
-    reg_current = __salt__['reg.read_value'](hive, key, vname)
+    reg_current = __salt__['reg.read_value'](hive=hive,
+                                             key=key,
+                                             vname=vname,
+                                             use_32bit_registry=use_32bit_registry)
 
     if vdata == reg_current['vdata'] and reg_current['success']:
         ret['comment'] = '{0} in {1} is already configured'.\
@@ -217,8 +229,12 @@ def present(name, value=None, vname=None, vdata=None, vtype='REG_SZ', reflection
         return ret
 
     # Configure the value
-    ret['result'] = __salt__['reg.set_value'](hive, key, vname, vdata, vtype,
-                                              reflection)
+    ret['result'] = __salt__['reg.set_value'](hive=hive,
+                                              key=key,
+                                              vname=vname,
+                                              vdata=vdata,
+                                              vtype=vtype,
+                                              use_32bit_registry=use_32bit_registry)
 
     if not ret['result']:
         ret['changes'] = {}
@@ -230,11 +246,33 @@ def present(name, value=None, vname=None, vdata=None, vtype='REG_SZ', reflection
     return ret
 
 
-def absent(name, vname=None):
+def absent(name, vname=None, use_32bit_registry=False):
     '''
     Ensure a registry value is removed. To remove a key use key_absent.
 
-    Example:
+    :param str name: A string value representing the full path of the key to
+    include the HIVE, Key, and all Subkeys. For example:
+
+    ``HKEY_LOCAL_MACHINE\\SOFTWARE\\Salt``
+
+    Valid hive values include:
+
+    - HKEY_CURRENT_USER or HKCU
+    - HKEY_LOCAL_MACHINE or HKLM
+    - HKEY_USERS or HKU
+
+    :param str vname: The name of the value you'd like to create beneath the
+    Key. If this parameter is not passed it will assume you want to set the
+    (Default) value
+
+    :param bool use_32bit_registry: Use the 32bit portion of the registry.
+    Applies only to 64bit windows. 32bit Windows will ignore this parameter.
+    Default if False.
+
+    :return: Returns a dictionary showing the results of the registry operation.
+    :rtype: dict
+
+    CLI Example:
 
     .. code-block:: yaml
 
@@ -242,9 +280,11 @@ def absent(name, vname=None):
           reg.absent
 
     In the above example the path is interpreted as follows:
+
     - ``HKEY_CURRENT_USER`` is the hive
     - ``SOFTWARE\\Salt`` is the key
     - ``version`` is the value name
+
     So the value ``version`` will be deleted from the ``SOFTWARE\\Salt`` key in
     the ``HKEY_CURRENT_USER`` hive.
     '''
@@ -256,11 +296,17 @@ def absent(name, vname=None):
     hive, key = _parse_key(name)
 
     # Determine what to do
-    reg_check = __salt__['reg.read_value'](hive, key, vname)
+    reg_check = __salt__['reg.read_value'](hive=hive,
+                                           key=key,
+                                           vname=vname,
+                                           use_32bit_registry=use_32bit_registry)
     if not reg_check['success'] or reg_check['vdata'] == '(value not set)':
         if not vname:
             hive, key, vname = _parse_key_value(name)
-            reg_check = __salt__['reg.read_value'](hive, key, vname)
+            reg_check = __salt__['reg.read_value'](hive=hive,
+                                                   key=key,
+                                                   vname=vname,
+                                                   use_32bit_registry=use_32bit_registry)
             if not reg_check['success'] or reg_check['vdata'] == '(value not set)':
                 ret['comment'] = '{0} is already absent'.format(name)
                 return ret
@@ -278,7 +324,10 @@ def absent(name, vname=None):
         return ret
 
     # Delete the value
-    ret['result'] = __salt__['reg.delete_value'](hive, key, vname)
+    ret['result'] = __salt__['reg.delete_value'](hive=hive,
+                                                 key=key,
+                                                 vname=vname,
+                                                 use_32bit_registry=use_32bit_registry)
     if not ret['result']:
         ret['changes'] = {}
         ret['comment'] = r'Failed to remove {0} from {1}'.format(key, hive)
@@ -289,39 +338,40 @@ def absent(name, vname=None):
     return ret
 
 
-def key_absent(name, force=False):
+def key_absent(name, force=False, use_32bit_registry=False):
     r'''
     .. versionadded:: 2015.5.4
 
     Ensure a registry key is removed. This will remove a key and all value
     entries it contains. It will fail if the key contains subkeys.
 
-    :param str name:
-        A string representing the full path to the key to be removed to include
-        the hive and the keypath. The hive can be any of the following:
-        - HKEY_LOCAL_MACHINE or HKLM
-        - HKEY_CURRENT_USER or HKCU
-        - HKEY_USER or HKU
+    :param str name: A string representing the full path to the key to be
+    removed to include the hive and the keypath. The hive can be any of the following:
 
-    :param bool force:
-        A boolean value indicating that all subkeys should be deleted with the
-        key. If force=False and subkeys exists beneath the key you want to
-        delete, key_absent will fail. Use with caution. The default is False.
+    - HKEY_LOCAL_MACHINE or HKLM
+    - HKEY_CURRENT_USER or HKCU
+    - HKEY_USER or HKU
 
-    :return:
-        Returns a dictionary showing the results of the registry operation.
+    :param bool force: A boolean value indicating that all subkeys should be
+    deleted with the key. If force=False and subkeys exists beneath the key you
+    want to delete, key_absent will fail. Use with caution. The default is False.
+
+    :return: Returns a dictionary showing the results of the registry operation.
     :rtype: dict
 
     The following example will delete the ``SOFTWARE\Salt`` key and all subkeys
     under the ``HKEY_CURRENT_USER`` hive.
 
-    Example::
+    Example:
+
+    .. codeblock:: yaml
 
         'HKEY_CURRENT_USER\SOFTWARE\Salt':
           reg.key_absent:
             - force: True
 
     In the above example the path is interpreted as follows:
+
     - ``HKEY_CURRENT_USER`` is the hive
     - ``SOFTWARE\Salt`` is the key
     '''
@@ -333,7 +383,9 @@ def key_absent(name, force=False):
     hive, key = _parse_key(name)
 
     # Determine what to do
-    if not __salt__['reg.read_value'](hive, key)['success']:
+    if not __salt__['reg.read_value'](hive=hive,
+                                      key=key,
+                                      use_32bit_registry=use_32bit_registry)['success']:
         ret['comment'] = '{0} is already absent'.format(name)
         return ret
 
@@ -348,8 +400,13 @@ def key_absent(name, force=False):
         return ret
 
     # Delete the value
-    __salt__['reg.delete_key'](hive, key, force=force)
-    if __salt__['reg.read_value'](hive, key)['success']:
+    __salt__['reg.delete_key'](hive=hive,
+                               key=key,
+                               force=force,
+                               use_32bit_registry=use_32bit_registry)
+    if __salt__['reg.read_value'](hive=hive,
+                                  key=key,
+                                  use_32bit_registry=use_32bit_registry)['success']:
         ret['result'] = False
         ret['changes'] = {}
         ret['comment'] = 'Failed to remove registry key {0}'.format(name)


### PR DESCRIPTION
Fixes #13513 

Removed reflection, hasn't worked since XP
Added a check for existing so it doesn't stack trace when deleting keys
Added use_32bit_registry option
- Works for 64bit machines
- Ignored on 32bit machines
  Updated documentation

Added use_32bit_registry option for use with the module
Updated documentation
