### PR TITLE
netntp state: manage NTP peers on network devices

### DIFF
--- a/doc/ref/states/all/index.rst
+++ b/doc/ref/states/all/index.rst
@@ -140,6 +140,7 @@ Full list of builtin state modules
     mysql_grants
     mysql_query
     mysql_user
+    netntp
     network
     nftables
     npm

--- a/doc/ref/states/all/salt.states.netntp.rst
+++ b/doc/ref/states/all/salt.states.netntp.rst
@@ -1,0 +1,8 @@
+==================
+salt.states.netntp
+==================
+
+.. automodule:: salt.states.netntp
+    :members:
+    :exclude-members:
+

--- a/salt/states/netntp.py
+++ b/salt/states/netntp.py
@@ -107,7 +107,8 @@ def _delete_ntp_peers(peers):
 # callable functions
 # ----------------------------------------------------------------------------------------------------------------------
 
-def managed(name, peers=[]):
+
+def managed(name, peers=None):
 
     """
     Updates the list of NTP peers on the devices as speified in the state SLS file.

--- a/salt/states/netntp.py
+++ b/salt/states/netntp.py
@@ -112,7 +112,7 @@ def managed(name, peers=None):
 
     """
     Updates the list of NTP peers on the devices as speified in the state SLS file.
-    NTP peers not specified in this list will be removed and peers that are not configures will be set.
+    NTP peers not specified in this list will be removed and peers that are not configured will be set.
 
 
     SLS Example:

