### PR TITLE
redact passwords and hashes from user.present updates

### DIFF
--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -516,7 +516,10 @@ def present(name,
         if 'shadow.info' in __salt__:
             for key in spost:
                 if lshad[key] != spost[key]:
-                    ret['changes'][key] = spost[key]
+                    if key == 'passwd':
+                        ret['changes'][key] = 'XXX-REDACTED-XXX'
+                    else:
+                        ret['changes'][key] = spost[key]
         if __grains__['kernel'] == 'OpenBSD':
             if lcpre != lcpost:
                 ret['changes']['loginclass'] = lcpost


### PR DESCRIPTION
### What does this PR do?

redact the user password from user.present if the password gets updated
### What issues does this PR fix or reference?

Fixes #32381
### Previous Behavior

```
minion-c0a675f3a03a:
----------
          ID: daniel
    Function: user.present
      Result: True
     Comment: Updated user daniel
     Started: 22:35:42.297577
    Duration: 15.902 ms
     Changes:
              ----------
              passwd:
                  Test
```
### New Behavior

```
minion-aa17c893f447:
----------
          ID: daniel
    Function: user.present
      Result: True
     Comment: Updated user daniel
     Started: 22:42:43.903988
    Duration: 17.426 ms
     Changes:
              ----------
              passwd:
                  XXX-REDACTED-XXX

Summary
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
```
### Tests written?

No
