### PR TITLE
Remove duplicate "timeout" definition in Roster docs

### DIFF
--- a/doc/topics/ssh/roster.rst
+++ b/doc/topics/ssh/roster.rst
@@ -45,5 +45,4 @@ The information which can be stored in a roster ``target`` is the following:
         priv:        # File path to ssh private key, defaults to salt-ssh.rsa
         timeout:     # Number of seconds to wait for response when establishing
                      # an SSH connection
-        timeout:     # Number of seconds to wait for response
         minion_opts: # Dictionary of minion opts


### PR DESCRIPTION
### What does this PR do?

Removes the duplicate definition of `timeout` in the Salt Rosters documentation.
### What issues does this PR fix or reference?

N/A
### Previous Behavior

N/A
### New Behavior

N/A
### Tests written?
- [ ] Yes
- [x] No
