### PR TITLE
Fix TCP transport presence events to work with a NAT

### DIFF
--- a/salt/transport/__init__.py
+++ b/salt/transport/__init__.py
@@ -4,6 +4,26 @@ Encapsulate the different transports available to Salt.
 '''
 from __future__ import absolute_import
 
+# Import third party libs
+import salt.ext.six as six
+
+
+def iter_transport_opts(opts):
+    '''
+    Yield transport, opts for all master configured transports
+    '''
+    transports = set()
+
+    for transport, opts_overrides in six.iteritems(opts.get('transport_opts', {})):
+        t_opts = dict(opts)
+        t_opts.update(opts_overrides)
+        t_opts['transport'] = transport
+        transports.add(transport)
+        yield transport, t_opts
+
+    if opts['transport'] not in transports:
+        yield opts['transport'], opts
+
 
 # for backwards compatibility
 class Channel(object):

--- a/salt/transport/mixins/auth.py
+++ b/salt/transport/mixins/auth.py
@@ -60,10 +60,15 @@ class AESReqServerMixin(object):
         '''
         Pre-fork we need to create the zmq router device
         '''
-        salt.master.SMaster.secrets['aes'] = {'secret': multiprocessing.Array(ctypes.c_char,
-                                                            salt.crypt.Crypticle.generate_key_string()),
-                                              'reload': salt.crypt.Crypticle.generate_key_string,
-                                              }
+        if 'aes' not in salt.master.SMaster.secrets:
+            # TODO: This is still needed only for the unit tests
+            # 'tcp_test.py' and 'zeromq_test.py'. Fix that. In normal
+            # cases, 'aes' is already set in the secrets.
+            salt.master.SMaster.secrets['aes'] = {
+                'secret': multiprocessing.Array(ctypes.c_char,
+                              salt.crypt.Crypticle.generate_key_string()),
+                'reload': salt.crypt.Crypticle.generate_key_string
+            }
 
     def post_fork(self, _, __):
         self.serial = salt.payload.Serial(self.opts)

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -32,6 +32,7 @@ import salt.transport.client
 import salt.transport.server
 import salt.transport.mixins.auth
 from salt.exceptions import SaltReqTimeoutError, SaltClientError
+from salt.transport import iter_transport_opts
 
 # Import Tornado Libs
 import tornado
@@ -256,6 +257,7 @@ class AsyncTCPPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.tran
 
         self.serial = salt.payload.Serial(self.opts)
 
+        self.crypt = kwargs.get('crypt', 'aes')
         self.io_loop = kwargs.get('io_loop') or tornado.ioloop.IOLoop.current()
         self.connected = False
         self._closing = False
@@ -276,9 +278,46 @@ class AsyncTCPPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.tran
     def __del__(self):
         self.close()
 
+    def _package_load(self, load):
+        return {
+            'enc': self.crypt,
+            'load': load,
+        }
+
+    @tornado.gen.coroutine
+    def send_id(self, tok, force_auth):
+        '''
+        Send the minion id to the master so that the master may better
+        track the connection state of the minion.
+        In case of authentication errors, try to renegotiate authentication
+        and retry the method.
+        '''
+        load = {'id': self.opts['id'], 'tok': tok}
+
+        @tornado.gen.coroutine
+        def _do_transfer():
+            msg = self._package_load(self.auth.crypticle.dumps(load))
+            package = salt.transport.frame.frame_msg(msg, header=None)
+            yield self.message_client._stream.write(package)
+            raise tornado.gen.Return(True)
+
+        if force_auth or not self.auth.authenticated:
+            yield self.auth.authenticate()
+        try:
+            ret = yield _do_transfer()
+            raise tornado.gen.Return(ret)
+        except salt.crypt.AuthenticationError:
+            yield self.auth.authenticate()
+            ret = yield _do_transfer()
+            raise tornado.gen.Return(ret)
+
+    @tornado.gen.coroutine
     def connect_callback(self, result):
         if self._closing:
             return
+        # Force re-auth on reconnect since the master
+        # may have been restarted
+        yield self.send_id(self.tok, self._reconnected)
         self.connected = True
         self.event.fire_event(
             {'master': self.opts['master']},
@@ -305,11 +344,10 @@ class AsyncTCPPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.tran
                     [self.opts['id'], 'start'],
                     'minion'
                 )
-            tok = self.auth.gen_token('salt')
             load = {'id': self.opts['id'],
                     'cmd': '_minion_event',
                     'pretag': None,
-                    'tok': tok,
+                    'tok': self.tok,
                     'data': data,
                     'tag': tag}
             req_channel = salt.utils.async.SyncWrapper(
@@ -339,6 +377,7 @@ class AsyncTCPPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.tran
     def connect(self):
         try:
             self.auth = salt.crypt.AsyncAuth(self.opts)
+            self.tok = self.auth.gen_token('salt')
             if not self.auth.authenticated:
                 yield self.auth.authenticate()
             self.message_client = SaltMessageClient(
@@ -773,38 +812,200 @@ class SaltMessageClient(object):
         return future
 
 
+class PubServerClient(object):
+    '''
+    Client object for use with the TCP publisher server
+    '''
+    def __init__(self, stream, address):
+        self.stream = stream
+        self.address = address
+        self._closing = False
+        self._read_until_future = None
+        self.id_ = None
+
+    def close(self):
+        if self._closing:
+            return
+        self._closing = True
+        if not self.stream.closed():
+            self.stream.close()
+            if self._read_until_future is not None:
+                # This will prevent this message from showing up:
+                # '[ERROR   ] Future exception was never retrieved:
+                # StreamClosedError'
+                # This happens because the logic is always waiting to read
+                # the next message and the associated read future is marked
+                # 'StreamClosedError' when the stream is closed.
+                self._read_until_future.exc_info()
+
+    def __del__(self):
+        self.close()
+
+
 class PubServer(tornado.tcpserver.TCPServer, object):
     '''
     TCP publisher
     '''
-    def __init__(self, *args, **kwargs):
-        super(PubServer, self).__init__(*args, **kwargs)
-        self.clients = []
+    def __init__(self, opts, io_loop=None):
+        super(PubServer, self).__init__(io_loop=io_loop)
+        self.opts = opts
+        self._closing = False
+        self.clients = set()
+        self.aes_funcs = salt.master.AESFuncs(self.opts)
+        self.present = {}
+        self.presence_events = False
+        if self.opts.get('presence_events', False):
+            tcp_only = True
+            for transport, _ in iter_transport_opts(self.opts):
+                if transport != 'tcp':
+                    tcp_only = False
+            if tcp_only:
+                # Only when the transport is TCP only, the presence events will
+                # be handled here. Otherwise, it will be handled in the
+                # 'Maintenance' process.
+                self.presence_events = True
+
+        if self.presence_events:
+            self.event = salt.utils.event.get_event(
+                'master',
+                opts=self.opts,
+                listen=False
+            )
+
+    def close(self):
+        if self._closing:
+            return
+        self._closing = True
+
+    def __del__(self):
+        self.close()
+
+    def _add_client_present(self, client):
+        id_ = client.id_
+        if id_ in self.present:
+            clients = self.present[id_]
+            clients.add(client)
+        else:
+            self.present[id_] = set([client])
+            if self.presence_events:
+                data = {'new': [id_],
+                        'lost': []}
+                self.event.fire_event(
+                    data,
+                    salt.utils.event.tagify('change', 'presence')
+                )
+                data = {'present': list(self.present.keys())}
+                self.event.fire_event(
+                    data,
+                    salt.utils.event.tagify('present', 'presence')
+                )
+
+    def _remove_client_present(self, client):
+        id_ = client.id_
+        if id_ is None or id_ not in self.present:
+            return
+
+        clients = self.present[id_]
+        if client not in clients:
+            return
+
+        clients.remove(client)
+        if len(clients) == 0:
+            del self.present[id_]
+            if self.presence_events:
+                data = {'new': [],
+                        'lost': [id_]}
+                self.event.fire_event(
+                    data,
+                    salt.utils.event.tagify('change', 'presence')
+                )
+                data = {'present': list(self.present.keys())}
+                self.event.fire_event(
+                    data,
+                    salt.utils.event.tagify('present', 'presence')
+                )
+
+    @tornado.gen.coroutine
+    def _stream_read(self, client):
+        unpacker = msgpack.Unpacker()
+        while not self._closing:
+            try:
+                client._read_until_future = client.stream.read_bytes(4096, partial=True)
+                wire_bytes = yield client._read_until_future
+                unpacker.feed(wire_bytes)
+                for framed_msg in unpacker:
+                    body = framed_msg['body']
+                    if body['enc'] != 'aes':
+                        # We only accept 'aes' encoded messages for 'id'
+                        continue
+                    crypticle = salt.crypt.Crypticle(self.opts, salt.master.SMaster.secrets['aes']['secret'].value)
+                    load = crypticle.loads(body['load'])
+                    if not self.aes_funcs.verify_minion(load['id'], load['tok']):
+                        continue
+                    client.id_ = load['id']
+                    self._add_client_present(client)
+            except tornado.iostream.StreamClosedError as e:
+                log.debug('tcp stream to {0} closed, unable to recv'.format(client.address))
+                client.close()
+                self._remove_client_present(client)
+                self.clients.discard(client)
+                return
+            except Exception as e:
+                log.error('Exception parsing response', exc_info=True)
+                continue
 
     def handle_stream(self, stream, address):
         log.trace('Subscriber at {0} connected'.format(address))
-        self.clients.append((stream, address))
+        client = PubServerClient(stream, address)
+        self.clients.add(client)
+        self.io_loop.spawn_callback(self._stream_read, client)
 
     # TODO: ACK the publish through IPC
     @tornado.gen.coroutine
-    def publish_payload(self, payload, _):
-        log.debug('TCP PubServer sending payload: {0}'.format(payload))
-        payload = salt.transport.frame.frame_msg(payload['payload'])
+    def publish_payload(self, package, _):
+        log.debug('TCP PubServer sending payload: {0}'.format(package))
+        payload = salt.transport.frame.frame_msg(package['payload'])
 
         to_remove = []
-        for item in self.clients:
-            client, address = item
-            try:
-                # Write the packed str
-                f = client.write(payload)
-                self.io_loop.add_future(f, lambda f: True)
-            except tornado.iostream.StreamClosedError:
-                to_remove.append(item)
-        for item in to_remove:
-            client, address = item
-            log.debug('Subscriber at {0} has disconnected from publisher'.format(address))
+        if 'topic_lst' in package:
+            topic_lst = package['topic_lst']
+            for topic in topic_lst:
+                if topic in self.present:
+                    # Create a separate copy (as a list this time) to iterate
+                    # over due to the possibility of removing from
+                    # 'self.present' in _stream_read.
+                    # This will rarely be a list of more than 1 item. It will
+                    # be more than 1 item if the minion disconnects from the
+                    # master in an unclean manner (eg cable yank), then
+                    # restarts and the master is yet to detect the disconnect
+                    # via TCP keep-alive.
+                    clients = list(self.present[topic])
+                    for client in clients:
+                        try:
+                            # Write the packed str
+                            f = client.stream.write(payload)
+                            self.io_loop.add_future(f, lambda f: True)
+                        except tornado.iostream.StreamClosedError:
+                            to_remove.append(client)
+                else:
+                    log.debug('Publish target {0} not connected'.format(topic))
+        else:
+            # Create a separate copy (as a list this time) to iterate over due
+            # to the possibility of removing from 'self.clients' in
+            # _stream_read.
+            clients = list(self.clients)
+            for client in clients:
+                try:
+                    # Write the packed str
+                    f = client.stream.write(payload)
+                    self.io_loop.add_future(f, lambda f: True)
+                except tornado.iostream.StreamClosedError:
+                    to_remove.append(client)
+        for client in to_remove:
+            log.debug('Subscriber at {0} has disconnected from publisher'.format(client.address))
             client.close()
-            self.clients.remove(item)
+            self._remove_client_present(client)
+            self.clients.discard(client)
         log.trace('TCP PubServer finished publishing payload')
 
 
@@ -819,10 +1020,12 @@ class TCPPubServerChannel(salt.transport.server.PubServerChannel):
         self.io_loop = None
 
     def __setstate__(self, state):
+        salt.master.SMaster.secrets = state['secrets']
         self.__init__(state['opts'])
 
     def __getstate__(self):
-        return {'opts': self.opts}
+        return {'opts': self.opts,
+                'secrets': salt.master.SMaster.secrets}
 
     def _publish_daemon(self, log_queue=None):
         '''
