### PR TITLE
Grains return wrong OS version and other OS related values for Oracle Linux

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1028,9 +1028,9 @@ def _parse_os_release():
 
     data = dict()
     with salt.utils.fopen(filename) as ifile:
-        regex = re.compile('^([\\w]+)=(?:\'|")?(.*?)(?:\'|")?\\s*$')
+        regex = re.compile('^([\\w]+)=(?:\'|")?(.*?)(?:\'|")?$')
         for line in ifile:
-            match = regex.match(line.strip('\n'))
+            match = regex.match(line.strip())
             if match:
                 # Shell special characters ("$", quotes, backslash, backtick)
                 # are escaped with backslashes

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1028,7 +1028,7 @@ def _parse_os_release():
 
     data = dict()
     with salt.utils.fopen(filename) as ifile:
-        regex = re.compile('^([\\w]+)=(?:\'|")?(.*?)(?:\'|")?$')
+        regex = re.compile('^([\\w]+)=(?:\'|")?(.*?)(?:\'|")?\\s*$')
         for line in ifile:
             match = regex.match(line.strip('\n'))
             if match:


### PR DESCRIPTION
OEL contains space characters at the end of some lines. The current regular expression doesn't expect that. This causes various issues especially for "service" module which doesn't work on OEL.

Fixes Issue #29425 
