### PR TITLE
Update rabbitmq_user.py

### DIFF
--- a/salt/states/rabbitmq_user.py
+++ b/salt/states/rabbitmq_user.py
@@ -16,9 +16,9 @@ Example:
           - user
         - perms:
           - '/':
-          - '.*'
-          - '.*'
-          - '.*'
+            - '.*'
+            - '.*'
+            - '.*'
         - runas: rabbitmq
 '''
 


### PR DESCRIPTION
Corrected spacing to make it clear that the permissions were a level below the vhost name.
