### PR TITLE
Set correct type for master_tops config value

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -228,7 +228,7 @@ VALID_OPTS = {
     'max_open_files': int,
     'auto_accept': bool,
     'autosign_timeout': int,
-    'master_tops': bool,
+    'master_tops': dict,
     'order_masters': bool,
     'job_cache': bool,
     'ext_job_cache': str,


### PR DESCRIPTION
Prior to this, the head of 2015.5 threw the following:

```
mp@silver ~/devel/salt % sudo salt silver test.ping                                                                                                     (git)-[795008b...|bisect] 
[WARNING ] Key master_tops with value {} has an invalid type of dict, a bool is required for this value
[WARNING ] Key master_tops with value {} has an invalid type of dict, a bool is required for this value
[WARNING ] Key master_tops with value {} has an invalid type of dict, a bool is required for this value
[WARNING ] Key master_tops with value {} has an invalid type of dict, a bool is required for this value
silver:
    True
```
