### PR TITLE
Check that the beacon exists before we try to disable or enable it

### DIFF
--- a/salt/beacons/__init__.py
+++ b/salt/beacons/__init__.py
@@ -166,15 +166,17 @@ class Beacon(object):
         Update whether an individual beacon is enabled
         '''
 
-        if isinstance(self.opts['beacons'][name], dict):
+        if name in self.opts['beacons'] and \
+                isinstance(self.opts['beacons'][name], dict):
             # Backwards compatibility
             self.opts['beacons'][name]['enabled'] = enabled_value
         else:
-            enabled_index = self._get_index(self.opts['beacons'][name], 'enabled')
-            if enabled_index >= 0:
-                self.opts['beacons'][name][enabled_index]['enabled'] = enabled_value
-            else:
-                self.opts['beacons'][name].append({'enabled': enabled_value})
+            if name in self.opts['beacons']:
+                enabled_index = self._get_index(self.opts['beacons'][name], 'enabled')
+                if enabled_index >= 0:
+                    self.opts['beacons'][name][enabled_index]['enabled'] = enabled_value
+                else:
+                    self.opts['beacons'][name].append({'enabled': enabled_value})
 
     def list_beacons(self):
         '''


### PR DESCRIPTION
### What does this PR do?

Checks that the beacon exists before we try to disable it
### What issues does this PR fix or reference?

N/A
### Previous Behavior

Events would not return properly if beacons.disable_beacon/enable_beacon is run on a beacon that does not exist.
### New Behavior

Checks that the beacon exists before we try to disable it
### Tests written?

No
