### PR TITLE
salt.states.zpool

### DIFF
--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -509,7 +509,7 @@ def exists(zpool):
     return True
 
 
-def destroy(zpool):
+def destroy(zpool, force=False):
     '''
     .. versionchanged:: Boron
 
@@ -517,6 +517,8 @@ def destroy(zpool):
 
     zpool : string
         name of storage pool
+    force : boolean
+        force destroy of pool
 
     CLI Example:
 
@@ -530,8 +532,9 @@ def destroy(zpool):
         ret[zpool] = 'storage pool does not exist'
     else:
         zpool_cmd = _check_zpool()
-        cmd = '{zpool_cmd} destroy {zpool}'.format(
+        cmd = '{zpool_cmd} destroy {force}{zpool}'.format(
             zpool_cmd=zpool_cmd,
+            force='-f ' if force else '',
             zpool=zpool
         )
         res = __salt__['cmd.run_all'](cmd, python_shell=False)

--- a/salt/states/zpool.py
+++ b/salt/states/zpool.py
@@ -18,30 +18,28 @@ Management zpool
     newpool:
       zpool.present:
         - config:
-            try_import: false
+            import: false
             force: true
         - properties:
-            comment: salty pool
+            comment: salty storage pool
         - layout:
-            mirror:
+            mirror-0:
               /dev/disk0
               /dev/disk1
-            mirror:
+            mirror-1:
               /dev/disk2
               /dev/disk3
-
-.. note::
-
-    only properties will be updated if possible, the layout is fixed at creation time and will not be updated.
 
 '''
 from __future__ import absolute_import
 
 # Import Python libs
+import os
+import stat
 import logging
 
 # Import Salt libs
-#from salt.utils.odict import OrderedDict
+from salt.utils.odict import OrderedDict
 
 log = logging.getLogger(__name__)
 
@@ -64,9 +62,232 @@ def __virtual__():
         )
 
 
