### PR TITLE
Issues/24050 pillar fixes

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -850,7 +850,7 @@ class Minion(MinionBase):
         '''
         self.opts['master'] = master
 
-        self.functions, self.returners, self.function_errors, self.executors = self._load_modules()
+        # Initialize pillar before loader to make pillar accessible in modules
         self.opts['pillar'] = yield salt.pillar.get_async_pillar(
             self.opts,
             self.opts['grains'],
@@ -858,6 +858,7 @@ class Minion(MinionBase):
             self.opts['environment'],
             pillarenv=self.opts.get('pillarenv')
         ).compile_pillar()
+        self.functions, self.returners, self.function_errors, self.executors = self._load_modules()
         self.serial = salt.payload.Serial(self.opts)
         self.mod_opts = self._prep_mod_opts()
         self.matcher = Matcher(self.opts, self.functions)

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -93,7 +93,8 @@ class AsyncRemotePillar(object):
         self.grains = grains
         self.minion_id = minion_id
         self.channel = salt.transport.client.AsyncReqChannel.factory(opts)
-        self.opts['pillarenv'] = pillarenv
+        if pillarenv is not None or 'pillarenv' not in self.opts:
+            self.opts['pillarenv'] = pillarenv
         self.pillar_override = {}
         if pillar is not None:
             if isinstance(pillar, dict):
@@ -145,7 +146,8 @@ class RemotePillar(object):
         self.grains = grains
         self.minion_id = minion_id
         self.channel = salt.transport.Channel.factory(opts)
-        self.opts['pillarenv'] = pillarenv
+        if pillarenv is not None or 'pillarenv' not in self.opts:
+            self.opts['pillarenv'] = pillarenv
         self.pillar_override = {}
         if pillar is not None:
             if isinstance(pillar, dict):


### PR DESCRIPTION
Fixes related to #24050 and #21765
- Properly initialize modules pillar data on minion start. Previously it was empty because minion was initializing modules before getting pillar from master so modules was initialized with an empty pillar dict.
- Use the current (set on the minion) pillar environment in `pillar.items` call. Previously it was returning pillar data merged from all environments.
