### PR TITLE
Add marathon restart functon to state and exec modules

### DIFF
--- a/salt/modules/marathon.py
+++ b/salt/modules/marathon.py
@@ -49,7 +49,9 @@ def apps():
     Return a list of the currently installed app ids.
 
     CLI Example:
+
     .. code-block:: bash
+
         salt marathon-minion-id marathon.apps
     '''
     response = salt.utils.http.query(
@@ -65,7 +67,9 @@ def has_app(id):
     Return whether the given app id is currently configured.
 
     CLI Example:
+
     .. code-block:: bash
+
         salt marathon-minion-id marathon.has_app my-app
     '''
     return _app_id(id) in apps()['apps']
@@ -76,7 +80,9 @@ def app(id):
     Return the current server configuration for the specified app.
 
     CLI Example:
+
     .. code-block:: bash
+
         salt marathon-minion-id marathon.app my-app
     '''
     response = salt.utils.http.query(
@@ -92,7 +98,9 @@ def update_app(id, config):
     Update the specified app with the given configuration.
 
     CLI Example:
+
     .. code-block:: bash
+
         salt marathon-minion-id marathon.update_app my-app '<config yaml>'
     '''
     if 'id' not in config:
@@ -130,7 +138,9 @@ def rm_app(id):
     Remove the specified app from the server.
 
     CLI Example:
+
     .. code-block:: bash
+
         salt marathon-minion-id marathon.rm_app my-app
     '''
     response = salt.utils.http.query(
@@ -147,7 +157,9 @@ def info():
     Return configuration and status information about the marathon instance.
 
     CLI Example:
+
     .. code-block:: bash
+
         salt marathon-minion-id marathon.info
     '''
     response = salt.utils.http.query(

--- a/salt/modules/marathon.py
+++ b/salt/modules/marathon.py
@@ -162,9 +162,27 @@ def restart_app(id, restart=False, force=True):
     '''
     Restart the current server configuration for the specified app.
 
+    :param restart: Restart the app
+    :param force: Override the current deployment
+
     CLI Example:
+
     .. code-block:: bash
-        salt marathon-minion-id marathon.restart_app my-app true
+
+        salt marathon-minion-id marathon.restart_app my-app
+
+    By default, this will only check if the app exists in marathon. It does
+    not check if there are any tasks associated with it or if the app is suspended.
+
+    .. code-block:: bash
+
+        salt marathon-minion-id marathon.restart_app my-app true true
+
+    The restart option needs to be set to True to actually issue a rolling
+    restart to marathon.
+
+    The force option tells marathon to ignore the current app deployment if
+    there is one.
     '''
     ret = {'restarted': None}
     if not restart:

--- a/salt/modules/marathon.py
+++ b/salt/modules/marathon.py
@@ -188,4 +188,8 @@ def restart_app(id, restart=False, force=True):
         return ret
     except Exception as ex:
         log.error('unable to restart marathon app: %s', ex.message)
-    return ret
+        return {
+            'exception': {
+                'message': ex.message,
+            }
+        }

--- a/salt/modules/marathon.py
+++ b/salt/modules/marathon.py
@@ -156,3 +156,24 @@ def info():
         decode=True,
     )
     return response['dict']
+
+
+def restart_app(id, force=True):
+    '''
+    Restart the current server configuration for the specified app.
+
+    CLI Example:
+    .. code-block:: bash
+        salt marathon-minion-id marathon.restart_app my-app true
+    '''
+    response = salt.utils.http.query(
+        "{0}/v2/apps/{1}/restart?force={2}".format(_base_url(), _app_id(id), force),
+        method='POST',
+        decode_type='json',
+        decode=True,
+        header_dict={
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+        },
+    )
+    return response['dict']

--- a/salt/states/marathon_app.py
+++ b/salt/states/marathon_app.py
@@ -118,7 +118,7 @@ def absent(name):
         return ret
 
 
-def restart(name, force=True):
+def restart(name, restart=False, force=True):
     '''
     Restart the marathon app with the given id if present.
 
@@ -138,7 +138,7 @@ def restart(name, force=True):
         ret['result'] = None
         ret['comment'] = 'App {0} is set to be restarted'.format(name)
         return ret
-    restart_result = __salt__['marathon.restart_app'](name, force)
+    restart_result = __salt__['marathon.restart_app'](name, restart, force)
     if restart_result:
         ret['changes'] = restart_result
         ret['result'] = True

--- a/salt/states/marathon_app.py
+++ b/salt/states/marathon_app.py
@@ -116,3 +116,35 @@ def absent(name):
         ret['result'] = False
         ret['comment'] = 'Failed to remove app {0}'.format(name)
         return ret
+
+
+def restart(name, force=True):
+    '''
+    Restart the marathon app with the given id if present.
+
+    :param name: The app name/id
+    :param force: Override the current deployment
+    :return: A standard Salt changes dictionary
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+    if not __salt__['marathon.has_app'](name):
+        ret['result'] = False
+        ret['comment'] = 'App {0} cannot be restarted because it is absent'.format(name)
+        return ret
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'App {0} is set to be restarted'.format(name)
+        return ret
+    restart_result = __salt__['marathon.restart_app'](name, force)
+    if restart_result:
+        ret['changes'] = restart_result
+        ret['result'] = True
+        ret['comment'] = 'Restarted app {0}'.format(name)
+        return ret
+    else:
+        ret['result'] = False
+        ret['comment'] = 'Failed to restart app {0}'.format(name)
+        return ret

--- a/salt/states/marathon_app.py
+++ b/salt/states/marathon_app.py
@@ -123,6 +123,7 @@ def running(name, restart=False, force=True):
     Ensure that the marathon app with the given id is present and restart if set.
 
     :param name: The app name/id
+    :param restart: Restart the app
     :param force: Override the current deployment
     :return: A standard Salt changes dictionary
     '''


### PR DESCRIPTION
### What does this PR do?

Allows a marathon app to be restarted through a state.
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/32319
### New Behavior

Add marathon_app.running exec module function.
Add marathon.restart_app state module function.
### Tests written?

No (need a working marathon cluster to verify).
Unless I should mock marathon's API response?

@jfindlay Thanks for helping me through the issue/PR.
