### PR TITLE
Reinit crypto before calling RSA.generate when generating keys.

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -85,6 +85,7 @@ def gen_keys(keydir, keyname, keysize, user=None):
     priv = '{0}.pem'.format(base)
     pub = '{0}.pub'.format(base)
 
+    salt.utils.reinit_crypto()
     gen = RSA.generate(bits=keysize, e=65537)
     if os.path.isfile(priv):
         # Between first checking and the generation another process has made


### PR DESCRIPTION
Fixes #28396

In order for the `-P` argument to work with salt-cloud, we need to
make sure we're re-initing crypto before calling RSA.generate. This
is similar to the fixes in #23825.
