### PR TITLE
Parallels Desktop execution module

### DIFF
--- a/salt/modules/parallels.py
+++ b/salt/modules/parallels.py
@@ -334,16 +334,16 @@ def snapshot_id_to_name(name, id, runas=None):
     try:
         data = yaml.safe_load(info)
         if isinstance(data, dict):
-            snapshot = data.get('Name', '')
+            snap_name = data.get('Name', '')
             # Do not return None if snapshot name is of type NoneType
-            return snapshot if snapshot else ''
+            return snap_name if snap_name else ''
         else:
             return ''
     except yaml.YAMLError:
         return ''
 
 
-def snapshot_name_to_id(name, snapshot, runas=None):
+def snapshot_name_to_id(name, snap_name, runas=None):
     '''
     Attempt to convert a snapshot name to a snapshot ID.  If the name is not
     found an empty string is returned.  If multiple snapshots share the same
@@ -353,7 +353,7 @@ def snapshot_name_to_id(name, snapshot, runas=None):
 
         Name/ID of VM whose snapshots are inspected
 
-    :param str name:
+    :param str snap_name:
 
         Name of the snapshot
 
@@ -375,12 +375,12 @@ def snapshot_name_to_id(name, snapshot, runas=None):
 
     # Try to match the snapshot name to an ID
     for id in ids:
-        if snapshot_id_to_name(name, id, runas=runas) == snapshot:
+        if snapshot_id_to_name(name, id, runas=runas) == snap_name:
             return id
     return ''
 
 
-def snapshot(name, snapshot=None, desc=None, runas=None):
+def snapshot(name, snap_name=None, desc=None, runas=None):
     '''
     Create a snapshot
 
@@ -388,7 +388,7 @@ def snapshot(name, snapshot=None, desc=None, runas=None):
 
         Name/ID of VM to take a snapshot of
 
-    :param str snapshot:
+    :param str snap_name:
 
         Name of snapshot
 
@@ -404,13 +404,13 @@ def snapshot(name, snapshot=None, desc=None, runas=None):
 
     .. code-block:: bash
 
-        salt '*' parallels.create_snapshot macvm snapshot=macvm-original runas=macdev
-        salt '*' parallels.create_snapshot macvm snapshot=macvm-updates desc='clean install with updates' runas=macdev
+        salt '*' parallels.create_snapshot macvm snap_name=macvm-original runas=macdev
+        salt '*' parallels.create_snapshot macvm snap_name=macvm-updates desc='clean install with updates' runas=macdev
     '''
     # Construct argument list
     args = [name]
-    if snapshot:
-        args.extend(['--name', snapshot])
+    if snap_name:
+        args.extend(['--name', snap_name])
     if desc:
         args.extend(['--description', desc])
 

--- a/salt/modules/parallels.py
+++ b/salt/modules/parallels.py
@@ -250,7 +250,7 @@ def status(name, runas=None):
     return prlctl('status', name, runas=runas)
 
 
-def list_snapshots(name, id=None, tree=False, runas=None):
+def list_snapshots(name, snap_id=None, tree=False, runas=None):
     '''
     List the snapshots
 
@@ -258,7 +258,7 @@ def list_snapshots(name, id=None, tree=False, runas=None):
 
         Name/ID of VM whose snapshots will be listed
 
-    :param str id:
+    :param str snap_id:
 
         ID of snapshot to display information about.  If ``tree=True`` is also
         specified, display the snapshot subtree having this snapshot as the
@@ -278,20 +278,20 @@ def list_snapshots(name, id=None, tree=False, runas=None):
 
         salt '*' parallels.list_snapshots macvm runas=macdev
         salt '*' parallels.list_snapshots macvm tree=True runas=macdev
-        salt '*' parallels.list_snapshots macvm id=eb56cd24-977f-43e6-b72f-5dcb75e815ad runas=macdev
+        salt '*' parallels.list_snapshots macvm snap_id=eb56cd24-977f-43e6-b72f-5dcb75e815ad runas=macdev
     '''
     # Construct argument list
     args = [name]
     if tree:
         args.append('--tree')
-    if id:
-        args.extend(['--id', id])
+    if snap_id:
+        args.extend(['--id', snap_id])
 
     # Execute command and return output
     return prlctl('snapshot-list', args, runas=runas)
 
 
-def snapshot_id_to_name(name, id, runas=None):
+def snapshot_id_to_name(name, snap_id, runas=None):
     '''
     Attempt to convert a snapshot ID to a snapshot name.  If the snapshot has
     no name or if the ID is not found or invalid, an empty string will be returned
@@ -300,7 +300,7 @@ def snapshot_id_to_name(name, id, runas=None):
 
         Name/ID of VM whose snapshots are inspected
 
-    :param str id:
+    :param str snap_id:
 
         ID of the snapshot
 
@@ -326,7 +326,7 @@ def snapshot_id_to_name(name, id, runas=None):
         salt '*' parallels.snapshot_id_to_name macvm a5b8999f-5d95-4aff-82de-e515b0101b66 runas=macdev
     '''
     # Get the snapshot information of the snapshot having the requested ID
-    info = list_snapshots(name, id=id, runas=runas)
+    info = list_snapshots(name, snap_id=snap_id, runas=runas)
 
     # Try to interpret the information.  This should be fine if parallels
     # desktop does not change its format too much, otherwise more custom logic
@@ -371,12 +371,12 @@ def snapshot_name_to_id(name, snap_name, runas=None):
     res = list_snapshots(name, runas=runas)
 
     # Find all GUIDs in the string
-    ids = set([found.group(0) for found in re.finditer(GUID_REGEX, res)])
+    snap_ids = set([found.group(0) for found in re.finditer(GUID_REGEX, res)])
 
     # Try to match the snapshot name to an ID
-    for id in ids:
-        if snapshot_id_to_name(name, id, runas=runas) == snap_name:
-            return id
+    for snap_id in snap_ids:
+        if snapshot_id_to_name(name, snap_id, runas=runas) == snap_name:
+            return snap_id
     return ''
 
 
@@ -418,7 +418,7 @@ def snapshot(name, snap_name=None, desc=None, runas=None):
     return prlctl('snapshot', args, runas=runas)
 
 
-def delete_snapshot(name, id, runas=None):
+def delete_snapshot(name, snap_id, runas=None):
     '''
     Delete a snapshot
 
@@ -431,7 +431,7 @@ def delete_snapshot(name, id, runas=None):
 
         Name/ID of VM whose snapshot will be deleted
 
-    :param str id:
+    :param str snap_id:
 
         ID of snapshot to delete
 
@@ -446,13 +446,13 @@ def delete_snapshot(name, id, runas=None):
         salt '*' parallels.delete_snapshot macvm eb56cd24-977f-43e6-b72f-5dcb75e815ad runas=macdev
     '''
     # Construct argument list
-    args = [name, '--id', id]
+    args = [name, '--id', snap_id]
 
     # Execute command and return output
     return prlctl('snapshot-delete', args, runas=runas)
 
 
-def revert_snapshot(name, id, runas=None):
+def revert_snapshot(name, snap_id, runas=None):
     '''
     Revert a VM to a snapshot
 
