### PR TITLE
Add an example to the watch requisite.

### DIFF
--- a/doc/ref/states/requisites.rst
+++ b/doc/ref/states/requisites.rst
@@ -238,6 +238,23 @@ to Salt ensuring that the service is running.
         - name: /etc/ntp.conf
         - source: salt://ntp/files/ntp.conf
 
+Or, we may want to run a state only if a previously defined state, in this case
+*Extract node package*, has run as well:
+
+.. code-block:: yaml
+
+    Extract node package:
+      archive.extracted:
+        - name: my-nodejs-package.tgz
+        - archive_format: tar
+        - if_missing: package/
+
+    Install node dependencies:
+      cmd.wait:
+        - watch:
+          - cmd: Extract node package
+        - name: npm rebuild
+
 .. _requisites-prereq:
 
 prereq

--- a/doc/ref/states/requisites.rst
+++ b/doc/ref/states/requisites.rst
@@ -226,7 +226,7 @@ in other states.
     If a state should only execute when another state has changes, and
     otherwise do nothing, the new ``onchanges`` requisite should be used
     instead of ``watch``. ``watch`` is designed to add *additional* behavior
-    when there are changes, but otherwise execute normally.
+    when there are changes, but otherwise the state executes normally.
 
 The state containing the ``watch`` requisite is defined as the watching
 state. The state specified in the ``watch`` statement is defined as the watched
@@ -235,36 +235,37 @@ a key named "changes". Here are two examples of state return dictionaries,
 shown in json for clarity:
 
 .. code-block:: json
