### PR TITLE
Adding NPM cache_cleaned state & module functions

### DIFF
--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -415,7 +415,7 @@ def cache_list(path=None,
             env.update({'SUDO_UID': b'{0}'.format(uid), 'SUDO_USER': b''})
 
     cmd = ['npm', 'cache ls']
-    if pkg:
+    if path:
         cmd.append(path)
 
     cmd = ' '.join(cmd)
@@ -471,4 +471,4 @@ def cache_path(runas=None,
             python_shell=True,
             ignore_retcode=True)
 
-    return result['stdout'] or result['stderr']
+    return result.get('stdout') or result.get('stderr')

--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -327,6 +327,7 @@ def list_(pkg=None,
 
     return json.loads(result['stdout']).get('dependencies', {})
 
+
 def cache_clean(path=None,
                 runas=None,
                 env=None):
@@ -362,7 +363,7 @@ def cache_clean(path=None,
             env.update({'SUDO_UID': b'{0}'.format(uid), 'SUDO_USER': b''})
 
     cmd = ['npm', 'cache clean']
-    if pkg:
+    if path:
         cmd.append(path)
 
     cmd = ' '.join(cmd)
@@ -430,7 +431,7 @@ def cache_list(path=None,
     if result['retcode'] != 0 and result['stderr']:
         raise CommandExecutionError(result['stderr'])
 
-    return result['stdout'].splitlines()
+    return result['stdout']
 
 
 def cache_path(runas=None,

--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -257,9 +257,9 @@ def uninstall(pkg,
 
 
 def list_(pkg=None,
-            dir=None,
-            runas=None,
-            env=None):
+          dir=None,
+          runas=None,
+          env=None):
     '''
     List installed NPM packages.
 
@@ -326,3 +326,149 @@ def list_(pkg=None,
         raise CommandExecutionError(result['stderr'])
 
     return json.loads(result['stdout']).get('dependencies', {})
+
+def cache_clean(path=None,
+                runas=None,
+                env=None):
+    '''
+    Delete data of the NPM cache folder.
+
+    If no package is specified, this will clear the entire cache.
+
+    path
+        The cache subpath to delete, or None to clear the entire cache
+
+    runas
+        The user to run NPM with
+
+    env
+        Environment variables to set when invoking npm. Uses the same ``env``
+        format as the :py:func:`cmd.run <salt.modules.cmdmod.run>` execution
+        function.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' npm.cache_clean
+
+    '''
+    if env is None:
+        env = {}
+
+    if runas:
+        uid = salt.utils.get_uid(runas)
+        if uid:
+            env.update({'SUDO_UID': b'{0}'.format(uid), 'SUDO_USER': b''})
+
+    cmd = ['npm', 'cache clean']
+    if pkg:
+        cmd.append(path)
+
+    cmd = ' '.join(cmd)
+    result = __salt__['cmd.run_all'](
+            cmd,
+            cwd=None,
+            runas=runas,
+            env=env,
+            python_shell=True,
+            ignore_retcode=True)
+
+    if result['retcode'] != 0:
+        log.error(result['stderr'])
+        return False
+    return True
+
+
+def cache_list(path=None,
+               runas=None,
+               env=None):
+    '''
+    List contents of the NPM cache folder.
+
+    If no package is specified, this will list all the cached packages.
+
+    path
+        The cache subpath to list, or None to list the entire cache
+
+    runas
+        The user to run NPM with
+
+    env
+        Environment variables to set when invoking npm. Uses the same ``env``
+        format as the :py:func:`cmd.run <salt.modules.cmdmod.run>` execution
+        function.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' npm.cache_clean
+
+    '''
+    if env is None:
+        env = {}
+
+    if runas:
+        uid = salt.utils.get_uid(runas)
+        if uid:
+            env.update({'SUDO_UID': b'{0}'.format(uid), 'SUDO_USER': b''})
+
+    cmd = ['npm', 'cache ls']
+    if pkg:
+        cmd.append(path)
+
+    cmd = ' '.join(cmd)
+    result = __salt__['cmd.run_all'](
+            cmd,
+            cwd=None,
+            runas=runas,
+            env=env,
+            python_shell=True,
+            ignore_retcode=True)
+
+    if result['retcode'] != 0 and result['stderr']:
+        raise CommandExecutionError(result['stderr'])
+
+    return result['stdout'].splitlines()
+
+
+def cache_path(runas=None,
+               env=None):
+    '''
+    List path of the NPM cache directory.
+
+    runas
+        The user to run NPM with
+
+    env
+        Environment variables to set when invoking npm. Uses the same ``env``
+        format as the :py:func:`cmd.run <salt.modules.cmdmod.run>` execution
+        function.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' npm.cache_path
+
+    '''
+    if env is None:
+        env = {}
+
+    if runas:
+        uid = salt.utils.get_uid(runas)
+        if uid:
+            env.update({'SUDO_UID': b'{0}'.format(uid), 'SUDO_USER': b''})
+
+    cmd = 'npm config get cache'
+
+    result = __salt__['cmd.run_all'](
+            cmd,
+            cwd=None,
+            runas=runas,
+            env=env,
+            python_shell=True,
+            ignore_retcode=True)
+
+    return result['stdout'] or result['stderr']

--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -331,9 +331,9 @@ def cache_clean(path=None,
                 runas=None,
                 env=None):
     '''
-    Delete data of the NPM cache folder.
+    Clean cached NPM packages.
 
-    If no package is specified, this will clear the entire cache.
+    If no path for a specific package is provided the entire cache will be cleared.
 
     path
         The cache subpath to delete, or None to clear the entire cache
@@ -384,9 +384,9 @@ def cache_list(path=None,
                runas=None,
                env=None):
     '''
-    List contents of the NPM cache folder.
+    List NPM cached packages.
 
-    If no package is specified, this will list all the cached packages.
+    If no path for a specific package is provided this will list all the cached packages.
 
     path
         The cache subpath to list, or None to list the entire cache

--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -328,12 +328,6 @@ def cache_cleaned(name=None,
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
     specific_pkg = None
 
-    if name:
-        all_cached_pkgs = __salt__['npm.cache_list'](path=None, runas=user)
-        # The first package is always the cache path
-        cache_root_path = all_cached_pkgs[0]
-        specific_pkg = '{0}/{1}/'.format(cache_root_path, name)
-
     try:
         cached_pkgs = __salt__['npm.cache_list'](path=name, runas=user)
     except (CommandExecutionError, CommandNotFoundError) as err:
@@ -342,10 +336,16 @@ def cache_cleaned(name=None,
             name or 'packages', err)
         return ret
 
-    if specific_pkg and (specific_pkg not in cached_pkgs):
-        ret['result'] = True
-        ret['comment'] = 'Package {0} is not in the cache'.format(name)
-        return ret
+    if name:
+        all_cached_pkgs = __salt__['npm.cache_list'](path=None, runas=user)
+        # The first package is always the cache path
+        cache_root_path = all_cached_pkgs[0]
+        specific_pkg = '{0}/{1}/'.format(cache_root_path, name)
+
+        if specific_pkg not in cached_pkgs:
+            ret['result'] = True
+            ret['comment'] = 'Package {0} is not in the cache'.format(name)
+            return ret
 
     if __opts__['test']:
         ret['result'] = None

--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -310,3 +310,55 @@ def bootstrap(name,
         ret['comment'] = 'Directory was successfully bootstrapped'
 
     return ret
+
+
+def cache_cleaned(name=None,
+                  user=None):
+    '''
+    Ensure that the given package is not cached.
+
+    If no package is specified, this ensures the entire cache is cleared.
+
+    name
+        The name of the package to remove from the cache, or None for all packages
+
+    user
+        The user to run NPM with
+    '''
+    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+
+    if name:
+        all_cached_pkgs = __salt__['npm.cache_list'](path=None, runas=user)
+        # The first package is always the cache path
+        cache_root_path = cached_pkgs[0]
+        specific_package = '{}/{}/'.format(cache_root_path, name)
+
+    try:
+        cached_pkgs = __salt__['npm.cache_list'](path=name, runas=user)
+    except (CommandExecutionError, CommandNotFoundError) as err:
+        ret['result'] = False
+        ret['comment'] = 'Error looking up cached {0!r}: {1}'.format(
+            name or 'packages', err)
+        return ret
+
+    if specific_package && specific_package not in cached_pkgs:
+        ret['result'] = True
+        ret['comment'] = 'Package {0!r} is not in the cache'.format(name)
+        return ret
+
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Cached {0!r} set to be removed'.format(name or 'packages')
+        return ret
+
+    if __salt__['npm.cache_clean'](path=name, runas=user):
+        ret['result'] = True
+        ret['changes'][name or 'cache'] = 'Removed'
+        ret['comment'] = 'Cached {0!r} successfully removed'.format(
+            name or 'packages'
+        )
+    else:
+        ret['result'] = False
+        ret['comment'] = 'Error cleaning cached {0!r}'.format(name or 'packages')
+
+    return ret

--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -331,35 +331,35 @@ def cache_cleaned(name=None,
     if name:
         all_cached_pkgs = __salt__['npm.cache_list'](path=None, runas=user)
         # The first package is always the cache path
-        cache_root_path = cached_pkgs[0]
-        specific_pkg = '{}/{}/'.format(cache_root_path, name)
+        cache_root_path = all_cached_pkgs[0]
+        specific_pkg = '{0}/{1}/'.format(cache_root_path, name)
 
     try:
         cached_pkgs = __salt__['npm.cache_list'](path=name, runas=user)
     except (CommandExecutionError, CommandNotFoundError) as err:
         ret['result'] = False
-        ret['comment'] = 'Error looking up cached {0!r}: {1}'.format(
+        ret['comment'] = 'Error looking up cached {0}: {1}'.format(
             name or 'packages', err)
         return ret
 
     if specific_pkg and (specific_pkg not in cached_pkgs):
         ret['result'] = True
-        ret['comment'] = 'Package {0!r} is not in the cache'.format(name)
+        ret['comment'] = 'Package {0} is not in the cache'.format(name)
         return ret
 
     if __opts__['test']:
         ret['result'] = None
-        ret['comment'] = 'Cached {0!r} set to be removed'.format(name or 'packages')
+        ret['comment'] = 'Cached {0} set to be removed'.format(name or 'packages')
         return ret
 
     if __salt__['npm.cache_clean'](path=name, runas=user):
         ret['result'] = True
         ret['changes'][name or 'cache'] = 'Removed'
-        ret['comment'] = 'Cached {0!r} successfully removed'.format(
+        ret['comment'] = 'Cached {0} successfully removed'.format(
             name or 'packages'
         )
     else:
         ret['result'] = False
-        ret['comment'] = 'Error cleaning cached {0!r}'.format(name or 'packages')
+        ret['comment'] = 'Error cleaning cached {0}'.format(name or 'packages')
 
     return ret

--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -331,7 +331,7 @@ def cache_cleaned(name=None,
         all_cached_pkgs = __salt__['npm.cache_list'](path=None, runas=user)
         # The first package is always the cache path
         cache_root_path = cached_pkgs[0]
-        specific_package = '{}/{}/'.format(cache_root_path, name)
+        specific_pkg = '{}/{}/'.format(cache_root_path, name)
 
     try:
         cached_pkgs = __salt__['npm.cache_list'](path=name, runas=user)
@@ -341,7 +341,7 @@ def cache_cleaned(name=None,
             name or 'packages', err)
         return ret
 
-    if specific_package && specific_package not in cached_pkgs:
+    if specific_pkg and (specific_pkg not in cached_pkgs):
         ret['result'] = True
         ret['comment'] = 'Package {0!r} is not in the cache'.format(name)
         return ret

--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -326,6 +326,7 @@ def cache_cleaned(name=None,
         The user to run NPM with
     '''
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+    specific_pkg = None
 
     if name:
         all_cached_pkgs = __salt__['npm.cache_list'](path=None, runas=user)

--- a/tests/integration/states/npm.py
+++ b/tests/integration/states/npm.py
@@ -50,6 +50,14 @@ class NpmStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
         ret = self.run_state('npm.installed', name=None, pkgs=['pm2', 'grunt'])
         self.assertSaltTrueReturn(ret)
 
+    @destructiveTest
+    def test_npm_cache_clean(self):
+        '''
+        Basic test to determine if NPM successfully cleans it's cached packages.
+        '''
+        ret = self.run_state('npm.cache_cleaned', name=None)
+        self.assertSaltTrueReturn(ret)
+
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/unit/modules/npm_test.py
+++ b/tests/unit/modules/npm_test.py
@@ -106,15 +106,15 @@ class NpmTestCase(TestCase):
         '''
         mock = MagicMock(return_value={'retcode': 1, 'stderr': 'error'})
         with patch.dict(npm.__salt__, {'cmd.run_all': mock}):
-            self.assertFalse(npm.clean_cache())
+            self.assertFalse(npm.cache_clean())
 
         mock = MagicMock(return_value={'retcode': 0})
         with patch.dict(npm.__salt__, {'cmd.run_all': mock}):
-            self.assertTrue(npm.clean_cache())
+            self.assertTrue(npm.cache_clean())
 
         mock = MagicMock(return_value={'retcode': 0})
         with patch.dict(npm.__salt__, {'cmd.run_all': mock}):
-            self.assertTrue(npm.clean_cache('coffee-script'))
+            self.assertTrue(npm.cache_clean('coffee-script'))
 
     # 'cache_list' function tests: 1
 

--- a/tests/unit/modules/npm_test.py
+++ b/tests/unit/modules/npm_test.py
@@ -96,6 +96,65 @@ class NpmTestCase(TestCase):
             with patch.object(json, 'loads', mock_err):
                 self.assertEqual(npm.list_('coffee-script'), 'SALT')
 
+    # 'cache_clean' function tests: 1
+
+    @patch('salt.modules.npm._check_valid_version',
+           MagicMock(return_value=True))
+    def test_cache_clean(self):
+        '''
+        Test if it cleans the cached NPM packages.
+        '''
+        mock = MagicMock(return_value={'retcode': 1, 'stderr': 'error'})
+        with patch.dict(npm.__salt__, {'cmd.run_all': mock}):
+            self.assertFalse(npm.clean_cache())
+
+        mock = MagicMock(return_value={'retcode': 0})
+        with patch.dict(npm.__salt__, {'cmd.run_all': mock}):
+            self.assertTrue(npm.clean_cache())
+
+        mock = MagicMock(return_value={'retcode': 0})
+        with patch.dict(npm.__salt__, {'cmd.run_all': mock}):
+            self.assertTrue(npm.clean_cache('coffee-script'))
+
+    # 'cache_list' function tests: 1
+
+    @patch('salt.modules.npm._check_valid_version',
+           MagicMock(return_value=True))
+    def test_cache_list(self):
+        '''
+        Test if it lists the NPM cache.
+        '''
+        mock = MagicMock(return_value={'retcode': 1, 'stderr': 'error'})
+        with patch.dict(npm.__salt__, {'cmd.run_all': mock}):
+            self.assertRaises(CommandExecutionError, npm.cache_list)
+
+        mock = MagicMock(return_value={'retcode': 0, 'stderr': 'error',
+                                       'stdout': ['~/.npm']})
+        with patch.dict(npm.__salt__, {'cmd.run_all': mock}):
+            self.assertEqual(npm.cache_list(), ['~/.npm'])
+
+        mock = MagicMock(return_value={'retcode': 0, 'stderr': 'error',
+                                       'stdout': ''})
+        with patch.dict(npm.__salt__, {'cmd.run_all': mock}):
+            self.assertEqual(npm.cache_list('coffee-script'), '')
+
+    # 'cache_path' function tests: 1
+
+    @patch('salt.modules.npm._check_valid_version',
+           MagicMock(return_value=True))
+    def test_cache_path(self):
+        '''
+        Test if it prints the NPM cache path.
+        '''
+        mock = MagicMock(return_value={'retcode': 1, 'stderr': 'error'})
+        with patch.dict(npm.__salt__, {'cmd.run_all': mock}):
+            self.assertEqual(npm.cache_path(), 'error')
+
+        mock = MagicMock(return_value={'retcode': 0, 'stderr': 'error',
+                                       'stdout': '/User/salt/.npm'})
+        with patch.dict(npm.__salt__, {'cmd.run_all': mock}):
+            self.assertEqual(npm.cache_path(), '/User/salt/.npm')
+
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/unit/states/npm_test.py
+++ b/tests/unit/states/npm_test.py
@@ -156,6 +156,7 @@ class NpmTestCase(TestCase):
 
         mock_list = MagicMock(return_value=['~/.npm', '~/.npm/{0}'.format(name)])
         mock_err = MagicMock(side_effect=CommandExecutionError)
+
         with patch.dict(npm.__salt__, {'npm.cache_list': mock_err}):
             comt = ('Error looking up cached packages: ')
             ret.update({'name': None, 'comment': comt})
@@ -168,29 +169,29 @@ class NpmTestCase(TestCase):
 
         mock_data = {'npm.cache_list': mock_list, 'npm.cache_clean': True}
         with patch.dict(npm.__salt__, mock_data):
-            comt = ('Package {0} is not in the cache'.format(name))
-            ret.update({'comment': comt, 'result': True})
-            self.assertDictEqual(npm.cache_cleaned(name), ret)
+            comt = ('Package {0} is not in the cache'.format('salt'))
+            ret.update({'name': 'salt', 'result': True, 'comment': comt})
+            self.assertDictEqual(npm.cache_cleaned('salt'), ret)
 
             with patch.dict(npm.__opts__, {'test': True}):
                 comt = ('Cached packages set to be removed')
-                ret.update({'name': None, 'comment': comt, 'result': None})
+                ret.update({'name': None, 'result': None, 'comment': comt})
                 self.assertDictEqual(npm.cache_cleaned(), ret)
 
             with patch.dict(npm.__opts__, {'test': True}):
                 comt = ('Cached {0} set to be removed'.format(name))
-                ret.update({'comment': comt, 'result': None})
+                ret.update({'result': None, 'comment': comt})
                 self.assertDictEqual(npm.cache_cleaned(name), ret)
 
             with patch.dict(npm.__opts__, {'test': False}):
                 comt = ('Cached packages successfully removed')
-                ret.update({'name': None, 'comment': comt, 'result': True,
+                ret.update({'name': None, 'result': True, 'comment': comt,
                             'changes': {'cache': 'Removed'}})
                 self.assertDictEqual(npm.cache_cleaned(), ret)
 
             with patch.dict(npm.__opts__, {'test': False}):
                 comt = ('Package {0} successfully removed'.format(name))
-                ret.update({'comment': comt, 'result': True,
+                ret.update({'result': True, 'comment': comt,
                             'changes': {name: 'Removed'}})
                 self.assertDictEqual(npm.cache_cleaned(name), ret)
 
@@ -198,12 +199,12 @@ class NpmTestCase(TestCase):
         with patch.dict(npm.__salt__, {'npm.cache_clean': False}):
             with patch.dict(npm.__opts__, {'test': False}):
                 comt = ('Error cleaning cached packages')
-                ret.update({'name': None, 'comment': comt, 'result': False})
+                ret.update({'name': None, 'result': False, 'comment': comt})
                 self.assertDictEqual(npm.cache_cleaned(), ret)
 
             with patch.dict(npm.__opts__, {'test': False}):
                 comt = ('Error cleaning cached {0}'.format(name))
-                ret.update({'comment': comt, 'result': False})
+                ret.update({'result': False, 'comment': comt})
                 self.assertDictEqual(npm.cache_cleaned(name), ret)
 
 

--- a/tests/unit/states/npm_test.py
+++ b/tests/unit/states/npm_test.py
@@ -194,7 +194,7 @@ class NpmTestCase(TestCase):
                 self.assertDictEqual(npm.cache_cleaned(name), ret)
 
         mock_data = {'npm.cache_list': mock_list, 'npm.cache_clean': False}
-        with patch.dict(npm.__salt__, {'npm.cache_clean': False})
+        with patch.dict(npm.__salt__, {'npm.cache_clean': False}):
             with patch.dict(npm.__opts__, {'test': False}):
                 comt = ('Error cleaning cached packages')
                 ret.update({'comment': comt, 'result': False})

--- a/tests/unit/states/npm_test.py
+++ b/tests/unit/states/npm_test.py
@@ -156,7 +156,6 @@ class NpmTestCase(TestCase):
 
         mock_list = MagicMock(return_value=['~/.npm', '~/.npm/{}'.format(name)])
         mock_err = MagicMock(side_effect=[CommandExecutionError, False, True])
-        mock_t = MagicMock(return_value=True)
         with patch.dict(npm.__salt__, {'npm.cache_list': mock_err}):
             comt = ('Error looking up cached packages: ')
             ret.update({'comment': comt})

--- a/tests/unit/states/npm_test.py
+++ b/tests/unit/states/npm_test.py
@@ -126,7 +126,7 @@ class NpmTestCase(TestCase):
                'comment': '',
                'changes': {}}
 
-        mock_err = MagicMock(side_effect=[CommandExecutionError, False, True])
+        mock_err = MagicMock(side_effect=CommandExecutionError)
         with patch.dict(npm.__salt__, {'npm.install': mock_err}):
             comt = ("Error Bootstrapping 'coffee-script': ")
             ret.update({'comment': comt})
@@ -155,12 +155,13 @@ class NpmTestCase(TestCase):
                'changes': {}}
 
         mock_list = MagicMock(return_value=['~/.npm', '~/.npm/{0}'.format(name)])
-        mock_err = MagicMock(side_effect=[CommandExecutionError, False, True])
+        mock_err = MagicMock(side_effect=CommandExecutionError)
         with patch.dict(npm.__salt__, {'npm.cache_list': mock_err}):
             comt = ('Error looking up cached packages: ')
             ret.update({'name': None, 'comment': comt})
             self.assertDictEqual(npm.cache_cleaned(), ret)
 
+        with patch.dict(npm.__salt__, {'npm.cache_list': mock_err}):
             comt = ("Error looking up cached {0}: ".format(name))
             ret.update({'comment': comt})
             self.assertDictEqual(npm.cache_cleaned(name), ret)

--- a/tests/unit/states/npm_test.py
+++ b/tests/unit/states/npm_test.py
@@ -163,6 +163,8 @@ class NpmTestCase(TestCase):
         }
 
         mock_list = MagicMock(return_value=['~/.npm', '~/.npm/{0}/'.format(name)])
+        mock_cache_clean_success = MagicMock(return_value=True)
+        mock_cache_clean_failure = MagicMock(return_value=False)
         mock_err = MagicMock(side_effect=CommandExecutionError)
 
         with patch.dict(npm.__salt__, {'npm.cache_list': mock_err}):
@@ -175,7 +177,10 @@ class NpmTestCase(TestCase):
             pkg_ret.update({'comment': comt})
             self.assertDictEqual(npm.cache_cleaned(name), pkg_ret)
 
-        mock_data = {'npm.cache_list': mock_list, 'npm.cache_clean': True}
+        mock_data = {
+            'npm.cache_list': mock_list,
+            'npm.cache_clean': mock_cache_clean_success
+        }
         with patch.dict(npm.__salt__, mock_data):
             non_cached_pkg = 'salt'
             comt = ('Package {0} is not in the cache'.format(non_cached_pkg))
@@ -205,7 +210,10 @@ class NpmTestCase(TestCase):
                             'changes': {name: 'Removed'}})
                 self.assertDictEqual(npm.cache_cleaned(name), pkg_ret)
 
-        mock_data = {'npm.cache_list': mock_list, 'npm.cache_clean': False}
+        mock_data = {
+            'npm.cache_list': mock_list,
+            'npm.cache_clean': mock_cache_clean_failure
+        }
         with patch.dict(npm.__salt__, {'npm.cache_clean': False}):
             with patch.dict(npm.__opts__, {'test': False}):
                 comt = ('Error cleaning cached packages')

--- a/tests/unit/states/npm_test.py
+++ b/tests/unit/states/npm_test.py
@@ -163,7 +163,7 @@ class NpmTestCase(TestCase):
 
         with patch.dict(npm.__salt__, {'npm.cache_list': mock_err}):
             comt = ("Error looking up cached {0}: ".format(name))
-            ret.update({'name': None, 'comment': comt})
+            ret.update({'name': name, 'comment': comt})
             self.assertDictEqual(npm.cache_cleaned(name), ret)
 
         mock_data = {'npm.cache_list': mock_list, 'npm.cache_clean': True}

--- a/tests/unit/states/npm_test.py
+++ b/tests/unit/states/npm_test.py
@@ -218,7 +218,7 @@ class NpmTestCase(TestCase):
             with patch.dict(npm.__opts__, {'test': False}):
                 comt = ('Error cleaning cached {0}'.format(name))
                 pkg_ret.update({'result': False, 'comment': comt})
-                pkg_ret['changes']  = {}
+                pkg_ret['changes'] = {}
                 self.assertDictEqual(npm.cache_cleaned(name), pkg_ret)
 
 

--- a/tests/unit/states/npm_test.py
+++ b/tests/unit/states/npm_test.py
@@ -158,7 +158,7 @@ class NpmTestCase(TestCase):
         mock_err = MagicMock(side_effect=[CommandExecutionError, False, True])
         with patch.dict(npm.__salt__, {'npm.cache_list': mock_err}):
             comt = ('Error looking up cached packages: ')
-            ret.update({'comment': comt})
+            ret.update({'name': None, 'comment': comt})
             self.assertDictEqual(npm.cache_cleaned(), ret)
 
             comt = ("Error looking up cached {0}: ".format(name))

--- a/tests/unit/states/npm_test.py
+++ b/tests/unit/states/npm_test.py
@@ -149,63 +149,72 @@ class NpmTestCase(TestCase):
         '''
         name = 'coffee-script'
 
-        ret = {'name': name,
-               'result': False,
-               'comment': '',
-               'changes': {}}
+        pkg_ret = {
+            'name': name,
+            'result': False,
+            'comment': '',
+            'changes': {}
+        }
+        ret = {
+            'name': None,
+            'result': False,
+            'comment': '',
+            'changes': {}
+        }
 
         mock_list = MagicMock(return_value=['~/.npm', '~/.npm/{0}/'.format(name)])
         mock_err = MagicMock(side_effect=CommandExecutionError)
 
         with patch.dict(npm.__salt__, {'npm.cache_list': mock_err}):
             comt = ('Error looking up cached packages: ')
-            ret.update({'name': None, 'comment': comt})
+            ret.update({'comment': comt})
             self.assertDictEqual(npm.cache_cleaned(), ret)
 
         with patch.dict(npm.__salt__, {'npm.cache_list': mock_err}):
             comt = ("Error looking up cached {0}: ".format(name))
-            ret.update({'name': name, 'comment': comt})
-            self.assertDictEqual(npm.cache_cleaned(name), ret)
+            pkg_ret.update({'comment': comt})
+            self.assertDictEqual(npm.cache_cleaned(name), pkg_ret)
 
         mock_data = {'npm.cache_list': mock_list, 'npm.cache_clean': True}
         with patch.dict(npm.__salt__, mock_data):
-            comt = ('Package {0} is not in the cache'.format('salt'))
-            ret.update({'name': 'salt', 'result': True, 'comment': comt})
-            self.assertDictEqual(npm.cache_cleaned('salt'), ret)
+            non_cached_pkg = 'salt'
+            comt = ('Package {0} is not in the cache'.format(non_cached_pkg))
+            pkg_ret.update({'name': non_cached_pkg, 'result': True, 'comment': comt})
+            self.assertDictEqual(npm.cache_cleaned(non_cached_pkg), pkg_ret)
 
             with patch.dict(npm.__opts__, {'test': True}):
                 comt = ('Cached packages set to be removed')
-                ret.update({'name': None, 'result': None, 'comment': comt})
+                ret.update({'result': None, 'comment': comt})
                 self.assertDictEqual(npm.cache_cleaned(), ret)
 
             with patch.dict(npm.__opts__, {'test': True}):
                 comt = ('Cached {0} set to be removed'.format(name))
-                ret.update({'result': None, 'comment': comt})
-                self.assertDictEqual(npm.cache_cleaned(name), ret)
+                pkg_ret.update({'result': None, 'comment': comt})
+                self.assertDictEqual(npm.cache_cleaned(name), pkg_ret)
 
             with patch.dict(npm.__opts__, {'test': False}):
                 comt = ('Cached packages successfully removed')
-                ret.update({'name': None, 'result': True, 'comment': comt,
+                ret.update({'result': True, 'comment': comt,
                             'changes': {'cache': 'Removed'}})
                 self.assertDictEqual(npm.cache_cleaned(), ret)
 
             with patch.dict(npm.__opts__, {'test': False}):
                 comt = ('Package {0} successfully removed'.format(name))
-                ret.update({'result': True, 'comment': comt,
+                pkg_ret.update({'result': True, 'comment': comt,
                             'changes': {name: 'Removed'}})
-                self.assertDictEqual(npm.cache_cleaned(name), ret)
+                self.assertDictEqual(npm.cache_cleaned(name), pkg_ret)
 
         mock_data = {'npm.cache_list': mock_list, 'npm.cache_clean': False}
         with patch.dict(npm.__salt__, {'npm.cache_clean': False}):
             with patch.dict(npm.__opts__, {'test': False}):
                 comt = ('Error cleaning cached packages')
-                ret.update({'name': None, 'result': False, 'comment': comt})
+                ret.update({'result': False, 'comment': comt})
                 self.assertDictEqual(npm.cache_cleaned(), ret)
 
             with patch.dict(npm.__opts__, {'test': False}):
                 comt = ('Error cleaning cached {0}'.format(name))
-                ret.update({'result': False, 'comment': comt})
-                self.assertDictEqual(npm.cache_cleaned(name), ret)
+                pkg_ret.update({'result': False, 'comment': comt})
+                self.assertDictEqual(npm.cache_cleaned(name), pkg_ret)
 
 
 if __name__ == '__main__':

--- a/tests/unit/states/npm_test.py
+++ b/tests/unit/states/npm_test.py
@@ -154,7 +154,7 @@ class NpmTestCase(TestCase):
                'comment': '',
                'changes': {}}
 
-        mock_list = MagicMock(return_value=['~/.npm', '~/.npm/{0}'.format(name)])
+        mock_list = MagicMock(return_value=['~/.npm', '~/.npm/{0}/'.format(name)])
         mock_err = MagicMock(side_effect=CommandExecutionError)
 
         with patch.dict(npm.__salt__, {'npm.cache_list': mock_err}):

--- a/tests/unit/states/npm_test.py
+++ b/tests/unit/states/npm_test.py
@@ -166,7 +166,7 @@ class NpmTestCase(TestCase):
             self.assertDictEqual(npm.cache_cleaned(name), ret)
 
         mock_data = {'npm.cache_list': mock_list, 'npm.cache_clean': True}
-        with patch.dict(npm.__salt__, mock_data)
+        with patch.dict(npm.__salt__, mock_data):
             comt = ('Package {} is not in the cache'.format(name))
             ret.update({'comment': comt, 'result': True})
             self.assertDictEqual(npm.cache_cleaned('salt'), ret)

--- a/tests/unit/states/npm_test.py
+++ b/tests/unit/states/npm_test.py
@@ -174,7 +174,7 @@ class NpmTestCase(TestCase):
 
             with patch.dict(npm.__opts__, {'test': True}):
                 comt = ('Cached packages set to be removed')
-                ret.update({'comment': comt, 'result': None})
+                ret.update({'name': None, 'comment': comt, 'result': None})
                 self.assertDictEqual(npm.cache_cleaned(), ret)
 
             with patch.dict(npm.__opts__, {'test': True}):
@@ -184,7 +184,7 @@ class NpmTestCase(TestCase):
 
             with patch.dict(npm.__opts__, {'test': False}):
                 comt = ('Cached packages successfully removed')
-                ret.update({'comment': comt, 'result': True,
+                ret.update({'name': None, 'comment': comt, 'result': True,
                             'changes': {'cache': 'Removed'}})
                 self.assertDictEqual(npm.cache_cleaned(), ret)
 
@@ -198,7 +198,7 @@ class NpmTestCase(TestCase):
         with patch.dict(npm.__salt__, {'npm.cache_clean': False}):
             with patch.dict(npm.__opts__, {'test': False}):
                 comt = ('Error cleaning cached packages')
-                ret.update({'comment': comt, 'result': False})
+                ret.update({'name': None, 'comment': comt, 'result': False})
                 self.assertDictEqual(npm.cache_cleaned(), ret)
 
             with patch.dict(npm.__opts__, {'test': False}):

--- a/tests/unit/states/npm_test.py
+++ b/tests/unit/states/npm_test.py
@@ -126,7 +126,7 @@ class NpmTestCase(TestCase):
                'comment': '',
                'changes': {}}
 
-        mock_err = MagicMock(side_effect=CommandExecutionError)
+        mock_err = MagicMock(side_effect=[CommandExecutionError, False, True])
         with patch.dict(npm.__salt__, {'npm.install': mock_err}):
             comt = ("Error Bootstrapping 'coffee-script': ")
             ret.update({'comment': comt})
@@ -163,7 +163,7 @@ class NpmTestCase(TestCase):
 
         with patch.dict(npm.__salt__, {'npm.cache_list': mock_err}):
             comt = ("Error looking up cached {0}: ".format(name))
-            ret.update({'comment': comt})
+            ret.update({'name': None, 'comment': comt})
             self.assertDictEqual(npm.cache_cleaned(name), ret)
 
         mock_data = {'npm.cache_list': mock_list, 'npm.cache_clean': True}

--- a/tests/unit/states/npm_test.py
+++ b/tests/unit/states/npm_test.py
@@ -181,6 +181,7 @@ class NpmTestCase(TestCase):
             comt = ('Package {0} is not in the cache'.format(non_cached_pkg))
             pkg_ret.update({'name': non_cached_pkg, 'result': True, 'comment': comt})
             self.assertDictEqual(npm.cache_cleaned(non_cached_pkg), pkg_ret)
+            pkg_ret.update({'name': name})
 
             with patch.dict(npm.__opts__, {'test': True}):
                 comt = ('Cached packages set to be removed')

--- a/tests/unit/states/npm_test.py
+++ b/tests/unit/states/npm_test.py
@@ -154,20 +154,20 @@ class NpmTestCase(TestCase):
                'comment': '',
                'changes': {}}
 
-        mock_list = MagicMock(return_value=['~/.npm', '~/.npm/{}'.format(name)])
+        mock_list = MagicMock(return_value=['~/.npm', '~/.npm/{0}'.format(name)])
         mock_err = MagicMock(side_effect=[CommandExecutionError, False, True])
         with patch.dict(npm.__salt__, {'npm.cache_list': mock_err}):
             comt = ('Error looking up cached packages: ')
             ret.update({'comment': comt})
             self.assertDictEqual(npm.cache_cleaned(), ret)
 
-            comt = ("Error looking up cached '{}': ".format(name))
+            comt = ("Error looking up cached {0}: ".format(name))
             ret.update({'comment': comt})
             self.assertDictEqual(npm.cache_cleaned(name), ret)
 
         mock_data = {'npm.cache_list': mock_list, 'npm.cache_clean': True}
         with patch.dict(npm.__salt__, mock_data):
-            comt = ('Package {} is not in the cache'.format(name))
+            comt = ('Package {0} is not in the cache'.format(name))
             ret.update({'comment': comt, 'result': True})
             self.assertDictEqual(npm.cache_cleaned('salt'), ret)
 
@@ -177,7 +177,7 @@ class NpmTestCase(TestCase):
                 self.assertDictEqual(npm.cache_cleaned(), ret)
 
             with patch.dict(npm.__opts__, {'test': True}):
-                comt = ('Cached {} set to be removed'.format(name))
+                comt = ('Cached {0} set to be removed'.format(name))
                 ret.update({'comment': comt, 'result': None})
                 self.assertDictEqual(npm.cache_cleaned(name), ret)
 
@@ -188,7 +188,7 @@ class NpmTestCase(TestCase):
                 self.assertDictEqual(npm.cache_cleaned(), ret)
 
             with patch.dict(npm.__opts__, {'test': False}):
-                comt = ('Package {} successfully removed'.format(name))
+                comt = ('Package {0} successfully removed'.format(name))
                 ret.update({'comment': comt, 'result': True,
                             'changes': {name: 'Removed'}})
                 self.assertDictEqual(npm.cache_cleaned(name), ret)
@@ -201,7 +201,7 @@ class NpmTestCase(TestCase):
                 self.assertDictEqual(npm.cache_cleaned(), ret)
 
             with patch.dict(npm.__opts__, {'test': False}):
-                comt = ('Error cleaning cached {}'.format(name))
+                comt = ('Error cleaning cached {0}'.format(name))
                 ret.update({'comment': comt, 'result': False})
                 self.assertDictEqual(npm.cache_cleaned(name), ret)
 

--- a/tests/unit/states/npm_test.py
+++ b/tests/unit/states/npm_test.py
@@ -175,7 +175,7 @@ class NpmTestCase(TestCase):
             pkg_ret.update({'comment': comt})
             self.assertDictEqual(npm.cache_cleaned(name), pkg_ret)
 
-        mock_data = {'npm.cache_list': mock_list, 'npm.cache_clean': True}
+        mock_data = {'npm.cache_list': mock_list, 'npm.cache_clean': MagicMock()}
         with patch.dict(npm.__salt__, mock_data):
             non_cached_pkg = 'salt'
             comt = ('Package {0} is not in the cache'.format(non_cached_pkg))
@@ -200,21 +200,23 @@ class NpmTestCase(TestCase):
                 self.assertDictEqual(npm.cache_cleaned(), ret)
 
             with patch.dict(npm.__opts__, {'test': False}):
-                comt = ('Package {0} successfully removed'.format(name))
+                comt = ('Cached {0} successfully removed'.format(name))
                 pkg_ret.update({'result': True, 'comment': comt,
                             'changes': {name: 'Removed'}})
                 self.assertDictEqual(npm.cache_cleaned(name), pkg_ret)
 
-        mock_data = {'npm.cache_list': mock_list, 'npm.cache_clean': False}
-        with patch.dict(npm.__salt__, {'npm.cache_clean': False}):
+        mock_data = {'npm.cache_list': mock_list, 'npm.cache_clean': MagicMock(return_value=False)}
+        with patch.dict(npm.__salt__, mock_data):
             with patch.dict(npm.__opts__, {'test': False}):
                 comt = ('Error cleaning cached packages')
                 ret.update({'result': False, 'comment': comt})
+                ret['changes'] = {}
                 self.assertDictEqual(npm.cache_cleaned(), ret)
 
             with patch.dict(npm.__opts__, {'test': False}):
                 comt = ('Error cleaning cached {0}'.format(name))
                 pkg_ret.update({'result': False, 'comment': comt})
+                pkg_ret['changes']  = {}
                 self.assertDictEqual(npm.cache_cleaned(name), pkg_ret)
 
 

--- a/tests/unit/states/npm_test.py
+++ b/tests/unit/states/npm_test.py
@@ -170,7 +170,7 @@ class NpmTestCase(TestCase):
         with patch.dict(npm.__salt__, mock_data):
             comt = ('Package {0} is not in the cache'.format(name))
             ret.update({'comment': comt, 'result': True})
-            self.assertDictEqual(npm.cache_cleaned('salt'), ret)
+            self.assertDictEqual(npm.cache_cleaned(name), ret)
 
             with patch.dict(npm.__opts__, {'test': True}):
                 comt = ('Cached packages set to be removed')


### PR DESCRIPTION
Adding state for NPM cache cleaned. This state ensures that either the whole cache is cleaned or that a specific package is either not present or cleaned if it is.
Also, the NPM module now has cache_clean, cache_list, and cache_path functions.
- cache_clean: cleans either all packages in a specified path or the entire cache if no path is specified
- cache_list: lists either all cached packages or if a path is specified, it will list all cached packages within that path
- cache_path: prints the absolute path to the NPM cache

All added functionality has unit tests and the cache_cleaned state has additional integration tests.
