### PR TITLE
An implementation of support for AWS Lambda

### DIFF
--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -256,9 +256,9 @@ def delete_function(FunctionName, Qualifier=None, region=None, key=None, keyid=N
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         if Qualifier:
-           conn.delete_function(FunctionName=FunctionName, Qualifier=Qualifier)
+           r = conn.delete_function(FunctionName=FunctionName, Qualifier=Qualifier)
         else:
-           conn.delete_function(FunctionName=FunctionName)
+           r = conn.delete_function(FunctionName=FunctionName)
         return {'deleted': True}
     except ClientError as e:
         return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}

--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -1,0 +1,367 @@
+# -*- coding: utf-8 -*-
+'''
+Connection module for Amazon Lambda
+
+.. versionadded:: 
+
+:configuration: This module accepts explicit Lambda credentials but can also
+    utilize IAM roles assigned to the instance trough Instance Profiles.
+    Dynamic credentials are then automatically obtained from AWS API and no
+    further configuration is necessary. More Information available at:
+
+    .. code-block:: text
+
+        http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+
+    If IAM roles are not used you need to specify them either in a pillar or
+    in the minion's config file:
+
+    .. code-block:: yaml
+
+        lambda.keyid: GKTADJGHEIQSXMKKRBJ08H
+        lambda.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+    A region may also be specified in the configuration:
+
+    .. code-block:: yaml
+
+        lambda.region: us-east-1
+
+    If a region is not specified, the default is us-east-1.
+
+    It's also possible to specify key, keyid and region via a profile, either
+    as a passed in dict, or as a string to pull from pillars or minion config:
+
+    .. code-block:: yaml
+
+        myprofile:
+            keyid: GKTADJGHEIQSXMKKRBJ08H
+            key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+            region: us-east-1
+
+.. versionchanged:: 2015.8.0
+    All methods now return a dictionary. Create and delete methods return:
+
+    .. code-block:: yaml
+
+        created: true
+
+    or
+
+    .. code-block:: yaml
+
+        created: false
+        error:
+          message: error message
+
+    Request methods (e.g., `describe_lambda`) return:
+
+    .. code-block:: yaml
+
+        lambda:
+          - {...}
+          - {...}
+
+    or
+
+    .. code-block:: yaml
+
+        error:
+          message: error message
+
+:depends: boto3
+
+'''
+# keep lint from choking on _get_conn and _cache_id
+#pylint: disable=E0602
+
+# Import Python libs
+from __future__ import absolute_import
+import logging
+import socket
+from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
+
+# Import Salt libs
+import salt.utils.boto
+import salt.utils.compat
+from salt.exceptions import SaltInvocationError, CommandExecutionError
+# from salt.utils import exactly_one
+# TODO: Uncomment this and s/_exactly_one/exactly_one/
+# See note in utils.boto
+
+log = logging.getLogger(__name__)
+
+# Import third party libs
+import salt.ext.six as six
+# pylint: disable=import-error
+try:
+    #pylint: disable=unused-import
+    import boto
+    import boto3
+    #pylint: enable=unused-import
+    from boto.exception import BotoServerError
+    logging.getLogger('boto').setLevel(logging.CRITICAL)
+    logging.getLogger('boto3').setLevel(logging.CRITICAL)
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+# pylint: enable=import-error
+
+
+def __virtual__():
+    '''
+    Only load if boto libraries exist and if boto libraries are greater than
+    a given version.
+    '''
+    required_boto_version = '2.8.0'
+    required_boto3_version = '1.2.1'
+    # the boto_lambda execution module relies on the connect_to_region() method
+    # which was added in boto 2.8.0
+    # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
+    if not HAS_BOTO:
+        return False
+    elif _LooseVersion(boto.__version__) < _LooseVersion(required_boto_version):
+        return False
+    elif _LooseVersion(boto3.__version__) < _LooseVersion(required_boto3_version):
+        return False
+    else:
+        return True
+
+
+def __init__(opts):
+    salt.utils.compat.pack_dunder(__name__)
+    if HAS_BOTO:
+        __utils__['boto3.assign_funcs'](__name__, 'lambda')
+
+
+def _find_lambda(lambda_id=None, lambda_name=None, 
+               region=None, key=None, keyid=None, profile=None):
+
+    '''
+    Given Lambda function properties, find and return matching Lambda information.
+    '''
+
+    if all((lambda_id, lambda_name)):
+        raise SaltInvocationError('Only one of lambda_name or lambda_id may be '
+                                  'provided.')
+
+    if not any((lambda_id, lambda_name)):
+        raise SaltInvocationError('At least one of the following must be '
+                                  'provided: lambda_id or lambda_name.')
+
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    lambdas = conn.list_functions()
+
+    found=False
+
+    if lambda_id:
+	for lmbda in lambdas['Functions']:
+            if lmbda['FunctionArn'] == lambda_id:
+                found=True
+                break
+
+    if lambda_name:
+	for lmbda in lambdas['Functions']:
+            if lmbda['FunctionName'] == lambda_name:
+                found=True
+                break
+    if found:
+       return lmbda
+    return None
+
+def _get_id(lambda_name=None, region=None, key=None,
+            keyid=None, profile=None):
+    '''
+    Given Lambda function name, return the Lambda function id if a match is found.
+    '''
+
+    lambda_id = _cache_id(lambda_name, region=region,
+                       key=key, keyid=keyid,
+                       profile=profile)
+    if lambda_id:
+        return lambda_id
+    log.info('No Lambda function found.')
+    return None
+
+def get_id(name=None, region=None, key=None, keyid=None,
+           profile=None):
+    '''
+    Given Lambda function name, return the Lambda id if a match is found.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_lambda.get_id mylambda
+
+    '''
+
+    try:
+        return {'id': _get_id(lambda_name=name, region=region,
+                              key=key, keyid=keyid, profile=profile)}
+    except BotoServerError as e:
+        return {'error': salt.utils.boto.get_error(e)}
+
+
+def exists(lambda_id=None, name=None, region=None, key=None,
+           keyid=None, profile=None):
+    '''
+    Given a Lambda function ID, check to see if the given Lambda function ID exists.
+
+    Returns True if the given Lambda function ID exists and returns False if the given
+    Lambda function ID does not exist.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_lambda.exists mylambda
+
+    '''
+
+    try:
+        lmbda = _find_lambda(lambda_id=lambda_id, lambda_name=name,
+                             region=region, key=key, keyid=keyid, profile=profile)
+        return {'exists': bool(lmbda)}
+    except BotoServerError as e:
+        return {'error': salt.utils.boto.get_error(e)}
+
+
+def create(cidr_block, instance_tenancy=None, lambda_name=None,
+           enable_dns_support=None, enable_dns_hostnames=None, tags=None,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a valid CIDR block, create a VPC.
+
+    An optional instance_tenancy argument can be provided. If provided, the
+    valid values are 'default' or 'dedicated'
+
+    An optional vpc_name argument can be provided.
+
+    Returns {created: true} if the VPC was created and returns
+    {created: False} if the VPC was not created.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_vpc.create '10.0.0.0/24'
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        vpc = conn.create_vpc(cidr_block, instance_tenancy=instance_tenancy)
+        if vpc:
+            log.info('The newly created VPC id is {0}'.format(vpc.id))
+
+            _maybe_set_name_tag(vpc_name, vpc)
+            _maybe_set_tags(tags, vpc)
+            _maybe_set_dns(conn, vpc.id, enable_dns_support, enable_dns_hostnames)
+            if vpc_name:
+                _cache_id(vpc_name, vpc.id,
+                          region=region, key=key,
+                          keyid=keyid, profile=profile)
+            return {'created': True, 'id': vpc.id}
+        else:
+            log.warning('VPC was not created')
+            return {'created': False}
+    except BotoServerError as e:
+        return {'created': False, 'error': salt.utils.boto.get_error(e)}
+
+
+def delete(vpc_id=None, name=None, vpc_name=None, tags=None,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a VPC ID or VPC name, delete the VPC.
+
+    Returns {deleted: true} if the VPC was deleted and returns
+    {deleted: false} if the VPC was not deleted.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_vpc.delete vpc_id='vpc-6b1fe402'
+        salt myminion boto_vpc.delete name='myvpc'
+
+    '''
+
+    if name:
+        log.warning('boto_vpc.delete: name parameter is deprecated '
+                    'use vpc_name instead.')
+        vpc_name = name
+
+    if not _exactly_one((vpc_name, vpc_id)):
+        raise SaltInvocationError('One (but not both) of vpc_name or vpc_id must be '
+                                  'provided.')
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not vpc_id:
+            vpc_id = _get_id(vpc_name=vpc_name, tags=tags, region=region, key=key,
+                             keyid=keyid, profile=profile)
+            if not vpc_id:
+                return {'deleted': False, 'error': {'message':
+                        'VPC {0} not found'.format(vpc_name)}}
+
+        if conn.delete_vpc(vpc_id):
+            log.info('VPC {0} was deleted.'.format(vpc_id))
+            if vpc_name:
+                _cache_id(vpc_name, resource_id=vpc_id,
+                          invalidate=True,
+                          region=region,
+                          key=key, keyid=keyid,
+                          profile=profile)
+            return {'deleted': True}
+        else:
+            log.warning('VPC {0} was not deleted.'.format(vpc_id))
+            return {'deleted': False}
+    except BotoServerError as e:
+        return {'deleted': False, 'error': salt.utils.boto.get_error(e)}
+
+
+def describe(vpc_id=None, vpc_name=None, region=None, key=None,
+             keyid=None, profile=None):
+    '''
+    Given a VPC ID describe its properties.
+
+    Returns a dictionary of interesting properties.
+
+    .. versionchanged:: 2015.8.0
+        Added vpc_name argument
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_vpc.describe vpc_id=vpc-123456
+        salt myminion boto_vpc.describe vpc_name=myvpc
+
+    '''
+
+    if not any((vpc_id, vpc_name)):
+        raise SaltInvocationError('A valid vpc id or name needs to be specified.')
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        vpc_id = _check_vpc(vpc_id, vpc_name, region, key, keyid, profile)
+        if not vpc_id:
+            return {'vpc': None}
+
+        filter_parameters = {'vpc_ids': vpc_id}
+
+        vpcs = conn.get_all_vpcs(**filter_parameters)
+
+        if vpcs:
+            vpc = vpcs[0]  # Found!
+            log.debug('Found VPC: {0}'.format(vpc.id))
+
+            keys = ('id', 'cidr_block', 'is_default', 'state', 'tags',
+                    'dhcp_options_id', 'instance_tenancy')
+            return {'vpc': dict([(k, getattr(vpc, k)) for k in keys])}
+        else:
+            return {'vpc': None}
+
+    except BotoServerError as e:
+        return {'error': salt.utils.boto.get_error(e)}

--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -322,7 +322,7 @@ def update_function_config(name, role, handler, description="", timeout=3, memor
             log.warning('Function was not updated')
             return {'updated': False}
     except ClientError as e:
-        return {'created': False, 'error': salt.utils.boto.get_error(e)}
+        return {'updated': False, 'error': salt.utils.boto.get_error(e)}
 
 
 def update_function_code(name, zipfile=None, s3bucket=None, s3key=None,

--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -2,7 +2,7 @@
 '''
 Connection module for Amazon Lambda
 
-.. versionadded:: 
+.. versionadded::
 
 :configuration: This module accepts explicit Lambda credentials but can also
     utilize IAM roles assigned to the instance trough Instance Profiles.
@@ -78,22 +78,18 @@ Connection module for Amazon Lambda
 # Import Python libs
 from __future__ import absolute_import
 import logging
-import socket
 from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
 
 # Import Salt libs
 import salt.utils.boto3
 import salt.utils.compat
 import salt.utils
-from salt.exceptions import SaltInvocationError, CommandExecutionError
-# from salt.utils import exactly_one
-# TODO: Uncomment this and s/_exactly_one/exactly_one/
-# See note in utils.boto
+from salt.exceptions import SaltInvocationError
 
 log = logging.getLogger(__name__)
 
 # Import third party libs
-import salt.ext.six as six
+
 # pylint: disable=import-error
 try:
     #pylint: disable=unused-import
@@ -133,6 +129,7 @@ def __init__(opts):
     salt.utils.compat.pack_dunder(__name__)
     if HAS_BOTO:
         __utils__['boto3.assign_funcs'](__name__, 'lambda')
+
 
 def _find_function(name,
                region=None, key=None, keyid=None, profile=None):
@@ -185,7 +182,8 @@ def _get_role_arn(name, region=None, key=None, keyid=None, profile=None):
 
 def _filedata(infile):
     with salt.utils.fopen(infile, 'rb') as f:
-       return f.read()
+        return f.read()
+
 
 def create_function(FunctionName, Runtime, Role, Handler, ZipFile=None,
                     S3Bucket=None, S3Key=None, S3ObjectVersion=None,
@@ -224,9 +222,9 @@ def create_function(FunctionName, Runtime, Role, Handler, ZipFile=None,
                'S3Key': S3Key,
             }
             if S3ObjectVersion:
-                code['S3ObjectVersion']= S3ObjectVersion
-        func = conn.create_function(FunctionName=FunctionName, Runtime=Runtime, Role=role_arn, Handler=Handler, 
-                                   Code=code, Description=Description, Timeout=Timeout, MemorySize=MemorySize, 
+                code['S3ObjectVersion'] = S3ObjectVersion
+        func = conn.create_function(FunctionName=FunctionName, Runtime=Runtime, Role=role_arn, Handler=Handler,
+                                   Code=code, Description=Description, Timeout=Timeout, MemorySize=MemorySize,
                                    Publish=Publish)
         if func:
             log.info('The newly created function name is {0}'.format(func['FunctionName']))
@@ -257,9 +255,9 @@ def delete_function(FunctionName, Qualifier=None, region=None, key=None, keyid=N
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         if Qualifier:
-           r = conn.delete_function(FunctionName=FunctionName, Qualifier=Qualifier)
+            r = conn.delete_function(FunctionName=FunctionName, Qualifier=Qualifier)
         else:
-           r = conn.delete_function(FunctionName=FunctionName)
+            r = conn.delete_function(FunctionName=FunctionName)
         return {'deleted': True}
     except ClientError as e:
         return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}
@@ -369,11 +367,11 @@ def update_function_code(FunctionName, ZipFile=None, S3Bucket=None, S3Key=None,
                 raise SaltInvocationError('Either ZipFile must be specified, or '
                                 'S3Bucket and S3Key must be provided.')
             args = {
-                'S3Bucket': S3Bucket, 
+                'S3Bucket': S3Bucket,
                 'S3Key': S3Key,
             }
             if S3ObjectVersion:
-              args['S3ObjectVersion'] = S3ObjectVersion
+                args['S3ObjectVersion'] = S3ObjectVersion
             r = conn.update_function_code(FunctionName=FunctionName,
                                    Publish=Publish, **args)
         if r:
@@ -388,7 +386,7 @@ def update_function_code(FunctionName, ZipFile=None, S3Bucket=None, S3Key=None,
         return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
 
 
-def list_function_versions(FunctionName, 
+def list_function_versions(FunctionName,
             region=None, key=None, keyid=None, profile=None):
     '''
     List the versions available for the given function.
@@ -407,12 +405,12 @@ def list_function_versions(FunctionName,
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         vers = []
-        for ret in salt.utils.boto3.paged_call(conn.list_versions_by_function, 
+        for ret in salt.utils.boto3.paged_call(conn.list_versions_by_function,
                                  FunctionName=FunctionName):
             vers.extend(ret['Versions'])
         if not bool(vers):
             log.warning('No versions found')
-        return { 'Versions': vers }
+        return {'Versions': vers}
     except ClientError as e:
         return {'error': salt.utils.boto3.get_error(e)}
 
@@ -560,7 +558,7 @@ def update_alias(FunctionName, Name, FunctionVersion=None, Description=None,
 
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-        args= {}
+        args = {}
         if FunctionVersion:
             args['FunctionVersion'] = FunctionVersion
         if Description:
@@ -577,7 +575,7 @@ def update_alias(FunctionName, Name, FunctionVersion=None, Description=None,
 
 
 def create_event_source_mapping(EventSourceArn, FunctionName, StartingPosition,
-            Enabled=True, BatchSize=100, 
+            Enabled=True, BatchSize=100,
             region=None, key=None, keyid=None, profile=None):
     '''
     Identifies a stream as an event source for a Lambda function. It can be
@@ -612,7 +610,7 @@ def create_event_source_mapping(EventSourceArn, FunctionName, StartingPosition,
         return {'created': False, 'error': salt.utils.boto3.get_error(e)}
 
 
-def get_event_source_mapping_ids(EventSourceArn, FunctionName, 
+def get_event_source_mapping_ids(EventSourceArn, FunctionName,
            region=None, key=None, keyid=None, profile=None):
     '''
     Given an event source and function name, return a list of mapping IDs
@@ -628,7 +626,7 @@ def get_event_source_mapping_ids(EventSourceArn, FunctionName,
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     try:
         mappings = []
-        for maps in salt.utils.boto3.paged_call(conn.list_event_source_mappings, 
+        for maps in salt.utils.boto3.paged_call(conn.list_event_source_mappings,
                                                EventSourceArn=EventSourceArn,
                                                FunctionName=FunctionName):
             mappings.extend([mapping['UUID'] for mapping in maps['EventSourceMappings']])
@@ -643,7 +641,7 @@ def _get_ids(UUID=None, EventSourceArn=None, FunctionName=None,
         if EventSourceArn or FunctionName:
             raise SaltInvocationError('Either UUID must be specified, or '
                                 'EventSourceArn and FunctionName must be provided.')
-        return [ UUID ]
+        return [UUID]
     else:
         if not EventSourceArn or not FunctionName:
             raise SaltInvocationError('Either UUID must be specified, or '
@@ -653,7 +651,7 @@ def _get_ids(UUID=None, EventSourceArn=None, FunctionName=None,
                        region=region, key=key, keyid=keyid, profile=profile)
 
 
-def delete_event_source_mapping(UUID=None, EventSourceArn=None, FunctionName=None, 
+def delete_event_source_mapping(UUID=None, EventSourceArn=None, FunctionName=None,
                                 region=None, key=None, keyid=None, profile=None):
     '''
     Given an event source mapping ID or an event source ARN and FunctionName,
@@ -736,8 +734,8 @@ def describe_event_source_mapping(UUID=None, EventSourceArn=None,
         desc = conn.get_event_source_mapping(UUID=UUID)
         if desc:
             keys = ('UUID', 'BatchSize', 'EventSourceArn',
-                    'FunctionArn','LastModified','LastProcessingResult',
-                    'State','StateTransitionReason')
+                    'FunctionArn', 'LastModified', 'LastProcessingResult',
+                    'State', 'StateTransitionReason')
             return {'event_source_mapping': dict([(k, desc.get(k)) for k in keys])}
         else:
             return {'event_source_mapping': None}
@@ -745,7 +743,7 @@ def describe_event_source_mapping(UUID=None, EventSourceArn=None,
         return {'error': salt.utils.boto3.get_error(e)}
 
 
-def update_event_source_mapping(UUID, 
+def update_event_source_mapping(UUID,
             FunctionName=None, Enabled=None, BatchSize=None,
             region=None, key=None, keyid=None, profile=None):
     '''
@@ -764,12 +762,12 @@ def update_event_source_mapping(UUID,
 
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-        args= {}
-        if not FunctionName is None:
+        args = {}
+        if FunctionName is not None:
             args['FunctionName'] = FunctionName
-        if not Enabled is None:
+        if Enabled is not None:
             args['Enabled'] = Enabled
-        if not BatchSize is None:
+        if BatchSize is not None:
             args['BatchSize'] = BatchSize
         r = conn.update_event_source_mapping(UUID=UUID, **args)
         if r:

--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -2,7 +2,7 @@
 '''
 Connection module for Amazon Lambda
 
-.. versionadded::
+.. versionadded:: Boron
 
 :configuration: This module accepts explicit Lambda credentials but can also
     utilize IAM roles assigned to the instance trough Instance Profiles.

--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -84,6 +84,7 @@ from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=i
 # Import Salt libs
 import salt.utils.boto3
 import salt.utils.compat
+import salt.utils
 from salt.exceptions import SaltInvocationError, CommandExecutionError
 # from salt.utils import exactly_one
 # TODO: Uncomment this and s/_exactly_one/exactly_one/
@@ -183,7 +184,7 @@ def _get_role_arn(name, region=None, key=None, keyid=None, profile=None):
 
 
 def _filedata(infile):
-    with open(infile, 'rb') as f:
+    with salt.utils.fopen(infile, 'rb') as f:
        return f.read()
 
 def create_function(FunctionName, Runtime, Role, Handler, ZipFile=None,

--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -82,7 +82,7 @@ import socket
 from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
 
 # Import Salt libs
-import salt.utils.boto
+import salt.utils.boto3
 import salt.utils.compat
 from salt.exceptions import SaltInvocationError, CommandExecutionError
 # from salt.utils import exactly_one
@@ -148,7 +148,7 @@ def _multi_call(function, *args, **kwargs):
     while marker:
         more = function(*args, Marker=marker, **kwargs)
         ret[content].extend(more[content])
-        marker = getattr(funcs, 'NextMarker', None)
+        marker = getattr(ret, 'NextMarker', None)
     return ret
 
 def _find_function(name,
@@ -188,7 +188,7 @@ def function_exists(FunctionName, region=None, key=None,
                              region=region, key=key, keyid=keyid, profile=profile)
         return {'exists': bool(func)}
     except ClientError as e:
-        return {'error': salt.utils.boto.get_error(e)}
+        return {'error': salt.utils.boto3.get_error(e)}
 
 
 def _get_role_arn(name, region=None, key=None, keyid=None, profile=None):
@@ -251,7 +251,7 @@ def create_function(FunctionName, Runtime, Role, Handler, ZipFile=None,
             log.warning('Function was not created')
             return {'created': False}
     except ClientError as e:
-        return {'created': False, 'error': salt.utils.boto.get_error(e)}
+        return {'created': False, 'error': salt.utils.boto3.get_error(e)}
 
 
 def delete_function(FunctionName, Qualifier=None, region=None, key=None, keyid=None, profile=None):
@@ -277,7 +277,7 @@ def delete_function(FunctionName, Qualifier=None, region=None, key=None, keyid=N
            conn.delete_function(FunctionName=FunctionName)
         return {'deleted': True}
     except ClientError as e:
-        return {'deleted': False, 'error': salt.utils.boto.get_error(e)}
+        return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}
 
 
 def describe_function(FunctionName, region=None, key=None,
@@ -306,7 +306,7 @@ def describe_function(FunctionName, region=None, key=None,
         else:
             return {'function': None}
     except ClientError as e:
-        return {'error': salt.utils.boto.get_error(e)}
+        return {'error': salt.utils.boto3.get_error(e)}
 
 
 def update_function_config(FunctionName, Role, Handler, Description="", Timeout=3, MemorySize=128,
@@ -341,7 +341,7 @@ def update_function_config(FunctionName, Role, Handler, Description="", Timeout=
             log.warning('Function was not updated')
             return {'updated': False}
     except ClientError as e:
-        return {'updated': False, 'error': salt.utils.boto.get_error(e)}
+        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
 
 
 def update_function_code(FunctionName, ZipFile=None, S3Bucket=None, S3Key=None,
@@ -388,7 +388,7 @@ def update_function_code(FunctionName, ZipFile=None, S3Bucket=None, S3Key=None,
             log.warning('Function was not updated')
             return {'updated': False}
     except ClientError as e:
-        return {'created': False, 'error': salt.utils.boto.get_error(e)}
+        return {'created': False, 'error': salt.utils.boto3.get_error(e)}
 
 
 def list_function_versions(FunctionName, 
@@ -418,7 +418,7 @@ def list_function_versions(FunctionName,
             log.warning('No versions found')
             return { 'Versions': [] }
     except ClientError as e:
-        return {'error': salt.utils.boto.get_error(e)}
+        return {'error': salt.utils.boto3.get_error(e)}
 
 
 def create_alias(FunctionName, Name, FunctionVersion, Description="",
@@ -448,7 +448,7 @@ def create_alias(FunctionName, Name, FunctionVersion, Description="",
             log.warning('Alias was not created')
             return {'created': False}
     except ClientError as e:
-        return {'created': False, 'error': salt.utils.boto.get_error(e)}
+        return {'created': False, 'error': salt.utils.boto3.get_error(e)}
 
 
 def delete_alias(FunctionName, Name, region=None, key=None, keyid=None, profile=None):
@@ -471,7 +471,7 @@ def delete_alias(FunctionName, Name, region=None, key=None, keyid=None, profile=
         conn.delete_alias(FunctionName=FunctionName, Name=Name)
         return {'deleted': True}
     except ClientError as e:
-        return {'deleted': False, 'error': salt.utils.boto.get_error(e)}
+        return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}
 
 
 def _find_alias(FunctionName, Name, FunctionVersion=None,
@@ -515,7 +515,7 @@ def alias_exists(FunctionName, Name, region=None, key=None,
                              region=region, key=key, keyid=keyid, profile=profile)
         return {'exists': bool(alias)}
     except ClientError as e:
-        return {'error': salt.utils.boto.get_error(e)}
+        return {'error': salt.utils.boto3.get_error(e)}
 
 
 def describe_alias(FunctionName, Name, region=None, key=None,
@@ -542,7 +542,7 @@ def describe_alias(FunctionName, Name, region=None, key=None,
         else:
             return {'alias': None}
     except ClientError as e:
-        return {'error': salt.utils.boto.get_error(e)}
+        return {'error': salt.utils.boto3.get_error(e)}
 
 
 def update_alias(FunctionName, Name, FunctionVersion=None, Description=None,
@@ -576,7 +576,7 @@ def update_alias(FunctionName, Name, FunctionVersion=None, Description=None,
             log.warning('Alias was not updated')
             return {'updated': False}
     except ClientError as e:
-        return {'created': False, 'error': salt.utils.boto.get_error(e)}
+        return {'created': False, 'error': salt.utils.boto3.get_error(e)}
 
 
 def create_event_source_mapping(EventSourceArn, FunctionName, StartingPosition,
@@ -612,7 +612,7 @@ def create_event_source_mapping(EventSourceArn, FunctionName, StartingPosition,
             log.warning('Event source mapping was not created')
             return {'created': False}
     except ClientError as e:
-        return {'created': False, 'error': salt.utils.boto.get_error(e)}
+        return {'created': False, 'error': salt.utils.boto3.get_error(e)}
 
 
 def get_event_source_mapping_ids(EventSourceArn, FunctionName, 
@@ -635,7 +635,7 @@ def get_event_source_mapping_ids(EventSourceArn, FunctionName,
                                                FunctionName=FunctionName)['EventSourceMappings']
         return [mapping['UUID'] for mapping in maps]
     except ClientError as e:
-        return {'error': salt.utils.boto.get_error(e)}
+        return {'error': salt.utils.boto3.get_error(e)}
 
 
 def _get_ids(UUID=None, EventSourceArn=None, FunctionName=None,
@@ -678,7 +678,7 @@ def delete_event_source_mapping(UUID=None, EventSourceArn=None, FunctionName=Non
             conn.delete_event_source_mapping(UUID=id)
         return {'deleted': True}
     except ClientError as e:
-        return {'deleted': False, 'error': salt.utils.boto.get_error(e)}
+        return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}
 
 
 def event_source_mapping_exists(UUID=None, EventSourceArn=None,
@@ -741,7 +741,7 @@ def describe_event_source_mapping(UUID=None, EventSourceArn=None,
         else:
             return {'event_source_mapping': None}
     except ClientError as e:
-        return {'error': salt.utils.boto.get_error(e)}
+        return {'error': salt.utils.boto3.get_error(e)}
 
 
 def update_event_source_mapping(UUID, 
@@ -780,4 +780,4 @@ def update_event_source_mapping(UUID,
             log.warning('Mapping was not updated')
             return {'updated': False}
     except ClientError as e:
-        return {'created': False, 'error': salt.utils.boto.get_error(e)}
+        return {'created': False, 'error': salt.utils.boto3.get_error(e)}

--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -533,7 +533,7 @@ def describe_alias(FunctionName, Name, region=None, key=None,
         alias = _find_alias(FunctionName, Name,
                              region=region, key=key, keyid=keyid, profile=profile)
         if alias:
-            keys = ('Name', 'FunctionVersion', 'Description')
+            keys = ('AliasArn', 'Name', 'FunctionVersion', 'Description')
             return {'alias': dict([(k, alias.get(k)) for k in keys])}
         else:
             return {'alias': None}
@@ -629,8 +629,8 @@ def get_event_source_mapping_ids(EventSourceArn, FunctionName,
         mappings = []
         for maps in salt.utils.boto3.paged_call(conn.list_event_source_mappings, 
                                                EventSourceArn=EventSourceArn,
-                                               FunctionName=FunctionName)['EventSourceMappings']:
-            mappings.extend([mapping['UUID'] for mapping in maps])
+                                               FunctionName=FunctionName):
+            mappings.extend([mapping['UUID'] for mapping in maps['EventSourceMappings']])
         return mappings
     except ClientError as e:
         return {'error': salt.utils.boto3.get_error(e)}
@@ -702,6 +702,8 @@ def event_source_mapping_exists(UUID=None, EventSourceArn=None,
                                          FunctionName=FunctionName,
                                          region=region, key=key,
                                          keyid=keyid, profile=profile)
+    if 'error' in desc:
+        return desc
     return {'exists': bool(desc.get('event_source_mapping'))}
 
 

--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -37,8 +37,8 @@ config:
 
 .. code-block:: yaml
 
-    Ensure Lambda function exists:
-        boto_lmabda.present:
+    Ensure function exists:
+        boto_lambda.function_present:
             - name: myfunction
             - runtime: python2.7
             - role: iam_role_name
@@ -73,25 +73,25 @@ def __virtual__():
     '''
     Only load if boto is available.
     '''
-    return 'boto_lambda' if 'boto_lambda.exists' in __salt__ else False
+    return 'boto_lambda' if 'boto_lambda.function_exists' in __salt__ else False
 
 
-def present(name, runtime, role, handler, zipfile=None, s3bucket=None,
+def function_present(name, runtime, role, handler, zipfile=None, s3bucket=None,
             s3key=None, s3objectversion=None, 
             description='', timeout=3, memorysize=128,
             region=None, key=None, keyid=None, profile=None):
     '''
-    Ensure Lambda Function exists.
+    Ensure function exists.
 
     name
-        Name of the Lambda Function.
+        Name of the Function.
 
     role
-        The name or ARN of the IAM role that Lambda assumes when it executes your
+        The name or ARN of the IAM role that the function assumes when it executes your
         function to access any other AWS resources.
 
     runtime
-        The runtime environment for the Lambda function. One of 
+        The runtime environment for the function. One of 
         'nodejs', 'java8', or 'python2.7'
 
     handler
@@ -122,12 +122,12 @@ def present(name, runtime, role, handler, zipfile=None, s3bucket=None,
         description as you see fit.
 
     timeout
-        The function execution time at which Lamda should terminate this function. Because the execution 
+        The function execution time at which Lambda should terminate this function. Because the execution 
         time has cost implications, we recommend you set this value based on your expected execution time.
         The default is 3 seconds.
 
     memorysize
-        The amount of memory, in MB, your Lambda function is given. Lamda uses this memory size to infer 
+        The amount of memory, in MB, your function is given. Lambda uses this memory size to infer 
         the amount of CPU and memory allocated to your function. Your function use-case determines your
         CPU and memory requirements. For example, a database operation might need less memory compared
         to an image processing function. The default value is 128 MB. The value must be a multiple of
@@ -152,42 +152,47 @@ def present(name, runtime, role, handler, zipfile=None, s3bucket=None,
            'changes': {}
            }
 
-    r = __salt__['boto_lambda.exists'](name=name, region=region,
+    r = __salt__['boto_lambda.function_exists'](name=name, region=region,
                                     key=key, keyid=keyid, profile=profile)
 
     if 'error' in r:
         ret['result'] = False
-        ret['comment'] = 'Failed to create Lambda function: {0}.'.format(r['error']['message'])
+        ret['comment'] = 'Failed to create function: {0}.'.format(r['error']['message'])
         return ret
 
     if not r.get('exists'):
         if __opts__['test']:
-            ret['comment'] = 'Lambda function {0} is set to be created.'.format(name)
+            ret['comment'] = 'Function {0} is set to be created.'.format(name)
             ret['result'] = None
             return ret
-        r = __salt__['boto_lambda.create'](name, runtime, role, handler, 
-            zipfile, s3bucket, s3key, s3objectversion,
-            description, timeout, memorysize, 
-            region, key, keyid, profile)
+        r = __salt__['boto_lambda.create_function'](name=name, runtime=runtime,
+                                                    role=role, handler=handler, 
+                                                    zipfile=zipfile, s3bucket=s3bucket, 
+                                                    s3key=s3key,
+                                                    s3objectversion=s3objectversion,
+                                                    description=description, 
+                                                    timeout=timeout, memorysize=memorysize, 
+                                                    region=region, key=key,
+                                                    keyid=keyid, profile=profile)
         if not r.get('created'):
             ret['result'] = False
-            ret['comment'] = 'Failed to create Lamda function: {0}.'.format(r['error']['message'])
+            ret['comment'] = 'Failed to create function: {0}.'.format(r['error']['message'])
             return ret
-        _describe = __salt__['boto_lambda.describe'](name, region=region, key=key,
+        _describe = __salt__['boto_lambda.describe_function'](name, region=region, key=key,
                                                   keyid=keyid, profile=profile)
-        ret['changes']['old'] = {'lambda': None}
+        ret['changes']['old'] = {'function': None}
         ret['changes']['new'] = _describe
-        ret['comment'] = 'Lambda function {0} created.'.format(name)
+        ret['comment'] = 'Function {0} created.'.format(name)
         return ret
 
-    ret['comment'] = os.linesep.join([ret['comment'], 'Lambda function {0} is present.'.format(name)])
+    ret['comment'] = os.linesep.join([ret['comment'], 'Function {0} is present.'.format(name)])
     ret['changes'] = {}
-    # Lambda function exists, ensure config matches
-    _ret = _lambda_config_present(name, role, handler, description, timeout,
+    # function exists, ensure config matches
+    _ret = _function_config_present(name, role, handler, description, timeout,
                                   memorysize, region, key, keyid, profile)
     ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
-    _ret = _lambda_code_present(name, zipfile, s3bucket, s3key, s3objectversion,
+    _ret = _function_code_present(name, zipfile, s3bucket, s3key, s3objectversion,
                                  region, key, keyid, profile)
     ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
@@ -204,11 +209,11 @@ def _get_role_arn(name, region=None, key=None, keyid=None, profile=None):
     return 'arn:aws:iam::{0}:role/{1}'.format(account_id, name)
 
 
-def _lambda_config_present(name, role, handler, description, timeout,
+def _function_config_present(name, role, handler, description, timeout,
                            memorysize, region, key, keyid, profile):
     ret = {'result': True, 'comment': '', 'changes': {}}
-    lmbda = __salt__['boto_lambda.describe'](name, 
-           region=region, key=key, keyid=keyid, profile=profile)['lambda']
+    func = __salt__['boto_lambda.describe_function'](name, 
+           region=region, key=key, keyid=keyid, profile=profile)['function']
     role_arn = _get_role_arn(role, region, key, keyid, profile)
     need_update = False
     for val, var in {
@@ -218,32 +223,37 @@ def _lambda_config_present(name, role, handler, description, timeout,
         'Timeout': 'timeout',
         'MemorySize': 'memorysize',
     }.iteritems():
-        if lmbda[val] != locals()[var]:
+        if func[val] != locals()[var]:
             need_update = True
             ret['changes'].setdefault('new',{})[var] = locals()[var]
-            ret['changes'].setdefault('old',{})[var] = lmbda[val]
+            ret['changes'].setdefault('old',{})[var] = func[val]
     if need_update:
-        ret['comment'] = os.linesep.join([ret['comment'], 'Lambda function config to be modified'])
-        _r = __salt__['boto_lambda.update_config'](name, role, handler, description,
+        ret['comment'] = os.linesep.join([ret['comment'], 'Function config to be modified'])
+        if __opts__['test']:
+            msg = 'Function {0} set to be modified.'.format(name)
+            ret['comment'] = msg
+            ret['result'] = None
+            return ret
+        _r = __salt__['boto_lambda.update_function_config'](name, role, handler, description,
                                         timeout, memorysize, region=region, key=key,
                                         keyid=keyid, profile=profile)
     return ret
 
 
-def _lambda_code_present(name, zipfile, s3bucket, s3key, s3objectversion,
+def _function_code_present(name, zipfile, s3bucket, s3key, s3objectversion,
                          region, key, keyid, profile):
     ret = {'result': True, 'comment': '', 'changes': {}}
-    lmbda = __salt__['boto_lambda.describe'](name, 
-           region=region, key=key, keyid=keyid, profile=profile)['lambda']
+    func = __salt__['boto_lambda.describe_function'](name, 
+           region=region, key=key, keyid=keyid, profile=profile)['function']
     update = False
     if zipfile:
         size = os.path.getsize(zipfile)
-        if size == lmbda['CodeSize']:
+        if size == func['CodeSize']:
             sha = hashlib.sha256()
             with open(zipfile, 'rb') as f:
                 sha.update(f.read())
             hashed = sha.digest().encode('base64').strip()
-            if hashed != lmbda['CodeSha256']:
+            if hashed != func['CodeSha256']:
                 update = True
         else:
             update=True
@@ -253,19 +263,24 @@ def _lambda_code_present(name, zipfile, s3bucket, s3key, s3objectversion,
        # idempotent
        update = True
     if update:
+        if __opts__['test']:
+            msg = 'Function {0} set to be modified.'.format(name)
+            ret['comment'] = msg
+            ret['result'] = None
+            return ret
         ret['changes']['old'] = {
-            'CodeSha256': lmbda['CodeSha256'],
-            'CodeSize': lmbda['CodeSize'],
+            'CodeSha256': func['CodeSha256'],
+            'CodeSize': func['CodeSize'],
         }
-        lmbda = __salt__['boto_lambda.update_code'](name, zipfile, s3bucket,
+        func = __salt__['boto_lambda.update_function_code'](name, zipfile, s3bucket,
             s3key, s3objectversion, 
-            region=region, key=key, keyid=keyid, profile=profile)['lambda']
-        if lmbda['CodeSha256'] != ret['changes']['old']['CodeSha256'] or \
-                lmbda['CodeSize'] != ret['changes']['old']['CodeSize']:
-            ret['comment'] = os.linesep.join([ret['comment'], 'Lambda function code to be modified'])
+            region=region, key=key, keyid=keyid, profile=profile)['function']
+        if func['CodeSha256'] != ret['changes']['old']['CodeSha256'] or \
+                func['CodeSize'] != ret['changes']['old']['CodeSize']:
+            ret['comment'] = os.linesep.join([ret['comment'], 'Function code to be modified'])
             ret['changes']['new'] = {
-                'CodeSha256': lmbda['CodeSha256'],
-                'CodeSize': lmbda['CodeSize'],
+                'CodeSha256': func['CodeSha256'],
+                'CodeSize': func['CodeSize'],
             }
         else:
 			del(ret['changes']['old'])
@@ -273,12 +288,12 @@ def _lambda_code_present(name, zipfile, s3bucket, s3key, s3objectversion,
 
 
 
-def absent(name, region=None, key=None, keyid=None, profile=None):
+def function_absent(name, region=None, key=None, keyid=None, profile=None):
     '''
-    Ensure Lamda function with passed properties is absent.
+    Ensure function with passed properties is absent.
 
     name
-        Name of the Lambda function.
+        Name of the function.
 
     region
         Region to connect to.
@@ -300,29 +315,184 @@ def absent(name, region=None, key=None, keyid=None, profile=None):
            'changes': {}
            }
 
-    r = __salt__['boto_lambda.exists'](name, region=region,
+    r = __salt__['boto_lambda.function_exists'](name, region=region,
                                     key=key, keyid=keyid, profile=profile)
     if 'error' in r:
         ret['result'] = False
-        ret['comment'] = 'Failed to delete Lambda function: {0}.'.format(r['error']['message'])
+        ret['comment'] = 'Failed to delete function: {0}.'.format(r['error']['message'])
         return ret
 
     if not r:
-        ret['comment'] = 'Lambda function {0} does not exist.'.format(name)
+        ret['comment'] = 'Function {0} does not exist.'.format(name)
         return ret
 
     if __opts__['test']:
-        ret['comment'] = 'Lambda function {0} is set to be removed.'.format(name)
+        ret['comment'] = 'Function {0} is set to be removed.'.format(name)
         ret['result'] = None
         return ret
-    r = __salt__['boto_lambda.delete'](name,
+    r = __salt__['boto_lambda.delete_function'](name,
                                     region=region, key=key,
                                     keyid=keyid, profile=profile)
     if not r['deleted']:
         ret['result'] = False
-        ret['comment'] = 'Failed to delete Lambda function: {0}.'.format(r['error']['message'])
+        ret['comment'] = 'Failed to delete function: {0}.'.format(r['error']['message'])
         return ret
-    ret['changes']['old'] = {'lambda': name}
-    ret['changes']['new'] = {'lambda': None}
-    ret['comment'] = 'Lambda function {0} deleted.'.format(name)
+    ret['changes']['old'] = {'function': name}
+    ret['changes']['new'] = {'function': None}
+    ret['comment'] = 'Function {0} deleted.'.format(name)
     return ret
+
+
+def alias_present(functionname, name, functionversion, description='', 
+            region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure alias exists.
+
+    functionname
+        Name of the function for which you want to create an alias.
+
+    name
+        The name of the alias to be created.
+
+    functionversion
+        Function version for which you are creating the alias.
+
+    description
+        A short, user-defined function description. Lambda does not use this value. Assign a meaningful
+        description as you see fit.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+    '''
+    ret = {'name': name,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    r = __salt__['boto_lambda.alias_exists'](functionname=functionname, name=name, region=region,
+                                    key=key, keyid=keyid, profile=profile)
+
+    if 'error' in r:
+        ret['result'] = False
+        ret['comment'] = 'Failed to create alias: {0}.'.format(r['error']['message'])
+        return ret
+
+    if not r.get('exists'):
+        if __opts__['test']:
+            ret['comment'] = 'Alias {0} is set to be created.'.format(name)
+            ret['result'] = None
+            return ret
+        r = __salt__['boto_lambda.create_alias'](functionname, name,
+                functionversion, description,
+                region, key, keyid, profile)
+        if not r.get('created'):
+            ret['result'] = False
+            ret['comment'] = 'Failed to create alias: {0}.'.format(r['error']['message'])
+            return ret
+        _describe = __salt__['boto_lambda.describe_alias'](functionname, name, region=region, key=key,
+                                                  keyid=keyid, profile=profile)
+        ret['changes']['old'] = {'alias': None}
+        ret['changes']['new'] = _describe
+        ret['comment'] = 'Alias {0} created.'.format(name)
+        return ret
+
+    ret['comment'] = os.linesep.join([ret['comment'], 'Alias {0} is present.'.format(name)])
+    ret['changes'] = {}
+    _describe = __salt__['boto_lambda.describe_alias'](functionname, name, 
+                                                  region=region, key=key, keyid=keyid,
+                                                  profile=profile)['alias']
+
+    need_update = False
+    for val, var in {
+        'FunctionVersion': 'functionversion',
+        'Description': 'description',
+    }.iteritems():
+        if _describe[val] != locals()[var]:
+            need_update = True
+            ret['changes'].setdefault('new',{})[var] = locals()[var]
+            ret['changes'].setdefault('old',{})[var] = func[val]
+    if need_update:
+        ret['comment'] = os.linesep.join([ret['comment'], 'Alias config to be modified'])
+        if __opts__['test']:
+            msg = 'Alias {0} set to be modified.'.format(name)
+            ret['comment'] = msg
+            ret['result'] = None
+            return ret
+        _r = __salt__['boto_lambda.update_alias'](functionname=functionname, name=name,
+                                        functionversion=functionversion, description=description, 
+                                        region=region, key=key,
+                                        keyid=keyid, profile=profile)
+        ret['changes'] = dictupdate.update(ret['changes'], _r['changes'])
+        ret['comment'] = ' '.join([ret['comment'], _r['comment']])
+    return ret
+
+
+def alias_absent(functionname, name, region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure alias with passed properties is absent.
+
+    functionname
+        Name of the function.
+
+    name
+        Name of the alias.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+    '''
+
+    ret = {'name': name,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    r = __salt__['boto_lambda.alias_exists'](functionname, name, region=region,
+                                    key=key, keyid=keyid, profile=profile)
+    if 'error' in r:
+        ret['result'] = False
+        ret['comment'] = 'Failed to delete alias: {0}.'.format(r['error']['message'])
+        return ret
+
+    if not r:
+        ret['comment'] = 'Alias {0} does not exist.'.format(name)
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'Alias {0} is set to be removed.'.format(name)
+        ret['result'] = None
+        return ret
+    r = __salt__['boto_lambda.delete_alias'](functionname, name,
+                                    region=region, key=key,
+                                    keyid=keyid, profile=profile)
+    if not r['deleted']:
+        ret['result'] = False
+        ret['comment'] = 'Failed to delete alias: {0}.'.format(r['error']['message'])
+        return ret
+    ret['changes']['old'] = {'function': name}
+    ret['changes']['new'] = {'function': None}
+    ret['comment'] = 'Function {0} deleted.'.format(name)
+    return ret
+
+

--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -41,13 +41,12 @@ config:
         boto_lmabda.present:
             - name: myfunction
             - runtime: python2.7
-            - role_name: iam_role_name
+            - role: iam_role_name
             - handler: entry_function
-            - code:
-              zipfile: code.zip
-              s3bucket: bucketname
-              s3key: keyname
-              s3objectversion: version
+            - zipfile: code.zip
+            - s3bucket: bucketname
+            - s3key: keyname
+            - s3objectversion: version
             - description: "My Lambda Function"
             - timeout: 3
             - memorysize: 128

--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -65,6 +65,7 @@ import hashlib
 
 # Import Salt Libs
 import salt.utils.dictupdate as dictupdate
+import salt.utils
 
 log = logging.getLogger(__name__)
 
@@ -269,7 +270,7 @@ def _function_code_present(FunctionName, ZipFile, S3Bucket, S3Key, S3ObjectVersi
         size = os.path.getsize(ZipFile)
         if size == func['CodeSize']:
             sha = hashlib.sha256()
-            with open(ZipFile, 'rb') as f:
+            with salt.utils.fopen(ZipFile, 'rb') as f:
                 sha.update(f.read())
             hashed = sha.digest().encode('base64').strip()
             if hashed != func['CodeSha256']:

--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -3,7 +3,7 @@
 Manage Lambda Functions
 =================
 
-.. versionadded:: 
+.. versionadded::
 
 Create and destroy Lambda Functions. Be aware that this interacts with Amazon's services,
 and so may incur charges.
@@ -78,7 +78,7 @@ def __virtual__():
 
 
 def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S3Bucket=None,
-            S3Key=None, S3ObjectVersion=None, 
+            S3Key=None, S3ObjectVersion=None,
             Description='', Timeout=3, MemorySize=128,
             region=None, key=None, keyid=None, profile=None):
     '''
@@ -91,7 +91,7 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S
         Name of the Function.
 
     Runtime
-        The Runtime environment for the function. One of 
+        The Runtime environment for the function. One of
         'nodejs', 'java8', or 'python2.7'
 
     Role
@@ -126,12 +126,12 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S
         description as you see fit.
 
     Timeout
-        The function execution time at which Lambda should terminate this function. Because the execution 
+        The function execution time at which Lambda should terminate this function. Because the execution
         time has cost implications, we recommend you set this value based on your expected execution time.
         The default is 3 seconds.
 
     MemorySize
-        The amount of memory, in MB, your function is given. Lambda uses this memory size to infer 
+        The amount of memory, in MB, your function is given. Lambda uses this memory size to infer
         the amount of CPU and memory allocated to your function. Your function use-case determines your
         CPU and memory requirements. For example, a database operation might need less memory compared
         to an image processing function. The default value is 128 MB. The value must be a multiple of
@@ -170,12 +170,12 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S
             ret['result'] = None
             return ret
         r = __salt__['boto_lambda.create_function'](FunctionName=FunctionName, Runtime=Runtime,
-                                                    Role=Role, Handler=Handler, 
-                                                    ZipFile=ZipFile, S3Bucket=S3Bucket, 
+                                                    Role=Role, Handler=Handler,
+                                                    ZipFile=ZipFile, S3Bucket=S3Bucket,
                                                     S3Key=S3Key,
                                                     S3ObjectVersion=S3ObjectVersion,
-                                                    Description=Description, 
-                                                    Timeout=Timeout, MemorySize=MemorySize, 
+                                                    Description=Description,
+                                                    Timeout=Timeout, MemorySize=MemorySize,
                                                     region=region, key=key,
                                                     keyid=keyid, profile=profile)
         if not r.get('created'):
@@ -226,7 +226,7 @@ def _get_role_arn(name, region=None, key=None, keyid=None, profile=None):
 def _function_config_present(FunctionName, Role, Handler, Description, Timeout,
                            MemorySize, region, key, keyid, profile):
     ret = {'result': True, 'comment': '', 'changes': {}}
-    func = __salt__['boto_lambda.describe_function'](FunctionName, 
+    func = __salt__['boto_lambda.describe_function'](FunctionName,
            region=region, key=key, keyid=keyid, profile=profile)['function']
     role_arn = _get_role_arn(Role, region, key, keyid, profile)
     need_update = False
@@ -239,8 +239,8 @@ def _function_config_present(FunctionName, Role, Handler, Description, Timeout,
     }.iteritems():
         if func[val] != locals()[var]:
             need_update = True
-            ret['changes'].setdefault('new',{})[var] = locals()[var]
-            ret['changes'].setdefault('old',{})[var] = func[val]
+            ret['changes'].setdefault('new', {})[var] = locals()[var]
+            ret['changes'].setdefault('old', {})[var] = func[val]
     if need_update:
         ret['comment'] = os.linesep.join([ret['comment'], 'Function config to be modified'])
         if __opts__['test']:
@@ -250,7 +250,7 @@ def _function_config_present(FunctionName, Role, Handler, Description, Timeout,
             return ret
         _r = __salt__['boto_lambda.update_function_config'](FunctionName=FunctionName,
                                         Role=Role, Handler=Handler, Description=Description,
-                                        Timeout=Timeout, MemorySize=MemorySize, 
+                                        Timeout=Timeout, MemorySize=MemorySize,
                                         region=region, key=key,
                                         keyid=keyid, profile=profile)
         if not _r.get('updated'):
@@ -263,7 +263,7 @@ def _function_config_present(FunctionName, Role, Handler, Description, Timeout,
 def _function_code_present(FunctionName, ZipFile, S3Bucket, S3Key, S3ObjectVersion,
                          region, key, keyid, profile):
     ret = {'result': True, 'comment': '', 'changes': {}}
-    func = __salt__['boto_lambda.describe_function'](FunctionName, 
+    func = __salt__['boto_lambda.describe_function'](FunctionName,
            region=region, key=key, keyid=keyid, profile=profile)['function']
     update = False
     if ZipFile:
@@ -276,12 +276,12 @@ def _function_code_present(FunctionName, ZipFile, S3Bucket, S3Key, S3ObjectVersi
             if hashed != func['CodeSha256']:
                 update = True
         else:
-            update=True
+            update = True
     else:
-       # No way to judge whether the item in the s3 bucket is current without
-       # downloading it. Cheaper to just request an update every time, and still
-       # idempotent
-       update = True
+        # No way to judge whether the item in the s3 bucket is current without
+        # downloading it. Cheaper to just request an update every time, and still
+        # idempotent
+        update = True
     if update:
         if __opts__['test']:
             msg = 'Function {0} set to be modified.'.format(FunctionName)
@@ -293,7 +293,7 @@ def _function_code_present(FunctionName, ZipFile, S3Bucket, S3Key, S3ObjectVersi
             'CodeSize': func['CodeSize'],
         }
         func = __salt__['boto_lambda.update_function_code'](FunctionName, ZipFile, S3Bucket,
-            S3Key, S3ObjectVersion, 
+            S3Key, S3ObjectVersion,
             region=region, key=key, keyid=keyid, profile=profile)
         if not func.get('updated'):
             ret['result'] = False
@@ -309,9 +309,8 @@ def _function_code_present(FunctionName, ZipFile, S3Bucket, S3Key, S3ObjectVersi
                 'CodeSize': func['CodeSize'],
             }
         else:
-			del(ret['changes']['old'])
+            del ret['changes']['old']
     return ret
-
 
 
 def function_absent(name, FunctionName, region=None, key=None, keyid=None, profile=None):
@@ -372,7 +371,7 @@ def function_absent(name, FunctionName, region=None, key=None, keyid=None, profi
     return ret
 
 
-def alias_present(name, FunctionName, Name, FunctionVersion, Description='', 
+def alias_present(name, FunctionName, Name, FunctionVersion, Description='',
             region=None, key=None, keyid=None, profile=None):
     '''
     Ensure alias exists.
@@ -441,7 +440,7 @@ def alias_present(name, FunctionName, Name, FunctionVersion, Description='',
 
     ret['comment'] = os.linesep.join([ret['comment'], 'Alias {0} is present.'.format(Name)])
     ret['changes'] = {}
-    _describe = __salt__['boto_lambda.describe_alias'](FunctionName, Name, 
+    _describe = __salt__['boto_lambda.describe_alias'](FunctionName, Name,
                                                   region=region, key=key, keyid=keyid,
                                                   profile=profile)['alias']
 
@@ -452,8 +451,8 @@ def alias_present(name, FunctionName, Name, FunctionVersion, Description='',
     }.iteritems():
         if _describe[val] != locals()[var]:
             need_update = True
-            ret['changes'].setdefault('new',{})[var] = locals()[var]
-            ret['changes'].setdefault('old',{})[var] = _describe[val]
+            ret['changes'].setdefault('new', {})[var] = locals()[var]
+            ret['changes'].setdefault('old', {})[var] = _describe[val]
     if need_update:
         ret['comment'] = os.linesep.join([ret['comment'], 'Alias config to be modified'])
         if __opts__['test']:
@@ -462,7 +461,7 @@ def alias_present(name, FunctionName, Name, FunctionVersion, Description='',
             ret['result'] = None
             return ret
         _r = __salt__['boto_lambda.update_alias'](FunctionName=FunctionName, Name=Name,
-                                        FunctionVersion=FunctionVersion, Description=Description, 
+                                        FunctionVersion=FunctionVersion, Description=Description,
                                         region=region, key=key,
                                         keyid=keyid, profile=profile)
         if not _r.get('updated'):
@@ -533,7 +532,6 @@ def alias_absent(name, FunctionName, Name, region=None, key=None, keyid=None, pr
     return ret
 
 
-
 def _get_function_arn(name, region=None, key=None, keyid=None, profile=None):
     if name.startswith('arn:aws:lambda:'):
         return name
@@ -545,7 +543,7 @@ def _get_function_arn(name, region=None, key=None, keyid=None, profile=None):
 
 
 def event_source_mapping_present(name, EventSourceArn, FunctionName, StartingPosition,
-            Enabled=True, BatchSize=100, 
+            Enabled=True, BatchSize=100,
             region=None, key=None, keyid=None, profile=None):
     '''
     Ensure event source mapping exists.
@@ -602,7 +600,7 @@ def event_source_mapping_present(name, EventSourceArn, FunctionName, StartingPos
            'changes': {}
            }
 
-    r = __salt__['boto_lambda.event_source_mapping_exists'](EventSourceArn=EventSourceArn, 
+    r = __salt__['boto_lambda.event_source_mapping_exists'](EventSourceArn=EventSourceArn,
                                     FunctionName=FunctionName,
                                     region=region, key=key, keyid=keyid, profile=profile)
 
@@ -648,15 +646,15 @@ def event_source_mapping_present(name, EventSourceArn, FunctionName, StartingPos
     }.iteritems():
         if _describe[val] != locals()[var]:
             need_update = True
-            ret['changes'].setdefault('new',{})[var] = locals()[var]
-            ret['changes'].setdefault('old',{})[var] = _describe[val]
+            ret['changes'].setdefault('new', {})[var] = locals()[var]
+            ret['changes'].setdefault('old', {})[var] = _describe[val]
     # verify FunctionName against FunctionArn
-    function_arn = _get_function_arn(FunctionName, 
+    function_arn = _get_function_arn(FunctionName,
                     region=region, key=key, keyid=keyid, profile=profile)
     if _describe['FunctionArn'] != function_arn:
         need_update = True
-        ret['changes'].setdefault('new',{})['FunctionArn'] = function_arn
-        ret['changes'].setdefault('old',{})['FunctionArn'] = _describe['FunctionArn']
+        ret['changes'].setdefault('new', {})['FunctionArn'] = function_arn
+        ret['changes'].setdefault('old', {})['FunctionArn'] = _describe['FunctionArn']
     # TODO check for 'Enabled', since it doesn't directly map to a specific state
     if need_update:
         ret['comment'] = os.linesep.join([ret['comment'], 'Event source mapping to be modified'])
@@ -712,7 +710,7 @@ def event_source_mapping_absent(name, EventSourceArn, FunctionName,
            'changes': {}
            }
 
-    desc = __salt__['boto_lambda.describe_event_source_mapping'](EventSourceArn=EventSourceArn, 
+    desc = __salt__['boto_lambda.describe_event_source_mapping'](EventSourceArn=EventSourceArn,
                                     FunctionName=FunctionName,
                                     region=region, key=key, keyid=keyid, profile=profile)
     if 'error' in desc:
@@ -741,5 +739,3 @@ def event_source_mapping_absent(name, EventSourceArn, FunctionName,
     ret['changes']['new'] = {'event_source_mapping': None}
     ret['comment'] = 'Event source mapping deleted.'
     return ret
-
-

--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*-
+'''
+Manage Lambda Functions
+=================
+
+.. versionadded:: 
+
+Create and destroy Lambda Functions. Be aware that this interacts with Amazon's services,
+and so may incur charges.
+
+This module uses ``boto3``, which can be installed via package, or pip.
+
+This module accepts explicit vpc credentials but can also utilize
+IAM roles assigned to the instance through Instance Profiles. Dynamic
+credentials are then automatically obtained from AWS API and no further
+configuration is necessary. More information available `here
+<http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html>`_.
+
+If IAM roles are not used you need to specify them either in a pillar file or
+in the minion's config file:
+
+.. code-block:: yaml
+
+    vpc.keyid: GKTADJGHEIQSXMKKRBJ08H
+    vpc.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+It's also possible to specify ``key``, ``keyid`` and ``region`` via a profile,
+either passed in as a dict, or as a string to pull from pillars or minion
+config:
+
+.. code-block:: yaml
+
+    myprofile:
+        keyid: GKTADJGHEIQSXMKKRBJ08H
+        key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+            region: us-east-1
+
+.. code-block:: yaml
+
+    Ensure Lambda function exists:
+        boto_lmabda.present:
+            - name: myfunction
+            - runtime: python2.7
+            - role_name: iam_role_name
+            - handler: entry_function
+            - code:
+              zipfile: code.zip
+              s3bucket: bucketname
+              s3key: keyname
+              s3objectversion: version
+            - description: "My Lambda Function"
+            - timeout: 3
+            - memorysize: 128
+            - publish: false
+            - region: us-east-1
+            - keyid: GKTADJGHEIQSXMKKRBJ08H
+            - key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+import logging
+
+# Import Salt Libs
+import salt.utils.dictupdate as dictupdate
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Only load if boto is available.
+    '''
+    return 'boto_lambda' if 'boto_lambda.exists' in __salt__ else False
+
+
+def present(name, runtime, handler, code, role_name=None, role_id=None, 
+            description=None, timeout=None, memorysize=None, publish=False,
+            region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure Lambda Function exists.
+
+    name
+        Name of the Lambda Function.
+
+    runtime
+        The runtime environment for the Lambda function. One of 
+        'nodejs', 'java8', or 'python2.7'
+
+    handler
+        The function within your code that Lambda calls to begin execution. For Node.js it is the
+        module-name.*export* value in your function. For Java, it can be package.classname::handler or
+        package.class-name.
+
+    code
+        The code for the lambda function.
+        * zipfile - A .zip file containing your deployment package.
+        * s3bucket - Amazon S3 bucket name where the .zip file containing your package is stored.
+        * s3key - The Amazon S3 object (the deployment package) key name you want to upload.
+        * s3objectversion - The Amazon S3 object (the deployment package) version you want to upload.
+
+    role_name
+        The name of the IAM role that Lambda assumes when it executes your
+        function to access any other AWS resources. One of role_name or role_id must be specified.
+
+    role_id
+        The Amazon Resource Name (ARN) of the IAM role that Lambda assumes when it executes your
+        function to access any other AWS resources. One of role_name or role_id must be specified.
+
+    description
+        A short, user-defined function description. Lambda does not use this value. Assign a meaningful
+        description as you see fit.
+
+    timeout
+        The function execution time at which Lamda should terminate this function. Because the execution 
+        time has cost implications, we recommend you set this value based on your expected execution time.
+        The default is 3 seconds.
+
+    memorysize
+        The amount of memory, in MB, your Lambda function is given. Lamda uses this memory size to infer 
+        the amount of CPU and memory allocated to your function. Your function use-case determines your
+        CPU and memory requirements. For example, a database operation might need less memory compared
+        to an image processing function. The default value is 128 MB. The value must be a multiple of
+        64 MB.
+
+    publish
+        This boolean parameter can be used to request AWS Lambda to create the Lambda function and publish
+        a version as an atomic operation.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+    '''
+    ret = {'name': name,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    r = __salt__['boto_lambda.exists'](name=name, region=region,
+                                    key=key, keyid=keyid, profile=profile)
+
+    if 'error' in r:
+        ret['result'] = False
+        ret['comment'] = 'Failed to create Lambda function: {0}.'.format(r['error']['message'])
+        return ret
+
+    if not r.get('exists'):
+        if __opts__['test']:
+            ret['comment'] = 'Lambda function {0} is set to be created.'.format(name)
+            ret['result'] = None
+            return ret
+        r = __salt__['boto_lambda.create'](name, runtime, handler, code, role_name=None, role_id=None, 
+            description=None, timeout=None, memorysize=None, publish=False,
+            region=None, key=None, keyid=None, profile=Nonecidr_block, instance_tenancy,
+                                        name, dns_support, dns_hostnames,
+                                        tags, region, key, keyid, profile)
+        if not r.get('created'):
+            ret['result'] = False
+            ret['comment'] = 'Failed to create Lamda function: {0}.'.format(r['error']['message'])
+            return ret
+        _describe = __salt__['boto_lambda.describe'](r['id'], region=region, key=key,
+                                                  keyid=keyid, profile=profile)
+        ret['changes']['old'] = {'lambda': None}
+        ret['changes']['new'] = _describe
+        ret['comment'] = 'Lambda function {0} created.'.format(name)
+        return ret
+    ret['comment'] = 'Lamda function present.'
+    return ret
+
+
+def absent(name, region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure Lamda function with passed properties is absent.
+
+    name
+        Name of the Lambda function.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+    '''
+
+    ret = {'name': name,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    r = __salt__['boto_lambda.get_id'](name=name, region=region,
+                                    key=key, keyid=keyid, profile=profile)
+    if 'error' in r:
+        ret['result'] = False
+        ret['comment'] = 'Failed to delete Lambda function: {0}.'.format(r['error']['message'])
+        return ret
+
+    _id = r.get('id')
+    if not _id:
+        ret['comment'] = 'Lambda function {0} does not exist.'.format(name)
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'Lambda function {0} is set to be removed.'.format(name)
+        ret['result'] = None
+        return ret
+    r = __salt__['boto_lambda.delete'](name=name, 
+                                    region=region, key=key,
+                                    keyid=keyid, profile=profile)
+    if not r['deleted']:
+        ret['result'] = False
+        ret['comment'] = 'Failed to delete Lambda function: {0}.'.format(r['error']['message'])
+        return ret
+    ret['changes']['old'] = {'lambda': _id}
+    ret['changes']['new'] = {'lambda': None}
+    ret['comment'] = 'Lambda function {0} deleted.'.format(name)
+    return ret

--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -3,7 +3,7 @@
 Manage Lambda Functions
 =================
 
-.. versionadded::
+.. versionadded:: Boron
 
 Create and destroy Lambda Functions. Be aware that this interacts with Amazon's services,
 and so may incur charges.

--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -61,6 +61,9 @@ config:
 # Import Python Libs
 from __future__ import absolute_import
 import logging
+import os
+import os.path
+import hashlib
 
 # Import Salt Libs
 import salt.utils.dictupdate as dictupdate
@@ -75,14 +78,19 @@ def __virtual__():
     return 'boto_lambda' if 'boto_lambda.exists' in __salt__ else False
 
 
-def present(name, runtime, handler, code, role_name=None, role_id=None, 
-            description=None, timeout=None, memorysize=None, publish=False,
+def present(name, runtime, role, handler, zipfile=None, s3bucket=None,
+            s3key=None, s3objectversion=None, 
+            description='', timeout=3, memorysize=128, publish=False,
             region=None, key=None, keyid=None, profile=None):
     '''
     Ensure Lambda Function exists.
 
     name
         Name of the Lambda Function.
+
+    role
+        The name or ARN of the IAM role that Lambda assumes when it executes your
+        function to access any other AWS resources.
 
     runtime
         The runtime environment for the Lambda function. One of 
@@ -93,20 +101,23 @@ def present(name, runtime, handler, code, role_name=None, role_id=None,
         module-name.*export* value in your function. For Java, it can be package.classname::handler or
         package.class-name.
 
-    code
-        The code for the lambda function.
-        * zipfile - A .zip file containing your deployment package.
-        * s3bucket - Amazon S3 bucket name where the .zip file containing your package is stored.
-        * s3key - The Amazon S3 object (the deployment package) key name you want to upload.
-        * s3objectversion - The Amazon S3 object (the deployment package) version you want to upload.
+    zipfile
+        A path to a .zip file containing your deployment package. If this is
+        specified, s3bucket and s3key must not be specified.
 
-    role_name
-        The name of the IAM role that Lambda assumes when it executes your
-        function to access any other AWS resources. One of role_name or role_id must be specified.
+    s3bucket
+        Amazon S3 bucket name where the .zip file containing your package is
+        stored. If this is specified, s3key must be specified and zipfile must
+        NOT be specified.
 
-    role_id
-        The Amazon Resource Name (ARN) of the IAM role that Lambda assumes when it executes your
-        function to access any other AWS resources. One of role_name or role_id must be specified.
+    s3key
+        The Amazon S3 object (the deployment package) key name you want to
+        upload. If this is specified, s3key must be specified and zipfile must
+        NOT be specified.
+
+    s3objectversion
+        The version of S3 object to use. Optional, should only be specified if
+        s3bucket and s3key are specified.
 
     description
         A short, user-defined function description. Lambda does not use this value. Assign a meaningful
@@ -160,23 +171,112 @@ def present(name, runtime, handler, code, role_name=None, role_id=None,
             ret['comment'] = 'Lambda function {0} is set to be created.'.format(name)
             ret['result'] = None
             return ret
-        r = __salt__['boto_lambda.create'](name, runtime, handler, code, role_name=None, role_id=None, 
-            description=None, timeout=None, memorysize=None, publish=False,
-            region=None, key=None, keyid=None, profile=Nonecidr_block, instance_tenancy,
-                                        name, dns_support, dns_hostnames,
-                                        tags, region, key, keyid, profile)
+        r = __salt__['boto_lambda.create'](name, runtime, role, handler, 
+            zipfile, s3bucket, s3key, s3objectversion,
+            description, timeout, memorysize, publish,
+            region, key, keyid, profile)
         if not r.get('created'):
             ret['result'] = False
             ret['comment'] = 'Failed to create Lamda function: {0}.'.format(r['error']['message'])
             return ret
-        _describe = __salt__['boto_lambda.describe'](r['id'], region=region, key=key,
+        _describe = __salt__['boto_lambda.describe'](name, region=region, key=key,
                                                   keyid=keyid, profile=profile)
         ret['changes']['old'] = {'lambda': None}
         ret['changes']['new'] = _describe
         ret['comment'] = 'Lambda function {0} created.'.format(name)
         return ret
-    ret['comment'] = 'Lamda function present.'
+
+    ret['comment'] = os.linesep.join([ret['comment'], 'Lambda function {0} is present.'.format(name)])
+    ret['changes'] = {}
+    # Lambda function exists, ensure config matches
+    _ret = _lambda_config_present(name, role, handler, description, timeout,
+                                  memorysize, region, key, keyid, profile)
+    ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
+    ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
+    _ret = _lambda_code_present(name, zipfile, s3bucket, s3key, s3objectversion,
+                                 publish, region, key, keyid, profile)
+    ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
+    ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
     return ret
+
+
+def _get_role_arn(name, region=None, key=None, keyid=None, profile=None):
+    if name.startswith('arn:aws:iam:'):
+        return name
+
+    account_id = __salt__['boto_iam.get_account_id'](
+        region=region, key=key, keyid=keyid, profile=profile
+    )
+    return 'arn:aws:iam::{0}:role/{1}'.format(account_id, name)
+
+
+def _lambda_config_present(name, role, handler, description, timeout,
+                           memorysize, region, key, keyid, profile):
+    ret = {'result': True, 'comment': '', 'changes': {}}
+    lmbda = __salt__['boto_lambda.describe'](name, 
+           region=region, key=key, keyid=keyid, profile=profile)['lambda']
+    role_arn = _get_role_arn(role, region, key, keyid, profile)
+    need_update = False
+    for val, var in {
+        'Role': 'role_arn',
+        'Handler': 'handler',
+        'Description': 'description',
+        'Timeout': 'timeout',
+        'MemorySize': 'memorysize',
+    }.iteritems():
+        if lmbda[val] != locals()[var]:
+            need_update = True
+            ret['changes'].setdefault('new',{})[var] = locals()[var]
+            ret['changes'].setdefault('old',{})[var] = lmbda[val]
+    if need_update:
+        ret['comment'] = os.linesep.join([ret['comment'], 'Lambda function config to be modified'])
+        _r = __salt__['boto_lambda.update_config'](name, role, handler, description,
+                                        timeout, memorysize, region=region, key=key,
+                                        keyid=keyid, profile=profile)
+    return ret
+
+
+def _lambda_code_present(name, zipfile, s3bucket, s3key, s3objectversion,
+                         publish, region, key, keyid, profile):
+    ret = {'result': True, 'comment': '', 'changes': {}}
+    lmbda = __salt__['boto_lambda.describe'](name, 
+           region=region, key=key, keyid=keyid, profile=profile)['lambda']
+    update = False
+    if zipfile:
+        size = os.path.getsize(zipfile)
+        if size == lmbda['CodeSize']:
+            sha = hashlib.sha256()
+            with open(zipfile, 'rb') as f:
+                sha.update(f.read())
+            hashed = sha.digest().encode('base64').strip()
+            if hashed != lmbda['CodeSha256']:
+                update = True
+        else:
+            update=True
+    else:
+       # No way to judge whether the item in the s3 bucket is current without
+       # downloading it. Cheaper to just request an update every time, and still
+       # idempotent
+       update = True
+    if update:
+        ret['changes']['old'] = {
+            'CodeSha256': lmbda['CodeSha256'],
+            'CodeSize': lmbda['CodeSize'],
+        }
+        lmbda = __salt__['boto_lambda.update_code'](name, zipfile, s3bucket,
+            s3key, s3objectversion, publish,
+            region=region, key=key, keyid=keyid, profile=profile)['lambda']
+        if lmbda['CodeSha256'] != ret['changes']['old']['CodeSha256'] or \
+                lmbda['CodeSize'] != ret['changes']['old']['CodeSize']:
+            ret['comment'] = os.linesep.join([ret['comment'], 'Lambda function code to be modified'])
+            ret['changes']['new'] = {
+                'CodeSha256': lmbda['CodeSha256'],
+                'CodeSize': lmbda['CodeSize'],
+            }
+        else:
+			del(ret['changes']['old'])
+    return ret
+
 
 
 def absent(name, region=None, key=None, keyid=None, profile=None):
@@ -206,15 +306,14 @@ def absent(name, region=None, key=None, keyid=None, profile=None):
            'changes': {}
            }
 
-    r = __salt__['boto_lambda.get_id'](name=name, region=region,
+    r = __salt__['boto_lambda.exists'](name, region=region,
                                     key=key, keyid=keyid, profile=profile)
     if 'error' in r:
         ret['result'] = False
         ret['comment'] = 'Failed to delete Lambda function: {0}.'.format(r['error']['message'])
         return ret
 
-    _id = r.get('id')
-    if not _id:
+    if not r:
         ret['comment'] = 'Lambda function {0} does not exist.'.format(name)
         return ret
 
@@ -222,14 +321,14 @@ def absent(name, region=None, key=None, keyid=None, profile=None):
         ret['comment'] = 'Lambda function {0} is set to be removed.'.format(name)
         ret['result'] = None
         return ret
-    r = __salt__['boto_lambda.delete'](name=name, 
+    r = __salt__['boto_lambda.delete'](name,
                                     region=region, key=key,
                                     keyid=keyid, profile=profile)
     if not r['deleted']:
         ret['result'] = False
         ret['comment'] = 'Failed to delete Lambda function: {0}.'.format(r['error']['message'])
         return ret
-    ret['changes']['old'] = {'lambda': _id}
+    ret['changes']['old'] = {'lambda': name}
     ret['changes']['new'] = {'lambda': None}
     ret['comment'] = 'Lambda function {0} deleted.'.format(name)
     return ret

--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -50,7 +50,6 @@ config:
             - description: "My Lambda Function"
             - timeout: 3
             - memorysize: 128
-            - publish: false
             - region: us-east-1
             - keyid: GKTADJGHEIQSXMKKRBJ08H
             - key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
@@ -79,7 +78,7 @@ def __virtual__():
 
 def present(name, runtime, role, handler, zipfile=None, s3bucket=None,
             s3key=None, s3objectversion=None, 
-            description='', timeout=3, memorysize=128, publish=False,
+            description='', timeout=3, memorysize=128,
             region=None, key=None, keyid=None, profile=None):
     '''
     Ensure Lambda Function exists.
@@ -134,10 +133,6 @@ def present(name, runtime, role, handler, zipfile=None, s3bucket=None,
         to an image processing function. The default value is 128 MB. The value must be a multiple of
         64 MB.
 
-    publish
-        This boolean parameter can be used to request AWS Lambda to create the Lambda function and publish
-        a version as an atomic operation.
-
     region
         Region to connect to.
 
@@ -172,7 +167,7 @@ def present(name, runtime, role, handler, zipfile=None, s3bucket=None,
             return ret
         r = __salt__['boto_lambda.create'](name, runtime, role, handler, 
             zipfile, s3bucket, s3key, s3objectversion,
-            description, timeout, memorysize, publish,
+            description, timeout, memorysize, 
             region, key, keyid, profile)
         if not r.get('created'):
             ret['result'] = False
@@ -193,7 +188,7 @@ def present(name, runtime, role, handler, zipfile=None, s3bucket=None,
     ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
     _ret = _lambda_code_present(name, zipfile, s3bucket, s3key, s3objectversion,
-                                 publish, region, key, keyid, profile)
+                                 region, key, keyid, profile)
     ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
     return ret
@@ -236,7 +231,7 @@ def _lambda_config_present(name, role, handler, description, timeout,
 
 
 def _lambda_code_present(name, zipfile, s3bucket, s3key, s3objectversion,
-                         publish, region, key, keyid, profile):
+                         region, key, keyid, profile):
     ret = {'result': True, 'comment': '', 'changes': {}}
     lmbda = __salt__['boto_lambda.describe'](name, 
            region=region, key=key, keyid=keyid, profile=profile)['lambda']
@@ -263,7 +258,7 @@ def _lambda_code_present(name, zipfile, s3bucket, s3key, s3objectversion,
             'CodeSize': lmbda['CodeSize'],
         }
         lmbda = __salt__['boto_lambda.update_code'](name, zipfile, s3bucket,
-            s3key, s3objectversion, publish,
+            s3key, s3objectversion, 
             region=region, key=key, keyid=keyid, profile=profile)['lambda']
         if lmbda['CodeSha256'] != ret['changes']['old']['CodeSha256'] or \
                 lmbda['CodeSize'] != ret['changes']['old']['CodeSize']:

--- a/salt/utils/boto3.py
+++ b/salt/utils/boto3.py
@@ -1,0 +1,287 @@
+# -*- coding: utf-8 -*-
+'''
+Boto3 Common Utils
+=================
+
+Note: This module depends on the dicts packed by the loader and,
+therefore, must be accessed via the loader or from the __utils__ dict.
+
+The __utils__ dict will not be automatically available to execution modules
+until 2015.8.0. The `salt.utils.compat.pack_dunder` helper function
+provides backwards compatibility.
+
+This module provides common functionality for the boto execution modules.
+The expected usage is to call `apply_funcs` from the `__virtual__` function
+of the module. This will bring properly initilized partials of  `_get_conn`
+and `_cache_id` into the module's namespace.
+
+Example Usage:
+
+    .. code-block:: python
+
+        import salt.utils.boto3
+
+        def __virtual__():
+            # only required in 2015.2
+            salt.utils.compat.pack_dunder(__name__)
+
+            __utils__['boto.apply_funcs'](__name__, 'vpc')
+
+        def test():
+            conn = _get_conn()
+            vpc_id = _cache_id('test-vpc')
+
+.. versionadded:: 2015.8.0
+'''
+
+# Import Python libs
+from __future__ import absolute_import
+import hashlib
+import logging
+import sys
+from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
+from functools import partial
+
+# Import salt libs
+from salt.ext.six import string_types  # pylint: disable=import-error
+from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
+from salt.exceptions import SaltInvocationError
+
+# Import third party libs
+# pylint: disable=import-error
+try:
+    # pylint: disable=import-error
+    import boto
+    import boto3
+    import boto.exception
+    import boto3.session
+
+    # pylint: enable=import-error
+    logging.getLogger('boto3').setLevel(logging.CRITICAL)
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+# pylint: enable=import-error
+
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Only load if boto libraries exist and if boto libraries are greater than
+    a given version.
+    '''
+    # TODO: Determine minimal version we want to support. VPC requires > 2.8.0.
+    required_boto_version = '2.0.0'
+    required_boto3_version = '1.2.1'
+    if not HAS_BOTO:
+        return False
+    elif _LooseVersion(boto.__version__) < _LooseVersion(required_boto_version):
+        return False
+    elif _LooseVersion(boto3.__version__) < _LooseVersion(required_boto3_version):
+        return False
+    else:
+        return True
+
+
+def _option(value):
+    '''
+    Look up the value for an option.
+    '''
+    if value in __opts__:
+        return __opts__[value]
+    master_opts = __pillar__.get('master', {})
+    if value in master_opts:
+        return master_opts[value]
+    if value in __pillar__:
+        return __pillar__[value]
+
+
+def _get_profile(service, region, key, keyid, profile):
+    if profile:
+        if isinstance(profile, string_types):
+            _profile = _option(profile)
+        elif isinstance(profile, dict):
+            _profile = profile
+        key = _profile.get('key', None)
+        keyid = _profile.get('keyid', None)
+        region = _profile.get('region', None)
+
+    if not region and _option(service + '.region'):
+        region = _option(service + '.region')
+
+    if not region:
+        region = 'us-east-1'
+
+    if not key and _option(service + '.key'):
+        key = _option(service + '.key')
+    if not keyid and _option(service + '.keyid'):
+        keyid = _option(service + '.keyid')
+
+    label = 'boto_{0}:'.format(service)
+    if keyid:
+        cxkey = label + hashlib.md5(region + keyid + key).hexdigest()
+    else:
+        cxkey = label + region
+
+    return (cxkey, region, key, keyid)
+
+
+def cache_id(service, name, sub_resource=None, resource_id=None,
+             invalidate=False, region=None, key=None, keyid=None,
+             profile=None):
+    '''
+    Cache, invalidate, or retrieve an AWS resource id keyed by name.
+
+    .. code-block:: python
+
+        __utils__['boto.cache_id']('ec2', 'myinstance',
+                                   'i-a1b2c3',
+                                   profile='custom_profile')
+    '''
+
+    cxkey, _, _, _ = _get_profile(service, region, key,
+                                  keyid, profile)
+    if sub_resource:
+        cxkey = '{0}:{1}:{2}:id'.format(cxkey, sub_resource, name)
+    else:
+        cxkey = '{0}:{1}:id'.format(cxkey, name)
+
+    if invalidate:
+        if cxkey in __context__:
+            del __context__[cxkey]
+            return True
+        elif resource_id in __context__.values():
+            ctx = dict((k, v) for k, v in __context__.items() if v != resource_id)
+            __context__.clear()
+            __context__.update(ctx)
+            return True
+        else:
+            return False
+    if resource_id:
+        __context__[cxkey] = resource_id
+        return True
+
+    return __context__.get(cxkey)
+
+
+def cache_id_func(service):
+    '''
+    Returns a partial `cache_id` function for the provided service.
+
+    ... code-block:: python
+
+        cache_id = __utils__['boto.cache_id_func']('ec2')
+        cache_id('myinstance', 'i-a1b2c3')
+        instance_id = cache_id('myinstance')
+    '''
+    return partial(cache_id, service)
+
+
+def get_connection(service, module=None, region=None, key=None, keyid=None,
+                   profile=None):
+    '''
+    Return a boto connection for the service.
+
+    .. code-block:: python
+
+        conn = __utils__['boto.get_connection']('ec2', profile='custom_profile')
+    '''
+
+    module = module or service
+
+    cxkey, region, key, keyid = _get_profile(service, region, key,
+                                             keyid, profile)
+    cxkey = cxkey + ':conn'
+
+    if cxkey in __context__:
+        return __context__[cxkey]
+
+    try:
+        session = boto3.session.Session(aws_access_key_id=keyid,
+                          aws_secret_access_key=key,
+                          region_name=region)
+        if session is None:
+            raise SaltInvocationError('Region "{0}" is not '
+                                      'valid.'.format(region))
+        conn = session.client(module)
+        if conn is None:
+            raise SaltInvocationError('Region "{0}" is not '
+                                      'valid.'.format(region))
+    except boto.exception.NoAuthHandlerFound:
+        raise SaltInvocationError('No authentication credentials found when '
+                                  'attempting to make boto {0} connection to '
+                                  'region "{1}".'.format(service, region))
+    __context__[cxkey] = conn
+    return conn
+
+
+def get_connection_func(service, module=None):
+    '''
+    Returns a partial `get_connection` function for the provided service.
+
+    ... code-block:: python
+
+        get_conn = __utils__['boto.get_connection_func']('ec2')
+        conn = get_conn()
+    '''
+    return partial(get_connection, service, module=module)
+
+
+def get_error(e):
+    # The returns from boto modules vary greatly between modules. We need to
+    # assume that none of the data we're looking for exists.
+    aws = {}
+    if hasattr(e, 'status'):
+        aws['status'] = e.status
+    if hasattr(e, 'reason'):
+        aws['reason'] = e.reason
+    if hasattr(e, 'message') and e.message != '':
+        aws['message'] = e.message
+    if hasattr(e, 'error_code') and e.error_code is not None:
+        aws['code'] = e.error_code
+
+    if 'message' in aws and 'reason' in aws:
+        message = '{0}: {1}'.format(aws['reason'], aws['message'])
+    elif 'message' in aws:
+        message = aws['message']
+    elif 'reason' in aws:
+        message = aws['reason']
+    else:
+        message = ''
+    r = {'message': message}
+    if aws:
+        r['aws'] = aws
+    return r
+
+
+def exactly_n(l, n=1):
+    '''
+    Tests that exactly N items in an iterable are "truthy" (neither None,
+    False, nor 0).
+    '''
+    i = iter(l)
+    return all(any(i) for j in range(n)) and not any(i)
+
+
+def exactly_one(l):
+    return exactly_n(l)
+
+
+def assign_funcs(modname, service, module=None):
+    '''
+    Assign _get_conn and _cache_id functions to the named module.
+
+    .. code-block:: python
+
+        _utils__['boto.assign_partials'](__name__, 'ec2')
+    '''
+    mod = sys.modules[modname]
+    setattr(mod, '_get_conn', get_connection_func(service, module=module))
+    setattr(mod, '_cache_id', cache_id_func(service))
+
+    # TODO: Remove this and import salt.utils.exactly_one into boto_* modules instead
+    # Leaving this way for now so boto modules can be back ported
+    setattr(mod, '_exactly_one', exactly_one)
+

--- a/salt/utils/boto3.py
+++ b/salt/utils/boto3.py
@@ -295,4 +295,4 @@ def paged_call(function, marker_flag='NextMarker', marker_arg='Marker', *args, *
         yield ret
         if not marker:
             break
-        args[marker_arg] = marker
+        kwargs[marker_arg] = marker

--- a/salt/utils/boto3.py
+++ b/salt/utils/boto3.py
@@ -113,6 +113,7 @@ def _get_profile(service, region, key, keyid, profile):
 
     if not region:
         region = 'us-east-1'
+        log.info('Assuming default region {0}'.format(region))
 
     if not key and _option(service + '.key'):
         key = _option(service + '.key')
@@ -284,6 +285,7 @@ def assign_funcs(modname, service, module=None):
     # TODO: Remove this and import salt.utils.exactly_one into boto_* modules instead
     # Leaving this way for now so boto modules can be back ported
     setattr(mod, '_exactly_one', exactly_one)
+
 
 def paged_call(function, marker_flag='NextMarker', marker_arg='Marker', *args, **kwargs):
     """Retrieve full set of values from a boto3 API call that may truncate

--- a/salt/utils/boto3.py
+++ b/salt/utils/boto3.py
@@ -285,3 +285,14 @@ def assign_funcs(modname, service, module=None):
     # Leaving this way for now so boto modules can be back ported
     setattr(mod, '_exactly_one', exactly_one)
 
+def paged_call(function, marker_flag='NextMarker', marker_arg='Marker', *args, **kwargs):
+    """Retrieve full set of values from a boto3 API call that may truncate
+    its results, yielding each page as it is obtained.
+    """
+    while True:
+        ret = function(*args, **kwargs)
+        marker = ret.get(marker_flag)
+        yield ret
+        if not marker:
+            break
+        args[marker_arg] = marker

--- a/tests/unit/modules/boto_lambda_test.py
+++ b/tests/unit/modules/boto_lambda_test.py
@@ -15,17 +15,15 @@ ensure_in_syspath('../../')
 import salt.config
 import salt.loader
 from salt.modules import boto_lambda
-from salt.exceptions import SaltInvocationError, CommandExecutionError
+from salt.exceptions import SaltInvocationError
 
 # Import 3rd-party libs
-import salt.ext.six as six
 from tempfile import NamedTemporaryFile
 import logging
 import os
-import copy
 
 # Import Mock libraries
-from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch, call
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
 
 # pylint: disable=import-error,no-name-in-module
 try:
@@ -100,12 +98,12 @@ def _has_required_boto():
     else:
         return True
 
+
 class BotoLambdaTestCaseBase(TestCase):
     conn = None
 
     # Set up MagicMock to replace the boto3 session
     def setUp(self):
-        global context
         context.clear()
 
         self.patcher = patch('boto3.session.Session')
@@ -116,14 +114,17 @@ class BotoLambdaTestCaseBase(TestCase):
         self.conn = MagicMock()
         session_instance.client.return_value = self.conn
 
+
 class TempZipFile:
     def __enter__(self):
         with NamedTemporaryFile(suffix='.zip', prefix='salt_test_', delete=False) as tmp:
             tmp.write('###\n')
             self.zipfile = tmp.name
         return self.zipfile
+
     def __exit__(self, type, value, traceback):
         os.remove(self.zipfile)
+
 
 class BotoLambdaTestCaseMixin(object):
     pass
@@ -143,7 +144,7 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         '''
         Tests checking lambda function existence when the lambda function already exists
         '''
-        self.conn.list_functions.return_value={'Functions': [function_ret]}
+        self.conn.list_functions.return_value = {'Functions': [function_ret]}
         func_exists_result = boto_lambda.function_exists(FunctionName=function_ret['FunctionName'], **conn_parameters)
 
         self.assertTrue(func_exists_result['exists'])
@@ -152,7 +153,7 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         '''
         Tests checking lambda function existence when the lambda function does not exist
         '''
-        self.conn.list_functions.return_value={'Functions': [function_ret]}
+        self.conn.list_functions.return_value = {'Functions': [function_ret]}
         func_exists_result = boto_lambda.function_exists(FunctionName='myfunc', **conn_parameters)
 
         self.assertFalse(func_exists_result['exists'])
@@ -161,18 +162,19 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         '''
         Tests checking lambda function existence when boto returns an error
         '''
-        self.conn.list_functions.side_effect=ClientError(error_content, 'list_functions')
+        self.conn.list_functions.side_effect = ClientError(error_content, 'list_functions')
         func_exists_result = boto_lambda.function_exists(FunctionName='myfunc', **conn_parameters)
 
-        self.assertEqual(func_exists_result.get('error',{}).get('message'), error_message.format('list_functions'))
+        self.assertEqual(func_exists_result.get('error', {}).get('message'), error_message.format('list_functions'))
 
     def test_that_when_creating_a_function_from_zipfile_succeeds_the_create_function_method_returns_true(self):
         '''
         tests True function created.
         '''
-        with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}), TempZipFile() as zipfile:
-            self.conn.create_function.return_value=function_ret
-            lambda_creation_result = boto_lambda.create_function(FunctionName='testfunction',
+        with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
+            with TempZipFile() as zipfile:
+                self.conn.create_function.return_value = function_ret
+                lambda_creation_result = boto_lambda.create_function(FunctionName='testfunction',
                                                     Runtime='python2.7',
                                                     Role='myrole',
                                                     Handler='file.method',
@@ -186,7 +188,7 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         tests True function created.
         '''
         with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
-            self.conn.create_function.return_value=function_ret
+            self.conn.create_function.return_value = function_ret
             lambda_creation_result = boto_lambda.create_function(FunctionName='testfunction',
                                                     Runtime='python2.7',
                                                     Role='myrole',
@@ -201,10 +203,10 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         '''
         tests Creating a function without code
         '''
-        with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}
-                       ), self.assertRaisesRegexp(SaltInvocationError,
+        with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
+            with self.assertRaisesRegexp(SaltInvocationError,
                                      'Either ZipFile must be specified, or S3Bucket and S3Key must be provided.'):
-            lambda_creation_result = boto_lambda.create_function(FunctionName='testfunction',
+                lambda_creation_result = boto_lambda.create_function(FunctionName='testfunction',
                                                     Runtime='python2.7',
                                                     Role='myrole',
                                                     Handler='file.method',
@@ -214,11 +216,11 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         '''
         tests Creating a function without code
         '''
-        with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}
-                      ), self.assertRaisesRegexp(SaltInvocationError,
-                                     'Either ZipFile must be specified, or S3Bucket and S3Key must be provided.'
-                       ), TempZipFile() as zipfile:
-                lambda_creation_result = boto_lambda.create_function(FunctionName='testfunction',
+        with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
+            with self.assertRaisesRegexp(SaltInvocationError,
+                                   'Either ZipFile must be specified, or S3Bucket and S3Key must be provided.'):
+                with TempZipFile() as zipfile:
+                    lambda_creation_result = boto_lambda.create_function(FunctionName='testfunction',
                                                     Runtime='python2.7',
                                                     Role='myrole',
                                                     Handler='file.method',
@@ -232,7 +234,7 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         tests False function not created.
         '''
         with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
-            self.conn.create_function.side_effect=ClientError(error_content, 'create_function')
+            self.conn.create_function.side_effect = ClientError(error_content, 'create_function')
             with TempZipFile() as zipfile:
                 lambda_creation_result = boto_lambda.create_function(FunctionName='testfunction',
                                                     Runtime='python2.7',
@@ -240,7 +242,7 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
                                                     Handler='file.method',
                                                     ZipFile=zipfile,
                                                     **conn_parameters)
-        self.assertEqual(lambda_creation_result.get('error',{}).get('message'), error_message.format('create_function'))
+        self.assertEqual(lambda_creation_result.get('error', {}).get('message'), error_message.format('create_function'))
 
     def test_that_when_deleting_a_function_succeeds_the_delete_function_method_returns_true(self):
         '''
@@ -258,7 +260,7 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         tests False function not deleted.
         '''
         with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
-            self.conn.delete_function.side_effect=ClientError(error_content, 'delete_function')
+            self.conn.delete_function.side_effect = ClientError(error_content, 'delete_function')
             result = boto_lambda.delete_function(FunctionName='testfunction',
                                                     **conn_parameters)
         self.assertFalse(result['deleted'])
@@ -267,18 +269,18 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         '''
         Tests describing parameters if function exists
         '''
-        self.conn.list_functions.return_value={ 'Functions': [ function_ret ]}
+        self.conn.list_functions.return_value = {'Functions': [function_ret]}
 
         with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
             result = boto_lambda.describe_function(FunctionName=function_ret['FunctionName'], **conn_parameters)
 
-        self.assertEqual(result, { 'function': function_ret })
+        self.assertEqual(result, {'function': function_ret})
 
     def test_that_when_describing_function_it_returns_the_dict_of_properties_returns_false(self):
         '''
         Tests describing parameters if function does not exist
         '''
-        self.conn.list_functions.return_value={ 'Functions': [ ]}
+        self.conn.list_functions.return_value = { 'Functions': []}
         with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
             result = boto_lambda.describe_function(FunctionName='testfunction', **conn_parameters)
 
@@ -288,7 +290,7 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         '''
         Tests describing parameters failure
         '''
-        self.conn.list_functions.side_effect=ClientError(error_content, 'list_functions')
+        self.conn.list_functions.side_effect = ClientError(error_content, 'list_functions')
         result = boto_lambda.describe_function(FunctionName='testfunction', **conn_parameters)
         self.assertTrue('error' in result)
 
@@ -297,7 +299,7 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         tests True function updated.
         '''
         with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
-            self.conn.update_function_config.return_value=function_ret
+            self.conn.update_function_config.return_value = function_ret
             result = boto_lambda.update_function_config(FunctionName=function_ret['FunctionName'], Role='myrole', **conn_parameters)
 
         self.assertTrue(result['updated'])
@@ -307,19 +309,20 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         tests False function not updated.
         '''
         with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
-            self.conn.update_function_configuration.side_effect=ClientError(error_content, 'update_function')
+            self.conn.update_function_configuration.side_effect = ClientError(error_content, 'update_function')
             result = boto_lambda.update_function_config(FunctionName='testfunction',
                                                     Role='myrole',
                                                     **conn_parameters)
-        self.assertEqual(result.get('error',{}).get('message'), error_message.format('update_function'))
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('update_function'))
 
     def test_that_when_updating_function_code_from_zipfile_succeeds_the_update_function_method_returns_true(self):
         '''
         tests True function updated.
         '''
-        with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}), TempZipFile() as zipfile:
-            self.conn.update_function_code.return_value=function_ret
-            result = boto_lambda.update_function_code(FunctionName=function_ret['FunctionName'], ZipFile=zipfile, **conn_parameters)
+        with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
+            with TempZipFile() as zipfile:
+                self.conn.update_function_code.return_value = function_ret
+                result = boto_lambda.update_function_code(FunctionName=function_ret['FunctionName'], ZipFile=zipfile, **conn_parameters)
 
         self.assertTrue(result['updated'])
 
@@ -328,7 +331,7 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         tests True function updated.
         '''
         with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
-            self.conn.update_function_code.return_value=function_ret
+            self.conn.update_function_code.return_value = function_ret
             result = boto_lambda.update_function_code(FunctionName='testfunction',
                                                     S3Bucket='bucket',
                                                     S3Key='key',
@@ -340,10 +343,10 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         '''
         tests Creating a function without code
         '''
-        with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}
-                       ), self.assertRaisesRegexp(SaltInvocationError,
+        with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
+            with self.assertRaisesRegexp(SaltInvocationError,
                                      'Either ZipFile must be specified, or S3Bucket and S3Key must be provided.'):
-            result = boto_lambda.update_function_code(FunctionName='testfunction',
+                result = boto_lambda.update_function_code(FunctionName='testfunction',
                                                     **conn_parameters)
 
     def test_that_when_updating_function_code_fails_the_update_function_method_returns_error(self):
@@ -351,19 +354,19 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         tests False function not updated.
         '''
         with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
-            self.conn.update_function_code.side_effect=ClientError(error_content, 'update_function_code')
+            self.conn.update_function_code.side_effect = ClientError(error_content, 'update_function_code')
             result = boto_lambda.update_function_code(FunctionName='testfunction',
                                                     S3Bucket='bucket',
                                                     S3Key='key',
                                                     **conn_parameters)
-        self.assertEqual(result.get('error',{}).get('message'), error_message.format('update_function_code'))
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('update_function_code'))
 
     def test_that_when_listing_function_versions_succeeds_the_list_function_versions_method_returns_true(self):
         '''
         tests True function versions listed.
         '''
         with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
-            self.conn.list_versions_by_function.return_value={'Versions': [ function_ret ]}
+            self.conn.list_versions_by_function.return_value = {'Versions': [function_ret]}
             result = boto_lambda.list_function_versions(FunctionName='testfunction',
                                                     **conn_parameters)
 
@@ -374,7 +377,7 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         tests False no function versions listed.
         '''
         with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
-            self.conn.list_versions_by_function.return_value={'Versions': [ ]}
+            self.conn.list_versions_by_function.return_value = {'Versions': []}
             result = boto_lambda.list_function_versions(FunctionName='testfunction',
                                                     **conn_parameters)
         self.assertFalse(result['Versions'])
@@ -384,10 +387,10 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         tests False function versions error.
         '''
         with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
-            self.conn.list_versions_by_function.side_effect=ClientError(error_content, 'list_versions_by_function')
+            self.conn.list_versions_by_function.side_effect = ClientError(error_content, 'list_versions_by_function')
             result = boto_lambda.list_function_versions(FunctionName='testfunction',
                                                     **conn_parameters)
-        self.assertEqual(result.get('error',{}).get('message'), error_message.format('list_versions_by_function'))
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('list_versions_by_function'))
 
 
 @skipIf(HAS_BOTO is False, 'The boto module must be installed.')
@@ -403,7 +406,7 @@ class BotoLambdaAliasTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin):
         '''
         tests True alias created.
         '''
-        self.conn.create_alias.return_value=alias_ret
+        self.conn.create_alias.return_value = alias_ret
         result = boto_lambda.create_alias(FunctionName='testfunction',
                                                     Name=alias_ret['Name'],
                                                     FunctionVersion=alias_ret['FunctionVersion'],
@@ -415,12 +418,12 @@ class BotoLambdaAliasTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin):
         '''
         tests False alias not created.
         '''
-        self.conn.create_alias.side_effect=ClientError(error_content, 'create_alias')
+        self.conn.create_alias.side_effect = ClientError(error_content, 'create_alias')
         result = boto_lambda.create_alias(FunctionName='testfunction',
                                                     Name=alias_ret['Name'],
                                                     FunctionVersion=alias_ret['FunctionVersion'],
                                                     **conn_parameters)
-        self.assertEqual(result.get('error',{}).get('message'), error_message.format('create_alias'))
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('create_alias'))
 
     def test_that_when_deleting_an_alias_succeeds_the_delete_alias_method_returns_true(self):
         '''
@@ -436,7 +439,7 @@ class BotoLambdaAliasTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin):
         '''
         tests False alias not deleted.
         '''
-        self.conn.delete_alias.side_effect=ClientError(error_content, 'delete_alias')
+        self.conn.delete_alias.side_effect = ClientError(error_content, 'delete_alias')
         result = boto_lambda.delete_alias(FunctionName='testfunction',
                                           Name=alias_ret['Name'],
                                           **conn_parameters)
@@ -446,9 +449,9 @@ class BotoLambdaAliasTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin):
         '''
         Tests checking lambda alias existence when the lambda alias already exists
         '''
-        self.conn.list_aliases.return_value={'Aliases': [alias_ret]}
+        self.conn.list_aliases.return_value = {'Aliases': [alias_ret]}
         result = boto_lambda.alias_exists(FunctionName='testfunction',
-                                          Name=alias_ret['Name'], 
+                                          Name=alias_ret['Name'],
                                           **conn_parameters)
         self.assertTrue(result['exists'])
 
@@ -456,7 +459,7 @@ class BotoLambdaAliasTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin):
         '''
         Tests checking lambda alias existence when the lambda alias does not exist
         '''
-        self.conn.list_aliases.return_value={'Aliases': [alias_ret]}
+        self.conn.list_aliases.return_value = {'Aliases': [alias_ret]}
         result = boto_lambda.alias_exists(FunctionName='testfunction',
                                           Name='otheralias',
                                           **conn_parameters)
@@ -467,30 +470,30 @@ class BotoLambdaAliasTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin):
         '''
         Tests checking lambda alias existence when boto returns an error
         '''
-        self.conn.list_aliases.side_effect=ClientError(error_content, 'list_aliases')
+        self.conn.list_aliases.side_effect = ClientError(error_content, 'list_aliases')
         result = boto_lambda.alias_exists(FunctionName='testfunction',
                                           Name=alias_ret['Name'], 
                                           **conn_parameters)
 
-        self.assertEqual(result.get('error',{}).get('message'), error_message.format('list_aliases'))
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('list_aliases'))
 
     def test_that_when_describing_alias_it_returns_the_dict_of_properties_returns_true(self):
         '''
         Tests describing parameters if alias exists
         '''
-        self.conn.list_aliases.return_value={'Aliases': [alias_ret]}
+        self.conn.list_aliases.return_value = {'Aliases': [alias_ret]}
 
         result = boto_lambda.describe_alias(FunctionName='testfunction',
                                             Name=alias_ret['Name'],
                                             **conn_parameters)
 
-        self.assertEqual(result, { 'alias': alias_ret })
+        self.assertEqual(result, {'alias': alias_ret})
 
     def test_that_when_describing_alias_it_returns_the_dict_of_properties_returns_false(self):
         '''
         Tests describing parameters if alias does not exist
         '''
-        self.conn.list_aliases.return_value={'Aliases': [alias_ret]}
+        self.conn.list_aliases.return_value = {'Aliases': [alias_ret]}
         result = boto_lambda.describe_alias(FunctionName='testfunction', 
                                             Name='othername',
                                             **conn_parameters)
@@ -501,7 +504,7 @@ class BotoLambdaAliasTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin):
         '''
         Tests describing parameters failure
         '''
-        self.conn.list_aliases.side_effect=ClientError(error_content, 'list_aliases')
+        self.conn.list_aliases.side_effect = ClientError(error_content, 'list_aliases')
         result = boto_lambda.describe_alias(FunctionName='testfunction', 
                                             Name=alias_ret['Name'],
                                             **conn_parameters)
@@ -511,7 +514,7 @@ class BotoLambdaAliasTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin):
         '''
         tests True alias updated.
         '''
-        self.conn.update_alias.return_value=alias_ret
+        self.conn.update_alias.return_value = alias_ret
         result = boto_lambda.update_alias(FunctionName='testfunctoin',
                                           Name=alias_ret['Name'],
                                           Description=alias_ret['Description'],
@@ -523,11 +526,11 @@ class BotoLambdaAliasTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin):
         '''
         tests False alias not updated.
         '''
-        self.conn.update_alias.side_effect=ClientError(error_content, 'update_alias')
+        self.conn.update_alias.side_effect = ClientError(error_content, 'update_alias')
         result = boto_lambda.update_alias(FunctionName='testfunction',
                                           Name=alias_ret['Name'],
                                           **conn_parameters)
-        self.assertEqual(result.get('error',{}).get('message'), error_message.format('update_alias'))
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('update_alias'))
 
 
 @skipIf(HAS_BOTO is False, 'The boto module must be installed.')
@@ -543,7 +546,7 @@ class BotoLambdaEventSourceMappingTestCase(BotoLambdaTestCaseBase, BotoLambdaTes
         '''
         tests True mapping created.
         '''
-        self.conn.create_event_source_mapping.return_value=event_source_mapping_ret
+        self.conn.create_event_source_mapping.return_value = event_source_mapping_ret
         result = boto_lambda.create_event_source_mapping(
                       EventSourceArn=event_source_mapping_ret['EventSourceArn'],
                       FunctionName=event_source_mapping_ret['FunctionArn'],
@@ -556,20 +559,20 @@ class BotoLambdaEventSourceMappingTestCase(BotoLambdaTestCaseBase, BotoLambdaTes
         '''
         tests False mapping not created.
         '''
-        self.conn.create_event_source_mapping.side_effect=ClientError(error_content, 'create_event_source_mapping')
+        self.conn.create_event_source_mapping.side_effect = ClientError(error_content, 'create_event_source_mapping')
         result = boto_lambda.create_event_source_mapping(
                       EventSourceArn=event_source_mapping_ret['EventSourceArn'],
                       FunctionName=event_source_mapping_ret['FunctionArn'],
                       StartingPosition='LATEST',
                       **conn_parameters)
-        self.assertEqual(result.get('error',{}).get('message'),
+        self.assertEqual(result.get('error', {}).get('message'),
                          error_message.format('create_event_source_mapping'))
 
     def test_that_when_listing_mapping_ids_succeeds_the_get_event_source_mapping_ids_method_returns_true(self):
         '''
         tests True mapping ids listed.
         '''
-        self.conn.list_event_source_mappings.return_value={'EventSourceMappings': [event_source_mapping_ret]}
+        self.conn.list_event_source_mappings.return_value = {'EventSourceMappings': [event_source_mapping_ret]}
         result = boto_lambda.get_event_source_mapping_ids(
                       EventSourceArn=event_source_mapping_ret['EventSourceArn'],
                       FunctionName=event_source_mapping_ret['FunctionArn'],
@@ -581,7 +584,7 @@ class BotoLambdaEventSourceMappingTestCase(BotoLambdaTestCaseBase, BotoLambdaTes
         '''
         tests False no mapping ids listed.
         '''
-        self.conn.list_event_source_mappings.return_value={'EventSourceMappings': [ ]}
+        self.conn.list_event_source_mappings.return_value = {'EventSourceMappings': []}
         result = boto_lambda.get_event_source_mapping_ids(
                       EventSourceArn=event_source_mapping_ret['EventSourceArn'],
                       FunctionName=event_source_mapping_ret['FunctionArn'],
@@ -592,12 +595,12 @@ class BotoLambdaEventSourceMappingTestCase(BotoLambdaTestCaseBase, BotoLambdaTes
         '''
         tests False mapping ids error.
         '''
-        self.conn.list_event_source_mappings.side_effect=ClientError(error_content, 'list_event_source_mappings')
+        self.conn.list_event_source_mappings.side_effect = ClientError(error_content, 'list_event_source_mappings')
         result = boto_lambda.get_event_source_mapping_ids(
                       EventSourceArn=event_source_mapping_ret['EventSourceArn'],
                       FunctionName=event_source_mapping_ret['FunctionArn'],
                       **conn_parameters)
-        self.assertEqual(result.get('error',{}).get('message'), error_message.format('list_event_source_mappings'))
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('list_event_source_mappings'))
 
     def test_that_when_deleting_an_event_source_mapping_by_UUID_succeeds_the_delete_event_source_mapping_method_returns_true(self):
         '''
@@ -612,7 +615,7 @@ class BotoLambdaEventSourceMappingTestCase(BotoLambdaTestCaseBase, BotoLambdaTes
         '''
         tests True mapping deleted.
         '''
-        self.conn.list_event_source_mappings.return_value={'EventSourceMappings': [event_source_mapping_ret]}
+        self.conn.list_event_source_mappings.return_value = {'EventSourceMappings': [event_source_mapping_ret]}
         result = boto_lambda.delete_event_source_mapping(
                              EventSourceArn=event_source_mapping_ret['EventSourceArn'],
                              FunctionName=event_source_mapping_ret['FunctionArn'],
@@ -631,7 +634,7 @@ class BotoLambdaEventSourceMappingTestCase(BotoLambdaTestCaseBase, BotoLambdaTes
         '''
         tests False mapping not deleted.
         '''
-        self.conn.delete_event_source_mapping.side_effect=ClientError(error_content, 'delete_event_source_mapping')
+        self.conn.delete_event_source_mapping.side_effect = ClientError(error_content, 'delete_event_source_mapping')
         result = boto_lambda.delete_event_source_mapping(UUID=event_source_mapping_ret['UUID'],
                                           **conn_parameters)
         self.assertFalse(result['deleted'])
@@ -641,7 +644,7 @@ class BotoLambdaEventSourceMappingTestCase(BotoLambdaTestCaseBase, BotoLambdaTes
         Tests checking lambda event_source_mapping existence when the lambda
         event_source_mapping already exists
         '''
-        self.conn.get_event_source_mapping.return_value=event_source_mapping_ret
+        self.conn.get_event_source_mapping.return_value = event_source_mapping_ret
         result = boto_lambda.event_source_mapping_exists(
                                           UUID=event_source_mapping_ret['UUID'],
                                           **conn_parameters)
@@ -652,7 +655,7 @@ class BotoLambdaEventSourceMappingTestCase(BotoLambdaTestCaseBase, BotoLambdaTes
         Tests checking lambda event_source_mapping existence when the lambda
         event_source_mapping does not exist
         '''
-        self.conn.get_event_source_mapping.return_value=None
+        self.conn.get_event_source_mapping.return_value = None
         result = boto_lambda.event_source_mapping_exists(
                                           UUID='other_UUID',
                                           **conn_parameters)
@@ -662,27 +665,27 @@ class BotoLambdaEventSourceMappingTestCase(BotoLambdaTestCaseBase, BotoLambdaTes
         '''
         Tests checking lambda event_source_mapping existence when boto returns an error
         '''
-        self.conn.get_event_source_mapping.side_effect=ClientError(error_content, 'list_event_source_mappings')
+        self.conn.get_event_source_mapping.side_effect = ClientError(error_content, 'list_event_source_mappings')
         result = boto_lambda.event_source_mapping_exists(
                                           UUID=event_source_mapping_ret['UUID'],
                                           **conn_parameters)
-        self.assertEqual(result.get('error',{}).get('message'), error_message.format('list_event_source_mappings'))
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('list_event_source_mappings'))
 
     def test_that_when_describing_event_source_mapping_it_returns_the_dict_of_properties_returns_true(self):
         '''
         Tests describing parameters if event_source_mapping exists
         '''
-        self.conn.get_event_source_mapping.return_value=event_source_mapping_ret
+        self.conn.get_event_source_mapping.return_value = event_source_mapping_ret
         result = boto_lambda.describe_event_source_mapping(
                                           UUID=event_source_mapping_ret['UUID'],
                                           **conn_parameters)
-        self.assertEqual(result, { 'event_source_mapping': event_source_mapping_ret })
+        self.assertEqual(result, {'event_source_mapping': event_source_mapping_ret})
 
     def test_that_when_describing_event_source_mapping_it_returns_the_dict_of_properties_returns_false(self):
         '''
         Tests describing parameters if event_source_mapping does not exist
         '''
-        self.conn.get_event_source_mapping.return_value=None
+        self.conn.get_event_source_mapping.return_value = None
         result = boto_lambda.describe_event_source_mapping(
                                           UUID=event_source_mapping_ret['UUID'],
                                           **conn_parameters)
@@ -692,7 +695,7 @@ class BotoLambdaEventSourceMappingTestCase(BotoLambdaTestCaseBase, BotoLambdaTes
         '''
         Tests describing parameters failure
         '''
-        self.conn.get_event_source_mapping.side_effect=ClientError(error_content, 'get_event_source_mapping')
+        self.conn.get_event_source_mapping.side_effect = ClientError(error_content, 'get_event_source_mapping')
         result = boto_lambda.describe_event_source_mapping(
                                           UUID=event_source_mapping_ret['UUID'],
                                           **conn_parameters)
@@ -702,7 +705,7 @@ class BotoLambdaEventSourceMappingTestCase(BotoLambdaTestCaseBase, BotoLambdaTes
         '''
         tests True event_source_mapping updated.
         '''
-        self.conn.update_event_source_mapping.return_value=event_source_mapping_ret
+        self.conn.update_event_source_mapping.return_value = event_source_mapping_ret
         result = boto_lambda.update_event_source_mapping(
                                           UUID=event_source_mapping_ret['UUID'],
                                           FunctionName=event_source_mapping_ret['FunctionArn'],
@@ -714,12 +717,12 @@ class BotoLambdaEventSourceMappingTestCase(BotoLambdaTestCaseBase, BotoLambdaTes
         '''
         tests False event_source_mapping not updated.
         '''
-        self.conn.update_event_source_mapping.side_effect=ClientError(error_content, 'update_event_source_mapping')
+        self.conn.update_event_source_mapping.side_effect = ClientError(error_content, 'update_event_source_mapping')
         result = boto_lambda.update_event_source_mapping(
                                           UUID=event_source_mapping_ret['UUID'],
                                           FunctionName=event_source_mapping_ret['FunctionArn'],
                                           **conn_parameters)
-        self.assertEqual(result.get('error',{}).get('message'), error_message.format('update_event_source_mapping'))
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('update_event_source_mapping'))
 
 
 if __name__ == '__main__':

--- a/tests/unit/modules/boto_lambda_test.py
+++ b/tests/unit/modules/boto_lambda_test.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-# TODO: Update skipped tests to expect dictionary results from the execution
-#       module functions.
-
 # Import Python libs
 from __future__ import absolute_import
 from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module
@@ -67,6 +64,18 @@ function_ret = dict(FunctionName='testfunction',
                     CodeSize=199,
                     FunctionArn='arn:lambda:us-east-1:1234:Something',
                     LastModified='yes')
+alias_ret = dict(AliasArn='arn:lambda:us-east-1:1234:Something',
+                 Name='testalias',
+                 FunctionVersion='3',
+                 Description='Alias description')
+event_source_mapping_ret = dict(UUID='1234-1-123',
+                                BatchSize=123,
+                                EventSourceArn='arn:lambda:us-east-1:1234:Something',
+                                FunctionArn='arn:lambda:us-east-1:1234:Something',
+                                LastModified='yes',
+                                LastProcessingResult='SUCCESS',
+                                State='Enabled',
+                                StateTransitionReason='Random')
 
 log = logging.getLogger(__name__)
 
@@ -237,7 +246,7 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         '''
         tests True function deleted.
         '''
-        with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}), TempZipFile() as zipfile:
+        with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
             result = boto_lambda.delete_function(FunctionName='testfunction',
                                                     Qualifier=1,
                                                     **conn_parameters)
@@ -379,6 +388,339 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
             result = boto_lambda.list_function_versions(FunctionName='testfunction',
                                                     **conn_parameters)
         self.assertEqual(result.get('error',{}).get('message'), error_message.format('list_versions_by_function'))
+
+
+@skipIf(HAS_BOTO is False, 'The boto module must be installed.')
+@skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
+                                       ' or equal to version {0}'
+        .format(required_boto3_version))
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class BotoLambdaAliasTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin):
+    '''
+    TestCase for salt.modules.boto_lambda module aliases
+    '''
+    def test_that_when_creating_an_alias_succeeds_the_create_alias_method_returns_true(self):
+        '''
+        tests True alias created.
+        '''
+        self.conn.create_alias.return_value=alias_ret
+        result = boto_lambda.create_alias(FunctionName='testfunction',
+                                                    Name=alias_ret['Name'],
+                                                    FunctionVersion=alias_ret['FunctionVersion'],
+                                                    **conn_parameters)
+
+        self.assertTrue(result['created'])
+
+    def test_that_when_creating_an_alias_fails_the_create_alias_method_returns_error(self):
+        '''
+        tests False alias not created.
+        '''
+        self.conn.create_alias.side_effect=ClientError(error_content, 'create_alias')
+        result = boto_lambda.create_alias(FunctionName='testfunction',
+                                                    Name=alias_ret['Name'],
+                                                    FunctionVersion=alias_ret['FunctionVersion'],
+                                                    **conn_parameters)
+        self.assertEqual(result.get('error',{}).get('message'), error_message.format('create_alias'))
+
+    def test_that_when_deleting_an_alias_succeeds_the_delete_alias_method_returns_true(self):
+        '''
+        tests True alias deleted.
+        '''
+        result = boto_lambda.delete_alias(FunctionName='testfunction',
+                                          Name=alias_ret['Name'],
+                                          **conn_parameters)
+
+        self.assertTrue(result['deleted'])
+
+    def test_that_when_deleting_an_alias_fails_the_delete_alias_method_returns_false(self):
+        '''
+        tests False alias not deleted.
+        '''
+        self.conn.delete_alias.side_effect=ClientError(error_content, 'delete_alias')
+        result = boto_lambda.delete_alias(FunctionName='testfunction',
+                                          Name=alias_ret['Name'],
+                                          **conn_parameters)
+        self.assertFalse(result['deleted'])
+
+    def test_that_when_checking_if_an_alias_exists_and_the_alias_exists_the_alias_exists_method_returns_true(self):
+        '''
+        Tests checking lambda alias existence when the lambda alias already exists
+        '''
+        self.conn.list_aliases.return_value={'Aliases': [alias_ret]}
+        result = boto_lambda.alias_exists(FunctionName='testfunction',
+                                          Name=alias_ret['Name'], 
+                                          **conn_parameters)
+        self.assertTrue(result['exists'])
+
+    def test_that_when_checking_if_an_alias_exists_and_the_alias_does_not_exist_the_alias_exists_method_returns_false(self):
+        '''
+        Tests checking lambda alias existence when the lambda alias does not exist
+        '''
+        self.conn.list_aliases.return_value={'Aliases': [alias_ret]}
+        result = boto_lambda.alias_exists(FunctionName='testfunction',
+                                          Name='otheralias',
+                                          **conn_parameters)
+
+        self.assertFalse(result['exists'])
+
+    def test_that_when_checking_if_an_alias_exists_and_boto3_returns_an_error_the_alias_exists_method_returns_error(self):
+        '''
+        Tests checking lambda alias existence when boto returns an error
+        '''
+        self.conn.list_aliases.side_effect=ClientError(error_content, 'list_aliases')
+        result = boto_lambda.alias_exists(FunctionName='testfunction',
+                                          Name=alias_ret['Name'], 
+                                          **conn_parameters)
+
+        self.assertEqual(result.get('error',{}).get('message'), error_message.format('list_aliases'))
+
+    def test_that_when_describing_alias_it_returns_the_dict_of_properties_returns_true(self):
+        '''
+        Tests describing parameters if alias exists
+        '''
+        self.conn.list_aliases.return_value={'Aliases': [alias_ret]}
+
+        result = boto_lambda.describe_alias(FunctionName='testfunction',
+                                            Name=alias_ret['Name'],
+                                            **conn_parameters)
+
+        self.assertEqual(result, { 'alias': alias_ret })
+
+    def test_that_when_describing_alias_it_returns_the_dict_of_properties_returns_false(self):
+        '''
+        Tests describing parameters if alias does not exist
+        '''
+        self.conn.list_aliases.return_value={'Aliases': [alias_ret]}
+        result = boto_lambda.describe_alias(FunctionName='testfunction', 
+                                            Name='othername',
+                                            **conn_parameters)
+
+        self.assertFalse(result['alias'])
+
+    def test_that_when_describing_lambda_on_client_error_it_returns_error(self):
+        '''
+        Tests describing parameters failure
+        '''
+        self.conn.list_aliases.side_effect=ClientError(error_content, 'list_aliases')
+        result = boto_lambda.describe_alias(FunctionName='testfunction', 
+                                            Name=alias_ret['Name'],
+                                            **conn_parameters)
+        self.assertTrue('error' in result)
+
+    def test_that_when_updating_an_alias_succeeds_the_update_alias_method_returns_true(self):
+        '''
+        tests True alias updated.
+        '''
+        self.conn.update_alias.return_value=alias_ret
+        result = boto_lambda.update_alias(FunctionName='testfunctoin',
+                                          Name=alias_ret['Name'],
+                                          Description=alias_ret['Description'],
+                                          **conn_parameters)
+
+        self.assertTrue(result['updated'])
+
+    def test_that_when_updating_an_alias_fails_the_update_alias_method_returns_error(self):
+        '''
+        tests False alias not updated.
+        '''
+        self.conn.update_alias.side_effect=ClientError(error_content, 'update_alias')
+        result = boto_lambda.update_alias(FunctionName='testfunction',
+                                          Name=alias_ret['Name'],
+                                          **conn_parameters)
+        self.assertEqual(result.get('error',{}).get('message'), error_message.format('update_alias'))
+
+
+@skipIf(HAS_BOTO is False, 'The boto module must be installed.')
+@skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
+                                       ' or equal to version {0}'
+        .format(required_boto3_version))
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class BotoLambdaEventSourceMappingTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin):
+    '''
+    TestCase for salt.modules.boto_lambda module mappings
+    '''
+    def test_that_when_creating_a_mapping_succeeds_the_create_event_source_mapping_method_returns_true(self):
+        '''
+        tests True mapping created.
+        '''
+        self.conn.create_event_source_mapping.return_value=event_source_mapping_ret
+        result = boto_lambda.create_event_source_mapping(
+                      EventSourceArn=event_source_mapping_ret['EventSourceArn'],
+                      FunctionName=event_source_mapping_ret['FunctionArn'],
+                      StartingPosition='LATEST',
+                      **conn_parameters)
+
+        self.assertTrue(result['created'])
+
+    def test_that_when_creating_an_event_source_mapping_fails_the_create_event_source_mapping_method_returns_error(self):
+        '''
+        tests False mapping not created.
+        '''
+        self.conn.create_event_source_mapping.side_effect=ClientError(error_content, 'create_event_source_mapping')
+        result = boto_lambda.create_event_source_mapping(
+                      EventSourceArn=event_source_mapping_ret['EventSourceArn'],
+                      FunctionName=event_source_mapping_ret['FunctionArn'],
+                      StartingPosition='LATEST',
+                      **conn_parameters)
+        self.assertEqual(result.get('error',{}).get('message'),
+                         error_message.format('create_event_source_mapping'))
+
+    def test_that_when_listing_mapping_ids_succeeds_the_get_event_source_mapping_ids_method_returns_true(self):
+        '''
+        tests True mapping ids listed.
+        '''
+        self.conn.list_event_source_mappings.return_value={'EventSourceMappings': [event_source_mapping_ret]}
+        result = boto_lambda.get_event_source_mapping_ids(
+                      EventSourceArn=event_source_mapping_ret['EventSourceArn'],
+                      FunctionName=event_source_mapping_ret['FunctionArn'],
+                      **conn_parameters)
+
+        self.assertTrue(result)
+
+    def test_that_when_listing_event_source_mapping_ids_fails_the_get_event_source_mapping_ids_versions_method_returns_false(self):
+        '''
+        tests False no mapping ids listed.
+        '''
+        self.conn.list_event_source_mappings.return_value={'EventSourceMappings': [ ]}
+        result = boto_lambda.get_event_source_mapping_ids(
+                      EventSourceArn=event_source_mapping_ret['EventSourceArn'],
+                      FunctionName=event_source_mapping_ret['FunctionArn'],
+                      **conn_parameters)
+        self.assertFalse(result)
+
+    def test_that_when_listing_event_source_mapping_ids_fails_the_get_event_source_mapping_ids_method_returns_error(self):
+        '''
+        tests False mapping ids error.
+        '''
+        self.conn.list_event_source_mappings.side_effect=ClientError(error_content, 'list_event_source_mappings')
+        result = boto_lambda.get_event_source_mapping_ids(
+                      EventSourceArn=event_source_mapping_ret['EventSourceArn'],
+                      FunctionName=event_source_mapping_ret['FunctionArn'],
+                      **conn_parameters)
+        self.assertEqual(result.get('error',{}).get('message'), error_message.format('list_event_source_mappings'))
+
+    def test_that_when_deleting_an_event_source_mapping_by_UUID_succeeds_the_delete_event_source_mapping_method_returns_true(self):
+        '''
+        tests True mapping deleted.
+        '''
+        result = boto_lambda.delete_event_source_mapping(
+                                          UUID=event_source_mapping_ret['UUID'],
+                                          **conn_parameters)
+        self.assertTrue(result['deleted'])
+
+    def test_that_when_deleting_an_event_source_mapping_by_name_succeeds_the_delete_event_source_mapping_method_returns_true(self):
+        '''
+        tests True mapping deleted.
+        '''
+        self.conn.list_event_source_mappings.return_value={'EventSourceMappings': [event_source_mapping_ret]}
+        result = boto_lambda.delete_event_source_mapping(
+                             EventSourceArn=event_source_mapping_ret['EventSourceArn'],
+                             FunctionName=event_source_mapping_ret['FunctionArn'],
+                             **conn_parameters)
+        self.assertTrue(result['deleted'])
+
+    def test_that_when_deleting_an_event_source_mapping_without_identifier_the_delete_event_source_mapping_method_raises_saltinvocationexception(self):
+        '''
+        tests Deleting a mapping without identifier
+        '''
+        with self.assertRaisesRegexp(SaltInvocationError,
+                                     'Either UUID must be specified, or EventSourceArn and FunctionName must be provided.'):
+            result = boto_lambda.delete_event_source_mapping(**conn_parameters)
+
+    def test_that_when_deleting_an_event_source_mapping_fails_the_delete_event_source_mapping_method_returns_false(self):
+        '''
+        tests False mapping not deleted.
+        '''
+        self.conn.delete_event_source_mapping.side_effect=ClientError(error_content, 'delete_event_source_mapping')
+        result = boto_lambda.delete_event_source_mapping(UUID=event_source_mapping_ret['UUID'],
+                                          **conn_parameters)
+        self.assertFalse(result['deleted'])
+
+    def test_that_when_checking_if_an_event_source_mapping_exists_and_the_event_source_mapping_exists_the_event_source_mapping_exists_method_returns_true(self):
+        '''
+        Tests checking lambda event_source_mapping existence when the lambda
+        event_source_mapping already exists
+        '''
+        self.conn.get_event_source_mapping.return_value=event_source_mapping_ret
+        result = boto_lambda.event_source_mapping_exists(
+                                          UUID=event_source_mapping_ret['UUID'],
+                                          **conn_parameters)
+        self.assertTrue(result['exists'])
+
+    def test_that_when_checking_if_an_event_source_mapping_exists_and_the_event_source_mapping_does_not_exist_the_event_source_mapping_exists_method_returns_false(self):
+        '''
+        Tests checking lambda event_source_mapping existence when the lambda
+        event_source_mapping does not exist
+        '''
+        self.conn.get_event_source_mapping.return_value=None
+        result = boto_lambda.event_source_mapping_exists(
+                                          UUID='other_UUID',
+                                          **conn_parameters)
+        self.assertFalse(result['exists'])
+
+    def test_that_when_checking_if_an_event_source_mapping_exists_and_boto3_returns_an_error_the_event_source_mapping_exists_method_returns_error(self):
+        '''
+        Tests checking lambda event_source_mapping existence when boto returns an error
+        '''
+        self.conn.get_event_source_mapping.side_effect=ClientError(error_content, 'list_event_source_mappings')
+        result = boto_lambda.event_source_mapping_exists(
+                                          UUID=event_source_mapping_ret['UUID'],
+                                          **conn_parameters)
+        self.assertEqual(result.get('error',{}).get('message'), error_message.format('list_event_source_mappings'))
+
+    def test_that_when_describing_event_source_mapping_it_returns_the_dict_of_properties_returns_true(self):
+        '''
+        Tests describing parameters if event_source_mapping exists
+        '''
+        self.conn.get_event_source_mapping.return_value=event_source_mapping_ret
+        result = boto_lambda.describe_event_source_mapping(
+                                          UUID=event_source_mapping_ret['UUID'],
+                                          **conn_parameters)
+        self.assertEqual(result, { 'event_source_mapping': event_source_mapping_ret })
+
+    def test_that_when_describing_event_source_mapping_it_returns_the_dict_of_properties_returns_false(self):
+        '''
+        Tests describing parameters if event_source_mapping does not exist
+        '''
+        self.conn.get_event_source_mapping.return_value=None
+        result = boto_lambda.describe_event_source_mapping(
+                                          UUID=event_source_mapping_ret['UUID'],
+                                          **conn_parameters)
+        self.assertFalse(result['event_source_mapping'])
+
+    def test_that_when_describing_event_source_mapping_on_client_error_it_returns_error(self):
+        '''
+        Tests describing parameters failure
+        '''
+        self.conn.get_event_source_mapping.side_effect=ClientError(error_content, 'get_event_source_mapping')
+        result = boto_lambda.describe_event_source_mapping(
+                                          UUID=event_source_mapping_ret['UUID'],
+                                          **conn_parameters)
+        self.assertTrue('error' in result)
+
+    def test_that_when_updating_an_event_source_mapping_succeeds_the_update_event_source_mapping_method_returns_true(self):
+        '''
+        tests True event_source_mapping updated.
+        '''
+        self.conn.update_event_source_mapping.return_value=event_source_mapping_ret
+        result = boto_lambda.update_event_source_mapping(
+                                          UUID=event_source_mapping_ret['UUID'],
+                                          FunctionName=event_source_mapping_ret['FunctionArn'],
+                                          **conn_parameters)
+
+        self.assertTrue(result['updated'])
+
+    def test_that_when_updating_an_event_source_mapping_fails_the_update_event_source_mapping_method_returns_error(self):
+        '''
+        tests False event_source_mapping not updated.
+        '''
+        self.conn.update_event_source_mapping.side_effect=ClientError(error_content, 'update_event_source_mapping')
+        result = boto_lambda.update_event_source_mapping(
+                                          UUID=event_source_mapping_ret['UUID'],
+                                          FunctionName=event_source_mapping_ret['FunctionArn'],
+                                          **conn_parameters)
+        self.assertEqual(result.get('error',{}).get('message'), error_message.format('update_event_source_mapping'))
+
 
 if __name__ == '__main__':
     from integration import run_tests  # pylint: disable=import-error

--- a/tests/unit/modules/boto_lambda_test.py
+++ b/tests/unit/modules/boto_lambda_test.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+
+# TODO: Update skipped tests to expect dictionary results from the execution
+#       module functions.
+
+# Import Python libs
+from __future__ import absolute_import
+from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module
+
+# Import Salt Testing libs
+from salttesting.unit import skipIf, TestCase
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, patch
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+# Import Salt libs
+import salt.config
+import salt.loader
+from salt.modules import boto_lambda
+from salt.exceptions import SaltInvocationError, CommandExecutionError
+
+# Import 3rd-party libs
+import salt.ext.six as six
+from tempfile import NamedTemporaryFile
+import logging
+
+# Import Mock libraries
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch, call
+
+# pylint: disable=import-error,no-name-in-module
+try:
+    import boto3
+    from botocore.exceptions import ClientError
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+
+# pylint: enable=import-error,no-name-in-module
+
+# the boto_lambda module relies on the connect_to_region() method
+# which was added in boto 2.8.0
+# https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
+required_boto3_version = '1.2.1'
+
+region = 'us-east-1'
+access_key = 'GKTADJGHEIQSXMKKRBJ08H'
+secret_key = 'askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs'
+conn_parameters = {'region': region, 'key': access_key, 'keyid': secret_key, 'profile': {}}
+error_message = 'An error occurred (101) when calling the {0} operation: Test-defined error'
+error_content = {
+  'Error': {
+    'Code': 101,
+    'Message': "Test-defined error"
+  }
+}
+#cidr_block = '10.0.0.0/24'
+#dhcp_options_parameters = {'domain_name': 'example.com', 'domain_name_servers': ['1.2.3.4'], 'ntp_servers': ['5.6.7.8'],
+#                           'netbios_name_servers': ['10.0.0.1'], 'netbios_node_type': 2}
+#network_acl_entry_parameters = ('fake', 100, -1, 'allow', cidr_block)
+#dhcp_options_parameters.update(conn_parameters)
+
+log = logging.getLogger(__name__)
+
+opts = salt.config.DEFAULT_MINION_OPTS
+context = {}
+utils = salt.loader.utils(opts, whitelist=['boto3'], context=context)
+
+boto_lambda.__utils__ = utils
+boto_lambda.__init__(opts)
+boto_lambda.__salt__ = {}
+
+
+def _has_required_boto():
+    '''
+    Returns True/False boolean depending on if Boto is installed and correct
+    version.
+    '''
+    if not HAS_BOTO:
+        return False
+    elif LooseVersion(boto3.__version__) < LooseVersion(required_boto3_version):
+        return False
+    else:
+        return True
+
+class BotoLambdaTestCaseBase(TestCase):
+    conn = None
+
+    # Set up MagicMock to replace the boto3 session
+    def setUp(self):
+        global context
+        context.clear()
+
+        self.patcher = patch('boto3.session.Session')
+        self.addCleanup(self.patcher.stop)
+        mock_session = self.patcher.start()
+
+        session_instance = mock_session.return_value
+        self.conn = MagicMock()
+        session_instance.client.return_value = self.conn
+
+
+class BotoLambdaTestCaseMixin(object):
+    zipfile = None
+
+    def _create_zipfile(self):
+        '''
+        Helper function to create an example zipfile
+        '''
+        if not self.zipfile:
+            with NamedTemporaryFile(suffix='.zip', prefix='salt_test_', delete=False) as tmp:
+            	tmp.write('###\n')
+            	self.zipfile = tmp.name
+
+        return self.zipfile
+
+
+@skipIf(HAS_BOTO is False, 'The boto module must be installed.')
+@skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
+                                       ' or equal to version {0}'
+        .format(required_boto3_version))
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class BotoLambdaTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin):
+    '''
+    TestCase for salt.modules.boto_lambda module
+    '''
+
+    def test_that_when_checking_if_a_function_exists_and_a_function_exists_the_function_exists_method_returns_true(self):
+        '''
+        Tests checking lambda function existence when the lambda function already exists
+        '''
+        self.conn.list_functions.return_value={'Functions': [{'FunctionName': 'myfunc'}]}
+        func_exists_result = boto_lambda.function_exists(FunctionName='myfunc', **conn_parameters)
+
+        self.assertTrue(func_exists_result['exists'])
+
+    def test_that_when_checking_if_a_function_exists_and_a_function_does_not_exist_the_function_exists_method_returns_false(self):
+        '''
+        Tests checking lambda function existence when the lambda function does not exist
+        '''
+        self.conn.list_functions.return_value={'Functions': [{'FunctionName': 'otherfunc'}]}
+        func_exists_result = boto_lambda.function_exists(FunctionName='myfunc', **conn_parameters)
+
+        self.assertFalse(func_exists_result['exists'])
+
+    def test_that_when_checking_if_a_function_exists_and_boto3_returns_an_error_the_function_exists_method_returns_error(self):
+        '''
+        Tests checking lambda function existence when boto returns an error
+        '''
+        self.conn.list_functions.side_effect=ClientError(error_content, 'list_functions')
+        func_exists_result = boto_lambda.function_exists(FunctionName='myfunc', **conn_parameters)
+
+        self.assertEqual(func_exists_result.get('error',{}).get('message'), error_message.format('list_functions'))
+
+    def test_that_when_creating_a_function_succeeds_the_create_function_method_returns_true(self):
+        '''
+        tests True function created.
+        '''
+        with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
+            self.conn.create_function.return_value={'FunctionName': 'testfunction'}
+            lambda_creation_result = boto_lambda.create_function(FunctionName='testfunction',
+                                                    Runtime='python2.7',
+                                                    Role='myrole',
+                                                    Handler='file.method',
+                                                    ZipFile=self._create_zipfile(),
+                                                    **conn_parameters)
+
+        self.assertTrue(lambda_creation_result['created'])
+
+    def test_that_when_creating_a_function_succeeds_the_create_function_method_returns_error(self):
+        '''
+        tests True function created.
+        '''
+        with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
+            self.conn.create_function.side_effect=ClientError(error_content, 'create_function')
+            lambda_creation_result = boto_lambda.create_function(FunctionName='testfunction',
+                                                    Runtime='python2.7',
+                                                    Role='myrole',
+                                                    Handler='file.method',
+                                                    ZipFile=self._create_zipfile(),
+                                                    **conn_parameters)
+        self.assertEqual(lambda_creation_result.get('error',{}).get('message'), error_message.format('create_function'))
+
+if __name__ == '__main__':
+    from integration import run_tests  # pylint: disable=import-error
+    run_tests(BotoLambdaTestCase, needs_daemon=False)

--- a/tests/unit/modules/boto_lambda_test.py
+++ b/tests/unit/modules/boto_lambda_test.py
@@ -115,7 +115,7 @@ class BotoLambdaTestCaseBase(TestCase):
         session_instance.client.return_value = self.conn
 
 
-class TempZipFile:
+class TempZipFile(object):
     def __enter__(self):
         with NamedTemporaryFile(suffix='.zip', prefix='salt_test_', delete=False) as tmp:
             tmp.write('###\n')
@@ -280,7 +280,7 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         '''
         Tests describing parameters if function does not exist
         '''
-        self.conn.list_functions.return_value = { 'Functions': []}
+        self.conn.list_functions.return_value = {'Functions': []}
         with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
             result = boto_lambda.describe_function(FunctionName='testfunction', **conn_parameters)
 
@@ -472,7 +472,7 @@ class BotoLambdaAliasTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin):
         '''
         self.conn.list_aliases.side_effect = ClientError(error_content, 'list_aliases')
         result = boto_lambda.alias_exists(FunctionName='testfunction',
-                                          Name=alias_ret['Name'], 
+                                          Name=alias_ret['Name'],
                                           **conn_parameters)
 
         self.assertEqual(result.get('error', {}).get('message'), error_message.format('list_aliases'))
@@ -494,7 +494,7 @@ class BotoLambdaAliasTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin):
         Tests describing parameters if alias does not exist
         '''
         self.conn.list_aliases.return_value = {'Aliases': [alias_ret]}
-        result = boto_lambda.describe_alias(FunctionName='testfunction', 
+        result = boto_lambda.describe_alias(FunctionName='testfunction',
                                             Name='othername',
                                             **conn_parameters)
 
@@ -505,7 +505,7 @@ class BotoLambdaAliasTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin):
         Tests describing parameters failure
         '''
         self.conn.list_aliases.side_effect = ClientError(error_content, 'list_aliases')
-        result = boto_lambda.describe_alias(FunctionName='testfunction', 
+        result = boto_lambda.describe_alias(FunctionName='testfunction',
                                             Name=alias_ret['Name'],
                                             **conn_parameters)
         self.assertTrue('error' in result)
@@ -727,4 +727,4 @@ class BotoLambdaEventSourceMappingTestCase(BotoLambdaTestCaseBase, BotoLambdaTes
 
 if __name__ == '__main__':
     from integration import run_tests  # pylint: disable=import-error
-    run_tests(BotoLambdaTestCase, needs_daemon=False)
+    run_tests(BotoLambdaFunctionTestCase, needs_daemon=False)

--- a/tests/unit/states/boto_lambda_test.py
+++ b/tests/unit/states/boto_lambda_test.py
@@ -149,11 +149,11 @@ class BotoLambdaFunctionTestCase(BotoLambdaStateTestCaseBase, BotoLambdaTestCase
         with patch.dict(funcs, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
             with TempZipFile() as zipfile:
                 with patch('hashlib.sha256') as sha256:
-                    with patch('os.path.getsize',return_value=199):
+                    with patch('os.path.getsize', return_value=199):
                         sha = sha256()
                         digest = sha.digest()
                         encoded = sha.encode()
-                        encoded.strip.return_value=function_ret['CodeSha256']
+                        encoded.strip.return_value = function_ret['CodeSha256']
                         result = salt_states['boto_lambda.function_present'](
                                      'function present',
                                      FunctionName=function_ret['FunctionName'],
@@ -172,7 +172,7 @@ class BotoLambdaFunctionTestCase(BotoLambdaStateTestCaseBase, BotoLambdaTestCase
         with patch.dict(funcs, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
             with TempZipFile() as zipfile:
                 with patch('hashlib.sha256') as sha256:
-                    with patch('os.path.getsize',return_value=199):
+                    with patch('os.path.getsize', return_value=199):
                         sha = sha256()
                         digest = sha.digest()
                         encoded = sha.encode()

--- a/tests/unit/states/boto_lambda_test.py
+++ b/tests/unit/states/boto_lambda_test.py
@@ -69,8 +69,8 @@ alias_ret = dict(AliasArn='arn:lambda:us-east-1:1234:Something',
                  Description='Alias description')
 event_source_mapping_ret = dict(UUID='1234-1-123',
                                 BatchSize=123,
-                                EventSourceArn='arn:lambda:us-east-1:1234:Something',
-                                FunctionArn='arn:lambda:us-east-1:1234:Something',
+                                EventSourceArn='arn:aws:dynamodb:us-east-1:1234::Something',
+                                FunctionArn='arn:aws:lambda:us-east-1:1234:function:myfunc',
                                 LastModified='yes',
                                 LastProcessingResult='SUCCESS',
                                 State='Enabled',
@@ -329,7 +329,7 @@ class BotoLambdaEventSourceMappingTestCase(BotoLambdaStateTestCaseBase, BotoLamb
         result = salt_states['boto_lambda.event_source_mapping_present'](
                          'event source mapping present',
                          EventSourceArn=event_source_mapping_ret['EventSourceArn'],
-                         FunctionName='myfunc',
+                         FunctionName=event_source_mapping_ret['FunctionArn'],
                          StartingPosition='LATEST',
                          BatchSize=event_source_mapping_ret['BatchSize'])
         self.assertTrue(result['result'])
@@ -342,7 +342,7 @@ class BotoLambdaEventSourceMappingTestCase(BotoLambdaStateTestCaseBase, BotoLamb
         result = salt_states['boto_lambda.event_source_mapping_present'](
                          'event source mapping present',
                          EventSourceArn=event_source_mapping_ret['EventSourceArn'],
-                         FunctionName='myfunc',
+                         FunctionName=event_source_mapping_ret['FunctionArn'],
                          StartingPosition='LATEST',
                          BatchSize=event_source_mapping_ret['BatchSize'])
         self.assertFalse(result['result'])

--- a/tests/unit/states/boto_lambda_test.py
+++ b/tests/unit/states/boto_lambda_test.py
@@ -1,0 +1,384 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+from __future__ import absolute_import
+from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module
+
+# Import Salt Testing libs
+from salttesting.unit import skipIf, TestCase
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, patch
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+# Import Salt libs
+import salt.config
+import salt.loader
+from salt.exceptions import SaltInvocationError, CommandExecutionError
+
+# Import 3rd-party libs
+import salt.ext.six as six
+import logging
+
+# Import Mock libraries
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch, call
+
+# pylint: disable=import-error,no-name-in-module
+from unit.modules.boto_lambda_test import BotoLambdaTestCaseMixin, TempZipFile
+
+# Import 3rd-party libs
+try:
+    import boto3
+    from botocore.exceptions import ClientError
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+
+# pylint: enable=import-error,no-name-in-module
+
+# the boto_lambda module relies on the connect_to_region() method
+# which was added in boto 2.8.0
+# https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
+required_boto3_version = '1.2.1'
+
+region = 'us-east-1'
+access_key = 'GKTADJGHEIQSXMKKRBJ08H'
+secret_key = 'askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs'
+conn_parameters = {'region': region, 'key': access_key, 'keyid': secret_key, 'profile': {}}
+error_message = 'An error occurred (101) when calling the {0} operation: Test-defined error'
+error_content = {
+  'Error': {
+    'Code': 101,
+    'Message': "Test-defined error"
+  }
+}
+function_ret = dict(FunctionName='testfunction',
+                    Runtime='python2.7',
+                    Role='arn:aws:iam::1234:role/functionrole',
+                    Handler='handler',
+                    Description='abcdefg',
+                    Timeout=5,
+                    MemorySize=128,
+                    CodeSha256='abcdef',
+                    CodeSize=199,
+                    FunctionArn='arn:lambda:us-east-1:1234:Something',
+                    LastModified='yes')
+alias_ret = dict(AliasArn='arn:lambda:us-east-1:1234:Something',
+                 Name='testalias',
+                 FunctionVersion='3',
+                 Description='Alias description')
+event_source_mapping_ret = dict(UUID='1234-1-123',
+                                BatchSize=123,
+                                EventSourceArn='arn:lambda:us-east-1:1234:Something',
+                                FunctionArn='arn:lambda:us-east-1:1234:Something',
+                                LastModified='yes',
+                                LastProcessingResult='SUCCESS',
+                                State='Enabled',
+                                StateTransitionReason='Random')
+
+log = logging.getLogger(__name__)
+
+opts = salt.config.DEFAULT_MINION_OPTS
+context = {}
+utils = salt.loader.utils(opts, whitelist=['boto3'], context=context)
+serializers = salt.loader.serializers(opts)
+funcs = salt.loader.minion_mods(opts, context=context, utils=utils, whitelist=['boto_lambda'])
+salt_states = salt.loader.states(opts=opts, functions=funcs, utils=utils, whitelist=['boto_lambda'], serializers=serializers)
+
+
+def _has_required_boto():
+    '''
+    Returns True/False boolean depending on if Boto is installed and correct
+    version.
+    '''
+    if not HAS_BOTO:
+        return False
+    elif LooseVersion(boto3.__version__) < LooseVersion(required_boto3_version):
+        return False
+    else:
+        return True
+
+class BotoLambdaStateTestCaseBase(TestCase):
+    conn = None
+
+    # Set up MagicMock to replace the boto3 session
+    def setUp(self):
+        global context
+        context.clear()
+
+        self.patcher = patch('boto3.session.Session')
+        self.addCleanup(self.patcher.stop)
+        mock_session = self.patcher.start()
+
+        session_instance = mock_session.return_value
+        self.conn = MagicMock()
+        session_instance.client.return_value = self.conn
+
+
+
+@skipIf(HAS_BOTO is False, 'The boto module must be installed.')
+@skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
+                                       ' or equal to version {0}'
+        .format(required_boto3_version))
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class BotoLambdaFunctionTestCase(BotoLambdaStateTestCaseBase, BotoLambdaTestCaseMixin):
+    '''
+    TestCase for salt.modules.boto_lambda state.module
+    '''
+
+    def test_present_when_function_does_not_exist(self):
+        '''
+        Tests present on a function that does not exist.
+        '''
+        self.conn.list_functions.side_effect=[{'Functions': []}, { 'Functions': [ function_ret ]}]
+        self.conn.create_function.return_value=function_ret
+        with patch.dict(funcs, {'boto_iam.get_account_id': MagicMock(return_value='1234')}), TempZipFile() as zipfile:
+            result = salt_states['boto_lambda.function_present'](
+                         'function present',
+                         FunctionName=function_ret['FunctionName'],
+                         Runtime=function_ret['Runtime'],
+                         Role=function_ret['Role'],
+                         Handler=function_ret['Handler'],
+                         ZipFile=zipfile)
+
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes']['new']['function']['FunctionName'],
+                         function_ret['FunctionName'])
+
+    def test_present_when_function_exists(self):
+        self.conn.list_functions.return_value={ 'Functions': [ function_ret ]}
+        self.conn.update_function_code.return_value=function_ret
+        with patch.dict(funcs, {'boto_iam.get_account_id': MagicMock(return_value='1234')}), \
+                TempZipFile() as zipfile, \
+                patch('hashlib.sha256') as sha256, \
+                patch('os.path.getsize',return_value=199):
+            sha = sha256()
+            digest = sha.digest()
+            encoded = sha.encode()
+            encoded.strip.return_value=function_ret['CodeSha256']
+            result = salt_states['boto_lambda.function_present'](
+                         'function present',
+                         FunctionName=function_ret['FunctionName'],
+                         Runtime=function_ret['Runtime'],
+                         Role=function_ret['Role'],
+                         Handler=function_ret['Handler'],
+                         ZipFile=zipfile,
+                         Description=function_ret['Description'],
+                         Timeout=function_ret['Timeout'])
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes'], {})
+
+    def test_present_with_failure(self):
+        self.conn.list_functions.side_effect=[{'Functions': []}, { 'Functions': [ function_ret ]}]
+        self.conn.create_function.side_effect=ClientError(error_content, 'create_function')
+        with patch.dict(funcs, {'boto_iam.get_account_id': MagicMock(return_value='1234')}), \
+                TempZipFile() as zipfile, \
+                patch('hashlib.sha256') as sha256, \
+                patch('os.path.getsize',return_value=199):
+            sha = sha256()
+            digest = sha.digest()
+            encoded = sha.encode()
+            encoded.strip.return_value=function_ret['CodeSha256']
+            result = salt_states['boto_lambda.function_present'](
+                         'function present',
+                         FunctionName=function_ret['FunctionName'],
+                         Runtime=function_ret['Runtime'],
+                         Role=function_ret['Role'],
+                         Handler=function_ret['Handler'],
+                         ZipFile=zipfile,
+                         Description=function_ret['Description'],
+                         Timeout=function_ret['Timeout'])
+        self.assertFalse(result['result'])
+        self.assertTrue('An error occurred' in result['comment'])
+
+    def test_absent_when_function_does_not_exist(self):
+        '''
+        Tests absent on a function that does not exist.
+        '''
+        self.conn.list_functions.return_value={ 'Functions': [ function_ret ]}
+        result = salt_states['boto_lambda.function_absent']('test', 'myfunc')
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes'], {})
+
+    def test_absent_when_function_exists(self):
+        self.conn.list_functions.return_value={ 'Functions': [ function_ret ]}
+        result = salt_states['boto_lambda.function_absent']('test', function_ret['FunctionName'])
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes']['new']['function'], None)
+
+    def test_absent_with_failure(self):
+        self.conn.list_functions.return_value={ 'Functions': [ function_ret ]}
+        self.conn.delete_function.side_effect=ClientError(error_content, 'delete_function')
+        result = salt_states['boto_lambda.function_absent']('test', function_ret['FunctionName'])
+        self.assertFalse(result['result'])
+        self.assertTrue('An error occurred' in result['comment'])
+
+
+@skipIf(HAS_BOTO is False, 'The boto module must be installed.')
+@skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
+                                       ' or equal to version {0}'
+        .format(required_boto3_version))
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class BotoLambdaAliasTestCase(BotoLambdaStateTestCaseBase, BotoLambdaTestCaseMixin):
+    '''
+    TestCase for salt.modules.boto_lambda state.module aliases
+    '''
+
+    def test_present_when_alias_does_not_exist(self):
+        '''
+        Tests present on a alias that does not exist.
+        '''
+        self.conn.list_aliases.side_effect=[{'Aliases': []}, { 'Aliases': [ alias_ret ]}]
+        self.conn.create_alias.return_value=alias_ret
+        result = salt_states['boto_lambda.alias_present'](
+                         'alias present',
+                         FunctionName='testfunc',
+                         Name=alias_ret['Name'],
+                         FunctionVersion=alias_ret['FunctionVersion'])
+
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes']['new']['alias']['Name'],
+                         alias_ret['Name'])
+
+    def test_present_when_alias_exists(self):
+        self.conn.list_aliases.return_value={ 'Aliases': [ alias_ret ]}
+        self.conn.create_alias.return_value=alias_ret
+        result = salt_states['boto_lambda.alias_present'](
+                         'alias present',
+                         FunctionName='testfunc',
+                         Name=alias_ret['Name'],
+                         FunctionVersion=alias_ret['FunctionVersion'],
+                         Description=alias_ret['Description'])
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes'], {})
+
+    def test_present_with_failure(self):
+        self.conn.list_aliases.side_effect=[{'Aliases': []}, { 'Aliases': [ alias_ret ]}]
+        self.conn.create_alias.side_effect=ClientError(error_content, 'create_alias')
+        result = salt_states['boto_lambda.alias_present'](
+                         'alias present',
+                         FunctionName='testfunc',
+                         Name=alias_ret['Name'],
+                         FunctionVersion=alias_ret['FunctionVersion'])
+        self.assertFalse(result['result'])
+        self.assertTrue('An error occurred' in result['comment'])
+
+    def test_absent_when_alias_does_not_exist(self):
+        '''
+        Tests absent on a alias that does not exist.
+        '''
+        self.conn.list_aliases.return_value={ 'Aliases': [ alias_ret ]}
+        result = salt_states['boto_lambda.alias_absent'](
+                         'alias absent',
+                         FunctionName='testfunc',
+                         Name='myalias')
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes'], {})
+
+    def test_absent_when_alias_exists(self):
+        self.conn.list_aliases.return_value={ 'Aliases': [ alias_ret ]}
+        result = salt_states['boto_lambda.alias_absent'](
+                         'alias absent',
+                         FunctionName='testfunc',
+                         Name=alias_ret['Name'])
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes']['new']['alias'], None)
+
+    def test_absent_with_failure(self):
+        self.conn.list_aliases.return_value={ 'Aliases': [ alias_ret ]}
+        self.conn.delete_alias.side_effect=ClientError(error_content, 'delete_alias')
+        result = salt_states['boto_lambda.alias_absent'](
+                         'alias absent',
+                         FunctionName='testfunc',
+                         Name=alias_ret['Name'])
+        self.assertFalse(result['result'])
+        self.assertTrue('An error occurred' in result['comment'])
+
+
+@skipIf(HAS_BOTO is False, 'The boto module must be installed.')
+@skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
+                                       ' or equal to version {0}'
+        .format(required_boto3_version))
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class BotoLambdaEventSourceMappingTestCase(BotoLambdaStateTestCaseBase, BotoLambdaTestCaseMixin):
+    '''
+    TestCase for salt.modules.boto_lambda state.module event_source_mappings
+    '''
+
+    def test_present_when_event_source_mapping_does_not_exist(self):
+        '''
+        Tests present on a event_source_mapping that does not exist.
+        '''
+        self.conn.list_event_source_mappings.side_effect=[{'EventSourceMappings': []}, { 'EventSourceMappings': [ event_source_mapping_ret ]}]
+        self.conn.get_event_source_mapping.return_value=event_source_mapping_ret
+        self.conn.create_event_source_mapping.return_value=event_source_mapping_ret
+        result = salt_states['boto_lambda.event_source_mapping_present'](
+                         'event source mapping present',
+                         EventSourceArn=event_source_mapping_ret['EventSourceArn'],
+                         FunctionName='myfunc',
+                         StartingPosition='LATEST')
+
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes']['new']['event_source_mapping']['UUID'],
+                         event_source_mapping_ret['UUID'])
+
+    def test_present_when_event_source_mapping_exists(self):
+        self.conn.list_event_source_mappings.return_value={ 'EventSourceMappings': [ event_source_mapping_ret ]}
+        self.conn.get_event_source_mapping.return_value=event_source_mapping_ret
+        self.conn.create_event_source_mapping.return_value=event_source_mapping_ret
+        result = salt_states['boto_lambda.event_source_mapping_present'](
+                         'event source mapping present',
+                         EventSourceArn=event_source_mapping_ret['EventSourceArn'],
+                         FunctionName='myfunc',
+                         StartingPosition='LATEST',
+                         BatchSize=event_source_mapping_ret['BatchSize'])
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes'], {})
+
+    def test_present_with_failure(self):
+        self.conn.list_event_source_mappings.side_effect=[{'EventSourceMappings': []}, { 'EventSourceMappings': [ event_source_mapping_ret ]}]
+        self.conn.get_event_source_mapping.return_value=event_source_mapping_ret
+        self.conn.create_event_source_mapping.side_effect=ClientError(error_content, 'create_event_source_mapping')
+        result = salt_states['boto_lambda.event_source_mapping_present'](
+                         'event source mapping present',
+                         EventSourceArn=event_source_mapping_ret['EventSourceArn'],
+                         FunctionName='myfunc',
+                         StartingPosition='LATEST',
+                         BatchSize=event_source_mapping_ret['BatchSize'])
+        self.assertFalse(result['result'])
+        self.assertTrue('An error occurred' in result['comment'])
+
+    def test_absent_when_event_source_mapping_does_not_exist(self):
+        '''
+        Tests absent on a event_source_mapping that does not exist.
+        '''
+        self.conn.list_event_source_mappings.return_value={ 'EventSourceMappings': [ ]}
+        result = salt_states['boto_lambda.event_source_mapping_absent'](
+                         'event source mapping absent',
+                         EventSourceArn=event_source_mapping_ret['EventSourceArn'],
+                         FunctionName='myfunc')
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes'], {})
+
+    def test_absent_when_event_source_mapping_exists(self):
+        self.conn.list_event_source_mappings.return_value={ 'EventSourceMappings': [ event_source_mapping_ret ]}
+        self.conn.get_event_source_mapping.return_value=event_source_mapping_ret
+        result = salt_states['boto_lambda.event_source_mapping_absent'](
+                         'event source mapping absent',
+                         EventSourceArn=event_source_mapping_ret['EventSourceArn'],
+                         FunctionName='myfunc')
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes']['new']['event_source_mapping'], None)
+
+    def test_absent_with_failure(self):
+        self.conn.list_event_source_mappings.return_value={ 'EventSourceMappings': [ event_source_mapping_ret ]}
+        self.conn.get_event_source_mapping.return_value=event_source_mapping_ret
+        self.conn.delete_event_source_mapping.side_effect=ClientError(error_content, 'delete_event_source_mapping')
+        result = salt_states['boto_lambda.event_source_mapping_absent'](
+                         'event source mapping absent',
+                         EventSourceArn=event_source_mapping_ret['EventSourceArn'],
+                         FunctionName='myfunc')
+        self.assertFalse(result['result'])
+        self.assertTrue('An error occurred' in result['comment'])
+
+


### PR DESCRIPTION
This adds a module and state module called boto_lambda, similar to the other boto_ modules, for support of Lambda.

There are a few notable aspects of this. The primary one is, there is no support in boto for Lambda, so this module is built on boto3. I expect that over time, there will be more AWS modules based on boto3 rather than boto 2.

Boto3 is a bit different from boto 2 in that it is a somewhat thinner wrapper over the AWS APIs. That's evident in the parameter and return value names - they follow Amazon's naming, rather than being python-ified.

In this implementation, I've chosen to use parameter names that match boto3. That way they're symmetric and match with the values returned in dictionaries that come from boto3. Also, that way they match Amazon's and boto3's documentation, making this module a bit easier to learn about and understand. The downside of this is, they're not consistent with the other boto_ modules that are based on boto 2, nor really salt as a whole. (They're camel case starting with a capital.) I felt that this would be the better precedent for future modules based on boto3, and possibly existing modules that are later updated to boto3. 

The alternatives would have been to have lowercase / underscore parameters that get camel case responses, or to write a mapping layer on top of boto3 to recursively iterate over returned dictionaries to make everything look more pythonic & consistent.

It seemed to me that the question of how the API looks in python should be left to the boto guys. I hope this design choice seems reasonable.

This is my first module contribution. I tried to follow policies and conventions as much as possible. Let me know if I missed something or got something wrong.
