### PR TITLE
Add support for docker's security_opt configuration (#23687)

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -1433,25 +1433,27 @@ def _validate_input(kwargs,
         kwargs['binds'] = new_binds
 
     def _valid_security_opt():  # pylint: disable=unused-variable
-      '''
-      Must be a single colon separated string or a list of colon separated strings
-      '''
-      if kwargs.get('security_opt') is None:
-          # No need to validate
-          return
+        '''
+        Must be a single colon separated string or a list of colon separated
+        strings
+        '''
+        if kwargs.get('security_opt') is None:
+            # No need to validate
+            return
 
-      try: # check whether python knows about 'basestring'
-          basestring
-      except NameError: # no, it doesn't (it's Python3); use 'str' instead
-          basestring=str
+        try:  # check whether python knows about 'basestring'
+            basestring
+        except NameError:  # no, it doesn't (it's Python3); use 'str' instead
+            basestring = str
 
-      if not isinstance(kwargs['security_opt'], basestring) and not isinstance(kwargs['security_opt'], list):
-          raise SaltInvocationError(
-              'security_opt must be a single value or a Python list')
-              
-      if isinstance(kwargs['security_opt'], basestring):
-        kwargs['security_opt'] = [kwargs['security_opt']]
-      
+        if (not isinstance(kwargs['security_opt'], basestring) and
+                not isinstance(kwargs['security_opt'], list)):
+            raise SaltInvocationError(
+                'security_opt must be a single value or a Python list')
+
+        if isinstance(kwargs['security_opt'], basestring):
+            kwargs['security_opt'] = [kwargs['security_opt']]
+
     def _valid_links():  # pylint: disable=unused-variable
         '''
         Must be a list of colon-delimited mappings
@@ -2791,12 +2793,12 @@ def create(image,
             These LXC configuration parameters will only have the desired
             effect if the container is using the LXC execution driver, which
             has not been the default for some time.
-            
+
     security_opt
         Security configuration for MLS systems such as SELinux and AppArmor.
 
         Example 1: ``security_opt="apparmor:unconfined"``
-        
+
         Example 2: ``security_opt=["apparmor:unconfined"]``
         ``security_opt=["apparmor:unconfined", "param2:value2"]``
 

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -1441,17 +1441,12 @@ def _validate_input(kwargs,
             # No need to validate
             return
 
-        try:  # check whether python knows about 'basestring'
-            basestring
-        except NameError:  # no, it doesn't (it's Python3); use 'str' instead
-            basestring = str
-
-        if (not isinstance(kwargs['security_opt'], basestring) and
+        if (not isinstance(kwargs['security_opt'], six.string_types) and
                 not isinstance(kwargs['security_opt'], list)):
             raise SaltInvocationError(
                 'security_opt must be a single value or a Python list')
 
-        if isinstance(kwargs['security_opt'], basestring):
+        if isinstance(kwargs['security_opt'], six.string_types):
             kwargs['security_opt'] = [kwargs['security_opt']]
 
     def _valid_links():  # pylint: disable=unused-variable

--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -1119,12 +1119,13 @@ def running(name,
             foo:
               dockerng.running:
                 - image: bar/baz:latest
-                - security_opts: 
+                - security_opts:
                   - 'apparmor:unconfined'
 
         .. note::
 
-            See the documentation for security_opt at https://docs.docker.com/engine/reference/run/#security-configuration
+            See the documentation for security_opt at
+            https://docs.docker.com/engine/reference/run/#security-configuration
 
     publish_all_ports : False
         Allocates a random host port for each port exposed using the ``ports``

--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -1111,6 +1111,21 @@ def running(name,
             effect if the container is using the LXC execution driver, which
             has not been the default for some time.
 
+    security_opt:
+        Security configuration for MLS systems such as SELinux and AppArmor.
+
+        .. code-block:: yaml
+
+            foo:
+              dockerng.running:
+                - image: bar/baz:latest
+                - security_opts: 
+                  - 'apparmor:unconfined'
+
+        .. note::
+
+            See the documentation for security_opt at https://docs.docker.com/engine/reference/run/#security-configuration
+
     publish_all_ports : False
         Allocates a random host port for each port exposed using the ``ports``
         parameter


### PR DESCRIPTION
This a pretty small and straightforward commit that will allow SELinux and AppArmor users to properly configure security capabilities. This is specifically important to AppArmor users (Debian and Ubuntu), since many containers use features that are restricted and will either fail or fill up the logs.

This fixes #23687
