### PR TITLE
Use warn instead of error if decrypt fails

### DIFF
--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -263,7 +263,7 @@ def _decrypt_ciphertext(cipher, translate_newlines=False):
         input=cipher.replace(r'\n', '\n') if translate_newlines else cipher
     )
     if not decrypted_data:
-        log.error(
+        log.warn(
             'Could not decrypt cipher %s, received: %s',
             cipher,
             decrypt_error


### PR DESCRIPTION
Error is too strong for this.  We have pillars with secrets signed from several keys, which are meant to be deciphered from some salt masters but not others.
