### PR TITLE
add_key/reject_key: do not crash w/Permission denied: '/var/cache/salt/master/.dfn' (#27796)

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -55,6 +55,9 @@ def dropfile(cachedir, user=None):
     mask = os.umask(191)
     try:
         log.info('Rotating AES key')
+        if os.path.isfile(dfn):
+            log.info('AES key rotation already requested')
+            return
 
         with salt.utils.fopen(dfn, 'wb+') as fp_:
             fp_.write('')


### PR DESCRIPTION
This happens when you reject a key right after you deleted one or vice-versa and the master has not yet processed the rotation request.

The umask set does not allow salt-key to overwrite the .dfn file. However, if the
master has not yet rotated the key but the rotation was requested, there should be no
reason to request a second time.

See https://github.com/saltstack/salt/issues/27796
