### PR TITLE
Improvements on Debian-style apache utilities a2(en|dis)(mode|site|conf)

### DIFF
--- a/salt/modules/deb_apache.py
+++ b/salt/modules/deb_apache.py
@@ -215,3 +215,96 @@ def a2dismod(mod):
         ret['Status'] = status
 
     return ret
+
+
+def check_conf_enabled(conf):
+    '''
+    .. versionadded:: Boron
+
+    Checks to see if the specific conf symlink is in /etc/apache2/conf-enabled.
+
+    This will only be functional on Debian-based operating systems (Ubuntu,
+    Mint, etc).
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' apache.check_conf_enabled security.conf
+        salt '*' apache.check_conf_enabled status.load
+    '''
+    return os.path.islink('/etc/apache2/conf-enabled/{0}'.format(conf))
+
+
+@salt.utils.decorators.which('a2enconf')
+def a2enconf(conf):
+    '''
+    .. versionadded:: Boron
+
+    Runs a2enconf for the given conf.
+
+    This will only be functional on Debian-based operating systems (Ubuntu,
+    Mint, etc).
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' apache.a2enconf security
+    '''
+    ret = {}
+    command = ['a2enconf', conf]
+
+    try:
+        status = __salt__['cmd.retcode'](command, python_shell=False)
+    except Exception as e:
+        return e
+
+    ret['Name'] = 'Apache2 Enable Conf'
+    ret['Conf'] = conf
+
+    if status == 1:
+        ret['Status'] = 'Conf {0} Not found'.format(conf)
+    elif status == 0:
+        ret['Status'] = 'Conf {0} enabled'.format(conf)
+    else:
+        ret['Status'] = status
+
+    return ret
+
+
+@salt.utils.decorators.which('a2disconf')
+def a2disconf(conf):
+    '''
+    .. versionadded:: Boron
+
+    Runs a2disconf for the given conf.
+
+    This will only be functional on Debian-based operating systems (Ubuntu,
+    Mint, etc).
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' apache.a2disconf security
+    '''
+    ret = {}
+    command = ['a2disconf', conf]
+
+    try:
+        status = __salt__['cmd.retcode'](command, python_shell=False)
+    except Exception as e:
+        return e
+
+    ret['Name'] = 'Apache2 Disable Conf'
+    ret['Conf'] = conf
+
+    if status == 256:
+        ret['Status'] = 'Conf {0} Not found'.format(conf)
+    elif status == 0:
+        ret['Status'] = 'Conf {0} disabled'.format(conf)
+    else:
+        ret['Status'] = status
+
+    return ret

