### PR TITLE
Fixed boto_lambda_test

### DIFF
--- a/tests/unit/modules/boto_lambda_test.py
+++ b/tests/unit/modules/boto_lambda_test.py
@@ -63,7 +63,8 @@ function_ret = dict(FunctionName='testfunction',
                     CodeSha256='abcdef',
                     CodeSize=199,
                     FunctionArn='arn:lambda:us-east-1:1234:Something',
-                    LastModified='yes')
+                    LastModified='yes',
+                    VpcConfig=None)
 alias_ret = dict(AliasArn='arn:lambda:us-east-1:1234:Something',
                  Name='testalias',
                  FunctionVersion='3',


### PR DESCRIPTION
### What does this PR do?

VpcConfig was not added to function_ret, which was causing
test_that_when_describing_function_it_returns_the_dict_of_properties_returns_true
to fail.
### What issues does this PR fix or reference?

Fixes a failing test on branch tests. 
### Tests written?

Yes
