### PR TITLE
Fixes #31645. Replaced pillar.item with pillar.get.

### DIFF
--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -408,7 +408,7 @@ def create_key(key_type='RSA',
         create_params['expire_date'] = expire_date
 
     if use_passphrase:
-        gpg_passphrase = __salt__['pillar.item']('gpg_passphrase')
+        gpg_passphrase = __salt__['pillar.get']('gpg_passphrase')
         if not gpg_passphrase:
             ret['res'] = False
             ret['message'] = "gpg_passphrase not available in pillar."
@@ -926,7 +926,7 @@ def sign(user=None,
     '''
     gpg = _create_gpg(user, gnupghome)
     if use_passphrase:
-        gpg_passphrase = __salt__['pillar.item']('gpg_passphrase')
+        gpg_passphrase = __salt__['pillar.get']('gpg_passphrase')
         if not gpg_passphrase:
             raise SaltInvocationError('gpg_passphrase not available in pillar.')
     else:
@@ -1068,7 +1068,7 @@ def encrypt(user=None,
     gpg = _create_gpg(user, gnupghome)
 
     if use_passphrase:
-        gpg_passphrase = __salt__['pillar.item']('gpg_passphrase')
+        gpg_passphrase = __salt__['pillar.get']('gpg_passphrase')
         if not gpg_passphrase:
             raise SaltInvocationError('gpg_passphrase not available in pillar.')
         gpg_passphrase = gpg_passphrase['gpg_passphrase']
@@ -1161,7 +1161,7 @@ def decrypt(user=None,
     }
     gpg = _create_gpg(user, gnupghome)
     if use_passphrase:
-        gpg_passphrase = __salt__['pillar.item']('gpg_passphrase')
+        gpg_passphrase = __salt__['pillar.get']('gpg_passphrase')
         if not gpg_passphrase:
             raise SaltInvocationError('gpg_passphrase not available in pillar.')
         gpg_passphrase = gpg_passphrase['gpg_passphrase']


### PR DESCRIPTION
### What does this PR do?

gpg_passphrase was set by pillar.item call instead of pillar.get, leading to false assumption of its content (dict instead of expected str)
### What issues does this PR fix or reference?
#31645 (fix)
### Previous Behavior

gpg passphrase was set to "{'gpg_passphrase': '<real passphrase>'}"
### New Behavior

gpg passphrase is set to "<real passphrase>"
### Tests written?
- [ ] Yes
- [X] No
