### PR TITLE
Fixes to FreeBSD pkg

### DIFF
--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -467,7 +467,7 @@ def _rehash():
     '''
     shell = __salt__['environ.get']('SHELL')
     if shell.split('/')[-1] in ('csh', 'tcsh'):
-        __salt__['cmd.run']('rehash', output_loglevel='trace')
+        __salt__['cmd.shell']('rehash', output_loglevel='trace')
 
 
 def file_list(*packages):

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -465,7 +465,7 @@ def _rehash():
     Recomputes internal hash table for the PATH variable. Use whenever a new
     command is created during the current session.
     '''
-    shell = __salt__['environ.get']('SHELL', output_loglevel='trace')
+    shell = __salt__['environ.get']('SHELL')
     if shell.split('/')[-1] in ('csh', 'tcsh'):
         __salt__['cmd.run']('rehash', output_loglevel='trace')
 


### PR DESCRIPTION
commit 012a69fa04780ba4760e8b02fb6bede2e3ea6a30 changed this call from `cmd.run` to `environ.get`, but `output_loglevel` remained, leading to stacktraces.

After that, a stack trace occurs

```
    Function: pkg.installed
        Name: python-psutil
      Result: False
     Comment: An error was encountered while installing package(s): Unable to run command ['rehash'] with the context {'with_communicate': True, 'shell': False, 'env': {'GROUP': 'wheel', 'REMOTEHOST': '', 'HOSTTYPE': 'FreeBSD', 'SSH_CLIENT': '109.72.87.254 52109 22', 'LOGNAME': 'root', 'USER': 'root', 'HOME': '/root', 'PATH': '/sbin:/bin:/usr/sbin:/usr/bin:/usr/games:/usr/local/sbin:/usr/local/bin:/root/bin', 'TERM': 'screen', 'SHELL': '/bin/tcsh', 'SHLVL': '1', 'BLOCKSIZE': 'K', 'PWD': '/usr/local/etc/salt/minion.d', 'EDITOR': 'vi', 'OSTYPE': 'FreeBSD', 'VENDOR': 'amd', 'HOST': 'zfs05.c01.p02.zone01.ams02.cldin.net', 'LC_ALL': 'C', 'STY': '5485.pts-0.zfs05', 'TERMCAP': 'SC|screen|VT 100/ANSI X3.64 virtual terminal:\\\n\t:DO=\\E[%dB:LE=\\E[%dD:RI=\\E[%dC:UP=\\E[%dA:bs:bt=\\E[Z:\\\n\t:cd=\\E[J:ce=\\E[K:cl=\\E[H\\E[J:cm=\\E[%i%d;%dH:ct=\\E[3g:\\\n\t:do=^J:nd=\\E[C:pt:rc=\\E8:rs=\\Ec:sc=\\E7:st=\\EH:up=\\EM:\\\n\t:le=^H:bl=^G:cr=^M:it#8:ho=\\E[H:nw=\\EE:ta=^I:is=\\E)0:\\\n\t:li#54:co#198:am:xn:xv:LP:sr=\\EM:al=\\E[L:AL=\\E[%dL:\\\n\t:cs=\\E[%i%d;%dr:dl=\\E[M:DL=\\E[%dM:dc=\\E[P:DC=\\E[%dP:\\\n\t:im=\\E[4h:ei=\\E[4l:mi:IC=\\E[%d@:ks=\\E[?1h\\E=:\\\n\t:ke=\\E[?1l\\E>:vi=\\E[?25l:ve=\\E[34h\\E[?25h:vs=\\E[34l:\\\n\t:ti=\\E[?1049h:te=\\E[?1049l:us=\\E[4m:ue=\\E[24m:so=\\E[3m:\\\n\t:se=\\E[23m:md=\\E[1m:mr=\\E[7m:me=\\E[m:ms:\\\n\t:Co#8:pa#64:AF=\\E[3%dm:AB=\\E[4%dm:op=\\E[39;49m:AX:G0:\\\n\t:as=\\E(0:ae=\\E(B:\\\n\t:ac=\\140\\140aaffggjjkkllmmnnooppqqrrssttuuvvwwxxyyzz{{||}}~~..--++,,hhII00:\\\n\t:Km=\\E[M:k0=\\E[10~:k1=\\EOP:k2=\\EOQ:k3=\\EOR:k4=\\EOS:\\\n\t:k5=\\E[15~:k6=\\E[17~:k7=\\E[18~:k8=\\E[19~:k9=\\E[20~:\\\n\t:k;=\\E[21~:F1=\\E[23~:F2=\\E[24~:kb=^H:K2=\\EOE:kB=\\E[Z:\\\n\t:kh=\\E[1~:@1=\\E[1~:kH=\\E[4~:@7=\\E[4~:kN=\\E[6~:kP=\\E[5~:\\\n\t:kI=\\E[2~:kD=\\E[3~:ku=\\EOA:kd=\\EOB:kr=\\EOC:kl=\\EOD:km:', 'MACHTYPE': 'x86_64', 'SSH_TTY': '/dev/pts/0', 'WINDOW': '1', 'MAIL': '/var/mail/root', 'SSH_CONNECTION': '', 'PAGER': 'more'}, 'stdout': -1, 'close_fds': True, 'stdin': None, 'stderr': -2, 'cwd': '/root'}, reason: [Errno 2] No such file or directory
     Started: 20:04:44.091434
    Duration: 208.932 ms
     Changes:   
```
