### PR TITLE
Make cert perms more secure by default

### DIFF
--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -624,6 +624,7 @@ def write_pem(text, path, pem_type=None):
 
         salt '*' x509.write_pem "-----BEGIN CERTIFICATE-----MIIGMzCCBBugA..." path=/etc/pki/mycert.crt
     '''
+    os.umask(077)
     text = get_pem_entry(text, pem_type=pem_type)
     salt.utils.fopen(path, 'w').write(text)
     return 'PEM written to {0}'.format(path)

--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -624,7 +624,7 @@ def write_pem(text, path, pem_type=None):
 
         salt '*' x509.write_pem "-----BEGIN CERTIFICATE-----MIIGMzCCBBugA..." path=/etc/pki/mycert.crt
     '''
-    old_umask = os.umask(077)
+    old_umask = os.umask(0o77)
     text = get_pem_entry(text, pem_type=pem_type)
     salt.utils.fopen(path, 'w').write(text)
     os.umask(old_umask)

--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -624,9 +624,10 @@ def write_pem(text, path, pem_type=None):
 
         salt '*' x509.write_pem "-----BEGIN CERTIFICATE-----MIIGMzCCBBugA..." path=/etc/pki/mycert.crt
     '''
-    os.umask(077)
+    old_umask = os.umask(077)
     text = get_pem_entry(text, pem_type=pem_type)
     salt.utils.fopen(path, 'w').write(text)
+    os.umask(old_umask)
     return 'PEM written to {0}'.format(path)
 
 


### PR DESCRIPTION
### What does this PR do?

As the title says.
### What issues does this PR fix or reference?

Cert files are normally created with the salt user's umask, such as 022 or 002. It would be better to use a more secure umask, such as 077.
### Previous Behavior

See above.
### New Behavior

Set the umask to 077 before writing the file.
### Tests written?
- [ ] Yes
- [X] No
