### PR TITLE
Add boto_elasticsearch_domain module

### DIFF
--- a/salt/modules/boto_elasticsearch_domain.py
+++ b/salt/modules/boto_elasticsearch_domain.py
@@ -342,6 +342,7 @@ def update(DomainName, ElasticsearchClusterConfig=None, EBSOptions=None,
     except ClientError as e:
         return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
 
+
 def add_tags(DomainName=None, ARN=None,
            region=None, key=None, keyid=None, profile=None, **kwargs):
     '''

--- a/salt/modules/boto_elasticsearch_domain.py
+++ b/salt/modules/boto_elasticsearch_domain.py
@@ -1,0 +1,469 @@
+# -*- coding: utf-8 -*-
+'''
+Connection module for Amazon Elasticsearch Service
+
+.. versionadded:: Carbon
+
+:configuration: This module accepts explicit AWS credentials but can also
+    utilize IAM roles assigned to the instance trough Instance Profiles.
+    Dynamic credentials are then automatically obtained from AWS API and no
+    further configuration is necessary. More Information available at:
+
+    .. code-block:: text
+
+        http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+
+    If IAM roles are not used you need to specify them either in a pillar or
+    in the minion's config file:
+
+    .. code-block:: yaml
+
+        lambda.keyid: GKTADJGHEIQSXMKKRBJ08H
+        lambda.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+    A region may also be specified in the configuration:
+
+    .. code-block:: yaml
+
+        lambda.region: us-east-1
+
+    If a region is not specified, the default is us-east-1.
+
+    It's also possible to specify key, keyid and region via a profile, either
+    as a passed in dict, or as a string to pull from pillars or minion config:
+
+    .. code-block:: yaml
+
+        myprofile:
+            keyid: GKTADJGHEIQSXMKKRBJ08H
+            key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+            region: us-east-1
+
+    Create and delete methods return:
+
+    .. code-block:: yaml
+
+        created: true
+
+    or
+
+    .. code-block:: yaml
+
+        created: false
+        error:
+          message: error message
+
+    Request methods (e.g., `describe_function`) return:
+
+    .. code-block:: yaml
+
+        domain:
+          - {...}
+          - {...}
+
+    or
+
+    .. code-block:: yaml
+
+        error:
+          message: error message
+
+:depends: boto3
+
+'''
+# keep lint from choking on _get_conn and _cache_id
+#pylint: disable=E0602
+
+# Import Python libs
+from __future__ import absolute_import
+import logging
+import json
+from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
+
+# Import Salt libs
+import salt.utils.boto3
+import salt.utils.compat
+import salt.utils
+from salt.exceptions import SaltInvocationError
+from salt.ext.six import string_types
+
+log = logging.getLogger(__name__)
+
+# Import third party libs
+
+# pylint: disable=import-error
+try:
+    #pylint: disable=unused-import
+    import boto
+    import boto3
+    #pylint: enable=unused-import
+    from botocore.exceptions import ClientError
+    logging.getLogger('boto').setLevel(logging.CRITICAL)
+    logging.getLogger('boto3').setLevel(logging.CRITICAL)
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+# pylint: enable=import-error
+
+
+def __virtual__():
+    '''
+    Only load if boto libraries exist and if boto libraries are greater than
+    a given version.
+    '''
+    required_boto_version = '2.8.0'
+    required_boto3_version = '1.2.5'
+    # the boto_lambda execution module relies on the connect_to_region() method
+    # which was added in boto 2.8.0
+    # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
+    if not HAS_BOTO:
+        return (False, 'The boto_lambda module could not be loaded: '
+                'boto libraries not found')
+    elif _LooseVersion(boto.__version__) < _LooseVersion(required_boto_version):
+        return (False, 'The boto_lambda module could not be loaded: '
+                'boto version {0} or later must be installed.'.format(required_boto_version))
+    elif _LooseVersion(boto3.__version__) < _LooseVersion(required_boto3_version):
+        return (False, 'The boto_lambda module could not be loaded: '
+                'boto version {0} or later must be installed.'.format(required_boto3_version))
+    else:
+        return True
+
+
+def __init__(opts):
+    salt.utils.compat.pack_dunder(__name__)
+    if HAS_BOTO:
+        __utils__['boto3.assign_funcs'](__name__, 'es')
+
+
+def exists(DomainName,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a domain name, check to see if the given domain exists.
+
+    Returns True if the given domain exists and returns False if the given
+    function does not exist.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_elasticsearch_domain.exists mydomain
+
+    '''
+
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        domain = conn.describe_elasticsearch_domain(DomainName=DomainName)
+        return {'exists': True}
+    except ClientError as e:
+        if e.response.get('Error', {}).get('Code') == 'ResourceNotFoundException':
+            return {'exists': False}
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def status(DomainName,
+             region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a domain name describe its status.
+
+    Returns a dictionary of interesting properties.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_elasticsearch_domain.status mydomain
+
+    '''
+
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        domain = conn.describe_elasticsearch_domain(DomainName=DomainName)
+        if domain and 'DomainStatus' in domain:
+            domain = domain.get('DomainStatus', {})
+            keys = ('Endpoint', 'Created', 'Deleted',
+                    'DomainName', 'DomainId', 'EBSOptions', 'SnapshotOptions',
+                    'AccessPolicies', 'Processing', 'AdvancedOptions', 'ARN')
+            return {'domain': dict([(k, domain.get(k)) for k in keys if k in domain])}
+        else:
+            return {'domain': None}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def describe(DomainName,
+             region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a domain name describe its properties.
+
+    Returns a dictionary of interesting properties.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_elasticsearch_domain.describe mydomain
+
+    '''
+
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        domain = conn.describe_elasticsearch_domain_config(DomainName=DomainName)
+        if domain and 'DomainConfig' in domain:
+            domain = domain['DomainConfig']
+            keys = ('ElasticsearchClusterConfig', 'EBSOptions', 'AccessPolicies',
+                    'SnapshotOptions', 'AdvancedOptions')
+            return {'domain': dict([(k, domain.get(k, {}).get('Options')) for k in keys if k in domain])}
+        else:
+            return {'domain': None}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def create(DomainName, ElasticsearchClusterConfig=None, EBSOptions=None,
+           AccessPolicies=None, SnapshotOptions=None, AdvancedOptions=None,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a valid config, create a domain.
+
+    Returns {created: true} if the domain was created and returns
+    {created: False} if the domain was not created.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_elasticsearch_domain.create mydomain \\
+              {'InstanceType': 't2.micro.elasticsearch', 'InstanceCount': 1, \\
+              'DedicatedMasterEnabled': false, 'ZoneAwarenessEnabled': false} \\
+              {'EBSEnabled': true, 'VolumeType': 'gp2', 'VolumeSize': 10, \\
+              'Iops': 0} \\
+              {"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Principal": {"AWS": "*"}, "Action": "es:*", \\
+               "Resource": "arn:aws:es:us-east-1:111111111111:domain/mydomain/*", \\
+               "Condition": {"IpAddress": {"aws:SourceIp": ["127.0.0.1"]}}}]} \\
+              {"AutomatedSnapshotStartHour": 0} \\
+              {"rest.action.multi.allow_explicit_index": "true"}
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        kwargs = {}
+        for k in ('ElasticsearchClusterConfig', 'EBSOptions',
+                    'AccessPolicies', 'SnapshotOptions', 'AdvancedOptions'):
+            if locals()[k] is not None:
+                val = locals()[k]
+                if isinstance(val, string_types):
+                    try:
+                        val = json.loads(val)
+                    except ValueError as e:
+                        return {'updated': False, 'error': 'Error parsing {0}: {1}'.format(k, e.message)}
+                kwargs[k] = val
+        if 'AccessPolicies' in kwargs:
+            kwargs['AccessPolicies'] = json.dumps(kwargs['AccessPolicies'])
+        domain = conn.create_elasticsearch_domain(DomainName=DomainName, **kwargs)
+        if domain and 'DomainStatus' in domain:
+            return {'created': True}
+        else:
+            log.warning('Domain was not created')
+            return {'created': False}
+    except ClientError as e:
+        return {'created': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def delete(DomainName, region=None, key=None, keyid=None, profile=None):
+    '''
+    Given a domain name, delete it.
+
+    Returns {deleted: true} if the domain was deleted and returns
+    {deleted: false} if the domain was not deleted.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_elasticsearch_domain.delete mydomain
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        conn.delete_elasticsearch_domain(DomainName=DomainName)
+        return {'deleted': True}
+    except ClientError as e:
+        return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def update(DomainName, ElasticsearchClusterConfig=None, EBSOptions=None,
+           AccessPolicies=None, SnapshotOptions=None, AdvancedOptions=None,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Update the named domain to the configuration.
+
+    Returns {updated: true} if the domain was updated and returns
+    {updated: False} if the domain was not updated.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_elasticsearch_domain.update mydomain \\
+              {'InstanceType': 't2.micro.elasticsearch', 'InstanceCount': 1, \\
+              'DedicatedMasterEnabled': false, 'ZoneAwarenessEnabled': false} \\
+              {'EBSEnabled': true, 'VolumeType': 'gp2', 'VolumeSize': 10, \\
+              'Iops': 0} \\
+              {"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Principal": {"AWS": "*"}, "Action": "es:*", \\
+               "Resource": "arn:aws:es:us-east-1:111111111111:domain/mydomain/*", \\
+               "Condition": {"IpAddress": {"aws:SourceIp": ["127.0.0.1"]}}}]} \\
+              {"AutomatedSnapshotStartHour": 0} \\
+              {"rest.action.multi.allow_explicit_index": "true"}
+
+    '''
+
+    call_args = {}
+    for k in ('ElasticsearchClusterConfig', 'EBSOptions',
+                'AccessPolicies', 'SnapshotOptions', 'AdvancedOptions'):
+        if locals()[k] is not None:
+            val = locals()[k]
+            if isinstance(val, string_types):
+                try:
+                    val = json.loads(val)
+                except ValueError as e:
+                    return {'updated': False, 'error': 'Error parsing {0}: {1}'.format(k, e.message)}
+            call_args[k] = val
+    if 'AccessPolicies' in call_args:
+        call_args['AccessPolicies'] = json.dumps(call_args['AccessPolicies'])
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        domain = conn.update_elasticsearch_domain_config(DomainName=DomainName, **call_args)
+        if not domain or 'DomainConfig' not in domain:
+            log.warning('Domain was not updated')
+            return {'updated': False}
+        return {'updated': True}
+    except ClientError as e:
+        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+
+def add_tags(DomainName=None, ARN=None,
+           region=None, key=None, keyid=None, profile=None, **kwargs):
+    '''
+    Add tags to a domain
+
+    Returns {tagged: true} if the domain was tagged and returns
+    {tagged: False} if the domain was not tagged.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_elasticsearch_domain.add_tags mydomain tag_a=tag_value tag_b=tag_value
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        tagslist = []
+        for k, v in kwargs.iteritems():
+            if str(k).startswith('__'):
+                continue
+            tagslist.append({'Key': str(k), 'Value': str(v)})
+        if ARN is None:
+            if DomainName is None:
+                raise SaltInvocationError('One (but not both) of ARN or '
+                         'domain must be specified.')
+            domaindata = status(DomainName=DomainName,
+                            region=region, key=key, keyid=keyid,
+                            profile=profile)
+            if not domaindata or 'domain' not in domaindata:
+                log.warning('Domain tags not updated')
+                return {'tagged': False}
+            ARN = domaindata.get('domain', {}).get('ARN')
+        elif DomainName is not None:
+            raise SaltInvocationError('One (but not both) of ARN or '
+                         'domain must be specified.')
+        conn.add_tags(ARN=ARN, TagList=tagslist)
+        return {'tagged': True}
+    except ClientError as e:
+        return {'tagged': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def remove_tags(TagKeys, DomainName=None, ARN=None,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Remove tags from a trail
+
+    Returns {tagged: true} if the trail was tagged and returns
+    {tagged: False} if the trail was not tagged.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_cloudtrail.remove_tags my_trail tag_a=tag_value tag_b=tag_value
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if ARN is None:
+            if DomainName is None:
+                raise SaltInvocationError('One (but not both) of ARN or '
+                         'domain must be specified.')
+            domaindata = status(DomainName=DomainName,
+                            region=region, key=key, keyid=keyid,
+                            profile=profile)
+            if not domaindata or 'domain' not in domaindata:
+                log.warning('Domain tags not updated')
+                return {'tagged': False}
+            ARN = domaindata.get('domain', {}).get('ARN')
+        elif DomainName is not None:
+            raise SaltInvocationError('One (but not both) of ARN or '
+                         'domain must be specified.')
+        conn.remove_tags(ARN=domaindata.get('domain', {}).get('ARN'),
+                         TagKeys=TagKeys)
+        return {'tagged': True}
+    except ClientError as e:
+        return {'tagged': False, 'error': salt.utils.boto3.get_error(e)}
+
+
+def list_tags(DomainName=None, ARN=None,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    List tags of a trail
+
+    Returns:
+        tags:
+          - {...}
+          - {...}
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_cloudtrail.list_tags my_trail
+
+    '''
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if ARN is None:
+            if DomainName is None:
+                raise SaltInvocationError('One (but not both) of ARN or '
+                         'domain must be specified.')
+            domaindata = status(DomainName=DomainName,
+                            region=region, key=key, keyid=keyid,
+                            profile=profile)
+            if not domaindata or 'domain' not in domaindata:
+                log.warning('Domain tags not updated')
+                return {'tagged': False}
+            ARN = domaindata.get('domain', {}).get('ARN')
+        elif DomainName is not None:
+            raise SaltInvocationError('One (but not both) of ARN or '
+                         'domain must be specified.')
+        ret = conn.list_tags(ARN=ARN)
+        log.warn(ret)
+        tlist = ret.get('TagList', [])
+        tagdict = {}
+        for tag in tlist:
+            tagdict[tag.get('Key')] = tag.get('Value')
+        return {'tags': tagdict}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}

--- a/salt/states/boto_elasticsearch_domain.py
+++ b/salt/states/boto_elasticsearch_domain.py
@@ -1,0 +1,359 @@
+# -*- coding: utf-8 -*-
+'''
+Manage Elasticsearch Domains
+=================
+
+.. versionadded:: 2016.3.0
+
+Create and destroy Elasticsearch domains. Be aware that this interacts with Amazon's services,
+and so may incur charges.
+
+This module uses ``boto3``, which can be installed via package, or pip.
+
+This module accepts explicit vpc credentials but can also utilize
+IAM roles assigned to the instance through Instance Profiles. Dynamic
+credentials are then automatically obtained from AWS API and no further
+configuration is necessary. More information available `here
+<http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html>`_.
+
+If IAM roles are not used you need to specify them either in a pillar file or
+in the minion's config file:
+
+.. code-block:: yaml
+
+    vpc.keyid: GKTADJGHEIQSXMKKRBJ08H
+    vpc.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+It's also possible to specify ``key``, ``keyid`` and ``region`` via a profile,
+either passed in as a dict, or as a string to pull from pillars or minion
+config:
+
+.. code-block:: yaml
+
+    myprofile:
+        keyid: GKTADJGHEIQSXMKKRBJ08H
+        key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+            region: us-east-1
+
+.. code-block:: yaml
+
+    Ensure domain exists:
+        boto_elasticsearch_domain.present:
+            - DomainName: mydomain
+            - profile='user-credentials'
+            - ElasticsearchClusterConfig:
+                InstanceType": "t2.micro.elasticsearch"
+                InstanceCount: 1
+                DedicatedMasterEnabled: False
+                ZoneAwarenessEnabled: False
+            - EBSOptions:
+                EBSEnabled: True
+                VolumeType: "gp2"
+                VolumeSize: 10
+                Iops: 0
+            - AccessPolicies:
+                Version: "2012-10-17"
+                Statement:
+                  - Effect: "Allow"
+                  - Principal:
+                      AWS: "*"
+                  - Action:
+                    - "es:*"
+                  - Resource: "arn:aws:es:*:111111111111:domain/mydomain/*
+                  - Condition:
+                      IpAddress:
+                        "aws:SourceIp":
+                          - "127.0.0.1",
+                          - "127.0.0.2",
+            - SnapshotOptions:
+                AutomatedSnapshotStartHour: 0
+            - AdvancedOptions:
+                rest.action.multi.allow_explicit_index": "true"
+            - Tags:
+                a: "b"
+            - region: us-east-1
+            - keyid: GKTADJGHEIQSXMKKRBJ08H
+            - key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+import logging
+import os
+import os.path
+import json
+
+# Import Salt Libs
+from salt.ext.six import string_types
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Only load if boto is available.
+    '''
+    return 'boto_elasticsearch_domain' if 'boto_elasticsearch_domain.exists' in __salt__ else False
+
+
+def present(name, DomainName,
+            ElasticsearchClusterConfig=None,
+            EBSOptions=None,
+            AccessPolicies=None,
+            SnapshotOptions=None,
+            AdvancedOptions=None,
+            Tags=None,
+            region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure domain exists.
+
+    name
+        The name of the state definition
+
+    DomainName
+        Name of the domain.
+
+    ElasticsearchClusterConfig
+        Configuration options for an Elasticsearch domain. Specifies the
+        instance type and number of instances in the domain cluster.
+
+        InstanceType (string) --
+        The instance type for an Elasticsearch cluster.
+
+        InstanceCount (integer) --
+        The number of instances in the specified domain cluster.
+
+        DedicatedMasterEnabled (boolean) --
+        A boolean value to indicate whether a dedicated master node is enabled.
+        See About Dedicated Master Nodes for more information.
+
+        ZoneAwarenessEnabled (boolean) --
+        A boolean value to indicate whether zone awareness is enabled. See About
+        Zone Awareness for more information.
+
+        DedicatedMasterType (string) --
+        The instance type for a dedicated master node.
+
+        DedicatedMasterCount (integer) --
+        Total number of dedicated master nodes, active and on standby, for the
+        cluster.
+
+    EBSOptions
+        Options to enable, disable and specify the type and size of EBS storage
+        volumes.
+
+        EBSEnabled (boolean) --
+        Specifies whether EBS-based storage is enabled.
+
+        VolumeType (string) --
+        Specifies the volume type for EBS-based storage.
+
+        VolumeSize (integer) --
+        Integer to specify the size of an EBS volume.
+
+        Iops (integer) --
+        Specifies the IOPD for a Provisioned IOPS EBS volume (SSD).
+
+    AccessPolicies
+        IAM access policy
+
+    SnapshotOptions
+        Option to set time, in UTC format, of the daily automated snapshot.
+        Default value is 0 hours.
+
+        AutomatedSnapshotStartHour (integer) --
+        Specifies the time, in UTC format, when the service takes a daily
+        automated snapshot of the specified Elasticsearch domain. Default value
+        is 0 hours.
+
+    AdvancedOptions
+        Option to allow references to indices in an HTTP request body. Must be
+        false when configuring access to individual sub-resources. By default,
+        the value is true .
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+    '''
+    ret = {'name': DomainName,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    if ElasticsearchClusterConfig is None:
+        ElasticsearchClusterConfig = {
+            'DedicatedMasterEnabled': False,
+            'InstanceCount': 1,
+            'InstanceType': 'm3.medium.elasticsearch',
+            'ZoneAwarenessEnabled': False
+        }
+    if EBSOptions is None:
+        EBSOptions = {
+            'EBSEnabled': False,
+        }
+    if SnapshotOptions is None:
+        SnapshotOptions = {
+            'AutomatedSnapshotStartHour': 0
+        }
+    if AdvancedOptions is None:
+        AdvancedOptions = {
+            'rest.action.multi.allow_explicit_index': 'true'
+        }
+    if Tags is None:
+        Tags = {}
+    if AccessPolicies is not None and isinstance(AccessPolicies, string_types):
+        try:
+            AccessPolicies = json.loads(AccessPolicies)
+        except ValueError as e:
+            ret['result'] = False
+            ret['comment'] = 'Failed to create domain: {0}.'.format(e.message)
+            return ret
+    r = __salt__['boto_elasticsearch_domain.exists'](DomainName=DomainName,
+                              region=region, key=key, keyid=keyid, profile=profile)
+
+    if 'error' in r:
+        ret['result'] = False
+        ret['comment'] = 'Failed to create domain: {0}.'.format(r['error']['message'])
+        return ret
+
+    if not r.get('exists'):
+        if __opts__['test']:
+            ret['comment'] = 'Domain {0} is set to be created.'.format(DomainName)
+            ret['result'] = None
+            return ret
+        r = __salt__['boto_elasticsearch_domain.create'](DomainName=DomainName,
+                                                     ElasticsearchClusterConfig=ElasticsearchClusterConfig,
+                                                     EBSOptions=EBSOptions,
+                                                     AccessPolicies=AccessPolicies,
+                                                     SnapshotOptions=SnapshotOptions,
+                                                     AdvancedOptions=AdvancedOptions,
+                                               region=region, key=key,
+                                               keyid=keyid, profile=profile)
+        if not r.get('created'):
+            ret['result'] = False
+            ret['comment'] = 'Failed to create domain: {0}.'.format(r['error']['message'])
+            return ret
+        _describe = __salt__['boto_elasticsearch_domain.describe'](DomainName,
+                                   region=region, key=key, keyid=keyid, profile=profile)
+        ret['changes']['old'] = {'domain': None}
+        ret['changes']['new'] = _describe
+        ret['comment'] = 'Domain {0} created.'.format(DomainName)
+        return ret
+
+    ret['comment'] = os.linesep.join([ret['comment'], 'Domain {0} is present.'.format(DomainName)])
+    ret['changes'] = {}
+    # domain exists, ensure config matches
+    _describe = __salt__['boto_elasticsearch_domain.describe'](DomainName=DomainName,
+                                  region=region, key=key, keyid=keyid,
+                                  profile=profile)['domain']
+    _describe['AccessPolicies'] = json.loads(_describe['AccessPolicies'])
+
+    # When EBSEnabled is false, describe returns extra values that can't be set
+    if not _describe.get('EBSOptions', {}).get('EBSEnabled'):
+        opts = _describe.get('EBSOptions', {})
+        opts.pop('VolumeSize', None)
+        opts.pop('VolumeType', None)
+
+    comm_args = {}
+    need_update = False
+    for k, v in {
+        'ElasticsearchClusterConfig': ElasticsearchClusterConfig,
+        'EBSOptions': EBSOptions,
+        'AccessPolicies': AccessPolicies,
+        'SnapshotOptions': SnapshotOptions,
+        'AdvancedOptions': AdvancedOptions
+    }.iteritems():
+        if v != _describe[k]:
+            need_update = True
+            ret['changes'].setdefault('new', {})[k] = v
+            ret['changes'].setdefault('old', {})[k] = _describe[k]
+    if need_update:
+        if __opts__['test']:
+            msg = 'Domain {0} set to be modified.'.format(DomainName)
+            ret['comment'] = msg
+            ret['result'] = None
+            return ret
+
+        ret['comment'] = os.linesep.join([ret['comment'], 'Domain to be modified'])
+
+        r = __salt__['boto_elasticsearch_domain.update'](DomainName=DomainName,
+                                               region=region, key=key,
+                                               keyid=keyid, profile=profile,
+                                               **comm_args)
+        if not r.get('updated'):
+            ret['result'] = False
+            ret['comment'] = 'Failed to update domain: {0}.'.format(r['error'])
+            ret['changes'] = {}
+            return ret
+    return ret
+
+
+def absent(name, DomainName,
+                  region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure domain with passed properties is absent.
+
+    name
+        The name of the state definition.
+
+    DomainName
+        Name of the domain.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+    '''
+
+    ret = {'name': DomainName,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    r = __salt__['boto_elasticsearch_domain.exists'](DomainName,
+                       region=region, key=key, keyid=keyid, profile=profile)
+    if 'error' in r:
+        ret['result'] = False
+        ret['comment'] = 'Failed to delete domain: {0}.'.format(r['error']['message'])
+        return ret
+
+    if r and not r['exists']:
+        ret['comment'] = 'Domain {0} does not exist.'.format(DomainName)
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'Domain {0} is set to be removed.'.format(DomainName)
+        ret['result'] = None
+        return ret
+
+    r = __salt__['boto_elasticsearch_domain.delete'](DomainName,
+                                    region=region, key=key,
+                                    keyid=keyid, profile=profile)
+    if not r['deleted']:
+        ret['result'] = False
+        ret['comment'] = 'Failed to delete domain: {0}.'.format(r['error']['message'])
+        return ret
+    ret['changes']['old'] = {'domain': DomainName}
+    ret['changes']['new'] = {'domain': None}
+    ret['comment'] = 'Domain {0} deleted.'.format(DomainName)
+    return ret

--- a/salt/states/boto_elasticsearch_domain.py
+++ b/salt/states/boto_elasticsearch_domain.py
@@ -3,7 +3,7 @@
 Manage Elasticsearch Domains
 =================
 
-.. versionadded:: 2016.3.0
+.. versionadded:: Carbon
 
 Create and destroy Elasticsearch domains. Be aware that this interacts with Amazon's services,
 and so may incur charges.

--- a/salt/states/boto_elasticsearch_domain.py
+++ b/salt/states/boto_elasticsearch_domain.py
@@ -276,6 +276,7 @@ def present(name, DomainName,
     }.iteritems():
         if v != _describe[k]:
             need_update = True
+            comm_args[k] = v
             ret['changes'].setdefault('new', {})[k] = v
             ret['changes'].setdefault('old', {})[k] = _describe[k]
     if need_update:

--- a/tests/unit/modules/boto_elasticsearch_domain_test.py
+++ b/tests/unit/modules/boto_elasticsearch_domain_test.py
@@ -1,0 +1,306 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+from __future__ import absolute_import
+from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module
+import copy
+
+# Import Salt Testing libs
+from salttesting.unit import skipIf, TestCase
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, patch
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+# Import Salt libs
+import salt.config
+import salt.loader
+from salt.modules import boto_elasticsearch_domain
+
+# Import 3rd-party libs
+import logging
+
+# Import Mock libraries
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
+
+# pylint: disable=import-error,no-name-in-module
+try:
+    import boto3
+    from botocore.exceptions import ClientError
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+
+# pylint: enable=import-error,no-name-in-module
+
+# the boto_elasticsearch_domain module relies on the connect_to_region() method
+# which was added in boto 2.8.0
+# https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
+required_boto3_version = '1.2.1'
+
+region = 'us-east-1'
+access_key = 'GKTADJGHEIQSXMKKRBJ08H'
+secret_key = 'askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs'
+conn_parameters = {'region': region, 'key': access_key, 'keyid': secret_key, 'profile': {}}
+error_message = 'An error occurred (101) when calling the {0} operation: Test-defined error'
+error_content = {
+  'Error': {
+    'Code': 101,
+    'Message': "Test-defined error"
+  }
+}
+not_found_error = ClientError({
+    'Error': {
+        'Code': 'ResourceNotFoundException',
+        'Message': "Test-defined error"
+    }
+}, 'msg')
+domain_ret = dict(DomainName='testdomain',
+                  ElasticsearchClusterConfig={},
+                  EBSOptions={},
+                  AccessPolicies={},
+                  SnapshotOptions={},
+                  AdvancedOptions={})
+
+log = logging.getLogger(__name__)
+
+opts = salt.config.DEFAULT_MINION_OPTS
+context = {}
+utils = salt.loader.utils(opts, whitelist=['boto3'], context=context)
+
+boto_elasticsearch_domain.__utils__ = utils
+boto_elasticsearch_domain.__init__(opts)
+boto_elasticsearch_domain.__salt__ = {}
+
+
+def _has_required_boto():
+    '''
+    Returns True/False boolean depending on if Boto is installed and correct
+    version.
+    '''
+    if not HAS_BOTO:
+        return False
+    elif LooseVersion(boto3.__version__) < LooseVersion(required_boto3_version):
+        return False
+    else:
+        return True
+
+
+class BotoElasticsearchDomainTestCaseBase(TestCase):
+    conn = None
+
+    # Set up MagicMock to replace the boto3 session
+    def setUp(self):
+        context.clear()
+
+        self.patcher = patch('boto3.session.Session')
+        self.addCleanup(self.patcher.stop)
+        mock_session = self.patcher.start()
+
+        session_instance = mock_session.return_value
+        self.conn = MagicMock()
+        session_instance.client.return_value = self.conn
+
+
+class BotoElasticsearchDomainTestCaseMixin(object):
+    pass
+
+
+@skipIf(HAS_BOTO is False, 'The boto module must be installed.')
+@skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
+                                       ' or equal to version {0}'
+        .format(required_boto3_version))
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class BotoElasticsearchDomainTestCase(BotoElasticsearchDomainTestCaseBase, BotoElasticsearchDomainTestCaseMixin):
+    '''
+    TestCase for salt.modules.boto_elasticsearch_domain module
+    '''
+
+    def test_that_when_checking_if_a_domain_exists_and_a_domain_exists_the_domain_exists_method_returns_true(self):
+        '''
+        Tests checking domain existence when the domain already exists
+        '''
+        result = boto_elasticsearch_domain.exists(DomainName='testdomain', **conn_parameters)
+
+        self.assertTrue(result['exists'])
+
+    def test_that_when_checking_if_a_domain_exists_and_a_domain_does_not_exist_the_domain_exists_method_returns_false(self):
+        '''
+        Tests checking domain existence when the domain does not exist
+        '''
+        self.conn.describe_elasticsearch_domain.side_effect = not_found_error
+        result = boto_elasticsearch_domain.exists(DomainName='mydomain', **conn_parameters)
+
+        self.assertFalse(result['exists'])
+
+    def test_that_when_checking_if_a_domain_exists_and_boto3_returns_an_error_the_domain_exists_method_returns_error(self):
+        '''
+        Tests checking domain existence when boto returns an error
+        '''
+        self.conn.describe_elasticsearch_domain.side_effect = ClientError(error_content, 'list_domains')
+        result = boto_elasticsearch_domain.exists(DomainName='mydomain', **conn_parameters)
+
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('list_domains'))
+
+    def test_that_when_checking_domain_status_and_a_domain_exists_the_domain_status_method_returns_info(self):
+        '''
+        Tests checking domain existence when the domain already exists
+        '''
+        self.conn.describe_elasticsearch_domain.return_value = {'DomainStatus': domain_ret}
+        result = boto_elasticsearch_domain.status(DomainName='testdomain', **conn_parameters)
+
+        self.assertTrue(result['domain'])
+
+    def test_that_when_checking_domain_status_and_boto3_returns_an_error_the_domain_status_method_returns_error(self):
+        '''
+        Tests checking domain existence when boto returns an error
+        '''
+        self.conn.describe_elasticsearch_domain.side_effect = ClientError(error_content, 'list_domains')
+        result = boto_elasticsearch_domain.status(DomainName='mydomain', **conn_parameters)
+
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('list_domains'))
+
+    def test_that_when_describing_domain_it_returns_the_dict_of_properties_returns_true(self):
+        '''
+        Tests describing parameters if domain exists
+        '''
+        domainconfig = {}
+        for k, v in domain_ret.iteritems():
+            if k == 'DomainName':
+                continue
+            domainconfig[k] = {'Options': v}
+        self.conn.describe_elasticsearch_domain_config.return_value = {'DomainConfig': domainconfig}
+
+        result = boto_elasticsearch_domain.describe(DomainName=domain_ret['DomainName'], **conn_parameters)
+
+        log.warn(result)
+        desired_ret = copy.copy(domain_ret)
+        desired_ret.pop('DomainName')
+        self.assertEqual(result, {'domain': desired_ret})
+
+    def test_that_when_describing_domain_on_client_error_it_returns_error(self):
+        '''
+        Tests describing parameters failure
+        '''
+        self.conn.describe_elasticsearch_domain_config.side_effect = ClientError(error_content, 'list_domains')
+        result = boto_elasticsearch_domain.describe(DomainName='testdomain', **conn_parameters)
+        self.assertTrue('error' in result)
+
+    def test_that_when_creating_a_domain_succeeds_the_create_domain_method_returns_true(self):
+        '''
+        tests True domain created.
+        '''
+        self.conn.create_elasticsearch_domain.return_value = {'DomainStatus': domain_ret}
+        args = copy.copy(domain_ret)
+        args.update(conn_parameters)
+        result = boto_elasticsearch_domain.create(**args)
+
+        self.assertTrue(result['created'])
+
+    def test_that_when_creating_a_domain_fails_the_create_domain_method_returns_error(self):
+        '''
+        tests False domain not created.
+        '''
+        self.conn.create_elasticsearch_domain.side_effect = ClientError(error_content, 'create_domain')
+        args = copy.copy(domain_ret)
+        args.update(conn_parameters)
+        result = boto_elasticsearch_domain.create(**args)
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('create_domain'))
+
+    def test_that_when_deleting_a_domain_succeeds_the_delete_domain_method_returns_true(self):
+        '''
+        tests True domain deleted.
+        '''
+        result = boto_elasticsearch_domain.delete(DomainName='testdomain',
+                                                    **conn_parameters)
+        self.assertTrue(result['deleted'])
+
+    def test_that_when_deleting_a_domain_fails_the_delete_domain_method_returns_false(self):
+        '''
+        tests False domain not deleted.
+        '''
+        self.conn.delete_elasticsearch_domain.side_effect = ClientError(error_content, 'delete_domain')
+        result = boto_elasticsearch_domain.delete(DomainName='testdomain',
+                                                    **conn_parameters)
+        self.assertFalse(result['deleted'])
+
+    def test_that_when_updating_a_domain_succeeds_the_update_domain_method_returns_true(self):
+        '''
+        tests True domain updated.
+        '''
+        self.conn.update_elasticsearch_domain_config.return_value = {'DomainConfig': domain_ret}
+        args = copy.copy(domain_ret)
+        args.update(conn_parameters)
+        result = boto_elasticsearch_domain.update(**args)
+
+        self.assertTrue(result['updated'])
+
+    def test_that_when_updating_a_domain_fails_the_update_domain_method_returns_error(self):
+        '''
+        tests False domain not updated.
+        '''
+        self.conn.update_elasticsearch_domain_config.side_effect = ClientError(error_content, 'update_domain')
+        args = copy.copy(domain_ret)
+        args.update(conn_parameters)
+        result = boto_elasticsearch_domain.update(**args)
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('update_domain'))
+
+    def test_that_when_adding_tags_succeeds_the_add_tags_method_returns_true(self):
+        '''
+        tests True tags added.
+        '''
+        self.conn.describe_elasticsearch_domain.return_value = {'DomainStatus': domain_ret}
+        result = boto_elasticsearch_domain.add_tags(DomainName='testdomain', a='b', **conn_parameters)
+
+        self.assertTrue(result['tagged'])
+
+    def test_that_when_adding_tags_fails_the_add_tags_method_returns_false(self):
+        '''
+        tests False tags not added.
+        '''
+        self.conn.add_tags.side_effect = ClientError(error_content, 'add_tags')
+        self.conn.describe_elasticsearch_domain.return_value = {'DomainStatus': domain_ret}
+        result = boto_elasticsearch_domain.add_tags(DomainName=domain_ret['DomainName'], a='b', **conn_parameters)
+        self.assertFalse(result['tagged'])
+
+    def test_that_when_removing_tags_succeeds_the_remove_tags_method_returns_true(self):
+        '''
+        tests True tags removed.
+        '''
+        self.conn.describe_elasticsearch_domain.return_value = {'DomainStatus': domain_ret}
+        result = boto_elasticsearch_domain.remove_tags(DomainName=domain_ret['DomainName'], TagKeys=['a'], **conn_parameters)
+
+        self.assertTrue(result['tagged'])
+
+    def test_that_when_removing_tags_fails_the_remove_tags_method_returns_false(self):
+        '''
+        tests False tags not removed.
+        '''
+        self.conn.remove_tags.side_effect = ClientError(error_content, 'remove_tags')
+        self.conn.describe_elasticsearch_domain.return_value = {'DomainStatus': domain_ret}
+        result = boto_elasticsearch_domain.remove_tags(DomainName=domain_ret['DomainName'], TagKeys=['b'], **conn_parameters)
+        self.assertFalse(result['tagged'])
+
+    def test_that_when_listing_tags_succeeds_the_list_tags_method_returns_true(self):
+        '''
+        tests True tags listed.
+        '''
+        self.conn.describe_elasticsearch_domain.return_value = {'DomainStatus': domain_ret}
+        result = boto_elasticsearch_domain.list_tags(DomainName=domain_ret['DomainName'], **conn_parameters)
+
+        self.assertEqual(result['tags'], {})
+
+    def test_that_when_listing_tags_fails_the_list_tags_method_returns_false(self):
+        '''
+        tests False tags not listed.
+        '''
+        self.conn.list_tags.side_effect = ClientError(error_content, 'list_tags')
+        self.conn.describe_elasticsearch_domain.return_value = {'DomainStatus': domain_ret}
+        result = boto_elasticsearch_domain.list_tags(DomainName=domain_ret['DomainName'], **conn_parameters)
+        self.assertTrue(result['error'])
+
+
+if __name__ == '__main__':
+    from integration import run_tests  # pylint: disable=import-error
+    run_tests(BotoElasticsearchDomainTestCase, needs_daemon=False)
+

