### PR TITLE
Vmware ESXi proxy - add hw grains

### DIFF
--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -168,6 +168,7 @@ import salt.ext.six as six
 import salt.utils
 import salt.utils.vmware
 import salt.utils.http
+from salt.utils import dictupdate
 from salt.exceptions import CommandExecutionError
 
 # Import Third Party Libs
@@ -1670,7 +1671,11 @@ def system_info(host, username, password, protocol=None, port=None):
                                                               password=password,
                                                               protocol=protocol,
                                                               port=port)
-    return salt.utils.vmware.get_inventory(service_instance).about.__dict__
+    ret = salt.utils.vmware.get_inventory(service_instance).about.__dict__ 
+    if 'apiType' in ret:
+        if ret['apiType'] == 'HostAgent':
+            ret = dictupdate.update(ret, salt.utils.vmware.get_hardware_grains(service_instance))
+    return ret
 
 
 def list_datacenters(host, username, password, protocol=None, port=None):

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -1671,7 +1671,7 @@ def system_info(host, username, password, protocol=None, port=None):
                                                               password=password,
                                                               protocol=protocol,
                                                               port=port)
-    ret = salt.utils.vmware.get_inventory(service_instance).about.__dict__ 
+    ret = salt.utils.vmware.get_inventory(service_instance).about.__dict__
     if 'apiType' in ret:
         if ret['apiType'] == 'HostAgent':
             ret = dictupdate.update(ret, salt.utils.vmware.get_hardware_grains(service_instance))

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -309,7 +309,7 @@ def _get_dvs_uplink_portgroup(dvs, portgroup_name):
 
 def get_hardware_grains(service_instance):
     '''
-    Return hardware info for standard minion grains
+    Return hardware info for standard minion grains if the service_instance is a HostAgent type
 
     service_instance
         The service instance object to get hardware info for
@@ -318,54 +318,56 @@ def get_hardware_grains(service_instance):
     if get_inventory(service_instance).about.apiType == 'HostAgent':
         view = service_instance.content.viewManager.CreateContainerView(service_instance.RetrieveContent().rootFolder,
                                                                         [vim.HostSystem], True)
-        if view and len(view) > 0:
-            hw_grain_data['manufacturer'] = view.view[0].hardware.systemInfo.vendor
-            hw_grain_data['productname'] = view.view[0].hardware.systemInfo.model
+        if view:
+            if view.view:
+                if len(view.view) > 0:
+                    hw_grain_data['manufacturer'] = view.view[0].hardware.systemInfo.vendor
+                    hw_grain_data['productname'] = view.view[0].hardware.systemInfo.model
 
-            for _data in view.view[0].hardware.systemInfo.otherIdentifyingInfo:
-                if _data.identifierType.key == 'ServiceTag':
-                    hw_grain_data['serialnumber'] = _data.identifierValue
+                    for _data in view.view[0].hardware.systemInfo.otherIdentifyingInfo:
+                        if _data.identifierType.key == 'ServiceTag':
+                            hw_grain_data['serialnumber'] = _data.identifierValue
 
-            hw_grain_data['osfullname'] = view.view[0].summary.config.product.fullName
-            hw_grain_data['osmanufacturer'] = view.view[0].summary.config.product.vendor
-            hw_grain_data['osrelease'] = view.view[0].summary.config.product.version
-            hw_grain_data['osbuild'] = view.view[0].summary.config.product.build
-            hw_grain_data['os_family'] = view.view[0].summary.config.product.name
-            hw_grain_data['os'] = view.view[0].summary.config.product.name
-            hw_grain_data['mem_total'] = view.view[0].hardware.memorySize /1024/1024
-            hw_grain_data['biosversion'] = view.view[0].hardware.biosInfo.biosVersion
-            hw_grain_data['biosreleasedate'] = view.view[0].hardware.biosInfo.releaseDate.date().strftime('%m/%d/%Y')
-            hw_grain_data['cpu_model'] = view.view[0].hardware.cpuPkg[0].description
-            hw_grain_data['kernel'] = view.view[0].summary.config.product.productLineId
-            hw_grain_data['num_cpu_sockets'] = view.view[0].hardware.cpuInfo.numCpuPackages
-            hw_grain_data['num_cpu_cores'] = view.view[0].hardware.cpuInfo.numCpuCores
-            hw_grain_data['num_cpus'] = hw_grain_data['num_cpu_sockets'] * hw_grain_data['num_cpu_cores']
-            hw_grain_data['ip_interfaces'] = {}
-            hw_grain_data['ip4_interfaces'] = {}
-            hw_grain_data['ip6_interfaces'] = {}
-            hw_grain_data['hwaddr_interfaces'] = {}
-            for _vnic in view.view[0].configManager.networkSystem.networkConfig.vnic:
-                hw_grain_data['ip_interfaces'][_vnic.device] = []
-                hw_grain_data['ip4_interfaces'][_vnic.device] = []
-                hw_grain_data['ip6_interfaces'][_vnic.device] = []
+                    hw_grain_data['osfullname'] = view.view[0].summary.config.product.fullName
+                    hw_grain_data['osmanufacturer'] = view.view[0].summary.config.product.vendor
+                    hw_grain_data['osrelease'] = view.view[0].summary.config.product.version
+                    hw_grain_data['osbuild'] = view.view[0].summary.config.product.build
+                    hw_grain_data['os_family'] = view.view[0].summary.config.product.name
+                    hw_grain_data['os'] = view.view[0].summary.config.product.name
+                    hw_grain_data['mem_total'] = view.view[0].hardware.memorySize /1024/1024
+                    hw_grain_data['biosversion'] = view.view[0].hardware.biosInfo.biosVersion
+                    hw_grain_data['biosreleasedate'] = view.view[0].hardware.biosInfo.releaseDate.date().strftime('%m/%d/%Y')
+                    hw_grain_data['cpu_model'] = view.view[0].hardware.cpuPkg[0].description
+                    hw_grain_data['kernel'] = view.view[0].summary.config.product.productLineId
+                    hw_grain_data['num_cpu_sockets'] = view.view[0].hardware.cpuInfo.numCpuPackages
+                    hw_grain_data['num_cpu_cores'] = view.view[0].hardware.cpuInfo.numCpuCores
+                    hw_grain_data['num_cpus'] = hw_grain_data['num_cpu_sockets'] * hw_grain_data['num_cpu_cores']
+                    hw_grain_data['ip_interfaces'] = {}
+                    hw_grain_data['ip4_interfaces'] = {}
+                    hw_grain_data['ip6_interfaces'] = {}
+                    hw_grain_data['hwaddr_interfaces'] = {}
+                    for _vnic in view.view[0].configManager.networkSystem.networkConfig.vnic:
+                        hw_grain_data['ip_interfaces'][_vnic.device] = []
+                        hw_grain_data['ip4_interfaces'][_vnic.device] = []
+                        hw_grain_data['ip6_interfaces'][_vnic.device] = []
 
-                hw_grain_data['ip_interfaces'][_vnic.device].append(_vnic.spec.ip.ipAddress)
-                hw_grain_data['ip4_interfaces'][_vnic.device].append(_vnic.spec.ip.ipAddress)
-                if _vnic.spec.ip.ipV6Config:
-                    hw_grain_data['ip6_interfaces'][_vnic.device].append(_vnic.spec.ip.ipV6Config.ipV6Address)
-                hw_grain_data['hwaddr_interfaces'][_vnic.device] = _vnic.spec.mac
-            hw_grain_data['host'] = view.view[0].configManager.networkSystem.dnsConfig.hostName
-            hw_grain_data['domain'] = view.view[0].configManager.networkSystem.dnsConfig.domainName
-            hw_grain_data['fqdn'] = '{0}{1}{2}'.format(
-                    view.view[0].configManager.networkSystem.dnsConfig.hostName,
-                    ('.' if view.view[0].configManager.networkSystem.dnsConfig.domainName else ''),
-                    view.view[0].configManager.networkSystem.dnsConfig.domainName)
+                        hw_grain_data['ip_interfaces'][_vnic.device].append(_vnic.spec.ip.ipAddress)
+                        hw_grain_data['ip4_interfaces'][_vnic.device].append(_vnic.spec.ip.ipAddress)
+                        if _vnic.spec.ip.ipV6Config:
+                            hw_grain_data['ip6_interfaces'][_vnic.device].append(_vnic.spec.ip.ipV6Config.ipV6Address)
+                        hw_grain_data['hwaddr_interfaces'][_vnic.device] = _vnic.spec.mac
+                    hw_grain_data['host'] = view.view[0].configManager.networkSystem.dnsConfig.hostName
+                    hw_grain_data['domain'] = view.view[0].configManager.networkSystem.dnsConfig.domainName
+                    hw_grain_data['fqdn'] = '{0}{1}{2}'.format(
+                            view.view[0].configManager.networkSystem.dnsConfig.hostName,
+                            ('.' if view.view[0].configManager.networkSystem.dnsConfig.domainName else ''),
+                            view.view[0].configManager.networkSystem.dnsConfig.domainName)
 
-            for _pnic in view.view[0].configManager.networkSystem.networkInfo.pnic:
-                hw_grain_data['hwaddr_interfaces'][_pnic.device] = _pnic.mac
+                    for _pnic in view.view[0].configManager.networkSystem.networkInfo.pnic:
+                        hw_grain_data['hwaddr_interfaces'][_pnic.device] = _pnic.mac
 
-            hw_grain_data['timezone'] = view.view[0].configManager.dateTimeSystem.dateTimeInfo.timeZone.name
-        view = None
+                    hw_grain_data['timezone'] = view.view[0].configManager.dateTimeSystem.dateTimeInfo.timeZone.name
+                view = None
     return hw_grain_data
 
 

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -313,6 +313,8 @@ def get_hardware_grains(service_instance):
 
     service_instance
         The service instance object to get hardware info for
+
+    .. versionadded:: Carbon
     '''
     hw_grain_data = {}
     if get_inventory(service_instance).about.apiType == 'HostAgent':

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -307,6 +307,68 @@ def _get_dvs_uplink_portgroup(dvs, portgroup_name):
     return None
 
 
