### PR TITLE
fixed ec2 get_console_output

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -4269,6 +4269,7 @@ def get_console_output(
 
     ret = {}
     data = aws.query(params,
+                     return_root=True,
                      location=location,
                      provider=get_provider(),
                      opts=__opts__,


### PR DESCRIPTION
### What does this PR do?

Fixes /cloud/clouds/ec2.py get_console_output function
### What issues does this PR fix or reference?

This was never reported (I think)
### Previous Behavior

```
# salt-cloud -a get_console_output <censored>
The following virtual machines are set to be actioned with "get_console_output":
  <censored>

Proceed? [N/y] y
... proceeding
<censored>:
    ----------
    ec2:
        ----------
        <censored>:
            ----------
```
### New Behavior

```
# salt-cloud -a get_console_output <censored>
The following virtual machines are set to be actioned with "get_console_output":
  <censored>

Proceed? [N/y] y
... proceeding
<censored>:
    ----------
    ec2:
        ----------
        <censored>:
            ----------
            instanceId:
                <censored>
            output_decoded:
                2016/03/09 15:59:32Z: EC2ConfigMonitorState: 0
                2016/03/09 15:59:32Z: Windows sysprep configuration complete.
                [...]
                2016/03/09 16:46:37Z: Message: Windows is Ready to use
                2016/03/09 16:46:42Z: Amazon EC2 Simple Systems Manager (SSM) is an optional service for custom configuration of instances.
                2016/03/09 16:46:42Z: Info EC2Config configuration: status:2; region:eu-west-1; iam:1; authz:1
                2016/03/09 16:46:42Z: SSM Config: status:Active; iam:Yes
            requestId:
                8bef182b-e385-459b-9008-e519fe14875e
            timestamp:
                2016-03-09T16:48:44.000Z
```
### Tests written?
- [ ] Yes
- [x] No
