### PR TITLE
Adding plugin_installed method to jenkins module to determine if a plugin is installed

### DIFF
--- a/salt/modules/jenkins.py
+++ b/salt/modules/jenkins.py
@@ -426,3 +426,31 @@ def get_job_config(name=None):
 
     job_info = server.get_job_config(name)
     return job_info
+
+
+def plugin_installed(name):
+    '''
+    .. versionadded:: Carbon
+
+    Return if the plugin is installed for the provided plugin name.
+
+    :param name: The name of the parameter to confirm installation.
+    :return: True if plugin exists, False if plugin does not exist.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' jenkins.plugin_installed pluginName
+
+    '''
+
+    server = _connect()
+    plugins = server.get_plugins()
+
+    exists = [plugin for plugin in plugins.keys() if name in plugin]
+
+    if exists:
+        return True
+    else:
+        return False


### PR DESCRIPTION
### What does this PR do?

Adds functionality to the Jenkins module to determine if a plugin is installed based on name argument
### What issues does this PR fix or reference?

No issues, just a feature addition.
### Previous Behavior

Nothing
### New Behavior

Returns True/False based on name argument
### Tests written?
- [ ] Yes
- [x] No
