### PR TITLE
Add test runner options that were lost in merge-forward

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -87,9 +87,6 @@ TEST_SUITES = {
     'cloud_provider':
        {'display_name': 'Cloud Provider',
         'path': 'integration/cloud/providers'},
-    'grains':
-        {'display_name': 'Grains',
-         'path': 'integration/grains'},
     'minion':
         {'display_name': 'Minion',
          'path': 'integration/minion'}

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -87,6 +87,12 @@ TEST_SUITES = {
     'cloud_provider':
        {'display_name': 'Cloud Provider',
         'path': 'integration/cloud/providers'},
+    'grains':
+        {'display_name': 'Grains',
+         'path': 'integration/grains'},
+    'minion':
+        {'display_name': 'Minion',
+         'path': 'integration/minion'}
 }
 
 


### PR DESCRIPTION
### What does this PR do?

Adds the `grains` and `minion` optparser args to the `TEST_SUITES` dictionary.
### What issues does this PR fix or reference?

runtests.py was refactored in #31476
### Previous Behavior

During the last merge-forward, the new grains and minion options were added to `runtests.py`. These options needed to be added to test_suites from the refactor.
### New Behavior

grains and minion are included in test_suites, allowing them to run.
### Tests written?
- [ ] Yes
- [x] No

ping @jfindlay 
