### PR TITLE
Don't fork in try with critical finally logic.

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -677,9 +677,11 @@ class Schedule(object):
             # Reconfigure multiprocessing logging after daemonizing
             log_setup.setup_multiprocessing_logging()
 
-        try:
-            salt.utils.daemonize_if(self.opts)
+        # Don't *BEFORE* to go into try to don't let it triple execute the finally section.
+        salt.utils.daemonize_if(self.opts)
 
+        # TODO: Make it readable! Splt to funcs, remove nested try-except-finally sections.
+        try:
             ret['pid'] = os.getpid()
 
             if 'jid_include' not in data or data['jid_include']:


### PR DESCRIPTION
### What does this PR do?

Fixes multimaster minion hanging (or long waiting) on failover when master disappears at runtime.
The problem appear because fork call was moved inside a try section in the scheduler code. This made the final section to be executed twice additionally before the actual scheduled logic.
### What issues does this PR fix or reference?

Fixes: #29567, #30643, #30181.
Fixes a mistake in 5a1b2ca486c5c5ffd9d929b43071a4e9cc56d74a.
Complements #30796: they both should be applied together to fix the mentioned issues.
Affects versions: 2015.8.[4-7], 2016.3
### Previous Behavior

Minion stops to handle minion events on failover to the second master so it doesn't connect.
### New Behavior

Minion properly failover to the next master.
### Tests written?
- [ ] Yes
- [x] No
