### PR TITLE
Add basic support for creating VPC routes

### DIFF
--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -1760,8 +1760,8 @@ def route_table_exists(route_table_id=None, name=None, route_table_name=None,
 
 
 def route_exists(destination_cidr_block, route_table_name=None, route_table_id=None,
-                 gateway_id=None, instance_id=None, interface_id=None, vpc_peering_connection_id=None,
-                 tags=None, region=None, key=None, keyid=None, profile=None):
+                 gateway_id=None, instance_id=None, interface_id=None, tags=None,
+                 region=None, key=None, keyid=None, profile=None, vpc_peering_connection_id=None):
     '''
     Checks if a route exists.
 
@@ -2030,8 +2030,8 @@ def delete_route(route_table_id=None, destination_cidr_block=None,
 def replace_route(route_table_id=None, destination_cidr_block=None,
                   route_table_name=None, gateway_id=None,
                   instance_id=None, interface_id=None,
-                  vpc_peering_connection_id=None,
-                  region=None, key=None, keyid=None, profile=None):
+                  region=None, key=None, keyid=None, profile=None,
+                  vpc_peering_connection_id=None):
     '''
     Replaces a route.
 

--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -1759,8 +1759,9 @@ def route_table_exists(route_table_id=None, name=None, route_table_name=None,
                            profile=profile)
 
 
-def route_exists(destination_cidr_block, route_table_name=None, route_table_id=None, gateway_id=None, instance_id=None,
-                 interface_id=None, tags=None, region=None, key=None, keyid=None, profile=None):
+def route_exists(destination_cidr_block, route_table_name=None, route_table_id=None,
+                 gateway_id=None, instance_id=None, interface_id=None, vpc_peering_connection_id=None,
+                 tags=None, region=None, key=None, keyid=None, profile=None):
     '''
     Checks if a route exists.
 
@@ -1777,9 +1778,9 @@ def route_exists(destination_cidr_block, route_table_name=None, route_table_id=N
     if not any((route_table_name, route_table_id)):
         raise SaltInvocationError('At least one of the following must be specified: route table name or route table id.')
 
-    if not any((gateway_id, instance_id, interface_id)):
-        raise SaltInvocationError('At least one of the following must be specified: gateway id, instance id'
-                                  ' or interface id.')
+    if not any((gateway_id, instance_id, interface_id, vpc_peering_connection_id)):
+        raise SaltInvocationError('At least one of the following must be specified: gateway id, instance id, '
+                                  'interface id or VPC peering connection id.')
 
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
@@ -1803,7 +1804,8 @@ def route_exists(destination_cidr_block, route_table_name=None, route_table_id=N
         route_check = {'destination_cidr_block': destination_cidr_block,
                        'gateway_id': gateway_id,
                        'instance_id': instance_id,
-                       'interface_id': interface_id
+                       'interface_id': interface_id,
+                       'vpc_peering_connection_id': vpc_peering_connection_id
                        }
 
         for route_match in route_tables[0].routes:
@@ -1811,7 +1813,8 @@ def route_exists(destination_cidr_block, route_table_name=None, route_table_id=N
             route_dict = {'destination_cidr_block': route_match.destination_cidr_block,
                           'gateway_id': route_match.gateway_id,
                           'instance_id': route_match.instance_id,
-                          'interface_id': route_match.interface_id
+                          'interface_id': route_match.interface_id,
+                          'vpc_peering_connection_id': vpc_peering_connection_id
                           }
             route_comp = set(route_dict.items()) ^ set(route_check.items())
             if len(route_comp) == 0:
@@ -1927,6 +1930,7 @@ def create_route(route_table_id=None, destination_cidr_block=None,
                  route_table_name=None, gateway_id=None,
                  internet_gateway_name=None,
                  instance_id=None, interface_id=None,
+                 vpc_peering_connection_id=None, vpc_peering_connection_name=None,
                  region=None, key=None, keyid=None, profile=None):
     '''
     Creates a route.
@@ -1943,9 +1947,9 @@ def create_route(route_table_id=None, destination_cidr_block=None,
         raise SaltInvocationError('One (but not both) of route_table_id or route_table_name '
                                   'must be provided.')
 
-    if not _exactly_one((gateway_id, internet_gateway_name, instance_id, interface_id)):
+    if not _exactly_one((gateway_id, internet_gateway_name, instance_id, interface_id, vpc_peering_connection_id)):
         raise SaltInvocationError('Only one of gateway_id, internet_gateway_name, instance_id, '
-                                  'or interface_id may be provided.')
+                                  'interface_id or vpc_peering_connection_id may be provided.')
 
     if destination_cidr_block is None:
         raise SaltInvocationError('destination_cidr_block is required.')
