### PR TITLE
modules.lxc.running_systemd: use `command -v` not `which`

### DIFF
--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -3188,7 +3188,7 @@ def running_systemd(name, cache=True, path=None):
             '''\
             #!/usr/bin/env bash
             set -x
-            if ! which systemctl 1>/dev/null 2>/dev/null;then exit 2;fi
+            if ! command -v systemctl 1>/dev/null 2>/dev/null;then exit 2;fi
             for i in \\
                 /run/systemd/journal/dev-log\\
                 /run/systemd/journal/flushed\\


### PR DESCRIPTION
Fixes #30676.

http://pubs.opengroup.org/onlinepubs/9699919799/utilities/command.html
