### PR TITLE
Set auth retry count to 0 if multimaster mode is failover.

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -411,6 +411,7 @@ class MinionBase(object):
                              ' {0}'.format(opts['master']))
                     if opts['master_shuffle']:
                         shuffle(opts['master'])
+                    opts['auth_tries'] = 0
                 # if opts['master'] is a str and we have never created opts['master_list']
                 elif isinstance(opts['master'], str) and ('master_list' not in opts):
                     # We have a string, but a list was what was intended. Convert.


### PR DESCRIPTION
### What does this PR do?

Sets retry count to 0 if failover, i.e. minion will not try bad master again in this mode
### What issues does this PR fix or reference?

Backport of #31382 to 2015.8 branch for #30183 
### Tests written?

No
