### PR TITLE
cleanup smartos_imgadm and more cleanup of smartos_vmadm

### DIFF
--- a/salt/modules/smartos_imgadm.py
+++ b/salt/modules/smartos_imgadm.py
@@ -97,7 +97,7 @@ def update_installed(uuid=''):
     Gather info on unknown image(s) (locally installed)
 
     uuid : string
-        Specifies uuid of image
+        optional uuid of image
 
     CLI Example:
 
@@ -117,9 +117,9 @@ def avail(search=None, verbose=False):
     Return a list of available images
 
     search : string
-        Specifies search keyword
+        search keyword
     verbose : boolean (False)
-        Specifies verbose output
+        toggle verbose output
 
     CLI Example:
 
@@ -154,7 +154,7 @@ def list_installed(verbose=False):
     Return a list of installed images
 
     verbose : boolean (False)
-        Specifies verbose output
+        toggle verbose output
 
     CLI Example:
 
@@ -182,6 +182,9 @@ def show(uuid):
     '''
     Show manifest of a given image
 
+    uuid : string
+        uuid of image
+
     CLI Example:
 
     .. code-block:: bash
@@ -203,6 +206,9 @@ def show(uuid):
 def get(uuid):
     '''
     Return info on an installed image
+
+    uuid : string
+        uuid of image
 
     CLI Example:
 
@@ -227,9 +233,9 @@ def import_image(uuid, verbose=False):
     Import an image from the repository
 
     uuid : string
-        Specifies uuid to import
+        uuid to import
     verbose : boolean (False)
-        Specifies verbose output
+        toggle verbose output
 
     CLI Example:
 
@@ -284,7 +290,7 @@ def vacuum(verbose=False):
     Remove unused images
 
     verbose : boolean (False)
-        Specifies verbose output
+        toggle verbose output
 
     CLI Example:
 

--- a/salt/modules/smartos_imgadm.py
+++ b/salt/modules/smartos_imgadm.py
@@ -178,7 +178,7 @@ def list_installed(verbose=False):
     return result
 
 
-def show(uuid=None):
+def show(uuid):
     '''
     Show manifest of a given image
 
@@ -189,9 +189,6 @@ def show(uuid=None):
         salt '*' imgadm.show e42f8c84-bbea-11e2-b920-078fab2aab1f
     '''
     ret = {}
-    if not uuid:
-        ret['Error'] = 'UUID parameter is mandatory'
-        return ret
     imgadm = _check_imgadm()
     cmd = '{0} show {1}'.format(imgadm, uuid)
     res = __salt__['cmd.run_all'](cmd, python_shell=False)
@@ -203,7 +200,7 @@ def show(uuid=None):
     return ret
 
 
-def get(uuid=None):
+def get(uuid):
     '''
     Return info on an installed image
 
@@ -214,9 +211,6 @@ def get(uuid=None):
         salt '*' imgadm.get e42f8c84-bbea-11e2-b920-078fab2aab1f
     '''
     ret = {}
-    if not uuid:
-        ret['Error'] = 'UUID parameter is mandatory'
-        return ret
     imgadm = _check_imgadm()
     cmd = '{0} get {1}'.format(imgadm, uuid)
     res = __salt__['cmd.run_all'](cmd, python_shell=False)
@@ -228,7 +222,7 @@ def get(uuid=None):
     return ret
 
 
-def import_image(uuid=None, verbose=False):
+def import_image(uuid, verbose=False):
     '''
     Import an image from the repository
 
@@ -244,9 +238,6 @@ def import_image(uuid=None, verbose=False):
         salt '*' imgadm.import e42f8c84-bbea-11e2-b920-078fab2aab1f [verbose=True]
     '''
     ret = {}
-    if not uuid:
-        ret['Error'] = 'UUID parameter is mandatory'
-        return ret
     imgadm = _check_imgadm()
     cmd = '{0} import {1}'.format(imgadm, uuid)
     res = __salt__['cmd.run_all'](cmd, python_shell=False)
