### PR TITLE
Adding new dunders to pylintrcs

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -163,7 +163,8 @@ additional-builtins=__opts__,
   __jid_event__,
   __instance_id__,
   __salt_system_encoding__,
-  __proxy__
+  __proxy__,
+  __serializers__
 
 # List of strings which can identify a callback function by name. A callback
 # name must start or end with one of those strings.

--- a/.testing.pylintrc
+++ b/.testing.pylintrc
@@ -226,7 +226,8 @@ additional-builtins=__opts__,
   __jid_event__,
   __instance_id__,
   __salt_system_encoding__,
-  __proxy__
+  __proxy__,
+  __serializers__
 
 
 # List of strings which can identify a callback function by name. A callback


### PR DESCRIPTION
Make `__serializers__` known to pylint. Refs #28926 and #28906
