### PR TITLE
Integration tests for mac_pkgutil

### DIFF
--- a/salt/modules/mac_pkgutil.py
+++ b/salt/modules/mac_pkgutil.py
@@ -66,10 +66,7 @@ def is_installed(package_id):
 
         salt '*' darwin_pkgutil.is_installed com.apple.pkg.gcc4.2Leo
     '''
-    for line in salt.utils.itertools.split(list_(), '\n'):
-        if line == package_id:
-            return True
-    return False
+    return package_id in list_()
 
 
 def _install_from_path(path):

--- a/salt/modules/mac_pkgutil.py
+++ b/salt/modules/mac_pkgutil.py
@@ -109,3 +109,18 @@ def install(source, package_id):
         raise SaltInvocationError(msg)
 
     return is_installed(package_id)
+
+
+def remove(package_id):
+    cmd = 'pkgutil --only-files --files {0}'.format(package_id)
+    cmd += ' | tr \'\n\' \'\0\' | xargs -n 1 -0 sudo rm -i'
+    salt.utils.mac_utils.execute_return_success(cmd)
+
+    cmd = 'pkgutil --only-dirs --files {0}'.format(package_id)
+    cmd += ' | tail -r | tr \'\n\' \'\0\' | xargs -n 1 -0 sudo rmdir'
+    salt.utils.mac_utils.execute_return_success(cmd)
+
+    cmd = 'pkgutil --forget {0}'.format(package_id)
+    salt.utils.mac_utils.execute_return_success(cmd)
+
+    return True

--- a/salt/modules/mac_pkgutil.py
+++ b/salt/modules/mac_pkgutil.py
@@ -8,34 +8,39 @@ Installer is the native .pkg/.mpkg package manager for OS X.
 # Import Python libs
 from __future__ import absolute_import
 import os.path
+from salt.exceptions import SaltInvocationError
 
 # Import 3rd-party libs
 from salt.ext.six.moves import urllib  # pylint: disable=import-error
 
 # Import salt libs
+import salt.utils
 import salt.utils.itertools
+import salt.utils.mac_utils
 
 # Don't shadow built-in's.
-__func_alias__ = {
-    'list_': 'list'
-}
-
-__PKGUTIL = '/usr/sbin/pkgutil'
+__func_alias__ = {'list_': 'list'}
 
 # Define the module's virtual name
 __virtualname__ = 'darwin_pkgutil'
 
 
 def __virtual__():
-    if __grains__['os'] == 'MacOS':
-        return __virtualname__
-    return (False, 'The darwin_pkgutil execution module cannot be loaded: '
-            'only available on MacOS systems.')
+    if not salt.utils.is_darwin():
+        return (False, 'darwin_pkgutil only available on Mac OS systems')
+
+    if not salt.utils.which('pkgkutil'):
+        return (False, 'darwin_pkgutil requires pkgutil')
+
+    return __virtualname__
 
 
 def list_():
     '''
     List the installed packages.
+
+    :return: A list of installed packages
+    :rtype: list
 
     CLI Example:
 
@@ -43,13 +48,17 @@ def list_():
 
         salt '*' darwin_pkgutil.list
     '''
-    cmd = [__PKGUTIL, '--pkgs']
-    return __salt__['cmd.run_stdout'](cmd, python_shell=False)
+    cmd = 'pkgutil --pkgs'
+    ret = salt.utils.mac_utils.execute_return_result(cmd)
+    return ret.splitlines()
 
 
 def is_installed(package_id):
     '''
     Returns whether a given package id is installed.
+
+    :return: True if installed, otherwise False
+    :rtype: bool
 
     CLI Example:
 
@@ -64,17 +73,27 @@ def is_installed(package_id):
 
 
 def _install_from_path(path):
+    '''
+    Internal function to install a package from the given path
+    '''
     if not os.path.exists(path):
         msg = 'Path \'{0}\' does not exist, cannot install'.format(path)
