### PR TITLE
Add max_depth parameter to file.directory, fixes #31989

### DIFF
--- a/tests/unit/states/file_test.py
+++ b/tests/unit/states/file_test.py
@@ -704,6 +704,12 @@ class FileTestCase(TestCase):
         ret.update({'comment': comt, 'name': ''})
         self.assertDictEqual(filestate.directory(''), ret)
 
+        comt = ('Cannot specify both max_depth and clean')
+        ret.update({'comment': comt, 'name': name})
+        self.assertDictEqual(
+                filestate.directory(name, clean=True, max_depth=2),
+                ret)
+
         mock_t = MagicMock(return_value=True)
         mock_f = MagicMock(return_value=False)
         mock_perms = MagicMock(return_value=(ret, ''))


### PR DESCRIPTION
### What does this PR do?

Introduce a max_depth parameter for file.directory that limits the recursion depth.
### What issues does this PR fix or reference?
#31989
### New Behavior

If max_depth and any recurse option for file.directory is specified, the recursion will stop once the relative depth to the `name` of state.file is exceeded.
### Tests written?

Yes. Integration and unit tests.
### Open questions

Version added currently set to 2016.4.0. This must very likely be adapted.
Furthermore, the change currently allows to specify max_depth without any recurse option. This does not change observed behavior. Yet, I could introduce a warning or even fail the state. This is up to discussion and your choice. Let me know.
