### PR TITLE
VMWare -> VMware

### DIFF
--- a/conf/cloud.providers.d/vsphere.conf
+++ b/conf/cloud.providers.d/vsphere.conf
@@ -5,7 +5,7 @@
 #  url: 'https://10.1.1.1:443'
 
 # Note: Your URL may or may not look like any of the following, depending on how
-# your VMWare installation is configured:
+# your VMware installation is configured:
 #
 #     10.1.1.1
 #     10.1.1.1:443

--- a/doc/topics/releases/2014.7.3.rst
+++ b/doc/topics/releases/2014.7.3.rst
@@ -20,7 +20,7 @@ Changes:
 
 - Major performance improvements to Saltnado
 
-- Allow KVM module to operate under KVM itself or VMWare Fusion
+- Allow KVM module to operate under KVM itself or VMware Fusion
 
 - Various fixes to the Windows installation scripts
 

--- a/doc/topics/releases/2014.7.4.rst
+++ b/doc/topics/releases/2014.7.4.rst
@@ -29,7 +29,7 @@ Changes:
 
 - Major performance improvements to Saltnado
 
-- Allow KVM module to operate under KVM itself or VMWare Fusion
+- Allow KVM module to operate under KVM itself or VMware Fusion
 
 - Various fixes to the Windows installation scripts
 

--- a/doc/topics/releases/carbon.rst
+++ b/doc/topics/releases/carbon.rst
@@ -1,0 +1,19 @@
+:orphan:
+
+====================================
+Salt Release Notes - Codename Carbon
+====================================
+
+Grains Changes
+==============
+
+- All core grains containing ``VMWare`` have been changed to ``VMware``, which
+  is the `official capitalization <https://www.vmware.com>`_.  Additionally,
+  all references to ``VMWare`` in the documentation have been changed to
+  ``VMware`` :issue:`30807`.  Environments using versions of Salt before and
+  after Salt Carbon should employ case-insensitive grain matching on these
+  grains.
+
+  .. code-block:: jinja
+
+      {% set on_vmware = grains['virtual'].lower() == 'vmware' %}

--- a/pkg/suse/salt.changes
+++ b/pkg/suse/salt.changes
@@ -358,7 +358,7 @@ Mon Mar 30 21:41:22 UTC 2015 - aboe76@gmail.com
 + net.arp will no longer be made available unless arp is installed on the
   system.
 + Major performance improvements to Saltnado
-+ Allow KVM module to operate under KVM itself or VMWare Fusion
++ Allow KVM module to operate under KVM itself or VMware Fusion
 + Various fixes to the Windows installation scripts
 + Fix issue where the syndic would not correctly propogate loads to the master
   job cache.

--- a/salt/cloud/clouds/vsphere.py
+++ b/salt/cloud/clouds/vsphere.py
@@ -13,7 +13,7 @@ vSphere Cloud Module
         :doc:`Getting started with VMware </topics/cloud/vmware>` to get started
         and convert your vsphere provider configurations to use the vmware driver.
 
-The vSphere cloud module is used to control access to VMWare vSphere.
+The vSphere cloud module is used to control access to VMware vSphere.
 
 :depends: PySphere Python module >= 0.1.8
 
@@ -42,7 +42,7 @@ configuration at:
       url: 'https://10.1.1.1:443'
 
 Note: Your URL may or may not look like any of the following, depending on how
-your VMWare installation is configured:
+your VMware installation is configured:
 
 .. code-block:: bash
 
@@ -744,7 +744,7 @@ def list_clusters(kwargs=None, call=None):  # pylint: disable=W0613
 
 def list_folders(kwargs=None, call=None):  # pylint: disable=W0613
     '''
-    List the folders for this VMWare environment
+    List the folders for this VMware environment
     '''
     if call != 'function':
         log.error(

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -559,7 +559,7 @@ def _virtual(osdata):
                 grains['virtual'] = output
                 break
             elif 'vmware' in output:
-                grains['virtual'] = 'VMWare'
+                grains['virtual'] = 'VMware'
                 break
             elif 'microsoft' in output:
                 grains['virtual'] = 'VirtualPC'
@@ -575,7 +575,7 @@ def _virtual(osdata):
                 grains['virtual'] = output
                 break
             elif 'vmware' in output:
-                grains['virtual'] = 'VMWare'
+                grains['virtual'] = 'VMware'
                 break
             elif 'parallels' in output:
                 grains['virtual'] = 'Parallels'
@@ -1016,9 +1016,9 @@ _OS_FAMILY_MAP = {
     'XCP': 'RedHat',
     'XenServer': 'RedHat',
     'Mandrake': 'Mandriva',
-    'ESXi': 'VMWare',
+    'ESXi': 'VMware',
     'Mint': 'Debian',
-    'VMWareESX': 'VMWare',
+    'VMwareESX': 'VMware',
     'Bluewhite64': 'Bluewhite',
     'Slamd64': 'Slackware',
     'SLES': 'Suse',

--- a/salt/proxy/esxi.py
+++ b/salt/proxy/esxi.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-Proxy Minion interface module for managing VMWare ESXi hosts.
+Proxy Minion interface module for managing VMware ESXi hosts.
 
 .. versionadded:: 2015.8.4
 

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 '''
-Connection library for VMWare
+Connection library for VMware
 
 .. versionadded:: 2015.8.2
 
-This is a base library used by a number of VMWare services such as VMWare
+This is a base library used by a number of VMware services such as VMware
 ESX, ESXi, and vCenter servers.
 
 :codeauthor: Nitin Madhok <nmadhok@clemson.edu>


### PR DESCRIPTION
Fixes #30807; replaces #30848. [VMware](https://vmware.com/) uses `VMware`, so so should we.  We also shouldn't be mixing grains between `VMWare` and `VMware`.