-        raise ValueError(msg)
-    else:
-        cmd = 'installer -pkg "{0}" -target /'.format(path)
-        return __salt__['cmd.retcode'](cmd)
+        raise SaltInvocationError(msg)
+
+    cmd = 'installer -pkg "{0}" -target /'.format(path)
+    return salt.utils.mac_utils.execute_return_success(cmd)
 
 
 def install(source, package_id=None):
     '''
     Install a .pkg from an URI or an absolute path.
+
+    :param str source: The path to a package.
+
+    :param str package_id: The package ID
+
+    :return: True if successful, otherwise False
+    :rtype: bool
 
     CLI Example:
 
@@ -87,7 +106,9 @@ def install(source, package_id=None):
 
     uri = urllib.parse.urlparse(source)
     if uri.scheme == "":
-        return _install_from_path(source)
+        _install_from_path(source)
     else:
         msg = 'Unsupported scheme for source uri: \'{0}\''.format(uri.scheme)
-        raise ValueError(msg)
+        raise  SaltInvocationError(msg)
+
+    return is_installed(package_id)

--- a/salt/modules/mac_pkgutil.py
+++ b/salt/modules/mac_pkgutil.py
@@ -29,7 +29,7 @@ def __virtual__():
     if not salt.utils.is_darwin():
         return (False, 'Only available on Mac OS systems')
 
-    if not salt.utils.which('pkgkutil'):
+    if not salt.utils.which('pkgutil'):
         return (False, 'Missing pkgutil binary')
 
     return __virtualname__

--- a/salt/modules/mac_pkgutil.py
+++ b/salt/modules/mac_pkgutil.py
@@ -111,16 +111,6 @@ def install(source, package_id):
     return is_installed(package_id)
 
 
-def remove(package_id):
-    cmd = 'pkgutil --only-files --files {0}'.format(package_id)
-    cmd += ' | tr \'\n\' \'\0\' | xargs -n 1 -0 sudo rm -i'
-    salt.utils.mac_utils.execute_return_success(cmd)
-
-    cmd = 'pkgutil --only-dirs --files {0}'.format(package_id)
-    cmd += ' | tail -r | tr \'\n\' \'\0\' | xargs -n 1 -0 sudo rmdir'
-    salt.utils.mac_utils.execute_return_success(cmd)
-
+def forget(package_id):
     cmd = 'pkgutil --forget {0}'.format(package_id)
-    salt.utils.mac_utils.execute_return_success(cmd)
-
-    return True
+    return salt.utils.mac_utils.execute_return_success(cmd)

--- a/salt/modules/mac_pkgutil.py
+++ b/salt/modules/mac_pkgutil.py
@@ -98,9 +98,6 @@ def install(source, package_id):
 
         salt '*' pkgutil.install source=/vagrant/build_essentials.pkg package_id=com.apple.pkg.gcc4.2Leo
     '''
-    if is_installed(package_id):
-        raise SaltInvocationError('Already installed: {0}'.format(package_id))
-
     uri = urllib.parse.urlparse(source)
     if uri.scheme == '':
         _install_from_path(source)
