### PR TITLE
fix for no grains in salt-ssh

### DIFF
--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -199,7 +199,7 @@ class Shell(object):
         Execute ssh-copy-id to plant the id file on the target
         '''
         stdout, stderr, retcode = self._run_cmd(self._copy_id_str_old())
-        if salt.defaults.exitcodes.EX_OK != retcode and stderr.startswith('Usage'):
+        if salt.defaults.exitcodes.EX_OK != retcode and 'Usage' in stderr:
             stdout, stderr, retcode = self._run_cmd(self._copy_id_str_new())
         return stdout, stderr, retcode
 

--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -144,7 +144,7 @@ def prep_trans_tar(file_client, chunks, file_refs, pillar=None, id_=None):
         fp_.write(json.dumps(chunks))
     if pillar:
         with salt.utils.fopen(pillarfn, 'w+') as fp_:
-            fp_.write(json.dumps(pillar._dict()))
+            fp_.write(json.dumps(pillar))
     cachedir = os.path.join('salt-ssh', id_)
     for saltenv in file_refs:
         file_refs[saltenv].extend(sync_refs)

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -551,7 +551,12 @@ def ssh_wrapper(opts, functions=None, context=None):
         ),
         opts,
         tag='wrapper',
-        pack={'__salt__': functions, '__context__': context},
+        pack={
+            '__salt__': functions,
+            '__grains__': opts.get('grains', {}),
+            '__pillar__': opts.get('pillar', {}),
+            '__context__': context,
+            },
     )
 
 

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -555,7 +555,7 @@ def ssh_wrapper(opts, functions=None, context=None):
             '__salt__': functions,
             '__grains__': opts.get('grains', {}),
             '__pillar__': opts.get('pillar', {}),
-            '__context__': context,
+            #'__context__': context,
             },
     )
 

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -555,7 +555,7 @@ def ssh_wrapper(opts, functions=None, context=None):
             '__salt__': functions,
             '__grains__': opts.get('grains', {}),
             '__pillar__': opts.get('pillar', {}),
-            #'__context__': context,
+            '__context__': context,
             },
     )
 

--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -18,6 +18,7 @@ import subprocess
 # Import third party libs
 import jinja2
 import yaml
+import msgpack
 import salt.ext.six as six
 import tornado
 
@@ -108,6 +109,7 @@ def get_tops(extra_mods='', so_mods=''):
             os.path.dirname(jinja2.__file__),
             os.path.dirname(yaml.__file__),
             os.path.dirname(tornado.__file__),
+            os.path.dirname(msgpack.__file__),
             ]
 
     tops.append(six.__file__.replace('.pyc', '.py'))

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1245,7 +1245,7 @@ class ShellCase(AdaptedConfigurationTestCaseMixIn, ShellTestCase):
         '''
         Execute salt-ssh
         '''
-        arg_str = '-c {0} -i --priv {1} --roster-file {2} --out=json localhost {3}'.format(self.get_config_dir(), os.path.join(TMP_CONF_DIR, 'key_test'), os.path.join(TMP_CONF_DIR, 'roster'), arg_str)
+        arg_str = '-W -c {0} -i --priv {1} --roster-file {2} --out=json localhost {3}'.format(self.get_config_dir(), os.path.join(TMP_CONF_DIR, 'key_test'), os.path.join(TMP_CONF_DIR, 'roster'), arg_str)
         return self.run_script('salt-ssh', arg_str, with_retcode=with_retcode, catch_stderr=catch_stderr, raw=True)
 
     def run_run(self, arg_str, with_retcode=False, catch_stderr=False, async=False, timeout=60):


### PR DESCRIPTION
### What does this PR do?

Fixes missing grains and pillar in salt-ssh due to the context dict in the loader, also adds msgpack to the thin
### What issues does this PR fix or reference?
### Previous Behavior

Remove this section if not relevant
### New Behavior

Remove this section if not relevant
### Tests written?

Yes/No
