### PR TITLE
Renaming salt-ssh option and documentation fix

### DIFF
--- a/doc/topics/ssh/index.rst
+++ b/doc/topics/ssh/index.rst
@@ -189,8 +189,8 @@ YAML contents:
 
     salt-ssh:
       config_dir: path/to/config/dir
-      max_procs: 30
-      wipe_ssh: True
+      ssh_max_procs: 30
+      ssh_wipe: True
 
 Instead of having to call
 ``salt-ssh --config-dir=path/to/config/dir --max-procs=30 --wipe \* test.ping`` you
@@ -204,7 +204,7 @@ Boolean-style options should be specified in their YAML representation.
    options specified in the parser
    :py:class:`salt.utils.parsers.SaltSSHOptionParser`.  For example, in the
    case of the ``--wipe`` command line option, its ``dest`` is configured to
-   be ``wipe_ssh`` and thus this is what should be configured in the
+   be ``ssh_wipe`` and thus this is what should be configured in the
    ``Saltfile``.  Using the names of flags for this option, being ``wipe:
    True`` or ``w: True``, will not work.
 

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -664,6 +664,13 @@ class Single(object):
         if kwargs.get('wipe'):
             self.wipe = 'False'
         else:
+            if self.opts.get('wipe_ssh'):
+                salt.utils.warn_until(
+                    'Carbon',
+                    'Support for \'wipe_ssh\' has been deprecated in Saltfile and will be removed '
+                    'in Salt Carbon. Please use \'ssh_wipe\' instead.'
+                )
+                self.wipe = 'True'
             self.wipe = 'True' if self.opts.get('ssh_wipe') else 'False'
         if kwargs.get('thin_dir'):
             self.thin_dir = kwargs['thin_dir']

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -666,9 +666,9 @@ class Single(object):
         else:
             if self.opts.get('wipe_ssh'):
                 salt.utils.warn_until(
-                    'Carbon',
+                    'Nitrogen',
                     'Support for \'wipe_ssh\' has been deprecated in Saltfile and will be removed '
-                    'in Salt Carbon. Please use \'ssh_wipe\' instead.'
+                    'in Salt Nitrogen. Please use \'ssh_wipe\' instead.'
                 )
                 self.wipe = 'True'
             self.wipe = 'True' if self.opts.get('ssh_wipe') else 'False'

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -277,7 +277,7 @@ class SSH(object):
             self.defaults['thin_dir'] = os.path.join(
                     '/tmp',
                     '.{0}'.format(uuid.uuid4().hex[:6]))
-            self.opts['wipe_ssh'] = 'True'
+            self.opts['ssh_wipe'] = 'True'
         self.serial = salt.payload.Serial(opts)
         self.returners = salt.loader.returners(self.opts, {})
         self.fsclient = salt.fileclient.FSClient(self.opts)
@@ -664,7 +664,7 @@ class Single(object):
         if kwargs.get('wipe'):
             self.wipe = 'False'
         else:
-            self.wipe = 'True' if self.opts.get('wipe_ssh') else 'False'
+            self.wipe = 'True' if self.opts.get('ssh_wipe') else 'False'
         if kwargs.get('thin_dir'):
             self.thin_dir = kwargs['thin_dir']
         else:

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2713,7 +2713,7 @@ class SaltSSHOptionParser(six.with_metaclass(OptionParserMeta,
             '-w', '--wipe',
             default=False,
             action='store_true',
-            dest='wipe_ssh',
+            dest='ssh_wipe',
             help='Remove the deployment of the salt files when done executing.',
         )
         self.add_option(


### PR DESCRIPTION
For consistency the wipe_ssh option is renamed in ssh_wipe as all other
options in the salt-ssh command are in this style.
The documentation was also adjusted to reflect the renaming.
There were also an wrong salt-ssh example in the documentation.
