### PR TITLE
Correctly fix #11405

### DIFF
--- a/salt/modules/debian_service.py
+++ b/salt/modules/debian_service.py
@@ -259,7 +259,8 @@ def enable(name, **kwargs):
         if int(osmajor) >= 6:
             cmd = 'insserv {0} && '.format(_cmd_quote(name)) + cmd
     except ValueError:
-        if osmajor == 'testing/unstable' or osmajor == 'unstable':
+        osrel = _osrel()
+        if osrel == 'testing/unstable' or osrel == 'unstable' or osrel.endswith("/sid"):
             cmd = 'insserv {0} && '.format(_cmd_quote(name)) + cmd
     return not __salt__['cmd.retcode'](cmd, python_shell=True)
 


### PR DESCRIPTION
The fix for #11405 was not working correctly on Debian Testing.
Also, `osrel.endswith("/sid")` is adde, because when lsb-release is not installed, `osrelease` equals to "..../sid", not "testing/unstable"
