### PR TITLE
New module: minion.list

### DIFF
--- a/salt/modules/minion.py
+++ b/salt/modules/minion.py
@@ -31,7 +31,7 @@ def list_():
     pki_dir = __salt__['config.get']('pki_dir', '')
     transport = __salt__['config.get']('transport', '')
 
-    # We have to replace the minion/master directoryies
+    # We have to replace the minion/master directories
     pki_dir = pki_dir.replace("minion", "master")
 
     # The source code below is (nearly) a copy of salt.key.Key.list_keys

--- a/salt/modules/minion.py
+++ b/salt/modules/minion.py
@@ -2,6 +2,7 @@
 '''
 Module to provide information about minions
 '''
+from __future__ import absolute_import
 
 # Import Python libs
 import os

--- a/salt/modules/minion.py
+++ b/salt/modules/minion.py
@@ -11,8 +11,13 @@ import os
 import salt.utils
 import salt.key
 
+# Don't shadow built-ins.
+__func_alias__ = {
+    'list_': 'list'
+}
 
-def list():
+
+def list_():
     '''
     Return a list of accepted, denied, unaccepted and rejected keys.
     This is the same output as `salt-key -L`

--- a/salt/modules/minion.py
+++ b/salt/modules/minion.py
@@ -32,7 +32,7 @@ def list_():
     transport = __salt__['config.get']('transport', '')
 
     # We have to replace the minion/master directories
-    pki_dir = pki_dir.replace("minion", "master")
+    pki_dir = pki_dir.replace('minion', 'master')
 
     # The source code below is (nearly) a copy of salt.key.Key.list_keys
 

--- a/salt/modules/minion.py
+++ b/salt/modules/minion.py
@@ -23,8 +23,8 @@ def list():
 
         salt 'master' minion.list
     '''
-    pki_dir = globals().get('__salt__')['config.get']('pki_dir', '')
-    transport = globals().get('__salt__')['config.get']('transport', '')
+    pki_dir = __salt__['config.get']('pki_dir', '')
+    transport = __salt__['config.get']('transport', '')
 
     # We have to replace the minion/master directoryies
     pki_dir = pki_dir.replace("minion", "master")

--- a/salt/modules/minion.py
+++ b/salt/modules/minion.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+'''
+Module to provide information about minions
+'''
+
+# Import Python libs
+import os
+
+# Import Salt libs
+import salt.utils
+import salt.key
+
+
+def list():
+    '''
+    Return a list of accepted, denied, unaccepted and rejected keys.
+    This is the same output as `salt-key -L`
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'master' minion.list
+    '''
+    pki_dir = globals().get('__salt__')['config.get']('pki_dir', '')
+    transport = globals().get('__salt__')['config.get']('transport', '')
+
+    # We have to replace the minion/master directoryies
+    pki_dir = pki_dir.replace("minion", "master")
+
+    # The source code below is (nearly) a copy of salt.key.Key.list_keys
+
+    # We have to differentiate between RaetKey._check_minions_directories
+    # and Zeromq-Keys. Raet-Keys only have three states while ZeroMQ-keys
+    # have an additional 'denied' state.
+    if transport in ('zeromq', 'tcp'):
+        key_dirs = _check_minions_directories(pki_dir)
+    else:
+        key_dirs = _check_minions_directories_raetkey(pki_dir)
+
+    ret = {}
+
+    for dir_ in key_dirs:
+        ret[os.path.basename(dir_)] = []
+        try:
+            for fn_ in salt.utils.isorted(os.listdir(dir_)):
+                if not fn_.startswith('.'):
+                    if os.path.isfile(os.path.join(dir_, fn_)):
+                        ret[os.path.basename(dir_)].append(fn_)
+        except (OSError, IOError):
+            # key dir kind is not created yet, just skip
+            continue
+
+    return ret
+
+
+def _check_minions_directories(pki_dir):
+    '''
+    Return the minion keys directory paths.
+
+    This function is a copy of salt.key.Key._check_minions_directories.
+    '''
+    minions_accepted = os.path.join(pki_dir, salt.key.Key.ACC)
+    minions_pre = os.path.join(pki_dir, salt.key.Key.PEND)
+    minions_rejected = os.path.join(pki_dir, salt.key.Key.REJ)
+    minions_denied = os.path.join(pki_dir, salt.key.Key.DEN)
+
+    return minions_accepted, minions_pre, minions_rejected, minions_denied
+
+
+def _check_minions_directories_raetkey(pki_dir):
+    '''
+    Return the minion keys directory paths.
+
+    This function is a copy of salt.key.RaetKey._check_minions_directories.
+    '''
+    accepted = os.path.join(pki_dir, salt.key.RaetKey.ACC)
+    pre = os.path.join(pki_dir, salt.key.RaetKey.PEND)
+    rejected = os.path.join(pki_dir, salt.key.RaetKey.REJ)
+
+    return accepted, pre, rejected


### PR DESCRIPTION
I described a possible feature in https://github.com/saltstack/salt/issues/28663.

This Pull Requests adds a new module to list all minions.
Of course, this module makes only sense to execute on a master, because a typical minion don't know about other minions.
This module is (nearly) the same as `salt-key -L`. But as a module it is available by REST-API. `salt-key` is only available as a shell command.

This is more like a draft, but maybe some people who are more familiar with the saltstack codebase can help to answer some questions (i will be happy to improve the code):
- Is there a smoother way to get the information about all minions? Is this information only stored in the filesystem at the `pki_dir` of the master?
- Is it possible to detect if the (current) minion is a master? With this we can skip the I/O on the minion
- This works only if the salt-master runs a salt-minion itself. Any other idea?
- Do you think this is a good idea?
- Do you suggest a better way to do this in general?

Call:

```
$ salt -l debug -c ./etc/salt 'saltdev' minion.list
```

Answer:

```
[DEBUG   ] Reading configuration from /private/tmp/salt-env/etc/salt/master
[DEBUG   ] Missing configuration file: /Users/agrunwald/.saltrc
[DEBUG   ] Configuration file path: /private/tmp/salt-env/etc/salt/master
[WARNING ] Insecure logging configuration detected! Sensitive data may be logged.
[DEBUG   ] Reading configuration from /private/tmp/salt-env/etc/salt/master
[DEBUG   ] Missing configuration file: /Users/agrunwald/.saltrc
[DEBUG   ] MasterEvent PUB socket URI: ipc:///tmp/salt-env/var/run/salt/master/master_event_pub.ipc
[DEBUG   ] MasterEvent PULL socket URI: ipc:///tmp/salt-env/var/run/salt/master/master_event_pull.ipc
[DEBUG   ] Initializing new AsyncZeroMQReqChannel for ('/tmp/salt-env/etc/salt/pki/master', '172.25.10.26_master', 'tcp://127.0.0.1:4506', 'clear')
[DEBUG   ] LazyLoaded local_cache.get_load
[DEBUG   ] get_iter_returns for jid 20151106222329855220 sent to set(['saltdev']) will timeout at 22:23:34.860702
[DEBUG   ] jid 20151106222329855220 return from saltdev
[DEBUG   ] LazyLoaded nested.output
saltdev:
    ----------
    minions:
        - saltdev
    minions_denied:
    minions_pre:
    minions_rejected:
[DEBUG   ] jid 20151106222329855220 found all minions set(['saltdev'])
```
