### PR TITLE
Refactor etcd modules

### DIFF
--- a/salt/modules/etcd_mod.py
+++ b/salt/modules/etcd_mod.py
@@ -29,7 +29,7 @@ import logging
 
 # Import third party libs
 try:
-    import salt.utils.etcd_util
+    import salt.utils.etcd_util  # pylint: disable=W0611
     HAS_LIBS = True
 except ImportError:
     HAS_LIBS = False
@@ -60,7 +60,7 @@ def get_(key, recurse=False, profile=None):
     '''
     .. versionadded:: 2014.7.0
 
-    Get a value from etcd, by direct path
+    Get a value from etcd, by direct path.  Returns None on failure.
 
     CLI Examples:
 
@@ -71,25 +71,18 @@ def get_(key, recurse=False, profile=None):
         salt myminion etcd.get /path/to/key recurse=True profile=my_etcd_config
     '''
     client = __utils__['etcd_util.get_conn'](__opts__, profile)
-    try:
-        result = client.get(key)
-    except KeyError as err:
-        log.error('etcd: {0}'.format(err))
-        return ''
-    except Exception:
-        raise
-
     if recurse:
-        return salt.utils.etcd_util.tree(client, key)
+        return client.tree(key)
     else:
-        return getattr(result, 'value')
+        return client.get(key, recurse=recurse)
 
 
-def set_(key, value, profile=None):
+def set_(key, value, profile=None, ttl=None, directory=False):
     '''
     .. versionadded:: 2014.7.0
 
-    Set a value in etcd, by direct path
+    Set a key in etcd by direct path. Optionally, create a directory
+    or set a TTL on the key.  Returns None on failure.
 
     CLI Example:
 
@@ -97,25 +90,44 @@ def set_(key, value, profile=None):
 
         salt myminion etcd.set /path/to/key value
         salt myminion etcd.set /path/to/key value profile=my_etcd_config
+        salt myminion etcd.set /path/to/dir '' directory=True
+        salt myminion etcd.set /path/to/key value ttl=5
     '''
 
     client = __utils__['etcd_util.get_conn'](__opts__, profile)
-    try:
-        result = client.write(key, value)
-    except KeyError as err:
-        log.error('etcd: {0}'.format(err))
-        return ''
-    except Exception:
-        raise
+    return client.set(key, value, ttl=ttl, directory=directory)
 
-    return getattr(result, 'value')
+
+def watch(key, recurse=False, profile=None, timeout=0, index=None):
+    '''
+    .. versionadded:: Boron
+
+    Makes a best effort to watch for a key or tree change in etcd.
+    Returns a dict containing the new key value ( or None if the key was
+    deleted ), the modifiedIndex of the key, whether the key changed or
+    not, the path to the key that changed and whether it is a directory or not.
+
+    If something catastrophic happens, returns {}
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion etcd.watch /path/to/key
+        salt myminion etcd.watch /path/to/key timeout=10
+        salt myminion etcd.watch /patch/to/key profile=my_etcd_config index=10
+    '''
+
+    client = __utils__['etcd_util.get_conn'](__opts__, profile)
+    return client.watch(key, recurse=recurse, timeout=timeout, index=index)
 
 
 def ls_(path='/', profile=None):
     '''
     .. versionadded:: 2014.7.0
 
-    Return all keys and dirs inside a specific path
+    Return all keys and dirs inside a specific path. Returns an empty dict on
+    failure.
 
     CLI Example:
 
@@ -126,29 +138,15 @@ def ls_(path='/', profile=None):
         salt myminion etcd.ls /path/to/dir/ profile=my_etcd_config
     '''
     client = __utils__['etcd_util.get_conn'](__opts__, profile)
-    try:
-        items = client.get(path)
-    except KeyError as err:
-        log.error('etcd: {0}'.format(err))
-        return {}
-    except Exception:
-        raise
-
-    ret = {}
-    for item in items.children:
-        if item.dir is True:
-            dir_name = '{0}/'.format(item.key)
-            ret[dir_name] = {}
-        else:
-            ret[item.key] = item.value
-    return {path: ret}
+    return client.ls(path)
 
 
 def rm_(key, recurse=False, profile=None):
     '''
     .. versionadded:: 2014.7.0
 
-    Delete a key from etcd
+    Delete a key from etcd.  Returns True if the key was deleted, False if it wasn
+    not and None if there was a failure.
 
     CLI Example:
 
@@ -160,23 +158,14 @@ def rm_(key, recurse=False, profile=None):
         salt myminion etcd.rm /path/to/dir recurse=True profile=my_etcd_config
     '''
     client = __utils__['etcd_util.get_conn'](__opts__, profile)
