### PR TITLE
PY3 support for Windows master/minion using TCP transport

### DIFF
--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -229,6 +229,9 @@ def access_keys(opts):
 
         if os.path.exists(keyfile):
             log.debug('Removing stale keyfile: {0}'.format(keyfile))
+            if salt.utils.is_windows() and not os.access(keyfile, os.W_OK):
+                # Cannot delete read-only files on Windows.
+                os.chmod(keyfile, stat.S_IRUSR | stat.S_IWUSR)
             os.unlink(keyfile)
 
         key = salt.crypt.Crypticle.generate_key_string()

--- a/salt/engines/__init__.py
+++ b/salt/engines/__init__.py
@@ -43,7 +43,7 @@ def start_engines(opts, proc_mgr):
 
     for engine in engines_opt:
         if isinstance(engine, dict):
-            engine, engine_opts = list(engine.items())[0]
+            engine, engine_opts = next(iter(engine.items()))
         else:
             engine_opts = None
         fun = '{0}.start'.format(engine)

--- a/salt/engines/__init__.py
+++ b/salt/engines/__init__.py
@@ -43,7 +43,7 @@ def start_engines(opts, proc_mgr):
 
     for engine in engines_opt:
         if isinstance(engine, dict):
-            engine, engine_opts = engine.items()[0]
+            engine, engine_opts = list(engine.items())[0]
         else:
             engine_opts = None
         fun = '{0}.start'.format(engine)

--- a/salt/master.py
+++ b/salt/master.py
@@ -957,12 +957,12 @@ class AESFuncs(object):
                       .format(tmp_pub, err))
         try:
             os.remove(tmp_pub)
-            if salt.crypt.public_decrypt(pub, token) == 'salt':
+            if salt.crypt.public_decrypt(pub, token) == b'salt':
                 return True
         except ValueError as err:
             log.error('Unable to decrypt token: {0}'.format(err))
 
