### PR TITLE
Add local file support for file.managed source list

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3217,11 +3217,13 @@ def source_list(source, source_hash, saltenv):
             if isinstance(single, dict):
                 # check the proto, if it is http or ftp then download the file
                 # to check, if it is salt then check the master list
+                # if it is a local file, check if the file exists
                 if len(single) != 1:
                     continue
                 single_src = next(iter(single))
                 single_hash = single[single_src] if single[single_src] else source_hash
-                proto = _urlparse(single_src).scheme
+                urlparsed_single_src = _urlparse(single_src)
+                proto = urlparsed_single_src.scheme
                 if proto == 'salt':
                     path, senv = salt.utils.url.parse(single_src)
                     if not senv:
@@ -3236,11 +3238,24 @@ def source_list(source, source_hash, saltenv):
                     if fn_:
                         ret = (single_src, single_hash)
                         break
+                elif proto == 'file' and os.path.exists(urlparsed_single_src.path):
+                    ret = (single_src, single_hash)
+                    break
+                elif single_src.startswith('/') and os.path.exists(single_src):
+                    ret = (single_src, single_hash)
+                    break
             elif isinstance(single, six.string_types):
                 path, senv = salt.utils.url.parse(single)
                 if not senv:
                     senv = saltenv
                 if (path, senv) in mfiles or (path, senv) in mdirs:
+                    ret = (single, source_hash)
+                    break
+                urlparsed_source = _urlparse(single)
+                if urlparsed_source.scheme == 'file' and os.path.exists(urlparsed_source.path):
+                    ret = (single, source_hash)
+                    break
+                if single.startswith('/') and os.path.exists(single):
                     ret = (single, source_hash)
                     break
         if ret is None:

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1106,7 +1106,9 @@ def managed(name,
 
         A list of sources can also be passed in to provide a default source and
         a set of fallbacks. The first source in the list that is found to exist
-        will be used and subsequent entries in the list will be ignored.
+        will be used and subsequent entries in the list will be ignored. Source
+        list functionality only supports local files and remote files hosted on
+        the salt master server or retrievable via HTTP, HTTPS, or FTP.
 
         .. code-block:: yaml
 

--- a/tests/integration/modules/file.py
+++ b/tests/integration/modules/file.py
@@ -217,6 +217,37 @@ class FileModuleTest(integration.ModuleCase):
         self.assertItemsEqual(ret, ['http://t.est.com/http/httpd.conf',
                                     'filehash'])
 
+    def test_source_list_for_single_local_file_slash_returns_unchanged(self):
+        ret = self.run_function('file.source_list', [self.myfile,
+                                                     'filehash', 'base'])
+        self.assertItemsEqual(ret, [self.myfile, 'filehash'])
+
+    def test_source_list_for_single_local_file_proto_returns_unchanged(self):
+        ret = self.run_function('file.source_list', ['file://' + self.myfile,
+                                                     'filehash', 'base'])
+        self.assertItemsEqual(ret, ['file://' + self.myfile, 'filehash'])
+
+    def test_source_list_for_list_returns_existing_local_file_slash(self):
+        ret = filemod.source_list([self.myfile + '-foo',
+                                   self.myfile],
+                                  'filehash', 'base')
+        self.assertItemsEqual(ret, [self.myfile, 'filehash'])
+
+    def test_source_list_for_list_returns_existing_local_file_proto(self):
+        ret = filemod.source_list(['file://' + self.myfile + '-foo',
+                                   'file://' + self.myfile],
+                                  'filehash', 'base')
+        self.assertItemsEqual(ret, ['file://' + self.myfile, 'filehash'])
+
+    def test_source_list_for_list_returns_local_file_slash_from_dict(self):
+        ret = filemod.source_list(
+            [{self.myfile: ''}], 'filehash', 'base')
+        self.assertItemsEqual(ret, [self.myfile, 'filehash'])
+
+    def test_source_list_for_list_returns_local_file_proto_from_dict(self):
+        ret = filemod.source_list(
+            [{'file://' + self.myfile: ''}], 'filehash', 'base')
+        self.assertItemsEqual(ret, ['file://' + self.myfile, 'filehash'])
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
Add local file support to file.source_list along with tests and documentation for file.managed to explicitly state the kinds of URLs that can be part of a source list.
