### PR TITLE
raise error on unsupported distro

### DIFF
--- a/salt/modules/nspawn.py
+++ b/salt/modules/nspawn.py
@@ -654,7 +654,10 @@ def bootstrap_container(name, dist=None, version=None):
             'nspawn.bootstrap: no dist provided, defaulting to \'{0}\''
             .format(dist)
         )
-    return globals()['_bootstrap_{0}'.format(dist)](name, version=version)
+    try:
+        return globals()['_bootstrap_{0}'.format(dist)](name, version=version)
+    except KeyError:
+        raise CommandExecutionError('Unsupported distribution "{0}"'.format(dist))
 
 
 def _needs_install(name):


### PR DESCRIPTION
### What does this PR do?

Raise error on nspawn.bootstrap_container when attempting to build an unsupported distro
### What issues does this PR fix or reference?

none
### Previous Behavior

Ugly/unclear KeyError exception
### New Behavior

```
Error running 'nspawn.bootstrap_container': Unsupported distribution "ubuntu"
```
### Tests written?
- [ ] Yes
- [x] No
