### PR TITLE
Summary:Correct a small defect in doc of salt/modules/nova.py

### DIFF
--- a/salt/modules/nova.py
+++ b/salt/modules/nova.py
@@ -12,7 +12,7 @@ Module for handling OpenStack Nova calls
         keystone.tenant: admin
         keystone.auth_url: 'http://127.0.0.1:5000/v2.0/'
         # Optional
-        keystone.region_name: 'regionOne'
+        keystone.region_name: 'RegionOne'
 
     If configuration for multiple OpenStack accounts is required, they can be
     set up as different configuration profiles:


### PR DESCRIPTION
As we all know keystone.region_name is an optional configuration. But if you config it as doc suggests, salt will throw SaltCloudSystemExit from get_entry in salt/utils/openstack/nova.py. Owing to that RegionOne is a default region name in keystone. Therefore, it should set keystone.region_name as RegionOne in doc of nova.py. I think it will helpful for people who don't understand of openstack :)
