### PR TITLE
Do not assume temporary files have the user's gid

### DIFF
--- a/tests/unit/utils/verify_test.py
+++ b/tests/unit/utils/verify_test.py
@@ -91,7 +91,6 @@ class TestVerify(TestCase):
         self.assertTrue(os.path.exists(var_dir))
         dir_stat = os.stat(var_dir)
         self.assertEqual(dir_stat.st_uid, os.getuid())
-        self.assertEqual(dir_stat.st_gid, os.getgid())
         self.assertEqual(dir_stat.st_mode & stat.S_IRWXU, stat.S_IRWXU)
         self.assertEqual(dir_stat.st_mode & stat.S_IRWXG, 40)
         self.assertEqual(dir_stat.st_mode & stat.S_IRWXO, 5)


### PR DESCRIPTION
### What does this PR do?

Do not assume temporary files have the user's gid

On BSD-like systems (including MacOS) files created in /tmp (or any dir with mod
1777) do not have the user's group. Therefore the st_gid for files created in
/tmp will usually be wheel. Easiest thing to do is to skip this test.
### Previous Behavior

self.assertEqual(dir_stat.st_gid, os.getgid())
    AssertionError: 0 != 1000