-
-    "local": {
-        "file_|-/tmp/foo_|-/tmp/foo_|-directory": {
-            "comment": "Directory /tmp/foo updated",
-            "__run_num__": 0,
-            "changes": {
-                "user": "bar"
-            },
-            "name": "/tmp/foo",
-            "result": true
+    {
+        "local": {
+            "file_|-/tmp/foo_|-/tmp/foo_|-directory": {
+                "comment": "Directory /tmp/foo updated",
+                "__run_num__": 0,
+                "changes": {
+                    "user": "bar"
+                },
+                "name": "/tmp/foo",
+                "result": true
+            }
         }
     }
 
-    "local": {
-        "pkgrepo_|-salt-minion_|-salt-minion_|-managed": {
-            "comment": "Package repo 'salt-minion' already configured",
-            "__run_num__": 0,
-            "changes": {},
-            "name": "salt-minion",
-            "result": true
+    {
+        "local": {
+            "pkgrepo_|-salt-minion_|-salt-minion_|-managed": {
+                "comment": "Package repo 'salt-minion' already configured",
+                "__run_num__": 0,
+                "changes": {},
+                "name": "salt-minion",
+                "result": true
+            }
         }
     }
 
 If the "result" of the watched state is ``True``, the watching state *will
-execute normally*. This part of ``watch`` mirrors the functionality of the
-``require`` requisite. If the "result" of the watched state is ``False``, the
-watching state will never run, nor will the watching state's ``mod_watch``
-function execute.
+execute normally*, and if it is ``False``, the watching state will never run.
+This part of ``watch`` mirrors the functionality of the ``require`` requisite.
 
-However, if the "result" of the watched state is ``True``, and the "changes"
+If the "result" of the watched state is ``True`` *and* the "changes"
 key contains a populated dictionary (changes occurred in the watched state),
 then the ``watch`` requisite can add additional behavior. This additional
 behavior is defined by the ``mod_watch`` function within the watching state
@@ -297,23 +298,6 @@ to Salt ensuring that the service is running.
       file.managed:
         - name: /etc/ntp.conf
         - source: salt://ntp/files/ntp.conf
-
-Or, we may want to run a state only if a previously defined state, in this case
-*Extract node package*, has run as well:
-
-.. code-block:: yaml
-
-    Extract node package:
-      archive.extracted:
-        - name: my-nodejs-package.tgz
-        - archive_format: tar
-        - if_missing: package/
-
-    Install node dependencies:
-      cmd.wait:
-        - watch:
-          - archive: Extract node package
-        - name: npm rebuild
 
 .. _requisites-prereq:
 

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -11,6 +11,7 @@ A simple example to execute a command:
 
 .. code-block:: yaml
 
+    # Store the current date in a file
     date > /tmp/salt-run:
       cmd.run
 
@@ -105,13 +106,13 @@ a simple protocol described below:
            - stateful: True
 
        Run only if myscript changed something:
-         cmd.wait:
+         cmd.run:
            - name: echo hello
            - cwd: /
-           - watch:
+           - onchanges:
                - cmd: Run myscript
 
-   Note that if the ``cmd.wait`` state also specifies ``stateful: True`` it can
+   Note that if the second ``cmd.run`` state also specifies ``stateful: True`` it can
    then be watched by some other states as well.
 
 4. :strong:`The stateful argument can optionally include a test_name parameter.`
@@ -139,26 +140,14 @@ a simple protocol described below:
            - stateful:
              - test_name: masterscript test
 
-``cmd.wait`` is not restricted to watching only cmd states. For example
-it can also watch a git state for changes
-
-.. code-block:: yaml
-
-    # Watch for changes to a git repo and rebuild the project on updates
-    my-project:
-      git.latest:
-        - name: git@github.com/repo/foo
-        - target: /opt/foo
-        - rev: master
-      cmd.wait:
-        - name: make install
-        - cwd: /opt/foo
-        - watch:
-          - git: my-project
-
 
 Should I use :mod:`cmd.run <salt.states.cmd.run>` or :mod:`cmd.wait <salt.states.cmd.wait>`?
 --------------------------------------------------------------------------------------------
+
+.. note::
+
+    Use ``cmd.run`` together with :mod:`onchanges </ref/states/requisites#onchanges>`
+    instead of ``cmd.wait``.
 
 These two states are often confused. The important thing to remember about them
 is that :mod:`cmd.run <salt.states.cmd.run>` states are run each time the SLS
@@ -173,6 +162,27 @@ executed when the state it is watching changes. Example:
     /usr/local/bin/postinstall.sh:
       cmd.wait:
         - watch:
+          - pkg: mycustompkg
+      file.managed:
+        - source: salt://utils/scripts/postinstall.sh
+
+    mycustompkg:
+      pkg.installed:
+        - require:
+          - file: /usr/local/bin/postinstall.sh
+
+``cmd.wait`` itself does not do anything; all functionality is inside its ``mod_watch``
+function, which is called by ``watch`` on changes.
+
+``cmd.wait`` will be deprecated in future due to the confusion it causes. The
+preferred format is using the :doc:`onchanges Requisite </ref/states/requisites>`, which
+works on ``cmd.run`` as well as on any other state. The example would then look as follows:
+
+.. code-block:: yaml
+
+    /usr/local/bin/postinstall.sh:
+      cmd.run:
+        - onchanges:
           - pkg: mycustompkg
       file.managed:
         - source: salt://utils/scripts/postinstall.sh
@@ -396,7 +406,11 @@ def wait(name,
          use_vt=False,
          **kwargs):
     '''
-    Run the given command only if the watch statement calls it
+    Run the given command only if the watch statement calls it.
+
+    .. note::
+
+        Use :mod:`cmd.run <salt.states.cmd.run>` with :mod:`onchange </ref/states/requisites#onchanges>` instead.
 
     name
         The command to execute, remember that the command will execute with the


### PR DESCRIPTION
I'd like to add a bit more information, so please do not merge just yet. (Or I can add more information in a second commit.)

I'm still lacking a bit of conceptual understanding. Why can I use `file:` and `cmd:`? Des `file:` come from salt.states.file? If yes, why does file know that it should watch for changes and not e.g. for absence (`salt.states.file.absent`)?

Generally, where can I find a list of “watchers” that I can use there?
