### PR TITLE
fix incorrect smartos grains

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2034,6 +2034,8 @@ def _smartos_zone_data():
     # allow roles to be defined in vmadm metadata
     for mdata_grain in __salt__['cmd.run']('mdata-list').splitlines():
         grain_name = 'mdata_{0}'.format(mdata_grain) if mdata_grain != 'salt:role' else 'role'
+        grain_name = grain_name.replace(':', '_')
+        grain_name = grain_name.replace('-', '_')
         grains[grain_name] = __salt__['cmd.run']('mdata-get {0}'.format(mdata_grain))
 
     return grains

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2033,10 +2033,19 @@ def _smartos_zone_data():
 
     # allow roles to be defined in vmadm metadata
     for mdata_grain in __salt__['cmd.run']('mdata-list').splitlines():
-        grain_name = 'mdata_{0}'.format(mdata_grain) if mdata_grain != 'salt:role' else 'role'
-        grain_name = grain_name.replace(':', '_')
-        grain_name = grain_name.replace('-', '_')
-        grains[grain_name] = __salt__['cmd.run']('mdata-get {0}'.format(mdata_grain))
+        grain_data = __salt__['cmd.run']('mdata-get {0}'.format(mdata_grain))
+
+        if mdata_grain == 'salt:roles':  # parse salt:roles as roles grain
+            grain_data = grain_data.split(',')
+            grains['roles'] = grain_data
+        else:  # parse other grains into mdata
+            if not mdata_grain.startswith('sdc:'):
+                if 'mdata' not in grains:
+                    grains['mdata'] = {}
+
+                mdata_grain = mdata_grain.replace('-', '_')
+                mdata_grain = mdata_grain.replace(':', '_')
+                grains['mdata'][mdata_grain] = grain_data
 
     return grains
 


### PR DESCRIPTION
- fix OS grain to report SmartOS again (was apparently broken)
- only try and collect zone related SmartOS grains if we are in a zone on SmartOS
- expose mdata (metadata specific for SmartOS) as grains
- map special 'salt:role' metadata to role grain

``` json
...
  "customer_metadata": {
    "salt:roles": "salt-master",
    "user-script": "/srv/salt/bootstrap/zoneinit"
  },
...
```

```
[root@cronos ~]# mdata-list
user-script
salt:roles
```

```
[root@cronos ~]# mdata-get salt:roles
salt-master,test-server
```

`[root@cronos ~]# salt-call --local grains.get roles`

``` yaml
local:
    - salt-master
    - test-serverl
```

`[root@cronos ~]# salt-call --local grains.get mdata`

``` yaml
local:
    ----------
    user_script:
        /srv/salt/bootstrap/zoneinit
```
