### PR TITLE
Feature: sdb.delete

### DIFF
--- a/doc/topics/sdb/index.rst
+++ b/doc/topics/sdb/index.rst
@@ -65,11 +65,11 @@ And the URI used to reference the password might look like:
     sdb://kevinopenstack/password
 
 
-Getting and Setting SDB Values
-==============================
+Getting, Setting and Deleting SDB Values
+========================================
 Once an SDB driver is configured, you can use the ``sdb`` execution module to
-set and get values from it. There are two functions that will appear in any
-SDB module: ``set`` and ``get``.
+get, set and delete values from it. There are two functions that may appear in
+most SDB modules: ``get``, ``set`` and ``delete``.
 
 Getting a value requires only the SDB URI to be specified. To retreive a value
 from the ``kevinopenstack`` profile above, you would use:
@@ -95,13 +95,22 @@ a new value using a command like:
 
     salt-call sdb.set 'sdb://myvault/secret/salt?saltstack' 'super awesome'
 
-The ``sdb.get`` and ``sdb.set`` functions are also available in the runner
-system:
+Deleting values (if supported by the driver) is done pretty much the same way as
+getting them. Provided that you have a profile called ``mykvstore`` that uses
+a driver allowing to delete values you would delete a value as shown bellow:
+
+.. code-block:: bash
+
+    salt-call sdb.delete 'sdb://mykvstore/foobar'
+
+The ``sdb.get``, ``sdb.set`` and ``sdb.delete`` functions are also available in
+the runner system:
 
 .. code-block:: bash
 
     salt-run sdb.get 'sdb://myvault/secret/salt?saltstack'
     salt-run sdb.set 'sdb://myvault/secret/salt?saltstack' 'super awesome'
+    salt-run sdb.delete 'sdb://mykvstore/foobar'
 
 
 Using SDB URIs in Files
@@ -147,9 +156,10 @@ as it requires the user to provide vaules in SDB, using a specific URI. Use
 
 Writing SDB Modules
 ===================
-There is currently one function that MUST exist in any SDB module (``get()``)
-and one that SHOULD exist (``set_()``). If using a (``set_()``) function, a
-``__func_alias__`` dictionary MUST be declared in the module as well:
+There is currently one function that MUST exist in any SDB module (``get()``),
+one that SHOULD exist (``set_()``) and one that MAY exist (``delete()``). If
+using a (``set_()``) function, a ``__func_alias__`` dictionary MUST be declared
+in the module as well:
 
 .. code-block:: python
 
@@ -169,6 +179,9 @@ areas of the code which make use of the ``sdb://`` URI. For example, the
 The ``set_()`` function may be provided, but is not required, as some sources
 may be read-only, or may be otherwise unwise to access via a URI (for instance,
 because of SQL injection attacks).
+
+The ``delete()`` function may be provided as well, but is not required, as many
+sources may be read-only or restrict such operations.
 
 A simple example of an SDB module is ``salt/sdb/keyring_db.py``, as it provides
 basic examples of most, if not all, of the types of functionality that are

--- a/salt/modules/sdb.py
+++ b/salt/modules/sdb.py
@@ -41,3 +41,18 @@ def set_(uri, value):
         salt '*' sdb.set sdb://mymemcached/foo bar
     '''
     return salt.utils.sdb.sdb_set(uri, value, __opts__)
+
+
+def delete(uri):
+    '''
+    Delete a value from a db, using a uri in the form of ``sdb://<profile>/<key>``.
+    If the uri provided does not start with ``sdb://`` or the value is not
+    successfully deleted, return ``False``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' sdb.delete sdb://mymemcached/foo
+    '''
+    return salt.utils.sdb.sdb_delete(uri, __opts__)

--- a/salt/runners/sdb.py
+++ b/salt/runners/sdb.py
@@ -40,3 +40,18 @@ def set_(uri, value):
         salt '*' sdb.set sdb://mymemcached/foo bar
     '''
     return salt.utils.sdb.sdb_set(uri, value, __opts__)
+
+
+def delete(uri):
+    '''
+    Delete a value from a db, using a uri in the form of ``sdb://<profile>/<key>``.
+    If the uri provided does not start with ``sdb://`` or the value is not
+    successfully deleted, return ``False``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' sdb.delete sdb://mymemcached/foo
+    '''
+    return salt.utils.sdb.sdb_delete(uri, __opts__)

--- a/salt/utils/sdb.py
+++ b/salt/utils/sdb.py
@@ -63,3 +63,31 @@ def sdb_set(uri, value, opts):
 
     loaded_db = salt.loader.sdb(opts, fun)
     return loaded_db[fun](query, value, profile=profile)
+
+
+def sdb_delete(uri, opts):
+    '''
+    Delete a value from a db, using a uri in the form of ``sdb://<profile>/<key>``. If
+    the uri provided does not start with ``sdb://`` or the value is not successfully
+    deleted, return ``False``.
+    '''
+    if not isinstance(uri, string_types):
+        return False
+
+    if not uri.startswith('sdb://'):
+        return False
+
+    comps = uri.replace('sdb://', '').split('/', 1)
+
+    if len(comps) < 2:
+        return False
+
+    profile = opts.get(comps[0], {})
+    if 'driver' not in profile:
+        return False
+
+    fun = '{0}.delete'.format(profile['driver'])
+    query = comps[1]
+
+    loaded_db = salt.loader.sdb(opts, fun)
+    return loaded_db[fun](query, profile=profile)


### PR DESCRIPTION
### What does this PR do?

Opens room for `sdb.delete` functionality.

Provided that this PR is merged I'm planning to contribute `sdb.delete` implementation to various `sdb` backends (where it makes sense).
### What issues does this PR fix or reference?

No issue was created.
### Previous Behavior

Only `sdb.get` and `sdb.set` functions available.
### New Behavior

Added `sdb.delete` function.
### Tests written?

No

Adds sdb.delete operation support to execution modules, runners and
utils. Docs updated as well.
