### PR TITLE
Account for no POST data

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -693,7 +693,7 @@ def lowdata_fmt():
     # if the data was sent as urlencoded, we need to make it a list.
     # this is a very forgiving implementation as different clients set different
     # headers for form encoded data (including charset or something similar)
-    if not isinstance(data, list):
+    if data and not isinstance(data, list):
         # Make the 'arg' param a list if not already
         if 'arg' in data and not isinstance(data['arg'], list):
             data['arg'] = [data['arg']]
@@ -2225,7 +2225,9 @@ class Webhook(object):
         '''
         tag = '/'.join(itertools.chain(self.tag_base, args))
         data = cherrypy.serving.request.unserialized_data
-        raw_body = cherrypy.serving.request.raw_body
+        if not data:
+            data = {}
+        raw_body = getattr(cherrypy.serving.request, 'raw_body', '')
         headers = dict(cherrypy.request.headers)
 
         ret = self.event.fire_event({


### PR DESCRIPTION
The serving.request doesn't include a raw_body when the POST data
is blank, so use getattr to give us a default value of "" ( which is the same value it's set to with a real POST anyways ).

cherrypy.serving.request.unserialized_data is also set to 'None' on a null POST, which shows up in the salt event data as 'null', rather than the normal dict, so if we don't have data, switch it to an empty dict.

Also fixed a bug where we assumed that if data wasn't a list, it was a dict, which bombs because null POSTS result in None.

Fixes #28714
