### PR TITLE
Stop the deprecation path started in 0.17 about ext_pillar

### DIFF
--- a/doc/topics/releases/boron.rst
+++ b/doc/topics/releases/boron.rst
@@ -8,6 +8,12 @@ Core Changes
 ============
 
 - The onchanges requisite now fires if _any_ watched state changes. Refs #19592.
+- The ``ext_pillar`` functions **must** now accept a minion ID as the first 
+  argument. This stops the deprecation path started in Salt 0.17.x. Before this 
+  minion ID first argument was introduced, the minion ID could be retrieved 
+  accessing ``__opts__['id']`` loosing the reference to the master ID initially 
+  set in opts. This is no longer the case, ``__opts__['id']`` will be kept as 
+  the master ID.
 
 
 Cloud Changes

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -183,10 +183,7 @@ class Pillar(object):
         self.actual_file_roots = opts['file_roots']
         # use the local file client
         self.opts = self.__gen_opts(opts, grains, saltenv=saltenv, ext=ext, pillarenv=pillarenv)
-        minion_opts = copy.deepcopy(self.opts)
-        minion_opts['id'] = minion_id
-        self.minion_opts = minion_opts
-        self.client = salt.fileclient.get_file_client(self.minion_opts, True)
+        self.client = salt.fileclient.get_file_client(self.opts, True)
 
         if opts.get('file_client', '') == 'local':
             opts['grains'] = grains
@@ -197,16 +194,18 @@ class Pillar(object):
             if opts.get('file_client', '') == 'local':
                 self.functions = salt.loader.minion_mods(opts, utils=utils)
             else:
-                self.functions = salt.loader.minion_mods(self.minion_opts, utils=utils)
+                self.functions = salt.loader.minion_mods(self.opts, utils=utils)
         else:
             self.functions = functions
 
-        self.matcher = salt.minion.Matcher(self.minion_opts, self.functions)
-        self.rend = salt.loader.render(self.minion_opts, self.functions)
+        self.matcher = salt.minion.Matcher(self.opts, self.functions)
+        self.rend = salt.loader.render(self.opts, self.functions)
+        ext_pillar_opts = copy.deepcopy(self.opts)
         # Fix self.opts['file_roots'] so that ext_pillars know the real
         # location of file_roots. Issue 5951
-        ext_pillar_opts = dict(self.opts)
         ext_pillar_opts['file_roots'] = self.actual_file_roots
+        # Keep the incoming opts ID intact, ie, the master id
+        ext_pillar_opts['id'] = opts['id']
         self.merge_strategy = 'smart'
         if opts.get('pillar_source_merging_strategy'):
             self.merge_strategy = opts['pillar_source_merging_strategy']
@@ -244,7 +243,7 @@ class Pillar(object):
             )
             # Backwards compatibility
             saltenv = env
-        opts = dict(opts_in)
+        opts = copy.deepcopy(opts_in)
         opts['file_roots'] = opts['pillar_roots']
         opts['file_client'] = 'local'
         if not grains:
@@ -253,6 +252,7 @@ class Pillar(object):
             opts['grains'] = grains
         if 'environment' not in opts:
             opts['environment'] = saltenv
+        opts['id'] = self.minion_id
         if 'pillarenv' not in opts:
             opts['pillarenv'] = pillarenv
         if opts['state_top'].startswith('salt://'):

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -205,7 +205,8 @@ class Pillar(object):
         # location of file_roots. Issue 5951
         ext_pillar_opts['file_roots'] = self.actual_file_roots
         # Keep the incoming opts ID intact, ie, the master id
-        ext_pillar_opts['id'] = opts['id']
+        if 'id' in opts:
+            ext_pillar_opts['id'] = opts['id']
         self.merge_strategy = 'smart'
         if opts.get('pillar_source_merging_strategy'):
             self.merge_strategy = opts['pillar_source_merging_strategy']

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -247,7 +247,6 @@ class Pillar(object):
             opts['grains'] = {}
         else:
             opts['grains'] = grains
-        opts['id'] = id_
         if 'environment' not in opts:
             opts['environment'] = saltenv
         if 'pillarenv' not in opts:
@@ -635,35 +634,23 @@ class Pillar(object):
                 return {}
             for key, val in six.iteritems(run):
                 if key not in self.ext_pillars:
