### PR TITLE
Enhance junos

### DIFF
--- a/doc/ref/modules/all/salt.modules.slsutil.rst
+++ b/doc/ref/modules/all/salt.modules.slsutil.rst
@@ -1,0 +1,6 @@
+====================
+salt.modules.slsutil
+====================
+
+.. automodule:: salt.modules.slsutil
+    :members:

--- a/salt/grains/junos.py
+++ b/salt/grains/junos.py
@@ -6,7 +6,7 @@ Thus, some grains make sense to get them from the minion (PYTHONPATH), but other
 don't (ip_interfaces)
 '''
 from __future__ import absolute_import
-
+from jnpr.junos.device import Device
 import logging
 
 __proxyenabled__ = ['junos']
@@ -43,11 +43,16 @@ def defaults():
 
 
 def facts():
-    if 'junos.facts' in __proxy__:
-        facts = __proxy__['junos.facts']()
-        facts['version_info'] = 'override'
-        return facts
-    return None
+    #This is a temporary work around until __proxy__ can be called from the grains.
+    
+    dev = Device(user=__opts__['proxy']['username'],
+                    host=__opts__['proxy']['host'],
+                    password=__opts__['proxy']['passwd'])
+    dev.open()
+    facts = dev.facts
+    facts['version_info'] = 'override'
+    dev.close()
+    return facts
 
 
 def os_family():

--- a/salt/grains/junos.py
+++ b/salt/grains/junos.py
@@ -1,18 +1,16 @@
 # -*- coding: utf-8 -*-
 '''
 Grains for junos.
-NOTE this is a little complicated--junos can only be accessed via salt-proxy-minion.
-Thus, some grains make sense to get them from the minion (PYTHONPATH), but others
-don't (ip_interfaces)
+NOTE this is a little complicated--junos can only be accessed
+via salt-proxy-minion.Thus, some grains make sense to get them
+from the minion (PYTHONPATH), but others don't (ip_interfaces)
 '''
 from __future__ import absolute_import
 from jnpr.junos.device import Device
 import logging
 
 __proxyenabled__ = ['junos']
-
 __virtualname__ = 'junos'
-
 log = logging.getLogger(__name__)
 
 
@@ -28,7 +26,6 @@ def _remove_complex_types(dictionary):
     Linode-python is now returning some complex types that
     are not serializable by msgpack.  Kill those.
     '''
-
     for k, v in dictionary.iteritems():
         if isinstance(v, dict):
             dictionary[k] = _remove_complex_types(v)
@@ -43,10 +40,11 @@ def defaults():
 
 
 def facts():
-    #This is a temporary work around until __proxy__ can be called from the grains.   
+    # This is a temporary work around until __proxy__ can be called from the
+    # grains.
     dev = Device(user=__opts__['proxy']['username'],
-                    host=__opts__['proxy']['host'],
-                    password=__opts__['proxy']['passwd'])
+                 host=__opts__['proxy']['host'],
+                 password=__opts__['proxy']['passwd'])
     dev.open()
     facts = dev.facts
     facts['version_info'] = 'override'

--- a/salt/grains/junos.py
+++ b/salt/grains/junos.py
@@ -43,8 +43,7 @@ def defaults():
 
 
 def facts():
-    #This is a temporary work around until __proxy__ can be called from the grains.
-    
+    #This is a temporary work around until __proxy__ can be called from the grains.   
     dev = Device(user=__opts__['proxy']['username'],
                     host=__opts__['proxy']['host'],
                     password=__opts__['proxy']['passwd'])

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -47,6 +47,7 @@ def __virtual__():
         return (False, 'The junos module could not be \
                 loaded: junos-eznc or proxy could not be loaded.')
 
+
 def facts_refresh():
     '''
     Reload the facts dictionary from the device.  Usually only needed
@@ -55,7 +56,7 @@ def facts_refresh():
     Usage:
 
     .. code-block:: bash
- 
+
         salt 'device_name' junos.facts_refresh
 
     '''
@@ -65,7 +66,7 @@ def facts_refresh():
     try:
         ret['message'] = conn.facts_refresh()
 
-    except Exception as exception:        
+    except Exception as exception:
         ret['message'] = 'Execution failed due to "{0}"'.format(exception)
         ret['out'] = False
 
@@ -92,18 +93,19 @@ def facts():
 
 def call_rpc(cmd=None, *args, **kwargs):
     '''
-    This function executes the rpc provided as arguments on the junos device. The returned data can be 
-    stored in a file whose destination can be specified with 'dest' keyword in the arguments.
+    This function executes the rpc provided as arguments on the junos device.
+    The returned data can be stored in a file whose destination can be
+    specified with 'dest' keyword in the arguments.
 
     Usage:
 
     .. code-block:: bash
 
-        salt 'device_name' junos.call_rpc 'get config' '<configuration><system/></configuration>' terse=True
+        salt 'device' junos.call_rpc 'get config' '<configuration><system/></configuration>' terse=True
 
-        salt 'device_name' junos.call_rpc 'get-chassis-inventory' dest=/home/user/rpc_information.txt
+        salt 'device' junos.call_rpc 'get-chassis-inventory' dest=/home/user/rpc_information.txt
 
-    
+
     Options:
       * cmd: the rpc to be executed
       * args: other arguments as taken by rpc call of PyEZ
@@ -119,7 +121,6 @@ def call_rpc(cmd=None, *args, **kwargs):
     else:
         op.update(kwargs)
 
-    
     for k, v in op.iteritems():
         op[k] = str(v)
 
@@ -128,12 +129,14 @@ def call_rpc(cmd=None, *args, **kwargs):
             filter_reply = None
             if len(args) > 0:
                 filter_reply = etree.XML(args[0])
-            ret['message'] = json.dumps(getattr(conn.rpc, cmd.replace('-', '_').replace(' ', '_'))(filter_reply, options=op))           
+            ret['message'] = json.dumps(getattr(conn.rpc, cmd.replace(
+                '-', '_').replace(' ', '_'))(filter_reply, options=op))
         else:
-            ret['message'] = json.dumps(getattr(conn.rpc, cmd.replace('-', '_').replace(' ', '_'))(op))
-           
+            ret['message'] = json.dumps(
+                getattr(conn.rpc, cmd.replace('-', '_').replace(' ', '_'))(op))
+
     except Exception as exception:
-        
+
         ret['message'] = 'Execution failed due to "{0}"'.format(exception)
         ret['out'] = False
 
@@ -144,7 +147,7 @@ def call_rpc(cmd=None, *args, **kwargs):
 
     return ret
 
-    
+
 def set_hostname(hostname=None, commit_change=True):
     '''
     To set the name of the device.