+def _check_device(device, config):
+    '''
+    Check if device is present
+    '''
+    if '/' not in device and config['device_dir'] and os.path.exists(config['device_dir']):
+        device = os.path.join(config['device_dir'], device)
+
+    if not os.path.exists(device):
+        return False, 'not present on filesystem'
+    else:
+        mode = os.stat(device).st_mode
+        if not stat.S_ISBLK(mode) and not stat.S_ISREG(mode) and not stat.S_ISCHR(mode):
+            return False, 'not a block device, a file vdev or character special device'
+
+    return True, ''
+
+
+def present(name, properties=None, filesystem_properties=None, layout=None, config=None):
+    '''
+    ensure storage pool is present on the system
+
+    name : string
+        name of storage pool
+    properties : dict
+        optional set of properties to set for the storage pool
+    filesystem_properties : dict
+        optional set of filesystem properties to set for the storage pool (creation only)
+    layout: dict
+        disk layout to use if the pool does not exist (creation only)
+    config : dict
+        fine grain control over this state
+
+    .. note::
+
+        The following configuration properties can be toggled in the config parameter.
+          - import (true) - try to import the pool before creating it if absent
+          - import_dirs (None) - specify additional locations to scan for devices on import
+          - device_dir (None, SunOS=/dev/rdsk) - specify device directory to use if not absolute path
+          - force (false) - try to force the import or creation
+
+    .. note::
+
+        Because ID's inside the layout dict must be unique they need to have a suffix.
+
+        .. code-block:: yaml
+
+            mirror-0:
+              /tmp/vdisk3
+              /tmp/vdisk2
+            mirror-1:
+              /tmp/vdisk0
+              /tmp/vdisk1
+
+        The above yaml will always result in the following zpool create:
+
+        .. code-block:: bash
+
+            zpool create mypool mirror /tmp/vdisk3 /tmp/vdisk2 mirror /tmp/vdisk0 /tmp/vdisk1
+
+        Pay attention to the order of your dict!
+
+        .. code-block:: yaml
+
+            mirror-0:
+              /tmp/vdisk0
+              /tmp/vdisk1
+            /tmp/vdisk2:
+
+        The above will result in the following zpool create:
+
+        .. code-block:: bash
+
+            zpool create mypool mirror /tmp/vdisk0 /tmp/vdisk1 /tmp/vdisk2
+
+        Creating a 3-way mirror! Why you probably expect it to be mirror root vdev with 2 devices + a root vdev of 1 device!
+
+    '''
+    name = name.lower()
+    ret = {'name': name,
+           'changes': {},
+           'result': None,
+           'comment': ''}
+
+    # config defaults
+    state_config = config if config else {}
+    config = {
+        'import': True,
+        'import_dirs': None,
+        'device_dir': None if __grains__['kernel'] != 'SunOS' else '/dev/rdsk',
+        'force': False
+    }
+    config.update(state_config)
+    log.debug('zpool.present::{0}::config - {1}'.format(name, config))
+
+    # validate layout
+    if layout:
+        layout_valid = True
+        layout_result = {}
+        for root_dev in layout:
+            if '-' in root_dev:
+                if root_dev.split('-')[0] not in ['mirror', 'log', 'cache', 'raidz1', 'raidz2', 'raidz3', 'spare']:
+                    layout_valid = False
+                    layout_result[root_dev] = 'not a valid vdev type'
+                layout[root_dev] = layout[root_dev].keys() if isinstance(layout[root_dev], OrderedDict) else layout[root_dev].split(' ')
+
+                for dev in layout[root_dev]:
+                    dev_info = _check_device(dev, config)
+                    if not dev_info[0]:
+                        layout_valid = False
+                        layout_result[root_dev] = {}
+                        layout_result[root_dev][dev] = dev_info[1]
+            else:
+                dev_info = _check_device(root_dev, config)
+                if not dev_info[0]:
+                    layout_valid = False
+                    layout_result[root_dev] = dev_info[1]
+
+        if not layout_valid:
+            ret['result'] = False
+            ret['comment'] = "{0}".format(layout_result)
+            return ret
+
+        log.debug('zpool.present::{0}::layout - {1}'.format(name, layout))
+
+    # ensure the pool is present
+    ret['result'] = False
+    if __salt__['zpool.exists'](name):  # update
+        ret['result'] = True
+
+        # retrieve current properties
+        properties_current = __salt__['zpool.get'](name)[name]
+
+        # figure out if updates needed
+        properties_update = []
+        for prop in properties:
+            if prop not in properties_current:
+                continue
+
+            value = properties[prop]
+            if isinstance(value, bool):
+                value = 'on' if value else 'off'
+
+            if properties_current[prop] != value:
+                properties_update.append(prop)
+
+        # update properties
+        for prop in properties_update:
+            value = properties[prop]
+            res = __salt__['zpool.set'](name, prop, value)
+
+            # also transform value so we match with the return
+            if isinstance(value, bool):
+                value = 'on' if value else 'off'
+            elif ' ' in value:
+                value = "'{0}'".format(value)
+
+            # check return
+            if name in res and prop in res[name] and res[name][prop] == value:
+                if name not in ret['changes']:
+                    ret['changes'][name] = {}
+                ret['changes'][name].update(res[name])
+            else:
+                ret['result'] = False
+                if ret['comment'] == '':
+                    ret['comment'] = 'The following properties were not updated:'
+                ret['comment'] = '{0} {1}'.format(ret['comment'], prop)
+
+        if ret['result']:
+            ret['comment'] = 'properties updated' if len(ret['changes']) > 0 else 'no update needed'
+
+    else:  # import or create
+        if config['import']:  # try import
+            log.debug('zpool.present::{0}::importing'.format(name))
+            ret['result'] = __salt__['zpool.import'](
+                name,
+                force=config['force'],
+                dir=config['import_dirs']
+            )
+            ret['result'] = name in ret['result'] and ret['result'][name] == 'imported'
+            if ret['result']:
+                ret['changes'][name] = 'imported'
+                ret['comment'] = 'storage pool {0} was imported'.format(name)
+
+        if not ret['result']:  # create
+            if not layout:
+                ret['comment'] = 'storage pool {0} was not imported, no layout specified for creation'.format(name)
+            else:
+                log.debug('zpool.present::{0}::creating'.format(name))
+                if __opts__['test']:
+                    ret['result'] = True
+                else:
+                    # construct *vdev parameter for zpool.create
+                    params = []
+                    params.append(name)
+                    for root_dev in layout:
+                        if '-' in root_dev:  # special device
+                            params.append(root_dev.split('-')[0])  # add the type by stripping the ID
+                            if root_dev.split('-')[0] in ['mirror', 'log', 'cache', 'raidz1', 'raidz2', 'raidz3', 'spare']:
+                                for sub_dev in layout[root_dev]:  # add all sub devices
+                                    if '/' not in sub_dev and config['device_dir'] and os.path.exists(config['device_dir']):
+                                        sub_dev = os.path.join(config['device_dir'], sub_dev)
+                                    params.append(sub_dev)
+                        else:  # normal device
+                            if '/' not in root_dev and config['device_dir'] and os.path.exists(config['device_dir']):
+                                root_dev = os.path.join(config['device_dir'], root_dev)
+                            params.append(root_dev)
+
+                    # execute zpool.create
+                    ret['result'] = __salt__['zpool.create'](*params, force=config['force'], properties=properties, filesystem_properties=filesystem_properties)
+                    if name in ret['result'] and ret['result'][name] == 'created':
+                        ret['result'] = True
+                    else:
+                        if name in ret['result']:
+                            ret['comment'] = ret['result'][name]
+                        ret['result'] = False
+
+                if ret['result']:
+                    ret['changes'][name] = 'created'
+                    ret['comment'] = 'storage pool {0} was created'.format(name)
+
+    return ret
+
+
 def absent(name, export=False, force=False):
     '''
-    Ensure storage pool is not absent on the system
+    ensure storage pool is absent on the system
 
     name : string
         name of storage pool
@@ -82,7 +303,12 @@ def absent(name, export=False, force=False):
            'result': None,
            'comment': ''}
 
-    if __salt__['zpool.exists'](name):
+    # config defaults
+    log.debug('zpool.absent::{0}::config::force = {1}'.format(name, force))
+    log.debug('zpool.absent::{0}::config::export = {1}'.format(name, export))
+
+    # ensure the pool is absent
+    if __salt__['zpool.exists'](name):  # looks like we need to do some work
         ret['result'] = False
 
         if export:  # try to export the zpool
@@ -99,12 +325,13 @@ def absent(name, export=False, force=False):
                 ret['result'] = __salt__['zpool.destroy'](name, force=force)
                 ret['result'] = name in ret['result'] and ret['result'][name] == 'destroyed'
 
-        if ret['result']:
+        if ret['result']:  # update the changes and comment
             ret['changes'][name] = 'exported' if export else 'destroyed'
-            ret['comment'] = 'zpool {0} was {1}'.format(name, ret['changes'][name])
-    else:
+            ret['comment'] = 'storage pool {0} was {1}'.format(name, ret['changes'][name])
+
+    else:  # we are looking good
         ret['result'] = True
-        ret['comment'] = 'zpool {0} is absent'.format(name)
+        ret['comment'] = 'storage pool {0} is absent'.format(name)
 
     return ret
 

--- a/salt/states/zpool.py
+++ b/salt/states/zpool.py
@@ -30,6 +30,13 @@ Management zpool
               /dev/disk2
               /dev/disk3
 
+    .. note::
+
+        The layout will never be updated, it will only be used at time of creation.
+        It's a whole lot of work to figure out if a devices needs to be detached, removed, ... this is best done by the sysadmin on a case per case basis.
+
+        Filesystem properties are also not updated, this should be managed by the zfs state module.
+
 '''
 from __future__ import absolute_import
 

