### PR TITLE
Adjusting script for cmd.script test

### DIFF
--- a/tests/integration/files/file/base/script.py
+++ b/tests/integration/files/file/base/script.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
-from __future__ import print_function
 import sys
 
-print(' '.join(sys.argv[1:]))
+try:
+    print ' '.join(sys.argv[1:])
+except SyntaxError:
+    print(' '.join(sys.argv[1:]))


### PR DESCRIPTION
After #29964 was merged the cmd.script and cmd.script_retcode tests on centos 5
started failing because the /usr/bin/env python version is the system default.
The script used print_function from **futures** which was not introduced until
python2.6.

@The-Loeki, I noticed this after your changes to cmdmod function. If you have
thoughts or comments as to why this behavior changed after your changes, I'm all ears.
otherwise, this should take care of the failures on centos 5 on jenkins.
