### PR TITLE
Fix doc test errors for boto_datapipeline and boto_iot modules

### DIFF
--- a/salt/modules/boto_datapipeline.py
+++ b/salt/modules/boto_datapipeline.py
@@ -37,7 +37,9 @@ def activate_pipeline(pipeline_id, region=None, key=None, keyid=None, profile=No
     '''
     Start processing pipeline tasks. This function is idempotent.
 
-    CLI example::
+    CLI example:
+
+    .. code-block:: bash
 
         salt myminion boto_datapipeline.activate_pipeline my_pipeline_id
     '''
@@ -56,7 +58,9 @@ def create_pipeline(name, unique_id, description='', region=None, key=None, keyi
     '''
     Create a new, empty pipeline. This function is idempotent.
 
-    CLI example::
+    CLI example:
+
+    .. code-block:: bash
 
         salt myminion boto_datapipeline.create_pipeline my_name my_unique_id
     '''
@@ -78,7 +82,9 @@ def delete_pipeline(pipeline_id, region=None, key=None, keyid=None, profile=None
     '''
     Delete a pipeline, its pipeline definition, and its run history. This function is idempotent.
 
-    CLI example::
+    CLI example:
+
+    .. code-block:: bash
 
         salt myminion boto_datapipeline.delete_pipeline my_pipeline_id
     '''
@@ -96,7 +102,9 @@ def describe_pipelines(pipeline_ids, region=None, key=None, keyid=None, profile=
     '''
     Retrieve metadata about one or more pipelines.
 
-    CLI example::
+    CLI example:
+
+    .. code-block:: bash
 
         salt myminion boto_datapipeline.describe_pipelines ['my_pipeline_id']
     '''
@@ -114,7 +122,9 @@ def get_pipeline_definition(pipeline_id, version='latest', region=None, key=None
     '''
     Get the definition of the specified pipeline.
 
-    CLI example::
+    CLI example:
+
+    .. code-block:: bash
 
         salt myminion boto_datapipeline.get_pipeline_definition my_pipeline_id
     '''
@@ -133,6 +143,12 @@ def get_pipeline_definition(pipeline_id, version='latest', region=None, key=None
 def list_pipelines(region=None, key=None, keyid=None, profile=None):
     '''
     Get a list of pipeline ids and names for all pipelines.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_datapipeline.list_pipelines profile=myprofile
     '''
     client = _get_client(region, key, keyid, profile)
     r = {}
@@ -151,7 +167,9 @@ def pipeline_id_from_name(name, region=None, key=None, keyid=None, profile=None)
     '''
     Get the pipeline id, if it exists, for the given name.
 
-    CLI example::
+    CLI example:
+
+    .. code-block:: bash
 
         salt myminion boto_datapipeline.pipeline_id_from_name my_pipeline_name
     '''
@@ -174,7 +192,9 @@ def put_pipeline_definition(pipeline_id, pipeline_objects, parameter_objects=Non
     Add tasks, schedules, and preconditions to the specified pipeline. This function is
     idempotent and will replace an existing definition.
 
-    CLI example::
+    CLI example:
+
+    .. code-block:: bash
 
         salt myminion boto_datapipeline.put_pipeline_definition my_pipeline_id my_pipeline_objects
     '''

--- a/salt/modules/boto_iot.py
+++ b/salt/modules/boto_iot.py
@@ -35,9 +35,9 @@ Connection module for Amazon IoT
     .. code-block:: yaml
 
         myprofile:
-            keyid: GKTADJGHEIQSXMKKRBJ08H
-            key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
-            region: us-east-1
+          keyid: GKTADJGHEIQSXMKKRBJ08H
+          key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+          region: us-east-1
 
 :depends: boto3
 
@@ -345,6 +345,12 @@ def list_policies(region=None, key=None, keyid=None, profile=None):
 
     CLI Example:
 
+    .. code-block:: bash
+
+        salt myminion boto_iot.list_policies
+
+    Example Return:
+
     .. code-block:: yaml
 
         policies:
@@ -371,7 +377,13 @@ def list_policy_versions(policyName,
     '''
     List the versions available for the given policy.
 
-    CLI Example
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iot.list_policy_versions mypolicy
+
+    Example Return:
 
     .. code-block:: yaml
 
@@ -427,7 +439,13 @@ def list_principal_policies(principal,
     '''
     List the policies attached to the given principal.
 
-    CLI Example
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iot.list_principal_policies myprincipal
+
+    Example Return:
 
     .. code-block:: yaml
 
@@ -661,6 +679,12 @@ def list_topic_rules(topic=None, ruleDisabled=None,
     Returns list of rules
 
     CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_iot.list_topic_rules
+
+    Example Return:
 
     .. code-block:: yaml
 

--- a/salt/states/boto_datapipeline.py
+++ b/salt/states/boto_datapipeline.py
@@ -2,6 +2,8 @@
 '''
 Manage Data Pipelines
 
+.. versionadded:: 2016.3.0
+
 Be aware that this interacts with Amazon's services, and so may incur charges.
 
 This module uses ``boto3``, which can be installed via package, or pip.


### PR DESCRIPTION
### What does this PR do?

There are several test errors on the 2016.3 branch for the `integration.modules.sysmod.SysModuleTest.test_valid_docs` test:

```
No example:
  - boto_datapipeline.list_pipelines
  - boto_iot.list_policy_versions
  - boto_iot.list_principal_policies
```
### Previous Behavior

Incorrect doc rendering of CLI examples, or there were no CLI examples at all.
### New Behavior

Corrected the doc rendering and added CLI examples where necessary. Some functions had nice examples of what the function would return listed under a CLI example. This PR makes it more clear what the return is vs. how to use the function.
### Tests written?
- [ ] Yes
- [x] No
