### PR TITLE
addressing #29265

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1080,6 +1080,7 @@ def user_exists(user,
                 host='localhost',
                 password=None,
                 password_hash=None,
+                password_column='Password',
                 passwordless=False,
                 unix_socket=False,
                 **connection_args):
@@ -1090,7 +1091,7 @@ def user_exists(user,
 
     .. versionadded:: 0.16.2
         The ``passwordless`` option was added.
-
+    
     CLI Example:
 
     .. code-block:: bash
@@ -1098,6 +1099,7 @@ def user_exists(user,
         salt '*' mysql.user_exists 'username' 'hostname' 'password'
         salt '*' mysql.user_exists 'username' 'hostname' password_hash='hash'
         salt '*' mysql.user_exists 'username' passwordless=True
+        salt '*' mysql.user_exists 'username' password_column='authentication_string'
     '''
     dbc = _connect(**connection_args)
     # Did we fail to connect with the user we are checking
@@ -1125,12 +1127,12 @@ def user_exists(user,
             qry += ' AND plugin=%(unix_socket)s'
             args['unix_socket'] = 'unix_socket'
         else:
-            qry += ' AND Password = \'\''
+            qry += ' AND ' + password_column + ' = \'\''
     elif password:
-        qry += ' AND Password = PASSWORD(%(password)s)'
+        qry += ' AND ' + password_column + ' = PASSWORD(%(password)s)'
         args['password'] = str(password)
     elif password_hash:
-        qry += ' AND Password = %(password)s'
+        qry += ' AND ' + password_column + ' = %(password)s'
         args['password'] = password_hash
 
     try:

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1091,7 +1091,7 @@ def user_exists(user,
 
     .. versionadded:: 0.16.2
         The ``passwordless`` option was added.
-    
+
     CLI Example:
 
     .. code-block:: bash

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1080,9 +1080,9 @@ def user_exists(user,
                 host='localhost',
                 password=None,
                 password_hash=None,
-                password_column='Password',
                 passwordless=False,
                 unix_socket=False,
+                password_column='Password',
                 **connection_args):
     '''
     Checks if a user exists on the MySQL server. A login can be checked to see


### PR DESCRIPTION
column name for password string has changed since MySQL 5.7 . This commit adds ability to specify it as a parameter
