### PR TITLE
Fix list absent

### DIFF
--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -180,16 +180,16 @@ def list_absent(name, value):
             for val in value:
                 if val not in grain:
                     ret['comment'].append('Value {1} is absent from ' \
-                        'grain {0}'.format(name, val))
+                                          'grain {0}'.format(name, val))
                 elif __opts__['test']:
                     ret['result'] = None
-                    ret['comment'].append('Value {1} in grain {0} is ' \ 
-                        'set to be deleted'.format(name, val))
+                    ret['comment'].append('Value {1} in grain {0} is set ' \ 
+                                          'to be deleted'.format(name, val))
                     ret['changes'].append({'deleted': val})
                 elif val in grain:
                     __salt__['grains.remove'](name, val)
                     ret['comment'].append('Value {1} was deleted from ' \
-                        'grain {0}'.format(name, val))
+                                          'grain {0}'.format(name, val))
                     ret['changes'].append({'deleted': val})
             return ret
         else:

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -172,6 +172,7 @@ def list_absent(name, value):
            'changes': {},
            'result': True,
            'comment': ''}
+    comments = []
     grain = __grains__.get(name)
     if grain:
         if isinstance(grain, list):
@@ -179,23 +180,28 @@ def list_absent(name, value):
                 value = [value]
             for val in value:
                 if val not in grain:
-                    ret['comment'] += ('\nValue {1} is absent from '
-                                       'grain {0}'.format(name, val))
+                    comments.append('Value {1} is absent from '
+                                      'grain {0}'.format(name, val))
                 elif __opts__['test']:
                     ret['result'] = None
-                    ret['comment'] += ('\nValue {1} in grain {0} is set '
-                                       'to be deleted'.format(name, val))
-                    ret['changes'][val] = 'deleted'
+                    comments.append('Value {1} in grain {0} is set '
+                                     'to be deleted'.format(name, val))
+                    if not ret['changes'].has_key('deleted'):
+                        ret['changes'] = {'deleted': []}
+                    ret['changes']['deleted'].append(val)
                 elif val in grain:
                     __salt__['grains.remove'](name, val)
-                    ret['comment'] += ('\nValue {1} was deleted from '
-                                       'grain {0}'.format(name, val))
-                    ret['changes'][val] = 'deleted'
+                    comments.append('Value {1} was deleted from '
+                                     'grain {0}'.format(name, val))
+                    if not ret['changes'].has_key('deleted'):
+                        ret['changes'] = {'deleted': []}
+                    ret['changes']['deleted'].append(val)
+            ret['comment'] = '\n'.join(comments)
             return ret
         else:
             ret['result'] = False
             ret['comment'] = 'Grain {0} is not a valid list'\
-                .format(name)
+                             .format(name)
     else:
         ret['comment'] = 'Grain {0} does not exist'.format(name)
     return ret

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -186,14 +186,14 @@ def list_absent(name, value):
                     ret['result'] = None
                     comments.append('Value {1} in grain {0} is set '
                                      'to be deleted'.format(name, val))
-                    if not 'deleted' in ret['changes']:
+                    if 'deleted' not in ret['changes'].keys():
                         ret['changes'] = {'deleted': []}
                     ret['changes']['deleted'].append(val)
                 elif val in grain:
                     __salt__['grains.remove'](name, val)
                     comments.append('Value {1} was deleted from '
                                      'grain {0}'.format(name, val))
-                    if not 'deleted' in ret['changes']:
+                    if 'deleted' not in ret['changes'].keys():
                         ret['changes'] = {'deleted': []}
                     ret['changes']['deleted'].append(val)
             ret['comment'] = '\n'.join(comments)

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -186,14 +186,14 @@ def list_absent(name, value):
                     ret['result'] = None
                     comments.append('Value {1} in grain {0} is set '
                                      'to be deleted'.format(name, val))
-                    if not ret['changes'].has_key('deleted'):
+                    if not 'deleted' in ret['changes']:
                         ret['changes'] = {'deleted': []}
                     ret['changes']['deleted'].append(val)
                 elif val in grain:
                     __salt__['grains.remove'](name, val)
                     comments.append('Value {1} was deleted from '
                                      'grain {0}'.format(name, val))
-                    if not ret['changes'].has_key('deleted'):
+                    if not 'deleted' in ret['changes']:
                         ret['changes'] = {'deleted': []}
                     ret['changes']['deleted'].append(val)
             ret['comment'] = '\n'.join(comments)

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -179,17 +179,17 @@ def list_absent(name, value):
                 value = [value]
             for val in value:
                 if val not in grain:
-                    ret['comment'].append('Value {1} is absent from grain {0}' \
-                                     .format(name, val))
+                    ret['comment'].append('Value {1} is absent from ' \
+                        'grain {0}'.format(name, val))
                 elif __opts__['test']:
                     ret['result'] = None
-                    ret['comment'].append('Value {1} in grain {0} is set to ' \
-                                     'be deleted'.format(name, val))
+                    ret['comment'].append('Value {1} in grain {0} is ' \ 
+                        'set to be deleted'.format(name, val))
                     ret['changes'].append({'deleted': val})
                 elif val in grain:
                     __salt__['grains.remove'](name, val)
