### PR TITLE
Fix forced remount if uid/gid is provided as a name

### DIFF
--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -319,6 +319,19 @@ def mounted(name,
                     if fstype in ['cifs'] and opt.split('=')[0] == 'user':
                         opt = "username={0}".format(opt.split('=')[1])
 
+                    # convert uid/gid to numeric value from user/group name
+                    name_id_opts = {'uid': 'user.info',
+                                    'gid': 'group.info'}
+                    if opt.split('=')[0] in name_id_opts:
+                        _givenid = opt.split('=')[1]
+                        _param = opt.split('=')[0]
+                        _id = _givenid
+                        if not re.match('[0-9]+$', _givenid):
+                            _info = __salt__[name_id_opts[_param]](_givenid)
+                            if _info and _param in _info:
+                                _id = _info[_param]
+                        opt = _param + '=' + str(_id)
+
                     if opt not in active[real_name]['opts'] \
                     and opt not in active[real_name].get('superopts', []) \
                     and opt not in mount_invisible_options \

--- a/tests/unit/states/mount_test.py
+++ b/tests/unit/states/mount_test.py
@@ -41,20 +41,31 @@ class MountTestCase(TestCase):
         device = '/dev/sdb5'
         fstype = 'xfs'
 
+        name2 = '/mnt/cifs'
+        device2 = '//SERVER/SHARE/'
+        fstype2 = 'cifs'
+        opts2 = ['noowners']
+        superopts2 = ['uid=510', 'gid=100', 'username=cifsuser',
+                      'domain=cifsdomain']
+
         ret = {'name': name,
                'result': False,
                'comment': '',
                'changes': {}}
 
         mock = MagicMock(side_effect=['new', 'present', 'new', 'change',
-                                      'bad config', 'salt'])
+                                      'bad config', 'salt', 'present'])
         mock_t = MagicMock(return_value=True)
         mock_f = MagicMock(return_value=False)
         mock_ret = MagicMock(return_value={'retcode': 1})
         mock_mnt = MagicMock(return_value={name: {'device': device, 'opts': [],
-                                                  'superopts': []}})
+                                                  'superopts': []},
+                                           name2: {'device': device2, 'opts': opts2,
+                                                   'superopts': superopts2}})
         mock_emt = MagicMock(return_value={})
         mock_str = MagicMock(return_value='salt')
+        mock_user = MagicMock(return_value={'uid': 510})
+        mock_group = MagicMock(return_value={'gid': 100})
         umount1 = ("Forced unmount because devices don't match. "
                    "Wanted: /dev/sdb6, current: /dev/sdb5, /dev/sdb5")
         with patch.dict(mount.__grains__, {'os': 'Darwin'}):
@@ -151,6 +162,26 @@ class MountTestCase(TestCase):
                                     'changes': {}})
                         self.assertDictEqual(mount.mounted(name, device, fstype,
                                                            mount=False), ret)
+
+        # Test no change for uid provided as a name #25293
+        with patch.dict(mount.__grains__, {'os': 'CentOS'}):
+            with patch.dict(mount.__salt__, {'mount.active': mock_mnt,
+                                             'mount.mount': mock_str,
+                                             'mount.umount': mock_f,
+                                             'mount.set_fstab': mock,
+                                             'user.info': mock_user,
+                                             'group.info': mock_group}):
+                with patch.dict(mount.__opts__, {'test': True}):
+                    with patch.object(os.path, 'exists', mock_t):
+                        comt = 'Target was already mounted. ' + \
+                               'Entry already exists in the fstab.'
+                        ret.update({'name': name2, 'result': True})
+                        ret.update({'comment': comt, 'changes': {}})
+                        self.assertDictEqual(mount.mounted(name2, device2,
+                                                           fstype2,
+                                                           opts=['uid=user1',
+                                                                 'gid=group1']),
+                                             ret)
 
     # 'swap' function tests: 1
 


### PR DESCRIPTION
mount: uid/gid verification with names provided, should fix #25293

This is done only for uid= and gid= opts, for now. It can be extended to others.