@@ -132,10 +129,5 @@ def forget(package_id):
         salt '*' pkgutil.forget com.apple.pkg.gcc4.2Leo
     '''
     cmd = 'pkgutil --forget {0}'.format(package_id)
-    if is_installed(package_id):
-        salt.utils.mac_utils.execute_return_success(cmd)
-    else:
-        msg = 'Package not installed: {0}'.format(package_id)
-        raise SaltInvocationError(msg)
-
+    salt.utils.mac_utils.execute_return_success(cmd)
     return not is_installed(package_id)

--- a/salt/modules/mac_pkgutil.py
+++ b/salt/modules/mac_pkgutil.py
@@ -112,5 +112,30 @@ def install(source, package_id):
 
 
 def forget(package_id):
+    '''
+    .. versionadded:: 2016.3.0
+
+    Remove the receipt data about the specified package. Does not remove files.
+
+    .. warning::
+        DO NOT use this command to fix broken package design
+
+    :param str package_id: The name of the package to forget
+
+    :return: True if successful, otherwise False
+    :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkgutil.forget com.apple.pkg.gcc4.2Leo
+    '''
     cmd = 'pkgutil --forget {0}'.format(package_id)
-    return salt.utils.mac_utils.execute_return_success(cmd)
+    if is_installed(package_id):
+        salt.utils.mac_utils.execute_return_success(cmd)
+    else:
+        msg = 'Package not installed: {0}'.format(package_id)
+        raise SaltInvocationError(msg)
+
+    return not is_installed(package_id)

--- a/salt/modules/mac_pkgutil.py
+++ b/salt/modules/mac_pkgutil.py
@@ -99,7 +99,7 @@ def install(source, package_id):
         salt '*' pkgutil.install source=/vagrant/build_essentials.pkg package_id=com.apple.pkg.gcc4.2Leo
     '''
     if is_installed(package_id):
-        return False
+        raise SaltInvocationError('Already installed: {0}'.format(package_id))
 
     uri = urllib.parse.urlparse(source)
     if uri.scheme == '':

--- a/salt/modules/mac_pkgutil.py
+++ b/salt/modules/mac_pkgutil.py
@@ -102,11 +102,11 @@ def install(source, package_id):
         return True
 
     uri = urllib.parse.urlparse(source)
-    if uri.scheme == '':
-        _install_from_path(source)
-    else:
+    if not uri.scheme == '':
         msg = 'Unsupported scheme for source uri: {0}'.format(uri.scheme)
         raise SaltInvocationError(msg)
+
+    _install_from_path(source)
 
     return is_installed(package_id)
 

--- a/salt/modules/mac_pkgutil.py
+++ b/salt/modules/mac_pkgutil.py
@@ -98,6 +98,9 @@ def install(source, package_id):
 
         salt '*' pkgutil.install source=/vagrant/build_essentials.pkg package_id=com.apple.pkg.gcc4.2Leo
     '''
+    if is_installed(package_id):
+        return True
+
     uri = urllib.parse.urlparse(source)
     if uri.scheme == '':
         _install_from_path(source)

--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -115,6 +115,7 @@ def execute_return_success(cmd):
         msg = 'Command Failed: {0}\n'.format(cmd)
         msg += 'Return Code: {0}\n'.format(ret['retcode'])
         msg += 'Output: {0}\n'.format(ret['stdout'])
+        msg += 'Error: {0}\n'.format(ret['stderr'])
         raise CommandExecutionError(msg)
 
     return True
@@ -133,7 +134,10 @@ def execute_return_result(cmd):
     ret = _run_all(cmd)
 
     if ret['retcode'] != 0:
-        msg = 'Command failed: {0}'.format(ret['stderr'])
+        msg = 'Command Failed: {0}\n'.format(cmd)
+        msg += 'Return Code: {0}\n'.format(ret['retcode'])
+        msg += 'Output: {0}\n'.format(ret['stdout'])
+        msg += 'Error: {0}\n'.format(ret['stderr'])
         raise CommandExecutionError(msg)
 
     return ret['stdout']

--- a/tests/integration/modules/mac_pkgutil.py
+++ b/tests/integration/modules/mac_pkgutil.py
@@ -67,9 +67,10 @@ class MacPkgutilModuleTest(integration.ModuleCase):
             self.run_function('pkgutil.is_installed', ['spongebob']))
 
     @destructiveTest
-    def test_install(self):
+    def test_install_forget(self):
         '''
         Test pkgutil.install
