### PR TITLE
add system name to platform versions report

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -608,6 +608,7 @@ def system_information():
             return ' '.join(win_ver)
 
     system = [
+        ('platform', platform.system()),
         ('dist', ' '.join(platform.dist())),
         ('release', platform.release()),
         ('machine', platform.machine()),

--- a/salt/version.py
+++ b/salt/version.py
@@ -609,17 +609,16 @@ def system_information():
                 return ' '.join([mac_ver[0], mac_ver[2]])
         elif win_ver[0]:
             return ' '.join(win_ver)
+        else:
+            return ''
 
     system = [
         ('system', platform.system()),
         ('dist', ' '.join(platform.dist())),
         ('release', platform.release()),
         ('machine', platform.machine()),
+        ('version', system_version()),
     ]
-
-    sys_ver = system_version()
-    if sys_ver:
-        system.append(('version', sys_ver))
 
     for name, attr in system:
         yield name, attr

--- a/salt/version.py
+++ b/salt/version.py
@@ -603,7 +603,10 @@ def system_information():
         if lin_ver[0]:
             return ' '.join(lin_ver)
         elif mac_ver[0]:
-            return ' '.join([mac_ver[0], '-'.join(mac_ver[1]), mac_ver[2]])
+            if isinstance(mac_ver[1], (tuple, list)) and ''.join(mac_ver[1]):
+                return ' '.join([mac_ver[0], '.'.join(mac_ver[1]), mac_ver[2]])
+            else:
+                return ' '.join([mac_ver[0], mac_ver[2]])
         elif win_ver[0]:
             return ' '.join(win_ver)
 

--- a/salt/version.py
+++ b/salt/version.py
@@ -611,7 +611,7 @@ def system_information():
             return ' '.join(win_ver)
 
     system = [
-        ('platform', platform.system()),
+        ('system', platform.system()),
         ('dist', ' '.join(platform.dist())),
         ('release', platform.release()),
         ('machine', platform.machine()),
@@ -619,7 +619,7 @@ def system_information():
 
     sys_ver = system_version()
     if sys_ver:
-        system.append(('system', sys_ver))
+        system.append(('version', sys_ver))
 
     for name, attr in system:
         yield name, attr


### PR DESCRIPTION
### What does this PR do?

Improve system versions reporting on Darwin, BSD, and probably other UNIX platforms.  Also, the system version is renamed `version` so that the system name can be named `system`.
### What issues does this PR fix or reference?
#21906
### Previous Behavior

```
saltadmin@macm2 ~/salt platform $ salt --versions
Salt Version:
           Salt: 2016.3.0rc1-20-g2b93f53

...

System Versions:
           dist:
        machine: x86_64
        release: 15.2.0
         system: 10.11.2 -- x86_64
```
### New Behavior

```
saltadmin@macm2 ~/salt platform $ python
>>> from salt import version
>>> version.versions_report()
<generator object versions_report at 0x1006d0f50>
>>> for v in version.versions_report():
...  print(v)
...
Salt Version:
           Salt: 2016.3.0rc1-51-gb28845f

...

System Versions:
           dist:
        machine: x86_64
        release: 15.2.0
         system: Darwin
        version: 10.11.2 x86_64
```
### Tests written?
- [ ] Yes
- [x] No
