### PR TITLE
firewalld state/module : add runtime and persist + add rich_rules + merge bind and present

### DIFF
--- a/salt/states/firewalld.py
+++ b/salt/states/firewalld.py
@@ -7,12 +7,15 @@ Management of firewalld
 The following example applies changes to the public zone, blocks echo-reply
 and echo-request packets, does not set the zone to be the default, enables
 masquerading, and allows ports 22/tcp and 25/tcp.
+It will be applied permanently and directly before restart/reload.
 
 .. code-block:: yaml
 
     public:
       firewalld.present:
         - name: public
+        - runtime: True
+        - persist: True
         - block_icmp:
           - echo-reply
           - echo-request
@@ -43,7 +46,7 @@ from all other interfaces or sources.
 .. code-block:: yaml
 
   public:
-    firewalld.bind:
+    firewalld.present:
       - name: public
       - interfaces:
         - eth0
@@ -69,7 +72,7 @@ def __virtual__():
     if salt.utils.which('firewall-cmd'):
         return True
 
-    return False
+    return (False, 'firewall-cmd is not available, firewalld is probably not installed.')
 
 
 def present(name,
@@ -78,7 +81,60 @@ def present(name,
             masquerade=False,
             ports=None,
             port_fwd=None,
-            services=None):
+            services=None,
+            interfaces=None,
+            sources=None,
+            rich_rules=None,
+            runtime=True,
+            persist=True):
+
+    '''
+    Ensure a zone has specific attributes.
+    '''
+
+    ret = {'name': name,
+           'result': False,
+           'changes': {},
+           'comment': ''}
+
+    if runtime:
+        ret_runtime = _present(name, False, block_icmp, default, masquerade, ports,
+                               port_fwd, services, interfaces, sources, rich_rules)
+
+        ret['changes'].update(ret_runtime['changes'])
+
+    if persist:
+        ret_persist = _present(name, True, block_icmp, default, masquerade, ports,
+                               port_fwd, services, interfaces, sources, rich_rules)
+
+        for k, v in ret_persist['changes'].items():
+            ret['changes'].update({k + "_permanent": v})
+
+    ret['result'] = True
+    if ret['changes'] == {}:
+        ret['comment'] = '\'{0}\' is already in the desired state.'.format(name)
+        return ret
+
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Configuration for \'{0}\' will change.'.format(name)
+        return ret
+
+    ret['comment'] = '\'{0}\' was configured.'.format(name)
+    return ret
+
+
+def _present(name,
+            permanent,
+            block_icmp=None,
+            default=None,
+            masquerade=False,
+            ports=None,
+            port_fwd=None,
+            services=None,
+            interfaces=None,
+            sources=None,
+            rich_rules=None):
     '''
     Ensure a zone has specific attributes.
     '''
@@ -88,7 +144,7 @@ def present(name,
            'comment': ''}
 
     try:
-        zones = __salt__['firewalld.get_zones']()
+        zones = __salt__['firewalld.get_zones'](permanent)
     except CommandExecutionError as err:
         ret['comment'] = 'Error: {0}'.format(err)
         return ret
@@ -105,32 +161,45 @@ def present(name,
                               {'old': zones,
                                'new': name}})
 
-    if block_icmp:
-        new_icmp_types = []
-        try:
-            _valid_icmp_types = __salt__['firewalld.get_icmp_types']()
-            _current_icmp_blocks = __salt__['firewalld.list_icmp_block'](name)
-        except CommandExecutionError as err:
-            ret['comment'] = 'Error: {0}'.format(err)
-            return ret
+    block_icmp = block_icmp or []
+    new_icmp_types = []
+    old_icmp_types = []
+    try:
+        _valid_icmp_types = __salt__['firewalld.get_icmp_types'](permanent)
+        _current_icmp_blocks = __salt__['firewalld.list_icmp_block'](name, permanent)
+    except CommandExecutionError as err:
+        ret['comment'] = 'Error: {0}'.format(err)
+        return ret
 
