### PR TITLE
Grant permissions using SID instead of name

### DIFF
--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -225,7 +225,7 @@ Section "MainSection" SEC01
   SetOverwrite off
   CreateDirectory $INSTDIR\conf\pki\minion
   File /r "..\buildenv\"
-  Exec 'icacls c:\salt /inheritance:r /grant:r "BUILTIN\Administrators":(OI)(CI)F /grant:r "NT AUTHORITY\SYSTEM":(OI)(CI)F'
+  Exec 'icacls c:\salt /inheritance:r /grant:r "*S-1-5-32-544":(OI)(CI)F /grant:r "*S-1-5-18":(OI)(CI)F'
 
 SectionEnd
 


### PR DESCRIPTION
### What does this PR do?

Grant Permissions using SID instead of Name
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/31428
### Previous Behavior

Worked fine in english. The problem was with other language installation of windows. The Administrators groups is called something else in french. The SID is consistent across all languages.
### New Behavior

Uses SID
### Tests written?
- [ ] Yes
- [ ] No
- [x] NA
