### PR TITLE
nspawn.py: Fix bad keyword assignment

### DIFF
--- a/salt/modules/nspawn.py
+++ b/salt/modules/nspawn.py
@@ -1319,7 +1319,7 @@ def _pull_image(pull_type, image, name, **kwargs):
 
     bad_kwargs = [x for x in kwargs
                   if not x.startswith('__')
-                  or x not in valid_kwargs]
+                  and x not in valid_kwargs]
 
     if bad_kwargs:
         _invalid_kwargs(*bad_kwargs, **kwargs)


### PR DESCRIPTION
Currently every keyword for _pull_image is considered a bad keyword.

```
% salt node nspawn.pull_tar url bar
ERROR executing 'nspawn.pull_tar': The following invalid keyword arguments were passed: verify=False.
```