@@ -258,7 +249,7 @@ def import_image(uuid=None, verbose=False):
     return {uuid: _parse_image_meta(get(uuid), verbose)}
 
 
-def delete(uuid=None):
+def delete(uuid):
     '''
     Remove an installed image
 
@@ -272,9 +263,6 @@ def delete(uuid=None):
         salt '*' imgadm.delete e42f8c84-bbea-11e2-b920-078fab2aab1f
     '''
     ret = {}
-    if not uuid:
-        ret['Error'] = 'UUID parameter is mandatory'
-        return ret
     imgadm = _check_imgadm()
     cmd = '{0} delete {1}'.format(imgadm, uuid)
     res = __salt__['cmd.run_all'](cmd, python_shell=False)

--- a/salt/modules/smartos_vmadm.py
+++ b/salt/modules/smartos_vmadm.py
@@ -403,8 +403,8 @@ def sysrq(vm=None, action='nmi', key='uuid'):
 
     vm : string
         vm to be targetted
-    action : string
-        nmi or screenshot
+    action : string 
+        nmi or screenshot -- Default: nmi
     key : string [uuid|alias|hostname]
         value type of 'vm' parameter
 

--- a/salt/modules/smartos_vmadm.py
+++ b/salt/modules/smartos_vmadm.py
@@ -158,7 +158,7 @@ def _create_update_from_cfg(mode='create', uuid=None, vmcfg=None):
     return True
 
 
-def start(vm=None, options=None, key='uuid'):
+def start(vm, options=None, key='uuid'):
     '''
     Start a vm
 
@@ -180,9 +180,6 @@ def start(vm=None, options=None, key='uuid'):
     '''
     ret = {}
     vmadm = _check_vmadm()
-    if vm is None:
-        ret['Error'] = 'uuid, alias or hostname must be provided'
-        return ret
     if key not in ['uuid', 'alias', 'hostname']:
         ret['Error'] = 'Key must be either uuid, alias or hostname'
         return ret
@@ -203,7 +200,7 @@ def start(vm=None, options=None, key='uuid'):
     return True
 
 
-def stop(vm=None, force=False, key='uuid'):
+def stop(vm, force=False, key='uuid'):
     '''
     Stop a vm
 
@@ -225,9 +222,6 @@ def stop(vm=None, force=False, key='uuid'):
     '''
     ret = {}
     vmadm = _check_vmadm()
-    if vm is None:
-        ret['Error'] = 'uuid, alias or hostname must be provided'
-        return ret
     if key not in ['uuid', 'alias', 'hostname']:
         ret['Error'] = 'Key must be either uuid, alias or hostname'
         return ret
@@ -248,7 +242,7 @@ def stop(vm=None, force=False, key='uuid'):
     return True
 
 
-def reboot(vm=None, force=False, key='uuid'):
+def reboot(vm, force=False, key='uuid'):
     '''
     Reboot a vm
 
@@ -270,9 +264,6 @@ def reboot(vm=None, force=False, key='uuid'):
     '''
     ret = {}
     vmadm = _check_vmadm()
-    if vm is None:
-        ret['Error'] = 'uuid, alias or hostname must be provided'
-        return ret
     if key not in ['uuid', 'alias', 'hostname']:
         ret['Error'] = 'Key must be either uuid, alias or hostname'
         return ret
@@ -397,13 +388,13 @@ def lookup(search=None, order=None, one=False):
     return result
 
 
-def sysrq(vm=None, action='nmi', key='uuid'):
+def sysrq(vm, action='nmi', key='uuid'):
     '''
     Send non-maskable interupt to vm or capture a screenshot
 
     vm : string
         vm to be targetted
-    action : string 
+    action : string
         nmi or screenshot -- Default: nmi
     key : string [uuid|alias|hostname]
         value type of 'vm' parameter
@@ -418,9 +409,6 @@ def sysrq(vm=None, action='nmi', key='uuid'):
     '''
     ret = {}
     vmadm = _check_vmadm()
