### PR TITLE
List products consistently across all SLES systems

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1175,22 +1175,6 @@ def _get_first_aggregate_text(node_list):
     return '\n'.join(out)
 
 
-def _parse_suse_product(path, *info):
-    '''
-    Parse SUSE LLC product.
-    '''
-    doc = dom.parse(path)
-    product = {}
-    for nfo in info:
-        product.update(
-            {nfo: _get_first_aggregate_text(
-                doc.getElementsByTagName(nfo)
-            )}
-        )
-
-    return product
-
-
 def list_products(all=False):
     '''
     List all available or installed SUSE products.

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1198,7 +1198,7 @@ def list_products(all=False):
         p_name = p_nfo.pop('name')
         p_data[p_name] = p_nfo
         p_data[p_name]['eol'] = prd.getElementsByTagName('endoflife')[0].getAttribute('text')
-        descr = prd.getElementsByTagName('description')[0].childNodes[0].nodeValue
+        descr = _get_first_aggregate_text(prd.getElementsByTagName('description'))
         p_data[p_name]['description'] = " ".join([line.strip() for line in descr.split(os.linesep)])
         ret.append(p_data)
 


### PR DESCRIPTION
`salt '*' pkg.list_products` and `salt '*' pkg.list_products all=true` fixed in terms of it is consistent across all versions of the SLES line.
