### PR TITLE
Remove epoch from version string if present when installing with yum

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1226,12 +1226,6 @@ def install(name=None,
     for pkg_item_list in pkg_params_items:
         if pkg_type == 'repository':
             pkgname, version_num = pkg_item_list
-            if _yum() == 'yum':
-                # yum install does not support epoch without the arch, and we
-                # won't know what the arch will be when it's not provided. It
-                # could either be the OS architecture, or 'noarch', and we
-                # don't make that distinction in the pkg.list_pkgs return data.
-                version_num = version_num.split(':', 1)[-1]
         else:
             try:
                 pkgname, pkgpath, version_num = pkg_item_list
@@ -1254,6 +1248,13 @@ def install(name=None,
             # not None, since the only way version_num is not None is if RPM
             # metadata parsing was successful.
             if pkg_type == 'repository':
+                if _yum() == 'yum':
+                    # yum install does not support epoch without the arch, and
+                    # we won't know what the arch will be when it's not
+                    # provided. It could either be the OS architecture, or
+                    # 'noarch', and we don't make that distinction in the
+                    # pkg.list_pkgs return data.
+                    version_num = version_num.split(':', 1)[-1]
                 arch = ''
                 try:
                     namepart, archpart = pkgname.rsplit('.', 1)

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1226,6 +1226,12 @@ def install(name=None,
     for pkg_item_list in pkg_params_items:
         if pkg_type == 'repository':
             pkgname, version_num = pkg_item_list
+            if _yum() == 'yum':
+                # yum install does not support epoch without the arch, and we
+                # won't know what the arch will be when it's not provided. It
+                # could either be the OS architecture, or 'noarch', and we
+                # don't make that distinction in the pkg.list_pkgs return data.
+                version_num = version_num.split(':', 1)[-1]
         else:
             try:
                 pkgname, pkgpath, version_num = pkg_item_list


### PR DESCRIPTION
yum install does not support epoch without the arch, and we won't know
what the arch will be when it's not provided. It could either be the OS
architecture, or 'noarch', and we don't make that distinction in the
pkg.list_pkgs return data.

Fixes #31619.
