### PR TITLE
Handle failures inside python's inspect if a module is reloaded

### DIFF
--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -64,8 +64,8 @@ class Depends(object):
         class wide depandancy_dict
         '''
         try:
-            # This inspect call may fail under certain conditions in the loader. Possibly related to 
-            # a Python bug here: 
+            # This inspect call may fail under certain conditions in the loader. Possibly related to
+            # a Python bug here:
             # http://bugs.python.org/issue17735
             frame = inspect.stack()[1][0]
             # due to missing *.py files under esky we cannot use inspect.getmodule

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -63,14 +63,21 @@ class Depends(object):
         and determine which module and function name it is to store in the
         class wide depandancy_dict
         '''
-        frame = inspect.stack()[1][0]
-        # due to missing *.py files under esky we cannot use inspect.getmodule
-        # module name is something like salt.loaded.int.modules.test
-        kind = frame.f_globals['__name__'].rsplit('.', 2)[1]
-        for dep in self.dependencies:
-            self.dependency_dict[kind][dep].add(
-                (frame, function, self.fallback_function)
-            )
+        try:
+            # This inspect call may fail under certain conditions in the loader. Possibly related to 
+            # a Python bug here: 
+            # http://bugs.python.org/issue17735
+            frame = inspect.stack()[1][0]
+            # due to missing *.py files under esky we cannot use inspect.getmodule
+            # module name is something like salt.loaded.int.modules.test
+            kind = frame.f_globals['__name__'].rsplit('.', 2)[1]
+            for dep in self.dependencies:
+                self.dependency_dict[kind][dep].add(
+                    (frame, function, self.fallback_function)
+                )
+        except Exception as exc:
+            log.error('Exception encountered when attempting to inspect frame in '
+                      'dependency decorator: {0}'.format(exc))
         return function
 
     @classmethod


### PR DESCRIPTION
Python has a known issue wherein calls to the inspect module which traverse the frame stack will fail if a module has been reloaded.

This caused a serious bug wherein certain uses of the depends decorator would fail hard and prevent the salt module from being initialized and loaded.

This works around that by simply ignoring the inspect failure.

Fixes #28810 and #28761 

cc: @sjorge (This may impact your fix for esky in #25946. Please have a look.)
