### PR TITLE
Better log message on minion restart if master couldn't be reached.

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -440,10 +440,11 @@ class AsyncAuth(object):
         channel = salt.transport.client.AsyncReqChannel.factory(self.opts,
                                                                 crypt='clear',
                                                                 io_loop=self.io_loop)
+        error = None
         while True:
             try:
                 creds = yield self.sign_in(channel=channel)
-            except SaltClientError:
+            except SaltClientError as error:
                 break
             if creds == 'retry':
                 if self.opts.get('caller'):
@@ -463,9 +464,9 @@ class AsyncAuth(object):
                 del AsyncAuth.creds_map[self.__key(self.opts)]
             except KeyError:
                 pass
-            self._authenticate_future.set_exception(
-                SaltClientError('Attempt to authenticate with the salt master failed')
-            )
+            if not error:
+                error = SaltClientError('Attempt to authenticate with the salt master failed')
+            self._authenticate_future.set_exception(error)
         else:
             AsyncAuth.creds_map[self.__key(self.opts)] = creds
             self._creds = creds
@@ -1037,7 +1038,7 @@ class SAuth(AsyncAuth):
             if safe:
                 log.warning('SaltReqTimeoutError: {0}'.format(e))
                 return 'retry'
-            raise SaltClientError('Attempt to authenticate with the salt master failed')
+            raise SaltClientError('Attempt to authenticate with the salt master failed with timeout error')
 
         if 'load' in payload:
             if 'ret' in payload['load']:


### PR DESCRIPTION
### What does this PR do?

Throw the original exception if any on auth errors. This would help to identify why minion can't connect to master: auth failure or timeout error.
### What issues does this PR fix or reference?
#32519
