### PR TITLE
Fixes performance and timeout issues on win_pkg.install

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -697,7 +697,7 @@ def install(name=None, refresh=False, pkgs=None, saltenv='base', **kwargs):
     tries = 0
     difference = salt.utils.compare_dicts(old, new)
     while not all(name in difference for name in changed) and tries < 10:
-        time.sleep( 3 )
+        time.sleep(3)
         new = list_pkgs()
         difference = salt.utils.compare_dicts(old, new)
         tries += 1

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -14,6 +14,7 @@ import errno
 import os
 import locale
 import logging
+import time
 from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module
 
 # Import third party libs
@@ -695,11 +696,13 @@ def install(name=None, refresh=False, pkgs=None, saltenv='base', **kwargs):
     new = list_pkgs()
     tries = 0
     difference = salt.utils.compare_dicts(old, new)
-    while not all(name in difference for name in changed) and tries <= 1000:
+    while not all(name in difference for name in changed) and tries < 10:
+        time.sleep( 3 )
         new = list_pkgs()
         difference = salt.utils.compare_dicts(old, new)
         tries += 1
-        if tries == 1000:
+        log.debug("Try {0}".format(tries))
+        if tries == 10:
             ret['_comment'] = 'Registry not updated.'
 
     # Compare the software list before and after


### PR DESCRIPTION
Whenever there are no changes in the registry, win_pkg.install will check for any difference applied to it 1001 times before giving up, this causes an unnecessary CPU spike that may lead to performance degradation on the host or in any of its running applications, and if the host it's an AWS burstable instance this may cause unnecessary CPU credit consumption. 

This commit changes that behaviour: the module will now check for any difference in the registry for a maximum of 10 times with an interval of 3 seconds before giving up.

See https://github.com/saltstack/salt/issues/30230.
