### PR TITLE
Use print as a function [PEP 3105].

### DIFF
--- a/pkg/rpm/build.py
+++ b/pkg/rpm/build.py
@@ -1,5 +1,5 @@
 #! /bin/env python
-
+from __future__ import print_function
 import sys
 import os
 import tarfile

--- a/pkg/windows/portable.py
+++ b/pkg/windows/portable.py
@@ -1,25 +1,26 @@
 #!/usr/bin/python
+from __future__ import print_function
 
 import sys, getopt
 
 def display_help():
-    print '####################################################################'
-    print '#                                                                  #'
-    print '# File: portable.py                                                #'
-    print '# Description:                                                     #'
-    print '#   - search and replace within a binary file                      #'
-    print '#                                                                  #'
-    print '# Parameters:                                                      #'
-    print '#   -f, --file    :  target file                                   #'
-    print '#   -s, --search  :  term to search for                            #'
-    print '#                    default is "C:\Python"                        #'
-    print '#   -r, --replace :  replace with this                             #'
-    print '#                    default is ".."                               #'
-    print '#                                                                  #'
-    print '# example:                                                         #'
-    print '#  portable.py -f <target_file> -s <search_term> -r <replace_term> #'
-    print '#                                                                  #'
-    print '####################################################################'
+    print('####################################################################')
+    print('#                                                                  #')
+    print('# File: portable.py                                                #')
+    print('# Description:                                                     #')
+    print('#   - search and replace within a binary file                      #')
+    print('#                                                                  #')
+    print('# Parameters:                                                      #')
+    print('#   -f, --file    :  target file                                   #')
+    print('#   -s, --search  :  term to search for                            #')
+    print('#                    default is "C:\Python"                        #')
+    print('#   -r, --replace :  replace with this                             #')
+    print('#                    default is ".."                               #')
+    print('#                                                                  #')
+    print('# example:                                                         #')
+    print('#  portable.py -f <target_file> -s <search_term> -r <replace_term> #')
+    print('#                                                                  #')
+    print('####################################################################')
     sys.exit(2)
 
 def main(argv):

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Import Python Libs
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import os
 import sys
 from subprocess import Popen, PIPE, STDOUT
@@ -435,7 +435,7 @@ def main(dbfile, pidfile, mode):
 
 if __name__ == '__main__':
     if len(sys.argv) != 4:
-        print >> sys.stderr, "This module is not intended to use directly!"
+        print("This module is not intended to use directly!", file=sys.stderr)
         sys.exit(1)
 
     pidfile, dbfile, mode = sys.argv[1:]

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -12,7 +12,7 @@ states themselves.
 '''
 
 # Import python libs
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import copy
 import fnmatch
 import json

--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -1,4 +1,6 @@
 # encoding: utf-8
+from __future__ import absolute_import, print_function
+
 '''
 A non-blocking REST API for Salt
 ================================
@@ -188,7 +190,6 @@ a return like::
 # pylint: disable=W0232
 
 # Import Python libs
-from __future__ import absolute_import
 import time
 import math
 import fnmatch

--- a/salt/transport/local.py
+++ b/salt/transport/local.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Import Python Libs
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import logging
 
 # Import Salt Libs
@@ -32,7 +32,7 @@ class LocalChannel(ReqChannel):
                     'data': ''.join(f.readlines()),
                     'dest': load['path'],
                 }
-                print ('returning', ret)
+                print('returning', ret)
         else:
             # end of buffer
             ret = {

--- a/tests/buildpackage.py
+++ b/tests/buildpackage.py
@@ -10,7 +10,7 @@
 
 # pylint: disable=file-perms
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import errno
 import glob
 import logging

--- a/tests/integration/files/file/base/script.py
+++ b/tests/integration/files/file/base/script.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import print_function
 import sys
 
 print(' '.join(sys.argv[1:]))

--- a/tests/perf/fire_fake.py
+++ b/tests/perf/fire_fake.py
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -**
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 # Import system libs
 import sys
 import time
@@ -14,7 +14,7 @@ import salt.client.raet
 try:
     opts = salt.config.master_config('/etc/salt/master')
 except OSError:
-    print 'Could not open master config. Do you need to be root?'
+    print('Could not open master config. Do you need to be root?')
     sys.exit(1)
 
 
@@ -48,7 +48,7 @@ class SwarmController(object):
                 self.calibrate()
                 last_check = 0
             if self.total_complete > goal:
-                print 'Test complete'
+                print('Test complete')
                 break
 
     def fire_it(self):
@@ -67,7 +67,7 @@ class SwarmController(object):
         #remaining_requests = (self.reqs_sec * self.run_time) - self.total_complete
         # Figure out what the reqs/sec has been up to this point and then adjust up or down
         runtime_reqs_sec = self.total_complete / elapsed_time.total_seconds()
-        print 'Recalibrating. Current reqs/sec: {0}'.format(runtime_reqs_sec)
+        print('Recalibrating. Current reqs/sec: {0}'.format(runtime_reqs_sec))
         return
 
 controller = SwarmController(opts)


### PR DESCRIPTION
This reduces warnings from the 2to3 utility
and future proofs the code when it is time to move to Python 3.
