### PR TITLE
Summary: correct a small defect in openstack_config.set function.

### DIFF
--- a/salt/modules/openstack_config.py
+++ b/salt/modules/openstack_config.py
@@ -72,7 +72,7 @@ def set_(filename, section, parameter, value):
     filename = _quote(filename)
     section = _quote(section)
     parameter = _quote(parameter)
-    value = _quote(value)
+    value = _quote(str(value))
 
     result = __salt__['cmd.run_all'](
             'openstack-config --set {0} {1} {2} {3}'.format(


### PR DESCRIPTION
Desrciption:
When execte command "salt  * openstack.set file section key true".
The openstack.set function will raise TypeError, because the "_quote" function need a
string as input parameter. However, salt bash resolve "true" to Ture a
bool variable which is passed into "_quote". Therefore, if user wants to
set a string "true" in openstack config file, he must use a command like
salt '*' openstack_config.set file section key "'true'". Similar issue
also occurs when input a number parameter in salt bash.
