### PR TITLE
Thorium timer, debug and grains/pillar support

### DIFF
--- a/doc/topics/thorium/index.rst
+++ b/doc/topics/thorium/index.rst
@@ -5,7 +5,8 @@ Thorium Complex Reactor
 .. note::
 
     Thorium was added to Salt as an experimental feature in the 2016.3.0
-    release, as of 2016.3 this feature is considered experimental.
+    release, as of 2016.3 this feature is considered experimental, no
+    guarantees are made for support of any kind yet.
 
 
 The original Salt Reactor is based on the idea of listening for a specific
@@ -13,9 +14,9 @@ event and then reacting to it. This model comes with many logical limitations,
 for instance it is very difficult (and hacky) to fire a reaction based on
 aggregate data or based on multiple events.
 
-The Thorium reactor is intended to aleviate this problem in a very elegant way.
+The Thorium reactor is intended to alleviate this problem in a very elegant way.
 Instead of using extensive jinja routines or complex python sls files the
-aggregation of data and the determinization of what should run becomes isolated
+aggregation of data and the determination of what should run becomes isolated
 to the sls data logic, makes the definitions much cleaner.
 
 

--- a/salt/engines/__init__.py
+++ b/salt/engines/__init__.py
@@ -50,6 +50,7 @@ def start_engines(opts, proc_mgr):
         if fun in engines:
             start_func = engines[fun]
             name = '{0}.Engine({1})'.format(__name__, start_func.__module__)
