### PR TITLE
Improve salt-cloud linode provider: add option to allocate a 'data' disk for a linode

### DIFF
--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -534,7 +534,7 @@ def create_config(kwargs=None, call=None):
 
     data_disk_id
         The Data Disk ID to be used for this config.
-    
+
     kernel_id
         The ID of the kernel to use for this configuration profile.
     '''
@@ -565,9 +565,9 @@ def create_config(kwargs=None, call=None):
                 '\'root_disk_id\', and \'swap_disk_id\'.'
             )
 
-    disklist = '{0},{1}'.format(root_disk_id,swap_disk_id)
+    disklist = '{0},{1}'.format(root_disk_id, swap_disk_id)
     if data_disk_id is not None:
-       disklist = '{0},{1},{2}'.format(root_disk_id,swap_disk_id,data_disk_id)
+        disklist = '{0},{1},{2}'.format(root_disk_id, swap_disk_id, data_disk_id)
 
     config_args = {'LinodeID': linode_id,
                    'KernelID': kernel_id,
@@ -649,11 +649,12 @@ def create_swap_disk(vm_, linode_id, swap_size=None):
 
     return _clean_data(result)
 
+
 def create_data_disk(vm_=None, linode_id=None, data_size=None):
     '''
     Create a data disk for the linode (type is hardcoded to ext4 at the moment)
 
-    vm\_
+    vm_
         The VM profile to create the data disk for.
 
     linode_id
@@ -664,13 +665,13 @@ def create_data_disk(vm_=None, linode_id=None, data_size=None):
 
     '''
     kwargs = {}
-    
+
     kwargs.update({'LinodeID': linode_id,
                    'Label': vm_['name']+"_data",
                    'Type': 'ext4',
                    'Size': data_size
                    })
-    
+
     result = _query('linode', 'disk.create', args=kwargs)
     return _clean_data(result)
 
@@ -800,7 +801,8 @@ def get_disk_size(vm_, swap, linode_id):
     return config.get_cloud_config_value(
         'disk_size', vm_, __opts__, default=disk_size - swap
     )
-    
+
+
 def get_data_disk_size(vm_, swap, linode_id):
     '''
     Return the size of of the data disk in MB
@@ -1006,6 +1008,7 @@ def get_private_ip(vm_):
         'assign_private_ip', vm_, __opts__, default=False
     )
 
+
 def get_data_disk(vm_):
     '''
     Return True if a data disk is requested
@@ -1013,6 +1016,7 @@ def get_data_disk(vm_):
     return config.get_cloud_config_value(
         'allocate_data_disk', vm_, __opts__, default=False
     )
+
 
 def get_pub_key(vm_):
     r'''

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -534,6 +534,8 @@ def create_config(kwargs=None, call=None):
 
     data_disk_id
         The Data Disk ID to be used for this config.
+    
+    .. versionadded:: Boron
 
     kernel_id
         The ID of the kernel to use for this configuration profile.
@@ -573,7 +575,7 @@ def create_config(kwargs=None, call=None):
                    'KernelID': kernel_id,
                    'Label': name,
                    'DiskList': disklist
-                   }
+                  }
 
     result = _query('linode', 'config.create', args=config_args)
 
@@ -643,7 +645,7 @@ def create_swap_disk(vm_, linode_id, swap_size=None):
                    'Label': vm_['name'],
                    'Type': 'swap',
                    'Size': swap_size
-                   })
+                  })
 
     result = _query('linode', 'disk.create', args=kwargs)
 
@@ -653,6 +655,8 @@ def create_swap_disk(vm_, linode_id, swap_size=None):
 def create_data_disk(vm_=None, linode_id=None, data_size=None):
     '''
     Create a data disk for the linode (type is hardcoded to ext4 at the moment)
+
+    .. versionadded:: Boron
 
     vm_
         The VM profile to create the data disk for.
@@ -670,7 +674,7 @@ def create_data_disk(vm_=None, linode_id=None, data_size=None):
                    'Label': vm_['name']+"_data",
                    'Type': 'ext4',
                    'Size': data_size
-                   })
+                  })
 
     result = _query('linode', 'disk.create', args=kwargs)
     return _clean_data(result)
@@ -806,6 +810,8 @@ def get_disk_size(vm_, swap, linode_id):
 def get_data_disk_size(vm_, swap, linode_id):
     '''
     Return the size of of the data disk in MB
+
+    .. versionadded:: Boron
     '''
     disk_size = get_linode(kwargs={'linode_id': linode_id})['TOTALHD']
     root_disk_size = config.get_cloud_config_value(
@@ -1012,6 +1018,8 @@ def get_private_ip(vm_):
 def get_data_disk(vm_):
     '''
     Return True if a data disk is requested
+
+    .. versionadded:: Boron
     '''
     return config.get_cloud_config_value(
         'allocate_data_disk', vm_, __opts__, default=False

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -441,7 +441,7 @@ def create(vm_):
     swap_disk_id = create_swap_disk(vm_, node_id)['DiskID']
     data_disk_id = None
     if get_data_disk(vm_):
-        data_disk_id = create_data_disk(vm_, node_id, get_data_disk_size(vm_, node_id, get_swap_size(vm_)))['DiskID']
+        data_disk_id = create_data_disk(vm_, node_id, get_data_disk_size(vm_, get_swap_size(vm_), node_id))['DiskID']
 
     # Add private IP address if requested
     private_ip_assignment = get_private_ip(vm_)
@@ -462,7 +462,7 @@ def create(vm_):
                                       'linode_id': node_id,
                                       'root_disk_id': root_disk_id,
                                       'swap_disk_id': swap_disk_id,
-                                      'data_disk_id': swap_disk_id,
+                                      'data_disk_id': data_disk_id,
                                       'helper_network': private_ip_assignment})['ConfigID']
     # Boot the Linode
     boot(kwargs={'linode_id': node_id,


### PR DESCRIPTION
This PR introduces a new option to the linode provider called:

```
 allocate_data_disk (boolean)
```

when set on a linode in a cloud map it will cause salt-cloud to allocate _all_ remaining storage space to a 'data' disk which will then be mapped to the third device or /dev/sdc.
The default value for this option is False and is therefore backwards compatible with clouds created with previous salt-cloud versions.
