### PR TITLE
Add sourcepath check to win_iis.create_vdir

### DIFF
--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -406,6 +406,11 @@ def create_vdir(name, site, sourcepath, app=_DEFAULT_APP):
         _LOG.debug("Virtual directory already present: %s", name)
         return True
 
+    # The target physical path must exist.
+    if not os.path.isdir(sourcepath):
+        _LOG.error('Path is not present: %s', sourcepath)
+        return False
+
     pscmd.append(r"New-WebVirtualDirectory -Name '{0}' -Site '{1}'".format(name, site))
     pscmd.append(r" -PhysicalPath '{0}'".format(sourcepath))
 


### PR DESCRIPTION
### What does this PR do?
- Checks the _sourcepath_ parameter of _win_iis.create_vdir_ to verify that it is a directory, and that it is accessible.
### What issues does this PR fix or reference?
- None
### Previous Behavior
- Checking the sourcepath parameter to verify type and accessibility was not previously performed, and would result in a PowerShell error if the sourcepath was not a directory or was not accessible.
### New Behavior
- Checks the sourcepath parameter to verify that it is a directory and that it is accessible before attempting to create the virtual directory.
### Tests written?

No
