### PR TITLE
modules.portage_config: __virtual__ return err msg.

### DIFF
--- a/salt/modules/portage_config.py
+++ b/salt/modules/portage_config.py
@@ -43,7 +43,7 @@ def __virtual__():
     '''
     if HAS_PORTAGE and __grains__['os'] == 'Gentoo':
         return 'portage_config'
-    return False
+    return (False, 'portage_config execution module cannot be loaded: only available on Gentoo with portage installed.')
 
 
 def _get_portage():


### PR DESCRIPTION
Updated message in portage_config module when return False if portage is not available or os
is not Gentoo.

Reference : https://github.com/saltstack/salt/wiki/December-2015-Sprint-Beginner-Bug-List
