### PR TITLE
[2015.8] Add special list-only nodegroup support to salt-ssh

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -520,7 +520,10 @@ class SSH(object):
 
         # save load to the master job cache
         try:
-            self.returners['{0}.save_load'.format(self.opts['master_job_cache'])](jid, job_load)
+            if self.opts['master_job_cache'] == 'local_cache':
+                self.returners['{0}.save_load'.format(self.opts['master_job_cache'])](jid, job_load, minions=self.targets.keys())
+            else:
+                self.returners['{0}.save_load'.format(self.opts['master_job_cache'])](jid, job_load)
         except Exception as exc:
             log.error('Could not save load with returner {0}: {1}'.format(self.opts['master_job_cache'], exc))
 

--- a/salt/config.py
+++ b/salt/config.py
@@ -591,7 +591,7 @@ VALID_OPTS = {
 
     # List-only nodegroups for salt-ssh. Each group must be formed as either a
     # comma-separated list, or a YAML list.
-    'ssh_nodegroups': dict,
+    'ssh_list_nodegroups': dict,
 
     # The logfile location for salt-key
     'key_logfile': str,
@@ -1116,7 +1116,7 @@ DEFAULT_MASTER_OPTS = {
     'search_index_interval': 3600,
     'loop_interval': 60,
     'nodegroups': {},
-    'ssh_nodegroups': {},
+    'ssh_list_nodegroups': {},
     'cython_enable': False,
     'enable_gpu_grains': False,
     # XXX: Remove 'key_logfile' support in 2014.1.0

--- a/salt/config.py
+++ b/salt/config.py
@@ -589,6 +589,10 @@ VALID_OPTS = {
     # A compound target definition. See: http://docs.saltstack.com/en/latest/topics/targeting/nodegroups.html
     'nodegroups': dict,
 
+    # List-only nodegroups for salt-ssh. Each group must be formed as either a
+    # comma-separated list, or a YAML list.
+    'ssh_nodegroups': dict,
+
     # The logfile location for salt-key
     'key_logfile': str,
 
@@ -1112,6 +1116,7 @@ DEFAULT_MASTER_OPTS = {
     'search_index_interval': 3600,
     'loop_interval': 60,
     'nodegroups': {},
+    'ssh_nodegroups': {},
     'cython_enable': False,
     'enable_gpu_grains': False,
     # XXX: Remove 'key_logfile' support in 2014.1.0

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -173,9 +173,13 @@ def returner(load):
         )
 
 
-def save_load(jid, clear_load):
+def save_load(jid, clear_load, minions=None):
     '''
     Save the load to the specified jid
+
+    minions argument is to provide a pre-computed list of matched minions for
+    the job, for cases when this function can't compute that list itself (such
+    as for salt-ssh)
     '''
     jid_dir = _jid_dir(jid)
 
@@ -202,12 +206,13 @@ def save_load(jid, clear_load):
 
     # if you have a tgt, save that for the UI etc
     if 'tgt' in clear_load:
-        ckminions = salt.utils.minions.CkMinions(__opts__)
-        # Retrieve the minions list
-        minions = ckminions.check_minions(
-                clear_load['tgt'],
-                clear_load.get('tgt_type', 'glob')
-                )
+        if minions is None:
+            ckminions = salt.utils.minions.CkMinions(__opts__)
+            # Retrieve the minions list
+            minions = ckminions.check_minions(
+                    clear_load['tgt'],
+                    clear_load.get('tgt_type', 'glob')
+                    )
         # save the minions to a cache so we can see in the UI
         try:
             serial.dump(

--- a/salt/roster/flat.py
+++ b/salt/roster/flat.py
@@ -82,6 +82,8 @@ class RosterMatcher(object):
         Return minions that match via list
         '''
         minions = {}
+        if not isinstance(self.tgt, list):
+            self.tgt = self.tgt.split(',')
         for minion in self.raw:
             if minion in self.tgt:
                 data = self.get_data(minion)

--- a/salt/roster/flat.py
+++ b/salt/roster/flat.py
@@ -94,10 +94,10 @@ class RosterMatcher(object):
     def ret_nodegroup_minions(self):
         '''
         Return minions which match the special list-only groups defined by
-        ssh_nodegroups
+        ssh_list_nodegroups
         '''
         minions = {}
-        nodegroup = __opts__.get('ssh_nodegroups', {}).get(self.tgt, [])
+        nodegroup = __opts__.get('ssh_list_nodegroups', {}).get(self.tgt, [])
         if not isinstance(nodegroup, list):
             nodegroup = nodegroup.split(',')
         for minion in self.raw:

--- a/salt/roster/flat.py
+++ b/salt/roster/flat.py
@@ -89,6 +89,22 @@ class RosterMatcher(object):
                     minions[minion] = data
         return minions
 
+    def ret_nodegroup_minions(self):
+        '''
+        Return minions which match the special list-only groups defined by
+        ssh_nodegroups
+        '''
+        minions = {}
+        nodegroup = __opts__.get('ssh_nodegroups', {}).get(self.tgt, [])
+        if not isinstance(nodegroup, list):
+            nodegroup = nodegroup.split(',')
+        for minion in self.raw:
+            if minion in nodegroup:
+                data = self.get_data(minion)
+                if data:
+                    minions[minion] = data
+        return minions
+
     def get_data(self, minion):
         '''
         Return the configured ip


### PR DESCRIPTION
Fixes #8516 

Nodegroups don't really work with salt-ssh, because we don't have grains, pillar, etc. However, it is useful to group your minions into easy-to-target groups, even if you only have access to list matching.

This adds a special `ssh_list_nodegroups` config value to the master config. It only support lists, whether comma-separated or true YAML lists in its groups. These groups can then be targeted with the normal -N argument to salt-ssh.

I also fixed the list targeting function to properly split comma separated targeting strings.

Finally, this uncovered a bug where the local_cache returner was trying to compute the list of matched minions for storing in the cache. However, since the local_cache doesn't know whether it's being called via salt-ssh or normal salt, it doesn't know to use the roster system to get the list of minions. So I added support (in only the local_cache) for a pre-computed list of targeted minions to be passed in and stored in the cache.
