### PR TITLE
Bug fix in file.serialize state

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -4142,7 +4142,7 @@ def _merge_dict(obj, k, v):
                         for x, y in six.iteritems(updates):
                             changes[k + "." + x] = y
                     else:
-                        if obj[k][a] != b:
+                        if a not in obj[k] or obj[k][a] != b:
                             changes[k + "." + a] = b
                             obj[k][a] = b
             else:


### PR DESCRIPTION
Hello, this patch fix the following error

---

With the following config:

Pillar

```
mylabels:
      labels:
        color1: red
        color2: green
```

State

```
{% set labels = salt['pillar.get']('mylabels:labels') %}
set_my_labels:
   file.serialize:
        - name: /tmp/myfiles
        - formatter: yaml
        - dataset:
            all_my_labels:
                labels: {{ labels }}
        - merge_if_exists: True
```

This works pretty good.

But, if I change my pillar:

```
mylabels:
      labels:
        disktype: ssd
        color1: red
        color2: green
        color3: blue
```

With the second run, I got

```
----------
          ID: set_my_labels
    Function: file.serialize
        Name: /tmp/myfiles
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/site-packages/salt/state.py", line 1561, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/site-packages/salt/states/file.py", line 4074, in serialize
                  ret['changes'].update(_merge_dict(existing_data, k, v))
                File "/usr/lib/python2.7/site-packages/salt/states/file.py", line 3891, in _merge_dict
                  updates = _merge_dict(obj[k], a, b)
                File "/usr/lib/python2.7/site-packages/salt/states/file.py", line 3895, in _merge_dict
                  if obj[k][a] != b:
              KeyError: 'color3'
     Started: 23:19:47.022047
    Duration: 5.576 ms
     Changes:   
```
