### PR TITLE
modules.marathon: __virtual__ return err msg.

### DIFF
--- a/salt/modules/marathon.py
+++ b/salt/modules/marathon.py
@@ -20,7 +20,9 @@ log = logging.getLogger(__file__)
 
 def __virtual__():
     # only valid in proxy minions for now
-    return salt.utils.is_proxy() and 'proxy' in __opts__
+    if salt.utils.is_proxy() and 'proxy' in __opts__:
+        return True
+    return (False, 'The marathon execution module cannot be loaded: this only works in proxy minions.')
 
 
 def _base_url():


### PR DESCRIPTION
Updated message in marathon  module when return False if is not used in proxy minions.

Doc updated https://github.com/saltstack/salt/wiki/December-2015-Sprint-Beginner-Bug-List
