### PR TITLE
Fix display of multiline strings when iterating over a list

### DIFF
--- a/salt/output/nested.py
+++ b/salt/output/nested.py
@@ -89,17 +89,20 @@ class NestDisplay(object):
                 )
             )
         elif isinstance(ret, string_types):
+            first_line = True
             for line in ret.splitlines():
                 if self.strip_colors:
                     line = salt.output.strip_esc_sequence(line)
+                line_prefix = ' ' * len(prefix) if not first_line else prefix
                 out.append(
                     self.ustring(
                         indent,
                         self.GREEN,
                         line,
-                        prefix=prefix
+                        prefix=line_prefix
                     )
                 )
+                first_line = False
         elif isinstance(ret, (list, tuple)):
             for ind in ret:
                 if isinstance(ind, (list, tuple, dict)):


### PR DESCRIPTION
When iterating over a list, the prefix is a dash followed by a space.
However, the prefix was being prepended to each line of a string before
adding it to the output. This means that each line of the string appears
to be a distinct list element.

This commit fixes this issue by only prepending the prefix on the first
line of a multiline string. On all other lines, a prefix consisting of a
number of spaces equal to the length of the prefix is used, ensuring
that the mulitline string is consistently indented.

Assuming a return value of `['foo\nbar\nbaz\n']`:
### Before

```
myminion:
  - foo
  - bar
  - baz
```
### After

```
myminion:
  - foo
    bar
    baz
```