-                    err = ('Specified ext_pillar interface {0} is '
-                           'unavailable').format(key)
-                    log.critical(err)
+                    log.critical(
+                        'Specified ext_pillar interface {0} is '
+                        'unavailable'.format(key)
+                    )
                     continue
                 try:
-                    try:
-                        ext = self._external_pillar_data(pillar,
-                                                         val,
-                                                         pillar_dirs,
-                                                         key)
-                    except TypeError as exc:
-                        if str(exc).startswith('ext_pillar() takes exactly '):
-                            log.warning('Deprecation warning: ext_pillar "{0}"'
-                                        ' needs to accept minion_id as first'
-                                        ' argument'.format(key))
-                        else:
-                            raise
-
-                        ext = self._external_pillar_data(pillar,
-                                                         val,
-                                                         pillar_dirs,
-                                                         key)
-                except Exception as exc:
+                    ext = self._external_pillar_data(pillar,
+                                                        val,
+                                                        pillar_dirs,
+                                                        key)
+                except Exception as exc:  # pylint: disable=broad-except
                     log.exception(
-                            'Failed to load ext_pillar {0}: {1}'.format(
-                                key,
-                                exc
-                                )
-                            )
+                        'Failed to load ext_pillar {0}: {1}'.format(
+                            key,
+                            exc
+                        )
+                    )
             if ext:
                 pillar = merge(
                     pillar,

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -176,46 +176,40 @@ class Pillar(object):
     '''
     Read over the pillar top files and render the pillar data
     '''
-    def __init__(self, opts, grains, minion_id, saltenv, ext=None,
-                 functions=None, pillar=None, pillarenv=None):
-        # Keep a copy of the incoming master opts. Any changes made to it won't change
-        # the passed dictionary, they are local to this class
-        self.master_opts = copy.deepcopy(opts)
+    def __init__(self, opts, grains, minion_id, saltenv, ext=None, functions=None,
+                 pillar=None, pillarenv=None):
         self.minion_id = minion_id
         # Store the file_roots path so we can restore later. Issue 5449
         self.actual_file_roots = opts['file_roots']
         # use the local file client
-        self.opts = self.__gen_opts(self.master_opts,
-                                    grains,
-                                    saltenv=saltenv,
-                                    ext=ext,
-                                    pillarenv=pillarenv)
-        self.client = salt.fileclient.get_file_client(self.opts, True)
+        self.opts = self.__gen_opts(opts, grains, saltenv=saltenv, ext=ext, pillarenv=pillarenv)
+        minion_opts = copy.deepcopy(self.opts)
+        minion_opts['id'] = minion_id
+        self.minion_opts = minion_opts
+        self.client = salt.fileclient.get_file_client(self.minion_opts, True)
 
-        if self.master_opts.get('file_client', '') == 'local':
-            self.master_opts['grains'] = grains
+        if opts.get('file_client', '') == 'local':
+            opts['grains'] = grains
 
         # if we didn't pass in functions, lets load them
         if functions is None:
-            utils = salt.loader.utils(self.master_opts)
-            if self.master_opts.get('file_client', '') == 'local':
-                self.functions = salt.loader.minion_mods(self.master_opts, utils=utils)
+            utils = salt.loader.utils(opts)
+            if opts.get('file_client', '') == 'local':
+                self.functions = salt.loader.minion_mods(opts, utils=utils)
             else:
-                self.functions = salt.loader.minion_mods(self.opts, utils=utils)
+                self.functions = salt.loader.minion_mods(self.minion_opts, utils=utils)
         else:
             self.functions = functions
 
-        self.matcher = salt.minion.Matcher(self.opts, self.functions)
-        self.rend = salt.loader.render(self.opts, self.functions)
+        self.matcher = salt.minion.Matcher(self.minion_opts, self.functions)
+        self.rend = salt.loader.render(self.minion_opts, self.functions)
         # Fix self.opts['file_roots'] so that ext_pillars know the real
         # location of file_roots. Issue 5951
-        # Additionally, pass the master options in order not to loose
-        # the master id under __opts__
-        ext_pillar_opts = copy.deepcopy(self.master_opts)
+        ext_pillar_opts = dict(self.opts)
         ext_pillar_opts['file_roots'] = self.actual_file_roots
         self.merge_strategy = 'smart'
-        if self.master_opts.get('pillar_source_merging_strategy'):
-            self.merge_strategy = self.master_opts['pillar_source_merging_strategy']
+        if opts.get('pillar_source_merging_strategy'):
+            self.merge_strategy = opts['pillar_source_merging_strategy']
 
         self.ext_pillars = salt.loader.pillars(ext_pillar_opts, self.functions)
         self.ignored_pillars = {}
@@ -250,7 +244,7 @@ class Pillar(object):
             )
             # Backwards compatibility
             saltenv = env
