### PR TITLE
Fix 2015.8 from incomplete back-port

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -811,3 +811,9 @@
 ############################################
 # Which returner(s) will be used for minion's result:
 #return: mysql
+
+
+######    Miscellaneous  settings     ######
+############################################
+# Default match type for filtering events tags: startswith, endswith, find, regex, fnmatch
+#event_match_type: startswith

--- a/conf/minion
+++ b/conf/minion
@@ -655,3 +655,9 @@
 ############################################
 # Which returner(s) will be used for minion's result:
 #return: mysql
+
+
+######    Miscellaneous  settings     ######
+############################################
+# Default match type for filtering events tags: startswith, endswith, find, regex, fnmatch
+#event_match_type: startswith

--- a/salt/config.py
+++ b/salt/config.py
@@ -387,6 +387,9 @@ VALID_OPTS = {
     # Events matching a tag in this list should never be sent to an event returner.
     'event_return_blacklist': list,
 
+    # default match type for filtering events tags: startswith, endswith, find, regex, fnmatch
+    'event_match_type': str,
+
     # This pidfile to write out to when a daemon starts
     'pidfile': str,
 
@@ -781,7 +784,7 @@ DEFAULT_MINION_OPTS = {
     'user': 'root',
     'root_dir': salt.syspaths.ROOT_DIR,
     'pki_dir': os.path.join(salt.syspaths.CONFIG_DIR, 'pki', 'minion'),
-    'id': None,
+    'id': '',
     'cachedir': os.path.join(salt.syspaths.CACHE_DIR, 'minion'),
     'cache_jobs': False,
     'grains_cache': False,
@@ -966,6 +969,7 @@ DEFAULT_MINION_OPTS = {
     'salt_event_pub_hwm': 2000,
     # ZMQ HWM for EventPublisher pub socket - different for minion vs. master
     'event_publisher_pub_hwm': 1000,
+    'event_match_type': 'startswith',
 }
 
 DEFAULT_MASTER_OPTS = {
@@ -1115,6 +1119,7 @@ DEFAULT_MASTER_OPTS = {
     'event_return_queue': 0,
     'event_return_whitelist': [],
     'event_return_blacklist': [],
+    'event_match_type': 'startswith',
     'serial': 'msgpack',
     'state_verbose': True,
     'state_output': 'full',

--- a/salt/config.py
+++ b/salt/config.py
@@ -2747,7 +2747,7 @@ def apply_minion_config(overrides=None,
 
     # No ID provided. Will getfqdn save us?
     using_ip_for_id = False
-    if opts['id'] is None:
+    if not opts.get('id'):
         opts['id'], using_ip_for_id = get_id(
                 opts,
                 cache_minion_id=cache_minion_id)
@@ -2864,7 +2864,7 @@ def apply_master_config(overrides=None, defaults=None):
 
     using_ip_for_id = False
     append_master = False
-    if opts.get('id') is None:
+    if not opts.get('id'):
         opts['id'], using_ip_for_id = get_id(
                 opts,
                 cache_minion_id=None)

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -220,10 +220,6 @@ class SaltEvent(object):
         Return the string URI for the location of the pull and pub sockets to
         use for firing and listening to events
         '''
-        hash_type = getattr(hashlib, self.opts['hash_type'])
-        # Only use the first 10 chars to keep longer hashes from exceeding the
-        # max socket path length.
-        id_hash = hash_type(salt.utils.to_bytes(self.opts.get('id', ''))).hexdigest()[:10]
         if node == 'master':
             if self.opts['ipc_mode'] == 'tcp':
                 puburi = 'tcp://127.0.0.1:{0}'.format(
@@ -252,6 +248,10 @@ class SaltEvent(object):
                     self.opts['tcp_pull_port']
                     )
             else:
+                hash_type = getattr(hashlib, self.opts['hash_type'])
+                # Only use the first 10 chars to keep longer hashes from exceeding the
+                # max socket path length.
+                id_hash = hash_type(salt.utils.to_bytes(self.opts['id'])).hexdigest()[:10]
                 puburi = 'ipc://{0}'.format(os.path.join(
                     sock_dir,
                     'minion_event_{0}_pub.ipc'.format(id_hash)
@@ -340,7 +340,7 @@ class SaltEvent(object):
 
     def _get_match_func(self, match_type=None):
         if match_type is None:
-            match_type = self.opts.get('event_match_type', 'startswith')
+            match_type = self.opts['event_match_type']
         return getattr(self, '_match_tag_{0}'.format(match_type), None)
 
     def _check_pending(self, tag, match_func=None):
@@ -724,7 +724,7 @@ class MinionEvent(SaltEvent):
     '''
     def __init__(self, opts, listen=True):
         super(MinionEvent, self).__init__(
-            'minion', sock_dir=opts['sock_dir'], opts=opts, listen=listen)
+            'minion', sock_dir=opts.get('sock_dir'), opts=opts, listen=listen)
 
 
 class AsyncEventPublisher(object):
@@ -745,7 +745,7 @@ class AsyncEventPublisher(object):
         hash_type = getattr(hashlib, self.opts['hash_type'])
         # Only use the first 10 chars to keep longer hashes from exceeding the
         # max socket path length.
-        id_hash = hash_type(salt.utils.to_bytes(self.opts.get('id', ''))).hexdigest()[:10]
+        id_hash = hash_type(salt.utils.to_bytes(self.opts['id'])).hexdigest()[:10]
         epub_sock_path = os.path.join(
             self.opts['sock_dir'],
             'minion_event_{0}_pub.ipc'.format(id_hash)

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -297,10 +297,10 @@ class SaltEvent(object):
         '''
         self.sub = self.context.socket(zmq.SUB)
         try:
-            self.sub.setsockopt(zmq.HWM, self.opts.get('salt_event_pub_hwm'))
+            self.sub.setsockopt(zmq.HWM, self.opts.get('salt_event_pub_hwm', 0))
         except AttributeError:
-            self.sub.setsockopt(zmq.SNDHWM, self.opts.get('salt_event_pub_hwm'))
-            self.sub.setsockopt(zmq.RCVHWM, self.opts.get('salt_event_pub_hwm'))
+            self.sub.setsockopt(zmq.SNDHWM, self.opts.get('salt_event_pub_hwm', 0))
+            self.sub.setsockopt(zmq.RCVHWM, self.opts.get('salt_event_pub_hwm', 0))
         self.sub.connect(self.puburi)
         self.poller.register(self.sub, zmq.POLLIN)
         self.sub.setsockopt_string(zmq.SUBSCRIBE, u'')
@@ -873,10 +873,10 @@ class EventPublisher(multiprocessing.Process):
         # Prepare the master event publisher
         self.epub_sock = self.context.socket(zmq.PUB)
         try:
-            self.epub_sock.setsockopt(zmq.HWM, self.opts.get('event_publisher_pub_hwm'))
+            self.epub_sock.setsockopt(zmq.HWM, self.opts.get('event_publisher_pub_hwm', 0))
         except AttributeError:
-            self.epub_sock.setsockopt(zmq.SNDHWM, self.opts.get('event_publisher_pub_hwm'))
-            self.epub_sock.setsockopt(zmq.RCVHWM, self.opts.get('event_publisher_pub_hwm'))
+            self.epub_sock.setsockopt(zmq.SNDHWM, self.opts.get('event_publisher_pub_hwm', 0))
+            self.epub_sock.setsockopt(zmq.RCVHWM, self.opts.get('event_publisher_pub_hwm', 0))
         # Prepare master event pull socket
         self.epull_sock = self.context.socket(zmq.PULL)
         if self.opts.get('ipc_mode', '') == 'tcp':


### PR DESCRIPTION
When back-porting #27606 with #30187, the salt-cloud `-p` and `-d` functions were broken, along with a couple of other things.

This PR fixes the 2015.8 branch by including some more fixes from the develop branch. The following PRs are included in this fix:
- #28131
- #28189
- #28431

@cachedout Please review.
