### PR TITLE
Fixed flag sent to salt.utils.http in order for verify_ssl to work correctly

### DIFF
--- a/salt/cloud/clouds/joyent.py
+++ b/salt/cloud/clouds/joyent.py
@@ -1069,7 +1069,7 @@ def query(action=None,
         text=True,
         status=True,
         headers=True,
-        verify=verify_ssl,
+        verify_ssl=verify_ssl,
         opts=__opts__,
     )
     log.debug(


### PR DESCRIPTION
I couldn't locate an issue, so none is linked. 
An inappropriate flag was being send to salt.utils.http ("verify" was being sent instead of "verify_ssl"). I tested it functionally in my lab environment that doesn't use a valid ssl cert and it behaved appropriately.
