### PR TITLE
Obtain default value of `memory_swap` from the container.

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -400,7 +400,7 @@ VALID_CREATE_OPTS = {
     'memory_swap': {
         'api_name': 'memswap_limit',
         'path': 'HostConfig:MemorySwap',
-        'default': 0,
+        'get_default_from_container': True,
     },
     'mac_address': {
         'validator': 'string',


### PR DESCRIPTION
### What does this PR do?

changes the way we obtain default value for memory_swap parameter. Because dockerd defines this value on behalf of user.
### What issues does this PR fix or reference?
#32033
### Previous Behavior

The default `0` is not always relevant.  if `memory`parameter is defined `memory_swap` reports something else than `0`, even if user didn't specify `memory_swap`.
### Tests written?

No
