### PR TITLE
salt.modules.zfs

### DIFF
--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -10,11 +10,6 @@ from __future__ import absolute_import
 # Import Python libs
 import logging
 
-# Some std libraries that are made
-# use of.
-import re
-import sys
-
 # Import Salt libs
 import salt.utils
 import salt.modules.cmdmod
@@ -55,45 +50,6 @@ def _check_features():
     return res['retcode'] == 0
 
 
-def _available_commands():
-    '''
-    List available commands based on 'zfs -?'. Returns a dict.
-    Does not work on illumos or solaris
-    '''
-    zfs_path = _check_zfs()
-    if not zfs_path:
-        return False
-
-    ret = {}
-    res = __salt__['cmd.run_stderr'](
-        '{0} -?'.format(zfs_path),
-        output_loglevel='trace',
-        ignore_retcode=True
-    )
-
-    # This bit is dependent on specific output from `zfs -?` - any major changes
-    # in how this works upstream will require a change.
-    for line in res.splitlines():
-        if re.match('  [a-zA-Z]', line):
-            cmds = line.split(' ')[0].split('|')
-            doc = ' '.join(line.split(' ')[1:])
-            for cmd in [cmd.strip() for cmd in cmds]:
-                if cmd not in ret:
-                    ret[cmd] = doc
-    return ret
-
-
-def _exit_status(retcode):
-    '''
-    Translate exit status of zfs
-    '''
-    ret = {0: 'Successful completion.',
-           1: 'An error occurred.',
-           2: 'Usage error.'
-           }[retcode]
-    return ret
-
-
 def __virtual__():
     '''
     Makes sure that ZFS kernel module is loaded.
@@ -118,75 +74,8 @@ def __virtual__():
     if cmd and salt.modules.cmdmod.retcode(
         cmd, output_loglevel='quiet', ignore_retcode=True
     ) == 0:
-        # Build dynamic functions and allow loading module
-        _build_zfs_cmd_list()
         return 'zfs'
     return (False, "The zfs module cannot be loaded: zfs not found")
-
-
-def _add_doc(func, doc, prefix='\n\n    '):
-    '''
-    Add documentation to a function
-    '''
-    if not func.__doc__:
-        func.__doc__ = ''
-    func.__doc__ += '{0}{1}'.format(prefix, doc)
-
-
-def _make_function(cmd_name, doc):
-    '''
-    Returns a function based on the command name.
-    '''
-    def _cmd(*args):
-        # Define a return value.
-        ret = {}
-
-        # Run the command.
-        res = __salt__['cmd.run_all'](
-                '{0} {1} {2}'.format(
-                    _check_zfs(),
-                    cmd_name,
-                    ' '.join(args)
-                    )
-                )
-
-        # Make a note of the error in the return object if retcode
-        # not 0.
-        if res['retcode'] != 0:
-            ret['error'] = _exit_status(res['retcode'])
-
-        # Set the output to be splitlines for now.
-        ret = res['stdout'].splitlines()
-
-        return ret
-
-    _add_doc(_cmd, 'This function is dynamically generated.', '\n    ')
-    _add_doc(_cmd, doc)
-    _add_doc(_cmd, '\n    CLI Example:\n\n')
-    _add_doc(_cmd, '\n        salt \'*\' zfs.{0} <args>'.format(cmd_name))
-
-    # At this point return the function we've just defined.
-    return _cmd
-
-
-def _build_zfs_cmd_list():
-    '''
-    Run through zfs command options, and build equivalent functions dynamically
-    '''
-    # Run through all the available commands
-    if _check_zfs():
-        available_cmds = _available_commands()
-        for available_cmd in available_cmds:
-            # Set the output from _make_function to be 'available_cmd_'.
-            # i.e. 'list' becomes 'list_' in local module.
-            setattr(
-                    sys.modules[__name__],
-                    '{0}_'.format(available_cmd),
-                    _make_function(available_cmd, available_cmds[available_cmd])
-                    )
-
-            # Update the function alias so that salt finds the functions properly.
-            __func_alias__['{0}_'.format(available_cmd)] = available_cmd
 
 
 def exists(name):

--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -482,7 +482,7 @@ def list_(name=None, **kwargs):
 
 def mount(name='-a', **kwargs):
     '''
-    .. versionadded:: Borson
+    .. versionadded:: Boron
 
     Mounts ZFS file systems
 
@@ -526,9 +526,9 @@ def mount(name='-a', **kwargs):
 
 def unmount(name, **kwargs):
     '''
-    .. versionadded:: Borson
+    .. versionadded:: Boron
 
-    Mounts ZFS file systems
+    Unmounts ZFS file systems
 
     name : string
         name of the filesystem, you can use '-a' to unmount all mounted filesystems.

--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -1208,9 +1208,10 @@ def get(*dataset, **kwargs):
 
     .. code-block:: bash
 
-        salt '*' zfs.list
-        salt '*' zfs.list myzpool/mydataset [recursive=True|False]
-        salt '*' zfs.list myzpool/mydataset properties="sharenfs,mountpoint"
+        salt '*' zfs.get
+        salt '*' zfs.get myzpool/mydataset [recursive=True|False]
+        salt '*' zfs.get myzpool/mydataset properties="sharenfs,mountpoint" [recursive=True|False]
+        salt '*' zfs.get myzpool/mydataset myzpool/myotherdataset properties=available fields=value depth=1
     '''
     ret = OrderedDict()
     zfs = _check_zfs()

