### PR TITLE
accept path as input to certificate managed state

### DIFF
--- a/salt/states/x509.py
+++ b/salt/states/x509.py
@@ -392,6 +392,9 @@ def certificate_managed(name,
     '''
     ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
 
+    if 'path' in kwargs:
+        name = kwargs.pop('path')
+
     current_days_remaining = 0
     current_comp = {}
 


### PR DESCRIPTION
### What does this PR do?

Allows the path for a managed certificate to be specified with the keyword `path`.
### What issues does this PR fix or reference?
#32075
### Previous Behavior

Path to the certificate must be specified as `name`, throws errors if it is specified as `path`, but the documentation implies it should be able to be specified as `path`.
### New Behavior

Certificate path can be specified as either `path` or `name`. If both are included, `path` takes precience.
### Tests written?

No
