### PR TITLE
Clarified the form of requisite targets/requisite-references

### DIFF
--- a/doc/ref/states/requisites.rst
+++ b/doc/ref/states/requisites.rst
@@ -43,7 +43,11 @@ Requisites
 
 The Salt requisite system is used to create relationships between states. The
 core idea being that, when one state is dependent somehow on another, that
-inter-dependency can be easily defined.
+inter-dependency can be easily defined. These dependencies are expressed by
+declaring the relationships using state names and ID's or names.  The 
+generalized form of a requisite target is ``<state name> : <ID or name>``.
+The specific form is defined as a :ref:`Requisite Reference 
+<requisite-reference>`
 
 Requisites come in two types: Direct requisites (such as ``require``),
 and requisite_ins (such as ``require_in``). The relationships are


### PR DESCRIPTION
It was unclear what exactly could be the target of a reference.  After discussion on IRC (http://irclog.perlgeek.de/salt/2015-05-26#i_10657618) It was suggested that I can attempt clarification and submit a fix.  I've included a short description of what can be a target and cross-linked to the formal definition of a requisite-reference.
