### PR TITLE
modules.parted: __virtual__ return err msg.

### DIFF
--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -49,13 +49,17 @@ def __virtual__():
     These are usually provided by the ``parted`` and ``util-linux`` packages.
     '''
     if salt.utils.is_windows():
-        return False
+        return (False, 'The parted execution module failed to load '
+                'Windows systems are not supported.')
     if not salt.utils.which('parted'):
-        return False
+        return (False, 'The parted execution module failed to load '
+                'parted binary is not in the path.')
     if not salt.utils.which('lsblk'):
-        return False
+        return (False, 'The parted execution module failed to load '
+                'lsblk binary is not in the path.')
     if not salt.utils.which('partprobe'):
-        return False
+        return (False, 'The parted execution module failed to load '
+                'partprobe binary is not in the path.')
     return __virtualname__
 
 

--- a/tests/unit/modules/parted_test.py
+++ b/tests/unit/modules/parted_test.py
@@ -41,25 +41,29 @@ class PartedTestCase(TestCase):
     def test_virtual_bails_on_windows(self):
         '''If running windows, __virtual__ shouldn't register module'''
         ret = parted.__virtual__()
-        self.assertFalse(ret)
+        err = (False, 'The parted execution module failed to load Windows systems are not supported.')
+        self.assertEqual(err, ret)
 
     @patch('salt.utils.which', lambda exe: not exe == "parted")
     def test_virtual_bails_without_parted(self):
         '''If parted not in PATH, __virtual__ shouldn't register module'''
         ret = parted.__virtual__()
-        self.assertFalse(ret)
+        err = (False, 'The parted execution module failed to load parted binary is not in the path.')
+        self.assertEqual(err, ret)
 
     @patch('salt.utils.which', lambda exe: not exe == "lsblk")
     def test_virtual_bails_without_lsblk(self):
         '''If lsblk not in PATH, __virtual__ shouldn't register module'''
         ret = parted.__virtual__()
-        self.assertFalse(ret)
+        err = (False, 'The parted execution module failed to load lsblk binary is not in the path.')
+        self.assertEqual(err, ret)
 
     @patch('salt.utils.which', lambda exe: not exe == "partprobe")
     def test_virtual_bails_without_partprobe(self):
         '''If partprobe not in PATH, __virtual__ shouldn't register module'''
         ret = parted.__virtual__()
-        self.assertFalse(ret)
+        err = (False, 'The parted execution module failed to load partprobe binary is not in the path.')
+        self.assertEqual(err, ret)
 
     @patch('salt.utils.is_windows', lambda: False)
     @patch('salt.utils.which',


### PR DESCRIPTION
Updated message when module is not supported based on systems or available binaries.
