### PR TITLE
modules.netaddress: __virtual__ return err msg.

### DIFF
--- a/salt/modules/netaddress.py
+++ b/salt/modules/netaddress.py
@@ -23,7 +23,8 @@ def __virtual__():
     Only load if netaddr library exist.
     '''
     if not HAS_NETADDR:
-        return False
+        return (False, 'The netaddress execution module cannot be loaded: '
+                'netaddr python library is not installed.')
     return __virtualname__
 
 


### PR DESCRIPTION
Updated message when netaddr library is not installed.
