### PR TITLE
Fix acl.present and acl.absent when adding default ACLs

### DIFF
--- a/salt/states/linux_acl.py
+++ b/salt/states/linux_acl.py
@@ -67,14 +67,26 @@ def present(name, acl_type, acl_name='', perms='', recurse=False):
         _acl_type = acl_type
         _current_perms = __current_perms[name]
 
+    # The getfacl execution module lists default with empty names as being
+    # applied to the user/group that owns the file, e.g.,
+    # default:group::rwx would be listed as default:group:root:rwx
+    # In this case, if acl_name is empty, we really want to search for root
+
+    # We search through the dictionary getfacl returns for the owner of the
+    # file if acl_name is empty.
+    if acl_name == '':
+        _search_name = __current_perms[name].get('comment').get(_acl_type)
+    else:
+        _search_name = acl_name
+
     if _current_perms.get(_acl_type, None):
         try:
-            user = [i for i in _current_perms[_acl_type] if next(six.iterkeys(i)) == acl_name].pop()
+            user = [i for i in _current_perms[_acl_type] if next(six.iterkeys(i)) == _search_name].pop()
         except (AttributeError, IndexError, StopIteration):
             user = None
 
         if user:
-            if user[acl_name]['octal'] == sum([_octal.get(i, i) for i in perms]):
+            if user[_search_name]['octal'] == sum([_octal.get(i, i) for i in perms]):
                 ret['comment'] = 'Permissions are in the desired state'
             else:
                 ret['comment'] = 'Permissions have been updated'
@@ -123,9 +135,21 @@ def absent(name, acl_type, acl_name='', perms='', recurse=False):
         _acl_type = acl_type
         _current_perms = __current_perms[name]
 
+    # The getfacl execution module lists default with empty names as being
+    # applied to the user/group that owns the file, e.g.,
+    # default:group::rwx would be listed as default:group:root:rwx
+    # In this case, if acl_name is empty, we really want to search for root
+
+    # We search through the dictionary getfacl returns for the owner of the
+    # file if acl_name is empty.
+    if acl_name == '':
+        _search_name = __current_perms[name].get('comment').get(_acl_type)
+    else:
+        _search_name = acl_name
+
     if _current_perms.get(_acl_type, None):
         try:
-            user = [i for i in _current_perms[_acl_type] if next(six.iterkeys(i)) == acl_name].pop()
+            user = [i for i in _current_perms[_acl_type] if next(six.iterkeys(i)) == _search_name].pop()
         except IndexError:
             user = None
 

--- a/salt/states/linux_acl.py
+++ b/salt/states/linux_acl.py
@@ -63,9 +63,11 @@ def present(name, acl_type, acl_name='', perms='', recurse=False):
     if acl_type.startswith(('d:', 'default:')):
         _acl_type = ':'.join(acl_type.split(':')[1:])
         _current_perms = __current_perms[name].get('defaults', {})
+        _default = True
     else:
         _acl_type = acl_type
         _current_perms = __current_perms[name]
+        _default = False
 
     # The getfacl execution module lists default with empty names as being
     # applied to the user/group that owns the file, e.g.,
@@ -79,10 +81,10 @@ def present(name, acl_type, acl_name='', perms='', recurse=False):
     else:
         _search_name = acl_name
 
-    if _current_perms.get(_acl_type, None):
+    if _current_perms.get(_acl_type, None) or _default:
         try:
             user = [i for i in _current_perms[_acl_type] if next(six.iterkeys(i)) == _search_name].pop()
-        except (AttributeError, IndexError, StopIteration):
+        except (AttributeError, IndexError, StopIteration, KeyError):
             user = None
 
         if user:
@@ -131,9 +133,11 @@ def absent(name, acl_type, acl_name='', perms='', recurse=False):
     if acl_type.startswith(('d:', 'default:')):
         _acl_type = ':'.join(acl_type.split(':')[1:])
         _current_perms = __current_perms[name].get('defaults', {})
+        _default = True
     else:
         _acl_type = acl_type
         _current_perms = __current_perms[name]
+        _default = False
 
     # The getfacl execution module lists default with empty names as being
     # applied to the user/group that owns the file, e.g.,
@@ -147,10 +151,10 @@ def absent(name, acl_type, acl_name='', perms='', recurse=False):
     else:
         _search_name = acl_name
 
-    if _current_perms.get(_acl_type, None):
+    if _current_perms.get(_acl_type, None) or _default:
         try:
             user = [i for i in _current_perms[_acl_type] if next(six.iterkeys(i)) == _search_name].pop()
-        except IndexError:
+        except (AttributeError, IndexError, StopIteration, KeyError):
             user = None
 
         if user:


### PR DESCRIPTION
This pull request fixes issue #22142. The issue was partially fixed with commit 02429aca , but the check still failed if no default ACLs were present before the state ran.

The PR changes the `linux_acl` state module to omit this check if a default `acl_type` was passed in. `acl.present` and `acl.absent` should now no longer fail with "_ACL Type does not exist_" when given a default `acl_type`

In addition, a blank `acl_name` indicates that the ACL should apply to the owner of the file. This already worked, but the state would incorrectly detect whether the file was already in the correct state, as it would search for a user matching the empty string.
