### PR TITLE
Add timelib to windows pip dependencies

### DIFF
--- a/pkg/windows/build_env.ps1
+++ b/pkg/windows/build_env.ps1
@@ -164,7 +164,7 @@ If (Test-Path "$($ini[$bitPaths]['VCforPythonDir'])\vcvarsall.bat") {
     # Install Microsoft Visual C++ for Python2.7
     Write-Output " - Installing $($ini['Prerequisites']['VCforPython']) . . ."
     $file = "$($ini['Settings']['DownloadDir'])\$($ini['Prerequisites']['VCforPython'])"
-    $p    = Start-Process msiexec.exe -ArgumentList "/i $file ALLUSERS=1" -Wait -NoNewWindow -PassThru
+    $p    = Start-Process msiexec.exe -ArgumentList "/i $file /qb ALLUSERS=1" -Wait -NoNewWindow -PassThru
 
 }
 

--- a/pkg/windows/build_env.ps1
+++ b/pkg/windows/build_env.ps1
@@ -182,11 +182,6 @@ $file = "$($ini['Settings']['DownloadDir'])\$($ini[$bitPrograms]['Python'])"
 $p    = Start-Process msiexec -ArgumentList "/i $file /qb ADDLOCAL=DefaultFeature,Extensions,pip_feature,PrependPath TARGETDIR=$($ini['Settings']['PythonDir'])" -Wait -NoNewWindow -PassThru
 
 #------------------------------------------------------------------------------
-# Update PIP to latest version
-#------------------------------------------------------------------------------
-$p = Start-Process "$($ini['Settings']['ScriptsDir'])\python.exe" -ArgumentList "-m pip --no-cache-dir install --upgrade pip" -Wait -NoNewWindow -PassThru
-
-#------------------------------------------------------------------------------
 # Update Environment Variables
 #------------------------------------------------------------------------------
 Write-Output " - Updating Environment Variables . . ."
@@ -198,18 +193,18 @@ If (!($Path.ToLower().Contains("$($ini['Settings']['ScriptsDir'])".ToLower()))) 
 }
 
 #==============================================================================
-# Install pypi resources using pip
+# Update PIP and SetupTools
 #==============================================================================
 Write-Output " ----------------------------------------------------------------"
-Write-Output " - Installing pypi resources using pip . . ."
+Write-Output " - Updating PIP and SetupTools . . ."
 Write-Output " ----------------------------------------------------------------"
 $p = Start-Process "$($ini['Settings']['PythonDir'])\python.exe" -ArgumentList "-m pip --no-cache-dir install -r $($script_path)\req_pip.txt" -Wait -NoNewWindow -PassThru
 
 #==============================================================================
-# Install additional pypi resources using pip
+# Install pypi resources using pip
 #==============================================================================
 Write-Output " ----------------------------------------------------------------"
-Write-Output " - Installing additional pypi resources using pip . . ."
+Write-Output " - Installing pypi resources using pip . . ."
 Write-Output " ----------------------------------------------------------------"
 $p = Start-Process "$($ini['Settings']['ScriptsDir'])\pip.exe" -ArgumentList "--no-cache-dir install -r $($script_path)\req.txt" -Wait -NoNewWindow -PassThru
 

--- a/pkg/windows/build_env.ps1
+++ b/pkg/windows/build_env.ps1
@@ -143,6 +143,32 @@ If (Test-Path "$($ini[$bitPaths]['NSISDir'])\NSIS.exe") {
 }
 
 #------------------------------------------------------------------------------
+# Check for installation of Microsoft Visual C++ Compiler for Python 2.7
+#------------------------------------------------------------------------------
+Write-Output " - Checking for VC Compiler for Python 2.7 installation . . ."
+If (Test-Path "$($ini[$bitPaths]['VCforPythonDir'])\vcvarsall.bat") {
+
+    # Found Microsoft Visual C++ for Python2.7, do nothing
+    Write-Output " - Microsoft Visual C++ for Python 2.7 Found . . ."
+
+} Else {
+
+    # Microsoft Visual C++ for Python2.7 not found, install
+    Write-Output " - Microsoft Visual C++ for Python2.7 Not Found . . ."
+    Write-Output " - Downloading $($ini['Prerequisites']['VCforPython']) . . ."
+    $file = "$($ini['Prerequisites']['VCforPython'])"
+    $url  = "$($ini['Settings']['SaltRepo'])/$file"
+    $file = "$($ini['Settings']['DownloadDir'])\$file"
+    DownloadFileWithProgress $url $file
+
+    # Install Microsoft Visual C++ for Python2.7
+    Write-Output " - Installing $($ini['Prerequisites']['VCforPython']) . . ."
+    $file = "$($ini['Settings']['DownloadDir'])\$($ini['Prerequisites']['VCforPython'])"
+    $p    = Start-Process msiexec.exe -ArgumentList '/i $($file) ALLUSERS=1' -Wait -NoNewWindow -PassThru
+
+}
+
+#------------------------------------------------------------------------------
 # Install Python
 #------------------------------------------------------------------------------
 Write-Output " - Downloading $($ini[$bitPrograms]['Python']) . . ."
@@ -156,6 +182,11 @@ $file = "$($ini['Settings']['DownloadDir'])\$($ini[$bitPrograms]['Python'])"
 $p    = Start-Process msiexec -ArgumentList "/i $file /qb ADDLOCAL=DefaultFeature,Extensions,pip_feature,PrependPath TARGETDIR=$($ini['Settings']['PythonDir'])" -Wait -NoNewWindow -PassThru
 
 #------------------------------------------------------------------------------
