### PR TITLE
Fix incorrect file permissions in file.line

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1459,9 +1459,9 @@ def line(path, content, match=None, mode=None, location=None,
         salt '*' file.line /etc/nsswitch.conf "networks:\tfiles dns", after="hosts:.*?", mode='ensure'
     '''
     path = os.path.realpath(os.path.expanduser(path))
-    if not os.path.exists(path):
+    if not os.path.isfile(path):
         if not quiet:
-            raise CommandExecutionError('File "{0}" does not exists.'.format(path))
+            raise CommandExecutionError('File "{0}" does not exists or is not a file.'.format(path))
         return False  # No changes had happened
 
     mode = mode and mode.lower() or mode

--- a/salt/utils/atomicfile.py
+++ b/salt/utils/atomicfile.py
@@ -12,6 +12,7 @@ import sys
 import errno
 import time
 import random
+import shutil
 import salt.ext.six as six
 
 
@@ -117,6 +118,7 @@ class _AtomicWFile(object):
         if self._fh.closed:
             return
         self._fh.close()
+        shutil.copymode(self._filename, self._tmp_filename)
         atomic_rename(self._tmp_filename, self._filename)
 
     def __exit__(self, exc_type, exc_value, traceback):


### PR DESCRIPTION
Looks like atomic_open() doesn't take care of preserving file permissions.  It will create
a new file, edit it and then move this temp file to the original file ignoring file permissions.
Also updated the check to be sure file exist and is a file. Otherwise code will try to update
directory content and will fail badly and throw a python error.

This was tested on Linux, sorry but I don't have any Windows to try it out.
Fixed #30150
