### PR TITLE
Fix lowpkg.info function for Ubuntu 12 - make sure we have a pkg name

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2233,7 +2233,12 @@ def owner(*paths):
 
 def info_installed(*names):
     '''
-    Return the information of the named package(s), installed on the system.
+    Return the information of the named package(s) installed on the system.
+
+    .. versionadded:: 2015.8.1
+
+    names
+        The names of the packages for which to return information.
 
     CLI example:
 

--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -247,17 +247,17 @@ def file_dict(*packages):
 
 def _get_pkg_info(*packages):
     '''
-    Return list of package informations. If 'packages' parameter is empty,
+    Return list of package information. If 'packages' parameter is empty,
     then data about all installed packages will be returned.
 
     :param packages: Specified packages.
     :return:
     '''
 
-    if __grains__['os'] == 'Ubuntu' and __grains__['osrelease_info'] <= (12, 4):
+    if __grains__['os'] == 'Ubuntu' and __grains__['osrelease_info'] < (12, 4):
         bin_var = '${binary}'
     else:
-        bin_var = '${binary:Package}'
+        bin_var = '${Package}'
 
     ret = []
     cmd = "dpkg-query -W -f='package:" + bin_var + "\\n" \
@@ -366,16 +366,19 @@ def _get_pkg_ds_avail():
 
 def info(*packages):
     '''
-    Return a detailed package(s) summary information.
-    If no packages specified, all packages will be returned.
+    Returns a detailed summary of package information for provided package names.
+    If no packages are specified, all packages will be returned.
 
-    :param packages:
-    :return:
+    .. versionadded:: 2015.8.1
+
+    packages
+        The names of the packages for which to return information.
 
     CLI example:
 
     .. code-block:: bash
 
+        salt '*' lowpkg.info
         salt '*' lowpkg.info apache2 bash
     '''
     # Get the missing information from the /var/lib/dpkg/available, if it is there.

--- a/tests/integration/modules/pkg.py
+++ b/tests/integration/modules/pkg.py
@@ -171,6 +171,19 @@ class PkgModuleTest(integration.ModuleCase,
             os_grain = self.run_function('grains.item', ['os'])['os']
             self.skipTest('{0} is unavailable on {1}'.format(func, os_grain))
 
+    def test_pkg_info(self):
+        '''
+        Test returning useful information on Ubuntu systems.
+        '''
+        func = 'pkg.info_installed'
+        os_family = self.run_function('grains.item', ['os_family'])['os_family']
+
+        if os_family == 'Debian':
+            ret = self.run_function(func, ['bash-completion', 'cron'])
+            keys = ret.keys()
+            self.assertIn('bash-completion', keys)
+            self.assertIn('cron', keys)
+
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/integration/modules/pkg.py
+++ b/tests/integration/modules/pkg.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 from salttesting.helpers import (
     destructiveTest,
     requires_network,
+    requires_salt_modules,
     ensure_in_syspath
 )
 ensure_in_syspath('../../')
@@ -171,6 +172,7 @@ class PkgModuleTest(integration.ModuleCase,
             os_grain = self.run_function('grains.item', ['os'])['os']
             self.skipTest('{0} is unavailable on {1}'.format(func, os_grain))
 
+    @requires_salt_modules('pkg.info_installed')
     def test_pkg_info(self):
         '''
         Test returning useful information on Ubuntu systems.


### PR DESCRIPTION
Fixes #31370

Without this change, the `pkg.info_installed` (which relies on `lowpkg.info`) on Ubuntu 12 stacktraces like this:

