### PR TITLE
Support for Open vSwitch

### DIFF
--- a/salt/modules/openvswitch.py
+++ b/salt/modules/openvswitch.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
-"""
-Support for Open vSwitch
-"""
+'''
+Support for Open vSwitch - module with basic Open vSwitch commands.
+
+Suitable for setting up Openstack Neutron.
+
+:codeauthor: Jiri Kotlin <jiri.kotlin@ultimum.io>
+'''
 from __future__ import absolute_import
 
 # Import python libs
@@ -14,24 +18,16 @@ log = logging.getLogger(__name__)
 
 
 def __virtual__():
-    """
+    '''
     Only load the module if Open vSwitch is installed
-    """
-    cmd = _detect_os()
-    if salt.utils.which(cmd):
+    '''
+    if salt.utils.which('ovs-vsctl'):
         return 'openvswitch'
     return False
 
 
-def _detect_os():
-    """
-    Open vSwitch command may differ depending on packaging.
-    """
-    return 'ovs-vsctl'
-
-
 def _param_may_exist(may_exist):
-    """
+    '''
     Returns --may-exist parameter for Open vSwitch command.
 
     Args:
@@ -39,7 +35,7 @@ def _param_may_exist(may_exist):
 
     Returns:
         String '--may-exist ' or empty string.
-    """
+    '''
     if may_exist:
         return '--may-exist '
     else:
@@ -47,7 +43,7 @@ def _param_may_exist(may_exist):
 
 
 def _param_if_exists(if_exists):
-    """
+    '''
     Returns --if-exist parameter for Open vSwitch command.
 
     Args:
@@ -55,7 +51,7 @@ def _param_if_exists(if_exists):
 
     Returns:
         String '--if-exist ' or empty string.
-    """
+    '''
     if if_exists:
         return '--if-exists '
     else:
@@ -63,7 +59,7 @@ def _param_if_exists(if_exists):
 
 
 def _retcode_to_bool(retcode):
