### PR TITLE
Fix credentials passing in boto_ec2.snapshot_created

### DIFF
--- a/salt/states/boto_ec2.py
+++ b/salt/states/boto_ec2.py
@@ -567,7 +567,7 @@ def snapshot_created(name, ami_name, instance_name, wait_until_available=True, w
 
     starttime = time()
     while True:
-        images = __salt__['boto_ec2.find_images'](ami_name=ami_name, return_objs=True)
+        images = __salt__['boto_ec2.find_images'](ami_name=ami_name, return_objs=True, **kwargs)
         if images and images[0].state == 'available':
             break
         if time() - starttime > wait_timeout_seconds:


### PR DESCRIPTION
Currently, credentials cannot be specified in boto_ec2.snapshot_created if wait_until_available is set, since they are not passed to find_images. This PR fixes it.
