### PR TITLE
Clean non-applicable SMBIOS info for serial, part, and version matches

### DIFF
--- a/salt/modules/smbios.py
+++ b/salt/modules/smbios.py
@@ -298,12 +298,13 @@ def _dmi_isclean(key, val):
         return False
     elif re.search('serial|part|version', key):
         # 'To be filled by O.E.M.
+        # 'Not applicable' etc.
         # 'Not specified' etc.
         # 0000000, 1234667 etc.
         # begone!
         return not re.match(r'^[0]+$', val) \
                 and not re.match(r'[0]?1234567[8]?[9]?[0]?', val) \
-                and not re.search(r'sernum|part[_-]?number|specified|filled', val, flags=re.IGNORECASE)
+                and not re.search(r'sernum|part[_-]?number|specified|filled|applicable', val, flags=re.IGNORECASE)
     elif re.search('asset|manufacturer', key):
         # AssetTag0. Manufacturer04. Begone.
         return not re.search(r'manufacturer|to be filled|available|asset|^no(ne|t)', val, flags=re.IGNORECASE)


### PR DESCRIPTION
### What does this PR do?

When cleaning out well-known bogus values from a DMI contents, this
change adds a filter for values containing the string "applicable" for
the serial number (as well as "part" and "version" matches). 
### What issues does this PR fix or reference?

For example, if "Not Applicable" is returned from SMBIOS for the serial
number (DMI string "system-serial-number"), this change will not allow
the string "Not Applicable" from being saved as the grain value.
### Previous Behavior

Previously, the grains value for the minion's serial number could read the string "Not Applicable", which can be confusing since it creates a grain value with a non-empty string when no logical value truthfully exists. Applications will likely determine the existence of grains based on whether or not a string value exists.
### New Behavior

See my previous explanation. The new behavior will filter "Not Applicable" in the serial number, as well as "part" and "version" matches.
### Tests written?
- [ ] Yes
- [x] No

Signed-off-by: Perry Zipoy perry.zipoy@ni.com
