### PR TITLE
Prevent adding port twice when adding entry in known hosts

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -1022,7 +1022,7 @@ def set_known_host(user=None,
     if key:
         remote_host = {'hostname': hostname, 'enc': enc, 'key': key}
 
-    if hash_known_hosts or port == DEFAULT_SSH_PORT:
+    if hash_known_hosts or port == DEFAULT_SSH_PORT or ':' in remote_host['hostname']:
         line = '{hostname} {enc} {key}\n'.format(**remote_host)
     else:
         remote_host['port'] = port


### PR DESCRIPTION
Check hostname value inside remote_host dictionary to find out ':'. In that case don't append port.

Issue #29206 
