### PR TITLE
Summary: Add two neutron api about listing and showing firewall.

### DIFF
--- a/salt/modules/neutron.py
+++ b/salt/modules/neutron.py
@@ -1465,10 +1465,10 @@ def list_firewalls(profile=None):
     :return: List of firewalls
     '''
     conn = _auth(profile)
-    return conn.list_firewall
+    return conn.list_firewalls()
 
 
-def show_firewall(firewall):
+def show_firewall(firewall, profile=None):
     '''
     Fetches information of a specific firewall rule
 
@@ -1483,7 +1483,7 @@ def show_firewall(firewall):
     :return: firewall information
     '''
     conn = _auth(profile)
-    return conn.show_firewall(firewall_rule)
+    return conn.show_firewall(firewall)
 
 
 # The following is a list of functions that need to be incorporated in the

--- a/salt/modules/neutron.py
+++ b/salt/modules/neutron.py
@@ -1453,6 +1453,39 @@ def delete_firewall_rule(firewall_rule, profile=None):
     return conn.delete_firewall_rule(firewall_rule)
 
 
+def list_firewalls(profile=None):
+    '''
+    Fetches a list of all firewalls for a tenant
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' neutron.list_firewalls
+    :param profile: Profile to build on (Optional)
+    :return: List of firewalls
+    '''
+    conn = _auth(profile)
+    return conn.list_firewall
+
+
+def show_firewall(firewall):
+    '''
+    Fetches information of a specific firewall rule
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' neutron.show_firewall firewall
+
+    :param firewall: ID or name of firewall to look up
+    :param profile: Profile to build on (Optional)
+    :return: firewall information
+    '''
+    conn = _auth(profile)
+    return conn.show_firewall(firewall_rule)
+
+
 # The following is a list of functions that need to be incorporated in the
 # neutron module. This list should be updated as functions are added.
 #

--- a/salt/utils/openstack/neutron.py
+++ b/salt/utils/openstack/neutron.py
@@ -170,6 +170,10 @@ class SaltNeutron(NeutronShell):
         resources = self.list_firewall_rules()['firewall_rules']
         return self._fetch(resources, name_or_id)
 
+    def _fetch_firewall(self, name_or_id):
+        resources = self.list_firewalls()['firewalls']
+        return self._fetch(resources, name_or_id)
+
     def get_quotas_tenant(self):
         '''
         Fetches tenant info in server's context
@@ -792,6 +796,18 @@ class SaltNeutron(NeutronShell):
         firewall_rule_id = self._find_firewall_rule_id(firewall_rule)
         ret = self.network_conn.delete_firewall_rule(firewall_rule_id)
         return ret if ret else True
+
+    def list_firewalls(self):
+        '''
+        Fetches a list of all firewalls for a tenant
+        '''
+        return self.network_conn.list_firewalls()
+
+    def show_firewall(self, firewall):
+        '''
+        Fetches information of a specific firewall
+        '''
+        return self._fetch_firewall(firewall)
 
 
 # The following is a list of functions that need to be incorporated in the


### PR DESCRIPTION
Description:
Add function list_firewalls and show_firewall in salt/modules/neutron.py
Add object function list_firewalls, show_firewall and _fetch_firewall in
salt/utils/openstack/neutron.py
