### PR TITLE
rename methods in pkg states test

### DIFF
--- a/tests/integration/states/pkg.py
+++ b/tests/integration/states/pkg.py
@@ -267,7 +267,7 @@ class PkgTest(integration.ModuleCase,
     @destructiveTest
     @skipIf(salt.utils.is_windows(), 'minion is windows')
     @requires_system_grains
-    def test_pkg_with_dot_in_pkgname(self, grains=None):
+    def test_pkg_007_with_dot_in_pkgname(self, grains=None):
         '''
         This tests for the regression found in the following issue:
         https://github.com/saltstack/salt/issues/8614
@@ -286,7 +286,7 @@ class PkgTest(integration.ModuleCase,
 
     @destructiveTest
     @skipIf(salt.utils.is_windows(), 'minion is windows')
-    def test_pkg_latest_with_epoch(self):
+    def test_pkg_008_latest_with_epoch(self):
         '''
         This tests for the following issue:
         https://github.com/saltstack/salt/issues/31014
@@ -298,7 +298,7 @@ class PkgTest(integration.ModuleCase,
         self.assertSaltTrueReturn(ret)
 
     @requires_salt_modules('pkg.info_installed')
-    def test_pkg_latest_with_epch_and_info_installed(self):
+    def test_pkg_009_latest_with_epoch_and_info_installed(self):
         '''
         Need to check to ensure the package has been
         installed after the pkg_latest_epoch sls


### PR DESCRIPTION
### What does this PR do?

It renames 3 methods in the integrations.states.pkg test. 
### What issues does this PR fix or reference?

NA
### Previous Behavior

The tests were failing because test_pkg_latest_with_epoch_and_info_installed was being run before test_pkg_latest_with_epoch. 
### New Behavior

I am following the naming scheme found in the pkg.py state test file: test_pkg_# to ensure the correct order of tests is run
### Tests written?
- [x] Yes
- [ ] No
