### PR TITLE
Fix nova driver bug parsing ip address

### DIFF
--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -804,6 +804,14 @@ def create(vm_):
            'access_ip' in node.get('extra', {}):
             result = [node['extra']['access_ip']]
 
+        if not result:
+            temp_dd = node.get('addresses', {})
+            for k, addr_ll in temp_dd.iteritems():
+                for addr_dd in addr_ll:
+                    addr = addr_dd.get('addr', None)
+                    if addr is not None:
+                        result.append(addr.strip())
+
         private = node.get('private_ips', [])
         public = node.get('public_ips', [])
         if private and not public:

--- a/tests/unit/modules/boto_cloudtrail_test.py
+++ b/tests/unit/modules/boto_cloudtrail_test.py
@@ -125,7 +125,6 @@ class BotoCloudTrailTestCaseMixin(object):
     pass
 
 
-@skipIf(True, 'Skip these tests while investigating failures')
 @skipIf(HAS_BOTO is False, 'The boto module must be installed.')
 @skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
                                        ' or equal to version {0}'

--- a/tests/unit/modules/boto_iot_test.py
+++ b/tests/unit/modules/boto_iot_test.py
@@ -100,7 +100,6 @@ if _has_required_boto():
                       ruleDisabled=True)
 
 
-@skipIf(True, 'These tests are pegging the CPU and eating all available RAM')
 class BotoIoTTestCaseBase(TestCase):
     conn = None
 
@@ -126,7 +125,6 @@ class BotoIoTTestCaseMixin(object):
     pass
 
 
-@skipIf(True, 'These tests are pegging the CPU and eating all available RAM')
 @skipIf(HAS_BOTO is False, 'The boto module must be installed.')
 @skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
                                        ' or equal to version {0}'

--- a/tests/unit/modules/boto_lambda_test.py
+++ b/tests/unit/modules/boto_lambda_test.py
@@ -137,7 +137,6 @@ class BotoLambdaTestCaseMixin(object):
     pass
 
 
-@skipIf(True, 'These tests are pegging the CPU and eating all available RAM')
 @skipIf(HAS_BOTO is False, 'The boto module must be installed.')
 @skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
                                        ' or equal to version {0}'
@@ -401,7 +400,6 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         self.assertEqual(result.get('error', {}).get('message'), error_message.format('list_versions_by_function'))
 
 
-@skipIf(True, 'Skip these tests while investigating failures')
 @skipIf(HAS_BOTO is False, 'The boto module must be installed.')
 @skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
                                        ' or equal to version {0}'
@@ -542,7 +540,6 @@ class BotoLambdaAliasTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin):
         self.assertEqual(result.get('error', {}).get('message'), error_message.format('update_alias'))
 
 
-@skipIf(True, 'These tests are pegging the CPU and eating all available RAM')
 @skipIf(HAS_BOTO is False, 'The boto module must be installed.')
 @skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
                                        ' or equal to version {0}'

--- a/tests/unit/modules/boto_s3_bucket_test.py
+++ b/tests/unit/modules/boto_s3_bucket_test.py
@@ -227,7 +227,6 @@ class BotoS3BucketTestCaseMixin(object):
     pass
 
 
-@skipIf(True, 'Skip these tests while investigating failures')
 @skipIf(HAS_BOTO is False, 'The boto module must be installed.')
 @skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
                                        ' or equal to version {0}'


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in the nova.py driver that prevents it from properly parsing out IP addresses from the data structure returned from OpenStack (Kilo version, but may work on others).
### What issues does this PR fix or reference?

I could find no issues directly on point, but it may be related to issue 29666 "Nova driver broken for 2015.8.[1-3]".
### Previous Behavior

Nova driver would hang (and ultimately time out) when used with OpenStack because it could not parse IP addresses for instances.
### New Behavior

The nova driver can now parse an IP address for instances when used with OpenStack.
### Tests written?

No, although it works well with the Kilo version of OpenStack.

To test, you need to create cloud provider and profile files, then use salt-cloud to create one or more instances on OpenStack. See https://docs.saltstack.com/en/latest/topics/cloud/openstack.html
