### PR TITLE
Fix the 'cidr' arg in salt.modules.network.ip_addrs6()

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -917,7 +917,7 @@ def ip_addrs6(interface=None, include_loopback=False, cidr=None):
     addrs = salt.utils.network.ip_addrs6(interface=interface,
                                         include_loopback=include_loopback)
     if cidr:
-        return [i for i in addrs if salt.utils.network.ip_in_subnet(cidr, [i])]
+        return [i for i in addrs if salt.utils.network.in_subnet(cidr, [i])]
     else:
         return addrs
 


### PR DESCRIPTION
The two arguments to ip_in_subnet() should be swapped around, but
since ip_in_subnet() is being deprecated in favor of in_subnet(),
removing three characters seemed like the most appropiate bugfix.

This fixes #29585
