### PR TITLE
salt/modules/sysrc.py: Fix documentation for set_

### DIFF
--- a/salt/modules/sysrc.py
+++ b/salt/modules/sysrc.py
@@ -82,7 +82,7 @@ def set_(name, value, **kwargs):
 
      .. code-block:: bash
 
-         salt '*' sysrc.remove name=sshd_enable
+         salt '*' sysrc.set name=sshd_flags value="-p 2222"
     '''
 
     cmd = 'sysrc -v'


### PR DESCRIPTION
set_ documentation was yank&pasted from remove without changing it.

Instead, give a proper example how to use sysrc.set.
