### PR TITLE
fix incorrect reinstallation of windows pkg

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -446,7 +446,7 @@ def install(name=None, refresh=False, pkgs=None, saltenv='base', **kwargs):
 
         version_num = options and options.get('version') or _get_latest_pkg_version(pkginfo)
 
-        if version_num in [old.get(pkginfo[x]['full_name']) for x in pkginfo]:
+        if version_num in [old.get(pkg_name) for x in pkginfo]:
             # Desired version number already installed
             continue
         elif version_num not in pkginfo:

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -448,7 +448,13 @@ def install(name=None, refresh=False, pkgs=None, saltenv='base', **kwargs):
 
         if version_num in [old.get(pkg_name) for x in pkginfo]:
             # Desired version number already installed
-            continue
+            log.info('Version {0} is already installed for '
+                     'package {1}'.format(version_num, pkg_name))
+            return {
+                pkg_name: {
+                    'old': '{0} already installed'.format(version_num)
+                }
+            }
         elif version_num not in pkginfo:
             log.error('Version {0} not found for package '
                       '{1}'.format(version_num, pkg_name))


### PR DESCRIPTION
the "old" variable holds list_pkgs() results which have the mapped application name as the key so when trying to find the installed version old.get() will return none with the package 'full_name' but it will return the installed version with mapped package name.
Also added some log and return immediately if package is already installed. 