@@ -155,10 +158,10 @@ def set_hostname(hostname=None, commit_change=True):
 
         salt 'device_name' junos.set_hostname hostname=salt-device
 
-    
+
     Options:
       * hostname: The name to be set.
-      * commit_change: Whether to commit the changes made by this module.(default=True)
+      * commit_change: Whether to commit the changes.(default=True)
     '''
     conn = __proxy__['junos.conn']()
     ret = dict()
@@ -201,7 +204,8 @@ def commit():
             ret['message'] = 'Commit Successful.'
         except Exception as exception:
             ret['out'] = False
-            ret['message'] = 'Pre-commit check succeeded but actual commit failed with "{0}"'.format(exception)
+            ret['message'] = 'Pre-commit check succeeded but actual commit failed with "{0}"'.format(
+                exception)
     else:
         ret['out'] = False
         ret['message'] = 'Pre-commit check failed.'
@@ -222,7 +226,7 @@ def rollback():
     '''
     ret = dict()
     conn = __proxy__['junos.conn']()
-    
+
     ret['out'] = conn.cu.rollback(0)
 
     if ret['out']:
@@ -250,6 +254,7 @@ def diff():
     ret['message'] = conn.cu.diff()
 
     return ret
+
 
 def ping():
     '''
@@ -282,7 +287,7 @@ def cli(command=None):
 
         salt 'device_name' junos.cli 'show version'
 
-    
+
     Options:
       * command: The command that need to be executed on Junos CLI.
     '''
@@ -291,6 +296,7 @@ def cli(command=None):
     ret['message'] = conn.cli(command)
     ret['out'] = True
     return ret
+
 
 def shutdown(time=0):
     '''
@@ -302,7 +308,7 @@ def shutdown(time=0):
 
         salt 'device_name' junos.shutdown 10
 
-    
+
     Options:
       * time: Time in seconds after which the device should shutdown (default=0)
     '''
@@ -320,6 +326,7 @@ def shutdown(time=0):
 
     return ret
 
+
 def install_config(path=None, **kwargs):
     '''
     Installs the given configuration file into the candidate configuration.
@@ -331,7 +338,7 @@ def install_config(path=None, **kwargs):
 
         salt 'device_name' junos.install_config '/home/user/config.set' timeout=300
 
-    
+
     Options:
       * path: Path where the configuration file is present.
       * kwargs: keyworded arguments taken by load fucntion of PyEZ
@@ -344,15 +351,16 @@ def install_config(path=None, **kwargs):
         conn.timeout = kwargs['timeout']
 
     options = {'path': path}
-  
+
     try:
         conn.cu.load(**options)
         conn.cu.pdiff()
 
     except Exception as exception:
-        ret['message'] = 'Could not load configuration due to : "{0}"'.format(exception)
+        ret['message'] = 'Could not load configuration due to : "{0}"'.format(
+            exception)
         ret['out'] = False
-    
+
     if conn.cu.commit_check():
         ret['message'] = 'Successfully loaded and committed!'
         conn.cu.commit()
@@ -360,7 +368,7 @@ def install_config(path=None, **kwargs):
         ret['message'] = 'Commit check failed.'
         ret['out'] = False
         conn.cu.rollback()
-        
+
     return ret
 
 
@@ -399,7 +407,7 @@ def install_os(path=None, **kwargs):
 
         salt 'device_name' junos.install_os '/home/user/junos_image.tgz' reboot=True
 
-    
+
     Options
       * path: Path where the image file is present.
       * kwargs: keyworded arguments to be given such as timeout, reboot etc
@@ -419,11 +427,12 @@ def install_os(path=None, **kwargs):
         ret['message'] = 'Installation failed due to : "{0}"'.format(exception)
         ret['out'] = False
 
-    if 'reboot' in kwargs and kwargs['reboot'] == True:
+    if 'reboot' in kwargs and kwargs['reboot'] is True:
         rbt = conn.sw.reboot()
         ret['message'] = 'Successfully installed and rebooted!'
 
     return ret
+
 
 def file_copy(src=None, dest=None):
     '''
@@ -435,7 +444,7 @@ def file_copy(src=None, dest=None):
 
         salt 'device_name' junos.file_copy /home/m2/info.txt info_copy.txt
 
-    
+
     Options
       * src: The sorce path where the file is kept.
       * dest: The destination path where the file will be copied.
@@ -446,8 +455,9 @@ def file_copy(src=None, dest=None):
     try:
         with SCP(conn, progress=True) as scp:
             scp.put(src, dest)
-        ret['message'] = 'Successfully copied file from {0} to {1}'.format(src, dest)
-    
+        ret['message'] = 'Successfully copied file from {0} to {1}'.format(
+            src, dest)
+
     except Exception as exception:
         ret['message'] = 'Could not copy file : "{0}"'.format(exception)
         ret['out'] = False

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -1,22 +1,22 @@
 # -*- coding: utf-8 -*-
 '''
-Module for interfacing to Junos devices
-
-ALPHA QUALITY code.
-
+Module for interfacing to Junos devices.
 '''
 from __future__ import absolute_import
 
 # Import python libraries
 import logging
-
+import json
+from lxml import etree
 # Juniper interface libraries
 # https://github.com/Juniper/py-junos-eznc
 
 
 try:
     # pylint: disable=W0611
-    import jnpr.junos
+    from jnpr.junos import Device
+    from jnpr.junos.utils.sw import SW
+    from jnpr.junos.utils.scp import SCP
     import jnpr.junos.utils
     import jnpr.junos.cfg
     # pylint: enable=W0611
@@ -47,21 +47,120 @@ def __virtual__():
         return (False, 'The junos module could not be \
                 loaded: junos-eznc or proxy could not be loaded.')
 
-
 def facts_refresh():
     '''
     Reload the facts dictionary from the device.  Usually only needed
     if the device configuration is changed by some other actor.
+
+    Usage:
+
+    .. code-block:: bash
+        
+        salt 'device_name' junos.facts_refresh
+
     '''
