### PR TITLE
load standard and external beacons in beacon execution module

### DIFF
--- a/salt/modules/beacons.py
+++ b/salt/modules/beacons.py
@@ -13,6 +13,7 @@ import os
 import yaml
 
 import salt.utils
+import salt.utils.loader
 
 import logging
 log = logging.getLogger(__name__)
@@ -91,10 +92,8 @@ def add(name, beacon_data, **kwargs):
         ret['comment'] = 'Beacon: {0} would be added.'.format(name)
     else:
         # Attempt to load the beacon module so we have access to the validate function
-        try:
-            beacon_module = __import__('salt.beacons.' + name, fromlist=['validate'])
-            log.debug('Successfully imported beacon.')
-        except ImportError:
+        beacon_module = salt.utils.loader.load_module(name, 'beacons')
+        if not beacon_module:
             ret['comment'] = 'Beacon {0} does not exist'.format(name)
             return ret
 
@@ -155,10 +154,8 @@ def modify(name, beacon_data, **kwargs):
         ret['comment'] = 'Beacon: {0} would be added.'.format(name)
     else:
         # Attempt to load the beacon module so we have access to the validate function
-        try:
-            beacon_module = __import__('salt.beacons.' + name, fromlist=['validate'])
-            log.debug('Successfully imported beacon.')
-        except ImportError:
+        beacon_module = salt.utils.loader.load_module(name, 'beacons')
+        if not beacon_module:
             ret['comment'] = 'Beacon {0} does not exist'.format(name)
             return ret
 

--- a/salt/utils/loader.py
+++ b/salt/utils/loader.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+'''
+Loading utilities.
+'''
+# Import std libs
+from __future__ import absolute_import
+import os
+import sys
+import logging
+
+# Import salt libs
+import salt.utils
+
+# Import 3rd party libs
+from salt.ext.six import string_types
+
+log = logging.getLogger(__name__)
+
+
+def load_module(name, package, extmods=None):
+    '''
+    Try to load the named module either from the salt standard library or from
+    the external modules library if ``extmods`` is given.  If ``extmods`` is
+    provided and the module is in both the external library and the standard
+    library, the external library will receive precedence and its module will
+    be returned.
+
+    .. versionadded:: Boron
+
+    name
+        the name of the module to load
+
+    package
+        the module type: states, modules, returners, beacons, etc.
+
+    extmods
+        the salt config for the location of external modules
+    '''
+    def load(mod_path):
+        '''
+        Load and return the rightmost module in ``mod_path``
+        '''
+        try:
+            module = __import__(mod_path, fromlist=[''])
+            log.debug('Successfully imported {0}'.format(mod_path))
+            return module
+        except ImportError as err:
+            log.info('Could not load {0}: {1}'.format(mod_path, err))
+            return False
+
+    if isinstance(extmods, string_types):
+        # parent dir of external library
+        extmods_parent, extpkg = os.path.split(extmods)
+        # subdir (package) of external library
+        package_dir = os.path.join(extmods, package)
+
+        if extmods_parent not in sys.path:
+            # add extmods parent dir to the system path
+            sys.path.append(extmods_parent)
+
+        # create python packages in external library directories
+        for pkg in (extmods_parent, extmods, package_dir):
+            if '__init__.py' not in os.path.listdir(pkg):
+                salt.utils.fopen(os.path.join(pkg, '__init__.py'), 'w').close()
+
+        if name + '.py' in os.listdir(package_dir):
+            mod_path = '{0}.{1}.{2}'.format(extpkg, package, name)
+            module = load(mod_path)
+            if module:
+                return module
+
+    mod_path = 'salt.{0}.{1}'.format(package, name)
+    return load(mod_path)


### PR DESCRIPTION
Attempt to fix #28795.

@cachedout, is there a better way to do this with loader.py?  If not, then I will add tests.
