### PR TITLE
clouds/ec2.py: fix _get_node's ability to retry

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -3116,12 +3116,12 @@ def _get_node(name=None, instance_id=None, location=None):
                                   opts=__opts__,
                                   sigver='4')
             return _extract_instance_info(instances).values()[0]
-        except KeyError:
+        except IndexError:
             attempts -= 1
             log.debug(
                 'Failed to get the data for node \'{0}\'. Remaining '
                 'attempts: {1}'.format(
-                    name, attempts
+                    instance_id or name, attempts
                 )
             )
             # Just a little delay between attempts...


### PR DESCRIPTION
Previous version of this code used [name] instead of .values()[0]
this would have given a KeyError if no instance info was returned
Now we get an IndexError instead
