### PR TITLE
Add source_hash param to win_pkg

### DIFF
--- a/doc/topics/windows/windows-package-manager.rst
+++ b/doc/topics/windows/windows-package-manager.rst
@@ -408,6 +408,27 @@ Here's an example for a software package that has dependent files:
 the installation. This is useful for running the salt installation itself as
 the installation process kills any currently running instances of salt.
 
+:param str source_hash: This tells salt to compare a hash sum of the installer
+to the provided hash sum before execution. The value can be formatted as
+``hash_algorithm=hash_sum``, or it can be a URI to a file containing the hash
+sum.
+For a list of supported algorithms, see the `hashlib documentation
+<https://docs.python.org/2/library/hashlib.html>`_.
+
+Here's an example of source_hash usage:
+
+.. code-block:: yaml
+
+    messageanalyzer:
+      '4.0.7551.0':
+        full_name: 'Microsoft Message Analyzer'
+        installer: 'salt://win/repo/messageanalyzer/MessageAnalyzer64.msi'
+        install_flags: '/quiet /norestart'
+        uninstaller: '{1CC02C23-8FCD-487E-860C-311EC0A0C933}'
+        uninstall_flags: '/quiet /norestart'
+        msiexec: True
+        source_hash: 'sha1=62875ff451f13b10a8ff988f2943e76a4735d3d4'
+
 :param bool reboot: Not implemented
 
 :param str local: Not implemented


### PR DESCRIPTION
### What does this PR do?
- Adds ability to check the hash sum of installer files to win_pkg. The code is largely influenced or outright lifted from relevant portions of `file.get_managed`.
- Adds documentation for the new parameter.
### What issues does this PR fix or reference?

Addresses issues:
- saltstack/salt#14872
- saltstack/salt-winrepo#492

Additionally, this addresses file integrity concerns raised in:
- saltstack/salt#27093
- saltstack/salt#20737
### Previous Behavior
- Ability to perform these checks did not previously exist.
### New Behavior
- Adds ability to check the hash sum of installer files to win_pkg.
### Tests written?

[ ] Yes
[x] No
- Manually tested both string and URI pattern against Windows 2012r2, running latest develop salt-minion. 
