### PR TITLE
Fix #31731 for CentOS 7 distros where osrelease grain is not a float.

### DIFF
--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -68,7 +68,8 @@ def __virtual__():
                 return (False, 'Cannot load rh_service module on SUSE > 11')
 
         try:
-            osrelease = float(__grains__.get('osrelease', 0))
+            osrelease_str = str(__grains__.get('osrelease', 0))
+            osrelease = float(osrelease_str.split('.', 2)[0])
         except ValueError:
             return (False, 'Cannot load rh_service module: '
                            'osrelease grain, {0}, not a float,'.format(osrelease))


### PR DESCRIPTION
### What does this PR do?

It updates the `rh_service` module to account for a `grains['osrelease']` value that might not be floatable.
### What issues does this PR fix or reference?

In the rh_service module, the **virtual** function is expecting a floatable value. However, in CentOS 7, this value can be x.x.x. This causes the float() function to fail and to report the variable `osrelease` is referenced before assignment.
### Previous Behavior

Users using a CentOS 7 Operating system would see the following error when using any `pkg` function:

```
Exception raised when processing __virtual__ function for rh_service. Module will not be loaded local variable 'osrelease' referenced before assignment
```
### Tests written?

Yes
The `rh_services_test` exists already.
