### PR TITLE
boto_lambda robustness fix in the face of restricted policies

### DIFF
--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -367,7 +367,9 @@ def _function_permissions_present(FunctionName, Permissions,
                            region, key, keyid, profile):
     ret = {'result': True, 'comment': '', 'changes': {}}
     curr_permissions = __salt__['boto_lambda.get_permissions'](FunctionName,
-           region=region, key=key, keyid=keyid, profile=profile)['permissions']
+           region=region, key=key, keyid=keyid, profile=profile).get('permissions')
+    if curr_permissions is None:
+        curr_permissions = {}
     need_update = False
     diffs = salt.utils.compare_dicts(curr_permissions, Permissions)
     if bool(diffs):


### PR DESCRIPTION
### What does this PR do?

Fixes a case when no permissions are obtained for a lambda function when doing function_present.
### What issues does this PR fix or reference?

None
### Previous Behavior

Throws a 'Nonetype is not iterable' exception.
### New Behavior

Correctly handles this case
### Tests written?
- [x] Yes
- [ ] No

A new test has not been written to cover this case, but this code already has unit tests.
