### PR TITLE
Added "Carbon" to the versionadded tag in boto_apigateway state

### DIFF
--- a/salt/states/boto_apigateway.py
+++ b/salt/states/boto_apigateway.py
@@ -3,7 +3,7 @@
 Manage Apigateway Rest APIs
 =================
 
-.. versionadded::
+.. versionadded:: Carbon
 
 Create and destroy rest apis depending on a swagger version 2 definition file.
 Be aware that this interacts with Amazon's services, and so may incur charges.


### PR DESCRIPTION
### What does this PR do?

Adds a version to the `.. versionadded::` tag already present at the top of the state.
### What issues does this PR fix or reference?

None.
### Previous Behavior

The `.. versionadded::` tag was there, but didn't have a release referenced.
### New Behavior

Docs will now display a version for the "New in x" text.
### Tests written?
- [ ] Yes
- [x] No
