### PR TITLE
Compare uid and gid instead of name and group

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3656,13 +3656,23 @@ def check_perms(name, ret, user, group, mode, follow_symlinks=False):
     if user:
         if isinstance(user, int):
             user = uid_to_user(user)
-        if user_to_uid(user) != user_to_uid(perms['luser']):
+        if (salt.utils.is_windows() and
+                user_to_uid(user) != user_to_uid(perms['luser'])
+            ) or (
+            not salt.utils.is_windows() and user != perms['luser']
+        ):
             perms['cuser'] = user
+
     if group:
         if isinstance(group, int):
             group = gid_to_group(group)
-        if group_to_gid(group) != group_to_gid(perms['lgroup']):
+        if (salt.utils.is_windows() and
+                group_to_gid(group) != group_to_gid(perms['lgroup'])
+            ) or (
+                not salt.utils.is_windows() and group != perms['lgroup']
+        ):
             perms['cgroup'] = group
+
     if 'cuser' in perms or 'cgroup' in perms:
         if not __opts__['test']:
             if os.path.islink(name) and not follow_symlinks:
@@ -3681,23 +3691,34 @@ def check_perms(name, ret, user, group, mode, follow_symlinks=False):
     if user:
         if isinstance(user, int):
             user = uid_to_user(user)
-        if user_to_uid(user) != user_to_uid(
-                get_user(name, follow_symlinks=follow_symlinks)) and \
-                user != '':
+        if (salt.utils.is_windows() and
+                user_to_uid(user) != user_to_uid(
+                    get_user(name, follow_symlinks=follow_symlinks)) and
+                user != ''
+            ) or (
+            not salt.utils.is_windows() and
+                user != get_user(name, follow_symlinks=follow_symlinks) and
+                user != ''
+        ):
             if __opts__['test'] is True:
                 ret['changes']['user'] = user
             else:
                 ret['result'] = False
                 ret['comment'].append('Failed to change user to {0}'
-                                      .format(user))
+                                          .format(user))
         elif 'cuser' in perms and user != '':
             ret['changes']['user'] = user
     if group:
         if isinstance(group, int):
             group = gid_to_group(group)
-        if group_to_gid(group) != group_to_gid(
-                get_group(name, follow_symlinks=follow_symlinks)) and \
-                user != '':
+        if (salt.utils.is_windows() and
+                group_to_gid(group) != group_to_gid(
+                    get_group(name, follow_symlinks=follow_symlinks)) and
+                user != '') or (
+            not salt.utils.is_windows() and
+                group != get_group(name, follow_symlinks=follow_symlinks) and
+                user != ''
+        ):
             if __opts__['test'] is True:
                 ret['changes']['group'] = group
             else:

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3656,12 +3656,12 @@ def check_perms(name, ret, user, group, mode, follow_symlinks=False):
     if user:
         if isinstance(user, int):
             user = uid_to_user(user)
-        if user != perms['luser']:
+        if user_to_uid(user) != user_to_uid(perms['luser']):
             perms['cuser'] = user
     if group:
         if isinstance(group, int):
             group = gid_to_group(group)
-        if group != perms['lgroup']:
+        if group_to_gid(group) != group_to_gid(perms['lgroup']):
             perms['cgroup'] = group
     if 'cuser' in perms or 'cgroup' in perms:
         if not __opts__['test']:
@@ -3681,7 +3681,9 @@ def check_perms(name, ret, user, group, mode, follow_symlinks=False):
     if user:
         if isinstance(user, int):
             user = uid_to_user(user)
-        if user != get_user(name, follow_symlinks=follow_symlinks) and user != '':
+        if user_to_uid(user) != user_to_uid(
+                get_user(name, follow_symlinks=follow_symlinks)) and \
+                user != '':
             if __opts__['test'] is True:
                 ret['changes']['user'] = user
             else:
@@ -3693,7 +3695,9 @@ def check_perms(name, ret, user, group, mode, follow_symlinks=False):
     if group:
         if isinstance(group, int):
             group = gid_to_group(group)
-        if group != get_group(name, follow_symlinks=follow_symlinks) and user != '':
+        if group_to_gid(group) != group_to_gid(
+                get_group(name, follow_symlinks=follow_symlinks)) and \
+                user != '':
             if __opts__['test'] is True:
                 ret['changes']['group'] = group
             else:


### PR DESCRIPTION
### What does this PR do?

Compares UID and GID instead of names to account for differences in capitalization
### What issues does this PR fix or reference?
#11801
### Previous Behavior

`file.managed` would return failure because it couldn't match 'Administrator' with 'administrator' due to differences in capitalization. Owner would change, but it would report failure.
### New Behavior

Now it compares the uid and gid instead of user and group names.
### Tests written?

No
