### PR TITLE
reliably detect duplicate keys during batch (or at least not crash)

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -180,11 +180,17 @@ class Batch(object):
                             continue
                         if self.opts.get('raw'):
                             parts.update({part['id']: part})
-                            minion_tracker[queue]['minions'].remove(part['id'])
+                            if part['id'] in minion_tracker[queue]['minions']:
+                                minion_tracker[queue]['minions'].remove(part['id'])
+                            else:
+                                print_cli('minion {0} was already deleted from tracker, probably a duplicate key'.format(part['id']))
                         else:
                             parts.update(part)
                             for id in part.keys():
-                                minion_tracker[queue]['minions'].remove(id)
+                                if id in minion_tracker[queue]['minions']:
+                                    minion_tracker[queue]['minions'].remove(id)
+                                else:
+                                    print_cli('minion {0} was already deleted from tracker, probably a duplicate key'.format(id))
                 except StopIteration:
                     # if a iterator is done:
                     # - set it to inactive


### PR DESCRIPTION
### What does this PR do?

prevent crash from duplicate minion-id with duplicate (valid) key
### What issues does this PR fix or reference?

n/a
### Previous Behavior

crash in a clumsy fashion without any indication about what happened
### New Behavior

print duplicate key warning
### Tests written?
- [ ] Yes
- [x] No

Sometimes some of the admins rsync copy /etc/salt configurations to new hosts.
I can detect these duplicates with this edit. The usual methods don't work
since the key is the same as the other hosts with that id.
