### PR TITLE
Add option to not save a backup with file.comment/uncomment

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1062,6 +1062,7 @@ def comment_line(path,
 
     :param backup: string
         The file extension to give the backup file. Default is ``.bak``
+        Set to False/None to not keep a backup.
 
     :return: boolean
         Returns True if successful, False if not
@@ -1191,16 +1192,19 @@ def comment_line(path,
     except (OSError, IOError) as exc:
         raise CommandExecutionError("Exception: {0}".format(exc))
 
-    # Move the backup file to the original directory
-    backup_name = '{0}{1}'.format(path, backup)
-    try:
-        shutil.move(temp_file, backup_name)
-    except (OSError, IOError) as exc:
-        raise CommandExecutionError(
-            "Unable to move the temp file '{0}' to the "
-            "backup file '{1}'. "
-            "Exception: {2}".format(path, temp_file, exc)
-        )
+    if backup:
+        # Move the backup file to the original directory
+        backup_name = '{0}{1}'.format(path, backup)
+        try:
+            shutil.move(temp_file, backup_name)
+        except (OSError, IOError) as exc:
+            raise CommandExecutionError(
+                "Unable to move the temp file '{0}' to the "
+                "backup file '{1}'. "
+                "Exception: {2}".format(path, temp_file, exc)
+            )
+    else:
+        os.remove(temp_file)
 
     if not salt.utils.is_windows():
         check_perms(path, None, pre_user, pre_group, pre_mode)

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3150,6 +3150,8 @@ def comment(name, regex, char='#', backup='.bak'):
             ``uncomment`` is called. Meaning the backup will only be useful
             after the first invocation.
 
+        Set to False/None to not keep a backup.
+
     Usage:
 
     .. code-block:: yaml
@@ -3242,6 +3244,8 @@ def uncomment(name, regex, char='#', backup='.bak'):
             This backup will be overwritten each time ``sed`` / ``comment`` /
             ``uncomment`` is called. Meaning the backup will only be useful
             after the first invocation.
+
+        Set to False/None to not keep a backup.
 
     Usage:
 


### PR DESCRIPTION
Currently, if you want/need to remove the backup file, you need to add a second file.absent state.