-        opts = copy.deepcopy(opts_in)
+        opts = dict(opts_in)
         opts['file_roots'] = opts['pillar_roots']
         opts['file_client'] = 'local'
         if not grains:
@@ -272,7 +266,6 @@ class Pillar(object):
                 opts['ext_pillar'].append(ext)
             else:
                 opts['ext_pillar'] = [ext]
-        opts['id'] = self.minion_id
         return opts
 
     def _get_envs(self):

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -176,12 +176,13 @@ class Pillar(object):
     '''
     Read over the pillar top files and render the pillar data
     '''
-    def __init__(self, opts, grains, id_, saltenv, ext=None, functions=None,
+    def __init__(self, opts, grains, minion_id, saltenv, ext=None, functions=None,
                  pillar=None, pillarenv=None):
+        self.minion_id = minion_id
         # Store the file_roots path so we can restore later. Issue 5449
         self.actual_file_roots = opts['file_roots']
         # use the local file client
-        self.opts = self.__gen_opts(opts, grains, id_, saltenv=saltenv, ext=ext, pillarenv=pillarenv)
+        self.opts = self.__gen_opts(opts, grains, saltenv=saltenv, ext=ext, pillarenv=pillarenv)
         self.client = salt.fileclient.get_file_client(self.opts, True)
 
         if opts.get('file_client', '') == 'local':
@@ -227,7 +228,7 @@ class Pillar(object):
             return {}
         return ext
 
-    def __gen_opts(self, opts_in, grains, id_, saltenv=None, ext=None, env=None, pillarenv=None):
+    def __gen_opts(self, opts_in, grains, saltenv=None, ext=None, env=None, pillarenv=None):
         '''
         The options need to be altered to conform to the file client
         '''
@@ -316,7 +317,7 @@ class Pillar(object):
             errors.append(
                     ('Rendering Primary Top file failed, render error:\n{0}'
                         .format(exc)))
-            log.error('Pillar rendering failed for minion {0}: '.format(self.opts['id']),
+            log.error('Pillar rendering failed for minion {0}: '.format(self.minion_id),
                     exc_info=True)
 
         # Search initial top files for includes
@@ -590,26 +591,24 @@ class Pillar(object):
         '''
         ext = None
 
-        # try the new interface, which includes the minion ID
-        # as first argument
         if isinstance(val, dict):
-            ext = self.ext_pillars[key](self.opts['id'], pillar, **val)
+            ext = self.ext_pillars[key](self.minion_id, pillar, **val)
         elif isinstance(val, list):
             if key == 'git':
-                ext = self.ext_pillars[key](self.opts['id'],
+                ext = self.ext_pillars[key](self.minion_id,
                                             val,
                                             pillar_dirs)
             else:
-                ext = self.ext_pillars[key](self.opts['id'],
+                ext = self.ext_pillars[key](self.minion_id,
                                             pillar,
                                             *val)
         else:
             if key == 'git':
-                ext = self.ext_pillars[key](self.opts['id'],
+                ext = self.ext_pillars[key](self.minion_id,
                                             val,
                                             pillar_dirs)
             else:
-                ext = self.ext_pillars[key](self.opts['id'],
+                ext = self.ext_pillars[key](self.minion_id,
                                             pillar,
                                             val)
         return ext


### PR DESCRIPTION
The `ext_pillar` functions **must** now accept a minion ID as the first argument.
This stops the deprecation path started in Salt [0.17.x](https://github.com/saltstack/salt/blob/0.17/salt/pillar/__init__.py#L429). Before this minion ID first argument was introduced, the minion ID could be retrieved accessing `__opts__['id']` loosing the reference to the master ID initially set in opts.
This is no longer the case, `__opts__['id']` will be kept as the master ID.
