### PR TITLE
Make sure __virtual__ error message is helpful when psutil is missing

### DIFF
--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -27,7 +27,7 @@ except ImportError:
 
 def __virtual__():
     if not HAS_PSUTIL:
-        return False
+        return False, 'The ps module cannot be loaded: psutil not installed.'
 
     # Functions and attributes used in this execution module seem to have been
     # added as of psutil 0.3.0, from an inspection of the source code. Only
@@ -38,7 +38,7 @@ def __virtual__():
     # as of Dec. 2013 EPEL is on 0.6.1, Debian 7 is on 0.5.1, etc.).
     if psutil.version_info >= (0, 3, 0):
         return True
-    return False
+    return False, 'The ps module cannot be loaded: psutil must be version 0.3.0 or greater.'
 
 
 def _get_proc_cmdline(proc):


### PR DESCRIPTION
### What does this PR do?

Provides a helpful error when the ps module isn't able to load.
### What issues does this PR fix or reference?

Fixes #19659
Fixes #31867
### Previous Behavior

The reason the ps function didn't work was only viewable via `-l debug`:

```
# salt rallytime ps.get_pid_list
...
[DEBUG   ] Could not LazyLoad ps.get_pid_list
Module 'ps' is not available.
```
### New Behavior

```
# salt rallytime ps.get_pid_list
rallytime:
    'ps' __virtual__ returned False: The ps module cannot be loaded: psutil not installed.
```
### Tests written?
- [ ] Yes
- [x] No
