### PR TITLE
Added sanity check: is 'pillar' in self.opts

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -867,7 +867,7 @@ class Schedule(object):
                 if isinstance(data['when'], list):
                     _when = []
                     for i in data['when']:
-                        if ('whens' in self.opts['pillar'] and
+                        if ('pillar' in self.opts and 'whens' in self.opts['pillar'] and
                                 i in self.opts['pillar']['whens']):
                             if not isinstance(self.opts['pillar']['whens'],
                                               dict):
@@ -936,7 +936,7 @@ class Schedule(object):
                         continue
 
                 else:
-                    if ('whens' in self.opts['pillar'] and
+                    if ('pillar' in self.opts and 'whens' in self.opts['pillar'] and
                             data['when'] in self.opts['pillar']['whens']):
                         if not isinstance(self.opts['pillar']['whens'], dict):
                             log.error('Pillar item "whens" must be dict.'


### PR DESCRIPTION
This fixes an exception that is thrown when using the 'when' clause in a
master scheduler. The master does not appear to create a 'pillar' entry
in self.opts (hence you get an exception when trying to check if 'whens' is in self.opts['pillar']).

For example - the following schedule entry in the master config would create this exception:

```
schedule:
  test_master_schedule:
    function: myrunner.test
    when: 10:00pm
```
