### PR TITLE
PY3: salt-key --gen-keys fix

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -35,7 +35,10 @@ def __define_global_system_encoding_variable__():
     # This is the most trustworthy source of the system encoding, though, if
     # salt is being imported after being daemonized, this information is lost
     # and reset to None
-    encoding = sys.stdin.encoding
+    if sys.stdin is not None:
+        encoding = sys.stdin.encoding
+    else:
+        encoding = None
     if not encoding:
         # If the system is properly configured this should return a valid
         # encoding. MS Windows has problems with this and reports the wrong

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -871,7 +871,7 @@ def pem_finger(path=None, key=None, sum_type='sha256'):
             return ''
 
         with fopen(path, 'rb') as fp_:
-            key = ''.join([x for x in fp_.readlines() if x.strip()][1:-1])
+            key = b''.join([x for x in fp_.readlines() if x.strip()][1:-1])
 
     pre = getattr(hashlib, sum_type)(key).hexdigest()
     finger = ''


### PR DESCRIPTION
### What does this PR do?

`__init__.py`:
- On certain invocations of salt-key (seen when invoked programmatically
  on Windows without going through the command interpreter `cmd.exe`),
  `sys.stdin` is None. This has only been seen on Python 3. So
  `encoding = sys.stdin.encoding` raises an exception in this case.

`utils/__init__.py`:
- `pem_finger` reads a file in binary mode. So in Python 3, the return
  type is bytes and not str. Simple fix by using `b''.join` instead of
  `''.join`.
### What issues does this PR fix or reference?
### Tests written?

No

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
