### PR TITLE
allow for nova servers to be built with premade volumes

### DIFF
--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -112,7 +112,7 @@ and one using cinder volumes already attached
     centos7-2-iad-rackspace:
       provider: rackspace-iad
       size: general1-2
-      block_volume: <volume id>
+      boot_volume: <volume id>
 
     # create the volume from a snapshot
     centos7-2-iad-rackspace:

--- a/salt/config.py
+++ b/salt/config.py
@@ -2640,7 +2640,7 @@ def is_profile_configured(opts, provider, profile_name):
     elif driver == 'vmware' or linode_cloning:
         required_keys.append('clonefrom')
     elif driver == 'nova':
-        nova_image_keys = ['image', 'block_device_mapping', 'block_device']
+        nova_image_keys = ['image', 'block_device_mapping', 'block_device', 'boot_volume']
         if not any([key in provider_key for key in nova_image_keys]) and not any([key in profile_key for key in nova_image_keys]):
             required_keys.extend(nova_image_keys)
 


### PR DESCRIPTION
if the boot_volume is specified, allow for that to be used instead of an image
