### PR TITLE
Back port nullsoft build script from 2015.8

### DIFF
--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -222,10 +222,10 @@ ShowUnInstDetails show
 Section "MainSection" SEC01
 
   SetOutPath "$INSTDIR\"
-  SetOverwrite try
+  SetOverwrite off
   CreateDirectory $INSTDIR\conf\pki\minion
   File /r "..\buildenv\"
-  Exec 'icacls c:\salt /inheritance:r /grant:r "BUILTIN\Administrators":(OI)(CI)F /grant:r "NT AUTHORITY\SYSTEM":(OI)(CI)F'
+  Exec 'icacls c:\salt /inheritance:r /grant:r "*S-1-5-32-544":(OI)(CI)F /grant:r "*S-1-5-18":(OI)(CI)F'
 
 SectionEnd
 


### PR DESCRIPTION
### What does this PR do?

Backport the nullsoft buildscript from 2015.8 for future builds. Fixes the overwrite config bug.
### Tests written?
- [ ] Yes
- [x] No
