### PR TITLE
Add return message on fail for zk_concurrency, zpool, znc, and zypper modules

### DIFF
--- a/salt/modules/zk_concurrency.py
+++ b/salt/modules/zk_concurrency.py
@@ -94,7 +94,7 @@ __virtualname__ = 'zk_concurrency'
 
 def __virtual__():
     if not HAS_DEPS:
-        return False
+        return (False, "Module zk_concurrency: dependencies failed")
 
     return __virtualname__
 

--- a/salt/modules/znc.py
+++ b/salt/modules/znc.py
@@ -28,7 +28,7 @@ def __virtual__():
     '''
     if salt.utils.which('znc'):
         return 'znc'
-    return False
+    return (False, "Module znc: znc binary not found")
 
 
 def _makepass(password, hasher='sha256'):

--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -63,7 +63,7 @@ def __virtual__():
     '''
     if _check_zpool():
         return 'zpool'
-    return False
+    return (False, "Module zpool: zpool not found")
 
 
 def healthy():

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -44,10 +44,10 @@ def __virtual__():
     Set the virtual pkg module if the os is openSUSE
     '''
     if __grains__.get('os_family', '') != 'Suse':
-        return False
+        return (False, "Module zypper: non SUSE OS not suppored by zypper package manager")
     # Not all versions of Suse use zypper, check that it is available
     if not salt.utils.which('zypper'):
-        return False
+        return (False, "Module zypper: zypper package manager not found")
     return __virtualname__
 
 


### PR DESCRIPTION
Added error message for return on false for the following

salt/modules/zk_concurrency.py
salt/modules/zpool.py
salt/modules/znc.py
salt/modules/zypper.py
