### PR TITLE
Salt ssh: don't write to stderr when using a tty.

### DIFF
--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -210,8 +210,9 @@ def main(argv):  # pylint: disable=W0613
     # Yes, the flush() is necessary.
     sys.stdout.write(OPTIONS.delimiter + '\n')
     sys.stdout.flush()
-    sys.stderr.write(OPTIONS.delimiter + '\n')
-    sys.stderr.flush()
+    if not OPTIONS.tty:
+        sys.stderr.write(OPTIONS.delimiter + '\n')
+        sys.stderr.flush()
     if OPTIONS.tty:
         stdout, _ = subprocess.Popen(salt_argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
         sys.stdout.write(stdout)


### PR DESCRIPTION
We're using salt ssh with a password and sudo (which also requires a password) so we're using the tty option.

We get a `Failed to return clean data` eg when running `salt-ssh '*' grains.ls`.

These seems to be because the delimiter is also in the result when it tries to do the `json.loads(stdout...` in `salt/client/ssh/wrapper/__init__.py`

With this patch the extra delimiter doesn't appear, so the result is read and returned correctly.

I'm a little nervous about the implications that this may have for other use cases, but it works for ours, so I thought I'd make the pull request, just in case it's useful :-)

No stress if this isn't useful :-)
