### PR TITLE
modules.bsd_shadow: __virtual__ return err msg.

### DIFF
--- a/salt/modules/bsd_shadow.py
+++ b/salt/modules/bsd_shadow.py
@@ -20,7 +20,10 @@ __virtualname__ = 'shadow'
 
 
 def __virtual__():
-    return __virtualname__ if 'BSD' in __grains__.get('os', '') else False
+    if 'BSD' in __grains__.get('os', ''):
+        return __virtualname__
+    return (False, 'The bsd_shadow execution module cannot be loaded: '
+            'only available on BSD family systems.')
 
 
 def default_hash():


### PR DESCRIPTION
Updated message in bsd_shadow module when return False if OS is not BSD family.
