### PR TITLE
file modules: fix checking user/group against an uid/gid

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3844,9 +3844,13 @@ def check_file_meta(
                 else:
                     changes['diff'] = 'Replace binary file with text file'
 
-    if user is not None and user != lstats['user']:
+    if (user is not None
+            and user != lstats['user']
+            and user != lstats['uid']):
         changes['user'] = user
-    if group is not None and group != lstats['group']:
+    if (group is not None
+            and group != lstats['group']
+            and group != lstats['gid']):
         changes['group'] = group
     # Normalize the file mode
     smode = __salt__['config.manage_mode'](lstats['mode'])

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -480,9 +480,13 @@ def _check_directory(name,
                 stats = __salt__['file.stats'](
                     path, None, follow_symlinks=False
                 )
-                if user is not None and user != stats.get('user'):
+                if (user is not None
+                        and user != stats.get('user')
+                        and user != stats.get('uid')):
                     fchange['user'] = user
-                if group is not None and group != stats.get('group'):
+                if (group is not None
+                        and group != stats.get('group')
+                        and group != stats.get('gid')):
                     fchange['group'] = group
                 if fchange:
                     changes[path] = fchange
@@ -538,9 +542,13 @@ def _check_dir_meta(name,
     if not stats:
         changes['directory'] = 'new'
         return changes
-    if user is not None and user != stats['user']:
+    if (user is not None
+            and user != stats['user']
+            and user != stats.get('uid')):
         changes['user'] = user
-    if group is not None and group != stats['group']:
+    if (group is not None
+            and group != stats['group']
+            and group != stats.get('gid')):
         changes['group'] = group
     # Normalize the dir mode
     smode = __salt__['config.manage_mode'](stats['mode'])


### PR DESCRIPTION
We can set group ownership to files and directories providing a `gid` instead of a group name. Example:

```
/tmp/file:
  file.managed:
    - source: salt://tmp/file
    - user: 1000
    - group: 1000
```

Using `test=True` with this state always returns in a "would change" state. This commit adds a check against the `uid`/`gid` after the check against the user/group names.
