### PR TITLE
Avoid KeyError if cron change does not include a diff

### DIFF
--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -564,7 +564,6 @@ def file(name,
     cron_ret = None
     if ret['changes']:
         cron_ret = __salt__['cron.write_cron_file_verbose'](user, cron_path)
-        ret['changes'] = {'diff': ret['changes']['diff']}
         ret['comment'] = 'Crontab for user {0} was updated'.format(user)
     elif ret['result']:
         ret['comment'] = 'Crontab for user {0} is in the correct ' \


### PR DESCRIPTION
### What does this PR do?

Fixes a KeyError if the cron changed (e.g. file permissions) but is otherwise
identical
### Previous Behavior

```
File "/tmp/saltenv/lib/python2.7/site-packages/salt/state.py", line 1703, in call
  **cdata['kwargs'])
File "/tmp/saltenv/lib/python2.7/site-packages/salt/loader.py", line 1661, in wrapper
  return f(*args, **kwargs)
File "/tmp/saltenv/lib/python2.7/site-packages/salt/states/cron.py", line 567, in file
  ret['changes'] = {'diff': ret['changes']['diff']}
KeyError: 'diff'
```
