### PR TITLE
cloud vmware ssl fail exception type changed

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -208,7 +208,7 @@ def _get_si():
             port=port
         )
     except Exception as exc:
-        if isinstance(exc, vim.fault.HostConnectFault) and '[SSL: CERTIFICATE_VERIFY_FAILED]' in exc.msg:
+        if '[SSL: CERTIFICATE_VERIFY_FAILED]' in exc.msg:
             try:
                 import ssl
                 default_context = ssl._create_default_https_context


### PR DESCRIPTION
@nmadhok 

the exception type seemed to have changed in the vmware driver /centos7/ pip install pyVmomi

also we should have an cloud providers option to force Verify Certificate.
