### PR TITLE
Replaced LC_ALL by explicit LC_* variables, since it is exceptional h…

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -385,7 +385,18 @@ def _run(cmd,
             # Default to C!
             # Salt only knows how to parse English words
             # Don't override if the user has passed LC_ALL
-            env.setdefault('LC_ALL', 'C')
+            env.setdefault('LC_CTYPE', 'C')
+            env.setdefault('LC_NUMERIC', 'C')
+            env.setdefault('LC_TIME', 'C')
+            env.setdefault('LC_COLLATE', 'C')
+            env.setdefault('LC_MONETARY', 'C')
+            env.setdefault('LC_MESSAGES', 'C')
+            env.setdefault('LC_PAPER', 'C')
+            env.setdefault('LC_NAME', 'C')
+            env.setdefault('LC_ADDRESS', 'C')
+            env.setdefault('LC_TELEPHONE', 'C')
+            env.setdefault('LC_MEASUREMENT', 'C')
+            env.setdefault('LC_IDENTIFICATION', 'C')
         else:
             # On Windows set the codepage to US English.
             if python_shell:


### PR DESCRIPTION
…ard to get rid of LC_ALL in script/programs.

I know there is an ongoing Discussion and it is feared removing the preset LC_ALL would break stuff/scripts again. But these change in between should provide a sane environment for these scripts, but don't breaks script/programs which actual set the needed LC variables itself. One example is portage. 

While I still think not changing the locales at all would be preferable, this atleast should allow all script/programs to work properly.

Kind Regards
Tetja Rediske
