### PR TITLE
Extend boto_iam with support for managed policies

### DIFF
--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -1992,4 +1992,100 @@ def list_entities_for_policy(policy_name, path_prefix=None, entity_filter=None,
         log.debug(e)
         msg = 'Failed to list {0} policy entities.'
         log.error(msg.format(policy_name))
+        return {}
+
+
+def list_attached_user_policies(user_name, path_prefix=None, entity_filter=None,
+                  region=None, key=None, keyid=None, profile=None):
+    '''
+    List entities attached to the given user.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iam.list_entities_for_policy mypolicy
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    params = {'UserName': user_name}
+    if path_prefix is not None:
+       params['PathPrefix'] = path_prefix
+
+    policies = []
+    try:
+        # Using conn.get_response is a bit of a hack, but it avoids having to
+        # rewrite this whole module based on boto3
+        for ret in salt.utils.boto.paged_call(conn.get_response, 'ListAttachedUserPolicies', params, list_marker='AttachedPolicies'):
+            policies.extend(ret.get('list_attached_user_policies_response',{}).get('list_attached_user_policies_result',{}
+                                   ).get('attached_policies',[]))
+        return policies
+    except boto.exception.BotoServerError as e:
+        log.debug(e)
+        msg = 'Failed to list user {0} attached policies.'
+        log.error(msg.format(user_name))
+        return []
+
+
+def list_attached_group_policies(group_name, path_prefix=None, entity_filter=None,
+                  region=None, key=None, keyid=None, profile=None):
+    '''
+    List entities attached to the given group.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iam.list_entities_for_policy mypolicy
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    params = {'GroupName': group_name}
+    if path_prefix is not None:
+       params['PathPrefix'] = path_prefix
+
+    policies = []
+    try:
+        # Using conn.get_response is a bit of a hack, but it avoids having to
+        # rewrite this whole module based on boto3
+        for ret in salt.utils.boto.paged_call(conn.get_response, 'ListAttachedGroupPolicies', params, list_marker='AttachedPolicies'):
+            policies.extend(ret.get('list_attached_group_policies_response',{}).get('list_attached_group_policies_result',{}
+                                   ).get('attached_policies',[]))
+        return policies
+    except boto.exception.BotoServerError as e:
+        log.debug(e)
+        msg = 'Failed to list group {0} attached policies.'
+        log.error(msg.format(group_name))
+        return []
+
+
+def list_attached_role_policies(role_name, path_prefix=None, entity_filter=None,
+                  region=None, key=None, keyid=None, profile=None):
+    '''
+    List entities attached to the given role.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iam.list_entities_for_policy mypolicy
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    params = {'RoleName': role_name}
+    if path_prefix is not None:
+       params['PathPrefix'] = path_prefix
+
+    policies = []
+    try:
+        # Using conn.get_response is a bit of a hack, but it avoids having to
+        # rewrite this whole module based on boto3
+        for ret in salt.utils.boto.paged_call(conn.get_response, 'ListAttachedRolePolicies', params, list_marker='AttachedPolicies'):
+            policies.extend(ret.get('list_attached_role_policies_response',{}).get('list_attached_role_policies_result',{}
+                                   ).get('attached_policies',[]))
+        return policies
+    except boto.exception.BotoServerError as e:
+        log.debug(e)
+        msg = 'Failed to list role {0} attached policies.'
+        log.error(msg.format(role_name))
         return []

--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -660,6 +660,37 @@ def get_all_group_policies(group_name, region=None, key=None, keyid=None,
         return []
 
 
+def delete_group(group_name, region=None, key=None,
+                        keyid=None, profile=None):
+    '''
+    Delete a group policy.
+
+    CLI Example::
+
+    .. code-block:: bash
+
+        salt myminion boto_iam.delete_group mygroup
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    if not conn:
+        return False
+    _group = get_group(
+        group_name, region, key, keyid, profile
+    )
+    if not _group:
+        return True
+    try:
+        conn.delete_group(group_name)
+        msg = 'Successfully deleted group {0}.'
+        log.info(msg.format(group_name))
+        return True
+    except boto.exception.BotoServerError as e:
+        log.debug(e)
+        msg = 'Failed to delete group {0}.'
+        log.error(msg.format(group_name))
+        return False
+
+
 def create_login_profile(user_name, password, region=None, key=None,
                          keyid=None, profile=None):
     '''

--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -41,8 +41,8 @@ Connection module for Amazon IAM
 from __future__ import absolute_import
 import logging
 import json
-import yaml
 import urllib
+import yaml
 
 # Import salt libs
 import salt.utils.compat
@@ -1565,7 +1565,7 @@ def get_policy(policy_name,
 
     try:
         ret = conn.get_policy(_get_policy_arn(policy_name))
-        return ret.get('get_policy_response',{}).get('get_policy_result',{})
+        return ret.get('get_policy_response', {}).get('get_policy_result', {})
     except boto.exception.BotoServerError:
         return None
 
@@ -1646,7 +1646,7 @@ def list_policies(region=None, key=None, keyid=None, profile=None):
     try:
         policies = []
         for ret in salt.utils.boto.paged_call(conn.list_policies):
-            policies.append(ret.get('list_policies_response',{}).get('list_policies_result',{}).get('policies'))
+            policies.append(ret.get('list_policies_response', {}).get('list_policies_result', {}).get('policies'))
         return policies
     except boto.exception.BotoServerError as e:
         log.debug(e)
@@ -1691,9 +1691,9 @@ def get_policy_version(policy_name, version_id,
 
     try:
         ret = conn.get_policy_version(_get_policy_arn(policy_name), version_id)
-        retval = ret.get('get_policy_version_response',{}).get('get_policy_version_result',{}).get('policy_version',{})
+        retval = ret.get('get_policy_version_response', {}).get('get_policy_version_result', {}).get('policy_version', {})
         retval['document'] = urllib.unquote(retval.get('document'))
-        return { 'policy_version': retval }
+        return {'policy_version': retval}
     except boto.exception.BotoServerError:
         return None
 
@@ -1720,8 +1720,7 @@ def create_policy_version(policy_name, policy_document, set_as_default=None,
     policy_arn = _get_policy_arn(policy_name, region, key, keyid, profile)
     try:
         ret = conn.create_policy_version(policy_arn, policy_document, **params)
-        vid = ret.get('create_policy_version_response',{}).get('create_policy_version_result',{}).get('policy_version',{}).get('version_id')
-        log.debug(ret)
+        vid = ret.get('create_policy_version_response', {}).get('create_policy_version_result', {}).get('policy_version', {}).get('version_id')
         log.info('Created {0} policy version {1}.'.format(policy_name, vid))
         return {'created': True, 'version_id': vid}
     except boto.exception.BotoServerError as e:
@@ -1775,7 +1774,7 @@ def list_policy_versions(policy_name,
     policy_arn = _get_policy_arn(policy_name, region, key, keyid, profile)
     try:
         ret = conn.list_policy_versions(policy_arn)
-        return ret.get('list_policy_versions_response',{}).get('list_policy_versions_result',{}).get('versions')
+        return ret.get('list_policy_versions_response', {}).get('list_policy_versions_result', {}).get('versions')
     except boto.exception.BotoServerError as e:
         log.debug(e)
         msg = 'Failed to list {0} policy vesions.'
@@ -1986,7 +1985,7 @@ def list_entities_for_policy(policy_name, path_prefix=None, entity_filter=None,
         }
         for ret in salt.utils.boto.paged_call(conn.list_entities_for_policy, policy_arn=policy_arn, **params):
             for k, v in allret.iteritems():
-                v.extend(ret.get('list_entities_for_policy_response',{}).get('list_entities_for_policy_result',{}).get(k))
+                v.extend(ret.get('list_entities_for_policy_response', {}).get('list_entities_for_policy_result', {}).get(k))
         return allret
     except boto.exception.BotoServerError as e:
         log.debug(e)
@@ -2010,15 +2009,15 @@ def list_attached_user_policies(user_name, path_prefix=None, entity_filter=None,
 
     params = {'UserName': user_name}
     if path_prefix is not None:
-       params['PathPrefix'] = path_prefix
+        params['PathPrefix'] = path_prefix
 
     policies = []
     try:
         # Using conn.get_response is a bit of a hack, but it avoids having to
         # rewrite this whole module based on boto3
         for ret in salt.utils.boto.paged_call(conn.get_response, 'ListAttachedUserPolicies', params, list_marker='AttachedPolicies'):
-            policies.extend(ret.get('list_attached_user_policies_response',{}).get('list_attached_user_policies_result',{}
-                                   ).get('attached_policies',[]))
+            policies.extend(ret.get('list_attached_user_policies_response', {}).get('list_attached_user_policies_result', {}
+                                   ).get('attached_policies', []))
         return policies
     except boto.exception.BotoServerError as e:
         log.debug(e)
@@ -2042,15 +2041,15 @@ def list_attached_group_policies(group_name, path_prefix=None, entity_filter=Non
 
     params = {'GroupName': group_name}
     if path_prefix is not None:
-       params['PathPrefix'] = path_prefix
+        params['PathPrefix'] = path_prefix
 
     policies = []
     try:
         # Using conn.get_response is a bit of a hack, but it avoids having to
         # rewrite this whole module based on boto3
         for ret in salt.utils.boto.paged_call(conn.get_response, 'ListAttachedGroupPolicies', params, list_marker='AttachedPolicies'):
-            policies.extend(ret.get('list_attached_group_policies_response',{}).get('list_attached_group_policies_result',{}
-                                   ).get('attached_policies',[]))
+            policies.extend(ret.get('list_attached_group_policies_response', {}).get('list_attached_group_policies_result', {}
+                                   ).get('attached_policies', []))
         return policies
     except boto.exception.BotoServerError as e:
         log.debug(e)
@@ -2074,15 +2073,15 @@ def list_attached_role_policies(role_name, path_prefix=None, entity_filter=None,
 
     params = {'RoleName': role_name}
     if path_prefix is not None:
-       params['PathPrefix'] = path_prefix
+        params['PathPrefix'] = path_prefix
 
     policies = []
     try:
         # Using conn.get_response is a bit of a hack, but it avoids having to
         # rewrite this whole module based on boto3
         for ret in salt.utils.boto.paged_call(conn.get_response, 'ListAttachedRolePolicies', params, list_marker='AttachedPolicies'):
-            policies.extend(ret.get('list_attached_role_policies_response',{}).get('list_attached_role_policies_result',{}
-                                   ).get('attached_policies',[]))
+            policies.extend(ret.get('list_attached_role_policies_response', {}).get('list_attached_role_policies_result', {}
+                                   ).get('attached_policies', []))
         return policies
     except boto.exception.BotoServerError as e:
         log.debug(e)

--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -1544,7 +1544,8 @@ def policy_exists(policy_name,
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
     try:
-        conn.get_policy(_get_policy_arn(policy_name))
+        conn.get_policy(_get_policy_arn(policy_name,
+                    region=region, key=key, keyid=keyid, profile=profile))
         return True
     except boto.exception.BotoServerError:
         return False
@@ -1564,7 +1565,8 @@ def get_policy(policy_name,
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
     try:
-        ret = conn.get_policy(_get_policy_arn(policy_name))
+        ret = conn.get_policy(_get_policy_arn(policy_name,
+                            region=region, key=key, keyid=keyid, profile=profile))
         return ret.get('get_policy_response', {}).get('get_policy_result', {})
     except boto.exception.BotoServerError:
         return None
@@ -1690,7 +1692,8 @@ def get_policy_version(policy_name, version_id,
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
     try:
-        ret = conn.get_policy_version(_get_policy_arn(policy_name), version_id)
+        ret = conn.get_policy_version(_get_policy_arn(policy_name,
+                            region=region, key=key, keyid=keyid, profile=profile), version_id)
         retval = ret.get('get_policy_version_response', {}).get('get_policy_version_result', {}).get('policy_version', {})
         retval['document'] = urllib.unquote(retval.get('document'))
         return {'policy_version': retval}

--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -787,7 +787,7 @@ def get_all_mfa_devices(user_name, region=None, key=None, keyid=None,
             log.info('Could not find user {0}.'.format(user_name))
             return []
         msg = 'Failed to get all MFA devices for user {0}.'
-        log.error(msg.format(user_name, serial))
+        log.error(msg.format(user_name))
         return False
 
 

--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -42,10 +42,12 @@ from __future__ import absolute_import
 import logging
 import json
 import yaml
+import urllib
 
 # Import salt libs
 import salt.utils.compat
 import salt.utils.odict as odict
+import salt.utils.boto
 
 # Import third party libs
 # pylint: disable=unused-import
@@ -1485,3 +1487,478 @@ def export_users(path_prefix='/', region=None, key=None, keyid=None,
         user_sls.append({"path": user.path})
         results["manage user " + name] = {"boto_iam.user_present": user_sls}
     return _safe_dump(results)
+
+
+def _get_policy_arn(name, region=None, key=None, keyid=None, profile=None):
+    if name.startswith('arn:aws:iam:'):
+        return name
+
+    account_id = get_account_id(
+        region=region, key=key, keyid=keyid, profile=profile
+    )
+    return 'arn:aws:iam::{0}:policy/{1}'.format(account_id, name)
+
+
+def policy_exists(policy_name,
+                  region=None, key=None, keyid=None, profile=None):
+    '''
+    Check to see if policy exists.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iam.instance_profile_exists myiprofile
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    try:
+        conn.get_policy(_get_policy_arn(policy_name))
+        return True
+    except boto.exception.BotoServerError:
+        return False
+
+
+def get_policy(policy_name,
+               region=None, key=None, keyid=None, profile=None):
+    '''
+    Check to see if policy exists.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iam.instance_profile_exists myiprofile
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    try:
+        ret = conn.get_policy(_get_policy_arn(policy_name))
+        return ret.get('get_policy_response',{}).get('get_policy_result',{})
+    except boto.exception.BotoServerError:
+        return None
+
+
+def create_policy(policy_name, policy_document, path=None, description=None,
+                 region=None, key=None, keyid=None, profile=None):
+    '''
+    Create a policy.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminios boto_iam.create_policy mypolicy '{"Version": "2012-10-17", "Statement": [{ "Effect": "Allow", "Action": ["s3:Get*", "s3:List*"], "Resource": ["arn:aws:s3:::my-bucket/shared/*"]},]}'
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    if not isinstance(policy_document, string_types):
+        policy_document = json.dumps(policy_document)
+    params = {}
+    for arg in 'path', 'description':
+        if locals()[arg] is not None:
+            params[arg] = locals()[arg]
+    log.debug(policy_document)
+    if policy_exists(policy_name, region, key, keyid, profile):
+        return True
+    try:
+        conn.create_policy(policy_name, policy_document, **params)
+        log.info('Created {0} policy.'.format(policy_name))
+    except boto.exception.BotoServerError as e:
+        log.debug(e)
+        msg = 'Failed to create {0} policy.'
+        log.error(msg.format(policy_name))
+        return False
+    return True
+
+
+def delete_policy(policy_name,
+                  region=None, key=None, keyid=None, profile=None):
+    '''
+    Delete a policy.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iam.delete_policy mypolicy
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    policy_arn = _get_policy_arn(policy_name, region, key, keyid, profile)
+    if not policy_exists(policy_arn, region, key, keyid, profile):
+        return True
+    try:
+        conn.delete_policy(policy_arn)
+        log.info('Deleted {0} policy.'.format(policy_name))
+    except boto.exception.BotoServerError as e:
+        aws = salt.utils.boto.get_error(e)
+        log.debug(aws)
+        msg = 'Failed to delete {0} policy: {1}.'
+        log.error(msg.format(policy_name, aws.get('message')))
+        return False
+    return True
+
+
+def list_policies(region=None, key=None, keyid=None, profile=None):
+    '''
+    List policies.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iam.list_policies
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    try:
+        policies = []
+        for ret in salt.utils.boto.paged_call(conn.list_policies):
+            policies.append(ret.get('list_policies_response',{}).get('list_policies_result',{}).get('policies'))
+        return policies
+    except boto.exception.BotoServerError as e:
+        log.debug(e)
+        msg = 'Failed to list policy versions.'
+        log.error(msg)
+        return []
+
+
+def policy_version_exists(policy_name, version_id,
+                  region=None, key=None, keyid=None, profile=None):
+    '''
+    Check to see if policy exists.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iam.instance_profile_exists myiprofile
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    policy_arn = _get_policy_arn(policy_name, region, key, keyid, profile)
+    try:
+        conn.get_policy_version(policy_arn, version_id)
+        return True
+    except boto.exception.BotoServerError:
+        return False
+
+
+def get_policy_version(policy_name, version_id,
+               region=None, key=None, keyid=None, profile=None):
+    '''
+    Check to see if policy exists.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iam.instance_profile_exists myiprofile
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    try:
+        ret = conn.get_policy_version(_get_policy_arn(policy_name), version_id)
+        retval = ret.get('get_policy_version_response',{}).get('get_policy_version_result',{}).get('policy_version',{})
+        retval['document'] = urllib.unquote(retval.get('document'))
+        return { 'policy_version': retval }
+    except boto.exception.BotoServerError:
+        return None
+
+
+def create_policy_version(policy_name, policy_document, set_as_default=None,
+                 region=None, key=None, keyid=None, profile=None):
+    '''
+    Create a policy version.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminios boto_iam.create_policy_version mypolicy '{"Version": "2012-10-17", "Statement": [{ "Effect": "Allow", "Action": ["s3:Get*", "s3:List*"], "Resource": ["arn:aws:s3:::my-bucket/shared/*"]},]}'
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    if not isinstance(policy_document, string_types):
+        policy_document = json.dumps(policy_document)
+    params = {}
+    for arg in ('set_as_default',):
+        if locals()[arg] is not None:
+            params[arg] = locals()[arg]
+    policy_arn = _get_policy_arn(policy_name, region, key, keyid, profile)
+    try:
+        ret = conn.create_policy_version(policy_arn, policy_document, **params)
+        vid = ret.get('create_policy_version_response',{}).get('create_policy_version_result',{}).get('policy_version',{}).get('version_id')
+        log.debug(ret)
+        log.info('Created {0} policy version {1}.'.format(policy_name, vid))
+        return {'created': True, 'version_id': vid}
+    except boto.exception.BotoServerError as e:
+        log.debug(e)
+        msg = 'Failed to create {0} policy version.'
+        log.error(msg.format(policy_name))
+        return {'created': False, 'error': salt.utils.boto.get_error(e)}
+
+
+def delete_policy_version(policy_name, version_id,
+                  region=None, key=None, keyid=None, profile=None):
+    '''
+    Delete a policy version.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iam.delete_policy_version mypolicy v1
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    policy_arn = _get_policy_arn(policy_name, region, key, keyid, profile)
+    if not policy_version_exists(policy_arn, version_id, region, key, keyid, profile):
+        return True
+    try:
+        conn.delete_policy_version(policy_arn, version_id)
+        log.info('Deleted {0} policy version {1}.'.format(policy_name, version_id))
+    except boto.exception.BotoServerError as e:
+        aws = salt.utils.boto.get_error(e)
+        log.debug(aws)
+        msg = 'Failed to delete {0} policy version {1}: {2}'
+        log.error(msg.format(policy_name, version_id, aws.get('message')))
+        return False
+    return True
+
+
+def list_policy_versions(policy_name,
+                  region=None, key=None, keyid=None, profile=None):
+    '''
+    List versions of a policy.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iam.list_policy_versions mypolicy
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    policy_arn = _get_policy_arn(policy_name, region, key, keyid, profile)
+    try:
+        ret = conn.list_policy_versions(policy_arn)
+        return ret.get('list_policy_versions_response',{}).get('list_policy_versions_result',{}).get('versions')
+    except boto.exception.BotoServerError as e:
+        log.debug(e)
+        msg = 'Failed to list {0} policy vesions.'
+        log.error(msg.format(policy_name))
+        return []
+
+
+def set_default_policy_version(policy_name, version_id,
+                  region=None, key=None, keyid=None, profile=None):
+    '''
+    Set the default version of  a policy.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iam.set_default_policy_version mypolicy v1
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    policy_arn = _get_policy_arn(policy_name, region, key, keyid, profile)
+    try:
+        conn.set_default_policy_version(policy_arn, version_id)
+        log.info('Set {0} policy to version {1}.'.format(policy_name, version_id))
+    except boto.exception.BotoServerError as e:
+        aws = salt.utils.boto.get_error(e)
+        log.debug(aws)
+        msg = 'Failed to set {0} policy to version {1}: {2}'
+        log.error(msg.format(policy_name, version_id, aws.get('message')))
+        return False
+    return True
+
+
+def attach_user_policy(policy_name, user_name,
+                  region=None, key=None, keyid=None, profile=None):
+    '''
+    Attach a managed policy to a user.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iam.attach_user_policy mypolicy myuser
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    policy_arn = _get_policy_arn(policy_name, region, key, keyid, profile)
+    try:
+        conn.attach_user_policy(policy_arn, user_name)
+        log.info('Attached {0} policy to user {1}.'.format(policy_name, user_name))
+    except boto.exception.BotoServerError as e:
+        log.debug(e)
+        msg = 'Failed to attach {0} policy to user {1}.'
+        log.error(msg.format(policy_name, user_name))
+        return False
+    return True
+
+
+def detach_user_policy(policy_name, user_name,
+                  region=None, key=None, keyid=None, profile=None):
+    '''
+    Detach a managed policy to a user.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iam.detach_user_policy mypolicy myuser
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    policy_arn = _get_policy_arn(policy_name, region, key, keyid, profile)
+    try:
+        conn.detach_user_policy(policy_arn, user_name)
+        log.info('Detached {0} policy to user {1}.'.format(policy_name, user_name))
+    except boto.exception.BotoServerError as e:
+        log.debug(e)
+        msg = 'Failed to detach {0} policy to user {1}.'
+        log.error(msg.format(policy_name, user_name))
+        return False
+    return True
+
+
+def attach_group_policy(policy_name, group_name,
+                  region=None, key=None, keyid=None, profile=None):
+    '''
+    Attach a managed policy to a group.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iam.attach_group_policy mypolicy mygroup
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    policy_arn = _get_policy_arn(policy_name, region, key, keyid, profile)
+    try:
+        conn.attach_group_policy(policy_arn, group_name)
+        log.info('Attached {0} policy to group {1}.'.format(policy_name, group_name))
+    except boto.exception.BotoServerError as e:
+        log.debug(e)
+        msg = 'Failed to attach {0} policy to group {1}.'
+        log.error(msg.format(policy_name, group_name))
+        return False
+    return True
+
+
+def detach_group_policy(policy_name, group_name,
+                  region=None, key=None, keyid=None, profile=None):
+    '''
+    Detach a managed policy to a group.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iam.detach_group_policy mypolicy mygroup
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    policy_arn = _get_policy_arn(policy_name, region, key, keyid, profile)
+    try:
+        conn.detach_group_policy(policy_arn, group_name)
+        log.info('Detached {0} policy to group {1}.'.format(policy_name, group_name))
+    except boto.exception.BotoServerError as e:
+        log.debug(e)
+        msg = 'Failed to detach {0} policy to group {1}.'
+        log.error(msg.format(policy_name, group_name))
+        return False
+    return True
+
+
+def attach_role_policy(policy_name, role_name,
+                  region=None, key=None, keyid=None, profile=None):
+    '''
+    Attach a managed policy to a role.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iam.attach_role_policy mypolicy myrole
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    policy_arn = _get_policy_arn(policy_name, region, key, keyid, profile)
+    try:
+        conn.attach_role_policy(policy_arn, role_name)
+        log.info('Attached {0} policy to role {1}.'.format(policy_name, role_name))
+    except boto.exception.BotoServerError as e:
+        log.debug(e)
+        msg = 'Failed to attach {0} policy to role {1}.'
+        log.error(msg.format(policy_name, role_name))
+        return False
+    return True
+
+
+def detach_role_policy(policy_name, role_name,
+                  region=None, key=None, keyid=None, profile=None):
+    '''
+    Detach a managed policy to a role.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iam.detach_role_policy mypolicy myrole
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    policy_arn = _get_policy_arn(policy_name, region, key, keyid, profile)
+    try:
+        conn.detach_role_policy(policy_arn, role_name)
+        log.info('Detached {0} policy to role {1}.'.format(policy_name, role_name))
+    except boto.exception.BotoServerError as e:
+        log.debug(e)
+        msg = 'Failed to detach {0} policy to role {1}.'
+        log.error(msg.format(policy_name, role_name))
+        return False
+    return True
+
+
+def list_entities_for_policy(policy_name, path_prefix=None, entity_filter=None,
+                  region=None, key=None, keyid=None, profile=None):
+    '''
+    List entities that a policy is attached to.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iam.list_entities_for_policy mypolicy
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    params = {}
+    for arg in ('path_prefix', 'entity_filter'):
+        if locals()[arg] is not None:
+            params[arg] = locals()[arg]
+
+    policy_arn = _get_policy_arn(policy_name, region, key, keyid, profile)
+    try:
+        allret = {
+          'policy_groups': [],
+          'policy_users': [],
+          'policy_roles': [],
+        }
+        for ret in salt.utils.boto.paged_call(conn.list_entities_for_policy, policy_arn=policy_arn, **params):
+            for k, v in allret.iteritems():
+                v.extend(ret.get('list_entities_for_policy_response',{}).get('list_entities_for_policy_result',{}).get(k))
+        return allret
+    except boto.exception.BotoServerError as e:
+        log.debug(e)
+        msg = 'Failed to list {0} policy entities.'
+        log.error(msg.format(policy_name))
+        return []

--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -41,7 +41,6 @@ Connection module for Amazon IAM
 from __future__ import absolute_import
 import logging
 import json
-import urllib
 import yaml
 
 # Import salt libs
@@ -1591,7 +1590,6 @@ def create_policy(policy_name, policy_document, path=None, description=None,
     for arg in 'path', 'description':
         if locals()[arg] is not None:
             params[arg] = locals()[arg]
-    log.debug(policy_document)
     if policy_exists(policy_name, region, key, keyid, profile):
         return True
     try:
@@ -1695,7 +1693,7 @@ def get_policy_version(policy_name, version_id,
         ret = conn.get_policy_version(_get_policy_arn(policy_name,
                             region=region, key=key, keyid=keyid, profile=profile), version_id)
         retval = ret.get('get_policy_version_response', {}).get('get_policy_version_result', {}).get('policy_version', {})
-        retval['document'] = urllib.unquote(retval.get('document'))
+        retval['document'] = _unquote(retval.get('document'))
         return {'policy_version': retval}
     except boto.exception.BotoServerError:
         return None

--- a/salt/states/boto_iam.py
+++ b/salt/states/boto_iam.py
@@ -220,15 +220,16 @@ def user_absent(name, delete_keys=True, delete_mfa_devices=True, delete_profile=
     # delete the user's MFA tokens
     if delete_mfa_devices:
         devices = __salt__['boto_iam.get_all_mfa_devices'](user_name=name, region=region, key=key, keyid=keyid, profile=profile)
-        for d in devices:
-            serial = d['serial_number']
-            if __opts__['test']:
-                ret['comment'] = os.linesep.join([ret['comment'], 'IAM user {0} MFA device {1} is set to be deleted.'.format(name, serial)])
-                ret['result'] = None
-            else:
-                mfa_deleted = __salt__['boto_iam.deactivate_mfa_device'](user_name=name, serial=serial, region=region, key=key, keyid=keyid, profile=profile)
-                if mfa_deleted:
-                    ret['comment'] = os.linesep.join([ret['comment'], 'IAM user {0} MFA device {1} are deleted.'.format(name, serial)])
+        if devices:
+            for d in devices:
+                serial = d['serial_number']
+                if __opts__['test']:
+                    ret['comment'] = os.linesep.join([ret['comment'], 'IAM user {0} MFA device {1} is set to be deleted.'.format(name, serial)])
+                    ret['result'] = None
+                else:
+                    mfa_deleted = __salt__['boto_iam.deactivate_mfa_device'](user_name=name, serial=serial, region=region, key=key, keyid=keyid, profile=profile)
+                    if mfa_deleted:
+                        ret['comment'] = os.linesep.join([ret['comment'], 'IAM user {0} MFA device {1} are deleted.'.format(name, serial)])
     # delete the user's login profile
     if delete_profile:
         if __opts__['test']:

--- a/salt/states/boto_iam.py
+++ b/salt/states/boto_iam.py
@@ -1355,7 +1355,7 @@ def policy_present(name, policy_document, path=None, description=None,
             ret['comment'] = os.linesep.join([ret['comment'], 'Policy {0} has been created.'.format(name)])
         else:
             ret['result'] = False
-            ret['comment'] = 'Failed to update policy: {0}.'.format(r['error']['message'])
+            ret['comment'] = 'Failed to update policy.'
             ret['changes'] = {}
             return ret
     else:

--- a/salt/states/boto_iam.py
+++ b/salt/states/boto_iam.py
@@ -1354,11 +1354,11 @@ def policy_present(name, policy_document, path=None, description=None,
             ret['changes']['policy'] = created
             ret['comment'] = os.linesep.join([ret['comment'], 'Policy {0} has been created.'.format(name)])
     else:
-        policy = policy.get('policy',{})
+        policy = policy.get('policy', {})
         log.debug(policy)
         ret['comment'] = os.linesep.join([ret['comment'], 'Policy {0} is present.'.format(name)])
-    	_describe = __salt__['boto_iam.get_policy_version'](name, policy.get('default_version_id'),
-    	                                               region, key, keyid, profile).get('policy_version',{})
+        _describe = __salt__['boto_iam.get_policy_version'](name, policy.get('default_version_id'),
+                                                       region, key, keyid, profile).get('policy_version', {})
         if isinstance(_describe['document'], string_types):
             describeDict = json.loads(_describe['document'])
         else:
@@ -1372,7 +1372,7 @@ def policy_present(name, policy_document, path=None, description=None,
 
         if bool(r):
             if __opts__['test']:
-                msg = 'Policy {0} set to be modified.'.format(policyName)
+                msg = 'Policy {0} set to be modified.'.format(name)
                 ret['comment'] = msg
                 ret['result'] = None
                 return ret

--- a/salt/states/boto_iam_role.py
+++ b/salt/states/boto_iam_role.py
@@ -420,7 +420,7 @@ def _policies_attached(
                                        entity_filter='Role',
                                        region=region, key=key, keyid=keyid,
                                        profile=profile)
-        if {'role_name': name} not in entities.get('policy_roles'):
+        if {'role_name': name} not in entities.get('policy_roles', []):
             policies_to_attach.append(policy)
     _list = __salt__['boto_iam.list_attached_role_policies'](name, region, key, keyid,
                                                     profile)

--- a/salt/states/boto_iam_role.py
+++ b/salt/states/boto_iam_role.py
@@ -93,6 +93,7 @@ import salt.ext.six as six
 
 log = logging.getLogger(__name__)
 
+
 def __virtual__():
     '''
     Only load if boto is available.

--- a/salt/states/boto_iam_role.py
+++ b/salt/states/boto_iam_role.py
@@ -87,8 +87,8 @@ on the IAM role to be persistent. This functionality was added in 2015.8.0.
 
 '''
 from __future__ import absolute_import
-import salt.utils.dictupdate as dictupdate
 import logging
+import salt.utils.dictupdate as dictupdate
 import salt.ext.six as six
 
 log = logging.getLogger(__name__)

--- a/salt/states/boto_iam_role.py
+++ b/salt/states/boto_iam_role.py
@@ -88,8 +88,10 @@ on the IAM role to be persistent. This functionality was added in 2015.8.0.
 '''
 from __future__ import absolute_import
 import salt.utils.dictupdate as dictupdate
+import logging
 import salt.ext.six as six
 
+log = logging.getLogger(__name__)
 
 def __virtual__():
     '''
@@ -104,6 +106,7 @@ def present(
         path=None,
         policies=None,
         policies_from_pillars=None,
+        managed_policies=None,
         create_instance_profile=True,
         region=None,
         key=None,
@@ -133,6 +136,9 @@ def present(
         policies defined in the policies argument. If keys conflict, the keys
         in the policies argument will override the keys defined in
         policies_from_pillars.
+
+    managed_policies
+        A list of (AWS or Customer) managed policies to be attached to the role.
 
     create_instance_profile
         A boolean of whether or not to create an instance profile and associate
@@ -165,6 +171,8 @@ def present(
         policies = {}
     if not policies_from_pillars:
         policies_from_pillars = []
+    if not managed_policies:
+        managed_policies = []
     _policies = {}
     for policy in policies_from_pillars:
         _policy = __salt__['pillar.get'](policy)
@@ -193,6 +201,11 @@ def present(
                 return ret
     _ret = _policies_present(name, _policies, region, key, keyid, profile,
                              delete_policies)
+    ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
+    ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
+    if not _ret['result']:
+        ret['result'] = _ret['result']
+    _ret = _policies_attached(name, managed_policies, region, key, keyid, profile)
     ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
     if not _ret['result']:
@@ -391,6 +404,81 @@ def _policies_present(
     return ret
 
 
+def _policies_attached(
+        name,
+        managed_policies=None,
+        region=None,
+        key=None,
+        keyid=None,
+        profile=None):
+    ret = {'result': True, 'comment': '', 'changes': {}}
+    policies_to_attach = []
+    policies_to_detach = []
+    for policy in managed_policies or []:
+        entities = __salt__['boto_iam.list_entities_for_policy'](policy,
+                                       entity_filter='Role',
+                                       region=region, key=key, keyid=keyid,
+                                       profile=profile)
+        if {'role_name': name} not in entities.get('policy_roles'):
+            policies_to_attach.append(policy)
+    _list = __salt__['boto_iam.list_attached_role_policies'](name, region, key, keyid,
+                                                    profile)
+    oldpolicies = [x.get('policy_arn') for x in _list]
+    for policy_data in _list:
+        if policy_data.get('policy_name') not in managed_policies \
+                  and policy_data.get('policy_arn') not in managed_policies:
+            policies_to_detach.append(policy_data.get('policy_arn'))
+    if policies_to_attach or policies_to_detach:
+        _to_modify = list(policies_to_detach)
+        _to_modify.extend(policies_to_attach)
+        if __opts__['test']:
+            msg = '{0} policies to be modified on role {1}.'
+            ret['comment'] = msg.format(', '.join(_to_modify), name)
+            ret['result'] = None
+            return ret
+        ret['changes']['old'] = {'managed_policies': oldpolicies}
+        for policy_name in policies_to_attach:
+            policy_set = __salt__['boto_iam.attach_role_policy'](policy_name,
+                                                                 name,
+                                                                 region, key,
+                                                                 keyid,
+                                                                 profile)
+            if not policy_set:
+                _list = __salt__['boto_iam.list_attached_role_policies'](name, region,
+                                                                key, keyid,
+                                                                profile)
+                newpolicies = [x.get('policy_arn') for x in _list]
+                ret['changes']['new'] = {'manged_policies': newpolicies}
+                ret['result'] = False
+                msg = 'Failed to add policy {0} to role {1}'
+                ret['comment'] = msg.format(policy_name, name)
+                return ret
+        for policy_name in policies_to_detach:
+            policy_unset = __salt__['boto_iam.detach_role_policy'](policy_name,
+                                                                   name,
+                                                                   region, key,
+                                                                   keyid,
+                                                                   profile)
+            if not policy_unset:
+                _list = __salt__['boto_iam.list_attached_role_policies'](name, region,
+                                                                key, keyid,
+                                                                profile)
+                newpolicies = [x.get('policy_arn') for x in _list]
+                ret['changes']['new'] = {'managed_policies': newpolicies}
+                ret['result'] = False
+                msg = 'Failed to remove policy {0} from role {1}'
+                ret['comment'] = msg.format(policy_name, name)
+                return ret
+        _list = __salt__['boto_iam.list_attached_role_policies'](name, region, key,
+                                                        keyid, profile)
+        newpolicies = [x.get('policy_arn') for x in _list]
+        log.debug(newpolicies)
+        ret['changes']['new'] = {'managed_policies': newpolicies}
+        msg = '{0} policies modified on role {1}.'
+        ret['comment'] = msg.format(', '.join(newpolicies), name)
+    return ret
+
+
 def absent(
         name,
         region=None,
@@ -418,6 +506,13 @@ def absent(
     '''
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     _ret = _policies_absent(name, region, key, keyid, profile)
+    ret['changes'] = _ret['changes']
+    ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
+    if not _ret['result']:
+        ret['result'] = _ret['result']
+        if ret['result'] is False:
+            return ret
+    _ret = _policies_detached(name, region, key, keyid, profile)
     ret['changes'] = _ret['changes']
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
     if not _ret['result']:
@@ -547,6 +642,51 @@ def _policies_absent(
     ret['changes']['new'] = {'policies': _list}
     msg = '{0} policies removed from role {1}.'
     ret['comment'] = msg.format(', '.join(_list), name)
+    return ret
+
+
+def _policies_detached(
+        name,
+        region=None,
+        key=None,
+        keyid=None,
+        profile=None):
+    ret = {'result': True, 'comment': '', 'changes': {}}
+    _list = __salt__['boto_iam.list_attached_role_policies'](role_name=name,
+                        region=region, key=key, keyid=keyid, profile=profile)
+    oldpolicies = [x.get('policy_arn') for x in _list]
+    if not _list:
+        msg = 'No attached policies in role {0}.'.format(name)
+        ret['comment'] = msg
+        return ret
+    if __opts__['test']:
+        msg = '{0} policies to be detached from role {1}.'
+        ret['comment'] = msg.format(', '.join(oldpolicies), name)
+        ret['result'] = None
+        return ret
+    ret['changes']['old'] = {'managed_policies': oldpolicies}
+    for policy_arn in oldpolicies:
+        policy_unset = __salt__['boto_iam.detach_role_policy'](policy_arn,
+                                                               name,
+                                                               region, key,
+                                                               keyid,
+                                                               profile)
+        if not policy_unset:
+            _list = __salt__['boto_iam.list_attached_role_policies'](name, region,
+                                                            key, keyid,
+                                                            profile)
+            newpolicies = [x.get('policy_arn') for x in _list]
+            ret['changes']['new'] = {'managed_policies': newpolicies}
+            ret['result'] = False
+            msg = 'Failed to detach {0} from role {1}'
+            ret['comment'] = msg.format(policy_arn, name)
+            return ret
+    _list = __salt__['boto_iam.list_attached_role_policies'](name, region, key,
+                                                    keyid, profile)
+    newpolicies = [x.get('policy_arn') for x in _list]
+    ret['changes']['new'] = {'managed_policies': newpolicies}
+    msg = '{0} policies detached from role {1}.'
+    ret['comment'] = msg.format(', '.join(newpolicies), name)
     return ret
 
 

--- a/salt/utils/boto.py
+++ b/salt/utils/boto.py
@@ -265,3 +265,18 @@ def assign_funcs(modname, service, module=None, pack=None):
     # TODO: Remove this and import salt.utils.exactly_one into boto_* modules instead
     # Leaving this way for now so boto modules can be back ported
     setattr(mod, '_exactly_one', exactly_one)
+
+
+def paged_call(function, *args, **kwargs):
+    """Retrieve full set of values from a boto API call that may truncate
+    its results, yielding each page as it is obtained.
+    """
+    marker_flag = kwargs.pop('marker_flag','marker')
+    marker_arg = kwargs.pop('marker_flag','marker')
+    while True:
+        ret = function(*args, **kwargs)
+        marker = ret.get(marker_flag)
+        yield ret
+        if not marker:
+            break
+        kwargs[marker_arg] = marker

--- a/salt/utils/boto.py
+++ b/salt/utils/boto.py
@@ -271,8 +271,8 @@ def paged_call(function, *args, **kwargs):
     """Retrieve full set of values from a boto API call that may truncate
     its results, yielding each page as it is obtained.
     """
-    marker_flag = kwargs.pop('marker_flag','marker')
-    marker_arg = kwargs.pop('marker_flag','marker')
+    marker_flag = kwargs.pop('marker_flag', 'marker')
+    marker_arg = kwargs.pop('marker_flag', 'marker')
     while True:
         ret = function(*args, **kwargs)
         marker = ret.get(marker_flag)

--- a/salt/utils/boto3.py
+++ b/salt/utils/boto3.py
@@ -291,8 +291,8 @@ def paged_call(function, *args, **kwargs):
     """Retrieve full set of values from a boto3 API call that may truncate
     its results, yielding each page as it is obtained.
     """
-    marker_flag = kwargs.pop('marker_flag','NextMarker')
-    marker_arg = kwargs.pop('marker_flag','Marker')
+    marker_flag = kwargs.pop('marker_flag', 'NextMarker')
+    marker_arg = kwargs.pop('marker_flag', 'Marker')
     while True:
         ret = function(*args, **kwargs)
         marker = ret.get(marker_flag)

--- a/salt/utils/boto3.py
+++ b/salt/utils/boto3.py
@@ -287,10 +287,12 @@ def assign_funcs(modname, service, module=None):
     setattr(mod, '_exactly_one', exactly_one)
 
 
-def paged_call(function, marker_flag='NextMarker', marker_arg='Marker', *args, **kwargs):
+def paged_call(function, *args, **kwargs):
     """Retrieve full set of values from a boto3 API call that may truncate
     its results, yielding each page as it is obtained.
     """
+    marker_flag = kwargs.pop('marker_flag','NextMarker')
+    marker_arg = kwargs.pop('marker_flag','Marker')
     while True:
         ret = function(*args, **kwargs)
         marker = ret.get(marker_flag)

--- a/tests/unit/states/boto_iam_role_test.py
+++ b/tests/unit/states/boto_iam_role_test.py
@@ -97,6 +97,7 @@ class BotoIAMRoleTestCase(TestCase):
                          'boto_iam.build_policy': mock_policy,
                          'boto_iam.update_assume_role_policy': mock_bool,
                          'boto_iam.instance_profile_exists': mock_ipe,
+                         'boto_iam.list_attached_role_policies': mock_lst,
                          'boto_iam.create_instance_profile': mock_bool,
                          'boto_iam.profile_associated': mock_pa,
                          'boto_iam.associate_profile_to_role': mock_bool,
@@ -121,7 +122,7 @@ class BotoIAMRoleTestCase(TestCase):
                 ret.update({'comment': comt})
 
                 self.assertDictEqual(boto_iam_role.present(name), ret)
-                comt = (' myrole role present.   ')
+                comt = (' myrole role present.    ')
                 ret.update({'comment': comt, 'result': True})
                 self.assertDictEqual(boto_iam_role.present(name), ret)
 
@@ -142,12 +143,14 @@ class BotoIAMRoleTestCase(TestCase):
                                       False, False, True, False, False, False,
                                       True])
         mock_bool = MagicMock(return_value=False)
