### PR TITLE
Cleaner deprecation process with decorators

### DIFF
--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -11,6 +11,8 @@ import os
 import re
 import fnmatch
 import collections
+import time
+import datetime
 
 # Import 3rd-party libs
 import salt.ext.six as six
@@ -23,6 +25,8 @@ import salt.utils.event
 from salt.utils.network import host_to_ip as _host_to_ip
 from salt.utils.network import remote_port_tcp as _remote_port_tcp
 from salt.ext.six.moves import zip
+from salt.utils.decorators import with_deprecated
+from salt.exceptions import CommandExecutionError
 
 __virtualname__ = 'status'
 __opts__ = {}
@@ -121,7 +125,40 @@ def custom():
     return ret
 
 
-def uptime(human_readable=True):
+@with_deprecated(globals(), "Boron")
+def uptime():
+    '''
+    Return the uptime for this system.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' status.uptime
+
+    :return: A structure of the uptime
+    '''
+    ut_path = "/proc/uptime"
+    if not os.path.exists(ut_path):
+        raise CommandExecutionError("File {ut_path} was not found.".format(ut_path=ut_path))
+
+    ut_ret = {
+        'seconds': int(float(open(ut_path).read().strip().split()[0]))
+    }
+
+    utc_time = datetime.datetime.utcfromtimestamp(time.time() - ut_ret['seconds'])
+    ut_ret['since_iso'] = utc_time.isoformat()
+    ut_ret['since_t'] = time.mktime(utc_time.timetuple())
+    ut_ret['days'] = ut_ret['seconds'] / 60 / 60 / 24
+    hours = (ut_ret['seconds'] - (ut_ret['days'] * 24 * 60 * 60)) / 60 / 60
+    minutes = ((ut_ret['seconds'] - (ut_ret['days'] * 24 * 60 * 60)) / 60) - hours * 60
+    ut_ret['time'] = '{0}:{1}'.format(hours, minutes)
+    ut_ret['users'] = len(__salt__['cmd.run']("who -s").split(os.linesep))
+
+    return ut_ret
+
+
+def _uptime(human_readable=True):
     '''
     Return the uptime for this minion
 

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -135,8 +135,6 @@ def uptime():
     .. code-block:: bash
 
         salt '*' status.uptime
-
-    :return: A structure of the uptime
     '''
     ut_path = "/proc/uptime"
     if not os.path.exists(ut_path):

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -30,7 +30,8 @@ __opts__ = {}
 
 def __virtual__():
     if salt.utils.is_windows():
-        return (False, 'Cannot load status module on windows')
+        return False, 'Windows platform is not supported by this module'
+
     return __virtualname__
 
 

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -365,7 +365,7 @@ class _WithDeprecated(_DeprecationDecorator):
 
     def __init__(self, globals, version, with_name=None):
         _DeprecationDecorator.__init__(self, globals, version)
-        self.with_name = with_name
+        self._with_name = with_name
 
     def _set_function(self, function):
         '''
@@ -379,7 +379,7 @@ class _WithDeprecated(_DeprecationDecorator):
                 f_name=function.func_name))
 
         if full_name in self._options.get(self.CFG_KEY, list()):
-            self._function = self._globals.get(self.with_name or "_{0}".format(function.func_name))
+            self._function = self._globals.get(self._with_name or "_{0}".format(function.func_name))
 
     def __call__(self, function):
         '''

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -292,7 +292,16 @@ class _DeprecationDecorator(object):
         '''
         if self._function:
             args, kwargs = self._get_args(kwargs)
-            return self._function(*args, **kwargs)
+            try:
+                return self._function(*args, **kwargs)
+            except TypeError as error:
+                log.error('Function "{f_name}" was not properly called: {error}'.format(f_name=self._function.func_name,
+                                                                                        error=error))
+                return self._function.__doc__
+            except Exception as error:
+                log.error('Unhandled exception occurred in '
+                          'function "{f_name}: {error}'.format(f_name=self._function.func_name,
+                                                               error=error))
         else:
             raise Exception("Decorator failure: Function not found for {0}".format(self.__class__.__name__))
 

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -248,3 +248,65 @@ def memoize(func):
             cache[args] = func(*args)
         return cache[args]
     return _memoize
+
+
+class _DeprecationDecorator(object):
+    '''
+    Base class for the decorator.
+    '''
+    def __init__(self, globals, version):
+        '''
+
+        :param globals:
+        :param version:
+        :return:
+        '''
+
+        self._globals = globals
+        self._version = version
+        self._options = self._globals['__opts__']
+        self._function = None
+
+    def _get_args(self, kwargs):
+        '''
+        Extract keywords.
+
+        :param kwargs:
+        :return:
+        '''
+        _args = list()
+        _kwargs = dict()
+
+        for arg_item in kwargs.get('__pub_arg', list()):
+            if type(arg_item) == dict:
+                _kwargs.update(arg_item.copy())
+            else:
+                _args.append(arg_item)
+
+        return _args, _kwargs
+
+    def _call_function(self, kwargs):
+        '''
+
+        :return:
+        '''
+        if self._function:
+            args, kwargs = self._get_args(kwargs)
+            return self._function(*args, **kwargs)
+        else:
+            raise Exception("Decorator failure: Function not found for {0}".format(self.__class__.__name__))
+
+    def __call__(self, function):
+        '''
+
+        :param function:
+        :return:
+        '''
+        self._function = function
+
+        def _decorate(*args, **kwargs):
+            return self._call_function(kwargs)
+
+        return _decorate
+
+

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -145,10 +145,7 @@ class Depends(object):
                         continue
 
 
-class depends(Depends):  # pylint: disable=C0103
-    '''
-    Wrapper of Depends for capitalization
-    '''
+depends = Depends
 
 
 def timing(function):

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -578,6 +578,7 @@ class _WithDeprecated(_DeprecationDecorator):
                     raise CommandExecutionError(' '.join(msg))
             return self._call_function(kwargs)
 
+        _decorate.__doc__ = self._function.__doc__
         return _decorate
 
 

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -328,6 +328,49 @@ class _DeprecationDecorator(object):
 
 class _IsDeprecated(_DeprecationDecorator):
     '''
+    This decorator should be used only with the deprecated functions
+    to mark them as deprecated and alter its behavior a corresponding way.
+    The usage is only suitable if deprecation process is renaming
+    the function from one to another. In case function name or even function
+    signature stays the same, please use 'with_deprecated' decorator instead.
+
+    It has the following functionality:
+
+    1. Put a warning level message to the log, informing that
+       the deprecated function has been in use.
+
+    2. Raise an exception, if deprecated function is being called,
+       but the lifetime of it already expired.
+
+    3. Point to the successor of the deprecated function in the
+       log messages as well during the blocking it, once expired.
+
+    Usage of this decorator as follows. In this example no successor
+    is mentioned, hence the function "foo()" will be logged with the
+    warning each time is called and blocked completely, once EOF of
+    it is reached:
+
+        from salt.util.decorators import is_deprecated
+
+        @is_deprecated(globals(), "Beryllium")
+        def foo():
+            pass
+
+    In the following example a successor function is mentioned, hence
+    every time the function "bar()" is called, message will suggest
+    to use function "baz()" instead. Once EOF is reached of the function
+    "bar()", an exception will ask to use function "baz()", in order
+    to continue:
+
+        from salt.util.decorators import is_deprecated
+
+        @is_deprecated(globals(), "Beryllium", with_successor="baz")
+        def bar():
+            pass
+
+        def baz():
+            pass
+    '''
 
     def __init__(self, globals, version, with_successor=None):
         '''

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -317,6 +317,10 @@ class _DeprecationDecorator(object):
 class _IsDeprecated(_DeprecationDecorator):
     '''
 
+    def __init__(self, globals, version, with_successor=None):
+        _DeprecationDecorator.__init__(self, globals, version)
+        self._successor = with_successor
+
     def __call__(self, function):
         '''
 

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -399,6 +399,30 @@ class _WithDeprecated(_DeprecationDecorator):
 
         def _decorate(*args, **kwargs):
             self._set_function(function)
