### PR TITLE
Address issues #32049 and #32050, regarding win_iis

### DIFF
--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -8,11 +8,17 @@ Microsoft IIS site management via WebAdministration powershell module
 
 '''
 
-
+# Import python libs
 from __future__ import absolute_import
+import json
+import logging
 
 # Import salt libs
+from salt.exceptions import SaltInvocationError
 import salt.utils
+
+_LOG = logging.getLogger(__name__)
+_VALID_PROTOCOLS = ('ftp', 'http', 'https')
 
 # Define the module's virtual name
 __virtualname__ = 'win_iis'
@@ -27,20 +33,31 @@ def __virtual__():
     return (False, 'Module win_iis: module only works on Windows systems')
 
 
-def _srvmgr(func):
+def _srvmgr(func, as_json=False):
     '''
     Execute a function from the WebAdministration PS module
     '''
+    command = 'Import-Module WebAdministration;'
 
-    return __salt__['cmd.run'](
-        'Import-Module WebAdministration; {0}'.format(func),
-        shell='powershell',
-        python_shell=True)
+    if as_json:
+        command = '{0} ConvertTo-Json -Compress -Depth 4 -InputObject @({1})'.format(command,
+                                                                                     func)
+    else:
+        command = '{0} {1}'.format(command, func)
+
+    cmd_ret = __salt__['cmd.run_all'](command, shell='powershell', python_shell=True)
+
+    if cmd_ret['retcode'] != 0:
+        _LOG.error('Unable to execute command: %s\nError: %s', command, cmd_ret['stderr'])
+    return cmd_ret
 
 
 def list_sites():
     '''
     List all the currently deployed websites
+
+    :return: A dictionary of the IIS sites and their properties.
+    :rtype: dict
 
     CLI Example:
 
@@ -48,53 +65,115 @@ def list_sites():
 
         salt '*' win_iis.list_sites
     '''
+    ret = dict()
     pscmd = []
-    pscmd.append(r'Get-WebSite -erroraction silentlycontinue -warningaction silentlycontinue')
-    pscmd.append(r' | foreach {')
-    pscmd.append(r' $_.Name')
-    pscmd.append(r'};')
+    pscmd.append(r"Get-ChildItem -Path 'IIS:\Sites'")
+    pscmd.append(' | Select-Object applicationPool, Bindings, ID, Name, PhysicalPath, State')
+    keep_keys = ('bindingInformation', 'certificateHash', 'certificateStoreName',
+                 'protocol', 'sslFlags')
 
-    command = ''.join(pscmd)
-    return _srvmgr(command)
+    cmd_ret = _srvmgr(func=str().join(pscmd), as_json=True)
+
+    try:
+        items = json.loads(cmd_ret['stdout'], strict=False)
+    except ValueError:
+        _LOG.error('Unable to parse return data as Json.')
+
+    for item in items:
+        bindings = list()
+
+        for binding in item['bindings']['Collection']:
+            filtered_binding = dict()
+
+            for key in binding:
+                if key in keep_keys:
+                    filtered_binding.update({key: binding[key]})
+            bindings.append(filtered_binding)
+
+        ret[item['name']] = {'apppool': item['applicationPool'], 'bindings': bindings,
+                             'id': item['id'], 'state': item['state'],
+                             'sourcepath': item['physicalPath']}
+
+    if not ret:
+        _LOG.warning('No sites found in output: %s', cmd_ret['stdout'])
+    return ret
 
 
-def create_site(
-        name,
-        protocol,
-        sourcepath,
-        port,
-        apppool='',
-        hostheader='',
-        ipaddress=''):
+def create_site(name, sourcepath, apppool='', hostheader='',
+                ipaddress='*', port=80, protocol='http'):
     '''
