### PR TITLE
Adding silent flag to npm.bootstrap

### DIFF
--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -261,7 +261,8 @@ def removed(name,
 
 
 def bootstrap(name,
-              user=None):
+              user=None,
+              silent=True):
     '''
     Bootstraps a node.js application.
 
@@ -276,7 +277,7 @@ def bootstrap(name,
 
     if __opts__['test']:
         try:
-            call = __salt__['npm.install'](dir=name, runas=user, pkg=None, dry_run=True)
+            call = __salt__['npm.install'](dir=name, runas=user, pkg=None, silent=silent, dry_run=True)
         except (CommandNotFoundError, CommandExecutionError) as err:
             ret['result'] = False
             ret['comment'] = 'Error Bootstrapping {0!r}: {1}'.format(name, err)
@@ -287,7 +288,7 @@ def bootstrap(name,
         return ret
 
     try:
-        call = __salt__['npm.install'](dir=name, runas=user, pkg=None)
+        call = __salt__['npm.install'](dir=name, runas=user, pkg=None, , silent=silent)
     except (CommandNotFoundError, CommandExecutionError) as err:
         ret['result'] = False
         ret['comment'] = 'Error Bootstrapping {0!r}: {1}'.format(name, err)

--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -288,7 +288,7 @@ def bootstrap(name,
         return ret
 
     try:
-        call = __salt__['npm.install'](dir=name, runas=user, pkg=None, , silent=silent)
+        call = __salt__['npm.install'](dir=name, runas=user, pkg=None, silent=silent)
     except (CommandNotFoundError, CommandExecutionError) as err:
         ret['result'] = False
         ret['comment'] = 'Error Bootstrapping {0!r}: {1}'.format(name, err)


### PR DESCRIPTION
Adds a flag to `npm.bootstap` to disable the silent flag when calling `npm install`
