### PR TITLE
Use '.' for tpldir if in root directory [fixes #4348]

### DIFF
--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -116,7 +116,7 @@ class SaltCacheLoader(BaseLoader):
             tpldir = path.dirname(template).replace('\\', '/')
             tpldata = {
                 'tplfile': template,
-                'tpldir': tpldir,
+                'tpldir': '.' if tpldir == '' else tpldir,
                 'tpldot': tpldir.replace('/', '.'),
             }
             environment.globals.update(tpldata)

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -141,7 +141,7 @@ def wrap_tmpl_func(render_str):
                 tpldir = os.path.dirname(template).replace('\\', '/')
                 tpldata = {
                     'tplfile': template,
-                    'tpldir': tpldir,
+                    'tpldir': '.' if tpldir == '' else tpldir,
                     'tpldot': tpldir.replace('/', '.'),
                 }
                 context.update(tpldata)


### PR DESCRIPTION
This resolves an issue when the var is used for relative paths for
templates in the root formula.

`salt://./path/to/asset` is valid, but `salt:///path/to/asset` is not.
