### PR TITLE
Integration tests for mac_system

### DIFF
--- a/salt/modules/mac_system.py
+++ b/salt/modules/mac_system.py
@@ -4,6 +4,9 @@
 
 System module for sleeping, restarting, and shutting down the system on Mac OS
 X.
+
+.. warning::
+    Using this module will enable ``atrun`` on the system if it is disabled.
 '''
 from __future__ import absolute_import
 
@@ -467,7 +470,7 @@ def set_startup_disk(path):
         salt '*' system.set_startup_disk /System/Library/CoreServices
     '''
     if path not in list_startup_disks():
-        msg = '\nInvalid value passed for path.\n' \
+        msg = 'Invalid value passed for path.\n' \
               'Must be a valid startup disk as found in ' \
               'system.list_startup_disks.\n' \
               'Passed: {0}'.format(path)
@@ -512,11 +515,15 @@ def set_restart_delay(seconds):
     power failure.
 
     .. warning::
+
         This command fails with the following error:
-            ``Error, IOServiceOpen returned 0x10000003``
+
+        ``Error, IOServiceOpen returned 0x10000003``
+
         The setting is not updated. This is an apple bug. It seems like it may
         only work on certain versions of Mac Server X. This article explains the
         issue in more detail, though it is quite old.
+
         http://lists.apple.com/archives/macos-x-server/2006/Jul/msg00967.html
 
     :param int seconds: The number of seconds. Must be a multiple of 30
@@ -531,7 +538,7 @@ def set_restart_delay(seconds):
         salt '*' system.set_restart_delay 180
     '''
     if seconds % 30 != 0:
-        msg = '\nInvalid value passed for seconds.\n' \
+        msg = 'Invalid value passed for seconds.\n' \
               'Must be a multiple of 30.\n' \
               'Passed: {0}'.format(seconds)
         raise SaltInvocationError(msg)
@@ -646,9 +653,11 @@ def set_boot_arch(arch='default'):
     Set the kernel to boot in 32 or 64 bit mode on next boot.
 
     .. note::
-        Though salt reports success, this command fails with the following
-        error:
+
+        This command fails with the following error:
+
         ``changes to kernel architecture failed to save!``
+
         The setting is not updated. This is either an apple bug, not available
         on the test system, or a result of system files now being locked down in
         OS X (SIP Protection).
@@ -669,7 +678,7 @@ def set_boot_arch(arch='default'):
         salt '*' system.set_boot_arch i386
     '''
     if arch not in ['i386', 'x86_64', 'default']:
-        msg = '\nInvalid value passed for arch.\n' \
+        msg = 'Invalid value passed for arch.\n' \
               'Must be i386, x86_64, or default.\n' \
               'Passed: {0}'.format(arch)
         raise SaltInvocationError(msg)

--- a/salt/modules/mac_system.py
+++ b/salt/modules/mac_system.py
@@ -195,17 +195,11 @@ def get_remote_login():
 
         salt '*' system.get_remote_login
     '''
-    try:
-        ret = salt.utils.mac_utils.execute_return_result(
-            'systemsetup -getremotelogin')
-    except CommandExecutionError as exc:
-        raise CommandExecutionError(exc)
+    ret = salt.utils.mac_utils.execute_return_result(
+        'systemsetup -getremotelogin')
 
-    try:
-        enabled = salt.utils.mac_utils.validate_enabled(
-            salt.utils.mac_utils.parse_return(ret))
-    except SaltInvocationError as exc:
-        raise SaltInvocationError(exc)
+    enabled = salt.utils.mac_utils.validate_enabled(
+        salt.utils.mac_utils.parse_return(ret))
 
     return enabled == 'on'
 
@@ -227,22 +221,12 @@ def set_remote_login(enable):
 
         salt '*' system.set_remote_login True
     '''
-    try:
-        state = salt.utils.mac_utils.validate_enabled(enable)
-    except SaltInvocationError as exc:
-        raise SaltInvocationError(exc)
+    state = salt.utils.mac_utils.validate_enabled(enable)
 
     cmd = 'systemsetup -f -setremotelogin {0}'.format(state)
+    salt.utils.mac_utils.execute_return_success(cmd)
 
-    try:
-        salt.utils.mac_utils.execute_return_success(cmd)
-    except CommandExecutionError as exc:
-        raise CommandExecutionError(exc)
-
-    try:
-        enabled = salt.utils.mac_utils.validate_enabled(get_remote_login())
-    except SaltInvocationError as exc:
-        raise SaltInvocationError(exc)
+    enabled = salt.utils.mac_utils.validate_enabled(get_remote_login())
 
     return state == enabled
 
@@ -260,17 +244,11 @@ def get_remote_events():
 
         salt '*' system.get_remote_events
     '''
-    try:
-        ret = salt.utils.mac_utils.execute_return_result(
-            'systemsetup -getremoteappleevents')
-    except CommandExecutionError as exc:
-        raise CommandExecutionError(exc)
+    ret = salt.utils.mac_utils.execute_return_result(
+        'systemsetup -getremoteappleevents')
 
-    try:
-        enabled = salt.utils.mac_utils.validate_enabled(
-            salt.utils.mac_utils.parse_return(ret))
-    except SaltInvocationError as exc:
-        raise SaltInvocationError(exc)
+    enabled = salt.utils.mac_utils.validate_enabled(
+        salt.utils.mac_utils.parse_return(ret))
 
     return enabled == 'on'
 
@@ -293,22 +271,12 @@ def set_remote_events(enable):
 
         salt '*' system.set_remote_events On
     '''
