### PR TITLE
Adds missing docs for Virtual Network and Subnet options in salt-cloud Azure cloud profile

### DIFF
--- a/doc/topics/cloud/azure.rst
+++ b/doc/topics/cloud/azure.rst
@@ -101,6 +101,8 @@ Set up an initial profile at ``/etc/salt/cloud.profiles``:
       ssh_password: verybadpass
       slot: production
       media_link: 'http://portalvhdabcdefghijklmn.blob.core.windows.net/vhds'
+      virtual_network_name: azure-virtual-network
+      subnet_name: azure-subnet
 
 These options are described in more detail below. Once configured, the profile
 can be realized with a salt command:
@@ -194,6 +196,16 @@ service_name
 ------------
 The name of the service in which to create the VM. If this is not specified,
 then a service will be created with the same name as the VM.
+
+virtual_network_name
+------------
+Optional. The name of the virtual network for the VM to join. If this is not
+specified, then no virtual network will be joined.
+
+subnet_name
+------------
+Optional. The name of the subnet in the virtual network for the VM to join.
+Requires that a ``virtual_network_name`` is specified.
 
 
 Show Instance


### PR DESCRIPTION
### What does this PR do?

Adds documentation for optional Virtual Network and Subnet options in salt-cloud Azure cloud profile.
The feature was introduced in 2015.8 by #24569, but not documented.
### What issues does this PR fix or reference?

Issue #24559
Merged in #24569
### Previous Behavior
### New Behavior
### Tests written?
- [ ] Yes
- [x] No
### Comments

I've tried to follow the wording and conventions of `azure.rst`, but please edit if it's unclear.
