### PR TITLE
Add python2_bin and python3_bin default values

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1202,6 +1202,8 @@ DEFAULT_MASTER_OPTS = {
     'dummy_pub': False,
     'http_request_timeout': 1 * 60 * 60.0,  # 1 hour
     'http_max_body': 100 * 1024 * 1024 * 1024,  # 100GB
+    'python2_bin': 'python2',
+    'python3_bin': 'python3',
 }
 
 


### PR DESCRIPTION
Some components such as the SSH client assume those
values will be there. When the code is invoked from
python scripts and not as an application is good to
provide sane defaults and not require the application
code to have to provide them.