--- a/salt/modules/deb_apache.py
+++ b/salt/modules/deb_apache.py
@@ -146,12 +146,7 @@ def check_mod_enabled(mod):
         salt '*' apache.check_mod_enabled status.conf
         salt '*' apache.check_mod_enabled status.load
     '''
-    if os.path.islink('/etc/apache2/mods-enabled/{0}'.format(mod)):
-        return True
-    elif mod == 'default' and os.path.islink('/etc/apache2/mods-enabled/000-{0}'.format(mod)):
-        return True
-    else:
-        return False
+    return os.path.islink('/etc/apache2/mods-enabled/{0}'.format(mod))
 
 
 def a2enmod(mod):

--- a/salt/states/apache_conf.py
+++ b/salt/states/apache_conf.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+'''
+Manage Apache Confs
+
+.. versionadded:: Boron
+
+Enable and disable apache confs.
+
+.. code-block:: yaml
+
+    Enable security conf:
+        apache_conf.enable:
+            - name: security
+
+    Disable security conf:
+        apache_conf.disable:
+            - name: security
+'''
+from __future__ import absolute_import
+from salt.ext.six import string_types
+
+# Import salt libs
+import salt.utils
+
+
+def __virtual__():
+    '''
+    Only load if a2enconf is available.
+    '''
+    return 'apache_conf' if 'apache.a2enconf' in __salt__ and salt.utils.which('a2enconf') else False
+
+
+def enable(name):
+    '''
+    Ensure an Apache conf is enabled.
+
+    name
+        Name of the Apache conf
+    '''
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
+
+    is_enabled = __salt__['apache.check_conf_enabled']('{0}.load'.format(name))
+    if not is_enabled:
+        if __opts__['test']:
+            msg = 'Apache conf {0} is set to be enabled.'.format(name)
+            ret['comment'] = msg
+            ret['changes']['old'] = None
+            ret['changes']['new'] = name
+            ret['result'] = None
+            return ret
+        status = __salt__['apache.a2enconf'](name)['Status']
+        if isinstance(status, string_types) and 'enabled' in status:
+            ret['result'] = True
+            ret['changes']['old'] = None
+            ret['changes']['new'] = name
+        else:
+            ret['result'] = False
+            ret['comment'] = 'Failed to enable {0} Apache conf'.format(name)
+            if isinstance(status, string_types):
+                ret['comment'] = ret['comment'] + ' ({0})'.format(status)
+            return ret
+    else:
+        ret['comment'] = '{0} already enabled.'.format(name)
+    return ret
+
+
+def disable(name):
+    '''
+    Ensure an Apache conf is disabled.
+
+    name
+        Name of the Apache conf
+    '''
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
+
+    is_enabled = __salt__['apache.check_conf_enabled']('{0}.load'.format(name))
+    if is_enabled:
+        if __opts__['test']:
+            msg = 'Apache conf {0} is set to be disabled.'.format(name)
+            ret['comment'] = msg
+            ret['changes']['old'] = name
+            ret['changes']['new'] = None
+            ret['result'] = None
+            return ret
+        status = __salt__['apache.a2disconf'](name)['Status']
+        if isinstance(status, string_types) and 'disabled' in status:
+            ret['result'] = True
+            ret['changes']['old'] = name
+            ret['changes']['new'] = None
+        else:
+            ret['result'] = False
+            ret['comment'] = 'Failed to disable {0} Apache conf'.format(name)
+            if isinstance(status, string_types):
+                ret['comment'] = ret['comment'] + ' ({0})'.format(status)
+            return ret
+    else:
+        ret['comment'] = '{0} already disabled.'.format(name)
+    return ret

--- a/salt/states/apache_site.py
+++ b/salt/states/apache_site.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+'''
+Manage Apache Sites
+
+.. versionadded:: Boron
+
+Enable and disable apache sites.
+
+.. code-block:: yaml
+
+    Enable default site:
+        apache_site.enable:
+            - name: default
+
+    Disable default site:
+        apache_site.disable:
+            - name: default
+'''
+from __future__ import absolute_import
+from salt.ext.six import string_types
+
+
+def __virtual__():
+    '''
+    Only load if a2ensite is available.
+    '''
+    return 'apache_site' if 'apache.a2ensite' in __salt__ else False
+
+
+def enable(name):
+    '''
+    Ensure an Apache site is enabled.
+
+    name
+        Name of the Apache site
+    '''
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
+
+    is_enabled = __salt__['apache.check_site_enabled']('{0}.load'.format(name))
+    if not is_enabled:
+        if __opts__['test']:
+            msg = 'Apache site {0} is set to be enabled.'.format(name)
+            ret['comment'] = msg
+            ret['changes']['old'] = None
+            ret['changes']['new'] = name
+            ret['result'] = None
+            return ret
+        status = __salt__['apache.a2ensite'](name)['Status']
+        if isinstance(status, string_types) and 'enabled' in status:
+            ret['result'] = True
+            ret['changes']['old'] = None
+            ret['changes']['new'] = name
+        else:
+            ret['result'] = False
+            ret['comment'] = 'Failed to enable {0} Apache site'.format(name)
+            if isinstance(status, string_types):
+                ret['comment'] = ret['comment'] + ' ({0})'.format(status)
+            return ret
+    else:
+        ret['comment'] = '{0} already enabled.'.format(name)
+    return ret
+
+
+def disable(name):
+    '''
+    Ensure an Apache site is disabled.
+
+    name
+        Name of the Apache site
+    '''
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
+
+    is_enabled = __salt__['apache.check_site_enabled']('{0}.load'.format(name))
+    if is_enabled:
+        if __opts__['test']:
+            msg = 'Apache site {0} is set to be disabled.'.format(name)
+            ret['comment'] = msg
+            ret['changes']['old'] = name
+            ret['changes']['new'] = None
+            ret['result'] = None
+            return ret
+        status = __salt__['apache.a2dissite'](name)['Status']
+        if isinstance(status, string_types) and 'disabled' in status:
+            ret['result'] = True
+            ret['changes']['old'] = name
+            ret['changes']['new'] = None
+        else:
+            ret['result'] = False
+            ret['comment'] = 'Failed to disable {0} Apache site'.format(name)
+            if isinstance(status, string_types):
+                ret['comment'] = ret['comment'] + ' ({0})'.format(status)
+            return ret
+    else:
+        ret['comment'] = '{0} already disabled.'.format(name)
+    return ret

--- a/tests/unit/modules/deb_apache_test.py
+++ b/tests/unit/modules/deb_apache_test.py
@@ -139,7 +139,7 @@ class DebApacheTestCase(TestCase):
             self.assertEqual(str(deb_apache.a2dissite('saltstack.com')),
                              'error')
 
-    # 'check_mod_enabled' function tests: 3
+    # 'check_mod_enabled' function tests: 2
 
     @patch('os.path.islink', MagicMock(return_value=True))
     def test_check_mod_enabled(self):
@@ -147,13 +147,6 @@ class DebApacheTestCase(TestCase):
         Test if the specific mod symlink is enabled.
         '''
         self.assertTrue(deb_apache.check_mod_enabled('status.conf'))
