### PR TITLE
workaround some SunOS oddities with ifconfig output

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -584,7 +584,8 @@ def _interfaces_ifconfig(out):
                     if not salt.utils.is_sunos():
                         ipv6scope = mmask6.group(3) or mmask6.group(4)
                         addr_obj['scope'] = ipv6scope.lower() if ipv6scope is not None else ipv6scope
-                data['inet6'].append(addr_obj)
+                if addr_obj['address'] != '::' and addr_obj['prefixlen'] != 0:  # SunOS sometimes has ::/0 as inet6 addr when using addrconf
+                    data['inet6'].append(addr_obj)
         data['up'] = updown
         if iface in ret:
             # SunOS optimization, where interfaces occur twice in 'ifconfig -a'


### PR DESCRIPTION
``` bash
salt-call network.ip_addrs6
```

``` yaml
local:
    - ::
    - 2001:6f8:1480:30::130
    - fe80::215:ff:fe05:d7d9
```

Some solaris addrconf configurations publish a ::/0 inet6 section

```
lo0: flags=2001000849<UP,LOOPBACK,RUNNING,MULTICAST,IPv4,VIRTUAL> mtu 8232 index 1
        inet 127.0.0.1 netmask ff000000
net0: flags=40201000843<UP,BROADCAST,RUNNING,MULTICAST,IPv4,CoS,L3PROTECT> mtu 1500 index 2
        inet 172.16.30.130 netmask ffffff00 broadcast 172.16.30.255
        ether 0:15:0:5:d7:d9
lo0: flags=2002000849<UP,LOOPBACK,RUNNING,MULTICAST,IPv6,VIRTUAL> mtu 8252 index 1
        inet6 ::1/128
net0: flags=40202000841<UP,RUNNING,MULTICAST,IPv6,CoS,L3PROTECT> mtu 1500 index 2
        inet6 fe80::215:ff:fe05:d7d9/10
        ether 0:15:0:5:d7:d9
net0:1: flags=40202000841<UP,RUNNING,MULTICAST,IPv6,CoS,L3PROTECT> mtu 1500 index 2
        inet6 2001:6f8:1480:30::130/64
net0:2: flags=40202080840<RUNNING,MULTICAST,ADDRCONF,IPv6,CoS,L3PROTECT> mtu 1500 index 2
        inet6 ::/0
```

We should ignore this one.

``` bash
salt-call network.ip_addrs6
```

``` yaml
local:
    - 2001:6f8:1480:30::130
    - fe80::215:ff:fe05:d7d9
```
