### PR TITLE
ZIP Archives options addon.

### DIFF
--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -7,6 +7,7 @@ A module to wrap (non-Windows) archive calls
 from __future__ import absolute_import
 import os
 import contextlib  # For < 2.7 compat
+import logging
 
 # Import salt libs
 from salt.exceptions import SaltInvocationError, CommandExecutionError
@@ -27,6 +28,8 @@ try:
     HAS_ZIPFILE = True
 except ImportError:
     pass
+
+log = logging.getLogger(__name__)
 
 
 def __virtual__():
@@ -417,14 +420,12 @@ def cmd_unzip(zip_file, dest, excludes=None,
 
             salt '*' archive.cmd_unzip template=jinja /tmp/zipfile.zip /tmp/{{grains.id}}/ excludes=file_1,file_2
 
-    options : None
-        Additional command-line options to pass to the ``unzip`` binary.
+    options
+        Optional when using ``zip`` archives, ignored when usign other archives
+        files. This is mostly used to overwrite exsiting files with ``o``.
+        This options are only used when ``unzip`` binary is used.
 
-        .. versionchanged:: 2015.8.0
-
-            The mandatory `-` prefixing has been removed.  An options string
-            beginning with a `--long-option`, would have uncharacteristically
-            needed its first `-` removed under the former scheme.
+        .. versionadded:: 2016.3.1
 
     runas : None
         Unpack the zip file as the specified user. Defaults to the user under
@@ -449,7 +450,7 @@ def cmd_unzip(zip_file, dest, excludes=None,
 
     cmd = ['unzip']
     if options:
-        cmd.extend(options.split())
+        cmd.append('{0}'.format(options))
     cmd.extend(['{0}'.format(zip_file), '-d', '{0}'.format(dest)])
 
     if excludes is not None:
@@ -464,7 +465,8 @@ def cmd_unzip(zip_file, dest, excludes=None,
 
 
 @salt.utils.decorators.depends('zipfile', fallback_function=cmd_unzip)
-def unzip(zip_file, dest, excludes=None, template=None, runas=None, trim_output=False):
+def unzip(zip_file, dest, excludes=None,
+          options=None, template=None, runas=None, trim_output=False):
     '''
     Uses the ``zipfile`` Python module to unpack zip files
 
@@ -484,6 +486,12 @@ def unzip(zip_file, dest, excludes=None, template=None, runas=None, trim_output=
     excludes : None
         Comma-separated list of files not to unpack. Can also be passed in a
         Python list.
+
+    options
+        This options are only used when ``unzip`` binary is used. In this
+        function is ignored.
+
+        .. versionadded:: 2016.3.1
 
     template : None
         Can be set to 'jinja' or another supported template engine to render
@@ -507,6 +515,8 @@ def unzip(zip_file, dest, excludes=None, template=None, runas=None, trim_output=
 
         salt '*' archive.unzip /tmp/zipfile.zip /home/strongbad/ excludes=file_1,file_2
     '''
+    if options:
+        log.warn('Options \'{0}\' ignored, only works with unzip binary.'.format(options))
     if not excludes:
         excludes = []
     if runas:

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -18,8 +18,6 @@ import salt.ext.six as six
 # # Use salt.utils.fopen
 import salt.utils
 
-# remove after archive_user deprecation.
-from salt.utils import warn_until
 
 log = logging.getLogger(__name__)
 
@@ -72,6 +70,7 @@ def extracted(name,
               user=None,
               group=None,
               tar_options=None,
+              zip_options=None,
               source_hash=None,
               if_missing=None,
               keep=False,
@@ -151,12 +150,6 @@ def extracted(name,
     archive_format
         tar, zip or rar
 
-    archive_user
-        The user to own each extracted file.
-
-        .. deprecated:: Boron
-            replaced by standardized `user` parameter.
-
     user
         The user to own each extracted file.
 
@@ -184,6 +177,13 @@ def extracted(name,
         then the Python tarfile module is used. The tarfile module supports gzip
         and bz2 in Python 2.
 
+    zip_options
+        Optional when using ``zip`` archives, ignored when usign other archives
+        files. This is mostly used to overwrite exsiting files with ``o``.
+        This options are only used when ``unzip`` binary is used.
+
+        .. versionadded:: 2016.3.1
+
     keep
         Keep the archive in the minion's cache
 
@@ -200,16 +200,6 @@ def extracted(name,
         ret['comment'] = '{0} is not supported, valid formats are: {1}'.format(
             archive_format, ','.join(valid_archives))
         return ret
-
-    # remove this whole block after formal deprecation.
-    if archive_user is not None:
-        warn_until(
-          'Boron',
-          'Passing \'archive_user\' is deprecated.'
-          'Pass \'user\' instead.'
-        )
-        if user is None:
-            user = archive_user
 
     if not name.endswith('/'):
         name += '/'
@@ -283,7 +273,7 @@ def extracted(name,
 
     log.debug('Extract {0} in {1}'.format(filename, name))
     if archive_format == 'zip':
-        files = __salt__['archive.unzip'](filename, name, trim_output=trim_output)
+        files = __salt__['archive.unzip'](filename, name, options=zip_options, trim_output=trim_output)
     elif archive_format == 'rar':
         files = __salt__['archive.unrar'](filename, name, trim_output=trim_output)
     else:


### PR DESCRIPTION
When using unzip binary extend command with zip_options. Note that options was
already present but not used. Also since cmd_unzip is just a fallback functions
zip_options will be ignored when zipfile library is present.
This is some kind hacky because zipfile library and unzip binary are way diferrent and having
the same variable to hold options for both function is really complex.

Additional notes:  Boron warning removed.

I didn't saw an option to force overwrite, Salt will check if directory exists and will not execute any unzip command. This is probably because I missing something.

Fixes #30688 / #23758.
