### PR TITLE
OS-EXT-IPS:type is not always defined on addresses

### DIFF
--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -661,7 +661,11 @@ def request_instance(vm_=None, call=None):
     if data.extra.get('password', None) is None and vm_.get('key_filename', None) is None:
         raise SaltCloudSystemExit('No password returned.  Set ssh_key_file.')
 
-    floating_ip_conf = config.get_cloud_config_value('floating_ip', vm_, __opts__, search_global=False)
+    floating_ip_conf = config.get_cloud_config_value('floating_ip',
+                                                     vm_,
+                                                     __opts__,
+                                                     search_global=False,
+                                                     default={})
     if floating_ip_conf.get('auto_assign', False):
         pool = floating_ip_conf.get('pool', 'public')
         for fl_ip, opts in conn.floating_ip_list().iteritems():

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -148,7 +148,7 @@ class NovaServer(object):
                     self.public_ips.append(addr['addr'])
                 else:
                     self.private_ips.append(addr['addr'])
-                if addr['OS-EXT-IPS:type'] == 'floating':
+                if addr.get('OS-EXT-IPS:type') == 'floating':
                     self.floating_ips.append(addr['addr'])
                 else:
                     self.fixed_ips.append(addr['addr'])


### PR DESCRIPTION
### What does this PR do?

fixes references to OS-EXT-IPS:type
### What issues does this PR fix or reference?

```
[DEBUG   ] Failed to execute 'nova.list_nodes_full()' while querying for running nodes: 'OS-EXT-IPS:type'
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/cloud/__init__.py", line 2334, in run_parallel_map_providers_query
    cloud.clouds[data['fun']]()
  File "/usr/lib/python2.7/site-packages/salt/cloud/clouds/nova.py", line 1088, in list_nodes_full
    server_list[server]['id']
  File "/usr/lib/python2.7/site-packages/salt/utils/openstack/nova.py", line 316, in server_show_libcloud
    ret = NovaServer(server_name, server, self.password)
  File "/usr/lib/python2.7/site-packages/salt/utils/openstack/nova.py", line 151, in __init__
    if addr['OS-EXT-IPS:type'] == 'floating':
KeyError: 'OS-EXT-IPS:type'
```
### Previous Behavior
### New Behavior
### Tests written?
- [ ] Yes
- [x] No

In novaclient servers
