### PR TITLE
Update grains before setting self.opts['pillar']

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -763,6 +763,7 @@ class Minion(MinionBase):
         '''
         self.opts['master'] = master
 
+        self.functions, self.returners, self.function_errors, self.executors = self._load_modules()
         self.opts['pillar'] = yield salt.pillar.get_async_pillar(
             self.opts,
             self.opts['grains'],
@@ -770,7 +771,6 @@ class Minion(MinionBase):
             self.opts['environment'],
             pillarenv=self.opts.get('pillarenv')
         ).compile_pillar()
-        self.functions, self.returners, self.function_errors, self.executors = self._load_modules()
         self.serial = salt.payload.Serial(self.opts)
         self.mod_opts = self._prep_mod_opts()
         self.matcher = Matcher(self.opts, self.functions)


### PR DESCRIPTION
Grains network information may not be ready the first time grains are
loaded (on minion init). On connect, grains information is re-loaded on
_post_master_init. However, self.opts['pillar'] is updated right before
grains are reloaded, causing the master cache to have outdated network
information.

Signed-off-by: Alejandro del Castillo alejandro.delcastillo@ni.com
