### PR TITLE
Add integration tests for salt-api using pam eauth

### DIFF
--- a/tests/integration/netapi/rest_cherrypy/app_pam_test.py
+++ b/tests/integration/netapi/rest_cherrypy/app_pam_test.py
@@ -1,4 +1,7 @@
 # coding: utf-8
+'''
+Integration Tests for restcherry salt-api with pam eauth
+'''
 
 # Import python libs
 from __future__ import absolute_import
@@ -31,7 +34,7 @@ USERA = 'saltdev'
 USERA_PWD = 'saltdev'
 SET_USERA_PWD = '$6$SALTsalt$ZZFD90fKFWq8AGmmX0L3uBtS9fXL62SrTk5zcnQ6EkD6zoiM3kB88G1Zvs0xm/gZ7WXJRs5nsTBybUvGSqZkT.'
 
-auth_creds = {
+AUTH_CREDS = {
     'username': USERA,
     'password': USERA_PWD,
     'eauth': 'pam'}
@@ -48,15 +51,16 @@ class TestAuthPAM(BaseRestCherryPyTest, integration.ModuleCase):
         super(TestAuthPAM, self).setUp()
         try:
             add_user = self.run_function('user.add', [USERA], createhome=False)
-            add_pwd = self.run_function('shadow.set_password', [USERA, SET_USERA_PWD])
+            add_pwd = self.run_function('shadow.set_password',
+                                        [USERA, SET_USERA_PWD])
             self.assertTrue(add_user)
             self.assertTrue(add_pwd)
             user_list = self.run_function('user.list_users')
             self.assertIn(USERA, str(user_list))
         except AssertionError:
-                self.run_function('user.delete', [USERA], remove=True)
-                self.skipTest(
-                    'Could not add user or password, skipping test'
+            self.run_function('user.delete', [USERA], remove=True)
+            self.skipTest(
+                'Could not add user or password, skipping test'
                 )
 
     def test_bad_pwd_pam_chsh_service(self):
@@ -65,7 +69,7 @@ class TestAuthPAM(BaseRestCherryPyTest, integration.ModuleCase):
         This test ensures this PR is working correctly:
         https://github.com/saltstack/salt/pull/31826
         '''
-        copyauth_creds = auth_creds.copy()
+        copyauth_creds = AUTH_CREDS.copy()
         copyauth_creds['service'] = 'chsh'
         copyauth_creds['password'] = 'wrong_password'
         body = urlencode(copyauth_creds)
@@ -81,7 +85,7 @@ class TestAuthPAM(BaseRestCherryPyTest, integration.ModuleCase):
         This test ensures this PR is working correctly:
         https://github.com/saltstack/salt/pull/31826
        '''
-        copyauth_creds = auth_creds.copy()
+        copyauth_creds = AUTH_CREDS.copy()
         copyauth_creds['service'] = 'login'
         copyauth_creds['password'] = 'wrong_password'
         body = urlencode(copyauth_creds)
@@ -97,7 +101,7 @@ class TestAuthPAM(BaseRestCherryPyTest, integration.ModuleCase):
         This test ensures this PR is working correctly:
         https://github.com/saltstack/salt/pull/31826
         '''
-        copyauth_creds = auth_creds.copy()
+        copyauth_creds = AUTH_CREDS.copy()
         copyauth_creds['service'] = 'chsh'
         body = urlencode(copyauth_creds)
         request, response = self.request('/login', method='POST', body=body,
@@ -112,7 +116,7 @@ class TestAuthPAM(BaseRestCherryPyTest, integration.ModuleCase):
         This test ensures this PR is working correctly:
         https://github.com/saltstack/salt/pull/31826
         '''
-        copyauth_creds = auth_creds.copy()
+        copyauth_creds = AUTH_CREDS.copy()
         copyauth_creds['service'] = 'login'
         body = urlencode(copyauth_creds)
         request, response = self.request('/login', method='POST', body=body,
@@ -123,7 +127,7 @@ class TestAuthPAM(BaseRestCherryPyTest, integration.ModuleCase):
 
     @destructiveTest
     @skipIf(os.geteuid() != 0, 'You must be logged in as root to run this test')
-    def tearDown(self, grains=None):
+    def tearDown(self):
         '''
         Clean up after tests. Delete user
         '''

--- a/tests/integration/netapi/rest_cherrypy/app_pam_test.py
+++ b/tests/integration/netapi/rest_cherrypy/app_pam_test.py
@@ -1,0 +1,133 @@
+# coding: utf-8
+
+# Import python libs
+from __future__ import absolute_import
+import os
+
+# Import salttesting libs
+from salttesting.unit import skipIf
+from salttesting.helpers import (
+    ensure_in_syspath,
+    destructiveTest)
+ensure_in_syspath('../../../')
+
+from tests.utils import BaseRestCherryPyTest
+
+# Import Salt Libs
+import integration
+import salt.utils
+
+# Import 3rd-party libs
+# pylint: disable=import-error,unused-import
+from salt.ext.six.moves.urllib.parse import urlencode  # pylint: disable=no-name-in-module
+try:
+    import cherrypy
+    HAS_CHERRYPY = True
+except ImportError:
+    HAS_CHERRYPY = False
+# pylint: enable=import-error,unused-import
+
+USERA = 'saltdev'
+USERA_PWD = 'saltdev'
+SET_USERA_PWD = '$6$SALTsalt$ZZFD90fKFWq8AGmmX0L3uBtS9fXL62SrTk5zcnQ6EkD6zoiM3kB88G1Zvs0xm/gZ7WXJRs5nsTBybUvGSqZkT.'
+
+auth_creds = {
+    'username': USERA,
+    'password': USERA_PWD,
+    'eauth': 'pam'}
+
+@skipIf(HAS_CHERRYPY is False, 'CherryPy not installed')
+class TestAuthPAM(BaseRestCherryPyTest, integration.ModuleCase):
+    '''
+    Test auth with pam using salt-api
+    '''
+
+    @destructiveTest
+    @skipIf(os.geteuid() != 0, 'You must be logged in as root to run this test')
+    def setUp(self):
+        super(TestAuthPAM, self).setUp()
+        try:
+            add_user = self.run_function('user.add', [USERA], createhome=False)
+            add_pwd = self.run_function('shadow.set_password', [USERA, SET_USERA_PWD])
+            self.assertTrue(add_user)
+            self.assertTrue(add_pwd)
+            user_list = self.run_function('user.list_users')
+            self.assertIn(USERA, str(user_list))
+        except AssertionError:
+                self.run_function('user.delete', [USERA], remove=True)
+                self.skipTest(
+                    'Could not add user or password, skipping test'
+                )
+
+    def test_bad_pwd_pam_chsh_service(self):
+        '''
+        Test login while specifying chsh service with bad passwd
+        This test ensures this PR is working correctly:
+        https://github.com/saltstack/salt/pull/31826
+        '''
+        copyauth_creds = auth_creds.copy()
+        copyauth_creds['service'] = 'chsh'
+        copyauth_creds['password'] = 'wrong_password'
+        body = urlencode(copyauth_creds)
+        request, response = self.request('/login', method='POST', body=body,
+            headers={
+                'content-type': 'application/x-www-form-urlencoded'
+        })
+        self.assertEqual(response.status, '401 Unauthorized')
+
+    def test_bad_pwd_pam_login_service(self):
+        '''
+        Test login while specifying login service with bad passwd
+        This test ensures this PR is working correctly:
+        https://github.com/saltstack/salt/pull/31826
+       '''
+        copyauth_creds = auth_creds.copy()
+        copyauth_creds['service'] = 'login'
+        copyauth_creds['password'] = 'wrong_password'
+        body = urlencode(copyauth_creds)
+        request, response = self.request('/login', method='POST', body=body,
+            headers={
+                'content-type': 'application/x-www-form-urlencoded'
+        })
+        self.assertEqual(response.status, '401 Unauthorized')
+
+    def test_good_pwd_pam_chsh_service(self):
+        '''
+        Test login while specifying chsh service with good passwd
+        This test ensures this PR is working correctly:
+        https://github.com/saltstack/salt/pull/31826
+        '''
+        copyauth_creds = auth_creds.copy()
+        copyauth_creds['service'] = 'chsh'
+        body = urlencode(copyauth_creds)
+        request, response = self.request('/login', method='POST', body=body,
+            headers={
+                'content-type': 'application/x-www-form-urlencoded'
+        })
+        self.assertEqual(response.status, '200 OK')
+
+    def test_good_pwd_pam_login_service(self):
+        '''
+        Test login while specifying login service with good passwd
+        This test ensures this PR is working correctly:
+        https://github.com/saltstack/salt/pull/31826
+        '''
+        copyauth_creds = auth_creds.copy()
+        copyauth_creds['service'] = 'login'
+        body = urlencode(copyauth_creds)
+        request, response = self.request('/login', method='POST', body=body,
+            headers={
+                'content-type': 'application/x-www-form-urlencoded'
+        })
+        self.assertEqual(response.status, '200 OK')
+
+    @destructiveTest
+    @skipIf(os.geteuid() != 0, 'You must be logged in as root to run this test')
+    def tearDown(self, grains=None):
+        '''
+        Clean up after tests. Delete user
+        '''
+        user_list = self.run_function('user.list_users')
+        # Remove saltdev user
+        if USERA in user_list:
+            self.run_function('user.delete', [USERA], remove=True)

--- a/tests/integration/netapi/rest_cherrypy/app_pam_test.py
+++ b/tests/integration/netapi/rest_cherrypy/app_pam_test.py
@@ -39,6 +39,7 @@ AUTH_CREDS = {
     'password': USERA_PWD,
     'eauth': 'pam'}
 
+
 @skipIf(HAS_CHERRYPY is False, 'CherryPy not installed')
 class TestAuthPAM(BaseRestCherryPyTest, integration.ModuleCase):
     '''
@@ -74,9 +75,9 @@ class TestAuthPAM(BaseRestCherryPyTest, integration.ModuleCase):
         copyauth_creds['password'] = 'wrong_password'
         body = urlencode(copyauth_creds)
         request, response = self.request('/login', method='POST', body=body,
-            headers={
-                'content-type': 'application/x-www-form-urlencoded'
-        })
+                                         headers={
+                                             'content-type': 'application/x-www-form-urlencoded'
+                                             })
         self.assertEqual(response.status, '401 Unauthorized')
 
     def test_bad_pwd_pam_login_service(self):
@@ -90,9 +91,9 @@ class TestAuthPAM(BaseRestCherryPyTest, integration.ModuleCase):
         copyauth_creds['password'] = 'wrong_password'
         body = urlencode(copyauth_creds)
         request, response = self.request('/login', method='POST', body=body,
-            headers={
-                'content-type': 'application/x-www-form-urlencoded'
-        })
+                                         headers={
+                                             'content-type': 'application/x-www-form-urlencoded'
+                                             })
         self.assertEqual(response.status, '401 Unauthorized')
 
     def test_good_pwd_pam_chsh_service(self):
@@ -105,9 +106,9 @@ class TestAuthPAM(BaseRestCherryPyTest, integration.ModuleCase):
         copyauth_creds['service'] = 'chsh'
         body = urlencode(copyauth_creds)
         request, response = self.request('/login', method='POST', body=body,
-            headers={
-                'content-type': 'application/x-www-form-urlencoded'
-        })
+                                         headers={
+                                             'content-type': 'application/x-www-form-urlencoded'
+                                             })
         self.assertEqual(response.status, '200 OK')
 
     def test_good_pwd_pam_login_service(self):
@@ -120,9 +121,9 @@ class TestAuthPAM(BaseRestCherryPyTest, integration.ModuleCase):
         copyauth_creds['service'] = 'login'
         body = urlencode(copyauth_creds)
         request, response = self.request('/login', method='POST', body=body,
-            headers={
-                'content-type': 'application/x-www-form-urlencoded'
-        })
+                                         headers={
+                                             'content-type': 'application/x-www-form-urlencoded'
+                                             })
         self.assertEqual(response.status, '200 OK')
 
     @destructiveTest
@@ -136,3 +137,5 @@ class TestAuthPAM(BaseRestCherryPyTest, integration.ModuleCase):
         # Remove saltdev user
         if USERA in user_list:
             self.run_function('user.delete', [USERA], remove=True)
+        #need to exit cherypy engine
+        cherrypy.engine.exit()

--- a/tests/integration/netapi/rest_cherrypy/app_pam_test.py
+++ b/tests/integration/netapi/rest_cherrypy/app_pam_test.py
@@ -131,6 +131,7 @@ class TestAuthPAM(BaseRestCherryPyTest, integration.ModuleCase):
         '''
         Clean up after tests. Delete user
         '''
+        super(TestAuthPAM, self).tearDown()
         user_list = self.run_function('user.list_users')
         # Remove saltdev user
         if USERA in user_list:

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -57,6 +57,14 @@ class BaseRestCherryPyTest(BaseCherryPyTestCase):
                         '@runner',
                         '.*',
                     ],
+                 },
+                 'pam': {
+                     'saltdev': [
+                         '@wheel',
+                         '@runner',
+                         '.*',
+                     ],
+
                 }
             },
             'rest_cherrypy': {


### PR DESCRIPTION
### What does this PR do?

Tests written to ensure pam eauth works with salt-api. Particularly checking to make sure the correct return code is received when using different password and services. 
### What issues does this PR fix or reference?
#31826
### Tests written?

xYes/No
