### PR TITLE
gen_password and del_password missing from solaris_shadow

### DIFF
--- a/salt/modules/solaris_shadow.py
+++ b/salt/modules/solaris_shadow.py
@@ -199,7 +199,7 @@ def set_mindays(name, mindays):
 
 def gen_password(password, crypt_salt=None, algorithm='sha512'):
     '''
-    .. versionadded:: 2014.7.0
+    .. versionadded:: 2015.8.8
 
     Generate hashed password
 
@@ -241,7 +241,7 @@ def gen_password(password, crypt_salt=None, algorithm='sha512'):
 
 def del_password(name):
     '''
-    .. versionadded:: 2014.7.0
+    .. versionadded:: 2015.8.8
 
     Delete the password from name user
 

--- a/salt/modules/solaris_shadow.py
+++ b/salt/modules/solaris_shadow.py
@@ -199,7 +199,7 @@ def set_mindays(name, mindays):
 
 def gen_password(password, crypt_salt=None, algorithm='sha512'):
     '''
-    .. versionadded:: 2015.8.8
+    .. versionadded:: 2015.8.9
 
     Generate hashed password
 
@@ -241,7 +241,7 @@ def gen_password(password, crypt_salt=None, algorithm='sha512'):
 
 def del_password(name):
     '''
-    .. versionadded:: 2015.8.8
+    .. versionadded:: 2015.8.9
 
     Delete the password from name user
 

--- a/salt/modules/solaris_shadow.py
+++ b/salt/modules/solaris_shadow.py
@@ -19,6 +19,13 @@ except ImportError:
 
 # Import salt libs
 import salt.utils
+from salt.exceptions import CommandExecutionError
+try:
+    import salt.utils.pycrypto
+    HAS_CRYPT = True
+except ImportError:
+    HAS_CRYPT = False
+
 
 # Define the module's virtual name
 __virtualname__ = 'shadow'
@@ -188,6 +195,66 @@ def set_mindays(name, mindays):
     if post_info['min'] != pre_info['min']:
         return post_info['min'] == mindays
     return False
+
+
+def gen_password(password, crypt_salt=None, algorithm='sha512'):
+    '''
+    .. versionadded:: 2014.7.0
+
+    Generate hashed password
+
+    .. note::
+
+        When called this function is called directly via remote-execution,
+        the password argument may be displayed in the system's process list.
+        This may be a security risk on certain systems.
+
+    password
+        Plaintext password to be hashed.
+
+    crypt_salt
+        Crpytographic salt. If not given, a random 8-character salt will be
+        generated.
+
+    algorithm
+        The following hash algorithms are supported:
+
+        * md5
+        * blowfish (not in mainline glibc, only available in distros that add it)
+        * sha256
+        * sha512 (default)
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' shadow.gen_password 'I_am_password'
+        salt '*' shadow.gen_password 'I_am_password' crypt_salt='I_am_salt' algorithm=sha256
+    '''
+    if not HAS_CRYPT:
+        raise CommandExecutionError(
+                'gen_password is not available on this operating system '
+                'because the "crypt" python module is not available.'
+                )
+    return salt.utils.pycrypto.gen_hash(crypt_salt, password, algorithm)
+
+
+def del_password(name):
+    '''
+    .. versionadded:: 2014.7.0
+
+    Delete the password from name user
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' shadow.del_password username
+    '''
+    cmd = 'passwd -d {0}'.format(name)
+    __salt__['cmd.run'](cmd, python_shell=False, output_loglevel='quiet')
+    uinfo = info(name)
+    return not uinfo['passwd']
 
 
 def set_password(name, password):


### PR DESCRIPTION
### What does this PR do?

salt.modules.solaris_shadow is missing del and gen_password.
### Effected branches
- 2015.8
- 2016.3 (developed and tested with this one)
- develop
### What issues does this PR fix or reference?

n/a
### Previous Behavior

Missing functions
### New Behavior

Function copied from the 'generic' shadow module. Copied to solaris_shadow and tested on SmartOS on multiple zones using the 2016.3 branch. Fix backported to 2015.8 to for PR.
### Tests written?
- [ ] Yes
- [X] No
