### PR TITLE
Stop postgres cluster by default when trying to remove it via postgres_cluster.absent

### DIFF
--- a/salt/states/postgres_cluster.py
+++ b/salt/states/postgres_cluster.py
@@ -121,7 +121,7 @@ def absent(version,
             msg = 'Cluster {0}/{1} is set to be removed'
             ret['comment'] = msg.format(version, name)
             return ret
-        if __salt__['postgres.cluster_remove'](version, name):
+        if __salt__['postgres.cluster_remove'](version, name, True):
             msg = 'Cluster {0}/{1} has been removed'
             ret['comment'] = msg.format(version, name)
             ret['changes'][name] = 'Absent'


### PR DESCRIPTION
When a postgres cluster is to be removed, the user doesn't know if it's running or not. Mostly, the cluster will be running, so an attempt to stop it should be made by default.

If that is not desired behavior, then an option to stop it needs to be added, because otherwise a running cluster can never be removed.