-    try:
-        if client.delete(key, recursive=recurse):
-            return True
-        else:
-            return False
-    except KeyError as err:
-        log.error('etcd: {0}'.format(err))
-        return False
-    except Exception:
-        raise
+    return client.rm(key, recurse=recurse)
 
 
 def tree(path='/', profile=None):
     '''
     .. versionadded:: 2014.7.0
 
-    Recurse through etcd and return all values
+    Recurse through etcd and return all values.  Returns None on failure.
 
     CLI Example:
 
@@ -188,10 +177,4 @@ def tree(path='/', profile=None):
         salt myminion etcd.tree /path/to/keys profile=my_etcd_config
     '''
     client = __utils__['etcd_util.get_conn'](__opts__, profile)
-    try:
-        return salt.utils.etcd_util.tree(client, path)
-    except KeyError as err:
-        log.error('etcd: {0}'.format(err))
-        return {}
-    except Exception:
-        raise
+    return client.tree(path)

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -85,7 +85,7 @@ def returner(ret):
     client, path = _get_conn(__opts__)
 
     # Make a note of this minion for the external job cache
-    client.write(
+    client.set(
         '/'.join((path, 'minions', ret['id'])),
         ret['jid'],
     )
@@ -99,7 +99,7 @@ def returner(ret):
             ret['id'],
             field
         ))
-        client.write(dest, json.dumps(ret[field]))
+        client.set(dest, json.dumps(ret[field]))
 
 
 def save_load(jid, load):
@@ -107,7 +107,7 @@ def save_load(jid, load):
     Save the load to the specified jid
     '''
     client, path = _get_conn(__opts__)
-    client.write(
+    client.set(
         '/'.join((path, 'jobs', jid, '.load.p')),
         json.dumps(load)
     )
@@ -127,7 +127,7 @@ def get_jid(jid):
     '''
     client, path = _get_conn(__opts__)
     jid_path = '/'.join((path, 'jobs', jid))
-    return salt.utils.etcd_util.tree(client, jid_path)
+    return client.tree(jid_path)
 
 
 def get_fun():

--- a/salt/states/etcd_mod.py
+++ b/salt/states/etcd_mod.py
@@ -107,7 +107,7 @@ __func_alias__ = {
 
 # Import third party libs
 try:
-    import etcd
+    import salt.utils.etcd_util  # pylint: disable=W0611
     HAS_ETCD = True
 except ImportError:
     HAS_ETCD = False
@@ -143,15 +143,13 @@ def set_(name, value, profile=None):
         'changes': {}
     }
 
-    try:
-        current = __salt__['etcd.get'](name, profile=profile)
-    except etcd.EtcdKeyNotFound:
+    current = __salt__['etcd.get'](name, profile=profile)
+    if not current:
         created = True
-        current = None
 
     result = __salt__['etcd.set'](name, value, profile=profile)
 
-    if result != current:
+    if result and result != current:
         if created:
             rtn['comment'] = 'New key created'
         else:
@@ -204,9 +202,7 @@ def rm_(name, recurse=False, profile=None):
         'changes': {}
     }
 
-    try:
-        __salt__['etcd.get'](name, profile=profile)
-    except etcd.EtcdKeyNotFound:
+    if not __salt__['etcd.get'](name, profile=profile):
         rtn['comment'] = 'Key does not exist'
         return rtn
 

--- a/salt/utils/etcd_util.py
+++ b/salt/utils/etcd_util.py
@@ -29,6 +29,13 @@ the name of a profile to be used.
     import salt.utils.etcd_utils
     client = salt.utils.etcd_utils.client(__opts__, profile='my_etcd_config')
 
+You may also use the newer syntax and bypass the generator function.
+
+.. code-block:: python
+
+    import salt.utils.etcd_utils
+    client = salt.utils.etcd_utils.EtcdClient(__opts__, profile='my_etcd_config')
+
 It should be noted that some usages of etcd require a profile to be specified,
 rather than top-level configurations. This being the case, it is better to
 always use a named configuration profile, as shown above.
@@ -44,6 +51,7 @@ from salt.exceptions import CommandExecutionError
 # Import third party libs
 try:
     import etcd
+    from urllib3.exceptions import ReadTimeoutError, MaxRetryError
     HAS_LIBS = True
 except ImportError:
     HAS_LIBS = False
