### PR TITLE
set a valid flag for docker-compose file  on get method

### DIFF
--- a/salt/modules/dockercompose.py
+++ b/salt/modules/dockercompose.py
@@ -279,7 +279,16 @@ def get(path):
 
         salt myminion dockercompose.get /path/where/docker-compose/stored
     '''
-    return __read_docker_compose(path)
+
+    salt_result = __read_docker_compose(path)
+    if not salt_result['status']:
+        return salt_result
+    project = __load_project(path)
+    if isinstance(project, dict):
+        salt_result['return']['valid'] = False
+    else:
+        salt_result['return']['valid'] = True
+    return salt_result
 
 
 def create(path, docker_compose):


### PR DESCRIPTION
Files could have been modified on the host, it is quite useful to know if the file is valid or not when we get it.

Since dockercompose is already loaded in the modules, it saves people from doing it themselves in their own module or state.
