### PR TITLE
ZeroMQ no longer required when transport is TCP

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -18,17 +18,25 @@ import tempfile
 import traceback
 
 # Import third party libs
-import zmq
 from Crypto.PublicKey import RSA
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 import salt.ext.six as six
 from salt.ext.six.moves import range
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
 
-import zmq.eventloop.ioloop
-# support pyzmq 13.0.x, TODO: remove once we force people to 14.0.x
-if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
-    zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
+try:
+    import zmq
+    import zmq.eventloop.ioloop
+    # support pyzmq 13.0.x, TODO: remove once we force people to 14.0.x
+    if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
+        zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
+    LOOP_CLASS = zmq.eventloop.ioloop.ZMQIOLoop
+    HAS_ZMQ = True
+except ImportError:
+    import tornado.ioloop
+    LOOP_CLASS = tornado.ioloop.IOLoop
+    HAS_ZMQ = False
+
 import tornado.gen  # pylint: disable=F0401
 
 # Import salt libs
@@ -311,22 +319,23 @@ class Master(SMaster):
 
         :param dict: The salt options
         '''
-        # Warn if ZMQ < 3.2
-        try:
-            zmq_version_info = zmq.zmq_version_info()
-        except AttributeError:
-            # PyZMQ <= 2.1.9 does not have zmq_version_info, fall back to
-            # using zmq.zmq_version() and build a version info tuple.
-            zmq_version_info = tuple(
-                [int(x) for x in zmq.zmq_version().split('.')]
-            )
-        if zmq_version_info < (3, 2):
-            log.warning(
-                'You have a version of ZMQ less than ZMQ 3.2! There are '
-                'known connection keep-alive issues with ZMQ < 3.2 which '
-                'may result in loss of contact with minions. Please '
-                'upgrade your ZMQ!'
-            )
+        if HAS_ZMQ:
+            # Warn if ZMQ < 3.2
+            try:
+                zmq_version_info = zmq.zmq_version_info()
+            except AttributeError:
+                # PyZMQ <= 2.1.9 does not have zmq_version_info, fall back to
+                # using zmq.zmq_version() and build a version info tuple.
+                zmq_version_info = tuple(
+                    [int(x) for x in zmq.zmq_version().split('.')]
+                )
+            if zmq_version_info < (3, 2):
+                log.warning(
+                    'You have a version of ZMQ less than ZMQ 3.2! There are '
+                    'known connection keep-alive issues with ZMQ < 3.2 which '
+                    'may result in loss of contact with minions. Please '
+                    'upgrade your ZMQ!'
+                )
         SMaster.__init__(self, opts)
 
     def __set_max_open_files(self):
@@ -663,10 +672,12 @@ class ReqServer(object):
 
     def destroy(self):
         if hasattr(self, 'clients') and self.clients.closed is False:
-            self.clients.setsockopt(zmq.LINGER, 1)
+            if HAS_ZMQ:
+                self.clients.setsockopt(zmq.LINGER, 1)
             self.clients.close()
         if hasattr(self, 'workers') and self.workers.closed is False:
-            self.workers.setsockopt(zmq.LINGER, 1)
+            if HAS_ZMQ:
+                self.workers.setsockopt(zmq.LINGER, 1)
             self.workers.close()
         if hasattr(self, 'context') and self.context.closed is False:
             self.context.term()
@@ -737,8 +748,9 @@ class MWorker(SignalHandlingMultiprocessingProcess):
         Bind to the local port
         '''
         # using ZMQIOLoop since we *might* need zmq in there
-        zmq.eventloop.ioloop.install()
-        self.io_loop = zmq.eventloop.ioloop.ZMQIOLoop()
+        if HAS_ZMQ:
+            zmq.eventloop.ioloop.install()
+        self.io_loop = LOOP_CLASS()
         for req_channel in self.req_channels:
             req_channel.post_fork(self._handle_payload, io_loop=self.io_loop)  # TODO: cleaner? Maybe lazily?
         self.io_loop.start()

--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -204,7 +204,7 @@ import tornado.ioloop
 import tornado.web
 import tornado.gen
 from tornado.concurrent import Future
-from zmq.eventloop import ioloop, zmqstream
+from zmq.eventloop import ioloop
 import salt.ext.six as six
 # pylint: enable=import-error
 
@@ -298,6 +298,7 @@ class EventListener(object):
             opts['transport'],
             opts=opts,
             listen=True,
+            io_loop=tornado.ioloop.IOLoop.current()
         )
 
         # tag -> list of futures
@@ -309,11 +310,7 @@ class EventListener(object):
         # map of future -> timeout_callback
         self.timeout_map = {}
 
-        self.stream = zmqstream.ZMQStream(
-            self.event.sub,
-            io_loop=tornado.ioloop.IOLoop.current(),
-        )
-        self.stream.on_recv(self._handle_event_socket_recv)
+        self.event.set_event_handler(self._handle_event_socket_recv)
 
     def clean_timeout_futures(self, request):
         '''
@@ -378,7 +375,7 @@ class EventListener(object):
         '''
         Callback for events on the event sub socket
         '''
-        mtag, data = self.event.unpack(raw[0], self.event.serial)
+        mtag, data = self.event.unpack(raw, self.event.serial)
         # see if we have any futures that need this info:
         for tag_prefix, futures in six.iteritems(self.tag_map):
             if mtag.startswith(tag_prefix):

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -9,6 +9,7 @@ import logging
 import socket
 import msgpack
 import weakref
+import time
 
 # Import Tornado libs
 import tornado
@@ -25,6 +26,59 @@ import salt.transport.frame
 log = logging.getLogger(__name__)
 
 
+# 'tornado.concurrent.Future' doesn't support
+# remove_done_callback() which we would have called
+# in the timeout case. Due to this, we have this
+# callback function outside of FutureWithTimeout.
+def future_with_timeout_callback(future):
+    if future._future_with_timeout is not None:
+        future._future_with_timeout._done_callback(future)
+
+
+class FutureWithTimeout(tornado.concurrent.Future):
+    def __init__(self, io_loop, future, timeout):
+        super(FutureWithTimeout, self).__init__()
+        self.io_loop = io_loop
+        self._future = future
+        if timeout is not None:
+            if timeout < 0.1:
+                timeout = 0.1
+            self._timeout_handle = self.io_loop.add_timeout(
+                self.io_loop.time() + timeout, self._timeout_callback)
+        else:
+            self._timeout_handle = None
+
+        if hasattr(self._future, '_future_with_timeout'):
+            # Reusing a future that has previously been used.
+            # Due to this, no need to call add_done_callback()
+            # because we did that before.
+            self._future._future_with_timeout = self
+            if self._future.done():
+                future_with_timeout_callback(self._future)
+        else:
+            self._future._future_with_timeout = self
+            self._future.add_done_callback(future_with_timeout_callback)
+
+    def _timeout_callback(self):
+        self._timeout_handle = None
+        # 'tornado.concurrent.Future' doesn't support
+        # remove_done_callback(). So we set an attribute
+        # inside the future itself to track what happens
+        # when it completes.
+        self._future._future_with_timeout = None
+        self.set_exception(tornado.ioloop.TimeoutError())
+
+    def _done_callback(self, future):
+        try:
+            if self._timeout_handle is not None:
+                self.io_loop.remove_timeout(self._timeout_handle)
+                self._timeout_handle = None
+
+            self.set_result(future.result())
+        except Exception as exc:
+            self.set_exception(exc)
+
+
 class IPCServer(object):
     '''
     A Tornado IPC server very similar to Tornado's TCPServer class
