### PR TITLE
Fixed saltversioninfo grain return

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1684,7 +1684,7 @@ def saltversioninfo():
     # Provides:
     #   saltversioninfo
     from salt.version import __version_info__
-    return {'saltversioninfo': __version_info__}
+    return {'saltversioninfo': list(__version_info__)}
 
 
 def _hw_data(osdata):


### PR DESCRIPTION
Looks like saltversioninfo is ruturning a string so there is no way to get values
by index. Updated return value to list.

Fixes #28763.
