### PR TITLE
Add NAT Gateway support to boto_vpc

### DIFF
--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -2138,11 +2138,12 @@ def replace_route_table_association(association_id, route_table_id, region=None,
 def create_route(route_table_id=None, destination_cidr_block=None,
                  route_table_name=None, gateway_id=None,
                  internet_gateway_name=None,
+                 instance_id=None, interface_id=None,
+                 region=None, key=None, keyid=None, profile=None,
                  nat_gateway_id=None,
                  nat_gateway_subnet_name=None,
                  nat_gateway_subnet_id=None,
-                 instance_id=None, interface_id=None,
-                 region=None, key=None, keyid=None, profile=None):
+                 ):
     '''
     Creates a route.
 

--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -1199,7 +1199,6 @@ def nat_gateway_exists(nat_gateway_id=None, subnet_id=None, subnet_name=None,
 
     '''
 
-
     return bool(_find_nat_gateways(nat_gateway_id=nat_gateway_id,
                                    subnet_id=subnet_id,
                                    subnet_name=subnet_name,
@@ -1225,7 +1224,6 @@ def describe_nat_gateways(nat_gateway_id=None, subnet_id=None, subnet_name=None,
         salt myminion boto_vpc.describe_nat_gateways subnet_id='subnet-5b05942d'
 
     '''
-
 
     return _find_nat_gateways(nat_gateway_id=nat_gateway_id,
                                    subnet_id=subnet_id,
@@ -2504,6 +2502,7 @@ def _key_iter(key, keys, item):
                 element[r_key] = getattr(r_item, r_key)
         elements_list.append(element)
     return elements_list
+
 
 def _key_remap(key, keys, item):
     elements_list = []

--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -129,8 +129,6 @@ def __virtual__():
         return (False, 'The boto_vpc module could not be loaded: boto libraries not found')
     elif _LooseVersion(boto.__version__) < _LooseVersion(required_boto_version):
         return (False, 'The boto_vpc module could not be loaded: boto library is not required version 2.8.0')
-    else:
-        return True
     required_boto3_version = '1.2.6'
     # the boto_vpc execution module relies on the create_nat_gateway() method
     # which was added in boto3 1.2.6
@@ -138,8 +136,7 @@ def __virtual__():
         return (False, 'The boto_vpc module could not be loaded: boto3 libraries not found')
     elif _LooseVersion(boto3.__version__) < _LooseVersion(required_boto3_version):
         return (False, 'The boto_vpc module could not be loaded: boto3 library is not required version 1.2.6')
-    else:
-        return True
+    return True
 
 
 def __init__(opts):
@@ -1190,6 +1187,10 @@ def nat_gateway_exists(nat_gateway_id=None, subnet_id=None, subnet_name=None,
     '''
     Checks if a nat gateway exists.
 
+    This function requires boto3 to be installed.
+
+    .. versionadded:: Carbon
+
     CLI Example:
 
     .. code-block:: bash
@@ -1215,6 +1216,8 @@ def describe_nat_gateways(nat_gateway_id=None, subnet_id=None, subnet_name=None,
                        region=None, key=None, keyid=None, profile=None):
     '''
     Return a description of nat gateways matching the selection criteria
+
+    This function requires boto3 to be installed.
 
     CLI Example:
 
@@ -1242,6 +1245,8 @@ def create_nat_gateway(subnet_id=None,
     Create a NAT Gateway within an existing subnet. If allocation_id is
     specified, the elastic IP address it references is associated with the
     gateway. Otherwise, a new allocation_id is created and used.
+
+    This function requires boto3 to be installed.
 
     Returns the nat gateway id if the nat gateway was created and
     returns False if the nat gateway was not created.
@@ -1294,7 +1299,9 @@ def delete_nat_gateway(nat_gateway_id,
 
     Returns True if the internet gateway was deleted and otherwise False.
 
-    .. versionadded:: 2015.8.0
+    This function requires boto3 to be installed.
+
+    .. versionadded:: Carbon
 
     CLI Examples:
 
@@ -2145,6 +2152,8 @@ def create_route(route_table_id=None, destination_cidr_block=None,
     '''
     Creates a route.
 
+    If a nat gateway is specified, boto3 must be installed
+
     CLI Example:
 
     .. code-block:: bash
@@ -2366,6 +2375,8 @@ def describe_route_tables(route_table_id=None, route_table_name=None,
                          profile=None):
     '''
     Given route table properties, return details of all matching route tables.
+
+    This function requires boto3 to be installed.
 
     .. versionadded:: Carbon
 

--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -2317,6 +2317,10 @@ def describe_route_table(route_table_id=None, route_table_name=None,
 
     '''
 
+    salt.utils.warn_until('Nitrogen',
+         'The \'describe_route_table\' method has been deprecated and '
+         'replaced by \'describe_route_tables\'.'
+    )
     if not any((route_table_id, route_table_name, tags)):
         raise SaltInvocationError('At least one of the following must be specified: '
                                   'route table id, route table name, or tags.')
@@ -2398,7 +2402,6 @@ def describe_route_tables(route_table_id=None, route_table_name=None,
                                                      'Values': [tag_value]})
 
         route_tables = conn3.describe_route_tables(**filter_parameters).get('RouteTables', [])
-        log.warn(route_tables)
 
         if not route_tables:
             return []

--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -83,6 +83,7 @@ from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=i
 
 # Import Salt libs
 import salt.utils.boto
+import salt.utils.boto3
 import salt.utils.compat
 from salt.exceptions import SaltInvocationError, CommandExecutionError
 # from salt.utils import exactly_one
@@ -105,6 +106,14 @@ try:
 except ImportError:
     HAS_BOTO = False
 # pylint: enable=import-error
+try:
+    #pylint: disable=unused-import
+    import boto3
+    #pylint: enable=unused-import
+    logging.getLogger('boto3').setLevel(logging.CRITICAL)
+    HAS_BOTO3 = True
+except ImportError:
+    HAS_BOTO3 = False
 
 
 def __virtual__():
@@ -121,7 +130,15 @@ def __virtual__():
     elif _LooseVersion(boto.__version__) < _LooseVersion(required_boto_version):
         return (False, 'The boto_vpc module could not be loaded: boto library is not required version 2.8.0')
     else:
-
+        return True
+    required_boto3_version = '1.2.6'
+    # the boto_vpc execution module relies on the create_nat_gateway() method
+    # which was added in boto3 1.2.6
+    if not HAS_BOTO3:
+        return (False, 'The boto_vpc module could not be loaded: boto3 libraries not found')
+    elif _LooseVersion(boto3.__version__) < _LooseVersion(required_boto3_version):
+        return (False, 'The boto_vpc module could not be loaded: boto3 library is not required version 1.2.6')
+    else:
         return True
 
 
@@ -129,6 +146,11 @@ def __init__(opts):
     salt.utils.compat.pack_dunder(__name__)
     if HAS_BOTO:
         __utils__['boto.assign_funcs'](__name__, 'vpc', pack=__salt__)
+    if HAS_BOTO3:
+        __utils__['boto3.assign_funcs'](__name__, 'ec2',
+                  get_conn_funcname='_get_conn3',
+                  cache_id_funcname='_cache_id3',
+                  exactly_one_funcname=None)
 
 
 def check_vpc(vpc_id=None, vpc_name=None, region=None, key=None,
@@ -556,6 +578,7 @@ def create(cidr_block, instance_tenancy=None, vpc_name=None,
             _maybe_set_name_tag(vpc_name, vpc)
             _maybe_set_tags(tags, vpc)
             _maybe_set_dns(conn, vpc.id, enable_dns_support, enable_dns_hostnames)
+            _maybe_name_route_table(conn, vpc.id, vpc_name)
             if vpc_name:
                 _cache_id(vpc_name, vpc.id,
                           region=region, key=key,
@@ -1104,6 +1127,195 @@ def delete_internet_gateway(internet_gateway_id=None,
                                 resource_id=internet_gateway_id,
                                 region=region, key=key, keyid=keyid,
                                 profile=profile)
+    except BotoServerError as e:
+        return {'deleted': False, 'error': salt.utils.boto.get_error(e)}
+
+
+def _find_nat_gateways(nat_gateway_id=None, subnet_id=None, subnet_name=None, vpc_id=None, vpc_name=None,
+                       states=('pending', 'available'),
+                       region=None, key=None, keyid=None, profile=None):
+    '''
+    Given gateway properties, find and return matching nat gateways
+    '''
+
+    if not any((nat_gateway_id, subnet_id, subnet_name, vpc_id, vpc_name)):
+        raise SaltInvocationError('At least one of the following must be '
+                                  'provided: nat_gateway_id, subnet_id, '
+                                  'subnet_name, vpc_id, or vpc_name.')
+    filter_parameters = {'Filter': []}
+
+    if nat_gateway_id:
+        filter_parameters['NatGatewayIds'] = [nat_gateway_id]
+
+    if subnet_name:
+        subnet_id = _get_resource_id('subnet', subnet_name,
+                                     region=region, key=key,
+                                     keyid=keyid, profile=profile)
+        if not subnet_id:
+            return False
+
+    if subnet_id:
+        filter_parameters['Filter'].append({'Name': 'subnet-id', 'Values': [subnet_id]})
+
+    if vpc_name:
+        vpc_id = _get_resource_id('vpc', vpc_name,
+                                     region=region, key=key,
+                                     keyid=keyid, profile=profile)
+        if not vpc_id:
+            return False
+
+    if vpc_id:
+        filter_parameters['Filter'].append({'Name': 'vpc-id', 'Values': [vpc_id]})
+
+    conn3 = _get_conn3(region=region, key=key, keyid=keyid, profile=profile)
+    nat_gateways = []
+    for ret in salt.utils.boto3.paged_call(conn3.describe_nat_gateways,
+                                           marker_flag='NextToken', marker_arg='NextToken',
+                                           **filter_parameters):
+        for gw in ret.get('NatGateways', []):
+            if gw.get('State') in states:
+                nat_gateways.append(gw)
+    log.debug('The filters criteria {0} matched the following nat gateways: {1}'.format(filter_parameters, nat_gateways))
+
+    if nat_gateways:
+        return nat_gateways
+    else:
+        return False
+
+
+def nat_gateway_exists(nat_gateway_id=None, subnet_id=None, subnet_name=None,
+                       vpc_id=None, vpc_name=None,
+                       states=('pending', 'available'),
+                       region=None, key=None, keyid=None, profile=None):
+    '''
+    Checks if a nat gateway exists.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_vpc.nat_gateway_exists nat_gateway_id='nat-03b02643b43216fe7'
+        salt myminion boto_vpc.nat_gateway_exists subnet_id='subnet-5b05942d'
+
+    '''
+
+
+    return bool(_find_nat_gateways(nat_gateway_id=nat_gateway_id,
+                                   subnet_id=subnet_id,
+                                   subnet_name=subnet_name,
+                                   vpc_id=vpc_id,
+                                   vpc_name=vpc_name,
+                                   states=states,
+                           region=region, key=key, keyid=keyid,
+                           profile=profile))
+
+
+def describe_nat_gateways(nat_gateway_id=None, subnet_id=None, subnet_name=None,
+                       vpc_id=None, vpc_name=None,
+                       states=('pending', 'available'),
+                       region=None, key=None, keyid=None, profile=None):
+    '''
+    Return a description of nat gateways matching the selection criteria
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_vpc.describe_nat_gateways nat_gateway_id='nat-03b02643b43216fe7'
+        salt myminion boto_vpc.describe_nat_gateways subnet_id='subnet-5b05942d'
+
+    '''
+
+
+    return _find_nat_gateways(nat_gateway_id=nat_gateway_id,
+                                   subnet_id=subnet_id,
+                                   subnet_name=subnet_name,
+                                   vpc_id=vpc_id,
+                                   vpc_name=vpc_name,
+                                   states=states,
+                           region=region, key=key, keyid=keyid,
+                           profile=profile)
+
+
+def create_nat_gateway(subnet_id=None,
+                       subnet_name=None, allocation_id=None,
+                       region=None, key=None, keyid=None, profile=None):
+    '''
+    Create a NAT Gateway within an existing subnet. If allocation_id is
+    specified, the elastic IP address it references is associated with the
+    gateway. Otherwise, a new allocation_id is created and used.
+
+    Returns the nat gateway id if the nat gateway was created and
+    returns False if the nat gateway was not created.
+
+    .. versionadded:: Carbon
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_vpc.create_nat_gateway subnet_name=mysubnet
+
+    '''
+
+    try:
+        if all((subnet_id, subnet_name)):
+            raise SaltInvocationError('Only one of subnet_name or subnet_id may be '
+                                  'provided.')
+        if subnet_name:
+            subnet_id = _get_resource_id('subnet', subnet_name,
+                                     region=region, key=key,
+                                     keyid=keyid, profile=profile)
+            if not subnet_id:
+                return {'created': False,
+                        'error': {'message': 'Subnet {0} does not exist.'.format(subnet_name)}}
+        else:
+            if not _get_resource('subnet', resource_id=subnet_id,
+                                 region=region, key=key, keyid=keyid, profile=profile):
+                return {'created': False,
+                        'error': {'message': 'Subnet {0} does not exist.'.format(subnet_id)}}
+
+        conn3 = _get_conn3(region=region, key=key, keyid=keyid, profile=profile)
+
+        if not allocation_id:
+            address = conn3.allocate_address(Domain='vpc')
+            allocation_id = address.get('AllocationId')
+
+        # Have to go to boto3 to create NAT gateway
+        r = conn3.create_nat_gateway(SubnetId=subnet_id, AllocationId=allocation_id)
+        return {'created': True, 'id': r.get('NatGateway', {}).get('NatGatewayId')}
+    except BotoServerError as e:
+        return {'created': False, 'error': salt.utils.boto.get_error(e)}
+
+
+def delete_nat_gateway(nat_gateway_id,
+                       release_eips=False, region=None,
+                       key=None, keyid=None, profile=None):
+    '''
+    Delete a nat gateway (by id).
+
+    Returns True if the internet gateway was deleted and otherwise False.
+
+    .. versionadded:: 2015.8.0
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt myminion boto_vpc.delete_nat_gateway nat_gateway_id=igw-1a2b3c
+
+    '''
+
+    try:
+        conn3 = _get_conn3(region=region, key=key, keyid=keyid, profile=profile)
+        gwinfo = conn3.describe_nat_gateways(NatGatewayIds=[nat_gateway_id])
+        if gwinfo:
+            gwinfo = gwinfo.get('NatGateways', [None])[0]
+        conn3.delete_nat_gateway(NatGatewayId=nat_gateway_id)
+        if release_eips and gwinfo:
+            for addr in gwinfo.get('NatGatewayAddresses'):
+                conn3.release_address(AllocationId=addr.get('AllocationId'))
+        return {'deleted': True}
     except BotoServerError as e:
         return {'deleted': False, 'error': salt.utils.boto.get_error(e)}
 
@@ -1926,6 +2138,9 @@ def replace_route_table_association(association_id, route_table_id, region=None,
 def create_route(route_table_id=None, destination_cidr_block=None,
                  route_table_name=None, gateway_id=None,
                  internet_gateway_name=None,
+                 nat_gateway_id=None,
+                 nat_gateway_subnet_name=None,
+                 nat_gateway_subnet_id=None,
                  instance_id=None, interface_id=None,
                  region=None, key=None, keyid=None, profile=None):
     '''
@@ -1943,9 +2158,10 @@ def create_route(route_table_id=None, destination_cidr_block=None,
         raise SaltInvocationError('One (but not both) of route_table_id or route_table_name '
                                   'must be provided.')
 
-    if not _exactly_one((gateway_id, internet_gateway_name, instance_id, interface_id)):
+    if not _exactly_one((gateway_id, internet_gateway_name, instance_id,
+                         interface_id, nat_gateway_id, nat_gateway_subnet_id, nat_gateway_subnet_name)):
         raise SaltInvocationError('Only one of gateway_id, internet_gateway_name, instance_id, '
-                                  'or interface_id may be provided.')
+                                  'interface_id, nat_gateway_id, nat_gateway_subnet_id or nat_gateway_subnet_name may be provided.')
 
     if destination_cidr_block is None:
         raise SaltInvocationError('destination_cidr_block is required.')
@@ -1966,14 +2182,38 @@ def create_route(route_table_id=None, destination_cidr_block=None,
             if not gateway_id:
                 return {'created': False,
                         'error': {'message': 'internet gateway {0} does not exist.'.format(internet_gatway_name)}}
+        if nat_gateway_subnet_name:
+            gws = describe_nat_gateways(subnet_name=nat_gateway_subnet_name,
+                                     region=region, key=key, keyid=keyid, profile=profile)
+            if not gws:
+                return {'created': False,
+                        'error': {'message': 'nat gateway for {0} does not exist.'.format(nat_gateway_subnet_name)}}
+            nat_gateway_id = gws[0]['NatGatewayId']
+        if nat_gateway_subnet_id:
+            gws = describe_nat_gateways(subnet_id=nat_gateway_subnet_id,
+                                     region=region, key=key, keyid=keyid, profile=profile)
+            if not gws:
+                return {'created': False,
+                        'error': {'message': 'nat gateway for {0} does not exist.'.format(nat_gateway_subnet_id)}}
+            nat_gateway_id = gws[0]['NatGatewayId']
     except BotoServerError as e:
         return {'created': False, 'error': salt.utils.boto.get_error(e)}
 
-    return _create_resource('route', route_table_id=route_table_id,
+    if not nat_gateway_id:
+        return _create_resource('route', route_table_id=route_table_id,
                             destination_cidr_block=destination_cidr_block,
                             gateway_id=gateway_id, instance_id=instance_id,
                             interface_id=interface_id, region=region,
                             key=key, keyid=keyid, profile=profile)
+    # for nat gateway, boto3 is required
+    try:
+        conn3 = _get_conn3(region=region, key=key, keyid=keyid, profile=profile)
+        ret = conn3.create_route(RouteTableId=route_table_id,
+                       DestinationCidrBlock=destination_cidr_block,
+                       NatGatewayId=nat_gateway_id)
+        return {'created': True, 'id': ret.get('NatGatewayId')}
+    except BotoServerError as e:
+        return {'created': False, 'error': salt.utils.boto.get_error(e)}
 
 
 def delete_route(route_table_id=None, destination_cidr_block=None,
@@ -2117,6 +2357,90 @@ def describe_route_table(route_table_id=None, route_table_name=None,
         return {'error': salt.utils.boto.get_error(e)}
 
 
+def describe_route_tables(route_table_id=None, route_table_name=None,
+                         vpc_id=None,
+                         tags=None, region=None, key=None, keyid=None,
+                         profile=None):
+    '''
+    Given route table properties, return details of all matching route tables.
+
+    .. versionadded:: Carbon
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_vpc.describe_route_tables vpc_id='vpc-a6a9efc3'
+
+    '''
+
+    if not any((route_table_id, route_table_name, tags, vpc_id)):
+        raise SaltInvocationError('At least one of the following must be specified: '
+                                  'route table id, route table name, vpc_id, or tags.')
+
+    try:
+        conn3 = _get_conn3(region=region, key=key, keyid=keyid, profile=profile)
+        filter_parameters = {'Filters': []}
+
+        if route_table_id:
+            filter_parameters['RouteTableIds'] = [route_table_id]
+
+        if vpc_id:
+            filter_parameters['Filters'].append({'Name': 'vpc-id', 'Values': [vpc_id]})
+
+        if route_table_name:
+            filter_parameters['Filters'].append({'Name': 'tag:Name', 'Values': [route_table_name]})
+
+        if tags:
+            for tag_name, tag_value in six.iteritems(tags):
+                filter_parameters['Filters'].append({'Name': 'tag:{0}'.format(tag_name),
+                                                     'Values': [tag_value]})
+
+        route_tables = conn3.describe_route_tables(**filter_parameters).get('RouteTables', [])
+        log.warn(route_tables)
+
+        if not route_tables:
+            return []
+
+        tables = []
+        keys = {'id': 'RouteTableId',
+                'vpc_id': 'VpcId',
+                'tags': 'Tags',
+                'routes': 'Routes',
+                'associations': 'Associations'
+            }
+        route_keys = {'destination_cidr_block': 'DestinationCidrBlock',
+                      'gateway_id': 'GatewayId',
+                      'instance_id': 'Instance',
+                      'interface_id': 'NetworkInterfaceId',
+                      'nat_gateway_id': 'NatGatewayId',
+                      }
+        assoc_keys = {'id': 'RouteTableAssociationId',
+                      'main': 'Main',
+                      'route_table_id': 'RouteTableId',
+                      'SubnetId': 'subnet_id',
+                      }
+        for item in route_tables:
+            route_table = {}
+            for outkey, inkey in keys.iteritems():
+                if inkey in item:
+                    if outkey == 'routes':
+                        route_table[outkey] = _key_remap(inkey, route_keys, item)
+                    elif outkey == 'associations':
+                        route_table[outkey] = _key_remap(inkey, assoc_keys, item)
+                    elif outkey == 'tags':
+                        route_table[outkey] = {}
+                        for tagitem in item.get(inkey, []):
+                            route_table[outkey][tagitem.get('Key')] = tagitem.get('Value')
+                    else:
+                        route_table[outkey] = item.get(inkey)
+            tables.append(route_table)
+        return tables
+
+    except BotoServerError as e:
+        return {'error': salt.utils.boto.get_error(e)}
+
+
 def _create_dhcp_options(conn, domain_name=None, domain_name_servers=None, ntp_servers=None, netbios_name_servers=None,
                          netbios_node_type=None):
     return conn.create_dhcp_options(domain_name=domain_name, domain_name_servers=domain_name_servers,
@@ -2147,6 +2471,26 @@ def _maybe_set_dns(conn, vpcid, dns_support, dns_hostnames):
         log.debug('DNS hostnames was set to: {0} on vpc {1}'.format(dns_hostnames, vpcid))
 
 
+def _maybe_name_route_table(conn, vpcid, vpc_name):
+    route_tables = conn.get_all_route_tables(filters={'vpc_id': vpcid})
+    if not route_tables:
+        log.warn('no default route table found')
+        return
+    default_table = None
+    for table in route_tables:
+        for association in getattr(table, 'associations', {}):
+            if getattr(association, 'main', False):
+                default_table = table
+                break
+    if not default_table:
+        log.warn('no default route table found')
+        return
+
+    name = '{0}-default-table'.format(vpc_name)
+    _maybe_set_name_tag(name, default_table)
+    log.debug('Default route table name was set to: {0} on vpc {1}'.format(name, vpcid))
+
+
 def _key_iter(key, keys, item):
     elements_list = []
     for r_item in getattr(item, key):
@@ -2154,5 +2498,15 @@ def _key_iter(key, keys, item):
         for r_key in keys:
             if hasattr(r_item, r_key):
                 element[r_key] = getattr(r_item, r_key)
+        elements_list.append(element)
+    return elements_list
+
+def _key_remap(key, keys, item):
+    elements_list = []
+    for r_item in item.get(key, []):
+        element = {}
+        for r_outkey, r_inkey in keys.iteritems():
+            if r_inkey in r_item:
+                element[r_outkey] = r_item.get(r_inkey)
         elements_list.append(element)
     return elements_list

--- a/salt/states/boto_vpc.py
+++ b/salt/states/boto_vpc.py
@@ -1224,7 +1224,7 @@ def nat_gateway_absent(name=None, subnet_name=None, subnet_id=None,
             ret['result'] = False
             ret['comment'] = 'Failed to delete nat gateway: {0}'.format(r['error']['message'])
             return ret
-        ret['comment'] = ', '.join(ret['comment'], 'Nat gateway {0} deleted.'.format(rtbl_id))
+        ret['comment'] = ', '.join((ret['comment'], 'Nat gateway {0} deleted.'.format(rtbl_id)))
     ret['changes']['old'] = {'nat_gateway': rtbl_id}
     ret['changes']['new'] = {'nat_gateway': None}
     return ret

--- a/salt/states/boto_vpc.py
+++ b/salt/states/boto_vpc.py
@@ -866,7 +866,11 @@ def _routes_present(route_table_name, routes, tags=None, region=None, key=None, 
     if routes:
         route_keys = set(('gateway_id', 'instance_id', 'destination_cidr_block', 'interface_id', 'nat_gateway_id'))
         for i in routes:
-            _r = {k:i[k] for k in i if k in route_keys}
+            #_r = {k:i[k] for k in i if k in route_keys}
+            _r = {}
+            for k, v in i.iteritems():
+                if k in route_keys:
+                    _r[k] = i[k]
             if i.get('internet_gateway_name'):
                 r = __salt__['boto_vpc.get_resource_id']('internet_gateway', name=i['internet_gateway_name'],
                                                          region=region, key=key, keyid=keyid, profile=profile)

--- a/salt/states/boto_vpc.py
+++ b/salt/states/boto_vpc.py
@@ -867,10 +867,6 @@ def _routes_present(route_table_name, routes, tags=None, region=None, key=None, 
         route_keys = set(('gateway_id', 'instance_id', 'destination_cidr_block', 'interface_id', 'nat_gateway_id'))
         for i in routes:
             _r = {k:i[k] for k in i if k in route_keys}
-            #_r = {}
-            #for k, v in i.iteritems():
-            #    if k in route_keys:
-            #        _r[k] = i[k]
             if i.get('internet_gateway_name'):
                 r = __salt__['boto_vpc.get_resource_id']('internet_gateway', name=i['internet_gateway_name'],
                                                          region=region, key=key, keyid=keyid, profile=profile)

--- a/salt/states/boto_vpc.py
+++ b/salt/states/boto_vpc.py
@@ -712,6 +712,8 @@ def route_table_present(name, vpc_name=None, vpc_id=None, routes=None,
     '''
     Ensure route table with routes exists and is associated to a VPC.
 
+    This function requires boto3 to be installed if nat gatewyas are specified.
+
     Example:
 
     .. code-block:: yaml
@@ -1102,6 +1104,10 @@ def nat_gateway_present(name, subnet_name=None, subnet_id=None,
     '''
     Ensure a nat gateway exists within the specified subnet
 
+    This function requires boto3.
+
+    .. versionadded:: Carbon
+
     Example:
 
     .. code-block:: yaml
@@ -1173,6 +1179,10 @@ def nat_gateway_absent(name=None, subnet_name=None, subnet_id=None,
                        region=None, key=None, keyid=None, profile=None):
     '''
     Ensure the nat gateway in the named subnet is absent.
+
+    This function requires boto3.
+
+    .. versionadded:: Carbon
 
     name
         Name of the state.

--- a/salt/states/boto_vpc.py
+++ b/salt/states/boto_vpc.py
@@ -852,7 +852,7 @@ def _routes_present(route_table_name, routes, tags=None, region=None, key=None, 
            'changes': {}
            }
 
-    route_table = __salt__['boto_vpc.describe_route_table'](route_table_name=route_table_name, tags=tags,
+    route_table = __salt__['boto_vpc.describe_route_tables'](route_table_name=route_table_name, tags=tags,
                                                             region=region, key=key, keyid=keyid, profile=profile)
     if 'error' in route_table:
         msg = 'Could not retrieve configuration for route table {0}: {1}`.'.format(route_table_name,
@@ -861,11 +861,16 @@ def _routes_present(route_table_name, routes, tags=None, region=None, key=None, 
         ret['result'] = False
         return ret
 
+    route_table = route_table[0]
     _routes = []
     if routes:
-        route_keys = ['gateway_id', 'instance_id', 'destination_cidr_block', 'interface_id']
+        route_keys = set(('gateway_id', 'instance_id', 'destination_cidr_block', 'interface_id', 'nat_gateway_id'))
         for i in routes:
-            _r = dict((k, i.get(k)) for k in route_keys)
+            _r = {k:i[k] for k in i if k in route_keys}
+            #_r = {}
+            #for k, v in i.iteritems():
+            #    if k in route_keys:
+            #        _r[k] = i[k]
             if i.get('internet_gateway_name'):
                 r = __salt__['boto_vpc.get_resource_id']('internet_gateway', name=i['internet_gateway_name'],
                                                          region=region, key=key, keyid=keyid, profile=profile)
@@ -892,6 +897,15 @@ def _routes_present(route_table_name, routes, tags=None, region=None, key=None, 
                     ret['result'] = False
                     return ret
                 _r['instance_id'] = r
+            if i.get('nat_gateway_subnet_name'):
+                r = __salt__['boto_vpc.describe_nat_gateways'](subnet_name=i['nat_gateway_subnet_name'],
+                                                         region=region, key=key, keyid=keyid, profile=profile)
+                if not r:
+                    msg = 'Nat gateway does not exist.'
+                    ret['comment'] = msg
+                    ret['result'] = False
+                    return ret
+                _r['nat_gateway_id'] = r[0]['NatGatewayId']
             _routes.append(_r)
 
     to_delete = []
@@ -901,7 +915,7 @@ def _routes_present(route_table_name, routes, tags=None, region=None, key=None, 
             to_create.append(dict(route))
     for route in route_table['routes']:
         if route not in _routes:
-            if route['gateway_id'] != 'local':
+            if route.get('gateway_id') != 'local':
                 to_delete.append(route)
     if to_create or to_delete:
         if __opts__['test']:
@@ -934,9 +948,9 @@ def _routes_present(route_table_name, routes, tags=None, region=None, key=None, 
                     return ret
                 ret['comment'] = 'Created route {0} in route table {1}.'.format(r['destination_cidr_block'], route_table_name)
         ret['changes']['old'] = {'routes': route_table['routes']}
-        route = __salt__['boto_vpc.describe_route_table'](route_table_name=route_table_name, tags=tags, region=region, key=key,
+        route = __salt__['boto_vpc.describe_route_tables'](route_table_name=route_table_name, tags=tags, region=region, key=key,
                                                           keyid=keyid, profile=profile)
-        ret['changes']['new'] = {'routes': route['routes']}
+        ret['changes']['new'] = {'routes': route[0]['routes']}
     return ret
 
 
@@ -1080,4 +1094,141 @@ def route_table_absent(name, region=None,
     ret['changes']['old'] = {'route_table': rtbl_id}
     ret['changes']['new'] = {'route_table': None}
     ret['comment'] = 'Route table {0} deleted.'.format(name)
+    return ret
+
+
+def nat_gateway_present(name, subnet_name=None, subnet_id=None,
+                        region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure a nat gateway exists within the specified subnet
+
+    Example:
+
+    .. code-block:: yaml
+
+        boto_vpc.nat_gateway_present:
+            - subnet_name: my-subnet
+
+    name
+        Name of the state
+
+    subnet_name
+        Name of the subnet within which the nat gateway should exist
+
+    subnet_id
+        Id of the subnet within which the nat gateway should exist.
+        Either subnet_name or subnet_id must be provided.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+    '''
+    ret = {'name': name,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    r = __salt__['boto_vpc.describe_nat_gateways'](subnet_name=subnet_name,
+                                             subnet_id=subnet_id,
+                                             region=region, key=key, keyid=keyid,
+                                             profile=profile)
+    if not r:
+        if __opts__['test']:
+            msg = 'Nat gateway is set to be created.'
+            ret['comment'] = msg
+            ret['result'] = None
+            return ret
+
+        r = __salt__['boto_vpc.create_nat_gateway'](subnet_name=subnet_name,
+                                                    subnet_id=subnet_id,
+                                                    region=region, key=key,
+                                                    keyid=keyid, profile=profile)
+        if not r.get('created'):
+            ret['result'] = False
+            ret['comment'] = 'Failed to create nat gateway: {0}.'.format(r['error']['message'])
+            return ret
+
+        ret['changes']['old'] = {'nat_gateway': None}
+        ret['changes']['new'] = {'nat_gateway': r['id']}
+        ret['comment'] = 'Nat gateway created.'
+        return ret
+
+    inst = r[0]
+    _id = inst.get('NatGatewayId')
+    ret['comment'] = 'Nat gateway {0} present.'.format(_id)
+    return ret
+
+
+def nat_gateway_absent(name=None, subnet_name=None, subnet_id=None,
+                       region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure the nat gateway in the named subnet is absent.
+
+    name
+        Name of the state.
+
+    subnet_name
+        Name of the subnet within which the nat gateway should exist
+
+    subnet_id
+        Id of the subnet within which the nat gateway should exist.
+        Either subnet_name or subnet_id must be provided.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+    '''
+
+    ret = {'name': name,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    r = __salt__['boto_vpc.describe_nat_gateways'](subnet_name=subnet_name,
+                                             subnet_id=subnet_id,
+                                             region=region, key=key, keyid=keyid,
+                                             profile=profile)
+    if not r:
+        ret['comment'] = 'Nat gateway does not exist.'
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'Nat gateway is set to be removed.'
+        ret['result'] = None
+        return ret
+
+    for gw in r:
+        rtbl_id = gw.get('NatGatewayId')
+        r = __salt__['boto_vpc.delete_nat_gateway'](nat_gateway_id=rtbl_id,
+                                                release_eips=True,
+                                                region=region,
+                                                key=key, keyid=keyid,
+                                                profile=profile)
+        if 'error' in r:
+            ret['result'] = False
+            ret['comment'] = 'Failed to delete nat gateway: {0}'.format(r['error']['message'])
+            return ret
+        ret['comment'] = ', '.join(ret['comment'], 'Nat gateway {0} deleted.'.format(rtbl_id))
+    ret['changes']['old'] = {'nat_gateway': rtbl_id}
+    ret['changes']['new'] = {'nat_gateway': None}
     return ret

--- a/salt/utils/boto3.py
+++ b/salt/utils/boto3.py
@@ -279,7 +279,9 @@ def exactly_one(l):
     return exactly_n(l)
 
 
-def assign_funcs(modname, service, module=None):
+def assign_funcs(modname, service, module=None,
+                get_conn_funcname='_get_conn', cache_id_funcname='_cache_id',
+                exactly_one_funcname='_exactly_one'):
     '''
     Assign _get_conn and _cache_id functions to the named module.
 
@@ -288,12 +290,13 @@ def assign_funcs(modname, service, module=None):
         _utils__['boto.assign_partials'](__name__, 'ec2')
     '''
     mod = sys.modules[modname]
-    setattr(mod, '_get_conn', get_connection_func(service, module=module))
-    setattr(mod, '_cache_id', cache_id_func(service))
+    setattr(mod, get_conn_funcname, get_connection_func(service, module=module))
+    setattr(mod, cache_id_funcname, cache_id_func(service))
 
     # TODO: Remove this and import salt.utils.exactly_one into boto_* modules instead
     # Leaving this way for now so boto modules can be back ported
-    setattr(mod, '_exactly_one', exactly_one)
+    if exactly_one_funcname is not None:
+        setattr(mod, exactly_one_funcname, exactly_one)
 
 
 def paged_call(function, *args, **kwargs):

--- a/tests/unit/modules/boto_vpc_test.py
+++ b/tests/unit/modules/boto_vpc_test.py
@@ -27,6 +27,7 @@ import salt.ext.six as six
 # pylint: disable=import-error,no-name-in-module
 try:
     import boto
+    import boto3
     from boto.exception import BotoServerError
     HAS_BOTO = True
 except ImportError:

--- a/tests/unit/modules/boto_vpc_test.py
+++ b/tests/unit/modules/boto_vpc_test.py
@@ -24,7 +24,7 @@ from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
 
 # Import 3rd-party libs
 import salt.ext.six as six
-# pylint: disable=import-error,no-name-in-module
+# pylint: disable=import-error,no-name-in-module,unused-import
 try:
     import boto
     import boto3
@@ -52,7 +52,7 @@ except ImportError:
             pass
 
         return stub_function
-# pylint: enable=import-error,no-name-in-module
+# pylint: enable=import-error,no-name-in-module,unused-import
 
 # the boto_vpc module relies on the connect_to_region() method
 # which was added in boto 2.8.0

--- a/tests/unit/modules/boto_vpc_test.py
+++ b/tests/unit/modules/boto_vpc_test.py
@@ -20,6 +20,7 @@ import salt.loader
 from salt.modules import boto_vpc
 from salt.exceptions import SaltInvocationError, CommandExecutionError
 from salt.modules.boto_vpc import _maybe_set_name_tag, _maybe_set_tags
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
 
 # Import 3rd-party libs
 import salt.ext.six as six
@@ -69,7 +70,7 @@ network_acl_entry_parameters = ('fake', 100, -1, 'allow', cidr_block)
 dhcp_options_parameters.update(conn_parameters)
 
 opts = salt.config.DEFAULT_MINION_OPTS
-utils = salt.loader.utils(opts, whitelist=['boto'])
+utils = salt.loader.utils(opts, whitelist=['boto','boto3'])
 mods = salt.loader.minion_mods(opts)
 
 boto_vpc.__utils__ = utils
@@ -112,9 +113,22 @@ def _has_required_moto():
         return True
 
 
+context = {}
 class BotoVpcTestCaseBase(TestCase):
+    conn3 = None
+
+    # Set up MagicMock to replace the boto3 session
     def setUp(self):
         boto_vpc.__context__ = {}
+        context.clear()
+
+        self.patcher = patch('boto3.session.Session')
+        self.addCleanup(self.patcher.stop)
+        mock_session = self.patcher.start()
+
+        session_instance = mock_session.return_value
+        self.conn3 = MagicMock()
+        session_instance.client.return_value = self.conn3
 
 
 class BotoVpcTestCaseMixin(object):
@@ -894,6 +908,55 @@ class BotoVpcInternetGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                                                vpc_id=vpc.id)
 
         self.assertTrue(igw_creation_result.get('created'))
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(HAS_BOTO is False, 'The boto module must be installed.')
+@skipIf(HAS_MOTO is False, 'The moto module must be installed.')
+@skipIf(_has_required_boto() is False, 'The boto module must be greater than'
+                                       ' or equal to version {0}'
+        .format(required_boto_version))
+class BotoVpcNatGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
+    @mock_ec2
+    def test_that_when_creating_an_nat_gateway_the_create_nat_gateway_method_returns_true(self):
+        '''
+        Tests creating an nat gateway successfully (with subnet_id specified)
+        '''
+
+        vpc = self._create_vpc()
+        subnet = self._create_subnet(vpc.id, name='subnet1', availability_zone='us-east-1a')
+        ngw_creation_result = boto_vpc.create_nat_gateway(subnet_id=subnet.id,
+                                                          region=region,
+                                                          key=secret_key,
+                                                          keyid=access_key)
+        self.assertTrue(ngw_creation_result.get('created'))
+
+    @mock_ec2
+    def test_that_when_creating_an_nat_gateway_with_non_existent_subnet_the_create_nat_gateway_method_returns_an_error(self):
+        '''
+        Tests that creating an nat gateway for a non-existent subnet fails.
+        '''
+
+        ngw_creation_result = boto_vpc.create_nat_gateway(region=region,
+                                                          key=secret_key,
+                                                          keyid=access_key,
+                                                          subnet_name='non-existent-subnet')
+        self.assertTrue('error' in ngw_creation_result)
+
+    @mock_ec2
+    def test_that_when_creating_an_nat_gateway_with_subnet_name_specified_the_create_nat_gateway_method_returns_true(self):
+        '''
+        Tests creating an nat gateway with subnet name specified.
+        '''
+
+        vpc = self._create_vpc()
+        subnet = self._create_subnet(vpc.id, name='test-subnet', availability_zone='us-east-1a')
+        ngw_creation_result = boto_vpc.create_nat_gateway(region=region,
+                                                          key=secret_key,
+                                                          keyid=access_key,
+                                                          subnet_name='test-subnet')
+
+        self.assertTrue(ngw_creation_result.get('created'))
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)

--- a/tests/unit/modules/boto_vpc_test.py
+++ b/tests/unit/modules/boto_vpc_test.py
@@ -70,7 +70,7 @@ network_acl_entry_parameters = ('fake', 100, -1, 'allow', cidr_block)
 dhcp_options_parameters.update(conn_parameters)
 
 opts = salt.config.DEFAULT_MINION_OPTS
-utils = salt.loader.utils(opts, whitelist=['boto','boto3'])
+utils = salt.loader.utils(opts, whitelist=['boto', 'boto3'])
 mods = salt.loader.minion_mods(opts)
 
 boto_vpc.__utils__ = utils
@@ -114,6 +114,8 @@ def _has_required_moto():
 
 
 context = {}
+
+
 class BotoVpcTestCaseBase(TestCase):
     conn3 = None
 

--- a/tests/unit/states/boto_vpc_test.py
+++ b/tests/unit/states/boto_vpc_test.py
@@ -22,6 +22,7 @@ from unit.modules.boto_vpc_test import BotoVpcTestCaseMixin
 # Import 3rd-party libs
 try:
     import boto
+    import boto3
     from boto.exception import BotoServerError
 
     HAS_BOTO = True

--- a/tests/unit/states/boto_vpc_test.py
+++ b/tests/unit/states/boto_vpc_test.py
@@ -16,7 +16,7 @@ ensure_in_syspath('../../')
 import salt.config
 import salt.loader
 
-# pylint: disable=import-error
+# pylint: disable=import-error,unused-import
 from unit.modules.boto_vpc_test import BotoVpcTestCaseMixin
 
 # Import 3rd-party libs
@@ -48,7 +48,7 @@ except ImportError:
             pass
 
         return stub_function
-# pylint: enable=import-error
+# pylint: enable=import-error,unused-import
 
 # the boto_vpc module relies on the connect_to_region() method
 # which was added in boto 2.8.0

--- a/tests/unit/states/boto_vpc_test.py
+++ b/tests/unit/states/boto_vpc_test.py
@@ -66,7 +66,7 @@ dhcp_options_parameters.update(conn_parameters)
 
 opts = salt.config.DEFAULT_MINION_OPTS
 ctx = {}
-utils = salt.loader.utils(opts, context=ctx, whitelist=['boto','boto3'])
+utils = salt.loader.utils(opts, context=ctx, whitelist=['boto', 'boto3'])
 serializers = salt.loader.serializers(opts)
 funcs = salt.loader.minion_mods(opts, context=ctx, utils=utils, whitelist=['boto_vpc'])
 salt_states = salt.loader.states(opts=opts, functions=funcs, utils=utils, whitelist=['boto_vpc'], serializers=serializers)

--- a/tests/unit/states/boto_vpc_test.py
+++ b/tests/unit/states/boto_vpc_test.py
@@ -58,6 +58,7 @@ access_key = 'GKTADJGHEIQSXMKKRBJ08H'
 secret_key = 'askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs'
 conn_parameters = {'region': region, 'key': access_key, 'keyid': secret_key, 'profile': {}}
 cidr_block = '10.0.0.0/24'
+subnet_id = 'subnet-123456'
 dhcp_options_parameters = {'domain_name': 'example.com', 'domain_name_servers': ['1.2.3.4'], 'ntp_servers': ['5.6.7.8'],
                            'netbios_name_servers': ['10.0.0.1'], 'netbios_node_type': 2}
 network_acl_entry_parameters = ('fake', 100, -1, 'allow', cidr_block)
@@ -65,7 +66,7 @@ dhcp_options_parameters.update(conn_parameters)
 
 opts = salt.config.DEFAULT_MINION_OPTS
 ctx = {}
-utils = salt.loader.utils(opts, context=ctx, whitelist=['boto'])
+utils = salt.loader.utils(opts, context=ctx, whitelist=['boto','boto3'])
 serializers = salt.loader.serializers(opts)
 funcs = salt.loader.minion_mods(opts, context=ctx, utils=utils, whitelist=['boto_vpc'])
 salt_states = salt.loader.states(opts=opts, functions=funcs, utils=utils, whitelist=['boto_vpc'], serializers=serializers)


### PR DESCRIPTION
### What does this PR do?

Adds support for AWS's new NAT Gateway functionality to boto_vpc
### What issues does this PR fix or reference?

None
### Previous Behavior

No support for NAT Gateway
### New Behavior

API support for this functionality is not available in boto2, so this creates a new dependency in boto_vpc on boto3. For the best possible backwards compatibility, existing code that makes use of boto 2 has been disturbed as little as possible. Only new functionality relies on boto 3. The downside of this is that boto_vpc actually depends on both boto2 and boto3 now.

This adds nat_gateway_exists, describe_nat_gateways, create_nat_gateway, and delete_nat_gateway methods to the boto_vpc module. It also adds nat_gateway_present and nat_gateway_absent methods to the boto_vpc state.

Also in support of this, the create_route method has been extended to support nat_gateway_id, nat_gateway_subnet_id, and nat_gateway_subnet_name as arguments for setting up routes via the NAT. Also, boto_vpc.present has been enhanced to add a name tag to the default route for the VPC, so it becomes straightforward to add a route via the NAT to the default routing table for the VPC. (Without this, it's hard to identify the correct route table to use to do this.)

The method describe_route_table has an issue where, if the arguments specified match more than one route table, the results returned are potentially an undefined mix of values from the set of possible results, returned as a single item.

To get past this without breaking backwards compatibility, the describe_route_tables method has been added which is extremely similar, but returns a list of results and therefore works when there's more than one match. It also supports querying by vpc ID This version also relies on boto3 and includes results for NAT Gateways. The older describe_route_table method has not been modified to support NAT gateways, and has been deprecated.
### Tests written?
- [x] Yes
- [ ] No
