### PR TITLE
Summary: Add some new neutron api about filewall rule.

### DIFF
--- a/salt/modules/neutron.py
+++ b/salt/modules/neutron.py
@@ -1371,6 +1371,49 @@ def delete_ipsecpolicy(ipsecpolicy, profile=None):
     conn = _auth(profile)
     return conn.delete_ipsecpolicy(ipsecpolicy)
 
+def list_firewall_rules(profile=None):
+    '''
+    Fetches a list of all firewall rules for a tenant
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' neutron.list_firewall_rules
+	:param profile: Profile to build on (Optional)
+	:return: List of firewall rules
+    '''
+    conn = _auth(profile)
+    return conn.list_firewall_rules()
+
+def show_firewall_rule(rule, profile=None):
+    '''
+    Show information of a given firewall rule
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' neutron.show_firewall_rule firewall-rule-name
+
+    :param rule: ID or name of firewall rule to look up
+    :param profile: Profile to build on (Optional)
+    :return: firewall rule information
+    '''
+    conn = _auth(profile)
+    return conn.show_firewall_rule(rule)
+
+def delete_firewall_rule(rule, profile=None):
+    '''
+    Deletes the specified firewall rule
+    CLI Example:
+    .. code-block:: bash
+        salt '*' neutron.delete_firewall_rule firewall-rule-name
+    :param rule: ID or name of firewall rule to delete
+    :param profile: Profile to build on (Optional)
+    :return: firewall rule information
+    '''
+    conn = _auth(profile)
+    return conn.delete_firewall_rule(rule)
 
 # The following is a list of functions that need to be incorporated in the
 # neutron module. This list should be updated as functions are added.

--- a/salt/modules/neutron.py
+++ b/salt/modules/neutron.py
@@ -1379,8 +1379,8 @@ def list_firewall_rules(profile=None):
     .. code-block:: bash
 
         salt '*' neutron.list_firewall_rules
-	:param profile: Profile to build on (Optional)
-	:return: List of firewall rules
+    :param profile: Profile to build on (Optional)
+    :return: List of firewall rules
     '''
     conn = _auth(profile)
     return conn.list_firewall_rules()

--- a/salt/modules/neutron.py
+++ b/salt/modules/neutron.py
@@ -1371,6 +1371,7 @@ def delete_ipsecpolicy(ipsecpolicy, profile=None):
     conn = _auth(profile)
     return conn.delete_ipsecpolicy(ipsecpolicy)
 
+
 def list_firewall_rules(profile=None):
     '''
     Fetches a list of all firewall rules for a tenant
@@ -1379,41 +1380,13 @@ def list_firewall_rules(profile=None):
     .. code-block:: bash
 
         salt '*' neutron.list_firewall_rules
-	:param profile: Profile to build on (Optional)
-	:return: List of firewall rules
+    :param profile: Profile to build on (Optional)
+    :return: List of firewall rules
     '''
     conn = _auth(profile)
     return conn.list_firewall_rules()
 
-def show_firewall_rule(rule, profile=None):
-    '''
-    Show information of a given firewall rule
 
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' neutron.show_firewall_rule firewall-rule-name
-
-    :param rule: ID or name of firewall rule to look up
-    :param profile: Profile to build on (Optional)
-    :return: firewall rule information
-    '''
-    conn = _auth(profile)
-    return conn.show_firewall_rule(rule)
-
-def delete_firewall_rule(rule, profile=None):
-    '''
-    Deletes the specified firewall rule
-    CLI Example:
-    .. code-block:: bash
-        salt '*' neutron.delete_firewall_rule firewall-rule-name
-    :param rule: ID or name of firewall rule to delete
-    :param profile: Profile to build on (Optional)
-    :return: firewall rule information
-    '''
-    conn = _auth(profile)
-    return conn.delete_firewall_rule(rule)
 
 # The following is a list of functions that need to be incorporated in the
 # neutron module. This list should be updated as functions are added.

--- a/salt/utils/openstack/neutron.py
+++ b/salt/utils/openstack/neutron.py
@@ -125,10 +125,6 @@ class SaltNeutron(NeutronShell):
         resource = self._fetch_ipsecpolicy(resource)
         return resource['id']
 
-    def _find_firewall_rule_id(self, resource):
-        resource = self._fetch_firewall_rule(resource)
-        return resource['id']
-
     def _fetch_port(self, name_or_id):
         resources = self.list_ports()['ports']
         return self._fetch(resources, name_or_id)
@@ -164,10 +160,6 @@ class SaltNeutron(NeutronShell):
 
     def _fetch_ipsecpolicy(self, name_or_id):
         resources = self.list_ipsecpolicies()['ipsecpolicies']
-        return self._fetch(resources, name_or_id)
-
-    def _fetch_firewall_rule(self, name_or_id):
-        resources = self.list_firewall_rule()['firewall_rules']
         return self._fetch(resources, name_or_id)
 
     def get_quotas_tenant(self):
@@ -749,25 +741,12 @@ class SaltNeutron(NeutronShell):
         ipseecpolicy_id = self._find_ipsecpolicy_id(ipseecpolicy)
         ret = self.network_conn.delete_ipsecpolicy(ipseecpolicy_id)
         return ret if ret else True
+
     def list_firewall_rules(self):
 	    '''
         Fetches a list of all configured firewall rules for a tenant
