### PR TITLE
rhel oscodename

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1271,6 +1271,8 @@ def os_data():
                 grains.get('lsb_distrib_release', osrelease).strip()
         grains['oscodename'] = grains.get('lsb_distrib_codename',
                                           oscodename).strip()
+        if 'Red Hat' in grains['oscodename']:
+            grains['oscodename'] = oscodename
         distroname = _REPLACE_LINUX_RE.sub('', grains['osfullname']).strip()
         # return the first ten characters with no spaces, lowercased
         shortname = distroname.replace(' ', '').lower()[:10]


### PR DESCRIPTION
### What does this PR do?

Fixes grains `oscodename` value for the newest RHEL having os-release file.
### What issues does this PR fix or reference?
#31365
### Previous Behavior

Previously RHEL had no os-release file and the info was given from `platform` module.
### New Behavior

Use the `codename` given from `platform`.
### Tests written?

No
Tested manually on RHEL 7.2
