### PR TITLE
Specify a different Dockerfile when building an image

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -3397,7 +3397,8 @@ def build(path=None,
           cache=True,
           rm=True,
           api_response=False,
-          fileobj=None):
+          fileobj=None,
+          dockerfile=None):
     '''
     Builds a docker image from a Dockerfile or a URL
 
@@ -3425,6 +3426,11 @@ def build(path=None,
         to be passed in place of a file ``path`` argument. This argument should
         not be used from the CLI, only from other Salt code.
 
+    dockerfile
+        Allows for an alternative Dockerfile to be specified.  Path to alternative
+        Dockefile is relative to the build path for the Docker container.
+
+        .. versionadded:: develop
 
     **RETURN DATA**
 
@@ -3456,6 +3462,10 @@ def build(path=None,
 
         salt myminion dockerng.build /path/to/docker/build/dir image=myimage:dev
         salt myminion dockerng.build https://github.com/myuser/myrepo.git image=myimage:latest
+
+        .. versionadded:: develop
+
+        salt myminion dockerng.build /path/to/docker/build/dir dockerfile=Dockefile.different image=myimage:dev
     '''
     _prep_pull()
 
@@ -3467,7 +3477,8 @@ def build(path=None,
                                quiet=False,
                                fileobj=fileobj,
                                rm=rm,
-                               nocache=not cache)
+                               nocache=not cache,
+                               dockerfile=dockerfile)
     ret = {'Time_Elapsed': time.time() - time_started}
     _clear_context()
 

--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -482,7 +482,8 @@ def image_present(name,
                   load=None,
                   force=False,
                   insecure_registry=False,
-                  client_timeout=CLIENT_TIMEOUT):
+                  client_timeout=CLIENT_TIMEOUT,
+                  dockerfile=None):
     '''
     Ensure that an image is present. The image can either be pulled from a
     Docker registry, built from a Dockerfile, or loaded from a saved image.
@@ -509,6 +510,14 @@ def image_present(name,
               dockerng.image_present:
                 - build: /home/myuser/docker/myimage
 
+
+            myuser/myimage:mytag:
+              dockerng.image_present:
+                - build: /home/myuser/docker/myimage
+                - dockerfile: Dockerfile.alternative
+
+            .. versionadded:: develop
+
         The image will be built using :py:func:`dockerng.build
         <salt.modules.dockerng.build>` and the specified image name and tag
         will be applied to it.
@@ -531,6 +540,12 @@ def image_present(name,
     client_timeout
         Timeout in seconds for the Docker client. This is not a timeout for
         the state, but for receiving a response from the API.
+
+    dockerfile
+        Allows for an alternative Dockerfile to be specified.  Path to alternative
+        Dockefile is relative to the build path for the Docker container.
+
+        .. versionadded:: develop
     '''
     ret = {'name': name,
            'changes': {},
@@ -575,7 +590,9 @@ def image_present(name,
 
     if build:
         try:
-            image_update = __salt__['dockerng.build'](path=build, image=image)
+            image_update = __salt__['dockerng.build'](path=build,
+                                                      image=image,
+                                                      dockerfile=dockerfile)
         except Exception as exc:
             ret['comment'] = (
                 'Encountered error building {0} as {1}: {2}'


### PR DESCRIPTION
### What does this PR do?

Adding the ability to the dockerng module and state module to specify an alternative Dockerfile
### What issues does this PR fix or reference?
#32426
### Previous Behavior

dockerng modules would use the default "Dockerfile" when building an image.
### New Behavior

An additional argument for the module and state module allow overriding the filename that Docker will look for when building an image.
### Tests written?

No
