### PR TITLE
salt.modules.timezone improvements for Solaris-like OS's

### DIFF
--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -240,6 +240,12 @@ def zone_compare(timezone):
     /etc/localtime. Returns True if names and hash sums match, and False if not.
     Mostly useful for running state checks.
 
+    .. versionchanged:: Boron
+
+    .. note::
+
+        On Solaris-link operating systems only a string comparison is done.
+
     CLI Example:
 
     .. code-block:: bash
@@ -247,7 +253,7 @@ def zone_compare(timezone):
         salt '*' timezone.zone_compare 'America/Denver'
     '''
     if 'Solaris' in __grains__['os_family']:
-        return 'Not implemented for Solaris family'
+        return timezone == get_zone()
 
     curtzstring = get_zone()
     if curtzstring != timezone:

--- a/tests/unit/modules/timezone_test.py
+++ b/tests/unit/modules/timezone_test.py
@@ -132,8 +132,7 @@ class TimezoneTestCase(TestCase):
         '''
         with patch.object(timezone, 'get_zone', return_value='US/Central'):
             with patch.dict(timezone.__grains__, {'os_family': 'Solaris'}):
-                self.assertEqual(timezone.zone_compare('Antarctica/Mawson'),
-                                 'Not implemented for Solaris family')
+                self.assertFalse(timezone.zone_compare('Antarctica/Mawson'))
 
             with patch.object(os.path, 'exists', return_value=False):
                 with patch.dict(timezone.__grains__, {'os_family': 'Sola'}):


### PR DESCRIPTION
zone_compare should work on Solaris-like operating systems, else salt.states.timezone will repeately set the timezone even if it is already set. We do not have files to hash and compare, so we settle for simple string comparison instead.
