### PR TITLE
Fix buggy state updates to attached user/group/role policies.

### DIFF
--- a/salt/states/boto_iam.py
+++ b/salt/states/boto_iam.py
@@ -589,10 +589,15 @@ def _user_policies_attached(
                                        entity_filter='User',
                                        region=region, key=key, keyid=keyid,
                                        profile=profile)
-        if {'user_name': name} not in entities.get('policy_users', []):
+        found = False
+        for userdict in entities.get('policy_users', []):
+            if name == userdict.get('user_name'):
+                found = True
+                break
+        if not found:
             policies_to_attach.append(policy)
-    _list = __salt__['boto_iam.list_attached_user_policies'](name, region, key, keyid,
-                                                    profile)
+    _list = __salt__['boto_iam.list_attached_user_policies'](name, region=region, key=key, keyid=keyid,
+                                                    profile=profile)
     oldpolicies = [x.get('policy_arn') for x in _list]
     for policy_data in _list:
         if policy_data.get('policy_name') not in managed_policies \
@@ -610,13 +615,14 @@ def _user_policies_attached(
         for policy_name in policies_to_attach:
             policy_set = __salt__['boto_iam.attach_user_policy'](policy_name,
                                                                  name,
-                                                                 region, key,
-                                                                 keyid,
-                                                                 profile)
+                                                                 region=region, key=key,
+                                                                 keyid=keyid,
+                                                                 profile=profile)
             if not policy_set:
-                _list = __salt__['boto_iam.list_attached_user_policies'](name, region,
-                                                                key, keyid,
-                                                                profile)
+                _list = __salt__['boto_iam.list_attached_user_policies'](name, region=region,
+                                                                key=key,
+                                                                keyid=keyid,
+                                                                profile=profile)
                 newpolicies = [x.get('policy_arn') for x in _list]
                 ret['changes']['new'] = {'manged_policies': newpolicies}
                 ret['result'] = False
@@ -626,21 +632,23 @@ def _user_policies_attached(
         for policy_name in policies_to_detach:
             policy_unset = __salt__['boto_iam.detach_user_policy'](policy_name,
                                                                    name,
-                                                                   region, key,
-                                                                   keyid,
-                                                                   profile)
+                                                                   region=region, key=key,
+                                                                   keyid=keyid,
+                                                                   profile=profile)
             if not policy_unset:
-                _list = __salt__['boto_iam.list_attached_user_policies'](name, region,
-                                                                key, keyid,
-                                                                profile)
+                _list = __salt__['boto_iam.list_attached_user_policies'](name, region=region,
+                                                                key=key,
+                                                                keyid=keyid,
+                                                                profile=profile)
                 newpolicies = [x.get('policy_arn') for x in _list]
                 ret['changes']['new'] = {'managed_policies': newpolicies}
                 ret['result'] = False
                 msg = 'Failed to remove policy {0} from user {1}'
                 ret['comment'] = msg.format(policy_name, name)
                 return ret
-        _list = __salt__['boto_iam.list_attached_user_policies'](name, region, key,
-                                                        keyid, profile)
+        _list = __salt__['boto_iam.list_attached_user_policies'](name, region=region, key=key,
+                                                        keyid=keyid,
+                                                        profile=profile)
         newpolicies = [x.get('policy_arn') for x in _list]
         log.debug(newpolicies)
         ret['changes']['new'] = {'managed_policies': newpolicies}
@@ -672,21 +680,21 @@ def _user_policies_detached(
     for policy_arn in oldpolicies:
         policy_unset = __salt__['boto_iam.detach_user_policy'](policy_arn,
                                                                name,
-                                                               region, key,
-                                                               keyid,
-                                                               profile)
+                                                               region=region, key=key,
+                                                               keyid=keyid,
+                                                               profile=profile)
         if not policy_unset:
-            _list = __salt__['boto_iam.list_attached_user_policies'](name, region,
-                                                            key, keyid,
-                                                            profile)
+            _list = __salt__['boto_iam.list_attached_user_policies'](name, region=region,
+                                                            key=key, keyid=keyid,
+                                                            profile=profile)
             newpolicies = [x.get('policy_arn') for x in _list]
             ret['changes']['new'] = {'managed_policies': newpolicies}
             ret['result'] = False
             msg = 'Failed to detach {0} from user {1}'
             ret['comment'] = msg.format(policy_arn, name)
             return ret
-    _list = __salt__['boto_iam.list_attached_user_policies'](name, region, key,
-                                                    keyid, profile)
+    _list = __salt__['boto_iam.list_attached_user_policies'](name, region=region, key=key,
+                                                    keyid=keyid, profile=profile)
     newpolicies = [x.get('policy_arn') for x in _list]
     ret['changes']['new'] = {'managed_policies': newpolicies}
     msg = '{0} policies detached from user {1}.'
