### PR TITLE
Replaces incorrect reference to `master_alive_check`

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -107,6 +107,8 @@ to manage the minion's master setting from an execution module. By simply
 changing the algorithm in the module to return a new master ip/fqdn, restart
 the minion and it will connect to the new master.
 
+.. conf_minion:: master_alive_interval
+
 ``master_alive_interval``
 -------------------------
 
@@ -117,6 +119,8 @@ the minion and it will connect to the new master.
 Configures how often, in seconds, the minion will verify that the current
 master is alive and responding.  The minion will try to establish a connection
 to the next master in the list if it finds the existing one is dead.
+
+.. conf_minion:: master_shuffle
 
 ``master_shuffle``
 ------------------
@@ -133,8 +137,10 @@ Python's :func:`random.shuffle <python2:random.shuffle>` method.
 
     master_shuffle: True
 
+.. conf_minion:: random_master
+
 ``random_master``
-------------------
+-----------------
 
 Default: ``False``
 
@@ -149,7 +155,7 @@ Python's :func:`random.randint <python2:random.randint>` method.
 .. conf_minion:: retry_dns
 
 ``retry_dns``
----------------
+-------------
 
 Default: ``30``
 

--- a/doc/topics/highavailability/index.rst
+++ b/doc/topics/highavailability/index.rst
@@ -28,14 +28,14 @@ A tutorial on setting up multimaster with "hot" masters is here:
 Multimaster with Failover
 =========================
 
-Changing the ``master_type`` parameter from ``str`` to ``failover`` will
-cause minions to connect to the first responding master in the list of masters.
-Every ``master_alive_check`` seconds the minions will check to make sure
-the current master is still responding.  If the master does not respond,
+Changing the ``master_type`` parameter from ``str`` to ``failover`` will cause
+minions to connect to the first responding master in the list of masters. Every
+:conf_minion:`master_alive_interval` seconds the minions will check to make
+sure the current master is still responding.  If the master does not respond,
 the minion will attempt to connect to the next master in the list.  If the
-minion runs out of masters, the list will be recycled in case dead masters
-have been restored.  Note that ``master_alive_check`` must be present in the
-minion configuration, or else the recurring job to check master status
+minion runs out of masters, the list will be recycled in case dead masters have
+been restored.  Note that :conf_minion:`master_alive_interval` must be present
+in the minion configuration, or else the recurring job to check master status
 will not get scheduled.
 
 Failover can be combined with PKI-style encrypted keys, but PKI is NOT


### PR DESCRIPTION
### What does this PR do?

Replaces incorrect reference to `master_alive_check` with `master_alive_interval` in docs
