### PR TITLE
Implement the latest_version function in mac_brew

### DIFF
--- a/salt/modules/mac_brew.py
+++ b/salt/modules/mac_brew.py
@@ -6,11 +6,14 @@ from __future__ import absolute_import
 
 # Import python libs
 import copy
+import json
 import logging
 
 # Import salt libs
 import salt.utils
 from salt.exceptions import CommandExecutionError, MinionError
+import salt.ext.six as six
+from salt.ext.six.moves import zip
 
 log = logging.getLogger(__name__)
 
@@ -141,8 +144,8 @@ def latest_version(*names, **kwargs):
     Return the latest version of the named package available for upgrade or
     installation
 
-    Note that this currently not fully implemented but needs to return
-    something to avoid a traceback when calling pkg.latest.
+    Currently chooses stable versions, falling back to devel if that does not
+    exist.
 
     CLI Example:
 
@@ -156,13 +159,16 @@ def latest_version(*names, **kwargs):
     if refresh:
         refresh_db()
 
-    if len(names) <= 1:
-        return ''
+    def get_version(pkg_info):
+        # Perhaps this will need an option to pick devel by default
+        return pkg_info['versions']['stable'] or pkg_info['versions']['devel']
+
+    versions_dict = dict((key, get_version(val)) for key, val in six.iteritems(_info(*names)))
+
+    if len(names) == 1:
+        return next(six.itervalues(versions_dict))
     else:
-        ret = {}
-        for name in names:
-            ret[name] = ''
-        return ret
+        return versions_dict
 
 # available_version is being deprecated
 available_version = salt.utils.alias_function(latest_version, 'available_version')
@@ -243,6 +249,30 @@ def refresh_db():
         return False
 
     return True
+
+
+def _info(*pkgs):
+    '''
+    Get all info brew can provide about a list of packages.
+
+    Does not do any kind of processing, so the format depends entirely on
+    the output brew gives. This may change if a new version of the format is
+    requested.
+
+    On failure, returns an empty dict and logs failure.
+    On success, returns a dict mapping each item in pkgs to its corresponding
+    object in the output of 'brew info'.
+
+    Caveat: If one of the packages does not exist, no packages will be
+            included in the output.
+    '''
+    cmd = 'brew info --json=v1 {0}'.format(' '.join(pkgs))
+    brew_result = _call_brew(cmd)
+    if brew_result['retcode']:
+        log.error('Failed to get info about packages: {0}'.format(' '.join(pkgs)))
+        return {}
+    output = json.loads(brew_result['stdout'])
+    return dict(zip(pkgs, output))
 
 
 def install(name=None, pkgs=None, taps=None, options=None, **kwargs):


### PR DESCRIPTION
### What does this PR do?

Implements `latest_version` in `mac_brew`, allowing `pkg.latest` to be used on macs.
### What issues does this PR fix or reference?

None that I can find.
### Previous Behavior

`latest_version` returns an empty string (if less than two packages are provided), or a dict mapping package names to empty strings (if two or more packages are provided).
### New Behavior

`latest_version` returns the "latest" available version of the packages. If exactly one package is provided, it will return the version as a string. Otherwise, it will return a dict mapping package names to package versions. If no arguments are passed, it will return an empty dict. If an error occurs in brew, it will return an empty dict and mention in the logs that an error occurred. If an error occurs parsing the json output of a successful run of brew, it will not suppress the ValueError.

"Latest" above is defined to be the current stable version, if one exists, or otherwise the current devel version. If neither exists, it will result in `None` (assuming brew is behaving itself).
### Tests written?
- [ ] Yes
- [x] No
