### PR TITLE
outputter virt_list does not exist anymore

### DIFF
--- a/salt/runners/virt.py
+++ b/salt/runners/virt.py
@@ -146,7 +146,7 @@ def list(host=None, quiet=False, hyper=None):  # pylint: disable=redefined-built
         chunk[id_] = data
         ret.update(chunk)
         if not quiet:
-            __jid_event__.fire_event({'data': chunk, 'outputter': 'virt_list'}, 'progress')
+            __jid_event__.fire_event({'data': chunk, 'outputter': 'nested'}, 'progress')
 
     return ret
 


### PR DESCRIPTION
### What does this PR do?

Stops calling removed code. Removes "Invalid outputter virt_list specified, fall back to nested" from logs.
### Tests written?

No
