### PR TITLE
Pip module/state -- handle requirements chaining

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -194,7 +194,7 @@ def _get_env_activate(bin_env):
 
 def _find_req(link):
 
-    logger.info('_find_req -- link = {}'.format(str(link)))
+    logger.info('_find_req -- link = %s', str(link))
 
     with salt.utils.fopen(link) as fh_link:
         child_links = rex_pip_chain_read.findall(fh_link.read())
@@ -203,6 +203,7 @@ def _find_req(link):
     child_links = [os.path.join(base_path, d) for d in child_links]
 
     return child_links
+
 
 def _resolve_requirements_chain(requirements):
     '''
@@ -300,7 +301,7 @@ def _process_requirements(requirements, cmd, cwd, saltenv, user):
                     target_base = os.path.dirname(target_path)
 
                     if not os.path.exists(target_base):
-                        os.makedirs(target_base, mode=0755)
+                        os.makedirs(target_base, mode=0o755)
                         __salt__['file.chown'](target_base, user, None)
 
                     if not os.path.exists(target_path):

--- a/salt/states/virtualenv_mod.py
+++ b/salt/states/virtualenv_mod.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import
 # Import python libs
 import logging
 import os
-import re
 
 # Import salt libs
 import salt.version

--- a/salt/states/virtualenv_mod.py
+++ b/salt/states/virtualenv_mod.py
@@ -9,11 +9,13 @@ from __future__ import absolute_import
 # Import python libs
 import logging
 import os
+import re
 
 # Import salt libs
 import salt.version
 import salt.utils
 
+from salt.ext import six
 log = logging.getLogger(__name__)
 
 # Define the module's virtual name
@@ -216,6 +218,21 @@ def managed(name,
     # Populate the venv via a requirements file
     if requirements or pip_pkgs:
         before = set(__salt__['pip.freeze'](bin_env=name, user=user, use_vt=use_vt))
+
+        if requirements:
+
+            if isinstance(requirements, six.string_types):
+                req_canary = requirements.split(',')[0]
+            elif isinstance(requirements, list):
+                req_canary = requirements[0]
+            else:
+                raise TypeError(
+                    'pip requirements must be either a string or a list'
+                )
+
+            if req_canary != os.path.abspath(req_canary):
+                cwd = os.path.dirname(os.path.abspath(req_canary))
+
         _ret = __salt__['pip.install'](
             pkgs=pip_pkgs,
             requirements=requirements,

--- a/tests/integration/modules/pip.py
+++ b/tests/integration/modules/pip.py
@@ -42,8 +42,12 @@ class PipModuleTest(integration.ModuleCase):
         os.environ['PIP_SOURCE_DIR'] = os.environ['PIP_BUILD_DIR'] = ''
 
     def pip_successful_install(self, target, expect=('flake8', 'pep8',)):
+        '''
+        isolate regex for extracting `successful install` message from pip
+        '''
 
         expect = set(expect)
+        expect_str = '|'.join(expect)
 
         success = re.search(
             r'^.*Successfully installed\s([^\n]+)(?:Clean.*)?',
@@ -51,7 +55,7 @@ class PipModuleTest(integration.ModuleCase):
             re.M | re.S)
 
         success_for = re.findall(
-            r'(flake8|pep8)-[\d\.]',
+            r'({0})(?:-(?:[\d\.-]))?'.format(expect_str),
             success.groups()[0]
         ) if success else []
 

--- a/tests/integration/modules/pip.py
+++ b/tests/integration/modules/pip.py
@@ -62,7 +62,6 @@ class PipModuleTest(integration.ModuleCase):
                 ret
             )
 
-
     @skipIf(os.geteuid() != 0, 'you must be root to run this test')
     def test_requirements_as_list_of_chains___sans_no_chown__cwd_set__absolute_file_path(self):
         self.run_function('virtualenv.create', [self.venv_dir])
@@ -95,7 +94,7 @@ class PipModuleTest(integration.ModuleCase):
             success = re.search(
                 r'^.*Successfully installed\s(.*)',
                 ret['stdout'],
-                re.M
+                re.M | re.S
             )
 
             if success:
@@ -104,13 +103,12 @@ class PipModuleTest(integration.ModuleCase):
                     success.groups()[0]
                 )
 
-            found = set(['flake8', 'pep8']) == set(success_for)
+            found = set(['flake8', 'pep8']) in set(success_for)
             self.assertTrue(found)
         except (AssertionError, TypeError):
             import pprint
             pprint.pprint(ret)
             raise
-
 
     @skipIf(os.geteuid() != 0, 'you must be root to run this test')
     def test_requirements_as_list_of_chains___sans_no_chown__cwd_not_set__absolute_file_path(self):
@@ -144,7 +142,7 @@ class PipModuleTest(integration.ModuleCase):
             success = re.search(
                 r'^.*Successfully installed\s(.*)',
                 ret['stdout'],
-                re.M
+                re.M | re.S
             )
 
             if success:
@@ -187,7 +185,7 @@ class PipModuleTest(integration.ModuleCase):
             success = re.search(
                 r'^.*Successfully installed\s(.*)',
                 ret['stdout'],
-                re.M
+                re.M | re.S
             )
 
             if success:
@@ -235,7 +233,7 @@ class PipModuleTest(integration.ModuleCase):
             success = re.search(
                 r'^.*Successfully installed\s(.*)',
                 ret['stdout'],
-                re.M
+                re.M | re.S
             )
 
             if success:
@@ -251,7 +249,6 @@ class PipModuleTest(integration.ModuleCase):
             import pprint
             pprint.pprint(ret)
             raise
-
 
     @skipIf(os.geteuid() != 0, 'you must be root to run this test')
     def test_chained_requirements__sans_no_chown___absolute_file_path(self):
@@ -279,7 +276,6 @@ class PipModuleTest(integration.ModuleCase):
             import pprint
             pprint.pprint(ret)
             raise
-
 
     @skipIf(os.geteuid() != 0, 'you must be root to run this test')
     def test_chained_requirements__sans_no_chown___non_absolute_file_path(self):

--- a/tests/integration/modules/pip.py
+++ b/tests/integration/modules/pip.py
@@ -43,19 +43,19 @@ class PipModuleTest(integration.ModuleCase):
 
     def pip_successful_install(self, target, expect=('flake8', 'pep8',)):
 
-            expect = set(expect)
+        expect = set(expect)
 
-            success = re.search(
-                r'^.*Successfully installed\s([^\n]+)(?:Clean.*)?',
-                target,
-                re.M | re.S)
+        success = re.search(
+            r'^.*Successfully installed\s([^\n]+)(?:Clean.*)?',
+            target,
+            re.M | re.S)
 
-            success_for = re.findall(
-                r'(flake8|pep8)-[\d\.]',
-                success.groups()[0]
-            ) if success else []
+        success_for = re.findall(
+            r'(flake8|pep8)-[\d\.]',
+            success.groups()[0]
+        ) if success else []
 
-            return expect.issubset(set(success_for))
+        return expect.issubset(set(success_for))
 
     def test_issue_2087_missing_pip(self):
         # Let's create the testing virtualenv

--- a/tests/unit/modules/pip_test.py
+++ b/tests/unit/modules/pip_test.py
@@ -30,7 +30,6 @@ class PipTestCase(TestCase):
                 expected_cmd,
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -62,7 +61,6 @@ class PipTestCase(TestCase):
                 expected,
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -75,7 +73,6 @@ class PipTestCase(TestCase):
                 expected,
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -99,7 +96,6 @@ class PipTestCase(TestCase):
                 expected,
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -112,7 +108,6 @@ class PipTestCase(TestCase):
                 expected,
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -125,7 +120,6 @@ class PipTestCase(TestCase):
                 ['pip', 'install', pkgs[0], '--editable', editables[0]],
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -149,7 +143,6 @@ class PipTestCase(TestCase):
                 expected,
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -162,7 +155,6 @@ class PipTestCase(TestCase):
                 expected,
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -175,7 +167,6 @@ class PipTestCase(TestCase):
                 ['pip', 'install', '--use-mirrors', '--mirrors', mirrors[0]],
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -201,7 +192,6 @@ class PipTestCase(TestCase):
                 expected,
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -214,7 +204,6 @@ class PipTestCase(TestCase):
                 expected,
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -227,7 +216,6 @@ class PipTestCase(TestCase):
                 ['pip', 'install', '--find-links', find_links[0], pkg],
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -250,7 +238,6 @@ class PipTestCase(TestCase):
                 expected,
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -288,7 +275,6 @@ class PipTestCase(TestCase):
                 expected,
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -312,7 +298,6 @@ class PipTestCase(TestCase):
                 env={'VIRTUAL_ENV': '/test_env'},
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -328,7 +313,6 @@ class PipTestCase(TestCase):
                 ['pip', 'install', '--log', log_path, pkg],
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -359,7 +343,6 @@ class PipTestCase(TestCase):
                 expected_prefix + [10, pkg],
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -372,7 +355,6 @@ class PipTestCase(TestCase):
                 expected_prefix + ['10', pkg],
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -397,7 +379,6 @@ class PipTestCase(TestCase):
                 ['pip', 'install', '--index-url', index_url, pkg],
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -412,7 +393,6 @@ class PipTestCase(TestCase):
                 ['pip', 'install', '--extra-index-url', extra_index_url, pkg],
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -426,7 +406,6 @@ class PipTestCase(TestCase):
                 ['pip', 'install', '--no-index', pkg],
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -441,7 +420,6 @@ class PipTestCase(TestCase):
                 ['pip', 'install', '--build', build, pkg],
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -456,7 +434,6 @@ class PipTestCase(TestCase):
                 ['pip', 'install', '--target', target, pkg],
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -471,7 +448,6 @@ class PipTestCase(TestCase):
                 ['pip', 'install', '--download', download, pkg],
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -485,7 +461,6 @@ class PipTestCase(TestCase):
                 ['pip', 'install', '--no-download', pkg],
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -500,7 +475,6 @@ class PipTestCase(TestCase):
                 ['pip', 'install', '--download-cache', download_cache, pkg],
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -515,7 +489,6 @@ class PipTestCase(TestCase):
                 ['pip', 'install', '--source', source, pkg],
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -530,7 +503,6 @@ class PipTestCase(TestCase):
                     ['pip', 'install', '--exists-action', action, pkg],
                     saltenv='base',
                     runas=None,
-                    cwd=None,
                     use_vt=False,
                     python_shell=False,
                 )
@@ -565,7 +537,6 @@ class PipTestCase(TestCase):
                 expected,
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -578,7 +549,6 @@ class PipTestCase(TestCase):
                 expected,
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -592,7 +562,6 @@ class PipTestCase(TestCase):
                  install_options[0], pkg],
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -617,7 +586,6 @@ class PipTestCase(TestCase):
                 expected,
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -630,7 +598,6 @@ class PipTestCase(TestCase):
                 expected,
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -643,7 +610,6 @@ class PipTestCase(TestCase):
                 ['pip', 'install', '--global-option', global_options[0], pkg],
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -657,7 +623,6 @@ class PipTestCase(TestCase):
                 ['pip', 'install', '--upgrade', pkg],
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -671,7 +636,6 @@ class PipTestCase(TestCase):
                 ['pip', 'install', '--force-reinstall', pkg],
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -685,7 +649,6 @@ class PipTestCase(TestCase):
                 ['pip', 'install', '--ignore-installed', pkg],
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -699,7 +662,6 @@ class PipTestCase(TestCase):
                 ['pip', 'install', '--no-deps', pkg],
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -713,7 +675,6 @@ class PipTestCase(TestCase):
                 ['pip', 'install', '--no-install', pkg],
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -728,7 +689,6 @@ class PipTestCase(TestCase):
                 ['pip', 'install', '--proxy', proxy, pkg],
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -755,7 +715,6 @@ class PipTestCase(TestCase):
                 expected,
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -769,7 +728,6 @@ class PipTestCase(TestCase):
                 expected,
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -783,7 +741,6 @@ class PipTestCase(TestCase):
                 ['pip', 'install', '--requirement', cached_reqs[0]],
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -808,9 +765,9 @@ class PipTestCase(TestCase):
             pip.uninstall(requirements=requirements)
             mock.assert_called_once_with(
                 expected,
+                cwd=None,
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -822,9 +779,9 @@ class PipTestCase(TestCase):
             pip.uninstall(requirements=','.join(requirements))
             mock.assert_called_once_with(
                 expected,
+                cwd=None,
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -836,9 +793,9 @@ class PipTestCase(TestCase):
             pip.uninstall(requirements=requirements[0])
             mock.assert_called_once_with(
                 ['pip', 'uninstall', '-y', '--requirement', cached_reqs[0]],
+                cwd=None,
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -852,8 +809,8 @@ class PipTestCase(TestCase):
             mock.assert_called_once_with(
                 ['pip', 'uninstall', '-y', '--proxy', proxy, pkg],
                 saltenv='base',
-                runas=None,
                 cwd=None,
+                runas=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -868,8 +825,8 @@ class PipTestCase(TestCase):
             mock.assert_called_once_with(
                 ['pip', 'uninstall', '-y', '--log', log_path, pkg],
                 saltenv='base',
-                runas=None,
                 cwd=None,
+                runas=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -894,9 +851,9 @@ class PipTestCase(TestCase):
             pip.uninstall(pkg, timeout=10)
             mock.assert_called_once_with(
                 expected_prefix + [10, pkg],
+                cwd=None,
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -907,9 +864,9 @@ class PipTestCase(TestCase):
             pip.uninstall(pkg, timeout='10')
             mock.assert_called_once_with(
                 expected_prefix + ['10', pkg],
+                cwd=None,
                 saltenv='base',
                 runas=None,
-                cwd=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -942,8 +899,8 @@ class PipTestCase(TestCase):
             ret = pip.freeze()
             mock.assert_called_once_with(
                 ['pip', 'freeze'],
-                runas=None,
                 cwd=None,
+                runas=None,
                 use_vt=False,
                 python_shell=False,
             )
@@ -973,8 +930,8 @@ class PipTestCase(TestCase):
                 ret = pip.list_()
                 mock.assert_called_with(
                     ['pip', 'freeze'],
-                    runas=None,
                     cwd=None,
+                    runas=None,
                     python_shell=False,
                 )
                 self.assertEqual(
@@ -1016,8 +973,8 @@ class PipTestCase(TestCase):
             ret = pip.list_(prefix='bb')
             mock.assert_called_with(
                 ['pip', 'freeze'],
-                runas=None,
                 cwd=None,
+                runas=None,
                 python_shell=False,
             )
             self.assertEqual(
@@ -1043,7 +1000,6 @@ class PipTestCase(TestCase):
                     ['pip', 'install', pkg],
                     saltenv='base',
                     runas=None,
-                    cwd=None,
                     use_vt=False,
                     python_shell=False,
                 )
@@ -1059,7 +1015,6 @@ class PipTestCase(TestCase):
                     ['pip', 'install', '--pre', pkg],
                     saltenv='base',
                     runas=None,
-                    cwd=None,
                     use_vt=False,
                     python_shell=False,
                 )


### PR DESCRIPTION
With regards to #4648, #4805

Because #4832 and http://www.frankwiles.com/posts/saltstack-and-multiple-pip-requirements-files/

I love you guys, but the whole `no_chown` business makes me want to go sit around naked in a tree and fling poop at innocent passers-by.   

I figured this could be tackled in one of three ways:
- fix the docs 
- fix the error message
- fix the module function

I chose the box.

Let me know if you have questions/comments/etc.
