### PR TITLE
Only remove the word linux from distroname when its not part of the name

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -970,7 +970,7 @@ def id_():
     '''
     return {'id': __opts__.get('id', '')}
 
-_REPLACE_LINUX_RE = re.compile(r'linux', re.IGNORECASE)
+_REPLACE_LINUX_RE = re.compile(r'\Wlinux', re.IGNORECASE)
 
 # This maps (at most) the first ten characters (no spaces, lowercased) of
 # 'osfullname' to the 'os' grain that Salt traditionally uses.


### PR DESCRIPTION
This will now still replace "CentOS Linux" with "CentOS" while leaving "CloudLinux" unmodified.
Fixes #28951 

Please also backport this to 2015.5 which is the actual stable version on CloudLinux.

Thanks
