### PR TITLE
added WaitForRole and RoleRetries to update_function_config

### DIFF
--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -245,7 +245,7 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S
     ret['changes'] = {}
     # function exists, ensure config matches
     _ret = _function_config_present(FunctionName, Role, Handler, Description, Timeout,
-                                  MemorySize, VpcConfig, region, key, keyid, profile)
+                                  MemorySize, VpcConfig, region, key, keyid, profile, RoleRetries)
     if not _ret.get('result'):
         ret['result'] = False
         ret['comment'] = _ret['comment']
@@ -285,7 +285,7 @@ def _get_role_arn(name, region=None, key=None, keyid=None, profile=None):
 
 
 def _function_config_present(FunctionName, Role, Handler, Description, Timeout,
-                           MemorySize, VpcConfig, region, key, keyid, profile):
+                           MemorySize, VpcConfig, region, key, keyid, profile, RoleRetries):
     ret = {'result': True, 'comment': '', 'changes': {}}
     func = __salt__['boto_lambda.describe_function'](FunctionName,
            region=region, key=key, keyid=keyid, profile=profile)['function']
@@ -322,7 +322,8 @@ def _function_config_present(FunctionName, Role, Handler, Description, Timeout,
                                         Timeout=Timeout, MemorySize=MemorySize,
                                         VpcConfig=VpcConfig,
                                         region=region, key=key,
-                                        keyid=keyid, profile=profile)
+                                        keyid=keyid, profile=profile,
+                                        WaitForRole=True, RoleRetries=RoleRetries)
         if not _r.get('updated'):
             ret['result'] = False
             ret['comment'] = 'Failed to update function: {0}.'.format(_r['error']['message'])


### PR DESCRIPTION
### What does this PR do?

add optional retry mechanism into update_function_config to retry on InvalidParameterValueException due to a Role that has not been propagated to the Lambda backend.
### What issues does this PR fix or reference?

This fixes an issue with an existing lambda function being updated with a Role that has been freshly created which may not have become consistent yet in AWS lambda backend.  Without this fix, the update attempt will just fail indicating that the Role is invalid.
### Previous Behavior

update_function_config in execution module (and thus in function_present state in the case of an existing lambda function) will fail if there is an InvalidParameterValueException.
### New Behavior

update_function_config by default will still behave as before with only single try.  Users have the option of turning on retry to deal with the freshly created role's eventual consistency issue in the Lambda backend.  

function_present in the state module is now more robust by turning on this retry feature, and succeeds in its attempt when updating an existing Lambda config with a newly created Role.
### Tests written?

No, manually tested against AWS.
