### PR TITLE
Workaround for non-xml output from gluster cli when not tty

### DIFF
--- a/salt/modules/glusterfs.py
+++ b/salt/modules/glusterfs.py
@@ -9,11 +9,6 @@ import logging
 import sys
 import xml.etree.ElementTree as ET
 
-# Import 3rd-party libs
-# pylint: disable=import-error,redefined-builtin
-from salt.ext.six.moves import range
-# pylint: enable=import-error,redefined-builtin
-
 # Import salt libs
 import salt.utils
 import salt.utils.cloud as suc
@@ -36,8 +31,7 @@ def _get_minor_version():
     version = 6
     cmd = 'gluster --version'
     result = __salt__['cmd.run'](cmd).splitlines()
-    for line_number in range(len(result)):
-        line = result[line_number]
+    for line in result:
         if line.startswith('glusterfs'):
             version = int(line.split()[1].split('.')[1])
     return version
@@ -54,14 +48,36 @@ def _gluster(cmd):
         'gluster --mode=script', stdin="{0}\n".format(cmd))
 
 
+def _gluster_output_cleanup(result):
+    '''
+    Gluster versions prior to 6 have a bug that requires tricking
+    isatty. This adds "gluster> " to the output. Strip it off and
+    produce clean xml for ElementTree.
+    '''
+    ret = ''
+    for line in result.splitlines():
+        if line.startswith('gluster>'):
+            ret += line[9:].strip()
+        else:
+            ret += line.strip()
+
+    return ret
+
+
 def _gluster_xml(cmd):
     '''
     Perform a gluster --xml command and check for and raise errors.
     '''
-    root = ET.fromstring(
-        __salt__['cmd.run'](
+    if _get_minor_version() < 6:
+        result = __salt__['cmd.run'](
+            'script -q -c "gluster --xml --mode=script"', stdin="{0}\n\004".format(cmd)
+        )
+    else:
+        result = __salt__['cmd.run'](
             'gluster --xml --mode=script', stdin="{0}\n".format(cmd)
-        ).replace("\n", ""))
+        )
+    root = ET.fromstring(_gluster_output_cleanup(result))
+
     if int(root.find('opRet').text) != 0:
         raise CommandExecutionError(root.find('opErrstr').text)
     return root
@@ -120,12 +136,14 @@ def list_peers():
     root = _gluster_xml('peer status')
     result = {}
     for et_peer in _iter(root, 'peer'):
-        result.update({et_peer.find('hostname').text: [
-                      x.text for x in _iter(et_peer.find('hostnames'), 'hostname')]})
-    if len(result) == 0:
-        return None
-    else:
-        return result
+        hostname = et_peer.find('hostname').text
+        aliases = []
+        hostnames = et_peer.find('hostnames')
+        if hostnames is not None:
+            aliases = [x.text for x in _iter(
+                hostnames, 'hostname') if not x.text == hostname]
+        result.update({hostname: aliases})
+    return result or None
 
 
 def peer(name):


### PR DESCRIPTION
Gluster has a bug in versions prior to 3.6 in that they will replace the
cli output mode if isatty() returns false. This patch uses the script
utility to trick the cli into thinking it's being called from a tty to
allow xml output.

Upstream bug: https://bugzilla.redhat.com:443/show_bug.cgi?id=1047378

Fixes #31596
