### PR TITLE
Support remote sources in a source list

### DIFF
--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -16,6 +16,7 @@ import salt.utils
 import salt.crypt
 import salt.transport
 from salt.exceptions import CommandExecutionError
+from salt.ext.six.moves.urllib.parse import urlparse as _urlparse  # pylint: disable=import-error,no-name-in-module
 
 log = logging.getLogger(__name__)
 
@@ -348,6 +349,25 @@ def cache_file(path, saltenv='base', env=None):
         # Backwards compatibility
         saltenv = env
 
+    contextkey = '{0}_|-{1}_|-{2}'.format('cp.cache_file', path, saltenv)
+    path_is_remote = _urlparse(path).scheme in ('http', 'https', 'ftp')
+    try:
+        if path_is_remote and contextkey in __context__:
+            # Prevent multiple caches in the same salt run. Affects remote URLs
+            # since the master won't know their hash, so the fileclient
+            # wouldn't be able to prevent multiple caches if we try to cache
+            # the remote URL more than once.
+            if os.path.isfile(__context__[contextkey]):
+                return __context__[contextkey]
+            else:
+                # File is in __context__ but no longer exists in the minion
+                # cache, get rid of the context key and re-cache below.
+                # Accounts for corner case where file is removed from minion
+                # cache between cp.cache_file calls in the same salt-run.
+                __context__.pop(contextkey)
+    except AttributeError:
+        pass
+
     _mk_client()
     if path.startswith('salt://|'):
         # Strip pipe. Windows doesn't allow pipes in filenames
@@ -371,6 +391,10 @@ def cache_file(path, saltenv='base', env=None):
                 path, saltenv
             )
         )
+    if path_is_remote:
+        # Cache was successful, store the result in __context__ to prevent
+        # multiple caches (see above).
+        __context__[contextkey] = result
     return result
 
 

--- a/tests/integration/modules/file.py
+++ b/tests/integration/modules/file.py
@@ -173,6 +173,7 @@ class FileModuleTest(integration.ModuleCase):
                 return_value=['http/httpd.conf.fallback']),
             'cp.list_master_dirs': MagicMock(return_value=[]),
         }
+        filemod.__context__ = {}
 
         ret = filemod.source_list(['salt://http/httpd.conf',
                                    'salt://http/httpd.conf.fallback'],
@@ -188,6 +189,8 @@ class FileModuleTest(integration.ModuleCase):
             'cp.list_master': MagicMock(side_effect=list_master),
             'cp.list_master_dirs': MagicMock(return_value=[]),
         }
+        filemod.__context__ = {}
+
         ret = filemod.source_list(['salt://http/httpd.conf?saltenv=dev',
                                    'salt://http/httpd.conf.fallback'],
                                   'filehash', 'base')
@@ -199,6 +202,8 @@ class FileModuleTest(integration.ModuleCase):
             'cp.list_master': MagicMock(return_value=['http/httpd.conf']),
             'cp.list_master_dirs': MagicMock(return_value=[]),
         }
+        filemod.__context__ = {}
+
         ret = filemod.source_list(
             [{'salt://http/httpd.conf': ''}], 'filehash', 'base')
         self.assertItemsEqual(ret, ['salt://http/httpd.conf', 'filehash'])
@@ -209,8 +214,10 @@ class FileModuleTest(integration.ModuleCase):
         filemod.__salt__ = {
             'cp.list_master': MagicMock(return_value=[]),
             'cp.list_master_dirs': MagicMock(return_value=[]),
-            'cp.get_url': MagicMock(return_value='/tmp/http.conf'),
+            'cp.cache_file': MagicMock(return_value='/tmp/http.conf'),
         }
+        filemod.__context__ = {}
+
         ret = filemod.source_list(
             [{'http://t.est.com/http/httpd.conf': 'filehash'}], '', 'base')
         self.assertItemsEqual(ret, ['http://t.est.com/http/httpd.conf',

--- a/tests/unit/states/archive_test.py
+++ b/tests/unit/states/archive_test.py
@@ -59,6 +59,7 @@ class ArchiveTest(TestCase):
         mock_false = MagicMock(return_value=False)
         ret = {'stdout': ['saltines', 'cheese'], 'stderr': 'biscuits', 'retcode': '31337', 'pid': '1337'}
         mock_run = MagicMock(return_value=ret)
+        mock_source_list = MagicMock(return_value=source)
 
         with patch('os.path.exists', mock_true):
             with patch.dict(archive.__opts__, {'test': False,
@@ -66,7 +67,8 @@ class ArchiveTest(TestCase):
                 with patch.dict(archive.__salt__, {'file.directory_exists': mock_false,
                                                    'file.file_exists': mock_false,
                                                    'file.makedirs': mock_true,
-                                                   'cmd.run_all': mock_run}):
+                                                   'cmd.run_all': mock_run,
+                                                   'file.source_list': mock_source_list}):
                     filename = os.path.join(
                         tmp_dir,
                         'files/test/_tmp_test_archive_.tar'


### PR DESCRIPTION
This commit modifies the source_list check so that remote sources
(http(s), ftp, etc.) are not fetched more than once. To do so, it
adds the use of `__context__` in `cp.cache_file` and
`file.source_list` to prevent multiple fetches of a single file in the
same salt run.
