### PR TITLE
Bugfix: match.filter_by minion_id regression fix

### DIFF
--- a/salt/modules/match.py
+++ b/salt/modules/match.py
@@ -331,9 +331,8 @@ def filter_by(lookup, expr_form='compound', minion_id=None):
         predicate=inspect.isfunction))
 
     for key in lookup:
-        if minion_id and expr_funcs[expr_form](key, minion_id):
-            return lookup[key]
-        elif expr_funcs[expr_form](key):
+        params = (key, minion_id) if minion_id else (key, )
+        if expr_funcs[expr_form](*params):
             return lookup[key]
 
     return None


### PR DESCRIPTION
### What does this PR do?

Fixes regression introduced by e61ac75d6f04e694bdb6440fffe5634fcbba7c8b which leads to 'current minion id' being used [as fallback for each pattern] even if explicit `minion_id` provided.
### What issues does this PR fix or reference?

No issue was created.
### Previous Behavior

Even if explicit `minion_id` is provided current minion id is tried agains each pattern.
### New Behavior

Do not use current minion id if explicit `minion_id is provided`
### Tests written?

No

There is a regression since e61ac75d6f04e694bdb6440fffe5634fcbba7c8b.
Even when minion_id is provided it tries to match against id from opts.
