### PR TITLE
Backport DNF support to 2015.5 branch

### DIFF
--- a/doc/ref/modules/all/salt.modules.yumpkg.rst
+++ b/doc/ref/modules/all/salt.modules.yumpkg.rst
@@ -4,4 +4,4 @@ salt.modules.yumpkg
 
 .. automodule:: salt.modules.yumpkg
     :members:
-    :exclude-members: available_version
+    :exclude-members: available_version, get_locked_packages


### PR DESCRIPTION
This will allow 2015.5 releases to operate successfully on Fedora 22 and
newer.

Resolves #23553.
