### PR TITLE
modules.dsc: __virtual__ return err msg.

### DIFF
--- a/salt/modules/dsc.py
+++ b/salt/modules/dsc.py
@@ -32,7 +32,8 @@ def __virtual__():
     '''
     if salt.utils.is_windows() and psversion() >= 5:
         return __virtualname__
-    return False
+    return (False, 'Module dsc: module only works on Windows systems '
+            'with PowerShell 3 or later installed.')
 
 
 def _pshell(cmd):


### PR DESCRIPTION
Updated message when return False if is not Windows or PowerShell version 3 or later
is not installed.
