### PR TITLE
New module: NAPALM_NTP, using NAPALM proxy

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -220,6 +220,7 @@ Full list of builtin execution modules
     nagios
     nagios_rpc
     napalm_network
+    napalm_ntp
     netaddress
     netbsd_sysctl
     netbsdservice

--- a/doc/ref/modules/all/salt.modules.napalm_ntp.rst
+++ b/doc/ref/modules/all/salt.modules.napalm_ntp.rst
@@ -1,0 +1,7 @@
+salt.modules.napalm_ntp module
+============================
+
+.. automodule:: salt.modules.napalm_ntp
+    :members:
+    :undoc-members:
+

--- a/salt/modules/napalm_ntp.py
+++ b/salt/modules/napalm_ntp.py
@@ -27,13 +27,14 @@ log = logging.getLogger(__file__)
 # module properties
 # ----------------------------------------------------------------------------------------------------------------------
 
-__virtualname__  = 'netntp'
+__virtualname__ = 'netntp'
 __proxyenabled__ = ['napalm']
 # uses NAPALM-based proxy to interact with network devices
 
 # ----------------------------------------------------------------------------------------------------------------------
 # property functions
 # ----------------------------------------------------------------------------------------------------------------------
+
 
 def __virtual__():
     return True
@@ -47,7 +48,7 @@ def __virtual__():
 # ----------------------------------------------------------------------------------------------------------------------
 
 
-def peers(peer = ''):
+def peers(peer=''):
 
     """
     Returns a dictionary containing all NTP peers and synchronization details.

--- a/salt/modules/napalm_ntp.py
+++ b/salt/modules/napalm_ntp.py
@@ -27,7 +27,7 @@ log = logging.getLogger(__file__)
 # module properties
 # ----------------------------------------------------------------------------------------------------------------------
 
-__virtualname__ = 'netntp'
+__virtualname__ = 'ntp'
 __proxyenabled__ = ['napalm']
 # uses NAPALM-based proxy to interact with network devices
 
@@ -69,7 +69,7 @@ def peers(peer=''):
 
     .. code-block:: bash
 
-        salt '*' netntp.peers
+        salt '*' ntp.peers
 
     Example output:
 
@@ -121,7 +121,7 @@ def set_peers(*peers):
 
     .. code-block:: bash
 
-        salt '*' netntp.set_peers 192.168.0.1 172.17.17.1 time.apple.com
+        salt '*' ntp.set_peers 192.168.0.1 172.17.17.1 time.apple.com
     """
 
     return __proxy__['napalm.call'](
@@ -143,7 +143,7 @@ def delete_peers(*peers):
 
     .. code-block:: bash
 
-        salt '*' netntp.delete_peers 8.8.8.8 time.apple.com
+        salt '*' ntp.delete_peers 8.8.8.8 time.apple.com
     """
 
     return __proxy__['napalm.call'](

--- a/salt/modules/napalm_ntp.py
+++ b/salt/modules/napalm_ntp.py
@@ -111,7 +111,7 @@ def peers(peer=''):
     return proxy_output
 
 
-def set_peers(*peers):
+def set_peers(peers):
 
     """
     Configures a list of NTP peers on the device.
@@ -133,7 +133,7 @@ def set_peers(*peers):
     )
 
 
