### PR TITLE
Make sure setting list_user_permissions to ['', '', ''] doesn't stacktrace

### DIFF
--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -81,7 +81,8 @@ def _strip_listing_to_done(output_list):
 
 
 def _output_to_dict(cmdoutput, values_mapper=None):
-    '''Convert rabbitmqctl output to a dict of data
+    '''
+    Convert rabbitmqctl output to a dict of data
     cmdoutput: string output of rabbitmqctl commands
     values_mapper: function object to process the values part of each line
     '''
@@ -93,7 +94,18 @@ def _output_to_dict(cmdoutput, values_mapper=None):
     data_rows = _strip_listing_to_done(cmdoutput.splitlines())
 
     for row in data_rows:
-        key, values = row.split('\t', 1)
+        try:
+            key, values = row.split('\t', 1)
+        except ValueError:
+            # If we have reached this far, we've hit an edge case where the row
+            # only has one item: the key. The key doesn't have any values, so we
+            # set it to an empty string to preserve rabbitmq reporting behavior.
+            # e.g. A user's permission string for '/' is set to ['', '', ''],
+            # Rabbitmq reports this only as '/' from the rabbitmqctl command.
+            log.debug('Could not find any values for key \'{0}\'. '
+                      'Setting to \'{0}\' to an empty string.'.format(row))
+            ret[row] = ''
+            continue
         ret[key] = values_mapper(values)
     return ret
 

--- a/salt/states/rabbitmq_user.py
+++ b/salt/states/rabbitmq_user.py
@@ -59,7 +59,13 @@ def _check_perms_changes(name, newperms, runas=None, existing=None):
     for vhost_perms in newperms:
         for vhost, perms in vhost_perms.iteritems():
             if vhost in existing:
-                if perms != existing[vhost]:
+                existing_vhost = existing[vhost]
+                if perms != existing_vhost:
+                    # This checks for setting permissions to nothing in the state,
+                    # when previous state runs have already set permissions to
+                    # nothing. We don't want to report a change in this case.
+                    if existing_vhost == '' and perms == ['', '', '']:
+                        continue
                     perm_need_change = True
             else:
                 perm_need_change = True

--- a/salt/states/rabbitmq_user.py
+++ b/salt/states/rabbitmq_user.py
@@ -79,7 +79,7 @@ def _check_tags_changes(name, new_tags, runas=None):
         except CommandExecutionError as err:
             log.error('Error: {0}'.format(err))
             return []
-        return users
+        return list(users)
     else:
         return []
 


### PR DESCRIPTION
And doesn't report changes on secondary state runs. Also fixed a bug in the state return when checking for new tags in rabbitmq_user state.

Fixes #28971
