### PR TITLE
Fix crash with scheduler and runners (#31106)

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -53,6 +53,12 @@ class ClientFuncsDict(collections.MutableMapping):
     def __init__(self, client):
         self.client = client
 
+    def __getattr__(self, attr):
+        '''
+        Provide access eg. to 'pack'
+        '''
+        return getattr(self.client.functions, attr)
+
     def __setitem__(self, key, val):
         raise NotImplementedError()
 

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -700,7 +700,10 @@ class Schedule(object):
                             )
                         )
 
-            ret['retcode'] = self.functions.pack['__context__']['retcode']
+            # runners do not provide retcode
+            if 'retcode' in self.functions.pack['__context__']:
+                ret['retcode'] = self.functions.pack['__context__']['retcode']
+
             ret['success'] = True
         except Exception:
             log.exception("Unhandled exception running {0}".format(ret['fun']))


### PR DESCRIPTION
- runner wrapper `ClientFuncsDict` does not provide access to 'pack' attribute, forward it
- runners do not provide retcode, therefore ignore it in the schedule if it is not
  provided by **context**

I am not 100% sure about exposing `pack` in `ClientFuncsDict` but it seems more sensible to me than testing explicitly in `schedule.py` that self is `ClientFuncsDict` to avoid crashing on accessing it.