-    try:
-        state = salt.utils.mac_utils.validate_enabled(enable)
-    except SaltInvocationError as exc:
-        raise SaltInvocationError(exc)
+    state = salt.utils.mac_utils.validate_enabled(enable)
 
     cmd = 'systemsetup -setremoteappleevents {0}'.format(state)
+    salt.utils.mac_utils.execute_return_success(cmd)
 
-    try:
-        salt.utils.mac_utils.execute_return_success(cmd)
-    except CommandExecutionError as exc:
-        raise CommandExecutionError(exc)
-
-    try:
-        enabled = salt.utils.mac_utils.validate_enabled(get_remote_events())
-    except SaltInvocationError as exc:
-        raise SaltInvocationError(exc)
+    enabled = salt.utils.mac_utils.validate_enabled(get_remote_events())
 
     return state == enabled
 
@@ -326,11 +294,8 @@ def get_computer_name():
 
         salt '*' system.get_computer_name
     '''
-    try:
-        ret = salt.utils.mac_utils.execute_return_result(
-            'systemsetup -getcomputername')
-    except CommandExecutionError as exc:
-        raise CommandExecutionError(exc)
+    ret = salt.utils.mac_utils.execute_return_result(
+        'systemsetup -getcomputername')
 
     return salt.utils.mac_utils.parse_return(ret)
 
@@ -350,11 +315,8 @@ def set_computer_name(name):
 
         salt '*' system.set_computer_name "Mike's Mac"
     '''
-    try:
-        cmd = 'systemsetup -setcomputername "{0}"'.format(name)
-        salt.utils.mac_utils.execute_return_success(cmd)
-    except CommandExecutionError as exc:
-        raise CommandExecutionError(exc)
+    cmd = 'systemsetup -setcomputername "{0}"'.format(name)
+    salt.utils.mac_utils.execute_return_success(cmd)
 
     return get_computer_name() == name
 
@@ -372,11 +334,8 @@ def get_subnet_name():
 
         salt '*' system.get_subnet_name
     '''
-    try:
-        ret = salt.utils.mac_utils.execute_return_result(
-            'systemsetup -getlocalsubnetname')
-    except CommandExecutionError as exc:
-        raise CommandExecutionError(exc)
+    ret = salt.utils.mac_utils.execute_return_result(
+        'systemsetup -getlocalsubnetname')
 
     return salt.utils.mac_utils.parse_return(ret)
 
@@ -400,11 +359,8 @@ def set_subnet_name(name):
         The following will be set as 'Mikes-Mac'
         salt '*' system.set_subnet_name "Mike's Mac"
     '''
-    try:
-        cmd = 'systemsetup -setlocalsubnetname "{0}"'.format(name)
-        salt.utils.mac_utils.execute_return_success(cmd)
-    except CommandExecutionError as exc:
-        raise CommandExecutionError(exc)
+    cmd = 'systemsetup -setlocalsubnetname "{0}"'.format(name)
+    salt.utils.mac_utils.execute_return_success(cmd)
 
     return get_subnet_name() == name
 
@@ -422,11 +378,8 @@ def get_startup_disk():
 
         salt '*' system.get_startup_disk
     '''
-    try:
-        ret = salt.utils.mac_utils.execute_return_result(
-            'systemsetup -getstartupdisk')
-    except CommandExecutionError as exc:
-        raise CommandExecutionError(exc)
+    ret = salt.utils.mac_utils.execute_return_result(
+        'systemsetup -getstartupdisk')
 
     return salt.utils.mac_utils.parse_return(ret)
 
@@ -444,11 +397,8 @@ def list_startup_disks():
 
         salt '*' system.list_startup_disks
     '''
-    try:
-        ret = salt.utils.mac_utils.execute_return_result(
-            'systemsetup -liststartupdisks')
-    except CommandExecutionError as exc:
-        raise CommandExecutionError(exc)
+    ret = salt.utils.mac_utils.execute_return_result(
+        'systemsetup -liststartupdisks')
 
     return ret.splitlines()
 
@@ -476,11 +426,8 @@ def set_startup_disk(path):
               'Passed: {0}'.format(path)
         raise SaltInvocationError(msg)
 
-    try:
-        cmd = 'systemsetup -setstartupdisk {0}'.format(path)
-        salt.utils.mac_utils.execute_return_result(cmd)
-    except CommandExecutionError as exc:
-        raise CommandExecutionError(exc)
+    cmd = 'systemsetup -setstartupdisk {0}'.format(path)
+    salt.utils.mac_utils.execute_return_result(cmd)
 
     return get_startup_disk() == path
 
