### PR TITLE
salt.states.smartos.image_vacuum should not throw and exception 

### DIFF
--- a/salt/states/smartos.py
+++ b/salt/states/smartos.py
@@ -370,6 +370,10 @@ def image_vacuum(name):
 
     # retreive image_present state data for host
     for state in __salt__['state.show_lowstate']():
+        # don't throw exceptions when not highstate run
+        if 'state' not in state:
+            continue
+
         # skip if not from this state module
         if state['state'] != __virtualname__:
             continue


### PR DESCRIPTION
### What does this PR do?

smartos.image_vacuum only works when running on a highstate (to collect and track all image_present states) This make it throw an exception when doing a single one of state run.

``` yaml
          ID: smartos.images::vacuum
    Function: smartos.image_vacuum
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "salt/state.py", line 1701, in call
                File "salt/loader.py", line 1607, in wrapper
                File "/opt/salt/var/cache/salt/minion/extmods/states/smartos.py", line 374, in image_vacuum
                  if state['state'] != __virtualname__:
              TypeError: string indices must be integers, not str
     Started: 11:28:34.858776
    Duration: 1148.884 ms
     Changes:
```
### What issues does this PR fix or reference?

n/a
### Previous Behavior

Exception resulting in a failed state
### New Behavior

Exception is avoided, we just don't clean up any images
### Tests written?
- [ ] Yes
- [X] No
### Affected branches
- 2016.3
- develop
