### PR TITLE
Update module.py

### DIFF
--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -265,8 +265,11 @@ def run(name, **kwargs):
         ret['result'] = mret
     else:
         changes_ret = ret['changes'].get('ret', {})
-        if isinstance(changes_ret, dict) and changes_ret.get('retcode', 0) != 0:
-            ret['result'] = False
+        if isinstance(changes_ret, dict):
+            if isinstance(changes_ret.get('result', {}), bool):
+                ret['result'] = changes_ret.get('result', {})
+            elif changes_ret.get('retcode', 0) != 0:
+                ret['result'] = False
     return ret
 
 mod_watch = salt.utils.alias_function(run, 'mod_watch')


### PR DESCRIPTION
using module.run to check if port is opened on my host, 
using module network.connect  
## example state: 

network.connect:
  module.run: 
    - host: {{ salt['network.ipaddrs']()|join }}
    - port: 1234
    - proto: udp

found unexpected behavior: 
module.run will always success as a result 
even If network.connect returns result: False
## example output (before the change): 

```
      ID: network.connect
Function: module.run
  Result: True
 Comment: Module function network.connect executed
 Started: 22:28:29.475623
Duration: 0.001 ms
 Changes:   
          ----------
          ret:
              ----------
              comment:
                  Unable to connect to 10.0.0.50 (10.0.0.50) on tcp port 1234
              result:
                  False
```

Proposal: 

Proposing to check 
if changes_ret.result exists, and if it's boolean return it as a result 
before attempting to check changes_ret.retcode 
## tested expected behavior: 

```
      ID: network.connect
Function: module.run
  Result: False
 Comment: Module function network.connect executed
 Started: 22:50:25.149832
Duration: 9.964 ms
 Changes:   
          ----------
          ret:
              ----------
              comment:
                  Unable to connect to 10.0.0.50 (10.0.0.50) on tcp port 1234
              result:
                  False
```

---

```
      ID: network.connect
Function: module.run
  Result: True
 Comment: Module function network.connect executed
 Started: 22:50:07.129629
Duration: 0.205 ms
 Changes:   
          ----------
          ret:
              ----------
              comment:
                  Successfully connected to 10.0.0.50 (10.0.0.50) on tcp port 53
              result:
                  True
```
