### PR TITLE
We can't query installed use flags for a non installed pkg

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1437,7 +1437,7 @@ def latest(
                     cmp_func=cmp_func):
                     targets[pkg] = avail[pkg]
                 else:
-                    if not cur[pkg] or if __salt__['portage_config.is_changed_uses'](pkg):
+                    if not cur[pkg] or __salt__['portage_config.is_changed_uses'](pkg):
                         targets[pkg] = avail[pkg]
     else:
         for pkg in desired_pkgs:

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1437,7 +1437,7 @@ def latest(
                     cmp_func=cmp_func):
                     targets[pkg] = avail[pkg]
                 else:
-                    if __salt__['portage_config.is_changed_uses'](pkg):
+                    if not cur[pkg] or if __salt__['portage_config.is_changed_uses'](pkg):
                         targets[pkg] = avail[pkg]
     else:
         for pkg in desired_pkgs:


### PR DESCRIPTION
Same as in the develop branch, you can't query installed information on a non installed package.

Brakes install of new packages.
