### PR TITLE
pagerduty runner: add missing salt.utils import

### DIFF
--- a/salt/runners/pagerduty.py
+++ b/salt/runners/pagerduty.py
@@ -22,6 +22,7 @@ import yaml
 import json
 
 # Import salt libs
+import salt.utils
 import salt.utils.pagerduty
 from salt.ext.six import string_types
 


### PR DESCRIPTION
Fixes #28981.
