### PR TITLE
Fix comment_line permissions.

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1097,7 +1097,7 @@ def comment_line(path,
     path = os.path.realpath(os.path.expanduser(path))
 
     # Make sure the file exists
-    if not os.path.exists(path):
+    if not os.path.isfile(path):
         raise SaltInvocationError('File not found: {0}'.format(path))
 
     # Make sure it is a text file
@@ -1138,6 +1138,11 @@ def comment_line(path,
     # We've searched the whole file. If we didn't find anything, return False
     if not found:
         return False
+
+    if not salt.utils.is_windows():
+        pre_user = get_user(path)
+        pre_group = get_group(path)
+        pre_mode = __salt__['config.manage_mode'](get_mode(path))
 
     # Create a copy to read from and to use as a backup later
     try:
@@ -1190,6 +1195,9 @@ def comment_line(path,
             "backup file '{1}'. "
             "Exception: {2}".format(path, temp_file, exc)
         )
+
+    if not salt.utils.is_windows():
+        check_perms(path, None, pre_user, pre_group, pre_mode)
 
     # Return a diff using the two dictionaries
     return ''.join(difflib.unified_diff(orig_file, new_file))


### PR DESCRIPTION
In order to preserve file permissions when comment/uncomment file
we should run check_perms before and after editing files.

Fixes #28320.

This should be a better approach @cachedout . Unit and integration tests run without easy in my local env.
