### PR TITLE
Master running under non-privileged account and pygit2 as gitfs provider fails pre-flight check

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -916,7 +916,7 @@ class Pygit2(GitProvider):
                     # https://github.com/libgit2/libgit2/issues/2122
                     if "Error stat'ing config file" not in str(exc):
                         raise
-                    home = pwd.getpwnam(salt.utils.get_user).pw_dir
+                    home = pwd.getpwnam(salt.utils.get_user()).pw_dir
                     pygit2.settings.search_path[pygit2.GIT_CONFIG_LEVEL_GLOBAL] = home
                     self.repo = pygit2.Repository(self.cachedir)
             except KeyError:


### PR DESCRIPTION
The following config always triggers the issue when master is started as system service. The same config works when master is started interactively from the configured non-privileged account:

```
user: salt
fileserver_backend:
  - git
gitfs_provider: pygit2
```

Stack trace for the exception

```
2016-02-20 14:03:05,970 [salt.utils.gitfs ][CRITICAL][7894] Exception caught while initializing gitfs remote 'ssh://git@git/salt.git': must be string, not function
Traceback (most recent call last):
  File "/usr/lib64/python2.7/site-packages/salt/utils/gitfs.py", line 263, in __init__
    self.new = self.init_remote()
  File "/usr/lib64/python2.7/site-packages/salt/utils/gitfs.py", line 918, in init_remote
    home = pwd.getpwnam(salt.utils.get_user).pw_dir
TypeError: must be string, not 
2016-02-20 14:03:05,971 [salt.master      ][CRITICAL][7894] Failed to load gitfs
2016-02-20 14:03:05,971 [salt.master      ][CRITICAL][7894] Master failed pre flight checks, exiting
```

```
salt --versions-report
Salt Version:
           Salt: 2015.8.7

Dependency Versions:
         Jinja2: 2.7.3
       M2Crypto: 0.22
           Mako: Not Installed
         PyYAML: 3.11
          PyZMQ: 14.4.1
         Python: 2.7.10 (default, Nov 21 2015, 14:26:07)
           RAET: Not Installed
        Tornado: 4.2.1
            ZMQ: 4.1.1
           cffi: 1.2.1
       cherrypy: Not Installed
       dateutil: Not Installed
          gitdb: Not Installed
      gitpython: Not Installed
          ioflo: Not Installed
        libgit2: 0.22.3
        libnacl: Not Installed
   msgpack-pure: Not Installed
 msgpack-python: 0.4.6
   mysql-python: 1.2.5
      pycparser: 2.14
       pycrypto: 2.6.1
         pygit2: 0.22.1
   python-gnupg: Not Installed
          smmap: Not Installed
        timelib: Not Installed

System Versions:
           dist: gentoo 2.2 
        machine: x86_64
        release: 4.1.15-gentoo-r1-r4
         system: Gentoo Base System 2.2 
```
