### PR TITLE
modules.pkgng: __virtual__ return err msg.

### DIFF
--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -66,7 +66,9 @@ def __virtual__():
             log.debug('Configuration option \'providers:pkg\' is set to '
                 '\'pkgng\', using \'pkgng\' in favor of \'freebsdpkg\'.')
             return __virtualname__
-    return False
+    return (False,
+            'The pkgng execution module cannot be loaded: only available '
+            'on FreeBSD 10 or FreeBSD 9 with providers.pkg set to pkgng.')
 
 
 def _pkg(jail=None, chroot=None):


### PR DESCRIPTION
Updated message in pkg module when return False depending on FreeBSD current release and providers configuration.
