### PR TITLE
Don't use thread-safe injection in salt-ssh

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -545,8 +545,8 @@ def ssh_wrapper(opts, functions=None, context=None):
     return LazyLoader(
         _module_dirs(
             opts,
-            'wrapper',
-            'wrapper',
+            'ssh_wrapper',
+            'ssh_wrapper',
             base_path=os.path.join(SALT_BASE_PATH, os.path.join('client', 'ssh')),
         ),
         opts,
@@ -1286,7 +1286,19 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             mod.__opts__.update(self.opts)
         else:
             mod.__opts__ = self.opts
-
+        if hasattr(self, 'tag') and self.tag == 'ssh_wrapper':
+            if 'grains' in self.opts:
+                self._grains = self.opts['grains']
+            else:
+                self._grains = {}
+            if 'pillar' in self.opts:
+                self._pillar = self.opts['pillar']
+            else:
+                self._pillar = {}
+## old
+        if hasattr(self, 'tag') and self.tag == 'ssh_wrapper':
+            mod.__grains__ = self._grains
+            mod.__pillar__ = self._pillar
         # pack whatever other globals we were asked to
         for p_name, p_value in six.iteritems(self.pack):
             setattr(mod, p_name, p_value)


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where grains and pillars were not correctly injected into functions. The stack context approach won't work for wrappers in salt-ssh. Instead, fall back to traditional globals injection.
### What issues does this PR fix or reference?
#38135
### Previous Behavior

salt-ssh <my_host> grains.items, would be empty
### New Behavior

salt-ssh <my_host> grains.items shows grains
### Tests written?

No

Closes #38135
