### PR TITLE
Check if byte strings are properly encoded in UTF-8

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -125,6 +125,12 @@ def info_installed(*names, **attr):
         t_nfo = dict()
         # Translate dpkg-specific keys to a common structure
         for key, value in pkg_nfo.items():
+            if type(value) == str:
+                # Check, if string is encoded in a proper UTF-8
+                value_ = value.decode('UTF-8', 'ignore').encode('UTF-8', 'ignore')
+                if value != value_:
+                    value = value_
+                    log.error('Package {0} has bad UTF-8 code in {1}: {2}'.format(pkg_name, key, value))
             if key == 'source_rpm':
                 t_nfo['source'] = value
             else:

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -96,7 +96,7 @@ def list_upgrades(refresh=True):
 list_updates = salt.utils.alias_function(list_upgrades, 'list_updates')
 
 
-def info_installed(*names, **attr):
+def info_installed(*names, **kwargs):
     '''
     Return the information of the named package(s), installed on the system.
 
@@ -121,7 +121,7 @@ def info_installed(*names, **attr):
         salt '*' pkg.info_installed <package1> <package2> <package3> ... attr=version,vendor
     '''
     ret = dict()
-    for pkg_name, pkg_nfo in __salt__['lowpkg.info'](*names, **attr).items():
+    for pkg_name, pkg_nfo in __salt__['lowpkg.info'](*names, **kwargs).items():
         t_nfo = dict()
         # Translate dpkg-specific keys to a common structure
         for key, value in pkg_nfo.items():

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -129,7 +129,7 @@ def info_installed(*names, **kwargs):
                 # Check, if string is encoded in a proper UTF-8
                 value_ = value.decode('UTF-8', 'ignore').encode('UTF-8', 'ignore')
                 if value != value_:
-                    value = value_
+                    value = kwargs.get('errors', 'ignore') == 'ignore' and value_ or 'N/A (broken)'
                     log.error('Package {0} has bad UTF-8 code in {1}: {2}'.format(pkg_name, key, value))
             if key == 'source_rpm':
                 t_nfo['source'] = value

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -111,6 +111,14 @@ def info_installed(*names, **kwargs):
             build_host, group, source_rpm, arch, epoch, size, license, signature, packager, url,
             summary, description.
 
+    :param errors:
+        Handle RPM field errors. If 'ignore' is chosen, then various mistakes are simply ignored and omitted
+        from the texts or strings. If 'report' is chonen, then a field with a mistake is not returned, instead
+        a 'N/A (broken)' (not available, broken) text is placed.
+
+        Valid attributes are:
+            ignore, report
+
     CLI example:
 
     .. code-block:: bash
@@ -119,6 +127,8 @@ def info_installed(*names, **kwargs):
         salt '*' pkg.info_installed <package1> <package2> <package3> ...
         salt '*' pkg.info_installed <package1> attr=version,vendor
         salt '*' pkg.info_installed <package1> <package2> <package3> ... attr=version,vendor
+        salt '*' pkg.info_installed <package1> <package2> <package3> ... attr=version,vendor errors=ignore
+        salt '*' pkg.info_installed <package1> <package2> <package3> ... attr=version,vendor errors=report
     '''
     ret = dict()
     for pkg_name, pkg_nfo in __salt__['lowpkg.info'](*names, **kwargs).items():

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -139,7 +139,7 @@ def info_installed(*names, **kwargs):
                 # Check, if string is encoded in a proper UTF-8
                 value_ = value.decode('UTF-8', 'ignore').encode('UTF-8', 'ignore')
                 if value != value_:
-                    value = kwargs.get('errors', 'ignore') == 'ignore' and value_ or 'N/A (broken)'
+                    value = kwargs.get('errors', 'ignore') == 'ignore' and value_ or 'N/A (invalid UTF-8)'
                     log.error('Package {0} has bad UTF-8 code in {1}: {2}'.format(pkg_name, key, value))
             if key == 'source_rpm':
                 t_nfo['source'] = value


### PR DESCRIPTION
Sometimes 3rd party packages contains broken UTF-8 strings. This renders JSON output crash (although works on STDOUT and YAML). This PR fixes this problem and logs the error log about bad package.
