### PR TITLE
boto_lambda: Add support for VPC access

### DIFF
--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -116,7 +116,7 @@ def __virtual__():
     a given version.
     '''
     required_boto_version = '2.8.0'
-    required_boto3_version = '1.2.1'
+    required_boto3_version = '1.2.5'
     # the boto_lambda execution module relies on the connect_to_region() method
     # which was added in boto 2.8.0
     # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
@@ -200,6 +200,7 @@ def _filedata(infile):
 def create_function(FunctionName, Runtime, Role, Handler, ZipFile=None,
                     S3Bucket=None, S3Key=None, S3ObjectVersion=None,
                     Description="", Timeout=3, MemorySize=128, Publish=False,
+                    VpcConfig=None,
                     WaitForRole=False, RoleRetries=5,
             region=None, key=None, keyid=None, profile=None):
     '''
@@ -236,6 +237,9 @@ def create_function(FunctionName, Runtime, Role, Handler, ZipFile=None,
             }
             if S3ObjectVersion:
                 code['S3ObjectVersion'] = S3ObjectVersion
+        kwargs = {}
+        if VpcConfig is not None:
+            kwargs['VpcConfig'] = VpcConfig
         if WaitForRole:
             retrycount = RoleRetries
         else:
@@ -244,7 +248,7 @@ def create_function(FunctionName, Runtime, Role, Handler, ZipFile=None,
             try:
                 func = conn.create_function(FunctionName=FunctionName, Runtime=Runtime, Role=role_arn, Handler=Handler,
                                    Code=code, Description=Description, Timeout=Timeout, MemorySize=MemorySize,
-                                   Publish=Publish)
+                                   Publish=Publish, **kwargs)
             except ClientError as e:
                 if retry > 1 and e.response.get('Error', {}).get('Code') == 'InvalidParameterValueException':
                     log.info('Function not created but IAM role may not have propagated, will retry')
@@ -313,7 +317,7 @@ def describe_function(FunctionName, region=None, key=None,
         if func:
             keys = ('FunctionName', 'Runtime', 'Role', 'Handler', 'CodeSha256',
                 'CodeSize', 'Description', 'Timeout', 'MemorySize', 'FunctionArn',
-                'LastModified')
+                'LastModified', 'VpcConfig')
             return {'function': dict([(k, func.get(k)) for k in keys])}
         else:
             return {'function': None}
@@ -323,6 +327,7 @@ def describe_function(FunctionName, region=None, key=None,
 
 def update_function_config(FunctionName, Role=None, Handler=None,
                            Description=None, Timeout=None, MemorySize=None,
+                           VpcConfig=None,
             region=None, key=None, keyid=None, profile=None):
     '''
     Update the named lambda function to the configuration.
@@ -344,6 +349,7 @@ def update_function_config(FunctionName, Role=None, Handler=None,
         'Description': Description,
         'Timeout': Timeout,
         'MemorySize': MemorySize,
+        'VpcConfig': VpcConfig,
     }.iteritems():
         if var:
             args[val] = var
@@ -356,7 +362,7 @@ def update_function_config(FunctionName, Role=None, Handler=None,
         if r:
             keys = ('FunctionName', 'Runtime', 'Role', 'Handler', 'CodeSha256',
                 'CodeSize', 'Description', 'Timeout', 'MemorySize', 'FunctionArn',
-                'LastModified')
+                'LastModified', 'VpcConfig')
             return {'updated': True, 'function': dict([(k, r.get(k)) for k in keys])}
         else:
             log.warning('Function was not updated')
@@ -406,7 +412,7 @@ def update_function_code(FunctionName, ZipFile=None, S3Bucket=None, S3Key=None,
         if r:
             keys = ('FunctionName', 'Runtime', 'Role', 'Handler', 'CodeSha256',
                 'CodeSize', 'Description', 'Timeout', 'MemorySize', 'FunctionArn',
-                'LastModified')
+                'LastModified', 'VpcConfig')
             return {'updated': True, 'function': dict([(k, r.get(k)) for k in keys])}
         else:
             log.warning('Function was not updated')

--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -200,9 +200,8 @@ def _filedata(infile):
 def create_function(FunctionName, Runtime, Role, Handler, ZipFile=None,
                     S3Bucket=None, S3Key=None, S3ObjectVersion=None,
                     Description="", Timeout=3, MemorySize=128, Publish=False,
-                    VpcConfig=None,
                     WaitForRole=False, RoleRetries=5,
-            region=None, key=None, keyid=None, profile=None):
+            region=None, key=None, keyid=None, profile=None, VpcConfig=None):
     '''
     Given a valid config, create a function.
 
@@ -327,8 +326,7 @@ def describe_function(FunctionName, region=None, key=None,
 
 def update_function_config(FunctionName, Role=None, Handler=None,
                            Description=None, Timeout=None, MemorySize=None,
-                           VpcConfig=None,
-            region=None, key=None, keyid=None, profile=None):
+            region=None, key=None, keyid=None, profile=None, VpcConfig=None):
     '''
     Update the named lambda function to the configuration.
 

--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -83,6 +83,7 @@ def __virtual__():
 def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S3Bucket=None,
             S3Key=None, S3ObjectVersion=None,
             Description='', Timeout=3, MemorySize=128,
+            VpcConfig=None,
             Permissions=None, RoleRetries=5,
             region=None, key=None, keyid=None, profile=None):
     '''
@@ -140,6 +141,12 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S
         CPU and memory requirements. For example, a database operation might need less memory compared
         to an image processing function. The default value is 128 MB. The value must be a multiple of
         64 MB.
+
+    VpcConfig
+        If your Lambda function accesses resources in a VPC, you provide this
+        parameter identifying the list of security group IDs and subnet IDs.
+        These must belong to the same VPC. You must provide at least one
+        security group and one subnet ID.
 
     Permissions
         A list of permission definitions to be added to the function's policy
@@ -203,6 +210,7 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S
                                                     S3ObjectVersion=S3ObjectVersion,
                                                     Description=Description,
                                                     Timeout=Timeout, MemorySize=MemorySize,
+                                                    VpcConfig=VpcConfig,
                                                     WaitForRole=True,
                                                     RoleRetries=RoleRetries,
                                                     region=region, key=key,
@@ -234,7 +242,7 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S
     ret['changes'] = {}
     # function exists, ensure config matches
     _ret = _function_config_present(FunctionName, Role, Handler, Description, Timeout,
-                                  MemorySize, region, key, keyid, profile)
+                                  MemorySize, VpcConfig, region, key, keyid, profile)
     if not _ret.get('result'):
         ret['result'] = False
         ret['comment'] = _ret['comment']
