### PR TITLE
Make sure all ignore_missing SLSes are catched

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -395,7 +395,7 @@ class Pillar(object):
                             if isinstance(comp, six.string_types):
                                 states[comp] = True
                         if ignore_missing:
-                            self.ignored_pillars[saltenv] = list(states.keys())
+                            self.ignored_pillars[saltenv].extend(states.keys())
                         top[saltenv][tgt] = matches
                         top[saltenv][tgt].extend(states)
         return self.sort_top_targets(top, orders)


### PR DESCRIPTION
Previously, only the last statement in top.sls with `ignore_missing: true` would actually be effective, because `self.ignored_pillars[saltenv]` was constantly being overwritten.

Related PR: #19429
