### PR TITLE
Add enabled, disabled, enable, disable to runit

### DIFF
--- a/salt/modules/runit.py
+++ b/salt/modules/runit.py
@@ -180,7 +180,7 @@ def enabled(name, **kwargs):
         return False
 
     files = os.listdir(SERVICE_DIR + '/'+name)
-    if not 'run' in files:
+    if 'run' not in files:
         return False
     mode = __salt__['file.get_mode'](SERVICE_DIR + '/'+name+'/run')
     return (atoi(mode, base=8) & 0b0000000001000000) > 0
@@ -202,10 +202,10 @@ def enable(name, **kwargs):
         return False
 
     files = os.listdir(SERVICE_DIR + '/'+name)
-    if not 'run' in files:
+    if 'run' not in files:
         return False
 
-    return '0700' == __salt__['file.set_mode']( SERVICE_DIR +'/' +name+'/run', '0700')
+    return '0700' == __salt__['file.set_mode'](SERVICE_DIR +'/' +name+'/run', '0700')
 
 
 def disabled(name, **kwargs):
@@ -237,10 +237,10 @@ def disable(name, **kwargs):
         return False
 
     files = os.listdir(SERVICE_DIR + '/'+name)
-    if not 'run' in files:
+    if 'run' not in files:
         return False
 
-    return '0600' == __salt__['file.set_mode']( SERVICE_DIR +'/' +name+'/run', '0600')
+    return '0600' == __salt__['file.set_mode'](SERVICE_DIR +'/' +name+'/run', '0600')
 
 def missing(name):
     '''

--- a/salt/modules/runit.py
+++ b/salt/modules/runit.py
@@ -164,7 +164,7 @@ def available(name):
     return name in get_all()
 
 
-def enabled(name, **kwargs):
+def enabled(name):
     '''
     Returns ``True`` if the specified service has a 'run' file and that
     file is executable, otherwhise returns
@@ -186,7 +186,7 @@ def enabled(name, **kwargs):
     return (atoi(mode, base=8) & 0b0000000001000000) > 0
 
 
-def enable(name, **kwargs):
+def enable(name):
     '''
     Returns ``True`` if the specified service is enabled - or becomes
     enabled - as defined by its run file being executable, otherise
@@ -208,7 +208,7 @@ def enable(name, **kwargs):
     return '0700' == __salt__['file.set_mode'](SERVICE_DIR +'/' +name+'/run', '0700')
 
 
-def disabled(name, **kwargs):
+def disabled(name):
     '''
     Returns the opposite of runit.enabled
 
@@ -221,7 +221,7 @@ def disabled(name, **kwargs):
     return not enabled(name)
 
 
-def disable(name, **kwargs):
+def disable(name):
     '''
     Returns ``True`` if the specified service is disabled - or becomes
     disabled - as defined by its run file being not-executable, otherise

--- a/salt/modules/runit.py
+++ b/salt/modules/runit.py
@@ -11,14 +11,14 @@ so it can be used to maintain services using the ``provider`` argument:
       service:
         - running
         - provider: runit
-
-Note that the ``enabled`` argument is not available with this provider.
 '''
 from __future__ import absolute_import
 
 # Import python libs
 import os
 import re
+#for octal permission conversion
+from string import atoi
 
 # Import salt libs
 from salt.exceptions import CommandExecutionError
