### PR TITLE
list only hd* and sd* devices in disks grain

### DIFF
--- a/salt/grains/disks.py
+++ b/salt/grains/disks.py
@@ -124,7 +124,7 @@ def _linux_disks():
     '''
     ret = {'disks': [], 'SSDs': []}
 
-    for entry in glob.glob('/sys/block/*/queue/rotational'):
+    for entry in glob.glob('/sys/block/[hs]d*/queue/rotational'):
         with salt.utils.fopen(entry) as entry_fp:
             device = entry.split('/')[3]
             flag = entry_fp.read(1)


### PR DESCRIPTION
### What does this PR do?

Fixes issue with previous PR (#31981) where disks grain under linux would display ram and loop devices if present.
### What issues does this PR fix or reference?

None
### Previous Behavior

Disks grain under linux would show ram and loop devices

```
root@ceph-dev:~# salt-call grains.get disks
local:
    - sda
    - sdb
    - sdc
    - sdd
    - sde
    - sdf
    - ram0
    - ram1
    - ram2
    - ram3
    - ram4
    - ram5
    - ram6
    - ram7
    - ram8
    - ram9
    - loop0
    - loop1
    - loop2
    - loop3
    - loop4
    - loop5
    - loop6
    - loop7
    - ram10
    - ram11
    - ram12
    - ram13
    - ram14
    - ram15
```
### New Behavior

Disks grain no longer shows ram or loop devices and is limited to showing hd\* (IDE) or sd\* (SATA/SCSI) devices

```
root@ceph-dev:~# salt-call grains.get disks
local:
    - sda
    - sdb
    - sdc
    - sdd
    - sde
    - sdf
```
### Tests written?
- [ ] Yes
- [x] No

Tested manually against salt 2015.8.7 on Debian 8.3 and CentOS 7.2
