### PR TITLE
Prevent metadata download when listing installed products

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1322,7 +1322,10 @@ def list_products(all=False, refresh=False):
 
     ret = list()
     OEM_PATH = "/var/lib/suseRegister/OEM"
-    cmd = _zypper('-x', 'products')
+    cmd = _zypper()
+    if not all:
+        cmd.append('--disable-repos')
+    cmd.extend(['-x', 'products'])
     if not all:
         cmd.append('-i')
 


### PR DESCRIPTION
### What does this PR do?

Fix a bug.
### What issues does this PR fix or reference?

When the system has assigned repos with invalid metadata, listing installed products
does not work, because the refresh failed. But all info about installed products are available
locally. So metadata are not needed.
This patch tempoary disable all repos when listing installed products.
### Tests written?

No
