### PR TITLE
Fix pkg install with version.

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -503,6 +503,8 @@ def _verify_install(desired, new_pkgs):
 
         if __grains__['os'] == 'FreeBSD' and origin:
             cver = [k for k, v in six.iteritems(new_pkgs) if v['origin'] == pkgname]
+        elif __grains__['os_family'] == 'Debian':
+            cver = new_pkgs.get(pkgname.split('=')[0])
         else:
             cver = new_pkgs.get(pkgname)
 


### PR DESCRIPTION
In new_pkgs dict keys are with the format package=version this makes this function
call to not return package version in Ubuntu systems.
Would be a good check to see if this also fails in other Linux distributions.

Fixes #30792.
