### PR TITLE
Remove humanname from yum repository options

### DIFF
--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -266,6 +266,7 @@ def managed(name, **kwargs):
 
     if 'humanname' in kwargs:
         kwargs['name'] = kwargs['humanname']
+        kwargs.pop('humanname')
 
     if kwargs.pop('enabled', None):
         kwargs['disabled'] = False


### PR DESCRIPTION
_humanname_ is not a valid yum repository option:

**epel.sls**

```
epel_repo:
  pkgrepo.managed:
    - name: epel
    - humanname: Extra Packages for Enterprise Linux $releasever - $basearch
    - comments:
      - '#baseurl=http://download.fedoraproject.org/pub/epel/$releasever/$basearch'
    - mirrorlist: https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch
    - failovermethod: priority
    - enabled: 1
    - gpgcheck: 1
    - gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-$releasever
```

**epel.repo**

```
[epel]
name=Extra Packages for Enterprise Linux $releasever - $basearch
failovermethod=priority
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-$releasever
enabled=1
humanname=Extra Packages for Enterprise Linux $releasever - $basearch
mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch
gpgcheck=1
#baseurl=http://download.fedoraproject.org/pub/epel/$releasever/$basearch
```

```
# salt --versions-report
           Salt: 2015.5.5
         Python: 2.7.5 (default, Jun 24 2015, 00:41:19)
         Jinja2: 2.7.2
       M2Crypto: 0.21.1
 msgpack-python: 0.4.6
   msgpack-pure: Not Installed
       pycrypto: 2.6.1
        libnacl: Not Installed
         PyYAML: 3.10
          ioflo: Not Installed
          PyZMQ: 14.3.1
           RAET: Not Installed
            ZMQ: 3.2.5
           Mako: Not Installed
        Tornado: Not Installed
        timelib: Not Installed
       dateutil: Not Installed
```

Btw is there a way to combine multiple yum repositories into a single file? I would like to have _epel_ and _epel-testing_ in a single _.repo_ file.