+def get_hardware_grains(service_instance):
+    '''
+    Return hardware info for standard minion grains
+
+    service_instance
+        The service instance object to get hardware info for
+    '''
+    hw_grain_data = {}
+    if get_inventory(service_instance).about.apiType == 'HostAgent':
+        view = service_instance.content.viewManager.CreateContainerView(service_instance.RetrieveContent().rootFolder,
+                                                                        [vim.HostSystem], True)
+        if view and len(view) > 0:
+            hw_grain_data['manufacturer'] = view.view[0].hardware.systemInfo.vendor
+            hw_grain_data['productname'] = view.view[0].hardware.systemInfo.model
+
+            for _data in view.view[0].hardware.systemInfo.otherIdentifyingInfo:
+                if _data.identifierType.key == 'ServiceTag':
+                    hw_grain_data['serialnumber'] = _data.identifierValue
+
+            hw_grain_data['osfullname'] = view.view[0].summary.config.product.fullName
+            hw_grain_data['osmanufacturer'] = view.view[0].summary.config.product.vendor
+            hw_grain_data['osrelease'] = view.view[0].summary.config.product.version
+            hw_grain_data['osbuild'] = view.view[0].summary.config.product.build
+            hw_grain_data['os_family'] = view.view[0].summary.config.product.name
+            hw_grain_data['os'] = view.view[0].summary.config.product.name
+            hw_grain_data['mem_total'] = view.view[0].hardware.memorySize /1024/1024
+            hw_grain_data['biosversion'] = view.view[0].hardware.biosInfo.biosVersion
+            hw_grain_data['biosreleasedate'] = view.view[0].hardware.biosInfo.releaseDate.date().strftime('%m/%d/%Y')
+            hw_grain_data['cpu_model'] = view.view[0].hardware.cpuPkg[0].description
+            hw_grain_data['kernel'] = view.view[0].summary.config.product.productLineId
+            hw_grain_data['num_cpu_sockets'] = view.view[0].hardware.cpuInfo.numCpuPackages
+            hw_grain_data['num_cpu_cores'] = view.view[0].hardware.cpuInfo.numCpuCores
+            hw_grain_data['num_cpus'] = hw_grain_data['num_cpu_sockets'] * hw_grain_data['num_cpu_cores']
+            hw_grain_data['ip_interfaces'] = {}
+            hw_grain_data['ip4_interfaces'] = {}
+            hw_grain_data['ip6_interfaces'] = {}
+            hw_grain_data['hwaddr_interfaces'] = {}
+            for _vnic in view.view[0].configManager.networkSystem.networkConfig.vnic:
+                hw_grain_data['ip_interfaces'][_vnic.device] = []
+                hw_grain_data['ip4_interfaces'][_vnic.device] = []
+                hw_grain_data['ip6_interfaces'][_vnic.device] = []
+
+                hw_grain_data['ip_interfaces'][_vnic.device].append(_vnic.spec.ip.ipAddress)
+                hw_grain_data['ip4_interfaces'][_vnic.device].append(_vnic.spec.ip.ipAddress)
+                if _vnic.spec.ip.ipV6Config:
+                    hw_grain_data['ip6_interfaces'][_vnic.device].append(_vnic.spec.ip.ipV6Config.ipV6Address)
+                hw_grain_data['hwaddr_interfaces'][_vnic.device] = _vnic.spec.mac
+            hw_grain_data['host'] = view.view[0].configManager.networkSystem.dnsConfig.hostName
+            hw_grain_data['domain'] = view.view[0].configManager.networkSystem.dnsConfig.domainName
+            hw_grain_data['fqdn'] = '{0}{1}{2}'.format(
+                    view.view[0].configManager.networkSystem.dnsConfig.hostName,
+                    ('.' if view.view[0].configManager.networkSystem.dnsConfig.domainName else ''),
+                    view.view[0].configManager.networkSystem.dnsConfig.domainName)
+
+            for _pnic in view.view[0].configManager.networkSystem.networkInfo.pnic:
+                hw_grain_data['hwaddr_interfaces'][_pnic.device] = _pnic.mac
+
+            hw_grain_data['timezone'] = view.view[0].configManager.dateTimeSystem.dateTimeInfo.timeZone.name
+        view = None
+    return hw_grain_data
+
+
 def get_inventory(service_instance):
     '''
     Return the inventory of a Service Instance Object.


### PR DESCRIPTION
Add more detailed hardware/OS grain data to the ESXi minion.

Following grains are set to slightly different values:
- os (set to a more generic "VMware ESXi" to match other OSes (i.e. Windows, RedHat)
- osrelease (set to the ESXi version number instead of proxy)
- osfullname (value of previous "os" grain)
- hwaddr_interfaces (populated with vmnic info)

Following grains are added:
- biosreleasedate
- biosversion
- cpu_model
- domain
- fqdn
- host
- ip4_interfaces
- ip6_interfaces
- ip_interfaces
- manufacturer
- mem_total
- num_cpu_cores
- num_cpu_sockets
- num_cpus
- osbuild
- osmanufacturer
- productname
- serialnumber
- timezone

example grain data before

```
myesx-minion:
    ----------
    apiType:
        HostAgent
    apiVersion:
        5.5
    build:
        2718055
    cpuarch:
        x86_64
    dynamicProperty:
    dynamicType:
        None
    fullName:
        VMware ESXi 5.5.0 build-2718055
    gpus:
    hwaddr_interfaces:
        ----------
    id:
        myesx-minion
    instanceUuid:
        None
    kernel:
        proxy
    kernelrelease:
        proxy
    licenseProductName:
        VMware ESX Server
    licenseProductVersion:
        5.0
    localeBuild:
        000
    localeVersion:
        INTL
    locale_info:
        ----------
    machine_id:
    master:
        salt
    mem_total:
        0
    name:
        VMware ESXi
    nodename:
        my-proxy-minion
    num_gpus:
        0
    os:
        VMware ESXi 5.5.0 build-2718055
    osType:
        vmnix-x86
    os_family:
        proxy
    osarch:
        x86_64
    osrelease:
        proxy
    osrelease_info:
        - proxy
    path:
        /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
    productLineId:
        embeddedEsx
    ps:
        ps -efH
    pythonexecutable:
        /usr/bin/python
    pythonpath:
        - /var/cache/salt/minion/extmods/utils
        - /usr/bin
        - /usr/lib64/python27.zip
        - /usr/lib64/python2.7
        - /usr/lib64/python2.7/plat-linux2
        - /usr/lib64/python2.7/lib-tk
        - /usr/lib64/python2.7/lib-old
        - /usr/lib64/python2.7/lib-dynload
        - /usr/lib64/python2.7/site-packages
        - /usr/lib/python2.7/site-packages
    pythonversion:
        - 2
        - 7
        - 5
        - final
        - 0
    saltpath:
        /usr/lib/python2.7/site-packages/salt
    saltversion:
        2015.8.7
    saltversioninfo:
        - 2015
        - 8
        - 7
        - 0
    vendor:
        VMware, Inc.
    version:
        5.5.0
    virtual:
        VMWare
    zmqversion:
        4.0.5

```

grain data with this commit:

```
myesx-minion:
    ----------
    apiType:
        HostAgent
    apiVersion:
        5.5
    biosreleasedate:
        05/06/2015
    biosversion:
        U17
    build:
        2718055
    cpu_model:
        Intel(R) Xeon(R) CPU E7-8890 v3 @ 2.50GHz
    cpuarch:
        x86_64
    domain:
        my.domain
    dynamicProperty:
    dynamicType:
        None
    fqdn:
        myesx-minion.my.domain
    fullName:
        VMware ESXi 5.5.0 build-2718055
    gpus:
    host:
        myesx-minion
    hwaddr_interfaces:
        ----------
        vmk0:
            28:80:23:xx:xx:xx
        vmnic0:
            5c:b9:01:xx:xx:xx
        vmnic1:
            5c:b9:01:xx:xx:xx
        vmnic2:
            00:11:0a:xx:xx:xx
        vmnic3:
            00:11:0a:xx:xx:xx
        vmnic4:
            28:80:23:xx:xx:xx
        vmnic5:
            28:80:23:xx:xx:xx
        vmnic6:
            28:80:23:xx:xx:xx
        vmnic7:
            28:80:23:xx:xx:xx
        vmnic8:
            00:22:64:xx:xx:xx
        vmnic9:
            00:22:64:xx:xx:xx
    id:
        myesx-minion
    instanceUuid:
        None
    ip4_interfaces:
        ----------
        vmk0:
            - 10.10.10.10
    ip6_interfaces:
        ----------
        vmk0:
    ip_interfaces:
        ----------
        vmk0:
            - 10.10.10.10
    kernel:
        proxy
    kernelrelease:
        proxy
    licenseProductName:
        VMware ESX Server
    licenseProductVersion:
        5.0
    localeBuild:
        000
    localeVersion:
        INTL
    locale_info:
        ----------
    machine_id:
    manufacturer:
        HP
    master:
        salt
    mem_total:
        1048456
    name:
        VMware ESXi
    nodename:
        my-proxy-minion
    num_cpu_cores:
        72
    num_cpu_sockets:
        4
    num_cpus:
        288
    num_gpus:
        0
    os:
        VMware ESXi
    osType:
        vmnix-x86
    os_family:
        proxy
    osarch:
        x86_64
    osbuild:
        2718055
    osfullname:
        VMware ESXi 5.5.0 build-2718055
    osmanufacturer:
        VMware, Inc.
    osrelease:
        5.5.0
    osrelease_info:
        - proxy
    path:
        /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
    productLineId:
        embeddedEsx
    productname:
        ProLiant DL580 Gen9
    ps:
        ps -efH
    pythonexecutable:
        /usr/bin/python
    pythonpath:
        - /var/cache/salt/minion/extmods/utils
        - /usr/bin
        - /usr/lib64/python27.zip
        - /usr/lib64/python2.7
        - /usr/lib64/python2.7/plat-linux2
        - /usr/lib64/python2.7/lib-tk
        - /usr/lib64/python2.7/lib-old
        - /usr/lib64/python2.7/lib-dynload
        - /usr/lib64/python2.7/site-packages
        - /usr/lib/python2.7/site-packages
    pythonversion:
        - 2
        - 7
        - 5
        - final
        - 0
    saltpath:
        /usr/lib/python2.7/site-packages/salt
    saltversion:
        2015.8.7
    saltversioninfo:
        - 2015
        - 8
        - 7
        - 0
    serialnumber:
        XXXXXXXXXX
    timezone:
        UTC
    vendor:
        VMware, Inc.
    version:
        5.5.0
    virtual:
        VMWare
    zmqversion:
        4.0.5
```
