### PR TITLE
[dockerng] Fix when ports are integers

### DIFF
--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -217,6 +217,8 @@ def _compare(actual, create_kwargs, defaults_from_image):
             actual_ports = sorted(actual_data)
             desired_ports = []
             for port_def in data:
+                if isinstance(port_def, six.integer_types):
+                    port_def = str(port_def)
                 if isinstance(port_def, tuple):
                     desired_ports.append('{0}/{1}'.format(*port_def))
                 elif '/' not in port_def:


### PR DESCRIPTION
ports will most likely be defined as integer

follow up for #31326