+            if self._is_used_deprecated():
+                if self._curr_version < self._exp_version:
+                    msg = list()
+                    if self._with_name:
+                        msg.append('The function "{f_name}" is deprecated and will '
+                                   'expire in version "{version_name}".'.format(f_name=self._with_name,
+                                                                                version_name=self._exp_version_name))
+                    else:
+                        msg.append('The function is using its deprecated version and will '
+                                   'expire in version "{version_name}".'.format(version_name=self._exp_version_name))
+                    msg.append('Use its successor "{successor}" instead.'.format(successor=self._orig_f_name))
+                    log.warning(' '.join(msg))
+                else:
+                    msg_patt = 'The lifetime of the function "{f_name}" expired.'
+                    if '_' + self._orig_f_name == self._function.func_name:
+                        msg = [msg_patt.format(f_name=self._orig_f_name),
+                               'Please turn off its deprecated version in the configuration']
+                    else:
+                        msg = ['Although function "{f_name}" is called, an alias "{f_alias}" '
+                               'is configured as its deprecated version.'.format(f_name=self._orig_f_name,
+                                                                                 f_alias=self._with_name),
+                               msg_patt.format(f_name=self._with_name),
+                               'Please use its successor "{successor}" instead.'.format(successor=self._orig_f_name)]
+                    raise CommandExecutionError(' '.join(msg))
             return self._call_function(kwargs)
 
         return _decorate

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -381,6 +381,14 @@ class _WithDeprecated(_DeprecationDecorator):
         if full_name in self._options.get(self.CFG_KEY, list()):
             self._function = self._globals.get(self._with_name or "_{0}".format(function.func_name))
 
+    def _is_used_deprecated(self):
+        '''
+
+        :return:
+        '''
+        return "{m_name}.{f_name}".format(m_name=self._globals.get(self.MODULE_NAME, ''),
+                                          f_name=self._orig_f_name) in self._options.get(self.CFG_KEY, list())
+
     def __call__(self, function):
         '''
 

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -296,7 +296,7 @@ class _DeprecationDecorator(object):
         :return:
         '''
         if self._raise_later:
-            raise self._raise_later
+            raise self._raise_later  # pylint: disable=E0702
 
         if self._function:
             args, kwargs = self._get_args(kwargs)

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -316,6 +316,31 @@ class _DeprecationDecorator(object):
         '''
         self._function = function
 
+
+class _IsDeprecated(_DeprecationDecorator):
+    '''
+
+    def __call__(self, function):
+        '''
+
+        :param function:
+        :return:
+        '''
+        _DeprecationDecorator.__call__(self, function)
+
+        def _decorate(*args, **kwargs):
+            if self._curr_version < self._exp_version:
+                log.warning('The function "{f_name}" is deprecated and will expire in version "{version_name}". '
+                            'Please use its successor instead.'.format(f_name=self._function.func_name,
+                                                                       version_name=self._exp_version_name))
+            else:
+                raise CommandExecutionError('The lifetime of the function "{f_name}" expired. '
+                                            'Please use its successor instead.'.format(f_name=self._function.func_name))
+            return self._call_function(kwargs)
+
+        return _decorate
+
+
         def _decorate(*args, **kwargs):
             return self._call_function(kwargs)
 

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -311,6 +311,7 @@ class _DeprecationDecorator(object):
                 log.error('Unhandled exception occurred in '
                           'function "{f_name}: {error}'.format(f_name=self._function.func_name,
                                                                error=error))
+                raise error
         else:
             raise CommandExecutionError("Function is deprecated, but the successor function was not found.")
 

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -308,7 +308,7 @@ class _DeprecationDecorator(object):
                           'function "{f_name}: {error}'.format(f_name=self._function.func_name,
                                                                error=error))
         else:
-            raise Exception("Decorator failure: Function not found for {0}".format(self.__class__.__name__))
+            raise CommandExecutionError("Function is deprecated, but the successor function was not found.")
 
     def __call__(self, function):
         '''

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -299,7 +299,8 @@ class _DeprecationDecorator(object):
             try:
                 return self._function(*args, **kwargs)
             except TypeError as error:
-                log.error('Function "{f_name}" was not properly called: {error}'.format(f_name=self._function.func_name,
+                error = str(error).replace(self._function.func_name, self._orig_f_name)  # Hide hidden functions
+                log.error('Function "{f_name}" was not properly called: {error}'.format(f_name=self._orig_f_name,
                                                                                         error=error))
                 return self._function.__doc__
             except Exception as error:

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -317,6 +317,7 @@ class _DeprecationDecorator(object):
         :return:
         '''
         self._function = function
+        self._orig_f_name = self._function.func_name
 
 
 class _IsDeprecated(_DeprecationDecorator):

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -422,6 +422,7 @@ class _WithDeprecated(_DeprecationDecorator):
                                                                                  f_alias=self._with_name),
                                msg_patt.format(f_name=self._with_name),
                                'Please use its successor "{successor}" instead.'.format(successor=self._orig_f_name)]
+                    log.error(' '.join(msg))
                     raise CommandExecutionError(' '.join(msg))
             return self._call_function(kwargs)
 

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -250,13 +250,16 @@ def memoize(func):
 
 class _DeprecationDecorator(object):
     '''
-    Base class for the decorator.
+    Base mix-in class for the deprecation decorator.
+    Takes care of a common functionality, used in its derivatives.
     '''
+
     def __init__(self, globals, version):
         '''
+        Constructor.
 
-        :param globals:
-        :param version:
+        :param globals: Module globals. Important for finding out replacement functions
+        :param version: Expiration version
         :return:
         '''
 
@@ -271,7 +274,7 @@ class _DeprecationDecorator(object):
 
     def _get_args(self, kwargs):
         '''
-        Extract keywords.
+        Extract function-specific keywords from all of the kwargs.
 
         :param kwargs:
         :return:
@@ -288,6 +291,7 @@ class _DeprecationDecorator(object):
 
     def _call_function(self, kwargs):
         '''
+        Call target function that has been decorated.
 
         :return:
         '''
@@ -312,6 +316,8 @@ class _DeprecationDecorator(object):
 
     def __call__(self, function):
         '''
+        Callable method of the decorator object when
+        the decorated function is gets called.
 
         :param function:
         :return:
