### PR TITLE
Update nacl.config docs to use key value instead of 'None'

### DIFF
--- a/salt/modules/nacl.py
+++ b/salt/modules/nacl.py
@@ -39,7 +39,7 @@ minion or master config. Avoid storing the config in pillars!
 
     cat /etc/salt/master.d/nacl.conf
     nacl.config:
-        key: None
+        key: 'cKEzd4kXsbeCE7/nLTIqXwnUiD1ulg4NoeeYcCFpd9k='
         keyfile: /root/.nacl
 
 When the key is defined in the master config you can use it from the nacl runner:

--- a/salt/runners/nacl.py
+++ b/salt/runners/nacl.py
@@ -15,7 +15,7 @@ so your users can create encrypted passwords using the runner nacl:
 
     cat /etc/salt/master.d/nacl.conf
     nacl.config:
-        key: None
+        key: 'cKEzd4kXsbeCE7/nLTIqXwnUiD1ulg4NoeeYcCFpd9k='
         keyfile: /root/.nacl
 
 Now with the config in the master you can use the runner nacl like:


### PR DESCRIPTION
### What does this PR do?

Updates the nacl.config docs to show using an actual key value instead of 'None', which is invalid.
### What issues does this PR fix or reference?

Fixes #27605
### Tests written?

No
