### PR TITLE
Do not use '__master_alive' schedule on TCP transport

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -867,7 +867,8 @@ class Minion(MinionBase):
             self.schedule.delete_job('__mine_interval', persist=True)
 
         # add master_alive job if enabled
-        if self.opts['master_alive_interval'] > 0:
+        if (self.opts['transport'] != 'tcp' and
+                self.opts['master_alive_interval'] > 0):
             self.schedule.add_job({
                 '__master_alive':
                 {
@@ -879,6 +880,8 @@ class Minion(MinionBase):
                                'connected': True}
                 }
             }, persist=True)
+        else:
+            self.schedule.delete_job('__master_alive', persist=True)
 
         self.grains_cache = self.opts['grains']
 
@@ -1672,7 +1675,6 @@ class Minion(MinionBase):
             log.debug('Forwarding master event tag={tag}'.format(tag=data['tag']))
             self._fire_master(data['data'], data['tag'], data['events'], data['pretag'])
         elif package.startswith('__master_disconnected'):
-            tag, data = salt.utils.event.MinionEvent.unpack(tag, data)
             # if the master disconnect event is for a different master, raise an exception
             if data['master'] != self.opts['master']:
                 raise Exception()
@@ -1680,16 +1682,17 @@ class Minion(MinionBase):
                 # we are not connected anymore
                 self.connected = False
                 # modify the scheduled job to fire only on reconnect
-                schedule = {
-                   'function': 'status.master',
-                   'seconds': self.opts['master_alive_interval'],
-                   'jid_include': True,
-                   'maxrunning': 2,
-                   'kwargs': {'master': self.opts['master'],
-                              'connected': False}
-                }
-                self.schedule.modify_job(name='__master_alive',
-                                         schedule=schedule)
+                if self.opts['transport'] != 'tcp':
+                    schedule = {
+                       'function': 'status.master',
+                       'seconds': self.opts['master_alive_interval'],
+                       'jid_include': True,
+                       'maxrunning': 2,
+                       'kwargs': {'master': self.opts['master'],
+                                  'connected': False}
+                    }
+                    self.schedule.modify_job(name='__master_alive',
+                                             schedule=schedule)
 
                 log.info('Connection to master {0} lost'.format(self.opts['master']))
 
@@ -1712,16 +1715,17 @@ class Minion(MinionBase):
                         log.info('Minion is ready to receive requests!')
 
                         # update scheduled job to run with the new master addr
-                        schedule = {
-                           'function': 'status.master',
-                           'seconds': self.opts['master_alive_interval'],
-                           'jid_include': True,
-                           'maxrunning': 2,
-                           'kwargs': {'master': self.opts['master'],
-                                      'connected': True}
-                        }
-                        self.schedule.modify_job(name='__master_alive',
-                                                 schedule=schedule)
+                        if self.opts['transport'] != 'tcp':
+                            schedule = {
+                               'function': 'status.master',
+                               'seconds': self.opts['master_alive_interval'],
+                               'jid_include': True,
+                               'maxrunning': 2,
+                               'kwargs': {'master': self.opts['master'],
+                                          'connected': True}
+                            }
+                            self.schedule.modify_job(name='__master_alive',
+                                                     schedule=schedule)
 
         elif package.startswith('__master_connected'):
             # handle this event only once. otherwise it will pollute the log
@@ -1730,17 +1734,18 @@ class Minion(MinionBase):
                 self.connected = True
                 # modify the __master_alive job to only fire,
                 # if the connection is lost again
-                schedule = {
-                   'function': 'status.master',
-                   'seconds': self.opts['master_alive_interval'],
-                   'jid_include': True,
-                   'maxrunning': 2,
-                   'kwargs': {'master': self.opts['master'],
-                              'connected': True}
-                }
+                if self.opts['transport'] != 'tcp':
+                    schedule = {
+                       'function': 'status.master',
+                       'seconds': self.opts['master_alive_interval'],
+                       'jid_include': True,
+                       'maxrunning': 2,
+                       'kwargs': {'master': self.opts['master'],
+                                  'connected': True}
+                    }
 
-                self.schedule.modify_job(name='__master_alive',
-                                         schedule=schedule)
+                    self.schedule.modify_job(name='__master_alive',
+                                             schedule=schedule)
         elif package.startswith('_salt_error'):
             log.debug('Forwarding salt error event tag={tag}'.format(tag=tag))
             self._fire_master(data, tag)
@@ -2748,7 +2753,8 @@ class ProxyMinion(Minion):
             self.schedule.delete_job('__mine_interval', persist=True)
 
         # add master_alive job if enabled
-        if self.opts['master_alive_interval'] > 0:
+        if (self.opts['transport'] != 'tcp' and
+                self.opts['master_alive_interval'] > 0):
             self.schedule.add_job({
                 '__master_alive':
                     {
@@ -2760,5 +2766,7 @@ class ProxyMinion(Minion):
                                    'connected': True}
                     }
             }, persist=True)
+        else:
+            self.schedule.delete_job('__master_alive', persist=True)
 
         self.grains_cache = self.opts['grains']


### PR DESCRIPTION
salt/minion.py
- Do not schedule `__master_alive` on TCP transport. This will
  avoid invoking `status.master` on a recurring basis.
- When handling `__master_disconnected` event, there was an extra
  unnecessary unpack that was causing an exception. Fixed.

salt/transport/tcp.py
- In `SaltMessageClient`, added a mechanism for both connect and
  disconnect callbacks which are optional.
- In `AsyncTCPPubChannel` used the connect and disconnect callbacks
  from `SaltMessageClient` to send local events `__master_connected`
  and `__master_disconnected` respectively. This obsoletes the need for
  scheduling `__master_alive`.
- In `AsyncTCPPubChannel`, on a reconnect (not the first connect),
  it will send a `minion_start` / `syndic_start` master event. This is
  necessary to inform the master of the reconnect so that a reactor may
  take action in case there was an IP address change between the connects.
  If there was an IP address change, the presence-change based features will
  not work correctly due to the grains containing the old ip address. One
  way to force an IP address change is to switch ethernet ports on a
  multi-NIC minion. This is also useful if the salt-master restarts (but
  not the salt-minion), the restarted salt-master will now get the event.

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