@@ -460,7 +460,7 @@ def revert_snapshot(name, id, runas=None):
 
         Name/ID of VM to revert to a snapshot
 
-    :param str id:
+    :param str snap_id:
 
         ID of snapshot to revert to
 
@@ -475,7 +475,7 @@ def revert_snapshot(name, id, runas=None):
         salt '*' parallels.revert_snapshot macvm eb56cd24-977f-43e6-b72f-5dcb75e815ad runas=macdev
     '''
     # Construct argument list
-    args = [name, '--id', id]
+    args = [name, '--id', snap_id]
 
     # Execute command and return output
     return prlctl('snapshot-switch', args, runas=runas)

--- a/salt/modules/parallels.py
+++ b/salt/modules/parallels.py
@@ -1,0 +1,337 @@
+# -*- coding: utf-8 -*-
+'''
+Manage Parallels Desktop VMs with prlctl
+
+http://download.parallels.com/desktop/v9/ga/docs/en_US/Parallels%20Command%20Line%20Reference%20Guide.pdf
+
+.. versionadded:: 2016.3.0
+'''
+from __future__ import absolute_import
+
+# Import python libs
+import logging
+import shlex
+
+# Import salt libs
+import salt.utils
+from salt.exceptions import SaltInvocationError
+
+# Import 3rd party libs
+import salt.ext.six as six
+
+__virtualname__ = 'parallels'
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Load this module if prlctl is available
+    '''
+    if not salt.utils.which('prlctl'):
+        return (False, 'Cannot load prlctl module: prlctl utility not available')
+    return __virtualname__
+
+
+def _normalize_args(args):
+    '''
+    Return args as a list of strings
+    '''
+    if isinstance(args, six.string_types):
+        return shlex.split(args)
+
+    if isinstance(args, (tuple, list)):
+        return [str(arg) for arg in args]
+    else:
+        return [str(args)]
+
+
+def prlctl(sub_cmd, args=None):
+    '''
+    Execute a prlctl command
+
+    :param str sub_cmd:
+
+        prlctl subcommand to execute
+
+    :param str args:
+
+        The arguments supplied to ``prlctl <sub_cmd>``
+
+    Example:
+
+    .. code-block:: bash
+
+        salt '*' parallels.prlctl user list
+        salt '*' parallels.prlctl exec 'macvm uname'
+    '''
+    # Construct command
+    cmd = ['prlctl', sub_cmd]
+    if args:
+        cmd.extend(_normalize_args(args))
+
+    # Execute command and return output
+    return __salt__['cmd.run'](cmd)
+
+
+def list_vms(name=None, info=False, args=None):
+    '''
+    List information about the VMs
+
+    :param str name:
+
+        Name/ID of VM to list; implies ``info=True``
+
+    :param str info:
+
+        List extra information
+
+    :param tuple args:
+
+        Additional arguments given to ``prctl list``.  This argument is
+        mutually exclusive with the ``name`` and ``info`` arguments
+
+    Example:
+
+    .. code-block:: bash
+
+        salt '*' parallels.list_vms
+        salt '*' parallels.list_vms name=macvm
+        salt '*' parallels.list_vms info=True
+        salt '*' parallels.list_vms '--all -o uuid,status --info'
+    '''
+    # Construct argument list
+    if args is None:
+        args = []
+    else:
+        args = _normalize_args(args)
+
+    if name:
+        args.extend(['--info', name])
+    elif info:
+        args.append('--info')
+
+    # Execute command and return output
+    return prlctl('list', args)
+
+
+def start(name):
+    '''
+    Start a VM
+
+    :param str name:
+
+        Name/ID of VM to start
+
+    Example:
+
+    .. code-block:: bash
+
+        salt '*' parallels.start macvm
+    '''
+    return prlctl('start', name)
+
+
+def stop(name, kill=False):
+    '''
+    Stop a VM
+
+    :param str name:
+
+        Name/ID of VM to stop
+
+    :param bool kill:
+
+        Perform a hard shutdown
+
+    Example:
+
+    .. code-block:: bash
+
+        salt '*' parallels.stop macvm
+        salt '*' parallels.stop macvm kill=True
+    '''
+    # Construct argument list
+    args = [name]
+    if kill:
+        args.append('--kill')
+
+    # Execute command and return output
+    return prlctl('stop', args)
+
+
+def restart(name):
+    '''
+    Restart a VM by gracefully shutting it down and then restarting
+    it
+
+    :param str name:
+
+        Name/ID of VM to restart
+
+    Example:
+
+    .. code-block:: bash
+
+        salt '*' parallels.restart macvm
+    '''
+    return prlctl('restart', name)
+
+
+def reset(name):
+    '''
+    Reset a VM by performing a hard shutdown and then a restart
+
+    :param str name:
+
+        Name/ID of VM to reset
+
+    Example:
+
+    .. code-block:: bash
+
+        salt '*' parallels.reset macvm
+    '''
+    return prlctl('reset', name)
+
+
+def status(name):
+    '''
+    Status of a VM
+
+    :param str name:
+
+        Name/ID of VM whose status will be returned
+
+    Example:
+
+    .. code-block:: bash
+
+        salt '*' parallels.status macvm
+    '''
+    return prlctl('status', name)
+
+
+def list_snapshots(name, id=None, tree=False):
+    '''
+    List the snapshots
+
+    :param str name:
+
+        Name/ID of VM whose snapshots will be listed
+
+    :param str id:
+
+        ID of snapshot to display information about.  If ``tree=True`` is also
+        specified, display the snapshot subtree having this snapshot as the
+        root snapshot
+
+    :param bool tree:
+
+        List snapshots in tree format rather than tabular format
+
+    Example:
+
+    .. code-block:: bash
+
+        salt '*' parallels.list_snapshots macvm
+        salt '*' parallels.list_snapshots macvm tree=True
+        salt '*' parallels.list_snapshots macvm id=eb56cd24-977f-43e6-b72f-5dcb75e815ad
+    '''
+    # Construct argument list
+    args = [name]
+    if tree:
+        args.append('--tree')
+    if id:
+        args.extend(['--id', id])
+
+    # Execute command and return output
+    return prlctl('snapshot-list', args)
+
+
+def snapshot(name, snapshot=None, desc=None):
+    '''
+    Create a snapshot
+
+    :param str name:
+
+        Name/ID of VM to take a snapshot of
+
+    :param str snapshot:
+
+        Name of snapshot
+
+    :param str desc:
+
+        Description of snapshot
+
+    Example:
+
+    .. code-block:: bash
+
+        salt '*' parallels.create_snapshot macvm snapshot=macvm-original
+        salt '*' parallels.create_snapshot macvm snapshot=macvm-updates desc='clean install with updates'
+    '''
+    # Construct argument list
+    args = [name]
+    if snapshot:
+        args.extend(['--name', snapshot])
+    if desc:
+        args.extend(['--description', desc])
+
+    # Execute command and return output
+    return prlctl('snapshot', args)
+
+
+def delete_snapshot(name, id):
+    '''
+    Delete a snapshot
+
+    .. note::
+
+        Deleting a snapshot from which other snapshots are dervied will not
+        delete the derived snapshots
+
+    :param str name:
+
+        Name/ID of VM whose snapshot will be deleted
+
+    :param str id:
+
+        ID of snapshot to delete
+
+    Example:
+
+    .. code-block:: bash
+
+        salt '*' parallels.delete_snapshot macvm eb56cd24-977f-43e6-b72f-5dcb75e815ad
+    '''
+    # Construct argument list
+    args = [name, '--id', id]
+
+    # Execute command and return output
+    return prlctl('snapshot-delete', args)
+
+
+def revert_snapshot(name, id):
+    '''
+    Revert a VM to a snapshot
+
+    :param str name:
+
+        Name/ID of VM to revert to a snapshot
+
+    :param str id:
+
+        ID of snapshot to revert to
+
+    Example:
+
+    .. code-block:: bash
+
+        salt '*' parallels.revert_snapshot macvm eb56cd24-977f-43e6-b72f-5dcb75e815ad
+    '''
+    # Construct argument list
+    args = [name, '--id', id]
+
+    # Execute command and return output
+    return prlctl('snapshot-switch', args)

