### PR TITLE
ConnectTimeout does not exist in all requests>=1.0.0

### DIFF
--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -85,7 +85,7 @@ def creds(provider):
             )
             result.raise_for_status()
             role = result.text
-        except (requests.exceptions.HTTPError, requests.exceptions.ConnectTimeout):
+        except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError):
             return provider['id'], provider['key'], ''
 
         try:
@@ -94,7 +94,7 @@ def creds(provider):
                 proxies={'http': ''}, timeout=AWS_METADATA_TIMEOUT,
             )
             result.raise_for_status()
-        except (requests.exceptions.HTTPError, requests.exceptions.ConnectTimeout):
+        except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError):
             return provider['id'], provider['key'], ''
 
         data = result.json()


### PR DESCRIPTION
Fixes #29036. I wasn't sure if the desired solution would be upgrading the requests requirement or using an exception in all versions of `requests>=1.0.0`. I've made the change for switching to what seems to be an equivalent exception given the usage of `ConnectTimeout` (look for `MaxRetryError` in both files):
https://github.com/kennethreitz/requests/blob/v1.0.0/requests/adapters.py
https://github.com/kennethreitz/requests/blob/v2.8.1/requests/adapters.py