-        for icmp_type in set(block_icmp):
-            if icmp_type in _valid_icmp_types:
-                if icmp_type not in _current_icmp_blocks:
-                    new_icmp_types.append(icmp_type)
-                    if not __opts__['test']:
-                        try:
-                            __salt__['firewalld.block_icmp'](name, icmp_type)
-                        except CommandExecutionError as err:
-                            ret['comment'] = 'Error: {0}'.format(err)
-                            return ret
-            else:
-                log.error('{0} is an invalid ICMP type'.format(icmp_type))
-        if new_icmp_types:
-            ret['changes'].update({'icmp_blocks':
-                                  {'old': _current_icmp_blocks,
-                                   'new': new_icmp_types}})
+    for icmp_type in set(block_icmp):
+        if icmp_type in _valid_icmp_types:
+            if icmp_type not in _current_icmp_blocks:
+                new_icmp_types.append(icmp_type)
+                if not __opts__['test']:
+                    try:
+                        __salt__['firewalld.block_icmp'](name, icmp_type, permanent)
+                    except CommandExecutionError as err:
+                        ret['comment'] = 'Error: {0}'.format(err)
+                        return ret
+        else:
+            log.error('{0} is an invalid ICMP type'.format(icmp_type))
 
+    for icmp_type in _current_icmp_blocks:
+        if icmp_type not in set(block_icmp):
+            old_icmp_types.append(icmp_type)
+            if not __opts__['test']:
+                try:
+                    __salt__['firewalld.allow_icmp'](name, icmp_type, permanent)
+                except CommandExecutionError as err:
+                    ret['comment'] = 'Error: {0}'.format(err)
+                    return ret
+
+    if new_icmp_types or old_icmp_types:
+        ret['changes'].update({'icmp_types':
+                                {'old': _current_icmp_blocks,
+                                'new': block_icmp}})
+
+    # that's the only parameter that can't be permanent or runtime, it's directly both
     if default:
         try:
             default_zone = __salt__['firewalld.default_zone']()
@@ -148,16 +217,17 @@ def present(name,
                                   {'old': default_zone,
                                    'new': name}})
 
+    masquerade = masquerade or False
     if masquerade:
         try:
-            masquerade_ret = __salt__['firewalld.get_masquerade'](name)
+            masquerade_ret = __salt__['firewalld.get_masquerade'](name, permanent)
         except CommandExecutionError as err:
             ret['comment'] = 'Error: {0}'.format(err)
             return ret
         if not masquerade_ret:
             if not __opts__['test']:
                 try:
-                    __salt__['firewalld.add_masquerade'](name)
+                    __salt__['firewalld.add_masquerade'](name, permanent)
                 except CommandExecutionError as err:
                     ret['comment'] = 'Error: {0}'.format(err)
                     return ret
@@ -165,132 +235,153 @@ def present(name,
                                   {'old': '',
                                    'new': 'Masquerading successfully set.'}})
 
-    if ports:
-        new_ports = []
+    if not masquerade:
         try:
-            _current_ports = __salt__['firewalld.list_ports'](name)
+            masquerade_ret = __salt__['firewalld.get_masquerade'](name, permanent)
         except CommandExecutionError as err:
             ret['comment'] = 'Error: {0}'.format(err)
             return ret
-        for port in ports:
-            if port not in _current_ports:
-                new_ports.append(port)
-                if not __opts__['test']:
-                    try:
-                        __salt__['firewalld.add_port'](name, port)
-                    except CommandExecutionError as err:
-                        ret['comment'] = 'Error: {0}'.format(err)
-                        return ret
-        if new_ports:
-            ret['changes'].update({'ports':
-                                  {'old': _current_ports,
-                                   'new': new_ports}})
+        if masquerade_ret:
+            if not __opts__['test']:
+                try:
+                    __salt__['firewalld.remove_masquerade'](name, permanent)
+                except CommandExecutionError as err:
+                    ret['comment'] = 'Error: {0}'.format(err)
+                    return ret
+            ret['changes'].update({'masquerade':
+                                  {'old': '',
+                                   'new': 'Masquerading successfully disabled.'}})
 
