### PR TITLE
Fixes to salt scheduler in 2015.5, ensuring that return_job is only used on minion scheduler

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -562,17 +562,20 @@ class Schedule(object):
                             )
                         )
 
-            if 'return_job' in data and not data['return_job']:
-                pass
-            else:
-                # Send back to master so the job is included in the job list
-                mret = ret.copy()
-                mret['jid'] = 'req'
-                channel = salt.transport.Channel.factory(self.opts, usage='salt_schedule')
-                load = {'cmd': '_return', 'id': self.opts['id']}
-                for key, value in mret.items():
-                    load[key] = value
-                channel.send(load)
+            # Only attempt to return data to the master
+            # if the scheduled job is running on a minion.
+            if '__role' in self.opts and self.opts['__role'] == 'minion':
+                if 'return_job' in data and not data['return_job']:
+                    pass
+                else:
+                    # Send back to master so the job is included in the job list
+                    mret = ret.copy()
+                    mret['jid'] = 'req'
+                    channel = salt.transport.Channel.factory(self.opts, usage='salt_schedule')
+                    load = {'cmd': '_return', 'id': self.opts['id']}
+                    for key, value in mret.items():
+                        load[key] = value
+                    channel.send(load)
 
         except Exception:
             log.exception("Unhandled exception running {0}".format(ret['fun']))


### PR DESCRIPTION
Fixing the salt scheduler so that it only attempts to return the job data to the master if the scheduled job is running from a minion's scheduler. #27392
