### PR TITLE
Make DaemonMixin subclass PidfileMixin and move check_running to DaemonMixin

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -848,43 +848,6 @@ class RunUserMixin(six.with_metaclass(MixInMeta, object)):
         )
 
 
-class PidfileMixin(six.with_metaclass(MixInMeta, object)):
-    _mixin_prio_ = 40
-
-    def _mixin_setup(self):
-        salt.utils.warn_until(
-            'Nitrogen',
-            'Please stop sub-classing PidfileMix and instead subclass '
-            'DaemonMixIn which contains the same behavior. PidfileMixin '
-            'will be supported until Salt {version}.'
-        )
-        self.add_option(
-            '--pid-file', dest='pidfile',
-            default=os.path.join(
-                syspaths.PIDFILE_DIR, '{0}.pid'.format(self.get_prog_name())
-            ),
-            help=('Specify the location of the pidfile. Default: %default')
-        )
-
-    def set_pidfile(self):
-        from salt.utils.process import set_pidfile
-        set_pidfile(self.config['pidfile'], self.config['user'])
-
-    def check_pidfile(self):
-        '''
-        Report whether a pidfile exists
-        '''
-        from salt.utils.process import check_pidfile
-        return check_pidfile(self.config['pidfile'])
-
-    def get_pidfile(self):
-        '''
-        Return a pid contained in a pidfile
-        '''
-        from salt.utils.process import get_pidfile
-        return get_pidfile(self.config['pidfile'])
-
-
 class DaemonMixIn(six.with_metaclass(MixInMeta, object)):
     _mixin_prio_ = 30
 
@@ -975,6 +938,43 @@ class DaemonMixIn(six.with_metaclass(MixInMeta, object)):
 
     def shutdown(self, exitcode=0, exitmsg=None):
         self.exit(exitcode, exitmsg)
+
+
+class PidfileMixin(six.with_metaclass(MixInMeta, object)):
+    _mixin_prio_ = 40
+
+    def _mixin_setup(self):
+        salt.utils.warn_until(
+            'Nitrogen',
+            'Please stop sub-classing PidfileMix and instead subclass '
+            'DaemonMixIn which contains the same behavior. PidfileMixin '
+            'will be supported until Salt {version}.'
+        )
+        self.add_option(
+            '--pid-file', dest='pidfile',
+            default=os.path.join(
+                syspaths.PIDFILE_DIR, '{0}.pid'.format(self.get_prog_name())
+            ),
+            help=('Specify the location of the pidfile. Default: %default')
+        )
+
+    def set_pidfile(self):
+        from salt.utils.process import set_pidfile
+        set_pidfile(self.config['pidfile'], self.config['user'])
+
+    def check_pidfile(self):
+        '''
+        Report whether a pidfile exists
+        '''
+        from salt.utils.process import check_pidfile
+        return check_pidfile(self.config['pidfile'])
+
+    def get_pidfile(self):
+        '''
+        Return a pid contained in a pidfile
+        '''
+        from salt.utils.process import get_pidfile
+        return get_pidfile(self.config['pidfile'])
 
 
 class TargetOptionsMixIn(six.with_metaclass(MixInMeta, object)):

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -7,12 +7,12 @@ import sys
 import time
 import types
 import signal
-import subprocess
 import logging
+import threading
+import subprocess
 import multiprocessing
 import multiprocessing.util
 
-import threading
 
 # Import salt libs
 import salt.defaults.exitcodes


### PR DESCRIPTION
The pidfile and daemon mixins only make sense together, so, they are now
one and only DaemonMixin needs to be passed as a subclass. Additionally,
it only makes sense that a parser inheriting from DaemonMixin needs to have
access to `check_running`, not just a subset of our daemons.

PidfileMixin is left for backwards compat.

Finally, before trying to read a pidfile, make sure it exists first.

@cachedout we probably didn't see this before because pidfiles are left behind, and because our test suite does not start our daemons from CLI, it uses multiprocessing processes...