-    if port_fwd:
-        new_port_fwds = []
-        try:
-            _current_port_fwd = __salt__['firewalld.list_port_fwd'](name)
-        except CommandExecutionError as err:
-            ret['comment'] = 'Error: {0}'.format(err)
-            return ret
-
-        for port in port_fwd:
-            dstaddr = ''
-            rule_exists = False
-
-            if len(port.split(':')) > 3:
-                (src, dest, protocol, dstaddr) = port.split(':')
-            else:
-                (src, dest, protocol) = port.split(':')
-
-            for item in _current_port_fwd:
-                if (src == item['Source port'] and dest == item['Destination port'] and
-                        protocol == item['Protocol'] and dstaddr == item['Destination address']):
-                    rule_exists = True
-
-            if rule_exists is False:
-                new_port_fwds.append(port)
-                if not __opts__['test']:
-                    try:
-                        __salt__['firewalld.add_port_fwd'](name, src, dest, protocol, dstaddr)
-                    except CommandExecutionError as err:
-                        ret['comment'] = 'Error: {0}'.format(err)
-                        return ret
-
-        if new_port_fwds:
-            ret['changes'].update({'port_fwd':
-                                  {'old': _current_port_fwd,
-                                   'new': new_port_fwds}})
-
-    if services:
-        new_services = []
-        try:
-            _current_services = __salt__['firewalld.list_services'](name)
-        except CommandExecutionError as err:
-            ret['comment'] = 'Error: {0}'.format(err)
-            return ret
-        for service in services:
-            if service not in _current_services:
-                new_services.append(service)
-                if not __opts__['test']:
-                    try:
-                        __salt__['firewalld.add_service'](service, zone=name)
-                    except CommandExecutionError as err:
-                        ret['comment'] = 'Error: {0}'.format(err)
-                        return ret
-        if new_services:
-            ret['changes'].update({'services':
-                                  {'old': _current_services,
-                                   'new': new_services}})
-
-    ret['result'] = True
-    if ret['changes'] == {}:
-        ret['comment'] = '\'{0}\' is already in the desired state.'.format(name)
-        return ret
-
-    if __opts__['test']:
-        ret['result'] = None
-        ret['comment'] = 'Configuration for \'{0}\' will change.'.format(name)
-        return ret
-
-    ret['comment'] = '\'{0}\' was configured.'.format(name)
-    return ret
-
-
-def bind(name,
-         interfaces=None,
-         sources=None):
-    '''
-    Ensure a zone is bound to specific interfaces or sources.
-
-    .. versionadded:: 2016.3.0
-
-    .. note::
-
-        This state does not enforce the existence of the zone. To ensure that
-        the zone exists, use :mod:`firewalld.present <salt.states.firewalld.present>`.
-    '''
-    ret = {'name': name,
-           'result': False,
-           'changes': {},
-           'comment': ''}
-
+    ports = ports or []
+    new_ports = []
+    old_ports = []
     try:
-        zones = __salt__['firewalld.get_zones']()
+        _current_ports = __salt__['firewalld.list_ports'](name, permanent)
+    except CommandExecutionError as err:
+        ret['comment'] = 'Error: {0}'.format(err)
+        return ret
+    for port in ports:
+        if port not in _current_ports:
+            new_ports.append(port)
+            if not __opts__['test']:
+                try:
+                    __salt__['firewalld.add_port'](name, port, permanent)
+                except CommandExecutionError as err:
+                    ret['comment'] = 'Error: {0}'.format(err)
+                    return ret
+    for port in _current_ports:
+        if port not in ports:
+            old_ports.append(port)
+            if not __opts__['test']:
+                try:
+                    __salt__['firewalld.remove_port'](name, port, permanent)
+                except CommandExecutionError as err:
+                    ret['comment'] = 'Error: {0}'.format(err)
+                    return ret
+
+    if new_ports or old_ports:
+        ret['changes'].update({'ports':
+                                {'old': _current_ports,
+                                'new': ports}})
+
+    port_fwd = port_fwd or []
+    new_port_fwds = []
+    old_port_fwds = []
+    try:
+        _current_port_fwd = __salt__['firewalld.list_port_fwd'](name, permanent)
     except CommandExecutionError as err:
         ret['comment'] = 'Error: {0}'.format(err)
         return ret
 
