### PR TITLE
Fix WheelClient.cmd() inheritance.

### DIFF
--- a/salt/wheel/__init__.py
+++ b/salt/wheel/__init__.py
@@ -121,6 +121,7 @@ class WheelClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
             >>> wheel.cmd('key.finger', ['jerry'])
             {'minions': {'jerry': '5d:f6:79:43:5e:d4:42:3f:57:b8:45:a8:7e:a4:6e:ca'}}
         '''
+        super(WheelClient, self).cmd(fun, arg, pub_data, kwarg)
 
 
 Wheel = WheelClient  # for backward-compat


### PR DESCRIPTION
### What does this PR do?

Fixes `WheelClient.cmd()` method override.
### What issues does this PR fix or reference?

Nope, by request from @cro 
### Previous Behavior

As I can see, originally the method was overridden just to overwrite the method docstring. But it wasn't calling the parent method that was the mistake. Then it was changed to call low() method instead of parent cmd that creates the correct data and calls low. That was incorrect too and I've reverted the change.
### New Behavior

Just call the parent cmd() method.
### Tests written?
- [ ] Yes
- [x] No

The method is overriden just to update the PyDoc string. So it should
call parent method.
