### PR TITLE
Fix dropfile support for non-privileged salt-master user.

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -60,11 +60,11 @@ def dropfile(cachedir, user=None):
     try:
         log.info('Rotating AES key')
 
-        if (salt.utils.is_windows() and os.path.isfile(dfn) and
-                not os.access(dfn, os.W_OK)):
-            os.chmod(dfn, stat.S_IWUSR)
+        if os.path.isfile(dfn) and not os.access(dfn, os.W_OK):
+            os.chmod(dfn, stat.S_IRUSR | stat.S_IWUSR)
         with salt.utils.fopen(dfn, 'wb+') as fp_:
             fp_.write('')
+        os.chmod(dfn, stat.S_IRUSR)
         if user:
             try:
                 import pwd


### PR DESCRIPTION
In 02d9684, a check was added to ensure that the crypto dfn file was
made writable on windows before overwriting it.  However, read-only
files are not only read-only on windows, they are read-only for
non-privileged users as well.

If you run the salt-master as a non-privileged user, you would observe
that the first child -- running _clear_old_jobs -- disappeared (went
defunct/zombie) after a while.  This patch fixes the cause of the
problem.

---

The dropfile function itself was tested on 'develop'. The problem of the
zombie _clear_old_jobs was observed with version 0.17.5+ds-1, but
it seems reasonable to assume the bug manifests itself in develop as
well.

Long explanation can be found here:
http://wjd.nu/notes/2016#salt-master-losing-children

Thanks for a great product!
