### PR TITLE
Change order of precedence in opts when executing minion_runner

### DIFF
--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -844,12 +844,13 @@ class RemoteFuncs(object):
             )
             return {}
         # Prepare the runner object
-        opts = {'fun': load['fun'],
+        opts = {}
+        opts.update(self.opts)
+        opts.update({'fun': load['fun'],
                 'arg': load['arg'],
                 'id': load['id'],
                 'doc': False,
-                'conf_file': self.opts['conf_file']}
-        opts.update(self.opts)
+                'conf_file': self.opts['conf_file']})
         runner = salt.runner.Runner(opts)
         return runner.run()
 


### PR DESCRIPTION
### What does this PR do?

When executing a runner in `publish.runner`, it is not possible to know what minion initiated the run, due to `id` being overridden with the master's `opts`. This PR changes the construction order so that `publish.runner` opts have precedence over the master `opts`.
### What issues does this PR fix or reference?
#20337
### Previous Behavior

`__opts__['id'] = 'master-id'`
### New Behavior

`__opts__['id'] = 'initiating-minion-id'`
### Tests written?

No
### Caveats

I'm _fairly_ sure that nothing within salt depends on this currently, and that the new behavior is actually what is intended to happen, but it is not clear that it is so. Would be great if someone with more historical insight could have a look!