@@ -34,9 +88,17 @@ class IPCServer(object):
         '''
         Create a new Tornado IPC server
 
+        :param str/int socket_path: Path on the filesystem for the
+                                    socket to bind to. This socket does
+                                    not need to exist prior to calling
+                                    this method, but parent directories
+                                    should.
+                                    It may also be of type 'int', in
+                                    which case it is used as the port
+                                    for a tcp localhost connection.
         :param IOLoop io_loop: A Tornado ioloop to handle scheduling
-        :param func stream_handler: A function to customize handling of an
-                                    incoming stream.
+        :param func payload_handler: A function to customize handling of
+                                     incoming data.
         '''
         self.socket_path = socket_path
         self._started = False
@@ -52,15 +114,6 @@ class IPCServer(object):
         Perform the work necessary to start up a Tornado IPC server
 
         Blocks until socket is established
-
-        :param str/int socket_path: Path on the filesystem for the
-                                    socket to bind to. This socket does
-                                    not need to exist prior to calling
-                                    this method, but parent directories
-                                    should.
-                                    It may also be of type 'int', in
-                                    which case it is used as the port
-                                    for a tcp localhost connection.
         '''
         # Start up the ioloop
         log.trace('IPCServer: binding to socket: {0}'.format(self.socket_path))
@@ -69,6 +122,7 @@ class IPCServer(object):
             self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             self.sock.setblocking(0)
             self.sock.bind(('127.0.0.1', self.socket_path))
+            # Based on default used in tornado.netutil.bind_sockets()
             self.sock.listen(128)
         else:
             self.sock = tornado.netutil.bind_unix_socket(self.socket_path)
@@ -199,15 +253,17 @@ class IPCClient(object):
         self.io_loop = io_loop or tornado.ioloop.IOLoop.current()
         self.socket_path = socket_path
         self._closing = False
+        self.stream = None
+        self.unpacker = msgpack.Unpacker()
 
     def __init__(self, socket_path, io_loop=None):
         # Handled by singleton __new__
         pass
 
     def connected(self):
-        return hasattr(self, 'stream')
+        return self.stream is not None and not self.stream.closed()
 
-    def connect(self, callback=None):
+    def connect(self, callback=None, timeout=None):
         '''
         Connect to the IPC socket
         '''
@@ -216,7 +272,7 @@ class IPCClient(object):
         else:
             future = tornado.concurrent.Future()
             self._connecting_future = future
-            self.io_loop.add_callback(self._connect)
+            self.io_loop.add_callback(self._connect, timeout=timeout)
 
         if callback is not None:
             def handle_future(future):
@@ -226,7 +282,7 @@ class IPCClient(object):
         return future
 
     @tornado.gen.coroutine
-    def _connect(self):
+    def _connect(self, timeout=None):
         '''
         Connect to a running IPCServer
         '''
@@ -237,21 +293,37 @@ class IPCClient(object):
             sock_type = socket.AF_UNIX
             sock_addr = self.socket_path
 
-        self.stream = IOStream(
-            socket.socket(sock_type, socket.SOCK_STREAM),
-            io_loop=self.io_loop,
-        )
+        self.stream = None
+        if timeout is not None:
+            timeout_at = time.time() + timeout
+
         while True:
             if self._closing:
                 break
+
+            if self.stream is None:
+                self.stream = IOStream(
+                    socket.socket(sock_type, socket.SOCK_STREAM),
+                    io_loop=self.io_loop,
+                )
+
             try:
                 log.trace('IPCClient: Connecting to socket: {0}'.format(self.socket_path))
                 yield self.stream.connect(sock_addr)
                 self._connecting_future.set_result(True)
                 break
             except Exception as e:
-                yield tornado.gen.sleep(1)  # TODO: backoff
-                #self._connecting_future.set_exception(e)
+                if self.stream.closed():
+                    self.stream = None
+
+                if timeout is None or time.time() > timeout_at:
+                    if self.stream is not None:
+                        self.stream.close()
+                        self.stream = None
+                    self._connecting_future.set_exception(e)
+                    break
+
+                yield tornado.gen.sleep(1)
 
     def __del__(self):
         self.close()
@@ -265,7 +337,7 @@ class IPCClient(object):
         if self._closing:
             return
         self._closing = True
-        if hasattr(self, 'stream'):
+        if self.stream is not None and not self.stream.closed():
             self.stream.close()
 
 
@@ -352,3 +424,283 @@ class IPCMessageServer(IPCServer):
 
     See IPCMessageClient() for an example of sending messages to an IPCMessageServer instance
     '''
