### PR TITLE
Add new repo, issue, and milestone functions to github module

### DIFF
--- a/salt/modules/github.py
+++ b/salt/modules/github.py
@@ -31,6 +31,7 @@ import logging
 
 # Import Salt Libs
 from salt.exceptions import CommandExecutionError
+import salt.utils.http
 
 # Import third party libs
 HAS_LIBS = False
@@ -112,6 +113,19 @@ def _get_members(organization, params=None):
         github.NamedUser.NamedUser,
         organization._requester,
         organization.url + "/members",
+        params
+    )
+
+
+def _get_repos(profile, params=None):
+    org_name = _get_config_value(profile, 'org_name')
+    client = _get_client(profile)
+    organization = client.get_organization(org_name)
+
+    return github.PaginatedList.PaginatedList(
+        github.Repository.Repository,
+        organization._requester,
+        organization.url + '/repos',
         params
     )
 
@@ -295,3 +309,430 @@ def remove_user(name, profile='github'):
         organization.remove_from_members(git_user)
 
     return not organization.has_in_members(git_user)
+
+
+def get_issue(issue_number, repo_name=None, profile='github', output='min'):
+    '''
+    Return information about a single issue in a named repository.
+
+    .. versionadded:: Carbon
+
+    issue_number
+        The number of the issue to retrieve.
+
+    repo_name
+        The name of the repository for which to list issues. This argument is
+        required, either passed via the CLI, or defined in the configured
+        profile. A ``repo_name`` passed as a CLI argument will override the
+        repo_name defined in the configured profile, if provided.
+
+    profile
+        The name of the profile configuration to use. Defaults to ``github``.
+
+    output
+        The amount of data returned by each issue. Defaults to ``min``. Change
+        to ``full`` to see all issue output.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion github.get_issue 514
+        salt myminion github.get_issue 514 repo_name=salt
+    '''
+    org_name = _get_config_value(profile, 'org_name')
+    if repo_name is None:
+        repo_name = _get_config_value(profile, 'repo_name')
+
+    action = 'repos/' + org_name + '/' + repo_name
+    command = 'issues/' + str(issue_number)
+
+    ret = {}
+    issue_data = _query(profile, action=action, command=command)
+
+    issue_id = issue_data.get('id')
+    if output == 'full':
+        ret[issue_id] = issue_data
+    else:
+        ret[issue_id] = _format_issue(issue_data)
+
+    return ret
+
+
+def get_issues(repo_name=None,
+               profile='github',
+               milestone=None,
+               state='open',
+               assignee=None,
+               creator=None,
+               mentioned=None,
+               labels=None,
+               sort='created',
+               direction='desc',
+               since=None,
+               output='min',
+               per_page=None):
+    '''
+    Lists all issues for a given repository, based on the search options.
+
+    .. versionadded:: Carbon
+
+    repo_name
+        The name of the repository for which to list issues. This argument is
+        required, either passed via the CLI, or defined in the configured
+        profile. A ``repo_name`` passed as a CLI argument will override the
+        repo_name defined in the configured profile, if provided.
+
+    profile
+        The name of the profile configuration to use. Defaults to ``github``.
+
+    milestone
+        The ID number of a GitHub milestone, or a string of either ``*`` or
+        ``none``.
+
+        If a number is passed, it should refer to a milestone by its number
+        field. If the string ``*`` is passed, issues with any milestone are
+        accepted. If the string ``none`` is passed, issues without milestones
+        are returned.
+
+    state
+        Indicates the state of the issues to return. Can be either ``open``,
+        ``closed``, or ``all``. Default is ``open``.
+
+    assignee
+        Can be the name of a user. Pass in ``none`` (as a string) for issues
+        with no assigned user or ``*`` for issues assigned to any user.
+
+    creator
+        The user that created the issue.
+
+    mentioned
+        A user that's mentioned in the issue.
+
+    labels
+        A string of comma separated label names. For example, ``bug,ui,@high``.
+
+    sort
+        What to sort results by. Can be either ``created``, ``updated``, or
+        ``comments``. Default is ``created``.
+
+    direction
+        The direction of the sort. Can be either ``asc`` or ``desc``. Default
+        is ``desc``.
+
+    since
+        Only issues updated at or after this time are returned. This is a
+        timestamp in ISO 8601 format: ``YYYY-MM-DDTHH:MM:SSZ``.
+
+    output
+        The amount of data returned by each issue. Defaults to ``min``. Change
+        to ``full`` to see all issue output.
+
+    per_page
+        GitHub paginates data in their API calls. Use this value to increase or
+        decrease the number of issues gathered from GitHub, per page. If not set,
+        GitHub defaults are used. Maximum is 100.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion github.get_issues my-github-repo
+    '''
+    org_name = _get_config_value(profile, 'org_name')
+    if repo_name is None:
+        repo_name = _get_config_value(profile, 'repo_name')
+
+    action = 'repos/' + org_name + '/' + repo_name
+    args = {}
+
+    # Build API arguments, as necessary.
+    if milestone:
+        args['milestone'] = milestone
+    if assignee:
+        args['assignee'] = assignee
+    if creator:
+        args['creator'] = creator
+    if mentioned:
+        args['mentioned'] = mentioned
+    if labels:
+        args['labels'] = labels
+    if since:
+        args['since'] = since
+    if per_page:
+        args['per_page'] = per_page
+
+    # Only pass the following API args if they're not the defaults listed.
+    if state and state != 'open':
+        args['state'] = state
+    if sort and sort != 'created':
+        args['sort'] = sort
+    if direction and direction != 'desc':
+        args['direction'] = direction
+
+    ret = {}
+    issues = _query(profile, action=action, command='issues', args=args)
+
+    for issue in issues:
+        # Pull requests are included in the issue list from GitHub
+        # Let's not include those in the return.
+        if issue.get('pull_request'):
+            continue
+        issue_id = issue.get('id')
+        if output == 'full':
+            ret[issue_id] = issue
+        else:
+            ret[issue_id] = _format_issue(issue)
+
+    return ret
+
+
+def get_repo_info(repo_name, profile='github'):
+    '''
+    Return information for a given repo.
+
+    .. versionadded:: Carbon
+
+    repo_name
+        The name of repository.
+
+    profile
+        The name of the profile configuration to use. Defaults to ``github``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion github.get_repo_info salt
+        salt myminion github.get_repo_info salt profile='my-github-profile'
+    '''
+    ret = {}
+    org_name = _get_config_value(profile, 'org_name')
+    client = _get_client(profile)
+
+    repo = client.get_repo('/'.join([org_name, repo_name]))
+    if repo:
+        # client.get_repo will return a github.Repository.Repository object,
+        # even if the repo is invalid. We need to catch the exception when
+        # we try to perform actions on the repo object, rather than above
+        # the if statement.
+        try:
+            ret['id'] = repo.id
+        except github.UnknownObjectException:
+            raise CommandExecutionError(
+                'The \'{0}\' repository under the \'{1}\' organization could not '
+                'be found.'.format(
+                    repo_name,
+                    org_name
+                )
+            )
+        ret['name'] = repo.name
+        ret['full_name'] = repo.full_name
+        ret['owner'] = repo.owner.login
+        ret['private'] = repo.private
+        ret['html_url'] = repo.html_url
+        ret['description'] = repo.description
+        ret['fork'] = repo.fork
+        ret['homepage'] = repo.homepage
+        ret['size'] = repo.size
+        ret['stargazers_count'] = repo.stargazers_count
+        ret['watchers_count'] = repo.watchers_count
+        ret['language'] = repo.language
+        ret['open_issues_count'] = repo.open_issues_count
+        ret['forks'] = repo.forks
+        ret['open_issues'] = repo.open_issues
+        ret['watchers'] = repo.watchers
+        ret['default_branch'] = repo.default_branch
+
+    return ret
+
+
+def list_repos(profile='github'):
+    '''
+    List all repositories within the organization. Includes public and private
+    repositories within the organization Dependent upon the access rights of
+    the profile token.
+
+    .. versionadded:: Carbon
+
+    profile
+        The name of the profile configuration to use. Defaults to ``github``.
+
+    .. code-block:: bash
+
+        salt myminion github.list_repos
+        salt myminion github.list_repos profile='my-github-profile'
+    '''
+    return [repo.name for repo in _get_repos(profile)]
+
+
+def list_private_repos(profile='github'):
+    '''
+    List private repositories within the organization. Dependent upon the access
+    rights of the profile token.
+
+    .. versionadded:: Carbon
+
+    profile
+        The name of the profile configuration to use. Defaults to ``github``.
+
+    .. code-block:: bash
+
+        salt myminion github.list_private_repos
+        salt myminion github.list_private_repos profile='my-github-profile'
+    '''
+    repos = []
+    for repo in _get_repos(profile):
+        if repo.private is True:
+            repos.append(repo.name)
+    return repos
+
+
+def list_public_repos(profile='github'):
+    '''
+    List public repositories within the organization.
+
+    .. versionadded:: Carbon
+
+    profile
+        The name of the profile configuration to use. Defaults to ``github``.
+
+    .. code-block:: bash
+
+        salt myminion github.list_public_repos
+        salt myminion github.list_public_repos profile='my-github-profile'
+    '''
+    repos = []
+    for repo in _get_repos(profile):
+        if repo.private is False:
+            repos.append(repo.name)
+    return repos
+
+
+def _format_issue(issue):
+    '''
+    Helper function to format API return information into a more manageable
+    and useful dictionary.
+
+    issue
+        The issue to format.
+    '''
+    ret = {'id': issue.get('id'),
+           'issue_number': issue.get('number'),
+           'state': issue.get('state'),
+           'title': issue.get('title'),
+           'user': issue.get('user').get('login')}
+
+    assignee = issue.get('assignee')
+    if assignee:
+        assignee = assignee.get('login')
+
+    labels = issue.get('labels')
+    label_names = []
+    for label in labels:
+        label_names.append(label.get('name'))
+
+    milestone = issue.get('milestone')
+    if milestone:
+        milestone = milestone.get('title')
+
+    ret['assignee'] = assignee
+    ret['labels'] = label_names
+    ret['milestone'] = milestone
+
+    return ret
+
+
+def _query(profile,
+           action=None,
+           command=None,
+           args=None,
+           method='GET',
+           header_dict=None,
+           data=None,
+           url='https://api.github.com/',
+           per_page=None):
+    '''
+    Make a web call to the GitHub API and deal with paginated results.
+    '''
+    if not isinstance(args, dict):
+        args = {}
+
+    if action:
+        url += action
+
+    if command:
+        url += '/{0}'.format(command)
+
+    log.debug('GitHub URL: {0}'.format(url))
+
+    if 'access_token' not in args.keys():
+        args['access_token'] = _get_config_value(profile, 'token')
+    if per_page and 'per_page' not in args.keys():
+        args['per_page'] = per_page
+
+    if header_dict is None:
+        header_dict = {}
+
+    if method != 'POST':
+        header_dict['Accept'] = 'application/json'
+
+    decode = True
+    if method == 'DELETE':
+        decode = False
+
+    # GitHub paginates all queries when returning many items.
+    # Gather all data using multiple queries and handle pagination.
+    complete_result = []
+    next_page = True
+    page_number = ''
+    while next_page is True:
+        if page_number:
+            args['page'] = page_number
+        result = salt.utils.http.query(url,
+                                       method,
+                                       params=args,
+                                       data=data,
+                                       header_dict=header_dict,
+                                       decode=decode,
+                                       decode_type='json',
+                                       headers=True,
+                                       status=True,
+                                       text=True,
+                                       hide_fields=['access_token'],
+                                       opts=__opts__,
+                                       )
+        log.debug(
+            'GitHub Response Status Code: {0}'.format(
+                result['status']
+            )
+        )
+
+        if result['status'] == 200:
+            if isinstance(result['dict'], dict):
+                # If only querying for one item, such as a single issue
+                # The GitHub API returns a single dictionary, instead of
+                # A list of dictionaries. In that case, we can return.
+                return result['dict']
+
+            complete_result = complete_result + result['dict']
+        else:
+            raise CommandExecutionError(
+                'GitHub Response Error: {0}'.format(result.get('error'))
+            )
+
+        try:
+            link_info = result.get('headers').get('Link').split(',')[0]
+        except AttributeError:
+            # Only one page of data was returned; exit the loop.
+            next_page = False
+            continue
+
+        if 'next' in link_info:
+            # Get the 'next' page number from the Link header.
+            page_number = link_info.split('>')[0][-1]
+        else:
+            # Last page already processed; break the loop.
+            next_page = False
+
+    return complete_result


### PR DESCRIPTION
### What does this PR do?

Refactors some helper functions to use a single function to return GitHub API config values
Adds the following new functions to view issues, repositories, and milestone information:
- get_issue
- get_issues
- get_milestone
- get_milestones
- get_repo_info
- list_repos
- list_public_repos
- list_private_repos
### What issues does this PR fix or reference?

None.
### Previous Behavior

N/A
### New Behavior

Also implements a `_query` function to use GitHub's API directly, instead of going through `PyGithub`'s functions. (PyGithub didn't have all of the required functionality, so using `salt.utils.http.query` was necessary.) Paginated results are also handled in the new `_query` function.
### Tests written?
- [ ] Yes
- [x] No
