### PR TITLE
Update boto_secgroup and boto_iam_role docs to only use region OR profile

### DIFF
--- a/salt/states/boto_iam_role.py
+++ b/salt/states/boto_iam_role.py
@@ -63,16 +63,15 @@ with the role. This is the default behavior of the AWS console.
     # Using a credentials profile from pillars
     myrole:
         boto_iam_role.present:
-            - region: us-east-1
             - profile: myiamprofile
 
     # Passing in a credentials profile
     myrole:
         boto_iam_role.present:
-            - region: us-east-1
             - profile:
                 key: GKTADJGHEIQSXMKKRBJ08H
                 keyid: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+                region: us-east-1
 
 If ``delete_policies: False`` is specified, existing policies that are not in
 the given list of policies will not be deleted. This allows manual modifications

--- a/salt/states/boto_secgroup.py
+++ b/salt/states/boto_secgroup.py
@@ -67,7 +67,6 @@ passed in as a dict, or as a string to pull from pillars or minion config:
         boto_secgroup.present:
             - name: mysecgroup
             - description: My security group
-            - region: us-east-1
             - profile: myprofile
 
     # Passing in a profile
@@ -75,10 +74,10 @@ passed in as a dict, or as a string to pull from pillars or minion config:
         boto_secgroup.present:
             - name: mysecgroup
             - description: My security group
-            - region: us-east-1
             - profile:
                 keyid: GKTADJGHEIQSXMKKRBJ08H
                 key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+                region: us-east-1
 '''
 from __future__ import absolute_import
 
@@ -149,7 +148,7 @@ def present(
 
     profile
         A dict with region, key and keyid, or a pillar key (string)
-        that contains a dict with region, key and keyid.
+        that contains a dict with region, key, and keyid.
     '''
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     _ret = _security_group_present(name, description, vpc_id, vpc_name, region, key,


### PR DESCRIPTION
If you specify a profile, you need to have key, keyid, and region set within
the profile. If region is set outside of the profile group, it is ignored,
and a default region is used.

This pull request updates the docs to model this usage correctly.

Refs #29078.
