### PR TITLE
[2015.5] Increase the default gather_job_timeout

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -607,7 +607,7 @@ DEFAULT_MASTER_OPTS = {
     'keysize': 2048,
     'transport': 'zeromq',
     'enumerate_proxy_minions': False,
-    'gather_job_timeout': 5,
+    'gather_job_timeout': 10,
     'syndic_event_forward_timeout': 0.5,
     'syndic_max_event_process_time': 0.5,
     'syndic_jid_forward_cache_hwm': 100,


### PR DESCRIPTION
If minions are offline, this will increase the total time it takes
for the CLI to realize they're offline and stop listening, but I
think that's a reasonable tradeoff for decreased issues with missing
real returns, like in #8647.

Fixes #8647
