### PR TITLE
Better boto elb error message.

### DIFF
--- a/salt/modules/boto_elb.py
+++ b/salt/modules/boto_elb.py
@@ -176,7 +176,7 @@ def create(name, availability_zones, listeners=None, subnets=None,
             return False
     except boto.exception.BotoServerError as error:
         log.debug(error)
-        msg = 'Failed to create ELB {0}: {1}'.format(name, error)
+        msg = 'Failed to create ELB {0}: {1}: {2}'.format(name, error.error_code, error.message)
         log.error(msg)
         return False
 


### PR DESCRIPTION
Based on how boto handle exceptions [ references: https://github.com/boto/boto/blob/develop/boto/exception.py#L77 ]
salt log should be well formated now.

BTW: I'm not able to test this since I don't have an AWS account.

Fixes #30840.
