### PR TITLE
Set auth retry count to 0 if multimaster mode is failover.

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -815,6 +815,7 @@ class Minion(MinionBase):
                     opts['master_active_list'] = opts['master']
                     if opts.get('master_shuffle'):
                         shuffle(opts['master_list'])
+                    opts['auth_tries'] = 0
                 elif isinstance(opts['master'], str):
                     # We have a string, but a list was what was intended. Convert.
                     # See issue 23611 for details


### PR DESCRIPTION
Backport of #31382 for 2015.5
