### PR TITLE
Allow state-output and state-verbose default settings to be set from CLI

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1076,14 +1076,14 @@ class OutputOptionsMixIn(six.with_metaclass(MixInMeta, object)):
         )
         group.add_option(
             '--state-output', '--state_output',
-            default='full',
+            default=None,
             help=('Override the configured state_output value for minion '
                   'output. One of full, terse, mixed, changes or filter. '
                   'Default: full.')
         )
         group.add_option(
             '--state-verbose', '--state_verbose',
-            default=True,
+            default=None,
             help=('Override the configured state_verbose value for minion '
                   'output. Set to True or False'
                   'Default: True')


### PR DESCRIPTION
Fixes #29795

If `state_output` is set in a config file to be something other than the default, such as `state_output: terse`, and you try to override the the setting in the config file from the CLI back to the default setting of `--state_output=full`, the CLI setting cannot override the setting in the config file. By changing these initial default settings to `None` in the config parser, we are able to override the config file with the default settings passed via the CLI. This behavior is also true for the `state_verbose` setting. For example:

```
# /etc/salt/master
state_output: terse
```

Original `terse` output:

```
root@rallytime:~# salt rallytime state.highstate
rallytime:
  Name: foo - Function: test.succeed_without_changes - Result: Clean
  Name: foo - Function: test.fail_without_changes - Result: Failed
  Name: foo - Function: test.succeed_with_changes - Result: Changed

Summary for rallytime
------------
Succeeded: 2 (changed=1)
Failed:    1
------------
Total states run:     3
```

Attempt to override with default of "full" (reproducing the bug):

```
root@rallytime:~# salt rallytime state.highstate --state-output=full
rallytime:
  Name: foo - Function: test.succeed_without_changes - Result: Clean
  Name: foo - Function: test.fail_without_changes - Result: Failed
  Name: foo - Function: test.succeed_with_changes - Result: Changed

Summary for rallytime
------------
Succeeded: 2 (changed=1)
Failed:    1
------------
Total states run:     3
```

With the fix (same behavior from config file):

```
root@rallytime:~# salt rallytime state.highstate
rallytime:
  Name: foo - Function: test.succeed_without_changes - Result: Clean
  Name: foo - Function: test.fail_without_changes - Result: Failed
  Name: foo - Function: test.succeed_with_changes - Result: Changed

Summary for rallytime
------------
Succeeded: 2 (changed=1)
Failed:    1
------------
Total states run:     3
```

Proper override with "full" from CLI:

```
root@rallytime:~# salt rallytime state.highstate --state-output=full
rallytime:
----------
          ID: always-passes
    Function: test.succeed_without_changes
        Name: foo
      Result: True
     Comment: Success!
     Started: 04:28:27.859193
    Duration: 0.347 ms
     Changes:
----------
          ID: always-fails
    Function: test.fail_without_changes
        Name: foo
      Result: False
     Comment: Failure!
     Started: 04:28:27.859626
    Duration: 0.428 ms
     Changes:
----------
          ID: always-changes-and-succeeds
    Function: test.succeed_with_changes
        Name: foo
      Result: True
     Comment: Success!
     Started: 04:28:27.860137
    Duration: 0.24 ms
     Changes:
              ----------
              testing:
                  ----------
                  new:
                      Something pretended to change
                  old:
                      Unchanged

Summary for rallytime
------------
Succeeded: 2 (changed=1)
Failed:    1
------------
Total states run:     3
```

Note: I tested this change with various settings in the master and minion config files against many combinations of overriding the config files via the CLI. The previous behavior works as well as fixing the bug, as the proper defaults here are populated elsewhere in `self.config` and `self.defaults` values in the `salt/utils/parsers.py` file.

This is also how the `--output` option works. The `default` is listed in the parser file as `None`, but the default is actually `nested`. In this way, the CLI can override a config setting of, for example, `output: json` with `--output=nested` from the CLI.
