### PR TITLE
Discard duplicate YAML nodes when merging anchors to avoid duplicate …

### DIFF
--- a/salt/utils/yamlloader.py
+++ b/salt/utils/yamlloader.py
@@ -96,3 +96,46 @@ class SaltYamlSafeLoader(yaml.SafeLoader, object):
                 if node.value == '':
                     node.value = '0'
         return super(SaltYamlSafeLoader, self).construct_scalar(node)
+
+    def flatten_mapping(self, node):
+        merge = []
+        index = 0
+        while index < len(node.value):
+            key_node, value_node = node.value[index]
+
+            if key_node.tag == u'tag:yaml.org,2002:merge':
+                del node.value[index]
+                if isinstance(value_node, MappingNode):
+                    self.flatten_mapping(value_node)
+                    merge.extend(value_node.value)
+                elif isinstance(value_node, SequenceNode):
+                    submerge = []
+                    for subnode in value_node.value:
+                        if not isinstance(subnode, MappingNode):
+                            raise ConstructorError("while constructing a mapping",
+                                                   node.start_mark,
+                                                   "expected a mapping for merging, but found %s"
+                                                   % subnode.id,
+                                                   subnode.start_mark)
+                        self.flatten_mapping(subnode)
+                        submerge.append(subnode.value)
+                    submerge.reverse()
+                    for value in submerge:
+                        merge.extend(value)
+                else:
+                    raise ConstructorError("while constructing a mapping",
+                                           node.start_mark,
+                                           "expected a mapping or list of mappings for merging, but found %s"
+                                           % value_node.id,
+                                           value_node.start_mark)
+            elif key_node.tag == u'tag:yaml.org,2002:value':
+                key_node.tag = u'tag:yaml.org,2002:str'
+                index += 1
+            else:
+                index += 1
+        if merge:
+            # Here we need to discard any duplicate entries based on key_node
+            existing_nodes = [name_node.value for name_node, value_node in node.value]
+            mergeable_items = [x for x in merge if x[0].value not in existing_nodes]
+
+            node.value = mergeable_items + node.value

--- a/salt/utils/yamlloader.py
+++ b/salt/utils/yamlloader.py
@@ -5,7 +5,7 @@ import warnings
 
 # Import third party libs
 import yaml
-from yaml.nodes import MappingNode
+from yaml.nodes import MappingNode, SequenceNode
 from yaml.constructor import ConstructorError
 try:
     yaml.Loader = yaml.CLoader
@@ -114,8 +114,7 @@ class SaltYamlSafeLoader(yaml.SafeLoader, object):
                         if not isinstance(subnode, MappingNode):
                             raise ConstructorError("while constructing a mapping",
                                                    node.start_mark,
-                                                   "expected a mapping for merging, but found %s"
-                                                   % subnode.id,
+                                                   "expected a mapping for merging, but found {0}".format(subnode.id),
                                                    subnode.start_mark)
                         self.flatten_mapping(subnode)
                         submerge.append(subnode.value)
@@ -125,8 +124,7 @@ class SaltYamlSafeLoader(yaml.SafeLoader, object):
                 else:
                     raise ConstructorError("while constructing a mapping",
                                            node.start_mark,
-                                           "expected a mapping or list of mappings for merging, but found %s"
-                                           % value_node.id,
+                                           "expected a mapping or list of mappings for merging, but found {0}".format(value_node.id),
                                            value_node.start_mark)
             elif key_node.tag == u'tag:yaml.org,2002:value':
                 key_node.tag = u'tag:yaml.org,2002:str'

--- a/tests/unit/utils/yamlloader_test.py
+++ b/tests/unit/utils/yamlloader_test.py
@@ -26,7 +26,6 @@ class YamlLoaderTestCase(TestCase):
     TestCase for salt.utils.yamlloader module
     '''
 
-
     @staticmethod
     def _render_yaml(data):
         '''
@@ -36,7 +35,6 @@ class YamlLoaderTestCase(TestCase):
         with patch('salt.utils.fopen', mock_open(read_data=data)) as mocked_file:
             with salt.utils.fopen(mocked_file) as mocked_stream:
                 return SaltYamlSafeLoader(mocked_stream).get_data()
-
 
     def test_yaml_basics(self):
         '''
@@ -48,9 +46,8 @@ class YamlLoaderTestCase(TestCase):
 p1:
   - alpha
   - beta'''),
-            {'p1':['alpha', 'beta']}
+            {'p1': ['alpha', 'beta']}
         )
