### PR TITLE
only load solarisips IF we actually have the pkg binary

### DIFF
--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -50,7 +50,8 @@ def __virtual__():
     Set the virtual pkg module if the os is Solaris 11
     '''
     if __grains__['os'] == 'Solaris' \
-            and float(__grains__['kernelrelease']) > 5.10:
+            and float(__grains__['kernelrelease']) > 5.10 \
+            and salt.utils.which('pkg'):
         return __virtualname__
     return (False,
             'The solarisips execution module failed to load: only available '


### PR DESCRIPTION
solarisips loads as the default pkg provider on SmartOS but it uses pkgin and completely lacks the ips tooling.

This just adds an extra check if we have the 'pkg' binary or not. No point in loading if we don't have it.
This leaves SmartOS without a pkg provider, which is better than loading an incorrect one. (Will fix the proper one later today)
