### PR TITLE
Fix indent in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1158,7 +1158,7 @@ class SaltDistribution(distutils.dist.Distribution):
                 'site',
                 'psutil',
             ])
-	elif IS_SMARTOS_PLATFORM:
+        elif IS_SMARTOS_PLATFORM:
             # we have them as requirements in pkg/smartos/esky/requirements.txt
             # all these should be safe to force include
             freezer_includes.extend([


### PR DESCRIPTION
Removed a single tab and replaced with eight spaces to fix:
- Incorrect mix of spaces and tabs
- Incorrect indentation

Installed in virtualenv successfully with `pip install git+https://github.com/hamzasheikh/salt.git@fixes-for-python3.5`
