### PR TITLE
Fix pkg state module to deal with version 'latest'

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -711,24 +711,12 @@ def install(name=None, refresh=False, pkgs=None, saltenv='base', **kwargs):
                 ret[pkg_name] = {'current': new[pkg_name]}
 
     # Sometimes the installer takes awhile to update the registry
-    # This checks 10 times, 3 seconds between each for a registry change
-    tries = 0
     difference = salt.utils.compare_dicts(old, new)
-    while not all(name in difference for name in changed) and tries < 10:
+    if not all(name in difference for name in changed):
         __salt__['reg.broadcast_change']()
         time.sleep(3)
         new = list_pkgs()
         difference = salt.utils.compare_dicts(old, new)
-        tries += 1
-        log.debug("Try {0}".format(tries))
-        if tries == 10:
-            if not latest:
-                ret['_comment'] = 'Software not found in the registry.\n' \
-                                  'Could be a problem with the Software\n' \
-                                  'definition file. Verify the full_name\n' \
-                                  'and the version match the registry ' \
-                                  'exactly.\n' \
-                                  'Failed after {0} tries.'.format(tries)
 
     # Compare the software list before and after
     # Add the difference to ret

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -511,6 +511,9 @@ def _verify_install(desired, new_pkgs):
         if not cver:
             failed.append(pkgname)
             continue
+        elif cver == 'latest':
+            ok.append(pkgname)
+            continue
         elif not __salt__['pkg_resource.version_clean'](pkgver):
             ok.append(pkgname)
             continue

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -511,7 +511,7 @@ def _verify_install(desired, new_pkgs):
         if not cver:
             failed.append(pkgname)
             continue
-        elif cver == 'latest':
+        elif pkgver == 'latest':
             ok.append(pkgname)
             continue
         elif not __salt__['pkg_resource.version_clean'](pkgver):
@@ -921,10 +921,9 @@ def installed(
 
     kwargs['saltenv'] = __env__
     rtag = __gen_rtag()
-    refresh = bool(
-        salt.utils.is_true(refresh)
-        or (os.path.isfile(rtag) and refresh is not False)
-    )
+    refresh = bool(salt.utils.is_true(refresh) or
+                   (os.path.isfile(rtag) and salt.utils.is_true(refresh))
+                   )
     if not isinstance(pkg_verify, list):
         pkg_verify = pkg_verify is True
     if (pkg_verify or isinstance(pkg_verify, list)) \
@@ -1377,9 +1376,9 @@ def latest(
 
     '''
     rtag = __gen_rtag()
-    refresh = bool(
-        salt.utils.is_true(refresh) or (os.path.isfile(rtag) and refresh is not False)
-    )
+    refresh = bool(salt.utils.is_true(refresh) or
+                   (os.path.isfile(rtag) and salt.utils.is_true(refresh))
+                   )
 
     if kwargs.get('sources'):
         return {'name': name,
@@ -1521,7 +1520,9 @@ def latest(
         if changes:
             # Find failed and successful updates
             failed = [x for x in targets
-                      if not changes.get(x) or changes[x]['new'] != targets[x]]
+                      if not changes.get(x) or
+                      changes[x].get('new') != targets[x] and
+                      targets[x] != 'latest']
             successful = [x for x in targets if x not in failed]
 
             comments = []


### PR DESCRIPTION
Adds special handling for software definitions with a version of latest
- Fixes pkg.installed and pkg.latest
- removed unnecessary loop from win_pkg.py module

Fixes: https://github.com/saltstack/zh/issues/422

Needs to be tested with linux to be sure I didn't break anything
