### PR TITLE
Fix mac_service and mac_system modules

### DIFF
--- a/salt/modules/mac_service.py
+++ b/salt/modules/mac_service.py
@@ -294,8 +294,11 @@ def disable(name, runas=None):
 
 def start(name, runas=None):
     '''
-    Start a launchd service. Enables the service if not enabled. Raises an error
-    if the service fails to start
+    Start a launchd service. Raises an error if the service fails to start
+
+    .. note::
+        To start a service in Mac OS X the service must be enabled first. Use
+        ``service.enable`` to enable the service.
 
     :param str name: Service label, file name, or full path
 
@@ -315,21 +318,20 @@ def start(name, runas=None):
     path = service['file_path']
     label = service['plist']['Label']
 
-    # Enable the service
-    launchctl('enable', 'system/{0}'.format(label), runas=runas)
-
     # Load the service: will raise an error if it fails
     return launchctl('load', path, runas=runas)
 
 
-def stop(name, no_disable=False, runas=None):
+def stop(name, runas=None):
     '''
-    Stop a launchd service. Raises an error if the service fails to stop.
+    Stop a launchd service. Raises an error if the service fails to stop
+
+    .. note::
+        Though ``service.stop`` will unload a service in Mac OS X, the service
+        will start on next boot unless it is disabled. Use ``service.disable``
+        to disable the service
 
     :param str name: Service label, file name, or full path
-
-    :param bool no_disable: Don't disable the service. The service will start on
-        next boot. Default is to disable the service
 
     :param str runas: User to run launchctl commands
 
@@ -346,10 +348,6 @@ def stop(name, no_disable=False, runas=None):
     service = _get_service(name)
     path = service['file_path']
     label = service['plist']['Label']
-
-    if not no_disable:
-        # Disable the service (default)
-        launchctl('disable', 'system/{0}'.format(label), runas=runas)
 
     # Disable the Launch Daemon: will raise an error if it fails
     return launchctl('unload', path, runas=runas)

--- a/salt/modules/mac_service.py
+++ b/salt/modules/mac_service.py
@@ -294,7 +294,7 @@ def disable(name, runas=None):
 
 def start(name, runas=None):
     '''
-    Start a launchd service. Raises an error if the service fails to start
+    Start a launchd service.  Raises an error if the service fails to start
 
     .. note::
         To start a service in Mac OS X the service must be enabled first. Use
@@ -316,7 +316,6 @@ def start(name, runas=None):
     # Get service information and file path
     service = _get_service(name)
     path = service['file_path']
-    label = service['plist']['Label']
 
     # Load the service: will raise an error if it fails
     return launchctl('load', path, runas=runas)
@@ -324,7 +323,7 @@ def start(name, runas=None):
 
 def stop(name, runas=None):
     '''
-    Stop a launchd service. Raises an error if the service fails to stop
+    Stop a launchd service.  Raises an error if the service fails to stop
 
     .. note::
         Though ``service.stop`` will unload a service in Mac OS X, the service
@@ -347,7 +346,6 @@ def stop(name, runas=None):
     # Get service information and file path
     service = _get_service(name)
     path = service['file_path']
-    label = service['plist']['Label']
 
     # Disable the Launch Daemon: will raise an error if it fails
     return launchctl('unload', path, runas=runas)

--- a/salt/modules/mac_system.py
+++ b/salt/modules/mac_system.py
@@ -48,8 +48,9 @@ def _atrun_enabled():
 
 def _enable_atrun():
     '''
-    Start and enable the atrun daemon
+    Enable and start the atrun daemon
     '''
+    __salt__['service.enable']('com.apple.atrun')
     __salt__['service.start']('com.apple.atrun')
     return _atrun_enabled()
 

--- a/salt/modules/mac_system.py
+++ b/salt/modules/mac_system.py
@@ -50,8 +50,7 @@ def _enable_atrun():
     '''
     Start and enable the atrun daemon
     '''
-    atrun = '/System/Library/LaunchDaemons/com.apple.atrun.plist'
-    __salt__['service.start'](atrun)
+    __salt__['service.start']('com.apple.atrun')
     return _atrun_enabled()
 
 

--- a/tests/integration/modules/mac_service.py
+++ b/tests/integration/modules/mac_service.py
@@ -98,6 +98,30 @@ class MacServiceModuleTest(integration.ModuleCase):
             self.run_function('service.list', ['spongebob']))
 
     @destructiveTest
+    def test_enable(self):
+        '''
+        Test service.enable
+        '''
+        self.assertTrue(
+            self.run_function('service.enable', [self.SERVICE_NAME]))
+
+        self.assertIn(
+            'Service not found',
+            self.run_function('service.enable', ['spongebob']))
+
+    @destructiveTest
+    def test_disable(self):
+        '''
+        Test service.disable
+        '''
+        self.assertTrue(
+            self.run_function('service.disable', [self.SERVICE_NAME]))
+
+        self.assertIn(
+            'Service not found',
+            self.run_function('service.disable', ['spongebob']))
+
+    @destructiveTest
     def test_start(self):
         '''
         Test service.start


### PR DESCRIPTION
### What does this PR do?

Fixes service and system modules for mac.
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/32585
### Previous Behavior

Mac system module fails to start because it can't enable the atrun service. This is because the `service.start` function fails to start disabled services.
### New Behavior

Added `service.enable` and `service.disable` to enable and disable services. Mac_system module now enables the atrun service using `service.enable` before it tries to start it.
### Tests written?

Yes
