### PR TITLE
Refactored GlusterFS support

### DIFF
--- a/salt/modules/glusterfs.py
+++ b/salt/modules/glusterfs.py
@@ -43,34 +43,46 @@ def _get_minor_version():
     return version
 
 
-def _gluster(cmd):
+def _gluster_ok(xml_data):
     '''
-    Perform a gluster command.
+    Extract boolean return value from Gluster's XML output.
     '''
-    # We will pass the command string as stdin to allow for much longer
-    # command strings. This is especially useful for creating large volumes
-    # where the list of bricks exceeds 128 characters.
-    return __salt__['cmd.run'](
-        'gluster --mode=script', stdin="{0}\n".format(cmd))
+    return int(xml_data.find('opRet').text) == 0
 
 
 def _gluster_xml(cmd):
     '''
-    Perform a gluster --xml command and check for and raise errors.
+    Perform a gluster --xml command and log result.
     '''
+    # We will pass the command string as stdin to allow for much longer
+    # command strings. This is especially useful for creating large volumes
+    # where the list of bricks exceeds 128 characters.
     root = ET.fromstring(
         __salt__['cmd.run'](
             'gluster --xml --mode=script', stdin="{0}\n".format(cmd)
         ).replace("\n", ""))
-    if int(root.find('opRet').text) != 0:
-        raise CommandExecutionError(root.find('opErrstr').text)
+    if _gluster_ok(root):
+        output = root.find('output')
+        if output:
+            log.info('Gluster call "{0}" succeeded: {1}'.format(cmd, root.find('output').text))
+        else:
+            log.info('Gluster call "{0}" succeeded'.format(cmd))
+    else:
+        log.error('Failed gluster call: {0}: {1}'.format(cmd, root.find('opErrstr').text))
     return root
 
 
+def _gluster(cmd):
+    '''
+    Perform a gluster command and return a boolean status.
+    '''
+    return _gluster_ok(_gluster_xml(cmd))
+
+
 def _etree_to_dict(t):
-    if len(t.getchildren()) > 0:
+    if len(list(t)) > 0:
         d = {}
-        for child in t.getchildren():
+        for child in t:
             d[child.tag] = _etree_to_dict(child)
     else:
         d = t.text
@@ -90,6 +102,10 @@ def _iter(root, term):
 def list_peers():
     '''
     Return a list of gluster peers
+
+    Gluster may list several hostnames for a single peer frmo which one is 
+    given separately. For consistency, this function attempts to return the 
+    longest version of the equally prefixed hostnames.
 
     CLI Example:
 
@@ -117,11 +133,20 @@ def list_peers():
 
     '''
     root = _gluster_xml('peer status')
-    result = [x.find('hostname').text for x in _iter(root, 'peer')]
-    if len(result) == 0:
+    if not _gluster_ok(root):
         return None
-    else:
-        return result
+
+    result = []
+    for peer in _iter(root, 'peer'):
+        hostname = peer.find('hostname').text
+        hostnames = peer.find('hostnames')
+        if hostnames is not None:
+            for alternative in hostnames:
+                if alternative.text.startswith(hostname + '.'):
+                    hostname = alternative.text
+        result.append(hostname)
+
+    return result
 
 
 def peer(name):
@@ -159,15 +184,10 @@ def peer(name):
             'Invalid characters in peer name "{0}"'.format(name))
 
     cmd = 'peer probe {0}'.format(name)
