### PR TITLE
Add `body` to salt.utils.http.query returns

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -618,11 +618,11 @@ class Client(object):
             if 'handle' not in query:
                 raise MinionError('Error: {0}'.format(query['error']))
             if no_cache:
-                return query['text']
+                return query['body']
             else:
                 dest_tmp = "{0}.part".format(dest)
                 with salt.utils.fopen(dest_tmp, 'wb') as destfp:
-                    destfp.write(query['text'])
+                    destfp.write(query['body'])
                 salt.utils.files.rename(dest_tmp, dest)
                 return dest
         except HTTPError as exc:

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -299,7 +299,10 @@ def query(url,
         )
         result.raise_for_status()
         if stream is True or handle is True:
-            return {'handle': result}
+            return {
+                'handle': result,
+                'body': result.content,
+            }
 
         log.debug('Final URL location of Response: {0}'.format(sanitize_url(result.url, hide_fields)))
 
@@ -307,6 +310,7 @@ def query(url,
         result_headers = result.headers
         result_text = result.text
         result_cookies = result.cookies
+        ret['body'] = result.content
     elif backend == 'urllib2':
         request = urllib_request.Request(url_full, data)
         handlers = [
@@ -383,11 +387,15 @@ def query(url,
         except URLError as exc:
             return {'Error': str(exc)}
         if stream is True or handle is True:
-            return {'handle': result}
+            return {
+                'handle': result,
+                'body': result.content,
+            }
 
         result_status_code = result.code
         result_headers = result.headers.headers
         result_text = result.read()
+        ret['body'] = result_text
     else:
         # Tornado
         req_kwargs = {}
@@ -449,11 +457,15 @@ def query(url,
             return ret
 
         if stream is True or handle is True:
-            return {'handle': result}
+            return {
+                'handle': result,
+                'body': result.body,
+            }
 
         result_status_code = result.code
         result_headers = result.headers
         result_text = result.body
+        ret['body'] = result.body
         if 'Set-Cookie' in result_headers.keys() and cookies is not None:
             result_cookies = parse_cookie_header(result_headers['Set-Cookie'])
             for item in result_cookies:


### PR DESCRIPTION
This way we have a consistent return method that some interal callers (fileclient) who don't care about the decoding of the message can just use.

Fixes #28477
