### PR TITLE
Fix doc build error by importing from salt.ext.six.moves.

### DIFF
--- a/salt/runners/asam.py
+++ b/salt/runners/asam.py
@@ -38,7 +38,7 @@ HAS_LIBS = False
 HAS_SIX = False
 try:
     import requests
-    from six.moves.html_parser import HTMLParser
+    from salt.ext.six.moves.html_parser import HTMLParser
     try:
         import salt.ext.six as six
         HAS_SIX = True

--- a/salt/runners/asam.py
+++ b/salt/runners/asam.py
@@ -38,7 +38,7 @@ HAS_LIBS = False
 HAS_SIX = False
 try:
     import requests
-    from salt.ext.six.moves.html_parser import HTMLParser
+    from salt.ext.six.moves.html_parser import HTMLParser  # pylint: disable=E0611
     try:
         import salt.ext.six as six
         HAS_SIX = True


### PR DESCRIPTION
Without this change, the docs won't build on the develop branch with the following error:

```
Exception occurred:
  File "/Users/pinyon/SaltStack/salt/salt/runners/asam.py", line 58, in <module>
    class ASAMHTMLParser(HTMLParser):
NameError: name 'HTMLParser' is not defined
```

Refs #23916
