### PR TITLE
Fix lxc cloud provided minion reporting present

### DIFF
--- a/salt/states/cloud.py
+++ b/salt/states/cloud.py
@@ -260,8 +260,7 @@ def profile(name, profile, onlyif=None, unless=None, **kwargs):
             if retcode(unless, python_shell=True) == 0:
                 return _valid(name, comment='unless execution succeeded')
     instance = _get_instance([name])
-    prov = str(next(six.iterkeys(instance)))
-    if instance and 'Not Actioned' not in prov:
+    if instance and not any('Not Actioned' in key for key in instance):
         ret['result'] = True
         ret['comment'] = 'Already present instance {0}'.format(name)
         return ret

--- a/tests/unit/states/cloud_test.py
+++ b/tests/unit/states/cloud_test.py
@@ -146,7 +146,11 @@ class CloudTestCase(TestCase):
         mock = MagicMock(side_effect=[True, False])
         mock_dict = MagicMock(side_effect=[{'cloud': 'saltcloud'},
                                            {'Not Actioned': True},
-                                           {'Not Actioned': True}])
+                                           {'Not Actioned': True},
+                                           {
+                                                'Not Found': True,
+                                                'Not Actioned/Not Running': True
+                                           }])
         mock_d = MagicMock(return_value={})
         with patch.dict(cloud.__salt__, {'cmd.retcode': mock,
                                          'cloud.profile': mock_d,
@@ -171,6 +175,12 @@ class CloudTestCase(TestCase):
             with patch.dict(cloud.__opts__, {'test': True}):
                 comt = ('Instance {0} needs to be created'.format(name))
                 ret.update({'comment': comt, 'result': None})
+                self.assertDictEqual(cloud.profile(name, profile), ret)
+
+            with patch.dict(cloud.__opts__, {'test': False}):
+                comt = (('Failed to create instance {0}'
+                         'using profile {1}').format(name, profile))
+                ret.update({'comment': comt, 'result': False})
                 self.assertDictEqual(cloud.profile(name, profile), ret)
 
             with patch.dict(cloud.__opts__, {'test': False}):


### PR DESCRIPTION
LXC minion is reporting as present when configured with cloud state, even though it is not.

Fixes issue #31000.

Note that this is probably present in earlier versions as well.
