### PR TITLE
Assume pillar_opts is False when not specified in masterless mode

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -327,6 +327,7 @@ DEFAULT_MINION_OPTS = {
     'autoload_dynamic_modules': True,
     'environment': None,
     'pillarenv': None,
+    'pillar_opts': False,
     'extension_modules': '',
     'state_top': 'top.sls',
     'state_top_saltenv': None,

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -586,7 +586,7 @@ class Pillar(object):
             matches = self.top_matches(top)
             pillar, errors = self.render_pillar(matches)
         errors.extend(top_errors)
-        if self.opts.get('pillar_opts', True):
+        if self.opts.get('pillar_opts', False):
             mopts = dict(self.opts)
             if 'grains' in mopts:
                 mopts.pop('grains')


### PR DESCRIPTION
When generating pillar data in `salt/pillar/__init__.py`, we were assuming a
`True` value when no `pillar_opts` was set, which goes against the change
made in 16a3938 where this value was changed to default to `False`. This,
coupled with the fact that `salt.config.DEFAULT_MINION_CONFIG` contained no
default value, meant that if `pillar_opts: False` was not explicitly set in
the minion config when running in masterless mode, the master config would be
incorrectly added to the pillar data.

This pull request adds a default value, and also changes
`salt/pillar/__init__.py` so that `False` is the fallback value when there
is no `pillar_opts`. However, given the fact that we will now have a default
value of `False`, the fallback value of [this dict.get](https://github.com/saltstack/salt/blob/88ff576/salt/pillar/__init__.py#L589) should technically never
be reached.

Fixes #31666.

CC @rallytime: I'm not certain how changes to `salt/config.py` will merge
forward once this reaches 2016.3 since this file has been moved to
`salt/config/__init__.py` in that branch, so this is something to watch when
we merge forward.
