### PR TITLE
Fix ebuild.install causing extra refresh_db calls.

### DIFF
--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -646,7 +646,9 @@ def install(name=None,
                 if not changes:
                     inst_v = version(param)
 
-                    if latest_version(param) == inst_v:
+                    # Prevent latest_version from calling refresh_db. Either we
+                    # just called it or we were asked not to.
+                    if latest_version(param, refresh=False) == inst_v:
                         all_uses = __salt__['portage_config.get_cleared_flags'](param)
                         if _flags_changed(*all_uses):
                             changes[param] = {'version': inst_v,


### PR DESCRIPTION
Fixes #28859.

The original call to `latest_version` caused a `refresh_db` to take
place. This is either unneeded (`refresh=True` was passed to `install`
and so refresh_db was done already) or something we were specifically
asked not to do (`refresh=False` was passed to `install`).
