### PR TITLE
ACL limit args

### DIFF
--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -283,6 +283,7 @@ class Authorize(object):
                 form,
                 sub_auth[name] if name in sub_auth else sub_auth['*'],
                 load.get('fun', None),
+                load.get('arg', None),
                 load.get('tgt', None),
                 load.get('tgt_type', 'glob'))
         if not good:

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -465,6 +465,7 @@ class RemoteFuncs(object):
         good = self.ckminions.auth_check(
                 perms,
                 load['fun'],
+                load['arg'],
                 load['tgt'],
                 load.get('tgt_type', 'glob'),
                 publish_validate=True)
@@ -1409,6 +1410,7 @@ class LocalFuncs(object):
                         if token['name'] in self.opts['external_auth'][token['eauth']]
                         else self.opts['external_auth'][token['eauth']]['*'],
                     load['fun'],
+                    load['arg'],
                     load['tgt'],
                     load.get('tgt_type', 'glob'))
             if not good:
@@ -1450,6 +1452,7 @@ class LocalFuncs(object):
                         if name in self.opts['external_auth'][extra['eauth']]
                         else self.opts['external_auth'][extra['eauth']]['*'],
                     load['fun'],
+                    load['arg'],
                     load['tgt'],
                     load.get('tgt_type', 'glob'))
             if not good:
@@ -1506,6 +1509,7 @@ class LocalFuncs(object):
                     good = self.ckminions.auth_check(
                             acl[load['user']],
                             load['fun'],
+                            load['arg'],
                             load['tgt'],
                             load.get('tgt_type', 'glob'))
                     if not good:

--- a/salt/master.py
+++ b/salt/master.py
@@ -945,6 +945,7 @@ class AESFuncs(object):
         return self.ckminions.auth_check(
             perms,
             clear_load['fun'],
+            clear_load['arg'],
             clear_load['tgt'],
             clear_load.get('tgt_type', 'glob'),
             publish_validate=True)
@@ -1867,6 +1868,7 @@ class ClearFuncs(object):
             good = self.ckminions.auth_check(
                 auth_list,
                 clear_load['fun'],
+                clear_load['arg'],
                 clear_load['tgt'],
                 clear_load.get('tgt_type', 'glob'))
             if not good:
@@ -1954,6 +1956,7 @@ class ClearFuncs(object):
             good = self.ckminions.auth_check(
                 auth_list,
                 clear_load['fun'],
+                clear_load['arg'],
                 clear_load['tgt'],
                 clear_load.get('tgt_type', 'glob')
                 )
@@ -1982,6 +1985,7 @@ class ClearFuncs(object):
                     good = self.ckminions.auth_check(
                                 publisher_acl.get(clear_load['user'].split('_', 1)[-1]),
                                 clear_load['fun'],
+                                clear_load['arg'],
                                 clear_load['tgt'],
                                 clear_load.get('tgt_type', 'glob'))
                     if not good:
@@ -2023,6 +2027,7 @@ class ClearFuncs(object):
                     good = self.ckminions.auth_check(
                         acl[clear_load['user']],
                         clear_load['fun'],
+                        clear_load['arg'],
                         clear_load['tgt'],
                         clear_load.get('tgt_type', 'glob'))
                     if not good:

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -690,7 +690,7 @@ class CkMinions(object):
                     vals.append(False)
             except Exception:
                 log.error('Invalid regular expression: {0}'.format(regex))
