### PR TITLE
Fix bug #28044 - look for 'pip' first, then 'pip2'

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -118,7 +118,7 @@ def _get_pip_bin(bin_env):
     executable itself, or from searching conventional filesystem locations
     '''
     if not bin_env:
-        which_result = __salt__['cmd.which_bin'](['pip2', 'pip', 'pip-python'])
+        which_result = __salt__['cmd.which_bin'](['pip', 'pip2', 'pip-python'])
         if which_result is None:
             raise CommandNotFoundError('Could not find a `pip` binary')
         if salt.utils.is_windows():


### PR DESCRIPTION
If Pip was installed with easy_install, the /usr/local/bin/pip2 file still belongs to apt-installed Pip. This makes salt-minion use the old version which is not yet ready for https://www.python.org/dev/peps/pep-0440/#arbitrary-equality
