### PR TITLE
Merge #32293 with test fixes

### DIFF
--- a/tests/unit/states/cmd_test.py
+++ b/tests/unit/states/cmd_test.py
@@ -131,11 +131,6 @@ class CmdTestCase(TestCase):
                'changes': {},
                'comment': ''}
 
-        with patch.object(os.path, 'isdir', MagicMock(return_value=False)):
-            comt = ('Desired working directory "/tmp/salt" is not available')
-            ret.update({'comment': comt})
-            self.assertDictEqual(cmd.run(name, cwd='/tmp/salt'), ret)
-
         comt = ("Invalidly-formatted 'env' parameter. See documentation.")
         ret.update({'comment': comt})
         self.assertDictEqual(cmd.run(name, env='salt'), ret)
@@ -176,11 +171,6 @@ class CmdTestCase(TestCase):
                'result': False,
                'changes': {},
                'comment': ''}
-
-        with patch.object(os.path, 'isdir', MagicMock(return_value=False)):
-            comt = ('Desired working directory "/tmp/salt" is not available')
-            ret.update({'comment': comt})
-            self.assertDictEqual(cmd.script(name, cwd='/tmp/salt'), ret)
 
         comt = ("Invalidly-formatted 'env' parameter. See documentation.")
         ret.update({'comment': comt})


### PR DESCRIPTION
### What does this PR do?

Merges #32293 with test fixes
### What issues does this PR fix or reference?
#32293 moves the test for working directory presence to after the `test=true` check. The tests needed to be adjusted to account for this change.
### Tests written?

Yes
