### PR TITLE
update suse information regarding to repositories fixes #29194 

### DIFF
--- a/doc/topics/installation/suse.rst
+++ b/doc/topics/installation/suse.rst
@@ -2,14 +2,19 @@
 SUSE Installation
 =================
 
-With openSUSE 13.2, Salt 2014.1.11 is available in the primary repositories.
-The devel:language:python repo will have more up to date versions of salt,
-all package development will be done there.
+Since openSUSE 13.2, Salt 2014.1.11 is available in the primary repositories.
+With the release of suse manager 3 a new repository setup has been created.
+The new repo will by systemsmanagement:saltstack, this repo will be the source
+for newer stable packages. For backward compatibilty a linkpackage will be 
+created to the old devel:language:python repo. 
+All development of suse packages will be done in systemsmanagement:saltstack:testing.
+This will ensure that salt will be in mainline suse repo's, a stable release
+repo and a testing repo for further enhancements.
 
 Installation
 ============
 
-Salt can be installed using ``zypper`` and is available in the standard openSUSE
+Salt can be installed using ``zypper`` and is available in the standard openSUSE/SLES
 repositories.
 
 Stable Release
@@ -93,11 +98,20 @@ Unstable Release
 openSUSE
 --------
 
-For openSUSE Factory run the following as root:
+For openSUSE Tumbleweed run the following as root:
 
 .. code-block:: bash
 
-    zypper addrepo http://download.opensuse.org/repositories/devel:languages:python/openSUSE_Factory/devel:languages:python.repo
+    zypper addrepo http://download.opensuse.org/repositories/systemsmanagement:/saltstack/openSUSE_Tumbleweed/systemsmanagement:saltstack.repo
+    zypper refresh
+    zypper install salt salt-minion salt-master
+
+
+For openSUSE 42.1 Leap run the following as root:
+
+.. code-block:: bash
+
+    zypper addrepo http://download.opensuse.org/repositories/systemsmanagement:/saltstack/openSUSE_Leap_42.1/systemsmanagement:saltstack.repo
     zypper refresh
     zypper install salt salt-minion salt-master
 
@@ -106,24 +120,7 @@ For openSUSE 13.2 run the following as root:
 
 .. code-block:: bash
 
-    zypper addrepo http://download.opensuse.org/repositories/devel:languages:python/openSUSE_13.2/devel:languages:python.repo
-    zypper refresh
-    zypper install salt salt-minion salt-master
-
-
-For openSUSE 13.1 run the following as root:
-
-.. code-block:: bash
-
-    zypper addrepo http://download.opensuse.org/repositories/devel:languages:python/openSUSE_13.1/devel:languages:python.repo
-    zypper refresh
-    zypper install salt salt-minion salt-master
-
-For bleeding edge python Factory run the following as root:
-
-.. code-block:: bash
-
-    zypper addrepo http://download.opensuse.org/repositories/devel:languages:python/bleeding_edge_python_Factory/devel:languages:python.repo
+    zypper addrepo http://download.opensuse.org/repositories/systemsmanagement:/saltstack/openSUSE_13.2/systemsmanagement:saltstack.repo
     zypper refresh
     zypper install salt salt-minion salt-master
 
@@ -134,23 +131,15 @@ For SLE 12 run the following as root:
 
 .. code-block:: bash
 
-    zypper addrepo http://download.opensuse.org/repositories/devel:languages:python/SLE_12/devel:languages:python.repo
+    zypper addrepo http://download.opensuse.org/repositories/systemsmanagement:/saltstack/SLE_12/systemsmanagement:saltstack.repo
     zypper refresh
     zypper install salt salt-minion salt-master
 
-For SLE 11 SP3 run the following as root:
+For SLE 11 SP4 run the following as root:
 
 .. code-block:: bash
 
-    zypper addrepo http://download.opensuse.org/repositories/devel:languages:python/SLE_11_SP3/devel:languages:python.repo
-    zypper refresh
-    zypper install salt salt-minion salt-master
-
-For SLE 11 SP2 run the following as root:
-
-.. code-block:: bash
-
-    zypper addrepo http://download.opensuse.org/repositories/devel:languages:python/SLE_11_SP2/devel:languages:python.repo
+    zypper addrepo http://download.opensuse.org/repositories/systemsmanagement:/saltstack/SLE_11_SP4/systemsmanagement:saltstack.repo
     zypper refresh
     zypper install salt salt-minion salt-master
 


### PR DESCRIPTION
Caution!!! don't merge without checking.

This requires coordination between salt, salt-bootstrap and suse/opensuse.
see https://github.com/saltstack/salt-bootstrap/issues/706

We need to make sure that everything in salt-bootstrap is also ready.
and all repo's are working perfectly.

I don't know if salt also wants a announcement of this change,
because a lot of suse / opensuse users using the old repo's

Please wait until I give the go ahead
