### PR TITLE
Remove env argument from compile_template - boron (2016.3) warning in template.py

### DIFF
--- a/salt/template.py
+++ b/salt/template.py
@@ -43,14 +43,6 @@ def compile_template(template,
     ret = {}
 
     log.debug('compile template: {0}'.format(template))
-    # We "map" env to the same as saltenv until Boron is out in order to follow the same deprecation path
-    kwargs.setdefault('env', saltenv)
-    salt.utils.warn_until(
-        'Boron',
-        'We are only supporting \'env\' in the templating context until Boron comes out. '
-        'Once this warning is shown, please remove the above mapping',
-        _dont_call_warnings=True
-    )
 
     if template != ':string:':
         # Template was specified incorrectly


### PR DESCRIPTION
Tried running salt-ssh from 2016.3 HEAD and got this:

```
RuntimeError: The warning triggered on filename '/home/andreas/dev/salt/salt/template.py',
line number 52, is supposed to be shown until version 2016.3.0 (Boron) is released.
Current version is now 2016.3.0 (Boron). Please remove the warning.
```