@@ -500,11 +447,8 @@ def get_restart_delay():
 
         salt '*' system.get_restart_delay
     '''
-    try:
-        ret = salt.utils.mac_utils.execute_return_result(
-            'systemsetup -getwaitforstartupafterpowerfailure')
-    except CommandExecutionError as exc:
-        raise CommandExecutionError(exc)
+    ret = salt.utils.mac_utils.execute_return_result(
+        'systemsetup -getwaitforstartupafterpowerfailure')
 
     return salt.utils.mac_utils.parse_return(ret)
 
@@ -544,10 +488,7 @@ def set_restart_delay(seconds):
         raise SaltInvocationError(msg)
 
     cmd = 'systemsetup -setwaitforstartupafterpowerfailure {0}'.format(seconds)
-    try:
-        salt.utils.mac_utils.execute_return_success(cmd)
-    except CommandExecutionError as exc:
-        raise CommandExecutionError(exc)
+    salt.utils.mac_utils.execute_return_success(cmd)
 
     return get_restart_delay() == seconds
 
@@ -566,17 +507,11 @@ def get_disable_keyboard_on_lock():
 
         salt '*' system.get_disable_keyboard_on_lock
     '''
-    try:
-        ret = salt.utils.mac_utils.execute_return_result(
-            'systemsetup -getdisablekeyboardwhenenclosurelockisengaged')
-    except CommandExecutionError as exc:
-        raise CommandExecutionError(exc)
+    ret = salt.utils.mac_utils.execute_return_result(
+        'systemsetup -getdisablekeyboardwhenenclosurelockisengaged')
 
-    try:
-        enabled = salt.utils.mac_utils.validate_enabled(
-            salt.utils.mac_utils.parse_return(ret))
-    except SaltInvocationError as exc:
-        raise SaltInvocationError(exc)
+    enabled = salt.utils.mac_utils.validate_enabled(
+        salt.utils.mac_utils.parse_return(ret))
 
     return enabled == 'on'
 
@@ -599,17 +534,11 @@ def set_disable_keyboard_on_lock(enable):
 
         salt '*' system.set_disable_keyboard_on_lock False
     '''
-    try:
-        state = salt.utils.mac_utils.validate_enabled(enable)
-    except SaltInvocationError as exc:
-        raise SaltInvocationError(exc)
+    state = salt.utils.mac_utils.validate_enabled(enable)
 
-    try:
-        cmd = 'systemsetup -setdisablekeyboardwhenenclosurelockisengaged ' \
-              '{0}'.format(state)
-        salt.utils.mac_utils.execute_return_success(cmd)
-    except CommandExecutionError as exc:
-        raise CommandExecutionError(exc)
+    cmd = 'systemsetup -setdisablekeyboardwhenenclosurelockisengaged ' \
+          '{0}'.format(state)
+    salt.utils.mac_utils.execute_return_success(cmd)
 
     enabled = salt.utils.mac_utils.validate_enabled(
         get_disable_keyboard_on_lock())
@@ -630,11 +559,8 @@ def get_boot_arch():
 
         salt '*' system.get_boot_arch
     '''
-    try:
-        ret = salt.utils.mac_utils.execute_return_result(
-            'systemsetup -getkernelbootarchitecturesetting')
-    except CommandExecutionError as exc:
-        raise CommandExecutionError(exc)
+    ret = salt.utils.mac_utils.execute_return_result(
+        'systemsetup -getkernelbootarchitecturesetting')
 
     arch = salt.utils.mac_utils.parse_return(ret)
 
@@ -683,10 +609,7 @@ def set_boot_arch(arch='default'):
               'Passed: {0}'.format(arch)
         raise SaltInvocationError(msg)
 
-    try:
-        cmd = 'systemsetup -setkernelbootarchitecture {0}'.format(arch)
-        salt.utils.mac_utils.execute_return_success(cmd)
-    except CommandExecutionError as exc:
-        raise CommandExecutionError(exc)
+    cmd = 'systemsetup -setkernelbootarchitecture {0}'.format(arch)
+    salt.utils.mac_utils.execute_return_success(cmd)
 
     return arch in get_boot_arch()

--- a/salt/modules/mac_system.py
+++ b/salt/modules/mac_system.py
@@ -16,7 +16,7 @@ except ImportError:  # python 2
 # Import salt libs
 import salt.utils
 import salt.utils.mac_utils
-from salt.exceptions import CommandExecutionError
+from salt.exceptions import CommandExecutionError, SaltInvocationError
 
 __virtualname__ = 'system'
 
@@ -192,9 +192,19 @@ def get_remote_login():
 
         salt '*' system.get_remote_login
     '''
-    ret = salt.utils.mac_utils.execute_return_result('systemsetup -getremotelogin')
-    return salt.utils.mac_utils.validate_enabled(
-        salt.utils.mac_utils.parse_return(ret)) == 'on'
+    try:
+        ret = salt.utils.mac_utils.execute_return_result(
+            'systemsetup -getremotelogin')
+    except CommandExecutionError as exc:
+        raise CommandExecutionError(exc)
+
+    try:
+        enabled = salt.utils.mac_utils.validate_enabled(
+            salt.utils.mac_utils.parse_return(ret))
+    except SaltInvocationError as exc:
+        raise SaltInvocationError(exc)
+
+    return enabled == 'on'
 
 
 def set_remote_login(enable):
@@ -214,12 +224,24 @@ def set_remote_login(enable):
 
         salt '*' system.set_remote_login True
     '''
-    state = salt.utils.mac_utils.validate_enabled(enable)
+    try:
+        state = salt.utils.mac_utils.validate_enabled(enable)
+    except SaltInvocationError as exc:
+        raise SaltInvocationError(exc)
 
     cmd = 'systemsetup -f -setremotelogin {0}'.format(state)
-    salt.utils.mac_utils.execute_return_success(cmd)
 
