### PR TITLE
modules.splunk: __virtual__ return err msg.

### DIFF
--- a/salt/modules/splunk.py
+++ b/salt/modules/splunk.py
@@ -66,7 +66,8 @@ def __virtual__():
     '''
     if HAS_LIBS:
         return __virtualname__
-    return False
+    return (False, 'The splunk execution module failed to load: '
+            'requires splunk python library to be installed.')
 
 
 def _get_secret_key(profile):


### PR DESCRIPTION
Updated message in splunk module when return False if python libraries are not installed.