--- a/tests/unit/modules/boto_elasticsearch_domain_test.py
+++ b/tests/unit/modules/boto_elasticsearch_domain_test.py
@@ -38,6 +38,7 @@ except ImportError:
 # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
 required_boto3_version = '1.2.1'
 
+
 def _has_required_boto():
     '''
     Returns True/False boolean depending on if Boto is installed and correct
@@ -304,4 +305,3 @@ class BotoElasticsearchDomainTestCase(BotoElasticsearchDomainTestCaseBase, BotoE
 if __name__ == '__main__':
     from integration import run_tests  # pylint: disable=import-error
     run_tests(BotoElasticsearchDomainTestCase, needs_daemon=False)
-

--- a/tests/unit/modules/boto_elasticsearch_domain_test.py
+++ b/tests/unit/modules/boto_elasticsearch_domain_test.py
@@ -38,41 +38,6 @@ except ImportError:
 # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
 required_boto3_version = '1.2.1'
 
-region = 'us-east-1'
-access_key = 'GKTADJGHEIQSXMKKRBJ08H'
-secret_key = 'askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs'
-conn_parameters = {'region': region, 'key': access_key, 'keyid': secret_key, 'profile': {}}
-error_message = 'An error occurred (101) when calling the {0} operation: Test-defined error'
-error_content = {
-  'Error': {
-    'Code': 101,
-    'Message': "Test-defined error"
-  }
-}
-not_found_error = ClientError({
-    'Error': {
-        'Code': 'ResourceNotFoundException',
-        'Message': "Test-defined error"
-    }
-}, 'msg')
-domain_ret = dict(DomainName='testdomain',
-                  ElasticsearchClusterConfig={},
-                  EBSOptions={},
-                  AccessPolicies={},
-                  SnapshotOptions={},
-                  AdvancedOptions={})
-
-log = logging.getLogger(__name__)
-
-opts = salt.config.DEFAULT_MINION_OPTS
-context = {}
-utils = salt.loader.utils(opts, whitelist=['boto3'], context=context)
-
-boto_elasticsearch_domain.__utils__ = utils
-boto_elasticsearch_domain.__init__(opts)
-boto_elasticsearch_domain.__salt__ = {}
-
-
 def _has_required_boto():
     '''
     Returns True/False boolean depending on if Boto is installed and correct
