### PR TITLE
There were two identical blocks concerning Windows Deploy Timeouts. This

### DIFF
--- a/doc/topics/cloud/aws.rst
+++ b/doc/topics/cloud/aws.rst
@@ -186,16 +186,6 @@ These retries and timeouts relate to validating the Administrator password
 once AWS provides the credentials via the AWS API.
 
 
-Windows Deploy Timeouts
-=======================
-For Windows instances, it may take longer than normal for the instance to be
-ready.  In these circumstances, the provider configuration can be configured
-with a ``win_deploy_auth_retries`` and/or a ``win_deploy_auth_retry_delay``
-setting, which default to 10 retries and a one second delay between retries.
-These retries and timeouts relate to validating the Administrator password
-once AWS provides the credentials via the AWS API.
-
-
 Key Pairs
 =========
 In order to create an instance with Salt installed and configured, a key pair


### PR DESCRIPTION
### What does this PR do?

Remove a duplicate block of text.
### What issues does this PR fix or reference?

Duplicated documentation in the cloud module
### Previous Behavior

There were two blocks of text that referenced `Windows Deploy Timeouts`
### New Behavior

There is one block of text that references `Window Deploy Timeouts`
### Tests written?
- [ ] Yes
- [ \* ] No

I didn't see any tests that were pertinent to strictly content-based issues.

pull request removes the extra block of text.