-        return all(vals)
+        return vals and all(vals)
 
     def any_auth(self, form, auth_list, fun, arg, tgt=None, tgt_type='glob'):
         '''

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -740,7 +740,7 @@ class CkMinions(object):
             funs = [funs]
             args = [args]
         try:
-            for num in six.range(funs):
+            for num in six.moves.range(funs):
                 fun = funs[num]
                 arg = args[num]
                 for ind in auth_list:
@@ -792,7 +792,7 @@ class CkMinions(object):
                                             # whitelist args, kwargs
                                             cond_args = acond.get('args', [])
                                             good = True
-                                            for i in six.range(len(cond_args)):
+                                            for i in six.moves.range(len(cond_args)):
                                                 if len(arg) <= i:
                                                     good = False
                                                     break

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -740,9 +740,7 @@ class CkMinions(object):
             funs = [funs]
             args = [args]
         try:
-            for num in six.moves.range(funs):
-                fun = funs[num]
-                arg = args[num]
+            for num, fun in enumerate(funs):
                 for ind in auth_list:
                     if isinstance(ind, six.string_types):
                         # Allowed for all minions
@@ -790,15 +788,16 @@ class CkMinions(object):
                                                 # Invalid argument
                                                 continue
                                             # whitelist args, kwargs
+                                            arg_list = args[num]
                                             cond_args = acond.get('args', [])
                                             good = True
-                                            for i in six.moves.range(len(cond_args)):
-                                                if len(arg) <= i:
+                                            for i, cond_arg in enumerate(cond_args):
+                                                if len(arg_list) <= i:
                                                     good = False
                                                     break
-                                                if acond[i] is None:  # None == '.*' i.e. allow any
+                                                if cond_arg is None:  # None == '.*' i.e. allow any
                                                     continue
-                                                if not self.match_check(acond[i], arg[i]):
+                                                if not self.match_check(cond_arg, arg_list[i]):
                                                     good = False
                                                     break
                                             if not good:
@@ -806,7 +805,7 @@ class CkMinions(object):
                                             # Check kwargs
                                             cond_kwargs = acond.get('kwargs', {})
                                             arg_kwargs = {}
-                                            for a in arg:
+                                            for a in arg_list:
                                                 if isinstance(a, dict) and '__kwarg__' in a:
                                                     arg_kwargs = a
                                                     break
@@ -816,7 +815,7 @@ class CkMinions(object):
                                                 if k not in arg_kwargs:
                                                     good = False
                                                     break
-                                                if not self.match_check(v, arg_kwargs.get[k]):
+                                                if not self.match_check(v, arg_kwargs[k]):
                                                     good = False
                                                     break
                                             if good:

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -692,7 +692,7 @@ class CkMinions(object):
                 log.error('Invalid regular expression: {0}'.format(regex))
         return all(vals)
 
-    def any_auth(self, form, auth_list, fun, tgt=None, tgt_type='glob'):
+    def any_auth(self, form, auth_list, fun, arg, tgt=None, tgt_type='glob'):
         '''
         Read in the form and determine which auth check routine to execute
         '''
@@ -700,6 +700,7 @@ class CkMinions(object):
             return self.auth_check(
                     auth_list,
                     fun,
+                    arg,
                     tgt,
                     tgt_type)
         return self.spec_check(
@@ -710,6 +711,7 @@ class CkMinions(object):
     def auth_check(self,
                    auth_list,
                    funs,
+                   args,
                    tgt,
                    tgt_type='glob',
                    groups=None,
@@ -736,8 +738,11 @@ class CkMinions(object):
         # compound commands will come in a list so treat everything as a list
         if not isinstance(funs, list):
             funs = [funs]
+            args = [args]
         try:
-            for fun in funs:
+            for num in six.range(funs):
+                fun = funs[num]
+                arg = args[num]
                 for ind in auth_list:
                     if isinstance(ind, six.string_types):
                         # Allowed for all minions
@@ -758,8 +763,11 @@ class CkMinions(object):
                                 if self.match_check(ind[valid], fun):
                                     return True
                             elif isinstance(ind[valid], list):
-                                for regex in ind[valid]:
-                                    if self.match_check(regex, fun):
+                                for cond in ind[valid]:
+                                    if isinstance(cond, six.string_types):
+                                        if self.match_check(cond, fun):
+                                            return True
+                                    elif isinstance(cond, dict):
                                         return True
         except TypeError:
             return False

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -809,12 +809,12 @@ class CkMinions(object):
                                                 if isinstance(a, dict) and '__kwarg__' in a:
                                                     arg_kwargs = a
                                                     break
-                                            for k, v in cond_kwargs:
-                                                if v is None:  # None == '.*' i.e. allow any
-                                                    continue
+                                            for k, v in six.iteritems(cond_kwargs):
                                                 if k not in arg_kwargs:
                                                     good = False
                                                     break
+                                                if v is None:  # None == '.*' i.e. allow any
+                                                    continue
                                                 if not self.match_check(v, arg_kwargs[k]):
                                                     good = False
                                                     break

--- a/tests/unit/auth_test.py
+++ b/tests/unit/auth_test.py
@@ -48,7 +48,7 @@ class LoadAuthTestCase(TestCase):
                 'eauth': 'pam'
             }, expected_extra_kws=auth.AUTH_INTERNAL_KEYWORDS)
             ret = self.lauth.load_name(valid_eauth_load)
-            format_call_mock.assert_has_calls((expected_ret,))
+            format_call_mock.assert_has_calls((expected_ret,), any_order=True)
 
     def test_get_groups(self):
         valid_eauth_load = {'username': 'test_user',
@@ -63,7 +63,7 @@ class LoadAuthTestCase(TestCase):
                 'eauth': 'pam'
                 }, expected_extra_kws=auth.AUTH_INTERNAL_KEYWORDS)
             self.lauth.get_groups(valid_eauth_load)
-            format_call_mock.assert_has_calls((expected_ret,))
+            format_call_mock.assert_has_calls((expected_ret,), any_order=True)
 
 
 @patch('zmq.Context', MagicMock())

--- a/tests/unit/auth_test.py
+++ b/tests/unit/auth_test.py
@@ -104,7 +104,7 @@ class MasterACLTestCase(integration.ModuleCase):
                                 {'minion1': [{'test.echo': {'args': ['TEST',
                                                                      None,
                                                                      'TEST.*']}},
-                                             {'test.empty:': {}}]}
+                                             {'test.empty': {}}]}
                                 ]
              }
         self.clear = salt.master.ClearFuncs(opts, MagicMock())
@@ -244,10 +244,7 @@ class MasterACLTestCase(integration.ModuleCase):
 
         'test_user_func':
             minion1:
-                - test.echo:
-                    args:
-                        - 'TEST'
-                        - 'TEST.*'
+                - test.empty:
         '''
         self.valid_clear_load['kwargs'].update({'username': 'test_user_func'})
         self.valid_clear_load.update({'user': 'test_user_func',

--- a/tests/unit/auth_test.py
+++ b/tests/unit/auth_test.py
@@ -48,7 +48,7 @@ class LoadAuthTestCase(TestCase):
                 'eauth': 'pam'
             }, expected_extra_kws=auth.AUTH_INTERNAL_KEYWORDS)
             ret = self.lauth.load_name(valid_eauth_load)
