### PR TITLE
RPM epoch is not part of the pakage name

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1309,7 +1309,14 @@ def install(name=None,
                         arch = '.' + archpart
                         pkgname = namepart
 
-                pkgstr = '{0}-{1}{2}'.format(pkgname, version_num, arch)
+                # epoch is not part of the pakage name
+                if HAS_RPMUTILS:
+                    epoch, version_str, release = rpmUtils.miscutils.stringToVersion(version_num)
+                    if release:
+                        version_str += '-{0}'.format(release)
+                    pkgstr = '"{0}-{1}{2}"'.format(pkgname, version_str, arch)
+                else:
+                    pkgstr = '"{0}-{1}{2}"'.format(pkgname, version_num, arch)
             else:
                 pkgstr = pkgpath
 


### PR DESCRIPTION
### What does this PR do?

Fixes a bug related to RPM epoch
### What issues does this PR fix or reference?
### Previous Behavior

If the epoch was set, it was used as part of the package name. For example, in case for package X, epoch=1, version=2.3.4 and release=9; it was trying to install `X-1:2.3.4-9` instead of `X-2.3.4-9`
### New Behavior

It ignores the epoch when constructing the package name
### Tests written?

No
