### PR TITLE
Exception when analysed process is turned off during execution.

### DIFF
--- a/salt/modules/restartcheck.py
+++ b/salt/modules/restartcheck.py
@@ -368,7 +368,11 @@ def restartcheck(ignorelist=None, blacklist=None, excludepid=None, verbose=True)
         name, pid, path = deleted_file[0], deleted_file[1], deleted_file[2]
         if path in blacklist or pid in excludepid:
             continue
-        readlink = os.readlink('/proc/{0}/exe'.format(pid))
+        try:
+            readlink = os.readlink('/proc/{0}/exe'.format(pid))
+        except OSError:
+            excludepid.append(pid)
+            continue
         try:
             packagename = owners_cache[readlink]
         except KeyError:


### PR DESCRIPTION
Modified the script to skip processes where os.readlink fails.  In very rare situation os.readlink fails when process folder is deleted (process ends) during his examination  - so we are just skipping this concrete process and continue examining other deleted files.
