### PR TITLE
Add missing 'global'

### DIFF
--- a/salt/log/handlers/sentry_mod.py
+++ b/salt/log/handlers/sentry_mod.py
@@ -93,7 +93,6 @@ except ImportError:
     HAS_RAVEN = False
 
 log = logging.getLogger(__name__)
-__grains__ = {}
 __salt__ = {}
 
 # Define the module's virtual name
@@ -101,9 +100,8 @@ __virtualname__ = 'sentry'
 
 
 def __virtual__():
-    global __grains__, __salt__
-    if HAS_RAVEN is True:
-        __grains__ = salt.loader.grains(__opts__)
+    global __salt__
+    if HAS_RAVEN:
         __salt__ = salt.loader.minion_mods(__opts__)
         return __virtualname__
     return False

--- a/salt/log/handlers/sentry_mod.py
+++ b/salt/log/handlers/sentry_mod.py
@@ -101,6 +101,7 @@ __virtualname__ = 'sentry'
 
 
 def __virtual__():
+    global __grains__, __salt__
     if HAS_RAVEN is True:
         __grains__ = salt.loader.grains(__opts__)
         __salt__ = salt.loader.minion_mods(__opts__)


### PR DESCRIPTION
Leaving the **salt** and **grains** global variables empty doesn't end
well.
