### PR TITLE
Correctly remove path we added after loader is completed

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1095,8 +1095,9 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         mod = None
         fpath, suffix = self.file_mapping[name]
         self.loaded_files.add(name)
+        fpath_dirname = os.path.dirname(fpath)
         try:
-            sys.path.append(os.path.dirname(fpath))
+            sys.path.append(fpath_dirname)
             if suffix == '.pyx':
                 mod = pyximport.load_module(name, fpath, tempfile.gettempdir())
             elif suffix == '.o':
@@ -1162,7 +1163,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             )
             return False
         finally:
-            sys.path.pop()
+            sys.path.remove(fpath_dirname)
 
         if hasattr(mod, '__opts__'):
             mod.__opts__.update(self.opts)


### PR DESCRIPTION
Before this was doing a .pop() which would remove the last thing in sys.path, which is not necessarily the thing we added (in the case that an import modifies sys.path). The original fix was introduced in 4bf1d6838a0bab43926390eaf9f71d2ae5e87748, this simply ensures that we remove the item we added.