+        Test pkgutil.forget
         '''
         # Test if installed
         self.assertFalse(
@@ -81,6 +82,17 @@ class MacPkgutilModuleTest(integration.ModuleCase):
         # Test install
         self.assertTrue(
             self.run_function('pkgutil.install', [TEST_PKG, TEST_PKG_NAME]))
+        self.assertIn(
+            'Already installed',
+            self.run_function('pkgutil.install', [TEST_PKG, TEST_PKG_NAME]))
+        self.assertIn(
+            'Unsupported scheme',
+            self.run_function('pkgutil.install', [TEST_PKG, 'ftp://test']))
+
+        # Test forget
+        self.assertTrue(self.run_function('pkgutil.forget', [TEST_PKG_NAME]))
+        self.assertIn('No receipt for',
+                      self.run_function('pkgutil.forget', [TEST_PKG_NAME]))
 
 
 if __name__ == '__main__':

--- a/tests/integration/modules/mac_pkgutil.py
+++ b/tests/integration/modules/mac_pkgutil.py
@@ -76,7 +76,7 @@ class MacPkgutilModuleTest(integration.ModuleCase):
         self.assertFalse(
             self.run_function('pkgutil.is_installed', [TEST_PKG_NAME]))
 
-        # Download the package from somewhere
+        # Download the package
         self.run_function('cp.get_url', [TEST_PKG_URL, TEST_PKG])
 
         # Test install

--- a/tests/integration/modules/mac_pkgutil.py
+++ b/tests/integration/modules/mac_pkgutil.py
@@ -83,16 +83,11 @@ class MacPkgutilModuleTest(integration.ModuleCase):
         self.assertTrue(
             self.run_function('pkgutil.install', [TEST_PKG, TEST_PKG_NAME]))
         self.assertIn(
-            'Already installed',
-            self.run_function('pkgutil.install', [TEST_PKG, TEST_PKG_NAME]))
-        self.assertIn(
             'Unsupported scheme',
             self.run_function('pkgutil.install', ['ftp://test', 'spongebob']))
 
         # Test forget
         self.assertTrue(self.run_function('pkgutil.forget', [TEST_PKG_NAME]))
-        self.assertIn('Package not installed',
-                      self.run_function('pkgutil.forget', [TEST_PKG_NAME]))
 
 
 if __name__ == '__main__':

--- a/tests/integration/modules/mac_pkgutil.py
+++ b/tests/integration/modules/mac_pkgutil.py
@@ -87,7 +87,7 @@ class MacPkgutilModuleTest(integration.ModuleCase):
             self.run_function('pkgutil.install', [TEST_PKG, TEST_PKG_NAME]))
         self.assertIn(
             'Unsupported scheme',
-            self.run_function('pkgutil.install', ['ftp://test', TEST_PKG_NAME]))
+            self.run_function('pkgutil.install', ['ftp://test', 'spongebob']))
 
         # Test forget
         self.assertTrue(self.run_function('pkgutil.forget', [TEST_PKG_NAME]))

--- a/tests/integration/modules/mac_pkgutil.py
+++ b/tests/integration/modules/mac_pkgutil.py
@@ -87,7 +87,7 @@ class MacPkgutilModuleTest(integration.ModuleCase):
             self.run_function('pkgutil.install', [TEST_PKG, TEST_PKG_NAME]))
         self.assertIn(
             'Unsupported scheme',
-            self.run_function('pkgutil.install', [TEST_PKG, 'ftp://test']))
+            self.run_function('pkgutil.install', ['ftp://test', TEST_PKG_NAME]))
 
         # Test forget
         self.assertTrue(self.run_function('pkgutil.forget', [TEST_PKG_NAME]))

--- a/tests/integration/modules/mac_pkgutil.py
+++ b/tests/integration/modules/mac_pkgutil.py
@@ -14,6 +14,8 @@ ensure_in_syspath('../../')
 import integration
 import salt.utils
 
+TEST_PKG = 'http://download.videolan.org/pub/videolan/libdvdcss/1.2.11/macosx/libdvdcss.pkg'
+
 
 def disabled(f):
     def _decorator(f):
@@ -57,7 +59,7 @@ class MacPkgutilModuleTest(integration.ModuleCase):
         # Test Package is installed
         self.assertTrue(
             self.run_function('darwin_pkgutil.is_installed',
-                              ['com.apple.atrun']))
+                              ['com.apple.pkg.BaseSystemResources']))
 
         # Test Package is not installed
         self.assertFalse(
@@ -70,7 +72,7 @@ class MacPkgutilModuleTest(integration.ModuleCase):
         '''
         # Test if installed
         self.assertFalse(
-            self.run_function('darwin_pkgutil.is_installed', ['????']))
+            self.run_function('darwin_pkgutil.is_installed', [TEST_PKG]))
 
         # Download the package from somewhere
         self.run_function('cp.get_url', ['????', '????'])

