### PR TITLE
Consul Pillar: don't crash on empty values

### DIFF
--- a/salt/pillar/consul_pillar.py
+++ b/salt/pillar/consul_pillar.py
@@ -208,11 +208,13 @@ def pillar_format(ret, keys, value):
     Perform data formatting to be used as pillar data and
     merge it with the current pillar data
     '''
-    # drop leading/trailing whitespace, if any
-    value = value.strip(' \t\n\r')
-    # skip it
+    # if value is empty in Consul then it's None here - skip it
     if value is None:
         return ret
+
+    # drop leading/trailing whitespace, if any
+    value = value.strip(' \t\n\r')
+
     # if wrapped in quotes, drop them
     if value[0] == value[-1] == '"':
         pillar_value = value[1:-1]


### PR DESCRIPTION
### What does this PR do?

Fixes bug in Consul pillar that leads to an exception (and hence no data loaded) when it encounters a key with an empty value.
### What issues does this PR fix or reference?

No issue was created.
### Previous Behavior

Consul pillar expects all values to be strings but empty values returned as None.
### New Behavior

Checking whether value is None before treating it as a string.
### Tests written?
- [ ] Yes
- [x] No
