### PR TITLE
salt.utils.network.in_subnet should check both ipv4 and ipv6

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -896,6 +896,7 @@ def in_subnet(cidr, addr=None):
 
     if addr is None:
         addr = ip_addrs()
+        addr.extend(ip_addrs6())
     elif isinstance(addr, six.string_types):
         return ipaddress.ip_address(addr) in cidr
 


### PR DESCRIPTION
``` bash
/opt/local/salt/bin/salt-call --local grains.get ipv4
```

``` yaml
local:
    - 127.0.0.1
    - 172.16.40.120
```

``` bash
/opt/local/salt/bin/salt-call --local grains.get ipv6
```

``` yaml
local:
    - ::1
    - 2001:6f8:1480:40::120
    - 2001:6f8:1480:40:a236:9fff:fe6e:ba6a
    - fe80::a236:9fff:fe6e:ba6a
```

``` bash
/opt/local/salt/bin/salt-call --local network.in_subnet 172.16.40.0/24
```

``` yaml
local:
    True
```

``` bash
/opt/local/salt/bin/salt-call --local network.in_subnet 2001:6f8:1480:40::/64
```

``` yaml
local:
    True
```

``` bash
/opt/local/salt/bin/salt-call --local network.in_subnet 172.16.30.0/24
```

``` yaml
local:
    False
```

``` bash
/opt/local/salt/bin/salt-call --local network.in_subnet 2001:6f8:1480:30::/64
```

``` yaml
local:
    False
```
