### PR TITLE
zypper: check package header content for valid utf-8

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -115,6 +115,11 @@ def info_installed(*names):
         t_nfo = dict()
         # Translate dpkg-specific keys to a common structure
         for key, value in pkg_nfo.items():
+            try:
+                value = value.encode('UTF-8', errors='replace')
+            except(UnicodeDecodeError):
+                log.error('Package {0} has bad UTF-8 code in {1}: {2}', pkg_name, key, value)                
+                value = '*** Bad UTF-8 ***'
             if key == 'source_rpm':
                 t_nfo['source'] = value
             else:


### PR DESCRIPTION
"salt 'system.domain.tld' pkg.info_installed --out json" can crash with

```
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
UnicodeDecodeError: 'utf8' codec can't decode byte ...
```

if a package name, summary, or description contains invalid UTF-8.

This patch detects such rpm header values, logs them as errors, and
replaces them with "**\* Bad UTF-8 ***".
