### PR TITLE
Fix pillar.json serialisation for salt-ssh.

### DIFF
--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -143,7 +143,7 @@ def prep_trans_tar(file_client, chunks, file_refs, pillar=None):
         fp_.write(json.dumps(chunks))
     if pillar:
         with salt.utils.fopen(pillarfn, 'w+') as fp_:
-            fp_.write(json.dumps(pillar))
+            fp_.write(json.dumps(pillar._dict()))
     for saltenv in file_refs:
         file_refs[saltenv].extend(sync_refs)
         env_root = os.path.join(gendir, saltenv)


### PR DESCRIPTION
I was getting squify results from salt-ssh (pillar data wasn't loading in jinja templates) and tracked it down to pillar.json only containing `{}` in the state tar.

After much `print`-ing :-p I tracked it down to the `NamespacedDictWrapper` used in the salt ssh wrapper not `json.dumps`-ing correctly (eg `print(json.dumps(__pillar__))` was `{}`, but `print(json.dumps(__pillar__['some-key']))` worked (iirc).

Looking at NamespacedDictWrapper I saw the `_dict()` method which returns a real dict, which then serialises correctly.

Quick python eg:

```
> python2                                                                                                                                                                      
Python 2.7.10 (default, Sep  7 2015, 13:51:49) 
[GCC 5.2.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from salt.utils.context import NamespacedDictWrapper
>>> a = NamespacedDictWrapper({"pillar": { "asd": "dsa" }}, 'pillar')
>>> import json
>>> json.dumps(a)
'{}'
>>> json.dumps(a._dict())
'{"asd": "dsa"}'
>>> 
```

This patch fixes this issue for me? :-s (not really sure what I'm doing :-p so I may be way off base :-) (and sorry for the noise if I am :-) ))
