### PR TITLE
A configuration option to disable job returns

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -270,6 +270,14 @@
 # often lower this value
 #loop_interval: 60
 
+# Some installations choose to start all job returns in a cache or a returner
+# and forgo sending the results back to a master. In this workflow, jobs
+# are most often executed with --async from the Salt CLI and then results
+# are evaluated by examining job caches on the minions or any configured returners.
+# WARNING: Setting this to False will **disable** returns back to the master.
+#pub_ret: True
+
+
 # The grains can be merged, instead of overridden, using this option.
 # This allows custom grains to defined different subvalues of a dictionary
 # grain. By default this feature is disabled, to enable set grains_deep_merge

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -817,6 +817,10 @@ VALID_OPTS = {
 
     # Command to use to restart salt-minion
     'minion_restart_command': list,
+
+    # Whether or not a minion should send the results of a command back to the master
+    # Useful when a returner is the source of truth for a job result
+    'pub_ret': bool,
 }
 
 # default configurations
@@ -1041,6 +1045,7 @@ DEFAULT_MINION_OPTS = {
     'event_publisher_pub_hwm': 1000,
     'event_match_type': 'startswith',
     'minion_restart_command': [],
+    'pub_ret': True,
 }
 
 DEFAULT_MASTER_OPTS = {

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1557,6 +1557,9 @@ class Minion(MinionBase):
                 os.makedirs(jdir)
             salt.utils.fopen(fn_, 'w+b').write(self.serial.dumps(ret))
 
+        if not self.opts['pub_ret']:
+            return ''
+
         def timeout_handler(*_):
             msg = ('The minion failed to return the job information for job '
                    '{0}. This is often due to the master being shut down or '


### PR DESCRIPTION
In some cases, minions do not need to return a job for a master,
such as installations where jobs are run asynchronously and a 3rd-party
system evaluates a job cache to determine the results of a job.
