### PR TITLE
Add missing import for reload() on Python3

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -49,7 +49,7 @@ import salt.utils.yamlloader as yamlloader
 # Import third party libs
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 import salt.ext.six as six
-from salt.ext.six.moves import map, range
+from salt.ext.six.moves import map, range, reload_module
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
 
 log = logging.getLogger(__name__)
@@ -873,7 +873,7 @@ class State(object):
             # process 'site-packages', the 'site' module needs to be reloaded in
             # order for the newly installed package to be importable.
             try:
-                reload(site)
+                reload_module(site)
             except RuntimeError:
                 log.error('Error encountered during module reload. Modules were not reloaded.')
             except TypeError:


### PR DESCRIPTION
### What does this PR do?

Eliminates a fatal exception (NameError) in Python 3 because of missing import
### What issues does this PR fix or reference?
### Previous Behavior

NameError: name 'reload' is not defined
