### PR TITLE
Reset yaml rendering hooks to avoid leaks

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -238,11 +238,15 @@ def setvals(grains, destructive=False):
             grains[key] = val
             __grains__[key] = val
     # Cast defaultdict to dict; is there a more central place to put this?
+    yaml_reps = copy.deepcopy(yaml.representer.SafeRepresenter.yaml_representers)
+    yaml_multi_reps = copy.deepcopy(yaml.representer.SafeRepresenter.yaml_multi_representers)
     yaml.representer.SafeRepresenter.add_representer(collections.defaultdict,
             yaml.representer.SafeRepresenter.represent_dict)
     yaml.representer.SafeRepresenter.add_representer(OrderedDict,
             yaml.representer.SafeRepresenter.represent_dict)
     cstr = yaml.safe_dump(grains, default_flow_style=False)
+    yaml.representer.SafeRepresenter.yaml_representers = yaml_reps
+    yaml.representer.SafeRepresenter.yaml_multi_representers = yaml_multi_reps
     try:
         with salt.utils.fopen(gfn, 'w+') as fp_:
             fp_.write(cstr)


### PR DESCRIPTION
So, this is an unusual problem. The issue was the with the introduction of an ordereredict representer to the yaml renderer inside the grains module, it was staying bound even outside of that module. This ends up breaking some types of rendering for anything that calls either safe_load or safe_dump after the ordereddict representer was attached.

I experimented a bunch with trying to centralize this inside the salt.serializers.yaml class. At the end of the day, it ended up adding a bunch of overhead and tracking to that module and made it fairly dirty just to handle a one-off case. If this becomes a problem in the future, I feel like we can revisit it then.

I also experimented with trying to create special yaml subclasses with yaml serialization hints inside them. While this worked fine for serialization, it's not supported in the pyyaml safe deserialization methods and so that approach was abandoned.

This should fix the failing serializer tests in 2015.8 and develop.