-    """
+    '''
     Evaulates Open vSwitch command`s retcode value.
 
     Args:
@@ -71,7 +67,7 @@ def _retcode_to_bool(retcode):
 
     Returns:
         True on 0, else False
-    """
+    '''
     if retcode == 0:
         return True
     else:
@@ -79,7 +75,7 @@ def _retcode_to_bool(retcode):
 
 
 def _stdout_list_split(retcode, stdout='', splitstring='\n'):
-    """
+    '''
     Evaulates Open vSwitch command`s retcode value.
 
     Args:
@@ -89,7 +85,7 @@ def _stdout_list_split(retcode, stdout='', splitstring='\n'):
 
     Returns:
         List or False.
-    """
+    '''
     if retcode == 0:
         ret = stdout.split(splitstring)
         return ret
@@ -98,19 +94,20 @@ def _stdout_list_split(retcode, stdout='', splitstring='\n'):
 
 
 def bridge_list():
-    """
+    '''
     Lists all existing real and fake bridges.
 
     Returns:
         List of bridges (or empty list), False on failure.
 
-    CLI Example:
+    .. versionadded:: 2015.8.1
 
+    CLI Example:
     .. code-block:: bash
 
         salt '*' openvswitch.bridge_list
-    """
-    cmd = _detect_os() + ' list-br'
+    '''
+    cmd = 'ovs-vsctl list-br'
     result = __salt__['cmd.run_all'](cmd)
     retcode = result['retcode']
     stdout = result['stdout']
@@ -118,26 +115,27 @@ def bridge_list():
 
 
 def bridge_exists(br):
-    """
+    '''
     Tests whether bridge exists as a real or fake  bridge.
 
     Returns:
         True if Bridge exists, else False.
 
-    CLI Example:
+    .. versionadded:: 2015.8.1
 
+    CLI Example:
     .. code-block:: bash
 
         salt '*' openvswitch.bridge_exists br0
-    """
-    cmd = _detect_os() + ' br-exists {0}'.format(br)
+    '''
+    cmd = 'ovs-vsctl br-exists {0}'.format(br)
     result = __salt__['cmd.run_all'](cmd)
     retcode = result['retcode']
     return _retcode_to_bool(retcode)
 
 
 def bridge_create(br, may_exist=True):
-    """
+    '''
     Creates a new bridge.
 
     Args:
@@ -147,20 +145,21 @@ def bridge_create(br, may_exist=True):
     Returns:
         True on success, else False.
 
-    CLI Example:
+    .. versionadded:: 2015.8.1
 
+    CLI Example:
     .. code-block:: bash
 
         salt '*' openvswitch.bridge_create br0
-    """
+    '''
     param_may_exist = _param_may_exist(may_exist)
-    cmd = _detect_os() + ' {1}add-br {0}'.format(br, param_may_exist)
+    cmd = 'ovs-vsctl {1}add-br {0}'.format(br, param_may_exist)
     result = __salt__['cmd.run_all'](cmd)
     return _retcode_to_bool(result['retcode'])
 
 
 def bridge_delete(br, if_exists=True):
-    """
+    '''
     Deletes bridge and all of  its  ports.
 
     Args:
@@ -170,21 +169,22 @@ def bridge_delete(br, if_exists=True):
     Returns:
         True on success, else False.
 
-    CLI Example:
+    .. versionadded:: 2015.8.1
 
+    CLI Example:
     .. code-block:: bash
 
         salt '*' openvswitch.bridge_delete br0
-    """
+    '''
     param_if_exists = _param_if_exists(if_exists)
-    cmd = _detect_os() + ' {1}del-br {0}'.format(br, param_if_exists)
+    cmd = 'ovs-vsctl {1}del-br {0}'.format(br, param_if_exists)
     result = __salt__['cmd.run_all'](cmd)
     retcode = result['retcode']
     return _retcode_to_bool(retcode)
 
 
 def port_add(br, port, may_exist=False):
-    """
+    '''
     Creates on bridge a new port named port.
 
     Returns:
@@ -195,108 +195,65 @@ def port_add(br, port, may_exist=False):
         port: A string - port name
         may_exist: Bool, if False - attempting to create a port that exists returns False.
 
-    CLI Example:
+    .. versionadded:: 2015.8.1
 
+    CLI Example:
     .. code-block:: bash
 
         salt '*' openvswitch.port_add br0 8080
-    """
+    '''
     param_may_exist = _param_may_exist(may_exist)
-    cmd = _detect_os() + ' {2}add-port {0} {1}'.format(br, port, param_may_exist)
+    cmd = 'ovs-vsctl {2}add-port {0} {1}'.format(br, port, param_may_exist)
     result = __salt__['cmd.run_all'](cmd)
     retcode = result['retcode']
     return _retcode_to_bool(retcode)
 
 
-def port_remove(*args, **kwargs):
-    """
+def port_remove(br, port, if_exists=True):
+    '''
      Deletes port.
 
     Args:
-        br: A string - bridge name (Optional: If bridge is not set, port is removed from  whatever bridge contains it)
+        br: A string - bridge name (If bridge is None, port is removed from  whatever bridge contains it)
         port: A string - port name (Required argument)
         if_exists: Bool, if False - attempting to delete a por that  does  not exist returns False. (Default True)
-t
+
     Returns:
         True on success, else False.
 
-    CLI Example:
+    .. versionadded:: 2015.8.1
 
+    CLI Example:
     .. code-block:: bash
 
         salt '*' openvswitch.port_remove br0 8080
-    """
-
-    default_args = {
-        0: None,    # br
-        1: None,    # port
-        2: None,    # if_exists
-    }
-
-    #kwargs
-    try:
-        if kwargs.get("br"):
-            default_args[0] = str(kwargs.get("br"))
-        if kwargs.get("port"):
-            default_args[1] = str(kwargs.get("port"))
-        default_args[2] = str(kwargs.get("if_exists", None))
-    except IndexError:
-        pass
-
-    #args
-    try:
-        for index, item in enumerate(args):
-            if not default_args[index]:
-                default_args[index] = str(item)
-    except KeyError:
-        pass
-
-    br = default_args[0]
-    port = default_args[1]
-    if_exists = default_args[2]
-
-    if br and not port:
-        try:
-            if not kwargs.get("br"):
-                # br argument was not called as kwarg br=name
-                raise IndexError
-        except IndexError:
-            port = br
-            br = ''
-
-    if not br:
-        br = ''
-
-    if if_exists == 'False':
-        if_exists = False
-    else:
-        if_exists = True
-
-    # port is the only required argument for this function
-    if not port:
-        raise TypeError
-
+    '''
     param_if_exists = _param_if_exists(if_exists)
-    cmd = _detect_os() + ' {2}del-port {0} {1}'.format(br, port, param_if_exists)
+
+    if port and not br:
+        cmd = 'ovs-vsctl {1}del-port {0}'.format(port, param_if_exists)
+    else:
+        cmd = 'ovs-vsctl {2}del-port {0} {1}'.format(br, port, param_if_exists)
     result = __salt__['cmd.run_all'](cmd)
     retcode = result['retcode']
     return _retcode_to_bool(retcode)
 
 
 def port_list(br):
-    """
+    '''
     Lists all of the ports within bridge.
 
     Returns:
         List of bridges (or empty list), False on failure.
 
-    CLI Example:
+    .. versionadded:: 2015.8.1
 
+    CLI Example:
     .. code-block:: bash
 
         salt '*' openvswitch.port_list br0
-    """
-    cmd = _detect_os() + ' list-ports {0}'.format(br)
+    '''
+    cmd = 'ovs-vsctl list-ports {0}'.format(br)
     result = __salt__['cmd.run_all'](cmd)
     retcode = result['retcode']
     stdout = result['stdout']

--- a/salt/modules/openvswitch.py
+++ b/salt/modules/openvswitch.py
@@ -1,0 +1,303 @@
+# -*- coding: utf-8 -*-
+"""
+Support for Open vSwitch
+"""
+from __future__ import absolute_import
+
+# Import python libs
+import logging
+
+# Import salt libs
+import salt.utils
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    """
+    Only load the module if Open vSwitch is installed
+    """
+    cmd = _detect_os()
+    if salt.utils.which(cmd):
+        return 'openvswitch'
+    return False
+
+
+def _detect_os():
+    """
+    Open vSwitch command may differ depending on packaging.
+    """
+    return 'ovs-vsctl'
+
+
+def _param_may_exist(may_exist):
+    """
+    Returns --may-exist parameter for Open vSwitch command.
+
+    Args:
+        may_exist: Boolean whether to use this parameter.
+
+    Returns:
+        String '--may-exist ' or empty string.
+    """
+    if may_exist:
+        return '--may-exist '
+    else:
+        return ''
+
+
+def _param_if_exists(if_exists):
+    """
+    Returns --if-exist parameter for Open vSwitch command.
+
+    Args:
+        if_exists: Boolean whether to use this parameter.
+
+    Returns:
+        String '--if-exist ' or empty string.
+    """
+    if if_exists:
+        return '--if-exists '
+    else:
+        return ''
+
+
+def _retcode_to_bool(retcode):
+    """
+    Evaulates Open vSwitch command`s retcode value.
+
+    Args:
+        retcode: Value of retcode field from response, should be 0, 1 or 2.
+
+    Returns:
+        True on 0, else False
+    """
+    if retcode == 0:
+        return True
+    else:
+        return False
+
+
+def _stdout_list_split(retcode, stdout='', splitstring='\n'):
+    """
+    Evaulates Open vSwitch command`s retcode value.
+
+    Args:
+        retcode: Value of retcode field from response, should be 0, 1 or 2.
+        stdout: Value of stdout filed from response.
+        splitstring: String used to split the stdout default new line.
+
+    Returns:
+        List or False.
+    """
+    if retcode == 0:
+        ret = stdout.split(splitstring)
+        return ret
+    else:
+        return False
+
+
+def bridge_list():
+    """
+    Lists all existing real and fake bridges.
+
+    Returns:
+        List of bridges (or empty list), False on failure.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' openvswitch.bridge_list
+    """
+    cmd = _detect_os() + ' list-br'
+    result = __salt__['cmd.run_all'](cmd)
+    retcode = result['retcode']
+    stdout = result['stdout']
+    return _stdout_list_split(retcode, stdout)
+
+
+def bridge_exists(br):
+    """
+    Tests whether bridge exists as a real or fake  bridge.
+
+    Returns:
+        True if Bridge exists, else False.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' openvswitch.bridge_exists br0
+    """
+    cmd = _detect_os() + ' br-exists {0}'.format(br)
+    result = __salt__['cmd.run_all'](cmd)
+    retcode = result['retcode']
+    return _retcode_to_bool(retcode)
+
+
+def bridge_create(br, may_exist=True):
+    """
+    Creates a new bridge.
+
+    Args:
+        br: A string - bridge name
+        may_exist: Bool, if False - attempting to create a bridge that exists returns False.
+
+    Returns:
+        True on success, else False.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' openvswitch.bridge_create br0
+    """
+    param_may_exist = _param_may_exist(may_exist)
+    cmd = _detect_os() + ' {1}add-br {0}'.format(br, param_may_exist)
+    result = __salt__['cmd.run_all'](cmd)
+    return _retcode_to_bool(result['retcode'])
+
+
+def bridge_delete(br, if_exists=True):
+    """
+    Deletes bridge and all of  its  ports.
+
+    Args:
+        br: A string - bridge name
+        if_exists: Bool, if False - attempting to delete a bridge that does not exist returns False.
+
+    Returns:
+        True on success, else False.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' openvswitch.bridge_delete br0
+    """
+    param_if_exists = _param_if_exists(if_exists)
+    cmd = _detect_os() + ' {1}del-br {0}'.format(br, param_if_exists)
+    result = __salt__['cmd.run_all'](cmd)
+    retcode = result['retcode']
+    return _retcode_to_bool(retcode)
+
+
+def port_add(br, port, may_exist=False):
+    """
+    Creates on bridge a new port named port.
+
+    Returns:
+        True on success, else False.
+
+    Args:
+        br: A string - bridge name
+        port: A string - port name
+        may_exist: Bool, if False - attempting to create a port that exists returns False.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' openvswitch.port_add br0 8080
+    """
+    param_may_exist = _param_may_exist(may_exist)
+    cmd = _detect_os() + ' {2}add-port {0} {1}'.format(br, port, param_may_exist)
+    result = __salt__['cmd.run_all'](cmd)
+    retcode = result['retcode']
+    return _retcode_to_bool(retcode)
+
+
+def port_remove(*args, **kwargs):
+    """
+     Deletes port.
+
+    Args:
+        br: A string - bridge name (Optional: If bridge is not set, port is removed from  whatever bridge contains it)
+        port: A string - port name (Required argument)
+        if_exists: Bool, if False - attempting to delete a por that  does  not exist returns False. (Default True)
+t
+    Returns:
+        True on success, else False.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' openvswitch.port_remove br0 8080
+    """
+
+    default_args = {
+        0: None,    # br
+        1: None,    # port
+        2: None,    # if_exists
+    }
+
+    #kwargs
+    try:
+        if kwargs.get("br"):
+            default_args[0] = str(kwargs.get("br"))
+        if kwargs.get("port"):
+            default_args[1] = str(kwargs.get("port"))
+        default_args[2] = str(kwargs.get("if_exists", None))
+    except IndexError:
+        pass
+
+    #args
+    try:
+        for index, item in enumerate(args):
+            if not default_args[index]:
+                default_args[index] = str(item)
+    except KeyError:
+        pass
+
+    br = default_args[0]
+    port = default_args[1]
+    if_exists = default_args[2]
+
+    if br and not port:
+        try:
+            if not kwargs.get("br"):
+                # br argument was not called as kwarg br=name
+                raise IndexError
+        except IndexError:
+            port = br
+            br = ''
+
+    if not br:
+        br = ''
+
+    if if_exists == 'False':
+        if_exists = False
+    else:
+        if_exists = True
+
+    # port is the only required argument for this function
+    if not port:
+        raise TypeError
+
+    param_if_exists = _param_if_exists(if_exists)
+    cmd = _detect_os() + ' {2}del-port {0} {1}'.format(br, port, param_if_exists)
+    result = __salt__['cmd.run_all'](cmd)
+    retcode = result['retcode']
+    return _retcode_to_bool(retcode)
+
+
+def port_list(br):
+    """
+    Lists all of the ports within bridge.
+
+    Returns:
+        List of bridges (or empty list), False on failure.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' openvswitch.port_list br0
+    """
+    cmd = _detect_os() + ' list-ports {0}'.format(br)
+    result = __salt__['cmd.run_all'](cmd)
+    retcode = result['retcode']
+    stdout = result['stdout']
+    return _stdout_list_split(retcode, stdout)

--- a/salt/states/openvswitch_bridge.py
+++ b/salt/states/openvswitch_bridge.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-"""
+'''
 Management of Open vSwitch bridges.
-"""
+'''
 
 
 def __virtual__():
@@ -12,16 +12,16 @@ def __virtual__():
 
 
 def present(name):
-    """
+    '''
     Ensures that the named bridge exists, eventually creates it.
 
     Args:
         name: The name of the bridge.
 
-    """
+    '''
     ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
 
-    #Comment and change messages
+    # Comment and change messages
     comment_bridge_created = 'Bridge {0} created.'.format(name)
     comment_bridge_notcreated = 'Unable to create bridge: {0}.'.format(name)
     comment_bridge_exists = 'Bridge {0} already exists.'.format(name)
@@ -61,17 +61,17 @@ def present(name):
 
 
 def absent(name):
-    """
+    '''
     Ensures that the named bridge does not exist, eventually deletes it.
 
     Args:
         name: The name of the bridge.
 
-    """
+    '''
 
     ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
 
-    #Comment and change messages
+    # Comment and change messages
     comment_bridge_deleted = 'Bridge {0} deleted.'.format(name)
     comment_bridge_notdeleted = 'Unable to delete bridge: {0}.'.format(name)
     comment_bridge_notexists = 'Bridge {0} does not exist.'.format(name)

--- a/salt/states/openvswitch_bridge.py
+++ b/salt/states/openvswitch_bridge.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""
+Management of Open vSwitch bridges.
+"""
+
+
+def __virtual__():
+    '''
+    Only make these states available if Open vSwitch module is available.
+    '''
+    return 'openvswitch.bridge_create' in __salt__
+
+
+def present(name):
+    """
+    Ensures that the named bridge exists, eventually creates it.
+
+    Args:
+        name: The name of the bridge.
+
+    """
+    ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
+
+    #Comment and change messages
+    comment_bridge_created = 'Bridge {0} created.'.format(name)
+    comment_bridge_notcreated = 'Unable to create bridge: {0}.'.format(name)
+    comment_bridge_exists = 'Bridge {0} already exists.'.format(name)
+    changes_bridge_created = {name: {'old': 'Bridge {0} does not exist.'.format(name),
+                                     'new': 'Bridge {0} created'.format(name),
+                                     }
+                              }
+
+    bridge_exists = __salt__['openvswitch.bridge_exists'](name)
+
+    # Dry run, test=true mode
+    if __opts__['test']:
+        if bridge_exists:
+            ret['result'] = True
+            ret['comment'] = comment_bridge_exists
+        else:
+            ret['result'] = None
+            ret['comment'] = comment_bridge_created
+            ret['changes'] = changes_bridge_created
+
+        return ret
+
+    if bridge_exists:
+        ret['result'] = True
+        ret['comment'] = comment_bridge_exists
+    else:
+        bridge_create = __salt__['openvswitch.bridge_create'](name)
+        if bridge_create:
+            ret['result'] = True
+            ret['comment'] = comment_bridge_created
+            ret['changes'] = changes_bridge_created
+        else:
+            ret['result'] = False
+            ret['comment'] = comment_bridge_notcreated
+
+    return ret
+
+
+def absent(name):
+    """
+    Ensures that the named bridge does not exist, eventually deletes it.
+
+    Args:
+        name: The name of the bridge.
+
+    """
+
+    ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
+
+    #Comment and change messages
+    comment_bridge_deleted = 'Bridge {0} deleted.'.format(name)
+    comment_bridge_notdeleted = 'Unable to delete bridge: {0}.'.format(name)
+    comment_bridge_notexists = 'Bridge {0} does not exist.'.format(name)
+    changes_bridge_deleted = {name: {'old': 'Bridge {0} exists.'.format(name),
+                                     'new': 'Bridge {0} deleted.'.format(name),
+                                     }
+                              }
+
+    bridge_exists = __salt__['openvswitch.bridge_exists'](name)
+
+    # Dry run, test=true mode
+    if __opts__['test']:
+        if not bridge_exists:
+            ret['result'] = True
+            ret['comment'] = comment_bridge_notexists
+        else:
+            ret['result'] = None
+            ret['comment'] = comment_bridge_deleted
+            ret['changes'] = changes_bridge_deleted
+
+        return ret
+
+    if not bridge_exists:
+        ret['result'] = True
+        ret['comment'] = comment_bridge_notexists
+    else:
+        bridge_delete = __salt__['openvswitch.bridge_delete'](name)
+        if bridge_delete:
+            ret['result'] = True
+            ret['comment'] = comment_bridge_deleted
+            ret['changes'] = changes_bridge_deleted
+        else:
+            ret['result'] = False
+            ret['comment'] = comment_bridge_notdeleted
+
+    return ret

--- a/salt/states/openvswitch_port.py
+++ b/salt/states/openvswitch_port.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-"""
+'''
 Management of Open vSwitch ports.
-"""
+'''
 
 
 def __virtual__():
@@ -12,14 +12,14 @@ def __virtual__():
 
 
 def present(name, bridge):
-    """
+    '''
     Ensures that the named port exists on bridge, eventually creates it.
 
     Args:
         name: The name of the port.
         bridge: The name of the bridge.
 
-    """
+    '''
     ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
 
     bridge_exists = __salt__['openvswitch.bridge_exists'](bridge)
@@ -27,7 +27,7 @@ def present(name, bridge):
     if bridge_exists:
         port_list = __salt__['openvswitch.port_list'](bridge)
 
-    #Comment and change messages
+    # Comment and change messages
     comment_bridge_notexists = 'Bridge {0} does not exist.'.format(bridge)
     comment_port_exists = 'Port {0} already exists.'.format(name)
     comment_port_created = 'Port {0} created on bridge {1}.'.format(name, bridge)
@@ -75,7 +75,7 @@ def present(name, bridge):
 
 
 def absent(name, bridge=None):
-    """
+    '''
     Ensures that the named port exists on bridge, eventually deletes it.
     If bridge is not set, port is removed from  whatever bridge contains it.
 
@@ -83,7 +83,7 @@ def absent(name, bridge=None):
         name: The name of the port.
         bridge: The name of the bridge.
 
-    """
+    '''
     ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
 
     if bridge:
@@ -95,7 +95,7 @@ def absent(name, bridge=None):
     else:
         port_list = [name]
 
-    #Comment and change messages
+    # Comment and change messages
     comment_bridge_notexists = 'Bridge {0} does not exist.'.format(bridge)
     comment_port_notexists = 'Port {0} does not exist on bridge {1}.'.format(name, bridge)
     comment_port_deleted = 'Port {0} deleted.'.format(name)
@@ -129,7 +129,7 @@ def absent(name, bridge=None):
         if bridge:
             port_remove = __salt__['openvswitch.port_remove'](br=bridge, port=name)
         else:
-            port_remove = __salt__['openvswitch.port_remove'](port=name)
+            port_remove = __salt__['openvswitch.port_remove'](br=None, port=name)
 
         if port_remove:
             ret['result'] = True

--- a/salt/states/openvswitch_port.py
+++ b/salt/states/openvswitch_port.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+"""
+Management of Open vSwitch ports.
+"""
+
+
+def __virtual__():
+    '''
+    Only make these states available if Open vSwitch module is available.
+    '''
+    return 'openvswitch.port_add' in __salt__
+
+
+def present(name, bridge):
+    """
+    Ensures that the named port exists on bridge, eventually creates it.
+
+    Args:
+        name: The name of the port.
+        bridge: The name of the bridge.
+
+    """
+    ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
+
+    bridge_exists = __salt__['openvswitch.bridge_exists'](bridge)
+
+    if bridge_exists:
+        port_list = __salt__['openvswitch.port_list'](bridge)
+
+    #Comment and change messages
+    comment_bridge_notexists = 'Bridge {0} does not exist.'.format(bridge)
+    comment_port_exists = 'Port {0} already exists.'.format(name)
+    comment_port_created = 'Port {0} created on bridge {1}.'.format(name, bridge)
+    comment_port_notcreated = 'Unable to create port {0} on bridge {1}.'.format(name, bridge)
+    changes_port_created = {name: {'old': 'No port named {0} present.'.format(name),
+                                   'new': 'Created port {1} on bridge {0}.'.format(bridge, name),
+                                   }
+                            }
+
+    # Dry run, test=true mode
+    if __opts__['test']:
+        if bridge_exists:
+            if name in port_list:
+                ret['result'] = True
+                ret['comment'] = comment_port_exists
+            else:
+                ret['result'] = None
+                ret['comment'] = comment_port_created
+                ret['changes'] = changes_port_created
+
+        else:
+            ret['result'] = None
+            ret['comment'] = comment_bridge_notexists
+
+        return ret
+
+    if bridge_exists:
+        if name in port_list:
+            ret['result'] = True
+            ret['comment'] = comment_port_exists
+        else:
+            port_add = __salt__['openvswitch.port_add'](bridge, name)
+            if port_add:
+                ret['result'] = True
+                ret['comment'] = comment_port_created
+                ret['changes'] = changes_port_created
+            else:
+                ret['result'] = False
+                ret['comment'] = comment_port_notcreated
+    else:
+        ret['result'] = False
+        ret['comment'] = comment_bridge_notexists
+
+    return ret
+
+
+def absent(name, bridge=None):
+    """
+    Ensures that the named port exists on bridge, eventually deletes it.
+    If bridge is not set, port is removed from  whatever bridge contains it.
+
+    Args:
+        name: The name of the port.
+        bridge: The name of the bridge.
+
+    """
+    ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
+
+    if bridge:
+        bridge_exists = __salt__['openvswitch.bridge_exists'](bridge)
+        if bridge_exists:
+            port_list = __salt__['openvswitch.port_list'](bridge)
+        else:
+            port_list = ()
+    else:
+        port_list = [name]
+
+    #Comment and change messages
+    comment_bridge_notexists = 'Bridge {0} does not exist.'.format(bridge)
+    comment_port_notexists = 'Port {0} does not exist on bridge {1}.'.format(name, bridge)
+    comment_port_deleted = 'Port {0} deleted.'.format(name)
+    comment_port_notdeleted = 'Unable to delete port {0}.'.format(name)
+    changes_port_deleted = {name: {'old': 'Port named {0} may exist.'.format(name),
+                                   'new': 'Deleted port {0}.'.format(name),
+                                   }
+                            }
+
+    # Dry run, test=true mode
+    if __opts__['test']:
+        if bridge and not bridge_exists:
+            ret['result'] = None
+            ret['comment'] = comment_bridge_notexists
+        elif name not in port_list:
+            ret['result'] = True
+            ret['comment'] = comment_port_notexists
+        else:
+            ret['result'] = None
+            ret['comment'] = comment_port_deleted
+            ret['changes'] = changes_port_deleted
+        return ret
+
+    if bridge and not bridge_exists:
+        ret['result'] = False
+        ret['comment'] = comment_bridge_notexists
+    elif name not in port_list:
+        ret['result'] = True
+        ret['comment'] = comment_port_notexists
+    else:
+        if bridge:
+            port_remove = __salt__['openvswitch.port_remove'](br=bridge, port=name)
+        else:
+            port_remove = __salt__['openvswitch.port_remove'](port=name)
+
+        if port_remove:
+            ret['result'] = True
+            ret['comment'] = comment_port_deleted
+            ret['changes'] = changes_port_deleted
+        else:
+            ret['result'] = False
+            ret['comment'] = comment_port_notdeleted
+
+    return ret


### PR DESCRIPTION
# Open vSwitch basic commands support

Suitable for setting up Openstack Neutron.
## Execution module
### Bridge

bridge_create - creates a new bridge

```
salt '*' openvswitch.bridge_create br0
```

bridge_delete - deletes bridge and all of  its  ports

```
salt '*' openvswitch.bridge_delete br0
```

bridge_exists - tests whether bridge exists as a real or fake  bridge

```
salt '*' openvswitch.bridge_exists br0
```

bridge_list - lists all existing real and fake bridges

```
salt '*' openvswitch.bridge_list
```
### Port

port_add - creates on bridge a new port

```
salt '*' openvswitch.port_add br0 8080
```

port_remove - deletes port

```
salt '*' openvswitch.port_remove br0 8080
```

port_list - lists all of the ports within bridge

```
salt '*' openvswitch.port_list br0
```
## State module
### Bridge

present - ensures that the named bridge exists, eventually creates it
absent - ensures that the named bridge does not exist, eventually deletes it

```
management:
  openvswitch_bridge.present

management2:
  openvswitch_bridge.absent:
    - names:
      - br-int
```
### Port

present - ensures that the named port exists on bridge, eventually creates it
absent - ensures that the named port exists on bridge, eventually deletes it

```
tap0:
  openvswitch_port.present:
    - bridge: management

tap0_2:
  openvswitch_port.absent:
    - bridge: management
    - names:
      - tap0
```
