### PR TITLE
Fix issue where deploy_kwargs is missing.

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2436,10 +2436,12 @@ def create(vm_):
                 vm_['key_filename'] = key_filename
                 vm_['ssh_host'] = ip
 
-                salt.utils.cloud.bootstrap(vm_, __opts__)
+                out = salt.utils.cloud.bootstrap(vm_, __opts__)
 
     data = show_instance(vm_name, call='action')
-
+    if deploy:
+        data['deploy_kwargs'] = out['deploy_kwargs']
+        
     salt.utils.cloud.fire_event(
         'event',
         'created instance',

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2441,7 +2441,7 @@ def create(vm_):
     data = show_instance(vm_name, call='action')
     if deploy:
         data['deploy_kwargs'] = out['deploy_kwargs']
-        
+
     salt.utils.cloud.fire_event(
         'event',
         'created instance',


### PR DESCRIPTION
https://github.com/saltstack/salt/blob/develop/salt/cloud/__init__.py#L2104

expects to be able to find deploy_kwargs in the return dict of

https://github.com/saltstack/salt/blob/develop/salt/cloud/__init__.py#L2089

and

https://github.com/saltstack/salt/blob/develop/salt/cloud/__init__.py#L2114

throws an exception if it can't.