--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -720,7 +720,7 @@ def rollback(name, **kwargs):
     ))
 
     if res['retcode'] != 0:
-        ret['error'] = res['stderr'] if 'stderr' in res else res['stdout']
+        ret[name[:name.index('@')]] = res['stderr'] if 'stderr' in res else res['stdout']
     else:
         ret[name[:name.index('@')]] = 'rolledback to snapshot: {0}'.format(name[name.index('@')+1:])
     return ret

--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -1171,7 +1171,13 @@ def snapshot(*snapshot, **kwargs):
     if res['retcode'] != 0:
         for err in res['stderr'].splitlines():
             if err.startswith('cannot create snapshot'):
-                ret[err[24:err.index(':')-1]] = err[err.index(':')+2:]
+                snap = err[24:err.index(':')-1]
+                msg = err[err.index(':')+2:]
+                if snap != '':
+                    ret[snap] = msg
+                else:
+                    for snap in ret.keys():
+                        ret[snap] = msg
             elif err.startswith('cannot open'):
                 for snap in ret.keys():
                     if snap.startswith(err[13:err.index(':')-1]):

--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -475,27 +475,24 @@ def list_(name=None, **kwargs):
     else:
         ret['error'] = res['stderr'] if 'stderr' in res else res['stdout']
 
+    log.warning(res)
+    log.warning(ret)
     return ret
 
 
-def mount(name='*', **kwargs):
+def mount(name='-a', **kwargs):
     '''
-    .. versionadded:: 2015.5.0
+    .. versionadded:: Borson
 
     Mounts ZFS file systems
 
     name : string
-        name of the filesystem, use ``*`` to mount all filesystems (-a).
+        name of the filesystem, you can use '-a' to mount all unmounted filesystems. (this is the default)
     overlay : boolean
         perform an overlay mount.
     options : string
         optional comma-separated list of mount options to use temporarily for
         the duration of the mount.
-
-    .. note::
-
-        If the ``name`` paramter is not provided, zfs.mount displays the mounted
-        filesystems.
 
     CLI Example:
 
@@ -513,17 +510,58 @@ def mount(name='*', **kwargs):
         zfs=zfs,
         overlay='-O ' if overlay else '',
         options='-o {0} '.format(options) if options else '',
-        filesystem='-a' if name == '*' else name
+        filesystem=name
     ))
 
     ret = {}
-    if name == '*':
+    if name == '-a':
         ret = res['retcode'] == 0
     else:
         if res['retcode'] != 0:
             ret[name] = res['stderr'] if 'stderr' in res else res['stdout']
         else:
             ret[name] = 'mounted'
+    return ret
+
+
+def unmount(name, **kwargs):
+    '''
+    .. versionadded:: Borson
+
+    Mounts ZFS file systems
+
+    name : string
+        name of the filesystem, you can use '-a' to unmount all mounted filesystems.
+    force : boolean
+        forcefully unmount the file system, even if it is currently in use.
+
+    .. warning::
+
+        Using ``-a`` for the name parameter will probably break your system, unless your rootfs is not on zfs.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' zfs.unmount myzpool/mydataset [force=True|False]
+    '''
+    zfs = _check_zfs()
+    force = kwargs.get('force', False)
+
+    res = __salt__['cmd.run_all']('{zfs} unmount {force}{filesystem}'.format(
+        zfs=zfs,
+        force='-f ' if force else '',
+        filesystem=name
+    ))
+
+    ret = {}
+    if name == '-a':
+        ret = res['retcode'] == 0
+    else:
+        if res['retcode'] != 0:
+            ret[name] = res['stderr'] if 'stderr' in res else res['stdout']
+        else:
+            ret[name] = 'unmounted'
     return ret
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -4,28 +4,6 @@ Salt interface to ZFS commands
 
 :codeauthor: Nitin Madhok <nmadhok@clemson.edu>
 
-.. note::
-    TODO
-
-    - list -> parse output
-    - destroy -> parse output (-P
-    - snapshot
-    - rollback
-    - clone
-    - promote
-    - set
-    - get
-    - inherit
-    - mount
-    - unmount
-    - bookmark
-    - hold
-    - holds
-    - release
-    - diff
-    - allow
-    - unallow
-
 '''
 from __future__ import absolute_import
 
@@ -310,6 +288,9 @@ def destroy(name, **kwargs):
     recursive_all : boolean
         recursively destroy all dependents, including cloned file systems
         outside the target hierarchy. (-R)
+
+    .. warning::
+        watch out when using recursive and recursive_all
 
     CLI Example:
 

