### PR TITLE
Allow custom types to sync to the master

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -216,13 +216,21 @@ The directory to store the pki authentication keys.
 ``extension_modules``
 ---------------------
 
+.. versionchanged:: Boron
+    The default location for this directory has been moved. Prior to this
+    version, the location was a directory named ``extmods`` in the Salt
+    cachedir (on most platforms, ``/var/cache/salt/extmods``). It has been
+    moved into the master cachedir (on most platforms,
+    ``/var/cache/salt/master/extmods``).
+
 Directory for custom modules. This directory can contain subdirectories for
-each of Salt's module types such as "runners", "output", "wheel", "modules",
-"states", "returners", etc. This path is appended to :conf_master:`root_dir`.
+each of Salt's module types such as ``runners``, ``output``, ``wheel``,
+``modules``, ``states``, ``returners``, etc. This path is appended to
+:conf_master:`root_dir`.
 
 .. code-block:: yaml
 
-    extension_modules: srv/modules
+    extension_modules: /root/salt_extmods
 
 .. conf_minion:: module_dirs
 

--- a/doc/ref/runners/all/salt.runners.saltutil.rst
+++ b/doc/ref/runners/all/salt.runners.saltutil.rst
@@ -1,0 +1,6 @@
+=====================
+salt.runners.saltutil
+=====================
+
+.. automodule:: salt.runners.saltutil
+    :members:

--- a/doc/topics/releases/boron.rst
+++ b/doc/topics/releases/boron.rst
@@ -4,23 +4,40 @@
 Salt Release Notes - Codename Boron
 ===================================
 
+Backwards-incompatible Changes
+==============================
+
+- The default path for the :conf_master:`extension_modules` master config
+  option has been changed.  Prior to this release, the location was a directory
+  named ``extmods`` in the Salt cachedir. On most platforms, this would put the
+  :conf_master:`extension_modules` directory in ``/var/cache/salt/extmods``.
+  It has been moved one directory down, into the master cachedir. On most
+  platforms, this is ``/var/cache/salt/master/extmods``.
+
+
 Core Changes
 ============
 
 - The onchanges requisite now fires if _any_ watched state changes. Refs #19592.
-- The ``ext_pillar`` functions **must** now accept a minion ID as the first 
-  argument. This stops the deprecation path started in Salt 0.17.x. Before this 
-  minion ID first argument was introduced, the minion ID could be retrieved 
-  accessing ``__opts__['id']`` loosing the reference to the master ID initially 
-  set in opts. This is no longer the case, ``__opts__['id']`` will be kept as 
+- The ``ext_pillar`` functions **must** now accept a minion ID as the first
+  argument. This stops the deprecation path started in Salt 0.17.x. Before this
+  minion ID first argument was introduced, the minion ID could be retrieved
+  accessing ``__opts__['id']`` loosing the reference to the master ID initially
+  set in opts. This is no longer the case, ``__opts__['id']`` will be kept as
   the master ID.
+- Custom types can now be synced to the master using the new :mod:`saltutil
+  runner <salt.runners.saltutil>`. Before, these needed to manually be placed
+  under the :conf_master:`extension_modules` directory. This allows custom
+  modules to easily be synced to the master to make them available when
+  compiling Pillar data.
 
 
 Cloud Changes
 =============
 
-- Refactored the OpenNebula driver and added numerous ``--function``s and ``--action``s to enhance Salt support for
-  image, template, security group, virtual network and virtual machine management in OpenNebula.
+- Refactored the OpenNebula driver and added numerous ``--function``s and
+  ``--action``s to enhance Salt support for image, template, security group,
+  virtual network and virtual machine management in OpenNebula.
 
 
 Platform Changes

