### PR TITLE
Improve error reporting in pkg states

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -667,8 +667,13 @@ def install(name=None,
     env = _parse_env(kwargs.get('env'))
     env.update(DPKG_ENV_VARS.copy())
 
+    errors = []
     for cmd in cmds:
-        __salt__['cmd.run'](cmd, output_loglevel='trace', python_shell=False)
+        out = __salt__['cmd.run_all'](cmd,
+                                      output_loglevel='trace',
+                                      python_shell=False)
+        if out['retcode'] != 0 and out['stderr']:
+            errors.append(out['stderr'])
 
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
@@ -678,6 +683,12 @@ def install(name=None,
         if pkgname not in ret or pkgname in old:
             ret.update({pkgname: {'old': old.get(pkgname, ''),
                                   'new': new.get(pkgname, '')}})
+
+    if errors:
+        raise CommandExecutionError(
+            'Problem encountered installing package(s)',
+            info={'errors': errors, 'changes': ret}
+        )
 
     return ret
 
@@ -703,22 +714,37 @@ def _uninstall(action='remove', name=None, pkgs=None, **kwargs):
     cmd.extend(targets)
     env = _parse_env(kwargs.get('env'))
     env.update(DPKG_ENV_VARS.copy())
-    __salt__['cmd.run'](
+    out = __salt__['cmd.run_all'](
         cmd,
         env=env,
         output_loglevel='trace',
         python_shell=False,
     )
+    if out['retcode'] != 0 and out['stderr']:
+        errors = [out['stderr']]
+    else:
+        errors = []
+
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
     new_removed = list_pkgs(removed=True)
 
-    ret = {'installed': salt.utils.compare_dicts(old, new)}
+    changes = salt.utils.compare_dicts(old, new)
     if action == 'purge':
-        ret['removed'] = salt.utils.compare_dicts(old_removed, new_removed)
-        return ret
+        ret = {
+            'removed': salt.utils.compare_dicts(old_removed, new_removed),
+            'installed': changes
+        }
     else:
-        return ret['installed']
+        ret = changes
+
+    if errors:
+        raise CommandExecutionError(
+            'Problem encountered removing package(s)',
+            info={'errors': errors, 'changes': ret}
+        )
+
+    return ret
 
 
 def autoremove(list_only=False, purge=False):
@@ -880,18 +906,20 @@ def upgrade(refresh=True, dist_upgrade=False, **kwargs):
     else:
         cmd = ['apt-get', '-q', '-y', '-o', 'DPkg::Options::={0}'.format(force_conf),
                '-o', 'DPkg::Options::=--force-confdef', 'upgrade']
-    call = __salt__['cmd.run_all'](cmd, python_shell=False, output_loglevel='trace',
+    call = __salt__['cmd.run_all'](cmd,
+                                   output_loglevel='trace',
+                                   python_shell=False,
+                                   redirect_stderr=True,
                                    env=DPKG_ENV_VARS.copy())
     if call['retcode'] != 0:
         ret['result'] = False
-        if 'stderr' in call:
-            ret['comment'] += call['stderr']
-        if 'stdout' in call:
-            ret['comment'] += call['stdout']
-    else:
-        __context__.pop('pkg.list_pkgs', None)
-        new = list_pkgs()
-        ret['changes'] = salt.utils.compare_dicts(old, new)
+        if call['stdout']:
+            ret['comment'] = call['stdout']
+
+    __context__.pop('pkg.list_pkgs', None)
+    new = list_pkgs()
+    ret['changes'] = salt.utils.compare_dicts(old, new)
+
     return ret
 
 

--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -61,7 +61,7 @@ def _homebrew_bin():
     return ret
 
 
-def _call_brew(cmd):
+def _call_brew(cmd, redirect_stderr=False):
     '''
     Calls the brew command with the user account of brew
     '''
@@ -70,7 +70,8 @@ def _call_brew(cmd):
     return __salt__['cmd.run_all'](cmd,
                                    runas=runas,
                                    output_loglevel='trace',
-                                   python_shell=False)
+                                   python_shell=False,
+                                   redirect_stderr=redirect_stderr)
 
 
 def list_pkgs(versions_as_list=False, **kwargs):
@@ -206,10 +207,24 @@ def remove(name=None, pkgs=None, **kwargs):
     if not targets:
         return {}
     cmd = 'brew uninstall {0}'.format(' '.join(targets))
-    _call_brew(cmd)
+
+    out = _call_brew(cmd)
+    if out['retcode'] != 0 and out['stderr']:
+        errors = [out['stderr']]
+    else:
+        errors = []
+
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return salt.utils.compare_dicts(old, new)
+    ret = salt.utils.compare_dicts(old, new)
+
+    if errors:
+        raise CommandExecutionError(
+            'Problem encountered removing package(s)',
+            info={'errors': errors, 'changes': ret}
+        )
+
+    return ret
 
 
 def refresh_db():
@@ -320,11 +335,23 @@ def install(name=None, pkgs=None, taps=None, options=None, **kwargs):
     else:
         cmd = 'brew install {0}'.format(formulas)
 
-    _call_brew(cmd)
+    out = _call_brew(cmd)
+    if out['retcode'] != 0 and out['stderr']:
+        errors = [out['stderr']]
+    else:
+        errors = []
 
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return salt.utils.compare_dicts(old, new)
+    ret = salt.utils.compare_dicts(old, new)
+
+    if errors:
+        raise CommandExecutionError(
+            'Problem encountered installing package(s)',
+            info={'errors': errors, 'changes': ret}
+        )
+
+    return ret
 
 
 def list_upgrades(refresh=True):
@@ -398,16 +425,15 @@ def upgrade(refresh=True):
         refresh_db()
 
     cmd = 'brew upgrade'
-    call = _call_brew(cmd)
+    call = _call_brew(cmd, redirect_stderr=True)
 
     if call['retcode'] != 0:
         ret['result'] = False
-        if 'stderr' in call:
-            ret['comment'] += call['stderr']
-        if 'stdout' in call:
-            ret['comment'] += call['stdout']
-    else:
-        __context__.pop('pkg.list_pkgs', None)
-        new = list_pkgs()
-        ret['changes'] = salt.utils.compare_dicts(old, new)
+        if call['stdout']:
+            ret['comment'] = call['stdout']
+
+    __context__.pop('pkg.list_pkgs', None)
+    new = list_pkgs()
+    ret['changes'] = salt.utils.compare_dicts(old, new)
+
     return ret

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -96,12 +96,11 @@ def _process_emerge_err(stdout, stderr):
     Used to parse emerge output to provide meaningful output when emerge fails
     '''
     ret = {}
-    changes = {}
     rexp = re.compile(r'^[<>=][^ ]+/[^ ]+ [^\n]+', re.M)
 
     slot_conflicts = re.compile(r'^[^ \n]+/[^ ]+:[^ ]', re.M).findall(stderr)
     if slot_conflicts:
-        changes['slot conflicts'] = slot_conflicts
+        ret['slot conflicts'] = slot_conflicts
 
     blocked = re.compile(r'(?m)^\[blocks .+\] '
                          r'([^ ]+/[^ ]+-[0-9]+[^ ]+)'
@@ -112,19 +111,18 @@ def _process_emerge_err(stdout, stderr):
 
     # If there were blocks and emerge could not resolve it.
     if blocked and unsatisfied:
-        changes['blocked'] = blocked
+        ret['blocked'] = blocked
 
     sections = re.split('\n\n', stderr)
     for section in sections:
         if 'The following keyword changes' in section:
-            changes['keywords'] = rexp.findall(section)
+            ret['keywords'] = rexp.findall(section)
         elif 'The following license changes' in section:
-            changes['license'] = rexp.findall(section)
+            ret['license'] = rexp.findall(section)
         elif 'The following USE changes' in section:
-            changes['use'] = rexp.findall(section)
+            ret['use'] = rexp.findall(section)
         elif 'The following mask changes' in section:
-            changes['mask'] = rexp.findall(section)
-    ret['changes'] = {'Needed changes': changes}
+            ret['mask'] = rexp.findall(section)
     return ret
 
 
@@ -650,8 +648,8 @@ def install(name=None,
                         all_uses = __salt__['portage_config.get_cleared_flags'](param)
                         if _flags_changed(*all_uses):
                             changes[param] = {'version': inst_v,
-                                                'old': {'use': all_uses[0]},
-                                                'new': {'use': all_uses[1]}}
+                                              'old': {'use': all_uses[0]},
+                                              'new': {'use': all_uses[1]}}
                 targets.append(target)
     else:
         targets = pkg_params
@@ -664,11 +662,21 @@ def install(name=None,
     call = __salt__['cmd.run_all'](cmd,
                                    output_loglevel='trace',
                                    python_shell=False)
-    __context__.pop('pkg.list_pkgs', None)
     if call['retcode'] != 0:
-        return _process_emerge_err(call['stdout'], call['stderr'])
+        needed_changes = _process_emerge_err(call['stdout'], call['stderr'])
+    else:
+        needed_changes = []
+
+    __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
     changes.update(salt.utils.compare_dicts(old, new))
+
+    if needed_changes:
+        raise CommandExecutionError(
+            'Error occurred installing package(s)',
+            info={'needed changes': needed_changes, 'changes': changes}
+        )
+
     return changes
 
 
@@ -725,11 +733,22 @@ def update(pkg, slot=None, fromrepo=None, refresh=False, binhost=None):
     call = __salt__['cmd.run_all'](cmd,
                                    output_loglevel='trace',
                                    python_shell=False)
-    __context__.pop('pkg.list_pkgs', None)
     if call['retcode'] != 0:
-        return _process_emerge_err(call['stdout'], call['stderr'])
+        needed_changes = _process_emerge_err(call['stdout'], call['stderr'])
+    else:
+        needed_changes = []
+
+    __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return salt.utils.compare_dicts(old, new)
+    ret = salt.utils.compare_dicts(old, new)
+
+    if needed_changes:
+        raise CommandExecutionError(
+            'Problem encountered updating package(s)',
+            info={'needed_changes': needed_changes, 'changes': ret}
+        )
+
+    return ret
 
 
 def upgrade(refresh=True, binhost=None, backtrack=3):
@@ -787,17 +806,18 @@ def upgrade(refresh=True, binhost=None, backtrack=3):
 
     call = __salt__['cmd.run_all'](cmd,
                                    output_loglevel='trace',
-                                   python_shell=False)
+                                   python_shell=False,
+                                   redirect_stderr=True)
+
     if call['retcode'] != 0:
         ret['result'] = False
-        if 'stderr' in call:
-            ret['comment'] += call['stderr']
-        if 'stdout' in call:
-            ret['comment'] += call['stdout']
-    else:
-        __context__.pop('pkg.list_pkgs', None)
-        new = list_pkgs()
-        ret['changes'] = salt.utils.compare_dicts(old, new)
+        if call['stdout']:
+            ret['comment'] = call['stdout']
+
+    __context__.pop('pkg.list_pkgs', None)
+    new = list_pkgs()
+    ret['changes'] = salt.utils.compare_dicts(old, new)
+
     return ret
 
 
@@ -853,12 +873,28 @@ def remove(name=None, slot=None, fromrepo=None, pkgs=None, **kwargs):
         return {}
     cmd = ['emerge', '--ask', 'n', '--quiet', '--unmerge',
            '--quiet-unmerge-warn'] + targets
-    __salt__['cmd.run_all'](cmd,
-                            output_loglevel='trace',
-                            python_shell=False)
+
+    out = __salt__['cmd.run_all'](
+        cmd,
+        output_loglevel='trace',
+        python_shell=False
+    )
+    if out['retcode'] != 0 and out['stderr']:
+        errors = [out['stderr']]
+    else:
+        errors = []
+
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return salt.utils.compare_dicts(old, new)
+    ret = salt.utils.compare_dicts(old, new)
+
+    if errors:
+        raise CommandExecutionError(
+            'Problem encountered removing package(s)',
+            info={'errors': errors, 'changes': ret}
+        )
+
+    return ret
 
 
 def purge(name=None, slot=None, fromrepo=None, pkgs=None, **kwargs):

--- a/salt/modules/macports.py
+++ b/salt/modules/macports.py
@@ -58,7 +58,11 @@ def __virtual__():
 
     if salt.utils.which('port') and __grains__['os'] == 'MacOS':
         return __virtualname__
-    return (False, 'The macports execution module cannot be loaded: only available on MacOS with the port binary in the path.')
+    return (
+        False,
+        'The macports execution module cannot be loaded: only available on '
+        'MacOS with the \'port\' binary in the PATH.'
+    )
 
 
 def _list(query=''):
@@ -228,10 +232,28 @@ def remove(name=None, pkgs=None, **kwargs):
         return {}
     cmd = ['port', 'uninstall']
     cmd.extend(targets)
-    __salt__['cmd.run_all'](cmd, output_loglevel='trace', python_shell=False)
+
+    out = __salt__['cmd.run_all'](
+        cmd,
+        output_loglevel='trace',
+        python_shell=False
+    )
+    if out['retcode'] != 0 and out['stderr']:
+        errors = [out['stderr']]
+    else:
+        errors = []
+
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return salt.utils.compare_dicts(old, new)
+    ret = salt.utils.compare_dicts(old, new)
+
+    if errors:
+        raise CommandExecutionError(
+            'Problem encountered removing package(s)',
+            info={'errors': errors, 'changes': ret}
+        )
+
+    return ret
 
 
 def install(name=None, refresh=False, pkgs=None, **kwargs):
@@ -326,10 +348,27 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
     cmd = ['port', 'install']
     cmd.extend(formulas_array)
 
-    __salt__['cmd.run'](cmd, output_loglevel='trace', python_shell=False)
+    out = __salt__['cmd.run_all'](
+        cmd,
+        output_loglevel='trace',
+        python_shell=False
+    )
+    if out['retcode'] != 0 and out['stderr']:
+        errors = [out['stderr']]
+    else:
+        errors = []
+
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return salt.utils.compare_dicts(old, new)
+    ret = salt.utils.compare_dicts(old, new)
+
+    if errors:
+        raise CommandExecutionError(
+            'Problem encountered installing package(s)',
+            info={'errors': errors, 'changes': ret}
+        )
+
+    return ret
 
 
 def list_upgrades(refresh=True):
@@ -401,13 +440,29 @@ def upgrade(refresh=True):  # pylint: disable=W0613
 
         salt '*' pkg.upgrade
     '''
+    ret = {'changes': {},
+           'result': True,
+           'comment': '',
+           }
+
     if refresh:
         refresh_db()
 
     old = list_pkgs()
     cmd = ['port', 'upgrade', 'outdated']
 
-    __salt__['cmd.run_all'](cmd, output_loglevel='trace', python_shell=False)
+    call = __salt__['cmd.run_all'](cmd,
+                                   output_loglevel='trace',
+                                   python_shell=False,
+                                   redirect_stderr=True)
+
+    if call['retcode'] != 0:
+        ret['result'] = False
+        if call['stdout']:
+            ret['comment'] = call['stdout']
+
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return salt.utils.compare_dicts(old, new)
+    ret['changes'] = salt.utils.compare_dicts(old, new)
+
+    return ret

--- a/salt/modules/openbsdpkg.py
+++ b/salt/modules/openbsdpkg.py
@@ -173,16 +173,31 @@ def install(name=None, pkgs=None, sources=None, **kwargs):
         return {}
 
     old = list_pkgs()
+    errors = []
     for pkg in pkg_params:
         if pkg_type == 'repository':
             stem, flavor = (pkg.split('--') + [''])[:2]
             pkg = '--'.join((stem, flavor))
         cmd = 'pkg_add -x {0}'.format(pkg)
-        __salt__['cmd.run'](cmd, python_shell=False, output_loglevel='trace')
+        out = __salt__['cmd.run_all'](
+            cmd,
+            python_shell=False,
+            output_loglevel='trace'
+        )
+        if out['retcode'] != 0 and out['stderr']:
+            errors.append(out['stderr'])
 
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return salt.utils.compare_dicts(old, new)
+    ret = salt.utils.compare_dicts(old, new)
+
+    if errors:
+        raise CommandExecutionError(
+            'Problem encountered installing package(s)',
+            info={'errors': errors, 'changes': ret}
+        )
+
+    return ret
 
 
 def remove(name=None, pkgs=None, **kwargs):
@@ -220,10 +235,28 @@ def remove(name=None, pkgs=None, **kwargs):
         return {}
 
     cmd = 'pkg_delete -xD dependencies {0}'.format(' '.join(targets))
-    __salt__['cmd.run'](cmd, python_shell=False, output_loglevel='trace')
+
+    out = __salt__['cmd.run_all'](
+        cmd,
+        python_shell=False,
+        output_loglevel='trace'
+    )
+    if out['retcode'] != 0 and out['stderr']:
+        errors = [out['stderr']]
+    else:
+        errors = []
+
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return salt.utils.compare_dicts(old, new)
+    ret = salt.utils.compare_dicts(old, new)
+
+    if errors:
+        raise CommandExecutionError(
+            'Problem encountered removing package(s)',
+            info={'errors': errors, 'changes': ret}
+        )
+
+    return ret
 
 
 def purge(name=None, pkgs=None, **kwargs):

--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -243,10 +243,28 @@ def install(name=None,
     if refreshdb:
         refresh_db()
 
-    __salt__['cmd.run'](cmd, output_loglevel='trace', python_shell=False)
+    out = __salt__['cmd.run_all'](
+        cmd,
+        output_loglevel='trace',
+        python_shell=False
+    )
+
+    if out['retcode'] != 0 and out['stderr']:
+        errors = [out['stderr']]
+    else:
+        errors = []
+
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return salt.utils.compare_dicts(old, new)
+    ret = salt.utils.compare_dicts(old, new)
+
+    if errors:
+        raise CommandExecutionError(
+            'Problem encountered installing package(s)',
+            info={'errors': errors, 'changes': ret}
+        )
+
+    return ret
 
 
 def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument
@@ -285,10 +303,28 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument
         return {}
     cmd = ['opkg', 'remove']
     cmd.extend(targets)
-    __salt__['cmd.run'](cmd, output_loglevel='trace', python_shell=False)
+
+    out = __salt__['cmd.run_all'](
+        cmd,
+        output_loglevel='trace',
+        python_shell=False
+    )
+    if out['retcode'] != 0 and out['stderr']:
+        errors = [out['stderr']]
+    else:
+        errors = []
+
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return salt.utils.compare_dicts(old, new)
+    ret = salt.utils.compare_dicts(old, new)
+
+    if errors:
+        raise CommandExecutionError(
+            'Problem encountered removing package(s)',
+            info={'errors': errors, 'changes': ret}
+        )
+
+    return ret
 
 
 def purge(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument
@@ -348,18 +384,18 @@ def upgrade(refresh=True):
     cmd = ['opkg', 'upgrade']
     call = __salt__['cmd.run_all'](cmd,
                                    output_loglevel='trace',
-                                   python_shell=False)
+                                   python_shell=False,
+                                   redirect_stderr=True)
 
     if call['retcode'] != 0:
         ret['result'] = False
-        if 'stderr' in call:
-            ret['comment'] += call['stderr']
-        if 'stdout' in call:
-            ret['comment'] += call['stdout']
-    else:
-        __context__.pop('pkg.list_pkgs', None)
-        new = list_pkgs()
-        ret['changes'] = salt.utils.compare_dicts(old, new)
+        if call['stdout']:
+            ret['comment'] = call['stdout']
+
+    __context__.pop('pkg.list_pkgs', None)
+    new = list_pkgs()
+    ret['changes'] = salt.utils.compare_dicts(old, new)
+
     return ret
 
 

--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -5,9 +5,10 @@ Package support for pkgin based systems, inspired from freebsdpkg module
 
 # Import python libs
 from __future__ import absolute_import
+import copy
+import logging
 import os
 import re
-import logging
 
 # Import salt libs
 import salt.utils
@@ -243,6 +244,14 @@ def list_pkgs(versions_as_list=False, **kwargs):
             for x in ('removed', 'purge_desired')]):
         return {}
 
+    if 'pkg.list_pkgs' in __context__:
+        if versions_as_list:
+            return __context__['pkg.list_pkgs']
+        else:
+            ret = copy.deepcopy(__context__['pkg.list_pkgs'])
+            __salt__['pkg_resource.stringify'](ret)
+            return ret
+
     pkgin = _check_pkgin()
     if pkgin:
         pkg_command = '{0} ls'.format(pkgin)
@@ -262,6 +271,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
         __salt__['pkg_resource.add_pkg'](ret, pkg, ver)
 
     __salt__['pkg_resource.sort_pkglist'](ret)
+    __context__['pkg.list_pkgs'] = copy.deepcopy(ret)
     if not versions_as_list:
         __salt__['pkg_resource.stringify'](ret)
     return ret
@@ -356,15 +366,30 @@ def install(name=None, refresh=False, fromrepo=None,
     args.extend(pkg_params)
 
     old = list_pkgs()
-    __salt__['cmd.run'](
+
+    out = __salt__['cmd.run_all'](
         '{0} {1}'.format(cmd, ' '.join(args)),
         env=env,
         output_loglevel='trace'
     )
+
+    if out['retcode'] != 0 and out['stderr']:
+        errors = [out['stderr']]
+    else:
+        errors = []
+
+    __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
+    ret = salt.utils.compare_dicts(old, new)
+
+    if errors:
+        raise CommandExecutionError(
+            'Problem encountered installing package(s)',
+            info={'errors': errors, 'changes': ret}
+        )
 
     _rehash()
-    return salt.utils.compare_dicts(old, new)
+    return ret
 
 
 def upgrade():
@@ -393,17 +418,22 @@ def upgrade():
         return {}
 
     old = list_pkgs()
-    call = __salt__['cmd.run_all']('{0} -y fug'.format(pkgin))
+
+    cmd = [pkgin, '-y', 'fug']
+    call = __salt__['cmd.run_all'](cmd,
+                                   output_loglevel='trace',
+                                   python_shell=False,
+                                   redirect_stderr=True)
+
     if call['retcode'] != 0:
         ret['result'] = False
-        if 'stderr' in call:
-            ret['comment'] += call['stderr']
-        if 'stdout' in call:
-            ret['comment'] += call['stdout']
-    else:
-        __context__.pop('pkg.list_pkgs', None)
-        new = list_pkgs()
-        ret['changes'] = salt.utils.compare_dicts(old, new)
+        if call['stdout']:
+            ret['comment'] = call['stdout']
+
+    __context__.pop('pkg.list_pkgs', None)
+    new = list_pkgs()
+    ret['changes'] = salt.utils.compare_dicts(old, new)
+
     return ret
 
 
@@ -465,10 +495,27 @@ def remove(name=None, pkgs=None, **kwargs):
     else:
         cmd = 'pkg_remove {0}'.format(for_remove)
 
-    __salt__['cmd.run'](cmd, output_loglevel='trace')
-    new = list_pkgs()
+    out = __salt__['cmd.run_all'](
+        cmd,
+        output_loglevel='trace'
+    )
 
-    return salt.utils.compare_dicts(old, new)
+    if out['retcode'] != 0 and out['stderr']:
+        errors = [out['stderr']]
+    else:
+        errors = []
+
+    __context__.pop('pkg.list_pkgs', None)
+    new = list_pkgs()
+    ret = salt.utils.compare_dicts(old, new)
+
+    if errors:
+        raise CommandExecutionError(
+            'Problem encountered removing package(s)',
+            info={'errors': errors, 'changes': ret}
+        )
+
+    return ret
 
 
 def purge(name=None, pkgs=None, **kwargs):

--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -32,11 +32,13 @@ Or you can override it globally by setting the :conf_minion:`providers` paramete
 # Import python libs
 from __future__ import print_function
 from __future__ import absolute_import
+import copy
 import logging
 
 
 # Import salt libs
 import salt.utils
+from salt.exceptions import CommandExecutionError
 
 # Define the module's virtual name
 __virtualname__ = 'pkg'
@@ -47,21 +49,26 @@ def __virtual__():
     '''
     Set the virtual pkg module if the os is Solaris 11
     '''
-    if __grains__['os'] == 'Solaris' and float(__grains__['kernelrelease']) > 5.10:
+    if __grains__['os'] == 'Solaris' \
+            and float(__grains__['kernelrelease']) > 5.10:
         return __virtualname__
-    return (False, 'The solarisips execution module failed to load: only available on Solaris >= 11.')
+    return (False,
+            'The solarisips execution module failed to load: only available '
+            'on Solaris >= 11.')
 
 
 ips_pkg_return_values = {
-        0: 'Command succeeded.',
-        1: 'An error occurred.',
-        2: 'Invalid command line options were specified.',
-        3: 'Multiple operations were requested, but only some of them succeeded.',
-        4: 'No changes were made - nothing to do.',
-        5: 'The requested operation cannot be performed on a  live image.',
-        6: 'The requested operation cannot  be  completed  because the  licenses  for  the  packages  being  installed or updated have not been accepted.',
-        7: 'The image is currently in use by another process and cannot be modified.'
-        }
+    0: 'Command succeeded.',
+    1: 'An error occurred.',
+    2: 'Invalid command line options were specified.',
+    3: 'Multiple operations were requested, but only some of them succeeded.',
+    4: 'No changes were made - nothing to do.',
+    5: 'The requested operation cannot be performed on a  live image.',
+    6: 'The requested operation cannot be completed because the licenses for '
+       'the packages being installed or updated have not been accepted.',
+    7: 'The image is currently in use by another process and cannot be '
+       'modified.'
+}
 
 
 def _ips_get_pkgname(line):
@@ -90,9 +97,16 @@ def _ips_get_pkgversion(line):
 
 def refresh_db(full=False):
     '''
-    Updates the remote repos database. You can force the full pkg DB refresh from all publishers regardless the last refresh time.
+    Updates the remote repos database.
 
-    CLI Example::
+    full : False
+
+        Set to ``True`` to force a refresh of the pkg DB from all publishers,
+        regardless of the last refresh time.
+
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.refresh_db
         salt '*' pkg.refresh_db full=True
@@ -108,7 +122,9 @@ def upgrade_available(name):
     Check if there is an upgrade available for a certain package
     Accepts full or partial FMRI. Returns all matches found.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.upgrade_available apache-22
     '''
@@ -127,10 +143,19 @@ def list_upgrades(refresh=False):
     '''
     Lists all packages available for update.
     When run in global zone, it reports only upgradable packages for the global zone.
-    When run in non-global zone, it can report more upgradable packages than "pkg update -vn" because "pkg update" hides packages that require newer version of pkg://solaris/entire (which means that they can be upgraded only from global zone). Simply said: if you see pkg://solaris/entire in the list of upgrades, you should upgrade the global zone to get all possible updates.
-    You can force full pkg DB refresh before listing.
+    When run in non-global zone, it can report more upgradable packages than
+    "pkg update -vn" because "pkg update" hides packages that require newer
+    version of pkg://solaris/entire (which means that they can be upgraded only
+    from global zone). Simply said: if you see pkg://solaris/entire in the list
+    of upgrades, you should upgrade the global zone to get all possible
+    updates.
 
-    CLI Example::
+    refresh : False
+        Set to ``True`` to force a full pkg DB refresh before listing
+
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.list_upgrades
         salt '*' pkg.list_upgrades refresh=True
@@ -149,14 +174,24 @@ def upgrade(refresh=False, **kwargs):
     '''
     Upgrade all packages to the latest possible version.
     When run in global zone, it updates also all non-global zones.
-    In non-global zones upgrade is limited by dependency constrains linked to the version of pkg://solaris/entire.
+    In non-global zones upgrade is limited by dependency constrains linked to
+    the version of pkg://solaris/entire.
 
-    Returns also a raw output of "pkg update" command (because if update creates a new boot environment, no immediate changes are visible in "pkg list").
+    Returns also the raw output of the ``pkg update`` command (because if
+    update creates a new boot environment, no immediate changes are visible in
+    ``pkg list``).
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.upgrade
     '''
+    ret = {'changes': {},
+           'result': True,
+           'comment': '',
+           }
+
     if salt.utils.is_true(refresh):
         refresh_db()
 
@@ -166,22 +201,26 @@ def upgrade(refresh=False, **kwargs):
 
     # Install or upgrade the package
     # If package is already installed
-    cmd = 'pkg update -v --accept '
-    ret = __salt__['cmd.run_all'](cmd)
+    cmd = ['pkg', 'update', '-v', '--accept']
+    out = __salt__['cmd.run_all'](cmd,
+                                  output_loglevel='trace',
+                                  python_shell=False)
 
-    # Get a list of the packages again, including newly installed ones.
+    __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
+    ret = salt.utils.compare_dicts(old, new)
 
-    changes = salt.utils.compare_dicts(old, new)
+    if out['retcode'] != 0:
+        raise CommandExecutionError(
+            'Error occurred updating package(s)',
+            info={
+                'changes': ret,
+                'retcode': ips_pkg_return_values[out['retcode']],
+                'errors': [out['stderr']]
+            }
+        )
 
-    output = {}
-    output['changes_in_current_be'] = changes
-    if ret['retcode']:
-        output['retcode'] = ips_pkg_return_values[ret['retcode']]   # translate error code if applicable
-        output['message'] = ret['stderr'] + '\n'
-    else:
-        output['raw_out'] = ret['stdout'] + '\n'
-    return output
+    return ret
 
 
 def list_pkgs(versions_as_list=False, **kwargs):
@@ -190,7 +229,9 @@ def list_pkgs(versions_as_list=False, **kwargs):
 
         {'<package_name>': '<version>'}
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.list_pkgs
     '''
@@ -198,6 +239,14 @@ def list_pkgs(versions_as_list=False, **kwargs):
     if any([salt.utils.is_true(kwargs.get(x))
         for x in ('removed', 'purge_desired')]):
         return {}
+
+    if 'pkg.list_pkgs' in __context__:
+        if versions_as_list:
+            return __context__['pkg.list_pkgs']
+        else:
+            ret = copy.deepcopy(__context__['pkg.list_pkgs'])
+            __salt__['pkg_resource.stringify'](ret)
+            return ret
 
     ret = {}
     cmd = '/bin/pkg list -Hv'
@@ -208,6 +257,8 @@ def list_pkgs(versions_as_list=False, **kwargs):
         version = _ips_get_pkgversion(line)
         __salt__['pkg_resource.add_pkg'](ret, name, version)
 
+    __salt__['pkg_resource.sort_pkglist'](ret)
+    __context__['pkg.list_pkgs'] = copy.deepcopy(ret)
     if not versions_as_list:
         __salt__['pkg_resource.stringify'](ret)
     return ret
@@ -218,7 +269,9 @@ def version(*names, **kwargs):
     Common interface for obtaining the version of installed packages.
     Accepts full or partial FMRI. If called using pkg_resource, full FMRI is required.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.version vim
         salt '*' pkg.version foo bar baz
@@ -241,11 +294,13 @@ def version(*names, **kwargs):
 def latest_version(name, **kwargs):
     '''
     The available version of the package in the repository.
-    In case of multiple match, it returns list of all matched packages.
+    In case of multiple matches, it returns list of all matched packages.
     Accepts full or partial FMRI.
     Please use pkg.latest_version as pkg.available_version is being deprecated.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.latest_version pkg://solaris/entire
     '''
@@ -267,7 +322,9 @@ def get_fmri(name, **kwargs):
     Returns FMRI from partial name. Returns empty string ('') if not found.
     In case of multiple match, the function returns list of all matched packages.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.get_fmri bash
     '''
@@ -289,8 +346,9 @@ def get_fmri(name, **kwargs):
 
 def normalize_name(name, **kwargs):
     '''
-    Internal function. Normalizes pkg name to full FMRI before running pkg.install.
-    In case of multiple match or no match, it returns the name without modifications and lets the "pkg install" to decide what to do.
+    Internal function. Normalizes pkg name to full FMRI before running
+    pkg.install. In case of multiple matches or no match, it returns the name
+    without modifications.
 
     CLI Example:
 
@@ -319,7 +377,9 @@ def is_installed(name, **kwargs):
     Name can be full or partial FMRI.
     In case of multiple match from partial FMRI name, it returns True.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.is_installed bash
     '''
@@ -331,9 +391,12 @@ def is_installed(name, **kwargs):
 def search(name, versions_as_list=False, **kwargs):
     '''
     Searches the repository for given pkg name.
-    The name can be full or partial FMRI. All matches are printed. Globs are also supported.
+    The name can be full or partial FMRI. All matches are printed. Globs are
+    also supported.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.search bash
     '''
@@ -373,7 +436,9 @@ def install(name=None, refresh=False, pkgs=None, version=None, test=False, **kwa
         A list of packages to install. Must be passed as a python list.
 
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.install vim
         salt '*' pkg.install pkg://solaris/editor/vim
@@ -391,10 +456,15 @@ def install(name=None, refresh=False, pkgs=None, version=None, test=False, **kwa
     if pkgs:    # multiple packages specified
         for pkg in pkgs:
             if list(pkg.items())[0][1]:   # version specified
-                pkg2inst += '{0}@{1} '.format(list(pkg.items())[0][0], list(pkg.items())[0][1])
+                pkg2inst += '{0}@{1} '.format(list(pkg.items())[0][0],
+                                              list(pkg.items())[0][1])
             else:
                 pkg2inst += '{0} '.format(list(pkg.items())[0][0])
-        log.debug('Installing these packages instead of {0}: {1}'.format(name, pkg2inst))
+        log.debug(
+            'Installing these packages instead of {0}: {1}'.format(
+                name, pkg2inst
+            )
+        )
 
     else:   # install single package
         if version:
@@ -413,27 +483,29 @@ def install(name=None, refresh=False, pkgs=None, version=None, test=False, **kwa
     # Install or upgrade the package
     # If package is already installed
     cmd += '{0}'.format(pkg2inst)
-    #ret = __salt__['cmd.retcode'](cmd)
-    ret = __salt__['cmd.run_all'](cmd)
+
+    out = __salt__['cmd.run_all'](cmd, output_loglevel='trace')
 
     # Get a list of the packages again, including newly installed ones.
+    __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
+    ret = salt.utils.compare_dicts(old, new)
 
-    changes = salt.utils.compare_dicts(old, new)
-
-    if ret['retcode'] != 0:     # there's something worth looking at
-        output = {}             # so we're adding some additional info
-        output['changes'] = changes
-        output['retcode'] = ips_pkg_return_values[ret['retcode']]   # translate error code
-        output['message'] = ret['stderr'] + '\n'
-        return output
+    if out['retcode'] != 0:
+        raise CommandExecutionError(
+            'Error occurred installing package(s)',
+            info={
+                'changes': ret,
+                'retcode': ips_pkg_return_values[out['retcode']],
+                'errors': [out['stderr']]
+            }
+        )
 
     # No error occurred
     if test:
-        return "Test succeeded."
+        return 'Test succeeded.'
 
-    # Return a list of the new packages installed.
-    return changes
+    return ret
 
 
 def remove(name=None, pkgs=None, **kwargs):
@@ -454,49 +526,50 @@ def remove(name=None, pkgs=None, **kwargs):
 
     Returns a list containing the removed packages.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.remove <package name>
         salt '*' pkg.remove tcsh
         salt '*' pkg.remove pkg://solaris/shell/tcsh
         salt '*' pkg.remove pkgs='["foo", "bar"]'
     '''
-
-    # Check to see if the package is installed before we proceed
-    if not pkgs:
-        if not is_installed(name):
-            return ''
-
     pkg2rm = ''
     if pkgs:    # multiple packages specified
         for pkg in pkgs:
             pkg2rm += '{0} '.format(pkg)
-        log.debug('Installing these packages instead of {0}: {1}'.format(name, pkg2rm))
+        log.debug(
+            'Installing these packages instead of {0}: {1}'.format(
+                name, pkg2rm
+            )
+        )
     else:   # remove single package
-        pkg2rm = "{0}".format(name)
+        pkg2rm = '{0}'.format(name)
 
     # Get a list of the currently installed pkgs.
     old = list_pkgs()
 
     # Remove the package(s)
     cmd = '/bin/pkg uninstall -v {0}'.format(pkg2rm)
-    ret = __salt__['cmd.run_all'](cmd)
+    out = __salt__['cmd.run_all'](cmd, output_loglevel='trace')
 
     # Get a list of the packages after the uninstall
+    __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
+    ret = salt.utils.compare_dicts(old, new)
 
-    # Compare the pre and post remove package objects and report the uninstalled pkgs.
-    changes = salt.utils.compare_dicts(old, new)
+    if out['retcode'] != 0:
+        raise CommandExecutionError(
+            'Error occurred removing package(s)',
+            info={
+                'changes': ret,
+                'retcode': ips_pkg_return_values[out['retcode']],
+                'errors': [out['stderr']]
+            }
+        )
 
-    if ret['retcode'] != 0:     # there's something worth looking at
-        output = {}             # so we're adding some additional info
-        output['changes'] = changes
-        output['retcode'] = ips_pkg_return_values[ret['retcode']]   # translate error code
-        output['message'] = ret['stderr'] + '\n'
-        return output
-
-    # No error occurred
-    return changes
+    return ret
 
 
 def purge(name, **kwargs):
@@ -505,7 +578,9 @@ def purge(name, **kwargs):
 
     Returns a list containing the removed packages.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.purge <package name>
     '''

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -68,7 +68,9 @@ def _write_adminfile(kwargs):
 
 def list_pkgs(versions_as_list=False, **kwargs):
     '''
-    List the packages currently installed as a dict::
+    List the packages currently installed as a dict:
+
+    .. code-block:: python
 
         {'<package_name>': '<version>'}
 
@@ -185,31 +187,39 @@ def version(*names, **kwargs):
 def install(name=None, sources=None, saltenv='base', **kwargs):
     '''
     Install the passed package. Can install packages from the following
-    sources::
+    sources:
 
-        * Locally (package already exists on the minion
-        * HTTP/HTTPS server
-        * FTP server
-        * Salt master
+    * Locally (package already exists on the minion
+    * HTTP/HTTPS server
+    * FTP server
+    * Salt master
 
-    Returns a dict containing the new package names and versions::
+    Returns a dict containing the new package names and versions:
+
+    .. code-block:: python
 
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
 
-    CLI Example, installing a data stream pkg that already exists on the
-    minion::
+    CLI Examples:
+
+    .. code-block:: bash
+
+        # Installing a data stream pkg that already exists on the minion
 
         salt '*' pkg.install sources='[{"<pkg name>": "/dir/on/minion/<pkg filename>"}]'
         salt '*' pkg.install sources='[{"SMClgcc346": "/var/spool/pkg/gcc-3.4.6-sol10-sparc-local.pkg"}]'
 
-    CLI Example, installing a data stream pkg that exists on the salt master::
+        # Installing a data stream pkg that exists on the salt master
 
         salt '*' pkg.install sources='[{"<pkg name>": "salt://pkgs/<pkg filename>"}]'
         salt '*' pkg.install sources='[{"SMClgcc346": "salt://pkgs/gcc-3.4.6-sol10-sparc-local.pkg"}]'
 
-    CLI Example, installing a data stream pkg that exists on a HTTP server::
+    CLI Example:
 
+    .. code-block:: bash
+
+        # Installing a data stream pkg that exists on a HTTP server
         salt '*' pkg.install sources='[{"<pkg name>": "http://packages.server.com/<pkg filename>"}]'
         salt '*' pkg.install sources='[{"SMClgcc346": "http://packages.server.com/gcc-3.4.6-sol10-sparc-local.pkg"}]'
 
@@ -220,8 +230,11 @@ def install(name=None, sources=None, saltenv='base', **kwargs):
     package in the global zone is to install it in all zones. This overrides
     that and installs the package only in the global.
 
-    CLI Example, installing a data stream package only in the global zone::
+    CLI Example:
 
+    .. code-block:: bash
+
+        # Installing a data stream package only in the global zone:
         salt 'global_zone' pkg.install sources='[{"SMClgcc346": "/var/spool/pkg/gcc-3.4.6-sol10-sparc-local.pkg"}]' current_zone_only=True
 
     By default salt automatically provides an adminfile, to automate package
@@ -245,17 +258,24 @@ def install(name=None, sources=None, saltenv='base', **kwargs):
     providing your own adminfile to the minions.
 
     Note: You can find all of the possible options to provide to the adminfile
-    by reading the admin man page::
+    by reading the admin man page:
+
+    .. code-block:: bash
 
         man -s 4 admin
 
-    CLI Example - Overriding the 'instance' adminfile option when calling the
-    module directly::
+    CLI Example:
 
+    .. code-block:: bash
+
+        # Overriding the 'instance' adminfile option when calling the module directly
         salt '*' pkg.install sources='[{"<pkg name>": "salt://pkgs/<pkg filename>"}]' instance="overwrite"
 
-    CLI Example - Overriding the 'instance' adminfile option when used in a
-    state::
+    SLS Example:
+
+    .. code-block:: yaml
+
+        # Overriding the 'instance' adminfile option when used in a state
 
         SMClgcc346:
           pkg.installed:
@@ -263,15 +283,19 @@ def install(name=None, sources=None, saltenv='base', **kwargs):
               - SMClgcc346: salt://srv/salt/pkgs/gcc-3.4.6-sol10-sparc-local.pkg
             - instance: overwrite
 
-    Note: the ID declaration is ignored, as the package name is read from the
-    "sources" parameter.
+    .. note::
+        The ID declaration is ignored, as the package name is read from the
+        ``sources`` parameter.
 
-    CLI Example - Providing your own adminfile when calling the module
-    directly::
+    CLI Example:
+
+    .. code-block:: bash
+
+        # Providing your own adminfile when calling the module directly
 
         salt '*' pkg.install sources='[{"<pkg name>": "salt://pkgs/<pkg filename>"}]' admin_source='salt://pkgs/<adminfile filename>'
 
-    CLI Example - Providing your own adminfile when using states::
+        # Providing your own adminfile when using states
 
         <pkg name>:
           pkg.installed:
@@ -279,8 +303,9 @@ def install(name=None, sources=None, saltenv='base', **kwargs):
               - <pkg name>: salt://pkgs/<pkg filename>
             - admin_source: salt://pkgs/<adminfile filename>
 
-    Note: the ID declaration is ignored, as the package name is read from the
-    "sources" parameter.
+    .. note::
+        The ID declaration is ignored, as the package name is read from the
+        ``sources`` parameter.
     '''
     if salt.utils.is_true(kwargs.get('refresh')):
         log.warning('\'refresh\' argument not implemented for solarispkg '
@@ -308,28 +333,38 @@ def install(name=None, sources=None, saltenv='base', **kwargs):
         adminfile = _write_adminfile(kwargs)
 
     old = list_pkgs()
-    cmd = '/usr/sbin/pkgadd -n -a {0} '.format(adminfile)
+    cmd_prefix = '/usr/sbin/pkgadd -n -a {0} '.format(adminfile)
 
     # Only makes sense in a global zone but works fine in non-globals.
     if kwargs.get('current_zone_only') == 'True':
-        cmd += '-G '
+        cmd_prefix += '-G '
 
+    errors = []
     for pkg in pkg_params:
-        temp_cmd = cmd + '-d {0} "all"'.format(pkg)
+        cmd = cmd_prefix + '-d {0} "all"'.format(pkg)
         # Install the package{s}
-        __salt__['cmd.run'](
-                temp_cmd,
-                python_shell=False,
-                output_loglevel='trace')
+        out = __salt__['cmd.run_all'](cmd,
+                                      output_loglevel='trace',
+                                      python_shell=False)
+
+        if out['retcode'] != 0 and out['stderr']:
+            errors.append(out['stderr'])
 
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
+    ret = salt.utils.compare_dicts(old, new)
+
+    if errors:
+        raise CommandExecutionError(
+            'Problem encountered installing package(s)',
+            info={'errors': errors, 'changes': ret}
+        )
 
     # Remove the temp adminfile
     if 'admin_source' not in kwargs:
         os.unlink(adminfile)
 
-    return salt.utils.compare_dicts(old, new)
+    return ret
 
 
 def remove(name=None, pkgs=None, saltenv='base', **kwargs):
@@ -431,15 +466,31 @@ def remove(name=None, pkgs=None, saltenv='base', **kwargs):
         os.close(fd_)
 
     # Remove the package
-    cmd = '/usr/sbin/pkgrm -n -a {0} {1}'.format(adminfile,
-                                                 ' '.join(targets))
-    __salt__['cmd.run'](cmd, python_shell=False, output_loglevel='trace')
+    cmd = ['/usr/sbin/pkgrm', '-n', '-a', adminfile] + targets
+    out = __salt__['cmd.run_all'](cmd,
+                                  python_shell=False,
+                                  output_loglevel='trace')
+
+    if out['retcode'] != 0 and out['stderr']:
+        errors = [out['stderr']]
+    else:
+        errors = []
+
+    __context__.pop('pkg.list_pkgs', None)
+    new = list_pkgs()
+    ret = salt.utils.compare_dicts(old, new)
+
+    if errors:
+        raise CommandExecutionError(
+            'Problem encountered removing package(s)',
+            info={'errors': errors, 'changes': ret}
+        )
+
     # Remove the temp adminfile
     if 'admin_source' not in kwargs:
         os.unlink(adminfile)
-    __context__.pop('pkg.list_pkgs', None)
-    new = list_pkgs()
-    return salt.utils.compare_dicts(old, new)
+
+    return ret
 
 
 def purge(name=None, pkgs=None, **kwargs):

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -86,9 +86,6 @@ these states. Here is some example SLS:
 '''
 from __future__ import absolute_import
 
-# Import python libs
-import sys
-
 # Import salt libs
 import salt.utils
 
@@ -372,12 +369,7 @@ def managed(name, **kwargs):
         ret['result'] = False
         ret['comment'] = \
             'Failed to confirm config of repo {0!r}: {1}'.format(name, exc)
-    # Clear cache of available packages, if present, since changes to the
-    # repositories may change the packages that are available.
-    if ret['changes']:
-        sys.modules[
-            __salt__['test.ping'].__module__
-        ].__context__.pop('pkg._avail', None)
+
     return ret
 
 
@@ -497,12 +489,5 @@ def absent(name, **kwargs):
     else:
         ret['result'] = False
         ret['comment'] = 'Failed to remove repo {0}'.format(name)
-
-    # Clear cache of available packages, if present, since changes to the
-    # repositories may change the packages that are available.
-    if ret['changes']:
-        sys.modules[
-            __salt__['test.ping'].__module__
-        ].__context__.pop('pkg._avail', None)
 
     return ret


### PR DESCRIPTION
This pull request modifies the `CommandExecutionError` exception, adding an
optional parameter `info` via which additional information about the failure
can be passed. If present, this value will be passed through the nested
outputter and added to the CLI return data. This allows us to report on partial
changes while still raising an exception.

``` python
if errors:
    raise CommandExecutionError(
        'Failed to do foo and/or bar',
        info={'errors': errors, 'changes': changes}
    )
```

This would result in the information returned to the master looking something
like this:

```
myminion:
    ERROR: Failed to do foo and/or bar. Additional info follows:

    changes:
        ----------
        baz:
            ----------
            old:
                123
            new:
                456
    errors:
        - foo failed with return code 1
        - bar failed with return code 127
```

3 new attributes have been added to all CommandExecutionError instances.
Assuming a CommandExecutionError instance named `exc`, these would be:
- `exc.error` - The string passed as the first postional parameter when
  raising the error. This is equivalent to what used to be available as
  `exc.strerror`, since this attribute now contains the additional
  information passed through the nested outputter. Note that if no `info`
  param is passed, `exc.error` and `exc.strerror` will both contain the
  same information.
- `exc.info` - The data structure passed as the newly-added `info` param
  when raising the exception.
- `exc.strerror_without_changes` - One useful application of this new
  functionality in `CommandExecutionError` is to use it to funnel partial
  changes in a failed state back up to the state function via try/except.
  However, when the `info` dict contains a `changes` parameter, this
  results in `exc.strerror` containing the changes. However, we want those
  changes to be in the `changes` key in the state return data, and having
  them in the comment for the state would be redundant as we'd get the changes
  displayed twice in the return data. Hence this attribute, which contains the
  nested output of the `info` dict like `exc.strerror`, minus the
  `changes` key. If `exc.info` contains just a `changes` key, then
  `exc.strerror_without_changes` will be the same as `exc.error` (that is,
  the error string passed when raising the exception).

The `info` param for the this exception does not need to be a dictionary, it
can be a list or string or int or float, anything that can be displayed using
the nested outputter. If it is not a dictionary, then
`exc.strerror_without_changes` will be identical to `exc.strerror`.

The pkg states now leverage this new information available to
CommandExecutionError instances to accurately report on partial changes made
during failed states. The package providers have in turn been modified to track
errors and report them via the new `info` param. This also has the benefit of
making calls to `pkg.install` more informative, as in the past we would just
be returning an empty dictionary if a package installation failed. The onus was
on the user to check the minion logs for errors. Now, these errors will be
shown right there in the return data, which will make troubleshooting failed
`pkg.install` calls much more convenient.
