### PR TITLE
mac_timezone to use mac_utils

### DIFF
--- a/salt/modules/mac_timezone.py
+++ b/salt/modules/mac_timezone.py
@@ -297,7 +297,7 @@ def set_using_network_time(enable):
 
         salt '*' timezone.set_using_network_time True
     '''
-    state = validate_enabled(enable)
+    state = mac_utils.validate_enabled(enable)
 
     cmd = 'systemsetup -setusingnetworktime {0}'.format(state)
     mac_utils.execute_return_success(cmd)

--- a/salt/modules/mac_timezone.py
+++ b/salt/modules/mac_timezone.py
@@ -11,7 +11,7 @@ from datetime import datetime
 
 # Import salt libs
 import salt.utils
-import salt.utils.mac_utils as mac_utils
+import salt.utils.mac_utils
 from salt.exceptions import CommandExecutionError
 
 __virtualname__ = 'timezone'
@@ -68,8 +68,8 @@ def get_date():
 
         salt '*' timezone.get_date
     '''
-    ret = mac_utils.execute_return_result('systemsetup -getdate')
-    return mac_utils.parse_return(ret)
+    ret = salt.utils.mac_utils.execute_return_result('systemsetup -getdate')
+    return salt.utils.mac_utils.parse_return(ret)
 
 
 def set_date(date):
@@ -95,7 +95,7 @@ def set_date(date):
     dt_obj = datetime.strptime(date, date_format)
 
     cmd = 'systemsetup -setdate {0}'.format(dt_obj.strftime('%m:%d:%Y'))
-    mac_utils.execute_return_success(cmd)
+    salt.utils.mac_utils.execute_return_success(cmd)
 
     new_date = get_date()
     date_format = _get_date_time_format(new_date)
@@ -117,8 +117,8 @@ def get_time():
 
         salt '*' timezone.get_time
     '''
-    ret = mac_utils.execute_return_result('systemsetup -gettime')
-    return mac_utils.parse_return(ret)
+    ret = salt.utils.mac_utils.execute_return_result('systemsetup -gettime')
+    return salt.utils.mac_utils.parse_return(ret)
 
 
 def set_time(time):
@@ -142,7 +142,7 @@ def set_time(time):
     dt_obj = datetime.strptime(time, time_format)
 
     cmd = 'systemsetup -settime {0}'.format(dt_obj.strftime('%H:%M:%S'))
-    mac_utils.execute_return_success(cmd)
+    salt.utils.mac_utils.execute_return_success(cmd)
 
     new_time = get_time()
     time_format = _get_date_time_format(new_time)
@@ -164,8 +164,8 @@ def get_zone():
 
         salt '*' timezone.get_zone
     '''
-    ret = mac_utils.execute_return_result('systemsetup -gettimezone')
-    return mac_utils.parse_return(ret)
+    ret = salt.utils.mac_utils.execute_return_result('systemsetup -gettimezone')
+    return salt.utils.mac_utils.parse_return(ret)
 
 
 def get_zonecode():
@@ -181,7 +181,7 @@ def get_zonecode():
 
         salt '*' timezone.get_zonecode
     '''
-    return mac_utils.execute_return_result('date +%Z')
+    return salt.utils.mac_utils.execute_return_result('date +%Z')
 
 
 def get_offset():
@@ -197,7 +197,7 @@ def get_offset():
 
         salt '*' timezone.get_offset
     '''
-    return mac_utils.execute_return_result('date +%z')
+    return salt.utils.mac_utils.execute_return_result('date +%z')
 
 
 def list_zones():
@@ -214,8 +214,8 @@ def list_zones():
 
         salt '*' timezone.list_zones
     '''
-    ret = mac_utils.execute_return_result('systemsetup -listtimezones')
-    return mac_utils.parse_return(ret)
+    ret = salt.utils.mac_utils.execute_return_result('systemsetup -listtimezones')
+    return salt.utils.mac_utils.parse_return(ret)
 
 
 def set_zone(time_zone):
@@ -238,7 +238,7 @@ def set_zone(time_zone):
         return (False, 'Not a valid timezone. '
                        'Use list_time_zones to find a valid time zone.')
 
-    mac_utils.execute_return_success('systemsetup -settimezone {0}'.format(time_zone))
+    salt.utils.mac_utils.execute_return_success('systemsetup -settimezone {0}'.format(time_zone))
 
     return time_zone in get_zone()
 
@@ -277,8 +277,8 @@ def get_using_network_time():
 
         salt '*' timezone.get_using_network_time
     '''
