### PR TITLE
#28526 fixed yumpkg module issue with pkg.installed

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -755,10 +755,11 @@ def check_db(*names, **kwargs):
         __context__['pkg._avail'] = avail
 
     ret = {}
-    repoquery_cmd = repoquery_base + ' {0}'.format(" ".join(names))
-    provides = sorted(
-        set(x.name for x in _repoquery_pkginfo(repoquery_cmd))
-    )
+    if names:
+        repoquery_cmd = repoquery_base + ' {0}'.format(" ".join(names))
+        provides = sorted(
+            set(x.name for x in _repoquery_pkginfo(repoquery_cmd))
+        )
     for name in names:
         ret.setdefault(name, {})['found'] = name in avail
         if not ret[name]['found']:


### PR DESCRIPTION
Provides a fix for #28526.

Has been tested on a CentOS 6.5 minion, works like a charm.
