### PR TITLE
Fix FLO_DIR path in 2015.8

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -59,8 +59,8 @@ else:
     _DFLT_MULTIPROCESSING_MODE = True
 
 FLO_DIR = os.path.join(
-            os.path.dirname(os.path.dirname(__file__)),
-            'daemons', 'flo')
+        os.path.dirname(__file__),
+        'daemons', 'flo')
 
 VALID_OPTS = {
     # The address of the salt master. May be specified as IP address or hostname


### PR DESCRIPTION
In release `2015.8.3`, in `salt.config`, `FLO_DIR` should be like it is at [92e0e90:salt/config.py#L61](https://github.com/saltstack/salt/blob/92e0e90e98b439175df41f862caf737baa05e9fc/salt/config.py#L61).

But somehow, [this commit](https://github.com/saltstack/salt/commit/d6192cd7e4c1be47814ae2427cecb17fb57ebf20) from `develop` seems to have been [backported (read: cherry-picked)](https://github.com/saltstack/salt/commit/2afbe6803c0a05b6184f6b5c880c842f535f0441). This commit was supposed to apply after `salt/config.py` was [made its own package](https://github.com/saltstack/salt/commit/e508088a2ab01ffc97f1da359c93992553d6be4f), but [the backported commit](https://github.com/saltstack/salt/commit/2afbe6803c0a05b6184f6b5c880c842f535f0441) applies before that event, thus breaking `FLO_DIR`.

TL;DR: Note the branches, tags, and the file paths at these two commits:

| Status | Commit |
| --- | --- |
| Good ✔ | https://github.com/saltstack/salt/commit/d6192cd7e4c1be47814ae2427cecb17fb57ebf20 |
| Bad ✖ | https://github.com/saltstack/salt/commit/2afbe6803c0a05b6184f6b5c880c842f535f0441 |