-    return state == salt.utils.mac_utils.validate_enabled(get_remote_login())
+    try:
+        salt.utils.mac_utils.execute_return_success(cmd)
+    except CommandExecutionError as exc:
+        raise CommandExecutionError(exc)
+
+    try:
+        enabled = salt.utils.mac_utils.validate_enabled(get_remote_login())
+    except SaltInvocationError as exc:
+        raise SaltInvocationError(exc)
+
+    return state == enabled
 
 
 def get_remote_events():
@@ -235,9 +257,19 @@ def get_remote_events():
 
         salt '*' system.get_remote_events
     '''
-    ret = salt.utils.mac_utils.execute_return_result('systemsetup -getremoteappleevents')
-    return salt.utils.mac_utils.validate_enabled(
-        salt.utils.mac_utils.parse_return(ret)) == 'on'
+    try:
+        ret = salt.utils.mac_utils.execute_return_result(
+            'systemsetup -getremoteappleevents')
+    except CommandExecutionError as exc:
+        raise CommandExecutionError(exc)
+
+    try:
+        enabled = salt.utils.mac_utils.validate_enabled(
+            salt.utils.mac_utils.parse_return(ret))
+    except SaltInvocationError as exc:
+        raise SaltInvocationError(exc)
+
+    return enabled == 'on'
 
 
 def set_remote_events(enable):
@@ -258,12 +290,24 @@ def set_remote_events(enable):
 
         salt '*' system.set_remote_events On
     '''
-    state = salt.utils.mac_utils.validate_enabled(enable)
+    try:
+        state = salt.utils.mac_utils.validate_enabled(enable)
+    except SaltInvocationError as exc:
+        raise SaltInvocationError(exc)
 
     cmd = 'systemsetup -setremoteappleevents {0}'.format(state)
-    salt.utils.mac_utils.execute_return_success(cmd)
 
-    return state == salt.utils.mac_utils.validate_enabled(get_remote_events())
+    try:
+        salt.utils.mac_utils.execute_return_success(cmd)
+    except CommandExecutionError as exc:
+        raise CommandExecutionError(exc)
+
+    try:
+        enabled = salt.utils.mac_utils.validate_enabled(get_remote_events())
+    except SaltInvocationError as exc:
+        raise SaltInvocationError(exc)
+
+    return state == enabled
 
 
 def get_computer_name():
@@ -279,8 +323,12 @@ def get_computer_name():
 
         salt '*' system.get_computer_name
     '''
-    ret = salt.utils.mac_utils.execute_return_result(
-        'systemsetup -getcomputername')
+    try:
+        ret = salt.utils.mac_utils.execute_return_result(
+            'systemsetup -getcomputername')
+    except CommandExecutionError as exc:
+        raise CommandExecutionError(exc)
+
     return salt.utils.mac_utils.parse_return(ret)
 
 
@@ -299,8 +347,12 @@ def set_computer_name(name):
 
         salt '*' system.set_computer_name "Mike's Mac"
     '''
-    cmd = 'systemsetup -setcomputername "{0}"'.format(name)
-    salt.utils.mac_utils.execute_return_success(cmd)
+    try:
+        cmd = 'systemsetup -setcomputername "{0}"'.format(name)
+        salt.utils.mac_utils.execute_return_success(cmd)
+    except CommandExecutionError as exc:
+        raise CommandExecutionError(exc)
+
     return get_computer_name() == name
 
 
@@ -317,8 +369,12 @@ def get_subnet_name():
 
         salt '*' system.get_subnet_name
     '''
-    ret = salt.utils.mac_utils.execute_return_result(
-        'systemsetup -getlocalsubnetname')
+    try:
+        ret = salt.utils.mac_utils.execute_return_result(
+            'systemsetup -getlocalsubnetname')
+    except CommandExecutionError as exc:
+        raise CommandExecutionError(exc)
+
     return salt.utils.mac_utils.parse_return(ret)
 
 
@@ -341,8 +397,12 @@ def set_subnet_name(name):
         The following will be set as 'Mikes-Mac'
         salt '*' system.set_subnet_name "Mike's Mac"
     '''
-    cmd = 'systemsetup -setlocalsubnetname "{0}"'.format(name)
-    salt.utils.mac_utils.execute_return_success(cmd)
+    try:
+        cmd = 'systemsetup -setlocalsubnetname "{0}"'.format(name)
+        salt.utils.mac_utils.execute_return_success(cmd)
+    except CommandExecutionError as exc:
+        raise CommandExecutionError(exc)
+
     return get_subnet_name() == name
 
 
@@ -359,8 +419,12 @@ def get_startup_disk():
 
         salt '*' system.get_startup_disk
     '''
-    ret = salt.utils.mac_utils.execute_return_result(
-        'systemsetup -getstartupdisk')
+    try:
+        ret = salt.utils.mac_utils.execute_return_result(
+            'systemsetup -getstartupdisk')
+    except CommandExecutionError as exc:
+        raise CommandExecutionError(exc)
+
     return salt.utils.mac_utils.parse_return(ret)
 
 
@@ -377,8 +441,12 @@ def list_startup_disks():
 
         salt '*' system.list_startup_disks
     '''