+            log.info('Starting Engine {0}'.format(name))
             proc_mgr.add_process(
                     Engine,
                     args=(

--- a/salt/engines/thorium.py
+++ b/salt/engines/thorium.py
@@ -15,7 +15,7 @@ def start(grains=False, grain_keys=None, pillar=False, pillar_keys=None):
     state = salt.thorium.ThorState(
             __opts__,
             grains,
-            grains_keys,
+            grain_keys,
             pillar,
             pillar_keys)
     state.start_runtime()

--- a/salt/engines/thorium.py
+++ b/salt/engines/thorium.py
@@ -8,9 +8,14 @@ from __future__ import absolute_import
 import salt.thorium
 
 
-def start():
+def start(grains=False, grain_keys=None, pillar=False, pillar_keys=None):
     '''
     Execute the Thorium runtime
     '''
-    state = salt.thorium.ThorState(__opts__)
+    state = salt.thorium.ThorState(
+            __opts__,
+            grains,
+            grains_keys,
+            pillar,
+            pillar_keys)
     state.start_runtime()

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -434,10 +434,11 @@ def thorium(opts, functions, runners):
     '''
     Load the thorium runtime modules
     '''
+    pack = {'__salt__': functions, '__runner__': runners, '__context__': {}}
     ret = LazyLoader(_module_dirs(opts, 'thorium', 'thorium'),
             opts,
             tag='thorium',
-            pack={'__salt__': functions, '__runner__': runners})
+            pack=pack)
     ret.pack['__thorium__'] = ret
     return ret
 

--- a/salt/thorium/__init__.py
+++ b/salt/thorium/__init__.py
@@ -26,7 +26,13 @@ class ThorState(salt.state.HighState):
     '''
     Compile the thorium state and manage it in the thorium runtime
     '''
-    def __init__(self, opts):
+    def __init__(
+            self,
+            opts,
+            grains=False,
+            grain_keys=None,
+            pillar=False,
+            pillar_keys=None):
         opts['file_roots'] = opts['thorium_roots']
         self.opts = opts
         salt.state.HighState.__init__(self, self.opts, loader='thorium')

--- a/salt/thorium/__init__.py
+++ b/salt/thorium/__init__.py
@@ -99,15 +99,21 @@ class ThorState(salt.state.HighState):
         Execute the runtime
         '''
         interval = self.opts['thorium_interval']
+        recompile = self.opts.get('thorium_recompile', 300)
+        r_start = time.time()
         while True:
             events = self.get_events()
             if not events:
                 time.sleep(interval)
-            self.state.inject_globals['__events__'] = events
+                continue
             start = time.time()
+            self.state.inject_globals['__events__'] = events
             self.state.call_chunks(chunks)
             elapsed = time.time() - start
             left = interval - elapsed
             if left > 0:
                 time.sleep(left)
             self.state.reset_run_num()
+            if (start - r_start) > recompile:
+                chunks = self.get_chunks()
+                r_start = start

--- a/salt/thorium/__init__.py
+++ b/salt/thorium/__init__.py
@@ -17,7 +17,7 @@ import traceback
 
 # Import Salt libs
 import salt.state
-import salt.serial
+import salt.payload
 from salt.exceptions import SaltRenderError
 
 log = logging.getLogger(__name__)

--- a/salt/thorium/__init__.py
+++ b/salt/thorium/__init__.py
@@ -96,6 +96,7 @@ class ThorState(salt.state.HighState):
             try:
                 self.call_runtime()
             except Exception:
+                log.error('Exception in Thorium: ', exc_info=True)
                 time.sleep(self.opts['thorium_interval'])
 
     def get_chunks(self, exclude=None, whitelist=None):
@@ -146,7 +147,7 @@ class ThorState(salt.state.HighState):
                 return ret
             ret.append(event)
 
-    def call_runtime(self, chunks):
+    def call_runtime(self):
         '''
         Execute the runtime
         '''

--- a/salt/thorium/__init__.py
+++ b/salt/thorium/__init__.py
@@ -11,6 +11,7 @@ The thorium system allows for advanced event tracking and reactions
 
 # Import python libs
 from __future__ import absolute_import
+import os
 import time
 import logging
 import traceback
@@ -39,6 +40,7 @@ class ThorState(salt.state.HighState):
         self.pillar = pillar
         self.pillar_keys = pillar_keys
         opts['file_roots'] = opts['thorium_roots']
+        opts['file_client'] = 'local'
         self.opts = opts
         salt.state.HighState.__init__(self, self.opts, loader='thorium')
         self.state.inject_globals = {'__reg__': {}}
@@ -53,7 +55,7 @@ class ThorState(salt.state.HighState):
         cache = {'grains': {}, 'pillar': {}}
         if self.grains or self.pillar:
             if self.opts.get('minion_data_cache'):
-                serial = salt.payload.Serial(__opts__)
+                serial = salt.payload.Serial(self.opts)
                 cdir = os.path.join(self.opts['cachedir'], 'minions')
                 if not os.path.isdir(cdir):
                     minions = []
@@ -62,8 +64,8 @@ class ThorState(salt.state.HighState):
                 if not minions:
                     return grains, pillar
                 for minion in minions:
-                    pillar[minion] = {}
-                    grains[minion] = {}
+                    cache['pillar'][minion] = {}
+                    cache['grains'][minion] = {}
                     datap = os.path.join(cdir, minion, 'data.p')
                     try:
                         with salt.utils.fopen(datap, 'rb') as fp_:

--- a/salt/thorium/__init__.py
+++ b/salt/thorium/__init__.py
@@ -80,10 +80,10 @@ class ThorState(salt.state.HighState):
                             if 'grains' in total:
                                 if self.grain_keys:
                                     for key in self.grain_keys:
-                                        if key in total['pillar']:
-                                            cache['pillar'][minion][key] = total['pillar'][key]
+                                        if key in total['grains']:
+                                            cache['grains'][minion][key] = total['grains'][key]
                                 else:
-                                    cache['pillar'][minion] = total['pillar']
+                                    cache['grains'][minion] = total['grains']
                             else:
                                 continue
                     except (IOError, OSError):

--- a/salt/thorium/check.py
+++ b/salt/thorium/check.py
@@ -59,7 +59,7 @@ def contains(name, value):
         ret['comment'] = 'Value {0} not in register'.format(name)
         return ret
     try:
-        if __reg__[name]['val'] in value:
+        if value in __reg__[name]['val']:
             ret['result'] = True
     except TypeError:
         pass

--- a/salt/thorium/file.py
+++ b/salt/thorium/file.py
@@ -22,7 +22,7 @@ def save(name):
            'result': True}
     tgt_dir = os.path.join(__opts__['cachedir'], 'thorium', 'saves')
     fn_ = os.path.join(tgt_dir, name)
-    if not os.isdir(tgt_dir):
+    if not os.path.isdir(tgt_dir):
         os.makedirs(tgt_dir)
     with salt.utils.fopen(fn_, 'w+') as fp_:
         fp_.write(json.dumps(__reg__))

--- a/salt/thorium/reg.py
+++ b/salt/thorium/reg.py
@@ -10,6 +10,7 @@ import fnmatch
 
 __func_alias__ = {
     'set_': 'set',
+    'list_': 'list',
 }
 
 

--- a/salt/thorium/timer.py
+++ b/salt/thorium/timer.py
@@ -1,0 +1,22 @@
+'''
+Allow for flow based timers. These timers allow for a sleep to exist across
+multiple runs of the flow
+'''
+
+def hold(name):
+    '''
+    Wait for a given period of time, then fire a result of True, requireing
+    this state allows for an action to be blocked for evaluation based on
+    time
+    '''
+    ret = {'name': name,
+           'result': False,
+           'comment': '',
+           'changes': {}}
+    start = time.time()
+    if 'hold' not in __context__:
+        __context__['hold'] = start
+    if (start - __context__['hold']) > name:
+        ret['result'] = True
+        __context__['hold'] = start
+    return ret

--- a/salt/thorium/timer.py
+++ b/salt/thorium/timer.py
@@ -3,7 +3,7 @@ Allow for flow based timers. These timers allow for a sleep to exist across
 multiple runs of the flow
 '''
 
-def hold(name):
+def hold(name, seconds):
     '''
     Wait for a given period of time, then fire a result of True, requireing
     this state allows for an action to be blocked for evaluation based on
@@ -14,9 +14,11 @@ def hold(name):
            'comment': '',
            'changes': {}}
     start = time.time()
-    if 'hold' not in __context__:
-        __context__['hold'] = start
-    if (start - __context__['hold']) > name:
+    if 'timer' not in __context__:
+        __context__['timer'] = {}
+    if name not in __context__['timer']:
+        __context__['timer'][name] = start
+    if (start - __context__['timer'][name]) > seconds:
         ret['result'] = True
-        __context__['hold'] = start
+        __context__['timer'][name] = start
     return ret


### PR DESCRIPTION
This allows all minions' grains and pillar to be available to the thorium runtime. This also adds the timer thorium state and adds better debug output to the logs
