### PR TITLE
fixes #31393 don't convert the iface to lower case

### DIFF
--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -955,7 +955,6 @@ def build_interface(iface, iface_type, enabled, **settings):
     else:
         rh_major = __grains__['osrelease'][:1]
 
-    iface = iface.lower()
     iface_type = iface_type.lower()
 
     if iface_type not in _IFACE_TYPES:


### PR DESCRIPTION
Fixes the issue, where the interface names has capital letters, such as the system we have for IBM Power8 Big Endian machines, making the lower case name, creates the wrong interfaces

This patch fixes the problem that we faced. 

It is case sensitive, and have tried a few things

It may need to be cherry-picked to other branches, so that this can be caught into epel next version
