### PR TITLE
Allow passing list of pip packages to virtualenv.managed

### DIFF
--- a/salt/states/virtualenv_mod.py
+++ b/salt/states/virtualenv_mod.py
@@ -48,7 +48,8 @@ def managed(name,
             proxy=None,
             use_vt=False,
             env_vars=None,
-            pip_upgrade=False):
+            pip_upgrade=False,
+            pip_pkgs=None):
     '''
     Create a virtualenv and optionally manage it with pip
 
@@ -80,6 +81,9 @@ def managed(name,
         pick up a header file while compiling.
     pip_upgrade: False
         Pass `--upgrade` to `pip install`.
+    pip_pkgs: None
+        As an alternative to `requirements`, pass a list of pip packages that
+        should be installed.
 
 
      Also accepts any kwargs that the virtualenv module will.
@@ -194,9 +198,10 @@ def managed(name,
             return ret
 
     # Populate the venv via a requirements file
-    if requirements:
+    if requirements or pip_pkgs:
         before = set(__salt__['pip.freeze'](bin_env=name, user=user, use_vt=use_vt))
         _ret = __salt__['pip.install'](
+            pkgs=pip_pkgs,
             requirements=requirements,
             bin_env=name,
             use_wheel=use_wheel,


### PR DESCRIPTION
If I want to create a simple virtualenv, I have to add a `file.managed` for a requirements.txt, or I have to use `pip.installed` with `bin_env`, but that requires the pip system package to be installed.
