### PR TITLE
modules.darwin_sysctl: __virtual__ return err msg.

### DIFF
--- a/salt/modules/darwin_sysctl.py
+++ b/salt/modules/darwin_sysctl.py
@@ -19,7 +19,10 @@ def __virtual__():
     '''
     Only run on Darwin (OS X) systems
     '''
-    return __virtualname__ if __grains__['os'] == 'MacOS' else False
+    if __grains__['os'] == 'MacOS':
+        return __virtualname__
+    return (False, 'The darwin_sysctl execution module cannot be loaded: '
+            'only available on MacOS systems.')
 
 
 def show(config_file=False):


### PR DESCRIPTION
Updated message in darwin_sysctl module when return False if OS is not OSX.
