### PR TITLE
Various ESXi Proxy Minion Bug Fixes

### DIFF
--- a/salt/proxy/esxi.py
+++ b/salt/proxy/esxi.py
@@ -245,6 +245,7 @@ def init(opts):
         return False
     if 'passwords' not in opts['proxy']:
         log.critical('No \'passwords\' key found in pillar for this proxy.')
+        return False
 
     host = opts['proxy']['host']
 

--- a/salt/states/esxi.py
+++ b/salt/states/esxi.py
@@ -254,7 +254,7 @@ def ntp_configured(name,
         Name of the state.
 
     service_running
-        Ensures the running state of the ntp deamon for the host. Boolean value where
+        Ensures the running state of the ntp daemon for the host. Boolean value where
         ``True`` indicates that ntpd should be running and ``False`` indicates that it
         should be stopped.
 
@@ -263,6 +263,14 @@ def ntp_configured(name,
 
     service_policy
         The policy to set for the NTP service.
+
+        .. note::
+
+            When setting the service policy to ``off`` or ``on``, you *must* quote the
+            setting. If you don't, the yaml parser will set the string to a boolean,
+            which will cause trouble checking for stateful changes and will error when
+            trying to set the policy on the ESXi host.
+
 
     service_restart
         If set to ``True``, the ntp daemon will be restarted, regardless of its previous
@@ -283,7 +291,7 @@ def ntp_configured(name,
             - ntp_servers:
               - 192.174.1.100
               - 192.174.1.200
-            - service_policy: 'automatic'
+            - service_policy: 'on'
             - service_restart: True
 
     '''
@@ -391,8 +399,8 @@ def ntp_configured(name,
                 ret['comment'] = 'Error: {0}'.format(error)
                 return ret
         ret['changes'].update({'service_restart':
-                              {'old': ntp_running,
-                               'new': 'NTP Deamon Restarted.'}})
+                              {'old': '',
+                               'new': 'NTP Daemon Restarted.'}})
 
     ret['result'] = True
     if ret['changes'] == {}:
@@ -550,10 +558,6 @@ def vsan_configured(name, enabled, add_disks_to_vsan=False):
 
         disks = current_eligible_disks.get('Eligible')
         if disks and isinstance(disks, list):
-            ret['changes'].update({'add_disks_to_vsan':
-                                  {'old': '',
-                                   'new': disks}})
-
             # Only run the command if not using test=True
             if not __opts__['test']:
                 response = __salt__[esxi_cmd]('vsan_add_disks').get(host)
@@ -561,6 +565,10 @@ def vsan_configured(name, enabled, add_disks_to_vsan=False):
                 if error:
                     ret['comment'] = 'Error: {0}'.format(error)
                     return ret
+
+            ret['changes'].update({'add_disks_to_vsan':
+                                  {'old': '',
+                                   'new': disks}})
 
     ret['result'] = True
     if ret['changes'] == {}:
@@ -607,6 +615,13 @@ def ssh_configured(name,
     service_policy
         The policy to set for the NTP service.
 
+        .. note::
+
+            When setting the service policy to ``off`` or ``on``, you *must* quote the
+            setting. If you don't, the yaml parser will set the string to a boolean,
+            which will cause trouble checking for stateful changes and will error when
+            trying to set the policy on the ESXi host.
+
     service_restart
         If set to ``True``, the SSH service will be restarted, regardless of its
         previous running state. Default is ``False``.
@@ -623,7 +638,7 @@ def ssh_configured(name,
           esxi.ssh_configured:
             - service_running: True
             - ssh_key_file: /etc/salt/ssh_keys/my_key.pub
-            - service_policy: 'automatic'
+            - service_policy: 'on'
             - service_restart: True
             - certificate_verify: True
 
@@ -748,7 +763,7 @@ def ssh_configured(name,
                 ret['comment'] = 'Error: {0}'.format(error)
                 return ret
         ret['changes'].update({'service_restart':
-                              {'old': ssh_running,
+                              {'old': '',
                                'new': 'SSH service restarted.'}})
 
     ret['result'] = True

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -80,20 +80,22 @@ def esxcli(host, user, pwd, cmd, protocol=None, port=None, esxi_host=None):
         # Then we are connecting directly to an ESXi server,
         # 'host' points at that server, and esxi_host is a reference to the
         # ESXi instance we are manipulating
-        esx_cmd += ' -s {0} -u {1} -p {2} --protocol={3} --portnumber={4} {5}'.format(host,
-                                                                                      user,
-                                                                                      pwd,
-                                                                                      protocol,
-                                                                                      port,
-                                                                                      cmd)
+        esx_cmd += ' -s {0} -u {1} -p \'{2}\' ' \
+                   '--protocol={3} --portnumber={4} {5}'.format(host,
+                                                                user,
+                                                                pwd,
+                                                                protocol,
+                                                                port,
+                                                                cmd)
     else:
-        esx_cmd += ' -s {0} -h {1} -u {2} -p {3} --protocol={4} --portnumber={5} {6}'.format(host,
-                                                                                             esxi_host,
-                                                                                             user,
-                                                                                             pwd,
-                                                                                             protocol,
-                                                                                             port,
-                                                                                             cmd)
+        esx_cmd += ' -s {0} -h {1} -u {2} -p \'{3}\' ' \
+                   '--protocol={4} --portnumber={5} {6}'.format(host,
+                                                                esxi_host,
+                                                                user,
+                                                                pwd,
+                                                                protocol,
+                                                                port,
+                                                                cmd)
 
     ret = salt.modules.cmdmod.run_all(esx_cmd)
 


### PR DESCRIPTION
Including, but not limited to:
- Quote ESXCLI password to handle password spaces
- Only return vsan disk names instead of disk objects for vsan funcs
- Add warning to quote "on" and "off" service policy states
- Catch vmodl.fault.SystemError Errors when resetting passwords