@@ -84,6 +49,42 @@ def _has_required_boto():
         return False
     else:
         return True
+
+
+if _has_required_boto():
+    region = 'us-east-1'
+    access_key = 'GKTADJGHEIQSXMKKRBJ08H'
+    secret_key = 'askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs'
+    conn_parameters = {'region': region, 'key': access_key, 'keyid': secret_key, 'profile': {}}
+    error_message = 'An error occurred (101) when calling the {0} operation: Test-defined error'
+    error_content = {
+      'Error': {
+        'Code': 101,
+        'Message': "Test-defined error"
+      }
+    }
+    not_found_error = ClientError({
+        'Error': {
+            'Code': 'ResourceNotFoundException',
+            'Message': "Test-defined error"
+        }
+    }, 'msg')
+    domain_ret = dict(DomainName='testdomain',
+                      ElasticsearchClusterConfig={},
+                      EBSOptions={},
+                      AccessPolicies={},
+                      SnapshotOptions={},
+                      AdvancedOptions={})
+
+log = logging.getLogger(__name__)
+
+opts = salt.config.DEFAULT_MINION_OPTS
+context = {}
+utils = salt.loader.utils(opts, whitelist=['boto3'], context=context)
+
+boto_elasticsearch_domain.__utils__ = utils
+boto_elasticsearch_domain.__init__(opts)
+boto_elasticsearch_domain.__salt__ = {}
 
 
 class BotoElasticsearchDomainTestCaseBase(TestCase):