--- a/salt/states/netntp.py
+++ b/salt/states/netntp.py
@@ -1,0 +1,212 @@
+# -*- coding: utf-8 -*-
+'''
+Network NTP
+===============
+
+Configure NTP peers on the device via a salt proxy.
+
+:codeauthor: Mircea Ulinic <mircea@cloudflare.com> & Jerome Fleury <jf@cloudflare.com>
+:maturity:   new
+:depends:    napalm
+:platform:   linux
+
+Dependencies
+------------
+
+- :doc:`napalm ntp management module (salt.modules.napalm_ntp) </ref/modules/all/salt.modules.napalm_ntp>`
+
+.. versionadded: 2016.3
+'''
+
+from __future__ import absolute_import
+
+import logging
+log = logging.getLogger(__name__)
+
+# std lib
+from netaddr import IPAddress
+from netaddr.core import AddrFormatError
+
+# third party libs
+import dns.resolver
+
+# ----------------------------------------------------------------------------------------------------------------------
+# state properties
+# ----------------------------------------------------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------------------------------------------------
+# global variables
+# ----------------------------------------------------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------------------------------------------------
+# property functions
+# ----------------------------------------------------------------------------------------------------------------------
+
+
+def __virtual__():
+    return 'netntp'
+
+# ----------------------------------------------------------------------------------------------------------------------
+# helper functions -- will not be exported
+# ----------------------------------------------------------------------------------------------------------------------
+
+
+def _retrieve_ntp_peers():
+
+    """Retrieves configured NTP peers"""
+
+    return __salt__['ntp.peers']()
+
+
+def _check_peers(peers):
+
+    """Checks whether the input is a valid list of peers and transforms domain names into IP Addresses"""
+
+    if not isinstance(peers, list):
+        return False
+
+    for peer in peers:
+        if not isinstance(peer, str):
+            return False
+
+    ip_only_peers = list()
+    for peer in peers:
+        try:
+            ip_only_peers.append(str(IPAddress(peer)))  # append the str value
+        except AddrFormatError:
+            # if not a valid IP Address
+            dns_reply = list()
+            try:
+                # try to see if it is a valid NS
+                dns_reply = dns.resolver.query(peer)
+            except dns.resolver.NoAnswer:
+                # no a valid DNS entry either
+                continue
+            for dns_ip in dns_reply:
+                ip_only_peers.append(str(dns_ip))
+
+    peers = ip_only_peers
+
+    return True
+
+
+def _set_ntp_peers(peers):
+
+    """Calls ntp.set_peers."""
+
+    return __salt__['ntp.set_peers'](peers)
+
+
+def _delete_ntp_peers(peers):
+
+    """Calls ntp.delete_peers."""
+
+    return __salt__['ntp.delete_peers'](peers)
+
+# ----------------------------------------------------------------------------------------------------------------------
+# callable functions
+# ----------------------------------------------------------------------------------------------------------------------
+
+def managed(name, peers=[]):
+
+    """
+    Updates the list of NTP peers on the devices as speified in the state SLS file.
+    NTP peers not specified in this list will be removed and peers that are not configures will be set.
+
+
+    SLS Example:
+
+    .. code-block:: yaml
+
+        netntp_example:
+            netntp.managed:
+                 - peers:
+                    - 192.168.0.1
+                    - 172.17.17.1
+    """
+
+    result = False
+    comment = ''
+    changes = dict()
+
+    ret = {
+        'name': name,
+        'changes': changes,
+        'result': result,
+        'comment': comment
+    }
+
+    if not _check_peers(peers):  # check and clean
+        ret['comment'] = 'NTP peers must be a list of valid IP Addresses or Domain Names'
+        return ret
+
+    # ----- Retrieve existing NTP peers and determine peers to be added/removed --------------------------------------->
+
+    ntp_peers_output = _retrieve_ntp_peers()  # contains only IP Addresses as dictionary keys
+
+    if not ntp_peers_output.get('result'):
+        ret['comment'] = 'Cannot retrieve NTP peers from the device: {reason}'.format(
+            reason=ntp_peers_output.get('comment')
+        )
+        return ret
+
+    configured_ntp_peers = set(ntp_peers_output.get('out', {}).keys())
+    desired_ntp_peers = set(peers)
+
+    if configured_ntp_peers == desired_ntp_peers:
+        ret['comment'] = 'NTP peers already configured as needed.'
+        return ret
+
+    peers_to_set = list(desired_ntp_peers - configured_ntp_peers)
+    peers_to_delete = list(configured_ntp_peers - desired_ntp_peers)
+
+    # <---- Retrieve existing NTP peers and determine peers to be added/removed --------------------------------------->
+
+    # ----- Call _set_ntp_peers and _delete_ntp_peers as needed ------------------------------------------------------->
+
+    config_change_expected = False
+
+    if peers_to_set:
+        _set = _set_ntp_peers(peers_to_set)
+        if _set.get('result'):
+            config_change_expected = True
+        else:  # something went wrong...
+            result = False
+            comment += 'Cannot set NTP peers: {reason}'.format(
+                reason=_set.get('comment')
+            )
+
+    if peers_to_delete:
+        _removed = _delete_ntp_peers(peers_to_delete)
+        if _removed.get('result'):
+            config_change_expected = True
+        else:  # something went wrong...
+            result = False
+            comment += 'Cannot remove NTP peers: {reason}'.format(
+                reason=_removed.get('comment')
+            )
+
+    # <---- Call _set_ntp_peers and _delete_ntp_peers as needed --------------------------------------------------------
+
+    # ----- Try to commit changes ------------------------------------------------------------------------------------->
+
+    if config_change_expected:
+        result, config_comment = __salt__['net.config_control']()
+        comment += config_comment
+
+    changes = {
+        'diff': {
+            'added': list(peers_to_set),
+            'removed': list(peers_to_delete)
+        }
+    }
+
+    # <---- Try to commit changes --------------------------------------------------------------------------------------
+
+    ret.update({
+        'result': result,
+        'comment': comment,
+        'changes': changes
+    })
+
+    return ret


### PR DESCRIPTION
### What does this PR do?

Defines a state module that manages NTP peers on network devices via proxy-minion 'napalm' and using execution module napalm_ntp (proposed in #32043).
### What issues does this PR fix or reference?

New Salt state.
### Tests written?

No
