### PR TITLE
Fix uppercase computer name issue

### DIFF
--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -390,8 +390,45 @@ def get_system_info():
         name, description, version, etc...
     :rtype: dict
     '''
-    system_info = win32net.NetServerGetInfo(None, 101)
-    return system_info
+    ps_state = {1: 'Other',
+                2: 'Unknown',
+                3: 'Safe',
+                4: 'Warning',
+                5: 'Critical',
+                6: 'Non-recoverable'}
+    os_type = {1: 'Work Station',
+               2: 'Domain Controller',
+               3: 'Server'}
+    pythoncom.CoInitialize()
+    c = wmi.WMI()
+    system = c.Win32_OperatingSystem()[0]
+    ret = {'name': system.CSName,
+           'description': system.Description,
+           'install_date': system.InstallDate,
+           'last_boot': system.LastBootUpTime,
+           'os_manufacturer': system.Manufacturer,
+           'os_name': system.Caption,
+           'users': system.NumberOfUsers,
+           'organization': system.Organization,
+           'os_architecture': system.OSArchitecture,
+           'primary': system.Primary,
+           'os_type': os_type[system.ProductType],
+           'registered_user': system.RegisteredUser,
+           'serial_number': system.SerialNumber,
+           'service_pack_maj': system.ServicePackMajorVersion,
+           'service_pack_min': system.ServicePackMinorVersion,
+           'system_directory': system.SystemDirectory,
+           'system_drive': system.SystemDrive,
+           'os_version': system.Version,
+           'windows_directory': system.WindowsDirectory}
+
+    system = c.Win32_ComputerSystem()[0]
+    ret.update({'processors': system.NumberOfProcessors,
+                'processors_logical': system.NumberOfLogicalProcessors,
+                'power_supply_state': ps_state[system.PowerSupplyState],
+                'status': system.Status,
+                'system_type': system.SystemType})
+    return ret
 
 
 def get_computer_desc():
@@ -407,7 +444,7 @@ def get_computer_desc():
 
         salt 'minion-id' system.get_computer_desc
     '''
-    desc = get_system_info()['comment']
+    desc = get_system_info()['description']
     return desc if desc else False
 
 

--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -322,7 +322,7 @@ def get_pending_computer_name():
 
         salt 'minion-id' system.get_pending_computer_name
     '''
-    current = get_computer_name()
+    current = get_computer_name().upper()
     pending = read_value('HKLM',
                          r'SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName',
                          'ComputerName')['vdata']

--- a/salt/states/win_system.py
+++ b/salt/states/win_system.py
@@ -87,8 +87,8 @@ def computer_name(name):
     name
         The desired computer name
     '''
-    # Just in case someone decides to enter a numeric description
-    name = str(name).upper()
+    # Just in case someone decides to enter a numeric name
+    name = str(name)
 
     ret = {'name': name,
            'changes': {},

--- a/salt/states/win_system.py
+++ b/salt/states/win_system.py
@@ -100,7 +100,7 @@ def computer_name(name):
 
     if before_name == name and pending_name is None:
         return ret
-    elif pending_name == name:
+    elif pending_name == name.upper():
         ret['comment'] = ('The current computer name is {0!r}, but will be '
                           'changed to {1!r} on the next reboot'
                           .format(before_name, name))
@@ -115,7 +115,7 @@ def computer_name(name):
     if result is not False:
         after_name = result['Computer Name']['Current']
         after_pending = result['Computer Name'].get('Pending')
-        if ((after_pending is not None and after_pending == name) or
+        if ((after_pending is not None and after_pending == name.upper()) or
                 (after_pending is None and after_name == name)):
             ret['comment'] = 'Computer name successfully set to {0!r}'.format(name)
             if after_pending is not None:

--- a/tests/unit/states/win_system_test.py
+++ b/tests/unit/states/win_system_test.py
@@ -63,27 +63,27 @@ class WinSystemTestCase(TestCase):
         '''
             Test to manage the computer's name
         '''
-        ret = {'name': 'SALT',
+        ret = {'name': 'salt',
                'changes': {},
                'result': True,
                'comment': ''}
-        mock = MagicMock(return_value='SALT')
+        mock = MagicMock(return_value='salt')
         with patch.dict(win_system.__salt__,
                         {"system.get_computer_name": mock}):
             mock = MagicMock(side_effect=[None, 'SALT', 'Stack', 'stack'])
             with patch.dict(win_system.__salt__,
                             {"system.get_pending_computer_name": mock}):
-                ret.update({'comment': "Computer name already set to 'SALT'"})
+                ret.update({'comment': "Computer name already set to 'salt'"})
                 self.assertDictEqual(win_system.computer_name('salt'), ret)
 
                 ret.update({'comment': "The current computer name"
-                            " is 'SALT', but will be changed to 'SALT' on"
+                            " is 'salt', but will be changed to 'salt' on"
                             " the next reboot"})
                 self.assertDictEqual(win_system.computer_name('salt'), ret)
 
                 with patch.dict(win_system.__opts__, {"test": True}):
                     ret.update({'result': None, 'comment': "Computer name will"
-                                " be changed to 'SALT'"})
+                                " be changed to 'salt'"})
                     self.assertDictEqual(win_system.computer_name('salt'), ret)
 
                 with patch.dict(win_system.__opts__, {"test": False}):
@@ -91,7 +91,7 @@ class WinSystemTestCase(TestCase):
                     with patch.dict(win_system.__salt__,
                                     {"system.set_computer_name": mock}):
                         ret.update({'comment': "Unable to set computer name"
-                                    " to 'SALT'", 'result': False})
+                                    " to 'salt'", 'result': False})
                         self.assertDictEqual(win_system.computer_name('salt'),
                                              ret)
 


### PR DESCRIPTION
Fixes Capitalized Computer name for states and for current in set_computer_name function
No way to fix the capitalization in Pending Computer name. (That's how it's stored in the registry). I couldn't find where windows stores the un-capitalized version of the pending computer name.

Execution Module returns:

```
gringo:
    ----------
    Computer Name:
        ----------
        Current:
            Gringo
        Pending:
            GRINGO_TEST
```

State returns:

```
gringo:
----------
          ID: set_name
    Function: system.computer_name
        Name: Gringo-Test
      Result: True
     Comment: Computer name successfully set to 'Gringo-Test' (reboot required for change to take effect)
     Started: 16:28:24.955000
    Duration: 16.0 ms
     Changes:
              ----------
              new:
                  Gringo-Test
              old:
                  Gringo

Summary for gringo
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
```

Also adds more computer information for get_system_info.

Fixes: https://github.com/saltstack/salt/issues/31290
Supercedes: https://github.com/saltstack/salt/pull/31222
