### PR TITLE
Update the minion.rst file with the new pub_ret option

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -265,10 +265,9 @@
 #
 #
 # The loop_interval sets how long in seconds the minion will wait between
-# evaluating the scheduler and running cleanup tasks. This defaults to a
-# sane 60 seconds, but if the minion scheduler needs to be evaluated more
-# often lower this value
-#loop_interval: 60
+# evaluating the scheduler and running cleanup tasks.  This defaults to 1
+# second on the minion scheduler.
+#loop_interval: 1
 
 # Some installations choose to start all job returns in a cache or a returner
 # and forgo sending the results back to a master. In this workflow, jobs

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -590,6 +590,39 @@ behavior is to have time-frame within all minions try to reconnect.
 
     recon_randomize: True
 
+.. conf_minion:: loop_interval
+
+``loop_interval``
+-----------------
+
+Default: ``1``
+
+The loop_interval sets how long in seconds the minion will wait between
+evaluating the scheduler and running cleanup tasks. This defaults to 1
+second on the minion scheduler.
+
+.. code-block:: yaml
+
+    loop_interval: 1
+
+
+.. conf_minion:: pub_ret
+
+``pub_ret``
+-----------
+
+Default: True
+
+Some installations choose to start all job returns in a cache or a returner
+and forgo sending the results back to a master. In this workflow, jobs
+are most often executed with --async from the Salt CLI and then results
+are evaluated by examining job caches on the minions or any configured returners.
+WARNING: Setting this to False will **disable** returns back to the master.
+
+.. code-block:: yaml
+
+    pub_ret: True
+
 .. conf_minion:: return_retry_timer
 
 ``return_retry_timer``


### PR DESCRIPTION
### What does this PR do?

Adds the pub_ret description to the minion.rst configuration 
documentation.

Also added the loop_interval docs to minion.rst and corrected
the default documented (this value is 1 second for the minion
schedule maintenance process, not 60 seconds - the master is 60).
### What issues does this PR fix or reference?

Refs #32623
