### PR TITLE
Typo

### DIFF
--- a/doc/topics/targeting/nodegroups.rst
+++ b/doc/topics/targeting/nodegroups.rst
@@ -32,7 +32,7 @@ nodegroups. Here's an example nodegroup configuration within
 
 .. note::
 
-    Nodgroups can reference other nodegroups as seen in ``group3``.  Ensure
+    Nodegroups can reference other nodegroups as seen in ``group3``.  Ensure
     that you do not have circular references.  Circular references will be
     detected and cause partial expansion with a logged error message.
 


### PR DESCRIPTION
### What does this PR do?

Fixes a typo in the docs about node groups.
### What issues does this PR fix or reference?

None.
### Previous Behavior

Nodgroups
### New Behavior

Nodegroups
### Tests written?
- [ ] Yes
- [ X ] No

Trivial typo. s/Nodgroups/Nodegroups/g
