### PR TITLE
add nxos grains just like salt/grains/nxos.py

### DIFF
--- a/salt/proxy/nxos.py
+++ b/salt/proxy/nxos.py
@@ -174,7 +174,7 @@ def grains():
         ret = system_info()
         log.debug(ret)
         DETAILS['grains_cache'].update(ret)
-    return DETAILS['grains_cache']
+    return {'nxos': DETAILS['grains_cache']}
 
 
 def grains_refresh():


### PR DESCRIPTION
### What does this PR do?

instead of including the grains for nxos with the rest of the grains, have them fall under the nxos key like in salt/grains/nxos.py

With this, the salt/grains/nxos.py can eventually be removed.
### Tests written?

No
