### PR TITLE
Restore FIPS compliance when using master_finger

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -2048,7 +2048,7 @@ class Map(Cloud):
             master_temp_pub = salt.utils.mkstemp()
             with salt.utils.fopen(master_temp_pub, 'w') as mtp:
                 mtp.write(pub)
-            master_finger = salt.utils.pem_finger(master_temp_pub)
+            master_finger = salt.utils.pem_finger(master_temp_pub, sum_type=self.opts['hash_type'])
             os.unlink(master_temp_pub)
 
             if master_profile.get('make_minion', True) is True:
@@ -2133,7 +2133,7 @@ class Map(Cloud):
             # mitigate man-in-the-middle attacks
             master_pub = os.path.join(self.opts['pki_dir'], 'master.pub')
             if os.path.isfile(master_pub):
-                master_finger = salt.utils.pem_finger(master_pub)
+                master_finger = salt.utils.pem_finger(master_pub, sum_type=self.opts['hash_type'])
 
         opts = self.opts.copy()
         if self.opts['parallel']:

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -1071,11 +1071,11 @@ class SAuth(AsyncAuth):
         if self.opts.get('syndic_master', False):  # Is syndic
             syndic_finger = self.opts.get('syndic_finger', self.opts.get('master_finger', False))
             if syndic_finger:
-                if salt.utils.pem_finger(m_pub_fn) != syndic_finger:
+                if salt.utils.pem_finger(m_pub_fn, sum_type=self.opts['hash_type']) != syndic_finger:
                     self._finger_fail(syndic_finger, m_pub_fn)
         else:
             if self.opts.get('master_finger', False):
-                if salt.utils.pem_finger(m_pub_fn) != self.opts['master_finger']:
+                if salt.utils.pem_finger(m_pub_fn, sum_type=self.opts['hash_type']) != self.opts['master_finger']:
                     self._finger_fail(self.opts['master_finger'], m_pub_fn)
         auth['publish_port'] = payload['publish_port']
         return auth
@@ -1089,7 +1089,7 @@ class SAuth(AsyncAuth):
             'this minion is not subject to a man-in-the-middle attack.'
             .format(
                 finger,
-                salt.utils.pem_finger(master_key)
+                salt.utils.pem_finger(master_key, sum_type=self.opts['hash_type'])
             )
         )
         sys.exit(42)

--- a/salt/key.py
+++ b/salt/key.py
@@ -933,7 +933,7 @@ class Key(object):
                     path = os.path.join(self.opts['pki_dir'], key)
                 else:
                     path = os.path.join(self.opts['pki_dir'], status, key)
-                ret[status][key] = salt.utils.pem_finger(path)
+                ret[status][key] = salt.utils.pem_finger(path, sum_type=self.opts['hash_type'])
         return ret
 
     def finger_all(self):
@@ -948,7 +948,7 @@ class Key(object):
                     path = os.path.join(self.opts['pki_dir'], key)
                 else:
                     path = os.path.join(self.opts['pki_dir'], status, key)
-                ret[status][key] = salt.utils.pem_finger(path)
+                ret[status][key] = salt.utils.pem_finger(path, sum_type=self.opts['hash_type'])
         return ret
 
 

--- a/salt/modules/key.py
+++ b/salt/modules/key.py
@@ -22,7 +22,8 @@ def finger():
         salt '*' key.finger
     '''
     return salt.utils.pem_finger(
-            os.path.join(__opts__['pki_dir'], 'minion.pub')
+            os.path.join(__opts__['pki_dir'], 'minion.pub'),
+	    sum_type=__opts__['hash_type']
             )
 
 
@@ -37,5 +38,6 @@ def finger_master():
         salt '*' key.finger_master
     '''
     return salt.utils.pem_finger(
-            os.path.join(__opts__['pki_dir'], 'minion_master.pub')
+            os.path.join(__opts__['pki_dir'], 'minion_master.pub'),
+	    sum_type=__opts__['hash_type']
             )

--- a/salt/modules/key.py
+++ b/salt/modules/key.py
@@ -23,7 +23,7 @@ def finger():
     '''
     return salt.utils.pem_finger(
             os.path.join(__opts__['pki_dir'], 'minion.pub'),
-	    sum_type=__opts__['hash_type']
+            sum_type=__opts__['hash_type']
             )
 
 
@@ -39,5 +39,5 @@ def finger_master():
     '''
     return salt.utils.pem_finger(
             os.path.join(__opts__['pki_dir'], 'minion_master.pub'),
-	    sum_type=__opts__['hash_type']
+            sum_type=__opts__['hash_type']
             )

--- a/tests/unit/modules/key_test.py
+++ b/tests/unit/modules/key_test.py
@@ -37,7 +37,7 @@ class KeyTestCase(TestCase):
             with patch.object(salt.utils,
                               'pem_finger', return_value='A'):
                 with patch.dict(key.__opts__,
-                                {'pki_dir': MagicMock(return_value='A')}):
+                        {'pki_dir': MagicMock(return_value='A'), 'hash_type': 'sha256'}):
                     self.assertEqual(key.finger(), 'A')
 
     def test_finger_master(self):
@@ -48,7 +48,7 @@ class KeyTestCase(TestCase):
             with patch.object(salt.utils,
                               'pem_finger', return_value='A'):
                 with patch.dict(key.__opts__,
-                                {'pki_dir': 'A'}):
+                        {'pki_dir': 'A', 'hash_type': 'sha256'}):
                     self.assertEqual(key.finger_master(), 'A')
 
 


### PR DESCRIPTION
### What does this PR do?

Fixes a crash in the salt-minion and in salt-key when FIPS mode is enabled and the `master_finger` option is used.
### What issues does this PR fix or reference?
#28585
### Previous Behavior

```
[root@mp-fips salt]# salt-key -F
Traceback (most recent call last):
  File "/usr/bin/salt-key", line 10, in <module>
    salt_key()
  File "/usr/lib/python2.6/site-packages/salt/scripts.py", line 181, in salt_key
    client.run()
  File "/usr/lib/python2.6/site-packages/salt/cli/key.py", line 62, in run
    key.run()
  File "/usr/lib/python2.6/site-packages/salt/key.py", line 427, in run
    self.finger_all()
  File "/usr/lib/python2.6/site-packages/salt/key.py", line 313, in finger_all
    matches = self.key.finger('*')
  File "/usr/lib/python2.6/site-packages/salt/key.py", line 862, in finger
    ret[status][key] = salt.utils.pem_finger(path)
  File "/usr/lib/python2.6/site-packages/salt/utils/__init__.py", line 704, in pem_finger
    pre = getattr(hashlib, sum_type)(key).hexdigest()
ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
```

Other similar stacktraces for calls to `pem_finger` as well, both in the master and minion.
### New Behavior

No stacktraces.
### Tests written?
- [ ] Yes
- [x] No

Resolves #28585
