### PR TITLE
Don't return None from eval_master

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -490,6 +490,7 @@ class MinionBase(object):
                 msg = ('No master could be reached or all masters denied '
                        'the minions connection attempt.')
                 log.error(msg)
+                raise SaltClientError(msg)
             else:
                 self.tok = pub_channel.auth.gen_token('salt')
                 self.connected = True


### PR DESCRIPTION
### What does this PR do?

Fixes the non-informative message `NoneType is not iterable` on minion restart when it can't connect to any master in multimaster mode.
### What issues does this PR fix or reference?
#32517
