### PR TITLE
Add "profile" loglevel

### DIFF
--- a/salt/log/mixins.py
+++ b/salt/log/mixins.py
@@ -17,6 +17,15 @@ import sys
 import logging
 
 
+class LoggingProfileMixIn(object):
+    '''
+    Simple mix-in class to add a trace method to python's logging.
+    '''
+
+    def profile(self, msg, *args, **kwargs):
+        self.log(getattr(logging, 'PROFILE', 15), msg, *args, **kwargs)
+
+
 class LoggingTraceMixIn(object):
     '''
     Simple mix-in class to add a trace method to python's logging.
@@ -45,7 +54,7 @@ class LoggingMixInMeta(type):
     the bases.
     '''
     def __new__(mcs, name, bases, attrs):
-        include_trace = include_garbage = True
+        include_profile = include_trace = include_garbage = True
         bases = list(bases)
         if name == 'SaltLoggingClass':
             for base in bases:
@@ -53,6 +62,8 @@ class LoggingMixInMeta(type):
                     include_trace = False
                 if hasattr(base, 'garbage'):
                     include_garbage = False
+        if include_profile:
+            bases.append(LoggingProfileMixIn)
         if include_trace:
             bases.append(LoggingTraceMixIn)
         if include_garbage:

--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -30,6 +30,7 @@ from salt.ext.six.moves.urllib.parse import urlparse  # pylint: disable=import-e
 
 # Let's define these custom logging levels before importing the salt.log.mixins
 # since they will be used there
+PROFILE = logging.PROFILE = 15
 TRACE = logging.TRACE = 5
 GARBAGE = logging.GARBAGE = 1
 QUIET = logging.QUIET = 1000
@@ -47,6 +48,7 @@ LOG_LEVELS = {
     'critical': logging.CRITICAL,
     'garbage': GARBAGE,
     'info': logging.INFO,
+    'profile': PROFILE,
     'quiet': QUIET,
     'trace': TRACE,
     'warning': logging.WARNING,
@@ -60,6 +62,7 @@ LOG_COLORS = {
         'ERROR': TextFormat('bold', 'red'),
         'WARNING': TextFormat('bold', 'yellow'),
         'INFO': TextFormat('bold', 'green'),
+        'PROFILE': TextFormat('bold', 'cyan'),
         'DEBUG': TextFormat('bold', 'cyan'),
         'TRACE': TextFormat('bold', 'magenta'),
         'GARBAGE': TextFormat('bold', 'blue'),
@@ -71,6 +74,7 @@ LOG_COLORS = {
         'ERROR': TextFormat('red'),
         'WARNING': TextFormat('yellow'),
         'INFO': TextFormat('green'),
+        'PROFILE': TextFormat('bold', 'cyan'),
         'DEBUG': TextFormat('cyan'),
         'TRACE': TextFormat('magenta'),
         'GARBAGE': TextFormat('blue'),
@@ -328,6 +332,7 @@ if logging.getLoggerClass() is not SaltLoggingClass:
 
     logging.setLoggerClass(SaltLoggingClass)
     logging.addLevelName(QUIET, 'QUIET')
+    logging.addLevelName(PROFILE, 'PROFILE')
     logging.addLevelName(TRACE, 'TRACE')
     logging.addLevelName(GARBAGE, 'GARBAGE')
 

--- a/salt/template.py
+++ b/salt/template.py
@@ -91,7 +91,15 @@ def compile_template(template,
         render_kwargs.update(kwargs)
         if argline:
             render_kwargs['argline'] = argline
+        start = time.time()
         ret = render(input_data, saltenv, sls, **render_kwargs)
+        log.profile(
+            'Time (in seconds) to render \'{0}\' using \'{1}\' renderer: {2}'.format(
+                template,
+                render.__module__.split('.')[-1],
+                time.time() - start
+            )
+        )
         if ret is None:
             # The file is empty or is being written elsewhere
             time.sleep(0.01)

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -1,18 +1,20 @@
 # -*- coding: utf-8 -*-
 '''
-Helpful decorators module writing
+Helpful decorators for module writing
 '''
 
 # Import python libs
 from __future__ import absolute_import
 import inspect
 import logging
+import time
 from functools import wraps
 from collections import defaultdict
 
 # Import salt libs
 import salt.utils
 from salt.exceptions import CommandNotFoundError
+from salt.log import LOG_LEVELS
 
 # Import 3rd-party libs
 import salt.ext.six as six
@@ -138,6 +140,29 @@ class depends(Depends):  # pylint: disable=C0103
     '''
     Wrapper of Depends for capitalization
     '''
+
+
+def timing(function):
+    '''
+    Decorator wrapper to log execution time, for profiling purposes
+    '''
+    def wrapped(*args, **kwargs):
+        start_time = time.time()
+        ret = function(*args, **salt.utils.clean_kwargs(**kwargs))
+        end_time = time.time()
+        if function.__module__.startswith('salt.loaded.int.'):
+            mod_name = function.__module__[16:]
+        else:
+            mod_name = function.__module__
+        log.profile(
+            'Function {0}.{1} took {2:.20f} seconds to execute'.format(
+                mod_name,
+                function.__name__,
+                end_time - start_time
+            )
+        )
+        return ret
+    return wrapped
 
 
 def which(exe):

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -146,6 +146,7 @@ def timing(function):
     '''
     Decorator wrapper to log execution time, for profiling purposes
     '''
+    @wraps(function)
     def wrapped(*args, **kwargs):
         start_time = time.time()
         ret = function(*args, **salt.utils.clean_kwargs(**kwargs))


### PR DESCRIPTION
This new loglevel sits between INFO and DEBUG, so that logging can be added to
aid in troubleshooting, without having to sift through all the debug logging.

This also adds a decorator which can be used on any function which will log
execution time, and also adds profile logging for template rendering.
