### PR TITLE
Force tornado below 4.3 to support python26.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,6 +3,6 @@ msgpack-python>0.3
 PyYAML
 MarkupSafe
 requests>=1.0.0
-tornado>=4.2.1
+tornado>=4.2.1,<4.3
 # Required by Tornado to handle threads stuff.
 futures>=2.0


### PR DESCRIPTION
Tornado 4.3 seems to break our python2.6 hosts (have tried any other python versions (RHEL 6.x...) ).

Looking at http://www.tornadoweb.org/en/latest/releases/v4.3.0.html it might be because of some missing dependencies?

For now, I just forced the install version below 4.3 and it worked... Potentially the actual fix is to add those dependencies? But for now this seemed like the easiest short-term solution.