+
+
+class IPCMessagePublisher(object):
+    '''
+    A Tornado IPC Publisher similar to Tornado's TCPServer class
+    but using either UNIX domain sockets or TCP sockets
+    '''
+    def __init__(self, socket_path, io_loop=None):
+        '''
+        Create a new Tornado IPC server
+        :param str/int socket_path: Path on the filesystem for the
+                                    socket to bind to. This socket does
+                                    not need to exist prior to calling
+                                    this method, but parent directories
+                                    should.
+                                    It may also be of type 'int', in
+                                    which case it is used as the port
+                                    for a tcp localhost connection.
+        :param IOLoop io_loop: A Tornado ioloop to handle scheduling
+        '''
+        self.socket_path = socket_path
+        self._started = False
+
+        # Placeholders for attributes to be populated by method calls
+        self.sock = None
+        self.io_loop = io_loop or IOLoop.current()
+        self._closing = False
+        self.streams = set()
+
+    def start(self):
+        '''
+        Perform the work necessary to start up a Tornado IPC server
+
+        Blocks until socket is established
+        '''
+        # Start up the ioloop
+        log.trace('IPCMessagePublisher: binding to socket: {0}'.format(self.socket_path))
+        if isinstance(self.socket_path, int):
+            self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            self.sock.setblocking(0)
+            self.sock.bind(('127.0.0.1', self.socket_path))
+            # Based on default used in tornado.netutil.bind_sockets()
+            self.sock.listen(128)
+        else:
+            self.sock = tornado.netutil.bind_unix_socket(self.socket_path)
+
+        tornado.netutil.add_accept_handler(
+            self.sock,
+            self.handle_connection,
+            io_loop=self.io_loop,
+        )
+        self._started = True
+
+    @tornado.gen.coroutine
+    def _write(self, stream, pack):
+        try:
+            yield stream.write(pack)
+        except tornado.iostream.StreamClosedError:
+            log.trace('Client disconnected from IPC {0}'.format(self.socket_path))
+            self.streams.discard(stream)
+        except Exception as exc:
+            log.error('Exception occurred while handling stream: {0}'.format(exc))
+            if not stream.closed():
+                stream.close()
+            self.streams.discard(stream)
+
+    def publish(self, msg):
+        '''
+        Send message to all connected sockets
+        '''
+        if not len(self.streams):
+            return
+
+        pack = salt.transport.frame.frame_msg(msg, raw_body=True)
+
+        for stream in self.streams:
+            self.io_loop.spawn_callback(self._write, stream, pack)
+
+    def handle_connection(self, connection, address):
+        log.trace('IPCServer: Handling connection to address: {0}'.format(address))
+        try:
+            stream = IOStream(
+                connection,
+                io_loop=self.io_loop,
+            )
+            self.streams.add(stream)
+        except Exception as exc:
+            log.error('IPC streaming error: {0}'.format(exc))
+
+    def close(self):
+        '''
+        Routines to handle any cleanup before the instance shuts down.
+        Sockets and filehandles should be closed explicitly, to prevent
+        leaks.
+        '''
+        if self._closing:
+            return
+        self._closing = True
+        for stream in self.streams:
+            stream.close()
+        self.streams.clear()
+        if hasattr(self.sock, 'close'):
+            self.sock.close()
+
+    def __del__(self):
+        self.close()
+
+
+class IPCMessageSubscriber(IPCClient):
+    '''
+    Salt IPC message subscriber
+
+    Create an IPC client to receive messages from IPC publisher
+
+    An example of a very simple IPCMessageSubscriber connecting to an IPCMessagePublisher.
+    This example assumes an already running IPCMessagePublisher.
+
+    IMPORTANT: The below example also assumes the IOLoop is NOT running.
+
+    # Import Tornado libs
+    import tornado.ioloop
+
+    # Import Salt libs
+    import salt.config
+    import salt.transport.ipc
+
+    # Create a new IO Loop.
+    # We know that this new IO Loop is not currently running.
+    io_loop = tornado.ioloop.IOLoop()
+
+    ipc_publisher_socket_path = '/var/run/ipc_publisher.ipc'
+
+    ipc_subscriber = salt.transport.ipc.IPCMessageSubscriber(ipc_server_socket_path, io_loop=io_loop)
+
+    # Connect to the server
+    # Use the associated IO Loop that isn't running.
+    io_loop.run_sync(ipc_subscriber.connect)
+
+    # Wait for some data
+    package = ipc_subscriber.read_sync()
+    '''
+    def __singleton_init__(self, socket_path, io_loop=None):
+        super(IPCMessageSubscriber, self).__singleton_init__(
+            socket_path, io_loop=io_loop)
+        self._read_sync_future = None
+        self._read_stream_future = None
+        self._sync_ioloop_running = False
+        self.saved_data = []
+
+    @tornado.gen.coroutine
+    def _read_sync(self, timeout):
+        exc_to_raise = None
+        ret = None
+
+        try:
+            while True:
+                if self._read_stream_future is None:
+                    self._read_stream_future = self.stream.read_bytes(4096, partial=True)
+
+                if timeout is None:
+                    wire_bytes = yield self._read_stream_future
+                else:
+                    future_with_timeout = FutureWithTimeout(
+                        self.io_loop, self._read_stream_future, timeout)
+                    wire_bytes = yield future_with_timeout
+
+                self._read_stream_future = None
+
+                # Remove the timeout once we get some data or an exception
+                # occurs. We will assume that the rest of the data is already
+                # there or is coming soon if an exception doesn't occur.
+                timeout = None
+
+                self.unpacker.feed(wire_bytes)
+                first = True
+                for framed_msg in self.unpacker:
+                    if first:
+                        ret = framed_msg['body']
+                        first = False
+                    else:
+                        self.saved_data.append(framed_msg['body'])
+                if not first:
+                    # We read at least one piece of data
+                    break
+        except tornado.ioloop.TimeoutError:
+            # In the timeout case, just return None.
+            # Keep 'self._read_stream_future' alive.
+            ret = None
+        except tornado.iostream.StreamClosedError as exc:
+            log.trace('Subscriber disconnected from IPC {0}'.format(self.socket_path))
+            self._read_stream_future = None
+            exc_to_raise = exc
+        except Exception as exc:
+            log.error('Exception occurred in Subscriber while handling stream: {0}'.format(exc))
+            self._read_stream_future = None
+            exc_to_raise = exc
+
+        if self._sync_ioloop_running:
+            # Stop the IO Loop so that self.io_loop.start() will return in
+            # read_sync().
+            self.io_loop.spawn_callback(self.io_loop.stop)
+
+        if exc_to_raise is not None:
+            raise exc_to_raise  # pylint: disable=E0702
+        raise tornado.gen.Return(ret)
+
+    def read_sync(self, timeout=None):
+        '''
+        Read a message from an IPC socket
+
+        The socket must already be connected.
+        The associated IO Loop must NOT be running.
+        :param int timeout: Timeout when receiving message
+        :return: message data if successful. None if timed out. Will raise an
+                 exception for all other error conditions.
+        '''
+        if self.saved_data:
+            return self.saved_data.pop(0)
+
+        self._sync_ioloop_running = True
+        self._read_sync_future = self._read_sync(timeout)
+        self.io_loop.start()
+        self._sync_ioloop_running = False
+
+        ret_future = self._read_sync_future
+        self._read_sync_future = None
+        return ret_future.result()
+
+    @tornado.gen.coroutine
+    def _read_async(self, callback):
+        while not self.connected():
+            try:
+                yield self.connect()
+            except tornado.iostream.StreamClosedError:
+                log.trace('Subscriber closed stream on IPC {0} before connect'.format(self.socket_path))
+            except Exception as exc:
+                log.error('Exception occurred while Subscriber connecting: {0}'.format(exc))
+
+        while not self.stream.closed():
+            try:
+                self._read_stream_future = self.stream.read_bytes(4096, partial=True)
+                wire_bytes = yield self._read_stream_future
+                self._read_stream_future = None
+                self.unpacker.feed(wire_bytes)
+                for framed_msg in self.unpacker:
+                    body = framed_msg['body']
+                    self.io_loop.spawn_callback(callback, body)
+            except tornado.iostream.StreamClosedError:
+                log.trace('Subscriber disconnected from IPC {0}'.format(self.socket_path))
+                break
+            except Exception as exc:
+                log.error('Exception occurred while Subscriber handling stream: {0}'.format(exc))
+
+    def read_async(self, callback):
+        '''
+        Asynchronously read messages and invoke a callback when they are ready.
+
+        :param callback: A callback with the received data
+        '''
+        self.io_loop.spawn_callback(self._read_async, callback)
+
+    def close(self):
+        '''
+        Routines to handle any cleanup before the instance shuts down.
+        Sockets and filehandles should be closed explicitly, to prevent
+        leaks.
+        '''
+        if not self._closing:
+            IPCClient.close(self)
+            # This will prevent this message from showing up:
+            # '[ERROR   ] Future exception was never retrieved:
+            # StreamClosedError'
+            if self._read_sync_future is not None:
+                self._read_sync_future.exc_info()
+            if self._read_stream_future is not None:
+                self._read_stream_future.exc_info()
+
+    def __del__(self):
+        self.close()

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -297,6 +297,10 @@ class AsyncTCPPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.tran
 
         @tornado.gen.coroutine
         def wrap_callback(body):
