### PR TITLE
Prevent crash if pygit2 package is requesting re-compilation of the e…

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -80,9 +80,11 @@ try:
         GitError = pygit2.errors.GitError
     except AttributeError:
         GitError = Exception
-except ImportError:
-    HAS_PYGIT2 = False
-
+except Exception:       # cffi VerificationError also may happen
+    HAS_PYGIT2 = False  # and pygit2 requrests re-compilation
+                        # on a production system (!),
+                        # but cffi might be absent as well!
+                        # Therefore just a generic Exception class.
 try:
     import dulwich.errors
     import dulwich.repo

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -19,6 +19,18 @@ import subprocess
 import time
 from datetime import datetime
 
+# Import salt libs
+import salt.utils
+import salt.utils.itertools
+import salt.utils.url
+import salt.fileserver
+from salt.utils.process import os_is_running as pid_exists
+from salt.exceptions import FileserverConfigError, GitLockError
+from salt.utils.event import tagify
+
+# Import third party libs
+import salt.ext.six as six
+
 VALID_PROVIDERS = ('gitpython', 'pygit2', 'dulwich')
 # Optional per-remote params that can only be used on a per-remote basis, and
 # thus do not have defaults in salt/config.py.
@@ -54,17 +66,7 @@ _INVALID_REPO = (
     'master to continue to use this {2} remote.'
 )
 
-# Import salt libs
-import salt.utils
-import salt.utils.itertools
-import salt.utils.url
-import salt.fileserver
-from salt.utils.process import os_is_running as pid_exists
-from salt.exceptions import FileserverConfigError, GitLockError
-from salt.utils.event import tagify
 
-# Import third party libs
-import salt.ext.six as six
 # pylint: disable=import-error
 try:
     import git

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -66,6 +66,7 @@ _INVALID_REPO = (
     'master to continue to use this {2} remote.'
 )
 
+log = logging.getLogger(__name__)
 
 # pylint: disable=import-error
 try:
@@ -97,8 +98,6 @@ try:
 except ImportError:
     HAS_DULWICH = False
 # pylint: enable=import-error
-
-log = logging.getLogger(__name__)
 
 # Minimum versions for backend providers
 GITPYTHON_MINVER = '0.3'

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -83,11 +83,14 @@ try:
         GitError = pygit2.errors.GitError
     except AttributeError:
         GitError = Exception
-except Exception:       # cffi VerificationError also may happen
-    HAS_PYGIT2 = False  # and pygit2 requrests re-compilation
-                        # on a production system (!),
-                        # but cffi might be absent as well!
-                        # Therefore just a generic Exception class.
+except Exception as err:  # cffi VerificationError also may happen
+    HAS_PYGIT2 = False    # and pygit2 requrests re-compilation
+                          # on a production system (!),
+                          # but cffi might be absent as well!
+                          # Therefore just a generic Exception class.
+    if not isinstance(err, ImportError):
+        log.error('Import pygit2 failed: {0}'.format(err))
+
 try:
     import dulwich.errors
     import dulwich.repo


### PR DESCRIPTION
### What does this PR do?

Bugfix.
### What issues does this PR fix or reference?
### Previous Behavior

