### PR TITLE
[WIP] Default to Fedora 23 now instead of F21

### DIFF
--- a/salt/modules/nspawn.py
+++ b/salt/modules/nspawn.py
@@ -185,9 +185,12 @@ def _bootstrap_fedora(name, **kwargs):
     pkg_mgr = salt.utils.which_bin(['dnf', 'yum'])
     if not pkg_mgr:
         raise CommandExecutionError('Neither "dnf" nor "yum" could be found')
+    pkg_mgr_dst = 'dnf'
+    if version < 22:
+        pkg_mgr_dst = 'yum'
     cmd = ('{0} -y --releasever={1} --nogpg --installroot={2} '
-           '--disablerepo="*" --enablerepo=fedora install systemd passwd dnf '
-           'fedora-release vim-minimal'.format(pkg_mgr, version, dst))
+           '--disablerepo="*" --enablerepo=fedora install systemd passwd {3} '
+           'fedora-release vim-minimal'.format(pkg_mgr, version, dst, pkg_mgr_dst))
     ret = __salt__['cmd.run_all'](cmd, python_shell=False)
     if ret['retcode'] != 0:
         _build_failed(dst, name)

--- a/salt/modules/nspawn.py
+++ b/salt/modules/nspawn.py
@@ -182,9 +182,12 @@ def _bootstrap_fedora(name, **kwargs):
             version = '23'
     else:
         version = '23'
-    cmd = ('yum -y --releasever={0} --nogpg --installroot={1} '
-           '--disablerepo="*" --enablerepo=fedora install systemd passwd yum '
-           'fedora-release vim-minimal'.format(version, dst))
+    pkg_mgr = salt.utils.which_bin(['dnf', 'yum'])
+    if not pkg_mgr:
+        raise CommandExecutionError('Neither "dnf" nor "yum" could be found')
+    cmd = ('{0} -y --releasever={1} --nogpg --installroot={2} '
+           '--disablerepo="*" --enablerepo=fedora install systemd passwd dnf '
+           'fedora-release vim-minimal'.format(pkg_mgr, version, dst))
     ret = __salt__['cmd.run_all'](cmd, python_shell=False)
     if ret['retcode'] != 0:
         _build_failed(dst, name)

--- a/salt/modules/nspawn.py
+++ b/salt/modules/nspawn.py
@@ -179,9 +179,9 @@ def _bootstrap_fedora(name, **kwargs):
         if __grains__['os'].lower() == 'fedora':
             version = __grains__['osrelease']
         else:
-            version = '21'
+            version = '23'
     else:
-        version = '21'
+        version = '23'
     cmd = ('yum -y --releasever={0} --nogpg --installroot={1} '
            '--disablerepo="*" --enablerepo=fedora install systemd passwd yum '
            'fedora-release vim-minimal'.format(version, dst))


### PR DESCRIPTION
### What does this PR do?

It changes the default Fedora release in `salt.modules.nspawn.bootstrap_container` from `21` to `23` and uses now `dnf` as default package manager with a fallback to `yum` for older environments.
### What issues does this PR fix or reference?

None
### Previous Behavior

`nspawn.bootstrap_container dist=fedora` created a `Fedora 21` image although `23` is the most recent release.
### New Behavior

It creates now a `Fedora 23` image.
### Tests written?
- [ ] Yes
- [x] No
