### PR TITLE
Updated win_organization_name default value for vmware driver

### DIFF
--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -476,7 +476,7 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
         During network configuration (if network specified), it is used to specify new administrator password for the machine. 
 
 ``win_organization_name``
-    Specify windows vm user's organization. Default organization name is blank
+    Specify windows vm user's organization. Default organization name is Organization
    	VMware vSphere documentation:
 	
     https://www.vmware.com/support/developer/vc-sdk/visdk25pubs/ReferenceGuide/vim.vm.customization.UserData.html

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2238,7 +2238,7 @@ def create(vm_):
         'win_password', vm_, __opts__, search_global=False, default=None
     )
     win_organization_name = config.get_cloud_config_value(
-        'win_organization_name', vm_, __opts__, search_global=False, default=''
+        'win_organization_name', vm_, __opts__, search_global=False, default='Organization'
     )
     plain_text = config.get_cloud_config_value(
         'plain_text', vm_, __opts__, search_global=False, default=False


### PR DESCRIPTION
Updated win_organization_name default value to "Organization" in Vmware driver as blank value not permitted.
