### PR TITLE
PY3: Fix `trim_dict` to work with `use_bin_type`

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1034,32 +1034,6 @@ class Minion(MinionBase):
             mod_opts[key] = val
         return mod_opts
 
-    def _process_beacons(self):
-        '''
-        Process each beacon and send events if appropriate
-        '''
-        # Process Beacons
-        try:
-            beacons = self.process_beacons(self.functions)
-        except Exception as exc:
-            log.critical('Beacon processing failed: {0}. No beacons will be processed.'.format(traceback.format_exc(exc)))
-            beacons = None
-        if beacons:
-            self._fire_master(events=beacons)
-            for beacon in beacons:
-                serialized_data = salt.utils.dicttrim.trim_dict(
-                    self.serial.dumps(beacon['data']),
-                    self.opts.get('max_event_size', 1048576),
-                    is_msgpacked=True,
-                )
-                log.debug('Sending event - data = {0}'.format(beacon['data']))
-                event = '{0}{1}{2}'.format(
-                        beacon['tag'],
-                        salt.utils.event.TAGEND,
-                        serialized_data,
-                )
-                self.event_publisher.handle_publish(event, None)
-
     def _load_modules(self, force_refresh=False, notify=False):
         '''
         Return the functions and the returners loaded up from the loader

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -665,6 +665,7 @@ class SaltEvent(object):
             dump_data,
             self.opts['max_event_size'],
             is_msgpacked=True,
+            use_bin_type=six.PY3
         )
         log.debug('Sending event - data = {0}'.format(data))
         if six.PY2:


### PR DESCRIPTION
### What does this PR do?

salt/utils/dicttrim.py:
- Changed `salt.utils.dicttrim.trim_dict` to take an extra parameter
  `use_bin_type`. Hence, when handling this data, it will decode
  using `encoding='utf-8'` and encode using `use_bin_type=True`.

salt/utils/event.py:
- Since events use `use_bin_type=True` for Python 3, when calling
  `salt.utils.dicttrim.trim_dict` set `use_bin_type=six.PY3`

salt/minion.py:
- `Minion._process_beacons` also uses `salt.utils.dicttrim.trim_dict`.
  However, it doesn't seem to be referenced anywhere, so it has been
  removed entirely. It wasn't PY3 compliant for other reasons anyway.
  Surprisingly, `salt.utils.dicttrim` wasn't even imported in
  minion.py to begin with.
### What issues does this PR fix or reference?
### Tests written?

No

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
