### PR TITLE
Fix salt-call on standalone minion case

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -229,7 +229,8 @@ class BaseCaller(object):
             if isinstance(oput, six.string_types):
                 ret['out'] = oput
         is_local = self.opts['local'] or self.opts.get(
-            'file_client', False) == 'local'
+            'file_client', False) == 'local' or self.opts.get(
+            'master_type') == 'disable'
         returners = self.opts.get('return', '').split(',')
         if (not is_local) or returners:
             ret['id'] = self.opts['id']
@@ -246,7 +247,6 @@ class BaseCaller(object):
                 pass
 
         # return the job infos back up to the respective minion's master
-
         if not is_local:
             try:
                 mret = ret.copy()

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -628,13 +628,15 @@ class SMinion(MinionBase):
         '''
         Load all of the modules for the minion
         '''
-        self.opts['pillar'] = salt.pillar.get_pillar(
-            self.opts,
-            self.opts['grains'],
-            self.opts['id'],
-            self.opts['environment'],
-            pillarenv=self.opts.get('pillarenv'),
-        ).compile_pillar()
+        if self.opts.get('master_type') != 'disable':
+            self.opts['pillar'] = salt.pillar.get_pillar(
+                self.opts,
+                self.opts['grains'],
+                self.opts['id'],
+                self.opts['environment'],
+                pillarenv=self.opts.get('pillarenv'),
+            ).compile_pillar()
+
         self.utils = salt.loader.utils(self.opts)
         self.functions = salt.loader.minion_mods(self.opts, utils=self.utils,
                                                  include_errors=True)

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2034,7 +2034,7 @@ class Minion(MinionBase):
         # add handler to subscriber
         if hasattr(self, 'pub_channel') and self.pub_channel is not None:
             self.pub_channel.on_recv(self._handle_payload)
-        else:
+        elif self.opts.get('master_type') != 'disable':
             log.error('No connection to master found. Scheduled jobs will not run.')
 
         if start:


### PR DESCRIPTION
### What does this PR do?

On [https://github.com/saltstack/salt/pull/31832] standalone minion support was added. However, when master_type == disable, salt-call errors out.  Also, a spurious error is being logged:

[ERROR   ][2104] No connection to master found. Scheduled jobs will not run

Disabled error  when master_type == disable.
### What issues does this PR fix or reference?
### Previous Behavior

salt-call errors out if when --local is not used:

KeyError: 'master_uri'
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    salt_call()
  File "/usr/lib/python2.7/site-packages/salt/scripts.py", line 335, in salt_call
    client.run()
  File "/usr/lib/python2.7/site-packages/salt/cli/call.py", line 43, in run
    caller = salt.cli.caller.Caller.factory(self.config)
  File "/usr/lib/python2.7/site-packages/salt/cli/caller.py", line 78, in factory
    return ZeroMQCaller(opts, *_kwargs)
  File "/usr/lib/python2.7/site-packages/salt/cli/caller.py", line 269, in **init**
    super(ZeroMQCaller, self).**init**(opts)
  File "/usr/lib/python2.7/site-packages/salt/cli/caller.py", line 101, in **init**
    self.minion = salt.minion.SMinion(opts)
  File "/usr/lib/python2.7/site-packages/salt/minion.py", line 576, in **init**
    self.gen_modules(initial_load=True)
  File "/usr/lib/python2.7/site-packages/salt/minion.py", line 587, in gen_modules
    pillarenv=self.opts.get('pillarenv'),
  File "/usr/lib/python2.7/site-packages/salt/pillar/**init**.py", line 52, in get_pillar
    pillar=pillar, pillarenv=pillarenv)
  File "/usr/lib/python2.7/site-packages/salt/pillar/**init**.py", line 140, in **init**
    self.channel = salt.transport.Channel.factory(opts)
  File "/usr/lib/python2.7/site-packages/salt/transport/**init**.py", line 49, in factory
    return ReqChannel.factory(opts, *_kwargs)
  File "/usr/lib/python2.7/site-packages/salt/transport/client.py", line 22, in factory
    sync = SyncWrapper(AsyncReqChannel.factory, (opts,), kwargs)
  File "/usr/lib/python2.7/site-packages/salt/utils/async.py", line 60, in **init**
    self.async = method(_args, *_kwargs)
  File "/usr/lib/python2.7/site-packages/salt/transport/client.py", line 114, in factory
    return salt.transport.tcp.AsyncTCPReqChannel(opts, *_kwargs)
  File "/usr/lib/python2.7/site-packages/salt/transport/tcp.py", line 127, in **new**
    key = cls.__key(opts, *_kwargs)
  File "/usr/lib/python2.7/site-packages/salt/transport/tcp.py", line 146, in __key
    opts['master_uri'],
KeyError: 'master_uri'
### New Behavior

Fixed
### Tests written?

/No
