### PR TITLE
Windows defaults to multiprocessing true

### DIFF
--- a/pkg/windows/buildenv/conf/minion
+++ b/pkg/windows/buildenv/conf/minion
@@ -281,7 +281,7 @@ pki_dir: /conf/pki/minion
 ###########################################
 # Disable multiprocessing support, by default when a minion receives a
 # publication a new process is spawned and the command is executed therein.
-multiprocessing: True
+# multiprocessing: True
 
 ######         Logging settings       #####
 ###########################################

--- a/salt/config.py
+++ b/salt/config.py
@@ -54,10 +54,8 @@ if salt.utils.is_windows():
     # support in ZeroMQ, we want the default to be something that has a
     # chance of working.
     _DFLT_IPC_MODE = 'tcp'
-    _DFLT_MULTIPROCESSING_MODE = False
 else:
     _DFLT_IPC_MODE = 'ipc'
-    _DFLT_MULTIPROCESSING_MODE = True
 
 FLO_DIR = os.path.join(
         os.path.dirname(__file__),
@@ -882,7 +880,7 @@ DEFAULT_MINION_OPTS = {
     'open_mode': False,
     'auto_accept': True,
     'autosign_timeout': 120,
-    'multiprocessing': _DFLT_MULTIPROCESSING_MODE,
+    'multiprocessing': True,
     'mine_interval': 60,
     'ipc_mode': _DFLT_IPC_MODE,
     'ipv6': False,


### PR DESCRIPTION
Fixes #30938 

Multiprocessing defaults to True for windows
Removed special handling for windows in `config.py`
