### PR TITLE
Remove overstate docs and a few references.

### DIFF
--- a/doc/ref/states/layers.rst
+++ b/doc/ref/states/layers.rst
@@ -78,7 +78,7 @@ the json, yaml, or pprint outputters:
 .. _state-layers-sls:
 
 SLS
-====
+===
 
 Above "High Data", the logical layers are no longer technically required to be
 executed, or to be executed in a hierarchy. This means that how the High data
@@ -122,13 +122,13 @@ To execute the High State call ``state.highstate``:
 
     salt '*' state.highstate
 
-.. _state-layers-overstate:
+.. _state-layers-orchestrate:
 
-OverState
-=========
+Orchestrate
+===========
 
-The overstate layer expresses the highest functional layer of Salt's automated
+The orchestrate layer expresses the highest functional layer of Salt's automated
 logic systems. The Overstate allows for stateful and functional orchestration
-of routines from the master. The overstate defines in data execution stages
+of routines from the master. The orchestrate defines in data execution stages
 which minions should execute states, or functions, and in what order using
 requisite logic.

--- a/doc/ref/states/overstate.rst
+++ b/doc/ref/states/overstate.rst
@@ -1,7 +1,0 @@
-================
-OverState System
-================
-
-.. note::
-
-    This documentation has been moved :ref:`here <states-overstate>`.

--- a/doc/topics/tutorials/states_pt5.rst
+++ b/doc/topics/tutorials/states_pt5.rst
@@ -32,7 +32,7 @@ The Orchestrate Runner
 
   The Orchestrate Runner was added with the intent to eventually deprecate the
   OverState system, however the OverState will still be maintained until Salt
-  Boron.
+  2015.8.0.
 
 The orchestrate runner generalizes the Salt state system to a Salt master
 context.  Whereas the ``state.sls``, ``state.highstate``, et al functions are


### PR DESCRIPTION
The overstate system was deprecated and removed in Beryllium, in favor of orchestrate.

Fixes #30993
