### PR TITLE
Correctly handle unset port in ssh set_known_host

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -1042,7 +1042,7 @@ def set_known_host(user=None,
     if key:
         remote_host = {'hostname': hostname, 'enc': enc, 'key': key}
 
-    if hash_known_hosts or port == DEFAULT_SSH_PORT or ':' in remote_host['hostname']:
+    if hash_known_hosts or port in [DEFAULT_SSH_PORT, None] or ':' in remote_host['hostname']:
         line = '{hostname} {enc} {key}\n'.format(**remote_host)
     else:
         remote_host['port'] = port


### PR DESCRIPTION
According to the documentation the port parameter is optional and 22 is
used by default. But when the port was unset the hostname became:

```
[hostname]:None
```

Instead only the hostname should be output, as if the default port value
were provided.
