### PR TITLE
Bugfix: Zypper `pkg.latest` crash fix

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -597,7 +597,7 @@ def install(name=None,
             pkgs=None,
             sources=None,
             downloadonly=None,
-            **kwargs):
+            version=None, **kwargs):
     '''
     Install the passed package(s), add refresh=True to run 'zypper refresh'
     before package is installed.
@@ -674,7 +674,7 @@ def install(name=None,
     if pkg_params is None or len(pkg_params) == 0:
         return {}
 
-    version_num = kwargs.get('version')
+    version_num = version
     if version_num:
         if pkgs is None and sources is None:
             # Allow "version" to work for single package target

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -746,6 +746,7 @@ def install(name=None,
         __salt__['cmd.run'](cmd, output_loglevel='trace', python_shell=False)
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
+
     return salt.utils.compare_dicts(old, new)
 
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -692,11 +692,7 @@ def install(name=None,
                 match = re.match(r'^([<>])?(=)?([^<>=]+)$', version_num)
                 if match:
                     gt_lt, equal, verstr = match.groups()
-                    prefix = gt_lt or ''
-                    prefix += equal or ''
-                    # If no prefix characters were supplied, use '='
-                    prefix = prefix or '='
-                    targets.append('{0}{1}{2}'.format(param, prefix, verstr))
+                    targets.append('{0}{1}{2}'.format(param, ((gt_lt or '') + (equal or '')) or '=', verstr))
                     log.debug(targets)
                 else:
                     msg = ('Invalid version string {0!r} for package '

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -665,9 +665,7 @@ def install(name=None,
                        'new': '<new-version>'}}
     '''
     try:
-        pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](
-            name, pkgs, sources, **kwargs
-        )
+        pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name, pkgs, sources, **kwargs)
     except MinionError as exc:
         raise CommandExecutionError(exc)
 
