### PR TITLE
modules.cassandra: __virtual__ return err msg.

### DIFF
--- a/salt/modules/cassandra.py
+++ b/salt/modules/cassandra.py
@@ -33,11 +33,11 @@ def __virtual__():
     Only load if pycassa is available and the system is configured
     '''
     if not HAS_PYCASSA:
-        return False
+        return (False, 'The cassandra execution module cannot be loaded: pycassa not installed.')
 
     if HAS_PYCASSA and salt.utils.which('nodetool'):
         return 'cassandra'
-    return False
+    return (False, 'The cassandra execution module cannot be loaded: nodetool not found.')
 
 
 def _nodetool(cmd):


### PR DESCRIPTION
Updated message in cassandra module when return False is nodetool is not found.

Reference ::  https://github.com/saltstack/salt/wiki/December-2015-Sprint-Beginner-Bug-List
