### PR TITLE
Fix binary search and replace

### DIFF
--- a/pkg/windows/portable.py
+++ b/pkg/windows/portable.py
@@ -43,6 +43,7 @@ def main(argv):
         display_help()
     f = open( target, 'rb' ).read()
     f = f.replace( search, replace )
+    f = f.replace( search.lower(), replace )
     open( target, 'wb' ).write(f)
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What does this PR do?

Fixes problem where the pip and easy_install executable files were failing to be edited.
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/32541
### Previous Behavior

Failed to replace the full path (`C:\Python27\Python.exe`) with a relative path (`..\python.exe`)
### New Behavior

Properly sets the relative path
### Tests written?

NA
