### PR TITLE
FreeBSD pkg provider battch support.

### DIFF
--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -388,6 +388,11 @@ def install(name=None,
 
     args.extend(pkg_params)
 
+    # Make sure BATCH=yes is used in salt if it is set
+    batch = __salt__['environ.get']('BATCH')
+    if batch == 'yes':
+        __salt__['environ.setval']('BATCH', 'yes')
+
     old = list_pkgs()
     __salt__['cmd.run'](
         ['pkg_add'] + args,


### PR DESCRIPTION
When installing packages in FreeBSD that have an interactive post-installation BATCH
environment variable is used to answer all post install questions. The idea here is
to check if that variable is set and in case is True make sure to use it

Fixes #27056

 I'm sending this against develop because is more or less WIP or a feature for now. I will take of doing a proper PR in case this code is good enough and do what it says.
