### PR TITLE
modification to `config.option()` and `config.merge()` to support

### DIFF
--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -23,6 +23,7 @@ except ImportError:
 import salt._compat
 import salt.syspaths as syspaths
 import salt.utils.sdb as sdb
+from salt.utils import traverse_dict
 
 # Import 3rd-party libs
 import salt.ext.six as six
@@ -136,23 +137,43 @@ def option(
     '''
     Pass in a generic option and receive the value that will be assigned
 
+    .. note::
+
+        for .merge() and .option(), pillar paths are expressed using `.` rather
+        than the more typical `:`.
+
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' config.option redis.host
+
     '''
+
+    log.debug('CONFIG.OPTION: %s', value)
     if not omit_opts:
-        if value in __opts__:
-            return __opts__[value]
+        retval = traverse_dict(__opts__, value, None, delimiter='.')
+        if retval:
+            log.debug('CONFIG.OPTION (opts): %s', str(retval))
+            return retval
     if not omit_master:
-        if value in __pillar__.get('master', {}):
-            return __pillar__['master'][value]
+        master_pillar = __pillar__.get('master', {})
+        retval = traverse_dict(master_pillar, value, None, delimiter='.')
+        if retval:
+            log.debug('CONFIG.OPTION (master): %s', str(retval))
+            return retval
     if not omit_pillar:
-        if value in __pillar__:
-            return __pillar__[value]
-    if value in DEFAULTS:
-        return DEFAULTS[value]
+        retval = traverse_dict(__pillar__, value, None, delimiter='.')
+        if retval:
+            log.debug('CONFIG.OPTION (pillar): %s', str(retval))
+            return retval
+
+    retval = traverse_dict(DEFAULTS, value, None, delimiter='.')
+
+    if retval:
+        return retval
+
     return default
 
 
@@ -167,6 +188,12 @@ def merge(value,
     Same as ``option()`` except that it merges all matches, rather than taking
     the first match.
 
+    .. note::
+
+        for .merge() and .option(), pillar paths are expressed using `.` rather
+        than the more typical `:`.
+
+
     CLI Example:
 
     .. code-block:: bash
@@ -175,13 +202,15 @@ def merge(value,
     '''
     ret = None
     if not omit_opts:
-        if value in __opts__:
-            ret = __opts__[value]
+        tmp = traverse_dict(__opts__, value, default, delimiter='.')
+        if tmp:
+            ret = tmp
             if isinstance(ret, str):
                 return ret
     if not omit_master:
-        if value in __pillar__.get('master', {}):
-            tmp = __pillar__['master'][value]
+        master_pillar = __pillar__.get('master', {})
+        if master_pillar:
+            tmp = traverse_dict(master_pillar, value, None, delimiter='.')
             if ret is None:
                 ret = tmp
                 if isinstance(ret, str):
@@ -193,8 +222,8 @@ def merge(value,
                                                                (list, tuple)):
                 ret = list(ret) + list(tmp)
     if not omit_pillar:
-        if value in __pillar__:
-            tmp = __pillar__[value]
+        tmp = traverse_dict(__pillar__, value, None, delimiter='.')
+        if tmp:
             if ret is None:
                 ret = tmp
                 if isinstance(ret, str):
@@ -205,8 +234,9 @@ def merge(value,
             elif isinstance(ret, (list, tuple)) and isinstance(tmp,
                                                                (list, tuple)):
                 ret = list(ret) + list(tmp)
-    if ret is None and value in DEFAULTS:
-        return DEFAULTS[value]
+
+    default = traverse_dict(DEFAULTS, value, None, delimiter='.')
+
     return ret or default
 
 


### PR DESCRIPTION
### What does this PR do?

Modifies the mechanism used to resolve dictionary key paths.  Rather than using a single level dictionary-lookup, this uses salt.utils.traverse_dict()
### What issues does this PR fix or reference?

I am submitting this as a precursor to fixing the boto execution modules disfunction with regards to auth profiles

https://github.com/saltstack/salt/pull/30158
### Tests written?

No (sorry--time 😞 )

multi-dimensional pillar support.

The existing implementation only takes care of single-depth pillar keys.
This patch maintains the existing functionality but rather than use
simple single-key dictionary lookups, this uses
`salt.utils.traverse_dict()` calls.

e.g.:
`salt-call config.option cloud.config.ec2` will properly return a value
from **opts**, **pillar**.master (if not disabled) or  **pillar**

similarly, config.merge() has also been updated to support the same
lookups while maintaining current merge logic.
