### PR TITLE
Only use LONGSIZE in rpm.info if available. Otherwise, use SIZE.

### DIFF
--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -422,6 +422,14 @@ def info(*packages, **attr):
         salt '*' lowpkg.info apache2 bash attr=version
         salt '*' lowpkg.info apache2 bash attr=version,build_date_iso,size
     '''
+    # LONGSIZE is not a valid tag for all versions of rpm. If LONGSIZE isn't
+    # available, then we can just use SIZE for older versions. See Issue #31366.
+    rpm_tags = __salt__['cmd.run_all']('rpm --querytags')
+    rpm_tags = rpm_tags.get('stdout').split('\n')
+    if 'LONGSIZE' in rpm_tags:
+        size_tag = '%{LONGSIZE}'
+    else:
+        size_tag = '%{SIZE}'
 
     cmd = packages and "rpm -q {0}".format(' '.join(packages)) or "rpm -qa"
 
@@ -440,7 +448,7 @@ def info(*packages, **attr):
         "build_host": "build_host: %{BUILDHOST}\\n",
         "group": "group: %{GROUP}\\n",
         "source_rpm": "source_rpm: %{SOURCERPM}\\n",
-        "size": "size: %{LONGSIZE}\\n",
+        "size": "size: " + size_tag + "\\n",
         "arch": "arch: %{ARCH}\\n",
         "license": "%|LICENSE?{license: %{LICENSE}\\n}|",
         "signature": "signature: %|DSAHEADER?{%{DSAHEADER:pgpsig}}:{%|RSAHEADER?{%{RSAHEADER:pgpsig}}:"

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -485,6 +485,8 @@ def info(*packages, **attr):
         if 'stderr' in call:
             comment += (call['stderr'] or call['stdout'])
         raise CommandExecutionError('{0}'.format(comment))
+    elif 'error' in call['stderr']:
+        raise CommandExecutionError(call['stderr'])
     else:
         out = call['stdout']
 

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -424,8 +424,9 @@ def info(*packages, **attr):
     '''
     # LONGSIZE is not a valid tag for all versions of rpm. If LONGSIZE isn't
     # available, then we can just use SIZE for older versions. See Issue #31366.
-    rpm_tags = __salt__['cmd.run_all']('rpm --querytags')
-    rpm_tags = rpm_tags.get('stdout').split('\n')
+    rpm_tags = __salt__['cmd.run_stdout'](
+        ['rpm', '--querytags'],
+        python_shell=False).splitlines()
     if 'LONGSIZE' in rpm_tags:
         size_tag = '%{LONGSIZE}'
     else:

--- a/tests/integration/modules/pkg.py
+++ b/tests/integration/modules/pkg.py
@@ -181,10 +181,20 @@ class PkgModuleTest(integration.ModuleCase,
         os_family = self.run_function('grains.item', ['os_family'])['os_family']
 
         if os_family == 'Debian':
-            ret = self.run_function(func, ['bash-completion', 'cron'])
+            ret = self.run_function(func, ['bash-completion', 'dpkg'])
             keys = ret.keys()
             self.assertIn('bash-completion', keys)
-            self.assertIn('cron', keys)
+            self.assertIn('dpkg', keys)
+        elif os_family == 'RedHat':
+            ret = self.run_function(func, ['rpm', 'yum'])
+            keys = ret.keys()
+            self.assertIn('rpm', keys)
+            self.assertIn('yum', keys)
+        elif os_family == 'Suse':
+            ret = self.run_function(func, ['bash-completion', 'zypper'])
+            keys = ret.keys()
+            self.assertIn('bash-completion', keys)
+            self.assertIn('zypper', keys)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #31366 

I have tested this manually on CentOS 6 and CentsOS 5, but I want to write an automated test. I started a test in #31439, which I want to add to here once that is merged. At that time I'll rebase and add the test.

Without this change, a call to `lowpkg.info` gets an error from the `cmd.run_all` call stating a tag is invalid, which is LONGSIZE. This change fixes error and returns successfully. Also added a more helpful error catch so we don't just return `None`  if there is information in the `stderr`, but we still got a `retcode: 0`.

```
# salt-call --local lowpkg.info git
<snipped>
local:
    ----------
    git:
        ----------
        arch:
            x86_64
        build_date:
            2013-11-21T19:57:31Z
        build_date_time_t:
            1385081851
        build_host:
            lisse.hasselt.wieers.com
        description:
            GIT comes in two layers. The bottom layer is merely an extremely fast
            and flexible filesystem-based database designed to store directory trees
            with regard to their history. The top layer is a SCM-like tool which
            enables human beings to work with the database in a manner to a degree
            similar to other SCM tools (like CVS, BitKeeper or Monotone).
        group:
            Development/Tools
        install_date:
            2016-02-23T16:27:28Z
        install_date_time_t:
            1456262848
        license:
            GPL
        packager:
            Dag Wieers <dag@wieers.com>
        release:
            1.el5.rf
        relocations:
            (not relocatable)
        signature:
            DSA/SHA1, Fri Nov 22 01:25:29 2013, Key ID a20e52146b8d79e6
        size:
            17639877
        source_rpm:
            git-1.7.12.4-1.el5.rf.src.rpm
        summary:
            Git core and tools
        url:
            http://git-scm.com/
        vendor:
            Dag Apt Repository, http://dag.wieers.com/apt/
        version:
            1.7.12.4
```
