### PR TITLE
Boto s3 bucket state

### DIFF
--- a/salt/modules/boto_s3_bucket.py
+++ b/salt/modules/boto_s3_bucket.py
@@ -245,14 +245,16 @@ def describe(Bucket,
                 del(data['ResponseMetadata'])
             result[key] = data
 
-        result['Tagging'] = {}
+        tags = {}
         try:
             data = conn.get_bucket_tagging(Bucket=Bucket)
             for tagdef in data.get('TagSet'):
-                result['Tagging'][tagdef.get('Key')] = tagdef.get('Value')
+                tags[tagdef.get('Key')] = tagdef.get('Value')
         except ClientError as e:
             if not e.response.get('Error', {}).get('Code') == 'NoSuchTagSet':
                 raise
+        if tags:
+            result['Tagging'] = tags
         return {'bucket': result}
     except ClientError as e:
         err = salt.utils.boto3.get_error(e)

--- a/salt/modules/boto_s3_bucket.py
+++ b/salt/modules/boto_s3_bucket.py
@@ -402,7 +402,7 @@ def put_lifecycle_configuration(Bucket,
 
 
 def put_logging(Bucket,
-           TargetBucket, TargetPrefix, TargetGrants=None,
+           TargetBucket=None, TargetPrefix=None, TargetGrants=None,
            region=None, key=None, keyid=None, profile=None):
     '''
     Given a valid config, update the logging parameters for a bucket.

--- a/salt/modules/boto_s3_bucket.py
+++ b/salt/modules/boto_s3_bucket.py
@@ -242,7 +242,8 @@ def describe(Bucket,
                             ):
                     continue
                 raise
-            del(data['ResponseMetadata'])
+            if 'ResponseMetadata' in data:
+                del(data['ResponseMetadata'])
             result[key] = data
         return {'bucket': result}
     except ClientError as e:

--- a/salt/modules/boto_s3_bucket.py
+++ b/salt/modules/boto_s3_bucket.py
@@ -1,0 +1,670 @@
+# -*- coding: utf-8 -*-
+'''
+Connection module for Amazon S3 Buckets
+
+.. versionadded:: Boron
+
+:configuration: This module accepts explicit Lambda credentials but can also
+    utilize IAM roles assigned to the instance trough Instance Profiles.
+    Dynamic credentials are then automatically obtained from AWS API and no
+    further configuration is necessary. More Information available at:
+
+    .. code-block:: text
+
+        http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+
+    If IAM roles are not used you need to specify them either in a pillar or
+    in the minion's config file:
+
+    .. code-block:: yaml
+
+        s3.keyid: GKTADJGHEIQSXMKKRBJ08H
+        s3.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+    A region may also be specified in the configuration:
+
+    .. code-block:: yaml
+
+        s3.region: us-east-1
+
+    If a region is not specified, the default is us-east-1.
+
+    It's also possible to specify key, keyid and region via a profile, either
+    as a passed in dict, or as a string to pull from pillars or minion config:
+
+    .. code-block:: yaml
+
+        myprofile:
+            keyid: GKTADJGHEIQSXMKKRBJ08H
+            key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+            region: us-east-1
+
+:depends: boto3
+
+'''
+# keep lint from choking on _get_conn and _cache_id
+#pylint: disable=E0602
+
+# Import Python libs
+from __future__ import absolute_import
+import logging
+from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
+import json
+
+# Import Salt libs
+import salt.utils.boto3
+import salt.utils.compat
+import salt.utils
+from salt.ext.six import string_types
+
+log = logging.getLogger(__name__)
+
+# Import third party libs
+
+# pylint: disable=import-error
+try:
+    #pylint: disable=unused-import
+    import boto
+    import boto3
+    #pylint: enable=unused-import
+    from botocore.exceptions import ClientError
+    logging.getLogger('boto3').setLevel(logging.CRITICAL)
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+# pylint: enable=import-error
+
+
+def __virtual__():
+    '''
+    Only load if boto libraries exist and if boto libraries are greater than
+    a given version.
+    '''
+    required_boto3_version = '1.2.1'
+    # the boto_lambda execution module relies on the connect_to_region() method
+    # which was added in boto 2.8.0
+    # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
+    if not HAS_BOTO:
+        return False
+    elif _LooseVersion(boto3.__version__) < _LooseVersion(required_boto3_version):
+        return False
+    else:
+        return True
+
+
+def __init__(opts):
+    salt.utils.compat.pack_dunder(__name__)
+    if HAS_BOTO:
+        __utils__['boto3.assign_funcs'](__name__, 's3')
+
+
+def exists(Bucket,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a bucket name, check to see if the given bucket exists.
+
+    Returns True if the given bucket exists and returns False if the given
+    bucket does not exist.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_s3_bucket.exists mybucket
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        buckets = conn.head_bucket(Bucket=Bucket)
+        return {'exists': True}
+    except ClientError as e:
+        if e.response.get('Error', {}).get('Code') == '404':
+            return {'exists': False}
+        err = salt.utils.boto3.get_error(e)
+        return {'error': err}
+
+
+def create(Bucket,
+           ACL=None, LocationConstraint=None,
+           GrantFullControl=None,
+           GrantRead=None,
+           GrantReadACP=None,
+           GrantWrite=None,
+           GrantWriteACP=None,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a valid config, create an S3 Bucket.
+
+    Returns {created: true} if the bucket was created and returns
+    {created: False} if the bucket was not created.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_s3_bucket.create my_bucket \\
+                         GrantFullControl='emailaddress=example@example.com' \\
+                         GrantRead='uri="http://acs.amazonaws.com/groups/global/AllUsers"' \\
+                         GrantReadACP='emailaddress="exampl@example.com",id="2345678909876432"' \\
+                         LocationConstraint=us-west-1
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        kwargs = {}
+        for arg in ('ACL', 'GrantFullControl',
+                    'GrantRead', 'GrantReadACP',
+                    'GrantWrite', 'GrantWriteACP'):
+            if locals()[arg] is not None:
+                kwargs[arg] = str(locals()[arg])
+        if LocationConstraint:
+            kwargs['CreateBucketConfiguration'] = {'LocationConstraint': LocationConstraint}
+        location = conn.create_bucket(Bucket=Bucket,
+                                  **kwargs)
+        if location:
+            log.info('The newly created bucket name is located at {0}'.format(location['Location']))
+
+            return {'created': True, 'name': Bucket, 'Location': location['Location']}
+        else:
+            log.warning('Bucket was not created')
+            return {'created': False}
+    except ClientError as e:
+        return {'created': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def delete(Bucket,
+            region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a bucket name, delete it.
+
+    Returns {deleted: true} if the bucket was deleted and returns
+    {deleted: false} if the bucket was not deleted.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_s3_bucket.delete mybucket
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        conn.delete_bucket(Bucket=Bucket)
+        return {'deleted': True}
+    except ClientError as e:
+        return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def describe(Bucket,
+             region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a bucket name describe its properties.
+
+    Returns a dictionary of interesting properties.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_s3_bucket.describe mybucket
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        result = {}
+        for key, query in {
+                'ACL': conn.get_bucket_acl,
+                'CORS': conn.get_bucket_cors,
+                'LifecycleConfiguration': conn.get_bucket_lifecycle_configuration,
+                'Location': conn.get_bucket_location,
+                'Logging': conn.get_bucket_logging,
+                'NotificationConfiguration': conn.get_bucket_notification_configuration,
+                'Policy': conn.get_bucket_policy,
+                'Replication': conn.get_bucket_replication,
+                'RequestPayment': conn.get_bucket_request_payment,
+                'Tagging': conn.get_bucket_tagging,
+                'Versioning': conn.get_bucket_versioning,
+                'Website': conn.get_bucket_website}.iteritems():
+            try:
+                data = query(Bucket=Bucket)
+            except ClientError as e:
+                if e.response.get('Error', {}).get('Code') in (
+                            'NoSuchLifecycleConfiguration',
+                            'NoSuchCORSConfiguration',
+                            'NoSuchBucketPolicy',
+                            'NoSuchWebsiteConfiguration',
+                            'ReplicationConfigurationNotFoundError',
+                            'NoSuchTagSet',
+                            ):
+                    continue
+                raise
+            del(data['ResponseMetadata'])
+            result[key] = data
+        return {'bucket': result}
+    except ClientError as e:
+        err = salt.utils.boto3.get_error(e)
+        if e.response.get('Error', {}).get('Code') == 'NoSuchBucket':
+            return {'bucket': None}
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def list(region=None, key=None, keyid=None, profile=None):
+    '''
+    List all buckets owned by the authenticated sender of the request.
+
+    Returns list of buckets
+
+    CLI Example:
+
+    .. code-block:: yaml
+
+        Owner: {...}
+        Buckets:
+          - {...}
+          - {...}
+
+    '''
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        buckets = conn.list_buckets()
+        if not bool(buckets.get('Buckets')):
+            log.warning('No buckets found')
+        del buckets['ResponseMetadata']
+        return buckets
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def put_acl(Bucket,
+           ACL=None,
+           AccessControlPolicy=None,
+           GrantFullControl=None,
+           GrantRead=None,
+           GrantReadACP=None,
+           GrantWrite=None,
+           GrantWriteACP=None,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a valid config, update the ACL for a bucket.
+
+    Returns {updated: true} if the ACL was updated and returns
+    {updated: False} if the ACL was not updated.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_s3_bucket.put_acl my_bucket 'public' \\
+                         GrantFullControl='emailaddress=example@example.com' \\
+                         GrantRead='uri="http://acs.amazonaws.com/groups/global/AllUsers"' \\
+                         GrantReadACP='emailaddress="exampl@example.com",id="2345678909876432"'
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if AccessControlPolicy is not None and not isinstance(AccessControlPolicy, string_types):
+                    AccessControlPolicy = json.dumps(AccessControlPolicy)
+        kwargs = {}
+        for arg in ('ACL', 'AccessControlPolicy',
+                    'GrantFullControl',
+                    'GrantRead', 'GrantReadACP',
+                    'GrantWrite', 'GrantWriteACP'):
+            if locals()[arg] is not None:
+                kwargs[arg] = str(locals()[arg])
+        conn.put_bucket_acl(Bucket=Bucket, **kwargs)
+        return {'updated': True, 'name': Bucket}
+    except ClientError as e:
+        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def put_cors(Bucket,
+           CORSRules,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a valid config, update the CORS rules for a bucket.
+
+    Returns {updated: true} if CORS was updated and returns
+    {updated: False} if CORS was not updated.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_s3_bucket.put_cors my_bucket '[{\\
+              "AllowedHeaders":[],\\
+              "AllowedMethods":["GET"],\\
+              "AllowedOrigins":["*"],\\
+              "ExposeHeaders":[],\\
+              "MaxAgeSeconds":123,\\
+        }]'
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if CORSRules is not None and isinstance(CORSRules, string_types):
+            CORSRules = json.loads(CORSRules)
+        conn.put_bucket_cors(Bucket=Bucket, CORSConfiguration={'CORSRules': CORSRules})
+        return {'updated': True, 'name': Bucket}
+    except ClientError as e:
+        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def put_lifecycle_configuration(Bucket,
+           Rules,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a valid config, update the Lifecycle rules for a bucket.
+
+    Returns {updated: true} if Lifecycle was updated and returns
+    {updated: False} if Lifecycle was not updated.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_s3_bucket.put_lifecycle_config my_bucket '[{\\
+              "Expiration": {...},\\
+              "ID": "idstring",\\
+              "Prefix": "prefixstring",\\
+              "Status": "enabled",\\
+              "Transitions": [{...},],\\
+              "NoncurrentVersionTransitions": [{...},],\\
+              "NoncurrentVersionExpiration": {...},\\
+        }]'
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if Rules is not None and isinstance(Rules, string_types):
+            Rules = json.loads(Rules)
+        conn.put_bucket_lifecycle_configuration(Bucket=Bucket, LifecycleConfiguration={'Rules': Rules})
+        return {'updated': True, 'name': Bucket}
+    except ClientError as e:
+        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def put_logging(Bucket,
+           TargetBucket, TargetPrefix, TargetGrants,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a valid config, update the logging parameters for a bucket.
+
+    Returns {updated: true} if parameters were updated and returns
+    {updated: False} if parameters were not updated.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_s3_bucket.put_logging my_bucket log_bucket '[{...}]' prefix
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if TargetGrants is not None and isinstance(TargetGrants, string_types):
+            TargetGrants = json.loads(TargetGrants)
+        conn.put_bucket_logging(Bucket=Bucket, BucketLoggingStatus={
+                'LoggingEnabled': {
+                    'TargetBucket': TargetBucket,
+                    'TargetGrants': TargetGrants,
+                    'TargetPrefix': TargetPrefix,
+                }
+        })
+        return {'updated': True, 'name': Bucket}
+    except ClientError as e:
+        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def put_notification_configuration(Bucket,
+           TopicConfigurations=None, QueueConfigurations=None,
+           LambdaFunctionConfigurations=None,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a valid config, update the notification parameters for a bucket.
+
+    Returns {updated: true} if parameters were updated and returns
+    {updated: False} if parameters were not updated.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_s3_bucket.put_notification_configuration my_bucket
+                [{...}] \\
+                [{...}] \\
+                [{...}]
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if TopicConfigurations is None:
+            TopicConfigurations = []
+        elif isinstance(TopicConfigurations, string_types):
+            TopicConfigurations = json.loads(TopicConfigurations)
+        if QueueConfigurations is None:
+            QueueConfigurations = []
+        elif isinstance(QueueConfigurations, string_types):
+            QueueConfigurations = json.loads(QueueConfigurations)
+        if LambdaFunctionConfigurations is None:
+            LambdaFunctionConfigurations = []
+        elif isinstance(LambdaFunctionConfigurations, string_types):
+            LambdaFunctionConfigurations = json.loads(LambdaFunctionConfigurations)
+        # TODO allow the user to use simple names & substitute ARNs for those names
+        conn.put_bucket_notification_configuration(Bucket=Bucket, NotificationConfiguration={
+                'TopicConfigurations': TopicConfigurations,
+                'QueueConfigurations': QueueConfigurations,
+                'LambdaFunctionConfigurations': LambdaFunctionConfigurations,
+        })
+        return {'updated': True, 'name': Bucket}
+    except ClientError as e:
+        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def put_policy(Bucket, Policy,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a valid config, update the policy for a bucket.
+
+    Returns {updated: true} if policy was updated and returns
+    {updated: False} if policy was not updated.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_s3_bucket.put_policy my_bucket {...}
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if Policy is None:
+            Policy = '{}'
+        elif not isinstance(Policy, string_types):
+            Policy = json.dumps(Policy)
+        conn.put_bucket_policy(Bucket=Bucket, Policy=Policy)
+        return {'updated': True, 'name': Bucket}
+    except ClientError as e:
+        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def _get_role_arn(name, region=None, key=None, keyid=None, profile=None):
+    if name.startswith('arn:aws:iam:'):
+        return name
+
+    account_id = __salt__['boto_iam.get_account_id'](
+        region=region, key=key, keyid=keyid, profile=profile
+    )
+    if profile and 'region' in profile:
+        region = profile['region']
+    if region is None:
+        region = 'us-east-1'
+    return 'arn:aws:iam::{0}:role/{1}'.format(account_id, name)
+
+
+def put_replication(Bucket, Role, Rules,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a valid config, update the replication configuration for a bucket.
+
+    Returns {updated: true} if replication configuration was updated and returns
+    {updated: False} if replication configuration was not updated.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_s3_bucket.put_replication my_bucket my_role [...]
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        Role = _get_role_arn(name=Role,
+                             region=region, key=key, keyid=keyid, profile=profile)
+        if Rules is None:
+            Rules = []
+        elif isinstance(Rules, string_types):
+            Rules = json.loads(Rules)
+        conn.put_bucket_replication(Bucket=Bucket, ReplicationConfiguration={
+                'Role': Role,
+                'Rules': Rules
+        })
+        return {'updated': True, 'name': Bucket}
+    except ClientError as e:
+        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def put_request_payment(Bucket, Payer,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a valid config, update the request payment configuration for a bucket.
+
+    Returns {updated: true} if request payment configuration was updated and returns
+    {updated: False} if request payment configuration was not updated.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_s3_bucket.put_request_payment my_bucket Requester
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        conn.put_bucket_request_payment(Bucket=Bucket, RequestPaymentConfiguration={
+                'Payer': Payer,
+        })
+        return {'updated': True, 'name': Bucket}
+    except ClientError as e:
+        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def put_tagging(Bucket,
+           region=None, key=None, keyid=None, profile=None, **kwargs):
+    '''
+    Given a valid config, update the tags for a bucket.
+
+    Returns {updated: true} if tags were updated and returns
+    {updated: False} if tags were not updated.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_s3_bucket.put_tagging my_bucket my_role [...]
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        tagslist = []
+        for k, v in kwargs.iteritems():
+            if str(k).startswith('__'):
+                continue
+            tagslist.append({'Key': str(k), 'Value': str(v)})
+        conn.put_bucket_tagging(Bucket=Bucket, Tagging={
+                'TagSet': tagslist,
+        })
+        return {'updated': True, 'name': Bucket}
+    except ClientError as e:
+        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def put_versioning(Bucket, Status, MFADelete=None, MFA=None,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a valid config, update the versioning configuration for a bucket.
+
+    Returns {updated: true} if versioning configuration was updated and returns
+    {updated: False} if versioning configuration was not updated.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_s3_bucket.put_versioning my_bucket Enabled
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        VersioningConfiguration = {'Status': Status}
+        if MFADelete is not None:
+            VersioningConfiguration['MFADelete'] = MFADelete
+        kwargs = {}
+        if MFA is not None:
+            kwargs['MFA'] = MFA
+        conn.put_bucket_versioning(Bucket=Bucket,
+                VersioningConfiguration=VersioningConfiguration,
+                **kwargs)
+        return {'updated': True, 'name': Bucket}
+    except ClientError as e:
+        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def put_website(Bucket, ErrorDocument=None, IndexDocument=None,
+           RedirectAllRequestsTo=None, RoutingRules=None,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a valid config, update the website configuration for a bucket.
+
+    Returns {updated: true} if website configuration was updated and returns
+    {updated: False} if website configuration was not updated.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_s3_bucket.put_website my_bucket IndexDocument='{"Suffix":"index.html"}'
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        WebsiteConfiguration = {}
+        for key in ('ErrorDocument', 'IndexDocument',
+                    'RedirectAllRequestsTo', 'RoutingRules'):
+            val = locals()[key]
+            if val is not None:
+                if isinstance(val, string_types):
+                    WebsiteConfiguration[key] = json.loads(val)
+                else:
+                    WebsiteConfiguration[key] = val
+        conn.put_bucket_website(Bucket=Bucket,
+                WebsiteConfiguration=WebsiteConfiguration)
+        return {'updated': True, 'name': Bucket}
+    except ClientError as e:
+        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+
+

--- a/salt/modules/boto_s3_bucket.py
+++ b/salt/modules/boto_s3_bucket.py
@@ -226,7 +226,6 @@ def describe(Bucket,
                 'Policy': conn.get_bucket_policy,
                 'Replication': conn.get_bucket_replication,
                 'RequestPayment': conn.get_bucket_request_payment,
-                'Tagging': conn.get_bucket_tagging,
                 'Versioning': conn.get_bucket_versioning,
                 'Website': conn.get_bucket_website}.iteritems():
             try:
@@ -245,6 +244,15 @@ def describe(Bucket,
             if 'ResponseMetadata' in data:
                 del(data['ResponseMetadata'])
             result[key] = data
+
+        result['Tagging'] = {}
+        try:
+            data = conn.get_bucket_tagging(Bucket=Bucket)
+            for tagdef in data.get('TagSet'):
+                result['Tagging'][tagdef.get('Key')] = tagdef.get('Value')
+        except ClientError as e:
+            if not e.response.get('Error', {}).get('Code') == 'NoSuchTagSet':
+                raise
         return {'bucket': result}
     except ClientError as e:
         err = salt.utils.boto3.get_error(e)

--- a/salt/modules/boto_s3_bucket.py
+++ b/salt/modules/boto_s3_bucket.py
@@ -316,10 +316,12 @@ def put_acl(Bucket,
 
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-        if AccessControlPolicy is not None and not isinstance(AccessControlPolicy, string_types):
-                    AccessControlPolicy = json.dumps(AccessControlPolicy)
         kwargs = {}
-        for arg in ('ACL', 'AccessControlPolicy',
+        if AccessControlPolicy is not None:
+            if isinstance(AccessControlPolicy, string_types):
+            	AccessControlPolicy = json.loads(AccessControlPolicy)
+            kwargs['AccessControlPolicy'] = AccessControlPolicy
+        for arg in ('ACL',
                     'GrantFullControl',
                     'GrantRead', 'GrantReadACP',
                     'GrantWrite', 'GrantWriteACP'):

--- a/salt/modules/boto_s3_bucket.py
+++ b/salt/modules/boto_s3_bucket.py
@@ -368,7 +368,7 @@ def put_lifecycle_configuration(Bucket,
 
     .. code-block:: bash
 
-        salt myminion boto_s3_bucket.put_lifecycle_config my_bucket '[{\\
+        salt myminion boto_s3_bucket.put_lifecycle_configuration my_bucket '[{\\
               "Expiration": {...},\\
               "ID": "idstring",\\
               "Prefix": "prefixstring",\\
@@ -668,3 +668,145 @@ def put_website(Bucket, ErrorDocument=None, IndexDocument=None,
         return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
 
 
+def delete_cors(Bucket,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Delete the CORS configuration for the given bucket
+
+    Returns {deleted: true} if CORS was deleted and returns
+    {deleted: False} if CORS was not deleted.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_s3_bucket.delete_cors my_bucket
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        conn.delete_bucket_cors(Bucket=Bucket)
+        return {'deleted': True, 'name': Bucket}
+    except ClientError as e:
+        return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def delete_lifecycle_configuration(Bucket,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Delete the lifecycle configuration for the given bucket
+
+    Returns {deleted: true} if Lifecycle was deleted and returns
+    {deleted: False} if Lifecycle was not deleted.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_s3_bucket.delete_lifecycle_configuration my_bucket
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        conn.delete_bucket_lifecycle(Bucket=Bucket)
+        return {'deleted': True, 'name': Bucket}
+    except ClientError as e:
+        return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def delete_policy(Bucket,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Delete the policy from the given bucket
+
+    Returns {deleted: true} if policy was deleted and returns
+    {deleted: False} if policy was not deleted.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_s3_bucket.delete_policy my_bucket
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        conn.delete_bucket_policy(Bucket=Bucket)
+        return {'deleted': True, 'name': Bucket}
+    except ClientError as e:
+        return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def delete_replication(Bucket,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Delete the replication config from the given bucket
+
+    Returns {deleted: true} if replication configuration was deleted and returns
+    {deleted: False} if replication configuration was not deleted.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_s3_bucket.delete_replication my_bucket
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        conn.delete_bucket_replication(Bucket=Bucket)
+        return {'deleted': True, 'name': Bucket}
+    except ClientError as e:
+        return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def delete_tagging(Bucket,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Delete the tags from the given bucket
+
+    Returns {deleted: true} if tags were deleted and returns
+    {deleted: False} if tags were not deleted.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_s3_bucket.delete_tagging my_bucket
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        conn.delete_bucket_tagging(Bucket=Bucket)
+        return {'deleted': True, 'name': Bucket}
+    except ClientError as e:
+        return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def delete_website(Bucket,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Remove the website configuration from the given bucket
+
+    Returns {deleted: true} if website configuration was deleted and returns
+    {deleted: False} if website configuration was not deleted.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_s3_bucket.delete_website my_bucket
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        conn.delete_bucket_website(Bucket=Bucket)
+        return {'deleted': True, 'name': Bucket}
+    except ClientError as e:
+        return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}

--- a/salt/modules/boto_s3_bucket.py
+++ b/salt/modules/boto_s3_bucket.py
@@ -242,7 +242,7 @@ def describe(Bucket,
                     continue
                 raise
             if 'ResponseMetadata' in data:
-                del(data['ResponseMetadata'])
+                del data['ResponseMetadata']
             result[key] = data
 
         tags = {}
@@ -321,7 +321,7 @@ def put_acl(Bucket,
         kwargs = {}
         if AccessControlPolicy is not None:
             if isinstance(AccessControlPolicy, string_types):
-            	AccessControlPolicy = json.loads(AccessControlPolicy)
+                AccessControlPolicy = json.loads(AccessControlPolicy)
             kwargs['AccessControlPolicy'] = AccessControlPolicy
         for arg in ('ACL',
                     'GrantFullControl',

--- a/salt/states/boto_s3_bucket.py
+++ b/salt/states/boto_s3_bucket.py
@@ -1,0 +1,437 @@
+# -*- coding: utf-8 -*-
+'''
+Manage S3 Buckets
+=================
+
+.. versionadded:: Boron
+
+Create and destroy S3 buckets. Be aware that this interacts with Amazon's services,
+and so may incur charges.
+
+This module uses ``boto3``, which can be installed via package, or pip.
+
+This module accepts explicit vpc credentials but can also utilize
+IAM roles assigned to the instance through Instance Profiles. Dynamic
+credentials are then automatically obtained from AWS API and no further
+configuration is necessary. More information available `here
+<http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html>`_.
+
+If IAM roles are not used you need to specify them either in a pillar file or
+in the minion's config file:
+
+.. code-block:: yaml
+
+    vpc.keyid: GKTADJGHEIQSXMKKRBJ08H
+    vpc.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+It's also possible to specify ``key``, ``keyid`` and ``region`` via a profile,
+either passed in as a dict, or as a string to pull from pillars or minion
+config:
+
+.. code-block:: yaml
+
+    myprofile:
+        keyid: GKTADJGHEIQSXMKKRBJ08H
+        key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+            region: us-east-1
+
+.. code-block:: yaml
+
+    Ensure bucket exists:
+        boto_s3_bucket.present:
+            - Bucket: mybucket
+            - LocationConstraint: EU
+            - ACL: 
+              - ACL: private
+                GrantRead: "uri=http://acs.amazonaws.com/groups/global/AllUsers"
+            - CORSRules:
+              - AllowedHeaders: []
+                AllowedMethods: ["GET"]
+                AllowedOrigins: ["*"]
+                ExposeHeaders: []
+                MaxAgeSeconds: 123
+            - LifecycleConfiguration:
+              - Expiration:
+                  Days: 123
+                ID: "idstring"
+                Prefix: "prefixstring"
+                Status: "enabled",
+                Transitions:
+                  - Days: 123
+                    StorageClass: "GLACIER"
+                NoncurrentVersionTransitions:
+                  - NoncurrentDays: 123
+                    StorageClass: "GLACIER"
+                NoncurrentVersionExpiration:
+                  NoncurrentDays: 123
+            - Logging:
+                TargetBucket: log_bucket
+                TargetPrefix: prefix
+                TargetGrants:
+                  - Grantee:
+                      DisplayName: "string"
+                      EmailAddress: "string"
+                      ID: "string"
+                      Type: "AmazonCustomerByEmail"
+                      URI: "string"
+                    Permission: "READ"
+            - NotificationConfiguration:
+                LambdaFunctionConfiguration:
+                  - Id: "string"
+                    LambdaFunctionArn: "string"
+                    Events:
+                      - "s3:ObjectCreated:*"
+                    Filter:
+                      Key:
+                        FilterRules:
+                          - Name: "prefix"
+                            Value: "string"
+            - Policy:
+                Version: "2012-10-17"
+                Statement:
+                  - Effect: "Allow"
+                    Principal:
+                      AWS:
+                        - "arn:aws:iam::133434421342:root"
+                    Action:
+                      - "s3:PutObject"
+                    Resource:
+                      - "arn:aws:s3:::my-bucket/*"
+            - Replication:
+                Role: myrole
+                Rules:
+                  - ID: "string"
+                    Prefix: "string"
+                    Status: "Enabled"
+                    Destination:
+                      Bucket: "arn:aws:s3:::my-bucket"
+            - RequestPayment:
+                Payer: Requester
+            - Tagging:
+                tag_name: tag_value
+                tag_name_2: tag_value
+            - Versioning:
+                Status: "Enabled"
+            - Website:
+                ErrorDocument:
+                  Key: "error.html"
+                IndexDocument:
+                  Suffix: "index.html"
+                RedirectAllRequestsTo:
+                  Hostname: "string"
+                  Protocol: "http"
+                RoutingRules:
+                  - Condition:
+                      HttpErrorCodeReturnedEquals: "string"
+                      KeyPrefixEquals: "string"
+                    Redirect:
+                      HostName: "string"
+                      HttpRedirectCode: "string"
+                      Protocol: "http"
+                      ReplaceKeyPrefixWith: "string"
+                      ReplaceKeyWith: "string"
+            - region: us-east-1
+            - keyid: GKTADJGHEIQSXMKKRBJ08H
+            - key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+import logging
+import os
+import os.path
+
+# Import Salt Libs
+import salt.utils
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Only load if boto is available.
+    '''
+    return 'boto_s3_bucket' if 'boto_s3_bucket.exists' in __salt__ else False
+
+
+def present(name, Bucket,
+            LocationConstraint=None,
+            ACL=None,
+            CORSRules=None,
+            LifecycleConfiguration=None,
+            Logging=None,
+            NotificationConfiguration=None,
+            Policy=None,
+            Replication=None,
+            RequestPayment=None,
+            Tagging=None,
+            Versioning=None,
+            Website=None,
+            region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure bucket exists.
+
+    name
+        The name of the state definition
+
+    Bucket
+        Name of the bucket.
+
+    LocationConstraint
+        'EU'|'eu-west-1'|'us-west-1'|'us-west-2'|'ap-southeast-1'|'ap-southeast-2'|'ap-northeast-1'|'sa-east-1'|'cn-north-1'|'eu-central-1'
+
+    ACL
+        The permissions on a bucket using access control lists (ACL).
+
+    CORSRules
+        The cors configuration for a bucket.
+
+    LifecycleConfiguration
+        Lifecycle configuration for your bucket
+
+    Logging
+        The logging parameters for a bucket and to specify permissions for who
+        can view and modify the logging parameters.
+
+    NotificationConfiguration
+        notifications of specified events for a bucket
+
+    Policy
+        Policy on the bucket
+
+    Replication
+        Replication rules. You can add as many as 1,000 rules.
+        Total replication configuration size can be up to 2 MB
+
+    RequestPayment
+        The request payment configuration for a bucket. By default, the bucket
+        owner pays for downloads from the bucket. This configuration parameter
+        enables the bucket owner (only) to specify that the person requesting
+        the download will be charged for the download
+
+    Tagging
+        A dictionary of tags that should be set on the bucket
+
+    Versioning
+        The versioning state of the bucket
+
+    Website
+        The website configuration of the bucket
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+    '''
+    ret = {'name': Bucket,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    if ACL is None:
+        ACL = {'ACL': 'private'}
+    if Logging is None:
+        Logging = {}
+    if NotificationConfiguration is None:
+        NotificationConfiguration = {}
+    if RequestPayment is None:
+        RequestPayment={'Payer': 'BucketOwner'}
+
+    r = __salt__['boto_s3_bucket.exists'](Bucket=Bucket,
+           region=region, key=key, keyid=keyid, profile=profile)
+
+    if 'error' in r:
+        ret['result'] = False
+        ret['comment'] = 'Failed to create bucket: {0}.'.format(r['error']['message'])
+        return ret
+
+    if not r.get('exists'):
+        if __opts__['test']:
+            ret['comment'] = 'S3 bucket {0} is set to be created.'.format(Bucket)
+            ret['result'] = None
+            return ret
+        r = __salt__['boto_s3_bucket.create'](Bucket=Bucket,
+                   LocationConstraint=LocationConstraint,
+                   region=region, key=key, keyid=keyid, profile=profile)
+        if not r.get('created'):
+            ret['result'] = False
+            ret['comment'] = 'Failed to create bucket: {0}.'.format(r['error']['message'])
+            return ret
+
+        for func, testval, funcargs in (
+                ('put_acl', ACL, ACL),
+                ('put_cors', CORSRules, {"CORSRules": CORSRules}),
+                ('put_lifecycle_configuration', LifecycleConfiguration, {"Rules":LifecycleConfiguration}),
+                ('put_logging', Logging, Logging),
+                ('put_notification_configuration', NotificationConfiguration, NotificationConfiguration),
+                ('put_policy', Policy, {"Policy": Policy}),
+                # versioning must be set before replication
+                ('put_versioning', Versioning, Versioning),
+                ('put_replication', Replication, Replication),
+                ('put_request_payment', RequestPayment, RequestPayment),
+                ('put_tagging', Tagging, Tagging),
+                ('put_website', Website, Website),
+        ):
+            if testval is not None:
+                log.info("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+                log.info(func)
+                log.info(funcargs)
+                r = __salt__['boto_s3_bucket.{0}'.format(func)](Bucket=Bucket,
+                                   region=region, key=key, keyid=keyid, profile=profile,
+                                   **funcargs)
+                if not r.get('updated'):
+                    ret['result'] = False
+                    ret['comment'] = 'Failed to create bucket: {0}.'.format(r['error']['message'])
+                    return ret
+
+        _describe = __salt__['boto_s3_bucket.describe'](Bucket,
+                                   region=region, key=key, keyid=keyid, profile=profile)
+        ret['changes']['old'] = {'bucket': None}
+        ret['changes']['new'] = _describe
+        ret['comment'] = 'S3 bucket {0} created.'.format(Bucket)
+
+        return ret
+
+    ret['comment'] = os.linesep.join([ret['comment'], 'S3 bucket {0} is present.'.format(Bucket)])
+    ret['changes'] = {}
+    # bucket exists, ensure config matches
+    _describe = __salt__['boto_s3_bucket.describe'](Bucket=Bucket,
+                                 region=region, key=key, keyid=keyid, profile=profile)
+    if 'error' in _describe:
+        ret['result'] = False
+        ret['comment'] = 'Failed to update bucket: {0}.'.format(_describe['error']['message'])
+        ret['changes'] = {}
+        return ret
+    _describe = _describe['bucket']
+
+    # Once versioning has been enabled, it can't completely go away, it can
+    # only be suspended
+    if not bool(Versioning) and _describe.get('Versioning') is not None:
+        Versioning = {'Status': 'Suspended'}
+
+    for varname, func, current, desired, deleter in (
+            ('ACL', 'put_acl', _describe.get('ACL'), ACL, None),
+            ('CORS', 'put_cors', _describe.get('CORS'), {"CORSRules": CORSRules} if CORSRules else None,
+                                                'delete_cors'),
+            ('LifecycleConfiguration', 'put_lifecycle_configuration', _describe.get('LifecycleConfiguration'), 
+                                            {"Rules": LifecycleConfiguration} if LifecycleConfiguration else None,
+                                            'delete_lifecycle_configuration'),
+            ('Logging', 'put_logging', _describe.get('Logging',{}).get('LoggingEnabled'), Logging, None),
+            ('NotificationConfiguration', 'put_notification_configuration', _describe.get('NotificationConfiguration'), NotificationConfiguration, None),
+            ('Policy', 'put_policy', _describe.get('Policy',{}).get('Policy'), Policy, 'delete_policy'),
+            # versioning must be set before replication
+            ('Versioning', 'put_versioning', _describe.get('Versioning'), Versioning, None),
+            ('Replication', 'put_replication', _describe.get('Replication',{}).get('ReplicationConfiguration'), Replication, 'delete_replication'),
+            ('RequestPayment', 'put_request_payment', _describe.get('RequestPayment'), RequestPayment, None),
+            ('Tagging', 'put_tagging', Tagging, Tagging, 'delete_tagging'),
+            ('Website', 'put_website', Website, Website, 'delete_website'),
+    ):
+        diffs = salt.utils.compare_dicts(current or {}, desired or {})
+        if bool(diffs):
+            if __opts__['test']:
+                msg = 'S3 bucket {0} set to be modified.'.format(Bucket)
+                ret['comment'] = msg
+                ret['result'] = None
+                return ret
+            ret['changes'].setdefault('new', {})[varname] = desired
+            ret['changes'].setdefault('old', {})[varname] = current
+
+            log.info("#####!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+            log.info(current)
+            log.info(func)
+            log.info(desired)
+            if deleter and desired is None:
+                r = __salt__['boto_s3_bucket.{0}'.format(deleter)](Bucket=Bucket,
+                   region=region, key=key, keyid=keyid, profile=profile)
+                if not r.get('deleted'):
+                    ret['result'] = False
+                    ret['comment'] = 'Failed to update bucket: {0}.'.format(r['error']['message'])
+                    ret['changes'] = {}
+                    return ret
+            else:
+                r = __salt__['boto_s3_bucket.{0}'.format(func)](Bucket=Bucket,
+                   region=region, key=key, keyid=keyid, profile=profile,
+                   **(desired or {}))
+                if not r.get('updated'):
+                    ret['result'] = False
+                    ret['comment'] = 'Failed to update bucket: {0}.'.format(r['error']['message'])
+                    ret['changes'] = {}
+                    return ret
+
+    if _describe.get('Location',{}).get('LocationConstraint') != LocationConstraint:
+        msg = 'Bucket {0} location does not match desired configuration, but cannot be changed'.format(LocationConstraint)
+        log.warn(msg)
+        ret['result'] = False
+        ret['comment'] = 'Failed to update bucket: {0}.'.format(msg)
+        return ret
+
+    return ret
+
+
+def absent(name, Bucket,
+                  region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure bucket with passed properties is absent.
+
+    name
+        The name of the state definition.
+
+    Bucket
+        Name of the bucket.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+    '''
+
+    ret = {'name': Bucket,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    r = __salt__['boto_s3_bucket.exists'](Bucket,
+                       region=region, key=key, keyid=keyid, profile=profile)
+    if 'error' in r:
+        ret['result'] = False
+        ret['comment'] = 'Failed to delete bucket: {0}.'.format(r['error']['message'])
+        return ret
+
+    if r and not r['exists']:
+        ret['comment'] = 'S3 bucket {0} does not exist.'.format(Bucket)
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'S3 bucket {0} is set to be removed.'.format(Bucket)
+        ret['result'] = None
+        return ret
+    r = __salt__['boto_s3_bucket.delete'](Bucket,
+                                    region=region, key=key,
+                                    keyid=keyid, profile=profile)
+    if not r['deleted']:
+        ret['result'] = False
+        ret['comment'] = 'Failed to delete bucket: {0}.'.format(r['error']['message'])
+        return ret
+    ret['changes']['old'] = {'bucket': Bucket}
+    ret['changes']['new'] = {'bucket': None}
+    ret['comment'] = 'S3 bucket {0} deleted.'.format(Bucket)
+    return ret

--- a/salt/states/boto_s3_bucket.py
+++ b/salt/states/boto_s3_bucket.py
@@ -145,6 +145,7 @@ from copy import deepcopy
 
 # Import Salt Libs
 import salt.utils
+from salt.utils.boto3 import json_objs_equal
 
 log = logging.getLogger(__name__)
 
@@ -333,8 +334,6 @@ def present(name, Bucket,
 
     if ACL is None:
         ACL = {'ACL': 'private'}
-    if Logging is None:
-        Logging = {}
     if NotificationConfiguration is None:
         NotificationConfiguration = {}
     if RequestPayment is None:
@@ -432,8 +431,7 @@ def present(name, Bucket,
             ('Tagging', 'put_tagging', Tagging, None, Tagging, 'delete_tagging'),
             ('Website', 'put_website', Website, None, Website, 'delete_website'),
     ):
-        diffs = salt.utils.compare_dicts(current or {}, compare or desired or {})
-        if bool(diffs):
+        if not json_objs_equal(current,(compare or desired)):
             if __opts__['test']:
                 msg = 'S3 bucket {0} set to be modified.'.format(Bucket)
                 ret['comment'] = msg

--- a/salt/states/boto_s3_bucket.py
+++ b/salt/states/boto_s3_bucket.py
@@ -143,7 +143,6 @@ from copy import deepcopy
 import json
 
 # Import Salt Libs
-import salt.utils
 from salt.ext.six import string_types  # pylint: disable=import-error
 from salt.utils.boto3 import json_objs_equal
 
@@ -189,7 +188,7 @@ def _acl_to_grant(ACL, owner_canonical_id):
                 },
                 'Permission': 'READ'
             })
-        if  acl == 'public-read-write':
+        if acl == 'public-read-write':
             ret['Grants'].append({
                 'Grantee': {
                     'URI': 'http://acs.amazonaws.com/groups/global/AllUsers'
@@ -272,6 +271,7 @@ def _get_role_arn(name, region=None, key=None, keyid=None, profile=None):
 
 def _compare_json(current, desired, region, key, keyid, profile):
     return json_objs_equal(current, desired)
+
 
 def _compare_acl(current, desired, region, key, keyid, profile):
     '''
@@ -426,7 +426,7 @@ def present(name, Bucket,
         for setter, testval, funcargs in (
                 ('put_acl', ACL, ACL),
                 ('put_cors', CORSRules, {"CORSRules": CORSRules}),
-                ('put_lifecycle_configuration', LifecycleConfiguration, {"Rules":LifecycleConfiguration}),
+                ('put_lifecycle_configuration', LifecycleConfiguration, {"Rules": LifecycleConfiguration}),
                 ('put_logging', Logging, Logging),
                 ('put_notification_configuration', NotificationConfiguration, NotificationConfiguration),
                 ('put_policy', Policy, {"Policy": Policy}),

--- a/salt/states/boto_s3_bucket.py
+++ b/salt/states/boto_s3_bucket.py
@@ -41,7 +41,7 @@ config:
         boto_s3_bucket.present:
             - Bucket: mybucket
             - LocationConstraint: EU
-            - ACL: 
+            - ACL:
               - GrantRead: "uri=http://acs.amazonaws.com/groups/global/AllUsers"
             - CORSRules:
               - AllowedHeaders: []
@@ -165,13 +165,13 @@ def _get_canonical_id(region, key, keyid, profile):
 
 def _acl_to_grant(ACL, owner_canonical_id):
     if 'AccessControlPolicy' in ACL:
-       ret = deepcopy(ACL['AccessControlPolicy'])
-       # Type is required as input, but is not returned as output
-       for item in ret.get('Grants'):
-           if 'Type' in item.get('Grantee',()):
-               del item['Grantee']['Type']
-       # If AccessControlPolicy is set, other options are not allowed
-       return ret
+        ret = deepcopy(ACL['AccessControlPolicy'])
+        # Type is required as input, but is not returned as output
+        for item in ret.get('Grants'):
+            if 'Type' in item.get('Grantee', ()):
+                del item['Grantee']['Type']
+        # If AccessControlPolicy is set, other options are not allowed
+        return ret
     ret = {
         'Grants': [{
             'Grantee': owner_canonical_id,
@@ -285,12 +285,12 @@ def _compare_acl(current, desired, region, key, keyid, profile):
 
 
 def _compare_policy(current, desired, region, key, keyid, profile):
-    ''' 
+    '''
     Policy discription is always returned as a JSON string. Comparison
     should be object-to-object, since order is not significant in JSON
     '''
     if isinstance(desired, string_types):
-        desired = json.loads(desired) 
+        desired = json.loads(desired)
 
     if current is not None:
         temp = current.get('Policy')
@@ -302,7 +302,7 @@ def _compare_policy(current, desired, region, key, keyid, profile):
 
 
 def _compare_replication(current, desired, region, key, keyid, profile):
-    ''' 
+    '''
     Replication accepts a non-ARN role name, but always returns an ARN
     '''
     if desired is not None and desired.get('Role'):
@@ -400,7 +400,7 @@ def present(name, Bucket,
     if NotificationConfiguration is None:
         NotificationConfiguration = {}
     if RequestPayment is None:
-        RequestPayment={'Payer': 'BucketOwner'}
+        RequestPayment = {'Payer': 'BucketOwner'}
 
     r = __salt__['boto_s3_bucket.exists'](Bucket=Bucket,
            region=region, key=key, keyid=keyid, profile=profile)
@@ -482,7 +482,7 @@ def present(name, Bucket,
                     _describe.get('LifecycleConfiguration'), _compare_json, {"Rules": LifecycleConfiguration} if LifecycleConfiguration else None,
                     'delete_lifecycle_configuration'),
             ('Logging', 'put_logging',
-                    _describe.get('Logging',{}).get('LoggingEnabled'), _compare_json, Logging,
+                    _describe.get('Logging', {}).get('LoggingEnabled'), _compare_json, Logging,
                     None),
             ('NotificationConfiguration', 'put_notification_configuration',
                     _describe.get('NotificationConfiguration'), _compare_json, NotificationConfiguration,
@@ -505,7 +505,7 @@ def present(name, Bucket,
                     None)
     # Substitute full ARN into desired state for comparison
     replication_item = ('Replication', 'put_replication',
-                    _describe.get('Replication',{}).get('ReplicationConfiguration'), _compare_replication, Replication,
+                    _describe.get('Replication', {}).get('ReplicationConfiguration'), _compare_replication, Replication,
                     'delete_replication')
 
     # versioning must be turned on before replication can be on, thus replication
@@ -552,7 +552,7 @@ def present(name, Bucket,
     # Since location can't be changed, try that last so at least the rest of
     # the things are correct by the time we fail here. Fail so the user will
     # notice something mismatches their desired state.
-    if _describe.get('Location',{}).get('LocationConstraint') != LocationConstraint:
+    if _describe.get('Location', {}).get('LocationConstraint') != LocationConstraint:
         msg = 'Bucket {0} location does not match desired configuration, but cannot be changed'.format(LocationConstraint)
         log.warn(msg)
         ret['result'] = False

--- a/salt/utils/boto3.py
+++ b/salt/utils/boto3.py
@@ -308,3 +308,17 @@ def get_role_arn(name, region=None, key=None, keyid=None, profile=None):
         region=region, key=key, keyid=keyid, profile=profile
     )
     return 'arn:aws:iam::{0}:role/{1}'.format(account_id, name)
+
+
+def _ordered(obj):
+    if isinstance(obj, (list, tuple)):
+        return sorted(_ordered(x) for x in obj)
+    elif isinstance(obj, dict):
+        return dict((k, _ordered(v)) for k, v in obj.items())
+    return obj
+
+
+def json_objs_equal(left, right):
+    """ Compare two parsed JSON objects, given non-ordering in JSON objects
+    """
+    return _ordered(left) == _ordered(right)

--- a/salt/utils/boto3.py
+++ b/salt/utils/boto3.py
@@ -41,6 +41,7 @@ import logging
 import sys
 from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
 from functools import partial
+from collections import OrderedDict
 
 # Import salt libs
 from salt.ext.six import string_types  # pylint: disable=import-error
@@ -313,8 +314,10 @@ def get_role_arn(name, region=None, key=None, keyid=None, profile=None):
 def _ordered(obj):
     if isinstance(obj, (list, tuple)):
         return sorted(_ordered(x) for x in obj)
-    elif isinstance(obj, dict):
-        return dict((k, _ordered(v)) for k, v in obj.items())
+    elif isinstance(obj, (dict, OrderedDict)):
+        return dict((unicode(k) if isinstance(k, string_types) else k, _ordered(v)) for k, v in obj.items())
+    elif isinstance(obj, string_types):
+        return unicode(obj)
     return obj
 
 

--- a/salt/utils/boto3.py
+++ b/salt/utils/boto3.py
@@ -43,9 +43,9 @@ from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=i
 from functools import partial
 
 # Import salt libs
-from salt.ext.six import string_types  # pylint: disable=import-error
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 from salt.exceptions import SaltInvocationError
+from salt.ext import six
 
 # Import third party libs
 # pylint: disable=import-error
@@ -100,7 +100,7 @@ def _option(value):
 
 def _get_profile(service, region, key, keyid, profile):
     if profile:
-        if isinstance(profile, string_types):
+        if isinstance(profile, six.string_types):
             _profile = _option(profile)
         elif isinstance(profile, dict):
             _profile = profile
@@ -314,9 +314,9 @@ def _ordered(obj):
     if isinstance(obj, (list, tuple)):
         return sorted(_ordered(x) for x in obj)
     elif isinstance(obj, dict):
-        return dict((unicode(k) if isinstance(k, string_types) else k, _ordered(v)) for k, v in obj.items())
-    elif isinstance(obj, string_types):
-        return unicode(obj)
+        return dict((six.text_type(k) if isinstance(k, six.string_types) else k, _ordered(v)) for k, v in obj.items())
+    elif isinstance(obj, six.string_types):
+        return six.text_type(obj)
     return obj
 
 

--- a/salt/utils/boto3.py
+++ b/salt/utils/boto3.py
@@ -41,7 +41,6 @@ import logging
 import sys
 from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
 from functools import partial
-from collections import OrderedDict
 
 # Import salt libs
 from salt.ext.six import string_types  # pylint: disable=import-error
@@ -314,7 +313,7 @@ def get_role_arn(name, region=None, key=None, keyid=None, profile=None):
 def _ordered(obj):
     if isinstance(obj, (list, tuple)):
         return sorted(_ordered(x) for x in obj)
-    elif isinstance(obj, (dict, OrderedDict)):
+    elif isinstance(obj, dict):
         return dict((unicode(k) if isinstance(k, string_types) else k, _ordered(v)) for k, v in obj.items())
     elif isinstance(obj, string_types):
         return unicode(obj)

--- a/tests/unit/modules/boto_s3_bucket_test.py
+++ b/tests/unit/modules/boto_s3_bucket_test.py
@@ -1,0 +1,715 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+from __future__ import absolute_import
+from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module
+from copy import deepcopy
+
+# Import Salt Testing libs
+from salttesting.unit import skipIf, TestCase
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, patch
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+# Import Salt libs
+import salt.config
+import salt.loader
+from salt.modules import boto_s3_bucket
+
+# Import 3rd-party libs
+import logging
+
+# Import Mock libraries
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
+
+# pylint: disable=import-error,no-name-in-module,unused-import
+try:
+    import boto
+    import boto3
+    from botocore.exceptions import ClientError
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+
+# pylint: enable=import-error,no-name-in-module,unused-import
+
+# the boto_s3_bucket module relies on the connect_to_region() method
+# which was added in boto 2.8.0
+# https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
+required_boto3_version = '1.2.1'
+
+log = logging.getLogger(__name__)
+
+opts = salt.config.DEFAULT_MINION_OPTS
+context = {}
+utils = salt.loader.utils(opts, whitelist=['boto3'], context=context)
+
+boto_s3_bucket.__utils__ = utils
+boto_s3_bucket.__init__(opts)
+boto_s3_bucket.__salt__ = {}
+
+
+def _has_required_boto():
+    '''
+    Returns True/False boolean depending on if Boto is installed and correct
+    version.
+    '''
+    if not HAS_BOTO:
+        return False
+    elif LooseVersion(boto3.__version__) < LooseVersion(required_boto3_version):
+        return False
+    else:
+        return True
+
+if _has_required_boto():
+    region = 'us-east-1'
+    access_key = 'GKTADJGHEIQSXMKKRBJ08H'
+    secret_key = 'askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs'
+    conn_parameters = {'region': region, 'key': access_key, 'keyid': secret_key, 'profile': {}}
+    error_message = 'An error occurred (101) when calling the {0} operation: Test-defined error'
+    e404_error = ClientError({
+        'Error': {
+            'Code': '404',
+            'Message': "Test-defined error"
+        }
+    }, 'msg')
+    not_found_error = ClientError({
+        'Error': {
+            'Code': 'NoSuchBucket',
+            'Message': "Test-defined error"
+        }
+    }, 'msg')
+    error_content = {
+      'Error': {
+        'Code': 101,
+        'Message': "Test-defined error"
+      }
+    }
+    create_ret = {
+        'Location': 'nowhere',
+    }
+    list_ret = {
+        'Buckets': [{
+            'Name': 'mybucket',
+            'CreationDate': None
+        }],
+        'Owner': {
+            'DisplayName': 'testuser',
+            'ID': '12341234123'
+        },
+        'ResponseMetadata': {'Key': 'Value'}
+    }
+    config_ret = {
+        'get_bucket_acl': {
+            'Grants': {
+                'Grantee': {
+                    'DisplayName': 'testuser',
+                    'ID': 'aaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbc255ce8ac627c5a8c35e9273589',
+                },
+                'Permission': 'FULL_CONTROL'
+            },
+            'Owner': {
+                'DisplayName': 'testuser',
+                'ID': 'aaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbc255ce8ac627c5a8c35e9273589'
+            }
+        },
+        'get_bucket_cors': {
+            'Grants': {
+                'Grantee': {
+                    'DisplayName': 'testuser',
+                    'ID': 'aaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbc255ce8ac627c5a8c35e9273589',
+                },
+                'Permission': 'FULL_CONTROL'
+            },
+            'Owner': {
+                'DisplayName': 'testuser',
+                'ID': 'aaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbc255ce8ac627c5a8c35e9273589'
+            }
+        },
+        'get_bucket_lifecycle_configuration': {
+            'Rules': [{
+                'Expiration': {'Days': 10},
+                'ID': 'Yjc0NGIyNDUtNmVhZi00OTM2LThhYWEtZDRmZGU0NzA0ZWIw',
+                'Prefix': 'expiring',
+                'Status': 'Enabled'
+            }]
+        },
+        'get_bucket_location': {
+            'LocationConstraint': None
+        },
+        'get_bucket_logging': {
+            'LoggingEnabled': {
+                'TargetBucket': 'auditinfo',
+                'TargetGrants': None,
+                'TargetPrefix': 'logging',
+            }
+        },
+        'get_bucket_notification_configuration': {
+            'LambdaFunctionConfigurations': [{
+                  'Events': ['s3:ObjectCreated:*'],
+                  'Filter': {
+                      'Key': {
+                          'FilterRules': [{
+                                'Name': 'Prefix',
+                                'Value': 'lambda'
+                           }]
+                      }
+                  },
+                  'Id': 'MGQ3MGYxYTEtZmRiYS00N2RkLWFhYTItMDRmYTRhNGUwMmZl',
+                  'LambdaFunctionArn':
+                      'arn:aws:lambda:us-east-1:213454234522:function:myfunction',
+            }]
+        },
+        'get_bucket_policy': {
+            'Policy':
+                '{"Version":"2012-10-17","Statement":[{"Sid":"","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::111111222222:root"},"Action":"s3:PutObject","Resource":"arn:aws:s3:::my-bucket/*"}]}'
+        },
+        'get_bucket_replication': {
+            'ReplicationConfiguration': {
+                'Role': 'arn:aws:iam::111111222222:role/my-role',
+                'Rules': [{
+                      'Destination': {
+                          'Bucket': 'arn:aws:s3:::my-bucket-2'
+                      },
+                      'ID': 'r1',
+                      'Prefix': 'repl',
+                      'Status': 'Enabled'
+                }]
+            }
+        },
+        'get_bucket_request_payment': {'Payer': 'Requester'},
+        'get_bucket_tagging': {
+            'TagSet': [{
+                'Key': 'c',
+                'Value': 'd'
+            }, {
+                'Key': 'a',
+                'Value': 'b',
+            }]
+        },
+        'get_bucket_versioning': {
+            'Status': 'Enabled'
+        },
+        'get_bucket_website': {
+            'IndexDocument': {
+                'Suffix': 'index.html'
+            }
+        }
+    }
+
+
+class BotoS3BucketTestCaseBase(TestCase):
+    conn = None
+
+    # Set up MagicMock to replace the boto3 session
+    def setUp(self):
+        context.clear()
+
+        self.patcher = patch('boto3.session.Session')
+        self.addCleanup(self.patcher.stop)
+        mock_session = self.patcher.start()
+
+        session_instance = mock_session.return_value
+        self.conn = MagicMock()
+        session_instance.client.return_value = self.conn
+
+
+class BotoS3BucketTestCaseMixin(object):
+    pass
+
+
+@skipIf(HAS_BOTO is False, 'The boto module must be installed.')
+@skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
+                                       ' or equal to version {0}'
+        .format(required_boto3_version))
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class BotoS3BucketTestCase(BotoS3BucketTestCaseBase, BotoS3BucketTestCaseMixin):
+    '''
+    TestCase for salt.modules.boto_s3_bucket module
+    '''
+
+    def test_that_when_checking_if_a_bucket_exists_and_a_bucket_exists_the_bucket_exists_method_returns_true(self):
+        '''
+        Tests checking s3 bucket existence when the s3 bucket already exists
+        '''
+        self.conn.head_bucket.return_value = None
+        result = boto_s3_bucket.exists(Bucket='mybucket', **conn_parameters)
+
+        self.assertTrue(result['exists'])
+
+    def test_that_when_checking_if_a_bucket_exists_and_a_bucket_does_not_exist_the_bucket_exists_method_returns_false(self):
+        '''
+        Tests checking s3 bucket existence when the s3 bucket does not exist
+        '''
+        self.conn.head_bucket.side_effect = e404_error
+        result = boto_s3_bucket.exists(Bucket='mybucket', **conn_parameters)
+
+        self.assertFalse(result['exists'])
+
+    def test_that_when_checking_if_a_bucket_exists_and_boto3_returns_an_error_the_bucket_exists_method_returns_error(self):
+        '''
+        Tests checking s3 bucket existence when boto returns an error
+        '''
+        self.conn.head_bucket.side_effect = ClientError(error_content, 'head_bucket')
+        result = boto_s3_bucket.exists(Bucket='mybucket', **conn_parameters)
+
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('head_bucket'))
+
+    def test_that_when_creating_a_bucket_succeeds_the_create_bucket_method_returns_true(self):
+        '''
+        tests True bucket created.
+        '''
+        self.conn.create_bucket.return_value = create_ret
+        result = boto_s3_bucket.create(Bucket='mybucket',
+                                       LocationConstraint='nowhere',
+                                        **conn_parameters)
+
+        self.assertTrue(result['created'])
+
+    def test_that_when_creating_a_bucket_fails_the_create_bucket_method_returns_error(self):
+        '''
+        tests False bucket not created.
+        '''
+        self.conn.create_bucket.side_effect = ClientError(error_content, 'create_bucket')
+        result = boto_s3_bucket.create(Bucket='mybucket',
+                                       LocationConstraint='nowhere',
+                                        **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('create_bucket'))
+
+    def test_that_when_deleting_a_bucket_succeeds_the_delete_bucket_method_returns_true(self):
+        '''
+        tests True bucket deleted.
+        '''
+        result = boto_s3_bucket.delete(Bucket='mybucket',
+                                        **conn_parameters)
+
+        self.assertTrue(result['deleted'])
+
+    def test_that_when_deleting_a_bucket_fails_the_delete_bucket_method_returns_false(self):
+        '''
+        tests False bucket not deleted.
+        '''
+        self.conn.delete_bucket.side_effect = ClientError(error_content, 'delete_bucket')
+        result = boto_s3_bucket.delete(Bucket='mybucket',
+                                        **conn_parameters)
+        self.assertFalse(result['deleted'])
+
+    def test_that_when_describing_bucket_it_returns_the_dict_of_properties_returns_true(self):
+        '''
+        Tests describing parameters if bucket exists
+        '''
+        for key, value in config_ret.iteritems():
+            getattr(self.conn, key).return_value = deepcopy(value)
+
+        result = boto_s3_bucket.describe(Bucket='mybucket', **conn_parameters)
+
+        self.assertTrue(result['bucket'])
+
+    def test_that_when_describing_bucket_it_returns_the_dict_of_properties_returns_false(self):
+        '''
+        Tests describing parameters if bucket does not exist
+        '''
+        self.conn.get_bucket_acl.side_effect = not_found_error
+        result = boto_s3_bucket.describe(Bucket='mybucket', **conn_parameters)
+
+        self.assertFalse(result['bucket'])
+
+    def test_that_when_describing_bucket_on_client_error_it_returns_error(self):
+        '''
+        Tests describing parameters failure
+        '''
+        self.conn.get_bucket_acl.side_effect = ClientError(error_content, 'get_bucket_acl')
+        result = boto_s3_bucket.describe(Bucket='mybucket', **conn_parameters)
+        self.assertTrue('error' in result)
+
+    def test_that_when_listing_buckets_succeeds_the_list_buckets_method_returns_true(self):
+        '''
+        tests True buckets listed.
+        '''
+        self.conn.list_buckets.return_value = deepcopy(list_ret)
+        result = boto_s3_bucket.list(**conn_parameters)
+
+        self.assertTrue(result['Buckets'])
+
+    def test_that_when_listing_bucket_fails_the_list_bucket_method_returns_false(self):
+        '''
+        tests False no bucket listed.
+        '''
+        ret = deepcopy(list_ret)
+        log.info(ret)
+        ret['Buckets'] = list()
+        self.conn.list_buckets.return_value = ret
+        result = boto_s3_bucket.list(**conn_parameters)
+        self.assertFalse(result['Buckets'])
+
+    def test_that_when_listing_bucket_fails_the_list_bucket_method_returns_error(self):
+        '''
+        tests False bucket error.
+        '''
+        self.conn.list_buckets.side_effect = ClientError(error_content, 'list_buckets')
+        result = boto_s3_bucket.list(**conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('list_buckets'))
+
+    def test_that_when_putting_acl_succeeds_the_put_acl_method_returns_true(self):
+        '''
+        tests True bucket updated.
+        '''
+        result = boto_s3_bucket.put_acl(Bucket='mybucket',
+                                        **conn_parameters)
+
+        self.assertTrue(result['updated'])
+
+    def test_that_when_putting_acl_fails_the_put_acl_method_returns_error(self):
+        '''
+        tests False bucket not updated.
+        '''
+        self.conn.put_bucket_acl.side_effect = ClientError(error_content,
+                       'put_bucket_acl')
+        result = boto_s3_bucket.put_acl(Bucket='mybucket',
+                                        **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'),
+                        error_message.format('put_bucket_acl'))
+
+    def test_that_when_putting_cors_succeeds_the_put_cors_method_returns_true(self):
+        '''
+        tests True bucket updated.
+        '''
+        result = boto_s3_bucket.put_cors(Bucket='mybucket', CORSRules='[]',
+                                        **conn_parameters)
+
+        self.assertTrue(result['updated'])
+
+    def test_that_when_putting_cors_fails_the_put_cors_method_returns_error(self):
+        '''
+        tests False bucket not updated.
+        '''
+        self.conn.put_bucket_cors.side_effect = ClientError(error_content,
+                       'put_bucket_cors')
+        result = boto_s3_bucket.put_cors(Bucket='mybucket', CORSRules='[]',
+                                        **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'),
+                        error_message.format('put_bucket_cors'))
+
+    def test_that_when_putting_lifecycle_configuration_succeeds_the_put_lifecycle_configuration_method_returns_true(self):
+        '''
+        tests True bucket updated.
+        '''
+        result = boto_s3_bucket.put_lifecycle_configuration(Bucket='mybucket',
+                                        Rules='[]',
+                                        **conn_parameters)
+
+        self.assertTrue(result['updated'])
+
+    def test_that_when_putting_lifecycle_configuration_fails_the_put_lifecycle_configuration_method_returns_error(self):
+        '''
+        tests False bucket not updated.
+        '''
+        self.conn.put_bucket_lifecycle_configuration.side_effect = ClientError(error_content,
+                       'put_bucket_lifecycle_configuration')
+        result = boto_s3_bucket.put_lifecycle_configuration(Bucket='mybucket',
+                                        Rules='[]',
+                                        **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'),
+                        error_message.format('put_bucket_lifecycle_configuration'))
+
+    def test_that_when_putting_logging_succeeds_the_put_logging_method_returns_true(self):
+        '''
+        tests True bucket updated.
+        '''
+        result = boto_s3_bucket.put_logging(Bucket='mybucket',
+                                        TargetBucket='arn:::::',
+                                        TargetPrefix='asdf',
+                                        TargetGrants='[]',
+                                        **conn_parameters)
+
+        self.assertTrue(result['updated'])
+
+    def test_that_when_putting_logging_fails_the_put_logging_method_returns_error(self):
+        '''
+        tests False bucket not updated.
+        '''
+        self.conn.put_bucket_logging.side_effect = ClientError(error_content,
+                       'put_bucket_logging')
+        result = boto_s3_bucket.put_logging(Bucket='mybucket',
+                                        TargetBucket='arn:::::',
+                                        TargetPrefix='asdf',
+                                        TargetGrants='[]',
+                                        **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'),
+                        error_message.format('put_bucket_logging'))
+
+    def test_that_when_putting_notification_configuration_succeeds_the_put_notification_configuration_method_returns_true(self):
+        '''
+        tests True bucket updated.
+        '''
+        result = boto_s3_bucket.put_notification_configuration(Bucket='mybucket',
+                                        **conn_parameters)
+
+        self.assertTrue(result['updated'])
+
+    def test_that_when_putting_notification_configuration_fails_the_put_notification_configuration_method_returns_error(self):
+        '''
+        tests False bucket not updated.
+        '''
+        self.conn.put_bucket_notification_configuration.side_effect = ClientError(error_content,
+                       'put_bucket_notification_configuration')
+        result = boto_s3_bucket.put_notification_configuration(Bucket='mybucket',
+                                        **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'),
+                        error_message.format('put_bucket_notification_configuration'))
+
+    def test_that_when_putting_policy_succeeds_the_put_policy_method_returns_true(self):
+        '''
+        tests True bucket updated.
+        '''
+        result = boto_s3_bucket.put_policy(Bucket='mybucket',
+                                        Policy='{}',
+                                        **conn_parameters)
+
+        self.assertTrue(result['updated'])
+
+    def test_that_when_putting_policy_fails_the_put_policy_method_returns_error(self):
+        '''
+        tests False bucket not updated.
+        '''
+        self.conn.put_bucket_policy.side_effect = ClientError(error_content,
+                       'put_bucket_policy')
+        result = boto_s3_bucket.put_policy(Bucket='mybucket',
+                                        Policy='{}',
+                                        **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'),
+                        error_message.format('put_bucket_policy'))
+
+    def test_that_when_putting_replication_succeeds_the_put_replication_method_returns_true(self):
+        '''
+        tests True bucket updated.
+        '''
+        result = boto_s3_bucket.put_replication(Bucket='mybucket',
+                                        Role='arn:aws:iam:::',
+                                        Rules='[]',
+                                        **conn_parameters)
+
+        self.assertTrue(result['updated'])
+
+    def test_that_when_putting_replication_fails_the_put_replication_method_returns_error(self):
+        '''
+        tests False bucket not updated.
+        '''
+        self.conn.put_bucket_replication.side_effect = ClientError(error_content,
+                       'put_bucket_replication')
+        result = boto_s3_bucket.put_replication(Bucket='mybucket',
+                                        Role='arn:aws:iam:::',
+                                        Rules='[]',
+                                        **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'),
+                        error_message.format('put_bucket_replication'))
+
+    def test_that_when_putting_request_payment_succeeds_the_put_request_payment_method_returns_true(self):
+        '''
+        tests True bucket updated.
+        '''
+        result = boto_s3_bucket.put_request_payment(Bucket='mybucket',
+                                        Payer='Requester',
+                                        **conn_parameters)
+
+        self.assertTrue(result['updated'])
+
+    def test_that_when_putting_request_payment_fails_the_put_request_payment_method_returns_error(self):
+        '''
+        tests False bucket not updated.
+        '''
+        self.conn.put_bucket_request_payment.side_effect = ClientError(error_content,
+                       'put_bucket_request_payment')
+        result = boto_s3_bucket.put_request_payment(Bucket='mybucket',
+                                        Payer='Requester',
+                                        **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'),
+                        error_message.format('put_bucket_request_payment'))
+
+    def test_that_when_putting_tagging_succeeds_the_put_tagging_method_returns_true(self):
+        '''
+        tests True bucket updated.
+        '''
+        result = boto_s3_bucket.put_tagging(Bucket='mybucket',
+                                        **conn_parameters)
+
+        self.assertTrue(result['updated'])
+
+    def test_that_when_putting_tagging_fails_the_put_tagging_method_returns_error(self):
+        '''
+        tests False bucket not updated.
+        '''
+        self.conn.put_bucket_tagging.side_effect = ClientError(error_content,
+                       'put_bucket_tagging')
+        result = boto_s3_bucket.put_tagging(Bucket='mybucket',
+                                        **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'),
+                        error_message.format('put_bucket_tagging'))
+
+    def test_that_when_putting_versioning_succeeds_the_put_versioning_method_returns_true(self):
+        '''
+        tests True bucket updated.
+        '''
+        result = boto_s3_bucket.put_versioning(Bucket='mybucket',
+                                        Status='Enabled',
+                                        **conn_parameters)
+
+        self.assertTrue(result['updated'])
+
+    def test_that_when_putting_versioning_fails_the_put_versioning_method_returns_error(self):
+        '''
+        tests False bucket not updated.
+        '''
+        self.conn.put_bucket_versioning.side_effect = ClientError(error_content,
+                       'put_bucket_versioning')
+        result = boto_s3_bucket.put_versioning(Bucket='mybucket',
+                                        Status='Enabled',
+                                        **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'),
+                        error_message.format('put_bucket_versioning'))
+
+    def test_that_when_putting_website_succeeds_the_put_website_method_returns_true(self):
+        '''
+        tests True bucket updated.
+        '''
+        result = boto_s3_bucket.put_website(Bucket='mybucket',
+                                        **conn_parameters)
+
+        self.assertTrue(result['updated'])
+
+    def test_that_when_putting_website_fails_the_put_website_method_returns_error(self):
+        '''
+        tests False bucket not updated.
+        '''
+        self.conn.put_bucket_website.side_effect = ClientError(error_content,
+                       'put_bucket_website')
+        result = boto_s3_bucket.put_website(Bucket='mybucket',
+                                        **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'),
+                        error_message.format('put_bucket_website'))
+
+    def test_that_when_deleting_cors_succeeds_the_delete_cors_method_returns_true(self):
+        '''
+        tests True bucket attribute deleted.
+        '''
+        result = boto_s3_bucket.delete_cors(Bucket='mybucket',
+                                        **conn_parameters)
+
+        self.assertTrue(result['deleted'])
+
+    def test_that_when_deleting_cors_fails_the_delete_cors_method_returns_error(self):
+        '''
+        tests False bucket attribute not deleted.
+        '''
+        self.conn.delete_bucket_cors.side_effect = ClientError(error_content,
+                       'delete_bucket_cors')
+        result = boto_s3_bucket.delete_cors(Bucket='mybucket',
+                                        **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'),
+                        error_message.format('delete_bucket_cors'))
+
+    def test_that_when_deleting_lifecycle_configuration_succeeds_the_delete_lifecycle_configuration_method_returns_true(self):
+        '''
+        tests True bucket attribute deleted.
+        '''
+        result = boto_s3_bucket.delete_lifecycle_configuration(Bucket='mybucket',
+                                        **conn_parameters)
+
+        self.assertTrue(result['deleted'])
+
+    def test_that_when_deleting_lifecycle_configuration_fails_the_delete_lifecycle_configuration_method_returns_error(self):
+        '''
+        tests False bucket attribute not deleted.
+        '''
+        self.conn.delete_bucket_lifecycle.side_effect = ClientError(error_content,
+                       'delete_bucket_lifecycle_configuration')
+        result = boto_s3_bucket.delete_lifecycle_configuration(Bucket='mybucket',
+                                        **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'),
+                        error_message.format('delete_bucket_lifecycle_configuration'))
+
+    def test_that_when_deleting_policy_succeeds_the_delete_policy_method_returns_true(self):
+        '''
+        tests True bucket attribute deleted.
+        '''
+        result = boto_s3_bucket.delete_policy(Bucket='mybucket',
+                                        **conn_parameters)
+
+        self.assertTrue(result['deleted'])
+
+    def test_that_when_deleting_policy_fails_the_delete_policy_method_returns_error(self):
+        '''
+        tests False bucket attribute not deleted.
+        '''
+        self.conn.delete_bucket_policy.side_effect = ClientError(error_content,
+                       'delete_bucket_policy')
+        result = boto_s3_bucket.delete_policy(Bucket='mybucket',
+                                        **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'),
+                        error_message.format('delete_bucket_policy'))
+
+    def test_that_when_deleting_policy_succeeds_the_delete_policy_method_returns_true(self):
+        '''
+        tests True bucket attribute deleted.
+        '''
+        result = boto_s3_bucket.delete_policy(Bucket='mybucket',
+                                        **conn_parameters)
+
+        self.assertTrue(result['deleted'])
+
+    def test_that_when_deleting_replication_fails_the_delete_replication_method_returns_error(self):
+        '''
+        tests False bucket attribute not deleted.
+        '''
+        self.conn.delete_bucket_replication.side_effect = ClientError(error_content,
+                       'delete_bucket_replication')
+        result = boto_s3_bucket.delete_replication(Bucket='mybucket',
+                                        **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'),
+                        error_message.format('delete_bucket_replication'))
+
+    def test_that_when_deleting_tagging_succeeds_the_delete_tagging_method_returns_true(self):
+        '''
+        tests True bucket attribute deleted.
+        '''
+        result = boto_s3_bucket.delete_tagging(Bucket='mybucket',
+                                        **conn_parameters)
+
+        self.assertTrue(result['deleted'])
+
+    def test_that_when_deleting_tagging_fails_the_delete_tagging_method_returns_error(self):
+        '''
+        tests False bucket attribute not deleted.
+        '''
+        self.conn.delete_bucket_tagging.side_effect = ClientError(error_content,
+                       'delete_bucket_tagging')
+        result = boto_s3_bucket.delete_tagging(Bucket='mybucket',
+                                        **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'),
+                        error_message.format('delete_bucket_tagging'))
+
+    def test_that_when_deleting_website_succeeds_the_delete_website_method_returns_true(self):
+        '''
+        tests True bucket attribute deleted.
+        '''
+        result = boto_s3_bucket.delete_website(Bucket='mybucket',
+                                        **conn_parameters)
+
+        self.assertTrue(result['deleted'])
+
+    def test_that_when_deleting_website_fails_the_delete_website_method_returns_error(self):
+        '''
+        tests False bucket attribute not deleted.
+        '''
+        self.conn.delete_bucket_website.side_effect = ClientError(error_content,
+                       'delete_bucket_website')
+        result = boto_s3_bucket.delete_website(Bucket='mybucket',
+                                        **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'),
+                        error_message.format('delete_bucket_website'))
+
+
+if __name__ == '__main__':
+    from integration import run_tests  # pylint: disable=import-error
+    run_tests(BotoS3BucketTestCase, needs_daemon=False)

--- a/tests/unit/modules/boto_s3_bucket_test.py
+++ b/tests/unit/modules/boto_s3_bucket_test.py
@@ -650,11 +650,11 @@ class BotoS3BucketTestCase(BotoS3BucketTestCaseBase, BotoS3BucketTestCaseMixin):
         self.assertEqual(result.get('error', {}).get('message'),
                         error_message.format('delete_bucket_policy'))
 
-    def test_that_when_deleting_policy_succeeds_the_delete_policy_method_returns_true(self):
+    def test_that_when_deleting_replication_succeeds_the_delete_replication_method_returns_true(self):
         '''
         tests True bucket attribute deleted.
         '''
-        result = boto_s3_bucket.delete_policy(Bucket='mybucket',
+        result = boto_s3_bucket.delete_replication(Bucket='mybucket',
                                         **conn_parameters)
 
         self.assertTrue(result['deleted'])

--- a/tests/unit/modules/boto_s3_bucket_test.py
+++ b/tests/unit/modules/boto_s3_bucket_test.py
@@ -102,63 +102,61 @@ if _has_required_boto():
     }
     config_ret = {
         'get_bucket_acl': {
-            'Grants': {
+            'Grants': [{
                 'Grantee': {
-                    'DisplayName': 'testuser',
-                    'ID': 'aaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbc255ce8ac627c5a8c35e9273589',
+                    'DisplayName': 'testowner',
+                    'ID': 'sdfghjklqwertyuiopzxcvbnm'
                 },
                 'Permission': 'FULL_CONTROL'
-            },
+            }, {
+                'Grantee': {
+                    'URI': 'http://acs.amazonaws.com/groups/global/AllUsers'
+                },
+                'Permission': 'READ'
+            }],
             'Owner': {
-                'DisplayName': 'testuser',
-                'ID': 'aaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbc255ce8ac627c5a8c35e9273589'
+                'DisplayName': 'testowner',
+                'ID': 'sdfghjklqwertyuiopzxcvbnm'
             }
         },
         'get_bucket_cors': {
-            'Grants': {
-                'Grantee': {
-                    'DisplayName': 'testuser',
-                    'ID': 'aaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbc255ce8ac627c5a8c35e9273589',
-                },
-                'Permission': 'FULL_CONTROL'
-            },
-            'Owner': {
-                'DisplayName': 'testuser',
-                'ID': 'aaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbc255ce8ac627c5a8c35e9273589'
-            }
+            'CORSRules': [{
+                'AllowedMethods': ["GET"],
+                'AllowedOrigins': ["*"],
+            }]
         },
         'get_bucket_lifecycle_configuration': {
             'Rules': [{
-                'Expiration': {'Days': 10},
-                'ID': 'Yjc0NGIyNDUtNmVhZi00OTM2LThhYWEtZDRmZGU0NzA0ZWIw',
-                'Prefix': 'expiring',
-                'Status': 'Enabled'
+                'Expiration': {
+                    'Days': 1
+                },
+                'Prefix': 'prefix',
+                'Status': 'Enabled',
+                'ID': 'asdfghjklpoiuytrewq'
             }]
         },
         'get_bucket_location': {
-            'LocationConstraint': None
+            'LocationConstraint': 'EU'
         },
         'get_bucket_logging': {
             'LoggingEnabled': {
-                'TargetBucket': 'auditinfo',
-                'TargetGrants': None,
-                'TargetPrefix': 'logging',
+                'TargetBucket': 'my-bucket',
+                'TargetPrefix': 'prefix'
             }
         },
         'get_bucket_notification_configuration': {
             'LambdaFunctionConfigurations': [{
-                  'Events': ['s3:ObjectCreated:*'],
-                  'Filter': {
-                      'Key': {
-                          'FilterRules': [{
-                                'Name': 'Prefix',
-                                'Value': 'lambda'
-                           }]
-                      }
-                  },
-                  'Id': 'MGQ3MGYxYTEtZmRiYS00N2RkLWFhYTItMDRmYTRhNGUwMmZl',
-                  'LambdaFunctionArn':
-                      'arn:aws:lambda:us-east-1:213454234522:function:myfunction',
+                'LambdaFunctionArn': 'arn:aws:lambda:us-east-1:111111222222:function:my-function',
+                'Id': 'zxcvbnmlkjhgfdsa',
+                'Events': ["s3:ObjectCreated:*"],
+                'Filter': {
+                    'Key': {
+                        'FilterRules': [{
+                            'Name': 'prefix',
+                            'Value': 'string'
+                        }]
+                    }
+                }
             }]
         },
         'get_bucket_policy': {
@@ -167,14 +165,14 @@ if _has_required_boto():
         },
         'get_bucket_replication': {
             'ReplicationConfiguration': {
-                'Role': 'arn:aws:iam::111111222222:role/my-role',
+                'Role': 'arn:aws:iam::11111222222:my-role',
                 'Rules': [{
-                      'Destination': {
-                          'Bucket': 'arn:aws:s3:::my-bucket-2'
-                      },
-                      'ID': 'r1',
-                      'Prefix': 'repl',
-                      'Status': 'Enabled'
+                    'ID': "r1",
+                    'Prefix': "prefix",
+                    'Status': "Enabled",
+                    'Destination': {
+                        'Bucket': "arn:aws:s3:::my-bucket"
+                    }
                 }]
             }
         },
@@ -192,6 +190,9 @@ if _has_required_boto():
             'Status': 'Enabled'
         },
         'get_bucket_website': {
+            'ErrorDocument': {
+                'Key': 'error.html'
+            },
             'IndexDocument': {
                 'Suffix': 'index.html'
             }

--- a/tests/unit/states/boto_s3_bucket_test.py
+++ b/tests/unit/states/boto_s3_bucket_test.py
@@ -316,7 +316,7 @@ class BotoS3BucketTestCase(BotoS3BucketStateTestCaseBase, BotoS3BucketTestCaseMi
                      )
 
         self.assertTrue(result['result'])
-        self.assertEqual(result['changes']['new']['bucket']['Location'],config_ret['get_bucket_location'])
+        self.assertEqual(result['changes']['new']['bucket']['Location'], config_ret['get_bucket_location'])
 
     def test_present_when_bucket_exists_no_mods(self):
         self.conn.list_buckets.return_value = deepcopy(list_ret)

--- a/tests/unit/states/boto_s3_bucket_test.py
+++ b/tests/unit/states/boto_s3_bucket_test.py
@@ -1,0 +1,380 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+from __future__ import absolute_import
+from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module
+from copy import deepcopy
+
+# Import Salt Testing libs
+from salttesting.unit import skipIf, TestCase
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, patch
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+# Import Salt libs
+import salt.config
+import salt.loader
+
+# Import 3rd-party libs
+import logging
+
+# Import Mock libraries
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
+
+# pylint: disable=import-error,no-name-in-module,unused-import
+from unit.modules.boto_s3_bucket_test import BotoS3BucketTestCaseMixin
+
+# Import 3rd-party libs
+try:
+    import boto
+    import boto3
+    from botocore.exceptions import ClientError
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+
+# pylint: enable=import-error,no-name-in-module,unused-import
+
+# the boto_s3_bucket module relies on the connect_to_region() method
+# which was added in boto 2.8.0
+# https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
+required_boto3_version = '1.2.1'
+
+log = logging.getLogger(__name__)
+
+opts = salt.config.DEFAULT_MINION_OPTS
+context = {}
+utils = salt.loader.utils(opts, whitelist=['boto3'], context=context)
+serializers = salt.loader.serializers(opts)
+funcs = salt.loader.minion_mods(opts, context=context, utils=utils, whitelist=['boto_s3_bucket'])
+salt_states = salt.loader.states(opts=opts, functions=funcs, utils=utils, whitelist=['boto_s3_bucket'], serializers=serializers)
+
+
+def _has_required_boto():
+    '''
+    Returns True/False boolean depending on if Boto is installed and correct
+    version.
+    '''
+    if not HAS_BOTO:
+        return False
+    elif LooseVersion(boto3.__version__) < LooseVersion(required_boto3_version):
+        return False
+    else:
+        return True
+
+if _has_required_boto():
+    region = 'us-east-1'
+    access_key = 'GKTADJGHEIQSXMKKRBJ08H'
+    secret_key = 'askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs'
+    conn_parameters = {'region': region, 'key': access_key, 'keyid': secret_key, 'profile': {}}
+    error_message = 'An error occurred (101) when calling the {0} operation: Test-defined error'
+    not_found_error = ClientError({
+        'Error': {
+            'Code': '404',
+            'Message': "Test-defined error"
+        }
+    }, 'msg')
+    error_content = {
+      'Error': {
+        'Code': 101,
+        'Message': "Test-defined error"
+      }
+    }
+    list_ret = {
+        'Buckets': [{
+            'Name': 'mybucket',
+            'CreationDate': None
+        }],
+        'Owner': {
+            'DisplayName': 'testuser',
+            'ID': '111111222222'
+        },
+        'ResponseMetadata': {'Key': 'Value'}
+    }
+    config_in = {
+        'LocationConstraint': 'EU',
+        'ACL': {
+            'ACL': 'public-read'
+        },
+        'CORSRules': [{
+            'AllowedMethods': ["GET"],
+            'AllowedOrigins': ["*"],
+        }],
+        'LifecycleConfiguration': [{
+            'Expiration': {
+                'Days': 1
+            },
+            'Prefix': 'prefix',
+            'Status': 'Enabled',
+            'ID': 'asdfghjklpoiuytrewq'
+        }],
+        'Logging': {
+            'TargetBucket': 'my-bucket',
+            'TargetPrefix': 'prefix'
+        },
+        'NotificationConfiguration': {
+            'LambdaFunctionConfigurations': [{
+                'LambdaFunctionArn': 'arn:aws:lambda:us-east-1:111111222222:function:my-function',
+                'Id': 'zxcvbnmlkjhgfdsa',
+                'Events': ["s3:ObjectCreated:*"],
+                'Filter': {
+                    'Key': {
+                        'FilterRules': [{
+                            'Name': 'prefix',
+                            'Value': 'string'
+                        }]
+                    }
+                }
+            }]
+        },
+        'Policy': {
+            'Version': "2012-10-17",
+            'Statement': [{
+                'Sid': "",
+                'Effect': "Allow",
+                'Principal': {
+                    'AWS': "arn:aws:iam::111111222222:root"
+                },
+                'Action': "s3:PutObject",
+                'Resource': "arn:aws:s3:::my-bucket/*"
+            }]
+        },
+        'Replication': {
+            'Role': 'arn:aws:iam::11111222222:my-role',
+            'Rules': [{
+                'ID': "r1",
+                'Prefix': "prefix",
+                'Status': "Enabled",
+                'Destination': {
+                    'Bucket': "arn:aws:s3:::my-bucket"
+                }
+            }]
+        },
+        'RequestPayment': {
+            'Payer': 'Requester'
+        },
+        'Tagging': {
+            'a': 'b',
+            'c': 'd'
+        },
+        'Versioning': {
+            'Status': 'Enabled'
+        },
+        'Website': {
+            'ErrorDocument': {
+                'Key': 'error.html'
+            },
+            'IndexDocument': {
+                'Suffix': 'index.html'
+            }
+        }
+    }
+    config_ret = {
+        'get_bucket_acl': {
+            'Grants': [{
+                'Grantee': {
+                    'DisplayName': 'testuser',
+                    'ID': '111111222222'
+                },
+                'Permission': 'FULL_CONTROL'
+            }, {
+                'Grantee': {
+                    'URI': 'http://acs.amazonaws.com/groups/global/AllUsers'
+                },
+                'Permission': 'READ'
+            }],
+            'Owner': {
+                'DisplayName': 'testuser',
+                'ID': '111111222222'
+            }
+        },
+        'get_bucket_cors': {
+            'CORSRules': [{
+                'AllowedMethods': ["GET"],
+                'AllowedOrigins': ["*"],
+            }]
+        },
+        'get_bucket_lifecycle_configuration': {
+            'Rules': [{
+                'Expiration': {
+                    'Days': 1
+                },
+                'Prefix': 'prefix',
+                'Status': 'Enabled',
+                'ID': 'asdfghjklpoiuytrewq'
+            }]
+        },
+        'get_bucket_location': {
+            'LocationConstraint': 'EU'
+        },
+        'get_bucket_logging': {
+            'LoggingEnabled': {
+                'TargetBucket': 'my-bucket',
+                'TargetPrefix': 'prefix'
+            }
+        },
+        'get_bucket_notification_configuration': {
+            'LambdaFunctionConfigurations': [{
+                'LambdaFunctionArn': 'arn:aws:lambda:us-east-1:111111222222:function:my-function',
+                'Id': 'zxcvbnmlkjhgfdsa',
+                'Events': ["s3:ObjectCreated:*"],
+                'Filter': {
+                    'Key': {
+                        'FilterRules': [{
+                            'Name': 'prefix',
+                            'Value': 'string'
+                        }]
+                    }
+                }
+            }]
+        },
+        'get_bucket_policy': {
+            'Policy':
+                '{"Version":"2012-10-17","Statement":[{"Sid":"","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::111111222222:root"},"Action":"s3:PutObject","Resource":"arn:aws:s3:::my-bucket/*"}]}'
+        },
+        'get_bucket_replication': {
+            'ReplicationConfiguration': {
+                'Role': 'arn:aws:iam::11111222222:my-role',
+                'Rules': [{
+                    'ID': "r1",
+                    'Prefix': "prefix",
+                    'Status': "Enabled",
+                    'Destination': {
+                        'Bucket': "arn:aws:s3:::my-bucket"
+                    }
+                }]
+            }
+        },
+        'get_bucket_request_payment': {'Payer': 'Requester'},
+        'get_bucket_tagging': {
+            'TagSet': [{
+                'Key': 'c',
+                'Value': 'd'
+            }, {
+                'Key': 'a',
+                'Value': 'b',
+            }]
+        },
+        'get_bucket_versioning': {
+            'Status': 'Enabled'
+        },
+        'get_bucket_website': {
+            'ErrorDocument': {
+                'Key': 'error.html'
+            },
+            'IndexDocument': {
+                'Suffix': 'index.html'
+            }
+        }
+    }
+    bucket_ret = {
+        'Location': 'EU'
+    }
+
+
+class BotoS3BucketStateTestCaseBase(TestCase):
+    conn = None
+
+    # Set up MagicMock to replace the boto3 session
+    def setUp(self):
+        context.clear()
+
+        self.patcher = patch('boto3.session.Session')
+        self.addCleanup(self.patcher.stop)
+        mock_session = self.patcher.start()
+
+        session_instance = mock_session.return_value
+        self.conn = MagicMock()
+        session_instance.client.return_value = self.conn
+
+
+@skipIf(HAS_BOTO is False, 'The boto module must be installed.')
+@skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
+                                       ' or equal to version {0}'
+        .format(required_boto3_version))
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class BotoS3BucketTestCase(BotoS3BucketStateTestCaseBase, BotoS3BucketTestCaseMixin):
+    '''
+    TestCase for salt.modules.boto_s3_bucket state.module
+    '''
+
+    def test_present_when_bucket_does_not_exist(self):
+        '''
+        Tests present on a bucket that does not exist.
+        '''
+        self.conn.head_bucket.side_effect = [not_found_error, None]
+        self.conn.list_buckets.return_value = deepcopy(list_ret)
+        self.conn.create_bucket.return_value = bucket_ret
+        for key, value in config_ret.iteritems():
+            getattr(self.conn, key).return_value = deepcopy(value)
+        with patch.dict(funcs, {'boto_iam.get_account_id': MagicMock(return_value='111111222222')}):
+            result = salt_states['boto_s3_bucket.present'](
+                         'bucket present',
+                         Bucket='testbucket',
+                         **config_in
+                     )
+
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes']['new']['bucket']['Location'],config_ret['get_bucket_location'])
+
+    def test_present_when_bucket_exists_no_mods(self):
+        self.conn.list_buckets.return_value = deepcopy(list_ret)
+        for key, value in config_ret.iteritems():
+            getattr(self.conn, key).return_value = deepcopy(value)
+        with patch.dict(funcs, {'boto_iam.get_account_id': MagicMock(return_value='111111222222')}):
+            result = salt_states['boto_s3_bucket.present'](
+                         'bucket present',
+                         Bucket='testbucket',
+                         **config_in
+                     )
+
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes'], {})
+
+    def test_present_when_bucket_exists_all_mods(self):
+        self.conn.list_buckets.return_value = deepcopy(list_ret)
+        for key, value in config_ret.iteritems():
+            getattr(self.conn, key).return_value = deepcopy(value)
+        with patch.dict(funcs, {'boto_iam.get_account_id': MagicMock(return_value='111111222222')}):
+            result = salt_states['boto_s3_bucket.present'](
+                         'bucket present',
+                         Bucket='testbucket',
+                         LocationConstraint=config_in['LocationConstraint']
+                     )
+
+        self.assertTrue(result['result'])
+        self.assertNotEqual(result['changes'], {})
+
+    def test_present_with_failure(self):
+        self.conn.head_bucket.side_effect = [not_found_error, None]
+        self.conn.list_buckets.return_value = deepcopy(list_ret)
+        self.conn.create_bucket.side_effect = ClientError(error_content, 'create_bucket')
+        with patch.dict(funcs, {'boto_iam.get_account_id': MagicMock(return_value='111111222222')}):
+            result = salt_states['boto_s3_bucket.present'](
+                         'bucket present',
+                         Bucket='testbucket',
+                         **config_in
+                     )
+        self.assertFalse(result['result'])
+        self.assertTrue('An error occurred' in result['comment'])
+
+    def test_absent_when_bucket_does_not_exist(self):
+        '''
+        Tests absent on a bucket that does not exist.
+        '''
+        self.conn.head_bucket.side_effect = [not_found_error, None]
+        result = salt_states['boto_s3_bucket.absent']('test', 'mybucket')
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes'], {})
+
+    def test_absent_when_bucket_exists(self):
+        result = salt_states['boto_s3_bucket.absent']('test', 'testbucket')
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes']['new']['bucket'], None)
+
+    def test_absent_with_failure(self):
+        self.conn.delete_bucket.side_effect = ClientError(error_content, 'delete_bucket')
+        result = salt_states['boto_s3_bucket.absent']('test', 'testbucket')
+        self.assertFalse(result['result'])
+        self.assertTrue('An error occurred' in result['comment'])


### PR DESCRIPTION
This module is for managing S3 buckets - not the content, but the configuration of the bucket itself. Related: #6443

This allows an S3 bucket to be created specifying location, ACLs, CORS, lifecycle, logging, notifications, policy, replication, payment, tagging, versioning, and website config. Module and state module are both included.

Note that S3 has a few quirks to be aware of. If no IDs are specified for items in your lifecycle, policy, and replication configurations, this is accepted and a random unique ID is generated. This means that these config items will never match the specified configuration when executing "present", so they'll be updated every time. That's probably harmless, but possibly annoying. Avoid it by specifying your own IDs rather than allowing them to be autogenerated.

Also, there doesn't seem to be any way to determine canonical user IDs based on the information accepted for setting them when configuring ACLs other than setting the ACL and seeing what it looks like when it comes back. Thus ACLs may also always update. Avoid by setting the ACL, using describe to see the result, and base your config on that directly using the "AccessControlPolicy" option for setting ACL. Again, updating an ACL to a completely equivalent setting is probably harmless in any case. It just clutters the logs.