--- a/salt/modules/parallels.py
+++ b/salt/modules/parallels.py
@@ -45,7 +45,7 @@ def _normalize_args(args):
         return [str(args)]
 
 
-def prlctl(sub_cmd, args=None):
+def prlctl(sub_cmd, args=None, runas=None):
     '''
     Execute a prlctl command
 
@@ -57,12 +57,16 @@ def prlctl(sub_cmd, args=None):
 
         The arguments supplied to ``prlctl <sub_cmd>``
 
+    :param str runas:
+
+        The user that the prlctl command will be run as
+
     Example:
 
     .. code-block:: bash
 
-        salt '*' parallels.prlctl user list
-        salt '*' parallels.prlctl exec 'macvm uname'
+        salt '*' parallels.prlctl user list runas=macdev
+        salt '*' parallels.prlctl exec 'macvm uname' runas=macdev
     '''
     # Construct command
     cmd = ['prlctl', sub_cmd]
@@ -70,10 +74,10 @@ def prlctl(sub_cmd, args=None):
         cmd.extend(_normalize_args(args))
 
     # Execute command and return output
-    return __salt__['cmd.run'](cmd)
+    return __salt__['cmd.run'](cmd, runas=runas)
 
 
-def list_vms(name=None, info=False, args=None):
+def list_vms(name=None, info=False, args=None, runas=None):
     '''
     List information about the VMs
 
@@ -90,14 +94,18 @@ def list_vms(name=None, info=False, args=None):
         Additional arguments given to ``prctl list``.  This argument is
         mutually exclusive with the ``name`` and ``info`` arguments
 
+    :param str runas:
+
+        The user that the prlctl command will be run as
+
     Example:
 
     .. code-block:: bash
 
-        salt '*' parallels.list_vms
-        salt '*' parallels.list_vms name=macvm
-        salt '*' parallels.list_vms info=True
-        salt '*' parallels.list_vms '--all -o uuid,status --info'
+        salt '*' parallels.list_vms runas=macdev
+        salt '*' parallels.list_vms name=macvm runas=macdev
+        salt '*' parallels.list_vms info=True runas=macdev
+        salt '*' parallels.list_vms '--all -o uuid,status --info' runas=macdev
     '''
     # Construct argument list
     if args is None:
@@ -111,10 +119,10 @@ def list_vms(name=None, info=False, args=None):
         args.append('--info')
 
     # Execute command and return output
-    return prlctl('list', args)
+    return prlctl('list', args, runas=runas)
 
 
-def start(name):
+def start(name, runas=None):
     '''
     Start a VM
 
@@ -122,16 +130,20 @@ def start(name):
 
         Name/ID of VM to start
 
+    :param str runas:
+
+        The user that the prlctl command will be run as
+
     Example:
 
     .. code-block:: bash
 
-        salt '*' parallels.start macvm
+        salt '*' parallels.start macvm runas=macdev
     '''
-    return prlctl('start', name)
+    return prlctl('start', name, runas=runas)
 
 
-def stop(name, kill=False):
+def stop(name, kill=False, runas=None):
     '''
     Stop a VM
 
@@ -143,12 +155,16 @@ def stop(name, kill=False):
 
         Perform a hard shutdown
 
+    :param str runas:
+
+        The user that the prlctl command will be run as
+
     Example:
 
     .. code-block:: bash
 
-        salt '*' parallels.stop macvm
-        salt '*' parallels.stop macvm kill=True
+        salt '*' parallels.stop macvm runas=macdev
+        salt '*' parallels.stop macvm kill=True runas=macdev
     '''
     # Construct argument list
     args = [name]
@@ -156,10 +172,10 @@ def stop(name, kill=False):
         args.append('--kill')
 
     # Execute command and return output
-    return prlctl('stop', args)
+    return prlctl('stop', args, runas=runas)
 
 
-def restart(name):
+def restart(name, runas=None):
     '''
     Restart a VM by gracefully shutting it down and then restarting
     it
@@ -168,16 +184,20 @@ def restart(name):
 
         Name/ID of VM to restart
 
+    :param str runas:
+
+        The user that the prlctl command will be run as
+
     Example:
 
     .. code-block:: bash
 
-        salt '*' parallels.restart macvm
+        salt '*' parallels.restart macvm runas=macdev
     '''
-    return prlctl('restart', name)
+    return prlctl('restart', name, runas=runas)
 
 
-def reset(name):
+def reset(name, runas=None):
     '''
     Reset a VM by performing a hard shutdown and then a restart
 
@@ -185,16 +205,20 @@ def reset(name):
 
         Name/ID of VM to reset
 
+    :param str runas:
+
+        The user that the prlctl command will be run as
+
     Example:
 
     .. code-block:: bash
 
-        salt '*' parallels.reset macvm
+        salt '*' parallels.reset macvm runas=macdev
     '''
-    return prlctl('reset', name)
+    return prlctl('reset', name, runas=runas)
 
 
-def status(name):
+def status(name, runas=None):
     '''
     Status of a VM
 
@@ -202,16 +226,20 @@ def status(name):
 
         Name/ID of VM whose status will be returned
 
+    :param str runas:
+
+        The user that the prlctl command will be run as
+
     Example:
 
     .. code-block:: bash
 
-        salt '*' parallels.status macvm
+        salt '*' parallels.status macvm runas=macdev
     '''
-    return prlctl('status', name)
+    return prlctl('status', name, runas=runas)
 
 
-def list_snapshots(name, id=None, tree=False):
+def list_snapshots(name, id=None, tree=False, runas=None):
     '''
     List the snapshots
 
@@ -229,13 +257,17 @@ def list_snapshots(name, id=None, tree=False):
 
         List snapshots in tree format rather than tabular format
 
+    :param str runas:
+
+        The user that the prlctl command will be run as
+
     Example:
 
     .. code-block:: bash
 
-        salt '*' parallels.list_snapshots macvm
-        salt '*' parallels.list_snapshots macvm tree=True
-        salt '*' parallels.list_snapshots macvm id=eb56cd24-977f-43e6-b72f-5dcb75e815ad
+        salt '*' parallels.list_snapshots macvm runas=macdev
+        salt '*' parallels.list_snapshots macvm tree=True runas=macdev
+        salt '*' parallels.list_snapshots macvm id=eb56cd24-977f-43e6-b72f-5dcb75e815ad runas=macdev
     '''
     # Construct argument list
     args = [name]
