### PR TITLE
Pop values from new_tags set before loading into dict value

### DIFF
--- a/salt/states/rabbitmq_user.py
+++ b/salt/states/rabbitmq_user.py
@@ -169,7 +169,7 @@ def present(name,
                 return ret
         ret['changes'].update({'tags':
                               {'old': tags,
-                               'new': new_tags}})
+                               'new': new_tags.pop()}})
     try:
         existing_perms = __salt__['rabbitmq.list_user_permissions'](name, runas=runas)
     except CommandExecutionError as err:

--- a/salt/states/rabbitmq_user.py
+++ b/salt/states/rabbitmq_user.py
@@ -169,7 +169,7 @@ def present(name,
                 return ret
         ret['changes'].update({'tags':
                               {'old': tags,
-                               'new': new_tags.pop()}})
+                               'new': list(new_tags)}})
     try:
         existing_perms = __salt__['rabbitmq.list_user_permissions'](name, runas=runas)
     except CommandExecutionError as err:


### PR DESCRIPTION
This was causing state to fail with - Passed invalid arguments: can't serialize set([' tag']). Everytime when tags were defined. I described this issue here - https://github.com/saltstack/salt/issues/30681
