### PR TITLE
Fixing CherryPy key bug

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -1108,6 +1108,7 @@ class Keys(LowDataAdapter):
     module <salt.wheel.key>` functions.
     '''
 
+    @cherrypy.config(**{'tools.salt_token.on': True})
     def GET(self, mid=None):
         '''
         Show the list of minion keys or detail on a specific key
@@ -1175,8 +1176,6 @@ class Keys(LowDataAdapter):
               minions:
                 jerry: 51:93:b3:d0:9f:3a:6d:e5:28:67:c2:4b:27:d6:cd:2b
         '''
-        self._cp_config['tools.salt_token.on'] = True
-
         if mid:
             lowstate = [{
                 'client': 'wheel',
@@ -1194,6 +1193,7 @@ class Keys(LowDataAdapter):
 
         return {'return': next(result, {}).get('data', {}).get('return', {})}
 
+    @cherrypy.config(**{'tools.hypermedia_out.on': False, 'tools.sessions.on': False})
     def POST(self, mid, keysize=None, force=None, **kwargs):
         r'''
         Easily generate keys for a minion and auto-accept the new key
@@ -1254,9 +1254,6 @@ class Keys(LowDataAdapter):
 
             jerry.pub0000644000000000000000000000070300000000000010730 0ustar  00000000000000
         '''
-        self._cp_config['tools.hypermedia_out.on'] = False
-        self._cp_config['tools.sessions.on'] = False
-
         lowstate = [{
             'client': 'wheel',
             'fun': 'key.gen_accept',


### PR DESCRIPTION
This issue resolves #28732, #22451, #22442 and #22452. 

This has been tested on `2015.5` and `develop`

``` bash
[INFO    ] 10.28.13.30 - - [11/Nov/2015:06:19:46] "POST /keys HTTP/1.1" 200 10240 "" "curl/7.22.0 (x86_64-pc-linux-gnu) libcurl/7.22.0 OpenSSL/1.0.2d zlib/1.2.3.4 libidn/1.23 librtmp/2.3"
[INFO    ] [11/Nov/2015:06:19:46] ENGINE Started monitor thread 'Session cleanup'.
[INFO    ] 10.28.13.30 - - [11/Nov/2015:06:19:46] "POST /login HTTP/1.1" 200 170 "" "curl/7.22.0 (x86_64-pc-linux-gnu) libcurl/7.22.0 OpenSSL/1.0.2d zlib/1.2.3.4 libidn/1.23 librtmp/2.3"
[INFO    ] 10.28.13.30 - - [11/Nov/2015:06:19:49] "GET /keys HTTP/1.1" 200 206887 "" "curl/7.22.0 (x86_64-pc-linux-gnu) libcurl/7.22.0 OpenSSL/1.0.2d zlib/1.2.3.4 libidn/1.23 librtmp/2.3"
```

@whiteinge @jfindlay could you merge this into develop too.
