### PR TITLE
Fix TCP transport PUB auth on failover with master restart

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -409,6 +409,13 @@ class AsyncAuth(object):
                self._authenticate_future.done() and \
                self._authenticate_future.exception() is None
 
+    def invalidate(self):
+        if self.authenticated:
+            del self._authenticate_future
+            key = self.__key(self.opts)
+            if key in AsyncAuth.creds_map:
+                del AsyncAuth.creds_map[key]
+
     def authenticate(self, callback=None):
         '''
         Ask for this client to reconnect to the origin

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1721,6 +1721,8 @@ class Minion(MinionBase):
 
                     if hasattr(self, 'pub_channel'):
                         self.pub_channel.on_recv(None)
+                        if hasattr(self.pub_channel, 'auth'):
+                            self.pub_channel.auth.invalidate()
                         if hasattr(self.pub_channel, 'close'):
                             self.pub_channel.close()
                         del self.pub_channel


### PR DESCRIPTION
If the salt-master restarts, and the salt-minion is using the TCP
transport on failover mode, the salt-master will reject the
salt-minion's pre-existing auth token.

This fix will reset the auth when handling the `__master_disconnected`
event in minion.py.

Note: A possible alternative to this fix is to have the master respond
to the minion during the PUB channel identification process. If the
response is that the authentication failed, the minion would then try
to re-authenticate at that time. Currently, the master does not
respond to the minion's identification token.

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
