### PR TITLE
Improve git_pillar documentation/logging

### DIFF
--- a/doc/topics/tutorials/states_pt1.rst
+++ b/doc/topics/tutorials/states_pt1.rst
@@ -1,3 +1,5 @@
+.. _states-tutorial:
+
 =====================================
 States tutorial, part 1 - Basic Usage
 =====================================

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -572,15 +572,24 @@ class Pillar(object):
                 log.error(msg)
                 errors.append(msg)
             else:
-                log.debug(
-                    'Specified SLS \'%s\' in environment \'%s\' was not '
-                    'found. This could be because SLS \'%s\' is in an '
-                    'environment other than \'%s\', but \'%s\' is included in '
-                    'that environment\'s Pillar top file. It could also be '
-                    'due to environment \'%s\' not being defined in '
-                    '"pillar_roots"',
-                    sls, saltenv, sls, saltenv, saltenv, saltenv
-                )
+                msg = ('Specified SLS \'{0}\' in environment \'{1}\' was not '
+                       'found. '.format(sls, saltenv))
+                if self.opts.get('__git_pillar', False) is True:
+                    msg += (
+                        'This is likely caused by a git_pillar top file '
+                        'containing an environment other than the one for the '
+                        'branch in which it resides. Each git_pillar '
+                        'branch/tag must have its own top file.'
+                    )
+                else:
+                    msg += (
+                        'This could be because SLS \'{0}\' is in an '
+                        'environment other than \'{1}\', but \'{1}\' is '
+                        'included in that environment\'s Pillar top file. It '
+                        'could also be due to environment \'{1}\' not being '
+                        'defined in \'pillar_roots\'.'.format(sls, saltenv)
+                    )
+                log.debug(msg)
                 # return state, mods, errors
                 return None, mods, errors
         state = None

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -25,6 +25,19 @@ Pillar top file must still contain the relevant environment, like so:
 The branch/tag which maps to that environment must then be specified along with
 the repo's URL. Configuration details can be found below.
 
+.. important::
+    Each branch/tag used for git_pillar must have its own top file. This is
+    different from how the top file works when configuring :ref:`States
+    <states-tutorial>`. The reason for this is that each git_pillar branch/tag
+    is processed separately from the rest. Therefore, if the ``qa`` branch is
+    to be used for git_pillar, it would need to have its own top file, with the
+    ``qa`` environment defined within it, like this:
+
+    .. code-block:: yaml
+
+        qa:
+          'dev-*':
+            - bar
 
 .. _git-pillar-pre-2015-8-0:
 

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -265,6 +265,7 @@ def ext_pillar(minion_id, repo, pillar_dirs):
     else:
         opts = copy.deepcopy(__opts__)
         opts['pillar_roots'] = {}
+        opts['__git_pillar'] = True
         pillar = salt.utils.gitfs.GitPillar(opts)
         pillar.init_remotes(repo, PER_REMOTE_OVERRIDES)
         pillar.checkout()
@@ -468,6 +469,7 @@ def _legacy_git_pillar(minion_id, repo_string, pillar_dirs):
     opts = copy.deepcopy(__opts__)
 
     opts['pillar_roots'][environment] = [pillar_dir]
+    opts['__git_pillar'] = True
 
     pil = Pillar(opts, __grains__, minion_id, branch)
 


### PR DESCRIPTION
This describes how pillar top files work differently than state top
files, and also makes the log entry more accurate when a pillar top file
has environments other than the current branch's one defined within it.
