### PR TITLE
Fix Netwotk hostname Module in Debian systems.

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1845,8 +1845,9 @@ def build_network_settings(**settings):
 
     # Only write the hostname if it has changed
     if not opts['hostname'] == current_network_settings['hostname']:
-        # TODO  replace wiht a call to network.mod_hostname instead
-        _write_file_network(hostname, _DEB_HOSTNAME_FILE)
+        if not ('test' in settings and settings['test']):
+            # TODO  replace wiht a call to network.mod_hostname instead
+            _write_file_network(hostname, _DEB_HOSTNAME_FILE)
 
     new_domain = False
     if len(sline) > 1:
@@ -1884,7 +1885,8 @@ def build_network_settings(**settings):
         new_resolv = ''.join(new_contents)
 
         # Write /etc/resolv.conf
-        _write_file_network(new_resolv, _DEB_RESOLV_FILE)
+        if not ('test' in settings and settings['test']):
+            _write_file_network(new_resolv, _DEB_RESOLV_FILE)
 
     #  used for returning the results back
     try:


### PR DESCRIPTION
Looks like there is no check for test in **settings. Because of this, even when using
test=True salt will edit /etc/hostname in Debian family distros.

Fixes #28751.
