### PR TITLE
Fix the always-false behavior on checking state

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1740,7 +1740,7 @@ def gen_state_tag(low):
     return '{0[state]}_|-{0[__id__]}_|-{0[name]}_|-{0[fun]}'.format(low)
 
 
-def check_state_result(running):
+def check_state_result(running, recurse=False):
     '''
     Check the total return value of the run and determine if the running
     dict has any issues
@@ -1753,13 +1753,15 @@ def check_state_result(running):
 
     ret = True
     for state_result in six.itervalues(running):
+        if not recurse and not isinstance(state_result, dict):
+            ret = False
         if ret and isinstance(state_result, dict):
             result = state_result.get('result', _empty)
             if result is False:
                 ret = False
             # only override return value if we are not already failed
             elif result is _empty and isinstance(state_result, dict) and ret:
-                ret = check_state_result(state_result)
+                ret = check_state_result(state_result, recurse=True)
         # return as soon as we got a failure
         if not ret:
             break

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1753,10 +1753,7 @@ def check_state_result(running):
 
     ret = True
     for state_result in six.itervalues(running):
-        if not isinstance(state_result, dict):
-            # return false when hosts return a list instead of a dict
-            ret = False
-        if ret:
+        if ret and isinstance(state_result, dict):
             result = state_result.get('result', _empty)
             if result is False:
                 ret = False

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1758,11 +1758,7 @@ def check_state_result(running):
             if result is False:
                 ret = False
             # only override return value if we are not already failed
-            elif (
-                result is _empty
-                and isinstance(state_result, dict)
-                and ret
-            ):
+            elif result is _empty and isinstance(state_result, dict) and ret:
                 ret = check_state_result(state_result)
         # return as soon as we got a failure
         if not ret:

--- a/tests/unit/utils/utils_test.py
+++ b/tests/unit/utils/utils_test.py
@@ -406,7 +406,7 @@ class UtilsTestCase(TestCase):
                          ('test_state0', {'result':  True}),
                          ('test_state', {'result': True}),
                      ])),
-                    ('host2', [])
+                    ('host2', OrderedDict([]))
                 ]))
             ])
         }


### PR DESCRIPTION
### What does this PR do?

Fixes a problem, when you see:

```
"ERROR: Minions returned with non-zero exit code"
```

This happens when issuing `state.show_highstate` for example.
### New Behavior

While this structure is invalid (first level is a list):

```
  {'host': []}
```

Apparently, this structure _should be_ also valid:

```
  {'host': {'something': []}}
```

The bug was that the function is using recursion, looking for lists everywhere, hence _always_ returns False, once anywhere a non-dict is found.
### Tests written?
- [x] Yes
- [ ] No
