### PR TITLE
Fix EC2 volume creation logic

### DIFF
--- a/doc/topics/cloud/aws.rst
+++ b/doc/topics/cloud/aws.rst
@@ -852,12 +852,20 @@ A size or a snapshot may be specified (in GiB). If neither is given, a default
 size of 10 GiB will be used. If a snapshot is given, the size of the snapshot
 will be used.
 
+The following parameters may also be set (when providing a snapshot OR size):
+
+* ``type``: choose between standard (magnetic disk), gp2 (SSD), or io1 (provisioned IOPS).
+  (default=standard)
+* ``iops``: the number of IOPS (only applicable to io1 volumes) (default varies on volume size)
+* ``encrypted``: enable encryption on the volume (default=false)
+
 .. code-block:: bash
 
     salt-cloud -f create_volume ec2 zone=us-east-1b
     salt-cloud -f create_volume ec2 zone=us-east-1b size=10
     salt-cloud -f create_volume ec2 zone=us-east-1b snapshot=snap12345678
     salt-cloud -f create_volume ec2 size=10 type=standard
+    salt-cloud -f create_volume ec2 size=10 type=gp2
     salt-cloud -f create_volume ec2 size=10 type=io1 iops=1000
 
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2598,15 +2598,20 @@ def create_attach_volumes(name, kwargs, call=None, wait_to_finish=True):
             volume_dict['volume_id'] = volume['volume_id']
         elif 'snapshot' in volume:
             volume_dict['snapshot'] = volume['snapshot']
-        else:
+        elif 'size' in volume:
             volume_dict['size'] = volume['size']
+        else:
+            raise SaltCloudConfigError(
+                'Cannot create volume.  Please define one of \'volume_id\', '
+                '\'snapshot\', or \'size\''
+            )
 
-            if 'type' in volume:
-                volume_dict['type'] = volume['type']
-            if 'iops' in volume:
-                volume_dict['iops'] = volume['iops']
-            if 'encrypted' in volume:
-                volume_dict['encrypted'] = volume['encrypted']
+        if 'type' in volume:
+            volume_dict['type'] = volume['type']
+        if 'iops' in volume:
+            volume_dict['iops'] = volume['iops']
+        if 'encrypted' in volume:
+            volume_dict['encrypted'] = volume['encrypted']
 
         if 'volume_id' not in volume_dict:
             created_volume = create_volume(volume_dict, call='function', wait_to_finish=wait_to_finish)


### PR DESCRIPTION
Currently, you can't create a volume from a snapshot and also specify the type, so it defaults to a standard magnetic disk.  This PR allows you to specify other types so that you can create an SSD volume from a snapshot.  It also lets you set `iops` and `encrypted` from a snapshot, too.

I also made a change will give a better error message than `KeyError` if you don't specify `volume_id`, `snapshot`, or `size`.
