### PR TITLE
Fix regression in git_pillar when multiple remotes are configured

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -269,10 +269,15 @@ def ext_pillar(minion_id, repo, pillar_dirs):
                 'git_pillar is processing pillar SLS from {0} for pillar '
                 'env \'{1}\''.format(pillar_dir, env)
             )
-            opts['pillar_roots'] = {
-                env: [d for (d, e) in six.iteritems(pillar.pillar_dirs)
-                      if env == e]
-            }
+            all_dirs = [d for (d, e) in six.iteritems(pillar.pillar_dirs)
+                        if env == e]
+
+            # Ensure that the current pillar_dir is first in the list, so that
+            # the pillar top.sls is sourced from the correct location.
+            pillar_roots = [pillar_dir]
+            pillar_roots.extend([x for x in all_dirs if x != pillar_dir])
+            opts['pillar_roots'] = {env: pillar_roots}
+
             local_pillar = Pillar(opts, __grains__, minion_id, env)
             ret = salt.utils.dictupdate.merge(
                 ret,


### PR DESCRIPTION
05782aa introduced a regression in which only one repo's pillar data
would be evaluated if more than one repo was configured under the same
"git" entry in ext_pillar.

The reason for this is that the `pillar_roots` list that we build
always has the same order, and that order of precedence means that when
the Pillar class goes to grab the top file, it always gets the first one
in the list. So when processing the pillar data for the 2nd source, it
grabs the first source's top.sls file instead, and when it doesn't find
SLS matches no pillar data is compiled for that 2nd source.

This fixes the problem by ensuring that the pillar_dir currently
being processed is always first in the `pillar_roots` list, so that
the correct top file is grabbed.

Fixes #30869.
