### PR TITLE
Skipped test if zeromq is not transport

### DIFF
--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -17,6 +17,11 @@ import integration
 from salt import client
 from salt.exceptions import EauthAuthenticationError, SaltInvocationError, SaltClientError
 
+if integration.SaltClientTestCaseMixIn().get_config('minion')['transport'] != 'zeromq':
+    NOT_ZMQ = True
+else:
+    NOT_ZMQ = False
+
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class LocalClientTestCase(TestCase,
@@ -60,6 +65,7 @@ class LocalClientTestCase(TestCase,
                                                 kwarg=None, expr_form='list',
                                                 ret=['first.func', 'second.func'])
 
+    @skipIf(NOT_ZMQ, 'This test only works with ZeroMQ')
     def test_pub(self):
         # Make sure we cleanly return if the publisher isn't running
         with patch('os.path.exists', return_value=False):


### PR DESCRIPTION
### What does this PR do?

Skips a transport test if the transport is not ZMQ. 
### What issues does this PR fix or reference?

Fixes issue where the test was hanging the test suite until it timed out. 

No