-    ret = salt.utils.mac_utils.execute_return_result(
-        'systemsetup -liststartupdisks')
+    try:
+        ret = salt.utils.mac_utils.execute_return_result(
+            'systemsetup -liststartupdisks')
+    except CommandExecutionError as exc:
+        raise CommandExecutionError(exc)
+
     return ret.splitlines()
 
 
@@ -403,9 +471,14 @@ def set_startup_disk(path):
               'Must be a valid startup disk as found in ' \
               'system.list_startup_disks.\n' \
               'Passed: {0}'.format(path)
-        raise CommandExecutionError(msg)
-    cmd = 'systemsetup -setstartupdisk {0}'.format(path)
-    salt.utils.mac_utils.execute_return_result(cmd)
+        raise SaltInvocationError(msg)
+
+    try:
+        cmd = 'systemsetup -setstartupdisk {0}'.format(path)
+        salt.utils.mac_utils.execute_return_result(cmd)
+    except CommandExecutionError as exc:
+        raise CommandExecutionError(exc)
+
     return get_startup_disk() == path
 
 
@@ -424,8 +497,12 @@ def get_restart_delay():
 
         salt '*' system.get_restart_delay
     '''
-    ret = salt.utils.mac_utils.execute_return_result(
-        'systemsetup -getwaitforstartupafterpowerfailure')
+    try:
+        ret = salt.utils.mac_utils.execute_return_result(
+            'systemsetup -getwaitforstartupafterpowerfailure')
+    except CommandExecutionError as exc:
+        raise CommandExecutionError(exc)
+
     return salt.utils.mac_utils.parse_return(ret)
 
 
@@ -457,9 +534,14 @@ def set_restart_delay(seconds):
         msg = '\nInvalid value passed for seconds.\n' \
               'Must be a multiple of 30.\n' \
               'Passed: {0}'.format(seconds)
-        raise CommandExecutionError(msg)
+        raise SaltInvocationError(msg)
+
     cmd = 'systemsetup -setwaitforstartupafterpowerfailure {0}'.format(seconds)
-    salt.utils.mac_utils.execute_return_success(cmd)
+    try:
+        salt.utils.mac_utils.execute_return_success(cmd)
+    except CommandExecutionError as exc:
+        raise CommandExecutionError(exc)
+
     return get_restart_delay() == seconds
 
 
@@ -477,10 +559,19 @@ def get_disable_keyboard_on_lock():
 
         salt '*' system.get_disable_keyboard_on_lock
     '''
-    ret = salt.utils.mac_utils.execute_return_result(
-        'systemsetup -getdisablekeyboardwhenenclosurelockisengaged')
-    return salt.utils.mac_utils.validate_enabled(
-        salt.utils.mac_utils.parse_return(ret)) == 'on'
+    try:
+        ret = salt.utils.mac_utils.execute_return_result(
+            'systemsetup -getdisablekeyboardwhenenclosurelockisengaged')
+    except CommandExecutionError as exc:
+        raise CommandExecutionError(exc)
+
+    try:
+        enabled = salt.utils.mac_utils.validate_enabled(
+            salt.utils.mac_utils.parse_return(ret))
+    except SaltInvocationError as exc:
+        raise SaltInvocationError(exc)
+
+    return enabled == 'on'
 
 
 def set_disable_keyboard_on_lock(enable):
@@ -501,13 +592,22 @@ def set_disable_keyboard_on_lock(enable):
 
         salt '*' system.set_disable_keyboard_on_lock False
     '''
+    try:
+        state = salt.utils.mac_utils.validate_enabled(enable)
+    except SaltInvocationError as exc:
+        raise SaltInvocationError(exc)
 
-    state = salt.utils.mac_utils.validate_enabled(enable)
-    cmd = 'systemsetup -setdisablekeyboardwhenenclosurelockisengaged ' \
-          '{0}'.format(state)
-    salt.utils.mac_utils.execute_return_success(cmd)
-    return salt.utils.mac_utils.validate_enabled(
-        get_disable_keyboard_on_lock()) == state
+    try:
+        cmd = 'systemsetup -setdisablekeyboardwhenenclosurelockisengaged ' \
+              '{0}'.format(state)
+        salt.utils.mac_utils.execute_return_success(cmd)
+    except CommandExecutionError as exc:
+        raise CommandExecutionError(exc)
+
+    enabled = salt.utils.mac_utils.validate_enabled(
+        get_disable_keyboard_on_lock())
+
+    return enabled == state
 
 
 def get_boot_arch():
@@ -523,8 +623,12 @@ def get_boot_arch():
 
         salt '*' system.get_boot_arch
     '''
-    ret = salt.utils.mac_utils.execute_return_result(
-        'systemsetup -getkernelbootarchitecturesetting')
+    try:
+        ret = salt.utils.mac_utils.execute_return_result(
+            'systemsetup -getkernelbootarchitecturesetting')
+    except CommandExecutionError as exc:
+        raise CommandExecutionError(exc)
+
     arch = salt.utils.mac_utils.parse_return(ret)
 
     if 'default' in arch:
@@ -568,7 +672,12 @@ def set_boot_arch(arch='default'):
         msg = '\nInvalid value passed for arch.\n' \
               'Must be i386, x86_64, or default.\n' \
               'Passed: {0}'.format(arch)
