### PR TITLE
Add etcd update function

### DIFF
--- a/salt/modules/etcd_mod.py
+++ b/salt/modules/etcd_mod.py
@@ -101,6 +101,59 @@ def set_(key, value, profile=None, ttl=None, directory=False):
     return client.set(key, value, ttl=ttl, directory=directory)
 
 
+def update(fields, path='', profile=None):
+    '''
+    .. versionadded:: Boron
+
+    Sets a dictionary of values in one call.  Useful for large updates
+    in syndic environments.  The dictionary can contain a mix of formats
+    such as:
+
+    .. code-block:: python
+
+        {
+          '/some/example/key': 'bar',
+          '/another/example/key': 'baz'
+        }
+
+    Or it may be a straight dictionary, which will be flattened to look
+    like the above format:
+
+    .. code-block:: python
+
+        {
+            'some': {
+                'example': {
+                    'key': 'bar'
+                }
+            },
+            'another': {
+                'example': {
+                    'key': 'baz'
+                }
+            }
+        }
+
+    You can even mix the two formats and it will be flattened to the first
+    format.  Leading and trailing '/' will be removed.
+
+    Empty directories can be created by setting the value of the key to an
+    empty dictionary.
+
+    The 'path' parameter will optionally set the root of the path to use.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion etcd.update "{'/path/to/key': 'baz', '/another/key': 'bar'}"
+        salt myminion etcd.update "{'/path/to/key': 'baz', '/another/key': 'bar'}" profile=my_etcd_config
+        salt myminion etcd.update "{'/path/to/key': 'baz', '/another/key': 'bar'}" path='/some/root'
+    '''
+    client = __utils__['etcd_util.get_conn'](__opts__, profile)
+    return client.update(fields, path)
+
+
 def watch(key, recurse=False, profile=None, timeout=0, index=None):
     '''
     .. versionadded:: Boron

--- a/tests/unit/modules/etcd_mod_test.py
+++ b/tests/unit/modules/etcd_mod_test.py
@@ -85,6 +85,36 @@ class EtcdModTestCase(TestCase):
             self.instance.set.side_effect = Exception
             self.assertRaises(Exception, etcd_mod.set_, 'err', 'stack')
 
+    # 'update' function tests: 1
+
+    def test_update(self):
+        '''
+        Test if can set multiple keys in etcd
+        '''
+        with patch.dict(etcd_mod.__utils__, {'etcd_util.get_conn': self.EtcdClientMock}):
+            args = {
+                'x': {
+                    'y': {
+                        'a': '1',
+                        'b': '2',
+                    }
+                },
+                'z': '4',
+                'd': {},
+            }
+
+            result = {
+                '/some/path/x/y/a': '1',
+                '/some/path/x/y/b': '2',
+                '/some/path/z': '4',
+                '/some/path/d': {},
+            }
+            self.instance.update.return_value = result
+            self.assertDictEqual(etcd_mod.update(args, path='/some/path'), result)
+            self.instance.update.assert_called_with(args, '/some/path')
+            self.assertDictEqual(etcd_mod.update(args), result)
+            self.instance.update.assert_called_with(args, '')
+
     # 'ls_' function tests: 1
 
     def test_ls(self):


### PR DESCRIPTION
This adds an update function to the etcd module that allows setting multiple keys in a single Salt call.

This is specifically targeted at the use-case that when using syndics and doing multiple etcd.set exec module calls, you hit the syndic-delay after each call, which causes quite a bit of lag time when trying to set multiple keys.

This allows you to pass a dictionary of either fully-qualified keys/values ( `/some/key/name: some-val` ) or nested dicts ( `{'some': {'key': {'name': 'some-val'}}}` ), or even a combination of both.  It flattens the passed dictionary to get full-qualified keys and then sets each of those.

Returns a dict of all the values it was able to set.
