### PR TITLE
RFE: base/branch for gitpillars per-remote

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -200,7 +200,7 @@ except ImportError:
     HAS_GITPYTHON = False
 # pylint: enable=import-error
 
-PER_REMOTE_OVERRIDES = ('env', 'root', 'ssl_verify', 'base')
+PER_REMOTE_OVERRIDES = ('env', 'root', 'ssl_verify', 'base', 'branch')
 
 # Set up logging
 log = logging.getLogger(__name__)

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -200,7 +200,7 @@ except ImportError:
     HAS_GITPYTHON = False
 # pylint: enable=import-error
 
-PER_REMOTE_OVERRIDES = ('env', 'root', 'ssl_verify')
+PER_REMOTE_OVERRIDES = ('env', 'root', 'ssl_verify', 'base')
 
 # Set up logging
 log = logging.getLogger(__name__)

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -443,7 +443,7 @@ class GitProvider(object):
             try:
                 self.branch, self.url = self.id.split(None, 1)
             except ValueError:
-                self.branch = self.opts['{0}_branch'.format(self.role)]
+                self.branch = getattr(self, 'branch', self.opts['{0}_branch'.format(self.role)])
                 self.url = self.id
         else:
             self.url = self.id
@@ -2382,7 +2382,7 @@ class GitPillar(GitBase):
                 if repo.env:
                     env = repo.env
                 else:
-                    base_branch = getattr(self, 'base', self.opts['{0}_base'.format(self.role)])
+                    base_branch = getattr(repo, 'base', self.opts['{0}_base'.format(self.role)])
                     env = 'base' if repo.branch == base_branch else repo.branch
                 self.pillar_dirs[cachedir] = env
 

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -2382,7 +2382,7 @@ class GitPillar(GitBase):
                 if repo.env:
                     env = repo.env
                 else:
-                    base_branch = self.opts['{0}_base'.format(self.role)]
+                    base_branch = getattr(self, 'base', self.opts['{0}_base'.format(self.role)])
                     env = 'base' if repo.branch == base_branch else repo.branch
                 self.pillar_dirs[cachedir] = env
 


### PR DESCRIPTION
Complementary to `git_pillar_branch` and `git_pillar_base` this makes both `branch` and `base` per-remote configurable.
