### PR TITLE
[dockerng] Fix Domainname introspection

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -370,7 +370,7 @@ VALID_CREATE_OPTS = {
     'domainname': {
         'validator': 'string',
         'path': 'Config:Domainname',
-        'default': '',
+        'get_default_from_container': True,
     },
     'interactive': {
         'api_name': 'stdin_open',


### PR DESCRIPTION
### What does this PR do?

Default value needs to be extracted from the container itself,
because dockerd set Domainname value when network_mode=host.
### What issues does this PR fix or reference?
#32033
### Tests written?

No

---

Default value needs to be extracted from the container itself,
because dockerd set Domainname value when network_mode=host.
