### PR TITLE
salt.version: case insensitive ordering of deps

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -650,7 +650,8 @@ def versions_report(include_salt_cloud=False):
     info = []
     for ver_type in ('Salt Version', 'Dependency Versions', 'System Versions'):
         info.append('{0}:'.format(ver_type))
-        for name in sorted(ver_info[ver_type]):
+        # List dependencies in alphabetical, case insensitive order
+        for name in sorted(ver_info[ver_type], cmp=lambda x, y: cmp(x.lower(), y.lower())):
             ver = fmt.format(name,
                              ver_info[ver_type][name] or 'Not Installed',
                              pad=padding)


### PR DESCRIPTION
### What does this PR do?

Order the salt dependency versions report by case insensitive alphabetical listing.  This should make the dependency list more readable.
### Previous Behavior

``` yaml
# salt-call --local test.versions
[INFO    ] Determining pillar cache
local:
    Salt Version:
               Salt: 2016.3.0rc2-174-g3561664

    Dependency Versions:
             Jinja2: 2.7.2
           M2Crypto: 0.21.1
               Mako: Not Installed
             PyYAML: 3.10
              PyZMQ: 14.3.1
             Python: 2.7.5 (default, Nov 20 2015, 02:00:19)
               RAET: Not Installed
            Tornado: 4.2.1
                ZMQ: 3.2.5
               cffi: Not Installed
           cherrypy: 3.6.0
           dateutil: Not Installed
              gitdb: 0.6.4
          gitpython: 0.3.6
              ioflo: Not Installed
            libgit2: Not Installed
            libnacl: Not Installed
       msgpack-pure: Not Installed
     msgpack-python: 0.4.7
       mysql-python: 1.2.3
          pycparser: Not Installed
           pycrypto: 2.6.1
             pygit2: Not Installed
       python-gnupg: 0.3.7
              smmap: 0.9.0
            timelib: 0.2.4

    System Versions:
               dist: centos 7.2.1511 Core
            machine: x86_64
            release: 3.10.0-327.10.1.el7.x86_64
             system: Linux
            version: CentOS Linux 7.2.1511 Core
```
### New Behavior

``` yaml
# salt-call --local test.versions
[INFO    ] Determining pillar cache
local:
    Salt Version:
               Salt: 2016.3.0rc2-175-gad0e949

    Dependency Versions:
               cffi: Not Installed
           cherrypy: 3.6.0
           dateutil: Not Installed
              gitdb: 0.6.4
          gitpython: 0.3.6
              ioflo: Not Installed
             Jinja2: 2.7.2
            libgit2: Not Installed
            libnacl: Not Installed
           M2Crypto: 0.21.1
               Mako: Not Installed
       msgpack-pure: Not Installed
     msgpack-python: 0.4.7
       mysql-python: 1.2.3
          pycparser: Not Installed
           pycrypto: 2.6.1
             pygit2: Not Installed
             Python: 2.7.5 (default, Nov 20 2015, 02:00:19)
       python-gnupg: 0.3.7
             PyYAML: 3.10
              PyZMQ: 14.3.1
               RAET: Not Installed
              smmap: 0.9.0
            timelib: 0.2.4
            Tornado: 4.2.1
                ZMQ: 3.2.5

    System Versions:
               dist: centos 7.2.1511 Core
            machine: x86_64
            release: 3.10.0-327.10.1.el7.x86_64
             system: Linux
            version: CentOS Linux 7.2.1511 Core
```
### Tests written?

No
