### PR TITLE
Correct versionadded tag for win_service.config

### DIFF
--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -458,7 +458,7 @@ def config(name,
     r'''
     Modify the named service.
 
-    .. versionadded:: 2015.8.6
+    .. versionadded:: 2015.8.8
 
     Required parameters:
 


### PR DESCRIPTION
### What does this PR do?

Adjusts the versionadded tag for the win_service.config function.
### What issues does this PR fix or reference?
#31041 and #31049
### Previous Behavior

The docs display 2015.5.6 as the version this was added, but this is incorrect. The function is actually available starting in 2015.8.8.
### New Behavior

Correctly identifies the versionadded release as 2015.8.8.
### Tests written?
- [ ] Yes
- [x] No
