### PR TITLE
Create salt-proxy instantiated service file

### DIFF
--- a/pkg/salt-proxy@.service
+++ b/pkg/salt-proxy@.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=salt-proxy service
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/salt-proxy --proxyid=%I
+Type=simple
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
### What does this PR do?

Add a systemd service file for salt-proxy. 
### What issues does this PR fix or reference?

None
### Previous Behavior

Every instance of a salt-proxy was custom made. 
### New Behavior

Ship an upstream salt-proxy service file.
### Tests written?
- [ ] Yes
- [x] No

Add a systemd service file for salt-proxy. 

Instantiate a new proxy service with proxyid=p8000:

```
# systemctl enable salt-proxy\@p8000.service
# systemctl start salt-proxy\@p8000.service
```
