### PR TITLE
Fix regression in scanning for state with 'name' param

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -190,7 +190,7 @@ def find_name(name, state, high):
                         if len(arg) != 1:
                             continue
                         if arg[next(iter(arg))] == name:
-                            ext_id.append((name, state))
+                            ext_id.append((nid, state))
     return ext_id
 
 


### PR DESCRIPTION
6d747df broke this by returing the name being searched for instead of
the state ID, causing the traceback found in #30820.

This fixes #30820 by returning the state ID and not the desired name.

cc: @jacksontj
