### PR TITLE
Pillar http yaml

### DIFF
--- a/salt/pillar/http_yaml.py
+++ b/salt/pillar/http_yaml.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""
+A module that adds data to the Pillar structure retrieved by an http request
+
+
+Configuring the HTTP_YAML ext_pillar
+====================================
+
+Set the following Salt config to setup Foreman as external pillar source:
+
+.. code-block:: yaml
+
+  ext_pillar:
+    - http_yaml:
+        url: http://example.com/api/minion_id
+        ::TODO::
+        username: username
+        password: password
+
+Module Documentation
+====================
+"""
+from __future__ import absolute_import
+
+# Import python libs
+import logging
+
+
+def ext_pillar(minion_id,
+               pillar,  # pylint: disable=W0613
+               url=None):
+    """
+    Read pillar data from HTTP response.
+
+    :param url String to make request
+    :returns dict with pillar data to add
+    :returns empty if error
+    """
+    # Set up logging
+    log = logging.getLogger(__name__)
+
+    data = __salt__['http.query'](url=url, decode=True, decode_type='yaml')
+
+    if 'dict' in data:
+        return data['dict']
+
+    log.error('Error caught on query to' + url + '\nMore Info:\n')
+
+    for k, v in dict:
+        log.error(k + ' : ' + v)
+
+    return {}

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -15,6 +15,7 @@ import pprint
 import socket
 import urllib
 import inspect
+import yaml
 
 import ssl
 try:
@@ -561,10 +562,12 @@ def query(url,
                 decode_type = 'xml'
             elif 'json' in content_type:
                 decode_type = 'json'
+            elif 'yaml' in content_type:
+                decode_type = 'yaml'
             else:
                 decode_type = 'plain'
 
-        valid_decodes = ('json', 'xml', 'plain')
+        valid_decodes = ('json', 'xml', 'yaml', 'plain')
         if decode_type not in valid_decodes:
             ret['error'] = (
                 'Invalid decode_type specified. '
@@ -582,6 +585,8 @@ def query(url,
             items = ET.fromstring(result_text)
             for item in items:
                 ret['dict'].append(xml.to_dict(item))
+        elif decode_type == 'yaml':
+            ret['dict'] = yaml.load(result_text)
         else:
             text = True
 


### PR DESCRIPTION
this PR adds the `http_yaml` external pillar module, which retrieves yaml data from a url, the `query` method from the `http` util is also updated to support for yaml decoding