-    return __proxy__['junos.refresh']()
+    conn = __proxy__['junos.conn']()
+    ret = dict()
+    ret['out'] = True
+    try:
+        ret['message'] = conn.facts_refresh()
+
+    except Exception as exception:
+        
+        ret['message'] = 'Execution failed due to "{0}"'.format(exception)
+        ret['out'] = False
+
+    return ret
 
 
-def call_rpc():
-    return __proxy__['junos.rpc']()
+def facts():
+    '''
+    Displays the facts gathered during the connection.
+
+    Usage:
+
+    .. code-block:: bash
+
+        salt 'device_name' junos.facts
+
+    '''
+    conn = __proxy__['junos.conn']()
+    ret = dict()
+    ret['message'] = json.dumps(conn.facts)
+    ret['out'] = True
+    return ret
 
 
+def call_rpc(cmd=None,*args,**kwargs):
+    '''
+    This function executes the rpc provided as arguments on the junos device. The returned data can be 
+    stored in a file whose destination can be specified with 'dest' keyword in the arguments.
+
+    Usage:
+
+    .. code-block:: bash
+
+        salt 'device_name' junos.call_rpc 'get config' '<configuration><system/></configuration>' terse=True
+
+        salt 'device_name' junos.call_rpc 'get-chassis-inventory' dest=/home/user/rpc_information.txt
+
+    
+    Options:
+      * cmd: the rpc to be executed
+      * args: other arguments as taken by rpc call of PyEZ
+      * kwargs: keyworded arguments taken by rpc call of PyEZ
+    '''
+    conn = __proxy__['junos.conn']()
+    ret = dict()
+    ret['out'] = True
+
+    op={}
+    if '__pub_arg' in kwargs and isinstance(kwargs['__pub_arg'][-1], dict):
+        op.update(kwargs['__pub_arg'][-1])
+    else:
+        op.update(kwargs)
+
+    
+    for k,v in op.iteritems():
+        op[k] = str(v)
+
+    try:
+        if cmd in ['get-config','get_config','get config']:
+            filter_reply = None
+            if len(args)>0:
+                filter_reply = etree.XML(args[0])
+            ret['message'] = json.dumps(getattr(conn.rpc, cmd.replace('-', '_').replace(' ','_'))(filter_reply,options=op))           
+        else:
+            ret['message'] = json.dumps(getattr(conn.rpc, cmd.replace('-', '_').replace(' ','_'))(op))
+           
+    except Exception as exception:
+        
+        ret['message'] = 'Execution failed due to "{0}"'.format(exception)
+        ret['out'] = False
+
+    if 'dest' in op:
+        f = open(op['dest'],'w')
+        f.write(ret['message'])
+        f.close()
+
+    return ret
+
+    
 def set_hostname(hostname=None, commit_change=True):
+    '''
+    To set the name of the device.
 
+    Usage:
+
+    .. code-block:: bash
+
+        salt 'device_name' junos.set_hostname hostname=salt-device
+
+    
+    Options:
+      * hostname: The name to be set.
+      * commit_change: Whether to commit the changes made by this module.(default=True)
+    '''
     conn = __proxy__['junos.conn']()
     ret = dict()
     if hostname is None:
@@ -71,7 +170,6 @@ def set_hostname(hostname=None, commit_change=True):
     # Added to recent versions of JunOs
     # Use text format instead
     set_string = 'set system host-name {0}'.format(hostname)
-
     conn.cu.load(set_string, format='set')
     if commit_change:
         return commit()
@@ -83,6 +181,16 @@ def set_hostname(hostname=None, commit_change=True):
 
 
 def commit():
+    '''
+    To commit the changes loaded in the candidate configuration.
+
+    Usage:
+
+    .. code-block:: bash
+
+        salt 'device_name' junos.commit
+
+    '''
 
     conn = __proxy__['junos.conn']()
     ret = {}
@@ -103,9 +211,19 @@ def commit():
 
 
 def rollback():
+    '''
+    To rollback the last committed configuration changes
+
+    Usage:
+
+    .. code-block:: bash
+
+        salt 'device_name' junos.rollback
+
+    '''
     ret = dict()
     conn = __proxy__['junos.conn']()
-
+    
     ret['out'] = conn.cu.rollback(0)
 
     if ret['out']:
@@ -117,7 +235,16 @@ def rollback():
 
 
 def diff():
+    '''
+    Gives the difference between the candidate and the current configuration.
 
+    Usage:
+
+    .. code-block:: bash
+
+        salt 'device_name' junos.diff
+
+    '''
     conn = __proxy__['junos.conn']()
     ret = dict()
     ret['out'] = True
@@ -125,21 +252,205 @@ def diff():
 
     return ret
 
-
 def ping():
+    '''
+    To check the connection with the device
 
+    Usage:
+
+    .. code-block:: bash
+
+        salt 'device_name' junos.ping
+
+    '''
     conn = __proxy__['junos.conn']()
     ret = dict()
     ret['message'] = conn.probe()
-    ret['out'] = True
-
+    if ret['message']:
+        ret['out'] = True
+    else:
+        ret['out'] = False
     return ret
 
 
-def cli(command):
+def cli(command=None):
+    '''
+    Executes the CLI commands and reuturns the text output.
 
+    Usage:
+
+    .. code-block:: bash
+
+        salt 'device_name' junos.cli 'show version'
+
+    
+    Options:
+      * command: The command that need to be executed on Junos CLI.
+    '''
     conn = __proxy__['junos.conn']()
     ret = dict()
     ret['message'] = conn.cli(command)
     ret['out'] = True
