### PR TITLE
Bugfix: `RunnerClient` keyword argument values processing

### DIFF
--- a/salt/runner.py
+++ b/salt/runner.py
@@ -65,9 +65,11 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
         # Support old style calls where arguments could be specified in 'low' top level
         if not low.get('args') and not low.get('kwargs'):  # not specified or empty
             verify_fun(self.functions, fun)
+            merged_args_kwargs = salt.utils.args.condition_input([], low)
+            parsed_input = salt.utils.args.parse_input(merged_args_kwargs)
             args, kwargs = salt.minion.load_args_and_kwargs(
                 self.functions[fun],
-                salt.utils.args.condition_input([], low),
+                parsed_input,
                 self.opts,
                 ignore_invalid=True
             )

--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -60,7 +60,8 @@ def parse_input(args, condition=True):
             # condition_input is called below, but this is the only way to
             # gracefully handle both CLI and API input.
             if arg.pop('__kwarg__', False) is True:
-                _kwargs.update(arg)
+                for key, val in six.iteritems(arg):
+                    _kwargs[key] = yamlify_arg(val)
             else:
                 _args.append(arg)
         else:


### PR DESCRIPTION
### What does this PR do?

Fixes long-standing regression since 18-03-2014 (09de057f71d8e5184828d5f50b0826bd6347da81) in `utils.args.parse_input`.

Fixes issue with RunnerClient arguments not being parsed with YAML. This issues manifests when runner is being called via a `libpeper`.
### What issues does this PR fix or reference?

https://github.com/saltstack/pepper/pull/55
https://github.com/saltstack/pepper/issues/57

There might be other issues open regarding this bug.
### Previous Behavior

`RunnerClient` keyword argument values are not parsed with YAML decoder.
### New Behavior

`RunnerClient` keyword argument values _are_ parsed with YAML decoder.
### Tests written?
- [ ] Yes
- [x] No
