### PR TITLE
Remove pkg.wait state

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -894,10 +894,7 @@ def installed(
         .. note::
             Setting and leaving this option as ``True`` will result in
             reinstallation every time the state is run, which may not be
-            desired. This argument exists more than anything to be used by the
-            :py:func:`pkg.wait <salt.states.pkg.wait>` state to determine the
-            behavior for already-installed packages when it is triggered by a
-            watch requisite.
+            desired.
 
     :param kwargs:
         These are specific to each OS. If it does not apply to the execution
@@ -2056,50 +2053,6 @@ def group_installed(name, skip=None, include=None, **kwargs):
     return ret
 
 
-def wait(name,
-         version=None,
-         refresh=None,
-         fromrepo=None,
-         skip_verify=False,
-         skip_suggestions=False,
-         pkgs=None,
-         sources=None,
-         allow_updates=False,
-         pkg_verify=False,
-         normalize=True,
-         reinstall=True,
-         **kwargs):
-    '''
-    .. versionadded:: Boron
-
-    Install/reinstall a package based on a watch requisite. Works exactly like
-    :py:func:`pkg.installed <salt.states.pkg.installed>`, the only difference
-    being that ``reinstall`` defaults to ``True``. Setting it to ``False`` will
-    result in already-installed packages **not** being reinstalled.
-
-    Example:
-
-    .. code-block:: yaml
-
-        /some/file:
-          file.managed:
-            - source: salt://some/file
-
-        mypkgs:
-          pkg.wait:
-            - pkgs:
-              - foo
-              - bar: '>=1.2.3-4'
-              - baz
-            - watch:
-              - file: /some/file
-    '''
-    return {'name': name,
-            'changes': {},
-            'result': True,
-            'comment': 'Watch requisite not present or not triggered'}
-
-
 def mod_init(low):
     '''
     Set a flag to tell the install functions to refresh the package database.
@@ -2179,12 +2132,10 @@ def mod_watch(name, **kwargs):
     mapfun = {'purged': purged,
               'latest': latest,
               'removed': removed,
-              'wait': installed,
               'installed': installed}
     if sfun in mapfun:
         return mapfun[sfun](name, **kwargs)
     return {'name': name,
             'changes': {},
-            'comment': 'pkg.{0} does not work with the watch requisite, '
-                       'please use pkg.wait'.format(sfun),
+            'comment': 'pkg.{0} does not work with the watch requisite'.format(sfun),
             'result': False}


### PR DESCRIPTION
This was added recently in #29582, but this sort of functionality has
been replaced wih the `onchanges` requisite so it is redundant. This
removes the state.
