### PR TITLE
TCP transport minion errors when deep-copying `RemoteClient`

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -64,6 +64,19 @@ class Client(object):
         self.opts = opts
         self.serial = salt.payload.Serial(self.opts)
 
+    # Add __setstate__ and __getstate__ so that the object may be
+    # deep copied. It normally can't be deep copied because its
+    # constructor requires an 'opts' parameter.
+    # The TCP transport needs to be able to deep copy this class
+    # due to 'salt.utils.context.ContextDict.clone'.
+    def __setstate__(self, state):
+        # This will polymorphically call __init__
+        # in the derived class.
+        self.__init__(state['opts'])
+
+    def __getstate__(self):
+        return {'opts': self.opts}
+
     def _check_proto(self, path):
         '''
         Make sure that this path is intended for the salt master and trim it


### PR DESCRIPTION
There is code that tried to deep-copy `salt.fileclient.RemoteClient` and
fails. The callstack below shows this occurring.
This change makes `RemoteClient` picklable so that it may be deep copied.
It requires this because its constructor requires an `opt` parameter.

The error looks like this:

[ERROR   ] Exception in callback (1260L, <function wrapped at 0x0000000007434828

> )
> Traceback (most recent call last):
>   File "C:\Program Files\National Instruments\Shared\salt\bin\lib\site-packages\
> tornado\ioloop.py", line 866, in start
>     handler_func(fd_obj, events)
>   File "C:\Program Files\National Instruments\Shared\salt\bin\lib\site-packages\
> tornado\stack_context.py", line 343, in wrapped
>     raise_exc_info(exc)
>   File "C:\Program Files\National Instruments\Shared\salt\bin\lib\site-packages\
> tornado\stack_context.py", line 304, in wrapped
>     n.enter()
>   File "C:\Program Files\National Instruments\Shared\salt\bin\lib\site-packages\
> tornado\stack_context.py", line 118, in enter
>     context = self.context_factory()
>   File "C:\Program Files\National Instruments\Shared\salt\bin\lib\site-packages\
> salt\minion.py", line 1012, in ctx
>     self.functions.context_dict.clone(),
>   File "C:\Program Files\National Instruments\Shared\salt\bin\lib\site-packages\
> salt\utils\context.py", line 92, in clone
>     child = ChildContextDict(parent=self, overrides=kwargs)
>   File "C:\Program Files\National Instruments\Shared\salt\bin\lib\site-packages\
> salt\utils\context.py", line 137, in **init**
>     self._data[k] = copy.deepcopy(v)
>   File "C:\Program Files\National Instruments\Shared\salt\bin\lib\copy.py", line
>  163, in deepcopy
>     y = copier(x, memo)
>   File "C:\Program Files\National Instruments\Shared\salt\bin\lib\copy.py", line
>  257, in _deepcopy_dict
>     y[deepcopy(key, memo)] = deepcopy(value, memo)
>   File "C:\Program Files\National Instruments\Shared\salt\bin\lib\copy.py", line
>  190, in deepcopy
>     y = _reconstruct(x, rv, 1, memo)
>   File "C:\Program Files\National Instruments\Shared\salt\bin\lib\copy.py", line
>  334, in _reconstruct
>     state = deepcopy(state, memo)
>   File "C:\Program Files\National Instruments\Shared\salt\bin\lib\copy.py", line
>  163, in deepcopy
>     y = copier(x, memo)
>   File "C:\Program Files\National Instruments\Shared\salt\bin\lib\copy.py", line
>  257, in _deepcopy_dict
>     y[deepcopy(key, memo)] = deepcopy(value, memo)
>   File "C:\Program Files\National Instruments\Shared\salt\bin\lib\copy.py", line
>  190, in deepcopy
>     y = _reconstruct(x, rv, 1, memo)
>   File "C:\Program Files\National Instruments\Shared\salt\bin\lib\copy.py", line
>  334, in _reconstruct
>     state = deepcopy(state, memo)
>   File "C:\Program Files\National Instruments\Shared\salt\bin\lib\copy.py", line
>  163, in deepcopy
>     y = copier(x, memo)
>   File "C:\Program Files\National Instruments\Shared\salt\bin\lib\copy.py", line
>  257, in _deepcopy_dict
>     y[deepcopy(key, memo)] = deepcopy(value, memo)
>   File "C:\Program Files\National Instruments\Shared\salt\bin\lib\copy.py", line
>  190, in deepcopy
>     y = _reconstruct(x, rv, 1, memo)
>   File "C:\Program Files\National Instruments\Shared\salt\bin\lib\copy.py", line
>  329, in _reconstruct
>     y = callable(*args)
>   File "C:\Program Files\National Instruments\Shared\salt\bin\lib\copy_reg.py",
> line 93, in __newobj__
>     return cls.**new**(cls, *args)
> TypeError: **new**() takes exactly 2 arguments (1 given)
> Exception RuntimeError: RuntimeError('maximum recursion depth exceeded while cal
> ling a Python object',) in <bound method SyncWrapper.__del__ of <salt.utils.asyn
> c.SyncWrapper object at 0x00000000051ACB00>> ignored
> Exception RuntimeError: RuntimeError('maximum recursion depth exceeded while cal
> ling a Python object',) in <bound method SyncWrapper.__del__ of <salt.utils.asyn
> c.SyncWrapper object at 0x00000000051ACB00>> ignored

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
