### PR TITLE
Do not exclude groups beginning with "_" on OSX

### DIFF
--- a/salt/modules/mac_user.py
+++ b/salt/modules/mac_user.py
@@ -406,8 +406,7 @@ def list_groups(name):
 
         salt '*' user.list_groups foo
     '''
-    groups = [group for group in salt.utils.get_group_list(name)
-              if not group.startswith('_')]
+    groups = [group for group in salt.utils.get_group_list(name)]
     return groups
 
 


### PR DESCRIPTION
### What does this PR do?

Removes the special case for groups beginning with `_`. This special case made it impossible to deal with those groups in salt states.

Since this is a behaviour change it has the potential to break people's salt setups, but I believe it's for the better this way.
### What issues does this PR fix or reference?

None
### Previous Behavior

On OSX, groups beginning with an underscore would not be reported in `user.info` and trying to reference them in states like `user.present` would cause confusing errors.
This has been the behaviour since `mac_user` was fully implemented in 2013, but I think it is the wrong behaviour and I have been unable to reach Eric Johnson to discuss the issue.
### New Behavior

This special case is removed, bringing the behaviour more in line with the behaviour on other operating systems.
### Tests written?
- [ ] Yes
- [X] No

Since the testing process is long and difficult, I'm going to once again leave it to the bot. If anyone has any suggestions for how to make the tests usable without relying on a CI I'd like to know. (It seems even the unit tests require a lot more packages than it says on the tin, and need root access.)
