### PR TITLE
[dockerng] Fix dockerng.network_present when container is given by name

### DIFF
--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -2045,6 +2045,8 @@ def network_present(name, driver=None, containers=None):
            'comment': ''}
     if containers is None:
         containers = []
+    # map containers to container's Ids.
+    containers = [__salt__['dockerng.inspect_container'](c)['Id'] for c in containers]
     networks = __salt__['dockerng.networks'](names=[name])
     if networks:
         network = networks[0]  # we expect network's name to be unique

--- a/tests/unit/states/dockerng_test.py
+++ b/tests/unit/states/dockerng_test.py
@@ -566,7 +566,9 @@ class DockerngTestCase(TestCase):
         '''
         dockerng_create_network = Mock(return_value='created')
         dockerng_connect_container_to_network = Mock(return_value='connected')
+        dockerng_inspect_container = Mock(return_value={'Id': 'abcd'})
         __salt__ = {'dockerng.create_network': dockerng_create_network,
+                    'dockerng.inspect_container': dockerng_inspect_container,
                     'dockerng.connect_container_to_network': dockerng_connect_container_to_network,
                     'dockerng.networks': Mock(return_value=[]),
                     }
@@ -577,7 +579,7 @@ class DockerngTestCase(TestCase):
                 containers=['container'],
                 )
         dockerng_create_network.assert_called_with('network_foo', driver=None)
-        dockerng_connect_container_to_network.assert_called_with('container',
+        dockerng_connect_container_to_network.assert_called_with('abcd',
                                                                  'network_foo')
         self.assertEqual(ret, {'name': 'network_foo',
                                'comment': '',


### PR DESCRIPTION
### What does this PR do?

`dockerng.network_present` check if given list of containers are already bound to a network. And `dockerng.network_present` expect containers to be given by ID, so we swap all names with their IDs, before performing comparison.
### What issues does this PR fix or reference?

none
### Previous Behavior

The container was repeatedly attached to the network.
### New Behavior

Act only on difference of configuration.
### Tests written?
- [x] Yes
- [ ] No
