### PR TITLE
Enable blocking on min_party until minimum set of nodes are available

### DIFF
--- a/salt/modules/zk_concurrency.py
+++ b/salt/modules/zk_concurrency.py
@@ -291,10 +291,10 @@ def party_members(path,
         zookeeper connect string
 
     min_nodes
-        The minimum number of nodes needed to be present in the party
+        The minimum number of nodes expected to be present in the party
 
     blocking
-        The flag indicating if we need to block until min_nodes are available
+        The boolean indicating if we need to block until min_nodes are available
 
     Example:
 

--- a/salt/modules/zk_concurrency.py
+++ b/salt/modules/zk_concurrency.py
@@ -281,7 +281,7 @@ def party_members(path,
                   blocking=False
                   ):
     '''
-    Get the List of identifiers in a particular party, optionally waiting for the 
+    Get the List of identifiers in a particular party, optionally waiting for the
     specified minimum number of nodes (min_nodes) to appear
 
     path

--- a/salt/modules/zk_concurrency.py
+++ b/salt/modules/zk_concurrency.py
@@ -301,6 +301,7 @@ def party_members(path,
     ... code-block: bash
 
         salt minion zk_concurrency.party_members /lock/path host1:1234,host2:1234
+        salt minion zk_concurrency.party_members /lock/path host1:1234,host2:1234 min_nodes=3 blocking=True
     '''
     zk = _get_zk_conn(zk_hosts)
     party = kazoo.recipe.party.ShallowParty(zk, path)

--- a/salt/modules/zk_concurrency.py
+++ b/salt/modules/zk_concurrency.py
@@ -277,17 +277,24 @@ def unlock(path,
 
 def party_members(path,
                   zk_hosts,
-                  min_nodes,
+                  min_nodes=1,
                   blocking=False
                   ):
     '''
-    Get the List of identifiers in a particular party
+    Get the List of identifiers in a particular party, optionally waiting for the specified
+    minimum number of nodes (min_nodes) to appear
 
     path
         The path in zookeeper where the lock is
 
     zk_hosts
         zookeeper connect string
+
+    min_nodes
+        The minimum number of nodes needed to be present in the party
+
+    blocking
+        The flag indicating if we need to block until min_nodes are available
 
     Example:
 

--- a/salt/modules/zk_concurrency.py
+++ b/salt/modules/zk_concurrency.py
@@ -281,8 +281,8 @@ def party_members(path,
                   blocking=False
                   ):
     '''
-    Get the List of identifiers in a particular party, optionally waiting for the specified
-    minimum number of nodes (min_nodes) to appear
+    Get the List of identifiers in a particular party, optionally waiting for the 
+    specified minimum number of nodes (min_nodes) to appear
 
     path
         The path in zookeeper where the lock is

--- a/salt/modules/zk_concurrency.py
+++ b/salt/modules/zk_concurrency.py
@@ -18,6 +18,7 @@ try:
         ForceRetryError
     )
     import kazoo.recipe.lock
+    import kazoo.recipe.barrier
     import kazoo.recipe.party
     from kazoo.exceptions import CancelledError
     from kazoo.exceptions import NoNodeError
@@ -276,6 +277,8 @@ def unlock(path,
 
 def party_members(path,
                   zk_hosts,
+                  min_nodes,
+                  blocking=False
                   ):
     '''
     Get the List of identifiers in a particular party
@@ -294,4 +297,9 @@ def party_members(path,
     '''
     zk = _get_zk_conn(zk_hosts)
     party = kazoo.recipe.party.ShallowParty(zk, path)
+    if blocking:
+        barrier = kazoo.recipe.barrier.DoubleBarrier(zk, path, min_nodes)
+        barrier.enter()
+        party = kazoo.recipe.party.ShallowParty(zk, path)
+        barrier.leave()
     return list(party)

--- a/salt/states/zk_concurrency.py
+++ b/salt/states/zk_concurrency.py
@@ -140,12 +140,18 @@ def min_party(name,
               blocking=False
               ):
     '''
-    Ensure that there are `min_nodes` in the party at `name`.
+    Ensure that there are `min_nodes` in the party at `name`, optionally blocking if not available.
     '''
     ret = {'name': name,
            'changes': {},
            'result': False,
            'comment': ''}
+
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Attempt to ensure min_party'
+        return ret
+
     nodes = __salt__['zk_concurrency.party_members'](name, zk_hosts, min_nodes, blocking=blocking)
     if not isinstance(nodes, list):
         raise Exception('Error from zk_concurrency.party_members, return was not a list: {0}'.format(nodes))

--- a/salt/states/zk_concurrency.py
+++ b/salt/states/zk_concurrency.py
@@ -157,8 +157,7 @@ def min_party(name,
         if not blocking:
             ret['comment'] = 'Currently {0} nodes, which is >= {1}'.format(num_nodes, min_nodes)
         else:
-            ret['comment'] = 'Blocked until {0} nodes were available. ' + \
-                'Unblocked after {1} nodes became available'.format(min_nodes, num_nodes)
+            ret['comment'] = 'Blocked until {0} nodes were available. Unblocked after {1} nodes became available'.format(min_nodes, num_nodes)
     else:
         ret['result'] = False
         ret['comment'] = 'Currently {0} nodes, which is < {1}'.format(num_nodes, min_nodes)

--- a/tests/unit/states/zk_concurrency_test.py
+++ b/tests/unit/states/zk_concurrency_test.py
@@ -76,7 +76,7 @@ class ZkConcurrencyTestCase(TestCase):
 
     def test_min_party(self):
         '''
-            Test to block state execution until you are able to get the lock
+            Test to ensure min party of nodes and the blocking behavior
         '''
         ret = {'name': 'salt',
                'changes': {},

--- a/tests/unit/states/zk_concurrency_test.py
+++ b/tests/unit/states/zk_concurrency_test.py
@@ -88,12 +88,12 @@ class ZkConcurrencyTestCase(TestCase):
             self.assertDictEqual(zk_concurrency.min_party('salt', 'dude', 1), ret)
 
         with patch.dict(zk_concurrency.__opts__, {"test": False}):
-            mock = MagicMock(return_value=['1','2','3'])
+            mock = MagicMock(return_value=['1', '2', '3'])
             with patch.dict(zk_concurrency.__salt__,
                             {"zk_concurrency.party_members": mock}):
                 ret.update({'comment': 'Currently 3 nodes, which is >= 2', 'result': True})
                 self.assertDictEqual(zk_concurrency.min_party('salt', 'dude', 2), ret)
-                ret.update({'comment': 'Blocked until 2 nodes were available. ' + \
+                ret.update({'comment': 'Blocked until 2 nodes were available. ' +
                            'Unblocked after 3 nodes became available', 'result': True})
                 self.assertDictEqual(zk_concurrency.min_party('salt', 'dude', 2, True), ret)
                 ret.update({'comment': 'Currently 3 nodes, which is < 4', 'result': False})

--- a/tests/unit/states/zk_concurrency_test.py
+++ b/tests/unit/states/zk_concurrency_test.py
@@ -74,6 +74,31 @@ class ZkConcurrencyTestCase(TestCase):
                                                            identifier='stack'),
                                      ret)
 
+    def test_min_party(self):
+        '''
+            Test to block state execution until you are able to get the lock
+        '''
+        ret = {'name': 'salt',
+               'changes': {},
+               'result': True,
+               'comment': ''}
+
+        with patch.dict(zk_concurrency.__opts__, {"test": True}):
+            ret.update({'comment': 'Attempt to ensure min_party', 'result': None})
+            self.assertDictEqual(zk_concurrency.min_party('salt', 'dude', 1), ret)
+
+        with patch.dict(zk_concurrency.__opts__, {"test": False}):
+            mock = MagicMock(return_value=['1','2','3'])
+            with patch.dict(zk_concurrency.__salt__,
+                            {"zk_concurrency.party_members": mock}):
+                ret.update({'comment': 'Currently 3 nodes, which is >= 2', 'result': True})
+                self.assertDictEqual(zk_concurrency.min_party('salt', 'dude', 2), ret)
+                ret.update({'comment': 'Blocked until 2 nodes were available. ' + \
+                           'Unblocked after 3 nodes became available', 'result': True})
+                self.assertDictEqual(zk_concurrency.min_party('salt', 'dude', 2, True), ret)
+                ret.update({'comment': 'Currently 3 nodes, which is < 4', 'result': False})
+                self.assertDictEqual(zk_concurrency.min_party('salt', 'dude', 4), ret)
+
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
### What does this PR do?

This PR enables blocking on zk_concurrency.min_party until a minimum set of nodes are available
### What issues does this PR fix or reference?

This adds a functionality for certain use-cases where we need to know that there are a minimum set of nodes at the same execution point
### Previous Behavior

min_party was not blocking until a minimum set of nodes became available. It used to only state the number of nodes available on a given zk root.
### New Behavior

The new optional blocking behaviour can enable a variety of new use cases, like sync the hosts before proceeding with the next step.
### Tests written?

Yes - For states/zk_concurrency.py
