### PR TITLE
Write lists of minions targeted by syndic masters to job cache

### DIFF
--- a/doc/ref/modules/all/salt.modules.slsutil.rst
+++ b/doc/ref/modules/all/salt.modules.slsutil.rst
@@ -1,0 +1,6 @@
+====================
+salt.modules.slsutil
+====================
+
+.. automodule:: salt.modules.slsutil
+    :members:

--- a/doc/ref/returners/all/salt.returners.cassandra_cql_return.rst
+++ b/doc/ref/returners/all/salt.returners.cassandra_cql_return.rst
@@ -4,3 +4,4 @@ salt.returners.cassandra_cql_return
 
 .. automodule:: salt.returners.cassandra_cql_return
     :members:
+    :exclude-members: save_minions

--- a/doc/ref/returners/all/salt.returners.couchdb_return.rst
+++ b/doc/ref/returners/all/salt.returners.couchdb_return.rst
@@ -4,3 +4,4 @@ salt.returners.couchdb_return
 
 .. automodule:: salt.returners.couchdb_return
     :members:
+    :exclude-members: save_minions

--- a/doc/ref/returners/all/salt.returners.etcd_return.rst
+++ b/doc/ref/returners/all/salt.returners.etcd_return.rst
@@ -4,3 +4,4 @@ salt.returners.etcd_return
 
 .. automodule:: salt.returners.etcd_return
     :members:
+    :exclude-members: save_minions

--- a/doc/ref/returners/all/salt.returners.influxdb_return.rst
+++ b/doc/ref/returners/all/salt.returners.influxdb_return.rst
@@ -4,3 +4,4 @@ salt.returners.influxdb_return
 
 .. automodule:: salt.returners.influxdb_return
     :members:
+    :exclude-members: save_minions

--- a/doc/ref/returners/all/salt.returners.memcache_return.rst
+++ b/doc/ref/returners/all/salt.returners.memcache_return.rst
@@ -4,3 +4,4 @@ salt.returners.memcache_return
 
 .. automodule:: salt.returners.memcache_return
     :members:
+    :exclude-members: save_minions

--- a/doc/ref/returners/all/salt.returners.mongo_future_return.rst
+++ b/doc/ref/returners/all/salt.returners.mongo_future_return.rst
@@ -4,3 +4,4 @@ salt.returners.mongo_future_return
 
 .. automodule:: salt.returners.mongo_future_return
     :members:
+    :exclude-members: save_minions

--- a/doc/ref/returners/all/salt.returners.mongo_return.rst
+++ b/doc/ref/returners/all/salt.returners.mongo_return.rst
@@ -4,3 +4,4 @@ salt.returners.mongo_return
 
 .. automodule:: salt.returners.mongo_return
     :members:
+    :exclude-members: save_minions

--- a/doc/ref/returners/all/salt.returners.multi_returner.rst
+++ b/doc/ref/returners/all/salt.returners.multi_returner.rst
@@ -4,3 +4,4 @@ salt.returners.multi_returner
 
 .. automodule:: salt.returners.multi_returner
     :members:
+    :exclude-members: save_minions

--- a/doc/ref/returners/all/salt.returners.mysql.rst
+++ b/doc/ref/returners/all/salt.returners.mysql.rst
@@ -4,3 +4,4 @@ salt.returners.mysql
 
 .. automodule:: salt.returners.mysql
     :members:
+    :exclude-members: save_minions

--- a/doc/ref/returners/all/salt.returners.odbc.rst
+++ b/doc/ref/returners/all/salt.returners.odbc.rst
@@ -4,3 +4,4 @@ salt.returners.odbc
 
 .. automodule:: salt.returners.odbc
     :members:
+    :exclude-members: save_minions

--- a/doc/ref/returners/all/salt.returners.pgjsonb.rst
+++ b/doc/ref/returners/all/salt.returners.pgjsonb.rst
@@ -4,3 +4,4 @@ salt.returners.pgjsonb
 
 .. automodule:: salt.returners.pgjsonb
     :members:
+    :exclude-members: save_minions

--- a/doc/ref/returners/all/salt.returners.postgres.rst
+++ b/doc/ref/returners/all/salt.returners.postgres.rst
@@ -4,3 +4,4 @@ salt.returners.postgres
 
 .. automodule:: salt.returners.postgres
     :members:
+    :exclude-members: save_minions

