### PR TITLE
Specify usage of `lookup` key in formulas pillars

### DIFF
--- a/doc/topics/development/conventions/formulas.rst
+++ b/doc/topics/development/conventions/formulas.rst
@@ -777,6 +777,21 @@ state file using the following syntax:
       service.running:
         - name: {{ mysql.service }}
 
+Organizing Pillar data
+``````````````````````
+
+It is considered a best practice to make formulas expect **all**
+formula-related parameters to be placed under second-level ``lookup`` key,
+within a main namespace designated for holding data for particular
+service/software/etc, managed by the formula:
+
+.. code-block:: yaml
+
+mysql:
+  lookup:
+    version: 5.7.11
+    ...
+
 Collecting common values
 ````````````````````````
 


### PR DESCRIPTION
There was a [discussion in `salt-users`](https://groups.google.com/d/topic/salt-users/N5Pz2DDygAE/discussion) about the subject and Seth House (@whiteinge) [stated](https://groups.google.com/d/msg/salt-users/N5Pz2DDygAE/hp3FGP_xCAAJ), that it is a best practice in formulas development, to make formulas expect all parameters placed under `lookup` sub-namespace.

This patch clarifies that in the documentation.
