### PR TITLE
Refactored GlusterFS support

### DIFF
--- a/tests/unit/states/glusterfs_test.py
+++ b/tests/unit/states/glusterfs_test.py
@@ -4,6 +4,7 @@
 '''
 # Import Python libs
 from __future__ import absolute_import
+import socket
 
 # Import Salt Testing Libs
 from salttesting import skipIf, TestCase
@@ -19,12 +20,13 @@ ensure_in_syspath('../../')
 
 # Import Salt Libs
 from salt.states import glusterfs
-from tests.unit.modules.glusterfs_test import GlusterResults
 import salt.modules.glusterfs as mod_glusterfs
 
 import salt.utils.cloud
 
 import salt.modules.glusterfs as mod_glusterfs
+
+# Globals
 glusterfs.__salt__ = {'glusterfs.peer': mod_glusterfs.peer}
 glusterfs.__opts__ = {}
 
@@ -41,132 +43,161 @@ class GlusterfsTestCase(TestCase):
         Test to verify if node is peered.
         '''
         name = 'server1'
-        other_name = 'server1'
 
         ret = {'name': name,
                'result': True,
                'comment': '',
                'changes': {}}
 
-        # probe new peer server2 under gluster 3.4.x
-        comt = ('Peer {0} added successfully.'.format(name))
-        ret.update({'comment': comt, 'result': True,
-                    'changes': {'new': {name: []}, 'old': {}}})
-        mock_xml = MagicMock(
-            return_value=GlusterResults.v34.peer_probe.success_other)
-        with patch.dict('salt.modules.glusterfs.__salt__', {'cmd.run': mock_xml}):
-            mock = MagicMock(side_effect=[{}, {name: []}])
-            with patch.dict(glusterfs.__salt__, {'glusterfs.list_peers': mock}):
+        mock_ip = MagicMock(return_value=['1.2.3.4', '1.2.3.5'])
+        mock_hostbyname = MagicMock(return_value='1.2.3.5')
+        mock_peer = MagicMock(return_value=True)
+        mock_status = MagicMock(return_value={'uuid1': {'hostnames': [name]}})
+
+        with patch.dict(glusterfs.__salt__, {'glusterfs.peer_status': mock_status,
+                                             'glusterfs.peer': mock_peer,
+                                             'network.ip_addrs': mock_ip}):
+            with patch.object(socket, 'gethostbyname', mock_hostbyname):
+                comt = 'Peering with localhost is not needed'
+                ret.update({'comment': comt})
                 self.assertDictEqual(glusterfs.peered(name), ret)
 
-        # probe new peer server2 under gluster 3.7.x
-        mock_xml = MagicMock(
-            return_value=GlusterResults.v37.peer_probe.success_other)
-        with patch.dict('salt.modules.glusterfs.__salt__', {'cmd.run': mock_xml}):
-            mock = MagicMock(side_effect=[{}, {name: []}])
-            with patch.dict(glusterfs.__salt__, {'glusterfs.list_peers': mock}):
+                mock_hostbyname.return_value = '1.2.3.42'
+                comt = ('Host {0} already peered'.format(name))
+                ret.update({'comment': comt})
                 self.assertDictEqual(glusterfs.peered(name), ret)
 
-        # probe already existing server2 under gluster 3.4.x
-        comt = ('Host {0} already peered'.format(name))
-        ret.update({'comment': comt, 'changes': {}})
-        mock_xml = MagicMock(
-            return_value=GlusterResults.v34.peer_probe.success_already_peer['hostname'])
-        with patch.dict('salt.modules.glusterfs.__salt__', {'cmd.run': mock_xml}):
-            mock = MagicMock(side_effect=[{name: []}, {name: []}])
-            with patch.dict(glusterfs.__salt__, {'glusterfs.list_peers': mock}):
-                self.assertDictEqual(glusterfs.peered(name), ret)
+                with patch.dict(glusterfs.__opts__, {'test': False}):
+                    old = {'uuid1': {'hostnames': ['other1']}}
+                    new = {'uuid1': {'hostnames': ['other1']},
+                           'uuid2': {'hostnames': ['someAlias', name]}}
+                    mock_status.side_effect = [old, new]
+                    comt = 'Host {0} successfully peered'.format(name)
+                    ret.update({'comment': comt,
+                                'changes': {'old': old, 'new': new}})
+                    self.assertDictEqual(glusterfs.peered(name), ret)
+                    mock_status.side_effect = None
 
