### PR TITLE
Add "python module" clarification to ps __virtual__ warning.

### DIFF
--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -27,7 +27,7 @@ except ImportError:
 
 def __virtual__():
     if not HAS_PSUTIL:
-        return False, 'The ps module cannot be loaded: psutil not installed.'
+        return False, 'The ps module cannot be loaded: python module psutil not installed.'
 
     # Functions and attributes used in this execution module seem to have been
     # added as of psutil 0.3.0, from an inspection of the source code. Only


### PR DESCRIPTION
Added based on comment from Issue #31867.
