### PR TITLE
git.latest: init submodules if not yet initialized

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -1117,7 +1117,7 @@ def latest(name,
                 if submodules:
                     __salt__['git.submodule'](target,
                                               'update',
-                                              opts=['--recursive'],
+                                              opts=['--init', '--recursive'],
                                               user=user,
                                               identity=identity)
             elif bare:
@@ -1376,7 +1376,7 @@ def latest(name,
             if submodules and remote_rev:
                 __salt__['git.submodule'](target,
                                           'update',
-                                          opts=['--recursive'],
+                                          opts=['--init', '--recursive'],
                                           user=user,
                                           identity=identity)
 


### PR DESCRIPTION
Fixes #29009.
