### PR TITLE
smtp_return: an empty optional config value "smtp.renderer" leads to …

### DIFF
--- a/salt/returners/__init__.py
+++ b/salt/returners/__init__.py
@@ -186,7 +186,7 @@ def _options_browser(cfg, ret_config, defaults, virtualname, options):
                 continue
 
         # fallback (implicit else for all ifs)
-        yield option, ''
+        continue
 
 
 def _fetch_profile_opts(


### PR DESCRIPTION
…a blank e-mail #30438

fixed salt/returners/**init**.py b/salt/returners/**init**.py

issue_#30438
