### PR TITLE
Fix sh beacon

### DIFF
--- a/salt/beacons/sh.py
+++ b/salt/beacons/sh.py
@@ -67,7 +67,7 @@ def beacon(config):
     ps_out = __salt__['status.procs']()
     track_pids = []
     for pid in ps_out:
-        if ps_out[pid].get('cmd', '') in shells:
+        if any(ps_out[pid].get('cmd', '').lstrip('-') in shell for shell in shells):
             track_pids.append(pid)
     if pkey not in __context__:
         __context__[pkey] = {}


### PR DESCRIPTION
The sh beacon wasn't working. _getShells() returns a list, but each item in the list is /bin/<shell>. ps lists the processes as just <shell>.

Also, bash sometimes has a hypen in front of it:

```
root     17884  1406  0 12:55 ?        00:00:00     sshd: root@pts/0
root     17908 17884  0 12:55 pts/0    00:00:00       -bash
```

This strips off leading hyphens.
