### PR TITLE
modules.debian_ip: __virtual__ return err msg.

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -49,7 +49,9 @@ def __virtual__():
     '''
     if __grains__['os_family'] == 'Debian':
         return __virtualname__
-    return False
+    return (False, 'The debian_ip module could not be loaded: '
+            'unsupported OS family')
+
 
 _ETHTOOL_CONFIG_OPTS = {
     'speed': 'link-speed',


### PR DESCRIPTION
Updated message in debian_ip module when return False if os family is not supported.
