### PR TITLE
Fix resource limits, systemd sets the default too small

### DIFF
--- a/pkg/salt-master.service
+++ b/pkg/salt-master.service
@@ -3,8 +3,11 @@ Description=The Salt Master Server
 After=syslog.target network.target
 
 [Service]
+LimitNOFILE=16384
 Type=notify
+NotifyAccess=all
 ExecStart=/usr/bin/salt-master
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/salt-minion.service
+++ b/pkg/salt-minion.service
@@ -4,6 +4,7 @@ After=syslog.target network.target
 
 [Service]
 Type=simple
+LimitNOFILE=8192
 ExecStart=/usr/bin/salt-minion
 KillMode=process
 


### PR DESCRIPTION
Default number of open files is 4096 which is not enough for a large Salt installation.
