### PR TITLE
Typo in comments for module_report() function

### DIFF
--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -48,7 +48,7 @@ def attr_call():
 
 def module_report():
     '''
-    Return a dict containing all of the exeution modules with a report on
+    Return a dict containing all of the execution modules with a report on
     the overall availability via different references
 
     CLI Example::


### PR DESCRIPTION
Corrected typo `exeution -> execution`
