### PR TITLE
Force-kill websocket's child processes faster than default two minutes.

### DIFF
--- a/pkg/salt-api.service
+++ b/pkg/salt-api.service
@@ -6,6 +6,7 @@ After=network.target
 Type=simple
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-api
+TimeoutStopSec=3
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This partially solves a problem where `salt-api` daemon cannot be nicely shut down once websocket is used. However, the design of the Salt API is still not the best: every time Salt API gets a new GET request, it spawns a child process, which stays there until forever. At some point Salt API can have a lot of these child processes...

@cachedout @jfindlay I think this is not exactly a bug, but a design flaw and should be fixed. Mainly I am talking about [this place](https://github.com/saltstack/salt/blob/develop/salt/netapi/rest_cherrypy/app.py#L2046). Please correct me if I am wrong.
