### PR TITLE
Check all providers, not just the current one

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1388,11 +1388,14 @@ class Cloud(object):
         if main_cloud_config is None:
             main_cloud_config = {}
 
-        profile_details = self.opts['profiles'][profile]
-        alias, driver = profile_details['provider'].split(':')
         mapped_providers = self.map_providers_parallel()
-        alias_data = mapped_providers.setdefault(alias, {})
-        vms = alias_data.setdefault(driver, {})
+        profile_details = self.opts['profiles'][profile]
+        vms = {}
+        for prov in mapped_providers:
+            prov_name = mapped_providers[prov].keys()[0]
+            for node in mapped_providers[prov][prov_name]:
+                vms[node] = mapped_providers[prov][prov_name][node]
+        alias, driver = profile_details['provider'].split(':')
 
         provider_details = self.opts['providers'][alias][driver].copy()
         del provider_details['profiles']


### PR DESCRIPTION
### What does this PR do?

Ensure that salt-cloud checks all providers for duplicate names, and not just the current one.
### What issues does this PR fix or reference?

Fixes #26498.
### Previous Behavior

When spinning up a new machine, salt-cloud was only checking to see if its name already existed in the requested provider, and not all other configured providers.
### New Behavior

Salt cloud now checks all providers.
### Tests written?
- [ ] Yes
- [X] No
