### PR TITLE
modules.debconfmod: __virtual__ return err msg.

### DIFF
--- a/salt/modules/debconfmod.py
+++ b/salt/modules/debconfmod.py
@@ -28,10 +28,12 @@ def __virtual__():
     is installed.
     '''
     if __grains__['os_family'] != 'Debian':
-        return False
+        return (False, 'The debconfmod module could not be loaded: '
+                'unsupported OS family')
 
     if salt.utils.which('debconf-get-selections') is None:
-        return False
+        return (False, 'The debconfmod module could not be loaded: '
+                'debconf-utils is not installed.')
 
     return __virtualname__
 


### PR DESCRIPTION
Updated message in debconfmod module when return False if os family is not supported or
defconf-utils is not installed.
