### PR TITLE
modules.win_timezone: don't list all zones in debug log

### DIFF
--- a/salt/modules/win_timezone.py
+++ b/salt/modules/win_timezone.py
@@ -493,7 +493,10 @@ def get_offset():
     string = False
     zone = __salt__['cmd.run'](['tzutil', '/g'], python_shell=False)
     prev = ''
-    for line in __salt__['cmd.run'](['tzutil', '/l'], python_shell=False).splitlines():
+    zone_list = __salt__['cmd.run'](['tzutil', '/l'],
+                                    python_shell=False,
+                                    output_loglevel='trace').splitlines()
+    for line in zone_list:
         if zone == line:
             string = prev
             break


### PR DESCRIPTION
### What does this PR do?

move timezone list to trace log
### What issues does this PR fix or reference?

prevents output such as #32375
### Tests written?

No
