### PR TITLE
No need to deepcopy since six.iterkeys() creates a copy

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -285,9 +285,8 @@ class SyncClientMixin(object):
             # Inject some useful globals to *all* the function's global
             # namespace only once per module-- not per func
             completed_funcs = []
-            _functions = copy.deepcopy(self.functions)
 
-            for mod_name in six.iterkeys(_functions):
+            for mod_name in six.iterkeys(self.functions):
                 if '.' not in mod_name:
                     continue
                 mod, _ = mod_name.split('.', 1)


### PR DESCRIPTION
The fix for issue https://github.com/saltstack/salt/issues/25223 only needed to go into the 2015.5 branch. This needs to be merged in the 2015.8 stable asap!

Fixes #25446
