### PR TITLE
[saltstack/salt#31534] Resolve a bug that rest_tornado doesn't response for invalid and dictionary type of request body.

### DIFF
--- a/salt/netapi/rest_tornado/__init__.py
+++ b/salt/netapi/rest_tornado/__init__.py
@@ -6,7 +6,7 @@ import logging
 import os
 import distutils.version  # pylint: disable=no-name-in-module
 
-__virtualname__ = os.path.abspath(__file__).rsplit('/')[-2] or 'rest_cherrypy'
+__virtualname__ = os.path.abspath(__file__).rsplit('/')[-2] or 'rest_tornado'
 
 logger = logging.getLogger(__virtualname__)
 

--- a/tests/integration/netapi/rest_tornado/test_app.py
+++ b/tests/integration/netapi/rest_tornado/test_app.py
@@ -117,6 +117,41 @@ class TestSaltAPIHandler(SaltnadoTestCase):
         response_obj = json.loads(response.body)
         self.assertEqual(response_obj['return'], ["No minions matched the target. No command was sent, no jid was assigned."])
 
+    # local client request body test
+    def test_simple_local_post_only_dictionary_request(self):
+        '''
+        Test a basic API of /
+        '''
+        low = {'client': 'local',
+                'tgt': '*',
+                'fun': 'test.ping',
+              }
+        response = self.fetch('/',
+                              method='POST',
+                              body=json.dumps(low),
+                              headers={'Content-Type': self.content_type_map['json'],
+                                       saltnado.AUTH_TOKEN_HEADER: self.token['token']},
+                              connect_timeout=30,
+                              request_timeout=30,
+                              )
+        response_obj = json.loads(response.body)
+        self.assertEqual(response_obj['return'], [{'minion': True, 'sub_minion': True}])
+
+    def test_simple_local_post_invalid_request(self):
+        '''
+        Test a basic API of /
+        '''
+        low = ["invalid request"]
+        response = self.fetch('/',
+                              method='POST',
+                              body=json.dumps(low),
+                              headers={'Content-Type': self.content_type_map['json'],
+                                       saltnado.AUTH_TOKEN_HEADER: self.token['token']},
+                              connect_timeout=30,
+                              request_timeout=30,
+                              )
+        self.assertEqual(response.code, 400)
+
     # local_batch tests
     @skipIf(True, 'to be reenabled when #23623 is merged')
     def test_simple_local_batch_post(self):


### PR DESCRIPTION
### What does this PR do?
- Resolve a bug that rest_tornado doesn't response for 1. invalid request, 2. dictionary type of request, and add test cases for it.
- Typo in `netapi/rest_tornado/__init__.py`
### What issues does this PR fix or reference?

saltstack/salt#31534
### Previous Behavior

Salt Api raise exceptions without any response for clients for some requests, which are mentioned above on this post.
### New Behavior

Salt Api response for 1. invalid request (valid as json, but not for Salt Api), 2. return results for not only list type of requests, but also only single dictionary type requests.
### Tests written?
- [x] Yes
- [ ] No
