### PR TITLE
error comments in some cases do not show up after a boto_apigateway present state

### DIFF
--- a/salt/states/boto_apigateway.py
+++ b/salt/states/boto_apigateway.py
@@ -982,7 +982,7 @@ class _Swagger(object):
         if not res.get('overwrite'):
             ret['result'] = False
             ret['abort'] = True
-            ret['common'] = res.get('error')
+            ret['comment'] = res.get('error')
         else:
             ret = _log_changes(ret,
                                'overwrite_stage_variables',
@@ -1105,7 +1105,7 @@ class _Swagger(object):
             if not res.get('set'):
                 ret['abort'] = True
                 ret['result'] = False
-                ret['common'] = res.get('error')
+                ret['comment'] = res.get('error')
             else:
                 ret = _log_changes(ret,
                                    'publish_api (reassociate deployment, set stage_variables)',
@@ -1121,7 +1121,7 @@ class _Swagger(object):
             if not res.get('created'):
                 ret['abort'] = True
                 ret['result'] = False
-                ret['common'] = res.get('error')
+                ret['comment'] = res.get('error')
             else:
                 ret = _log_changes(ret, 'publish_api (new deployment)', res.get('deployment'))
         return ret


### PR DESCRIPTION
### What does this PR do?

report errors to result['comment'] for a few places it was incorrectly setting the errors to result['common']
### What issues does this PR fix or reference?

more elaborate errors should show up now for a few exception cases during publishing an API.
### Previous Behavior

present state for will just return result being false for a few exception cases, but no elborate info on the errors.
### New Behavior

shows the reason why the operation failed.
### Tests written?

No
