### PR TITLE
If datacenter is specified in the config, then look for managed objects under it

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -254,12 +254,12 @@ def _edit_existing_network_adapter(network_adapter, new_network_name, adapter_ty
         edited_network_adapter = network_adapter
 
     if switch_type == 'standard':
-        network_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.Network, new_network_name, container_ref)
+        network_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.Network, new_network_name, container_ref=container_ref)
         edited_network_adapter.backing = vim.vm.device.VirtualEthernetCard.NetworkBackingInfo()
         edited_network_adapter.backing.deviceName = new_network_name
         edited_network_adapter.backing.network = network_ref
     elif switch_type == 'distributed':
-        network_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.dvs.DistributedVirtualPortgroup, new_network_name, container_ref)
+        network_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.dvs.DistributedVirtualPortgroup, new_network_name, container_ref=container_ref)
         dvs_port_connection = vim.dvs.PortConnection(
             portgroupKey=network_ref.key,
             switchUuid=network_ref.config.distributedVirtualSwitch.uuid
@@ -316,12 +316,12 @@ def _add_new_network_adapter_helper(network_adapter_label, network_name, adapter
         network_spec.device.backing.network = salt.utils.vmware.get_mor_by_property(_get_si(),
                                                                                     vim.Network,
                                                                                     network_name,
-                                                                                    container_ref)
+                                                                                    container_ref=container_ref)
     elif switch_type == 'distributed':
         network_ref = salt.utils.vmware.get_mor_by_property(_get_si(),
                                                             vim.dvs.DistributedVirtualPortgroup,
                                                             network_name,
-                                                            container_ref)
+                                                            container_ref=container_ref)
         dvs_port_connection = vim.dvs.PortConnection(
             portgroupKey=network_ref.key,
             switchUuid=network_ref.config.distributedVirtualSwitch.uuid
@@ -2055,7 +2055,7 @@ def create(vm_):
             container_ref = datacenter_ref if datacenter_ref else None
 
         # Clone VM/template from specified VM/template
-        object_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.VirtualMachine, vm_['clonefrom'], container_ref)
+        object_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.VirtualMachine, vm_['clonefrom'], container_ref=container_ref)
         if object_ref:
             clone_type = "template" if object_ref.config.template else "vm"
         else:
@@ -2065,13 +2065,13 @@ def create(vm_):
 
         # Either a cluster, or a resource pool must be specified when cloning from template.
         if resourcepool:
-            resourcepool_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.ResourcePool, resourcepool, container_ref)
+            resourcepool_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.ResourcePool, resourcepool, container_ref=container_ref)
             if not resourcepool_ref:
                 log.error("Specified resource pool: '{0}' does not exist".format(resourcepool))
                 if clone_type == "template":
                     raise SaltCloudSystemExit('You must specify a resource pool that exists.')
         elif cluster:
-            cluster_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.ClusterComputeResource, cluster, container_ref)
+            cluster_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.ClusterComputeResource, cluster, container_ref=container_ref)
             if not cluster_ref:
                 log.error("Specified cluster: '{0}' does not exist".format(cluster))
                 if clone_type == "template":
@@ -2088,7 +2088,7 @@ def create(vm_):
         # Either a datacenter or a folder can be optionally specified
         # If not specified, the existing VM/template\'s parent folder is used.
         if folder:
-            folder_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.Folder, folder, container_ref)
+            folder_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.Folder, folder, container_ref=container_ref)
             if not folder_ref:
                 log.error("Specified folder: '{0}' does not exist".format(folder))
                 log.debug("Using folder in which {0} {1} is present".format(clone_type, vm_['clonefrom']))
@@ -2113,12 +2113,12 @@ def create(vm_):
         # Either a datastore/datastore cluster can be optionally specified.
         # If not specified, the current datastore is used.
         if datastore:
-            datastore_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.Datastore, datastore, container_ref)
+            datastore_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.Datastore, datastore, container_ref=container_ref)
             if datastore_ref:
                 # specific datastore has been specified
                 reloc_spec.datastore = datastore_ref
             else:
