### PR TITLE
Install correct package version, if provided, for npm state.

### DIFF
--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -186,12 +186,8 @@ def installed(name,
             'runas': user,
             'registry': registry,
             'env': env,
+            'pkgs': pkg_list,
         }
-
-        if pkgs is not None:
-            cmd_args['pkgs'] = pkgs
-        else:
-            cmd_args['pkg'] = pkg_name
 
         call = __salt__['npm.install'](**cmd_args)
     except (CommandNotFoundError, CommandExecutionError) as err:


### PR DESCRIPTION
Fixes #23343

We already have taken care of the correct formatting for either
a list of packages, or a single package name with 'pkg_list'. Let's
use it so the version information can be passed to the install
function as well as the name.

Refs #18647
