### PR TITLE
Account for new headers class in tornado 4.3

### DIFF
--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -1608,7 +1608,12 @@ class WebhookSaltAPIHandler(SaltAPIHandler):  # pylint: disable=W0223
 
         ret = self.event.fire_event({
             'post': self.raw_data,
-            'headers': self.request.headers,
+            # In Tornado >= v4.0.3, the headers come
+            # back as an HTTPHeaders instance, which
+            # is a dictionary. We must cast this as
+            # a dictionary in order for msgpack to
+            # serialize it.
+            'headers': dict(self.request.headers),
         }, tag)
 
         self.write(self.serialize({'success': ret}))


### PR DESCRIPTION
This started to fail with the test:  integration.netapi.rest_tornado.test_app.TestWebhookSaltAPIHandler.test_post

This happened with the introduction of Tornado 4.3 wherein headers were delivered as a subclass of a python dict, called HTTPHeaders http://www.tornadoweb.org/en/stable/releases/v4.3.0.html

This in turn caused msgpack serialization errors as we couldn't figure out how to serialize the new class. (Somewhat ironically, since the upstream change was made to better support serialization, but c'est la vie). Instead of trying to give hints to our serialialization lib, it seemed more sensible just to cast this back into a python dictionary before we put it onto the event bus.

Tested against tornado 4.3 and 4.2
