### PR TITLE
Make systemd service state less slow

### DIFF
--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -127,12 +127,12 @@ def _get_all_legacy_init_scripts():
 
 def _untracked_custom_unit_found(name):
     '''
-    If the passed service name is not in the output from get_all(), but a unit
-    file exist in /etc/systemd/system, return True. Otherwise, return False.
+    If the passed service name is not available, but a unit file exist in
+    /etc/systemd/system, return True. Otherwise, return False.
     '''
     unit_path = os.path.join('/etc/systemd/system',
                              _canonical_unit_name(name))
-    return os.access(unit_path, os.R_OK) and name not in get_all()
+    return os.access(unit_path, os.R_OK) and not available(name)
 
 
 def _unit_file_changed(name):

--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -132,7 +132,7 @@ def _untracked_custom_unit_found(name):
     '''
     unit_path = os.path.join('/etc/systemd/system',
                              _canonical_unit_name(name))
-    return name not in get_all() and os.access(unit_path, os.R_OK)
+    return os.access(unit_path, os.R_OK) and name not in get_all()
 
 
 def _unit_file_changed(name):

--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -349,17 +349,18 @@ def available(name):
 
         salt '*' service.available sshd
     '''
-    name = _canonical_template_unit_name(name)
-    if name.endswith('.service'):
-        name = name[:-8]  # len('.service') is 8
-    units = get_all()
-    if name in units:
+    name = _canonical_unit_name(name)
+    list_unit = 'systemctl --full --no-legend --no-pager list-units ' + name
+    matched_units = __salt__['cmd.run_stdout'](list_unit)
+    if len(matched_units) > 0:
         return True
-    elif '@' in name:
-        templatename = name[:name.find('@') + 1]
-        return templatename in units
-    else:
-        return False
+    # Units such as getty@tty1.service appear in list-units only if they are
+    # already running, so we have to check list-unit-files for getty@.service
+    # aswell.
+    name = _canonical_template_unit_name(name)
+    list_unit_file = 'systemctl --full --no-legend --no-pager list-unit-files ' + name
+    matched_files = __salt__['cmd.run_stdout'](list_unit_file)
+    return len(matched_files) > 0
 
 
 def missing(name):

--- a/tests/unit/modules/systemd_test.py
+++ b/tests/unit/modules/systemd_test.py
@@ -99,17 +99,19 @@ class SystemdTestCase(TestCase):
         '''
             Test to check that the given service is available
         '''
-        mock = MagicMock(side_effect=["a", "@", "c"])
-        with patch.object(systemd, '_canonical_template_unit_name', mock):
-            mock = MagicMock(side_effect=[{"a": "z", "b": "z"},
-                                          {"@": "z", "b": "z"},
-                                          {"a": "z", "b": "z"}])
-            with patch.object(systemd, 'get_all', mock):
-                self.assertTrue(systemd.available("sshd"))
+        name = 'thing1'
 
-                self.assertTrue(systemd.available("sshd"))
+        mock_stdout = MagicMock(return_value=name)
+        with patch.dict(systemd.__salt__, {'cmd.run_stdout': mock_stdout}):
+            self.assertTrue(systemd.available(name))
 
-                self.assertFalse(systemd.available("sshd"))
+        mock_stdout = MagicMock(side_effect=['', ''])
+        with patch.dict(systemd.__salt__, {'cmd.run_stdout': mock_stdout}):
+            self.assertFalse(systemd.available(name))
+
+        mock_stdout = MagicMock(side_effect=['', name])
+        with patch.dict(systemd.__salt__, {'cmd.run_stdout': mock_stdout}):
+            self.assertTrue(systemd.available(name))
 
     def test_missing(self):
         '''


### PR DESCRIPTION
As has been noted in #10710, execution of a systemd service state is quite slow. The suggested solution of using `systemctl is-enabled` only helps for the enable operation. Instead, these commits address the expensive function `_untracked_custom_unit_found()`, which is used in several other places.

Previously our highstate runs took about 45s to several minutes due to a bug in systemd/logind which leaks unit files. With these patches we are down to about 36s in all cases.
