### PR TITLE
Fixes failed pkg tests on opensuse

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -789,7 +789,7 @@ def install(name=None,
         if out['retcode'] != 0 and out['stderr']:
             errors.append(out['stderr'])
 
-        for line in out.splitlines():
+        for line in out:
             match = re.match(
                 "^The selected package '([^']+)'.+has lower version",
                 line


### PR DESCRIPTION
When the install function changed to cmd.run_all from cmd.run (#29732), the version
checking wasn't updated along with it. This allows the version check to happen
with a dict instead of a string.