-    ret = mac_utils.execute_return_result('systemsetup -getusingnetworktime')
-    return mac_utils.validate_enabled(mac_utils.parse_return(ret)) == 'on'
+    ret = salt.utils.mac_utils.execute_return_result('systemsetup -getusingnetworktime')
+    return salt.utils.mac_utils.validate_enabled(salt.utils.mac_utils.parse_return(ret)) == 'on'
 
 
 def set_using_network_time(enable):
@@ -297,12 +297,12 @@ def set_using_network_time(enable):
 
         salt '*' timezone.set_using_network_time True
     '''
-    state = mac_utils.validate_enabled(enable)
+    state = salt.utils.mac_utils.validate_enabled(enable)
 
     cmd = 'systemsetup -setusingnetworktime {0}'.format(state)
-    mac_utils.execute_return_success(cmd)
+    salt.utils.mac_utils.execute_return_success(cmd)
 
-    return state == mac_utils.validate_enabled(get_using_network_time())
+    return state == salt.utils.mac_utils.validate_enabled(get_using_network_time())
 
 
 def get_time_server():
@@ -318,8 +318,8 @@ def get_time_server():
 
         salt '*' timezone.get_time_server
     '''
-    ret = mac_utils.execute_return_result('systemsetup -getnetworktimeserver')
-    return mac_utils.parse_return(ret)
+    ret = salt.utils.mac_utils.execute_return_result('systemsetup -getnetworktimeserver')
+    return salt.utils.mac_utils.parse_return(ret)
 
 
 def set_time_server(time_server='time.apple.com'):
@@ -341,6 +341,6 @@ def set_time_server(time_server='time.apple.com'):
         salt '*' timezone.set_time_server time.acme.com
     '''
     cmd = 'systemsetup -setnetworktimeserver {0}'.format(time_server)
-    mac_utils.execute_return_success(cmd)
+    salt.utils.mac_utils.execute_return_success(cmd)
 
     return time_server in get_time_server()

--- a/salt/modules/mac_timezone.py
+++ b/salt/modules/mac_timezone.py
@@ -11,8 +11,7 @@ from datetime import datetime
 
 # Import salt libs
 import salt.utils
-from salt.utils.mac_utils import execute_return_result, \
-    execute_return_success, parse_return, validate_enabled
+import salt.utils.mac_utils as mac_utils
 from salt.exceptions import CommandExecutionError
 
 __virtualname__ = 'timezone'
@@ -69,8 +68,8 @@ def get_date():
 
         salt '*' timezone.get_date
     '''
-    ret = execute_return_result('systemsetup -getdate')
-    return parse_return(ret)
+    ret = mac_utils.execute_return_result('systemsetup -getdate')
+    return mac_utils.parse_return(ret)
 
 
 def set_date(date):
@@ -96,7 +95,7 @@ def set_date(date):
     dt_obj = datetime.strptime(date, date_format)
 
     cmd = 'systemsetup -setdate {0}'.format(dt_obj.strftime('%m:%d:%Y'))
-    execute_return_success(cmd)
+    mac_utils.execute_return_success(cmd)
 
     new_date = get_date()
     date_format = _get_date_time_format(new_date)
@@ -118,8 +117,8 @@ def get_time():
 
         salt '*' timezone.get_time
     '''
-    ret = execute_return_result('systemsetup -gettime')
-    return parse_return(ret)
+    ret = mac_utils.execute_return_result('systemsetup -gettime')
+    return mac_utils.parse_return(ret)
 
 
 def set_time(time):
@@ -143,7 +142,7 @@ def set_time(time):
     dt_obj = datetime.strptime(time, time_format)
 
     cmd = 'systemsetup -settime {0}'.format(dt_obj.strftime('%H:%M:%S'))
-    execute_return_success(cmd)
+    mac_utils.execute_return_success(cmd)
 
     new_time = get_time()
     time_format = _get_date_time_format(new_time)
@@ -165,8 +164,8 @@ def get_zone():
 
         salt '*' timezone.get_zone
     '''
