### PR TITLE
tune_in: do not fire master event in standalone minion mode

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1999,7 +1999,7 @@ class Minion(MinionBase):
         self.periodic_callbacks = {}
         # schedule the stuff that runs every interval
         ping_interval = self.opts.get('ping_interval', 0) * 60
-        if ping_interval > 0:
+        if ping_interval > 0 and self.connected:
             def ping_master():
                 try:
                     if not self._fire_master('ping', 'minion_ping'):
@@ -2022,7 +2022,7 @@ class Minion(MinionBase):
                 beacons = self.process_beacons(self.functions)
             except Exception:
                 log.critical('The beacon errored: ', exc_info=True)
-            if beacons:
+            if beacons and self.connected:
                 self._fire_master(events=beacons)
 
         self.periodic_callbacks['beacons'] = tornado.ioloop.PeriodicCallback(handle_beacons, loop_interval * 1000, io_loop=self.io_loop)


### PR DESCRIPTION
### What does this PR do?

Fixes errors when the minion is configured in standalone mode and beacons are configured or ping_interval is configured.

There is still work to be done to get the standalone minion working in all cases. I already identify 2 areas that need to be modified:
- handle_events: some events are OK to process (a beacon or engine can trigger them), such as grains_refresh. Others, are not, such as pillar_refresh. Need to add warnings strings, etc to this functions.
- startup_states: highstate and top_file should not be OK for the standalone minion, but sls_list should be OK, need to test all cases.

I am planning on working on this soon to bring the feature to production quality. The work is likely going to be spread through a few commits.
### What issues does this PR fix or reference?
### Previous Behavior

Remove this section if not relevant
### New Behavior

Remove this section if not relevant
### Tests written?

Yes/No

Signed-off-by: Alejandro del Castillo alejandro.delcastillo@ni.com
