### PR TITLE
Fix supervisord state bug when name contains `:*`

### DIFF
--- a/salt/states/supervisord.py
+++ b/salt/states/supervisord.py
@@ -78,6 +78,9 @@ def running(name,
         installed
 
     '''
+    if name.endswith(':*'):
+        name = name[:-1]
+
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
     if 'supervisord.status' not in __salt__:


### PR DESCRIPTION
### What does this PR do?

Fix supervisord state bug when name contains `:*`
### What issues does this PR fix or reference?
#12506
#12521
### Previous Behavior

Result will be False if name contains `:*` when process group already active.
### New Behavior

Result will be True, because we don't need to add process group when it's already active.
### Tests written?

No
