### PR TITLE
[states/schedule] docstring: args, kwargs -> job_args, job_kwargs

### DIFF
--- a/salt/states/schedule.py
+++ b/salt/states/schedule.py
@@ -59,9 +59,9 @@ Management of the Salt scheduler
     job1:
       schedule.present:
         - function: state.sls
-        - args:
+        - job_args:
           - httpd
-        - kwargs:
+        - job_kwargs:
             test: True
         - when:
             - Monday 5:00pm


### PR DESCRIPTION
I fixed docstring in states/schedule.py file. Are there any other places where job_args and args can be mixed up?
