### PR TITLE
Fix mod_random.py that is broken for CentOS 6

### DIFF
--- a/salt/modules/mod_random.py
+++ b/salt/modules/mod_random.py
@@ -25,8 +25,8 @@ def __virtual__():
     '''
     # Certain versions of hashlib do not contain
     # the necessary functions
-    if not hasattr(hashlib, 'algorithms'):
-        return False
+    #if not hasattr(hashlib, 'algorithms'):
+    #    return False
     return __virtualname__
 
 


### PR DESCRIPTION
mod_random.py is currently broken in my CentOS 6 boxes when running Salt 2015.8.0. Doing the proposed change fix the issue. Finding a better way to validate this function on Debian systems would be great!
