### PR TITLE
Fix more logger related memory leaks on Windows

### DIFF
--- a/salt/engines/__init__.py
+++ b/salt/engines/__init__.py
@@ -67,16 +67,38 @@ class Engine(SignalHandlingMultiprocessingProcess):
     '''
     Execute the given engine in a new process
     '''
-    def __init__(self, opts, fun, config, funcs, runners, **kwargs):
+    def __init__(self, opts, fun, config, funcs, runners, log_queue=None):
         '''
         Set up the process executor
         '''
-        super(Engine, self).__init__(**kwargs)
+        super(Engine, self).__init__(log_queue=log_queue)
         self.opts = opts
         self.config = config
         self.fun = fun
         self.funcs = funcs
         self.runners = runners
+
+    # __setstate__ and __getstate__ are only used on Windows.
+    # We do this so that __init__ will be invoked on Windows in the child
+    # process so that a register_after_fork() equivalent will work on Windows.
+    def __setstate__(self, state):
+        self._is_child = True
+        self.__init__(
+            state['opts'],
+            state['fun'],
+            state['config'],
+            state['funcs'],
+            state['runners'],
+            log_queue=state['log_queue']
+        )
+
+    def __getstate__(self):
+        return {'opts': self.opts,
+                'fun': self.fun,
+                'config': self.config,
+                'funcs': self.funcs,
+                'runners': self.runners,
+                'log_queue': self.log_queue}
 
     def run(self):
         '''

--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -766,6 +766,12 @@ def get_multiprocessing_logging_queue():
     return __MP_LOGGING_QUEUE
 
 
+def set_multiprocessing_logging_queue(queue):
+    global __MP_LOGGING_QUEUE
+    if __MP_LOGGING_QUEUE is not queue:
+        __MP_LOGGING_QUEUE = queue
+
+
 def setup_multiprocessing_logging_listener(opts, queue=None):
     global __MP_LOGGING_QUEUE_PROCESS
     global __MP_LOGGING_LISTENER_CONFIGURED
@@ -917,6 +923,7 @@ def __process_multiprocessing_logging_queue(opts, queue):
         # On Windows, creating a new process doesn't fork (copy the parent
         # process image). Due to this, we need to setup extended logging
         # inside this process.
+        setup_temp_logger()
         setup_extended_logging(opts)
     while True:
         try:

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -921,6 +921,17 @@ class EventPublisher(salt.utils.process.SignalHandlingMultiprocessingProcess):
         self.opts.update(opts)
         self._closing = False
 
+    # __setstate__ and __getstate__ are only used on Windows.
+    # We do this so that __init__ will be invoked on Windows in the child
+    # process so that a register_after_fork() equivalent will work on Windows.
+    def __setstate__(self, state):
+        self._is_child = True
+        self.__init__(state['opts'], log_queue=state['log_queue'])
+
+    def __getstate__(self):
+        return {'opts': self.opts,
+                'log_queue': self.log_queue}
+
     def run(self):
         '''
         Bind the pub and pull sockets for events
@@ -1028,6 +1039,17 @@ class EventReturn(salt.utils.process.SignalHandlingMultiprocessingProcess):
         self.minion = salt.minion.MasterMinion(local_minion_opts)
         self.event_queue = []
         self.stop = False
+
+    # __setstate__ and __getstate__ are only used on Windows.
+    # We do this so that __init__ will be invoked on Windows in the child
+    # process so that a register_after_fork() equivalent will work on Windows.
+    def __setstate__(self, state):
+        self._is_child = True
+        self.__init__(state['opts'], log_queue=state['log_queue'])
+
+    def __getstate__(self):
+        return {'opts': self.opts,
+                'log_queue': self.log_queue}
 
     def _handle_signals(self, signum, sigframe):
         # Flush and terminate

--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -43,6 +43,7 @@ class Reactor(salt.utils.process.MultiprocessingProcess, salt.state.Compiler):
     # These methods are only used when pickling so will not be used on
     # non-Windows platforms.
     def __setstate__(self, state):
+        self._is_child = True
         Reactor.__init__(
             self, state['opts'],
             log_queue=state['log_queue'])


### PR DESCRIPTION
Some observations have been made on Windows:
- Any process (besides the main process) that does not call
  `salt.log.setup.setup_multiprocessing_logging()` will leak. The reason is
  that because Windows doesn't copy process state when spawning processes,
  each new process will have the temp null and temp queue log handlers
  installed (the default state in `salt/log/setup.py` when initializing).
  Those handlers just store stuff and hence will use much memory.
- It was obversed that for some of the classes, `register_after_fork()`
  wouldn't work and so `salt.log.setup.setup_multiprocessing_logging()`
  wouldn't be invoked causing leaks. However, for some of the classes,
  `register_after_fork()` would work. After investigation, it was determined
  that `register_after_fork()` worked only on processes that used
  `__setstate__` / `__getstate__` and hence would invoke `__init__()` inside
  the child process. Thus, `register_after_fork()` only seems to work on
  Windows when invoked from within the child process, but not the parent
  process, making it not very useful (since if we are in the child process,
  we can invoke `salt.log.setup.setup_multiprocessing_logging()` directly).

The following changes have been made based on these observations:
- Try to make almost every process use or inherit from
  `MultiprocessingProcess` so as to call
  `salt.log.setup.setup_multiprocessing_logging()`.
- Processes that don't use or inherit from `MultiprocessingProcess` invoke
  `salt.log.setup.setup_multiprocessing_logging()` themselves.
- Try to make every process that uses or inherits from
  `MultiprocessingProcess` invoke `__init__` from the child process.
  In order to accomplish this, all such processes use `__setstate__` and
  `__getstate__`.
- When `multiprocessing.Process` is constructed via `__init__` in the child
  process, certain features such as `is_alive()` and `ident()` don't work.
  Thus we set `self._is_child = True` in each `__setstate__` to be able to
  distinguish whether the `__init__` invocation is from the parent or child
  process.

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