@@ -245,10 +277,10 @@ def list_snapshots(name, id=None, tree=False):
         args.extend(['--id', id])
 
     # Execute command and return output
-    return prlctl('snapshot-list', args)
+    return prlctl('snapshot-list', args, runas=runas)
 
 
-def snapshot(name, snapshot=None, desc=None):
+def snapshot(name, snapshot=None, desc=None, runas=None):
     '''
     Create a snapshot
 
@@ -264,12 +296,16 @@ def snapshot(name, snapshot=None, desc=None):
 
         Description of snapshot
 
+    :param str runas:
+
+        The user that the prlctl command will be run as
+
     Example:
 
     .. code-block:: bash
 
-        salt '*' parallels.create_snapshot macvm snapshot=macvm-original
-        salt '*' parallels.create_snapshot macvm snapshot=macvm-updates desc='clean install with updates'
+        salt '*' parallels.create_snapshot macvm snapshot=macvm-original runas=macdev
+        salt '*' parallels.create_snapshot macvm snapshot=macvm-updates desc='clean install with updates' runas=macdev
     '''
     # Construct argument list
     args = [name]
@@ -279,10 +315,10 @@ def snapshot(name, snapshot=None, desc=None):
         args.extend(['--description', desc])
 
     # Execute command and return output
-    return prlctl('snapshot', args)
+    return prlctl('snapshot', args, runas=runas)
 
 
-def delete_snapshot(name, id):
+def delete_snapshot(name, id, runas=None):
     '''
     Delete a snapshot
 
@@ -299,20 +335,24 @@ def delete_snapshot(name, id):
 
         ID of snapshot to delete
 
+    :param str runas:
+
+        The user that the prlctl command will be run as
+
     Example:
 
     .. code-block:: bash
 
-        salt '*' parallels.delete_snapshot macvm eb56cd24-977f-43e6-b72f-5dcb75e815ad
+        salt '*' parallels.delete_snapshot macvm eb56cd24-977f-43e6-b72f-5dcb75e815ad runas=macdev
     '''
     # Construct argument list
     args = [name, '--id', id]
 
     # Execute command and return output
-    return prlctl('snapshot-delete', args)
+    return prlctl('snapshot-delete', args, runas=runas)
 
 
-def revert_snapshot(name, id):
+def revert_snapshot(name, id, runas=None):
     '''
     Revert a VM to a snapshot
 
@@ -324,14 +364,18 @@ def revert_snapshot(name, id):
 
         ID of snapshot to revert to
 
+    :param str runas:
+
+        The user that the prlctl command will be run as
+
     Example:
 
     .. code-block:: bash
 
-        salt '*' parallels.revert_snapshot macvm eb56cd24-977f-43e6-b72f-5dcb75e815ad
+        salt '*' parallels.revert_snapshot macvm eb56cd24-977f-43e6-b72f-5dcb75e815ad runas=macdev
     '''
     # Construct argument list
     args = [name, '--id', id]
 
     # Execute command and return output
-    return prlctl('snapshot-switch', args)
+    return prlctl('snapshot-switch', args, runas=runas)

--- a/salt/modules/parallels.py
+++ b/salt/modules/parallels.py
@@ -58,7 +58,6 @@ def _find_guids(guid_string):
     Return the set of GUIDs found in guid_string
 
     :param str guid_string:
-
         String containing zero or more GUIDs.  Each GUID may or may not be
         enclosed in {}
 
@@ -82,15 +81,12 @@ def prlctl(sub_cmd, args=None, runas=None):
     Execute a prlctl command
 
     :param str sub_cmd:
-
         prlctl subcommand to execute
 
     :param str args:
-
         The arguments supplied to ``prlctl <sub_cmd>``
 
     :param str runas:
-
         The user that the prlctl command will be run as
 
     Example:
@@ -114,24 +110,19 @@ def list_vms(name=None, info=False, all=False, args=None, runas=None):
     List information about the VMs
 
     :param str name:
-
         Name/ID of VM to list; implies ``info=True``
 
     :param str info:
-
         List extra information
 
     :param bool all:
-
         Also list non-running VMs
 
     :param tuple args:
-
         Additional arguments given to ``prctl list``.  This argument is
         mutually exclusive with the other arguments
 
     :param str runas:
-
         The user that the prlctl command will be run as
 
     Example:
@@ -166,11 +157,9 @@ def start(name, runas=None):
     Start a VM
 
     :param str name:
-
         Name/ID of VM to start
 
     :param str runas:
-
         The user that the prlctl command will be run as
 
     Example:
@@ -187,15 +176,12 @@ def stop(name, kill=False, runas=None):
     Stop a VM
 
     :param str name:
-
         Name/ID of VM to stop
 
     :param bool kill:
-
         Perform a hard shutdown
 
     :param str runas:
-
         The user that the prlctl command will be run as
 
     Example:
@@ -220,11 +206,9 @@ def restart(name, runas=None):
     it
 
     :param str name:
-
         Name/ID of VM to restart
 
     :param str runas:
-
         The user that the prlctl command will be run as
 
     Example:
@@ -241,11 +225,9 @@ def reset(name, runas=None):
     Reset a VM by performing a hard shutdown and then a restart
 
     :param str name:
-
         Name/ID of VM to reset
 
     :param str runas:
-
         The user that the prlctl command will be run as
 
     Example:
@@ -262,11 +244,9 @@ def status(name, runas=None):
     Status of a VM
 
     :param str name:
-
         Name/ID of VM whose status will be returned
 
     :param str runas:
-
         The user that the prlctl command will be run as
 
     Example:
@@ -283,15 +263,12 @@ def exec_(name, command, runas=None):
     Run a command on a VM
 
     :param str name:
-
         Name/ID of VM whose exec will be returned
 
     :param str command:
-
         Command to run on the VM
 
     :param str runas:
-
         The user that the prlctl command will be run as
 
     Example:
@@ -314,19 +291,15 @@ def snapshot_id_to_name(name, snap_id, strict=False, runas=None):
     no name or if the ID is not found or invalid, an empty string will be returned
 
     :param str name:
-
         Name/ID of VM whose snapshots are inspected
 
     :param str snap_id:
-
         ID of the snapshot
 
     :param bool strict:
-
         Raise an exception if a name cannot be found for the given ``snap_id``
 
     :param str runas:
-
         The user that the prlctl command will be run as
 
     Example data
@@ -401,19 +374,15 @@ def snapshot_name_to_id(name, snap_name, strict=False, runas=None):
     name, a list will be returned
 
     :param str name:
-
         Name/ID of VM whose snapshots are inspected
 
     :param str snap_name:
-
         Name of the snapshot
 
     :param bool strict:
-
         Raise an exception if multiple snapshot IDs are found
 
     :param str runas:
-
         The user that the prlctl command will be run as
 
     CLI Example:
