### PR TITLE
Add ability to multimaster mode with master_type = func

### DIFF
--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -276,6 +276,8 @@ class Minion(parsers.MinionOptionParser):  # pylint: disable=no-init
             # This is the latest safe place to daemonize
             self.daemonize_if_required()
             self.set_pidfile()
+            if self.config.get('master_type') == 'func':
+                salt.minion.eval_master_func(self.config)
             if isinstance(self.config.get('master'), list):
                 if self.config.get('master_type') == 'failover':
                     self.minion = salt.minion.Minion(self.config)

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -339,6 +339,26 @@ def load_args_and_kwargs(func, args, data=None, ignore_invalid=False):
     return _args, _kwargs
 
 
+def eval_master_func(opts):
+    '''
+    Evaluate master function if master type is 'func'
+    and save it result in opts['master']
+    '''
+    if '__master_func_evaluated' not in opts:
+        # split module and function and try loading the module
+        mod, fun = opts['master'].split('.')
+        try:
+            master_mod = salt.loader.raw_mod(opts, mod, fun)
+            # we take whatever the module returns as master address
+            opts['master'] = master_mod[mod + '.' + fun]()
+            opts['__master_func_evaluated'] = True
+        except TypeError:
+            log.error("Failed to evaluate master address from module '{0}'".format(
+                      opts['master']))
+            sys.exit(salt.defaults.exitcodes.EX_GENERIC)
+        log.info('Evaluated master from module: {0}'.format(master_mod))
+
+
 class MinionBase(object):
     def __init__(self, opts):
         self.opts = opts
@@ -400,20 +420,7 @@ class MinionBase(object):
         if opts['master_type'] != 'str' and opts['__role'] != 'syndic':
             # check for a valid keyword
             if opts['master_type'] == 'func':
-                # split module and function and try loading the module
-                mod, fun = opts['master'].split('.')
-                try:
-                    master_mod = salt.loader.raw_mod(opts, mod, fun)
-                    if not master_mod:
-                        raise TypeError
-                    # we take whatever the module returns as master address
-                    opts['master'] = master_mod[mod + '.' + fun]()
-                except TypeError:
-                    msg = ('Failed to evaluate master address from '
-                           'module \'{0}\''.format(opts['master']))
-                    log.error(msg)
-                    sys.exit(salt.defaults.exitcodes.EX_GENERIC)
-                log.info('Evaluated master from module: {0}'.format(master_mod))
+                eval_master_func(opts)
 
             # if failover is set, master has to be of type list
             elif opts['master_type'] == 'failover':


### PR DESCRIPTION
### What does this PR do?

Add ability to multimaster mode with master_type = func
### Previous Behavior

master_type 'func' always run one minion
### New Behavior

if master=<func> return list of masters minion will work in multi master mode
### Tests written?
- [ ] Yes
- [x] No
