### PR TITLE
minor bug fixes in call_rpc

### DIFF
--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -101,7 +101,7 @@ def call_rpc(cmd=None, *args, **kwargs):
 
     .. code-block:: bash
 
-        salt 'device' junos.call_rpc 'get config' '<configuration><system/></configuration>' terse=True
+        salt 'device' junos.call_rpc 'get_config' '<configuration><system/></configuration>' terse=True
 
         salt 'device' junos.call_rpc 'get-chassis-inventory' dest=/home/user/rpc_information.txt
 
@@ -123,17 +123,16 @@ def call_rpc(cmd=None, *args, **kwargs):
 
     for k, v in op.iteritems():
         op[k] = str(v)
+    op['format'] = 'json'
 
     try:
-        if cmd in ['get-config', 'get_config', 'get config']:
+        if cmd in ['get-config', 'get_config']:
             filter_reply = None
             if len(args) > 0:
                 filter_reply = etree.XML(args[0])
-            ret['message'] = json.dumps(getattr(conn.rpc, cmd.replace(
-                '-', '_').replace(' ', '_'))(filter_reply, options=op))
+            ret['message'] = getattr(conn.rpc, cmd.replace('-', '_'))(filter_reply, options=op)
         else:
-            ret['message'] = json.dumps(
-                getattr(conn.rpc, cmd.replace('-', '_').replace(' ', '_'))(op))
+            ret['message'] = getattr(conn.rpc, cmd.replace('-', '_'))(op)
 
     except Exception as exception:
 


### PR DESCRIPTION
## What does this PR do?

The call_rpc function did not return all the information from the device, as some of it was ignored by json. This is fixed by getting the reply from the device in json format itself.
## What issues does this PR fix or reference?

None
## Previous Behavior

Not all of the information was returned to the salt system. 
## New Behavior

All of the information is gathered.
## Tests written?

No
