### PR TITLE
Don't load minion opts in a master

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -560,10 +560,10 @@ class MasterMinion(object):
             rend=True,
             matcher=True,
             whitelist=None):
-        self.opts = salt.config.minion_config(opts['conf_file'])
+        self.opts = salt.config.master_config(opts['conf_file'])
         self.opts.update(opts)
         self.whitelist = whitelist
-        self.opts['grains'] = salt.loader.grains(opts)
+        self.opts['grains'] = {}
         self.opts['pillar'] = {}
         self.mk_returners = returners
         self.mk_states = states


### PR DESCRIPTION
There should be no need to load grains into a master process. This is expensive and time-consuming. Additionally, it attempts to parse the minion config file which should never be necessary for a master.

Closes #29831