-        raise CommandExecutionError(msg)
-    cmd = 'systemsetup -setkernelbootarchitecture {0}'.format(arch)
-    salt.utils.mac_utils.execute_return_success(cmd)
+        raise SaltInvocationError(msg)
+
+    try:
+        cmd = 'systemsetup -setkernelbootarchitecture {0}'.format(arch)
+        salt.utils.mac_utils.execute_return_success(cmd)
+    except CommandExecutionError as exc:
+        raise CommandExecutionError(exc)
+
     return arch in get_boot_arch()

--- a/salt/modules/mac_system.py
+++ b/salt/modules/mac_system.py
@@ -19,7 +19,7 @@ except ImportError:  # python 2
 # Import salt libs
 import salt.utils
 import salt.utils.mac_utils
-from salt.exceptions import CommandExecutionError, SaltInvocationError
+from salt.exceptions import SaltInvocationError
 
 __virtualname__ = 'system'
 

--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -168,23 +168,23 @@ def validate_enabled(enabled):
     '''
     Helper function to validate the enabled parameter. Boolean values are
     converted to "on" and "off". String values are checked to make sure they are
-    either "on" or "off". Integer ``0`` will return "off". All other integers
-    will return "on"
+    either "on" or "off"/"yes" or "no". Integer ``0`` will return "off". All
+    other integers will return "on"
 
     :param enabled: Enabled can be boolean True or False, Integers, or string
-    values "on" and "off".
+    values "on" and "off"/"yes" and "no".
     :type: str, int, bool
 
     :return: "on" or "off" or errors
     :rtype: str
     '''
     if isinstance(enabled, str):
-        if enabled.lower() not in ['on', 'off']:
+        if enabled.lower() not in ['on', 'off', 'yes', 'no']:
             msg = '\nMac Power: Invalid String Value for Enabled.\n' \
-                  'String values must be \'on\' or \'off\'.\n' \
+                  'String values must be \'on\' or \'off\'/\'yes\' or \'no\'.\n' \
                   'Passed: {0}'.format(enabled)
             raise SaltInvocationError(msg)
 
-        return enabled.lower()
+        return 'on' if enabled.lower() in ['on', 'yes'] else 'off'
 
     return 'on' if bool(enabled) else 'off'

--- a/tests/integration/modules/mac_system.py
+++ b/tests/integration/modules/mac_system.py
@@ -9,7 +9,6 @@ import random
 import string
 
 # Import Salt Testing libs
-from unittest import skip
 from salttesting.helpers import ensure_in_syspath, destructiveTest
 from salt.ext.six.moves import range
 ensure_in_syspath('../../')
@@ -17,6 +16,12 @@ ensure_in_syspath('../../')
 # Import salt libs
 import integration
 import salt.utils
+
+
+def disabled(f):
+    def _decorator():
+        print '{0} has been disabled'.format(f.__name__)
+    return _decorator
 
 
 def __random_string(size=6):
@@ -177,7 +182,7 @@ class MacSystemModuleTest(integration.ModuleCase):
             'Invalid value passed for path.',
             self.run_function('system.set_startup_disk', ['spongebob']))
 
-    @skip
+    @disabled
     def test_get_set_restart_delay(self):
         '''
         Test system.get_restart_delay
@@ -236,7 +241,7 @@ class MacSystemModuleTest(integration.ModuleCase):
             self.run_function('system.set_disable_keyboard_on_lock',
                               ['spongebob']))
 
-    @skip
+    @disabled
     def test_get_set_boot_arch(self):
         '''
         Test system.get_boot_arch

--- a/tests/integration/modules/mac_system.py
+++ b/tests/integration/modules/mac_system.py
@@ -10,11 +10,22 @@ import string
 
 # Import Salt Testing libs
 from salttesting.helpers import ensure_in_syspath, destructiveTest
+from salt.ext.six.moves import range
 ensure_in_syspath('../../')
 
 # Import salt libs
 import integration
 import salt.utils
+
+ATRUN_ENABLED = False
+REMOTE_LOGIN_ENABLED = False
+REMOTE_EVENTS_ENABLED = False
+COMPUTER_NAME = ''
+SUBNET_NAME = ''
+KEYBOARD_DISABLED = False
+SET_COMPUTER_NAME = __random_string()
+SET_SUBNET_NAME = __random_string()
+
 
 def __random_string(size=6):
     '''
@@ -25,14 +36,6 @@ def __random_string(size=6):
         for x in range(size)
     )
 
-ATRUN_ENABLED = False
-REMOTE_LOGIN_ENABLED = False
-REMOTE_EVENTS_ENABLED = False
-COMPUTER_NAME = ''
-SUBNET_NAME = ''
-KEYBOARD_DISABLED = False
-SET_COMPUTER_NAME = __random_string()
-SET_SUBNET_NAME = __random_string()
 
 class MacSystemModuleTest(integration.ModuleCase):
     '''

--- a/tests/integration/modules/mac_system.py
+++ b/tests/integration/modules/mac_system.py
@@ -19,9 +19,9 @@ import salt.utils
 
 
 def disabled(f):
-    def _decorator():
+    def _decorator(f):
         print '{0} has been disabled'.format(f.__name__)
-    return _decorator
+    return _decorator(f)
 
 
 def __random_string(size=6):

--- a/tests/integration/modules/mac_system.py
+++ b/tests/integration/modules/mac_system.py
@@ -53,6 +53,13 @@ class MacSystemModuleTest(integration.ModuleCase):
         '''
         Get current settings
         '''