-                datastore_cluster_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.StoragePod, datastore, container_ref)
+                datastore_cluster_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.StoragePod, datastore, container_ref=container_ref)
                 if not datastore_cluster_ref:
                     log.error("Specified datastore/datastore cluster: '{0}' does not exist".format(datastore))
                     log.debug("Using datastore used by the {0} {1}".format(clone_type, vm_['clonefrom']))
@@ -2127,7 +2127,7 @@ def create(vm_):
             log.debug("Using datastore used by the {0} {1}".format(clone_type, vm_['clonefrom']))
 
         if host:
-            host_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.HostSystem, host, container_ref)
+            host_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.HostSystem, host, container_ref=container_ref)
             if host_ref:
                 reloc_spec.host = host_ref
             else:
@@ -2170,7 +2170,7 @@ def create(vm_):
             config_spec.memoryMB = memory_mb
 
         if devices:
-            specs = _manage_devices(devices, object_ref, container_ref)
+            specs = _manage_devices(devices, object_ref, container_ref=container_ref)
             config_spec.deviceChange = specs['device_specs']
 
         if extra_config:
@@ -2256,7 +2256,7 @@ def create(vm_):
             )
             return {'Error': err_msg}
 
-        new_vm_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.VirtualMachine, vm_name, container_ref)
+        new_vm_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.VirtualMachine, vm_name, container_ref=container_ref)
 
         # If it a template or if it does not need to be powered on then do not wait for the IP
         if not template and power:

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -237,7 +237,7 @@ def _add_new_hard_disk_helper(disk_label, size_gb, unit_number):
     return disk_spec
 
 
-def _edit_existing_network_adapter(network_adapter, new_network_name, adapter_type, switch_type):
+def _edit_existing_network_adapter(network_adapter, new_network_name, adapter_type, switch_type, container_ref=None):
     adapter_type.strip().lower()
     switch_type.strip().lower()
 
@@ -254,12 +254,12 @@ def _edit_existing_network_adapter(network_adapter, new_network_name, adapter_ty
         edited_network_adapter = network_adapter
 
     if switch_type == 'standard':
-        network_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.Network, new_network_name)
+        network_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.Network, new_network_name, container_ref)
         edited_network_adapter.backing = vim.vm.device.VirtualEthernetCard.NetworkBackingInfo()
         edited_network_adapter.backing.deviceName = new_network_name
         edited_network_adapter.backing.network = network_ref
     elif switch_type == 'distributed':