+    return ret
+
+def shutdown(time=0):
+    '''
+    Shuts down the device after the given time.
+
+    Usage:
+
+    .. code-block:: bash
+
+        salt 'device_name' junos.shutdown 10
+
+    
+    Options:
+      * time: Time in seconds after which the device should shutdown (default=0)
+    '''
+    conn = __proxy__['junos.conn']()
+    ret = dict()
+    sw = SW(conn)
+    try:
+        shut = sw.poweroff()
+        shut(time)
+        ret['message'] = 'Successfully powered off.'
+        ret['out'] = False
+    except Exception as exception:
+        ret['message'] = 'Could not poweroff'
+        ret['out'] = False
+
+    return ret
+
+def install_config(path=None,**kwargs):
+    '''
+    Installs the given configuration file into the candidate configuration.
+    Commits the changes if the commit checks or throws an error.
+
+    Usage:
+
+    .. code-block:: bash
+
+        salt 'device_name' junos.install_config '/home/user/config.set' timeout=300
+
+    
+    Options:
+      * path: Path where the configuration file is present.
+      * kwargs: keyworded arguments taken by load fucntion of PyEZ
+    '''
+    conn = __proxy__['junos.conn']()
+    ret = dict()
+    ret['out'] = True
+
+    if 'timeout' in kwargs:
+        conn.timeout = kwargs['timeout']
+
+    options = {'path': path}
+  
+    try:
+        conn.cu.load(**options)
+        conn.cu.pdiff()
+
+    except Exception as exception:
+        ret['message'] = 'Could not load configuration due to : "{0}"'.format(exception)
+        ret['out'] = False
+    
+    if conn.cu.commit_check():
+        ret['message'] = 'Successfully loaded and committed!'
+        conn.cu.commit()
+    else:
+        ret['message'] = 'Commit check failed.'
+        ret['out'] = False
+        conn.cu.rollback()
+        
+    return ret
+
+
+def zeroize():
+    '''
+    Resets the device to default factory settings
+
+    Usage:
+
+    .. code-block:: bash
+
+        salt 'device_name' junos.zeroize
+
+    '''
+    conn = __proxy__['junos.conn']()
+    ret = dict()
+    ret['out'] = True
+    try:
+        conn.cli('request system zeroize')
+        ret['message'] = 'Completed zeroize and rebooted'
+    except Exception as exception:
+        ret['message'] = 'Could not zeroize due to : "{0}"'.format(exception)
+        ret['out'] = False
+
+    return ret
+
+
+def install_os(path=None,**kwargs):
+    '''
+    Installs the given image on the device. After the installation is complete the device is rebooted,
+    if reboot=True is given as a keyworded argument.
+
+    Usage:
+
+    .. code-block:: bash
+
+        salt 'device_name' junos.install_os '/home/user/junos_image.tgz' reboot=True
+
+    
+    Options
+      * path: Path where the image file is present.
+      * kwargs: keyworded arguments to be given such as timeout, reboot etc
+
+    '''
+    conn = __proxy__['junos.conn']()
+    ret = dict()
+    ret['out'] = True
+
+    if 'timeout' in kwargs:
+        conn.timeout = kwargs['timeout']
+
+    try:
+        install = conn.sw.install(path,progress=True)
+        ret['message'] = 'Installed the os.'
+    except Exception as exception:
+        ret['message'] = 'Installation failed due to : "{0}"'.format(exception)
+        ret['out'] = False
+
+    if 'reboot' in kwargs and kwargs['reboot'] == True:
+        rbt = conn.sw.reboot()
+        ret['message'] = 'Successfully installed and rebooted!'
+
+    return ret
+
+def file_copy(src=None,dest=None):
+    '''
+    Copies the file from the local device to the junos device.
+
+    Usage:
+
+    .. code-block:: bash
+
+        salt 'device_name' junos.file_copy /home/m2/info.txt info_copy.txt
+
+    
+    Options
+      * src: The sorce path where the file is kept.
+      * dest: The destination path where the file will be copied.
+    '''
+    conn = __proxy__['junos.conn']()
+    ret = dict()
+    ret['out'] = True
+    try:
+        with SCP(conn, progress=True) as scp:
+            scp.put(src,dest)
+        ret['message'] = 'Successfully copied file from {0} to {1}'.format(src,dest)
+    
+    except Exception as exception:
+        ret['message'] = 'Could not copy file : "{0}"'.format(exception)
+        ret['out'] = False
+
     return ret

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -55,7 +55,7 @@ def facts_refresh():
     Usage:
 
     .. code-block:: bash
-        
+ 
         salt 'device_name' junos.facts_refresh
 
     '''
@@ -65,8 +65,7 @@ def facts_refresh():
     try:
         ret['message'] = conn.facts_refresh()
 
-    except Exception as exception:
-        
+    except Exception as exception:        
         ret['message'] = 'Execution failed due to "{0}"'.format(exception)
         ret['out'] = False
 
@@ -91,7 +90,7 @@ def facts():
     return ret
 
 
-def call_rpc(cmd=None,*args,**kwargs):
+def call_rpc(cmd=None, *args, **kwargs):
     '''
     This function executes the rpc provided as arguments on the junos device. The returned data can be 
     stored in a file whose destination can be specified with 'dest' keyword in the arguments.
@@ -114,24 +113,24 @@ def call_rpc(cmd=None,*args,**kwargs):
     ret = dict()
     ret['out'] = True
 
-    op={}
+    op = dict()
     if '__pub_arg' in kwargs and isinstance(kwargs['__pub_arg'][-1], dict):
         op.update(kwargs['__pub_arg'][-1])
     else:
         op.update(kwargs)
 
     
-    for k,v in op.iteritems():
+    for k, v in op.iteritems():
         op[k] = str(v)
 
     try:
-        if cmd in ['get-config','get_config','get config']:
+        if cmd in ['get-config', 'get_config', 'get config']:
             filter_reply = None
-            if len(args)>0:
+            if len(args) > 0:
                 filter_reply = etree.XML(args[0])
-            ret['message'] = json.dumps(getattr(conn.rpc, cmd.replace('-', '_').replace(' ','_'))(filter_reply,options=op))           
+            ret['message'] = json.dumps(getattr(conn.rpc, cmd.replace('-', '_').replace(' ', '_'))(filter_reply, options=op))           
         else:
-            ret['message'] = json.dumps(getattr(conn.rpc, cmd.replace('-', '_').replace(' ','_'))(op))
+            ret['message'] = json.dumps(getattr(conn.rpc, cmd.replace('-', '_').replace(' ', '_'))(op))
            
     except Exception as exception:
         
@@ -139,7 +138,7 @@ def call_rpc(cmd=None,*args,**kwargs):
         ret['out'] = False
 
     if 'dest' in op:
-        f = open(op['dest'],'w')
+        f = open(op['dest'], 'w')
         f.write(ret['message'])
         f.close()
 
@@ -321,7 +320,7 @@ def shutdown(time=0):
 
     return ret
 
-def install_config(path=None,**kwargs):
+def install_config(path=None, **kwargs):
     '''
     Installs the given configuration file into the candidate configuration.
     Commits the changes if the commit checks or throws an error.
@@ -389,7 +388,7 @@ def zeroize():
     return ret
 
 
-def install_os(path=None,**kwargs):
+def install_os(path=None, **kwargs):
     '''
     Installs the given image on the device. After the installation is complete the device is rebooted,
     if reboot=True is given as a keyworded argument.
@@ -414,7 +413,7 @@ def install_os(path=None,**kwargs):
         conn.timeout = kwargs['timeout']
 
     try:
-        install = conn.sw.install(path,progress=True)
+        install = conn.sw.install(path, progress=True)
         ret['message'] = 'Installed the os.'
     except Exception as exception:
         ret['message'] = 'Installation failed due to : "{0}"'.format(exception)