--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -722,7 +722,7 @@ def rollback(name, **kwargs):
     if res['retcode'] != 0:
         ret['error'] = res['stderr'] if 'stderr' in res else res['stdout']
     else:
-        ret[name[:name.index('@')]] = 'rolledback to snapshot {0}'.format(name[name.index('@')+1:])
+        ret[name[:name.index('@')]] = 'rolledback to snapshot: {0}'.format(name[name.index('@')+1:])
     return ret
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -1013,7 +1013,7 @@ def hold(tag, *snapshot, **kwargs):
     ))
 
     for snap in snapshot:
-        ret[snap] = 'held'
+        ret[snap] = 'held (tag={0})'.format(tag)
     if res['retcode'] != 0:
         for err in res['stderr'].splitlines():
             if err.startswith('cannot hold snapshot'):

--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -78,7 +78,7 @@ def __virtual__():
     return (False, "The zfs module cannot be loaded: zfs not found")
 
 
-def exists(name):
+def exists(name, **kwargs):
     '''
     .. versionadded:: 2015.5.0
 
@@ -86,15 +86,21 @@ def exists(name):
 
     name : string
         name of dataset
+    type : string
+        also check if dataset is of a certain type, valid choices are:
+        filesystem, snapshot, volume, bookmark, or all.
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zfs.exists myzpool/mydataset
+        salt '*' zfs.exists myzpool/myvolume type=volume
     '''
     zfs = _check_zfs()
-    cmd = '{0} list {1}'.format(zfs, name)
+    ltype = kwargs.get('type', None)
+
+    cmd = '{0} list {1}{2}'.format(zfs, '-t {0} '.format(ltype) if ltype else '', name)
     res = __salt__['cmd.run_all'](cmd, ignore_retcode=True)
 
     return res['retcode'] == 0

--- a/tests/unit/modules/zfs_test.py
+++ b/tests/unit/modules/zfs_test.py
@@ -276,6 +276,17 @@ class ZfsTestCase(TestCase):
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertEqual(zfs.inherit('canmount', 'myzpool/mydataset'), res)
 
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_diff(self):
+        '''
+        Tests zfs diff
+        '''
+        res = ['M\t/\t/myzpool/mydataset/', '+\tF\t/myzpool/mydataset/hello']
+        ret = {'pid': 51495, 'retcode': 0, 'stderr': '', 'stdout': 'M\t/\t/myzpool/mydataset/\n+\tF\t/myzpool/mydataset/hello'}
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.diff('myzpool/mydataset@yesterday', 'myzpool/mydataset'), res)
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(ZfsTestCase, needs_daemon=False)

--- a/tests/unit/modules/zfs_test.py
+++ b/tests/unit/modules/zfs_test.py
@@ -468,6 +468,28 @@ class ZfsTestCase(TestCase):
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertEqual(zfs.snapshot('myzpool/mydataset@baseline'), res)
 
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_set_success(self):
+        '''
+        Tests zfs set success
+        '''
+        res = {'myzpool/mydataset': {'compression': 'set'}}
+        ret = {'pid': 79736, 'retcode': 0, 'stderr': '', 'stdout': ''}
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.set('myzpool/mydataset', compression='lz4'), res)
+
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_set_failure(self):
+        '''
+        Tests zfs set failure
+        '''
+        res = {'myzpool/mydataset': {'canmount': "'canmount' must be one of 'on | off | noauto'"}}
+        ret = {'pid': 79887, 'retcode': 1, 'stderr': "cannot set property for 'myzpool/mydataset': 'canmount' must be one of 'on | off | noauto'", 'stdout': ''}
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.set('myzpool/mydataset', canmount='lz4'), res)
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(ZfsTestCase, needs_daemon=False)

--- a/tests/unit/modules/zfs_test.py
+++ b/tests/unit/modules/zfs_test.py
@@ -25,6 +25,7 @@ ensure_in_syspath('../../')
 
 # Import Salt Execution module to test
 from salt.modules import zfs
+from salt.utils.odict import OrderedDict
 
 # Globals
 zfs.__salt__ = {}
@@ -181,6 +182,17 @@ class ZfsTestCase(TestCase):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertEqual(zfs.create('myzpool/mydataset/mysubdataset'), res)
+
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_list_success(self):
+        '''
+        Tests zfs list
+        '''
+        res = OrderedDict([('myzpool', {'avail': '79.9M', 'mountpoint': '/myzpool', 'used': '113K', 'refer': '19K'})])
+        ret = {'pid': 31817, 'retcode': 0, 'stderr': '', 'stdout': 'myzpool\t113K\t79.9M\t19K\t/myzpool'}
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.list_('myzpool'), res)
 
     @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
     def test_mount_success(self):

--- a/tests/unit/modules/zfs_test.py
+++ b/tests/unit/modules/zfs_test.py
@@ -42,9 +42,12 @@ class ZfsTestCase(TestCase):
         '''
         Tests successful return of exists function
         '''
