### PR TITLE
Correct installation documentation for Debian

### DIFF
--- a/doc/topics/installation/debian.rst
+++ b/doc/topics/installation/debian.rst
@@ -77,7 +77,7 @@ For Jessie, the following line is needed in either
 Wheezy (Old Stable)
 -------------------
 
-For wheezy, the following line is needed in either
+For Wheezy, the following line is needed in either
 ``/etc/apt/sources.list`` or a file in ``/etc/apt/sources.list.d``:
 
 .. code-block:: bash
@@ -87,7 +87,7 @@ For wheezy, the following line is needed in either
 Squeeze (Old Old Stable)
 ------------------------
 
-For squeeze, you will need to enable the Debian backports repository
+For Squeeze, you will need to enable the Debian backports repository
 as well as the debian.saltstack.com repository. To do so, add the
 following to ``/etc/apt/sources.list`` or a file in
 ``/etc/apt/sources.list.d``:
@@ -97,10 +97,21 @@ following to ``/etc/apt/sources.list`` or a file in
     deb http://debian.saltstack.com/debian squeeze-saltstack main
     deb http://backports.debian.org/debian-backports squeeze-backports main
 
+Stretch (Testing)
+-----------------
+
+For Stretch, the following line is needed in either
+``/etc/apt/sources.list`` or a file in ``/etc/apt/sources.list.d``:
+
+.. code-block:: bash
+
+    deb http://debian.saltstack.com/debian stretch-saltstack main
+
+
 Sid (Unstable)
 --------------
 
-For sid, the following line is needed in either
+For Sid, the following line is needed in either
 ``/etc/apt/sources.list`` or a file in ``/etc/apt/sources.list.d``:
 
 .. code-block:: bash
@@ -152,4 +163,3 @@ Post-installation tasks
 -----------------------
 
 Now, go to the :doc:`Configuring Salt </ref/configuration/index>` page.
-

--- a/doc/topics/installation/debian.rst
+++ b/doc/topics/installation/debian.rst
@@ -9,13 +9,19 @@ Debian Installation
 Installation from the SaltStack Repository
 ==========================================
 
-2015.5 and later packages for Debian 8 (Jessie) are available in the
+2015.5 and later packages for Debian 8 ("Jessie") are available in the
 SaltStack repository.
 
+.. note::
+    SaltStack repository contains only packages suitable for ``i386`` (32-bit
+    Intel-compatible CPUs) and ``amd64`` (64-bit) architectures. While Salt
+    packages are built for all Debian ports (have ``all`` suffix in package
+    names), some of the dependencies are avaivable only for ``amd64`` systems.
+
 .. important::
-  The repository folder structure changed in the 2015.8.3 release, though the
-  previous repository structure that was documented in 2015.8.1 can continue to
-  be used.
+    The repository folder structure changed in the 2015.8.3 release, though the
+    previous repository structure that was documented in 2015.8.1 can continue to
+    be used.
 
 To install using the SaltStack repository:
 

--- a/doc/topics/installation/debian.rst
+++ b/doc/topics/installation/debian.rst
@@ -152,6 +152,23 @@ may be given at a time:
    - ``apt-get install salt-ssh``
    - ``apt-get install salt-syndic``
 
+Installation from the Debian Main Repository
+============================================
+
+Stretch (Testing) and Sid (Unstable) distributions are already contain mostly
+up-to-date Salt packages built by Debian Salt Team.
+
+Install Salt components directly from Debian:
+
+   - ``apt-get install salt-api``
+   - ``apt-get install salt-cloud``
+   - ``apt-get install salt-doc``
+   - ``apt-get install salt-master``
+   - ``apt-get install salt-minion``
+   - ``apt-get install salt-proxy``
+   - ``apt-get install salt-ssh``
+   - ``apt-get install salt-syndic``
+
 .. _Debian-config:
 
 Post-installation tasks

--- a/doc/topics/installation/debian.rst
+++ b/doc/topics/installation/debian.rst
@@ -47,11 +47,6 @@ To install using the SaltStack repository:
    - ``apt-get install salt-syndic``
    - ``apt-get install salt-cloud``
 
-Post-installation tasks
------------------------
-
-Now, go to the :doc:`Configuring Salt </ref/configuration/index>` page.
-
 Installation from the Community Repository
 ==========================================
 
@@ -160,6 +155,6 @@ may be given at a time:
 .. _Debian-config:
 
 Post-installation tasks
------------------------
+=======================
 
 Now, go to the :doc:`Configuring Salt </ref/configuration/index>` page.


### PR DESCRIPTION
This adds explanation for saltstack/salt-bootstrap#695