-    if name not in zones:
-        ret['result'] = False
-        ret['comment'] = 'Zone {0} does not exist'.format(name)
+    for port in port_fwd:
+        dstaddr = ''
+        rule_exists = False
+
+        if len(port.split(':')) > 3:
+            (src, dest, protocol, dstaddr) = port.split(':')
+        else:
+            (src, dest, protocol) = port.split(':')
+
+        for item in _current_port_fwd:
+            if (src == item['Source port'] and dest == item['Destination port'] and
+                    protocol == item['Protocol'] and dstaddr == item['Destination address']):
+                rule_exists = True
+
+        if rule_exists is False:
+            new_port_fwds.append(port)
+            if not __opts__['test']:
+                try:
+                    __salt__['firewalld.add_port_fwd'](name, src, dest, protocol, dstaddr, permanent)
+                except CommandExecutionError as err:
+                    ret['comment'] = 'Error: {0}'.format(err)
+                    return ret
+
+    for port in _current_port_fwd:
+        dstaddr = ''
+        rule_exists = False
+
+        for item in port_fwd:
+            if len(item.split(':')) > 3:
+                (src, dest, protocol, dstaddr) = item.split(':')
+            else:
+                (src, dest, protocol) = item.split(':')
+
+            if (src == port['Source port'] and dest == port['Destination port'] and
+                    protocol == port['Protocol'] and dstaddr == port['Destination address']):
+                rule_exists = True
+
+        if rule_exists is False:
+            old_port_fwds.append(port)
+            if not __opts__['test']:
+                try:
+                    __salt__['firewalld.remove_port_fwd'](name, port['Source port'], port['Destination port'],
+                                                          port['Protocol'], port['Destination address'], permanent)
+                except CommandExecutionError as err:
+                    ret['comment'] = 'Error: {0}'.format(err)
+                    return ret
+
+    if new_port_fwds or old_port_fwds:
+        ret['changes'].update({'port_fwd':
+                                {'old': _current_port_fwd,
+                                'new': port_fwd}})
+
+    services = services or []
+    new_services = []
+    old_services = []
+    try:
+        _current_services = __salt__['firewalld.list_services'](name, permanent)
+    except CommandExecutionError as err:
+        ret['comment'] = 'Error: {0}'.format(err)
         return ret
+    for service in services:
+        if service not in _current_services:
+            new_services.append(service)
+            if not __opts__['test']:
+                try:
+                    __salt__['firewalld.add_service'](service, name, permanent)
+                except CommandExecutionError as err:
+                    ret['comment'] = 'Error: {0}'.format(err)
+                    return ret
+    for service in _current_services:
+        if service not in services:
+            old_services.append(service)
+            if not __opts__['test']:
+                try:
+                    __salt__['firewalld.remove_service'](service, name, permanent)
+                except CommandExecutionError as err:
+                    ret['comment'] = 'Error: {0}'.format(err)
+                    return ret
+
+    if new_services or old_services:
+        ret['changes'].update({'services':
+                                {'old': _current_services,
+                                'new': services}})
 
     interfaces = interfaces or []
     new_interfaces = []
     old_interfaces = []
     try:
-        _current_interfaces = __salt__['firewalld.get_interfaces'](name)
+        _current_interfaces = __salt__['firewalld.get_interfaces'](name, permanent)
     except CommandExecutionError as err:
         ret['comment'] = 'Error: {0}'.format(err)
         return ret
