### PR TITLE
Added Documentation note in salt cloud.

### DIFF
--- a/doc/topics/cloud/misc.rst
+++ b/doc/topics/cloud/misc.rst
@@ -150,6 +150,7 @@ can tweak.
 
 .. admonition:: Note
 
+    All settings should be provided in lowercase
     All values should be provided in seconds
 
 


### PR DESCRIPTION
Added a Note for salt cloud settings since documentation shows those key in uppercase, but salt cloud expects those in lowercase.

Related to issue #28862 
