### PR TITLE
Changed references from MacOS to Mac

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -833,7 +833,7 @@ def _ps(osdata):
     Return the ps grain
     '''
     grains = {}
-    bsd_choices = ('FreeBSD', 'NetBSD', 'OpenBSD', 'MacOS')
+    bsd_choices = ('FreeBSD', 'NetBSD', 'OpenBSD', 'Mac')
     if osdata['os'] in bsd_choices:
         grains['ps'] = 'ps auxwww'
     elif osdata['os_family'] == 'Solaris':

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -334,7 +334,7 @@ def _run(cmd,
                 'import sys, os, itertools; '
                 'sys.stdout.write(\"\\0\".join(itertools.chain(*os.environ.items())))'
             )
-            if __grains__['os'] in ['MacOS', 'Darwin']:
+            if __grains__['os'] in ['Mac', 'Darwin']:
                 env_cmd = ('sudo', '-i', '-u', runas, '--',
                            sys.executable)
             elif __grains__['os'] in ['FreeBSD']:

--- a/salt/modules/mac_brew.py
+++ b/salt/modules/mac_brew.py
@@ -22,10 +22,16 @@ def __virtual__():
     '''
     Confine this module to Mac OS with Homebrew.
     '''
+    if not salt.utils.is_darwin():
+        return (False, 'The mac_brew module could not be loaded:\n'
+                       'module only works on Mac OS X systems.')
 
-    if salt.utils.which('brew') and __grains__['os'] == 'MacOS':
-        return __virtualname__
-    return (False, 'The brew module could not be loaded: brew not found or grain os != MacOS')
+    if not salt.utils.which('brew'):
+        return (False, 'The mac_brew module could not be loaded:\n'
+                       'brew not found on this system.\n'
+                       'Make sure the \'brew\' binary is in the path')
+
+    return __virtualname__
 
 
 def _list_taps():

--- a/salt/modules/mac_pkgutil.py
+++ b/salt/modules/mac_pkgutil.py
@@ -27,10 +27,14 @@ __virtualname__ = 'darwin_pkgutil'
 
 
 def __virtual__():
-    if __grains__['os'] == 'MacOS':
-        return __virtualname__
-    return (False, 'The darwin_pkgutil execution module cannot be loaded: '
-            'only available on MacOS systems.')
+    '''
+    Module only available on Mac OS X
+    '''
+    if not salt.utils.is_darwin():
+        return (False, 'The mac_pkgutil module could not be loaded:\n'
+                       'module only works on Mac OS X systems.')
+
+    return __virtualname__
 
 
 def list_():

--- a/salt/modules/mac_ports.py
+++ b/salt/modules/mac_ports.py
@@ -55,14 +55,16 @@ def __virtual__():
     '''
     Confine this module to Mac OS with MacPorts.
     '''
+    if not salt.utils.is_darwin():
+        return (False, 'The mac_ports module could not be loaded:\n'
+                       'module only works on Mac OS X systems.')
 
-    if salt.utils.which('port') and __grains__['os'] == 'MacOS':
-        return __virtualname__
-    return (
-        False,
-        'The macports execution module cannot be loaded: only available on '
-        'MacOS with the \'port\' binary in the PATH.'
-    )
+    if not salt.utils.which('port'):
+        return (False, 'The mac_ports module could not be loaded:\n'
+                       'Mac ports not found on this system.\n'
+                       'Make sure the \'port\' binary is in the path')
+
+    return __virtualname__
 
 
 def _list(query=''):

--- a/salt/modules/mac_sysctl.py
+++ b/salt/modules/mac_sysctl.py
@@ -19,10 +19,11 @@ def __virtual__():
     '''
     Only run on Darwin (OS X) systems
     '''
-    if __grains__['os'] == 'MacOS':
-        return __virtualname__
-    return (False, 'The darwin_sysctl execution module cannot be loaded: '
-            'only available on MacOS systems.')
+    if not salt.utils.is_darwin():
+        return (False, 'The mac_sysctl module could not be loaded:\n'
+                       'module only works on Mac OS X systems.')
+
+    return __virtualname__
 
 
 def show(config_file=False):

--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -37,7 +37,7 @@ def __virtual__():
 
 def _list_mounts():
     ret = {}
-    if __grains__['os'] in ['MacOS', 'Darwin']:
+    if __grains__['os'] in ['Mac', 'Darwin']:
         mounts = __salt__['cmd.run_stdout']('mount')
     else:
         mounts = __salt__['cmd.run_stdout']('mount -l')
@@ -206,7 +206,7 @@ def active(extended=False):
         _active_mounts_solaris(ret)
     elif __grains__['os'] == 'OpenBSD':
         _active_mounts_openbsd(ret)
-    elif __grains__['os'] in ['MacOS', 'Darwin']:
+    elif __grains__['os'] in ['Mac', 'Darwin']:
         _active_mounts_darwin(ret)
     else:
         if extended:
@@ -730,7 +730,7 @@ def mount(name, device, mkmnt=False, fstype='', opts='defaults', user=None, util
         return False
 
     # Darwin doesn't expect defaults when mounting without other options
-    if 'defaults' in opts and __grains__['os'] in ['MacOS', 'Darwin']:
+    if 'defaults' in opts and __grains__['os'] in ['Mac', 'Darwin']:
         opts = None
 
     if isinstance(opts, six.string_types):
@@ -764,7 +764,7 @@ def remount(name, device, mkmnt=False, fstype='', opts='defaults', user=None):
         salt '*' mount.remount /mnt/foo /dev/sdz1 True
     '''
     force_mount = False
