### PR TITLE
rework salt.module.zpool

### DIFF
--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -466,6 +466,8 @@ def set(zpool, prop, value):
     ret[zpool] = {}
     if isinstance(value, bool):
         value = 'on' if value else 'off'
+    elif ' ' in value:
+        value = "'{0}'".format(value)
 
     # get zpool list data
     zpool_cmd = _check_zpool()

--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -1206,4 +1206,39 @@ def offline(zpool, *vdevs, **kwargs):
         ret[zpool]['offlined'] = dlist
     return ret
 
+
+def reguid(zpool):
+    '''
+    .. verionadded:: Boron
+
+    Generates a new unique identifier for the pool
+
+    .. note::
+        You must ensure that all devices in this pool are online
+        and healthy before performing this action.
+
+    zpool : string
+        name of zpool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' zpool.exists myzpool
+    '''
+    ret = {}
+    ret[zpool] = {}
+
+    zpool_cmd = _check_zpool()
+    cmd = '{zpool_cmd} reguid {zpool}'.format(
+        zpool_cmd=zpool_cmd,
+        zpool=zpool
+    )
+    res = __salt__['cmd.run_all'](cmd, python_shell=False)
+    if res['retcode'] != 0:
+        ret[zpool] = res['stderr'] if 'stderr' in res and res['stderr'] != '' else res['stdout']
+    else:
+        ret[zpool] = 'reguided'
+    return ret
+
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -481,11 +481,16 @@ def scrub(zpool, stop=False):
     return ret
 
 
-def create(pool_name, *vdevs, **kwargs):
+def create(zpool, *vdevs, **kwargs):
     '''
     .. versionadded:: 2015.5.0
 
     Create a simple zpool, a mirrored zpool, a zpool having nested VDEVs, a hybrid zpool with cache, spare and log drives or a zpool with RAIDZ-1, RAIDZ-2 or RAIDZ-3
+
+    zpool : string
+        name of zpool
+    * : string
+        one or move devices
 
     CLI Example:
 
@@ -515,8 +520,8 @@ def create(pool_name, *vdevs, **kwargs):
     dlist = []
 
     # Check if the pool_name is already being used
-    if exists(pool_name):
-        ret['Error'] = 'Storage Pool `{0}` already exists'.format(pool_name)
+    if exists(zpool):
+        ret['Error'] = 'Storage Pool `{0}` already exists'.format(zpool)
         ret['retcode'] = 1
         return ret
 
@@ -542,10 +547,10 @@ def create(pool_name, *vdevs, **kwargs):
         dlist.append(vdev)
 
     devs = ' '.join(dlist)
-    zpool = _check_zpool()
+    zpool_cmd = _check_zpool()
     force = kwargs.get('force', False)
     properties = kwargs.get('properties', None)
-    cmd = '{0} create'.format(zpool)
+    cmd = '{0} create'.format(zpool_cmd)
 
     if force:
         cmd = '{0} -f'.format(cmd)
@@ -558,18 +563,18 @@ def create(pool_name, *vdevs, **kwargs):
             optlist.append('-o {0}={1}'.format(prop, properties[prop]))
         opts = ' '.join(optlist)
         cmd = '{0} {1}'.format(cmd, opts)
-    cmd = '{0} {1} {2}'.format(cmd, pool_name, devs)
+    cmd = '{0} {1} {2}'.format(cmd, zpool, devs)
 
     # Create storage pool
     res = __salt__['cmd.run'](cmd, python_shell=False)
 
     # Check and see if the pools is available
-    if exists(pool_name):
-        ret[pool_name] = 'created'
+    if exists(zpool):
+        ret[zpool] = 'created'
         return ret
     else:
         ret['Error'] = {}
-        ret['Error']['Messsage'] = 'Unable to create storage pool {0}'.format(pool_name)
+        ret['Error']['Messsage'] = 'Unable to create storage pool {0}'.format(zpool)
         ret['Error']['Reason'] = res
         ret['retcode'] = 5
 

--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -667,7 +667,7 @@ def attach(zpool, device, new_device, force=False):
 
     .. code-block:: bash
 
-        salt '*' zpool.add myzpool /path/to/vdev1 /path/to/vdev2 [...]
+        salt '*' zpool.attach myzpool /path/to/vdev1 /path/to/vdev2 [...]
     '''
     ret = {}
     dlist = []
