### PR TITLE
Add optional max_open_files for minion

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -294,6 +294,16 @@
 # minion event bus. The value is expressed in bytes.
 #max_event_size: 1048576
 
+# On systems with high ulimits set for the maximum number of open files,
+# Salt may take a long time to launch any subprocesses, especially with
+# cmd.run, due to the amount of time it takes to evaluate and close the
+# associated file handles. To limit the maximum number of open files and
+# ensure the performance of python subprocesses launched by Salt, uncomment
+# the below line. Changing the value will correspond directly to the maximum
+# number of open files that salt processes are allowed to open. If this value
+# is not set, no change will be made to resource limits on the Salt minion.
+# max_open_files: 2048
+
 # To detect failed master(s) and fire events on connect/disconnect, set
 # master_alive_interval to the number of seconds to poll the masters for
 # connection events.

--- a/doc/topics/troubleshooting/minion.rst
+++ b/doc/topics/troubleshooting/minion.rst
@@ -149,3 +149,13 @@ salt-minion service.
     Modifying the minion timeout value is not required when running commands
     from a Salt Master. It is only required when running commands locally on
     the minion.
+
+Salt Minion Performance is Slow When Using cmd.run or Other Subprocesses
+========================================================================
+
+The salt-minion and salt-call will attempt to clean up all file handles
+allocated by any subprocess that is generated, including those spawned
+by functions in the `cmd` remote-execution module, includding `cmd.run`.
+
+To limit the maximum number of open file-handles and work around this issue,
+uncomment the `max_open_files` line in the minion configuration.

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -811,7 +811,7 @@ DEFAULT_MINION_OPTS = {
     'autoload_dynamic_modules': True,
     'environment': None,
     'pillarenv': None,
-    'max_open_files': 2048,
+    'max_open_files': -1,  # Indicates that no adjustement should be made
     'extension_modules': '',
     'state_top': 'top.sls',
     'state_top_saltenv': None,

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -811,6 +811,7 @@ DEFAULT_MINION_OPTS = {
     'autoload_dynamic_modules': True,
     'environment': None,
     'pillarenv': None,
+    'max_open_files': 2048,
     'extension_modules': '',
     'state_top': 'top.sls',
     'state_top_saltenv': None,

--- a/tests/unit/minion_test.py
+++ b/tests/unit/minion_test.py
@@ -52,6 +52,20 @@ class MinionTestCase(TestCase):
                 result = False
         self.assertTrue(result)
 
+    @skipIf(os.geteuid() != 0, 'You must be root to run this test')
+    def test_minion_max_open_files(self):
+        '''
+        Tests surrounding the modification of the maximum number of files
+        that a minion can open if the minion is configured to limit them.
+        '''
+        opts = {'max_open_files': 2048}
+        minion = salt.minion.Minion(opts)
+        with patch('resource.setrlimit') as set_limit_mock:
+            minion._set_max_open_files()
+            set_limit_mock.assert_called_with(resource.RLIMIT_NOFILE, 2048)
+
+
+
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
There is a known issue with Python subprocesses and closing filehandles which is outlined in #26255.

This adds a `max_open_files` option for a minion that will lower the maximum number of open files to mitigate this issue. It is _not_ on by default, but instead is documented as a performance improvement for cases where the ulimit may be artificially set higher than normal for users on some systems.

Closes #26255 
