### PR TITLE
Add state file name to warning log line

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1416,11 +1416,11 @@ def managed(name,
     if not source and contents_count == 0 and replace:
         replace = False
         log.warning(
-            'Neither \'source\' nor \'contents\' nor \'contents_pillar\' nor '
-            '\'contents_grains\' was defined, yet \'replace\' was set to '
-            '\'True\'. As there is no source to replace the file with, '
-            '\'replace\' has been set to \'False\' to avoid reading the file '
-            'unnecessarily.'
+            'State for file: {0} - Neither \'source\' nor \'contents\' nor '
+            '\'contents_pillar\' nor \'contents_grains\' was defined, yet '
+            '\'replace\' was set to \'True\'. As there is no source to '
+            'replace the file with, \'replace\' has been set to \'False\' to '
+            'avoid reading the file unnecessarily.'.format(name)
         )
 
     # Use this below to avoid multiple '\0' checks and save some CPU cycles


### PR DESCRIPTION
```
2016-03-30 15:42:29,932 [salt.loaded.int.states.file][WARNING ][7188] Neither 'source'
nor 'contents' nor 'contents_pillar' nor 'contents_grains' was defined, yet 'replace'
was set to 'True'. As there is no source to replace the file with, 'replace' has been
set to 'False' to avoid reading the file unnecessarily.
```

Pretty annoying having to increase the log level to figure out which state causes this warning.
