### PR TITLE
Fixed nodegroup doc formatting to correctly link to pillar_opts in the master config

### DIFF
--- a/doc/topics/targeting/nodegroups.rst
+++ b/doc/topics/targeting/nodegroups.rst
@@ -71,7 +71,7 @@ nodegroup`` on the line directly following the nodegroup name.
 Using Nodegroups in SLS files
 =============================
 
-To use Nodegroups in Jinja logic for SLS files, the :conf_master:'pillar_opts' option in 
+To use Nodegroups in Jinja logic for SLS files, the :conf_master:`pillar_opts` option in 
 ``/etc/salt/master`` must be set to "True". This will pass the master's configuration as 
 Pillar data to each minion.
 


### PR DESCRIPTION
See #28453 which is a fix to #28306 