@@ -52,52 +60,224 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 
+class EtcdUtilWatchTimeout(Exception):
+    """
+    A watch timed out without returning a result
+    """
+    pass
+
+
+class EtcdClient(object):
+    def __init__(self, opts, profile=None):
+        opts_pillar = opts.get('pillar', {})
+        opts_master = opts_pillar.get('master', {})
+
+        opts_merged = {}
+        opts_merged.update(opts_master)
+        opts_merged.update(opts_pillar)
+        opts_merged.update(opts)
+
+        if profile:
+            self.conf = opts_merged.get(profile, {})
+        else:
+            self.conf = opts_merged
+
+        host = self.conf.get('etcd.host', '127.0.0.1')
+        port = self.conf.get('etcd.port', 4001)
+
+        if HAS_LIBS:
+            self.client = etcd.Client(host, port)
+        else:
+            raise CommandExecutionError(
+                '(unable to import etcd, '
+                'module most likely not installed)'
+            )
+
+    def watch(self, key, recurse=False, timeout=0, index=None):
+        ret = {
+            'key': key,
+            'value': None,
+            'changed': False,
+            'mIndex': 0,
+            'dir': False
+        }
+        try:
+            result = self.read(key, recursive=recurse, wait=True, timeout=timeout, waitIndex=index)
+        except EtcdUtilWatchTimeout:
+            try:
+                result = self.read(key)
+            except etcd.EtcdKeyNotFound:
+                log.debug("etcd: key was not created while watching")
+                return ret
+            if result and getattr(result, "dir"):
+                ret['dir'] = True
+            ret['value'] = getattr(result, 'value')
+            ret['mIndex'] = getattr(result, 'modifiedIndex')
+            return ret
+        except (etcd.EtcdConnectionFailed, MaxRetryError):
+            # This gets raised when we can't contact etcd at all
+            log.error("etcd: failed to perform 'watch' operation on key {0} due to connection error".format(key))
+            return {}
+        except ValueError:
+            return {}
+
+        if recurse:
+            ret['key'] = getattr(result, 'key', None)
+        ret['value'] = getattr(result, 'value', None)
+        ret['dir'] = getattr(result, 'dir', None)
+        ret['changed'] = True
+        ret['mIndex'] = getattr(result, 'modifiedIndex')
+        return ret
+
+    def get(self, key, recurse=False):
+        try:
+            result = self.read(key, recursive=recurse)
+        except etcd.EtcdKeyNotFound:
+            # etcd already logged that the key wasn't found, no need to do
+            # anything here but return
+            return None
+        except etcd.EtcdConnectionFailed:
+            log.error("etcd: failed to perform 'get' operation on key {0} due to connection error".format(key))
+            return None
+        except ValueError:
+            return None
+
+        return getattr(result, 'value', None)
+
+    def read(self, key, recursive=False, wait=False, timeout=None, waitIndex=None):
+        try:
+            if waitIndex:
+                result = self.client.read(key, recursive=recursive, wait=wait, timeout=timeout, waitIndex=waitIndex)
+            else:
+                result = self.client.read(key, recursive=recursive, wait=wait, timeout=timeout)
+        except (etcd.EtcdConnectionFailed, etcd.EtcdKeyNotFound) as err:
+            log.error("etcd: {0}".format(err))
+            raise
+        except ReadTimeoutError:
+            # For some reason, we have to catch this directly.  It falls through
+            # from python-etcd because it's trying to catch
+            # urllib3.exceptions.ReadTimeoutError and strangely, doesn't catch.
+            # This can occur from a watch timeout that expires, so it may be 'expected'
+            # behavior. See issue #28553
+            if wait:
+                # Wait timeouts will throw ReadTimeoutError, which isn't bad
+                log.debug("etcd: Timed out while executing a wait")
+                raise EtcdUtilWatchTimeout("Watch on {0} timed out".format(key))
+            log.error("etcd: Timed out")
+            raise etcd.EtcdConnectionFailed("Connection failed")
+        except MaxRetryError as err:
+            # Same issue as ReadTimeoutError.  When it 'works', python-etcd
+            # throws EtcdConnectionFailed, so we'll do that for it.
+            log.error("etcd: Could not connect")
+            raise etcd.EtcdConnectionFailed("Could not connect to etcd server")
+        except etcd.EtcdException as err:
+            # EtcdValueError inherits from ValueError, so we don't want to accidentally
+            # catch this below on ValueError and give a bogus error message
+            log.error("etcd: {0}".format(err))
+            raise
+        except ValueError:
+            # python-etcd doesn't fully support python 2.6 and ends up throwing this for *any* exception because
+            # it uses the newer {} format syntax
+            log.error("etcd: error. python-etcd does not fully support python 2.6, no error information available")
+            raise
+        except Exception as err:
+            log.error('etcd: uncaught exception {0}'.format(err))
+            raise
+        return result
+
+    def set(self, key, value, ttl=None, directory=False):
+        return self.write(key, value, ttl=ttl, directory=directory)
+
+    def write(self, key, value, ttl=None, directory=False):
+        # directories can't have values, but have to have it passed
+        if directory:
+            value = None
+        try:
+            result = self.client.write(key, value, ttl=ttl, dir=directory)
+        except (etcd.EtcdNotFile, etcd.EtcdNotDir, etcd.EtcdRootReadOnly, ValueError) as err:
+            log.error('etcd: {0}'.format(err))
+            return None
+        except MaxRetryError as err:
+            log.error("etcd: Could not connect to etcd server: {0}".format(err))
+            return None
+        except Exception as err:
+            log.error('etcd: uncaught exception {0}'.format(err))
+            raise
+
+        if directory:
+            return getattr(result, 'dir')
+        else:
+            return getattr(result, 'value')
+
+    def ls(self, path):
+        ret = {}
+        try:
+            items = self.read(path)
+        except (etcd.EtcdKeyNotFound, ValueError):
+            return {}
+        except etcd.EtcdConnectionFailed:
+            log.error("etcd: failed to perform 'ls' operation on path {0} due to connection error".format(path))
+            return None
+
+        for item in items.children:
+            if item.dir is True:
+                if item.key == path:
+                    continue
+                dir_name = '{0}/'.format(item.key)
+                ret[dir_name] = {}
+            else:
+                ret[item.key] = item.value
+        return {path: ret}
+
+    def rm(self, key, recurse=False):
+        return self.delete(key, recurse)
+
+    def delete(self, key, recursive=False):
+        try:
+            if self.client.delete(key, recursive=recursive):
+                return True
+            else:
+                return False
+        except (etcd.EtcdNotFile, etcd.EtcdRootReadOnly, etcd.EtcdDirNotEmpty, etcd.EtcdKeyNotFound, ValueError) as err:
+            log.error('etcd: {0}'.format(err))
+            return None
+        except MaxRetryError as err:
+            log.error('etcd: Could not connect to etcd server: {0}'.format(err))
+            return None
+        except Exception as err:
+            log.error('etcd: uncaught exception {0}'.format(err))
+            raise
+
+    def tree(self, path):
+        '''
+        .. versionadded:: 2014.7.0
+
+        Recurse through etcd and return all values
+        '''
+        ret = {}
+        try:
+            items = self.read(path)
+        except (etcd.EtcdKeyNotFound, ValueError):
+            return None
+        except etcd.EtcdConnectionFailed:
+            log.error("etcd: failed to perform 'tree' operation on path {0} due to connection error".format(path))
+            return None
+
+        for item in items.children:
+            comps = str(item.key).split('/')
+            if item.dir is True:
+                if item.key == path:
+                    continue
+                ret[comps[-1]] = self.tree(item.key)
+            else:
+                ret[comps[-1]] = item.value
+        return ret
+
+
 def get_conn(opts, profile=None):
