### PR TITLE
When daemonizing allow stopping multiprocessing.

### DIFF
--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -859,13 +859,14 @@ def shutdown_multiprocessing_logging():
         logging._releaseLock()
 
 
-def shutdown_multiprocessing_logging_listener():
+def shutdown_multiprocessing_logging_listener(daemonizing=False):
     global __MP_LOGGING_QUEUE
     global __MP_LOGGING_QUEUE_PROCESS
     global __MP_LOGGING_LISTENER_CONFIGURED
 
-    if __MP_IN_MAINPROCESS is True:
-        # We're in the MainProcess, return! No multiprocessing logging listener shutdown shall happen
+    if daemonizing is False and __MP_IN_MAINPROCESS is True:
+        # We're in the MainProcess and we're not daemonizing, return!
+        # No multiprocessing logging listener shutdown shall happen
         return
     if __MP_LOGGING_QUEUE_PROCESS is None:
         return

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -898,7 +898,7 @@ class DaemonMixIn(six.with_metaclass(MixInMeta, object)):
             if self._setup_mp_logging_listener_ is True:
                 # Stop the logging queue listener for the current process
                 # We'll restart it once forked
-                log.shutdown_multiprocessing_logging_listener()
+                log.shutdown_multiprocessing_logging_listener(daemonizing=True)
 
             # Late import so logging works correctly
             salt.utils.daemonize()


### PR DESCRIPTION
Allow stopping the multiprocessing logging queue listener from the main
process while daemonizing.

Fixes #30247
