### PR TITLE
rpm.py: Add epoch and architecture to lowpkg.info

### DIFF
--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -435,9 +435,11 @@ def info(*packages):
     # Locale needs to be en_US instead of C, because RPM otherwise will yank the timezone from the timestamps
     call = __salt__['cmd.run_all'](cmd + (" --queryformat 'Name: %{NAME}\n"
                                                           "Relocations: %|PREFIXES?{[%{PREFIXES} ]}:{(not relocatable)}|\n"
+                                                          "%|EPOCH?{Epoch: %{EPOCH}\n}|"
                                                           "Version: %{VERSION}\n"
                                                           "Vendor: %{VENDOR}\n"
                                                           "Release: %{RELEASE}\n"
+                                                          "Architecture: %{ARCH}\n"
                                                           "Build Date: %{BUILDTIME:date}\n"
                                                           "Install Date: %|INSTALLTIME?{%{INSTALLTIME:date}}:{(not installed)}|\n"
                                                           "Build Host: %{BUILDHOST}\n"


### PR DESCRIPTION
Epoch is essential version information for rpm packages on RHEL and
Fedora.

Architecture is essential information on all RPM based distributions