--- a/doc/ref/returners/all/salt.returners.postgres_local_cache.rst
+++ b/doc/ref/returners/all/salt.returners.postgres_local_cache.rst
@@ -4,3 +4,4 @@ salt.returners.postgres_local_cache
 
 .. automodule:: salt.returners.postgres_local_cache
     :members:
+    :exclude-members: save_minions

--- a/doc/ref/returners/all/salt.returners.redis_return.rst
+++ b/doc/ref/returners/all/salt.returners.redis_return.rst
@@ -4,3 +4,4 @@ salt.returners.redis_return
 
 .. automodule:: salt.returners.redis_return
     :members:
+    :exclude-members: save_minions

--- a/doc/ref/returners/all/salt.returners.sqlite3_return.rst
+++ b/doc/ref/returners/all/salt.returners.sqlite3_return.rst
@@ -4,3 +4,4 @@ salt.returners.sqlite3
 
 .. automodule:: salt.returners.sqlite3_return
     :members:
+    :exclude-members: save_minions

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -6,7 +6,13 @@ from __future__ import absolute_import
 
 # Import python libs
 import copy
+import logging
+import time
+
+# Import salt libs
 import salt.defaults.exitcodes
+
+log = logging.getLogger(__name__)
 
 
 class SaltException(Exception):
@@ -96,6 +102,23 @@ class FileserverConfigError(SaltException):
     '''
     Used when invalid fileserver settings are detected
     '''
+
+
+class FileLockError(SaltException):
+    '''
+    Used when an error occurs obtaining a file lock
+    '''
+    def __init__(self, msg, time_start=None, *args, **kwargs):
+        super(FileLockError, self).__init__(msg, *args, **kwargs)
+        if time_start is None:
+            log.warning(
+                'time_start should be provided when raising a FileLockError. '
+                'Defaulting to current time as a fallback, but this may '
+                'result in an inaccurate timeout.'
+            )
+            self.time_start = time.time()
+        else:
+            self.time_start = time_start
 
 
 class SaltInvocationError(SaltException, TypeError):

--- a/salt/master.py
+++ b/salt/master.py
@@ -1182,31 +1182,32 @@ class AESFuncs(object):
         '''
         Act on specific events from minions
         '''
+        id_ = load['id']
         if load.get('tag', '') == '_salt_error':
-            log.error('Received minion error from [{minion}]: '
-                      '{data}'.format(minion=load['id'],
-                                      data=load['data']['message']))
+            log.error(
+                'Received minion error from [{minion}]: {data}'
+                .format(minion=id_, data=load['data']['message'])
+            )
+
         for event in load.get('events', []):
             event_data = event.get('data', {})
             if 'minions' in event_data:
                 jid = event_data.get('jid')
                 if not jid:
-                    # Should not happen but if it ever does we definitely want
-                    # to know about it.
-                    log.warning('No jid in event: %s', event_data)
-                else:
-                    minions = event_data['minions']
-                    try:
-                        salt.utils.job.store_minions(
-                            self.opts,
-                            jid,
-                            minions,
-                            mminion=self.mminion)
-                    except (KeyError, salt.exceptions.SaltCacheError) as exc:
-                        log.error(
-                            'Could not add minion(s) {0} for job {1}: {2}'
-                            .format(minions, jid, exc)
-                        )
+                    continue
+                minions = event_data['minions']
+                try:
+                    salt.utils.job.store_minions(
+                        self.opts,
+                        jid,
+                        minions,
+                        mminion=self.mminion,
+                        syndic_id=id_)
+                except (KeyError, salt.exceptions.SaltCacheError) as exc:
+                    log.error(
+                        'Could not add minion(s) {0} for job {1}: {2}'
+                        .format(minions, jid, exc)
+                    )
 
     def _return(self, load):
         '''

--- a/salt/master.py
+++ b/salt/master.py
@@ -1186,6 +1186,27 @@ class AESFuncs(object):
             log.error('Received minion error from [{minion}]: '
                       '{data}'.format(minion=load['id'],
                                       data=load['data']['message']))
+        for event in load.get('events', []):
+            event_data = event.get('data', {})
+            if 'minions' in event_data:
+                jid = event_data.get('jid')
+                if not jid:
+                    # Should not happen but if it ever does we definitely want
+                    # to know about it.
+                    log.warning('No jid in event: %s', event_data)
+                else:
+                    minions = event_data['minions']
+                    try:
+                        salt.utils.job.store_minions(
+                            self.opts,
+                            jid,
+                            minions,
+                            mminion=self.mminion)
+                    except (KeyError, salt.exceptions.SaltCacheError) as exc:
+                        log.error(
+                            'Could not add minion(s) {0} for job {1}: {2}'
+                            .format(minions, jid, exc)
+                        )
 
     def _return(self, load):
         '''