-            format_call_mock.assert_has_calls(expected_ret)
+            format_call_mock.assert_has_calls((expected_ret,))
 
     def test_get_groups(self):
         valid_eauth_load = {'username': 'test_user',
@@ -63,7 +63,7 @@ class LoadAuthTestCase(TestCase):
                 'eauth': 'pam'
                 }, expected_extra_kws=auth.AUTH_INTERNAL_KEYWORDS)
             self.lauth.get_groups(valid_eauth_load)
-            format_call_mock.assert_has_calls(expected_ret)
+            format_call_mock.assert_has_calls((expected_ret,))
 
 
 @patch('zmq.Context', MagicMock())

--- a/tests/unit/auth_test.py
+++ b/tests/unit/auth_test.py
@@ -86,14 +86,25 @@ class MasterACLTestCase(integration.ModuleCase):
         opts['master_job_cache'] = ''
         opts['sign_pub_messages'] = False
         opts['con_cache'] = ''
-        opts['external_auth'] = {'pam': {'test_user': [{'*': ['test.ping']},
-                                                       {'minion_glob*': ['foo.bar']},
-                                                       {'minion_func_test': ['func_test.*']}],
-                                                       'test_group%': [{'*': ['test.echo']}],
-                                                       'test_user_mminion': [{'target_minion': ['test.ping']}],
-                                                       '*': [{'my_minion': ['my_mod.my_func']}],
-                                         }
-                                 }
+        opts['external_auth'] = {}
+        opts['external_auth']['pam'] = \
+            {'test_user': [{'*': ['test.ping']},
+                           {'minion_glob*': ['foo.bar']},
+                           {'minion_func_test': ['func_test.*']}],
+             'test_group%': [{'*': ['test.echo']}],
+             'test_user_mminion': [{'target_minion': ['test.ping']}],
+             '*': [{'my_minion': ['my_mod.my_func']}],
+             'test_user_func': [{'*': [{'test.echo': {'args': ['MSG:.*']}},
+                                       {'test.echo': {'kwargs': {'text': 'KWMSG:.*',
+                                                                 'anything': '.*',
+                                                                 'none': None}}},
+                                       {'my_mod.*': {'args': ['a.*', 'b.*'],
+                                                     'kwargs': {'kwa': 'kwa.*',
+                                                                'kwb': 'kwb'}}}]},
+                                {'minion1': [{'test.echo': {'args': ['TEST',
+                                                                     'TEST.*']}}]}
+                                ]
+             }
         self.clear = salt.master.ClearFuncs(opts, MagicMock())
 
         # overwrite the _send_pub method so we don't have to serialize MagicMock
