### PR TITLE
Mac assistive tests

### DIFF
--- a/salt/modules/mac_assistive.py
+++ b/salt/modules/mac_assistive.py
@@ -2,6 +2,8 @@
 '''
 This module allows you to manage assistive access on OS X minions with 10.9+
 
+.. versionadded:: 2016.3.0
+
 .. code-block:: bash
 
     salt '*' assistive.install /usr/bin/osascript
@@ -15,6 +17,7 @@ import logging
 
 # Import salt libs
 import salt.utils
+from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 
@@ -27,13 +30,19 @@ def __virtual__():
     '''
     if salt.utils.is_darwin() and LooseVersion(__grains__['osrelease']) >= LooseVersion('10.9'):
         return True
-    return False
+    return False, 'The assistive module cannot be loaded: must be run on OSX 10.9 or newer.'
 
 
 def install(app_id, enable=True):
     '''
     Install a bundle ID or command as being allowed to use
     assistive access.
+
+    app_id
+        The bundle ID or command to install for assistive access.
+
+    enabled
+        Sets enabled or disabled status. Default is ``True``.
 
     CLI Example:
 
@@ -48,7 +57,20 @@ def install(app_id, enable=True):
           '"INSERT or REPLACE INTO access VALUES(\'kTCCServiceAccessibility\',\'{0}\',{1},{2},1,NULL)"'.\
         format(app_id, client_type, enable_str)
 
-    __salt__['cmd.run'](cmd)
+    call = __salt__['cmd.run_all'](
+        cmd,
+        output_loglevel='debug',
+        python_shell=False
+    )
+    if call['retcode'] != 0:
+        comment = ''
+        if 'stderr' in call:
+            comment += call['stderr']
+        if 'stdout' in call:
+            comment += call['stdout']
+
+        raise CommandExecutionError('Error installing app: {0}'.format(comment))
+
     return True
 
 
@@ -56,6 +78,9 @@ def installed(app_id):
     '''
     Check if a bundle ID or command is listed in assistive access.
     This will not check to see if it's enabled.
+
+    app_id
+        The bundle ID or command to check installed status.
 
     CLI Example:
 
@@ -73,7 +98,13 @@ def installed(app_id):
 
 def enable(app_id, enabled=True):
     '''
-    Enable or disable an existing assitive access application.
+    Enable or disable an existing assistive access application.
+
+    app_id
+        The bundle ID or command to set assistive access status.
+
+    enabled
+        Sets enabled or disabled status. Default is ``True``.
 
     CLI Example:
 
@@ -88,7 +119,20 @@ def enable(app_id, enabled=True):
             cmd = 'sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" ' \
                   '"UPDATE access SET allowed=\'{0}\' WHERE client=\'{1}\'"'.format(enable_str, app_id)
 
-            __salt__['cmd.run'](cmd)
+            call = __salt__['cmd.run_all'](
+                cmd,
+                output_loglevel='debug',
+                python_shell=False
+            )
+
+            if call['retcode'] != 0:
+                comment = ''
+                if 'stderr' in call:
+                    comment += call['stderr']
+                if 'stdout' in call:
+                    comment += call['stdout']
+
+                raise CommandExecutionError('Error enabling app: {0}'.format(comment))
 
             return True
 
@@ -99,6 +143,9 @@ def enabled(app_id):
     '''
     Check if a bundle ID or command is listed in assistive access and
     enabled.
+
+    app_id
+        The bundle ID or command to retrieve assistive access status.
 
     CLI Example:
 
@@ -112,6 +159,40 @@ def enabled(app_id):
             return True
 
     return False
+
+
+def remove(app_id):
+    '''
+    Remove a bundle ID or command as being allowed to use assistive access.
+
+    app_id
+        The bundle ID or command to remove from assistive access list.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' assistive.remove /usr/bin/osascript
+        salt '*' assistive.remove com.smileonmymac.textexpander
+    '''
+    cmd = 'sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" ' \
+          '"DELETE from access where client=\'{0}\'"'.format(app_id)
+    call = __salt__['cmd.run_all'](
+        cmd,
+        output_loglevel='debug',
+        python_shell=False
+    )
+
+    if call['retcode'] != 0:
+        comment = ''
+        if 'stderr' in call:
+            comment += call['stderr']
+        if 'stdout' in call:
+            comment += call['stdout']
+
+        raise CommandExecutionError('Error removing app: {0}'.format(comment))
+
+    return True
 
 
 def _client_type(app_id):
