### PR TITLE
fix pillar sqlite3 documentation examples

### DIFF
--- a/salt/pillar/sqlite3.py
+++ b/salt/pillar/sqlite3.py
@@ -40,7 +40,7 @@ Complete example
           fromdb:
             query: 'SELECT col1,col2,col3,col4,col5,col6,col7
                       FROM some_random_table
-                     WHERE minion_pattern LIKE %s'
+                     WHERE minion_pattern LIKE ?'
             depth: 5
             as_list: True
             with_lists: [1,3]


### PR DESCRIPTION
The default examples provided in the pillar sqlite3 module are incorrect and generate
a syntax error when used. This is because sqlite3 uses qmark paramstyle but the
examples use format paramstyle.

Fixes #29736
