### PR TITLE
Fix RPM issues with the date/time and add package attributes filtering

### DIFF
--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -433,6 +433,7 @@ def info(*packages, **attr):
                                                           "Version: %{VERSION}\n"
                                                           "Vendor: %{VENDOR}\n"
                                                           "Release: %{RELEASE}\n"
+                                                          "%|EPOCH?{Epoch: %{EPOCH}\n}|"
                                                           "Build Date: %{BUILDTIME}\n"
                                                           "Install Date: %|INSTALLTIME?{%{INSTALLTIME}}:{(not installed)}|\n"
                                                           "Build Host: %{BUILDHOST}\n"

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -435,6 +435,7 @@ def info(*packages, **attr):
                                                           "Group: %{GROUP}\n"
                                                           "Source RPM: %{SOURCERPM}\n"
                                                           "Size: %{LONGSIZE}\n"
+                                                          "Arch: %{ARCH}\n"
                                                           "%|LICENSE?{License: %{LICENSE}\n}|"
                                                           "Signature: %|DSAHEADER?{%{DSAHEADER:pgpsig}}:{%|RSAHEADER?{%{RSAHEADER:pgpsig}}:{%|SIGGPG?{%{SIGGPG:pgpsig}}:{%|SIGPGP?{%{SIGPGP:pgpsig}}:{(none)}|}|}|}|\n"
                                                           "%|PACKAGER?{Packager: %{PACKAGER}\n}|"

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -399,18 +399,6 @@ def diff(package, path):
     return res
 
 
