### PR TITLE
Reimplement #31172, which got removed in a merge-forward.

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1913,6 +1913,7 @@ def cloud_config(path, env_var='SALT_CLOUD_CONFIG', defaults=None,
         os.path.abspath(
             os.path.join(
                 os.path.dirname(__file__),
+                '..',
                 'cloud',
                 'deploy'
             )

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -465,6 +465,7 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
         self.assertRaises(SaltCloudConfigError, sconfig.cloud_config, PATH,
                           providers_config_path='bar')
 
+    @patch('os.path.isdir', MagicMock(return_value=True))
     def test_cloud_config_deploy_scripts_search_path(self):
         '''
         Tests the contents of the 'deploy_scripts_search_path' tuple to ensure that
@@ -474,24 +475,14 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
         and ``<path-to-salt-install>/salt/cloud/deploy``.
         '''
         search_paths = sconfig.cloud_config('/etc/salt/cloud').get('deploy_scripts_search_path')
-        print('search_paths = {0}'.format(search_paths))
-        etc_deploy_path = '/etc/salt/cloud.deploy.d'
+        etc_deploy_path = '/salt/cloud.deploy.d'
         deploy_path = '/salt/cloud/deploy'
 
-        # First, assert the cloud.deploy.d path is present in search_paths tuple
-        self.assertIn(etc_deploy_path, search_paths)
+        # Check cloud.deploy.d path is the first element in the search_paths tuple
+        self.assertTrue(search_paths[0].endswith(etc_deploy_path))
 
-        # Get the indexes of each deploy path, just in case something changes.
-        etc_index = search_paths.index(etc_deploy_path)
-        if etc_index == 0:
-            deploy_index = 1
-        else:
-            deploy_index = 0
-
-        # Test the second deploy path
-        self.assertTrue(
-            search_paths[deploy_index].endswith(deploy_path)
-        )
+        # Check the second element in the search_paths tuple
+        self.assertTrue(search_paths[1].endswith(deploy_path))
 
     # apply_cloud_config tests
 

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -465,6 +465,33 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
         self.assertRaises(SaltCloudConfigError, sconfig.cloud_config, PATH,
                           providers_config_path='bar')
 
+    def test_cloud_config_deploy_scripts_search_path(self):
+        '''
+        Tests the contents of the 'deploy_scripts_search_path' tuple to ensure that
+        the correct deploy search paths are present.
+
+        There should be two search paths reported in the tuple: ``/etc/salt/cloud.deploy.d``
+        and ``<path-to-salt-install>/salt/cloud/deploy``.
+        '''
+        search_paths = sconfig.cloud_config('/etc/salt/cloud').get('deploy_scripts_search_path')
+        etc_deploy_path = '/etc/salt/cloud.deploy.d'
+        deploy_path = '/salt/cloud/deploy'
+
+        # First, assert the cloud.deploy.d path is present in search_paths tuple
+        self.assertIn(etc_deploy_path, search_paths)
+
+        # Get the indexes of each deploy path, just in case something changes.
+        etc_index = search_paths.index(etc_deploy_path)
+        if etc_index == 0:
+            deploy_index = 1
+        else:
+            deploy_index = 0
+
+        # Test the second deploy path
+        self.assertTrue(
+            search_paths[deploy_index].endswith(deploy_path)
+        )
+
     # apply_cloud_config tests
 
     def test_apply_cloud_config_no_provider_detail_list(self):

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -474,6 +474,7 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
         and ``<path-to-salt-install>/salt/cloud/deploy``.
         '''
         search_paths = sconfig.cloud_config('/etc/salt/cloud').get('deploy_scripts_search_path')
+        print('search_paths = {0}'.format(search_paths))
         etc_deploy_path = '/etc/salt/cloud.deploy.d'
         deploy_path = '/salt/cloud/deploy'
 


### PR DESCRIPTION
### What does this PR do?

This fixes #32183 for the 2016.3 branch. #32105 fixed the salt-cloud deploy directory regression in the 2015.8 branch, but during a merge forward, removed the reference in the 2016.3 branch. This reinstates the necessary change in #31172 for the 2016.3 branch.
### Tests written?

Yes
