### PR TITLE
Add runners to __salt__ docs

### DIFF
--- a/doc/topics/development/dunder_dictionaries.rst
+++ b/doc/topics/development/dunder_dictionaries.rst
@@ -54,6 +54,11 @@ functions to be called as they have been set up by the salt loader.
     __salt__['cmd.run']('fdisk -l')
     __salt__['network.ip_addrs']()
 
+.. note::
+
+    When used in runners, ``__salt__`` references other runner modules, and not
+    execution modules.
+
 __grains__
 ----------
 

--- a/doc/topics/development/dunder_dictionaries.rst
+++ b/doc/topics/development/dunder_dictionaries.rst
@@ -44,6 +44,7 @@ Available in
 - Execution Modules
 - State Modules
 - Returners
+- Runners
 
 ``__salt__`` contains the execution module functions. This allows for all
 functions to be called as they have been set up by the salt loader.


### PR DESCRIPTION
The `__salt__` dictionary is available in runners as noted in `loader.py` here: https://github.com/saltstack/salt/blob/c03e8757e30a471ff38f09a7413b463dcb24bc9e/salt/loader.py#L775

So we should note that in the dunder dictionary docs.
