### PR TITLE
Add mac_desktop integration tests

### DIFF
--- a/tests/integration/modules/mac_desktop.py
+++ b/tests/integration/modules/mac_desktop.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+'''
+Integration tests for the mac_desktop execution module.
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+import os
+
+# Import Salt Testing Libs
+from salttesting import skipIf
+from salttesting.helpers import (
+    destructiveTest,
+    ensure_in_syspath,
+    requires_system_grains
+)
+
+ensure_in_syspath('../../')
+
+# Import Salt Libs
+import integration
+
+
+@skipIf(os.geteuid() != 0, 'You must be logged in as root to run this test')
+class MacDesktopTestCase(integration.ModuleCase):
+    '''
+    Integration tests for the mac_desktop module.
+    '''
+
+    def setUp(self):
+        '''
+        Sets up test requirements.
+        '''
+        os_grain = self.run_function('grains.item', ['kernel'])
+        if os_grain['kernel'] not in 'Darwin':
+            self.skipTest(
+                'Test not applicable to \'{kernel}\' kernel'.format(
+                    **os_grain
+                )
+            )
+
+    @requires_system_grains
+    def test_get_output_volume(self, grains=None):
+        '''
+        Tests the return of get_output_volume.
+        '''
+        ret = self.run_function('desktop.get_output_volume')
+        self.assertIsNotNone(ret)
+
+    @destructiveTest
+    @requires_system_grains
+    def test_set_output_volume(self, grains=None):
+        '''
+        Tests the return of set_output_volume.
+        '''
+        current_vol = self.run_function('desktop.get_output_volume')
+        to_set = 10
+        if current_vol == str(to_set):
+            to_set += 2
+        new_vol = self.run_function('desktop.set_output_volume', [str(to_set)])
+        check_vol = self.run_function('desktop.get_output_volume')
+        self.assertEqual(new_vol, check_vol)
+
+        # Set volume back to what it was before
+        self.run_function('desktop.set_output_volume', [current_vol])
+
+    @destructiveTest
+    @requires_system_grains
+    def test_screensaver(self, grains=None):
+        '''
+        Tests the return of the screensaver function.
+        '''
+        self.assertTrue(
+            self.run_function('desktop.screensaver')
+        )
+
+    @destructiveTest
+    @requires_system_grains
+    def test_lock(self, grains=None):
+        '''
+        Tests the return of the lock function.
+        '''
+        self.assertTrue(
+            self.run_function('desktop.lock')
+        )
+
+    @destructiveTest
+    @requires_system_grains
+    def test_say(self, grains=None):
+        '''
+        Tests the return of the say function.
+        '''
+        self.assertTrue(
+            self.run_function('desktop.say', ['hello', 'world'])
+        )
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(MacDesktopTestCase)

--- a/tests/unit/modules/mac_desktop_test.py
+++ b/tests/unit/modules/mac_desktop_test.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
 '''
