### PR TITLE
Launchctl yosemite

### DIFF
--- a/salt/modules/launchctl.py
+++ b/salt/modules/launchctl.py
@@ -69,19 +69,23 @@ def _available_services():
                     continue
 
                 try:
-                    # This assumes most of the plist files will be already in XML format
+                    # This assumes most of the plist files
+                    # will be already in XML format
                     with salt.utils.fopen(file_path):
                         plist = plistlib.readPlist(true_path)
 
                 except Exception:
                     # If plistlib is unable to read the file we'll need to use
                     # the system provided plutil program to do the conversion
-                    cmd = '/usr/bin/plutil -convert xml1 -o - -- "{0}"'.format(true_path)
-                    plist_xml = __salt__['cmd.run_all'](cmd, python_shell=False)['stdout']
+                    cmd = '/usr/bin/plutil -convert xml1 -o - -- "{0}"'.format(
+                        true_path)
+                    plist_xml = __salt__['cmd.run_all'](
+                        cmd, python_shell=False)['stdout']
                     if six.PY2:
                         plist = plistlib.readPlistFromString(plist_xml)
                     else:
-                        plist = plistlib.readPlistFromBytes(salt.utils.to_bytes(plist_xml))
+                        plist = plistlib.readPlistFromBytes(
+                            salt.utils.to_bytes(plist_xml))
 
                 available_services[plist.Label.lower()] = {
                     'filename': filename,
@@ -226,7 +230,8 @@ def stop(job_label, runas=None):
     '''
     service = _service_by_name(job_label)
     if service:
-        cmd = 'launchctl unload -w {0}'.format(service['file_path'], runas=runas)
+        cmd = 'launchctl unload -w {0}'.format(service['file_path'],
+                                               runas=runas)
         return not __salt__['cmd.retcode'](cmd, runas=runas, python_shell=False)
 
     return False

--- a/salt/modules/launchctl.py
+++ b/salt/modules/launchctl.py
@@ -269,3 +269,47 @@ def restart(job_label, runas=None):
     '''
     stop(job_label, runas=runas)
     return start(job_label, runas=runas)
+
+
+def enabled(job_label, runas=None):
+    '''
+    Return True if the named service is enabled, false otherwise
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.enabled <service label>
+    '''
+    overrides_data = dict(plistlib.readPlist(
+        '/var/db/launchd.db/com.apple.launchd/overrides.plist'
+    ))
+    if overrides_data.get(job_label, False):
+        if overrides_data[job_label]['Disabled']:
+            return False
+        else:
+            return True
+    else:
+        return False
+
+
+def disabled(job_label, runas=None):
+    '''
+    Return True if the named service is disabled, false otherwise
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.disabled <service label>
+    '''
+    overrides_data = dict(plistlib.readPlist(
+        '/var/db/launchd.db/com.apple.launchd/overrides.plist'
+    ))
+    if overrides_data.get(job_label, False):
+        if overrides_data[job_label]['Disabled']:
+            return True
+        else:
+            return False
+    else:
+        return True

--- a/tests/unit/modules/launchctl_test.py
+++ b/tests/unit/modules/launchctl_test.py
@@ -58,12 +58,34 @@ class LaunchctlTestCase(TestCase):
         '''
         Test for Return the status for a service
         '''
+        launchctl_data = '''<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>salt-minion</string>
+    <key>LastExitStatus</key>
+    <integer>0</integer>
+    <key>LimitLoadToSessionType</key>
+    <string>System</string>
+    <key>OnDemand</key>
+    <false/>
+    <key>PID</key>
+    <integer>71</integer>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/salt-minion</string>
+    </array>
+    <key>TimeOut</key>
+    <integer>30</integer>
+</dict>
+</plist>'''
         with patch.object(launchctl,
                           '_service_by_name',
                           return_value={'plist':
                                         {'Label': 'A'}}):
             with patch.object(launchctl, '_get_launchctl_data',
-                              return_value={'PID': 'B'}):
+                              return_value=launchctl_data):
                 self.assertTrue(launchctl.status('job_label'))
 
     def test_stop(self):


### PR DESCRIPTION
Fix https://github.com/saltstack/salt/issues/22357

On Yosemite, `-x` is no longer supported as mentioned in the manpage:

```
     list [-x] [label]
              With no arguments, list all of the jobs loaded into launchd in three columns. The first column displays the PID of the job if it
              is running.  The second column displays the last exit status of the job. If the number in this column is negative, it represents
              the negative of the signal which stopped the job. Thus, "-15" would indicate that the job was terminated with SIGTERM.  The
              third column is the job's label. If [label] is specified, prints information about the requested job.

              -x       This flag is no longer supported.
```

So, we have to parse the launchctl data to check if a service is running or not:

`sudo launchctl list com.agendaless.supervisord`:

```
{
    "LimitLoadToSessionType" = "System";
    "Label" = "com.agendaless.supervisord";
    "TimeOut" = 30;
    "OnDemand" = true;
    "LastExitStatus" = 0;
    "PID" = 70377;
    "Program" = "/usr/local/bin/supervisord";
    "ProgramArguments" = (
        "/usr/local/bin/supervisord";
        "-n";
        "-c";
        "/usr/local/etc/supervisord.conf";
    );
};
```
