### PR TITLE
Allow for users to set expiration date of -1.

### DIFF
--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -72,7 +72,7 @@ def _changes(name,
              maxdays=999999,
              inactdays=0,
              warndays=7,
-             expire=-1,
+             expire=None,
              win_homedrive=None,
              win_profile=None,
              win_logonscript=None,
@@ -142,7 +142,7 @@ def _changes(name,
             change['inactdays'] = inactdays
         if warndays and warndays is not 7 and lshad['warn'] != warndays:
             change['warndays'] = warndays
-        if expire and expire is not -1 and lshad['expire'] != expire:
+        if expire and lshad['expire'] != expire:
             change['expire'] = expire
     # GECOS fields
     if isinstance(fullname, string_types):


### PR DESCRIPTION
### What does this PR do?

Allow for users to set expiration date of -1.
### What issues does this PR fix or reference?

N/A
### Previous Behavior

Users that previously had an expiration date (expire > -1) could not set their expiration date to -1 (because this was the default value).
### New Behavior

Default value is now None. Any other value (including -1) will set off a change.
### Tests written?
- [ ] Yes
- [X] No
