### PR TITLE
modules.deb_postgres: __virtual__ return err msg.

### DIFF
--- a/salt/modules/deb_postgres.py
+++ b/salt/modules/deb_postgres.py
@@ -25,7 +25,7 @@ def __virtual__():
     '''
     if salt.utils.which('pg_createcluster'):
         return __virtualname__
-    return False
+    return (False, 'postgres execution module not loaded: pg_createcluste command not found.')
 
 
 def cluster_create(version,


### PR DESCRIPTION
Updated message in deb_postgres module when return False if pg_createcluste command is not available.

Reference : https://github.com/saltstack/salt/wiki/December-2015-Sprint-Beginner-Bug-List