-
 
     def test_yaml_merge(self):
         '''
@@ -65,7 +62,7 @@ p1: &p1
 p2:
   <<: *p1
   v2: beta'''),
-            {'p1':{'v1':'alpha'}, 'p2':{'v1':'alpha', 'v2':'beta'}}
+            {'p1': {'v1': 'alpha'}, 'p2': {'v1': 'alpha', 'v2': 'beta'}}
         )
 
         # Test that keys/nodes are overwritten
@@ -76,7 +73,7 @@ p1: &p1
 p2:
   <<: *p1
   v1: new_alpha'''),
-            {'p1':{'v1':'alpha'}, 'p2':{'v1':'new_alpha'}}
+            {'p1': {'v1': 'alpha'}, 'p2': {'v1': 'new_alpha'}}
         )
 
         # Test merging of lists
@@ -90,7 +87,6 @@ p2:
   v2: *v1'''),
             {"p2": {"v2": ["t1", "t2"]}, "p1": {"v1": ["t1", "t2"]}}
         )
-
 
     def test_yaml_duplicates(self):
         '''

--- a/tests/unit/utils/yamlloader_test.py
+++ b/tests/unit/utils/yamlloader_test.py
@@ -1,34 +1,23 @@
 # -*- coding: utf-8 -*-
+'''
+    Unit tests for salt.utils.yamlloader.SaltYamlSafeLoader
+'''
 
 # Import python libs
 from __future__ import absolute_import
 
 # Import Salt Libs
+from yaml.constructor import ConstructorError
 from salt.utils.yamlloader import SaltYamlSafeLoader
 import salt.utils
 
 # Import Salt Testing Libs
 from salttesting import TestCase, skipIf
 from salttesting.helpers import ensure_in_syspath
-from salttesting.mock import (
-    MagicMock,
-    patch,
-    NO_MOCK,
-    NO_MOCK_REASON,
-    mock_open
-)
+from salttesting.mock import patch, NO_MOCK, NO_MOCK_REASON, mock_open
+
 
 ensure_in_syspath('../../')
-
-
-def _render_yaml(data):
-    '''
-    Takes a YAML string, puts it into a mock file, passes it to the YAML
-    SaltYamlSafeLoader and then returns the rendered/parsed YAML data
-    '''
-    with patch('salt.utils.fopen', mock_open(read_data=data)) as m:
-        with salt.utils.fopen(m) as fp:
-            return SaltYamlSafeLoader(fp).get_data()
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -37,19 +26,31 @@ class YamlLoaderTestCase(TestCase):
     TestCase for salt.utils.yamlloader module
     '''
 
+
+    @staticmethod
+    def _render_yaml(data):
+        '''
+        Takes a YAML string, puts it into a mock file, passes that to the YAML
+        SaltYamlSafeLoader and then returns the rendered/parsed YAML data
+        '''
+        with patch('salt.utils.fopen', mock_open(read_data=data)) as mocked_file:
+            with salt.utils.fopen(mocked_file) as mocked_stream:
+                return SaltYamlSafeLoader(mocked_stream).get_data()
+
+
     def test_yaml_basics(self):
         '''
         Test parsing an ordinary path
         '''
 
-        result = _render_yaml(b'''
+        self.assertEqual(
+            self._render_yaml(b'''
 p1:
   - alpha
-  - beta''')
-        self.assertEqual(
-            result,
+  - beta'''),
             {'p1':['alpha', 'beta']}
         )
+
 
     def test_yaml_merge(self):
         '''
@@ -58,61 +59,50 @@ p1:
 
         # Simple merge test
         self.assertEqual(
-            _render_yaml(b'''
+            self._render_yaml(b'''
 p1: &p1
   v1: alpha
 p2:
   <<: *p1
   v2: beta'''),
