### PR TITLE
add grains on smartos computenodes

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1881,8 +1881,8 @@ def _smartos_computenode_data():
 
     # *_vms grains
     grains['computenode_vms_total'] = len(__salt__['cmd.run']('vmadm list -p').split("\n"))
-    grains['computenode_vms_running'] = len(__salt__['cmd.run']('vmadm list -p "state=running"').split("\n"))
-    grains['computenode_vms_stopped'] = len(__salt__['cmd.run']('vmadm list -p "state=stopped"').split("\n"))
+    grains['computenode_vms_running'] = len(__salt__['cmd.run']('vmadm list -p state=running').split("\n"))
+    grains['computenode_vms_stopped'] = len(__salt__['cmd.run']('vmadm list -p state=stopped').split("\n"))
 
     # sysinfo derived grains
     sysinfo = json.loads(__salt__['cmd.run']('sysinfo'))

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1888,7 +1888,7 @@ def _smartos_computenode_data():
     sysinfo = json.loads(__salt__['cmd.run']('sysinfo'))
     grains['computenode_sdc_version'] = sysinfo['SDC Version']
     grains['computenode_vm_capable'] = sysinfo['VM Capable']
-    if sysinfo['VM Capable'] == True:
+    if sysinfo['VM Capable']:
         grains['computenode_vm_hw_virt'] = sysinfo['CPU Virtualization']
 
     # sysinfo derived smbios grains

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -14,6 +14,7 @@ as those returned here
 from __future__ import absolute_import
 import itertools
 import os
+import json
 import socket
 import sys
 import re
@@ -1296,6 +1297,8 @@ def os_data():
             uname_v = __salt__['cmd.run']('uname -v')
             grains['os'] = grains['osfullname'] = 'SmartOS'
             grains['osrelease'] = uname_v[uname_v.index('_')+1:]
+        if salt.utils.is_smartos_globalzone():
+            grains.update(_smartos_computenode_data())
         elif os.path.isfile('/etc/release'):
             with salt.utils.fopen('/etc/release', 'r') as fp_:
                 rel_data = fp_.read()
@@ -1855,6 +1858,43 @@ def _hw_data(osdata):
             value = __salt__['cmd.run']('{0} -b {1}'.format(sysctl, oid))
             if not value.endswith(' is invalid'):
                 grains[key] = value
+
+    return grains
+
+
+def _smartos_computenode_data():
+    '''
+    Return useful information from a SmartOS compute node
+    '''
+    # Provides:
+    #   vms_total
+    #   vms_running
+    #   vms_stopped
+    #   sdc_version
+    #   vm_capable
+    #   vm_hw_virt
+
+    if salt.utils.is_proxy():
+        return {}
+
+    grains = {}
+
+    # *_vms grains
+    grains['computenode_vms_total'] = len(__salt__['cmd.run']('vmadm list -p').split("\n"))
+    grains['computenode_vms_running'] = len(__salt__['cmd.run']('vmadm list -p "state=running"').split("\n"))
+    grains['computenode_vms_stopped'] = len(__salt__['cmd.run']('vmadm list -p "state=stopped"').split("\n"))
+
+    # sysinfo derived grains
+    sysinfo = json.loads(__salt__['cmd.run']('sysinfo'))
+    grains['computenode_sdc_version'] = sysinfo['SDC Version']
+    grains['computenode_vm_capable'] = sysinfo['VM Capable']
+    if sysinfo['VM Capable'] == True:
+        grains['computenode_vm_hw_virt'] = sysinfo['CPU Virtualization']
+
+    # sysinfo derived smbios grains
+    grains['manufacturer'] = sysinfo['Manufacturer']
+    grains['productname'] = sysinfo['Product']
+    grains['uuid'] = sysinfo['UUID']
 
     return grains
 


### PR DESCRIPTION
Add some more grains on SmartOS computenodes.

```
[root@core ~]# /opt/local/salt/bin/salt-call --local grains.items
local:
    ----------
    computenode_sdc_version:
        7.0
    computenode_vm_capable:
        True
    computenode_vm_hw_virt:
        vmx
    computenode_vms_running:
        6
    computenode_vms_stopped:
        3
    computenode_vms_total:
        9
...
```

and since we are at it, sysinfo also knows some of the smbios info we are missing

```
...
    manufacturer:
        Supermicro
    productname:
        X9DRi-LN4+/X9DR3-LN4+
    uuid:
        00000000-0000-0000-0000-002590f15506
...
```
