### PR TITLE
fixing file.managed with requests lib

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -299,7 +299,16 @@ def query(url,
             method, url, params=params, data=data, **req_kwargs
         )
         result.raise_for_status()
-        if stream is True or handle is True:
+        if stream is True:
+            # fake a HTTP response header
+            header_callback('HTTP/1.0 {0} MESSAGE'.format(result.status_code))
+            # fake streaming the content
+            streaming_callback(result.content)
+            return {
+                'handle': result,
+            }
+
+        if handle is True:
             return {
                 'handle': result,
                 'body': result.content,


### PR DESCRIPTION
### What does this PR do?

This PR fixes the use of the requests lib when retrieving files via http. This worked in 2015.5, but stopped working in 2015.8.

In 2015.5 and before requests lib is the only way to retrieve files via a http proxy.
### What issues does this PR fix or reference?

This issue was also mentioned as part of #23617 for the 2015.8 branch (@The-Loeki commented on 8 Oct 2015).
### Previous Behavior

The following code downloads the file correctly in 2015.5, but retrieves an empty file in 2015.8. 

```
# minon
requests_lib: True

# state.sls
{% set docker_compose_completion_url = 'https://raw.githubusercontent.com/docker/compose/1.6.2/contrib/completion/bash/docker-compose' %}
{% set docker_compose_completion_hash = '03bb978332f6a9c047314f15f901805459cac2647ccb6f7606a87209a6c3c0d4' %}

/etc/bash_completion.d/docker-compose.bash:
  file.managed:
    - source: {{ docker_compose_completion_url }}
    - source_hash: sha256={{ docker_compose_completion_hash }}
    - mode: 644
```
### Tests written?

No - a hint on how to write a test for this would be appreciated.

This was manually tested on 2015.8.8.2 on CentOS
