### PR TITLE
Fixes #30569

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -498,7 +498,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
 
         .. deprecated:: 2014.7.2
             If `bin_env` is given, pip will already be sourced from that
-            virualenv, making `activate` effectively a noop.
+            virtualenv, making `activate` effectively a noop.
 
     pre_releases
         Include pre-releases in the available versions
@@ -537,7 +537,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
         HTTPS.
 
     use_vt
-        Use VT terminal emulation (see ouptut while installing)
+        Use VT terminal emulation (see output while installing)
 
     CLI Example:
 
@@ -895,7 +895,7 @@ def uninstall(pkgs=None,
     cwd
         Current working directory to run pip from
     use_vt
-        Use VT terminal emulation (see ouptut while installing)
+        Use VT terminal emulation (see output while installing)
 
     CLI Example:
 

--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -108,7 +108,7 @@ def create(path,
             ``user`` should be used instead
 
     use_vt : False
-        Use VT terminal emulation (see ouptut while installing)
+        Use VT terminal emulation (see output while installing)
 
         .. versionadded:: 2015.5.0
 

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -377,7 +377,7 @@ def installed(name,
 
         .. deprecated:: 2014.7.2
             If `bin_env` is given, pip will already be sourced from that
-            virualenv, making `activate` effectively a noop.
+            virtualenv, making `activate` effectively a noop.
 
     pre_releases
         Include pre-releases in the available versions
@@ -419,7 +419,7 @@ def installed(name,
                     VERBOSE: True
 
     use_vt
-        Use VT terminal emulation (see ouptut while installing)
+        Use VT terminal emulation (see output while installing)
 
     trusted_host
         Mark this host as trusted, even though it does not have valid or any
@@ -833,7 +833,7 @@ def removed(name,
     bin_env : None
         the pip executable or virtualenenv to use
     use_vt
-        Use VT terminal emulation (see ouptut while installing)
+        Use VT terminal emulation (see output while installing)
     '''
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
 
@@ -890,7 +890,7 @@ def uptodate(name,
     bin_env
         the pip executable or virtualenenv to use
     use_vt
-        Use VT terminal emulation (see ouptut while installing)
+        Use VT terminal emulation (see output while installing)
     '''
     ret = {'name': name,
            'changes': {},


### PR DESCRIPTION
Corrects ‘ouptut’ to ‘output’ and ‘virualenv’ to ‘virtualenv’
