### PR TITLE
Allow excluding minion in mine.get

### DIFF
--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -272,11 +272,11 @@ def get(tgt, fun, expr_form='glob', exclude_minion=False):
             'fun': fun,
             'expr_form': expr_form,
     }
-    ret = _mine_get(load, __opts__)                                                                                                                                                                                                                                                          
-    if exclude_minion:                                                                                                                                                                                                                                                                       
-        if __opts__['id'] in ret:                                                                                                                                                                                                                                                            
-            del ret[__opts__['id']]                                                                                                                                                                                                                                                          
-    return ret 
+    ret = _mine_get(load, __opts__)
+    if exclude_minion:
+        if __opts__['id'] in ret:
+            del ret[__opts__['id']]
+    return ret
 
 
 def delete(fun):

--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -203,7 +203,7 @@ def send(func, *args, **kwargs):
     return _mine_send(load, __opts__)
 
 
-def get(tgt, fun, expr_form='glob'):
+def get(tgt, fun, expr_form='glob', exclude_minion=False):
     '''
     Get data from the mine based on the target, function and expr_form
 
@@ -220,6 +220,9 @@ def get(tgt, fun, expr_form='glob'):
 
     Note that all pillar matches, whether using the compound matching system or
     the pillar matching system, will be exact matches, with globbing disabled.
+
+    exclude_minion
+        Excludes the current minion from the result set
 
     CLI Example:
 
@@ -269,7 +272,11 @@ def get(tgt, fun, expr_form='glob'):
             'fun': fun,
             'expr_form': expr_form,
     }
-    return _mine_get(load, __opts__)
+    ret = _mine_get(load, __opts__)                                                                                                                                                                                                                                                          
+    if exclude_minion:                                                                                                                                                                                                                                                                       
+        if __opts__['id'] in ret:                                                                                                                                                                                                                                                            
+            del ret[__opts__['id']]                                                                                                                                                                                                                                                          
+    return ret 
 
 
 def delete(fun):


### PR DESCRIPTION
Adds the functionality described in #19629 to exclude the minion making the mine call from the result set.
