### PR TITLE
Fixed installing keychain certificates from salt fileserver

### DIFF
--- a/salt/states/mac_keychain.py
+++ b/salt/states/mac_keychain.py
@@ -61,6 +61,9 @@ def installed(name, password, keychain="/Library/Keychains/System.keychain", **k
            'comment': '',
            'changes': {}}
 
+    if 'http' in name or 'salt' in name:
+        name = __salt__['cp.cache_file'](name)
+
     certs = __salt__['keychain.list_certs'](keychain)
     friendly_name = __salt__['keychain.get_friendly_name'](name, password)
 
@@ -110,6 +113,9 @@ def uninstalled(name, password, keychain="/Library/Keychains/System.keychain", k
     certs = __salt__['keychain.list_certs'](keychain)
 
     if ".p12" in name:
+        if 'http' in name or 'salt' in name:
+            name = __salt__['cp.cache_file'](name)
+
         friendly_name = __salt__['keychain.get_friendly_name'](name, password)
     else:
         friendly_name = name


### PR DESCRIPTION
### What does this PR do?

Fix installing keychain certs from the salt fileserver
### What issues does this PR fix or reference?
### Previous Behavior

Using the salt fileserver as the source will simply fail
### New Behavior

The file will be fetched from the salt fileserver and then worked on with a local copy
### Tests written?
- [x] Yes
- [ ] No
