### PR TITLE
Fixed Windows salt-master memory leaks in logger

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -784,6 +784,7 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
     def _setup_mp_logging_listener(self, *args):  # pylint: disable=unused-argument
         if self._setup_mp_logging_listener_:
             log.setup_multiprocessing_logging_listener(
+                self.config,
                 self._get_mp_logging_listener_queue()
             )
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -185,7 +185,9 @@ class TestDaemon(object):
         Start a master and minion
         '''
         # Setup the multiprocessing logging queue listener
-        salt_log_setup.setup_multiprocessing_logging_listener()
+        salt_log_setup.setup_multiprocessing_logging_listener(
+            self.parser.options
+        )
 
         # Set up PATH to mockbin
         self._enter_mockbin()


### PR DESCRIPTION
__process_multiprocessing_logging_queue:
- A leak was observed in this process on Windows. On Windows, creating a
  new process doesn't fork (copy the parent process image). Due to this, we
  need to setup extended logging inside this process. The leak was due to
  the temp null and temp logging handlers being active which just store
  messages but don't process them. Setting up extended logging removes
  those handlers and fixes the leak (as well as properly dealing with
  incoming logging messages).

setup_multiprocessing_logging:
- A leak was obversed in processes that used this on Windows. Similar
  to above, due to lack of fork, the new process will have the temp null
  and temp logging handlers enabled, causing the leak. In this function,
  removing those handlers prevents the leak.

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
