### PR TITLE
Added ability to install PKG, DMG and APP files for OS X minions

### DIFF
--- a/salt/modules/mac_package.py
+++ b/salt/modules/mac_package.py
@@ -1,0 +1,245 @@
+# -*- coding: utf-8 -*-
+'''
+Install pkg, dmg and .app applications on Mac OS X minions.
+
+'''
+
+# Import python libs
+from __future__ import absolute_import
+import os
+import random
+import logging
+
+# Import salt libs
+import salt.utils
+
+log = logging.getLogger(__name__)
+__virtualname__ = "macpackage"
+
+
+def __virtual__():
+    '''
+    Only work on Mac OS
+    '''
+    if salt.utils.is_darwin():
+        return __virtualname__
+    return False
+
+
+def install(pkg, target="LocalSystem", store=False, allow_untrusted=False):
+    '''
+    Install a pkg file
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' macpackage.install test.pkg
+
+    target
+        The target in which to install the package to
+
+    store
+        Should the package be installed as if it was from the store?
+
+    allow_untrusted
+        Allow the installation of untrusted packages?
+
+
+    '''
+    cmd = 'installer -pkg {0} -target {1}'.format(pkg, target)
+    if store:
+        cmd += ' -store'
+    if allow_untrusted:
+        cmd += ' -allowUntrusted'
+
+    # We can only use wildcards in python_shell which is
+    # sent by the macpackage state
+    python_shell = False
+    if '*.' in cmd:
+        python_shell = True
+
+    return __salt__['cmd.run_all'](cmd, python_shell=python_shell)
+
+
+def install_app(app, target="/Applications/"):
+    '''
+    Install an app file
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' macpackage.install_app /tmp/tmp.app /Applications/
+
+    app
+        The location of the .app file
+
+    target
+        The target in which to install the package to
+
+
+    '''
+    if not target[-4:] == ".app":
+        if app[-1:] == "/":
+            base_app = os.path.basename(app[:-1])
+        else:
+            base_app = os.path.basename(app)
+
+        target = os.path.join(target, base_app)
+
+    if not app[-1] == "/":
+        app += "/"
+
+    cmd = 'rsync -a --no-compress --delete "{0}" "{1}"'.format(app, target)
+    return __salt__['cmd.run'](cmd)
+
+
+def uninstall_app(app):
+    '''
+    Uninstall an app file
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' macpackage.uninstall_app /Applications/app.app
+
+    app
+        The location of the .app file
+
+
+    '''
+
+    return __salt__['file.remove'](app)
+
+
+def mount(dmg):
+    '''
+    Attempt to mount a dmg file to a temporary location and return the
+    location of the pkg file inside
+
+    dmg
+        The location of the dmg file to mount
+    '''
+
+    temp_dir = __salt__['temp.dir'](prefix='dmg-')
+
+    cmd = 'hdiutil attach -readonly -nobrowse -mountpoint {0} "{1}"'.format(temp_dir, dmg)
+
+    return __salt__['cmd.run'](cmd), temp_dir
+
+
+def unmount(mountpoint):
+    '''
+    Attempt to unmount a dmg file from a temporary location
+
+    mountpoint
+        The location of the mount point
+    '''
+
+    cmd = 'hdiutil detach "{0}"'.format(mountpoint)
+
+    return __salt__['cmd.run'](cmd)
+
+
+def installed_pkgs():
+    '''
+    Return the list of installed packages on the machine
+
+    '''
+
+    cmd = 'pkgutil --pkgs'
+
+    return __salt__['cmd.run'](cmd).split("\n")
+
+
+def get_pkg_id(pkg):
+    '''
+    Attempt to get the package id from a .pkg file
+
+    Returns all of the package ids if the pkg file contains multiple
+
+    pkg
+        The location of the pkg file
+    '''
+    package_ids = []
+
+    # Create temp directory
+    temp_dir = __salt__['temp.dir'](prefix='pkg-')
+
+    try:
+        # List all of the PackageInfo files
+        cmd = 'xar -t -f "{0}" | grep PackageInfo'.format(pkg)
+        out = __salt__['cmd.run'](cmd, python_shell=True, output_loglevel="quiet")
+        files = out.split("\n")
+
+        if 'Error opening' not in out:
+            # Extract the PackageInfo files
+            cmd = 'xar -x -f "{0}" {1}'.format(pkg, ' '.join(files))
+            __salt__['cmd.run'](cmd, cwd=temp_dir, output_loglevel="quiet")
+
+            # Find our identifiers
+            for f in files:
+                i = _get_pkg_id_from_pkginfo(os.path.join(temp_dir, f))
+                if len(i):
+                    package_ids.extend(i)
+        else:
+            package_ids = _get_pkg_id_dir(pkg)
+
+    finally:
+        # Clean up
+        __salt__['file.remove'](temp_dir)
+
+    return package_ids
+
+
+def get_mpkg_ids(mpkg):
+    '''
+    Attempt to get the package ids from a mounted .mpkg file
+
+    Returns all of the package ids if the pkg file contains multiple
+
+    pkg
+        The location of the mounted mpkg file
+    '''
+    package_infos = []
+    base_path = os.path.dirname(mpkg)
+
+    # List all of the .pkg files
+    cmd = 'find {0} -name "*.pkg"'.format(base_path)
+    out = __salt__['cmd.run'](cmd, python_shell=True)
+
+    pkg_files = out.split('\n')
+    for p in pkg_files:
+        package_infos.extend(get_pkg_id(p))
+
+    return package_infos
+
+
+def _get_pkg_id_from_pkginfo(pkginfo):
+    # Find our identifiers
+    cmd = 'cat {0} | grep -Eo \'identifier="[a-zA-Z.0-9\\-]*"\' | cut -c 13- | tr -d \'"\''.format(pkginfo)
+    out = __salt__['cmd.run'](cmd, python_shell=True)
+
+    if "No such file" not in out:
+        return out.split("\n")
+
+    return []
+
+
+def _get_pkg_id_dir(path):
+    cmd = '/usr/libexec/PlistBuddy -c "print :CFBundleIdentifier" {0}'.format(os.path.join(path, "Contents/Info.plist"))
+
+    # We can only use wildcards in python_shell which is
+    # sent by the macpackage state
+    python_shell = False
+    if '*.' in cmd:
+        python_shell = True
+
+    out = __salt__['cmd.run'](cmd, python_shell=python_shell)
+
+    if "Does Not Exist" not in out:
+        return [out]
+
+    return []

