### PR TITLE
Don't require the decode_out file to already exist

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -552,7 +552,7 @@ def query(url,
         else:
             text = True
 
-        if decode_out and os.path.exists(decode_out):
+        if decode_out:
             with salt.utils.fopen(decode_out, 'w') as dof:
                 dof.write(result_text)
 


### PR DESCRIPTION
### What does this PR do?

As the title says.
### What issues does this PR fix or reference?

None that I know of.
### Previous Behavior

The `decode_out` file would have to exist before `http.query()` would write to it. If you touched the file first, it worked fine.
### New Behavior

The `decode_out` file no longer needs to exist.
### Tests written?
- [ ] Yes
- [X] No

Ping @meggiebot.
