### PR TITLE
modules.opkg: __virtual__ return err msg.

### DIFF
--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -47,7 +47,7 @@ def __virtual__():
     '''
     if __grains__.get('os_family', False) == 'NILinuxRT':
         return __virtualname__
-    return False
+    return (False, "Module opkg only works on nilrt based systems")
 
 
 def latest_version(*names, **kwargs):


### PR DESCRIPTION
Updated message in **virtual** when system is not based on nilrt.
