### PR TITLE
states.boto_rds: __virtual__ return err msg.

### DIFF
--- a/salt/states/boto_rds.py
+++ b/salt/states/boto_rds.py
@@ -94,7 +94,9 @@ def __virtual__():
     '''
     Only load if boto is available.
     '''
-    return 'boto_rds' if 'boto_rds.exists' in __salt__ else False
+    if 'boto_rds.exists' in __salt__:
+        return 'boto_rds'
+    return(False, __salt__.missing_fun_string('boto_rds.exists'))
 
 
 def present(name,


### PR DESCRIPTION
### What does this PR do?

Adds call to missing_fun_string() in order to display module return message.
### What issues does this PR fix or reference?
#32123.
### Previous Behavior

```
ubuntu:
----------
          ID: Ensure myrds RDS exists
    Function: boto_rds.present
        Name: myrds
      Result: False
     Comment: State 'boto_rds.present' was not found in SLS 'source'
              Reason: 'boto_rds' __virtual__ returned False
     Started:
    Duration:
     Changes:
```
### New Behavior

```
ubuntu:
----------
          ID: Ensure myrds RDS exists
    Function: boto_rds.present
        Name: myrds
      Result: False
     Comment: State 'boto_rds.present' was not found in SLS 'source'
              Reason: 'boto_rds' __virtual__ returned False: 'boto_rds' __virtual__ returned False: The boto_rds module could not be loaded: boto libraries not found
     Started:
    Duration:
     Changes:
```
### Tests written?

No
