### PR TITLE
Added temporary workaround for CentOS 7 os-release id bug.

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1260,6 +1260,13 @@ def os_data():
             grains['osfullname'] = \
                 grains.get('lsb_distrib_id', osname).strip()
         if 'osrelease' not in grains:
+            # NOTE: This is a workaround for CentOS 7 os-release bug
+            # https://bugs.centos.org/view.php?id=8359
+            # /etc/os-release contains no minor distro release number so we fall back to parse
+            # /etc/centos-release file instead.
+            # Commit introducing this comment should be reverted after the upstream bug is released.
+            if 'CentOS Linux 7' in grains.get('lsb_distrib_codename', ''):
+                grains.pop('lsb_distrib_release', None)
             grains['osrelease'] = \
                 grains.get('lsb_distrib_release', osrelease).strip()
         grains['oscodename'] = grains.get('lsb_distrib_codename',


### PR DESCRIPTION
### What does this PR do?

Use /etc/centos-release file to get the os release number instead of /etc/os-release if the os is CentOS 7. This is done because CentOS 7 lacks minor release id number in the os-release file that is a known opened but https://bugs.centos.org/view.php?id=8359
### What issues does this PR fix or reference?

Fixes: #31365 
### Previous Behavior

Set grains release id to 7
### New Behavior

Set grains release id to 7.2.1511 (in my case)
### Tests written?
- [ ] Yes
- [x] No