-    Create a basic website in IIS
+    Create a basic website in IIS.
+
+    ..note:
+
+        This function only validates against the site name, and will return True even
+        if the site already exists with a different configuration. It will not modify
+        the configuration of an existing site.
+
+    :param str name: The IIS site name.
+    :param str sourcepath: The physical path.
+    :param str apppool: The IIS application pool.
+    :param str hostheader: The host header of the binding.
+    :param str ipaddress: The IP address of the binding.
+    :param str port: The TCP port of the binding.
+    :param str protocol: The application protocol of the binding.
+
+    :return: A boolean representing whether all changes succeeded.
+    :rtype: bool
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' win_iis.create_site name='My Test Site' protocol='http' sourcepath='c:\\stage' port='80' apppool='TestPool'
-
+        salt '*' win_iis.create_site name='My Test Site' sourcepath='c:\\stage' apppool='TestPool'
     '''
-
     pscmd = []
-    pscmd.append(r'cd IIS:\Sites\;')
-    pscmd.append(r'New-Item \'iis:\Sites\{0}\''.format(name))
-    pscmd.append(r' -bindings @{{protocol=\'{0}\';bindingInformation=\':{1}:{2}\'}}'.format(
-        protocol, port, hostheader.replace(' ', '')))
-    pscmd.append(r'-physicalPath {0};'.format(sourcepath))
+    protocol = str(protocol).lower()
+    site_path = r'IIS:\Sites\{0}'.format(name)
+    binding_info = r'{0}:{1}:{2}'.format(ipaddress, port, hostheader.replace(' ', ''))
+    current_sites = list_sites()
+
+    if name in current_sites:
+        _LOG.debug("Site '%s' already present.", name)
+        return True
+
+    if protocol not in _VALID_PROTOCOLS:
+        message = ("Invalid protocol '{0}' specified. Valid formats:"
+                   ' {1}').format(protocol, _VALID_PROTOCOLS)
+        raise SaltInvocationError(message)
+
+    pscmd.append(r"New-Item -Path '{0}' -Bindings".format(site_path))
+    pscmd.append(r" @{{ protocol='{0}'; bindingInformation='{1}' }}".format(protocol,
+                                                                            binding_info))
+    pscmd.append(r" -physicalPath '{0}';".format(sourcepath))
 
     if apppool:
-        pscmd.append(r'Set-ItemProperty \'iis:\Sites\{0}\''.format(name))
-        pscmd.append(r' -name applicationPool -value \'{0}\';'.format(apppool))
+        if apppool in list_apppools():
+            _LOG.debug('Utilizing pre-existing application pool: %s', apppool)
+        else:
+            _LOG.debug('Application pool will be created: %s', apppool)
+            create_apppool(apppool)
 
-    command = ''.join(pscmd)
-    return _srvmgr(command)
+        pscmd.append(r" Set-ItemProperty -Path '{0}'".format(site_path))
+        pscmd.append(r" -Name applicationPool -Value '{0}'".format(apppool))
+
+    cmd_ret = _srvmgr(str().join(pscmd))
+
+    if cmd_ret['retcode'] == 0:
+        _LOG.debug('Site created successfully: %s', name)
+        return True
+    _LOG.error('Unable to create site: %s', name)
+    return False
 
 
 def remove_site(name):
     '''
     Delete website from IIS
+
+    :param str name: The IIS site name.
+
+    :return: A boolean representing whether all changes succeeded.
+    :rtype: bool
 
     CLI Example:
 
@@ -103,18 +182,30 @@ def remove_site(name):
         salt '*' win_iis.remove_site name='My Test Site'
 
     '''
-
     pscmd = []
-    pscmd.append(r'cd IIS:\Sites\;')
-    pscmd.append(r'Remove-WebSite -Name \'{0}\''.format(name))
+    current_sites = list_sites()
 
-    command = ''.join(pscmd)
-    return _srvmgr(command)
+    if name not in current_sites:
+        _LOG.debug('Site already absent: %s', name)
+        return True
+
+    pscmd.append(r"Remove-WebSite -Name '{0}'".format(name))
+
+    cmd_ret = _srvmgr(str().join(pscmd))
+
+    if cmd_ret['retcode'] == 0:
+        _LOG.debug('Site removed successfully: %s', name)
+        return True
+    _LOG.error('Unable to remove site: %s', name)
+    return False
 
 
 def list_apppools():
     '''
     List all configured IIS Application pools
+
+    :return: A dictionary of IIS application pools and their details.
+    :rtype: dict
 
     CLI Example:
 
