### PR TITLE
Better message when minion fail to start

### DIFF
--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -173,6 +173,10 @@ def verify_files(files, user):
                     fp_.write('')
 
         except IOError as err:
+            if os.path.isfile(dirname):
+                msg = 'Failed to create path {0}, is {1} a file?\n'
+                sys.stderr.write(msg.format(fn_, dirname))
+                sys.exit(err.errno)
             if err.errno != errno.EACCES:
                 raise
             msg = 'No permissions to access "{0}", are you running as the correct user?\n'


### PR DESCRIPTION
### What does this PR do?

When minion fail to start due to issues related to log path, print a better message
to help fix it.
### What issues does this PR fix or reference?
#32255
### Previous Behavior

```
[ERROR   ] Minion failed to start                                  
```
### New Behavior

```
Failed to create path /var/log/salt/minion/minion, is /var/log/salt/minion a file? 
```
### Tests written?

No
