### PR TITLE
Fix check_exists in alternatives module

### DIFF
--- a/salt/modules/alternatives.py
+++ b/salt/modules/alternatives.py
@@ -98,7 +98,7 @@ def check_exists(name, path):
     if out['retcode'] > 0 and out['stderr'] != '':
         return False
 
-    return any((line.startswith(path) for line in out['stdout'].splitlines())
+    return any((line.startswith(path) for line in out['stdout'].splitlines()))
 
 
 def check_installed(name, path):

--- a/salt/modules/alternatives.py
+++ b/salt/modules/alternatives.py
@@ -98,7 +98,7 @@ def check_exists(name, path):
     if out['retcode'] > 0 and out['stderr'] != '':
         return False
 
-    return path in out['stdout'].splitlines()
+    return any((line.startswith(path) for line in out['stdout'].splitlines())
 
 
 def check_installed(name, path):


### PR DESCRIPTION
### What does this PR do?

Fix the alternatives module to correctly detect if an alternative has installed a specific path.
### What issues does this PR fix or reference?

none
### Previous Behavior

The alternatives state always showed that the alternative was not set correctly although it was.
### New Behavior

The alternatives state now correctly detects that the alternative is installed as desired.
### Tests written?

No

The output of update-alternatives --display contains not only a path but
a path followed by its priority. The check must therefore use startswith
on each output line.

This code will still fail if the provided path is a prefix of one of the installed paths for that alternative. (It reports that path as being installed although it is not.) To fix this the whole line needs to be parsed into segments: `[path] - priority [number]` I'm not sure if this format is used on every platform so I didn't go that far.
