### PR TITLE
Fix regression in vmware.create_snapshot function.

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1497,13 +1497,18 @@ class Cloud(object):
                             argnames = inspect.getargspec(self.clouds[fun]).args
                             for _ in inspect.getargspec(self.clouds[fun]).defaults:
                                 argnames.pop(0)
-                            kws = {}
-                            for kwarg in argnames:
-                                kws[kwarg] = kwargs.get(kwarg, None)
-                            kws['call'] = 'action'
-                            ret[alias][driver][vm_name] = self.clouds[fun](
-                                vm_name, **kws
-                            )
+                            if argnames:
+                                kws = {}
+                                for kwarg in argnames:
+                                    kws[kwarg] = kwargs.get(kwarg, None)
+                                kws['call'] = 'action'
+                                ret[alias][driver][vm_name] = self.clouds[fun](
+                                    vm_name, **kws
+                                )
+                            else:
+                                ret[alias][driver][vm_name] = self.clouds[fun](
+                                    vm_name, kwargs, call='action'
+                                )
                         else:
                             ret[alias][driver][vm_name] = self.clouds[fun](
                                 vm_name, call='action'

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -3056,7 +3056,7 @@ def create_snapshot(name, kwargs=None, call=None):
         log.warning('You can only set either memdump or quiesce to True. Setting quiesce=False')
         quiesce = False
 
-    desc = kwargs.get('description') if 'description' in kwargs else ''
+    desc = kwargs.get('description') if kwargs and 'description' in kwargs else ''
 
     try:
         task = vm_ref.CreateSnapshot(snapshot_name, desc, memdump, quiesce)

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -3031,9 +3031,6 @@ def create_snapshot(name, kwargs=None, call=None):
             '-a or --action.'
         )
 
-    if kwargs is None:
-        kwargs = {}
-
     snapshot_name = kwargs.get('snapshot_name') if kwargs and 'snapshot_name' in kwargs else None
 
     if not snapshot_name:
@@ -3041,8 +3038,11 @@ def create_snapshot(name, kwargs=None, call=None):
             'You must specify snapshot name for the snapshot to be created.'
         )
 
-    memdump = _str_to_bool(kwargs.get('memdump', True))
-    quiesce = _str_to_bool(kwargs.get('quiesce', False))
+    memdump = kwargs.get('memdump') if kwargs and 'memdump' in kwargs else True
+    memdump = _str_to_bool(memdump)
+
+    quiesce = kwargs.get('quiesce') if kwargs and 'quiesce' in kwargs else False
+    quiesce = _str_to_bool(quiesce)
 
     vm_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.VirtualMachine, name)
 
@@ -3104,10 +3104,7 @@ def revert_to_snapshot(name, kwargs=None, call=None):
             '-a or --action.'
         )
 
-    if kwargs is None:
-        kwargs = {}
-
-    suppress_power_on = _str_to_bool(kwargs.get('power_off', False))
+    suppress_power_on = _str_to_bool(kwargs.get('power_off', False)) if kwargs else False
 
     vm_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.VirtualMachine, name)
 

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -3038,11 +3038,8 @@ def create_snapshot(name, kwargs=None, call=None):
             'You must specify snapshot name for the snapshot to be created.'
         )
 
-    memdump = kwargs.get('memdump') if kwargs and 'memdump' in kwargs else True
-    memdump = _str_to_bool(memdump)
-
-    quiesce = kwargs.get('quiesce') if kwargs and 'quiesce' in kwargs else False
-    quiesce = _str_to_bool(quiesce)
+    memdump = _str_to_bool(kwargs.get('memdump', True))
+    quiesce = _str_to_bool(kwargs.get('quiesce', False))
 
     vm_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.VirtualMachine, name)
 
@@ -3056,7 +3053,7 @@ def create_snapshot(name, kwargs=None, call=None):
         log.warning('You can only set either memdump or quiesce to True. Setting quiesce=False')
         quiesce = False
 
-    desc = kwargs.get('description') if kwargs and 'description' in kwargs else ''
+    desc = kwargs.get('description', '')
 
     try:
         task = vm_ref.CreateSnapshot(snapshot_name, desc, memdump, quiesce)

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2996,7 +2996,7 @@ def create_folder(kwargs=None, call=None):
         return {inventory_path: 'created the specified path'}
 
 
-def create_snapshot(name, kwargs=None, call=None):
+def create_snapshot(name=None, kwargs=None, call=None):
     '''
     Create a snapshot of the specified virtual machine in this VMware
     environment
@@ -3023,7 +3023,7 @@ def create_snapshot(name, kwargs=None, call=None):
     .. code-block:: bash
 
         salt-cloud -a create_snapshot vmname snapshot_name="mySnapshot"
-        salt-cloud -a create_snapshot vmname snapshot_name="mySnapshot" [description="My snapshot"] [memdump=False] [quiesce=True]
+        salt-cloud -a create_snapshot vmname snapshot_name="mySnapshot" description="My snapshot" memdump=False quiesce=True
     '''
     if call != 'action':
         raise SaltCloudSystemExit(


### PR DESCRIPTION
Fixes #30950

The VMware driver uses a little bit different syntax than other cloud drivers.
This PR reverts the breakage caused by #29646 and ensures other 'kwargs.get'
stacktraces do not occur, as present in issue #29488.

ping @nmadhok 
