### PR TITLE
Add support for unicode in all GECOS fields

### DIFF
--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -23,7 +23,7 @@ import salt.utils
 import salt.utils.decorators as decorators
 from salt.ext import six
 from salt.exceptions import CommandExecutionError
-from salt.utils.locales import sdecode
+from salt.utils import locales
 
 log = logging.getLogger(__name__)
 
@@ -52,10 +52,10 @@ def _get_gecos(name):
         # Assign empty strings for any unspecified trailing GECOS fields
         while len(gecos_field) < 4:
             gecos_field.append('')
-        return {'fullname': sdecode(gecos_field[0]),
-                'roomnumber': sdecode(gecos_field[1]),
-                'workphone': sdecode(gecos_field[2]),
-                'homephone': sdecode(gecos_field[3])}
+        return {'fullname': locales.sdecode(gecos_field[0]),
+                'roomnumber': locales.sdecode(gecos_field[1]),
+                'workphone': locales.sdecode(gecos_field[2]),
+                'homephone': locales.sdecode(gecos_field[3])}
 
 
 def _build_gecos(gecos_dict):

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -23,6 +23,7 @@ import salt.utils
 import salt.utils.decorators as decorators
 from salt.ext import six
 from salt.exceptions import CommandExecutionError
+from salt.utils.locales import sdecode
 
 log = logging.getLogger(__name__)
 
@@ -51,10 +52,10 @@ def _get_gecos(name):
         # Assign empty strings for any unspecified trailing GECOS fields
         while len(gecos_field) < 4:
             gecos_field.append('')
-        return {'fullname': str(gecos_field[0]),
-                'roomnumber': str(gecos_field[1]),
-                'workphone': str(gecos_field[2]),
-                'homephone': str(gecos_field[3])}
+        return {'fullname': sdecode(gecos_field[0]),
+                'roomnumber': sdecode(gecos_field[1]),
+                'workphone': sdecode(gecos_field[2]),
+                'homephone': sdecode(gecos_field[3])}
 
 
 def _build_gecos(gecos_dict):
@@ -62,7 +63,7 @@ def _build_gecos(gecos_dict):
     Accepts a dictionary entry containing GECOS field names and their values,
     and returns a full GECOS comment string, to be used with usermod.
     '''
-    return '{0},{1},{2},{3}'.format(gecos_dict.get('fullname', ''),
+    return u'{0},{1},{2},{3}'.format(gecos_dict.get('fullname', ''),
                                     gecos_dict.get('roomnumber', ''),
                                     gecos_dict.get('workphone', ''),
                                     gecos_dict.get('homephone', ''))

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -31,7 +31,7 @@ import logging
 
 # Import salt libs
 import salt.utils
-from salt.utils.locales import sdecode
+from salt.utils.locales import sdecode, sdecode_if_string
 
 # Import 3rd-party libs
 from salt.ext.six import string_types, iteritems
@@ -149,10 +149,8 @@ def _changes(name,
             change['expire'] = expire
 
     # GECOS fields
-    if isinstance(fullname, string_types):
-        fullname = sdecode(fullname)
-    if isinstance(lusr['fullname'], string_types):
-        lusr['fullname'] = sdecode(lusr['fullname'])
+    fullname = sdecode_if_string(fullname)
+    lusr['fullname'] = sdecode_if_string(lusr['fullname'])
     if fullname is not None and lusr['fullname'] != fullname:
         change['fullname'] = fullname
     if win_homedrive and lusr['homedrive'] != win_homedrive:
@@ -167,17 +165,23 @@ def _changes(name,
     # MacOS doesn't have full GECOS support, so check for the "ch" functions
     # and ignore these parameters if these functions do not exist.
     if 'user.chroomnumber' in __salt__ \
-            and roomnumber is not None \
-            and lusr['roomnumber'] != roomnumber:
-        change['roomnumber'] = roomnumber
+            and roomnumber is not None:
+        roomnumber = sdecode_if_string(roomnumber)
+        lusr['roomnumber'] = sdecode_if_string(lusr['roomnumber'])
+        if lusr['roomnumber'] != roomnumber:
+            change['roomnumber'] = roomnumber
     if 'user.chworkphone' in __salt__ \
-            and workphone is not None \
-            and lusr['workphone'] != workphone:
-        change['workphone'] = workphone
+            and workphone is not None:
+        workphone = sdecode_if_string(workphone)
+        lusr['workphone'] = sdecode_if_string(lusr['workphone'])
+        if lusr['workphone'] != workphone:
+            change['workphone'] = workphone
     if 'user.chhomephone' in __salt__ \
-            and homephone is not None \
-            and lusr['homephone'] != homephone:
-        change['homephone'] = homephone
+            and homephone is not None:
+        homephone = sdecode_if_string(homephone)
+        lusr['homephone'] = sdecode_if_string(lusr['homephone'])
+        if lusr['homephone'] != homephone:
+            change['homephone'] = homephone
     # OpenBSD/FreeBSD login class
     if __grains__['kernel'] in ('OpenBSD', 'FreeBSD'):
         if loginclass:
@@ -460,7 +464,7 @@ def present(name,
             for key, val in iteritems(changes):
                 if key == 'password':
                     val = 'XXX-REDACTED-XXX'
-                ret['comment'] += '{0}: {1}\n'.format(key, val)
+                ret['comment'] += u'{0}: {1}\n'.format(key, val)
             return ret
         # The user is present
         if 'shadow.info' in __salt__:

--- a/salt/utils/locales.py
+++ b/salt/utils/locales.py
@@ -11,6 +11,7 @@ import salt.utils
 from salt.utils.decorators import memoize as real_memoize
 from salt.ext.six import string_types
 
+
 @real_memoize
 def get_encodings():
     '''
