### PR TITLE
Fixes an file.search on python2.6

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1434,7 +1434,7 @@ def replace(path,
                 r_data = mmap.mmap(r_file.fileno(),
                                    0,
                                    access=mmap.ACCESS_READ)
-            except ValueError:
+            except (ValueError, mmap.error):
                 # size of file in /proc is 0, but contains data
                 r_data = "".join(r_file)
             if search_only:


### PR DESCRIPTION
mmap throws `mmap.error` instead of a ValueError when mmap length is set to 0. 

Fixes #29344 

@lorengordon Ping
