### PR TITLE
fix broken system module on SunOS cause by a0a66fa32600751d394d724b2f…

### DIFF
--- a/salt/modules/system.py
+++ b/salt/modules/system.py
@@ -12,13 +12,16 @@ __virtualname__ = 'system'
 def __virtual__():
     '''
     Only supported on POSIX-like systems
-    Windows and Mac have their own modules
+    Windows, Solaris, and Mac have their own modules
     '''
     if salt.utils.is_windows():
         return (False, 'This module is not available on windows')
 
     if salt.utils.is_darwin():
         return (False, 'This module is not available on Mac OS')
+
+    if salt.utils.is_sunos():
+        return (False, 'This module is not available on SunOS')
 
     if not salt.utils.which('shutdown'):
         return (False, 'The system execution module failed to load: '


### PR DESCRIPTION
### What does this PR do?

Fixes bad rebase 63172cd0752472f60cec523cb8a0b69e
### What issues does this PR fix or reference?

This fixes SunOS being broken by 63172cd0752472f60cec523cb8a0b69e
### Previous Behavior

Rebase 63172cd0752472f60cec523cb8a0b69e causes system.py to be loaded again on SunOS.
### New Behavior

Don't load system.py on SunOS
### Tests written?
- [ ] Yes
- [X] No
### Affected branches
- 2016.3
- develop

…18825ea23a93d7
