### PR TITLE
Fixed references to boto3 in boto_s3_bucket module

### DIFF
--- a/salt/modules/boto_s3_bucket.py
+++ b/salt/modules/boto_s3_bucket.py
@@ -45,6 +45,7 @@ Connection module for Amazon S3 Buckets
 # keep lint from choking on _get_conn and _cache_id
 #pylint: disable=E0602
 
+
 # Import Python libs
 from __future__ import absolute_import
 import logging
@@ -52,7 +53,6 @@ from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=i
 import json
 
 # Import Salt libs
-import salt.utils.boto3
 import salt.utils.compat
 import salt.utils
 from salt.ext.six import string_types
@@ -121,7 +121,7 @@ def exists(Bucket,
     except ClientError as e:
         if e.response.get('Error', {}).get('Code') == '404':
             return {'exists': False}
-        err = salt.utils.boto3.get_error(e)
+        err = __utils__['boto3.get_error'](e)
         return {'error': err}
 
 
@@ -171,7 +171,7 @@ def create(Bucket,
             log.warning('Bucket was not created')
             return {'created': False}
     except ClientError as e:
-        return {'created': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'created': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def delete(Bucket,
@@ -195,7 +195,7 @@ def delete(Bucket,
         conn.delete_bucket(Bucket=Bucket)
         return {'deleted': True}
     except ClientError as e:
-        return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'deleted': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def describe(Bucket,
@@ -257,10 +257,10 @@ def describe(Bucket,
             result['Tagging'] = tags
         return {'bucket': result}
     except ClientError as e:
-        err = salt.utils.boto3.get_error(e)
+        err = __utils__['boto3.get_error'](e)
         if e.response.get('Error', {}).get('Code') == 'NoSuchBucket':
             return {'bucket': None}
-        return {'error': salt.utils.boto3.get_error(e)}
+        return {'error': __utils__['boto3.get_error'](e)}
 
 
 def list(region=None, key=None, keyid=None, profile=None):
@@ -287,7 +287,7 @@ def list(region=None, key=None, keyid=None, profile=None):
         del buckets['ResponseMetadata']
         return buckets
     except ClientError as e:
-        return {'error': salt.utils.boto3.get_error(e)}
+        return {'error': __utils__['boto3.get_error'](e)}
 
 
 def put_acl(Bucket,
@@ -332,7 +332,7 @@ def put_acl(Bucket,
         conn.put_bucket_acl(Bucket=Bucket, **kwargs)
         return {'updated': True, 'name': Bucket}
     except ClientError as e:
-        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'updated': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def put_cors(Bucket,
@@ -365,7 +365,7 @@ def put_cors(Bucket,
         conn.put_bucket_cors(Bucket=Bucket, CORSConfiguration={'CORSRules': CORSRules})
         return {'updated': True, 'name': Bucket}
     except ClientError as e:
-        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'updated': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def put_lifecycle_configuration(Bucket,
@@ -400,7 +400,7 @@ def put_lifecycle_configuration(Bucket,
         conn.put_bucket_lifecycle_configuration(Bucket=Bucket, LifecycleConfiguration={'Rules': Rules})
         return {'updated': True, 'name': Bucket}
     except ClientError as e:
-        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'updated': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def put_logging(Bucket,
@@ -439,7 +439,7 @@ def put_logging(Bucket,
         conn.put_bucket_logging(Bucket=Bucket, BucketLoggingStatus=logstatus)
         return {'updated': True, 'name': Bucket}
     except ClientError as e:
-        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'updated': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def put_notification_configuration(Bucket,
@@ -485,7 +485,7 @@ def put_notification_configuration(Bucket,
         })
         return {'updated': True, 'name': Bucket}
     except ClientError as e:
-        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'updated': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def put_policy(Bucket, Policy,
@@ -513,7 +513,7 @@ def put_policy(Bucket, Policy,
         conn.put_bucket_policy(Bucket=Bucket, Policy=Policy)
         return {'updated': True, 'name': Bucket}
     except ClientError as e:
-        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'updated': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def _get_role_arn(name, region=None, key=None, keyid=None, profile=None):
@@ -560,7 +560,7 @@ def put_replication(Bucket, Role, Rules,
         })
         return {'updated': True, 'name': Bucket}
     except ClientError as e:
-        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'updated': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def put_request_payment(Bucket, Payer,
@@ -586,7 +586,7 @@ def put_request_payment(Bucket, Payer,
         })
         return {'updated': True, 'name': Bucket}
     except ClientError as e:
-        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'updated': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def put_tagging(Bucket,
@@ -617,7 +617,7 @@ def put_tagging(Bucket,
         })
         return {'updated': True, 'name': Bucket}
     except ClientError as e:
-        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'updated': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def put_versioning(Bucket, Status, MFADelete=None, MFA=None,
@@ -649,7 +649,7 @@ def put_versioning(Bucket, Status, MFADelete=None, MFA=None,
                 **kwargs)
         return {'updated': True, 'name': Bucket}
     except ClientError as e:
-        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'updated': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def put_website(Bucket, ErrorDocument=None, IndexDocument=None,
@@ -684,7 +684,7 @@ def put_website(Bucket, ErrorDocument=None, IndexDocument=None,
                 WebsiteConfiguration=WebsiteConfiguration)
         return {'updated': True, 'name': Bucket}
     except ClientError as e:
-        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'updated': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def delete_cors(Bucket,
@@ -708,7 +708,7 @@ def delete_cors(Bucket,
         conn.delete_bucket_cors(Bucket=Bucket)
         return {'deleted': True, 'name': Bucket}
     except ClientError as e:
-        return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'deleted': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def delete_lifecycle_configuration(Bucket,
@@ -732,7 +732,7 @@ def delete_lifecycle_configuration(Bucket,
         conn.delete_bucket_lifecycle(Bucket=Bucket)
         return {'deleted': True, 'name': Bucket}
     except ClientError as e:
-        return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'deleted': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def delete_policy(Bucket,
@@ -756,7 +756,7 @@ def delete_policy(Bucket,
         conn.delete_bucket_policy(Bucket=Bucket)
         return {'deleted': True, 'name': Bucket}
     except ClientError as e:
-        return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'deleted': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def delete_replication(Bucket,
@@ -780,7 +780,7 @@ def delete_replication(Bucket,
         conn.delete_bucket_replication(Bucket=Bucket)
         return {'deleted': True, 'name': Bucket}
     except ClientError as e:
-        return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'deleted': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def delete_tagging(Bucket,
@@ -804,7 +804,7 @@ def delete_tagging(Bucket,
         conn.delete_bucket_tagging(Bucket=Bucket)
         return {'deleted': True, 'name': Bucket}
     except ClientError as e:
-        return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'deleted': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def delete_website(Bucket,
@@ -828,4 +828,4 @@ def delete_website(Bucket,
         conn.delete_bucket_website(Bucket=Bucket)
         return {'deleted': True, 'name': Bucket}
     except ClientError as e:
-        return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'deleted': False, 'error': __utils__['boto3.get_error'](e)}

--- a/salt/modules/boto_s3_bucket.py
+++ b/salt/modules/boto_s3_bucket.py
@@ -45,7 +45,6 @@ Connection module for Amazon S3 Buckets
 # keep lint from choking on _get_conn and _cache_id
 #pylint: disable=E0602
 
-
 # Import Python libs
 from __future__ import absolute_import
 import logging

--- a/salt/states/boto_s3_bucket.py
+++ b/salt/states/boto_s3_bucket.py
@@ -144,7 +144,6 @@ import json
 
 # Import Salt Libs
 from salt.ext.six import string_types  # pylint: disable=import-error
-from salt.utils.boto3 import json_objs_equal
 
 log = logging.getLogger(__name__)
 
@@ -270,7 +269,7 @@ def _get_role_arn(name, region=None, key=None, keyid=None, profile=None):
 
 
 def _compare_json(current, desired, region, key, keyid, profile):
-    return json_objs_equal(current, desired)
+    return __utils__['boto3.json_objs_equal'](current, desired)
 
 
 def _compare_acl(current, desired, region, key, keyid, profile):
@@ -281,7 +280,7 @@ def _compare_acl(current, desired, region, key, keyid, profile):
     rather than the input itself.
     '''
     ocid = _get_canonical_id(region, key, keyid, profile)
-    return json_objs_equal(current, _acl_to_grant(desired, ocid))
+    return __utils__['boto3.json_objs_equal'](current, _acl_to_grant(desired, ocid))
 
 
 def _compare_policy(current, desired, region, key, keyid, profile):
@@ -298,7 +297,7 @@ def _compare_policy(current, desired, region, key, keyid, profile):
             current = {'Policy': json.loads(temp)}
         else:
             current = None
-    return json_objs_equal(current, desired)
+    return __utils__['boto3.json_objs_equal'](current, desired)
 
 
 def _compare_replication(current, desired, region, key, keyid, profile):
@@ -309,7 +308,7 @@ def _compare_replication(current, desired, region, key, keyid, profile):
         desired = deepcopy(desired)
         desired['Role'] = _get_role_arn(desired['Role'],
                                  region=region, key=key, keyid=keyid, profile=profile)
-    return json_objs_equal(current, desired)
+    return __utils__['boto3.json_objs_equal'](current, desired)
 
 
 def present(name, Bucket,


### PR DESCRIPTION
### What does this PR do?

Removes boto3 import dependency.
### What issues does this PR fix or reference?

N/A
### Previous Behavior

The module imports salt.utils.boto3 and calls functions from it directly.
### New Behavior

boto3 functions are called from __utils__ instead.
### Tests written?
- [ ] Yes
- [X] No

@ryan-lane 
