### PR TITLE
Fix issue #32077

### DIFF
--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -51,6 +51,7 @@ from __future__ import absolute_import
 import json
 
 # Import Salt libs
+import salt.utils
 import salt.utils.jid
 import salt.returners
 
@@ -78,6 +79,13 @@ def _get_options(ret=None):
     attrs = {'host': 'host',
              'port': 'port',
              'db': 'db'}
+
+    if salt.utils.is_proxy():
+        return {
+            'host': __opts__.get('redis.host', 'salt'),
+            'port': __opts__.get('redis.port', 6379),
+            'db': __opts__.get('redis.db', '0')
+        }
 
     _options = salt.returners.get_returner_options(__virtualname__,
                                                    ret,


### PR DESCRIPTION
### What does this PR do?

Potential solution for #32077
### Previous Behavior

Connection details for redis returner not available when called through a proxy minion.
### New Behavior

Connection details retrieved directly from `__opts__`
### Tests written?

No
