### PR TITLE
changes to debian_ip module

### DIFF
--- a/salt/templates/debian_ip/display-network.jinja
+++ b/salt/templates/debian_ip/display-network.jinja
@@ -1,4 +1,5 @@
 {% if networking %}NETWORKING={{networking}}
 {%endif%}{% if hostname %}HOSTNAME={{hostname}}
 {%endif-%}{% if domainname %}DOMAIN={{domainname}}
+{%endif-%}{% if searchdomain %}SEARCH={{searchdomain}}
 {%endif-%}


### PR DESCRIPTION
Changes to the debian_ip module to be able to manage the search domain in /etc/resolv.conf by passing search as an option to the network.system state.  This change only affects Debian based distributions, eg. Debian, Ubuntu, etc. #30935
