### PR TITLE
Fix file.append logic

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3288,7 +3288,6 @@ def append(name,
                     name,
                     salt.utils.build_whitespace_split_regex(chunk),
                     multiline=True):
-                        print('IGNORING WHITESPACE')
                         continue
             elif __salt__['file.search'](
                     name,

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3288,7 +3288,7 @@ def append(name,
                     name,
                     salt.utils.build_whitespace_split_regex(chunk),
                     multiline=True):
-                        continue
+                    continue
             elif __salt__['file.search'](
                     name,
                     chunk,

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3283,12 +3283,13 @@ def append(name,
 
     try:
         for chunk in text:
-
-            if ignore_whitespace and __salt__['file.search'](
+            if ignore_whitespace:
+                if __salt__['file.search'](
                     name,
                     salt.utils.build_whitespace_split_regex(chunk),
                     multiline=True):
-                continue
+                        print('IGNORING WHITESPACE')
+                        continue
             elif __salt__['file.search'](
                     name,
                     chunk,


### PR DESCRIPTION
The logic in #30156 was slightly incorrect. This properly nests the conditionals. Fixes test for: `integration.states.file.FileTest.test_issue_2379_file_append`
