### PR TITLE
py3 rejects foo.decode("base64") so switch to base64.b64decode(foo)

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -1147,7 +1147,7 @@ class Crypticle(object):
 
     @classmethod
     def extract_keys(cls, key_string, key_size):
-        key = key_string.decode('base64')
+        key = base64.b64decode(key_string.encode('ascii'))
         assert len(key) == key_size / 8 + cls.SIG_SIZE, 'invalid key'
         return key[:-cls.SIG_SIZE], key[-cls.SIG_SIZE:]
 

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -1147,7 +1147,7 @@ class Crypticle(object):
 
     @classmethod
     def extract_keys(cls, key_string, key_size):
-        key = base64.b64decode(key_string.encode('ascii'))
+        key = base64.b64decode(six.b(key_string))
         assert len(key) == key_size / 8 + cls.SIG_SIZE, 'invalid key'
         return key[:-cls.SIG_SIZE], key[-cls.SIG_SIZE:]
 

--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -25,6 +25,7 @@ from salt.exceptions import (
     SaltInvocationError,
     CommandExecutionError,
 )
+from salt.ext import six
 from salt.ext.six.moves import range
 
 log = logging.getLogger(__name__)
@@ -232,7 +233,7 @@ def _fingerprint(public_key):
     If the key is invalid (incorrect base64 string), return None
     '''
     try:
-        raw_key = base64.b64decode(public_key.encode('ascii'))
+        raw_key = base64.b64decode(six.b(public_key))
     except binascii.Error:
         return None
     ret = hashlib.md5(raw_key).hexdigest()

--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -16,6 +16,7 @@ import hashlib
 import binascii
 import logging
 import subprocess
+import base64
 
 # Import salt libs
 import salt.utils
@@ -231,7 +232,7 @@ def _fingerprint(public_key):
     If the key is invalid (incorrect base64 string), return None
     '''
     try:
-        raw_key = public_key.decode('base64')
+        raw_key = base64.b64decode(public_key.encode('ascii'))
     except binascii.Error:
         return None
     ret = hashlib.md5(raw_key).hexdigest()


### PR DESCRIPTION
``` log
[ERROR   ] An un-handled exception from the multiprocessing process 'MWorker-2' was caught:
Traceback (most recent call last):
  File "/home/david/Desktop/Projects/salt/salt/utils/process.py", line 613, in _run
    return self._original_run()
  File "/home/david/Desktop/Projects/salt/salt/master.py", line 866, in run
    self.__bind()
  File "/home/david/Desktop/Projects/salt/salt/master.py", line 795, in __bind
    req_channel.post_fork(self._handle_payload, io_loop=self.io_loop)  # TODO: cleaner? Maybe lazily?
  File "/home/david/Desktop/Projects/salt/salt/transport/zeromq.py", line 535, in post_fork
    salt.transport.mixins.auth.AESReqServerMixin.post_fork(self, payload_handler, io_loop)
  File "/home/david/Desktop/Projects/salt/salt/transport/mixins/auth.py", line 75, in post_fork
    self.crypticle = salt.crypt.Crypticle(self.opts, salt.master.SMaster.secrets['aes']['secret'].value)
  File "/home/david/Desktop/Projects/salt/salt/crypt.py", line 1136, in __init__
    self.keys = self.extract_keys(self.key_string, key_size)
  File "/home/david/Desktop/Projects/salt/salt/crypt.py", line 1150, in extract_keys
    key = key_string.decode('base64')
LookupError: 'base64' is not a text encoding; use codecs.decode() to handle arbitrary codecs
```

since we are already using the base64 module in some places, continue using it for consistency rather than import yet another module (codecs).

this makes for a happy py2 and py3