@@ -122,19 +213,68 @@ def list_apppools():
 
         salt '*' win_iis.list_apppools
     '''
+    ret = dict()
     pscmd = []
-    pscmd.append(r'Get-ChildItem IIS:\AppPools\ -erroraction silentlycontinue -warningaction silentlycontinue')
-    pscmd.append(r' | foreach {')
-    pscmd.append(r' $_.Name')
-    pscmd.append(r'};')
 
-    command = ''.join(pscmd)
-    return _srvmgr(command)
+    pscmd.append(r"Get-ChildItem -Path 'IIS:\AppPools' | Select-Object Name, State")
+
+    # Include the equivalient of output from the Applications column, since this isn't
+    # a normal property, we have to populate it via filtered output from the
+    # Get-WebConfigurationProperty cmdlet.
+
+    pscmd.append(r", @{ Name = 'Applications'; Expression = { $AppPool = $_.Name;")
+    pscmd.append(" $AppPath = 'machine/webroot/apphost';")
+    pscmd.append(" $FilterBase = '/system.applicationHost/sites/site/application';")
+    pscmd.append(' $FilterBase += "[@applicationPool = \'$($AppPool)\' and @path";')
+    pscmd.append(' $FilterRoot = "$($FilterBase) = \'/\']/parent::*";')
+    pscmd.append(' $FilterNonRoot = "$($FilterBase) != \'/\']";')
+    pscmd.append(' Get-WebConfigurationProperty -Filter $FilterRoot -PsPath $AppPath -Name Name')
+    pscmd.append(r' | ForEach-Object { $_.Value };')
+    pscmd.append(' Get-WebConfigurationProperty -Filter $FilterNonRoot -PsPath $AppPath -Name Path')
+    pscmd.append(r" | ForEach-Object { $_.Value } | Where-Object { $_ -ne '/' }")
+    pscmd.append(r' } }')
+
+    cmd_ret = _srvmgr(func=str().join(pscmd), as_json=True)
+
+    try:
+        items = json.loads(cmd_ret['stdout'], strict=False)
+    except ValueError:
+        _LOG.error('Unable to parse return data as Json.')
+
+    for item in items:
+        applications = list()
+
+        # If there are no associated apps, Applications will be an empty dict,
+        # if there is one app, it will be a string, and if there are multiple,
+        # it will be a dict with 'Count' and 'value' as the keys.
+
+        if isinstance(item['Applications'], dict):
+            if 'value' in item['Applications']:
+                applications += item['Applications']['value']
+        else:
+            applications.append(item['Applications'])
+
+        ret[item['name']] = {'state': item['state'], 'applications': applications}
+
+    if not ret:
+        _LOG.warning('No application pools found in output: %s', cmd_ret['stdout'])
+    return ret
 
 
 def create_apppool(name):
     '''
     Create IIS Application pools
+
+    ..note:
+
+        This function only validates against the application pool name, and will return
+        True even if the application pool already exists with a different configuration.
+        It will not modify the configuration of an existing application pool.
+
+    :param str name: The IIS application pool.
+
+    :return: A boolean representing whether all changes succeeded.
+    :rtype: bool
 
     CLI Example:
 
@@ -143,15 +283,32 @@ def create_apppool(name):
         salt '*' win_iis.create_apppool name='MyTestPool'
     '''
     pscmd = []
-    pscmd.append(r'New-Item \'IIS:\AppPools\{0}\''.format(name))
+    current_apppools = list_apppools()
+    apppool_path = r'IIS:\AppPools\{0}'.format(name)
 
-    command = ''.join(pscmd)
-    return _srvmgr(command)
+    if name in current_apppools:
+        _LOG.debug("Application pool '%s' already present.", name)
+        return True
+
+    pscmd.append(r"New-Item -Path '{0}'".format(apppool_path))
+
+    cmd_ret = _srvmgr(str().join(pscmd))
+
+    if cmd_ret['retcode'] == 0:
+        _LOG.debug('Application pool created successfully: %s', name)
+        return True
+    _LOG.error('Unable to create application pool: %s', name)
+    return False
 
 
 def remove_apppool(name):
     '''
     Removes IIS Application pools
