### PR TITLE
Fix missing salt.1 man page in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1005,6 +1005,7 @@ class SaltDistribution(distutils.dist.Distribution):
                                  'doc/man/salt-proxy.1',
                                  'doc/man/salt-run.1',
                                  'doc/man/spm.1',
+                                 'doc/man/salt.1',
                                  'doc/man/salt-ssh.1',
                                  'doc/man/salt-syndic.1',
                                  'doc/man/salt-unity.1'])


### PR DESCRIPTION
setup.py wasn't installing the salt.1 man page; downstream packages
using setup.py to build ended up with salt.1 missing.
