### PR TITLE
fix yum repo check

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2065,6 +2065,8 @@ def _parse_repo_file(filename):
                         'Failed to parse line in {0}, offending line was '
                         '\'{1}\''.format(filename, line.rstrip())
                     )
+                if comps[0].strip() == 'enabled':
+                    repos[repo]['disabled'] = comps[1] != "1"
 
     return (header, repos)
 


### PR DESCRIPTION
The `enabled` parameter in `pkgrepo` has been replaced by `disabled`.
The `yumpkg.get_repo` function didn't report this key, so the check
failed.

Another way would be to change the `expand_repo_def` function to convert the `disabled=True` state parameter to the `enable=1` yum repository option.