-
-    @patch('os.path.islink', MagicMock(side_effect=[False, True]))
-    def test_check_mod_enabled_default(self):
-        '''
-        Test if the specific mod symlink is enabled.
-        '''
-        self.assertTrue(deb_apache.check_mod_enabled('default'))
 
     @patch('os.path.islink', MagicMock(return_value=False))
     def test_check_mod_enabled_false(self):
@@ -166,7 +159,7 @@ class DebApacheTestCase(TestCase):
 
     def test_a2enmod_notfound(self):
         '''
-        Test if it runs a2enmod for the given site.
+        Test if it runs a2enmod for the given module.
         '''
         mock = MagicMock(return_value=1)
         with patch.dict(deb_apache.__salt__, {'cmd.retcode': mock}):
@@ -177,7 +170,7 @@ class DebApacheTestCase(TestCase):
 
     def test_a2enmod_enabled(self):
         '''
-        Test if it runs a2enmod for the given site.
+        Test if it runs a2enmod for the given module.
         '''
         mock = MagicMock(return_value=0)
         with patch.dict(deb_apache.__salt__, {'cmd.retcode': mock}):
@@ -188,7 +181,7 @@ class DebApacheTestCase(TestCase):
 
     def test_a2enmod(self):
         '''
-        Test if it runs a2enmod for the given site.
+        Test if it runs a2enmod for the given module.
         '''
         mock = MagicMock(return_value=2)
         with patch.dict(deb_apache.__salt__, {'cmd.retcode': mock}):
@@ -199,7 +192,7 @@ class DebApacheTestCase(TestCase):
 
     def test_a2enmod_exception(self):
         '''
-        Test if it runs a2enmod for the given site.
+        Test if it runs a2enmod for the given module.
         '''
         mock = MagicMock(side_effect=Exception('error'))
         with patch.dict(deb_apache.__salt__, {'cmd.retcode': mock}):
@@ -210,7 +203,7 @@ class DebApacheTestCase(TestCase):
 
     def test_a2dismod_notfound(self):
         '''
-        Test if it runs a2dismod for the given site.
+        Test if it runs a2dismod for the given module.
         '''
         mock = MagicMock(return_value=256)
         with patch.dict(deb_apache.__salt__, {'cmd.retcode': mock}):
@@ -221,7 +214,7 @@ class DebApacheTestCase(TestCase):
 
     def test_a2dismod_disabled(self):
         '''
-        Test if it runs a2dismod for the given site.
+        Test if it runs a2dismod for the given module.
         '''
         mock = MagicMock(return_value=0)
         with patch.dict(deb_apache.__salt__, {'cmd.retcode': mock}):
