### PR TITLE
Fix ini issues

### DIFF
--- a/salt/modules/ini_manage.py
+++ b/salt/modules/ini_manage.py
@@ -289,7 +289,8 @@ class _Section(OrderedDict):
             if key not in self:
                 changes.update({key: {'before': None,
                                       'after': value}})
-                # If it's not a section, it may be a commented key/value pair
+                # If it's not a section, it may already exist as a
+                # commented-out key/value pair
                 if not hasattr(value, 'iteritems'):
                     self._uncomment_if_commented(key)
 

--- a/salt/modules/ini_manage.py
+++ b/salt/modules/ini_manage.py
@@ -283,12 +283,14 @@ class _Section(OrderedDict):
                 )
                 sect.update(value)
                 value = sect
+                value_plain = value.as_dict()
             else:
                 value = str(value)
+                value_plain = value
 
             if key not in self:
                 changes.update({key: {'before': None,
-                                      'after': value}})
+                                      'after': value_plain}})
                 # If it's not a section, it may already exist as a
                 # commented-out key/value pair
                 if not hasattr(value, 'iteritems'):
@@ -304,7 +306,7 @@ class _Section(OrderedDict):
                 else:
                     if curr_value != value:
                         changes.update({key: {'before': curr_value,
-                                              'after': value}})
+                                              'after': value_plain}})
                         super(_Section, self).update({key: value})
         return changes
 

--- a/salt/states/ini_manage.py
+++ b/salt/states/ini_manage.py
@@ -113,14 +113,15 @@ def options_absent(name, sections=None, separator='='):
             ret['comment'] = 'No changes detected.'
         return ret
     sections = sections or {}
-    for section, key in sections.iteritems():
-        current_value = __salt__['ini.remove_option'](name, section, key, separator)
-        if not current_value:
-            continue
-        if section not in ret['changes']:
-            ret['changes'].update({section: {}})
-        ret['changes'][section].update({key: current_value})
-        ret['comment'] = 'Changes take effect'
+    for section, keys in sections.iteritems():
+        for key in keys:
+            current_value = __salt__['ini.remove_option'](name, section, key, separator)
+            if not current_value:
+                continue
+            if section not in ret['changes']:
+                ret['changes'].update({section: {}})
+            ret['changes'][section].update({key: current_value})
+            ret['comment'] = 'Changes take effect'
     return ret
 
 

--- a/salt/states/ini_manage.py
+++ b/salt/states/ini_manage.py
@@ -81,10 +81,10 @@ def options_absent(name, sections=None, separator='='):
             - separator: '='
             - sections:
                 test:
-                  testkey
-                  secondoption
+                  - testkey
+                  - secondoption
                 test1:
-                  testkey1
+                  - testkey1
 
     options present in file and not specified in sections
     dict will be untouched


### PR DESCRIPTION
I recently ran `brew upgrade --HEAD saltstack` and noticed _a lot_ of breakage in ini-related states.

The first thing I discovered is that `ini.options_absent` no longer supported multiple options and would not take lists. This is both a breaking change and a huge inconvenience, requiring a separate state per key deleted (because you could only delete one key per section per state). The documentation had been modified in an attempt to reflect the changes but ended up still incorrect.

The next thing I noticed is that I had an integer being replaced in the ini file, but it was being registered as a change every time, even when the number was identical. I had to cast it to a string to fix this.

Finally, I wiped the ini file and re-ran the salt call, and to my horror it had been replaced with several lines similar to:

```
section1 = OrderedDict([...])
section2 = OrderedDict([...])
```

I've attached a set of commits which I believe fixes all these issues, undoes the breaking change, and reverts the documentation to describe the original behaviour again.
