### PR TITLE
Pass eauth user/groups through salt-api to destination functions

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -759,9 +759,9 @@ class LowDataAdapter(object):
             if token:
                 chunk['token'] = token
                 if cherrypy.session.get('user'):
-                    chunk['__user__'] = cherrypy.session.get('user')
+                    chunk['__current_eauth_user'] = cherrypy.session.get('user')
                 if cherrypy.session.get('groups'):
-                    chunk['__groups__'] = cherrypy.session.get('groups')
+                    chunk['__current_eauth_groups'] = cherrypy.session.get('groups')
 
             if client:
                 chunk['client'] = client

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -758,6 +758,10 @@ class LowDataAdapter(object):
         for chunk in lowstate:
             if token:
                 chunk['token'] = token
+                if cherrypy.session.get('user'):
+                    chunk['__user__'] = cherrypy.session.get('user')
+                if cherrypy.session.get('groups'):
+                    chunk['__groups__'] = cherrypy.session.get('groups')
 
             if client:
                 chunk['client'] = client
@@ -1499,6 +1503,9 @@ class Login(LowDataAdapter):
         cherrypy.response.headers['X-Auth-Token'] = cherrypy.session.id
         cherrypy.session['token'] = token['token']
         cherrypy.session['timeout'] = (token['expire'] - token['start']) / 60
+        cherrypy.session['user'] = token['name']
+        if 'groups' in token:
+            cherrypy.session['groups'] = token['groups']
 
         # Grab eauth config for the current backend for the current user
         try:


### PR DESCRIPTION
### What does this PR do?

Passes through the salt-api eauth user/groups to the target functions. This way we can know which user authenticated to run the command, which is useful for user-specific operations, which need to be authenticated.
### What issues does this PR fix or reference?

None
### New Behavior

In salt-api, the user that auth'd will be sent in as the `__user__` kwarg. Group information from the auth will be sent in as the `__groups__` kwarg. The target function must take `**kwargs` in order to see this information.
### Tests written?

No

@whiteinge FYI
