### PR TITLE
remove annoying warning about dmidecode and lspci on SunOS ...

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -479,7 +479,7 @@ def _virtual(osdata):
     # Skip the below loop on platforms which have none of the desired cmds
     # This is a temporary measure until we can write proper virtual hardware
     # detection.
-    skip_cmds = ('AIX', 'SunOS',)
+    skip_cmds = ('AIX',)
 
     # list of commands to be executed to determine the 'virtual' grain
     _cmds = ['systemd-detect-virt', 'virt-what', 'dmidecode']
@@ -509,6 +509,9 @@ def _virtual(osdata):
         if osdata['kernel'] == 'Darwin':
             command = 'system_profiler'
             args = ['SPDisplaysDataType']
+        elif osdata['kernel'] == 'SunOS':
+            command = 'prtdiag'
+            args = []
 
         cmd = salt.utils.which(command)
 
@@ -640,6 +643,16 @@ def _virtual(osdata):
             if output:
                 grains['virtual'] = output.lower()
             break
+        elif command == 'prtdiag':
+            module = output.lower().split("\n")[0]
+            if 'vmware' in model:
+                grains['virtual'] = 'VMware'
+            elif 'virtualbox' in model:
+                grains['virtual'] = 'VirtualBox'
+            elif 'qemu' in model:
+                grains['virtual'] = 'kvm'
+            elif 'joyent smartdc hvm' in model:
+                grains['virtual'] = 'kvm'
     else:
         if osdata['kernel'] in skip_cmds:
             log.warn(

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -644,7 +644,7 @@ def _virtual(osdata):
                 grains['virtual'] = output.lower()
             break
         elif command == 'prtdiag':
-            module = output.lower().split("\n")[0]
+            modul = output.lower().split("\n")[0]
             if 'vmware' in model:
                 grains['virtual'] = 'VMware'
             elif 'virtualbox' in model:

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -644,7 +644,7 @@ def _virtual(osdata):
                 grains['virtual'] = output.lower()
             break
         elif command == 'prtdiag':
-            modul = output.lower().split("\n")[0]
+            model = output.lower().split("\n")[0]
             if 'vmware' in model:
                 grains['virtual'] = 'VMware'
             elif 'virtualbox' in model:


### PR DESCRIPTION
by using prtdiag to get the information ;)

``` bash
[root@soth /opt]# /opt/salt/bin/salt-call --local grains. -l debug
[DEBUG   ] Reading configuration from /opt/salt/etc/minion
[DEBUG   ] Using cached minion ID from /opt/salt/etc/minion_id: soth.acheron.be
[DEBUG   ] Reading configuration from /opt/salt/etc/minion
[DEBUG   ] Please install 'virt-what' to improve results of the 'virtual' grain.
[DEBUG   ] Configuration file path: /opt/salt/etc/minion
[WARNING ] Insecure logging configuration detected! Sensitive data may be logged.
[DEBUG   ] Reading configuration from /opt/salt/etc/minion
[DEBUG   ] Please install 'virt-what' to improve results of the 'virtual' grain.
[DEBUG   ] LazyLoaded jinja.render
[DEBUG   ] LazyLoaded yaml.render
[DEBUG   ] LazyLoaded jinja.render
[DEBUG   ] LazyLoaded yaml.render
[DEBUG   ] LazyLoaded grains.items
[DEBUG   ] LazyLoaded nested.output
```