+        global ATRUN_ENABLED
+        global REMOTE_LOGIN_ENABLED
+        global REMOTE_EVENTS_ENABLED
+        global COMPUTER_NAME
+        global SUBNET_NAME
+        global KEYBOARD_DISABLED
+
         if not salt.utils.is_darwin():
             self.skipTest('Test only available on Mac OS X')
 

--- a/tests/integration/modules/mac_system.py
+++ b/tests/integration/modules/mac_system.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+'''
+integration tests for mac_system
+'''
+
+# Import python libs
+from __future__ import absolute_import
+from datetime import datetime
+
+# Import Salt Testing libs
+from salttesting.helpers import ensure_in_syspath
+ensure_in_syspath('../../')
+
+# Import salt libs
+import integration
+import salt.utils
+
+ATRUN_ENABLED = False
+REMOTE_LOGIN_ENABLED
+
+
+class MacSystemModuleTest(integration.ModuleCase):
+    '''
+    Validate the mac_system module
+    '''
+
+    def setUp(self):
+        '''
+        Get current settings
+        '''
+        if not salt.utils.is_darwin():
+            self.skipTest('Test only available on Mac OS X')
+
+        if not salt.utils.which('systemsetup'):
+            self.skipTest('Test requires systemsetup binary')
+
+        if not salt.utils.which('launchctl'):
+            self.skipTest('Test requires launchctl binary')
+
+        if salt.utils.get_uid(salt.utils.get_user()) != 0:
+            self.skipTest('Test requires root')
+
+        ATRUN_ENABLED = self.run_function('service.enabled',
+                                          ['com.apple.atrun'])
+
+        super(MacSystemModuleTest, self).setUp()
+
+    def tearDown(self):
+        '''
+        Reset to original settings
+        '''
+        if not ATRUN_ENABLED:
+            atrun = '/System/Library/LaunchDaemons/com.apple.atrun.plist'
+            self.run_function('service.stop', [atrun])
+
+        super(MacSystemModuleTest, self).tearDown()
+
+    def test_get_set_remote_login(self):
+
+
+    def test_get_set_date(self):
+        '''
+        Test timezone.get_date
+        Test timezone.set_date
+        '''
+        self.run_function('timezone.set_date', ['2/20/2011'])
+        self.assertEqual(self.run_function('timezone.get_date'), '2/20/2011')
+
+    def test_get_set_time(self):
+        '''
+        Test timezone.get_time
+        Test timezone.set_time
+        '''
+        self.run_function('timezone.set_time', ['3:14'])
+        new_time = self.run_function('timezone.get_time')
+        new_time = datetime.strptime(new_time, '%H:%M:%S').strftime('%H:%M')
+        self.assertEqual(new_time, '03:14')
+
+    def test_get_set_zone(self):
+        '''
+        Test timezone.get_zone
+        Test timezone.set_zone
+        '''
+        self.run_function('timezone.set_zone', ['Pacific/Wake'])
+        self.assertEqual(self.run_function('timezone.get_zone'), 'Pacific/Wake')
+
+    def test_get_offset(self):
+        '''
+        Test timezone.get_offset
+        '''
+        self.run_function('timezone.set_zone', ['Pacific/Wake'])
+        self.assertEqual(self.run_function('timezone.get_offset'), '+1200')
+
+    def test_get_zonecode(self):
+        '''
+        Test timezone.get_zonecode
+        '''
+        self.run_function('timezone.set_zone', ['Pacific/Wake'])
+        self.assertEqual(self.run_function('timezone.get_zonecode'), 'WAKT')
+
+    def test_list_zones(self):
+        '''
+        Test timezone.list_zones
+        '''
+        ret = self.run_function('timezone.list_zones')
+        self.assertIn('America/Denver', ret)
+        self.assertIn('Asia/Hong_Kong', ret)
+        self.assertIn('Australia/Sydney', ret)
+        self.assertIn('Europe/London', ret)
+
+    def test_zone_compare(self):
+        '''
+        Test timezone.zone_compare
+        '''
+        self.run_function('timezone.set_zone', ['Pacific/Wake'])
+        self.assertTrue(self.run_function('timezone.zone_compare',
+                                          ['Pacific/Wake']))
+        self.assertFalse(self.run_function('timezone.zone_compare',
+                                           ['America/Denver']))
+
+    def test_get_set_using_network_time(self):
+        '''
+        Test timezone.get_using_network_time
+        Test timezone.set_using_network_time
+        '''
+        self.run_function('timezone.set_using_network_time', [True])
+        self.assertTrue(self.run_function('timezone.get_using_network_time'))
+
+        self.run_function('timezone.set_using_network_time', [False])
+        self.assertFalse(self.run_function('timezone.get_using_network_time'))
+
+    def test_get_set_time_server(self):
+        '''
+        Test timezone.get_time_server
+        Test timezone.set_time_server
+        '''
+        self.run_function('timezone.set_time_server', ['time.spongebob.com'])
+        self.assertEqual(self.run_function('timezone.get_time_server'),
+                         'time.spongebob.com')
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(MacTimezoneModuleTest)

