### PR TITLE
modules.bluez: __virtual__ return err msg.

### DIFF
--- a/salt/modules/bluez.py
+++ b/salt/modules/bluez.py
@@ -46,7 +46,7 @@ def __virtual__():
     '''
     if HAS_PYBLUEZ:
         return __virtualname__
-    return False
+    return (False, 'The bluetooth execution module cannot be loaded: bluetooth not installed.')
 
 
 def version():


### PR DESCRIPTION
Updated message in bluez module when return False in systems without bluetooth installed.

Reference :: https://github.com/saltstack/salt/wiki/December-2015-Sprint-Beginner-Bug-List