@@ -717,6 +717,47 @@ def attach(zpool, device, new_device, force=False):
         ret['retcode'] = res['retcode']
     else:
         ret['Attached'] = '{0} to {1}'.format(new_device, zpool)
+
+    return ret
+
+
+def detach(zpool, device):
+    '''
+    Detach specified device to zpool
+
+    zpool : string
+        name of zpool
+    device : string
+        device to detach too
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' zpool.detach myzpool /path/to/vdev1
+    '''
+    ret = {}
+    dlist = []
+
+    # check for pool
+    if not exists(zpool):
+        ret['Error'] = 'Storage Pool `{0}` doesn\'t exist'.format(zpool)
+        ret['retcode'] = 1
+        return ret
+
+    # try and add watch out for mismatched replication levels
+    zpool_cmd = _check_zpool()
+    cmd = '{zpool_cmd} detach {zpool} {device}'.format(
+        zpool_cmd=zpool_cmd,
+        zpool=zpool,
+        device=device
+    )
+    res = __salt__['cmd.run_all'](cmd, python_shell=False)
+    if res['retcode'] != 0:
+        ret['Error'] = res['stderr'] if 'stderr' in res else res['stdout']
+        ret['retcode'] = res['retcode']
+    else:
+        ret['Detached'] = '{0} from {1}'.format(device, zpool)
 
     return ret
 

--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -733,7 +733,7 @@ def create_file_vdev(size, *vdevs):
             ret[vdev] = 'The vdev can\'t be created'
             ret['retcode'] = 1
     ret['status'] = True
-    ret[cmd] = cmd
+    ret['cmd'] = ' '.join(cmd)
     return ret
 
 

--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -693,8 +693,11 @@ def replace(zpool, old_device, new_device=None, force=False):
     return ret
 
 
+@salt.utils.decorators.which('mkfile')
 def create_file_vdev(size, *vdevs):
     '''
+    .. versionchanged:: Boron
+
     Creates file based ``virtual devices`` for a zpool
 
     ``*vdevs`` is a list of full paths for mkfile to create
@@ -710,8 +713,6 @@ def create_file_vdev(size, *vdevs):
         Depending on file size, the above command may take a while to return.
     '''
     ret = {}
-    if not _check_mkfile():
-        return False
     dlist = []
     # Get file names to create
     for vdev in vdevs:

--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -196,7 +196,7 @@ def status(zpool=None):
     return zp_data
 
 
-def iostat(zpool=None):
+def iostat(zpool=None, sample_time=0):
     '''
     .. versionchanged:: Boron
 
@@ -204,6 +204,8 @@ def iostat(zpool=None):
 
     zpool : string
         optional name of zpool to list
+    sample_time : int
+        seconds to capture data before output
 
     CLI Example:
 
@@ -215,9 +217,10 @@ def iostat(zpool=None):
 
     # get zpool list data
     zpool_cmd = _check_zpool()
-    cmd = '{zpool_cmd} iostat -v{zpool}'.format(
+    cmd = '{zpool_cmd} iostat -v{zpool}{sample_time}'.format(
         zpool_cmd=zpool_cmd,
-        zpool=' {0}'.format(zpool) if zpool else ''
+        zpool=' {0}'.format(zpool) if zpool else '',
+        sample_time=' {0} 2'.format(sample_time) if sample_time else ''
     )
     res = __salt__['cmd.run_all'](cmd, python_shell=False)
     if res['retcode'] != 0:
@@ -243,6 +246,12 @@ def iostat(zpool=None):
     current_pool = None
     for line in res['stdout'].splitlines():
         if line.strip() == '':
+            continue
+
+        # ignore header
+        if line.startswith('pool') and line.endswith('write'):
+            continue
+        if line.endswith('bandwidth'):
             continue
 
         if line.startswith('-') and line.endswith('-'):

--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -1241,4 +1241,35 @@ def reguid(zpool):
         ret[zpool] = 'reguided'
     return ret
 
+
+def reopen(zpool):
+    '''
+    .. verionadded:: Boron
+
+    Reopen all the vdevs associated with the pooll
+
+    zpool : string
+        name of zpool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' zpool.exists myzpool
+    '''
+    ret = {}
+    ret[zpool] = {}
+
+    zpool_cmd = _check_zpool()
+    cmd = '{zpool_cmd} reopen {zpool}'.format(
+        zpool_cmd=zpool_cmd,
+        zpool=zpool
+    )
+    res = __salt__['cmd.run_all'](cmd, python_shell=False)
+    if res['retcode'] != 0:
+        ret[zpool] = res['stderr'] if 'stderr' in res and res['stderr'] != '' else res['stdout']
+    else:
+        ret[zpool] = 'reopened'
+    return ret
+
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -88,6 +88,8 @@ def healthy():
 
 def status(zpool=''):
     '''
