### PR TITLE
Add html_url to "min" dictionary that is returned for issues

### DIFF
--- a/salt/modules/github.py
+++ b/salt/modules/github.py
@@ -847,7 +847,8 @@ def _format_issue(issue):
            'issue_number': issue.get('number'),
            'state': issue.get('state'),
            'title': issue.get('title'),
-           'user': issue.get('user').get('login')}
+           'user': issue.get('user').get('login'),
+           'html_url': issue.get('html_url')}
 
     assignee = issue.get('assignee')
     if assignee:


### PR DESCRIPTION
### What does this PR do?

Adds the issue link (htm_url) to the minimum output when searching for issues:

```
root@rallytime:~# salt-call --local github.get_issue 32540
[INFO    ] Determining pillar cache
local:
    ----------
    148095783:
        ----------
        assignee:
            None
        html_url:
            https://github.com/saltstack/salt/issues/32540
        id:
            148095783
        issue_number:
            32540
        labels:
        milestone:
            None
        state:
            open
        title:
            Feature request: provide a state module to manage Consul's content
        user:
            multani
```
### Tests written?

No
