### PR TITLE
Fix uppercase computer names

### DIFF
--- a/doc/topics/releases/carbon.rst
+++ b/doc/topics/releases/carbon.rst
@@ -36,6 +36,11 @@ Functionality Changes
 
 - The ``onfail`` requisite now uses OR logic instead of AND logic. :issue:`22370`
 - The consul external pillar now strips leading and trailing whitespace. :issue:`31165`
+- The win_system.py state is now case sensitive for computer names. Previously
+  computer names set with a state were converted to all caps. If you have a
+  state setting computer names with lower case letters in the name that has
+  been applied, the computer name will be changed again to apply the case
+  sensitive name.
 
 Deprecations
 ============

--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -55,6 +55,15 @@ def _convert_minutes_seconds(timeout, in_seconds=False):
     return timeout if in_seconds else timeout*60
 
 
+def _convert_date_time_string(dt_string):
+    '''
+    convert string to date time object
+    '''
+    dt_string = dt_string.split('.')[0]
+    dt_obj = datetime.strptime(dt_string, '%Y%m%d%H%M%S')
+    return dt_obj.strftime('%Y-%m-%d %H:%M:%S')
+
+
 def halt(timeout=5, in_seconds=False):
     '''
     Halt a running system.
@@ -306,10 +315,13 @@ def set_computer_name(name):
 
     if windll.kernel32.SetComputerNameExW(win32con.ComputerNamePhysicalDnsHostname,
                                           name):
-        ret = {'Computer Name': {'Current': get_system_info()['name']}}
+        ret = {'Computer Name': {'Current': get_computer_name()}}
         pending = get_pending_computer_name()
         if pending not in (None, False):
-            ret['Computer Name']['Pending'] = pending
+            if pending == name.upper():
+                ret['Computer Name']['Pending'] = name
+            else:
+                ret['Computer Name']['Pending'] = pending
         return ret
     return False
 
@@ -332,7 +344,7 @@ def get_pending_computer_name():
 
         salt 'minion-id' system.get_pending_computer_name
     '''
-    current = get_computer_name()
+    current = get_computer_name().upper()
     pending = read_value('HKLM',
                          r'SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName',
                          'ComputerName')['vdata']
@@ -354,7 +366,7 @@ def get_computer_name():
 
         salt 'minion-id' system.get_computer_name
     '''
-    name = get_system_info()['name']
+    name = win32api.GetComputerNameEx(win32con.ComputerNamePhysicalDnsHostname)
     return name if name else False
 
 
@@ -409,14 +421,49 @@ def get_system_info():
         name, description, version, etc...
     :rtype: dict
     '''
-    system_info = win32net.NetServerGetInfo(None, 101)
-    return system_info
+    os_type = {1: 'Work Station',
+              2: 'Domain Controller',
+              3: 'Server'}
+    pythoncom.CoInitialize()
+    c = wmi.WMI()
+    system = c.Win32_OperatingSystem()[0]
+    ret = {'name': get_computer_name(),
+           'description': system.Description,
+           'install_date': system.InstallDate,
+           'last_boot': system.LastBootUpTime,
+           'os_manufacturer': system.Manufacturer,
+           'os_name': system.Caption,
+           'users': system.NumberOfUsers,
+           'organization': system.Organization,
+           'os_architecture': system.OSArchitecture,
+           'primary': system.Primary,
+           'os_type': os_type[system.ProductType],
+           'registered_user': system.RegisteredUser,
+           'system_directory': system.SystemDirectory,
+           'system_drive': system.SystemDrive,
+           'os_version': system.Version,
+           'windows_directory': system.WindowsDirectory}
+    system = c.Win32_ComputerSystem()[0]
+    ret.update({'hardware_manufacturer': system.Manufacturer,
+               'hardware_model': system.Model,
+               'processors': system.NumberOfProcessors,
+               'processors_logical': system.NumberOfLogicalProcessors,
+               'system_type': system.SystemType})
+    system = c.Win32_BIOS()[0]
+    ret.update({'hardware_serial': system.SerialNumber,
+                'bios_manufacturer': system.Manufacturer,
+                'bios_version': system.Version,
+                'bios_details': system.BIOSVersion,
+                'bios_caption': system.Caption,
+                'bios_description': system.Description})
+    ret['install_date'] = _convert_date_time_string(ret['install_date'])
+    ret['last_boot'] = _convert_date_time_string(ret['last_boot'])
+    return ret
 
 
 def get_computer_desc():
     '''
     Get the Windows computer description
-
     :return:
         Returns the computer description if found. Otherwise returns False
 
@@ -426,7 +473,7 @@ def get_computer_desc():
 
         salt 'minion-id' system.get_computer_desc
     '''
