### PR TITLE
Only connect to event publisher when we want to listen

### DIFF
--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -353,7 +353,7 @@ class SaltEvent(object):
                     )
                 try:
                     self.io_loop.run_sync(
-                        lambda: self.subscriber.connect(timeout=timeout))
+                        lambda: self.pusher.connect(timeout=timeout))
                     self.cpush = True
                 except Exception:
                     pass

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -214,9 +214,13 @@ class SaltEvent(object):
         self.puburi, self.pulluri = self.__load_uri(sock_dir, node)
         self.pending_tags = []
         self.pending_events = []
-        if not self.cpub:
-            self.connect_pub()
         self.__load_cache_regex()
+        if listen and not self.cpub:
+            # Only connect to the publisher at initialization time if
+            # we know we want to listen. If we connect to the publisher
+            # and don't read out events from the buffer on an on-going basis,
+            # the buffer will grow resulting in big memory usage.
+            self.connect_pub()
 
     @classmethod
     def __load_cache_regex(cls):


### PR DESCRIPTION
Two commits:
- `connect_pull()` was erroneously using `self.subscriber` instead of
  `self.pusher` when connecting. So it would only work if `self.subscriber`
  was previously constructed with a call to `connect_pub()`.
- Only connect to the publisher at event initialization time if
  we know we want to listen. If we connect to the publisher
  and don't read out events from the buffer on an on-going basis,
  the buffer will grow resulting in big memory usage.
