### PR TITLE
Add minion.restart

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -809,6 +809,9 @@ VALID_OPTS = {
 
     # Delay in seconds before executing bootstrap (salt cloud)
     'bootstrap_delay': int,
+
+    # Command to use to restart salt-minion
+    'minion_restart_command': list,
 }
 
 # default configurations
@@ -1032,6 +1035,7 @@ DEFAULT_MINION_OPTS = {
     # ZMQ HWM for EventPublisher pub socket - different for minion vs. master
     'event_publisher_pub_hwm': 1000,
     'event_match_type': 'startswith',
+    'minion_restart_command': [],
 }
 
 DEFAULT_MASTER_OPTS = {

--- a/salt/defaults/exitcodes.py
+++ b/salt/defaults/exitcodes.py
@@ -25,12 +25,13 @@ EX_AGGREGATE = 20
 # These constants are documented here:
 # https://docs.python.org/2/library/os.html#os.EX_OK
 
-EX_OK = 0
-EX_NOUSER = 67
-EX_UNAVAILABLE = 69
-EX_CANTCREAT = 73
-EX_SOFTWARE = 70
-EX_USAGE = 64
+EX_OK = 0                 # successful termination
+EX_USAGE = 64             # command line usage error
+EX_NOUSER = 67            # addressee unknown
+EX_UNAVAILABLE = 69       # service unavailable
+EX_SOFTWARE = 70          # internal software error
+EX_CANTCREAT = 73         # can't create (user) output file
+EX_TEMPFAIL = 75          # temp failure; user is invited to retry
 
 # The Salt specific exit codes are defined below:
 

--- a/salt/modules/minion.py
+++ b/salt/modules/minion.py
@@ -6,10 +6,15 @@ from __future__ import absolute_import
 
 # Import Python libs
 import os
+import sys
+import time
 
 # Import Salt libs
 import salt.utils
 import salt.key
+
+# Import third party libs
+import salt.ext.six as six
 
 # Don't shadow built-ins.
 __func_alias__ = {
@@ -87,9 +92,12 @@ def _check_minions_directories_raetkey(pki_dir):
     return accepted, pre, rejected
 
 
-def kill():
+def kill(timeout=15):
     '''
     Kill the salt minion.
+
+    timeout
+        int seconds to wait for the minion to die.
 
     If you have a monitor that restarts ``salt-minion`` when it dies then this is
     a great way to restart after a minion upgrade.
@@ -101,18 +109,169 @@ def kill():
             ----------
             killed:
                 7874
+            retcode:
+                0
         minion2:
             ----------
             killed:
                 29071
+            retcode:
+                0
 
-    The result of the salt command shows the process ID of the minions that were
-    successfully killed - in this case they were ``7874`` and ``29071``.
+    The result of the salt command shows the process ID of the minions and the
+    results of a kill signal to the minion in as the ``retcode`` value: ``0``
+    is success, anything else is a failure.
     '''
+
+    ret = {
+        'pid': None,
+        'retcode': 1,
+    }
+    comment = []
     pid = __grains__.get('pid')
-    if pid:
-        if 'ps.kill_pid' in __salt__:
-            __salt__['ps.kill_pid'](pid)
+    if not pid:
+        comment.append('Unable to find "pid" in grains')
+        ret['retcode'] = salt.defaults.exitcodes.EX_SOFTWARE
+    else:
+        ret['pid'] = pid
+        if not 'ps.kill_pid' in __salt__:
+            comment.append('Missing command: ps.kill_pid')
+            ret['retcode'] = salt.defaults.exitcodes.EX_SOFTWARE
         else:
-            pid = None
-    return {'killed': pid}
+            # The retcode status comes from the first kill signal
+            ret['retcode'] = int(not __salt__['ps.kill_pid'](pid))
+
+            # If the signal was successfully delivered then wait for the
+            # process to die - check by sending signals until signal delivery
+            # fails.
+            if ret['retcode']:
+                comment.append('ps.kill_pid failed')
+            else:
+                for tick in range(timeout):
+                    time.sleep(1)
+                    signaled = __salt__['ps.kill_pid'](pid)
+                    if not signaled:
+                        break
+                else:
+                    # The process did not exit before the timeout
+                    comment.append('Timed out waiting for minion to exit')
+                    ret['retcode'] = salt.defaults.exitcodes.EX_TEMPFAIL
+
+    if comment:
+        ret['comment'] = comment
+    return ret
+
+
+def restart():
+    '''
+    Kill and restart the salt minion.
+
+    The configuration key ``minion_restart_command`` is an argv list for the
+    command to restart the minion.  If ``minion_restart_command`` is not
+    specified or empty then the ``argv`` of the current process will be used.
+
+    if the configuration value ``minion_restart_command`` is not set and the
+    ``-d`` (daemonize) argument is missing from ``argv`` then the minion
+    *will* be killed but will *not* be restarted and will require the parent
+    process to perform the restart.  This behavior is intended for managed
+    salt minion processes.
+
+    CLI example::
+
+        >$ salt minion[12] minion.restart
+        minion1:
+            ----------
+            comment:
+                - Restart using process argv:
+                -     /home/omniture/install/bin/salt-minion
+                -     -d
+                -     -c
+                -     /home/omniture/install/etc/salt
+            killed:
+                10070
+            restart:
+                ----------
+                stderr:
+                stdout:
+            retcode:
+                0
+        minion2:
+            ----------
+            comment:
+                - Using configuration minion_restart_command:
+                -     /home/omniture/install/bin/salt-minion
+                -     --not-an-option
+                -     -d
+                -     -c
+                -     /home/omniture/install/etc/salt
+                - Restart failed
+            killed:
+                10896
+            restart:
+                ----------
+                stderr:
+                    Usage: salt-minion
+        
+                    salt-minion: error: no such option: --not-an-option
+                stdout:
+            retcode:
+                64
+
+    The result of the command shows the process ID of ``minion1`` that is
+    shutdown (killed) and the results of the restart.  If there is a failure
+    in the restart it will be reflected in a non-zero ``retcode`` and possibly
+    output in the ``stderr`` and/or ``stdout`` values along with addition
+    information in the ``comment`` field as is demonstrated with ``minion2``.
+    '''
+
+    should_kill = True
+    should_restart = True
+    comment = []
+    ret = {
+        'killed': None,
+        'restart': None,
+        'retcode': 0,
+    }
+
+    restart_cmd = __salt__['config.get']('minion_restart_command')
+    if restart_cmd:
+        comment.append('Using configuration minion_restart_command:')
+        comment.extend(['    {0}'.format(arg) for arg in restart_cmd])
+    else:
+        if '-d' in sys.argv:
+            restart_cmd = sys.argv
+            comment.append('Restart using process argv:')
+            comment.extend(['    {0}'.format(arg) for arg in restart_cmd])
+        else:
+            should_restart = False
+            comment.append('Not running in daemon mode - will not restart process after killing')
+
+    if should_kill:
+        ret.update(kill())
+        if 'comment' in ret and ret['comment']:
+            if isinstance(ret['comment'], six.string_types):
+                comment.append(ret['comment'])
+            else:
+                comment.extend(ret['comment'])
+        if ret['retcode']:
+            comment.append('Kill failed - not restarting')
+            should_restart = False
+
+    if should_restart:
+        ret['restart'] = __salt__['cmd.run_all'](restart_cmd, env=os.environ)
+        # Do not want to mislead users to think that the returned PID from
+        # cmd.run_all() is the PID of the new salt minion - just delete the
+        # returned PID.
+        if 'pid' in ret['restart']:
+            del ret['restart']['pid']
+        if ret['restart'].get('retcode', None):
+            comment.append('Restart failed')
+            ret['retcode'] = ret['restart']['retcode']
+        if 'retcode' in ret['restart']:
+            # Just want a single retcode
+            del ret['restart']['retcode']
+
+    if comment:
+        ret['comment'] = comment
+
+    return ret

--- a/salt/modules/minion.py
+++ b/salt/modules/minion.py
@@ -124,7 +124,6 @@ def kill(timeout=15):
     '''
 
     ret = {
-        'pid': None,
         'retcode': 1,
     }
     comment = []
@@ -133,7 +132,6 @@ def kill(timeout=15):
         comment.append('Unable to find "pid" in grains')
         ret['retcode'] = salt.defaults.exitcodes.EX_SOFTWARE
     else:
-        ret['pid'] = pid
         if 'ps.kill_pid' not in __salt__:
             comment.append('Missing command: ps.kill_pid')
             ret['retcode'] = salt.defaults.exitcodes.EX_SOFTWARE
@@ -151,6 +149,7 @@ def kill(timeout=15):
                     time.sleep(1)
                     signaled = __salt__['ps.kill_pid'](pid)
                     if not signaled:
+                        ret['killed'] = pid
                         break
                 else:
                     # The process did not exit before the timeout

--- a/salt/modules/minion.py
+++ b/salt/modules/minion.py
@@ -134,7 +134,7 @@ def kill(timeout=15):
         ret['retcode'] = salt.defaults.exitcodes.EX_SOFTWARE
     else:
         ret['pid'] = pid
-        if not 'ps.kill_pid' in __salt__:
+        if 'ps.kill_pid' not in __salt__:
             comment.append('Missing command: ps.kill_pid')
             ret['retcode'] = salt.defaults.exitcodes.EX_SOFTWARE
         else:
@@ -147,7 +147,7 @@ def kill(timeout=15):
             if ret['retcode']:
                 comment.append('ps.kill_pid failed')
             else:
-                for tick in range(timeout):
+                for _ in range(timeout):
                     time.sleep(1)
                     signaled = __salt__['ps.kill_pid'](pid)
                     if not signaled:
@@ -211,7 +211,7 @@ def restart():
                 ----------
                 stderr:
                     Usage: salt-minion
-        
+
                     salt-minion: error: no such option: --not-an-option
                 stdout:
             retcode:
@@ -229,7 +229,7 @@ def restart():
     comment = []
     ret = {
         'killed': None,
-        'restart': None,
+        'restart': {},
         'retcode': 0,
     }
 


### PR DESCRIPTION
### What does this PR do?

Adds minion.restart (and improves minion.kill)
### What issues does this PR fix or reference?
### Previous Behavior
### New Behavior

Can now restart minions from master
### Tests written?
- [ ] Yes
- [X] Not yet - coming
- Improve minion.kill for use by minion.restart
  - Add "retcode" status
  - Wait until the process dies (add timeout value)
  - Provide meaningful "comment" information when appropriate
- Add minion.restart: kills minion with minion.kill and then starts a new minion process
  - Can provide a specific `minion_restart_command` arg vector in minion configuration
  - If no `minion_restart_command` is available then uses `argv` of current process
  - If minion is not daemonized then it will kill but not restart - allows for
    direct management of minion by init, systemd or other direct process
    manager.
- Add EX_TEMPFAIL to exitcodes for timeout situtations (used by minion.kill)

TODO: integration tests