-
-    op_result = {
-        "exitval": _gluster_xml(cmd).find('opRet').text,
-        "output": _gluster_xml(cmd).find('output').text
-    }
-    return op_result
+    return _gluster(cmd)
 
 
-def create(name, bricks, stripe=False, replica=False, device_vg=False,
+def create_volume(name, bricks, stripe=False, replica=False, device_vg=False,
            transport='tcp', start=False, force=False):
     '''
     Create a glusterfs volume.
@@ -245,14 +265,12 @@ def create(name, bricks, stripe=False, replica=False, device_vg=False,
     if force:
         cmd += ' force'
 
-    log.debug('Clustering command:\n{0}'.format(cmd))
-    _gluster_xml(cmd)
+    if not _gluster(cmd):
+        return False
 
     if start:
-        _gluster_xml('volume start {0}'.format(name))
-        return 'Volume {0} created and started'.format(name)
-    else:
-        return 'Volume {0} created. Start volume to use'.format(name)
+        return start_volume(name)
+    return True
 
 
 def list_volumes():
@@ -266,8 +284,9 @@ def list_volumes():
         salt '*' glusterfs.list_volumes
     '''
 
-    get_volume_list = 'gluster --xml volume list'
     root = _gluster_xml('volume list')
+    if not _gluster_ok(root):
+        return None
     results = [x.text for x in _iter(root, 'volume')]
     return results
 
@@ -287,6 +306,8 @@ def status(name):
     '''
     # Get volume status
     root = _gluster_xml('volume status {0}'.format(name))
+    if not _gluster_ok(root):
+        return root.find('opErrstr').text
 
     ret = {'bricks': {}, 'nfs': {}, 'healers': {}}
 
@@ -322,44 +343,50 @@ def status(name):
     return ret
 
 
-def info(name):
+def info(name=None):
     '''
     .. versionadded:: 2015.8.4
 
-    Return the gluster volume info.
+    Return gluster volume info.
 
     name
-        Volume name
+        Optional name to retrieve only information of one volume
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' glusterfs.info myvolume
+        salt '*' glusterfs.info
 
     '''
-    cmd = 'volume info {0}'.format(name)
+    cmd = 'volume info'
+    if name is not None:
+        cmd += ' ' + name
+
     root = _gluster_xml(cmd)
+    if not _gluster_ok(root):
+        return None
 
-    volume = [x for x in _iter(root, 'volume')][0]
+    ret = {}
+    for volume in _iter(root, 'volume'):
+        name = volume.find('name').text
+        ret[name] = _etree_to_dict(volume)
 
-    ret = {name: _etree_to_dict(volume)}
+        bricks = {}
+        for i, brick in enumerate(_iter(volume, 'brick'), start=1):
+            brickkey = 'brick{0}'.format(i)
+            bricks[brickkey] = {'path': brick.text}
+            for child in brick:
+                if not child.tag == 'name':
+                    bricks[brickkey].update({child.tag: child.text})
+            for k, v in brick.items():
+                bricks[brickkey][k] = v
+        ret[name]['bricks'] = bricks
 
-    bricks = {}
-    for i, brick in enumerate(_iter(volume, 'brick'), start=1):
-        brickkey = 'brick{0}'.format(i)
-        bricks[brickkey] = {'path': brick.text}
-        for child in brick.getchildren():
-            if not child.tag == 'name':
-                bricks[brickkey].update({child.tag: child.text})
-        for k, v in brick.items():
-            bricks[brickkey][k] = v
-    ret[name]['bricks'] = bricks
-
-    options = {}
-    for option in _iter(volume, 'option'):
-        options[option.find('name').text] = option.find('value').text
-    ret[name]['options'] = options
+        options = {}
+        for option in _iter(volume, 'option'):
+            options[option.find('name').text] = option.find('value').text
+        ret[name]['options'] = options
 
     return ret
 
@@ -386,12 +413,15 @@ def start_volume(name, force=False):
         cmd = '{0} force'.format(cmd)
 
     volinfo = info(name)
+    if name not in volinfo:
+        log.error("Cannot start non-existing volume {0}".format(name))
+        return False
 
-    if not force and volinfo['status'] == '1':
-        return 'Volume already started'
+    if not force and volinfo[name]['status'] == '1':
+        log.info("Volume {0} already started".format(name))
+        return True
 
-    _gluster_xml(cmd)
-    return 'Volume {0} started'.format(name)
+    return _gluster(cmd)
 
 
 def stop_volume(name, force=False):
@@ -411,17 +441,22 @@ def stop_volume(name, force=False):
 
         salt '*' glusterfs.stop_volume mycluster
     '''
-    status(name)
+    volinfo = info()
+    if name not in volinfo:
+        log.error('Cannot stop non-existing volume {0}'.format(name))
+        return False
+    if int(volinfo[name]['status']) != 1:
+        log.warning('Attempt to stop already stopped volume {0}'.format(name))
+        return True
 
     cmd = 'volume stop {0}'.format(name)
     if force:
         cmd += ' force'
 
-    _gluster_xml(cmd)
-    return 'Volume {0} stopped'.format(name)
+    return _gluster(cmd)
 
 
-def delete(target, stop=True):
+def delete_volume(target, stop=True):
     '''
     Deletes a gluster volume
 
@@ -435,7 +470,11 @@ def delete(target, stop=True):
         raise SaltInvocationError('Volume {0} does not exist'.format(target))
 
     # Stop volume if requested to and it is running
-    running = (info(target)['status'] == '1')
+    volinfo = info()
+    if target not in volinfo:
+        log.error('Cannot delete non-existing volume {0}'.format(target))
+        return False
+    running = (volinfo[target]['status'] == '1')
 
     if not stop and running:
         # Fail if volume is running if stop is not requested
@@ -443,14 +482,11 @@ def delete(target, stop=True):
             'Volume {0} must be stopped before deletion'.format(target))
 
     if running:
-        stop_volume(target, force=True)
+        if not stop_volume(target, force=True):
+            return False
 
     cmd = 'volume delete {0}'.format(target)
-    _gluster_xml(cmd)
-    if running:
-        return 'Volume {0} stopped and deleted'.format(target)
-    else:
-        return 'Volume {0} deleted'.format(target)
+    return _gluster(cmd)
 
 
 def add_volume_bricks(name, bricks):
@@ -464,6 +500,11 @@ def add_volume_bricks(name, bricks):
         List of bricks to add to the volume
     '''
 
+    volinfo = info()
+    if name not in volinfo:
+        log.error('Volume {0} does not exist, cannot add bricks'.format(name))
+        return False
+
     new_bricks = []
 
     cmd = 'volume add-brick {0}'.format(name)
@@ -471,7 +512,7 @@ def add_volume_bricks(name, bricks):
     if isinstance(bricks, str):
         bricks = [bricks]
 
-    volume_bricks = [x['path'] for x in info(name)['bricks'].values()]
+    volume_bricks = [x['path'] for x in volinfo[name]['bricks'].values()]
 
     for brick in bricks:
         if brick in volume_bricks:
@@ -483,10 +524,5 @@ def add_volume_bricks(name, bricks):
     if len(new_bricks) > 0:
         for brick in new_bricks:
             cmd += ' {0}'.format(brick)
-
-        _gluster_xml(cmd)
-
-        return '{0} bricks successfully added to the volume {1}'.format(len(new_bricks), name)
-
-    else:
-        return 'Bricks already in volume {0}'.format(name)
+        return _gluster(cmd)
+    return True

--- a/salt/modules/glusterfs.py
+++ b/salt/modules/glusterfs.py
@@ -273,6 +273,18 @@ def create_volume(name, bricks, stripe=False, replica=False, device_vg=False,
     return True
 
 
+def create(*args, **kwargs):
+    '''
+    Deprecated version of more consistently named create_volume
+    '''
+    salt.utils.warn_until(
+        'Nitrogen',
+        'The glusterfs.create function is deprecated in favor of'
+        ' more descriptive glusterfs.create_volume.'
+    )
+    return create_volume(*args, **kwargs)
+
+
 def list_volumes():
     '''
     List configured volumes
@@ -487,6 +499,18 @@ def delete_volume(target, stop=True):
 
     cmd = 'volume delete {0}'.format(target)
     return _gluster(cmd)
+
+
+def delete(*args, **kwargs):
+    '''
+    Deprecated version of more consistently named delete_volume
+    '''
+    salt.utils.warn_until(
+        'Nitrogen',
+        'The glusterfs.delete function is deprecated in favor of'
+        ' more descriptive glusterfs.delete_volume.'
+    )
+    return delete_volume(*args, **kwargs)
 
 
 def add_volume_bricks(name, bricks):

--- a/salt/states/glusterfs.py
+++ b/salt/states/glusterfs.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-Manage glusterfs pool.
+Manage GlusterFS pool.
 '''
 
 # Import python libs
@@ -11,6 +11,7 @@ import socket
 
 # Import salt libs
 import salt.utils.cloud as suc
+import salt.utils
 
 log = logging.getLogger(__name__)
 
@@ -48,56 +49,58 @@ def peered(name):
            'comment': '',
            'result': False}
 
+    # Check if the name resolves to localhost
+    if socket.gethostbyname(name) in __salt__['network.ip_addrs']():
+        ret['result'] = True
+        ret['comment'] = 'Peering with localhost is not needed'
+        return ret
+
     peers = __salt__['glusterfs.list_peers']()
 
-    if peers:
-        if name in peers:
-            ret['result'] = True
-            ret['comment'] = 'Host {0} already peered'.format(name)
-            return ret
-        elif __opts__['test']:
-            ret['comment'] = 'Peer {0} will be added.'.format(name)
-            ret['result'] = None
-            return ret
+    if peers and name in peers:
+        ret['result'] = True
+        ret['comment'] = 'Host {0} already peered'.format(name)
+        return ret
 
     if suc.check_name(name, 'a-zA-Z0-9._-'):
         ret['comment'] = 'Invalid characters in peer name.'
         ret['result'] = False
         return ret
 
-    if 'output' in __salt__['glusterfs.peer'](name):
-        ret['comment'] = __salt__['glusterfs.peer'](name)['output']
-    else:
-        ret['comment'] = ''
+    if __opts__['test']:
+        ret['comment'] = 'Peer {0} will be added.'.format(name)
+        ret['result'] = None
+        return ret
 
+    peered = __salt__['glusterfs.peer'](name)
+    if not peered:
+        ret['comment'] = 'Failed to peer with {0}, please check logs for errors'.format(name)
+        return ret
+
+    # Double check that the action succeeded
     newpeers = __salt__['glusterfs.list_peers']()
-    #if newpeers was null, we know something didn't work.
     if newpeers and name in newpeers:
         ret['result'] = True
+        ret['comment'] = 'Host {0} successfully peered'.format(name)
         ret['changes'] = {'new': newpeers, 'old': peers}
-    #In case the hostname doesn't have any periods in it
-    elif name == socket.gethostname():
-        ret['result'] = True
-        return ret
-    #In case they have a hostname like "example.com"
-    elif name == socket.gethostname().split('.')[0]:
-        ret['result'] = True
-        return ret
-    elif 'on localhost not needed' in ret['comment']:
-        ret['result'] = True
-        ret['comment'] = 'Peering with localhost is not needed'
     else:
-        ret['result'] = False
+        ret['comment'] = 'Host {0} was successfully peered but did not appear in the list of peers'.format(name)
     return ret
 
 
-def created(name, bricks, stripe=False, replica=False, device_vg=False,
+def volume_present(name, bricks, stripe=False, replica=False, device_vg=False,
             transport='tcp', start=False, force=False):
     '''
-    Check if volume already exists
+    Ensure that the volume exists
 
     name
         name of the volume
+
+    bricks
+        list of brick paths
+
+    start
+        ensure that the volume is also started
 
     .. code-block:: yaml
 
@@ -120,51 +123,71 @@ def created(name, bricks, stripe=False, replica=False, device_vg=False,
            'changes': {},
            'comment': '',
            'result': False}
-    volumes = __salt__['glusterfs.list_volumes']()
-    if name in volumes:
-        if start:
-            if isinstance(__salt__['glusterfs.status'](name), dict):
-                ret['result'] = True
-                cmnt = 'Volume {0} already exists and is started.'.format(name)
-            else:
-                result = __salt__['glusterfs.start_volume'](name)
-                if 'started' in result:
-                    ret['result'] = True
-                    cmnt = 'Volume {0} started.'.format(name)
-                    ret['changes'] = {'new': 'started', 'old': 'stopped'}
-                else:
-                    ret['result'] = False
-                    cmnt = result
-        else:
-            ret['result'] = True
-            cmnt = 'Volume {0} already exists.'.format(name)
-        ret['comment'] = cmnt
-        return ret
-    elif __opts__['test']:
-        if start and isinstance(__salt__['glusterfs.status'](name), dict):
-            comment = 'Volume {0} will be created and started'.format(name)
-        else:
-            comment = 'Volume {0} will be created'.format(name)
-        ret['comment'] = comment
-        ret['result'] = None
-        return ret
 
     if suc.check_name(name, 'a-zA-Z0-9._-'):
         ret['comment'] = 'Invalid characters in volume name.'
-        ret['result'] = False
         return ret
 
-    ret['comment'] = __salt__['glusterfs.create'](name, bricks, stripe,
+    volumes = __salt__['glusterfs.list_volumes']()
+    if name not in volumes:
+        if __opts__['test']:
+            comment = 'Volume {0} will be created'.format(name)
+            if start:
+                comment += ' and started'
+            ret['comment'] = comment
+            ret['result'] = None
+            return ret
+
+        vol_created = __salt__['glusterfs.create_volume'](name, bricks, stripe,
                                                   replica, device_vg,
                                                   transport, start, force)
 
-    old_volumes = volumes
-    volumes = __salt__['glusterfs.list_volumes']()
-    if name in volumes:
-        ret['changes'] = {'new': volumes, 'old': old_volumes}
-        ret['result'] = True
+        if not vol_created:
+            ret['comment'] = 'Creation of volume {0} failed. Check logs for further information'.format(name)
+            return ret
+        old_volumes = volumes
+        volumes = __salt__['glusterfs.list_volumes']()
+        if name in volumes:
+            ret['changes'] = {'new': volumes, 'old': old_volumes}
+            ret['comment'] = 'Volume {0} is created'.format(name)
 
+    else:
+        ret['comment'] = 'Volume {0} already exists'.format(name)
+
+    if start:
+        if __opts__['test']:
+            # volume already exists
+            ret['comment'] = ret['comment'] + ' and will be started'
+            ret['result'] = None
+            return ret
+        if int(__salt__['glusterfs.info']()[name]['status']) == 1:
+            ret['result'] = True
+            ret['comment'] = ret['comment'] + ' and is started'
+        else:
+            vol_started = __salt__['glusterfs.start_volume'](name)
+            if vol_started:
+                ret['result'] = True
+                ret['comment'] = ret['comment'] + ' and is now started'
+                if not ret['changes']:
+                    ret['changes'] = {'new': 'started', 'old': 'stopped'}
+            else:
+                ret['comment'] = ret['comment'] + ' but failed to start. Check logs for further information'
+                return ret
+
+    ret['result'] = True
     return ret
+
+
+def created(*args, **kwargs):
+    '''
+    Deprecated version of more descriptively named volume_present
+    '''
+    salt.utils.warn_until(
+        'Nitrogen',
+        'The glusterfs.creaged state is deprecated in favor of more descriptive'
+        ' glusterfs.volume_present.'
+    )
+    return volume_present(*args, **kwargs)
 
 
 def started(name):
@@ -183,13 +206,14 @@ def started(name):
            'changes': {},
            'comment': '',
            'result': False}
-    volumes = __salt__['glusterfs.list_volumes']()
-    if name not in volumes:
+
+    volinfo = __salt__['glusterfs.info']()
+    if name not in volinfo:
         ret['result'] = False
         ret['comment'] = 'Volume {0} does not exist'.format(name)
         return ret
 
-    if isinstance(__salt__['glusterfs.status'](name), dict):
+    if int(volinfo[name]['status']) == 1:
         ret['comment'] = 'Volume {0} is already started'.format(name)
         ret['result'] = True
         return ret
@@ -198,12 +222,14 @@ def started(name):
         ret['result'] = None
         return ret
 
-    ret['comment'] = __salt__['glusterfs.start_volume'](name)
-    if 'started' in ret['comment']:
+    vol_started = __salt__['glusterfs.start_volume'](name)
+    if vol_started:
         ret['result'] = True
+        ret['comment'] = 'Volume {0} is started'.format(name)
         ret['change'] = {'new': 'started', 'old': 'stopped'}
     else:
         ret['result'] = False
+        ret['comment'] = 'Failed to start volume'.format(name)
 
     return ret
 
@@ -238,30 +264,28 @@ def add_volume_bricks(name, bricks):
        'comment': '',
        'result': False}
 
-    current_bricks = __salt__['glusterfs.status'](name)
-
-    if 'does not exist' in current_bricks:
-        ret['result'] = False
-        ret['comment'] = current_bricks
+    volinfo = __salt__['glusterfs.info']()
+    if name not in volinfo:
+        ret['comment'] = 'Volume {0} does not exist, cannot add bricks into it'.format(name)
         return ret
 
-    if 'is not started' in current_bricks:
-        ret['result'] = False
-        ret['comment'] = current_bricks
+    if int(volinfo[name]['status']) != 1:
+        ret['comment'] = 'Volume {0} is not started, cannot add bricks into it'.format(name)
         return ret
 
-    add_bricks = __salt__['glusterfs.add_volume_bricks'](name, bricks)
-    ret['comment'] = add_bricks
-
-    if 'bricks successfully added' in add_bricks:
-        old_bricks = current_bricks
-        new_bricks = __salt__['glusterfs.status'](name)
+    current_bricks = [brick['path'] for brick in volinfo[name]['bricks'].values()]
+    if not (set(bricks) - set(current_bricks)):
         ret['result'] = True
-        ret['changes'] = {'new': list(new_bricks['bricks'].keys()), 'old': list(old_bricks['bricks'].keys())}
+        ret['comment'] = 'Bricks already added in volume {0}'.format(name)
         return ret
 
-    if 'Bricks already in volume' in add_bricks:
+    bricks_added = __salt__['glusterfs.add_volume_bricks'](name, bricks)
+    if bricks_added:
         ret['result'] = True
+        ret['comment'] = 'Bricks successfully added to volume {0}'.format(name)
+        new_bricks = [brick['path'] for brick in __salt__['glusterfs.info']()[name]['bricks'].values()]
+        ret['changes'] = {'new': new_bricks, 'old': current_bricks}
         return ret
 
+    ret['comment'] = 'Adding bricks to volume {0} failed'.format(name)
     return ret

--- a/salt/states/glusterfs.py
+++ b/salt/states/glusterfs.py
@@ -232,7 +232,7 @@ def started(name):
         ret['change'] = {'new': 'started', 'old': 'stopped'}
     else:
         ret['result'] = False
-        ret['comment'] = 'Failed to start volume'.format(name)
+        ret['comment'] = 'Failed to start volume {0}'.format(name)
 
     return ret
 
@@ -277,7 +277,7 @@ def add_volume_bricks(name, bricks):
         return ret
 
     current_bricks = [brick['path'] for brick in volinfo[name]['bricks'].values()]
-    if not (set(bricks) - set(current_bricks)):
+    if not set(bricks) - set(current_bricks):
         ret['result'] = True
         ret['comment'] = 'Bricks already added in volume {0}'.format(name)
         return ret

--- a/tests/unit/modules/glusterfs_test.py
+++ b/tests/unit/modules/glusterfs_test.py
@@ -19,7 +19,7 @@ from salttesting.mock import (
 # Import Salt Libs
 from salt.modules import glusterfs
 import salt.utils.cloud as suc
-from salt.exceptions import CommandExecutionError, SaltInvocationError
+from salt.exceptions import SaltInvocationError
 
 # Globals
 glusterfs.__salt__ = {}
@@ -277,18 +277,18 @@ class GlusterfsTestCase(TestCase):
             mock_start_volume = MagicMock(return_value=True)
             with patch.object(glusterfs, 'start_volume', mock_start_volume):
                 # Create, do not start
-                self.assertTrue(glusterfs.create_volume('newvolume', 
+                self.assertTrue(glusterfs.create_volume('newvolume',
                                                         'host1:/brick'))
                 self.assertFalse(mock_start_volume.called)
                 # Create and start
-                self.assertTrue(glusterfs.create_volume('newvolume', 
+                self.assertTrue(glusterfs.create_volume('newvolume',
                                                         'host1:/brick',
                                                         start=True))
                 self.assertTrue(mock_start_volume.called)
             mock_start_volume = MagicMock(return_value=False)
             with patch.object(glusterfs, 'start_volume', mock_start_volume):
                 # Create and fail start
-                self.assertFalse(glusterfs.create_volume('newvolume', 
+                self.assertFalse(glusterfs.create_volume('newvolume',
                                                          'host1:/brick',
                                                          start=True))
 
@@ -484,8 +484,8 @@ class GlusterfsTestCase(TestCase):
             'Newvolume1': {
                 'status': '1',
                 'bricks': {
-                    'brick1' : {'path': 'host:/path1'},
-                    'brick2' : {'path': 'host:/path2'}
+                    'brick1': {'path': 'host:/path1'},
+                    'brick2': {'path': 'host:/path2'}
                 }
             }
         })

--- a/tests/unit/modules/glusterfs_test.py
+++ b/tests/unit/modules/glusterfs_test.py
@@ -157,7 +157,7 @@ xml_peer_probe_success = """
 </cliOutput>
 """
 
-xml_peer_probe_fail_already_member = """
+xml_peer_probe_already_member = """
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <cliOutput>
   <opRet>0</opRet>
@@ -167,7 +167,7 @@ xml_peer_probe_fail_already_member = """
 </cliOutput>
 """
 
-xml_peer_probe_fail_localhost = """
+xml_peer_probe_localhost = """
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <cliOutput>
   <opRet>0</opRet>
@@ -221,7 +221,7 @@ class GlusterfsTestCase(TestCase):
 
         mock = MagicMock(return_value=xml_command_success)
         with patch.dict(glusterfs.__salt__, {'cmd.run': mock}):
-            self.assertIsNone(glusterfs.list_peers())
+            self.assertListEqual(glusterfs.list_peers(), [])
 
     # 'peer' function tests: 1
 
@@ -233,57 +233,64 @@ class GlusterfsTestCase(TestCase):
         # Peers can be added successfully, already present, be the localhost, or not be connected.
         mock = MagicMock(return_value=xml_peer_probe_success)
         with patch.dict(glusterfs.__salt__, {'cmd.run': mock}):
-            self.assertEqual(glusterfs.peer('salt'),
-                             {'exitval': '0', 'output': None})
+            self.assertEqual(glusterfs.peer('salt'), True)
 
-        mock = MagicMock(return_value=xml_peer_probe_fail_already_member)
+        mock = MagicMock(return_value=xml_peer_probe_already_member)
         with patch.dict(glusterfs.__salt__, {'cmd.run': mock}):
-            self.assertEqual(glusterfs.peer('salt'),
-                             {'exitval': '0', 'output': 'Host salt port 24007 already in peer list'})
+            self.assertEqual(glusterfs.peer('salt'), True)
 
-        mock = MagicMock(return_value=xml_peer_probe_fail_localhost)
+        mock = MagicMock(return_value=xml_peer_probe_localhost)
         with patch.dict(glusterfs.__salt__, {'cmd.run': mock}):
-            self.assertEqual(glusterfs.peer('salt'),
-                             {'exitval': '0', 'output': 'Probe on localhost not needed'})
+            self.assertEqual(glusterfs.peer('salt'), True)
 
         mock = MagicMock(return_value=xml_peer_probe_fail_cant_connect)
         with patch.dict(glusterfs.__salt__, {'cmd.run': mock}):
-            self.assertRaises(CommandExecutionError, glusterfs.peer, 'salt')
+            self.assertEqual(glusterfs.peer('salt'), False)
 
         mock = MagicMock(return_value=True)
         with patch.object(suc, 'check_name', mock):
             self.assertRaises(SaltInvocationError, glusterfs.peer, 'a')
 
-    # 'create' function tests: 1
+    # 'create_volume' function tests: 1
 
-    def test_create(self):
+    def test_create_volume(self):
         '''
-        Test if it create a glusterfs volume.
+        Test if it creates a glusterfs volume.
         '''
-        mock = MagicMock(return_value='')
-        with patch.dict(glusterfs.__salt__, {'cmd.run': mock}):
+        mock_run = MagicMock(return_value='')
+        with patch.dict(glusterfs.__salt__, {'cmd.run': mock_run}):
             self.assertRaises(
-                SaltInvocationError, glusterfs.create, 'newvolume', 'host1:brick')
+                SaltInvocationError, glusterfs.create_volume, 'newvolume', 'host1:brick')
 
-        mock = MagicMock(return_value='')
-        with patch.dict(glusterfs.__salt__, {'cmd.run': mock}):
+        mock_run = MagicMock(return_value='')
+        with patch.dict(glusterfs.__salt__, {'cmd.run': mock_run}):
             self.assertRaises(
-                SaltInvocationError, glusterfs.create, 'newvolume', 'host1/brick')
+                SaltInvocationError, glusterfs.create_volume, 'newvolume', 'host1/brick')
 
-        mock = MagicMock(return_value=xml_command_fail)
-        with patch.dict(glusterfs.__salt__, {'cmd.run': mock}):
-            self.assertRaises(CommandExecutionError, glusterfs.create, 'newvolume', 'host1:/brick',
-                              True, True, True, 'tcp', True)
+        mock_run = MagicMock(return_value=xml_command_fail)
+        with patch.dict(glusterfs.__salt__, {'cmd.run': mock_run}):
+            self.assertFalse(glusterfs.create_volume('newvolume', 'host1:/brick',
+                              True, True, True, 'tcp', True))
 
-        mock = MagicMock(return_value=xml_command_success)
-        with patch.dict(glusterfs.__salt__, {'cmd.run': mock}):
-            self.assertEqual(glusterfs.create('newvolume', 'host1:/brick',
-                                              True, True, True, 'tcp', True),
-                             'Volume newvolume created and started')
-
-        with patch.dict(glusterfs.__salt__, {'cmd.run': mock}):
-            self.assertEqual(glusterfs.create('newvolume', 'host1:/brick'),
-                             'Volume newvolume created. Start volume to use')
+        mock_run = MagicMock(return_value=xml_command_success)
+        with patch.dict(glusterfs.__salt__, {'cmd.run': mock_run}):
+            mock_start_volume = MagicMock(return_value=True)
+            with patch.object(glusterfs, 'start_volume', mock_start_volume):
+                # Create, do not start
+                self.assertTrue(glusterfs.create_volume('newvolume', 
+                                                        'host1:/brick'))
+                self.assertFalse(mock_start_volume.called)
+                # Create and start
+                self.assertTrue(glusterfs.create_volume('newvolume', 
+                                                        'host1:/brick',
+                                                        start=True))
+                self.assertTrue(mock_start_volume.called)
+            mock_start_volume = MagicMock(return_value=False)
+            with patch.object(glusterfs, 'start_volume', mock_start_volume):
+                # Create and fail start
+                self.assertFalse(glusterfs.create_volume('newvolume', 
+                                                         'host1:/brick',
+                                                         start=True))
 
     # 'list_volumes' function tests: 1
 
@@ -306,10 +313,9 @@ class GlusterfsTestCase(TestCase):
         '''
         Test if it check the status of a gluster volume.
         '''
-        mock = MagicMock(return_value=xml_command_fail)
-        with patch.dict(glusterfs.__salt__, {'cmd.run': mock}):
-            self.assertRaises(
-                CommandExecutionError, glusterfs.status, 'myvol1')
+        mock_run = MagicMock(return_value=xml_command_fail)
+        with patch.dict(glusterfs.__salt__, {'cmd.run': mock_run}):
+            self.assertIsNone(glusterfs.status('myvol1'))
 
         res = {'bricks': {
             'node01:/tmp/foo': {
@@ -378,26 +384,35 @@ class GlusterfsTestCase(TestCase):
         '''
         Test if it start a gluster volume.
         '''
-        mock_list = MagicMock(return_value=['Newvolume1', 'Newvolume2'])
-        with patch.object(glusterfs, 'list_volumes', mock_list):
-            mock_status = MagicMock(return_value={'status': '1'})
-            with patch.object(glusterfs, 'info', mock_status):
-                mock = MagicMock(return_value=xml_command_success)
-                with patch.dict(glusterfs.__salt__, {'cmd.run': mock}):
-                    self.assertEqual(glusterfs.start_volume('Newvolume1'),
-                                     'Volume already started')
+        # Stopped volume
+        mock_info = MagicMock(return_value={'Newvolume1': {'status': '0'}})
+        with patch.object(glusterfs, 'info', mock_info):
+            mock_run = MagicMock(return_value=xml_command_success)
+            with patch.dict(glusterfs.__salt__, {'cmd.run': mock_run}):
+                self.assertEqual(glusterfs.start_volume('Newvolume1'), True)
+                self.assertEqual(glusterfs.start_volume('nonExisting'), False)
+            mock_run = MagicMock(return_value=xml_command_fail)
+            with patch.dict(glusterfs.__salt__, {'cmd.run': mock_run}):
+                self.assertEqual(glusterfs.start_volume('Newvolume1'), False)
 
-            mock_status = MagicMock(return_value={'status': '0'})
-            with patch.object(glusterfs, 'info', mock_status):
-                mock_run = MagicMock(return_value=xml_command_success)
-                with patch.dict(glusterfs.__salt__, {'cmd.run': mock_run}):
-                    self.assertEqual(glusterfs.start_volume('Newvolume1'),
-                                     'Volume Newvolume1 started')
-
-        mock = MagicMock(return_value=xml_command_fail)
-        with patch.dict(glusterfs.__salt__, {'cmd.run': mock}):
-            self.assertRaises(
-                CommandExecutionError, glusterfs.start_volume, 'Newvolume1')
+        # Started volume
+        mock_info = MagicMock(return_value={'Newvolume1': {'status': '1'}})
+        with patch.object(glusterfs, 'info', mock_info):
+            mock_run = MagicMock(return_value=xml_command_success)
+            with patch.dict(glusterfs.__salt__, {'cmd.run': mock_run}):
+                self.assertEqual(
+                    glusterfs.start_volume('Newvolume1', force=True),
+                    True
+                )
+            mock_run = MagicMock(return_value=xml_command_fail)
+            with patch.dict(glusterfs.__salt__, {'cmd.run': mock_run}):
+                # cmd.run should not be called for already running volume:
+                self.assertEqual(glusterfs.start_volume('Newvolume1'), True)
+                # except when forcing:
+                self.assertEqual(
+                    glusterfs.start_volume('Newvolume1', force=True),
+                    False
+                )
 
     # 'stop_volume' function tests: 1
 
@@ -405,55 +420,59 @@ class GlusterfsTestCase(TestCase):
         '''
         Test if it stop a gluster volume.
         '''
-        mock = MagicMock(return_value={})
-        with patch.object(glusterfs, 'status', mock):
-            mock = MagicMock(return_value=xml_command_success)
-            with patch.dict(glusterfs.__salt__, {'cmd.run': mock}):
-                self.assertEqual(glusterfs.stop_volume('Newvolume1'),
-                                 'Volume Newvolume1 stopped')
+        # Stopped volume
+        mock_info = MagicMock(return_value={'Newvolume1': {'status': '0'}})
+        with patch.object(glusterfs, 'info', mock_info):
+            mock_run = MagicMock(return_value=xml_command_success)
+            with patch.dict(glusterfs.__salt__, {'cmd.run': mock_run}):
+                self.assertEqual(glusterfs.stop_volume('Newvolume1'), True)
+                self.assertEqual(glusterfs.stop_volume('nonExisting'), False)
+            mock_run = MagicMock(return_value=xml_command_fail)
+            with patch.dict(glusterfs.__salt__, {'cmd.run': mock_run}):
+                # cmd.run should not be called for already stopped volume:
+                self.assertEqual(glusterfs.stop_volume('Newvolume1'), True)
 
-            mock = MagicMock(return_value=xml_command_fail)
-            with patch.dict(glusterfs.__salt__, {'cmd.run': mock}):
-                self.assertRaises(
-                    CommandExecutionError, glusterfs.stop_volume, 'Newvolume1')
+        # Started volume
+        mock_info = MagicMock(return_value={'Newvolume1': {'status': '1'}})
+        with patch.object(glusterfs, 'info', mock_info):
+            mock_run = MagicMock(return_value=xml_command_success)
+            with patch.dict(glusterfs.__salt__, {'cmd.run': mock_run}):
+                self.assertEqual(glusterfs.stop_volume('Newvolume1'), True)
+                self.assertEqual(glusterfs.stop_volume('nonExisting'), False)
+            mock_run = MagicMock(return_value=xml_command_fail)
+            with patch.dict(glusterfs.__salt__, {'cmd.run': mock_run}):
+                self.assertEqual(glusterfs.stop_volume('Newvolume1'), False)
 
-        mock = MagicMock(return_value=xml_command_fail)
-        with patch.dict(glusterfs.__salt__, {'cmd.run': mock}):
-            self.assertRaises(
-                CommandExecutionError, glusterfs.stop_volume, 'Newvolume1')
+    # 'delete_volume' function tests: 1
 
-    # 'delete' function tests: 1
-
-    def test_delete(self):
+    def test_delete_volume(self):
         '''
         Test if it deletes a gluster volume.
         '''
-        mock = MagicMock(return_value=['Newvolume1', 'Newvolume2'])
-        with patch.object(glusterfs, 'list_volumes', mock):
+        mock_info = MagicMock(return_value={'Newvolume1': {'status': '1'}})
+        with patch.object(glusterfs, 'info', mock_info):
             # volume doesn't exist
-            self.assertRaises(
-                SaltInvocationError, glusterfs.delete, 'Newvolume3')
+            self.assertFalse(glusterfs.delete_volume('Newvolume3'))
 
-            mock = MagicMock(return_value={'status': '1'})
-            with patch.object(glusterfs, 'info', mock):
-                mock = MagicMock(return_value=xml_command_success)
-                # volume exists, should not be stopped, and is started
-                with patch.dict(glusterfs.__salt__, {'cmd.run': mock}):
-                    self.assertRaises(
-                        SaltInvocationError, glusterfs.delete, 'Newvolume1', False)
+            mock_stop_volume = MagicMock(return_value=True)
+            mock_run = MagicMock(return_value=xml_command_success)
+            with patch.dict(glusterfs.__salt__, {'cmd.run': mock_run}):
+                with patch.object(glusterfs, 'stop_volume', mock_stop_volume):
+                    # volume exists, should not be stopped, and is started
+                    self.assertFalse(glusterfs.delete_volume('Newvolume1',
+                                                             False))
+                    self.assertFalse(mock_stop_volume.called)
 
-                # volume exists, should be stopped, and is started
-                with patch.dict(glusterfs.__salt__, {'cmd.run': mock}):
-                    self.assertEqual(glusterfs.delete('Newvolume1'),
-                                     'Volume Newvolume1 stopped and deleted')
+                    # volume exists, should be stopped, and is started
+                    self.assertTrue(glusterfs.delete_volume('Newvolume1'))
+                    self.assertTrue(mock_stop_volume.called)
 
-            # volume exists and isn't started
-            mock = MagicMock(return_value={'status': '0'})
-            with patch.object(glusterfs, 'info', mock):
-                mock = MagicMock(return_value=xml_command_success)
-                with patch.dict(glusterfs.__salt__, {'cmd.run': mock}):
-                    self.assertEqual(glusterfs.delete('Newvolume1'),
-                                     'Volume Newvolume1 deleted')
+        # volume exists and isn't started
+        mock_info = MagicMock(return_value={'Newvolume1': {'status': '2'}})
+        with patch.object(glusterfs, 'info', mock_info):
+            mock_run = MagicMock(return_value=xml_command_success)
+            with patch.dict(glusterfs.__salt__, {'cmd.run': mock_run}):
+                self.assertTrue(glusterfs.delete_volume('Newvolume1'))
 
     # 'add_volume_bricks' function tests: 1
 
@@ -461,36 +480,36 @@ class GlusterfsTestCase(TestCase):
         '''
         Test if it add brick(s) to an existing volume
         '''
-        # volume does not exist
-        mock = MagicMock(return_value=xml_command_fail)
-        with patch.dict(glusterfs.__salt__, {'cmd.run': mock}):
-            self.assertRaises(
-                CommandExecutionError, glusterfs.add_volume_bricks, 'Newvolume1', ['bricks'])
-
-        ret = '1 bricks successfully added to the volume Newvolume1'
-        # volume does exist
-        mock = MagicMock(return_value={'bricks': {}})
-        with patch.object(glusterfs, 'info', mock):
-            mock = MagicMock(return_value=xml_command_success)
-            # ... and the added brick does not exist
-            with patch.dict(glusterfs.__salt__, {'cmd.run': mock}):
-                self.assertEqual(glusterfs.add_volume_bricks('Newvolume1',
-                                                             ['bricks']), ret)
-
-        mock = MagicMock(
-            return_value={'bricks': {'brick1': {'path': 'bricks'}}})
-        with patch.object(glusterfs, 'info', mock):
-            # ... and the added brick does exist
-            with patch.dict(glusterfs.__salt__, {'cmd.run': mock}):
-                # As a list
-                self.assertEqual(glusterfs.add_volume_bricks('Newvolume1', ['bricks']),
-                                 'Bricks already in volume Newvolume1')
-                # As a string
-                self.assertEqual(glusterfs.add_volume_bricks('Newvolume1', 'bricks'),
-                                 'Bricks already in volume Newvolume1')
-                # And empty list
-                self.assertEqual(glusterfs.add_volume_bricks('Newvolume1', []),
-                                 'Bricks already in volume Newvolume1')
+        mock_info = MagicMock(return_value={
+            'Newvolume1': {
+                'status': '1',
+                'bricks': {
+                    'brick1' : {'path': 'host:/path1'},
+                    'brick2' : {'path': 'host:/path2'}
+                }
+            }
+        })
+        with patch.object(glusterfs, 'info', mock_info):
+            mock_run = MagicMock(return_value=xml_command_success)
+            with patch.dict(glusterfs.__salt__, {'cmd.run': mock_run}):
+                # Volume does not exist
+                self.assertFalse(glusterfs.add_volume_bricks('nonExisting',
+                                                             ['bricks']))
+                # Brick already exists
+                self.assertTrue(glusterfs.add_volume_bricks('Newvolume1',
+                                                       ['host:/path2']))
+                # Already existing brick as a string
+                self.assertTrue(glusterfs.add_volume_bricks('Newvolume1',
+                                                            'host:/path2'))
+                self.assertFalse(mock_run.called)
+                # A new brick:
+                self.assertTrue(glusterfs.add_volume_bricks('Newvolume1',
+                                                            ['host:/new1']))
+                self.assertTrue(mock_run.called)
+            mock_run = MagicMock(return_value=xml_command_fail)
+            with patch.dict(glusterfs.__salt__, {'cmd.run': mock_run}):
+                self.assertFalse(glusterfs.add_volume_bricks('Newvolume1',
+                                                             ['new/path']))
 
 
 if __name__ == '__main__':

--- a/tests/unit/states/glusterfs_test.py
+++ b/tests/unit/states/glusterfs_test.py
@@ -44,80 +44,153 @@ class GlusterfsTestCase(TestCase):
                'comment': '',
                'changes': {}}
 
-        mock = MagicMock(side_effect=[[name], [''], [], [], [], [], [], [],
-                                      [name]])
-        mock_lst = MagicMock(return_value=[])
-        with patch.dict(glusterfs.__salt__, {'glusterfs.list_peers': mock,
-                                             'glusterfs.peer': mock_lst}):
-            comt = ('Host {0} already peered'.format(name))
-            ret.update({'comment': comt})
-            self.assertDictEqual(glusterfs.peered(name), ret)
+        mock_ip = MagicMock(return_value=['1.2.3.4', '1.2.3.5'])
+        mock_hostbyname = MagicMock(return_value='1.2.3.5')
+        mock_peer = MagicMock(return_value=True)
+        mock_list = MagicMock(return_value=[name])
 
-            with patch.dict(glusterfs.__opts__, {'test': True}):
-                comt = ('Peer {0} will be added.'.format(name))
-                ret.update({'comment': comt, 'result': None})
+        with patch.dict(glusterfs.__salt__, {'glusterfs.list_peers': mock_list,
+                                             'glusterfs.peer': mock_peer,
+                                             'network.ip_addrs': mock_ip}):
+            with patch.object(socket, 'gethostbyname', mock_hostbyname):
+                comt = ('Peering with localhost is not needed'.format(name))
+                ret.update({'comment': comt})
                 self.assertDictEqual(glusterfs.peered(name), ret)
 
-            with patch.object(salt.utils.cloud, 'check_name',
-                              MagicMock(return_value=True)):
-                comt = ('Invalid characters in peer name.')
-                ret.update({'comment': comt, 'result': False})
-                self.assertDictEqual(glusterfs.peered(name), ret)
-
-            with patch.object(socket, 'gethostname',
-                              MagicMock(side_effect=[name, 'salt.host',
-                                                     'salt.host'])):
-                ret.update({'comment': '', 'result': True})
-                self.assertDictEqual(glusterfs.peered(name), ret)
-
+                mock_hostbyname.return_value = '1.2.3.42'
                 comt = ('Host {0} already peered'.format(name))
-                ret.update({'comment': '', 'result': True})
+                ret.update({'comment': comt})
                 self.assertDictEqual(glusterfs.peered(name), ret)
 
-            comt = ('Host {0} already peered'.format(name))
-            ret.update({'comment': '', 'result': True,
-                        'changes': {'new': ['salt'], 'old': []}})
-            self.assertDictEqual(glusterfs.peered(name), ret)
+                with patch.dict(glusterfs.__opts__, {'test': False}):
+                    mock_list.side_effect = [['other'], ['other', name]]
+                    comt = 'Host salt successfully peered'.format(name)
+                    ret.update({'comment': comt,
+                                'changes': {'old': ['other'],
+                                            'new': ['other', name]}})
+                    self.assertDictEqual(glusterfs.peered(name), ret)
+                    mock_list.side_effect = None
 
-    # 'created' function tests: 1
+                    mock_list.return_value = ['other']
+                    mock_peer.return_value = False
 
-    def test_created(self):
+                    ret.update({'result': False})
+
+                    comt = ('Failed to peer with salt,'
+                            + ' please check logs for errors').format(name)
+                    ret.update({'comment': comt, 'changes':{}})
+                    self.assertDictEqual(glusterfs.peered(name), ret)
+
+                with patch.object(salt.utils.cloud, 'check_name',
+                                  MagicMock(return_value=True)):
+                    comt = ('Invalid characters in peer name.')
+                    ret.update({'comment': comt})
+                    self.assertDictEqual(glusterfs.peered(name), ret)
+
+                with patch.dict(glusterfs.__opts__, {'test': True}):
+                    comt = ('Peer {0} will be added.'.format(name))
+                    ret.update({'comment': comt, 'result': None})
+                    self.assertDictEqual(glusterfs.peered(name), ret)
+
+
+
+    # 'volume_present' function tests: 1
+
+    def test_volume_present(self):
         '''
-        Test to check if volume already exists
+        Test to ensure that a volume exists
         '''
         name = 'salt'
-        bricks = {'host1': '/srv/gluster/drive1',
-                  'host2': '/srv/gluster/drive2'}
-
+        bricks = ['host1:/brick1']
         ret = {'name': name,
                'result': True,
                'comment': '',
                'changes': {}}
 
-        mock = MagicMock(side_effect=[[name], [], [], [], [name]])
-        mock_lst = MagicMock(return_value=[])
-        with patch.dict(glusterfs.__salt__, {'glusterfs.list_volumes': mock,
-                                             'glusterfs.create': mock_lst}):
-            comt = ('Volume {0} already exists.'.format(name))
-            ret.update({'comment': comt})
-            self.assertDictEqual(glusterfs.created(name, bricks), ret)
+        started_info = {name: {'status': '1'}}
+        stopped_info = {name: {'status': '0'}}
 
+        mock_info = MagicMock()
+        mock_list = MagicMock()
+        mock_create = MagicMock()
+        mock_start = MagicMock(return_value=True)
+
+        with patch.dict(glusterfs.__salt__, {
+                        'glusterfs.info': mock_info,
+                        'glusterfs.list_volumes': mock_list,
+                        'glusterfs.create_volume': mock_create,
+                        'glusterfs.start_volume': mock_start}):
+            with patch.dict(glusterfs.__opts__, {'test': False}):
+                mock_list.return_value = [name]
+                mock_info.return_value = started_info
+                comt = ('Volume {0} already exists and is started'.format(name))
+                ret.update({'comment': comt})
+                self.assertDictEqual(glusterfs.created(name, bricks, 
+                                                       start=True), ret)
+
+                mock_info.return_value = stopped_info
+                comt = ('Volume {0} already exists and is now started'.format(name))
+                ret.update({'comment': comt,
+                            'changes': {'old':'stopped', 'new':'started'}})
+                self.assertDictEqual(glusterfs.created(name, bricks, 
+                                                       start=True), ret)
+
+                comt = ('Volume {0} already exists'.format(name))
+                ret.update({'comment': comt, 'changes':{}})
+                self.assertDictEqual(glusterfs.created(name, bricks, 
+                                                       start=False), ret)
             with patch.dict(glusterfs.__opts__, {'test': True}):
+                comt = ('Volume {0} already exists'.format(name))
+                ret.update({'comment': comt, 'result': None})
+                self.assertDictEqual(glusterfs.created(name, bricks, 
+                                                       start=False), ret)
+
+                comt = ('Volume {0} already exists'
+                        + ' and will be started').format(name)
+                ret.update({'comment': comt, 'result': None})
+                self.assertDictEqual(glusterfs.created(name, bricks, 
+                                                       start=True), ret)
+
+                mock_list.return_value = []
                 comt = ('Volume {0} will be created'.format(name))
                 ret.update({'comment': comt, 'result': None})
-                self.assertDictEqual(glusterfs.created(name, bricks), ret)
+                self.assertDictEqual(glusterfs.created(name, bricks, 
+                                                       start=False), ret)
+
+                comt = ('Volume {0} will be created'
+                        + ' and started').format(name)
+                ret.update({'comment': comt, 'result': None})
+                self.assertDictEqual(glusterfs.created(name, bricks, 
+                                                       start=True), ret)
 
             with patch.dict(glusterfs.__opts__, {'test': False}):
-                with patch.object(salt.utils.cloud, 'check_name',
-                                  MagicMock(return_value=True)):
-                    comt = ('Invalid characters in volume name.')
-                    ret.update({'comment': comt, 'result': False})
-                    self.assertDictEqual(glusterfs.created(name, bricks), ret)
+                mock_list.side_effect = [[], [name]]
+                comt = ('Volume {0} is created'.format(name))
+                ret.update({'comment': comt,
+                            'result': True,
+                            'changes': {'old':[], 'new':[name]}})
+                self.assertDictEqual(glusterfs.created(name, bricks, 
+                                                       start=False), ret)
 
-                comt = ('Host {0} already peered'.format(name))
-                ret.update({'comment': [], 'result': True,
-                            'changes': {'new': ['salt'], 'old': []}})
+                mock_list.side_effect = [[], [name]]
+                comt = ('Volume {0} is created and is now started'.format(name))
+                ret.update({'comment': comt, 'result': True})
+                self.assertDictEqual(glusterfs.created(name, bricks, 
+                                                       start=True), ret)
+
+                mock_list.side_effect = None
+                mock_list.return_value = []
+                mock_create.return_value = False
+                comt = 'Creation of volume {0} failed'.format(name)
+                ret.update({'comment': comt, 'result': False, 'changes':{}})
                 self.assertDictEqual(glusterfs.created(name, bricks), ret)
+
+            with patch.object(salt.utils.cloud, 'check_name',
+                              MagicMock(return_value=True)):
+                comt = ('Invalid characters in volume name.')
+                ret.update({'comment': comt, 'result': False})
+                self.assertDictEqual(glusterfs.created(name, bricks), ret)
+
 
     # 'started' function tests: 1
 
@@ -132,27 +205,32 @@ class GlusterfsTestCase(TestCase):
                'comment': '',
                'changes': {}}
 
-        mock = MagicMock(side_effect=[[], [name], [name], [name]])
-        mock_t = MagicMock(return_value='started')
-        mock_dict = MagicMock(side_effect=[{}, '', ''])
-        with patch.dict(glusterfs.__salt__, {'glusterfs.list_volumes': mock,
-                                             'glusterfs.status': mock_dict,
-                                             'glusterfs.start_volume': mock_t}):
+        started_info = {name: {'status': '1'}}
+        stopped_info = {name: {'status': '0'}}
+        mock_info = MagicMock(return_value={})
+        mock_start = MagicMock(return_value=True)
+
+        with patch.dict(glusterfs.__salt__,
+                        {'glusterfs.info': mock_info,
+                         'glusterfs.start_volume': mock_start}):
             comt = ('Volume {0} does not exist'.format(name))
             ret.update({'comment': comt})
             self.assertDictEqual(glusterfs.started(name), ret)
 
+            mock_info.return_value = started_info
             comt = ('Volume {0} is already started'.format(name))
             ret.update({'comment': comt, 'result': True})
             self.assertDictEqual(glusterfs.started(name), ret)
 
             with patch.dict(glusterfs.__opts__, {'test': True}):
+                mock_info.return_value = stopped_info
                 comt = ('Volume {0} will be started'.format(name))
                 ret.update({'comment': comt, 'result': None})
                 self.assertDictEqual(glusterfs.started(name), ret)
 
             with patch.dict(glusterfs.__opts__, {'test': False}):
-                ret.update({'comment': 'started', 'result': True,
+                comt = 'Volume {0} is started'.format(name)
+                ret.update({'comment': comt, 'result': True,
                             'change': {'new': 'started', 'old': 'stopped'}})
                 self.assertDictEqual(glusterfs.started(name), ret)
 
@@ -163,34 +241,57 @@ class GlusterfsTestCase(TestCase):
         Test to add brick(s) to an existing volume
         '''
         name = 'salt'
-        bricks = {'bricks': {'host1': '/srv/gluster/drive1'}}
+        bricks = ['host1:/drive1']
+        old_bricks = ['host1:/drive2']
 
         ret = {'name': name,
                'result': False,
                'comment': '',
                'changes': {}}
 
-        mock = MagicMock(side_effect=['does not exist', 'is not started',
-                                      bricks, bricks, bricks, ''])
-        mock_t = MagicMock(side_effect=['bricks successfully added',
-                                        'Bricks already in volume', ''])
+        stopped_volinfo = {'salt': {'status': '0'}}
+        volinfo = {
+            'salt': {
+                'status': '1',
+                'bricks': {'brick1': {'path': old_bricks[0]}}
+            }
+        }
+        new_volinfo = {
+            'salt': {
+                'status': '1',
+                'bricks': {
+                    'brick1': {'path': old_bricks[0]},
+                    'brick2': {'path': bricks[0]}
+                }
+            }
+        }
+
+        mock_info = MagicMock(return_value={})
+        mock_add = MagicMock(side_effect=[False, True])
+
         with patch.dict(glusterfs.__salt__,
-                        {'glusterfs.status': mock,
-                         'glusterfs.add_volume_bricks': mock_t}):
-            ret.update({'comment': 'does not exist'})
+                        {'glusterfs.info': mock_info,
+                        'glusterfs.add_volume_bricks': mock_add}):
+            ret.update({'comment': 'Volume salt does not exist'})
             self.assertDictEqual(glusterfs.add_volume_bricks(name, bricks), ret)
 
-            ret.update({'comment': 'is not started'})
+            mock_info.return_value = stopped_volinfo
+            ret.update({'comment': 'Volume salt is not started'})
             self.assertDictEqual(glusterfs.add_volume_bricks(name, bricks), ret)
 
-            ret.update({'comment': 'bricks successfully added', 'result': True,
-                        'changes': {'new': ['host1'], 'old': ['host1']}})
+            mock_info.return_value = volinfo
+            ret.update({'comment': 'Adding bricks to volume salt failed'})
             self.assertDictEqual(glusterfs.add_volume_bricks(name, bricks), ret)
 
-            ret.update({'comment': 'Bricks already in volume', 'changes': {}})
-            self.assertDictEqual(glusterfs.add_volume_bricks(name, bricks), ret)
+            ret.update({'result': True})
+            ret.update({'comment': 'Bricks already added in volume salt'})
+            self.assertDictEqual(glusterfs.add_volume_bricks(name, old_bricks), 
+                                                             ret)
 
-            ret.update({'comment': '', 'result': False})
+            mock_info.side_effect = [volinfo, new_volinfo]
+            ret.update({'comment': 'Bricks successfully added to volume salt',
+                        'changes': {'new': bricks + old_bricks,
+                                    'old': old_bricks}})
             self.assertDictEqual(glusterfs.add_volume_bricks(name, bricks), ret)
 
 

--- a/tests/unit/states/glusterfs_test.py
+++ b/tests/unit/states/glusterfs_test.py
@@ -53,7 +53,7 @@ class GlusterfsTestCase(TestCase):
                                              'glusterfs.peer': mock_peer,
                                              'network.ip_addrs': mock_ip}):
             with patch.object(socket, 'gethostbyname', mock_hostbyname):
