### PR TITLE
states.timezone: Fix 'desrired' typo

### DIFF
--- a/salt/states/timezone.py
+++ b/salt/states/timezone.py
@@ -63,7 +63,7 @@ def system(name, utc=True):
     except (SaltInvocationError, CommandExecutionError) as exc:
         ret['result'] = False
         ret['comment'] = (
-            'Unable to compare desrired timezone {0!r} to system timezone: {1}'
+            'Unable to compare desired timezone {0!r} to system timezone: {1}'
             .format(name, exc)
         )
         return ret

--- a/tests/unit/states/timezone_test.py
+++ b/tests/unit/states/timezone_test.py
@@ -46,7 +46,7 @@ class TimezoneTestCase(TestCase):
         with patch.dict(timezone.__salt__, {"timezone.zone_compare": mock,
                                             "timezone.get_hwclock": mock1,
                                             "timezone.set_hwclock": mock2}):
-            ret.update({'comment': "Unable to compare desrired timezone"
+            ret.update({'comment': "Unable to compare desired timezone"
                         " 'salt' to system timezone: ", 'result': False})
             self.assertDictEqual(timezone.system('salt'), ret)
 


### PR DESCRIPTION
Just a small fix of a typo I noticed in timezone.py :)
