### PR TITLE
regular expression in specifiing targets salt-run survey.diff

### DIFF
--- a/salt/runners/survey.py
+++ b/salt/runners/survey.py
@@ -150,9 +150,13 @@ def _get_pool_results(*args, **kwargs):
     sort = kwargs.get('survey_sort', 'down')
     direction = sort != 'up'
 
+    expr_form = kwargs.get('expr_form', 'compound')
+    if expr_form not in ['compound', 'pcre']:
+        expr_form='compound'
+
     client = salt.client.get_local_client(__opts__['conf_file'])
     try:
-        minions = client.cmd(tgt, cmd, args[2:], timeout=__opts__['timeout'], expr_form='compound')
+        minions = client.cmd(tgt, cmd, args[2:], timeout=__opts__['timeout'], expr_form=expr_form)
     except SaltClientError as client_error:
         print(client_error)
         return ret

--- a/salt/runners/survey.py
+++ b/salt/runners/survey.py
@@ -152,7 +152,7 @@ def _get_pool_results(*args, **kwargs):
 
     expr_form = kwargs.get('expr_form', 'compound')
     if expr_form not in ['compound', 'pcre']:
-        expr_form='compound'
+        expr_form = 'compound'
 
     client = salt.client.get_local_client(__opts__['conf_file'])
     try:


### PR DESCRIPTION
Support for use of regular expressions in salt-run survey.diff and salt-run survey.hash.

Example targeting only minions called _www1_ and _www2_:

```
salt-run survey.diff '^www[12]$' expr_form=pcre test.ping
```
