### PR TITLE
For #31309. If value option not supplied then grain will only be checked for existence

### DIFF
--- a/tests/unit/states/grains_test.py
+++ b/tests/unit/states/grains_test.py
@@ -78,7 +78,26 @@ class GrainsTestCase(TestCase):
         with open(grains_file, "w+") as grf:
             grf.write(cstr)
 
-    # 'present' function tests: 12
+    # 'present' function tests: 13
+
+    def test_present_no_value(self):
+        self.setGrains({'a': 'aval', 'foo': 'bar'})
+        # Grain already set
+        ret = grains.present(
+            name='foo',
+            value=None)
+        self.assertEqual(ret['result'], True)
+        self.assertEqual(ret['comment'], 'Grain is present')
+        self.assertEqual(ret['changes'], {})
+
+        # Grain not present
+        self.setGrains({'a': 'aval'})
+        ret = grains.present(
+            name='foo',
+            value=None)
+        self.assertEqual(ret['result'], False)
+        self.assertEqual(ret['comment'], 'Grain is not present')
+        self.assertEqual(ret['changes'], {})
 
     def test_present_add(self):
         # Set a non existing grain
@@ -198,20 +217,6 @@ class GrainsTestCase(TestCase):
                                   + "foo: newbar\n"
         )
 
-        self.setGrains({'a': 'aval', 'foo': 'bar'})
-        # Clear a grain (set to None)
-        ret = grains.present(
-            name='foo',
-            value=None)
-        self.assertEqual(ret['result'], True)
-        self.assertEqual(ret['changes'], {'foo': None})
-        self.assertEqual(
-            grains.__grains__,
-            {'a': 'aval', 'foo': None})
-        self.assertGrainFileContent("a: aval\n"
-                                  + "foo: null\n"
-        )
-
         self.setGrains({'a': 'aval', 'foo': {'is': {'nested': 'bar'}}})
         # Overwrite an existing nested grain
         ret = grains.present(
@@ -228,40 +233,12 @@ class GrainsTestCase(TestCase):
                                   + "    nested: newbar\n"
         )
 
-        self.setGrains({'a': 'aval', 'foo': {'is': {'nested': 'bar'}}})
-        # Clear a nested grain (set to None)
-        ret = grains.present(
-            name='foo:is:nested',
-            value=None)
-        self.assertEqual(ret['result'], True)
-        self.assertEqual(ret['changes'], {'foo': {'is': {'nested': None}}})
-        self.assertEqual(
-            grains.__grains__,
-            {'a': 'aval', 'foo': {'is': {'nested': None}}})
-        self.assertGrainFileContent("a: aval\n"
-                                  + "foo:\n"
-                                  + "  is:\n"
-                                  + "    nested: null\n"
-        )
-
     def test_present_fail_overwrite(self):
         self.setGrains({'a': 'aval', 'foo': {'is': {'nested': 'val'}}})
         # Overwrite an existing grain
         ret = grains.present(
             name='foo:is',
             value='newbar')
-        self.assertEqual(ret['result'], False)
-        self.assertEqual(ret['changes'], {})
-        self.assertEqual(ret['comment'], 'The key \'foo:is\' exists but is a dict or a list. Use \'force=True\' to overwrite.')
-        self.assertEqual(
-            grains.__grains__,
-            {'a': 'aval', 'foo': {'is': {'nested': 'val'}}})
-
-        self.setGrains({'a': 'aval', 'foo': {'is': {'nested': 'val'}}})
-        # Clear a grain (set to None)
-        ret = grains.present(
-            name='foo:is',
-            value=None)
         self.assertEqual(ret['result'], False)
         self.assertEqual(ret['changes'], {})
         self.assertEqual(ret['comment'], 'The key \'foo:is\' exists but is a dict or a list. Use \'force=True\' to overwrite.')


### PR DESCRIPTION
### What does this PR do?
### What issues does this PR fix or reference?

Add functionality so that when states.grains.present called with value=None, the state works as it's name would suggest and just asserts that the grain exists regardless of the value.
### Previous Behavior

If value=None was supplied, the grain would be deleted although this was not made clear in the docs and so the more obvious way would be to use state.grains.absent
### New Behavior

See above.
### Tests written?
- [x ] Yes
- [ ] No
  Unit tests updated to handle new conditions.
