### PR TITLE
Hotfix/windows proxy enable

### DIFF
--- a/salt/modules/proxy.py
+++ b/salt/modules/proxy.py
@@ -86,6 +86,13 @@ def _get_proxy_windows(types=None):
             if key not in types:
                 del ret[key]
 
+    # Return enabled info
+    reg_val = __salt__['reg.read_value']('HKEY_CURRENT_USER',
+                                         r'SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings',
+                                         'ProxyEnable')
+    enabled = reg_val.get('vdata', 0)
+    ret['enabled'] = True if enabled == 1 else False
+
     return ret
 
 
@@ -99,6 +106,9 @@ def _set_proxy_windows(server, port, types=None, bypass_hosts=None, import_winht
 
     __salt__['reg.set_value']('HKEY_CURRENT_USER', r'SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings',
                               'ProxyServer', server_str)
+
+    __salt__['reg.set_value']('HKEY_CURRENT_USER', r'SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings',
+                              'ProxyEnable', 1, vtype='REG_DWORD')
 
     if bypass_hosts is not None:
         bypass_hosts_str = '<local>;{0}'.format(';'.join(bypass_hosts))

--- a/salt/states/proxy.py
+++ b/salt/states/proxy.py
@@ -111,15 +111,19 @@ def managed(name, port, services=None, user=None, password=None, bypass_domains=
         current_settings = __salt__['proxy.get_proxy_win']()
         current_domains = __salt__['proxy.get_proxy_bypass']()
 
-        for service in services:
-            # We need to update one of our proxy servers
-            if service not in current_settings:
-                changes_needed = True
-                break
+        if current_settings.get('enabled', False) is True:
+            for service in services:
+                # We need to update one of our proxy servers
+                if service not in current_settings:
+                    changes_needed = True
+                    break
 
-            if current_settings[service]['server'] != name or current_settings[service]['port'] != str(port):
-                changes_needed = True
-                break
+                if current_settings[service]['server'] != name or current_settings[service]['port'] != str(port):
+                    changes_needed = True
+                    break
+        else:
+            # Proxy settings aren't enabled
+            changes_needed = True
 
         # We need to update our bypass domains
         if len(set(current_domains).intersection(bypass_domains)) != len(bypass_domains):

--- a/salt/states/proxy.py
+++ b/salt/states/proxy.py
@@ -64,7 +64,7 @@ def managed(name, port, services=None, user=None, password=None, bypass_domains=
     ret = {'name': name,
            'result': True,
            'comment': '',
-           'changes': {'new': []}}
+           'changes': {}}
 
     valid_services = ['http', 'https', 'ftp']
 
@@ -73,6 +73,7 @@ def managed(name, port, services=None, user=None, password=None, bypass_domains=
 
     # Darwin
     if __grains__['os'] in ['MacOS', 'Darwin']:
+        ret['changes'] = {'new': []}
 
         for service in services:
             current_settings = __salt__['proxy.get_{0}_proxy'.format(service)]()
@@ -98,6 +99,11 @@ def managed(name, port, services=None, user=None, password=None, bypass_domains=
             else:
                 ret['result'] = False
                 ret['comment'] += 'Failed to set bypass proxy domains.\n'
+
+        if len(ret['changes']['new']) == 0:
+            del ret['changes']['new']
+
+        return ret
 
     # Windows - Needs its own branch as all settings need to be set at the same time
     if __grains__['os'] in ['Windows']:
@@ -127,8 +133,5 @@ def managed(name, port, services=None, user=None, password=None, bypass_domains=
                 ret['comment'] = 'Failed to set {0} proxy settings.'
         else:
             ret['comment'] = 'Proxy settings already correct.'
-
-    if len(ret['changes']['new']) == 0:
-        del ret['changes']['new']
 
     return ret

--- a/tests/unit/modules/proxy_test.py
+++ b/tests/unit/modules/proxy_test.py
@@ -211,11 +211,18 @@ class ProxyTestCase(TestCase):
             on Windows
         '''
         proxy.__grains__['os'] = 'Windows'
-        result = {
-            'vdata': 'http=192.168.0.1:3128;https=192.168.0.2:3128;ftp=192.168.0.3:3128'
-        }
-        mock = MagicMock(return_value=result)
+        results = [
+            {
+                'vdata': 'http=192.168.0.1:3128;https=192.168.0.2:3128;ftp=192.168.0.3:3128'
+            },
+            {
+                'vdata': 1
+            }
+        ]
+        mock = MagicMock(side_effect=results)
+
         expected = {
+            'enabled': True,
             'http': {
                 'server': '192.168.0.1',
                 'port': '3128'
@@ -231,9 +238,16 @@ class ProxyTestCase(TestCase):
         }
         with patch.dict(proxy.__salt__, {'reg.read_value': mock}):
             out = proxy.get_proxy_win()
-            mock.assert_called_once_with('HKEY_CURRENT_USER',
-                                         'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
-                                         'ProxyServer')
+            calls = [
+                call('HKEY_CURRENT_USER',
+                     'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                     'ProxyServer'),
+                call('HKEY_CURRENT_USER',
+                     'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                     'ProxyEnable'),
+            ]
+
+            mock.assert_has_calls(calls)
             self.assertEqual(expected, out)
 
     def test_set_http_proxy_windows(self):
@@ -253,6 +267,11 @@ class ProxyTestCase(TestCase):
                      'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
                      'ProxyServer',
                      'http=192.168.0.1:3128;'),
+                call('HKEY_CURRENT_USER',
+                     'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                     'ProxyEnable',
+                     1,
+                     vtype='REG_DWORD'),
                 call('HKEY_CURRENT_USER',
                      'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
                      'ProxyOverride',
@@ -281,6 +300,11 @@ class ProxyTestCase(TestCase):
                      'https=192.168.0.1:3128;'),
                 call('HKEY_CURRENT_USER',
                      'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                     'ProxyEnable',
+                     1,
+                     vtype='REG_DWORD'),
+                call('HKEY_CURRENT_USER',
+                     'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
                      'ProxyOverride',
                      '<local>;.moo.com;.salt.com')
             ]
@@ -305,6 +329,11 @@ class ProxyTestCase(TestCase):
                      'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
                      'ProxyServer',
                      'ftp=192.168.0.1:3128;'),
+                call('HKEY_CURRENT_USER',
+                     'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                     'ProxyEnable',
+                     1,
+                     vtype='REG_DWORD'),
                 call('HKEY_CURRENT_USER',
                      'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
                      'ProxyOverride',
@@ -333,6 +362,11 @@ class ProxyTestCase(TestCase):
                      'http=192.168.0.1:3128;https=192.168.0.1:3128;ftp=192.168.0.1:3128;'),
                 call('HKEY_CURRENT_USER',
                      'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                     'ProxyEnable',
+                     1,
+                     vtype='REG_DWORD'),
+                call('HKEY_CURRENT_USER',
+                     'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
                      'ProxyOverride',
                      '<local>;.moo.com;.salt.com')
             ]
@@ -358,6 +392,11 @@ class ProxyTestCase(TestCase):
                      'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
                      'ProxyServer',
                      'http=192.168.0.1:3128;https=192.168.0.1:3128;'),
+                call('HKEY_CURRENT_USER',
+                     'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                     'ProxyEnable',
+                     1,
+                     vtype='REG_DWORD'),
                 call('HKEY_CURRENT_USER',
                      'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
                      'ProxyOverride',

--- a/tests/unit/states/proxy_test.py
+++ b/tests/unit/states/proxy_test.py
@@ -157,6 +157,7 @@ class ProxyTestCase(TestCase):
         }
 
         proxy_val = {
+            'enabled': True,
             'http': {
                 'enabled': True,
                 'server': '192.168.0.1',


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where windows proxy was not enabled after updating the settings
### What issues does this PR fix or reference?

See above
### Previous Behavior

The proxy settings were set but not enabled
### New Behavior

The proxy settings will now be enabled when set on windows
### Tests written?
- [x] Yes
- [ ] No