-    ret = execute_return_result('systemsetup -gettimezone')
-    return parse_return(ret)
+    ret = mac_utils.execute_return_result('systemsetup -gettimezone')
+    return mac_utils.parse_return(ret)
 
 
 def get_zonecode():
@@ -182,7 +181,7 @@ def get_zonecode():
 
         salt '*' timezone.get_zonecode
     '''
-    return execute_return_result('date +%Z')
+    return mac_utils.execute_return_result('date +%Z')
 
 
 def get_offset():
@@ -198,7 +197,7 @@ def get_offset():
 
         salt '*' timezone.get_offset
     '''
-    return execute_return_result('date +%z')
+    return mac_utils.execute_return_result('date +%z')
 
 
 def list_zones():
@@ -215,8 +214,8 @@ def list_zones():
 
         salt '*' timezone.list_zones
     '''
-    ret = execute_return_result('systemsetup -listtimezones')
-    return parse_return(ret)
+    ret = mac_utils.execute_return_result('systemsetup -listtimezones')
+    return mac_utils.parse_return(ret)
 
 
 def set_zone(time_zone):
@@ -239,7 +238,7 @@ def set_zone(time_zone):
         return (False, 'Not a valid timezone. '
                        'Use list_time_zones to find a valid time zone.')
 
-    execute_return_success('systemsetup -settimezone {0}'.format(time_zone))
+    mac_utils.execute_return_success('systemsetup -settimezone {0}'.format(time_zone))
 
     return time_zone in get_zone()
 
@@ -278,12 +277,8 @@ def get_using_network_time():
 
         salt '*' timezone.get_using_network_time
     '''
-    ret = execute_return_result('systemsetup -getusingnetworktime')
-
-    if parse_return(ret) == 'On':
-        return True
-    else:
-        return False
+    ret = mac_utils.execute_return_result('systemsetup -getusingnetworktime')
+    return mac_utils.validate_enabled(mac_utils.parse_return(ret)) == 'on'
 
 
 def set_using_network_time(enable):
@@ -305,9 +300,9 @@ def set_using_network_time(enable):
     state = validate_enabled(enable)
 
     cmd = 'systemsetup -setusingnetworktime {0}'.format(state)
-    execute_return_success(cmd)
+    mac_utils.execute_return_success(cmd)
 
-    return state == validate_enabled(get_using_network_time())
+    return state == mac_utils.validate_enabled(get_using_network_time())
 
 
 def get_time_server():
@@ -323,8 +318,8 @@ def get_time_server():
 
         salt '*' timezone.get_time_server
     '''
-    ret = execute_return_result('systemsetup -getnetworktimeserver')
-    return parse_return(ret)
+    ret = mac_utils.execute_return_result('systemsetup -getnetworktimeserver')
+    return mac_utils.parse_return(ret)
 
 
 def set_time_server(time_server='time.apple.com'):
@@ -346,6 +341,6 @@ def set_time_server(time_server='time.apple.com'):
         salt '*' timezone.set_time_server time.acme.com
     '''
     cmd = 'systemsetup -setnetworktimeserver {0}'.format(time_server)
-    execute_return_success(cmd)
+    mac_utils.execute_return_success(cmd)
 
     return time_server in get_time_server()

--- a/salt/modules/mac_timezone.py
+++ b/salt/modules/mac_timezone.py
@@ -11,6 +11,8 @@ from datetime import datetime
 
 # Import salt libs
 import salt.utils
+from salt.utils.mac_utils import execute_return_result, \
+    execute_return_success, parse_return, validate_enabled
 from salt.exceptions import CommandExecutionError
 
 __virtualname__ = 'timezone'
@@ -55,48 +57,6 @@ def _get_date_time_format(dt_string):
     raise CommandExecutionError(msg)
 
 
