### PR TITLE
Add os.path.exists(src) to file.py, def copy

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2428,7 +2428,7 @@ def copy(src, dst, recurse=False, remove_existing=False):
         raise SaltInvocationError('File path must be absolute.')
 
     if not os.path.exists(src):
-        raise CommandExecutionError('No such file or directory \'{0}.\''.format(src))
+        raise CommandExecutionError('No such file or directory \'{0}\''.format(src))
 
     if not salt.utils.is_windows():
         pre_user = get_user(src)

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2427,6 +2427,9 @@ def copy(src, dst, recurse=False, remove_existing=False):
     if not os.path.isabs(src):
         raise SaltInvocationError('File path must be absolute.')
 
+    if not os.path.exists(src):
+        raise CommandExecutionError('No such file or directory \'{0}.\''.format(src))
+
     if not salt.utils.is_windows():
         pre_user = get_user(src)
         pre_group = get_group(src)


### PR DESCRIPTION
Fixes #31356

Discovered that using .copy and recurse=true, with a non-existing directory as source, the dst directory would have it's permissions reset. The routine for finding the permissions are not preceded by a test for _if_ the src exists. That is added in this PR.

The same issue exists all the way up to the develop branch.
