### PR TITLE
Type mess in git.latest

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -104,6 +104,8 @@ def _uptodate(ret, target, comments=None):
         # Shouldn't be making any changes if the repo was up to date, but
         # report on them so we are alerted to potential problems with our
         # logic.
+        if isinstance(comments, list):
+            comments = '\n'.join(comments)
         ret['comment'] += '\n\nChanges made: ' + comments
     return ret
 


### PR DESCRIPTION
Did not get why, but we can have a list of comments instead of stings.

This fixes:

```
     line 107, in _uptodate\n    ret['comment'] += '\\n\\nChanges made: ' + comments\nTypeError:
      cannot concatenate 'str' and 'list' objects\n"
    duration: 366.804
    name: https://github.com/makinacorpus/makina-states.git
    result: false
```
