### PR TITLE
Improve %h and %u handling in SSH module

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -116,9 +116,9 @@ def _get_config_file(user, config):
     if not uinfo:
         raise CommandExecutionError('User \'{0}\' does not exist'.format(user))
     home = uinfo['home']
+    config = _expand_authorized_keys_path(config, user, home)
     if not os.path.isabs(config):
         config = os.path.join(home, config)
-    config = _expand_authorized_keys_path(config, user, home)
     return config
 
 

--- a/tests/unit/modules/ssh_test.py
+++ b/tests/unit/modules/ssh_test.py
@@ -34,6 +34,10 @@ class SSHAuthKeyTestCase(TestCase):
                 '/home/user')
         self.assertEqual(output, '/home//home/user')
 
+        output = ssh._expand_authorized_keys_path('%h/foo', 'user',
+                '/home/user')
+        self.assertEqual(output, '/home/user/foo')
+
         output = ssh._expand_authorized_keys_path('/srv/%h/aaa/%u%%', 'user',
                 '/home/user')
         self.assertEqual(output, '/srv//home/user/aaa/user%')


### PR DESCRIPTION
Consider this state:

``` yaml
foobar:
  ssh_auth.present:
    - user: somedude
    - source: salt://ssh_keys/somedude@randombox.pub
    - config: "%h/.ssh/authorized_keys"
```

This will put the key in `/home/somedude/some/somedude/.ssh/authorized_keys`.  Why?  Because the path expansion function was called _after_ determining whether the path is relative or absolute.  Since `%h/.ssh/authorized_keys` does not start with a `/`, it was determined to be relative.  Expanding `%h` and `%u` before checking relative/absolute fixes this.