@@ -128,5 +209,20 @@ def _get_assistive_access():
     returns as a ternary showing whether each app is enabled or not.
     '''
     cmd = 'sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" "SELECT * FROM access"'
-    out = __salt__['cmd.run'](cmd)
+    call = __salt__['cmd.run_all'](
+        cmd,
+        output_loglevel='debug',
+        python_shell=False
+    )
+
+    if call['retcode'] != 0:
+        comment = ''
+        if 'stderr' in call:
+            comment += call['stderr']
+        if 'stdout' in call:
+            comment += call['stdout']
+
+        raise CommandExecutionError('Error: {0}'.format(comment))
+
+    out = call['stdout']
     return re.findall(r'kTCCServiceAccessibility\|(.*)\|[0-9]{1}\|([0-9]{1})\|[0-9]{1}\|', out, re.MULTILINE)

--- a/tests/integration/modules/mac_assistive.py
+++ b/tests/integration/modules/mac_assistive.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Nicole Thomas <nicole@saltstack.com>`
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+import os
+
+# Import Salt Testing Libs
+from salttesting import skipIf
+from salttesting.helpers import (
+    destructiveTest,
+    ensure_in_syspath,
+    requires_system_grains
+)
+ensure_in_syspath('../../')
+
+# Import Salt Libs
+import integration
+
+OSA_SCRIPT = '/usr/bin/osascript'
+
+
+@destructiveTest
+@skipIf(os.geteuid() != 0, 'You must be logged in as root to run this test')
+class MacAssistiveTest(integration.ModuleCase):
+    '''
+    Integration tests for the mac_assistive module.
+    '''
+
+    def setUp(self):
+        '''
+        Sets up test requirements
+        '''
+        os_grain = self.run_function('grains.item', ['kernel'])
+        if os_grain['kernel'] not in 'Darwin':
+            self.skipTest(
+                'Test not applicable to \'{kernel}\' kernel'.format(
+                    **os_grain
+                )
+            )
+
+        # Let's install a bundle to use in tests
+        self.run_function('assistive.install', [OSA_SCRIPT, True])
+
+    def tearDown(self):
+        '''
+        Clean up after tests
+        '''
+        # Delete any bundles that were installed
+        osa_script = self.run_function('assistive.installed', OSA_SCRIPT)
+        if osa_script:
+            self.run_function('assistive.remove', OSA_SCRIPT)
+
+        smile_bundle = 'com.smileonmymac.textexpander'
+        smile_bundle_present = self.run_function('assistive.installed', smile_bundle)
+        if smile_bundle_present:
+            self.run_function('assistive.remove', smile_bundle)
+
+    @requires_system_grains
+    def test_install_and_remove(self, grains=None):
+        '''
+        Tests installing and removing a bundled ID or command to use assistive access.
+        '''
+        new_bundle = 'com.smileonmymac.textexpander'
+        self.assertTrue(
+            self.run_function('assistive.install', new_bundle)
+        )
+        self.assertTrue(
+            self.run_function('assistive.remove', new_bundle)
+        )
+
+    @requires_system_grains
+    def test_installed(self, grains=None):
+        '''
+        Tests the True and False return of assistive.installed.
+        '''
+        # OSA script should have been installed in setUp function
+        self.assertTrue(
+            self.run_function('assistive.installed', OSA_SCRIPT)
+        )
+        # Clean up install
+        self.run_function('assistive.remove', [OSA_SCRIPT])
+        # Installed should now return False
+        self.assertFalse(
+            self.run_function('assistive.installed', [OSA_SCRIPT])
+        )
+
+    @requires_system_grains
+    def test_enable(self, grains=None):
+        '''
+        Tests setting the enabled status of a bundled ID or command.
+        '''
+        # OSA script should have been installed and enabled in setUp function
+        # Now let's disable it, which should return True.
+        self.assertTrue(
+            self.run_function('assistive.enable', [OSA_SCRIPT, False])
+        )
+        # Double check the script was disabled, as intended.
+        self.assertFalse(
+            self.run_function('assistive.enabled', [OSA_SCRIPT])
+        )
+        # Now re-enable
+        self.assertTrue(
+            self.run_function('assistive.enable', OSA_SCRIPT)
+        )
+        # Double check the script was enabled, as intended.
+        self.assertTrue(
+            self.run_function('assistive.enabled', OSA_SCRIPT)
+        )
+
+    @requires_system_grains
+    def test_enabled(self, grains=None):
+        '''
+        Tests if a bundled ID or command is listed in assistive access returns True.
+        '''
+        # OSA script should have been installed in setUp function, which sets
+        # enabled to True by default.
+        self.assertTrue(
+            self.run_function('assistive.enabled', OSA_SCRIPT)
+        )
+        # Disable OSA Script
+        self.run_function('assistive.enable', [OSA_SCRIPT, False])
+        # Assert against new disabled status
+        self.assertFalse(
+            self.run_function('assistive.enabled', [OSA_SCRIPT])
+        )
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(MacAssistiveTest)

--- a/tests/unit/modules/mac_assistive_test.py
+++ b/tests/unit/modules/mac_assistive_test.py
@@ -3,9 +3,6 @@
 # Import Python libs
 from __future__ import absolute_import
 
-# Import Salt Libs
-from salt.modules import mac_assistive as assistive
-
 # Import Salt Testing Libs
 from salttesting import TestCase
 from salttesting.helpers import ensure_in_syspath
@@ -16,6 +13,10 @@ from salttesting.mock import (
 
 ensure_in_syspath('../../')
 
+# Import Salt Libs
+from salt.exceptions import CommandExecutionError
+from salt.modules import mac_assistive as assistive
+
 assistive.__salt__ = {}
 
 
@@ -23,90 +24,80 @@ class AssistiveTestCase(TestCase):
 
     def test_install_assistive_bundle(self):
         '''
