### PR TITLE
Fix dockerng.push, and allow for multiple images

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -1033,28 +1033,18 @@ def _push_status(data, item):
     '''
     Process a status update from a docker push, updating the data structure
     '''
-    status = item['status']
+    status = item['status'].lower()
     if 'id' in item:
-        if 'already pushed' in status:
+        if 'already pushed' in status or 'already exists' in status:
             # Layer already exists
             already_pushed = data.setdefault('Layers', {}).setdefault(
                 'Already_Pushed', [])
             already_pushed.append(item['id'])
-        elif 'successfully pushed' in status:
+        elif 'successfully pushed' in status or status == 'pushed':
             # Pushed a new layer
             pushed = data.setdefault('Layers', {}).setdefault(
                 'Pushed', [])
             pushed.append(item['id'])
-    else:
-        try:
-            image_id = re.match(
-                r'Pushing tags? for rev \[([0-9a-f]+)',
-                status
-            ).group(1)
-        except AttributeError:
-            return
-        else:
-            data['Id'] = image_id
 
 
 def _error_detail(data, item):
@@ -3893,12 +3883,20 @@ def push(image,
          api_response=False,
          client_timeout=CLIENT_TIMEOUT):
     '''
+    .. versionchanged:: 2015.8.4
+        The ``Id`` and ``Image`` keys are no longer present in the return data.
+        This is due to changes in the Docker Remote API.
+
     Pushes an image to a Docker registry. See the documentation at top of this
     page to configure authenticated access.
 
     image
-        Image to be pushed, in ``repo:tag`` notation. If just the repository
-        name is passed, a tag name of ``latest`` will be assumed.
+        Image to be pushed, in ``repo:tag`` notation.
+
+        .. versionchanged:: 2015.8.4
+            If just the repository name is passed, then all tagged images for
+            the specified repo will be pushed. In prior releases, a tag of
+            ``latest`` was assumed if the tag was omitted.
 
     insecure_registry : False
         If ``True``, the Docker client will permit the use of insecure
@@ -3917,8 +3915,6 @@ def push(image,
 
     A dictionary will be returned, containing the following keys:
 
-    - ``Id`` - ID of the image that was pushed
-    - ``Image`` - Name of the image that was pushed
     - ``Layers`` - A dictionary containing one or more of the following keys:
         - ``Already_Pushed`` - Layers that that were already present on the
           Minion
@@ -3933,7 +3929,14 @@ def push(image,
         salt myminion dockerng.push myuser/mycontainer
         salt myminion dockerng.push myuser/mycontainer:mytag
     '''
-    repo_name, repo_tag = _get_repo_tag(image)
+    if ':' in image:
+        repo_name, repo_tag = _get_repo_tag(image)
+    else:
+        repo_name = image
+        repo_tag = None
+        log.info('Attempting to push all tagged images matching {0}'
+                 .format(repo_name))
+
     kwargs = {'tag': repo_tag,
               'stream': True,
               'client_auth': True,
@@ -3966,17 +3969,6 @@ def push(image,
         elif item_type == 'errorDetail':
             _error_detail(errors, item)
 
-    if 'Id' not in ret:
-        # API returned information, but there was no confirmation of a
-        # successful push.
-        msg = 'Push failed for {0}'.format(image)
-        if errors:
-            msg += '. Error(s) follow:\n\n{0}'.format(
-                '\n\n'.join(errors)
-            )
-        raise CommandExecutionError(msg)
-
-    ret['Image'] = '{0}:{1}'.format(repo_name, repo_tag)
     return ret
 
 


### PR DESCRIPTION
When I wrote dockerng, I was scraping the API response for the ID of the
image specified in the docker 'push' command. This information is no
longer present in the Docker Remote API response, which makes the
function think that the push failed when it did not.

This commit removes the `Id` and `Image` keys from the return
dictionary, as they can no longer reliably be determined from the API
response without it being some sort of hack that will no doubt be broken
the next time Docker decides to change their API.

Not only that, but the status message used to detect a pushed or
already-present layer has also been changed, which necessitated a fix in
`_push_status()`.

This also resolves #29994 by allowing the user to push all tags for a
given repo by omitting the tag.

This also fixes #29993.
