### PR TITLE
Prevent traceback when deprecation warnings reference Oxygen

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -85,8 +85,8 @@ class SaltStackVersion(object):
         'Boron'         : (2016, 3),
         'Carbon'        : (MAX_SIZE - 103, 0),
         'Nitrogen'      : (MAX_SIZE - 102, 0),
+        'Oxygen'        : (MAX_SIZE - 101, 0),
         # pylint: disable=E8265
-        #'Oxygen'       : (MAX_SIZE - 101, 0),
         #'Fluorine'     : (MAX_SIZE - 100, 0),
         #'Neon'         : (MAX_SIZE - 99 , 0),
         #'Sodium'       : (MAX_SIZE - 98 , 0),


### PR DESCRIPTION
If a warn_until references Oxygen, a traceback will result since this
was still commented out in version.py. With a recent PR being merged we
now have deprecation warnings referencing this version, so this version
must be uncommented in version.py.
