### PR TITLE
cron: support for commented cron jobs

### DIFF
--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -131,13 +131,15 @@ def _render_tab(lst):
 
             comment += '\n'
             ret.append(comment)
-        ret.append('{0} {1} {2} {3} {4} {5}\n'.format(cron['minute'],
-                                                      cron['hour'],
-                                                      cron['daymonth'],
-                                                      cron['month'],
-                                                      cron['dayweek'],
-                                                      cron['cmd']
-                                                      )
+        ret.append('{0}{1} {2} {3} {4} {5} {6}\n'.format(
+                            cron['commented'] is True and '#DISABLED#' or '',
+                            cron['minute'],
+                            cron['hour'],
+                            cron['daymonth'],
+                            cron['month'],
+                            cron['dayweek'],
+                            cron['cmd']
+                            )
                    )
     for spec in lst['special']:
         ret.append('{0} {1}\n'.format(spec['spec'], spec['cmd']))
@@ -264,6 +266,11 @@ def list_tab(user):
             flag = True
             continue
         if flag:
+            commented_cron_job = False
+            if line.startswith('#DISABLED#'):
+                # It's a commented cron job
+                line = line[10:]
+                commented_cron_job = True
             if line.startswith('@'):
                 # Its a "special" line
                 dat = {}
@@ -300,10 +307,14 @@ def list_tab(user):
                        'dayweek': comps[4],
                        'identifier': identifier,
                        'cmd': ' '.join(comps[5:]),
-                       'comment': comment}
+                       'comment': comment,
+                       'commented': False}
+                if commented_cron_job:
+                    dat['commented'] = True
                 ret['crons'].append(dat)
                 identifier = None
                 comment = None
+                commented_cron_job = False
             elif line.find('=') > 0:
                 # Appears to be a ENV setup line
                 comps = line.split('=')
@@ -388,6 +399,7 @@ def set_job(user,
             month,
             dayweek,
             cmd,
+            commented=False,
             comment=None,
             identifier=None):
     '''
@@ -414,6 +426,7 @@ def set_job(user,
                 and SALT_CRON_NO_IDENTIFIER
                 or cron['identifier'])
             tests = [(cron['comment'], comment),
+                     (cron['commented'], commented),
                      (identifier, test_setted_id),
                      (cron['minute'], minute),
                      (cron['hour'], hour),
@@ -437,6 +450,8 @@ def set_job(user,
                     month = cron['month']
                 if not _needs_change(cron['dayweek'], dayweek):
                     dayweek = cron['dayweek']
+                if not _needs_change(cron['commented'], commented):
+                    commented = cron['commented']
                 if not _needs_change(cron['comment'], comment):
                     comment = cron['comment']
                 if not _needs_change(cron['cmd'], cmd):
@@ -457,8 +472,8 @@ def set_job(user,
                 ):
                     identifier = cid
                 jret = set_job(user, minute, hour, daymonth,
-                               month, dayweek, cmd, comment,
-                               identifier=identifier)
+                               month, dayweek, cmd, commented=commented,
+                               comment=comment, identifier=identifier)
                 if jret == 'new':
                     return 'updated'
                 else:
@@ -466,7 +481,8 @@ def set_job(user,
             return 'present'
     cron = {'cmd': cmd,
             'identifier': identifier,
-            'comment': comment}
+            'comment': comment,
+            'commented': commented}
     cron.update(_get_cron_date_time(minute=minute, hour=hour,
                                     daymonth=daymonth, month=month,
                                     dayweek=dayweek))

--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -137,6 +137,7 @@ def _check_cron(user,
                 month=None,
                 dayweek=None,
                 comment=None,
+                commented=None,
                 identifier=None):
     '''
     Return the changes
@@ -153,6 +154,8 @@ def _check_cron(user,
         dayweek = str(dayweek).lower()
     if identifier is not None:
         identifier = str(identifier)
+    if commented is not None:
+        commented = commented is True
     if cmd is not None:
         cmd = str(cmd)
     lst = __salt__['cron.list_tab'](user)
@@ -162,7 +165,8 @@ def _check_cron(user,
                     ((cron['minute'], minute), (cron['hour'], hour),
                      (cron['daymonth'], daymonth), (cron['month'], month),
                      (cron['dayweek'], dayweek), (cron['identifier'], identifier),
-                     (cron['cmd'], cmd), (cron['comment'], comment))]):
+                     (cron['cmd'], cmd), (cron['comment'], comment),
+                     (cron['commented'], commented))]):
                 return 'update'
             return 'present'
     return 'absent'