--- a/tests/unit/states/boto_elasticsearch_domain_test.py
+++ b/tests/unit/states/boto_elasticsearch_domain_test.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+from __future__ import absolute_import
+from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module
+
+# Import Salt Testing libs
+from salttesting.unit import skipIf, TestCase
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, patch
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+# Import Salt libs
+import salt.config
+import salt.loader
+
+# Import 3rd-party libs
+import logging
+
+# Import Mock libraries
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
+
+# pylint: disable=import-error,no-name-in-module,unused-import
+from unit.modules.boto_elasticsearch_domain_test import BotoElasticsearchDomainTestCaseMixin
+
+# Import 3rd-party libs
+try:
+    import boto
+    import boto3
+    from botocore.exceptions import ClientError
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+
+# pylint: enable=import-error,no-name-in-module,unused-import
+
+# the boto_elasticsearch_domain module relies on the connect_to_region() method
+# which was added in boto 2.8.0
+# https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
+required_boto3_version = '1.2.1'
+
+log = logging.getLogger(__name__)
+
+opts = salt.config.DEFAULT_MINION_OPTS
+context = {}
+utils = salt.loader.utils(opts, whitelist=['boto3'], context=context)
+serializers = salt.loader.serializers(opts)
+funcs = salt.loader.minion_mods(opts, context=context, utils=utils, whitelist=['boto_elasticsearch_domain'])
+salt_states = salt.loader.states(opts=opts, functions=funcs, utils=utils, whitelist=['boto_elasticsearch_domain'], serializers=serializers)
+
+
+def _has_required_boto():
+    '''
+    Returns True/False boolean depending on if Boto is installed and correct
+    version.
+    '''
+    if not HAS_BOTO:
+        return False
+    elif LooseVersion(boto3.__version__) < LooseVersion(required_boto3_version):
+        return False
+    else:
+        return True
+
+if _has_required_boto():
+    region = 'us-east-1'
+    access_key = 'GKTADJGHEIQSXMKKRBJ08H'
+    secret_key = 'askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs'
+    conn_parameters = {'region': region, 'key': access_key, 'keyid': secret_key, 'profile': {}}
+    error_message = 'An error occurred (101) when calling the {0} operation: Test-defined error'
+    not_found_error = ClientError({
+        'Error': {
+            'Code': 'ResourceNotFoundException',
+            'Message': "Test-defined error"
+        }
+    }, 'msg')
+    error_content = {
+      'Error': {
+        'Code': 101,
+        'Message': "Test-defined error"
+      }
+    }
+    domain_ret = dict(DomainName='testdomain',
+                  ElasticsearchClusterConfig={},
+                  EBSOptions={},
+                  AccessPolicies={},
+                  SnapshotOptions={},
+                  AdvancedOptions={})
+
+
+class BotoElasticsearchDomainStateTestCaseBase(TestCase):
+    conn = None
+
+    # Set up MagicMock to replace the boto3 session
+    def setUp(self):
+        context.clear()
+
+        self.patcher = patch('boto3.session.Session')
+        self.addCleanup(self.patcher.stop)
+        mock_session = self.patcher.start()
+
+        session_instance = mock_session.return_value
+        self.conn = MagicMock()
+        session_instance.client.return_value = self.conn
+
+
+@skipIf(HAS_BOTO is False, 'The boto module must be installed.')
+@skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
+                                       ' or equal to version {0}'
+        .format(required_boto3_version))
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class BotoElasticsearchDomainTestCase(BotoElasticsearchDomainStateTestCaseBase, BotoElasticsearchDomainTestCaseMixin):
+    '''
+    TestCase for salt.modules.boto_elasticsearch_domain state.module
+    '''
+
+    def test_present_when_domain_does_not_exist(self):
+        '''
+        Tests present on a domain that does not exist.
+        '''
+        self.conn.describe_elasticsearch_domain.side_effect = not_found_error
+        self.conn.describe_elasticsearch_domain_config.return_value = {'DomainConfig': domain_ret}
+        self.conn.create_elasticsearch_domain.return_value = {'DomainStatus': domain_ret}
+        result = salt_states['boto_elasticsearch_domain.present'](
+                         'domain present',
+                         **domain_ret)
+
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes']['new']['domain']['ElasticsearchClusterConfig'], None)
+
+    def test_present_when_domain_exists(self):
+        self.conn.describe_elasticsearch_domain.return_value = {'DomainStatus': domain_ret}
+        cfg = {}
+        for k, v in domain_ret.iteritems():
+            cfg[k] = {'Options': v}
+        cfg['AccessPolicies'] = {'Options': '{"a": "b"}'}
+        self.conn.describe_elasticsearch_domain_config.return_value = {'DomainConfig': cfg}
+        self.conn.update_elasticsearch_domain_config.return_value = {'DomainConfig': cfg}
+        result = salt_states['boto_elasticsearch_domain.present'](
+                         'domain present',
+                         **domain_ret)
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes'], {'new': {'AccessPolicies': {}}, 'old': {'AccessPolicies': {u'a': u'b'}}})
+
+    def test_present_with_failure(self):
+        self.conn.describe_elasticsearch_domain.side_effect = not_found_error
+        self.conn.describe_elasticsearch_domain_config.return_value = {'DomainConfig': domain_ret}
+        self.conn.create_elasticsearch_domain.side_effect = ClientError(error_content, 'create_domain')
+        result = salt_states['boto_elasticsearch_domain.present'](
+                         'domain present',
+                         **domain_ret)
+        self.assertFalse(result['result'])
+        self.assertTrue('An error occurred' in result['comment'])
+
+    def test_absent_when_domain_does_not_exist(self):
+        '''
+        Tests absent on a domain that does not exist.
+        '''
+        self.conn.describe_elasticsearch_domain.side_effect = not_found_error
+        result = salt_states['boto_elasticsearch_domain.absent']('test', 'mydomain')
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes'], {})
+
+    def test_absent_when_domain_exists(self):
+        self.conn.describe_elasticsearch_domain.return_value = {'DomainStatus': domain_ret}
+        self.conn.describe_elasticsearch_domain_config.return_value = {'DomainConfig': domain_ret}
+        result = salt_states['boto_elasticsearch_domain.absent']('test', domain_ret['DomainName'])
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes']['new']['domain'], None)
+
+    def test_absent_with_failure(self):
+        self.conn.describe_elasticsearch_domain.return_value = {'DomainStatus': domain_ret}
+        self.conn.describe_elasticsearch_domain_config.return_value = {'DomainConfig': domain_ret}
+        self.conn.delete_elasticsearch_domain.side_effect = ClientError(error_content, 'delete_domain')
+        result = salt_states['boto_elasticsearch_domain.absent']('test', domain_ret['DomainName'])
+        self.assertFalse(result['result'])
+        self.assertTrue('An error occurred' in result['comment'])


### PR DESCRIPTION
### What does this PR do?

Adds a module for managing Amazon Elasticsearch Service domains.
### What issues does this PR fix or reference?

None
### Previous Behavior

Functionality did not exist.
### New Behavior

Adds both module and state module for elasticsearch_domain.
### Tests written?
- [x] Yes
- [ ] No
