### PR TITLE
Create file option .

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2533,14 +2533,97 @@ def recurse(name,
 
 def line(name, content, match=None, mode=None, location=None,
          before=None, after=None, show_changes=True, backup=False,
-         quiet=False, indent=True):
+         quiet=False, indent=True, create=False, user=None,
+         group=None, file_mode=None):
     '''
     Line-based editing of a file.
 
     .. versionadded:: 2015.8.0
 
-    Params are identical to the remote execution function
-    :mod:`file.line <salt.modules.file.line>`.
+    Edit a line in the configuration file.
+
+    name:
+        Filesystem path to the file to be edited.
+
+    content:
+        Content of the line.
+
+    match:
+        Match the target line for an action by
+        a fragment of a string or regular expression.
+
+    mode:
+        Ensure
+            If line does not exist, it will be added.
+
+        Replace
+            If line already exist, it will be replaced.
+
+        Delete
+            Delete the line, once found.
+
+        Insert
+            Insert a line.
+
+    location:
+        start
+            Place the content at the beginning of the file.
+
+        end
+            Place the content at the end of the file.
+
+    before:
+        Regular expression or an exact case-sensitive fragment of the string.
+
+    after:
+        Regular expression or an exact case-sensitive fragment of the string.
+
+    show_changes
+        Output a unified diff of the old file and the new file.
+        If ``False`` return a boolean if any changes were made.
+        Default is ``True``
+
+        .. note::
+
+            Using this option will store two copies of the file in-memory
+            (the original version and the edited version) in order to generate the diff.
+
+    backup
+        Create a backup of the original file with the extension:
+        "Year-Month-Day-Hour-Minutes-Seconds".
+
+    quiet
+        Do not raise any exceptions. E.g. ignore the fact that the file that is
+        tried to be edited does not exist and nothing really happened.
+
+    indent
+        Keep indentation with the previous line.
+
+    If an equal sign (``=``) appears in an argument to a Salt command, it is
+    interpreted as a keyword argument in the format of ``key=val``. That
+    processing can be bypassed in order to pass an equal sign through to the
+    remote shell command by manually specifying the kwarg:
+
+    create
+        Create an empty file if doesn't exists.
+
+    user
+        The user to own the file, this defaults to the user salt is running as
+        on the minion.
+
+        .. versionadded:: Carbon
+
+    group
+        The group ownership set for the file, this defaults to the group salt
+        is running as on the minion On Windows, this is ignored.
+
+        .. versionadded:: Carbon
+
+    file_mode
+        The permissions to set on this file, aka 644, 0775, 4664. Not supported
+        on Windows.
+
+        .. versionadded:: Carbon
 
     .. code-block: yaml
 
@@ -2558,6 +2641,9 @@ def line(name, content, match=None, mode=None, location=None,
            'comment': ''}
     if not name:
         return _error(ret, 'Must provide name to file.line')
+
+    if create and not os.path.isfile(name):
+        managed(name, create=create, user=user, group=group, mode=file_mode)
 
     check_res, check_msg = _check_file(name)
     if not check_res:


### PR DESCRIPTION
While using file.line there is no option to create an empty file. The idea here
is to use managed since is more accurate to create files and set correct permissions
touch is only to update atime/mtime on the file.

This is more or less worj in progress. Unit test went fine but integration tests fails in my VM due memory issues.

Fixes #31136.
