### PR TITLE
Removed forcing uppercase of hostname

### DIFF
--- a/salt/states/win_system.py
+++ b/salt/states/win_system.py
@@ -88,7 +88,7 @@ def computer_name(name):
         The desired computer name
     '''
     # Just in case someone decides to enter a numeric description
-    name = str(name).upper()
+    name = str(name)
 
     ret = {'name': name,
            'changes': {},


### PR DESCRIPTION
Why force uppercase of hostname when this is not default Windows behavior?

When I set the hostname using `win_service`, the hostname is being yelled back at me by default. That's not nice.