-        # probe already existing server2 under gluster 3.7.x
-        mock_xml = MagicMock(
-            return_value=GlusterResults.v37.peer_probe.success_already_peer['hostname'])
-        with patch.dict('salt.modules.glusterfs.__salt__', {'cmd.run': mock_xml}):
-            mock = MagicMock(side_effect=[{name: []}, {name: []}])
-            with patch.dict(glusterfs.__salt__, {'glusterfs.list_peers': mock}):
-                self.assertDictEqual(glusterfs.peered(name), ret)
+                    mock_status.return_value = {
+                        'uuid1': {'hostnames': ['other']}
+                    }
+                    mock_peer.return_value = False
 
-        # Issue 30932: Peering an existing server by IP fails with gluster 3.7+
-        #
-        # server2 was probed by address, 10.0.0.2. Under 3.4, server1 would be
-        # known as 10.0.0.1 but starting with 3.7, its hostname of server1 would be
-        # known instead. Subsequent probing of server1 by server2 used to result in
-        # "success_already_peer" but now it should succeed in adding an alternate
-        # hostname entry.
+                    ret.update({'result': False})
 
-        name = 'server1'
-        ip = '10.0.0.1'
-        comt = ('Host {0} already peered'.format(ip))
-        ret.update({'name': ip, 'comment': comt, 'changes': {}})
-        mock_xml = MagicMock(
-            return_value=GlusterResults.v34.peer_probe.success_first_ip_from_second_first_time)
-        with patch.dict('salt.modules.glusterfs.__salt__', {'cmd.run': mock_xml}):
-            mock = MagicMock(side_effect=[{ip: []}, {ip: []}])
-            with patch.dict(glusterfs.__salt__, {'glusterfs.list_peers': mock}):
-                self.assertDictEqual(glusterfs.peered(ip), ret)
+                    comt = ('Failed to peer with {0},'
+                            + ' please check logs for errors').format(name)
+                    ret.update({'comment': comt, 'changes': {}})
+                    self.assertDictEqual(glusterfs.peered(name), ret)
 
-        comt = ('Peer {0} added successfully.'.format(ip))
-        ret.update({'name': ip, 'comment': comt, 'changes': {
-                   'old': {name: []}, 'new': {name: [ip]}}})
-        mock_xml = MagicMock(
-            return_value=GlusterResults.v37.peer_probe.success_first_ip_from_second_first_time)
-        with patch.dict('salt.modules.glusterfs.__salt__', {'cmd.run': mock_xml}):
-            mock = MagicMock(side_effect=[{name: []}, {name: [ip]}])
-            with patch.dict(glusterfs.__salt__, {'glusterfs.list_peers': mock}):
-                self.assertDictEqual(glusterfs.peered(ip), ret)
+                    comt = ('Invalid characters in peer name.')
+                    ret.update({'comment': comt, 'name': ':/'})
+                    self.assertDictEqual(glusterfs.peered(':/'), ret)
+                    ret.update({'name': name})
 
-        comt = ('Host {0} already peered'.format(ip))
-        ret.update({'name': ip, 'comment': comt, 'changes': {}})
-        mock_xml = MagicMock(
-            return_value=GlusterResults.v37.peer_probe.success_first_ip_from_second_second_time)
-        with patch.dict('salt.modules.glusterfs.__salt__', {'cmd.run': mock_xml}):
-            mock = MagicMock(side_effect=[{name: [ip]}, {name: [ip]}])
-            with patch.dict(glusterfs.__salt__, {'glusterfs.list_peers': mock}):
-                self.assertDictEqual(glusterfs.peered(ip), ret)
+                with patch.dict(glusterfs.__opts__, {'test': True}):
+                    comt = ('Peer {0} will be added.'.format(name))
+                    ret.update({'comment': comt, 'result': None})
+                    self.assertDictEqual(glusterfs.peered(name), ret)
 
