### PR TITLE
S3 Get binary method bug

### DIFF
--- a/salt/utils/s3.py
+++ b/salt/utils/s3.py
@@ -176,7 +176,7 @@ def query(key, keyid, method='GET', params=None, headers=None,
     # This can be used to save a binary object to disk
     if local_file and method == 'GET':
         log.debug('Saving to local file: {0}'.format(local_file))
-        with salt.utils.fopen(local_file, 'w') as out:
+        with salt.utils.fopen(local_file, 'wb') as out:
             out.write(response)
         return 'Saved to local file: {0}'.format(local_file)
 


### PR DESCRIPTION
Compressed file downloads are being corrupted due to not being written as binary. Add 'b' option to the write to enable binary writing, as the comment on the method infers.

Reproduced and tested on 2014.7.1 on Windows Minion.
