### PR TITLE
Add missing S3 module import

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -28,6 +28,7 @@ import salt.utils.templates
 import salt.utils.url
 import salt.utils.gzip_util
 import salt.utils.http
+import salt.utils.s3
 from salt.utils.locales import sdecode
 from salt.utils.openstack.swift import SaltSwift
 


### PR DESCRIPTION
In the get_url method in fileclient.py, a salt.utils.s3.query method call is made, but this won't work unless the salt.utils.s3 module is imported first. This missing line breaks file.managed resources where source and source_hash attributes use s3:// style URLs.
