### PR TITLE
Add Cumulus support to aptpkg

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -89,6 +89,8 @@ def __virtual__():
         return __virtualname__
     elif __grains__.get('os_family', False) == 'Debian':
         return __virtualname__
+    elif __grains__.get('os_family', False) == 'Cumulus':
+        return __virtualname__
     return (False, 'The pkg module could not be loaded: unsupported OS family')
 
 


### PR DESCRIPTION
### What does this PR do?

Adds ﻿Cumulus support to aptpkg (so you can use the pkg module)
### What issues does this PR fix or reference?

N/A
### Previous Behavior

pkg functions would not work as the os_family was unknown to aptpkg
### New Behavior

pkg functions work
### Tests written?

No

Cumulus is a Debian based switch OS, needs support for pkg installs.