-        # test for invalid characters
-        comt = ('Invalid characters in peer name.')
-        ret.update({'name': '#badhostname', 'comment': comt, 'result': False})
-        self.assertDictEqual(glusterfs.peered('#badhostname'), ret)
+    # 'volume_present' function tests: 1
 
-    # 'created' function tests: 1
-
-    def test_created(self):
+    def test_volume_present(self):
         '''
-        Test to check if volume already exists
+        Test to ensure that a volume exists
         '''
         name = 'salt'
-        bricks = {'host1': '/srv/gluster/drive1',
-                  'host2': '/srv/gluster/drive2'}
-
+        bricks = ['host1:/brick1']
         ret = {'name': name,
                'result': True,
                'comment': '',
                'changes': {}}
 
-        mock = MagicMock(side_effect=[[name], [], [], [], [name]])
-        mock_lst = MagicMock(return_value=[])
-        with patch.dict(glusterfs.__salt__, {'glusterfs.list_volumes': mock,
-                                             'glusterfs.create': mock_lst}):
-            comt = ('Volume {0} already exists.'.format(name))
-            ret.update({'comment': comt})
-            self.assertDictEqual(glusterfs.created(name, bricks), ret)
+        started_info = {name: {'status': '1'}}
+        stopped_info = {name: {'status': '0'}}
 
+        mock_info = MagicMock()
+        mock_list = MagicMock()
+        mock_create = MagicMock()
+        mock_start = MagicMock(return_value=True)
+
+        with patch.dict(glusterfs.__salt__, {
+                        'glusterfs.info': mock_info,
+                        'glusterfs.list_volumes': mock_list,
+                        'glusterfs.create_volume': mock_create,
+                        'glusterfs.start_volume': mock_start}):
+            with patch.dict(glusterfs.__opts__, {'test': False}):
+                mock_list.return_value = [name]
+                mock_info.return_value = started_info
+                comt = ('Volume {0} already exists and is started'.format(name))
+                ret.update({'comment': comt})
+                self.assertDictEqual(glusterfs.volume_present(name, bricks,
+                                                              start=True), ret)
+
+                mock_info.return_value = stopped_info
+                comt = ('Volume {0} already exists and is now started'.format(name))
+                ret.update({'comment': comt,
+                            'changes': {'old': 'stopped', 'new': 'started'}})
+                self.assertDictEqual(glusterfs.volume_present(name, bricks,
+                                                              start=True), ret)
+
+                comt = ('Volume {0} already exists'.format(name))
+                ret.update({'comment': comt, 'changes': {}})
+                self.assertDictEqual(glusterfs.volume_present(name, bricks,
+                                                              start=False), ret)
             with patch.dict(glusterfs.__opts__, {'test': True}):
+                comt = ('Volume {0} already exists'.format(name))
+                ret.update({'comment': comt, 'result': None})
+                self.assertDictEqual(glusterfs.volume_present(name, bricks,
+                                                              start=False), ret)
+
+                comt = ('Volume {0} already exists'
+                        + ' and will be started').format(name)
+                ret.update({'comment': comt, 'result': None})
+                self.assertDictEqual(glusterfs.volume_present(name, bricks,
+                                                              start=True), ret)
+
+                mock_list.return_value = []
                 comt = ('Volume {0} will be created'.format(name))
                 ret.update({'comment': comt, 'result': None})
-                self.assertDictEqual(glusterfs.created(name, bricks), ret)
+                self.assertDictEqual(glusterfs.volume_present(name, bricks,
+                                                              start=False), ret)
+
+                comt = ('Volume {0} will be created'
+                        + ' and started').format(name)
+                ret.update({'comment': comt, 'result': None})
+                self.assertDictEqual(glusterfs.volume_present(name, bricks,
+                                                              start=True), ret)
 
             with patch.dict(glusterfs.__opts__, {'test': False}):
