### PR TITLE
Fix version check, fix extracting Major and Minor versions from __ver…

### DIFF
--- a/salt/modules/glance.py
+++ b/salt/modules/glance.py
@@ -55,7 +55,8 @@ from salt.version import (
     )
 # is there not SaltStackVersion.current() to get
 # the version of the salt running this code??
-CUR_VER = SaltStackVersion(__version__[0], __version__[1])
+_version_ary = __version__.split('.')
+CUR_VER = SaltStackVersion(_version_ary[0], _version_ary[1])
 BORON = SaltStackVersion.from_name('Boron')
 
 # pylint: disable=import-error


### PR DESCRIPTION
### What does this PR do?

Fixes a version check, was using version[1] which is either the '0' in 2015 or '.' in '4.1.5'.
Fixes by obtaining major and minor versions correctly for SaltStackVersion
### What issues does this PR fix or reference?

zh #619
### Previous Behavior

Throw error exception in logs but continue functioning
### New Behavior

Fixes error exception and now correctly compares current version again Boron
### Tests written?

No
