### PR TITLE
Fix comments value in salt.states.pkgrepo example

### DIFF
--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -13,7 +13,7 @@ these states. Here is some example SLS:
         - humanname: CentOS-$releasever - Base
         - mirrorlist: http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os
         - comments:
-            - '#http://mirror.centos.org/centos/$releasever/os/$basearch/'
+            - 'http://mirror.centos.org/centos/$releasever/os/$basearch/'
         - gpgcheck: 1
         - gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 


### PR DESCRIPTION
### What does this PR do?

Removes extra `#` from `comments` value  salt.states.pkgrepo example.

`comments` option adds `#` automatically. Example contains `#http://mirror.centos.org/centos/$releasever/os/$basearch/` string which becomes prefixed with `##` in generated file instead.
