### PR TITLE
Fix version not passed to pkg.remove module

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1746,7 +1746,7 @@ def _uninstall(
                 'comment': 'The following packages will be {0}d: '
                            '{1}.'.format(action, ', '.join(targets))}
 
-    changes = __salt__['pkg.{0}'.format(action)](name, pkgs=pkgs, **kwargs)
+    changes = __salt__['pkg.{0}'.format(action)](name, pkgs=pkgs, version=version, **kwargs)
     new = __salt__['pkg.list_pkgs'](versions_as_list=True, **kwargs)
     failed = [x for x in pkg_params if x in new]
     if action == 'purge':


### PR DESCRIPTION
### What does this PR do?

Fix the problem that a specific version could not be removed
### What issues does this PR fix or reference?

None this problem has not yet been reported
### Previous Behavior

Because no version was set, the pkg.remove function automatically refers to the latest version which is not the desired functionality - because we want to remove/uninstall a specific version.
### New Behavior

Only the given version is deleted. If version is not set (None), the latest version will be uninstalled (like the documentation says)
### Tests written?
- [ ] Yes
- [x] No

In the pkg.py state the version was not passed to the pkg.remove function
preventing the uninstall of a specific version.
