### PR TITLE
Remove list2cmdline usage from win_service.py

### DIFF
--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import
 import salt.utils
 import time
 import logging
-from subprocess import list2cmdline
 from salt.ext.six.moves import zip
 from salt.ext.six.moves import range
 
@@ -97,8 +96,8 @@ def get_all():
         salt '*' service.get_all
     '''
     ret = set()
-    cmd = list2cmdline(['sc', 'query', 'type=', 'service', 'state=', 'all', 'bufsize=', str(BUFFSIZE)])
-    lines = __salt__['cmd.run'](cmd).splitlines()
+    cmd = ['sc', 'query', 'type=', 'service', 'state=', 'all', 'bufsize=', str(BUFFSIZE)]
+    lines = __salt__['cmd.run'](cmd, python_shell=False).splitlines()
     for line in lines:
         if 'SERVICE_NAME:' in line:
             comps = line.split(':', 1)
@@ -335,8 +334,8 @@ def enabled(name, **kwargs):
 
         salt '*' service.enabled <service name>
     '''
-    cmd = list2cmdline(['sc', 'qc', name])
-    lines = __salt__['cmd.run'](cmd).splitlines()
+    cmd = ['sc', 'qc', name]
+    lines = __salt__['cmd.run'](cmd, python_shell=False).splitlines()
     for line in lines:
         if 'AUTO_START' in line:
             return True
@@ -353,8 +352,8 @@ def disabled(name):
 
         salt '*' service.disabled <service name>
     '''
-    cmd = list2cmdline(['sc', 'qc', name])
-    lines = __salt__['cmd.run'](cmd).splitlines()
+    cmd = ['sc', 'qc', name]
+    lines = __salt__['cmd.run'](cmd, python_shell=False).splitlines()
     for line in lines:
         if 'DEMAND_START' in line:
             return True


### PR DESCRIPTION
### What does this PR do?

Removes list2cmdline usage from win_service.py. Commands passed to cmd.run\* should be passed as a list instead of a string. The cmd.run\* functions will parse the list correctly and correct for injection attacks etc. This was also causing a problem with some windows commands that were single and double-quoting a portion of the command which was causing it to fail.
### What issues does this PR fix or reference?
#32031
### Tests written?

No
