### PR TITLE
Fix CLI Example for file.line inaccuracy

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1460,7 +1460,7 @@ def line(path, content, match=None, mode=None, location=None,
 
     .. code-block:: bash
 
-        salt '*' file.line /etc/nsswitch.conf "networks:\tfiles dns", after="hosts:.*?", mode='ensure'
+        salt '*' file.line /etc/nsswitch.conf "networks:\tfiles dns" after="hosts:.*?" mode='ensure'
     '''
     path = os.path.realpath(os.path.expanduser(path))
     if not os.path.exists(path):


### PR DESCRIPTION
the CLI Example for file.line contains commas which if actually used in cli causes parsing issues for python.
