### PR TITLE
State mock

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -568,12 +568,14 @@ def highstate(test=None,
                                    pillar,
                                    kwargs.get('__pub_jid'),
                                    pillar_enc=pillar_enc,
-                                   proxy=__proxy__)
+                                   proxy=__proxy__,
+                                   mock=kwargs.get('mock', False))
     except NameError:
         st_ = salt.state.HighState(opts,
                                    pillar,
                                    kwargs.get('__pub_jid'),
-                                   pillar_enc=pillar_enc)
+                                   pillar_enc=pillar_enc,
+                                   mock=kwargs.get('mock', False))
 
     st_.push_active()
     try:

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -574,13 +574,13 @@ def highstate(test=None,
                                    kwargs.get('__pub_jid'),
                                    pillar_enc=pillar_enc,
                                    proxy=__proxy__,
-                                   mock=kwargs.get('mock', False))
+                                   mocked=kwargs.get('mock', False))
     except NameError:
         st_ = salt.state.HighState(opts,
                                    pillar,
                                    kwargs.get('__pub_jid'),
                                    pillar_enc=pillar_enc,
-                                   mock=kwargs.get('mock', False))
+                                   mocked=kwargs.get('mock', False))
 
     st_.push_active()
     try:
@@ -764,13 +764,13 @@ def sls(mods,
                                    kwargs.get('__pub_jid'),
                                    pillar_enc=pillar_enc,
                                    proxy=__proxy__,
-                                   mock=kwargs.get('mock', False))
+                                   mocked=kwargs.get('mock', False))
     except NameError:
         st_ = salt.state.HighState(opts,
                                    pillar,
                                    kwargs.get('__pub_jid'),
                                    pillar_enc=pillar_enc,
-                                   mock=kwargs.get('mock', False))
+                                   mocked=kwargs.get('mock', False))
 
     umask = os.umask(0o77)
     if kwargs.get('cache'):

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -504,6 +504,11 @@ def highstate(test=None,
         "roots" of salt directories (with their own minion config, pillars,
         file_roots) to run highstate out of.
 
+    mock:
+        The mock option allows for the state run to execute without actually
+        calling any states. This then returns a mocked return which will show
+        the requisite ordering as well as fully validate the state run.
+
     CLI Example:
 
     .. code-block:: bash
@@ -666,6 +671,11 @@ def sls(mods,
         "roots" of salt directories (with their own minion config, pillars,
         file_roots) to run highstate out of.
 
+    mock:
+        The mock option allows for the state run to execute without actually
+        calling any states. This then returns a mocked return which will show
+        the requisite ordering as well as fully validate the state run.
+
     CLI Example:
 
     .. code-block:: bash
@@ -753,12 +763,14 @@ def sls(mods,
                                    pillar,
                                    kwargs.get('__pub_jid'),
                                    pillar_enc=pillar_enc,
-                                   proxy=__proxy__)
+                                   proxy=__proxy__,
+                                   mock=kwargs.get('mock', False))
     except NameError:
         st_ = salt.state.HighState(opts,
                                    pillar,
                                    kwargs.get('__pub_jid'),
-                                   pillar_enc=pillar_enc)
+                                   pillar_enc=pillar_enc,
+                                   mock=kwargs.get('mock', False))
 
     umask = os.umask(0o77)
     if kwargs.get('cache'):

--- a/salt/state.py
+++ b/salt/state.py
@@ -264,8 +264,8 @@ def ishashable(obj):
 
 def mock_ret(cdata):
     '''
-    Returns a mocked return dict with inforwation about therun without
-    executing
+    Returns a mocked return dict with information about the run, without
+    executing the state function
     '''
     # As this is expanded it should be sent into the execution module
     # layer or it should be turned into a standalone loader system

--- a/salt/state.py
+++ b/salt/state.py
@@ -269,10 +269,14 @@ def mock_ret(cdata):
     '''
     # As this is expanded it should be sent into the execution module
     # layer or it should be turned into a standalone loader system
-    return = {'name': cdata['name'],
-              'comment': 'Not called, mocked',
-              'changes': {},
-              'result': True}
+    if cdata['args']:
+        name = cdata['args'][0]
+    else:
+        name = cdata['kwargs']['name']
+    return {'name': name,
+            'comment': 'Not called, mocked',
+            'changes': {},
+            'result': True}
 
 
 class StateError(Exception):

--- a/salt/state.py
+++ b/salt/state.py
@@ -623,7 +623,7 @@ class State(object):
     '''
     Class used to execute salt states
     '''
-    def __init__(self, opts, pillar=None, jid=None, pillar_enc=None, proxy=None, mock=False):
+    def __init__(self, opts, pillar=None, jid=None, pillar_enc=None, proxy=None, mocked=False):
         if 'grains' not in opts:
             opts['grains'] = salt.loader.grains(opts)
         self.opts = opts
@@ -650,7 +650,7 @@ class State(object):
         self.jid = jid
         self.instance_id = str(id(self))
         self.inject_globals = {}
-        self.mock = mock
+        self.mocked = mocked
 
     def _decrypt_pillar_override(self):
         '''
@@ -1675,7 +1675,7 @@ class State(object):
 
             if 'result' not in ret or ret['result'] is False:
                 self.states.inject_globals = inject_globals
-                if self.mock:
+                if self.mocked:
                     ret = mock_ret(cdata)
                 else:
                     ret = self.states[cdata['full']](*cdata['args'],
@@ -3259,11 +3259,11 @@ class HighState(BaseHighState):
     # a stack of active HighState objects during a state.highstate run
     stack = []
 
-    def __init__(self, opts, pillar=None, jid=None, pillar_enc=None, proxy=None, mock=False):
+    def __init__(self, opts, pillar=None, jid=None, pillar_enc=None, proxy=None, mocked=False):
         self.opts = opts
         self.client = salt.fileclient.get_file_client(self.opts)
         BaseHighState.__init__(self, opts)
-        self.state = State(self.opts, pillar, jid, pillar_enc, proxy=proxy, mock=mock)
+        self.state = State(self.opts, pillar, jid, pillar_enc, proxy=proxy, mocked=mocked)
         self.matcher = salt.minion.Matcher(self.opts)
 
         # tracks all pydsl state declarations globally across sls files


### PR DESCRIPTION
This adds the "mock" option to state.sls and state.highstate. This allows for the state to be run without calling anything. The returned data is the return as if the states all ran successfully.

What would be nice to have here would be the ability to make mock states so that you could program what the mocked returns would look like.
