### PR TITLE
Use correct deploy directory

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1842,6 +1842,7 @@ def cloud_config(path, env_var='SALT_CLOUD_CONFIG', defaults=None,
         os.path.abspath(
             os.path.join(
                 os.path.dirname(__file__),
+                '..',
                 'cloud',
                 'deploy'
             )


### PR DESCRIPTION
This was likely introduced when `config.py` became `config/__init__.py`.