@@ -988,10 +996,15 @@ def _group_policies_attached(
                                        entity_filter='Group',
                                        region=region, key=key, keyid=keyid,
                                        profile=profile)
-        if {'group_name': name} not in entities.get('policy_groups', []):
+        found = False
+        for groupdict in entities.get('policy_groups', []):
+            if name == groupdict.get('group_name'):
+                found = True
+                break
+        if not found:
             policies_to_attach.append(policy)
-    _list = __salt__['boto_iam.list_attached_group_policies'](name, region, key, keyid,
-                                                    profile)
+    _list = __salt__['boto_iam.list_attached_group_policies'](name, region=region, key=key, keyid=keyid,
+                                                    profile=profile)
     oldpolicies = [x.get('policy_arn') for x in _list]
     for policy_data in _list:
         if policy_data.get('policy_name') not in managed_policies \
@@ -1009,13 +1022,13 @@ def _group_policies_attached(
         for policy_name in policies_to_attach:
             policy_set = __salt__['boto_iam.attach_group_policy'](policy_name,
                                                                  name,
-                                                                 region, key,
-                                                                 keyid,
-                                                                 profile)
+                                                                 region=region, key=key,
+                                                                 keyid=keyid,
+                                                                 profile=profile)
             if not policy_set:
-                _list = __salt__['boto_iam.list_attached_group_policies'](name, region,
-                                                                key, keyid,
-                                                                profile)
+                _list = __salt__['boto_iam.list_attached_group_policies'](name, region=region,
+                                                                key=key, keyid=keyid,
+                                                                profile=profile)
                 newpolicies = [x.get('policy_arn') for x in _list]
                 ret['changes']['new'] = {'manged_policies': newpolicies}
                 ret['result'] = False
@@ -1025,21 +1038,21 @@ def _group_policies_attached(
         for policy_name in policies_to_detach:
             policy_unset = __salt__['boto_iam.detach_group_policy'](policy_name,
                                                                    name,
-                                                                   region, key,
-                                                                   keyid,
-                                                                   profile)
+                                                                   region=region, key=key,
+                                                                   keyid=keyid,
+                                                                   profile=profile)
             if not policy_unset:
-                _list = __salt__['boto_iam.list_attached_group_policies'](name, region,
-                                                                key, keyid,
-                                                                profile)
+                _list = __salt__['boto_iam.list_attached_group_policies'](name, region=region,
+                                                                key=key, keyid=keyid,
+                                                                profile=profile)
                 newpolicies = [x.get('policy_arn') for x in _list]
                 ret['changes']['new'] = {'managed_policies': newpolicies}
                 ret['result'] = False
                 msg = 'Failed to remove policy {0} from group {1}'
                 ret['comment'] = msg.format(policy_name, name)
                 return ret
-        _list = __salt__['boto_iam.list_attached_group_policies'](name, region, key,
-                                                        keyid, profile)
+        _list = __salt__['boto_iam.list_attached_group_policies'](name, region=region, key=key,
+                                                        keyid=keyid, profile=profile)
         newpolicies = [x.get('policy_arn') for x in _list]
         log.debug(newpolicies)
         ret['changes']['new'] = {'managed_policies': newpolicies}
@@ -1071,21 +1084,21 @@ def _group_policies_detached(
     for policy_arn in oldpolicies:
         policy_unset = __salt__['boto_iam.detach_group_policy'](policy_arn,
                                                                name,
-                                                               region, key,
-                                                               keyid,
-                                                               profile)
+                                                               region=region, key=key,
+                                                               keyid=keyid,
+                                                               profile=profile)
         if not policy_unset:
-            _list = __salt__['boto_iam.list_attached_group_policies'](name, region,
-                                                            key, keyid,
-                                                            profile)
+            _list = __salt__['boto_iam.list_attached_group_policies'](name, region=region,
+                                                            key=key, keyid=keyid,
+                                                            profile=profile)
             newpolicies = [x.get('policy_arn') for x in _list]
             ret['changes']['new'] = {'managed_policies': newpolicies}
             ret['result'] = False
             msg = 'Failed to detach {0} from group {1}'
             ret['comment'] = msg.format(policy_arn, name)
             return ret
-    _list = __salt__['boto_iam.list_attached_group_policies'](name, region, key,
-                                                    keyid, profile)
+    _list = __salt__['boto_iam.list_attached_group_policies'](name, region=region, key=key,
+                                                    keyid=keyid, profile=profile)
     newpolicies = [x.get('policy_arn') for x in _list]
     ret['changes']['new'] = {'managed_policies': newpolicies}
     msg = '{0} policies detached from group {1}.'

--- a/salt/states/boto_iam_role.py
+++ b/salt/states/boto_iam_role.py
@@ -420,10 +420,15 @@ def _policies_attached(
                                        entity_filter='Role',
                                        region=region, key=key, keyid=keyid,
                                        profile=profile)