--- a/salt/modules/mac_package.py
+++ b/salt/modules/mac_package.py
@@ -7,7 +7,6 @@ Install pkg, dmg and .app applications on Mac OS X minions.
 # Import python libs
 from __future__ import absolute_import
 import os
-import random
 import logging
 
 # Import salt libs

--- a/salt/states/mac_package.py
+++ b/salt/states/mac_package.py
@@ -1,0 +1,268 @@
+# -*- coding: utf-8 -*-
+'''
+Installing of mac pkg files
+=======================
+
+Install any kind of pkg, dmg or app file on Mac OS X:
+
+.. code-block:: yaml
+
+    /mnt/test.pkg:
+      macpackage.installed:
+        - store: True
+
+    /mnt/test.dmg:
+      macpackage.installed:
+        - dmg: True
+
+    /mnt/xcode.dmg:
+        macpackage.installed:
+            - dmg: True
+            - app: True
+            - target: /Applications/Xcode.app
+            - version_check: xcodebuild -version=Xcode 7.1\n.*7B91b
+'''
+
+# Import python libs
+from __future__ import absolute_import
+import logging
+import os
+import re
+
+# Import salt libs
+import salt.utils
+from salt.exceptions import CommandExecutionError
+
+log = logging.getLogger(__name__)
+__virtualname__ = "macpackage"
+
+
+def __virtual__():
+    '''
+    Only work on Mac OS
+    '''
+    if salt.utils.is_darwin():
+        return __virtualname__
+    return False
+
+
+def installed(name, target="LocalSystem", dmg=False, store=False, app=False, mpkg=False, user=None, onlyif=None,
+              unless=None, force=False, allow_untrusted=False, version_check=None):
+    '''
+    Install a Mac OS Package from a pkg or dmg file, if given a dmg file it
+    will first be mounted in a temporary location
+
+    name
+        The pkg or dmg file to install
+
+    target
+        The location in which to install the package. This can be a path or LocalSystem
+
+    dmg
+        Is the given file a dmg file?
+
+    store
+        Should the pkg be installed as if it was from the Mac OS Store?
+
+    app
+        Is the file a .app? If so then we'll just copy that to /Applications/ or the given
+        target
+
+    mpkg
+        Is the file a .mpkg? If so then we'll check all of the .pkg files found are installed
+
+    user
+        Name of the user performing the unless or onlyif checks
+
+    onlyif
+        A command to run as a check, run the named command only if the command
+        passed to the ``onlyif`` option returns true
+
+    unless
+        A command to run as a check, only run the named command if the command
+        passed to the ``unless`` option returns false
+
+    force
+        Force the package to be installed even if its already been found installed
+
+    allow_untrusted
+        Allow the installation of untrusted packages
+
+    version_check
+        The command and version that we want to check against, the version number can use regex.
+
+        .. code-block:: yaml
+            version_check: python --version_check=2.7.[0-9]
+
+    '''
+    ret = {'name': name,
+           'result': True,
+           'comment': '',
+           'changes': {}}
+    found = []
+    installing = []
+
+    real_pkg = name
+
+    # Check onlyif, unless first
+    run_check_cmd_kwargs = {'runas': user, 'python_shell': True}
+    if 'shell' in __grains__:
+        run_check_cmd_kwargs['shell'] = __grains__['shell']
+
+    cret = _mod_run_check(run_check_cmd_kwargs, onlyif, unless)
+
+    if isinstance(cret, dict):
+        ret.update(cret)
+        return ret
+
+    # Check version info
+    if version_check is not None:
+        split = version_check.split("=")
+        if len(split) == 2:
+            version_cmd = split[0]
+            expected_version = split[1]
+            try:
+                version_out = __salt__['cmd.run'](version_cmd, output_loglevel="quiet", ignore_retcode=True)
+                version_out = version_out.strip()
+            except CommandExecutionError:
+                version_out = ""
+
+            if re.match(expected_version, version_out) is not None:
+                ret['comment'] += "Version already matches {0}".format(expected_version)
+                return ret
+            else:
+                ret['comment'] += "Version {0} doesn't match {1}. ".format(version_out, expected_version)
+
+    if app and target == "LocalSystem":
+        target = "/Applications/"
+
+    # Mount the dmg first
+    mount_point = None
+    if dmg:
+        out, mount_point = __salt__['macpackage.mount'](name)
+        if 'attach failed' in out:
+            ret['result'] = False
+            ret['comment'] += 'Unable to mount {0}'.format(name)
+            return ret
+
+        if app:
+            real_pkg = mount_point + "/*.app"
+        elif mpkg:
+            real_pkg = mount_point + "/*.mpkg"
+        else:
+            real_pkg = mount_point + "/*.pkg"
+
+    try:
+        # Check if we have already installed this
+        if app:
+            if dmg:
+                # Run with python shell due to the wildcard
+                cmd = 'ls -d *.app'.format(real_pkg)
+                out = __salt__['cmd.run'](cmd, cwd=mount_point, python_shell=True)
+
+                if '.app' not in out:
+                    ret['result'] = False
+                    ret['comment'] += 'Unable to find .app in {0}'.format(mount_point)
+                    return ret
+                else:
+                    pkg_ids = out.split("\n")
+            else:
+                pkg_ids = [os.path.basename(name)]
+                mount_point = os.path.dirname(name)
+
+            if onlyif is None and unless is None and version_check is None:
+                for p in pkg_ids:
+                    if target[-4:] == ".app":
+                        install_dir = target
+                    else:
+                        install_dir = os.path.join(target, p)
+                    if os.path.exists(install_dir) and force is False:
+                        found.append(p)
+                    else:
+                        installing.append(p)
+            else:
+                installing = pkg_ids
+        else:
+            installed_pkgs = __salt__['macpackage.installed_pkgs']()
+
+            if mpkg:
+                pkg_ids = __salt__['macpackage.get_mpkg_ids'](real_pkg)
+            else:
+                pkg_ids = __salt__['macpackage.get_pkg_id'](real_pkg)
+
+            if len(pkg_ids) > 0:
+                for p in pkg_ids:
+                    if p in installed_pkgs and force is False:
+                        found.append(p)
+                    else:
+                        installing.append(p)
+                if len(pkg_ids) == len(found):
+                    return ret
+
+        if app:
+            def failed_pkg(f_pkg):
+                    ret['result'] = False
+                    ret['comment'] += '{0} failed to install: {1}'.format(name, out)
+
+                    if 'failed' in ret['changes']:
+                        ret['changes']['failed'].append(f_pkg)
+                    else:
+                        ret['changes']['failed'] = [f_pkg]
+
+            for app in installing:
+                try:
+                    log.info('Copying {0} to {1}'.format(app, target))
+
+                    out = __salt__['macpackage.install_app'](os.path.join(mount_point, app), target)
+
+                    if len(out) != 0:
+                        failed_pkg(app)
+                    else:
+                        ret['comment'] += '{0} installed'.format(app)
+                        if 'installed' in ret['changes']:
+                            ret['changes']['installed'].append(app)
+                        else:
+                            ret['changes']['installed'] = [app]
+
+                except OSError:
+                    failed_pkg(app)
+        else:
+            out = __salt__['macpackage.install'](real_pkg, target, store, allow_untrusted)
+
+            if out['retcode'] != 0:
+                ret['result'] = False
+                ret['comment'] += '. {0} failed to install: {1}'.format(name, out)
+            else:
+                ret['comment'] += '{0} installed'.format(name)
+                ret['changes']['installed'] = installing
+
+    finally:
+        if dmg:
+            # Unmount to be kind
+            __salt__['macpackage.unmount'](mount_point)
+
+    return ret
+
+
+def _mod_run_check(cmd_kwargs, onlyif, unless):
+    '''
+    Execute the onlyif and unless logic.
+    Return a result dict if:
+    * onlyif failed (onlyif != 0)
+    * unless succeeded (unless == 0)
+    else return True
+    '''
+    if onlyif:
+        if __salt__['cmd.retcode'](onlyif, **cmd_kwargs) != 0:
+            return {'comment': 'onlyif execution failed',
+                    'skip_watch': True,
+                    'result': True}
+
+    if unless:
+        if __salt__['cmd.retcode'](unless, **cmd_kwargs) == 0:
+            return {'comment': 'unless execution succeeded',
+                    'skip_watch': True,
+                    'result': True}
+
+    # No reason to stop, return True
+    return True

