### PR TITLE
Prevent event logs from writing huge amounts of data

### DIFF
--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -975,16 +975,17 @@ class EventReturn(multiprocessing.Process):
             try:
                 self.minion.returners[event_return](self.event_queue)
             except Exception as exc:
-                log.error('Could not store events {0}. '
-                          'Returner raised exception: {1}'.format(
-                    self.event_queue, exc))
+                log.error('Could not store events - returner \'{0}\' raised '
+                    'exception: {1}'.format(self.opts['event_return'], exc))
+                # don't waste processing power unnecessarily on converting a
+                # potentially huge dataset to a string
+                if log.level <= logging.DEBUG:
+                    log.debug('Event data that caused an exception: {0}'.format(
+                        self.event_queue))
             del self.event_queue[:]
         else:
-            log.error(
-                'Could not store return for event(s) {0}. Returner '
-                '\'{1}\' not found.'
-                    .format(self.event_queue, self.opts['event_return'])
-            )
+            log.error('Could not store return for event(s) - returner '
+                '\'{1}\' not found.'.format(self.opts['event_return']))
 
     def run(self):
         '''


### PR DESCRIPTION
See discussion in issue https://github.com/saltstack/salt/issues/28357 - this PR does **not** fix the issue entirely!

Changes made:
- don't log event data on returner not found
- only log event data if log_level is debug or lower
