### PR TITLE
modules.random: __virtual__ return err msg.

### DIFF
--- a/salt/modules/mod_random.py
+++ b/salt/modules/mod_random.py
@@ -26,7 +26,7 @@ def __virtual__():
     # Certain versions of hashlib do not contain
     # the necessary functions
     if not hasattr(hashlib, 'algorithms'):
-        return False
+        return (False, 'The random execution module cannot be loaded: only available in Python >= 2.7.')
     return __virtualname__
 
 


### PR DESCRIPTION
Updated message in mod_random module when return False if Python version is not 2.7 or higher.

This is only available in Python 2.7 or higher as show documentation here https://docs.python.org/2/library/hashlib.html#hashlib.hashlib.algorithms
