### PR TITLE
fix bug introduced by moving config into directory

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -59,7 +59,7 @@ else:
     _DFLT_IPC_MODE = 'ipc'
 
 FLO_DIR = os.path.join(
-        os.path.dirname(__file__),
+        os.path.dirname(os.path.dirname(__file__)),
         'daemons', 'flo')
 
 VALID_OPTS = {


### PR DESCRIPTION
### What does this PR do?

Fix the path passed to ioflo for raet startup
### What issues does this PR fix or reference?

To my knowledge they are not yet filed, this is only on the 2016.3 branch
### Previous Behavior

Raet broken on 2016.3
### New Behavior

Raet works on 2016.3
### Tests written?
- [X] Yes
- [ ] No
  Yes in that the raet transport tests that we just enabled for 2016.3 picked this up:)
