### PR TITLE
salt.states.zfs

### DIFF
--- a/doc/ref/states/all/index.rst
+++ b/doc/ref/states/all/index.rst
@@ -202,4 +202,5 @@ Full list of builtin state modules
     zcbuildout
     zenoss
     zk_concurrency
+    zfs
     zpool

--- a/doc/ref/states/all/salt.states.zfs.rst
+++ b/doc/ref/states/all/salt.states.zfs.rst
@@ -1,0 +1,6 @@
+===================
+salt.states.zfs
+===================
+
+.. automodule:: salt.states.zfs
+    :members:

--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -235,7 +235,7 @@ def destroy(name, **kwargs):
     if res['retcode'] != 0:
         if "operation does not apply to pools" in res['stderr']:
             ret[name] = '{0}, use zpool.destroy to destroy the pool'.format(res['stderr'].splitlines()[0])
-        if "filesystem has children" in res['stderr']:
+        if "has children" in res['stderr']:
             ret[name] = '{0}, you can add the "recursive=True" parameter'.format(res['stderr'].splitlines()[0])
         else:
             ret[name] = res['stderr'] if 'stderr' in res else res['stdout']

--- a/salt/states/zfs.py
+++ b/salt/states/zfs.py
@@ -151,4 +151,18 @@ def volume_absent(name, force=False, recursive=False):
     '''
     return _absent(name, 'volume', force, recursive)
 
+
+def snapshot_absent(name, force=False, recursive=False):
+    '''
+    ensure snapshot is absent on the system
+
+    name : string
+        name of snapshot
+    force : boolean
+        try harder to destroy the dataset (zfs destroy -f)
+    recursive : boolean
+        also destroy all the child datasets (zfs destroy -r)
+    '''
+    return _absent(name, 'snapshot', force, recursive)
+
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/salt/states/zfs.py
+++ b/salt/states/zfs.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8 -*-
+'''
+Management zfs datasets
+
+:maintainer:    Jorge Schrauwen <sjorge@blackdot.be>
+:maturity:      new
+:depends:       zfs
+:platform:      smartos, illumos, solaris, freebsd, linux
+
+.. versionadded:: Boron
+
+.. code-block:: yaml
+
+    TODO: add example here
+
+'''
+from __future__ import absolute_import
+
+# Import Python libs
+import os
+import stat
+import logging
+
+# Import Salt libs
+from salt.utils.odict import OrderedDict
+
+log = logging.getLogger(__name__)
+
+# Define the state's virtual name
+__virtualname__ = 'zfs'
+
+
+def __virtual__():
+    '''
+    Provides zfs state
+    '''
+    if 'zfs.create' in __salt__:
+        return True
+    else:
+        return (
+            False,
+            '{0} state module can only be loaded on illumos, Solaris, SmartOS, FreeBSD, ...'.format(
+                __virtualname__
+            )
+        )
+
+
+def _absent(name, dataset_type, force=False, recursive=False):
+    '''
+    internal shared function for *_absent
+
+    name : string
+        name of dataset
+    dataset_type : string [filesystem, volume, snapshot, or bookmark]
+        type of dataset to remove
+    force : boolean
+        try harder to destroy the dataset
+    recursive : boolean
+        also destroy all the child datasets
+
+    '''
+    name = name.lower()
+    dataset_type = dataset_type.lower()
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    log.debug('zfs.{0}_absent::{1}::config::force = {2}'.format(dataset_type, name, force))
+    log.debug('zfs.{0}_absent::{1}::config::recursive = {2}'.format(dataset_type, name, recursive))
+
+    # check name and type
+    if dataset_type not in ['filesystem', 'volume', 'snapshot', 'bookmark']:
+        ret['result'] = False
+        ret['comment'] = 'unknown dateset type: {0}'.format(dataset_type)
+
+    if ret['result'] and dataset_type in ['snapshot'] and '@' not in name:
+        ret['result'] = False
+        ret['comment'] = 'invalid snapshot name: {0}'.format(name)
+
+    if ret['result'] and dataset_type in ['bookmark'] and '#' not in name:
+        ret['result'] = False
+        ret['comment'] = 'invalid bookmark name: {0}'.format(name)
+
+    if ret['result'] and dataset_type in ['filesystem', 'volume']:
+        if '@' in name or '#' in name:
+            ret['result'] = False
+            ret['comment'] = 'invalid filesystem or volume name: {0}'.format(name)
+
+    # check if dataset exists
+    if ret['result']:
+        if name in __salt__['zfs.list'](name, **{'type': dataset_type}):  # we need to destroy it
+            result = {name: 'destroyed'}
+            if not __opts__['test']:
+                result = __salt__['zfs.destroy'](name, **{'force': force, 'recursive': recursive})
+
+            ret['result'] = name in result and result[name] == 'destroyed'
+            ret['changes'] = result if ret['result'] else {}
+            if ret['result']:
+                ret['comment'] = '{0} {1} was destroyed'.format(
+                    dataset_type,
+                    name
+                )
+            else:
+                ret['comment'] = 'failed to destroy {0}'.format(name)
+                if name in result:
+                    ret['comment'] = result[name]
+        else:  # dataset with type and name does not exist! (all good)
+            ret['comment'] = '{0} {1} is not present'.format(
+                dataset_type,
+                name
+            )
+
+    return ret
+
+
+def filesystem_absent(name, force=False, recursive=False):
+    '''
+    ensure filesystem is absent on the system
+
+    name : string
+        name of filesystem
+    force : boolean
+        try harder to destroy the dataset (zfs destroy -f)
+    recursive : boolean
+        also destroy all the child datasets (zfs destroy -r)
+
+    '''
+    return _absent(name, 'filesystem', force, recursive)
+
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/salt/states/zfs.py
+++ b/salt/states/zfs.py
@@ -88,7 +88,8 @@ def _absent(name, dataset_type, force=False, recursive=False):
 
     # check if dataset exists
     if ret['result']:
-        if name in __salt__['zfs.list'](name, **{'type': dataset_type}):  # we need to destroy it
+        dataset = name if '#' not in name else None  # work around bookmark oddities
+        if name in __salt__['zfs.list'](dataset, **{'type': dataset_type}):  # we need to destroy it
             result = {name: 'destroyed'}
             if not __opts__['test']:
                 result = __salt__['zfs.destroy'](name, **{'force': force, 'recursive': recursive})

--- a/salt/states/zfs.py
+++ b/salt/states/zfs.py
@@ -165,4 +165,18 @@ def snapshot_absent(name, force=False, recursive=False):
     '''
     return _absent(name, 'snapshot', force, recursive)
 
