### PR TITLE
Update regex to detect ip alias in OpenBSD.

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -537,7 +537,7 @@ def _interfaces_ifconfig(out):
         pip6 = re.compile('.*?(?:inet6 )([0-9a-fA-F:]+)')
         pmask6 = re.compile(r'.*?(?:inet6 [0-9a-fA-F:]+/(\d+)).*')
     else:
-        pip = re.compile(r'.*?(?:inet addr:|inet )(.*?)\s')
+        pip = re.compile(r'.*?(?:inet addr:|inet [^\d]*)(.*?)\s')
         pip6 = re.compile('.*?(?:inet6 addr: (.*?)/|inet6 )([0-9a-fA-F:]+)')
         pmask6 = re.compile(r'.*?(?:inet6 addr: [0-9a-fA-F:]+/(\d+)|prefixlen (\d+))(?: Scope:([a-zA-Z]+)| scopeid (0x[0-9a-fA-F]))?')
     pmask = re.compile(r'.*?(?:Mask:|netmask )(?:((?:0x)?[0-9a-fA-F]{8})|([\d\.]+))')


### PR DESCRIPTION
As suggested by @iMilnb regex updated. The other way around is fix this would be
to use the same approach as for Solaris systems adding a elif statement when system
is OpenBSD.

Fixes #29833.
