### PR TITLE
fixup mount.fstab to accommodate entries with the same name

### DIFF
--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -313,6 +313,9 @@ def fstab(config='/etc/fstab'):
                     _fstab_entry.compatibility_keys)
 
                 entry['opts'] = entry['opts'].split(',')
+                while entry['name'] in ret:
+                    entry['name'] += '_'
+
                 ret[entry.pop('name')] = entry
             except _fstab_entry.ParseError:
                 pass


### PR DESCRIPTION
It turns out that it's quite common for multiple 'swap' entries to be put in place. To accommodate this, the first entry will get the name 'swap', while additional entries will be appended with an underscore.  ('swap_', 'swap__', etc.)
