### PR TITLE
Fixed a couple more ESXi proxy minion bugs

### DIFF
--- a/doc/topics/tutorials/esxi_proxy_minion.rst
+++ b/doc/topics/tutorials/esxi_proxy_minion.rst
@@ -215,7 +215,16 @@ restart the proxy minion--it should just pick up the the new password
 provided in the list. You can then change pillar at will to move that
 password to the front and retire the unused ones.
 
-This also allows you to use any number of potential fallback passwords.
+Use-case/reasoning for using a list of passwords: You are setting up an
+ESXi host for the first time, and the host comes with a default password.
+You know that you'll be changing this password during your initial setup
+from the default to a new password. If you only have one password option,
+and if you have a state changing the password, any remote execution commands
+or states that run after the password change will not be able to run on the
+host until the password is updated in Pillar and the Proxy Minion process is
+restarted.
+
+This allows you to use any number of potential fallback passwords.
 
 .. note::
 

--- a/salt/states/esxi.py
+++ b/salt/states/esxi.py
@@ -711,6 +711,10 @@ def ssh_configured(name,
             # Check that the first two list items of clean key lists are equal.
             if clean_current_key[0] != clean_ssh_key[0] or clean_current_key[1] != clean_ssh_key[1]:
                 ssh_key_changed = True
+        else:
+            # If current_ssh_key is None, but we're setting a new key with
+            # either ssh_key or ssh_key_file, then we need to flag the change.
+            ssh_key_changed = True
 
     # Upload SSH key, if changed.
     if ssh_key_changed:

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -97,7 +97,7 @@ def esxcli(host, user, pwd, cmd, protocol=None, port=None, esxi_host=None):
                                                                 port,
                                                                 cmd)
 
-    ret = salt.modules.cmdmod.run_all(esx_cmd)
+    ret = salt.modules.cmdmod.run_all(esx_cmd, output_loglevel='quiet')
 
     return ret
 


### PR DESCRIPTION
- Don't log the salt.utils.vmware.esxcli command (shouldn't log password)
- Make sure we catch all ssh key changes possibilities in esxi state
- Provide a use-case example of why using a list of passwords for the host is a useful idea