-            Test installing a bundle ID as being allowed to run with assistive access
+        Test installing a bundle ID as being allowed to run with assistive access
         '''
-        mock = MagicMock()
-        with patch.dict(assistive.__salt__, {'cmd.run': mock}):
-            assistive.install('com.apple.Chess')
-            mock.assert_called_once_with('sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" '
-                                         '"INSERT or REPLACE INTO access '
-                                         'VALUES(\'kTCCServiceAccessibility\',\'com.apple.Chess\',0,1,1,NULL)"')
+        mock_ret = MagicMock(return_value={'retcode': 0})
+        with patch.dict(assistive.__salt__, {'cmd.run_all': mock_ret}):
+            self.assertTrue(assistive.install('foo'))
 
-    def test_install_assistive_bundle_disable(self):
+    def test_install_assistive_error(self):
         '''
-            Test installing a bundle ID as being allowed to run with assistive access
+        Test installing a bundle ID as being allowed to run with assistive access
         '''
-        mock = MagicMock()
-        with patch.dict(assistive.__salt__, {'cmd.run': mock}):
-            assistive.install('com.apple.Chess', False)
-            mock.assert_called_once_with('sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" '
-                                         '"INSERT or REPLACE INTO access '
-                                         'VALUES(\'kTCCServiceAccessibility\',\'com.apple.Chess\',0,0,1,NULL)"')
+        mock_ret = MagicMock(return_value={'retcode': 1})
+        with patch.dict(assistive.__salt__, {'cmd.run_all': mock_ret}):
+            self.assertRaises(CommandExecutionError, assistive.install, 'foo')
 
-    def test_install_assistive_command(self):
-        '''
-            Test installing a command as being allowed to run with assistive access
-        '''
-        mock = MagicMock()
-        with patch.dict(assistive.__salt__, {'cmd.run': mock}):
-            assistive.install('/usr/bin/osascript')
-            mock.assert_called_once_with('sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" '
-                                         '"INSERT or REPLACE INTO access '
-                                         'VALUES(\'kTCCServiceAccessibility\',\'/usr/bin/osascript\',1,1,1,NULL)"')
-
+    @patch('salt.modules.mac_assistive._get_assistive_access', MagicMock(return_value=[('foo', 0)]))
     def test_installed_bundle(self):
         '''
