### PR TITLE
Revert service.mod_watch() bug introduced in Issue 21084

### DIFF
--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -554,8 +554,6 @@ def mod_watch(name,
                 func = __salt__['service.restart']
                 verb = 'restart'
         else:
-            if 'service.stop' in __salt__:
-                __salt__['service.stop'](name)
             func = __salt__['service.start']
             verb = 'start'
         if not past_participle:


### PR DESCRIPTION
This reverts commits 61ed479 and dd60432, which blatantly break
`test=True` protections.

The code should be reverted for the following reasons:
1. The code modified relates purely to variable assignment
      only&#8212;it determines which action will be taken _after_ the `test`
      option is checked. This block of code represents over 60% of the
      function and is for reconnaissance/assignment only.
2. The change was originally made because a sysv init script didn't
      support the `status` argument; the correct way to work around
      this in salt is by passing the `sig` argument into the service
      state (as seen in Issue #7614, which was closed for this reason).
