### PR TITLE
Summary: Add a neutron api which shows a specific firewall rule.

### DIFF
--- a/salt/modules/neutron.py
+++ b/salt/modules/neutron.py
@@ -1387,6 +1387,24 @@ def list_firewall_rules(profile=None):
     return conn.list_firewall_rules()
 
 
+def show_firewall_rule(firewall_rule, profile=None):
+    '''
+    Fetches information of a specific firewall rule
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' neutron.show_firewall_rule firewall-rule-name
+
+    :param ipsecpolicy: ID or name of firewall rule to look up
+    :param profile: Profile to build on (Optional)
+    :return: firewall rule information
+    '''
+    conn = _auth(profile)
+    return conn.show_firewall_rule(firewall_rule)
+
+
 # The following is a list of functions that need to be incorporated in the
 # neutron module. This list should be updated as functions are added.
 #

--- a/salt/utils/openstack/neutron.py
+++ b/salt/utils/openstack/neutron.py
@@ -162,6 +162,10 @@ class SaltNeutron(NeutronShell):
         resources = self.list_ipsecpolicies()['ipsecpolicies']
         return self._fetch(resources, name_or_id)
 
+    def _fetch_firewall_rule(self, name_or_id):
+        resources = self.list_firewall_rules()['firewall_rules']
+        return self._fetch(resources, name_or_id)
+
     def get_quotas_tenant(self):
         '''
         Fetches tenant info in server's context
@@ -747,6 +751,12 @@ class SaltNeutron(NeutronShell):
         Fetches a list of all configured firewall rules for a tenant
         '''
         return self.network_conn.list_firewall_rules()
+
+    def show_firewall_rule(self, firewall_rule):
+        '''
+        Fetches information of a specific firewall rule
+        '''
+        return self._fetch_firewall_rule(firewall_rule)
 
 # The following is a list of functions that need to be incorporated in the
 # neutron module. This list should be updated as functions are added.


### PR DESCRIPTION
Description: Add a show_firewall_rule function in salt/modules/neutron.py
Add show_firewall_rule and _fetch_firewall_rule functions in
salt/utils/openstack/neutron.py
