### PR TITLE
Add support for permissions in boto_lambda

### DIFF
--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -78,6 +78,7 @@ Connection module for Amazon Lambda
 # Import Python libs
 from __future__ import absolute_import
 import logging
+import json
 from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
 
 # Import Salt libs
@@ -85,6 +86,7 @@ import salt.utils.boto3
 import salt.utils.compat
 import salt.utils
 from salt.exceptions import SaltInvocationError
+from salt.ext.six import string_types
 
 log = logging.getLogger(__name__)
 
@@ -262,9 +264,9 @@ def delete_function(FunctionName, Qualifier=None, region=None, key=None, keyid=N
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         if Qualifier:
-            r = conn.delete_function(FunctionName=FunctionName, Qualifier=Qualifier)
+            conn.delete_function(FunctionName=FunctionName, Qualifier=Qualifier)
         else:
-            r = conn.delete_function(FunctionName=FunctionName)
+            conn.delete_function(FunctionName=FunctionName)
         return {'deleted': True}
     except ClientError as e:
         return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}
@@ -391,6 +393,122 @@ def update_function_code(FunctionName, ZipFile=None, S3Bucket=None, S3Key=None,
             return {'updated': False}
     except ClientError as e:
         return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def add_permission(FunctionName, StatementId, Action, Principal, SourceArn=None,
+                   SourceAccount=None, Qualifier=None,
+                   region=None, key=None, keyid=None, profile=None):
+    '''
+    Add a permission to a lambda function.
+
+    Returns {added: true} if the permission was added and returns
+    {added: False} if the permission was not added.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_lamba.add_permission my_function my_id "lambda:*" \\
+                           s3.amazonaws.com aws:arn::::bucket-name \\
+                           aws-account-id
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        kwargs = {}
+        for key in ('SourceArn', 'SourceAccount', 'Qualifier'):
+            if locals()[key] is not None:
+                kwargs[key] = str(locals()[key])
+        conn.add_permission(FunctionName=FunctionName, StatementId=StatementId,
+                                   Action=Action, Principal=str(Principal),
+                                   **kwargs)
+        return {'updated': True}
+    except ClientError as e:
+        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def remove_permission(FunctionName, StatementId, Qualifier=None,
+                   region=None, key=None, keyid=None, profile=None):
+    '''
+    Remove a permission from a lambda function.
+
+    Returns {removed: true} if the permission was removed and returns
+    {removed: False} if the permission was not removed.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_lamba.remove_permission my_function my_id
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        kwargs = {}
+        if Qualifier is not None:
+            kwargs['Qualifier'] = Qualifier
+        conn.remove_permission(FunctionName=FunctionName, StatementId=StatementId,
+                                   **kwargs)
+        return {'updated': True}
+    except ClientError as e:
+        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def get_permissions(FunctionName, Qualifier=None,
+                   region=None, key=None, keyid=None, profile=None):
+    '''
+    Get resource permissions for the given lambda function
+
+    Returns dictionary of permissions, by statement ID
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_lamba.get_permissions my_function
+
+        permissions: {...}
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        kwargs = {}
+        if Qualifier is not None:
+            kwargs['Qualifier'] = Qualifier
+        # The get_policy call is not symmetric with add/remove_permissions. So
+        # massage it until it is, for better ease of use.
+        policy = conn.get_policy(FunctionName=FunctionName,
+                                   **kwargs)
+        policy = policy.get('Policy', {})
+        if isinstance(policy, string_types):
+            policy = json.loads(policy)
+        if policy is None:
+            policy = {}
+        permissions = {}
+        for statement in policy.get('Statement', []):
+            condition = statement.get('Condition', {})
+            principal = statement.get('Principal', {})
+            if 'AWS' in principal:
+                principal = principal['AWS'].split(':')[4]
+            else:
+                principal = principal.get('Service')
+            permission = {
+                'Action': statement.get('Action'),
+                'Principal': principal,
+            }
+            if 'ArnLike' in condition:
+                permission['SourceArn'] = condition['ArnLike'].get('AWS:SourceArn')
+            if 'StringEquals' in condition:
+                permission['SourceAccount'] = condition['StringEquals'].get('AWS:SourceAccount')
+            permissions[statement.get('Sid')] = permission
+        return {'permissions': permissions}
+    except ClientError as e:
+        err = salt.utils.boto3.get_error(e)
+        if e.response.get('Error', {}).get('Code') == 'ResourceNotFoundException':
+            return {'permissions': None}
+        return {'permissions': None, 'error': err}
 
 
 def list_function_versions(FunctionName,

--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -62,10 +62,13 @@ import logging
 import os
 import os.path
 import hashlib
+import json
 
 # Import Salt Libs
 import salt.utils.dictupdate as dictupdate
 import salt.utils
+from salt.exceptions import SaltInvocationError
+from salt.ext.six import string_types
 
 log = logging.getLogger(__name__)
 
@@ -80,6 +83,7 @@ def __virtual__():
 def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S3Bucket=None,
             S3Key=None, S3ObjectVersion=None,
             Description='', Timeout=3, MemorySize=128,
+            Permissions=None,
             region=None, key=None, keyid=None, profile=None):
     '''
     Ensure function exists.
@@ -137,6 +141,9 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S
         to an image processing function. The default value is 128 MB. The value must be a multiple of
         64 MB.
 
+    Permissions
+        A list of permission definitions to be added to the function's policy
+
     region
         Region to connect to.
 
@@ -155,6 +162,21 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S
            'comment': '',
            'changes': {}
            }