@@ -274,7 +282,7 @@ def _get_role_arn(name, region=None, key=None, keyid=None, profile=None):
 
 
 def _function_config_present(FunctionName, Role, Handler, Description, Timeout,
-                           MemorySize, region, key, keyid, profile):
+                           MemorySize, VpcConfig, region, key, keyid, profile):
     ret = {'result': True, 'comment': '', 'changes': {}}
     func = __salt__['boto_lambda.describe_function'](FunctionName,
            region=region, key=key, keyid=keyid, profile=profile)['function']
@@ -291,6 +299,13 @@ def _function_config_present(FunctionName, Role, Handler, Description, Timeout,
             need_update = True
             ret['changes'].setdefault('new', {})[var] = locals()[var]
             ret['changes'].setdefault('old', {})[var] = func[val]
+    # VpcConfig returns the extra value 'VpcId' so do a special compare
+    oldval = func.get('VpcConfig', {})
+    oldval.pop('VpcId', None)
+    if oldval != VpcConfig:
+        need_update = True
+        ret['changes'].setdefault('new', {})['VpcConfig'] = VpcConfig
+        ret['changes'].setdefault('old', {})['VpcConfig'] = func.get('VpcConfig')
     if need_update:
         ret['comment'] = os.linesep.join([ret['comment'], 'Function config to be modified'])
         if __opts__['test']:
@@ -301,6 +316,7 @@ def _function_config_present(FunctionName, Role, Handler, Description, Timeout,
         _r = __salt__['boto_lambda.update_function_config'](FunctionName=FunctionName,
                                         Role=Role, Handler=Handler, Description=Description,
                                         Timeout=Timeout, MemorySize=MemorySize,
+                                        VpcConfig=VpcConfig,
                                         region=region, key=key,
                                         keyid=keyid, profile=profile)
         if not _r.get('updated'):

--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -83,9 +83,8 @@ def __virtual__():
 def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S3Bucket=None,
             S3Key=None, S3ObjectVersion=None,
             Description='', Timeout=3, MemorySize=128,
-            VpcConfig=None,
             Permissions=None, RoleRetries=5,
-            region=None, key=None, keyid=None, profile=None):
+            region=None, key=None, keyid=None, profile=None, VpcConfig=None):
     '''
     Ensure function exists.
 
@@ -147,6 +146,8 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S
         parameter identifying the list of security group IDs and subnet IDs.
         These must belong to the same VPC. You must provide at least one
         security group and one subnet ID.
+
+        .. versionadded:: Carbon
 
     Permissions
         A list of permission definitions to be added to the function's policy


### PR DESCRIPTION
### What does this PR do?

Amazon recently announced new config that lets a lambda function access resources that are in a VPC. This adds parameters to the relevant boto_lambda functions to make that functionality accessible. Requires a bump to the minimum rev of boto3.
### What issues does this PR fix or reference?

None
### Previous Behavior

No support for VPC
### New Behavior

Access VPC
### Tests written?
- [x] Yes
- [ ] No
