### PR TITLE
Make sure we are really updating the mercurial repository

### DIFF
--- a/salt/states/hg.py
+++ b/salt/states/hg.py
@@ -116,7 +116,7 @@ def _update_repo(ret, name, target, clean, user, identity, rev, opts):
             '"hg pull && hg up is probably required"'.format(target)
     )
 
-    current_rev = __salt__['hg.revision'](target, user=user)
+    current_rev = __salt__['hg.revision'](target, user=user, rev='.')
     if not current_rev:
         return _fail(
                 ret,
@@ -137,7 +137,7 @@ def _update_repo(ret, name, target, clean, user, identity, rev, opts):
     else:
         __salt__['hg.update'](target, 'tip', force=clean, user=user)
 
-    new_rev = __salt__['hg.revision'](cwd=target, user=user)
+    new_rev = __salt__['hg.revision'](cwd=target, user=user, rev='.')
 
     if current_rev != new_rev:
         revision_text = '{0} => {1}'.format(current_rev, new_rev)


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in the mercurial state where any changes pulled even if they are not on your branch will claim it as an update to your repo. This also allows you to now switch between branches and run other states based on that change.
### What issues does this PR fix or reference?

As above
### Previous Behavior

Uses tip to check for the latest revision however tip for mercurial means the latest commit that was pushed no matter which branch its on.
### New Behavior

Uses the '.' notation that means the version you are current checked-out with 
### Tests written?
- [ ] Yes
- [x] No
