### PR TITLE
Remove trailing newline in ssh.user_keys()

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -1133,7 +1133,7 @@ def user_keys(user=None, pubfile=None, prvfile=None):
             if os.path.exists(fn_):
                 try:
                     with salt.utils.fopen(fn_, 'r') as _fh:
-                        keys[u][keyname] = ''.join(_fh.readlines())
+                        keys[u][keyname] = ''.join(_fh.readlines()).strip()
                 except (IOError, OSError):
                     pass
 


### PR DESCRIPTION
### What does this PR do?

Removes trailing newline from `user_keys()` function in `salt.modules.ssh.py`
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/32627
### Tests written?

No