--- a/salt/states/mac_package.py
+++ b/salt/states/mac_package.py
@@ -157,7 +157,7 @@ def installed(name, target="LocalSystem", dmg=False, store=False, app=False, mpk
         if app:
             if dmg:
                 # Run with python shell due to the wildcard
-                cmd = 'ls -d *.app'.format(real_pkg)
+                cmd = 'ls -d *.app'
                 out = __salt__['cmd.run'](cmd, cwd=mount_point, python_shell=True)
 
                 if '.app' not in out:
@@ -201,13 +201,13 @@ def installed(name, target="LocalSystem", dmg=False, store=False, app=False, mpk
 
         if app:
             def failed_pkg(f_pkg):
-                    ret['result'] = False
-                    ret['comment'] += '{0} failed to install: {1}'.format(name, out)
+                ret['result'] = False
+                ret['comment'] += '{0} failed to install: {1}'.format(name, out)
 
-                    if 'failed' in ret['changes']:
-                        ret['changes']['failed'].append(f_pkg)
-                    else:
-                        ret['changes']['failed'] = [f_pkg]
+                if 'failed' in ret['changes']:
+                    ret['changes']['failed'].append(f_pkg)
+                else:
+                    ret['changes']['failed'] = [f_pkg]
 
             for app in installing:
                 try:

--- a/tests/unit/modules/mac_package_test.py
+++ b/tests/unit/modules/mac_package_test.py
@@ -38,7 +38,7 @@ class MacPackageTestCase(TestCase):
         mock = MagicMock()
         with patch.dict(macpackage.__salt__, {'cmd.run_all': mock}):
             macpackage.install('/path/to/*.pkg')
-            mock.assert_called_once_with('installer -pkg /path/to/*.pkg -target LocalSystem', python_shell=True)
+            mock.assert_called_once_with('installer -pkg \'/path/to/*.pkg\' -target LocalSystem', python_shell=True)
 
     def test_install_with_extras(self):
         '''
@@ -57,8 +57,8 @@ class MacPackageTestCase(TestCase):
         mock = MagicMock()
         with patch.dict(macpackage.__salt__, {'cmd.run': mock}):
             macpackage.install_app('/path/to/file.app')
-            mock.assert_called_once_with('rsync -a --no-compress --delete "/path/to/file.app/" '
-                                         '"/Applications/file.app"')
+            mock.assert_called_once_with('rsync -a --no-compress --delete /path/to/file.app/ '
+                                         '/Applications/file.app')
 
     def test_install_app_specify_target(self):
         '''
@@ -67,8 +67,8 @@ class MacPackageTestCase(TestCase):
         mock = MagicMock()
         with patch.dict(macpackage.__salt__, {'cmd.run': mock}):
             macpackage.install_app('/path/to/file.app', '/Applications/new.app')
-            mock.assert_called_once_with('rsync -a --no-compress --delete "/path/to/file.app/" '
-                                         '"/Applications/new.app"')
+            mock.assert_called_once_with('rsync -a --no-compress --delete /path/to/file.app/ '
+                                         '/Applications/new.app')
 
     def test_install_app_with_slash(self):
         '''
@@ -77,8 +77,8 @@ class MacPackageTestCase(TestCase):
         mock = MagicMock()
         with patch.dict(macpackage.__salt__, {'cmd.run': mock}):
             macpackage.install_app('/path/to/file.app/')
-            mock.assert_called_once_with('rsync -a --no-compress --delete "/path/to/file.app/" '
-                                         '"/Applications/file.app"')
+            mock.assert_called_once_with('rsync -a --no-compress --delete /path/to/file.app/ '
+                                         '/Applications/file.app')
 
     def test_uninstall(self):
         '''
@@ -94,7 +94,7 @@ class MacPackageTestCase(TestCase):
             Test mounting an dmg file to a temporary location
         '''
         cmd_mock = MagicMock()
-        temp_mock = MagicMock(return_value="dmg-ABCDEF")
+        temp_mock = MagicMock(return_value='dmg-ABCDEF')
         with patch.dict(macpackage.__salt__, {'cmd.run': cmd_mock,
                                               'temp.dir': temp_mock}):
             macpackage.mount('/path/to/file.dmg')
@@ -116,7 +116,7 @@ class MacPackageTestCase(TestCase):
             Test getting a list of the installed packages
         '''
         expected = ['com.apple.this', 'com.salt.that']
-        mock = MagicMock(return_value="com.apple.this\ncom.salt.that")
+        mock = MagicMock(return_value='com.apple.this\ncom.salt.that')
         with patch.dict(macpackage.__salt__, {'cmd.run': mock}):
             out = macpackage.installed_pkgs()
             mock.assert_called_once_with('pkgutil --pkgs')
@@ -134,7 +134,7 @@ class MacPackageTestCase(TestCase):
             ''
         ])
         pkg_id_pkginfo_mock.side_effect = [['com.apple.this'], []]
