### PR TITLE
Make note of pylint dependencies in docs

### DIFF
--- a/doc/topics/development/conventions/style.rst
+++ b/doc/topics/development/conventions/style.rst
@@ -18,15 +18,24 @@ improve Salt)!!
 Linting
 =======
 
-Most Salt style conventions are codified in Salt's ``.pylintrc`` file. This file
-is found in the root of the Salt project and can be passed as an argument to the
-pylint_ program as follows:
+Most Salt style conventions are codified in Salt's ``.pylintrc`` file. Salt's
+pylint file has two dependencies: pylint_ and saltpylint_. You can install
+these dependencies with ``pip``:
+
+.. code-block:: bash
+
+    pip install pylint
+    pip install saltpylint
+
+The ``.pylintrc`` file is found in the root of the Salt project and can be passed
+as an argument to the pylint_ program as follows:
 
 .. code-block:: bash
 
     pylint --rcfile=/path/to/salt/.pylintrc salt/dir/to/lint
 
 .. _pylint: http://www.pylint.org
+.. _saltpylint: https://github.com/saltstack/salt-pylint
 
 Variables
 =========


### PR DESCRIPTION
### What does this PR do?

Adds instructions to install `pylint` and `saltpylint` packages via pip in order to run the Salt's `.pylintrc` file.
### What issues does this PR fix or reference?
#21932
### Previous Behavior

It was intuitive to me to install pylint, but if you don't have saltpylint installed, the `pylint --rcfile` run stacktraces.
### New Behavior

After installing `saltpylint`, things work as expected. These instructions should help others avoid that.
### Tests written?
- [ ] Yes
- [x] No
