### PR TITLE
Use a broader test for unset "id"

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2743,7 +2743,7 @@ def apply_minion_config(overrides=None,
 
     # No ID provided. Will getfqdn save us?
     using_ip_for_id = False
-    if opts['id'] is None:
+    if not opts.get('id'):
         opts['id'], using_ip_for_id = get_id(
                 opts,
                 cache_minion_id=cache_minion_id)
@@ -2860,7 +2860,7 @@ def apply_master_config(overrides=None, defaults=None):
 
     using_ip_for_id = False
     append_master = False
-    if opts.get('id') is None:
+    if not opts.get('id'):
         opts['id'], using_ip_for_id = get_id(
                 opts,
                 cache_minion_id=None)


### PR DESCRIPTION
The "id" option is of type string - testing that an uninitialized "id" is
specifically None is too narrow.

Fixes #28339
References #28189
Alternate #28423
