### PR TITLE
drop M2Crypto from the SmartOS esky builds

### DIFF
--- a/pkg/smartos/esky/zeromq_requirements.txt
+++ b/pkg/smartos/esky/zeromq_requirements.txt
@@ -1,7 +1,6 @@
 # Need to set a specific version of pyzmq, so can't use the main project's requirements file... have to copy it in and modify...
 #-r ../../../requirements/zeromq.txt
 -r ../../../requirements/base.txt
-M2Crypto
-pycrypto
+pycrypto>=2.6.1
 pyzmq == 13.1.0
 -r requirements.txt


### PR DESCRIPTION
### What does this PR do?

Drop the M2Crypto dependency for SmartOS esky packages.
### What issues does this PR fix or reference?

n/a
### Previous Behavior

Required M2Crypto
### New Behavior

Does not require M2Crypto
### Tests written?
- [ ] Yes
- [X] No
