### PR TITLE
Added InfluxDB 0.9+ support to the influxdb_return.py class

### DIFF
--- a/salt/returners/influxdb_return.py
+++ b/salt/returners/influxdb_return.py
@@ -127,7 +127,7 @@ def _get_serv(ret=None):
     user = _options.get('user')
     password = _options.get('password')
     version = _get_version(host, port, user, password)
-    
+
     if version and "v0.8" in version:
         return influxdb.influxdb08.InfluxDBClient(host=host,
                             port=port,
@@ -149,12 +149,12 @@ def returner(ret):
     Return data to a influxdb data store
     '''
     serv = _get_serv(ret)
-    
+
     # strip the 'return' key to avoid data duplication in the database
     json_return = json.dumps(ret['return'])
     del ret['return']
     json_full_ret = json.dumps(ret)
-    
+
     # create legacy request in case an InfluxDB 0.8.x version is used
     if "influxdb08" in serv.__module__:
         req = [
@@ -194,7 +194,7 @@ def save_load(jid, load):
     Save the load to the specified jid
     '''
     serv = _get_serv(ret=None)
-    
+
     # create legacy request in case an InfluxDB 0.8.x version is used
     if "influxdb08" in serv.__module__:
         req = [

--- a/salt/returners/influxdb_return.py
+++ b/salt/returners/influxdb_return.py
@@ -62,7 +62,7 @@ import salt.returners
 
 # Import third party libs
 try:
-    from influxdb.influxdb08 import InfluxDBClient
+    from influxdb import InfluxDBClient
     HAS_INFLUXDB = True
 except ImportError:
     HAS_INFLUXDB = False
@@ -123,11 +123,14 @@ def returner(ret):
 
     req = [
             {
-                'name': 'returns',
-                'columns': ['fun', 'id', 'jid', 'return', 'full_ret'],
-                'points': [
-                    [ret['fun'], ret['id'], ret['jid'], json.dumps(ret['return']), json.dumps(ret)]
-                ],
+                'measurement': 'returns',
+                'fields': {
+                    'fun': ret['fun'],
+                    'id': ret['id'],
+                    'jid': ret['jid'],
+                    'return': json.dumps(ret['return']),
+                    'ful_ret': json.dumps(ret)
+                }
             }
         ]
 
@@ -144,11 +147,11 @@ def save_load(jid, load):
     serv = _get_serv(ret=None)
     req = [
         {
-            'name': 'jids',
-            'columns': ['jid', 'load'],
-            'points': [
-                        [jid, json.dumps(load)]
-                    ],
+            'measurement': 'jids',
+            'fields': {
+                'jid': jid,
+                'load': json.dumps(load)
+            }
         }
     ]
 


### PR DESCRIPTION
### What does this PR do?

Added InfluxDB 0.9+ support to the _influxdb_return.py_ class while maintaining compatibility with the older 0.8 InfluxDB client still offered by the latest [InfluxDB Python client](https://github.com/influxdata/influxdb-python).

To determine the InfluxDB version the _requests_ module is used to call the [/ping API endpoint](https://docs.influxdata.com/influxdb/v0.11/concepts/api/#ping) to get version from the _X-Influxdb-Version_ header field. Based on this information the matching _InfluxDBClient_ class is used.

Furthermore the _return_ key has been removed while storing the _full_ret_ value to avoid data duplication.
### What issues does this PR fix or reference?
#31504
### Tests written?

No