@@ -324,11 +330,21 @@ class _IsDeprecated(_DeprecationDecorator):
     '''
 
     def __init__(self, globals, version, with_successor=None):
+        '''
+        Constructor of the decorator 'is_deprecated'.
+
+        :param globals: Module globals
+        :param version: Version to be deprecated
+        :param with_successor: Successor function (optional)
+        :return:
+        '''
         _DeprecationDecorator.__init__(self, globals, version)
         self._successor = with_successor
 
     def __call__(self, function):
         '''
+        Callable method of the decorator object when
+        the decorated function is gets called.
 
         :param function:
         :return:
@@ -336,6 +352,13 @@ class _IsDeprecated(_DeprecationDecorator):
         _DeprecationDecorator.__call__(self, function)
 
         def _decorate(*args, **kwargs):
+            '''
+            Decorator function.
+
+            :param args:
+            :param kwargs:
+            :return:
+            '''
             if self._curr_version < self._exp_version:
                 msg = ['The function "{f_name}" is deprecated and will '
                        'expire in version "{version_name}".'.format(f_name=self._function.func_name,
@@ -364,12 +387,20 @@ class _WithDeprecated(_DeprecationDecorator):
     CFG_KEY = 'use_deprecated'
 
     def __init__(self, globals, version, with_name=None):
+        '''
+        Constructor of the decorator 'with_deprecated'
+
+        :param globals:
+        :param version:
+        :param with_name:
+        :return:
+        '''
         _DeprecationDecorator.__init__(self, globals, version)
         self._with_name = with_name
 
     def _set_function(self, function):
         '''
-        Get old or new function
+        Based on the configuration, set to execute an old or a new function.
         :return:
         '''
         full_name = "{m_name}.{f_name}".format(m_name=self._globals.get(self.MODULE_NAME, ''),
@@ -383,6 +414,8 @@ class _WithDeprecated(_DeprecationDecorator):
 
     def _is_used_deprecated(self):
         '''
+        Returns True, if a component configuration explicitly is
+        asking to use an old version of the deprecated function.
 
         :return:
         '''
@@ -391,6 +424,8 @@ class _WithDeprecated(_DeprecationDecorator):
 
     def __call__(self, function):
         '''
+        Callable method of the decorator object when
+        the decorated function is gets called.
 
         :param function:
         :return:
@@ -398,6 +433,13 @@ class _WithDeprecated(_DeprecationDecorator):
         _DeprecationDecorator.__call__(self, function)
 
         def _decorate(*args, **kwargs):
+            '''
+            Decorator function.
+
+            :param args:
+            :param kwargs:
+            :return:
+            '''
             self._set_function(function)
             if self._is_used_deprecated():
                 if self._curr_version < self._exp_version:

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -13,7 +13,8 @@ from collections import defaultdict
 
 # Import salt libs
 import salt.utils
-from salt.exceptions import CommandNotFoundError
+from salt.exceptions import CommandNotFoundError, CommandExecutionError
+from salt.version import SaltStackVersion, __saltstack_version__
 from salt.log import LOG_LEVELS
 
 # Import 3rd-party libs
@@ -263,7 +264,9 @@ class _DeprecationDecorator(object):
         '''
 
         self._globals = globals
-        self._version = version
+        self._exp_version_name = version
+        self._exp_version = SaltStackVersion.from_name(self._exp_version_name)
+        self._curr_version = __saltstack_version__.info
         self._options = self._globals['__opts__']
         self._function = None
 

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -284,7 +284,6 @@ class _DeprecationDecorator(object):
                 _kwargs.update(arg_item.copy())
             else:
                 _args.append(arg_item)
-
         return _args, _kwargs
 
     def _call_function(self, kwargs):

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -423,8 +423,72 @@ is_deprecated = _IsDeprecated
 
 class _WithDeprecated(_DeprecationDecorator):
     '''
-    Switches the deprecated function between new and old implementation.
-    Uses function with the new version, if expired.
+    This decorator should be used with the successor functions
+    to mark them as a new and alter its behavior in a corresponding way.
+    It is used alone if a function content or function signature
+    needs to be replaced, leaving the name of the function same.
+    In case function needs to be renamed or just dropped, it has
+    to be used in pair with 'is_deprecated' decorator.
+
+    It has the following functionality:
+
+    1. Put a warning level message to the log, in case a component
+       is using its deprecated version.
+
+    2. Switch between old and new function in case an older version
+       is configured for the desired use.
+
+    3. Raise an exception, if deprecated version reached EOL and
+       point out for the new version.
+
+    Usage of this decorator as follows. If 'with_name' is not specified,
+    then the name of the deprecated function is assumed with the "_" prefix.
+    In this case, in order to deprecate a function, it is required:
+
+    - Add a prefix "_" to an existing function. E.g.: "foo()" to "_foo()".
+
+    - Implement a new function with exactly the same name, just without
+      the prefix "_".
+
+    Example:
+
+        from salt.util.decorators import with_deprecated
+
+        @with_deprecated(globals(), "Beryllium")
+        def foo():
+            "This is a new function"
+
+        def _foo():
+            "This is a deprecated function"
+
+
+    In case there is a need to deprecate a function and rename it,
+    the decorator shuld be used with the 'with_name' parameter. This
+    parameter is pointing to the existing deprecated function. In this
+    case deprecation process as follows:
+
+    - Leave a deprecated function without changes, as is.
+
+    - Implement a new function and decorate it with this decorator.
+
+    - Set a parameter 'with_name' to the deprecated function.
+
+    - If a new function has a different name than a deprecated,
+      decorate a deprecated function with the  'is_deprecated' decorator
+      in order to let the function have a deprecated behavior.
+
+    Example:
+
+        from salt.util.decorators import with_deprecated
+
+        @with_deprecated(globals(), "Beryllium", with_name="an_old_function")
+        def a_new_function():
+            "This is a new function"
+
+        @is_deprecated(globals(), "Beryllium", with_successor="a_new_function")
+        def an_old_function():
+            "This is a deprecated function"
+
     '''
     MODULE_NAME = '__virtualname__'
     CFG_KEY = 'use_deprecated'

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -338,7 +338,6 @@ class _IsDeprecated(_DeprecationDecorator):
         return _decorate
 
 
-
 is_deprecated = _IsDeprecated
 
 

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -553,8 +553,9 @@ class _WithDeprecated(_DeprecationDecorator):
                     msg = list()
                     if self._with_name:
                         msg.append('The function "{f_name}" is deprecated and will '
-                                   'expire in version "{version_name}".'.format(f_name=self._with_name,
-                                                                                version_name=self._exp_version_name))
+                                   'expire in version "{version_name}".'.format(
+                                       f_name=self._with_name.startswith("_") and self._orig_f_name or self._with_name,
+                                       version_name=self._exp_version_name))
                     else:
                         msg.append('The function is using its deprecated version and will '
                                    'expire in version "{version_name}".'.format(version_name=self._exp_version_name))

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -413,6 +413,7 @@ class _IsDeprecated(_DeprecationDecorator):
                 msg = ['The lifetime of the function "{f_name}" expired.'.format(f_name=self._function.func_name)]
                 if self._successor:
                     msg.append('Please use its successor "{successor}" instead.'.format(successor=self._successor))
+                log.warning(' '.join(msg))
                 raise CommandExecutionError(' '.join(msg))
             return self._call_function(kwargs)
         return _decorate

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -331,19 +331,41 @@ class _IsDeprecated(_DeprecationDecorator):
 
         def _decorate(*args, **kwargs):
             if self._curr_version < self._exp_version:
-                log.warning('The function "{f_name}" is deprecated and will expire in version "{version_name}". '
-                            'Please use its successor instead.'.format(f_name=self._function.func_name,
-                                                                       version_name=self._exp_version_name))
+                msg = ['The function "{f_name}" is deprecated and will '
+                       'expire in version "{version_name}".'.format(f_name=self._function.func_name,
+                                                                    version_name=self._exp_version_name)]
+                if self._successor:
+                    msg.append('Use successor "{successor}" instead.'.format(successor=self._successor))
+                log.warning(' '.join(msg))
             else:
-                raise CommandExecutionError('The lifetime of the function "{f_name}" expired. '
-                                            'Please use its successor instead.'.format(f_name=self._function.func_name))
+                msg = ['The lifetime of the function "{f_name}" expired.'.format(f_name=self._function.func_name)]
+                if self._successor:
+                    msg.append('Please use its successor "{successor}" instead.'.format(successor=self._successor))
+                raise CommandExecutionError(' '.join(msg))
             return self._call_function(kwargs)
-
         return _decorate
 
 
 is_deprecated = _IsDeprecated
 
+
+class _WithDeprecated(_DeprecationDecorator):
+    '''
+    Switches the deprecated function between new and old implementation.
+    Uses function with the new version, if expired.
+    '''
+
+    def __init__(self, globals, version, with_name=None):
+        _DeprecationDecorator.__init__(self, globals, version)
+        self.with_name = with_name
+
+    def __call__(self, function):
+        '''
+
+        :param function:
+        :return:
+        '''
+        _DeprecationDecorator.__call__(self, function)
 
         def _decorate(*args, **kwargs):
             return self._call_function(kwargs)
@@ -351,3 +373,4 @@ is_deprecated = _IsDeprecated
         return _decorate
 
 
+with_deprecated = _WithDeprecated

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -341,6 +341,10 @@ class _IsDeprecated(_DeprecationDecorator):
         return _decorate
 
 
+
+is_deprecated = _IsDeprecated
+
+
         def _decorate(*args, **kwargs):
             return self._call_function(kwargs)
 

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -569,9 +569,9 @@ class _WithDeprecated(_DeprecationDecorator):
                                'Please turn off its deprecated version in the configuration']
                     else:
                         msg = ['Although function "{f_name}" is called, an alias "{f_alias}" '
-                               'is configured as its deprecated version.'.format(f_name=self._orig_f_name,
-                                                                                 f_alias=self._with_name),
-                               msg_patt.format(f_name=self._with_name),
+                               'is configured as its deprecated version.'.format(
+                                   f_name=self._orig_f_name, f_alias=self._with_name or self._orig_f_name),
+                               msg_patt.format(f_name=self._with_name or self._orig_f_name),
                                'Please use its successor "{successor}" instead.'.format(successor=self._orig_f_name)]
                     log.error(' '.join(msg))
                     raise CommandExecutionError(' '.join(msg))

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -265,7 +265,9 @@ class _DeprecationDecorator(object):
         self._exp_version = SaltStackVersion.from_name(self._exp_version_name)
         self._curr_version = __saltstack_version__.info
         self._options = self._globals['__opts__']
+        self._raise_later = None
         self._function = None
+        self._orig_f_name = None
 
     def _get_args(self, kwargs):
         '''
@@ -290,6 +292,9 @@ class _DeprecationDecorator(object):
 
         :return:
         '''
+        if self._raise_later:
+            raise self._raise_later
+
         if self._function:
             args, kwargs = self._get_args(kwargs)
             try:

--- a/tests/unit/modules/status_test.py
+++ b/tests/unit/modules/status_test.py
@@ -24,9 +24,31 @@ class StatusTestCase(TestCase):
     '''
     test modules.status functions
     '''
+
     def test_uptime(self):
         '''
-        test modules.status.uptime function
+        Test modules.status.uptime function, new version
+        :return:
+        '''
+        class ProcUptime(object):
+            def __init__(self, *args, **kwargs):
+                self.data = "773865.18 1003405.46"
+
+            def read(self):
+                return self.data
+
+        with patch.dict(status.__salt__, {'cmd.run': MagicMock(return_value="1\n2\n3")}):
+            with patch('os.path.exists', MagicMock(return_value=True)):
+                with patch('time.time', MagicMock(return_value=1458821523.72)):
+                    status.open = ProcUptime
+                    u_time = status.uptime()
+                    self.assertEqual(u_time['users'], 3)
+                    self.assertEqual(u_time['seconds'], 773865)
+                    self.assertEqual(u_time['since_t'], 1458044058.0)
+                    self.assertEqual(u_time['days'], 8)
+                    self.assertEqual(u_time['since_iso'], '2016-03-15T13:14:18.720000')
+                    self.assertEqual(u_time['time'], '22:57')
+
         '''
         mock_uptime = 'very often'
         mock_run = MagicMock(return_value=mock_uptime)

--- a/tests/unit/modules/status_test.py
+++ b/tests/unit/modules/status_test.py
@@ -3,8 +3,6 @@
 # Import Python libs
 from __future__ import absolute_import
 
-import datetime
-
 # Import Salt Libs
 from salt.modules import status
 from salt.exceptions import CommandExecutionError

--- a/tests/unit/modules/status_test.py
+++ b/tests/unit/modules/status_test.py
@@ -7,13 +7,11 @@ from __future__ import absolute_import
 from salt.modules import status
 
 # Import Salt Testing Libs
-from salttesting import skipIf, TestCase
+from salttesting import TestCase
 from salttesting.helpers import ensure_in_syspath
 from salttesting.mock import (
     MagicMock,
     patch,
-    NO_MOCK,
-    NO_MOCK_REASON
 )
 
 ensure_in_syspath('../../')
@@ -22,7 +20,6 @@ ensure_in_syspath('../../')
 status.__salt__ = {}
 
 
-@skipIf(NO_MOCK, NO_MOCK_REASON)
 class StatusTestCase(TestCase):
     '''
     test modules.status functions

--- a/tests/unit/modules/status_test.py
+++ b/tests/unit/modules/status_test.py
@@ -3,6 +3,8 @@
 # Import Python libs
 from __future__ import absolute_import
 
+import datetime
+
 # Import Salt Libs
 from salt.modules import status
 from salt.exceptions import CommandExecutionError
@@ -45,9 +47,7 @@ class StatusTestCase(TestCase):
                     u_time = status.uptime()
                     self.assertEqual(u_time['users'], 3)
                     self.assertEqual(u_time['seconds'], 773865)
-                    self.assertEqual(u_time['since_t'], 1458044058.0)
                     self.assertEqual(u_time['days'], 8)
-                    self.assertEqual(u_time['since_iso'], '2016-03-15T13:14:18.720000')
                     self.assertEqual(u_time['time'], '22:57')
 
     def test_uptime_failure(self):

--- a/tests/unit/modules/status_test.py
+++ b/tests/unit/modules/status_test.py
@@ -59,6 +59,9 @@ class StatusTestCase(TestCase):
             with self.assertRaises(CommandExecutionError):
                 status.uptime()
 
+    def test_deprecated_uptime(self):
+        '''
+        test modules.status.uptime function, deprecated version
         '''
         mock_uptime = 'very often'
         mock_run = MagicMock(return_value=mock_uptime)

--- a/tests/unit/modules/status_test.py
+++ b/tests/unit/modules/status_test.py
@@ -34,24 +34,24 @@ class StatusTestCase(TestCase):
         mock_uptime = 'very often'
         mock_run = MagicMock(return_value=mock_uptime)
         with patch.dict(status.__salt__, {'cmd.run': mock_run}):
-            self.assertEqual(status.uptime(), mock_uptime)
+            self.assertEqual(status._uptime(), mock_uptime)
 
         mock_uptime = 'very idle'
         mock_run = MagicMock(return_value=mock_uptime)
         with patch.dict(status.__salt__, {'cmd.run': mock_run}):
             with patch('os.path.exists', MagicMock(return_value=True)):
-                self.assertEqual(status.uptime(human_readable=False), mock_uptime.split()[0])
+                self.assertEqual(status._uptime(human_readable=False), mock_uptime.split()[0])
 
         mock_uptime = ''
         mock_return = 'unexpected format in /proc/uptime'
         mock_run = MagicMock(return_value=mock_uptime)
         with patch.dict(status.__salt__, {'cmd.run': mock_run}):
             with patch('os.path.exists', MagicMock(return_value=True)):
-                self.assertEqual(status.uptime(human_readable=False), mock_return)
+                self.assertEqual(status._uptime(human_readable=False), mock_return)
 
         mock_return = 'cannot find /proc/uptime'
         with patch('os.path.exists', MagicMock(return_value=False)):
-            self.assertEqual(status.uptime(human_readable=False), mock_return)
+            self.assertEqual(status._uptime(human_readable=False), mock_return)
 
 
 if __name__ == '__main__':

--- a/tests/unit/modules/status_test.py
+++ b/tests/unit/modules/status_test.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 
 # Import Salt Libs
 from salt.modules import status
+from salt.exceptions import CommandExecutionError
 
 # Import Salt Testing Libs
 from salttesting import TestCase
@@ -48,6 +49,15 @@ class StatusTestCase(TestCase):
                     self.assertEqual(u_time['days'], 8)
                     self.assertEqual(u_time['since_iso'], '2016-03-15T13:14:18.720000')
                     self.assertEqual(u_time['time'], '22:57')
+
+    def test_uptime_failure(self):
+        '''
+        Test modules.status.uptime function should raise an exception if /proc/uptime does not exists.
+        :return:
+        '''
+        with patch('os.path.exists', MagicMock(return_value=False)):
+            with self.assertRaises(CommandExecutionError):
+                status.uptime()
 
         '''
         mock_uptime = 'very often'

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -173,6 +173,10 @@ class DecoratorsTest(TestCase):
         depr._curr_version = self._mk_version("Beryllium")[1]
         with self.assertRaises(CommandExecutionError):
             depr(self.new_function)()
+        self.assertEqual(self.messages,
+                         ['Although function "new_function" is called, an alias "new_function" '
+                          'is configured as its deprecated version. The lifetime of the function '
+                          '"new_function" expired. Please use its successor "new_function" instead.'])
 
     def test_with_deprecated_no_conf(self):
         '''

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -66,6 +66,7 @@ class DecoratorsTest(TestCase):
         '''
         Use of is_deprecated will result to the exception,
         if the expiration version is lower than the current version.
+        A successor function is not pointed.
 
         :return:
         '''

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -128,6 +128,20 @@ class DecoratorsTest(TestCase):
                           'and will expire in version "Beryllium". '
                           'Use successor "old_function" instead.'])
 
