### PR TITLE
adding split_env call to cp.hash_file to pick up saltenv in file quer…

### DIFF
--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -656,6 +656,10 @@ def hash_file(path, saltenv='base', env=None):
         # Backwards compatibility
         saltenv = env
 
+    path, senv = salt.utils.url.split_env(path)
+    if senv:
+        saltenv = senv
+
     _mk_client()
     return __context__['cp.fileclient'].hash_file(path, saltenv)
 


### PR DESCRIPTION
…y parameter

fixes issue #28822