@@ -426,7 +425,7 @@ def install_os(path=None,**kwargs):
 
     return ret
 
-def file_copy(src=None,dest=None):
+def file_copy(src=None, dest=None):
     '''
     Copies the file from the local device to the junos device.
 
@@ -446,8 +445,8 @@ def file_copy(src=None,dest=None):
     ret['out'] = True
     try:
         with SCP(conn, progress=True) as scp:
-            scp.put(src,dest)
-        ret['message'] = 'Successfully copied file from {0} to {1}'.format(src,dest)
+            scp.put(src, dest)
+        ret['message'] = 'Successfully copied file from {0} to {1}'.format(src, dest)
     
     except Exception as exception:
         ret['message'] = 'Could not copy file : "{0}"'.format(exception)

--- a/salt/proxy/junos.py
+++ b/salt/proxy/junos.py
@@ -30,8 +30,8 @@ def init(opts):
     '''
     log.debug('Opening connection to junos')
     thisproxy['conn'] = jnpr.junos.Device(user=opts['proxy']['username'],
-                                            host=opts['proxy']['host'],
-                                            password=opts['proxy']['passwd'])
+                                          host=opts['proxy']['host'],
+                                          password=opts['proxy']['passwd'])
     thisproxy['conn'].open()
     thisproxy['conn'].bind(cu=jnpr.junos.utils.config.Config)
     thisproxy['conn'].bind(sw=jnpr.junos.utils.sw.SW)
@@ -51,6 +51,7 @@ def proxytype():
 def id(opts):
     return thisproxy['conn'].facts['hostname']
 
+
 def ping():
     '''
     Ping?  Pong!
@@ -67,5 +68,6 @@ def shutdown(opts):
     log.debug('Proxy module {0} shutting down!!'.format(opts['id']))
     try:
         thisproxy['conn'].close()
+
     except Exception:
         pass

--- a/salt/proxy/junos.py
+++ b/salt/proxy/junos.py
@@ -10,9 +10,11 @@ from __future__ import absolute_import
 import logging
 
 # Import 3rd-party libs
+from jnpr.junos import Device
 import jnpr.junos
 import jnpr.junos.utils
 import jnpr.junos.utils.config
+import jnpr.junos.utils.sw
 import json
 HAS_JUNOS = True
 
@@ -21,7 +23,6 @@ __proxyenabled__ = ['junos']
 thisproxy = {}
 
 log = logging.getLogger(__name__)
-
 
 def init(opts):
     '''
@@ -34,18 +35,11 @@ def init(opts):
                                             password=opts['proxy']['passwd'])
     thisproxy['conn'].open()
     thisproxy['conn'].bind(cu=jnpr.junos.utils.config.Config)
+    thisproxy['conn'].bind(sw=jnpr.junos.utils.sw.SW)
 
 
 def conn():
     return thisproxy['conn']
-
-
-def facts():
-    return thisproxy['conn'].facts
-
-
-def refresh():
-    return thisproxy['conn'].facts_refresh()
 
 
 def proxytype():
@@ -56,9 +50,7 @@ def proxytype():
 
 
 def id(opts):
-    '''
-    Returns a unique ID for this proxy minion
-    '''
+    
     return thisproxy['conn'].facts['hostname']
 
 
@@ -80,7 +72,3 @@ def shutdown(opts):
         thisproxy['conn'].close()
     except Exception:
         pass
-
-
-def rpc():
-    return json.dumps(thisproxy['conn'].rpc.get_software_information())

--- a/salt/proxy/junos.py
+++ b/salt/proxy/junos.py
@@ -10,12 +10,10 @@ from __future__ import absolute_import
 import logging
 
 # Import 3rd-party libs
-from jnpr.junos import Device
 import jnpr.junos
 import jnpr.junos.utils
 import jnpr.junos.utils.config
 import jnpr.junos.utils.sw
-import json
 HAS_JUNOS = True
 
 __proxyenabled__ = ['junos']
@@ -23,6 +21,7 @@ __proxyenabled__ = ['junos']
 thisproxy = {}
 
 log = logging.getLogger(__name__)
+
 
 def init(opts):
     '''
@@ -50,9 +49,7 @@ def proxytype():
 
 
 def id(opts):
-    
     return thisproxy['conn'].facts['hostname']
-
 
 def ping():
     '''

--- a/salt/states/junos.py
+++ b/salt/states/junos.py
@@ -6,12 +6,12 @@ State modules to interact with Junos devices.
 These modules call the corresponding execution modules.
 Refer to :mod:`junos <salt.modules.junos>` for further information.
 '''
-
+from __future__ import absolute_import
 import logging
 
 log = logging.getLogger()
 
-def call_rpc(name,args=None,**kwargs):
+def call_rpc(name, args=None, **kwargs):
 	'''
 	Executes the given rpc. The returned data can be stored in a file by specifying the
 	destination path with dest as an argument
@@ -31,14 +31,14 @@ def call_rpc(name,args=None,**kwargs):
     
     kwargs: keyworded arguments taken by rpc call of PyEZ
 	'''
-	ret = {'name':name,'changes':{},'result':True,'comment':''}
+	ret = {'name': name, 'changes': {}, 'result':True, 'comment': ''}
 	if args!=None:
-		ret['changes'] = __salt__['junos.call_rpc'](name,*args,**kwargs)
+		ret['changes'] = __salt__['junos.call_rpc'](name, *args, **kwargs)
 	else:
-		ret['changes'] = __salt__['junos.call_rpc'](name,**kwargs)
+		ret['changes'] = __salt__['junos.call_rpc'](name, **kwargs)
 	return ret
 
-def set_hostname(name,commit_changes=True):
+def set_hostname(name, commit_changes=True):
 	'''
 	Changes the hostname of the device.
 
@@ -53,8 +53,8 @@ def set_hostname(name,commit_changes=True):
 
     commit_changes: whether to commit the changes
 	'''
-	ret = {'name':name,'changes':{},'result':True,'comment':''}
-	ret['changes'] = __salt__['junos.set_hostname'](name,commit_changes)
+	ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
+	ret['changes'] = __salt__['junos.set_hostname'](name, commit_changes)
 	return ret
 
 def commit(name):
@@ -68,7 +68,7 @@ def commit(name):
 
   	name: can be anything
 	'''
-	ret = {'name':name,'changes':{},'result':True,'comment':''}
+	ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
 	ret['changes'] = __salt__['junos.commit']()
 	return ret
 