+    def test_with_deprecated_lo_hi_ver_notfound(self):
+        '''
+        Test with_deprecated should raise an exception, if a same name
+        function with the "_" prefix not implemented.
+
+        :return:
+        '''
+        self.globs['__opts__']['use_deprecated'] = ['test.new_function']
+        depr = decorators.with_deprecated(self.globs, "Beryllium")
+        depr._curr_version = self._mk_version("Helium")[1]
+        with self.assertRaises(CommandExecutionError):
+            depr(self.new_function)()
+
+
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -69,6 +69,13 @@ class DecoratorsTest(TestCase):
         :return:
         '''
 
+    def test_is_deprecated_hi_lo_version(self):
+        '''
+        Use of is_deprecated will result to the log message,
+        if the expiration version is higher than the current version.
+
+        :return:
+        '''
         depr = decorators.is_deprecated(self.globs, "Beryllium")
         depr._curr_version = self._mk_version("Helium")[1]
         depr(self.old_function)()

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -48,6 +48,19 @@ class DecoratorsTest(TestCase):
         '''
         return name, SaltStackVersion.from_name(name)
 
+    def setUp(self):
+        '''
+        Setup a test
+        :return:
+        '''
+        self.globs = {
+            '__opts__': {},
+            'old_function': self.old_function,
+            'new_function': self.new_function,
+        }
+        self.messages = list()
+        decorators.log = DummyLogger(self.messages)
+
     def test_is_deprecated_log_message_appears(self):
         '''
         Use of is_deprecated will result to the log message,
@@ -55,18 +68,12 @@ class DecoratorsTest(TestCase):
 
         :return:
         '''
