### PR TITLE
Minor docs fix: file_tree pillar (Fixes #31124)

### DIFF
--- a/salt/pillar/file_tree.py
+++ b/salt/pillar/file_tree.py
@@ -43,11 +43,13 @@ intended to be used to deploy a file using ``contents_pillar`` with a
         ext_pillar:
           - file_tree:
               root_dir: /path/to/root/directory
-              keep_newlines:
+              keep_newline:
                 - files/testdir/*
 
 .. note::
-    Binary files are not affected by the ``keep_newlines`` configuration.
+    In earlier releases, this documentation incorrectly stated that binary
+    files would not affected by the ``keep_newline`` configuration.  However,
+    this module does not actually distinguish between binary and text files.
 
 
 Assigning Pillar Data to Individual Hosts


### PR DESCRIPTION
Corrected `keep_newlines` to `keep_newline`, and pointed out
that `keep_newline` is _not_ ignored for binary files, as previously
stated by the documentation.