-        ret = "NAME        USED  AVAIL  REFER  MOUNTPOINT\nmyzpool/mydataset    30K   157G    30K  /myzpool/mydataset"
+        ret = {}
+        ret['stdout'] = "NAME        USED  AVAIL  REFER  MOUNTPOINT\nmyzpool/mydataset    30K   157G    30K  /myzpool/mydataset"
+        ret['stderr'] = ''
+        ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertTrue(zfs.exists('myzpool/mydataset'))
 
     @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
@@ -52,9 +55,12 @@ class ZfsTestCase(TestCase):
         '''
         Tests unsuccessful return of exists function if dataset does not exist
         '''
-        ret = "cannot open 'myzpool/mydataset': dataset does not exist"
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot open 'myzpool/mydataset': dataset does not exist"
+        ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertFalse(zfs.exists('myzpool/mydataset'))
 
     @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
@@ -62,9 +68,12 @@ class ZfsTestCase(TestCase):
         '''
         Tests unsuccessful return of exists function if dataset name is invalid
         '''
-        ret = "cannot open 'myzpool/': invalid dataset name"
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot open 'myzpool/': invalid dataset name"
+        ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertFalse(zfs.exists('myzpool/'))
 
     @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
@@ -72,29 +81,41 @@ class ZfsTestCase(TestCase):
         '''
         Tests successful return of create function on ZFS file system creation
         '''
-        ret = {'myzpool/mydataset': 'created'}
-        mock_cmd = MagicMock(return_value="")
-        with patch.dict(zfs.__salt__, {'cmd.run': mock_cmd}):
-            self.assertEqual(zfs.create('myzpool/mydataset'), ret)
+        res = {'myzpool/mydataset': 'created'}
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.create('myzpool/mydataset'), res)
 
     @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
     def test_create_success_with_create_parent(self):
         '''
         Tests successful return of create function when ``create_parent=True``
         '''
-        ret = {'myzpool/mydataset/mysubdataset': 'created'}
-        mock_cmd = MagicMock(return_value="")
-        with patch.dict(zfs.__salt__, {'cmd.run': mock_cmd}):
-            self.assertEqual(zfs.create('myzpool/mydataset/mysubdataset'), ret)
+        res = {'myzpool/mydataset/mysubdataset': 'created'}
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.create('myzpool/mydataset/mysubdataset', create_parent=True), res)
 
     @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
     def test_create_success_with_properties(self):
         '''
         Tests successful return of create function on ZFS file system creation (with properties)
         '''
-        ret = {'myzpool/mydataset': 'created'}
-        mock_cmd = MagicMock(return_value="")
-        with patch.dict(zfs.__salt__, {'cmd.run': mock_cmd}):
+        res = {'myzpool/mydataset': 'created'}
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertEqual(
                 zfs.create(
                     'myzpool/mydataset',
@@ -102,7 +123,7 @@ class ZfsTestCase(TestCase):
                         'mountpoint': '/export/zfs',
                         'sharenfs': 'on'
                     }
-                ), ret
+                ), res
             )
 
     @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
@@ -110,45 +131,59 @@ class ZfsTestCase(TestCase):
         '''
         Tests unsuccessful return of create function if dataset name is missing
         '''
-        msg = "cannot create 'myzpool': missing dataset name"
-        ret = {'Error': 'cannot create \'myzpool\': missing dataset name'}
-        mock_cmd = MagicMock(return_value=msg)
-        with patch.dict(zfs.__salt__, {'cmd.run': mock_cmd}):
-            self.assertEqual(zfs.create('myzpool'), ret)
+        res = {'myzpool': 'cannot create \'myzpool\': missing dataset name'}
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot create 'myzpool': missing dataset name"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.create('myzpool'), res)
 
     @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
     def test_create_error_trailing_slash(self):
         '''
         Tests unsuccessful return of create function if trailing slash in name is present
         '''
-        msg = "cannot create 'myzpool/': trailing slash in name"
-        ret = {'Error': 'cannot create \'myzpool/\': trailing slash in name'}
-        mock_cmd = MagicMock(return_value=msg)
-        with patch.dict(zfs.__salt__, {'cmd.run': mock_cmd}):
-            self.assertEqual(zfs.create('myzpool/'), ret)
+        res = {'myzpool/': 'cannot create \'myzpool/\': trailing slash in name'}
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot create 'myzpool/': trailing slash in name"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.create('myzpool/'), res)
 
     @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
     def test_create_error_no_such_pool(self):
         '''
         Tests unsuccessful return of create function if the pool is not present
         '''
-        msg = "cannot create 'myzpool/mydataset': no such pool 'myzpool'"
-        ret = {'Error': 'cannot create \'myzpool/mydataset\': no such pool \'myzpool\''}
-        mock_cmd = MagicMock(return_value=msg)
-        with patch.dict(zfs.__salt__, {'cmd.run': mock_cmd}):
-            self.assertEqual(zfs.create('myzpool/mydataset'), ret)
+        res = {'myzpool/mydataset': 'cannot create \'myzpool/mydataset\': no such pool \'myzpool\''}
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot create 'myzpool/mydataset': no such pool 'myzpool'"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.create('myzpool/mydataset'), res)
 
     @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
     def test_create_error_missing_parent(self):
         '''
         Tests unsuccessful return of create function if the parent datasets do not exist
         '''
