### PR TITLE
Fix the process_test.test_kill failure in 2016.3

### DIFF
--- a/tests/unit/utils/process_test.py
+++ b/tests/unit/utils/process_test.py
@@ -59,6 +59,7 @@ class TestProcessManager(TestCase):
         process_manager.add_process(spin)
         initial_pid = next(six.iterkeys(process_manager._process_map))
         # kill the child
+        time.sleep(1)
         os.kill(initial_pid, signal.SIGTERM)
         # give the OS time to give the signal...
         time.sleep(0.1)


### PR DESCRIPTION
### What does this PR do?

Lets the test suite rest for a second to let os.kill() happen. 
### Previous Behavior

test_kill was failing because the process never got killed. 
### New Behavior

Process killed correctly
### Tests written?

Yes
