### PR TITLE
fix pillar sqlite not honouring config options

### DIFF
--- a/salt/pillar/sqlite3.py
+++ b/salt/pillar/sqlite3.py
@@ -79,6 +79,11 @@ class SQLite3ExtPillar(SqlBaseExtPillar):
                     'timeout': 5.0}
         _options = {}
         _opts = __opts__.get('pillar', {}).get('sqlite3', {})
+        if 'database' not in _opts:
+            _sqlite3_opts = __opts__.get('pillar', {}).get('master', {})\
+                .get('pillar', {}).get('sqlite3')
+            if _sqlite3_opts is not None:
+                _opts = _sqlite3_opts
         for attr in defaults:
             if attr not in _opts:
                 log.debug('Using default for SQLite3 pillar {0}'.format(attr))


### PR DESCRIPTION
Pillar Sqlite3 does not honour database config option when using salt-call, this fixes the issue

Fixes #29741
