### PR TITLE
Update link to the java API library project

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -17,7 +17,7 @@ A REST API for Salt
       CherryPy milestone 3.3, but the patch was committed for version 3.6.1.
 :optdepends:    - ws4py Python module for websockets support.
 :client_libraries:
-    - Java: https://github.com/SUSE/saltstack-netapi-client-java
+    - Java: https://github.com/SUSE/salt-netapi-client
     - Python: https://github.com/saltstack/pepper
 :setup:
     All steps below are performed on the machine running the Salt Master


### PR DESCRIPTION
The github project name was recently changed as part of a larger refactoring, therefore we should update the link here as well. Please see [some information about the latest release](https://github.com/SUSE/salt-netapi-client/releases/tag/v0.7.0) if you are interested.