@@ -299,7 +390,7 @@ def bind(name,
             new_interfaces.append(interface)
             if not __opts__['test']:
                 try:
-                    __salt__['firewalld.add_interface'](name, interface)
+                    __salt__['firewalld.add_interface'](name, interface, permanent)
                 except CommandExecutionError as err:
                     ret['comment'] = 'Error: {0}'.format(err)
                     return ret
@@ -308,7 +399,7 @@ def bind(name,
             old_interfaces.append(interface)
             if not __opts__['test']:
                 try:
-                    __salt__['firewalld.remove_interface'](name, interface)
+                    __salt__['firewalld.remove_interface'](name, interface, permanent)
                 except CommandExecutionError as err:
                     ret['comment'] = 'Error: {0}'.format(err)
                     return ret
@@ -322,7 +413,7 @@ def bind(name,
     new_sources = []
     old_sources = []
     try:
-        _current_sources = __salt__['firewalld.get_sources'](name)
+        _current_sources = __salt__['firewalld.get_sources'](name, permanent)
     except CommandExecutionError as err:
         ret['comment'] = 'Error: {0}'.format(err)
         return ret
@@ -331,7 +422,7 @@ def bind(name,
             new_sources.append(source)
             if not __opts__['test']:
                 try:
-                    __salt__['firewalld.add_source'](name, source)
+                    __salt__['firewalld.add_source'](name, source, permanent)
                 except CommandExecutionError as err:
                     ret['comment'] = 'Error: {0}'.format(err)
                     return ret
@@ -340,7 +431,7 @@ def bind(name,
             old_sources.append(source)
             if not __opts__['test']:
                 try:
-                    __salt__['firewalld.remove_source'](name, source)
+                    __salt__['firewalld.remove_source'](name, source, permanent)
                 except CommandExecutionError as err:
                     ret['comment'] = 'Error: {0}'.format(err)
                     return ret
@@ -349,12 +440,36 @@ def bind(name,
                                 {'old': _current_sources,
                                 'new': sources}})
 
-    if ret['changes'] != {}:
-        try:
-            __salt__['firewalld.make_permanent']()
-        except CommandExecutionError as err:
-            ret['comment'] = 'Error: {0}'.format(err)
-            return ret
+    rich_rules = rich_rules or []
+    new_rich_rules = []
+    old_rich_rules = []
+    try:
+        _current_rich_rules = __salt__['firewalld.get_rich_rules'](name, permanent)
+    except CommandExecutionError as err:
+        ret['comment'] = 'Error: {0}'.format(err)
+        return ret
+    for rich_rule in rich_rules:
+        if rich_rule not in _current_rich_rules:
+            new_rich_rules.append(rich_rule)
+            if not __opts__['test']:
+                try:
+                    __salt__['firewalld.add_rich_rule'](name, rich_rule, permanent)
+                except CommandExecutionError as err:
+                    ret['comment'] = 'Error: {0}'.format(err)
+                    return ret
+    for rich_rule in _current_rich_rules:
+        if rich_rule not in rich_rules:
+            old_rich_rules.append(rich_rule)
+            if not __opts__['test']:
+                try:
+                    __salt__['firewalld.remove_rich_rule'](name, rich_rule, permanent)
+                except CommandExecutionError as err:
+                    ret['comment'] = 'Error: {0}'.format(err)
+                    return ret
+    if new_rich_rules or old_rich_rules:
+        ret['changes'].update({'rich_rules':
+                              {'old': _current_rich_rules,
+                               'new': rich_rules}})
 
     ret['result'] = True
     if ret['changes'] == {}:

--- a/tests/unit/modules/firewalld_test.py
+++ b/tests/unit/modules/firewalld_test.py
@@ -268,6 +268,27 @@ class FirewalldTestCase(TestCase):
         with patch.object(firewalld, '__firewall_cmd', return_value=ret):
             self.assertEqual(firewalld.list_icmp_block('zone'), exp)
 
+    def test_get_rich_rules(self):
+        '''
+        Test listing rich rules bound to a zone
+        '''
+        with patch.object(firewalld, '__firewall_cmd', return_value=''):
+            self.assertEqual(firewalld.get_rich_rules('zone'), [])
+
+    def test_add_rich_rule(self):
+        '''
+        Test adding a rich rule to a zone
+        '''
+        with patch.object(firewalld, '__firewall_cmd', return_value='success'):
+            self.assertEqual(firewalld.add_rich_rule('zone', 'rule family="ipv4" source address="1.2.3.4" accept'), 'success')
+
+    def test_remove_rich_rule(self):
+        '''
+        Test removing a rich rule to a zone
+        '''
+        with patch.object(firewalld, '__firewall_cmd', return_value='success'):
+            self.assertEqual(firewalld.remove_rich_rule('zone', 'rule family="ipv4" source address="1.2.3.4" accept'), 'success')
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(FirewalldTestCase, needs_daemon=False)


### PR DESCRIPTION
### What does this PR do? Correction/Improvement of firewalld module and state
- I add runtime and persist parameter, the base of firewalld with permanent or not
- I correct consistency of permanent parameter
- I add rich_rules parameter, to add iptables rules directly (function of firewalld)
- I removed firewalld.bind, it's now merged in present (with the consent its developer) 
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/29641
https://github.com/saltstack/salt/issues/30240
### Tests written?

No

@jfindlay
