### PR TITLE
Properly set the default value for pillar_merge_lists

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -636,7 +636,7 @@ class Pillar(object):
                                         nstate,
                                         self.merge_strategy,
                                         self.opts.get('renderer', 'yaml'),
-                                        self.opts.get('pillar_merge_lists', 'False'))
+                                        self.opts.get('pillar_merge_lists', False))
 
                                 if err:
                                     errors += err
@@ -674,7 +674,7 @@ class Pillar(object):
                         pstate,
                         self.merge_strategy,
                         self.opts.get('renderer', 'yaml'),
-                        self.opts.get('pillar_merge_lists', 'False'))
+                        self.opts.get('pillar_merge_lists', False))
 
         return pillar, errors
 
@@ -761,7 +761,7 @@ class Pillar(object):
                     ext,
                     self.merge_strategy,
                     self.opts.get('renderer', 'yaml'),
-                    self.opts.get('pillar_merge_lists', 'False'))
+                    self.opts.get('pillar_merge_lists', False))
                 ext = None
         return pillar
 
@@ -779,7 +779,7 @@ class Pillar(object):
                                self.opts['pillar'],
                                self.merge_strategy,
                                self.opts.get('renderer', 'yaml'),
-                               self.opts.get('pillar_merge_lists', 'False'))
+                               self.opts.get('pillar_merge_lists', False))
             else:
                 matches = self.top_matches(top)
                 pillar, errors = self.render_pillar(matches)

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -262,7 +262,7 @@ def ext_pillar(minion_id, repo, pillar_dirs):
         )
         merge_lists = __opts__.get(
             'pillar_merge_lists',
-            'False'
+            False
         )
         for pillar_dir, env in six.iteritems(pillar.pillar_dirs):
             log.debug(


### PR DESCRIPTION
Issue: #30809
Related PRs: #30062 #30458 

Note that I still can't get the master option `pillar_merge_lists` to actually do anything, but that's not my problem. This merely fixes the default behavior so that it's consistent with previous 2015.8 releases.

Alternatively, you could just revert the pull requests linked above.

IMO, this should be reason for a bugfix release.
