### PR TITLE
SMinion need wait future from eval_master

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -448,6 +448,7 @@ class MinionBase(object):
                 log.error(msg)
                 sys.exit(salt.defaults.exitcodes.EX_GENERIC)
 
+        # FIXME: if SMinion don't define io_loop, it can't switch master see #29088
         # Specify kwargs for the channel factory so that SMinion doesn't need to define an io_loop
         # (The channel factories will set a default if the kwarg isn't passed)
         factory_kwargs = {'timeout': timeout, 'safe': safe}
@@ -517,9 +518,13 @@ class SMinion(MinionBase):
         super(SMinion, self).__init__(opts)
 
         # Clean out the proc directory (default /var/cache/salt/minion/proc)
-        if (self.opts.get('file_client', 'remote') == 'remote'
-                or self.opts.get('use_master_when_local', False)):
-            self.eval_master(self.opts, failed=True)
+        if (self.opts.get('file_client', 'remote') == 'remote' or
+                self.opts.get('use_master_when_local', False)):
+            # actually eval_master returns the future and we need to wait for it
+            self.io_loop = zmq.eventloop.ioloop.ZMQIOLoop()
+            far_future = self.eval_master(self.opts, failed=True)
+            self.io_loop.add_future(far_future, lambda _: self.io_loop.stop())
+            self.io_loop.start()
         self.gen_modules(initial_load=True)
 
     def gen_modules(self, initial_load=False):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -522,9 +522,7 @@ class SMinion(MinionBase):
                 self.opts.get('use_master_when_local', False)):
             # actually eval_master returns the future and we need to wait for it
             self.io_loop = zmq.eventloop.ioloop.ZMQIOLoop()
-            far_future = self.eval_master(self.opts, failed=True)
-            self.io_loop.add_future(far_future, lambda _: self.io_loop.stop())
-            self.io_loop.start()
+            self.io_loop.run_sync(lambda: self.eval_master(self.opts, failed=True))
         self.gen_modules(initial_load=True)
 
     def gen_modules(self, initial_load=False):


### PR DESCRIPTION
### What does this PR do?

Solves the problem of switching master when calling salt-call in multi-master mode.
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/29088
### Previous Behavior

salt-call was broken, if the first master is unavailable
### New Behavior

salt-call is switched to another master if the first master is unavailable
### Tests written?
- [ ] Yes
- [x] No
