### PR TITLE
Fix config overwrite by windows installer

### DIFF
--- a/pkg/windows/BuildSalt.bat
+++ b/pkg/windows/BuildSalt.bat
@@ -44,6 +44,8 @@ python "%CurrDir%\portable.py" -f "%BinDir%\Scripts\pip2.exe"
 del /S /Q "%BinDir%\*.pyc"
 :: Remove all Compiled HTML Help (.chm)
 del /S /Q "%BinDir%\*.chm"
+:: Remove all empty text files (they are placeholders for git)
+del /S /Q "%BinDir%\empty"
 
 :: Delete Unused Docs and Modules
 If Exist "%BinDir%\Doc"           rd /S /Q "%BinDir%\Doc"

--- a/pkg/windows/BuildSalt.bat
+++ b/pkg/windows/BuildSalt.bat
@@ -45,7 +45,7 @@ del /S /Q "%BinDir%\*.pyc"
 :: Remove all Compiled HTML Help (.chm)
 del /S /Q "%BinDir%\*.chm"
 :: Remove all empty text files (they are placeholders for git)
-del /S /Q "%BinDir%\empty"
+del /S /Q "%BinDir%\empty.*"
 
 :: Delete Unused Docs and Modules
 If Exist "%BinDir%\Doc"           rd /S /Q "%BinDir%\Doc"

--- a/pkg/windows/BuildSalt.bat
+++ b/pkg/windows/BuildSalt.bat
@@ -45,7 +45,7 @@ del /S /Q "%BinDir%\*.pyc"
 :: Remove all Compiled HTML Help (.chm)
 del /S /Q "%BinDir%\*.chm"
 :: Remove all empty text files (they are placeholders for git)
-del /S /Q "%BinDir%\empty.*"
+del /S /Q "%BinDir%\..\empty.*"
 
 :: Delete Unused Docs and Modules
 If Exist "%BinDir%\Doc"           rd /S /Q "%BinDir%\Doc"

--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -222,7 +222,7 @@ ShowUnInstDetails show
 Section "MainSection" SEC01
 
   SetOutPath "$INSTDIR\"
-  SetOverwrite try
+  SetOverwrite off
   CreateDirectory $INSTDIR\conf\pki\minion
   File /r "..\buildenv\"
   Exec 'icacls c:\salt /inheritance:r /grant:r "BUILTIN\Administrators":(OI)(CI)F /grant:r "NT AUTHORITY\SYSTEM":(OI)(CI)F'


### PR DESCRIPTION
Fixes #30938 

Windows Installer no longer overwrites minion config
Git folder place holders removed (empty.txt)