--- a/tests/integration/modules/mac_system.py
+++ b/tests/integration/modules/mac_system.py
@@ -4,7 +4,7 @@ integration tests for mac_system
 '''
 
 # Import python libs
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import random
 import string
 
@@ -20,7 +20,7 @@ import salt.utils
 
 def disabled(f):
     def _decorator(f):
-        print '{0} has been disabled'.format(f.__name__)
+        print('{0} has been disabled'.format(f.__name__))
     return _decorator(f)
 
 

--- a/tests/integration/modules/mac_system.py
+++ b/tests/integration/modules/mac_system.py
@@ -34,12 +34,6 @@ def __random_string(size=6):
     )
 
 
-ATRUN_ENABLED = False
-REMOTE_LOGIN_ENABLED = False
-REMOTE_EVENTS_ENABLED = False
-COMPUTER_NAME = ''
-SUBNET_NAME = ''
-KEYBOARD_DISABLED = False
 SET_COMPUTER_NAME = __random_string()
 SET_SUBNET_NAME = __random_string()
 
@@ -48,18 +42,17 @@ class MacSystemModuleTest(integration.ModuleCase):
     '''
     Validate the mac_system module
     '''
+    ATRUN_ENABLED = False
+    REMOTE_LOGIN_ENABLED = False
+    REMOTE_EVENTS_ENABLED = False
+    COMPUTER_NAME = ''
+    SUBNET_NAME = ''
+    KEYBOARD_DISABLED = False
 
     def setUp(self):
         '''
         Get current settings
         '''
-        global ATRUN_ENABLED
-        global REMOTE_LOGIN_ENABLED
-        global REMOTE_EVENTS_ENABLED
-        global COMPUTER_NAME
-        global SUBNET_NAME
-        global KEYBOARD_DISABLED
-
         if not salt.utils.is_darwin():
             self.skipTest('Test only available on Mac OS X')
 
@@ -69,29 +62,27 @@ class MacSystemModuleTest(integration.ModuleCase):
         if salt.utils.get_uid(salt.utils.get_user()) != 0:
             self.skipTest('Test requires root')
 
-        ATRUN_ENABLED = self.run_function('service.enabled',
-                                          ['com.apple.atrun'])
-        REMOTE_LOGIN_ENABLED = self.run_function('system.get_remote_login')
-        REMOTE_EVENTS_ENABLED = self.run_function('system.get_remote_events')
-        COMPUTER_NAME = self.run_function('system.get_computer_name')
-        SUBNET_NAME = self.run_function('system.get_subnet_name')
-        KEYBOARD_DISABLED = self.run_function(
-            'system.get_disable_keyboard_on_lock')
+        self.ATRUN_ENABLED = self.run_function('service.enabled', ['com.apple.atrun'])
+        self.REMOTE_LOGIN_ENABLED = self.run_function('system.get_remote_login')
+        self.REMOTE_EVENTS_ENABLED = self.run_function('system.get_remote_events')
+        self.COMPUTER_NAME = self.run_function('system.get_computer_name')
+        self.SUBNET_NAME = self.run_function('system.get_subnet_name')
+        self.KEYBOARD_DISABLED = self.run_function('system.get_disable_keyboard_on_lock')
 
     def tearDown(self):
         '''
         Reset to original settings
         '''
-        if not ATRUN_ENABLED:
+        if not self.ATRUN_ENABLED:
             atrun = '/System/Library/LaunchDaemons/com.apple.atrun.plist'
             self.run_function('service.stop', [atrun])
 
-        self.run_function('system.set_remote_login', [REMOTE_LOGIN_ENABLED])
-        self.run_function('system.set_remote_events', [REMOTE_EVENTS_ENABLED])
-        self.run_function('system.set_computer_name', [COMPUTER_NAME])
-        self.run_function('system.set_subnet_name', [SUBNET_NAME])
+        self.run_function('system.set_remote_login', [self.REMOTE_LOGIN_ENABLED])
+        self.run_function('system.set_remote_events', [self.REMOTE_EVENTS_ENABLED])
+        self.run_function('system.set_computer_name', [self.COMPUTER_NAME])
+        self.run_function('system.set_subnet_name', [self.SUBNET_NAME])
         self.run_function('system.set_disable_keyboard_on_lock',
-                          [KEYBOARD_DISABLED])
+                          [self.KEYBOARD_DISABLED])
 
     @destructiveTest
     def test_get_set_remote_login(self):
@@ -169,8 +160,7 @@ class MacSystemModuleTest(integration.ModuleCase):
             self.run_function('system.set_subnet_name', [SET_SUBNET_NAME]))
         self.assertEqual(
             self.run_function('system.get_subnet_name'),
-            SET_SUBNET_NAME
-        )
+            SET_SUBNET_NAME)
 
     def test_get_list_startup_disk(self):
         '''


### PR DESCRIPTION
### What does this PR do?

Adds integration tests for `mac_system.py` execution module
Fixes `service.start` and `service.stop` functions in mac_service
`mac_system.py` now uses `mac_utils.py`
### What issues does this PR fix or reference?

https://github.com/saltstack/zh/issues/553
### Previous Behavior

`service.start` and `service.stop` incorrectly checked `service.get_all` to see if the service was already enabled.
`mac_system.py` used incorrect import method: `from salt.utils.mac_utils import validate_enabled, parse_return, execute_return_success, execute_return_results`
### New Behavior

`service.start` and `service.stop` now use `service._get_enabled` to see if the service is already running
`mac_system.py` now uses correct import method: `import salt.utils.mac_utils`
### Tests written?

Yes