@@ -1965,15 +1969,24 @@ def create_route(route_table_id=None, destination_cidr_block=None,
                                           keyid=keyid, profile=profile)
             if not gateway_id:
                 return {'created': False,
-                        'error': {'message': 'internet gateway {0} does not exist.'.format(internet_gatway_name)}}
+                        'error': {'message': 'internet gateway {0} does not exist.'.format(internet_gateway_name)}}
+
+        if vpc_peering_connection_name:
+            vpc_peering_connection_id = _get_resource_id('vpc_peering_connection', vpc_peering_connection_name,
+                                                         region=region, key=key,
+                                                         keyid=keyid, profile=profile)
+            if not vpc_peering_connection_id:
+                return {'created': False,
+                        'error': {'message': 'VPC peering connection {0} does not exist.'.format(vpc_peering_connection_name)}}
+
     except BotoServerError as e:
         return {'created': False, 'error': salt.utils.boto.get_error(e)}
 
     return _create_resource('route', route_table_id=route_table_id,
                             destination_cidr_block=destination_cidr_block,
                             gateway_id=gateway_id, instance_id=instance_id,
-                            interface_id=interface_id, region=region,
-                            key=key, keyid=keyid, profile=profile)
+                            interface_id=interface_id, vpc_peering_connection_id=vpc_peering_connection_id,
+                            region=region, key=key, keyid=keyid, profile=profile)
 
 
 def delete_route(route_table_id=None, destination_cidr_block=None,
@@ -2017,6 +2030,7 @@ def delete_route(route_table_id=None, destination_cidr_block=None,
 def replace_route(route_table_id=None, destination_cidr_block=None,
                   route_table_name=None, gateway_id=None,
                   instance_id=None, interface_id=None,
+                  vpc_peering_connection_id=None,
                   region=None, key=None, keyid=None, profile=None):
     '''
     Replaces a route.
@@ -2048,7 +2062,7 @@ def replace_route(route_table_id=None, destination_cidr_block=None,
 
         if conn.replace_route(route_table_id, destination_cidr_block,
                               gateway_id=gateway_id, instance_id=instance_id,
-                              interface_id=interface_id):
+                              interface_id=interface_id, vpc_peering_connection_id=vpc_peering_connection_id):
             log.info('Route with cidr block {0} on route table {1} was '
                      'replaced'.format(route_table_id, destination_cidr_block))
             return {'replaced': True}
@@ -2101,7 +2115,7 @@ def describe_route_table(route_table_id=None, route_table_name=None,
 
         route_table = {}
         keys = ['id', 'vpc_id', 'tags', 'routes', 'associations']
-        route_keys = ['destination_cidr_block', 'gateway_id', 'instance_id', 'interface_id']
+        route_keys = ['destination_cidr_block', 'gateway_id', 'instance_id', 'interface_id', 'vpc_peering_connection_id']
         assoc_keys = ['id', 'main', 'route_table_id', 'subnet_id']
         for item in route_tables:
             for key in keys:

--- a/salt/states/boto_vpc.py
+++ b/salt/states/boto_vpc.py
@@ -863,7 +863,7 @@ def _routes_present(route_table_name, routes, tags=None, region=None, key=None, 
 
     _routes = []
     if routes:
-        route_keys = ['gateway_id', 'instance_id', 'destination_cidr_block', 'interface_id']
+        route_keys = ['gateway_id', 'instance_id', 'destination_cidr_block', 'interface_id', 'vpc_peering_connection_id']
         for i in routes:
             _r = dict((k, i.get(k)) for k in route_keys)
             if i.get('internet_gateway_name'):
@@ -881,6 +881,21 @@ def _routes_present(route_table_name, routes, tags=None, region=None, key=None, 
                     ret['result'] = False
                     return ret
                 _r['gateway_id'] = r['id']
+            if i.get('vpc_peering_connection_name'):
+                r = __salt__['boto_vpc.get_resource_id']('vpc_peering_connection', name=i['vpc_peering_connection_name'],
+                                                         region=region, key=key, keyid=keyid, profile=profile)
+                if 'error' in r:
+                    msg = 'Error looking up id for VPC peering connection {0}: {1}'.format(i.get('vpc_peering_connection_name'),
+                                                                                     r['error']['message'])
+                    ret['comment'] = msg
+                    ret['result'] = False
+                    return ret
+                if r['id'] is None:
+                    msg = 'VPC peering connection {0} does not exist.'.format(i)
+                    ret['comment'] = msg
+                    ret['result'] = False
+                    return ret
+                _r['vpc_peering_connection_id'] = r['id']
             if i.get('instance_name'):
                 running_states = ('pending', 'rebooting', 'running', 'stopping', 'stopped')
                 r = __salt__['boto_ec2.get_id'](name=i['instance_name'], region=region,


### PR DESCRIPTION
### What does this PR do?

Allows boto_vpc.route_table_present to handle routes using a VPC peering connection as gateway.
First step to fully support VPC peering connections in Saltstack
### Previous Behavior

All the routes defining a peering connection were removed when calling boto_vpc.route_table_present
### New Behavior

Specifying a vpc_peering_connection_id or vpc_peering_connection_name will create the necessary routes in the specified route table.
### Tests written?
- [ ] Yes
- [X] No
