### PR TITLE
Note added to pyenv docs requiring git.

### DIFF
--- a/salt/modules/pyenv.py
+++ b/salt/modules/pyenv.py
@@ -2,6 +2,10 @@
 '''
 Manage python installations with pyenv.
 
+.. note::
+    Git needs to be installed and available via PATH if pyenv is to be
+    installed automatically by the module.
+
 .. versionadded:: v2014.04
 '''
 from __future__ import absolute_import

--- a/salt/states/pyenv.py
+++ b/salt/states/pyenv.py
@@ -43,6 +43,10 @@ This is how a state configuration could look like:
         - default: True
         - require:
           - pkg: pyenv-deps
+
+.. note::
+    Git needs to be installed and available via PATH if pyenv is to be
+    installed automatically by the module.
 '''
 from __future__ import absolute_import
 


### PR DESCRIPTION
The documentation for the pyenv module and state didn't mention git had to be installed and available via PATH. This resolves #31066.
