### PR TITLE
modules.omapi: __virtual__ return err msg.

### DIFF
--- a/salt/modules/omapi.py
+++ b/salt/modules/omapi.py
@@ -33,7 +33,8 @@ def __virtual__():
     '''
     if omapi_support:
         return 'omapi'
-    return False
+    return (False, 'The omapi execution module cannot be loaded: '
+            'the pypureomapi python library is not available.')
 
 
 def _conn():


### PR DESCRIPTION
Updated return message in virtual when pypureomapi python library is not available.
