### PR TITLE
Process -s (default sleep for service restarts) in bootstrap-salt.sh

### DIFF
--- a/salt/cloud/deploy/bootstrap-salt.sh
+++ b/salt/cloud/deploy/bootstrap-salt.sh
@@ -291,7 +291,7 @@ EOT
 }   # ----------  end of function usage  ----------
 
 
-while getopts ":hvnDc:Gg:k:MSNXCPFUKIA:i:Lp:dH:Zb" opt
+while getopts ":hvnDc:Gg:k:MSNXCPFUKIA:i:Lp:dH:Zbs:" opt
 do
   case "${opt}" in
 
@@ -326,6 +326,7 @@ do
              exit 1
          fi
          ;;
+    s )  __DEFAULT_SLEEP="$OPTARG"                      ;;
     M )  _INSTALL_MASTER=$BS_TRUE                       ;;
     S )  _INSTALL_SYNDIC=$BS_TRUE                       ;;
     N )  _INSTALL_MINION=$BS_FALSE                      ;;


### PR DESCRIPTION
An -s option for the 'default sleep' time in bootstrap-salt.sh is
documented in the usage instructions, but not implemented. This commit
lets bootstrap-salt.sh recognise and use the -s option.
