### PR TITLE
pool_absent when the given pool name does not exist should return Tru…

### DIFF
--- a/salt/states/boto_cognitoidentity.py
+++ b/salt/states/boto_cognitoidentity.py
@@ -332,7 +332,7 @@ def pool_absent(name, IdentityPoolName, RemoveAllMatched=False,
     identity_pools = r.get('identity_pools')
 
     if identity_pools is None:
-        ret['result'] = False
+        ret['result'] = True
         ret['comment'] = 'No matching identity pool for the given name {0}'.format(IdentityPoolName)
         return ret
 

--- a/tests/unit/states/boto_cognitoidentity_test.py
+++ b/tests/unit/states/boto_cognitoidentity_test.py
@@ -353,7 +353,7 @@ class BotoCognitoIdentityTestCase(BotoCognitoIdentityStateTestCaseBase, BotoCogn
                              IdentityPoolName='no_such_pool_name',
                              RemoveAllMatched=False,
                              **conn_parameters)
-        self.assertEqual(result.get('result'), False)
+        self.assertEqual(result.get('result'), True)
         self.assertEqual(result['changes'], {})
 
     def test_absent_when_removeallmatched_is_false_and_multiple_pools_matched(self):


### PR DESCRIPTION
### What does this PR do?

fixed a minor bug on the result value from running pool_absent.
### What issues does this PR fix or reference?

NA
### Previous Behavior

if the given pool name does not exist, it returned False previously.
### New Behavior

this should return True since the given pool name was already absent.
### Tests written?
- [x] Yes
- [ ] No

…e instead of False.
