### PR TITLE
Windows: Correctly handle time.sleep IOError exception

### DIFF
--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -392,6 +392,12 @@ class ProcessManager(object):
             # OSError is raised if a signal handler is called (SIGTERM) during os.wait
             except OSError:
                 break
+            except IOError as exc:
+                # IOError with errno of EINTR (4) may be raised
+                # when using time.sleep() on Windows.
+                if exc.errno != errno.EINTR:
+                    raise
+                break
 
     def check_children(self):
         '''


### PR DESCRIPTION
### What does this PR do?

`ProcessManager.run()` uses `time.sleep()` on Windows. When
the process exits on Windows, sometimes we see a call stack
that looks like this:

```
IOError: [Errno 4] Interrupted function call
Traceback (most recent call last):
  File "... \bin\Scripts\salt-master", line 22, in
    salt_master()
  File "... \site-packages\salt\scripts.py", line 47, in salt_master
    master.start()
  File "... \site-packages\salt\cli\daemons.py", line 157, in start
    self.master.start()
  File "... \site-packages\salt\master.py", line 557, in start
    process_manager.run()
  File "... \site-packages\salt\utils\process.py", line 301, in run
    time.sleep(10)
IOError: [Errno 4] Interrupted function call
```

It seems that `time.sleep()` on Windows can throw an `IOError`
exception with an errno of `EINTR` (4). We now cleanly handle this
case to avoid this being logged as an error.
### What issues does this PR fix or reference?
### Previous Behavior

Remove this section if not relevant
### New Behavior

Remove this section if not relevant
### Tests written?

No

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
