### PR TITLE
utils.process: reduce log level

### DIFF
--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -372,7 +372,7 @@ class ProcessManager(object):
             signal.signal(signal.SIGINT, self.kill_children)
 
         while True:
-            log.debug('Process manager iteration')
+            log.trace('Process manager iteration')
             try:
                 # in case someone died while we were waiting...
                 self.check_children()


### PR DESCRIPTION
Similar to 33844c3c.  Without this, the minion debug log fills up with
`Process manager iteration` at a rate of about 1 every 10-15 seconds.
