### PR TITLE
Correct issue where duplicate items in grains list during state run will result in duplicate grains

### DIFF
--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -128,14 +128,14 @@ def list_present(name, value, delimiter=DEFAULT_TARGET_DELIM):
               - web
               - dev
     '''
-
     name = re.sub(delimiter, DEFAULT_TARGET_DELIM, name)
     ret = {'name': name,
            'changes': {},
            'result': True,
            'comment': ''}
     grain = __salt__['grains.get'](name)
-
+    print('Pinting context')
+    print(__context__)
     if grain:
         # check whether grain is a list
         if not isinstance(grain, list):
@@ -152,9 +152,12 @@ def list_present(name, value, delimiter=DEFAULT_TARGET_DELIM):
                 if intersection:
                     value = list(set(value).difference(__context__['pending_grains'][name]))
                     ret['comment'] = 'Removed value {0} from update due to context found in "{1}".\n'.format(value, name)
+            print('pre context set')
             if 'pending_grains' not in __context__:
+                print('init pending grains context')
                 __context__['pending_grains'] = {}
             if name not in __context__['pending_grains']:
+                print('populating pending grains context')
                 __context__['pending_grains'][name] = set()
             __context__['pending_grains'][name].update(value)
         else:

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -134,8 +134,6 @@ def list_present(name, value, delimiter=DEFAULT_TARGET_DELIM):
            'result': True,
            'comment': ''}
     grain = __salt__['grains.get'](name)
-    print('Pinting context')
-    print(__context__)
     if grain:
         # check whether grain is a list
         if not isinstance(grain, list):
@@ -152,12 +150,9 @@ def list_present(name, value, delimiter=DEFAULT_TARGET_DELIM):
                 if intersection:
                     value = list(set(value).difference(__context__['pending_grains'][name]))
                     ret['comment'] = 'Removed value {0} from update due to context found in "{1}".\n'.format(value, name)
-            print('pre context set')
             if 'pending_grains' not in __context__:
-                print('init pending grains context')
                 __context__['pending_grains'] = {}
             if name not in __context__['pending_grains']:
-                print('populating pending grains context')
                 __context__['pending_grains'][name] = set()
             __context__['pending_grains'][name].update(value)
         else:

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -146,6 +146,17 @@ def list_present(name, value, delimiter=DEFAULT_TARGET_DELIM):
             if set(value).issubset(set(__salt__['grains.get'](name))):
                 ret['comment'] = 'Value {1} is already in grain {0}'.format(name, value)
                 return ret
+            elif name in __context__.get('pending_grains', {}):
+                # elements common to both
+                intersection = set(value).intersection(__context__.get('pending_grains', {})[name])
+                if intersection:
+                    value = list(set(value).difference(__context__['pending_grains'][name]))
+                    ret['comment'] = 'Removed value {0} from update due to context found in "{1}".\n'.format(value, name)
+            if 'pending_grains' not in __context__:
+                __context__['pending_grains'] = {}
+            if name not in __context__['pending_grains']:
+                __context__['pending_grains'][name] = set()
+            __context__['pending_grains'][name].update(value)
         else:
             if value in grain:
                 ret['comment'] = 'Value {1} is already in grain {0}'.format(name, value)

--- a/tests/integration/files/file/base/issue-31427.sls
+++ b/tests/integration/files/file/base/issue-31427.sls
@@ -1,0 +1,15 @@
+roles:
+  grains.list_present:
+    - name: roles
+    - value:
+      - elliptic
+      - parabolic
+      - hyperbolic
+
+additional-roles:
+  grains.list_present:
+    - name: roles
+    - value:
+      - hyperbolic
+      - diabolic
+

--- a/tests/integration/modules/grains.py
+++ b/tests/integration/modules/grains.py
@@ -100,16 +100,6 @@ class TestModulesGrains(integration.ModuleCase):
                     ['level1:level2']),
                 'foo')
 
-    def test_list_present_distinct(self):
-        '''
-        Test a case where two states are run and both attempt to update a list
-        of grains, resulting in duplicate keys.
-
-        This issue is fully outlined in GitHub issue #31427
-        '''
-
-
-
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(TestModulesGrains)

--- a/tests/integration/modules/grains.py
+++ b/tests/integration/modules/grains.py
@@ -100,6 +100,15 @@ class TestModulesGrains(integration.ModuleCase):
                     ['level1:level2']),
                 'foo')
 
+    def test_list_present_distinct(self):
+        '''
+        Test a case where two states are run and both attempt to update a list
+        of grains, resulting in duplicate keys.
+
+        This issue is fully outlined in GitHub issue #31427
+        '''
+
+
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
Refs #31427 

The test written for this is currently disabled because something is going in on the test suite that seems to be resetting **context**. That needs to be fixed first.
