### PR TITLE
Add log_exceptions decorator and wrap Maintenance.run.

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -74,6 +74,7 @@ from salt.exceptions import FileserverConfigError
 from salt.utils.debug import (
     enable_sigusr1_handler, enable_sigusr2_handler, inspect_stack
 )
+from salt.utils.decorators import log_exceptions
 from salt.utils.event import tagify
 from salt.utils.master import ConnectedCache
 from salt.utils.process import default_signals, SignalHandlingMultiprocessingProcess
@@ -194,6 +195,7 @@ class Maintenance(SignalHandlingMultiprocessingProcess):
         # Set up search object
         self.search = salt.search.Search(self.opts)
 
+    @log_exceptions(log, 'Maintenance.run')
     def run(self):
         '''
         This is the general passive maintenance process controller for the Salt


### PR DESCRIPTION
In order to debug problems with unhandled errors, it is beneficial if
dying subprocesses write their fatal exception to the log.

This changeset adds a decorator to wrap the run() function, and wraps
the Maintenance run method.  Other run() methods could benefit from
this wrapping as well.

---

When debugging the problem which is fixed by #30382 it would have
helped if the maintenance subprocess had output its exception to
the salt/master log.  This patch should fix that it does.
