### PR TITLE
Add mentioned of Salt's Coding Style docs to the Contributing docs

### DIFF
--- a/doc/topics/development/contributing.rst
+++ b/doc/topics/development/contributing.rst
@@ -13,6 +13,21 @@ There are a number of ways to contribute to Salt development.
 For details on how to contribute documentation improvements please review
 :ref:`Writing Salt Documentation <salt-docs>`.
 
+
+Salt Coding Style
+-----------------
+
+SaltStack has its own coding style guide that informs contributors on various coding
+approaches. Please review the :ref:`Salt Coding Style<coding-style>`_ documentation
+for information about Salt's particular coding patterns.
+
+Within the :ref:`Salt Coding Style<coding-style>`_ documentation, there is a section
+about running Salt's ``.pylintrc`` file. SaltStack recommends running the ``.pylintrc``
+file on any files you are changing with your code contribution before submitting a
+pull request to Salt's repository. Please see the :ref:`Linting<pylint-instructions>`_
+documentation for more information.
+
+
 .. _github-pull-request:
 
 Sending a GitHub pull request

--- a/doc/topics/development/conventions/style.rst
+++ b/doc/topics/development/conventions/style.rst
@@ -1,3 +1,5 @@
+.. _coding-style:
+
 =================
 Salt Coding Style
 =================
@@ -14,6 +16,8 @@ and is never grounds to talk down to another member of the community (There are
 no grounds to treat others without respect, especially people working to
 improve Salt)!!
 
+
+.. _pylint-instructions:
 
 Linting
 =======


### PR DESCRIPTION
### What does this PR do?

Adds a references to the Coding Style docs in the Contributing section.
### What issues does this PR fix or reference?

None.
### Previous Behavior

There weren't any references before. Knowing about Salt's coding style would be information when learning about how to contribute to Salt.
### New Behavior

References style doc as well as mentioning the docs on how to run pylint before submitting PRs.
### Tests written?
- [ ] Yes
- [x] No