-            {
-                'p1':{'v1':'alpha'},
-                'p2':{'v1':'alpha','v2':'beta'}
-            }
+            {'p1':{'v1':'alpha'}, 'p2':{'v1':'alpha', 'v2':'beta'}}
         )
 
         # Test that keys/nodes are overwritten
         self.assertEqual(
-            _render_yaml(b'''
+            self._render_yaml(b'''
 p1: &p1
   v1: alpha
 p2:
   <<: *p1
   v1: new_alpha'''),
-            {
-                'p1':{'v1':'alpha'},
-                'p2':{'v1':'new_alpha'}
-            }
+            {'p1':{'v1':'alpha'}, 'p2':{'v1':'new_alpha'}}
         )
 
         # Test merging of lists
         self.assertEqual(
-            _render_yaml(b'''
+            self._render_yaml(b'''
 p1: &p1
   v1: &v1
     - t1
     - t2
-    - t3
 p2:
   v2: *v1'''),
-            {
-                "p2": {"v2": ["t1", "t2", "t3"]}, 
-                "p1": {"v1": ["t1", "t2", "t3"]}
-            }
+            {"p2": {"v2": ["t1", "t2"]}, "p1": {"v1": ["t1", "t2"]}}
         )
+
 
     def test_yaml_duplicates(self):
         '''
         Test that duplicates still throw an error
         '''
-        from yaml.constructor import ConstructorError
-
         with self.assertRaises(ConstructorError):
-            _render_yaml(b'''
+            self._render_yaml(b'''
 p1: alpha
 p1: beta''')
 
         with self.assertRaises(ConstructorError):
-            _render_yaml(b'''
+            self._render_yaml(b'''
 p1: &p1
   v1: alpha
 p2:

--- a/tests/unit/utils/yamlloader_test.py
+++ b/tests/unit/utils/yamlloader_test.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+
+# Import python libs
+from __future__ import absolute_import
+
+# Import Salt Libs
+from salt.utils.yamlloader import SaltYamlSafeLoader
+import salt.utils
+
+# Import Salt Testing Libs
+from salttesting import TestCase, skipIf
+from salttesting.helpers import ensure_in_syspath
+from salttesting.mock import (
+    MagicMock,
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON,
+    mock_open
+)
+
+ensure_in_syspath('../../')
+
+
+def _render_yaml(data):
+    '''
+    Takes a YAML string, puts it into a mock file, passes it to the YAML
+    SaltYamlSafeLoader and then returns the rendered/parsed YAML data
+    '''
+    with patch('salt.utils.fopen', mock_open(read_data=data)) as m:
+        with salt.utils.fopen(m) as fp:
+            return SaltYamlSafeLoader(fp).get_data()
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class YamlLoaderTestCase(TestCase):
+    '''
+    TestCase for salt.utils.yamlloader module
+    '''
+
+    def test_yaml_basics(self):
+        '''
+        Test parsing an ordinary path
+        '''
+
+        result = _render_yaml(b'''
+p1:
+  - alpha
+  - beta''')
+        self.assertEqual(
+            result,
+            {'p1':['alpha', 'beta']}
+        )
+
+    def test_yaml_merge(self):
+        '''
+        Test YAML anchors
+        '''
+
+        # Simple merge test
+        self.assertEqual(
+            _render_yaml(b'''
+p1: &p1
+  v1: alpha
+p2:
+  <<: *p1
+  v2: beta'''),
+            {
+                'p1':{'v1':'alpha'},
+                'p2':{'v1':'alpha','v2':'beta'}
+            }
+        )
+
+        # Test that keys/nodes are overwritten
+        self.assertEqual(
+            _render_yaml(b'''
+p1: &p1
+  v1: alpha
+p2:
+  <<: *p1
+  v1: new_alpha'''),
+            {
+                'p1':{'v1':'alpha'},
+                'p2':{'v1':'new_alpha'}
+            }
+        )
+
+        # Test merging of lists
+        self.assertEqual(
+            _render_yaml(b'''
+p1: &p1
+  v1: &v1
+    - t1
+    - t2
+    - t3
+p2:
+  v2: *v1'''),
+            {
+                "p2": {"v2": ["t1", "t2", "t3"]}, 
+                "p1": {"v1": ["t1", "t2", "t3"]}
+            }
+        )
+
+    def test_yaml_duplicates(self):
+        '''
+        Test that duplicates still throw an error
+        '''
+        from yaml.constructor import ConstructorError
+
+        with self.assertRaises(ConstructorError):
+            _render_yaml(b'''
+p1: alpha
+p1: beta''')
+
+        with self.assertRaises(ConstructorError):
+            _render_yaml(b'''
+p1: &p1
+  v1: alpha
+p2:
+  <<: *p1
+  v2: beta
+  v2: betabeta''')
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(YamlLoaderTestCase, needs_daemon=False)


### PR DESCRIPTION
### What does this PR do?

Fixes the duplicate node error when using YAML anchors to merge YAML nodes. Also adds some unit testsfor yamlloader.
### What issues does this PR fix or reference?
#14550
### Previous Behavior

Using YAML anchor to merge nodes would throw an error about duplicates and prevent the Pillar data compiling.
### New Behavior

Merging YAML nodes now works as expected.
### Tests written?
- [x] Yes

…node errors. Add yamlloader unit tests.

Fixed #14550 Using YAML anchors/references in Pillars causes conflicting IDs
