### PR TITLE
Updated pip module internal check for log.

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -125,7 +125,8 @@ def _get_pip_bin(bin_env):
     # try to get pip bin from virtualenv, bin_env
     if os.path.isdir(bin_env):
         if salt.utils.is_windows():
-            pip_bin = os.path.join(bin_env, 'Scripts', 'pip.exe').encode('string-escape')
+            pip_bin = os.path.join(
+                bin_env, 'Scripts', 'pip.exe').encode('string-escape')
         else:
             pip_bin = os.path.join(bin_env, 'bin', 'pip')
         if os.path.isfile(pip_bin):
@@ -468,10 +469,10 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
 
     if activate:
         salt.utils.warn_until(
-                'Boron',
-                'Passing \'activate\' to the pip module is deprecated. If '
-                'bin_env refers to a virtualenv, there is no need to activate '
-                'that virtualenv before using pip to install packages in it.'
+            'Boron',
+            'Passing \'activate\' to the pip module is deprecated. If '
+            'bin_env refers to a virtualenv, there is no need to activate '
+            'that virtualenv before using pip to install packages in it.'
         )
 
     if isinstance(__env__, string_types):
@@ -525,10 +526,10 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
             cmd.append('--no-use-wheel')
 
     if log:
-        try:
-            # TODO make this check if writeable
-            os.path.exists(log)
-        except IOError:
+        if os.path.isdir(log):
+            raise IOError(
+                '\'{0}\' is a directory. Use --log path_to_file'.format(log))
+        elif not os.access(log, os.W_OK):
             raise IOError('\'{0}\' is not writeable'.format(log))
 
         cmd.extend(['--log', log])
@@ -714,7 +715,8 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
         if isinstance(env_vars, dict):
             os.environ.update(env_vars)
         else:
-            raise CommandExecutionError('env_vars {0} is not a dictionary'.format(env_vars))
+            raise CommandExecutionError(
+                'env_vars {0} is not a dictionary'.format(env_vars))
 
     if trusted_host:
         cmd.extend(['--trusted-host', trusted_host])
@@ -856,7 +858,8 @@ def uninstall(pkgs=None,
                             pass
         cmd.extend(pkgs)
 
-    cmd_kwargs = dict(python_shell=False, runas=user, cwd=cwd, saltenv=saltenv, use_vt=use_vt)
+    cmd_kwargs = dict(python_shell=False, runas=user,
+                      cwd=cwd, saltenv=saltenv, use_vt=use_vt)
     if bin_env and os.path.isdir(bin_env):
         cmd_kwargs['env'] = {'VIRTUAL_ENV': bin_env}
 
@@ -983,7 +986,8 @@ def version(bin_env=None):
     '''
     pip_bin = _get_pip_bin(bin_env)
 
-    output = __salt__['cmd.run']('{0} --version'.format(pip_bin), python_shell=False)
+    output = __salt__['cmd.run'](
+        '{0} --version'.format(pip_bin), python_shell=False)
     try:
         return re.match(r'^pip (\S+)', output).group(1)
     except AttributeError:


### PR DESCRIPTION
When using pip you can append --log to store pip logs. In this case i made a change to make sure
argument to --log is not a directory, other way pip will throw and error. Also we need to make sure that
we have write permissions to that file.
Finally i made a small update on this file regarding indentation following pep8 standards.

Related to issue #29470

In this case, since is a feature hope is ok to make this PR against develop.
