### PR TITLE
Boto ec2 eni updates

### DIFF
--- a/salt/modules/boto_ec2.py
+++ b/salt/modules/boto_ec2.py
@@ -272,6 +272,8 @@ def associate_eip_address(instance_id=None, instance_name=None, public_ip=None,
         (string) – Public IP address, for standard EC2 based allocations.
     allocation_id
         (string) – Allocation ID for a VPC-based EIP.
+    network_interface_id
+        (string) ID of the network interface to associate the EIP with
     private_ip_address
         (string) – The primary or secondary private IP address to associate with the Elastic IP address.
     allow_reassociation
@@ -288,9 +290,9 @@ def associate_eip_address(instance_id=None, instance_name=None, public_ip=None,
 
     .. versionadded:: Boron
     '''
-    if not _exactly_one((instance_id, instance_name)):
+    if not _exactly_one((instance_id, instance_name)) or not network_interface_id:
         raise SaltInvocationError('Exactly one (but not both) of \'instance_id\' '
-                                  'or \'instance_name\' must be provided')
+                                  'or \'instance_name\' must be provided or a network_interface_id')
 
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
@@ -300,10 +302,9 @@ def associate_eip_address(instance_id=None, instance_name=None, public_ip=None,
         except boto.exception.BotoServerError as e:
             log.error(e)
             return False
-
-    if not instance_id:
-        log.error("Given instance_name cannot be mapped to an instance_id")
-        return False
+        if not instance_id:
+            log.error("Given instance_name cannot be mapped to an instance_id")
+            return False
 
     try:
         return conn.associate_address(instance_id=instance_id, public_ip=public_ip,

--- a/salt/modules/boto_ec2.py
+++ b/salt/modules/boto_ec2.py
@@ -260,8 +260,8 @@ def associate_eip_address(instance_id=None, instance_name=None, public_ip=None,
         allocation_id=None, network_interface_id=None, private_ip_address=None,
         allow_reassociation=False, region=None, key=None, keyid=None, profile=None):
     '''
-    Associate an Elastic IP address with a currently running instance.  This
-    requires exactly one of either 'public_ip' or 'allocation_id', depending
+    Associate an Elastic IP address with a currently running instance or a network interface.
+    This requires exactly one of either 'public_ip' or 'allocation_id', depending
     on whether you’re associating a VPC address or a plain EC2 address.
 
     instance_id
@@ -290,9 +290,10 @@ def associate_eip_address(instance_id=None, instance_name=None, public_ip=None,
 
     .. versionadded:: Boron
     '''
-    if not _exactly_one((instance_id, instance_name)) or not network_interface_id:
-        raise SaltInvocationError('Exactly one (but not both) of \'instance_id\' '
-                                  'or \'instance_name\' must be provided or a network_interface_id')
+    if not network_interface_id:
+        if not _exactly_one((instance_id, instance_name)):
+            raise SaltInvocationError('Exactly one (but not both) of \'instance_id\' '
+                                      'or \'instance_name\' must be provided or a network_interface_id')
 
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 

--- a/salt/states/boto_ec2.py
+++ b/salt/states/boto_ec2.py
@@ -343,7 +343,7 @@ def eni_present(
                     arecord['value'] = eip_alloc['public_ip']
                 else:
                     msg = 'Unable to add an A record for the public IP address, a public IP address does not seem to be allocated to this ENI.'
-                    raise CommandExectuionError(msg)
+                    raise CommandExecutionError(msg)
             else:
                 arecord['value'] = r['result']['private_ip_address']
             if 'provider' in arecord:

--- a/salt/states/boto_ec2.py
+++ b/salt/states/boto_ec2.py
@@ -172,7 +172,9 @@ def eni_present(
         region=None,
         key=None,
         keyid=None,
-        profile=None):
+        profile=None,
+        allocate_eip=False,
+        arecords=None):
     '''
     Ensure the EC2 ENI exists.
 
@@ -211,6 +213,18 @@ def eni_present(
     profile
         A dict with region, key and keyid, or a pillar key (string)
         that contains a dict with region, key and keyid.
+
+    allocate_eip
+        .. versionadded:: Boron
+        True/False - allocate and associate an EIP to the ENI
+
+    arecords
+        .. versionadded:: Boron
+        A list of arecord dicts with attributes needed for the DNS add_record state.
+        By default the boto_route53.add_record state will be used, which requires: name, zone, ttl, and identifier.
+        See the boto_route53 state for information about these attributes.
+        Other DNS modules can be called by specifying the provider keyword.
+        By default, the private ENI IP address will be used, set 'public: True' in the arecord dict to use the ENI's public IP address
     '''
     if not subnet_id:
         raise SaltInvocationError('subnet_id is a required argument.')
@@ -278,6 +292,79 @@ def eni_present(
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
     if not _ret['result']:
         ret['result'] = _ret['result']
+        return ret
+    if allocate_eip:
+        if 'allocationId' not in r['result']: 
+            eip_alloc = __salt__['boto_ec2.allocate_eip_address'](domain=None,
+                                                                region=region,
+                                                                key=key,
+                                                                keyid=keyid,
+                                                                profile=profile)
+            if eip_alloc:
+                _ret = __salt__['boto_ec2.associate_eip_address'](instance_id=None,
+                                                                  instance_name=None,
+                                                                  public_ip=None,
+                                                                  allocation_id=eip_alloc['allocation_id'],
+                                                                  network_interface_id=r['result']['id'],
+                                                                  private_ip_address=None,
+                                                                  allow_reassociation=False,
+                                                                  region=region,
+                                                                  key=key,
+                                                                  keyid=keyid,
+                                                                  profile=profile)
+                if not _ret:
+                    _ret = __salt__['boto_ec2.release_eip_address'](public_ip=None,
+                                                                    allocation_id=eip_alloc['allocation_id'],
+                                                                    region=region,
+                                                                    key=key,
+                                                                    keyid=keyid,
+                                                                    profile=profile)
+                    ret['result'] = False
+                    msg = 'Failed to assocaite the allocated EIP address with the ENI.  The EIP {0}'.format('was successfully released.' if _ret else 'was NOT RELEASED.')
+                    ret['comment'] = ' '.join([ret['comment'], msg])
+                    return ret
+            else:
+                ret['result'] = False
+                ret['comment'] = ' '.join([ret['comment'], 'Failed to allocate an EIP address'])
+                return ret
+    if arecords:
+        for arecord in arecords:
+            log.debug('processing arecord {0}'.format(arecord))
+            _ret = None
+            dns_provider = 'boto_route53'
+            arecord['record_type'] = 'A'
+            public_ip_arecord = False
+            if 'public' in arecord:
+                public_ip_arecord = arecord.pop('public')
+            if public_ip_arecord:
+                if 'publicIp' in r['result']:
+                    arecord['value'] = r['result']['publicIp']
+                elif 'public_ip' in eip_alloc:
+                    arecord['value'] = eip_alloc['public_ip']
+                else:
+                    msg = 'Unable to add an A record for the public IP address, a public IP address does not seem to be allocated to this ENI.'
+                    raise CommandExectuionError(msg)
+            else:
+                arecord['value'] = r['result']['private_ip_address']
+            if 'provider' in arecord:
+                dns_provider = arecord.pop('provider')
+            if dns_provider == 'boto_route53':
+                if 'profile' not in arecord:
+                    arecord['profile'] = profile
+                if 'key' not in arecord:
+                    arecord['key'] = key
+                if 'keyid' not in arecord:
+                    arecord['keyid'] = keyid
+                if 'region' not in arecord:
+                    arecord['region'] = region
+            _ret = __states__['.'.join([dns_provider, 'present'])](**arecord)
+            log.debug('ret from dns_provider.present = {0}'.format(_ret))
+            ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
+            ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
+            if not _ret['result']:
+                ret['result'] = _ret['result']
+                if ret['result'] is False:
+                    return ret
     return ret
 
 
@@ -346,7 +433,8 @@ def eni_absent(
         region=None,
         key=None,
         keyid=None,
-        profile=None):
+        profile=None,
+        release_eip=False):
     '''
     Ensure the EC2 ENI is absent.
 
@@ -367,6 +455,9 @@ def eni_absent(
     profile
         A dict with region, key and keyid, or a pillar key (string)
         that contains a dict with region, key and keyid.
+
+    release_eip
+        True/False - release any EIP associated with the ENI
     '''
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     r = __salt__['boto_ec2.get_network_interface'](
@@ -386,6 +477,8 @@ def eni_absent(
     else:
         if __opts__['test']:
             ret['comment'] = 'ENI is set to be deleted.'
+            if release_eip and allocationId in r['result']:
+                ret['comment'] = ' '.join([ret['comment'], 'Allocated/associated EIP is set to be released'])
             ret['result'] = None
             return ret
         if 'id' in r['result']['attachment']:
@@ -412,6 +505,20 @@ def eni_absent(
             return ret
         ret['comment'] = 'Deleted ENI {0}'.format(name)
         ret['changes']['id'] = None
+        if release_eip and allocationId in r['result']:
+            _ret = __salt__['boto_ec2.release_eip_address'](public_ip=None,
+                                                            allocation_id=r['result']['allocationId'],
+                                                            region=region,
+                                                            key=key,
+                                                            keyid=keyid,
+                                                            profile=profile)
+            if not _ret:
+                ret['comment'] = ' '.join([ret['comment'], 'Failed to release EIP allocated to the ENI.'])
+                ret['result'] = False
+                return ret
+            else:
+                ret['comment'] = ' '.join([ret['comment'], 'EIP released.'])
+                ret['changes']['eip released'] = True
     return ret
 
 

--- a/salt/states/boto_ec2.py
+++ b/salt/states/boto_ec2.py
@@ -248,7 +248,9 @@ def eni_present(
         if __opts__['test']:
             ret['comment'] = 'ENI is set to be created.'
             if allocate_eip:
-                ret['comment'] = ' '.join([ret['comment'], 'An EIP is set to be allocated/assocaited to the ENI.']) 
+                ret['comment'] = ' '.join([ret['comment'], 'An EIP is set to be allocated/assocaited to the ENI.'])
+            if arecords:
+                ret['comment'] = ' '.join([ret['comment'], 'A records are set to be created.'])
             ret['result'] = None
             return ret
         result_create = __salt__['boto_ec2.create_network_interface'](
@@ -298,7 +300,7 @@ def eni_present(
     if allocate_eip:
         if 'allocationId' not in r['result']:
             if __opts__['test']:
-                ret['comment'] = ' '.join([ret['comment'], 'An EIP is set to be allocated and assocaited to the ENI.']) 
+                ret['comment'] = ' '.join([ret['comment'], 'An EIP is set to be allocated and assocaited to the ENI.'])
             else:
                 eip_alloc = __salt__['boto_ec2.allocate_eip_address'](domain=None,
                                                                       region=region,

--- a/salt/states/boto_ec2.py
+++ b/salt/states/boto_ec2.py
@@ -294,7 +294,7 @@ def eni_present(
         ret['result'] = _ret['result']
         return ret
     if allocate_eip:
-        if 'allocationId' not in r['result']: 
+        if 'allocationId' not in r['result']:
             eip_alloc = __salt__['boto_ec2.allocate_eip_address'](domain=None,
                                                                 region=region,
                                                                 key=key,
@@ -477,7 +477,7 @@ def eni_absent(
     else:
         if __opts__['test']:
             ret['comment'] = 'ENI is set to be deleted.'
-            if release_eip and allocationId in r['result']:
+            if release_eip and 'allocationId' in r['result']:
                 ret['comment'] = ' '.join([ret['comment'], 'Allocated/associated EIP is set to be released'])
             ret['result'] = None
             return ret
@@ -505,7 +505,7 @@ def eni_absent(
             return ret
         ret['comment'] = 'Deleted ENI {0}'.format(name)
         ret['changes']['id'] = None
-        if release_eip and allocationId in r['result']:
+        if release_eip and 'allocationId' in r['result']:
             _ret = __salt__['boto_ec2.release_eip_address'](public_ip=None,
                                                             allocation_id=r['result']['allocationId'],
                                                             region=region,

--- a/salt/states/boto_ec2.py
+++ b/salt/states/boto_ec2.py
@@ -341,45 +341,42 @@ def eni_present(
             if 'name' not in arecord:
                 msg = 'The arecord must contain a "name" property.'
                 raise SaltInvocationError(msg)
-            if __opts__['test']:
-                ret['comment'] = ' '.join([ret['comment'], 'The following A record is set to be added: {0}'.format(arecord['name'])])
-            else:
-                log.debug('processing arecord {0}'.format(arecord))
-                _ret = None
-                dns_provider = 'boto_route53'
-                arecord['record_type'] = 'A'
-                public_ip_arecord = False
-                if 'public' in arecord:
-                    public_ip_arecord = arecord.pop('public')
-                if public_ip_arecord:
-                    if 'publicIp' in r['result']:
-                        arecord['value'] = r['result']['publicIp']
-                    elif 'public_ip' in eip_alloc:
-                        arecord['value'] = eip_alloc['public_ip']
-                    else:
-                        msg = 'Unable to add an A record for the public IP address, a public IP address does not seem to be allocated to this ENI.'
-                        raise CommandExecutionError(msg)
+            log.debug('processing arecord {0}'.format(arecord))
+            _ret = None
+            dns_provider = 'boto_route53'
+            arecord['record_type'] = 'A'
+            public_ip_arecord = False
+            if 'public' in arecord:
+                public_ip_arecord = arecord.pop('public')
+            if public_ip_arecord:
+                if 'publicIp' in r['result']:
+                    arecord['value'] = r['result']['publicIp']
+                elif 'public_ip' in eip_alloc:
+                    arecord['value'] = eip_alloc['public_ip']
                 else:
-                    arecord['value'] = r['result']['private_ip_address']
-                if 'provider' in arecord:
-                    dns_provider = arecord.pop('provider')
-                if dns_provider == 'boto_route53':
-                    if 'profile' not in arecord:
-                        arecord['profile'] = profile
-                    if 'key' not in arecord:
-                        arecord['key'] = key
-                    if 'keyid' not in arecord:
-                        arecord['keyid'] = keyid
-                    if 'region' not in arecord:
-                        arecord['region'] = region
-                _ret = __states__['.'.join([dns_provider, 'present'])](**arecord)
-                log.debug('ret from dns_provider.present = {0}'.format(_ret))
-                ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
-                ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
-                if not _ret['result']:
-                    ret['result'] = _ret['result']
-                    if ret['result'] is False:
-                        return ret
+                    msg = 'Unable to add an A record for the public IP address, a public IP address does not seem to be allocated to this ENI.'
+                    raise CommandExecutionError(msg)
+            else:
+                arecord['value'] = r['result']['private_ip_address']
+            if 'provider' in arecord:
+                dns_provider = arecord.pop('provider')
+            if dns_provider == 'boto_route53':
+                if 'profile' not in arecord:
+                    arecord['profile'] = profile
+                if 'key' not in arecord:
+                    arecord['key'] = key
+                if 'keyid' not in arecord:
+                    arecord['keyid'] = keyid
+                if 'region' not in arecord:
+                    arecord['region'] = region
+            _ret = __states__['.'.join([dns_provider, 'present'])](**arecord)
+            log.debug('ret from dns_provider.present = {0}'.format(_ret))
+            ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
+            ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
+            if not _ret['result']:
+                ret['result'] = _ret['result']
+                if ret['result'] is False:
+                    return ret
     return ret
 
 

--- a/salt/states/boto_ec2.py
+++ b/salt/states/boto_ec2.py
@@ -169,12 +169,12 @@ def eni_present(
         description=None,
         groups=None,
         source_dest_check=True,
+        allocate_eip=False,
+        arecords=None,
         region=None,
         key=None,
         keyid=None,
-        profile=None,
-        allocate_eip=False,
-        arecords=None):
+        profile=None):
     '''
     Ensure the EC2 ENI exists.
 
@@ -201,6 +201,18 @@ def eni_present(
         Boolean specifying whether source/destination checking is enabled on
         the ENI.
 
+    allocate_eip
+        .. versionadded:: Boron
+        True/False - allocate and associate an EIP to the ENI
+
+    arecords
+        .. versionadded:: Boron
+        A list of arecord dicts with attributes needed for the DNS add_record state.
+        By default the boto_route53.add_record state will be used, which requires: name, zone, ttl, and identifier.
+        See the boto_route53 state for information about these attributes.
+        Other DNS modules can be called by specifying the provider keyword.
+        By default, the private ENI IP address will be used, set 'public: True' in the arecord dict to use the ENI's public IP address
+
     region
         Region to connect to.
 
@@ -213,18 +225,6 @@ def eni_present(
     profile
         A dict with region, key and keyid, or a pillar key (string)
         that contains a dict with region, key and keyid.
-
-    allocate_eip
-        .. versionadded:: Boron
-        True/False - allocate and associate an EIP to the ENI
-
-    arecords
-        .. versionadded:: Boron
-        A list of arecord dicts with attributes needed for the DNS add_record state.
-        By default the boto_route53.add_record state will be used, which requires: name, zone, ttl, and identifier.
-        See the boto_route53 state for information about these attributes.
-        Other DNS modules can be called by specifying the provider keyword.
-        By default, the private ENI IP address will be used, set 'public: True' in the arecord dict to use the ENI's public IP address
     '''
     if not subnet_id:
         raise SaltInvocationError('subnet_id is a required argument.')
@@ -430,11 +430,11 @@ def _eni_groups(metadata, groups, region, key, keyid, profile):
 
 def eni_absent(
         name,
+        release_eip=False,
         region=None,
         key=None,
         keyid=None,
-        profile=None,
-        release_eip=False):
+        profile=None):
     '''
     Ensure the EC2 ENI is absent.
 
@@ -442,6 +442,9 @@ def eni_absent(
 
     name
         Name tag associated with the ENI.
+
+    release_eip
+        True/False - release any EIP associated with the ENI
 
     region
         Region to connect to.
@@ -455,9 +458,6 @@ def eni_absent(
     profile
         A dict with region, key and keyid, or a pillar key (string)
         that contains a dict with region, key and keyid.
-
-    release_eip
-        True/False - release any EIP associated with the ENI
     '''
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     r = __salt__['boto_ec2.get_network_interface'](


### PR DESCRIPTION
Modify associate_eip_address function in boto_ec2 module to allow associating an EIP to an ENI that is not yet attached to an instance (remove requirement for instance_id or instance_name to have a value)

Modify boto_ec2 state to allocate/associate an EIP to an ENI on eni_present
Modify boto_ec2 state to allow creation of DNS A records (similar to cname attribute in boto_elb)
Modify boto_ec2 state to allow release of EIP on eni_absent

@ryan-lane : FYI
