### PR TITLE
Handle ancient pip versions

### DIFF
--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -48,7 +48,7 @@ if HAS_PIP is True:
         if 'pip' in sys.modules:
             del sys.modules['pip']
 
-    ver = pip.__version__.split('.')
+    ver = getattr(pip, '__version__', '0.0.0').split('.')
     pip_ver = tuple([int(x) for x in ver if x.isdigit()])
     if pip_ver >= (8, 0, 0):
         from pip.exceptions import InstallationError

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -57,13 +57,6 @@ if HAS_PIP is True:
 
 # pylint: enable=import-error
 
-    ver = pip.__version__.split('.')
-    pip_ver = tuple([int(x) for x in ver if x.isdigit()])
-    if pip_ver >= (8, 0, 0):
-        from pip.exceptions import InstallationError
-    else:
-        InstallationError = ValueError
-
 logger = logging.getLogger(__name__)
 
 # Define the module's virtual name


### PR DESCRIPTION
The version of pip that ships with Ubuntu 12.04 doesn't have the `__version__` attribute. This causes the state module to fail to load and throw an ugly error on every highstate run.

See #31025
