### PR TITLE
Fix typo in example for section `winrepo_dir_ng`

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -2853,7 +2853,7 @@ out for 2015.8.0 and later minions.
 
 .. code-block:: yaml
 
-    winrepo_dir: /srv/salt/win/repo-ng
+    winrepo_dir_ng: /srv/salt/win/repo-ng
 
 .. conf_master:: winrepo_cachefile
 .. conf_master:: win_repo_mastercachefile


### PR DESCRIPTION
### What does this PR do?

Found a problem in the docs that needs to be fixed:

https://docs.saltstack.com/en/latest/ref/configuration/master.html#winrepo-dir:

> ```
> winrepo_dir: /srv/salt/win/repo
> ```

https://docs.saltstack.com/en/latest/ref/configuration/master.html#winrepo-dir-ng:

> ```
> winrepo_dir: /srv/salt/win/repo-ng
> ```
1. The second example needs to be corrected from `winrepo_dir` to `winrepo_dir_ng`
### What issues does this PR fix or reference?

N/A.
### Previous Behavior

N/A.
### New Behavior

N/A.
### Tests written?

N/A.
