### PR TITLE
Add /opt/salt/bin to PATH in postinstall script for Mac

### DIFF
--- a/pkg/osx/scripts/postinstall
+++ b/pkg/osx/scripts/postinstall
@@ -60,7 +60,7 @@ launchctl disable system/com.saltstack.salt.syndic
 launchctl disable system/com.saltstack.salt.api
 
 # echo "Path: Adding salt to the path..." >> /tmp/postinstall.txt
-# echo "/opt/salt/bin" > /etc/paths.d/salt
+sh -c 'echo "/opt/salt/bin" > /etc/paths.d/salt'
 
 echo "Post install completed successfully" >> /tmp/postinstall.txt
 

--- a/pkg/osx/scripts/postinstall
+++ b/pkg/osx/scripts/postinstall
@@ -34,10 +34,14 @@ if [ ! -f /etc/salt/minion ]; then
 fi
 
 ###############################################################################
+# Add salt to paths.d
+###############################################################################
+# echo "Path: Adding salt to the path..." >> /tmp/postinstall.txt
+sh -c 'echo "/opt/salt/bin" > /etc/paths.d/salt'
+
+###############################################################################
 # Register Salt as a service
 ###############################################################################
-echo "Service start: Started..." >> /tmp/postinstall.txt
-# launchctl load "/Library/LaunchDaemons/com.saltstack.salt.minion.plist"
 echo "Service start: Enabling service..." >> /tmp/postinstall.txt
 launchctl enable system/com.saltstack.salt.minion
 echo "Service start: Bootstrapping service..." >> /tmp/postinstall.txt
@@ -58,9 +62,6 @@ echo "Service disable: Disabling Master, Syndic, and API" >> /tmp/postinstall.tx
 launchctl disable system/com.saltstack.salt.master
 launchctl disable system/com.saltstack.salt.syndic
 launchctl disable system/com.saltstack.salt.api
-
-# echo "Path: Adding salt to the path..." >> /tmp/postinstall.txt
-sh -c 'echo "/opt/salt/bin" > /etc/paths.d/salt'
 
 echo "Post install completed successfully" >> /tmp/postinstall.txt
 


### PR DESCRIPTION
### What does this PR do?

Adds `/opt/salt/bin` to path. Creates a file in `/etc/paths.d/` named `salt`
Removes legacy command for starting salt service (`launchctl load`). The command was redundant.
### What issues does this PR fix or reference?

https://github.com/saltstack/zh/issues/599
### Previous Behavior

`/opt/salt/bin` was not being added to the system path. The full path to salt had to be specified from the command line when launching salt-minion.
### New Behavior

`/opt/salt/bin` is now added to the system path. `echo $PATH` now shows `/opt/salt/bin` at the end.
### Tests written?

NA
