### PR TITLE
NetapiClient client method whitelist

### DIFF
--- a/salt/netapi/__init__.py
+++ b/salt/netapi/__init__.py
@@ -28,16 +28,6 @@ class NetapiClient(object):
     >>> lowstate = {'client': 'local', 'tgt': '*', 'fun': 'test.ping', 'arg': ''}
     >>> client.run(lowstate)
     '''
-    clients = (
-        'local_async',
-        'local',
-        'local_batch',
-        'local_subset',
-        'ssh',
-        'ssh_async',
-        'wheel',
-        'wheel_async'
-    )
 
     def __init__(self, opts):
         self.opts = opts
@@ -69,7 +59,7 @@ class NetapiClient(object):
             raise salt.exceptions.SaltDaemonNotRunning(
                     'Salt Master is not available.')
 
-        if low.get('client') not in self.clients:
+        if low.get('client') not in CLIENTS:
             raise salt.exceptions.SaltInvocationError('Invalid client specified')
 
         if not ('token' in low or 'eauth' in low) and low['client'] != 'ssh':
@@ -212,3 +202,9 @@ class NetapiClient(object):
         kwargs['fun'] = fun
         wheel = salt.wheel.WheelClient(self.opts)
         return wheel.cmd_async(kwargs)
+
+CLIENTS = [
+    name for name, _
+    in inspect.getmembers(NetapiClient, predicate=inspect.ismethod)
+    if not (name == 'run' or name.startswith('_'))
+]

--- a/salt/netapi/__init__.py
+++ b/salt/netapi/__init__.py
@@ -28,6 +28,17 @@ class NetapiClient(object):
     >>> lowstate = {'client': 'local', 'tgt': '*', 'fun': 'test.ping', 'arg': ''}
     >>> client.run(lowstate)
     '''
+    clients = (
+        'local_async',
+        'local',
+        'local_batch',
+        'local_subset',
+        'ssh',
+        'ssh_async',
+        'wheel',
+        'wheel_async'
+    )
+
     def __init__(self, opts):
         self.opts = opts
 
@@ -58,8 +69,8 @@ class NetapiClient(object):
             raise salt.exceptions.SaltDaemonNotRunning(
                     'Salt Master is not available.')
 
-        if 'client' not in low:
-            raise salt.exceptions.SaltException('No client specified')
+        if low.get('client') not in self.clients:
+            raise salt.exceptions.SaltInvocationError('Invalid client specified')
 
         if not ('token' in low or 'eauth' in low) and low['client'] != 'ssh':
             raise salt.exceptions.EauthAuthenticationError(

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -245,6 +245,7 @@ command sent to minions as well as a runner function on the master::
     :mailheader:`Accept` request header.
 
 .. |200| replace:: success
+.. |400| replace:: bad or malformed request
 .. |401| replace:: authentication required
 .. |406| replace:: requested Content-Type not available
 '''
@@ -520,6 +521,8 @@ def hypermedia_handler(*args, **kwargs):
     except (salt.exceptions.EauthAuthenticationError,
             salt.exceptions.TokenAuthenticationError):
         raise cherrypy.HTTPError(401)
+    except salt.exceptions.SaltInvocationError:
+        raise cherrypy.HTTPError(400)
     except (salt.exceptions.SaltDaemonNotRunning,
             salt.exceptions.SaltReqTimeoutError) as exc:
         raise cherrypy.HTTPError(503, exc.strerror)
@@ -823,9 +826,7 @@ class LowDataAdapter(object):
         import inspect
 
         # Grab all available client interfaces
-        clients = [name for name, _ in inspect.getmembers(salt.netapi.NetapiClient,
-            predicate=inspect.ismethod) if not name.startswith('__')]
-        clients.remove('run')  # run method calls client interfaces
+        clients = salt.netapi.NetapiClient.clients
 
         return {
             'return': "Welcome",
@@ -847,6 +848,7 @@ class LowDataAdapter(object):
             :resheader Content-Type: |res_ct|
 
             :status 200: |200|
+            :status 400: |400|
             :status 401: |401|
             :status 406: |406|
 
@@ -1011,6 +1013,7 @@ class Minions(LowDataAdapter):
             :resheader Content-Type: |res_ct|
 
             :status 200: |200|
+            :status 400: |400|
             :status 401: |401|
             :status 406: |406|
 
@@ -1591,6 +1594,7 @@ class Run(LowDataAdapter):
             request body.
 
             :status 200: |200|
+            :status 400: |400|
             :status 401: |401|
             :status 406: |406|
 

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -825,12 +825,10 @@ class LowDataAdapter(object):
         '''
         import inspect
 
-        # Grab all available client interfaces
-        clients = salt.netapi.NetapiClient.clients
 
         return {
             'return': "Welcome",
-            'clients': clients,
+            'clients': salt.netapi.CLIENTS,
         }
 
     @cherrypy.tools.salt_token()

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -825,7 +825,6 @@ class LowDataAdapter(object):
         '''
         import inspect
 
-
         return {
             'return': "Welcome",
             'clients': salt.netapi.CLIENTS,


### PR DESCRIPTION
### What does this PR do?

Sets a static whitelist of allowable client methods of `salt.netapi.NetApiclient` and updates the rest_cherrypy netapi module to return HTTP 400 when an invalid client method is specified in the request. 
### What issues does this PR fix or reference?

This PR prevents accessing methods of `salt.netapi.NetApiclient` that are not intended to be exposed to the user.
### Previous Behavior

```
>>> login = requests.post('http://localhost:8889/login', data={'username': user, 'password': password, 'eauth': eauth})
>>> token = login.json()['return'][0]['token']
>>> print requests.post('http://localhost:8889', data={'tgt': '*', 'fun': 'test.ping', 'client': '_is_master_running'}, headers={'X-Auth-Token': token}).content
{"return": [true]}
```
### New Behavior

```
>>> login = requests.post('http://localhost:8889/login', data={'username': user, 'password': password, 'eauth': eauth})
>>> token = login.json()['return'][0]['token']
>>> print requests.post('http://localhost:8889', data={'tgt': '*', 'fun': 'test.ping', 'client': '_is_master_running'}, headers={'X-Auth-Token': token}).content
<!DOCTYPE html PUBLIC
"-//W3C//DTD XHTML 1.0 Transitional//EN"
"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
<html>
<head>
    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"></meta>
    <title>400 Bad Request</title>
    <style type="text/css">
    #powered_by {
        margin-top: 20px;
        border-top: 2px solid black;
        font-style: italic;
    }

    #traceback {
        color: red;
    }
    </style>
</head>
    <body>
        <h2>400 Bad Request</h2>
        <p>Bad request syntax or unsupported method</p>
        <pre id="traceback"></pre>
    <div id="powered_by">
      <span>
        Powered by <a href="http://www.cherrypy.org">CherryPy 3.8.0</a>
      </span>
    </div>
    </body>
</html>
```
### Tests written?
- [ ] Yes
- [x] No
