### PR TITLE
Allow modules to be packed into boto utils

### DIFF
--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -125,10 +125,10 @@ def __virtual__():
         return True
 
 
-def __init__(opts):
+def __init__(opts, pack=None):
     salt.utils.compat.pack_dunder(__name__)
     if HAS_BOTO:
-        __utils__['boto.assign_funcs'](__name__, 'vpc')
+        __utils__['boto.assign_funcs'](__name__, 'vpc', pack=pack)
 
 
 def _check_vpc(vpc_id, vpc_name, region, key, keyid, profile):

--- a/salt/utils/boto.py
+++ b/salt/utils/boto.py
@@ -254,7 +254,7 @@ def assign_funcs(modname, service, module=None, pack=None):
         _utils__['boto.assign_partials'](__name__, 'ec2')
     '''
     if pack:
-        global __salt__
+        global __salt__  # pylint: disable=W0601
         __salt__ = pack
     mod = sys.modules[modname]
     setattr(mod, '_get_conn', get_connection_func(service, module=module))

--- a/salt/utils/boto.py
+++ b/salt/utils/boto.py
@@ -88,13 +88,11 @@ def _get_profile(service, region, key, keyid, profile):
         key = _profile.get('key', None)
         keyid = _profile.get('keyid', None)
         region = _profile.get('region', None)
-
     if not region and __salt__['config.option'](service + '.region'):
         region = __salt__['config.option'](service + '.region')
 
     if not region:
         region = 'us-east-1'
-
     if not key and __salt__['config.option'](service + '.key'):
         key = __salt__['config.option'](service + '.key')
     if not keyid and __salt__['config.option'](service + '.keyid'):
@@ -247,7 +245,7 @@ def exactly_one(l):
     return exactly_n(l)
 
 
-def assign_funcs(modname, service, module=None):
+def assign_funcs(modname, service, module=None, pack=None):
     '''
     Assign _get_conn and _cache_id functions to the named module.
 
@@ -255,6 +253,9 @@ def assign_funcs(modname, service, module=None):
 
         _utils__['boto.assign_partials'](__name__, 'ec2')
     '''
+    if pack:
+        global __salt__
+        __salt__ = pack
     mod = sys.modules[modname]
     setattr(mod, '_get_conn', get_connection_func(service, module=module))
     setattr(mod, '_cache_id', cache_id_func(service))

--- a/tests/unit/modules/boto_vpc_test.py
+++ b/tests/unit/modules/boto_vpc_test.py
@@ -9,7 +9,7 @@ from distutils.version import LooseVersion  # pylint: disable=import-error,no-na
 
 # Import Salt Testing libs
 from salttesting.unit import skipIf, TestCase
-from salttesting.mock import NO_MOCK, NO_MOCK_REASON, patch, MagicMock
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, patch
 from salttesting.helpers import ensure_in_syspath
 
 ensure_in_syspath('../../')

--- a/tests/unit/modules/boto_vpc_test.py
+++ b/tests/unit/modules/boto_vpc_test.py
@@ -9,7 +9,7 @@ from distutils.version import LooseVersion  # pylint: disable=import-error,no-na
 
 # Import Salt Testing libs
 from salttesting.unit import skipIf, TestCase
-from salttesting.mock import NO_MOCK, NO_MOCK_REASON, patch
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, patch, MagicMock
 from salttesting.helpers import ensure_in_syspath
 
 ensure_in_syspath('../../')
@@ -70,9 +70,10 @@ dhcp_options_parameters.update(conn_parameters)
 
 opts = salt.config.DEFAULT_MINION_OPTS
 utils = salt.loader.utils(opts, whitelist=['boto'])
+mods = salt.loader.minion_mods(opts)
 
 boto_vpc.__utils__ = utils
-boto_vpc.__init__(opts)
+boto_vpc.__init__(opts, pack=mods)
 
 
 def _has_required_boto():

--- a/tests/unit/utils/boto_test.py
+++ b/tests/unit/utils/boto_test.py
@@ -6,7 +6,7 @@ from distutils.version import LooseVersion  # pylint: disable=import-error,no-na
 
 # Import Salt Testing libs
 from salttesting.unit import skipIf, TestCase
-from salttesting.mock import NO_MOCK, NO_MOCK_REASON, patch
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, patch, MagicMock
 from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../')
 
@@ -111,6 +111,7 @@ class BotoUtilsTestCaseBase(TestCase):
         salt.utils.boto.__context__ = {}
         salt.utils.boto.__opts__ = {}
         salt.utils.boto.__pillar__ = {}
+        salt.utils.boto.__salt__ = {'config.option': MagicMock(return_value='dummy_opt')}
 
 
 class BotoUtilsCacheIdTestCase(BotoUtilsTestCaseBase):


### PR DESCRIPTION
A workaround to allow modules to be packed into the namespace for the boto utils.