@@ -216,6 +220,7 @@ def present(name,
             month='*',
             dayweek='*',
             comment=None,
+            commented=False,
             identifier=False):
     '''
     Verifies that the specified cron job is present for the specified user.
@@ -251,6 +256,12 @@ def present(name,
     comment
         User comment to be added on line previous the cron job
 
+    commented
+        The cron job is set commented (prefixed with ``#DISABLED#``).
+        Defaults to False.
+
+        .. versionadded:: Boron
+
     identifier
         Custom-defined identifier for tracking the cron line for future crontab
         edits. This defaults to the state id
@@ -271,6 +282,7 @@ def present(name,
                              month=month,
                              dayweek=dayweek,
                              comment=comment,
+                             commented=commented,
                              identifier=identifier)
         ret['result'] = None
         if status == 'absent':
@@ -290,6 +302,7 @@ def present(name,
                                     dayweek=dayweek,
                                     cmd=name,
                                     comment=comment,
+                                    commented=commented,
                                     identifier=identifier)
     if data == 'present':
         ret['comment'] = 'Cron {0} already present'.format(name)

--- a/tests/unit/modules/cron_test.py
+++ b/tests/unit/modules/cron_test.py
@@ -297,50 +297,50 @@ class CronTestCase(TestCase):
                 'crons': [
                     {'cmd': 'ls', 'comment': 'uoo', 'daymonth': '*',
                      'dayweek': '*', 'hour': '*', 'identifier': 'NO ID SET',
-                     'minute': '*', 'month': '*'},
+                     'minute': '*', 'month': '*', 'commented': False},
                     {'cmd': 'too', 'comment': 'uuoo', 'daymonth': '*',
                      'dayweek': '*', 'hour': '*', 'identifier': 'NO ID SET',
-                     'minute': '*', 'month': '*'},
+                     'minute': '*', 'month': '*', 'commented': False},
                     {'cmd': 'zoo', 'comment': 'uuuoo', 'daymonth': '*',
                      'dayweek': '*', 'hour': '*', 'identifier': 'NO ID SET',
-                     'minute': '*', 'month': '*'},
+                     'minute': '*', 'month': '*', 'commented': False},
                     {'cmd': 'yoo', 'comment': '', 'daymonth': '*',
                      'dayweek': '*', 'hour': '*', 'identifier': 'NO ID SET',
-                     'minute': '*', 'month': '*'},
+                     'minute': '*', 'month': '*', 'commented': False},
                     {'cmd': 'xoo', 'comment': '', 'daymonth': '*',
                      'dayweek': '*', 'hour': '*', 'identifier': 'NO ID SET',
-                     'minute': '*', 'month': '*'},
+                     'minute': '*', 'month': '*', 'commented': False},
                     {'cmd': 'samecmd', 'comment': '', 'daymonth': '*',
                      'dayweek': '*', 'hour': '*', 'identifier': 'NO ID SET',
-                     'minute': '*', 'month': '*'},
+                     'minute': '*', 'month': '*', 'commented': False},
                     {'cmd': 'samecmd', 'comment': None, 'daymonth': '*',
                      'dayweek': '*', 'hour': '*', 'identifier': None,
-                     'minute': '*', 'month': '*'},
+                     'minute': '*', 'month': '*', 'commented': False},
                     {'cmd': 'otheridcmd', 'comment': None, 'daymonth': '*',
                      'dayweek': '*', 'hour': '*', 'identifier': None,
-                     'minute': '*', 'month': '*'},
+                     'minute': '*', 'month': '*', 'commented': False},
                     {'cmd': 'otheridcmd', 'comment': None, 'daymonth': '*',
                      'dayweek': '*', 'hour': '*', 'identifier': None,
-                     'minute': '*', 'month': '*'},
+                     'minute': '*', 'month': '*', 'commented': False},
                     {'cmd': 'samecmd1', 'comment': '', 'daymonth': '*',
                      'dayweek': '*', 'hour': '*', 'identifier': 'NO ID SET',
-                     'minute': '0', 'month': '*'},
+                     'minute': '0', 'month': '*', 'commented': False},
                     {'cmd': 'samecmd1', 'comment': None, 'daymonth': '*',
                      'dayweek': '*', 'hour': '*', 'identifier': None,
-                     'minute': '1', 'month': '*'},
+                     'minute': '1', 'month': '*', 'commented': False},
                     {'cmd': 'otheridcmd1', 'comment': None, 'daymonth': '*',
                      'dayweek': '*', 'hour': '*', 'identifier': None,
-                     'minute': '0', 'month': '*'},
+                     'minute': '0', 'month': '*', 'commented': False},
                     {'cmd': 'otheridcmd1', 'comment': None, 'daymonth': '*',
                      'dayweek': '*', 'hour': '*', 'identifier': None,
-                     'minute': '1', 'month': '*'},
+                     'minute': '1', 'month': '*', 'commented': False},
                     {'cmd': 'otheridcmd1', 'comment': '', 'daymonth': '*',
                      'dayweek': '*', 'hour': '*', 'identifier': '1',
-                     'minute': '0', 'month': '*'},
+                     'minute': '0', 'month': '*', 'commented': False},
                     {'cmd': 'otheridcmd1',
                      'comment': '', 'daymonth': '*', 'dayweek': '*',
                      'hour': '*', 'identifier': '2', 'minute': '0',
-                     'month': '*'}
+                     'month': '*', 'commented': False}
                 ],
                 'env': [],
                 'pre': [],
@@ -484,10 +484,56 @@ class CronTestCase(TestCase):
                     ).format(
                         idx, get_crontab(), inc_tests[idx]))
 
+    @patch('salt.modules.cron._write_cron_lines',
+           new=MagicMock(side_effect=write_crontab))
+    def test_list_tab_commented_cron_jobs(self):
+        '''
+        handle commented cron jobs
+        https://github.com/saltstack/salt/issues/29082
+        '''
+        self.maxDiff = None
+        with patch(
+            'salt.modules.cron.raw_cron',
+            new=MagicMock(side_effect=get_crontab)
+        ):
+            set_crontab(
+                '# An unmanaged commented cron job\n'
+                '#0 * * * * /bin/true\n'
+                '# Lines below here are managed by Salt, do not edit\n'
+                '# cron_1 SALT_CRON_IDENTIFIER:cron_1\n#DISABLED#0 * * * * my_cmd_1\n'
+                '# cron_2 SALT_CRON_IDENTIFIER:cron_2\n#DISABLED#* * * * * my_cmd_2\n'
+                '# cron_3 SALT_CRON_IDENTIFIER:cron_3\n'
+                '#DISABLED#but it is a comment line'
+                '#DISABLED#0 * * * * my_cmd_3\n'
+                '# cron_4 SALT_CRON_IDENTIFIER:cron_4\n0 * * * * my_cmd_4\n'
+            )
+            crons1 = cron.list_tab('root')
+            self.assertEqual(crons1, {
+                'crons': [
+                    {'cmd': 'my_cmd_1', 'comment': 'cron_1', 'daymonth': '*',
+                     'dayweek': '*', 'hour': '*', 'identifier': 'cron_1',
+                     'minute': '0', 'month': '*', 'commented': True},
+                    {'cmd': 'my_cmd_2', 'comment': 'cron_2', 'daymonth': '*',
+                     'dayweek': '*', 'hour': '*', 'identifier': 'cron_2',
+                     'minute': '*', 'month': '*', 'commented': True},
+                    {'cmd': 'line#DISABLED#0 * * * * my_cmd_3',
+                     'comment': 'cron_3', 'daymonth': 'is',
+                     'dayweek': 'comment', 'hour': 'it', 'identifier': 'cron_3',
+                     'minute': 'but', 'month': 'a', 'commented': True},
+                    {'cmd': 'my_cmd_4', 'comment': 'cron_4', 'daymonth': '*',
+                     'dayweek': '*', 'hour': '*', 'identifier': 'cron_4',
+                     'minute': '0', 'month': '*', 'commented': False},
+                ],
+                'env': [],
+                'pre': ['# An unmanaged commented cron job', '#0 * * * * /bin/true'],
+                'special': []})
+
     @patch('salt.modules.cron.raw_cron',
            new=MagicMock(side_effect=[
                (L + '\n'),
                (L + '* * * * * ls\nn'),
+               (L + '# commented\n'
+                '#DISABLED#* * * * * ls\n'),
                (L + '# foo\n'
                 '* * * * * ls\n'),
                (L + '# foo {0}:blah\n'.format(
@@ -501,12 +547,14 @@ class CronTestCase(TestCase):
             crons2 = cron.list_tab('root')
             crons3 = cron.list_tab('root')
             crons4 = cron.list_tab('root')
+            crons5 = cron.list_tab('root')
             self.assertEqual(
                 crons1,
                 {'pre': [], 'crons': [], 'env': [], 'special': []})
             self.assertEqual(
                 crons2['crons'][0],
                 {'comment': None,
+                 'commented': False,
                  'dayweek': '*',
                  'hour': '*',
                  'identifier': None,
@@ -516,7 +564,8 @@ class CronTestCase(TestCase):
                  'month': '*'})
             self.assertEqual(
                 crons3['crons'][0],
-                {'comment': 'foo',
+                {'comment': 'commented',
+                 'commented': True,
                  'dayweek': '*',
                  'hour': '*',
                  'identifier': None,
@@ -527,6 +576,18 @@ class CronTestCase(TestCase):
             self.assertEqual(
                 crons4['crons'][0],
                 {'comment': 'foo',
+                 'commented': False,
+                 'dayweek': '*',
+                 'hour': '*',
+                 'identifier': None,
+                 'cmd': 'ls',
+                 'daymonth': '*',
+                 'minute': '*',
+                 'month': '*'})
+            self.assertEqual(
+                crons5['crons'][0],
+                {'comment': 'foo',
+                 'commented': False,
                  'dayweek': '*',
                  'hour': '*',
                  'identifier': 'blah',

--- a/tests/unit/states/cron_test.py
+++ b/tests/unit/states/cron_test.py
@@ -101,7 +101,7 @@ class CronTestCase(TestCase):
             hour='1',
             identifier='1',
             user='root')
-        self.assertEqual(
+        self.assertMultiLineEqual(
             get_crontab(),
             '# Lines below here are managed by Salt, do not edit\n'
             '# SALT_CRON_IDENTIFIER:1\n'
@@ -111,23 +111,55 @@ class CronTestCase(TestCase):
             hour='2',
             identifier='1',
             user='root')
-        self.assertEqual(
+        self.assertMultiLineEqual(
             get_crontab(),
             '# Lines below here are managed by Salt, do not edit\n'
             '# SALT_CRON_IDENTIFIER:1\n'
             '* 2 * * * foo')
         cron.present(
-            name='foo',
-            hour='2',
-            identifier='2',
+            name='cmd1',
+            minute='0',
+            comment='Commented cron job',
+            commented=True,
+            identifier='commented_1',
             user='root')
-        self.assertEqual(
+        self.assertMultiLineEqual(
             get_crontab(),
             '# Lines below here are managed by Salt, do not edit\n'
             '# SALT_CRON_IDENTIFIER:1\n'
             '* 2 * * * foo\n'
+            '# Commented cron job SALT_CRON_IDENTIFIER:commented_1\n'
+            '#DISABLED#0 * * * * cmd1')
+        cron.present(
+            name='foo',
+            hour='2',
+            identifier='2',
+            user='root')
+        self.assertMultiLineEqual(
+            get_crontab(),
+            '# Lines below here are managed by Salt, do not edit\n'
+            '# SALT_CRON_IDENTIFIER:1\n'
+            '* 2 * * * foo\n'
+            '# Commented cron job SALT_CRON_IDENTIFIER:commented_1\n'
+            '#DISABLED#0 * * * * cmd1\n'
             '# SALT_CRON_IDENTIFIER:2\n'
             '* 2 * * * foo')
+        cron.present(
+            name='cmd2',
+            commented=True,
+            identifier='commented_2',
+            user='root')
+        self.assertMultiLineEqual(
+            get_crontab(),
+            '# Lines below here are managed by Salt, do not edit\n'
+            '# SALT_CRON_IDENTIFIER:1\n'
+            '* 2 * * * foo\n'
+            '# Commented cron job SALT_CRON_IDENTIFIER:commented_1\n'
+            '#DISABLED#0 * * * * cmd1\n'
+            '# SALT_CRON_IDENTIFIER:2\n'
+            '* 2 * * * foo\n'
+            '# SALT_CRON_IDENTIFIER:commented_2\n'
+            '#DISABLED#* * * * * cmd2')
         set_crontab(
             '# Lines below here are managed by Salt, do not edit\n'
             '# SALT_CRON_IDENTIFIER:1\n'


### PR DESCRIPTION
This change is an implementation for managing commented cron jobs.

Before that, commented cron jobs were not manageable by salt. They were ignored
at reading, and thus lost while writing the new crontab.
This is described in issue #29082, which should be fixed now.

There is a new `commented` parameter, defaulting to False. The cron job is
set like any other, but is prefixed by `#DISABLED#`.