-    if vm is None:
-        ret['Error'] = 'uuid, alias or hostname must be provided'
-        return ret
     if key not in ['uuid', 'alias', 'hostname']:
         ret['Error'] = 'Key must be either uuid, alias or hostname'
         return ret
@@ -444,7 +432,7 @@ def sysrq(vm=None, action='nmi', key='uuid'):
     return True
 
 
-def delete(vm=None, key='uuid'):
+def delete(vm, key='uuid'):
     '''
     Delete a vm
 
@@ -462,9 +450,6 @@ def delete(vm=None, key='uuid'):
     '''
     ret = {}
     vmadm = _check_vmadm()
-    if vm is None:
-        ret['Error'] = 'uuid, alias or hostname must be provided'
-        return ret
     if key not in ['uuid', 'alias', 'hostname']:
         ret['Error'] = 'Key must be either uuid, alias or hostname'
         return ret
@@ -484,7 +469,7 @@ def delete(vm=None, key='uuid'):
     return True
 
 
-def get(vm=None, key='uuid'):
+def get(vm, key='uuid'):
     '''
     Output the JSON object describing a VM
 
@@ -502,9 +487,6 @@ def get(vm=None, key='uuid'):
     '''
     ret = {}
     vmadm = _check_vmadm()
-    if vm is None:
-        ret['Error'] = 'uuid, alias or hostname must be provided'
-        return ret
     if key not in ['uuid', 'alias', 'hostname']:
         ret['Error'] = 'Key must be either uuid, alias or hostname'
         return ret
@@ -524,7 +506,7 @@ def get(vm=None, key='uuid'):
     return json.loads(res['stdout'])
 
 
-def info(vm=None, info_type='all', key='uuid'):
+def info(vm, info_type='all', key='uuid'):
     '''
     Lookup info on running kvm
 
@@ -546,9 +528,6 @@ def info(vm=None, info_type='all', key='uuid'):
     '''
     ret = {}
     vmadm = _check_vmadm()
-    if vm is None:
-        ret['Error'] = 'uuid, alias or hostname must be provided'
-        return ret
     if info_type not in ['all', 'block', 'blockstats', 'chardev', 'cpus', 'kvm', 'pci', 'spice', 'version', 'vnc']:
         ret['Error'] = 'Requested info_type is not available'
         return ret
@@ -572,7 +551,7 @@ def info(vm=None, info_type='all', key='uuid'):
     return json.loads(res['stdout'])
 
 
-def create_snapshot(vm=None, name=None, key='uuid'):
+def create_snapshot(vm, name, key='uuid'):
     '''
     Create snapshot of a vm
 
@@ -595,12 +574,6 @@ def create_snapshot(vm=None, name=None, key='uuid'):
     '''
     ret = {}
     vmadm = _check_vmadm()
-    if vm is None:
-        ret['Error'] = 'uuid, alias or hostname must be provided'
-        return ret
-    if name is None:
-        ret['Error'] = 'Snapshot name most be specified'
-        return ret
     if key not in ['uuid', 'alias', 'hostname']:
         ret['Error'] = 'Key must be either uuid, alias or hostname'
         return ret
@@ -631,7 +604,7 @@ def create_snapshot(vm=None, name=None, key='uuid'):
     return True
 
 
-def delete_snapshot(vm=None, name=None, key='uuid'):
+def delete_snapshot(vm, name, key='uuid'):
     '''
     Delete snapshot of a vm
 
@@ -654,12 +627,6 @@ def delete_snapshot(vm=None, name=None, key='uuid'):
     '''
     ret = {}
     vmadm = _check_vmadm()
-    if vm is None:
-        ret['Error'] = 'uuid, alias or hostname must be provided'
-        return ret
-    if name is None:
-        ret['Error'] = 'Snapshot name most be specified'
-        return ret
     if key not in ['uuid', 'alias', 'hostname']:
         ret['Error'] = 'Key must be either uuid, alias or hostname'
         return ret
@@ -687,7 +654,7 @@ def delete_snapshot(vm=None, name=None, key='uuid'):
     return True
 
 