-                with patch.object(salt.utils.cloud, 'check_name',
-                                  MagicMock(return_value=True)):
-                    comt = ('Invalid characters in volume name.')
-                    ret.update({'comment': comt, 'result': False})
-                    self.assertDictEqual(glusterfs.created(name, bricks), ret)
+                mock_list.side_effect = [[], [name]]
+                comt = ('Volume {0} is created'.format(name))
+                ret.update({'comment': comt,
+                            'result': True,
+                            'changes': {'old': [], 'new': [name]}})
+                self.assertDictEqual(glusterfs.volume_present(name, bricks,
+                                                              start=False), ret)
 
-                comt = ('Host {0} already peered'.format(name))
-                ret.update({'comment': [], 'result': True,
-                            'changes': {'new': ['salt'], 'old': []}})
-                self.assertDictEqual(glusterfs.created(name, bricks), ret)
+                mock_list.side_effect = [[], [name]]
+                comt = ('Volume {0} is created and is now started'.format(name))
+                ret.update({'comment': comt, 'result': True})
+                self.assertDictEqual(glusterfs.volume_present(name, bricks,
+                                                              start=True), ret)
+
+                mock_list.side_effect = None
+                mock_list.return_value = []
+                mock_create.return_value = False
+                comt = 'Creation of volume {0} failed'.format(name)
+                ret.update({'comment': comt, 'result': False, 'changes': {}})
+                self.assertDictEqual(glusterfs.volume_present(name, bricks),
+                                     ret)
+
+            with patch.object(salt.utils.cloud, 'check_name',
+                              MagicMock(return_value=True)):
+                comt = ('Invalid characters in volume name.')
+                ret.update({'comment': comt, 'result': False})
+                self.assertDictEqual(glusterfs.volume_present(name, bricks),
+                                     ret)
 
     # 'started' function tests: 1
 
@@ -181,27 +212,32 @@ class GlusterfsTestCase(TestCase):
                'comment': '',
                'changes': {}}
 
-        mock = MagicMock(side_effect=[[], [name], [name], [name]])
-        mock_t = MagicMock(return_value='started')
-        mock_dict = MagicMock(side_effect=[{}, '', ''])
-        with patch.dict(glusterfs.__salt__, {'glusterfs.list_volumes': mock,
-                                             'glusterfs.status': mock_dict,
-                                             'glusterfs.start_volume': mock_t}):
+        started_info = {name: {'status': '1'}}
+        stopped_info = {name: {'status': '0'}}
+        mock_info = MagicMock(return_value={})
+        mock_start = MagicMock(return_value=True)
+
+        with patch.dict(glusterfs.__salt__,
+                        {'glusterfs.info': mock_info,
+                         'glusterfs.start_volume': mock_start}):
             comt = ('Volume {0} does not exist'.format(name))
             ret.update({'comment': comt})
             self.assertDictEqual(glusterfs.started(name), ret)
 
+            mock_info.return_value = started_info
             comt = ('Volume {0} is already started'.format(name))
             ret.update({'comment': comt, 'result': True})
             self.assertDictEqual(glusterfs.started(name), ret)
 
             with patch.dict(glusterfs.__opts__, {'test': True}):
+                mock_info.return_value = stopped_info
                 comt = ('Volume {0} will be started'.format(name))
                 ret.update({'comment': comt, 'result': None})
                 self.assertDictEqual(glusterfs.started(name), ret)
 
             with patch.dict(glusterfs.__opts__, {'test': False}):
