### PR TITLE
Added term_all_jobs and kill_all_jobs to saltutil module

### DIFF
--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -770,6 +770,22 @@ def term_job(jid):
     return signal_job(jid, signal.SIGTERM)
 
 
+def term_all_jobs():
+    '''
+    Sends a termination signal (SIGTERM 15) to all currently running jobs
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' saltutil.term_all_jobs
+    '''
+    ret = []
+    for data in running():
+        ret.append(signal_job(data['jid'], salt_SIGTERM))
+    return ret
+
+
 def kill_job(jid):
     '''
     Sends a kill signal (SIGKILL 9) to the named salt job's process
@@ -783,6 +799,24 @@ def kill_job(jid):
     # Some OS's (Win32) don't have SIGKILL, so use salt_SIGKILL which is set to
     # an appropriate value for the operating system this is running on.
     return signal_job(jid, salt_SIGKILL)
+
+
+def kill_all_jobs():
+    '''
+    Sends a kill signal (SIGKILL 9) to all currently running jobs
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' saltutil.kill_all_jobs
+    '''
+    # Some OS's (Win32) don't have SIGKILL, so use salt_SIGKILL which is set to
+    # an appropriate value for the operating system this is running on.
+    ret = []
+    for data in running():
+        ret.append(signal_job(data['jid'], salt_SIGKILL))
+    return ret
 
 
 def regen_keys():

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -782,7 +782,7 @@ def term_all_jobs():
     '''
     ret = []
     for data in running():
-        ret.append(signal_job(data['jid'], salt_SIGTERM))
+        ret.append(signal_job(data['jid'], signal.SIGTERM))
     return ret
 
 


### PR DESCRIPTION
### What does this PR do?

This PR adds 2 new methods to saltutil: kill_all_jobs and term_all_jobs as an easier way to terminate or kill active jobs on a minion
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/10688
### Previous Behavior

No changes in previous behavior, added new methods
### New Behavior

kill_all_jobs and term_all_jobs in saltutil loop through all running jobs and send the signal to the minion
### Tests written?
- [ ] Yes
- [X] No
