### PR TITLE
Utilize prepared grains var in master-side ipcidr matching

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2414,26 +2414,28 @@ class Matcher(object):
         '''
         Matches based on IP address or CIDR notation
         '''
-
         try:
-            tgt = ipaddress.ip_network(tgt)
-            # Target is a network
-            proto = 'ipv{0}'.format(tgt.version)
-            if proto not in self.opts['grains']:
-                return False
-            else:
-                return salt.utils.network.in_subnet(tgt, self.opts['grains'][proto])
+            # Target is an address?
+            tgt = ipaddress.ip_address(tgt)
         except:  # pylint: disable=bare-except
             try:
-               # Target should be an address
-                proto = 'ipv{0}'.format(ipaddress.ip_address(tgt).version)
-                if proto not in self.opts['grains']:
-                    return False
-                else:
-                    return tgt in self.opts['grains'][proto]
+                # Target is a network?
+                tgt = ipaddress.ip_network(tgt)
             except:  # pylint: disable=bare-except
-                log.error('Invalid IP/CIDR target {0}"'.format(tgt))
-                return False
+                log.error('Invalid IP/CIDR target: {0}'.format(tgt))
+                return []
+        proto = 'ipv{0}'.format(tgt.version)
+
+        grains = self.opts['grains']
+
+        if proto not in grains:
+            match = False
+        elif isinstance(tgt, (ipaddress.IPv4Address, ipaddress.IPv6Address)):
+            match = str(tgt) in grains[proto]
+        else:
+            match = salt.utils.network.in_subnet(tgt, grains[proto])
+
+        return match
 
     def range_match(self, tgt):
         '''

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -322,12 +322,26 @@ class CkMinions(object):
         elif cache_enabled:
             minions = os.listdir(os.path.join(self.opts['cachedir'], 'minions'))
         else:
-            return list()
+            return []
 
         if cache_enabled:
             cdir = os.path.join(self.opts['cachedir'], 'minions')
             if not os.path.isdir(cdir):
                 return list(minions)
+
+            tgt = expr
+            try:
+                # Target is an address?
+                tgt = ipaddress.ip_address(tgt)
+            except:  # pylint: disable=bare-except
+                try:
+                    # Target is a network?
+                    tgt = ipaddress.ip_network(tgt)
+                except:  # pylint: disable=bare-except
+                    log.error('Invalid IP/CIDR target: {0}'.format(tgt))
+                    return []
+            proto = 'ipv{0}'.format(tgt.version)
+
             for id_ in os.listdir(cdir):
                 if not greedy and id_ not in minions:
                     continue
@@ -342,26 +356,12 @@ class CkMinions(object):
                 except (IOError, OSError):
                     continue
 
-                match = True
-                tgt = expr
-                try:
-                    tgt = ipaddress.ip_network(tgt)
-                    # Target is a network
-                    proto = 'ipv{0}'.format(tgt.version)
-                    if proto not in grains:
-                        match = False
-                    else:
-                        match = salt.utils.network.in_subnet(tgt, grains[proto])
-                except:  # pylint: disable=bare-except
-                    try:
-                       # Target should be an address
-                        proto = 'ipv{0}'.format(ipaddress.ip_address(tgt).version)
-                        if proto not in grains:
-                            match = False
-                        else:
-                            match = tgt in grains[proto]
-                    except:  # pylint: disable=bare-except
-                        log.error('Invalid IP/CIDR target {0}"'.format(tgt))
+                if proto not in grains:
+                    match = False
+                elif isinstance(tgt, (ipaddress.IPv4Address, ipaddress.IPv6Address)):
+                    match = str(tgt) in grains[proto]
+                else:
+                    match = salt.utils.network.in_subnet(tgt, grains[proto])
 
                 if not match and id_ in minions:
                     minions.remove(id_)

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -348,18 +348,18 @@ class CkMinions(object):
                     tgt = ipaddress.ip_network(tgt)
                     # Target is a network
                     proto = 'ipv{0}'.format(tgt.version)
-                    if proto not in self.opts['grains']:
+                    if proto not in grains:
                         match = False
                     else:
-                        match = salt.utils.network.in_subnet(tgt, self.opts['grains'][proto])
+                        match = salt.utils.network.in_subnet(tgt, grains[proto])
                 except:  # pylint: disable=bare-except
                     try:
                        # Target should be an address
                         proto = 'ipv{0}'.format(ipaddress.ip_address(tgt).version)
-                        if proto not in self.opts['grains']:
+                        if proto not in grains:
                             match = False
                         else:
-                            match = tgt in self.opts['grains'][proto]
+                            match = tgt in grains[proto]
                     except:  # pylint: disable=bare-except
                         log.error('Invalid IP/CIDR target {0}"'.format(tgt))
 


### PR DESCRIPTION
At least partially fixes #29188 (see discussion there), #30169, #30962, #29733, #29188 et al. (tnx @fantasy86 for analysis)