-            Test checking to see if a bundle id is installed as being able to use assistive access
+        Test checking to see if a bundle id is installed as being able to use assistive access
         '''
-        mock = MagicMock(return_value="kTCCServiceAccessibility|/bin/bash|1|1|1|\n"
-                                      "kTCCServiceAccessibility|com.apple.Chess|0|1|1|")
-        with patch.dict(assistive.__salt__, {'cmd.run': mock}):
-            out = assistive.installed('com.apple.Chess')
-            mock.assert_called_once_with('sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db"'
-                                         ' "SELECT * FROM access"')
+        self.assertTrue(assistive.installed('foo'))
 
-            self.assertEqual(out, True)
-
+    @patch('salt.modules.mac_assistive._get_assistive_access',
+           MagicMock(return_value=[]))
     def test_installed_bundle_not(self):
         '''
-            Test checking to see if a bundle id is installed as being able to use assistive access
+        Test checking to see if a bundle id is installed as being able to use assistive access
         '''
-        mock = MagicMock(return_value="kTCCServiceAccessibility|/bin/bash|1|1|1|\n"
-                                      "kTCCServiceAccessibility|com.apple.Safari|0|1|1|")
-        with patch.dict(assistive.__salt__, {'cmd.run': mock}):
-            out = assistive.installed('com.apple.Chess')
-            mock.assert_called_once_with('sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db"'
-                                         ' "SELECT * FROM access"')
+        self.assertFalse(assistive.installed('foo'))
 
-            self.assertEqual(out, False)
-
-    @patch("salt.modules.mac_assistive._get_assistive_access")
-    def test_enable_assistive(self, get_assistive_mock):
+    @patch('salt.modules.mac_assistive._get_assistive_access',
+           MagicMock(return_value=[('foo', 0)]))
+    def test_enable_assistive(self):
         '''
-            Test enabling a bundle ID as being allowed to run with assistive access
+        Test enabling a bundle ID as being allowed to run with assistive access
         '''
-        get_assistive_mock.return_value = [("com.apple.Chess", '1')]
-        mock = MagicMock()
+        mock_ret = MagicMock(return_value={'retcode': 0})
+        with patch.dict(assistive.__salt__, {'cmd.run_all': mock_ret}):
+            self.assertTrue(assistive.enable('foo', True))
 
-        with patch.dict(assistive.__salt__, {'cmd.run': mock}):
-            assistive.enable('com.apple.Chess')
-            mock.assert_called_once_with('sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" '
-                                         '"UPDATE access SET allowed=\'1\' WHERE client=\'com.apple.Chess\'"')
-            get_assistive_mock.assert_called_once_with()
-
-    @patch("salt.modules.mac_assistive._get_assistive_access")
-    def test_disable_assistive(self, get_assistive_mock):
+    @patch('salt.modules.mac_assistive._get_assistive_access',
+           MagicMock(return_value=[('foo', 0)]))
+    def test_enable_error(self):
         '''
-            Test dsiabling a bundle ID as being allowed to run with assistive access
+        Test enabled a bundle ID that throws a command error
         '''
-        get_assistive_mock.return_value = [("com.apple.Chess", '1')]
-        mock = MagicMock()
+        mock_ret = MagicMock(return_value={'retcode': 1})
+        with patch.dict(assistive.__salt__, {'cmd.run_all': mock_ret}):
+            self.assertRaises(CommandExecutionError,
+                              assistive.enable,
+                              'foo')
 
-        with patch.dict(assistive.__salt__, {'cmd.run': mock}):
-            assistive.enable('com.apple.Chess', False)
-            mock.assert_called_once_with('sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" '
-                                         '"UPDATE access SET allowed=\'0\' WHERE client=\'com.apple.Chess\'"')
-            get_assistive_mock.assert_called_once_with()
+    @patch('salt.modules.mac_assistive._get_assistive_access',
+           MagicMock(return_value=[]))
+    def test_enable_false(self):
+        '''
+        Test return of enable function when app isn't found.
+        '''
+        self.assertFalse(assistive.enable('foo'))
+
+    @patch('salt.modules.mac_assistive._get_assistive_access',
+           MagicMock(return_value=[('foo', '1')]))
+    def test_enabled_assistive(self):
+        '''
+        Test enabling a bundle ID as being allowed to run with assistive access
+        '''
+        self.assertTrue(assistive.enabled('foo'))
+
+    @patch('salt.modules.mac_assistive._get_assistive_access',
+           MagicMock(return_value=[]))
+    def test_enabled_assistive_false(self):
+        '''
+        Test if a bundle ID is disabled for assistive access
+        '''
+        self.assertFalse(assistive.enabled('foo'))
 
     @patch("salt.modules.mac_assistive._get_assistive_access")
     def test_enabled_assistive(self, get_assistive_mock):
@@ -121,17 +112,23 @@ class AssistiveTestCase(TestCase):
 
     def test_get_assistive_access(self):
         '''
