### PR TITLE
Doc fix - route_table_present needs subnet_names (not subnets) as a key

### DIFF
--- a/salt/states/boto_vpc.py
+++ b/salt/states/boto_vpc.py
@@ -71,7 +71,7 @@ config:
               - destination_cidr_block: 0.0.0.0/0
                 instance_id: i-123456
                 interface_id: eni-123456
-            - subnets:
+            - subnet_names:
               - name: subnet1
               - name: subnet2
             - region: us-east-1

--- a/salt/states/boto_vpc.py
+++ b/salt/states/boto_vpc.py
@@ -72,8 +72,8 @@ config:
                 instance_id: i-123456
                 interface_id: eni-123456
             - subnet_names:
-              - name: subnet1
-              - name: subnet2
+              - subnet1
+              - subnet2
             - region: us-east-1
             - keyid: GKTADJGHEIQSXMKKRBJ08H
             - key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs


### PR DESCRIPTION
One of the examples for route_table_present in the docstrings uses 'subnet_names', the other uses 'subnets'. I think the former is correct, so this pull request fixes the latter.
