### PR TITLE
Fixed invalid deploy_scripts_search_path

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -1851,7 +1851,6 @@ def cloud_config(path, env_var='SALT_CLOUD_CONFIG', defaults=None,
         os.path.abspath(
             os.path.join(
                 os.path.dirname(__file__),
-                '..',
                 'cloud',
                 'deploy'
             )


### PR DESCRIPTION
### What does this PR do?

This fixes an issue where the `deploy_scripts_search_path` was invalidly being set to `site-packages/cloud/deploy` instead of `site-packages/salt/cloud/deploy`.
### What issues does this PR fix or reference?

None
### Previous Behavior

Salt-cloud couldn't find the default bootstrap scripts and would fail silently
### New Behavior

Salt-cloud works again with the default bootstrap scripts
### Tests written?

No