@@ -232,7 +225,7 @@ class DebApacheTestCase(TestCase):
 
     def test_a2dismod(self):
         '''
-        Test if it runs a2dismod for the given site.
+        Test if it runs a2dismod for the given module.
         '''
         mock = MagicMock(return_value=2)
         with patch.dict(deb_apache.__salt__, {'cmd.retcode': mock}):
@@ -243,7 +236,7 @@ class DebApacheTestCase(TestCase):
 
     def test_a2dismod_exception(self):
         '''
-        Test if it runs a2dismod for the given site.
+        Test if it runs a2dismod for the given module.
         '''
         mock = MagicMock(side_effect=Exception('error'))
         with patch.dict(deb_apache.__salt__, {'cmd.retcode': mock}):

--- a/tests/unit/modules/deb_apache_test.py
+++ b/tests/unit/modules/deb_apache_test.py
@@ -243,6 +243,117 @@ class DebApacheTestCase(TestCase):
             self.assertEqual(str(deb_apache.a2dismod('vhost_alias')),
                              'error')
 
+    # 'check_conf_enabled' function tests: 2
+
+    @patch('os.path.islink', MagicMock(return_value=True))
+    def test_check_conf_enabled(self):
+        '''
+        Test if the specific conf symlink is enabled.
+        '''
+        self.assertTrue(deb_apache.check_conf_enabled('security.conf'))
+
+    @patch('os.path.islink', MagicMock(return_value=False))
+    def test_check_conf_enabled_false(self):
+        '''
+        Test if the specific conf symlink is enabled.
+        '''
+        self.assertFalse(deb_apache.check_conf_enabled('security.conf'))
+
+    # 'a2enconf' function tests: 4
+
+    @patch('salt.utils.which', MagicMock(return_value='a2enconf'))
+    def test_a2enconf_notfound(self):
+        '''
+        Test if it runs a2enconf for the given conf.
+        '''
+        mock = MagicMock(return_value=1)
+        with patch.dict(deb_apache.__salt__, {'cmd.retcode': mock}):
+            self.assertEqual(deb_apache.a2enconf('security'),
+                {'Name': 'Apache2 Enable Conf',
+                'Conf': 'security',
+                'Status': 'Conf security Not found'})
+
+    @patch('salt.utils.which', MagicMock(return_value='a2enconf'))
+    def test_a2enconf_enabled(self):
+        '''
+        Test if it runs a2enconf for the given conf.
+        '''
+        mock = MagicMock(return_value=0)
+        with patch.dict(deb_apache.__salt__, {'cmd.retcode': mock}):
+            self.assertEqual(deb_apache.a2enconf('security'),
+                {'Name': 'Apache2 Enable Conf',
+                'Conf': 'security',
+                'Status': 'Conf security enabled'})
+
+    @patch('salt.utils.which', MagicMock(return_value='a2enconf'))
+    def test_a2enconf(self):
+        '''
+        Test if it runs a2enconf for the given conf.
+        '''
+        mock = MagicMock(return_value=2)
+        with patch.dict(deb_apache.__salt__, {'cmd.retcode': mock}):
+            self.assertEqual(deb_apache.a2enconf('security'),
+                {'Name': 'Apache2 Enable Conf',
+                'Conf': 'security',
+                'Status': 2})
+
+    @patch('salt.utils.which', MagicMock(return_value='a2enconf'))
+    def test_a2enconf_exception(self):
+        '''
+        Test if it runs a2enconf for the given conf.
+        '''
+        mock = MagicMock(side_effect=Exception('error'))
+        with patch.dict(deb_apache.__salt__, {'cmd.retcode': mock}):
+            self.assertEqual(str(deb_apache.a2enconf('security')),
+                'error')
+
+    # 'a2disconf' function tests: 4
+
+    @patch('salt.utils.which', MagicMock(return_value='a2disconf'))
+    def test_a2disconf_notfound(self):
+        '''
+        Test if it runs a2disconf for the given conf.
+        '''
+        mock = MagicMock(return_value=256)
+        with patch.dict(deb_apache.__salt__, {'cmd.retcode': mock}):
+            self.assertEqual(deb_apache.a2disconf('security'),
+                {'Name': 'Apache2 Disable Conf',
+                'Conf': 'security',
+                'Status': 'Conf security Not found'})
+
+    @patch('salt.utils.which', MagicMock(return_value='a2disconf'))
+    def test_a2disconf_disabled(self):
+        '''
+        Test if it runs a2disconf for the given conf.
+        '''
+        mock = MagicMock(return_value=0)
+        with patch.dict(deb_apache.__salt__, {'cmd.retcode': mock}):
+            self.assertEqual(deb_apache.a2disconf('security'),
+                {'Name': 'Apache2 Disable Conf',
+                'Conf': 'security',
+                'Status': 'Conf security disabled'})
+
+    @patch('salt.utils.which', MagicMock(return_value='a2disconf'))
+    def test_a2disconf(self):
+        '''
+        Test if it runs a2disconf for the given conf.
+        '''
+        mock = MagicMock(return_value=2)
+        with patch.dict(deb_apache.__salt__, {'cmd.retcode': mock}):
+            self.assertEqual(deb_apache.a2disconf('security'),
+                {'Name': 'Apache2 Disable Conf',
+                'Conf': 'security',
+                'Status': 2})
+
+    @patch('salt.utils.which', MagicMock(return_value='a2disconf'))
+    def test_a2disconf_exception(self):
+        '''
+        Test if it runs a2disconf for the given conf.
+        '''
+        mock = MagicMock(side_effect=Exception('error'))
+        with patch.dict(deb_apache.__salt__, {'cmd.retcode': mock}):
+            self.assertEqual(str(deb_apache.a2disconf('security')),
+                'error')
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/unit/states/apache_conf_test.py
+++ b/tests/unit/states/apache_conf_test.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+# Import Python libs
+from __future__ import absolute_import
+
+# Import Salt Testing Libs
+from salttesting import skipIf, TestCase
+from salttesting.mock import (
+    NO_MOCK,
+    NO_MOCK_REASON,
+    MagicMock,
+    patch
+)
+
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+# Import Salt Libs
+from salt.states import apache_conf
+
+apache_conf.__opts__ = {}
+apache_conf.__salt__ = {}
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class ApacheConfTestCase(TestCase):
+    '''
+    Test cases for salt.states.apache_conf
+    '''
+    # 'enable' function tests: 1
+
+    def test_enable(self):
+        '''
+        Test to ensure an Apache conf is enabled.
+        '''
+        name = 'saltstack.com'
+
+        ret = {'name': name,
+               'result': True,
+               'changes': {},
+               'comment': ''}
+
+        mock = MagicMock(side_effect=[True, False, False])
+        mock_str = MagicMock(return_value={'Status': ['enabled']})
+        with patch.dict(apache_conf.__salt__,
+                        {'apache.check_conf_enabled': mock,
+                         'apache.a2enconf': mock_str}):
+            comt = ('{0} already enabled.'.format(name))
+            ret.update({'comment': comt})
+            self.assertDictEqual(apache_conf.enable(name), ret)
+
+            comt = ('Apache conf {0} is set to be enabled.'.format(name))
+            ret.update({'comment': comt, 'result': None,
+                        'changes': {'new': name, 'old': None}})
+            with patch.dict(apache_conf.__opts__, {'test': True}):
+                self.assertDictEqual(apache_conf.enable(name), ret)
+
+            comt = ('Failed to enable {0} Apache conf'.format(name))
+            ret.update({'comment': comt, 'result': False, 'changes': {}})
+            with patch.dict(apache_conf.__opts__, {'test': False}):
+                self.assertDictEqual(apache_conf.enable(name), ret)
+
+    # 'disable' function tests: 1
+
+    def test_disable(self):
+        '''
+        Test to ensure an Apache conf is disabled.
+        '''
+        name = 'saltstack.com'
+
+        ret = {'name': name,
+               'result': None,
+               'changes': {},
+               'comment': ''}
+
+        mock = MagicMock(side_effect=[True, True, False])
+        mock_str = MagicMock(return_value={'Status': ['disabled']})
+        with patch.dict(apache_conf.__salt__,
+                        {'apache.check_conf_enabled': mock,
+                         'apache.a2disconf': mock_str}):
+            comt = ('Apache conf {0} is set to be disabled.'.format(name))
+            ret.update({'comment': comt, 'changes': {'new': None, 'old': name}})
+            with patch.dict(apache_conf.__opts__, {'test': True}):
+                self.assertDictEqual(apache_conf.disable(name), ret)
+
+            comt = ('Failed to disable {0} Apache conf'.format(name))
+            ret.update({'comment': comt, 'result': False,
+                        'changes': {}})
+            with patch.dict(apache_conf.__opts__, {'test': False}):
+                self.assertDictEqual(apache_conf.disable(name), ret)
+
+            comt = ('{0} already disabled.'.format(name))
+            ret.update({'comment': comt, 'result': True})
+            self.assertDictEqual(apache_conf.disable(name), ret)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(ApacheConfTestCase, needs_daemon=False)

