### PR TITLE
Create minion.d directory on install for Windows

### DIFF
--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -224,6 +224,7 @@ Section "MainSection" SEC01
   SetOutPath "$INSTDIR\"
   SetOverwrite off
   CreateDirectory $INSTDIR\conf\pki\minion
+  CreateDirectory $INSTDIR\conf\minion.d
   File /r "..\buildenv\"
   Exec 'icacls c:\salt /inheritance:r /grant:r "*S-1-5-32-544":(OI)(CI)F /grant:r "*S-1-5-18":(OI)(CI)F'
 


### PR DESCRIPTION
### What does this PR do?

The Windows Installer now creates the minion.d directory under `C:\salt\conf`. Though I must say that launching the minion created the minion.d directory automatically.
### What issues does this PR fix or reference?
#31976
### Previous Behavior

minion.d directory was not being created by the windows installer. It gets created when the minion starts though.
### New Behavior

minion.d directory is now created by the Windows Installer
### Tests written?

NA
