### PR TITLE
[2015.8] Fix rabbitmq_user.present tag handling

### DIFF
--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -126,7 +126,7 @@ def list_users(runas=None):
                               runas=runas)
 
     # func to get tags from string such as "[admin, monitoring]"
-    func = lambda string: set(string[1:-1].split(','))
+    func = lambda string: set([x.strip() for x in string[1:-1].split(',')])
     return _output_to_dict(res, func)
 
 

--- a/salt/states/rabbitmq_user.py
+++ b/salt/states/rabbitmq_user.py
@@ -73,20 +73,14 @@ def _check_perms_changes(name, newperms, runas=None, existing=None):
     return perm_need_change
 
 
-def _check_tags_changes(name, new_tags, runas=None):
+def _get_current_tags(name, runas=None):
     '''
     Whether Rabbitmq user's tags need to be changed
     '''
-    if new_tags:
-        if isinstance(new_tags, str):
-            new_tags = new_tags.split()
-        try:
-            users = __salt__['rabbitmq.list_users'](runas=runas)[name] - set(new_tags)
-        except CommandExecutionError as err:
-            log.error('Error: {0}'.format(err))
-            return []
-        return list(users)
-    else:
+    try:
+        return list(__salt__['rabbitmq.list_users'](runas=runas)[name])
+    except CommandExecutionError as err:
+        log.error('Error: {0}'.format(err))
         return []
 
 
@@ -165,17 +159,22 @@ def present(name,
                                       {'old': 'Removed password.',
                                        'new': ''}})
 
-    new_tags = _check_tags_changes(name, tags, runas=runas)
-    if new_tags:
-        if not __opts__['test']:
-            try:
-                __salt__['rabbitmq.set_user_tags'](name, tags, runas=runas)
-            except CommandExecutionError as err:
-                ret['comment'] = 'Error: {0}'.format(err)
-                return ret
-        ret['changes'].update({'tags':
-                              {'old': tags,
-                               'new': list(new_tags)}})
+    if tags is not None:
+        current_tags = _get_current_tags(name, tags, runas=runas)
+        if isinstance(tags, str):
+            tags = tags.split()
+        # Diff the tags sets. Symmetric difference operator ^ will give us
+        # any element in one set, but not both
+        if set(tags) ^ set(current_tags):
+            if not __opts__['test']:
+                try:
+                    __salt__['rabbitmq.set_user_tags'](name, tags, runas=runas)
+                except CommandExecutionError as err:
+                    ret['comment'] = 'Error: {0}'.format(err)
+                    return ret
+            ret['changes'].update({'tags':
+                                  {'old': current_tags,
+                                   'new': tags}})
     try:
         existing_perms = __salt__['rabbitmq.list_user_permissions'](name, runas=runas)
     except CommandExecutionError as err:

--- a/salt/states/rabbitmq_user.py
+++ b/salt/states/rabbitmq_user.py
@@ -160,7 +160,7 @@ def present(name,
                                        'new': ''}})
 
     if tags is not None:
-        current_tags = _get_current_tags(name, tags, runas=runas)
+        current_tags = _get_current_tags(name, runas=runas)
         if isinstance(tags, str):
             tags = tags.split()
         # Diff the tags sets. Symmetric difference operator ^ will give us

--- a/tests/unit/states/rabbitmq_user_test.py
+++ b/tests/unit/states/rabbitmq_user_test.py
@@ -30,69 +30,6 @@ class RabbitmqUserTestCase(TestCase):
     '''
     Test cases for salt.states.rabbitmq_user
     '''
-    # 'present' function tests: 1
-
-    def test_present(self):
-        '''
-        Test to ensure the RabbitMQ user exists.
-        '''
-        name = 'foo'
-        passwd = 'password'
-        tag = 'user'
-        existing_perms = {'/': ['.*', '.*']}
-        perms = [existing_perms]
-
-        ret = {'name': name,
-               'changes': {},
-               'result': True,
-               'comment': ''}
-
-        mock = MagicMock(side_effect=[True, False, True, True,
-                                      True, True, True])
-        mock_dct = MagicMock(return_value={name: set(tag)})
-        mock_pr = MagicMock(return_value=existing_perms)
-        mock_add = MagicMock(return_value={'Added': name})
-        with patch.dict(rabbitmq_user.__salt__,
-                        {'rabbitmq.user_exists': mock,
-                         'rabbitmq.list_users': mock_dct,
-                         'rabbitmq.list_user_permissions': mock_pr,
-                         'rabbitmq.set_user_tags': mock_add}):
-            comment = 'User \'foo\' is already present.'
-            ret.update({'comment': comment})
-            self.assertDictEqual(rabbitmq_user.present(name), ret)
-
-            with patch.dict(rabbitmq_user.__opts__, {'test': True}):
-                comment = 'User \'foo\' is set to be created.'
-                changes = {'user': {'new': 'foo', 'old': ''}}
-                ret.update({'comment': comment, 'result': None, 'changes': changes})
-                self.assertDictEqual(rabbitmq_user.present(name), ret)
-
-                comment = 'Configuration for \'foo\' will change.'
-                changes = {'password': {'new': 'Set password.', 'old': ''}}
-                ret.update({'comment': comment, 'changes': changes})
-                self.assertDictEqual(rabbitmq_user.present(name,
-                                                           password=passwd,
-                                                           force=True), ret)
-
-                changes = {'password': {'new': '', 'old': 'Removed password.'}}
-                ret.update({'changes': changes})
-                self.assertDictEqual(rabbitmq_user.present(name, force=True),
-                                     ret)
-
-                changes = {'tags': {'new': ['u', 's', 'r', 'e'], 'old': 'user'}}
-                ret.update({'changes': changes})
-                self.assertDictEqual(rabbitmq_user.present(name, tags=tag), ret)
-
-                comment = '\'foo\' is already in the desired state.'
-                ret.update({'changes': {}, 'comment': comment, 'result': True})
-                self.assertDictEqual(rabbitmq_user.present(name, perms=perms),
-                                     ret)
-
-            with patch.dict(rabbitmq_user.__opts__, {'test': False}):
-                ret.update({'comment': '\'foo\' was configured.', 'result': True,
-                            'changes': {'tags': {'new': ['u', 's', 'r', 'e'], 'old': 'user'}}})
-                self.assertDictEqual(rabbitmq_user.present(name, tags=tag), ret)
-
     # 'absent' function tests: 1
 
     def test_absent(self):


### PR DESCRIPTION
### What does this PR do?

Fixes tag handling for rabbitmq_user.present

Also fixes a bug in rabbitmq.list_users
### What issues does this PR fix or reference?

None
### Previous Behavior

1) rabbitmq.list_users would not properly strip whitespace from tags, resulting in tag "differences" that were invalid
2) rabbitmq_user.present would only handle removed tags, not added tags. It also would report differences that were invalid, because of (1)
### New Behavior

1) rabbitmq.list_users now returns a correct list of tags, stripped for whitespace
2) rabbitmq_user.present now does a proper diff of tags, and reports the correct proposed changes
