### PR TITLE
Fix small bug with starting volumes after creation.

### DIFF
--- a/salt/modules/glusterfs.py
+++ b/salt/modules/glusterfs.py
@@ -244,7 +244,7 @@ def create(name, bricks, stripe=False, replica=False, device_vg=False,
     _gluster_xml(cmd)
 
     if start:
-        _gluster_xml('gluster volume start {0}'.format(name))
+        _gluster_xml('volume start {0}'.format(name))
         return 'Volume {0} created and started'.format(name)
     else:
         return 'Volume {0} created. Start volume to use'.format(name)


### PR DESCRIPTION
Looks like when the module got changed to use the _gluster_xml function, this command was missed; using create now with start: True will raise an exception. Removing the initial 'gluster' will fix it.

Fixes #30923.
