### PR TITLE
Change pkg name to less for suse pkg.info_installed test

### DIFF
--- a/tests/integration/modules/pkg.py
+++ b/tests/integration/modules/pkg.py
@@ -191,9 +191,9 @@ class PkgModuleTest(integration.ModuleCase,
             self.assertIn('rpm', keys)
             self.assertIn('yum', keys)
         elif os_family == 'Suse':
-            ret = self.run_function(func, ['bash-completion', 'zypper'])
+            ret = self.run_function(func, ['less', 'zypper'])
             keys = ret.keys()
-            self.assertIn('bash-completion', keys)
+            self.assertIn('less', keys)
             self.assertIn('zypper', keys)
 
 


### PR DESCRIPTION
### What does this PR do?

Changes the pkg to check for in pkg.info_installed from bash-completion to less
### What issues does this PR fix or reference?

NA - fixes a test
### Previous Behavior

The opensuse 13.2 tests were failling on jenkins and included this error in the logs:
"A command in 'pkg.info_installed' had a problem: package bash-completion is not installed"
### New Behavior

This will use the less package instead of bash-completion, which should not fail, because the less package should be installed by default. 
### Tests written?
- [x] Yes
- [ ] No