-        msg = "cannot create 'myzpool/mydataset/mysubdataset': parent does not exist"
-        ret = {'Error': 'cannot create \'myzpool/mydataset/mysubdataset\': parent does not exist'}
-        mock_cmd = MagicMock(return_value=msg)
-        with patch.dict(zfs.__salt__, {'cmd.run': mock_cmd}):
-            self.assertEqual(zfs.create('myzpool/mydataset/mysubdataset'), ret)
+        res = {'myzpool/mydataset/mysubdataset': 'cannot create \'myzpool/mydataset/mysubdataset\': parent does not exist'}
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot create 'myzpool/mydataset/mysubdataset': parent does not exist"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.create('myzpool/mydataset/mysubdataset'), res)
 
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(ZfsTestCase, needs_daemon=False)
+
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/tests/unit/modules/zfs_test.py
+++ b/tests/unit/modules/zfs_test.py
@@ -182,6 +182,34 @@ class ZfsTestCase(TestCase):
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertEqual(zfs.create('myzpool/mydataset/mysubdataset'), res)
 
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_mount_success(self):
+        '''
+        Tests zfs mount of filesystem
+        '''
+        res = {'myzpool/mydataset': 'mounted'}
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.mount('myzpool/mydataset'), res)
+
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_mount_failure(self):
+        '''
+        Tests zfs mount of already mounted filesystem
+        '''
+        res = {'myzpool/mydataset': "cannot mount 'myzpool/mydataset': filesystem already mounted"}
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot mount 'myzpool/mydataset': filesystem already mounted"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.mount('myzpool/mydataset'), res)
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(ZfsTestCase, needs_daemon=False)

--- a/tests/unit/modules/zfs_test.py
+++ b/tests/unit/modules/zfs_test.py
@@ -222,6 +222,34 @@ class ZfsTestCase(TestCase):
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertEqual(zfs.mount('myzpool/mydataset'), res)
 
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_unmount_success(self):
+        '''
+        Tests zfs unmount of filesystem
+        '''
+        res = {'myzpool/mydataset': 'unmounted'}
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.unmount('myzpool/mydataset'), res)
+
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_unmount_failure(self):
+        '''
+        Tests zfs unmount of already mounted filesystem
+        '''
+        res = {'myzpool/mydataset': "cannot mount 'myzpool/mydataset': not currently mounted"}
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot mount 'myzpool/mydataset': not currently mounted"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.unmount('myzpool/mydataset'), res)
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(ZfsTestCase, needs_daemon=False)

--- a/tests/unit/modules/zfs_test.py
+++ b/tests/unit/modules/zfs_test.py
@@ -358,6 +358,17 @@ class ZfsTestCase(TestCase):
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertEqual(zfs.promote('myzpool/yesterday'), res)
 
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_bookmark_success(self):
+        '''
+        Tests zfs bookmark success
+        '''
+        res = {'myzpool/mydataset@yesterday': 'bookmarked as myzpool/mydataset#important'}
+        ret = {'pid': 20990, 'retcode': 0, 'stderr': '', 'stdout': ''}
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.bookmark('myzpool/mydataset@yesterday', 'myzpool/mydataset#important'), res)
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(ZfsTestCase, needs_daemon=False)

--- a/tests/unit/modules/zfs_test.py
+++ b/tests/unit/modules/zfs_test.py
@@ -396,7 +396,7 @@ class ZfsTestCase(TestCase):
         '''
         Tests zfs hold success
         '''
