### PR TITLE
[saltstack/salt#31534] Resolve data['arg'] type issue. Now rest_tornado can accept not only a list of string type for 'arg', but also a string type data for 'arg'.

### DIFF
--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -565,14 +565,14 @@ class BaseSaltAPIHandler(tornado.web.RequestHandler, SaltClientsMixIn):  # pylin
         data = self.deserialize(self.request.body)
         self.raw_data = copy(data)
 
-        if self.request.headers.get('Content-Type') == 'application/x-www-form-urlencoded':
-            if 'arg' in data and not isinstance(data['arg'], list):
-                data['arg'] = [data['arg']]
-            lowstate = [data]
-        elif type(data) != list:
+        if 'arg' in data and not isinstance(data['arg'], list):
+            data['arg'] = [data['arg']]
+
+        if not isinstance(data, list):
             lowstate = [data]
         else:
             lowstate = data
+
         return lowstate
 
     def set_default_headers(self):

--- a/tests/unit/netapi/rest_tornado/test_handlers.py
+++ b/tests/unit/netapi/rest_tornado/test_handlers.py
@@ -272,6 +272,91 @@ class TestBaseSaltAPIHandler(SaltnadoTestCase):
                               headers={'Content-Type': self.content_type_map['json-utf8']})
         self.assertEqual(valid_lowstate, json.loads(response.body)['lowstate'])
 
+    def test_get_lowstate(self):
+        '''
+        Test transformations low data of the function _get_lowstate
+        '''
+        valid_lowstate = [{
+                "client": "local",
+                "tgt": "*",
+                "fun": "test.fib",
+                "arg": ["10"]
+            }]
+
+        # Case 1. dictionary type of lowstate
+        request_lowstate = {
+                "client": "local",
+                "tgt": "*",
+                "fun": "test.fib",
+                "arg": ["10"]
+            }
+
+        response = self.fetch('/',
+                              method='POST',
+                              body=json.dumps(request_lowstate),
+                              headers={'Content-Type': self.content_type_map['json']})
+
+        self.assertEqual(valid_lowstate, json.loads(response.body)['lowstate'])
+
+        # Case 2. string type of arg
+        request_lowstate = [{
+                "client": "local",
+                "tgt": "*",
+                "fun": "test.fib",
+                "arg": "10"
+            }]
+
+        response = self.fetch('/',
+                              method='POST',
+                              body=json.dumps(request_lowstate),
+                              headers={'Content-Type': self.content_type_map['json']})
+
+        self.assertEqual(valid_lowstate, json.loads(response.body)['lowstate'])
+
+        # Case 3. Combine Case 1 and Case 2.
+        request_lowstate = {
+                "client": "local",
+                "tgt": "*",
+                "fun": "test.fib",
+                "arg": "10"
+            }
+
+        # send as json
+        response = self.fetch('/',
+                              method='POST',
+                              body=json.dumps(request_lowstate),
+                              headers={'Content-Type': self.content_type_map['json']})
+
+        self.assertEqual(valid_lowstate, json.loads(response.body)['lowstate'])
+
+        # send as yaml
+        response = self.fetch('/',
+                              method='POST',
+                              body=yaml.dump(request_lowstate),
+                              headers={'Content-Type': self.content_type_map['yaml']})
+        self.assertEqual(valid_lowstate, json.loads(response.body)['lowstate'])
+
+        # send as plain text
+        response = self.fetch('/',
+                              method='POST',
+                              body=json.dumps(request_lowstate),
+                              headers={'Content-Type': self.content_type_map['text']})
+        self.assertEqual(valid_lowstate, json.loads(response.body)['lowstate'])
+
+        # send as form-urlencoded
+        request_form_lowstate = (
+            ('client', 'local'),
+            ('tgt', '*'),
+            ('fun', 'test.fib'),
+            ('arg', '10'),
+        )
+
+        response = self.fetch('/',
+                              method='POST',
+                              body=urlencode(request_form_lowstate),
+                              headers={'Content-Type': self.content_type_map['form']})
+        self.assertEqual(valid_lowstate, json.loads(response.body)['lowstate'])
+
     def test_cors_origin_wildcard(self):
         '''
         Check that endpoints returns Access-Control-Allow-Origin


### PR DESCRIPTION
### What does this PR do?

Resolve type handling issue for `data['arg']` in `rest_tornado`.
### What issues does this PR fix or reference?

saltstack/salt#31534
### Previous Behavior

When user try to call Salt Api with a string type for 'arg' parameter, `rest_tornado` receives error from Salt Minion such as `The shell   is not available` and returns it as a response.
### New Behavior

Work well not only a list of string for 'arg' parameter, but also a string for 'arg'.
### Tests written?
- [x] Yes
- [ ] No
