### PR TITLE
The ret result must contain 'name', not 'chassis_name' for the state compiler.

### DIFF
--- a/salt/states/dellchassis.py
+++ b/salt/states/dellchassis.py
@@ -168,7 +168,7 @@ def __virtual__():
     return 'chassis.cmd' in __salt__
 
 
-def blade_idrac(idrac_password=None, idrac_ipmi=None,
+def blade_idrac(name, idrac_password=None, idrac_ipmi=None,
                 idrac_ip=None, idrac_netmask=None, idrac_gateway=None,
                 idrac_dnsname=None,
                 drac_dhcp=None):
@@ -185,7 +185,8 @@ def blade_idrac(idrac_password=None, idrac_ipmi=None,
     :return: A standard Salt changes dictionary
     '''
 
-    ret = {'result': True,
+    ret = {'name': name,
+           'result': True,
            'changes': {},
            'comment': ''}
 

--- a/salt/states/dellchassis.py
+++ b/salt/states/dellchassis.py
@@ -281,7 +281,7 @@ def chassis(name, chassis_name=None, password=None, datacenter=None,
               - server-2: off
               - server-3: powercycle
     '''
-    ret = {'chassis_name': chassis_name,
+    ret = {'name': chassis_name,
            'result': True,
            'changes': {},
            'comment': ''}


### PR DESCRIPTION
ping @cro, @cedwards, @basepi, and @meggiebot 

Without this change, any state using the `chassis` or `blade_idrac` function will stacktrace in the state compiler.