--- a/doc/topics/releases/boron.rst
+++ b/doc/topics/releases/boron.rst
@@ -29,7 +29,9 @@ Core Changes
   runner <salt.runners.saltutil>`. Before, these needed to manually be placed
   under the :conf_master:`extension_modules` directory. This allows custom
   modules to easily be synced to the master to make them available when
-  compiling Pillar data.
+  compiling Pillar data. Just place custom runners into ``salt://_runners``,
+  custom outputters into ``salt://_output``, etc. and use the functions from
+  the :mod:`saltutil runner <salt.runners.saltutil>` to sync them.
 
 
 Cloud Changes

--- a/doc/topics/releases/boron.rst
+++ b/doc/topics/releases/boron.rst
@@ -12,7 +12,15 @@ Backwards-incompatible Changes
   named ``extmods`` in the Salt cachedir. On most platforms, this would put the
   :conf_master:`extension_modules` directory in ``/var/cache/salt/extmods``.
   It has been moved one directory down, into the master cachedir. On most
-  platforms, this is ``/var/cache/salt/master/extmods``.
+  platforms, this is ``/var/cache/salt/master/extmods``. Most users won't have
+  to worry about this, but those who have been manually placing custom runners
+  into ``/var/cache/salt/extmods/runners``, or ouputters into
+  ``/var/cache/salt/extmods/output``, etc. will be affected by this. To
+  transition, it is recommended not to simply move the extmods directory into
+  ``/var/cache/salt/master``, but to copy the custom modules into the salt
+  fileserver under ``salt://_runners``, ``salt://_output``, etc. and sync them
+  using the functions in the new :mod:`saltutil runner
+  <salt.runners.saltutil>`.
 
 
 Core Changes

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -811,7 +811,7 @@ DEFAULT_MINION_OPTS = {
     'autoload_dynamic_modules': True,
     'environment': None,
     'pillarenv': None,
-    'extension_modules': '',
+    'extension_modules': os.path.join(salt.syspaths.CACHE_DIR, 'minion', 'extmods'),
     'state_top': 'top.sls',
     'state_top_saltenv': None,
     'startup_states': '',
@@ -2802,12 +2802,6 @@ def apply_minion_config(overrides=None,
     # Enabling open mode requires that the value be set to True, and
     # nothing else!
     opts['open_mode'] = opts['open_mode'] is True
-
-    # set up the extension_modules location from the cachedir
-    opts['extension_modules'] = (
-        opts.get('extension_modules') or
-        os.path.join(opts['cachedir'], 'extmods')
-    )
 
     # Set up the utils_dirs location from the extension_modules location
     opts['utils_dirs'] = (

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1086,7 +1086,7 @@ DEFAULT_MASTER_OPTS = {
     'sudo_acl': False,
     'external_auth': {},
     'token_expire': 43200,
-    'extension_modules': os.path.join(salt.syspaths.CACHE_DIR, 'extmods'),
+    'extension_modules': os.path.join(salt.syspaths.CACHE_DIR, 'master', 'extmods'),
     'file_recv': False,
     'file_recv_max_size': 100,
     'file_buffer_size': 1048576,

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -82,7 +82,7 @@ def _get_top_file_envs():
         return envs
 
 
-def _sync(form, saltenv='base'):
+def _sync(form, saltenv=None):
     '''
     Sync the given directory in the given environment
     '''
@@ -172,7 +172,7 @@ def update(version=None):
     return ret
 
 
-def sync_beacons(saltenv='base', refresh=True):
+def sync_beacons(saltenv=None, refresh=True):
     '''
     .. versionadded:: 2015.5.1
 
@@ -200,7 +200,7 @@ def sync_beacons(saltenv='base', refresh=True):
     return ret
 
 
-def sync_sdb(saltenv='base'):
+def sync_sdb(saltenv=None):
     '''
     .. versionadded:: 2015.5.8,2015.8.3
 
@@ -221,7 +221,7 @@ def sync_sdb(saltenv='base'):
     return ret
 
 
-def sync_modules(saltenv='base', refresh=True):
+def sync_modules(saltenv=None, refresh=True):
     '''
     .. versionadded:: 0.10.0
 
@@ -266,7 +266,7 @@ def sync_modules(saltenv='base', refresh=True):
     return ret
 
 
-def sync_states(saltenv='base', refresh=True):
+def sync_states(saltenv=None, refresh=True):
     '''
     .. versionadded:: 0.10.0
 
@@ -294,7 +294,7 @@ def sync_states(saltenv='base', refresh=True):
     return ret
 
 
-def sync_grains(saltenv='base', refresh=True):
+def sync_grains(saltenv=None, refresh=True):
     '''
     .. versionadded:: 0.10.0
 
@@ -324,7 +324,7 @@ def sync_grains(saltenv='base', refresh=True):
     return ret
 
 
-def sync_renderers(saltenv='base', refresh=True):
+def sync_renderers(saltenv=None, refresh=True):
     '''
     .. versionadded:: 0.10.0
 
@@ -353,7 +353,7 @@ def sync_renderers(saltenv='base', refresh=True):
     return ret
 
 
-def sync_returners(saltenv='base', refresh=True):
+def sync_returners(saltenv=None, refresh=True):
     '''
     .. versionadded:: 0.10.0
 
@@ -380,7 +380,7 @@ def sync_returners(saltenv='base', refresh=True):
     return ret
 
 
-def sync_proxymodules(saltenv='base', refresh=False):
+def sync_proxymodules(saltenv=None, refresh=False):
     '''
     .. versionadded:: 2015.8.2
 
@@ -408,7 +408,7 @@ def sync_proxymodules(saltenv='base', refresh=False):
     return ret
 
 
-def sync_output(saltenv='base', refresh=True):
+def sync_output(saltenv=None, refresh=True):
     '''
     Sync outputters from ``salt://_output`` to the minion
 
@@ -436,7 +436,7 @@ def sync_output(saltenv='base', refresh=True):
 sync_outputters = salt.utils.alias_function(sync_output, 'sync_outputters')
 
 
-def sync_utils(saltenv='base', refresh=True):
+def sync_utils(saltenv=None, refresh=True):
     '''
     .. versionadded:: 2014.7.0
 
@@ -464,7 +464,7 @@ def sync_utils(saltenv='base', refresh=True):
     return ret
 
 
-def sync_log_handlers(saltenv='base', refresh=True):
+def sync_log_handlers(saltenv=None, refresh=True):
     '''
     .. versionadded:: 2015.8.0
 
@@ -492,7 +492,7 @@ def sync_log_handlers(saltenv='base', refresh=True):
     return ret
 
 
-def sync_all(saltenv='base', refresh=True):
+def sync_all(saltenv=None, refresh=True):
     '''
     Sync down all of the dynamic modules from the file server for a specific
     environment. This function synchronizes custom modules, states, beacons,

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -82,7 +82,7 @@ def _get_top_file_envs():
         return envs
 
 
-def _sync(form, saltenv=None):
+def _sync(form, saltenv='base'):
     '''
     Sync the given directory in the given environment
     '''
@@ -122,7 +122,7 @@ def update(version=None):
 
     Returns details about the transaction upon completion.
 
-    CLI Example:
+    CLI Examples:
 
     .. code-block:: bash
 
@@ -172,20 +172,27 @@ def update(version=None):
     return ret
 
 
-def sync_beacons(saltenv=None, refresh=True):
+def sync_beacons(saltenv='base', refresh=True):
     '''
-    Sync the beacons from the _beacons directory on the salt master file
-    server. This function is environment aware, pass the desired environment
-    to grab the contents of the _beacons directory, base is the default
-    environment.
-
     .. versionadded:: 2015.5.1
 
-    CLI Example:
+    Sync beacons from ``salt://_beacons`` to the minion
+
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
+
+    refresh : True
+        If ``True``, refresh the available beacons on the minion. This refresh
+        will be performed even if no new beacons are synced. Set to ``False``
+        to prevent this refresh.
+
+    CLI Examples:
 
     .. code-block:: bash
 
         salt '*' saltutil.sync_beacons
+        salt '*' saltutil.sync_beacons saltenv=base,dev
     '''
     ret = _sync('beacons', saltenv)
     if refresh:
@@ -193,31 +200,41 @@ def sync_beacons(saltenv=None, refresh=True):
     return ret
 
 
-def sync_sdb(saltenv=None, refresh=False):  # pylint: disable=unused-argument
+def sync_sdb(saltenv='base'):
     '''
-    Sync sdb modules from the _sdb directory on the salt master file
-    server. This function is environment aware, pass the desired environment
-    to grab the contents of the _sdb directory, base is the default
-    environment.
+    .. versionadded:: 2015.5.8,2015.8.3
 
-    .. versionadded:: 2015.5.7
+    Sync sdb modules from ``salt://_sdb`` to the minion
 
-    CLI Example:
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
+
+    CLI Examples:
 
     .. code-block:: bash
 
         salt '*' saltutil.sync_sdb
+        salt '*' saltutil.sync_sdb saltenv=base,dev
     '''
     ret = _sync('sdb', saltenv)
     return ret
 
 
-def sync_modules(saltenv=None, refresh=True):
+def sync_modules(saltenv='base', refresh=True):
     '''
-    Sync the modules from the _modules directory on the salt master file
-    server. This function is environment aware, pass the desired environment
-    to grab the contents of the _modules directory, base is the default
-    environment.
+    .. versionadded:: 0.10.0
+
+    Sync execution modules from ``salt://_modules`` to the minion
+
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
+
+    refresh : True
+        If ``True``, refresh the available execution modules on the minion.
+        This refresh will be performed even if no new execution modules are
+        synced. Set to ``False`` to prevent this refresh.
 
     .. important::
 
@@ -236,13 +253,12 @@ def sync_modules(saltenv=None, refresh=True):
         See :ref:`here <reloading-modules>` for a more detailed explanation of
         why this is necessary.
 
-    .. versionadded:: 2015.5.1
-
-    CLI Example:
+    CLI Examples:
 
     .. code-block:: bash
 
         salt '*' saltutil.sync_modules
+        salt '*' saltutil.sync_modules saltenv=base,dev
     '''
     ret = _sync('modules', saltenv)
     if refresh:
@@ -250,18 +266,27 @@ def sync_modules(saltenv=None, refresh=True):
     return ret
 
 
-def sync_states(saltenv=None, refresh=True):
+def sync_states(saltenv='base', refresh=True):
     '''
-    Sync the states from the _states directory on the salt master file
-    server. This function is environment aware, pass the desired environment
-    to grab the contents of the _states directory, base is the default
-    environment.
+    .. versionadded:: 0.10.0
 
-    CLI Example:
+    Sync state modules from ``salt://_states`` to the minion
+
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
+
+    refresh : True
+        If ``True``, refresh the available states on the minion. This refresh
+        will be performed even if no new state modules are synced. Set to
+        ``False`` to prevent this refresh.
+
+    CLI Examples:
 
     .. code-block:: bash
 
         salt '*' saltutil.sync_states
+        salt '*' saltutil.sync_states saltenv=base,dev
     '''
     ret = _sync('states', saltenv)
     if refresh:
@@ -269,18 +294,28 @@ def sync_states(saltenv=None, refresh=True):
     return ret
 
 
-def sync_grains(saltenv=None, refresh=True):
+def sync_grains(saltenv='base', refresh=True):
     '''
-    Sync the grains from the _grains directory on the salt master file
-    server. This function is environment aware, pass the desired environment
-    to grab the contents of the _grains directory, base is the default
-    environment.
+    .. versionadded:: 0.10.0
 
-    CLI Example:
+    Sync grains modules from ``salt://_grains`` to the minion
+
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
+
+    refresh : True
+        If ``True``, refresh the available execution modules and recompile
+        pillar data for the minion. This refresh will be performed even if no
+        new grains modules are synced. Set to ``False`` to prevent this
+        refresh.
+
+    CLI Examples:
 
     .. code-block:: bash
 
         salt '*' saltutil.sync_grains
+        salt '*' saltutil.sync_grains saltenv=base,dev
     '''
     ret = _sync('grains', saltenv)
     if refresh:
@@ -289,18 +324,28 @@ def sync_grains(saltenv=None, refresh=True):
     return ret
 
 
-def sync_renderers(saltenv=None, refresh=True):
+def sync_renderers(saltenv='base', refresh=True):
     '''
-    Sync the renderers from the _renderers directory on the salt master file
-    server. This function is environment aware, pass the desired environment
-    to grab the contents of the _renderers directory, base is the default
-    environment.
+    .. versionadded:: 0.10.0
 
-    CLI Example:
+    Sync renderers from ``salt://_renderers`` to the minion
+
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
+
+    refresh : True
+        If ``True``, refresh the available execution modules on the minion.
+        This refresh will be performed even if no new renderers are synced.
+        Set to ``False`` to prevent this refresh. Set to ``False`` to prevent
+        this refresh.
+
+    CLI Examples:
 
     .. code-block:: bash
 
         salt '*' saltutil.sync_renderers
+        salt '*' saltutil.sync_renderers saltenv=base,dev
     '''
     ret = _sync('renderers', saltenv)
     if refresh:
@@ -308,14 +353,22 @@ def sync_renderers(saltenv=None, refresh=True):
     return ret
 
 
-def sync_returners(saltenv=None, refresh=True):
+def sync_returners(saltenv='base', refresh=True):
     '''
-    Sync the returners from the _returners directory on the salt master file
-    server. This function is environment aware, pass the desired environment
-    to grab the contents of the _returners directory, base is the default
-    environment.
+    .. versionadded:: 0.10.0
 
-    CLI Example:
+    Sync beacons from ``salt://_returners`` to the minion
+
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
+
+    refresh : True
+        If ``True``, refresh the available execution modules on the minion.
+        This refresh will be performed even if no new returners are synced. Set
+        to ``False`` to prevent this refresh.
+
+    CLI Examples:
 
     .. code-block:: bash
 
@@ -327,18 +380,27 @@ def sync_returners(saltenv=None, refresh=True):
     return ret
 
 
-def sync_proxymodules(saltenv=None, refresh=False):
+def sync_proxymodules(saltenv='base', refresh=False):
     '''
-    Sync the proxy modules from the _proxy directory on the salt master file
-    server. This function is environment aware, pass the desired environment
-    to grab the contents of the _returners directory, base is the default
-    environment.
+    .. versionadded:: 2015.8.2
 
-    CLI Example:
+    Sync proxy modules from ``salt://_proxy`` to the minion
+
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
+
+    refresh : True
+        If ``True``, refresh the available execution modules on the minion.
+        This refresh will be performed even if no new proxy modules are synced.
+        Set to ``False`` to prevent this refresh.
+
+    CLI Examples:
 
     .. code-block:: bash
 
         salt '*' saltutil.sync_proxymodules
+        salt '*' saltutil.sync_proxymodules saltenv=base,dev
     '''
     ret = _sync('proxy', saltenv)
     if refresh:
@@ -346,18 +408,25 @@ def sync_proxymodules(saltenv=None, refresh=False):
     return ret
 
 
-def sync_output(saltenv=None, refresh=True):
+def sync_output(saltenv='base', refresh=True):
     '''
-    Sync the output modules from the _output directory on the salt master file
-    server. This function is environment aware. Pass the desired environment
-    to grab the contents of the _output directory. Base is the default
-    environment.
+    Sync outputters from ``salt://_output`` to the minion
 
-    CLI Example:
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
+
+    refresh : True
+        If ``True``, refresh the available execution modules on the minion.
+        This refresh will be performed even if no new outputters are synced.
+        Set to ``False`` to prevent this refresh.
+
+    CLI Examples:
 
     .. code-block:: bash
 
         salt '*' saltutil.sync_output
+        salt '*' saltutil.sync_output saltenv=base,dev
     '''
     ret = _sync('output', saltenv)
     if refresh:
@@ -367,18 +436,27 @@ def sync_output(saltenv=None, refresh=True):
 sync_outputters = salt.utils.alias_function(sync_output, 'sync_outputters')
 
 
-def sync_utils(saltenv=None, refresh=True):
+def sync_utils(saltenv='base', refresh=True):
     '''
-    Sync utility source files from the _utils directory on the salt master file
-    server. This function is environment aware, pass the desired environment
-    to grab the contents of the _utils directory, base is the default
-    environment.
+    .. versionadded:: 2014.7.0
 
-    CLI Example:
+    Sync utility modules from ``salt://_utils`` to the minion
+
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
+
+    refresh : True
+        If ``True``, refresh the available execution modules on the minion.
+        This refresh will be performed even if no new utility modules are
+        synced. Set to ``False`` to prevent this refresh.
+
+    CLI Examples:
 
     .. code-block:: bash
 
         salt '*' saltutil.sync_utils
+        salt '*' saltutil.sync_utils saltenv=base,dev
     '''
     ret = _sync('utils', saltenv)
     if refresh:
@@ -386,20 +464,27 @@ def sync_utils(saltenv=None, refresh=True):
     return ret
 
 
-def sync_log_handlers(saltenv=None, refresh=True):
+def sync_log_handlers(saltenv='base', refresh=True):
     '''
     .. versionadded:: 2015.8.0
 
-    Sync utility source files from the _log_handlers directory on the salt master file
-    server. This function is environment aware, pass the desired environment
-    to grab the contents of the _log_handlers directory, base is the default
-    environment.
+    Sync log handlers from ``salt://_log_handlers`` to the minion
 
-    CLI Example:
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
+
+    refresh : True
+        If ``True``, refresh the available execution modules on the minion.
+        This refresh will be performed even if no new log handlers are synced.
+        Set to ``False`` to prevent this refresh.
+
+    CLI Examples:
 
     .. code-block:: bash
 
         salt '*' saltutil.sync_log_handlers
+        salt '*' saltutil.sync_log_handlers saltenv=base,dev
     '''
     ret = _sync('log_handlers', saltenv)
     if refresh:
@@ -407,14 +492,16 @@ def sync_log_handlers(saltenv=None, refresh=True):
     return ret
 
 
-def sync_all(saltenv=None, refresh=True):
+def sync_all(saltenv='base', refresh=True):
     '''
     Sync down all of the dynamic modules from the file server for a specific
     environment. This function synchronizes custom modules, states, beacons,
     grains, returners, output modules, renderers, and utils.
 
     refresh : True
-        Also refresh the execution modules and pillar data available to the minion.
+        Also refresh the execution modules and recompile pillar data available
+        to the minion. This refresh will be performed even if no new dynamic
+        modules are synced. Set to ``False`` to prevent this refresh.
 
     .. important::
 
@@ -433,18 +520,19 @@ def sync_all(saltenv=None, refresh=True):
         See :ref:`here <reloading-modules>` for a more detailed explanation of
         why this is necessary.
 
-    CLI Example:
+    CLI Examples:
 
     .. code-block:: bash
 
         salt '*' saltutil.sync_all
+        salt '*' saltutil.sync_all saltenv=base,dev
     '''
     log.debug('Syncing all')
     ret = {}
     ret['beacons'] = sync_beacons(saltenv, False)
     ret['modules'] = sync_modules(saltenv, False)
     ret['states'] = sync_states(saltenv, False)
-    ret['sdb'] = sync_sdb(saltenv, False)
+    ret['sdb'] = sync_sdb(saltenv)
     ret['grains'] = sync_grains(saltenv, False)
     ret['renderers'] = sync_renderers(saltenv, False)
     ret['returners'] = sync_returners(saltenv, False)

--- a/salt/runners/saltutil.py
+++ b/salt/runners/saltutil.py
@@ -15,9 +15,15 @@ import salt.utils.extmods
 log = logging.getLogger(__name__)
 
 
-def sync_all(saltenv=None):
+def sync_all(saltenv='base'):
     '''
+    .. versionadded:: Boron
+
     Sync all custom types
+
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
 
     CLI Example:
 
@@ -43,8 +49,13 @@ def sync_all(saltenv=None):
 
 def sync_modules(saltenv='base'):
     '''
-    Sync execution modules to the Master's :conf_master:`extension_modules`
-    directory
+    .. versionadded:: Boron
+
+    Sync execution modules from ``salt://_modules`` to the master
+
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
 
     CLI Example:
 
@@ -57,8 +68,13 @@ def sync_modules(saltenv='base'):
 
 def sync_states(saltenv='base'):
     '''
-    Sync state modules to the Master's :conf_master:`extension_modules`
-    directory
+    .. versionadded:: Boron
+
+    Sync state modules from ``salt://_states`` to the master
+
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
 
     CLI Example:
 
@@ -71,8 +87,13 @@ def sync_states(saltenv='base'):
 
 def sync_grains(saltenv='base'):
     '''
-    Sync grains modules to the Master's :conf_master:`extension_modules`
-    directory
+    .. versionadded:: Boron
+
+    Sync grains modules from ``salt://_grains`` to the master
+
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
 
     CLI Example:
 
@@ -85,8 +106,13 @@ def sync_grains(saltenv='base'):
 
 def sync_renderers(saltenv='base'):
     '''
-    Sync renderer modules to the Master's :conf_master:`extension_modules`
-    directory
+    .. versionadded:: Boron
+
+    Sync renderer modules from from ``salt://_renderers`` to the master
+
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
 
     CLI Example:
 
@@ -99,8 +125,13 @@ def sync_renderers(saltenv='base'):
 
 def sync_returners(saltenv='base'):
     '''
-    Sync returner modules to the Master's :conf_master:`extension_modules`
-    directory
+    .. versionadded:: Boron
+
+    Sync returner modules from ``salt://_returners`` to the master
+
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
 
     CLI Example:
 
@@ -113,8 +144,13 @@ def sync_returners(saltenv='base'):
 
 def sync_output(saltenv='base'):
     '''
-    Sync output modules to the Master's :conf_master:`extension_modules`
-    directory
+    .. versionadded:: Boron
+
+    Sync output modules from ``salt://_output`` to the master
+
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
 
     CLI Example:
 
@@ -127,8 +163,13 @@ def sync_output(saltenv='base'):
 
 def sync_proxymodules(saltenv='base'):
     '''
-    Sync proxy modules to the Master's :conf_master:`extension_modules`
-    directory
+    .. versionadded:: Boron
+
+    Sync proxy modules from ``salt://_proxy`` to the master
+
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
 
     CLI Example:
 
@@ -141,7 +182,13 @@ def sync_proxymodules(saltenv='base'):
 
 def sync_runners(saltenv='base'):
     '''
-    Sync runners to the Master's :conf_master:`extension_modules` directory
+    .. versionadded:: Boron
+
+    Sync runners from ``salt://_runners`` to the master
+
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
 
     CLI Example:
 
@@ -154,8 +201,13 @@ def sync_runners(saltenv='base'):
 
 def sync_wheel(saltenv='base'):
     '''
-    Sync wheel modules to the Master's :conf_master:`extension_modules`
-    directory
+    .. versionadded:: Boron
+
+    Sync wheel modules from ``salt://_wheel`` to the master
+
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
 
     CLI Example:
 
@@ -168,8 +220,13 @@ def sync_wheel(saltenv='base'):
 
 def sync_engines(saltenv='base'):
     '''
-    Sync engine modules to the Master's :conf_master:`extension_modules`
-    directory
+    .. versionadded:: Boron
+
+    Sync engines from ``salt://_engines`` to the master
+
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
 
     CLI Example:
 
@@ -182,8 +239,13 @@ def sync_engines(saltenv='base'):
 
 def sync_queues(saltenv='base'):
     '''
-    Sync queue modules to the Master's :conf_master:`extension_modules`
-    directory
+    .. versionadded:: Boron
+
+    Sync queue modules from ``salt://_queues`` to the master
+
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
 
     CLI Example:
 

--- a/salt/runners/saltutil.py
+++ b/salt/runners/saltutil.py
@@ -35,6 +35,7 @@ def sync_all(saltenv=None):
     ret['runners'] = sync_runners(saltenv=saltenv)
     ret['wheel'] = sync_wheel(saltenv=saltenv)
     ret['engines'] = sync_engines(saltenv=saltenv)
+    ret['queues'] = sync_queues(saltenv=saltenv)
     return ret
 
 
@@ -175,3 +176,17 @@ def sync_engines(saltenv='base'):
         salt-run saltutil.sync_engines
     '''
     return salt.utils.extmods.sync(__opts__, 'engines', saltenv=saltenv)[0]
+
+
+def sync_queues(saltenv='base'):
+    '''
+    Sync queue modules to the Master's :conf_master:`extension_modules`
+    directory
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run saltutil.sync_queues
+    '''
+    return salt.utils.extmods.sync(__opts__, 'queues', saltenv=saltenv)[0]

--- a/salt/runners/saltutil.py
+++ b/salt/runners/saltutil.py
@@ -34,6 +34,7 @@ def sync_all(saltenv=None):
     ret['proxymodules'] = sync_proxymodules(saltenv=saltenv)
     ret['runners'] = sync_runners(saltenv=saltenv)
     ret['wheel'] = sync_wheel(saltenv=saltenv)
+    ret['engines'] = sync_engines(saltenv=saltenv)
     return ret
 
 
@@ -160,3 +161,17 @@ def sync_wheel(saltenv='base'):
         salt-run saltutil.sync_wheel
     '''
     return salt.utils.extmods.sync(__opts__, 'wheel', saltenv=saltenv)[0]
+
+
+def sync_engines(saltenv='base'):
+    '''
+    Sync engine modules to the Master's :conf_master:`extension_modules`
+    directory
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run saltutil.sync_engines
+    '''
+    return salt.utils.extmods.sync(__opts__, 'engines', saltenv=saltenv)[0]

--- a/salt/runners/saltutil.py
+++ b/salt/runners/saltutil.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 '''
 Sync custom types to the Master
+
+.. versionadded:: Boron
 '''
 from __future__ import absolute_import
 

--- a/salt/runners/saltutil.py
+++ b/salt/runners/saltutil.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+'''
+Sync custom types to the Master
+'''
+from __future__ import absolute_import
+
+# Import python libs
+import logging
+
+# Import salt libs
+import salt.utils.extmods
+
+log = logging.getLogger(__name__)
+
+
+def sync_all(saltenv=None):
+    '''
+    Sync all custom types
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' saltutil.sync_all
+    '''
+    log.debug('Syncing all')
+    ret = {}
+    ret['modules'] = sync_modules(saltenv=saltenv)
+    ret['states'] = sync_states(saltenv=saltenv)
+    ret['grains'] = sync_grains(saltenv=saltenv)
+    ret['renderers'] = sync_renderers(saltenv=saltenv)
+    ret['returners'] = sync_returners(saltenv=saltenv)
+    ret['output'] = sync_output(saltenv=saltenv)
+    ret['proxymodules'] = sync_proxymodules(saltenv=saltenv)
+    ret['runners'] = sync_runners(saltenv=saltenv)
+    ret['wheel'] = sync_wheel(saltenv=saltenv)
+    return ret
+
+
+def sync_modules(saltenv='base'):
+    '''
+    Sync execution modules to the Master's :conf_master:`extension_modules`
+    directory
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run saltutil.sync_modules
+    '''
+    return salt.utils.extmods.sync(__opts__, 'modules', saltenv=saltenv)[0]
+
+
+def sync_states(saltenv='base'):
+    '''
+    Sync state modules to the Master's :conf_master:`extension_modules`
+    directory
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run saltutil.sync_states
+    '''
+    return salt.utils.extmods.sync(__opts__, 'states', saltenv=saltenv)[0]
+
+
+def sync_grains(saltenv='base'):
+    '''
+    Sync grains modules to the Master's :conf_master:`extension_modules`
+    directory
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run saltutil.sync_grains
+    '''
+    return salt.utils.extmods.sync(__opts__, 'grains', saltenv=saltenv)[0]
+
+
+def sync_renderers(saltenv='base'):
+    '''
+    Sync renderer modules to the Master's :conf_master:`extension_modules`
+    directory
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run saltutil.sync_renderers
+    '''
+    return salt.utils.extmods.sync(__opts__, 'renderers', saltenv=saltenv)[0]
+
+
+def sync_returners(saltenv='base'):
+    '''
+    Sync returner modules to the Master's :conf_master:`extension_modules`
+    directory
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run saltutil.sync_returners
+    '''
+    return salt.utils.extmods.sync(__opts__, 'returners', saltenv=saltenv)[0]
+
+
+def sync_output(saltenv='base'):
+    '''
+    Sync output modules to the Master's :conf_master:`extension_modules`
+    directory
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run saltutil.sync_output
+    '''
+    return salt.utils.extmods.sync(__opts__, 'output', saltenv=saltenv)[0]
+
+
+def sync_proxymodules(saltenv='base'):
+    '''
+    Sync proxy modules to the Master's :conf_master:`extension_modules`
+    directory
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run saltutil.sync_proxy
+    '''
+    return salt.utils.extmods.sync(__opts__, 'proxy', saltenv=saltenv)[0]
+
+
+def sync_runners(saltenv='base'):
+    '''
+    Sync runners to the Master's :conf_master:`extension_modules` directory
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run saltutil.sync_runners
+    '''
+    return salt.utils.extmods.sync(__opts__, 'runners', saltenv=saltenv)[0]
+
+
+def sync_wheel(saltenv='base'):
+    '''
+    Sync wheel modules to the Master's :conf_master:`extension_modules`
+    directory
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run saltutil.sync_wheel
+    '''
+    return salt.utils.extmods.sync(__opts__, 'wheel', saltenv=saltenv)[0]

--- a/salt/utils/extmods.py
+++ b/salt/utils/extmods.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+'''
+Functions used to sync external modules
+'''
+from __future__ import absolute_import
+
+# Import Python libs
+import logging
+import os
+import shutil
+
+# Import salt libs
+import salt.fileclient
+import salt.utils.url
+
+# Import 3rd-party libs
+from salt.ext import six
+
+log = logging.getLogger(__name__)
+
+
+def _list_emptydirs(rootdir):
+    emptydirs = []
+    for root, dirs, files in os.walk(rootdir):
+        if not files and not dirs:
+            emptydirs.append(root)
+    return emptydirs
+
+
+def _listdir_recursively(rootdir):
+    file_list = []
+    for root, dirs, files in os.walk(rootdir):
+        for filename in files:
+            relpath = os.path.relpath(root, rootdir).strip('.')
+            file_list.append(os.path.join(relpath, filename))
+    return file_list
+
+
+def sync(opts, form, saltenv=None):
+    '''
+    Sync custom modules into the extension_modules directory
+    '''
+    if saltenv is None:
+        saltenv = ['base']
+    if isinstance(saltenv, six.string_types):
+        saltenv = saltenv.split(',')
+    ret = []
+    remote = set()
+    source = salt.utils.url.create('_' + form)
+    mod_dir = os.path.join(opts['extension_modules'], '{0}'.format(form))
+    cumask = os.umask(0o77)
+    try:
+        if not os.path.isdir(mod_dir):
+            log.info('Creating module dir \'{0}\''.format(mod_dir))
+            try:
+                os.makedirs(mod_dir)
+            except (IOError, OSError):
+                log.error(
+                    'Cannot create cache module directory {0}. Check '
+                    'permissions.'.format(mod_dir)
+                )
+        fileclient = salt.fileclient.get_file_client(opts)
+        for sub_env in saltenv:
+            log.info(
+                'Syncing {0} for environment \'{1}\''.format(form, sub_env)
+            )
+            cache = []
+            log.info(
+                'Loading cache from {0}, for {1})'.format(source, sub_env)
+            )
+            # Grab only the desired files (.py, .pyx, .so)
+            cache.extend(
+                fileclient.cache_dir(
+                    source, sub_env, include_empty=False,
+                    include_pat=r'E@\.(pyx?|so|zip)$', exclude_pat=None
+                )
+            )
+            local_cache_dir = os.path.join(
+                    opts['cachedir'],
+                    'files',
+                    sub_env,
+                    '_{0}'.format(form)
+                    )
+            log.debug('Local cache dir: \'{0}\''.format(local_cache_dir))
+            for fn_ in cache:
+                relpath = os.path.relpath(fn_, local_cache_dir)
+                relname = os.path.splitext(relpath)[0].replace(os.sep, '.')
+                remote.add(relpath)
+                dest = os.path.join(mod_dir, relpath)
+                log.info('Copying \'{0}\' to \'{1}\''.format(fn_, dest))
+                if os.path.isfile(dest):
+                    # The file is present, if the sum differs replace it
+                    hash_type = opts.get('hash_type', 'md5')
+                    src_digest = salt.utils.get_hash(fn_, hash_type)
+                    dst_digest = salt.utils.get_hash(dest, hash_type)
+                    if src_digest != dst_digest:
+                        # The downloaded file differs, replace!
+                        shutil.copyfile(fn_, dest)
+                        ret.append('{0}.{1}'.format(form, relname))
+                else:
+                    dest_dir = os.path.dirname(dest)
+                    if not os.path.isdir(dest_dir):
+                        os.makedirs(dest_dir)
+                    shutil.copyfile(fn_, dest)
+                    ret.append('{0}.{1}'.format(form, relname))
+
+        touched = bool(ret)
+        if opts.get('clean_dynamic_modules', True):
+            current = set(_listdir_recursively(mod_dir))
+            for fn_ in current - remote:
+                full = os.path.join(mod_dir, fn_)
+                if os.path.isfile(full):
+                    touched = True
+                    os.remove(full)
+            # Cleanup empty dirs
+            while True:
+                emptydirs = _list_emptydirs(mod_dir)
+                if not emptydirs:
+                    break
+                for emptydir in emptydirs:
+                    touched = True
+                    shutil.rmtree(emptydir, ignore_errors=True)
+    except Exception as exc:
+        log.error('Failed to sync {0} module: {1}'.format(form, exc))
+    finally:
+        os.umask(cumask)
+    return ret, touched


### PR DESCRIPTION
This adds a new runner module called `saltutil` which syncs custom types into
the `extension_modules` directory on the master. It also changes the default
path for the `extension_modules` directory to place it inside the master
cachedir, like its counterpart on the minion.

Resolves #11304.
