### PR TITLE
Update windows-package-manager.rst (minor edit) adding missing single quote pairs.

### DIFF
--- a/doc/topics/windows/windows-package-manager.rst
+++ b/doc/topics/windows/windows-package-manager.rst
@@ -280,7 +280,7 @@ project's wiki_:
 .. code-block:: yaml
 
     7zip:
-      9.20.00.0:
+      '9.20.00.0':
         installer: salt://win/repo/7zip/7z920-x64.msi
         full_name: 7-Zip 9.20 (x64 edition)
         reboot: False
@@ -294,7 +294,7 @@ Alternatively the ``uninstaller`` can also simply repeat the URL of the msi file
 .. code-block:: yaml
 
     7zip:
-      9.20.00.0:
+      '9.20.00.0':
         installer: salt://win/repo/7zip/7z920-x64.msi
         full_name: 7-Zip 9.20 (x64 edition)
         reboot: False
@@ -310,7 +310,7 @@ Only applies to salt: installer URLs.
 .. code-block:: yaml
 
     sqlexpress:
-      12.0.2000.8:
+      '12.0.2000.8':
         installer: 'salt://win/repo/sqlexpress/setup.exe'
         full_name: Microsoft SQL Server 2014 Setup (English)
         reboot: False


### PR DESCRIPTION
All the 'version' numbers in the salt windows sls files need to be single quoted, as we all recently learned.

And it would be good, and consistent, to also reflect this in the documentation. 

(some of the 'sls' file samples had already been updated, but at least these three must have been missed.)
