### PR TITLE
MacOS tmpdir

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -858,41 +858,6 @@ def path_join(*parts):
     ))
 
 
-def abs_readlink(path):
-    '''
-    Return the absolute path.  If path is a link, dereference it first.
-
-    .. code-block:: python
-
-        >>> import os
-        >>> os.makedirs('/tmp/dir')
-        >>> os.chdir('/tmp/dir')
-        >>> open('/tmp/dir/target', 'w').close()
-        >>> os.symlink('target', 'link1')
-        >>> os.symlink('../dir/target', 'link2')
-        >>> os.symlink('/tmp/dir/target', 'link3')
-        >>> abs_readlink('/tmp/dir/target')
-        '/tmp/dir/target'
-        >>> abs_readlink('/tmp/dir/link1')
-        '/tmp/dir/target'
-        >>> abs_readlink('/tmp/dir/link2')
-        '/tmp/dir/target'
-        >>> abs_readlink('/tmp/dir/link3')
-        '/tmp/dir/target'
-        >>> from subprocess import call
-        >>> call(['rm', '-r', '/tmp/dir'])
-    '''
-    if os.path.islink(path):
-        base, lname = os.path.split(os.path.abspath(path))
-        target = os.readlink(path)
-        if target.startswith(os.sep):
-            return os.path.abspath(target)
-        else:  # target path is relative to supplied path
-            return os.path.abspath(os.path.join(base, target))
-    else:
-        return os.path.abspath(path)
-
-
 def pem_finger(path=None, key=None, sum_type='sha256'):
     '''
     Pass in either a raw pem string, or the path on disk to the location of a

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -78,7 +78,7 @@ if salt.utils.is_windows():
     import win32api
 
 
-SYS_TMP_DIR = salt.utils.abs_readlink(os.environ.get('TMPDIR', tempfile.gettempdir()))
+SYS_TMP_DIR = os.path.realpath(os.environ.get('TMPDIR', tempfile.gettempdir()))
 
 # Gentoo Portage prefers ebuild tests are rooted in ${TMPDIR}
 TMP = os.path.join(SYS_TMP_DIR, 'salt-tests-tmpdir')

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -73,14 +73,20 @@ except ImportError:
 # Import 3rd-party libs
 import yaml
 import salt.ext.six as six
-
 if salt.utils.is_windows():
     import win32api
 
 
-SYS_TMP_DIR = os.path.realpath(os.environ.get('TMPDIR', tempfile.gettempdir()))
+SYS_TMP_DIR = os.path.realpath(
+    os.environ.get(
+        # Avoid MacOS ${TMPDIR} as it yields a base path too long for unix sockets:
+        # 'error: AF_UNIX path too long'
+        # Gentoo Portage prefers ebuild tests are rooted in ${TMPDIR}
+        'TMPDIR' if not salt.utils.is_darwin() else '',
+        tempfile.gettempdir()
+    )
+)
 
-# Gentoo Portage prefers ebuild tests are rooted in ${TMPDIR}
 TMP = os.path.join(SYS_TMP_DIR, 'salt-tests-tmpdir')
 FILES = os.path.join(INTEGRATION_TEST_DIR, 'files')
 PYEXEC = 'python{0}.{1}'.format(*sys.version_info)

--- a/tests/integration/files/file/base/_modules/runtests_helpers.py
+++ b/tests/integration/files/file/base/_modules/runtests_helpers.py
@@ -12,11 +12,8 @@ from __future__ import absolute_import
 import os
 import tempfile
 
-# Import salt libs
-import salt.utils
 
-
-SYS_TMP_DIR = salt.utils.abs_readlink(os.environ.get('TMPDIR', tempfile.gettempdir()))
+SYS_TMP_DIR = os.path.realpath(os.environ.get('TMPDIR', tempfile.gettempdir()))
 # This tempdir path is defined on tests.integration.__init__
 TMP = os.path.join(SYS_TMP_DIR, 'salt-tests-tmpdir')
 

--- a/tests/integration/files/file/base/_modules/runtests_helpers.py
+++ b/tests/integration/files/file/base/_modules/runtests_helpers.py
@@ -12,8 +12,20 @@ from __future__ import absolute_import
 import os
 import tempfile
 
+# Import salt libs
+import salt.utils
 
-SYS_TMP_DIR = os.path.realpath(os.environ.get('TMPDIR', tempfile.gettempdir()))
+
+SYS_TMP_DIR = os.path.realpath(
+    os.environ.get(
+        # Avoid MacOS ${TMPDIR} as it yields a base path too long for unix sockets:
+        # 'error: AF_UNIX path too long'
+        # Gentoo Portage prefers ebuild tests are rooted in ${TMPDIR}
+        'TMPDIR' if not salt.utils.is_darwin() else '',
+        tempfile.gettempdir()
+    )
+)
+
 # This tempdir path is defined on tests.integration.__init__
 TMP = os.path.join(SYS_TMP_DIR, 'salt-tests-tmpdir')
 


### PR DESCRIPTION
### What does this PR do?

Use `os.path.realpath` and on MacOS use `tempfile.gettempdir()` rather than `${TMPDIR}` in the test suite.  The latter results in paths that are too long for unix sockets.
### What issues does this PR fix or reference?

Reverts bf894c3, 6b99798, and 4028d80.  `os.path.realpath` behaves identically to `salt.utils.abs_readlink` on the doc tests in that function.
### Tests written?

No
