### PR TITLE
Support the new 17 character AWS IDs

### DIFF
--- a/salt/pillar/ec2_pillar.py
+++ b/salt/pillar/ec2_pillar.py
@@ -84,7 +84,7 @@ def ext_pillar(minion_id,
     # if there is a grain named 'instance-id' use that.  Because this is a
     # security risk, the master config must contain a use_grain: True option
     # for this external pillar, which defaults to no
-    if re.search(r'^i-[0-9a-z]{8}$', minion_id) is None:
+    if re.search(r'^i-([0-9a-z]{17}|[0-9a-z]{8})$', minion_id) is None:
         if 'instance-id' not in __grains__:
             log.debug("Minion-id is not in AWS instance-id formation, and there "
                       "is no instance-id grain for minion {0}".format(minion_id))
@@ -103,7 +103,7 @@ def ext_pillar(minion_id,
                       "not in the list of allowed minions {1}".format(minion_id,
                       minion_ids))
             return {}
-        if re.search(r'^i-[0-9a-z]{8}$', __grains__['instance-id']) is not None:
+        if re.search(r'^i-([0-9a-z]{17}|[0-9a-z]{8})$', __grains__['instance-id']) is not None:
             minion_id = __grains__['instance-id']
             log.debug("Minion-id is not in AWS instance ID format, but a grain"
                       " is, so using {0} as the minion ID".format(minion_id))


### PR DESCRIPTION
Hello!

This change allows the matcher to find both 8 and 17 character IDs (https://aws.amazon.com/ec2/faqs/#longer-ids). I noticed it's using a-z which probably should be a-f but that's for another MR.