@@ -695,8 +693,7 @@ def install(name=None,
                     targets.append('{0}{1}{2}'.format(param, ((gt_lt or '') + (equal or '')) or '=', verstr))
                     log.debug(targets)
                 else:
-                    msg = ('Invalid version string {0!r} for package '
-                           '{1!r}'.format(version_num, name))
+                    msg = ('Invalid version string {0!r} for package {1!r}'.format(version_num, name))
                     problems.append(msg)
         if problems:
             for problem in problems:

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -680,8 +680,7 @@ def install(name=None,
             # Allow "version" to work for single package target
             pkg_params = {name: version_num}
         else:
-            log.warning('\'version\' parameter will be ignored for multiple '
-                        'package targets')
+            log.warning("'version' parameter will be ignored for multiple package targets")
 
     if pkg_type == 'repository':
         targets = []

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -690,7 +690,7 @@ def install(name=None,
             if version_num is None:
                 targets.append(param)
             else:
-                match = re.match('^([<>])?(=)?([^<>=]+)$', version_num)
+                match = re.match(r'^([<>])?(=)?([^<>=]+)$', version_num)
                 if match:
                     gt_lt, equal, verstr = match.groups()
                     prefix = gt_lt or ''

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -597,7 +597,8 @@ def install(name=None,
             pkgs=None,
             sources=None,
             downloadonly=None,
-            version=None, **kwargs):
+            version=None,
+            **kwargs):
     '''
     Install the passed package(s), add refresh=True to run 'zypper refresh'
     before package is installed.

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1442,7 +1442,7 @@ def latest(
                     msg = 'No information found for \'{0}\'.'.format(pkg)
                     log.error(msg)
                     problems.append(msg)
-            elif pkg not in cur \
+            elif not cur.get(pkg) \
                     or salt.utils.compare_versions(ver1=cur[pkg], oper='<', ver2=avail[pkg], cmp_func=cmp_func):
                 targets[pkg] = avail[pkg]
 

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1447,10 +1447,12 @@ def latest(
                 targets[pkg] = avail[pkg]
 
     if problems:
-        return {'name': name,
-                'changes': {},
-                'result': False,
-                'comment': ' '.join(problems)}
+        return {
+            'name': name,
+            'changes': {},
+            'result': False,
+            'comment': ' '.join(problems)
+        }
 
     if targets:
         # Find up-to-date packages

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1467,9 +1467,7 @@ def latest(
 
         if __opts__['test']:
             to_be_upgraded = ', '.join(sorted(targets))
-            comment = 'The following packages are set to be ' \
-                      'installed/upgraded: ' \
-                      '{0}'.format(to_be_upgraded)
+            comment = ['The following packages are set to be installed/upgraded: {0}'.format(to_be_upgraded)]
             if up_to_date:
                 up_to_date_nb = len(up_to_date)
                 if up_to_date_nb <= 10:
@@ -1478,19 +1476,16 @@ def latest(
                         '{0} ({1})'.format(name, cur[name])
                         for name in up_to_date_sorted
                     )
-                    comment += (
-                        ' The following packages are already '
-                        'up-to-date: {0}'
-                    ).format(up_to_date_details)
+                    comment.append('The following packages are already up-to-date: {0}'.format(up_to_date_details))
                 else:
-                    comment += ' {0} packages are already up-to-date'.format(
-                        up_to_date_nb
-                    )
+                    comment.append('{0} packages are already up-to-date'.format(up_to_date_nb))
 
-            return {'name': name,
-                    'changes': {},
-                    'result': None,
-                    'comment': comment}
+            return {
+                'name': name,
+                'changes': {},
+                'result': None,
+                'comment': ' '.join(comment)
+            }
 
         # Build updated list of pkgs to exclude non-targeted ones
         targeted_pkgs = list(targets.keys()) if pkgs else None

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1442,11 +1442,8 @@ def latest(
                     msg = 'No information found for \'{0}\'.'.format(pkg)
                     log.error(msg)
                     problems.append(msg)
-            elif not cur[pkg] \
-                    or salt.utils.compare_versions(ver1=cur[pkg],
-                                                   oper='<',
-                                                   ver2=avail[pkg],
-                                                   cmp_func=cmp_func):
+            elif pkg not in cur \
+                    or salt.utils.compare_versions(ver1=cur[pkg], oper='<', ver2=avail[pkg], cmp_func=cmp_func):
                 targets[pkg] = avail[pkg]
 
     if problems:

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1373,8 +1373,7 @@ def latest(
     '''
     rtag = __gen_rtag()
     refresh = bool(
-        salt.utils.is_true(refresh)
-        or (os.path.isfile(rtag) and refresh is not False)
+        salt.utils.is_true(refresh) or (os.path.isfile(rtag) and refresh is not False)
     )
 
     if kwargs.get('sources'):

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1391,7 +1391,15 @@ def latest(
                     'comment': 'Invalidly formatted "pkgs" parameter. See '
                                'minion log.'}
     else:
-        desired_pkgs = [name]
+        if isinstance(pkgs, list) and len(pkgs) == 0:
+            return {
+                'name': name,
+                'changes': {},
+                'result': True,
+                'comment': 'No packages to install provided'
+            }
+        else:
+            desired_pkgs = [name]
 
     cur = __salt__['pkg.version'](*desired_pkgs, **kwargs)
     try:

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1430,10 +1430,7 @@ def latest(
                 log.error(msg)
                 problems.append(msg)
             else:
-                if salt.utils.compare_versions(ver1=cur[pkg],
-                    oper='!=',
-                    ver2=avail[pkg],
-                    cmp_func=cmp_func):
+                if salt.utils.compare_versions(ver1=cur[pkg], oper='!=', ver2=avail[pkg], cmp_func=cmp_func):
                     targets[pkg] = avail[pkg]
                 else:
                     if not cur[pkg] or __salt__['portage_config.is_changed_uses'](pkg):

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1437,8 +1437,8 @@ def latest(
                         targets[pkg] = avail[pkg]
     else:
         for pkg in desired_pkgs:
-            if not avail[pkg]:
-                if not cur[pkg]:
+            if pkg not in avail:
+                if not cur.get(pkg):
                     msg = 'No information found for \'{0}\'.'.format(pkg)
                     log.error(msg)
                     problems.append(msg)


### PR DESCRIPTION
This PR fixes a crash in the `pkg.latest` state when multiple packages are passed in.
Additionally:
- Add basic error handling in `pkg.install`
- Cleanup the code (remove unnecessary verbosity and PEPs)
- Fixes behavior, when `pkg.latest` was treating SLS file ID as a package even when `pkgs` parameter is specified as empty. Now SLS ID is only a package when no `pkgs` is specified at all, similar to `pkg.installed`.
