### PR TITLE
Fix epoch handling in old version for Yum

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1090,6 +1090,12 @@ def install(name=None,
                 pkgstr = pkgpath
 
             cver = old.get(pkgname, '')
+            if _yum() == 'yum':
+                # We remove the epoch from new version in case of yum.
+                # It needs to be removed from cver as well, otherwise
+                # compare_version gets the comparison wrong
+                cver = cver.split(':', 1)[-1]
+
             if reinstall and cver \
                     and salt.utils.compare_versions(ver1=version_num,
                                                     oper='==',


### PR DESCRIPTION
yumpkg removes the epoch from "new" package version for "yum". However, when evaluating "old" version already installed on the system, the epoch is kept as it is. This leads to wrong results in version comparison (E.g. 1:2.9.8.0-2 is shown to be newer than 2.9.8.2-1 because epoch has not been removed from both).
This causes salt to issue a `yum downgrade` when it is actually an update and leads to `pkg.installed` state failures.

Fixes #32229 

This PR removes epoch from the version of "old" package too, if "yum" is used.
