### PR TITLE
Add an alias fetch function to grains and pillar module get

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -703,3 +703,7 @@ def set(key,
         ret['comment'] = _setval_ret
         ret['result'] = False
     return ret
+
+
+# Provide a jinja function call compatible get aliased as fetch
+fetch = get

--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -357,3 +357,7 @@ def file_exists(path, saltenv=None):
                 return True
 
     return False
+
+
+# Provide a jinja function call compatible get aliased as fetch
+fetch = get


### PR DESCRIPTION
### What does this PR do?

Add an alias called 'fetch' to grains and pillar module.

Just gauging interest and want to discuss naming etc.

I find the function call syntax lends better to syntax highlighting and what conceptually is being done vs salt['grains.get']('abc:def').
### What issues does this PR fix or reference?
### Previous Behavior
### New Behavior
### Tests written?
- [ ] Yes
- [X ] No
