### PR TITLE
Make __virtual__ for rhservice.py more robust (2015.5 branch)

### DIFF
--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -63,14 +63,14 @@ def __virtual__():
             else:
                 return False
         try:
-            osrelease = float(__grains__.get('osrelease', 0))
+            osrelease_major = __grains__.get('osrelease_info', [0])[0]
         except ValueError:
             return False
         if __grains__['os'] == 'Fedora':
-            if osrelease > 15:
+            if osrelease_major >= 15:
                 return False
         if __grains__['os'] in ('RedHat', 'CentOS', 'ScientificLinux', 'OEL'):
-            if osrelease >= 7:
+            if osrelease_major >= 7:
                 return False
         return __virtualname__
     return False


### PR DESCRIPTION
**NOTE: Do not merge this until #32165 has been merged into 2015.8.**

We already have an `osrelease_info` grain that provides a
versioninfo-style list. Using `float()` here is unnecessary and also a
brittle solution as it falls over when the verson contains a third part
(as an exception is raised since the string can no longer be evaluated as
a float).

Moreover, as we're not checking anything special for point releases, the
extra resolution provided by using a float is superfluous.

Additionally, this fixes incorrect logic which would result in this
module being loaded on Fedora 15, which uses systemd.
