### PR TITLE
Do not exit process on invalid master key

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -42,7 +42,7 @@ import salt.utils.rsax931
 import salt.utils.verify
 import salt.version
 from salt.exceptions import (
-    AuthenticationError, SaltClientError, SaltReqTimeoutError, SaltSystemExit
+    AuthenticationError, SaltClientError, SaltReqTimeoutError
 )
 
 import tornado.gen
@@ -582,7 +582,7 @@ class AsyncAuth(object):
                 'Salt Minion.\nThe master public key can be found '
                 'at:\n{1}'.format(salt.version.__version__, m_pub_fn)
             )
-            raise SaltSystemExit('Invalid master key')
+            raise SaltClientError('Invalid master key')
         if self.opts.get('syndic_master', False):  # Is syndic
             syndic_finger = self.opts.get('syndic_finger', self.opts.get('master_finger', False))
             if syndic_finger:


### PR DESCRIPTION
### What does this PR do?

Currently, the behavior is to exit the salt-minion process on
an invalid master key. This change will pass an error back via
'SaltClientError' instead. Some benefits of this:
- If 'failover' mode is in use, it will correctly move to the
  next master in the list.
- Relying on the salt-minion keep-alive mechanism to retry
  may not be desirable (extra process) or available (not supported
  on Windows minions).
- This will defer to the pre-existing mechanisms of `auth_tries`
  and `master_tries` which seem better tailored for this type of
  issue.
- There has been observed a race condition (at least in the TCP
  transport) where if the salt-master goes up at a certain time when
  the salt-minion is already trying to connect to the master, the
  'invalid master key' condition will be triggered. This condition will
  automatically clear itself on the next retry / failover.
### What issues does this PR fix or reference?
### Previous Behavior

Remove this section if not relevant
### New Behavior

Remove this section if not relevant
### Tests written?

No

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
