### PR TITLE
Returners get_jids() return dict.

### DIFF
--- a/salt/returners/__init__.py
+++ b/salt/returners/__init__.py
@@ -21,7 +21,7 @@ def get_returner_options(virtualname=None,
 
     :param str virtualname: The returner virtualname (as returned
         by __virtual__()
-    :param ret: result of the module that ran. dit-like object
+    :param ret: result of the module that ran. dict-like object
 
         May contain a `ret_config` key pointing to a string
         If a `ret_config` is specified, config options are read from::

--- a/salt/returners/__init__.py
+++ b/salt/returners/__init__.py
@@ -100,7 +100,7 @@ def get_returner_options(virtualname=None,
 
     # override some values with relevant options from
     # keyword arguments passed via return_kwargs
-    if 'ret_kwargs' in ret:
+    if ret and 'ret_kwargs' in ret:
         _options.update(ret['ret_kwargs'])
 
     return _options

--- a/salt/returners/cassandra_cql_return.py
+++ b/salt/returners/cassandra_cql_return.py
@@ -347,9 +347,9 @@ def get_jids():
     '''
     Return a list of all job ids
     '''
-    query = '''SELECT DISTINCT jid FROM salt.jids;'''
+    query = '''SELECT DISTINCT jid, load FROM salt.jids;'''
 
-    ret = []
+    ret = {}
 
     # cassandra_cql.cql_query may raise a CommandExecutionError
     try:
@@ -357,8 +357,9 @@ def get_jids():
         if data:
             for row in data:
                 jid = row.get('jid')
-                if jid:
-                    ret.append(jid)
+                load = row.get('load')
+                if jid and load:
+                    ret[jid] = salt.utils.jid.format_jid_instance(jid, json.loads(load))
     except CommandExecutionError:
         log.critical('Could not get a list of all job ids.')
         raise

--- a/salt/returners/cassandra_cql_return.py
+++ b/salt/returners/cassandra_cql_return.py
@@ -83,11 +83,11 @@ Return data to a cassandra server
 
 Required python modules: cassandra-driver
 
-To use the cassandra returner, append '--return cassandra' to the salt command. ex:
+To use the cassandra returner, append '--return cassandra_cql' to the salt command. ex:
 
 .. code-block:: bash
 
-    salt '*' test.ping --return cassandra
+    salt '*' test.ping --return_cql cassandra
 '''
 from __future__ import absolute_import
 # Let's not allow PyLint complain about string substitution
@@ -347,7 +347,7 @@ def get_jids():
     '''
     Return a list of all job ids
     '''
-    query = '''SELECT DISTINCT jid, load FROM salt.jids;'''
+    query = '''SELECT jid, load FROM salt.jids;'''
 
     ret = {}
 

--- a/salt/returners/couchdb_return.py
+++ b/salt/returners/couchdb_return.py
@@ -86,26 +86,23 @@ def _get_options(ret=None):
     '''
     Get the couchdb options from salt.
     '''
-    attrs = {'url': 'server_url',
-             'db': 'db_name'}
+    attrs = {'url': 'url',
+             'db': 'db'}
 
     _options = salt.returners.get_returner_options(__virtualname__,
                                                    ret,
                                                    attrs,
                                                    __salt__=__salt__,
                                                    __opts__=__opts__)
-    server_url = _options.get('server_url')
-    db_name = _options.get('db_name')
-
-    if not server_url:
+    if 'url' not in _options:
         log.debug("Using default url.")
-        server_url = "http://salt:5984/"
+        _options['url'] = "http://salt:5984/"
 
-    if not db_name:
+    if 'db' not in _options:
         log.debug("Using default database.")
-        db_name = "salt"
+        _options['db'] = "salt"
 
-    return {"url": server_url, "db": db_name}
+    return _options
 
 
 def _generate_doc(ret):
@@ -197,31 +194,24 @@ def get_jids():
     List all the jobs that we have..
     '''
     options = _get_options(ret=None)
-    _response = _request("GET", options['url'] + options['db'] + "/_all_docs")
+    _response = _request("GET", options['url'] + options['db'] + "/_all_docs?include_docs=true")
 
     # Make sure the 'total_rows' is returned.. if not error out.
     if 'total_rows' not in _response:
         log.error('Didn\'t get valid response from requesting all docs: {0}'
                   .format(_response))
-        return []
+        return {}
 
     # Return the rows.
-    ret = []
+    ret = {}
     for row in _response['rows']:
         # Because this shows all the documents in the database, including the
-        # design documents, whitelist the matching salt jid's which is a 20
-        # digit int.
-
-        # See if the identifier is an int..
-        try:
-            int(row['id'])
-        except ValueError:
+        # design documents, verify the id is salt jid
+        jid = row['id']
+        if not salt.utils.jid.is_jid(jid):
             continue
 
-        # Check the correct number of digits by simply casting to str and
-        # splitting.
-        if len(str(row['id'])) == 20:
-            ret.append(row['id'])
+        ret[jid] = salt.utils.jid.format_jid_instance(jid, row['doc'])
 
     return ret
 

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -147,13 +147,14 @@ def get_jids():
     '''
     Return a list of all job ids
     '''
-    ret = []
+    ret = {}
     client, path = _get_conn(__opts__)
     items = client.get('/'.join((path, 'jobs')))
     for item in items.children:
         if item.dir is True:
-            comps = str(item.key).split('/')
-            ret.append(comps[-1])
+            jid = str(item.key).split('/')[-1]
+            load = client.get('/'.join((item.key, '.load.p'))).value
+            ret[jid] = salt.utils.jid.format_jid_instance(jid, json.loads(load))
     return ret
 
 

--- a/salt/returners/influxdb_return.py
+++ b/salt/returners/influxdb_return.py
@@ -62,7 +62,7 @@ import salt.returners
 
 # Import third party libs
 try:
-    import influxdb.influxdb08
+    from influxdb.influxdb08 import InfluxDBClient
     HAS_INFLUXDB = True
 except ImportError:
     HAS_INFLUXDB = False
@@ -108,11 +108,11 @@ def _get_serv(ret=None):
     user = _options.get('user')
     password = _options.get('password')
 
-    return influxdb.influxdb08.InfluxDBClient(host=host,
-                                              port=port,
-                                              username=user,
-                                              password=password,
-                                              database=database)
+    return InfluxDBClient(host=host,
+                          port=port,
+                          username=user,
+                          password=password,
+                          database=database)
 
 
 def returner(ret):
@@ -218,15 +218,17 @@ def get_jids():
     Return a list of all job ids
     '''
     serv = _get_serv(ret=None)
-    sql = "select distinct(jid) from jids"
+    sql = "select distinct(jid) from jids group by load"
 
-    #  [{u'points': [[0, u'saltdev']], u'name': u'returns', u'columns': [u'time', u'distinct']}]
+    # [{u'points': [[0, jid, load],
+    #               [0, jid, load]],
+    #   u'name': u'jids',
+    #   u'columns': [u'time', u'distinct', u'load']}]
     data = serv.query(sql)
-    ret = []
+    ret = {}
     if data:
-        for jid in data[0]['points']:
-            ret.append(jid[1])
-
+        for _, jid, load in data[0]['points']:
+            ret[jid] = salt.utils.jid.format_jid_instance(jid, json.loads(load))
     return ret
 
 

--- a/salt/returners/memcache_return.py
+++ b/salt/returners/memcache_return.py
@@ -182,7 +182,9 @@ def get_jid(jid):
     minions = _get_list(serv, 'minions')
     returns = serv.get_multi(minions, key_prefix='{0}:'.format(jid))
     # returns = {minion: return, minion: return, ...}
-    ret = {minion: json.loads(data) for minion, data in six.iteritems(returns)}
+    ret = {}
+    for minion, data in six.iteritems(returns):
+        ret[minion] = json.loads(data)
     return ret
 
 
@@ -194,7 +196,9 @@ def get_fun(fun):
     minions = _get_list(serv, 'minions')
     returns = serv.get_multi(minions, key_prefix='{0}:'.format(fun))
     # returns = {minion: return, minion: return, ...}
-    ret = {minion: json.loads(data) for minion, data in six.iteritems(returns)}
+    ret = {}
+    for minion, data in six.iteritems(returns):
+        ret[minion] = json.loads(data)
     return ret
 
 
@@ -209,6 +213,7 @@ def get_jids():
     for jid, load in six.iteritems(loads):
         ret[jid] = salt.utils.jid.format_jid_instance(jid, json.loads(load))
     return ret
+
 
 def get_minions():
     '''

--- a/salt/returners/memcache_return.py
+++ b/salt/returners/memcache_return.py
@@ -206,7 +206,7 @@ def get_jids():
     jids = _get_list(serv, 'jids')
     loads = serv.get_multi(jids)  # {jid: load, jid: load, ...}
     ret = {}
-    for jid, load in six.iteritems(loads)
+    for jid, load in six.iteritems(loads):
         ret[jid] = salt.utils.jid.format_jid_instance(jid, json.loads(load))
     return ret
 

--- a/salt/returners/memcache_return.py
+++ b/salt/returners/memcache_return.py
@@ -50,9 +50,10 @@ from __future__ import absolute_import
 # Import python libs
 import json
 import logging
-import salt.utils.jid
 
+import salt.utils.jid
 import salt.returners
+from salt.ext import six
 
 log = logging.getLogger(__name__)
 
@@ -113,6 +114,21 @@ def _get_serv(ret):
     #    an integer weight value.
 
 
+def _get_list(serv, key):
+    try:
+        return serv.get(key).strip(',').split(',')
+    except AttributeError:
+        return []
+
+
+def _append_list(serv, key, value):
+    if value in _get_list(serv, key):
+        return
+    r = serv.append(key, '{0},'.format(value))
+    if not r:
+        serv.add(key, '{0},'.format(value))
+
+
 def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     '''
     Do any work necessary to prepare a JID, including sending a custom id
@@ -125,18 +141,14 @@ def returner(ret):
     Return data to a memcache data store
     '''
     serv = _get_serv(ret)
-    serv.set('{0}:{1}'.format(ret['id'], ret['jid']), json.dumps(ret))
+    minion = ret['id']
+    jid = ret['jid']
+    serv.set('{0}:{1}'.format(minion, jid), json.dumps(ret))
 
     # The following operations are neither efficient nor atomic.
     # If there is a way to make them so, this should be updated.
-    if ret['id'] not in get_minions():
-        r = serv.append('minions', ret['id'] + ',')
-        if not r:
-            serv.add('minions', ret['id'] + ',')
-    if ret['jid'] not in get_jids():
-        r = serv.append('jids', ret['jid'] + ',')
-        if not r:
-            serv.add('jids', ret['jid'] + ',')
+    _append_list(serv, 'minions', minion)
+    _append_list(serv, 'jids', jid)
 
 
 def save_load(jid, load):
@@ -145,7 +157,7 @@ def save_load(jid, load):
     '''
     serv = _get_serv(ret=None)
     serv.set(jid, json.dumps(load))
-    serv.append('jids', jid)
+    _append_list(serv, 'jids', jid)
 
 
 def get_load(jid):
@@ -165,7 +177,7 @@ def get_jid(jid):
     '''
     serv = _get_serv(ret=None)
     ret = {}
-    for minion in get_minions():
+    for minion in _get_list(serv, 'minions'):
         data = serv.get('{0}:{1}'.format(minion, jid))
         if data:
             ret[minion] = json.loads(data)
@@ -195,18 +207,19 @@ def get_jids():
     Return a list of all job ids
     '''
     serv = _get_serv(ret=None)
+    ret = {}
     try:
-        return serv.get('jids').strip(',').split(',')
+        jids = _get_list(serv, 'jids')
+        loads = serv.get_multi(jids)  # {jid: load, jid: load, ...}
+        for jid, load in six.iteritems(loads)
+            ret[jid] = salt.utils.jid.format_jid_instance(jid, json.loads(load))
     except AttributeError:
-        return []
-
+        pass
+    return ret
 
 def get_minions():
     '''
     Return a list of minions
     '''
     serv = _get_serv(ret=None)
-    try:
-        return serv.get('minions').strip(',').split(',')
-    except AttributeError:
-        return []
+    return _get_list(serv, 'minions')

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -263,9 +263,13 @@ def get_jids():
     Return a list of job ids
     '''
     conn, mdb = _get_conn(ret=None)
-    ret = []
-    name = mdb.jobs.distinct('jid')
-    ret.append(name)
+    map = "function() { emit(this.jid, this); }"
+    reduce = "function (key, values) { return values[0]; }"
+    result = mdb.jobs.inline_map_reduce(map, reduce)
+    ret = {}
+    for r in result:
+        jid = r['_id']
+        ret[jid] = salt.utils.jid.format_jid_instance(jid, r['value'])
     return ret
 
 

--- a/salt/returners/odbc.py
+++ b/salt/returners/odbc.py
@@ -290,13 +290,13 @@ def get_jids():
     '''
     conn = _get_conn(ret=None)
     cur = conn.cursor()
-    sql = '''SELECT distinct jid FROM jids'''
+    sql = '''SELECT distinct jid, load FROM jids'''
 
     cur.execute(sql)
     data = cur.fetchall()
-    ret = []
-    for jid in data:
-        ret.append(jid[0])
+    ret = {}
+    for jid, load in data:
+        ret[jid] = salt.utils.jid.format_jid_instance(jid, json.loads(load))
     _close_conn(conn)
     return ret
 

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -55,7 +55,7 @@ Use the following Pg database schema:
     -- Table structure for table `jids`
     --
     DROP TABLE IF EXISTS jids;
-    CREATE OR REPLACE TABLE jids (
+    CREATE TABLE jids (
        jid varchar(255) NOT NULL primary key,
        load jsonb NOT NULL
     );
@@ -353,14 +353,14 @@ def get_jids():
     '''
     with _get_serv(ret=None, commit=True) as cur:
 
-        sql = '''SELECT DISTINCT jid
+        sql = '''SELECT jid, load
                 FROM jids'''
 
         cur.execute(sql)
         data = cur.fetchall()
-        ret = []
-        for jid in data:
-            ret.append(jid[0])
+        ret = {}
+        for jid, load in data:
+            ret[jid] = salt.utils.jid.format_jid_instance(jid, load)
         return ret
 
 

--- a/salt/returners/postgres.py
+++ b/salt/returners/postgres.py
@@ -266,13 +266,13 @@ def get_jids():
     '''
     conn = _get_conn(ret=None)
     cur = conn.cursor()
-    sql = '''SELECT jid FROM jids'''
+    sql = '''SELECT jid, load FROM jids'''
 
     cur.execute(sql)
     data = cur.fetchall()
-    ret = []
-    for jid in data:
-        ret.append(jid[0])
+    ret = {}
+    for jid, load in data:
+        ret[jid] = salt.utils.jid.format_jid_instance(jid, json.loads(load))
     _close_conn(conn)
     return ret
 

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -171,7 +171,12 @@ def get_jids():
     Return a list of all job ids
     '''
     serv = _get_serv(ret=None)
-    return list(serv.smembers('jids'))
+    ret = {}
+    for s in serv.mget(serv.smembers('jids')):
+        load = json.loads(s)
+        jid = load['jid']
+        ret[jid] = salt.utils.jid.format_jid_instance(jid, load)
+    return ret
 
 
 def get_minions():

--- a/salt/returners/sqlite3_return.py
+++ b/salt/returners/sqlite3_return.py
@@ -16,8 +16,8 @@ minion config:
 
 .. code-block:: yaml
 
-    returner.sqlite3.database: /usr/lib/salt/salt.db
-    returner.sqlite3.timeout: 5.0
+    sqlite3.database: /usr/lib/salt/salt.db
+    sqlite3.timeout: 5.0
 
 Alternative configuration values can be used by prefacing the configuration.
 Any values not found in the alternative configuration will be pulled from
@@ -25,8 +25,8 @@ the default location:
 
 .. code-block:: yaml
 
-    alternative.returner.sqlite3.database: /usr/lib/salt/salt.db
-    alternative.returner.sqlite3.timeout: 5.0
+    alternative.sqlite3.database: /usr/lib/salt/salt.db
+    alternative.sqlite3.timeout: 5.0
 
 Use the commands to create the sqlite3 database and tables:
 
@@ -137,10 +137,10 @@ def _get_conn(ret=None):
 
     if not database:
         raise Exception(
-                'sqlite3 config option "returner.sqlite3.database" is missing')
+                'sqlite3 config option "sqlite3.database" is missing')
     if not timeout:
         raise Exception(
-                'sqlite3 config option "returner.sqlite3.timeout" is missing')
+                'sqlite3 config option "sqlite3.timeout" is missing')
     log.debug('Connecting the sqlite3 database: {0} timeout: {1}'.format(
               database,
               timeout))
@@ -171,10 +171,10 @@ def returner(ret):
                 {'fun': ret['fun'],
                  'jid': ret['jid'],
                  'id': ret['id'],
-                 'fun_args': str(ret['fun_args']) if ret['fun_args'] else None,
+                 'fun_args': str(ret['fun_args']) if ret.get('fun_args') else None,
                  'date': str(datetime.datetime.now()),
                  'full_ret': json.dumps(ret['return']),
-                 'success': ret['success']})
+                 'success': ret.get('success', '')})
     _close_conn(conn)
 
 
@@ -262,15 +262,15 @@ def get_jids():
     '''
     Return a list of all job ids
     '''
-    log.debug('sqlite3 returner <get_fun> called')
+    log.debug('sqlite3 returner <get_jids> called')
     conn = _get_conn(ret=None)
     cur = conn.cursor()
-    sql = '''SELECT jid FROM jids'''
+    sql = '''SELECT jid, load FROM jids'''
     cur.execute(sql)
     data = cur.fetchall()
-    ret = []
-    for jid in data:
-        ret.append(jid[0])
+    ret = {}
+    for jid, load in data:
+        ret[jid] = salt.utils.jid.format_jid_instance(jid, json.loads(load))
     _close_conn(conn)
     return ret
 


### PR DESCRIPTION
The following returners are updated: cassandra_cql, couchdb, sqlite3, etcd, influxdb, memcache, mongo_future, odbc, pgjsonb, postgres, redis.

Fix for #22713 
