### PR TITLE
some fixes for the new smartos state module

### DIFF
--- a/salt/states/smartos.py
+++ b/salt/states/smartos.py
@@ -408,8 +408,10 @@ def vm_present(name, vmconfig, config=None):
 
         Instances for the follow properties should have unique ids.
           - nic : mac
-          - disk : path
+          - disk : path or diskN for zvols
           - filesystem: target
+
+        e.g. disk0 will be the first disk added, disk1 the 2nd,...
 
     '''
     name = name.lower()

--- a/salt/states/smartos.py
+++ b/salt/states/smartos.py
@@ -2,9 +2,6 @@
 '''
 Management of SmartOS Standalone Compute Nodes
 
-TODO:
-- test disks
-
 .. code-block:: yaml
 
     test.example.org:

--- a/salt/states/smartos.py
+++ b/salt/states/smartos.py
@@ -16,14 +16,12 @@ TODO:
           - quota: 5
           - max_physical_memory: 512
           - nics:
-            -
-              - mac: "82:1b:8e:49:e9:12"
+            - "82:1b:8e:49:e9:12"
               - nic_tag: trunk
               - mtu: 1500
               - ips: [ "dhcp" ]
               - vlan_id: 10
-            -
-              - mac: "82:1b:8e:49:e9:13"
+            - "82:1b:8e:49:e9:13"
               - nic_tag: trunk
               - mtu: 1500
               - ips: [ "dhcp" ]

--- a/salt/states/smartos.py
+++ b/salt/states/smartos.py
@@ -580,6 +580,9 @@ def vm_present(name, vmconfig, config=None):
 
                 # find instance with matching ids
                 for current_cfg in vmconfig['current'][instance]:
+                    if vmconfig_type['instance'][instance] not in state_cfg:
+                        continue
+
                     if state_cfg[vmconfig_type['instance'][instance]] == current_cfg[vmconfig_type['instance'][instance]]:
                         # ids have matched, disable add instance
                         add_instance = False
@@ -603,6 +606,7 @@ def vm_present(name, vmconfig, config=None):
                             if 'update_{0}'.format(instance) not in vmconfig['changed']:
                                 vmconfig['changed']['update_{0}'.format(instance)] = []
 
+                            update_cfg[vmconfig_type['instance'][instance]] = state_cfg[vmconfig_type['instance'][instance]]
                             vmconfig['changed']['update_{0}'.format(instance)].append(update_cfg)
 
                 if add_instance:
@@ -611,11 +615,10 @@ def vm_present(name, vmconfig, config=None):
                         vmconfig['changed']['add_{0}'.format(instance)] = []
 
                     # add instance
-                    update_cfg[vmconfig_type['instance'][instance]] = state_cfg[vmconfig_type['instance'][instance]]
                     vmconfig['changed']['add_{0}'.format(instance)].append(state_cfg)
 
             # skip remove instances if none in current
-            if prop not in vmconfig['current']:
+            if instance not in vmconfig['current']:
                 continue
 
             # remove instances
@@ -624,6 +627,9 @@ def vm_present(name, vmconfig, config=None):
 
                 # find instance with matching ids
                 for state_cfg in vmconfig['state'][instance]:
+                    if vmconfig_type['instance'][instance] not in state_cfg:
+                        continue
+
                     if state_cfg[vmconfig_type['instance'][instance]] == current_cfg[vmconfig_type['instance'][instance]]:
                         # keep instance if matched
                         remove_instance = False


### PR DESCRIPTION
I got some feedback and made an improvement and fixed a few bugs
- vm_present now has 'key' value as section name vs being empty (also makes parsing cleaner)
- disks now get correctly added/removed
- improved error handling on update failures
- don't try to update filesystems (add_filesystem partially works but is not officially supported or documented, update_ and remove_ are completely broken in the backend tool)
