### PR TITLE
Fix assignment of virtual_subtype for Docker when systemd is used

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -682,7 +682,8 @@ def _virtual(osdata):
                     if ':/lxc/' in fhr.read():
                         grains['virtual_subtype'] = 'LXC'
                 with salt.utils.fopen('/proc/1/cgroup', 'r') as fhr:
-                    if ':/docker/' in fhr.read():
+                    fhr_contents = fhr.read()
+                    if ':/docker/' in fhr_contents or ':/system.slice/docker' in fhr_contents:
                         grains['virtual_subtype'] = 'Docker'
             except IOError:
                 pass


### PR DESCRIPTION
When systemd is used under Docker the virtual_subtype field is not being assigned because the current pattern matching is too strict. Here's a sample `/proc/1/cgroup` file: 

```
[root@2a2bd359df69 root]# cat /proc/1/cgroup 
10:hugetlb:/system.slice/docker-2a2bd359df69c523d5bf39a6023b107c257610e68bd7c5012c48d0cf331362b3.scope
9:perf_event:/
8:blkio:/system.slice/docker-2a2bd359df69c523d5bf39a6023b107c257610e68bd7c5012c48d0cf331362b3.scope
7:net_cls:/system.slice/docker-2a2bd359df69c523d5bf39a6023b107c257610e68bd7c5012c48d0cf331362b3.scope
6:freezer:/system.slice/docker-2a2bd359df69c523d5bf39a6023b107c257610e68bd7c5012c48d0cf331362b3.scope
5:devices:/system.slice/docker-2a2bd359df69c523d5bf39a6023b107c257610e68bd7c5012c48d0cf331362b3.scope
4:memory:/system.slice/docker-2a2bd359df69c523d5bf39a6023b107c257610e68bd7c5012c48d0cf331362b3.scope
3:cpuacct,cpu:/system.slice/docker-2a2bd359df69c523d5bf39a6023b107c257610e68bd7c5012c48d0cf331362b3.scope
2:cpuset:/system.slice/docker-2a2bd359df69c523d5bf39a6023b107c257610e68bd7c5012c48d0cf331362b3.scope
1:name=systemd:/system.slice/docker-2a2bd359df69c523d5bf39a6023b107c257610e68bd7c5012c48d0cf331362b3.scope
```
