### PR TITLE
Perform initial gitfs/git_pillar fetch when init'ing remotes on masterless minion

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -1758,7 +1758,7 @@ class GitBase(object):
                 repo_obj.root = repo_obj.root.rstrip(os.path.sep)
                 # Sanity check and assign the credential parameter
                 repo_obj.verify_auth()
-                if repo_obj.new:
+                if self.opts['__role'] == 'minion' and repo_obj.new:
                     # Perform initial fetch
                     repo_obj.fetch()
                 self.remotes.append(repo_obj)

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -565,6 +565,7 @@ class GitPython(GitProvider):
                                      'remote.origin.fetch',
                                      '+refs/tags/*:refs/tags/*')
                 self.repo.git.config('http.sslVerify', self.ssl_verify)
+                self.fetch()
             except os.error:
                 # This exception occurs when two processes are trying to write
                 # to the git config at once, go ahead and pass over it since

--- a/tests/integration/fileserver/gitfs_test.py
+++ b/tests/integration/fileserver/gitfs_test.py
@@ -93,7 +93,8 @@ class GitFSTest(integration.ModuleCase):
 
         with patch.dict(gitfs.__opts__, {'cachedir': self.master_opts['cachedir'],
                                          'gitfs_remotes': ['file://' + self.tmp_repo_dir],
-                                         'sock_dir': self.master_opts['sock_dir']}):
+                                         'sock_dir': self.master_opts['sock_dir'],
+                                         '__role': self.master_opts['__role']}):
             gitfs.update()
 
     def tearDown(self):
@@ -108,7 +109,8 @@ class GitFSTest(integration.ModuleCase):
     def test_file_list(self):
         with patch.dict(gitfs.__opts__, {'cachedir': self.master_opts['cachedir'],
                                          'gitfs_remotes': ['file://' + self.tmp_repo_dir],
-                                         'sock_dir': self.master_opts['sock_dir']}):
+                                         'sock_dir': self.master_opts['sock_dir'],
+                                         '__role': self.master_opts['__role']}):
             ret = gitfs.file_list(LOAD)
             self.assertIn('testfile', ret)
 
@@ -116,7 +118,8 @@ class GitFSTest(integration.ModuleCase):
     def test_dir_list(self):
         with patch.dict(gitfs.__opts__, {'cachedir': self.master_opts['cachedir'],
                                          'gitfs_remotes': ['file://' + self.tmp_repo_dir],
-                                         'sock_dir': self.master_opts['sock_dir']}):
+                                         'sock_dir': self.master_opts['sock_dir'],
+                                         '__role': self.master_opts['__role']}):
             ret = gitfs.dir_list(LOAD)
             self.assertIn('grail', ret)
 
@@ -124,7 +127,8 @@ class GitFSTest(integration.ModuleCase):
     def test_envs(self):
         with patch.dict(gitfs.__opts__, {'cachedir': self.master_opts['cachedir'],
                                          'gitfs_remotes': ['file://' + self.tmp_repo_dir],
-                                         'sock_dir': self.master_opts['sock_dir']}):
+                                         'sock_dir': self.master_opts['sock_dir'],
+                                         '__role': self.master_opts['__role']}):
             ret = gitfs.envs()
             self.assertIn('base', ret)
 


### PR DESCRIPTION
This pull request incorporates pull #30703, building upon it so that all GitProvider subclasses are supported.

It also restricts this initial fetch to standalone minions only, to suppress a warning on the initial fetch when the master's maintenance process tries to fetch all gitfs/git_pillar remotes on startup.
