### PR TITLE
use defaults if opts doesn't have the keys either

### DIFF
--- a/salt/auth/ldap.py
+++ b/salt/auth/ldap.py
@@ -25,7 +25,8 @@ except ImportError:
     HAS_LDAP = False
 
 # Defaults, override in master config
-__defopts__ = {'auth.ldap.uri': '',
+__defopts__ = {'auth.ldap.basedn': '',
+               'auth.ldap.uri': '',
                'auth.ldap.server': 'localhost',
                'auth.ldap.port': '389',
                'auth.ldap.tls': False,
@@ -45,26 +46,20 @@ def _config(key, mandatory=True, opts=None):
     '''
     Return a value for 'name' from master config file options or defaults.
     '''
-    if opts:
+    try:
+        if opts:
+            value = opts['auth.ldap.{0}'.format(key)]
+        else:
+            value = __opts__['auth.ldap.{0}'.format(key)]
+    except KeyError:
         try:
-            return opts['auth.ldap.{0}'.format(key)]
+            value = __defopts__['auth.ldap.{0}'.format(key)]
         except KeyError:
             if mandatory:
                 msg = 'missing auth.ldap.{0} in master config'.format(key)
                 raise SaltInvocationError(msg)
             return False
-    else:
-        try:
-            value = __opts__['auth.ldap.{0}'.format(key)]
-        except KeyError:
-            try:
-                value = __defopts__['auth.ldap.{0}'.format(key)]
-            except KeyError:
-                if mandatory:
-                    msg = 'missing auth.ldap.{0} in master config'.format(key)
-                    raise SaltInvocationError(msg)
-                return False
-        return value
+    return value
 
 
 def _render_template(param, username):


### PR DESCRIPTION
### What does this PR do?

Set defaults for ldap expand search if necessary
### What issues does this PR fix or reference?

Fixes #32456 
### Previous Behavior

```
[root@salt /]# salt -a pam -T \* test.ping
username: daniel
password:
[CRITICAL] Could not deserialize msgpack message: Some exception handling minion payloadThis often happens when trying to read a file not in binary mode.Please open an issue and include the following error: unpack(b) received extra data.
[ERROR   ] Uncaught exception, closing connection.
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/zmq/eventloop/zmqstream.py", line 414, in _run_callback
    callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/tornado/stack_context.py", line 275, in null_wrapper
    return fn(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/salt/transport/zeromq.py", line 882, in mark_future
    future.set_result(self.serial.loads(msg[0]))
  File "/usr/local/lib/python2.7/site-packages/salt/payload.py", line 117, in loads
    return msgpack.loads(msg, use_list=True)
  File "msgpack/_unpacker.pyx", line 143, in msgpack._unpacker.unpackb (msgpack/_unpacker.cpp:143)
ExtraData: unpack(b) received extra data.
[ERROR   ] Uncaught exception, closing connection.
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/zmq/eventloop/zmqstream.py", line 440, in _handle_events
    self._handle_recv()
  File "/usr/local/lib/python2.7/site-packages/zmq/eventloop/zmqstream.py", line 472, in _handle_recv
    self._run_callback(callback, msg)
  File "/usr/local/lib/python2.7/site-packages/zmq/eventloop/zmqstream.py", line 414, in _run_callback
    callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/tornado/stack_context.py", line 275, in null_wrapper
    return fn(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/salt/transport/zeromq.py", line 882, in mark_future
    future.set_result(self.serial.loads(msg[0]))
  File "/usr/local/lib/python2.7/site-packages/salt/payload.py", line 117, in loads
    return msgpack.loads(msg, use_list=True)
  File "msgpack/_unpacker.pyx", line 143, in msgpack._unpacker.unpackb (msgpack/_unpacker.cpp:143)
ExtraData: unpack(b) received extra data.
[ERROR   ] Exception in callback None
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/tornado/ioloop.py", line 883, in start
    handler_func(fd_obj, events)
  File "/usr/local/lib/python2.7/site-packages/tornado/stack_context.py", line 275, in null_wrapper
    return fn(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/zmq/eventloop/zmqstream.py", line 440, in _handle_events
    self._handle_recv()
  File "/usr/local/lib/python2.7/site-packages/zmq/eventloop/zmqstream.py", line 472, in _handle_recv
    self._run_callback(callback, msg)
  File "/usr/local/lib/python2.7/site-packages/zmq/eventloop/zmqstream.py", line 414, in _run_callback
    callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/tornado/stack_context.py", line 275, in null_wrapper
    return fn(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/salt/transport/zeromq.py", line 882, in mark_future
    future.set_result(self.serial.loads(msg[0]))
  File "/usr/local/lib/python2.7/site-packages/salt/payload.py", line 117, in loads
    return msgpack.loads(msg, use_list=True)
  File "msgpack/_unpacker.pyx", line 143, in msgpack._unpacker.unpackb (msgpack/_unpacker.cpp:143)
ExtraData: unpack(b) received extra data.
```

With this in the master log

```
master_1 | [ERROR   ] Some exception handling a payload from minion
master_1 | Traceback (most recent call last):
master_1 |   File "/usr/local/lib/python2.7/site-packages/salt/transport/zeromq.py", line 577, in handle_message
master_1 |     ret, req_opts = yield self.payload_handler(payload)
master_1 |   File "/usr/local/lib/python2.7/site-packages/tornado/gen.py", line 1008, in run
master_1 |     value = future.result()
master_1 |   File "/usr/local/lib/python2.7/site-packages/tornado/concurrent.py", line 232, in result
master_1 |     raise_exc_info(self._exc_info)
master_1 |   File "/usr/local/lib/python2.7/site-packages/tornado/gen.py", line 267, in wrapper
master_1 |     result = func(*args, **kwargs)
master_1 |   File "/usr/local/lib/python2.7/site-packages/salt/master.py", line 842, in _handle_payload
master_1 |     'clear': self._handle_clear}[key](load)
master_1 |   File "/usr/local/lib/python2.7/site-packages/salt/master.py", line 856, in _handle_clear
master_1 |     return getattr(self.clear_funcs, load['cmd'])(load), {'fun': 'send_clear'}
master_1 |   File "/usr/local/lib/python2.7/site-packages/salt/master.py", line 1972, in publish
master_1 |     auth_list = self.ckminions.fill_auth_list_from_ou(auth_list, self.opts)
master_1 |   File "/usr/local/lib/python2.7/site-packages/salt/utils/minions.py", line 965, in fill_auth_list_from_ou
master_1 |     auth_list = salt.auth.ldap.expand_ldap_entries(auth_list, opts)
master_1 |   File "/usr/local/lib/python2.7/site-packages/salt/auth/ldap.py", line 397, in expand_ldap_entries
master_1 |     bind = _bind_for_search(opts=opts)
master_1 |   File "/usr/local/lib/python2.7/site-packages/salt/auth/ldap.py", line 147, in _bind_for_search
master_1 |     paramvalues[param] = _config(param, opts=opts)
master_1 |   File "/usr/local/lib/python2.7/site-packages/salt/auth/ldap.py", line 55, in _config
master_1 |     raise SaltInvocationError(msg)
master_1 | SaltInvocationError: missing auth.ldap.uri in master config
```
### New Behavior

```
[root@salt /]# salt -a pam -T \* test.ping
minion-2b60453900c1:
    True
minion-1c9e2ffd85cc:
    True
```
### Tests written?

No
