### PR TITLE
Change how alternatives states check for installed

### DIFF
--- a/salt/modules/alternatives.py
+++ b/salt/modules/alternatives.py
@@ -80,6 +80,25 @@ def show_current(name):
     return False
 
 
+def check_exists(name, path):
+    '''
+    Check if the given path is an alternative for a name.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' alternatives.check_exists name path
+    '''
+    cmd = [_get_cmd(), '--list', name]
+    out = __salt__['cmd.run_all'](cmd, python_shell=False)
+
+    if out['retcode'] > 0 and out['stderr'] != '':
+        return False
+
+    return path in out['stdout'].splitlines()
+
+
 def check_installed(name, path):
     '''
     Check if the current highest-priority match for a given alternatives link

--- a/salt/states/alternatives.py
+++ b/salt/states/alternatives.py
@@ -62,7 +62,7 @@ def install(name, link, path, priority):
            'changes': {},
            'comment': ''}
 
-    isinstalled = __salt__['alternatives.check_installed'](name, path)
+    isinstalled = __salt__['alternatives.check_exists'](name, path)
     if not isinstalled:
         if __opts__['test']:
             ret['comment'] = (
@@ -103,7 +103,7 @@ def remove(name, path):
            'changes': {},
            'comment': ''}
 
-    isinstalled = __salt__['alternatives.check_installed'](name, path)
+    isinstalled = __salt__['alternatives.check_exists'](name, path)
     if isinstalled:
         if __opts__['test']:
             ret['comment'] = ('Alternative for {0} will be removed'

--- a/tests/unit/states/alternatives_test.py
+++ b/tests/unit/states/alternatives_test.py
@@ -52,7 +52,7 @@ class AlternativesTestCase(TestCase):
         mock = MagicMock(side_effect=[True, False, False])
         mock_bool = MagicMock(return_value=True)
         with patch.dict(alternatives.__salt__,
-                        {'alternatives.check_installed': mock,
+                        {'alternatives.check_exists': mock,
                          'alternatives.install': mock_bool}):
             comt = ('Alternatives for {0} is already set to {1}'
                     ).format(name, path)
@@ -96,7 +96,7 @@ class AlternativesTestCase(TestCase):
         mock_bool = MagicMock(return_value=True)
         mock_bol = MagicMock(side_effect=[False, True, True, False])
         with patch.dict(alternatives.__salt__,
-                        {'alternatives.check_installed': mock,
+                        {'alternatives.check_exists': mock,
                          'alternatives.show_current': mock_bol,
                          'alternatives.remove': mock_bool}):
             comt = ('Alternative for {0} will be removed'.format(name))


### PR DESCRIPTION
`salt.states.alternatives.installed` calls `salt.modules.alternatives.check_installed` to check if an alternative is already installed. However, this module function only returns `True` if the given alternative is the currently symlinked alternative.

If I have a system with both vim and vim-tiny installed, I want to have a `alternatives.installed` state for both of them - but I can't, because the `check_install` function assumes I want both of them to be the currently selected alternative.

I'm not 100% sure if this is a breaking change or a bugfix. I currently have a state that uses `alternatives.installed` and it reports a change every time I run the highstate. If this can be considered a bugfix, it should be backported to 2015.8.