+
+def bookmark_absent(name, force=False, recursive=False):
+    '''
+    ensure bookmark is absent on the system
+
+    name : string
+        name of snapshot
+    force : boolean
+        try harder to destroy the dataset (zfs destroy -f)
+    recursive : boolean
+        also destroy all the child datasets (zfs destroy -r)
+    '''
+    return _absent(name, 'bookmark', force, recursive)
+
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/salt/states/zfs.py
+++ b/salt/states/zfs.py
@@ -17,8 +17,6 @@ Management zfs datasets
 from __future__ import absolute_import
 
 # Import Python libs
-import os
-import stat
 import logging
 
 # Import Salt libs
@@ -125,7 +123,32 @@ def filesystem_absent(name, force=False, recursive=False):
     recursive : boolean
         also destroy all the child datasets (zfs destroy -r)
 
+    ..warning:
+
+        If a volume with ``name`` exists, this state will succeed without
+        destroying the volume specified by ``name``. This module is dataset type sensitive.
+
     '''
     return _absent(name, 'filesystem', force, recursive)
+
+
+def volume_absent(name, force=False, recursive=False):
+    '''
+    ensure volume is absent on the system
+
+    name : string
+        name of volume
+    force : boolean
+        try harder to destroy the dataset (zfs destroy -f)
+    recursive : boolean
+        also destroy all the child datasets (zfs destroy -r)
+
+    ..warning:
+
+        If a volume with ``name`` exists, this state will succeed without
+        destroying the volume specified by ``name``. This module is dataset type sensitive.
+
+    '''
+    return _absent(name, 'volume', force, recursive)
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
Still work in progress... I will remove [WIP] once done.

State module to go with the revamped salt.module.zfs, there is also a small fix for salt.module.zfs in here.

Done:
- filesystem_absent
- volume_absent
- snapshot_absent
- bookmark_absent
- filesystem_present
- volume_present
- bookmark_present
- snapshot_present
- promoted
- hold_present
- hold_absent

``` yaml
test/shares/yuki:
  zfs.filesystem_present:
    - create_parent: true
    - properties:
        quota: 16M
```

``` bash
local:
----------
          ID: test/shares/yuki
    Function: zfs.filesystem_present
      Result: True
     Comment: filesystem test/shares/yuki was created
     Started: 08:07:27.763930
    Duration: 238.431 ms
     Changes:   
              ----------
              test/shares/yuki:
                  ----------
                  quota:
                      16M

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
```

``` yaml
test/shares/yuki:
  zfs.filesystem_present:
    - create_parent: true
    - properties:
        quota: 16M
```

``` bash
local:
----------
          ID: test/shares/yuki
    Function: zfs.filesystem_present
      Result: True
     Comment: filesystem test/shares/yuki was updated
     Started: 08:09:11.827212
    Duration: 176.999 ms
     Changes:   
              ----------
              test/shares/yuki:
                  ----------
                  quota:
                      8M

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
```

``` yaml
test/shares/yuki:
  zfs.filesystem_present:
    - create_parent: true
    - properties:
        quota: 8M

test/shares/yuki@frozen:
  zfs.snapshot_present

test/shares/moka:
  zfs.filesystem_present:
    - cloned_from: test/shares/yuki@frozen
```

``` bash
local:
----------
          ID: test/shares/yuki
    Function: zfs.filesystem_present
      Result: True
     Comment: filesystem test/shares/yuki is up to date
     Started: 08:12:24.006911
    Duration: 125.559 ms
     Changes:   
----------
          ID: test/shares/yuki@frozen
    Function: zfs.snapshot_present
      Result: True
     Comment: snapshot test/shares/yuki@frozen was created
     Started: 08:12:24.132961
    Duration: 125.657 ms
     Changes:   
              ----------
              test/shares/yuki@frozen:
                  snapshotted
----------
          ID: test/shares/moka
    Function: zfs.filesystem_present
      Result: True
     Comment: filesystem test/shares/moka was created
     Started: 08:12:24.259453
    Duration: 345.361 ms
     Changes:   
              ----------
              test/shares/moka:
                  cloned from test/shares/yuki@frozen

Summary for local
------------
Succeeded: 3 (changed=2)
Failed:    0
------------
Total states run:     3
```

``` yaml
test/shares/moka:
  zfs.promoted

test/shares/yuki:
  zfs.filesystem_absent
```

``` bash
local:
----------
          ID: test/shares/moka
    Function: zfs.promoted
      Result: True
     Comment: test/shares/moka was promoted
     Started: 08:14:51.825718
    Duration: 172.27 ms
     Changes:   
              ----------
              test/shares/moka:
                  promoted
----------
          ID: test/shares/yuki
    Function: zfs.filesystem_absent
      Result: True
     Comment: filesystem test/shares/yuki was destroyed
     Started: 08:14:51.998843
    Duration: 336.046 ms
     Changes:   
              ----------
              test/shares/yuki:
                  destroyed

Summary for local
------------
Succeeded: 2 (changed=2)
Failed:    0
------------
Total states run:     2
```

``` yaml
test/iscsi/haruhi:
  zfs.volume_present:
    - volume_size: 16M
    - sparse: true
    - properties:
        readonly: on
```

``` bash
local:
----------
          ID: test/iscsi/haruhi
    Function: zfs.volume_present
      Result: False
     Comment: cannot create 'test/iscsi/haruhi': parent does not exist
     Started: 08:20:07.551613
    Duration: 110.069 ms
     Changes:   
```

``` yaml
test/iscsi/haruhi:
  zfs.volume_present:
    - volume_size: 16M
    - sparse: true
    - create_parent: true
    - properties:
        readonly: on
```

``` bash
local:
----------
          ID: test/iscsi/haruhi
    Function: zfs.volume_present
      Result: True
     Comment: volume test/iscsi/haruhi was created
     Started: 08:22:42.149372
    Duration: 163.401 ms
     Changes:   
              ----------
              test/iscsi/haruhi:
                  ----------
                  readonly:
                      on

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
```