+# Update PIP to latest version
+#------------------------------------------------------------------------------
+$p = Start-Process "$($ini['Settings']['ScriptsDir'])\pip.exe" -ArgumentList "--no-cache-dir install --upgrade pip" -Wait -NoNewWindow -PassThru
+
+#------------------------------------------------------------------------------
 # Update Environment Variables
 #------------------------------------------------------------------------------
 Write-Output " - Updating Environment Variables . . ."
@@ -167,18 +198,18 @@ If (!($Path.ToLower().Contains("$($ini['Settings']['ScriptsDir'])".ToLower()))) 
 }
 
 #==============================================================================
-# update pip and easy_install
+# Install pypi resources using pip
 #==============================================================================
 Write-Output " ----------------------------------------------------------------"
-Write-Output " - Updating pip and easy_install . . ."
+Write-Output " - Installing pypi resources using pip . . ."
 Write-Output " ----------------------------------------------------------------"
 $p = Start-Process "$($ini['Settings']['PythonDir'])\python.exe" -ArgumentList "-m pip --no-cache-dir install -r $($script_path)\req_pip.txt" -Wait -NoNewWindow -PassThru
 
 #==============================================================================
-# Install pypi resources using pip
+# Install additional pypi resources using pip
 #==============================================================================
 Write-Output " ----------------------------------------------------------------"
-Write-Output " - Installing additional prereqs . . ."
+Write-Output " - Installing additional pypi resources using pip . . ."
 Write-Output " ----------------------------------------------------------------"
 $p = Start-Process "$($ini['Settings']['ScriptsDir'])\pip.exe" -ArgumentList "--no-cache-dir install -r $($script_path)\req.txt" -Wait -NoNewWindow -PassThru
 

--- a/pkg/windows/build_env.ps1
+++ b/pkg/windows/build_env.ps1
@@ -164,7 +164,7 @@ If (Test-Path "$($ini[$bitPaths]['VCforPythonDir'])\vcvarsall.bat") {
     # Install Microsoft Visual C++ for Python2.7
     Write-Output " - Installing $($ini['Prerequisites']['VCforPython']) . . ."
     $file = "$($ini['Settings']['DownloadDir'])\$($ini['Prerequisites']['VCforPython'])"
-    $p    = Start-Process msiexec.exe -ArgumentList '/i $($file) ALLUSERS=1' -Wait -NoNewWindow -PassThru
+    $p    = Start-Process msiexec.exe -ArgumentList "/i $file ALLUSERS=1" -Wait -NoNewWindow -PassThru
 
 }
 

--- a/pkg/windows/build_env.ps1
+++ b/pkg/windows/build_env.ps1
@@ -184,7 +184,7 @@ $p    = Start-Process msiexec -ArgumentList "/i $file /qb ADDLOCAL=DefaultFeatur
 #------------------------------------------------------------------------------
 # Update PIP to latest version
 #------------------------------------------------------------------------------
-$p = Start-Process "$($ini['Settings']['ScriptsDir'])\pip.exe" -ArgumentList "--no-cache-dir install --upgrade pip" -Wait -NoNewWindow -PassThru
+$p = Start-Process "$($ini['Settings']['ScriptsDir'])\python.exe" -ArgumentList "-m pip --no-cache-dir install --upgrade pip" -Wait -NoNewWindow -PassThru
 
 #------------------------------------------------------------------------------
 # Update Environment Variables

--- a/pkg/windows/modules/get-settings.psm1
+++ b/pkg/windows/modules/get-settings.psm1
@@ -24,14 +24,15 @@ Function Get-Settings {
 
         # Prerequisite software
         $Prerequisites = @{
-            "Git"  = "Git-1.9.5-preview20141217.exe"
-            "NSIS" = "nsis-3.0b1-setup.exe"
+            "NSIS"        = "nsis-3.0b1-setup.exe"
+            "VCforPython" = "VCForPython27.msi"
         }
         $ini.Add("Prerequisites", $Prerequisites)
 
         # Location of programs on 64 bit Windows
         $64bitPaths = @{
-            "NSISDir" = "C:\Program Files (x86)\NSIS"
+            "NSISDir"        = "C:\Program Files (x86)\NSIS"
+            "VCforPythonDir" = "C:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0"
         }
         $ini.Add("64bitPaths", $64bitPaths)
 

--- a/pkg/windows/req.txt
+++ b/pkg/windows/req.txt
@@ -26,6 +26,7 @@ requests==2.9.1
 singledispatch==3.4.0.3
 six==1.10.0
 smmap==0.9.0
+timelib==0.2.4
 tornado==4.3
 wheel==0.26.0
 WMI==1.4.9

--- a/pkg/windows/req_pip.txt
+++ b/pkg/windows/req_pip.txt
@@ -1,2 +1,2 @@
-pip==8.0.2
-setuptools==20.0
+pip==8.1.1
+setuptools==20.3.1


### PR DESCRIPTION
### What does this PR do?

Adds timelib to the list of pip installed dependencies for windows. This is needed to handle date/time conversion and checking more easily. Timelib requires Microsoft Visual C++ Compiler for Python 2.7 to compile correctly so that is now a part of the build_env script.
### What issues does this PR fix or reference?

This is a precurser to fixing the expires parameter for windows using user.present. Plan to use `salt.utils.date_cast` function... which needs timelib.
### Tests written?

NA