--- a/salt/states/zpool.py
+++ b/salt/states/zpool.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+'''
+Management zpool
+
+:maintainer:    Jorge Schrauwen <sjorge@blackdot.be>
+:maturity:      new
+:depends:       zpool
+:platform:      smartos, illumos, solaris, freebsd, linux
+
+.. versionadded:: Boron
+
+.. code-block:: yaml
+
+    oldpool:
+      zpool.absent:
+        - export: true
+
+    newpool:
+      zpool.present:
+        - config:
+            try_import: false
+            force: true
+        - properties:
+            comment: salty pool
+        - layout:
+            mirror:
+              /dev/disk0
+              /dev/disk1
+            mirror:
+              /dev/disk2
+              /dev/disk3
+
+.. note::
+
+    only properties will be updated if possible, the layout is fixed at creation time and will not be updated.
+
+'''
+from __future__ import absolute_import
+
+# Import Python libs
+import logging
+
+# Import Salt libs
+#from salt.utils.odict import OrderedDict
+
+log = logging.getLogger(__name__)
+
+# Define the state's virtual name
+__virtualname__ = 'zpool'
+
+
+def __virtual__():
+    '''
+    Provides zpool state
+    '''
+    if 'zpool.create' in __salt__:
+        return True
+    else:
+        return (
+            False,
+            '{0} state module can only be loaded on illumos, Solaris, SmartOS, FreeBSD, ...'.format(
+                __virtualname__
+            )
+        )
+
+
+def absent(name, export=False, force=False):
+    '''
+    Ensure storage pool is not absent on the system
+
+    name : string
+        name of storage pool
+    export : boolean
+        export instread of destroy the zpool if present
+    force : boolean
+        force destroy or export
+
+    '''
+    name = name.lower()
+    ret = {'name': name,
+           'changes': {},
+           'result': None,
+           'comment': ''}
+
+    if __salt__['zpool.exists'](name):
+        ret['result'] = False
+
+        if export:  # try to export the zpool
+            if __opts__['test']:
+                ret['result'] = True
+            else:
+                ret['result'] = __salt__['zpool.export'](name, force=force)
+                ret['result'] = name in ret['result'] and ret['result'][name] == 'exported'
+
+        else:  # try to destroy the zpool
+            if __opts__['test']:
+                ret['result'] = True
+            else:
+                ret['result'] = __salt__['zpool.destroy'](name, force=force)
+                ret['result'] = name in ret['result'] and ret['result'][name] == 'destroyed'
+
+        if ret['result']:
+            ret['changes'][name] = 'exported' if export else 'destroyed'
+            ret['comment'] = 'zpool {0} was {1}'.format(name, ret['changes'][name])
+    else:
+        ret['result'] = True
+        ret['comment'] = 'zpool {0} is absent'.format(name)
+
+    return ret
+
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
Nothing super fancy, but it will do for my needs. The docs should be pretty good at explaining how this works.

