### PR TITLE
Updating documentation and example minion config for random_master/master_shuffle.

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -20,7 +20,11 @@
 # set to True, the order will be randomized instead. This can be helpful in distributing
 # the load of many minions executing salt-call requests, for example, from a cron job.
 # If only one master is listed, this setting is ignored and a warning will be logged.
+# NOTE: If master_type is set to failover, use master_shuffle instead.
 #random_master: False
+
+# Use if master_type is set to failover.
+#master_shuffle: False
 
 # Minions can connect to multiple masters simultaneously (all masters
 # are "hot"), or can be configured to failover if a master becomes

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -125,13 +125,26 @@ to the next master in the list if it finds the existing one is dead.
 
 Default: ``False``
 
-If :conf_minion:`master` is a list of addresses, shuffle them before trying to
+If :conf_minion:`master` is a list of addresses and :conf_minion`master_type` is ``failover``, shuffle them before trying to
 connect to distribute the minions over all available masters. This uses
 Python's :func:`random.shuffle <python2:random.shuffle>` method.
 
 .. code-block:: yaml
 
     master_shuffle: True
+
+``random_master``
+------------------
+
+Default: ``False``
+
+If :conf_minion:`master` is a list of addresses, shuffle them before trying to
+connect to distribute the minions over all available masters. This uses
+Python's :func:`random.randint <python2:random.randint>` method.
+
+.. code-block:: yaml
+
+    random_master: True
 
 .. conf_minion:: retry_dns
 


### PR DESCRIPTION
Pending the resolution of #10155 this pull request updates the documentation to make the function of the two similar master selection settings more clear.

Added random_master to reference and updating master_shuffle.
Added master_shuffle to the minion example config file as it is needed for multi-master PKI.
