### PR TITLE
win_dacl state & module: return comment field as strings, not lists.

### DIFF
--- a/salt/modules/win_dacl.py
+++ b/salt/modules/win_dacl.py
@@ -367,7 +367,7 @@ def add_ace(path, objectType, user, permission, acetype, propagation):
     '''
     ret = {'result': None,
            'changes': {},
-           'comment': []}
+           'comment': ''}
 
     if (path and user and
             permission and acetype
@@ -406,19 +406,15 @@ def add_ace(path, objectType, user, permission, acetype, propagation):
                     dc.getPropagationText(objectTypeBit, propagation)))
                 ret['result'] = True
             except Exception as e:
-                ret['comment'].append((
-                    'An error occurred attempting to add the ace.  The error was {0}'
-                    ).format(e))
+                ret['comment'] = 'An error occurred attempting to add the ace.  The error was {0}'.format(e)
                 ret['result'] = False
                 return ret
             if acesAdded:
                 ret['changes']['Added ACEs'] = acesAdded
         else:
-            ret['comment'].append((
-                'Unable to obtain the DACL of {0}'
-                ).format(path))
+            ret['comment'] = 'Unable to obtain the DACL of {0}'.format(path)
     else:
-        ret['comment'].append('An empty value was specified for a required item.')
+        ret['comment'] = 'An empty value was specified for a required item.'
         ret['result'] = False
     return ret
 
@@ -444,7 +440,7 @@ def rm_ace(path, objectType, user, permission, acetype, propagation):
     '''
     ret = {'result': None,
            'changes': {},
-           'comment': []}
+           'comment': ''}
 
     if (path and user and
             permission and acetype
@@ -501,13 +497,10 @@ def rm_ace(path, objectType, user, permission, acetype, propagation):
                     ret['result'] = True
                 except Exception as e:
                     ret['result'] = False
-                    ret['comment'].append((
-                        'Error removing ACE.  The error was {0}'
-                        ).format(e))
+                    ret['comment'] = 'Error removing ACE.  The error was {0}.'.format(e)
                     return ret
         else:
-            ret['comment'].append((
-                'The specified ACE was not found on the path'))
+            ret['comment'] = 'The specified ACE was not found on the path.'
     return ret
 
 
@@ -609,9 +602,7 @@ def _set_dacl_inheritance(path, objectType, inheritance=True, copy=True, clear=F
             ret['result'] = True
         except Exception as e:
             ret['result'] = False
-            ret['comment'] = (
-                'Error attempting to set the inheritance.  The error was {0}'
-                ).format(e)
+            ret['comment'] = 'Error attempting to set the inheritance.  The error was {0}.'.format(e)
 
     return ret
 
@@ -653,7 +644,7 @@ def check_inheritance(path, objectType):
 
     ret = {'result': False,
            'Inheritance': False,
-           'comment': []}
+           'comment': ''}
     dc = daclConstants()
     objectType = dc.getObjectTypeBit(objectType)
     path = dc.processPath(path, objectType)
@@ -663,9 +654,7 @@ def check_inheritance(path, objectType):
         dacls = sd.GetSecurityDescriptorDacl()
     except Exception as e:
         ret['result'] = False
-        ret['comment'].append((
-            'Error obtaining the Security Descriptor or DACL of the path:  {0}'
-            ).format(e))
+        ret['comment'] = 'Error obtaining the Security Descriptor or DACL of the path: {0}.'.format(e)
         return ret
 
     for counter in range(0, dacls.GetAceCount()):
@@ -691,7 +680,7 @@ def check_ace(path, objectType, user=None, permission=None, acetype=None, propag
     '''
     ret = {'result': False,
            'Exists': False,
-           'comment': []}
+           'comment': ''}
 
     dc = daclConstants()
     objectTypeBit = dc.getObjectTypeBit(objectType)
@@ -709,12 +698,11 @@ def check_ace(path, objectType, user=None, permission=None, acetype=None, propag
         userSid = win32security.LookupAccountName('', user)[0]
     except Exception as e:
         ret['result'] = False
-        ret['comment'].append((
-            'Unable to obtain the security identifier for {0}.  The exception was {1}'
-            ).format(user, e))
+        ret['comment'] = 'Unable to obtain the security identifier for {0}.  The exception was {1}.'.format(user, e)
         return ret
 
     dacls = _get_dacl(path, objectTypeBit)
+    ret['result'] = True
     if dacls:
         if objectTypeBit == win32security.SE_FILE_OBJECT:
             if check_inheritance(path, objectType)['Inheritance']:
@@ -730,17 +718,12 @@ def check_ace(path, objectType, user=None, permission=None, acetype=None, propag
                     if (ace[0][1] & propagationbit) == propagationbit:
                         if exactPermissionMatch:
                             if ace[1] == permissionbit:
-                                ret['result'] = True
                                 ret['Exists'] = True
                                 return ret
                         else:
                             if (ace[1] & permissionbit) == permissionbit:
-                                ret['result'] = True
                                 ret['Exists'] = True
                                 return ret
     else:
-        ret['result'] = False
-        ret['comment'].append(
-            'Error obtaining DACL for object')
-    ret['result'] = True
+        ret['comment'] = 'No DACL found for object.'
     return ret

--- a/salt/states/win_dacl.py
+++ b/salt/states/win_dacl.py
@@ -89,14 +89,13 @@ def present(name, objectType, user, permission, acetype, propagation):
     ret = {'name': name,
            'result': True,
            'changes': {},
-           'comment': []}
+           'comment': ''}
     tRet = __salt__['win_dacl.check_ace'](name, objectType, user, permission, acetype, propagation, True)
     if tRet['result']:
         if not tRet['Exists']:
             if __opts__['test']:
                 ret['result'] = None
-                ret['comment'].append(
-                    'The ACE is set to be added')
+                ret['comment'] = 'The ACE is set to be added.'
                 ret['changes']['Added ACEs'] = ((
                     '{0} {1} {2} on {3}'
                     ).format(user, acetype, permission, propagation))
@@ -107,16 +106,14 @@ def present(name, objectType, user, permission, acetype, propagation):
                 ret['changes'] = dict(ret['changes'], **addRet['changes'])
             else:
                 ret['result'] = False
-                ret['comment'] = ret['comment'] + addRet['comment']
+                ret['comment'] = ' '.join([ret['comment'], addRet['comment']])
         else:
             if __opts__['test']:
                 ret['result'] = None
-                ret['comment'].append(
-                    'The ACE is present')
+                ret['comment'] = 'The ACE is present.'
     else:
         ret['result'] = False
         ret['comment'] = tRet['comment']
-        return ret
     return ret
 
 
@@ -127,14 +124,13 @@ def absent(name, objectType, user, permission, acetype, propagation):
     ret = {'name': name,
            'result': True,
            'changes': {},
-           'comment': []}
+           'comment': ''}
     tRet = __salt__['win_dacl.check_ace'](name, objectType, user, permission, acetype, propagation, True)
     if tRet['result']:
         if tRet['Exists']:
             if __opts__['test']:
                 ret['result'] = None
-                ret['comment'].append(
-                    'The ACE is set to be removed')
+                ret['comment'] = 'The ACE is set to be removed.'
                 ret['changes']['Removed ACEs'] = ((
                     '{0} {1} {2} on {3}'
                     ).format(user, acetype, permission, propagation))
@@ -145,16 +141,14 @@ def absent(name, objectType, user, permission, acetype, propagation):
                 ret['changes'] = dict(ret['changes'], **addRet['changes'])
             else:
                 ret['result'] = False
-                ret['comment'] = ret['comment'] + addRet['comment']
+                ret['comment'] = ' '.join([ret['comment'], addRet['comment']])
         else:
             if __opts__['test']:
                 ret['result'] = None
-                ret['comment'].append(
-                    'The ACE is not present')
+                ret['comment'] = 'The ACE is not present.'
     else:
         ret['result'] = False
         ret['comment'] = tRet['comment']
-        return ret
     return ret
 
 
@@ -165,15 +159,14 @@ def inherit(name, objectType, clear_existing_acl=False):
     ret = {'name': name,
            'result': True,
            'changes': {},
-           'comment': []}
+           'comment': ''}
     tRet = __salt__['win_dacl.check_inheritance'](name, objectType)
     if tRet['result']:
         if not tRet['Inheritance']:
             if __opts__['test']:
                 ret['result'] = None
                 ret['changes']['Inheritance'] = "Enabled"
-                ret['comment'].append(
-                    'Inheritance is set to be enabled')
+                ret['comment'] = 'Inheritance is set to be enabled.'
                 ret['changes']['Existing ACLs'] = (
                     'Are set to be removed' if clear_existing_acl else 'Are set to be kept')
                 return ret
@@ -183,16 +176,14 @@ def inherit(name, objectType, clear_existing_acl=False):
                 ret['changes'] = dict(ret['changes'], **eRet['changes'])
             else:
                 ret['result'] = False
-                ret['comment'] = ret['comment'] + eRet['comment']
+                ret['comment'] = ' '.join([ret['comment'], eRet['comment']])
         else:
             if __opts__['test']:
                 ret['result'] = None
-                ret['comment'].append(
-                    'Inheritance is enabled')
+                ret['comment'] = 'Inheritance is enabled.'
     else:
         ret['result'] = False
         ret['comment'] = tRet['comment']
-        return ret
     return ret
 
 
@@ -203,32 +194,28 @@ def disinherit(name, objectType, copy_inherited_acl=True):
     ret = {'name': name,
            'result': True,
            'changes': {},
-           'comment': []}
+           'comment': ''}
     tRet = __salt__['win_dacl.check_inheritance'](name, objectType)
     if tRet['result']:
         if tRet['Inheritance']:
             if __opts__['test']:
                 ret['result'] = None
                 ret['changes']['Inheritance'] = "Disabled"
-                ret['comment'].append(
-                    'Inheritance is set to be disabled')
+                ret['comment'] = 'Inheritance is set to be disabled.'
                 ret['changes']['Inherited ACLs'] = (
                         'Are set to be kept' if copy_inherited_acl else 'Are set to be removed')
                 return ret
             eRet = __salt__['win_dacl.disable_inheritance'](name, objectType, copy_inherited_acl)
+            ret['result'] = eRet['result']
             if eRet['result']:
-                ret['result'] = True
                 ret['changes'] = dict(ret['changes'], **eRet['changes'])
             else:
-                ret['result'] = False
-                ret['comment'] = ret['comment'] + eRet['comment']
+                ret['comment'] = ' '.join([ret['comment'], eRet['comment']])
         else:
             if __opts__['test']:
                 ret['result'] = None
-                ret['comment'].append(
-                    'Inheritance is disabled')
+                ret['comment'] = 'Inheritance is disabled.'
     else:
         ret['result'] = False
         ret['comment'] = tRet['comment']
-        return ret
     return ret


### PR DESCRIPTION
### What does this PR do?

This alters the win_dacl state and module to return the 'comment' field as a string instead of a list, as per the state requirements.
### What issues does this PR fix or reference?

Addresses issue #31772.
### Previous Behavior

The state function comment returns were lists. This caused state/highstate output to appear as YAML.
### New Behavior

State function comment returns are now strings, and state/highstate output appears normal (highstate format).
### Tests written?
- [ ] Yes
- [x] No