-                ret.update({'comment': 'started', 'result': True,
+                comt = 'Volume {0} is started'.format(name)
+                ret.update({'comment': comt, 'result': True,
                             'change': {'new': 'started', 'old': 'stopped'}})
                 self.assertDictEqual(glusterfs.started(name), ret)
 
@@ -212,40 +248,58 @@ class GlusterfsTestCase(TestCase):
         Test to add brick(s) to an existing volume
         '''
         name = 'salt'
-        bricks = {'bricks': {'host1': '/srv/gluster/drive1'}}
+        bricks = ['host1:/drive1']
+        old_bricks = ['host1:/drive2']
 
         ret = {'name': name,
                'result': False,
                'comment': '',
                'changes': {}}
 
-        mock = MagicMock(side_effect=['does not exist', 'is not started',
-                                      bricks, bricks, bricks, ''])
-        mock_t = MagicMock(side_effect=['bricks successfully added',
-                                        'Bricks already in volume', ''])
+        stopped_volinfo = {'salt': {'status': '0'}}
+        volinfo = {
+            'salt': {
+                'status': '1',
+                'bricks': {'brick1': {'path': old_bricks[0]}}
+            }
+        }
+        new_volinfo = {
+            'salt': {
+                'status': '1',
+                'bricks': {
+                    'brick1': {'path': old_bricks[0]},
+                    'brick2': {'path': bricks[0]}
+                }
+            }
+        }
+
+        mock_info = MagicMock(return_value={})
+        mock_add = MagicMock(side_effect=[False, True])
+
         with patch.dict(glusterfs.__salt__,
-                        {'glusterfs.status': mock,
-                         'glusterfs.add_volume_bricks': mock_t}):
-            ret.update({'comment': 'does not exist'})
-            self.assertDictEqual(
-                glusterfs.add_volume_bricks(name, bricks), ret)
+                        {'glusterfs.info': mock_info,
+                        'glusterfs.add_volume_bricks': mock_add}):
+            ret.update({'comment': 'Volume salt does not exist'})
+            self.assertDictEqual(glusterfs.add_volume_bricks(name, bricks), ret)
 
-            ret.update({'comment': 'is not started'})
-            self.assertDictEqual(
-                glusterfs.add_volume_bricks(name, bricks), ret)
+            mock_info.return_value = stopped_volinfo
+            ret.update({'comment': 'Volume salt is not started'})
+            self.assertDictEqual(glusterfs.add_volume_bricks(name, bricks), ret)
 
-            ret.update({'comment': 'bricks successfully added', 'result': True,
-                        'changes': {'new': ['host1'], 'old': ['host1']}})
-            self.assertDictEqual(
-                glusterfs.add_volume_bricks(name, bricks), ret)
+            mock_info.return_value = volinfo
+            ret.update({'comment': 'Adding bricks to volume salt failed'})
+            self.assertDictEqual(glusterfs.add_volume_bricks(name, bricks), ret)
 
-            ret.update({'comment': 'Bricks already in volume', 'changes': {}})
-            self.assertDictEqual(
-                glusterfs.add_volume_bricks(name, bricks), ret)
+            ret.update({'result': True})
+            ret.update({'comment': 'Bricks already added in volume salt'})
+            self.assertDictEqual(glusterfs.add_volume_bricks(name, old_bricks),
+                                                             ret)
 
-            ret.update({'comment': '', 'result': False})
-            self.assertDictEqual(
-                glusterfs.add_volume_bricks(name, bricks), ret)
+            mock_info.side_effect = [volinfo, new_volinfo]
+            ret.update({'comment': 'Bricks successfully added to volume salt',
+                        'changes': {'new': bricks + old_bricks,
+                                    'old': old_bricks}})
+            self.assertDictEqual(glusterfs.add_volume_bricks(name, bricks), ret)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Note: This moved #31395 over to the develop branch, as discussed there.

Usage of GlusterFS states did not change except the state 'created' was deprecated in favor of more descriptive name 'volume_present'.
- Improved separation of functionality in the execution module from the states. Module functions now return booleans instead of varying
  strings. Parsing those strings in the states was very error-prone. In glusterfs.peer() function this problem was earlier solved by returning
  a dict containing both the exit value and output string of the gluster call. This could be a good idea, although without calling the gluster
  calls twice, and applied to other functios too.
- Calls to gluster are now logged more verbosely, while a failing call no longer raises an immediate exception.
- Improved checking and verbosity in the state level. Cleaned code a lot, removed some bugs and other odd behaviour.
- Updated tests to match the changes. Refactored some test code to be more readable. Added assertions to test that some functions are not
  called when things are already in the desired state. Preferred changing behaviour of the mocked functions while proceeding instead of listing
  all of the return values first.
- Replaced glusterfs.list_peers() with more informative peer_status() and deprecated the old name. The function now returns a dict with UUIDs as its keys.
- glusterfs.info() can now be called without volume name. It always returns a dictionary. Use this function instead of status() in sates.
- Functions glusterfs.delete() and glusterfs.create() were deprecated and renamed to delete_volume() and create_volume().
