### PR TITLE
Do not fail service.{running,dead} if $(runlevel) = 'unknown'

### DIFF
--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -226,7 +226,7 @@ def _runlevel():
     contextkey = 'systemd._runlevel'
     if contextkey in __context__:
         return __context__[contextkey]
-    out = __salt__['cmd.run']('runlevel', python_shell=False)
+    out = __salt__['cmd.run']('runlevel', python_shell=False, ignore_retcode=True)
     try:
         ret = out.split()[1]
     except IndexError:


### PR DESCRIPTION
### What does this PR do?

Prevents irrelevant status of runlevel command from getting into **context**['retcode'].
### What issues does this PR fix or reference?

Failure of service.running or service.dead when runlevel command prints "unknown" and returns status 1.
### Previous Behavior

service.running and service.dead fail when runlevel command prints "unknown" and returns status 1.
### New Behavior

service.running and service.dead complete successfully even if runlevel command prints "unknown" and returns status 1.
### Tests written?
- [ ] Yes
- [x] No
