### PR TITLE
Ensure that the latest node data is returned

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2583,6 +2583,10 @@ def create(vm_=None, call=None):
         transport=__opts__['transport']
     )
 
+    # Ensure that the latest node data is returned
+    node = _get_node(instance_id=vm_['instance_id'])
+    ret.update(node)
+
     return ret
 
 


### PR DESCRIPTION
### What does this PR do?

As the subject says.
### What issues does this PR fix or reference?

Previously when node data was collected, there was a possibility that not all of it was available yet. This updates the return with the most up-to-date information available.
### Previous Behavior

See above.
### New Behavior

See above.
### Tests written?
- [ ] Yes
- [X] No

@Ch3LL, @rallytime, @meggiebot.
