### PR TITLE
salt.states.zfs -> schedule_snapshot

### DIFF
--- a/salt/states/zfs.py
+++ b/salt/states/zfs.py
@@ -728,7 +728,7 @@ def scheduled_snapshot(name, prefix, recursive=True, schedule=None):
 
         snapshots will only be created and pruned every time the state runs.
         a schedule must be setup to automatically run the state. this means that if
-        you run the state daily the hourly snapshot will only be made ones per day!
+        you run the state daily the hourly snapshot will only be made once per day!
 
     ..note::
 
@@ -820,29 +820,29 @@ def scheduled_snapshot(name, prefix, recursive=True, schedule=None):
                 snapshots[hold].sort()
                 timestamp = strptime(snapshots[hold][-1], '{0}@{1}-%Y%m%d_%H%M%S'.format(name, prefix))
                 if hold == 'minute':
-                    if current_timestamp.tm_min == timestamp.tm_min and \
-                       current_timestamp.tm_hour == timestamp.tm_hour and \
-                       current_timestamp.tm_mday == timestamp.tm_mday and \
-                       current_timestamp.tm_mon == timestamp.tm_mon and \
-                       current_timestamp.tm_year == current_timestamp.tm_year:
+                    if current_timestamp.tm_min <= timestamp.tm_min and \
+                       current_timestamp.tm_hour <= timestamp.tm_hour and \
+                       current_timestamp.tm_mday <= timestamp.tm_mday and \
+                       current_timestamp.tm_mon <= timestamp.tm_mon and \
+                       current_timestamp.tm_year <= timestamp.tm_year:
                         continue
                 elif hold == 'hour':
-                    if current_timestamp.tm_hour == timestamp.tm_hour and \
-                       current_timestamp.tm_mday == timestamp.tm_mday and \
-                       current_timestamp.tm_mon == timestamp.tm_mon and \
-                       current_timestamp.tm_year == current_timestamp.tm_year:
+                    if current_timestamp.tm_hour <= timestamp.tm_hour and \
+                       current_timestamp.tm_mday <= timestamp.tm_mday and \
+                       current_timestamp.tm_mon <= timestamp.tm_mon and \
+                       current_timestamp.tm_year <= timestamp.tm_year:
                         continue
                 elif hold == 'day':
-                    if current_timestamp.tm_mday == timestamp.tm_mday and \
-                       current_timestamp.tm_mon == timestamp.tm_mon and \
-                       current_timestamp.tm_year == current_timestamp.tm_year:
+                    if current_timestamp.tm_mday <= timestamp.tm_mday and \
+                       current_timestamp.tm_mon <= timestamp.tm_mon and \
+                       current_timestamp.tm_year <= timestamp.tm_year:
                         continue
                 elif hold == 'month':
-                    if current_timestamp.tm_mon == timestamp.tm_mon and \
-                       current_timestamp.tm_year == current_timestamp.tm_year:
+                    if current_timestamp.tm_mon <= timestamp.tm_mon and \
+                       current_timestamp.tm_year <= timestamp.tm_year:
                         continue
                 elif hold == 'year':
-                    if current_timestamp.tm_year == current_timestamp.tm_year:
+                    if current_timestamp.tm_year <= timestamp.tm_year:
                         continue
                 else:
                     log.debug('zfs.scheduled_snapshot::{0}::hold_unknown = {1}'.format(name, hold))

--- a/salt/states/zfs.py
+++ b/salt/states/zfs.py
@@ -803,7 +803,7 @@ def scheduled_snapshot(name, prefix, recursive=True, schedule=None):
                 if snap not in holds or holds[snap] == 'no holds':
                     continue
                 for hold in holds[snap].keys():
-                    if hold not in snapshots:
+                    if hold not in snapshots.keys():
                         continue
                     snapshots[hold].append(snap)
 
@@ -854,6 +854,7 @@ def scheduled_snapshot(name, prefix, recursive=True, schedule=None):
             prefix=prefix,
             timestamp=strftime('%Y%m%d_%H%M%S')
         )
+        log.debug('zfs.scheduled_snapshot::{0}::needed_holds = {1}'.format(name, needed_holds))
         if len(needed_holds) > 0:
             snap = '{dataset}@{snapshot}'.format(dataset=name, snapshot=snap_name)
             res = __salt__['zfs.snapshot'](snap, **{'recursive': recursive})

--- a/salt/states/zfs.py
+++ b/salt/states/zfs.py
@@ -803,9 +803,11 @@ def scheduled_snapshot(name, prefix, recursive=True, schedule=None):
                 if snap not in holds or holds[snap] == 'no holds':
                     continue
                 for hold in holds[snap].keys():
+                    hold = hold.strip()
                     if hold not in snapshots.keys():
                         continue
                     snapshots[hold].append(snap)
+        log.debug('zfs.scheduled_snapshot::{0}::snapshots = {1}'.format(name, snapshots))
 
         # create snapshot
         needed_holds = []

--- a/salt/states/zfs.py
+++ b/salt/states/zfs.py
@@ -709,7 +709,7 @@ def promoted(name):
 
 def scheduled_snapshot(name, prefix, recursive=True, schedule=None):
     '''
-    create snapshots based on a schedule
+    maintain a set of snapshots based on a schedule
 
     name : string
         name of filesystem or volume
@@ -728,16 +728,6 @@ def scheduled_snapshot(name, prefix, recursive=True, schedule=None):
         snapshots will only be created and pruned every time the state runs.
         a schedule must be setup to automatically run the state. this means that if
         you run the state daily the hourly snapshot will only be made once per day!
-
-    ..note::
-
-        because we are dependant on the scheduler on were to run snapshot are not
-        made at absolute times. times will be rounded down.
-
-        e.g. schedule runs every 10 minutes the hourly snapshot 'example-20160115_2100'
-        will be made during the first scheduled run of that hour. for exmaple if the state
-        gets execute at 21:03, 21:13, 21:23, 21:33, 21:43, and 21:53 the snapshot will be
-        taken at 21:03.
 
     '''
     name = name.lower()

--- a/salt/states/zfs.py
+++ b/salt/states/zfs.py
@@ -305,7 +305,6 @@ def hold_present(name, snapshot, recursive=False):
                 if not __opts__['test']:
                     result = __salt__['zfs.hold'](name, snapshot, **{'recursive': recursive})
 
-                log.warning(result)
                 ret['result'] = snapshot in result and name in result[snapshot]
                 if ret['result']:
                     ret['changes'] = result[snapshot]


### PR DESCRIPTION
Additional state for salt.states.zfs that will create and prune snapshots on filesystems or volumes.

``` yaml
zsnapper:
  zfs.scheduled_snapshot:
    - name: test/ds1
    - prefix: snap
    - recursive: true
    - schedule:
        minute: 60
        hour: 24
        day: 7
```

This will keep snapshots for test/ds1 and all its children, the snapshots will be named:
 `test/ds1@snap-YYYYMMDD_HHmmSS`. This allows other applications like samba to offer shadow copies based on the snapshot name.

Holds are use to determine if a snapshot is still needed for this schedule.
This means there will be:
- 7 snapshots with the hold `day`
- 24 snapshots with the hold `hour`
- 60 snapshots with the hold `minute`

For a total of 89 (7+23+59) snapshots because there will be 1 snapshots that has the holds `minutes` + `hour` + `day` and one that has `minutes` + `hour` tags.

Once a snapshot has no tags left it gets pruned. Snapshots that do not have the prefix defined will be ignored.
