### PR TITLE
Use the -q argument to strip extraneous messages from rabbitmq

### DIFF
--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -128,11 +128,9 @@ def list_vhosts(runas=None):
     '''
     if runas is None:
         runas = salt.utils.get_user()
-    res = __salt__['cmd.run']('rabbitmqctl list_vhosts',
-                              runas=runas)
-
-    # remove first and last line: Listing ... - ...done
-    return _strip_listing_to_done(res.splitlines())
+    res = __salt__['cmd.run']('rabbitmqctl list_vhosts -q',
+                              runas=runas).splitlines()
+    return res
 
 
 def user_exists(name, runas=None):


### PR DESCRIPTION
Instead of trying to do it ourselves and worrying about which
version prints 'Listing vhosts...' and '...done' at the beginning
or end of the output or not.

Fixes #26592
