### PR TITLE
Append missing wget in debian installation guide

### DIFF
--- a/doc/topics/installation/debian.rst
+++ b/doc/topics/installation/debian.rst
@@ -23,7 +23,7 @@ To install using the SaltStack repository:
 
    .. code-block:: bash
 
-       https://repo.saltstack.com/apt/debian/8/amd64/latest/SALTSTACK-GPG-KEY.pub | sudo apt-key add -
+       wget -O - https://repo.saltstack.com/apt/debian/8/amd64/latest/SALTSTACK-GPG-KEY.pub | sudo apt-key add -
 
 #. Add the following line to ``/etc/apt/sources.list``:
 


### PR DESCRIPTION
I was going through the installation docs for `debian` and noticed it was missing a `wget` in Step 1.
