### PR TITLE
Salt-SSH: Return more concise error when SSH command fails

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -544,6 +544,10 @@ class SSH(object):
 
             self.cache_job(jid, host, ret[host], fun)
             ret = self.key_deploy(host, ret)
+
+            if ret[host].get('stderr', '').startswith('ssh:'):
+                ret[host] = ret[host]['stderr']
+
             if not isinstance(ret[host], dict):
                 p_data = {host: ret[host]}
             elif 'return' not in ret[host]:


### PR DESCRIPTION
See issue: https://github.com/saltstack/salt/issues/26368

![](http://i.imgur.com/vxdSXWJ.png)

Compared to before:

```
$ salt-ssh -L 'vagrant-dev,vagrant-test' state.apply | wc -l
524
```

I'm a bit confused as to why the server that's down is cyan while the server that's up is green. Is this how it's intended to look?
