### PR TITLE
Add the list_nodes_select function to linode driver

### DIFF
--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -1076,6 +1076,15 @@ def list_nodes_min(call=None):
     return ret
 
 
+def list_nodes_select(call=None):
+    '''
+    Return a list of the VMs that are on the provider, with select fields.
+    '''
+    return salt.utils.cloud.list_nodes_select(
+        list_nodes_full(), __opts__['query.selection'], call,
+    )
+
+
 def reboot(name, call=None):
     '''
     Reboot a linode.


### PR DESCRIPTION
All salt-cloud drivers are supposed to have this function, but it was missing from the linode driver.
