### PR TITLE
Append failed cmd in comments.

### DIFF
--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -327,11 +327,11 @@ def mod_run_check(cmd_kwargs, onlyif, unless, creates):
         elif isinstance(onlyif, list):
             for entry in onlyif:
                 cmd = __salt__['cmd.retcode'](entry, ignore_retcode=True, python_shell=True, **cmd_kwargs)
-                log.debug('Last command return code: {0}'.format(cmd))
+                log.debug('Last command \'{0}\' return code: {1}'.format(entry, cmd))
                 if cmd != 0:
-                    return {'comment': 'onlyif execution failed',
-                        'skip_watch': True,
-                        'result': True}
+                    return {'comment': 'onlyif execution failed: {0}'.format(entry),
+                            'skip_watch': True,
+                            'result': True}
         elif not isinstance(onlyif, string_types):
             if not onlyif:
                 log.debug('Command not run: onlyif did not evaluate to string_type')

--- a/tests/unit/states/cmd_test.py
+++ b/tests/unit/states/cmd_test.py
@@ -49,9 +49,14 @@ class CmdTestCase(TestCase):
                        'skip_watch': True}
                 self.assertDictEqual(cmd.mod_run_check(cmd_kwargs, '', '', creates), ret)
 
-                self.assertDictEqual(cmd.mod_run_check(cmd_kwargs, [''], '', creates), ret)
-
                 self.assertDictEqual(cmd.mod_run_check(cmd_kwargs, {}, '', creates), ret)
+
+        mock = MagicMock(return_value=1)
+        with patch.dict(cmd.__salt__, {'cmd.retcode': mock}):
+            with patch.dict(cmd.__opts__, {'test': True}):
+                ret = {'comment': 'onlyif execution failed: ', 'result': True,
+                       'skip_watch': True}
+                self.assertDictEqual(cmd.mod_run_check(cmd_kwargs, [''], '', creates), ret)
 
         mock = MagicMock(return_value=0)
         with patch.dict(cmd.__salt__, {'cmd.retcode': mock}):


### PR DESCRIPTION
### What does this PR do?

When onlyif fail, append the command to comment so we know which command
is failing.
### What issues does this PR fix or reference?

Fixes #32575.
### Previous Behavior

``` yml
ubuntu:
----------
          ID: test5
    Function: cmd.run
        Name: echo 'Test 5 - Should fail onlyif test'
      Result: True
     Comment: onlyif execution failed
     Started: 12:06:21.343446
    Duration: 10.044 ms
     Changes:

Summary for ubuntu
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1
```
### New Behavior

``` yml
ubuntu:
----------
          ID: test5
    Function: cmd.run
        Name: echo 'Test 5 - Should fail onlyif test'
      Result: True
     Comment: onlyif execution failed: test -d /foooooo
     Started: 12:24:09.944105
    Duration: 8.323 ms
     Changes:

Summary for ubuntu
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1
```
### Tests written?

No
