### PR TITLE
Update Salt Bootstrap tutorial

### DIFF
--- a/doc/topics/tutorials/salt_bootstrap.rst
+++ b/doc/topics/tutorials/salt_bootstrap.rst
@@ -17,25 +17,6 @@ is available on GitHub: https://github.com/saltstack/salt-bootstrap
 
 Supported Operating Systems
 ---------------------------
-- Amazon Linux 2012.09
-- Arch
-- CentOS 5/6/7
-- Debian 6/7/8
-- Fedora 17/18/20/21/22
-- FreeBSD 9.1/9.2/10/11
-- Gentoo
-- Linaro
-- Linux Mint 13/14
-- OpenSUSE 12/13
-- Oracle Linux 5/5
-- Red Hat 5/6
-- Red Hat Enterprise 5/6
-- Scientific Linux 5/6
-- SmartOS
-- SUSE Linux Enterprise 11 SP1/11 SP2/11 SP3
-- Ubuntu 10.x/11.x/12.x/13.x/14.x/15.04
-- Elementary OS 0.2
-
 
 .. note::
 
@@ -45,86 +26,204 @@ Supported Operating Systems
     https://github.com/saltstack/salt-bootstrap/tree/develop
 
 
+Debian and derivatives
+~~~~~~~~~~~~~~~~~~~~~~
+
+- Debian GNU/Linux 7/8
+- Linux Mint Debian Edition 1 (based on Debian 8)
+- Kali Linux 1.0 (based on Debian 7)
+
+
+Red Hat family
+~~~~~~~~~~~~~~
+
+- Amazon Linux 2012.09/2013.03/2013.09/2014.03/2014.09
+- CentOS 5/6/7
+- Fedora 17/18/20/21/22
+- Oracle Linux 5/6/7
+- Red Hat Enterprise Linux 5/6/7
+- Scientific Linux 5/6/7
+
+
+SUSE family
+~~~~~~~~~~~
+
+- openSUSE 12/13
+- openSUSE Leap 42
+- openSUSE Tumbleweed 2015
+- SUSE Linux Enterprise Server 11 SP1/11 SP2/11 SP3/12
+
+
+Ubuntu and derivatives
+~~~~~~~~~~~~~~~~~~~~~~
+
+- Elementary OS 0.2 (based on Ubuntu 12.04)
+- Linaro 12.04
+- Linux Mint 13/14/16/17
+- Trisquel GNU/Linux 6 (based on Ubuntu 12.04)
+- Ubuntu 10.x/11.x/12.x/13.x/14.x/15.04
+
+
+Other Linux distro
+~~~~~~~~~~~~~~~~~~
+
+- Arch Linux
+- Gentoo
+
+
+UNIX systems
+~~~~~~~~~~~~
+
+**BSD**:
+
+- OpenBSD (``pip`` installation)
+- FreeBSD 9/10/11
+
+**SunOS**:
+
+- SmartOS
+
 
 Example Usage
-~~~~~~~~~~~~~
+-------------
 
-If you're looking for the *one-liner* to install salt, please scroll to the
+If you're looking for the *one-liner* to install Salt, please scroll to the
 bottom and use the instructions for `Installing via an Insecure One-Liner`_
 
 .. note::
+
     In every two-step example, you would be well-served to examine the downloaded file and examine
     it to ensure that it does what you expect.
 
 
-Using ``curl`` to install latest git:
+The Salt Bootstrap script has a wide variety of options that can be passed as
+well as several ways of obtaining the bootstrap script itself.
 
-.. code-block:: bash
+.. note::
 
-  curl -L https://bootstrap.saltstack.com -o install_salt.sh
-  sudo sh install_salt.sh git develop
+    These examples below show how to bootstrap Salt directly from GitHub or other Git repository.
+    Run the script without any parameters to get latest stable Salt packages for your system from
+    `SaltStack corporate repository`_. See first example in the `Install using wget`_ section.
 
