### PR TITLE
Update user.py

### DIFF
--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -36,9 +36,6 @@ import salt.utils.locales
 # Import 3rd-party libs
 import salt.ext.six as six
 
-# Import 3rd-party libs
-import salt.ext.six as six
-
 log = logging.getLogger(__name__)
 
 
@@ -469,10 +466,16 @@ def present(name,
                 continue
             # run chhome once to avoid any possible bad side-effect
             if key == 'home' and 'homeDoesNotExist' not in changes:
-                __salt__['user.chhome'](name, val, False)
+                if __grains__['kernel'] == 'Darwin':
+                        __salt__['user.chhome'](name, val)
+                else:
+                   __salt__['user.chhome'](name, val, False)
                 continue
             if key == 'homeDoesNotExist':
-                __salt__['user.chhome'](name, val, True)
+                if __grains__['kernel'] == 'Darwin':
+                    __salt__['user.chhome'](name, val)
+                else:
+                    __salt__['user.chhome'](name, val, True)
                 if not os.path.isdir(val):
                     __salt__['file.mkdir'](val, pre['uid'], pre['gid'], 0o755)
                 continue

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -467,9 +467,9 @@ def present(name,
             # run chhome once to avoid any possible bad side-effect
             if key == 'home' and 'homeDoesNotExist' not in changes:
                 if __grains__['kernel'] == 'Darwin':
-                        __salt__['user.chhome'](name, val)
+                    __salt__['user.chhome'](name, val)
                 else:
-                   __salt__['user.chhome'](name, val, False)
+                    __salt__['user.chhome'](name, val, False)
                 continue
             if key == 'homeDoesNotExist':
                 if __grains__['kernel'] == 'Darwin':


### PR DESCRIPTION
### ISSUE:

`salt/states/user.py` passes 3 args to virtual module user, but 
`salt/modules/mac_user.py` accepts only 2 arguments 

actual exception: 

```
 Name: lemon - Function: group.present - Result: Clean
----------
          ID: lemon
    Function: user.present
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/salt/state.py", line 1594, in call
                  **cdata['kwargs'])
                File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/salt/loader.py", line 1491, in wrapper
                  return f(*args, **kwargs)
                File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/salt/states/user.py", line 471, in present
                  __salt__['user.chhome'](name, val, True)
              TypeError: chhome() takes exactly 2 arguments (3 given)
     Started: 23:03:30.934322
    Duration: 643.339 ms
     Changes:   
```
### PROPOSAL

Added check: if Darwin kernel, then ignoring persist arg,
