### PR TITLE
Fixes to ssh_auth state module

### DIFF
--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -284,7 +284,10 @@ def present(
 
     # Get only the path to the file without env referrences to check if exists
     if source != '':
-        source_path = __salt__['cp.get_url'](source, None)
+        source_path = __salt__['cp.get_url'](
+                        source,
+                        None,
+                        saltenv=__env__)
 
     if source != '' and not source_path:
         data = 'no key'


### PR DESCRIPTION
The call to cp.get_url needs the saltenv, if you're using environments other than base, it will fail.
