### PR TITLE
[saltstack/salt#31194] Fix issue of running multiple salt-api instances.

### DIFF
--- a/doc/topics/netapi/writing.rst
+++ b/doc/topics/netapi/writing.rst
@@ -40,6 +40,18 @@ The ``start()`` function will be called for each :py:mod:`~salt.netapi`
 module that is loaded. This function should contain the server loop that
 actually starts the service. This is started in a multiprocess.
 
+Multiple instances
+==================
+
+.. versionadded:: Boron
+
+:py:mod:`~salt.netapi.rest_cherrypy` and :py:mod:`~salt.netapi.rest_tornado`
+support running multiple instances by copying and renaming entire directory
+of those. To start the copied multiple :py:mod:`~salt.netapi` modules, add 
+configuration blocks for the copied :py:mod:`~salt.netapi` modules in the
+Salt Master config. The name of each added configuration block must match
+with the name of each directory of the copied :py:mod:`~salt.netapi` module.
+
 Inline documentation
 ====================
 

--- a/salt/netapi/rest_cherrypy/__init__.py
+++ b/salt/netapi/rest_cherrypy/__init__.py
@@ -20,11 +20,7 @@ try:
 except ImportError as exc:
     cpy_error = exc
 
-
-try:
-    __virtualname__ = os.path.abspath(__file__).rsplit('/')[-2]
-except IndexError:
-    __virtualname__ = 'rest_cherrypy'
+__virtualname__ = os.path.abspath(__file__).rsplit('/')[-2] or 'rest_cherrypy'
 
 logger = logging.getLogger(__virtualname__)
 cpy_min = '3.2.2'

--- a/salt/netapi/rest_cherrypy/__init__.py
+++ b/salt/netapi/rest_cherrypy/__init__.py
@@ -20,10 +20,14 @@ try:
 except ImportError as exc:
     cpy_error = exc
 
-logger = logging.getLogger(__name__)
-cpy_min = '3.2.2'
 
-__virtualname__ = 'rest'
+try:
+    __virtualname__ = os.path.abspath(__file__).rsplit('/')[-2]
+except IndexError:
+    __virtualname__ = 'rest_cherrypy'
+
+logger = logging.getLogger(__virtualname__)
+cpy_min = '3.2.2'
 
 
 def __virtual__():
@@ -36,7 +40,7 @@ def __virtual__():
 
         # Everything looks good; return the module name
         if not cpy_error and 'port' in mod_opts:
-            return True
+            return __virtualname__
 
         # CherryPy wasn't imported; explain why
         if cpy_error:

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -1724,9 +1724,9 @@ class Events(object):
 
         # First check if the given token is in our session table; if so it's a
         # salt-api token and we need to get the Salt token from there.
-        orig_sesion, _ = cherrypy.session.cache.get(auth_token, ({}, None))
+        orig_session, _ = cherrypy.session.cache.get(auth_token, ({}, None))
         # If it's not in the session table, assume it's a regular Salt token.
-        salt_token = orig_sesion.get('token', auth_token)
+        salt_token = orig_session.get('token', auth_token)
 
         # The eauth system does not currently support perms for the event
         # stream, so we're just checking if the token exists not if the token
@@ -2011,8 +2011,8 @@ class WebsocketEndpoint(object):
         # Pulling the session token from an URL param is a workaround for
         # browsers not supporting CORS in the EventSource API.
         if token:
-            orig_sesion, _ = cherrypy.session.cache.get(token, ({}, None))
-            salt_token = orig_sesion.get('token')
+            orig_session, _ = cherrypy.session.cache.get(token, ({}, None))
+            salt_token = orig_session.get('token')
         else:
             salt_token = cherrypy.session.get('token')
 

--- a/salt/netapi/rest_tornado/__init__.py
+++ b/salt/netapi/rest_tornado/__init__.py
@@ -3,9 +3,13 @@
 from __future__ import absolute_import, print_function
 import hashlib
 import logging
+import os
 import distutils.version  # pylint: disable=no-name-in-module
 
-__virtualname__ = 'rest_tornado'
+try:
+    __virtualname__ = os.path.abspath(__file__).rsplit('/')[-2]
+except IndexError:
+    __virtualname__ = 'rest_tornado'
 
 logger = logging.getLogger(__virtualname__)
 

--- a/salt/netapi/rest_tornado/__init__.py
+++ b/salt/netapi/rest_tornado/__init__.py
@@ -6,10 +6,7 @@ import logging
 import os
 import distutils.version  # pylint: disable=no-name-in-module
 
-try:
-    __virtualname__ = os.path.abspath(__file__).rsplit('/')[-2]
-except IndexError:
-    __virtualname__ = 'rest_tornado'
+__virtualname__ = os.path.abspath(__file__).rsplit('/')[-2] or 'rest_cherrypy'
 
 logger = logging.getLogger(__virtualname__)
 


### PR DESCRIPTION
- Change return value from 'True' to '**virtualname**' in rest_cherrypy/**init**.py
  The **virtualname** value must be set as name of salt-api instance, thus the code try to get the instance name from **init**.py's directory name.
- Change setting **virtualname** logic because the rest_tornado has a same issue with the rest_cherrypy.
- Typo, 'orig_sesion' to 'orig_session' in rest_cherrypy/app.py
