### PR TITLE
Make sure we use the "instance" kwarg in cloud.action.

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -469,16 +469,28 @@ class CloudClient(object):
             )
         '''
         mapper = salt.cloud.Map(self._opts_defaults(action=fun, names=names))
+        if instance:
+            if names:
+                raise SaltCloudConfigError(
+                    'Please specify either a list of \'names\' or a single '
+                    '\'instance\', but not both.'
+                )
+            names = [instance]
+
         if names and not provider:
             self.opts['action'] = fun
             return mapper.do_action(names, kwargs)
-        if provider:
+
+        if provider and not names:
             return mapper.do_function(provider, fun, kwargs)
         else:
             # This should not be called without either an instance or a
-            # provider.
+            # provider. If both an instance/list of names and a provider
+            # are given, then we also need to exit. We can only have one
+            # or the other.
             raise SaltCloudConfigError(
-                'Either an instance or a provider must be specified.'
+                'Either an instance (or list of names) or a provider must be '
+                'specified, but not both.'
             )
 
 

--- a/salt/runners/cloud.py
+++ b/salt/runners/cloud.py
@@ -6,13 +6,18 @@ The Salt Cloud Runner
 This runner wraps the functionality of salt cloud making salt cloud routines
 available to all internal apis via the runner system
 '''
-from __future__ import absolute_import
 
 # Import python libs
+from __future__ import absolute_import
+import logging
 import os
 
 # Import Salt libs
 import salt.cloud
+from salt.exceptions import SaltCloudConfigError
+
+# Get logging started
+log = logging.getLogger(__name__)
 
 
 def _get_client():
@@ -136,12 +141,17 @@ def action(*args, **kwargs):
         salt-run cloud.actions start my-salt-vm
     '''
     client = _get_client()
-    info = client.action(args[0],
-                         kwargs.get('cloudmap', None),
-                         args[1:],
-                         kwargs.get('provider', None),
-                         kwargs.get('instance', None),
-                         kwargs)
+    try:
+        info = client.action(args[0],
+                             kwargs.get('cloudmap', None),
+                             args[1:],
+                             kwargs.get('provider', None),
+                             kwargs.get('instance', None),
+                             kwargs)
+    except SaltCloudConfigError as err:
+        log.error(err)
+        return {}
+
     return info
 
 

--- a/salt/runners/cloud.py
+++ b/salt/runners/cloud.py
@@ -132,7 +132,10 @@ def destroy(instances):
 
 def action(*args, **kwargs):
     '''
-    Execute a single action on the given map/provider/instance
+    Execute a single action on the given map/provider/instance.
+
+    Returns a dictionary of action info. If something goes wrong,
+    an empty dictionary will be returned.
 
     CLI Example:
 


### PR DESCRIPTION
Fixes #29602 

Related to #30217.

In #30217, the original stacktrace as reported in #29602 was fixed in regards to `cloud/__init__.py` handling kwargs in action calls, but using `instance=my-instance provider=my-provider` with the cloud runner also didn't work, as "instance" was never used in the cloud runner action function. This PR fixes using "instance" and also provides helpful error logging information when the incorrect parameters are used in combination. Namely, you can't use an instance with a list of names together or instance/names combined with a provider.

ping @techhat and @pass-by-value 
