### PR TITLE
Make return types consistent in sdb_set

### DIFF
--- a/salt/utils/sdb.py
+++ b/salt/utils/sdb.py
@@ -44,7 +44,7 @@ def sdb_set(uri, value, opts):
     successfully set, return ``False``.
     '''
     if not isinstance(uri, string_types):
-        return uri
+        return False
 
     if not uri.startswith('sdb://'):
         return False


### PR DESCRIPTION
### What does this PR do?

Makes return types consistent in `salt.utils.sdb_set`. Issue highlighted by @techhat in #32242

P.S.: I guess whether in long run it's better to raise an error rather than return `False`...
### What issues does this PR fix or reference?
#32242
### Previous Behavior

If URI is not a string, return a URI. Otherwise return `True`/`False` based on validation and execution results.
### New Behavior

Always return `True`/`False`.
### Tests written?

No