-        if {'role_name': name} not in entities.get('policy_roles', []):
+        found = False
+        for roledict in entities.get('policy_roles', []):
+            if name == roledict.get('role_name'):
+                found = True
+                break
+        if not found:
             policies_to_attach.append(policy)
-    _list = __salt__['boto_iam.list_attached_role_policies'](name, region, key, keyid,
-                                                    profile)
+    _list = __salt__['boto_iam.list_attached_role_policies'](name, region=region, key=key, keyid=keyid,
+                                                    profile=profile)
     oldpolicies = [x.get('policy_arn') for x in _list]
     for policy_data in _list:
         if policy_data.get('policy_name') not in managed_policies \
@@ -440,14 +445,16 @@ def _policies_attached(
         ret['changes']['old'] = {'managed_policies': oldpolicies}
         for policy_name in policies_to_attach:
             policy_set = __salt__['boto_iam.attach_role_policy'](policy_name,
-                                                                 name,
-                                                                 region, key,
-                                                                 keyid,
-                                                                 profile)
+                                                                 role_name=name,
+                                                                 region=region,
+                                                                 key=key,
+                                                                 keyid=keyid,
+                                                                 profile=profile)
             if not policy_set:
-                _list = __salt__['boto_iam.list_attached_role_policies'](name, region,
-                                                                key, keyid,
-                                                                profile)
+                _list = __salt__['boto_iam.list_attached_role_policies'](name, region=region,
+                                                                key=key,
+                                                                keyid=keyid,
+                                                                profile=profile)
                 newpolicies = [x.get('policy_arn') for x in _list]
                 ret['changes']['new'] = {'manged_policies': newpolicies}
                 ret['result'] = False
@@ -456,22 +463,25 @@ def _policies_attached(
                 return ret
         for policy_name in policies_to_detach:
             policy_unset = __salt__['boto_iam.detach_role_policy'](policy_name,
-                                                                   name,
-                                                                   region, key,
-                                                                   keyid,
-                                                                   profile)
+                                                                   role_name=name,
+                                                                   region=region,
+                                                                   key=key,
+                                                                   keyid=keyid,
+                                                                   profile=profile)
             if not policy_unset:
-                _list = __salt__['boto_iam.list_attached_role_policies'](name, region,
-                                                                key, keyid,
-                                                                profile)
+                _list = __salt__['boto_iam.list_attached_role_policies'](name, region=region,
+                                                                key=key,
+                                                                keyid=keyid,
+                                                                profile=profile)
                 newpolicies = [x.get('policy_arn') for x in _list]
                 ret['changes']['new'] = {'managed_policies': newpolicies}
                 ret['result'] = False
                 msg = 'Failed to remove policy {0} from role {1}'
                 ret['comment'] = msg.format(policy_name, name)
                 return ret
-        _list = __salt__['boto_iam.list_attached_role_policies'](name, region, key,
-                                                        keyid, profile)
+        _list = __salt__['boto_iam.list_attached_role_policies'](name, region=region, key=key,
+                                                        keyid=keyid,
+                                                        profile=profile)
         newpolicies = [x.get('policy_arn') for x in _list]
         log.debug(newpolicies)
         ret['changes']['new'] = {'managed_policies': newpolicies}
@@ -669,21 +679,22 @@ def _policies_detached(
     for policy_arn in oldpolicies:
         policy_unset = __salt__['boto_iam.detach_role_policy'](policy_arn,
                                                                name,
-                                                               region, key,
-                                                               keyid,
-                                                               profile)
+                                                               region=region,
+                                                               key=key,
+                                                               keyid=keyid,
+                                                               profile=profile)
         if not policy_unset:
-            _list = __salt__['boto_iam.list_attached_role_policies'](name, region,
-                                                            key, keyid,
-                                                            profile)
+            _list = __salt__['boto_iam.list_attached_role_policies'](name, region=region,
+                                                            key=key, keyid=keyid,
+                                                            profile=profile)
             newpolicies = [x.get('policy_arn') for x in _list]
             ret['changes']['new'] = {'managed_policies': newpolicies}
             ret['result'] = False
             msg = 'Failed to detach {0} from role {1}'
             ret['comment'] = msg.format(policy_arn, name)
             return ret
-    _list = __salt__['boto_iam.list_attached_role_policies'](name, region, key,
-                                                    keyid, profile)
+    _list = __salt__['boto_iam.list_attached_role_policies'](name, region=region, key=key,
+                                                    keyid=keyid, profile=profile)
     newpolicies = [x.get('policy_arn') for x in _list]
     ret['changes']['new'] = {'managed_policies': newpolicies}
     msg = '{0} policies detached from role {1}.'


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in state updates that include managed policies.
### What issues does this PR fix or reference?

None
### Previous Behavior

Attached policies would always be updated, even if no change is necessary. Also, for some ways of specifying user credentials, the call would fail entirely.
### New Behavior

Works correctly.
### Tests written?
- [ ] Yes
- [X] No
