### PR TITLE
Fix improper use of yield in generator

### DIFF
--- a/salt/log/handlers/log4mongo_mod.py
+++ b/salt/log/handlers/log4mongo_mod.py
@@ -69,33 +69,32 @@ class FormatterWithHost(logging.Formatter, NewStyleClassMixIn):
 
 def setup_handlers():
     handler_id = 'log4mongo_handler'
-    if handler_id not in __opts__:
-        yield False
+    if handler_id in __opts__:
+        config_fields = {
+            'host': 'host',
+            'port': 'port',
+            'database_name': 'database_name',
+            'collection': 'collection',
+            'username': 'username',
+            'password': 'password',
+            'write_concern': 'w'
+        }
 
-    config_fields = {
-        'host': 'host',
-        'port': 'port',
-        'database_name': 'database_name',
-        'collection': 'collection',
-        'username': 'username',
-        'password': 'password',
-        'write_concern': 'w'
-    }
+        config_opts = {}
+        for config_opt, arg_name in config_fields.iteritems():
+            config_opts[arg_name] = __opts__[handler_id].get(config_opt)
 
-    config_opts = {}
-    for config_opt, arg_name in config_fields.iteritems():
-        config_opts[arg_name] = __opts__[handler_id].get(config_opt)
+        config_opts['level'] = LOG_LEVELS[
+            __opts__[handler_id].get(
+                'log_level',
+                __opts__.get('log_level', 'error')
+            )
+        ]
 
-    config_opts['level'] = LOG_LEVELS[
-        __opts__[handler_id].get(
-            'log_level',
-            __opts__.get('log_level', 'error')
+        handler = MongoHandler(
+            formatter=FormatterWithHost(),
+            **config_opts
         )
-    ]
-
-    handler = MongoHandler(
-        formatter=FormatterWithHost(),
-        **config_opts
-    )
-
-    yield handler
+        yield handler
+    else:
+        yield False


### PR DESCRIPTION
The log4mongo setup_handler was using yield incorrectly.  Yield simply pauses execution at the point of the yield, and then the next call continues from the point of the yield.

By yielding false at the beginning of the generator and not checking the **opts** for the name ( again ), it was simply continuing the execution, even if log4mongo was not configured, resulting in an exception being thrown.

Fixes #30706 
