### PR TITLE
Fix code for proto args in modules.iptables

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -195,22 +195,12 @@ def build_rule(table='filter', chain=None, command=None, position='', full=None,
         rule.append('{0}-o {1}'.format(maybe_add_negation('of'), kwargs['of']))
         del kwargs['of']
 
-    if 'protocol' in kwargs:
-        proto = kwargs['protocol']
-        proto_negation = maybe_add_negation('protocol')
-        del kwargs['protocol']
-    elif 'proto' in kwargs:
-        proto = kwargs['proto']
-        proto_negation = maybe_add_negation('proto')
-        del kwargs['proto']
-
-    if proto:
-        if proto.startswith('!') or proto.startswith('not'):
-            proto = re.sub(bang_not_pat, '', proto)
-            rule += '! '
-
-        rule.append('{0}-p {1}'.format(proto_negation, proto))
-        proto = True
+    for proto_arg in ('protocol', 'proto'):
+        if proto_arg in kwargs:
+            if not proto:
+                rule.append('{0}-p {1}'.format(maybe_add_negation(proto_arg), kwargs[proto_arg]))
+                proto = True
+            del kwargs[proto_arg]
 
     if 'match' in kwargs:
         match_value = kwargs['match']


### PR DESCRIPTION
### What does this PR do?

In `modules.iptables.build_rule`:
  Fix incorrect output when providing `proto='!tcp'`
  Make salt cleverer when both `protocol` and `proto` in kwargs.    
### What issues does this PR fix or reference?

None found
### Previous Behavior

```
# salt-call --local iptables.build_rule proto='!tcp'
local:
    !   ! -p tcp
# salt-call --local iptables.build_rule proto='tcp' protocol='udp'
local:
    -p udp  --proto tcp
```
### New Behavior

```
# salt-call --local iptables.build_rule proto='!tcp'
local:
    ! -p tcp
# salt-call --local iptables.build_rule proto='tcp' protocol='udp'
local:
    -p udp
```
### Tests written?

No
