### PR TITLE
Fix locale generation on Ubuntu

### DIFF
--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -272,7 +272,7 @@ def gen_locale(locale, **kwargs):
     locale_info = salt.utils.locales.split_locale(locale)
 
     # if the charmap has not been supplied, normalize by appening it
-    if not locale_info['charmap']:
+    if not locale_info['charmap'] and not on_ubuntu:
         locale_info['charmap'] = locale_info['codeset']
         locale = salt.utils.locales.join_locale(locale_info)
 


### PR DESCRIPTION
On ubuntu you can not append the charmap.

root@ubuntu:~# locale-gen fr_FR.UTF-8 UTF-8 ; echo $?
1

root@ubuntu:~# locale-gen fr_FR.UTF-8 ; echo $?
Generating locales...
  fr_FR.UTF-8... up-to-date
Generation complete.
0

Can you backport to v2015.8?

Thanks
