### PR TITLE
It doesn't seem like there was a populated salt dunder within the

### DIFF
--- a/salt/utils/boto.py
+++ b/salt/utils/boto.py
@@ -41,6 +41,7 @@ import logging
 import sys
 from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
 from functools import partial
+from salt.loader import minion_mods
 
 # Import salt libs
 from salt.ext.six import string_types  # pylint: disable=import-error
@@ -63,7 +64,7 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
-__salt__ = {}
+__salt__ = None
 
 
 def __virtual__():
@@ -78,6 +79,9 @@ def __virtual__():
     elif _LooseVersion(boto.__version__) < _LooseVersion(required_boto_version):
         return False
     else:
+        global __salt__
+        if not __salt__:
+            __salt__ = minion_mods(__opts__)
         return True
 
 
@@ -89,7 +93,7 @@ def _get_profile(service, region, key, keyid, profile):
             _profile = profile
         key = _profile.get('key', None)
         keyid = _profile.get('keyid', None)
-        region = _profile.get('region', None)
+        region = _profile.get('region', region or None)
     if not region and __salt__['config.option'](service + '.region'):
         region = __salt__['config.option'](service + '.region')
 


### PR DESCRIPTION
### What does this PR do?

On v2015.8.8 .utils.boto() was choking on not finding  `__salt__['config.option']()`
Additionally,`.utils.boto._get_profile()` was stomping on the region argument
### What issues does this PR fix or reference?

This one--maybe others? :)
### Previous Behavior

specifying a profile and a region would result in all boto_\* calls being dispatched to us-east-1
### Tests written?

No

It doesn't seem like there was a populated salt dunder within the salt.utils.boto namespace, so, that.

in .utils.boto._get_profile(), when a profile was specified, the getter
logic wasn't checking for the region argument being set.
