### PR TITLE
modules.system: __virtual__ return err msg.

### DIFF
--- a/salt/modules/system.py
+++ b/salt/modules/system.py
@@ -12,7 +12,8 @@ def __virtual__():
     Only supported on POSIX-like systems
     '''
     if salt.utils.is_windows() or not salt.utils.which('shutdown'):
-        return False
+        return (False, 'The system execution module failed to load: '
+                'only available on Linux systems with shutdown command.')
     return True
 
 


### PR DESCRIPTION
Updated message in system  module when return False if system is not Linux or shutdown command is not available.
