### PR TITLE
locale module: don't escape the slash in \n

### DIFF
--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -276,7 +276,7 @@ def gen_locale(locale, **kwargs):
         __salt__['file.replace'](
             '/etc/locale.gen',
             r'^\s*#\s*{0}\s*$'.format(locale),
-            '{0}\\n'.format(locale),
+            '{0}\n'.format(locale),
             append_if_not_found=True
         )
     elif on_ubuntu:


### PR DESCRIPTION
This would cause the literal string "\n" to be appended to the locale file, after the name of the locale.

I'm not sure what the reason for double-escaping the newline in the first place is. Maybe it works if a locale is replaced, but not if it's appended?

Ref. https://github.com/saltstack/salt/commit/44d44ec5740b7ac443fc52b251660edd42d55be6 https://github.com/saltstack/salt/pull/25328 https://github.com/saltstack/salt/pull/25309
