### PR TITLE
Fix routes for redhat < 6

### DIFF
--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -1008,8 +1008,11 @@ def build_routes(iface, **settings):
     '''
 
     template = 'rh6_route_eth.jinja'
-    if __grains__['osrelease'][0] < 6:
-        template = 'route_eth.jinja'
+    try:
+        if int(__grains__['osrelease'][0]) < 6:
+            template = 'route_eth.jinja'
+    except ValueError:
+        pass
     log.debug('Template name: ' + template)
 
     iface = iface.lower()


### PR DESCRIPTION
Fix routes for redhat < 6 - choose the right template.

__grains__['osrelease'][0] is a string... therefore the condition does not work:

```
>>> "5" < 6
False
```

Can you backport to 2015.8 (cherry-pick)?

Thank you
