### PR TITLE
use already created vsphere connection

### DIFF
--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -86,7 +86,7 @@ import salt.utils
 
 # Import Third Party Libs
 try:
-    from pyVim.connect import SmartConnect, Disconnect
+    from pyVim.connect import GetSi, SmartConnect, Disconnect
     from pyVmomi import vim, vmodl
     HAS_PYVMOMI = True
 except ImportError:
@@ -183,6 +183,13 @@ def get_service_instance(host, username, password, protocol=None, port=None):
         protocol = 'https'
     if port is None:
         port = 443
+
+    service_instance = GetSi()
+    if service_instance:
+        if service_instance._GetStub().host == ':'.join([host, str(port)]):
+            service_instance._GetStub().GetConnection()
+            return service_instance
+        Disconnect(service_instance)
 
     try:
         service_instance = SmartConnect(


### PR DESCRIPTION
### What does this PR do?

If we have connected to this host before, just reconnect.  If the host
is different than what is in the already configured connection, make
sure we are disconnected, and connect to the new one.

There is still a memory leak in this somewhere.
### What issues does this PR fix or reference?

Fixes #31776
### Previous Behavior

The initial connection made 13 connections to the esxi server, then every command opens up 2 more connections.

For `multiprocessing: True` this isn't a problem, because they get cleaned up when the process dies, but it would be nice to not have the extra connections on the first proxy process, that are never used.

For `multiprocessing: False`, every command adds 2 more, until we hit the max connections to the esxi master.
### New Behavior

Only ever have the one connection.

If we switch to multiple hosts, Disconnect, otherwise just use the same connection if the host is the same.
### Tests written?
- [ ] Yes
- [X] No
