### PR TITLE
Changed /tmp/ to /home/ user.present test

### DIFF
--- a/tests/integration/states/user.py
+++ b/tests/integration/states/user.py
@@ -71,7 +71,7 @@ class UserTest(integration.ModuleCase,
         And then destroys that user.
         Assume that it will break any system you run it on.
         '''
-        HOMEDIR = '/tmp/home_of_salt_test'
+        HOMEDIR = '/home/home_of_salt_test'
         ret = self.run_state('user.present', name='salt_test',
                              home=HOMEDIR)
         self.assertSaltTrueReturn(ret)


### PR DESCRIPTION
### What does this PR do?

Changes the home directory from /tmp/home_of_salt_test to /home/home_of_salt_test. This change is due to https://github.com/saltstack/salt/issues/32280
### What issues does this PR fix or reference?

Fixes failing test on Fedora 23
### Tests written?

Yes
