### PR TITLE
Fix for issue 32523

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -538,12 +538,12 @@ def grains(opts, force_refresh=False):
         print __grains__['id']
     '''
     # if we hae no grains, lets try loading from disk (TODO: move to decorator?)
+    cfn = os.path.join(
+        opts['cachedir'],
+        'grains.cache.p'
+    )
     if not force_refresh:
         if opts.get('grains_cache', False):
-            cfn = os.path.join(
-                opts['cachedir'],
-                'grains.cache.p'
-            )
             if os.path.isfile(cfn):
                 grains_cache_age = int(time.time() - os.path.getmtime(cfn))
                 if opts.get('grains_cache_expiration', 300) >= grains_cache_age and not \


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where cfn isn't defined.

```
      ID: dummy0
Function: network.managed
  Result: False
 Comment: An exception occurred in this state: Traceback (most recent call last):
            File "/usr/lib/python2.7/site-packages/salt/state.py", line 1624, in call
              **cdata['kwargs'])
            File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1491, in wrapper
              return f(*args, **kwargs)
            File "/usr/lib/python2.7/site-packages/salt/states/network.py", line 413, in managed
              grains_info = salt.loader.grains(__opts__, True)
            File "/usr/lib/python2.7/site-packages/salt/loader.py", line 656, in grains
              with salt.utils.fopen(cfn, 'w+b') as fp_:
          UnboundLocalError: local variable 'cfn' referenced before assignment
 Started: 19:21:47.301853
Duration: 2632.383 ms
 Changes:   
```
### What issues does this PR fix or reference?
#32523
### Previous Behavior

```
      ID: dummy0
Function: network.managed
  Result: False
 Comment: An exception occurred in this state: Traceback (most recent call last):
            File "/usr/lib/python2.7/site-packages/salt/state.py", line 1624, in call
              **cdata['kwargs'])
            File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1491, in wrapper
              return f(*args, **kwargs)
            File "/usr/lib/python2.7/site-packages/salt/states/network.py", line 413, in managed
              grains_info = salt.loader.grains(__opts__, True)
            File "/usr/lib/python2.7/site-packages/salt/loader.py", line 656, in grains
              with salt.utils.fopen(cfn, 'w+b') as fp_:
          UnboundLocalError: local variable 'cfn' referenced before assignment
 Started: 19:21:47.301853
Duration: 2632.383 ms
 Changes:   
```
### New Behavior

Works without throwing an exception.
### Tests written?

No
