### PR TITLE
small spelling errors in docs for salt.states.x509

### DIFF
--- a/salt/states/x509.py
+++ b/salt/states/x509.py
@@ -346,11 +346,11 @@ def certificate_managed(name,
         Path to the certificate
 
     days_remaining:
-        The minimum number of days remaining when the certificate should be recreted. Default is 90. A
+        The minimum number of days remaining when the certificate should be recreated. Default is 90. A
         value of 0 disables automatic renewal.
 
     backup:
-        When replacing an existing file, backup the old file onthe minion. Default is False.
+        When replacing an existing file, backup the old file on the minion. Default is False.
 
     kwargs:
         Any arguments supported by :mod:`x509.create_certificate <salt.modules.x509.create_certificate>`


### PR DESCRIPTION
Still exploring the state modules, both docs and code. Some minor spellings fixes.
