### PR TITLE
Avoid pkg_add to go in interactive mode.

### DIFF
--- a/salt/modules/openbsdpkg.py
+++ b/salt/modules/openbsdpkg.py
@@ -179,7 +179,7 @@ def install(name=None, pkgs=None, sources=None, **kwargs):
         if pkg_type == 'repository':
             stem, flavor = (pkg.split('--') + [''])[:2]
             pkg = '--'.join((stem, flavor))
-        cmd = 'pkg_add -x {0}'.format(pkg)
+        cmd = 'pkg_add -x -I {0}'.format(pkg)
         out = __salt__['cmd.run_all'](
             cmd,
             python_shell=False,


### PR DESCRIPTION
### What does this PR do?

Adds -I flag to pkg_add.
### What issues does this PR fix or reference?

Avoids salt to lock up because pkg_add goes in interactive mode on an ambiguous package (e.g. php or php-mysql).
### Previous Behavior

salt would lock waiting for pkg_add to return/stop.
### New Behavior

pkg_add no longer waits for user input.
### Tests written?

No
