### PR TITLE
Clean up remaining file_ignore_glob type error warning

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1145,7 +1145,7 @@ DEFAULT_MASTER_OPTS = {
     'file_recv_max_size': 100,
     'file_buffer_size': 1048576,
     'file_ignore_regex': [],
-    'file_ignore_glob': None,
+    'file_ignore_glob': [],
     'fileserver_backend': ['roots'],
     'fileserver_followsymlinks': True,
     'fileserver_ignoresymlinks': False,


### PR DESCRIPTION
### What does this PR do?

The `file_ignore_glob` type should be a list, not None. One of the type changes was missed in #32117. This grabs the last one.
### Tests written?

No
