### PR TITLE
Broader exception handling in compt

### DIFF
--- a/salt/_compat.py
+++ b/salt/_compat.py
@@ -17,19 +17,19 @@ from salt.ext.six.moves import cStringIO, StringIO
 try:
     # Python >2.5
     import xml.etree.cElementTree as ElementTree
-except ImportError:
+except Exception:
     try:
         # Python >2.5
         import xml.etree.ElementTree as ElementTree
-    except ImportError:
+    except Exception:
         try:
             # normal cElementTree install
             import elementtree.cElementTree as ElementTree
-        except ImportError:
+        except Exception:
             try:
                 # normal ElementTree install
                 import elementtree.ElementTree as ElementTree
-            except ImportError:
+            except Exception:
                 raise
 
 


### PR DESCRIPTION
When modules cannot be imported, such as in cases wherein there is a version incompatability between Python versions, sometimes those modules will raise errors other than ImportError. This accounts for that.

Fixes a broken test on develop: integration.cli.custom_module.SSHCustomModuleTest.test_ssh_sls_with_custom_module
