### PR TITLE
mysql: use replication safe create db statement

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -984,7 +984,7 @@ def db_create(name, character_set=None, collate=None, **connection_args):
     cur = dbc.cursor()
     s_name = quote_identifier(name)
     # identifiers cannot be used as values
-    qry = 'CREATE DATABASE {0}'.format(s_name)
+    qry = 'CREATE DATABASE IF NOT EXISTS {0}'.format(s_name)
     args = {}
     if character_set is not None:
         qry += ' CHARACTER SET %(character_set)s'


### PR DESCRIPTION
### What does this PR do?

Prevent create database statement breaking MySQL replication
### What issues does this PR fix or reference?

N/A
### Previous Behavior

CREATE DATABASE is written to the binary log. Statement is executed on a slave, which already has the database due to Salt managing them, and causes replication failure.
### New Behavior

No changes in behavior due to the fact that DB existence is already checked before creation. This does however fix the issue of breaking replication.
### Tests written?

No