-        res = {'myzpool/mydataset@baseline': 'held (tag=important)', 'myzpool/mydataset@release-1.0': 'held (tag=important)'}
+        res = {'myzpool/mydataset@baseline': {'important': 'held'}, 'myzpool/mydataset@release-1.0': {'important': 'held'}}
         ret = {'pid': 50876, 'retcode': 0, 'stderr': '', 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
@@ -407,7 +407,7 @@ class ZfsTestCase(TestCase):
         '''
         Tests zfs hold failure
         '''
-        res = {'myzpool/mydataset@baseline': 'tag already exists on this dataset'}
+        res = {'myzpool/mydataset@baseline': {'important': 'tag already exists on this dataset'}}
         ret = {'pid': 51006, 'retcode': 1, 'stderr': "cannot hold snapshot 'myzpool/mydataset@baseline': tag already exists on this dataset", 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
@@ -418,7 +418,7 @@ class ZfsTestCase(TestCase):
         '''
         Tests zfs release success
         '''
-        res = {'myzpool/mydataset@baseline': 'released (tag=important)', 'myzpool/mydataset@release-1.0': 'released (tag=important)'}
+        res = {'myzpool/mydataset@baseline': {'important': 'released'}, 'myzpool/mydataset@release-1.0': {'important': 'released'}}
         ret = {'pid': 50876, 'retcode': 0, 'stderr': '', 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
@@ -429,7 +429,7 @@ class ZfsTestCase(TestCase):
         '''
         Tests zfs release failure
         '''
-        res = {'myzpool/mydataset@baseline': 'no such tag on this dataset'}
+        res = {'myzpool/mydataset@baseline': {'important': 'no such tag on this dataset'}}
         ret = {'pid': 51006, 'retcode': 1, 'stderr': "cannot release hold from snapshot 'myzpool/mydataset@baseline': no such tag on this dataset", 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):

--- a/tests/unit/modules/zfs_test.py
+++ b/tests/unit/modules/zfs_test.py
@@ -490,6 +490,17 @@ class ZfsTestCase(TestCase):
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertEqual(zfs.set('myzpool/mydataset', canmount='lz4'), res)
 
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_get_success(self):
+        '''
+        Tests zfs get success
+        '''
+        res = OrderedDict([('myzpool', {'compression': {'value': 'off'}})])
+        ret = {'pid': 562, 'retcode': 0, 'stderr': '', 'stdout': 'myzpool\tcompression\toff'}
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.get('myzpool', properties='compression', fields='value'), res)
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(ZfsTestCase, needs_daemon=False)

--- a/tests/unit/modules/zfs_test.py
+++ b/tests/unit/modules/zfs_test.py
@@ -250,6 +250,32 @@ class ZfsTestCase(TestCase):
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertEqual(zfs.unmount('myzpool/mydataset'), res)
 
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_inherit_success(self):
+        '''
+        Tests zfs inherit of compression property
+        '''
+        res = {'myzpool/mydataset': {'compression': 'cleared'}}
+        ret = {'pid': 45193, 'retcode': 0, 'stderr': '', 'stdout': ''}
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.inherit('compression', 'myzpool/mydataset'), res)
+
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_inherit_failure(self):
+        '''
+        Tests zfs inherit of canmount
+        '''
+        res = {
+            'myzpool/mydataset': {
+                'canmount': "'canmount' property cannot be inherited, use revert=True to try and reset it to it's default value."
+            }
+        }
+        ret = {'pid': 43898, 'retcode': 1, 'stderr': "'canmount' property cannot be inherited", 'stdout': ''}
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.inherit('canmount', 'myzpool/mydataset'), res)
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(ZfsTestCase, needs_daemon=False)

--- a/tests/unit/modules/zfs_test.py
+++ b/tests/unit/modules/zfs_test.py
@@ -303,7 +303,7 @@ class ZfsTestCase(TestCase):
         '''
         Tests zfs rollback failure
         '''
-        res = {'myzpool/mydataset': "cannot rollback to 'myzpool/mydataset@yesterday': more recent snapshots or bookmarks exist\nuse '-r' to force deletion of the following snapshots and bookmarks:\nmyzpool/mydataset@today" }
+        res = {'myzpool/mydataset': "cannot rollback to 'myzpool/mydataset@yesterday': more recent snapshots or bookmarks exist\nuse '-r' to force deletion of the following snapshots and bookmarks:\nmyzpool/mydataset@today"}
         ret = {
             'pid': 57471,
             'retcode': 1,

--- a/tests/unit/modules/zfs_test.py
+++ b/tests/unit/modules/zfs_test.py
@@ -391,6 +391,28 @@ class ZfsTestCase(TestCase):
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertEqual(zfs.holds('myzpool/mydataset@baseline'), res)
 
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_hold_success(self):
+        '''
+        Tests zfs hold success
+        '''
+        res = {'myzpool/mydataset@baseline': 'held (tag=important)', 'myzpool/mydataset@release-1.0': 'held (tag=important)'}
+        ret = {'pid': 50876, 'retcode': 0, 'stderr': '', 'stdout': ''}
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.hold('important', 'myzpool/mydataset@baseline', 'myzpool/mydataset@release-1.0'), res)
+
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_hold_failure(self):
+        '''
+        Tests zfs hold failure
+        '''
+        res = {'myzpool/mydataset@baseline': ' tag already exists on this dataset'}
+        ret = {'pid': 51006, 'retcode': 1, 'stderr': "cannot hold snapshot 'myzpool/mydataset@baseline': tag already exists on this dataset", 'stdout': ''}
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.hold('important', 'myzpool/mydataset@baseline'), res)
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(ZfsTestCase, needs_daemon=False)

