### PR TITLE
Fix user_create and db_create for new versions of influxdb

### DIFF
--- a/salt/modules/influx.py
+++ b/salt/modules/influx.py
@@ -152,11 +152,7 @@ def db_create(name, user=None, password=None, host=None, port=None):
         log.info('DB {0!r} already exists'.format(name))
         return False
     client = _client(user=user, password=password, host=host, port=port)
-    try:
-        client.create_database(name)
-    except:
-        log.exception('InfluxDB client raised an exception')
-        return False
+    client.create_database(name)
     return True
 
 
@@ -332,12 +328,8 @@ def user_create(name, passwd, database=None, user=None, password=None,
 
     # influxdb 0.9+
     if hasattr(client, 'create_user'):
-        try:
-            client.create_user(name, passwd)
-            return True
-        except:
-            log.exception('InfluxDB client raised an exception')
-            return False
+        client.create_user(name, passwd)
+        return True
 
     # influxdb 0.8 and older
     if database:

--- a/salt/modules/influx.py
+++ b/salt/modules/influx.py
@@ -324,6 +324,18 @@ def user_create(name, passwd, database=None, user=None, password=None,
     client = _client(user=user, password=password, host=host, port=port)
     if database:
         client.switch_database(database)
+
+    # influxdb 0.9+
+    if hasattr(client, 'create_user'):
+        try:
+            client.create_user(name, passwd)
+            return True
+        except:
+            log.exception('InfluxDB client raised an exception')
+            return False
+
+    # influxdb 0.8 and older
+    if database:
         return client.add_database_user(name, passwd)
     return client.add_cluster_admin(name, passwd)
 

--- a/salt/modules/influx.py
+++ b/salt/modules/influx.py
@@ -152,7 +152,12 @@ def db_create(name, user=None, password=None, host=None, port=None):
         log.info('DB {0!r} already exists'.format(name))
         return False
     client = _client(user=user, password=password, host=host, port=port)
-    return client.create_database(name)
+    try:
+        client.create_database(name)
+    except:
+        log.exception('InfluxDB client raised an exception')
+        return False
+    return True
 
 
 def db_remove(name, user=None, password=None, host=None, port=None):


### PR DESCRIPTION
This is a followup to https://github.com/saltstack/salt/pull/31770 which I didn't test properly - all my users already existed, so I never bothered to check if the create user functionality was working.

I also noticed db_create had a similar bug, so I fixed that as well.

Again, this should fix #30489
