### PR TITLE
Fix for the patch for #31282 

### DIFF
--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -269,12 +269,6 @@ def _compare(actual, create_kwargs):
                                     host_port,
                                     container_port)
                     actual_binds.append(':'.join(bind_def))
-                    # The any address (0.0.0.0) is omitted from the
-                    # actual_binds comparison key, so be sure to
-                    # strip it from the desired_binds comparison
-                    # key if it's included.
-                    if bind_def.startswith('0.0.0.0:'):
-                        bind_def = bind_def.replace('0.0.0.0:', '')
 
             desired_binds = []
             for container_port, bind_list in six.iteritems(data):
@@ -305,6 +299,12 @@ def _compare(actual, create_kwargs):
                             )
                         else:
                             bind_def = container_port
+                    # The any address (0.0.0.0) is omitted from the
+                    # actual_binds comparison key, so be sure to
+                    # strip it from the desired_binds comparison
+                    # key if it's included.
+                    if  bind_def.startswith('0.0.0.0:'):
+                        bind_def = bind_def.replace('0.0.0.0:', '')
                     desired_binds.append(bind_def)
             actual_binds.sort()
             desired_binds.sort()

--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -303,7 +303,7 @@ def _compare(actual, create_kwargs):
                     # actual_binds comparison key, so be sure to
                     # strip it from the desired_binds comparison
                     # key if it's included.
-                    if  bind_def.startswith('0.0.0.0:'):
+                    if bind_def.startswith('0.0.0.0:'):
                         bind_def = bind_def.replace('0.0.0.0:', '')
                     desired_binds.append(bind_def)
             actual_binds.sort()


### PR DESCRIPTION
@cachedout 

After using the patch from our last [pull request](https://github.com/saltstack/salt/pull/31285) in our environment, we realized that we needed to make a small change. In certain cases, bind_def could be a tuple and not a string, so we just needed to move the earlier patch down a few lines.

Sorry for the hassle!
