### PR TITLE
Allow loading external modules using setuptools entry points

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -35,6 +35,11 @@ import salt.modules.cmdmod
 
 # Import 3rd-party libs
 import salt.ext.six as six
+try:
+    import pkg_resources
+    HAS_PKG_RESOURCES = True
+except ImportError:
+    HAS_PKG_RESOURCES = False
 
 __salt__ = {
     'cmd.run': salt.modules.cmdmod._run_quiet
@@ -131,6 +136,11 @@ def _module_dirs(
             ext_type_dirs = '{0}_dirs'.format(tag)
         if ext_type_dirs in opts:
             ext_type_types.extend(opts[ext_type_dirs])
+        if HAS_PKG_RESOURCES and ext_type_dirs:
+            for entry_point in pkg_resources.iter_entry_points('salt.loader', ext_type_dirs):
+                loaded_entry_point = entry_point.load()
+                for path in loaded_entry_point():
+                    ext_type_types.append(path)
 
     cli_module_dirs = []
     # The dirs can be any module dir, or a in-tree _{ext_type} dir


### PR DESCRIPTION
Since I was unable to find the right document to properly document this addition, here's what should be added to said document.
# External Modules Setuptools Entry-Points Support

The salt loader was enhanced to look for external modules by looking at the `salt.loader` [entry-point](https://pythonhosted.org/setuptools/setuptools.html#dynamic-discovery-of-services-and-plugins).
If [`pkg_resources`](https://pythonhosted.org/setuptools/pkg_resources.html) is available(which it should if setuptools is installed).

The package which has custom engines, minion modules, outputters, etc, should require setuptools and should define the following entry points in it's setup function:

``` python
from setuptools import setup, find_packages

setup(name=<NAME>,
      version=<VERSION>,
      description=<DESC>,
      author=<AUTHOR>,
      author_email=<AUTHOR-EMAIL>,
      url=' ... ',
      packages=find_packages(),
      entry_points='''
        [salt.loader]
        engines_dirs = <package>.<loader-module>:engines_dirs
        fileserver_dirs = <package>.<loader-module>:fileserver_dirs
        pillar_dirs = <package>.<loader-module>:pillar_dirs
        returner_dirs = <package>.<loader-module>:returner_dirs
        roster_dirs = <package>.<loader-module>:roster_dirs
      ''')
```

The above setup script example mentions a loader module, here's an example of how `<package>/<loader-module>.py` should look like:

``` python
# -*- coding: utf-8 -*-

# Import python libs
import os

PKG_DIR = os.path.abspath(os.path.dirname(__file__))


def engines_dirs():
    '''
    yield one path per parent directory of where engines can be found
    '''
    yield os.path.join(PKG_DIR, 'engines_1')
    yield os.path.join(PKG_DIR, 'engines_2')


def fileserver_dirs():
    '''
    yield one path per parent directory of where fileserver modules can be found
    '''
    yield os.path.join(PKG_DIR, 'fileserver')


def pillar_dirs():
    '''
    yield one path per parent directory of where external pillar modules can be found
    '''
    yield os.path.join(PKG_DIR, 'pillar')


def returner_dirs():
    '''
    yield one path per parent directory of where returner modules can be found
    '''
    yield os.path.join(PKG_DIR, 'returners')


def roster_dirs():
    '''
    yield one path per parent directory of where roster modules can be found
    '''
    yield os.path.join(PKG_DIR, 'roster')
```

---

Refs https://github.com/saltstack/salt/issues/31206
