### PR TITLE
fix type in test data

### DIFF
--- a/tests/unit/modules/zpool_test.py
+++ b/tests/unit/modules/zpool_test.py
@@ -60,7 +60,7 @@ class ZpoolTestCase(TestCase):
         '''
         ret = {}
         ret['stdout'] = ""
-        ret['stderr'] = "cannot open 'mypool': no such pool"
+        ret['stderr'] = "cannot open 'myzpool': no such pool"
         ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):


### PR DESCRIPTION
As noticed by @nmadhok, fix a small typo.

``` bash
[root@nacl /salt_dev/salt]# ./tests/runtests.py -n unit.modules.zpool_test
default
default
```
- Transplanting configuration files to '/tmp/salt-tests-tmpdir/config'
- Current Directory: /salt_dev/salt
- Test suite is running under PID 4499
- Logging tests on /tmp/salt-runtests.log

```
```

Starting unit.modules.zpool_test Tests

```
.......
----------------------------------------------------------------------
Ran 7 tests in 0.006s

OK

============================  Overall Tests Report  ============================
***  No Problems Found While Running Tests  ************************************
================================================================================
OK (total=7, skipped=0, passed=7, failures=0, errors=0)
============================  Overall Tests Report  ============================
[root@nacl /salt_dev/salt]# ./tests/runtests.py -n unit.modules.zpool_test
default
default
```
- Transplanting configuration files to '/tmp/salt-tests-tmpdir/config'
- Current Directory: /salt_dev/salt
- Test suite is running under PID 4548
- Logging tests on /tmp/salt-runtests.log

```
```

Starting unit.modules.zpool_test Tests

```
.......
----------------------------------------------------------------------
Ran 7 tests in 0.006s

OK

============================  Overall Tests Report  ============================
***  No Problems Found While Running Tests  ************************************
================================================================================
OK (total=7, skipped=0, passed=7, failures=0, errors=0)
============================  Overall Tests Report  ============================
```