-    '''
-    .. versionadded:: 2014.7.0
-
-    Return a client object for accessing etcd
-    '''
-    opts_pillar = opts.get('pillar', {})
-    opts_master = opts_pillar.get('master', {})
-
-    opts_merged = {}
-    opts_merged.update(opts_master)
-    opts_merged.update(opts_pillar)
-    opts_merged.update(opts)
-
-    if profile:
-        conf = opts_merged.get(profile, {})
-    else:
-        conf = opts_merged
-
-    host = conf.get('etcd.host', '127.0.0.1')
-    port = conf.get('etcd.port', 4001)
-
-    if HAS_LIBS:
-        return etcd.Client(host, port)
-    else:
-        raise CommandExecutionError(
-            '(unable to import etcd, '
-            'module most likely not installed)'
-        )
+    client = EtcdClient(opts, profile)
+    return client
 
 
 def tree(client, path):
-    '''
-    .. versionadded:: 2014.7.0
-
-    Recurse through etcd and return all values
-    '''
-    ret = {}
-    items = client.get(path)
-
-    for item in items.children:
-        comps = str(item.key).split('/')
-        if item.dir is True:
-            if item.key == path:
-                continue
-            ret[comps[-1]] = tree(client, item.key)
-        else:
-            ret[comps[-1]] = item.value
-    return ret
+    return client.tree(path)

