### PR TITLE
Add pgjsonb_queue to queue doc index

### DIFF
--- a/doc/ref/queues/all/index.rst
+++ b/doc/ref/queues/all/index.rst
@@ -10,4 +10,5 @@ Full list of builtin queues
     :toctree:
     :template: autosummary.rst.tmpl
 
+    pgjsonb_queue
     sqlite_queue


### PR DESCRIPTION
### What does this PR do?

Adds pgjsonb_queue to the list in `doc/ref/queues/all/index.rst` list.
### Previous Behavior

pgjsonb_queue was missing from doc build.
### New Behavior

pgjsonb_queue should show up now.
### Tests written?

No
