### PR TITLE
Updated states.virtualenv_mod comments to reflect that some kwargs need 'distribute: True'

### DIFF
--- a/salt/states/virtualenv_mod.py
+++ b/salt/states/virtualenv_mod.py
@@ -82,7 +82,8 @@ def managed(name,
         Pass `--upgrade` to `pip install`.
 
 
-    Also accepts any kwargs that the virtualenv module will.
+    Also accepts any kwargs that the virtualenv module will. 
+     However, some kwargs require `- distribute: True`
 
     .. code-block:: yaml
 


### PR DESCRIPTION
The virtualenv mod will automatically set distribute=True, but this must be explicitly set for the state

see #26011
