### PR TITLE
Use LOOP_CLASS current() to share same IOLoop

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -532,7 +532,7 @@ class SMinion(MinionBase):
                 or self.opts.get('use_master_when_local', False)):
             if HAS_ZMQ:
                 zmq.eventloop.ioloop.install()
-            io_loop = LOOP_CLASS()
+            io_loop = LOOP_CLASS.current()
             io_loop.run_sync(
                 lambda: self.eval_master(self.opts, failed=True)
             )
@@ -653,7 +653,7 @@ class MultiMinion(MinionBase):
 
         if HAS_ZMQ:
             zmq.eventloop.ioloop.install()
-        self.io_loop = LOOP_CLASS()
+        self.io_loop = LOOP_CLASS.current()
 
     def _spawn_minions(self):
         '''
@@ -755,7 +755,7 @@ class Minion(MinionBase):
         if io_loop is None:
             if HAS_ZMQ:
                 zmq.eventloop.ioloop.install()
-            self.io_loop = LOOP_CLASS()
+            self.io_loop = LOOP_CLASS.current()
         else:
             self.io_loop = io_loop
 


### PR DESCRIPTION
### What does this PR do?

Use `LOOP_CLASS.current()` instead of `LOOP_CLASS()` where it makes sense that
you want to use the main thread's IOLoop.
### What issues does this PR fix or reference?

None
### Previous Behavior
### New Behavior

This doesn't fix any issues but is an optimization and is the recommended
use in the Tornado docs. `LOOP_CLASS.current()` should be used unless
we want to use a different IOLoop than the main thread's IOLoop.
Not using `current()` makes sense in places such as `SyncWrapper` and `MWorker`.

However, for use in places such as `SMinion.__init__()`, what essentially
happens is that one IOLoop is used for the `run_sync()`. The `run_sync()`
invokes `start()`. `start()` will make this IOLoop current, but it will put
the original current IOLoop back when it is finished, even if it is None.
So what essentially happens is that one IOLoop is used within the ZeroMQ
and TCP transports during the `run_sync` and another is used during
subsequent operations.

Using `current()` will either use the current IOLoop or create a new one
and call it current if none exists. This plays well with both the
ZeroMQ and TCP transports since they use `current()` internally and so the
same IOLoop will be used throughout execution, both before and after
the run_sync.
### Tests written?
- [ ] Yes
- [X] No

I did retest on Linux using pyzmq and the ZeroMQ transport to ensure that the
`salt-call test.ping` bug didn't reappear.

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
