### PR TITLE
make prtdiag fix play nicer with zones

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -527,7 +527,8 @@ def _virtual(osdata):
                 if salt.log.is_logging_configured():
                     # systemd-detect-virt always returns > 0 on non-virtualized
                     # systems
-                    if salt.utils.is_windows() or 'systemd-detect-virt' in cmd:
+                    # prtdiag only works in the global zone, skip if it fails
+                    if salt.utils.is_windows() or 'systemd-detect-virt' in cmd or 'prtdiag' in cmd:
                         continue
                     failed_commands.add(command)
                 continue


### PR DESCRIPTION
The recent virtual grain fix on Solaris gave a warning when ran inside a zone:

``` bash
[root@nacl /salt_dev/salt]# /opt/salt/bin/salt-call --local grains.get virtual
[WARNING ] Although 'prtdiag' was found in path, the current user cannot execute it. Grains output might not be accurate.
local:
    zone
```

This small pr fixes this

``` bash
[root@nacl /salt_dev/salt]# /opt/salt/bin/salt-call --local grains.get virtual
local:
    zone
```
