### PR TITLE
Fix password variable type is int instead of string in postgres module

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -926,6 +926,8 @@ def _maybe_encrypt_password(role,
     '''
     pgsql passwords are md5 hashes of the string: 'md5{password}{rolename}'
     '''
+    if password is not None:
+        password = str(password)
     if encrypted and password and not password.startswith('md5'):
         password = "md5{0}".format(
             hashlib.md5(salt.utils.to_bytes('{0}{1}'.format(password, role))).hexdigest())


### PR DESCRIPTION
There is a minor flaw in postgres module. When a postgres user is created, if a password contains only numbers it will be of type int instead of string, and the module execution fails in _maybe_encrypt_password function.
