### PR TITLE
Fix chef logfile default arg value

### DIFF
--- a/salt/modules/chef.py
+++ b/salt/modules/chef.py
@@ -124,7 +124,7 @@ def client(whyrun=False,
 
     '''
     if logfile is None:
-        logfile = _default_logfile('chef-client'),
+        logfile = _default_logfile('chef-client')
     args = ['chef-client',
             '--no-color',
             '--once',
@@ -193,7 +193,7 @@ def solo(whyrun=False,
         Enable whyrun mode when set to True
     '''
     if logfile is None:
-        logfile = _default_logfile('chef-solo'),
+        logfile = _default_logfile('chef-solo')
     args = ['chef-solo',
             '--no-color',
             '--logfile "{0}"'.format(logfile),


### PR DESCRIPTION
Removed trailing comma so that the default logfile arg is the intended string

```
>>> _default_logfile('chef-client'),
('/var/log/chef-client.log',)
>>> _default_logfile('chef-client')
'/var/log/chef-client.log'
>>>
```

Bug was introduced in https://github.com/saltstack/salt/commit/89b9cc6812e218610e5b1572f5c9a2230ac75a38
