### PR TITLE
Fix salt.modules.gpg.import_key exception: 'GPG_1_3_1 referenced before assignment'

### DIFF
--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -651,11 +651,6 @@ def import_key(user=None,
 
     imported_data = gpg.import_keys(text)
 
-    # include another check for Salt unit tests
-    gnupg_version = distutils.version.LooseVersion(gnupg.__version__)
-    if gnupg_version >= '1.3.1':
-        GPG_1_3_1 = True
-
     if GPG_1_3_1:
         counts = imported_data.counts
         if counts.get('imported') or counts.get('imported_rsa'):

--- a/tests/unit/modules/gpg_test.py
+++ b/tests/unit/modules/gpg_test.py
@@ -336,6 +336,10 @@ class GpgTestCase(TestCase):
                 self.assertRaises(SaltInvocationError, gpg.import_key,
                                   filename='/path/to/public-key-file')
 
+            gpg.GPG_1_3_1 = True
+            self.assertDictEqual(gpg.import_key(text='-BEGIN PGP PUBLIC KEY BLOCK-'), ret)
+
+            gpg.GPG_1_3_1 = False
             self.assertDictEqual(gpg.import_key(text='-BEGIN PGP PUBLIC KEY BLOCK-'), ret)
 
     # 'export_key' function tests: 1


### PR DESCRIPTION
###### Changes:
- Fix gpg.import_key() exception: local variable 'GPG_1_3_1' referenced before assignment
- Update the unit tests to test both the gpg.GPG_1_3_1=True and
  gpg.GPG_1_3_1=False cases.
###### Purpose:

Checking the gnupg version and assigning a value to the GPG_1_3_1 global within gpg.import_key() uses local variable scope. This results in it being undefined if the version is < 1.3.1. Checking the version here is unnecessary, because it is already checked and saved globally in `__virtual__()`. When the the python-gnupg version is < 1.3.1, this exception results:

``` yaml
----------
          ID: import-gpg-key
    Function: module.run
        Name: gpg.import_key
      Result: False
     Comment: Module function gpg.import_key threw an exception. Exception: local variable 'GPG_1_3_1' referenced before assignment
     Started: 04:35:16.756421
    Duration: 12.642 ms
     Changes:
```
###### Reproduction steps:
1. Create a state file containing:
   
   ``` yaml
   {% set public_key = salt['cp.get_file_str']('https://repo.saltstack.com/apt/debian/latest/SALTSTACK-GPG-KEY.pub') %}
   
   import-gpg-key:
     module.run:
       - name: gpg.import_key
       - user: salt
       - text: {{ public_key | yaml_encode }}
   ```
2. Run the state:
   `salt-call --local --file-root=$(pwd) state.sls gpgbug -l debug`
###### Debug log: [debug.txt](https://github.com/saltstack/salt/files/39144/debug.txt)
