### PR TITLE
Use win32api to get Total System Memory

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -58,6 +58,7 @@ if salt.utils.is_windows():
     try:
         import wmi  # pylint: disable=import-error
         import salt.utils.winapi
+        import win32api
         HAS_WMI = True
     except ImportError:
         log.exception(
@@ -406,13 +407,10 @@ def _memdata(osdata):
             if comps[0].strip() == 'Memory' and comps[1].strip() == 'size:':
                 grains['mem_total'] = int(comps[2].strip())
     elif osdata['kernel'] == 'Windows' and HAS_WMI:
-        with salt.utils.winapi.Com():
-            wmi_c = wmi.WMI()
-            # this is a list of each stick of ram in a system
-            # WMI returns it as the string value of the number of bytes
-            tot_bytes = sum([int(x.Capacity) for x in wmi_c.Win32_PhysicalMemory()], 0)
-            # return memory info in gigabytes
-            grains['mem_total'] = int(tot_bytes / (1024 ** 2))
+        # get the Total Physical memory as reported by msinfo32
+        tot_bytes = win32api.GlobalMemoryStatusEx()['TotalPhys']
+        # return memory info in gigabytes
+        grains['mem_total'] = int(tot_bytes / (1024 ** 2))
     return grains
 
 


### PR DESCRIPTION
### What does this PR do?

Uses win32api to populate `mem_total` grain for windows.
### What issues does this PR fix or reference?
#32327
### Previous Behavior

In some edge cases the wmi call failed to return an expected value and would cause the minion to fail to start.
### New Behavior

Uses win32api to get `mem_total` grain.
### Tests written?

No
