### PR TITLE
Only display error when tty is True in salt-ssh

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -766,7 +766,7 @@ class Single(object):
 
             if '_error' in opts_pkg:
                 #Refresh failed
-                ret = json.dumps({'local': opts_pkg})
+                ret = json.dumps({'local': opts_pkg['_error']})
                 return ret
 
             pillar = salt.pillar.Pillar(


### PR DESCRIPTION
### What does this PR do?

Only displays the relevent error instead of a full dump of opts
### What issues does this PR fix or reference?
#31501
### Previous Behavior

Dumped all opts, including master opts
### Tests written?

No
