### PR TITLE
Fix typo in gpgkey URL

### DIFF
--- a/doc/topics/installation/rhel.rst
+++ b/doc/topics/installation/rhel.rst
@@ -58,7 +58,7 @@ To install using the SaltStack repository:
        baseurl=https://repo.saltstack.com/yum/redhat/$releasever/$basearch/latest
        enabled=1
        gpgcheck=1
-       gpgkey=https://repo.saltstack.com/yum/redhat/$releasever/$basearch/latest/$releaseverSALTSTACK-GPG-KEY.pub
+       gpgkey=https://repo.saltstack.com/yum/redhat/$releasever/$basearch/latest/SALTSTACK-GPG-KEY.pub
 
    Version 5:
 


### PR DESCRIPTION
Fixes following error on yum update:

```
Retrieving key from
https://repo.saltstack.com/yum/redhat/6/x86_64/latest/$releaseverSALTSTACK-GPG-KEY.pub

GPG key retrieval failed: [Errno 14] PYCURL ERROR 22 - "The requested
URL returned error: 404 Not Found"
```
