### PR TITLE
Better message when minion fail to start

### DIFF
--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -80,7 +80,7 @@ def minion_process(queue):
         minion = salt.cli.daemons.Minion()
         minion.start()
     except (Exception, SaltClientError, SaltReqTimeoutError, SaltSystemExit) as exc:
-        log.error('Minion failed to start', exc_info=False)
+        log.error('Minion failed to start: {0}'.format(exc.message), exc_info=False)
         restart = True
     except SystemExit as exc:
         restart = False

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -23,7 +23,7 @@ else:
 
 # Import salt libs
 from salt.log import is_console_configured
-from salt.exceptions import SaltClientError
+from salt.exceptions import SaltClientError, SaltSystemExit
 import salt.defaults.exitcodes
 import salt.utils
 
@@ -173,6 +173,9 @@ def verify_files(files, user):
                     fp_.write('')
 
         except IOError as err:
+            if os.path.isfile(dirname):
+                msg = 'Failed to create path {0}, is {1} a file?'.format(fn_, dirname)
+                raise SaltSystemExit(msg=msg)
             if err.errno != errno.EACCES:
                 raise
             msg = 'No permissions to access "{0}", are you running as the correct user?\n'


### PR DESCRIPTION
### What does this PR do?

When minion fail to start due to issues related to log path, print a better message
to help fix it.
### What issues does this PR fix or reference?
#32255
### Previous Behavior

```
[ERROR   ] Minion failed to start                                  
```
### New Behavior

```
[ERROR   ] Minion failed to start: Failed to create path /var/log/salt/minion/minion, is /var/log/salt/minion a file?
```
### Tests written?

No
