### PR TITLE
update consul ext_pillar to support root based on role

### DIFF
--- a/salt/pillar/consul_pillar.py
+++ b/salt/pillar/consul_pillar.py
@@ -32,13 +32,14 @@ Using these configuration profiles, multiple consul sources may also be used:
       - consul: my_consul_config
       - consul: my_other_consul_config
 
-The ``minion_id`` may be used in the ``root`` path to expose minion-specific
-information stored in consul.
+Either the ``minion_id``, or the ``role`` grain  may be used in the ``root``
+path to expose minion-specific information stored in consul.
 
 .. code-block:: yaml
 
     ext_pillar:
       - consul: my_consul_config root=/salt/%(minion_id)s
+      - consul: my_consul_config root=/salt/%(role)s
 
 Minion-specific values may override shared values when the minion-specific root
 appears after the shared root:
@@ -48,6 +49,13 @@ appears after the shared root:
     ext_pillar:
       - consul: my_consul_config root=/salt-shared
       - consul: my_other_consul_config root=/salt-private/%(minion_id)s
+
+If using the ``role`` grain in the consul key path, be sure to define it using
+`/etc/salt/grains`, or similar:
+
+.. code-block:: yaml
+
+    role: my-minion-role
 
 '''
 from __future__ import absolute_import
@@ -97,9 +105,11 @@ def ext_pillar(minion_id,
     if len(comps) > 1 and comps[1].startswith('root='):
         path = comps[1].replace('root=', '')
 
+    role = __salt__['grains.get']('role')
     # put the minion's ID in the path if necessary
     path %= {
-        'minion_id': minion_id
+        'minion_id': minion_id,
+        'role': role
     }
 
     try:


### PR DESCRIPTION
If there is a "role" grain, provide that as an option to
format the path prefix.
