### PR TITLE
modules.openbsdservice: __virtual__ return err msg.

### DIFF
--- a/salt/modules/openbsdservice.py
+++ b/salt/modules/openbsdservice.py
@@ -39,7 +39,8 @@ def __virtual__():
         if krel[0] > 5 or (krel[0] == 5 and krel[1] > 0):
             if not os.path.exists('/usr/sbin/rcctl'):
                 return __virtualname__
-    return False
+    return (False, 'The openbsdservice execution module cannot be loaded: '
+            'only available on OpenBSD systems.')
 
 
 def start(name):


### PR DESCRIPTION
Updated message when system is not OpenBSD.
