### PR TITLE
Kill unneeded import

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -571,8 +571,6 @@ class Client(object):
 
         if url_data.scheme == 's3':
             try:
-                import salt.utils.s3
-
                 def s3_opt(key, default=None):
                     '''Get value of s3.<key> from Minion config or from Pillar'''
                     if 's3.' + key in self.opts:


### PR DESCRIPTION
Kill the extra import in fileclient causing #28883. This might help `2015.5` as well as discussed in #28740, but I haven't done any testing besides seeing if it works for my states.
