### PR TITLE
Add syndic ordered failover.

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -539,6 +539,11 @@ VALID_OPTS = {
     'peer': dict,
     'preserve_minion_cache': bool,
     'syndic_master': str,
+
+    # The behaviour of the multisyndic when connection to a master of masters failed. Can specify
+    # 'random' (default) or 'ordered'. If set to 'random' masters will be iterated in random order
+    # if 'ordered' the configured order will be used.
+    'syndic_failover': str,
     'runner_dirs': list,
     'client_acl': dict,
     'client_acl_blacklist': dict,
@@ -1100,6 +1105,7 @@ DEFAULT_MASTER_OPTS = {
     'peer': {},
     'preserve_minion_cache': False,
     'syndic_master': '',
+    'syndic_failover': 'random',
     'syndic_log_file': os.path.join(salt.syspaths.LOGS_DIR, 'syndic'),
     'syndic_pidfile': os.path.join(salt.syspaths.PIDFILE_DIR, 'salt-syndic.pid'),
     'runner_dirs': [],

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -101,6 +101,7 @@ from salt.defaults import DEFAULT_TARGET_DELIM
 from salt.executors import FUNCTION_EXECUTORS
 from salt.utils.debug import enable_sigusr1_handler
 from salt.utils.event import tagify
+from salt.utils.odict import OrderedDict
 from salt.utils.process import (default_signals,
                                 SignalHandlingMultiprocessingProcess,
                                 ProcessManager)
@@ -2216,6 +2217,7 @@ class MultiSyndic(MinionBase):
         self.mminion = salt.minion.MasterMinion(opts)
         # sync (old behavior), cluster (only returns and publishes)
         self.syndic_mode = self.opts.get('syndic_mode', 'sync')
+        self.syndic_failover = self.opts.get('syndic_failover', 'random')
 
         self.auth_wait = self.opts['acceptance_wait_time']
         self.max_auth_wait = self.opts['acceptance_wait_time_max']
@@ -2233,8 +2235,8 @@ class MultiSyndic(MinionBase):
         '''
         Spawn all the coroutines which will sign in the syndics
         '''
-        self._syndics = {}  # mapping of opts['master'] -> syndic
-        for master in set(self.opts['master']):
+        self._syndics = OrderedDict()  # mapping of opts['master'] -> syndic
+        for master in self.opts['master']:
             s_opts = copy.copy(self.opts)
             s_opts['master'] = master
             self._syndics[master] = self._connect_syndic(s_opts)
@@ -2309,7 +2311,8 @@ class MultiSyndic(MinionBase):
         Iterate (in order) over your options for master
         '''
         masters = list(self._syndics.keys())
-        shuffle(masters)
+        if self.opts['syndic_failover'] == 'random':
+            shuffle(masters)
         if master_id not in self._syndics:
             master_id = masters.pop(0)
         else:


### PR DESCRIPTION
### What does this PR do?

Adds a way to keep the configured order of Masters of Masters in MultiSyndic when it forwards messages.
### What issues does this PR fix or reference?

This is feature request for Intuit
saltstack/zh#551
### Previous Behavior

If the targeted master failed MultiSyndic was always forwarding messages to the next master in random order.
### New Behavior

If `syndic_failover` is set to `ordered` it keeps the MoMs config order.
### Tests written?
- [ ] Yes
- [x] No
