### PR TITLE
[dockerng] Improve detection for older versions of docker-py

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -525,15 +525,14 @@ def __virtual__():
     Only load if docker libs are present
     '''
     if HAS_DOCKER_PY:
-        try:
-            docker_py_versioninfo = _get_docker_py_versioninfo()
-        except CommandExecutionError:
-            docker_py_versioninfo = None
+        docker_py_versioninfo = _get_docker_py_versioninfo()
 
         # Don't let a failure to interpret the version keep this module from
         # loading. Log a warning (log happens in _get_docker_py_versioninfo()).
-        if docker_py_versioninfo is None \
-                or docker_py_versioninfo >= MIN_DOCKER_PY:
+        if docker_py_versioninfo is None:
+            return (False, 'Docker module found, but no version could be'
+                    ' extracted')
+        if docker_py_versioninfo >= MIN_DOCKER_PY:
             try:
                 docker_versioninfo = version().get('VersionInfo')
             except CommandExecutionError:
@@ -547,20 +546,22 @@ def __virtual__():
                     '{0}, installed: {1})'.format(
                         '.'.join(map(str, MIN_DOCKER)),
                         '.'.join(map(str, docker_versioninfo))))
-        else:
-            return (False,
-                'Insufficient docker-py version for dockerng (required: '
-                '{0}, installed: {1})'.format(
-                    '.'.join(map(str, MIN_DOCKER_PY)),
-                    '.'.join(map(str, docker_py_versioninfo))))
+        return (False,
+            'Insufficient docker-py version for dockerng (required: '
+            '{0}, installed: {1})'.format(
+                '.'.join(map(str, MIN_DOCKER_PY)),
+                '.'.join(map(str, docker_py_versioninfo))))
     return (False, 'Docker module could not get imported')
 
 
 def _get_docker_py_versioninfo():
     '''
-    Returns a version_info tuple for docker-py
+    Returns the version_info tuple from docker-py
     '''
-    return docker.version_info
+    try:
+        return docker.version_info
+    except AttributeError:
+        pass
 
 
 # Decorators


### PR DESCRIPTION
### What does this PR do?

Improve detection for older versions of docker-py. Older means docker module without a `docker.version_info` property.
### What issues does this PR fix or reference?

fixes #32261
precedes #32262
### Previous Behavior

When old docker-py was installed salt was reporting an exception instead of discarding `dockerng` execution module.
### Tests written?

No
