### PR TITLE
fixes issue #32075

### DIFF
--- a/salt/states/x509.py
+++ b/salt/states/x509.py
@@ -169,7 +169,6 @@ import salt.utils
 # Import 3rd-party libs
 import salt.ext.six as six
 
-
 def __virtual__():
     '''
     only load this module if the corresponding execution module is loaded
@@ -426,7 +425,7 @@ def certificate_managed(name,
     if 'ca_server' in kwargs and 'signing_policy' not in kwargs:
         raise salt.exceptions.SaltInvocationError('signing_policy must be specified if ca_server is.')
 
-    new = __salt__['x509.create_certificate'](testrun=True, **kwargs)
+    new = __salt__['x509.create_certificate'](**kwargs)
 
     if isinstance(new, dict):
         new_comp = copy.deepcopy(new)
@@ -469,7 +468,9 @@ def certificate_managed(name,
         bkroot = os.path.join(__opts__['cachedir'], 'file_backup')
         salt.utils.backup_minion(name, bkroot)
 
-    ret['comment'] = __salt__['x509.create_certificate'](path=name, **kwargs)
+    if 'path' not in kwargs:
+        kwargs['path'] = name
+    ret['comment'] = __salt__['x509.create_certificate'](**kwargs)
     ret['result'] = True
 
     return ret

--- a/salt/states/x509.py
+++ b/salt/states/x509.py
@@ -169,6 +169,7 @@ import salt.utils
 # Import 3rd-party libs
 import salt.ext.six as six
 
+
 def __virtual__():
     '''
     only load this module if the corresponding execution module is loaded


### PR DESCRIPTION
### What does this PR do?

Fixes remote signing of certificates
### What issues does this PR fix or reference?
#32075
### Previous Behavior

Signing failed with exception
### New Behavior

Signs the certificate
### Tests written?

No
### Affected branches
- 2015.8
- 2016.3
- develop
### Patch file

Forward merging from 2015.8 gives conflicts, this patch applies cleanly to 2016.3 and develop also.

``` patch
--- x509.py     2016-03-24 10:22:41.852109162 +0100
+++ x509.py.fix 2016-03-24 10:22:32.741078941 +0100
@@ -426,7 +425,7 @@
     if 'ca_server' in kwargs and 'signing_policy' not in kwargs:
         raise salt.exceptions.SaltInvocationError('signing_policy must be specified if ca_server is.')

-    new = __salt__['x509.create_certificate'](testrun=True, **kwargs)
+    new = __salt__['x509.create_certificate'](**kwargs)

     if isinstance(new, dict):
         new_comp = copy.deepcopy(new)
@@ -469,7 +468,9 @@
         bkroot = os.path.join(__opts__['cachedir'], 'file_backup')
         salt.utils.backup_minion(name, bkroot)

-    ret['comment'] = __salt__['x509.create_certificate'](path=name, **kwargs)
+    if 'path' not in kwargs:
+        kwargs['path'] = name
+    ret['comment'] = __salt__['x509.create_certificate'](**kwargs)
     ret['result'] = True

     return ret

```
