### PR TITLE
Fix stacktrace in batch with dup minion ids

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -165,7 +165,8 @@ class Batch(object):
                         else:
                             parts.update(part)
                             for id in part.keys():
-                                minion_tracker[queue]['minions'].remove(id)
+                                if id in minion_tracker[queue]['minions']:
+                                    minion_tracker[queue]['minions'].remove(id)
                 except StopIteration:
                     # if a iterator is done:
                     # - set it to inactive


### PR DESCRIPTION
### What does this PR do?

Resolves stacktrace when running batch mode against multiple minions with the same id
### What issues does this PR fix or reference?
#32661

Resolves #32661
