### PR TITLE
Improve Kapacitor state/module

### DIFF
--- a/salt/modules/kapacitor.py
+++ b/salt/modules/kapacitor.py
@@ -56,7 +56,26 @@ def get_task(name):
     return data
 
 
-def define_task(name, tick_script, task_type='stream', database=None,
+def _run_cmd(cmd):
+    '''
+    Run a Kapacitor task and return a dictionary of info.
+    '''
+    ret = {}
+    result = __salt__['cmd.run_all'](cmd)
+
+    if result.get('stdout'):
+        ret['stdout'] = result['stdout']
+    if result.get('stderr'):
+        ret['stderr'] = result['stderr']
+    ret['success'] = result['retcode'] == 0
+
+    return ret
+
+
+def define_task(name,
+                tick_script,
+                task_type='stream',
+                database=None,
                 retention_policy='default'):
     '''
     Define a task. Serves as both create/update.
@@ -94,7 +113,7 @@ def define_task(name, tick_script, task_type='stream', database=None,
     if database and retention_policy:
         cmd += ' -dbrp {0}.{1}'.format(database, retention_policy)
 
-    return __salt__['cmd.retcode'](cmd) == 0
+    return _run_cmd(cmd)
 
 
 def delete_task(name):
@@ -110,8 +129,7 @@ def delete_task(name):
 
         salt '*' kapacitor.delete_task cpu
     '''
-    cmd = 'kapacitor delete tasks {0}'.format(name)
-    return __salt__['cmd.retcode'](cmd) == 0
+    return _run_cmd('kapacitor delete tasks {0}'.format(name))
 
 
 def enable_task(name):
@@ -127,8 +145,7 @@ def enable_task(name):
 
         salt '*' kapacitor.enable_task cpu
     '''
-    cmd = 'kapacitor enable {0}'.format(name)
-    return __salt__['cmd.retcode'](cmd) == 0
+    return _run_cmd('kapacitor enable {0}'.format(name))
 
 
 def disable_task(name):
@@ -144,5 +161,4 @@ def disable_task(name):
 
         salt '*' kapacitor.disable_task cpu
     '''
-    cmd = 'kapacitor disable {0}'.format(name)
-    return __salt__['cmd.retcode'](cmd) == 0
+    return _run_cmd('kapacitor disable {0}'.format(name))

--- a/salt/modules/kapacitor.py
+++ b/salt/modules/kapacitor.py
@@ -46,11 +46,12 @@ def get_task(name):
     host = __salt__['config.option']('kapacitor.host', 'localhost')
     port = __salt__['config.option']('kapacitor.port', 9092)
     url = 'http://{0}:{1}/task?name={2}'.format(host, port, name)
-    response = salt.utils.http.query(url)
-    data = json.loads(response['body'])
+    response = salt.utils.http.query(url, status=True)
 
-    if 'Error' in data and data['Error'].startswith('unknown task'):
+    if response['status'] == 404:
         return None
+
+    data = json.loads(response['body'])
 
     return data
 

--- a/salt/states/kapacitor.py
+++ b/salt/states/kapacitor.py
@@ -82,9 +82,11 @@ def task_present(name,
             result = __salt__['kapacitor.define_task'](name, script_path,
                 task_type=task_type, database=database,
                 retention_policy=retention_policy)
-            if not result:
-                ret['result'] = False
+            ret['result'] = result['success']
+            if not ret['result']:
                 comments.append('Could not define task')
+                if result.get('stderr'):
+                    comments.append(result['stderr'])
                 ret['comment'] = '\n'.join(comments)
                 return ret
         ret['changes']['TICKscript diff'] = '\n'.join(difflib.unified_diff(
@@ -102,9 +104,11 @@ def task_present(name,
                 comments.append('Task would have been enabled')
             else:
                 result = __salt__['kapacitor.enable_task'](name)
-                if not result:
-                    ret['result'] = False
+                ret['result'] = result['success']
+                if not ret['result']:
                     comments.append('Could not enable task')
+                    if result.get('stderr'):
+                        comments.append(result['stderr'])
                     ret['comment'] = '\n'.join(comments)
                     return ret
                 comments.append('Task was enabled')
@@ -118,9 +122,11 @@ def task_present(name,
                 comments.append('Task would have been disabled')
             else:
                 result = __salt__['kapacitor.disable_task'](name)
-                if not result:
-                    ret['result'] = False
+                ret['result'] = result['success']
+                if not ret['result']:
                     comments.append('Could not disable task')
+                    if result.get('stderr'):
+                        comments.append(result['stderr'])
                     ret['comment'] = '\n'.join(comments)
                     return ret
                 comments.append('Task was disabled')

--- a/salt/states/kapacitor.py
+++ b/salt/states/kapacitor.py
@@ -143,7 +143,6 @@ def task_absent(name):
     name
         Name of the task.
     '''
-
     ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
 
     task = __salt__['kapacitor.get_task'](name)
@@ -153,7 +152,13 @@ def task_absent(name):
             ret['result'] = None
             ret['comment'] = 'Task would have been deleted'
         else:
-            __salt__['kapacitor.delete_task'](name)
+            result = __salt__['kapacitor.delete_task'](name)
+            ret['result'] = result['success']
+            if not ret['result']:
+                ret['comment'] = 'Could not disable task'
+                if result.get('stderr'):
+                    ret['comment'] += '\n' + result['stderr']
+                return ret
             ret['comment'] = 'Task was deleted'
         ret['changes'][name] = 'deleted'
     else:

--- a/tests/unit/modules/kapacitor_test.py
+++ b/tests/unit/modules/kapacitor_test.py
@@ -18,37 +18,40 @@ kapacitor.__env__ = 'test'
 
 class KapacitorTestCase(TestCase):
     def test_get_task_success(self):
-        with patch('salt.utils.http.query', return_value={'body': '{"foo":"bar"}'}) as http_mock:
+        query_ret = {'body': '{"foo":"bar"}', 'status': 200}
+        with patch('salt.utils.http.query', return_value=query_ret) as http_mock:
             task = kapacitor.get_task('taskname')
-        http_mock.assert_called_once_with('http://localhost:9092/task?name=taskname')
+        http_mock.assert_called_once_with('http://localhost:9092/task?name=taskname', status=True)
         assert {'foo': 'bar'} == task
 
     def test_get_task_not_found(self):
-        with patch('salt.utils.http.query', return_value={'body': '{"Error":"unknown task taskname"}'}) as http_mock:
+        query_ret = {'body': '{"Error":"unknown task taskname"}', 'status': 404}
+        with patch('salt.utils.http.query', return_value=query_ret) as http_mock:
             task = kapacitor.get_task('taskname')
-        http_mock.assert_called_once_with('http://localhost:9092/task?name=taskname')
+        http_mock.assert_called_once_with('http://localhost:9092/task?name=taskname', status=True)
         assert task is None
 
     def test_define_task(self):
-        cmd_mock = Mock(return_value=True)
-        with patch.dict(kapacitor.__salt__, {'cmd.retcode': cmd_mock}):
+        cmd_mock = Mock(return_value={'retcode': 0})
+        with patch.dict(kapacitor.__salt__, {'cmd.run_all': cmd_mock}):
             kapacitor.define_task('taskname', '/tmp/script.tick')
-        cmd_mock.assert_called_once_with('kapacitor define -name taskname -tick /tmp/script.tick -type stream')
+        cmd_mock.assert_called_once_with('kapacitor define -name taskname '
+            '-tick /tmp/script.tick -type stream')
 
     def test_enable_task(self):
-        cmd_mock = Mock(return_value=True)
-        with patch.dict(kapacitor.__salt__, {'cmd.retcode': cmd_mock}):
+        cmd_mock = Mock(return_value={'retcode': 0})
+        with patch.dict(kapacitor.__salt__, {'cmd.run_all': cmd_mock}):
             kapacitor.enable_task('taskname')
         cmd_mock.assert_called_once_with('kapacitor enable taskname')
 
     def test_disable_task(self):
-        cmd_mock = Mock(return_value=True)
-        with patch.dict(kapacitor.__salt__, {'cmd.retcode': cmd_mock}):
+        cmd_mock = Mock(return_value={'retcode': 0})
+        with patch.dict(kapacitor.__salt__, {'cmd.run_all': cmd_mock}):
             kapacitor.disable_task('taskname')
         cmd_mock.assert_called_once_with('kapacitor disable taskname')
 
     def test_delete_task(self):
-        cmd_mock = Mock(return_value=True)
-        with patch.dict(kapacitor.__salt__, {'cmd.retcode': cmd_mock}):
+        cmd_mock = Mock(return_value={'retcode': 0})
+        with patch.dict(kapacitor.__salt__, {'cmd.run_all': cmd_mock}):
             kapacitor.delete_task('taskname')
         cmd_mock.assert_called_once_with('kapacitor delete tasks taskname')

--- a/tests/unit/states/kapacitor_test.py
+++ b/tests/unit/states/kapacitor_test.py
@@ -27,9 +27,19 @@ def _present(name='testname',
              disable_result=True,
              script='test'):
     get_mock = Mock(return_value=task)
+
+    if isinstance(define_result, bool):
+        define_result = {'success': define_result}
     define_mock = Mock(return_value=define_result)
+
+    if isinstance(enable_result, bool):
+        enable_result = {'success': enable_result}
     enable_mock = Mock(return_value=enable_result)
+
+    if isinstance(disable_result, bool):
+        disable_result = {'success': disable_result}
     disable_mock = Mock(return_value=disable_result)
+
     with patch.dict(kapacitor.__salt__, {
         'kapacitor.get_task': get_mock,
         'kapacitor.define_task': define_mock,


### PR DESCRIPTION
Follow-up to #31761 / #31795

Module now returns a dict with success, stdout and stderr.

More reliable detection of task not found by using HTTP status codes.

State now returns stderr as part of the comment if something goes wrong.
