### PR TITLE
Remove Deprecated Functions and Parameters from reg

### DIFF
--- a/doc/topics/releases/carbon.rst
+++ b/doc/topics/releases/carbon.rst
@@ -41,3 +41,80 @@ Deprecations
   ``salt.utils.jid``. ``jid_dir`` functionality for job_cache management was moved to
   the ``local_cache`` returner. ``jid_load`` data is now retreived from the
   ``master_job_cache``
+
+reg execution module
+  Functions in the ``reg`` execution module had misleading and confusing names
+  for dealing with the Windows registry. They failed to clearly differentiate
+  between hives, keys, and name/value pairs. Keys were treated like value names.
+  There was no way to delete a key.
+
+  New functions were added in 2015.5 to properly work with the registry. They
+  also made it possible to edit key default values as well as delete an entire
+  key tree recursively. With the new functions in place, the following functions
+  have been deprecated:
+
+  - read_key
+  - set_key
+  - create_key
+  - delete_key
+
+  Use the following functions instead:
+
+  - for ``read_key`` use ``read_value``
+  - for ``set_key`` use ``set_value``
+  - for ``create_key`` use ``set_value`` with no ``vname`` and no ``vdata``
+  - for ``delete_key`` use ``delete_key_recursive``. To delete a value, use
+    ``delete_value``.
+
+reg state module
+  The ``reg`` state module was modified to work with the new functions in the
+  execution module. Some logic was left in the ``reg.present`` and the
+  ``reg.absent`` functions to handle existing state files that used the final
+  key in the name as the value name. That logic has been removed so you now must
+  specify value name (``vname``) and, if needed, value data (``vdata``).
+
+  For example, a state file that adds the version value/data pair to the
+  Software\\Salt key in the HKEY_LOCAL_MACHINE hive used to look like this:
+
+  .. code-block:: yaml
+
+      HKEY_LOCAL_MACHINE\\Software\\Salt\\version:
+        reg.present:
+          - value: 2016.3.1
+
+  Now it should look like this:
+
+  .. code-block:: yaml
+
+      HKEY_LOCAL_MACHINE\\Software\\Salt
+        reg.present:
+          - vname: version
+          - vdata: 2016.3.1
+
+  A state file for removing the same value added above would have looked like
+  this:
+
+  .. code-block:: yaml
+
+      HKEY_LOCAL_MACHINE\\Software\\Salt\\version:
+        reg.absent:
+
+  Now it should look like this:
+
+  .. code-block:: yaml
+
+      HKEY_LOCAL_MACHINE\\Software\\Salt
+        reg.absent:
+          - vname: version
+
+  This new structure is important as it allows salt to deal with key default
+  values which was not possible before. If vname is not passed, salt will work
+  with the default value for that hive\key.
+
+  Additionally, since you could only delete a value from a the state module, a
+  new function (``key_absent``) has been added to allow you to delete a registry
+  key and all subkeys and name/value pairs recursively. It uses the new
+  ``delete_key_recursive`` function.
+
+  For additional information see the documentation for the ``reg`` execution and
+  state modules.

--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -485,4 +485,5 @@ def delete_value(hive, key, vname=None, use_32bit_registry=False):
         log.error('Hive: {0}'.format(hive))
         log.error('Key: {0}'.format(key))
         log.error('ValueName: {0}'.format(vname))
+        log.error('32bit Reg: {0}'.format(use_32bit_registry))
         return False

--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -128,7 +128,7 @@ def _key_exists(hive, key, use_32bit_registry=False):
         handle = _winreg.OpenKey(hkey, key, 0, access_mask)
         _winreg.CloseKey(handle)
         return True
-    except WindowsError:
+    except WindowsError:  # pylint: disable=E0602
         return False
 
 
@@ -240,7 +240,7 @@ def read_value(hive, key, vname=None, use_32bit_registry=False):
                 ret['vdata'] = vdata
             else:
                 ret['comment'] = 'Empty Value'
