### PR TITLE
Bugfix/relative requisites

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1294,6 +1294,15 @@ class State(object):
                                   not isinstance(val, six.string_types)):
                                 # Invalid name, fall back to ID
                                 chunk[key] = name
+                            elif ('__sls__' in body and
+                                  '__env__' in body and
+                                  key in STATE_REQUISITE_KEYWORDS):
+                                _val = type(val)()
+                                for req_key, req_val in six.iteritems(val):
+                                    if req_key == 'sls':
+                                        req_val = resolve_relative_sls(req_val, body['__env__'], body['__sls__'])
+                                    _val[req_key] = req_val
+                                chunk[key] = _val
                             else:
                                 chunk[key] = val
                 if names:

--- a/salt/state.py
+++ b/salt/state.py
@@ -279,27 +279,27 @@ def mock_ret(cdata):
             'result': True}
 
 
-def resolve_relative_sls(inc_sls, saltenv, sls):
+def resolve_relative_sls(target_sls, saltenv, base_sls):
     '''
-    Convert relative sls ``inc_sls`` into an absolute reference,
-    relative to ``sls``.
+    Convert relative sls ``target_sls`` into an absolute reference,
+    relative to ``base_sls``.
     '''
-    match = re.match(r'^(\.+)(.*)$', inc_sls)
+    match = re.match(r'^(\.+)(.*)$', target_sls)
     if match:
         levels, include = match.groups()
     else:
         msg = ('Badly formatted include {0} found in include '
                 'in SLS \'{2}:{3}\''
-                .format(inc_sls, saltenv, sls))
+                .format(target_sls, saltenv, base_sls))
         log.error(msg)
         raise RelativeSlsError(msg)
     level_count = len(levels)
-    p_comps = sls.split('.')
+    p_comps = base_sls.split('.')
     if level_count > len(p_comps):
         msg = ('Attempted relative include of \'{0}\' '
                'within SLS \'{1}:{2}\' '
                'goes beyond top level package '
-               .format(inc_sls, saltenv, sls))
+               .format(target_sls, saltenv, base_sls))
         log.error(msg)
         raise RelativeSlsError(msg)
     return '.'.join(p_comps[:-level_count] + [include])

--- a/tests/integration/files/file/base/requisites/issue-10838-relative-includes/foo/init.sls
+++ b/tests/integration/files/file/base/requisites/issue-10838-relative-includes/foo/init.sls
@@ -1,0 +1,8 @@
+include:
+  - .other
+
+first_state:
+  cmd.run:
+    - name: echo "Success!"
+    - require:
+      - sls: .other

--- a/tests/integration/files/file/base/requisites/issue-10838-relative-includes/foo/other.sls
+++ b/tests/integration/files/file/base/requisites/issue-10838-relative-includes/foo/other.sls
@@ -1,0 +1,3 @@
+second_state:
+  cmd.run:
+    - name: echo "Also success!"

--- a/tests/integration/files/file/base/requisites/issue-10838-relative-includes/include-test.sls
+++ b/tests/integration/files/file/base/requisites/issue-10838-relative-includes/include-test.sls
@@ -1,0 +1,2 @@
+include:
+  - issue-10838-relative-includes.foo

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -1078,6 +1078,23 @@ class StateModuleTest(integration.ModuleCase,
         listener_state = 'cmd_|-listener_test_listening_resolution_two_|-echo "Successful listen resolution"_|-mod_watch'
         self.assertIn(listener_state, state_run)
 
+    def test_issue_10838_requisite_in_match_by_name(self):
+        '''
+        This tests the case where a requisite references a relative include
+
+        See https://github.com/saltstack/salt/issues/30820 for more info
+        '''
+        state_run = self.run_function(
+            'state.sls',
+            mods='requisites.issue-10838-relative-includes.include-test'
+        )
+
+        second_state = 'cmd_|-second_state_|-echo "Also success!"_|-run'
+
+        self.assertIn(second_state, state_run)
+        self.assertEqual(state_run[second_state]['comment'],
+                         'Command "echo "Also success!"" run')
+
     def test_issue_30820_requisite_in_match_by_name(self):
         '''
         This tests the case where a requisite_in matches by name instead of ID


### PR DESCRIPTION
### What does this PR do?

Fixes requisite lookup so that (given the following defined in `foo/init.sls`):

```
bar:
    cmd.run:
        - require:
            - sls: .baz
```

`foo` would depend on `foo.baz`. Currently, this fails with the following:

```
          ID: foo
    Function: cmd.run
        Name: foo
      Result: False
     Comment: The following requisites were not found:
                                 require:
                                     sls: .baz
     Started: 
    Duration: 
     Changes:   
```
### What issues does this PR fix or reference?
#10838
### New Behavior

Allows for relative sls requisites
### Tests written?

Yes
