### PR TITLE
fixing init system detection on sles 11, refs #31617

### DIFF
--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -60,14 +60,19 @@ def __virtual__():
     if __grains__['os'] in enable:
         if __grains__['os'] == 'XenServer':
             return __virtualname__
+
+        if __grains__['os'] == 'SUSE':
+            if str(__grains__['osrelease']).startswith('11'):
+                return __virtualname__
+            else:
+                return (False, 'Cannot load rh_service module on SUSE > 11')
+
         try:
             osrelease = float(__grains__.get('osrelease', 0))
         except ValueError:
             return (False, 'Cannot load rh_service module: '
                            'osrelease grain, {0}, not a float,'.format(osrelease))
-        if __grains__['os'] == 'SUSE':
-            if osrelease >= 12:
-                return (False, 'Cannot load rh_service module on SUSE >= 12')
+
         if __grains__['os'] == 'Fedora':
             if osrelease > 15:
                 return (False, 'Cannot load rh_service module on Fedora >= 15')


### PR DESCRIPTION
### What does this PR do?

Fix init detection for SLES 11 
### What issues does this PR fix or reference?
#31617
### Previous Behavior

Returned false unable to check if service was running
Previous fix only worked when grain['osrelease'] was numeric,
sometimes value is string (e.g. "11 SP3")
### New Behavior

Returns **virtual** and uses the init system.
### Tests written?
- [ ] Yes
- [x] No

FYI @bechtoldt
