### PR TITLE
Take into account a pygit2 bug

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -781,6 +781,7 @@ class Pygit2(GitProvider):
                 try:
                     self.repo = pygit2.Repository(self.cachedir)
                 except pygit2.GitError as exc:
+                    import pwd
                     # https://github.com/libgit2/pygit2/issues/339
                     # https://github.com/libgit2/libgit2/issues/2122
                     if "Error stat'ing config file" not in str(exc):


### PR DESCRIPTION
```
[root@jenkins-ee ~]# salt-master                                                                                                                                                               
[DEBUG   ] Configuration file path: /etc/salt/master
[WARNING ] Insecure logging configuration detected! Sensitive data may be logged.
[INFO    ] Setting up the Salt Master
[DEBUG   ] Loaded master key: /etc/salt/pki/master/master.pem
[INFO    ] Preparing the jenkins key for local communication
[DEBUG   ] Removing stale keyfile: /var/cache/salt/master/.jenkins_key
[INFO    ] Preparing the root key for local communication
[DEBUG   ] Removing stale keyfile: /var/cache/salt/master/.root_key
[DEBUG   ] Created pidfile: /var/run/salt-master.pid
[DEBUG   ] Chowned pidfile: /var/run/salt-master.pid to user: jenkins
[INFO    ] The salt master is starting up
[DEBUG   ] pygit2 gitfs_provider enabled
[DEBUG   ] LazyLoaded git.envs
[DEBUG   ] LazyLoaded roots.envs
[CRITICAL] Exception caught while initializing gitfs remote 'git://github.com/saltstack/jenkins-ci-states.git': /var/cache/salt/master/gitfs/b225659defa14fef94ac84d7d47c7fb1: Error stat'ing c
onfig file '/root/.gitconfig'
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/utils/gitfs.py", line 261, in __init__
    self.new = self.init_remote()
  File "/usr/lib/python2.7/site-packages/salt/utils/gitfs.py", line 781, in init_remote
    self.repo = pygit2.Repository(self.cachedir)
  File "/usr/lib64/python2.7/site-packages/pygit2/repository.py", line 59, in __init__
    super(Repository, self).__init__(*args, **kwargs)
GitError: /var/cache/salt/master/gitfs/b225659defa14fef94ac84d7d47c7fb1: Error stat'ing config file '/root/.gitconfig'
[CRITICAL] Failed to load gitfs
[CRITICAL] Master failed pre flight checks, exiting
```

/cc @terminalmage 