-                comt = ('Peering with localhost is not needed'.format(name))
+                comt = 'Peering with localhost is not needed'
                 ret.update({'comment': comt})
                 self.assertDictEqual(glusterfs.peered(name), ret)
 
@@ -64,7 +64,7 @@ class GlusterfsTestCase(TestCase):
 
                 with patch.dict(glusterfs.__opts__, {'test': False}):
                     mock_list.side_effect = [['other'], ['other', name]]
-                    comt = 'Host salt successfully peered'.format(name)
+                    comt = 'Host {0} successfully peered'.format(name)
                     ret.update({'comment': comt,
                                 'changes': {'old': ['other'],
                                             'new': ['other', name]}})
@@ -78,7 +78,7 @@ class GlusterfsTestCase(TestCase):
 
                     comt = ('Failed to peer with salt,'
                             + ' please check logs for errors').format(name)
-                    ret.update({'comment': comt, 'changes':{}})
+                    ret.update({'comment': comt, 'changes': {}})
                     self.assertDictEqual(glusterfs.peered(name), ret)
 
                 with patch.object(salt.utils.cloud, 'check_name',
@@ -91,8 +91,6 @@ class GlusterfsTestCase(TestCase):
                     comt = ('Peer {0} will be added.'.format(name))
                     ret.update({'comment': comt, 'result': None})
                     self.assertDictEqual(glusterfs.peered(name), ret)
-
-
 
     # 'volume_present' function tests: 1
 
@@ -125,72 +123,73 @@ class GlusterfsTestCase(TestCase):
                 mock_info.return_value = started_info
                 comt = ('Volume {0} already exists and is started'.format(name))
                 ret.update({'comment': comt})
-                self.assertDictEqual(glusterfs.created(name, bricks, 
-                                                       start=True), ret)
+                self.assertDictEqual(glusterfs.volume_present(name, bricks,
+                                                              start=True), ret)
 
                 mock_info.return_value = stopped_info
                 comt = ('Volume {0} already exists and is now started'.format(name))
                 ret.update({'comment': comt,
-                            'changes': {'old':'stopped', 'new':'started'}})
-                self.assertDictEqual(glusterfs.created(name, bricks, 
-                                                       start=True), ret)
+                            'changes': {'old': 'stopped', 'new': 'started'}})
+                self.assertDictEqual(glusterfs.volume_present(name, bricks,
+                                                              start=True), ret)
 
                 comt = ('Volume {0} already exists'.format(name))