--- a/tests/unit/modules/zfs_test.py
+++ b/tests/unit/modules/zfs_test.py
@@ -287,6 +287,33 @@ class ZfsTestCase(TestCase):
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertEqual(zfs.diff('myzpool/mydataset@yesterday', 'myzpool/mydataset'), res)
 
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_rollback_success(self):
+        '''
+        Tests zfs rollback success
+        '''
+        res = {'myzpool/mydataset': 'rolledback to snapshot: yesterday'}
+        ret = {'pid': 56502, 'retcode': 0, 'stderr': '', 'stdout': ''}
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.rollback('myzpool/mydataset@yesterday'), res)
+
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_rollback_failure(self):
+        '''
+        Tests zfs rollback failure
+        '''
+        res = {'myzpool/mydataset': "cannot rollback to 'myzpool/mydataset@yesterday': more recent snapshots or bookmarks exist\nuse '-r' to force deletion of the following snapshots and bookmarks:\nmyzpool/mydataset@today" }
+        ret = {
+            'pid': 57471,
+            'retcode': 1,
+            'stderr': "cannot rollback to 'myzpool/mydataset@yesterday': more recent snapshots or bookmarks exist\nuse '-r' to force deletion of the following snapshots and bookmarks:\nmyzpool/mydataset@today",
+            'stdout': ''
+        }
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.rollback('myzpool/mydataset@yesterday'), res)
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(ZfsTestCase, needs_daemon=False)

--- a/tests/unit/modules/zfs_test.py
+++ b/tests/unit/modules/zfs_test.py
@@ -314,6 +314,28 @@ class ZfsTestCase(TestCase):
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertEqual(zfs.rollback('myzpool/mydataset@yesterday'), res)
 
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_clone_success(self):
+        '''
+        Tests zfs clone success
+        '''
+        res = {'myzpool/yesterday': 'cloned from myzpool/mydataset@yesterday'}
+        ret = {'pid': 64532, 'retcode': 0, 'stderr': '', 'stdout': ''}
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.clone('myzpool/mydataset@yesterday', 'myzpool/yesterday'), res)
+
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_clone_failure(self):
+        '''
+        Tests zfs clone failure
+        '''
+        res = {'myzpool/archive/yesterday': "cannot create 'myzpool/archive/yesterday': parent does not exist"}
+        ret = {'pid': 64864, 'retcode': 1, 'stderr': "cannot create 'myzpool/archive/yesterday': parent does not exist", 'stdout': ''}
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.clone('myzpool/mydataset@yesterday', 'myzpool/archive/yesterday'), res)
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(ZfsTestCase, needs_daemon=False)

--- a/tests/unit/modules/zfs_test.py
+++ b/tests/unit/modules/zfs_test.py
@@ -369,6 +369,28 @@ class ZfsTestCase(TestCase):
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertEqual(zfs.bookmark('myzpool/mydataset@yesterday', 'myzpool/mydataset#important'), res)
 
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_holds_success(self):
+        '''
+        Tests zfs holds success
+        '''
+        res = {'myzpool/mydataset@baseline': {'important  ': 'Wed Dec 23 21:06 2015', 'release-1.0': 'Wed Dec 23 21:08 2015'}}
+        ret = {'pid': 40216, 'retcode': 0, 'stderr': '', 'stdout': 'myzpool/mydataset@baseline\timportant  \tWed Dec 23 21:06 2015\nmyzpool/mydataset@baseline\trelease-1.0\tWed Dec 23 21:08 2015'}
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.holds('myzpool/mydataset@baseline'), res)
+
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_holds_failure(self):
+        '''
+        Tests zfs holds failure
+        '''
+        res = {'myzpool/mydataset@baseline': "cannot open 'myzpool/mydataset@baseline': dataset does not exist"}
+        ret = {'pid': 40993, 'retcode': 1, 'stderr': "cannot open 'myzpool/mydataset@baseline': dataset does not exist", 'stdout': 'no datasets available'}
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.holds('myzpool/mydataset@baseline'), res)
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(ZfsTestCase, needs_daemon=False)

--- a/tests/unit/modules/zfs_test.py
+++ b/tests/unit/modules/zfs_test.py
@@ -435,6 +435,39 @@ class ZfsTestCase(TestCase):
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertEqual(zfs.release('important', 'myzpool/mydataset@baseline'), res)
 
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_snapshot_success(self):
+        '''
+        Tests zfs snapshot success
+        '''
+        res = {'myzpool/mydataset@baseline': 'snapshotted'}
+        ret = {'pid': 69125, 'retcode': 0, 'stderr': '', 'stdout': ''}
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.snapshot('myzpool/mydataset@baseline'), res)
+
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_snapshot_failure(self):
+        '''
+        Tests zfs snapshot failure
+        '''
+        res = {'myzpool/mydataset@baseline': 'dataset already exists'}
+        ret = {'pid': 68526, 'retcode': 1, 'stderr': "cannot create snapshot 'myzpool/mydataset@baseline': dataset already exists", 'stdout': ''}
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.snapshot('myzpool/mydataset@baseline'), res)
+
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_snapshot_failure2(self):
+        '''
+        Tests zfs snapshot failure
+        '''
+        res = {'myzpool/mydataset@baseline': 'dataset does not exist'}
+        ret = {'pid': 69256, 'retcode': 2, 'stderr': "cannot open 'myzpool/mydataset': dataset does not exist\nusage:\n\tsnapshot [-r] [-o property=value] ... <filesystem|volume>@<snap> ...\n\nFor the property list, run: zfs set|get\n\nFor the delegated permission list, run: zfs allow|unallow", 'stdout': ''}
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.snapshot('myzpool/mydataset@baseline'), res)
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(ZfsTestCase, needs_daemon=False)