-def _execute_return_success(cmd):
-    '''
-    Helper function to execute the command
-    Returns: bool
-    '''
-    ret = __salt__['cmd.run_all'](cmd)
-
-    if ret['retcode'] != 0:
-        msg = 'Command failed: {0}'.format(ret['stderr'])
-        raise CommandExecutionError(msg)
-
-    return True
-
-
-def _execute_return_result(cmd):
-    ret = __salt__['cmd.run_all'](cmd)
-
-    if ret['retcode'] != 0:
-        msg = 'Command failed: {0}'.format(ret['stderr'])
-        raise CommandExecutionError(msg)
-
-    return ret['stdout']
-
-
-def _parse_return(data):
-    '''
-    Parse a return in the format:
-    ``Time Zone: America/Denver``
-    to return only:
-    ``America/Denver``
-
-    Returns: The value portion of a return
-    '''
-
-    if ': ' in data:
-        return data.split(': ')[1]
-    if ':\n' in data:
-        return data.split(':\n')[1]
-    else:
-        return data
-
-
 def get_date():
     '''
     Displays the current date
@@ -109,8 +69,8 @@ def get_date():
 
         salt '*' timezone.get_date
     '''
-    ret = _execute_return_result('systemsetup -getdate')
-    return _parse_return(ret)
+    ret = execute_return_result('systemsetup -getdate')
+    return parse_return(ret)
 
 
 def set_date(date):
@@ -136,7 +96,7 @@ def set_date(date):
     dt_obj = datetime.strptime(date, date_format)
 
     cmd = 'systemsetup -setdate {0}'.format(dt_obj.strftime('%m:%d:%Y'))
-    _execute_return_success(cmd)
+    execute_return_success(cmd)
 
     new_date = get_date()
     date_format = _get_date_time_format(new_date)
@@ -158,8 +118,8 @@ def get_time():
 
         salt '*' timezone.get_time
     '''
-    ret = _execute_return_result('systemsetup -gettime')
-    return _parse_return(ret)
+    ret = execute_return_result('systemsetup -gettime')
+    return parse_return(ret)
 
 
 def set_time(time):
@@ -183,7 +143,7 @@ def set_time(time):
     dt_obj = datetime.strptime(time, time_format)
 
     cmd = 'systemsetup -settime {0}'.format(dt_obj.strftime('%H:%M:%S'))
-    _execute_return_success(cmd)
+    execute_return_success(cmd)
 
     new_time = get_time()
     time_format = _get_date_time_format(new_time)
@@ -205,8 +165,8 @@ def get_zone():
 
         salt '*' timezone.get_zone
     '''
-    ret = _execute_return_result('systemsetup -gettimezone')
-    return _parse_return(ret)
+    ret = execute_return_result('systemsetup -gettimezone')
+    return parse_return(ret)
 
 
 def get_zonecode():
@@ -222,7 +182,7 @@ def get_zonecode():
 
         salt '*' timezone.get_zonecode
     '''
-    return _execute_return_result('date +%Z')
+    return execute_return_result('date +%Z')
 
 
 def get_offset():
@@ -238,7 +198,7 @@ def get_offset():
 
         salt '*' timezone.get_offset
     '''
-    return _execute_return_result('date +%z')
+    return execute_return_result('date +%z')
 
 
 def list_zones():
@@ -255,8 +215,8 @@ def list_zones():
 
         salt '*' timezone.list_zones
     '''
-    ret = _execute_return_result('systemsetup -listtimezones')
-    return _parse_return(ret)
+    ret = execute_return_result('systemsetup -listtimezones')
+    return parse_return(ret)
 
 
 def set_zone(time_zone):
@@ -279,7 +239,7 @@ def set_zone(time_zone):
         return (False, 'Not a valid timezone. '
                        'Use list_time_zones to find a valid time zone.')
 
-    _execute_return_success('systemsetup -settimezone {0}'.format(time_zone))
+    execute_return_success('systemsetup -settimezone {0}'.format(time_zone))
 
     return time_zone in get_zone()
 
@@ -318,9 +278,9 @@ def get_using_network_time():
 
         salt '*' timezone.get_using_network_time
     '''
-    ret = _execute_return_result('systemsetup -getusingnetworktime')
+    ret = execute_return_result('systemsetup -getusingnetworktime')
 
-    if _parse_return(ret) == 'On':
+    if parse_return(ret) == 'On':
         return True
     else:
         return False