--- a/tests/integration/modules/mac_pkgutil.py
+++ b/tests/integration/modules/mac_pkgutil.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+'''
+integration tests for mac_pkgutil
+'''
+
+# Import python libs
+from __future__ import absolute_import, print_function
+
+# Import Salt Testing libs
+from salttesting.helpers import ensure_in_syspath, destructiveTest
+ensure_in_syspath('../../')
+
+# Import salt libs
+import integration
+import salt.utils
+
+
+def disabled(f):
+    def _decorator(f):
+        print('{0} has been disabled'.format(f.__name__))
+    return _decorator(f)
+
+
+class MacPkgutilModuleTest(integration.ModuleCase):
+    '''
+    Validate the mac_pkgutil module
+    '''
+
+    def setUp(self):
+        '''
+        Get current settings
+        '''
+        if not salt.utils.is_darwin():
+            self.skipTest('Test only available on Mac OS X')
+
+        if not salt.utils.which('pkgutil'):
+            self.skipTest('Test requires pkgutil binary')
+
+        if salt.utils.get_uid(salt.utils.get_user()) != 0:
+            self.skipTest('Test requires root')
+
+    def tearDown(self):
+        '''
+        Reset to original settings
+        '''
+
+    def test_list(self):
+        '''
+        Test darwin_pkgutil.list
+        '''
+        self.assertIsInstance(self.run_function('darwin_pkgutil.list'), list)
+
+    def test_is_installed(self):
+        '''
+        Test darwin_pkgutil.is_installed
+        '''
+        # Test Package is installed
+        self.assertTrue(
+            self.run_function('darwin_pkgutil.is_installed',
+                              ['com.apple.atrun']))
+
+        # Test Package is not installed
+        self.assertFalse(
+            self.run_function('darwin_pkgutil.is_installed', ['spongebob']))
+
+    @destructiveTest
+    def test_install(self):
+        '''
+        Test darwin_pkgutil.install
+        '''
+        # Test if installed
+        self.assertFalse(
+            self.run_function('darwin_pkgutil.is_installed', ['????']))
+
+        # Download the package from somewhere
+        self.run_function('cp.get_url', ['????', '????'])
+
+        # Test install
+        self.assertTrue(self.run_function('darwin_pkgutil.install', ['?????']))
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(MacPkgutilModuleTest)

--- a/tests/integration/modules/mac_pkgutil.py
+++ b/tests/integration/modules/mac_pkgutil.py
@@ -5,6 +5,7 @@ integration tests for mac_pkgutil
 
 # Import python libs
 from __future__ import absolute_import, print_function
+import os
 
 # Import Salt Testing libs
 from salttesting.helpers import ensure_in_syspath, destructiveTest

--- a/tests/integration/modules/mac_pkgutil.py
+++ b/tests/integration/modules/mac_pkgutil.py
@@ -82,7 +82,8 @@ class MacPkgutilModuleTest(integration.ModuleCase):
         self.run_function('cp.get_url', [TEST_PKG_URL, TEST_PKG])
 
         # Test install
-        self.assertTrue(self.run_function('pkgutil.install', [TEST_PKG]))
+        self.assertTrue(
+            self.run_function('pkgutil.install', [TEST_PKG, TEST_PKG_NAME]))
 
 
 if __name__ == '__main__':