-def delete_peers(*peers):
+def delete_peers(peers):
 
     """
     Removes NTP peers configured on the device.

--- a/salt/proxy/napalm.py
+++ b/salt/proxy/napalm.py
@@ -97,7 +97,6 @@ def init(opts):
     NETWORK_DEVICE['PASSWORD'] = opts.get('proxy', {}).get('passwd')
     NETWORK_DEVICE['DRIVER_NAME'] = opts.get('proxy', {}).get('driver')
 
-
     NETWORK_DEVICE['UP'] = False
 
     _driver_ = napalm.get_network_driver(NETWORK_DEVICE.get('DRIVER_NAME'))

--- a/salt/proxy/napalm.py
+++ b/salt/proxy/napalm.py
@@ -4,6 +4,7 @@ NAPALM
 ========
 
 Proxy minion for managing network devices via NAPALM_ library.
+
 .. _NAPALM: http://napalm.readthedocs.org
 
 :codeauthor: Mircea Ulinic <mircea@cloudflare.com> & Jerome Fleury <jf@cloudflare.com>
@@ -16,10 +17,16 @@ Dependencies
 
 - :doc:`napalm basic network functions (salt.modules.napalm_network) </ref/modules/all/salt.modules.napalm_network>`
 
+See also
+--------
+
+- :doc:`NTP peers management (salt.modules.napalm_ntp) </ref/modules/all/salt.modules.napalm_ntp>`
+
 Pillar
 ------
 
 The napalm proxy configuration requires four mandatory parameters in order to connect to the network device:
+
 * driver: specifies the network device operating system. For a complete list of the supported operating systems \
 please refer to the `NAPALM Read the Docs page`_.
 * host: hostname
@@ -89,6 +96,7 @@ def init(opts):
     NETWORK_DEVICE['USERNAME'] = opts.get('proxy', {}).get('username')
     NETWORK_DEVICE['PASSWORD'] = opts.get('proxy', {}).get('passwd')
     NETWORK_DEVICE['DRIVER_NAME'] = opts.get('proxy', {}).get('driver')
+
 
     NETWORK_DEVICE['UP'] = False
 
@@ -163,11 +171,12 @@ def call(method, **params):
     :param method: specifies the name of the method to be called
     :param params: contains the mapping between the name and the values of the parameters needed to call the method
     :return: A dictionary with three keys:
+
         * result (True/False): if the operation succeeded
         * out (object): returns the object as-is from the call
         * comment (string): provides more details in case the call failed
 
-    Example::
+    Example:
 
     .. code-block:: python
 

--- a/salt/proxy/napalm.py
+++ b/salt/proxy/napalm.py
@@ -20,7 +20,7 @@ Dependencies
 See also
 --------
 
-- :doc:`NTP peers management (salt.modules.napalm_ntp) </ref/modules/all/salt.modules.napalm_ntp>`
+- :doc:`NTP peers management module (salt.modules.napalm_ntp) </ref/modules/all/salt.modules.napalm_ntp>`
 
 Pillar
 ------

--- a/salt/proxy/napalm_ntp.py
+++ b/salt/proxy/napalm_ntp.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+'''
+NAPALM NTP
+===============
+
+Manages NTP peers of a network device.
+
+:codeauthor: Mircea Ulinic <mircea@cloudflare.com> & Jerome Fleury <jf@cloudflare.com>
+:maturity:   new
+:depends:    napalm
+:platform:   linux
+
+Dependencies
+------------
+
+- :doc:`napalm proxy minion (salt.proxy.napalm) </ref/proxy/all/salt.proxy.napalm>`
+
+.. versionadded: 2016.3
+'''
+
+from __future__ import absolute_import
+
+import logging
+log = logging.getLogger(__file__)
+
+# ----------------------------------------------------------------------------------------------------------------------
+# module properties
+# ----------------------------------------------------------------------------------------------------------------------
+
+__virtualname__  = 'netntp'
+__proxyenabled__ = ['napalm']
+# uses NAPALM-based proxy to interact with network devices
+
+# ----------------------------------------------------------------------------------------------------------------------
+# property functions
+# ----------------------------------------------------------------------------------------------------------------------
+
+def __virtual__():
+    return True
+
+# ----------------------------------------------------------------------------------------------------------------------
+# helper functions -- will not be exported
+# ----------------------------------------------------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------------------------------------------------
+# callable functions
+# ----------------------------------------------------------------------------------------------------------------------
+
+
+def peers(peer = ''):
+
+    """
+    Returns a dictionary containing all NTP peers and synchronization details.
+    :param peer: Returns only the details of a specific NTP peer.
+    :return: a dictionary of NTP peers, each peer having the following details:
+
+        * referenceid
+        * stratum
+        * type
+        * when
+        * hostpoll
+        * reachability
+        * delay
+        * offset
+        * jitter
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' netntp.peers
+
+    Example output:
+
+    .. code-block:: python
+
+        {
+            u'188.114.101.4': {
+                'referenceid'   : u'188.114.100.1',
+                'stratum'       : 4,
+                'type'          : u'-',
+                'when'          : u'107',
+                'hostpoll'      : 256,
+                'reachability'  : 377,
+                'delay'         : 164.228,
+                'offset'        : -13.866,
+                'jitter'        : 2.695
+            }
+        }
+    """
+
+    proxy_output = __proxy__['napalm.call'](
+        'get_ntp_peers',
+        **{
+        }
+    )
+
+    if not proxy_output.get('result'):
+        return proxy_output
+
+    ntp_peers = proxy_output.get('out')
+
+    if peer:
+        ntp_peers = {peer: ntp_peers.get(peer)}
+
+    proxy_output.update({
+        'out': ntp_peers
+    })
+
+    return proxy_output
+
+
+def set_peers(*peers):
+
+    """
+    Configures a list of NTP peers on the device.
+    :param peers: list of IP Addresses/Domain Names
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' netntp.set_peers 192.168.0.1 172.17.17.1 time.apple.com
+    """
+
+    return __proxy__['napalm.call'](
+        'load_template',
+        **{
+            'template_name': 'set_ntp_peers',
+            'peers': peers
+        }
+    )
+
+
+def delete_peers(*peers):
+
+    """
+    Removes NTP peers configured on the device.
+    :param peers: list of IP Addresses/Domain Names to be removed as NTP peers
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' netntp.delete_peers 8.8.8.8 time.apple.com
+    """
+
+    return __proxy__['napalm.call'](
+        'load_template',
+        **{
+            'template_name': 'delete_ntp_peers',
+            'peers': peers
+        }
+    )


### PR DESCRIPTION
### What does this PR do?

We propose now a new module for the management of NTP peers on network devices, using the proxy module 'NAPALM'. For further reference, please check our previous PRs: #31868 and #31431.
### What issues does this PR fix or reference?

New module proposed.
### Previous Behavior

There's no module for NTP management on network devices.
### New Behavior

Ease of configuration and maintenance of NTP peers.
### Tests written?
- [ ] Yes
- [x] No