+
+    if Permissions is not None:
+        if isinstance(Permissions, string_types):
+            Permissions = json.loads(Permissions)
+        required_keys = set(('Action', 'Principal'))
+        optional_keys = set(('SourceArn', 'SourceAccount'))
+        for sid, permission in Permissions.iteritems():
+            keyset = set(permission.keys())
+            if not keyset.issuperset(required_keys):
+                raise SaltInvocationError('{0} are required for each permission '
+                           'specification'.format(', '.join(required_keys)))
+            keyset = keyset - required_keys
+            keyset = keyset - optional_keys
+            if bool(keyset):
+                raise SaltInvocationError('Invalid permission value {0}'.format(', '.join(keyset)))
 
     r = __salt__['boto_lambda.function_exists'](FunctionName=FunctionName, region=region,
                                     key=key, keyid=keyid, profile=profile)
@@ -182,8 +204,20 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S
             ret['result'] = False
             ret['comment'] = 'Failed to create function: {0}.'.format(r['error']['message'])
             return ret
-        _describe = __salt__['boto_lambda.describe_function'](FunctionName, region=region, key=key,
-                                                  keyid=keyid, profile=profile)
+
+        if Permissions:
+            for sid, permission in Permissions.iteritems():
+                r = __salt__['boto_lambda.add_permission'](FunctionName=FunctionName,
+                                                       StatementId=sid,
+                                                       **permission)
+                if not r.get('updated'):
+                    ret['result'] = False
+                    ret['comment'] = 'Failed to create function: {0}.'.format(r['error']['message'])
+
+        _describe = __salt__['boto_lambda.describe_function'](FunctionName,
+                           region=region, key=key, keyid=keyid, profile=profile)
+        _describe['function']['Permissions'] = __salt__['boto_lambda.get_permissions'](FunctionName,
+                           region=region, key=key, keyid=keyid, profile=profile)['permissions']
         ret['changes']['old'] = {'function': None}
         ret['changes']['new'] = _describe
         ret['comment'] = 'Function {0} created.'.format(FunctionName)
@@ -202,6 +236,15 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S
     ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
     _ret = _function_code_present(FunctionName, ZipFile, S3Bucket, S3Key, S3ObjectVersion,
+                                 region, key, keyid, profile)
+    if not _ret.get('result'):
+        ret['result'] = False
+        ret['comment'] = _ret['comment']
+        ret['changes'] = {}
+        return ret
+    ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
+    ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
+    _ret = _function_permissions_present(FunctionName, Permissions,
                                  region, key, keyid, profile)
     if not _ret.get('result'):
         ret['result'] = False
@@ -310,6 +353,51 @@ def _function_code_present(FunctionName, ZipFile, S3Bucket, S3Key, S3ObjectVersi
             }
         else:
             del ret['changes']['old']
+    return ret
+
+
+def _function_permissions_present(FunctionName, Permissions,
+                           region, key, keyid, profile):
+    ret = {'result': True, 'comment': '', 'changes': {}}
+    curr_permissions = __salt__['boto_lambda.get_permissions'](FunctionName,
+           region=region, key=key, keyid=keyid, profile=profile)['permissions']
+    need_update = False
+    diffs = salt.utils.compare_dicts(curr_permissions, Permissions)
+    if bool(diffs):
+        ret['comment'] = os.linesep.join([ret['comment'], 'Function permissions to be modified'])
+        if __opts__['test']:
+            msg = 'Function {0} set to be modified.'.format(FunctionName)
+            ret['comment'] = msg
+            ret['result'] = None
+            return ret
+        for sid, diff in diffs.iteritems():
+            if diff.get('old', '') != '':
+                # There's a permssion that needs to be removed
+                _r = __salt__['boto_lambda.remove_permission'](FunctionName=FunctionName,
+                                        StatementId=sid,
+                                        region=region, key=key,
+                                        keyid=keyid, profile=profile)
+                ret['changes'].setdefault('new', {}).setdefault('Permissions',
+                                 {})[sid] = {}
+                ret['changes'].setdefault('old', {}).setdefault('Permissions',
+                                 {})[sid] = diff['old']
+            if diff.get('new', '') != '':
+                # New permission information needs to be added
+                _r = __salt__['boto_lambda.add_permission'](FunctionName=FunctionName,
+                                        StatementId=sid,
+                                        region=region, key=key,
+                                        keyid=keyid, profile=profile,
+                                        **diff['new'])
+                ret['changes'].setdefault('new', {}).setdefault('Permissions',
+                                 {})[sid] = diff['new']
+                oldperms = ret['changes'].setdefault('old', {}).setdefault('Permissions',
+                                 {})
+                if sid not in oldperms:
+                    oldperms[sid] = {}
+            if not _r.get('updated'):
+                ret['result'] = False
+                ret['comment'] = 'Failed to update function: {0}.'.format(_r['error']['message'])
+                ret['changes'] = {}
     return ret
 
 


### PR DESCRIPTION
In development of boto_s3_buckets, I noticed that I'd omitted the ability to set permissions on lambda functions in the boto_lambda module. (S3 buckets can issue events to lamdba functions, but need to be given permission to do so.)

This adds that missing piece of functionality to boto_lambda.
