### PR TITLE
Fixed typo in order to use the keyboard module for RHEL without systemd

### DIFF
--- a/salt/modules/keyboard.py
+++ b/salt/modules/keyboard.py
@@ -19,7 +19,7 @@ def __virtual__():
     Only works with systemd or on supported POSIX-like systems
     '''
     if salt.utils.which('localectl') \
-            or __grains__['os_family'] in ('Redhat', 'Debian', 'Gentoo'):
+            or __grains__['os_family'] in ('RedHat', 'Debian', 'Gentoo'):
         return True
     return False
 


### PR DESCRIPTION
Redhat is written "Redhat" instead of "RedHat" in the os_family check
