### PR TITLE
do not shadow ret function argument for salt.function

### DIFF
--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -340,14 +340,14 @@ def function(
     ssh
         Set to `True` to use the ssh client instead of the standard salt client
     '''
-    ret = {'name': name,
+    state_ret = {'name': name,
            'changes': {},
            'comment': '',
            'result': True}
     if kwarg is None:
         kwarg = {}
     if isinstance(arg, str):
-        ret['warnings'] = ['Please specify \'arg\' as a list, not a string. '
+        state_ret['warnings'] = ['Please specify \'arg\' as a list, not a string. '
                            'Modifying in place, but please update SLS file '
                            'to remove this warning.']
         arg = arg.split()
@@ -355,7 +355,7 @@ def function(
     cmd_kw = {'arg': arg or [], 'kwarg': kwarg, 'ret': ret, 'timeout': timeout}
 
     if expr_form and tgt_type:
-        ret['warnings'] = [
+        state_ret['warnings'] = [
             'Please only use \'tgt_type\' or \'expr_form\' not both. '
             'Preferring \'tgt_type\' over \'expr_form\''
         ]
@@ -371,17 +371,17 @@ def function(
     cmd_kw['_cmd_meta'] = True
     fun = name
     if __opts__['test'] is True:
-        ret['comment'] = (
+        state_ret['comment'] = (
                 'Function {0} will be executed on target {1} as test={2}'
                 ).format(fun, tgt, str(False))
-        ret['result'] = None
-        return ret
+        state_ret['result'] = None
+        return state_ret
     try:
         cmd_ret = __salt__['saltutil.cmd'](tgt, fun, **cmd_kw)
     except Exception as exc:
-        ret['result'] = False
-        ret['comment'] = str(exc)
-        return ret
+        state_ret['result'] = False
+        state_ret['comment'] = str(exc)
+        return state_ret
 
     changes = {}
     fail = set()
@@ -392,7 +392,7 @@ def function(
     elif isinstance(fail_minions, string_types):
         fail_minions = [minion.strip() for minion in fail_minions.split(',')]
     elif not isinstance(fail_minions, list):
-        ret.setdefault('warnings', []).append(
+        state_ret.setdefault('warnings', []).append(
             '\'fail_minions\' needs to be a list or a comma separated '
             'string. Ignored.'
         )
@@ -400,7 +400,7 @@ def function(
     for minion, mdata in six.iteritems(cmd_ret):
         m_ret = False
         if mdata.get('retcode'):
-            ret['result'] = False
+            state_ret['result'] = False
             fail.add(minion)
         if mdata.get('failed', False):
             m_func = False
@@ -417,22 +417,22 @@ def function(
             continue
         changes[minion] = m_ret
     if not cmd_ret:
-        ret['result'] = False
-        ret['command'] = 'No minions responded'
+        state_ret['result'] = False
+        state_ret['command'] = 'No minions responded'
     else:
         if changes:
-            ret['changes'] = {'out': 'highstate', 'ret': changes}
+            state_ret['changes'] = {'out': 'highstate', 'ret': changes}
         if fail:
-            ret['result'] = False
-            ret['comment'] = 'Running function {0} failed on minions: {1}'.format(name, ', '.join(fail))
+            state_ret['result'] = False
+            state_ret['comment'] = 'Running function {0} failed on minions: {1}'.format(name, ', '.join(fail))
         else:
-            ret['comment'] = 'Function ran successfully.'
+            state_ret['comment'] = 'Function ran successfully.'
         if changes:
-            ret['comment'] += ' Function {0} ran on {1}.'.format(name, ', '.join(changes))
+            state_ret['comment'] += ' Function {0} ran on {1}.'.format(name, ', '.join(changes))
         if failures:
-            ret['comment'] += '\nFailures:\n'
+            state_ret['comment'] += '\nFailures:\n'
             for minion, failure in six.iteritems(failures):
-                ret['comment'] += '\n'.join(
+                state_ret['comment'] += '\n'.join(
                         (' ' * 4 + l)
                         for l in salt.output.out_format(
                             {minion: failure},
@@ -440,8 +440,8 @@ def function(
                             __opts__,
                             ).splitlines()
                         )
-                ret['comment'] += '\n'
-    return ret
+                state_ret['comment'] += '\n'
+    return state_ret
 
 
 def wait_for_event(


### PR DESCRIPTION
This elaborates on the fix for the #29161 issue. It  fixes the ret function for salt.funciton in addition to state.state which is fixed in PR #29207

This fixes the ability to user a returner in an orchestration sls file for salt.function. `ret` is being used as both the variable for setting the returner and the return status. 
