### PR TITLE
Added ssm document support to ec2 salt-cloud driver

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2502,7 +2502,7 @@ def create(vm_=None, call=None):
             call='action'
         )
         ret['Attached Volumes'] = created
-    
+
     # Associate instance with a ssm document, if present
     ssm_document = config.get_cloud_config_value(
         'ssm_document', vm_, __opts__, None, search_global=False
@@ -2511,9 +2511,7 @@ def create(vm_=None, call=None):
         log.debug('Associating with ssm document: {0}'.format(ssm_document))
         assoc = ssm_create_association(
             vm_['name'],
-            {
-                'ssm_document': ssm_document 
-            },
+            {'ssm_document': ssm_document},
             instance_id=vm_['instance_id'],
             call='action'
         )
@@ -4611,7 +4609,7 @@ def ssm_create_association(name=None, kwargs=None, instance_id=None, call=None):
 
     params = {'Action': 'CreateAssociation',
               'InstanceId': instance_id,
-              'Name': kwargs['ssm_document'] }
+              'Name': kwargs['ssm_document']}
 
     result = aws.query(params,
                        return_root=True,
@@ -4661,7 +4659,7 @@ def ssm_describe_association(name=None, kwargs=None, instance_id=None, call=None
 
     params = {'Action': 'DescribeAssociation',
               'InstanceId': instance_id,
-              'Name': kwargs['ssm_document'] }
+              'Name': kwargs['ssm_document']}
 
     result = aws.query(params,
                        return_root=True,

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2511,7 +2511,9 @@ def create(vm_=None, call=None):
         log.debug('Associating with ssm document: {0}'.format(ssm_document))
         assoc = ssm_create_association(
             vm_['name'],
-            { 'ssm_document': ssm_document },
+            {
+                'ssm_document': ssm_document 
+            },
             instance_id=vm_['instance_id'],
             call='action'
         )

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -225,7 +225,7 @@ def sig4(method, endpoint, params, prov_dict,
         location = DEFAULT_LOCATION
 
     params_with_headers = params.copy()
-    if product != 's3':
+    if product not in ('s3', 'ssm'):
         params_with_headers['Version'] = aws_api_version
     keys = sorted(params_with_headers.keys())
     values = list(map(params_with_headers.get, keys))
@@ -427,6 +427,12 @@ def query(params=None, setname=None, requesturl=None, location=None,
             DEFAULT_AWS_API_VERSION
         )
     )
+
+
+    # Fallback to ec2's id & key if none is found, for this component
+    if not prov_dict.get('id', None):
+        prov_dict['id'] = providers.get(provider, {}).get('ec2', {}).get('id', {})
+        prov_dict['key'] = providers.get(provider, {}).get('ec2', {}).get('key', {})
 
     if sigver == '4':
         headers, requesturl = sig4(

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -428,7 +428,6 @@ def query(params=None, setname=None, requesturl=None, location=None,
         )
     )
 
-
     # Fallback to ec2's id & key if none is found, for this component
     if not prov_dict.get('id', None):
         prov_dict['id'] = providers.get(provider, {}).get('ec2', {}).get('id', {})


### PR DESCRIPTION
If a 'ssm_document' key is present either in cloud.profile, or cloud.map this ssm document will now be automatically associated to the instance, right after it is provisioned.

I also ran into/fixed an issue with utils.aws.query which doesn't seem to find an id/key for any other product than 'ec2'. 
