### PR TITLE
Fix pkg state module to deal with version 'latest'

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -804,24 +804,11 @@ def install(name=None, refresh=False, pkgs=None, saltenv='base', **kwargs):
                 ret[pkg_name] = {'current': new[pkg_name]}
 
     # Sometimes the installer takes awhile to update the registry
-    # This checks 10 times, 3 seconds between each for a registry change
-    tries = 0
     difference = salt.utils.compare_dicts(old, new)
-    while not all(name in difference for name in changed) and tries < 10:
+    if not all(name in difference for name in changed):
         __salt__['reg.broadcast_change']()
-        time.sleep(3)
         new = list_pkgs()
         difference = salt.utils.compare_dicts(old, new)
-        tries += 1
-        log.debug("Try {0}".format(tries))
-        if tries == 10:
-            if not latest:
-                ret['_comment'] = 'Software not found in the registry.\n' \
-                                  'Could be a problem with the Software\n' \
-                                  'definition file. Verify the full_name\n' \
-                                  'and the version match the registry ' \
-                                  'exactly.\n' \
-                                  'Failed after {0} tries.'.format(tries)
 
     # Compare the software list before and after
     # Add the difference to ret

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -9,7 +9,6 @@ import errno
 import os
 import locale
 import logging
-import time
 from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module
 
 # Import third party libs
@@ -523,7 +522,6 @@ def install(name=None, refresh=False, pkgs=None, saltenv='base', **kwargs):
         directories on ``salt://``
 
     :return: Return a dict containing the new package names and versions::
-
     :rtype: dict
 
         If the package is installed by ``pkg.install``:
@@ -533,13 +531,11 @@ def install(name=None, refresh=False, pkgs=None, saltenv='base', **kwargs):
             {'<package>': {'old': '<old-version>',
                            'new': '<new-version>'}}
 
-
         If the package is already installed:
 
         .. code-block:: cfg
 
             {'<package>': {'current': '<current-version>'}}
-
 
     The following example will refresh the winrepo and install a single package,
     7zip.
@@ -796,8 +792,6 @@ def install(name=None, refresh=False, pkgs=None, saltenv='base', **kwargs):
     # The software definition file will have a version of 'latest'
     # In that case there's no way to know which version has been installed
     # Just return the current installed version
-    # This has to be done before the loop below, otherwise the installation
-    # will not be detected
     if latest:
         for pkg_name in latest:
             if old.get(pkg_name, 'old') == new.get(pkg_name, 'new'):

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -797,12 +797,8 @@ def install(name=None, refresh=False, pkgs=None, saltenv='base', **kwargs):
             if old.get(pkg_name, 'old') == new.get(pkg_name, 'new'):
                 ret[pkg_name] = {'current': new[pkg_name]}
 
-    # Sometimes the installer takes awhile to update the registry
+    # Check for changes in the registry
     difference = salt.utils.compare_dicts(old, new)
-    if not all(name in difference for name in changed):
-        __salt__['reg.broadcast_change']()
-        new = list_pkgs()
-        difference = salt.utils.compare_dicts(old, new)
 
     # Compare the software list before and after
     # Add the difference to ret

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -524,7 +524,7 @@ def _verify_install(desired, new_pkgs):
         if not cver:
             failed.append(pkgname)
             continue
-        elif cver == 'latest':
+        elif pkgver == 'latest':
             ok.append(pkgname)
             continue
         elif not __salt__['pkg_resource.version_clean'](pkgver):
@@ -961,10 +961,9 @@ def installed(
 
     kwargs['saltenv'] = __env__
     rtag = __gen_rtag()
-    refresh = bool(
-        salt.utils.is_true(refresh)
-        or (os.path.isfile(rtag) and refresh is not False)
-    )
+    refresh = bool(salt.utils.is_true(refresh) or
+                   (os.path.isfile(rtag) and salt.utils.is_true(refresh))
+                   )
     if not isinstance(pkg_verify, list):
         pkg_verify = pkg_verify is True
     if (pkg_verify or isinstance(pkg_verify, list)) \
@@ -1451,9 +1450,9 @@ def latest(
 
     '''
     rtag = __gen_rtag()
-    refresh = bool(
-        salt.utils.is_true(refresh) or (os.path.isfile(rtag) and refresh is not False)
-    )
+    refresh = bool(salt.utils.is_true(refresh) or
+                   (os.path.isfile(rtag) and salt.utils.is_true(refresh))
+                   )
 
     if kwargs.get('sources'):
         return {'name': name,
@@ -1600,7 +1599,9 @@ def latest(
         if changes:
             # Find failed and successful updates
             failed = [x for x in targets
-                      if not changes.get(x) or changes[x]['new'] != targets[x]]
+                      if not changes.get(x) or
+                      changes[x].get('new') != targets[x] and
+                      targets[x] != 'latest']
             successful = [x for x in targets if x not in failed]
 
             comments = []

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -524,6 +524,9 @@ def _verify_install(desired, new_pkgs):
         if not cver:
             failed.append(pkgname)
             continue
+        elif cver == 'latest':
+            ok.append(pkgname)
+            continue
         elif not __salt__['pkg_resource.version_clean'](pkgver):
             ok.append(pkgname)
             continue


### PR DESCRIPTION
Adds special handling for software definitions with a version of latest
- Fixes pkg.installed and pkg.latest
- removed unnecessary loop from win_pkg.py module (the loop was added to deal with situations like chrome where you can't predict the version number. I didn't understand what was going on at the time and thought it was an issue with the registry not being refreshed.)

Fixes: https://github.com/saltstack/zh/issues/422

Needs to be tested with linux to be sure I didn't break anything

Rebased from: https://github.com/saltstack/salt/pull/31064
