### PR TITLE
salt.states.smartos should handling newlines better

### DIFF
--- a/salt/modules/smartos_vmadm.py
+++ b/salt/modules/smartos_vmadm.py
@@ -128,7 +128,6 @@ def _create_update_from_cfg(mode='create', uuid=None, vmcfg=None):
     vmadm_json_file = __salt__['temp.file'](prefix='vmadm-')
     with salt.utils.fopen(vmadm_json_file, 'w') as vmadm_json:
         vmadm_json.write(json.dumps(vmcfg))
-        vmadm_json.close()
 
     # vmadm validate create|update [-f <filename>]
     cmd = '{vmadm} validate {mode} {brand} -f {vmadm_json_file}'.format(

--- a/salt/modules/smartos_vmadm.py
+++ b/salt/modules/smartos_vmadm.py
@@ -123,12 +123,19 @@ def _create_update_from_cfg(mode='create', uuid=None, vmcfg=None):
     '''
     ret = {}
     vmadm = _check_vmadm()
+
+    # write json file
+    vmadm_json_file = __salt__['temp.file'](prefix='vmadm-')
+    with salt.utils.fopen(vmadm_json_file, 'w') as vmadm_json:
+        vmadm_json.write(json.dumps(vmcfg))
+        vmadm_json.close()
+
     # vmadm validate create|update [-f <filename>]
-    cmd = 'echo {vmcfg} | {vmadm} validate {mode} {brand}'.format(
+    cmd = '{vmadm} validate {mode} {brand} -f {vmadm_json_file}'.format(
         vmadm=vmadm,
         mode=mode,
         brand=get(uuid)['brand'] if uuid is not None else '',
-        vmcfg=_quote_args(json.dumps(vmcfg))
+        vmadm_json_file=vmadm_json_file
     )
     res = __salt__['cmd.run_all'](cmd, python_shell=True)
     retcode = res['retcode']
@@ -141,11 +148,11 @@ def _create_update_from_cfg(mode='create', uuid=None, vmcfg=None):
                 ret['Error'] = res['stderr']
         return ret
     # vmadm create|update [-f <filename>]
-    cmd = 'echo {vmcfg} | {vmadm} {mode} {uuid}'.format(
+    cmd = '{vmadm} {mode} {uuid} -f {vmadm_json_file}'.format(
         vmadm=vmadm,
         mode=mode,
         uuid=uuid if uuid is not None else '',
-        vmcfg=_quote_args(json.dumps(vmcfg))
+        vmadm_json_file=vmadm_json_file
     )
     res = __salt__['cmd.run_all'](cmd, python_shell=True)
     retcode = res['retcode']
@@ -158,8 +165,13 @@ def _create_update_from_cfg(mode='create', uuid=None, vmcfg=None):
                 ret['Error'] = res['stderr']
         return ret
     else:
+        # cleanup json file (only when succesful to help troubleshooting)
+        salt.utils.safe_rm(vmadm_json_file)
+
+        # return uuid
         if res['stderr'].startswith('Successfully created VM'):
             return res['stderr'][24:]
+
     return True
 
 


### PR DESCRIPTION
### What does this PR do?

Took me a long time to track and properly fix...

When passing yaml to salt.states.smartos containing new lines they would get eating, this PR fixes this.
The underlying problem was the 'echo' used in salt.modules.smartos_vmadm.
### What issues does this PR fix or reference?

n/a
### Previous Behavior

\n gets turned into ' ', which is not the expected beheavior
### New Behavior

\n gets left as \n which is the expected beheavior.
### Tests written?
- [ ] Yes
- [X] No
### Affected branches
- 2016.3
- develop
