### PR TITLE
Improve git fast-forward error message

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -985,8 +985,8 @@ def latest(name,
                         if isinstance(exc, CommandExecutionError):
                             msg += (
                                 '. Set \'force_fetch\' to True to force '
-                                'the fetch if the failure was due to it '
-                                'bein non-fast-forward. Output of the '
+                                'the fetch if the failure was due to not '
+                                'being able fast-forward. Output of the '
                                 'fetch command follows:\n\n'
                             )
                             msg += _strip_exc(exc)


### PR DESCRIPTION
Fixes a typo and improves slightly awkward copy when there is a `git fetch` failure.
