### PR TITLE
Zypper refresh handling

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1244,9 +1244,14 @@ def _get_patterns(installed_only=None):
     return patterns
 
 
-def list_patterns():
+def list_patterns(refresh=False):
     '''
     List all known patterns from available repos.
+
+    refresh
+        force a refresh if set to True.
+        If set to False (default) it depends on zypper if a refresh is
+        executed.
 
     CLI Examples:
 
@@ -1254,6 +1259,9 @@ def list_patterns():
 
         salt '*' pkg.list_patterns
     '''
+    if salt.utils.is_true(refresh):
+        refresh_db()
+
     return _get_patterns()
 
 
@@ -1270,9 +1278,14 @@ def list_installed_patterns():
     return _get_patterns(installed_only=True)
 
 
-def search(criteria):
+def search(criteria, refresh=False):
     '''
     List known packags, available to the system.
+
+    refresh
+        force a refresh if set to True.
+        If set to False (default) it depends on zypper if a refresh is
+        executed.
 
     CLI Examples:
 
@@ -1280,6 +1293,9 @@ def search(criteria):
 
         salt '*' pkg.search <criteria>
     '''
+    if salt.utils.is_true(refresh):
+        refresh_db()
+
     doc = dom.parseString(__salt__['cmd.run'](_zypper('--xmlout', 'se', criteria),
                                               output_loglevel='trace'))
     solvables = doc.getElementsByTagName('solvable')
@@ -1310,12 +1326,17 @@ def _get_first_aggregate_text(node_list):
     return '\n'.join(out)
 
 
-def list_products(all=False):
+def list_products(all=False, refresh=False):
     '''
     List all available or installed SUSE products.
 
     all
         List all products available or only installed. Default is False.
+
+    refresh
+        force a refresh if set to True.
+        If set to False (default) it depends on zypper if a refresh is
+        executed.
 
     Includes handling for OEM products, which read the OEM productline file
     and overwrite the release value.
@@ -1327,6 +1348,9 @@ def list_products(all=False):
         salt '*' pkg.list_products
         salt '*' pkg.list_products all=True
     '''
+    if salt.utils.is_true(refresh):
+        refresh_db()
+
     ret = list()
     OEM_PATH = "/var/lib/suseRegister/OEM"
     cmd = _zypper('-x', 'products')
@@ -1356,9 +1380,14 @@ def list_products(all=False):
     return ret
 
 
-def download(*packages):
+def download(refresh=False, *packages):
     """
     Download packages to the local disk.
+
+    refresh
+        force a refresh if set to True.
+        If set to False (default) it depends on zypper if a refresh is
+        executed.
 
     CLI example:
 
@@ -1369,6 +1398,9 @@ def download(*packages):
     """
     if not packages:
         raise CommandExecutionError("No packages has been specified.")
+
+    if salt.utils.is_true(refresh):
+        refresh_db()
 
     doc = dom.parseString(__salt__['cmd.run'](
         _zypper('-x', 'download', *packages), output_loglevel='trace'))

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -74,6 +74,11 @@ def list_upgrades(refresh=True):
     '''
     List all available package upgrades on this system
 
+    refresh
+        force a refresh if set to True (default).
+        If set to False it depends on zypper if a refresh is
+        executed.
+
     CLI Example:
 
     .. code-block:: bash
@@ -173,6 +178,11 @@ def info_installed(*names, **kwargs):
 def info_available(*names, **kwargs):
     '''
     Return the information of the named package available for the system.
+
+    refresh
+        force a refresh if set to True (default).
+        If set to False it depends on zypper if a refresh is
+        executed or not.
 
     CLI example:
 
@@ -656,7 +666,7 @@ def mod_repo(repo, **kwargs):
 
 def refresh_db():
     '''
-    Just run a ``zypper refresh``, return a dict::
+    Force a repository refresh by calling ``zypper refresh --force``, return a dict::
 
         {'<database name>': Bool}
 
@@ -666,7 +676,7 @@ def refresh_db():
 
         salt '*' pkg.refresh_db
     '''
-    cmd = _zypper('refresh')
+    cmd = _zypper('refresh', '--force')
     ret = {}
     call = __salt__['cmd.run_all'](cmd, output_loglevel='trace')
     if call['retcode'] != 0:
