### PR TITLE
Allow file.directory state to operate on "/"

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1878,8 +1878,8 @@ def directory(name,
            'comment': ''}
     if not name:
         return _error(ret, 'Must provide name to file.directory')
-    # Remove trailing slash, if present
-    if name[-1] == '/':
+    # Remove trailing slash, if present and we're not working on "/" itself
+    if name[-1] == '/' and name != '/':
         name = name[:-1]
 
     user = _test_owner(kwargs, user=user)


### PR DESCRIPTION
When working on slash, it currently trims the trailing slash and the absolute
path check fails due to being given an empty string. This removes the trailing
slash check if we're just working on "/"
