### PR TITLE
tests.integration: bypass MacOS TMPDIR, gettempdir

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -78,15 +78,11 @@ if salt.utils.is_windows():
 
 
 SYS_TMP_DIR = os.path.realpath(
-    os.environ.get(
-        # Avoid MacOS ${TMPDIR} as it yields a base path too long for unix sockets:
-        # 'error: AF_UNIX path too long'
-        # Gentoo Portage prefers ebuild tests are rooted in ${TMPDIR}
-        'TMPDIR' if not salt.utils.is_darwin() else '',
-        tempfile.gettempdir()
-    )
+    # Avoid ${TMPDIR} and gettempdir() on MacOS as they yield a base path too long
+    # for unix sockets: ``error: AF_UNIX path too long``
+    # Gentoo Portage prefers ebuild tests are rooted in ${TMPDIR}
+    os.environ.get('TMPDIR', tempfile.gettempdir()) if salt.utils.is_darwin() != 'Darwin' else '/tmp'
 )
-
 TMP = os.path.join(SYS_TMP_DIR, 'salt-tests-tmpdir')
 FILES = os.path.join(INTEGRATION_TEST_DIR, 'files')
 PYEXEC = 'python{0}.{1}'.format(*sys.version_info)

--- a/tests/integration/files/file/base/_modules/runtests_helpers.py
+++ b/tests/integration/files/file/base/_modules/runtests_helpers.py
@@ -17,15 +17,11 @@ import salt.utils
 
 
 SYS_TMP_DIR = os.path.realpath(
-    os.environ.get(
-        # Avoid MacOS ${TMPDIR} as it yields a base path too long for unix sockets:
-        # 'error: AF_UNIX path too long'
-        # Gentoo Portage prefers ebuild tests are rooted in ${TMPDIR}
-        'TMPDIR' if not salt.utils.is_darwin() else '',
-        tempfile.gettempdir()
-    )
+    # Avoid ${TMPDIR} and gettempdir() on MacOS as they yield a base path too long
+    # for unix sockets: ``error: AF_UNIX path too long``
+    # Gentoo Portage prefers ebuild tests are rooted in ${TMPDIR}
+    os.environ.get('TMPDIR', tempfile.gettempdir()) if salt.utils.is_darwin() != 'Darwin' else '/tmp'
 )
-
 # This tempdir path is defined on tests.integration.__init__
 TMP = os.path.join(SYS_TMP_DIR, 'salt-tests-tmpdir')
 


### PR DESCRIPTION
### What does this PR do?

Updates #32259.

When logging in as root over `ssh root@host`, `$TMPDIR` and
`tempfile.gettempdir()` are both set to a variation of:

```
/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/
```

When logging in as root over `sudo -i`, `$TMPDIR` is unset and
`tempfile.gettempdir()` is set to `/tmp`.

My guess is that the second case is an unintended or uncorrected omision
by Apple as they have introduced the longer, randomized temp path in a
recent version of MacOS.
### What issues does this PR fix or reference?

saltstack/salt-testing#55
### Tests written?

No
