### PR TITLE
Add support for numCoresPerSocket parameter in vmware driver

### DIFF
--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -201,8 +201,8 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
 ``cores_per_socket``
     .. versionadded:: Boron
     Enter the number of cores per vCPU that you want the VM/template to have. If not specified,
-    the current VM/template\'s vCPU count is used. Note that you cannot assign more cores per socket
-    than the total number of vCPUs assigned to the VM.
+    this will default to 1. Note that you cannot assign more cores per socket than the total 
+    number of vCPUs assigned to the VM.
 
 ``memory``
     Enter the memory size (in MB or GB) that you want the VM/template to have. If

--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -198,6 +198,12 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
     Enter the number of vCPUS that you want the VM/template to have. If not specified,
     the current VM/template\'s vCPU count is used.
 
+``cores_per_socket``
+    .. versionadded:: Boron
+    Enter the number of cores per vCPU that you want the VM/template to have. If not specified,
+    the current VM/template\'s vCPU count is used. Note that you cannot assign more cores per socket
+    than the total number of vCPUs assigned to the VM.
+
 ``memory``
     Enter the memory size (in MB or GB) that you want the VM/template to have. If
     not specified, the current VM/template\'s memory size is used. Example

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2137,6 +2137,9 @@ def create(vm_):
     num_cpus = config.get_cloud_config_value(
         'num_cpus', vm_, __opts__, default=None
     )
+    cores_per_socket = config.get_cloud_config_value(
+        'cores_per_socket', vm_, __opts__, default=None
+    )
     memory = config.get_cloud_config_value(
         'memory', vm_, __opts__, default=None
     )
@@ -2297,6 +2300,10 @@ def create(vm_):
     if num_cpus:
         log.debug("Setting cpu to: {0}".format(num_cpus))
         config_spec.numCPUs = int(num_cpus)
+
+    if cores_per_socket:
+        log.debug("Setting cores per socket to: {0}".format(cores_per_socket))
+        config_spec.numCoresPerSocket = int(num_cpus)
 
     if memory:
         try:

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2303,7 +2303,7 @@ def create(vm_):
 
     if cores_per_socket:
         log.debug("Setting cores per socket to: {0}".format(cores_per_socket))
-        config_spec.numCoresPerSocket = int(num_cpus)
+        config_spec.numCoresPerSocket = int(cores_per_socket)
 
     if memory:
         try:


### PR DESCRIPTION
While browsing the Salt issues I noticed someone requesting this feature (#31017) and it seemed easy to add. This pull request adds basic support for setting the cores_per_socket option with the vmware driver. When querying vcenter these seem to be added to the CPU already reported, so deploying a VM with 2 vCPU's and cores_per_socket 2 reports cpu: 4 in a query.
