### PR TITLE
Prevent backtrace (KeyError) in `ssh_known_hosts.present` state

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -854,7 +854,7 @@ def check_known_host(user=None, hostname=None, key=None, fingerprint=None,
 
     known_host = get_known_host(user, hostname, config=config, port=port)
 
-    if not known_host:
+    if not known_host or 'fingerprint' not in known_host:
         return 'add'
     if key:
         return 'exists' if key == known_host['key'] else 'update'


### PR DESCRIPTION
When using `test=true`, the `ssh_known_hosts.present` state will run
into a backtrace because of an KeyError. Prevent that.

```
An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/state.py", line 1591, in call
    **cdata['kwargs'])
  File "/usr/lib/python2.7/site-packages/salt/states/ssh_known_hosts.py", line 122, in present
    config=config)
  File "/usr/lib/python2.7/site-packages/salt/modules/ssh.py", line 827, in check_known_host
    return ('exists' if fingerprint == known_host['fingerprint']
KeyError: 'fingerprint'
```