-		'''
+        '''
         return self.network_conn.list_firewall_rules()
-    
-    def show_firewall_rule(self, rule):
-	    '''
-        Fetches information of a specific firewall rule
-        '''
-        return self._fetch_firewall_rule(rule)
-	
-    def delete_firewall_rule(self, rule):
-        '''
-        Deletes the specified firewall rule
-        '''
-        firewall_rule_id = self._find_firewall_rule_id(rule)
-        ret = self.network_conn.delete_firewall_rule(firewall_rule_id)
-        return ret if ret else True
 
 # The following is a list of functions that need to be incorporated in the
 # neutron module. This list should be updated as functions are added.

--- a/salt/utils/openstack/neutron.py
+++ b/salt/utils/openstack/neutron.py
@@ -125,10 +125,6 @@ class SaltNeutron(NeutronShell):
         resource = self._fetch_ipsecpolicy(resource)
         return resource['id']
 
-    def _find_firewall_rule_id(self, resource):
-        resource = self._fetch_firewall_rule(resource)
-        return resource['id']
-
     def _fetch_port(self, name_or_id):
         resources = self.list_ports()['ports']
         return self._fetch(resources, name_or_id)
@@ -164,10 +160,6 @@ class SaltNeutron(NeutronShell):
 
     def _fetch_ipsecpolicy(self, name_or_id):
         resources = self.list_ipsecpolicies()['ipsecpolicies']
-        return self._fetch(resources, name_or_id)
-
-    def _fetch_firewall_rule(self, name_or_id):
-        resources = self.list_firewall_rule()['firewall_rules']
         return self._fetch(resources, name_or_id)
 
     def get_quotas_tenant(self):
@@ -749,25 +741,12 @@ class SaltNeutron(NeutronShell):
         ipseecpolicy_id = self._find_ipsecpolicy_id(ipseecpolicy)
         ret = self.network_conn.delete_ipsecpolicy(ipseecpolicy_id)
         return ret if ret else True
+
     def list_firewall_rules(self):
-	    '''
+        '''
         Fetches a list of all configured firewall rules for a tenant
-		'''
+        '''
         return self.network_conn.list_firewall_rules()
-    
-    def show_firewall_rule(self, rule):
-	    '''
-        Fetches information of a specific firewall rule
-        '''
-        return self._fetch_firewall_rule(rule)
-	
-    def delete_firewall_rule(self, rule):
-        '''
-        Deletes the specified firewall rule
-        '''
-        firewall_rule_id = self._find_firewall_rule_id(rule)
-        ret = self.network_conn.delete_firewall_rule(firewall_rule_id)
-        return ret if ret else True
 
 # The following is a list of functions that need to be incorporated in the
 # neutron module. This list should be updated as functions are added.

--- a/salt/utils/openstack/neutron.py
+++ b/salt/utils/openstack/neutron.py
@@ -125,6 +125,10 @@ class SaltNeutron(NeutronShell):
         resource = self._fetch_ipsecpolicy(resource)
         return resource['id']
 
+    def _find_firewall_rule_id(self, resource):
+        resource = self._fetch_firewall_rule(resource)
+        return resource['id']
+
     def _fetch_port(self, name_or_id):
         resources = self.list_ports()['ports']
         return self._fetch(resources, name_or_id)
@@ -160,6 +164,10 @@ class SaltNeutron(NeutronShell):
 
     def _fetch_ipsecpolicy(self, name_or_id):
         resources = self.list_ipsecpolicies()['ipsecpolicies']
+        return self._fetch(resources, name_or_id)
+
+    def _fetch_firewall_rule(self, name_or_id):
+        resources = self.list_firewall_rule()['firewall_rules']
         return self._fetch(resources, name_or_id)
 
     def get_quotas_tenant(self):
@@ -741,7 +749,25 @@ class SaltNeutron(NeutronShell):
         ipseecpolicy_id = self._find_ipsecpolicy_id(ipseecpolicy)
         ret = self.network_conn.delete_ipsecpolicy(ipseecpolicy_id)
         return ret if ret else True
-
+    def list_firewall_rules(self):
+	    '''
+        Fetches a list of all configured firewall rules for a tenant
+		'''
+        return self.network_conn.list_firewall_rules()
+    
+    def show_firewall_rule(self, rule):
+	    '''
+        Fetches information of a specific firewall rule
+        '''
+        return self._fetch_firewall_rule(rule)
+	
+    def delete_firewall_rule(self, rule):
+        '''
+        Deletes the specified firewall rule
+        '''
+        firewall_rule_id = self._find_firewall_rule_id(rule)
+        ret = self.network_conn.delete_firewall_rule(firewall_rule_id)
+        return ret if ret else True
 
 # The following is a list of functions that need to be incorporated in the
 # neutron module. This list should be updated as functions are added.


### PR DESCRIPTION
Description: Add list_firewall_rules, show_firewall_rule,
delete_firewall_rule functions in salt/modules/neutron.py.
Add list_firewall_rules, show_firewall_rule, _fetch_firewall_rule,
delete_firewall_rule, _find_firewall_rule_id functions in
salt/utils/openstack/neutron.py