-        globs = {
-            '__opts__': {},
-            'old_function': self.old_function,
-        }
 
-        messages = list()
-        decorators.log = DummyLogger(messages)
-        depr = decorators.is_deprecated(globs, "Beryllium")
+        depr = decorators.is_deprecated(self.globs, "Beryllium")
         depr._curr_version = self._mk_version("Helium")[1]
         depr(self.old_function)()
 
-        self.assertEqual(messages,
+        self.assertEqual(self.messages,
                          ['The function "old_function" is deprecated '
                           'and will expire in version "Beryllium".'])
 

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -154,6 +154,10 @@ class DecoratorsTest(TestCase):
         depr = decorators.with_deprecated(self.globs, "Beryllium")
         depr._curr_version = self._mk_version("Helium")[1]
         self.assertEqual(depr(self.new_function)(), self.old_function())
+        self.assertEqual(self.messages,
+                         ['The function is using its deprecated version '
+                          'and will expire in version "Beryllium". '
+                          'Use its successor "new_function" instead.']),
 
     def test_with_deprecated_lo_hi_ver_no_conf(self):
         '''

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -143,8 +143,9 @@ class DecoratorsTest(TestCase):
 
     def test_with_deprecated_lo_hi_ver_found(self):
         '''
-        Test with_deprecated should raise an exception, if a same name
-        function with the "_" prefix not implemented.
+        Test with_deprecated should not raise an exception, if a same name
+        function with the "_" prefix is implemented, but should use
+        an old version instead, if "use_deprecated" is requested.
 
         :return:
         '''

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -154,10 +154,9 @@ class DecoratorsTest(TestCase):
         depr = decorators.with_deprecated(self.globs, "Beryllium")
         depr._curr_version = self._mk_version("Helium")[1]
         self.assertEqual(depr(self.new_function)(), self.old_function())
-        self.assertEqual(self.messages,
-                         ['The function is using its deprecated version '
-                          'and will expire in version "Beryllium". '
-                          'Use its successor "new_function" instead.']),
+        log_msg = ['The function is using its deprecated version and will expire in version "Beryllium". '
+                   'Use its successor "new_function" instead.']
+        self.assertEqual(self.messages, log_msg),
 
     def test_with_deprecated_found_eol(self):
         '''

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -90,7 +90,6 @@ class DecoratorsTest(TestCase):
         depr._curr_version = self._mk_version("Beryllium")[1]
         with self.assertRaises(CommandExecutionError):
             depr(self.old_function)()
-
         self.assertEqual(self.messages,
                          ['The lifetime of the function "old_function" expired. '
                           'Please use its successor "new_function" instead.'])
@@ -105,8 +104,7 @@ class DecoratorsTest(TestCase):
         '''
         depr = decorators.is_deprecated(self.globs, "Beryllium")
         depr._curr_version = self._mk_version("Helium")[1]
-        depr(self.old_function)()
-
+        self.assertEqual(depr(self.old_function)(), self.old_function())
         self.assertEqual(self.messages,
                          ['The function "old_function" is deprecated '
                           'and will expire in version "Beryllium".'])
@@ -121,8 +119,7 @@ class DecoratorsTest(TestCase):
         '''
         depr = decorators.is_deprecated(self.globs, "Beryllium", with_successor="old_function")
         depr._curr_version = self._mk_version("Helium")[1]
-        depr(self.old_function)()
-
+        self.assertEqual(depr(self.old_function)(), self.old_function())
         self.assertEqual(self.messages,
                          ['The function "old_function" is deprecated '
                           'and will expire in version "Beryllium". '
@@ -140,7 +137,6 @@ class DecoratorsTest(TestCase):
         depr._curr_version = self._mk_version("Helium")[1]
         with self.assertRaises(CommandExecutionError):
             depr(self.new_function)()
-
         self.assertEqual(self.messages,
                          ['The function is using its deprecated version and will expire in version "Beryllium". '
                           'Use its successor "new_function" instead.'])

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -110,6 +110,23 @@ class DecoratorsTest(TestCase):
                          ['The function "old_function" is deprecated '
                           'and will expire in version "Beryllium".'])
 
+    def test_is_deprecated_hi_lo_version_with_successor(self):
+        '''
+        Use of is_deprecated will result to the log message,
+        if the expiration version is higher than the current version.
+        A successor function is pointed out.
+
+        :return:
+        '''
+        depr = decorators.is_deprecated(self.globs, "Beryllium", with_successor="old_function")
+        depr._curr_version = self._mk_version("Helium")[1]
+        depr(self.old_function)()
+
+        self.assertEqual(self.messages,
+                         ['The function "old_function" is deprecated '
+                          'and will expire in version "Beryllium". '
+                          'Use successor "old_function" instead.'])
+
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -188,6 +188,22 @@ class DecoratorsTest(TestCase):
         self.assertEqual(depr(self.new_function)(), self.new_function())
         self.assertFalse(self.messages)
 
+    def test_with_deprecated_with_name(self):
+        '''
+        Test with_deprecated should not raise an exception, if a different name
+        function is implemented and specified with the "with_name" parameter,
+        but should use an old version instead and log a warning log message.
+
+        :return:
+        '''
+        self.globs['__opts__']['use_deprecated'] = ['test.new_function']
+        depr = decorators.with_deprecated(self.globs, "Beryllium", with_name="old_function")
+        depr._curr_version = self._mk_version("Helium")[1]
+        self.assertEqual(depr(self.new_function)(), self.old_function())
+        self.assertEqual(self.messages,
+                         ['The function "old_function" is deprecated and will expire in version "Beryllium". '
+                          'Use its successor "new_function" instead.'])
+
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -171,7 +171,7 @@ class DecoratorsTest(TestCase):
         depr = decorators.with_deprecated(self.globs, "Beryllium")
         depr._curr_version = self._mk_version("Helium")[1]
         self.assertEqual(depr(self.new_function)(), self.new_function())
-
+        self.assertFalse(self.messages)
 
 
 if __name__ == '__main__':

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -141,6 +141,19 @@ class DecoratorsTest(TestCase):
         with self.assertRaises(CommandExecutionError):
             depr(self.new_function)()
 
+    def test_with_deprecated_lo_hi_ver_found(self):
+        '''
+        Test with_deprecated should raise an exception, if a same name
+        function with the "_" prefix not implemented.
+
+        :return:
+        '''
+        self.globs['__opts__']['use_deprecated'] = ['test.new_function']
+        self.globs['_new_function'] = self.old_function
+        depr = decorators.with_deprecated(self.globs, "Beryllium")
+        depr._curr_version = self._mk_version("Helium")[1]
+        self.assertEqual(depr(self.new_function)(), self.old_function())
+
 
 
 if __name__ == '__main__':

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -204,6 +204,25 @@ class DecoratorsTest(TestCase):
                          ['The function "old_function" is deprecated and will expire in version "Beryllium". '
                           'Use its successor "new_function" instead.'])
 
+    def test_with_deprecated_with_name_eol(self):
+        '''
+        Test with_deprecated should not raise an exception, if a different name
+        function is implemented and specified with the "with_name" parameter,
+        but should use an old version instead and log a warning log message.
+
+        :return:
+        '''
+        self.globs['__opts__']['use_deprecated'] = ['test.new_function']
+        depr = decorators.with_deprecated(self.globs, "Helium", with_name="old_function")
+        depr._curr_version = self._mk_version("Beryllium")[1]
+        with self.assertRaises(CommandExecutionError):
+            depr(self.new_function)()
+        self.assertEqual(self.messages,
+                         ['Although function "new_function" is called, '
+                          'an alias "old_function" is configured as its deprecated version. '
+                          'The lifetime of the function "old_function" expired. '
+                          'Please use its successor "new_function" instead.'])
+
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -66,7 +66,7 @@ class DecoratorsTest(TestCase):
         '''
         Use of is_deprecated will result to the exception,
         if the expiration version is lower than the current version.
-        A successor function is not pointed.
+        A successor function is not pointed out.
 
         :return:
         '''
@@ -81,7 +81,7 @@ class DecoratorsTest(TestCase):
         '''
         Use of is_deprecated will result to the exception,
         if the expiration version is lower than the current version.
-        A successor function is pointed.
+        A successor function is pointed out.
 
         :return:
         '''
@@ -98,6 +98,7 @@ class DecoratorsTest(TestCase):
         '''
         Use of is_deprecated will result to the log message,
         if the expiration version is higher than the current version.
+        A successor function is not pointed out.
 
         :return:
         '''

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -34,48 +34,41 @@ class DecoratorsTest(TestCase):
     '''
     Testing decorators.
     '''
-    def deprecated_function(self):
-        return "deprecated"
+    def old_function(self):
+        return "old"
 
     def new_function(self):
         return "new"
 
-
-    def _get_hi_ver(self):
+    def _mk_version(self, name):
         '''
-        Get higher version.
-
-        :return:
-        '''
-        return SaltStackVersion.from_name("Beryllium")
-
-    def _get_lo_ver(self):
-        '''
-        Get lower version.
+        Make a version
 
         :return:
         '''
-        return SaltStackVersion.from_name("Helium")
+        return name, SaltStackVersion.from_name(name)
 
-    def test_is_deprecated(self):
+    def test_is_deprecated_log_message_appears(self):
         '''
-        Test deprecated decorator class.
+        Use of is_deprecated will result to the log message,
+        if expiration version is higher than current version.
 
         :return:
         '''
         globs = {
             '__opts__': {},
-            'deprecated_function': self.deprecated_function,
+            'old_function': self.old_function,
         }
 
         messages = list()
         decorators.log = DummyLogger(messages)
-        depr = decorators.is_deprecated(globs, "Boron")
-        depr(self.deprecated_function)()
+        depr = decorators.is_deprecated(globs, "Beryllium")
+        depr._curr_version = self._mk_version("Helium")[1]
+        depr(self.old_function)()
 
         self.assertEqual(messages,
-                         ['The function "deprecated_function" is deprecated '
-                          'and will expire in version "Boron".'])
+                         ['The function "old_function" is deprecated '
+                          'and will expire in version "Beryllium".'])
 
     def with_deprecated_test(self):
         pass

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -77,6 +77,23 @@ class DecoratorsTest(TestCase):
         self.assertEqual(self.messages,
                          ['The lifetime of the function "old_function" expired.'])
 
