### PR TITLE
closes #28783

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -430,7 +430,7 @@ def get_saved_rules(conf_file=None, family='ipv4'):
         IPv6:
         salt '*' iptables.get_saved_rules family=ipv6
     '''
-    return _parse_conf(conf_file, family)
+    return _parse_conf(conf_file=conf_file, family=family)
 
 
 def get_rules(family='ipv4'):


### PR DESCRIPTION
Passing family in get_saved_rules to _parse_conf correctly.
