### PR TITLE
Don't worry about KeyErrors if the node is already removed

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1665,7 +1665,11 @@ class Map(Cloud):
                         if driver not in interpolated_map[alias]:
                             interpolated_map[alias][driver] = {}
                         interpolated_map[alias][driver][vm_name] = vm_details
-                        names.remove(vm_name)
+                        try:
+                            names.remove(vm_name)
+                        except KeyError:
+                            # If it's not there, then our job is already done
+                            pass
 
             if not names:
                 continue
@@ -1764,7 +1768,7 @@ class Map(Cloud):
                         #   - bar2
                         mapping = {mapping: None}
                     for name, overrides in six.iteritems(mapping):
-                        if overrides is None:
+                        if overrides is None or isinstance(overrides, bool):
                             # Foo:
                             #   - bar1:
                             #   - bar2:
@@ -1777,7 +1781,7 @@ class Map(Cloud):
                                 'is a reserved word. Please change \'name\' to a different '
                                 'minion id reference.'
                             )
-                            return ''
+                            return {}
                         entries[name] = overrides
                 map_[profile] = entries
                 continue


### PR DESCRIPTION
### What does this PR do?

When looking at a delete map, salt-cloud used to fail when trying to remove nodes that were already removed. Since they're already removed as they need to be, we just ignore the KeyError.

I also fixed a check that I ran across while testing this, and a return value that was inconsistent with the rest of its function.
### What issues does this PR fix or reference?

Fixes #31579
### Previous Behavior

See above.
### New Behavior

See above.
### Tests written?
- [ ] Yes
- [X] No