@@ -49,6 +50,7 @@ def sdecode(string_):
             continue
     return string_
 
+
 def sdecode_if_string(value_):
     '''
     If the value is a string, run sdecode() on it to ensure it is parsed
@@ -57,6 +59,7 @@ def sdecode_if_string(value_):
     if isinstance(value_, string_types):
         value_ = sdecode(value_)
     return value_
+
 
 def split_locale(loc):
     '''

--- a/salt/utils/locales.py
+++ b/salt/utils/locales.py
@@ -9,7 +9,7 @@ import sys
 
 import salt.utils
 from salt.utils.decorators import memoize as real_memoize
-
+from salt.ext.six import string_types
 
 @real_memoize
 def get_encodings():
@@ -49,6 +49,14 @@ def sdecode(string_):
             continue
     return string_
 
+def sdecode_if_string(value_):
+    '''
+    If the value is a string, run sdecode() on it to ensure it is parsed
+    properly. If it is not a string, return it as-is
+    '''
+    if isinstance(value_, string_types):
+        value_ = sdecode(value_)
+    return value_
 
 def split_locale(loc):
     '''

--- a/tests/integration/states/user.py
+++ b/tests/integration/states/user.py
@@ -170,7 +170,7 @@ class UserTest(integration.ModuleCase,
             workphone=u'١٢٣٤', homephone=u'६७८'
         )
         self.assertSaltTrueReturn(ret)
-        # Ensure updates also work
+        # Ensure updating a user also works
         ret = self.run_state(
             'user.present', name='salt_test', fullname=u'Sølt Test', roomnumber=u'①③②',
             workphone=u'٣٤١٢', homephone=u'६८७'

--- a/tests/integration/states/user.py
+++ b/tests/integration/states/user.py
@@ -170,7 +170,7 @@ class UserTest(integration.ModuleCase,
             workphone=u'١٢٣٤', homephone=u'६७८'
         )
         self.assertSaltTrueReturn(ret)
-	# Ensure updates also work
+        # Ensure updates also work
         ret = self.run_state(
             'user.present', name='salt_test', fullname=u'Sølt Test', roomnumber=u'①③②',
             workphone=u'٣٤١٢', homephone=u'६८७'

--- a/tests/integration/states/user.py
+++ b/tests/integration/states/user.py
@@ -158,6 +158,29 @@ class UserTest(integration.ModuleCase,
 
     @destructiveTest
     @skipIf(os.geteuid() != 0, 'you must be root to run this test')
+    def test_user_present_unicode(self):
+        '''
+        This is a DESTRUCTIVE TEST it creates a new user on the on the minion.
+
+        It ensures that unicode GECOS data will be properly handled, without
+        any encoding-related failures.
+        '''
+        ret = self.run_state(
+            'user.present', name='salt_test', fullname=u'Sålt Test', roomnumber=u'①②③',
+            workphone=u'١٢٣٤', homephone=u'६७८'
+        )
+        self.assertSaltTrueReturn(ret)
+	# Ensure updates also work
+        ret = self.run_state(
+            'user.present', name='salt_test', fullname=u'Sølt Test', roomnumber=u'①③②',
+            workphone=u'٣٤١٢', homephone=u'६८७'
+        )
+        self.assertSaltTrueReturn(ret)
+        ret = self.run_state('user.absent', name='salt_test')
+        self.assertSaltTrueReturn(ret)
+
+    @destructiveTest
+    @skipIf(os.geteuid() != 0, 'you must be root to run this test')
     def test_user_present_gecos(self):
         '''
         This is a DESTRUCTIVE TEST it creates a new user on the on the minion.


### PR DESCRIPTION
### What does this PR do?

Makes the GECOS fields in user.present support Unicode
### What issues does this PR fix or reference?

Fixes #26901 - UnicodeError when user.present fullname contains unicode
### Previous Behavior

When using user.present with a fullname containing a non-ASCII character, the state would fail:

```
          ID: johndoe
    Function: user.present
        Name: johndoe
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1626, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1492, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/states/user.py", line 451, in present
                  ret['comment'] += '{0}: {1}\n'.format(key, val)
              UnicodeEncodeError: 'ascii' codec can't encode character u'\xe5' in position 2: ordinal not in range(128)
     Started: 04:46:53.050846
    Duration: 4.25 ms
     Changes:
```
### New Behavior

user.present now supports Unicode in all fields of the GECOS.
### Tests written?

Yes