-                ret.update({'comment': comt, 'changes':{}})
-                self.assertDictEqual(glusterfs.created(name, bricks, 
-                                                       start=False), ret)
+                ret.update({'comment': comt, 'changes': {}})
+                self.assertDictEqual(glusterfs.volume_present(name, bricks,
+                                                              start=False), ret)
             with patch.dict(glusterfs.__opts__, {'test': True}):
                 comt = ('Volume {0} already exists'.format(name))
                 ret.update({'comment': comt, 'result': None})
-                self.assertDictEqual(glusterfs.created(name, bricks, 
-                                                       start=False), ret)
+                self.assertDictEqual(glusterfs.volume_present(name, bricks,
+                                                              start=False), ret)
 
                 comt = ('Volume {0} already exists'
                         + ' and will be started').format(name)
                 ret.update({'comment': comt, 'result': None})
-                self.assertDictEqual(glusterfs.created(name, bricks, 
-                                                       start=True), ret)
+                self.assertDictEqual(glusterfs.volume_present(name, bricks,
+                                                              start=True), ret)
 
                 mock_list.return_value = []
                 comt = ('Volume {0} will be created'.format(name))
                 ret.update({'comment': comt, 'result': None})
-                self.assertDictEqual(glusterfs.created(name, bricks, 
-                                                       start=False), ret)
+                self.assertDictEqual(glusterfs.volume_present(name, bricks,
+                                                              start=False), ret)
 
                 comt = ('Volume {0} will be created'
                         + ' and started').format(name)
                 ret.update({'comment': comt, 'result': None})
