### PR TITLE
Ignore Raspbian in service.py __virtual__

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -169,7 +169,7 @@ def minion_mods(
             # sometimes providers opts is not to diverge modules but
             # for other configuration
             try:
-                funcs = raw_mod(opts, providers[mod], ret.items())
+                funcs = raw_mod(opts, providers[mod], ret)
             except TypeError:
                 break
             else:

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -158,6 +158,8 @@ def minion_mods(
                      whitelist=whitelist,
                      loaded_base_name=loaded_base_name)
 
+    ret.pack['__salt__'] = ret
+
     # Load any provider overrides from the configuration file providers option
     #  Note: Providers can be pkg, service, user or group - not to be confused
     #        with cloud providers.
@@ -175,8 +177,6 @@ def minion_mods(
                     for func in funcs:
                         f_key = '{0}{1}'.format(mod, func[func.rindex('.'):])
                         ret[f_key] = funcs[func]
-
-    ret.pack['__salt__'] = ret
 
     return ret
 

--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -40,7 +40,8 @@ def __virtual__():
         'OEL',
         'Linaro',
         'elementary OS',
-        'McAfee  OS Server'
+        'McAfee  OS Server',
+        'Raspbian'
     ))
     if __grains__.get('os', '') in disable:
         return False


### PR DESCRIPTION
This prevents more than one execution module from trying to load as the
service virtual module.

Refs: #32413