@@ -82,7 +82,7 @@ def rollback(name):
 
   	name: can be anything
 	'''
-	ret = {'name':name,'changes':{},'result':True,'comment':''}
+	ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
 	ret['changes'] = __salt__['junos.rollback']()
 	return ret
 
@@ -97,7 +97,7 @@ def diff(name):
 
   	name: can be anything
 	'''
-	ret = {'name':name,'changes':{},'result':True,'comment':''}
+	ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
 	ret['changes'] = __salt__['junos.diff']()
 	return ret
 
@@ -112,11 +112,11 @@ def cli(name):
 
   	name: the command to be executed on junos CLI.
 	'''
-	ret = {'name':name,'changes':{},'result':True,'comment':''}
+	ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
 	ret['changes'] = __salt__['junos.cli'](name)
 	return ret
 
-def shutdown(name,time=0):
+def shutdown(name, time=0):
 	'''
 	Shuts down the device.
 
@@ -131,11 +131,11 @@ def shutdown(name,time=0):
 
   	time: time after which the system should shutdown(in seconds, default=0)
 	'''
-	ret = {'name':name,'changes':{},'result':True,'comment':''}
+	ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
 	ret['changes'] = __salt__['junos.shutdown'](time)
 	return ret
 
-def install_config(name,**kwargs):
+def install_config(name, **kwargs):
 	'''
 	Loads and commits the configuration provided.
 
@@ -150,8 +150,8 @@ def install_config(name,**kwargs):
 
   	keyworded arguments taken by load fucntion of PyEZ
 	'''
-	ret = {'name':name,'changes':{},'result':True,'comment':''}
-	ret['changes'] = __salt__['junos.install_config'](name,**kwargs)
+	ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
+	ret['changes'] = __salt__['junos.install_config'](name, **kwargs)
 	return ret
 
 def zeroize(name):
@@ -165,11 +165,11 @@ def zeroize(name):
 
   	name: can be anything
 	'''
-	ret = {'name':name,'changes':{},'result':True,'comment':''}
+	ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
 	ret['changes'] = __salt__['junos.zeroize']()
 	return ret
 
-def install_os(name,**kwargs):
+def install_os(name, **kwargs):
 	'''
 	Installs the given image on the device. After the installation is complete the device is rebooted,
     if reboot=True is given as a keyworded argument.
@@ -186,11 +186,11 @@ def install_os(name,**kwargs):
 
   	kwargs: keyworded arguments to be given such as timeout, reboot etc
 	'''
-	ret = {'name':name,'changes':{},'result':True,'comment':''}
-	ret['changes'] = __salt__['junos.install_os'](name,**kwargs)
+	ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
+	ret['changes'] = __salt__['junos.install_os'](name, **kwargs)
 	return ret
 
-def file_copy(name,dest=None):
+def file_copy(name, dest=None):
 	'''
 	Copies the file from the local device to the junos device.
 
@@ -205,6 +205,6 @@ def file_copy(name,dest=None):
 
   	dest: destination path where the file will be placed.
 	'''
-	ret = {'name':name,'changes':{},'result':True,'comment':''}
-	ret['changes'] = __salt__['junos.file_copy'](name,dest)
+	ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
+	ret['changes'] = __salt__['junos.file_copy'](name, dest)
 	return ret

--- a/salt/states/junos.py
+++ b/salt/states/junos.py
@@ -1,0 +1,208 @@
+tate modules to interact with Junos devices.
+==============================================
+
+These modules call the corresponding execution modules.
+Refer to :mod:`junos <salt.modules.junos>` for further information.
+'''
+
+import logging
+
+log = logging.getLogger()
+
+def call_rpc(name,args=None,**kwargs):
+	'''
+	Executes the given rpc. The returned data can be stored in a file by specifying the
+	destination path with dest as an argument
+
+	.. code-block:: yaml
+
+		get config:
+  		  junos:
+    	    - call_rpc
+    		- args: 
+    		  - <configuration><system/></configuration>
+    		- dest: /home/user/rpc_data.txt
+
+    name: the rpc to be executed.
+    
+    args: other arguments as taken by rpc call of PyEZ
+    
+    kwargs: keyworded arguments taken by rpc call of PyEZ
+	'''
+	ret = {'name':name,'changes':{},'result':True,'comment':''}
+	if args!=None:
+		ret['changes'] = __salt__['junos.call_rpc'](name,*args,**kwargs)
+	else:
+		ret['changes'] = __salt__['junos.call_rpc'](name,**kwargs)
+	return ret
+
+def set_hostname(name,commit_changes=True):
+	'''
+	Changes the hostname of the device.
+
+	.. code-block:: yaml
+
+		device name:
+  		  junos:
+    	    - set_hostname
+    		- commit_changes: False
+
+    name: the name to be given to the device
+
+    commit_changes: whether to commit the changes
+	'''
+	ret = {'name':name,'changes':{},'result':True,'comment':''}
+	ret['changes'] = __salt__['junos.set_hostname'](name,commit_changes)
+	return ret
+
+def commit(name):
+	'''
+	Commits the changes loaded into the candidate configuration.
+
+	.. code-block:: yaml
+
+		commit the changes:
+  		  junos.commit
+
+  	name: can be anything
+	'''
+	ret = {'name':name,'changes':{},'result':True,'comment':''}
+	ret['changes'] = __salt__['junos.commit']()
+	return ret
+
+def rollback(name):
+	'''
+	Rollbacks the committed changes.
+	.. code-block:: yaml
+
+		rollback the changes:
+  		  junos.rollback
+
+  	name: can be anything
+	'''
+	ret = {'name':name,'changes':{},'result':True,'comment':''}
+	ret['changes'] = __salt__['junos.rollback']()
+	return ret
+
+def diff(name):
+	'''
+	Gets the difference between the candidate and the current configuration.
+
+	.. code-block:: yaml
+
+		get the diff:
+  		  junos.diff
+
+  	name: can be anything
+	'''
+	ret = {'name':name,'changes':{},'result':True,'comment':''}
+	ret['changes'] = __salt__['junos.diff']()
+	return ret
+
+def cli(name):
+	'''
+	Executes the CLI commands and reuturns the text output.
+
+	.. code-block:: yaml
+
+		show version:
+  		  junos.cli
+
+  	name: the command to be executed on junos CLI.
+	'''
+	ret = {'name':name,'changes':{},'result':True,'comment':''}
+	ret['changes'] = __salt__['junos.cli'](name)
+	return ret
+
+def shutdown(name,time=0):
+	'''
+	Shuts down the device.
+
+	.. code-block:: yaml
+
+		shut the device:
+  		  junos:
+  		    - shutdown
+  		    - time: 10
+
+  	name: can be anything
+
+  	time: time after which the system should shutdown(in seconds, default=0)
+	'''
+	ret = {'name':name,'changes':{},'result':True,'comment':''}
+	ret['changes'] = __salt__['junos.shutdown'](time)
+	return ret
+
+def install_config(name,**kwargs):
+	'''
+	Loads and commits the configuration provided.
+
+	.. code-block:: yaml
+
+		/home/user/config.set:
+  		  junos:
+  		    - install_config
+  		    - timeout: 100
+
+  	name: path to the configuration file.
+
+  	keyworded arguments taken by load fucntion of PyEZ
+	'''
+	ret = {'name':name,'changes':{},'result':True,'comment':''}
+	ret['changes'] = __salt__['junos.install_config'](name,**kwargs)
+	return ret
+
+def zeroize(name):
+	'''
+	Resets the device to default factory settings.
+
+	.. code-block:: yaml
+
+		reset my device:
+  		  junos.zeroize
+
+  	name: can be anything
+	'''
+	ret = {'name':name,'changes':{},'result':True,'comment':''}
+	ret['changes'] = __salt__['junos.zeroize']()
+	return ret
+
+def install_os(name,**kwargs):
+	'''
+	Installs the given image on the device. After the installation is complete the device is rebooted,
+    if reboot=True is given as a keyworded argument.
+
+	.. code-block:: yaml
+
+		/home/user/junos_image.tgz:
+  		  junos:
+  		    - install_os
+  		    - timeout: 100
+  		    - reboot: True
+
+  	name: path to the image file.
+
+  	kwargs: keyworded arguments to be given such as timeout, reboot etc
+	'''
+	ret = {'name':name,'changes':{},'result':True,'comment':''}
+	ret['changes'] = __salt__['junos.install_os'](name,**kwargs)
+	return ret
+
+def file_copy(name,dest=None):
+	'''
+	Copies the file from the local device to the junos device.
+
+	.. code-block:: yaml
+
+		/home/m2/info.txt:
+  		  junos:
+  		    - file_copy
+  		    - dest: info_copy.txt
+
+  	name: source path of the file.
+
+  	dest: destination path where the file will be placed.
+	'''
+	ret = {'name':name,'changes':{},'result':True,'comment':''}
+	ret['changes'] = __salt__['junos.file_copy'](name,dest)
+	return ret

--- a/salt/states/junos.py
+++ b/salt/states/junos.py
@@ -1,4 +1,6 @@
-tate modules to interact with Junos devices.
+# -*- coding: utf-8 -*-
+'''
+State modules to interact with Junos devices.
 ==============================================
 
 These modules call the corresponding execution modules.

