### PR TITLE
Older versions of ipset don't support comments

### DIFF
--- a/salt/modules/ipset.py
+++ b/salt/modules/ipset.py
@@ -425,11 +425,16 @@ def check(set=None, entry=None, family='ipv4'):
     else:
         _entry = entry.split()[0]
         _entry_extra = entry.split()[1:]
-        if _entry.find('-') != -1 and _entry.count('-') == 1:
-            start, end = _entry.split('-')
+        if entry.find('-') != -1 and entry.count('-') == 1:
+            start, end = entry.split('-')
 
             if settype == 'hash:ip':
-                entries = [' '.join([str(ipaddress.ip_address(ip)), ' '.join(_entry_extra)]) for ip in range(
+                if _entry_extra:
+                    entries = [' '.join([str(ipaddress.ip_address(ip)), ' '.join(_entry_extra)]) for ip in range(
+                        ipaddress.ip_address(start),
+                        ipaddress.ip_address(end) + 1
+                    )]
+                entries = [' '.join([str(ipaddress.ip_address(ip))]) for ip in range(
                     ipaddress.ip_address(start),
                     ipaddress.ip_address(end) + 1
                 )]
@@ -439,22 +444,31 @@ def check(set=None, entry=None, family='ipv4'):
                                                              ipaddress.ip_address(end))
                 entries = []
                 for network in networks:
+                    entries.append(network.with_prefixlen)
                     _network = [str(ip) for ip in ipaddress.ip_network(network)]
                     if len(_network) == 1:
-                        __network = ' '.join([str(_network[0]), ' '.join(_entry_extra)])
+                        if _entry_extra:
+                            __network = ' '.join([str(_network[0]), ' '.join(_entry_extra)])
+                        __network = ' '.join([str(_network[0])])
                     else:
-                        __network = ' '.join([str(network), ' '.join(_entry_extra)])
+                        if _entry_extra:
+                            __network = ' '.join([str(network), ' '.join(_entry_extra)])
+                        __network = ' '.join([str(network)])
                     entries.append(__network)
             else:
                 entries = [entry]
 
         elif _entry.find('/') != -1 and _entry.count('/') == 1:
             if settype == 'hash:ip':
-                entries = [' '.join([str(ip), ' '.join(_entry_extra)]) for ip in ipaddress.ip_network(_entry)]
+                if _entry_extra:
+                    entries = [' '.join([str(ip), ' '.join(_entry_extra)]) for ip in ipaddress.ip_network(_entry)]
+                entries = [' '.join([str(ip)]) for ip in ipaddress.ip_network(_entry)]
             elif settype == 'hash:net':
                 _entries = [str(ip) for ip in ipaddress.ip_network(_entry)]
                 if len(_entries) == 1:
-                    entries = [' '.join([_entries[0], ' '.join(_entry_extra)])]
+                    if _entry_extra:
+                        entries = [' '.join([_entries[0], ' '.join(_entry_extra)])]
+                    entries = [' '.join([_entries[0]])]
                 else:
                     entries = [entry]
             else:

--- a/salt/modules/ipset.py
+++ b/salt/modules/ipset.py
@@ -425,8 +425,8 @@ def check(set=None, entry=None, family='ipv4'):
     else:
         _entry = entry.split()[0]
         _entry_extra = entry.split()[1:]
-        if entry.find('-') != -1 and entry.count('-') == 1:
-            start, end = entry.split('-')
+        if _entry.find('-') != -1 and _entry.count('-') == 1:
+            start, end = _entry.split('-')
 
             if settype == 'hash:ip':
                 if _entry_extra:


### PR DESCRIPTION
This should also fix a problem where the module will report incorrectly if there
isn't a comment.

I have a feeling there is a better way to do this, so if anyone has a critique or a better way of doing this, I'm all ears :) 

Addresses this failing test: http://166.78.178.63:8080/job/branch_tests/job/2015.8/job/salt-2015_8-linode-debian8/lastFailedBuild/
