### PR TITLE
[2015.5] Update "Low Hanging Fruit" to "Help Wanted"

### DIFF
--- a/doc/topics/development/labels.rst
+++ b/doc/topics/development/labels.rst
@@ -273,9 +273,9 @@ with labels.
 ``Awesome``
     The pull request implements an especially well crafted solution, or a very difficult but necessary change.
 
-``Low Hanging Fruit``
-    The issue is trivial or almost trivial to implement or fix.  Issues having this label should be a good starting
-    place for new contributors to Salt.
+``Help Wanted``
+    The issue appears to have a simple solution.  Issues having this label
+    should be a good starting place for new contributors to Salt.
 
 ``Needs Testcase``
     The issue or pull request relates to a feature that needs test coverage.  The pull request containing the tests


### PR DESCRIPTION
### What does this PR do?

Updates the "Low Hanging Fruit" label to "Help Wanted", to match the actual labels on the repo. Also rewords that label explanation a little.
