### PR TITLE
Enhance 'which' decorator reliability

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -543,7 +543,7 @@ def which(exe=None):
         for default_path in ['/bin', '/sbin', '/usr/bin', '/usr/sbin', '/usr/local/bin']:
             if default_path not in search_path:
                 search_path.append(default_path)
-
+        os.environ['PATH'] = os.pathsep.join(search_path)
         for path in search_path:
             full_path = os.path.join(path, exe)
             if _is_executable_file_or_link(full_path):

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -537,9 +537,13 @@ def which(exe=None):
                     continue
             return False
 
-        # enhance POSIX path for the reliability at some environments, when $PATH is changing
-        default_path = '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin'
-        search_path = list(set(os.pathsep.join([os.environ.get('PATH', ''), default_path]).split(os.pathsep)))
+        # Enhance POSIX path for the reliability at some environments, when $PATH is changing
+        # This also keeps order, where 'first came, first win' for cases to find optional alternatives
+        search_path = os.environ.get('PATH') and os.environ['PATH'].split(os.pathsep) or list()
+        for default_path in ['/bin', '/sbin', '/usr/bin', '/usr/sbin', '/usr/local/bin']:
+            if default_path not in search_path:
+                search_path.append(default_path)
+
         for path in search_path:
             full_path = os.path.join(path, exe)
             if _is_executable_file_or_link(full_path):


### PR DESCRIPTION
In some automated systems, where vagrant or similar tools are involved, sometimes `$PATH` can be incorrect, which results to an errors.

I suggest always double-check the `$PATH` environment _with_ the default path _regardless_ what is the current setting. This also preserves _"First found, first win"_ ordering, in case one would need to override path to find `/opt/your/bin/foo` instead of `/usr/bin/foo`.
