### PR TITLE
Now a check_file_meta deletes temporary files when test=True

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3865,6 +3865,7 @@ def check_file_meta(
                 salt.utils.fopen(name, 'r')) as (src, name_):
             slines = src.readlines()
             nlines = name_.readlines()
+        __clean_tmp(tmp)
         if ''.join(nlines) != ''.join(slines):
             if __salt__['config.option']('obfuscate_templates'):
                 changes['diff'] = '<Obfuscated Template>'


### PR DESCRIPTION
### What does this PR do?

fix check_file_meta that it deletes temporary files when test = True
### Tests written?
- [ ] Yes
- [x] No
