### PR TITLE
fix salt.states.smartos.vm_present update needed check 

### DIFF
--- a/salt/states/smartos.py
+++ b/salt/states/smartos.py
@@ -530,9 +530,13 @@ def vm_present(name, vmconfig, config=None):
                 continue
 
             # skip unchanged properties
-            if prop in vmconfig['current'] and \
-                vmconfig['current'][prop] == vmconfig['state'][prop]:
-                continue
+            if prop in vmconfig['current']:
+                if isinstance(vmconfig['current'][prop], (list)) or isinstance(vmconfig['current'][prop], (dict)):
+                    if vmconfig['current'][prop] == vmconfig['state'][prop]:
+                        continue
+                else:
+                    if "{0}".format(vmconfig['current'][prop]) == "{0}".format(vmconfig['state'][prop]):
+                        continue
 
             # add property to changeset
             vmconfig['changed'][prop] = vmconfig['state'][prop]


### PR DESCRIPTION
### What does this PR do?

Sometimes (due to the way the json is parsed vs yaml) it would always result in a change.

e.g. 'vnc_port' has value of '-1', yaml data we get from the state parses this as int, the json we parse from the tool parses it as a str. This check takes care of this to do a better comparison. (This is logical as the tool assumes all values are strings to the json we get back is: { "prop": "4" } vs { "prop": 4 }.
### What issues does this PR fix or reference?

n/a, someone bugged me in person.
### Previous Behavior

vm_present would always result in a change if a value was int.
### New Behavior

vm_present converts all non dict or lists objects to a string using '{0}'.format(val) to do a more type neutral comparison.
### Tests written?
- [ ] Yes
- [X] No
### Branches affected:
- 2016.3
- develop
