### PR TITLE
Allow queueing of state runs through saltmod

### DIFF
--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -57,7 +57,8 @@ def state(
         allow_fail=0,
         concurrent=False,
         timeout=None,
-        batch=None):
+        batch=None,
+        queue=False):
     '''
     Invoke a state run on a given target
 
@@ -117,6 +118,9 @@ def state(
         WARNING: This flag is potentially dangerous. It is designed
         for use when multiple state runs can safely be run at the same
         Do not use this flag for performance optimization.
+
+    queue
+        Pass ``queue=true`` through to the state function
 
     Examples:
 
@@ -206,6 +210,7 @@ def state(
         cmd_kw['kwarg']['pillar'] = pillar
 
     cmd_kw['kwarg']['saltenv'] = __env__
+    cmd_kw['kwarg']['queue'] = queue
 
     if isinstance(concurrent, bool):
         cmd_kw['kwarg']['concurrent'] = concurrent


### PR DESCRIPTION
Adds the option to set `queue=true` when running salt states through saltmod - in my use case, when running an orchestrator.
### Tests written?
- [ ] Yes
- [x] No