+
+    :param str name: The IIS application pool.
+
+    :return: A boolean representing whether all changes succeeded.
+    :rtype: bool
 
     CLI Example:
 
@@ -160,7 +317,19 @@ def remove_apppool(name):
         salt '*' win_iis.remove_apppool name='MyTestPool'
     '''
     pscmd = []
-    pscmd.append(r'Remove-Item \'IIS:\AppPools\{0}\' -recurse'.format(name))
+    current_apppools = list_apppools()
+    apppool_path = r'IIS:\AppPools\{0}'.format(name)
 
-    command = ''.join(pscmd)
-    return _srvmgr(command)
+    if name not in current_apppools:
+        _LOG.debug('Application pool already absent: %s', name)
+        return True
+
+    pscmd.append(r"Remove-Item -Path '{0}' -Recurse".format(apppool_path))
+
+    cmd_ret = _srvmgr(str().join(pscmd))
+
+    if cmd_ret['retcode'] == 0:
+        _LOG.debug('Application pool removed successfully: %s', name)
+        return True
+    _LOG.error('Unable to remove application pool: %s', name)
+    return False

--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -35,7 +35,7 @@ def __virtual__():
 
 def _srvmgr(func, as_json=False):
     '''
-    Execute a function from the WebAdministration PS module
+    Execute a function from the WebAdministration PS module.
     '''
     command = 'Import-Module WebAdministration;'
 
@@ -54,7 +54,7 @@ def _srvmgr(func, as_json=False):
 
 def list_sites():
     '''
-    List all the currently deployed websites
+    List all the currently deployed websites.
 
     :return: A dictionary of the IIS sites and their properties.
     :rtype: dict
