### PR TITLE
Survey runner: actually pass kwargs to LocalClient

### DIFF
--- a/salt/runners/survey.py
+++ b/salt/runners/survey.py
@@ -154,9 +154,11 @@ def _get_pool_results(*args, **kwargs):
     if expr_form not in ['compound', 'pcre']:
         expr_form = 'compound'
 
+    kwargs_passthru = dict((k, kwargs[k]) for k in kwargs.iterkeys() if not k.startswith('_'))
+
     client = salt.client.get_local_client(__opts__['conf_file'])
     try:
-        minions = client.cmd(tgt, cmd, args[2:], timeout=__opts__['timeout'], expr_form=expr_form, kwarg=kwargs)
+        minions = client.cmd(tgt, cmd, args[2:], timeout=__opts__['timeout'], expr_form=expr_form, kwarg=kwargs_passthru)
     except SaltClientError as client_error:
         print(client_error)
         return ret

--- a/salt/runners/survey.py
+++ b/salt/runners/survey.py
@@ -147,16 +147,16 @@ def _get_pool_results(*args, **kwargs):
     cmd = args[1]
     ret = {}
 
-    sort = kwargs.get('survey_sort', 'down')
+    sort = kwargs.pop('survey_sort', 'down')
     direction = sort != 'up'
 
-    expr_form = kwargs.get('expr_form', 'compound')
+    expr_form = kwargs.pop('expr_form', 'compound')
     if expr_form not in ['compound', 'pcre']:
         expr_form = 'compound'
 
     client = salt.client.get_local_client(__opts__['conf_file'])
     try:
-        minions = client.cmd(tgt, cmd, args[2:], timeout=__opts__['timeout'], expr_form=expr_form)
+        minions = client.cmd(tgt, cmd, args[2:], timeout=__opts__['timeout'], expr_form=expr_form, kwarg=kwargs)
     except SaltClientError as client_error:
         print(client_error)
         return ret


### PR DESCRIPTION
Dear Salt developers,

**Summary**

I've noticed an inconsistency between the behaviour described in the comments of salt.runners.survey, and the actual behaviour exhibited, and have created a patch to correct this.

I've explained the difference in behaviour, and the nature of my fix, below.

Comment on L136 indicates that "salt" and "survey" share a kwargs namespace, but salt.runners.survey **fails to actually pass on the kwargs**, making it difficult to, for example, pass "template=jinja" to cmdmod.run when using salt-run survey.diff.

I've included a simple example, contrasting the expected and actual output, from a trivial usage.

**Expected behaviour:**

```
[root@salt-master ~]# salt-run survey.diff template=jinja '*elided*' cmd.run 'echo {{grains.os}}'
minion pool :
------------
['elided-elided-devadmin001.elided.co.uk', 'elided-elided-devapp001.elided.co.uk']
pool size :
----------
    2
pool result :
------------
    CentOS

|_
  ----------
  pool:
      - elided-elided-devadmin001.elided.co.uk
      - elided-elided-devapp001.elided.co.uk
  result:
      CentOS
```

**Actual behaviour:**

```
[root@salt-master ~]# salt-run survey.diff template=jinja '*elided*' cmd.run 'echo {{grains.os}}'
minion pool :
------------
['elided-elided-devadmin001.elided.co.uk', 'elided-elided-devapp001.elided.co.uk']
pool size :
----------
    2
pool result :
------------
    {{grains.os}}

|_
  ----------
  pool:
      - elided-elided-devadmin001.elided.co.uk
      - elided-elided-devapp001.elided.co.uk
  result:
      {{grains.os}}
```

**Conclusion**

Note that you can observe from the actual output indicates that the jinja template tag was never expanded, which suggested that the template=jinja argument never got passed to cmdmod.run.

My reading of the source confirmed this intuition.

**Details of patch**

The patch I have written changes salt.runners.survey to use kwargs.pop instead of kwargs.get to remove the survey-specific kwargs from the dict, and then pass the remainder on in the call to LocalClient.

I have tested my version of this runner by putting it in /srv/salt/modules/runners (having set extension_modules appropriately in /etc/salt/master) under a different name, and it works correctly for me.

I hope that this patch is acceptable, please let me know if any changes are required.

Thanks,

Hazel.
