### PR TITLE
Use S3 credentials from Pillar

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -556,8 +556,9 @@ class Client(object):
         if url_data.scheme == 's3':
             try:
                 import salt.utils.s3
+
                 def s3_opt(key, default=None):
-                    '''get value of s3.<key> from Minion config or from Pillar'''
+                    '''Get value of s3.<key> from Minion config or from Pillar'''
                     if 's3.' + key in self.opts:
                         return self.opts['s3.' + key]
                     try:

--- a/salt/utils/s3.py
+++ b/salt/utils/s3.py
@@ -130,10 +130,10 @@ def query(key, keyid, method='GET', params=None, headers=None,
                                   verify=verify_ssl)
         response = result.content
     except requests.exceptions.HTTPError as exc:
-        log.error('There was an error::')
-        if hasattr(exc, 'code') and hasattr(exc, 'msg'):
-            log.error('    Code: {0}: {1}'.format(exc.code, exc.msg))
-        log.error('    Content: \n{0}'.format(exc.read()))
+        log.error('Failed to {0} {1}::'.format(method, requesturl))
+        log.error('    Exception: {0}'.format(exc))
+        if exc.response:
+            log.error('    Response content: {0}'.format(exc.response.content))
         return False
 
     log.debug('S3 Response Status Code: {0}'.format(result.status_code))


### PR DESCRIPTION
I want to use `file.managed` with `source` from AWS S3 and store S3 credentials in Pillar, like it is mentioned in documentation:
- [salt.states.file](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.file.html) says _Both HTTPS and HTTP are supported as well as downloading directly from Amazon S3 compatible URLs with both pre-configured and automatic IAM credentials. (see s3.get state documentation)_
- well, there appears to be no s3 state. only s3 module
- [salt.modules.s3](https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.s3.html) says that I can store `s3.keyid` and `s3.key` _... either in a pillar or in the minion's config file_

But it looks that Salt allows S3 credentials only in minion config file (or EC2 instance metadata): #13850 and possibly #26911

Since I really want to use Pillar I fixed it myself and if you are interested it can be merged to the upstream. But maybe you are already working on a different way how to fix this.
