### PR TITLE
seconds is not always set, do not assume it is

### DIFF
--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -133,7 +133,7 @@ def list_(show_all=False,
             # original item didn't include it.
             if schedule[job]['_seconds'] > 0:
                 schedule[job]['seconds'] = schedule[job]['_seconds']
-            else:
+            elif 'seconds' in schedule[job]:
                 del schedule[job]['seconds']
 
             # remove _seconds from the listing


### PR DESCRIPTION
### What does this PR do?

Stops the assumption that 'seconds' is always set in a schedule job, check before deleting
### What issues does this PR fix or reference?

Back-port PR #31691, see notes on PR
### Previous Behavior

Depending on the state, it would throw an exception when deleting 'seconds' for the job dict.
### New Behavior

Check before delete, so we don't hit the exception.
### Tests written?
- [ ] Yes
- [X] No
### Affected branches
- 2016.3
- develop
