### PR TITLE
Make sure we get the page number from the link header appropriately

### DIFF
--- a/salt/modules/github.py
+++ b/salt/modules/github.py
@@ -893,7 +893,7 @@ def _query(profile,
 
         if 'next' in link_info:
             # Get the 'next' page number from the Link header.
-            page_number = link_info.split('>')[0][-1]
+            page_number = link_info.split('>')[0].split('&page=')[1]
         else:
             # Last page already processed; break the loop.
             next_page = False


### PR DESCRIPTION
### What does this PR do?

There was a bug in the _query function that was not getting the page number properly when more than 9 pages were needed.
### What issues does this PR fix or reference?
### Previous Behavior

Would infinitely loop querying the same 1-9 pages from GitHub over and over.
### New Behavior

Allows the page number to advance beyond page 9, allowing the query to complete and exit.
### Tests written?
- [ ] Yes
- [x] No