--- a/tests/unit/states/apache_site_test.py
+++ b/tests/unit/states/apache_site_test.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+# Import Python libs
+from __future__ import absolute_import
+
+# Import Salt Testing Libs
+from salttesting import skipIf, TestCase
+from salttesting.mock import (
+    NO_MOCK,
+    NO_MOCK_REASON,
+    MagicMock,
+    patch
+)
+
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+# Import Salt Libs
+from salt.states import apache_site
+
+apache_site.__opts__ = {}
+apache_site.__salt__ = {}
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class ApacheSiteTestCase(TestCase):
+    '''
+    Test cases for salt.states.apache_site
+    '''
+    # 'enable' function tests: 1
+
+    def test_enable(self):
+        '''
+        Test to ensure an Apache site is enabled.
+        '''
+        name = 'saltstack.com'
+
+        ret = {'name': name,
+               'result': True,
+               'changes': {},
+               'comment': ''}
+
+        mock = MagicMock(side_effect=[True, False, False])
+        mock_str = MagicMock(return_value={'Status': ['enabled']})
+        with patch.dict(apache_site.__salt__,
+                        {'apache.check_site_enabled': mock,
+                         'apache.a2ensite': mock_str}):
+            comt = ('{0} already enabled.'.format(name))
+            ret.update({'comment': comt})
+            self.assertDictEqual(apache_site.enable(name), ret)
+
+            comt = ('Apache site {0} is set to be enabled.'.format(name))
+            ret.update({'comment': comt, 'result': None,
+                        'changes': {'new': name, 'old': None}})
+            with patch.dict(apache_site.__opts__, {'test': True}):
+                self.assertDictEqual(apache_site.enable(name), ret)
+
+            comt = ('Failed to enable {0} Apache site'.format(name))
+            ret.update({'comment': comt, 'result': False, 'changes': {}})
+            with patch.dict(apache_site.__opts__, {'test': False}):
+                self.assertDictEqual(apache_site.enable(name), ret)
+
+    # 'disable' function tests: 1
+
+    def test_disable(self):
+        '''
+        Test to ensure an Apache site is disabled.
+        '''
+        name = 'saltstack.com'
+
+        ret = {'name': name,
+               'result': None,
+               'changes': {},
+               'comment': ''}
+
+        mock = MagicMock(side_effect=[True, True, False])
+        mock_str = MagicMock(return_value={'Status': ['disabled']})
+        with patch.dict(apache_site.__salt__,
+                        {'apache.check_site_enabled': mock,
+                         'apache.a2dissite': mock_str}):
+            comt = ('Apache site {0} is set to be disabled.'.format(name))
+            ret.update({'comment': comt, 'changes': {'new': None, 'old': name}})
+            with patch.dict(apache_site.__opts__, {'test': True}):
+                self.assertDictEqual(apache_site.disable(name), ret)
+
+            comt = ('Failed to disable {0} Apache site'.format(name))
+            ret.update({'comment': comt, 'result': False,
+                        'changes': {}})
+            with patch.dict(apache_site.__opts__, {'test': False}):
+                self.assertDictEqual(apache_site.disable(name), ret)
+
+            comt = ('{0} already disabled.'.format(name))
+            ret.update({'comment': comt, 'result': True})
+            self.assertDictEqual(apache_site.disable(name), ret)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(ApacheSiteTestCase, needs_daemon=False)


### PR DESCRIPTION
- Some fix on apache modules handling
- Add state for `a2xxsite` + tests
- Add module functions and state for `a2xxconf` + tests

:warning: `versionadded::` are left blank for setting the right version when merging this PR.
