### PR TITLE
Avoid a crash in "status.diskusage" when not on Linux or FreeBSD

### DIFF
--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -458,6 +458,8 @@ def diskusage(*args):
             ifile = salt.utils.fopen(procf, 'r').readlines()
         elif __grains__['kernel'] == 'FreeBSD':
             ifile = __salt__['cmd.run']('mount -p').splitlines()
+        else:
+            ifile = []
 
         for line in ifile:
             comps = line.split()


### PR DESCRIPTION
In its current status, a salt minion will crash in "status.diskusage" when not running on Linux or FreeBSD, raising the following exception:

> ```
> The minion function caused an exception: Traceback (most recent call last):
>   File "/usr/pkg/lib/python2.7/site-packages/salt/minion.py", line 1022, in _thread_return
>     return_data = func(*args, **kwargs)
>   File "/usr/pkg/lib/python2.7/site-packages/salt/modules/status.py", line 440, in diskusage
>     for line in ifile:
> UnboundLocalError: local variable 'ifile' referenced before assignment
> ```

This trivial patch sets the "ifile" variable as an empty list as fallback, thus avoiding the crash.
