### PR TITLE
Fix YAML-block in "Organizing Pillar data" part of "Salt Formulas" do…

### DIFF
--- a/doc/topics/development/conventions/formulas.rst
+++ b/doc/topics/development/conventions/formulas.rst
@@ -788,10 +788,9 @@ service/software/etc, managed by the formula:
 
 .. code-block:: yaml
 
-mysql:
-  lookup:
-    version: 5.7.11
-    ...
+    mysql:
+      lookup:
+        version: 5.7.11
 
 Collecting common values
 ````````````````````````


### PR DESCRIPTION
### What does this PR do?

There is a YAML block in [this](https://docs.saltstack.com/en/develop/topics/development/conventions/formulas.html#organizing-pillar-data) section of the docs and it's broken: 
![block](https://cloud.githubusercontent.com/assets/4378647/14484749/1be460ce-015b-11e6-90fe-d4156060a2eb.png)

This PR fixes it.
### What issues does this PR fix or reference?

The bug was introduced in #31035