--- a/salt/returners/cassandra_cql_return.py
+++ b/salt/returners/cassandra_cql_return.py
@@ -260,6 +260,13 @@ def save_load(jid, load):
         raise
 
 
+def save_minions(jid, minions):  # pylint: disable=unused-argument
+    '''
+    Included for API consistency
+    '''
+    pass
+
+
 # salt-run jobs.list_jobs FAILED
 def get_load(jid):
     '''

--- a/salt/returners/couchbase_return.py
+++ b/salt/returners/couchbase_return.py
@@ -210,9 +210,10 @@ def save_load(jid, clear_load):
         save_minions(jid, minions)
 
 
-def save_minions(jid, minions):
+def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument
     '''
-    Save/update the minion list for a given jid
+    Save/update the minion list for a given jid. The syndic_id argument is
+    included for API compatibility only.
     '''
     cb_ = _get_connection()
 
@@ -223,7 +224,12 @@ def save_minions(jid, minions):
         return False
 
     # save the minions to a cache so we can see in the UI
-    jid_doc.value['minions'] = minions
+    if 'minions' in jid_doc.value:
+        jid_doc.value['minions'] = sorted(
+            set(jid_doc.value['minions'] + minions)
+        )
+    else:
+        jid_doc.value['minions'] = minions
     cb_.replace(str(jid), jid_doc.value, cas=jid_doc.cas, ttl=_get_ttl())
 
 

--- a/salt/returners/couchbase_return.py
+++ b/salt/returners/couchbase_return.py
@@ -124,7 +124,8 @@ def _get_ttl():
 def prep_jid(nocache=False, passed_jid=None):
     '''
     Return a job id and prepare the job id directory
-    This is the function responsible for making sure jids don't collide (unless its passed a jid)
+    This is the function responsible for making sure jids don't collide (unless
+    its passed a jid)
     So do what you have to do to make sure that stays the case
     '''
     if passed_jid is None:
@@ -195,6 +196,9 @@ def save_load(jid, clear_load):
         log.warning('Could not write job cache file for jid: {0}'.format(jid))
         return False
 
+    jid_doc.value['load'] = clear_load
+    cb_.replace(str(jid), jid_doc.value, cas=jid_doc.cas, ttl=_get_ttl())
+
     # if you have a tgt, save that for the UI etc
     if 'tgt' in clear_load:
         ckminions = salt.utils.minions.CkMinions(__opts__)
@@ -203,16 +207,24 @@ def save_load(jid, clear_load):
             clear_load['tgt'],
             clear_load.get('tgt_type', 'glob')
             )
-        # save the minions to a cache so we can see in the UI
-        jid_doc.value['minions'] = minions
+        save_minions(jid, minions)
 
-    jid_doc.value['load'] = clear_load
 
-    cb_.replace(str(jid),
-               jid_doc.value,
-               cas=jid_doc.cas,
-               ttl=_get_ttl()
-               )
+def save_minions(jid, minions):
+    '''
+    Save/update the minion list for a given jid
+    '''
+    cb_ = _get_connection()
+
+    try:
+        jid_doc = cb_.get(str(jid))
+    except couchbase.exceptions.NotFoundError:
+        log.warning('Could not write job cache file for jid: {0}'.format(jid))
+        return False
+
+    # save the minions to a cache so we can see in the UI
+    jid_doc.value['minions'] = minions
+    cb_.replace(str(jid), jid_doc.value, cas=jid_doc.cas, ttl=_get_ttl())
 
 
 def get_load(jid):

--- a/salt/returners/couchdb_return.py
+++ b/salt/returners/couchdb_return.py
@@ -367,3 +367,10 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     Do any work necessary to prepare a JID, including sending a custom id
     '''
     return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
+
+
+def save_minions(jid, minions):  # pylint: disable=unused-argument
+    '''
+    Included for API consistency
+    '''
+    pass

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -113,6 +113,13 @@ def save_load(jid, load):
     )
 
 