@@ -163,6 +163,84 @@ def available(name):
     '''
     return name in get_all()
 
+
+def enabled(name, **kwargs):
+    '''
+    Returns ``True`` if the specified service has a 'run' file and that
+    file is executable, otherwhise returns
+    ``False``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' runit.enabled foo
+    '''
+    if not available(name):
+        return False
+
+    files = os.listdir(SERVICE_DIR + '/'+name)
+    if not 'run' in files:
+        return False
+    mode = __salt__['file.get_mode'](SERVICE_DIR + '/'+name+'/run')
+    return (atoi(mode, base=8) & 0b0000000001000000) > 0
+
+
+def enable(name, **kwargs):
+    '''
+    Returns ``True`` if the specified service is enabled - or becomes
+    enabled - as defined by its run file being executable, otherise
+    ``False``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' runit.enable foo
+    '''
+    if not available(name):
+        return False
+
+    files = os.listdir(SERVICE_DIR + '/'+name)
+    if not 'run' in files:
+        return False
+
+    return '0700' == __salt__['file.set_mode']( SERVICE_DIR +'/' +name+'/run', '0700')
+
+
+def disabled(name, **kwargs):
+    '''
+    Returns the opposite of runit.enabled
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' runit.disabled foo
+    '''
+    return not enabled(name)
+
+
+def disable(name, **kwargs):
+    '''
+    Returns ``True`` if the specified service is disabled - or becomes
+    disabled - as defined by its run file being not-executable, otherise
+    ``False``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' runit.disable foo
+    '''
+    if not available(name):
+        return False
+
+    files = os.listdir(SERVICE_DIR + '/'+name)
+    if not 'run' in files:
+        return False
+
+    return '0600' == __salt__['file.set_mode']( SERVICE_DIR +'/' +name+'/run', '0600')
 
 def missing(name):
     '''

--- a/salt/modules/runit.py
+++ b/salt/modules/runit.py
@@ -242,6 +242,7 @@ def disable(name, **kwargs):
 
     return '0600' == __salt__['file.set_mode'](SERVICE_DIR +'/' +name+'/run', '0600')
 
+
 def missing(name):
     '''
     The inverse of runit.available.

--- a/tests/unit/modules/runit_test.py
+++ b/tests/unit/modules/runit_test.py
@@ -124,7 +124,8 @@ class RunitTestCase(TestCase):
         '''
         with patch.object(os, 'listdir',
                           MagicMock(return_value=['run', 'supervise'])):
-            with patch.dict(runit.__salt__, {'file.get_mode': '0700'}):
+            mock_mode = MagicMock(return_value='0700')
+            with patch.dict(runit.__salt__, {'file.get_mode': mock_mode}):
                 self.assertTrue(runit.enabled('foo'))
 
     # 'missing' function tests: 1

--- a/tests/unit/modules/runit_test.py
+++ b/tests/unit/modules/runit_test.py
@@ -115,6 +115,19 @@ class RunitTestCase(TestCase):
                           MagicMock(return_value=['/etc/service'])):
             self.assertTrue(runit.available('/etc/service'))
 
+    # 'enabled' function tests: 1
+
+    def test_enabled(self):
+        '''
+        Test if it returns ``True`` if the specified service is available,
+        otherwise returns ``False``.
+        '''
+        with patch.object(os, 'listdir',
+                          MagicMock(return_value=['run', 'supervise'])):
+            with patch.dict(runit.__salt__, {'file.get_mode': '0700'}):
+                self.assertTrue(runit.enabled('foo'))
+
+
     # 'missing' function tests: 1
 
     def test_missing(self):

--- a/tests/unit/modules/runit_test.py
+++ b/tests/unit/modules/runit_test.py
@@ -127,7 +127,6 @@ class RunitTestCase(TestCase):
             with patch.dict(runit.__salt__, {'file.get_mode': '0700'}):
                 self.assertTrue(runit.enabled('foo'))
 
-
     # 'missing' function tests: 1
 
     def test_missing(self):


### PR DESCRIPTION
New methods test if the standard 'run' file in the services folder has
the executable bit set.  When the 'run' file is not executable, runit
will not launch the service on boot.  This mimicks the enabled/diabled
behavior of other service providers.

The file permissions are set to 700 and 600 for enabled and disabled
states.  Because of the ad-hoc nature that runit service files can
sometimes posess, the run files may have passwords or other sensitive
information.  Therefore, the permissions are hard coded to only be
readable by the file owner, who is also the user who runs the process.

This patch enables salt-ssh to use serivce.\* calls when ssh_minion_opts
sets runit as a global service provider.  It also allows adding "enabled" keys
to state files that manage services and may or may not override the
provider key

```
enable_service:
    service.running:
       - name: mysql
       - provider: {{ mysql.service_provider }}  <== overridable
       - enable: True     <== breaks because runit doesn't have enable
       - reload: True
```
