### PR TITLE
Catch errors that were ignored in cloud trail state updates.

### DIFF
--- a/salt/modules/boto_cloudtrail.py
+++ b/salt/modules/boto_cloudtrail.py
@@ -488,7 +488,8 @@ def list_tags(Name,
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         rid = _get_trail_arn(Name,
-                             region=None, key=None, keyid=None, profile=None)
+                             region=region, key=key, keyid=keyid,
+                             profile=profile)
         ret = conn.list_tags(ResourceIdList=[rid])
         tlist = ret.get('ResourceTagList', []).pop().get('TagsList')
         tagdict = {}

--- a/salt/modules/boto_cloudtrail.py
+++ b/salt/modules/boto_cloudtrail.py
@@ -428,7 +428,9 @@ def add_tags(Name,
             if str(k).startswith('__'):
                 continue
             tagslist.append({'Key': str(k), 'Value': str(v)})
-        conn.add_tags(ResourceId=_get_trail_arn(Name), TagsList=tagslist)
+        conn.add_tags(ResourceId=_get_trail_arn(Name,
+                      region=region, key=key, keyid=keyid,
+                      profile=profile), TagsList=tagslist)
         return {'tagged': True}
     except ClientError as e:
         return {'tagged': False, 'error': salt.utils.boto3.get_error(e)}
@@ -457,7 +459,9 @@ def remove_tags(Name,
             if str(k).startswith('__'):
                 continue
             tagslist.append({'Key': str(k), 'Value': str(v)})
-        conn.remove_tags(ResourceId=_get_trail_arn(Name), TagsList=tagslist)
+        conn.remove_tags(ResourceId=_get_trail_arn(Name,
+                              region=region, key=key, keyid=keyid,
+                              profile=profile), TagsList=tagslist)
         return {'tagged': True}
     except ClientError as e:
         return {'tagged': False, 'error': salt.utils.boto3.get_error(e)}
@@ -483,7 +487,8 @@ def list_tags(Name,
 
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-        rid = _get_trail_arn(Name)
+        rid = _get_trail_arn(Name,
+                             region=None, key=None, keyid=None, profile=None)
         ret = conn.list_tags(ResourceIdList=[rid])
         tlist = ret.get('ResourceTagList', []).pop().get('TagsList')
         tagdict = {}

--- a/salt/states/boto_cloudtrail.py
+++ b/salt/states/boto_cloudtrail.py
@@ -209,7 +209,13 @@ def present(name, Name,
     ret['changes'] = {}
     # trail exists, ensure config matches
     _describe = __salt__['boto_cloudtrail.describe'](Name=Name,
-                                  region=region, key=key, keyid=keyid, profile=profile)['trail']
+                                  region=region, key=key, keyid=keyid, profile=profile)
+    if 'error' in _describe:
+        ret['result'] = False
+        ret['comment'] = 'Failed to update trail: {0}.'.format(r['error']['message'])
+        ret['changes'] = {}
+        return ret
+    _describe = _describe.get('trail')
 
     r = __salt__['boto_cloudtrail.status'](Name=Name,
                    region=region, key=key, keyid=keyid, profile=profile)

--- a/salt/states/boto_cloudtrail.py
+++ b/salt/states/boto_cloudtrail.py
@@ -185,6 +185,11 @@ def present(name, Name,
         if LoggingEnabled:
             r = __salt__['boto_cloudtrail.start_logging'](Name=Name,
                    region=region, key=key, keyid=keyid, profile=profile)
+            if 'error' in r:
+                ret['result'] = False
+                ret['comment'] = 'Failed to create trail: {0}.'.format(r['error']['message'])
+                ret['changes'] = {}
+                return ret
             ret['changes']['new']['trail']['LoggingEnabled'] = True
         else:
             ret['changes']['new']['trail']['LoggingEnabled'] = False
@@ -192,6 +197,11 @@ def present(name, Name,
         if bool(Tags):
             r = __salt__['boto_cloudtrail.add_tags'](Name=Name,
                    region=region, key=key, keyid=keyid, profile=profile, **Tags)
+            if not r.get('tagged'):
+                ret['result'] = False
+                ret['comment'] = 'Failed to create trail: {0}.'.format(r['error']['message'])
+                ret['changes'] = {}
+                return ret
             ret['changes']['new']['trail']['Tags'] = Tags
         return ret
 
@@ -280,7 +290,7 @@ def present(name, Name,
                     # there's an update for this key
                     adds[k] = Tags[k]
                 elif diff.get('old', '') != '':
-                    removes[k] = _describe[k]
+                    removes[k] = _describe['Tags'][k]
             if bool(adds):
                 r = __salt__['boto_cloudtrail.add_tags'](Name=Name,
                    region=region, key=key, keyid=keyid, profile=profile, **adds)


### PR DESCRIPTION
Plus fix a bug discovered as a result - was not passing authentication information to _get_trail_arn, causing it to work with the awscli configuration rather than the salt specific one. This works unless those happen to be different or awscli is not configured (which is why I hadn't previously noticed the bug.)
