### PR TITLE
Remove fsutils references from modules list

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -107,7 +107,6 @@ Full list of builtin execution modules
     freebsdpkg
     freebsdports
     freebsdservice
-    fsutils
     gem
     genesis
     gentoo_service

--- a/doc/ref/modules/all/salt.modules.fsutils.rst
+++ b/doc/ref/modules/all/salt.modules.fsutils.rst
@@ -1,6 +1,0 @@
-====================
-salt.modules.fsutils
-====================
-
-.. automodule:: salt.modules.fsutils
-    :members:


### PR DESCRIPTION
Fixes #22820

`fsutils` was moved from `salt/modules/fsutils.py` to `salt/utils/fsutils.py` in b36d48b84f679f87a9b8a6f82a8995fd6c1479cc, because fsutils is a utility function used in the `salt/modules/btrfs.py` execution module, and not its own salt module.

When the moved happened, however, we forgot to remove the module doc references.
