### PR TITLE
Fix up salt.modules.locale(mod) for Solaris and some generic improvements

### DIFF
--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -210,8 +210,8 @@ def set_locale(locale):
             'LANG="{0}"'.format(locale),
             append_if_not_found=True
         )
-    else:
-        return False
+    else:  # unknown platform, we pretend everything is OK
+        return True
 
     return True
 

--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -141,7 +141,9 @@ def get_locale():
     elif 'Solaris' in __grains__['os_family']:
         cmd = 'grep "^LANG=" /etc/default/init'
     else:  # don't wast time on a failing cmd.run
-        return ''
+        raise CommandExecutionError(
+            'Error: Unsupported platform!'
+        )
 
     try:
         return __salt__['cmd.run'](cmd).split('=')[1].replace('"', '')
@@ -210,8 +212,10 @@ def set_locale(locale):
             'LANG="{0}"'.format(locale),
             append_if_not_found=True
         )
-    else:  # unknown platform, we pretend everything is OK
-        return True
+    else:
+        raise CommandExecutionError(
+            'Error: Unsupported platform!'
+        )
 
     return True
 

--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -116,8 +116,6 @@ def get_locale():
     '''
     Get the current system locale
 
-    .. versionchanged:: Boron
-
     CLI Example:
 
     .. code-block:: bash
@@ -154,8 +152,6 @@ def get_locale():
 def set_locale(locale):
     '''
     Sets the current system locale
-
-    .. versionchanged:: Boron
 
     CLI Example:
 
@@ -248,7 +244,6 @@ def gen_locale(locale, **kwargs):
     Generate a locale. Options:
 
     .. versionadded:: 2014.7.0
-    .. versionchanged:: Boron
 
     :param locale: Any locale listed in /usr/share/i18n/locales or
         /usr/share/i18n/SUPPORTED for Debian and Gentoo based distributions,

--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -48,6 +48,8 @@ def _uses_dbus():
         return False
     elif 'Gentoo' in __grains__['os_family']:
         return False
+    else:  # when unknown, assume no dbus
+        return False
 
 
 def _parse_dbus_locale():
@@ -114,6 +116,8 @@ def get_locale():
     '''
     Get the current system locale
 
+    .. versionchanged:: Boron
+
     CLI Example:
 
     .. code-block:: bash
@@ -130,11 +134,14 @@ def get_locale():
     elif 'Debian' in __grains__['os_family']:
         if salt.utils.which('localectl'):
             return _locale_get()
-
         cmd = 'grep "^LANG=" /etc/default/locale'
     elif 'Gentoo' in __grains__['os_family']:
         cmd = 'eselect --brief locale show'
         return __salt__['cmd.run'](cmd).strip()
+    elif 'Solaris' in __grains__['os_family']:
+        cmd = 'grep "^LANG=" /etc/default/init'
+    else:  # don't wast time on a failing cmd.run
+        return ''
 
     try:
         return __salt__['cmd.run'](cmd).split('=')[1].replace('"', '')
@@ -145,6 +152,8 @@ def get_locale():
 def set_locale(locale):
     '''
     Sets the current system locale
+
+    .. versionchanged:: Boron
 
     CLI Example:
 
@@ -192,6 +201,17 @@ def set_locale(locale):
     elif 'Gentoo' in __grains__['os_family']:
         cmd = 'eselect --brief locale set {0}'.format(locale)
         return __salt__['cmd.retcode'](cmd, python_shell=False) == 0
+    elif 'Solaris' in __grains__['os_family']:
+        if locale not in __salt__['locale.list_avail']():
+            return False
+        __salt__['file.replace'](
+            '/etc/default/init',
+            '^LANG=.*',
+            'LANG="{0}"'.format(locale),
+            append_if_not_found=True
+        )
+    else:
+        return False
 
     return True
 
@@ -224,6 +244,7 @@ def gen_locale(locale, **kwargs):
     Generate a locale. Options:
 
     .. versionadded:: 2014.7.0
+    .. versionchanged:: Boron
 
     :param locale: Any locale listed in /usr/share/i18n/locales or
         /usr/share/i18n/SUPPORTED for Debian and Gentoo based distributions,
@@ -244,6 +265,10 @@ def gen_locale(locale, **kwargs):
     on_ubuntu = __grains__.get('os') == 'Ubuntu'
     on_gentoo = __grains__.get('os_family') == 'Gentoo'
     on_suse = __grains__.get('os_family') == 'Suse'
+    on_solaris = __grains__.get('os_family') == 'Solaris'
+
+    if on_solaris:  # all locales are pre-generated
+        return locale in __salt__['locale.list_avail']()
 
     locale_info = salt.utils.locales.split_locale(locale)
 

--- a/salt/states/locale.py
+++ b/salt/states/locale.py
@@ -18,6 +18,11 @@ Manage the available locales and the system default:
           - locale: us_locale
 '''
 
+from __future__ import absolute_import
+
+# Import salt libs
+from salt.exceptions import CommandNotFoundError
+
 
 def __virtual__():
     '''
@@ -37,21 +42,26 @@ def system(name):
            'changes': {},
            'result': None,
            'comment': ''}