+            if not isinstance(body, dict):
+                # TODO: For some reason we need to decode here for things
+                #       to work. Fix this.
+                body = msgpack.loads(body)
             ret = yield self._decode_payload(body)
             callback(ret)
         return self.message_client.on_recv(wrap_callback)

--- a/salt/utils/async.py
+++ b/salt/utils/async.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import
 
 import tornado.ioloop
 import tornado.concurrent
-LOOP_CLASS = tornado.ioloop.IOLoop
 # attempt to use zmq-- if we have it otherwise fallback to tornado loop
 try:
     import zmq.eventloop.ioloop
@@ -15,8 +14,10 @@ try:
     if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
         zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
     LOOP_CLASS = zmq.eventloop.ioloop.ZMQIOLoop
+    HAS_ZMQ = True
 except ImportError:
-    pass  # salt-ssh doesn't dep zmq
+    LOOP_CLASS = tornado.ioloop.IOLoop
+    HAS_ZMQ = False
 
 import contextlib
 
@@ -52,7 +53,7 @@ class SyncWrapper(object):
         if kwargs is None:
             kwargs = {}
 
-        self.io_loop = zmq.eventloop.ioloop.ZMQIOLoop()
+        self.io_loop = LOOP_CLASS()
         kwargs['io_loop'] = self.io_loop
 
         with current_ioloop(self.io_loop):

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -55,7 +55,6 @@ from __future__ import absolute_import
 # Import python libs
 import os
 import time
-import errno
 import fnmatch
 import hashlib
 import logging
@@ -65,28 +64,22 @@ from multiprocessing.util import Finalize
 
 # Import third party libs
 import salt.ext.six as six
-try:
-    import zmq
-    import zmq.eventloop.ioloop
-    # support pyzmq 13.0.x, TODO: remove once we force people to 14.0.x
-    if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
-        zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
-    import zmq.eventloop.zmqstream
-except ImportError:
-    # Local mode does not need zmq
-    pass
+import tornado.ioloop
+import tornado.iostream
 
 # Import salt libs
 import salt.config
 import salt.payload
 import salt.loader
 import salt.utils
+import salt.utils.async
 import salt.utils.cache
 import salt.utils.dicttrim
 import salt.utils.process
 import salt.utils.zeromq
 import salt.log.setup
 import salt.defaults.exitcodes
+import salt.transport.ipc
 
 log = logging.getLogger(__name__)
 
@@ -117,16 +110,23 @@ TAGS = {
 }
 
 
-def get_event(node, sock_dir=None, transport='zeromq', opts=None, listen=True):
+def get_event(
+        node, sock_dir=None, transport='zeromq',
+        opts=None, listen=True, io_loop=None):
     '''
     Return an event object suitable for the named transport
+
+    :param IOLoop io_loop: Pass in an io_loop if you want asynchronous
+                           operation for obtaining events. Eg use of
+                           set_event_handler() API. Otherwise, operation
+                           will be synchronous.
     '''
     sock_dir = sock_dir or opts['sock_dir']
     # TODO: AIO core is separate from transport
     if transport in ('zeromq', 'tcp'):
         if node == 'master':
-            return MasterEvent(sock_dir, opts, listen=listen)
-        return SaltEvent(node, sock_dir, opts, listen=listen)
+            return MasterEvent(sock_dir, opts, listen=listen, io_loop=io_loop)
+        return SaltEvent(node, sock_dir, opts, listen=listen, io_loop=io_loop)
     elif transport == 'raet':
         import salt.utils.raetevent
         return salt.utils.raetevent.RAETEvent(node,
@@ -135,13 +135,13 @@ def get_event(node, sock_dir=None, transport='zeromq', opts=None, listen=True):
                                               opts=opts)
 
 
-def get_master_event(opts, sock_dir, listen=True):
+def get_master_event(opts, sock_dir, listen=True, io_loop=None):
     '''
     Return an event object suitable for the named transport
     '''
     # TODO: AIO core is separate from transport
     if opts['transport'] in ('zeromq', 'tcp'):
