### PR TITLE
Remove debian repo from raspbian installation

### DIFF
--- a/doc/topics/installation/debian.rst
+++ b/doc/topics/installation/debian.rst
@@ -167,7 +167,6 @@ To install fresh release of Salt minion on Jessie:
 
    .. code-block:: bash
 
-       echo 'deb http://httpredir.debian.org/debian jessie-backports main' >> /etc/apt/sources.list
        echo 'deb http://archive.raspbian.org/raspbian/ stretch main' >> /etc/apt/sources.list
 
 #. Make Jessie a default release:
@@ -181,7 +180,7 @@ To install fresh release of Salt minion on Jessie:
    .. code-block:: bash
 
        apt-get update
-       apt-get install python-zmq python-tornado/jessie-backports salt-common/stretch
+       apt-get install python-zmq python-tornado/stretch salt-common/stretch
 
 #. Install Salt minion package from Stretch:
 

--- a/doc/topics/installation/debian.rst
+++ b/doc/topics/installation/debian.rst
@@ -177,6 +177,15 @@ To install fresh release of Salt minion on Jessie:
 
 #. Install Salt dependencies:
 
+   **Debian**:
+   
+   .. code-block:: bash
+   
+       apt-get update
+       apt-get install python-zmq python-tornado/jessie-backports salt-common/stretch
+
+   **Raspbian**:
+   
    .. code-block:: bash
 
        apt-get update


### PR DESCRIPTION
Binary packages from stock debain repo (http://httpredir.debian.org/debian) are not armv6 compatible so should not be installed on Raspberry Pi v1 (A, A+, B, B+). Rasbian doesn't have jessie-backports so safer just to install python-tornado from stretch.

See #24955
