### PR TITLE
Issues/29643 fix invalid retcode

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -235,7 +235,8 @@ def high(data, test=False, queue=False, **kwargs):
             'is specified.'
         )
     try:
-        st_ = salt.state.State(__opts__, pillar, pillar_enc=pillar_enc, proxy=__proxy__)
+        st_ = salt.state.State(__opts__, pillar, pillar_enc=pillar_enc, proxy=__proxy__,
+                context=__context__)
     except NameError:
         st_ = salt.state.State(__opts__, pillar, pillar_enc=pillar_enc)
 
@@ -272,7 +273,7 @@ def template(tem, queue=False, **kwargs):
     conflict = _check_queue(queue, kwargs)
     if conflict is not None:
         return conflict
-    st_ = salt.state.HighState(__opts__)
+    st_ = salt.state.HighState(__opts__, context=__context__)
     if not tem.endswith('.sls'):
         tem = '{sls}.sls'.format(sls=tem)
     high_state, errors = st_.render_state(tem, saltenv, '', None, local=True)
@@ -576,6 +577,7 @@ def highstate(test=None,
                                    kwargs.get('__pub_jid'),
                                    pillar_enc=pillar_enc,
                                    proxy=__proxy__,
+                                   context=__context__,
                                    mocked=kwargs.get('mock', False))
     except NameError:
         st_ = salt.state.HighState(opts,
@@ -768,6 +770,7 @@ def sls(mods,
                                    kwargs.get('__pub_jid'),
                                    pillar_enc=pillar_enc,
                                    proxy=__proxy__,
+                                   context=__context__,
                                    mocked=kwargs.get('mock', False))
     except NameError:
         st_ = salt.state.HighState(opts,
@@ -881,7 +884,7 @@ def top(topfn,
             'is specified.'
         )
 
-    st_ = salt.state.HighState(opts, pillar, pillar_enc=pillar_enc)
+    st_ = salt.state.HighState(opts, pillar, pillar_enc=pillar_enc, context=__context__)
     st_.push_active()
     st_.opts['state_top'] = salt.utils.url.create(topfn)
     if saltenv:

--- a/salt/state.py
+++ b/salt/state.py
@@ -630,6 +630,7 @@ class State(object):
             jid=None,
             pillar_enc=None,
             proxy=None,
+            context=None,
             mocked=False,
             loader='states'):
         self.states_loader = loader
@@ -650,7 +651,7 @@ class State(object):
                 )
         self._pillar_enc = pillar_enc
         self.opts['pillar'] = self._gather_pillar()
-        self.state_con = {}
+        self.state_con = context or {}
         self.load_modules(proxy=proxy)
         self.active = set()
         self.mod_init = set()
@@ -3284,6 +3285,7 @@ class HighState(BaseHighState):
             jid=None,
             pillar_enc=None,
             proxy=None,
+            context=None,
             mocked=False,
             loader='states'):
         self.opts = opts
@@ -3295,6 +3297,7 @@ class HighState(BaseHighState):
                            jid,
                            pillar_enc,
                            proxy=proxy,
+                           context=context,
                            mocked=mocked,
                            loader=loader)
         self.matcher = salt.minion.Matcher(self.opts)

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -803,6 +803,7 @@ class AsyncReqMessageClient(object):
             self.stream.io_loop.remove_handler(self.stream.socket)
             # set this to None, more hacks for messed up pyzmq
             self.stream.socket = None
+            self.stream = None
             self.socket.close()
         if self.context.closed is False:
             self.context.term()


### PR DESCRIPTION
Fixes: #29643 
Relates to: #28569 

Problem:
Salt highstate is executed. One of states failed. Result retcode is 0.
Expected result retcode: 2.

Explanation:
The problem is the following: minion instance have `functions` `LazyLoader` instance keeping `context` inside. It calls `modules.state.highstate()` that is loaded by the loader and injected with the `context` instance. This `state` module function creates `state.State` instance that creates it's own `LazyLoader` instance with another `context'` instance and executes states. Some states uses modules and during modules loading the new `context'` instance is injected into the modules instead of the old one. By the `LazyLoader` design it searches a module to load by matching file names. If no exact nor partial match found it loads modules one-by-one and checks does the module registered the desired name with it's `__virtual__` function. So loading using virtual modules such `pkg` could produce loading of the state module with the new loader and injecting the new `context'` into it.
When states execution is finished `modules.state.highstate()` function writes `retcode` value into the module `context'` dict that was updated by loader. But when it returns minon reads the value from its `context` dict it keeps in the old loader.

Fix:
I've changed `state` module to pass it's `__context__` object to `State` object that is uses it when it creates the new `LazyLoader` instance. This keeps the `context` instance in all modules called indirectly from the `state` module.
