### PR TITLE
Made postgres module initdb dependency optional

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -105,7 +105,7 @@ def __virtual__():
     '''
     Only load this module if the psql bin exists
     '''
-    if all((salt.utils.which('psql'), salt.utils.which('initdb'), HAS_CSV)):
+    if all((salt.utils.which('psql'), HAS_CSV)):
         return True
     return (False, 'The postgres execution module failed to load: '
         'either the psql or initdb binary are not in the path or '
@@ -3022,6 +3022,10 @@ def datadir_init(name,
     runas
         The system user the operation should be performed on behalf of
     '''
+    if salt.utils.which('initdb') is None:
+        log.error('initdb not found in path')
+        return False
+
     if datadir_exists(name):
         log.info('%s already exists', name)
         return False


### PR DESCRIPTION
On some distros (like ubuntu, debian) initdb is
not in the $PATH and is provided by the server
package.

The initdb dependency would require that the
server package be installed to manage remote
databases which is not optimal.

Issue reported by @ticosax in pull request
https://github.com/saltstack/salt/pull/30537#issuecomment-185675050
