### PR TITLE
Changed glusterfs.peer() module so state can handle localhost peering attempts.

### DIFF
--- a/salt/modules/glusterfs.py
+++ b/salt/modules/glusterfs.py
@@ -159,7 +159,12 @@ def peer(name):
             'Invalid characters in peer name "{0}"'.format(name))
 
     cmd = 'peer probe {0}'.format(name)
-    return _gluster_xml(cmd).find('opRet').text == '0'
+
+    op_result = {
+        "exitval": _gluster_xml(cmd).find('opRet').text,
+        "output": _gluster_xml(cmd).find('output').text
+    }
+    return op_result
 
 
 def create(name, bricks, stripe=False, replica=False, device_vg=False,

--- a/salt/states/glusterfs.py
+++ b/salt/states/glusterfs.py
@@ -65,7 +65,7 @@ def peered(name):
         ret['result'] = False
         return ret
 
-    ret['comment'] = __salt__['glusterfs.peer'](name)
+    ret['comment'] = __salt__['glusterfs.peer'](name)['output']
 
     newpeers = __salt__['glusterfs.list_peers']()
     #if newpeers was null, we know something didn't work.

--- a/salt/states/glusterfs.py
+++ b/salt/states/glusterfs.py
@@ -65,7 +65,10 @@ def peered(name):
         ret['result'] = False
         return ret
 
-    ret['comment'] = __salt__['glusterfs.peer'](name)['output']
+    if 'output' in __salt__['glusterfs.peer'](name):
+        ret['comment'] = __salt__['glusterfs.peer'](name)['output']
+    else:
+        ret['comment'] = ''
 
     newpeers = __salt__['glusterfs.list_peers']()
     #if newpeers was null, we know something didn't work.

--- a/tests/unit/states/glusterfs_test.py
+++ b/tests/unit/states/glusterfs_test.py
@@ -67,15 +67,15 @@ class GlusterfsTestCase(TestCase):
             with patch.object(socket, 'gethostname',
                               MagicMock(side_effect=[name, 'salt.host',
                                                      'salt.host'])):
-                ret.update({'comment': [], 'result': True})
+                ret.update({'comment': '', 'result': True})
                 self.assertDictEqual(glusterfs.peered(name), ret)
 
                 comt = ('Host {0} already peered'.format(name))
-                ret.update({'comment': [], 'result': True})
+                ret.update({'comment': '', 'result': True})
                 self.assertDictEqual(glusterfs.peered(name), ret)
 
             comt = ('Host {0} already peered'.format(name))
-            ret.update({'comment': [], 'result': True,
+            ret.update({'comment': '', 'result': True,
                         'changes': {'new': ['salt'], 'old': []}})
             self.assertDictEqual(glusterfs.peered(name), ret)
 


### PR DESCRIPTION
When the _gluster_xml command-calling method was introduced, glusterfs.peer() lost the ability to pass the output string back to the calling function. This meant that, in the case that you were attempting to peer probe localhost, glusterfs.peer would return successfully, the state would populate its .comment return value with a boolean value, and the output formatters would not be able to cast bool correctly, making the output look different. Not a functional regression, just a display one.

This just changes glusterfs.peer() to return a dict with the return code and output - possibly overkill since it's not used anywhere, but it's a little nicer for command-line execution now as well. I couldn't find any other references to return codes anywhere else, but if people were relying on the return val of the module being boolean, this would break that.

I think having the command exitval is more useful, personally.
