### PR TITLE
Check for windows dropfile existence

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -60,7 +60,8 @@ def dropfile(cachedir, user=None):
     try:
         log.info('Rotating AES key')
 
-        if salt.utils.is_windows() and not os.access(dfn, os.W_OK):
+        if (salt.utils.is_windows() and os.path.isfile(dfn) and
+                not os.access(dfn, os.W_OK)):
             os.chmod(dfn, stat.S_IWUSR)
         with salt.utils.fopen(dfn, 'wb+') as fp_:
             fp_.write('')


### PR DESCRIPTION
This will check the existence of the .dfn dropfile before attempting to
change its permissions to avoid the exception, "The system cannot find
the file specified" in the case when the file does not exist.

Signed-off-by: Perry Zipoy perry.zipoy@ni.com
