### PR TITLE
Log retryable transport errors as warnings

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -1097,12 +1097,17 @@ class RemoteClient(Client):
                 fn_.write(data)
             except (TypeError, KeyError) as e:
                 transport_tries += 1
-                log.error('Data transport is broken, got: {0}, type: {1}, '
-                          'exception: {2}, attempt {3} of 3'.format(
-                              data, type(data), e, transport_tries)
-                          )
+                log.warning('Data transport is broken, got: {0}, type: {1}, '
+                            'exception: {2}, attempt {3} of 3'.format(
+                                data, type(data), e, transport_tries)
+                            )
                 self._refresh_channel()
                 if transport_tries > 3:
+                    log.error('Data transport is broken, got: {0}, type: {1}, '
+                              'exception: {2}, '
+                              'Retry attempts exhausted'.format(
+                                data, type(data), e)
+                            )
                     break
 
         if fn_:


### PR DESCRIPTION
This error reached our monitoring system:

```
Jan 03 05:09:56.719 [ERROR:fileclient.py:1102]: Data transport is broken, got: {'hsum': 'd3b07384d113edec49eaa6238ad5ff00', 'hash_type': 'md5'}, type: <type 'dict'>, exception: 'data', attempt 1 of 3
```

Given that this failure is going to be immediately retried, logging this at `error` is inappropriately severe.  This PR makes the original `error` a `warning`, with an `error` log message generated when retry attempts are exhausted.
