### PR TITLE
added logic to check for installed package

### DIFF
--- a/tests/integration/files/file/base/pkg_latest_epoch.sls
+++ b/tests/integration/files/file/base/pkg_latest_epoch.sls
@@ -1,3 +1,3 @@
 nova_packages:
   pkg.latest:
-    - name: libguestfs-tools
+    - name: bash-completion

--- a/tests/integration/states/pkg.py
+++ b/tests/integration/states/pkg.py
@@ -294,12 +294,12 @@ class PkgTest(integration.ModuleCase,
         This is a destructive test as it installs a package
         '''
         package = 'bash-completion'
-        pkgquery= 'version'
+        pkgquery = 'version'
 
         ret = self.run_function('state.sls', mods='pkg_latest_epoch')
         self.assertSaltTrueReturn(ret)
 
-        #After the pkg has been instlaled by the sls file above we
+        #After the pkg has been installed by the sls file above we
         #need to verify that it actually installed
         ret = self.run_function('pkg.info_installed', [package])
         self.assertTrue(pkgquery in str(ret))

--- a/tests/integration/states/pkg.py
+++ b/tests/integration/states/pkg.py
@@ -46,7 +46,7 @@ _PKG_TARGETS_DOT = {
 }
 
 
-@requires_salt_modules('pkg.version', 'pkg.latest_version')
+@requires_salt_modules('pkg.version', 'pkg.latest_version', 'pkg.info_installed')
 class PkgTest(integration.ModuleCase,
               integration.SaltReturnAssertsMixIn):
     '''
@@ -293,8 +293,16 @@ class PkgTest(integration.ModuleCase,
 
         This is a destructive test as it installs a package
         '''
+        package = 'bash-completion'
+        pkgquery= 'version'
+
         ret = self.run_function('state.sls', mods='pkg_latest_epoch')
         self.assertSaltTrueReturn(ret)
+
+        #After the pkg has been instlaled by the sls file above we
+        #need to verify that it actually installed
+        ret = self.run_function('pkg.info_installed', [package])
+        self.assertTrue(pkgquery in str(ret))
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
This adds additional logic to the test to check for the installed package after pkg.latest has run. I tested this on a ubuntu and centos. My worry is that pkg.info_installed is not platform independent, so parsing the results for 'version' might not work on other OSs if the output is different. 

I also decided to change the name of the package from libguestfs-tools to bash-completion because bash-completion will not install a ton of dependencies like libguest. 
