### PR TITLE
Selinux mode toggle

### DIFF
--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -38,7 +38,7 @@ def __virtual__():
         if not salt.utils.which(cmd):
             return (False, cmd + ' is not in the path')
     # SELinux only makes sense on Linux *obviously*
-    if __grains__['kernel'] == 'Linux'
+    if __grains__['kernel'] == 'Linux':
         return 'selinux'
     return (False, 'Module only works on Linux with selinux installed')
 
@@ -115,12 +115,13 @@ def setenforce(mode):
         return 'Invalid mode {0}'.format(mode)
 
     enforce = os.path.join(selinux_fs_path(), 'enforce')
-    try:
-        with salt.utils.fopen(enforce, 'w') as _fp:
-            _fp.write(mode)
-    except (IOError, OSError) as exc:
-        msg = 'Could not write SELinux enforce file: {0}'
-        raise CommandExecutionError(msg.format(str(exc)))
+    if getenforce() != 'Disabled': # enforce file does not exist if currently disabled.  Only for toggling enforcing/permissive
+        try:
+            with salt.utils.fopen(enforce, 'w') as _fp:
+                _fp.write(mode)
+        except (IOError, OSError) as exc:
+            msg = 'Could not write SELinux enforce file: {0}'
+            raise CommandExecutionError(msg.format(str(exc)))
 
     config = '/etc/selinux/config'
     try:

--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -118,7 +118,7 @@ def setenforce(mode):
     else:
         return 'Invalid mode {0}'.format(mode)
 
-    if getenforce() != 'Disabled': # enforce file does not exist if currently disabled.  Only for toggling enforcing/permissive
+    if getenforce() != 'Disabled':  # enforce file does not exist if currently disabled.  Only for toggling enforcing/permissive
         enforce = os.path.join(selinux_fs_path(), 'enforce')
         try:
             with salt.utils.fopen(enforce, 'w') as _fp:

--- a/salt/states/selinux.py
+++ b/salt/states/selinux.py
@@ -46,6 +46,8 @@ def _refine_mode(mode):
             mode == '0',
             mode == 'off']):
         return 'Permissive'
+    if any([mode.startswith('d')]):
+        return 'Disabled'
     return 'unknown'
 
 
@@ -76,11 +78,13 @@ def _refine_module_state(module_state):
 
 def mode(name):
     '''
-    Verifies the mode SELinux is running in, can be set to enforcing or
-    permissive
+    Verifies the mode SELinux is running in, can be set to enforcing,
+    permissive, or disabled
+        Note: A change to or from disabled mode requires a system reboot.
+            You will need to perform this yourself.
 
     name
-        The mode to run SELinux in, permissive or enforcing
+        The mode to run SELinux in, permissive, enforcing, or disabled.
     '''
     ret = {'name': name,
            'result': False,


### PR DESCRIPTION
I'm not as confident about this as I was about the last set of changes.

This would help address https://github.com/saltstack/salt/issues/8640 as well as (I believe) properly address what people intend to do when changing SELinux modes.

The core issue is the current reliance on the 'enforce' file, which is not existent if SELinux is Disabled.  Even if the system is capable and all prerequisites are covered, the file only exists when SELinux is in Permissive or Enforcing modes.

The changes here would keep the toggle between Permissive/Enforcing, but would also allow changing to/from Disabled mode.  Doing so does require a reboot, and I'm leaving that up to the end user.

Also by making additional changes to the /etc/selinux/config file, the changes would persist across reboots, modifying the contents of /sysfs/selinux/enforce does not do so.
