### PR TITLE
[2015.8] [salt-ssh] Remove umask around actual execution for salt-ssh

### DIFF
--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -216,7 +216,6 @@ def main(argv):  # pylint: disable=W0613
     sys.stdout.flush()
     sys.stderr.write(OPTIONS.delimiter + '\n')
     sys.stderr.flush()
-    old_umask = os.umask(0o077)
     if OPTIONS.tty:
         stdout, _ = subprocess.Popen(salt_argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
         sys.stdout.write(stdout)
@@ -228,7 +227,6 @@ def main(argv):  # pylint: disable=W0613
         shutil.rmtree(OPTIONS.saltdir)
     else:
         os.execv(sys.executable, salt_argv)
-    os.umask(old_umask)
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv))


### PR DESCRIPTION
Fixes #29486 

Refs #29126 

@fcrozat I'm reverting this piece of your umask fixes. It changes the umask for the whole command execution, which is too much for some setups. We could potentially make this configurable and add it back in (don't change the umask by default, that kind of thing).