-                self.assertDictEqual(glusterfs.created(name, bricks, 
-                                                       start=True), ret)
+                self.assertDictEqual(glusterfs.volume_present(name, bricks,
+                                                              start=True), ret)
 
             with patch.dict(glusterfs.__opts__, {'test': False}):
                 mock_list.side_effect = [[], [name]]
                 comt = ('Volume {0} is created'.format(name))
                 ret.update({'comment': comt,
                             'result': True,
-                            'changes': {'old':[], 'new':[name]}})
-                self.assertDictEqual(glusterfs.created(name, bricks, 
-                                                       start=False), ret)
+                            'changes': {'old': [], 'new': [name]}})
+                self.assertDictEqual(glusterfs.volume_present(name, bricks,
+                                                              start=False), ret)
 
                 mock_list.side_effect = [[], [name]]
                 comt = ('Volume {0} is created and is now started'.format(name))
                 ret.update({'comment': comt, 'result': True})
-                self.assertDictEqual(glusterfs.created(name, bricks, 
-                                                       start=True), ret)
+                self.assertDictEqual(glusterfs.volume_present(name, bricks,
+                                                              start=True), ret)
 
                 mock_list.side_effect = None
                 mock_list.return_value = []
                 mock_create.return_value = False
                 comt = 'Creation of volume {0} failed'.format(name)
