### PR TITLE
boto_ec2: support subnet_name when creating a network interface

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1829,6 +1829,9 @@ def exactly_n(l, n=1):
 
 
 def exactly_one(l):
+    '''
+    Check if only one item is not None, False, or 0 in an iterable.
+    '''
     return exactly_n(l)
 
 


### PR DESCRIPTION
This allows to specify `subnet_name` when creating a network interface:

```
aws_ec2_network:
  module:
    - run
    - name: boto_ec2.create_network_interface
    - m_name: salt
    - subnet_name: Public
    - private_ip_address: 172.16.0.4
    - description: Gateway
    - groups: ['salt']
    - region: {{ region }}
    - keyid: {{ key }}
    - key: "{{ secret }}"
    - require:
      - boto_secgroup: aws_ec2_secgroup
```
