### PR TITLE
Proxy infinite loop

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1537,7 +1537,8 @@ class Minion(MinionBase):
             # in the setup process, but we can't load grains for proxies until
             # we talk to the device we are proxying for.  So force a grains
             # sync here.
-            self.functions['saltutil.sync_grains'](saltenv='base')
+            # Hmm...We can't seem to sync grains here, makes the event bus go nuts
+            # self.functions['saltutil.sync_grains'](saltenv='base')
         else:
             self.functions, self.returners, _, self.executors = self._load_modules(force_refresh, notify=notify)
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1538,6 +1538,7 @@ class Minion(MinionBase):
             # we talk to the device we are proxying for.  So force a grains
             # sync here.
             # Hmm...We can't seem to sync grains here, makes the event bus go nuts
+            # leaving this commented to remind future me that this is not a good idea here.
             # self.functions['saltutil.sync_grains'](saltenv='base')
         else:
             self.functions, self.returners, _, self.executors = self._load_modules(force_refresh, notify=notify)


### PR DESCRIPTION
### What does this PR do?

Corrects a problem where proxies would flood the event bus and cause a pegged CPU when syncing grains.
### What issues does this PR fix or reference?

Fixes #31728 and #31791.
### Previous Behavior

Syncing grains for proxy would cause a recursive loop (event posted to bus, proxy reacts to event that would post same event to bus, etc)
### New Behavior

Grains syncing and custom grains for proxies work without flooding the event bus.
### Tests written?
- [ ] Yes
- [X] No
