### PR TITLE
Don't create io_loop before fork

### DIFF
--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -629,16 +629,20 @@ class PubServer(tornado.tcpserver.TCPServer, object):
 
 
 class TCPPubServerChannel(salt.transport.server.PubServerChannel):
-    def __init__(self, opts, io_loop=None):
+    def __init__(self, opts):
         self.opts = opts
         self.serial = salt.payload.Serial(self.opts)  # TODO: in init?
-        self.io_loop = io_loop or tornado.ioloop.IOLoop.current()
+        self.io_loop = None
 
     def _publish_daemon(self):
         '''
         Bind to the interface specified in the configuration file
         '''
         salt.utils.appendproctitle(self.__class__.__name__)
+
+        # Check if io_loop was set outside
+        if self.io_loop is None:
+            self.io_loop = tornado.ioloop.IOLoop.current()
 
         # Spin up the publisher
         pub_server = PubServer(io_loop=self.io_loop)


### PR DESCRIPTION
This fix avoids  to use io_loop created by parent process.

Fixed TCP transport on FreeBSD
This needs to be merged to develop also.

Fix for #26364.
