### PR TITLE
SyntaxError not appropriately caught.

### DIFF
--- a/tests/integration/files/file/base/script.py
+++ b/tests/integration/files/file/base/script.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python
 import sys
 
-try:
-    print ' '.join(sys.argv[1:])
-except SyntaxError:
-    print(' '.join(sys.argv[1:]))
+print(' '.join(sys.argv[1:]))


### PR DESCRIPTION
Further testing shows that python2.4 will use print() without an error.

Follow up to #30744