-                    ret['comment'].append('Value {1} was deleted from grain {0}'\
-                        .format(name, val))
+                    ret['comment'].append('Value {1} was deleted from ' \
+                        'grain {0}'.format(name, val))
                     ret['changes'].append({'deleted': val})
             return ret
         else:

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -169,9 +169,9 @@ def list_absent(name, value):
               - dev
     '''
     ret = {'name': name,
-           'changes': [],
+           'changes': {},
            'result': True,
-           'comment': []}
+           'comment': ''}
     grain = __grains__.get(name)
     if grain:
         if isinstance(grain, list):
@@ -179,18 +179,18 @@ def list_absent(name, value):
                 value = [value]
             for val in value:
                 if val not in grain:
-                    ret['comment'].append('Value {1} is absent from ' \
-                                          'grain {0}'.format(name, val))
+                    ret['comment'] += ('\nValue {1} is absent from '
+                                       'grain {0}'.format(name, val))
                 elif __opts__['test']:
                     ret['result'] = None
-                    ret['comment'].append('Value {1} in grain {0} is set ' \
-                                          'to be deleted'.format(name, val))
-                    ret['changes'].append({'deleted': val})
+                    ret['comment'] += ('\nValue {1} in grain {0} is set '
+                                       'to be deleted'.format(name, val))
+                    ret['changes'][val] = 'deleted'
                 elif val in grain:
                     __salt__['grains.remove'](name, val)
-                    ret['comment'].append('Value {1} was deleted from ' \
-                                          'grain {0}'.format(name, val))
-                    ret['changes'].append({'deleted': val})
+                    ret['comment'] += ('\nValue {1} was deleted from '
+                                       'grain {0}'.format(name, val))
+                    ret['changes'][val] = 'deleted'
             return ret
         else:
             ret['result'] = False

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -183,7 +183,7 @@ def list_absent(name, value):
                                           'grain {0}'.format(name, val))
                 elif __opts__['test']:
                     ret['result'] = None
-                    ret['comment'].append('Value {1} in grain {0} is set ' \ 
+                    ret['comment'].append('Value {1} in grain {0} is set ' \
                                           'to be deleted'.format(name, val))
                     ret['changes'].append({'deleted': val})
                 elif val in grain:

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -200,6 +200,7 @@ def list_absent(name, value):
         ret['comment'] = 'Grain {0} does not exist'.format(name)
     return ret
 
+
 def absent(name, destructive=False):
     '''
     .. versionadded:: 2014.7.0

--- a/tests/unit/states/grains_test.py
+++ b/tests/unit/states/grains_test.py
@@ -142,7 +142,7 @@ class GrainsTestCase(TestCase):
         ret = {'changes': {}, 'name': self.name, 'result': True,
                'comment': 'Value edam is absent from grain cheese'}
 
-        ret1 = {'changes': {'deleted': self.value}, 'name': self.name,
+        ret1 = {'changes': {'deleted': [self.value]}, 'name': self.name,
                 'result': None,
                 'comment': 'Value edam in grain cheese is set to be deleted'}
 
@@ -157,7 +157,7 @@ class GrainsTestCase(TestCase):
 
         with patch.dict(grains.__opts__, {'test': True}):
             with patch.dict(grains.__grains__, {self.name: [self.value]}):
-                self.assertDictEqual(grains.list_absent(self.name, [self.value]),
+                self.assertDictEqual(grains.list_absent(self.name, self.value),
                                      ret1)
 
         self.assertDictEqual(grains.list_absent(self.name, self.value), ret2)

--- a/tests/unit/states/grains_test.py
+++ b/tests/unit/states/grains_test.py
@@ -157,7 +157,7 @@ class GrainsTestCase(TestCase):
 
         with patch.dict(grains.__opts__, {'test': True}):
             with patch.dict(grains.__grains__, {self.name: [self.value]}):
-                self.assertDictEqual(grains.list_absent(self.name, self.value),
+                self.assertDictEqual(grains.list_absent(self.name, [self.value]),
                                      ret1)
 
         self.assertDictEqual(grains.list_absent(self.name, self.value), ret2)


### PR DESCRIPTION
### What does this PR do?

Adds a loop in the list_absent function to loop through the list of values as described in the documentation. 
### What issues does this PR fix or reference?

Bug #32052:  list_absent function doesn't loop through list of values
### Previous Behavior

List values never matched.

```
local:
----------
          ID: subrole
    Function: grains.list_absent
      Result: True
     Comment: Value ['item1', 'item2'] is absent from grain subrole
     Started: 16:58:25.333743
    Duration: 0.768 ms
     Changes:

Summary
------------
Succeeded: 1
Failed:    0
------------
```
### New Behavior

```
local:
----------
          ID: subrole
    Function: grains.list_absent
      Result: True
     Comment: Value item1 was deleted from grain subrole
              Value item2 was deleted from grain subrole
              Value itemx is absent from grain subrole
     Started: 01:03:58.924140
    Duration: 10048.179 ms
     Changes:
              ----------
              deleted:
                  - item1
                  - item2

Summary
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
```
### Tests written?

No
