### PR TITLE
Fix salt.utils.decorators.Depends

### DIFF
--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -101,7 +101,8 @@ class Depends(object):
                     )
                     continue
 
-                if dependency in dir(frame):
+                if dependency in frame.f_globals \
+                        or dependency in frame.f_locals:
                     log.trace(
                         'Dependency ({0}) already loaded inside {1}, '
                         'skipping'.format(

--- a/tests/integration/loader/loader.py
+++ b/tests/integration/loader/loader.py
@@ -31,6 +31,59 @@ from salt.config import minion_config
 
 from salt.loader import LazyLoader, _module_dirs, grains
 
+loader_template = '''
+import os
+from salt.utils.decorators import depends
+
+@depends('os')
+def loaded():
+    return True
+
+@depends('non_existantmodulename')
+def not_loaded():
+    return True
+'''
+
+class LazyLoaderTest(TestCase):
+    '''
+    Test the loader
+    '''
+    module_name = 'lazyloadertest'
+
+    def setUp(self):
+        self.opts = minion_config(None)
+        self.opts['disable_modules'] = ['pillar']
+        self.opts['grains'] = grains(self.opts)
+
+        # Setup the module
+        self.module_dir = tempfile.mkdtemp(dir=tests.integration.TMP)
+        self.module_file = os.path.join(self.module_dir,
+                                        '{0}.py'.format(self.module_name))
+        with open(self.module_file, 'w') as fh:
+            fh.write(loader_template)
+            fh.flush()
+            os.fsync(fh.fileno())
+
+        # Invoke the loader
+        self.loader = LazyLoader([self.module_dir], self.opts, tag='module')
+
+    def tearDown(self):
+        shutil.rmtree(self.module_dir)
+
+    def test_depends(self):
+        '''
+        Test that the depends decorator works properly
+        '''
+        # Make sure depends correctly allowed a function to load. If this
+        # results in a KeyError, the decorator is broken.
+        self.assertTrue(
+            inspect.isfunction(
+                self.loader[self.module_name + '.loaded']
+            )
+        )
+        # Make sure depends correctly kept a function from loading
+        self.assertTrue(self.module_name + '.not_loaded' not in self.loader)
+
 
 class LazyLoaderVirtualEnabledTest(TestCase):
     '''


### PR DESCRIPTION
bebdc266 broke this decorator, because switching from getting the module to
getting a frame means `dir(frame)` does not contain the imported names. Those
now reside in `frame.f_globals` and `frame.f_locals`.

This pull request fixes the membership check to look in the proper location,
and adds an integration test to confirm correct behavior of the depends
decorator.
