### PR TITLE
removed "all": pillar is about "particular minion"

### DIFF
--- a/doc/topics/pillar/index.rst
+++ b/doc/topics/pillar/index.rst
@@ -5,7 +5,7 @@ Storing Static Data in the Pillar
 =================================
 
 Pillar is an interface for Salt designed to offer global values that can be
-distributed to all minions. Pillar data is managed in a similar way as
+distributed to minions. Pillar data is managed in a similar way as
 the Salt State Tree.
 
 Pillar was added to Salt in version 0.9.8


### PR DESCRIPTION
### What does this PR do?

Improve docs
### What issues does this PR fix or reference?

Before you got the impression that the pillar data is accessible by all minions. But it is about sensitive data ...
### Tests written?

No :-)
