### PR TITLE
Fix for win_network changing dhcp to static DNS

### DIFF
--- a/salt/states/win_network.py
+++ b/salt/states/win_network.py
@@ -181,6 +181,11 @@ def _changes(cur, dns_proto, dns_servers, ip_proto, ip_addrs, gateway):
             changes['dns_servers'] = dns_servers
     elif 'DNS servers configured through DHCP' in cur:
         cur_dns_servers = cur['DNS servers configured through DHCP']
+        if dns_proto == 'static':
+            # If we're currently set to 'dhcp' but moving to 'static', specify the changes.
+            if set(dns_servers or ['None']) != set(cur_dns_servers):
+                changes['dns_servers'] = dns_servers
+
     cur_ip_proto = 'static' if cur['DHCP enabled'] == 'No' else 'dhcp'
     cur_ip_addrs = _addrdict_to_ip_addrs(cur.get('ip_addrs', []))
     cur_gateway = cur.get('Default Gateway')


### PR DESCRIPTION
This fixes a bug that happens when managing network configuration for Windows hosts.

If the current mode is 'dhcp' but the state specifies 'static', the state fails with a generic error "Failed to set desired configuration settings for interface {IFACE}"

This is because the changes['dns_servers'] value doesn't get set so the win_ip module doesn't get invoked later on.

This can be reproduced by creating a Windows VM with DNS set to DHCP and running the following state config.

``` yaml
Ethernet:
  network.managed:
    - ip_proto: dhcp
    - dns_proto: static
    - dns_servers:
      - 8.8.8.8
      - 8.8.4.4
```
