### PR TITLE
remove "duplicate" fetch array when updating a marathon app

### DIFF
--- a/salt/modules/marathon.py
+++ b/salt/modules/marathon.py
@@ -98,6 +98,9 @@ def update_app(id, config):
     if 'id' not in config:
         config['id'] = id
     config.pop('version', None)
+    # mirror marathon-ui handling for uris deprecation (see
+    # mesosphere/marathon-ui#594 for more details)
+    config.pop('fetch', None)
     data = json.dumps(config)
     try:
         response = salt.utils.http.query(


### PR DESCRIPTION
### What does this PR do?

This fixes a bug introduced in marathon 0.15.0 that deprecates the "uris" array in favor of the "fetch" array in the app configuration.  The v2 api now returns both collections back, but when they are both submitted to update the app the following exception is returned:

You cannot specify both uris and fetch fields
### What issues does this PR fix or reference?

This issue was also reported in the UI:

mesosphere/marathon#3054

and fixed with the following PR:

mesosphere/marathon-ui#594

This PR applies the same fix to the marathon execution module.
### Tests written?

No (need a working marathon cluster to verify)

fixes mesosphere/marathon#3054 for the marathon module by implementing the same fix used in the marathon ui