@@ -839,7 +1042,7 @@ class TCPPubServerChannel(salt.transport.server.PubServerChannel):
             self.io_loop = tornado.ioloop.IOLoop.current()
 
         # Spin up the publisher
-        pub_server = PubServer(io_loop=self.io_loop)
+        pub_server = PubServer(self.opts, io_loop=self.io_loop)
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         _set_tcp_keepalive(sock, self.opts)


### PR DESCRIPTION
Currently, the presence events do not work when a salt-master is
communicating with salt-minions that are behind a NAT. This is a common
cloud administration use case. It doesn't work for the following reasons:
- The IP address that the salt-master sees is the NAT IP address and it
  is different than the IP address that the salt-minion thinks it has.
  Hence matching by IP address fails.
- The salt-master may see multiple minions through a NAT with the same
  IP address, but different port numbers.

The following challenges have been observed:
- The PUB server connections are the ones that are persistent.
  Unfortunately, the server has no idea which PUB connection corresponds
  to which salt-minion.
- The salt-master can figure out which salt-minion it is communicating
  with it over the REQ server connections. However, these are not
  persistent and there is no way to correlate the REQ Server connections
  with the PUB server connections. The reason is that in the NAT case,
  multiple salt-minions can have the same IP address. And the REQ and PUB
  port numbers will obviously be different.

Due to these challenges, the following solution has been implemented:
- When the minion connects or reconnects the PUB connection to the
  master, it will send data that identifies it to the master over the PUB
  connection. This data is encrypted with AES and includes an identifying
  token, similar to how REQ connections are protected.
- Once the master receives this data and verifies its authenticity, it
  will proceed to fire the correct presence events. Also, when the
  connection is disconnected, it will also proceed to fire the correct
  presence events.
- These presence events will fire from the PUB Server only when the TCP
  transport is the only transport used, and when `presence_events` is
  True in the opts. In this case, it will disable the `presence_events`
  functionality in the `Maintenance` process.

Additional comments:
- Now we also selectively publish to minions (when using tgt_type
  'list') instead of always publishing to all connected minions, since
  we now associate a minion id for each PUB connection. For large numbers
  of minions, publishing to all minions when only a small subset are
  needed greatly increase network traffic and degrade performance.

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