+.. _`SaltStack corporate repository`: https://repo.saltstack.com/
+
+
+Install using curl
+~~~~~~~~~~~~~~~~~~
+
+Using ``curl`` to install latest development version from GitHub:
+
+.. code:: console
+
+    curl -o bootstrap_salt.sh -L https://bootstrap.saltstack.com
+    sudo sh bootstrap_salt.sh git develop
+
+If you want to install a specific release version (based on the Git tags):
+
+.. code:: console
+
+    curl -o bootstrap_salt.sh -L https://bootstrap.saltstack.com
+    sudo sh bootstrap_salt.sh git v2015.8.8
+
+To install a specific branch from a Git fork:
+
+.. code:: console
+
+    curl -o bootstrap_salt.sh -L https://bootstrap.saltstack.com
+    sudo sh bootstrap_salt.sh -g https://github.com/myuser/salt.git git mybranch
+
+If all you want is to install a ``salt-master`` using latest Git:
+
+.. code:: console
+
+    curl -o bootstrap_salt.sh -L https://bootstrap.saltstack.com
+    sudo sh bootstrap_salt.sh -M -N git develop
+
+If your host has Internet access only via HTTP proxy:
+
+.. code:: console
+
+    PROXY='http://user:password@myproxy.example.com:3128'
+    curl -o bootstrap_salt.sh -L -x "$PROXY" https://bootstrap.saltstack.com
+    sudo sh bootstrap_salt.sh -G -H "$PROXY" git
+
+
+Install using wget
+~~~~~~~~~~~~~~~~~~
 
 Using ``wget`` to install your distribution's stable packages:
 
-.. code-block:: bash
+.. code:: console
 
-  wget -O install_salt.sh https://bootstrap.saltstack.com
-  sudo sh install_salt.sh
+    wget -O bootstrap_salt.sh https://bootstrap.saltstack.com
+    sudo sh bootstrap_salt.sh
 
-
-Install a specific version from git using ``wget``:
-
-.. code-block:: bash
-
-  wget -O install_salt.sh https://bootstrap.saltstack.com
-  sudo sh install_salt.sh -P git v0.16.4
-
-If you already have python installed, ``python 2.6``, then it's as easy as:
+Downloading the script from develop branch:
 
 .. code-block:: bash
 
-  python -m urllib "https://bootstrap.saltstack.com" > install_salt.sh
-  sudo sh install_salt.sh git develop
+    wget https://bootstrap.saltstack.com/develop
+    sudo sh bootstrap_salt.sh
+
+Installing a specific version from git using ``wget``:
+
+.. code:: console
+
+    wget -O bootstrap_salt.sh https://bootstrap.saltstack.com
+    sudo sh bootstrap_salt.sh -P git v2015.8.8
+
+.. note::
+
+    On the above example we added `-P` which will allow PIP packages to be installed if required but
+    it's not a necessary flag for Git based bootstraps.
 
 
-All python versions should support the following one liner:
+Install using Python
+~~~~~~~~~~~~~~~~~~~~
 
-.. code-block:: bash
+If you already have Python installed, ``python 2.6``, then it's as easy as:
 
-  python -c 'import urllib; print urllib.urlopen("https://bootstrap.saltstack.com").read()' > install_salt.sh
-  sudo sh install_salt.sh git develop
+.. code:: console
 
+    python -m urllib "https://bootstrap.saltstack.com" > bootstrap_salt.sh
+    sudo sh bootstrap_salt.sh git develop
+
+All Python versions should support the following in-line code:
+
+.. code:: console
+
+    python -c 'import urllib; print urllib.urlopen("https://bootstrap.saltstack.com").read()' > bootstrap_salt.sh
+    sudo sh bootstrap_salt.sh git develop
+
+
+Install using fetch
+~~~~~~~~~~~~~~~~~~~
 
 On a FreeBSD base system you usually don't have either of the above binaries available. You **do**
 have ``fetch`` available though:
 
-.. code-block:: bash
+.. code:: console
 
-  fetch -o install_salt.sh https://bootstrap.saltstack.com
-  sudo sh install_salt.sh
+  fetch -o bootstrap_salt.sh https://bootstrap.saltstack.com
+  sudo sh bootstrap_salt.sh
 
+If you have any SSL issues install ``ca_root_nssp``:
 
-If all you want is to install a ``salt-master`` using latest git:
+.. code:: console
 
-.. code-block:: bash
+   pkg install ca_root_nssp
 
-  curl -o install_salt.sh -L https://bootstrap.saltstack.com
-  sudo sh install_salt.sh -M -N git develop
+And either copy the certificates to the place where fetch can find them:
 
-If you want to install a specific release version (based on the git tags):
+.. code:: console
 
-.. code-block:: bash
+   cp /usr/local/share/certs/ca-root-nss.crt /etc/ssl/cert.pem
 
-  curl -o install_salt.sh -L https://bootstrap.saltstack.com
-  sudo sh install_salt.sh git v0.16.4
+Or link them to the right place:
 
-To install a specific branch from a git fork:
+.. code:: console
 
-.. code-block:: bash
-
-  curl -o install_salt.sh -L https://bootstrap.saltstack.com
-  sudo sh install_salt.sh -g https://github.com/myuser/salt.git git mybranch
+   ln -s /usr/local/share/certs/ca-root-nss.crt /etc/ssl/cert.pem
 
 
 Installing via an Insecure One-Liner
