### PR TITLE
Fix lsscsi issues for certain platforms

### DIFF
--- a/tests/unit/modules/scsi_test.py
+++ b/tests/unit/modules/scsi_test.py
@@ -21,10 +21,12 @@ ensure_in_syspath('../../')
 # Import Salt Libs
 from salt.modules import scsi
 import os
-
+import salt.utils
+import copy
 
 # Globals
 scsi.__salt__ = {}
+scsi.__context__ = {}
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -36,13 +38,51 @@ class ScsiTestCase(TestCase):
         '''
         Test for list SCSI devices, with details
         '''
-        with patch.dict(scsi.__salt__,
-                        {'cmd.run':
-                         MagicMock(return_value='[A:a B:b C:c D:d]')}):
-            self.assertDictEqual(scsi.ls_(),
-                                 {'[A:a':
-                                  {'major': 'C', 'lun': 'A:a', 'device': 'B:b',
-                                   'model': '', 'minor': 'c', 'size': 'D:d]'}})
+        lsscsi = {
+            'stdout': '[0:0:0:0] disk HP LOGICAL VOLUME 6.68 /dev/sda [8:0]',
+            'stderr': '',
+            'retcode': 0
+        }
+
+        lsscsi_size = {
+            'stdout': '[0:0:0:0] disk HP LOGICAL VOLUME 6.68 /dev/sda [8:0] 1.20TB',
+            'stderr': '',
+            'retcode': 0
+        }
+
+        result = {
+            '[0:0:0:0]': {
+                'major': '8',
+                'lun': '0:0:0:0',
+                'device': '/dev/sda',
+                'model': 'LOGICAL VOLUME 6.68',
+                'minor': '0',
+                'size': None,
+            }
+        }
+        result_size = copy.deepcopy(result)
+        result_size['[0:0:0:0]']['size'] = '1.20TB'
+
+        mock = MagicMock(return_value='/usr/bin/lsscsi')
+        with patch.object(salt.utils, 'which', mock):
+            # get_size = True
+
+            cmd_mock = MagicMock(return_value=lsscsi_size)
+            with patch.dict(scsi.__salt__, {'cmd.run_all': cmd_mock}):
+                self.assertDictEqual(scsi.ls_(), result_size)
+                with patch.dict(lsscsi_size, {'retcode': 1, 'stderr': 'An error occurred'}):
+                    self.assertEqual(scsi.ls_(), 'An error occurred')
+                with patch.dict(lsscsi_size, {'retcode': 1, 'stderr': "lsscsi: invalid option -- 's'\nUsage:"}):
+                    self.assertEqual(scsi.ls_(), "lsscsi: invalid option -- 's' - try get_size=False")
+
+            # get_size = False
+            cmd_mock = MagicMock(return_value=lsscsi)
+            with patch.dict(scsi.__salt__, {'cmd.run_all': cmd_mock}):
+                self.assertDictEqual(scsi.ls_(get_size=False), result)
+
+        mock = MagicMock(return_value=None)
+        with patch.object(salt.utils, 'which', mock):
+            self.assertEqual(scsi.ls_(), 'scsi.ls not available - lsscsi command not found')
 
     def test_rescan_all(self):
         '''


### PR DESCRIPTION
The lsscsi command doesn't support the '-s' flag on any RHEL/CentOs system until RHEL7.

The command now has an option to specify 'get_size' to enable compatibility with the older platforms.

Also fixes some issues with lsscsi not being installed and exceptions getting thrown because of that.

Fixes #30565, needs to be ported to 2015.8 as well.
