### PR TITLE
Fix template on contents 2015.8

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3324,6 +3324,61 @@ def source_list(source, source_hash, saltenv):
         return source, source_hash
 
 
+def apply_template_on_contents(
+        contents,
+        template,
+        context,
+        defaults,
+        saltenv):
+    '''
+    Return the contents after applying the templating engine
+
+    contents
+        template string
+
+    template
+        template format
+
+    context
+        Overrides default context variables passed to the template.
+
+    defaults
+        Default context passed to the template.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' file.apply_template_on_contents \\
+            contents='This is a {{ template }} string.' \\
+            template=jinja \\
+            "context={}" "defaults={'template': 'cool'}" \\
+            saltenv=base
+    '''
+    if template in salt.utils.templates.TEMPLATE_REGISTRY:
+        context_dict = defaults if defaults else {}
+        if context:
+            context_dict.update(context)
+        # Apply templating
+        contents = salt.utils.templates.TEMPLATE_REGISTRY[template](
+            contents,
+            from_str=True,
+            to_str=True,
+            context=context_dict,
+            saltenv=saltenv,
+            grains=__grains__,
+            pillar=__pillar__,
+            salt=__salt__,
+            opts=__opts__)['data'].encode('utf-8')
+    else:
+        ret = {}
+        ret['result'] = False
+        ret['comment'] = ('Specified template format {0} is not supported'
+                          ).format(template)
+        return ret
+    return contents
+
+
 def get_managed(
         name,
         template,

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1477,6 +1477,23 @@ def managed(name,
             contents = os.linesep.join(validated_contents)
             if contents_newline and not contents.endswith(os.linesep):
                 contents += os.linesep
+        if template:
+            contents = __salt__['file.apply_template_on_contents'](
+                contents,
+                template=template,
+                context=context,
+                defaults=defaults,
+                saltenv=__env__)
+            if not isinstance(contents, six.string_types):
+                if 'result' in contents:
+                    ret['result'] = contents['result']
+                else:
+                    ret['result'] = False
+                if 'comment' in contents:
+                    ret['comment'] = contents['comment']
+                else:
+                    ret['comment'] = 'Error while applying template on contents'
+                return ret
 
     # Make sure that leading zeros stripped by YAML loader are added back
     mode = __salt__['config.manage_mode'](mode)

--- a/tests/unit/modules/file_test.py
+++ b/tests/unit/modules/file_test.py
@@ -25,7 +25,12 @@ filemod.__salt__ = {
     'cmd.run': cmdmod.run,
     'cmd.run_all': cmdmod.run_all
 }
-filemod.__opts__ = {'test': False}
+filemod.__opts__ = {
+    'test': False,
+    'file_roots': {'base': 'tmp'},
+    'pillar_roots': {'base': 'tmp'},
+    'cachedir': 'tmp',
+}
 
 SED_CONTENT = """test
 some
@@ -33,6 +38,9 @@ content
 /var/lib/foo/app/test
 here
 """
+
+filemod.__grains__ = {}
+filemod.__pillar__ = {}
 
 
 class FileReplaceTestCase(TestCase):
@@ -515,6 +523,20 @@ class FileModuleTestCase(TestCase):
         group = 5034
         ret = filemod.group_to_gid(group)
         self.assertEqual(ret, group)
+
+    def test_apply_template_on_contents(self):
+        '''
+        Tests that the templating engine works on string contents
+        '''
+        contents = 'This is a {{ template }}.'
+        defaults = {'template': 'templated file'}
+        ret = filemod.apply_template_on_contents(
+            contents,
+            template='jinja',
+            context={'opts': filemod.__opts__},
+            defaults=defaults,
+            saltenv='base')
+        self.assertEqual(ret, 'This is a templated file.')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?

Allow to use a templating engine with `contents` and `contents_pillar` (or any contents string) on `file.managed`
### What issues does this PR fix or reference?
#8927
#14664
#26944
### Previous Behavior

The `template` parameter does nothing on string contents.
### New Behavior

The `template` parameter is applied on string contents.
### Tests written?
- [X] Yes
- [ ] No