--- a/tests/integration/modules/mac_pkgutil.py
+++ b/tests/integration/modules/mac_pkgutil.py
@@ -14,7 +14,9 @@ ensure_in_syspath('../../')
 import integration
 import salt.utils
 
-TEST_PKG = 'http://download.videolan.org/pub/videolan/libdvdcss/1.2.11/macosx/libdvdcss.pkg'
+TEST_PKG_URL = 'https://distfiles.macports.org/MacPorts/MacPorts-2.3.4-10.11-ElCapitan.pkg'
+TEST_PKG_NAME = 'org.macports.MacPorts'
+TEST_PKG = os.path.join(integration.TMP, 'MacPorts-2.3.4-10.11-ElCapitan.pkg')
 
 
 def disabled(f):
@@ -50,7 +52,9 @@ class MacPkgutilModuleTest(integration.ModuleCase):
         '''
         Test darwin_pkgutil.list
         '''
-        self.assertIsInstance(self.run_function('darwin_pkgutil.list'), list)
+        self.assertIsInstance(self.run_function('pkgutil.list'), list)
+        self.assertIn('com.apple.pkg.BaseSystemResources',
+                      self.run_function('pkgutil.list'))
 
     def test_is_installed(self):
         '''
@@ -58,27 +62,27 @@ class MacPkgutilModuleTest(integration.ModuleCase):
         '''
         # Test Package is installed
         self.assertTrue(
-            self.run_function('darwin_pkgutil.is_installed',
+            self.run_function('pkgutil.is_installed',
                               ['com.apple.pkg.BaseSystemResources']))
 
         # Test Package is not installed
         self.assertFalse(
-            self.run_function('darwin_pkgutil.is_installed', ['spongebob']))
+            self.run_function('pkgutil.is_installed', ['spongebob']))
 
     @destructiveTest
     def test_install(self):
         '''
-        Test darwin_pkgutil.install
+        Test pkgutil.install
         '''
         # Test if installed
         self.assertFalse(
-            self.run_function('darwin_pkgutil.is_installed', [TEST_PKG]))
+            self.run_function('pkgutil.is_installed', [TEST_PKG_NAME]))
 
         # Download the package from somewhere
-        self.run_function('cp.get_url', ['????', '????'])
+        self.run_function('cp.get_url', [TEST_PKG_URL, TEST_PKG])
 
         # Test install
-        self.assertTrue(self.run_function('darwin_pkgutil.install', ['?????']))
+        self.assertTrue(self.run_function('pkgutil.install', [TEST_PKG]))
 
 
 if __name__ == '__main__':

--- a/tests/integration/modules/mac_pkgutil.py
+++ b/tests/integration/modules/mac_pkgutil.py
@@ -91,7 +91,7 @@ class MacPkgutilModuleTest(integration.ModuleCase):
 
         # Test forget
         self.assertTrue(self.run_function('pkgutil.forget', [TEST_PKG_NAME]))
