### PR TITLE
Make sure hash_type is lowercase in master/minion config files

### DIFF
--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -70,7 +70,7 @@ class DaemonsMixin(object):  # pylint: disable=no-init
         '''
         if self.config['hash_type'].lower() in ['md5', 'sha1']:
             logger.warning('IMPORTANT: Do not use {h_type} hashing algorithm! Please set "hash_type" to '
-                           'SHA256 in Salt {d_name} config!'.format(
+                           'sha256 in Salt {d_name} config!'.format(
                 h_type=self.config['hash_type'], d_name=self.__class__.__name__))
 
     def start_log_info(self):

--- a/salt/config.py
+++ b/salt/config.py
@@ -2858,6 +2858,10 @@ def apply_minion_config(overrides=None,
     # if there is no schedule option yet, add an empty scheduler
     if 'schedule' not in opts:
         opts['schedule'] = {}
+
+    # Make sure hash_type is lowercase
+    opts['hash_type'] = opts['hash_type'].lower()
+
     return opts
 
 
@@ -3003,6 +3007,9 @@ def apply_master_config(overrides=None, defaults=None):
         opts['worker_threads'] = 3
 
     opts.setdefault('pillar_source_merging_strategy', 'smart')
+
+    # Make sure hash_type is lowercase
+    opts['hash_type'] = opts['hash_type'].lower()
 
     return opts
 


### PR DESCRIPTION
### What does this PR do?

Ensures that the hash_type config option is listed as lowercase.
### What issues does this PR fix or reference?

Fixes #32354
### Previous Behavior

Setting something like `SHA256` for the `hash_type` stacktraces and the process exits (this is an example from the minion starting up):

```
Process Process-1:
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/root/SaltStack/salt/salt/scripts.py", line 83, in minion_process
    minion.start()
  File "/root/SaltStack/salt/salt/cli/daemons.py", line 349, in start
    self.minion.tune_in()
  File "/root/SaltStack/salt/salt/minion.py", line 1950, in tune_in
    io_loop=self.io_loop,
  File "/root/SaltStack/salt/salt/utils/event.py", line 810, in __init__
    hash_type = getattr(hashlib, self.opts['hash_type'])
AttributeError: 'module' object has no attribute 'SHA256'
```
### New Behavior

If `SHA256` is set in the config file, then the setting is forced to `sha256` and the minion/master will start.
### Tests written?

No
