### PR TITLE
Added feature: cp.push delete source file

### DIFF
--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -725,6 +725,14 @@ def push(path, keep_symlinks=False, upload_path=None, remove_source=False):
             load['loc'] = fp_.tell()
             load['data'] = fp_.read(__opts__['file_buffer_size'])
             if not load['data'] and init_send:
+                if remove_source:
+                    try:
+                        salt.utils.rm_rf(path)
+                        log.debug('Removing source file \'{0}\''.format(path))
+                    except IOError:
+                        log.error('cp.push failed to remove file \
+                                  \'{0}\''.format(path))
+                        return False
                 return True
             ret = channel.send(load)
             if not ret:
@@ -734,12 +742,6 @@ def push(path, keep_symlinks=False, upload_path=None, remove_source=False):
                           'setting on the master.')
                 return ret
             init_send = True
-    if remove_source:
-        try:
-            salt.utils.rm_rf(path)
-            log.debug('Removing source file \'{0}\'').format(path)
-        except IOError:
-            log.error('cp.push failed to remove file \'{0}\'').format(path)
 
 
 def push_dir(path, glob=None, upload_path=None):

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -777,7 +777,7 @@ def push_dir(path, glob=None, upload_path=None):
         return push(path, upload_path=upload_path)
     else:
         filelist = []
-        for root, files in os.walk(path):
+        for root, _, files in os.walk(path):
             filelist += [os.path.join(root, tmpfile) for tmpfile in files]
         if glob is not None:
             filelist = [fi for fi in filelist if fnmatch.fnmatch(os.path.basename(fi), glob)]


### PR DESCRIPTION
As I tried to help over at #30415 I misunderstood the question and ended up with some code that didn't solve the issue. It is, however, a new feature.

Basicly add "remove_source=False" as default to cp.push. If "remove_source" is set to True, it will remove the pushed file from the minion, after it's been pushed.
