### PR TITLE
fixes 32108

### DIFF
--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -269,11 +269,15 @@ def state(
                 fail.add(minion)
             failures[minion] = m_ret and m_ret or 'Minion did not respond'
             continue
-        for state_item in six.itervalues(m_ret):
-            if state_item['changes']:
-                changes[minion] = m_ret
-                break
-        else:
+        try:
+            for state_item in six.itervalues(m_ret):
+                if 'changes' in state_item and state_item['changes']:
+                    changes[minion] = m_ret
+                    break
+            else:
+                no_change.add(minion)
+        except AttributeError:
+            log.error("m_ret did not have changes %s %s", type(m_ret), m_ret)
             no_change.add(minion)
 
     if changes:


### PR DESCRIPTION
### What does this PR do?

Catches the case where a state returns a result that is a string indicating the state failed.
The original case was one in which the state was already running on the targeted minion.
### What issues does this PR fix or reference?

fixes issue 32108
### Previous Behavior

Result an parsing exception for the state result.
### New Behavior

Remove this section if not relevant
### Tests written?

No, But if you point me in the right direction I will.
