### PR TITLE
added a feature to hash a password if provided as clear text

### DIFF
--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -264,8 +264,8 @@ def present(name,
        BSD support added.
 
     hash_password
-        Set to True to encrypt the clear text password. Default is ``False``. 
-        
+        Set to True to encrypt the clear text password. Default is ``False``.
+
 
     enforce_password
         Set to False to keep the password from being changed if it has already
@@ -366,9 +366,10 @@ def present(name,
     '''
 
     '''
-    First check if a password is set. If password is set, check if 
-    hash_password is True, then encrypt it. 
+    First check if a password is set. If password is set, check if
+    hash_password is True, then encrypt it.
     '''
+
     if password:
         if hash_password is True:
             log.debug('Encrypting a clear text password')

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -365,10 +365,8 @@ def present(name,
         .. versionchanged:: 2015.8.0
     '''
 
-    '''
-    First check if a password is set. If password is set, check if
-    hash_password is True, then encrypt it.
-    '''
+    # First check if a password is set. If password is set, check if
+    # hash_password is True, then encrypt it.
 
     if password:
         if hash_password is True:

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -187,6 +187,7 @@ def present(name,
             home=None,
             createhome=True,
             password=None,
+            hash_password=False,
             enforce_password=True,
             empty_password=False,
             shell=None,
@@ -261,6 +262,10 @@ def present(name,
 
     .. versionchanged:: 0.16.0
        BSD support added.
+
+    hash_password
+        Set to True to encrypt the clear text password. Default is ``False``. 
+        
 
     enforce_password
         Set to False to keep the password from being changed if it has already
@@ -359,6 +364,16 @@ def present(name,
 
         .. versionchanged:: 2015.8.0
     '''
+
+    '''
+    First check if a password is set. If password is set, check if 
+    hash_password is True, then encrypt it. 
+    '''
+    if password:
+        if hash_password is True:
+            log.debug('Encrypting a clear text password')
+            password = __salt__['shadow.gen_password'](password)
+
     if fullname is not None:
         fullname = salt.utils.locales.sdecode(fullname)
     if roomnumber is not None:

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -368,10 +368,9 @@ def present(name,
     # First check if a password is set. If password is set, check if
     # hash_password is True, then encrypt it.
 
-    if password:
-        if hash_password is True:
-            log.debug('Encrypting a clear text password')
-            password = __salt__['shadow.gen_password'](password)
+    if password and hash_password:
+        log.debug('Encrypting a clear text password')
+        password = __salt__['shadow.gen_password'](password)
 
     if fullname is not None:
         fullname = salt.utils.locales.sdecode(fullname)

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -264,7 +264,7 @@ def present(name,
        BSD support added.
 
     hash_password
-        Set to True to encrypt the clear text password. Default is ``False``.
+        Set to True to hash the clear text password. Default is ``False``.
 
 
     enforce_password
@@ -366,10 +366,10 @@ def present(name,
     '''
 
     # First check if a password is set. If password is set, check if
-    # hash_password is True, then encrypt it.
+    # hash_password is True, then hash it.
 
     if password and hash_password:
-        log.debug('Encrypting a clear text password')
+        log.debug('Hashing a clear text password')
         password = __salt__['shadow.gen_password'](password)
 
     if fullname is not None:


### PR DESCRIPTION
This feature will enable to initially encrypt a password using GPG in pillar, then decrypt the GPG value and pass it to user.present state, which will hash it for linux shadow file. This is useful, when the the same password for a same user must be set in Windows as well as Linux OS. Having this feature will allow to store the GPG value in pillar only once for both OS's. 
