### PR TITLE
Fix KeyError when adding ignored pillars

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -395,6 +395,8 @@ class Pillar(object):
                             if isinstance(comp, six.string_types):
                                 states[comp] = True
                         if ignore_missing:
+                            if saltenv not in self.ignored_pillars:
+                                self.ignored_pillars[saltenv] = []
                             self.ignored_pillars[saltenv].extend(states.keys())
                         top[saltenv][tgt] = matches
                         top[saltenv][tgt].extend(states)


### PR DESCRIPTION
Fixes a mistake I did in https://github.com/saltstack/salt/pull/30354

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/home/andreas/dev/salt/salt/client/ssh/__init__.py", line 345, in handle_routine
    stdout, stderr, retcode = single.run()
  File "/home/andreas/dev/salt/salt/client/ssh/__init__.py", line 736, in run
    stdout, retcode = self.run_wfunc()
  File "/home/andreas/dev/salt/salt/client/ssh/__init__.py", line 811, in run_wfunc
    pillar_data = pillar.compile_pillar(pillar_dirs=pillar_dirs)
  File "/home/andreas/dev/salt/salt/pillar/__init__.py", line 666, in compile_pillar
    top, top_errors = self.get_top()
  File "/home/andreas/dev/salt/salt/pillar/__init__.py", line 423, in get_top
    merged_tops = self.merge_tops(tops)
  File "/home/andreas/dev/salt/salt/pillar/__init__.py", line 398, in merge_tops
    self.ignored_pillars[saltenv].extend(states.keys())
KeyError: 'base'
```
