### PR TITLE
Use win_reg for registry calls

### DIFF
--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -143,6 +143,30 @@ def broadcast_change():
 
 
 def list_keys(hive, key=None, use_32bit_registry=False):
+    '''
+    Enumerates the subkeys in a registry key or hive.
+
+    :param str hive: The name of the hive. Can be one of the following
+
+        - HKEY_LOCAL_MACHINE or HKLM
+        - HKEY_CURRENT_USER or HKCU
+        - HKEY_USER or HKU
+
+    :param str key: The key (looks like a path) to the value name. If a key is
+        not passed, the keys under the hive will be returned.
+
+    :param bool use_32bit_registry: Accesses the 32bit portion of the registry
+        on 64 bit installations. On 32bit machines this is ignored.
+
+    :return: A list of keys/subkeys under the hive or key.
+    :rtype: list
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' reg.list_keys HKLM 'SOFTWARE'
+    '''
     registry = Registry()
     hkey = registry.hkeys[hive]
     access_mask = registry.registry_32[use_32bit_registry]

--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -142,6 +142,30 @@ def broadcast_change():
     return not bool(res)
 
 
+def list_keys(hive, key=None, use_32bit_registry=False):
+    registry = Registry()
+    hkey = registry.hkeys[hive]
+    access_mask = registry.registry_32[use_32bit_registry]
+
+    subkeys = []
+    try:
+        handle = _winreg.OpenKey(hkey, key, 0, access_mask)
+        i = 0
+        while True:
+            try:
+                subkey = _winreg.EnumKey(handle, i)
+                subkeys.append(subkey)
+                i += 1
+            except WindowsError:  # pylint: disable=E0602
+                break
+    except WindowsError as exc:  # pylint: disable=E0602
+        log.debug(exc)
+        log.debug('Cannot find key: {0}\\{1}'.format(hive, key))
+        return False, 'Cannot find key: {0}\\{1}'.format(hive, key)
+
+    return subkeys
+
+
 def read_key(hkey, path, key=None, use_32bit_registry=False):
     '''
     .. important::

--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -174,14 +174,13 @@ def list_keys(hive, key=None, use_32bit_registry=False):
     subkeys = []
     try:
         handle = _winreg.OpenKey(hkey, key, 0, access_mask)
-        i = 0
-        while True:
-            try:
-                subkey = _winreg.EnumKey(handle, i)
-                subkeys.append(subkey)
-                i += 1
-            except WindowsError:  # pylint: disable=E0602
-                break
+
+        for i in range(_winreg.QueryInfoKey(handle)[0]):
+            subkey = _winreg.EnumKey(handle, i)
+            subkeys.append(subkey)
+
+        handle.Close()
+
     except WindowsError as exc:  # pylint: disable=E0602
         log.debug(exc)
         log.debug('Cannot find key: {0}\\{1}'.format(hive, key))

--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -35,6 +35,7 @@ Values/Entries are name/data pairs. There can be many values in a key. The
 # Import python libs
 from __future__ import absolute_import
 import logging
+from salt.ext.six.moves import range
 
 # Import third party libs
 try:

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -15,11 +15,6 @@ from distutils.version import LooseVersion  # pylint: disable=import-error,no-na
 import salt.ext.six as six
 # pylint: disable=import-error
 try:
-    from salt.ext.six.moves import winreg as _winreg  # pylint: disable=import-error,no-name-in-module
-    HAS_DEPENDENCIES = True
-except ImportError:
-    HAS_DEPENDENCIES = False
-try:
     import msgpack
 except ImportError:
     import msgpack_pure as msgpack
@@ -41,7 +36,7 @@ def __virtual__():
     '''
     Set the virtual pkg module if the os is Windows
     '''
-    if salt.utils.is_windows() and HAS_DEPENDENCIES:
+    if salt.utils.is_windows():
         return __virtualname__
     return (False, "Module win_pkg: module only works on Windows systems")
 
@@ -231,7 +226,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
     for pkg_name, val in six.iteritems(_get_reg_software()):
         if pkg_name in name_map:
             key = name_map[pkg_name]
-            if val in ['Not Found', None, False]:
+            if val in ['(value not set)', 'Not Found', None, False]:
                 # Look up version from winrepo
                 pkg_info = _get_package_info(key)
                 if not pkg_info:
@@ -270,79 +265,6 @@ def _get_reg_software():
     a match in the sub keys, it will return a dict with the
     display name as the key and the version as the value
     '''
