### PR TITLE
Update salt-cloud proxmox driver for Proxmox 4/LXC

### DIFF
--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -6,7 +6,7 @@ Proxmox Cloud Module
 .. versionadded:: 2014.7.0
 
 The Proxmox cloud module is used to control access to cloud providers using
-the Proxmox system (KVM / OpenVZ).
+the Proxmox system (KVM / OpenVZ / LXC).
 
 Set up the cloud configuration at ``/etc/salt/cloud.providers`` or
  ``/etc/salt/cloud.providers.d/proxmox.conf``:
@@ -688,7 +688,7 @@ def create_node(vm_, newid):
         # Proxmox 3, I've mapped the ip_address and gw to a generic net0 config.
         # If you need more control, please use the net0 option directly.
         # This also assumes a /24 subnet.
-        if 'ip_address' in vm_ and not 'net0' in vm_:
+        if 'ip_address' in vm_ and 'net0' not in vm_:
             newnode['net0'] = 'bridge=vmbr0,ip=' + vm_['ip_address'] + '/24,name=eth0,type=veth'
 
             # gateway is optional and does not assume a default

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -679,6 +679,10 @@ def create_node(vm_, newid):
             if prop in vm_:  # if the property is set, use it for the VM request
                 newnode[prop] = vm_[prop]
 
+        # inform user the "disk" option is not supported for LXC hosts
+        if 'disk' in vm_:
+            log.warning('The "disk" option is not supported for LXC hosts and was ignored')
+
         # LXC specific network config
         # OpenVZ allowed specifying IP and gateway. To ease migration from
         # Proxmox 3, I've mapped the ip_address and gw to a generic net0 config.

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -557,7 +557,7 @@ def create(vm_):
 
     ret['creation_data'] = data
     name = vm_['name']        # hostname which we know
-    if (vm_['clone']) is True:
+    if 'clone' in vm_ and vm_['clone'] is True:
         vmid = newid
     else:
         vmid = data['vmid']       # vmid which we have received
@@ -707,7 +707,7 @@ def create_node(vm_, newid):
 
     log.debug('Preparing to generate a node using these parameters: {0} '.format(
               newnode))
-    if vm_['clone'] is True and vm_['technology'] == 'qemu':
+    if 'clone' in vm_ and vm_['clone'] is True and vm_['technology'] == 'qemu':
         postParams = {}
         postParams['newid'] = newnode['vmid']
 

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -675,7 +675,7 @@ def create_node(vm_, newid):
         newnode['hostname'] = vm_['name']
         newnode['ostemplate'] = vm_['image']
 
-        for prop in 'cpuunits', 'description', 'memory', 'onboot', 'net0', 'password':
+        for prop in 'cpuunits', 'description', 'memory', 'onboot', 'net0', 'password', 'nameserver', 'swap', 'storage':
             if prop in vm_:  # if the property is set, use it for the VM request
                 newnode[prop] = vm_[prop]
 
@@ -833,6 +833,10 @@ def destroy(name, call=None):
         # wait until stopped
         if not wait_for_state(vmobj['vmid'], 'stopped'):
             return {'Error': 'Unable to stop {0}, command timed out'.format(name)}
+
+        # required to wait a bit here, otherwise the VM is sometimes
+        # still locked and destroy fails.
+        time.sleep(1)
 
         query('delete', 'nodes/{0}/{1}'.format(
             vmobj['node'], vmobj['id']

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -322,7 +322,7 @@ def get_resources_vms(call=None, resFilter=None, includeConfig=True):
 
     ret = {}
     for resource in resources:
-        if 'type' in resource and resource['type'] in ['openvz', 'qemu']:
+        if 'type' in resource and resource['type'] in ['openvz', 'qemu', 'lxc']:
             name = resource['name']
             ret[name] = resource
 
@@ -636,8 +636,9 @@ def create_node(vm_, newid):
     if 'technology' not in vm_:
         vm_['technology'] = 'openvz'  # default virt tech if none is given
 
-    if vm_['technology'] not in ['qemu', 'openvz']:
+    if vm_['technology'] not in ['qemu', 'openvz', 'lxc']:
         # Wrong VM type given
+        log.error('Wrong VM type. Valid options are: qemu, openvz (proxmox3) or lxc (proxmox4)')
         raise SaltCloudExecutionFailure
 
     if 'host' not in vm_:
@@ -668,6 +669,28 @@ def create_node(vm_, newid):
         for prop in 'cpus', 'disk', 'ip_address', 'nameserver', 'password', 'swap', 'poolid', 'storage':
             if prop in vm_:  # if the property is set, use it for the VM request
                 newnode[prop] = vm_[prop]
+
+    elif vm_['technology'] == 'lxc':
+        # LXC related settings, using non-default names:
+        newnode['hostname'] = vm_['name']
+        newnode['ostemplate'] = vm_['image']
+
+        for prop in 'cpuunits', 'description', 'memory', 'onboot', 'net0', 'password':
+            if prop in vm_:  # if the property is set, use it for the VM request
+                newnode[prop] = vm_[prop]
+
+        # LXC specific network config
+        # OpenVZ allowed specifying IP and gateway. To ease migration from
+        # Proxmox 3, I've mapped the ip_address and gw to a generic net0 config.
+        # If you need more control, please use the net0 option directly.
+        # This also assumes a /24 subnet.
+        if 'ip_address' in vm_ and not 'net0' in vm_:
+            newnode['net0'] = 'bridge=vmbr0,ip=' + vm_['ip_address'] + '/24,name=eth0,type=veth'
+
+            # gateway is optional and does not assume a default
+            if 'gw' in vm_:
+                newnode['net0'] = newnode['net0'] + ',gw=' + vm_['gw']
+
     elif vm_['technology'] == 'qemu':
         # optional Qemu settings
         for prop in 'acpi', 'cores', 'cpu', 'pool', 'storage', 'sata0', 'ostype', 'ide2', 'net0':


### PR DESCRIPTION
Proxmox 4 [adds several nice features](https://forum.proxmox.com/threads/proxmox-ve-4-0-released.23780/) like the switch from OpenVZ to LXC. When users [update their Proxmox installation](https://pve.proxmox.com/wiki/Upgrade_from_3.x_to_4.0) and follow the [OpenVZ to LXC migration guide](http://pve.proxmox.com/wiki/Convert_OpenVZ_to_LXC), they'll notice that salt-cloud can no longer see the LXC VMs.

This pull request updates the proxmox driver to support management of LXC containers, while it should remain backward compatible (though I haven't tested this as I only have one proxmox server at home, which now runs v4). Feedback welcome!