+def save_minions(jid, minions):  # pylint: disable=unused-argument
+    '''
+    Included for API consistency
+    '''
+    pass
+
+
 def get_load(jid):
     '''
     Return the load data that marks a specified jid

--- a/salt/returners/influxdb_return.py
+++ b/salt/returners/influxdb_return.py
@@ -149,6 +149,13 @@ def save_load(jid, load):
         log.critical('Failed to store load with InfluxDB returner: {0}'.format(ex))
 
 
+def save_minions(jid, minions):  # pylint: disable=unused-argument
+    '''
+    Included for API consistency
+    '''
+    pass
+
+
 def get_load(jid):
     '''
     Return the load data that marks a specified jid

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -13,10 +13,12 @@ import shutil
 import time
 import hashlib
 import bisect
+import time
 
 # Import salt libs
 import salt.payload
 import salt.utils
+import salt.utils.files
 import salt.utils.jid
 import salt.exceptions
 
@@ -48,9 +50,7 @@ def _jid_dir(jid):
     '''
     jid = str(jid)
     jhash = getattr(hashlib, __opts__['hash_type'])(jid).hexdigest()
-    return os.path.join(_job_dir(),
-                        jhash[:2],
-                        jhash[2:])
+    return os.path.join(_job_dir(), jhash[:2], jhash[2:])
 
 
 def _walk_through(job_dir):
@@ -182,7 +182,8 @@ def save_load(jid, clear_load, minions=None, recurse_count=0):
     as for salt-ssh)
     '''
     if recurse_count >= 5:
-        err = 'save_load could not write job cache file after {0} retries.'.format(recurse_count)
+        err = ('save_load could not write job cache file after {0} retries.'
+               .format(recurse_count))
         log.error(err)
         raise salt.exceptions.SaltCacheError(err)
 
@@ -207,7 +208,9 @@ def save_load(jid, clear_load, minions=None, recurse_count=0):
             salt.utils.fopen(os.path.join(jid_dir, LOAD_P), 'w+b')
             )
     except IOError as exc:
-        log.warning('Could not write job invocation cache file: {0}'.format(exc))
+        log.warning(
+            'Could not write job invocation cache file: %s', exc
+        )
         time.sleep(0.1)
         return save_load(jid=jid, clear_load=clear_load,
                          recurse_count=recurse_count+1)
@@ -222,14 +225,57 @@ def save_load(jid, clear_load, minions=None, recurse_count=0):
                     clear_load.get('tgt_type', 'glob')
                     )
         # save the minions to a cache so we can see in the UI
-        try:
-            serial.dump(
-                minions,
-                salt.utils.fopen(os.path.join(jid_dir, MINIONS_P), 'w+b')
+        save_minions(jid, minions)
+
+
+def save_minions(jid, minions):
+    '''
+    Save/update the serialized list of minions for a given job
+    '''
+    log.trace('Adding minions for job %s: %s', jid, minions)
+    serial = salt.payload.Serial(__opts__)
+
+    jid_dir = _jid_dir(jid)
+    minions_path = os.path.join(jid_dir, MINIONS_P)
+    try:
+        cur_minions = serial.load(salt.utils.fopen(minions_path, 'rb'))
+    except IOError as exc:
+        if exc.errno == errno.ENOENT:
+            cur_minions = []
+        else:
+            raise salt.exceptions.SaltCacheError(
+                'Unable to read from minions file %s: %s',
+                minions_path, exc
+            )
+            return
+
+    def write_minions_file(data, minions_path):
+        '''
+        Write the minions file
+        '''
+        with salt.utils.files.wait_lock(minions_path, timeout=5):
+            try:
+                serial.dump(data, salt.utils.fopen(minions_path, 'w+b'))
+            except IOError as exc:
+                raise salt.exceptions.SaltCacheError(
+                    'Could not write job cache file for minions: {0}'.format(
+                        data
+                    )
                 )
-        except IOError as exc:
-            log.warning('Could not write job cache file for minions: {0}'.format(minions))
-            log.debug('Job cache write failure: {0}'.format(exc))
+
+    data = sorted(set(cur_minions + minions))
+    try:
+        write_minions_file(data, minions_path)
+    except salt.exceptions.FileLockError as exc:
+        if exc.race:
+            # We hit a race condition betwen the lock being removed and
+            # attempting to obtain a lock. Try one more time.
+            try:
+                write_minions_file(data, minions_path)
+            except salt.exceptions.FileLockError as exc:
+                raise salt.exceptions.SaltCacheError(exc)
+        else:
+            raise salt.exceptions.SaltCacheError(exc)
 
 
 def get_load(jid):

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -247,7 +247,6 @@ def save_minions(jid, minions):
                 'Unable to read from minions file %s: %s',
                 minions_path, exc
             )