-        except WindowsError:
+        except WindowsError:  # pylint: disable=E0602
             ret['vdata'] = ('(value not set)')
             ret['vtype'] = 'REG_SZ'
     except WindowsError as exc:  # pylint: disable=E0602

--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -252,57 +252,6 @@ def read_value(hive, key, vname=None, use_32bit_registry=False):
     return ret
 
 
-def set_key(hkey,
-            path,
-            value,
-            key=None,
-            vtype='REG_DWORD',
-            reflection=True,
-            use_32bit_registry=False):
-    '''
-    .. important ::
-        The name of this function is misleading and will be changed to reflect
-        proper usage in the Boron release of Salt. The path option will be removed
-        and the key will be the actual key. See the following issue:
-
-        https://github.com/saltstack/salt/issues/25618
-
-        In order to not break existing state files this function will call the
-        set_value function if a key is passed. Key will be passed as the value
-        name. If key is not passed, this function will return the default value for
-        the key.
-
-        In the Boron release this function will be removed in favor of set_value.
-
-    Set a registry key
-
-    vtype: http://docs.python.org/2/library/_winreg.html#value-types
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' reg.set_key HKEY_CURRENT_USER 'SOFTWARE\\Salt' 'version' '0.97' REG_DWORD
-    '''
-
-    if key:  # This if statement will be removed in Boron
-        salt.utils.warn_until('Boron', 'Use reg.set_value to set a registry '
-                                       'value. This functionality will be '
-                                       'removed in Salt Boron')
-        return set_value(hive=hkey,
-                         key=path,
-                         vname=key,
-                         vdata=value,
-                         vtype=vtype,
-                         use_32bit_registry=use_32bit_registry)
-
-    return set_value(hive=hkey,
-                     key=path,
-                     vdata=value,
-                     vtype=vtype,
-                     use_32bit_registry=use_32bit_registry)
-
-
 def set_value(hive,
               key,
               vname=None,

--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -4,9 +4,6 @@
 Manage the Windows registry
 ===========================
 
-The read_key and set_key functions will be updated in Boron to reflect proper
-registry usage. The registry has three main components. Hives, Keys, and Values.
-
 -----
 Hives
 -----
@@ -130,54 +127,6 @@ def _key_exists(hive, key, use_32bit_registry=False):
         return True
     except WindowsError:  # pylint: disable=E0602
         return False
-
-
-def read_key(hkey, path, key=None, use_32bit_registry=False):
-    '''
-    .. important::
-        The name of this function is misleading and will be changed to reflect
-        proper usage in the Boron release of Salt. The path option will be removed
-        and the key will be the actual key. See the following issue:
-
-        https://github.com/saltstack/salt/issues/25618
-
-        In order to not break existing state files this function will call the
-        read_value function if a key is passed. Key will be passed as the value
-        name. If key is not passed, this function will return the default value for
-        the key.
-
-        In the Boron release this function will be removed in favor of read_value.
-
-    Read registry key value
-
-    Returns the first unnamed value (Default) as a string.
-    Returns none if first unnamed value is empty.
-    Returns False if key not found.
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' reg.read_key HKEY_LOCAL_MACHINE 'SOFTWARE\\Salt' 'version'
-    '''
-
-    ret = {'hive': hkey,
-           'key': path,
-           'vdata': None,
-           'success': True}
-
-    if key:  # This if statement will be removed in Boron
-        salt.utils.warn_until('Boron', 'Use reg.read_value to read a registry '
-                                       'value. This functionality will be '
-                                       'removed in Salt Boron')
-        return read_value(hive=hkey,
-                          key=path,
-                          vname=key,
-                          use_32bit_registry=use_32bit_registry)
-
-    return read_value(hive=hkey,
-                      key=path,
-                      use_32bit_registry=use_32bit_registry)
 
 
 def read_value(hive, key, vname=None, use_32bit_registry=False):

--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -472,14 +472,17 @@ def delete_value(hive, key, vname=None, use_32bit_registry=False):
         salt '*' reg.delete_value HKEY_CURRENT_USER 'SOFTWARE\\Salt' 'version'
     '''
     registry = Registry()
-    hive = registry.hkeys[hive]
+    h_hive = registry.hkeys[hive]
     access_mask = registry.registry_32[use_32bit_registry]
 
     try:
-        handle = _winreg.OpenKey(hive, key, 0, access_mask)
+        handle = _winreg.OpenKey(h_hive, key, 0, access_mask)
         _winreg.DeleteValue(handle, vname)
         _winreg.CloseKey(handle)
         return True
     except WindowsError as exc:  # pylint: disable=E0602
         log.error(exc, exc_info=True)
+        log.error('Hive: {0}'.format(hive))
+        log.error('Key: {0}'.format(key))
+        log.error('ValueName: {0}'.format(vname))
         return False

--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -29,9 +29,6 @@ Values/Entries are name/data pairs. There can be many values in a key. The
 
 :depends:   - winreg Python module
 '''
-
-# TODO: Figure out the exceptions _winreg can raise and properly catch them
-
 # Import python libs
 from __future__ import absolute_import
 import logging
@@ -51,6 +48,21 @@ log = logging.getLogger(__name__)
 
 # Define the module's virtual name
 __virtualname__ = 'reg'
+
+
+def __virtual__():
+    '''
+    Only works on Windows systems with the _winreg python module
+    '''
+    if not salt.utils.is_windows():
+        return (False, 'reg execution module failed to load: '
+                       'The module will only run on Windows systems')
+
+    if not HAS_WINDOWS_MODULES:
+        return (False, 'reg execution module failed to load: '
+                       'The _winreg python library could not be loaded')
+
+    return __virtualname__
 
 
 class Registry(object):
@@ -97,15 +109,6 @@ class Registry(object):
             raise CommandExecutionError(msg.format(k, hkeys))
 
 
-def __virtual__():
-    '''
-    Only works on Windows systems
-    '''
-    if salt.utils.is_windows() and HAS_WINDOWS_MODULES:
-        return __virtualname__
-    return (False, 'reg execution module failed to load: either the system is not Windows or the _winreg python library not available.')
-
-
 def _key_exists(hive, key, use_32bit_registry=False):
     '''
     Check that the key is found in the registry
@@ -125,7 +128,7 @@ def _key_exists(hive, key, use_32bit_registry=False):
         handle = _winreg.OpenKey(hkey, key, 0, access_mask)
         _winreg.CloseKey(handle)
         return True
-    except WindowsError as exc:  # pylint: disable=E0602
+    except WindowsError:
         return False
 
 
@@ -190,14 +193,13 @@ def read_value(hive, key, vname=None, use_32bit_registry=False):
     :param str key: The key (looks like a path) to the value name.
 
     :param str vname: The value name. These are the individual name/data pairs
-      under the key. If not passed, the key (Default) value will be returned
+    under the key. If not passed, the key (Default) value will be returned
 
     :param bool use_32bit_registry: Accesses the 32bit portion of the registry
-      on 64 bit installations. On 32bit machines this is ignored.
+    on 64bit installations. On 32bit machines this is ignored.
 
     :return: A dictionary containing the passed settings as well as the
-      value_data if successful. If unsuccessful, sets success to False
-
+    value_data if successful. If unsuccessful, sets success to False
     :rtype: dict
 
     If vname is not passed:
@@ -238,7 +240,7 @@ def read_value(hive, key, vname=None, use_32bit_registry=False):
                 ret['vdata'] = vdata
             else:
                 ret['comment'] = 'Empty Value'
-        except WindowsError as exc:  # pylint: disable=E0602
+        except WindowsError:
             ret['vdata'] = ('(value not set)')
             ret['vtype'] = 'REG_SZ'
     except WindowsError as exc:  # pylint: disable=E0602
@@ -306,7 +308,6 @@ def set_value(hive,
               vname=None,
               vdata=None,
               vtype='REG_SZ',
-              reflection=True,
               use_32bit_registry=False):
     '''
     Sets a registry value entry or the default value for a key.
@@ -320,7 +321,7 @@ def set_value(hive,
     :param str key: The key (looks like a path) to the value name.
 
     :param str vname: The value name. These are the individual name/data pairs
-      under the key. If not passed, the key (Default) value will be set.
+    under the key. If not passed, the key (Default) value will be set.
 
     :param str vdata: The value data to be set.
 
@@ -332,17 +333,10 @@ def set_value(hive,
         - REG_MULTI_SZ
         - REG_SZ
 
-    :param bool reflection: A boolean value indicating that the value should
-      also be set in the Wow6432Node portion of the registry. Only applies to 64
-      bit Windows. This setting is ignored for 32 bit Windows.
-
-    .. deprecated:: 2015.8.2
-       Use ``use_32bit_registry`` instead. The parameter seems to have no effect
-       since Windows 7 / Windows 2008R2 removed support for reflection. The
-       parameter will be removed in Boron.
+    :param bool use_32bit_registry: Sets the 32bit portion of the registry on
+    64bit installations. On 32bit machines this is ignored.
 
     :return: Returns True if successful, False if not
-
     :rtype: bool
 
     CLI Example:
@@ -370,140 +364,6 @@ def set_value(hive,
         return False
 
 
-def create_key(hkey,
-               path,
-               key=None,
-               value=None,
-               reflection=True,
-               use_32bit_registry=False):
-    '''
-    .. important ::
-        The name of this function is misleading and will be changed to reflect
-        proper usage in the Boron release of Salt. The path option will be removed
-        and the key will be the actual key. See the following issue:
-
-        https://github.com/saltstack/salt/issues/25618
-
-        In order to not break existing state files this function will call the
-        set_value function if key is passed. Key will be passed as the value name.
-        If key is not passed, this function will return the default value for the
-        key.
-
-        In the Boron release path will be removed and key will be the path. You will
-        not pass value.
-
-    Create a registry key
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' reg.create_key HKEY_CURRENT_USER 'SOFTWARE\\Salt' 'version' '0.97'
-    '''
-    if key:  # This if statement will be removed in Boron
-        salt.utils.warn_until('Boron', 'Use reg.set_value to create a registry '
-                                       'value. This functionality will be '
-                                       'removed in Salt Boron')
-        return set_value(hive=hkey,
-                         key=path,
-                         vname=key,
-                         vdata=value,
-                         use_32bit_registry=use_32bit_registry)
-
-    return set_value(hive=hkey, key=path, use_32bit_registry=use_32bit_registry)
-
-
-def delete_key(hkey,
-               path,
-               key=None,
-               reflection=True,
-               force=False,
-               use_32bit_registry=False):
-    '''
-    .. important::
-        The name of this function is misleading and will be changed to reflect
-        proper usage in the Boron release of Salt. The path option will be removed
-        and the key will be the actual key. See the following issue:
-
-        https://github.com/saltstack/salt/issues/25618
-
-        In order to not break existing state files this function will call the
-        delete_value function if a key is passed. Key will be passed as the value
-        name. If key is not passed, this function will return the default value for
-        the key.
-
-        In the Boron release path will be removed and key will be the path.
-        reflection will also be removed.
-
-    Delete a registry key
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' reg.delete_key HKEY_CURRENT_USER 'SOFTWARE\\Salt'
-
-    :param str hkey: (will be changed to hive) The name of the hive. Can be one
-      of the following
-
-        - HKEY_LOCAL_MACHINE or HKLM
-        - HKEY_CURRENT_USER or HKCU
-        - HKEY_USER or HKU
-
-    :param str path: (will be changed to key) The key (looks like a path) to
-      remove.
-
-    :param str key: (used incorrectly) Will be removed in Boron
-
-    :param bool reflection: A boolean value indicating that the value should
-      also be removed from the Wow6432Node portion of the registry. Only applies
-      to 64 bit Windows. This setting is ignored for 32 bit Windows.
-
-      Only applies to delete value. If the key parameter is passed, this function
-      calls delete_value instead. Will be changed in Boron.
-
-    :param bool force: A boolean value indicating that all subkeys should be
-      removed as well. If this is set to False (default) and there are subkeys,
-      the delete_key function will fail.
-
-    :return: Returns True if successful, False if not. If force=True, the
-      results of delete_key_recursive are returned.
-
-    :rtype: bool
-    '''
-
-    if key:  # This if statement will be removed in Boron
-        salt.utils.warn_until('Boron',
-                              'Variable names will be changed to match Windows '
-                              'Registry terminology. These changes will be '
-                              'made in Boron')
-        return delete_value(hive=hkey,
-                            key=path,
-                            vname=key,
-                            reflection=reflection,
-                            use_32bit_registry=use_32bit_registry)
-
-    if force:
-        return delete_key_recursive(hkey,
-                                    path,
-                                    use_32bit_registry=use_32bit_registry)
-
-    registry = Registry()
-    hive = registry.hkeys[hkey]
-    key = path
-    access_mask = registry.registry_32[use_32bit_registry]
-
-    try:
-        # Can't use delete_value to delete a key
-        key_handle = _winreg.OpenKey(hive, key, 0, access_mask)
-        _winreg.DeleteKey(key_handle, '')
-        _winreg.CloseKey(key_handle)
-        return True
-    except WindowsError as exc:  # pylint: disable=E0602
-        log.error(exc, exc_info=True)
-        return False
-
-
 def delete_key_recursive(hive, key, use_32bit_registry=False):
     '''
     .. versionadded:: 2015.5.4
@@ -518,9 +378,11 @@ def delete_key_recursive(hive, key, use_32bit_registry=False):
 
     :param key: The key to remove (looks like a path)
 
+    :param bool use_32bit_registry: Deletes the 32bit portion of the registry on
+    64bit installations. On 32bit machines this is ignored.
+
     :return: A dictionary listing the keys that deleted successfully as well as
     those that failed to delete.
-
     :rtype: dict
 
     The following example will remove ``salt`` and all its subkeys from the
@@ -542,23 +404,23 @@ def delete_key_recursive(hive, key, use_32bit_registry=False):
         return False
 
     # Functions for traversing the registry tree
-    def subkeys(key):
+    def subkeys(_key):
         i = 0
         while True:
             try:
-                subkey = _winreg.EnumKey(key, i)
+                subkey = _winreg.EnumKey(_key, i)
                 yield subkey
                 i += 1
             except WindowsError:  # pylint: disable=E0602
                 break
 
-    def traverse_registry_tree(hkey, keypath, ret, access_mask):
-        key = _winreg.OpenKey(hkey, keypath, 0, access_mask)
-        for subkeyname in subkeys(key):
-            subkeypath = r'{0}\{1}'.format(keypath, subkeyname)
-            ret = traverse_registry_tree(hkey, subkeypath, ret, access_mask)
-            ret.append('{0}'.format(subkeypath))
-        return ret
+    def traverse_registry_tree(_hkey, _keypath, _ret, _access_mask):
+        _key = _winreg.OpenKey(_hkey, _keypath, 0, _access_mask)
+        for subkeyname in subkeys(_key):
+            subkeypath = r'{0}\{1}'.format(_keypath, subkeyname)
+            _ret = traverse_registry_tree(_hkey, subkeypath, _ret, access_mask)
+            _ret.append('{0}'.format(subkeypath))
+        return _ret
 
     # Get a reverse list of registry keys to be deleted
     key_list = []
@@ -582,7 +444,7 @@ def delete_key_recursive(hive, key, use_32bit_registry=False):
     return ret
 
 
-def delete_value(hive, key, vname=None, reflection=True, use_32bit_registry=False):
+def delete_value(hive, key, vname=None, use_32bit_registry=False):
     '''
     Delete a registry value entry or the default value for a key.
 
@@ -595,19 +457,12 @@ def delete_value(hive, key, vname=None, reflection=True, use_32bit_registry=Fals
     :param str key: The key (looks like a path) to the value name.
 
     :param str vname: The value name. These are the individual name/data pairs
-      under the key. If not passed, the key (Default) value will be deleted.
+    under the key. If not passed, the key (Default) value will be deleted.
 
-    :param bool reflection: A boolean value indicating that the value should
-      also be set in the Wow6432Node portion of the registry. Only applies to 64
-      bit Windows. This setting is ignored for 32 bit Windows.
-
-    .. deprecated:: 2015.8.2
-       Use ``use_32bit_registry`` instead. The parameter seems to have no effect
-       since Windows 7 / Windows 2008R2 removed support for reflection. This
-       parameter will be removed in Boron.
+    :param bool use_32bit_registry: Deletes the 32bit portion of the registry on
+    64bit installations. On 32bit machines this is ignored.
 
     :return: Returns True if successful, False if not
-
     :rtype: bool
 
     CLI Example:

--- a/salt/states/reg.py
+++ b/salt/states/reg.py
@@ -358,11 +358,6 @@ def key_absent(name, use_32bit_registry=False):
     - HKEY_CURRENT_USER or HKCU
     - HKEY_USER or HKU
 
-    :param bool force: A boolean value indicating that all subkeys should be
-    deleted with the key. If force=False and subkeys exists beneath the key you
-    want to delete, key_absent will fail. Use with caution. The default is
-    False.
-
     :param bool use_32bit_registry: Use the 32bit portion of the registry.
     Applies only to 64bit windows. 32bit Windows will ignore this parameter.
     Default is False.

--- a/salt/states/reg.py
+++ b/salt/states/reg.py
@@ -343,7 +343,7 @@ def absent(name, vname=None, use_32bit_registry=False):
     return ret
 
 
-def key_absent(name, force=False, use_32bit_registry=False):
+def key_absent(name, use_32bit_registry=False):
     r'''
     .. versionadded:: 2015.5.4
 
@@ -413,7 +413,6 @@ def key_absent(name, force=False, use_32bit_registry=False):
     # Delete the value
     __salt__['reg.delete_key_recursive'](hive=hive,
                                          key=key,
-                                         force=force,
                                          use_32bit_registry=use_32bit_registry)
     if __salt__['reg.read_value'](hive=hive,
                                   key=key,

--- a/salt/states/reg.py
+++ b/salt/states/reg.py
@@ -60,9 +60,6 @@ from __future__ import absolute_import
 # Import python libs
 import logging
 
-# Import salt libs
-import salt.utils
-
 log = logging.getLogger(__name__)
 
 
@@ -272,18 +269,8 @@ def absent(name, vname=None, use_32bit_registry=False):
                                            vname=vname,
                                            use_32bit_registry=use_32bit_registry)
     if not reg_check['success'] or reg_check['vdata'] == '(value not set)':
-        if not vname:
-            hive, key, vname = _parse_key_value(name)
-            reg_check = __salt__['reg.read_value'](hive=hive,
-                                                   key=key,
-                                                   vname=vname,
-                                                   use_32bit_registry=use_32bit_registry)
-            if not reg_check['success'] or reg_check['vdata'] == '(value not set)':
-                ret['comment'] = '{0} is already absent'.format(name)
-                return ret
-        else:
-            ret['comment'] = '{0} is already absent'.format(name)
-            return ret
+        ret['comment'] = '{0} is already absent'.format(name)
+        return ret
 
     remove_change = {'Key': r'{0}\{1}'.format(hive, key),
                      'Entry': '{0}'.format(vname if vname else '(Default)')}


### PR DESCRIPTION
Removed the following functions from the reg module:
- `read_key`
- `set_key`
- `create_key`
- `delete_key`

Added missing documentation
Removed `force` parameter from reg state module
Fixed virtual function in state
Improved error information for `reg.delete_value` function

https://github.com/saltstack/zh/issues/475

First attempt: https://github.com/saltstack/salt/pull/30956
