### PR TITLE
Improve logging when master cannot decode a payload

### DIFF
--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -512,8 +512,8 @@ class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.
         try:
             payload = self.serial.loads(payload[0])
             payload = self._decode_payload(payload)
-        except Exception as e:
-            log.error('Bad load from minion')
+        except Exception as exc:
+            log.error('Bad load from minion: %s: %s', type(exc).__name__, exc)
             stream.send(self.serial.dumps('bad load'))
             raise tornado.gen.Return()
 


### PR DESCRIPTION
This includes the exception type and message in the log message instead
of simply logging "Bad load from minion".
