### PR TITLE
 fixes to schedule.list in schedule module

### DIFF
--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -127,7 +127,16 @@ def list_(show_all=False,
             continue
 
         if '_seconds' in schedule[job]:
-            schedule[job]['seconds'] = schedule[job]['_seconds']
+            # if _seconds is greater than zero
+            # then include the original back in seconds.
+            # otherwise remove seconds from the listing as the
+            # original item didn't include it.
+            if schedule[job]['_seconds'] > 0:
+                schedule[job]['seconds'] = schedule[job]['_seconds']
+            else:
+                del schedule[job]['seconds']
+
+            # remove _seconds from the listing
             del schedule[job]['_seconds']
 
     if schedule:


### PR DESCRIPTION
when using splay, seconds was being included in listing for schedule items that didn't original include it.  This PR fixes that scenario. #30563 
