### PR TITLE
Fix osx scripts location

### DIFF
--- a/pkg/osx/build_env.sh
+++ b/pkg/osx/build_env.sh
@@ -325,7 +325,7 @@ sudo -H /opt/salt/bin/pip install \
 echo "--------------------------------------------------------------------------------"
 echo "Create Symlink to certifi for openssl"
 echo "--------------------------------------------------------------------------------"
-ln -s /opt/salt/lib/python2.7/site-packages/certifi/cacert.pem /opt/salt/openssl/cert.pem
+sudo ln -s /opt/salt/lib/python2.7/site-packages/certifi/cacert.pem /opt/salt/openssl/cert.pem
 
 echo -n -e "\033]0;Build_Evn: Finished\007"
 

--- a/pkg/osx/build_pkg.sh
+++ b/pkg/osx/build_pkg.sh
@@ -109,7 +109,7 @@ fi
 
 echo -n -e "\033]0;Build_Pkg: Copy Start Scripts\007"
 
-cp $PKGRESOURCES/scripts/start-*.sh /opt/salt
+sudo cp $PKGRESOURCES/scripts/start-*.sh /opt/salt/bin/
 
 ############################################################################
 # Copy Service Definitions from Salt Repo to the Package Directory


### PR DESCRIPTION
This fixes the build script. Without those changes, I could  not build a functioning package (using `v2015.8.3` tag)
