### PR TITLE
Improve and clarify docs on provider overrides.

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -103,6 +103,7 @@ Full list of builtin execution modules
     gnomedesktop
     gpg
     grains
+    group
     groupadd
     grub_legacy
     guestfs
@@ -268,6 +269,7 @@ Full list of builtin execution modules
     tomcat
     twilio_notify
     upstart
+    user
     useradd
     uwsgi
     varnish

--- a/doc/ref/modules/all/salt.modules.group.rst
+++ b/doc/ref/modules/all/salt.modules.group.rst
@@ -1,0 +1,24 @@
+.. _virtual-group:
+
+==================
+salt.modules.group
+==================
+
+.. py:module:: salt.modules.group
+    :synopsis: A virtual module for group management
+
+``group`` is a virtual module that is fulfilled by one of the following
+modules:
+
+====================================== ========================================
+Execution Module                       Used for
+====================================== ========================================
+:py:mod:`~salt.modules.groupadd`       Linux, NetBSD, and OpenBSD systems using
+                                       ``groupadd(8)``, ``groupdel(8)``, and
+                                       ``groupmod(8)``
+:py:mod:`~salt.modules.pw_group`       FreeBSD-based OSes using ``pw(8)``
+:py:mod:`~salt.modules.solaris_group`  Solaris-based OSes using
+                                       ``groupadd(1M)``, ``groupdel(1M)``, and
+                                       ``groupmod(1M)``
+:py:mod:`~salt.modules.win_groupadd`   Windows
+====================================== ========================================

--- a/doc/ref/modules/all/salt.modules.pkg.rst
+++ b/doc/ref/modules/all/salt.modules.pkg.rst
@@ -1,3 +1,5 @@
+.. _virtual-pkg:
+
 ================
 salt.modules.pkg
 ================
@@ -7,16 +9,33 @@ salt.modules.pkg
 
 ``pkg`` is a virtual module that is fulfilled by one of the following modules:
 
