### PR TITLE
Add extra module path in Arch Linux.

### DIFF
--- a/salt/modules/kmod.py
+++ b/salt/modules/kmod.py
@@ -128,6 +128,15 @@ def available():
         for fn_ in files:
             if '.ko' in fn_:
                 ret.append(fn_[:fn_.index('.ko')].replace('-', '_'))
+
+    if 'Arch' in __grains__['os_family']:
+        # Sadly this path is relative to kernel major version but ignores minor version
+        mod_dir_arch = '/lib/modules/extramodules-' + os.uname()[2][0:3] + '-ARCH'
+        for root, dirs, files in os.walk(mod_dir_arch):
+            for fn_ in files:
+                if '.ko' in fn_:
+                    ret.append(fn_[:fn_.index('.ko')].replace('-', '_'))
+
     return sorted(list(ret))
 
 


### PR DESCRIPTION
Since Arch Linux distribution also uses /lib/modules/extramodules-4.2-ARCH to
save extra kernel modules, the idea here is to include that path in case os family is Arch.
Note that this path is only relative to kernel major version, but do ignore kernel minor version,
that's why is a little bit hacky, but should work after a major kernel change

Related to issue #28233

Please, feel free to add comments, suggestion on better approach for this, i will work to do that.
