### PR TITLE
Fix ImportError when using virtualbox cloud driver

### DIFF
--- a/salt/utils/virtualbox.py
+++ b/salt/utils/virtualbox.py
@@ -14,7 +14,7 @@ import re
 
 import time
 
-from utils.timeout import wait_for
+from salt.utils.timeout import wait_for
 from salt.ext.six.moves import range
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
### What does this PR do?

When using the new `virtualbox` cloud driver, this PR avoids the warning that reads "The cloud driver, 'virtualbox', configured under the 'my-virtualbox' cloud provider alias, could not be loaded. Please check ..."

This warning makes it impossible to use the VirtualBox cloud driver. It is due to an ImportError in `salt/utils/virtualbox.py`, fixed by this PR.
### What issues does this PR fix or reference?

virtualbox provider was introduced with issue #27089
### Tests written?

No
