### PR TITLE
Add **kwargs to debconf.set.

### DIFF
--- a/salt/states/debconfmod.py
+++ b/salt/states/debconfmod.py
@@ -132,7 +132,7 @@ def set_file(name, source, template=None, context=None, defaults=None, **kwargs)
     return ret
 
 
-def set(name, data):
+def set(name, data, **kwargs):
     '''
     Set debconf selections
 


### PR DESCRIPTION
This will allow setting prereq in states for debconf related tasks.

Related to issue #29001 