-    desc = get_system_info()['comment']
+    desc = get_system_info()['description']
     return desc if desc else False
 
 

--- a/salt/states/win_system.py
+++ b/salt/states/win_system.py
@@ -88,7 +88,7 @@ def computer_name(name):
         The desired computer name
     '''
     # Just in case someone decides to enter a numeric description
-    name = str(name).upper()
+    name = str(name)
 
     ret = {'name': name,
            'changes': {},
@@ -100,7 +100,7 @@ def computer_name(name):
 
     if before_name == name and pending_name is None:
         return ret
-    elif pending_name == name:
+    elif pending_name == name.upper():
         ret['comment'] = ('The current computer name is {0!r}, but will be '
                           'changed to {1!r} on the next reboot'
                           .format(before_name, name))

--- a/tests/unit/states/win_system_test.py
+++ b/tests/unit/states/win_system_test.py
@@ -63,27 +63,27 @@ class WinSystemTestCase(TestCase):
         '''
             Test to manage the computer's name
         '''
-        ret = {'name': 'SALT',
+        ret = {'name': 'salt',
                'changes': {},
                'result': True,
                'comment': ''}
-        mock = MagicMock(return_value='SALT')
+        mock = MagicMock(return_value='salt')
         with patch.dict(win_system.__salt__,
                         {"system.get_computer_name": mock}):
             mock = MagicMock(side_effect=[None, 'SALT', 'Stack', 'stack'])
             with patch.dict(win_system.__salt__,
                             {"system.get_pending_computer_name": mock}):
-                ret.update({'comment': "Computer name already set to 'SALT'"})
+                ret.update({'comment': "Computer name already set to 'salt'"})
                 self.assertDictEqual(win_system.computer_name('salt'), ret)
 
                 ret.update({'comment': "The current computer name"
-                            " is 'SALT', but will be changed to 'SALT' on"
+                            " is 'salt', but will be changed to 'salt' on"
                             " the next reboot"})
                 self.assertDictEqual(win_system.computer_name('salt'), ret)
 
                 with patch.dict(win_system.__opts__, {"test": True}):
                     ret.update({'result': None, 'comment': "Computer name will"
-                                " be changed to 'SALT'"})
+                                " be changed to 'salt'"})
                     self.assertDictEqual(win_system.computer_name('salt'), ret)
 
                 with patch.dict(win_system.__opts__, {"test": False}):
@@ -91,7 +91,7 @@ class WinSystemTestCase(TestCase):
                     with patch.dict(win_system.__salt__,
                                     {"system.set_computer_name": mock}):
                         ret.update({'comment': "Unable to set computer name"
-                                    " to 'SALT'", 'result': False})
+                                    " to 'salt'", 'result': False})
                         self.assertDictEqual(win_system.computer_name('salt'),
                                              ret)
 


### PR DESCRIPTION
Supercedes: https://github.com/saltstack/salt/pull/31375
Which superceded: https://github.com/saltstack/salt/pull/31222

Fixes: https://github.com/saltstack/salt/issues/31290

Fixes Capitalized Computer name for states and for current in set_computer_name function
No way to fix the capitalization in Pending Computer name. (That's how it's stored in the registry). I couldn't find where windows stores the un-capitalized version of the pending computer name. So, if
the pending name matches the new name, it will pass the new name. Otherwise, it will return an All Caps pending name.

Execution Module returns:

```
gringo:
    ----------
    Computer Name:
        ----------
        Current:
            Gringo
        Pending:
            Gringo-Test
```

State returns:

```
gringo:
----------
          ID: set_name
    Function: system.computer_name
        Name: Gringo-Test
      Result: True
     Comment: Computer name successfully set to 'Gringo-Test' (reboot required for change to take effect)
     Started: 16:28:24.955000
    Duration: 16.0 ms
     Changes:
              ----------
              new:
                  Gringo-Test
              old:
                  Gringo

Summary for gringo
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
```

Also adds more computer information for get_system_info.
