### PR TITLE
Drop obsolete syslog.target from systemd services

### DIFF
--- a/pkg/salt-api.service
+++ b/pkg/salt-api.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=The Salt API
-After=syslog.target network.target
+After=network.target
 
 [Service]
 Type=simple

--- a/pkg/salt-master.service
+++ b/pkg/salt-master.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=The Salt Master Server
-After=syslog.target network.target
+After=network.target
 
 [Service]
 LimitNOFILE=16384

--- a/pkg/salt-minion.service
+++ b/pkg/salt-minion.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=The Salt Minion
-After=syslog.target network.target
+After=network.target
 
 [Service]
 Type=simple

--- a/pkg/salt-syndic.service
+++ b/pkg/salt-syndic.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=The Salt Master Server
-After=syslog.target network.target
+After=network.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
Declaring After=syslog.target is unnecessary by now because syslog is
socket-activated and will therefore be started when needed. Thus remove
the obsolete syslog.target from the systemd service files.