-        return MasterEvent(sock_dir, opts, listen=listen)
+        return MasterEvent(sock_dir, opts, listen=listen, io_loop=io_loop)
     elif opts['transport'] == 'raet':
         import salt.utils.raetevent
         return salt.utils.raetevent.MasterEvent(
@@ -175,12 +175,26 @@ class SaltEvent(object):
     RAET compatible
     The base class used to manage salt events
     '''
-    def __init__(self, node, sock_dir=None, opts=None, listen=True):
+    def __init__(
+            self, node, sock_dir=None,
+            opts=None, listen=True, io_loop=None):
+        '''
+        :param IOLoop io_loop: Pass in an io_loop if you want asynchronous
+                               operation for obtaining events. Eg use of
+                               set_event_handler() API. Otherwise, operation
+                               will be synchronous.
+        '''
         self.serial = salt.payload.Serial({'serial': 'msgpack'})
-        self.context = zmq.Context()
-        self.poller = zmq.Poller()
+        if io_loop is not None:
+            self.io_loop = io_loop
+            self._run_io_loop_sync = False
+        else:
+            self.io_loop = tornado.ioloop.IOLoop()
+            self._run_io_loop_sync = True
         self.cpub = False
         self.cpush = False
+        self.subscriber = None
+        self.pusher = None
 
         if opts is None:
             opts = {}
@@ -223,46 +237,34 @@ class SaltEvent(object):
         '''
         if node == 'master':
             if self.opts['ipc_mode'] == 'tcp':
-                puburi = 'tcp://127.0.0.1:{0}'.format(
-                    self.opts['tcp_master_pub_port']
-                    )
-                pulluri = 'tcp://127.0.0.1:{0}'.format(
-                    self.opts['tcp_master_pull_port']
-                    )
+                puburi = int(self.opts['tcp_master_pub_port'])
+                pulluri = int(self.opts['tcp_master_pull_port'])
             else:
-                puburi = 'ipc://{0}'.format(os.path.join(
+                puburi = os.path.join(
                     sock_dir,
                     'master_event_pub.ipc'
-                    ))
-                salt.utils.zeromq.check_ipc_path_max_len(puburi)
-                pulluri = 'ipc://{0}'.format(os.path.join(
+                )
+                pulluri = os.path.join(
                     sock_dir,
                     'master_event_pull.ipc'
-                    ))
-                salt.utils.zeromq.check_ipc_path_max_len(pulluri)
+                )
         else:
             if self.opts['ipc_mode'] == 'tcp':
-                puburi = 'tcp://127.0.0.1:{0}'.format(
-                    self.opts['tcp_pub_port']
-                    )
-                pulluri = 'tcp://127.0.0.1:{0}'.format(
-                    self.opts['tcp_pull_port']
-                    )
+                puburi = int(self.opts['tcp_pub_port'])
+                pulluri = int(self.opts['tcp_pull_port'])
             else:
                 hash_type = getattr(hashlib, self.opts['hash_type'])
                 # Only use the first 10 chars to keep longer hashes from exceeding the
                 # max socket path length.
                 id_hash = hash_type(salt.utils.to_bytes(self.opts['id'])).hexdigest()[:10]
-                puburi = 'ipc://{0}'.format(os.path.join(
+                puburi = os.path.join(
                     sock_dir,
                     'minion_event_{0}_pub.ipc'.format(id_hash)
-                    ))
-                salt.utils.zeromq.check_ipc_path_max_len(puburi)
-                pulluri = 'ipc://{0}'.format(os.path.join(
+                )
+                pulluri = os.path.join(
                     sock_dir,
                     'minion_event_{0}_pull.ipc'.format(id_hash)
-                    ))
-                salt.utils.zeromq.check_ipc_path_max_len(pulluri)
+                )
         log.debug(
             '{0} PUB socket URI: {1}'.format(self.__class__.__name__, puburi)
         )
@@ -302,32 +304,69 @@ class SaltEvent(object):
             if any(pmatch_func(evt['tag'], ptag) for ptag, pmatch_func in self.pending_tags):
                 self.pending_events.append(evt)
 
-    def connect_pub(self):
+    def connect_pub(self, timeout=None):
         '''
         Establish the publish connection
         '''
-        self.sub = self.context.socket(zmq.SUB)
-        try:
-            self.sub.setsockopt(zmq.HWM, self.opts['salt_event_pub_hwm'])
-        except AttributeError:
-            self.sub.setsockopt(zmq.SNDHWM, self.opts['salt_event_pub_hwm'])
-            self.sub.setsockopt(zmq.RCVHWM, self.opts['salt_event_pub_hwm'])
-        self.sub.connect(self.puburi)
-        self.poller.register(self.sub, zmq.POLLIN)
-        self.sub.setsockopt_string(zmq.SUBSCRIBE, u'')
-        self.sub.setsockopt(zmq.LINGER, 5000)
-        self.cpub = True
+        if self.cpub:
+            return True
 
-    def connect_pull(self, timeout=1000):
+        if self._run_io_loop_sync:
+            with salt.utils.async.current_ioloop(self.io_loop):
+                if self.subscriber is None:
+                    self.subscriber = salt.transport.ipc.IPCMessageSubscriber(
+                    self.puburi,
+                    io_loop=self.io_loop
+                )
+                try:
+                    self.io_loop.run_sync(
+                        lambda: self.subscriber.connect(timeout=timeout))
+                    self.cpub = True
+                except Exception:
+                    pass
+        else:
+            if self.subscriber is None:
+                self.subscriber = salt.transport.ipc.IPCMessageSubscriber(
+                self.puburi,
+                io_loop=self.io_loop
+            )
+
+            # For the async case, the connect will be defered to when
+            # set_event_handler() is invoked.
+            self.cpub = True
+        return self.cpub
+
+    def connect_pull(self, timeout=1):
         '''
         Establish a connection with the event pull socket
-        Set the linger timeout of the socket options to timeout (in milliseconds)
-        Default timeout is 1000 ms
+        Default timeout is 1 s
         '''
-        self.push = self.context.socket(zmq.PUSH)
-        self.push.setsockopt(zmq.LINGER, timeout)
-        self.push.connect(self.pulluri)
-        self.cpush = True
+        if self.cpush:
+            return True
+
+        if self._run_io_loop_sync:
+            with salt.utils.async.current_ioloop(self.io_loop):
+                if self.pusher is None:
+                    self.pusher = salt.transport.ipc.IPCMessageClient(
+                        self.pulluri,
+                        io_loop=self.io_loop
+                    )
+                try:
+                    self.io_loop.run_sync(
+                        lambda: self.subscriber.connect(timeout=timeout))
+                    self.cpush = True
+                except Exception:
+                    pass
+        else:
+            if self.pusher is None:
+                self.pusher = salt.transport.ipc.IPCMessageClient(
+                    self.pulluri,
+                    io_loop=self.io_loop
+                )
+            # For the async case, the connect will be defered to when
+            # fire_event() is invoked.
+            self.cpush = True
+        return self.cpush
 
     @classmethod
     def unpack(cls, raw, serial=None):
@@ -422,6 +461,10 @@ class SaltEvent(object):
         run_once = False
         if no_block is True:
             wait = 0
+        elif wait == 0:
+            # If no_block is False and wait is 0, that
+            # means an infinite timeout.
+            wait = None
         while (run_once is False and not wait) or time.time() <= timeout_at:
             if no_block is True:
                 if run_once is True:
@@ -429,19 +472,20 @@ class SaltEvent(object):
                 # Trigger that at least a single iteration has gone through
                 run_once = True
             try:
-                # convert to milliseconds
-                socks = dict(self.poller.poll(wait * 1000))
-                if socks.get(self.sub) != zmq.POLLIN:
-                    continue
+                # tornado.ioloop.IOLoop.run_sync() timeouts are in seconds.
+                # IPCMessageSubscriber.read_sync() uses this type of timeout.
+                if not self.cpub and not self.connect_pub(timeout=wait):
+                    break
 
-                ret = self.get_event_block()
+                raw = self.subscriber.read_sync(timeout=wait)
+                if raw is None:
+                    break
+                mtag, data = self.unpack(raw, self.serial)
+                ret = {'data': data, 'tag': mtag}
             except KeyboardInterrupt:
                 return {'tag': 'salt/event/exit', 'data': {}}
-            except zmq.ZMQError as ex:
-                if ex.errno == errno.EAGAIN or ex.errno == errno.EINTR:
-                    continue
-                else:
-                    raise
+            except tornado.iostream.StreamClosedError:
+                return None
 
             if not match_func(ret['tag'], tag):
                 # tag not match
@@ -509,6 +553,8 @@ class SaltEvent(object):
         request, it MUST subscribe the result to ensure the response is not lost
         should other regions of code call get_event for other purposes.
         '''
+        assert self._run_io_loop_sync
+
         if use_pending is not None:
             salt.utils.warn_until(
                 'Nitrogen',
@@ -525,7 +571,8 @@ class SaltEvent(object):
 
         ret = self._check_pending(tag, match_func)
         if ret is None:
-            ret = self._get_event(wait, tag, match_func, no_block)
+            with salt.utils.async.current_ioloop(self.io_loop):
+                ret = self._get_event(wait, tag, match_func, no_block)
 
         if ret is None or full:
             return ret
@@ -535,9 +582,14 @@ class SaltEvent(object):
     def get_event_noblock(self):
         '''Get the raw event without blocking or any other niceties
         '''
+        assert self._run_io_loop_sync
+
         if not self.cpub:
-            self.connect_pub()
-        raw = self.sub.recv(zmq.NOBLOCK)
+            if not self.connect_pub():
+                return None
+        raw = self.subscriber.read_sync(timeout=0)
+        if raw is None:
+            return None
         mtag, data = self.unpack(raw, self.serial)
         return {'data': data, 'tag': mtag}
 
@@ -545,7 +597,14 @@ class SaltEvent(object):
         '''Get the raw event in a blocking fashion
            Slower, but decreases the possibility of dropped events
         '''
-        raw = self.sub.recv()
+        assert self._run_io_loop_sync
+
+        if not self.cpub:
+            if not self.connect_pub():
+                return None
+        raw = self.subscriber.read_sync(timeout=None)
+        if raw is None:
+            return None
         mtag, data = self.unpack(raw, self.serial)
         return {'data': data, 'tag': mtag}
 
@@ -565,7 +624,6 @@ class SaltEvent(object):
         event identifier "tag"
 
         The default is 1000 ms
-        Note the linger timeout must be at least as long as this timeout
         '''
         if not str(tag):  # no empty tags allowed
             raise ValueError('Empty tag.')
@@ -576,7 +634,12 @@ class SaltEvent(object):
             )
 
         if not self.cpush:
