### PR TITLE
Don't send REQ while another one is waiting for response.

### DIFF
--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -736,7 +736,7 @@ class SaltMessageClient(object):
         while not self._connecting_future.done() or self._connecting_future.result() is not True:
             yield self._connecting_future
         while len(self.send_queue) > 0:
-            message_id, item = self.send_queue.pop(0)
+            message_id, item = self.send_queue[0]
             try:
                 yield self._stream.write(item)
             # if the connection is dead, lets fail this send, and make sure we
@@ -744,6 +744,7 @@ class SaltMessageClient(object):
             except tornado.iostream.StreamClosedError as e:
                 self.send_future_map.pop(message_id).set_exception(Exception())
                 self.remove_message_timeout(message_id)
+                del self.send_queue[0]
                 if self._closing:
                     return
                 if self.disconnect_callback:
@@ -752,6 +753,7 @@ class SaltMessageClient(object):
                 if self._connecting_future.done():
                     self._connecting_future = self.connect()
                 yield self._connecting_future
+            del self.send_queue[0]
 
     def _message_id(self):
         wrap = False


### PR DESCRIPTION
Relates: #30183

The message has to be removed from the queue the only _after_ it's
already processed to don't confuse send() and timeout_message() functionality that expects
empty queue means: there's no active sendings.
