### PR TITLE
Decouple jboss7.deployed from Artifactory

### DIFF
--- a/salt/states/jboss7.py
+++ b/salt/states/jboss7.py
@@ -370,7 +370,7 @@ def __validate_arguments(jboss_config, salt_source):
     if salt_source is None:
         result = False
         comment = __append_comment('No salt_source defined', comment)
-    result, comment = __check_dict_contains(salt_source, 'salt_source', ['source', 'target_file'], comment, result)
+    result, comment = __check_dict_contains(salt_source, 'salt_source', ['target_file'], comment, result)
     return result, comment
 
 

--- a/salt/states/jboss7.py
+++ b/salt/states/jboss7.py
@@ -277,12 +277,12 @@ def deployed(name, jboss_config, salt_source=None):
         Dict with connection properties (see state description)
     salt_source:
         How to find the artifact to be deployed.
-            target_file
-                Temporary file on minion to save file to (eg. '/tmp/application-web-0.39.war')
-            source
-                (optional) File on salt master (eg. salt://application-web-0.39.war).  If absent, only target_file will be considered.
-            undeploy
-                (optional) Regular expression to match against existing deployments. If present, and there is a deployment that matches the regular expression, then it will be undeployed before the new artifact is deployed.
+            target_file:
+                Where to look in the minion's file system for the artifact to be deployed (e.g. '/tmp/application-web-0.39.war').  When source is specified,  also specifies where to save the retrieved file.
+            source:
+                (optional) File on salt master (e.g. salt://application-web-0.39.war).  If absent, no files will be retrieved and the artifact in target_file will be used for the deployment.
+            undeploy:
+                (optional) Regular expression to match against existing deployments.  When present, if there is a deployment that matches the regular expression, it will be undeployed before the new artifact is deployed.
 
     Examples:
 

--- a/salt/states/jboss7.py
+++ b/salt/states/jboss7.py
@@ -379,7 +379,7 @@ def __find_deployment(jboss_config, salt_source=None):
     success = True
     comment = ''
     deployments = __salt__['jboss7.list_deployments'](jboss_config)
-    if salt_source is not None and salt_source['undeploy']:
+    if salt_source is not None and 'undeploy' in salt_source and salt_source['undeploy']:
         deployment_re = re.compile(salt_source['undeploy'])
         for deployment in deployments:
             if deployment_re.match(deployment):

--- a/salt/states/jboss7.py
+++ b/salt/states/jboss7.py
@@ -4,9 +4,9 @@ Manage JBoss 7 Application Server via CLI interface
 
 .. versionadded:: 2015.5.0
 
-This state uses jboss-cli.sh script from JBoss installation and parses its output to determine execution result.
+This state uses the jboss-cli.sh script from a JBoss or Wildfly installation and parses its output to determine the execution result.
 
-In order to run each state, jboss_config dictionary with the following properties must be passed:
+In order to run each state, a jboss_config dictionary with the following properties must be passed:
 
 .. code-block:: yaml
 
@@ -16,61 +16,22 @@ In order to run each state, jboss_config dictionary with the following propertie
       cli_user: 'jbossadm'
       cli_password: 'jbossadm'
 
-If controller doesn't require password, then passing cli_user and cli_password parameters is not obligatory.
+If the controller doesn't require a password, then the cli_user and cli_password parameters are optional.
 
-Example of application deployment:
+Since same dictionary with configuration will be used in all the states, it may be more convenient to move JBoss configuration and other properties
+to the pillar.
 
-.. code-block:: yaml
-
-     application_deployed:
-      jboss7.deployed:
-       - artifact:
-           artifactory_url: http://artifactory.intranet.example.com/artifactory
-           repository: 'ext-release-local'
-           artifact_id: 'webcomponent'
-           group_id: 'com.company.application'
-           packaging: 'war'
-           version: '0.1'
-           target_dir: '/tmp'
-        - jboss_config:
-           cli_path: '/opt/jboss/jboss-7.0/bin/jboss-cli.sh'
-           controller: 10.11.12.13:9999
-           cli_user: 'jbossadm'
-           cli_password: 'jbossadm'
-
-Since same dictionary with configuration will be used in all the states, it is much more convenient to move jboss configuration and other properties
-to pillar. For example, configuration of jboss server, artifactory address and application version could be moved to pillars:
+Example of application deployment from local filesystem:
 
 .. code-block:: yaml
 
      application_deployed:
-      jboss7.deployed:
-       - artifact:
-           artifactory_url: {{ pillar['artifactory']['url'] }}
-           repository: {{ pillar['artifactory']['repository'] }}
-           artifact_id: 'webcomponent'
-           group_id: 'com.company.application'
-           packaging: 'war'
-           version: {{ pillar['webcomponent-artifact']['version'] }}
-           latest_snapshot: {{ pillar['webcomponent-artifact']['latest_snapshot'] }}
-           repository: {{ pillar['webcomponent-artifact']['repository'] }}
-       - jboss_config: {{ pillar['jboss'] }}
+       jboss7.deployed:
+         - salt_source:
+             target_file: '/tmp/webapp.war'
+         - jboss_config: {{ pillar['jboss'] }}
 
-
-Configuration in pillars:
-
-.. code-block:: yaml
-
-   artifactory:
-      url: 'http://artifactory.intranet.example.com/artifactory'
-      repository: 'libs-snapshots-local'
-
-   webcomponent-artifact:
-      repository: 'libs-snapshots-local'
-      latest_snapshot: True
-      version: -1 #If latest_snapshot then version is ignored
-
-For the sake of brevity, examples for each state assume that jboss_config is moved to pillars.
+For the sake of brevity, examples for each state assume that jboss_config is contained in the pillar.
 
 
 '''
@@ -310,38 +271,37 @@ def __log_binding_change(changes, type_, key, new, old=None):
 
 
 def deployed(name, jboss_config, artifact=None, salt_source=None):
-    '''
-    Ensures that the given application is deployed on server.
+    '''Ensures that the given application is deployed on server.
 
     jboss_config:
         Dict with connection properties (see state description)
-    artifact:
-        If set, the artifact will be fetched from artifactory. This is a Dict object with the following properties:
-           - artifactory_url: Full url to artifactory instance, for example: http://artifactory.intranet.example.com/artifactory
-           - repository: One of the repositories, for example: libs-snapshots, ext-release-local, etc..
-           - artifact_id: Artifact ID of the artifact
-           - group_id: Group ID of the artifact
-           - packaging: war/jar/ear, etc...
-           - version: Artifact version. If latest_snapshot is set to True, the value of this attribute will be ignored, and newest snapshot will be taken instead.
-           - latest_snapshot: If set to True and repository is a snapshot repository it will automatically select the newest snapshot.
-           - snapshot_version: Exact version of the snapshot (with timestamp). A snapshot version may have several builds and a way to differentiate is to provide a build timestamp.
-           - target_dir: Temporary directory on minion where artifacts will be downloaded
     salt_source:
-        If set, the artifact to be deployed will be fetched from salt master. This is a Dict object with the following properties:
-           - source: File on salt master (eg. salt://application-web-0.39.war)
-           - target_file: Temporary file on minion to save file to (eg. '/tmp/application-web-0.39.war')
-           - undeploy: Regular expression to match against existing deployments. If any deployment matches the regular expression then it will be undeployed.
-
-    The deployment consists of the following steps:
-
-    * Fetch artifact (salt filesystem, artifact or filesystem on minion)
-    * Check if same artifact is not deployed yet (perhaps with different version)
-    * Undeploy the artifact if it is already deployed
-    * Deploy the new artifact
+        How to find the artifact to be deployed.
+            target_file
+                Temporary file on minion to save file to (eg. '/tmp/application-web-0.39.war')
+            source
+                (optional) File on salt master (eg. salt://application-web-0.39.war).  If absent, only target_file will be considered.
+            undeploy
+                (optional) Regular expression to match against existing deployments. If present, and there is a deployment that matches the regular expression, then it will be undeployed before the new artifact is deployed.
 
     Examples:
 
-    Deployment of a file from Salt file system:
+    Deployment of a file from minion's local file system:
+
+    .. code-block:: yaml
+
+        application_deployed:
+          jboss7.deployed:
+            - salt_source:
+                target_file: '/tmp/webapp.war'
+            - jboss_config: {{ pillar['jboss'] }}
+
+    It is assumed that /tmp/webapp.war was made available by some
+    other means.  No applications will be undeployed; if an existing
+    deployment that shares that name exists, then it will be replaced
+    with the updated version.
+
+    Deployment of a file from the Salt master's file system:
 
     .. code-block:: yaml
 
@@ -357,101 +317,10 @@ def deployed(name, jboss_config, artifact=None, salt_source=None):
     Existing deployments are checked if any of them matches 'application-web-.*' regular expression, and if so then it
     is undeployed before deploying the application. This is useful to automate deployment of new application versions.
 
-    JBoss state is capable of deploying artifacts directly from Artifactory repository. Here are some examples of deployments:
-
-    1) Deployment of released version of artifact from Artifactory.
-
-    .. code-block:: yaml
-
-            application_deployed:
-              jboss7.deployed:
-               - artifact:
-                   artifactory_url: http://artifactory.intranet.example.com/artifactory
-                   repository: 'ext-release-local'
-                   artifact_id: 'webcomponent'
-                   group_id: 'com.company.application'
-                   packaging: 'war'
-                   version: '0.1'
-                   target_dir: '/tmp'
-                - jboss_config: {{ pillar['jboss'] }}
-
-    This performs the following operations:
-
-    * Download artifact from artifactory. In the example above the artifact will be fetched from: http://artifactory.intranet.example.com/artifactory/ext-release-local/com/company/application/webcomponent/0.1/webcomponent-0.1.war
-      As a rule, for released versions the artifacts are downloaded from: artifactory_url/repository/group_id_with_slashed_instead_of_dots/artifact_id/version/artifact_id-version.packaging'
-      This follows artifactory convention for artifact resolution. By default the artifact will be downloaded to /tmp directory on minion.
-    * Connect to JBoss via controller (defined in jboss_config dict) and check if the artifact is not deployed already. In case of artifactory
-      it will check if any deployment's name starts with artifact_id value. If deployment already exists it will be undeployed
-    * Deploy the downloaded artifact to JBoss via cli interface.
-
-    2) Deployment of last updated version of given SNAPSHOT version of artifact from Artifactory.
-
-    .. code-block:: yaml
-
-        application_deployed:
-          jboss7.deployed:
-           - artifact:
-               artifactory_url: http://artifactory.intranet.example.com/artifactory
-               repository: 'ext-snapshot-local'
-               artifact_id: 'webcomponent'
-               group_id: 'com.company.application'
-               packaging: 'war'
-               version: '0.1-SNAPSHOT'
-            - jboss_config: {{ pillar['jboss'] }}
-
-    Deploying snapshot version involves an additional step of resolving the exact version of the artifact (including the timestamp), which
-    is not necessary when deploying a release.
-    In the example above first a request will be made to retrieve the update timestamp from:
-    http://artifactory.intranet.example.com/artifactory/ext-snapshot-local/com/company/application/webcomponent/0.1-SNAPSHOT/maven-metadata.xml
-    Then the artifact will be fetched from
-    http://artifactory.intranet.example.com/artifactory/ext-snapshot-local/com/company/application/webcomponent/0.1-SNAPSHOT/webcomponent-RESOLVED_SNAPSHOT_VERSION.war
-
-    .. note:: In order to perform a snapshot deployment you have to:
-
-        * Set repository to a snapshot repository.
-        * Choose a version that ends with "SNAPSHOT" string.
-          Snapshot repositories have a different layout and provide some extra information that is needed for deployment of the last or a specific snapshot.
-
-    3) Deployment of SNAPSHOT version (with exact timestamp) of artifact from Artifactory.
-
-    If you need to deploy an exact version of the snapshot you may provide snapshot_version parameter.
-
-    .. code-block:: yaml
-
-        application_deployed:
-          jboss7.deployed:
-           - artifact:
-               artifactory_url: http://artifactory.intranet.example.com/artifactory
-               repository: 'ext-snapshot-local'
-               artifact_id: 'webcomponent'
-               group_id: 'com.company.application'
-               packaging: 'war'
-               version: '0.1-SNAPSHOT'
-               snapshot_version: '0.1-20141023.131756-19'
-            - jboss_config: {{ pillar['jboss'] }}
-
-
-    In this example the artifact will be retrieved from:
-    http://artifactory.intranet.example.com/artifactory/ext-snapshot-local/com/company/application/webcomponent/0.1-SNAPSHOT/webcomponent-0.1-20141023.131756-19.war
-
-    4) Deployment of latest snapshot of artifact from Artifactory.
-
-    .. code-block:: yaml
-
-        application_deployed:
-          jboss7.deployed:
-           - artifact:
-               artifactory_url: http://artifactory.intranet.example.com/artifactory
-               repository: 'ext-snapshot-local'
-               artifact_id: 'webcomponent'
-               group_id: 'com.company.application'
-               packaging: 'war'
-               latest_snapshot: True
-            - jboss_config: {{ pillar['jboss'] }}
-
-    Instead of providing an exact version of a snapshot it is sometimes more convenient to get the newest version. If artifact.latest_snapshot
-    is set to True, then the newest snapshot will be downloaded from Artifactory. In this case it is not necessary to specify version.
-    This is particulary useful when integrating with CI tools that will deploy the current snapshot to the Artifactory.
+    If the source parameter of salt_source is specified, it can use
+    any protocol that the file states use.  This includes not only
+    downloading from the master but also HTTP, HTTPS, FTP,
+    Amazon S3, and OpenStack Swift.
 
     '''
     log.debug(" ======================== STATE: jboss7.deployed (name: %s) ", name)
@@ -462,12 +331,11 @@ def deployed(name, jboss_config, artifact=None, salt_source=None):
 
     comment = ''
 
-    validate_success, validate_comment = __validate_arguments(jboss_config, artifact, salt_source)
+    validate_success, validate_comment = __validate_arguments(jboss_config, salt_source)
     if not validate_success:
         return _error(ret, validate_comment)
 
-    log.debug('artifact=%s', str(artifact))
-    resolved_source, get_artifact_comment = __get_artifact(artifact, salt_source)
+    resolved_source, get_artifact_comment = __get_artifact(salt_source)
     log.debug('resolved_source=%s', resolved_source)
     log.debug('get_artifact_comment=%s', get_artifact_comment)
 
@@ -475,7 +343,7 @@ def deployed(name, jboss_config, artifact=None, salt_source=None):
     if resolved_source is None:
         return _error(ret, get_artifact_comment)
 
-    find_success, deployment, find_comment = __find_deployment(jboss_config, artifact, salt_source)
+    find_success, deployment, find_comment = __find_deployment(jboss_config, salt_source)
     if not find_success:
         return _error(ret, find_comment)
 
@@ -497,46 +365,21 @@ def deployed(name, jboss_config, artifact=None, salt_source=None):
     return ret
 
 
-def __validate_arguments(jboss_config, artifact, salt_source):
+def __validate_arguments(jboss_config, salt_source):
     result, comment = __check_dict_contains(jboss_config, 'jboss_config', ['cli_path', 'controller'])
-    if artifact is None and salt_source is None:
+    if salt_source is None:
         result = False
-        comment = __append_comment('No salt_source or artifact defined', comment)
-    if artifact:
-        result, comment = __check_dict_contains(artifact, 'artifact', ['artifactory_url', 'repository', 'artifact_id', 'group_id', 'packaging'], comment, result)
-        if 'latest_snapshot' in artifact and isinstance(artifact['latest_snapshot'], str):
-            if artifact['latest_snapshot'] == 'True':
-                artifact['latest_snapshot'] = True
-            elif artifact['latest_snapshot'] == 'False':
-                artifact['latest_snapshot'] = False
-            else:
-                result = False
-                comment = __append_comment('Cannot convert jboss_config.latest_snapshot={0} to boolean'.format(artifact['latest_snapshot']), comment)
-        if 'version' not in artifact and ('latest_snapshot' not in artifact or not artifact['latest_snapshot']):
-            result = False
-            comment = __append_comment('No version or latest_snapshot=True in artifact')
-    if salt_source:
-        result, comment = __check_dict_contains(salt_source, 'salt_source', ['source', 'target_file'], comment, result)
-
+        comment = __append_comment('No salt_source defined', comment)
+    result, comment = __check_dict_contains(salt_source, 'salt_source', ['source', 'target_file'], comment, result)
     return result, comment
 
 
-def __find_deployment(jboss_config, artifact=None, salt_source=None):
+def __find_deployment(jboss_config, salt_source=None):
     result = None
     success = True
     comment = ''
     deployments = __salt__['jboss7.list_deployments'](jboss_config)
-    if artifact is not None:
-        for deployment in deployments:
-            if deployment.startswith(artifact['artifact_id']):
-                if result is not None:
-                    success = False
-                    comment = "More than one deployment's name starts with {0}. \n" \
-                              "For deployments from artifactory existing deployments on JBoss are searched to find one that starts with artifact_id.\n"\
-                              "Existing deployments: {1}".format(artifact['artifact_id'], ",".join(deployments))
-                else:
-                    result = deployment
-    elif salt_source is not None and salt_source['undeploy']:
+    if salt_source is not None and salt_source['undeploy']:
         deployment_re = re.compile(salt_source['undeploy'])
         for deployment in deployments:
             if deployment_re.match(deployment):
@@ -551,29 +394,19 @@ def __find_deployment(jboss_config, artifact=None, salt_source=None):
     return success, result, comment
 
 
-def __get_artifact(artifact, salt_source):
+def __get_artifact(salt_source):
     resolved_source = None
     comment = None
 
-    if artifact is None and salt_source is None:
-        log.debug('artifact == None and salt_source == None')
-        comment = 'No salt_source or artifact defined'
-    elif isinstance(artifact, dict):
-        log.debug('artifact from artifactory')
-        try:
-            fetch_result = __fetch_from_artifactory(artifact)
-            log.debug('fetch_result={0}'.format(fetch_result))
-        except Exception as exception:
-            log.debug(traceback.format_exc())
-            return None, exception
+    if salt_source is None:
+        log.debug('salt_source == None')
+        comment = 'No salt_source defined'
 
-        if fetch_result['status']:
-            resolved_source = fetch_result['target_file']
-            comment = fetch_result['comment']
-        else:
-            comment = 'Cannot fetch artifact (artifactory comment:{0}) '.format(fetch_result['comment'])
     elif isinstance(salt_source, dict):
         log.debug('file from salt master')
+
+        # TODO: handle case when copying from salt://
+        # TODO: handle case when artifact present in local filesystem
 
         try:
             sfn, source_sum, comment_ = __salt__['file.get_managed'](
@@ -615,47 +448,6 @@ def __get_artifact(artifact, salt_source):
             comment = 'Unable to manage file: {0}'.format(e)
 
     return resolved_source, comment
-
-
-def __fetch_from_artifactory(artifact):
-    target_dir = '/tmp'
-    if 'temp_dir' in artifact:
-        target_dir = artifact['temp_dir']
-
-    if 'latest_snapshot' in artifact and artifact['latest_snapshot']:
-        fetch_result = __salt__['artifactory.get_latest_snapshot'](artifactory_url=artifact['artifactory_url'],
-                                                                   repository=artifact['repository'],
-                                                                   group_id=artifact['group_id'],
-                                                                   artifact_id=artifact['artifact_id'],
-                                                                   packaging=artifact['packaging'],
-                                                                   target_dir=target_dir)
-    elif str(artifact['version']).endswith('SNAPSHOT'):
-        if 'snapshot_version' in artifact:
-            fetch_result = __salt__['artifactory.get_snapshot'](artifactory_url=artifact['artifactory_url'],
-                                                                repository=artifact['repository'],
-                                                                group_id=artifact['group_id'],
-                                                                artifact_id=artifact['artifact_id'],
-                                                                packaging=artifact['packaging'],
-                                                                version=artifact['version'],
-                                                                snapshot_version=artifact['snapshot_version'],
-                                                                target_dir=target_dir)
-        else:
-            fetch_result = __salt__['artifactory.get_snapshot'](artifactory_url=artifact['artifactory_url'],
-                                                                repository=artifact['repository'],
-                                                                group_id=artifact['group_id'],
-                                                                artifact_id=artifact['artifact_id'],
-                                                                packaging=artifact['packaging'],
-                                                                version=artifact['version'],
-                                                                target_dir=target_dir)
-    else:
-        fetch_result = __salt__['artifactory.get_release'](artifactory_url=artifact['artifactory_url'],
-                                                           repository=artifact['repository'],
-                                                           group_id=artifact['group_id'],
-                                                           artifact_id=artifact['artifact_id'],
-                                                           packaging=artifact['packaging'],
-                                                           version=artifact['version'],
-                                                           target_dir=target_dir)
-    return fetch_result
 
 
 def reloaded(name, jboss_config, timeout=60, interval=5):

--- a/salt/states/jboss7.py
+++ b/salt/states/jboss7.py
@@ -446,9 +446,9 @@ def __get_artifact(salt_source):
                 log.debug(traceback.format_exc())
                 comment = 'Unable to manage file: {0}'.format(e)
 
-        else:
-            resolved_source = salt_source['target_file']
-            comment = ''
+            else:
+                resolved_source = salt_source['target_file']
+                comment = ''
 
     return resolved_source, comment
 

--- a/salt/states/jboss7.py
+++ b/salt/states/jboss7.py
@@ -448,6 +448,7 @@ def __get_artifact(salt_source):
 
         else:
             resolved_source = salt_source['target_file']
+            comment = ''
 
     return resolved_source, comment
 


### PR DESCRIPTION
Fix issue #30515 by purging Artifactory-specific functionality.  Documentation adjusted accordingly.

Verified that deployments with and without remote fetch of the artifact work.  Sample state file:

``` yaml
minimal_deployed:
  jboss7.deployed:
    - salt_source:
        source: salt://webapps/minimal.war
        target_file: "/tmp/minimal.war"
    - jboss_config:
        controller: "127.0.0.1:9999"
        cli_path: "/opt/wildfly/bin/jboss-cli.sh"
```

For testing a no-fetch deployment, remove `source:` from the file above.

You must supploy your own `minimal.war` and JBoss installation.  I was using Wildfly 8.2.0.Final installed in `/opt/wildfly`.
