### PR TITLE
modules.debian_service: __virtual__ return err msg.

### DIFF
--- a/salt/modules/debian_service.py
+++ b/salt/modules/debian_service.py
@@ -36,7 +36,8 @@ def __virtual__():
     '''
     if __grains__['os'] in ('Debian', 'Raspbian', 'Devuan') and not salt.utils.systemd.booted(__context__):
         return __virtualname__
-    return False
+        return (False, 'The debian_service module could not be loaded: '
+                'unsupported OS family and/or systemd running.')
 
 
 def _service_cmd(*args):


### PR DESCRIPTION
Updated message in debian_service module when return False if os family is not supported or
systemd is running.
