### PR TITLE
When creating lambda function, retry waiting for IAM role to be propagated

### DIFF
--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -89,6 +89,7 @@ import salt.utils.compat
 import salt.utils
 from salt.exceptions import SaltInvocationError
 from salt.ext.six import string_types
+from salt.ext.six.moves import range
 
 log = logging.getLogger(__name__)
 
@@ -239,7 +240,7 @@ def create_function(FunctionName, Runtime, Role, Handler, ZipFile=None,
             retrycount = RoleRetries
         else:
             retrycount = 1
-        for retry in xrange(retrycount, 0, -1):
+        for retry in range(retrycount, 0, -1):
             try:
                 func = conn.create_function(FunctionName=FunctionName, Runtime=Runtime, Role=role_arn, Handler=Handler,
                                    Code=code, Description=Description, Timeout=Timeout, MemorySize=MemorySize,

--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -83,7 +83,7 @@ def __virtual__():
 def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S3Bucket=None,
             S3Key=None, S3ObjectVersion=None,
             Description='', Timeout=3, MemorySize=128,
-            Permissions=None,
+            Permissions=None, RoleRetries=5,
             region=None, key=None, keyid=None, profile=None):
     '''
     Ensure function exists.
@@ -144,6 +144,11 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S
     Permissions
         A list of permission definitions to be added to the function's policy
 
+    RoleRetries
+        IAM Roles may take some time to propagate to all regions once created.
+        During that time function creation may fail; this state will
+        atuomatically retry this number of times. The default is 5.
+
     region
         Region to connect to.
 
@@ -198,6 +203,8 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S
                                                     S3ObjectVersion=S3ObjectVersion,
                                                     Description=Description,
                                                     Timeout=Timeout, MemorySize=MemorySize,
+                                                    WaitForRole=True,
+                                                    RoleRetries=RoleRetries,
                                                     region=region, key=key,
                                                     keyid=keyid, profile=profile)
         if not r.get('created'):


### PR DESCRIPTION
When an AWS IAM role is created, it may take some time before it's propagated to all regions. In the meantime, creating a lambda function referencing that role may fail. In salt states that create a role and then immediately create a lambda function, this can lead to errors. Add an exponential backoff retry to cover this case, rather than forcing users to work around in their state files.

See https://github.com/hashicorp/terraform/issues/1885 for more info on the situation that occurs.
