### PR TITLE
Added the key value service_name to service beacon

### DIFF
--- a/salt/beacons/service.py
+++ b/salt/beacons/service.py
@@ -82,6 +82,7 @@ def beacon(config):
     for service in config:
         ret_dict = {}
         ret_dict[service] = {'running': __salt__['service.status'](service)}
+        ret_dict['service_name'] = service
 
         # If no options is given to the service, we fall back to the defaults
         # assign a False value to oncleanshutdown and onchangeonly. Those


### PR DESCRIPTION
This feature allows you to call the service name as a key in reactor files. The use case being that you can then create one reactor file that can run states of the same name. An example being:

/srv/reactor/service.sls
service:
  local.state.sls:
    - tgt: {{ data['data']['id'] }}
    - arg:
      - {{ data['data']['service_name'] }}

Then if you had state with a matching name it could ensure the service is set in the right state when any event is fired by the beacon.
