### PR TITLE
Fixes wrong function scope

### DIFF
--- a/salt/modules/win_update.py
+++ b/salt/modules/win_update.py
@@ -295,7 +295,7 @@ class PyWinUpdater(object):
             if update.InstallationBehavior.CanRequestUserInput:
                 log.debug('Skipped update {0}'.format(str(update)))
                 continue
-            updates.append(salt.utils.sdecode(update))
+            updates.append(salt.utils.locales.sdecode(update))
             log.debug('added update {0}'.format(str(update)))
         return updates
 


### PR DESCRIPTION
`sdecode` is not in `salt.utils` but rather in `salt.utils.locales`.

This causes Python to throw an exception when executing
 `# salt <hostname> win_update.list_updates verbose`

```
The minion function caused an exception: Traceback (most recent call last):
  File "c:\salt\bin\lib\site-packages\salt\minion.py", line 1036, in _thread_return
    return_data = func(*args, **kwargs)
  File "c:\salt\bin\lib\site-packages\salt\modules\win_update.py", line 512, in list_updates
    return str(quidditch.GetSearchResultsPretty())
  File "c:\salt\bin\lib\site-packages\salt\modules\win_update.py", line 310, in GetSearchResultsPretty
    updates = self.GetSearchResults()
  File "c:\salt\bin\lib\site-packages\salt\modules\win_update.py", line 305, in GetSearchResults
    updates.append(salt.utils.sdecode(update))
AttributeError: 'module' object has no attribute 'sdecode'
```