@@ -138,24 +237,8 @@ The following examples illustrate how to install Salt via a one-liner.
     the delivered file is trustworthy.
 
 
-Examples
-~~~~~~~~
-
-Installing the latest develop branch of Salt:
-
-.. code-block:: bash
-
-  curl -L https://bootstrap.saltstack.com | sudo sh -s -- git develop
-
 Any of the example above which use two-lines can be made to run in a single-line
 configuration with minor modifications.
-
-
-Example Usage
--------------
-
-The Salt Bootstrap script has a wide variety of options that can be passed as
-well as several ways of obtaining the bootstrap script itself.
 
 For example, using ``curl`` to install your distribution's stable packages:
 
@@ -171,63 +254,12 @@ Using ``wget`` to install your distribution's stable packages:
     wget -O - https://bootstrap.saltstack.com | sudo sh
 
 
-Installing the latest version available from git with ``curl``:
+Installing the latest develop branch of Salt:
 
 .. code-block:: bash
 
     curl -L https://bootstrap.saltstack.com | sudo sh -s -- git develop
 
-
-Install a specific version from git using ``wget``:
-
-.. code-block:: bash
-
-    wget -O - https://bootstrap.saltstack.com | sh -s -- -P git v0.16.4
-
-
-If you already have python installed, ``python 2.6``, then it's as easy as:
-
-.. code-block:: bash
-
-    python -m urllib "https://bootstrap.saltstack.com" | sudo sh -s -- git develop
-
-
-All python versions should support the following one liner:
-
-.. code-block:: bash
-
-    python -c 'import urllib; print urllib.urlopen("https://bootstrap.saltstack.com").read()' | \
-    sudo  sh -s -- git develop
-
-
-On a FreeBSD base system you usually don't have either of the above binaries
-available. You **do** have ``fetch`` available though:
-
-.. code-block:: bash
-
-    fetch -o - https://bootstrap.saltstack.com | sudo sh
-
-
-If all you want is to install a ``salt-master`` using latest git:
-
-.. code-block:: bash
-
-    curl -L https://bootstrap.saltstack.com | sudo sh -s -- -M -N git develop
-
-
-If you want to install a specific release version (based on the git tags):
-
-.. code-block:: bash
-
-    curl -L https://bootstrap.saltstack.com | sudo sh -s -- git v0.16.4
-
-
-Downloading the develop branch (from here standard command line options may be
-passed):
-
-.. code-block:: bash
-
-    wget https://bootstrap.saltstack.com/develop
 
 Command Line Options
 --------------------
@@ -288,9 +320,9 @@ Here's a summary of the command line options:
       -I  If set, allow insecure connections while downloading any files. For
           example, pass '--no-check-certificate' to 'wget' or '--insecure' to 'curl'
       -A  Pass the salt-master DNS name or IP. This will be stored under
-          ${_SALT_ETC_DIR}/minion.d/99-master-address.conf
+          ${BS_SALT_ETC_DIR}/minion.d/99-master-address.conf
       -i  Pass the salt-minion id. This will be stored under
-          ${_SALT_ETC_DIR}/minion_id
+          ${BS_SALT_ETC_DIR}/minion_id
       -L  Install the Apache Libcloud package if possible(required for salt-cloud)
       -p  Extra-package to install while installing salt dependencies. One package
           per -p flag. You're responsible for providing the proper package name.
@@ -299,3 +331,5 @@ Here's a summary of the command line options:
           touching /tmp/disable_salt_checks on the target host. Defaults ${BS_FALSE}
       -H  Use the specified http proxy for the installation
       -Z  Enable external software source for newer ZeroMQ(Only available for RHEL/CentOS/Fedora/Ubuntu based distributions)
+      -b  Assume that dependencies are already installed and software sources are set up.
+          If git is selected, git tree is still checked out as dependency step.


### PR DESCRIPTION
### What does this PR do?

Makes Salt Bootstrap tutorial consistent with latest script available from [salt-bootstrap](https://github.com/saltstack/salt-bootstrap) repo.
### What issues does this PR fix or reference?

Partially adds explanations for the following issues and probably some others:
- saltstack/salt-bootstrap#695
- saltstack/salt-bootstrap#742
- saltstack/salt-bootstrap#782
### Previous Behavior

Outdated info about OS supported by Salt Bootstrap.
### New Behavior
- Supported OS sorted by family
- Command line examples sorted by downloading tool
- Actual command line options