@@ -342,21 +302,12 @@ def set_using_network_time(enable):
 
         salt '*' timezone.set_using_network_time True
     '''
-    if enable not in ['On', 'on', 'Off', 'off', True, False]:
-        msg = 'Must pass a boolean value. Passed: {0}'.format(enable)
-        raise CommandExecutionError(msg)
+    state = validate_enabled(enable)
 
-    if enable in ['On', 'on', True]:
-        enable = 'on'
-        expect = True
-    else:
-        enable = 'off'
-        expect = False
-    cmd = 'systemsetup -setusingnetworktime {0}'.format(enable)
+    cmd = 'systemsetup -setusingnetworktime {0}'.format(state)
+    execute_return_success(cmd)
 
-    _execute_return_success(cmd)
-
-    return expect == get_using_network_time()
+    return state == validate_enabled(get_using_network_time())
 
 
 def get_time_server():
@@ -372,8 +323,8 @@ def get_time_server():
 
         salt '*' timezone.get_time_server
     '''
-    ret = _execute_return_result('systemsetup -getnetworktimeserver')
-    return _parse_return(ret)
+    ret = execute_return_result('systemsetup -getnetworktimeserver')
+    return parse_return(ret)
 
 
 def set_time_server(time_server='time.apple.com'):
@@ -395,6 +346,6 @@ def set_time_server(time_server='time.apple.com'):
         salt '*' timezone.set_time_server time.acme.com
     '''
     cmd = 'systemsetup -setnetworktimeserver {0}'.format(time_server)
-    _execute_return_success(cmd)
+    execute_return_success(cmd)
 
     return time_server in get_time_server()

--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -7,12 +7,19 @@ from __future__ import absolute_import
 
 # Import Python Libraries
 import logging
+import subprocess
+import os
 
 # Import Third Party Libs
 
 # Import Salt Libs
 import salt.utils
-from salt.exceptions import CommandExecutionError, SaltInvocationError
+import salt.utils.timed_subprocess
+import salt.grains.extra
+from salt.exceptions import CommandExecutionError, SaltInvocationError,\
+    TimedProcTimeoutError
+
+DEFAULT_SHELL = salt.grains.extra.shell()['shell']
 
 # Set up logging
 log = logging.getLogger(__name__)
@@ -31,6 +38,63 @@ def __virtual__():
     return __virtualname__
 
 
+def _run_all(cmd):
+    '''
+
+    Args:
+        cmd:
+
+    Returns:
+
+    '''
+
+    run_env = os.environ.copy()
+    run_env.update(None)
+
+    kwargs = {'cwd': None,
+              'shell': DEFAULT_SHELL,
+              'env': run_env,
+              'stdin': None,
+              'stdout': subprocess.PIPE,
+              'stderr': subprocess.PIPE,
+              'with_communicate': True,
+              'timeout': None,
+              'bg': False,
+              }
+
+    try:
+        proc = salt.utils.timed_subprocess.TimedProc(cmd, **kwargs)
+
+    except (OSError, IOError) as exc:
+        raise CommandExecutionError(
+            'Unable to run command \'{0}\' with the context \'{1}\', '
+            'reason: {2}'.format(cmd, kwargs, exc)
+        )
+
+    try:
+        proc.run()
+    except TimedProcTimeoutError as exc:
+        ret['stdout'] = str(exc )
+        ret['stderr'] = ''
+        ret['retcode'] = 1
+        ret['pid'] = proc.process.pid
+        return ret
+
+    out, err = proc.stdout, proc.stderr
+
+    if out is not None:
+        out = salt.utils.to_str(out).rstrip()
+    if err is not None:
+        err = salt.utils.to_str(err).rstrip()
+
+    ret['pid'] = proc.process.pid
+    ret['retcode'] = proc.process.returncode
+    ret['stdout'] = out
+    ret['stderr'] = err
+
+    return ret
+
+
 def execute_return_success(cmd):
     '''
     Executes the passed command. Returns True if successful
@@ -40,7 +104,8 @@ def execute_return_success(cmd):
     :return: True if successful, otherwise False
     :rtype: bool
     '''
-    ret = __salt__['cmd.run_all'](cmd)
+
+    ret = _run_all(cmd)
 
     if 'not supported' in ret['stdout'].lower():
         return 'Not supported on this machine'
@@ -64,7 +129,7 @@ def execute_return_result(cmd):
     an error
     :rtype: str
     '''
-    ret = __salt__['cmd.run_all'](cmd)
+    ret = _run_all(cmd)
 
     if ret['retcode'] != 0:
         msg = 'Command failed: {0}'.format(ret['stderr'])

