### PR TITLE
modules.ddns: __virtual__ return err msg.

### DIFF
--- a/salt/modules/ddns.py
+++ b/salt/modules/ddns.py
@@ -48,7 +48,7 @@ def __virtual__():
     '''
     if dns_support:
         return 'ddns'
-    return False
+    return (False, 'The ddns execution module cannot be loaded: dnspython not installed.')
 
 
 def _config(name, key=None, **kwargs):


### PR DESCRIPTION
Updated message in ddns module when return False if dnspython is not installed.

Reference : https://github.com/saltstack/salt/wiki/December-2015-Sprint-Beginner-Bug-List
