### PR TITLE
Automatically detect correct MySQL password column for 5.7 and fix setting passwords

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -243,6 +243,7 @@ def __optimize_table(name, table, **connection_args):
     log.debug(results)
     return results
 
+
 def __password_column(**connection_args):
     dbc = _connect(**connection_args)
     if dbc is None:
@@ -250,7 +251,7 @@ def __password_column(**connection_args):
     cur = dbc.cursor()
     qry = ('SELECT column_name from information_schema.COLUMNS '
            'WHERE table_schema=%(schema)s and table_name=%(table)s '
-           'and column_name=%(column)s');
+           'and column_name=%(column)s')
     args = {
       'schema': 'mysql',
       'table':  'user',
@@ -261,6 +262,7 @@ def __password_column(**connection_args):
         return 'Password'
     else:
         return 'authentication_string'
+
 
 def _connect(**kwargs):
     '''

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1309,6 +1309,7 @@ def user_chpass(user,
                 password_hash=None,
                 allow_passwordless=False,
                 unix_socket=None,
+                password_column=None,
                 **connection_args):
     '''
     Change password for a MySQL user
@@ -1366,8 +1367,11 @@ def user_chpass(user,
     if dbc is None:
         return False
 
+    if not password_column:
+        password_column = __password_column(**connection_args)
+
     cur = dbc.cursor()
-    qry = ('UPDATE mysql.user SET password='
+    qry = ('UPDATE mysql.user SET ' + password_column + '='
            + password_sql +
            ' WHERE User=%(user)s AND Host = %(host)s;')
     args['user'] = user

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -258,7 +258,7 @@ def __password_column(**connection_args):
       'column': 'Password'
     }
     _execute(cur, qry, args)
-    if cur.rowcount > 0:
+    if int(cur.rowcount) > 0:
         return 'Password'
     else:
         return 'authentication_string'

--- a/tests/unit/modules/mysql_test.py
+++ b/tests/unit/modules/mysql_test.py
@@ -88,7 +88,7 @@ class MySQLTestCase(TestCase):
             mysql.user_chpass('testuser', password='BLUECOW')
             calls = (
                 call().cursor().execute(
-                    'UPDATE mysql.user SET password=PASSWORD(%(password)s) WHERE User=%(user)s AND Host = %(host)s;',
+                    'UPDATE mysql.user SET Password=PASSWORD(%(password)s) WHERE User=%(user)s AND Host = %(host)s;',
                     {'password': 'BLUECOW',
                      'user': 'testuser',
                      'host': 'localhost',


### PR DESCRIPTION
### What does this PR do?

Adds a function to automatically detect the correct password column depending on the MySQL version.  This function is called by any module function that needs to know the name of the password column, unless password_column has been explicitly passed to the function to override it.
### What issues does this PR fix or reference?

This extends the work in PR #30603 to fix issue #29265.  There is nothing wrong with the previous PR, and having password_column as an argument may be useful if further changes are made in future versions.  But in general, as an end user calling a state or execution module, I shouldn't need to know anything about MySQL's internal column mappings.

The existing changes also leave user_chpass unfixed, which I have modified in the same way as the other functions.
### Previous Behavior

Queries and updates against mysql.user would request the column 'Password' unless a different column name was manually specified to the module function.  You would have to pass password_column='authentication_string' to have password related functions to work on MySQL 5.7.  user_chpass had no password_column kwarg and could not be used against MySQL 5.7.
### New Behavior

If password_column is supplied as a keyword argument, it will still be taken as the name of the password column in the mysql.user table.  Otherwise, information_schema will be queried to determine whether the default 'Password' column exists.  If it does not, 'authentication_string' will be preferred.  This allows password-related functions to work without a user-specified column name on MySQL 5.7 as well as previous versions.

The reason for writing the check this way around is that both columns exist in MySQL 5.6.  Only in 5.7, where Password has been removed, is authentication_string used to store the password.
### Tests written?

No
