### PR TITLE
Trigger onfail state if any target failed

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1853,7 +1853,7 @@ class State(object):
                     continue
                 if r_state == 'onfail':
                     if run_dict[tag]['result'] is True:
-                        fun_stats.add('onfail')
+                        fun_stats.add('onfail')  # At least one state is OK
                         continue
                 else:
                     if run_dict[tag]['result'] is False:
@@ -1884,8 +1884,8 @@ class State(object):
                 status = 'met'
             else:
                 status = 'pre'
-        elif 'onfail' in fun_stats:
-            status = 'onfail'
+        elif 'onfail' in fun_stats and 'met' not in fun_stats:
+            status = 'onfail'  # all onfail states are OK
         elif 'onchanges' in fun_stats and 'onchangesmet' not in fun_stats:
             status = 'onchanges'
         elif 'change' in fun_stats:


### PR DESCRIPTION
Fixes: #22370

Previously onfail used AND logic, so it triggered the onfail state
only if all targets failed. This fix changes the logic to trigger
onfail state if ANY of targets is failed.