-            self.connect_pull(timeout=timeout)
+            if timeout is not None:
+                timeout_s = float(timeout) / 1000
+            else:
+                timeout_s = None
+            if not self.connect_pull(timeout=timeout_s):
+                return False
 
         data['_stamp'] = datetime.datetime.utcnow().isoformat()
 
@@ -588,11 +651,16 @@ class SaltEvent(object):
         )
         log.debug('Sending event - data = {0}'.format(data))
         event = '{0}{1}{2}'.format(tag, tagend, serialized_data)
-        try:
-            self.push.send(salt.utils.to_bytes(event, 'utf-8'))
-        except Exception as ex:
-            log.debug(ex)
-            raise
+        msg = salt.utils.to_bytes(event, 'utf-8')
+        if self._run_io_loop_sync:
+            with salt.utils.async.current_ioloop(self.io_loop):
+                try:
+                    self.io_loop.run_sync(lambda: self.pusher.send(msg))
+                except Exception as ex:
+                    log.debug(ex)
+                    raise
+        else:
+            self.io_loop.spawn_callback(self.pusher.send, msg)
         return True
 
     def fire_master(self, data, tag, timeout=1000):
@@ -610,39 +678,13 @@ class SaltEvent(object):
         }
         return self.fire_event(msg, "fire_master", timeout)
 
-    def destroy(self, linger=5000):
-        if self.cpub is True and self.sub.closed is False:
-            # Wait at most 2.5 secs to send any remaining messages in the
-            # socket or the context.term() below will hang indefinitely.
-            # See https://github.com/zeromq/pyzmq/issues/102
-            self.sub.close()
-        if self.cpush is True and self.push.closed is False:
-            self.push.close()
-        # If sockets are not unregistered from a poller, nothing which touches
-        # that poller gets garbage collected. The Poller itself, its
-        # registered sockets and the Context
-        if isinstance(self.poller.sockets, dict):
-            for socket in six.iterkeys(self.poller.sockets):
-                if socket.closed is False:
-                    socket.setsockopt(zmq.LINGER, linger)
-                    socket.close()
-                self.poller.unregister(socket)
-        else:
-            for socket in self.poller.sockets:
-                if socket[0].closed is False:
-                    socket[0].setsockopt(zmq.LINGER, linger)
-                    socket[0].close()
-                self.poller.unregister(socket[0])
-        if self.context.closed is False:
-            self.context.term()
-
-        # Hardcore destruction
-        if hasattr(self.context, 'destroy'):
-            self.context.destroy(linger=1)
-
-        # https://github.com/zeromq/pyzmq/issues/173#issuecomment-4037083
-        # Assertion failed: get_load () == 0 (poller_base.cpp:32)
-        time.sleep(0.025)
+    def destroy(self):
+        if self.subscriber is not None:
+            self.subscriber.close()
+        if self.pusher is not None:
+            self.pusher.close()
+        if self._run_io_loop_sync:
+            self.io_loop.close()
 
     def fire_ret_load(self, load):
         '''
@@ -678,6 +720,17 @@ class SaltEvent(object):
                 except Exception:
                     pass
 
+    def set_event_handler(self, event_handler):
+        '''
+        Invoke the event_handler callback each time an event arrives.
+        '''
+        assert not self._run_io_loop_sync
+
+        if not self.cpub:
+            self.connect_pub()
+        # This will handle reconnects
+        self.subscriber.read_async(event_handler)
+
     def __del__(self):
         # skip exceptions in destroy-- since destroy() doesn't cover interpreter
         # shutdown-- where globals start going missing
@@ -693,8 +746,9 @@ class MasterEvent(SaltEvent):
     RAET compatible
     Create a master event management object
     '''
-    def __init__(self, sock_dir, opts=None, listen=True):
-        super(MasterEvent, self).__init__('master', sock_dir, opts, listen=listen)
+    def __init__(self, sock_dir, opts=None, listen=True, io_loop=None):
+        super(MasterEvent, self).__init__(
+            'master', sock_dir, opts, listen=listen, io_loop=io_loop)
 
 
 class LocalClientEvent(MasterEvent):
