### PR TITLE
add name for lxc for use with cloud cache

### DIFF
--- a/salt/cloud/clouds/lxc.py
+++ b/salt/cloud/clouds/lxc.py
@@ -281,6 +281,7 @@ def list_nodes(conn=None, call=None):
         for lxcc, linfos in lxcs.items():
             info = {
                 'id': lxcc,
+                'name': lxcc,  # required for cloud cache
                 'image': None,
                 'size': linfos['size'],
                 'state': state.lower(),
@@ -332,7 +333,7 @@ def list_nodes_select(call=None):
         call = 'select'
     if not get_configured_provider():
         return
-    info = ['id', 'image', 'size', 'state', 'public_ips', 'private_ips']
+    info = ['id', 'name', 'image', 'size', 'state', 'public_ips', 'private_ips']
     return salt.utils.cloud.list_nodes_select(
         list_nodes_full(call='action'),
         __opts__.get('query.selection', info), call)


### PR DESCRIPTION
### What does this PR do?

needed for use in `cache_node` in salt/utils/cloud.py
### What issues does this PR fix or reference?

Allows the lxc cloud driver to be used with the cloud cache
### Tests written?

No
