### PR TITLE
integration test for issue #31014

### DIFF
--- a/tests/integration/files/file/base/pkg_latest_epoch.sls
+++ b/tests/integration/files/file/base/pkg_latest_epoch.sls
@@ -1,0 +1,3 @@
+nova_packages:
+  pkg.latest:
+    - name: libguestfs-tools

--- a/tests/integration/states/pkg.py
+++ b/tests/integration/states/pkg.py
@@ -284,6 +284,17 @@ class PkgTest(integration.ModuleCase,
             ret = self.run_state('pkg.installed', name=target)
             self.assertSaltTrueReturn(ret)
 
+    @destructiveTest
+    @skipIf(salt.utils.is_windows(), 'minion is windows')
+    def test_pkg_latest_with_epoch(self):
+        '''
+        This tests for the following issue:
+        https://github.com/saltstack/salt/issues/31014
+
+        This is a destructive test as it installs a package
+        '''
+        ret = self.run_function('state.sls', mods='pkg_latest_epoch')
+        self.assertSaltTrueReturn(ret)
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
integration test that calls an sls file to install libguestfs-tools. There was an issue where using package.latest it would report incorrectly that a package was updated if it had an epoch. A good example of this is the libguestfs-tools because they have an epoch of 1.
