### PR TITLE
modules.dpkg._get_pkg_info: allow for ubuntu 12.04

### DIFF
--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -254,8 +254,13 @@ def _get_pkg_info(*packages):
     :return:
     '''
 
+    if __grains__['os'] == 'Ubuntu' and __grains__['osrelease_info'] <= (12, 4):
+        bin_var = '${binary}'
+    else:
+        bin_var = '${binary:Package}'
+
     ret = []
-    cmd = "dpkg-query -W -f='package:${binary:Package}\\n" \
+    cmd = "dpkg-query -W -f='package:" + bin_var + "\\n" \
           "revision:${binary:Revision}\\n" \
           "architecture:${Architecture}\\n" \
           "maintainer:${Maintainer}\\n" \

--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -254,7 +254,7 @@ def _get_pkg_info(*packages):
     :return:
     '''
 
-    ret = list()
+    ret = []
     cmd = "dpkg-query -W -f='package:${binary:Package}\\n" \
           "revision:${binary:Revision}\\n" \
           "architecture:${Architecture}\\n" \
@@ -281,7 +281,7 @@ def _get_pkg_info(*packages):
         raise CommandExecutionError("Error getting packages information: {0}".format(call['stderr']))
 
     for pkg_info in [elm for elm in re.split(r"----*", call['stdout']) if elm.strip()]:
-        pkg_data = dict()
+        pkg_data = {}
         pkg_info, pkg_descr = re.split(r"====*", pkg_info)
         for pkg_info_line in [el.strip() for el in pkg_info.split(os.linesep) if el.strip()]:
             key, value = pkg_info_line.split(":", 1)


### PR DESCRIPTION
Fixes #30814.
