### PR TITLE
Allow managing empty files

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1385,8 +1385,9 @@ def managed(name,
            'name': name,
            'result': True}
 
+    content_sources = (contents, contents_pillar, contents_grains)
     contents_count = len(
-        [x for x in (contents, contents_pillar, contents_grains) if x]
+        [x for x in content_sources if x is not None]
     )
 
     if source and contents_count > 0:


### PR DESCRIPTION
Without this patch, specifying an empty file like this:

``` yaml
empty-file:
    file.managed:
        - name: /tmp/empty
        - contents: ''
```

Did not actually ensure that the file was empty, since the check for content
sources didn't separate between unset values and the empty string.
