### PR TITLE
grains.get ordered parameter implementation

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -12,6 +12,7 @@ import random
 import logging
 import operator
 import collections
+import json
 from functools import reduce
 
 # Import 3rd-party libs
@@ -72,7 +73,7 @@ _SANITIZERS = {
 }
 
 
-def get(key, default='', delimiter=DEFAULT_TARGET_DELIM):
+def get(key, default='', delimiter=DEFAULT_TARGET_DELIM, ordered=True):
     '''
     Attempt to retrieve the named value from grains, if the named value is not
     available return the passed default. The default return is an empty string.
@@ -93,13 +94,22 @@ def get(key, default='', delimiter=DEFAULT_TARGET_DELIM):
 
         .. versionadded:: 2014.7.0
 
+    :param ordered:
+        Outputs an ordered dict if applicable (default: True)
+
+        .. versionadded:: 2016.3.0
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' grains.get pkg:apache
     '''
-    return salt.utils.traverse_dict_and_list(__grains__,
+    if ordered is True:
+        grains = __grains__
+    else:
+        grains = json.loads(json.dumps(__grains__))
+    return salt.utils.traverse_dict_and_list(grains,
                                              key,
                                              default,
                                              delimiter)

--- a/tests/unit/modules/grains_test.py
+++ b/tests/unit/modules/grains_test.py
@@ -21,6 +21,10 @@ from salt.exceptions import SaltException
 from salt.modules import grains as grainsmod
 from salt.utils import dictupdate
 
+# Import 3rd-party libs
+import salt.utils.compat
+from salt.utils.odict import OrderedDict
+
 grainsmod.__opts__ = {
   'conf_file': '/tmp/__salt_test_grains',
   'cachedir':  '/tmp/__salt_test_grains_cache_dir'
@@ -534,6 +538,52 @@ class GrainsModuleTestCase(TestCase):
                                                     {'l23': 'l23val'},
                                                     {'l24': {'l241': 'val'}}]},
                                                 'c': 8})
+
+    def test_get_ordered(self):
+        grainsmod.__grains__ = OrderedDict([
+                                ('a', 'aval'),
+                                ('b', OrderedDict([
+                                    ('z', 'zval'),
+                                    ('l1', ['l21',
+                                            'l22',
+                                            OrderedDict([('l23', 'l23val')])])
+                                    ])),
+                                ('c', 8)])
+        res = grainsmod.get('b')
+        self.assertEqual(type(res), OrderedDict)
+        # Check that order really matters
+        self.assertTrue(res == OrderedDict([
+                                  ('z', 'zval'),
+                                  ('l1', ['l21',
+                                          'l22',
+                                          OrderedDict([('l23', 'l23val')])]),
+                                  ]))
+        self.assertFalse(res == OrderedDict([
+                                  ('l1', ['l21',
+                                          'l22',
+                                          OrderedDict([('l23', 'l23val')])]),
+                                  ('z', 'zval'),
+                                  ]))
+
+    def test_get_unordered(self):
+        grainsmod.__grains__ = OrderedDict([
+                                ('a', 'aval'),
+                                ('b', OrderedDict([
+                                    ('z', 'zval'),
+                                    ('l1', ['l21',
+                                            'l22',
+                                            OrderedDict([('l23', 'l23val')])])
+                                    ])),
+                                ('c', 8)])
+        res = grainsmod.get('b', ordered=False)
+        self.assertEqual(type(res), dict)
+        # Check that order doesn't matter
+        self.assertTrue(res == OrderedDict([
+                                  ('l1', ['l21',
+                                          'l22',
+                                          OrderedDict([('l23', 'l23val')])]),
+                                  ('z', 'zval'),
+                                  ]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?

Adds a new `ordered` parameter to `grains.get` to choose between an `OrderedDict` or a `dict` answer.
### What issues does this PR fix or reference?

It does help to compare inside a jinja template, the existing value of a complex grain.
### Previous Behavior

Output for a complex grain is an `OrderedDict`.
### New Behavior

Output for a complex grain is an `OrderedDict`, by default. With `ordered=False`, the output is a simple `dict`
### Tests written?
- [X] Yes
- [ ] No
### Notes
- I'm not sure the json technique is the best to convert an `OrderedDict` to a simple `dict`.
- I documented this new parameter as added with 2016.3.0 release. Is that OK?
