### PR TITLE
Winrm fix for ec2

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2107,7 +2107,7 @@ def wait_for_instance(
             'win_deploy_auth_retry_delay', vm_, __opts__, default=1
         )
         use_winrm = config.get_cloud_config_value(
-            'use_winrm', vm_, __opts__, default=false
+            'use_winrm', vm_, __opts__, default=False
         )
 
         if win_passwd and win_passwd == 'auto':

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2106,6 +2106,10 @@ def wait_for_instance(
         win_deploy_auth_retry_delay = config.get_cloud_config_value(
             'win_deploy_auth_retry_delay', vm_, __opts__, default=1
         )
+        use_winrm = config.get_cloud_config_value(
+            'use_winrm', vm_, __opts__, default=false
+        )
+
         if win_passwd and win_passwd == 'auto':
             log.debug('Waiting for auto-generated Windows EC2 password')
             while True:
@@ -2142,7 +2146,8 @@ def wait_for_instance(
                                                       username,
                                                       win_passwd,
                                                       retries=win_deploy_auth_retries,
-                                                      retry_delay=win_deploy_auth_retry_delay):
+                                                      retry_delay=win_deploy_auth_retry_delay,
+                                                      winrm=use_winrm):
             raise SaltCloudSystemExit(
                 'Failed to authenticate against remote windows host'
             )

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -847,10 +847,16 @@ def validate_windows_cred(host,
                           username='Administrator',
                           password=None,
                           retries=10,
-                          retry_delay=1):
+                          retry_delay=1,
+                          winrm=False):
     '''
     Check if the windows credentials are valid
     '''
+    # if winrm was requested, lets use that instead of winexe
+    if(winrm and HAS_WINRM):
+        return wait_for_winrm(host,port=5986,username,password, retries * delay)
+
+    # if winrm was not requested, lets use winexe
     cmd = "winexe -U '{0}%{1}' //{2} \"hostname\"".format(
         username,
         password,

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -854,7 +854,7 @@ def validate_windows_cred(host,
     '''
     # if winrm was requested, lets use that instead of winexe
     if(winrm and HAS_WINRM):
-        return wait_for_winrm(host,5986,username,password, retries * delay)
+        return wait_for_winrm(host,5986,username,password, retries * retry_delay)
 
     # if winrm was not requested, lets use winexe
     cmd = "winexe -U '{0}%{1}' //{2} \"hostname\"".format(

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -853,8 +853,8 @@ def validate_windows_cred(host,
     Check if the windows credentials are valid
     '''
     # if winrm was requested, lets use that instead of winexe
-    if(winrm and HAS_WINRM):
-        return wait_for_winrm(host,5986,username,password, retries * retry_delay)
+    if winrm and HAS_WINRM:
+        return wait_for_winrm(host, 5986, username, password, retries * retry_delay)
 
     # if winrm was not requested, lets use winexe
     cmd = "winexe -U '{0}%{1}' //{2} \"hostname\"".format(

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -854,7 +854,7 @@ def validate_windows_cred(host,
     '''
     # if winrm was requested, lets use that instead of winexe
     if(winrm and HAS_WINRM):
-        return wait_for_winrm(host,port=5986,username,password, retries * delay)
+        return wait_for_winrm(host,5986,username,password, retries * delay)
 
     # if winrm was not requested, lets use winexe
     cmd = "winexe -U '{0}%{1}' //{2} \"hostname\"".format(


### PR DESCRIPTION
There was an issue when provisioning cloud boxes on Windows 2012R2 where winexe was giving an "Invalid switch parameter" message when attempting to validate username / password. Using WinRM fixed, however there is one step where salt-cloud attempts to verify the password. This was done using winexe regardless of the use_winrm setting. Winrm check was only done after password validated.

This fix will allow the salt.utils.cloud.validate_windows_cred function to use defer to the 'wait_for_winrm' which will test the user and password. 