-    reg_software = {}
-
-    #attempt to corral the wild west of the multiple ways to install
-    #software in windows
-    reg_entries = dict(_get_machine_keys().items())
-    for reg_hive, reg_keys in six.iteritems(reg_entries):
-        for reg_key in reg_keys:
-
-            reg_handle = _open_registry_key(reg_hive, reg_key)
-            if reg_handle is None:
-                continue
-
-            products = _get_product_information(reg_hive, reg_key, reg_handle)
-            reg_software.update(products)
-
-            _winreg.CloseKey(reg_handle)
-
-    return reg_software
-
-
-def _get_machine_keys():
-    '''
-    This will return the hive 'const' value and some registry keys where
-    installed software information has been known to exist for the
-    HKEY_LOCAL_MACHINE hive
-    '''
-    machine_hive_and_keys = {}
-    machine_keys = [
-        "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
-        "Software\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall"
-    ]
-    machine_hive = _winreg.HKEY_LOCAL_MACHINE
-    machine_hive_and_keys[machine_hive] = machine_keys
-    return machine_hive_and_keys
-
-
-def _open_registry_key(reg_hive, reg_key):
-    reg_handle = None
-    try:
-        flags = _get_flags(reg_hive)
-
-        reg_handle = _winreg.OpenKeyEx(
-            reg_hive,
-            reg_key,
-            0,
-            flags)
-    # Unsinstall key may not exist for all users
-    except Exception:
-        pass
-
-    return reg_handle
-
-
-def _get_flags(reg_hive):
-    try:
-        reflect = _winreg.QueryReflectionKey(reg_hive)
-    except NotImplemented:
-        flags = reg_hive
-    else:
-        if reflect:
-            flags = _winreg.KEY_READ | _winreg.KEY_WOW64_64KEY
-        else:
-            flags = _winreg.KEY_READ | _winreg.KEY_WOW64_32KEY
-
-    return flags
-
-
-def _get_product_information(reg_hive, reg_key, reg_handle):
-
-    # This is a list of default OS reg entries that don't seem to be installed
-    # software and no version information exists on any of these items
-    # Also, some MS Office updates don't register a product name which means
-    # their information is useless.
     ignore_list = ['AddressBook',
                    'Connection Manager',
                    'DirectDrawEx',
@@ -354,44 +276,46 @@ def _get_product_information(reg_hive, reg_key, reg_handle):
                    'MobileOptionPack',
                    'SchedulingAgent',
                    'WIC',
-                   'Not Found']
+                   'Not Found',
+                   '(value not set)',
+                   '']
     encoding = locale.getpreferredencoding()
+    reg_software = {}
 
-    products = {}
-    try:
-        i = 0
-        while True:
-            product_key = None
-            asubkey = _winreg.EnumKey(reg_handle, i)
-            rd_uninst_key = "\\".join([reg_key, asubkey])
-            displayName = ''
-            displayVersion = ''
-            try:
-                # these are not garuanteed to exist
-                product_key = _open_registry_key(reg_hive, rd_uninst_key)
-                displayName, value_type = _winreg.QueryValueEx(product_key, "DisplayName")
-                try:
-                    displayName = displayName.decode(encoding)
-                except Exception:
-                    pass
-                displayVersion, value_type = _winreg.QueryValueEx(product_key, "DisplayVersion")
-            except Exception:
-                pass
+    hive = 'HKLM'
+    key = "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall"
 
-            if product_key is not None:
-                _winreg.CloseKey(product_key)
-            i += 1
+    def update(hive, key, reg_key, use_32bit):
 
-            if displayName not in ignore_list:
-                # some MS Office updates don't register a product name which means
-                # their information is useless
-                if displayName != '':
-                    products[displayName] = displayVersion
+        d_name = ''
+        d_vers = ''
 
-    except WindowsError:  # pylint: disable=E0602
-        pass
+        d_name = __salt__['reg.read_value'](hive,
+                                            '{0}\\{1}'.format(key, reg_key),
+                                            'DisplayName',
+                                            use_32bit)['vdata']
+        try:
+            d_name = d_name.decode(encoding)
+        except Exception:
+            pass
 
-    return products
+        d_vers = __salt__['reg.read_value'](hive,
+                                            '{0}\\{1}'.format(key, reg_key),
+                                            'DisplayVersion',
+                                            use_32bit)['vdata']
+
+        if d_name not in ignore_list:
+            # some MS Office updates don't register a product name which means
+            # their information is useless
+            reg_software.update({d_name: d_vers})
+
+    for reg_key in __salt__['reg.list_keys'](hive, key):
+        update(hive, key, reg_key, False)
+
+    for reg_key in __salt__['reg.list_keys'](hive, key, True):
+        update(hive, key, reg_key, True)
+
+    return reg_software
 
 
 def refresh_db(saltenv='base'):


### PR DESCRIPTION
### What does this PR do?

Makes win_pkg.py use reg.py for all registry lookups
### What issues does this PR fix or reference?

https://github.com/saltstack/zh/issues/197
### Previous Behavior

Used its own implementation of winreg
### New Behavior

Uses reg.py
### Tests written?
- [ ] Yes
- [x] No