--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -49,7 +49,6 @@ def _run_all(cmd):
     '''
 
     run_env = os.environ.copy()
-    run_env.update(None)
 
     kwargs = {'cwd': None,
               'shell': DEFAULT_SHELL,
@@ -70,6 +69,8 @@ def _run_all(cmd):
             'Unable to run command \'{0}\' with the context \'{1}\', '
             'reason: {2}'.format(cmd, kwargs, exc)
         )
+
+    ret = {}
 
     try:
         proc.run()

--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -75,7 +75,7 @@ def _run_all(cmd):
     try:
         proc.run()
     except TimedProcTimeoutError as exc:
-        ret['stdout'] = str(exc )
+        ret['stdout'] = str(exc)
         ret['stderr'] = ''
         ret['retcode'] = 1
         ret['pid'] = proc.process.pid

--- a/tests/unit/utils/mac_utils_test.py
+++ b/tests/unit/utils/mac_utils_test.py
@@ -18,8 +18,6 @@ ensure_in_syspath('../../')
 from salt.utils import mac_utils
 from salt.exceptions import SaltInvocationError, CommandExecutionError
 
-mac_utils.__salt__ = {}
-
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class MacUtilsTestCase(TestCase):
@@ -33,7 +31,7 @@ class MacUtilsTestCase(TestCase):
         '''
         mock_cmd = MagicMock(return_value={'retcode': 0,
                                            'stdout': 'not supported'})
-        with patch.dict(mac_utils.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.object(mac_utils, '_run_all', mock_cmd):
             ret = mac_utils.execute_return_success('dir c:\\')
             self.assertEqual(ret, 'Not supported on this machine')
 
@@ -44,7 +42,7 @@ class MacUtilsTestCase(TestCase):
         '''
         mock_cmd = MagicMock(return_value={'retcode': 1,
                                            'stdout': 'spongebob'})
-        with patch.dict(mac_utils.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.object(mac_utils, '_run_all', mock_cmd):
             self.assertRaises(CommandExecutionError,
                               mac_utils.execute_return_success,
                               'dir c:\\')
@@ -56,7 +54,7 @@ class MacUtilsTestCase(TestCase):
         '''
         mock_cmd = MagicMock(return_value={'retcode': 0,
                                            'stdout': 'spongebob'})
-        with patch.dict(mac_utils.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.object(mac_utils, '_run_all', mock_cmd):
             ret = mac_utils.execute_return_success('dir c:\\')
             self.assertEqual(ret, True)
 
@@ -68,7 +66,7 @@ class MacUtilsTestCase(TestCase):
         mock_cmd = MagicMock(return_value={'retcode': 1,
                                            'stdout': 'spongebob',
                                            'stderr': 'squarepants'})
-        with patch.dict(mac_utils.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.object(mac_utils, '_run_all', mock_cmd):
             self.assertRaises(CommandExecutionError,
                               mac_utils.execute_return_result,
                               'dir c:\\')
@@ -80,7 +78,7 @@ class MacUtilsTestCase(TestCase):
         '''
         mock_cmd = MagicMock(return_value={'retcode': 0,
                                            'stdout': 'spongebob'})
-        with patch.dict(mac_utils.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.object(mac_utils, '_run_all', mock_cmd):
             ret = mac_utils.execute_return_result('dir c:\\')
             self.assertEqual(ret, 'spongebob')
 


### PR DESCRIPTION
### What does this PR do?

`mac_timezone.py` will use `mac_utils` for shared functions
`mac_utils.py` will call the TimedProc class directly
### What issues does this PR fix or reference?

This originally stemmed from writing tests for mac_timezone. Tests are already written for mac_utils
### Previous Behavior

`mac_timezone.py` used its own version of functions that exist in `mac_utils.py`
`mac_utils.py` called `cmd.run` from `__salt__`, which was problematic because `timezone.get_offset` gets called when the minion starts and `__salt__` isn't available.
### New Behavior

`mac_timezone.py` now uses shared functions found in `mac_utils.py`
`mac_utils.py` now calls TimedProc class directly to execute commands using a new `_run_all` function
### Tests written?
- [x] Yes (fixed)
- [ ] No
