### PR TITLE
New salt-cloud instances should not use old hash_type default.

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -219,7 +219,8 @@ def minion_config(opts, vm_):
     # Some default options are Null, let's set a reasonable default
     minion.update(
         log_level='info',
-        log_level_logfile='info'
+        log_level_logfile='info',
+        hash_type='sha256'
     )
 
     # Now, let's update it to our needs


### PR DESCRIPTION
### What does this PR do?

Updates hash_type default to sha256 instead of md5 for new instances created via salt-cloud.
### What issues does this PR fix or reference?

Fixes #32246
Refs #31162
### Previous Behavior

Whenever the minion is started/restarted, the following warning occurs:

```
[WARNING ] IMPORTANT: Do not use md5 hashing algorithm! Please set "hash_type" to SHA256 in Salt Master config
```

Because the minion config file is generated from the defaults in `salt/config.py`. New instances that are spun up via salt-cloud should have the new hash_type "default" of sha256 instead of md5.
### New Behavior

The minion generated via salt-cloud has sha256 set as its hash_type, instead of md5, and does not display the warning.
### Tests written?

No
