### PR TITLE
Catch ValueError on timeout on non-existing key

### DIFF
--- a/salt/utils/etcd_util.py
+++ b/salt/utils/etcd_util.py
@@ -109,6 +109,8 @@ class EtcdClient(object):
             except etcd.EtcdKeyNotFound:
                 log.debug("etcd: key was not created while watching")
                 return ret
+            except ValueError:
+                return {}
             if result and getattr(result, "dir"):
                 ret['dir'] = True
             ret['value'] = getattr(result, 'value')

--- a/tests/unit/utils/etcd_util_test.py
+++ b/tests/unit/utils/etcd_util_test.py
@@ -232,6 +232,9 @@ class EtcdUtilTestCase(TestCase):
             self.assertEqual(client.watch('/some-key'),
                              {'value': None, 'changed': False, 'mIndex': 0, 'key': '/some-key', 'dir': False})
 
+            mock.side_effect = iter([etcd_util.EtcdUtilWatchTimeout, ValueError])
+            self.assertEqual(client.watch('/some-key'), {})
+
             mock.side_effect = None
             mock.return_value = MagicMock(value='stack', key='/some-key', modifiedIndex=1, dir=True)
             self.assertDictEqual(client.watch('/some-dir', recurse=True, timeout=5, index=10),


### PR DESCRIPTION
The etcd watch function tries to read a key when it reaches the timeout
in order to obtain details about the key.

On python 2.6, when it tries to re-read the key, it throws a ValueError,
since python-etcd doesn't officially support python 2.6.  The watch
function wasn't catching this ValueError, so it was returning the
exception, rather than a blank dict.
