### PR TITLE
mdata grains missing on 2016.3 and develop when running linux

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -503,6 +503,14 @@ def _virtual(osdata):
     if osdata['kernel'] in skip_cmds:
         _cmds = ()
 
+    # Quick backout for BrandZ (Solaris LX Branded zones, don't wast time on other commands)
+    uname = salt.utils.which('uname')
+    if osdata['kernel'] == 'Linux' and uname:
+        ret = __salt__['cmd.run_all']('{0} -v'.format(uname))
+        if 'BrandZ' in ret['stdout']:
+            grains['virtual'] = 'zone'
+            return grains
+
     failed_commands = set()
     for command in _cmds:
         args = []

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -503,7 +503,8 @@ def _virtual(osdata):
     if osdata['kernel'] in skip_cmds:
         _cmds = ()
 
-    # Quick backout for BrandZ (Solaris LX Branded zones, don't wast time on other commands)
+    # Quick backout for BrandZ (Solaris LX Branded zones)
+    # Don't waste time trying other commands to detect the virtual grain
     uname = salt.utils.which('uname')
     if osdata['kernel'] == 'Linux' and uname:
         ret = __salt__['cmd.run_all']('{0} -v'.format(uname))

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -509,6 +509,7 @@ def _virtual(osdata):
         ret = __salt__['cmd.run_all']('{0} -v'.format(uname))
         if 'BrandZ' in ret['stdout']:
             grains['virtual'] = 'zone'
+            grains.update(_mdata())
             return grains
 
     failed_commands = set()
@@ -2033,16 +2034,30 @@ def _smartos_zone_data():
 
     grains['zonename'] = __salt__['cmd.run']('zonename')
     grains['zoneid'] = __salt__['cmd.run']('zoneadm list -p | awk -F: \'{ print $1 }\'', python_shell=True)
-    grains['hypervisor_uuid'] = __salt__['cmd.run']('mdata-get sdc:server_uuid')
+    grains.update(_mdata())
+
+    return grains
+
+
+def _mdata():
+    '''
+    Provide grains from the SmartOS metadata
+    '''
+    grains = {}
+    mdata_list = salt.utils.which('mdata-list')
+    mdata_get = salt.utils.which('mdata-get')
+
+    # parse sdc metadata
+    grains['hypervisor_uuid'] = __salt__['cmd.run']('{0} sdc:server_uuid'.format(mdata_get))
     if "FAILURE" in grains['hypervisor_uuid'] or "No metadata" in grains['hypervisor_uuid']:
         grains['hypervisor_uuid'] = "Unknown"
-    grains['datacenter'] = __salt__['cmd.run']('mdata-get sdc:datacenter_name')
+    grains['datacenter'] = __salt__['cmd.run']('{0} sdc:datacenter_name'.format(mdata_get))
     if "FAILURE" in grains['datacenter'] or "No metadata" in grains['datacenter']:
         grains['datacenter'] = "Unknown"
 
-    # allow roles to be defined in vmadm metadata
-    for mdata_grain in __salt__['cmd.run']('mdata-list').splitlines():
-        grain_data = __salt__['cmd.run']('mdata-get {0}'.format(mdata_grain))
+    # parse vmadm metadata
+    for mdata_grain in __salt__['cmd.run'](mdata_list).splitlines():
+        grain_data = __salt__['cmd.run']('{0} {1}'.format(mdata_get, mdata_grain))
 
         if mdata_grain == 'roles':  # parse roles as roles grain
             grain_data = grain_data.split(',')


### PR DESCRIPTION
Someone pointed out the the mdata grains were still not loaded in develop when running in a lx branded zone. The BrandZ (lx branded zones) detection needed to load the mdata grains also allows us to skip the time consuming virtual checks since if we have that in uname we are running as a zone on SmartOS/illumos.

This fixes the problem, also present in 2016.3 so targeted that branch.