-        network_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.dvs.DistributedVirtualPortgroup, new_network_name)
+        network_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.dvs.DistributedVirtualPortgroup, new_network_name, container_ref)
         dvs_port_connection = vim.dvs.PortConnection(
             portgroupKey=network_ref.key,
             switchUuid=network_ref.config.distributedVirtualSwitch.uuid
@@ -291,7 +291,7 @@ def _edit_existing_network_adapter(network_adapter, new_network_name, adapter_ty
     return network_spec
 
 
-def _add_new_network_adapter_helper(network_adapter_label, network_name, adapter_type, switch_type):
+def _add_new_network_adapter_helper(network_adapter_label, network_name, adapter_type, switch_type, container_ref=None):
     random_key = randint(-4099, -4000)
 
     adapter_type.strip().lower()
@@ -315,11 +315,13 @@ def _add_new_network_adapter_helper(network_adapter_label, network_name, adapter
         network_spec.device.backing.deviceName = network_name
         network_spec.device.backing.network = salt.utils.vmware.get_mor_by_property(_get_si(),
                                                                                     vim.Network,
-                                                                                    network_name)
+                                                                                    network_name,
+                                                                                    container_ref)
     elif switch_type == 'distributed':
         network_ref = salt.utils.vmware.get_mor_by_property(_get_si(),
                                                             vim.dvs.DistributedVirtualPortgroup,
-                                                            network_name)
+                                                            network_name,
+                                                            container_ref)
         dvs_port_connection = vim.dvs.PortConnection(
             portgroupKey=network_ref.key,
             switchUuid=network_ref.config.distributedVirtualSwitch.uuid
@@ -490,7 +492,7 @@ def _set_network_adapter_mapping(adapter_specs):
     return adapter_mapping
 
 
-def _manage_devices(devices, vm):
+def _manage_devices(devices, vm, container_ref=None):
     unit_number = 0
     bus_number = 0
     device_specs = []
@@ -527,7 +529,7 @@ def _manage_devices(devices, vm):
                     network_name = devices['network'][device.deviceInfo.label]['name']
                     adapter_type = devices['network'][device.deviceInfo.label]['adapter_type'] if 'adapter_type' in devices['network'][device.deviceInfo.label] else ''
                     switch_type = devices['network'][device.deviceInfo.label]['switch_type'] if 'switch_type' in devices['network'][device.deviceInfo.label] else ''
-                    network_spec = _edit_existing_network_adapter(device, network_name, adapter_type, switch_type)
+                    network_spec = _edit_existing_network_adapter(device, network_name, adapter_type, switch_type, container_ref)
                     adapter_mapping = _set_network_adapter_mapping(devices['network'][device.deviceInfo.label])
                     device_specs.append(network_spec)
                     nics_map.append(adapter_mapping)
@@ -585,7 +587,7 @@ def _manage_devices(devices, vm):
             adapter_type = devices['network'][network_adapter_label]['adapter_type'] if 'adapter_type' in devices['network'][network_adapter_label] else ''
             switch_type = devices['network'][network_adapter_label]['switch_type'] if 'switch_type' in devices['network'][network_adapter_label] else ''
             # create the network adapter
-            network_spec = _add_new_network_adapter_helper(network_adapter_label, network_name, adapter_type, switch_type)
+            network_spec = _add_new_network_adapter_helper(network_adapter_label, network_name, adapter_type, switch_type, container_ref)
             adapter_mapping = _set_network_adapter_mapping(devices['network'][network_adapter_label])
             device_specs.append(network_spec)
             nics_map.append(adapter_mapping)
@@ -2079,14 +2081,18 @@ def create(vm_):
 
         # Either a datacenter or a folder can be optionally specified
         # If not specified, the existing VM/template\'s parent folder is used.
+        container_ref = None
+        if datacenter:
+            datacenter_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.Datacenter, datacenter)
+            container_ref = datacenter_ref if datacenter_ref else None
+
         if folder:
-            folder_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.Folder, folder)
+            folder_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.Folder, folder, container_ref)
             if not folder_ref:
                 log.error("Specified folder: '{0}' does not exist".format(folder))
                 log.debug("Using folder in which {0} {1} is present".format(clone_type, vm_['clonefrom']))
                 folder_ref = object_ref.parent
         elif datacenter:
-            datacenter_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.Datacenter, datacenter)
             if not datacenter_ref:
                 log.error("Specified datacenter: '{0}' does not exist".format(datacenter))
                 log.debug("Using datacenter folder in which {0} {1} is present".format(clone_type, vm_['clonefrom']))
@@ -2106,12 +2112,12 @@ def create(vm_):
         # Either a datastore/datastore cluster can be optionally specified.
         # If not specified, the current datastore is used.
         if datastore:
-            datastore_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.Datastore, datastore)
+            datastore_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.Datastore, datastore, container_ref)
             if datastore_ref:
                 # specific datastore has been specified
                 reloc_spec.datastore = datastore_ref
             else:
-                datastore_cluster_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.StoragePod, datastore)
+                datastore_cluster_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.StoragePod, datastore, container_ref)
                 if not datastore_cluster_ref:
                     log.error("Specified datastore/datastore cluster: '{0}' does not exist".format(datastore))
                     log.debug("Using datastore used by the {0} {1}".format(clone_type, vm_['clonefrom']))
@@ -2120,7 +2126,7 @@ def create(vm_):
             log.debug("Using datastore used by the {0} {1}".format(clone_type, vm_['clonefrom']))
 
         if host:
-            host_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.HostSystem, host)
+            host_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.HostSystem, host, container_ref)
             if host_ref:
                 reloc_spec.host = host_ref
             else:
@@ -2163,7 +2169,7 @@ def create(vm_):
             config_spec.memoryMB = memory_mb
 
         if devices:
-            specs = _manage_devices(devices, object_ref)
+            specs = _manage_devices(devices, object_ref, container_ref)
             config_spec.deviceChange = specs['device_specs']
 
         if extra_config:

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -176,7 +176,7 @@ def get_inventory(service_instance):
     return service_instance.RetrieveContent()
 
 
-def get_content(service_instance, obj_type, property_list=None):
+def get_content(service_instance, obj_type, property_list=None, container_ref=None):
     '''
     Returns the content of the specified type of object for a Service Instance.
 
@@ -191,10 +191,19 @@ def get_content(service_instance, obj_type, property_list=None):
 
     property_list
         An optional list of object properties to used to return even more filtered content results.
+
+    container_ref
+        An optional reference to the managed object to search under. Can either be an object of type Folder, Datacenter,
+        ComputeResource, Resource Pool or HostSystem. If not specified, default behaviour is to search under the inventory
+        rootFolder.
     '''
+    # Start at the rootFolder if container starting point not specified
+    if not container_ref:
+        container_ref = service_instance.content.rootFolder
+
     # Create an object view
     obj_view = service_instance.content.viewManager.CreateContainerView(
-        service_instance.content.rootFolder, [obj_type], True)
+        container_ref, [obj_type], True)
 
     # Create traversal spec to determine the path for collection
     traversal_spec = vmodl.query.PropertyCollector.TraversalSpec(
@@ -234,7 +243,7 @@ def get_content(service_instance, obj_type, property_list=None):
     return content
 
 
-def get_mor_by_property(service_instance, object_type, property_value, property_name='name'):
+def get_mor_by_property(service_instance, object_type, property_value, property_name='name', container_ref=None):
     '''
     Returns the first managed object reference having the specified property value.
 
@@ -249,9 +258,14 @@ def get_mor_by_property(service_instance, object_type, property_value, property_
 
     property_name
         An object property used to return the specified object reference results. Defaults to ``name``.
+
+    container_ref
+        An optional reference to the managed object to search under. Can either be an object of type Folder, Datacenter,
+        ComputeResource, Resource Pool or HostSystem. If not specified, default behaviour is to search under the inventory
+        rootFolder.
     '''
     # Get list of all managed object references with specified property
-    object_list = get_mors_with_properties(service_instance, object_type, property_list=[property_name])
+    object_list = get_mors_with_properties(service_instance, object_type, property_list=[property_name], container_ref=container_ref)
 
     for obj in object_list:
         if obj[property_name] == property_value:
@@ -260,7 +274,7 @@ def get_mor_by_property(service_instance, object_type, property_value, property_
     return None
 
 
-def get_mors_with_properties(service_instance, object_type, property_list=None):
+def get_mors_with_properties(service_instance, object_type, property_list=None, container_ref=None):
     '''
     Returns a list containing properties and managed object references for the managed object.
 
@@ -272,9 +286,14 @@ def get_mors_with_properties(service_instance, object_type, property_list=None):
 
     property_list
         An optional list of object properties used to return even more filtered managed object reference results.
+
+    container_ref
+        An optional reference to the managed object to search under. Can either be an object of type Folder, Datacenter,
+        ComputeResource, Resource Pool or HostSystem. If not specified, default behaviour is to search under the inventory
+        rootFolder.
     '''
     # Get all the content
-    content = get_content(service_instance, object_type, property_list=property_list)
+    content = get_content(service_instance, object_type, property_list=property_list, container_ref=container_ref)
 
     object_list = []
     for obj in content:


### PR DESCRIPTION
If datacenter is specified in the config, then look for managed objects under it instead of looking across all datacenters. Reason of this is that there may be multiple objects with the same name across datacenters such as DVS port group names. 

Fixes https://github.com/saltstack/salt/issues/30264