+    .. versionchanged:: Boron
+
     Return the status of the named zpool
 
     CLI Example:

--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -1340,7 +1340,7 @@ def reopen(zpool):
     '''
     .. verionadded:: Boron
 
-    Reopen all the vdevs associated with the pooll
+    Reopen all the vdevs associated with the pool
 
     zpool : string
         name of zpool
@@ -1364,6 +1364,50 @@ def reopen(zpool):
         ret[zpool] = res['stderr'] if 'stderr' in res and res['stderr'] != '' else res['stdout']
     else:
         ret[zpool] = 'reopened'
+    return ret
+
+
+def upgrade(zpool=None, version=None):
+    '''
+    .. verionadded:: Boron
+
+    Enables all supported features on the given pool
+
+    .. note::
+        Once this is done, the pool will no longer be accessible on systems that do not
+        support feature flags. See zpool-features(5) for details on compatibility with
+        systems that support feature flags, but do not support all features enabled on the pool.
+
+    zpool : string
+        optional zpool, applies to all otherwize
+    version : int
+        version to upgrade to, if unspecified upgrade to the highest possible
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' zpool.exists myzpool
+    '''
+    ret = {}
+
+    zpool_cmd = _check_zpool()
+    cmd = '{zpool_cmd} upgrade {version}{zpool}'.format(
+        zpool_cmd=zpool_cmd,
+        version='-V {0} '.format(version) if version else '',
+        zpool=zpool if zpool else '-a'
+    )
+    res = __salt__['cmd.run_all'](cmd, python_shell=False)
+    if res['retcode'] != 0:
+        if zpool:
+            ret[zpool] = res['stderr'] if 'stderr' in res and res['stderr'] != '' else res['stdout']
+        else:
+            ret['error'] = res['stderr'] if 'stderr' in res and res['stderr'] != '' else res['stdout']
+    else:
+        if zpool:
+            ret[zpool] = 'upgraded to {0}'.format('version {0}'.format(version) if version else 'the highest supported version')
+        else:
+            ret = 'all pools upgraded to {0}'.format('version {0}'.format(version) if version else 'the highest supported version')
     return ret
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -743,6 +743,11 @@ def export(*pools, **kwargs):
 
     Export storage pools
 
+    * : string
+        one or more zpools to export
+    force : boolean
+        force export of zpools
+
     CLI Example:
 
     .. code-block:: bash

--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -429,8 +429,8 @@ def destroy(zpool):
             zpool=zpool
         )
         res = __salt__['cmd.run_all'](cmd, python_shell=False)
-        if not exists(zpool):
-            if 'stderr' in res:
+        if exists(zpool):
+            if 'stderr' in res and res['stderr'] != '':
                 ret['Error'] = res['stderr']
             else:
                 ret = False

--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -686,13 +686,21 @@ def create(zpool, *vdevs, **kwargs):
     if properties:  # create "-o property=value" pairs
         optlist = []
         for prop in properties:
-            optlist.append('-o {0}={1}'.format(prop, properties[prop]))
+            if ' ' in properties[prop]:
+                value = "'{0}'".format(properties[prop])
+            else:
+                value = properties[prop]
+            optlist.append('-o {0}={1}'.format(prop, value))
         opts = ' '.join(optlist)
         cmd = '{0} {1}'.format(cmd, opts)
     if filesystem_properties:  # create "-O property=value" pairs
         optlist = []
         for prop in filesystem_properties:
-            optlist.append('-O {0}={1}'.format(prop, filesystem_properties[prop]))
+            if ' ' in filesystem_properties[prop]:
+                value = "'{0}'".format(filesystem_properties[prop])
+            else:
+                value = filesystem_properties[prop]
+            optlist.append('-O {0}={1}'.format(prop, value))
         opts = ' '.join(optlist)
         cmd = '{0} {1}'.format(cmd, opts)
     if mountpoint:  # set mountpoint
@@ -1134,7 +1142,11 @@ def import_(zpool=None, new_name=None, **kwargs):
     if properties:  # create "-o property=value" pairs
         optlist = []
         for prop in properties:
-            optlist.append('-o {0}={1}'.format(prop, properties[prop]))
+            if ' ' in properties[prop]:
+                value = "'{0}'".format(properties[prop])
+            else:
+                value = properties[prop]
+            optlist.append('-o {0}={1}'.format(prop, value))
         opts = ' '.join(optlist)
         cmd = '{0} {1}'.format(cmd, opts)
     if mntopts:  # set mountpoint

--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -428,7 +428,13 @@ def destroy(zpool):
             zpool=zpool
         )
         res = __salt__['cmd.run_all'](cmd, python_shell=False)
-        ret = not exists(zpool)
+        if not exists(zpool):
+            if 'stderr' in res:
+                ret['Error'] = res['stderr']
+            else:
+                ret = False
+        else:
+            ret = True
 
     return ret
 

--- a/tests/unit/modules/zpool_test.py
+++ b/tests/unit/modules/zpool_test.py
@@ -44,10 +44,24 @@ class ZpoolTestCase(TestCase):
         '''
         ret = {}
         ret['stdout'] = "NAME      SIZE  ALLOC   FREE    CAP  DEDUP  HEALTH  ALTROOT\nmyzpool   149G   128K   149G     0%  1.00x  ONLINE  -"
