### PR TITLE
[Py3 w/raet startup only] change salt/master.py:510 to work in both py2 & py3

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -508,7 +508,7 @@ class Master(SMaster):
             # Setup the secrets here because the PubServerChannel may need
             # them as well.
             SMaster.secrets['aes'] = {'secret': multiprocessing.Array(ctypes.c_char,
-                                                bytearray(salt.crypt.Crypticle.generate_key_string(), encoding='ascii')),
+                                                salt.crypt.Crypticle.generate_key_string().encode('ascii')),
                                       'reload': salt.crypt.Crypticle.generate_key_string
                                      }
             log.info('Creating master process manager')

--- a/salt/master.py
+++ b/salt/master.py
@@ -508,7 +508,7 @@ class Master(SMaster):
             # Setup the secrets here because the PubServerChannel may need
             # them as well.
             SMaster.secrets['aes'] = {'secret': multiprocessing.Array(ctypes.c_char,
-                                                salt.crypt.Crypticle.generate_key_string()),
+                                                bytearray(salt.crypt.Crypticle.generate_key_string(), encoding='ascii')),
                                       'reload': salt.crypt.Crypticle.generate_key_string
                                      }
             log.info('Creating master process manager')


### PR DESCRIPTION
this is a compatibility fix so both py2 and py3 will accept the supplied data. 

salt.crypt.Crypticle.generate_key_string() returns an str() object which is simple bytes in py2 and unicode in py3. multiprocessing.Array() wants single byte characters and in py3, a string may have more than one byte per character. therefore, encode the output of generate_key_string() to a bytes object which Array() will happily accept.

``` python
Python 2.7.11 (default, Dec  6 2015, 15:43:46) 
[GCC 5.2.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import multiprocessing
>>> import ctypes
>>> multiprocessing.Array(ctypes.c_char, 'abc')
<SynchronizedString wrapper for <multiprocessing.sharedctypes.c_char_Array_3 object at 0x7f5302e8c950>>
>>> multiprocessing.Array(ctypes.c_char, 'abc'.encode('ascii'))
<SynchronizedString wrapper for <multiprocessing.sharedctypes.c_char_Array_3 object at 0x7f5302e8c950>>
```

``` python
Python 3.5.1 (default, Dec  7 2015, 12:58:09) 
[GCC 5.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import multiprocessing
>>> import ctypes
>>> multiprocessing.Array(ctypes.c_char, 'abc')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.5/multiprocessing/context.py", line 140, in Array
    ctx=self.get_context())
  File "/usr/lib/python3.5/multiprocessing/sharedctypes.py", line 87, in Array
    obj = RawArray(typecode_or_type, size_or_initializer)
  File "/usr/lib/python3.5/multiprocessing/sharedctypes.py", line 66, in RawArray
    result.__init__(*size_or_initializer)
TypeError: one character bytes, bytearray or integer expected
>>> multiprocessing.Array(ctypes.c_char, 'abc'.encode('ascii'))
<SynchronizedString wrapper for <multiprocessing.sharedctypes.c_char_Array_3 object at 0x7f2e5cd91a60>>
```

be mindful that the returned obj.value will be 'abc' in py2 and b'abc' in py3
