### PR TITLE
Fix an issue with the minion targeting example in docs

### DIFF
--- a/doc/topics/tutorials/states_pt1.rst
+++ b/doc/topics/tutorials/states_pt1.rst
@@ -68,7 +68,7 @@ collection of minion matches is defined; for now simply specify all hosts
     .. code-block:: yaml
 
         base:
-          'os:Fedora':
+          'G@os:Fedora':
             - match: grain
             - webserver
 


### PR DESCRIPTION
### What does this PR do?

It fixes and issue with targeting minions in the docs. The grain selector wasn't used so it would always show that no nodes were found.
### What issues does this PR fix or reference?

N/A
### Tests written?

N/A

There wasn't the grain selector during the targeting, so the example actually never targets any minions.
