### PR TITLE
Better handling for broken modules in salt versions report

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -583,7 +583,7 @@ def dependency_information(include_salt_cloud=False):
             if isinstance(version, (tuple, list)):
                 version = '.'.join(map(str, version))
             yield name, version
-        except ImportError:
+        except Exception:
             yield name, None
 
 


### PR DESCRIPTION
Modules can throw all kinds of exceptions on import, not just importerror. This prevents a hard stacktrace.