-            return
 
     def write_minions_file(data, minions_path):
         '''

--- a/salt/returners/memcache_return.py
+++ b/salt/returners/memcache_return.py
@@ -139,6 +139,13 @@ def save_load(jid, load):
     serv.append('jids', jid)
 
 
+def save_minions(jid, minions):  # pylint: disable=unused-argument
+    '''
+    Included for API consistency
+    '''
+    pass
+
+
 def get_load(jid):
     '''
     Return the load data that marks a specified jid

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -202,6 +202,13 @@ def save_load(jid, load):
         mdb.jobs.insert(load.copy())
 
 
+def save_minions(jid, minions):  # pylint: disable=unused-argument
+    '''
+    Included for API consistency
+    '''
+    pass
+
+
 def get_load(jid):
     '''
     Return the load associated with a given job id

--- a/salt/returners/mongo_return.py
+++ b/salt/returners/mongo_return.py
@@ -215,3 +215,10 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     Do any work necessary to prepare a JID, including sending a custom id
     '''
     return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
+
+
+def save_minions(jid, minions):  # pylint: disable=unused-argument
+    '''
+    Included for API consistency
+    '''
+    pass

--- a/salt/returners/multi_returner.py
+++ b/salt/returners/multi_returner.py
@@ -69,6 +69,13 @@ def save_load(jid, clear_load):
         _mminion().returners['{0}.save_load'.format(returner_)](jid, clear_load)
 
 
+def save_minions(jid, minions):  # pylint: disable=unused-argument
+    '''
+    Included for API consistency
+    '''
+    pass
+
+
 def get_load(jid):
     '''
     Merge the load data from all returners

--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -297,6 +297,13 @@ def save_load(jid, load):
             pass
 
 
+def save_minions(jid, minions):  # pylint: disable=unused-argument
+    '''
+    Included for API consistency
+    '''
+    pass
+
+
 def get_load(jid):
     '''
     Return the load data that marks a specified jid

--- a/salt/returners/odbc.py
+++ b/salt/returners/odbc.py
@@ -217,6 +217,13 @@ def save_load(jid, load):
     _close_conn(conn)
 
 
+def save_minions(jid, minions):  # pylint: disable=unused-argument
+    '''
+    Included for API consistency
+    '''
+    pass
+
+
 def get_load(jid):
     '''
     Return the load data that marks a specified jid

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -282,6 +282,13 @@ def save_load(jid, load):
             pass
 
 
+def save_minions(jid, minions):  # pylint: disable=unused-argument
+    '''
+    Included for API consistency
+    '''
+    pass
+
+
 def get_load(jid):
     '''
     Return the load data that marks a specified jid

--- a/salt/returners/postgres.py
+++ b/salt/returners/postgres.py
@@ -193,6 +193,13 @@ def save_load(jid, load):
     _close_conn(conn)
 
 
+def save_minions(jid, minions):  # pylint: disable=unused-argument
+    '''
+    Included for API consistency
+    '''
+    pass
+
+
 def get_load(jid):
     '''
     Return the load data that marks a specified jid

--- a/salt/returners/postgres_local_cache.py
+++ b/salt/returners/postgres_local_cache.py
@@ -256,6 +256,13 @@ def save_load(jid, clear_load):
     _close_conn(conn)
 
 
+def save_minions(jid, minions):  # pylint: disable=unused-argument
+    '''
+    Included for API consistency
+    '''
+    pass
+
+
 def _escape_jid(jid):
     '''
     Do proper formatting of the jid

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -115,6 +115,13 @@ def save_load(jid, load):
     serv.sadd('jids', jid)
 
 
+def save_minions(jid, minions):  # pylint: disable=unused-argument
+    '''
+    Included for API consistency
+    '''
+    pass
+
+
 def get_load(jid):
     '''
     Return the load data that marks a specified jid

--- a/salt/returners/sqlite3_return.py
+++ b/salt/returners/sqlite3_return.py
@@ -185,6 +185,13 @@ def save_load(jid, load):
     _close_conn(conn)
 
 
+def save_minions(jid, minions):  # pylint: disable=unused-argument
+    '''
+    Included for API consistency
+    '''
+    pass
+
+
 def get_load(jid):
     '''
     Return the load from a specified jid

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -2874,3 +2874,15 @@ def invalid_kwargs(invalid_kwargs, raise_exc=True):
         raise SaltInvocationError(msg)
     else:
         return msg
