### PR TITLE
Set auth retry count to 0 if multimaster mode is failover

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -422,6 +422,7 @@ class MinionBase(object):
                              ' {0}'.format(opts['master']))
                     if opts['master_shuffle']:
                         shuffle(opts['master'])
+                    opts['auth_tries'] = 0
                 # if opts['master'] is a str and we have never created opts['master_list']
                 elif isinstance(opts['master'], str) and ('master_list' not in opts):
                     # We have a string, but a list was what was intended. Convert.


### PR DESCRIPTION
Fixes: #30183.

This affects the only ZeroMQ transport. This makes minion to don't retry auth on master fail if the multimaster and failover are set in options.
