### PR TITLE
Add integration test for alternatives state

### DIFF
--- a/tests/integration/states/alternatives.py
+++ b/tests/integration/states/alternatives.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+'''
+Integration tests for the alternatives state module
+'''
+
+# Import Python libs
+from __future__ import absolute_import
+import json
+
+# Import Salt Testing libs
+from salttesting.helpers import destructiveTest, ensure_in_syspath
+ensure_in_syspath('../../')
+
+# Import salt libs
+import integration
+import salt.utils
+
+
+class AlterantivesStateTest(integration.ModuleCase,
+                            integration.SaltReturnAssertsMixIn):
+    @destructiveTest
+    def test_install_set_and_remove(self):
+        ret = self.run_state('alternatives.set', name='alt-test', path='/bin/true')
+        self.assertSaltFalseReturn(ret)
+
+        ret = self.run_state('alternatives.install', name='alt-test',
+            link='/usr/local/bin/alt-test', path='/bin/true', priority=50)
+        self.assertSaltTrueReturn(ret)
+        self.assertSaltStateChangesEqual(ret, '/bin/true', keys=['path'])
+
+        ret = self.run_state('alternatives.install', name='alt-test',
+            link='/usr/local/bin/alt-test', path='/bin/true', priority=50)
+        self.assertSaltTrueReturn(ret)
+        self.assertSaltStateChangesEqual(ret, {})
+
+        ret = self.run_state('alternatives.install', name='alt-test',
+            link='/usr/local/bin/alt-test', path='/bin/false', priority=90)
+        self.assertSaltTrueReturn(ret)
+        self.assertSaltStateChangesEqual(ret, '/bin/false', keys=['path'])
+
+        ret = self.run_state('alternatives.set', name='alt-test', path='/bin/false')
+        self.assertSaltTrueReturn(ret)
+        self.assertSaltStateChangesEqual(ret, {})
+
+        ret = self.run_state('alternatives.set', name='alt-test', path='/bin/true')
+        self.assertSaltTrueReturn(ret)
+        self.assertSaltStateChangesEqual(ret, '/bin/true', keys=['path'])
+
+        ret = self.run_state('alternatives.set', name='alt-test', path='/bin/true')
+        self.assertSaltTrueReturn(ret)
+        self.assertSaltStateChangesEqual(ret, {})
+
+        ret = self.run_state('alternatives.remove', name='alt-test', path='/bin/true')
+        self.assertSaltTrueReturn(ret)
+
+        ret = self.run_state('alternatives.remove', name='alt-test', path='/bin/false')
+        self.assertSaltTrueReturn(ret)


### PR DESCRIPTION
The alternatives state module has been through some contradictory changes recently. An integration test should help validate that it actually works.
