### PR TITLE
Issue #28527 boto_rds.create does not work

### DIFF
--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -229,7 +229,7 @@ def create(name, allocated_storage, db_instance_class, engine,
                                       option_group_name, character_set_name,
                                       publicly_accessible, tags)
         if not rds:
-            msg = 'Failed to create RDS {0}, reason: {1}'.format(name, e.body)
+            msg = 'Failed to create RDS {0}'.format(name)
             log.error(msg)
             return False
         if not wait_status:

--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -171,7 +171,7 @@ def subnet_group_exists(name, tags=None, region=None, key=None, keyid=None,
         return False
 
 
-def create(name, allocated_storage, storage_type, db_instance_class, engine,
+def create(name, allocated_storage, db_instance_class, engine,
            master_username, master_user_password, db_name=None,
            db_security_groups=None, vpc_security_group_ids=None,
            availability_zone=None, db_subnet_group_name=None,
@@ -187,21 +187,15 @@ def create(name, allocated_storage, storage_type, db_instance_class, engine,
 
     CLI example to create an RDS::
 
-        salt myminion boto_rds.create myrds 10 db.t2.micro MySQL sqlusr sqlpass
+        salt myminion boto_rds.create myrds 10 db.t2.micro MySQL sqlusr sqlpassw
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
     if __salt__['boto_rds.exists'](name, tags, region, key, keyid, profile):
         return True
 
-    a_s = ['standard', 'gp2', 'io1']
     if not allocated_storage:
         raise SaltInvocationError('allocated_storage is required')
-    if not storage_type:
-        raise SaltInvocationError('storage_type is required')
-    if storage_type not in a_s:
-        raise SaltInvocationError('storage_type must be one of: '
-                                  '{0}'.format(", ".join(str(e) for e in a_s)))
     if not db_instance_class:
         raise SaltInvocationError('db_instance_class is required')
     if not engine:
@@ -231,11 +225,11 @@ def create(name, allocated_storage, storage_type, db_instance_class, engine,
                                       preferred_backup_window, port, multi_az,
                                       engine_version,
                                       auto_minor_version_upgrade,
-                                      license_model, storage_type, iops,
+                                      license_model, iops,
                                       option_group_name, character_set_name,
                                       publicly_accessible, tags)
         if not rds:
-            msg = 'Failed to create RDS {0}'.format(name)
+            msg = 'Failed to create RDS {0}, reason: {1}'.format(name, e.body)
             log.error(msg)
             return False
         if not wait_status:
@@ -253,7 +247,7 @@ def create(name, allocated_storage, storage_type, db_instance_class, engine,
 
     except boto.exception.BotoServerError as e:
         log.debug(e)
-        msg = 'Failed to create RDS {0}'.format(name)
+        msg = 'Failed to create RDS {0}, reason: {1}'.format(name, e.body)
         log.error(msg)
         return False
 


### PR DESCRIPTION
Fixes #28527 by removing an unsupported parameter in boto (storage_type)
Additionally, fixed the description to a working example (otherwise it
would fail due to a too-short password) and added additional output to
the message in case of an error
