### PR TITLE
Add warning about using "=" in file.line function

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1452,6 +1452,15 @@ def line(path, content, match=None, mode=None, location=None,
     :param indent
         Keep indentation with the previous line.
 
+    If an equal sign (``=``) appears in an argument to a Salt command, it is
+    interpreted as a keyword argument in the format of ``key=val``. That
+    processing can be bypassed in order to pass an equal sign through to the
+    remote shell command by manually specifying the kwarg:
+
+    .. code-block:: bash
+
+        salt '*' file.line /path/to/file content="CREATEMAIL_SPOOL=no" match="CREATE_MAIL_SPOOL=yes" mode="replace"
+
     CLI Examples:
 
     .. code-block:: bash


### PR DESCRIPTION
Warnings for passing kwargs with equal signs as part of the value
exist in other file.x functions, but was missing for the file.line
execution module function. This adds the relevant warning.

Fixes #28923
