### PR TITLE
[dockerng] Consider labels carried by the image when comparing user defined labels.

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -443,6 +443,7 @@ VALID_CREATE_OPTS = {
     },
     'labels': {
       'path': 'Config:Labels',
+      'image_path': 'Config:Labels',
       'default': {},
     },
     'binds': {

--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -411,6 +411,21 @@ def _compare(actual, create_kwargs, defaults_from_image):
             # sometimes `[]`. We have to deal with it.
             if bool(actual_data) != bool(data):
                 ret.update({item: {'old': actual_data, 'new': data}})
+        elif item == 'labels':
+            if actual_data is None:
+                actual_data = {}
+            if data is None:
+                data = {}
+            image_labels = _image_get(config['image_path'], default={})
+            if image_labels is not None:
+                image_labels = image_labels.copy()
+                if isinstance(data, list):
+                    data = dict((k, '') for k in data)
+                image_labels.update(data)
+                data = image_labels
+            if actual_data != data:
+                ret.update({item: {'old': actual_data, 'new': data}})
+                continue
 
         elif isinstance(data, list):
             # Compare two sorted lists of items. Won't work for "command"


### PR DESCRIPTION
### What does this PR do?

When comparing `Labels`, take into consideration the ones carried by the image.
### What issues does this PR fix or reference?
#31595
### Previous Behavior

`Labels` coming from the image were ignored.
### Tests written?

Yes