--- a/salt/states/junos.py
+++ b/salt/states/junos.py
@@ -11,200 +11,211 @@ import logging
 
 log = logging.getLogger()
 
+
 def call_rpc(name, args=None, **kwargs):
-	'''
-	Executes the given rpc. The returned data can be stored in a file by specifying the
-	destination path with dest as an argument
+    '''
+    Executes the given rpc. The returned data can be stored in a file
+    by specifying the destination path with dest as an argument
 
-	.. code-block:: yaml
+    .. code-block:: yaml
 
-		get config:
-  		  junos:
-    	    - call_rpc
-    		- args: 
-    		  - <configuration><system/></configuration>
-    		- dest: /home/user/rpc_data.txt
+            get config:
+              junos:
+        - call_rpc
+                    - args:
+          - <configuration><system/></configuration>
+          - dest: /home/user/rpc_data.txt
 
-    name: the rpc to be executed.
-    
-    args: other arguments as taken by rpc call of PyEZ
-    
-    kwargs: keyworded arguments taken by rpc call of PyEZ
-	'''
-	ret = {'name': name, 'changes': {}, 'result':True, 'comment': ''}
-	if args!=None:
-		ret['changes'] = __salt__['junos.call_rpc'](name, *args, **kwargs)
-	else:
-		ret['changes'] = __salt__['junos.call_rpc'](name, **kwargs)
-	return ret
+name: the rpc to be executed.
+
+args: other arguments as taken by rpc call of PyEZ
+
+kwargs: keyworded arguments taken by rpc call of PyEZ
+    '''
+    ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
+    if args is not None:
+        ret['changes'] = __salt__['junos.call_rpc'](name, *args, **kwargs)
+    else:
+        ret['changes'] = __salt__['junos.call_rpc'](name, **kwargs)
+    return ret
+
 
 def set_hostname(name, commit_changes=True):
-	'''
-	Changes the hostname of the device.
+    '''
+    Changes the hostname of the device.
 
-	.. code-block:: yaml
+    .. code-block:: yaml
 
-		device name:
-  		  junos:
-    	    - set_hostname
-    		- commit_changes: False
+            device name:
+              junos:
+                - set_hostname
+                - commit_changes: False
 
-    name: the name to be given to the device
+name: the name to be given to the device
 
-    commit_changes: whether to commit the changes
-	'''
-	ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
-	ret['changes'] = __salt__['junos.set_hostname'](name, commit_changes)
-	return ret
+commit_changes: whether to commit the changes
+    '''
+    ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
+    ret['changes'] = __salt__['junos.set_hostname'](name, commit_changes)
+    return ret
+
 
 def commit(name):
-	'''
-	Commits the changes loaded into the candidate configuration.
+    '''
+    Commits the changes loaded into the candidate configuration.
 
-	.. code-block:: yaml
+    .. code-block:: yaml
 
-		commit the changes:
-  		  junos.commit
+            commit the changes:
+              junos.commit
 
-  	name: can be anything
-	'''
-	ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
-	ret['changes'] = __salt__['junos.commit']()
-	return ret
+    name: can be anything
+    '''
+    ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
+    ret['changes'] = __salt__['junos.commit']()
+    return ret
+
 
 def rollback(name):
-	'''
-	Rollbacks the committed changes.
-	.. code-block:: yaml
+    '''
+    Rollbacks the committed changes.
+    .. code-block:: yaml
 
-		rollback the changes:
-  		  junos.rollback
+            rollback the changes:
+              junos.rollback
 
-  	name: can be anything
-	'''
-	ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
-	ret['changes'] = __salt__['junos.rollback']()
-	return ret
+    name: can be anything
+    '''
+    ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
+    ret['changes'] = __salt__['junos.rollback']()
+    return ret
+
 
 def diff(name):
