### PR TITLE
Remove error logging of missing boto libraries

### DIFF
--- a/salt/modules/boto_route53.py
+++ b/salt/modules/boto_route53.py
@@ -60,6 +60,7 @@ from salt.exceptions import SaltInvocationError
 log = logging.getLogger(__name__)
 
 # Import third party libs
+REQUIRED_BOTO_VERSION = '2.35.0'
 try:
     #pylint: disable=unused-import
     import boto
@@ -67,10 +68,7 @@ try:
     from boto.route53.exception import DNSServerError
     #pylint: enable=unused-import
     # create_zone params were changed in boto 2.35+
-    required_boto_version = '2.35.0'
-    if _LooseVersion(boto.__version__) < _LooseVersion(required_boto_version):
-        msg = 'boto_route53 requires at least boto {0}.'.format(required_boto_version)
-        log.error(msg)
+    if _LooseVersion(boto.__version__) < _LooseVersion(REQUIRED_BOTO_VERSION):
         raise ImportError()
     logging.getLogger('boto').setLevel(logging.CRITICAL)
     HAS_BOTO = True
@@ -83,7 +81,9 @@ def __virtual__():
     Only load if boto libraries exist.
     '''
     if not HAS_BOTO:
-        return (False, 'The boto_route53 module could not be loaded: boto libraries not found')
+        msg = ('A boto library with version at least {0} was not '
+               'found').format(REQUIRED_BOTO_VERSION)
+        return (False, msg)
     return True
 
 


### PR DESCRIPTION
Current behavior always error logs, even if the module is not going to
be used. The loader will raise a proper error if it's attempted
accessed without having loaded properly anyway, and if that happens I'm
assuming you'll turn on debug logging and look for the cause. The
loader also logs which modules are not loaded and their reason, thus
there's no point in repeating the module name in the error message.
