### PR TITLE
2015.8

### DIFF
--- a/salt/modules/puppet.py
+++ b/salt/modules/puppet.py
@@ -156,17 +156,19 @@ def run(*args, **kwargs):
     '''
     _check_puppet()
     puppet = _Puppet()
-
-    if args:
+    
+    # new args tuple to filter out agent/apply for _Puppet.arguments()     
+    buildargs = ()
+    for arg in range(len(args)):
         # based on puppet documentation action must come first. making the same
         # assertion. need to ensure the list of supported cmds here matches
         # those defined in _Puppet.arguments()
-        if args[0] in ['agent', 'apply']:
-            puppet.subcmd = args[0]
-            puppet.arguments(args[1:])
-    else:
-        # args will exist as an empty list even if none have been provided
-        puppet.arguments(args)
+        if args[arg] in ['agent', 'apply']:
+            puppet.subcmd = args[arg]
+        else:
+            buildargs += (args[arg],)
+    # args will exist as an empty list even if none have been provided
+    puppet.arguments(buildargs)
 
     puppet.kwargs.update(salt.utils.clean_kwargs(**kwargs))
 

--- a/salt/modules/puppet.py
+++ b/salt/modules/puppet.py
@@ -16,7 +16,7 @@ from salt.exceptions import CommandExecutionError
 # Import 3rd-party libs
 import yaml
 import salt.ext.six as six
-
+from salt.ext.six.moves import range
 log = logging.getLogger(__name__)
 
 

--- a/salt/modules/puppet.py
+++ b/salt/modules/puppet.py
@@ -156,8 +156,8 @@ def run(*args, **kwargs):
     '''
     _check_puppet()
     puppet = _Puppet()
-    
-    # new args tuple to filter out agent/apply for _Puppet.arguments()     
+
+    # new args tuple to filter out agent/apply for _Puppet.arguments()
     buildargs = ()
     for arg in range(len(args)):
         # based on puppet documentation action must come first. making the same


### PR DESCRIPTION
Proposed fix for #28692. Fixes bug when running puppet.noop with no arguemtns results in an empty puppet run. Or when running puppet.run with argumetns, but not providing agent as the first argument. 
