### PR TITLE
Change RunnerClient support for args and kwargs in low to singular

### DIFF
--- a/salt/runner.py
+++ b/salt/runner.py
@@ -63,7 +63,7 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
         reformatted_low = {'fun': fun}
         reformatted_low.update(auth_creds)
         # Support old style calls where arguments could be specified in 'low' top level
-        if not low.get('args') and not low.get('kwargs'):  # not specified or empty
+        if not low.get('arg') and not low.get('kwarg'):  # not specified or empty
             verify_fun(self.functions, fun)
             args, kwargs = salt.minion.load_args_and_kwargs(
                 self.functions[fun],
@@ -71,12 +71,12 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
                 self.opts,
                 ignore_invalid=True
             )
-            low['args'] = args
-            low['kwargs'] = kwargs
-        if 'kwargs' not in low:
-            low['kwargs'] = {}
-        if 'args' not in low:
-            low['args'] = []
+            low['arg'] = args
+            low['kwarg'] = kwargs
+        if 'kwarg' not in low:
+            low['kwarg'] = {}
+        if 'arg' not in low:
+            low['arg'] = []
         reformatted_low['kwarg'] = low
         return reformatted_low
 


### PR DESCRIPTION
LocalClient makes local use (master-side) of `*args` and `**kwargs`
(plural) and sends `arg` and `kwarg` (singular) down to the minion
(minion-side) so the minion will execute the final function using data
from the singular-form arguments.

RunnerClient and WheelClient have traditionally worked differently in
that was no singular version of those arguments and simply passed all
keyword args through to the actual execution of the target function.

Pull req #23408 added equivalent support to RunnerClient but used the
plural forms which is not consistent. (I signed off on it so this is my
mistake.)

I don't beleve this addition was ever documented so this shouldn't
affect existing users but it may help people who try to use RunnerClient
via things like the Reactor as though it were LocalClient.
