### PR TITLE
modules.deb_apache: __virtual__ return err msg.

### DIFF
--- a/salt/modules/deb_apache.py
+++ b/salt/modules/deb_apache.py
@@ -27,7 +27,7 @@ def __virtual__():
     cmd = _detect_os()
     if salt.utils.which(cmd) and __grains__['os_family'] == 'Debian':
         return __virtualname__
-    return False
+    return (False, 'apache execution module not loaded: apache not installed.')
 
 
 def _detect_os():


### PR DESCRIPTION
Updated message in deb_apache module when return False if apache is not installed.

Reference : https://github.com/saltstack/salt/wiki/December-2015-Sprint-Beginner-Bug-List

Sorry for the amount of PR.