--- a/tests/unit/modules/zfs_test.py
+++ b/tests/unit/modules/zfs_test.py
@@ -336,6 +336,28 @@ class ZfsTestCase(TestCase):
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertEqual(zfs.clone('myzpool/mydataset@yesterday', 'myzpool/archive/yesterday'), res)
 
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_promote_success(self):
+        '''
+        Tests zfs promote success
+        '''
+        res = {'myzpool/yesterday': 'promoted'}
+        ret = {'pid': 69075, 'retcode': 0, 'stderr': '', 'stdout': ''}
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.promote('myzpool/yesterday'), res)
+
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_promote_failure(self):
+        '''
+        Tests zfs promote failure
+        '''
+        res = {'myzpool/yesterday': "cannot promote 'myzpool/yesterday': not a cloned filesystem"}
+        ret = {'pid': 69209, 'retcode': 1, 'stderr': "cannot promote 'myzpool/yesterday': not a cloned filesystem", 'stdout': ''}
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.promote('myzpool/yesterday'), res)
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(ZfsTestCase, needs_daemon=False)

--- a/tests/unit/modules/zfs_test.py
+++ b/tests/unit/modules/zfs_test.py
@@ -407,11 +407,33 @@ class ZfsTestCase(TestCase):
         '''
         Tests zfs hold failure
         '''
-        res = {'myzpool/mydataset@baseline': ' tag already exists on this dataset'}
+        res = {'myzpool/mydataset@baseline': 'tag already exists on this dataset'}
         ret = {'pid': 51006, 'retcode': 1, 'stderr': "cannot hold snapshot 'myzpool/mydataset@baseline': tag already exists on this dataset", 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertEqual(zfs.hold('important', 'myzpool/mydataset@baseline'), res)
+
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_release_success(self):
+        '''
+        Tests zfs release success
+        '''
+        res = {'myzpool/mydataset@baseline': 'released (tag=important)', 'myzpool/mydataset@release-1.0': 'released (tag=important)'}
+        ret = {'pid': 50876, 'retcode': 0, 'stderr': '', 'stdout': ''}
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.release('important', 'myzpool/mydataset@baseline', 'myzpool/mydataset@release-1.0'), res)
+
+    @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    def test_release_failure(self):
+        '''
+        Tests zfs release failure
+        '''
+        res = {'myzpool/mydataset@baseline': 'no such tag on this dataset'}
+        ret = {'pid': 51006, 'retcode': 1, 'stderr': "cannot release hold from snapshot 'myzpool/mydataset@baseline': no such tag on this dataset", 'stdout': ''}
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertEqual(zfs.release('important', 'myzpool/mydataset@baseline'), res)
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
Last part to close #28779

Pinging @nmadhok so he is aware of the chances.

I'm not sure what to do with the 'auto-generated' commands, the code doesn't seem to work on illumos or solaris. Once all the other commands are implemented there may not be any need to keep it?

``` bash
/opt/local/salt/bin/salt-call --local zfs.list test recursive=True
```

``` yaml
local:
    ----------
    test:
        ----------
        avail:
            79.9M
        mountpoint:
            /test
        refer:
            19K
        used:
            138K
    test/dataset1:
        ----------
        avail:
            79.9M
        mountpoint:
            /test/dataset1
        refer:
            19K
        used:
            19K
    test/dataset2:
        ----------
        avail:
            79.9M
        mountpoint:
            /test/dataset2
        refer:
            19K
        used:
            19K
```

``` bash
/opt/local/salt/bin/salt-call --local zfs.diff test/ds1@clean test/ds1 show_changetime=True
```

``` yaml
local:
    - 1450886500.730159657        M       /       /test/ds1/
    - 1450886500.730258359        +       F       /test/ds1/hello
```

``` bash
/opt/local/salt/bin/salt-call --local zfs.holds test/ds1@baseline
```

``` yaml
local:
    ----------
    test/ds1@baseline:
        ----------
        important  :
            Wed Dec 23 21:06 2015
        release-1.0:
            Wed Dec 23 21:08 2015
```

``` bash
/opt/local/salt/bin/salt-call --local zfs.get test depth=1 properties='compression,canmount' type=filesystem
```

``` yaml
local:
    ----------
    test:
        ----------
        canmount:
            ----------
            source:
                default
            value:
                on
        compression:
            ----------
            source:
                default
            value:
                off
    test/ds1:
        ----------
        canmount:
            ----------
            source:
                local
            value:
                noauto
        compression:
            ----------
            source:
                local
            value:
                lz4
    test/ds2:
        ----------
        canmount:
            ----------
            source:
                default
            value:
                on
        compression:
            ----------
            source:
                default
            value:
                off
```
