### PR TITLE
Fix another call to _get_node

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2653,7 +2653,7 @@ def set_tags(name=None,
 
         if resource_id is None:
             if instance_id is None:
-                instance_id = _get_node(name=name, instance_id=None, location=location)[name]['instanceId']
+                instance_id = _get_node(name=name, instance_id=None, location=location)['instanceId']
         else:
             instance_id = resource_id
 


### PR DESCRIPTION
As of https://github.com/saltstack/salt/pull/26357 _get_node returns
instance information directly rather than as a dictionary.

This call to _get_node should have been modified in that commit,
but was overlooked.
