### PR TITLE
Always-modify bug in boto_s3_bucket.present

### DIFF
--- a/salt/states/boto_s3_bucket.py
+++ b/salt/states/boto_s3_bucket.py
@@ -468,7 +468,7 @@ def present(name, Bucket,
 
     # Once versioning has been enabled, it can't completely go away, it can
     # only be suspended
-    if not bool(Versioning) and _describe.get('Versioning') is not None:
+    if not bool(Versioning) and bool(_describe.get('Versioning')):
         Versioning = {'Status': 'Suspended'}
 
     config_items = [


### PR DESCRIPTION
 When versioning has never been turned on, boto_s3_bucket.present always tries to set it to suspended, which is a no-op that clutters the logs.
