### PR TITLE
Argument name in docs should match actual arg name

### DIFF
--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -928,8 +928,9 @@ def runner(_fun, **kwargs):
 
     .. versionadded:: 2014.7.0
 
-    name
+    _fun
         The name of the function to run
+
     kwargs
         Any keyword arguments to pass to the runner function
 


### PR DESCRIPTION
### What does this PR do?

Changes the `name` description of the `_fun` arg to be `_fun` in the docs to match.
### What issues does this PR fix or reference?

Fixes #31851
`fun` was changed to `_fun` in #26676.
### Previous Behavior

If you try to use `m_name` via the states module (because you're expecting the first arg to be `name`, which is how you reach duplicate "name" arguments in the `module.run` state) then you'll get an error when you run the state:

```
The following arguments are missing: _fun
```
### New Behavior

Since `fun` was changed to `_fun` (and `name` isn't correct either), the `module.run` state needs to be given the `_fun` argument to work correctly. This makes that more clear by correcting the docs.
### Tests written?

No
