### PR TITLE
2015.5 tweaks from #30529

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1419,7 +1419,7 @@ def upgrade(refresh=True, skip_verify=False, **kwargs):
 
 def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=W0613
     '''
-    Remove packages with ``yum -q -y remove``.
+    Remove packages
 
     name
         The name of the package to be removed
@@ -1667,9 +1667,9 @@ def unhold(name=None, pkgs=None, sources=None, **kwargs):  # pylint: disable=W06
                                           .format(target))
             else:
                 quoted_targets = [_cmd_quote(item) for item in search_locks]
-                cmd = _yum() + ' -q versionlock delete {0}'.format(
-                        ' '.join(quoted_targets)
-                        )
+                cmd = _yum() + ' versionlock delete {0}'.format(
+                    ' '.join(quoted_targets)
+                )
                 out = __salt__['cmd.run_all'](cmd)
 
                 if out['retcode'] == 0:
@@ -1983,7 +1983,6 @@ def list_repos(basedir=None):
 
 def get_repo(repo, basedir=None, **kwargs):  # pylint: disable=W0613
     '''
-
     Display a repo from <basedir> (default basedir: all dirs in ``reposdir``
     yum option).
 


### PR DESCRIPTION
In the process of resolving merge conflicts in the merge-forward of 2015.5 to 2015.8 which I did in #30529, I found two changes that should have been made in the 2015.5 branch. One was the removal of yum-specific information in the pkg.remove docstring, and the other was needless use of -q when deleting a version lock in pkg.unhold. We're not parsing the output and the default loglevel is debug, so using -q here removes helpful troubleshooting output from the log.

These changes have already been made in #30529, so I am making them here in 2015.5 separately. When merged forward, this commit should be a no-op as it will not modify yumpkg.py.
