### PR TITLE
Bug fix: pip command to not quote spaces in cmd line args

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -646,7 +646,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
             cmd.append('--pre')
 
     if cert:
-        cmd.append(['--cert', cert])
+        cmd.extend(['--cert', cert])
 
     if global_options:
         if isinstance(global_options, string_types):
@@ -697,7 +697,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
             allow_external = [p.strip() for p in allow_external.split(',')]
 
         for pkg in allow_external:
-            cmd.append('--allow-external {0}'.format(pkg))
+            cmd.extend(['--allow-external', pkg])
 
     if allow_unverified:
         if isinstance(allow_unverified, string_types):
@@ -705,7 +705,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
                 [p.strip() for p in allow_unverified.split(',')]
 
         for pkg in allow_unverified:
-            cmd.append('--allow-unverified {0}'.format(pkg))
+            cmd.extend(['--allow-unverified', pkg])
 
     if process_dependency_links:
         cmd.append('--process-dependency-links')
@@ -717,7 +717,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
             raise CommandExecutionError('env_vars {0} is not a dictionary'.format(env_vars))
 
     if trusted_host:
-        cmd.append('--trusted-host {0}'.format(trusted_host))
+        cmd.extend(['--trusted-host', trusted_host])
 
     try:
         cmd_kwargs = dict(cwd=cwd, saltenv=saltenv, use_vt=use_vt, runas=user)


### PR DESCRIPTION
With a pip state that involves the trusted_host option in both 2015.8.1 and in the HEAD of 2015.8:

```
foobar-pip-initial-requirements:
  pip.installed:
    - bin_env: /home/foobar
    - requirements: /home/foobar/requirements.txt
    - user: ubuntu
    - trusted_host: foobar.com
```

I get this error:

```
----------
          ID: foobar-pip-initial-requirements
    Function: pip.installed
      Result: False
     Comment: Unable to process requirements file "/home/foobar/requirements.txt". Error:
              Usage:
                pip install [options] <requirement specifier> [package-index-options] ...
                pip install [options] -r <requirements file> [package-index-options] ...
                pip install [options] [-e] <vcs project url> ...
                pip install [options] [-e] <local project path> ...
                pip install [options] <archive url/path> ...

              no such option: --trusted-host foobar.com
     Started: 16:23:34.561430
    Duration: 880.101 ms
     Changes:
```

I traced this down to the pip module quoting the space inside the command being run. With this fix, the pip command runs successfully, properly trusting my non-HTTPS hosted package specified inside the requirements.txt file.

While I was there, I also changed several other places which had suspicious use of spaces, and fixed a place where list.append was used where list.extend should have been.

Side note: in surveying the rest of the code, there are suspicious similar usage of spaces that would get quoted in modules/btrfs.py and modules/xfs.py.
