### PR TITLE
replaced ',' for whitespace as split seperator for rabbitmq tags

### DIFF
--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -134,7 +134,7 @@ def list_users(runas=None):
         python_shell=False)
 
     # func to get tags from string such as "[admin, monitoring]"
-    func = lambda string: set([tag.strip() for tag in string[1:-1].split(',')])
+    func = lambda string: [tag.strip() for tag in string[1:-1].split(' ')]
     return _output_to_dict(res, func)
 
 

--- a/salt/states/rabbitmq_user.py
+++ b/salt/states/rabbitmq_user.py
@@ -81,8 +81,8 @@ def _check_tags_changes(name, new_tags, runas=None):
         if isinstance(new_tags, str):
             new_tags = new_tags.split()
         try:
-            old_tags =  __salt__['rabbitmq.list_users'](runas=runas)[name]
-            users =  set(old_tags) - set(new_tags)
+            old_tags = __salt__['rabbitmq.list_users'](runas=runas)[name]
+            users = set(old_tags) - set(new_tags)
         except CommandExecutionError as err:
             log.error('Error: {0}'.format(err))
             return []

--- a/salt/states/rabbitmq_user.py
+++ b/salt/states/rabbitmq_user.py
@@ -81,7 +81,8 @@ def _check_tags_changes(name, new_tags, runas=None):
         if isinstance(new_tags, str):
             new_tags = new_tags.split()
         try:
-            users = __salt__['rabbitmq.list_users'](runas=runas)[name] - set(new_tags)
+            old_tags =  __salt__['rabbitmq.list_users'](runas=runas)[name]
+            users =  set(old_tags) - set(new_tags)
         except CommandExecutionError as err:
             log.error('Error: {0}'.format(err))
             return []

--- a/tests/unit/modules/rabbitmq_test.py
+++ b/tests/unit/modules/rabbitmq_test.py
@@ -40,7 +40,7 @@ class RabbitmqTestCase(TestCase):
         '''
         mock_run = MagicMock(return_value='Listing users ...\nguest\t[administrator]\n')
         with patch.dict(rabbitmq.__salt__, {'cmd.run': mock_run}):
-            self.assertDictEqual(rabbitmq.list_users(), {'guest': set(['administrator'])})
+            self.assertDictEqual(rabbitmq.list_users(), {'guest': ['administrator']})
 
     # 'list_users_with_warning' function tests: 1
 
@@ -55,7 +55,7 @@ class RabbitmqTestCase(TestCase):
         ])
         mock_run = MagicMock(return_value=rtn_val)
         with patch.dict(rabbitmq.__salt__, {'cmd.run': mock_run}):
-            self.assertDictEqual(rabbitmq.list_users(), {'guest': set(['administrator'])})
+            self.assertDictEqual(rabbitmq.list_users(), {'guest': ['administrator']})
 
     # 'list_vhosts' function tests: 1
 

--- a/tests/unit/states/rabbitmq_user_test.py
+++ b/tests/unit/states/rabbitmq_user_test.py
@@ -87,7 +87,7 @@ class RabbitmqUserTestCase(TestCase):
                 self.assertDictEqual(rabbitmq_user.present(name, force=True),
                                      ret)
 
-                changes = {'tags': {'new': ['user], 'old': 'user'}}
+                changes = {'tags': {'new': ['user'], 'old': 'user'}}
                 ret.update({'changes': changes})
                 self.assertDictEqual(rabbitmq_user.present(name, tags=tag), ret)
 

--- a/tests/unit/states/rabbitmq_user_test.py
+++ b/tests/unit/states/rabbitmq_user_test.py
@@ -87,18 +87,18 @@ class RabbitmqUserTestCase(TestCase):
                 self.assertDictEqual(rabbitmq_user.present(name, force=True),
                                      ret)
 
-                changes = {'tags': {'new': ['u', 's', 'r', 'e'], 'old': 'user'}}
+                changes = {'tags': {'new': ['user], 'old': 'user'}}
                 ret.update({'changes': changes})
                 self.assertDictEqual(rabbitmq_user.present(name, tags=tag), ret)
 
                 comment = '\'foo\' is already in the desired state.'
                 ret.update({'changes': {}, 'comment': comment, 'result': True})
                 self.assertDictEqual(rabbitmq_user.present(name, perms=perms),
-                                     ret)
 
             with patch.dict(rabbitmq_user.__opts__, {'test': False}):
+                                     ret)
                 ret.update({'comment': '\'foo\' was configured.', 'result': True,
-                            'changes': {'tags': {'new': ['u', 's', 'r', 'e'], 'old': 'user'}}})
+                            'changes': {'tags': {'new': ['user'], 'old': 'user'}}})
                 self.assertDictEqual(rabbitmq_user.present(name, tags=tag), ret)
 
     # 'absent' function tests: 1


### PR DESCRIPTION
### What does this PR do?

  fix change handling for rabbitmq user tags
### What issues does this PR fix or reference?
### Previous Behavior
### New Behavior
### Tests written?
- [ ] Yes
- [x] No
