### PR TITLE
Fix state runs with salt-ssh

### DIFF
--- a/salt/utils/context.py
+++ b/salt/utils/context.py
@@ -158,7 +158,7 @@ class ChildContextDict(collections.MutableMapping):
         self.parent._state.data = None
 
 
-class NamespacedDictWrapper(collections.MutableMapping, dict):
+class NamespacedDictWrapper(dict):
     '''
     Create a dict which wraps another dict with a specific prefix of key(s)
 


### PR DESCRIPTION
With the introducion of salt.context.NamespacedDictWrapper, we started seeing stacktraces similar to the following when running any state function in salt-ssh using Python2.6: https://gist.github.com/cachedout/0149ff984d956a0b85bc

While I'm not completely sure why the introduction of a mixin here is causing Python 2.6 to be unable to resolve a private attribute when copying, it seems clear that it is. Since the ABC is simply providing a skeleton for the necessary classes which should already be present with inheretance from `dict`, this seems relatively safe to do without losing any functionality.

cc: @jacksontj
