### PR TITLE
Fix documentation for pillar_merge_lists which default is False, not …

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -2327,7 +2327,7 @@ strategy between different sources. It accepts 4 values:
 
 .. versionadded:: 2015.8.0
 
-Default: ``True``
+Default: ``False``
 
 Recursively merge lists by aggregating them instead of replacing them.
 


### PR DESCRIPTION
Fix documentation for pillar_merge_lists which default is False, not True. From PR #30062.  Backport from develop.
