### PR TITLE
modules.jenkins: __virtual__ return err msg.

### DIFF
--- a/salt/modules/jenkins.py
+++ b/salt/modules/jenkins.py
@@ -46,7 +46,8 @@ def __virtual__():
     '''
     if HAS_JENKINS:
         return __virtualname__
-    return False
+    return (False, 'The jenkins execution module cannot be loaded: '
+            'python jenkins library is not installed.')
 
 
 def _connect():


### PR DESCRIPTION
Updated message in jenkins module when return False if python libraries are not installed.
