### PR TITLE
Engines with proxies

### DIFF
--- a/salt/engines/__init__.py
+++ b/salt/engines/__init__.py
@@ -58,7 +58,8 @@ def start_engines(opts, proc_mgr, proxy=None):
                         fun,
                         engine_opts,
                         funcs,
-                        runners
+                        runners,
+                        proxy
                         ),
                     name=name
                     )
@@ -68,7 +69,7 @@ class Engine(SignalHandlingMultiprocessingProcess):
     '''
     Execute the given engine in a new process
     '''
-    def __init__(self, opts, fun, config, funcs, runners, log_queue=None):
+    def __init__(self, opts, fun, config, funcs, runners, proxy, log_queue=None):
         '''
         Set up the process executor
         '''
@@ -78,6 +79,7 @@ class Engine(SignalHandlingMultiprocessingProcess):
         self.fun = fun
         self.funcs = funcs
         self.runners = runners
+        self.proxy = proxy
 
     # __setstate__ and __getstate__ are only used on Windows.
     # We do this so that __init__ will be invoked on Windows in the child
@@ -90,6 +92,7 @@ class Engine(SignalHandlingMultiprocessingProcess):
             state['config'],
             state['funcs'],
             state['runners'],
+            state['proxy'],
             log_queue=state['log_queue']
         )
 
@@ -99,6 +102,7 @@ class Engine(SignalHandlingMultiprocessingProcess):
                 'config': self.config,
                 'funcs': self.funcs,
                 'runners': self.runners,
+                'proxy': self.proxy,
                 'log_queue': self.log_queue}
 
     def run(self):
@@ -116,7 +120,8 @@ class Engine(SignalHandlingMultiprocessingProcess):
 
         self.engine = salt.loader.engines(self.opts,
                                           self.funcs,
-                                          self.runners)
+                                          self.runners,
+                                          proxy=self.proxy)
         kwargs = self.config or {}
         try:
             self.engine[self.fun](**kwargs)

--- a/salt/engines/__init__.py
+++ b/salt/engines/__init__.py
@@ -17,7 +17,7 @@ from salt.utils.process import SignalHandlingMultiprocessingProcess
 log = logging.getLogger(__name__)
 
 
-def start_engines(opts, proc_mgr):
+def start_engines(opts, proc_mgr, proxy=None):
     '''
     Fire up the configured engines!
     '''
@@ -27,7 +27,7 @@ def start_engines(opts, proc_mgr):
         runners = []
     utils = salt.loader.utils(opts)
     funcs = salt.loader.minion_mods(opts, utils=utils)
-    engines = salt.loader.engines(opts, funcs, runners)
+    engines = salt.loader.engines(opts, funcs, runners, proxy=proxy)
 
     engines_opt = opts.get('engines', [])
     if isinstance(engines_opt, dict):

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -272,12 +272,13 @@ def raw_mod(opts, name, functions, mod='modules'):
     return dict(loader._dict)  # return a copy of *just* the funcs for `name`
 
 
-def engines(opts, functions, runners):
+def engines(opts, functions, runners, proxy=None):
     '''
     Return the master services plugins
     '''
     pack = {'__salt__': functions,
-            '__runners__': runners}
+            '__runners__': runners,
+            '__proxy__': proxy}
     return LazyLoader(
         _module_dirs(opts, 'engines', 'engines'),
         opts,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -841,7 +841,12 @@ class Minion(MinionBase):
         log.info('Creating minion process manager')
         self.process_manager = ProcessManager(name='MinionProcessManager')
         self.io_loop.spawn_callback(self.process_manager.run, async=True)
-        self.io_loop.spawn_callback(salt.engines.start_engines, self.opts, self.process_manager)
+        # We don't have the proxy setup yet, so we can't start engines
+        # Engines need to be able to access __proxy__
+        if not salt.utils.is_proxy():
+            self.io_loop.spawn_callback(salt.engines.start_engines, self.opts,
+                                        self.process_manager)
+
 
         # Install the SIGINT/SIGTERM handlers if not done so far
         if signal.getsignal(signal.SIGINT) is signal.SIG_DFL:
@@ -2960,7 +2965,7 @@ class ProxyMinion(Minion):
         # Then load the proxy module
         self.proxy = salt.loader.proxy(self.opts)
 
-        # Check config 'add_proxymodule_to_opts'  Remove this in Boron.
+        # Check config 'add_proxymodule_to_opts'  Remove this in Carbon.
         if self.opts['add_proxymodule_to_opts']:
             self.opts['proxymodule'] = self.proxy
 
@@ -2970,6 +2975,12 @@ class ProxyMinion(Minion):
         self.proxy.pack['__salt__'] = self.functions
         self.proxy.pack['__ret__'] = self.returners
         self.proxy.pack['__pillar__'] = self.opts['pillar']
+
+        # Start engines here instead of in the Minion superclass __init__
+        # This is because we need to inject the __proxy__ variable but
+        # it is not setup until now.
+        self.io_loop.spawn_callback(salt.engines.start_engines, self.opts,
+                                    self.process_manager, proxy=self.proxy)
 
         if ('{0}.init'.format(fq_proxyname) not in self.proxy
                 or '{0}.shutdown'.format(fq_proxyname) not in self.proxy):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -847,7 +847,6 @@ class Minion(MinionBase):
             self.io_loop.spawn_callback(salt.engines.start_engines, self.opts,
                                         self.process_manager)
 
-
         # Install the SIGINT/SIGTERM handlers if not done so far
         if signal.getsignal(signal.SIGINT) is signal.SIG_DFL:
             # No custom signal handling was added, install our own


### PR DESCRIPTION
### What does this PR do?

Ensures the `__proxy__` variable is available to engines running on minions.
### What issues does this PR fix or reference?

No current issue for this.
### Previous Behavior

Engines running on minions did not have `__proxy__` injected.
### New Behavior

`__proxy__` is now available.
### Tests written?

No
