### PR TITLE
Allow user login class to be empty on OpenBSD

### DIFF
--- a/salt/modules/linux_sysctl.py
+++ b/salt/modules/linux_sysctl.py
@@ -41,7 +41,11 @@ def _check_systemd_salt_config():
         sysctl_dir = os.path.split(conf)[0]
         if not os.path.exists(sysctl_dir):
             os.makedirs(sysctl_dir)
-        salt.utils.fopen(conf, 'w').close()
+        try:
+            salt.utils.fopen(conf, 'w').close()
+        except (IOError, OSError):
+            msg = 'Could not create file: {0}'
+            raise CommandExecutionError(msg.format(conf))
     return conf
 
 

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -551,7 +551,7 @@ def get_loginclass(name):
             try:
                 ret = line.split(None, 1)[1]
                 break
-            except ValueError:
+            except (ValueError, IndexError):
                 continue
     else:
         ret = ''

--- a/tests/unit/modules/mac_sysctl_test.py
+++ b/tests/unit/modules/mac_sysctl_test.py
@@ -72,11 +72,11 @@ class DarwinSysctlTestCase(TestCase):
         Tests adding of config file failure
         '''
         with patch('salt.utils.fopen', mock_open()) as m_open:
-            helper_open = m_open()
-            helper_open.write.assertRaises(CommandExecutionError,
-                                           mac_sysctl.persist,
-                                           'net.inet.icmp.icmplim',
-                                           50, config=None)
+            m_open.side_effect = IOError(13, 'Permission denied', '/file')
+            self.assertRaises(CommandExecutionError,
+                              mac_sysctl.persist,
+                              'net.inet.icmp.icmplim',
+                              50, config=None)
 
     @patch('os.path.isfile', MagicMock(return_value=False))
     def test_persist_no_conf_success(self):

--- a/tests/unit/modules/mount_test.py
+++ b/tests/unit/modules/mount_test.py
@@ -114,10 +114,10 @@ class MountTestCase(TestCase):
         mock_fstab = MagicMock(return_value={'name': 'name'})
         with patch.object(mount, 'fstab', mock_fstab):
             with patch('salt.utils.fopen', mock_open()) as m_open:
-                helper_open = m_open()
-                helper_open.write.assertRaises(CommandExecutionError,
-                                               mount.rm_fstab,
-                                               config=None)
+                m_open.side_effect = IOError(13, 'Permission denied:', '/file')
+                self.assertRaises(CommandExecutionError,
+                                  mount.rm_fstab,
+                                  'name', 'device')
 
     def test_set_fstab(self):
         '''
@@ -153,11 +153,7 @@ class MountTestCase(TestCase):
 
         mock = MagicMock(return_value={'name': 'name'})
         with patch.object(mount, 'fstab', mock):
-            with patch('salt.utils.fopen', mock_open()) as m_open:
-                helper_open = m_open()
-                helper_open.write.assertRaises(CommandExecutionError,
-                                               mount.rm_automaster,
-                                               'name', 'device')
+            self.assertTrue(mount.rm_automaster('name', 'device'))
 
     def test_set_automaster(self):
         '''

--- a/tests/unit/modules/puppet_test.py
+++ b/tests/unit/modules/puppet_test.py
@@ -85,10 +85,12 @@ class PuppetTestCase(TestCase):
                 with patch('salt.utils.fopen', mock_open()):
                     self.assertTrue(puppet.disable())
 
-                with patch('salt.utils.fopen', mock_open()) as m_open:
-                    helper_open = m_open()
-                    helper_open.write.assertRaises(CommandExecutionError,
-                                                    puppet.disable)
+                try:
+                    with patch('salt.utils.fopen', mock_open()) as m_open:
+                        m_open.side_effect = IOError(13, 'Permission denied:', '/file')
+                        self.assertRaises(CommandExecutionError, puppet.disable)
+                except StopIteration:
+                    pass
 
     def test_status(self):
         '''
@@ -145,9 +147,8 @@ class PuppetTestCase(TestCase):
                 self.assertDictEqual(puppet.summary(), {'resources': 1})
 
             with patch('salt.utils.fopen', mock_open()) as m_open:
-                helper_open = m_open()
-                helper_open.write.assertRaises(CommandExecutionError,
-                                                puppet.summary)
+                m_open.side_effect = IOError(13, 'Permission denied:', '/file')
+                self.assertRaises(CommandExecutionError, puppet.summary)
 
     def test_plugin_sync(self):
         '''


### PR DESCRIPTION
### What does this PR do?

Allows for the case where a user does not have a login class
### What issues does this PR fix or reference?
#32512
### Previous Behavior

```
ret = line.split(None, 1)[1]
          IndexError: list index out of range
```
### More information

Fetching the login class does work on OpenBSD for users that are part of a group

```
$ salt-ssh workstation user.get_loginclass eradman
workstation:
    staff

$ salt-ssh workstation user.get_loginclass backrest
workstation:
```
