### PR TITLE
fix return value of rabbitmq_user when tags are specified

### DIFF
--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -134,7 +134,7 @@ def list_users(runas=None):
         python_shell=False)
 
     # func to get tags from string such as "[admin, monitoring]"
-    func = lambda string: set(string[1:-1].split(','))
+    func = lambda string: set([tag.strip() for tag in string[1:-1].split(',')])
     return _output_to_dict(res, func)
 
 


### PR DESCRIPTION
### What does this PR do?

fix output of state rabbitmq_user when tags are specified 
### What issues does this PR fix or reference?
#31765
### Previous Behavior

tags string was parsed incorrectly, whitespaces wheren't stipped so instead of ['monitoring','user'] ['monitoring', ' user'] was returned, so changes where reported even if nothing changed and messagepack wasn't able to parse set([' user'])... 
### New Behavior

whitespaces are stripped for tags items
### Tests written?
- [ ] Yes
- [x] No
