### PR TITLE
Added more descriptive error message

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -1023,6 +1023,7 @@ class Pygit2(GitProvider):
                     and isinstance(self.credentials, pygit2.Keypair):
                 log.error(
                     'Unable to fetch SSH-based {0} remote \'{1}\'. '
+                    'You may need to add ssh:// to the repo string or '
                     'libgit2 must be compiled with libssh2 to support '
                     'SSH authentication.'.format(self.role, self.id)
                 )


### PR DESCRIPTION
My wording could be different but I chased myself around tonight with this one. 

This doc:

https://docs.saltstack.com/en/latest/topics/tutorials/gitfs.html

States the following:

> SSH repositories can be configured using the ssh:// protocol designation, or using scp-like syntax. So, the following two configurations are equivalent:
> 
> ```
> ssh://git@github.com/user/repo.git
> git@github.com:user/repo.git
> ```

This is not true when using pygit2. You'll get the original error message if you don't include the ssh://
