### PR TITLE
Expand firewalld state.

### DIFF
--- a/salt/modules/firewalld.py
+++ b/salt/modules/firewalld.py
@@ -629,6 +629,8 @@ def make_permanent():
     '''
     Make current runtime configuration permanent.
 
+    .. versionadded:: Boron
+
     CLI Example:
 
     .. code-block:: bash
@@ -640,7 +642,9 @@ def make_permanent():
 
 def get_interfaces(zone):
     '''
-    List interfaces boud to a zone
+    List interfaces bound to a zone
+
+    .. versionadded:: Boron
 
     CLI Example:
 
@@ -654,6 +658,8 @@ def get_interfaces(zone):
 def add_interface(zone, interface):
     '''
     Bind an interface to a zone
+
+    .. versionadded:: Boron
 
     CLI Example:
 
@@ -671,6 +677,8 @@ def remove_interface(zone, interface):
     '''
     Remove an interface bound to a zone
 
+    .. versionadded:: Boron
+
     CLI Example:
 
     .. code-block:: bash
@@ -687,6 +695,8 @@ def get_sources(zone):
     '''
     List sources bound to a zone
 
+    .. versionadded:: Boron
+
     CLI Example:
 
     .. code-block:: bash
@@ -699,6 +709,8 @@ def get_sources(zone):
 def add_source(zone, source):
     '''
     Bind a source to a zone
+
+    .. versionadded:: Boron
 
     CLI Example:
 
@@ -715,6 +727,8 @@ def add_source(zone, source):
 def remove_source(zone, source):
     '''
     Remove a source bound to a zone
+
+    .. versionadded:: Boron
 
     CLI Example:
 

--- a/salt/modules/firewalld.py
+++ b/salt/modules/firewalld.py
@@ -623,3 +623,106 @@ def list_icmp_block(zone):
         salt '*' firewlld.list_icmp_block zone
     '''
     return __firewall_cmd('--zone={0} --list-icmp-blocks'.format(zone)).split()
+
+
+def make_permanent():
+    '''
+    Make current runtime configuration permanent.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' firewalld.make_permanent
+    '''
+    return __firewall_cmd('--runtime-to-permanent')
+
+
+def get_interfaces(zone):
+    '''
+    List interfaces boud to a zone
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' firewalld.get_interfaces zone
+    '''
+    return __firewall_cmd('--zone={0} --list-interfaces'.format(zone)).split()
+
+
+def add_interface(zone, interface):
+    '''
+    Bind an interface to a zone
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' firewalld.add_interface zone eth0
+    '''
+    if interface in get_interfaces(zone):
+        log.info('Interface is already bound to zone.')
+
+    return __firewall_cmd('--zone={0} --add-interface={1}'.format(zone, interface))
+
+
+def remove_interface(zone, interface):
+    '''
+    Remove an interface bound to a zone
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' firewalld.remove_interface zone eth0
+    '''
+    if interface not in get_interfaces(zone):
+        log.info('Interface is not bound to zone.')
+
+    return __firewall_cmd('--zone={0} --remove-interface={1}'.format(zone, interface))
+
+
+def get_sources(zone):
+    '''
+    List sources bound to a zone
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' firewalld.get_sources zone
+    '''
+    return __firewall_cmd('--zone={0} --list-sources'.format(zone)).split()
+
+
+def add_source(zone, source):
+    '''
+    Bind a source to a zone
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' firewalld.add_source zone 192.168.1.0/24
+    '''
+    if source in get_sources(zone):
+        log.info('Source is already bound to zone.')
+
+    return __firewall_cmd('--zone={0} --add-source={1}'.format(zone, source))
+
+
+def remove_source(zone, source):
+    '''
+    Remove a source bound to a zone
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' firewalld.remove_source zone 192.168.1.0/24
+    '''
+    if source not in get_sources(zone):
+        log.info('Source is not bound to zone.')
+
+    return __firewall_cmd('--zone={0} --remove-source={1}'.format(zone, source))

