### PR TITLE
Remove instructions to update salt with pip

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -40,39 +40,6 @@ with a state, for example, the following will work:
        - cwd: 'C:\salt\bin\scripts'
        - bin_env: 'C:\salt\bin\scripts\pip.exe'
        - upgrade: True
-
-Upgrading Salt using Pip
-------------------------
-
-You can now update salt using pip to any version from the 2014.7 branch
-forward. Previous version require recompiling some of the dependencies which is
-painful in windows.
-
-To do this you just use pip with git to update to the version you want and then
-restart the service. Here is a sample state file that upgrades salt to the head
-of the 2015.5 branch:
-
-.. code-block:: yaml
-
-   install_salt:
-     pip.installed:
-       - cwd: 'C:\salt\bin\scripts'
-       - bin_env: 'C:\salt\bin\scripts\pip.exe'
-       - editable: git+https://github.com/saltstack/salt@2015.5#egg=salt
-       - upgrade: True
-
-   restart_service:
-     service.running:
-       - name: salt-minion
-       - enable: True
-       - watch:
-         - pip: install_salt
-
-.. note::
-   If you're having problems, you might try doubling the back slashes. For
-   example, cwd: 'C:\\salt\\bin\\scripts'. Sometimes python thinks the single
-   back slash is an escape character.
-
 '''
 from __future__ import absolute_import
 


### PR DESCRIPTION
Fixes: #30957

This doesn't work right now. I don't know how long it's been since it has worked. Seems to be a problem with setup.py. Get's the following:

```
   installing to build\bdist.win-amd64\wheel                 
   running install                                           
   running install-pycrypto-windows                          
   No handlers could be found for logger "pip.utils"         
   error: [Error 2] The system cannot find the file specified

   ----------------------------------------                  
   Failed building wheel for salt                            
   Running setup.py clean for salt                           
 Failed to build salt                                        
```

Removing this because using pip to upgrade salt leaves things in a strange state with other dependencies, especially when updating major versions (ie: 2015.5 to 2015.8). There are other methods for salt to self update.
