### PR TITLE
Add link to provider override docs to opkg.py

### DIFF
--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -2,6 +2,12 @@
 '''
 Support for Opkg
 
+.. important::
+    If you feel that Salt should be using this module to manage packages on a
+    minion, and it is using a different module (or gives an error similar to
+    *'pkg.install' is not available*), see :ref:`here
+    <module-provider-override>`.
+
 .. versionadded: 2016.3.0
 
 .. note::


### PR DESCRIPTION
This is a companion to https://github.com/saltstack/salt/pull/32458, but
this module was not added until the 2016.3 branch, so the documentation
is being updated there for this module.
