### PR TITLE
strip extra whitespace from regex match on roles for nxos state

### DIFF
--- a/salt/proxy/nxos.py
+++ b/salt/proxy/nxos.py
@@ -211,7 +211,7 @@ def get_roles(username):
     info = sendline('show user-account {0}'.format(username))
     roles = re.search(r'^\s*roles:(.*)$', info, re.MULTILINE)
     if roles:
-        roles = roles.group(1).split(' ')
+        roles = roles.group(1).strip().split(' ')
     else:
         roles = []
     return roles


### PR DESCRIPTION
### What does this PR do?

removes extra '' from list of `salt proxy\* nxos.cmd get_roles <user>`
### Tests written?

No
