### PR TITLE
Removes suspected copy/paste error for zmq_filtering functionailty 

### DIFF
--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -264,7 +264,6 @@ class AsyncZeroMQPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.t
         else:
             self._socket.setsockopt(zmq.SUBSCRIBE, '')
 
-        self._socket.setsockopt(zmq.SUBSCRIBE, '')
         self._socket.setsockopt(zmq.IDENTITY, self.opts['id'])
 
         # TODO: cleanup all the socket opts stuff


### PR DESCRIPTION
Subscribing to ‘’ empty topic regardless of zmq_filtering setting will cause messages to be sent to all minions in the case zmq_filtering is set to true. Can confirm by enabling zmq_filtering on master and minion, running minion with debug log level, issuing a master command using -L targeting towards minion that is NOT the one you are watching the log of, you will see it report that it received a message not for that minion. 

Relevant logs below of me targeting just Node0 - other nodes still get the message. 

`````` bash
==> Node1/rootfs/var/log/salt/minion <==
2016-01-13 20:35:09,109 [salt.transport.zeromq][DEBUG   ][1099] Publish received for not this minion: 542b9d66a1669f36607c8f24faff098d69f6316d

==> Node2/rootfs/var/log/salt/minion <==
2016-01-13 20:35:09,109 [salt.transport.zeromq][DEBUG   ][1086] Publish received for not this minion: 542b9d66a1669f36607c8f24faff098d69f6316d

==> Node3/rootfs/var/log/salt/minion <==
2016-01-13 20:35:09,108 [salt.transport.zeromq][DEBUG   ][1068] Publish received for not this minion: 542b9d66a1669f36607c8f24faff098d69f6316d

==> Node0/rootfs/var/log/salt/minion <==
2016-01-13 20:35:09,111 [salt.minion      ][INFO    ][1078] User sudo_vagrant Executing command sys.list_modules with jid 20160113203509105836
2016-01-13 20:35:09,111 [salt.minion      ][DEBUG   ][1078] Command details {'tgt_type': 'list', 'jid': '20160113203509105836', 'tgt': ['Node0'], 'ret': '', 'user': 'sudo_vagrant', 'arg': [], 'fun': 'sys.list_modules'}
2016-01-13 20:35:09,118 [salt.minion      ][INFO    ][1518] Starting a new job with PID 1518
2016-01-13 20:35:09,120 [salt.minion      ][DEBUG   ][1518] Minion return retry timer set to 7 seconds (randomized)
2016-01-13 20:35:09,120 [salt.minion      ][INFO    ][1518] Returning information for job: 20160113203509105836
2016-01-13 20:35:09,121 [salt.transport.zeromq][DEBUG   ][1518] Initializing new AsyncZeroMQReqChannel for ('/etc/salt/pki/minion', 'Node0', 'tcp://10.0.3.12:4506', 'aes')
2016-01-13 20:35:09,121 [salt.crypt       ][DEBUG   ][1518] Initializing new SAuth for ('/etc/salt/pki/minion', 'Node0', 'tcp://10.0.3.12:4506')```
``````
