### PR TITLE
Ignore trailing whitespace in certificate file.

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -871,7 +871,7 @@ def pem_finger(path=None, key=None, sum_type='md5'):
             return ''
 
         with fopen(path, 'rb') as fp_:
-            key = ''.join(fp_.readlines()[1:-1])
+            key = ''.join([x for x in fp_.readlines() if x.strip()][1:-1])
 
     pre = getattr(hashlib, sum_type)(key).hexdigest()
     finger = ''


### PR DESCRIPTION
Fixes #30078 

Simply strips the whitespace before removing the first and last element of the list - which should correspond the `-----BEGIN PUBLIC KEY-----` and `-----END PUBLIC KEY-----` lines if everything went to plan.

Unfortunately, prior to this patch, a trailing line containing only whitespace would be removed instead of the `-----END PUBLIC KEY-----` line, causing the computed hash to be invalid.
