### PR TITLE
Fix orchestration failure-checking

### DIFF
--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -254,7 +254,7 @@ def state(
         if not m_state:
             if minion not in fail_minions:
                 fail.add(minion)
-            failures[minion] = m_ret and m_ret or 'Minion did not respond'
+            failures[minion] = m_ret or 'Minion did not respond'
             continue
         for state_item in six.itervalues(m_ret):
             if state_item['changes']:

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -248,7 +248,7 @@ def state(
                 m_ret = mdata['ret']
             except KeyError:
                 m_state = False
-            if not m_state:
+            if m_state:
                 m_state = salt.utils.check_state_result(m_ret)
 
         if not m_state:


### PR DESCRIPTION
Fixed an incorrect boolean that was skipping failure-checking for states in state.orchestrate.

This actually fixed both #29546 and #29586.

The mistake was a typo here: https://github.com/saltstack/salt/pull/28012

I also cleaned up an unnecessary `and m_ret` while I was there.