-def _pkg_time_to_iso(pkg_time):
-    '''
-    Convert package time to ISO 8601.
-
-    :param pkg_time:
-    :return:
-    '''
-    ptime = time.strptime(pkg_time, '%a %d %b %Y %H:%M:%S %p %Z')
-    return datetime.datetime(ptime.tm_year, ptime.tm_mon, ptime.tm_mday,
-                             ptime.tm_hour, ptime.tm_min, ptime.tm_sec).isoformat() + "Z"
-
-
 def info(*packages):
     '''
     Return a detailed package(s) summary information.
@@ -435,7 +423,7 @@ def info(*packages):
                                                           "Vendor: %{VENDOR}\n"
                                                           "Release: %{RELEASE}\n"
                                                           "Build Date: %{BUILDTIME:date}\n"
-                                                          "Install Date: %|INSTALLTIME?{%{INSTALLTIME:date}}:{(not installed)}|\n"
+                                                          "Install Date: %|INSTALLTIME?{%{INSTALLTIME}}:{(not installed)}|\n"
                                                           "Build Host: %{BUILDHOST}\n"
                                                           "Group: %{GROUP}\n"
                                                           "Source RPM: %{SOURCERPM}\n"
@@ -447,7 +435,7 @@ def info(*packages):
                                                           "Summary: %{SUMMARY}\n"
                                                           "Description:\n%{DESCRIPTION}\n"
                                                           "-----\n'"),
-                                   output_loglevel='trace', env={'LC_ALL': 'en_US', 'TZ': 'UTC'}, clean_env=True)
+                                   output_loglevel='trace', env={'TZ': 'UTC'}, clean_env=True)
     if call['retcode'] != 0:
         comment = ''
         if 'stderr' in call:
@@ -484,7 +472,10 @@ def info(*packages):
             if key == 'name':
                 pkg_name = value
             if key in ['build_date', 'install_date']:
-                value = _pkg_time_to_iso(value)
+                try:
+                    pkg_data['{0}_iso'.format(key)] = datetime.datetime.fromtimestamp(int(value)).isoformat()
+                except ValueError:
+                    log.warning('Could not convert "{0}" into Unix time'.format(value))
             if key != 'description' and value:
                 pkg_data[key] = value
         pkg_data['description'] = os.linesep.join(descr)

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -409,9 +409,8 @@ def info(*packages, **attr):
         Comma-separated package attributes. If no 'attr' is specified, all available attributes returned.
 
         Valid attributes are:
-            version, vendor, release, build_date, build_date_time_t, install_date, install_date_time_t,
-            build_host, group, source_rpm, arch, epoch, size, license, signature, packager, url,
-            summary, description.
+            version, vendor, release, build_date, install_date, build_host, group, source_rpm,
+            arch, epoch, size, license, signature, packager, url, summary, description.
 
     :return:
 

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -409,8 +409,8 @@ def info(*packages, **attr):
         Comma-separated package attributes. If no 'attr' is specified, all available attributes returned.
 
         Valid attributes are:
-            version, vendor, release, build_date, install_date, build_host, group, source_rpm,
-            arch, epoch, size, license, signature, packager, url, summary, description.
+            version, vendor, release, build_date, build_date_time_t, install_date, install_date_time_t,
+            build_host, group, source_rpm, arch, epoch, size, license, signature, packager, url, summary, description.
 
     :return:
 

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -407,7 +407,7 @@ def info(*packages, **attr):
     :param packages:
 
     :param attr:
-        If no 'attr' is specified, all available attributes returned.
+        Comma-separated package attributes. If no 'attr' is specified, all available attributes returned.
 
         Valid attributes are:
             version, vendor, release, build_date, install_date, build_host, group, source_rpm,

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -429,7 +429,7 @@ def info(*packages, **attr):
                                                           "Version: %{VERSION}\n"
                                                           "Vendor: %{VENDOR}\n"
                                                           "Release: %{RELEASE}\n"
-                                                          "Build Date: %{BUILDTIME:date}\n"
+                                                          "Build Date: %{BUILDTIME}\n"
                                                           "Install Date: %|INSTALLTIME?{%{INSTALLTIME}}:{(not installed)}|\n"
                                                           "Build Host: %{BUILDHOST}\n"
                                                           "Group: %{GROUP}\n"

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -478,7 +478,6 @@ def info(*packages, **attr):
             if len(line) != 2:
                 continue
             key, value = line
-            key = key.replace(' ', '_').lower()
             if key != 'name' and filter_attrs and key not in filter_attrs:
                 continue
             if key == 'description':

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -408,7 +408,7 @@ def info(*packages, **attr):
     :attr attributes. If no 'attr' is specified, all available attributes returned.
         Valid attributes are:
             version, vendor, release, build_date, install_date, build_host, group, source_rpm,
-            size, license, signature, packager, url, summary, description.
+            arch, size, license, signature, packager, url, summary, description.
     :return:
 
     CLI example:

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -410,8 +410,9 @@ def info(*packages, **attr):
         Comma-separated package attributes. If no 'attr' is specified, all available attributes returned.
 
         Valid attributes are:
-            version, vendor, release, build_date, install_date, build_host, group, source_rpm,
-            arch, size, license, signature, packager, url, summary, description.
+            version, vendor, release, build_date, build_date_time_t, install_date, install_date_time_t,
+            build_host, group, source_rpm, arch, epoch, size, license, signature, packager, url,
+            summary, description.
 
     :return:
 

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -490,7 +490,7 @@ def info(*packages, **attr):
                 try:
                     value = int(value)
                     pkg_data['{0}_time_t'.format(key)] = value
-                    value = datetime.datetime.fromtimestamp(value).isoformat()
+                    value = datetime.datetime.fromtimestamp(value).isoformat() + "Z"
                 except ValueError:
                     log.warning('Could not convert "{0}" into Unix time'.format(value))
                     continue

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import
 import logging
 import os
 import re
-import time
 import datetime
 
 # Import Salt libs

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -488,9 +488,12 @@ def info(*packages, **attr):
                 pkg_name = value
             if key in ['build_date', 'install_date']:
                 try:
-                    pkg_data['{0}_iso'.format(key)] = datetime.datetime.fromtimestamp(int(value)).isoformat()
+                    value = int(value)
+                    pkg_data['{0}_time_t'.format(key)] = value
+                    value = datetime.datetime.fromtimestamp(value).isoformat()
                 except ValueError:
                     log.warning('Could not convert "{0}" into Unix time'.format(value))
+                    continue
             if key not in ['description', 'name'] and value:
                 pkg_data[key] = value
         if filter_attrs and 'description' in filter_attrs or not filter_attrs:

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -405,6 +405,10 @@ def info(*packages, **attr):
     If no packages specified, all packages will be returned.
 
     :param packages:
+    :attr attributes. If no 'attr' is specified, all available attributes returned.
+        Valid attributes are:
+            version, vendor, release, build_date, install_date, build_host, group, source_rpm,
+            size, license, signature, packager, url, summary, description.
     :return:
 
     CLI example:
@@ -412,6 +416,8 @@ def info(*packages, **attr):
     .. code-block:: bash
 
         salt '*' lowpkg.info apache2 bash
+        salt '*' lowpkg.info apache2 bash attr=version
+        salt '*' lowpkg.info apache2 bash attr=version,build_date_iso,size
     '''
 
     cmd = packages and "rpm -q {0}".format(' '.join(packages)) or "rpm -qa"

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -493,7 +493,7 @@ def info(*packages, **attr):
                     continue
             if key not in ['description', 'name'] and value:
                 pkg_data[key] = value
