### PR TITLE
modules.pacman: __virtual__ return err msg.

### DIFF
--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -30,7 +30,7 @@ def __virtual__():
     '''
     if __grains__['os'] in ('Arch', 'Arch ARM'):
         return __virtualname__
-    return False
+    return (False, 'The pacman module could not be loaded: unsupported OS family.')
 
 
 def _list_removed(old, new):


### PR DESCRIPTION
Updated message in pacman module when return False if OS family is not supported.