-            Test if a bundle ID is enabled for assistive access
+        Test if a bundle ID is enabled for assistive access
         '''
+        mock_out = 'kTCCServiceAccessibility|/bin/bash|1|1|1|\n' \
+                   'kTCCServiceAccessibility|/usr/bin/osascript|1|1|1|'
+        mock_ret = MagicMock(return_value={'retcode': 0, 'stdout': mock_out})
         expected = [('/bin/bash', '1'), ('/usr/bin/osascript', '1')]
-        mock = MagicMock(return_value="kTCCServiceAccessibility|/bin/bash|1|1|1|\n"
-                                      "kTCCServiceAccessibility|/usr/bin/osascript|1|1|1|")
+        with patch.dict(assistive.__salt__, {'cmd.run_all': mock_ret}):
+            self.assertEqual(assistive._get_assistive_access(), expected)
 
-        with patch.dict(assistive.__salt__, {'cmd.run': mock}):
-            out = assistive._get_assistive_access()
-            mock.assert_called_once_with('sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" '
-                                         '"SELECT * FROM access"')
-            self.assertEqual(out, expected)
+    def test_get_assistive_access_error(self):
+        '''
+        Test a CommandExecutionError is raised when something goes wrong.
+        '''
+        mock_ret = MagicMock(return_value={'retcode': 1})
+        with patch.dict(assistive.__salt__, {'cmd.run_all': mock_ret}):
+            self.assertRaises(CommandExecutionError,
+                              assistive._get_assistive_access)
 
 
 if __name__ == '__main__':

--- a/tests/unit/modules/mac_assistive_test.py
+++ b/tests/unit/modules/mac_assistive_test.py
@@ -99,16 +99,23 @@ class AssistiveTestCase(TestCase):
         '''
         self.assertFalse(assistive.enabled('foo'))
 
-    @patch("salt.modules.mac_assistive._get_assistive_access")
-    def test_enabled_assistive(self, get_assistive_mock):
+    def test_remove_assistive(self):
         '''
-            Test if a bundle ID is enabled for assistive access
+        Test removing an assitive bundle.
         '''
-        get_assistive_mock.return_value = [("com.apple.Chess", '1')]
+        mock_ret = MagicMock(return_value={'retcode': 0})
+        with patch.dict(assistive.__salt__, {'cmd.run_all': mock_ret}):
+            self.assertTrue(assistive.remove('foo'))
 
-        out = assistive.enabled('com.apple.Chess')
-        get_assistive_mock.assert_called_once_with()
-        self.assertTrue(out)
+    def test_remove_assistive_error(self):
+        '''
+        Test removing an assitive bundle.
+        '''
+        mock_ret = MagicMock(return_value={'retcode': 1})
+        with patch.dict(assistive.__salt__, {'cmd.run_all': mock_ret}):
+            self.assertRaises(CommandExecutionError,
+                              assistive.remove,
+                              'foo')
 
     def test_get_assistive_access(self):
         '''


### PR DESCRIPTION
### What does this PR do?
- Updates mac_assistive module to use cmd.run_all
- Updates current mac_assistive_test unit tests with cmd.run_all change
- Adds module integration tests for mac_assistive execution module
- Adds a `remove` function to mac_assistive module - this was necessary to help with testing the install functions, as there wasn't a way to "clean up" after the destructive integration tests without it.
### Previous Behavior

The mac_assistive module used a lot of `cmd.run` calls. Since `cmd.run` was changed to `cmd.run_all`, that necessitated a change to the unit tests that were already present.
### New Behavior

This PR updates any of those calls to `cmd.run_all`, so we can gather the stderr/stdout as necessary if something goes wrong with the underlying sqlite3 call and handle them as needed.
### Tests written?

Yes