``` yaml
test:
  zpool.present:
    - config:
        import_dirs: /tmp
        device_dir: /tmp
    - properties:
        comment: salty storage pool
    - layout:
        mirror-1:
          disk3:
          disk2:
        mirror-0:
          disk1
          disk0
```

The above will try to ensure a storage pool 'test' is available on the system. It will first try and import it, since the test pool is file based some extra dirs are provided for import to find the pool.

If the import fails, the state will check if a layout for the pool was provided. If this is the case it will try and create the storage pool. For the test an alternative device_dir is provided as we will be a file based pool.

``` bash
## lets create some test files
~$ mkfile 128M /tmp/disk0 /tmp/disk1 /tmp/disk2 /tmp/disk3 /tmp/disk4
## our initial run, will create the zpool
~$  /opt/local/salt/bin/salt-call --local state.highstate
## oh my some silly admin exported the pool? the next run will import it (keeping all the data)
~$ zpool export test
~$  /opt/local/salt/bin/salt-call --local state.highstate
## silly admin destroyes the test pool
~$ zpool destroy test
~$  /opt/local/salt/bin/salt-call --local state.highstate
## silly admin does more stuff
~$ zpool destroy test
~$ zpool create test2 /tmp/disk1
~$ zpool export test2
~$  /opt/local/salt/bin/salt-call --local state.highstate
```

Initial run, creats the zpool

``` yaml
local:
----------
          ID: test
    Function: zpool.present
      Result: True
     Comment: storage pool test was created
     Started: 15:20:38.204099
    Duration: 405.862 ms
     Changes:
              ----------
              test:
                  created

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time: 405.862 ms
```

2nd highstate run, since the pool was exported and not destroyed, we reimport it

``` yaml
local:
----------
          ID: test
    Function: zpool.present
      Result: True
     Comment: storage pool test was imported
     Started: 15:22:20.923880
    Duration: 1974.249 ms
     Changes:
              ----------
              test:
                  imported

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time:   1.974 s
```

3rd highstate, we create the pool again wiping all date

``` yaml
local:
----------
          ID: test
    Function: zpool.present
      Result: True
     Comment: storage pool test was created
     Started: 15:23:34.184890
    Duration: 2048.555 ms
     Changes:
              ----------
              test:
                  created

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time:   2.049 s
```

4h highstate, we fail to create the pool, as /tmp/disk1 belongs to an exported pool test2

``` yaml
local:
----------
          ID: test
    Function: zpool.present
      Result: False
     Comment: invalid vdev specification
              use '-f' to override the following errors:
              /tmp/disk1 is part of exported pool 'test2'
     Started: 15:25:32.027814
    Duration: 1908.807 ms
     Changes:

Summary for local
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:   1.909 s
```

Updating the state

``` yaml
test:
  zpool.present:
    - config:
        force: true
        import_dirs: /tmp
        device_dir: /tmp
    - properties:
        comment: salty storage pool
    - layout:
        mirror-1:
          disk3:
          disk2:
        mirror-0:
          disk1
          disk0
```

5th highstate, forces pool creation

``` yaml
local:
----------
          ID: test
    Function: zpool.present
      Result: True
     Comment: storage pool test was created
     Started: 15:27:12.023682
    Duration: 2111.254 ms
     Changes:
              ----------
              test:
                  created

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time:   2.111 s
```

What happens if one of the 'disks' goes missing?

``` yaml
local:
----------
          ID: test
    Function: zpool.present
      Result: False
     Comment: {'mirror-0': {'disk1': 'not present on filesystem'}}
     Started: 15:27:49.374443
    Duration: 1.101 ms
     Changes:

Summary for local
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:   1.101 ms
```
