### PR TITLE
Remove duplicate import of salt.utils.s3

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -556,8 +556,6 @@ class Client(object):
 
         if url_data.scheme == 's3':
             try:
-                import salt.utils.s3
-
                 def s3_opt(key, default=None):
                     '''Get value of s3.<key> from Minion config or from Pillar'''
                     if 's3.' + key in self.opts:


### PR DESCRIPTION
`salt.utils.s3` is already imported at the top of the file.

I have no idea why this fixes #29144 - but it does.