-        self.assertIn('No receipt for',
+        self.assertIn('Package not installed',
                       self.run_function('pkgutil.forget', [TEST_PKG_NAME]))
 
 

--- a/tests/integration/modules/mac_pkgutil.py
+++ b/tests/integration/modules/mac_pkgutil.py
@@ -4,7 +4,7 @@ integration tests for mac_pkgutil
 '''
 
 # Import python libs
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import
 import os
 
 # Import Salt Testing libs
@@ -18,12 +18,6 @@ import salt.utils
 TEST_PKG_URL = 'https://distfiles.macports.org/MacPorts/MacPorts-2.3.4-10.11-ElCapitan.pkg'
 TEST_PKG_NAME = 'org.macports.MacPorts'
 TEST_PKG = os.path.join(integration.TMP, 'MacPorts-2.3.4-10.11-ElCapitan.pkg')
-
-
-def disabled(f):
-    def _decorator(f):
-        print('{0} has been disabled'.format(f.__name__))
-    return _decorator(f)
 
 
 class MacPkgutilModuleTest(integration.ModuleCase):
@@ -48,10 +42,11 @@ class MacPkgutilModuleTest(integration.ModuleCase):
         '''
         Reset to original settings
         '''
+        pass
 
     def test_list(self):
         '''
-        Test darwin_pkgutil.list
+        Test pkgutil.list
         '''
         self.assertIsInstance(self.run_function('pkgutil.list'), list)
         self.assertIn('com.apple.pkg.BaseSystemResources',
@@ -59,7 +54,7 @@ class MacPkgutilModuleTest(integration.ModuleCase):
 
     def test_is_installed(self):
         '''
-        Test darwin_pkgutil.is_installed
+        Test pkgutil.is_installed
         '''
         # Test Package is installed
         self.assertTrue(

--- a/tests/integration/modules/mac_pkgutil.py
+++ b/tests/integration/modules/mac_pkgutil.py
@@ -42,7 +42,8 @@ class MacPkgutilModuleTest(integration.ModuleCase):
         '''
         Reset to original settings
         '''
-        pass
+        self.run_function('pkgutil.forget', ['org.macports.MacPorts'])
+        self.run_function('file.remove', ['/opt/local'])
 
     def test_list(self):
         '''

--- a/tests/unit/modules/mac_pkgutil_test.py
+++ b/tests/unit/modules/mac_pkgutil_test.py
@@ -17,7 +17,7 @@ mac_pkgutil.__salt__ = {}
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class MacPkgutilTestCase(TestCase):
-    def test_list_command(self):
+    def test_list(self):
         # Given
         r_output = "com.apple.pkg.iTunes"
 
@@ -80,7 +80,7 @@ class MacPkgutilTestCase(TestCase):
         with patch("salt.modules.mac_pkgutil.is_installed",
                    return_value=False) as is_installed:
             with patch("salt.modules.mac_pkgutil._install_from_path",
-                   return_value=True) as _install_from_path:
+                       return_value=True) as _install_from_path:
                 ret = mac_pkgutil.install(source, package_id)
 
         # Then

--- a/tests/unit/modules/mac_pkgutil_test.py
+++ b/tests/unit/modules/mac_pkgutil_test.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 
 # Import salt module
 from salt.modules import mac_pkgutil
+import salt.utils.mac_utils
 
 # Import Salt Testing libs
 from salttesting import TestCase, skipIf
@@ -15,19 +16,26 @@ mac_pkgutil.__salt__ = {}
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
-class DarwingPkgutilTestCase(TestCase):
-    def test_list_installed_command(self):
+class MacPkgutilTestCase(TestCase):
+    def test_list_command(self):
         # Given
         r_output = "com.apple.pkg.iTunes"
 
         # When
         mock_cmd = MagicMock(return_value=r_output)
-        with patch.dict(mac_pkgutil.__salt__, {'cmd.run_stdout': mock_cmd}):
+        with patch.object(salt.utils.mac_utils,
+                          'execute_return_result',
+                          mock_cmd):
             output = mac_pkgutil.list_()
 
         # Then
+        self.assertEqual(
+            output,
+            [r_output]
+        )
+
         mock_cmd.assert_called_with(
-            ['/usr/sbin/pkgutil', '--pkgs'],
+            ['pkgutil', '--pkgs'],
             python_shell=False
         )
 

--- a/tests/unit/modules/mac_pkgutil_test.py
+++ b/tests/unit/modules/mac_pkgutil_test.py
@@ -5,11 +5,10 @@ from __future__ import absolute_import
 
 # Import salt module
 from salt.modules import mac_pkgutil
-import salt.utils.mac_utils
 
 # Import Salt Testing libs
 from salttesting import TestCase, skipIf
-from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, patch
 
 
 mac_pkgutil.__salt__ = {}
