### PR TITLE
pip: add --no-cache-dir

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -370,7 +370,8 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
             saltenv='base',
             env_vars=None,
             use_vt=False,
-            trusted_host=None):
+            trusted_host=None,
+            no_cache_dir=False):
     '''
     Install packages with pip
 
@@ -538,6 +539,9 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
 
     use_vt
         Use VT terminal emulation (see output while installing)
+
+    no_cache_dir
+        Disable the cache.
 
     CLI Example:
 
@@ -739,6 +743,9 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
 
     if no_download:
         cmd.append('--no-download')
+
+    if no_cache_dir:
+        cmd.append('--no-cache-dir')
 
     if pre_releases:
         # Check the locally installed pip version

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -261,7 +261,8 @@ def installed(name,
               process_dependency_links=False,
               env_vars=None,
               use_vt=False,
-              trusted_host=None):
+              trusted_host=None,
+              no_cache_dir=False):
     '''
     Make sure the package is installed
 
@@ -367,6 +368,9 @@ def installed(name,
     no_chown
         When user is given, do not attempt to copy and chown
         a requirements file
+
+    no_cache_dir:
+        Disable the cache.
 
     cwd
         Current working directory to run pip from
@@ -716,7 +720,8 @@ def installed(name,
         saltenv=__env__,
         env_vars=env_vars,
         use_vt=use_vt,
-        trusted_host=trusted_host
+        trusted_host=trusted_host,
+        no_cache_dir=no_cache_dir
     )
 
     # Check the retcode for success, but don't fail if using pip1 and the package is


### PR DESCRIPTION
Add the --no-cache-dir general options to the pip state/module. This option disable the cache.
