### PR TITLE
Allow using Windows path in archive.extracted name attribute

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -7,6 +7,7 @@ Extract an archive
 
 # Import Python libs
 from __future__ import absolute_import
+import re
 import os
 import logging
 import tarfile
@@ -168,7 +169,7 @@ def extracted(name,
     filename = os.path.join(__opts__['cachedir'],
                             'files',
                             __env__,
-                            '{0}.{1}'.format(if_missing.replace('/', '_'),
+                            '{0}.{1}'.format(re.sub('[:/\\\\]', '_', if_missing),
                                              archive_format))
     if not os.path.exists(filename):
         if __opts__['test']:


### PR DESCRIPTION
The following SLS will fail to compile on a Windows minion:

```
cygwin-salt-1:
  archive.extracted:
    - name: g:/somedir/
    - source: salt://files/tools/cygwin-salt-1.zip
    - archive_format: zip
```

Processing fails with this error message:

```
Comment: Specified file g:_somedir_.zip is not an absolute path
```

The issue here is that the colon is not replaced. If backslashes are used, the issue becomes even more convoluted as backslashes are not replaced either and are kept effective as part of the link for the downloaded archive into the salt cache.

The fix is simply to not only replace forward slashes but also backward slashes and colons.

I applied it to 2015.8 branch, please let me know if it shoulg go elsewhere too.
