### PR TITLE
fixes 32109

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -798,6 +798,23 @@ class LocalClient(object):
                 raise StopIteration()
 
     # TODO: tests!!
+    def get_returns_no_block(
+            self,
+            jid,
+            tags_regex=None
+            ):
+        '''
+        Raw function to just return events of jid excluding timeout logic.  Uses a very short timeout to
+        simulate a non blocking call
+
+        Yield either the raw event data or None
+
+        Pass a list of additional regular expressions as `tags_regex` to search
+        the event bus for non-return data, such as minion lists returned from
+        syndics.
+        '''
+        self.get_returns_short_block(jid, tags_regex, wait=0.01)
+
     def get_returns_short_block(
             self,
             jid,
@@ -805,7 +822,8 @@ class LocalClient(object):
             wait=5
            ):
         '''
-        Raw function to just return events of jid excluding timeout logic
+        Raw function to just return events of jid with a short wait.  The
+        wait value should generally be some factor of the job timeout.
 
         Yield either the raw event data or None
 


### PR DESCRIPTION
### What does this PR do?

Make no_block be short_block and set a timeout of 1/4 of whatever the timeout is.
This was we don't spin and allow the event loop to do the waiting for us.
We still wake up periodically and check on the underlying job
### What issues does this PR fix or reference?
#32109
### Previous Behavior

Would iterate every .10 seconds checking for events and for the  timeout.
### New Behavior

Iterates 4 times between each timeout
### Tests written?

No
