### PR TITLE
modules.lxc: __virtual__ return err msg.

### DIFF
--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -81,7 +81,7 @@ def __virtual__():
     #     return 'lxc'
     # return False
     #
-    return False
+    return (False, 'The lxc execution module cannot be loaded: the lxc-start binary is not in the path.')
 
 
 def get_root_path(path):


### PR DESCRIPTION
Updated message in lxc module when return False if lxc-start command is not available.

Reference : https://github.com/saltstack/salt/wiki/December-2015-Sprint-Beginner-Bug-List
