### PR TITLE
Properly handle non-string saltenvs

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -1275,9 +1275,14 @@ def _validate_file_roots(opts):
                     ' using defaults')
         return {'base': _expand_glob_path([salt.syspaths.BASE_FILE_ROOTS_DIR])}
     for saltenv, dirs in six.iteritems(opts['file_roots']):
+        normalized_saltenv = six.text_type(saltenv)
+        if normalized_saltenv != saltenv:
+            opts['file_roots'][normalized_saltenv] = \
+                opts['file_roots'].pop(saltenv)
         if not isinstance(dirs, (list, tuple)):
-            opts['file_roots'][saltenv] = []
-        opts['file_roots'][saltenv] = _expand_glob_path(opts['file_roots'][saltenv])
+            opts['file_roots'][normalized_saltenv] = []
+        opts['file_roots'][normalized_saltenv] = \
+            _expand_glob_path(opts['file_roots'][normalized_saltenv])
     return opts['file_roots']
 
 

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -314,25 +314,38 @@ class Fileserver(object):
         '''
         Return the backend list
         '''
-        ret = []
         if not back:
             back = self.opts['fileserver_backend']
-        if isinstance(back, six.string_types):
-            back = back.split(',')
-        if all((x.startswith('-') for x in back)):
-            # Only subtracting backends from enabled ones
-            ret = self.opts['fileserver_backend']
-            for sub in back:
-                if '{0}.envs'.format(sub[1:]) in self.servers:
-                    ret.remove(sub[1:])
-                elif '{0}.envs'.format(sub[1:-2]) in self.servers:
-                    ret.remove(sub[1:-2])
         else:
-            for sub in back:
-                if '{0}.envs'.format(sub) in self.servers:
-                    ret.append(sub)
-                elif '{0}.envs'.format(sub[:-2]) in self.servers:
-                    ret.append(sub[:-2])
+            try:
+                back = back.split(',')
+            except AttributeError:
+                back = six.text_type(back).split(',')
+
+        ret = []
+        if not isinstance(back, list):
+            return ret
+
+        try:
+            subtract_only = all((x.startswith('-') for x in back))
+        except AttributeError:
+            pass
+        else:
+            if subtract_only:
+                # Only subtracting backends from enabled ones
+                ret = self.opts['fileserver_backend']
+                for sub in back:
+                    if '{0}.envs'.format(sub[1:]) in self.servers:
+                        ret.remove(sub[1:])
+                    elif '{0}.envs'.format(sub[1:-2]) in self.servers:
+                        ret.remove(sub[1:-2])
+                return ret
+
+        for sub in back:
+            if '{0}.envs'.format(sub) in self.servers:
+                ret.append(sub)
+            elif '{0}.envs'.format(sub[:-2]) in self.servers:
+                ret.append(sub[:-2])
         return ret
 
     def master_opts(self, load):
@@ -502,6 +515,9 @@ class Fileserver(object):
             saltenv = kwargs.pop('env')
         elif 'saltenv' in kwargs:
             saltenv = kwargs.pop('saltenv')
+        if not isinstance(saltenv, six.string_types):
+            saltenv = six.text_type(saltenv)
+
         for fsb in back:
             fstr = '{0}.find_file'.format(fsb)
             if fstr in self.servers:
@@ -528,6 +544,9 @@ class Fileserver(object):
 
         if 'path' not in load or 'loc' not in load or 'saltenv' not in load:
             return ret
+        if not isinstance(load['saltenv'], six.string_types):
+            load['saltenv'] = six.text_type(load['saltenv'])
+
         fnd = self.find_file(load['path'], load['saltenv'])
         if not fnd.get('back'):
             return ret
@@ -551,6 +570,9 @@ class Fileserver(object):
 
         if 'path' not in load or 'saltenv' not in load:
             return ''
+        if not isinstance(load['saltenv'], six.string_types):
+            load['saltenv'] = six.text_type(load['saltenv'])
+
         fnd = self.find_file(salt.utils.locales.sdecode(load['path']),
                 load['saltenv'])
         if not fnd.get('back'):
@@ -576,6 +598,9 @@ class Fileserver(object):
         ret = set()
         if 'saltenv' not in load:
             return []
+        if not isinstance(load['saltenv'], six.string_types):
+            load['saltenv'] = six.text_type(load['saltenv'])
+
         for fsb in self._gen_back(load.pop('fsbackend', None)):
             fstr = '{0}.file_list'.format(fsb)
             if fstr in self.servers:
@@ -604,6 +629,9 @@ class Fileserver(object):
         ret = set()
         if 'saltenv' not in load:
             return []
+        if not isinstance(load['saltenv'], six.string_types):
+            load['saltenv'] = six.text_type(load['saltenv'])
+
         for fsb in self._gen_back(None):
             fstr = '{0}.file_list_emptydirs'.format(fsb)
             if fstr in self.servers:
@@ -632,6 +660,9 @@ class Fileserver(object):
         ret = set()
         if 'saltenv' not in load:
             return []
+        if not isinstance(load['saltenv'], six.string_types):
+            load['saltenv'] = six.text_type(load['saltenv'])
+
         for fsb in self._gen_back(load.pop('fsbackend', None)):
             fstr = '{0}.dir_list'.format(fsb)
             if fstr in self.servers:
@@ -660,6 +691,9 @@ class Fileserver(object):
         ret = {}
         if 'saltenv' not in load:
             return {}
+        if not isinstance(load['saltenv'], six.string_types):
+            load['saltenv'] = six.text_type(load['saltenv'])
+
         for fsb in self._gen_back(load.pop('fsbackend', None)):
             symlstr = '{0}.symlink_list'.format(fsb)
             if symlstr in self.servers:


### PR DESCRIPTION
Force the saltenv to be a string, preventing AttributeError exceptions in
the various backends if someone passes an int/float as a saltenv.

This pull request also forces file_roots environments to be strings, as forcing
the saltenv to be a string in the salt.fileserver.Fileserver class will make
numeric saltenvs not match and would have broken the roots backend in those
cases.

Fixes #28911.