+    def test_is_deprecated_lo_hi_ver_with_successor(self):
+        '''
+        Use of is_deprecated will result to the exception,
+        if the expiration version is lower than the current version.
+        A successor function is pointed.
+
+        :return:
+        '''
+        depr = decorators.is_deprecated(self.globs, "Helium", with_successor="new_function")
+        depr._curr_version = self._mk_version("Beryllium")[1]
+        with self.assertRaises(CommandExecutionError):
+            depr(self.old_function)()
+
+        self.assertEqual(self.messages,
+                         ['The lifetime of the function "old_function" expired. '
+                          'Please use its successor "new_function" instead.'])
+
     def test_is_deprecated_hi_lo_version(self):
         '''
         Use of is_deprecated will result to the log message,

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -159,7 +159,7 @@ class DecoratorsTest(TestCase):
                           'and will expire in version "Beryllium". '
                           'Use its successor "new_function" instead.']),
 
-    def test_with_deprecated_lo_hi_ver_found_eol(self):
+    def test_with_deprecated_hi_lo_ver_found_eol(self):
         '''
         Test with_deprecated should raise an exception, if a same name
         function with the "_" prefix is implemented, "use_deprecated" is requested

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -92,8 +92,6 @@ class DecoratorsTest(TestCase):
                          ['The function "old_function" is deprecated '
                           'and will expire in version "Beryllium".'])
 
