### PR TITLE
Fix 'failover' mode when using salt-call

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -530,7 +530,9 @@ class SMinion(MinionBase):
         # Clean out the proc directory (default /var/cache/salt/minion/proc)
         if (self.opts.get('file_client', 'remote') == 'remote'
                 or self.opts.get('use_master_when_local', False)):
-            self.eval_master(self.opts, failed=True)
+            LOOP_CLASS.current().run_sync(
+                lambda: self.eval_master(self.opts, failed=True)
+            )
         self.gen_modules(initial_load=True)
 
         # If configured, cache pillar data on the minion


### PR DESCRIPTION
'failover' mode, among other things, was intended to be handled in
`SMinion.__init__`. Unfortunately, the original code simply had:

`self.eval_master(self.opts, failed=True)`

This will do nothing, since `self.eval_master` will return a future
and nothing actually runs that future (it isn't added to any IO loop,
just discarded). Now we synchronously invoke that future to make sure
that this logic is executed before code flow continues.

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
