### PR TITLE
Update call to sdecode for new location

### DIFF
--- a/salt/modules/win_update.py
+++ b/salt/modules/win_update.py
@@ -29,8 +29,8 @@ except ImportError:
 # pylint: enable=import-error
 
 # Import salt libs
-from salt.utils.locales import sdecode
 import salt.utils
+import salt.utils.locales
 
 log = logging.getLogger(__name__)
 

--- a/salt/modules/win_update.py
+++ b/salt/modules/win_update.py
@@ -29,6 +29,7 @@ except ImportError:
 # pylint: enable=import-error
 
 # Import salt libs
+from salt.utils.locales import sdecode
 import salt.utils
 
 log = logging.getLogger(__name__)
@@ -302,7 +303,7 @@ class PyWinUpdater(object):
             if update.InstallationBehavior.CanRequestUserInput:
                 log.debug('Skipped update {0}'.format(str(update)))
                 continue
-            updates.append(salt.utils.sdecode(update))
+            updates.append(salt.utils.locales.sdecode(update))
             log.debug('added update {0}'.format(str(update)))
         return updates
 


### PR DESCRIPTION
sdecode was moved from utils to utils.locales so win_update needs
to reference the new location for the verbose reture to work.

Fixes issue #30092.
