### PR TITLE
Fix broken state orchestration

### DIFF
--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -248,6 +248,7 @@ def state(
         if 'return' in mdata and 'ret' not in mdata:
             mdata['ret'] = mdata.pop('return')
 
+        m_state = None
         if mdata.get('failed', False):
             m_state = False
         else:
@@ -255,7 +256,7 @@ def state(
                 m_ret = mdata['ret']
             except KeyError:
                 m_state = False
-            if not m_state:
+            if m_state is None:
                 m_state = salt.utils.check_state_result(m_ret)
 
         if not m_state:


### PR DESCRIPTION
This corrects an issue introduced in #28012 wherein the `m_ret` variable
was not set prior to evaluation. Here, we simply set it to None and then check for this type explicitely.

Fixes #29110
