### PR TITLE
Add support for ap-northeast-2 and us-gov-west-1 regions in AWS

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -143,11 +143,11 @@ EC2_LOCATIONS = {
     'ap-southeast-2': 'ec2_ap_southeast_2',
     'eu-west-1': 'ec2_eu_west',
     'eu-central-1': 'ec2_eu_central',
-    'us-gov-west-1': 'ec2_us_gov_west_1’,
+    'sa-east-1': 'ec2_sa_east',
     'us-east-1': 'ec2_us_east',
+    'us-gov-west-1': 'ec2_us_gov_west_1',
     'us-west-1': 'ec2_us_west',
     'us-west-2': 'ec2_us_west_oregon',
-    'sa-east-1': 'ec2_sa_east',
 }
 DEFAULT_LOCATION = 'us-east-1'
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -138,14 +138,16 @@ log = logging.getLogger(__name__)
 
 EC2_LOCATIONS = {
     'ap-northeast-1': 'ec2_ap_northeast',
+    'ap-northeast-2': 'ec2_ap_northeast_2',
     'ap-southeast-1': 'ec2_ap_southeast',
     'ap-southeast-2': 'ec2_ap_southeast_2',
     'eu-west-1': 'ec2_eu_west',
     'eu-central-1': 'ec2_eu_central',
-    'sa-east-1': 'ec2_sa_east',
+    'us-gov-west-1': 'ec2_us_gov_west_1’,
     'us-east-1': 'ec2_us_east',
     'us-west-1': 'ec2_us_west',
     'us-west-2': 'ec2_us_west_oregon',
+    'sa-east-1': 'ec2_sa_east',
 }
 DEFAULT_LOCATION = 'us-east-1'
 


### PR DESCRIPTION
### What does this PR do?

This PR will add support for two additional regions in AWS (ap-northeast-2 and us-gov-west-1)
### What issues does this PR fix or reference?

Support for ap-northeast-2 and us-gov-west-1 were missing
### Previous Behavior

Salt Cloud users were unable to use these two AWS regions
### New Behavior

These regions will be accessible via Salt Cloud
### Tests written?
- [ ] Yes
- [X] No
