### PR TITLE
Pass RBENV_VERSION in env dict, and protect shlex.split

### DIFF
--- a/salt/modules/rbenv.py
+++ b/salt/modules/rbenv.py
@@ -357,7 +357,7 @@ def rehash(runas=None):
     return True
 
 
-def do(cmdline, runas=None):
+def do(cmdline, runas=None, env=None):
     '''
     Execute a ruby command with rbenv's shims from the user or the system
 
@@ -375,7 +375,10 @@ def do(cmdline, runas=None):
         raise SaltInvocationError('Command must be specified')
 
     path = _rbenv_path(runas)
-    environ = {'PATH': '{0}/shims:{1}'.format(path, os.environ['PATH'])}
+    if not env:
+        env = {}
+
+    env['PATH'] = '{0}/shims:{1}'.format(path, os.environ['PATH'])
 
     try:
         cmdline = salt.utils.shlex_split(cmdline)
@@ -385,7 +388,7 @@ def do(cmdline, runas=None):
     result = __salt__['cmd.run_all'](
         cmdline,
         runas=runas,
-        env=environ,
+        env=env,
         python_shell=False
     )
 
@@ -418,9 +421,11 @@ def do_with_ruby(ruby, cmdline, runas=None):
     except AttributeError:
         cmdline = salt.utils.shlex_split(str(cmdline))
 
+    env = {}
     if ruby:
-        cmd = ['RBENV_VERSION={0}'.format(ruby)] + cmdline
+        env['RBENV_VERSION'] = ruby
+        cmd = cmdline
     else:
         cmd = cmdline
 
-    return do(cmd, runas=runas)
+    return do(cmd, runas=runas, env=env)


### PR DESCRIPTION
This should fix the behavior of some commands being run with rbenv failing without a default ruby version with "No such file or directory" as described in #23215
