### PR TITLE
modules.openbsdrcctl: __virtual__ return err msg.

### DIFF
--- a/salt/modules/openbsdrcctl.py
+++ b/salt/modules/openbsdrcctl.py
@@ -26,7 +26,8 @@ def __virtual__():
     '''
     if __grains__['os'] == 'OpenBSD' and os.path.exists('/usr/sbin/rcctl'):
         return __virtualname__
-    return False
+    return (False, 'The openbsdpkg execution module cannot be loaded: '
+            'only available on OpenBSD systems.')
 
 
 @decorators.memoize


### PR DESCRIPTION
Updated message when system is not OpenBSD.
