### PR TITLE
Handling error from using gevent 1.1.

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -804,6 +804,8 @@ class State(object):
                 reload(site)
             except RuntimeError:
                 log.error('Error encountered during module reload. Modules were not reloaded.')
+            except TypeError:
+                log.error('Error encountered during module reload. Modules were not reloaded.')
         self.load_modules(proxy=self.proxy)
         if not self.opts.get('local', False) and self.opts.get('multiprocessing', True):
             self.functions['saltutil.refresh_modules']()


### PR DESCRIPTION
### What does this PR do?

Handles another error case when refreshing modules.
### What issues does this PR fix or reference?

Fixes runs to work with gevent 1.1 Ticket: https://github.com/saltstack/salt/issues/31009
### Previous Behavior

Halt execution so that package management fails.
### New Behavior

Logs the error but continues execution.
### Tests written?
- [ ] Yes
- [x] No
