### PR TITLE
monit.summary should only return the exact match of given svc_name

### DIFF
--- a/salt/modules/monit.py
+++ b/salt/modules/monit.py
@@ -124,6 +124,8 @@ def summary(svc_name=''):
                 resource, name, status_ = (
                     parts[0].strip(), parts[1], parts[2].strip()
                 )
+                if svc_name != '' and svc_name != name:
+                    continue
                 if resource not in ret:
                     ret[resource] = {}
                 ret[resource][name] = status_


### PR DESCRIPTION
### What does this PR do?

monit.summary should only return the exact match of given svc_name

If there exists two services whose names are "prog" and "prog_bin",
monit.summary("prog") would return both services.

states.monit.monitor uses monit.summary() to determine the status
of a given service, but it only scans the first kind of resource,
and complains service not found if the service is not in the first
resource kind. In the above example, previous code would return:

```
  File:
    prog_bin:
      Accessible
  Process:
    prog:
      Not monitored
```

And state.monit.monitor("prog") would fail with

```
  Comment: prog not found in configuration
```

With this patch, monit.summary will only return the exact match
of given svc_name, makes state.monit.monitor always happy.
