### PR TITLE
Fix scaleway cloud provider and manage x86 servers

### DIFF
--- a/salt/cloud/clouds/scaleway.py
+++ b/salt/cloud/clouds/scaleway.py
@@ -237,10 +237,15 @@ def create(server_):
         'access_key', get_configured_provider(), __opts__, search_global=False
     )
 
+    commercial_type = config.get_cloud_config_value(
+        'commercial_type', server_, __opts__, default='C1'
+    )
+
     kwargs = {
         'name': server_['name'],
         'organization': access_key,
         'image': get_image(server_),
+        'commercial_type': commercial_type,
     }
 
     salt.utils.cloud.fire_event(
@@ -331,7 +336,7 @@ def query(method='servers', server_id=None, command=None, args=None,
         get_configured_provider(),
         __opts__,
         search_global=False,
-        default='https://api.scaleway.com'
+        default='https://api.cloud.online.net'
     ))
 
     path = '{0}/{1}/'.format(base_path, method)
@@ -360,7 +365,7 @@ def query(method='servers', server_id=None, command=None, args=None,
         raise SaltCloudSystemExit(
             'An error occurred while querying Scaleway. HTTP Code: {0}  '
             'Error: {1!r}'.format(
-                request.getcode(),
+                request.status_code,
                 request.text
             )
         )


### PR DESCRIPTION
### What does this PR do?

This PR fixes the scaleway provider to take into account that Scaleway provides different types of X86 servers (aka C2) in addition to C1 arm servers.
It also fixes small errors preventing the driver from working.
### What issues does this PR fix or reference?
### Previous Behavior

Unable to use scaleway cloud provider.
### New Behavior

Scaleway provider working, and able to manage different kind of servers
- `request.get_code()` replaced by `request.status_code`
- default API url updated
- type of server to create needs to be passed to API
### Tests written?
- [ ] Yes
- [X] No
