### PR TITLE
Add grains_cache: True to salt-ssh

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -703,8 +703,7 @@ class Single(object):
                 'identities_only': identities_only}
         # Pre apply changeable defaults
         self.minion_opts = {
-                    'grains_cache': self.opts.get('grains_cache', True),
-                    'grains_cache_expiration': self.opts.get('grains_cache_expiration', 300),
+                    'grains_cache': True,
                 }
         self.minion_opts.update(opts.get('ssh_minion_opts', {}))
         if minion_opts is not None:

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -708,7 +708,8 @@ class Single(object):
                     'root_dir': os.path.join(self.thin_dir, 'running_data'),
                     'id': self.id,
                     'sock_dir': '/',
-                    'grains_cache': True,
+                    'grains_cache': self.opts.get('grains_cache', True),
+                    'grains_cache_expiration': self.opts.get('grains_cache_expiration', 300),
                     'log_file': 'salt-call.log'
                 })
         self.minion_config = salt.serializers.yaml.serialize(self.minion_opts)

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -708,6 +708,7 @@ class Single(object):
                     'root_dir': os.path.join(self.thin_dir, 'running_data'),
                     'id': self.id,
                     'sock_dir': '/',
+                    'grains_cache': True,
                     'log_file': 'salt-call.log'
                 })
         self.minion_config = salt.serializers.yaml.serialize(self.minion_opts)

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -701,15 +701,19 @@ class Single(object):
                 'tty': tty,
                 'mods': self.mods,
                 'identities_only': identities_only}
-        self.minion_opts = opts.get('ssh_minion_opts', {})
+        # Pre apply changeable defaults
+        self.minion_opts = {
+                    'grains_cache': self.opts.get('grains_cache', True),
+                    'grains_cache_expiration': self.opts.get('grains_cache_expiration', 300),
+                }
+        self.minion_opts.update(opts.get('ssh_minion_opts', {}))
         if minion_opts is not None:
             self.minion_opts.update(minion_opts)
+        # Post apply system needed defaults
         self.minion_opts.update({
                     'root_dir': os.path.join(self.thin_dir, 'running_data'),
                     'id': self.id,
                     'sock_dir': '/',
-                    'grains_cache': self.opts.get('grains_cache', True),
-                    'grains_cache_expiration': self.opts.get('grains_cache_expiration', 300),
                     'log_file': 'salt-call.log'
                 })
         self.minion_config = salt.serializers.yaml.serialize(self.minion_opts)


### PR DESCRIPTION
This makes salt-ssh cache grains for 300 seconds which should speed up salt-ssh calls
