### PR TITLE
Module network fixes

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -530,7 +530,7 @@ def active_tcp():
     '''
     Return a dict containing information on all of the running TCP connections (currently linux and solaris only)
 
-    .. versionchanged:: Boron
+    .. versionchanged:: 2015.8.4
 
         Added support for SunOS
 

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -655,6 +655,7 @@ def traceroute(host):
     return ret
 
 
+@decorators.which('dig')
 def dig(host):
     '''
     Performs a DNS lookup with dig

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -556,6 +556,8 @@ def active_tcp():
                 'remote_port': '.'.join(connection['remote-address'].split('.')[-1:])
             }
         return ret
+    else:
+        return {}
 
 
 def traceroute(host):

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -1328,7 +1328,10 @@ def default_route(family=None):
     ret = []
     for route in _routes:
         if family:
+            log.info(route)
             if route['destination'] in default_route[family]:
+                if __grains__['kernel'] == 'SunOS' and route['addr_family'] != family:
+                    continue
                 ret.append(route)
         else:
             if route['destination'] in default_route['inet'] or \

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -1179,13 +1179,13 @@ def _get_bufsize_linux(iface):
 
 def get_bufsize(iface):
     '''
-    Return network buffer sizes as a dict
+    Return network buffer sizes as a dict (currently linux only)
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' network.getbufsize
+        salt '*' network.ge_tbufsize
     '''
     if __grains__['kernel'] == 'Linux':
         if os.path.exists('/sbin/ethtool'):

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -1231,7 +1231,7 @@ def mod_bufsize(iface, *args, **kwargs):
 
     .. code-block:: bash
 
-        salt '*' network.getBuffers
+        salt '*' network.mod_bufsize tx=<val> rx=<val> rx-mini=<val> rx-jumbo=<val>
     '''
     if __grains__['kernel'] == 'Linux':
         if os.path.exists('/sbin/ethtool'):

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -531,6 +531,7 @@ def active_tcp():
     Return a dict containing information on all of the running TCP connections (currently linux and solaris only)
 
     .. versionchanged:: Boron
+
         Added support for SunOS
 
     CLI Example:
@@ -1207,7 +1208,7 @@ def get_bufsize(iface):
 
     .. code-block:: bash
 
-        salt '*' network.ge_tbufsize
+        salt '*' network.get_bufsize
     '''
     if __grains__['kernel'] == 'Linux':
         if os.path.exists('/sbin/ethtool'):

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -1328,7 +1328,6 @@ def default_route(family=None):
     ret = []
     for route in _routes:
         if family:
-            log.info(route)
             if route['destination'] in default_route[family]:
                 if __grains__['kernel'] == 'SunOS' and route['addr_family'] != family:
                     continue

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -42,12 +42,6 @@ def sanitize_host(host):
 def isportopen(host, port):
     '''
     Return status of a port
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' network.isportopen 127.0.0.1 22
     '''
 
     if not 1 <= int(port) <= 65535:
@@ -62,12 +56,6 @@ def isportopen(host, port):
 def host_to_ip(host):
     '''
     Returns the IP address of a given hostname
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' network.host_to_ip example.com
     '''
     try:
         family, socktype, proto, canonname, sockaddr = socket.getaddrinfo(
@@ -266,12 +254,6 @@ def generate_minion_id():
     '''
     Returns a minion id after checking multiple sources for a FQDN.
     If no FQDN is found you may get an ip address
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' network.generate_minion_id
     '''
     possible_ids = get_hostnames()
 
@@ -309,12 +291,6 @@ def get_socket(addr, type=socket.SOCK_STREAM, proto=0):
 def get_fqhostname():
     '''
     Returns the fully qualified hostname
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' network.get_fqhostname
     '''
     l = []
     l.append(socket.getfqdn())
@@ -342,12 +318,6 @@ def get_fqhostname():
 def ip_to_host(ip):
     '''
     Returns the hostname of a given IP
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' network.ip_to_host 8.8.8.8
     '''
     try:
         hostname, aliaslist, ipaddrlist = socket.gethostbyaddr(ip)

--- a/tests/unit/modules/network_test.py
+++ b/tests/unit/modules/network_test.py
@@ -107,7 +107,8 @@ class NetworkTestCase(TestCase):
          of the running TCP connections
         '''
         with patch.object(salt.utils.network, 'active_tcp', return_value='A'):
-            self.assertEqual(network.active_tcp(), 'A')
+            with patch.dict(network.__grains__, {'kernel': 'Linux'}):
+                self.assertEqual(network.active_tcp(), 'A')
 
     def test_traceroute(self):
         '''


### PR DESCRIPTION
Since it was actually giving me some issues when testing some stuff... I fixed them all up so I could continue.

Fixes the following:
- #29236
- #29235
- #29234
-  #29231

Partially fixes:
- #29233
- #29232

Similar fixes can probably be done for *BSD also but I do not have test systems for those at hand.

``` bash
[root@core /opt/local/salt_dev/_mod]# /opt/local/salt/bin/salt-call --local network.active_tcp
```

``` yaml
local:
    ----------
    1:
        ----------
        local_addr:
            2001:6f8:xxxx:yyyy::120
        local_port:
            22
        remote_addr:
            2001:6f8:xxxx:yyyy::1
        remote_port:
            3463
    2:
        ----------
        local_addr:
            2001:6f8:xxxx:yyyy::120
        local_port:
            22
        remote_addr:
            2001:6f8:xxxx:yyyy::1
        remote_port:
            19744
```

``` bash
[root@core /opt/local/salt_dev/_mod]# /opt/local/salt/bin/salt-call --local network.default_route inet
```

``` yaml
local:
    |_
      ----------
      addr_family:
          inet
      destination:
          default
      flags:
          UG
      gateway:
          172.16.yy.1
      interface:
          igb0
      netmask:
```
