### PR TITLE
Ensure that vm_details is a dict

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1473,6 +1473,8 @@ class Cloud(object):
                     if not names:
                         break
                     if vm_name not in names:
+                        if not isinstance(vm_details, dict):
+                            vm_details = {}
                         if 'id' in vm_details and vm_details['id'] in names:
                             vm_name = vm_details['id']
                         else:


### PR DESCRIPTION
### What does this PR do?

`vm_details` should have been a `dict`, but was showing up as a `bool`. Now if it shows up as anything but a `dict`, it will be converted to an empty `dict`, which will trigger the debug message just below it.
### What issues does this PR fix or reference?

Fixes #31681.
### Previous Behavior

See above.
### New Behavior

See above.
### Tests written?
- [ ] Yes
- [X] No
