### PR TITLE
Clarify pillar top file requirement for git external pillars

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -13,8 +13,9 @@ This external pillar allows for a Pillar top file and Pillar SLS files to be
 sourced from a git repository.
 
 However, since git_pillar does not have an equivalent to the
-:conf_master:`pillar_roots` parameter, configuration is slightly different. The
-Pillar top file must still contain the relevant environment, like so:
+:conf_master:`pillar_roots` parameter, configuration is slightly different. A
+Pillar top file is required to be in the git repository and must still contain 
+the relevant environment, like so:
 
 .. code-block:: yaml
 

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -14,7 +14,7 @@ sourced from a git repository.
 
 However, since git_pillar does not have an equivalent to the
 :conf_master:`pillar_roots` parameter, configuration is slightly different. A
-Pillar top file is required to be in the git repository and must still contain 
+Pillar top file is required to be in the git repository and must still contain
 the relevant environment, like so:
 
 .. code-block:: yaml


### PR DESCRIPTION
Very small change to clarify the need to add a top.sls file in a external git_pillars setup.
