### PR TITLE
implement salt.module.smartos_mdata

### DIFF
--- a/salt/modules/smartos_mdata.py
+++ b/salt/modules/smartos_mdata.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-Module for running mdata command on SmartOS
+Module for managaging metadata on SmartOS
 
 .. versionadded:: Boron
 
@@ -79,7 +79,7 @@ def __virtual__():
 
 def list_():
     '''
-    List available properties
+    List available metadata
 
     CLI Example:
 
@@ -94,16 +94,16 @@ def list_():
     return {}
 
 
-def get_(*prop):
+def get_(*keyname):
     '''
-    Get mdata property
+    Get metadata
 
-    prop : string
-        name of property
+    keyname : string
+        name of key
 
     .. note::
 
-        If no properties are specified, we get all properties
+        If no keynames are specified, we get all properties
 
     CLI Example:
 
@@ -113,25 +113,25 @@ def get_(*prop):
         salt '*' mdata.get user-script salt:role
     '''
     mdata = _check_mdata_get()
-    valid_props = list_()
+    valid_keynames = list_()
     ret = {}
 
-    if len(prop) == 0:
-        prop = valid_props
+    if len(keyname) == 0:
+        keyname = valid_keynames
 
-    for p in prop:
-        if mdata and p in valid_props:
-            cmd = '{0} {1}'.format(mdata, p)
-            ret[p] = __salt__['cmd.run'](cmd)
+    for k in keyname:
+        if mdata and k in valid_keynames:
+            cmd = '{0} {1}'.format(mdata, k)
+            ret[k] = __salt__['cmd.run'](cmd)
         else:
-            ret[p] = ''
+            ret[k] = ''
 
     return ret
 
 
-def put_(prop, val):
+def put_(keyname, val):
     '''
-    Put mdata property
+    Put metadata
 
     prop : string
         name of property
@@ -148,15 +148,15 @@ def put_(prop, val):
     ret = {}
 
     if mdata:
-        cmd = 'echo {2} | {0} {1}'.format(mdata, prop, val)
+        cmd = 'echo {2} | {0} {1}'.format(mdata, keyname, val)
         ret = __salt__['cmd.run_all'](cmd, python_shell=True)
 
     return ret['retcode'] == 0
 
 
-def delete_(*prop):
+def delete_(*keyname):
     '''
-    Delete mdata property
+    Delete metadata
 
     prop : string
         name of property
@@ -169,15 +169,15 @@ def delete_(*prop):
         salt '*' mdata.get user-script salt:role
     '''
     mdata = _check_mdata_delete()
-    valid_props = list_()
+    valid_keynames = list_()
     ret = {}
 
-    for p in prop:
-        if mdata and p in valid_props:
-            cmd = '{0} {1}'.format(mdata, p)
-            ret[p] = __salt__['cmd.run_all'](cmd)['retcode'] == 0
+    for k in keyname:
+        if mdata and k in valid_keynames:
+            cmd = '{0} {1}'.format(mdata, k)
+            ret[k] = __salt__['cmd.run_all'](cmd)['retcode'] == 0
         else:
-            ret[p] = True
+            ret[k] = True
 
     return ret
 

--- a/salt/modules/smartos_mdata.py
+++ b/salt/modules/smartos_mdata.py
@@ -101,6 +101,10 @@ def get_(*prop):
     prop : string
         name of property
 
+    .. note::
+
+        If no properties are specified, we get all properties
+
     CLI Example:
 
     .. code-block:: bash
@@ -109,10 +113,14 @@ def get_(*prop):
         salt '*' mdata.get user-script salt:role
     '''
     mdata = _check_mdata_get()
+    valid_props = list_()
     ret = {}
 
+    if len(prop) == 0:
+        prop = valid_props
+
     for p in prop:
-        if mdata and p in list_():
+        if mdata and p in valid_props:
             cmd = '{0} {1}'.format(mdata, p)
             ret[p] = __salt__['cmd.run'](cmd)
         else:
@@ -161,10 +169,11 @@ def delete_(*prop):
         salt '*' mdata.get user-script salt:role
     '''
     mdata = _check_mdata_delete()
+    valid_props = list_()
     ret = {}
 
     for p in prop:
-        if mdata and p in list_():
+        if mdata and p in valid_props:
             cmd = '{0} {1}'.format(mdata, p)
             ret[p] = __salt__['cmd.run_all'](cmd)['retcode'] == 0
         else:

