### PR TITLE
Sync all modules at proxy startup in case the proxymodule needs other modules.

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2953,7 +2953,9 @@ class ProxyMinion(Minion):
         self.functions, self.returners, self.function_errors, self.executors = self._load_modules()
 
         # we can then sync any proxymodules down from the master
-        self.functions['saltutil.sync_proxymodules'](saltenv='base')
+        # we do a sync_all here in case proxy code was installed by
+        # SPM or was manually placed in /srv/salt/_modules etc.
+        self.functions['saltutil.sync_all'](saltenv='base')
 
         # Then load the proxy module
         self.proxy = salt.loader.proxy(self.opts)


### PR DESCRIPTION
### What does this PR do?

Instead of syncing just proxymodules from the master at startup, sync all modules.
### Previous Behavior

On startup `salt-proxy` would sync proxymodules from the master so custom proxies or proxies installed via SPM could be used.  However, some proxymodules need execution modules or grains that would not be synced.
### New Behavior

Do the equivalent of `saltutil.sync_all` at proxy start before attempting to LazyLoad and call the proxy's `init()` function.
### Tests written?

No
