### PR TITLE
salt.utils.context deepcopy fix

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -380,7 +380,7 @@ class AsyncAuth(object):
 
     def __deepcopy__(self, memo):
         cls = self.__class__
-        result = cls.__new__(cls, copy.deepcopy(self.opts), io_loop=None)
+        result = cls.__new__(cls, copy.deepcopy(self.opts, memo), io_loop=None)
         memo[id(self)] = result
         for key, value in self.__dict__.items():
             if key in ('io_loop',):

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -382,13 +382,13 @@ class AsyncAuth(object):
         cls = self.__class__
         result = cls.__new__(cls, copy.deepcopy(self.opts, memo), io_loop=None)
         memo[id(self)] = result
-        for key, value in self.__dict__.items():
+        for key in self.__dict__:
             if key in ('io_loop',):
                 # The io_loop has a thread Lock which will fail to be deep
                 # copied. Skip it because it will just be recreated on the
                 # new copy.
                 continue
-            setattr(result, key, copy.deepcopy(value, memo))
+            setattr(result, key, copy.deepcopy(self.__dict__[key], memo))
         return result
 
     @property

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -100,7 +100,7 @@ class AsyncZeroMQReqChannel(salt.transport.client.ReqChannel):
         cls = self.__class__
         result = cls.__new__(cls, copy.deepcopy(self.opts, memo))  # pylint: disable=too-many-function-args
         memo[id(self)] = result
-        for key, value in self.__dict__.items():
+        for key in self.__dict__:
             if key in ('_io_loop',):
                 continue
                 # The _io_loop has a thread Lock which will fail to be deep
@@ -114,7 +114,7 @@ class AsyncZeroMQReqChannel(salt.transport.client.ReqChannel):
                                               self.master_uri,
                                               io_loop=result._io_loop))
                 continue
-            setattr(result, key, copy.deepcopy(value, memo))
+            setattr(result, key, copy.deepcopy(self.__dict__[key], memo))
         return result
 
     @classmethod

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -98,7 +98,7 @@ class AsyncZeroMQReqChannel(salt.transport.client.ReqChannel):
 
     def __deepcopy__(self, memo):
         cls = self.__class__
-        result = cls.__new__(cls, copy.deepcopy(self.opts))  # pylint: disable=too-many-function-args
+        result = cls.__new__(cls, copy.deepcopy(self.opts, memo))  # pylint: disable=too-many-function-args
         memo[id(self)] = result
         for key, value in self.__dict__.items():
             if key in ('_io_loop',):

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -5,10 +5,11 @@ Zeromq transport classes
 
 # Import Python Libs
 from __future__ import absolute_import
-import logging
 import os
+import copy
 import errno
 import hashlib
+import logging
 import weakref
 from random import randint
 
@@ -94,6 +95,27 @@ class AsyncZeroMQReqChannel(salt.transport.client.ReqChannel):
             new_obj.__singleton_init__(opts, **kwargs)
             loop_instance_map[key] = new_obj
             return loop_instance_map[key]
+
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        result = cls.__new__(cls, copy.deepcopy(self.opts))  # pylint: disable=too-many-function-args
+        memo[id(self)] = result
+        for key, value in self.__dict__.items():
+            if key in ('_io_loop',):
+                continue
+                # The _io_loop has a thread Lock which will fail to be deep
+                # copied. Skip it because it will just be recreated on the
+                # new copy.
+            if key == 'message_client':
+                # Recreate the message client because it will fail to be deep
+                # copied. The reason is the same as the io_loop skip above.
+                setattr(result, key,
+                        AsyncReqMessageClient(result.opts,
+                                              self.master_uri,
+                                              io_loop=result._io_loop))
+                continue
+            setattr(result, key, copy.deepcopy(value, memo))
+        return result
 
     @classmethod
     def __key(cls, opts, **kwargs):


### PR DESCRIPTION
This avoids tracebacks like:

```
00:55:08 00:53:52,728 [tornado.application                     :612 ][ERROR   ] Exception in callback <functools.partial object at 0x7f4df131ecb0>
00:55:08 Traceback (most recent call last):
00:55:08   File "/usr/lib/python2.7/site-packages/tornado/ioloop.py", line 592, in _run_callback
00:55:08     ret = callback()
00:55:08   File "/usr/lib/python2.7/site-packages/tornado/stack_context.py", line 343, in wrapped
00:55:08     raise_exc_info(exc)
00:55:08   File "/usr/lib/python2.7/site-packages/tornado/stack_context.py", line 304, in wrapped
00:55:08     n.enter()
00:55:08   File "/usr/lib/python2.7/site-packages/tornado/stack_context.py", line 118, in enter
00:55:08     context = self.context_factory()
00:55:08   File "/testing/salt/minion.py", line 999, in ctx
00:55:08     self.functions.context_dict.clone(),
00:55:08   File "/testing/salt/utils/context.py", line 91, in clone
00:55:08     child = ChildContextDict(parent=self, overrides=kwargs)
00:55:08   File "/testing/salt/utils/context.py", line 136, in __init__
00:55:08     self._data[k] = copy.deepcopy(v)
00:55:08   File "/usr/lib/python2.7/copy.py", line 163, in deepcopy
00:55:08     y = copier(x, memo)
00:55:08   File "/usr/lib/python2.7/copy.py", line 257, in _deepcopy_dict
00:55:08     y[deepcopy(key, memo)] = deepcopy(value, memo)
00:55:08   File "/usr/lib/python2.7/copy.py", line 190, in deepcopy
00:55:08     y = _reconstruct(x, rv, 1, memo)
00:55:08   File "/usr/lib/python2.7/copy.py", line 334, in _reconstruct
00:55:09     state = deepcopy(state, memo)
00:55:09   File "/usr/lib/python2.7/copy.py", line 163, in deepcopy
00:55:09     y = copier(x, memo)
00:55:09   File "/usr/lib/python2.7/copy.py", line 257, in _deepcopy_dict
00:55:09     y[deepcopy(key, memo)] = deepcopy(value, memo)
00:55:09   File "/usr/lib/python2.7/copy.py", line 190, in deepcopy
00:55:09     y = _reconstruct(x, rv, 1, memo)
00:55:09   File "/usr/lib/python2.7/copy.py", line 329, in _reconstruct
00:55:09     y = callable(*args)
00:55:09   File "/usr/lib/python2.7/copy_reg.py", line 93, in __newobj__
00:55:09     return cls.__new__(cls, *args)
00:55:09 TypeError: __new__() takes at least 2 arguments (1 given)
```

seen for example, [here](https://jenkins.saltstack.com/job/salt-linode-arch/3093/consoleFull)
