### PR TITLE
Do not accept comma in GECOS field

### DIFF
--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -373,6 +373,14 @@ def present(name,
            'result': True,
            'comment': 'User {0} is present and up to date'.format(name)}
 
+    # the comma is used to separate field in GECOS, thus resulting into
+    # salt adding the end of fullname each time this function is called
+    for gecos_field in ['fullname', 'roomnumber', 'workphone', 'homephone']:
+        if isinstance(locals()[gecos_field], type('')) and ',' in locals()[gecos_field]:
+            ret['comment'] = "Unsupported char ',' in {0}".format(gecos_field)
+            ret['result'] = False
+            return ret
+
     if groups:
         missing_groups = [x for x in groups if not __salt__['group.info'](x)]
         if missing_groups:


### PR DESCRIPTION
Salt will accept it, and deploy it, but will not be able to read again
the line, and will apply the change again, adding the end of the string
after the comma to again. See https://github.com/saltstack/salt/issues/28835
for details.
