### PR TITLE
Fix for AttributeError with libcloud <0.15

### DIFF
--- a/salt/cloud/clouds/cloudstack.py
+++ b/salt/cloud/clouds/cloudstack.py
@@ -202,7 +202,11 @@ def get_project(conn, vm_):
     '''
     Return the project to use.
     '''
-    projects = conn.ex_list_projects()
+    try:
+        projects = conn.ex_list_projects()
+    except AttributeError:
+        # with versions <0.15 of libcloud this is causing an AttributeError.
+        return False
     projid = config.get_cloud_config_value('projectid', vm_, __opts__)
 
     if not projid:

--- a/salt/cloud/clouds/cloudstack.py
+++ b/salt/cloud/clouds/cloudstack.py
@@ -206,6 +206,7 @@ def get_project(conn, vm_):
         projects = conn.ex_list_projects()
     except AttributeError:
         # with versions <0.15 of libcloud this is causing an AttributeError.
+        log.warning('Cannot get projects, you may need to update libcloud to 0.15 or later')
         return False
     projid = config.get_cloud_config_value('projectid', vm_, __opts__)
 

--- a/salt/cloud/clouds/cloudstack.py
+++ b/salt/cloud/clouds/cloudstack.py
@@ -6,7 +6,7 @@ CloudStack Cloud Module
 The CloudStack cloud module is used to control access to a CloudStack based
 Public Cloud.
 
-:depends: libcloud
+:depends: libcloud >= 0.15
 
 Use of this module requires the ``apikey``, ``secretkey``, ``host`` and
 ``path`` parameters.


### PR DESCRIPTION
### What does this PR do?

Fixes an issue with libcloud <0.15 and CloudStack. The CloudStack implementation is using a method that was introduced with libcloud 0.15. But e.g. Ubuntu 12.04 is shipping with libcloud version 0.14.1.

An alternative would be pinning the version of libcloud to >=0.15 and maybe packaging and shipping libcloud in a version needed.
### What issues does this PR fix or reference?
#31729
### Previous Behavior

Crashed with AttributeError during VM creation. Noticed this with Exoscale as the provider.
### New Behavior

VM creation is now working.
### Tests written?
- [ ] Yes
- [x] No