-        log.error('Salt minion claiming to be {0} has attempted to'
+        log.error('Salt minion claiming to be {0} has attempted to '
                   'communicate with the master and could not be verified'
                   .format(id_))
         return False

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -108,13 +108,33 @@ class Serial(object):
         else:
             self.serial = 'msgpack'
 
-    def loads(self, msg):
+    def loads(self, msg, encoding=None):
         '''
         Run the correct loads serialization format
+
+        :param encoding: Useful for Python 3 support. If the msgpack data
+                         was encoded using "use_bin_type=True", this will
+                         differentiate between the 'bytes' type and the
+                         'str' type by decoding contents with 'str' type
+                         to what the encoding was set as. Recommended
+                         encoding is 'utf-8' when using Python 3.
+                         If the msgpack data was not encoded using
+                         "use_bin_type=True", it will try to decode
+                         all 'bytes' and 'str' data (the distinction has
+                         been lost in this case) to what the encoding is
+                         set as. In this case, it will fail if any of
+                         the contents cannot be converted.
         '''
         try:
             gc.disable()  # performance optimization for msgpack
-            return msgpack.loads(msg, use_list=True)
+            if msgpack.version >= (0, 4, 0):
+                # msgpack only supports 'encoding' starting in 0.4.0.
+                # Due to this, if we don't need it, don't pass it at all so
+                # that under Python 2 we can still work with older versions
+                # of msgpack.
+                return msgpack.loads(msg, use_list=True, encoding=encoding)
+            else:
+                return msgpack.loads(msg, use_list=True)
         except Exception as exc:
             log.critical('Could not deserialize msgpack message: {0}'
                          'This often happens when trying to read a file not in binary mode.'
@@ -130,14 +150,30 @@ class Serial(object):
         data = fn_.read()
         fn_.close()
         if data:
-            return self.loads(data)
+            if six.PY3:
+                return self.loads(data, encoding='utf-8')
+            else:
+                return self.loads(data)
 
-    def dumps(self, msg):
+    def dumps(self, msg, use_bin_type=False):
         '''
         Run the correct dumps serialization format
+
+        :param use_bin_type: Useful for Python 3 support. Tells msgpack to
+                             differentiate between 'str' and 'bytes' types
+                             by encoding them differently.
+                             Since this changes the wire protocol, this
+                             option should not be used outside of IPC.
         '''
         try:
-            return msgpack.dumps(msg)
+            if msgpack.version >= (0, 4, 0):
+                # msgpack only supports 'use_bin_type' starting in 0.4.0.
+                # Due to this, if we don't need it, don't pass it at all so
+                # that under Python 2 we can still work with older versions
+                # of msgpack.
+                return msgpack.dumps(msg, use_bin_type=use_bin_type)
+            else:
+                return msgpack.dumps(msg)
         except (OverflowError, msgpack.exceptions.PackValueError):
             # msgpack can't handle the very long Python longs for jids
             # Convert any very long longs to strings
@@ -158,7 +194,10 @@ class Serial(object):
                     return str(obj)
                 else:
                     return obj
-            return msgpack.dumps(verylong_encoder(msg))
+            if msgpack.version >= (0, 4, 0):
+                return msgpack.dumps(verylong_encoder(msg), use_bin_type=use_bin_type)
+            else:
+                return msgpack.dumps(verylong_encoder(msg))
         except TypeError as e:
             # msgpack doesn't support datetime.datetime datatype
             # So here we have converted datetime.datetime to custom datatype
@@ -168,7 +207,10 @@ class Serial(object):
 
             def dt_encode(obj):
                 datetime_str = obj.strftime("%Y%m%dT%H:%M:%S.%f")
-                return msgpack.packb(datetime_str, default=default)
+                if msgpack.version >= (0, 4, 0):
+                    return msgpack.packb(datetime_str, default=default, use_bin_type=use_bin_type)
+                else:
+                    return msgpack.packb(datetime_str, default=default)
 
             def datetime_encoder(obj):
                 if isinstance(obj, dict):
@@ -186,7 +228,10 @@ class Serial(object):
                     return obj
 
             if "datetime.datetime" in str(e):
-                return msgpack.dumps(datetime_encoder(msg))
+                if msgpack.version >= (0, 4, 0):
+                    return msgpack.dumps(datetime_encoder(msg), use_bin_type=use_bin_type)
+                else:
+                    return msgpack.dumps(datetime_encoder(msg))
 
             if msgpack.version >= (0, 2, 0):
                 # Should support OrderedDict serialization, so, let's
@@ -210,7 +255,10 @@ class Serial(object):
                         obj[idx] = odict_encoder(entry)
                     return obj
                 return obj
-            return msgpack.dumps(odict_encoder(msg))
+            if msgpack.version >= (0, 4, 0):
+                return msgpack.dumps(odict_encoder(msg), use_bin_type=use_bin_type)
+            else:
+                return msgpack.dumps(odict_encoder(msg))
         except (SystemError, TypeError) as exc:  # pylint: disable=W0705
             log.critical('Unable to serialize message! Consider upgrading msgpack. '
                          'Message which failed was {failed_message} '
@@ -220,7 +268,13 @@ class Serial(object):
         '''
         Serialize the correct data into the named file object
         '''
-        fn_.write(self.dumps(msg))
+        if six.PY2:
+            fn_.write(self.dumps(msg))
+        else:
+            # When using Python 3, write files in such a way
+            # that the 'bytes' and 'str' types are distinguishable
+            # by using "use_bin_type=True".
+            fn_.write(self.dumps(msg, use_bin_type=True))
         fn_.close()
 
 

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -123,7 +123,7 @@ def prep_jid(nocache=False, passed_jid=None, recurse_count=0):
                 fn_.write(bytes(jid, 'utf-8'))
         if nocache:
             with salt.utils.fopen(os.path.join(jid_dir_, 'nocache'), 'wb+') as fn_:
-                fn_.write('')
+                fn_.write(b'')
     except IOError:
         log.warning('Could not write out jid file for job {0}. Retrying.'.format(jid))
         time.sleep(0.1)

--- a/salt/transport/frame.py
+++ b/salt/transport/frame.py
@@ -5,9 +5,10 @@ Helper functions for transport components to handle message framing
 # Import python libs
 from __future__ import absolute_import
 import msgpack
+import salt.ext.six as six
 
 
-def frame_msg(body, header=None, raw_body=False):
+def frame_msg(body, header=None, raw_body=False):  # pylint: disable=unused-argument
     '''
     Frame the given message with our wire protocol
     '''
@@ -18,3 +19,94 @@ def frame_msg(body, header=None, raw_body=False):
     framed_msg['head'] = header
     framed_msg['body'] = body
     return msgpack.dumps(framed_msg)
+
+
+def frame_msg_ipc(body, header=None, raw_body=False):  # pylint: disable=unused-argument
+    '''
+    Frame the given message with our wire protocol for IPC
+
+    For IPC, we don't need to be backwards compatible, so
+    use the more efficient "use_bin_type=True" on Python 3.
+    '''
+    framed_msg = {}
+    if header is None:
+        header = {}
+
+    framed_msg['head'] = header
+    framed_msg['body'] = body
+    if six.PY2:
+        return msgpack.dumps(framed_msg)
+    else:
+        return msgpack.dumps(framed_msg, use_bin_type=True)
+
+
+def _decode_embedded_list(src):
+    '''
+    Convert enbedded bytes to strings if possible.
+    List helper.
+    '''
+    output = []
+    for elem in src:
+        if isinstance(elem, dict):
+            elem = _decode_embedded_dict(elem)
+        elif isinstance(elem, list):
+            elem = _decode_embedded_list(elem)  # pylint: disable=redefined-variable-type
+        elif isinstance(elem, bytes):
+            try:
+                elem = elem.decode()
+            except UnicodeError:
+                pass
+        output.append(elem)
+    return output
+
+
+def _decode_embedded_dict(src):
+    '''
+    Convert enbedded bytes to strings if possible.
+    Dict helper.
+    '''
+    output = {}
+    for key, val in six.iteritems(src):
+        if isinstance(val, dict):
+            val = _decode_embedded_dict(val)
+        elif isinstance(val, list):
+            val = _decode_embedded_list(val)  # pylint: disable=redefined-variable-type
+        elif isinstance(val, bytes):
+            try:
+                val = val.decode()
+            except UnicodeError:
+                pass
+        if isinstance(key, bytes):
+            try:
+                key = key.decode()
+            except UnicodeError:
+                pass
+        output[key] = val
+    return output
+
+
+def decode_embedded_strs(src):
+    '''
+    Convert enbedded bytes to strings if possible.
+    This is necessary because Python 3 makes a distinction
+    between these types.
+
+    This wouldn't be needed if we used "use_bin_type=True" when encoding
+    and "encoding='utf-8'" when decoding. Unfortunately, this would break
+    backwards compatibility due to a change in wire protocol, so this less
+    than ideal solution is used instead.
+    '''
+    if not six.PY3:
+        return src
+
+    if isinstance(src, dict):
+        return _decode_embedded_dict(src)
+    elif isinstance(src, list):
+        return _decode_embedded_list(src)
+    elif isinstance(src, bytes):
+        try:
+            return src.decode()  # pylint: disable=redefined-variable-type
+        except UnicodeError:
+            return src
+    else:
+        return src

--- a/salt/transport/mixins/auth.py
+++ b/salt/transport/mixins/auth.py
@@ -14,7 +14,9 @@ import binascii
 import salt.crypt
 import salt.payload
 import salt.master
+import salt.transport.frame
 import salt.utils.event
+import salt.ext.six as six
 from salt.utils.cache import CacheCli
 
 # Import Third Party Libs
@@ -109,7 +111,10 @@ class AESReqServerMixin(object):
 
         pret = {}
         cipher = PKCS1_OAEP.new(pub)
-        pret['key'] = cipher.encrypt(key)
+        if six.PY2:
+            pret['key'] = cipher.encrypt(key)
+        else:
+            pret['key'] = cipher.encrypt(salt.utils.to_bytes(key))
         pret[dictkey] = pcrypt.dumps(
             ret if ret is not False else {}
         )

--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -150,6 +150,25 @@ def yamlify_arg(arg):
         return original_arg
 
 
+if six.PY3:
+    from collections import namedtuple  # pylint: disable=wrong-import-position,wrong-import-order
+
+    _ArgSpec = namedtuple('ArgSpec', 'args varargs keywords defaults')
+
+    def _getargspec(func):
+        '''
+        Python 3 wrapper for inspect.getargsspec
+
+        inspect.getargsspec is deprecated and will be removed in Python 3.6.
+        '''
+        args, varargs, varkw, defaults, kwonlyargs, _, ann = \
+            inspect.getfullargspec(func)  # pylint: disable=no-member
+        if kwonlyargs or ann:
+            raise ValueError('Function has keyword-only arguments or annotations'
+                             ', use getfullargspec() API which can support them')
+        return _ArgSpec(args, varargs, varkw, defaults)
+
+
 def get_function_argspec(func):
     '''
     A small wrapper around getargspec that also supports callable classes
@@ -157,15 +176,30 @@ def get_function_argspec(func):
     if not callable(func):
         raise TypeError('{0} is not a callable'.format(func))
 
-    if inspect.isfunction(func):
-        aspec = inspect.getargspec(func)
-    elif inspect.ismethod(func):
-        aspec = inspect.getargspec(func)
-        del aspec.args[0]  # self
-    elif isinstance(func, object):
-        aspec = inspect.getargspec(func.__call__)
-        del aspec.args[0]  # self
+    if six.PY2:
+        if inspect.isfunction(func):
+            aspec = inspect.getargspec(func)
+        elif inspect.ismethod(func):
+            aspec = inspect.getargspec(func)
+            del aspec.args[0]  # self
+        elif isinstance(func, object):
+            aspec = inspect.getargspec(func.__call__)
+            del aspec.args[0]  # self
+        else:
+            raise TypeError(
+                'Cannot inspect argument list for \'{0}\''.format(func)
+            )
     else:
-        raise TypeError('Cannot inspect argument list for \'{0}\''.format(func))
-
+        if inspect.isfunction(func):
+            aspec = _getargspec(func)  # pylint: disable=redefined-variable-type
+        elif inspect.ismethod(func):
+            aspec = _getargspec(func)
+            del aspec.args[0]  # self
+        elif isinstance(func, object):
+            aspec = _getargspec(func.__call__)
+            del aspec.args[0]  # self
+        else:
+            raise TypeError(
+                'Cannot inspect argument list for \'{0}\''.format(func)
+            )
     return aspec

--- a/salt/utils/context.py
+++ b/salt/utils/context.py
@@ -17,7 +17,7 @@ import threading
 import collections
 from contextlib import contextmanager
 
-import salt.ext.six
+import salt.ext.six as six
 
 
 @contextmanager
@@ -132,7 +132,7 @@ class ChildContextDict(collections.MutableMapping):
         self._data = {} if overrides is None else overrides
 
         # merge self.global_data into self._data
-        for k, v in self.parent.global_data.iteritems():
+        for k, v in six.iteritems(self.parent.global_data):
             if k not in self._data:
                 self._data[k] = copy.deepcopy(v)
 
@@ -166,7 +166,7 @@ class NamespacedDictWrapper(collections.MutableMapping, dict):
     '''
     def __init__(self, d, pre_keys):  # pylint: disable=W0231
         self.__dict = d
-        if isinstance(pre_keys, salt.ext.six.string_types):
+        if isinstance(pre_keys, six.string_types):
             self.pre_keys = (pre_keys,)
         else:
             self.pre_keys = pre_keys

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -377,9 +377,13 @@ class SaltEvent(object):
         if serial is None:
             serial = salt.payload.Serial({'serial': 'msgpack'})
 
-        mtag, sep, mdata = raw.partition(TAGEND)  # split tag from data
-
-        data = serial.loads(mdata)
+        if six.PY2:
+            mtag, sep, mdata = raw.partition(TAGEND)  # split tag from data
+            data = serial.loads(mdata)
+        else:
+            mtag, sep, mdata = raw.partition(salt.utils.to_bytes(TAGEND))  # split tag from data
+            mtag = salt.utils.to_str(mtag)
+            data = serial.loads(mdata, encoding='utf-8')
         return mtag, data
 
     def _get_match_func(self, match_type=None):
@@ -648,13 +652,28 @@ class SaltEvent(object):
         data['_stamp'] = datetime.datetime.utcnow().isoformat()
 
         tagend = TAGEND
+        if six.PY2:
+            dump_data = self.serial.dumps(data)
+        else:
+            # Since the pack / unpack logic here is for local events only,
+            # it is safe to change the wire protocol. The mechanism
+            # that sends events from minion to master is outside this
+            # file.
+            dump_data = self.serial.dumps(data, use_bin_type=True)
+
         serialized_data = salt.utils.dicttrim.trim_dict(
-            self.serial.dumps(data),
+            dump_data,
             self.opts['max_event_size'],
             is_msgpacked=True,
         )
         log.debug('Sending event - data = {0}'.format(data))
-        event = '{0}{1}{2}'.format(tag, tagend, serialized_data)
+        if six.PY2:
+            event = '{0}{1}{2}'.format(tag, tagend, serialized_data)
+        else:
+            event = b''.join([
+                salt.utils.to_bytes(tag),
+                salt.utils.to_bytes(tagend),
+                serialized_data])
         msg = salt.utils.to_bytes(event, 'utf-8')
         if self._run_io_loop_sync:
             with salt.utils.async.current_ioloop(self.io_loop):

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -355,7 +355,11 @@ class Schedule(object):
         log.debug('Persisting schedule')
         try:
             with salt.utils.fopen(schedule_conf, 'wb+') as fp_:
-                fp_.write(yaml.dump({'schedule': self.opts['schedule']}))
+                fp_.write(
+                    salt.utils.to_bytes(
+                        yaml.dump({'schedule': self.opts['schedule']})
+                    )
+                )
         except (IOError, OSError):
             log.error('Failed to persist the updated schedule',
                       exc_info_on_loglevel=logging.DEBUG)

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -37,7 +37,9 @@ if mswindows:
     from win32file import ReadFile, WriteFile
     from win32pipe import PeekNamedPipe
     import msvcrt
-    import _subprocess
+    import win32api
+    import win32con
+    import win32process
     # pylint: enable=F0401,W0611
 else:
     import pty
@@ -384,12 +386,12 @@ class Terminal(object):
             Terminates the process
             '''
             try:
-                _subprocess.TerminateProcess(self._handle, 1)
+                win32api.TerminateProcess(self._handle, 1)
             except OSError:
                 # ERROR_ACCESS_DENIED (winerror 5) is received when the
                 # process already died.
-                ecode = _subprocess.GetExitCodeProcess(self._handle)
-                if ecode == _subprocess.STILL_ACTIVE:
+                ecode = win32process.GetExitCodeProcess(self._handle)
+                if ecode == win32con.STILL_ACTIVE:
                     raise
                 self.exitstatus = ecode
 

--- a/setup.py
+++ b/setup.py
@@ -435,12 +435,20 @@ class DownloadWindowsDlls(Command):
 
                         if req.getcode() == 200:
                             with open(fdest, 'wb') as wfh:
-                                while True:
-                                    for chunk in req.read(4096):
-                                        if not chunk:
-                                            break
+                                if IS_PY3:
+                                    while True:
+                                        chunk = req.read(4096)
+                                        if len(chunk) == 0:
+                                            break;
                                         wfh.write(chunk)
                                         wfh.flush()
+                                else:
+                                    while True:
+                                        for chunk in req.read(4096):
+                                            if not chunk:
+                                                break
+                                            wfh.write(chunk)
+                                            wfh.flush()
                         else:
                             log.error(
                                 'Failed to download {0}32.dll to {1} from {2}'.format(


### PR DESCRIPTION
### What does this PR do?

This allows masters and minions to run on Windows using Python 3. Tested
with Python 3.5.1 64-bit on Windows 7. Only the TCP transport has been
ported. It will likely not work with other transports such as ZeroMQ or
RAET without further work.

Since there were many changes necessary to make this work, here is a list
of common changes:
- Python 3 distinguishes `bytes` from `str`. In some cases `bytes` must be
  used (eg read/write to binary file). In other cases `str` must be used
  (eg general Salt dictionary look-ups, read/write to text file). Due to
  this, there are a lot of extra uses of `salt.utils.to_bytes` in necessary
  locations.
- Use `six.itervalues(varname)` instead of `varname.itervalues()`.
- In Python 2.6 and 2.7, the 'b' prefix is ignored. So instead of

```
if six.PY2:
    some_var = 'some_value'
else:
    some_var = b'some_value'
```

we choose to simply use:

```
some_var = b'some_value'

```

`salt/engine/__init__.py`:
- In Python 3, `engine.items()` will return an iterator instead of
  a list. Due to this, needed to change `engine.items()[0]` to
  `list(engine.items())[0]`.

`salt/minion.py`:
- `contextlib.nested` no longer supported in Python 3. Use
  `contextlib.ExitStack` in this case.
- In `Minion.handle_event`, in PY3, `package` is of type `bytes` and `tag`
  is of type `str`. Due to this, do all string searches via `tag` instead
  of `package` since you can't search for a `str` in a `bytes` object.

`salt/payload.py`:
- Added `encoding` parameter to `Serial.loads`. See description in comments
  for details.
- Added `use_bin_type` parameter to `Serial.dumps`. See description in
  comments for details.
- When reading / writing local files, encode using `use_bin_type=True` and
  decode using `encoding='utf-8'` to distinguish `bytes` and `str` types.

`salt/transport/frame.py`:
- Added `frame_msg_ipc`. This is used for IPC communications where it is
  safe to break the wire protocol and so we encode using `use_bin_type=True`.
- Added `decode_embedded_strs`. This is used when it is not safe to break
  the wire protocol (eg external communications). This will convert `bytes`
  objects to `str` objects if possible. This will search for such objects
  within dicts and lists.

`salt/transport/ipc.py`:
- Use `salt.transport.frame.frame_msg_ipc` to encode using
  `use_bin_type=True`.
- Use `encoding='utf-8'` to decode such messages and ensure proper
  distinction of `bytes` and `str` types.

`salt/transport/tpc.py`:
- Since we need to preserve the wire protocol, we don't use
  `use_bin_type=True`. When decoding, we use `decode_embedded_strs` to
  convert the embedded `bytes` objects that can be converted to `str`.
- `urlparse` doesn't exist in PY3. Use `urllib.parse` instead.
- `sys.maxint` not supported in PY3. Use `int((1 << 31) - 1)` instead.
  Hence `sys.maxint - 1` becomes `int((1 << 31) - 2)`.

`salt/utils/__init__.py`:
- `libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("c"))` returns
  `TypeError` in PY3. This is because `ctypes.util.find_library("c")`
  returns `None` and in PY3 `ctypes.cdll.LoadLibrary(None)` is a
  `TypeError`.
- On Windows, `salt.utils.fopen` would always read and write files in
  binary mode. This has been changed for Python 3 since `bytes` must be
  used for binary mode and `str` must be used for text mode and forcing
  binary mode would screw things up if you want to read/write to `str`
  objects. Preserved original behavior on PY2.
- For `salt.utils.fopen`, when reading and writing text files in PY3, if
  an encoding is not specified, it will choose 'utf-8'.

`salt/utils/args.py`:
- In Python 3.5, every time `inspect.getargsspec` is used, a warning would
  appear announcing its deprecation (it will be removed entirely in Python
  3.6). Due to this, implemented our own version using
  `inspect.getfullargspec`.

`salt/utils/event.py`:
- Since all functionality here is used only in IPC (the mechanism for
  firing an event from minion to master is outside this file), we can break
  the wire protocol and hence encode using `use_bin_type=True` and decode
  using `encoding='utf-8'`.

`salt/utils/vt.py`:
- `_subprocess` is not available in PY3 under Windows, so we use an
  alternate method to invoke `TerminateProcess` and `GetExitCodeProcess`.

`setup.py`:
- In PY3, `req.read(4096)` returns a `bytes` object. If you try to for
  loop through it, each element is an `int` which represents an individual
  byte. Trying to write an `int` to `wfh.write` raises an exception. Due to
  this, use an alternate approach when writing from a
  `http.client.HTTPResponse` object to file in PY3.
### What issues does this PR fix or reference?

This is a prerequisite for issue #27367

I believe Python 3 is required to implement the load balancer for Windows using the TCP transport in the manner described in that issue.
### Tests written?

No

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
