### PR TITLE
file.line state: add missing colon in docstring

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2539,7 +2539,7 @@ def line(name, content, match=None, mode=None, location=None,
 
     .. code-block: yaml
 
-       /etc/myconfig.conf
+       /etc/myconfig.conf:
          file.line:
            - mode: ensure
            - content: my key = my value


### PR DESCRIPTION
Just a tiny one character YAML syntax fix.