``` yaml
local:
    ----------
    computenode_sdc_version:
        7.0
    computenode_vm_capable:
        True
    computenode_vm_hw_virt:
        none
    computenode_vms_running:
        1
    computenode_vms_stopped:
        1
    computenode_vms_total:
        1
    cpu_flags:
        - popcnt
        - cx16
        - sse3
        - sse2
        - sse
        - fxsr
        - mmx
        - cmov
        - amd_sysc
        - cx8
        - tsc
        - fpu
    cpu_model:
        QEMU Virtual CPU version 0.14.1
    cpuarch:
        amd64
    dns:
        ----------
        domain:
            acheron.be
        ip4_nameservers:
            - 172.16.10.1
        ip6_nameservers:
        nameservers:
            - 172.16.10.1
        search:
    domain:
        acheron.be
    fqdn:
        soth.acheron.be
    fqdn_ip4:
        - 172.16.10.227
    fqdn_ip6:
    gid:
        0
    gpus:
    groupname:
        root
    host:
        soth
    hwaddr_interfaces:
        ----------
        vioif0:
            0:15:0:5:d9:c1
    id:
        soth.acheron.be
    ip4_interfaces:
        ----------
        lo0:
            - 127.0.0.1
        vioif0:
            - 172.16.10.227
    ip6_interfaces:
        ----------
        lo0:
            - ::1
        vioif0:
            - fe80::215:ff:fe05:d9c1
            - 2001:6f8:1480:10::234
            - 2001:6f8:1480:10:215:ff:fe05:d9c1
    ip_interfaces:
        ----------
        lo0:
            - 127.0.0.1
            - ::1
        vioif0:
            - 172.16.10.227
            - fe80::215:ff:fe05:d9c1
            - 2001:6f8:1480:10::234
            - 2001:6f8:1480:10:215:ff:fe05:d9c1
    ipv4:
        - 127.0.0.1
        - 172.16.10.227
    ipv6:
        - ::1
        - 2001:6f8:1480:10::234
        - 2001:6f8:1480:10:215:ff:fe05:d9c1
        - fe80::215:ff:fe05:d9c1
    kernel:
        SunOS
    kernelrelease:
        5.11
    locale_info:
        ----------
        defaultencoding:
            UTF-8
        defaultlanguage:
            en_US
        detectedencoding:
            UTF-8
    localhost:
        soth
    manufacturer:
        Joyent
    master:
        salt
    mem_total:
        2047
    nodename:
        soth
    num_cpus:
        2
    num_gpus:
        0
    os:
        SmartOS
    os_family:
        Solaris
    osarch:
        amd64
    osfullname:
        SmartOS
    osrelease:
        20151117T180556Z
    osrelease_info:
        - 20151117T180556Z
    path:
        /opt/salt/bin/appdata/salt-2015.8.0-661-ga3abab1.solaris-2_11-i86pc_64bit:/usr/bin:/usr/sbin:/smartdc/bin:/opt/smartdc/bin:/opt/local/bin:/opt/local/sbin:/opt/smartdc/agents/bin:/bin:/sbin:/usr/local/bin
    pid:
        3524
    productname:
        SmartDC HVM
    ps:
        /usr/ucb/ps auxwww
    pythonexecutable:
        /opt/salt/bin/appdata/salt-2015.8.0-661-ga3abab1.solaris-2_11-i86pc_64bit/salt-call
    pythonpath:
        - /opt/salt/bin/appdata/salt-2015.8.0-661-ga3abab1.solaris-2_11-i86pc_64bit/library.zip
        - /opt/salt/bin/appdata/salt-2015.8.0-661-ga3abab1.solaris-2_11-i86pc_64bit
        - /opt/salt/bin/appdata/salt-2015.8.0-661-ga3abab1.solaris-2_11-i86pc_64bit/salt-2015.8.0_661_ga3abab1-py2.7.egg
        - /opt/salt/bin/appdata/salt-2015.8.0-661-ga3abab1.solaris-2_11-i86pc_64bit/enum34-1.0.4-py2.7.egg
        - /opt/salt/bin/appdata/salt-2015.8.0-661-ga3abab1.solaris-2_11-i86pc_64bit/raet-0.6.3-py2.7.egg
        - /opt/salt/bin/appdata/salt-2015.8.0-661-ga3abab1.solaris-2_11-i86pc_64bit/gitdb-0.6.4-py2.7-solaris-2.11-i86pc.64bit.egg
        - /opt/salt/bin/appdata/salt-2015.8.0-661-ga3abab1.solaris-2_11-i86pc_64bit/yappi-0.94-py2.7-solaris-2.11-i86pc.64bit.egg
        - /opt/salt/bin/appdata/salt-2015.8.0-661-ga3abab1.solaris-2_11-i86pc_64bit/timelib-0.2.4-py2.7-solaris-2.11-i86pc.64bit.egg
        - /opt/salt/bin/appdata/salt-2015.8.0-661-ga3abab1.solaris-2_11-i86pc_64bit/esky-0.9.8-py2.7.egg
        - /opt/salt/bin/appdata/salt-2015.8.0-661-ga3abab1.solaris-2_11-i86pc_64bit/smmap-0.9.0-py2.7.egg
        - /opt/salt/bin/appdata/salt-2015.8.0-661-ga3abab1.solaris-2_11-i86pc_64bit/tornado-4.2.1-py2.7-solaris-2.11-i86pc.64bit.egg
        - /opt/salt/bin/appdata/salt-2015.8.0-661-ga3abab1.solaris-2_11-i86pc_64bit/libnacl-1.4.3-py2.7.egg
        - /opt/salt/bin/appdata/salt-2015.8.0-661-ga3abab1.solaris-2_11-i86pc_64bit/six-1.9.0-py2.7.egg
        - /opt/salt/bin/appdata/salt-2015.8.0-661-ga3abab1.solaris-2_11-i86pc_64bit/certifi-2015.4.28-py2.7.egg
        - /opt/salt/bin/appdata/salt-2015.8.0-661-ga3abab1.solaris-2_11-i86pc_64bit/pyzmq-13.1.0-py2.7-solaris-2.11-i86pc.64bit.egg
        - /opt/salt/bin/appdata/salt-2015.8.0-661-ga3abab1.solaris-2_11-i86pc_64bit/backports.ssl_match_hostname-3.4.0.2-py2.7.egg
        - /opt/salt/bin/appdata/salt-2015.8.0-661-ga3abab1.solaris-2_11-i86pc_64bit/ioflo-1.3.8-py2.7.egg
        - /opt/salt/bin/appdata/salt-2015.8.0-661-ga3abab1.solaris-2_11-i86pc_64bit/GitPython-0.3.2c1-py2.7.egg
    pythonversion:
        - 2
        - 7
        - 9
        - final
        - 0
    saltpath:
        /opt/salt/bin/appdata/salt-2015.8.0-661-ga3abab1.solaris-2_11-i86pc_64bit/salt-2015.8.0_661_ga3abab1-py2.7.egg/salt
    saltversion:
        2015.8.0-661-ga3abab1
    saltversioninfo:
        - 2015
        - 8
        - 0
        - 0
    server_id:
        1087124336
    shell:
        /usr/bin/bash
    uid:
        0
    username:
        root
    uuid:
        618a01b8-c37b-473f-8cdb-ca2a66d6adf7
    virtual:
        kvm
    zmqversion:
        4.0.5
```