@@ -461,11 +430,9 @@ def _validate_snap_name(name, snap_name, runas=None):
     Validate snapshot name and convert to snapshot ID
 
     :param str snap_name:
-
         Name/ID of snapshot
 
     :param str runas:
-
         The user that the prlctl command will be run as
     '''
     snap_name = _sdecode(snap_name)
@@ -482,25 +449,20 @@ def list_snapshots(name, snap_name=None, tree=False, names=False, runas=None):
     List the snapshots
 
     :param str name:
-
         Name/ID of VM whose snapshots will be listed
 
     :param str snap_id:
-
         Name/ID of snapshot to display information about.  If ``tree=True`` is
         also specified, display the snapshot subtree having this snapshot as
         the root snapshot
 
     :param bool tree:
-
         List snapshots in tree format rather than tabular format
 
     :param bool names:
-
         List snapshots as ID, name pairs
 
     :param str runas:
-
         The user that the prlctl command will be run as
 
     Example:
@@ -549,19 +511,15 @@ def snapshot(name, snap_name=None, desc=None, runas=None):
     Create a snapshot
 
     :param str name:
-
         Name/ID of VM to take a snapshot of
 
     :param str snap_name:
-
         Name of snapshot
 
     :param str desc:
-
         Description of snapshot
 
     :param str runas:
-
         The user that the prlctl command will be run as
 
     Example:
@@ -597,15 +555,12 @@ def delete_snapshot(name, snap_name, runas=None):
         delete the derived snapshots
 
     :param str name:
-
         Name/ID of VM whose snapshot will be deleted
 
     :param str snap_name:
-
         Name/ID of snapshot to delete
 
     :param str runas:
-
         The user that the prlctl command will be run as
 
     Example:
@@ -630,15 +585,12 @@ def revert_snapshot(name, snap_name, runas=None):
     Revert a VM to a snapshot
 
     :param str name:
-
         Name/ID of VM to revert to a snapshot
 
     :param str snap_name:
-
         Name/ID of snapshot to revert to
 
     :param str runas:
-
         The user that the prlctl command will be run as
 
     Example:

--- a/salt/modules/parallels.py
+++ b/salt/modules/parallels.py
@@ -23,6 +23,9 @@ from salt.exceptions import SaltInvocationError
 import salt.ext.six as six
 
 __virtualname__ = 'parallels'
+__func_alias__ = {
+    'exec_': 'exec',
+}
 log = logging.getLogger(__name__)
 # Match any GUID
 GUID_REGEX = re.compile(r'{?([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})}?', re.I)
@@ -273,6 +276,36 @@ def status(name, runas=None):
         salt '*' parallels.status macvm runas=macdev
     '''
     return prlctl('status', name, runas=runas)
+
+
+def exec_(name, command, runas=None):
+    '''
+    Run a command on a VM
+
+    :param str name:
+
+        Name/ID of VM whose exec will be returned
+
+    :param str command:
+
+        Command to run on the VM
+
+    :param str runas:
+
+        The user that the prlctl command will be run as
+
+    Example:
+
+    .. code-block:: bash
+
+        salt '*' parallels.exec macvm 'find /etc/paths.d' runas=macdev
+    '''
+    # Construct argument list
+    args = [name]
+    args.extend(_normalize_args(command))
+
+    # Execute command and return output
+    return prlctl('exec', args, runas=runas)
 
 
 def snapshot_id_to_name(name, snap_id, strict=False, runas=None):

--- a/salt/modules/parallels.py
+++ b/salt/modules/parallels.py
@@ -77,7 +77,7 @@ def prlctl(sub_cmd, args=None, runas=None):
     return __salt__['cmd.run'](cmd, runas=runas)
 
 
-def list_vms(name=None, info=False, args=None, runas=None):
+def list_vms(name=None, info=False, all=False, args=None, runas=None):
     '''
     List information about the VMs
 
@@ -89,10 +89,14 @@ def list_vms(name=None, info=False, args=None, runas=None):
 
         List extra information
 
+    :param bool all:
+
+        Also list non-running VMs
+
     :param tuple args:
 
         Additional arguments given to ``prctl list``.  This argument is
-        mutually exclusive with the ``name`` and ``info`` arguments
+        mutually exclusive with the other arguments
 
     :param str runas:
 
@@ -105,7 +109,7 @@ def list_vms(name=None, info=False, args=None, runas=None):
         salt '*' parallels.list_vms runas=macdev
         salt '*' parallels.list_vms name=macvm runas=macdev
         salt '*' parallels.list_vms info=True runas=macdev
-        salt '*' parallels.list_vms '--all -o uuid,status --info' runas=macdev
+        salt '*' parallels.list_vms ' -o uuid,status' all=True runas=macdev
     '''
     # Construct argument list
     if args is None:
@@ -117,6 +121,9 @@ def list_vms(name=None, info=False, args=None, runas=None):
         args.extend(['--info', name])
     elif info:
         args.append('--info')
+
+    if all:
+        args.append('--all')
 
     # Execute command and return output
     return prlctl('list', args, runas=runas)

--- a/salt/modules/parallels.py
+++ b/salt/modules/parallels.py
@@ -456,6 +456,27 @@ def snapshot_name_to_id(name, snap_name, strict=False, runas=None):
         return named_ids
 
 
+def _validate_snap_name(name, snap_name, runas=None):
+    '''
+    Validate snapshot name and convert to snapshot ID
+
+    :param str snap_name:
+
+        Name/ID of snapshot
+
+    :param str runas:
+
+        The user that the prlctl command will be run as
+    '''
+    snap_name = _sdecode(snap_name)
+
+    # Try to convert snapshot name to an ID without {}
+    if re.match(GUID_REGEX, snap_name):
+        return snap_name.strip('{}')
+    else:
+        return snapshot_name_to_id(name, snap_name, strict=True, runas=runas)
+
+
 def list_snapshots(name, snap_name=None, tree=False, names=False, runas=None):
     '''
     List the snapshots
@@ -493,13 +514,8 @@ def list_snapshots(name, snap_name=None, tree=False, names=False, runas=None):
     '''
     # Validate VM and snapshot names
     name = _sdecode(name)
-    snap_name = _sdecode(snap_name)
-
-    # Try to convert snapshot name to an ID without {}
-    if isinstance(snap_name, six.string_types) and re.match(GUID_REGEX, snap_name):
-        snap_name = snap_name.strip('{}')
-    elif snap_name:
-        snap_name = snapshot_name_to_id(name, snap_name, strict=True, runas=runas)
+    if snap_name:
+        snap_name = _validate_snap_name(name, snap_name, runas=runas)
 
     # Construct argument list
     args = [name]
@@ -557,7 +573,8 @@ def snapshot(name, snap_name=None, desc=None, runas=None):
     '''
     # Validate VM and snapshot names
     name = _sdecode(name)
-    snap_name = _sdecode(snap_name)
+    if snap_name:
+        snap_name = _sdecode(snap_name)
 
     # Construct argument list
     args = [name]
@@ -599,13 +616,7 @@ def delete_snapshot(name, snap_name, runas=None):
     '''
     # Validate VM and snapshot names
     name = _sdecode(name)
