### PR TITLE
Change the undocumented 'quiet' master opt to 'debug_async_events_to_console'

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -459,7 +459,7 @@ class AsyncClientMixin(object):
             return
 
         # if we are "quiet", don't print
-        if self.opts.get('quiet', False):
+        if self.opts.get('debug_async_events_to_console', False):
             return
 
         # some suffixes we don't want to print

--- a/salt/config.py
+++ b/salt/config.py
@@ -776,6 +776,10 @@ VALID_OPTS = {
 
     # Delay in seconds before executing bootstrap (salt cloud)
     'bootstrap_delay': int,
+
+    # Output async events to console for debugging.  Defaults to False
+    # Set to True to print these events with a standard Python print statement
+    'debug_async_events_to_console': bool,
 }
 
 # default configurations
@@ -1224,6 +1228,7 @@ DEFAULT_MASTER_OPTS = {
     'dummy_pub': False,
     'http_request_timeout': 1 * 60 * 60.0,  # 1 hour
     'http_max_body': 100 * 1024 * 1024 * 1024,  # 100GB
+    'debug_async_events_to_console': False,
 }
 
 

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -181,7 +181,7 @@ class Runner(RunnerClient):
                                           False)  # Don't daemonize
             except salt.exceptions.SaltException as exc:
                 ret = '{0}'.format(exc)
-                if not self.opts.get('quiet', False):
+                if self.opts.get('debug_async_events_to_console', False):
                     display_output(ret, 'nested', self.opts)
                 return ret
             log.debug('Runner return: {0}'.format(ret))


### PR DESCRIPTION
### What does this PR do?

Sometime in the past an undocumented master option called `quiet` was added.  When `__opts__.get('quiet', False)` (**the default**) asynchronous events and exceptions generated during asynchronous events would be printed to the console with a standard Python print statement.  This PR changes that option to `debug_async_events_to_console`, deliberately defaults it to False, and syncs up all 2 references in the code.

This was a problem because if folks wrote Python programs using the WheelClient or RunnerClient, spurious output would get printed to the console.
### What issues does this PR fix or reference?

At least #28354, maybe others.
### Previous Behavior

By default Python code using RunnerClient and WheelClient would dump spurious output to the console.
### New Behavior

No debug output is printed.

The debug output behavior can be restored by putting `debug_async_events_to_console: True` in the master config.
### Tests written?
- [ ] Yes
- [X] No