@@ -17,58 +16,6 @@ mac_pkgutil.__salt__ = {}
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class MacPkgutilTestCase(TestCase):
-    def test_list(self):
-        # Given
-        r_output = "com.apple.pkg.iTunes"
-
-        # When
-        mock_cmd = MagicMock(return_value=r_output)
-        with patch.object(salt.utils.mac_utils,
-                          'execute_return_result',
-                          mock_cmd):
-            output = mac_pkgutil.list_()
-
-        # Then
-        self.assertEqual(
-            output,
-            [r_output]
-        )
-
-        mock_cmd.assert_called_with(
-            ['pkgutil', '--pkgs'],
-            python_shell=False
-        )
-
-    def test_list_installed_output(self):
-        # Given
-        r_output = "com.apple.pkg.iTunes"
-
-        # When
-        mock_cmd = MagicMock(return_value=r_output)
-        with patch.dict(mac_pkgutil.__salt__, {'cmd.run_stdout': mock_cmd}):
-            output = mac_pkgutil.list_()
-
-        # Then
-        self.assertEqual(output, r_output)
-
-    def test_is_installed(self):
-        # Given
-        r_output = "com.apple.pkg.iTunes"
-
-        # When
-        mock_cmd = MagicMock(return_value=r_output)
-        with patch.dict(mac_pkgutil.__salt__, {'cmd.run_stdout': mock_cmd}):
-            ret = mac_pkgutil.is_installed("com.apple.pkg.iTunes")
-
-        # Then
-        self.assertTrue(ret)
-
-        # When
-        with patch.dict(mac_pkgutil.__salt__, {'cmd.run_stdout': mock_cmd}):
-            ret = mac_pkgutil.is_installed("com.apple.pkg.Safari")
-
-        # Then
-        self.assertFalse(ret)
 
     def test_install(self):
         # Given
@@ -76,12 +23,11 @@ class MacPkgutilTestCase(TestCase):
         package_id = "com.foo.fubar.pkg"
 
         # When
-        mock_cmd = MagicMock(return_value=True)
         with patch("salt.modules.mac_pkgutil.is_installed",
-                   return_value=False) as is_installed:
+                   return_value=False):
             with patch("salt.modules.mac_pkgutil._install_from_path",
                        return_value=True) as _install_from_path:
-                ret = mac_pkgutil.install(source, package_id)
+                mac_pkgutil.install(source, package_id)
 
         # Then
         _install_from_path.assert_called_with(source)
@@ -92,12 +38,11 @@ class MacPkgutilTestCase(TestCase):
         package_id = "com.foo.fubar.pkg"
 
         # When
-        mock_cmd = MagicMock(return_value=True)
         with patch("salt.modules.mac_pkgutil.is_installed",
-                   return_value=True) as is_installed:
+                   return_value=True):
             with patch("salt.modules.mac_pkgutil._install_from_path",
-                   return_value=True) as _install_from_path:
-                ret = mac_pkgutil.install(source, package_id)
+                       return_value=True) as _install_from_path:
+                mac_pkgutil.install(source, package_id)
 
         # Then
         self.assertEqual(_install_from_path.called, 0)

--- a/tests/unit/utils/mac_utils_test.py
+++ b/tests/unit/utils/mac_utils_test.py
@@ -41,7 +41,8 @@ class MacUtilsTestCase(TestCase):
         command failed
         '''
         mock_cmd = MagicMock(return_value={'retcode': 1,
-                                           'stdout': 'spongebob'})
+                                           'stdout': 'spongebob',
+                                           'stderr': 'error'})
         with patch.object(mac_utils, '_run_all', mock_cmd):
             self.assertRaises(CommandExecutionError,
                               mac_utils.execute_return_success,


### PR DESCRIPTION
### What does this PR do?

Adds integration tests for mac_pkgutil.
Makes mac_pkgutil less fire and forget by using salt.utils.mac_utils.
Make mac_pkgutil functions return consistent types.
Fix unit tests.
### What issues does this PR fix or reference?

https://github.com/saltstack/zh/issues/553
### Tests written?

Yes