-    snap_name = _sdecode(snap_name)
-
-    # Try to convert snapshot name to an ID without {}
-    if isinstance(snap_name, six.string_types) and re.match(GUID_REGEX, snap_name):
-        snap_name = snap_name.strip('{}')
-    else:
-        snap_name = snapshot_name_to_id(name, snap_name, strict=True, runas=runas)
+    snap_name = _validate_snap_name(name, snap_name, runas=runas)
 
     # Construct argument list
     args = [name, '--id', snap_name]
@@ -638,13 +649,7 @@ def revert_snapshot(name, snap_name, runas=None):
     '''
     # Validate VM and snapshot names
     name = _sdecode(name)
-    snap_name = _sdecode(snap_name)
-
-    # Try to convert snapshot name to an ID without {}
-    if isinstance(snap_name, six.string_types) and re.match(GUID_REGEX, snap_name):
-        snap_name = snap_name.strip('{}')
-    else:
-        snap_name = snapshot_name_to_id(name, snap_name, strict=True, runas=runas)
+    snap_name = _validate_snap_name(name, snap_name, runas=runas)
 
     # Construct argument list
     args = [name, '--id', snap_name]

--- a/tests/unit/modules/parallels_test.py
+++ b/tests/unit/modules/parallels_test.py
@@ -1,0 +1,474 @@
+# -*- coding: utf-8 -*-
+
+# Import python libs
+from __future__ import absolute_import
+import textwrap
+
+# Import Salt Libs
+from salt.modules import parallels
+from salt.exceptions import SaltInvocationError
+
+# Import Salt Testing Libs
+from salttesting import TestCase, skipIf
+from salttesting.mock import MagicMock, patch, NO_MOCK, NO_MOCK_REASON
+from salttesting.helpers import ensure_in_syspath
+
+# Import third party libs
+import salt.ext.six as six
+
+ensure_in_syspath('../../')
+parallels.__salt__ = {}
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class ParallelsTestCase(TestCase):
+    '''
+    Test parallels desktop execution module functions
+    '''
+    def test___virtual__(self):
+        '''
+        Test parallels.__virtual__
+        '''
+        mock_true = MagicMock(return_value=True)
+        mock_false = MagicMock(return_value=False)
+
+        # Validate false return
+        with patch('salt.utils.which', mock_false):
+            ret = parallels.__virtual__()
+            self.assertTrue(isinstance(ret, tuple))
+            self.assertEqual(len(ret), 2)
+            self.assertFalse(ret[0])
+            self.assertTrue(isinstance(ret[1], six.string_types))
+
+        # Validate true return
+        with patch('salt.utils.which', mock_true):
+            ret = parallels.__virtual__()
+            self.assertTrue(ret)
+            self.assertEqual(ret, 'parallels')
+
+    def test__normalize_args(self):
+        '''
+        Test parallels._normalize_args
+        '''
+        def _validate_ret(ret):
+            '''
+            Assert that the returned data is a list of strings
+            '''
+            self.assertTrue(isinstance(ret, list))
+            for arg in ret:
+                self.assertTrue(isinstance(arg, six.string_types))
+
+        # Validate string arguments
+        str_args = 'electrolytes --aqueous --anion hydroxide --cation=ammonium free radicals -- hydrogen'
+        _validate_ret(parallels._normalize_args(str_args))
+
+        # Validate list arguments
+        list_args = ' '.join(str_args)
+        _validate_ret(parallels._normalize_args(list_args))
+
+        # Validate tuple arguments
+        tuple_args = tuple(list_args)
+        _validate_ret(parallels._normalize_args(tuple_args))
+
+        # Validate dictionary arguments
+        other_args = {'anion': 'hydroxide', 'cation': 'ammonium'}
+        _validate_ret(parallels._normalize_args(other_args))
+
+    def test__find_guids(self):
+        '''
+        Test parallels._find_guids
+        '''
+        guid_str = textwrap.dedent('''
+            PARENT_SNAPSHOT_ID                      SNAPSHOT_ID
+                                                    {a5b8999f-5d95-4aff-82de-e515b0101b66}
+            {a5b8999f-5d95-4aff-82de-e515b0101b66} *{a7345be5-ab66-478c-946e-a6c2caf14909}
+        ''')
+        guids = set(['a5b8999f-5d95-4aff-82de-e515b0101b66',
+                     'a7345be5-ab66-478c-946e-a6c2caf14909'])
+
+        self.assertEqual(parallels._find_guids(guid_str), guids)
+
+    def test_prlctl(self):
+        '''
+        Test parallels.prlctl
+        '''
+        runas = 'macdev'
+
+        # Validate 'prlctl user list'
+        user_cmd = ['prlctl', 'user', 'list']
+        user_fcn = MagicMock()
+        with patch.dict(parallels.__salt__, {'cmd.run': user_fcn}):
+            parallels.prlctl('user', 'list', runas=runas)
+            user_fcn.assert_called_once_with(user_cmd, runas=runas)
+
+        # Validate 'prlctl exec macvm uname'
+        exec_cmd = ['prlctl', 'exec', 'macvm', 'uname']
+        exec_fcn = MagicMock()
+        with patch.dict(parallels.__salt__, {'cmd.run': exec_fcn}):
+            parallels.prlctl('exec', 'macvm uname', runas=runas)
+            exec_fcn.assert_called_once_with(exec_cmd, runas=runas)
+
+    def test_list_vms(self):
+        '''
+        Test parallels.list_vms
+        '''
+        runas = 'macdev'
+
+        # Validate a simple list
+        mock_plain = MagicMock()
+        with patch.object(parallels, 'prlctl', mock_plain):
+            parallels.list_vms(runas=runas)
+            mock_plain.assert_called_once_with('list', [], runas=runas)
+
+        # Validate listing a single VM
+        mock_name = MagicMock()
+        with patch.object(parallels, 'prlctl', mock_name):
+            parallels.list_vms(name='macvm', runas=runas)
+            mock_name.assert_called_once_with('list',
+                                              ['--info', 'macvm'],
+                                              runas=runas)
+
+        # Validate listing extra info
+        mock_info = MagicMock()
+        with patch.object(parallels, 'prlctl', mock_info):
+            parallels.list_vms(info=True, runas=runas)
+            mock_info.assert_called_once_with('list',
+                                              ['--info'],
+                                              runas=runas)
+
+        # Validate listing with extra options
+        mock_complex = MagicMock()
+        with patch.object(parallels, 'prlctl', mock_complex):
+            parallels.list_vms(args=' -o uuid,status', all=True, runas=runas)
+            mock_complex.assert_called_once_with('list',
+                                                 ['-o', 'uuid,status', '--all'],
+                                                 runas=runas)
+
+    def test_start(self):
+        '''
+        Test parallels.start
+        '''
+        name = 'macvm'
+        runas = 'macdev'
+
+        mock_start = MagicMock()
+        with patch.object(parallels, 'prlctl', mock_start):
+            parallels.start(name, runas=runas)
+            mock_start.assert_called_once_with('start', name, runas=runas)
+
+    def test_stop(self):
+        '''
+        Test parallels.stop
+        '''
+        name = 'macvm'
+        runas = 'macdev'
+
+        # Validate stop
+        mock_stop = MagicMock()
+        with patch.object(parallels, 'prlctl', mock_stop):
+            parallels.stop(name, runas=runas)
+            mock_stop.assert_called_once_with('stop', [name], runas=runas)
+
+        # Validate immediate stop
+        mock_kill = MagicMock()
+        with patch.object(parallels, 'prlctl', mock_kill):
+            parallels.stop(name, kill=True, runas=runas)
+            mock_kill.assert_called_once_with('stop', [name, '--kill'], runas=runas)
+
+    def test_restart(self):
+        '''
+        Test parallels.restart
+        '''
+        name = 'macvm'
+        runas = 'macdev'
+
+        mock_start = MagicMock()
+        with patch.object(parallels, 'prlctl', mock_start):
+            parallels.restart(name, runas=runas)
+            mock_start.assert_called_once_with('restart', name, runas=runas)
+
+    def test_reset(self):
+        '''
+        Test parallels.reset
+        '''
+        name = 'macvm'
+        runas = 'macdev'
+
+        mock_start = MagicMock()
+        with patch.object(parallels, 'prlctl', mock_start):
+            parallels.reset(name, runas=runas)
+            mock_start.assert_called_once_with('reset', name, runas=runas)
+
+    def test_status(self):
+        '''
+        Test parallels.status
+        '''
+        name = 'macvm'
+        runas = 'macdev'
+
+        mock_start = MagicMock()
+        with patch.object(parallels, 'prlctl', mock_start):
+            parallels.status(name, runas=runas)
+            mock_start.assert_called_once_with('status', name, runas=runas)
+
+    def test_exec_(self):
+        '''
+        Test parallels.exec_
+        '''
+        name = 'macvm'
+        runas = 'macdev'
+
+        mock_start = MagicMock()
+        with patch.object(parallels, 'prlctl', mock_start):
+            parallels.exec_(name, 'find /etc/paths.d', runas=runas)
+            mock_start.assert_called_once_with('exec',
+                                               [name, 'find', '/etc/paths.d'],
+                                               runas=runas)
+
+    def test_snapshot_id_to_name(self):
+        '''
+        Test parallels.snapshot_id_to_name
+        '''
+        name = 'macvm'
+        snap_id = 'a5b8999f-5d95-4aff-82de-e515b0101b66'
+
+        # Invalid GUID raises error
+        self.assertRaises(SaltInvocationError,
+                          parallels.snapshot_id_to_name,
+                          name,
+                          '{8-4-4-4-12}')
+
+        # Empty return from prlctl raises error (name/snap_id mismatch?)
+        mock_no_data = MagicMock(return_value='')
+        with patch.object(parallels, 'prlctl', mock_no_data):
+            self.assertRaises(SaltInvocationError,
+                              parallels.snapshot_id_to_name,
+                              name,
+                              snap_id)
+
+        # Data returned from prlctl is invalid YAML
+        mock_invalid_data = MagicMock(return_value='[string theory is falsifiable}')
+        with patch.object(parallels, 'prlctl', mock_invalid_data):
+            snap_name = parallels.snapshot_id_to_name(name, snap_id)
+            self.assertEqual(snap_name, '')
+
+        # Data returned from prlctl does not render as a dictionary
+        mock_unknown_data = MagicMock(return_value="['sfermions', 'bosinos']")
+        with patch.object(parallels, 'prlctl', mock_unknown_data):
+            snap_name = parallels.snapshot_id_to_name(name, snap_id)
+            self.assertEqual(snap_name, '')
+
+        # Snapshot is unnamed
+        mock_no_name = MagicMock(return_value='Name:')
+        with patch.object(parallels, 'prlctl', mock_no_name):
+            snap_name = parallels.snapshot_id_to_name(name, snap_id)
+            self.assertEqual(snap_name, '')
+
+        # If strict, then raise an error when name is not found
+        mock_no_name = MagicMock(return_value='Name:')
+        with patch.object(parallels, 'prlctl', mock_no_name):
+            self.assertRaises(SaltInvocationError,
+                              parallels.snapshot_id_to_name,
+                              name,
+                              snap_id,
+                              strict=True)
+
+        # Return name when found
+        mock_yes_name = MagicMock(return_value='Name: top')
+        with patch.object(parallels, 'prlctl', mock_yes_name):
+            snap_name = parallels.snapshot_id_to_name(name, snap_id)
+            self.assertEqual(snap_name, 'top')
+
+    def test_snapshot_name_to_id(self):
+        '''
+        Test parallels.snapshot_name_to_id
+        '''
+        name = 'macvm'
+        snap_ids = ['a5b8999f-5d95-4aff-82de-e515b0101b66',
+                    'a7345be5-ab66-478c-946e-a6c2caf14909']
+        snap_id = snap_ids[0]
+        guid_str = textwrap.dedent('''
+            PARENT_SNAPSHOT_ID                      SNAPSHOT_ID
+                                                    {a5b8999f-5d95-4aff-82de-e515b0101b66}
+            {a5b8999f-5d95-4aff-82de-e515b0101b66} *{a7345be5-ab66-478c-946e-a6c2caf14909}
+        ''')
+        mock_guids = MagicMock(return_value=guid_str)
+
+        # Raise error when no IDs found for snapshot name
+        with patch.object(parallels, 'prlctl', mock_guids):
+            mock_no_names = MagicMock(return_value=[])
+            with patch.object(parallels, 'snapshot_id_to_name', mock_no_names):
+                self.assertRaises(SaltInvocationError,
+                                  parallels.snapshot_name_to_id,
+                                  name,
+                                  'graviton')
+
+        # Validate singly-valued name
+        with patch.object(parallels, 'prlctl', mock_guids):
+            mock_one_name = MagicMock(side_effect=[u'', u'ν_e'])
+            with patch.object(parallels, 'snapshot_id_to_name', mock_one_name):
+                self.assertEqual(parallels.snapshot_name_to_id(name, u'ν_e'), snap_id)
+
+        # Validate multiply-valued name
+        with patch.object(parallels, 'prlctl', mock_guids):
+            mock_many_names = MagicMock(side_effect=[u'J/Ψ', u'J/Ψ'])
+            with patch.object(parallels, 'snapshot_id_to_name', mock_many_names):
+                self.assertEqual(sorted(parallels.snapshot_name_to_id(name, u'J/Ψ')),
+                                 sorted(snap_ids))
+
+        # Raise error for multiply-valued name
+        with patch.object(parallels, 'prlctl', mock_guids):
+            mock_many_names = MagicMock(side_effect=[u'J/Ψ', u'J/Ψ'])
+            with patch.object(parallels, 'snapshot_id_to_name', mock_many_names):
+                self.assertRaises(SaltInvocationError,
+                                  parallels.snapshot_name_to_id,
+                                  name,
+                                  u'J/Ψ',
+                                  strict=True)
+
+    def test__validate_snap_name(self):
+        '''
+        Test parallels._validate_snap_name
+        '''
+        name = 'macvm'
+        snap_id = 'a5b8999f-5d95-4aff-82de-e515b0101b66'
+
+        # Validate a GUID passthrough
+        self.assertEqual(parallels._validate_snap_name(name, snap_id), snap_id)
+
+        # Validate an unicode name
+        mock_snap_symb = MagicMock(return_value=snap_id)
+        with patch.object(parallels, 'snapshot_name_to_id', mock_snap_symb):
+            self.assertEqual(parallels._validate_snap_name(name, u'π'), snap_id)
+            mock_snap_symb.assert_called_once_with(name, u'π', strict=True, runas=None)
+
+        # Validate an ascii name
+        mock_snap_name = MagicMock(return_value=snap_id)
+        with patch.object(parallels, 'snapshot_name_to_id', mock_snap_name):
+            self.assertEqual(parallels._validate_snap_name(name, 'pion'), snap_id)
+            mock_snap_name.assert_called_once_with(name, 'pion', strict=True, runas=None)
+
+        # Validate a numerical name
+        mock_snap_numb = MagicMock(return_value=snap_id)
+        with patch.object(parallels, 'snapshot_name_to_id', mock_snap_numb):
+            self.assertEqual(parallels._validate_snap_name(name, 3.14159), snap_id)
+            mock_snap_numb.assert_called_once_with(name, u'3.14159', strict=True, runas=None)
+
+    def test_list_snapshots(self):
+        '''
+        Test parallels.list_snapshots
+        '''
+        name = 'macvm'
+        guid_str = textwrap.dedent('''
+            PARENT_SNAPSHOT_ID                      SNAPSHOT_ID
+                                                    {a5b8999f-5d95-4aff-82de-e515b0101b66}
+            {a5b8999f-5d95-4aff-82de-e515b0101b66} *{a7345be5-ab66-478c-946e-a6c2caf14909}
+            {a5b8999f-5d95-4aff-82de-e515b0101b66}  {5da9faef-cb0e-466d-9b41-e5571b62ac2a}
+        ''')
+
+        # Validate listing all snapshots for the VM
+        mock_prlctl = MagicMock(return_value=guid_str)
+        with patch.object(parallels, 'prlctl', mock_prlctl):
+            parallels.list_snapshots(name)
+            mock_prlctl.assert_called_once_with('snapshot-list', [name], runas=None)
+
+        # Validate listing all snapshots in tree mode
+        mock_prlctl = MagicMock(return_value=guid_str)
+        with patch.object(parallels, 'prlctl', mock_prlctl):
+            parallels.list_snapshots(name, tree=True)
+            mock_prlctl.assert_called_once_with('snapshot-list', [name, '--tree'], runas=None)
+
+        # Validate listing a single snapshot
+        snap_name = 'muon'
+        mock_snap_name = MagicMock(return_value=snap_name)
+        with patch.object(parallels, '_validate_snap_name', mock_snap_name):
+            mock_prlctl = MagicMock(return_value=guid_str)
+            with patch.object(parallels, 'prlctl', mock_prlctl):
+                parallels.list_snapshots(name, snap_name)
+                mock_prlctl.assert_called_once_with('snapshot-list',
+                                                    [name, '--id', snap_name],
+                                                    runas=None)
+
+        # Validate listing snapshot ID and name pairs
+        snap_names = ['electron', 'muon', 'tauon']
+        mock_snap_name = MagicMock(side_effect=snap_names)
+        with patch.object(parallels, 'snapshot_id_to_name', mock_snap_name):
+            mock_prlctl = MagicMock(return_value=guid_str)
+            with patch.object(parallels, 'prlctl', mock_prlctl):
+                ret = parallels.list_snapshots(name, names=True)
+                for snap_name in snap_names:
+                    self.assertIn(snap_name, ret)
+                mock_prlctl.assert_called_once_with('snapshot-list', [name], runas=None)
+
+    def test_snapshot(self):
+        '''
+        Test parallels.snapshot
+        '''
+        name = 'macvm'
+
+        # Validate creating a snapshot
+        mock_snap = MagicMock(return_value='')
+        with patch.object(parallels, 'prlctl', mock_snap):
+            parallels.snapshot(name)
+            mock_snap.assert_called_once_with('snapshot', [name], runas=None)
+
+        # Validate creating a snapshot with a name
+        snap_name = 'h_0'
+        mock_snap_name = MagicMock(return_value='')
+        with patch.object(parallels, 'prlctl', mock_snap_name):
+            parallels.snapshot(name, snap_name)
+            mock_snap_name.assert_called_once_with('snapshot',
+                                                   [name, '--name', snap_name],
+                                                   runas=None)
+
+        # Validate creating a snapshot with a name and a description
+        snap_name = 'h_0'
+        snap_desc = textwrap.dedent('The ground state particle of the higgs '
+            'multiplet family of bosons')
+        mock_snap_name = MagicMock(return_value='')
+        with patch.object(parallels, 'prlctl', mock_snap_name):
+            parallels.snapshot(name, snap_name, snap_desc)
+            mock_snap_name.assert_called_once_with('snapshot',
+                                                   [name,
+                                                    '--name', snap_name,
+                                                    '--description', snap_desc],
+                                                   runas=None)
+
+    def test_delete_snapshot(self):
+        '''
+        Test parallels.delete_snapshot
+        '''
+        name = 'macvm'
+        snap_name = 'kaon'
+        snap_id = 'c2eab062-a635-4ccd-b9ae-998370f898b5'
+
+        mock_snap_name = MagicMock(return_value=snap_id)
+        with patch.object(parallels, '_validate_snap_name', mock_snap_name):
+            mock_delete = MagicMock(return_value='')
+            with patch.object(parallels, 'prlctl', mock_delete):
+                parallels.delete_snapshot(name, snap_name)
+                mock_delete.assert_called_once_with('snapshot-delete',
+                                                    [name, '--id', snap_id],
+                                                    runas=None)
+
+    def test_revert_snapshot(self):
+        '''
+        Test parallels.revert_snapshot
+        '''
+        name = 'macvm'
+        snap_name = 'k-bar'
+        snap_id = 'c2eab062-a635-4ccd-b9ae-998370f898b5'
+
+        mock_snap_name = MagicMock(return_value=snap_id)
+        with patch.object(parallels, '_validate_snap_name', mock_snap_name):
+            mock_delete = MagicMock(return_value='')
+            with patch.object(parallels, 'prlctl', mock_delete):
+                parallels.revert_snapshot(name, snap_name)
+                mock_delete.assert_called_once_with('snapshot-switch',
+                                                    [name, '--id', snap_id],
+                                                    runas=None)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(ParallelsTestCase, needs_daemon=False)


### PR DESCRIPTION
### What does this PR do?

This implements (a little more than) what is needed to run automated salt tests in MacOS Parallels VMs.  There are [many more](http://download.parallels.com/desktop/v9/ga/docs/en_US/Parallels%20Command%20Line%20Reference%20Guide.pdf) `prlctl` subcommands that are not implemented, but can be easily accessed through `parallels.prlctl` if necessary or added later if desired.  There is also the `prlsrvctl` command, which has not been implemented, but for which adding support should be easy.
### What issues does this PR fix or reference?

I am still working on a parallel (heh) [pull request](https://github.com/saltstack/salt-testing/compare/develop...jfindlay:parallels) to https://github.com/saltstack/salt-testing/.
### Tests written?

Yes
