### PR TITLE
Fix Key.finger_all() method to actually consider all keys

### DIFF
--- a/salt/key.py
+++ b/salt/key.py
@@ -1007,10 +1007,10 @@ class Key(object):
 
     def finger_all(self):
         '''
-        Return fingerprins for all keys
+        Return fingerprints for all keys
         '''
         ret = {}
-        for status, keys in six.iteritems(self.list_keys()):
+        for status, keys in six.iteritems(self.all_keys()):
             ret[status] = {}
             for key in keys:
                 if status == 'local':


### PR DESCRIPTION
### What does this PR do?

Fix Key.finger_all() API
### What issues does this PR fix or reference?

issue #32377 
### Previous Behavior

The API would return this when executed on a minion with default configuration:

```
{'minions': {},
 'minions_denied': {},
 'minions_pre': {},
 'minions_rejected': {}}
```
### New Behavior

The API returns the fingerprint for the minion local keys

```
{'local': {'minion.pem': '8d:5c:e6:06:61:9e:c1:3a:83:f2:a6:4a:bf:ee:f9:ce',
  'minion.pub': '98:92:32:5b:6b:94:bf:fc:dd:b8:7f:7c:48:1a:9c:71'},
 'minions': {},
 'minions_denied': {},
 'minions_pre': {},
 'minions_rejected': {}}
```
### Tests written?

No.
