### PR TITLE
Fix AttributeError when trying to access psutil.get_users

### DIFF
--- a/salt/utils/psutil_compat.py
+++ b/salt/utils/psutil_compat.py
@@ -41,7 +41,11 @@ else:
 
     # Alias renamed module functions
     pids = psutil.get_pid_list
-    users = psutil.get_users
+    try:
+        users = psutil.get_users
+    except AttributeError:
+        users = lambda: (_ for _ in ()).throw(NotImplementedError('Your '
+                                              'psutil version is too old'))
 
     # Deprecated in 1.0.1, but not mentioned in blog post
     if psutil.version_info < (1, 0, 1):


### PR DESCRIPTION
Very old versions of psutil do not even have get_users at all.
This commit at least allows using the rest of the functionality
instead of throwing an error right away when importing the psutil
compatibility layer.
