### PR TITLE
Added missing grains for MacOS

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1360,8 +1360,9 @@ def os_data():
         grains['osfinger'] = '{os}-{ver}'.format(
             os=grains['osfullname'],
             ver=grains['osrelease'].partition('.')[0])
-    elif grains.get('os') in ('FreeBSD', 'OpenBSD', 'NetBSD'):
+    elif grains.get('os') in ('FreeBSD', 'OpenBSD', 'NetBSD', 'MacOS'):
         grains['osmajorrelease'] = grains['osrelease'].split('.', 1)[0]
+        grains['osfullname'] = grains['os']
 
         grains['osfinger'] = '{os}-{ver}'.format(
             os=grains['os'],


### PR DESCRIPTION
Fixes #29552 

Added:
- osfinger
- osfullname

These grains are also missing for other BSD OS's
