### PR TITLE
Fix psutil.cpu_times unpack error

### DIFF
--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -133,6 +133,8 @@ def top(num_processes=5, interval=3):
         try:
             process = psutil.Process(pid)
             user, system = process.cpu_times()
+        except ValueError:
+            user, system, _, _ = process.cpu_times()
         except psutil.NoSuchProcess:
             continue
         start_usage[process] = user + system
@@ -141,6 +143,8 @@ def top(num_processes=5, interval=3):
     for process, start in six.iteritems(start_usage):
         try:
             user, system = process.cpu_times()
+        except ValueError:
+            user, system, _, _ = process.cpu_times()
         except psutil.NoSuchProcess:
             continue
         now = user + system


### PR DESCRIPTION
### What does this PR do?

I got a error when use `sudo salt '*' ps.top`:

```
130:
    The minion function caused an exception: Traceback (most recent call last):
      File "/usr/lib/python2.7/dist-packages/salt/minion.py", line 1071, in _thread_return
        return_data = func(*args, **kwargs)
      File "/usr/lib/python2.7/dist-packages/salt/modules/ps.py", line 136, in top
        user, system = process.cpu_times()
    ValueError: too many values to unpack
```

We need compatible with the new method.
### What issues does this PR fix or reference?

https://github.com/giampaolo/psutil/pull/785/  Now cpu_times return four values
### New Behavior

Now `ps.top` works.
### Tests written?

No
