### PR TITLE
Fix issue that #32420 exposed in timezone_test

### DIFF
--- a/tests/unit/modules/timezone_test.py
+++ b/tests/unit/modules/timezone_test.py
@@ -66,6 +66,9 @@ class TimezoneTestCase(TestCase):
                                                       'os': 'Debian'}):
                     self.assertEqual(timezone.get_zone(), '#\nA')
 
+            with patch('salt.utils.fopen', mock_open(read_data=file_data),
+                       create=True) as mfile:
+                mfile.return_value.__iter__.return_value = file_data.splitlines()
                 with patch.dict(timezone.__grains__, {'os_family': 'Gentoo',
                                                       'os': 'Gentoo'}):
                     self.assertEqual(timezone.get_zone(), '#\nA')


### PR DESCRIPTION
### What does this PR do?

The patched file was not propagating down to the gentoo os assert. This gives that assert it's own patched file to test against. This was noticed after #32420 was merged. 
### Tests written?

Yes
