### PR TITLE
Fix docstring code-block alignment in rdp

### DIFF
--- a/salt/modules/rdp.py
+++ b/salt/modules/rdp.py
@@ -161,9 +161,9 @@ def get_session(session_id):
 
     .. code-block:: bash
 
-    salt '*' rdp.get_session session_id
+        salt '*' rdp.get_session session_id
 
-    salt '*' rdp.get_session 99
+        salt '*' rdp.get_session 99
     '''
     ret = dict()
     sessions = list_sessions()


### PR DESCRIPTION
### What does this PR do?
- Simple docstring fix to correct code-block alignment for the get_session function of the rdp module.
### What issues does this PR fix or reference?
- None
### Previous Behavior
- code-block for the get_session function was misaligned.
### New Behavior
- code-block for the get_session function will be aligned properly.
### Tests written?
- [ ] Yes
- [x] No
