### PR TITLE
Added OS lookup for openSUSE Leap

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -981,6 +981,7 @@ _OS_FAMILY_MAP = {
     'SUSE  Enterprise Server': 'Suse',
     'SLED': 'Suse',
     'openSUSE': 'Suse',
+    'openSUSE Leap': 'Suse',
     'SUSE': 'Suse',
     'Solaris': 'Solaris',
     'SmartOS': 'Solaris',


### PR DESCRIPTION
Open SUSE Leap (https://software.opensuse.org/421/en) uses a different distroname.
