### PR TITLE
Fix salt-ssh module function call argument type juggling by JSON encoding them

### DIFF
--- a/salt/client/ssh/wrapper/__init__.py
+++ b/salt/client/ssh/wrapper/__init__.py
@@ -103,8 +103,8 @@ class FunctionWrapper(object):
             The remote execution function
             '''
             argv = [cmd]
-            argv.extend([str(arg) for arg in args])
-            argv.extend(['{0}={1}'.format(key, val) for key, val in six.iteritems(kwargs)])
+            argv.extend([json.dumps(arg) for arg in args])
+            argv.extend(['{0}={1}'.format(key, json.dumps(val)) for key, val in six.iteritems(kwargs)])
             single = salt.client.ssh.Single(
                     self.opts,
                     argv,


### PR DESCRIPTION
This fixes problems where you could pass a string to a module function, which thanks to the yaml decoder which is used when parsing command line arguments could change its type entirely. For example:

```
__salt__['test.echo')('{foo: bar}')
```

The `test.echo` function just returns the argument it's given. However, because it's being called through a `salt-call` process like this:

```
salt-call --local test.echo {foo: bar}
```

Salt thinks it's YAML and therefore YAML decodes it. The return value from the test.echo call above is therefore a dict, not a string.

Should fix #31542
