### PR TITLE
modules.solarispkg: __virtual__ return err msg.

### DIFF
--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -25,7 +25,9 @@ def __virtual__():
     '''
     if __grains__['os'] == 'Solaris' and float(__grains__['kernelrelease']) <= 5.10:
         return __virtualname__
-    return False
+    return (False,
+            'The solarispkg execution module failed to load: only available '
+            'on Solaris <= 10.')
 
 
 def _write_adminfile(kwargs):


### PR DESCRIPTION
Updated message in solarispkg module when return False if Solaris is not <= 10.
