### PR TITLE
The cron module does not work with SmartOS

### DIFF
--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -152,7 +152,7 @@ def _get_cron_cmdstr(path, user=None):
     '''
     cmd = 'crontab'
 
-    if user:
+    if user and __grains__.get('os_family') not in ('Solaris', 'AIX'):
         cmd += ' -u {0}'.format(user)
 
     return '{0} {1}'.format(cmd, path)


### PR DESCRIPTION
The cron module in salt does not work completely with SmartOS, and likely Solaris and AIX.

The crontab command in these operating systems do not support a "-u" argument and in order to supply a crontab as a file for a particular user the crontab command needs to be executed as that user in the form of:

```
/usr/bin/crontab [filename]
```

This pull request only makes the cron module functional for the user that is running salt, but in my case, and I assume others using these operating systems, that is better than the module not working at all.  A better long-term fix may be need to be found.

This change has only been tested on SmartOS, but the man pages of Solaris and AIX were referenced and I assume they would be compatible with this change as well.

References:
- https://smartos.org/man/1/crontab
- https://docs.oracle.com/cd/E26502_01/html/E29030/crontab-1.html
- http://www-01.ibm.com/support/knowledgecenter/ssw_aix_61/com.ibm.aix.cmds1/crontab.htm
