### PR TITLE
Return a dict in `redis_return.get_jids`.

### DIFF
--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -173,10 +173,17 @@ def get_fun(fun):
 
 def get_jids():
     '''
-    Return a list of all job ids
+    Return a dict mapping all job ids to job information
     '''
     serv = _get_serv(ret=None)
-    return list(serv.keys('load:*'))
+    ret = {}
+    for s in serv.mget(serv.keys('load:*')):
+        if s is None:
+            continue
+        load = json.loads(s)
+        jid = load['jid']
+        ret[jid] = salt.utils.jid.format_jid_instance(jid, load)
+    return ret
 
 
 def get_minions():


### PR DESCRIPTION
which was fixed in #28654, but broken by #30571
