### PR TITLE
ini_manage dry-run time optimisation

### DIFF
--- a/salt/states/ini_manage.py
+++ b/salt/states/ini_manage.py
@@ -49,8 +49,9 @@ def options_present(name, sections=None):
         ret['comment'] = ''
         for section in sections or {}:
             section_name = ' in section ' + section if section != 'DEFAULT_IMPLICIT' else ''
+            cur_section = __salt__['ini.get_section'](name, section)
             for key in sections[section]:
-                cur_value = __salt__['ini.get_option'](name, section, key)
+                cur_value = cur_section.get(key)
                 if cur_value == str(sections[section][key]):
                     ret['comment'] += 'Key {0}{1} unchanged.\n'.format(key, section_name)
                     continue
@@ -98,8 +99,9 @@ def options_absent(name, sections=None):
         ret['comment'] = ''
         for section in sections or {}:
             section_name = ' in section ' + section if section != 'DEFAULT_IMPLICIT' else ''
+            cur_section = __salt__['ini.get_section'](name, section)
             for key in sections[section]:
-                cur_value = __salt__['ini.get_option'](name, section, key)
+                cur_value = cur_section.get(key)
                 if not cur_value:
                     ret['comment'] += 'Key {0}{1} does not exist.\n'.format(key, section_name)
                     continue


### PR DESCRIPTION
Hello !
This preloads all the INI section in options_present and options_absent methods, when doing a dry-run, instead of calling ini.get_option() for each managed INI option.

It results in a quicker dry-run (from ~50s to ~9s, in my case).

It fixes #31154
