### PR TITLE
Make __virtual__ for rhservice.py more robust

### DIFF
--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -67,18 +67,22 @@ def __virtual__():
             else:
                 return (False, 'Cannot load rh_service module on SUSE > 11')
 
-        try:
-            osrelease = float(__grains__.get('osrelease', 0))
-        except ValueError:
-            return (False, 'Cannot load rh_service module: '
-                           'osrelease grain, {0}, not a float,'.format(osrelease))
+        osrelease_major = __grains__.get('osrelease_info', [0])[0]
 
         if __grains__['os'] == 'Fedora':
-            if osrelease > 15:
-                return (False, 'Cannot load rh_service module on Fedora >= 15')
+            if osrelease_major >= 15:
+                return (
+                    False,
+                    'Fedora >= 15 uses systemd, will not load rh_service.py '
+                    'as virtual \'service\''
+                )
         if __grains__['os'] in ('RedHat', 'CentOS', 'ScientificLinux', 'OEL'):
-            if osrelease >= 7:
-                return (False, 'Cannot load rh_service module on RedHat >= 7')
+            if osrelease_major >= 7:
+                return (
+                    False,
+                    'RedHat-based distros >= version 7 use systemd, will not '
+                    'load rh_service.py as virtual \'service\''
+                )
         return __virtualname__
     return (False, 'Cannot load rh_service module: OS not in {0}'.format(enable))
 


### PR DESCRIPTION
**NOTE: This should be merged before #32164, which was opened against the 2015.5 branch. Following the merging of both pull requests, when 2015.5 is merged forward into 2015.8, a merge conflict will result. The 2015.8 side of this merge conflict should likely be kept wholesale and the 2015.5 side discarded, but feel free to ping me to have a look at the merge conflict.**

We already have an `osrelease_info` grain that provides a
versioninfo-style list. Using `float()` here is unnecessary and also a
brittle solution as it falls over when the verson contains a third part
(as an exception is raised since the string can no longer be evaluated as
a float).

Moreover, as we're not checking anything special for point releases, the
extra resolution provided by using a float is superfluous.

Additionally, this fixes incorrect logic which would result in this
module being loaded on Fedora 15, which uses systemd.

Fixes #31731.
