### PR TITLE
Move check for the working directory before running the command. Fix …

### DIFF
--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -567,10 +567,6 @@ def run(name,
            'result': False,
            'comment': ''}
 
-    if cwd and not os.path.isdir(cwd):
-        ret['comment'] = 'Desired working directory "{0}" is not available'.format(cwd)
-        return ret
-
     # Need the check for None here, if env is not provided then it falls back
     # to None and it is assumed that the environment is not being overridden.
     if env is not None and not isinstance(env, (list, dict)):
@@ -593,6 +589,10 @@ def run(name,
         cret = _run_check(cmd_kwargs, onlyif, unless, group)
         if isinstance(cret, dict):
             ret.update(cret)
+            return ret
+
+        if cwd and not os.path.isdir(cwd):
+            ret['comment'] = 'Desired working directory "{0}" is not available'.format(cwd)
             return ret
 
         # Wow, we passed the test, run this sucker!
@@ -712,10 +712,6 @@ def script(name,
            'result': False,
            'comment': ''}
 
-    if cwd and not os.path.isdir(cwd):
-        ret['comment'] = 'Desired working directory "{0}" is not available'.format(cwd)
-        return ret
-
     # Need the check for None here, if env is not provided then it falls back
     # to None and it is assumed that the environment is not being overridden.
     if env is not None and not isinstance(env, (list, dict)):
@@ -767,6 +763,10 @@ def script(name,
             ret['comment'] = 'Command {0!r} would have been executed'
             ret['comment'] = ret['comment'].format(name)
             return _reinterpreted_state(ret) if stateful else ret
+
+        if cwd and not os.path.isdir(cwd):
+            ret['comment'] = 'Desired working directory "{0}" is not available'.format(cwd)
+            return ret
 
         # Wow, we passed the test, run this sucker!
         try:


### PR DESCRIPTION
### What does this PR do?

Fix issue #11497
### What issues does this PR fix or reference?

Move the test for working directory presence after the should run test (unless or if).
### Previous Behavior

If the working directory does not exists, the command will failed even if check commands (unless) returns that the command should not be runned.
### New Behavior

cmd.run and cmd.wait won't failed if the working directory does not exists and unless check returns that the command should not be runned.
### Tests written?

No. no test for cmd in version 2014.1
