### PR TITLE
Adds thin provisioning support for new hard disks in VMware driver

### DIFF
--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -239,7 +239,8 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
         size
             Enter the size of disk in GB
         thin_provision
-            Set to True if you want the disk to be thin provisioned. Defaults to False.
+            Specifies whether the disk should be thin provisioned or not. Default is ``thin_provision: False``.
+            .. versionadded:: Boron
         controller
             Specify the SCSI controller label to which this disk should be attached.
             This should be specified only when creating both the specified SCSI

--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -238,6 +238,8 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
 
         size
             Enter the size of disk in GB
+        thin_provision
+            Set to True if you want the disk to be thin provisioned. Defaults to False.
         controller
             Specify the SCSI controller label to which this disk should be attached.
             This should be specified only when creating both the specified SCSI

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -230,7 +230,7 @@ def _edit_existing_hard_disk_helper(disk, size_kb):
     return disk_spec
 
 
-def _add_new_hard_disk_helper(disk_label, size_gb, unit_number, thin_provision=False, controller_key=1000):
+def _add_new_hard_disk_helper(disk_label, size_gb, unit_number, controller_key=1000, thin_provision=False):
     random_key = randint(-2099, -2000)
 
     size_kb = int(size_gb * 1024.0 * 1024.0)
@@ -651,8 +651,8 @@ def _manage_devices(devices, vm=None):
         for disk_label in disks_to_create:
             # create the disk
             size_gb = float(devices['disk'][disk_label]['size'])
-            thin_provision = bool(devices['disk'][disk_label]['thin_provision'])
-            disk_spec = _add_new_hard_disk_helper(disk_label, size_gb, unit_number, thin_provision)
+            thin_provision = bool(devices['disk'][disk_label]['thin_provision']) if 'thin_provision' in devices['disk'][disk_label] else False
+            disk_spec = _add_new_hard_disk_helper(disk_label, size_gb, unit_number, thin_provision=thin_provision)
 
             # when creating both SCSI controller and Hard disk at the same time we need the randomly
             # assigned (temporary) key of the newly created SCSI controller

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -230,7 +230,7 @@ def _edit_existing_hard_disk_helper(disk, size_kb):
     return disk_spec
 
 
-def _add_new_hard_disk_helper(disk_label, size_gb, unit_number, controller_key=1000):
+def _add_new_hard_disk_helper(disk_label, size_gb, unit_number, thin_provision=False, controller_key=1000):
     random_key = randint(-2099, -2000)
 
     size_kb = int(size_gb * 1024.0 * 1024.0)
@@ -245,7 +245,7 @@ def _add_new_hard_disk_helper(disk_label, size_gb, unit_number, controller_key=1
     disk_spec.device.deviceInfo.label = disk_label
     disk_spec.device.deviceInfo.summary = "{0} GB".format(size_gb)
     disk_spec.device.backing = vim.vm.device.VirtualDisk.FlatVer2BackingInfo()
-    disk_spec.device.backing.thinProvisioned = True
+    disk_spec.device.backing.thinProvisioned = thin_provision
     disk_spec.device.backing.diskMode = 'persistent'
     disk_spec.device.controllerKey = controller_key
     disk_spec.device.unitNumber = unit_number
@@ -651,7 +651,8 @@ def _manage_devices(devices, vm=None):
         for disk_label in disks_to_create:
             # create the disk
             size_gb = float(devices['disk'][disk_label]['size'])
-            disk_spec = _add_new_hard_disk_helper(disk_label, size_gb, unit_number)
+            thin_provision = bool(evices['disk'][disk_label]['thin_provision'])
+            disk_spec = _add_new_hard_disk_helper(disk_label, size_gb, unit_number, thin_provision)
 
             # when creating both SCSI controller and Hard disk at the same time we need the randomly
             # assigned (temporary) key of the newly created SCSI controller

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -245,6 +245,7 @@ def _add_new_hard_disk_helper(disk_label, size_gb, unit_number, controller_key=1
     disk_spec.device.deviceInfo.label = disk_label
     disk_spec.device.deviceInfo.summary = "{0} GB".format(size_gb)
     disk_spec.device.backing = vim.vm.device.VirtualDisk.FlatVer2BackingInfo()
+    disk_spec.device.backing.thinProvisioned = True
     disk_spec.device.backing.diskMode = 'persistent'
     disk_spec.device.controllerKey = controller_key
     disk_spec.device.unitNumber = unit_number

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -651,7 +651,7 @@ def _manage_devices(devices, vm=None):
         for disk_label in disks_to_create:
             # create the disk
             size_gb = float(devices['disk'][disk_label]['size'])
-            thin_provision = bool(evices['disk'][disk_label]['thin_provision'])
+            thin_provision = bool(devices['disk'][disk_label]['thin_provision'])
             disk_spec = _add_new_hard_disk_helper(disk_label, size_gb, unit_number, thin_provision)
 
             # when creating both SCSI controller and Hard disk at the same time we need the randomly


### PR DESCRIPTION
This pull request adds a configurable option 'thin_provision' to the VMware driver for Salt Cloud. I use this with a cloud profile like this:

```
myprofile:
  clonefrom: some-vm
  provider: my-cloud
  devices:
    disk:
      Hard disk 2:
        size: 50
        thin_provision: True
```

If the option is not specified it should default to False so behaviour for existing cloud maps should be the same. I'm not a regular contributor so please let me know if I need to change something :smiley_cat: 
