### PR TITLE
Unbreak timezone test for Gentoo

### DIFF
--- a/tests/unit/modules/timezone_test.py
+++ b/tests/unit/modules/timezone_test.py
@@ -68,7 +68,7 @@ class TimezoneTestCase(TestCase):
 
                 with patch.dict(timezone.__grains__, {'os_family': 'Gentoo',
                                                       'os': 'Gentoo'}):
-                    self.assertEqual(timezone.get_zone(), '')
+                    self.assertEqual(timezone.get_zone(), '#\nA')
 
             with patch.dict(timezone.__grains__, {'os_family': 'FreeBSD',
                                                   'os': 'FreeBSD'}):


### PR DESCRIPTION
### What does this PR do?

Fixes unit.modules.timezone_test.TimezoneTestCase.test_get_zone  
### Previous Behavior

```
self.assertEqual(timezone.get_zone(), '') 
    AssertionError: '#\nA' != ''   
```
