### PR TITLE
fix salt.states.smartos tripping over NoneType

### DIFF
--- a/salt/states/smartos.py
+++ b/salt/states/smartos.py
@@ -757,7 +757,7 @@ def vm_present(name, vmconfig, config=None):
 
         # create vm
         if ret['result']:
-            uuid = __salt__['vmadm.create'](**vmconfig) if not __opts__['test'] else None
+            uuid = __salt__['vmadm.create'](**vmconfig) if not __opts__['test'] else True
             if not isinstance(uuid, (bool)) and 'Error' in uuid:
                 ret['result'] = False
                 ret['comment'] = "{0}".format(uuid['Error'])


### PR DESCRIPTION
Present in 2016.3 and develop, so targetting 2016.3

Fixes the following:

```
----------
          ID: smartos.zones.native::test
    Function: smartos.vm_present
        Name: test
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "salt/state.py", line 1701, in call
                File "salt/loader.py", line 1597, in wrapper
                File "salt/states/smartos.py", line 761, in vm_present
              TypeError: argument of type 'NoneType' is not iterable
     Started: 15:06:50.099882
    Duration: 1067.997 ms
     Changes:
```

Only happens when 'test=True' is given for state.sls or state.highstate