-    if __grains__['os'] in ['MacOS', 'Darwin']:
+    if __grains__['os'] in ['Mac', 'Darwin']:
         if opts == 'defaults':
             opts = 'noowners'
         if fstype == 'smbfs':
@@ -775,7 +775,7 @@ def remount(name, device, mkmnt=False, fstype='', opts='defaults', user=None):
     mnts = active()
     if name in mnts:
         # The mount point is mounted, attempt to remount it with the given data
-        if 'remount' not in opts and __grains__['os'] not in ['OpenBSD', 'MacOS', 'Darwin']:
+        if 'remount' not in opts and __grains__['os'] not in ['OpenBSD', 'Mac', 'Darwin']:
             opts.append('remount')
         if force_mount:
             # We need to force the mount but first we should unmount
@@ -784,7 +784,7 @@ def remount(name, device, mkmnt=False, fstype='', opts='defaults', user=None):
         args = '-o {0}'.format(lopts)
         if fstype:
             args += ' -t {0}'.format(fstype)
-        if __grains__['os'] not in ['OpenBSD', 'MacOS', 'Darwin'] or force_mount:
+        if __grains__['os'] not in ['OpenBSD', 'Mac', 'Darwin'] or force_mount:
             cmd = 'mount {0} {1} {2} '.format(args, device, name)
         else:
             cmd = 'mount -u {0} {1} {2} '.format(args, device, name)

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -1293,7 +1293,7 @@ def routes(family=None):
         routes_ = _netstat_route_linux()
     elif __grains__['kernel'] == 'SunOS':
         routes_ = _netstat_route_sunos()
-    elif __grains__['os'] in ['FreeBSD', 'MacOS', 'Darwin']:
+    elif __grains__['os'] in ['FreeBSD', 'Mac', 'Darwin']:
         routes_ = _netstat_route_freebsd()
     elif __grains__['os'] in ['NetBSD']:
         routes_ = _netstat_route_netbsd()
@@ -1331,7 +1331,7 @@ def default_route(family=None):
     if __grains__['kernel'] == 'Linux':
         default_route['inet'] = ['0.0.0.0', 'default']
         default_route['inet6'] = ['::/0', 'default']