@@ -703,7 +713,7 @@ def install(name=None,
             version=None,
             **kwargs):
     '''
-    Install the passed package(s), add refresh=True to run 'zypper refresh'
+    Install the passed package(s), add refresh=True to force a 'zypper refresh'
     before package is installed.
 
     name
@@ -720,7 +730,9 @@ def install(name=None,
             salt '*' pkg.install <package name>
 
     refresh
-        Whether or not to refresh the package database before installing.
+        force a refresh if set to True.
+        If set to False (default) it depends on zypper if a refresh is
+        executed.
 
     fromrepo
         Specify a package repository to install from.
@@ -768,6 +780,9 @@ def install(name=None,
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
     '''
+    if salt.utils.is_true(refresh):
+        refresh_db()
+
     try:
         pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name, pkgs, sources, **kwargs)
     except MinionError as exc:
@@ -814,8 +829,6 @@ def install(name=None,
     else:
         fromrepoopt = ''
     cmd_install = _zypper()
-    if not refresh:
-        cmd_install.append('--no-refresh')
     cmd_install += ['install', '--name', '--auto-agree-with-licenses']
     if downloadonly:
         cmd_install.append('--download-only')
@@ -849,6 +862,11 @@ def install(name=None,
 def upgrade(refresh=True):
     '''
     Run a full system upgrade, a zypper upgrade
+
+    refresh
+        force a refresh if set to True (default).
+        If set to False it depends on zypper if a refresh is
+        executed.
 
     Return a dict containing the new package names and versions::
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -85,7 +85,7 @@ def list_upgrades(refresh=True):
 
         salt '*' pkg.list_upgrades
     '''
-    if salt.utils.is_true(refresh):
+    if refresh:
         refresh_db()
     ret = {}
     call = __salt__['cmd.run_all'](
@@ -199,7 +199,7 @@ def info_available(*names, **kwargs):
         names = sorted(list(set(names)))
 
     # Refresh db before extracting the latest package
-    if salt.utils.is_true(kwargs.pop('refresh', True)):
+    if kwargs.pop('refresh', True):
         refresh_db()
 
     pkg_info = []
@@ -780,7 +780,7 @@ def install(name=None,
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
     '''
-    if salt.utils.is_true(refresh):
+    if refresh:
         refresh_db()
 
     try:
@@ -884,7 +884,7 @@ def upgrade(refresh=True):
            'comment': '',
     }
 
-    if salt.utils.is_true(refresh):
+    if refresh:
         refresh_db()
     old = list_pkgs()
     cmd = _zypper('update', '--auto-agree-with-licenses')
@@ -1259,7 +1259,7 @@ def list_patterns(refresh=False):
 
         salt '*' pkg.list_patterns
     '''
-    if salt.utils.is_true(refresh):
+    if refresh:
         refresh_db()
 
     return _get_patterns()
@@ -1293,7 +1293,7 @@ def search(criteria, refresh=False):
 
         salt '*' pkg.search <criteria>
     '''
-    if salt.utils.is_true(refresh):
+    if refresh:
         refresh_db()
 
     doc = dom.parseString(__salt__['cmd.run'](_zypper('--xmlout', 'se', criteria),
@@ -1348,7 +1348,7 @@ def list_products(all=False, refresh=False):
         salt '*' pkg.list_products
         salt '*' pkg.list_products all=True
     '''
-    if salt.utils.is_true(refresh):
+    if refresh:
         refresh_db()
 
     ret = list()
@@ -1399,7 +1399,7 @@ def download(refresh=False, *packages):
     if not packages:
         raise CommandExecutionError("No packages has been specified.")
 
-    if salt.utils.is_true(refresh):
+    if refresh:
         refresh_db()
 
     doc = dom.parseString(__salt__['cmd.run'](

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -199,7 +199,7 @@ def info_available(*names, **kwargs):
         names = sorted(list(set(names)))
 
     # Refresh db before extracting the latest package
-    if kwargs.pop('refresh', True):
+    if kwargs.get('refresh', True):
         refresh_db()
 
     pkg_info = []


### PR DESCRIPTION
clarify and unify zypper refresh handling.

Requesting refresh is a force refresh. If not forcing refresh, we let zypper decide if a refresh is needed or not.

In the meanwhile zypper has for all refresh operations a threshold to prevent useless refreshes. It would be good to trust zypper here.

@isbm : maybe you want to check this again.