+        ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertTrue(zpool.exists('myzpool'))
+
+    @patch('salt.modules.zpool._check_zpool', MagicMock(return_value='/sbin/zpool'))
+    def test_exists_failure(self):
+        '''
+        Tests failure return of exists function
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot open 'mypool': no such pool"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertFalse(zpool.exists('myzpool'))
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/unit/modules/zpool_test.py
+++ b/tests/unit/modules/zpool_test.py
@@ -145,6 +145,21 @@ class ZpoolTestCase(TestCase):
             res = OrderedDict([('mypool', {'alloc': '47.4G', 'cap': '42%', 'free': '63.6G', 'health': 'ONLINE', 'size': '111G'})])
             self.assertEqual(res, ret)
 
+    @patch('salt.modules.zpool._check_zpool', MagicMock(return_value='/sbin/zpool'))
+    def test_get(self):
+        '''
+        Tests successful return of get function
+        '''
+        ret = {}
+        ret['stdout'] = "readonly\toff\t-\n"
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
+            ret = zpool.get('mypool', 'readonly')
+            res = OrderedDict([('mypool', OrderedDict([('readonly', 'off')]))])
+            self.assertEqual(res, ret)
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(ZpoolTestCase, needs_daemon=False)

--- a/tests/unit/modules/zpool_test.py
+++ b/tests/unit/modules/zpool_test.py
@@ -42,9 +42,11 @@ class ZpoolTestCase(TestCase):
         '''
         Tests successful return of exists function
         '''
-        ret = "NAME      SIZE  ALLOC   FREE    CAP  DEDUP  HEALTH  ALTROOT\nmyzpool   149G   128K   149G     0%  1.00x  ONLINE  -"
+        ret = {}
+        ret['stdout'] = "NAME      SIZE  ALLOC   FREE    CAP  DEDUP  HEALTH  ALTROOT\nmyzpool   149G   128K   149G     0%  1.00x  ONLINE  -"
+        ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zpool.__salt__, {'cmd.run': mock_cmd}):
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertTrue(zpool.exists('myzpool'))
 
 if __name__ == '__main__':

--- a/tests/unit/modules/zpool_test.py
+++ b/tests/unit/modules/zpool_test.py
@@ -63,6 +63,46 @@ class ZpoolTestCase(TestCase):
         with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertFalse(zpool.exists('myzpool'))
 
+    @patch('salt.modules.zpool._check_zpool', MagicMock(return_value='/sbin/zpool'))
+    def test_healthy_success(self):
+        '''
+        Tests successful return of healthy function
+        '''
+        ret = {}
+        ret['stdout'] = "all pools are healthy"
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertTrue(zpool.healthy())
+
+    @patch('salt.modules.zpool._check_zpool', MagicMock(return_value='/sbin/zpool'))
+    def test_status(self):
+        '''
+        Tests successful return of status function
+        '''
+        ret = {}
+        ret['stdout'] = "\n".join([
+            "  pool: mypool",
+            " state: ONLINE",
+            "  scan: scrub repaired 0 in 0h6m with 0 errors on Mon Dec 21 02:06:17 2015",
+            "config:",
+            "",
+            "        NAME        STATE     READ WRITE CKSUM",
+            "        mypool      ONLINE       0     0     0",
+            "          mirror-0  ONLINE       0     0     0",
+            "            c2t0d0  ONLINE       0     0     0",
+            "            c2t1d0  ONLINE       0     0     0",
+            "",
+            "errors: No known data errors",
+        ])
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
+            ret = zpool.status()
+            self.assertEqual('ONLINE', ret['mypool']['state'])
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(ZpoolTestCase, needs_daemon=False)


### PR DESCRIPTION
Part of #28779, the zpool module has been reworked to parse data where possible.
Missing feature were also implemented.

``` bash
/opt/local/salt/bin/salt-call --local zpool.status zones
```

``` yaml
local:
    ----------
    zones:
        ----------
        config:
            ----------
            zones:
                ----------
                cksum:
                    0
                mirror-0:
                    ----------
                    c2t0d0:
                        ----------
                        cksum:
                            0
                        read:
                            0
                        state:
                            ONLINE
                        write:
                            0
                    c2t1d0:
                        ----------
                        cksum:
                            0
                        read:
                            0
                        state:
                            ONLINE
                        write:
                            0
                    cksum:
                        0
                    read:
                        0
                    state:
                        ONLINE
                    write:
                        0
                read:
                    0
                state:
                    ONLINE
                write:
                    0
        errors:
            No known data errors
        scan:
            scrub repaired 0 in 0h5m with 0 errors on Mon Dec 14 02
        state:
            ONLINE
```

``` bash
/opt/local/salt/bin/salt-call --local zpool.iostat zones sample_time=60
```

``` yaml
local:
    ----------
    zones:
        ----------
        zones:
            ----------
            bandwith-read:
                0
            bandwith-write:
                690K
            capacity-alloc:
                42.7G
            capacity-free:
                68.3G
            mirror:
                ----------
                bandwith-read:
                    0
                bandwith-write:
                    690K
                c2t0d0:
                    ----------
                    bandwith-read:
                        0
                    bandwith-write:
                        692K
                    operations-read:
                        0
                    operations-write:
                        12
                c2t1d0:
                    ----------
                    bandwith-read:
                        0
                    bandwith-write:
                        692K
                    operations-read:
                        0
                    operations-write:
                        12
                capacity-alloc:
                    42.7G
                capacity-free:
                    68.3G
                operations-read:
                    0
                operations-write:
                    20
            operations-read:
                0
            operations-write:
                20
```

``` bash
/opt/local/salt/bin/salt-call --local zpool.detach test /tmp/disk2
```

``` yaml
local:
    ----------
    test:
        ----------
        detached:
            - /tmp/disk2
```

``` bash
/opt/local/salt/bin/salt-call --local zpool.attach test /tmp/disk1 /tmp/disk2 force=True
```

``` yaml
local:
    ----------
    test:
        ----------
        attached:
            - /tmp/disk2
```

``` bash
/opt/local/salt/bin/salt-call --local zpool.reguid test
```

``` yaml
local:
    ----------
    test:
        reguided
```

``` bash
/opt/local/salt/bin/salt-call --local zpool.reopen test
```

``` yaml
local:
    ----------
    test:
        reopened
```

``` bash
 /opt/local/salt/bin/salt-call --local zpool.get test readonly
```

``` yaml
local:
    ----------
    test:
        ----------
        readonly:
            off
```

``` bash
 /opt/local/salt/bin/salt-call --local zpool.get test
```

``` yaml
local:
    ----------
    test:
        ----------
        allocated:
            118K
        altroot:
            -
        autoexpand:
            off
        autoreplace:
            off
        bootfs:
            -
        cachefile:
            -
        capacity:
            0%
        comment:
            -
        dedupditto:
            0
        dedupratio:
            1.00x
        delegation:
            on
        expandsize:
            -
        failmode:
            wait
        feature@async_destroy:
            enabled
        feature@bookmarks:
            enabled
        feature@edonr:
            enabled
        feature@embedded_data:
            active
        feature@empty_bpobj:
            enabled
        feature@enabled_txg:
            active
        feature@extensible_dataset:
            enabled
        feature@filesystem_limits:
            enabled
        feature@hole_birth:
            active
        feature@large_blocks:
            enabled
        feature@lz4_compress:
            active
        feature@multi_vdev_crash_dump:
            enabled
        feature@sha512:
            enabled
        feature@skein:
            enabled
        feature@spacemap_histogram:
            active
        fragmentation:
            0%
        free:
            224M
        freeing:
            0
        guid:
            5784117219602689890
        health:
            ONLINE
        leaked:
            0
        listsnapshots:
            off
        readonly:
            off
        size:
            224M
        version:
            -
```

``` bash
/opt/local/salt/bin/salt-call --local zpool.set test comment 'hello world'
```

``` yaml
local:
    ----------
    test:
        ----------
        comment:
            'hello world'
```

``` bash
/opt/local/salt/bin/salt-call --local zpool.history test
```

``` yaml
local:
    ----------
    test:
        - 2015-12-20.19:34:07 zpool create -f test /tmp/disk0
        - 2015-12-20.19:52:52 zpool add -f test /tmp/disk1
        - 2015-12-20.19:54:37 zpool attach -f test /tmp/disk1 /tmp/disk2
        - 2015-12-20.19:54:48 zpool offline test /tmp/disk1
        - 2015-12-20.19:54:57 zpool online test /tmp/disk1
        - 2015-12-20.19:55:05 zpool online test /tmp/disk1 /tmp/disk0
        - 2015-12-20.20:01:05 zpool offline test /tmp/disk1
        - 2015-12-20.20:01:11 zpool offline test /tmp/disk1
        - 2015-12-20.20:12:47 zpool online test /tmp/disk1
        - 2015-12-20.20:16:32 zpool offline test /tmp/disk1
        - 2015-12-20.20:18:46 zpool online test /tmp/disk1
        - 2015-12-20.20:19:11 zpool reguid test
        - 2015-12-20.20:21:31 zpool reopen test
        - 2015-12-20.20:45:17 zpool set autoexpand=on test
        - 2015-12-20.20:45:28 zpool set autoexpand=off test
        - 2015-12-20.21:36:17 zpool detach test /tmp/disk2
        - 2015-12-20.21:38:12 zpool attach -f test /tmp/disk1 /tmp/disk2
        - 2015-12-20.21:38:29 zpool reguid test
        - 2015-12-20.21:38:54 zpool reopen test
        - 2015-12-20.21:41:28 zpool set comment=hello test
        - 2015-12-20.21:44:25 zpool set comment=hello world test
```
