### PR TITLE
Fix outputter for state.apply

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -43,7 +43,7 @@ __outputter__ = {
     'highstate': 'highstate',
     'template': 'highstate',
     'template_str': 'highstate',
-    'apply': 'highstate',
+    'apply_': 'highstate',
     'request': 'highstate',
     'check_request': 'highstate',
     'run_request': 'highstate',


### PR DESCRIPTION
Because of an incorrectly configured `__outputter__` dunder dict,
`state.apply` was falling back to the nested outputter. This corrects
the configuration, allowing `state.apply` to use the highstate
outputter as intended.