-        temp_mock = MagicMock(return_value="/tmp/dmg-ABCDEF")
+        temp_mock = MagicMock(return_value='/tmp/dmg-ABCDEF')
         remove_mock = MagicMock()
 
         with patch.dict(macpackage.__salt__, {'cmd.run': cmd_mock,
@@ -144,9 +144,9 @@ class MacPackageTestCase(TestCase):
 
             temp_mock.assert_called_once_with(prefix='pkg-')
             cmd_calls = [
-                call('xar -t -f "/path/to/file.pkg" | grep PackageInfo', python_shell=True, output_loglevel="quiet"),
-                call('xar -x -f "/path/to/file.pkg" /path/to/PackageInfo /path/to/some/other/fake/PackageInfo',
-                     cwd='/tmp/dmg-ABCDEF', output_loglevel="quiet")
+                call('xar -t -f /path/to/file.pkg | grep PackageInfo', python_shell=True, output_loglevel='quiet'),
+                call('xar -x -f /path/to/file.pkg /path/to/PackageInfo /path/to/some/other/fake/PackageInfo',
+                     cwd='/tmp/dmg-ABCDEF', output_loglevel='quiet')
             ]
             cmd_mock.assert_has_calls(cmd_calls)
 
@@ -167,7 +167,7 @@ class MacPackageTestCase(TestCase):
         expected = ['com.apple.this']
         pkg_id_dir_mock.return_value = ['com.apple.this']
         cmd_mock = MagicMock(return_value='Error opening /path/to/file.pkg')
-        temp_mock = MagicMock(return_value="/tmp/dmg-ABCDEF")
+        temp_mock = MagicMock(return_value='/tmp/dmg-ABCDEF')
         remove_mock = MagicMock()
 
         with patch.dict(macpackage.__salt__, {'cmd.run': cmd_mock,
@@ -176,8 +176,8 @@ class MacPackageTestCase(TestCase):
             out = macpackage.get_pkg_id('/path/to/file.pkg')
 
             temp_mock.assert_called_once_with(prefix='pkg-')
-            cmd_mock.assert_called_once_with('xar -t -f "/path/to/file.pkg" | grep PackageInfo',
-                                             python_shell=True, output_loglevel="quiet")
+            cmd_mock.assert_called_once_with('xar -t -f /path/to/file.pkg | grep PackageInfo',
+                                             python_shell=True, output_loglevel='quiet')
             pkg_id_dir_mock.assert_called_once_with('/path/to/file.pkg')
             remove_mock.assert_called_once_with('/tmp/dmg-ABCDEF')
 
@@ -195,7 +195,7 @@ class MacPackageTestCase(TestCase):
         with patch.dict(macpackage.__salt__, {'cmd.run': mock}):
             out = macpackage.get_mpkg_ids('/path/to/file.mpkg')
 
-            mock.assert_called_once_with('find /path/to -name "*.pkg"', python_shell=True)
+            mock.assert_called_once_with('find /path/to -name *.pkg', python_shell=True)
 
             calls = [
                 call('/tmp/dmg-X/file.pkg'),
@@ -251,7 +251,7 @@ class MacPackageTestCase(TestCase):
         mock = MagicMock(return_value='com.apple.this')
         with patch.dict(macpackage.__salt__, {'cmd.run': mock}):
             out = macpackage._get_pkg_id_dir('/tmp/dmg-X/*.pkg/')
-            cmd = '/usr/libexec/PlistBuddy -c "print :CFBundleIdentifier" /tmp/dmg-X/*.pkg/Contents/Info.plist'
+            cmd = '/usr/libexec/PlistBuddy -c "print :CFBundleIdentifier" \'/tmp/dmg-X/*.pkg/Contents/Info.plist\''
             mock.assert_called_once_with(cmd, python_shell=True)
             self.assertEqual(out, expected)
 

--- a/tests/unit/modules/mac_package_test.py
+++ b/tests/unit/modules/mac_package_test.py
@@ -190,7 +190,7 @@ class MacPackageTestCase(TestCase):
         '''
         expected = ['com.apple.this', 'com.salt.other']
         mock = MagicMock(return_value='/tmp/dmg-X/file.pkg\n/tmp/dmg-X/other.pkg')
-        get_pkg_id_mock.side_effect=[['com.apple.this'], ['com.salt.other']]
+        get_pkg_id_mock.side_effect = [['com.apple.this'], ['com.salt.other']]
 
         with patch.dict(macpackage.__salt__, {'cmd.run': mock}):
             out = macpackage.get_mpkg_ids('/path/to/file.mpkg')

--- a/tests/unit/modules/mac_package_test.py
+++ b/tests/unit/modules/mac_package_test.py
@@ -1,0 +1,260 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+from __future__ import absolute_import
+
+# Import Salt Libs
+from salt.modules import mac_package as macpackage
+
+# Import Salt Testing Libs
+from salttesting import TestCase
+from salttesting.helpers import ensure_in_syspath
+from salttesting.mock import (
+    MagicMock,
+    patch,
+    call
+)
+
+ensure_in_syspath('../../')
+
+macpackage.__salt__ = {}
+
+
+class MacPackageTestCase(TestCase):
+
+    def test_install(self):
+        '''
+            Test installing a PKG file
+        '''
+        mock = MagicMock()
+        with patch.dict(macpackage.__salt__, {'cmd.run_all': mock}):
+            macpackage.install('/path/to/file.pkg')
+            mock.assert_called_once_with('installer -pkg /path/to/file.pkg -target LocalSystem', python_shell=False)
+
+    def test_install_wildcard(self):
+        '''
+            Test installing a PKG file with a wildcard
+        '''
+        mock = MagicMock()
+        with patch.dict(macpackage.__salt__, {'cmd.run_all': mock}):
+            macpackage.install('/path/to/*.pkg')
+            mock.assert_called_once_with('installer -pkg /path/to/*.pkg -target LocalSystem', python_shell=True)
+
+    def test_install_with_extras(self):
+        '''
+            Test installing a PKG file with extra options
+        '''
+        mock = MagicMock()
+        with patch.dict(macpackage.__salt__, {'cmd.run_all': mock}):
+            macpackage.install('/path/to/file.pkg', store=True, allow_untrusted=True)
+            mock.assert_called_once_with('installer -pkg /path/to/file.pkg -target LocalSystem -store -allowUntrusted',
+                                         python_shell=False)
+
+    def test_install_app(self):
+        '''
+            Test installing an APP package
+        '''
+        mock = MagicMock()
+        with patch.dict(macpackage.__salt__, {'cmd.run': mock}):
+            macpackage.install_app('/path/to/file.app')
+            mock.assert_called_once_with('rsync -a --no-compress --delete "/path/to/file.app/" '
+                                         '"/Applications/file.app"')
+
+    def test_install_app_specify_target(self):
+        '''
+            Test installing an APP package with a specific target
+        '''
+        mock = MagicMock()
+        with patch.dict(macpackage.__salt__, {'cmd.run': mock}):
+            macpackage.install_app('/path/to/file.app', '/Applications/new.app')
+            mock.assert_called_once_with('rsync -a --no-compress --delete "/path/to/file.app/" '
+                                         '"/Applications/new.app"')
+
+    def test_install_app_with_slash(self):
+        '''
+            Test installing an APP package with a specific target
+        '''
+        mock = MagicMock()
+        with patch.dict(macpackage.__salt__, {'cmd.run': mock}):
+            macpackage.install_app('/path/to/file.app/')
+            mock.assert_called_once_with('rsync -a --no-compress --delete "/path/to/file.app/" '
+                                         '"/Applications/file.app"')
+
+    def test_uninstall(self):
+        '''
+            Test Uninstalling an APP package with a specific target
+        '''
+        mock = MagicMock()
+        with patch.dict(macpackage.__salt__, {'file.remove': mock}):
+            macpackage.uninstall_app('/path/to/file.app')
+            mock.assert_called_once_with('/path/to/file.app')
+
+    def test_mount(self):
+        '''
+            Test mounting an dmg file to a temporary location
+        '''
+        cmd_mock = MagicMock()
+        temp_mock = MagicMock(return_value="dmg-ABCDEF")
+        with patch.dict(macpackage.__salt__, {'cmd.run': cmd_mock,
+                                              'temp.dir': temp_mock}):
+            macpackage.mount('/path/to/file.dmg')
+            temp_mock.assert_called_once_with(prefix='dmg-')
+            cmd_mock.assert_called_once_with('hdiutil attach -readonly -nobrowse -mountpoint '
+                                             'dmg-ABCDEF "/path/to/file.dmg"')
+
+    def test_unmount(self):
+        '''
+            Test Unmounting an dmg file to a temporary location
+        '''
+        mock = MagicMock()
+        with patch.dict(macpackage.__salt__, {'cmd.run': mock}):
+            macpackage.unmount('/path/to/file.dmg')
+            mock.assert_called_once_with('hdiutil detach "/path/to/file.dmg"')
+
+    def test_installed_pkgs(self):
+        '''
+            Test getting a list of the installed packages
+        '''
+        expected = ['com.apple.this', 'com.salt.that']
+        mock = MagicMock(return_value="com.apple.this\ncom.salt.that")
+        with patch.dict(macpackage.__salt__, {'cmd.run': mock}):
+            out = macpackage.installed_pkgs()
+            mock.assert_called_once_with('pkgutil --pkgs')
+            self.assertEqual(out, expected)
+
+    @patch('salt.modules.mac_package._get_pkg_id_from_pkginfo')
+    def test_get_pkg_id_with_files(self, pkg_id_pkginfo_mock):
+        '''
+            Test getting a the id for a package
+        '''
+        expected = ['com.apple.this']
+        cmd_mock = MagicMock(side_effect=[
+            '/path/to/PackageInfo\n/path/to/some/other/fake/PackageInfo',
+            '',
+            ''
+        ])
+        pkg_id_pkginfo_mock.side_effect = [['com.apple.this'], []]
+        temp_mock = MagicMock(return_value="/tmp/dmg-ABCDEF")
+        remove_mock = MagicMock()
+
+        with patch.dict(macpackage.__salt__, {'cmd.run': cmd_mock,
+                                              'temp.dir': temp_mock,
+                                              'file.remove': remove_mock}):
+            out = macpackage.get_pkg_id('/path/to/file.pkg')
+
+            temp_mock.assert_called_once_with(prefix='pkg-')
+            cmd_calls = [
+                call('xar -t -f "/path/to/file.pkg" | grep PackageInfo', python_shell=True, output_loglevel="quiet"),
+                call('xar -x -f "/path/to/file.pkg" /path/to/PackageInfo /path/to/some/other/fake/PackageInfo',
+                     cwd='/tmp/dmg-ABCDEF', output_loglevel="quiet")
+            ]
+            cmd_mock.assert_has_calls(cmd_calls)
+
+            pkg_id_pkginfo_calls = [
+                call('/path/to/PackageInfo'),
+                call('/path/to/some/other/fake/PackageInfo')
+            ]
+            pkg_id_pkginfo_mock.assert_has_calls(pkg_id_pkginfo_calls)
+            remove_mock.assert_called_once_with('/tmp/dmg-ABCDEF')
+
+            self.assertEqual(out, expected)
+
+    @patch('salt.modules.mac_package._get_pkg_id_dir')
+    def test_get_pkg_id_with_dir(self, pkg_id_dir_mock):
+        '''
+            Test getting a the id for a package with a directory
+        '''
+        expected = ['com.apple.this']
+        pkg_id_dir_mock.return_value = ['com.apple.this']
+        cmd_mock = MagicMock(return_value='Error opening /path/to/file.pkg')
+        temp_mock = MagicMock(return_value="/tmp/dmg-ABCDEF")
+        remove_mock = MagicMock()
+
+        with patch.dict(macpackage.__salt__, {'cmd.run': cmd_mock,
+                                              'temp.dir': temp_mock,
+                                              'file.remove': remove_mock}):
+            out = macpackage.get_pkg_id('/path/to/file.pkg')
+
+            temp_mock.assert_called_once_with(prefix='pkg-')
+            cmd_mock.assert_called_once_with('xar -t -f "/path/to/file.pkg" | grep PackageInfo',
+                                             python_shell=True, output_loglevel="quiet")
+            pkg_id_dir_mock.assert_called_once_with('/path/to/file.pkg')
+            remove_mock.assert_called_once_with('/tmp/dmg-ABCDEF')
+
+            self.assertEqual(out, expected)
+
+    @patch('salt.modules.mac_package.get_pkg_id')
+    def test_get_mpkg_ids(self, get_pkg_id_mock):
+        '''
+            Test getting the ids of a mpkg file
+        '''
+        expected = ['com.apple.this', 'com.salt.other']
+        mock = MagicMock(return_value='/tmp/dmg-X/file.pkg\n/tmp/dmg-X/other.pkg')
+        get_pkg_id_mock.side_effect=[['com.apple.this'], ['com.salt.other']]
+
+        with patch.dict(macpackage.__salt__, {'cmd.run': mock}):
+            out = macpackage.get_mpkg_ids('/path/to/file.mpkg')
+
+            mock.assert_called_once_with('find /path/to -name "*.pkg"', python_shell=True)
+
+            calls = [
+                call('/tmp/dmg-X/file.pkg'),
+                call('/tmp/dmg-X/other.pkg')
+            ]
+            get_pkg_id_mock.assert_has_calls(calls)
+
+            self.assertEqual(out, expected)
+
+    def test_get_pkg_id_from_pkginfo(self):
+        '''
+            Test getting a package id from pkginfo files
+        '''
+        expected = ['com.apple.this', 'com.apple.that']
+        mock = MagicMock(return_value='com.apple.this\ncom.apple.that')
+        with patch.dict(macpackage.__salt__, {'cmd.run': mock}):
+            out = macpackage._get_pkg_id_from_pkginfo('/tmp/dmg-X/PackageInfo')
+            cmd = 'cat /tmp/dmg-X/PackageInfo | grep -Eo \'identifier="[a-zA-Z.0-9\\-]*"\' | ' \
+                  'cut -c 13- | tr -d \'"\''
+            mock.assert_called_once_with(cmd, python_shell=True)
+            self.assertEqual(out, expected)
+
+    def test_get_pkg_id_from_pkginfo_no_file(self):
+        '''
+            Test getting a package id from pkginfo file when it doesn't exist
+        '''
+        expected = []
+        mock = MagicMock(return_value='No such file')
+        with patch.dict(macpackage.__salt__, {'cmd.run': mock}):
+            out = macpackage._get_pkg_id_from_pkginfo('/tmp/dmg-X/PackageInfo')
+            cmd = 'cat /tmp/dmg-X/PackageInfo | grep -Eo \'identifier="[a-zA-Z.0-9\\-]*"\' | ' \
+                  'cut -c 13- | tr -d \'"\''
+            mock.assert_called_once_with(cmd, python_shell=True)
+            self.assertEqual(out, expected)
+
+    def test_get_pkg_id_dir(self):
+        '''
+            Test getting a package id from a directory
+        '''
+        expected = ['com.apple.this']
+        mock = MagicMock(return_value='com.apple.this')
+        with patch.dict(macpackage.__salt__, {'cmd.run': mock}):
+            out = macpackage._get_pkg_id_dir('/tmp/dmg-X/')
+            cmd = '/usr/libexec/PlistBuddy -c "print :CFBundleIdentifier" /tmp/dmg-X/Contents/Info.plist'
+            mock.assert_called_once_with(cmd, python_shell=False)
+            self.assertEqual(out, expected)
+
+    def test_get_pkg_id_dir_wildcard(self):
+        '''
+            Test getting a package id from a directory with a wildcard
+        '''
+        expected = ['com.apple.this']
+        mock = MagicMock(return_value='com.apple.this')
+        with patch.dict(macpackage.__salt__, {'cmd.run': mock}):
+            out = macpackage._get_pkg_id_dir('/tmp/dmg-X/*.pkg/')
+            cmd = '/usr/libexec/PlistBuddy -c "print :CFBundleIdentifier" /tmp/dmg-X/*.pkg/Contents/Info.plist'
+            mock.assert_called_once_with(cmd, python_shell=True)
+            self.assertEqual(out, expected)
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(MacPackageTestCase, needs_daemon=False)

--- a/tests/unit/states/mac_package_test.py
+++ b/tests/unit/states/mac_package_test.py
@@ -1,0 +1,373 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+from __future__ import absolute_import
+
+# Import Salt Libs
+from salt.states import mac_package as macpackage
+
+# Import Salt Testing Libs
+from salttesting import TestCase
+from salttesting.helpers import ensure_in_syspath
+from salttesting.mock import (
+    MagicMock,
+    patch
+)
+
+ensure_in_syspath('../../')
+
+macpackage.__salt__ = {}
+macpackage.__grains__ = {}
+
+
+class MacPackageTestCase(TestCase):
+
+    @patch('salt.states.mac_package._mod_run_check')
+    def test_installed_pkg(self, _mod_run_check_mock):
+        '''
+            Test installing a PKG file
+        '''
+        expected = {
+            'changes': {'installed': ['some.other.id']},
+            'comment': '/path/to/file.pkg installed',
+            'name': '/path/to/file.pkg',
+            'result': True
+        }
+
+        installed_mock = MagicMock(return_value=['com.apple.id'])
+        get_pkg_id_mock = MagicMock(return_value=['some.other.id'])
+        install_mock = MagicMock(return_value={'retcode': 0})
+        _mod_run_check_mock.return_value = True
+
+        with patch.dict(macpackage.__salt__, {'macpackage.installed_pkgs': installed_mock,
+                                              'macpackage.get_pkg_id': get_pkg_id_mock,
+                                              'macpackage.install': install_mock}):
+            out = macpackage.installed('/path/to/file.pkg')
+            installed_mock.assert_called_once_with()
+            get_pkg_id_mock.assert_called_once_with('/path/to/file.pkg')
+            install_mock.assert_called_once_with('/path/to/file.pkg', 'LocalSystem', False, False)
+            self.assertEqual(out, expected)
+
+    @patch('salt.states.mac_package._mod_run_check')
+    def test_installed_pkg_exists(self, _mod_run_check_mock):
+        '''
+            Test installing a PKG file where it's already installed
+        '''
+        expected = {
+            'changes': {},
+            'comment': '',
+            'name': '/path/to/file.pkg',
+            'result': True
+        }
+
+        installed_mock = MagicMock(return_value=['com.apple.id', 'some.other.id'])
+        get_pkg_id_mock = MagicMock(return_value=['some.other.id'])
+        install_mock = MagicMock(return_value={'retcode': 0})
+        _mod_run_check_mock.return_value = True
+
+        with patch.dict(macpackage.__salt__, {'macpackage.installed_pkgs': installed_mock,
+                                              'macpackage.get_pkg_id': get_pkg_id_mock,
+                                              'macpackage.install': install_mock}):
+            out = macpackage.installed('/path/to/file.pkg')
+            installed_mock.assert_called_once_with()
+            get_pkg_id_mock.assert_called_once_with('/path/to/file.pkg')
+            assert not install_mock.called
+            self.assertEqual(out, expected)
+
+    @patch('salt.states.mac_package._mod_run_check')
+    def test_installed_pkg_version_succeeds(self, _mod_run_check_mock):
+        '''
+            Test installing a PKG file where the version number matches the current installed version
+        '''
+        expected = {
+            'changes': {},
+            'comment': 'Version already matches .*5\\.1\\.[0-9]',
+            'name': '/path/to/file.pkg',
+            'result': True
+        }
+
+        installed_mock = MagicMock(return_value=['com.apple.id', 'some.other.id'])
+        get_pkg_id_mock = MagicMock(return_value=['some.other.id'])
+        install_mock = MagicMock(return_value={'retcode': 0})
+        cmd_mock = MagicMock(return_value='Version of this: 5.1.9')
+        _mod_run_check_mock.return_value = True
+
+        with patch.dict(macpackage.__salt__, {'macpackage.installed_pkgs': installed_mock,
+                                              'macpackage.get_pkg_id': get_pkg_id_mock,
+                                              'macpackage.install': install_mock,
+                                              'cmd.run': cmd_mock}):
+            out = macpackage.installed('/path/to/file.pkg', version_check=r'/usr/bin/runme --version=.*5\.1\.[0-9]')
+            cmd_mock.assert_called_once_with('/usr/bin/runme --version', output_loglevel="quiet", ignore_retcode=True)
+            assert not installed_mock.called
+            assert not get_pkg_id_mock.called
+            assert not install_mock.called
+            self.assertEqual(out, expected)
+
+    @patch('salt.states.mac_package._mod_run_check')
+    def test_installed_pkg_version_fails(self, _mod_run_check_mock):
+        '''
+            Test installing a PKG file where the version number if different from the expected one
+        '''
+        expected = {
+            'changes': {'installed': ['some.other.id']},
+            'comment': 'Version Version of this: 1.8.9 doesn\'t match .*5\\.1\\.[0-9]. /path/to/file.pkg installed',
+            'name': '/path/to/file.pkg',
+            'result': True
+        }
+
+        installed_mock = MagicMock(return_value=['com.apple.id'])
+        get_pkg_id_mock = MagicMock(return_value=['some.other.id'])
+        install_mock = MagicMock(return_value={'retcode': 0})
+        cmd_mock = MagicMock(return_value='Version of this: 1.8.9')
+        _mod_run_check_mock.return_value = True
+
+        with patch.dict(macpackage.__salt__, {'macpackage.installed_pkgs': installed_mock,
+                                              'macpackage.get_pkg_id': get_pkg_id_mock,
+                                              'macpackage.install': install_mock,
+                                              'cmd.run': cmd_mock}):
+            out = macpackage.installed('/path/to/file.pkg', version_check=r'/usr/bin/runme --version=.*5\.1\.[0-9]')
+            cmd_mock.assert_called_once_with('/usr/bin/runme --version', output_loglevel="quiet", ignore_retcode=True)
+            installed_mock.assert_called_once_with()
+            get_pkg_id_mock.assert_called_once_with('/path/to/file.pkg')
+            install_mock.assert_called_once_with('/path/to/file.pkg', 'LocalSystem', False, False)
+            self.assertEqual(out, expected)
+
+    @patch('salt.states.mac_package._mod_run_check')
+    def test_installed_dmg(self, _mod_run_check_mock):
+        '''
+            Test installing a DMG file
+        '''
+        expected = {
+            'changes': {'installed': ['some.other.id']},
+            'comment': '/path/to/file.dmg installed',
+            'name': '/path/to/file.dmg',
+            'result': True
+        }
+
+        mount_mock = MagicMock(return_value=['success', '/tmp/dmg-X'])
+        unmount_mock = MagicMock()
+        installed_mock = MagicMock(return_value=['com.apple.id'])
+        get_pkg_id_mock = MagicMock(return_value=['some.other.id'])
+        install_mock = MagicMock(return_value={'retcode': 0})
+        _mod_run_check_mock.return_value = True
+
+        with patch.dict(macpackage.__salt__, {'macpackage.mount': mount_mock,
+                                              'macpackage.unmount': unmount_mock,
+                                              'macpackage.installed_pkgs': installed_mock,
+                                              'macpackage.get_pkg_id': get_pkg_id_mock,
+                                              'macpackage.install': install_mock}):
+            out = macpackage.installed('/path/to/file.dmg', dmg=True)
+            mount_mock.assert_called_once_with('/path/to/file.dmg')
+            unmount_mock.assert_called_once_with('/tmp/dmg-X')
+            installed_mock.assert_called_once_with()
+            get_pkg_id_mock.assert_called_once_with('/tmp/dmg-X/*.pkg')
+            install_mock.assert_called_once_with('/tmp/dmg-X/*.pkg', 'LocalSystem', False, False)
+            self.assertEqual(out, expected)
+
+    @patch('salt.states.mac_package._mod_run_check')
+    def test_installed_dmg_exists(self, _mod_run_check_mock):
+        '''
+            Test installing a DMG file when the package already exists
+        '''
+        expected = {
+            'changes': {},
+            'comment': '',
+            'name': '/path/to/file.dmg',
+            'result': True
+        }
+
+        mount_mock = MagicMock(return_value=['success', '/tmp/dmg-X'])
+        unmount_mock = MagicMock()
+        installed_mock = MagicMock(return_value=['com.apple.id', 'some.other.id'])
+        get_pkg_id_mock = MagicMock(return_value=['some.other.id'])
+        install_mock = MagicMock(return_value={'retcode': 0})
+        _mod_run_check_mock.return_value = True
+
+        with patch.dict(macpackage.__salt__, {'macpackage.mount': mount_mock,
+                                              'macpackage.unmount': unmount_mock,
+                                              'macpackage.installed_pkgs': installed_mock,
+                                              'macpackage.get_pkg_id': get_pkg_id_mock,
+                                              'macpackage.install': install_mock}):
+            out = macpackage.installed('/path/to/file.dmg', dmg=True)
+            mount_mock.assert_called_once_with('/path/to/file.dmg')
+            unmount_mock.assert_called_once_with('/tmp/dmg-X')
+            installed_mock.assert_called_once_with()
+            get_pkg_id_mock.assert_called_once_with('/tmp/dmg-X/*.pkg')
+            assert not install_mock.called
+            self.assertEqual(out, expected)
+
+    @patch('os.path.exists')
+    @patch('salt.states.mac_package._mod_run_check')
+    def test_installed_app(self, _mod_run_check_mock, exists_mock):
+        '''
+            Test installing an APP file
+        '''
+        expected = {
+            'changes': {'installed': ['file.app']},
+            'comment': 'file.app installed',
+            'name': '/path/to/file.app',
+            'result': True
+        }
+
+        install_mock = MagicMock()
+        _mod_run_check_mock.return_value = True
+        exists_mock.return_value = False
+
+        with patch.dict(macpackage.__salt__, {'macpackage.install_app': install_mock}):
+            out = macpackage.installed('/path/to/file.app', app=True)
+
+            install_mock.assert_called_once_with('/path/to/file.app', '/Applications/')
+            self.assertEqual(out, expected)
+
+    @patch('os.path.exists')
+    @patch('salt.states.mac_package._mod_run_check')
+    def test_installed_app_exists(self, _mod_run_check_mock, exists_mock):
+        '''
+            Test installing an APP file that already exists
+        '''
+        expected = {
+            'changes': {},
+            'comment': '',
+            'name': '/path/to/file.app',
+            'result': True
+        }
+
+        install_mock = MagicMock()
+        _mod_run_check_mock.return_value = True
+        exists_mock.return_value = True
+
+        with patch.dict(macpackage.__salt__, {'macpackage.install_app': install_mock}):
+            out = macpackage.installed('/path/to/file.app', app=True)
+
+            assert not install_mock.called
+            self.assertEqual(out, expected)
+
+    @patch('os.path.exists')
+    @patch('salt.states.mac_package._mod_run_check')
+    def test_installed_app_dmg(self, _mod_run_check_mock, exists_mock):
+        '''
+            Test installing an APP file contained in a DMG file
+        '''
+        expected = {
+            'changes': {'installed': ['file.app']},
+            'comment': 'file.app installed',
+            'name': '/path/to/file.dmg',
+            'result': True
+        }
+
+        install_mock = MagicMock()
+        mount_mock = MagicMock(return_value=['success', '/tmp/dmg-X'])
+        unmount_mock = MagicMock()
+        cmd_mock = MagicMock(return_value='file.app')
+        _mod_run_check_mock.return_value = True
+        exists_mock.return_value = False
+
+        with patch.dict(macpackage.__salt__, {'macpackage.install_app': install_mock,
+                                              'macpackage.mount': mount_mock,
+                                              'macpackage.unmount': unmount_mock,
+                                              'cmd.run': cmd_mock}):
+            out = macpackage.installed('/path/to/file.dmg', app=True, dmg=True)
+
+            mount_mock.assert_called_once_with('/path/to/file.dmg')
+            unmount_mock.assert_called_once_with('/tmp/dmg-X')
+            cmd_mock.assert_called_once_with('ls -d *.app', python_shell=True, cwd='/tmp/dmg-X')
+            install_mock.assert_called_once_with('/tmp/dmg-X/file.app', '/Applications/')
+            self.assertEqual(out, expected)
+
+    @patch('os.path.exists')
+    @patch('salt.states.mac_package._mod_run_check')
+    def test_installed_app_dmg_exists(self, _mod_run_check_mock, exists_mock):
+        '''
+            Test installing an APP file contained in a DMG file where the file exists
+        '''
+        expected = {
+            'changes': {},
+            'comment': '',
+            'name': '/path/to/file.dmg',
+            'result': True
+        }
+
+        install_mock = MagicMock()
+        mount_mock = MagicMock(return_value=['success', '/tmp/dmg-X'])
+        unmount_mock = MagicMock()
+        cmd_mock = MagicMock(return_value='file.app')
+        _mod_run_check_mock.return_value = True
+        exists_mock.return_value = True
+
+        with patch.dict(macpackage.__salt__, {'macpackage.install_app': install_mock,
+                                              'macpackage.mount': mount_mock,
+                                              'macpackage.unmount': unmount_mock,
+                                              'cmd.run': cmd_mock}):
+            out = macpackage.installed('/path/to/file.dmg', app=True, dmg=True)
+
+            mount_mock.assert_called_once_with('/path/to/file.dmg')
+            unmount_mock.assert_called_once_with('/tmp/dmg-X')
+            cmd_mock.assert_called_once_with('ls -d *.app', python_shell=True, cwd='/tmp/dmg-X')
+            assert not install_mock.called
+            self.assertEqual(out, expected)
+
+    def test_installed_pkg_only_if_pass(self):
+        '''
+            Test installing a PKG file where the only if call passes
+        '''
+        expected = {
+            'changes': {'installed': ['some.other.id']},
+            'comment': '/path/to/file.pkg installed',
+            'name': '/path/to/file.pkg',
+            'result': True
+        }
+
+        installed_mock = MagicMock(return_value=['com.apple.id'])
+        get_pkg_id_mock = MagicMock(return_value=['some.other.id'])
+        install_mock = MagicMock(return_value={'retcode': 0})
+        cmd_mock = MagicMock(return_value=0)
+
+        with patch.dict(macpackage.__salt__, {'macpackage.installed_pkgs': installed_mock,
+                                              'macpackage.get_pkg_id': get_pkg_id_mock,
+                                              'macpackage.install': install_mock,
+                                              'cmd.retcode': cmd_mock}):
+            out = macpackage.installed('/path/to/file.pkg')
+            installed_mock.assert_called_once_with()
+            get_pkg_id_mock.assert_called_once_with('/path/to/file.pkg')
+            install_mock.assert_called_once_with('/path/to/file.pkg', 'LocalSystem', False, False)
+            self.assertEqual(out, expected)
+
+    def test_installed_pkg_onlyif_fail(self,):
+        '''
+            Test installing a PKG file where the onlyif call fails
+        '''
+        expected = {
+            'changes': {},
+            'comment': 'onlyif execution failed',
+            'skip_watch': True,
+            'result': True,
+            'name': '/path/to/file.pkg',
+        }
+
+        mock = MagicMock(return_value=1)
+
+        with patch.dict(macpackage.__salt__, {'cmd.retcode': mock}):
+            out = macpackage.installed('/path/to/file.pkg', onlyif='some command')
+            self.assertEqual(out, expected)
+
+    def test_installed_pkg_unless_fail(self,):
+        '''
+            Test installing a PKG file where the unless run fails
+        '''
+        expected = {
+            'changes': {},
+            'comment': 'unless execution succeeded',
+            'skip_watch': True,
+            'result': True,
+            'name': '/path/to/file.pkg',
+        }
+
+        mock = MagicMock(return_value=0)
+
+        with patch.dict(macpackage.__salt__, {'cmd.retcode': mock}):
+            out = macpackage.installed('/path/to/file.pkg', unless='some command')
+            self.assertEqual(out, expected)
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(MacPackageTestCase, needs_daemon=False)


### PR DESCRIPTION
I realise there was a pkgutil module added recently, but this is a module I've been using for quite a while in our production system and it supports all types of different package installations as well as a state for installing those packages easily.
