### PR TITLE
Typo in win_service.py

### DIFF
--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -419,7 +419,7 @@ def create(name,
 
     :param depend: Specifies the names of services or groups that myust start before this service. The names are separated by forward slashes.
 
-    :param obj: Specifies th ename of an account in which a service will run. Default is LocalSystem
+    :param obj: Specifies the name of an account in which a service will run. Default is LocalSystem
 
     :param password: Specifies a password. Required if other than LocalSystem account is used.
 

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -530,7 +530,7 @@ def config(name,
     :param str depend: Specifies the names of services or groups that must start
     before this service. The names are separated by forward slashes.
 
-    :param str obj: Specifies th name of an account in which a service will run
+    :param str obj: Specifies the name of an account in which a service will run
     or specifies a name of the Windows driver object in which the driver will
     run. Default is LocalSystem
 


### PR DESCRIPTION
### What does this PR do?

Fix space documentation
### What issues does this PR fix or reference?

Seems pointless to create a issue for such small typing mistake

Space at the wrong place
