### PR TITLE
fix for nfs mounts in _active_mounts_openbsd()

### DIFF
--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -156,6 +156,7 @@ def _active_mounts_openbsd(ret):
                             'opts': parens[0].split(", ")}
     return ret
 
+
 def _active_mounts_darwin(ret):
     '''
     List active mounts on Mac OS systems

--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -143,14 +143,18 @@ def _active_mounts_openbsd(ret):
         nod = __salt__['cmd.run_stdout']('ls -l {0}'.format(comps[0]))
         nod = ' '.join(nod.split()).split(" ")
         parens = re.findall(r'\((.*?)\)', line, re.DOTALL)
-        ret[comps[3]] = {'device': comps[0],
+        if len(parens) > 1:
+            ret[comps[3]] = {'device': comps[0],
                          'fstype': comps[5],
                          'opts': parens[1].split(", "),
                          'major': str(nod[4].strip(",")),
                          'minor': str(nod[5]),
                          'device_uuid': parens[0]}
+        else:
+            ret[comps[2]] = {'device': comps[0],
+                            'fstype': comps[4],
+                            'opts': parens[0].split(", ")}
     return ret
-
 
 def _active_mounts_darwin(ret):
     '''


### PR DESCRIPTION
## attempting to run following state

/backup:
  mount.mounted:
    - device: joule:/backup
    - fstype: nfs
    - mkmnt: True
    - opts: rw,nodev,nosuid
## getting unexpected behavior: 

```
        ID: /backup
    Function: mount.mounted
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/local/lib/python2.7/site-packages/salt/state.py", line 1591, in call
                  **cdata['kwargs'])
                File "/usr/local/lib/python2.7/site-packages/salt/states/mount.py", line 120, in mounted
                  active = __salt__['mount.active'](extended=True)
                File "/usr/local/lib/python2.7/site-packages/salt/modules/mount.py", line 184, in active
                  _active_mounts_openbsd(ret)
                File "/usr/local/lib/python2.7/site-packages/salt/modules/mount.py", line 148, in _active_mounts_openbsd
                  'opts': parens[1].split(", "),
              IndexError: list index out of range
     Started: 21:51:47.764708
    Duration: 38.882 ms
```
## issue clarification: 

function _active_mounts_openbsd() 
expecting all mount points to have DUID  
but NFS mounts do not have DUIDs generated, so line need to be parsed separately  
## proposal: 
1. check length of parens array 
2. and have a different parsing for lines with no DUIDs  in them
## testing same state after change: 

```
  Name: /etc/fstab - Function: file.blockreplace - Result: Clean
  Name: /d01 - Function: mount.mounted - Result: Clean
  Name: /stage - Function: mount.mounted - Result: Clean
  Name: /backup - Function: mount.mounted - Result: Changed
```

---

Thanks, 
Sergey.
