### PR TITLE
ipset: fix comment and test

### DIFF
--- a/salt/modules/ipset.py
+++ b/salt/modules/ipset.py
@@ -430,11 +430,13 @@ def check(set=None, entry=None, family='ipv4'):
     if isinstance(entry, list):
         entries = entry
     else:
-        if entry.find('-') != -1 and entry.count('-') == 1:
-            start, end = entry.split('-')
+        _entry = entry.split()[0]
+        _entry_extra = entry.split()[1:]
+        if _entry.find('-') != -1 and _entry.count('-') == 1:
+            start, end = _entry.split('-')
 
             if settype == 'hash:ip':
-                entries = [str(ipaddress.ip_address(ip)) for ip in long_range(
+                entries = [' '.join([str(ipaddress.ip_address(ip)), ' '.join(_entry_extra)]) for ip in long_range(
                     ipaddress.ip_address(start),
                     ipaddress.ip_address(end) + 1
                 )]
@@ -444,17 +446,22 @@ def check(set=None, entry=None, family='ipv4'):
                                                              ipaddress.ip_address(end))
                 entries = []
                 for network in networks:
-                    entries.append(network.with_prefixlen)
+                    _network = [str(ip) for ip in ipaddress.ip_network(network)]
+                    if len(_network) == 1:
+                        __network = ' '.join([str(_network[0]), ' '.join(_entry_extra)])
+                    else:
+                        __network = ' '.join([str(network), ' '.join(_entry_extra)])
+                    entries.append(__network)
             else:
                 entries = [entry]
 
-        elif entry.find('/') != -1 and entry.count('/') == 1:
+        elif _entry.find('/') != -1 and _entry.count('/') == 1:
             if settype == 'hash:ip':
-                entries = [str(ip) for ip in ipaddress.ip_network(entry)]
+                entries = [' '.join([str(ip), ' '.join(_entry_extra)]) for ip in ipaddress.ip_network(_entry)]
             elif settype == 'hash:net':
-                _entries = [str(ip) for ip in ipaddress.ip_network(entry)]
+                _entries = [str(ip) for ip in ipaddress.ip_network(_entry)]
                 if len(_entries) == 1:
-                    entries = [_entries[0]]
+                    entries = [' '.join([_entries[0], ' '.join(_entry_extra)])]
                 else:
                     entries = [entry]
             else:

--- a/salt/states/ipset.py
+++ b/salt/states/ipset.py
@@ -184,6 +184,7 @@ def present(name, entry=None, family='ipv4', **kwargs):
            'changes': {},
            'result': None,
            'comment': ''}
+    test_flag = False
 
     if not entry:
         ret['result'] = False
@@ -198,19 +199,25 @@ def present(name, entry=None, family='ipv4', **kwargs):
 
     for entry in entries:
         _entry = '{0}'.format(entry)
-        if 'comment' in kwargs:
-            _entry = '{0} comment "{1}"'.format(entry, kwargs['comment'])
+        if 'timeout' in kwargs:
+            if 'comment' in _entry:
+                _entry = '{0} timeout {1} {2} {3}'.format(entry.split()[0], kwargs['timeout'], entry.split()[1], entry.split()[2])
+            else:
+                _entry = '{0} timeout {1}'.format(entry.split()[0], kwargs['timeout'])
 
         if __salt__['ipset.check'](kwargs['set_name'],
                                    _entry,
                                    family) is True:
-            ret['result'] = True
+            if test_flag is False:
+                ret['result'] = True
             ret['comment'] += 'entry for {0} already in set ({1}) for {2}\n'.format(
                 entry,
                 kwargs['set_name'],
                 family)
         else:
             if __opts__['test']:
+                test_flag = True
+                ret['result'] = None
                 ret['comment'] += 'entry {0} needs to be added to set {1} for family {2}\n'.format(
                     entry,
                     kwargs['set_name'],


### PR DESCRIPTION
1.Add comment for every entry. The followings is sls config:

```
setname:
  ipset.set_present:
    - name: tt
    - set_type: hash:net
    - hashsize: 2048
    - comment: True
    - timeout: 0

entries:
  ipset.present:
    - set_name: tt
    - timeout: 0
    - entry:
        - 192.168.1.0/24 comment "hello"
        - 192.168.2.0/32 comment "hello"
```

2.fix test=True.
To avoid some diff is not reported.
For example, the machine has entries: ["192.168.1.1"]. the sls config's entry: ["192.168.1.1, 192.168.1.2"]