--- a/tests/unit/modules/etcd_mod_test.py
+++ b/tests/unit/modules/etcd_mod_test.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import
 # Import Salt Testing Libs
 from salttesting import TestCase, skipIf
 from salttesting.mock import (
+    create_autospec,
     MagicMock,
     patch,
     NO_MOCK,
@@ -32,77 +33,56 @@ class EtcdModTestCase(TestCase):
     '''
     Test cases for salt.modules.etcd_mod
     '''
+
+    def setUp(self):
+        self.instance = create_autospec(etcd_util.EtcdClient)
+        self.EtcdClientMock = MagicMock()
+        self.EtcdClientMock.return_value = self.instance
+
+    def tearDown(self):
+        self.instance = None
+        self.EtcdClientMock = None
+
     # 'get_' function tests: 1
 
     def test_get(self):
         '''
         Test if it get a value from etcd, by direct path
         '''
-        class MockEtcd(object):
-            """
-            Mock of etcd
-            """
-            value = 'salt'
+        with patch.dict(etcd_mod.__utils__, {'etcd_util.get_conn': self.EtcdClientMock}):
+            self.instance.get.return_value = 'stack'
+            self.assertEqual(etcd_mod.get_('salt'), 'stack')
+            self.instance.get.assert_called_with('salt', recurse=False)
 
-            def __init__(self):
-                self.key = None
+            self.instance.tree.return_value = {}
+            self.assertEqual(etcd_mod.get_('salt', recurse=True), {})
+            self.instance.tree.assert_called_with('salt')
 
-            def get(self, key):
-                """
-                Mock of get method
-                """
-                self.key = key
-                if key == '':
-                    raise KeyError
-                elif key == 'err':
-                    raise
-                return MockEtcd
-
-        with patch.dict(etcd_mod.__utils__, {'etcd_util.get_conn':
-                        MagicMock(return_value=MockEtcd())}):
-            self.assertEqual(etcd_mod.get_('salt'), 'salt')
-
-            with patch.object(etcd_util, 'tree', MagicMock(return_value={})):
-                self.assertDictEqual(etcd_mod.get_('salt', recurse=True), {})
-
-            self.assertEqual(etcd_mod.get_(''), '')
-
+            self.instance.get.side_effect = Exception
             self.assertRaises(Exception, etcd_mod.get_, 'err')
 
     # 'set_' function tests: 1
 
     def test_set(self):
         '''
-        Test if it set a value in etcd, by direct path
+        Test if it set a key in etcd, by direct path
         '''
-        class MockEtcd(object):
-            """
-            Mock of etcd
-            """
-            value = 'salt'
+        with patch.dict(etcd_mod.__utils__, {'etcd_util.get_conn': self.EtcdClientMock}):
+            self.instance.set.return_value = 'stack'
+            self.assertEqual(etcd_mod.set_('salt', 'stack'), 'stack')
+            self.instance.set.assert_called_with('salt', 'stack', directory=False, ttl=None)
 
-            def __init__(self):
-                self.key = None
-                self.value = None
+            self.instance.set.return_value = True
+            self.assertEqual(etcd_mod.set_('salt', '', directory=True), True)
+            self.instance.set.assert_called_with('salt', '', directory=True, ttl=None)
 
-            def write(self, key, value):
-                """
-                Mock of write method
-                """
-                self.key = key
-                self.value = value
-                if key == '':
-                    raise KeyError
-                elif key == 'err':
-                    raise
-                return MockEtcd
+            self.assertEqual(etcd_mod.set_('salt', '', directory=True, ttl=5), True)
+            self.instance.set.assert_called_with('salt', '', directory=True, ttl=5)
 
-        with patch.dict(etcd_mod.__utils__, {'etcd_util.get_conn':
-                        MagicMock(return_value=MockEtcd())}):
-            self.assertEqual(etcd_mod.set_('salt', 'stack'), 'salt')
+            self.assertEqual(etcd_mod.set_('salt', '', None, 10, True), True)
+            self.instance.set.assert_called_with('salt', '', directory=True, ttl=10)
 
-            self.assertEqual(etcd_mod.set_('', 'stack'), '')
-
+            self.instance.set.side_effect = Exception
             self.assertRaises(Exception, etcd_mod.set_, 'err', 'stack')
 
     # 'ls_' function tests: 1
@@ -111,32 +91,16 @@ class EtcdModTestCase(TestCase):
         '''
         Test if it return all keys and dirs inside a specific path
         '''
-        class MockEtcd(object):
-            """
-            Mock of etcd
-            """
-            children = []
+        with patch.dict(etcd_mod.__utils__, {'etcd_util.get_conn': self.EtcdClientMock}):
+            self.instance.ls.return_value = {'/some-dir': {}}
+            self.assertDictEqual(etcd_mod.ls_('/some-dir'), {'/some-dir': {}})
+            self.instance.ls.assert_called_with('/some-dir')
 
-            def __init__(self):
-                self.path = None
-
-            def get(self, path):
-                """
-                Mock of get method
-                """
-                self.path = path
-                if path == '':
-                    raise KeyError
-                elif path == 'err':
-                    raise
-                return MockEtcd
-
-        with patch.dict(etcd_mod.__utils__, {'etcd_util.get_conn':
-                        MagicMock(return_value=MockEtcd())}):
+            self.instance.ls.return_value = {'/': {}}
             self.assertDictEqual(etcd_mod.ls_(), {'/': {}})
+            self.instance.ls.assert_called_with('/')
 
-            self.assertDictEqual(etcd_mod.ls_(''), {})
-
+            self.instance.ls.side_effect = Exception
             self.assertRaises(Exception, etcd_mod.ls_, 'err')
 
     # 'rm_' function tests: 1
@@ -145,66 +109,60 @@ class EtcdModTestCase(TestCase):
         '''
         Test if it delete a key from etcd
         '''
-        class MockEtcd(object):
-            """
-            Mock of etcd
-            """
-            children = []
+        with patch.dict(etcd_mod.__utils__, {'etcd_util.get_conn': self.EtcdClientMock}):
+            self.instance.rm.return_value = False
+            self.assertFalse(etcd_mod.rm_('dir'))
+            self.instance.rm.assert_called_with('dir', recurse=False)
 
-            def __init__(self):
-                self.key = None
-                self.recursive = None
+            self.instance.rm.return_value = True
+            self.assertTrue(etcd_mod.rm_('dir', recurse=True))
+            self.instance.rm.assert_called_with('dir', recurse=True)
 
-            def delete(self, key, recursive):
-                """
-                Mock of delete method
-                """
-                self.key = key
-                self.recursive = recursive
-                if key == '':
-                    raise KeyError
-                elif key == 'err':
-                    raise
-                if recursive:
-                    return True
-                else:
-                    return False
-                return MockEtcd
-
-        with patch.dict(etcd_mod.__utils__, {'etcd_util.get_conn':
-                        MagicMock(return_value=MockEtcd())}):
-            self.assertFalse(etcd_mod.rm_('salt'))
-
-            self.assertTrue(etcd_mod.rm_('salt', recurse=True))
-
-            self.assertFalse(etcd_mod.rm_(''))
-
+            self.instance.rm.side_effect = Exception
             self.assertRaises(Exception, etcd_mod.rm_, 'err')
 
     # 'tree' function tests: 1
 
     def test_tree(self):
         '''
-        Test if it recurse through etcd and return all values
+        Test if it recurses through etcd and return all values
         '''
-        class MockEtcd(object):
-            """
-            Mock of etcd
-            """
-            children = []
+        with patch.dict(etcd_mod.__utils__, {'etcd_util.get_conn': self.EtcdClientMock}):
+            self.instance.tree.return_value = {}
+            self.assertDictEqual(etcd_mod.tree('/some-dir'), {})
+            self.instance.tree.assert_called_with('/some-dir')
 
-        with patch.dict(etcd_mod.__utils__, {'etcd_util.get_conn':
-                        MagicMock(return_value=MockEtcd())}):
-            with patch.object(etcd_util, 'tree', MagicMock(return_value={})):
-                self.assertDictEqual(etcd_mod.tree(), {})
+            self.assertDictEqual(etcd_mod.tree(), {})
+            self.instance.tree.assert_called_with('/')
 
-            with patch.object(etcd_util, 'tree',
-                              MagicMock(side_effect=KeyError)):
-                self.assertDictEqual(etcd_mod.tree(), {})
+            self.instance.tree.side_effect = Exception
+            self.assertRaises(Exception, etcd_mod.tree, 'err')
 
-            with patch.object(etcd_util, 'tree',
-                              MagicMock(side_effect=Exception)):
-                self.assertRaises(Exception, etcd_mod.tree)
+    # 'watch' function tests: 1
+
+    def test_watch(self):
+        '''
+        Test if watch returns the right tuples
+        '''
+        with patch.dict(etcd_mod.__utils__, {'etcd_util.get_conn': self.EtcdClientMock}):
+            self.instance.watch.return_value = {
+                'value': 'stack',
+                'changed': True,
+                'dir': False,
+                'mIndex': 1,
+                'key': '/salt'
+            }
+            self.assertEqual(etcd_mod.watch('/salt'), self.instance.watch.return_value)
+            self.instance.watch.assert_called_with('/salt', recurse=False, timeout=0, index=None)
+
+            self.instance.watch.return_value['dir'] = True
+            self.assertEqual(etcd_mod.watch('/some-dir', recurse=True, timeout=5, index=10),
+                             self.instance.watch.return_value)
+            self.instance.watch.assert_called_with('/some-dir', recurse=True, timeout=5, index=10)
+
+            self.assertEqual(etcd_mod.watch('/some-dir', True, None, 5, 10),
+                             self.instance.watch.return_value)
+            self.instance.watch.assert_called_with('/some-dir', recurse=True, timeout=5, index=10)
 
 
 if __name__ == '__main__':

--- a/tests/unit/utils/etcd_util_test.py
+++ b/tests/unit/utils/etcd_util_test.py
@@ -1,0 +1,253 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Jayesh Kariya <jayeshk@saltstack.com>`
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+
+# Import Salt Testing Libs
+from salttesting import TestCase, skipIf
+from salttesting.mock import (
+    MagicMock,
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+# Import Salt Libs
+from salt.utils import etcd_util
+from urllib3.exceptions import ReadTimeoutError, MaxRetryError
+
+try:
+    import etcd
+    HAS_ETCD = True
+except ImportError:
+    HAS_ETCD = False
+
+
+@skipIf(HAS_ETCD is False, 'python-etcd module must be installed.')
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class EtcdUtilTestCase(TestCase):
+    '''
+    Test cases for salt.utils.etcd_util
+    '''
+    # 'get_' function tests: 1
+
+    @patch('etcd.Client', autospec=True)
+    def test_read(self, mock):
+        '''
+        Test to make sure we interact with etcd correctly
+        '''
+
+        etcd_client = mock.return_value
+        etcd_return = MagicMock(value='salt')
+        etcd_client.read.return_value = etcd_return
+        client = etcd_util.EtcdClient({})
+
+        self.assertEqual(client.read('/salt'), etcd_return)
+        etcd_client.read.assert_called_with('/salt', recursive=False, wait=False, timeout=None)
+
+        client.read('salt', True, True, 10, 5)
+        etcd_client.read.assert_called_with('salt', recursive=True, wait=True, timeout=10, waitIndex=5)
+
+        etcd_client.read.side_effect = etcd.EtcdKeyNotFound
+        self.assertRaises(etcd.EtcdKeyNotFound, client.read, 'salt')
+
+        etcd_client.read.side_effect = etcd.EtcdConnectionFailed
+        self.assertRaises(etcd.EtcdConnectionFailed, client.read, 'salt')
+
+        etcd_client.read.side_effect = etcd.EtcdValueError
+        self.assertRaises(etcd.EtcdValueError, client.read, 'salt')
+
+        etcd_client.read.side_effect = ValueError
+        self.assertRaises(ValueError, client.read, 'salt')
+
+        etcd_client.read.side_effect = ReadTimeoutError(None, None, None)
+        self.assertRaises(etcd.EtcdConnectionFailed, client.read, 'salt')
+
+        etcd_client.read.side_effect = MaxRetryError(None, None)
+        self.assertRaises(etcd.EtcdConnectionFailed, client.read, 'salt')
+
+    @patch('etcd.Client')
+    def test_get(self, mock):
+        '''
+        Test if it get a value from etcd, by direct path
+        '''
+        client = etcd_util.EtcdClient({})
+
+        with patch.object(client, 'read', autospec=True) as mock:
+            mock.return_value = MagicMock(value='stack')
+            self.assertEqual(client.get('salt'), 'stack')
+            mock.assert_called_with('salt', recursive=False)
+
+            self.assertEqual(client.get('salt', recurse=True), 'stack')
+            mock.assert_called_with('salt', recursive=True)
+
+            mock.side_effect = etcd.EtcdKeyNotFound()
+            self.assertEqual(client.get('not-found'), None)
+
+            mock.side_effect = etcd.EtcdConnectionFailed()
+            self.assertEqual(client.get('watching'), None)
+
+            # python 2.6 test
+            mock.side_effect = ValueError
+            self.assertEqual(client.get('not-found'), None)
+
+            mock.side_effect = Exception
+            self.assertRaises(Exception, client.get, 'some-error')
+
+    @patch('etcd.Client')
+    def test_tree(self, mock):
+        '''
+        Test recursive gets
+        '''
+        client = etcd_util.EtcdClient({})
+
+        with patch.object(client, 'read', autospec=True) as mock:
+
+            c1, c2 = MagicMock(), MagicMock()
+            c1.__iter__.return_value = [
+                MagicMock(key='/x/a', value='1'),
+                MagicMock(key='/x/b', value='2'),
+                MagicMock(key='/x/c', dir=True)]
+            c2.__iter__.return_value = [
+                MagicMock(key='/x/c/d', value='3')
+            ]
+            mock.side_effect = iter([
+                MagicMock(children=c1),
+                MagicMock(children=c2)
+            ])
+            self.assertDictEqual(client.tree('/x'), {'a': '1', 'b': '2', 'c': {'d': '3'}})
+            mock.assert_any_call('/x')
+            mock.assert_any_call('/x/c')
+
+            mock.side_effect = etcd.EtcdKeyNotFound()
+            self.assertEqual(client.tree('not-found'), None)
+
+            mock.side_effect = ValueError
+            self.assertEqual(client.tree('/x'), None)
+
+            mock.side_effect = Exception
+            self.assertRaises(Exception, client.tree, 'some-error')
+
+    @patch('etcd.Client')
+    def test_ls(self, mock):
+        client = etcd_util.EtcdClient({})
+
+        with patch.object(client, 'read', autospec=True) as mock:
+            c1 = MagicMock()
+            c1.__iter__.return_value = [
+                MagicMock(key='/x/a', value='1'),
+                MagicMock(key='/x/b', value='2'),
+                MagicMock(key='/x/c', dir=True)]
+            mock.return_value = MagicMock(children=c1)
+            self.assertEqual(client.ls('/x'), {'/x': {'/x/a': '1', '/x/b': '2', '/x/c/': {}}})
+            mock.assert_called_with('/x')
+
+            mock.side_effect = etcd.EtcdKeyNotFound()
+            self.assertEqual(client.ls('/not-found'), {})
+
+            mock.side_effect = Exception
+            self.assertRaises(Exception, client.tree, 'some-error')
+
+    @patch('etcd.Client', autospec=True)
+    def test_write(self, mock):
+        client = etcd_util.EtcdClient({})
+        etcd_client = mock.return_value
+
+        etcd_client.write.return_value = MagicMock(value='salt')
+        self.assertEqual(client.write('/some-key', 'salt'), 'salt')
+        etcd_client.write.assert_called_with('/some-key', 'salt', ttl=None, dir=False)
+
+        self.assertEqual(client.write('/some-key', 'salt', ttl=5), 'salt')
+        etcd_client.write.assert_called_with('/some-key', 'salt', ttl=5, dir=False)
+
+        etcd_client.write.return_value = MagicMock(dir=True)
+        self.assertEqual(client.write('/some-dir', 'salt', ttl=0, directory=True), True)
+        etcd_client.write.assert_called_with('/some-dir', None, ttl=0, dir=True)
+
+        etcd_client.write.side_effect = etcd.EtcdRootReadOnly()
+        self.assertEqual(client.write('/', 'some-val'), None)
+
+        etcd_client.write.side_effect = etcd.EtcdNotFile()
+        self.assertEqual(client.write('/some-key', 'some-val'), None)
+
+        etcd_client.write.side_effect = etcd.EtcdNotDir()
+        self.assertEqual(client.write('/some-dir', 'some-val'), None)
+
+        etcd_client.write.side_effect = MaxRetryError(None, None)
+        self.assertEqual(client.write('/some-key', 'some-val'), None)
+
+        etcd_client.write.side_effect = ValueError
+        self.assertEqual(client.write('/some-key', 'some-val'), None)
+
+        etcd_client.write.side_effect = Exception
+        self.assertRaises(Exception, client.set, 'some-key', 'some-val')
+
+    @patch('etcd.Client', autospec=True)
+    def test_rm(self, mock):
+        etcd_client = mock.return_value
+        client = etcd_util.EtcdClient({})
+
+        etcd_client.delete.return_value = True
+        self.assertEqual(client.rm('/some-key'), True)
+        etcd_client.delete.assert_called_with('/some-key', recursive=False)
+        self.assertEqual(client.rm('/some-dir', recurse=True), True)
+        etcd_client.delete.assert_called_with('/some-dir', recursive=True)
+
+        etcd_client.delete.side_effect = etcd.EtcdNotFile()
+        self.assertEqual(client.rm('/some-dir'), None)
+
+        etcd_client.delete.side_effect = etcd.EtcdDirNotEmpty()
+        self.assertEqual(client.rm('/some-key'), None)
+
+        etcd_client.delete.side_effect = etcd.EtcdRootReadOnly()
+        self.assertEqual(client.rm('/'), None)
+
+        etcd_client.delete.side_effect = ValueError
+        self.assertEqual(client.rm('/some-dir'), None)
+
+        etcd_client.delete.side_effect = Exception
+        self.assertRaises(Exception, client.rm, 'some-dir')
+
+    @patch('etcd.Client', autospec=True)
+    def test_watch(self, client_mock):
+        client = etcd_util.EtcdClient({})
+
+        with patch.object(client, 'read', autospec=True) as mock:
+            mock.return_value = MagicMock(value='stack', key='/some-key', modifiedIndex=1, dir=False)
+            self.assertDictEqual(client.watch('/some-key'),
+                                 {'value': 'stack', 'key': '/some-key', 'mIndex': 1, 'changed': True, 'dir': False})
+            mock.assert_called_with('/some-key', wait=True, recursive=False, timeout=0, waitIndex=None)
+
+            mock.side_effect = iter([etcd_util.EtcdUtilWatchTimeout, mock.return_value])
+            self.assertDictEqual(client.watch('/some-key'),
+                                 {'value': 'stack', 'changed': False, 'mIndex': 1, 'key': '/some-key', 'dir': False})
+
+            mock.side_effect = iter([etcd_util.EtcdUtilWatchTimeout, etcd.EtcdKeyNotFound])
+            self.assertEqual(client.watch('/some-key'),
+                             {'value': None, 'changed': False, 'mIndex': 0, 'key': '/some-key', 'dir': False})
+
+            mock.side_effect = None
+            mock.return_value = MagicMock(value='stack', key='/some-key', modifiedIndex=1, dir=True)
+            self.assertDictEqual(client.watch('/some-dir', recurse=True, timeout=5, index=10),
+                                 {'value': 'stack', 'key': '/some-key', 'mIndex': 1, 'changed': True, 'dir': True})
+            mock.assert_called_with('/some-dir', wait=True, recursive=True, timeout=5, waitIndex=10)
+
+            mock.side_effect = MaxRetryError(None, None)
+            self.assertEqual(client.watch('/some-key'), {})
+
+            mock.side_effect = etcd.EtcdConnectionFailed()
+            self.assertEqual(client.watch('/some-key'), {})
+
+            mock.return_value = None
+            self.assertEqual(client.watch('/some-key'), {})
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(EtcdUtilTestCase, needs_daemon=False)


### PR DESCRIPTION
The etcd modules were using bits and pieces of python-etcd directly and
were using outdated exceptions to catch errors.  These errors were
causing issues when trying to use etcd modules for logic.

A summary of changes
    - Most of the 'work' is now done in etcd_util
    - Removed import of python-etcd from states/etcd_mod and the
      returner
    - Added new tests for etcd_util
    - Put in proper exceptions and catches for python-etcd
    - Added support for ValueError catching.  python-etcd doesn't
      support python 2.6 and raises ValueError when trying to format
      exceptions
    - Added watch function to etcd execution module
    - Added autospec to unit tests so hopefully less brittle
    - Added TTL and directory features to the set function

_BACKWARDS INCOMPATIBLE CHANGES_

All interfaces are still backwards incompatible.  However, the returns
from several of the etcd util functions have been changed.  The old
returns presented issues with certain test cases.  For instance, a
failed 'get' returned '', but a key with no value will also return ''.

The same issues occured with the 'ls', 'tree' and 'set' functions.  Trying to
ls a blank directory returned the same result as a failed ls of a
non-existent key.
