### PR TITLE
Fix states.boto_iam group users

### DIFF
--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -476,8 +476,8 @@ def remove_user_from_group(group_name, user_name, region=None, key=None, keyid=N
         msg = 'Username : {0} does not exist.'
         log.error(msg.format(user_name, group_name))
         return False
-    if not user_exists_in_group(user_name, group_name, region=None, key=None, keyid=None,
-                                profile=None):
+    if not user_exists_in_group(user_name, group_name, region=region, key=key,
+                                keyid=keyid, profile=profile):
         return True
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     try:

--- a/salt/states/boto_iam.py
+++ b/salt/states/boto_iam.py
@@ -587,7 +587,7 @@ def group_present(name, policies=None, policies_from_pillars=None, users=None, r
     if not _ret['result']:
         ret['result'] = _ret['result']
         return ret
-    if users:
+    if users is not None:
         log.debug('Users are : {0}.'.format(users))
         group_result = __salt__['boto_iam.get_group'](group_name=name, region=region, key=key, keyid=keyid, profile=profile)
         ret = _case_group(ret, users, name, group_result, region, key, keyid, profile)


### PR DESCRIPTION
- passes connection information down to the other boto\* related functions or Salt raises an exception because it can't connect to AWS
- handle the case where a group's users list is empty, which removes all users from the group