-    :codeauthor: :email:`Jayesh Kariya <jayeshk@saltstack.com>`
+Unit Tests for the mac_desktop execution module.
 '''
 
 # Import Python Libs
 from __future__ import absolute_import
-
-# Import Salt Libs
-from salt.modules import mac_desktop
 
 # Import Salt Testing Libs
 from salttesting import TestCase, skipIf
@@ -17,10 +14,13 @@ from salttesting.mock import (
     NO_MOCK,
     NO_MOCK_REASON
 )
-
 from salttesting.helpers import ensure_in_syspath
 
 ensure_in_syspath('../../')
+
+# Import Salt Libs
+from salt.modules import mac_desktop
+from salt.exceptions import CommandExecutionError
 
 # Globals
 mac_desktop.__salt__ = {}
@@ -31,55 +31,103 @@ class MacDesktopTestCase(TestCase):
     '''
     Test cases for salt.modules.mac_desktop
     '''
-    # 'get_output_volume' function tests: 1
+    # 'get_output_volume' function tests: 2
 
     def test_get_output_volume(self):
         '''
         Test if it get the output volume (range 0 to 100)
         '''
-        mock = MagicMock(return_value=True)
-        with patch.dict(mac_desktop.__salt__, {'cmd.run': mock}):
-            self.assertTrue(mac_desktop.get_output_volume())
+        mock = MagicMock(return_value={'retcode': 0, 'stdout': '25'})
+        with patch.dict(mac_desktop.__salt__, {'cmd.run_all': mock}):
+            self.assertEqual(mac_desktop.get_output_volume(), '25')
 
-    # 'set_output_volume' function tests: 1
+    def test_get_output_volume_error(self):
+        '''
+        Tests that an error is raised when cmd.run_all errors
+        '''
+        mock = MagicMock(return_value={'retcode': 1})
+        with patch.dict(mac_desktop.__salt__, {'cmd.run_all': mock}):
+            self.assertRaises(CommandExecutionError,
+                              mac_desktop.get_output_volume)
 
+    # 'set_output_volume' function tests: 2
+
+    @patch('salt.modules.mac_desktop.get_output_volume',
+           MagicMock(return_value='25'))
     def test_set_output_volume(self):
         '''
         Test if it set the volume of sound (range 0 to 100)
         '''
-        mock = MagicMock(return_value=True)
-        with patch.dict(mac_desktop.__salt__, {'cmd.run': mock}):
-            self.assertTrue(mac_desktop.set_output_volume('my-volume'))
+        mock = MagicMock(return_value={'retcode': 0})
+        with patch.dict(mac_desktop.__salt__, {'cmd.run_all': mock}):
+            self.assertTrue(mac_desktop.set_output_volume('25'))
 
-    # 'screensaver' function tests: 1
+    def test_set_output_volume_error(self):
+        '''
+        Tests that an error is raised when cmd.run_all errors
+        '''
+        mock = MagicMock(return_value={'retcode': 1})
+        with patch.dict(mac_desktop.__salt__, {'cmd.run_all': mock}):
+            self.assertRaises(CommandExecutionError,
+                              mac_desktop.set_output_volume,
+                              '25')
+
+    # 'screensaver' function tests: 2
 
     def test_screensaver(self):
         '''
         Test if it launch the screensaver
         '''
-        mock = MagicMock(return_value=True)
-        with patch.dict(mac_desktop.__salt__, {'cmd.run': mock}):
+        mock = MagicMock(return_value={'retcode': 0})
+        with patch.dict(mac_desktop.__salt__, {'cmd.run_all': mock}):
             self.assertTrue(mac_desktop.screensaver())
 
-    # 'lock' function tests: 1
+    def test_screensaver_error(self):
+        '''
+        Tests that an error is raised when cmd.run_all errors
+        '''
+        mock = MagicMock(return_value={'retcode': 1})
+        with patch.dict(mac_desktop.__salt__, {'cmd.run_all': mock}):
+            self.assertRaises(CommandExecutionError,
+                              mac_desktop.screensaver)
+
+    # 'lock' function tests: 2
 
     def test_lock(self):
         '''
         Test if it lock the desktop session
         '''
-        mock = MagicMock(return_value=True)
-        with patch.dict(mac_desktop.__salt__, {'cmd.run': mock}):
+        mock = MagicMock(return_value={'retcode': 0})
+        with patch.dict(mac_desktop.__salt__, {'cmd.run_all': mock}):
             self.assertTrue(mac_desktop.lock())
 
-    # 'say' function tests: 1
+    def test_lock_error(self):
+        '''
+        Tests that an error is raised when cmd.run_all errors
+        '''
+        mock = MagicMock(return_value={'retcode': 1})
+        with patch.dict(mac_desktop.__salt__, {'cmd.run_all': mock}):
+            self.assertRaises(CommandExecutionError,
+                              mac_desktop.lock)
+
+    # 'say' function tests: 2
 
     def test_say(self):
         '''
         Test if it says some words.
         '''
-        mock = MagicMock(return_value=True)
-        with patch.dict(mac_desktop.__salt__, {'cmd.run': mock}):
+        mock = MagicMock(return_value={'retcode': 0})
+        with patch.dict(mac_desktop.__salt__, {'cmd.run_all': mock}):
             self.assertTrue(mac_desktop.say())
+
+    def test_say_error(self):
+        '''
+        Tests that an error is raised when cmd.run_all errors
+        '''
+        mock = MagicMock(return_value={'retcode': 1})
+        with patch.dict(mac_desktop.__salt__, {'cmd.run_all': mock}):
+            self.assertRaises(CommandExecutionError,
+                              mac_desktop.say)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?
- Updates mac_desktop module to use cmd.run_all
- Updates current mac_desktop_test unit tests with cmd.run_all change
- Adds integration tests for mac_desktop execution module
### Previous Behavior

The mac_desktop module used a lot of `cmd.run` calls. Since `cmd.run` was changed to `cmd.run_all`, that necessitated a change to the unit tests that were already present.
### New Behavior

This PR updates any of those calls to `cmd.run_all`, so we can gather the stderr/stdout as necessary if something goes wrong with the underlying commands and handle them as needed.
### Tests written?

Yes
