### PR TITLE
Add rm_special to crontab module

### DIFF
--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -480,6 +480,15 @@ def set_job(user,
 
 
 def rm_special(user, special, cmd):
+    '''
+    Remove a special cron job for a specified user.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cron.rm_job root @hourly /usr/bin/foo
+    '''
     lst = list_tab(user)
     ret = 'absent'
     rm_ = None

--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -479,6 +479,24 @@ def set_job(user,
     return 'new'
 
 
+def rm_special(user, special, cmd):
+    lst = list_tab(user)
+    ret = 'absent'
+    rm_ = None
+    for ind in range(len(lst['special'])):
+        if lst['special'][ind]['cmd'] == cmd and \
+                lst['special'][ind]['spec'] == special:
+            lst['special'].pop(ind)
+            rm_ = ind
+    if rm_ is not None:
+        ret = 'removed'
+        comdat = _write_cron_lines(user, _render_tab(lst))
+        if comdat['retcode']:
+            # Failed to commit
+            return comdat['stderr']
+    return ret
+
+
 def rm_job(user,
            cmd,
            minute=None,


### PR DESCRIPTION
There is no way to remove a special cron entry. This adds a new function called `rm_special` to compliment the `set_special` function in the cron execution module.

Closes #28171
