### PR TITLE
[2015.8] Log minion list for all rosters, at debug level

### DIFF
--- a/salt/roster/__init__.py
+++ b/salt/roster/__init__.py
@@ -89,4 +89,5 @@ class Roster(object):
                         tgt_type)
                     )
 
+        log.debug('Matched minions: {0}'.format(targets))
         return targets

--- a/salt/roster/flat.py
+++ b/salt/roster/flat.py
@@ -63,7 +63,6 @@ class RosterMatcher(object):
                 data = self.get_data(minion)
                 if data:
                     minions[minion] = data
-        log.info('minions list: {0}'.format(minions))
         return minions
 
     def ret_pcre_minions(self):
@@ -76,7 +75,6 @@ class RosterMatcher(object):
                 data = self.get_data(minion)
                 if data:
                     minions[minion] = data
-        log.info('minions list: {0}'.format(minions))
         return minions
 
     def ret_list_minions(self):


### PR DESCRIPTION
Logging the minion list at INFO is noisy for every call. It's debug
information. Additionally, we want to log the targets for every roster
type, so move the log higher in the call chain.
