### PR TITLE
Windows salt-master failures due to passing 'log_queue'

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -271,16 +271,6 @@ class Compiler(object):
         self.opts = opts
         self.rend = renderers
 
-    # We need __setstate__ and __getstate__ to avoid pickling errors since
-    # 'self.rend' contains a function reference which is not picklable.
-    # These methods are only used when pickling so will not be used on
-    # non-Windows platforms.
-    def __setstate__(self, state):
-        self.__init__(state['opts'])
-
-    def __getstate__(self):
-        return {'opts': self.opts}
-
     def render_template(self, template, **kwargs):
         '''
         Enforce the states in a template

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -871,8 +871,8 @@ class EventPublisher(salt.utils.process.SignalHandlingMultiprocessingProcess):
     The interface that takes master events and republishes them out to anyone
     who wants to listen
     '''
-    def __init__(self, opts):
-        super(EventPublisher, self).__init__()
+    def __init__(self, opts, **kwargs):
+        super(EventPublisher, self).__init__(**kwargs)
         self.opts = salt.config.DEFAULT_MASTER_OPTS.copy()
         self.opts.update(opts)
 
@@ -963,13 +963,13 @@ class EventReturn(salt.utils.process.SignalHandlingMultiprocessingProcess):
     A dedicated process which listens to the master event bus and queues
     and forwards events to the specified returner.
     '''
-    def __init__(self, opts):
+    def __init__(self, opts, **kwargs):
         '''
         Initialize the EventReturn system
 
         Return an EventReturn instance
         '''
-        super(EventReturn, self).__init__()
+        super(EventReturn, self).__init__(**kwargs)
 
         self.opts = opts
         self.event_return_queue = self.opts['event_return_queue']

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -871,8 +871,8 @@ class EventPublisher(salt.utils.process.SignalHandlingMultiprocessingProcess):
     The interface that takes master events and republishes them out to anyone
     who wants to listen
     '''
-    def __init__(self, opts, **kwargs):
-        super(EventPublisher, self).__init__(**kwargs)
+    def __init__(self, opts, log_queue=None):
+        super(EventPublisher, self).__init__(log_queue=log_queue)
         self.opts = salt.config.DEFAULT_MASTER_OPTS.copy()
         self.opts.update(opts)
 
@@ -963,13 +963,13 @@ class EventReturn(salt.utils.process.SignalHandlingMultiprocessingProcess):
     A dedicated process which listens to the master event bus and queues
     and forwards events to the specified returner.
     '''
-    def __init__(self, opts, **kwargs):
+    def __init__(self, opts, log_queue=None):
         '''
         Initialize the EventReturn system
 
         Return an EventReturn instance
         '''
-        super(EventReturn, self).__init__(**kwargs)
+        super(EventReturn, self).__init__(log_queue=log_queue)
 
         self.opts = opts
         self.event_return_queue = self.opts['event_return_queue']

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -443,7 +443,9 @@ class ProcessManager(object):
 
 class MultiprocessingProcess(multiprocessing.Process, NewStyleClassMixIn):
     def __init__(self, *args, **kwargs):
-        self.log_queue = kwargs.pop('log_queue', salt.log.setup.get_multiprocessing_logging_queue())
+        self.log_queue = kwargs.pop('log_queue', None)
+        if self.log_queue is None:
+            self.log_queue = salt.log.setup.get_multiprocessing_logging_queue()
         multiprocessing.util.register_after_fork(self, MultiprocessingProcess.__setup_process_logging)
         multiprocessing.util.Finalize(self, salt.log.setup.shutdown_multiprocessing_logging, exitpriority=16)
         super(MultiprocessingProcess, self).__init__(*args, **kwargs)

--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -29,12 +29,26 @@ class Reactor(salt.utils.process.MultiprocessingProcess, salt.state.Compiler):
     The reactor has the capability to execute pre-programmed executions
     as reactions to events
     '''
-    def __init__(self, opts):
-        salt.utils.process.MultiprocessingProcess.__init__(self)
+    def __init__(self, opts, **kwargs):
+        salt.utils.process.MultiprocessingProcess.__init__(self, **kwargs)
         local_minion_opts = opts.copy()
         local_minion_opts['file_client'] = 'local'
         self.minion = salt.minion.MasterMinion(local_minion_opts)
         salt.state.Compiler.__init__(self, opts, self.minion.rend)
+
+    # We need __setstate__ and __getstate__ to avoid pickling errors since
+    # 'self.rend' (from salt.state.Compiler) contains a function reference
+    # which is not picklable.
+    # These methods are only used when pickling so will not be used on
+    # non-Windows platforms.
+    def __setstate__(self, state):
+        Reactor.__init__(
+            self, state['opts'],
+            log_queue=state['log_queue'])
+
+    def __getstate__(self):
+        return {'opts': self.opts,
+                'log_queue': self.log_queue}
 
     def sig_stop(self, signum, frame):
         msg = 'Received a '

--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -29,8 +29,9 @@ class Reactor(salt.utils.process.MultiprocessingProcess, salt.state.Compiler):
     The reactor has the capability to execute pre-programmed executions
     as reactions to events
     '''
-    def __init__(self, opts, **kwargs):
-        salt.utils.process.MultiprocessingProcess.__init__(self, **kwargs)
+    def __init__(self, opts, log_queue=None):
+        salt.utils.process.MultiprocessingProcess.__init__(
+            self, log_queue=log_queue)
         local_minion_opts = opts.copy()
         local_minion_opts['file_client'] = 'local'
         self.minion = salt.minion.MasterMinion(local_minion_opts)


### PR DESCRIPTION
On Windows, there are failures that appear like:
`TypeError: __init__() got an unexpected keyword argument 'log_queue'`

To fix this:

salt/utils/events.py:
- Objects inheriting from
  `salt.utils.process.SignalHandlingMultiprocessingProcess` must be
  capable of passing the kwarg 'log_queue' through to the parent class
  `MultiprocessingProcess` so that it will be used on Windows. See PR
  #26999 as to why this was needed.

salt/utils/reactor.py:
- Same as event.py
- Moved `__setstate__` and `__getstate__` from `salt.state.Compiler`
  to `salt.utils.reactor.Reactor`. The reason is that this is the most
  derived class, and we want to accomplish two things:
  1) Avoid pickling self.rend (inherited from salt.state.Compiler)
  which is unpicklable, hence the need for `__setstate__` and
  `__getstate__` in the first place.
  2) Initialize the class from the top-most point. The `__init__` function
  here will, in turn, initialize parent classes such as
  `salt.state.Compiler`, creating the renderer as needed.

salt/state.py:
- Removed `__setstate__` and `__getstate__` from `salt.state.Compiler`
  as per comment above.

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
