### PR TITLE
Fix a typo in the gpgkey URL

### DIFF
--- a/doc/topics/installation/rhel.rst
+++ b/doc/topics/installation/rhel.rst
@@ -58,7 +58,7 @@ To install using the SaltStack repository:
        baseurl=https://repo.saltstack.com/yum/redhat/$releasever/$basearch/latest
        enabled=1
        gpgcheck=1
-       gpgkey=https://repo.saltstack.com/yum/redhat/$releasever/$basearch/latest/$releaseverSALTSTACK-GPG-KEY.pub
+       gpgkey=https://repo.saltstack.com/yum/redhat/$releasever/$basearch/latest/$releasever/SALTSTACK-GPG-KEY.pub
 
    Version 5:
 


### PR DESCRIPTION
Without this change the documented yum repo configuration for RHEL 6/7 doesn't work.
