### PR TITLE
selinux module documentation fix

### DIFF
--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -4,9 +4,10 @@ Execute calls on selinux
 
 .. note::
     This module requires the ``semanage`` and ``setsebool`` commands to be
-    available on the minion. On RHEL-based distros, this means that the
-    ``policycoreutils`` and ``policycoreutils-python`` packages must be
-    installed. If not on a RHEL-based distribution, consult the selinux
+    available on the minion. On RHEL-based distributions, ensure that the
+    ``policycoreutils-python`` package is installed. On Fedora 23 and up,
+    ensure that the ``policycoreutils-python-utils`` package is installed.  If
+    not on a Fedora or RHEL-based distribution, consult the selinux
     documentation for your distro to ensure that the proper packages are
     installed.
 '''


### PR DESCRIPTION
Selinux commands were moved from policycoreutils-python package to
policycoreutils-python-utils package in Fedora 23.  The docstring needs to be
updated to reflect that.

reference: http://pkgs.fedoraproject.org/cgit/rpms/policycoreutils.git/commit/?id=3c89d24456836170bff46efe449a8fb076996a5d