-        if filter_attrs and 'description' in filter_attrs or not filter_attrs:
+        if attr and 'description' in attr or not attr:
             pkg_data['description'] = os.linesep.join(descr)
         if pkg_name:
             ret[pkg_name] = pkg_data

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -405,10 +405,14 @@ def info(*packages, **attr):
     If no packages specified, all packages will be returned.
 
     :param packages:
-    :attr attributes. If no 'attr' is specified, all available attributes returned.
+
+    :param attr:
+        If no 'attr' is specified, all available attributes returned.
+
         Valid attributes are:
             version, vendor, release, build_date, install_date, build_host, group, source_rpm,
             arch, size, license, signature, packager, url, summary, description.
+
     :return:
 
     CLI example:

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -478,8 +478,6 @@ def info(*packages, **attr):
             if len(line) != 2:
                 continue
             key, value = line
-            if key != 'name' and filter_attrs and key not in filter_attrs:
-                continue
             if key == 'description':
                 descr_marker = True
                 continue

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -100,8 +100,11 @@ def info_installed(*names, **attr):
     '''
     Return the information of the named package(s), installed on the system.
 
-    :names names of the packages to get information about.
-    :attr attributes. If no 'attr' is specified, all available attributes returned.
+    :param names:
+        Names of the packages to get information about.
+
+    :param attr:
+        Comma-separated package attributes. If no 'attr' is specified, all available attributes returned.
         Valid attributes are:
             version, vendor, release, build_date, install_date, build_host, group, source_rpm,
             size, license, signature, packager, url, summary, description.

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -105,9 +105,11 @@ def info_installed(*names, **attr):
 
     :param attr:
         Comma-separated package attributes. If no 'attr' is specified, all available attributes returned.
+
         Valid attributes are:
-            version, vendor, release, build_date, install_date, build_host, group, source_rpm,
-            size, license, signature, packager, url, summary, description.
+            version, vendor, release, build_date, build_date_time_t, install_date, install_date_time_t,
+            build_host, group, source_rpm, arch, epoch, size, license, signature, packager, url,
+            summary, description.
 
     CLI example:
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -100,12 +100,20 @@ def info_installed(*names, **attr):
     '''
     Return the information of the named package(s), installed on the system.
 
+    :names names of the packages to get information about.
+    :attr attributes. If no 'attr' is specified, all available attributes returned.
+        Valid attributes are:
+            version, vendor, release, build_date, install_date, build_host, group, source_rpm,
+            size, license, signature, packager, url, summary, description.
+
     CLI example:
 
     .. code-block:: bash
 
         salt '*' pkg.info_installed <package1>
         salt '*' pkg.info_installed <package1> <package2> <package3> ...
+        salt '*' pkg.info_installed <package1> attr=version,vendor
+        salt '*' pkg.info_installed <package1> <package2> <package3> ... attr=version,vendor
     '''
     ret = dict()
     for pkg_name, pkg_nfo in __salt__['lowpkg.info'](*names, **attr).items():

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -96,7 +96,7 @@ def list_upgrades(refresh=True):
 list_updates = salt.utils.alias_function(list_upgrades, 'list_updates')
 
 
-def info_installed(*names):
+def info_installed(*names, **attr):
     '''
     Return the information of the named package(s), installed on the system.
 
@@ -108,7 +108,7 @@ def info_installed(*names):
         salt '*' pkg.info_installed <package1> <package2> <package3> ...
     '''
     ret = dict()
-    for pkg_name, pkg_nfo in __salt__['lowpkg.info'](*names).items():
+    for pkg_name, pkg_nfo in __salt__['lowpkg.info'](*names, **attr).items():
         t_nfo = dict()
         # Translate dpkg-specific keys to a common structure
         for key, value in pkg_nfo.items():


### PR DESCRIPTION
**Date/time issues:** date/time was returned only in the ISO format. Now it is returned in ISO and Unix format.

**Attributes filtering:** Information about installed package was overwhelming. Now it is possible to narrow down to only those attributes that are necessary to view. For example:

```
salt '*' pkg.info_installed vim attr=url,build_date,release,arch
```

Documentation is updated accordingly.
