### PR TITLE
Newline character at the end of crontab

### DIFF
--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -189,6 +189,7 @@ def _write_cron_lines(user, lines):
     Takes a list of lines to be committed to a user's crontab and writes it
     '''
     path = salt.utils.mkstemp()
+    lines += '\n'
     with salt.utils.fopen(path, 'w+') as fp_:
         fp_.writelines(lines)
     ret = __salt__['cmd.run_all'](_get_cron_cmdstr(path, user),


### PR DESCRIPTION
"Cron requires that each entry in a crontab end in a newline character. If  the last entry in a crontab is missing a newline (ie, terminated by EOF), cron will consider the crontab (at  least  partially)  broken."
(http://manpages.ubuntu.com/manpages/maverick/man5/crontab.5.html)