@@ -111,8 +111,8 @@ def create_site(name, sourcepath, apppool='', hostheader='',
         the configuration of an existing site.
 
     :param str name: The IIS site name.
-    :param str sourcepath: The physical path.
-    :param str apppool: The IIS application pool.
+    :param str sourcepath: The physical path of the IIS site.
+    :param str apppool: The name of the IIS application pool.
     :param str hostheader: The host header of the binding.
     :param str ipaddress: The IP address of the binding.
     :param str port: The TCP port of the binding.
@@ -120,6 +120,11 @@ def create_site(name, sourcepath, apppool='', hostheader='',
 
     :return: A boolean representing whether all changes succeeded.
     :rtype: bool
+
+    ..note:
+
+        If an application pool is specified, and that application pool does not already exist,
+        it will be created.
 
     CLI Example:
 
@@ -168,7 +173,7 @@ def create_site(name, sourcepath, apppool='', hostheader='',
 
 def remove_site(name):
     '''
-    Delete website from IIS
+    Delete a website from IIS.
 
     :param str name: The IIS site name.
 
@@ -202,7 +207,7 @@ def remove_site(name):
 
 def list_apppools():
     '''
-    List all configured IIS Application pools
+    List all configured IIS application pools.
 
     :return: A dictionary of IIS application pools and their details.
     :rtype: dict
@@ -263,7 +268,7 @@ def list_apppools():
 
 def create_apppool(name):
     '''
-    Create IIS Application pools
+    Create an IIS application pool.
 
     ..note:
 
@@ -271,7 +276,7 @@ def create_apppool(name):
         True even if the application pool already exists with a different configuration.
         It will not modify the configuration of an existing application pool.
 
-    :param str name: The IIS application pool.
+    :param str name: The name of the IIS application pool.
 
     :return: A boolean representing whether all changes succeeded.
     :rtype: bool
@@ -303,9 +308,9 @@ def create_apppool(name):
 
 def remove_apppool(name):
     '''
-    Removes IIS Application pools
+    Remove an IIS application pool.
 
-    :param str name: The IIS application pool.
+    :param str name: The name of the IIS application pool.
 
     :return: A boolean representing whether all changes succeeded.
     :rtype: bool

--- a/salt/states/win_iis.py
+++ b/salt/states/win_iis.py
@@ -28,33 +28,26 @@ def __virtual__():
 
 def deployed(name, sourcepath, apppool='', hostheader='', ipaddress='*', port=80, protocol='http'):
     '''
-    Ensure the website has been deployed. This only validates against the
-    website name and will not update information on existing websites with the
-    same name. If the website name doesn't exist it will create with the
-    provided parameters.
+    Ensure the website has been deployed.
 
-    name
-        Name of the website in IIS.
+    ..note:
 
-    sourcepath
-        The directory path on the IIS server to use as a root file store.
-        example: c:\\websites\\website1
+        This function only validates against the site name, and will return True even
+        if the site already exists with a different configuration. It will not modify
+        the configuration of an existing site.
 
-    apppool
-        The application pool to configure for the website. Must already exist.
+    :param str name: The IIS site name.
+    :param str sourcepath: The physical path of the IIS site.
+    :param str apppool: The name of the IIS application pool.
+    :param str hostheader: The host header of the binding.
+    :param str ipaddress: The IP address of the binding.
+    :param str port: The TCP port of the binding.
+    :param str protocol: The application protocol of the binding.
 
-    hostheader
-        The hostheader to route to this website.
+    ..note:
 
-    ipaddress
-        The website ipaddress
-
-    port
-        The network port to listen for traffic.
-        example: 80
-
-    protocol
-        http or https
+        If an application pool is specified, and that application pool does not already exist,
+        it will be created.
     '''
     ret = {'name': name,
            'changes': {},
@@ -81,14 +74,10 @@ def deployed(name, sourcepath, apppool='', hostheader='', ipaddress='*', port=80
 
 
 def remove_site(name):
-    # Remove IIS website
     '''
-    Remove an existing website from the webserver.
+    Delete a website from IIS.
 
-    name
-        The website name as shown in IIS.
-
-
+    :param str name: The IIS site name.
     '''
 
     ret = {'name': name,
@@ -114,14 +103,16 @@ def remove_site(name):
 
 
 def create_apppool(name):
-    # Confirm IIS Application is deployed
-
     '''
-    Creates an IIS application pool.
+    Create an IIS application pool.
 
-    name
-        The name of the application pool to use
+    ..note:
 
+        This function only validates against the application pool name, and will return
+        True even if the application pool already exists with a different configuration.
+        It will not modify the configuration of an existing application pool.
+
+    :param str name: The name of the IIS application pool.
     '''
 
     ret = {'name': name,
@@ -149,11 +140,9 @@ def create_apppool(name):
 def remove_apppool(name):
     # Remove IIS AppPool
     '''
-    Removes an existing Application Pool from the server
+    Remove an IIS application pool.
 
-    name
-        The name of the application pool to remove
-
+    :param str name: The name of the IIS application pool.
     '''
 
     ret = {'name': name,


### PR DESCRIPTION
### What does this PR do?
- Fixes issues which caused several functions to consistently fail.
- Improves logging and documentation.
- Makes output of execution module functions easier to parse and act upon.
- Lays groundwork for expanding the functionality of the win_iis module (which will be greatly expanded in an upcoming PR).
### What issues does this PR fix or reference?
- saltstack/salt#32049
- saltstack/salt#32050
### Previous Behavior
- _create_site_, _create_apppool_, and _remove_apppool_ did not work.
- There was no logging occurring.
- Site protocol types were not validated.
- When creating a site and specifying the application pool to use, if it did not already exist, the application pool would not be created.
- Execution module docstrings contained minimal information.
- Arguments that correspond to some IIS bindings did not contain defaults.
- Execution module was returning empty results on success, and raw PowerShell output on failure.
- list_\* functions were returning strings of raw PowerShell output.
- State module was importing logging but not using it.
### New Behavior
- Fixes the issues that caused _create_site_, _create_apppool_, and _remove_apppool_ to fail.
- Adds logging of some events in order to improve debugging.
- Validate protocol argument for _create_site_.
- Adds creation of the application pool to _create_site_, in the instance where one is specified and does not already exist.
- Adds more detailed information to docstrings.
- Adds default values to the create_site arguments that correspond to IIS bindings, mimicking the behavior of the IIS GUI.
- Changes output of create_\* and remove_\* functions to boolean indicating success or failure.
- Improve output of list_\* functions by converting the PowerShell output into dictionaries.
- Remove unnecessary imports in the state module.
- Add _**opts**['test']_ for state module functions.
### Tests written?

No
