### PR TITLE
Adding ability to disable npm install silent flag

### DIFF
--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -126,7 +126,8 @@ def install(pkg=None,
         pkgs = pkg_list
     if registry:
         registry = _cmd_quote(registry)
-        cmd = ['npm', 'install']
+        
+    cmd = ['npm', 'install']
     if silent:
         cmd.append(['--silent'])
     cmd.append(['--json'])

--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -126,7 +126,7 @@ def install(pkg=None,
         pkgs = pkg_list
     if registry:
         registry = _cmd_quote(registry)
-        
+
     cmd = ['npm', 'install']
     if silent:
         cmd.append(['--silent'])

--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -65,7 +65,8 @@ def install(pkg=None,
             dir=None,
             runas=None,
             registry=None,
-            env=None):
+            env=None,
+            silent=True):
     '''
     Install an NPM package.
 
@@ -101,6 +102,11 @@ def install(pkg=None,
 
         .. versionadded:: 2014.7.0
 
+    silent
+        Wether or not to run NPM install with --silent flag.
+
+        .. versionadded::2015.9.0
+
     CLI Example:
 
     .. code-block:: bash
@@ -120,8 +126,10 @@ def install(pkg=None,
         pkgs = pkg_list
     if registry:
         registry = _cmd_quote(registry)
-
-    cmd = ['npm', 'install', '--silent', '--json']
+        cmd = ['npm', 'install']
+    if silent:
+        cmd.append(['--silent'])
+    cmd.append(['--json'])
 
     if dir is None:
         cmd.append(' --global')

--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -129,8 +129,8 @@ def install(pkg=None,
 
     cmd = ['npm', 'install']
     if silent:
-        cmd.append(['--silent'])
-    cmd.append(['--json'])
+        cmd.append('--silent')
+    cmd.append('--json')
 
     if dir is None:
         cmd.append(' --global')


### PR DESCRIPTION
Fixes issue #29678

When trying to debug NPM package installation failures/issues it is very difficult to see what is what is happening during the install/being installed that causes a failure. Adding the ability to disable the silent flag will give users the ability to chose if they want to see the output from install.
