### PR TITLE
Features/intuit failover failback

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -90,6 +90,14 @@ VALID_OPTS = {
     # is interrupted and try another master in the list.
     'master_alive_interval': int,
 
+    # When in multi-master failover mode, fail back to the first master in the list if it's back
+    # online.
+    'master_failback': bool,
+
+    # When in multi-master mode, and master_failback is enabled ping the top master with this
+    # interval.
+    'master_failback_interval': int,
+
     # The name of the signing key-pair
     'master_sign_key_name': str,
 
@@ -802,6 +810,8 @@ DEFAULT_MINION_OPTS = {
     'master_finger': '',
     'master_shuffle': False,
     'master_alive_interval': 0,
+    'master_failback': False,
+    'master_failback_interval': 0,
     'verify_master_pubkey_sign': False,
     'always_verify_signature': False,
     'master_sign_key_name': 'master_sign',

--- a/salt/master.py
+++ b/salt/master.py
@@ -2354,6 +2354,12 @@ class ClearFuncs(object):
         log.debug('Published command details {0}'.format(load))
         return load
 
+    def ping(self, clear_load):
+        '''
+        Send the load back to the sender.
+        '''
+        return clear_load
+
 
 class FloMWorker(MWorker):
     '''

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -12,6 +12,7 @@ import os
 import re
 import fnmatch
 import collections
+import copy
 
 # Import 3rd-party libs
 import salt.ext.six as six
@@ -19,6 +20,7 @@ from salt.ext.six.moves import range  # pylint: disable=import-error,no-name-in-
 
 # Import salt libs
 import salt.config
+import salt.minion
 import salt.utils
 import salt.utils.event
 from salt.utils.network import host_to_ip as _host_to_ip
@@ -827,6 +829,42 @@ def master(master=None, connected=True):
         if master_ip in ips:
             event = salt.utils.event.get_event('minion', opts=__opts__, listen=False)
             event.fire_event({'master': master}, '__master_connected')
+
+
+def ping_master(master):
+    '''
+    Sends ping request to the given master.
+    Fires '__master_alive' event on success.
+    Returns bool result.
+    '''
+    if master is None or master == '':
+        return False
+
+    opts = copy.deepcopy(__opts__)
+    opts['master'] = master
+    del opts['master_ip']  # avoid 'master ip changed' warning
+    opts.update(salt.minion.prep_ip_port(opts))
+    try:
+        opts.update(salt.minion.resolve_dns(opts, fallback=False))
+    except Exception:
+        return False
+
+    timeout = opts.get('auth_timeout', 60)
+    load = {'cmd': 'ping'}
+
+    result = False
+    channel = salt.transport.client.ReqChannel.factory(opts, crypt='clear')
+    try:
+        payload = channel.send(load, tries=0, timeout=timeout)
+        result = True
+    except Exception as e:
+        pass
+
+    if result:
+        event = salt.utils.event.get_event('minion', opts=__opts__, listen=False)
+        event.fire_event({'master': master}, '__master_failback')
+
+    return result
 
 
 def time(format='%A, %d. %B %Y %I:%M%p'):

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -833,9 +833,16 @@ def master(master=None, connected=True):
 
 def ping_master(master):
     '''
-    Sends ping request to the given master.
-    Fires '__master_alive' event on success.
+    .. versionadded:: 2016.3.0
+
+    Sends ping request to the given master. Fires '__master_alive' event on success.
     Returns bool result.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' status.ping_master localhost
     '''
     if master is None or master == '':
         return False

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -764,11 +764,11 @@ class Schedule(object):
                         # Send back to master so the job is included in the job list
                         mret = ret.copy()
                         mret['jid'] = 'req'
-                        channel = salt.transport.Channel.factory(self.opts, usage='salt_schedule')
+                        event = salt.utils.event.get_event('minion', opts=self.opts, listen=False)
                         load = {'cmd': '_return', 'id': self.opts['id']}
                         for key, value in six.iteritems(mret):
                             load[key] = value
-                        channel.send(load)
+                        event.fire_event(load, '__schedule_return')
 
                 log.debug('schedule.handle_func: Removing {0}'.format(proc_fn))
                 os.unlink(proc_fn)


### PR DESCRIPTION
### What does this PR do?

Add an option to minion in multimaster failover mode to still ping the topmost master in the list after it faled and reconnect back if it appears again.
This PR introduces 2 new minion config options:

``` yaml
master_failback: bool  # default: False
master_failback_interval: int  # default: 0
```

Works only in multimaster failover mode. Shouldn't touch other modes.
### What issues does this PR fix or reference?

This is feature request for Intuit
https://github.com/saltstack/zh/issues/551
### Previous Behavior

N/A
### New Behavior

N/A
### Tests written?
- [ ] Yes
- [x] No
