### PR TITLE
salt-boto_rds updates

### DIFF
--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -236,7 +236,7 @@ def create(name, allocated_storage, db_instance_class, engine,
             log.info('Created RDS {0}'.format(name))
             return True
         while True:
-            log.info('Waiting 10 secs...'.format(wait_time))
+            log.info('Waiting 10 secs...')
             sleep(10)
             _describe = describe(name, tags, region, key, keyid, profile)
             if not _describe:

--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -236,14 +236,16 @@ def create(name, allocated_storage, db_instance_class, engine,
             log.info('Created RDS {0}'.format(name))
             return True
         while True:
+            log.info('Waiting 10 secs...'.format(wait_time))
             sleep(10)
             _describe = describe(name, tags, region, key, keyid, profile)
             if not _describe:
                 return True
-            if _describe['db_instance_status'] in wait_statuses:
+            if _describe['db_instance_status'] == wait_status:
                 log.info('Created RDS {0} with current status '
                          '{1}'.format(name, _describe['db_instance_status']))
                 return True
+            log.info('Current status: {0}'.format(_describe['db_instance_status']))
 
     except boto.exception.BotoServerError as e:
         log.debug(e)
@@ -457,6 +459,8 @@ def get_endpoint(name, tags=None, region=None, key=None, keyid=None,
         salt myminion boto_rds.get_endpoint myrds
 
     '''
+    ret = False
+
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
     if not __salt__['boto_rds.exists'](name, tags, region, key, keyid,
@@ -468,10 +472,17 @@ def get_endpoint(name, tags=None, region=None, key=None, keyid=None,
         log.debug(e)
         return False
     insts = rds['DescribeDBInstancesResponse']['DescribeDBInstancesResult']
+    found = False
     endpoints = []
     for instance in insts['DBInstances']:
-        endpoints.append(instance['Endpoint']['Address'])
-    return endpoints[0]
+        if 'Endpoint' in instance and instance['Endpoint'] is not None and 'Address' in instance['Endpoint']:
+            found = True
+            endpoints.append(instance['Endpoint']['Address'])
+
+    if found:
+        ret = endpoints[0]
+
+    return ret
 
 
 def delete(name, skip_final_snapshot=None, final_db_snapshot_identifier=None,

--- a/salt/states/boto_rds.py
+++ b/salt/states/boto_rds.py
@@ -204,7 +204,7 @@ def present(name,
         private IP address.
 
     wait_status
-        Wait for the RDS instance to reach a disared status before finishing
+        Wait for the RDS instance to reach a desired status before finishing
         the state. Available states: available, modifying, backing-up
 
     tags


### PR DESCRIPTION
- added log info while waiting. displays current status and wait time.
- updated conditional check for wait status to check for specified status from state sls data.
  - previously was only checking to see if the current status was in ['available', 'modifying', 'backing-up'], which defeats the purpose of specifying wait_status at all.
  - PR forces state run to wait until the specified status is returned. So, if you specify 'available' in the state, you know the database instance can be contacted when the state run returns.
- Updated call for get_endpoint to make sure the Endpoint and its Address are set
- spelling error in state
