### PR TITLE
Support mounting labelled volumes with multiple drives

### DIFF
--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -125,6 +125,7 @@ def mounted(name,
     if not name == '/':
         name = name.rstrip('/')
 
+    device_list = []
     # Get the active data
     active = __salt__['mount.active'](extended=True)
     real_name = os.path.realpath(name)
@@ -153,14 +154,21 @@ def mounted(name,
         real_device = device.split('=')[1].strip('"').lower()
     elif device.upper().startswith('LABEL='):
         _label = device.split('=')[1]
-        cmd = 'blkid -L {0}'.format(_label)
+        cmd = 'blkid -t LABEL={0}'.format(_label)
         res = __salt__['cmd.run_all']('{0}'.format(cmd))
         if res['retcode'] > 0:
             ret['comment'] = 'Unable to find device with label {0}.'.format(_label)
             ret['result'] = False
             return ret
         else:
-            real_device = res['stdout']
+            # output is a list of entries like this:
+            # /dev/sda: LABEL="<label>" UUID="<uuid>" UUID_SUB="<uuid>" TYPE="btrfs"
+            # exact list of properties varies between filesystems, but we're
+            # only interested in the device in the first column
+            for line in res['stdout']:
+                dev_with_label = line.split(':')[0]
+                device_list.append(dev_with_label)
+            real_device = device_list[0]
     else:
         real_device = device
 
@@ -188,7 +196,6 @@ def mounted(name,
         if 'device_name' in fuse_match.groupdict():
             real_device = fuse_match.group('device_name')
 
-    device_list = []
     if real_name in active:
         if 'superopts' not in active[real_name]:
             active[real_name]['superopts'] = []


### PR DESCRIPTION
Previous code always tried to remount multi-drive volumes which are common
under btrfs and similar filesystems, because it assumed only a single drive
matched a label.
