### PR TITLE
Infinite recursion when using prereq with sls

### DIFF
--- a/tests/integration/files/file/base/requisites/fullsls_require_import.sls
+++ b/tests/integration/files/file/base/requisites/fullsls_require_import.sls
@@ -1,0 +1,7 @@
+include:
+  - requisites.fullsls_require_import2
+A:
+  test.succeed_without_changes:
+    - name: A
+    - require:
+      - sls: requisites.fullsls_require_import2

--- a/tests/integration/files/file/base/requisites/fullsls_require_import2.sls
+++ b/tests/integration/files/file/base/requisites/fullsls_require_import2.sls
@@ -1,0 +1,2 @@
+include:
+  - requisites.fullsls_test

--- a/tests/integration/files/file/base/requisites/prereq_sls_infinite_recursion.sls
+++ b/tests/integration/files/file/base/requisites/prereq_sls_infinite_recursion.sls
@@ -1,0 +1,7 @@
+include:
+  - requisites.prereq_sls_infinite_recursion_2
+A:
+  test.succeed_without_changes:
+    - name: A
+    - prereq:
+      - sls: requisites.prereq_sls_infinite_recursion_2

--- a/tests/integration/files/file/base/requisites/prereq_sls_infinite_recursion_2.sls
+++ b/tests/integration/files/file/base/requisites/prereq_sls_infinite_recursion_2.sls
@@ -1,0 +1,4 @@
+
+B:
+  test.succeed_without_changes:
+    - name: B

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -692,6 +692,13 @@ class StateModuleTest(integration.ModuleCase,
         #ret = self.run_function('state.sls', mods='requisites.fullsls_prereq')
         #self.assertEqual(['sls command can only be used with require requisite'], ret)
 
+    def test_requisites_full_sls_import(self):
+        '''
+        Test full sls requisite with nothing but an import
+        '''
+        ret = self.run_function('state.sls', mods='requisites.fullsls_require_import')
+        self.assertSaltTrueReturn(ret)
+
     def test_requisites_prereq_simple_ordering_and_errors(self):
         '''
         Call sls file containing several prereq_in and prereq.

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -859,6 +859,9 @@ class StateModuleTest(integration.ModuleCase,
         #    ret,
         #    ['A recursive requisite was found, SLS "requisites.prereq_recursion_error" ID "B" ID "A"']
         #)
+    def test_infinite_recursion_sls_prereq(self):
+        ret = self.run_function('state.sls', mods='requisites.prereq_sls_infinite_recursion')
+        self.assertSaltTrueReturn(ret)
 
     def test_requisites_use(self):
         '''


### PR DESCRIPTION
If you have a state that `prereq`'s an `sls`, it causes infinite recursion.
eg:

a.sls

``` yaml
include:
  - b
A:
  test.succeed_without_changes:
    - name: A
    - prereq:
      - sls: b

```

b.sls

``` yaml
B:
  test.succeed_without_changes:
    - name: B
```

Causes:

```
    The minion function caused an exception: Traceback (most recent call last):
      File "/usr/lib/python2.6/site-packages/salt/minion.py", line 1007, in _thread_return
        return_data = func(*args, **kwargs)
      File "/usr/lib/python2.6/site-packages/salt/modules/state.py", line 710, in sls
        ret = st_.state.call_high(high_)
      File "/usr/lib/python2.6/site-packages/salt/state.py", line 2122, in call_high
        ret = dict(list(disabled.items()) + list(self.call_chunks(chunks).items()))
      File "/usr/lib/python2.6/site-packages/salt/state.py", line 1654, in call_chunks
        running = self.call_chunk(low, running, chunks)
      File "/usr/lib/python2.6/site-packages/salt/state.py", line 1922, in call_chunk
        running = self.call_chunk(low, running, chunks)
--- snip ---
      File "/usr/lib/python2.6/site-packages/salt/state.py", line 1922, in call_chunk
        running = self.call_chunk(low, running, chunks)
      File "/usr/lib/python2.6/site-packages/salt/state.py", line 1922, in call_chunk
        running = self.call_chunk(low, running, chunks)
      File "/usr/lib/python2.6/site-packages/salt/state.py", line 1821, in call_chunk
        low = self._mod_aggregate(low, running, chunks)
      File "/usr/lib/python2.6/site-packages/salt/state.py", line 651, in _mod_aggregate
        agg_opt = self.functions['config.option']('state_aggregate')
      File "/usr/lib/python2.6/site-packages/salt/utils/lazy.py", line 83, in __getitem__
        if self._missing(key):
    RuntimeError: maximum recursion depth exceeded
```

Tested on:

```
Salt Version:
           Salt: 2015.5.2-12287-g35f3409

Dependency Versions:
         Jinja2: 2.7-dev
       M2Crypto: 0.20.2
           Mako: 0.3.4
         PyYAML: 3.10
          PyZMQ: 14.3.0
         Python: 2.6.6 (r266:84292, Nov 21 2013, 10:50:32)
           RAET: Not Installed
        Tornado: 4.2
            ZMQ: 3.2.4
           cffi: Not Installed
       cherrypy: Not Installed
       dateutil: 1.4.1
          gitdb: Not Installed
      gitpython: Not Installed
          ioflo: Not Installed
        libnacl: Not Installed
   msgpack-pure: Not Installed
 msgpack-python: 0.3.0
   mysql-python: Not Installed
      pycparser: Not Installed
       pycrypto: 2.6.1
         pygit2: Not Installed
   python-gnupg: Not Installed
          smmap: Not Installed
        timelib: Not Installed

System Versions:
           dist: redhat 6.5 Santiago
        machine: x86_64
        release: 2.6.32-431.5.1.el6.x86_64
         system: Red Hat Enterprise Linux Server 6.5 Santiago
```

Tests attached.
