### PR TITLE
[Saltnado] - Add support for CORS preflight request for parametrized urls

### DIFF
--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -587,7 +587,7 @@ class BaseSaltAPIHandler(tornado.web.RequestHandler, SaltClientsMixIn):  # pylin
             if allowed_origin:
                 self.set_header("Access-Control-Allow-Origin", allowed_origin)
 
-    def options(self):
+    def options(self, *args, **kwargs):
         '''
         Return CORS headers for preflight requests
         '''


### PR DESCRIPTION
The implementation was broken for jobs and minions handlers, I added a test and the fix.
