### PR TITLE
fix for #30651 grains.list_present and grains.list_absent

### DIFF
--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -134,7 +134,7 @@ def list_present(name, value, delimiter=DEFAULT_TARGET_DELIM):
            'changes': {},
            'result': True,
            'comment': ''}
-    grain = __grains__.get(name)
+    grain = __salt__['grains.get'](name)
 
     if grain:
         # check whether grain is a list
@@ -143,7 +143,7 @@ def list_present(name, value, delimiter=DEFAULT_TARGET_DELIM):
             ret['comment'] = 'Grain {0} is not a valid list'.format(name)
             return ret
         if isinstance(value, list):
-            if set(value).issubset(set(__grains__.get(name))):
+            if set(value).issubset(set(__salt__['grains.get'](name))):
                 ret['comment'] = 'Value {1} is already in grain {0}'.format(name, value)
                 return ret
         else:
@@ -163,7 +163,7 @@ def list_present(name, value, delimiter=DEFAULT_TARGET_DELIM):
         return ret
     new_grains = __salt__['grains.append'](name, value)
     if isinstance(value, list):
-        if not set(value).issubset(set(__grains__.get(name))):
+        if not set(value).issubset(set(__salt__['grains.get'](name))):
             ret['result'] = False
             ret['comment'] = 'Failed append value {1} to grain {0}'.format(name, value)
             return ret


### PR DESCRIPTION
…orting the ":" separator

This fixes #30651

Sorry it took me so long to track this down and fix. It was a super easy one actually.
