### PR TITLE
Accept non-lowercase gitfs_provider config

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -1971,6 +1971,13 @@ class GitBase(object):
                 elif self.verify_dulwich(quiet=True):
                     self.provider = 'dulwich'
             else:
+                if any(c.isupper() for c in desired_provider):
+                    salt.utils.warn_until(
+                        'Carbon',
+                        'Uppercase {0}_provider name \'{1}\' is deprecated.'
+                        .format(self.role, desired_provider))
+                    desired_provider = desired_provider.lower()
+
                 if desired_provider not in self.valid_providers:
                     log.critical(
                         'Invalid {0}_provider \'{1}\'. Valid choices are: {2}'


### PR DESCRIPTION
Until 2015.5 `gitfs_provider` options containing uppercase letters (like "GitPython") were accepted without a warning. The rewritten gitfs code doesn't contain the `provider = __opts__.get('gitfs_provider', '').lower()` command, which renders formerly valid (and sensible, as GitPyhon is often mentioned with camelcase letters) configs invalid.

The patch is written blindly, I couldn't try it.
