### PR TITLE
salt.module.zfs now works on solaris

### DIFF
--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -54,7 +54,7 @@ def _available_commands():
     # This bit is dependent on specific output from `zfs -?` - any major changes
     # in how this works upstream will require a change.
     for line in res.splitlines():
-        if re.match('	[a-zA-Z]', line):
+        if re.match('  [a-zA-Z]', line):
             cmds = line.split(' ')[0].split('|')
             doc = ' '.join(line.split(' ')[1:])
             for cmd in [cmd.strip() for cmd in cmds]:
@@ -80,6 +80,7 @@ def __virtual__():
     '''
     on_freebsd = __grains__['kernel'] == 'FreeBSD'
     on_linux = __grains__['kernel'] == 'Linux'
+    on_solaris = __grains__['kernel'] == 'SunOS' and __grains__['kernelrelease'] == '5.11'
 
     cmd = ''
     if on_freebsd:
@@ -90,6 +91,9 @@ def __virtual__():
             cmd = '{0} zfs'.format(modinfo)
         else:
             cmd = 'ls /sys/module/zfs'
+    elif on_solaris:
+        # not using salt.utils.which('zfs') to keep compatible with others
+        cmd = 'which zfs'
 
     if cmd and salt.modules.cmdmod.retcode(
         cmd, output_loglevel='quiet', ignore_retcode=True


### PR DESCRIPTION
As mentioned in #28779 salt.module.zfs does not get enabled on solaris.
This small commit fixes that, it does not fix any of the other things mentioned in the issue.

Not sure why line 57 is marked as changed, I tried on 3 different computers and it keeps getting marked :/