-    if __salt__['locale.get_locale']() == name:
-        ret['result'] = True
-        ret['comment'] = 'System locale {0} already set'.format(name)
-        return ret
-    if __opts__['test']:
-        ret['comment'] = 'System locale {0} needs to be set'.format(name)
-        return ret
-    if __salt__['locale.set_locale'](name):
-        ret['changes'] = {'locale': name}
-        ret['result'] = True
-        ret['comment'] = 'Set system locale {0}'.format(name)
-        return ret
-    else:
+    try:
+        if __salt__['locale.get_locale']() == name:
+            ret['result'] = True
+            ret['comment'] = 'System locale {0} already set'.format(name)
+            return ret
+        if __opts__['test']:
+            ret['comment'] = 'System locale {0} needs to be set'.format(name)
+            return ret
+        if __salt__['locale.set_locale'](name):
+            ret['changes'] = {'locale': name}
+            ret['result'] = True
+            ret['comment'] = 'Set system locale {0}'.format(name)
+            return ret
+        else:
+            ret['result'] = False
+            ret['comment'] = 'Failed to set system locale to {0}'.format(name)
+            return ret
+    except CommandNotFoundError as err:
         ret['result'] = False
-        ret['comment'] = 'Failed to set system locale to {0}'.format(name)
+        ret['comment'] = 'Failed to set sysstem locale: {0}'.format(err)
         return ret
 
 

--- a/salt/states/locale.py
+++ b/salt/states/locale.py
@@ -61,7 +61,7 @@ def system(name):
             return ret
     except CommandNotFoundError as err:
         ret['result'] = False
-        ret['comment'] = 'Failed to set sysstem locale: {0}'.format(err)
+        ret['comment'] = 'Failed to set system locale: {0}'.format(err)
         return ret
 
 

--- a/tests/unit/modules/localemod_test.py
+++ b/tests/unit/modules/localemod_test.py
@@ -54,10 +54,8 @@ class LocalemodTestCase(TestCase):
                             {'cmd.run': MagicMock(return_value='A=B')}):
                 self.assertEqual(localemod.get_locale(), 'B')
 
-        with patch.dict(localemod.__grains__, {'os_family': ['Debian']}):
-            with patch.dict(localemod.__salt__, {'cmd.run':
-                                                 MagicMock(return_value='A')}):
-                self.assertEqual(localemod.get_locale(), '')
+        with patch.dict(localemod.__grains__, {'os_family': ['Unknown']}):
+            self.assertEqual(localemod.get_locale(), '')
 
     def test_set_locale(self):
         '''

--- a/tests/unit/modules/localemod_test.py
+++ b/tests/unit/modules/localemod_test.py
@@ -17,6 +17,7 @@ from salttesting.mock import (
 
 # Import Salt Libs
 from salt.modules import localemod
+from salt.exceptions import CommandExecutionError
 
 # Globals
 localemod.__grains__ = {}
@@ -55,7 +56,7 @@ class LocalemodTestCase(TestCase):
                 self.assertEqual(localemod.get_locale(), 'B')
 
         with patch.dict(localemod.__grains__, {'os_family': ['Unknown']}):
-            self.assertEqual(localemod.get_locale(), '')
+            self.assertRaises(CommandExecutionError, localemod.get_locale)
 
     def test_set_locale(self):
         '''
@@ -71,7 +72,7 @@ class LocalemodTestCase(TestCase):
                 self.assertFalse(localemod.set_locale('l'))
 
         with patch.dict(localemod.__grains__, {'os_family': ['A']}):
-            self.assertTrue(localemod.set_locale('locale'))
+            self.assertRaises(CommandExecutionError, localemod.set_locale, 'A')
 
     @patch('salt.utils.which', MagicMock(side_effect=[None, '/usr/sbin/update-locale']))
     def test_set_locale_debian_no_localectl(self):

--- a/tests/unit/modules/localemod_test.py
+++ b/tests/unit/modules/localemod_test.py
@@ -49,12 +49,12 @@ class LocalemodTestCase(TestCase):
                                                  MagicMock(return_value='A')}):
                 self.assertEqual(localemod.get_locale(), 'A')
 
-        with patch.dict(localemod.__grains__, {'os_family': ['A']}):
+        with patch.dict(localemod.__grains__, {'os_family': ['Debian']}):
             with patch.dict(localemod.__salt__,
                             {'cmd.run': MagicMock(return_value='A=B')}):
                 self.assertEqual(localemod.get_locale(), 'B')
 
-        with patch.dict(localemod.__grains__, {'os_family': ['A']}):
+        with patch.dict(localemod.__grains__, {'os_family': ['Debian']}):
             with patch.dict(localemod.__salt__, {'cmd.run':
                                                  MagicMock(return_value='A')}):
                 self.assertEqual(localemod.get_locale(), '')

--- a/tests/unit/modules/localemod_test.py
+++ b/tests/unit/modules/localemod_test.py
@@ -49,7 +49,7 @@ class LocalemodTestCase(TestCase):
                                                  MagicMock(return_value='A')}):
                 self.assertEqual(localemod.get_locale(), 'A')
 
-        with patch.dict(localemod.__grains__, {'os_family': ['Debian']}):
+        with patch.dict(localemod.__grains__, {'os_family': ['RedHat']}):
             with patch.dict(localemod.__salt__,
                             {'cmd.run': MagicMock(return_value='A=B')}):
                 self.assertEqual(localemod.get_locale(), 'B')


### PR DESCRIPTION
I also fixed a few unit tests, it assumed a cmd.run that we can skip on unknown/unsupported platforms.
Running **salt**['cmd.run']('') is kind of pointless!

Originally i had set_locale to return False on unknown/unsupported platforms, I changed this back to True to not break unit tests.

Currently: we pretend to success, meaning when called via salt.states.locale... we keep hitting 1 state that will always return a change (as we 'pretend to set' but don't actually set it)

I would prefer to just hard fail on that, that way a sysadmin won't assume the locale got set correctly when it obviously didn't.

If you agree I can do a follow up commit to change it set_locale to return False.