-    def with_deprecated_test(self):
-        pass
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -206,9 +206,9 @@ class DecoratorsTest(TestCase):
 
     def test_with_deprecated_with_name_eol(self):
         '''
-        Test with_deprecated should not raise an exception, if a different name
-        function is implemented and specified with the "with_name" parameter,
-        but should use an old version instead and log a warning log message.
+        Test with_deprecated should raise an exception, if a different name
+        function is implemented and specified with the "with_name" parameter
+        and EOL is reached.
 
         :return:
         '''

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -12,6 +12,7 @@ from salttesting import TestCase
 from salttesting.helpers import ensure_in_syspath
 from salt.utils import decorators
 from salt.version import SaltStackVersion
+from salt.exceptions import CommandExecutionError
 
 ensure_in_syspath('../../')
 
@@ -61,13 +62,19 @@ class DecoratorsTest(TestCase):
         self.messages = list()
         decorators.log = DummyLogger(self.messages)
 
-    def test_is_deprecated_log_message_appears(self):
+    def test_is_deprecated_lo_hi_version(self):
         '''
-        Use of is_deprecated will result to the log message,
-        if expiration version is higher than current version.
+        Use of is_deprecated will result to the exception,
+        if the expiration version is lower than the current version.
 
         :return:
         '''
+        depr = decorators.is_deprecated(self.globs, "Helium")
+        depr._curr_version = self._mk_version("Beryllium")[1]
+        with self.assertRaises(CommandExecutionError):
+            depr(self.old_function)()
+        self.assertEqual(self.messages,
+                         ['The lifetime of the function "old_function" expired.'])
 
     def test_is_deprecated_hi_lo_version(self):
         '''

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -161,9 +161,9 @@ class DecoratorsTest(TestCase):
 
     def test_with_deprecated_lo_hi_ver_found_eol(self):
         '''
-        Test with_deprecated should not raise an exception, if a same name
-        function with the "_" prefix is implemented, but should use
-        an old version instead, if "use_deprecated" is requested.
+        Test with_deprecated should raise an exception, if a same name
+        function with the "_" prefix is implemented, "use_deprecated" is requested
+        and EOL is reached.
 
         :return:
         '''

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Bo Maryniuk (bo@suse.de)`
+    unit.utils.decorators_test
+'''
+
+# Import Pytohn libs
+from __future__ import absolute_import
+
+# Import Salt Testing libs
+from salttesting import TestCase
+from salttesting.helpers import ensure_in_syspath
+from salt.utils import decorators
+from salt.version import SaltStackVersion
+
+ensure_in_syspath('../../')
+
+
+class DummyLogger(object):
+    '''
+    Dummy logger accepts everything and simply logs
+    '''
+    def __init__(self, messages):
+        self._messages = messages
+
+    def __getattr__(self, item):
+        return self._log
+
+    def _log(self, msg):
+        self._messages.append(msg)
+
+
+class DecoratorsTest(TestCase):
+    '''
+    Testing decorators.
+    '''
+    def deprecated_function(self):
+        return "deprecated"
+
+    def new_function(self):
+        return "new"
+
+
+    def _get_hi_ver(self):
+        '''
+        Get higher version.
+
+        :return:
+        '''
+        return SaltStackVersion.from_name("Beryllium")
+
+    def _get_lo_ver(self):
+        '''
+        Get lower version.
+
+        :return:
+        '''
+        return SaltStackVersion.from_name("Helium")
+
+    def test_is_deprecated(self):
+        '''
+        Test deprecated decorator class.
+
+        :return:
+        '''
+        globs = {
+            '__opts__': {},
+            'deprecated_function': self.deprecated_function,
+        }
+
+        messages = list()
+        decorators.log = DummyLogger(messages)
+        depr = decorators.is_deprecated(globs, "Boron")
+        depr(self.deprecated_function)()
+
+        self.assertEqual(messages,
+                         ['The function "deprecated_function" is deprecated '
+                          'and will expire in version "Boron".'])
+
+    def with_deprecated_test(self):
+        pass
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(DecoratorsTest, needs_daemon=False)

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -55,6 +55,7 @@ class DecoratorsTest(TestCase):
         :return:
         '''
         self.globs = {
+            '__virtualname__': 'test',
             '__opts__': {},
             'old_function': self.old_function,
             'new_function': self.new_function,

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -156,7 +156,7 @@ class DecoratorsTest(TestCase):
         self.assertEqual(depr(self.new_function)(), self.old_function())
         log_msg = ['The function is using its deprecated version and will expire in version "Beryllium". '
                    'Use its successor "new_function" instead.']
-        self.assertEqual(self.messages, log_msg),
+        self.assertEqual(self.messages, log_msg)
 
     def test_with_deprecated_found_eol(self):
         '''

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -141,6 +141,10 @@ class DecoratorsTest(TestCase):
         with self.assertRaises(CommandExecutionError):
             depr(self.new_function)()
 
