### PR TITLE
Document "grains" setting in the minion configuration reference

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -380,6 +380,28 @@ feature is disabled, to enable set minion_pillar_cache to ``True``.
 
     minion_pillar_cache: False
 
+.. conf_minion:: grains
+
+``grains``
+----------
+
+Default: (empty)
+
+.. seealso::
+    :ref:`static-custom-grains`
+
+Statically assigns grains to the minion.
+
+.. code-block:: yaml
+
+    grains:
+      roles:
+        - webserver
+        - memcache
+      deployment: datacenter4
+      cabinet: 13
+      cab_u: 14-15
+
 .. conf_minion:: grains_cache
 
 ``grains_cache``

--- a/doc/topics/grains/index.rst
+++ b/doc/topics/grains/index.rst
@@ -45,7 +45,7 @@ Grains in the Minion Config
 ===========================
 
 Grains can also be statically assigned within the minion configuration file.
-Just add the option ``grains`` and pass options to it:
+Just add the option :conf_minion:`grains` and pass options to it:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
### What does this PR do?

The minion configuration [reference](https://docs.saltstack.com/en/develop/ref/configuration/minion.html) doesn't mention `grains` setting. This PR adds a section about it.
