### PR TITLE
align OS grains from older SLES with current one

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1182,14 +1182,19 @@ def os_data():
                         for line in fhr:
                             if 'enterprise' in line.lower():
                                 grains['lsb_distrib_id'] = 'SLES'
+                                grains['lsb_distrib_codename'] = re.sub(r'\(.+\)', '', line).strip()
                             elif 'version' in line.lower():
                                 version = re.sub(r'[^0-9]', '', line)
                             elif 'patchlevel' in line.lower():
                                 patch = re.sub(r'[^0-9]', '', line)
                     grains['lsb_distrib_release'] = version
                     if patch:
-                        grains['lsb_distrib_release'] += ' SP' + patch
-                    grains['lsb_distrib_codename'] = 'n.a'
+                        grains['lsb_distrib_release'] += '.' + patch
+                        patchstr = 'SP' + patch
+                        if grains['lsb_distrib_codename'] and patchstr not in grains['lsb_distrib_codename']:
+                            grains['lsb_distrib_codename'] += ' ' + patchstr
+                    if not grains['lsb_distrib_codename']:
+                        grains['lsb_distrib_codename'] = 'n.a'
                 elif os.path.isfile('/etc/altlinux-release'):
                     # ALT Linux
                     grains['lsb_distrib_id'] = 'altlinux'


### PR DESCRIPTION
### What does this PR do?

Align os grains for older SLES versions to the format the new SLES versions has.
### What issues does this PR fix or reference?

Try to unify the os grains between SLE11 and SLE12 independent of existing os-release file:

This commit change SLES11 SP3 in the following way:

oscodename: n.a => SUSE Linux Enterprise Server 11 SP3
osrelease:   "11 SP3" => 11.3
osrelease_info: ["11 SP3"] => [11, 3]

Even older should follow the same rules and eval to SP2, 11.2, [11,2], SP1, 11.1, [11,1], ...
### Tests written?

No

@isbm - maybe you want to have a look too.
