### PR TITLE
Make grains for proxies work (though differently than the rest of Salt)

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -687,9 +687,6 @@ VALID_OPTS = {
     # The transport system for this daemon. (i.e. zeromq, raet, etc)
     'transport': str,
 
-    # FIXME Appears to be unused
-    'enumerate_proxy_minions': bool,
-
     # The number of seconds to wait when the client is requesting information about running jobs
     'gather_job_timeout': int,
 
@@ -805,6 +802,14 @@ VALID_OPTS = {
 
     # Delay in seconds before executing bootstrap (salt cloud)
     'bootstrap_delay': int,
+
+    # If a proxymodule has a function called 'grains', then call it during
+    # regular grains loading and merge the results with the proxy's grains
+    # dictionary.  Otherwise it is assumed that the module calls the grains
+    # function in a custom way and returns the data elsewhere
+    #
+    # Default to False for 2016.3 and Carbon.  Switch to True for Nitrogen
+    'proxy_merge_grains_in_module': bool,
 }
 
 # default configurations
@@ -1024,6 +1029,8 @@ DEFAULT_MINION_OPTS = {
     # ZMQ HWM for EventPublisher pub socket - different for minion vs. master
     'event_publisher_pub_hwm': 1000,
     'event_match_type': 'startswith',
+    # If a proxymodule has a function called 'grains' then call it and merge
+    # the results with the rest of the grains
 }
 
 DEFAULT_MASTER_OPTS = {
@@ -1230,7 +1237,6 @@ DEFAULT_MASTER_OPTS = {
     'sign_pub_messages': False,
     'keysize': 2048,
     'transport': 'zeromq',
-    'enumerate_proxy_minions': False,
     'gather_job_timeout': 10,
     'syndic_event_forward_timeout': 0.5,
     'syndic_max_event_process_time': 0.5,
@@ -1289,6 +1295,7 @@ DEFAULT_PROXY_MINION_OPTS = {
     'conf_file': os.path.join(salt.syspaths.CONFIG_DIR, 'proxy'),
     'log_file': os.path.join(salt.syspaths.LOGS_DIR, 'proxy'),
     'add_proxymodule_to_opts': False,
+    'proxy_merge_grains_in_module': False,
 }
 
 # ----- Salt Cloud Configuration Defaults ----------------------------------->

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1029,8 +1029,6 @@ DEFAULT_MINION_OPTS = {
     # ZMQ HWM for EventPublisher pub socket - different for minion vs. master
     'event_publisher_pub_hwm': 1000,
     'event_match_type': 'startswith',
-    # If a proxymodule has a function called 'grains' then call it and merge
-    # the results with the rest of the grains
 }
 
 DEFAULT_MASTER_OPTS = {

--- a/salt/grains/ssh_sample.py
+++ b/salt/grains/ssh_sample.py
@@ -5,14 +5,14 @@ Generate baseline proxy minion grains
 from __future__ import absolute_import
 import salt.utils
 
-__proxyenabled__ = ['rest_sample']
+__proxyenabled__ = ['ssh_sample']
 
-__virtualname__ = 'rest_sample'
+__virtualname__ = 'ssh_sample'
 
 
 def __virtual__():
     try:
-        if salt.utils.is_proxy() and __opts__['proxy']['proxytype'] == 'rest_sample':
+        if salt.utils.is_proxy() and __opts__['proxy']['proxytype'] == 'ssh_sample':
             return __virtualname__
     except KeyError:
         pass
@@ -31,21 +31,12 @@ def proxy_functions(proxy):
     grains sometimes get called before the LazyLoader object is setup
     so `proxy` might be None.
     '''
-    if proxy:
-        return {'proxy_functions': proxy['rest_sample.fns']()}
-
-
-def os():
-    return {'os': 'RestExampleOS'}
+    return {'proxy_functions': proxy['ssh_sample.fns']()}
 
 
 def location():
-    return {'location': 'In this darn virtual machine.  Let me out!'}
-
-
-def os_family():
-    return {'os_family': 'proxy'}
+    return {'location': 'At the other end of an SSH Tunnel!!'}
 
 
 def os_data():
-    return {'os_data': 'funkyHttp release 1.0.a.4.g'}
+    return {'os_data': 'DumbShell Endpoint release 4.09.g'}

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1044,7 +1044,7 @@ class Minion(MinionBase):
                 )
                 self.event_publisher.handle_publish(event, None)
 
-    def _load_modules(self, force_refresh=False, notify=False, proxy=None):
+    def _load_modules(self, force_refresh=False, notify=False):
         '''
         Return the functions and the returners loaded up from the loader
         module
@@ -1066,8 +1066,15 @@ class Minion(MinionBase):
             if not HAS_RESOURCE:
                 log.error('Unable to enforce modules_max_memory because resource is missing')
 
-        self.opts['grains'] = salt.loader.grains(self.opts, force_refresh)
+        # This might be a proxy minion
+        if hasattr(self, 'proxy'):
+            proxy = self.proxy
+        else:
+            proxy = None
+
+        self.opts['grains'] = salt.loader.grains(self.opts, force_refresh, proxy=proxy)
         self.utils = salt.loader.utils(self.opts)
+
         if self.opts.get('multimaster', False):
             s_opts = copy.deepcopy(self.opts)
             functions = salt.loader.minion_mods(s_opts, utils=self.utils, proxy=proxy,
@@ -1626,19 +1633,7 @@ class Minion(MinionBase):
         Refresh the functions and returners.
         '''
         log.debug('Refreshing modules. Notify={0}'.format(notify))
-        if hasattr(self, 'proxy'):
-            self.functions, self.returners, _, self.executors = self._load_modules(force_refresh,
-                                                                                   notify=notify,
-                                                                                   proxy=self.proxy)  # pylint: disable=no-member
-            # Proxies have a chicken-and-egg problem.  Usually we load grains early
-            # in the setup process, but we can't load grains for proxies until
-            # we talk to the device we are proxying for.  So force a grains
-            # sync here.
-            # Hmm...We can't seem to sync grains here, makes the event bus go nuts
-            # leaving this commented to remind future me that this is not a good idea here.
-            # self.functions['saltutil.sync_grains'](saltenv='base')
-        else:
-            self.functions, self.returners, _, self.executors = self._load_modules(force_refresh, notify=notify)
+        self.functions, self.returners, _, self.executors = self._load_modules(force_refresh, notify=notify)
 
         self.schedule.functions = self.functions
         self.schedule.returners = self.returners
@@ -2954,9 +2949,6 @@ class ProxyMinion(Minion):
         fq_proxyname = self.opts['pillar']['proxy']['proxytype']
         self.opts['proxy'] = self.opts['pillar']['proxy']
 
-        # We need to do this again, because we are going to throw out a lot of grains.
-        self.opts['grains'] = salt.loader.grains(self.opts)
-
         # Need to load the modules so they get all the dunder variables
         self.functions, self.returners, self.function_errors, self.executors = self._load_modules()
 
@@ -2971,7 +2963,7 @@ class ProxyMinion(Minion):
             self.opts['proxymodule'] = self.proxy
 
         # And re-load the modules so the __proxy__ variable gets injected
-        self.functions, self.returners, self.function_errors, self.executors = self._load_modules(proxy=self.proxy)
+        self.functions, self.returners, self.function_errors, self.executors = self._load_modules()
         self.functions.pack['__proxy__'] = self.proxy
         self.proxy.pack['__salt__'] = self.functions
         self.proxy.pack['__ret__'] = self.returners
@@ -2987,11 +2979,7 @@ class ProxyMinion(Minion):
         proxy_init_fn = self.proxy[fq_proxyname+'.init']
         proxy_init_fn(self.opts)
 
-        # Proxies have a chicken-and-egg problem.  Usually we load grains early
-        # in the setup process, but we can't load grains for proxies until
-        # we talk to the device we are proxying for.  So reload the grains
-        # functions here, and then force a grains sync in modules_refresh
-        self.opts['grains'] = salt.loader.grains(self.opts, force_refresh=True)
+        self.opts['grains'] = salt.loader.grains(self.opts, proxy=self.proxy)
 
         self.serial = salt.payload.Serial(self.opts)
         self.mod_opts = self._prep_mod_opts()
@@ -3054,4 +3042,6 @@ class ProxyMinion(Minion):
             self.schedule.delete_job('__master_alive', persist=True)
             self.schedule.delete_job('__master_failback', persist=True)
 
+        #  Sync the grains here so the proxy can communicate them to the master
+        self.functions['saltutil.sync_grains'](saltenv='base')
         self.grains_cache = self.opts['grains']

--- a/salt/proxy/rest_sample.py
+++ b/salt/proxy/rest_sample.py
@@ -33,12 +33,14 @@ def __virtual__():
     log.debug('rest_sample proxy __virtual__() called...')
     return True
 
-# Every proxy module needs an 'init', though you can
-# just put a 'pass' here if it doesn't need to do anything.
 
+# Every proxy module needs an 'init', though you can
+# just put DETAILS['initialized'] = True here if nothing
+# else needs to be done.
 
 def init(opts):
     log.debug('rest_sample proxy init() called...')
+    DETAILS['initialized'] = True
 
     # Save the REST URL
     DETAILS['url'] = opts['proxy']['url']
@@ -46,6 +48,15 @@ def init(opts):
     # Make sure the REST URL ends with a '/'
     if not DETAILS['url'].endswith('/'):
         DETAILS['url'] += '/'
+
+
+def initialized():
+    '''
+    Since grains are loaded in many different places and some of those
+    places occur before the proxy can be initialized, return whether
+    our init() function has been called
+    '''
+    return DETAILS.get('initialized', False)
 
 
 def id(opts):
@@ -62,18 +73,23 @@ def grains():
     '''
     Get the grains from the proxied device
     '''
-    if not GRAINS_CACHE:
+    if not DETAILS.get('grains_cache', {}):
         r = salt.utils.http.query(DETAILS['url']+'info', decode_type='json', decode=True)
-        GRAINS_CACHE = r['dict']
-    return GRAINS_CACHE
+        DETAILS['grains_cache'] = r['dict']
+    return DETAILS['grains_cache']
 
 
 def grains_refresh():
     '''
     Refresh the grains from the proxied device
     '''
-    GRAINS_CACHE = {}
+    DETAILS['grains_cache'] = None
     return grains()
+
+
+def fns():
+    return {'details': 'This key is here because a function in '
+                       'grains/rest_sample.py called fns() here in the proxymodule.'}
 
 
 def service_start(name):

--- a/salt/proxy/ssh_sample.py
+++ b/salt/proxy/ssh_sample.py
@@ -45,10 +45,50 @@ def init(opts):
                                           username=__opts__['proxy']['username'],
                                           password=__opts__['proxy']['password'])
         out, err = DETAILS['server'].sendline('help')
+        DETAILS['initialized'] = True
 
     except TerminalException as e:
         log.error(e)
         return False
+
+
+def initialized():
+    '''
+    Since grains are loaded in many different places and some of those
+    places occur before the proxy can be initialized, return whether
+    our init() function has been called
+    '''
+    return DETAILS.get('initialized', False)
+
+
+def grains():
+    '''
+    Get the grains from the proxied device
+    '''
+
+    if not DETAILS.get('grains_cache', {}):
+        cmd = 'info'
+
+        # Send the command to execute
+        out, err = DETAILS['server'].sendline(cmd)
+
+        # "scrape" the output and return the right fields as a dict
+        DETAILS['grains_cache'] = parse(out)
+
+    return DETAILS['grains_cache']
+
+
+def grains_refresh():
+    '''
+    Refresh the grains from the proxied device
+    '''
+    DETAILS['grains_cache'] = None
+    return grains()
+
+
+def fns():
+    return {'details': 'This key is here because a function in '
+            'grains/ssh_sample.py called fns() here in the proxymodule.'}
 
 
 def ping():


### PR DESCRIPTION
### What does this PR do?

Grains for proxy minions don't work well because during grain load, no dunder variables are injected.
Instead of allowing grains to look for `__proxy__` to cross-call to the proxymodule (to load information like facts from a network device, for example), have the loader pass the proxy LazyLoader object to any grains function that takes one argument.

Since grains functions normally take _no_ arguments, this should not affect backward compatibility.

In addition, the grains loading process will automatically call a function in the proxymodule called `grains` in case that is a better place to put the grains retrieval for a controlled device.  This functionality is controlled by a new config variable `proxy_merge_grains_in_module`, which defaults to `False` but will default to True in Nitrogen.  This is to prevent breaking existing proxymodules that have a `grains` function but execute it manually somehow.

This PR also updates the rest_sample and ssh_sample proxies to reflect this functionality.
### What issues does this PR fix or reference?
#30779
#30642
### Previous Behavior

Attempts to call `__proxy__` from grains modules would always fail since there is no `__proxy__` variable injected.  This behavior doesn't go away, but the (correct) approach is now...
### New Behavior

Grains functions that need access to the proxymodule can include one parameter in their function definition.  See the `rest_sample` and `ssh_sample` grains for an example.
### Tests written?

[ ] Yes
[X] No