-	'''
-	Gets the difference between the candidate and the current configuration.
+    '''
+    Gets the difference between the candidate and the current configuration.
 
-	.. code-block:: yaml
+    .. code-block:: yaml
 
-		get the diff:
-  		  junos.diff
+            get the diff:
+              junos.diff
 
-  	name: can be anything
-	'''
-	ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
-	ret['changes'] = __salt__['junos.diff']()
-	return ret
+    name: can be anything
+    '''
+    ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
+    ret['changes'] = __salt__['junos.diff']()
+    return ret
+
 
 def cli(name):
-	'''
-	Executes the CLI commands and reuturns the text output.
+    '''
+    Executes the CLI commands and reuturns the text output.
 
-	.. code-block:: yaml
+    .. code-block:: yaml
 
-		show version:
-  		  junos.cli
+            show version:
+              junos.cli
 
-  	name: the command to be executed on junos CLI.
-	'''
-	ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
-	ret['changes'] = __salt__['junos.cli'](name)
-	return ret
+    name: the command to be executed on junos CLI.
+    '''
+    ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
+    ret['changes'] = __salt__['junos.cli'](name)
+    return ret
+
 
 def shutdown(name, time=0):
-	'''
-	Shuts down the device.
+    '''
+    Shuts down the device.
 
-	.. code-block:: yaml
+    .. code-block:: yaml
 
-		shut the device:
-  		  junos:
-  		    - shutdown
-  		    - time: 10
+            shut the device:
+              junos:
+                - shutdown
+                - time: 10
 
-  	name: can be anything
+    name: can be anything
 
-  	time: time after which the system should shutdown(in seconds, default=0)
-	'''
-	ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
-	ret['changes'] = __salt__['junos.shutdown'](time)
-	return ret
+    time: time after which the system should shutdown(in seconds, default=0)
+    '''
+    ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
+    ret['changes'] = __salt__['junos.shutdown'](time)
+    return ret
+
 
 def install_config(name, **kwargs):
-	'''
-	Loads and commits the configuration provided.
+    '''
+    Loads and commits the configuration provided.
 
-	.. code-block:: yaml
+    .. code-block:: yaml
 
-		/home/user/config.set:
-  		  junos:
-  		    - install_config
-  		    - timeout: 100
+            /home/user/config.set:
+              junos:
+                - install_config
+                - timeout: 100
 
-  	name: path to the configuration file.
+    name: path to the configuration file.
 
-  	keyworded arguments taken by load fucntion of PyEZ
-	'''
-	ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
-	ret['changes'] = __salt__['junos.install_config'](name, **kwargs)
-	return ret
+    keyworded arguments taken by load fucntion of PyEZ
+    '''
+    ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
+    ret['changes'] = __salt__['junos.install_config'](name, **kwargs)
+    return ret
+
 
 def zeroize(name):
-	'''
-	Resets the device to default factory settings.
+    '''
+    Resets the device to default factory settings.
 
-	.. code-block:: yaml
+    .. code-block:: yaml
 
-		reset my device:
-  		  junos.zeroize
+            reset my device:
+              junos.zeroize
 
-  	name: can be anything
-	'''
-	ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
-	ret['changes'] = __salt__['junos.zeroize']()
-	return ret
+    name: can be anything
+    '''
+    ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
+    ret['changes'] = __salt__['junos.zeroize']()
+    return ret
+
 
 def install_os(name, **kwargs):
-	'''
-	Installs the given image on the device. After the installation is complete the device is rebooted,
-    if reboot=True is given as a keyworded argument.
+    '''
+    Installs the given image on the device. After the installation is complete
+    the device is rebooted, if reboot=True is given as a keyworded argument.
 
-	.. code-block:: yaml
+    .. code-block:: yaml
 
-		/home/user/junos_image.tgz:
-  		  junos:
-  		    - install_os
-  		    - timeout: 100
-  		    - reboot: True
+            /home/user/junos_image.tgz:
+              junos:
+                - install_os
+                - timeout: 100
+                - reboot: True
 
-  	name: path to the image file.
+    name: path to the image file.
 
-  	kwargs: keyworded arguments to be given such as timeout, reboot etc
-	'''
-	ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
-	ret['changes'] = __salt__['junos.install_os'](name, **kwargs)
-	return ret
+    kwargs: keyworded arguments to be given such as timeout, reboot etc
+    '''
+    ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
+    ret['changes'] = __salt__['junos.install_os'](name, **kwargs)
+    return ret
+
 
 def file_copy(name, dest=None):
-	'''
-	Copies the file from the local device to the junos device.
+    '''
+    Copies the file from the local device to the junos device.
 
-	.. code-block:: yaml
+    .. code-block:: yaml
 
-		/home/m2/info.txt:
-  		  junos:
-  		    - file_copy
-  		    - dest: info_copy.txt
+            /home/m2/info.txt:
+              junos:
+                - file_copy
+                - dest: info_copy.txt
 
-  	name: source path of the file.
+    name: source path of the file.
 
-  	dest: destination path where the file will be placed.
-	'''
-	ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
-	ret['changes'] = __salt__['junos.file_copy'](name, dest)
-	return ret
+    dest: destination path where the file will be placed.
+    '''
+    ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
+    ret['changes'] = __salt__['junos.file_copy'](name, dest)
+    return ret


### PR DESCRIPTION
#### What does this PR do?

The main purpose of this PR is to improve the junos execution modules. Also junos state modules are added. A workaround to set the junos grain data is added.
#### What issues does this PR fix or reference?

The junos grains faces this issue. The issue remains unsolved but a temporary work around is added. 
https://github.com/saltstack/salt/issues/30642
#### Changes made:

In salt/modules/junos.py  these new functionalities were added:
- facts()
- install_config()
- install_os()
- file_copy()
- shutdown()
-  zeroize()

In salt/modules/junos.py  this functionality was changed were added:
- call_rpc() - Initially this function was hard coded to call 'get system information', this is changed so as to any call any rpc which is provided as an argument.

In salt/proxy/junos.py  these things were deleted:
- facts()
- refresh()
- rpc()

These functions were deleted because as far as I can interpret proxy is used to make initial connection with the device and to check if the connection is active. The above three functions are more suitable in the execution module.
#### New files added:

salt/states/junos.py contains the following functionalities:
- call_rpc
- set_hostname
- commit
- rollback
- diff
- cli
- shutdown
- install_config
- zeroize
- install_os
- file_copy

These state modules simply call the corresponding execution modules.
#### Tests written?
- [x] No
