### PR TITLE
Format entire device force option.

### DIFF
--- a/salt/modules/blockdev.py
+++ b/salt/modules/blockdev.py
@@ -110,7 +110,8 @@ def dump(device, args=None):
 
 @decorators.which('sync')
 @decorators.which('mkfs')
-def format_(device, fs_type='ext4', inode_size=None, lazy_itable_init=None):
+def format_(device, fs_type='ext4',
+            inode_size=None, lazy_itable_init=None, force=False):
     '''
     Format a filesystem onto a block device
 
@@ -137,6 +138,15 @@ def format_(device, fs_type='ext4', inode_size=None, lazy_itable_init=None):
 
         This option is only enabled for ext filesystems
 
+    force
+        Force mke2fs to create a filesystem, even if the specified device is
+        not a partition on a block special device. This option is only enabled
+        for ext and xfs filesystems
+
+        This option is dangerous, use it with caution.
+
+        .. versionadded:: Carbon
+
     CLI Example:
 
     .. code-block:: bash
@@ -152,6 +162,11 @@ def format_(device, fs_type='ext4', inode_size=None, lazy_itable_init=None):
     if lazy_itable_init is not None:
         if fs_type[:3] == 'ext':
             cmd.extend(['-E', 'lazy_itable_init={0}'.format(lazy_itable_init)])
+    if force:
+        if fs_type[:3] == 'ext':
+            cmd.append('-F')
+        elif fs_type == 'xfs':
+            cmd.append('-f')
     cmd.append(str(device))
 
     mkfs_success = __salt__['cmd.retcode'](cmd, ignore_retcode=True) == 0

--- a/salt/states/blockdev.py
+++ b/salt/states/blockdev.py
@@ -117,7 +117,7 @@ def tuned(name, **kwargs):
     return ret
 
 
-def formatted(name, fs_type='ext4', **kwargs):
+def formatted(name, fs_type='ext4', force=False, **kwargs):
     '''
     Manage filesystems of partitions.
 
@@ -126,6 +126,15 @@ def formatted(name, fs_type='ext4', **kwargs):
 
     fs_type
         The filesystem it should be formatted as
+
+    force
+        Force mke2fs to create a filesystem, even if the specified device is
+        not a partition on a block special device. This option is only enabled
+        for ext and xfs filesystems
+
+        This option is dangerous, use it with caution.
+
+        .. versionadded:: Carbon
     '''
     ret = {'changes': {},
            'comment': '{0} already formatted with {1}'.format(name, fs_type),
@@ -150,7 +159,7 @@ def formatted(name, fs_type='ext4', **kwargs):
         ret['result'] = None
         return ret
 
-    __salt__['blockdev.format'](name, fs_type, **kwargs)
+    __salt__['blockdev.format'](name, fs_type, force=force, **kwargs)
     current_fs = __salt__['blockdev.fstype'](name)
 
     # Repeat lsblk check up to 10 times with 3s sleeping between each


### PR DESCRIPTION
In order to force mke2fs to create a filesystem, even if the specified device is
not a partition on a block special device, force option added.

Fixes #31033.