+        mock_lst = MagicMock(return_value=[])
         with patch.dict(boto_iam_role.__salt__,
                         {'boto_iam.list_role_policies': mock,
                          'boto_iam.delete_role_policy': mock_bool,
                          'boto_iam.profile_associated': mock,
                          'boto_iam.disassociate_profile_from_role': mock_bool,
                          'boto_iam.instance_profile_exists': mock,
+                         'boto_iam.list_attached_role_policies': mock_lst,
                          'boto_iam.delete_instance_profile': mock_bool,
                          'boto_iam.role_exists': mock,
                          'boto_iam.delete_role': mock_bool}):
@@ -158,17 +161,20 @@ class BotoIAMRoleTestCase(TestCase):
                                         'old': {'policies': ['mypolicy']}}})
                 self.assertDictEqual(boto_iam_role.absent(name), ret)
 
-                comt = (' No policies in role myrole. Failed to disassociate '
+                comt = (' No policies in role myrole.'
+                        ' No attached policies in role myrole. Failed to disassociate '
                         'myrole instance profile from myrole role.')
                 ret.update({'comment': comt, 'changes': {}})
                 self.assertDictEqual(boto_iam_role.absent(name), ret)
 
-                comt = (' No policies in role myrole.  '
-                        'Failed to delete myrole instance profile.')
+                comt = (' No policies in role myrole.'
+                        ' No attached policies in role myrole. '
+                        ' Failed to delete myrole instance profile.')
                 ret.update({'comment': comt, 'changes': {}})
                 self.assertDictEqual(boto_iam_role.absent(name), ret)
 
-                comt = (' No policies in role myrole.  myrole instance profile '
+                comt = (' No policies in role myrole.'
+                        ' No attached policies in role myrole.  myrole instance profile '
                         'does not exist. Failed to delete myrole iam role.')
                 ret.update({'comment': comt, 'changes': {}})
                 self.assertDictEqual(boto_iam_role.absent(name), ret)


### PR DESCRIPTION
Managed policies are a relatively new feature of IAM. This change adds support for them to boto_iam and boto_iam_role.

This adds create, delete, and related functionality for customer managed policies themselves. In additional, the states for user, group, and role have all been updated to allow attachment of both customer and AWS managed policies.

Given only a policy name, this assumes a customer managed policy is what's desired and generates an ARN for that for the config. If you want AWS managed policies, you have to use their full ARN.

Users of boto_iam for users, groups, and roles previously should note that the previous behavior was to ignore managed policies, so if you attached some manually, they would remain undisturbed. Now they're managed, so if you haven't specified them in your SLS, any that were manually attached will be detached when you apply the state.

Along with this change, the missing "group_absent" state was also added, to make group management symmetrical.