-def rollback_snapshot(vm=None, name=None, key='uuid'):
+def rollback_snapshot(vm, name, key='uuid'):
     '''
     Rollback snapshot of a vm
 
@@ -710,12 +677,6 @@ def rollback_snapshot(vm=None, name=None, key='uuid'):
     '''
     ret = {}
     vmadm = _check_vmadm()
-    if vm is None:
-        ret['Error'] = 'uuid, alias or hostname must be provided'
-        return ret
-    if name is None:
-        ret['Error'] = 'Snapshot name most be specified'
-        return ret
     if key not in ['uuid', 'alias', 'hostname']:
         ret['Error'] = 'Key must be either uuid, alias or hostname'
         return ret
@@ -743,7 +704,7 @@ def rollback_snapshot(vm=None, name=None, key='uuid'):
     return True
 
 
-def reprovision(vm=None, image=None, key='uuid'):
+def reprovision(vm, image, key='uuid'):
     '''
     Reprovision a vm
 
@@ -763,12 +724,6 @@ def reprovision(vm=None, image=None, key='uuid'):
     '''
     ret = {}
     vmadm = _check_vmadm()
-    if vm is None:
-        ret['Error'] = 'uuid, alias or hostname must be provided'
-        return ret
-    if image is None:
-        ret['Error'] = 'Image uuid must be specified'
-        return ret
     if key not in ['uuid', 'alias', 'hostname']:
         ret['Error'] = 'Key must be either uuid, alias or hostname'
         return ret
@@ -874,7 +829,7 @@ def update(**kwargs):
         return _create_update_from_cfg('update', uuid, vmcfg=vmcfg)
 
 
-def send(vm=None, target=None, key='uuid'):
+def send(vm, target, key='uuid'):
     '''
     Send a vm to a directory
 
@@ -895,14 +850,8 @@ def send(vm=None, target=None, key='uuid'):
     ret = {}
     vmadm = _check_vmadm()
     zfs = _check_zfs()
-    if vm is None:
-        ret['Error'] = 'uuid, alias or hostname must be provided'
-        return ret
     if key not in ['uuid', 'alias', 'hostname']:
         ret['Error'] = 'Key must be either uuid, alias or hostname'
-        return ret
-    if target is None:
-        ret['Error'] = 'Target must be specified'
         return ret
     if not os.path.isdir(target):
         ret['Error'] = 'Target must be a directory or host'
@@ -942,7 +891,7 @@ def send(vm=None, target=None, key='uuid'):
     return True
 
 
-def receive(uuid=None, source=None):
+def receive(uuid, source):
     '''
     Receive a vm from a directory
 
@@ -960,12 +909,6 @@ def receive(uuid=None, source=None):
     ret = {}
     vmadm = _check_vmadm()
     zfs = _check_zfs()
-    if uuid is None:
-        ret['Error'] = 'uuid must be provided'
-        return ret
-    if source is None:
-        ret['Error'] = 'Source must be specified'
-        return ret
     if not os.path.isdir(source):
         ret['Error'] = 'Source must be a directory or host'
         return ret

--- a/salt/modules/smartos_vmadm.py
+++ b/salt/modules/smartos_vmadm.py
@@ -305,7 +305,7 @@ def list_vms(search=None, sort=None, order='uuid,type,ram,state,alias', keyed=Fa
         vmadm order (-o) property -- Default: uuid,type,ram,state,alias
     keyed : boolean
         specified if the output should be an array (False) or dict (True)
-            For a dict the key is the first ietem from the order parameter.
+            For a dict the key is the first item from the order parameter.
             Note: If key is not unique last vm wins.
 
     CLI Example:


### PR DESCRIPTION
While checking out some state modules to figure out how they worked I noticed I could make salt do some work for me.
- improved docs for imgadm
- minor docs tweak for vmadm
- drops some of the ``var=None` and checks of var for None in vmadm and imgadm

This results in a somewhat useful output if you forgot a parameters :) Also less code is usually good.