-    elif __grains__['os'] in ['FreeBSD', 'NetBSD', 'OpenBSD', 'MacOS', 'Darwin'] or \
+    elif __grains__['os'] in ['FreeBSD', 'NetBSD', 'OpenBSD', 'Mac', 'Darwin'] or \
         __grains__['kernel'] == 'SunOS':
         default_route['inet'] = ['default']
         default_route['inet6'] = ['default']

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -113,7 +113,7 @@ def parse_targets(name=None,
         # Backwards compatibility
         saltenv = kwargs['__env__']
 
-    if __grains__['os'] == 'MacOS' and sources:
+    if __grains__['os'] == 'Mac' and sources:
         log.warning('Parameter "sources" ignored on MacOS hosts.')
 
     if pkgs and sources:
@@ -127,7 +127,7 @@ def parse_targets(name=None,
         else:
             return pkgs, 'repository'
 
-    elif sources and __grains__['os'] != 'MacOS':
+    elif sources and __grains__['os'] != 'Mac':
         sources = pack_sources(sources, normalize=normalize)
         if not sources:
             return None, None

--- a/salt/state.py
+++ b/salt/state.py
@@ -849,7 +849,7 @@ class State(object):
         Refresh all the modules
         '''
         log.debug('Refreshing modules...')
-        if self.opts['grains'].get('os') != 'MacOS':
+        if self.opts['grains'].get('os') != 'Mac':
             # In case a package has been installed into the current python
             # process 'site-packages', the 'site' module needs to be reloaded in
             # order for the newly installed package to be importable.

--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -203,7 +203,7 @@ def _get_cron_info():
     elif __grains__['os_family'] == 'Solaris':
         group = 'root'
         crontab_dir = '/var/spool/cron/crontabs'
-    elif __grains__['os'] == 'MacOS':
+    elif __grains__['os'] == 'Mac':
         group = 'wheel'
         crontab_dir = '/usr/lib/cron/tabs'
     else:

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -142,7 +142,7 @@ def mounted(name,
            'comment': ''}
 
     # Defaults is not a valid option on Mac OS
-    if __grains__['os'] in ['MacOS', 'Darwin'] and opts == 'defaults':
+    if __grains__['os'] in ['Mac', 'Darwin'] and opts == 'defaults':
         opts = 'noowners'
 
     # Make sure that opts is correct, it can be a list or a comma delimited
@@ -421,11 +421,11 @@ def mounted(name,
 
     if persist:
         # Override default for Mac OS
-        if __grains__['os'] in ['MacOS', 'Darwin'] and config == '/etc/fstab':
+        if __grains__['os'] in ['Mac', 'Darwin'] and config == '/etc/fstab':
             config = "/etc/auto_salt"
 
         if __opts__['test']:
-            if __grains__['os'] in ['MacOS', 'Darwin']:
+            if __grains__['os'] in ['Mac', 'Darwin']:
                 out = __salt__['mount.set_automaster'](name,
                                               device,
                                               fstype,
@@ -470,7 +470,7 @@ def mounted(name,
                 return ret
 
         else:
-            if __grains__['os'] in ['MacOS', 'Darwin']:
+            if __grains__['os'] in ['Mac', 'Darwin']:
                 out = __salt__['mount.set_automaster'](name,
                                               device,
                                               fstype,
@@ -654,7 +654,7 @@ def unmounted(name,
 
     if persist:
         # Override default for Mac OS
-        if __grains__['os'] in ['MacOS', 'Darwin'] and config == '/etc/fstab':
+        if __grains__['os'] in ['Mac', 'Darwin'] and config == '/etc/fstab':
             config = "/etc/auto_salt"
             fstab_data = __salt__['mount.automaster'](config)
         else:
@@ -674,7 +674,7 @@ def unmounted(name,
                                   'persistent').format(name, config)
                 return ret
             else:
-                if __grains__['os'] in ['MacOS', 'Darwin']:
+                if __grains__['os'] in ['Mac', 'Darwin']:
                     out = __salt__['mount.rm_automaster'](name, device, config)
                 else:
                     out = __salt__['mount.rm_fstab'](name, device, config)


### PR DESCRIPTION
os grain for mac was changed from 'MacOS' to 'Mac'
Changed references to the old grain
Used 'salt.utils.is_darwin()' where possible
