### PR TITLE
TCP Load balancer for Windows Python 3

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -696,9 +696,12 @@ class ReqServer(SignalHandlingMultiprocessingProcess):
         kwargs = {}
         if salt.utils.is_windows():
             kwargs['log_queue'] = self.log_queue
-            # Use one worker thread if the only TCP transport is set up on Windows. See #27188.
-            if tcp_only:
-                log.warning("TCP transport is currently supporting the only 1 worker on Windows.")
+            # Use one worker thread if only the TCP transport is set up on
+            # Windows and we are using Python 2. There is load balancer
+            # support on Windows for the TCP transport when using Python 3.
+            if tcp_only and six.PY2 and int(self.opts['worker_threads']) != 1:
+                log.warning('TCP transport supports only 1 worker on Windows '
+                            'when using Python 2.')
                 self.opts['worker_threads'] = 1
 
         for ind in range(int(self.opts['worker_threads'])):


### PR DESCRIPTION
### What does this PR do?

This will add load balancer functionality to the salt-master
when running on Windows Python 3. Unfortunately, on Python 2, the
limit for `worker_threads` remains 1 due to a lack of needed
functionality in Python 2. See issue #27367 for details.

salt/master.py:
- Modified the `tcp_only` check to only issue the warning if we are
  using Windows Python 2 and `worker_threads` is not already set to 1.

salt/transport/tcp.py:
- Added global `USE_LOAD_BALANCER` to tell if we need to add the
  extra load balancer functionality. Currently, it will be set if
  we are using Windows and Python 3.
- Added `LoadBalancerServer`. This runs in its own process and will
  listen for incoming connections. Each incoming connection will be
  sent via multiprocessing queue to the workers. Since the queue is shared
  amongst workers, only one worker will handle a given connection.
- Added `LoadBalancerWorker`. This inherits from `SaltMessageServer`
  and is used in its place for `TCPReqServerChannel.req_server` when
  `USE_LOAD_BALANCER` is True. It adds the additional functionality of
  getting connections from the shared multiprocessing queue that
  `LoadBalancerServer` sends connections to and processes those
  connections.
### What issues does this PR fix or reference?

Issue #27367
### Tests written?

No

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