```
bash-4.2# salt-master
usr/lib64/python2.7/site-packages/pygit2/__pycache__/_cffi__x50f7320ax7286955d.c:2:20: fatal error: Python.h: No such file or directory
 #include <Python.h>
                    ^
compilation terminated.
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
VerificationError: CompileError: command 'gcc' failed with exit status 1
Traceback (most recent call last):
  File "/usr/bin/salt-master", line 22, in <module>
    salt_master()
  File "/usr/lib/python2.7/site-packages/salt/scripts.py", line 47, in salt_master
    master.start()
  File "/usr/lib/python2.7/site-packages/salt/cli/daemons.py", line 196, in start
    self.prepare()
  File "/usr/lib/python2.7/site-packages/salt/cli/daemons.py", line 176, in prepare
    import salt.master
  File "/usr/lib/python2.7/site-packages/salt/master.py", line 46, in <module>
    import salt.key
  File "/usr/lib/python2.7/site-packages/salt/key.py", line 23, in <module>
    import salt.daemons.masterapi
  File "/usr/lib/python2.7/site-packages/salt/daemons/masterapi.py", line 37, in <module>
    from salt.pillar import git_pillar
  File "/usr/lib/python2.7/site-packages/salt/pillar/git_pillar.py", line 188, in <module>
    import salt.utils.gitfs
  File "/usr/lib/python2.7/site-packages/salt/utils/gitfs.py", line 77, in <module>
    import pygit2
  File "/usr/lib64/python2.7/site-packages/pygit2/__init__.py", line 35, in <module>
    from .blame import Blame, BlameHunk
  File "/usr/lib64/python2.7/site-packages/pygit2/blame.py", line 32, in <module>
    from .errors import check_error
  File "/usr/lib64/python2.7/site-packages/pygit2/errors.py", line 29, in <module>
    from .ffi import ffi, C
  File "/usr/lib64/python2.7/site-packages/pygit2/ffi.py", line 36, in <module>
    C = ffi.verify(preamble, **C_KEYWORDS)
  File "/usr/lib64/python2.7/site-packages/cffi/api.py", line 373, in verify
    lib = self.verifier.load_library()
  File "/usr/lib64/python2.7/site-packages/cffi/verifier.py", line 96, in load_library
    self._compile_module()
  File "/usr/lib64/python2.7/site-packages/cffi/verifier.py", line 192, in _compile_module
    outputfilename = ffiplatform.compile(tmpdir, self.get_extension())
  File "/usr/lib64/python2.7/site-packages/cffi/ffiplatform.py", line 38, in compile
    outputfilename = _build(tmpdir, ext)
  File "/usr/lib64/python2.7/site-packages/cffi/ffiplatform.py", line 65, in _build
    raise VerificationError('%s: %s' % (e.__class__.__name__, e))
VerificationError: CompileError: command 'gcc' failed with exit status 1
Traceback (most recent call last):
  File "/usr/bin/salt-master", line 22, in <module>
    salt_master()
  File "/usr/lib/python2.7/site-packages/salt/scripts.py", line 47, in salt_master
    master.start()
  File "/usr/lib/python2.7/site-packages/salt/cli/daemons.py", line 196, in start
    self.prepare()
  File "/usr/lib/python2.7/site-packages/salt/cli/daemons.py", line 176, in prepare
    import salt.master
  File "/usr/lib/python2.7/site-packages/salt/master.py", line 46, in <module>
    import salt.key
  File "/usr/lib/python2.7/site-packages/salt/key.py", line 23, in <module>
    import salt.daemons.masterapi
  File "/usr/lib/python2.7/site-packages/salt/daemons/masterapi.py", line 37, in <module>
    from salt.pillar import git_pillar
  File "/usr/lib/python2.7/site-packages/salt/pillar/git_pillar.py", line 188, in <module>
    import salt.utils.gitfs
  File "/usr/lib/python2.7/site-packages/salt/utils/gitfs.py", line 77, in <module>
    import pygit2
  File "/usr/lib64/python2.7/site-packages/pygit2/__init__.py", line 35, in <module>
    from .blame import Blame, BlameHunk
  File "/usr/lib64/python2.7/site-packages/pygit2/blame.py", line 32, in <module>
    from .errors import check_error
  File "/usr/lib64/python2.7/site-packages/pygit2/errors.py", line 29, in <module>
    from .ffi import ffi, C
  File "/usr/lib64/python2.7/site-packages/pygit2/ffi.py", line 36, in <module>
    C = ffi.verify(preamble, **C_KEYWORDS)
  File "/usr/lib64/python2.7/site-packages/cffi/api.py", line 373, in verify
    lib = self.verifier.load_library()
  File "/usr/lib64/python2.7/site-packages/cffi/verifier.py", line 96, in load_library
    self._compile_module()
  File "/usr/lib64/python2.7/site-packages/cffi/verifier.py", line 192, in _compile_module
    outputfilename = ffiplatform.compile(tmpdir, self.get_extension())
  File "/usr/lib64/python2.7/site-packages/cffi/ffiplatform.py", line 38, in compile
    outputfilename = _build(tmpdir, ext)
  File "/usr/lib64/python2.7/site-packages/cffi/ffiplatform.py", line 65, in _build
    raise VerificationError('%s: %s' % (e.__class__.__name__, e))
cffi.ffiplatform.VerificationError: CompileError: command 'gcc' failed with exit status 1
```

And then a complete Salt Master or Salt Minion stop (crash).
### New Behavior

```
# salt-master
usr/lib64/python2.7/site-packages/pygit2/__pycache__/_cffi__x50f7320ax7286955d.c:2:20: fatal error: Python.h: No such file or directory
 #include <Python.h>
                    ^
compilation terminated.
[ERROR   ] Import pygit2 failed: CompileError: command 'gcc' failed with exit status 1
```

Still throws an error to the STDERR (pygit2 part), but at least no crash and an error log message is put in case of Exception had happened for other than `ImportError` reasons.
### Tests written?

No
