### PR TITLE
Catch Attribute Error when docker.version_info doesn't exist

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -529,7 +529,7 @@ def __virtual__():
     if HAS_DOCKER_PY:
         try:
             docker_py_versioninfo = _get_docker_py_versioninfo()
-        except CommandExecutionError:
+        except (CommandExecutionError, AttributeError):
             docker_py_versioninfo = None
 
         # Don't let a failure to interpret the version keep this module from


### PR DESCRIPTION
### What does this PR do?
### What issues does this PR fix or reference?
#32261
### Previous Behavior

bunch of errors in the log
### New Behavior

catch old versions of docker-python
### Tests written?

No

fixes #32261