+        self.assertEqual(self.messages,
+                         ['The function is using its deprecated version and will expire in version "Beryllium". '
+                          'Use its successor "new_function" instead.'])
+
     def test_with_deprecated_found(self):
         '''
         Test with_deprecated should not raise an exception, if a same name

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -159,6 +159,21 @@ class DecoratorsTest(TestCase):
                           'and will expire in version "Beryllium". '
                           'Use its successor "new_function" instead.']),
 
+    def test_with_deprecated_lo_hi_ver_found_eol(self):
+        '''
+        Test with_deprecated should not raise an exception, if a same name
+        function with the "_" prefix is implemented, but should use
+        an old version instead, if "use_deprecated" is requested.
+
+        :return:
+        '''
+        self.globs['__opts__']['use_deprecated'] = ['test.new_function']
+        self.globs['_new_function'] = self.old_function
+        depr = decorators.with_deprecated(self.globs, "Helium")
+        depr._curr_version = self._mk_version("Beryllium")[1]
+        with self.assertRaises(CommandExecutionError):
+            depr(self.new_function)()
+
     def test_with_deprecated_lo_hi_ver_no_conf(self):
         '''
         Test with_deprecated should not raise an exception, if a same name

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -4,7 +4,7 @@
     unit.utils.decorators_test
 '''
 
-# Import Pytohn libs
+# Import Python libs
 from __future__ import absolute_import
 
 # Import Salt Testing libs

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -63,7 +63,7 @@ class DecoratorsTest(TestCase):
         self.messages = list()
         decorators.log = DummyLogger(self.messages)
 
-    def test_is_deprecated_lo_hi_version(self):
+    def test_is_deprecated_version_eol(self):
         '''
         Use of is_deprecated will result to the exception,
         if the expiration version is lower than the current version.
@@ -78,7 +78,7 @@ class DecoratorsTest(TestCase):
         self.assertEqual(self.messages,
                          ['The lifetime of the function "old_function" expired.'])
 
-    def test_is_deprecated_lo_hi_ver_with_successor(self):
+    def test_is_deprecated_with_successor_eol(self):
         '''
         Use of is_deprecated will result to the exception,
         if the expiration version is lower than the current version.
@@ -95,7 +95,7 @@ class DecoratorsTest(TestCase):
                          ['The lifetime of the function "old_function" expired. '
                           'Please use its successor "new_function" instead.'])
 
-    def test_is_deprecated_hi_lo_version(self):
+    def test_is_deprecated(self):
         '''
         Use of is_deprecated will result to the log message,
         if the expiration version is higher than the current version.
@@ -111,7 +111,7 @@ class DecoratorsTest(TestCase):
                          ['The function "old_function" is deprecated '
                           'and will expire in version "Beryllium".'])
 
-    def test_is_deprecated_hi_lo_version_with_successor(self):
+    def test_is_deprecated_with_successor(self):
         '''
         Use of is_deprecated will result to the log message,
         if the expiration version is higher than the current version.
@@ -128,7 +128,7 @@ class DecoratorsTest(TestCase):
                           'and will expire in version "Beryllium". '
                           'Use successor "old_function" instead.'])
 
-    def test_with_deprecated_lo_hi_ver_notfound(self):
+    def test_with_deprecated_notfound(self):
         '''
         Test with_deprecated should raise an exception, if a same name
         function with the "_" prefix not implemented.
@@ -141,7 +141,7 @@ class DecoratorsTest(TestCase):
         with self.assertRaises(CommandExecutionError):
             depr(self.new_function)()
 
-    def test_with_deprecated_lo_hi_ver_found(self):
+    def test_with_deprecated_found(self):
         '''
         Test with_deprecated should not raise an exception, if a same name
         function with the "_" prefix is implemented, but should use
@@ -159,7 +159,7 @@ class DecoratorsTest(TestCase):
                           'and will expire in version "Beryllium". '
                           'Use its successor "new_function" instead.']),
 
-    def test_with_deprecated_hi_lo_ver_found_eol(self):
+    def test_with_deprecated_found_eol(self):
         '''
         Test with_deprecated should raise an exception, if a same name
         function with the "_" prefix is implemented, "use_deprecated" is requested
@@ -174,7 +174,7 @@ class DecoratorsTest(TestCase):
         with self.assertRaises(CommandExecutionError):
             depr(self.new_function)()
 
-    def test_with_deprecated_lo_hi_ver_no_conf(self):
+    def test_with_deprecated_no_conf(self):
         '''
         Test with_deprecated should not raise an exception, if a same name
         function with the "_" prefix is implemented, but should use

--- a/tests/unit/utils/decorators_test.py
+++ b/tests/unit/utils/decorators_test.py
@@ -155,6 +155,19 @@ class DecoratorsTest(TestCase):
         depr._curr_version = self._mk_version("Helium")[1]
         self.assertEqual(depr(self.new_function)(), self.old_function())
 
+    def test_with_deprecated_lo_hi_ver_no_conf(self):
+        '''
+        Test with_deprecated should not raise an exception, if a same name
+        function with the "_" prefix is implemented, but should use
+        a new version instead, if "use_deprecated" is not requested.
+
+        :return:
+        '''
+        self.globs['_new_function'] = self.old_function
+        depr = decorators.with_deprecated(self.globs, "Beryllium")
+        depr._curr_version = self._mk_version("Helium")[1]
+        self.assertEqual(depr(self.new_function)(), self.new_function())
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?

Allows to deprecate any function with just a decorator, following a simple usage process. The process consists of two decorators: [`is_deprecated`](https://github.com/saltstack/salt/pull/32068/files#diff-7bd4f0af6512326b8c5a14e4ecb70b40R329) and [`with_deprecated`](https://github.com/saltstack/salt/pull/32068/files#diff-7bd4f0af6512326b8c5a14e4ecb70b40R425). For example, if there is a need to rewrite a function with a different output, but an old content is still required to keep around with the same function signature, do the following:

``` python
from salt.decorators import with_deprecated

@with_deprecated(globals(), "Boron")
def foo():
    """
    This is brand new function.
    """
    return {"data": "New content", "error": None}

def _foo():
    """
    This is an old function that does not know how to return an error code.
    """
    return "Old content"
```

Users, who are heavily using `foo()` function and still require an old output (because of the API etc) still can enjoy an old version of it. For this, they should add the following entry to the `/etc/salt/<minion|master|proxy>` config file:

``` yaml
use_deprecated:
  - mymodule.foo
```

In this case Master or Minion or Proxy will switch to the older version of `mymodule.foo`.

This PR also contains [an example of deprecated `state.uptime` function](https://github.com/saltstack/salt/pull/32068/files#diff-863fe796699698f25dd05040797759a9R129) with a complete rewrite of it that does the same, but is nicely parse-able when used via the API.
### What issues does this PR fix or reference?
- There is a need to deprecate a function, replacing its content but keeping its name and/or signature
- Put to the log a warning that a deprecated function is in use
- Roll-back to the deprecated _version_ of the replaced function, where its name is the same, while _content_ is different.
- Block further usage of the deprecated function, when its EOL is reached but function is still there for various reasons.
### Tests written?

[Yes!](https://github.com/isbm/salt/blob/isbm-deprecation-process/tests/unit/utils/decorators_test.py)
