### PR TITLE
Allow forced matching on pillar top

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -659,8 +659,17 @@
 #
 #pillar_cache_backend: disk
 
-
-
+# The pillarenv_force_match allows you to enforce target matchers upon
+# an environment.  It will combine the defined target matchers with the target
+# matchers defined that are defined within an environment. This helps prevent
+# pillar data from leaking or being overridden between environments.  This
+# feature cannot fully prevent pillar data leakage or overwrites and should
+# not be used as a security measure.
+#pillarenv_force_match:
+#  dev:
+#    - '*dev*'
+#  staging:
+#    - 'G@role:staging'
 
 #####          Syndic settings       #####
 ##########################################

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -2412,6 +2412,27 @@ Recursively merge lists by aggregating them instead of replacing them.
 
     pillar_merge_lists: False
 
+.. conf_master:: pillarenv_force_match
+
+``pillarenv_force_match``
+----------------------
+
+.. versionadded:: Carbon
+
+Default: ``[]``
+
+Force target matchers upon specified environments to help prevent top.sls files within those environments from overriding or leaking pillar data to other environments.
+
+.. code-block:: yaml
+
+    pillarenv_force_match:
+        dev:
+            - 'G@role:development'
+        prod:
+            - '*prod*'
+            - 'S@192.168.2.0/24'
+        staging:
+            - 'S@192.168.1.0/24'
 
 Syndic Server Settings
 ======================

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -500,6 +500,12 @@ class Pillar(object):
         Returns the high data derived from the top file
         '''
         tops, errors = self.get_tops()
+        for saltenv, ctops in six.iteritems(tops):
+            if saltenv in self.opts['pillarenv_force_match']:
+                for ctop in six.iteritems(ctops):
+                    ctop_env = ctop.get(saltenv, OrderedDict())
+                    ctop.clear()
+                    ctop[saltenv] = ctop_env
         try:
             merged_tops = self.merge_tops(tops)
         except TypeError as err:
@@ -526,7 +532,7 @@ class Pillar(object):
                     if match == '*':
                         match = force
                     else:
-                        match += ' and ({0})'.format(force)
+                        match = '( {0} ) and ( {1} )'.format(match, force)
                 if self.matcher.confirm_top(
                         match,
                         data,

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -527,7 +527,7 @@ class Pillar(object):
                 if saltenv != self.opts['pillarenv']:
                     continue
             for match, data in six.iteritems(body):
-                if saltenv in self.opts['pillarenv_force_match'].keys():
+                if saltenv in self.opts['pillarenv_force_match']:
                     force = ' and '.join(self.opts['pillarenv_force_match'][saltenv])
                     if match == '*':
                         match = force

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -329,6 +329,8 @@ class Pillar(object):
         opts['id'] = self.minion_id
         if 'pillarenv' not in opts:
             opts['pillarenv'] = pillarenv
+        if 'pillarenv_force_match' not in opts:
+            opts['pillarenv_force_match'] = {}
         if opts['state_top'].startswith('salt://'):
             opts['state_top'] = opts['state_top']
         elif opts['state_top'].startswith('/'):
@@ -519,6 +521,12 @@ class Pillar(object):
                 if saltenv != self.opts['pillarenv']:
                     continue
             for match, data in six.iteritems(body):
+                if saltenv in self.opts['pillarenv_force_match'].keys():
+                    force = ' and '.join(self.opts['pillarenv_force_match'][saltenv])
+                    if match == '*':
+                        match = force
+                    else:
+                        match += ' and ({0})'.format(force)
                 if self.matcher.confirm_top(
                         match,
                         data,


### PR DESCRIPTION
This allows for forcing a compound match on a pillar env in an attempt to make top-file modifications to be 'safer' in an attempt to fix #27709.

For every pillarenv, you can specify a list of matchers.  If the saltenv being matched against is in the pillarenv_force_match dict, it will add the matchers to the matcher specified in the top file in that environment.

If '*' is used in the top file of an environment and the environment is in the pillarenv_force_match, it just discards the '*' and uses the matcher from pillarenv_force_match.

So, if we have something like this ( ignoring the fact that matching on grains is insecure, it works better as an example in my lab since I don't have a huge diverse set of hosts ):

```
pillar_roots:
  base:
    - /srv/pillar
  ctg:
    - /srv/pillar/ctg
  sbg:
    - /srv/pillar/sbg

pillarenv_force_match:
  ctg:
    - 'G@bu:ctg'
  sbg:
    - 'G@bu:sbg'
```

And we have this in our /srv/pillar/top.sls:

```
base:
  '*':
    - core
```

And this in /srv/pillar/ctg/top.sls:

```
ctg:
  '*':
    - ctg_core
  'G@role:db':
    - ctg_db
```

All servers would get core. ctg_core gets applied only to servers that match G@bu:ctg.  ctg_db only gets applied to servers that match 'G@role:db AND G@bu:ctg'.  

I haven't tested this with the git_pillar but the hope was that I could combine this with git_pillar and allow other organizations to control their own repo and top file within that, without me having to worry about them accidentally clobbering other org's pillar data, or leaking their pillar data to a host they accidentally target ( or globally.. ), because I've effectively limited their targeting to a subset of hosts.

I'm not sure this is ready for a merge, but I wanted to get some feedback on it and if this would be the right area to implement something like this.
