### PR TITLE
Location from profiles not correctly set

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1187,7 +1187,7 @@ def block_device_mappings(vm_):
     )
 
 
-def _request_eip(interface, vm_=None):
+def _request_eip(interface, vm_):
     '''
     Request and return Elastic IP
     '''
@@ -1685,7 +1685,7 @@ def request_instance(vm_=None, call=None):
         eni_devices = []
         for interface in network_interfaces:
             log.debug('Create network interface: {0}'.format(interface))
-            _new_eni = _create_eni_if_necessary(interface)
+            _new_eni = _create_eni_if_necessary(interface, vm_)
             eni_devices.append(_new_eni)
         params.update(_param_from_config(spot_prefix + 'NetworkInterface',
                                          eni_devices))
@@ -1726,7 +1726,7 @@ def request_instance(vm_=None, call=None):
         }
         try:
             rd_data = aws.query(rd_params,
-                                location=get_location(),
+                                location=get_location(vm_),
                                 provider=get_provider(),
                                 opts=__opts__,
                                 sigver='4')


### PR DESCRIPTION
With the following profile, the location (which is different from the default location) is not correctly set:

```
b-debian-t2.micro-ec2-eu-west-1:
  provider: b-default-ec2
  location: eu-west-1
  image: ami-e31a6594
  size: t2.micro
  ssh_username: admin
  securitygroup:
    - default
    - cloudhero
```
