### PR TITLE
Fixed invalid host causing 'reference to variable before assignment'

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -1078,7 +1078,12 @@ def connect(host, port=None, **kwargs):
          _proto,
          garbage,
          _address) = socket.getaddrinfo(address, port, __family, 0, __proto)[0]
+    except socket.gaierror:
+        ret['result'] = False
+        ret['comment'] = 'Unable to resolve host {0} on {1} port {2}'.format(host, proto, port)
+        return ret
 
+    try:
         skt = socket.socket(family, socktype, _proto)
         skt.settimeout(timeout)
 


### PR DESCRIPTION
The current version of exception handling for network.connect references variable '_address', but '_address' can be undefined if a call to socket.getaddrinfo failed in the same try block.

eg.
salt 'minion' network.connect junkdomain 80

>    The minion function caused an exception: Traceback (most recent call last):
>       File "/usr/lib/python2.7/site-packages/salt/minion.py", line 1071, in _thread_return
>         return_data = func(_args, *_kwargs)
>       File "/usr/lib/python2.7/site-packages/salt/modules/network.py", line 1104, in connect
>         ret['comment'] = 'Unable to connect to {0} ({1}) on {2} port {3}'.format(host, _address[0], proto, port)
>     UnboundLocalError: local variable '_address' referenced before assignment

This patch catches socket.getaddrinfo execption socket.gaierror and returns with a friendly fail message.