@@ -727,9 +781,10 @@ class MinionEvent(SaltEvent):
     RAET compatible
     Create a master event management object
     '''
-    def __init__(self, opts, listen=True):
+    def __init__(self, opts, listen=True, io_loop=None):
         super(MinionEvent, self).__init__(
-            'minion', sock_dir=opts.get('sock_dir'), opts=opts, listen=listen)
+            'minion', sock_dir=opts.get('sock_dir'),
+            opts=opts, listen=listen, io_loop=io_loop)
 
 
 class AsyncEventPublisher(object):
@@ -745,8 +800,8 @@ class AsyncEventPublisher(object):
 
         self.publish_handler = publish_handler
 
-        self.io_loop = io_loop or zmq.eventloop.ioloop.ZMQIOLoop()
-        self.context = zmq.Context()
+        self.io_loop = io_loop or tornado.ioloop.IOLoop.current()
+        self._closing = False
 
         hash_type = getattr(hashlib, self.opts['hash_type'])
         # Only use the first 10 chars to keep longer hashes from exceeding the
@@ -765,20 +820,12 @@ class AsyncEventPublisher(object):
         if os.path.exists(epull_sock_path):
             os.unlink(epull_sock_path)
 
-        self.epub_sock = self.context.socket(zmq.PUB)
-
         if self.opts['ipc_mode'] == 'tcp':
-            epub_uri = 'tcp://127.0.0.1:{0}'.format(
-                self.opts['tcp_pub_port']
-            )
-            epull_uri = 'tcp://127.0.0.1:{0}'.format(
-                self.opts['tcp_pull_port']
-            )
+            epub_uri = int(self.opts['tcp_pub_port'])
+            epull_uri = int(self.opts['tcp_pull_port'])
         else:
-            epub_uri = 'ipc://{0}'.format(epub_sock_path)
-            salt.utils.zeromq.check_ipc_path_max_len(epub_uri)
-            epull_uri = 'ipc://{0}'.format(epull_sock_path)
-            salt.utils.zeromq.check_ipc_path_max_len(epull_uri)
+            epub_uri = epub_sock_path
+            epull_uri = epull_sock_path
 
         log.debug(
             '{0} PUB socket URI: {1}'.format(
@@ -813,57 +860,50 @@ class AsyncEventPublisher(object):
                         # Let's stop at this stage
                         raise
 
-        # Create the pull socket
-        self.epull_sock = self.context.socket(zmq.PULL)
+        self.publisher = salt.transport.ipc.IPCMessagePublisher(
+            epub_uri,
+            io_loop=self.io_loop
+        )
 
-        # Securely bind the event sockets
-        if self.opts['ipc_mode'] != 'tcp':
-            old_umask = os.umask(0o177)
+        self.puller = salt.transport.ipc.IPCMessageServer(
+            epull_uri,
+            io_loop=self.io_loop,
+            payload_handler=self.handle_publish
+        )
+
+        log.info('Starting pull socket on {0}'.format(epull_uri))
+        old_umask = os.umask(0o177)
         try:
-            log.info('Starting pub socket on {0}'.format(epub_uri))
-            self.epub_sock.bind(epub_uri)
-            log.info('Starting pull socket on {0}'.format(epull_uri))
-            self.epull_sock.bind(epull_uri)
+            self.publisher.start()
+            self.puller.start()
         finally:
-            if self.opts['ipc_mode'] != 'tcp':
-                os.umask(old_umask)
+            os.umask(old_umask)
 
-        self.stream = zmq.eventloop.zmqstream.ZMQStream(self.epull_sock, io_loop=self.io_loop)
-        self.stream.on_recv(self.handle_publish)
-
-    def handle_publish(self, package):
+    def handle_publish(self, package, _):
         '''
         Get something from epull, publish it out epub, and return the package (or None)
         '''
-        package = package[0]
         try:
-            self.epub_sock.send(package)
+            self.publisher.publish(package)
             self.io_loop.spawn_callback(self.publish_handler, package)
             return package
         # Add an extra fallback in case a forked process leeks through
-        except zmq.ZMQError as exc:
-            # The interrupt caused by python handling the
-            # SIGCHLD. Throws this error with errno == EINTR.
-            # Nothing to receive on the zmq socket throws this error
-            # with EAGAIN.
-            # Both are safe to ignore
-            if exc.errno != errno.EAGAIN and exc.errno != errno.EINTR:
-                log.critical('Unexpected ZMQError while polling minion',
-                             exc_info=True)
+        except Exception:
+            log.critical('Unexpected error while polling minion events',
+                         exc_info=True)
             return None
 
-    def destroy(self):
-        if hasattr(self, 'stream') and self.stream.closed is False:
-            self.stream.close()
-        if hasattr(self, 'epub_sock') and self.epub_sock.closed is False:
-            self.epub_sock.close()
-        if hasattr(self, 'epull_sock') and self.epull_sock.closed is False:
-            self.epull_sock.close()
-        if hasattr(self, 'context') and self.context.closed is False:
-            self.context.term()
+    def close(self):
+        if self._closing:
+            return
+        self._closing = True
+        if hasattr(self, 'publisher'):
+            self.publisher.close()
+        if hasattr(self, 'puller'):
+            self.puller.close()
 
     def __del__(self):
-        self.destroy()
+        self.close()
 
 
 class EventPublisher(salt.utils.process.SignalHandlingMultiprocessingProcess):
@@ -875,87 +915,93 @@ class EventPublisher(salt.utils.process.SignalHandlingMultiprocessingProcess):
         super(EventPublisher, self).__init__(log_queue=log_queue)
         self.opts = salt.config.DEFAULT_MASTER_OPTS.copy()
         self.opts.update(opts)
+        self._closing = False
 
     def run(self):
         '''
         Bind the pub and pull sockets for events
         '''
         salt.utils.appendproctitle(self.__class__.__name__)
-        # Set up the context
-        self.context = zmq.Context(1)
-        # Prepare the master event publisher
-        self.epub_sock = self.context.socket(zmq.PUB)
-        try:
-            self.epub_sock.setsockopt(zmq.HWM, self.opts['event_publisher_pub_hwm'])
-        except AttributeError:
-            self.epub_sock.setsockopt(zmq.SNDHWM, self.opts['event_publisher_pub_hwm'])
-            self.epub_sock.setsockopt(zmq.RCVHWM, self.opts['event_publisher_pub_hwm'])
-        # Prepare master event pull socket
-        self.epull_sock = self.context.socket(zmq.PULL)
-        if self.opts['ipc_mode'] == 'tcp':
-            epub_uri = 'tcp://127.0.0.1:{0}'.format(
-                self.opts['tcp_master_pub_port']
+        self.io_loop = tornado.ioloop.IOLoop()
+        with salt.utils.async.current_ioloop(self.io_loop):
+            if self.opts['ipc_mode'] == 'tcp':
+                epub_uri = int(self.opts['tcp_master_pub_port'])
+                epull_uri = int(self.opts['tcp_master_pull_port'])
+            else:
+                epub_uri = os.path.join(
+                    self.opts['sock_dir'],
+                    'master_event_pub.ipc'
                 )
-            epull_uri = 'tcp://127.0.0.1:{0}'.format(
-                self.opts['tcp_master_pull_port']
+                epull_uri = os.path.join(
+                    self.opts['sock_dir'],
+                    'master_event_pull.ipc'
                 )
-        else:
-            epub_uri = 'ipc://{0}'.format(
-                os.path.join(self.opts['sock_dir'], 'master_event_pub.ipc')
-                )
-            salt.utils.zeromq.check_ipc_path_max_len(epub_uri)
-            epull_uri = 'ipc://{0}'.format(
-                os.path.join(self.opts['sock_dir'], 'master_event_pull.ipc')
-                )
-            salt.utils.zeromq.check_ipc_path_max_len(epull_uri)
 
-        # Start the master event publisher
-        old_umask = os.umask(0o177)
-        try:
-            self.epull_sock.bind(epull_uri)
-            self.epub_sock.bind(epub_uri)
-            if self.opts['client_acl'] or self.opts['client_acl_blacklist']:
-                salt.utils.warn_until(
-                        'Nitrogen',
-                        'ACL rules should be configured with \'publisher_acl\' and '
-                        '\'publisher_acl_blacklist\' not \'client_acl\' and '
-                        '\'client_acl_blacklist\'. This functionality will be removed in Salt '
-                        'Nitrogen.'
-                        )
-            if (self.opts['ipc_mode'] != 'tcp' and (
-                    self.opts['publisher_acl'] or
-                    self.opts['client_acl'] or
-                    self.opts['external_auth'])):
-                os.chmod(os.path.join(
-                    self.opts['sock_dir'], 'master_event_pub.ipc'), 0o666)
-        finally:
-            os.umask(old_umask)
+            self.publisher = salt.transport.ipc.IPCMessagePublisher(
+                epub_uri,
+                io_loop=self.io_loop
+            )
 
-        # Make sure the ZMQ context and respective sockets are closed and
-        # destroyed
-        Finalize(self, self.destroy_zmq_context, exitpriority=15)
+            self.puller = salt.transport.ipc.IPCMessageServer(
+                epull_uri,
+                io_loop=self.io_loop,
+                payload_handler=self.handle_publish,
+            )
 
-        while True:
-            # Catch and handle EINTR from when this process is sent
-            # SIGUSR1 gracefully so we don't choke and die horribly
+            # Start the master event publisher
+            old_umask = os.umask(0o177)
             try:
-                package = self.epull_sock.recv()
-                self.epub_sock.send(package)
-            except zmq.ZMQError as exc:
-                if exc.errno == errno.EINTR:
-                    continue
-                raise exc
+                self.publisher.start()
+                self.puller.start()
+                if self.opts['client_acl'] or self.opts['client_acl_blacklist']:
+                    salt.utils.warn_until(
+                            'Nitrogen',
+                            'ACL rules should be configured with \'publisher_acl\' and '
+                            '\'publisher_acl_blacklist\' not \'client_acl\' and '
+                            '\'client_acl_blacklist\'. This functionality will be removed in Salt '
+                            'Nitrogen.'
+                            )
+                if (self.opts['ipc_mode'] != 'tcp' and (
+                        self.opts['publisher_acl'] or
+                        self.opts['client_acl'] or
+                        self.opts['external_auth'])):
+                    os.chmod(os.path.join(
+                        self.opts['sock_dir'], 'master_event_pub.ipc'), 0o666)
+            finally:
+                os.umask(old_umask)
 
-    def destroy_zmq_context(self):
-        linger = 5000
-        if self.epub_sock.closed is False:
-            self.epub_sock.setsockopt(zmq.LINGER, linger)
-            self.epub_sock.close()
-        if self.epull_sock.closed is False:
-            self.epull_sock.setsockopt(zmq.LINGER, linger)
-            self.epull_sock.close()
-        if self.context.closed is False:
-            self.context.term()
+            # Make sure the IO loop and respective sockets are closed and
+            # destroyed
+            Finalize(self, self.close, exitpriority=15)
+
+            self.io_loop.start()
+
+    def handle_publish(self, package, _):
+        '''
+        Get something from epull, publish it out epub, and return the package (or None)
+        '''
+        try:
+            self.publisher.publish(package)
+            return package
+        # Add an extra fallback in case a forked process leeks through
+        except Exception:
+            log.critical('Unexpected error while polling master events',
+                         exc_info=True)
+            return None
+
+    def close(self):
+        if self._closing:
+            return
+        self._closing = True
+        if hasattr(self, 'publisher'):
+            self.publisher.close()
+        if hasattr(self, 'puller'):
+            self.puller.close()
+        if hasattr(self, 'io_loop'):
+            self.io_loop.close()
+
+    def __del__(self):
+        self.close()
 
 
 class EventReturn(salt.utils.process.SignalHandlingMultiprocessingProcess):
@@ -1023,9 +1069,6 @@ class EventReturn(salt.utils.process.SignalHandlingMultiprocessingProcess):
                     self.flush_events()
                 if self.stop:
                     break
-        except zmq.error.ZMQError as exc:
-            if exc.errno != errno.EINTR:  # Outside interrupt is a normal shutdown case
-                raise
         finally:  # flush all we have at this moment
             if self.event_queue:
                 self.flush_events()

--- a/tests/unit/utils/event_test.py
+++ b/tests/unit/utils/event_test.py
@@ -103,13 +103,13 @@ class TestSaltEvent(TestCase):
     def test_master_event(self):
         me = event.MasterEvent(SOCK_DIR, listen=False)
         self.assertEqual(
-            me.puburi, 'ipc://{0}'.format(
+            me.puburi, '{0}'.format(
                 os.path.join(SOCK_DIR, 'master_event_pub.ipc')
             )
         )
         self.assertEqual(
             me.pulluri,
-            'ipc://{0}'.format(
+            '{0}'.format(
                 os.path.join(SOCK_DIR, 'master_event_pull.ipc')
             )
         )
@@ -120,7 +120,7 @@ class TestSaltEvent(TestCase):
         me = event.MinionEvent(opts, listen=False)
         self.assertEqual(
             me.puburi,
-            'ipc://{0}'.format(
+            '{0}'.format(
                 os.path.join(
                     SOCK_DIR, 'minion_event_{0}_pub.ipc'.format(id_hash)
                 )
@@ -128,7 +128,7 @@ class TestSaltEvent(TestCase):
         )
         self.assertEqual(
             me.pulluri,
-            'ipc://{0}'.format(
+            '{0}'.format(
                 os.path.join(
                     SOCK_DIR, 'minion_event_{0}_pull.ipc'.format(id_hash)
                 )
@@ -138,15 +138,15 @@ class TestSaltEvent(TestCase):
     def test_minion_event_tcp_ipc_mode(self):
         opts = dict(id='foo', ipc_mode='tcp')
         me = event.MinionEvent(opts, listen=False)
-        self.assertEqual(me.puburi, 'tcp://127.0.0.1:4510')
-        self.assertEqual(me.pulluri, 'tcp://127.0.0.1:4511')
+        self.assertEqual(me.puburi, 4510)
+        self.assertEqual(me.pulluri, 4511)
 
     def test_minion_event_no_id(self):
         me = event.MinionEvent(dict(sock_dir=SOCK_DIR), listen=False)
         id_hash = hashlib.md5('').hexdigest()[:10]
         self.assertEqual(
             me.puburi,
-            'ipc://{0}'.format(
+            '{0}'.format(
                 os.path.join(
                     SOCK_DIR, 'minion_event_{0}_pub.ipc'.format(id_hash)
                 )
@@ -154,7 +154,7 @@ class TestSaltEvent(TestCase):
         )
         self.assertEqual(
             me.pulluri,
-            'ipc://{0}'.format(
+            '{0}'.format(
                 os.path.join(
                     SOCK_DIR, 'minion_event_{0}_pull.ipc'.format(id_hash)
                 )


### PR DESCRIPTION
salt/master.py:
- If ZMQ is not importable, use `tornado.ioloop.IOLoop` as the loop class.
- Check HAS_ZMQ before using any zmq.\* content.
- Did not touch `FloMWorker` usage of zmq.*. This is only used when the
  transport is RAET.

salt/minion.py:
- If ZMQ is not importable, use `tornado.ioloop.IOLoop` as the loop class.
- Check HAS_ZMQ before using any zmq.\* content.
- `Syndic` and `MultiSyndic` classes still require ZeroMQ.

salt/transport/ipc.py:
- Added `IPCMessagePublisher`. This is intended to function much like
  ZMQ's zmq.PUB sockets. Used in implementing utils/event.py to function
  without ZMQ.
- Added `IPCMessageSubscriber`. This is intended to function much like
  ZMQ's zmq.SUB sockets. Used in implementing utils/event.py to function
  without ZMQ. What makes this class a bit different is that the associated
  IO Loop is meant to not be running when it is used. Due to this, it is
  recommended that the caller create a new IO Loop for this purpose. The
  reason for this is that the `get_event()` API may be invoked from
  anywhere, whether or not there is a current IO Loop that is running in
  the thread of the invocation.

salt/utils/async.py:
- If ZMQ is not importable, use `tornado.ioloop.IOLoop` as the loop class.

salt/utils/event.py:
- Implemented using `salt.transport.ipc` instead of ZMQ.
- zmq.PUB ==> `IPCMessagePublisher`
- zmq.SUB ==> `IPCMessageSubscriber`
- zmq.PUSH ==> `IPCMessageClient`
- zmq.PULL ==> `IPCMessageServer`

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
