### PR TITLE
Don't stacktrace if ssh binary is not installed with salt-ssh

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -164,6 +164,8 @@ class SSH(object):
         else:
             self.event = None
         self.opts = opts
+        if not salt.utils.which('ssh'):
+            raise salt.exceptions.SaltSystemExit('No ssh binary found in path -- ssh must be installed for salt-ssh to run. Exiting.')
         self.opts['_ssh_version'] = ssh_version()
         self.tgt_type = self.opts['selected_target_option'] \
                 if self.opts['selected_target_option'] else 'glob'


### PR DESCRIPTION
### What does this PR do?

Prevents the following stacktrace:

```
[root@a560d76a7f4c /]# salt-ssh localhost test.ping
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
OSError: [Errno 2] No such file or directory
Traceback (most recent call last):
  File "/usr/bin/salt-ssh", line 10, in <module>
    salt_ssh()
  File "/usr/lib/python2.6/site-packages/salt/scripts.py", line 381, in salt_ssh
    client.run()
  File "/usr/lib/python2.6/site-packages/salt/cli/ssh.py", line 20, in run
    ssh = salt.client.ssh.SSH(self.config)
  File "/usr/lib/python2.6/site-packages/salt/client/ssh/__init__.py", line 172, in __init__
    self.opts['_ssh_version'] = ssh_version()
  File "/usr/lib/python2.6/site-packages/salt/client/ssh/__init__.py", line 1251, in ssh_version
    stderr=subprocess.PIPE).communicate()
  File "/usr/lib64/python2.6/subprocess.py", line 623, in __init__
    errread, errwrite)
  File "/usr/lib64/python2.6/subprocess.py", line 1141, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```
### What issues does this PR fix or reference?

An issue where the `ssh` binary is not installed on a system.
### Previous Behavior

Above stacktrace
### New Behavior

`No ssh binary found in path -- ssh must be installed for salt-ssh to run. Exiting.`
### Tests written?
- [ ] Yes
- [x] No
