### PR TITLE
Deprecate 'user' and 'group' in state cmd

### DIFF
--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -486,10 +486,10 @@ def wait(name,
     '''
     if 'user' in kwargs or 'group' in kwargs:
         salt.utils.warn_until(
-            'Nitrogen',
+            'Oxygen',
             'The legacy user/group arguments are deprecated. '
             'Replace them with runas. '
-            'These arguments will be removed in Salt Nitrogen.'
+            'These arguments will be removed in Salt Oxygen.'
         )
         if kwargs['user'] is not None and runas is None:
             runas = kwargs.pop('user')
@@ -617,10 +617,10 @@ def wait_script(name,
     '''
     if 'user' in kwargs or 'group' in kwargs:
         salt.utils.warn_until(
-            'Nitrogen',
+            'Oxygen',
             'The legacy user/group arguments are deprecated. '
             'Replace them with runas. '
-            'These arguments will be removed in Salt Nitrogen.'
+            'These arguments will be removed in Salt Oxygen.'
         )
         if kwargs['user'] is not None and runas is None:
             runas = kwargs.pop('user')
@@ -800,10 +800,10 @@ def run(name,
 
     if 'user' in kwargs or 'group' in kwargs:
         salt.utils.warn_until(
-            'Nitrogen',
+            'Oxygen',
             'The legacy user/group arguments are deprecated. '
             'Replace them with runas. '
-            'These arguments will be removed in Salt Nitrogen.'
+            'These arguments will be removed in Salt Oxygen.'
         )
         if kwargs['user'] is not None and runas is None:
             runas = kwargs.pop('user')
@@ -1033,10 +1033,10 @@ def script(name,
 
     if 'user' in kwargs or 'group' in kwargs:
         salt.utils.warn_until(
-            'Nitrogen',
+            'Oxygen',
             'The legacy user/group arguments are deprecated. '
             'Replace them with runas. '
-            'These arguments will be removed in Salt Nitrogen.'
+            'These arguments will be removed in Salt Oxygen.'
         )
         if kwargs['user'] is not None and runas is None:
             runas = kwargs.pop('user')

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -384,7 +384,7 @@ def wait(name,
          unless=None,
          creates=None,
          cwd=None,
-         user=None,
+         runas=None,
          shell=None,
          env=(),
          stateful=False,
@@ -415,7 +415,7 @@ def wait(name,
         The current working directory to execute the command in, defaults to
         /root
 
-    user
+    runas
         The user name to run the command as
 
     shell
@@ -484,6 +484,16 @@ def wait(name,
         interactively to the console and the logs.
         This is experimental.
     '''
+    if 'user' in kwargs or 'group' in kwargs:
+        salt.utils.warn_until(
+            'Nitrogen',
+            'The legacy user/group arguments are deprecated. '
+            'Replace them with runas. '
+            'These arguments will be removed in Salt Nitrogen.'
+        )
+        if kwargs['user'] is not None and runas is None:
+            runas = kwargs.pop('user')
+
     # Ignoring our arguments is intentional.
     return {'name': name,
             'changes': {},
@@ -1038,7 +1048,7 @@ def script(name,
 
     run_check_cmd_kwargs = {
         'cwd': cwd,
-        'runas': user,
+        'runas': runas,
         'shell': shell or __grains__['shell']
     }
 

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -511,7 +511,7 @@ def wait_script(name,
                 onlyif=None,
                 unless=None,
                 cwd=None,
-                user=None,
+                runas=None,
                 shell=None,
                 env=None,
                 stateful=False,
@@ -550,7 +550,7 @@ def wait_script(name,
         The current working directory to execute the command in, defaults to
         /root
 
-    user
+    runas
         The user name to run the command as
 
     shell
@@ -615,6 +615,16 @@ def wait_script(name,
         regardless, unless ``quiet`` is used for this value.
 
     '''
+    if 'user' in kwargs or 'group' in kwargs:
+        salt.utils.warn_until(
+            'Nitrogen',
+            'The legacy user/group arguments are deprecated. '
+            'Replace them with runas. '
+            'These arguments will be removed in Salt Nitrogen.'
+        )
+        if kwargs['user'] is not None and runas is None:
+            runas = kwargs.pop('user')
+
     # Ignoring our arguments is intentional.
     return {'name': name,
             'changes': {},

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -617,7 +617,7 @@ def run(name,
         unless=None,
         creates=None,
         cwd=None,
-        user=None,
+        runas=None,
         shell=None,
         env=None,
         stateful=False,
@@ -648,7 +648,7 @@ def run(name,
         The current working directory to execute the command in, defaults to
         /root
 
-    user
+    runas
         The user name to run the command as
 
     shell
@@ -778,8 +778,18 @@ def run(name,
                           'documentation.')
         return ret
 
+    if 'user' in kwargs or 'group' in kwargs:
+        salt.utils.warn_until(
+            'Nitrogen',
+            'The legacy user/group arguments are deprecated. '
+            'Replace them with runas. '
+            'These arguments will be removed in Salt Nitrogen.'
+        )
+        if kwargs['user'] is not None and runas is None:
+            runas = kwargs.pop('user')
+
     cmd_kwargs = {'cwd': cwd,
-                  'runas': user,
+                  'runas': runas,
                   'use_vt': use_vt,
                   'shell': shell or __grains__['shell'],
                   'env': env,

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -1169,7 +1169,7 @@ def call(name,
                   'output_loglevel': output_loglevel,
                   'umask': kwargs.get('umask')}
 
-    cret = mod_run_check(cmd_kwargs, onlyif, unless, None, creates)
+    cret = mod_run_check(cmd_kwargs, onlyif, unless, creates)
     if isinstance(cret, dict):
         ret.update(cret)
         return ret

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -848,7 +848,7 @@ def script(name,
            unless=None,
            creates=None,
            cwd=None,
-           user=None,
+           runas=None,
            shell=None,
            env=None,
            stateful=False,
@@ -888,7 +888,7 @@ def script(name,
         The current working directory to execute the command in, defaults to
         /root
 
-    user
+    runas
         The name of the user to run the command as
 
     shell
@@ -1011,13 +1011,22 @@ def script(name,
     if context:
         tmpctx.update(context)
 
+    if 'user' in kwargs or 'group' in kwargs:
+        salt.utils.warn_until(
+            'Nitrogen',
+            'The legacy user/group arguments are deprecated. '
+            'Replace them with runas. '
+            'These arguments will be removed in Salt Nitrogen.'
+        )
+        if kwargs['user'] is not None and runas is None:
+            runas = kwargs.pop('user')
+
     cmd_kwargs = copy.deepcopy(kwargs)
-    cmd_kwargs.update({'runas': user,
+    cmd_kwargs.update({'runas': runas,
                        'shell': shell or __grains__['shell'],
                        'env': env,
                        'onlyif': onlyif,
                        'unless': unless,
-                       'user': user,
                        'cwd': cwd,
                        'template': template,
                        'umask': umask,

--- a/tests/unit/states/cmd_test.py
+++ b/tests/unit/states/cmd_test.py
@@ -40,52 +40,38 @@ class CmdTestCase(TestCase):
         Test to execute the onlyif and unless logic.
         '''
         cmd_kwargs = {}
-        group = 'saltgrp'
         creates = '/tmp'
-
-        ret = {'comment': 'The group saltgrp is not available', 'result': False}
-        self.assertDictEqual(cmd.mod_run_check(cmd_kwargs, '', '', group,
-                                               creates), ret)
 
         mock = MagicMock(return_value=1)
         with patch.dict(cmd.__salt__, {'cmd.retcode': mock}):
             with patch.dict(cmd.__opts__, {'test': True}):
                 ret = {'comment': 'onlyif execution failed', 'result': True,
                        'skip_watch': True}
-                self.assertDictEqual(cmd.mod_run_check(cmd_kwargs, '', '',
-                                                       False, creates), ret)
+                self.assertDictEqual(cmd.mod_run_check(cmd_kwargs, '', '', creates), ret)
 
-                self.assertDictEqual(cmd.mod_run_check(cmd_kwargs, [''], '',
-                                                       False, creates), ret)
+                self.assertDictEqual(cmd.mod_run_check(cmd_kwargs, [''], '', creates), ret)
 
-                self.assertDictEqual(cmd.mod_run_check(cmd_kwargs, {}, '',
-                                                       False, creates), ret)
+                self.assertDictEqual(cmd.mod_run_check(cmd_kwargs, {}, '', creates), ret)
 
         mock = MagicMock(return_value=0)
         with patch.dict(cmd.__salt__, {'cmd.retcode': mock}):
             ret = {'comment': 'unless execution succeeded', 'result': True,
                    'skip_watch': True}
-            self.assertDictEqual(cmd.mod_run_check(cmd_kwargs, None, '', False,
-                                                   creates), ret)
+            self.assertDictEqual(cmd.mod_run_check(cmd_kwargs, None, '', creates), ret)
 
-            self.assertDictEqual(cmd.mod_run_check(cmd_kwargs, None, [''],
-                                                   False, creates), ret)
+            self.assertDictEqual(cmd.mod_run_check(cmd_kwargs, None, [''], creates), ret)
 
-            self.assertDictEqual(cmd.mod_run_check(cmd_kwargs, None, True,
-                                                   False, creates), ret)
+            self.assertDictEqual(cmd.mod_run_check(cmd_kwargs, None, True, creates), ret)
 
         with patch.object(os.path, 'exists',
                           MagicMock(sid_effect=[True, True, False])):
             ret = {'comment': '/tmp exists', 'result': True}
-            self.assertDictEqual(cmd.mod_run_check(cmd_kwargs, None, None,
-                                                   False, creates), ret)
+            self.assertDictEqual(cmd.mod_run_check(cmd_kwargs, None, None, creates), ret)
 
             ret = {'comment': 'All files in creates exist', 'result': True}
-            self.assertDictEqual(cmd.mod_run_check(cmd_kwargs, None, None,
-                                                   False, [creates]), ret)
+            self.assertDictEqual(cmd.mod_run_check(cmd_kwargs, None, None, [creates]), ret)
 
-            self.assertTrue(cmd.mod_run_check(cmd_kwargs, None, None, False,
-                                              {}))
+            self.assertTrue(cmd.mod_run_check(cmd_kwargs, None, None, {}))
 
     # 'wait' function tests: 1
 


### PR DESCRIPTION
### What does this PR do?

Deprecate `user` and deprecate/remove `group` from state `cmd`
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/pull/32603
https://github.com/saltstack/salt/issues/32579

https://github.com/saltstack/salt/issues/5352

This is the 2016.3 version of the previous PR
