### PR TITLE
Make mine.update more manageable for large environments

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -231,8 +231,14 @@ VALID_OPTS = {
     # A flag indicating that a master should accept any minion connection without any authentication
     'open_mode': bool,
 
-    # Whether or not processes should be forked when needed. The altnerative is to use threading.
+    # Whether or not processes should be forked when needed. The alternative is to use threading.
     'multiprocessing': bool,
+
+    # Whether or not the salt minion should run scheduled mine updates
+    'mine_enabled': bool,
+
+    # Whether or not scheduled mine updates should be accompanied by a job return for the job cache
+    'mine_return_job': bool,
 
     # Schedule a mine update every n number of seconds
     'mine_interval': int,
@@ -862,6 +868,8 @@ DEFAULT_MINION_OPTS = {
     'auto_accept': True,
     'autosign_timeout': 120,
     'multiprocessing': _DFLT_MULTIPROCESSING_MODE,
+    'mine_enabled': True,
+    'mine_return_job': False,
     'mine_interval': 60,
     'ipc_mode': _DFLT_IPC_MODE,
     'ipv6': False,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -783,7 +783,6 @@ class Minion(MinionBase):
 
         # add default scheduling jobs to the minions scheduler
         if self.opts.get('mine_enabled', True) and 'mine.update' in self.functions:
-            log.info('Added mine.update to scheduler')
             self.schedule.add_job({
                 '__mine_interval':
                 {
@@ -794,6 +793,7 @@ class Minion(MinionBase):
                     'return_job': self.opts.get('mine_return_job', False)
                 }
             }, persist=True)
+            log.info('Added mine.update to scheduler')
 
         # add master_alive job if enabled
         if self.opts['master_alive_interval'] > 0:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -794,6 +794,8 @@ class Minion(MinionBase):
                 }
             }, persist=True)
             log.info('Added mine.update to scheduler')
+        else:
+            self.schedule.delete_job('__mine_interval', persist=True)
 
         # add master_alive job if enabled
         if self.opts['master_alive_interval'] > 0:
@@ -2627,7 +2629,6 @@ class ProxyMinion(Minion):
 
         # add default scheduling jobs to the minions scheduler
         if self.opts.get('mine_enabled', True) and 'mine.update' in self.functions:
-            log.info('Added mine.update to scheduler')
             self.schedule.add_job({
                 '__mine_interval':
                     {
@@ -2638,6 +2639,9 @@ class ProxyMinion(Minion):
                         'return_job': self.opts.get('mine_return_job', False)
                     }
             }, persist=True)
+            log.info('Added mine.update to scheduler')
+        else:
+            self.schedule.delete_job('__mine_interval', persist=True)
 
         # add master_alive job if enabled
         if self.opts['master_alive_interval'] > 0:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -782,7 +782,7 @@ class Minion(MinionBase):
             self.returners)
 
         # add default scheduling jobs to the minions scheduler
-        if 'mine.update' in self.functions:
+        if self.opts.get('mine_enabled', True) and 'mine.update' in self.functions:
             log.info('Added mine.update to scheduler')
             self.schedule.add_job({
                 '__mine_interval':
@@ -790,7 +790,8 @@ class Minion(MinionBase):
                     'function': 'mine.update',
                     'minutes': self.opts['mine_interval'],
                     'jid_include': True,
-                    'maxrunning': 2
+                    'maxrunning': 2,
+                    'return_job': self.opts.get('mine_return_job', False)
                 }
             }, persist=True)
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2626,7 +2626,7 @@ class ProxyMinion(Minion):
             self.returners)
 
         # add default scheduling jobs to the minions scheduler
-        if 'mine.update' in self.functions:
+        if self.opts.get('mine_enabled', True) and 'mine.update' in self.functions:
             log.info('Added mine.update to scheduler')
             self.schedule.add_job({
                 '__mine_interval':
@@ -2634,7 +2634,8 @@ class ProxyMinion(Minion):
                         'function': 'mine.update',
                         'minutes': self.opts['mine_interval'],
                         'jid_include': True,
-                        'maxrunning': 2
+                        'maxrunning': 2,
+                        'return_job': self.opts.get('mine_return_job', False)
                     }
             }, persist=True)
 

--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -103,6 +103,10 @@ def update(clear=False):
         salt '*' mine.update
     '''
     m_data = __salt__['config.option']('mine_functions', {})
+    # If we don't have any mine functions configured, then we should just bail out
+    if not m_data:
+        return
+
     data = {}
     for func in m_data:
         try:


### PR DESCRIPTION
In 2015.8 with a large environment, mine.update creates a very large amount of unnecessary traffic and load on the master.

This is partially due to the change from 2015.5 to 2015.8 where scheduled jobs now send job returns to the master by default, when previously the opposite was true.  I don't really understand the motivation for that change, but regardless, we need to be able to configure the behavior of the hard-coded `mine.update` scheduled job beyond adjusting the interval.

So the changes here are:
(1) Add two new config options to the minion to allow configuration of the mine.update scheduled job
(2) Have mine.update stop sending superfluous payloads when no mine functions are configured on the minion
