### PR TITLE
Use get_local_client with MASTER opts, not MINION

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1290,11 +1290,13 @@ class Cloud(object):
                     )
                 )
 
-                client = salt.client.get_local_client(mopts=mopts_)
+                client = salt.client.get_local_client(mopts=self.opts)
 
-                ret = client.cmd(vm_['name'], 'saltutil.sync_{0}'.format(
-                    self.opts['sync_after_install']
-                ))
+                ret = client.cmd(
+                    vm_['name'],
+                    'saltutil.sync_{0}'.format(self.opts['sync_after_install']),
+                    timeout=self.opts['timeout']
+                )
                 log.info(
                     six.u('Synchronized the following dynamic modules: '
                           '  {0}').format(ret)


### PR DESCRIPTION
### What does this PR do?

`get_local_client` was being called with the wrong set of `opts`, causing it to behave like a minion instead of a master. This fixes the opts, and provides the necessary `timeout` parameter.
### What issues does this PR fix or reference?

Fixes #27960.
### Previous Behavior

See above.
### New Behavior

See above.
### Tests written?
- [ ] Yes
- [X] No