@@ -222,6 +233,238 @@ class MasterACLTestCase(integration.ModuleCase):
         '''
         # Unimplemented
         pass
+
+    @patch('salt.utils.minions.CkMinions.check_minions',
+           MagicMock(return_value='minion1'))
+    def test_args_simple_match(self, fire_event_mock):
+        '''
+        Test simple arg restricion allowed.
+
+        'test_user_func':
+            minion1:
+                - test.echo:
+                    args:
+                        - 'TEST'
+                        - 'TEST.*'
+        '''
+        self.valid_clear_load['kwargs'].update({'username': 'test_user_func'})
+        self.valid_clear_load.update({'user': 'test_user_func',
+                                      'tgt': 'minion1',
+                                      'fun': 'test.echo',
+                                      'arg': ['TEST', 'TEST ABC']})
+        self.clear.publish(self.valid_clear_load)
+        self.assertEqual(fire_event_mock.call_args[0][0]['fun'], 'test.echo')
+
+    @patch('salt.utils.minions.CkMinions.check_minions',
+           MagicMock(return_value='minion1'))
+    def test_args_more_args(self, fire_event_mock):
+        '''
+        Test simple arg restricion allowed to pass other unlistd args.
+
+        'test_user_func':
+            minion1:
+                - test.echo:
+                    args:
+                        - 'TEST'
+                        - 'TEST.*'
+        '''
+        self.valid_clear_load['kwargs'].update({'username': 'test_user_func'})
+        self.valid_clear_load.update({'user': 'test_user_func',
+                                      'tgt': 'minion1',
+                                      'fun': 'test.echo',
+                                      'arg': ['TEST',
+                                              'TEST ABC',
+                                              'arg 3',
+                                              {'kwarg1': 'val1',
+                                               '__kwarg__': True}]})
+        self.clear.publish(self.valid_clear_load)
+        self.assertEqual(fire_event_mock.call_args[0][0]['fun'], 'test.echo')
+
+    @patch('salt.utils.minions.CkMinions.check_minions',
+           MagicMock(return_value='minion1'))
+    def test_args_simple_forbidden(self, fire_event_mock):
+        '''
+        Test simple arg restriction forbidden.
+
+        'test_user_func':
+            minion1:
+                - test.echo:
+                    args:
+                        - 'TEST'
+                        - 'TEST.*'
+        '''
+        self.valid_clear_load['kwargs'].update({'username': 'test_user_func'})
+        # Wrong second arg
+        self.valid_clear_load.update({'user': 'test_user_func',
+                                      'tgt': 'minion1',
+                                      'fun': 'test.echo',
+                                      'arg': ['TEST', 'TESLA']})
+        self.clear.publish(self.valid_clear_load)
+        self.assertEqual(fire_event_mock.mock_calls, [])
+        # Wrong first arg
+        self.valid_clear_load['arg'] = ['TES', 'TEST1234']
+        self.clear.publish(self.valid_clear_load)
+        self.assertEqual(fire_event_mock.mock_calls, [])
+        # Missing the second arg
+        self.valid_clear_load['arg'] = ['TEST']
+        self.clear.publish(self.valid_clear_load)
+        self.assertEqual(fire_event_mock.mock_calls, [])
+        # No args
+        self.valid_clear_load['arg'] = []
+        self.clear.publish(self.valid_clear_load)
+        self.assertEqual(fire_event_mock.mock_calls, [])
+
+    @patch('salt.utils.minions.CkMinions.check_minions',
+           MagicMock(return_value='some_minions'))
+    def test_args_kwargs_match(self, fire_event_mock):
+        '''
+        Test simple kwargs restricion allowed.
+
+        'test_user_func':
+            '*':
+                - test.echo:
+                    kwargs:
+                        text: 'KWMSG:.*'
+        '''
+        self.valid_clear_load['kwargs'].update({'username': 'test_user_func'})
+        self.valid_clear_load.update({'user': 'test_user_func',
+                                      'tgt': '*',
+                                      'fun': 'test.echo',
+                                      'arg': [{'text': 'KWMSG: a message',
+                                               'anything': 'hello all',
+                                               'none': 'hello none',
+                                               '__kwarg__': True}]})
+        self.clear.publish(self.valid_clear_load)
+        self.assertEqual(fire_event_mock.call_args[0][0]['fun'], 'test.echo')
+
+    @patch('salt.utils.minions.CkMinions.check_minions',
+           MagicMock(return_value='some_minions'))
+    def test_args_kwargs_mismatch(self, fire_event_mock):
+        '''
+        Test simple kwargs restricion allowed.
+
+        'test_user_func':
+            '*':
+                - test.echo:
+                    kwargs:
+                        text: 'KWMSG:.*'
+        '''
+        self.valid_clear_load['kwargs'].update({'username': 'test_user_func'})
+        self.valid_clear_load.update({'user': 'test_user_func',
+                                      'tgt': '*',
+                                      'fun': 'test.echo'})
+        # Wrong kwarg value
+        self.valid_clear_load['arg'] = [{'text': 'KWMSG a message',
+                                         'anything': 'hello all',
+                                         'none': 'hello none',
+                                         '__kwarg__': True}]
+        self.clear.publish(self.valid_clear_load)
+        self.assertEqual(fire_event_mock.mock_calls, [])
+        # Missing kwarg value
+        self.valid_clear_load['arg'] = [{'anything': 'hello all',
+                                         'none': 'hello none',
+                                         '__kwarg__': True}]
+        self.clear.publish(self.valid_clear_load)
+        self.assertEqual(fire_event_mock.mock_calls, [])
+        # Missing kwarg allowing any value
+        self.valid_clear_load['arg'] = [{'text': 'KWMSG: a message',
+                                         'none': 'hello none',
+                                         '__kwarg__': True}]
+        self.clear.publish(self.valid_clear_load)
+        self.assertEqual(fire_event_mock.mock_calls, [])
+        self.valid_clear_load['arg'] = [{'text': 'KWMSG: a message',
+                                         'anything': 'hello all',
+                                         '__kwarg__': True}]
+        self.clear.publish(self.valid_clear_load)
+        self.assertEqual(fire_event_mock.mock_calls, [])
+
+    @patch('salt.utils.minions.CkMinions.check_minions',
+           MagicMock(return_value='some_minions'))
+    def test_args_mixed_match(self, fire_event_mock):
+        '''
+        Test mixed args and kwargs restricion allowed.
+
+        'test_user_func':
+            '*':
+                - 'my_mod.*':
+                    args:
+                        - 'a.*'
+                        - 'b.*'
+                    kwargs:
+                        'kwa': 'kwa.*'
+                        'kwb': 'kwb'
+        '''
+        self.valid_clear_load['kwargs'].update({'username': 'test_user_func'})
+        self.valid_clear_load.update({'user': 'test_user_func',
+                                      'tgt': '*',
+                                      'fun': 'my_mod.some_func',
+                                      'arg': ['alpha',
+                                              'beta',
+                                              'gamma',
+                                              {'kwa': 'kwarg #1',
+                                               'kwb': 'kwb',
+                                               'one_more': 'just one more',
+                                               '__kwarg__': True}]})
+        self.clear.publish(self.valid_clear_load)
+        self.assertEqual(fire_event_mock.call_args[0][0]['fun'],
+                         'my_mod.some_func')
+
+    @patch('salt.utils.minions.CkMinions.check_minions',
+           MagicMock(return_value='some_minions'))
+    def test_args_mixed_mismatch(self, fire_event_mock):
+        '''
+        Test mixed args and kwargs restricion forbidden.
+
+        'test_user_func':
+            '*':
+                - 'my_mod.*':
+                    args:
+                        - 'a.*'
+                        - 'b.*'
+                    kwargs:
+                        'kwa': 'kwa.*'
+                        'kwb': 'kwb'
+        '''
+        self.valid_clear_load['kwargs'].update({'username': 'test_user_func'})
+        self.valid_clear_load.update({'user': 'test_user_func',
+                                      'tgt': '*',
+                                      'fun': 'my_mod.some_func'})
+        # Wrong arg value
+        self.valid_clear_load['arg'] = ['alpha',
+                                        'gamma',
+                                        {'kwa': 'kwarg #1',
+                                         'kwb': 'kwb',
+                                         'one_more': 'just one more',
+                                         '__kwarg__': True}]
+        self.clear.publish(self.valid_clear_load)
+        self.assertEqual(fire_event_mock.mock_calls, [])
+        # Wrong kwarg value
+        self.valid_clear_load['arg'] = ['alpha',
+                                        'beta',
+                                        'gamma',
+                                        {'kwa': 'kkk',
+                                         'kwb': 'kwb',
+                                         'one_more': 'just one more',
+                                         '__kwarg__': True}]
+        self.clear.publish(self.valid_clear_load)
+        self.assertEqual(fire_event_mock.mock_calls, [])
+        # Missing arg
+        self.valid_clear_load['arg'] = ['alpha',
+                                        {'kwa': 'kwarg #1',
+                                         'kwb': 'kwb',
+                                         'one_more': 'just one more',
+                                         '__kwarg__': True}]
+        self.clear.publish(self.valid_clear_load)
+        self.assertEqual(fire_event_mock.mock_calls, [])
+        # Missing kwarg
+        self.valid_clear_load['arg'] = ['alpha',
+                                        'beta',
+                                        'gamma',
+                                        {'kwa': 'kwarg #1',
+                                         'one_more': 'just one more',
+                                         '__kwarg__': True}]
+        self.clear.publish(self.valid_clear_load)
+        self.assertEqual(fire_event_mock.mock_calls, [])
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/unit/modules/cron_test.py
+++ b/tests/unit/modules/cron_test.py
@@ -577,7 +577,7 @@ class PsTestCase(TestCase):
                                     '# Lines below here are managed by Salt, do not edit\n',
                                     '@hourly echo Hi!\n'])
         ret = cron.set_special('DUMMY_USER', '@hourly', 'echo Hi!')
-        write_cron_lines_mock.assert_has_calls(expected_write_call)
+        write_cron_lines_mock.assert_has_calls((expected_write_call,), any_order=True)
 
     def test__get_cron_date_time(self):
         ret = cron._get_cron_date_time(minute=STUB_CRON_TIMESTAMP['minute'],

--- a/tests/unit/modules/mysql_test.py
+++ b/tests/unit/modules/mysql_test.py
@@ -282,10 +282,10 @@ class MySQLTestCase(TestCase):
         with patch.dict(mysql.__salt__, {'config.option': MagicMock()}):
             function(*args, **kwargs)
             if isinstance(expected_sql, dict):
-                calls = (call().cursor().execute('{0}'.format(expected_sql['sql']), expected_sql['sql_args']))
+                calls = call().cursor().execute('{0}'.format(expected_sql['sql']), expected_sql['sql_args'])
             else:
-                calls = (call().cursor().execute('{0}'.format(expected_sql)))
-            connect_mock.assert_has_calls(calls)
+                calls = call().cursor().execute('{0}'.format(expected_sql))
+            connect_mock.assert_has_calls((calls,), True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This allows to limit function arguments values with 'external_auth' in master config.
The feature is implemented for #3077 
