### PR TITLE
Don't delete a Docker volume if the volume's driver differs

### DIFF
--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -2081,7 +2081,7 @@ def network_absent(name, driver=None):
     return ret
 
 
-def volume_present(name, driver=None, driver_opts=None):
+def volume_present(name, driver=None, driver_opts=None, force=True):
     '''
     Ensure that a volume is present.
 
@@ -2101,6 +2101,15 @@ def volume_present(name, driver=None, driver_opts=None):
 
     driver_opts
         Options for the volume driver
+
+    force : True
+        If the volume already exists but the existing volume's driver
+        does not match the driver specified by the ``driver``
+        parameter, this parameter controls whether the function errors
+        out (if ``False``) or deletes and re-creates the volume (if
+        ``True``).
+
+        .. versionadded:: 2015.8.6
 
     Usage Examples:
 
@@ -2152,6 +2161,12 @@ def volume_present(name, driver=None, driver_opts=None):
     # volume exits, check if driver is the same.
     volume = volumes[0]
     if driver is not None and volume['Driver'] != driver:
+        if not force:
+            ret['comment'] = "Driver for existing volume '{0}' ('{1}')" \
+                             " does not match specified driver ('{2}')" \
+                             " and force is False".format(
+                                 name, volume['Driver'], driver)
+            return ret
         try:
             ret['changes']['removed'] = __salt__['dockerng.remove_volume'](name)
         except Exception as exc:

--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -2100,7 +2100,7 @@ def volume_present(name, driver=None, driver_opts=None):
         explicitly name Docker's default driver here.)
 
     driver_opts
-        Option for tha volume driver
+        Options for the volume driver
 
     Usage Examples:
 

--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -2081,11 +2081,16 @@ def network_absent(name, driver=None):
     return ret
 
 
-def volume_present(name, driver=None, driver_opts=None, force=True):
+def volume_present(name, driver=None, driver_opts=None, force=False):
     '''
     Ensure that a volume is present.
 
     .. versionadded:: 2015.8.4
+
+    .. versionchanged:: 2015.8.6
+        This function no longer deletes and re-creates a volume if the
+        existing volume's driver does not match the ``driver``
+        parameter (unless the ``force`` parameter is set to ``True``).
 
     name
         Name of the volume
@@ -2102,7 +2107,7 @@ def volume_present(name, driver=None, driver_opts=None, force=True):
     driver_opts
         Options for the volume driver
 
-    force : True
+    force : False
         If the volume already exists but the existing volume's driver
         does not match the driver specified by the ``driver``
         parameter, this parameter controls whether the function errors

--- a/tests/unit/states/dockerng_test.py
+++ b/tests/unit/states/dockerng_test.py
@@ -572,7 +572,22 @@ class DockerngTestCase(TestCase):
                 ret)
             self.assertEqual(orig_volumes, volumes)
 
-            # run it again, except with a different driver
+            # run it again with a different driver but don't force
+            ret = dockerng_state.volume_present(
+                'volume_foo', driver='local', force=False)
+            self.assertEqual(
+                {
+                    'name': 'volume_foo',
+                    'comment': ("Driver for existing volume 'volume_foo'"
+                                " ('dummy_default') does not match specified"
+                                " driver ('local') and force is False"),
+                    'changes': {},
+                    'result': False,
+                },
+                ret)
+            self.assertEqual(orig_volumes, volumes)
+
+            # run it again with a different driver and force
             ret = dockerng_state.volume_present('volume_foo', driver='local')
             self.assertEqual(
                 {

--- a/tests/unit/states/dockerng_test.py
+++ b/tests/unit/states/dockerng_test.py
@@ -573,8 +573,7 @@ class DockerngTestCase(TestCase):
             self.assertEqual(orig_volumes, volumes)
 
             # run it again with a different driver but don't force
-            ret = dockerng_state.volume_present(
-                'volume_foo', driver='local', force=False)
+            ret = dockerng_state.volume_present('volume_foo', driver='local')
             self.assertEqual(
                 {
                     'name': 'volume_foo',
@@ -588,7 +587,8 @@ class DockerngTestCase(TestCase):
             self.assertEqual(orig_volumes, volumes)
 
             # run it again with a different driver and force
-            ret = dockerng_state.volume_present('volume_foo', driver='local')
+            ret = dockerng_state.volume_present(
+                'volume_foo', driver='local', force=True)
             self.assertEqual(
                 {
                     'name': 'volume_foo',
@@ -626,7 +626,8 @@ class DockerngTestCase(TestCase):
                         {'__salt__': __salt__}):
             ret = dockerng_state.volume_present(
                 'volume_foo',
-                driver='bar'
+                driver='bar',
+                force=True,
                 )
         dockerng_remove_volume.assert_called_with('volume_foo')
         dockerng_create_volume.assert_called_with('volume_foo',


### PR DESCRIPTION
Currently, if an existing volume's driver does not match the specified driver, `states.dockerng.volume_present()` deletes and re-creates the volume.  To avoid surprising the user with data loss, this PR introduces a new `force` parameter—defaulting to `False`—that controls this behavior.

These commits add `versionadded` and `versionchanged` documentation that assume these commits will make it into the 2015.8.6 release.  Please let me know if I should change them.