-                ret.update({'comment': comt, 'result': False, 'changes':{}})
-                self.assertDictEqual(glusterfs.created(name, bricks), ret)
+                ret.update({'comment': comt, 'result': False, 'changes': {}})
+                self.assertDictEqual(glusterfs.volume_present(name, bricks),
+                                     ret)
 
             with patch.object(salt.utils.cloud, 'check_name',
                               MagicMock(return_value=True)):
                 comt = ('Invalid characters in volume name.')
                 ret.update({'comment': comt, 'result': False})
-                self.assertDictEqual(glusterfs.created(name, bricks), ret)
-
+                self.assertDictEqual(glusterfs.volume_present(name, bricks),
+                                     ret)
 
     # 'started' function tests: 1
 
@@ -285,7 +284,7 @@ class GlusterfsTestCase(TestCase):
 
             ret.update({'result': True})
             ret.update({'comment': 'Bricks already added in volume salt'})
-            self.assertDictEqual(glusterfs.add_volume_bricks(name, old_bricks), 
+            self.assertDictEqual(glusterfs.add_volume_bricks(name, old_bricks),
                                                              ret)
 
             mock_info.side_effect = [volinfo, new_volinfo]


### PR DESCRIPTION
Usage of GlusterFS states did not change except the state 'created' was deprecated in favor of more descriptive name 'volume_present'.
Improved separation of functionality in the execution module from the states. Module functions now return booleans instead of varying
strings. Parsing those strings in the sates were very error-prone. Improved checking and verbosity in states. Calls to gluster are now logged more verbosely,
while a failing call no longer raises an immediate exception. Cleaned code a lot, removed some bugs and other odd behaviour. It could be beneficial to return
dictionaries with boolean status and gluster output string from some of the module functions but please don't do error checking based on the messages!
Some other functional changes:
- glusterfs.info() can now be called without volume name. It always returns a dictionary. Use this function instead of status() in sates.
- glusterfs.list_peers() function now attempts to list the longest possible form of the hostnames. GlusterFS may list several hostnames from which one
  is a default. An alternative hosts is used instead if it is prefixed by the default. (e.g. gluster1 is replaced with gluster1.example.com).
- Functions glusterfs.delete() and glusterfs.create() were renamed to delete_volume() and create_volume().