+
+
+def split_input(val):
+    '''
+    Take an input value and split it into a list, returning the resulting list
+    '''
+    if isinstance(val, list):
+        return val
+    try:
+        return val.split(',')
+    except AttributeError:
+        return str(val).split(',')

--- a/salt/utils/files.py
+++ b/salt/utils/files.py
@@ -200,7 +200,6 @@ def wait_lock(path, lock_fn=None, timeout=5, sleep=0.1, time_start=None):
                 'to be released'.format(timeout, lock_fn)
             )
 
-
     except FileLockError:
         raise
 

--- a/salt/utils/files.py
+++ b/salt/utils/files.py
@@ -3,15 +3,23 @@
 from __future__ import absolute_import
 
 # Import Python libs
+import contextlib
 import errno
+import logging
 import os
 import shutil
 import subprocess
+import time
 
 # Import salt libs
 import salt.utils
 import salt.modules.selinux
-from salt.exceptions import CommandExecutionError, MinionError
+from salt.exceptions import CommandExecutionError, FileLockError, MinionError
+
+# Import 3rd-party libs
+from salt.ext import six
+
+log = logging.getLogger(__name__)
 
 
 def recursive_copy(source, dest):
@@ -130,3 +138,81 @@ def process_read_exception(exc, path):
                 exc.errno, path, exc.strerror
             )
         )
+
+
+@contextlib.contextmanager
+def wait_lock(path, lock_fn=None, timeout=5, sleep=0.1, time_start=None):
+    '''
+    Obtain a write lock. If one exists, wait for it to release first
+    '''
+    if not isinstance(path, six.string_types):
+        raise FileLockError('path must be a string')
+    if lock_fn is None:
+        lock_fn = path + '.w'
+    if time_start is None:
+        time_start = time.time()
+    obtained_lock = False
+
+    def _raise_error(msg, race=False):
+        '''
+        Raise a FileLockError
+        '''
+        raise FileLockError(msg, time_start=time_start)
+
+    try:
+        if os.path.exists(lock_fn) and not os.path.isfile(lock_fn):
+            _raise_error(
+                'lock_fn {0} exists and is not a file'.format(lock_fn)
+            )
+
+        open_flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+        while time.time() - time_start < timeout:
+            try:
+                # Use os.open() to obtain filehandle so that we can force an
+                # exception if the file already exists. Concept found here:
+                # http://stackoverflow.com/a/10979569
+                fh_ = os.open(lock_fn, open_flags)
+            except (IOError, OSError) as exc:
+                if exc.errno != errno.EEXIST:
+                    _raise_error(
+                        'Error {0} encountered obtaining file lock {1}: {2}'
+                        .format(exc.errno, lock_fn, exc.strerror)
+                    )
+                log.trace(
+                    'Lock file %s exists, sleeping %f seconds', lock_fn, sleep
+                )
+                time.sleep(sleep)
+            else:
+                # Write the lock file
+                with os.fdopen(fh_, 'w'):
+                    pass
+                # Lock successfully acquired
+                log.trace('Write lock %s obtained', lock_fn)
+                obtained_lock = True
+                # Transfer control back to the code inside the with block
+                yield
+                # Exit the loop
+                break
+
+        else:
+            _raise_error(
+                'Timeout of {0} seconds exceeded waiting for lock_fn {1} '
+                'to be released'.format(timeout, lock_fn)
+            )
+
+
+    except FileLockError:
+        raise
+
+    except Exception as exc:
+        _raise_error(
+            'Error encountered obtaining file lock {0}: {1}'.format(
+                lock_fn,
+                exc
+            )
+        )
+
+    finally:
+        if obtained_lock:
+            os.remove(lock_fn)
+            log.trace('Write lock for %s (%s) released', path, lock_fn)

--- a/salt/utils/job.py
+++ b/salt/utils/job.py
@@ -83,7 +83,9 @@ def store_job(opts, load, event=None, mminion=None):
         if 'user' in ret_:
             load.update({'user': ret_['user']})
     try:
