### PR TITLE
address color log dict lookup exceptions w/ non-posix log level names

### DIFF
--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -175,19 +175,20 @@ class SaltColorLogRecord(logging.LogRecord):
         logging.LogRecord.__init__(self, *args, **kwargs)
         reset = TextFormat('reset')
 
+        clevel = LOG_COLORS['levels'].get(self.levelname, reset)
+        cmsg = LOG_COLORS['msgs'].get(self.levelname, reset)
+
         # pylint: disable=E1321
         self.colorname = '%s[%-17s]%s' % (LOG_COLORS['name'],
                                           self.name,
                                           reset)
-        self.colorlevel = '%s[%-8s]%s' % (LOG_COLORS['levels'][self.levelname],
+        self.colorlevel = '%s[%-8s]%s' % (clevel,
                                           self.levelname,
                                           TextFormat('reset'))
         self.colorprocess = '%s[%5s]%s' % (LOG_COLORS['process'],
                                            self.process,
                                            reset)
-        self.colormsg = '%s%s%s' % (LOG_COLORS['msgs'][self.levelname],
-                                    self.msg,
-                                    reset)
+        self.colormsg = '%s%s%s' % (cmsg, self.msg, reset)
         # pylint: enable=E1321
 
 


### PR DESCRIPTION
Some 3rd-party modules (e.g. gnupg) define custom log levels that emit at INFO level and above.  This patch sets the color data lookups to default to TextFormat('reset') rather than producing a stack trace
every time a log message is generated from an affected module.