```
# salt-call --local pkg.info_installed bash-completion vim
[INFO    ] Determining pillar cache
[INFO    ] Executing command "dpkg-query -W -f='package:${binary}\\nrevision:${binary:Revision}\\narchitecture:${Architecture}\\nmaintainer:${Maintainer}\\nsummary:${Summary}\\nsource:${source:Package}\\nversion:${Version}\\nsection:${Section}\\ninstalled_size:${Installed-size}\\nsize:${Size}\\nMD5:${MD5sum}\\nSHA1:${SHA1}\\nSHA256:${SHA256}\\norigin:${Origin}\\nhomepage:${Homepage}\\n======\\ndescription:${Description}\\n------\\n' bash-completion vim" in directory '/root'
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
KeyError: 'package'
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    salt_call()
  File "/root/salt/salt/scripts.py", line 335, in salt_call
    client.run()
  File "/root/salt/salt/cli/call.py", line 53, in run
    caller.run()
  File "/root/salt/salt/cli/caller.py", line 133, in run
    ret = self.call()
  File "/root/salt/salt/cli/caller.py", line 196, in call
    ret['return'] = func(*args, **kwargs)
  File "/root/salt/salt/modules/aptpkg.py", line 2246, in info_installed
    for pkg_name, pkg_nfo in __salt__['lowpkg.info'](*names).items():
  File "/root/salt/salt/modules/dpkg.py", line 388, in info
    for pkg_ext_k, pkg_ext_v in dselect_pkg_avail.get(pkg['package'], {}).items():
KeyError: 'package'
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    salt_call()
  File "/root/salt/salt/scripts.py", line 335, in salt_call
    client.run()
  File "/root/salt/salt/cli/call.py", line 53, in run
    caller.run()
  File "/root/salt/salt/cli/caller.py", line 133, in run
    ret = self.call()
  File "/root/salt/salt/cli/caller.py", line 196, in call
    ret['return'] = func(*args, **kwargs)
  File "/root/salt/salt/modules/aptpkg.py", line 2246, in info_installed
    for pkg_name, pkg_nfo in __salt__['lowpkg.info'](*names).items():
  File "/root/salt/salt/modules/dpkg.py", line 388, in info
    for pkg_ext_k, pkg_ext_v in dselect_pkg_avail.get(pkg['package'], {}).items():
KeyError: 'package'
```

This fix restores functionality to Ubuntu 12:

```
root@localhost:~/salt# salt-call --local pkg.info_installed bash-completion vim
[INFO    ] Determining pillar cache
[INFO    ] Executing command "dpkg-query -W -f='package:${Package}\\nrevision:${binary:Revision}\\narchitecture:${Architecture}\\nmaintainer:${Maintainer}\\nsummary:${Summary}\\nsource:${source:Package}\\nversion:${Version}\\nsection:${Section}\\ninstalled_size:${Installed-size}\\nsize:${Size}\\nMD5:${MD5sum}\\nSHA1:${SHA1}\\nSHA256:${SHA256}\\norigin:${Origin}\\nhomepage:${Homepage}\\n======\\ndescription:${Description}\\n------\\n' bash-completion vim" in directory '/root'
local:
    ----------
    bash-completion:
        ----------
        architecture:
            all
        description:
            programmable completion for the bash shell
             bash completion extends bash's standard completion behavior to achieve
             complex command lines with just a few keystrokes.  This project was
             conceived to produce programmable completion routines for the most
             common Linux/UNIX commands, reducing the amount of typing sysadmins
             and programmers need to do on a daily basis.
        group:
            shells
        install_date:
            2014-04-27T14:33:32Z
        license:
            GPL-2+
        name:
            bash-completion
        packager:
            Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
        url:
            http://bash-completion.alioth.debian.org
        version:
            1:1.3-1ubuntu8.1
    vim:
        ----------
        architecture:
            amd64
        description:
            Vi IMproved - enhanced vi editor
             Vim is an almost compatible version of the UNIX editor Vi.
             .
             Many new features have been added: multi level undo, syntax
             highlighting, command line history, on-line help, filename
             completion, block operations, folding, Unicode support, etc.
             .
             This package contains a version of vim compiled with a rather
             standard set of features.  This package does not provide a GUI
             version of Vim.  See the other vim-* packages if you need more
             (or less).
        group:
            editors
        install_date:
            2013-04-26T18:24:56Z
        name:
            vim
        packager:
            Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
        url:
            http://www.vim.org/
        version:
            2:7.3.429-2ubuntu2.1
```

I also tested this on Ubuntu 14 to ensure this didn't cause a regression there. I also wrote an integration test.
