### PR TITLE
Refactored ESXCLI-based functions to accept a list of esxi_hosts

### DIFF
--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -65,10 +65,16 @@ def esxcli(host, user, pwd, cmd, protocol=None, port=None, esxi_host=None):
     :return: Dictionary
     '''
 
-    esx_cmd = salt.utils.which('esxicli')
+    esx_cmd = salt.utils.which('esxcli')
     if not esx_cmd:
         log.error('Missing dependency: The salt.utils.vmware.esxcli function requires ESXCLI.')
         return False
+
+    # Set default port and protocol if none are provided.
+    if port is None:
+        port = 443
+    if protocol is None:
+        protocol = 'https'
 
     if not esxi_host:
         # Then we are connecting directly to an ESXi server,


### PR DESCRIPTION
Previously, only one esxi_host could be passed in when connecting
to a vCenter server. This brings feature-partiy for ESXCLI-based
functions with pyVmomi-based functions, which already accept and
handle a list of hosts.

State functions were also updated.

Also fixes a bug with the ESXCLI `which` check in salt.utils.vmware
and provides default protocol and port options if none are provided 
for `salt.utils.vmware.esxcli`.

ping @cro 
