### PR TITLE
modules.oracle: __virtual__ return err msg.

### DIFF
--- a/salt/modules/oracle.py
+++ b/salt/modules/oracle.py
@@ -54,7 +54,10 @@ def __virtual__():
     '''
     Load module only if cx_Oracle installed
     '''
-    return __virtualname__ if HAS_CX_ORACLE else False
+    if HAS_CX_ORACLE:
+        return __virtualname__
+    return (False, 'The oracle execution module not loaded: '
+            'python oracle library not found.')
 
 
 def _cx_oracle_req():


### PR DESCRIPTION
Updated message in **virtual** when python oracle library is not present.
