### PR TITLE
Fix bad output for chocolatey.version (fixes #14277)

### DIFF
--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -786,13 +786,7 @@ def version(name, check_remote=False, source=None, pre_versions=False):
         log.error(err)
         raise CommandExecutionError(err)
 
-    use_list = _LooseVersion(chocolatey_version()) >= _LooseVersion('0.9.9')
-    if use_list:
-        choco_cmd = "list"
-    else:
-        choco_cmd = "version"
-
-    cmd = [choc_path, choco_cmd, name]
+    cmd = [choc_path, 'list', name]
     if not salt.utils.is_true(check_remote):
         cmd.append('-LocalOnly')
     if salt.utils.is_true(pre_versions):
@@ -810,22 +804,11 @@ def version(name, check_remote=False, source=None, pre_versions=False):
     ret = {}
 
     res = result['stdout'].split('\n')
-    if use_list:
-        res = res[:-1]
 
-    # the next bit is to deal with the stupid default PowerShell formatting.
-    # printing two value pairs is shown in columns, whereas printing six
-    # pairs is shown in rows...
-    if not salt.utils.is_true(check_remote):
-        ver_re = re.compile(r'(\S+)\s+(.+)')
-        for line in res:
+    ver_re = re.compile(r'(\S+)\s+(.+)')
+    for line in res:
+        if 'packages found' not in line:
             for name, ver in ver_re.findall(line):
-                ret['name'] = name
-                ret['found'] = ver
-    else:
-        ver_re = re.compile(r'(\S+)\s+:\s*(.*)')
-        for line in res:
-            for key, value in ver_re.findall(line):
-                ret[key] = value
+                ret[name] = ver
 
     return ret

--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -807,7 +807,7 @@ def version(name, check_remote=False, source=None, pre_versions=False):
 
     ver_re = re.compile(r'(\S+)\s+(.+)')
     for line in res:
-        if 'packages found' not in line:
+        if 'packages found' not in line and 'packages installed' not in line:
             for name, ver in ver_re.findall(line):
                 ret[name] = ver
 


### PR DESCRIPTION
### What does this PR do?

Fixes chocolatey.version. Tested on Chocolatey 9.8 and 9.9.
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/14277
### Previous Behavior

The function would return an empty dict or random text
### New Behavior

The function returns a list of installed software or a list of available software if `check_remote=True` that matches the passed name.
### Tests written?

No
