### PR TITLE
Don't error out on lambda functions with no VPC info

### DIFF
--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -301,8 +301,9 @@ def _function_config_present(FunctionName, Role, Handler, Description, Timeout,
             ret['changes'].setdefault('new', {})[var] = locals()[var]
             ret['changes'].setdefault('old', {})[var] = func[val]
     # VpcConfig returns the extra value 'VpcId' so do a special compare
-    oldval = func.get('VpcConfig', {})
-    oldval.pop('VpcId', None)
+    oldval = func.get('VpcConfig')
+    if oldval is not None:
+        oldval.pop('VpcId', None)
     if oldval != VpcConfig:
         need_update = True
         ret['changes'].setdefault('new', {})['VpcConfig'] = VpcConfig


### PR DESCRIPTION
### What does this PR do?

Fix a robustness bug when Lambda doesn't return VPC info.
### What issues does this PR fix or reference?

None
### Previous Behavior

For a lambda not having VPC info, returns a stack trace.
### New Behavior

Properly handles this condition.
### Tests written?
- [x] Yes
- [ ] No
