### PR TITLE
modules.cassandra_cql: __virtual__ return err msg.

### DIFF
--- a/salt/modules/cassandra_cql.py
+++ b/salt/modules/cassandra_cql.py
@@ -69,7 +69,7 @@ def __virtual__():
     '''
     if HAS_DRIVER:
         return __virtualname__
-    return False
+    return (False, 'Cannot load cassandra_cql module: python driver not found')
 
 
 def _load_properties(property_name, config_option, set_default=False, default=None):


### PR DESCRIPTION
Updated message in cassandra_cql module when return False in systems without python driver installed.

Reference :: https://github.com/saltstack/salt/wiki/December-2015-Sprint-Beginner-Bug-List
