### PR TITLE
More complete fix for #31014

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -238,8 +238,7 @@ def _repoquery(repoquery_args,
     '''
     _check_repoquery()
     if _yum() == 'dnf':
-        cmd = ['dnf', 'repoquery', '--quiet', '--queryformat',
-               query_format.replace('-%{VERSION}_', '-%{EPOCH}:%{VERSION}_')]
+        cmd = ['dnf', 'repoquery', '--quiet', '--queryformat', query_format]
     else:
         cmd = ['repoquery', '--plugins', '--queryformat', query_format]
 
@@ -257,11 +256,7 @@ def _repoquery(repoquery_args,
             comment += call['stdout']
         raise CommandExecutionError(comment)
     else:
-        if _yum() == 'dnf':
-            # Remove the epoch when it is zero to maintain backward compatibility
-            return call['stdout'].replace('_|-0:', '_|-').splitlines()
-        else:
-            return call['stdout'].splitlines()
+        return call['stdout'].splitlines()
 
 
 def _get_repo_options(**kwargs):

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -336,11 +336,11 @@ def _get_branch_option(**kwargs):
     # Get branch option from the kwargs
     branch = kwargs.get('branch', '')
 
-    branch_arg = ''
+    ret = []
     if branch:
         log.info('Adding branch \'{0}\''.format(branch))
-        branch_arg = '--branch=\'{0}\''.format(branch)
-    return branch_arg
+        ret.append('--branch=\'{0}\''.format(branch))
+    return ret
 
 
 def _get_yum_config():

--- a/salt/utils/pkg/rpm.py
+++ b/salt/utils/pkg/rpm.py
@@ -31,6 +31,7 @@ ARCHES_SH = ('sh3', 'sh4', 'sh4a')
 ARCHES = ARCHES_64 + ARCHES_32 + ARCHES_PPC + ARCHES_S390 + \
     ARCHES_ALPHA + ARCHES_ARM + ARCHES_SH
 
+# EPOCHNUM can't be used until RHEL5 is EOL as it is not present
 QUERYFORMAT = '%{NAME}_|-%{EPOCH}_|-%{VERSION}_|-%{RELEASE}_|-%{ARCH}_|-%{REPOID}'
 
 
@@ -96,6 +97,6 @@ def parse_pkginfo(line, osarch=None):
     if release:
         version += '-{0}'.format(release)
     if epoch not in ('(none)', '0'):
-        version = '{0}:{1}'.format(epoch, version)
+        version = ':'.join((epoch, version))
 
     return pkginfo(name, version, arch, repoid)

--- a/salt/utils/pkg/rpm.py
+++ b/salt/utils/pkg/rpm.py
@@ -31,7 +31,7 @@ ARCHES_SH = ('sh3', 'sh4', 'sh4a')
 ARCHES = ARCHES_64 + ARCHES_32 + ARCHES_PPC + ARCHES_S390 + \
     ARCHES_ALPHA + ARCHES_ARM + ARCHES_SH
 
-QUERYFORMAT = '%{NAME}_|-%{VERSION}_|-%{RELEASE}_|-%{ARCH}_|-%{REPOID}'
+QUERYFORMAT = '%{NAME}_|-%{EPOCH}_|-%{VERSION}_|-%{RELEASE}_|-%{ARCH}_|-%{REPOID}'
 
 
 def get_osarch():
@@ -86,7 +86,7 @@ def parse_pkginfo(line, osarch=None):
     pkginfo namedtuple.
     '''
     try:
-        name, version, release, arch, repoid = line.split('_|-')
+        name, epoch, version, release, arch, repoid = line.split('_|-')
     # Handle unpack errors (should never happen with the queryformat we are
     # using, but can't hurt to be careful).
     except ValueError:
@@ -95,5 +95,7 @@ def parse_pkginfo(line, osarch=None):
     name = resolve_name(name, arch, osarch)
     if release:
         version += '-{0}'.format(release)
+    if epoch not in ('(none)', '0'):
+        version = '{0}:{1}'.format(epoch, version)
 
     return pkginfo(name, version, arch, repoid)


### PR DESCRIPTION
This pull request incorporates the partial fix in #31015 and makes it work
properly for dnf as well as yum.

It also resolves a regression in epoch handling that was introduced when
`pkg.latest_version` was modified to the output from `yum list available`
instead of using repoquery, which is the root cause of #31014.

Resolves #31014.
