### PR TITLE
fix the os grain in sle11sp4 to be SUSE instead of SLES

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -952,6 +952,7 @@ _OS_NAME_MAP = {
     'synology': 'Synology',
     'nilrt': 'NILinuxRT',
     'manjaro': 'Manjaro',
+    'sles': 'SUSE',
 }
 
 # Map the 'os' grain to the 'os_family' grain


### PR DESCRIPTION
due to the existence of /etc/os-release on SLE11SP4, the os grain between
SLE11SP3 and SLE11SP4 was different (SLES vs SUSE). Thus, it was falsely trying
to use systemd on SLE11SP4 to start services

see also https://github.com/saltstack/salt/issues/28854
