### PR TITLE
Added an app pool restart command

### DIFF
--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -489,6 +489,29 @@ def remove_apppool(name):
     return False
 
 
+def restart_apppool(name):
+    '''
+    Restart an IIS application pool.
+
+    :param str name: The name of the IIS application pool.
+
+    :return: A boolean representing whether all changes succeeded.
+    :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' win_iis.restart_apppool name='MyTestPool'
+    '''
+    pscmd = list()
+    
+    pscmd.append("Restart-WebAppPool '{0}'".format(name))
+
+    cmd_ret = _srvmgr(str().join(pscmd))
+    return cmd_ret['retcode'] == 0
+
+
 def list_apps(site):
     '''
     Get all configured IIS applications for the specified site.

--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -498,6 +498,8 @@ def restart_apppool(name):
     :return: A boolean representing whether all changes succeeded.
     :rtype: bool
 
+    .. versionadded:: Carbon
+
     CLI Example:
 
     .. code-block:: bash


### PR DESCRIPTION
### Add a restart_apppool command to the IIS module

I'm in the Windows training at the conference and it says to restart IIS which you generally wouldn't do for a small change, you'd restart the app pool instead.
