### PR TITLE
Fixes a doc build exception caused by missing mocks for modules.win_dacl

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -118,6 +118,9 @@ MOCK_MODULES = [
     'yum',
     'OpenSSL',
     'zfs',
+    'salt.ext.six.moves.winreg',
+    'win32security',
+    'ntsecuritycon',
 ]
 
 for mod_name in MOCK_MODULES:
@@ -126,6 +129,8 @@ for mod_name in MOCK_MODULES:
 # Define a fake version attribute for the following libs.
 sys.modules['libcloud'].__version__ = '0.0.0'
 sys.modules['pymongo'].version = '0.0.0'
+sys.modules['ntsecuritycon'].STANDARD_RIGHTS_REQUIRED = 0
+sys.modules['ntsecuritycon'].SYNCHRONIZE = 0
 
 
 # -- Add paths to PYTHONPATH ---------------------------------------------------


### PR DESCRIPTION
### What does this PR do?

Fixes a doc build exception caused by missing mocks for modules.win_dacl
### What issues does this PR fix or reference?

Issues are in the sphinx build log, but not reported in a GitHub issue.
### Tests written?
- [ ] Yes
- [ ] No
- [X] N/A (doc fixes only) 
