### PR TITLE
Fixes test failure where Fedora 23 has /etc/grub.conf by default

### DIFF
--- a/tests/unit/states/file_test.py
+++ b/tests/unit/states/file_test.py
@@ -199,13 +199,14 @@ class FileTestCase(TestCase):
                                              'file.is_link': mock_f}):
             with patch.dict(filestate.__opts__, {'test': False}):
                 with patch.object(os.path, 'isdir', mock_f):
-                    comt = ('Directory /etc for symlink is not present')
-                    ret.update({'comment': comt,
-                                'result': False,
-                                'pchanges': {'new': '/etc/grub.conf'}})
-                    self.assertDictEqual(filestate.symlink(name, target,
-                                                           user=user,
-                                                           group=group), ret)
+                    with patch.object(os.path, 'exists', mock_f):
+                        comt = ('Directory /etc for symlink is not present')
+                        ret.update({'comment': comt,
+                                    'result': False,
+                                    'pchanges': {'new': '/etc/grub.conf'}})
+                        self.assertDictEqual(filestate.symlink(name, target,
+                                                               user=user,
+                                                               group=group), ret)
 
         with patch.dict(filestate.__salt__, {'config.manage_mode': mock_t,
                                              'file.user_to_uid': mock_uid,


### PR DESCRIPTION
### What does this PR do?

Fedora 23 has /etc/grub.conf by default. I added an additional mock to assume that it does not. 
### What issues does this PR fix or reference?

Fixes a failing test on Fedora 23
### Tests written?

Yes
