### PR TITLE
Support for AWS IoT

### DIFF
--- a/salt/modules/boto_iot.py
+++ b/salt/modules/boto_iot.py
@@ -686,4 +686,3 @@ def list_topic_rules(topic=None, ruleDisabled=None,
         return {'rules': rules}
     except ClientError as e:
         return {'error': salt.utils.boto3.get_error(e)}
-

--- a/salt/modules/boto_iot.py
+++ b/salt/modules/boto_iot.py
@@ -1,0 +1,689 @@
+# -*- coding: utf-8 -*-
+'''
+Connection module for Amazon IoT
+
+.. versionadded:: Boron
+
+:configuration: This module accepts explicit Lambda credentials but can also
+    utilize IAM roles assigned to the instance trough Instance Profiles.
+    Dynamic credentials are then automatically obtained from AWS API and no
+    further configuration is necessary. More Information available at:
+
+    .. code-block:: text
+
+        http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+
+    If IAM roles are not used you need to specify them either in a pillar or
+    in the minion's config file:
+
+    .. code-block:: yaml
+
+        iot.keyid: GKTADJGHEIQSXMKKRBJ08H
+        iot.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+    A region may also be specified in the configuration:
+
+    .. code-block:: yaml
+
+        iot.region: us-east-1
+
+    If a region is not specified, the default is us-east-1.
+
+    It's also possible to specify key, keyid and region via a profile, either
+    as a passed in dict, or as a string to pull from pillars or minion config:
+
+    .. code-block:: yaml
+
+        myprofile:
+            keyid: GKTADJGHEIQSXMKKRBJ08H
+            key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+            region: us-east-1
+
+:depends: boto3
+
+'''
+# keep lint from choking on _get_conn and _cache_id
+#pylint: disable=E0602
+
+# Import Python libs
+from __future__ import absolute_import
+import logging
+import json
+from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
+
+# Import Salt libs
+import salt.utils.boto3
+import salt.utils.compat
+import salt.utils
+from salt.ext.six import string_types
+
+log = logging.getLogger(__name__)
+
+# Import third party libs
+
+# pylint: disable=import-error
+try:
+    #pylint: disable=unused-import
+    import boto3
+    #pylint: enable=unused-import
+    from botocore.exceptions import ClientError
+    logging.getLogger('boto3').setLevel(logging.CRITICAL)
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+# pylint: enable=import-error
+
+
+def __virtual__():
+    '''
+    Only load if boto libraries exist and if boto libraries are greater than
+    a given version.
+    '''
+    required_boto3_version = '1.2.1'
+    # the boto_lambda execution module relies on the connect_to_region() method
+    # which was added in boto 2.8.0
+    # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
+    if not HAS_BOTO:
+        return False
+    elif _LooseVersion(boto3.__version__) < _LooseVersion(required_boto3_version):
+        return False
+    else:
+        return True
+
+
+def __init__(opts):
+    salt.utils.compat.pack_dunder(__name__)
+    if HAS_BOTO:
+        __utils__['boto3.assign_funcs'](__name__, 'iot')
+
+
+def policy_exists(policyName,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a policy name, check to see if the given policy exists.
+
+    Returns True if the given policy exists and returns False if the given
+    policy does not exist.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iot.policy_exists mypolicy
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        conn.get_policy(policyName=policyName)
+        return {'exists': True}
+    except ClientError as e:
+        err = salt.utils.boto3.get_error(e)
+        if e.response.get('Error', {}).get('Code') == 'ResourceNotFoundException':
+            return {'exists': False}
+        return {'error': err}
+
+
+def create_policy(policyName, policyDocument,
+            region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a valid config, create a policy.
+
+    Returns {created: true} if the policy was created and returns
+    {created: False} if the policy was not created.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iot.create_policy my_policy \\
+              '{"Version":"2015-12-12",\\
+              "Statement":[{"Effect":"Allow",\\
+                            "Action":["iot:Publish"],\\
+                            "Resource":["arn:::::topic/foo/bar"]}]}'
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not isinstance(policyDocument, string_types):
+            policyDocument = json.dumps(policyDocument)
+        policy = conn.create_policy(policyName=policyName,
+                                    policyDocument=policyDocument)
+        if policy:
+            log.info('The newly created policy version is {0}'.format(policy['policyVersionId']))
+
+            return {'created': True, 'versionId': policy['policyVersionId']}
+        else:
+            log.warning('Policy was not created')
+            return {'created': False}
+    except ClientError as e:
+        return {'created': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def delete_policy(policyName,
+            region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a policy name, delete it.
+
+    Returns {deleted: true} if the policy was deleted and returns
+    {deleted: false} if the policy was not deleted.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iot.delete_policy mypolicy
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        conn.delete_policy(policyName=policyName)
+        return {'deleted': True}
+    except ClientError as e:
+        return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def describe_policy(policyName,
+             region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a policy name describe its properties.
+
+    Returns a dictionary of interesting properties.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iot.describe_policy mypolicy
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        policy = conn.get_policy(policyName=policyName)
+        if policy:
+            keys = ('policyName', 'policyArn', 'policyDocument',
+                    'defaultVersionId')
+            return {'policy': dict([(k, policy.get(k)) for k in keys])}
+        else:
+            return {'policy': None}
+    except ClientError as e:
+        err = salt.utils.boto3.get_error(e)
+        if e.response.get('Error', {}).get('Code') == 'ResourceNotFoundException':
+            return {'policy': None}
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def policy_version_exists(policyName, policyVersionId,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a policy name and version ID, check to see if the given policy version exists.
+
+    Returns True if the given policy version exists and returns False if the given
+    policy version does not exist.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iot.policy_version_exists mypolicy versionid
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        policy = conn.get_policy_version(policyName=policyName,
+                                         policyversionId=policyVersionId)
+        return {'exists': bool(policy)}
+    except ClientError as e:
+        err = salt.utils.boto3.get_error(e)
+        if e.response.get('Error', {}).get('Code') == 'ResourceNotFoundException':
+            return {'exists': False}
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def create_policy_version(policyName, policyDocument, setAsDefault=False,
+            region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a valid config, create a new version of a policy.
+
+    Returns {created: true} if the policy version was created and returns
+    {created: False} if the policy version was not created.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iot.create_policy_version my_policy \\
+               '{"Statement":[{"Effect":"Allow","Action":["iot:Publish"],"Resource":["arn:::::topic/foo/bar"]}]}'
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not isinstance(policyDocument, string_types):
+            policyDocument = json.dumps(policyDocument)
+        policy = conn.create_policy_version(policyName=policyName,
+                                    policyDocument=policyDocument,
+                                    setAsDefault=setAsDefault)
+        if policy:
+            log.info('The newly created policy version is {0}'.format(policy['policyVersionId']))
+
+            return {'created': True, 'name': policy['policyVersionId']}
+        else:
+            log.warning('Policy version was not created')
+            return {'created': False}
+    except ClientError as e:
+        return {'created': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def delete_policy_version(policyName, policyVersionId,
+            region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a policy name and version, delete it.
+
+    Returns {deleted: true} if the policy version was deleted and returns
+    {deleted: false} if the policy version was not deleted.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iot.delete_policy_version mypolicy version
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        conn.delete_policy_version(policyName=policyName,
+                                   policyVersionId=policyVersionId)
+        return {'deleted': True}
+    except ClientError as e:
+        return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def describe_policy_version(policyName, policyVersionId,
+             region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a policy name and version describe its properties.
+
+    Returns a dictionary of interesting properties.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iot.describe_policy_version mypolicy version
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        policy = conn.get_policy_version(policyName=policyName,
+                                         policyVersionId=policyVersionId)
+        if policy:
+            keys = ('policyName', 'policyArn', 'policyDocument',
+                    'policyVersionId', 'isDefaultVersion')
+            return {'policy': dict([(k, policy.get(k)) for k in keys])}
+        else:
+            return {'policy': None}
+    except ClientError as e:
+        err = salt.utils.boto3.get_error(e)
+        if e.response.get('Error', {}).get('Code') == 'ResourceNotFoundException':
+            return {'policy': None}
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def list_policies(region=None, key=None, keyid=None, profile=None):
+    '''
+    List all policies
+
+    Returns list of policies
+
+    CLI Example:
+
+    .. code-block:: yaml
+
+        policies:
+          - {...}
+          - {...}
+
+    '''
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        policies = []
+        for ret in salt.utils.boto3.paged_call(conn.list_policies,
+                                 marker_flag='nextMarker',
+                                 marker_arg='marker'):
+            policies.extend(ret['policies'])
+        if not bool(policies):
+            log.warning('No policies found')
+        return {'policies': policies}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def list_policy_versions(policyName,
+            region=None, key=None, keyid=None, profile=None):
+    '''
+    List the versions available for the given policy.
+
+    CLI Example
+
+    .. code-block:: yaml
+
+        policyVersions:
+          - {...}
+          - {...}
+
+    '''
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        vers = []
+        for ret in salt.utils.boto3.paged_call(conn.list_policy_versions,
+                                 marker_flag='nextMarker',
+                                 marker_arg='marker',
+                                 policyName=policyName):
+            vers.extend(ret['policyVersions'])
+        if not bool(vers):
+            log.warning('No versions found')
+        return {'policyVersions': vers}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def set_default_policy_version(policyName, policyVersionId,
+            region=None, key=None, keyid=None, profile=None):
+    '''
+    Sets the specified version of the specified policy as the policy's default
+    (operative) version. This action affects all certificates that the policy is
+    attached to.
+
+    Returns {changed: true} if the policy version was set
+    {changed: False} if the policy version was not set.
+
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iot.set_default_policy_version mypolicy versionid
+
+    '''
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        conn.set_default_policy_version(policyName=policyName,
+                                 policyVersionId=str(policyVersionId))
+        return {'changed': True}
+    except ClientError as e:
+        return {'changed': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def list_principal_policies(principal,
+            region=None, key=None, keyid=None, profile=None):
+    '''
+    List the policies attached to the given principal.
+
+    CLI Example
+
+    .. code-block:: yaml
+
+        policies:
+          - {...}
+          - {...}
+
+    '''
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        vers = []
+        for ret in salt.utils.boto3.paged_call(conn.list_principal_policies,
+                                 principal=principal,
+                                 marker_flag='nextMarker',
+                                 marker_arg='marker'):
+            vers.extend(ret['policies'])
+        if not bool(vers):
+            log.warning('No policies found')
+        return {'policies': vers}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def attach_principal_policy(policyName, principal,
+            region=None, key=None, keyid=None, profile=None):
+    '''
+    Attach the specified policy to the specified principal (certificate or other
+    credential.)
+
+    Returns {attached: true} if the policy was attached
+    {attached: False} if the policy was not attached.
+
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iot.attach_principal_policy mypolicy mycognitoID
+
+    '''
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        conn.attach_principal_policy(policyName=policyName,
+                                 principal=principal)
+        return {'attached': True}
+    except ClientError as e:
+        return {'attached': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def detach_principal_policy(policyName, principal,
+            region=None, key=None, keyid=None, profile=None):
+    '''
+    Detach the specified policy from the specified principal (certificate or other
+    credential.)
+
+    Returns {detached: true} if the policy was detached
+    {detached: False} if the policy was not detached.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iot.detach_principal_policy mypolicy mycognitoID
+
+    '''
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        conn.detach_principal_policy(policyName=policyName,
+                                 principal=principal)
+        return {'detached': True}
+    except ClientError as e:
+        return {'detached': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def topic_rule_exists(ruleName,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a rule name, check to see if the given rule exists.
+
+    Returns True if the given rule exists and returns False if the given
+    rule does not exist.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iot.topic_rule_exists myrule
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        rule = conn.get_topic_rule(ruleName=ruleName)
+        return {'exists': True}
+    except ClientError as e:
+        # Nonexistent rules show up as unauthorized exceptions. It's unclear how
+        # to distinguish this from a real authorization exception. In practical
+        # use, it's more useful to assume lack of existence than to assume a
+        # genuine authorization problem; authorization problems should not be
+        # the common case.
+        err = salt.utils.boto3.get_error(e)
+        if e.response.get('Error', {}).get('Code') == 'UnauthorizedException':
+            return {'exists': False}
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def create_topic_rule(ruleName, sql, actions, description,
+            ruleDisabled=False,
+            region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a valid config, create a topic rule.
+
+    Returns {created: true} if the rule was created and returns
+    {created: False} if the rule was not created.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iot.create_topic_rule my_rule "SELECT * FROM 'some/thing'" \\
+            '[{"lambda":{"functionArn":"arn:::::something"}},{"sns":{\\
+            "targetArn":"arn:::::something","roleArn":"arn:::::something"}}]'
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        conn.create_topic_rule(ruleName=ruleName,
+                               topicRulePayload={
+                                      'sql': sql,
+                                      'description': description,
+                                      'actions': actions,
+                                      'ruleDisabled': ruleDisabled
+                               })
+        return {'created': True}
+    except ClientError as e:
+        return {'created': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def replace_topic_rule(ruleName, sql, actions, description,
+            ruleDisabled=False,
+            region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a valid config, replace a topic rule with the new values.
+
+    Returns {created: true} if the rule was created and returns
+    {created: False} if the rule was not created.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iot.replace_topic_rule my_rule 'SELECT * FROM some.thing' \\
+            '[{"lambda":{"functionArn":"arn:::::something"}},{"sns":{\\
+            "targetArn":"arn:::::something","roleArn":"arn:::::something"}}]'
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        conn.replace_topic_rule(ruleName=ruleName,
+                               topicRulePayload={
+                                      'sql': sql,
+                                      'description': description,
+                                      'actions': actions,
+                                      'ruleDisabled': ruleDisabled
+                               })
+        return {'replaced': True}
+    except ClientError as e:
+        return {'replaced': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def delete_topic_rule(ruleName,
+            region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a rule name, delete it.
+
+    Returns {deleted: true} if the rule was deleted and returns
+    {deleted: false} if the rule was not deleted.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iot.delete_rule myrule
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        conn.delete_topic_rule(ruleName=ruleName)
+        return {'deleted': True}
+    except ClientError as e:
+        return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def describe_topic_rule(ruleName,
+             region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a topic rule name describe its properties.
+
+    Returns a dictionary of interesting properties.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iot.describe_topic_rule myrule
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        rule = conn.get_topic_rule(ruleName=ruleName)
+        if rule and 'rule' in rule:
+            rule = rule['rule']
+            keys = ('ruleName', 'sql', 'description',
+                    'actions', 'ruleDisabled')
+            return {'rule': dict([(k, rule.get(k)) for k in keys])}
+        else:
+            return {'rule': None}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def list_topic_rules(topic=None, ruleDisabled=None,
+            region=None, key=None, keyid=None, profile=None):
+    '''
+    List all rules (for a given topic, if specified)
+
+    Returns list of rules
+
+    CLI Example:
+
+    .. code-block:: yaml
+
+        rules:
+          - {...}
+          - {...}
+
+    '''
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        kwargs = {}
+        if topic is not None:
+            kwargs['topic'] = topic
+        if ruleDisabled is not None:
+            kwargs['ruleDisabled'] = ruleDisabled
+        rules = []
+        for ret in salt.utils.boto3.paged_call(conn.list_topic_rules,
+                                 marker_flag='nextToken',
+                                 marker_arg='nextToken',
+                                 **kwargs):
+            rules.extend(ret['rules'])
+        if not bool(rules):
+            log.warning('No rules found')
+        return {'rules': rules}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+

--- a/salt/modules/boto_iot.py
+++ b/salt/modules/boto_iot.py
@@ -64,6 +64,7 @@ log = logging.getLogger(__name__)
 # pylint: disable=import-error
 try:
     #pylint: disable=unused-import
+    import boto
     import boto3
     #pylint: enable=unused-import
     from botocore.exceptions import ClientError

--- a/salt/states/boto_iot.py
+++ b/salt/states/boto_iot.py
@@ -157,7 +157,13 @@ def policy_present(name, policyName, policyDocument,
     _describe = __salt__['boto_iot.describe_policy'](policyName=policyName,
                                   region=region, key=key, keyid=keyid, profile=profile)['policy']
 
-    describeDict = json.loads(_describe['policyDocument'])
+    if isinstance(_describe['policyDocument'], string_types):
+        describeDict = json.loads(_describe['policyDocument'])
+    else:
+        describeDict = _describe['policyDocument']
+
+    if isinstance(policyDocument, string_types):
+        policyDocument = json.loads(policyDocument)
 
     r = salt.utils.compare_dicts(describeDict, policyDocument)
     if bool(r):
@@ -405,10 +411,10 @@ def policy_detached(name, policyName, principal,
             return ret
         ret['changes']['old'] = {'attached': True}
         ret['changes']['new'] = {'attached': False}
-        ret['comment'] = 'Policy {0} attached to {1}.'.format(policyName, principal)
+        ret['comment'] = 'Policy {0} detached from {1}.'.format(policyName, principal)
         return ret
 
-    ret['comment'] = os.linesep.join([ret['comment'], 'Policy {0} is attached.'.format(policyName)])
+    ret['comment'] = os.linesep.join([ret['comment'], 'Policy {0} is detached.'.format(policyName)])
     ret['changes'] = {}
 
     return ret

--- a/salt/states/boto_iot.py
+++ b/salt/states/boto_iot.py
@@ -1,0 +1,591 @@
+# -*- coding: utf-8 -*-
+'''
+Manage IoT Objects
+=================
+
+.. versionadded:: Boron
+
+Create and destroy IoT objects. Be aware that this interacts with Amazon's services,
+and so may incur charges.
+
+This module uses ``boto3``, which can be installed via package, or pip.
+
+This module accepts explicit vpc credentials but can also utilize
+IAM roles assigned to the instance through Instance Profiles. Dynamic
+credentials are then automatically obtained from AWS API and no further
+configuration is necessary. More information available `here
+<http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html>`_.
+
+If IAM roles are not used you need to specify them either in a pillar file or
+in the minion's config file:
+
+.. code-block:: yaml
+
+    vpc.keyid: GKTADJGHEIQSXMKKRBJ08H
+    vpc.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+It's also possible to specify ``key``, ``keyid`` and ``region`` via a profile,
+either passed in as a dict, or as a string to pull from pillars or minion
+config:
+
+.. code-block:: yaml
+
+    myprofile:
+        keyid: GKTADJGHEIQSXMKKRBJ08H
+        key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+            region: us-east-1
+
+.. code-block:: yaml
+
+    Ensure policy exists:
+        boto_iot.policy_present:
+            - policyName: mypolicy
+            - policyDocument:
+                Version: "2012-10-17"
+                Statement:
+                  Action:
+                    - iot:Publish
+                  Resource:
+                    - "*"
+                  Effect: "Allow"
+            - region: us-east-1
+            - keyid: GKTADJGHEIQSXMKKRBJ08H
+            - key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+    Ensure topic rule exists:
+        boto_iot.topic_rule_present:
+            - ruleName: myrule
+            - sql: "SELECT * FROM 'iot/test'"
+            - description: 'test rule'
+            - ruleDisabled: false
+            - actions:
+              - lambda:
+                  functionArn: "arn:aws:us-east-1:1234:function/functionname"
+            - region: us-east-1
+            - keyid: GKTADJGHEIQSXMKKRBJ08H
+            - key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+import logging
+import os
+import os.path
+import json
+
+# Import Salt Libs
+import salt.utils
+from salt.ext.six import string_types
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Only load if boto is available.
+    '''
+    return 'boto_iot' if 'boto_iot.policy_exists' in __salt__ else False
+
+
+def policy_present(name, policyName, policyDocument,
+            region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure policy exists.
+
+    name
+        The name of the state definition
+
+    policyName
+        Name of the policy.
+
+    policyDocument
+        The JSON document that describes the policy. The length of the
+        policyDocument must be a minimum length of 1, with a maximum length of
+        2048, excluding whitespace.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+    '''
+    ret = {'name': policyName,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    r = __salt__['boto_iot.policy_exists'](policyName=policyName,
+                              region=region, key=key, keyid=keyid, profile=profile)
+
+    if 'error' in r:
+        ret['result'] = False
+        ret['comment'] = 'Failed to create policy: {0}.'.format(r['error']['message'])
+        return ret
+
+    if not r.get('exists'):
+        if __opts__['test']:
+            ret['comment'] = 'Policy {0} is set to be created.'.format(policyName)
+            ret['result'] = None
+            return ret
+        r = __salt__['boto_iot.create_policy'](policyName=policyName,
+                                               policyDocument=policyDocument,
+                                               region=region, key=key,
+                                               keyid=keyid, profile=profile)
+        if not r.get('created'):
+            ret['result'] = False
+            ret['comment'] = 'Failed to create policy: {0}.'.format(r['error']['message'])
+            return ret
+        _describe = __salt__['boto_iot.describe_policy'](policyName,
+                                   region=region, key=key, keyid=keyid, profile=profile)
+        ret['changes']['old'] = {'policy': None}
+        ret['changes']['new'] = _describe
+        ret['comment'] = 'Policy {0} created.'.format(policyName)
+        return ret
+
+    ret['comment'] = os.linesep.join([ret['comment'], 'Policy {0} is present.'.format(policyName)])
+    ret['changes'] = {}
+    # policy exists, ensure config matches
+    _describe = __salt__['boto_iot.describe_policy'](policyName=policyName,
+                                  region=region, key=key, keyid=keyid, profile=profile)['policy']
+
+    describeDict = json.loads(_describe['policyDocument'])
+
+    r = salt.utils.compare_dicts(describeDict, policyDocument)
+    if bool(r):
+        if __opts__['test']:
+            msg = 'Policy {0} set to be modified.'.format(policyName)
+            ret['comment'] = msg
+            ret['result'] = None
+            return ret
+
+        ret['comment'] = os.linesep.join([ret['comment'], 'Policy to be modified'])
+        policyDocument = json.dumps(policyDocument)
+
+        r = __salt__['boto_iot.create_policy_version'](policyName=policyName,
+                                               policyDocument=policyDocument,
+                                               setAsDefault=True,
+                                               region=region, key=key,
+                                               keyid=keyid, profile=profile)
+        if not r.get('created'):
+            ret['result'] = False
+            ret['comment'] = 'Failed to update policy: {0}.'.format(r['error']['message'])
+            ret['changes'] = {}
+            return ret
+
+        __salt__['boto_iot.delete_policy_version'](policyName=policyName,
+                                               policyVersionId=_describe['defaultVersionId'],
+                                               region=region, key=key,
+                                               keyid=keyid, profile=profile)
+
+        ret['changes'].setdefault('new', {})['policyDocument'] = policyDocument
+        ret['changes'].setdefault('old', {})['policyDocument'] = _describe['policyDocument']
+    return ret
+
+
+def policy_absent(name, policyName,
+                  region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure policy with passed properties is absent.
+
+    name
+        The name of the state definition.
+
+    policyName
+        Name of the policy.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+    '''
+
+    ret = {'name': policyName,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    r = __salt__['boto_iot.policy_exists'](policyName,
+                       region=region, key=key, keyid=keyid, profile=profile)
+    if 'error' in r:
+        ret['result'] = False
+        ret['comment'] = 'Failed to delete policy: {0}.'.format(r['error']['message'])
+        return ret
+
+    if r and not r['exists']:
+        ret['comment'] = 'Policy {0} does not exist.'.format(policyName)
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'Policy {0} is set to be removed.'.format(policyName)
+        ret['result'] = None
+        return ret
+    # delete non-default versions
+    versions = __salt__['boto_iot.list_policy_versions'](policyName,
+                                    region=region, key=key,
+                                    keyid=keyid, profile=profile)
+    if versions:
+        for version in versions.get('policyVersions', []):
+            if version.get('isDefaultVersion', False):
+                continue
+            r = __salt__['boto_iot.delete_policy_version'](policyName,
+                                    policyVersionId=version.get('versionId'),
+                                    region=region, key=key,
+                                    keyid=keyid, profile=profile)
+            if not r['deleted']:
+                ret['result'] = False
+                ret['comment'] = 'Failed to delete policy: {0}.'.format(r['error']['message'])
+                return ret
+    # For the delete to succeed, the policy must be detached from any
+    # principals. However, no API is provided to list the principals to which it
+    # is attached. (A policy may be attached to a principal not associated with
+    # any Thing.) So it is up to the user to ensure that it is properly
+    # detached.
+
+    # delete policy
+    r = __salt__['boto_iot.delete_policy'](policyName,
+                                    region=region, key=key,
+                                    keyid=keyid, profile=profile)
+    if not r['deleted']:
+        ret['result'] = False
+        ret['comment'] = 'Failed to delete policy: {0}.'.format(r['error']['message'])
+        return ret
+    ret['changes']['old'] = {'policy': policyName}
+    ret['changes']['new'] = {'policy': None}
+    ret['comment'] = 'Policy {0} deleted.'.format(policyName)
+    return ret
+
+
+def policy_attached(name, policyName, principal,
+            region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure policy is attached to the given principal.
+
+    name
+        The name of the state definition
+
+    policyName
+        Name of the policy.
+
+    principal
+        The principal which can be a certificate ARN or a Cognito ID.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+    '''
+    ret = {'name': policyName,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    r = __salt__['boto_iot.list_principal_policies'](principal=principal,
+                              region=region, key=key, keyid=keyid, profile=profile)
+
+    if 'error' in r:
+        ret['result'] = False
+        ret['comment'] = 'Failed to attach policy: {0}.'.format(r['error']['message'])
+        return ret
+
+    attached = False
+    for policy in r.get('policies', []):
+        if policy.get('policyName') == policyName:
+            attached = True
+            break
+    if not attached:
+        if __opts__['test']:
+            ret['comment'] = 'Policy {0} is set to be attached to {1}.'.format(policyName, principal)
+            ret['result'] = None
+            return ret
+        r = __salt__['boto_iot.attach_principal_policy'](policyName=policyName,
+                                               principal=principal,
+                                               region=region, key=key,
+                                               keyid=keyid, profile=profile)
+        if not r.get('attached'):
+            ret['result'] = False
+            ret['comment'] = 'Failed to attach policy: {0}.'.format(r['error']['message'])
+            return ret
+        ret['changes']['old'] = {'attached': False}
+        ret['changes']['new'] = {'attached': True}
+        ret['comment'] = 'Policy {0} attached to {1}.'.format(policyName, principal)
+        return ret
+
+    ret['comment'] = os.linesep.join([ret['comment'], 'Policy {0} is attached.'.format(policyName)])
+    ret['changes'] = {}
+
+    return ret
+
+
+def policy_detached(name, policyName, principal,
+                  region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure policy is attached to the given principal.
+
+    name
+        The name of the state definition.
+
+    policyName
+        Name of the policy.
+
+    principal
+        The principal which can be a certificate ARN or a Cognito ID.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+    '''
+
+    ret = {'name': policyName,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    r = __salt__['boto_iot.list_principal_policies'](principal=principal,
+                              region=region, key=key, keyid=keyid, profile=profile)
+
+    if 'error' in r:
+        ret['result'] = False
+        ret['comment'] = 'Failed to detached policy: {0}.'.format(r['error']['message'])
+        return ret
+
+    attached = False
+    for policy in r.get('policies', []):
+        if policy.get('policyName') == policyName:
+            attached = True
+            break
+    if attached:
+        if __opts__['test']:
+            ret['comment'] = 'Policy {0} is set to be detached from {1}.'.format(policyName, principal)
+            ret['result'] = None
+            return ret
+        r = __salt__['boto_iot.detach_principal_policy'](policyName=policyName,
+                                               principal=principal,
+                                               region=region, key=key,
+                                               keyid=keyid, profile=profile)
+        if not r.get('detached'):
+            ret['result'] = False
+            ret['comment'] = 'Failed to detach policy: {0}.'.format(r['error']['message'])
+            return ret
+        ret['changes']['old'] = {'attached': True}
+        ret['changes']['new'] = {'attached': False}
+        ret['comment'] = 'Policy {0} attached to {1}.'.format(policyName, principal)
+        return ret
+
+    ret['comment'] = os.linesep.join([ret['comment'], 'Policy {0} is attached.'.format(policyName)])
+    ret['changes'] = {}
+
+    return ret
+
+
+def topic_rule_present(name, ruleName, sql, actions, description='',
+            ruleDisabled=False,
+            region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure topic rule exists.
+
+    name
+        The name of the state definition
+
+    ruleName
+        Name of the rule.
+
+    sql
+        The SQL statement used to query the topic.
+
+    actions
+        The actions associated with the rule.
+
+    description
+        The description of the rule.
+
+    ruleDisable
+        Specifies whether the rule is disabled.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+    '''
+    ret = {'name': ruleName,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    r = __salt__['boto_iot.topic_rule_exists'](ruleName=ruleName,
+                              region=region, key=key, keyid=keyid, profile=profile)
+
+    if 'error' in r:
+        ret['result'] = False
+        ret['comment'] = 'Failed to create rule: {0}.'.format(r['error']['message'])
+        return ret
+
+    if not r.get('exists'):
+        if __opts__['test']:
+            ret['comment'] = 'Rule {0} is set to be created.'.format(ruleName)
+            ret['result'] = None
+            return ret
+        r = __salt__['boto_iot.create_topic_rule'](ruleName=ruleName,
+                                               sql=sql,
+                                               actions=actions,
+                                               description=description,
+                                               ruleDisabled=ruleDisabled,
+                                               region=region, key=key,
+                                               keyid=keyid, profile=profile)
+        if not r.get('created'):
+            ret['result'] = False
+            ret['comment'] = 'Failed to create rule: {0}.'.format(r['error']['message'])
+            return ret
+        _describe = __salt__['boto_iot.describe_topic_rule'](ruleName,
+                                   region=region, key=key, keyid=keyid, profile=profile)
+        ret['changes']['old'] = {'rule': None}
+        ret['changes']['new'] = _describe
+        ret['comment'] = 'Rule {0} created.'.format(ruleName)
+        return ret
+
+    ret['comment'] = os.linesep.join([ret['comment'], 'Rule {0} is present.'.format(ruleName)])
+    ret['changes'] = {}
+    # policy exists, ensure config matches
+    _describe = __salt__['boto_iot.describe_topic_rule'](ruleName=ruleName,
+                                  region=region, key=key, keyid=keyid, profile=profile)['rule']
+
+    if isinstance(actions, string_types):
+        actions = json.loads(actions)
+
+    need_update = False
+    r = cmp(_describe['actions'], actions)
+    if bool(r):
+        need_update = True
+        ret['changes'].setdefault('new', {})['actions'] = actions
+        ret['changes'].setdefault('old', {})['actions'] = _describe['actions']
+
+    for var in ('sql', 'description', 'ruleDisabled'):
+        if _describe[var] != locals()[var]:
+            need_update = True
+            ret['changes'].setdefault('new', {})[var] = locals()[var]
+            ret['changes'].setdefault('old', {})[var] = _describe[var]
+    if need_update:
+        if __opts__['test']:
+            msg = 'Rule {0} set to be modified.'.format(ruleName)
+            ret['changes'] = None
+            ret['comment'] = msg
+            ret['result'] = None
+            return ret
+        ret['comment'] = os.linesep.join([ret['comment'], 'Rule to be modified'])
+        r = __salt__['boto_iot.replace_topic_rule'](ruleName=ruleName,
+                                               sql=sql,
+                                               actions=actions,
+                                               description=description,
+                                               ruleDisabled=ruleDisabled,
+                                               region=region, key=key,
+                                               keyid=keyid, profile=profile)
+        if not r.get('replaced'):
+            ret['result'] = False
+            ret['comment'] = 'Failed to update rule: {0}.'.format(r['error']['message'])
+            ret['changes'] = {}
+    return ret
+
+
+def topic_rule_absent(name, ruleName,
+                  region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure topic rule with passed properties is absent.
+
+    name
+        The name of the state definition.
+
+    ruleName
+        Name of the policy.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+    '''
+
+    ret = {'name': ruleName,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    r = __salt__['boto_iot.topic_rule_exists'](ruleName,
+                       region=region, key=key, keyid=keyid, profile=profile)
+    if 'error' in r:
+        ret['result'] = False
+        ret['comment'] = 'Failed to delete rule: {0}.'.format(r['error']['message'])
+        return ret
+
+    if r and not r['exists']:
+        ret['comment'] = 'Rule {0} does not exist.'.format(ruleName)
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'Rule {0} is set to be removed.'.format(ruleName)
+        ret['result'] = None
+        return ret
+    r = __salt__['boto_iot.delete_topic_rule'](ruleName,
+                                    region=region, key=key,
+                                    keyid=keyid, profile=profile)
+    if not r['deleted']:
+        ret['result'] = False
+        ret['comment'] = 'Failed to delete rule: {0}.'.format(r['error']['message'])
+        return ret
+    ret['changes']['old'] = {'rule': ruleName}
+    ret['changes']['new'] = {'rule': None}
+    ret['comment'] = 'Rule {0} deleted.'.format(ruleName)
+    return ret
+

--- a/salt/states/boto_iot.py
+++ b/salt/states/boto_iot.py
@@ -594,4 +594,3 @@ def topic_rule_absent(name, ruleName,
     ret['changes']['new'] = {'rule': None}
     ret['comment'] = 'Rule {0} deleted.'.format(ruleName)
     return ret
-

--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -466,7 +466,7 @@ def alias_present(name, FunctionName, Name, FunctionVersion, Description='',
                                         keyid=keyid, profile=profile)
         if not _r.get('updated'):
             ret['result'] = False
-            ret['comment'] = 'Failed to update mapping: {0}.'.format(_r['error']['message'])
+            ret['comment'] = 'Failed to update alias: {0}.'.format(_r['error']['message'])
             ret['changes'] = {}
     return ret
 
@@ -638,7 +638,6 @@ def event_source_mapping_present(name, EventSourceArn, FunctionName, StartingPos
                                  EventSourceArn=EventSourceArn,
                                  FunctionName=FunctionName,
                                  region=region, key=key, keyid=keyid, profile=profile)['event_source_mapping']
-    log.warn(_describe)
 
     need_update = False
     for val, var in {

--- a/salt/utils/boto3.py
+++ b/salt/utils/boto3.py
@@ -298,3 +298,14 @@ def paged_call(function, marker_flag='NextMarker', marker_arg='Marker', *args, *
         if not marker:
             break
         kwargs[marker_arg] = marker
+
+
+def get_role_arn(name, region=None, key=None, keyid=None, profile=None):
+    if name.startswith('arn:aws:iam:'):
+        return name
+
+    account_id = __salt__['boto_iam.get_account_id'](
+        region=region, key=key, keyid=keyid, profile=profile
+    )
+    return 'arn:aws:iam::{0}:role/{1}'.format(account_id, name)
+

--- a/salt/utils/boto3.py
+++ b/salt/utils/boto3.py
@@ -308,4 +308,3 @@ def get_role_arn(name, region=None, key=None, keyid=None, profile=None):
         region=region, key=key, keyid=keyid, profile=profile
     )
     return 'arn:aws:iam::{0}:role/{1}'.format(account_id, name)
-

--- a/tests/unit/modules/boto_iot_test.py
+++ b/tests/unit/modules/boto_iot_test.py
@@ -44,13 +44,13 @@ conn_parameters = {'region': region, 'key': access_key, 'keyid': secret_key, 'pr
 error_message = 'An error occurred (101) when calling the {0} operation: Test-defined error'
 not_found_error = ClientError({
     'Error': {
-        'Code':'ResourceNotFoundException', 
+        'Code': 'ResourceNotFoundException',
         'Message': "Test-defined error"
     }
 }, 'msg')
 topic_rule_not_found_error = ClientError({
     'Error': {
-        'Code':'UnauthorizedException', 
+        'Code': 'UnauthorizedException',
         'Message': "Test-defined error"
     }
 }, 'msg')
@@ -69,7 +69,7 @@ topic_rule_ret = dict(ruleName='testrule',
                   sql="SELECT * FROM 'iot/test'",
                   description='topic rule description',
                   createdAt='1970-01-01',
-                  actions=[{'lambda':{'functionArn':'arn:aws:::function'}}], 
+                  actions=[{'lambda': {'functionArn': 'arn:aws:::function'}}],
                   ruleDisabled=True)
 
 log = logging.getLogger(__name__)

--- a/tests/unit/modules/boto_iot_test.py
+++ b/tests/unit/modules/boto_iot_test.py
@@ -22,7 +22,7 @@ import logging
 # Import Mock libraries
 from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
 
-# pylint: disable=import-error,no-name-in-module
+# pylint: disable=import-error,no-name-in-module,unused-import
 try:
     import boto
     import boto3
@@ -31,7 +31,7 @@ try:
 except ImportError:
     HAS_BOTO = False
 
-# pylint: enable=import-error,no-name-in-module
+# pylint: enable=import-error,no-name-in-module,unused-import
 
 # the boto_iot module relies on the connect_to_region() method
 # which was added in boto 2.8.0

--- a/tests/unit/modules/boto_iot_test.py
+++ b/tests/unit/modules/boto_iot_test.py
@@ -15,12 +15,9 @@ ensure_in_syspath('../../')
 import salt.config
 import salt.loader
 from salt.modules import boto_iot
-from salt.exceptions import SaltInvocationError
 
 # Import 3rd-party libs
-from tempfile import NamedTemporaryFile
 import logging
-import os
 
 # Import Mock libraries
 from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
@@ -47,16 +44,16 @@ conn_parameters = {'region': region, 'key': access_key, 'keyid': secret_key, 'pr
 error_message = 'An error occurred (101) when calling the {0} operation: Test-defined error'
 not_found_error = ClientError({
     'Error': {
-        'Code':'ResourceNotFoundException',
+        'Code':'ResourceNotFoundException', 
         'Message': "Test-defined error"
     }
-},'msg')
+}, 'msg')
 topic_rule_not_found_error = ClientError({
     'Error': {
-        'Code':'UnauthorizedException',
+        'Code':'UnauthorizedException', 
         'Message': "Test-defined error"
     }
-},'msg')
+}, 'msg')
 error_content = {
   'Error': {
     'Code': 101,
@@ -72,7 +69,7 @@ topic_rule_ret = dict(ruleName='testrule',
                   sql="SELECT * FROM 'iot/test'",
                   description='topic rule description',
                   createdAt='1970-01-01',
-                  actions=[{'lambda':{'functionArn':'arn:aws:::function'}}],
+                  actions=[{'lambda':{'functionArn':'arn:aws:::function'}}], 
                   ruleDisabled=True)
 
 log = logging.getLogger(__name__)
@@ -175,7 +172,7 @@ class BotoIoTPolicyTestCase(BotoIoTTestCaseBase, BotoIoTTestCaseMixin):
         result = boto_iot.create_policy(policyName=policy_ret['policyName'],
                                         policyDocument=policy_ret['policyDocument'],
                                         **conn_parameters)
-        self.assertEqual(result.get('error', {}).get('message'), error_message.format('create_policy')) 
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('create_policy'))
 
     def test_that_when_deleting_a_policy_succeeds_the_delete_policy_method_returns_true(self):
         '''
@@ -227,7 +224,7 @@ class BotoIoTPolicyTestCase(BotoIoTTestCaseBase, BotoIoTTestCaseMixin):
         Tests checking iot policy existence when the iot policy version already exists
         '''
         self.conn.get_policy.return_value = {'policy': policy_ret}
-        result = boto_iot.policy_version_exists(policyName=policy_ret['policyName'], 
+        result = boto_iot.policy_version_exists(policyName=policy_ret['policyName'],
                                                 policyVersionId=1,
                                                 **conn_parameters)
 
@@ -238,7 +235,7 @@ class BotoIoTPolicyTestCase(BotoIoTTestCaseBase, BotoIoTTestCaseMixin):
         Tests checking iot policy_version existence when the iot policy_version does not exist
         '''
         self.conn.get_policy_version.side_effect = not_found_error
-        result = boto_iot.policy_version_exists(policyName=policy_ret['policyName'], 
+        result = boto_iot.policy_version_exists(policyName=policy_ret['policyName'],
                                                 policyVersionId=1,
                                                 **conn_parameters)
 
@@ -249,7 +246,7 @@ class BotoIoTPolicyTestCase(BotoIoTTestCaseBase, BotoIoTTestCaseMixin):
         Tests checking iot policy_version existence when boto returns an error
         '''
         self.conn.get_policy_version.side_effect = ClientError(error_content, 'get_policy_version')
-        result = boto_iot.policy_version_exists(policyName=policy_ret['policyName'], 
+        result = boto_iot.policy_version_exists(policyName=policy_ret['policyName'],
                                                 policyVersionId=1,
                                                 **conn_parameters)
 
@@ -274,7 +271,7 @@ class BotoIoTPolicyTestCase(BotoIoTTestCaseBase, BotoIoTTestCaseMixin):
         result = boto_iot.create_policy_version(policyName=policy_ret['policyName'],
                                         policyDocument=policy_ret['policyDocument'],
                                         **conn_parameters)
-        self.assertEqual(result.get('error', {}).get('message'), error_message.format('create_policy_version')) 
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('create_policy_version'))
 
     def test_that_when_deleting_a_policy_version_succeeds_the_delete_policy_version_method_returns_true(self):
         '''
@@ -302,7 +299,7 @@ class BotoIoTPolicyTestCase(BotoIoTTestCaseBase, BotoIoTTestCaseMixin):
         '''
         self.conn.get_policy_version.return_value = {'policy': policy_ret}
 
-        result = boto_iot.describe_policy_version(policyName=policy_ret['policyName'], 
+        result = boto_iot.describe_policy_version(policyName=policy_ret['policyName'],
                                         policyVersionId=1,
                                         **conn_parameters)
 
@@ -313,7 +310,7 @@ class BotoIoTPolicyTestCase(BotoIoTTestCaseBase, BotoIoTTestCaseMixin):
         Tests describing parameters if policy_version does not exist
         '''
         self.conn.get_policy_version.side_effect = not_found_error
-        result = boto_iot.describe_policy_version(policyName=policy_ret['policyName'], 
+        result = boto_iot.describe_policy_version(policyName=policy_ret['policyName'],
                                         policyVersionId=1,
                                         **conn_parameters)
 
@@ -324,7 +321,7 @@ class BotoIoTPolicyTestCase(BotoIoTTestCaseBase, BotoIoTTestCaseMixin):
         Tests describing parameters failure
         '''
         self.conn.get_policy_version.side_effect = ClientError(error_content, 'get_policy_version')
-        result = boto_iot.describe_policy_version(policyName=policy_ret['policyName'], 
+        result = boto_iot.describe_policy_version(policyName=policy_ret['policyName'],
                                         policyVersionId=1,
                                         **conn_parameters)
         self.assertTrue('error' in result)
@@ -401,7 +398,7 @@ class BotoIoTPolicyTestCase(BotoIoTTestCaseBase, BotoIoTTestCaseMixin):
         result = boto_iot.set_default_policy_version(policyName='testpolicy',
                                                policyVersionId=1,
                                                **conn_parameters)
-        self.assertEqual(result.get('error', {}).get('message'), 
+        self.assertEqual(result.get('error', {}).get('message'),
                          error_message.format('set_default_policy_version'))
 
     def test_that_when_list_principal_policies_succeeds_the_list_principal_policies_method_returns_true(self):
@@ -414,7 +411,7 @@ class BotoIoTPolicyTestCase(BotoIoTTestCaseBase, BotoIoTTestCaseMixin):
 
         self.assertTrue(result['policies'])
 
-    def test_that_when_set_default_policy_version_fails_the_set_default_policy_version_method_returns_error(self):
+    def test_that_when_list_principal_policies_fails_the_list_principal_policies_method_returns_error(self):
         '''
         tests False policy version error.
         '''
@@ -422,7 +419,7 @@ class BotoIoTPolicyTestCase(BotoIoTTestCaseBase, BotoIoTTestCaseMixin):
                                 ClientError(error_content, 'list_principal_policies')
         result = boto_iot.list_principal_policies(principal='us-east-1:GUID-GUID-GUID',
                                                **conn_parameters)
-        self.assertEqual(result.get('error', {}).get('message'), 
+        self.assertEqual(result.get('error', {}).get('message'),
                          error_message.format('list_principal_policies'))
 
     def test_that_when_attach_principal_policy_succeeds_the_attach_principal_policy_method_returns_true(self):
@@ -444,7 +441,7 @@ class BotoIoTPolicyTestCase(BotoIoTTestCaseBase, BotoIoTTestCaseMixin):
         result = boto_iot.attach_principal_policy(policyName='testpolicy',
                                                principal='us-east-1:GUID-GUID-GUID',
                                                **conn_parameters)
-        self.assertEqual(result.get('error', {}).get('message'), 
+        self.assertEqual(result.get('error', {}).get('message'),
                          error_message.format('attach_principal_policy'))
 
     def test_that_when_detach_principal_policy_succeeds_the_detach_principal_policy_method_returns_true(self):
@@ -466,7 +463,7 @@ class BotoIoTPolicyTestCase(BotoIoTTestCaseBase, BotoIoTTestCaseMixin):
         result = boto_iot.detach_principal_policy(policyName='testpolicy',
                                                principal='us-east-1:GUID-GUID-GUID',
                                                **conn_parameters)
-        self.assertEqual(result.get('error', {}).get('message'), 
+        self.assertEqual(result.get('error', {}).get('message'),
                          error_message.format('detach_principal_policy'))
 
 
@@ -485,7 +482,7 @@ class BotoIoTTopicRuleTestCase(BotoIoTTestCaseBase, BotoIoTTestCaseMixin):
         Tests checking iot topic_rule existence when the iot topic_rule already exists
         '''
         self.conn.get_topic_rule.return_value = {'rule': topic_rule_ret}
-        result = boto_iot.topic_rule_exists(ruleName=topic_rule_ret['ruleName'], 
+        result = boto_iot.topic_rule_exists(ruleName=topic_rule_ret['ruleName'],
                                             **conn_parameters)
 
         self.assertTrue(result['exists'])
@@ -506,7 +503,7 @@ class BotoIoTTopicRuleTestCase(BotoIoTTestCaseBase, BotoIoTTestCaseMixin):
         self.conn.get_topic_rule.side_effect = ClientError(error_content, 'get_topic_rule')
         result = boto_iot.topic_rule_exists(ruleName='myrule', **conn_parameters)
 
-        self.assertEqual(result.get('error', {}).get('message'), 
+        self.assertEqual(result.get('error', {}).get('message'),
                                       error_message.format('get_topic_rule'))
 
     def test_that_when_creating_a_topic_rule_succeeds_the_create_topic_rule_method_returns_true(self):
@@ -532,7 +529,7 @@ class BotoIoTTopicRuleTestCase(BotoIoTTestCaseBase, BotoIoTTestCaseMixin):
                                         description=topic_rule_ret['description'],
                                         actions=topic_rule_ret['actions'],
                                         **conn_parameters)
-        self.assertEqual(result.get('error', {}).get('message'), error_message.format('create_topic_rule')) 
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('create_topic_rule'))
 
     def test_that_when_replacing_a_topic_rule_succeeds_the_replace_topic_rule_method_returns_true(self):
         '''
@@ -557,7 +554,7 @@ class BotoIoTTopicRuleTestCase(BotoIoTTestCaseBase, BotoIoTTestCaseMixin):
                                         description=topic_rule_ret['description'],
                                         actions=topic_rule_ret['actions'],
                                         **conn_parameters)
-        self.assertEqual(result.get('error', {}).get('message'), error_message.format('replace_topic_rule')) 
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('replace_topic_rule'))
 
     def test_that_when_deleting_a_topic_rule_succeeds_the_delete_topic_rule_method_returns_true(self):
         '''
@@ -583,7 +580,7 @@ class BotoIoTTopicRuleTestCase(BotoIoTTestCaseBase, BotoIoTTestCaseMixin):
         '''
         self.conn.get_topic_rule.return_value = {'rule': topic_rule_ret}
 
-        result = boto_iot.describe_topic_rule(ruleName=topic_rule_ret['ruleName'], 
+        result = boto_iot.describe_topic_rule(ruleName=topic_rule_ret['ruleName'],
                                               **conn_parameters)
 
         self.assertTrue(result['rule'])

--- a/tests/unit/modules/boto_iot_test.py
+++ b/tests/unit/modules/boto_iot_test.py
@@ -37,12 +37,35 @@ except ImportError:
 # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
 required_boto3_version = '1.2.1'
 
-region = 'us-east-1'
-access_key = 'GKTADJGHEIQSXMKKRBJ08H'
-secret_key = 'askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs'
-conn_parameters = {'region': region, 'key': access_key, 'keyid': secret_key, 'profile': {}}
-error_message = 'An error occurred (101) when calling the {0} operation: Test-defined error'
-if HAS_BOTO:
+log = logging.getLogger(__name__)
+
+opts = salt.config.DEFAULT_MINION_OPTS
+context = {}
+utils = salt.loader.utils(opts, whitelist=['boto3'], context=context)
+
+boto_iot.__utils__ = utils
+boto_iot.__init__(opts)
+boto_iot.__salt__ = {}
+
+
+def _has_required_boto():
+    '''
+    Returns True/False boolean depending on if Boto is installed and correct
+    version.
+    '''
+    if not HAS_BOTO:
+        return False
+    elif LooseVersion(boto3.__version__) < LooseVersion(required_boto3_version):
+        return False
+    else:
+        return True
+
+if _has_required_boto():
+    region = 'us-east-1'
+    access_key = 'GKTADJGHEIQSXMKKRBJ08H'
+    secret_key = 'askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs'
+    conn_parameters = {'region': region, 'key': access_key, 'keyid': secret_key, 'profile': {}}
+    error_message = 'An error occurred (101) when calling the {0} operation: Test-defined error'
     not_found_error = ClientError({
         'Error': {
             'Code': 'ResourceNotFoundException',
@@ -72,29 +95,6 @@ if HAS_BOTO:
                       createdAt='1970-01-01',
                       actions=[{'lambda': {'functionArn': 'arn:aws:::function'}}],
                       ruleDisabled=True)
-
-log = logging.getLogger(__name__)
-
-opts = salt.config.DEFAULT_MINION_OPTS
-context = {}
-utils = salt.loader.utils(opts, whitelist=['boto3'], context=context)
-
-boto_iot.__utils__ = utils
-boto_iot.__init__(opts)
-boto_iot.__salt__ = {}
-
-
-def _has_required_boto():
-    '''
-    Returns True/False boolean depending on if Boto is installed and correct
-    version.
-    '''
-    if not HAS_BOTO:
-        return False
-    elif LooseVersion(boto3.__version__) < LooseVersion(required_boto3_version):
-        return False
-    else:
-        return True
 
 
 class BotoIoTTestCaseBase(TestCase):

--- a/tests/unit/modules/boto_iot_test.py
+++ b/tests/unit/modules/boto_iot_test.py
@@ -1,0 +1,620 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+from __future__ import absolute_import
+from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module
+
+# Import Salt Testing libs
+from salttesting.unit import skipIf, TestCase
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, patch
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+# Import Salt libs
+import salt.config
+import salt.loader
+from salt.modules import boto_iot
+from salt.exceptions import SaltInvocationError
+
+# Import 3rd-party libs
+from tempfile import NamedTemporaryFile
+import logging
+import os
+
+# Import Mock libraries
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
+
+# pylint: disable=import-error,no-name-in-module
+try:
+    import boto3
+    from botocore.exceptions import ClientError
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+
+# pylint: enable=import-error,no-name-in-module
+
+# the boto_iot module relies on the connect_to_region() method
+# which was added in boto 2.8.0
+# https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
+required_boto3_version = '1.2.1'
+
+region = 'us-east-1'
+access_key = 'GKTADJGHEIQSXMKKRBJ08H'
+secret_key = 'askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs'
+conn_parameters = {'region': region, 'key': access_key, 'keyid': secret_key, 'profile': {}}
+error_message = 'An error occurred (101) when calling the {0} operation: Test-defined error'
+not_found_error = ClientError({
+    'Error': {
+        'Code':'ResourceNotFoundException',
+        'Message': "Test-defined error"
+    }
+},'msg')
+topic_rule_not_found_error = ClientError({
+    'Error': {
+        'Code':'UnauthorizedException',
+        'Message': "Test-defined error"
+    }
+},'msg')
+error_content = {
+  'Error': {
+    'Code': 101,
+    'Message': "Test-defined error"
+  }
+}
+policy_ret = dict(policyName='testpolicy',
+                  policyDocument='{"Version": "2012-10-17", "Statement": [{"Action": ["iot:Publish"], "Resource": ["*"], "Effect": "Allow"}]}',
+                  policyArn='arn:aws:iot:us-east-1:123456:policy/my_policy',
+                  policyVersionId=1,
+                  defaultVersionId=1)
+topic_rule_ret = dict(ruleName='testrule',
+                  sql="SELECT * FROM 'iot/test'",
+                  description='topic rule description',
+                  createdAt='1970-01-01',
+                  actions=[{'lambda':{'functionArn':'arn:aws:::function'}}],
+                  ruleDisabled=True)
+
+log = logging.getLogger(__name__)
+
+opts = salt.config.DEFAULT_MINION_OPTS
+context = {}
+utils = salt.loader.utils(opts, whitelist=['boto3'], context=context)
+
+boto_iot.__utils__ = utils
+boto_iot.__init__(opts)
+boto_iot.__salt__ = {}
+
+
+def _has_required_boto():
+    '''
+    Returns True/False boolean depending on if Boto is installed and correct
+    version.
+    '''
+    if not HAS_BOTO:
+        return False
+    elif LooseVersion(boto3.__version__) < LooseVersion(required_boto3_version):
+        return False
+    else:
+        return True
+
+
+class BotoIoTTestCaseBase(TestCase):
+    conn = None
+
+    # Set up MagicMock to replace the boto3 session
+    def setUp(self):
+        context.clear()
+
+        self.patcher = patch('boto3.session.Session')
+        self.addCleanup(self.patcher.stop)
+        mock_session = self.patcher.start()
+
+        session_instance = mock_session.return_value
+        self.conn = MagicMock()
+        session_instance.client.return_value = self.conn
+
+
+class BotoIoTTestCaseMixin(object):
+    pass
+
+
+@skipIf(HAS_BOTO is False, 'The boto module must be installed.')
+@skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
+                                       ' or equal to version {0}'
+        .format(required_boto3_version))
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class BotoIoTPolicyTestCase(BotoIoTTestCaseBase, BotoIoTTestCaseMixin):
+    '''
+    TestCase for salt.modules.boto_iot module
+    '''
+
+    def test_that_when_checking_if_a_policy_exists_and_a_policy_exists_the_policy_exists_method_returns_true(self):
+        '''
+        Tests checking iot policy existence when the iot policy already exists
+        '''
+        self.conn.get_policy.return_value = {'policy': policy_ret}
+        result = boto_iot.policy_exists(policyName=policy_ret['policyName'], **conn_parameters)
+
+        self.assertTrue(result['exists'])
+
+    def test_that_when_checking_if_a_policy_exists_and_a_policy_does_not_exist_the_policy_exists_method_returns_false(self):
+        '''
+        Tests checking iot policy existence when the iot policy does not exist
+        '''
+        self.conn.get_policy.side_effect = not_found_error
+        result = boto_iot.policy_exists(policyName='mypolicy', **conn_parameters)
+
+        self.assertFalse(result['exists'])
+
+    def test_that_when_checking_if_a_policy_exists_and_boto3_returns_an_error_the_policy_exists_method_returns_error(self):
+        '''
+        Tests checking iot policy existence when boto returns an error
+        '''
+        self.conn.get_policy.side_effect = ClientError(error_content, 'get_policy')
+        result = boto_iot.policy_exists(policyName='mypolicy', **conn_parameters)
+
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('get_policy'))
+
+    def test_that_when_creating_a_policy_succeeds_the_create_policy_method_returns_true(self):
+        '''
+        tests True policy created.
+        '''
+        self.conn.create_policy.return_value = policy_ret
+        result = boto_iot.create_policy(policyName=policy_ret['policyName'],
+                                        policyDocument=policy_ret['policyDocument'],
+                                        **conn_parameters)
+
+        self.assertTrue(result['created'])
+
+    def test_that_when_creating_a_policy_fails_the_create_policy_method_returns_error(self):
+        '''
+        tests False policy not created.
+        '''
+        self.conn.create_policy.side_effect = ClientError(error_content, 'create_policy')
+        result = boto_iot.create_policy(policyName=policy_ret['policyName'],
+                                        policyDocument=policy_ret['policyDocument'],
+                                        **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('create_policy')) 
+
+    def test_that_when_deleting_a_policy_succeeds_the_delete_policy_method_returns_true(self):
+        '''
+        tests True policy deleted.
+        '''
+        result = boto_iot.delete_policy(policyName='testpolicy',
+                                        **conn_parameters)
+
+        self.assertTrue(result['deleted'])
+
+    def test_that_when_deleting_a_policy_fails_the_delete_policy_method_returns_false(self):
+        '''
+        tests False policy not deleted.
+        '''
+        self.conn.delete_policy.side_effect = ClientError(error_content, 'delete_policy')
+        result = boto_iot.delete_policy(policyName='testpolicy',
+                                        **conn_parameters)
+        self.assertFalse(result['deleted'])
+
+    def test_that_when_describing_policy_it_returns_the_dict_of_properties_returns_true(self):
+        '''
+        Tests describing parameters if policy exists
+        '''
+        self.conn.get_policy.return_value = {'policy': policy_ret}
+
+        result = boto_iot.describe_policy(policyName=policy_ret['policyName'], **conn_parameters)
+
+        self.assertTrue(result['policy'])
+
+    def test_that_when_describing_policy_it_returns_the_dict_of_properties_returns_false(self):
+        '''
+        Tests describing parameters if policy does not exist
+        '''
+        self.conn.get_policy.side_effect = not_found_error
+        result = boto_iot.describe_policy(policyName='testpolicy', **conn_parameters)
+
+        self.assertFalse(result['policy'])
+
+    def test_that_when_describing_policy_on_client_error_it_returns_error(self):
+        '''
+        Tests describing parameters failure
+        '''
+        self.conn.get_policy.side_effect = ClientError(error_content, 'get_policy')
+        result = boto_iot.describe_policy(policyName='testpolicy', **conn_parameters)
+        self.assertTrue('error' in result)
+
+    def test_that_when_checking_if_a_policy_version_exists_and_a_policy_version_exists_the_policy_version_exists_method_returns_true(self):
+        '''
+        Tests checking iot policy existence when the iot policy version already exists
+        '''
+        self.conn.get_policy.return_value = {'policy': policy_ret}
+        result = boto_iot.policy_version_exists(policyName=policy_ret['policyName'], 
+                                                policyVersionId=1,
+                                                **conn_parameters)
+
+        self.assertTrue(result['exists'])
+
+    def test_that_when_checking_if_a_policy_version_exists_and_a_policy_version_does_not_exist_the_policy_version_exists_method_returns_false(self):
+        '''
+        Tests checking iot policy_version existence when the iot policy_version does not exist
+        '''
+        self.conn.get_policy_version.side_effect = not_found_error
+        result = boto_iot.policy_version_exists(policyName=policy_ret['policyName'], 
+                                                policyVersionId=1,
+                                                **conn_parameters)
+
+        self.assertFalse(result['exists'])
+
+    def test_that_when_checking_if_a_policy_version_exists_and_boto3_returns_an_error_the_policy_version_exists_method_returns_error(self):
+        '''
+        Tests checking iot policy_version existence when boto returns an error
+        '''
+        self.conn.get_policy_version.side_effect = ClientError(error_content, 'get_policy_version')
+        result = boto_iot.policy_version_exists(policyName=policy_ret['policyName'], 
+                                                policyVersionId=1,
+                                                **conn_parameters)
+
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('get_policy_version'))
+
+    def test_that_when_creating_a_policy_version_succeeds_the_create_policy_version_method_returns_true(self):
+        '''
+        tests True policy_version created.
+        '''
+        self.conn.create_policy_version.return_value = policy_ret
+        result = boto_iot.create_policy_version(policyName=policy_ret['policyName'],
+                                        policyDocument=policy_ret['policyDocument'],
+                                        **conn_parameters)
+
+        self.assertTrue(result['created'])
+
+    def test_that_when_creating_a_policy_version_fails_the_create_policy_version_method_returns_error(self):
+        '''
+        tests False policy_version not created.
+        '''
+        self.conn.create_policy_version.side_effect = ClientError(error_content, 'create_policy_version')
+        result = boto_iot.create_policy_version(policyName=policy_ret['policyName'],
+                                        policyDocument=policy_ret['policyDocument'],
+                                        **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('create_policy_version')) 
+
+    def test_that_when_deleting_a_policy_version_succeeds_the_delete_policy_version_method_returns_true(self):
+        '''
+        tests True policy_version deleted.
+        '''
+        result = boto_iot.delete_policy_version(policyName='testpolicy',
+                                        policyVersionId=1,
+                                        **conn_parameters)
+
+        self.assertTrue(result['deleted'])
+
+    def test_that_when_deleting_a_policy_version_fails_the_delete_policy_version_method_returns_false(self):
+        '''
+        tests False policy_version not deleted.
+        '''
+        self.conn.delete_policy_version.side_effect = ClientError(error_content, 'delete_policy_version')
+        result = boto_iot.delete_policy_version(policyName='testpolicy',
+                                        policyVersionId=1,
+                                        **conn_parameters)
+        self.assertFalse(result['deleted'])
+
+    def test_that_when_describing_policy_version_it_returns_the_dict_of_properties_returns_true(self):
+        '''
+        Tests describing parameters if policy_version exists
+        '''
+        self.conn.get_policy_version.return_value = {'policy': policy_ret}
+
+        result = boto_iot.describe_policy_version(policyName=policy_ret['policyName'], 
+                                        policyVersionId=1,
+                                        **conn_parameters)
+
+        self.assertTrue(result['policy'])
+
+    def test_that_when_describing_policy_version_it_returns_the_dict_of_properties_returns_false(self):
+        '''
+        Tests describing parameters if policy_version does not exist
+        '''
+        self.conn.get_policy_version.side_effect = not_found_error
+        result = boto_iot.describe_policy_version(policyName=policy_ret['policyName'], 
+                                        policyVersionId=1,
+                                        **conn_parameters)
+
+        self.assertFalse(result['policy'])
+
+    def test_that_when_describing_policy_version_on_client_error_it_returns_error(self):
+        '''
+        Tests describing parameters failure
+        '''
+        self.conn.get_policy_version.side_effect = ClientError(error_content, 'get_policy_version')
+        result = boto_iot.describe_policy_version(policyName=policy_ret['policyName'], 
+                                        policyVersionId=1,
+                                        **conn_parameters)
+        self.assertTrue('error' in result)
+
+    def test_that_when_listing_policies_succeeds_the_list_policies_method_returns_true(self):
+        '''
+        tests True policies listed.
+        '''
+        self.conn.list_policies.return_value = {'policies': [policy_ret]}
+        result = boto_iot.list_policies(**conn_parameters)
+
+        self.assertTrue(result['policies'])
+
+    def test_that_when_listing_policy_fails_the_list_policy_method_returns_false(self):
+        '''
+        tests False no policy listed.
+        '''
+        self.conn.list_policies.return_value = {'policies': []}
+        result = boto_iot.list_policies(**conn_parameters)
+        self.assertFalse(result['policies'])
+
+    def test_that_when_listing_policy_fails_the_list_policy_method_returns_error(self):
+        '''
+        tests False policy error.
+        '''
+        self.conn.list_policies.side_effect = ClientError(error_content, 'list_policies')
+        result = boto_iot.list_policies(**conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('list_policies'))
+
+    def test_that_when_listing_policy_versions_succeeds_the_list_policy_versions_method_returns_true(self):
+        '''
+        tests True policy versions listed.
+        '''
+        self.conn.list_policy_versions.return_value = {'policyVersions': [policy_ret]}
+        result = boto_iot.list_policy_versions(policyName='testpolicy',
+                                               **conn_parameters)
+
+        self.assertTrue(result['policyVersions'])
+
+    def test_that_when_listing_policy_versions_fails_the_list_policy_versions_method_returns_false(self):
+        '''
+        tests False no policy versions listed.
+        '''
+        self.conn.list_policy_versions.return_value = {'policyVersions': []}
+        result = boto_iot.list_policy_versions(policyName='testpolicy',
+                                               **conn_parameters)
+        self.assertFalse(result['policyVersions'])
+
+    def test_that_when_listing_policy_versions_fails_the_list_policy_versions_method_returns_error(self):
+        '''
+        tests False policy versions error.
+        '''
+        self.conn.list_policy_versions.side_effect = ClientError(error_content, 'list_policy_versions')
+        result = boto_iot.list_policy_versions(policyName='testpolicy',
+                                               **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('list_policy_versions'))
+
+    def test_that_when_setting_default_policy_version_succeeds_the_set_default_policy_version_method_returns_true(self):
+        '''
+        tests True policy version set.
+        '''
+        result = boto_iot.set_default_policy_version(policyName='testpolicy',
+                                               policyVersionId=1,
+                                               **conn_parameters)
+
+        self.assertTrue(result['changed'])
+
+    def test_that_when_set_default_policy_version_fails_the_set_default_policy_version_method_returns_error(self):
+        '''
+        tests False policy version error.
+        '''
+        self.conn.set_default_policy_version.side_effect = \
+                                ClientError(error_content, 'set_default_policy_version')
+        result = boto_iot.set_default_policy_version(policyName='testpolicy',
+                                               policyVersionId=1,
+                                               **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'), 
+                         error_message.format('set_default_policy_version'))
+
+    def test_that_when_list_principal_policies_succeeds_the_list_principal_policies_method_returns_true(self):
+        '''
+        tests True policies listed.
+        '''
+        self.conn.list_principal_policies.return_value = {'policies': [policy_ret]}
+        result = boto_iot.list_principal_policies(principal='us-east-1:GUID-GUID-GUID',
+                                               **conn_parameters)
+
+        self.assertTrue(result['policies'])
+
+    def test_that_when_set_default_policy_version_fails_the_set_default_policy_version_method_returns_error(self):
+        '''
+        tests False policy version error.
+        '''
+        self.conn.list_principal_policies.side_effect = \
+                                ClientError(error_content, 'list_principal_policies')
+        result = boto_iot.list_principal_policies(principal='us-east-1:GUID-GUID-GUID',
+                                               **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'), 
+                         error_message.format('list_principal_policies'))
+
+    def test_that_when_attach_principal_policy_succeeds_the_attach_principal_policy_method_returns_true(self):
+        '''
+        tests True policy attached.
+        '''
+        result = boto_iot.attach_principal_policy(policyName='testpolicy',
+                                               principal='us-east-1:GUID-GUID-GUID',
+                                               **conn_parameters)
+
+        self.assertTrue(result['attached'])
+
+    def test_that_when_attach_principal_policy_version_fails_the_attach_principal_policy_version_method_returns_error(self):
+        '''
+        tests False policy version error.
+        '''
+        self.conn.attach_principal_policy.side_effect = \
+                                ClientError(error_content, 'attach_principal_policy')
+        result = boto_iot.attach_principal_policy(policyName='testpolicy',
+                                               principal='us-east-1:GUID-GUID-GUID',
+                                               **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'), 
+                         error_message.format('attach_principal_policy'))
+
+    def test_that_when_detach_principal_policy_succeeds_the_detach_principal_policy_method_returns_true(self):
+        '''
+        tests True policy detached.
+        '''
+        result = boto_iot.detach_principal_policy(policyName='testpolicy',
+                                               principal='us-east-1:GUID-GUID-GUID',
+                                               **conn_parameters)
+
+        self.assertTrue(result['detached'])
+
+    def test_that_when_detach_principal_policy_version_fails_the_detach_principal_policy_version_method_returns_error(self):
+        '''
+        tests False policy version error.
+        '''
+        self.conn.detach_principal_policy.side_effect = \
+                                ClientError(error_content, 'detach_principal_policy')
+        result = boto_iot.detach_principal_policy(policyName='testpolicy',
+                                               principal='us-east-1:GUID-GUID-GUID',
+                                               **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'), 
+                         error_message.format('detach_principal_policy'))
+
+
+@skipIf(HAS_BOTO is False, 'The boto module must be installed.')
+@skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
+                                       ' or equal to version {0}'
+        .format(required_boto3_version))
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class BotoIoTTopicRuleTestCase(BotoIoTTestCaseBase, BotoIoTTestCaseMixin):
+    '''
+    TestCase for salt.modules.boto_iot module
+    '''
+
+    def test_that_when_checking_if_a_topic_rule_exists_and_a_topic_rule_exists_the_topic_rule_exists_method_returns_true(self):
+        '''
+        Tests checking iot topic_rule existence when the iot topic_rule already exists
+        '''
+        self.conn.get_topic_rule.return_value = {'rule': topic_rule_ret}
+        result = boto_iot.topic_rule_exists(ruleName=topic_rule_ret['ruleName'], 
+                                            **conn_parameters)
+
+        self.assertTrue(result['exists'])
+
+    def test_that_when_checking_if_a_rule_exists_and_a_rule_does_not_exist_the_topic_rule_exists_method_returns_false(self):
+        '''
+        Tests checking iot rule existence when the iot rule does not exist
+        '''
+        self.conn.get_topic_rule.side_effect = topic_rule_not_found_error
+        result = boto_iot.topic_rule_exists(ruleName='mypolicy', **conn_parameters)
+
+        self.assertFalse(result['exists'])
+
+    def test_that_when_checking_if_a_topic_rule_exists_and_boto3_returns_an_error_the_topic_rule_exists_method_returns_error(self):
+        '''
+        Tests checking iot topic_rule existence when boto returns an error
+        '''
+        self.conn.get_topic_rule.side_effect = ClientError(error_content, 'get_topic_rule')
+        result = boto_iot.topic_rule_exists(ruleName='myrule', **conn_parameters)
+
+        self.assertEqual(result.get('error', {}).get('message'), 
+                                      error_message.format('get_topic_rule'))
+
+    def test_that_when_creating_a_topic_rule_succeeds_the_create_topic_rule_method_returns_true(self):
+        '''
+        tests True topic_rule created.
+        '''
+        self.conn.create_topic_rule.return_value = topic_rule_ret
+        result = boto_iot.create_topic_rule(ruleName=topic_rule_ret['ruleName'],
+                                        sql=topic_rule_ret['sql'],
+                                        description=topic_rule_ret['description'],
+                                        actions=topic_rule_ret['actions'],
+                                        **conn_parameters)
+
+        self.assertTrue(result['created'])
+
+    def test_that_when_creating_a_topic_rule_fails_the_create_topic_rule_method_returns_error(self):
+        '''
+        tests False topic_rule not created.
+        '''
+        self.conn.create_topic_rule.side_effect = ClientError(error_content, 'create_topic_rule')
+        result = boto_iot.create_topic_rule(ruleName=topic_rule_ret['ruleName'],
+                                        sql=topic_rule_ret['sql'],
+                                        description=topic_rule_ret['description'],
+                                        actions=topic_rule_ret['actions'],
+                                        **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('create_topic_rule')) 
+
+    def test_that_when_replacing_a_topic_rule_succeeds_the_replace_topic_rule_method_returns_true(self):
+        '''
+        tests True topic_rule replaced.
+        '''
+        self.conn.replace_topic_rule.return_value = topic_rule_ret
+        result = boto_iot.replace_topic_rule(ruleName=topic_rule_ret['ruleName'],
+                                        sql=topic_rule_ret['sql'],
+                                        description=topic_rule_ret['description'],
+                                        actions=topic_rule_ret['actions'],
+                                        **conn_parameters)
+
+        self.assertTrue(result['replaced'])
+
+    def test_that_when_replacing_a_topic_rule_fails_the_replace_topic_rule_method_returns_error(self):
+        '''
+        tests False topic_rule not replaced.
+        '''
+        self.conn.replace_topic_rule.side_effect = ClientError(error_content, 'replace_topic_rule')
+        result = boto_iot.replace_topic_rule(ruleName=topic_rule_ret['ruleName'],
+                                        sql=topic_rule_ret['sql'],
+                                        description=topic_rule_ret['description'],
+                                        actions=topic_rule_ret['actions'],
+                                        **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('replace_topic_rule')) 
+
+    def test_that_when_deleting_a_topic_rule_succeeds_the_delete_topic_rule_method_returns_true(self):
+        '''
+        tests True topic_rule deleted.
+        '''
+        result = boto_iot.delete_topic_rule(ruleName='testrule',
+                                        **conn_parameters)
+
+        self.assertTrue(result['deleted'])
+
+    def test_that_when_deleting_a_topic_rule_fails_the_delete_topic_rule_method_returns_false(self):
+        '''
+        tests False topic_rule not deleted.
+        '''
+        self.conn.delete_topic_rule.side_effect = ClientError(error_content, 'delete_topic_rule')
+        result = boto_iot.delete_topic_rule(ruleName='testrule',
+                                        **conn_parameters)
+        self.assertFalse(result['deleted'])
+
+    def test_that_when_describing_topic_rule_it_returns_the_dict_of_properties_returns_true(self):
+        '''
+        Tests describing parameters if topic_rule exists
+        '''
+        self.conn.get_topic_rule.return_value = {'rule': topic_rule_ret}
+
+        result = boto_iot.describe_topic_rule(ruleName=topic_rule_ret['ruleName'], 
+                                              **conn_parameters)
+
+        self.assertTrue(result['rule'])
+
+    def test_that_when_describing_topic_rule_on_client_error_it_returns_error(self):
+        '''
+        Tests describing parameters failure
+        '''
+        self.conn.get_topic_rule.side_effect = ClientError(error_content, 'get_topic_rule')
+        result = boto_iot.describe_topic_rule(ruleName='testrule', **conn_parameters)
+        self.assertTrue('error' in result)
+
+    def test_that_when_listing_topic_rules_succeeds_the_list_topic_rules_method_returns_true(self):
+        '''
+        tests True topic_rules listed.
+        '''
+        self.conn.list_topic_rules.return_value = {'rules': [topic_rule_ret]}
+        result = boto_iot.list_topic_rules(**conn_parameters)
+
+        self.assertTrue(result['rules'])
+
+    def test_that_when_listing_topic_rules_fails_the_list_topic_rules_method_returns_error(self):
+        '''
+        tests False policy error.
+        '''
+        self.conn.list_topic_rules.side_effect = ClientError(error_content, 'list_topic_rules')
+        result = boto_iot.list_topic_rules(**conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('list_topic_rules'))
+
+
+if __name__ == '__main__':
+    from integration import run_tests  # pylint: disable=import-error
+    run_tests(BotoIoTPolicyTestCase, needs_daemon=False)
+    run_tests(BotoIoTTopicRuleTestCase, needs_daemon=False)

--- a/tests/unit/modules/boto_iot_test.py
+++ b/tests/unit/modules/boto_iot_test.py
@@ -42,35 +42,36 @@ access_key = 'GKTADJGHEIQSXMKKRBJ08H'
 secret_key = 'askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs'
 conn_parameters = {'region': region, 'key': access_key, 'keyid': secret_key, 'profile': {}}
 error_message = 'An error occurred (101) when calling the {0} operation: Test-defined error'
-not_found_error = ClientError({
-    'Error': {
-        'Code': 'ResourceNotFoundException',
+if HAS_BOTO:
+    not_found_error = ClientError({
+        'Error': {
+            'Code': 'ResourceNotFoundException',
+            'Message': "Test-defined error"
+        }
+    }, 'msg')
+    topic_rule_not_found_error = ClientError({
+        'Error': {
+            'Code': 'UnauthorizedException',
+            'Message': "Test-defined error"
+        }
+    }, 'msg')
+    error_content = {
+      'Error': {
+        'Code': 101,
         'Message': "Test-defined error"
+      }
     }
-}, 'msg')
-topic_rule_not_found_error = ClientError({
-    'Error': {
-        'Code': 'UnauthorizedException',
-        'Message': "Test-defined error"
-    }
-}, 'msg')
-error_content = {
-  'Error': {
-    'Code': 101,
-    'Message': "Test-defined error"
-  }
-}
-policy_ret = dict(policyName='testpolicy',
-                  policyDocument='{"Version": "2012-10-17", "Statement": [{"Action": ["iot:Publish"], "Resource": ["*"], "Effect": "Allow"}]}',
-                  policyArn='arn:aws:iot:us-east-1:123456:policy/my_policy',
-                  policyVersionId=1,
-                  defaultVersionId=1)
-topic_rule_ret = dict(ruleName='testrule',
-                  sql="SELECT * FROM 'iot/test'",
-                  description='topic rule description',
-                  createdAt='1970-01-01',
-                  actions=[{'lambda': {'functionArn': 'arn:aws:::function'}}],
-                  ruleDisabled=True)
+    policy_ret = dict(policyName='testpolicy',
+                      policyDocument='{"Version": "2012-10-17", "Statement": [{"Action": ["iot:Publish"], "Resource": ["*"], "Effect": "Allow"}]}',
+                      policyArn='arn:aws:iot:us-east-1:123456:policy/my_policy',
+                      policyVersionId=1,
+                      defaultVersionId=1)
+    topic_rule_ret = dict(ruleName='testrule',
+                      sql="SELECT * FROM 'iot/test'",
+                      description='topic rule description',
+                      createdAt='1970-01-01',
+                      actions=[{'lambda': {'functionArn': 'arn:aws:::function'}}],
+                      ruleDisabled=True)
 
 log = logging.getLogger(__name__)
 

--- a/tests/unit/modules/boto_iot_test.py
+++ b/tests/unit/modules/boto_iot_test.py
@@ -24,6 +24,7 @@ from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
 
 # pylint: disable=import-error,no-name-in-module
 try:
+    import boto
     import boto3
     from botocore.exceptions import ClientError
     HAS_BOTO = True

--- a/tests/unit/states/boto_iot_test.py
+++ b/tests/unit/states/boto_iot_test.py
@@ -46,13 +46,13 @@ conn_parameters = {'region': region, 'key': access_key, 'keyid': secret_key, 'pr
 error_message = 'An error occurred (101) when calling the {0} operation: Test-defined error'
 not_found_error = ClientError({
     'Error': {
-        'Code':'ResourceNotFoundException', 
+        'Code': 'ResourceNotFoundException',
         'Message': "Test-defined error"
     }
 }, 'msg')
 topic_rule_not_found_error = ClientError({
     'Error': {
-        'Code':'UnauthorizedException', 
+        'Code': 'UnauthorizedException',
         'Message': "Test-defined error"
     }
 }, 'msg')
@@ -71,7 +71,7 @@ topic_rule_ret = dict(ruleName='testrule',
                   sql="SELECT * FROM 'iot/test'",
                   description='topic rule description',
                   createdAt='1970-01-01',
-                  actions=[{'iot':{'functionArn':'arn:aws:::function'}}],
+                  actions=[{'iot': {'functionArn': 'arn:aws:::function'}}],
                   ruleDisabled=True)
 principal = 'arn:aws:iot:us-east-1:1234:cert/21fc104aaaf6043f5756c1b57bda84ea8395904c43f28517799b19e4c42514'
 log = logging.getLogger(__name__)

--- a/tests/unit/states/boto_iot_test.py
+++ b/tests/unit/states/boto_iot_test.py
@@ -1,0 +1,318 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+from __future__ import absolute_import
+from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module
+
+# Import Salt Testing libs
+from salttesting.unit import skipIf, TestCase
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, patch
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+# Import Salt libs
+import salt.config
+import salt.loader
+
+# Import 3rd-party libs
+import logging
+
+# Import Mock libraries
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
+
+# pylint: disable=import-error,no-name-in-module
+from unit.modules.boto_iot_test import BotoIoTTestCaseMixin
+
+# Import 3rd-party libs
+try:
+    import boto3
+    from botocore.exceptions import ClientError
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+
+# pylint: enable=import-error,no-name-in-module
+
+# the boto_iot module relies on the connect_to_region() method
+# which was added in boto 2.8.0
+# https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
+required_boto3_version = '1.2.1'
+
+region = 'us-east-1'
+access_key = 'GKTADJGHEIQSXMKKRBJ08H'
+secret_key = 'askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs'
+conn_parameters = {'region': region, 'key': access_key, 'keyid': secret_key, 'profile': {}}
+error_message = 'An error occurred (101) when calling the {0} operation: Test-defined error'
+not_found_error = ClientError({
+    'Error': {
+        'Code':'ResourceNotFoundException',
+        'Message': "Test-defined error"
+    }
+},'msg')
+topic_rule_not_found_error = ClientError({
+    'Error': {
+        'Code':'UnauthorizedException',
+        'Message': "Test-defined error"
+    }
+},'msg')
+error_content = {
+  'Error': {
+    'Code': 101,
+    'Message': "Test-defined error"
+  }
+}
+policy_ret = dict(policyName='testpolicy',
+                  policyDocument='{"Version": "2012-10-17", "Statement": [{"Action": ["iot:Publish"], "Resource": ["*"], "Effect": "Allow"}]}',
+                  policyArn='arn:aws:iot:us-east-1:123456:policy/my_policy',
+                  policyVersionId=1,
+                  defaultVersionId=1)
+topic_rule_ret = dict(ruleName='testrule',
+                  sql="SELECT * FROM 'iot/test'",
+                  description='topic rule description',
+                  createdAt='1970-01-01',
+                  actions=[{'iot':{'functionArn':'arn:aws:::function'}}],
+                  ruleDisabled=True)
+principal = 'arn:aws:iot:us-east-1:1234:cert/21fc104aaaf6043f5756c1b57bda84ea8395904c43f28517799b19e4c42514'
+log = logging.getLogger(__name__)
+
+opts = salt.config.DEFAULT_MINION_OPTS
+context = {}
+utils = salt.loader.utils(opts, whitelist=['boto3'], context=context)
+serializers = salt.loader.serializers(opts)
+funcs = salt.loader.minion_mods(opts, context=context, utils=utils, whitelist=['boto_iot'])
+salt_states = salt.loader.states(opts=opts, functions=funcs, utils=utils, whitelist=['boto_iot'], serializers=serializers)
+
+
+def _has_required_boto():
+    '''
+    Returns True/False boolean depending on if Boto is installed and correct
+    version.
+    '''
+    if not HAS_BOTO:
+        return False
+    elif LooseVersion(boto3.__version__) < LooseVersion(required_boto3_version):
+        return False
+    else:
+        return True
+
+
+class BotoIoTStateTestCaseBase(TestCase):
+    conn = None
+
+    # Set up MagicMock to replace the boto3 session
+    def setUp(self):
+        context.clear()
+
+        self.patcher = patch('boto3.session.Session')
+        self.addCleanup(self.patcher.stop)
+        mock_session = self.patcher.start()
+
+        session_instance = mock_session.return_value
+        self.conn = MagicMock()
+        session_instance.client.return_value = self.conn
+
+
+@skipIf(HAS_BOTO is False, 'The boto module must be installed.')
+@skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
+                                       ' or equal to version {0}'
+        .format(required_boto3_version))
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class BotoIoTPolicyTestCase(BotoIoTStateTestCaseBase, BotoIoTTestCaseMixin):
+    '''
+    TestCase for salt.modules.boto_iot state.module
+    '''
+
+    def test_present_when_policy_does_not_exist(self):
+        '''
+        Tests present on a policy that does not exist.
+        '''
+        self.conn.get_policy.side_effect = [not_found_error, policy_ret]
+        self.conn.create_policy.return_value = policy_ret
+        result = salt_states['boto_iot.policy_present'](
+                         'policy present',
+                         policyName=policy_ret['policyName'],
+                         policyDocument=policy_ret['policyDocument'])
+
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes']['new']['policy']['policyName'],
+                         policy_ret['policyName'])
+
+    def test_present_when_policy_exists(self):
+        self.conn.get_policy.return_value = policy_ret
+        self.conn.create_policy_version.return_value = policy_ret
+        result = salt_states['boto_iot.policy_present'](
+                         'policy present',
+                         policyName=policy_ret['policyName'],
+                         policyDocument=policy_ret['policyDocument'])
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes'], {})
+
+    def test_present_with_failure(self):
+        self.conn.get_policy.side_effect = [not_found_error, policy_ret]
+        self.conn.create_policy.side_effect = ClientError(error_content, 'create_policy')
+        result = salt_states['boto_iot.policy_present'](
+                         'policy present',
+                         policyName=policy_ret['policyName'],
+                         policyDocument=policy_ret['policyDocument'])
+        self.assertFalse(result['result'])
+        self.assertTrue('An error occurred' in result['comment'])
+
+    def test_absent_when_policy_does_not_exist(self):
+        '''
+        Tests absent on a policy that does not exist.
+        '''
+        self.conn.get_policy.side_effect = not_found_error
+        result = salt_states['boto_iot.policy_absent']('test', 'mypolicy')
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes'], {})
+
+    def test_absent_when_policy_exists(self):
+        self.conn.get_policy.return_value = policy_ret
+        self.conn.list_policy_versions.return_value = {'policyVersions': []}
+        result = salt_states['boto_iot.policy_absent']('test', policy_ret['policyName'])
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes']['new']['policy'], None)
+
+    def test_absent_with_failure(self):
+        self.conn.get_policy.return_value = policy_ret
+        self.conn.list_policy_versions.return_value = {'policyVersions': []}
+        self.conn.delete_policy.side_effect = ClientError(error_content, 'delete_policy')
+        result = salt_states['boto_iot.policy_absent']('test', policy_ret['policyName'])
+        self.assertFalse(result['result'])
+        self.assertTrue('An error occurred' in result['comment'])
+
+    def test_attached_when_policy_not_attached(self):
+        '''
+        Tests attached on a policy that is not attached.
+        '''
+        self.conn.list_principal_policies.return_value = {'policies': []}
+        result = salt_states['boto_iot.policy_attached']('test', 'myfunc', principal)
+        self.assertTrue(result['result'])
+        self.assertTrue(result['changes']['new']['attached'])
+
+    def test_attached_when_policy_attached(self):
+        '''
+        Tests attached on a policy that is attached.
+        '''
+        self.conn.list_principal_policies.return_value = {'policies': [policy_ret]}
+        result = salt_states['boto_iot.policy_attached']('test', policy_ret['policyName'], principal)
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes'], {})
+
+    def test_attached_with_failure(self):
+        '''
+        Tests attached on a policy that is attached.
+        '''
+        self.conn.list_principal_policies.return_value = {'policies': []}
+        self.conn.attach_principal_policy.side_effect = ClientError(error_content, 'attach_principal_policy')
+        result = salt_states['boto_iot.policy_attached']('test', policy_ret['policyName'], principal)
+        self.assertFalse(result['result'])
+        self.assertEqual(result['changes'], {})
+
+    def test_detached_when_policy_not_detached(self):
+        '''
+        Tests detached on a policy that is not detached.
+        '''
+        self.conn.list_principal_policies.return_value = {'policies': [policy_ret]}
+        result = salt_states['boto_iot.policy_detached']('test', policy_ret['policyName'], principal)
+        self.assertTrue(result['result'])
+        log.warn(result)
+        self.assertFalse(result['changes']['new']['attached'])
+
+    def test_detached_when_policy_detached(self):
+        '''
+        Tests detached on a policy that is detached.
+        '''
+        self.conn.list_principal_policies.return_value = {'policies': []}
+        result = salt_states['boto_iot.policy_detached']('test', policy_ret['policyName'], principal)
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes'], {})
+
+    def test_detached_with_failure(self):
+        '''
+        Tests detached on a policy that is detached.
+        '''
+        self.conn.list_principal_policies.return_value = {'policies': [policy_ret]}
+        self.conn.detach_principal_policy.side_effect = ClientError(error_content, 'detach_principal_policy')
+        result = salt_states['boto_iot.policy_detached']('test', policy_ret['policyName'], principal)
+        self.assertFalse(result['result'])
+        self.assertEqual(result['changes'], {})
+
+
+@skipIf(HAS_BOTO is False, 'The boto module must be installed.')
+@skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
+                                       ' or equal to version {0}'
+        .format(required_boto3_version))
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class BotoIoTTopicRuleTestCase(BotoIoTStateTestCaseBase, BotoIoTTestCaseMixin):
+    '''
+    TestCase for salt.modules.boto_iot state.module rules
+    '''
+
+    def test_present_when_topic_rule_does_not_exist(self):
+        '''
+        Tests present on a topic_rule that does not exist.
+        '''
+        self.conn.get_topic_rule.side_effect = [topic_rule_not_found_error, {'rule': topic_rule_ret}]
+        self.conn.create_topic_rule.return_value = {'created': True}
+        result = salt_states['boto_iot.topic_rule_present'](
+                         'topic rule present',
+                         ruleName=topic_rule_ret['ruleName'],
+                         sql=topic_rule_ret['sql'],
+                         description=topic_rule_ret['description'],
+                         actions=topic_rule_ret['actions'],
+                         ruleDisabled=topic_rule_ret['ruleDisabled'])
+
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes']['new']['rule']['ruleName'],
+                         topic_rule_ret['ruleName'])
+
+    def test_present_when_policy_exists(self):
+        self.conn.get_topic_rule.return_value = {'rule': topic_rule_ret}
+        self.conn.create_topic_rule.return_value = {'created': True}
+        result = salt_states['boto_iot.topic_rule_present'](
+                         'topic rule present',
+                         ruleName=topic_rule_ret['ruleName'],
+                         sql=topic_rule_ret['sql'],
+                         description=topic_rule_ret['description'],
+                         actions=topic_rule_ret['actions'],
+                         ruleDisabled=topic_rule_ret['ruleDisabled'])
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes'], {})
+
+    def test_present_with_failure(self):
+        self.conn.get_topic_rule.side_effect = [topic_rule_not_found_error, {'rule': topic_rule_ret}]
+        self.conn.create_topic_rule.side_effect = ClientError(error_content, 'create_topic_rule')
+        result = salt_states['boto_iot.topic_rule_present'](
+                         'topic rule present',
+                         ruleName=topic_rule_ret['ruleName'],
+                         sql=topic_rule_ret['sql'],
+                         description=topic_rule_ret['description'],
+                         actions=topic_rule_ret['actions'],
+                         ruleDisabled=topic_rule_ret['ruleDisabled'])
+        self.assertFalse(result['result'])
+        self.assertTrue('An error occurred' in result['comment'])
+
+    def test_absent_when_topic_rule_does_not_exist(self):
+        '''
+        Tests absent on a topic rule that does not exist.
+        '''
+        self.conn.get_topic_rule.side_effect = topic_rule_not_found_error
+        result = salt_states['boto_iot.topic_rule_absent']('test', 'myrule')
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes'], {})
+
+    def test_absent_when_topic_rule_exists(self):
+        self.conn.get_topic_rule.return_value = topic_rule_ret
+        result = salt_states['boto_iot.topic_rule_absent']('test', topic_rule_ret['ruleName'])
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes']['new']['rule'], None)
+
+    def test_absent_with_failure(self):
+        self.conn.get_topic_rule.return_value = topic_rule_ret
+        self.conn.delete_topic_rule.side_effect = ClientError(error_content, 'delete_topic_rule')
+        result = salt_states['boto_iot.topic_rule_absent']('test', topic_rule_ret['ruleName'])
+        self.assertFalse(result['result'])
+        self.assertTrue('An error occurred' in result['comment'])
+

--- a/tests/unit/states/boto_iot_test.py
+++ b/tests/unit/states/boto_iot_test.py
@@ -46,16 +46,16 @@ conn_parameters = {'region': region, 'key': access_key, 'keyid': secret_key, 'pr
 error_message = 'An error occurred (101) when calling the {0} operation: Test-defined error'
 not_found_error = ClientError({
     'Error': {
-        'Code':'ResourceNotFoundException',
+        'Code':'ResourceNotFoundException', 
         'Message': "Test-defined error"
     }
-},'msg')
+}, 'msg')
 topic_rule_not_found_error = ClientError({
     'Error': {
-        'Code':'UnauthorizedException',
+        'Code':'UnauthorizedException', 
         'Message': "Test-defined error"
     }
-},'msg')
+}, 'msg')
 error_content = {
   'Error': {
     'Code': 101,
@@ -315,4 +315,3 @@ class BotoIoTTopicRuleTestCase(BotoIoTStateTestCaseBase, BotoIoTTestCaseMixin):
         result = salt_states['boto_iot.topic_rule_absent']('test', topic_rule_ret['ruleName'])
         self.assertFalse(result['result'])
         self.assertTrue('An error occurred' in result['comment'])
-

--- a/tests/unit/states/boto_iot_test.py
+++ b/tests/unit/states/boto_iot_test.py
@@ -99,6 +99,7 @@ if _has_required_boto():
                       ruleDisabled=True)
     principal = 'arn:aws:iot:us-east-1:1234:cert/21fc104aaaf6043f5756c1b57bda84ea8395904c43f28517799b19e4c42514'
 
+
 class BotoIoTStateTestCaseBase(TestCase):
     conn = None
 

--- a/tests/unit/states/boto_iot_test.py
+++ b/tests/unit/states/boto_iot_test.py
@@ -26,6 +26,7 @@ from unit.modules.boto_iot_test import BotoIoTTestCaseMixin
 
 # Import 3rd-party libs
 try:
+    import boto
     import boto3
     from botocore.exceptions import ClientError
     HAS_BOTO = True
@@ -39,41 +40,6 @@ except ImportError:
 # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
 required_boto3_version = '1.2.1'
 
-region = 'us-east-1'
-access_key = 'GKTADJGHEIQSXMKKRBJ08H'
-secret_key = 'askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs'
-conn_parameters = {'region': region, 'key': access_key, 'keyid': secret_key, 'profile': {}}
-error_message = 'An error occurred (101) when calling the {0} operation: Test-defined error'
-not_found_error = ClientError({
-    'Error': {
-        'Code': 'ResourceNotFoundException',
-        'Message': "Test-defined error"
-    }
-}, 'msg')
-topic_rule_not_found_error = ClientError({
-    'Error': {
-        'Code': 'UnauthorizedException',
-        'Message': "Test-defined error"
-    }
-}, 'msg')
-error_content = {
-  'Error': {
-    'Code': 101,
-    'Message': "Test-defined error"
-  }
-}
-policy_ret = dict(policyName='testpolicy',
-                  policyDocument='{"Version": "2012-10-17", "Statement": [{"Action": ["iot:Publish"], "Resource": ["*"], "Effect": "Allow"}]}',
-                  policyArn='arn:aws:iot:us-east-1:123456:policy/my_policy',
-                  policyVersionId=1,
-                  defaultVersionId=1)
-topic_rule_ret = dict(ruleName='testrule',
-                  sql="SELECT * FROM 'iot/test'",
-                  description='topic rule description',
-                  createdAt='1970-01-01',
-                  actions=[{'iot': {'functionArn': 'arn:aws:::function'}}],
-                  ruleDisabled=True)
-principal = 'arn:aws:iot:us-east-1:1234:cert/21fc104aaaf6043f5756c1b57bda84ea8395904c43f28517799b19e4c42514'
 log = logging.getLogger(__name__)
 
 opts = salt.config.DEFAULT_MINION_OPTS
@@ -96,6 +62,42 @@ def _has_required_boto():
     else:
         return True
 
+if _has_required_boto():
+    region = 'us-east-1'
+    access_key = 'GKTADJGHEIQSXMKKRBJ08H'
+    secret_key = 'askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs'
+    conn_parameters = {'region': region, 'key': access_key, 'keyid': secret_key, 'profile': {}}
+    error_message = 'An error occurred (101) when calling the {0} operation: Test-defined error'
+    not_found_error = ClientError({
+        'Error': {
+            'Code': 'ResourceNotFoundException',
+            'Message': "Test-defined error"
+        }
+    }, 'msg')
+    topic_rule_not_found_error = ClientError({
+        'Error': {
+            'Code': 'UnauthorizedException',
+            'Message': "Test-defined error"
+        }
+    }, 'msg')
+    error_content = {
+      'Error': {
+        'Code': 101,
+        'Message': "Test-defined error"
+      }
+    }
+    policy_ret = dict(policyName='testpolicy',
+                      policyDocument='{"Version": "2012-10-17", "Statement": [{"Action": ["iot:Publish"], "Resource": ["*"], "Effect": "Allow"}]}',
+                      policyArn='arn:aws:iot:us-east-1:123456:policy/my_policy',
+                      policyVersionId=1,
+                      defaultVersionId=1)
+    topic_rule_ret = dict(ruleName='testrule',
+                      sql="SELECT * FROM 'iot/test'",
+                      description='topic rule description',
+                      createdAt='1970-01-01',
+                      actions=[{'iot': {'functionArn': 'arn:aws:::function'}}],
+                      ruleDisabled=True)
+    principal = 'arn:aws:iot:us-east-1:1234:cert/21fc104aaaf6043f5756c1b57bda84ea8395904c43f28517799b19e4c42514'
 
 class BotoIoTStateTestCaseBase(TestCase):
     conn = None

--- a/tests/unit/states/boto_iot_test.py
+++ b/tests/unit/states/boto_iot_test.py
@@ -21,7 +21,7 @@ import logging
 # Import Mock libraries
 from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
 
-# pylint: disable=import-error,no-name-in-module
+# pylint: disable=import-error,no-name-in-module,unused-import
 from unit.modules.boto_iot_test import BotoIoTTestCaseMixin
 
 # Import 3rd-party libs
@@ -33,7 +33,7 @@ try:
 except ImportError:
     HAS_BOTO = False
 
-# pylint: enable=import-error,no-name-in-module
+# pylint: enable=import-error,no-name-in-module,unused-import
 
 # the boto_iot module relies on the connect_to_region() method
 # which was added in boto 2.8.0


### PR DESCRIPTION
This change adds support for using Salt to manage Amazon's IoT service. It manages policies and topic rules. As implemented, it doesn't manage "Things" since that's seen as more of a run time operation; it's analogous to managing a database schema, and not trying to manage the rows in the database.

This follows the boto3-based model put in place by boto_lambda.
