### PR TITLE
Fix grains and pillars in salt-ssh

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -832,6 +832,7 @@ class Single(object):
         if not data_cache:
             refresh = True
         if refresh:
+            print('Refreshing')
             # Make the datap
             # TODO: Auto expire the datap
             pre_wrapper = salt.client.ssh.wrapper.FunctionWrapper(
@@ -901,7 +902,7 @@ class Single(object):
             fsclient=self.fsclient,
             minion_opts=self.minion_opts,
             **self.target)
-        self.wfuncs = salt.loader.ssh_wrapper(opts, wrapper, self.context)
+        self.wfuncs = salt.loader.ssh_wrapper(opts, wrapper, self.context, grains=opts['grains'], pillar=opts['pillar'])
         wrapper.wfuncs = self.wfuncs
 
         # We're running in the mind, need to fetch the arguments from the

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -832,7 +832,6 @@ class Single(object):
         if not data_cache:
             refresh = True
         if refresh:
-            print('Refreshing')
             # Make the datap
             # TODO: Auto expire the datap
             pre_wrapper = salt.client.ssh.wrapper.FunctionWrapper(

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -538,7 +538,7 @@ def log_handlers(opts, functions=None, grains=None):
     return FilterDictWrapper(ret, '.setup_handlers')
 
 
-def ssh_wrapper(opts, functions=None, context=None):
+def ssh_wrapper(opts, functions=None, context=None, grains=None, pillar=None):
     '''
     Returns the custom logging handler modules
     '''
@@ -551,7 +551,7 @@ def ssh_wrapper(opts, functions=None, context=None):
         ),
         opts,
         tag='wrapper',
-        pack={'__salt__': functions, '__context__': context},
+        pack={'__salt__': functions, '__context__': context, '__grains__': grains, '__pillar__': pillar},
     )
 
 


### PR DESCRIPTION
### What does this PR do?

Restores the ability to use grains and pillars in salt-ssh
### What issues does this PR fix or reference?
#38135
### Previous Behavior

salt-ssh <host> grains.get would return nothing
### New Behavior

Returns grains
### Tests written?
- [ ] Yes
- [x] No

Due to changes in #23373, we need to explicitely pass in the grains
and pillar we have generated.