-* :mod:`salt.modules.aptpkg`
-* :mod:`salt.modules.brew`
-* :mod:`salt.modules.ebuild`
-* :mod:`salt.modules.freebsdpkg`
-* :mod:`salt.modules.openbsdpkg`
-* :mod:`salt.modules.pacman`
-* :mod:`salt.modules.pkgin`
-* :mod:`salt.modules.pkgng`
-* :mod:`salt.modules.pkgutil`
-* :mod:`salt.modules.solarispkg`
-* :mod:`salt.modules.win_pkg`
-* :mod:`salt.modules.yumpkg`
-* :mod:`salt.modules.zypper`
+====================================== ========================================
+Execution Module                       Used for
+====================================== ========================================
+:py:mod:`~salt.modules.aptpkg`         Debian/Ubuntu-based distros which use
+                                       ``apt-get(8)`` for package management
+:py:mod:`~salt.modules.brew`           Mac OS software management using
+                                       `Homebrew`_
+:py:mod:`~salt.modules.ebuild`         Gentoo-based systems (utilizes the
+                                       ``portage`` python module as well as
+                                       ``emerge(1)``)
+:py:mod:`~salt.modules.freebsdpkg`     FreeBSD-based OSes using ``pkg_add(1)``
+:py:mod:`~salt.modules.openbsdpkg`     OpenBSD-based OSes using ``pkg_add(1)``
+:py:mod:`~salt.modules.pacman`         Arch Linux-based distros using
+                                       ``pacman(8)``
+:py:mod:`~salt.modules.pkgin`          NetBSD-based OSes using ``pkgin(1)``
+:py:mod:`~salt.modules.pkgng`          FreeBSD-based OSes using ``pkg(8)``
+:py:mod:`~salt.modules.pkgutil`        Solaris-based OSes using `OpenCSW`_'s
+                                       ``pkgutil(1)``
+:py:mod:`~salt.modules.solarispkg`     Solaris-based OSes using ``pkgadd(1M)``
+:py:mod:`~salt.modules.solarisips`     Solaris-based OSes using IPS ``pkg(1)``
+:py:mod:`~salt.modules.win_pkg`        Salt's :ref:`Windows Package Manager
+                                       <windows-package-manager`
+:py:mod:`~salt.modules.yumpkg`         RedHat-based distros and derivatives
+                                       using ``yum(8)`` or ``dnf(8)``
+:py:mod:`~salt.modules.zypper`         SUSE-based distros using ``zypper(8)``
+====================================== ========================================
+
+.. _Homebrew: http://brew.sh/
+.. _OpenCSW: http://www.opencsw.org/
+

--- a/doc/ref/modules/all/salt.modules.service.rst
+++ b/doc/ref/modules/all/salt.modules.service.rst
@@ -1,6 +1,39 @@
+.. _virtual-service:
+
 ====================
 salt.modules.service
 ====================
+
+.. py:module:: salt.modules.service
+    :synopsis: A virtual module for service management
+
+``service`` is a virtual module that is fulfilled by one of the following
+modules:
+
+====================================== ========================================
+Execution Module                       Used for
+====================================== ========================================
+:py:mod:`~salt.modules.debian_service` Debian Wheezy and earlier
+:py:mod:`~salt.modules.freebsdservice` FreeBSD-based OSes using ``service(8)``
+:py:mod:`~salt.modules.gentoo_service` Gentoo Linux using ``sysvinit`` and
+                                       ``rc-update(8)``
+:py:mod:`~salt.modules.launchctl`      Mac OS hosts using ``launchctl(1)``
+:py:mod:`~salt.modules.netbsdservice`  NetBSD-based OSes
+:py:mod:`~salt.modules.openbsdservice` OpenBSD-based OSes
+:py:mod:`~salt.modules.rh_service`     RedHat-based distros and derivatives
+                                       using ``service(8)`` and
+                                       ``chkconfig(8)``. Supports both pure
+                                       sysvinit and mixed sysvinit/upstart
+                                       systems.
+:py:mod:`~salt.modules.service`        Fallback which simply wraps sysvinit
+                                       scripts
+:py:mod:`~salt.modules.smf`            Solaris-based OSes which use SMF
+:py:mod:`~salt.modules.systemd`        Linux distros which use systemd
+:py:mod:`~salt.modules.upstart`        Ubuntu-based distros using upstart
+:py:mod:`~salt.modules.win_service`    Windows
+====================================== ========================================
+
+|
 
 .. automodule:: salt.modules.service
     :members:

--- a/doc/ref/modules/all/salt.modules.shadow.rst
+++ b/doc/ref/modules/all/salt.modules.shadow.rst
@@ -1,6 +1,26 @@
+.. _virtual-shadow:
+
 ===================
 salt.modules.shadow
 ===================
 
+.. py:module:: salt.modules.shadow
+    :synopsis: A virtual module for shadow file / password management
+
+``shadow`` is a virtual module that is fulfilled by one of the following
+modules:
+
+====================================== ========================================
+Execution Module                       Used for
+====================================== ========================================
+:py:mod:`~salt.modules.shadow`         Linux
+:py:mod:`~salt.modules.bsd_shadow`     FreeBSD, OpenBSD, NetBSD
+:py:mod:`~salt.modules.solaris_shadow` Solaris-based OSes
+:py:mod:`~salt.modules.win_shadow`     Windows
+====================================== ========================================
+
+|
+
 .. automodule:: salt.modules.shadow
     :members:
+

--- a/doc/ref/modules/all/salt.modules.user.rst
+++ b/doc/ref/modules/all/salt.modules.user.rst
@@ -1,0 +1,24 @@
+.. _virtual-user:
+
+=================
+salt.modules.user
+=================
+
+.. py:module:: salt.modules.user
+    :synopsis: A virtual module for user management
+
+``user`` is a virtual module that is fulfilled by one of the following modules:
+
+====================================== ========================================
+Execution Module                       Used for
+====================================== ========================================
+:py:mod:`~salt.modules.useradd`        Linux, NetBSD, and OpenBSD systems using
+                                       ``useradd(8)``, ``userdel(8)``, and
+                                       ``usermod(8)``
+:py:mod:`~salt.modules.pw_user`        FreeBSD-based OSes using ``pw(8)``
+:py:mod:`~salt.modules.solaris_user`   Solaris-based OSes using
+                                       ``useradd(1M)``, ``userdel(1M)``, and
+                                       ``usermod(1M)``
+:py:mod:`~salt.modules.mac_user`       MacOS
+:py:mod:`~salt.modules.win_useradd`    Windows
+====================================== ========================================

--- a/doc/ref/modules/index.rst
+++ b/doc/ref/modules/index.rst
@@ -130,8 +130,8 @@ Outputter.
 .. code-block:: python
 
     __outputter__ = {
-                    'run': 'txt'
-                    }
+        'run': 'txt'
+    }
 
 This will ensure that the text outputter is used.
 
@@ -170,8 +170,8 @@ Since ``__virtual__`` is called before the module is loaded, ``__salt__`` will b
 unavailable as it will not have been packed into the module at this point in time.
 
 .. note::
-    Modules which return a string from ``__virtual__`` that is already used by a module that
-    ships with Salt will _override_ the stock module.
+    Modules which return a string from ``__virtual__`` that is already used by
+    a module that ships with Salt will _override_ the stock module.
 
 .. _modules-error-info:
 
@@ -180,21 +180,58 @@ Returning Error Information from ``__virtual__``
 
 Optionally, modules may additionally return a list of reasons that a module could
 not be loaded. For example, if a dependency for 'my_mod' was not met, a
-__virtual__ function could do as follows:
+``__virtual__`` function could do as follows:
 
- return False, ['My Module must be installed before this module can be
- used.']
+.. code-block:: python
+
+    return False, 'My Module must be installed before this module can be used.'
 
 Examples
 --------
 
-The package manager modules are among the best examples of using the ``__virtual__``
-function. Some examples:
+The package manager modules are among the best examples of using the
+``__virtual__`` function. A table of all the virtual ``pkg`` modules can be
+found :ref:`here <virtual-pkg>`.
 
-- :blob:`pacman.py <salt/modules/pacman.py>`
-- :blob:`yumpkg.py <salt/modules/yumpkg.py>`
-- :blob:`aptpkg.py <salt/modules/aptpkg.py>`
-- :blob:`at.py <salt/modules/at.py>`
+.. _module-provider-override:
+
+Overriding Virtual Module Providers
+-----------------------------------
+
+Salt often uses OS grains (``os``, ``osrelease``, ``os_family``, etc.) to
+determine which module should be loaded as the virtual module for ``pkg``,
+``service``, etc. Sometimes this OS detection is incomplete, with new distros
+popping up, existing distros changing init systems, etc. The virtual modules
+likely to be affected by this are in the list below (click each item for more
+information):
+
+- :ref:`pkg <virtual-pkg>`
+- :ref:`service <virtual-service>`
+- :ref:`user <virtual-user>`
+- :ref:`shadow <virtual-shadow>`
+- :ref:`group <virtual-group>`
+
+If Salt is using the wrong module for one of these, first of all, please
+`report it on the issue tracker`__, so that this issue can be resolved for a
+future release. To make it easier to troubleshoot, please also provide the
+:py:mod:`grains.items <salt.modules.grains.items>` output, taking care to
+redact any sensitive information.
+
+Then, while waiting for the SaltStack development team to fix the issue, Salt
+can be made to use the correct module using the :conf_minion:`providers` option
+in the minion config file:
+
+.. code-block:: yaml
+
+    providers:
+      service: systemd
+      pkg: aptpkg
+
+The above example will force the minion to use the :py:mod:`systemd
+<salt.modules.systemd>` module to provide service mangement, and the
+:py:mod:`aptpkg <salt.modules.aptpkg>` module to provide package management.
+
+.. __: https://github.com/saltstack/salt/issues/new
 
 .. _modules-virtual-name:
 

--- a/doc/ref/states/providers.rst
+++ b/doc/ref/states/providers.rst
@@ -9,9 +9,9 @@ properties of a system. These determinations are generally made for modules
 that provide things like package and service management.
 
 Sometimes in states, it may be necessary to use an alternative module to
-provide the needed functionality. For instance, an older Arch Linux system may
-not be running systemd, so instead of using the systemd service module, you can
-revert to the default service module:
+provide the needed functionality. For instance, an very old Arch Linux system
+may not be running systemd, so instead of using the systemd service module, you
+can revert to the default service module:
 
 .. code-block:: yaml
 
@@ -26,116 +26,7 @@ manages :program:`sysvinit`-based services) will replace the
 
 However, if it is necessary to make this override for most or every service,
 it is better to just override the provider in the minion config file, as
-described in the section below.
-
-Setting a Provider in the Minion Config File
-============================================
-
-.. _`issue tracker`: https://github.com/saltstack/salt/issues
-
-Sometimes, when running Salt on custom Linux spins, or distribution that are derived
-from other distributions, Salt does not successfully detect providers. The providers
-which are most likely to be affected by this are:
-
-- pkg
-- service
-- user
-- group
-
-When something like this happens, rather than specifying the provider manually
-in each state, it easier to use the :conf_minion:`providers` parameter in the
-minion config file to set the provider.
-
-If you end up needing to override a provider because it was not detected,
-please let us know! File an issue on the `issue tracker`_, and provide the
-output from the :mod:`grains.items <salt.modules.grains.items>` function,
-taking care to sanitize any sensitive information.
-
-Below are tables that should help with deciding which provider to use if one
-needs to be overridden.
-
-
-Provider: ``pkg``
-*****************
-
-======================= =======================================================
-Execution Module        Used for
-======================= =======================================================
-apt                     Debian/Ubuntu-based distros which use ``apt-get(8)``
-                        for package management
-brew                    Mac OS software management using `Homebrew`_
-ebuild                  Gentoo-based systems (utilizes the ``portage`` python
-                        module as well as ``emerge(1)``)
-freebsdpkg              FreeBSD-based OSes using ``pkg_add(1)``
-openbsdpkg              OpenBSD-based OSes using ``pkg_add(1)``
-pacman                  Arch Linux-based distros using ``pacman(8)``
-pkgin                   NetBSD-based OSes using ``pkgin(1)``
-pkgng                   FreeBSD-based OSes using ``pkg(8)``
-pkgutil                 Solaris-based OSes using `OpenCSW`_'s ``pkgutil(1)``
-solarispkg              Solaris-based OSes using ``pkgadd(1M)``
-solarisips              Solaris-based OSes using IPS ``pkg(1)``
-win_pkg                 Windows
-yumpkg                  RedHat-based distros and derivatives (wraps ``yum(8)``)
-zypper                  SUSE-based distros using ``zypper(8)``
-======================= =======================================================
-
-.. _Homebrew: http://brew.sh/
-.. _OpenCSW: http://www.opencsw.org/
-
-
-Provider: ``service``
-*********************
-
-======================= =======================================================
-Execution Module        Used for
-======================= =======================================================
-debian_service          Debian (non-systemd)
-freebsdservice          FreeBSD-based OSes using ``service(8)``
-gentoo_service          Gentoo Linux using :program:`sysvinit` and
-                        ``rc-update(8)``
-launchctl               Mac OS hosts using ``launchctl(1)``
-netbsdservice           NetBSD-based OSes
-openbsdservice          OpenBSD-based OSes
-rh_service              RedHat-based distros and derivatives using
-                        ``service(8)`` and ``chkconfig(8)``. Supports both
-                        pure sysvinit and mixed sysvinit/upstart systems.
-service                 Fallback which simply wraps sysvinit scripts
-smf                     Solaris-based OSes which use SMF
-systemd                 Linux distros which use systemd
-upstart                 Ubuntu-based distros using upstart
-win_service             Windows
-======================= =======================================================
-
-
-Provider: ``user``
-******************
-
-======================= =======================================================
-Execution Module        Used for
-======================= =======================================================
-useradd                 Linux, NetBSD, and OpenBSD systems using
-                        ``useradd(8)``, ``userdel(8)``, and ``usermod(8)``
-pw_user                 FreeBSD-based OSes using ``pw(8)``
-solaris_user            Solaris-based OSes using ``useradd(1M)``,
-                        ``userdel(1M)``, and ``usermod(1M)``
-win_useradd             Windows
-======================= =======================================================
-
-
-Provider: ``group``
-*******************
-
-======================= =======================================================
-Execution Module        Used for
-======================= =======================================================
-groupadd                Linux, NetBSD, and OpenBSD systems using
-                        ``groupadd(8)``, ``groupdel(8)``, and ``groupmod(8)``
-pw_group                FreeBSD-based OSes using ``pw(8)``
-solaris_group           Solaris-based OSes using ``groupadd(1M)``,
-                        ``groupdel(1M)``, and ``groupmod(1M)``
-win_groupadd            Windows
-======================= =======================================================
-
+described :ref:`here <module-provider-override>`.
 
 Arbitrary Module Redirects
 ==========================

--- a/doc/ref/states/providers.rst
+++ b/doc/ref/states/providers.rst
@@ -24,9 +24,13 @@ In this instance, the basic :py:mod:`~salt.modules.service` module (which
 manages :program:`sysvinit`-based services) will replace the
 :py:mod:`~salt.modules.systemd` module which is used by default on Arch Linux.
 
-However, if it is necessary to make this override for most or every service,
-it is better to just override the provider in the minion config file, as
-described :ref:`here <module-provider-override>`.
+This change only affects this one state though. If it is necessary to make this
+override for most or every service, it is better to just override the provider
+in the minion config file, as described :ref:`here <module-provider-override>`.
+
+Also, keep in mind that this only works for states with an identically-named
+virtual module (:py:mod:`~salt.states.pkg`, :py:mod:`~salt.states.service`,
+etc.).
 
 Arbitrary Module Redirects
 ==========================

--- a/doc/topics/windows/windows-package-manager.rst
+++ b/doc/topics/windows/windows-package-manager.rst
@@ -1,3 +1,5 @@
+.. _windows-package-manager:
+
 ===========================
 Windows Software Repository
 ===========================
@@ -169,7 +171,7 @@ project's wiki_:
         uninstaller: '{23170F69-40C1-2702-0920-000001000000}'
         uninstall_flags: '/qn /norestart'
 
-Alternatively the ``uninstaller`` can also simply repeat the URL of the msi file. 
+Alternatively the ``uninstaller`` can also simply repeat the URL of the msi file.
 
 .. code-block:: yaml
 

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2,8 +2,13 @@
 '''
 Support for APT (Advanced Packaging Tool)
 
-.. note::
+.. important::
+    If you feel that Salt should be using this module to manage packages on a
+    minion, and it is using a different module (or gives an error similar to
+    *'pkg.install' is not available*), see :ref:`here
+    <module-provider-override>`.
 
+.. note::
     For virtual package support, either the ``python-apt`` or ``dctrl-tools``
     package must be installed.
 

--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
 Homebrew for Mac OS X
+
+.. important::
+    If you feel that Salt should be using this module to manage packages on a
+    minion, and it is using a different module (or gives an error similar to
+    *'pkg.install' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 from __future__ import absolute_import
 

--- a/salt/modules/bsd_shadow.py
+++ b/salt/modules/bsd_shadow.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
 Manage the password database on BSD systems
+
+.. important::
+    If you feel that Salt should be using this module to manage passwords on a
+    minion, and it is using a different module (or gives an error similar to
+    *'shadow.info' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 
 # Import python libs

--- a/salt/modules/debian_service.py
+++ b/salt/modules/debian_service.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
 Service support for Debian systems (uses update-rc.d and /sbin/service)
+
+.. important::
+    If you feel that Salt should be using this module to manage services on a
+    minion, and it is using a different module (or gives an error similar to
+    *'service.start' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 from __future__ import absolute_import
 

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -2,6 +2,12 @@
 '''
 Support for Portage
 
+.. important::
+    If you feel that Salt should be using this module to manage packages on a
+    minion, and it is using a different module (or gives an error similar to
+    *'pkg.install' is not available*), see :ref:`here
+    <module-provider-override>`.
+
 :optdepends:    - portage Python adapter
 
 For now all package names *MUST* include the package category,

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -2,6 +2,12 @@
 '''
 Remote package support using ``pkg_add(1)``
 
+.. important::
+    If you feel that Salt should be using this module to manage packages on a
+    minion, and it is using a different module (or gives an error similar to
+    *'pkg.install' is not available*), see :ref:`here
+    <module-provider-override>`.
+
 .. warning::
 
     This module has been completely rewritten. Up to and including version

--- a/salt/modules/freebsdservice.py
+++ b/salt/modules/freebsdservice.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
 The service module for FreeBSD
+
+.. important::
+    If you feel that Salt should be using this module to manage services on a
+    minion, and it is using a different module (or gives an error similar to
+    *'service.start' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 from __future__ import absolute_import
 

--- a/salt/modules/gentoo_service.py
+++ b/salt/modules/gentoo_service.py
@@ -2,6 +2,12 @@
 '''
 Top level package command wrapper, used to translate the os detected by grains
 to the correct service manager
+
+.. important::
+    If you feel that Salt should be using this module to manage services on a
+    minion, and it is using a different module (or gives an error similar to
+    *'service.start' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 
 # Define the module's virtual name

--- a/salt/modules/groupadd.py
+++ b/salt/modules/groupadd.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
 Manage groups on Linux, OpenBSD and NetBSD
+
+.. important::
+    If you feel that Salt should be using this module to manage groups on a
+    minion, and it is using a different module (or gives an error similar to
+    *'group.info' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 
 # Import python libs

--- a/salt/modules/launchctl.py
+++ b/salt/modules/launchctl.py
@@ -2,6 +2,12 @@
 '''
 Module for the management of MacOS systems that use launchd/launchctl
 
+.. important::
+    If you feel that Salt should be using this module to manage services on a
+    minion, and it is using a different module (or gives an error similar to
+    *'service.start' is not available*), see :ref:`here
+    <module-provider-override>`.
+
 :depends:   - plistlib Python module
 '''
 from __future__ import absolute_import

--- a/salt/modules/mac_user.py
+++ b/salt/modules/mac_user.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
 Manage users on Mac OS 10.7+
+
+.. important::
+    If you feel that Salt should be using this module to manage users on a
+    minion, and it is using a different module (or gives an error similar to
+    *'user.info' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 
 # Import python libs

--- a/salt/modules/netbsdservice.py
+++ b/salt/modules/netbsdservice.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
 The service module for NetBSD
+
+.. important::
+    If you feel that Salt should be using this module to manage services on a
+    minion, and it is using a different module (or gives an error similar to
+    *'service.start' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 from __future__ import absolute_import
 

--- a/salt/modules/openbsdpkg.py
+++ b/salt/modules/openbsdpkg.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
 Package support for OpenBSD
+
+.. important::
+    If you feel that Salt should be using this module to manage packages on a
+    minion, and it is using a different module (or gives an error similar to
+    *'pkg.install' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 from __future__ import absolute_import
 

--- a/salt/modules/openbsdservice.py
+++ b/salt/modules/openbsdservice.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
 The service module for OpenBSD
+
+.. important::
+    If you feel that Salt should be using this module to manage services on a
+    minion, and it is using a different module (or gives an error similar to
+    *'service.start' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 
 # Import python libs

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -2,6 +2,12 @@
 '''
 A module to wrap pacman calls, since Arch is the best
 (https://wiki.archlinux.org/index.php/Arch_is_the_best)
+
+.. important::
+    If you feel that Salt should be using this module to manage packages on a
+    minion, and it is using a different module (or gives an error similar to
+    *'pkg.install' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 from __future__ import absolute_import
 

--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
 Package support for pkgin based systems, inspired from freebsdpkg module
+
+.. important::
+    If you feel that Salt should be using this module to manage packages on a
+    minion, and it is using a different module (or gives an error similar to
+    *'pkg.install' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 
 # Import python libs

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -2,6 +2,12 @@
 '''
 Support for ``pkgng``, the new package manager for FreeBSD
 
+.. important::
+    If you feel that Salt should be using this module to manage packages on a
+    minion, and it is using a different module (or gives an error similar to
+    *'pkg.install' is not available*), see :ref:`here
+    <module-provider-override>`.
+
 .. warning::
 
     This module has been completely rewritten. Up to and including version

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
 Pkgutil support for Solaris
+
+.. important::
+    If you feel that Salt should be using this module to manage packages on a
+    minion, and it is using a different module (or gives an error similar to
+    *'pkg.install' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 from __future__ import absolute_import
 

--- a/salt/modules/pw_group.py
+++ b/salt/modules/pw_group.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
 Manage groups on FreeBSD
+
+.. important::
+    If you feel that Salt should be using this module to manage groups on a
+    minion, and it is using a different module (or gives an error similar to
+    *'group.info' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 from __future__ import absolute_import
 

--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
 Manage users with the useradd command
+
+.. important::
+    If you feel that Salt should be using this module to manage users on a
+    minion, and it is using a different module (or gives an error similar to
+    *'user.info' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 
 # Import python libs

--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
 Service support for RHEL-based systems, including support for both upstart and sysvinit
+
+.. important::
+    If you feel that Salt should be using this module to manage services on a
+    minion, and it is using a different module (or gives an error similar to
+    *'service.start' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 from __future__ import absolute_import
 

--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-The default service module, if not otherwise specified salt will fall back
-to this basic module
+If Salt's OS detection does not identify a different virtual service module, the minion will fall back to using this basic module, which simply wraps sysvinit scripts.
 '''
 from __future__ import absolute_import
 

--- a/salt/modules/shadow.py
+++ b/salt/modules/shadow.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
 Manage the shadow file on Linux systems
+
+.. important::
+    If you feel that Salt should be using this module to manage passwords on a
+    minion, and it is using a different module (or gives an error similar to
+    *'shadow.info' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 from __future__ import absolute_import
 

--- a/salt/modules/shadow.py
+++ b/salt/modules/shadow.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-Manage the shadow file
+Manage the shadow file on Linux systems
 '''
 from __future__ import absolute_import
 

--- a/salt/modules/smf.py
+++ b/salt/modules/smf.py
@@ -2,6 +2,12 @@
 '''
 Service support for Solaris 10 and 11, should work with other systems
 that use SMF also. (e.g. SmartOS)
+
+.. important::
+    If you feel that Salt should be using this module to manage services on a
+    minion, and it is using a different module (or gives an error similar to
+    *'service.start' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 
 __func_alias__ = {

--- a/salt/modules/solaris_group.py
+++ b/salt/modules/solaris_group.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
 Manage groups on Solaris
+
+.. important::
+    If you feel that Salt should be using this module to manage groups on a
+    minion, and it is using a different module (or gives an error similar to
+    *'group.info' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 from __future__ import absolute_import
 

--- a/salt/modules/solaris_shadow.py
+++ b/salt/modules/solaris_shadow.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
 Manage the password database on Solaris systems
+
+.. important::
+    If you feel that Salt should be using this module to manage passwords on a
+    minion, and it is using a different module (or gives an error similar to
+    *'shadow.info' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 from __future__ import absolute_import
 

--- a/salt/modules/solaris_user.py
+++ b/salt/modules/solaris_user.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
 Manage users with the useradd command
+
+.. important::
+    If you feel that Salt should be using this module to manage users on a
+    minion, and it is using a different module (or gives an error similar to
+    *'user.info' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 
 # Import python libs

--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -2,6 +2,12 @@
 '''
 IPS pkg support for Solaris
 
+.. important::
+    If you feel that Salt should be using this module to manage packages on a
+    minion, and it is using a different module (or gives an error similar to
+    *'pkg.install' is not available*), see :ref:`here
+    <module-provider-override>`.
+
 This module provides support for Solaris 11 new package management - IPS (Image Packaging System).
 This is the default pkg module for Solaris 11 (and later).
 

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
 Package support for Solaris
+
+.. important::
+    If you feel that Salt should be using this module to manage packages on a
+    minion, and it is using a different module (or gives an error similar to
+    *'pkg.install' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 from __future__ import absolute_import
 

--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
 Provide the service module for systemd
+
+.. important::
+    If you feel that Salt should be using this module to manage services on a
+    minion, and it is using a different module (or gives an error similar to
+    *'service.start' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 # Import python libs
 from __future__ import absolute_import

--- a/salt/modules/upstart.py
+++ b/salt/modules/upstart.py
@@ -3,6 +3,12 @@
 Module for the management of upstart systems. The Upstart system only supports
 service starting, stopping and restarting.
 
+.. important::
+    If you feel that Salt should be using this module to manage services on a
+    minion, and it is using a different module (or gives an error similar to
+    *'service.start' is not available*), see :ref:`here
+    <module-provider-override>`.
+
 Currently (as of Ubuntu 12.04) there is no tool available to disable
 Upstart services (like update-rc.d). This[1] is the recommended way to
 disable an Upstart service. So we assume that all Upstart services

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
 Manage users with the useradd command
+
+.. important::
+    If you feel that Salt should be using this module to manage users on a
+    minion, and it is using a different module (or gives an error similar to
+    *'user.info' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 from __future__ import absolute_import
 

--- a/salt/modules/win_groupadd.py
+++ b/salt/modules/win_groupadd.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
 Manage groups on Windows
+
+.. important::
+    If you feel that Salt should be using this module to manage groups on a
+    minion, and it is using a different module (or gives an error similar to
+    *'group.info' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 from __future__ import absolute_import
 

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -2,6 +2,12 @@
 '''
 A module to manage software on Windows
 
+.. important::
+    If you feel that Salt should be using this module to manage packages on a
+    minion, and it is using a different module (or gives an error similar to
+    *'pkg.install' is not available*), see :ref:`here
+    <module-provider-override>`.
+
 :depends:   - win32com
             - win32con
             - win32api

--- a/salt/modules/win_shadow.py
+++ b/salt/modules/win_shadow.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
 Manage the shadow file
+
+.. important::
+    If you feel that Salt should be using this module to manage passwords on a
+    minion, and it is using a different module (or gives an error similar to
+    *'shadow.info' is not available*), see :ref:`here
+    <module-provider-override>`.
 '''
 from __future__ import absolute_import
 

--- a/salt/modules/win_useradd.py
+++ b/salt/modules/win_useradd.py
@@ -2,6 +2,12 @@
 '''
 Module for managing Windows Users
 
+.. important::
+    If you feel that Salt should be using this module to manage users on a
+    minion, and it is using a different module (or gives an error similar to
+    *'user.info' is not available*), see :ref:`here
+    <module-provider-override>`.
+
 :depends:
         - pywintypes
         - win32api

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2,6 +2,12 @@
 '''
 Support for YUM/DNF
 
+.. important::
+    If you feel that Salt should be using this module to manage packages on a
+    minion, and it is using a different module (or gives an error similar to
+    *'pkg.install' is not available*), see :ref:`here
+    <module-provider-override>`.
+
 .. note::
     This module makes use of the **repoquery** utility, from the yum-utils_
     package. This package will be installed as a dependency if salt is

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -2,6 +2,12 @@
 '''
 Package support for openSUSE via the zypper package manager
 
+.. important::
+    If you feel that Salt should be using this module to manage packages on a
+    minion, and it is using a different module (or gives an error similar to
+    *'pkg.install' is not available*), see :ref:`here
+    <module-provider-override>`.
+
 :depends: - ``zypp`` Python module.  Install with ``zypper install python-zypp``
 '''
 from __future__ import absolute_import


### PR DESCRIPTION
This modifies the State Provider docs, which were a bit misleading in that they
suggest that the state is being overriden when in fact it is the underlying
virtual module of the same name that is being overridden.

It also removes the tables of virtual modules from the State Providers docs
page (where they did not belong, as provider overrides happen at the execution
module level and not the state level), and moves them to pages within
docs/ref/modules/all for each virtual module.

A new section has been added to the execution module docs referencing the
different virtual modules, linking to pages referenced in the paragraph above
(which now contain tables expressing which execution modules are virtual
modules for `pkg`, `service`, etc.).

Finally, all of the modules which are virtual modules now link to the new
section described above, which contains instructions to open a bug report in
case of misdetection of OS/version leading to incorrect assignment of a virtual
module. Additionally, explanation of how to work around this issue using the
`providers` option in the minion config file.

Refs: #32413
