### PR TITLE
Fixed message deletion from the queue for TCP.

### DIFF
--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -744,6 +744,7 @@ class SaltMessageClient(object):
             message_id, item = self.send_queue[0]
             try:
                 yield self._stream.write(item)
+                del self.send_queue[0]
             # if the connection is dead, lets fail this send, and make sure we
             # attempt to reconnect
             except tornado.iostream.StreamClosedError as e:
@@ -759,7 +760,6 @@ class SaltMessageClient(object):
                 if self._connecting_future.done():
                     self._connecting_future = self.connect()
                 yield self._connecting_future
-            del self.send_queue[0]
 
     def _message_id(self):
         wrap = False


### PR DESCRIPTION
### What does this PR do?

There is a mistake I've made in the message deletion logic when I've
updated the message sending and timeout handling code.

Found when was porting this back into 2015.8.

Thanks to @cachedout.
