### PR TITLE
Fixed named external_ip reservation/re-use code in gce driver.

### DIFF
--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -2043,7 +2043,7 @@ def create(vm_=None, call=None):
         external_ip = None
     else:
         region = '-'.join(kwargs['location'].name.split('-')[:2])
-        kwargs['external_ip'] = __create_orget_address(conn, kwargs['external_ip'], region)
+        external_ip = __create_orget_address(conn, external_ip, region)
     kwargs['external_ip'] = external_ip
     vm_['external_ip'] = external_ip
 


### PR DESCRIPTION
When using a named external_ip, an exception was thrown every time.

Updated the __create_orget_address call and return to use the correct variable. Exceptions are no longer thrown and IP creation and re-use happens as expected. To test setup a profile like this:

dns-primary-w1c:
  external_ip: "dns-primary"
  size: f1-micro
  image: centos-6-v20160126
  location: europe-west1-c
  use_persistent_disk: True
  ex_disk_type: 'pd-standard'
  delete_boot_pd: False
  ssh_interface: private_ips
  make_master: False
  deploy: True
  provider: my-gce-provider

Then in a map, use it in an example.map:

dns-primary-w1c:
- my-dns-server

salt-cloud -m example.map

Check that it reserves a new static IP and assigns it to your new instance.
