### PR TITLE
Bring up ext_pillar rendering errors as well

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -642,13 +642,14 @@ class Pillar(object):
                                     errors += err
         return state, mods, errors
 
-    def render_pillar(self, matches):
+    def render_pillar(self, matches, errors=None):
         '''
         Extract the sls pillar files from the matches and render them into the
         pillar
         '''
         pillar = copy.copy(self.pillar_override)
-        errors = []
+        if errors is None:
+            errors = []
         for saltenv, pstates in six.iteritems(matches):
             mods = set()
             for sls in pstates:
@@ -708,22 +709,26 @@ class Pillar(object):
                                             val)
         return ext
 
-    def ext_pillar(self, pillar, pillar_dirs):
+    def ext_pillar(self, pillar, pillar_dirs, errors=None):
         '''
         Render the external pillar data
         '''
+        if errors is None:
+            errors = []
         if 'ext_pillar' not in self.opts:
-            return pillar
+            return pillar, errors
         if not isinstance(self.opts['ext_pillar'], list):
-            log.critical('The "ext_pillar" option is malformed')
-            return pillar
+            errors.append('The "ext_pillar" option is malformed')
+            log.critical(errors[-1])
+            return pillar, errors
         ext = None
         # Bring in CLI pillar data
         pillar.update(self.pillar_override)
         for run in self.opts['ext_pillar']:
             if not isinstance(run, dict):
-                log.critical('The "ext_pillar" option is malformed')
-                return {}
+                errors.append('The "ext_pillar" option is malformed')
+                log.critical(errors[-1])
+                return {}, errors
             for key, val in six.iteritems(run):
                 if key not in self.ext_pillars:
                     err = ('Specified ext_pillar interface {0} is '
@@ -749,12 +754,8 @@ class Pillar(object):
                                                          pillar_dirs,
                                                          key)
                 except Exception as exc:
-                    log.exception(
-                            'Failed to load ext_pillar {0}: {1}'.format(
-                                key,
-                                exc
-                                )
-                            )
+                    errors.append('Failed to load ext_pillar {0}: {1}'.format(
+                        key, exc))
             if ext:
                 pillar = merge(
                     pillar,
@@ -763,7 +764,7 @@ class Pillar(object):
                     self.opts.get('renderer', 'yaml'),
                     self.opts.get('pillar_merge_lists', False))
                 ext = None
-        return pillar
+        return pillar, errors
 
     def compile_pillar(self, ext=True, pillar_dirs=None):
         '''
@@ -772,9 +773,9 @@ class Pillar(object):
         top, top_errors = self.get_top()
         if ext:
             if self.opts.get('ext_pillar_first', False):
-                self.opts['pillar'] = self.ext_pillar({}, pillar_dirs)
+                self.opts['pillar'], errors = self.ext_pillar({}, pillar_dirs)
                 matches = self.top_matches(top)
-                pillar, errors = self.render_pillar(matches)
+                pillar, errors = self.render_pillar(matches, errors=errors)
                 pillar = merge(pillar,
                                self.opts['pillar'],
                                self.merge_strategy,
@@ -783,7 +784,8 @@ class Pillar(object):
             else:
                 matches = self.top_matches(top)
                 pillar, errors = self.render_pillar(matches)
-                pillar = self.ext_pillar(pillar, pillar_dirs)
+                pillar, errors = self.ext_pillar(
+                    pillar, pillar_dirs, errors=errors)
         else:
             matches = self.top_matches(top)
             pillar, errors = self.render_pillar(matches)


### PR DESCRIPTION
i dont know if that can go in 2015.8 considering the non trivial change.

Idea is to also bring the errors from ext_pillars inside the _errors subdict for pillar to bring errors as with static sls files.

Indeed, for now, the errors show up inside logs, but up then, as this is just a log, anything will be ignored, sls will execute and etc, even if the pillar is lacking critical information to run
