### PR TITLE
Bugfix: salt-key crashes if tries to generate keys to the directory w/o write access

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -15,6 +15,7 @@ import logging
 import traceback
 import binascii
 import weakref
+import getpass
 from salt.ext.six.moves import zip  # pylint: disable=import-error,redefined-builtin
 
 # Import third party libs
@@ -94,6 +95,11 @@ def gen_keys(keydir, keyname, keysize, user=None):
         # Between first checking and the generation another process has made
         # a key! Use the winner's key
         return priv
+
+    # Do not try writing anything, if directory has no permissions.
+    if not os.access(keydir, os.W_OK):
+        raise IOError('Write access denied to "{0}" for user "{1}".'.format(os.path.abspath(keydir), getpass.getuser()))
+
     cumask = os.umask(191)
     with salt.utils.fopen(priv, 'wb+') as f:
         f.write(gen.exportKey('PEM'))

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -297,6 +297,8 @@ def salt_key():
             SystemExit('\nExiting gracefully on Ctrl-c'),
             err,
             hardcrash, trace=trace)
+    except Exception as err:
+        sys.stderr.write("Error: {0}\n".format(err.message))
 
 
 def salt_cp():

--- a/tests/unit/crypt_test.py
+++ b/tests/unit/crypt_test.py
@@ -86,6 +86,7 @@ class CryptTestCase(TestCase):
     @patch('os.umask', MagicMock())
     @patch('os.chmod', MagicMock())
     @patch('os.chown', MagicMock())
+    @patch('os.access', MagicMock(return_value=True))
     def test_gen_keys(self):
         with patch('salt.utils.fopen', mock_open()):
             open_priv_wb = call('/keydir/keyname.pem', 'wb+')


### PR DESCRIPTION
### What does this PR do?

Fixes a bug.
### What issues does this PR fix or reference?

The `salt-key` utility crashes when tries to generate key-pair in the directory without write access.
### Previous Behavior

```
# salt-key --gen-keys=figaro
Traceback (most recent call last):
  File "/usr/bin/salt-key", line 10, in <module>
    salt_key()
  File "/usr/lib/python2.7/site-packages/salt/scripts.py", line 289, in salt_key
    client.run()
  File "/usr/lib/python2.7/site-packages/salt/cli/key.py", line 32, in run
    key.run()
  File "/usr/lib/python2.7/site-packages/salt/key.py", line 397, in run
    self.key.gen_keys()
  File "/usr/lib/python2.7/site-packages/salt/key.py", line 544, in gen_keys
    self.opts['keysize'])
  File "/usr/lib/python2.7/site-packages/salt/crypt.py", line 98, in gen_keys
    with salt.utils.fopen(priv, 'wb+') as f:
  File "/usr/lib/python2.7/site-packages/salt/utils/__init__.py", line 1205, in fopen
    fhandle = open(*args, **kwargs)
IOError: [Errno 13] Permission denied: './figaro.pem'
```
### New Behavior

```
# sudo salt-key --gen-keys=figaro
Error: Write access denied to "/tmp/mozart" for user "salt".
```
### Tests written?

No
