### PR TITLE
FreeBSD pkgng fix for non-interactive install.

### DIFF
--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -730,7 +730,7 @@ def install(name=None,
     if pkg_params is None or len(pkg_params) == 0:
         return {}
 
-    opts = ''
+    opts = 'y'
     repo_opts = ''
     if salt.utils.is_true(orphan):
         opts += 'A'
@@ -742,8 +742,6 @@ def install(name=None,
         opts += 'U'
     if salt.utils.is_true(dryrun):
         opts += 'n'
-    if not salt.utils.is_true(dryrun):
-        opts += 'y'
     if salt.utils.is_true(quiet):
         opts += 'q'
     if salt.utils.is_true(reinstall_requires):


### PR DESCRIPTION
In pkgng the way to install packages and assuming yes in pre and post install scripts is to use
-y, same as apt-get or yum, for example. Also env variable ASSUME_ALWAYS_YES=YES can be used, but
in this case, is a good idea to follow others package manager implementation.
Also remove the check where only -y is used if pkgng is executed in dryrun mode. In this case
there is no difference between dry run or not.

Fixes #27056