--- a/salt/modules/smartos_mdata.py
+++ b/salt/modules/smartos_mdata.py
@@ -1,0 +1,175 @@
+# -*- coding: utf-8 -*-
+'''
+Module for running mdata command on SmartOS
+
+.. versionadded:: Boron
+
+:maintainer:    Jorge Schrauwen <sjorge@blackdot.be>
+:maturity:      new
+:platform:      smartos
+'''
+from __future__ import absolute_import
+
+# Import Python libs
+import logging
+
+# Import Salt libs
+import salt.utils
+import salt.utils.decorators as decorators
+
+log = logging.getLogger(__name__)
+
+# Function aliases
+__func_alias__ = {
+    'list_': 'list',
+    'get_': 'get',
+    'put_': 'put',
+    'delete_': 'delete',
+}
+
+# Define the module's virtual name
+__virtualname__ = 'mdata'
+
+
+@decorators.memoize
+def _check_mdata_list():
+    '''
+    looks to see if mdata-list is present on the system
+    '''
+    return salt.utils.which('mdata-list')
+
+
+@decorators.memoize
+def _check_mdata_get():
+    '''
+    looks to see if mdata-get is present on the system
+    '''
+    return salt.utils.which('mdata-get')
+
+
+@decorators.memoize
+def _check_mdata_put():
+    '''
+    looks to see if mdata-put is present on the system
+    '''
+    return salt.utils.which('mdata-put')
+
+
+@decorators.memoize
+def _check_mdata_delete():
+    '''
+    looks to see if mdata-delete is present on the system
+    '''
+    return salt.utils.which('mdata-delete')
+
+
+def __virtual__():
+    '''
+    Provides mdata only on SmartOS
+    '''
+    if salt.utils.is_smartos_zone() and _check_mdata_list():
+        return __virtualname__
+    return (
+        False,
+        '{0} module can only be loaded on SmartOS zones'.format(
+            __virtualname__
+        )
+    )
+
+
+def list_():
+    '''
+    List available properties
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' mdata.list
+    '''
+    mdata = _check_mdata_list()
+    if mdata:
+        cmd = '{0}'.format(mdata)
+        return __salt__['cmd.run'](cmd).splitlines()
+    return {}
+
+
+def get_(*prop):
+    '''
+    Get mdata property
+
+    prop : string
+        name of property
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' mdata.get salt:role
+        salt '*' mdata.get user-script salt:role
+    '''
+    mdata = _check_mdata_get()
+    ret = {}
+
+    for p in prop:
+        if mdata and p in list_():
+            cmd = '{0} {1}'.format(mdata, p)
+            ret[p] = __salt__['cmd.run'](cmd)
+        else:
+            ret[p] = ''
+
+    return ret
+
+
+def put_(prop, val):
+    '''
+    Put mdata property
+
+    prop : string
+        name of property
+    val : string
+        value to set
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' mdata.list
+    '''
+    mdata = _check_mdata_put()
+    ret = {}
+
+    if mdata:
+        cmd = 'echo {2} | {0} {1}'.format(mdata, prop, val)
+        ret = __salt__['cmd.run_all'](cmd, python_shell=True)
+
+    return ret['retcode'] == 0
+
+
+def delete_(*prop):
+    '''
+    Delete mdata property
+
+    prop : string
+        name of property
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' mdata.get salt:role
+        salt '*' mdata.get user-script salt:role
+    '''
+    mdata = _check_mdata_delete()
+    ret = {}
+
+    for p in prop:
+        if mdata and p in list_():
+            cmd = '{0} {1}'.format(mdata, p)
+            ret[p] = __salt__['cmd.run_all'](cmd)['retcode'] == 0
+        else:
+            ret[p] = True
+
+    return ret
+
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
We should be able to manipulate mdata properties via salt.

``` bash
/opt/salt/bin/salt-call --local mdata.put salt 'is awesome'
[INFO    ] Executing command 'echo is awesome | /usr/sbin/mdata-put salt' in directory '/root'
```

``` yaml
local:
    True
```

``` bash
/opt/salt/bin/salt-call --local mdata.get smartos
[INFO    ] Executing command '/usr/sbin/mdata-list' in directory '/root'
[INFO    ] Executing command '/usr/sbin/mdata-get smartos' in directory '/root'
```

``` yaml
local:
    ----------
    smartos:
        is my OS of choice
```

``` bash
/opt/salt/bin/salt-call --local mdata.list
[INFO    ] Executing command '/usr/sbin/mdata-list' in directory '/root'
```

``` yaml
local:
    - salt
    - smartos
```

``` bash
/opt/salt/bin/salt-call --local mdata.delete salt
[INFO    ] Executing command '/usr/sbin/mdata-list' in directory '/root'
[INFO    ] Executing command '/usr/sbin/mdata-delete salt' in directory '/root'
```

``` yaml
local:
    ----------
    salt:
        True
```
