### PR TITLE
Add missing __salt__ assignment in boto_vpc

### DIFF
--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -128,7 +128,7 @@ def __virtual__():
 def __init__(opts, pack=None):
     salt.utils.compat.pack_dunder(__name__)
     if HAS_BOTO:
-        __utils__['boto.assign_funcs'](__name__, 'vpc', pack=pack)
+        __utils__['boto.assign_funcs'](__name__, 'vpc', pack=__salt__)
 
 
 def check_vpc(vpc_id=None, vpc_name=None, region=None, key=None,


### PR DESCRIPTION
Ref #30867 - fix was not applied to the boto_vpc module

@rallytime - you might want to review/merge this
