### PR TITLE
[2016.3] Add support for minion blackouts

### DIFF
--- a/doc/topics/blackout/index.rst
+++ b/doc/topics/blackout/index.rst
@@ -1,0 +1,16 @@
+.. _blackout:
+
+=============================
+Minion Blackout Configuration
+=============================
+
+.. versionadded:: 2016.3.0
+
+Salt supports minion blackouts. When a minion is in blackout mode, all remote
+execution commands are disabled. This allows production minions to be put
+"on hold", eliminating the risk of an untimely configuration change.
+
+Minion blackouts are configured via a special pillar key, ``minion_blackout``.
+If this key is set to ``True``, then the minion will reject all incoming
+commands, except for ``saltutil.refresh_pillar``. (The exception is important,
+so minions can be brought out of blackout mode)

--- a/doc/topics/blackout/index.rst
+++ b/doc/topics/blackout/index.rst
@@ -14,3 +14,13 @@ Minion blackouts are configured via a special pillar key, ``minion_blackout``.
 If this key is set to ``True``, then the minion will reject all incoming
 commands, except for ``saltutil.refresh_pillar``. (The exception is important,
 so minions can be brought out of blackout mode)
+
+Salt also supports an explicit whitelist of additional functions that will be
+allowed during blackout. This is configured with the special pillar key
+``minion_blackout_whitelist``, which is formed as a list:
+
+.. code_block:: yaml
+
+    minion_blackout_whitelist:
+      - test.ping
+      - pillar.get

--- a/doc/topics/configuration/index.rst
+++ b/doc/topics/configuration/index.rst
@@ -11,6 +11,7 @@ secure and troubleshoot, and how to perform many other administrative tasks.
     ../../ref/configuration/master
     ../../ref/configuration/minion
     ../../ref/configuration/examples
+    ../blackout/index
     ../eauth/access_control
     ../jobs/index
     ../jobs/job_cache

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1342,7 +1342,6 @@ class Minion(MinionBase):
             try:
                 if minion_instance.opts['pillar'].get('minion_blackout', False):
                     # this minion is blacked out. Only allow saltutil.refresh_pillar
-                    if data['fun'][ind] != 'saltutil.refresh_pillar':
                     if data['fun'][ind] != 'saltutil.refresh_pillar' and \
                             data['fun'][ind] not in minion_instance.opts['pillar'].get('minion_blackout_whitelist', []):
                         raise SaltInvocationError('Minion in blackout mode. Set \'minion_blackout\' '

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1172,7 +1172,7 @@ class Minion(MinionBase):
                 if minion_instance.opts['pillar'].get('minion_blackout', False):
                     # this minion is blacked out. Only allow saltutil.refresh_pillar
                     if function_name != 'saltutil.refresh_pillar':
-                        raise SaltInvocaionError('Minion in blackout mode. Set \'minion_blackout\' '
+                        raise SaltInvocationError('Minion in blackout mode. Set \'minion_blackout\' '
                                                  'to False in pillar to resume operations. Only '
                                                  'saltutil.refresh_pillar allowed in blackout mode.')
                 func = minion_instance.functions[function_name]
@@ -1342,7 +1342,7 @@ class Minion(MinionBase):
                 if minion_instance.opts['pillar'].get('minion_blackout', False):
                     # this minion is blacked out. Only allow saltutil.refresh_pillar
                     if data['fun'][ind] != 'saltutil.refresh_pillar':
-                        raise SaltInvocaionError('Minion in blackout mode. Set \'minion_blackout\' '
+                        raise SaltInvocationError('Minion in blackout mode. Set \'minion_blackout\' '
                                                  'to False in pillar to resume operations. Only '
                                                  'saltutil.refresh_pillar allowed in blackout mode.')
                 func = minion_instance.functions[data['fun'][ind]]

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1169,6 +1169,12 @@ class Minion(MinionBase):
         function_name = data['fun']
         if function_name in minion_instance.functions:
             try:
+                if minion_instance.opts['pillar'].get('minion_blackout', False):
+                    # this minion is blacked out. Only allow saltutil.refresh_pillar
+                    if function_name != 'saltutil.refresh_pillar':
+                        raise SaltInvocaionError('Minion in blackout mode. Set \'minion_blackout\' '
+                                                 'to False in pillar to resume operations. Only '
+                                                 'saltutil.refresh_pillar allowed in blackout mode.')
                 func = minion_instance.functions[function_name]
                 args, kwargs = load_args_and_kwargs(
                     func,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1339,6 +1339,12 @@ class Minion(MinionBase):
         for ind in range(0, len(data['fun'])):
             ret['success'][data['fun'][ind]] = False
             try:
+                if minion_instance.opts['pillar'].get('minion_blackout', False):
+                    # this minion is blacked out. Only allow saltutil.refresh_pillar
+                    if data['fun'][ind] != 'saltutil.refresh_pillar':
+                        raise SaltInvocaionError('Minion in blackout mode. Set \'minion_blackout\' '
+                                                 'to False in pillar to resume operations. Only '
+                                                 'saltutil.refresh_pillar allowed in blackout mode.')
                 func = minion_instance.functions[data['fun'][ind]]
                 args, kwargs = load_args_and_kwargs(
                     func,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1171,7 +1171,8 @@ class Minion(MinionBase):
             try:
                 if minion_instance.opts['pillar'].get('minion_blackout', False):
                     # this minion is blacked out. Only allow saltutil.refresh_pillar
-                    if function_name != 'saltutil.refresh_pillar':
+                    if function_name != 'saltutil.refresh_pillar' and \
+                            function_name not in minion_instance.opts['pillar'].get('minion_blackout_whitelist', []):
                         raise SaltInvocationError('Minion in blackout mode. Set \'minion_blackout\' '
                                                  'to False in pillar to resume operations. Only '
                                                  'saltutil.refresh_pillar allowed in blackout mode.')
@@ -1342,6 +1343,8 @@ class Minion(MinionBase):
                 if minion_instance.opts['pillar'].get('minion_blackout', False):
                     # this minion is blacked out. Only allow saltutil.refresh_pillar
                     if data['fun'][ind] != 'saltutil.refresh_pillar':
+                    if data['fun'][ind] != 'saltutil.refresh_pillar' and \
+                            data['fun'][ind] not in minion_instance.opts['pillar'].get('minion_blackout_whitelist', []):
                         raise SaltInvocationError('Minion in blackout mode. Set \'minion_blackout\' '
                                                  'to False in pillar to resume operations. Only '
                                                  'saltutil.refresh_pillar allowed in blackout mode.')


### PR DESCRIPTION
Refs #24929 

Adds support for a special pillar key, `minion_blackout`. When set to `True`, minions will not execute any remote execution commands, except for `saltutil.refresh_pillar`.
