### PR TITLE
Fix race condition with self.connected on TCP transport

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -752,6 +752,7 @@ class Minion(MinionBase):
         self._running = None
         self.win_proc = []
         self.loaded_base_name = loaded_base_name
+        self.connected = False
 
         if io_loop is None:
             if HAS_ZMQ:
@@ -1837,7 +1838,7 @@ class Minion(MinionBase):
 
         if start:
             self.sync_connect_master()
-        if hasattr(self, 'connected') and self.connected:
+        if self.connected:
             self._fire_master_minion_start()
             log.info('Minion is ready to receive requests!')
 


### PR DESCRIPTION
### What does this PR do?

There is a race condition that occasionally happens when using
the TCP transport. When using the TCP transport, it will fire the
`__master_connected` event before returning from tcp.py's
`AsyncTCPPubChannel.connect_callback`. What sometimes happens is
that the event handler for `__master_connected` is executed before
the control is returned to `eval_master` in master.py. If this
happens, `self.connected` is not yet defined, since `eval_master`
defines it. The event handler for `__master_connected` tries to
access the not yet defined `self.connected` and an exception occurs.

One possible solution is to use `hasattr` to check if `self.connected`
is defined before accessing it in the `__master_connected` handler.
However, I think it is cleaner just to set `self.connected = False` in
`Minion.__init__`, that way this variable will be defined in all cases
and can be relied upon.
### What issues does this PR fix or reference?
### Previous Behavior
### New Behavior
### Tests written?
- [ ] Yes
- [X] No

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
