### PR TITLE
Fix typo in str formatting in rpm module

### DIFF
--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -359,7 +359,7 @@ def owner(*paths):
         return ''
     ret = {}
     for path in paths:
-        cmd = ['rpm', '-qf', '--queryformat', '%{{NAME}}', path]
+        cmd = ['rpm', '-qf', '--queryformat', '%{name}', path]
         ret[path] = __salt__['cmd.run_stdout'](cmd,
                                                output_loglevel='trace',
                                                python_shell=False)


### PR DESCRIPTION
Introduced by #27521 and causing integration.modules.pkg.PkgModuleTest.test_owner on suse to fail
