### PR TITLE
Documentation fix for parted module

### DIFF
--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -640,6 +640,9 @@ def set_(device, minor, flag, state):
         "on" or "off". Some or all of these flags will be available, depending
         on what disk label you are using.
 
+    Valid flags are: bios_grub, legacy_boot, boot, lba, root, swap, hidden, raid,
+        LVM, PALO, PREP, DIAG
+
     CLI Example:
 
     .. code-block:: bash
@@ -671,13 +674,14 @@ def toggle(device, partition, flag):
     '''
     partition.toggle device partition flag
 
-    Toggle the state of <flag> on <partition>
+    Toggle the state of <flag> on <partition>. Valid flags are the same as 
+        the set command.
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' partition.name /dev/sda 1 boot
+        salt '*' partition.toggle /dev/sda 1 boot
     '''
     _validate_device(device)
 

--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -674,7 +674,7 @@ def toggle(device, partition, flag):
     '''
     partition.toggle device partition flag
 
-    Toggle the state of <flag> on <partition>. Valid flags are the same as 
+    Toggle the state of <flag> on <partition>. Valid flags are the same as
         the set command.
 
     CLI Example:


### PR DESCRIPTION
I noticed the sample command for the partition.toggle command was wrong. I fixed it and added the valid flags for easier reference for others.
