### PR TITLE
Return correct value for services that must be enabled in Systemd

### DIFF
--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -762,8 +762,10 @@ def enabled(name, **kwargs):  # pylint: disable=unused-argument
         # string will be non-empty.
         if bool(__salt__['cmd.run'](cmd, python_shell=False)):
             return True
-    else:
+    elif name in _get_sysv_services():
         return _sysv_enabled(name)
+
+    return False
 
 
 def disabled(name):


### PR DESCRIPTION
### What does this PR do?

Fix incorrect return value for service.enabled
### Previous Behavior

True is returned when the Systemd-based service is disabled in Systemd
but enabled in SysV
### New Behavior

True is returned only when the Systemd-based service is enabled in Systemd
### Tests written?
- [ ] Yes
- [X] No

This fixes situations, when a server is switched from SysV to Systemd.
SysV symlinks are still in place and Salt incorrectly determines, that
service is enabled.

For example:

```
~$ salt-call --local service.enabled spamassassin
[INFO    ] Executing command 'systemctl is-enabled spamassassin.service'
[INFO    ] Executing command 'runlevel' in directory '/root'
local:
    True
```

However:

```
~$ systemctl is-enabled spamassassin.service
disabled
```

```
~$ find /etc/rc*.d/ -name
'*spamassassin'
/etc/rc0.d/K02spamassassin
/etc/rc1.d/K02spamassassin
/etc/rc2.d/S02spamassassin
/etc/rc3.d/S02spamassassin
/etc/rc4.d/S02spamassassin
/etc/rc5.d/S02spamassassin
/etc/rc6.d/K02spamassassin
```
