### PR TITLE
mac_service: use load/unload for service operations

### DIFF
--- a/salt/modules/mac_service.py
+++ b/salt/modules/mac_service.py
@@ -79,8 +79,8 @@ def _available_services():
                     # the system provided plutil program to do the conversion
                     cmd = '/usr/bin/plutil -convert xml1 -o - -- "{0}"'.format(
                         true_path)
-                    plist_xml = __salt__['cmd.run_all'](
-                        cmd, python_shell=False)['stdout']
+                    plist_xml = __salt__['cmd.run'](
+                        cmd, python_shell=False, output_loglevel='trace')
                     if six.PY2:
                         plist = plistlib.readPlistFromString(plist_xml)
                     else:

--- a/salt/modules/mac_service.py
+++ b/salt/modules/mac_service.py
@@ -335,11 +335,15 @@ def restart(service_target):
     return not ret['stderr']
 
 
-def status(name):
+def status(name, sig=None):
     '''
     Return the status for a service.
 
-    :param str name: Can be any part of the service name or a regex expression
+    :param str name: Used to find the service from launchctl.  Can be any part
+        of the service name or a regex expression.
+
+    :param str sig: Find the service with status.pid instead.  Note that
+        ``name`` must still be provided.
 
     :return: The PID for the service if it is running, otherwise an empty string
     :rtype: str
@@ -350,7 +354,10 @@ def status(name):
 
         salt '*' service.status cups
     '''
-    # TODO: Move this to mac_status function if ever created
+    # Find service with ps
+    if sig:
+        return __salt__['status.pid'](sig)
+
     cmd = ['launchctl', 'list']
     output = __salt__['cmd.run_stdout'](cmd)
 

--- a/salt/modules/mac_service.py
+++ b/salt/modules/mac_service.py
@@ -60,8 +60,8 @@ def _available_services():
     available_services = dict()
     for launch_dir in _launchd_paths():
         for root, dirs, files in os.walk(launch_dir):
-            for filename in files:
-                file_path = os.path.join(root, filename)
+            for file_name in files:
+                file_path = os.path.join(root, file_name)
                 # Follow symbolic links of files in _launchd_paths
                 true_path = os.path.realpath(file_path)
                 # ignore broken symlinks
@@ -88,7 +88,7 @@ def _available_services():
                             salt.utils.to_bytes(plist_xml))
 
                 available_services[plist.Label.lower()] = {
-                    'filename': filename,
+                    'file_name': file_name,
                     'file_path': true_path,
                     'plist': plist,
                 }
@@ -118,7 +118,7 @@ def _get_service(name):
         if service['file_path'].lower() == name:
             # Match on full path
             return service
-        basename, ext = os.path.splitext(service['filename'])
+        basename, ext = os.path.splitext(service['file_name'])
         if basename.lower() == name:
             # Match on basename
             return service


### PR DESCRIPTION
### What does this PR do?

Use load/unload for mac_service execution module.  The new bootstrap/bootout, enable/disable do not seem to work in a consistent way, so we'll use load/unload until that can get sorted out.
### What issues does this PR fix or reference?

Homebrew/homebrew#33259
### Previous Behavior

Broken mac_service
### New Behavior

Working mac_service
### Tests written?
- [ ] Yes
- [x] No
  Tests to be written in a separate pull request.
