### PR TITLE
Switch volumes and del_*_on_destroy example ordering

### DIFF
--- a/doc/topics/cloud/aws.rst
+++ b/doc/topics/cloud/aws.rst
@@ -270,12 +270,12 @@ Set up an initial profile at ``/etc/salt/cloud.profiles``:
           SubnetId: subnet-813d4bbf
           SecurityGroupId:
             - sg-750af413
+      del_root_vol_on_destroy: True
+      del_all_vol_on_destroy: True
       volumes:
         - { size: 10, device: /dev/sdf }
         - { size: 10, device: /dev/sdg, type: io1, iops: 1000 }
         - { size: 10, device: /dev/sdh, type: io1, iops: 1000 }
-      del_root_vol_on_destroy: True
-      del_all_vol_on_destroy: True
       tag: {'Environment': 'production', 'Role': 'database'}
       sync_after_install: grains
 


### PR DESCRIPTION
According to issue #29101, if del___on_destroy settings are placed _after_ the volumes settings, the del___on_destroy options don't have an effect. I haven't worked out why that is yet, but this updates the profile example in the mean time.
