### PR TITLE
Move _option(value) calls to __salt__['config.option'] in boto utils

### DIFF
--- a/salt/utils/boto.py
+++ b/salt/utils/boto.py
@@ -79,39 +79,26 @@ def __virtual__():
         return True
 
 
-def _option(value):
-    '''
-    Look up the value for an option.
-    '''
-    if value in __opts__:
-        return __opts__[value]
-    master_opts = __pillar__.get('master', {})
-    if value in master_opts:
-        return master_opts[value]
-    if value in __pillar__:
-        return __pillar__[value]
-
-
 def _get_profile(service, region, key, keyid, profile):
     if profile:
         if isinstance(profile, string_types):
-            _profile = _option(profile)
+            _profile = __salt__['config.option'](profile)
         elif isinstance(profile, dict):
             _profile = profile
         key = _profile.get('key', None)
         keyid = _profile.get('keyid', None)
         region = _profile.get('region', None)
 
-    if not region and _option(service + '.region'):
-        region = _option(service + '.region')
+    if not region and __salt__['config.option'](service + '.region'):
+        region = __salt__['config.option'](service + '.region')
 
     if not region:
         region = 'us-east-1'
 
-    if not key and _option(service + '.key'):
-        key = _option(service + '.key')
-    if not keyid and _option(service + '.keyid'):
-        keyid = _option(service + '.keyid')
+    if not key and __salt__['config.option'](service + '.key'):
+        key = __salt__['config.option'](service + '.key')
+    if not keyid and __salt__['config.option'](service + '.keyid'):
+        keyid = __salt__['config.option'](service + '.keyid')
 
     label = 'boto_{0}:'.format(service)
     if keyid:


### PR DESCRIPTION
Removed the `_option` function and replaced it with `__salt__['config.option']` - the former isn't a complete offering of finding pillar lookups.

Refs #29905
