### PR TITLE
Updated documentation for Salt Development.

### DIFF
--- a/doc/topics/development/hacking.rst
+++ b/doc/topics/development/hacking.rst
@@ -50,6 +50,12 @@ functionality
     again, although it does assume that the listed modules are all installed in the
     system PYTHONPATH at the time of virtualenv creation.
 
+.. note:: Python development package
+
+    Be sure to install python devel package in order to install required Python
+    modules. In Debian/Ubuntu run ``sudo apt-get install -y python-dev``. In RedHat
+    based system install ``python-devel``
+
 Activate the virtualenv:
 
 .. code-block:: bash
@@ -183,22 +189,22 @@ If you would like to log to the console instead of to the log file, remove the
 .. note:: Too long socket path?
 
     Once the minion starts, you may see an error like the following:
-    
+
     .. code-block:: bash
-    
+
         zmq.core.error.ZMQError: ipc path "/path/to/your/virtualenv/
         var/run/salt/minion/minion_event_7824dcbcfd7a8f6755939af70b96249f_pub.ipc"
         is longer than 107 characters (sizeof(sockaddr_un.sun_path)).
-    
+
     This means that the path to the socket the minion is using is too long. This is
     a system limitation, so the only workaround is to reduce the length of this
     path. This can be done in a couple different ways:
-    
+
     1.  Create your virtualenv in a path that is short enough.
     2.  Edit the :conf_minion:`sock_dir` minion config variable and reduce its
         length. Remember that this path is relative to the value you set in
         :conf_minion:`root_dir`.
-    
+
     ``NOTE:`` The socket path is limited to 107 characters on Solaris and Linux,
     and 103 characters on BSD-based systems.
 


### PR DESCRIPTION
In order to install pip modules for salt development we need to make sure that python devel is installed. Otherwise pip command will fail.

Issue #29664 
