### PR TITLE
Protect getattr from recursion

### DIFF
--- a/salt/utils/async.py
+++ b/salt/utils/async.py
@@ -61,8 +61,9 @@ class SyncWrapper(object):
     def __getattribute__(self, key):
         try:
             return object.__getattribute__(self, key)
-        except AttributeError:
-            pass
+        except AttributeError as ex:
+            if key == 'async':
+                raise ex
         attr = getattr(self.async, key)
         if hasattr(attr, '__call__'):
             def wrap(*args, **kwargs):


### PR DESCRIPTION
### What does this PR do?

Protect `SyncWrapper.__getattribute__()` from infinity recursion if called on an object having no attribute `async`. This happens if constructor raises an error before the attribute is assigned after this `__del__` method checks for the attribute that downs the code into the recursion calls to `__getattribute`
### What issues does this PR fix or reference?

Fixes `salt-call` errors on accessing `/etc/salt/pki/minion`:

```
Exception ValueError: 'I/O operation on closed file' in <bound method SyncWrapper.__del__ of <salt.utils.async.SyncWrapper object at 0x28a3f50>> ignored
```

mentioned in #27063 and #29701.
### Previous Behavior

`SyncWrapper` goes to the infinitie recursion calls until the stack limit is reached if an exception throwed in `SyncWrapper.__init__()` that could produce a number of different errors.
### New Behavior

Don't use custrom code to get the `async` attribute in `__getattribute__` if it requested. Just use basic `object` logic for this case.
### Tests written?
- [ ] Yes
- [x] No
