### PR TITLE
Re-add shebang to ssh-id-wrapper shell script

### DIFF
--- a/salt/templates/git/ssh-id-wrapper
+++ b/salt/templates/git/ssh-id-wrapper
@@ -1,3 +1,4 @@
+#!/bin/sh
 OPTS="-oStrictHostKeyChecking=no -oPasswordAuthentication=no -oKbdInteractiveAuthentication=no -oChallengeResponseAuthentication=no"
 if test -n "$GIT_IDENTITY"; then
     OPTS="$OPTS -i $GIT_IDENTITY"


### PR DESCRIPTION
Commit 0b286f1bc3e8873b97f3ed6e05e06e96d024a45f removed the shebang line
from the shell script ssh-id-wrapper without reasoning. This script is
executable and needs a shebang for calling it directly. Thus re-add it.
