### PR TITLE
Simplify TCP/IPC wire protocol

### DIFF
--- a/doc/topics/transports/tcp.rst
+++ b/doc/topics/transports/tcp.rst
@@ -16,10 +16,10 @@ like:
 
 .. code-block:: text
 
-    len(payload) msgpack({'head': SOMEHEADER, 'body': SOMEBODY})
+    msgpack({'head': SOMEHEADER, 'body': SOMEBODY})
 
-The wire protocol is basically two parts, the length of the payload and a payload
-(which is a msgpack'd dict). Within that payload we have two items "head" and "body".
+Since msgpack is an iterably parsed serialization, we can simply write the serialized
+payload to the wire. Within that payload we have two items "head" and "body".
 Head contains header information (such as "message id"). The Body contains the
 actual message that we are sending. With this flexible wire protocol we can
 implement any message semantics that we'd like-- including multiplexed message

--- a/salt/transport/frame.py
+++ b/salt/transport/frame.py
@@ -15,10 +15,6 @@ def frame_msg(body, header=None, raw_body=False):
     if header is None:
         header = {}
 
-    # if the body wasn't already msgpacked-- lets do that.
-    if not raw_body:
-        body = msgpack.dumps(body)
-
     framed_msg['head'] = header
     framed_msg['body'] = body
     return msgpack.dumps(framed_msg)

--- a/salt/transport/frame.py
+++ b/salt/transport/frame.py
@@ -21,5 +21,4 @@ def frame_msg(body, header=None, raw_body=False):
 
     framed_msg['head'] = header
     framed_msg['body'] = body
-    framed_msg_packed = msgpack.dumps(framed_msg)
-    return '{0} {1}'.format(len(framed_msg_packed), framed_msg_packed)
+    return msgpack.dumps(framed_msg)

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -427,14 +427,15 @@ class SaltMessageServer(tornado.tcpserver.TCPServer, object):
         '''
         log.trace('Req client {0} connected'.format(address))
         self.clients.append((stream, address))
+        unpacker = msgpack.Unpacker()
         try:
             while True:
-                framed_msg_len = yield stream.read_until(' ')
-                framed_msg_raw = yield stream.read_bytes(int(framed_msg_len.strip()))
-                framed_msg = msgpack.loads(framed_msg_raw)
-                header = framed_msg['head']
-                body = msgpack.loads(framed_msg['body'])
-                self.io_loop.spawn_callback(self.message_handler, stream, header, body)
+                wire_bytes = yield stream.read_bytes(4096, partial=True)
+                unpacker.feed(wire_bytes)
+                for framed_msg in unpacker:
+                    header = framed_msg['head']
+                    body = msgpack.loads(framed_msg['body'])
+                    self.io_loop.spawn_callback(self.message_handler, stream, header, body)
 
         except tornado.iostream.StreamClosedError:
             log.trace('req client disconnected {0}'.format(address))
@@ -567,24 +568,25 @@ class SaltMessageClient(object):
                 not self._connecting_future.done() or
                 self._connecting_future.result() is not True):
             yield self._connecting_future
+        unpacker = msgpack.Unpacker()
         while not self._closing:
             try:
-                self._read_until_future = self._stream.read_until(' ')
-                framed_msg_len = yield self._read_until_future
-                framed_msg_raw = yield self._stream.read_bytes(int(framed_msg_len.strip()))
-                framed_msg = msgpack.loads(framed_msg_raw)
-                header = framed_msg['head']
-                message_id = header.get('mid')
-                body = msgpack.loads(framed_msg['body'])
+                self._read_until_future = self._stream.read_bytes(4096, partial=True)
+                wire_bytes = yield self._read_until_future
+                unpacker.feed(wire_bytes)
+                for framed_msg in unpacker:
+                    header = framed_msg['head']
+                    message_id = header.get('mid')
+                    body = msgpack.loads(framed_msg['body'])
 
-                if message_id in self.send_future_map:
-                    self.send_future_map.pop(message_id).set_result(body)
-                    self.remove_message_timeout(message_id)
-                else:
-                    if self._on_recv is not None:
-                        self.io_loop.spawn_callback(self._on_recv, header, body)
+                    if message_id in self.send_future_map:
+                        self.send_future_map.pop(message_id).set_result(body)
+                        self.remove_message_timeout(message_id)
                     else:
-                        log.error('Got response for message_id {0} that we are not tracking'.format(message_id))
+                        if self._on_recv is not None:
+                            self.io_loop.spawn_callback(self._on_recv, header, body)
+                        else:
+                            log.error('Got response for message_id {0} that we are not tracking'.format(message_id))
             except tornado.iostream.StreamClosedError as e:
                 log.debug('tcp stream to {0}:{1} closed, unable to recv'.format(self.host, self.port))
                 for future in self.send_future_map.itervalues():


### PR DESCRIPTION
As I was working on another project, I ran into some other project doing exactly this. Our current wire protocol is effectively "len-of-thing thing", but msgpack already includes headers in the serialization--making it an iterably consumable format. This means we don't need to use/waste bytes on the wire for the len of the string (esp. since its currently a string serialization of how many bytes).

This change simplifies the wire protocol, but still maintains flexibility for changes later-- since we are effectively just msgpacking dicts across the wire.

Note: this is a backwards incompatible wire protocol change. This is only being done as TCP is considered "experimental". This will be the last and only change to the wire protocol in a backwards incompatible fashion-- as we are working towards first-class support for the next release.