--- a/salt/states/firewalld.py
+++ b/salt/states/firewalld.py
@@ -313,7 +313,6 @@ def bind(name,
                     ret['comment'] = 'Error: {0}'.format(err)
                     return ret
 
-
     if new_interfaces or old_interfaces:
         ret['changes'].update({'interfaces':
                                 {'old': _current_interfaces,

--- a/salt/states/firewalld.py
+++ b/salt/states/firewalld.py
@@ -35,6 +35,20 @@ to 2222, and forwards TCP traffic from port 80 to 443 at 192.168.0.1.
       - port_fwd:
         - 22:2222:tcp
         - 80:443:tcp:192.168.0.1
+
+The following example binds the public zone to interface eth0 and to all
+packets coming from the 192.168.1.0/24 subnet. It also removes the zone
+from all other interfaces or sources.
+
+.. code-block:: yaml
+
+  public:
+    firewalld.bind:
+      - name: public
+      - interfaces:
+        - eth0
+      - sources:
+        - 192.168.1.0/24
 '''
 
 # Import Python Libs
@@ -228,6 +242,118 @@ def present(name,
             ret['changes'].update({'services':
                                   {'old': _current_services,
                                    'new': new_services}})
+
+    ret['result'] = True
+    if ret['changes'] == {}:
+        ret['comment'] = '\'{0}\' is already in the desired state.'.format(name)
+        return ret
+
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Configuration for \'{0}\' will change.'.format(name)
+        return ret
+
+    ret['comment'] = '\'{0}\' was configured.'.format(name)
+    return ret
+
+
+def bind(name,
+         interfaces=None,
+         sources=None):
+    '''
+    Ensure a zone is bound to specific interfaces or sources.
+
+    .. note::
+
+        This state does not enforce the existence of the zone. To ensure that
+        the zone exists, use :mod:`firewalld.present <salt.states.firewalld.present>`.
+    '''
+    ret = {'name': name,
+           'result': False,
+           'changes': {},
+           'comment': ''}
+
+    try:
+        zones = __salt__['firewalld.get_zones']()
+    except CommandExecutionError as err:
+        ret['comment'] = 'Error: {0}'.format(err)
+        return ret
+
+    if name not in zones:
+        ret['result'] = False
+        ret['comment'] = 'Zone {0} does not exist'.format(name)
+        return ret
+
+    interfaces = interfaces or []
+    new_interfaces = []
+    old_interfaces = []
+    try:
+        _current_interfaces = __salt__['firewalld.get_interfaces'](name)
+    except CommandExecutionError as err:
+        ret['comment'] = 'Error: {0}'.format(err)
+        return ret
+    for interface in interfaces:
+        if interface not in _current_interfaces:
+            new_interfaces.append(interface)
+            if not __opts__['test']:
+                try:
+                    __salt__['firewalld.add_interface'](name, interface)
+                except CommandExecutionError as err:
+                    ret['comment'] = 'Error: {0}'.format(err)
+                    return ret
+    for interface in _current_interfaces:
+        if interface not in interfaces:
+            old_interfaces.append(interface)
+            if not __opts__['test']:
+                try:
+                    __salt__['firewalld.remove_interface'](name, interface)
+                except CommandExecutionError as err:
+                    ret['comment'] = 'Error: {0}'.format(err)
+                    return ret
+
+
+    if new_interfaces or old_interfaces:
+        ret['changes'].update({'interfaces':
+                                {'old': _current_interfaces,
+                                'new': interfaces}})
+
+    sources = sources or []
+    new_sources = []
+    old_sources = []
+    try:
+        _current_sources = __salt__['firewalld.get_sources'](name)
+    except CommandExecutionError as err:
+        ret['comment'] = 'Error: {0}'.format(err)
+        return ret
+    for source in sources:
+        if source not in _current_sources:
+            new_sources.append(source)
+            if not __opts__['test']:
+                try:
+                    __salt__['firewalld.add_source'](name, source)
+                except CommandExecutionError as err:
+                    ret['comment'] = 'Error: {0}'.format(err)
+                    return ret
+    for source in _current_sources:
+        if source not in sources:
+            old_sources.append(source)
+            if not __opts__['test']:
+                try:
+                    __salt__['firewalld.remove_source'](name, source)
+                except CommandExecutionError as err:
+                    ret['comment'] = 'Error: {0}'.format(err)
+                    return ret
+    if new_sources or old_sources:
+        ret['changes'].update({'sources':
+                                {'old': _current_sources,
+                                'new': sources}})
+
+    if ret['changes'] != {}:
+        try:
+            __salt__['firewalld.make_permanent']()
+        except CommandExecutionError as err:
+            ret['comment'] = 'Error: {0}'.format(err)
+            return ret
 
     ret['result'] = True
     if ret['changes'] == {}:

--- a/salt/states/firewalld.py
+++ b/salt/states/firewalld.py
@@ -263,6 +263,8 @@ def bind(name,
     '''
     Ensure a zone is bound to specific interfaces or sources.
 
+    .. versionadded:: Boron
+
     .. note::
 
         This state does not enforce the existence of the zone. To ensure that


### PR DESCRIPTION
This expands the firewalld execution and state module to allow binding zones to interfaces and sources.

I left the existing `firewalld.present` state intact and added a new `firewalld.bind` state that can be used to accomplish the binding. To make sure the settings remain consistent, all changes are first done in the runtime configuration of firewalld and "committed" to the permanent configuration at the end.

An example state might look like this:

```
firewalld-public-zone:
    firewalld.bind:
      - name: public
      - interfaces:
        - eth0
      - sources:
        - 192.168.0.0/24
```

The state expects the zone to already exist, so a `require` of `firewalld.present` might be necessary.

Important: The state removes all interfaces and sources from the zone that are not explicitly given as parameters. I think this is quite important for a firewall, so one does not end up with "leftover" rules that were configured manually or remain after a previous run and allow possibly unwanted packets to pass the firewall.

The pull request also adds some functions to the firewalld execution module that are used by the state.

Resolves #29473 

Edit: I have not added `versionadded` statements to the docstrings, how should this be handled?
