### PR TITLE
Fix for gitfs ext_pillar on standalone minion

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -565,6 +565,7 @@ class GitPython(GitProvider):
                                      'remote.origin.fetch',
                                      '+refs/tags/*:refs/tags/*')
                 self.repo.git.config('http.sslVerify', self.ssl_verify)
+                self.fetch()
             except os.error:
                 # This exception occurs when two processes are trying to write
                 # to the git config at once, go ahead and pass over it since


### PR DESCRIPTION
When configured to use a gitpython-based ext_pillar, `salt-call --local` (I don't have a master) was giving the error:
  `Failed to checkout <branch> from git_pillar remote '<repo location>': remote ref does not exist`

regardless of whether the branch existed or not. Poking around in the cache directory, I found that the cloned repository had a remote named 'origin' set, but no fetch had ever been done, so 'git checkout' would always fail. It doesn't know about any branches yet.

Adding the fetch here, immediately after creating the remote, resolves the problem.

I'm not totally sure this is the _correct_ fix as I'm not familiar with this code, and this code is used in many situations, not just mine. But I believe it to be harmless in the worst case, a redundant fetch.
