### PR TITLE
Only shlex.split strings

### DIFF
--- a/salt/engines/slack.py
+++ b/salt/engines/slack.py
@@ -42,6 +42,7 @@ except ImportError:
 import salt.client
 import salt.loader
 import salt.runner
+import salt.utils
 import salt.utils.event
 import salt.utils.http
 import salt.utils.slack
@@ -129,7 +130,7 @@ def start(token,
 
                                 # Trim the ! from the front
                                 # cmdline = _text[1:].split(' ', 1)
-                                cmdline = shlex.split(_text[1:])
+                                cmdline = salt.utils.shlex_split(_text[1:])
                                 cmd = cmdline[0]
                                 args = []
                                 kwargs = {}

--- a/salt/engines/slack.py
+++ b/salt/engines/slack.py
@@ -31,7 +31,6 @@ prefaced with a !.
 from __future__ import absolute_import
 import logging
 import pprint
-import shlex
 try:
     import slackclient
     HAS_SLACKCLIENT = True

--- a/salt/modules/augeas_cfg.py
+++ b/salt/modules/augeas_cfg.py
@@ -42,6 +42,7 @@ except ImportError:
     pass
 
 # Import salt libs
+import salt.utils
 from salt.exceptions import SaltInvocationError
 
 log = logging.getLogger(__name__)
@@ -149,7 +150,7 @@ def execute(context=None, lens=None, commands=()):
         nargs = arg_map[method]
 
         try:
-            parts = shlex.split(arg)
+            parts = salt.utils.shlex_split(arg)
             if len(parts) not in nargs:
                 err = '{0} takes {1} args: {2}'.format(method, nargs, parts)
                 raise ValueError(err)

--- a/salt/modules/augeas_cfg.py
+++ b/salt/modules/augeas_cfg.py
@@ -31,7 +31,6 @@ import re
 import logging
 from salt.ext.six.moves import zip
 import salt.ext.six as six
-import shlex
 
 # Make sure augeas python interface is installed
 HAS_AUGEAS = False

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -312,7 +312,7 @@ def _run(cmd,
             raise CommandExecutionError(msg)
 
         if not isinstance(cmd, list):
-            cmd = shlex.split(cmd, posix=False)
+            cmd = salt.utils.shlex_split(cmd, posix=False)
 
         cmd = ' '.join(cmd)
 
@@ -448,7 +448,7 @@ def _run(cmd,
         posix = True
         if salt.utils.is_windows():
             posix = False
-        cmd = shlex.split(cmd, posix=posix)
+        cmd = salt.utils.shlex_split(cmd, posix=posix)
     if not use_vt:
         # This is where the magic happens
         try:

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -13,7 +13,6 @@ import glob
 import json
 import logging
 import os
-import shlex
 import shutil
 import subprocess
 import sys

--- a/salt/modules/composer.py
+++ b/salt/modules/composer.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import
 # Import python libs
 import logging
 import os.path
-import shlex
 
 # Import salt libs
 import salt.utils

--- a/salt/modules/composer.py
+++ b/salt/modules/composer.py
@@ -153,7 +153,7 @@ def _run_composer(action,
     cmd = [composer, action, '--no-interaction', '--no-ansi']
 
     if extra_flags is not None:
-        cmd.extend(shlex.split(extra_flags))
+        cmd.extend(salt.utils.shlex_split(extra_flags))
 
     # If php is set, prepend it
     if php is not None:

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -1119,7 +1119,7 @@ def _validate_input(kwargs,
         if isinstance(kwargs['command'], six.string_types):
             # Translate command into a list of strings
             try:
-                kwargs['command'] = shlex.split(kwargs['command'])
+                kwargs['command'] = salt.utils.shlex_split(kwargs['command'])
             except AttributeError:
                 pass
         try:
@@ -1263,7 +1263,7 @@ def _validate_input(kwargs,
         if isinstance(kwargs['entrypoint'], six.string_types):
             # Translate entrypoint into a list of strings
             try:
-                kwargs['entrypoint'] = shlex.split(kwargs['entrypoint'])
+                kwargs['entrypoint'] = salt.utils.shlex_split(kwargs['entrypoint'])
             except AttributeError:
                 pass
         try:

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -780,7 +780,7 @@ def sed(path,
 
     cmd = ['sed']
     cmd.append('-i{0}'.format(backup) if backup else '-i')
-    cmd.extend(shlex.split(options))
+    cmd.extend(salt.utils.shlex_split(options))
     cmd.append(
         r'{limit}{negate_match}s/{before}/{after}/{flags}'.format(
             limit='/{0}/ '.format(limit) if limit else '',
@@ -827,7 +827,7 @@ def sed_contains(path,
         options = options.replace('-r', '-E')
 
     cmd = ['sed']
-    cmd.extend(shlex.split(options))
+    cmd.extend(salt.utils.shlex_split(options))
     cmd.append(
         r'{limit}s/{before}/$/{flags}'.format(
             limit='/{0}/ '.format(limit) if limit else '',
@@ -2252,7 +2252,7 @@ def patch(originalfile, patchfile, options='', dry_run=False):
         )
 
     cmd = [patchpath]
-    cmd.extend(shlex.split(options))
+    cmd.extend(salt.utils.shlex_split(options))
     if dry_run:
         if __grains__['kernel'] in ('FreeBSD', 'OpenBSD'):
             cmd.append('-C')
@@ -4937,9 +4937,9 @@ def grep(path,
     split_opts = []
     for opt in opts:
         try:
-            opt = shlex.split(opt)
+            opt = salt.utils.shlex_split(opt)
         except AttributeError:
-            opt = shlex.split(str(opt))
+            opt = salt.utils.shlex_split(str(opt))
         if len(opt) > 1:
             salt.utils.warn_until(
                 'Carbon',

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -22,7 +22,6 @@ import logging
 import operator
 import os
 import re
-import shlex
 import shutil
 import stat
 import sys

--- a/salt/modules/freebsdjail.py
+++ b/salt/modules/freebsdjail.py
@@ -122,7 +122,7 @@ def show_config(jail):
     ret = {}
     if subprocess.call(["jls", "-nq", "-j", jail]) == 0:
         jls = subprocess.check_output(["jls", "-nq", "-j", jail])  # pylint: disable=minimum-python-version
-        jailopts = shlex.split(salt.utils.to_str(jls))
+        jailopts = salt.utils.shlex_split(salt.utils.to_str(jls))
         for jailopt in jailopts:
             if '=' not in jailopt:
                 ret[jailopt.strip().rstrip(";")] = '1'

--- a/salt/modules/freebsdjail.py
+++ b/salt/modules/freebsdjail.py
@@ -6,7 +6,6 @@ The jail module for FreeBSD
 # Import python libs
 from __future__ import absolute_import
 import os
-import shlex
 import re
 
 # Import salt libs

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -9,7 +9,6 @@ import copy
 import errno
 import logging
 import os
-import shlex
 from distutils.version import LooseVersion as _LooseVersion
 
 # Import salt libs

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -117,7 +117,7 @@ def _format_opts(opts):
         if not isinstance(opts, six.string_types):
             opts = [str(opts)]
         else:
-            opts = shlex.split(opts)
+            opts = salt.utils.shlex_split(opts)
     try:
         if opts[-1] == '--':
             # Strip the '--' if it was passed at the end of the opts string,
@@ -2398,7 +2398,7 @@ def rebase(cwd, rev='master', opts='', user=None, ignore_retcode=False):
     command.extend(opts)
     if not isinstance(rev, six.string_types):
         rev = str(rev)
-    command.extend(shlex.split(rev))
+    command.extend(salt.utils.shlex_split(rev))
     return _git_run(command,
                     cwd=cwd,
                     runas=user,

--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -932,7 +932,7 @@ def _parse_conf(conf_file=None, in_mem=False, family='ipv4'):
             ret[table][chain]['rules'] = []
             ret[table][chain]['rules_comment'] = {}
         elif line.startswith('-A'):
-            args = shlex.split(line)
+            args = salt.utils.shlex_split(line)
             index = 0
             while index + 1 < len(args):
                 swap = args[index] == '!' and args[index + 1].startswith('-')

--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -9,7 +9,6 @@ import os
 import re
 import sys
 import uuid
-import shlex
 import string
 
 # Import salt libs

--- a/salt/modules/rbenv.py
+++ b/salt/modules/rbenv.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 import os
 import re
 import logging
-import shlex
 
 # Import Salt libs
 import salt.utils

--- a/salt/modules/rbenv.py
+++ b/salt/modules/rbenv.py
@@ -47,12 +47,12 @@ def __virtual__():
 
 
 def _shlex_split(s):
-    # from python:shlex.split: passing None for s will read
+    # from python:salt.utils.shlex_split: passing None for s will read
     # the string to split from standard input.
     if s is None:
-        ret = shlex.split('')
+        ret = salt.utils.shlex_split('')
     else:
-        ret = shlex.split(s)
+        ret = salt.utils.shlex_split(s)
 
     return ret
 
@@ -379,9 +379,9 @@ def do(cmdline, runas=None):
     environ = {'PATH': '{0}/shims:{1}'.format(path, os.environ['PATH'])}
 
     try:
-        cmdline = shlex.split(cmdline)
+        cmdline = salt.utils.shlex_split(cmdline)
     except AttributeError:
-        cmdline = shlex.split(str(cmdline))
+        cmdline = salt.utils.shlex_split(str(cmdline))
 
     result = __salt__['cmd.run_all'](
         cmdline,
@@ -415,9 +415,9 @@ def do_with_ruby(ruby, cmdline, runas=None):
         raise SaltInvocationError('Command must be specified')
 
     try:
-        cmdline = shlex.split(cmdline)
+        cmdline = salt.utils.shlex_split(cmdline)
     except AttributeError:
-        cmdline = shlex.split(str(cmdline))
+        cmdline = salt.utils.shlex_split(str(cmdline))
 
     if ruby:
         cmd = ['RBENV_VERSION={0}'.format(ruby)] + cmdline

--- a/salt/modules/rvm.py
+++ b/salt/modules/rvm.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import
 import re
 import os
 import logging
-import shlex
 
 # Import salt libs
 import salt.utils

--- a/salt/modules/rvm.py
+++ b/salt/modules/rvm.py
@@ -11,6 +11,7 @@ import logging
 import shlex
 
 # Import salt libs
+import salt.utils
 from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
@@ -452,7 +453,7 @@ def do(ruby, command, runas=None, cwd=None):  # pylint: disable=C0103
         salt '*' rvm.do 2.0.0 <command>
     '''
     try:
-        command = shlex.split(command)
+        command = salt.utils.shlex_split(command)
     except AttributeError:
-        command = shlex.split(str(command))
+        command = salt.utils.shlex_split(str(command))
     return _rvm_do(ruby, command, runas=runas, cwd=cwd)

--- a/salt/modules/svn.py
+++ b/salt/modules/svn.py
@@ -9,6 +9,7 @@ import re
 import shlex
 
 # Import salt libs
+import salt.utils
 from salt import utils, exceptions
 
 _INI_RE = re.compile(r"^([^:]+):\s+(\S.*)$", re.M)
@@ -112,7 +113,7 @@ def info(cwd,
     if fmt == 'xml':
         opts.append('--xml')
     if targets:
-        opts += shlex.split(targets)
+        opts += salt.utils.shlex_split(targets)
     infos = _run_svn('info', cwd, user, username, password, opts)
 
     if fmt in ('str', 'xml'):
@@ -241,7 +242,7 @@ def update(cwd, targets=None, user=None, username=None, password=None, *opts):
         salt '*' svn.update /path/to/repo
     '''
     if targets:
-        opts += tuple(shlex.split(targets))
+        opts += tuple(salt.utils.shlex_split(targets))
     return _run_svn('update', cwd, user, username, password, opts)
 
 
@@ -275,7 +276,7 @@ def diff(cwd, targets=None, user=None, username=None, password=None, *opts):
         salt '*' svn.diff /path/to/repo
     '''
     if targets:
-        opts += tuple(shlex.split(targets))
+        opts += tuple(salt.utils.shlex_split(targets))
     return _run_svn('diff', cwd, user, username, password, opts)
 
 
@@ -320,7 +321,7 @@ def commit(cwd,
     if msg:
         opts += ('-m', msg)
     if targets:
-        opts += tuple(shlex.split(targets))
+        opts += tuple(salt.utils.shlex_split(targets))
     return _run_svn('commit', cwd, user, username, password, opts)
 
 
@@ -352,7 +353,7 @@ def add(cwd, targets, user=None, username=None, password=None, *opts):
         salt '*' svn.add /path/to/repo /path/to/new/file
     '''
     if targets:
-        opts += tuple(shlex.split(targets))
+        opts += tuple(salt.utils.shlex_split(targets))
     return _run_svn('add', cwd, user, username, password, opts)
 
 
@@ -395,7 +396,7 @@ def remove(cwd,
     if msg:
         opts += ('-m', msg)
     if targets:
-        opts += tuple(shlex.split(targets))
+        opts += tuple(salt.utils.shlex_split(targets))
     return _run_svn('remove', cwd, user, username, password, opts)
 
 
@@ -429,7 +430,7 @@ def status(cwd, targets=None, user=None, username=None, password=None, *opts):
         salt '*' svn.status /path/to/repo
     '''
     if targets:
-        opts += tuple(shlex.split(targets))
+        opts += tuple(salt.utils.shlex_split(targets))
     return _run_svn('status', cwd, user, username, password, opts)
 
 

--- a/salt/modules/svn.py
+++ b/salt/modules/svn.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import
 
 # Import python libs
 import re
-import shlex
 
 # Import salt libs
 import salt.utils

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -742,10 +742,10 @@ def install(name=None, refresh=False, pkgs=None, saltenv='base', **kwargs):
                 arguments = ['/i', cached_pkg]
                 if pkginfo['version_num'].get('allusers', True):
                     arguments.append('ALLUSERS="1"')
-                arguments.extend(shlex.split(install_flags))
+                arguments.extend(salt.utils.shlex_split(install_flags))
             else:
                 cmd = cached_pkg
-                arguments = shlex.split(install_flags)
+                arguments = salt.utils.shlex_split(install_flags)
 
             # Create Scheduled Task
             __salt__['task.create_task'](name='update-salt-software',
@@ -769,7 +769,7 @@ def install(name=None, refresh=False, pkgs=None, saltenv='base', **kwargs):
                     cmd.append('ALLUSERS="1"')
             else:
                 cmd.append(cached_pkg)
-            cmd.extend(shlex.split(install_flags))
+            cmd.extend(salt.utils.shlex_split(install_flags))
             # Launch the command
             result = __salt__['cmd.run_stdout'](cmd,
                                                 cache_path,
@@ -963,10 +963,10 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
             if pkginfo[version_num].get('msiexec'):
                 cmd = 'msiexec.exe'
                 arguments = ['/x']
-                arguments.extend(shlex.split(uninstall_flags))
+                arguments.extend(salt.utils.shlex_split(uninstall_flags))
             else:
                 cmd = expanded_cached_pkg
-                arguments = shlex.split(uninstall_flags)
+                arguments = salt.utils.shlex_split(uninstall_flags)
 
             # Create Scheduled Task
             __salt__['task.create_task'](name='update-salt-software',
@@ -988,7 +988,7 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
                 cmd.extend(['msiexec', '/x', expanded_cached_pkg])
             else:
                 cmd.append(expanded_cached_pkg)
-            cmd.extend(shlex.split(uninstall_flags))
+            cmd.extend(salt.utils.shlex_split(uninstall_flags))
             # Launch the command
             result = __salt__['cmd.run_stdout'](cmd,
                                                 output_loglevel='trace',

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -24,7 +24,6 @@ try:
 except ImportError:
     import msgpack_pure as msgpack
 # pylint: enable=import-error
-import shlex
 
 # Import salt libs
 from salt.exceptions import CommandExecutionError, SaltRenderError

--- a/salt/roster/ansible.py
+++ b/salt/roster/ansible.py
@@ -96,7 +96,6 @@ from __future__ import absolute_import
 import os
 import re
 import fnmatch
-import shlex
 import json
 import subprocess
 

--- a/salt/roster/ansible.py
+++ b/salt/roster/ansible.py
@@ -210,7 +210,7 @@ class Inventory(Target):
         '''
         Parse lines in the inventory file that are under the same group block
         '''
-        line_args = shlex.split(line)
+        line_args = salt.utils.shlex_split(line)
         name = line_args[0]
         host = {line_args[0]: dict()}
         for arg in line_args[1:]:

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -253,7 +253,7 @@ def _reinterpreted_state(state):
             out = out[idx + 1:]
         data = {}
         try:
-            for item in shlex.split(out):
+            for item in salt.utils.shlex_split(out):
                 key, val = item.split('=')
                 data[key] = val
         except ValueError:

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -206,7 +206,6 @@ from __future__ import absolute_import
 import os
 import copy
 import json
-import shlex
 import logging
 
 HAS_GRP = False

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -2882,7 +2882,7 @@ def shlex_split(s, **kwargs):
     '''
     Only split if variable is a string
     '''
-    if isinstance(s, basestring):
+    if isinstance(s, six.string_types):
         return shlex.split(s, **kwargs)
     else:
         return s

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -2878,6 +2878,7 @@ def invalid_kwargs(invalid_kwargs, raise_exc=True):
     else:
         return msg
 
+
 def shlex_split(s, **kwargs):
     '''
     Only split if variable is a string

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -2877,3 +2877,12 @@ def invalid_kwargs(invalid_kwargs, raise_exc=True):
         raise SaltInvocationError(msg)
     else:
         return msg
+
+def shlex_split(s, **kwargs):
+    '''
+    Only split if variable is a string
+    '''
+    if isinstance(s, basestring):
+        return shlex.split(s, **kwargs)
+    else:
+        return s

--- a/salt/utils/find.py
+++ b/salt/utils/find.py
@@ -92,7 +92,6 @@ import stat
 import shutil
 import sys
 import time
-import shlex
 from subprocess import Popen, PIPE
 try:
     import grp

--- a/salt/utils/find.py
+++ b/salt/utils/find.py
@@ -559,8 +559,8 @@ class ExecOption(Option):
     def execute(self, fullpath, fstat, test=False):
         try:
             command = self.command.replace('{}', fullpath)
-            print(shlex.split(command))
-            p = Popen(shlex.split(command),
+            print(salt.utils.shlex_split(command))
+            p = Popen(salt.utils.shlex_split(command),
                       stdout=PIPE,
                       stderr=PIPE)
             (out, err) = p.communicate()

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1173,7 +1173,7 @@ def _freebsd_remotes_on(port, which_end):
     remotes = set()
 
     try:
-        cmd = shlex.split('sockstat -4 -c -p {0}'.format(port))
+        cmd = salt.utils.shlex_split('sockstat -4 -c -p {0}'.format(port))
         data = subprocess.check_output(cmd)  # pylint: disable=minimum-python-version
     except subprocess.CalledProcessError as ex:
         log.error('Failed "sockstat" with returncode = {0}'.format(ex.returncode))

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -7,7 +7,6 @@ Define some generic socket functions for network modules
 from __future__ import absolute_import
 import os
 import re
-import shlex
 import socket
 import logging
 from string import ascii_letters, digits


### PR DESCRIPTION
The recently added calls to shlex.split can cause improper results when shlex.split tries to split a value that is already a list. This adds a util function `shlex.split` that checks to make sure the value being split is a string.

As an example, a value coming in to `rbenv.do_with_ruby` of `['gem', 'list', 'bundler']`, gets mangled to: `['[[gem,,', 'list,,', 'bundler]]']` by the time it is actually executed upon which time it fails as an invalid command.
