### PR TITLE
Added a tag to the event that is generated by the beacon for journald

### DIFF
--- a/salt/beacons/journald.py
+++ b/salt/beacons/journald.py
@@ -91,5 +91,7 @@ def beacon(config):
                         n_flag += 1
             if n_flag == len(config[name]):
                 # Match!
-                ret.append(salt.utils.cloud.simple_types_filter(cur))
+                sub = salt.utils.cloud.simple_types_filter(cur)
+                sub.update({'tag': name})
+                ret.append(sub)
     return ret


### PR DESCRIPTION
From the docu:

```
beacons:
  journald:
    sshd:
      SYSLOG_IDENTIFIER: sshd
      PRIORITY: 6
```

Currently the event has an ambigous tag like
`"tag": "salt/beacon/minion/journald/"`
which is the same for all journald beacon events.

This pull request appends the tag to
`"tag": "salt/beacon/minion/journald/sshd"`

The `sshd` comes from line 3 in my pasted documentation excerpt, and is not the SYSLOG_IDENTIFIER.