-        if 'jid' in load and 'get_load' in mminion.returners and not mminion.returners[getfstr](load.get('jid', '')):
+        if 'jid' in load \
+				and 'get_load' in mminion.returners \
+				and not mminion.returners[getfstr](load.get('jid', '')):
             mminion.returners[savefstr](load['jid'], load)
         mminion.returners[fstr](load)
 
@@ -96,6 +98,26 @@ def store_job(opts, load, event=None, mminion=None):
         emsg = "Returner '{0}' does not support function returner".format(job_cache)
         log.error(emsg)
         raise KeyError(emsg)
+
+
+def store_minions(opts, jid, minions, mminion=None):
+    '''
+    Store additional minions matched on lower-level masters using the configured
+    master_job_cache
+    '''
+    if mminion is None:
+        mminion = salt.minion.MasterMinion(opts, states=False, rend=False)
+    job_cache = opts['master_job_cache']
+    minions_fstr = '{0}.save_minions'.format(job_cache)
+
+    try:
+        mminion.returners[minions_fstr](jid, minions)
+    except KeyError:
+        raise KeyError(
+            'Returner \'{0}\' does not support function save_minions'.format(
+                job_cache
+            )
+        )
 
 
 def get_retcode(ret):

--- a/salt/utils/job.py
+++ b/salt/utils/job.py
@@ -100,7 +100,7 @@ def store_job(opts, load, event=None, mminion=None):
         raise KeyError(emsg)
 
 
-def store_minions(opts, jid, minions, mminion=None):
+def store_minions(opts, jid, minions, mminion=None, syndic_id=None):
     '''
     Store additional minions matched on lower-level masters using the configured
     master_job_cache
@@ -111,7 +111,7 @@ def store_minions(opts, jid, minions, mminion=None):
     minions_fstr = '{0}.save_minions'.format(job_cache)
 
     try:
-        mminion.returners[minions_fstr](jid, minions)
+        mminion.returners[minions_fstr](jid, minions, syndic_id=syndic_id)
     except KeyError:
         raise KeyError(
             'Returner \'{0}\' does not support function save_minions'.format(

--- a/salt/utils/job.py
+++ b/salt/utils/job.py
@@ -84,8 +84,8 @@ def store_job(opts, load, event=None, mminion=None):
             load.update({'user': ret_['user']})
     try:
         if 'jid' in load \
-				and 'get_load' in mminion.returners \
-				and not mminion.returners[getfstr](load.get('jid', '')):
+                and 'get_load' in mminion.returners \
+                and not mminion.returners[getfstr](load.get('jid', '')):
             mminion.returners[savefstr](load['jid'], load)
         mminion.returners[fstr](load)
 


### PR DESCRIPTION
## Summary

When a master-of-masters publishes a command, and a syndic master re-publishes it to its subscribed minions, it fires an event back to the master containing the list of minions matched by the syndic master for that job.

This pull request scans these events for lists of minions, and writes them to the job cache.

Fixes #30528.
## How to test
1. Use [this documentation](https://help.github.com/articles/checking-out-pull-requests-locally/) to check out this pull request into a new branch, and install from git.
2. Recommended setup: 3 hosts (1 master-of-masters, 1 syndic master, 1 lower-level minion). Set `order_masters: True` on the master-of-masters and subscribe the lower-level minion to the syndic master, and the syndic master to the master-of-masters.
3. From the master-of-masters, run `salt -v '*' test.ping`
4. Take the jid obtained in step 3 and run `salt-run jobs.list_job <jid>`. The `Minions` list in the return data should contain the minion ID of the lower-level minion. Prior to this pull request, the lower-level minions would not be in this return data. After completing the rest of the test steps, installing Salt from the head of `2015.8` on the master-of-masters and repeating steps 3 and 4 should show no lower-level minions in the `jobs.list_job` return data.
5. Stop the `salt-minion` service on the lower-level minion, and then repeat step 3.
6. Take the jid obtained in step 5 and run `salt-run jobs.lookup_jid <jid> missing=True`. The lower-level minion should be included in the return data, and should show `Minion did not return`. Repeating the call to `jobs.lookup_jid` without the `missing=True` should exclude the lower-level minion from the return data.
## Review notes

Of particular focus in the review of this pull request should be the following:
- [ ] The `couchbase_return` returner. To maintain API compatibility I needed to move the writing of minion lists into a separate function, as I did for the `local_cache` returner, and I did not have an instance to test this.
- [ ] The file locking code added in salt/utils/files.py.
