### PR TITLE
fix regex so that entire line in mdadm config will be replaced, not o…

### DIFF
--- a/salt/modules/mdadm.py
+++ b/salt/modules/mdadm.py
@@ -290,12 +290,16 @@ def save_config():
     try:
         vol_d = dict([(line.split()[1], line) for line in scan])
         for vol in vol_d:
-            pattern = r'^ARRAY\s+{0}'.format(re.escape(vol))
+            pattern = r'^ARRAY\s+{0}.*$'.format(re.escape(vol))
             __salt__['file.replace'](cfg_file, pattern, vol_d[vol], append_if_not_found=True)
     except SaltInvocationError:  # File is missing
         __salt__['file.write'](cfg_file, args=scan)
 
-    return __salt__['cmd.run']('update-initramfs -u')
+    if __grains__.get('os_family') == 'Debian':
+      return __salt__['cmd.run']('update-initramfs -u')
+    elif __grains__.get('os_family') == 'RedHat':
+      return __salt__['cmd.run']('dracut --force')
+
 
 
 def assemble(name,


### PR DESCRIPTION
### What does this PR do?
- In `save_config` updates the mdadm config file incorrectly, since only the matched prefix is replaced. Instead, the _entire_ line must be replaced by the output of the RAID scan.
- On CentOS, calling `update-initramfs` results in an error since that utility does not exists. Instead, we must use `dracut`.
### Tests written?
- has been tested on CentOS successfully.

…nly the matched prefix. Also, the update-initramfs utility is available only on Debian. On RedHat, use dracut.
