### PR TITLE
Unbreak cron.file

### DIFF
--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -527,7 +527,7 @@ def file(name,
             __env__,
             context,
             defaults,
-            False, # skip_verify
+            False,        # skip_verify
             **kwargs
         )
     except Exception as exc:

--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -527,6 +527,7 @@ def file(name,
             __env__,
             context,
             defaults,
+            False, # skip_verify
             **kwargs
         )
     except Exception as exc:
@@ -560,12 +561,12 @@ def file(name,
         ret['comment'] = 'Unable to manage file: {0}'.format(exc)
         return ret
 
+    cron_ret = None
     if ret['changes']:
         cron_ret = __salt__['cron.write_cron_file_verbose'](user, cron_path)
         ret['changes'] = {'diff': ret['changes']['diff']}
         ret['comment'] = 'Crontab for user {0} was updated'.format(user)
     elif ret['result']:
-        cron_ret = None
         ret['comment'] = 'Crontab for user {0} is in the correct ' \
                          'state'.format(user)
 


### PR DESCRIPTION
### What does this PR do?

Unbreak cron.file
### Previous Behavior

An extra argument (skip_verify) was recently added to get_managed(),
resulting in this error:

  Unable to manage file: get_managed() takes exactly 11 arguments (10 given)
