### PR TITLE
Handle when beacon not configured and we try to enable/disable them

### DIFF
--- a/salt/modules/beacons.py
+++ b/salt/modules/beacons.py
@@ -394,6 +394,7 @@ def enable_beacon(name, **kwargs):
     if not name:
         ret['comment'] = 'Beacon name is required.'
         ret['result'] = False
+        return ret
 
     if 'test' in kwargs and kwargs['test']:
         ret['comment'] = 'Beacon {0} would be enabled.'.format(name)
@@ -444,6 +445,7 @@ def disable_beacon(name, **kwargs):
     if not name:
         ret['comment'] = 'Beacon name is required.'
         ret['result'] = False
+        return ret
 
     if 'test' in kwargs and kwargs['test']:
         ret['comment'] = 'Beacons would be enabled.'

--- a/salt/modules/beacons.py
+++ b/salt/modules/beacons.py
@@ -398,9 +398,11 @@ def enable_beacon(name, **kwargs):
     if 'test' in kwargs and kwargs['test']:
         ret['comment'] = 'Beacon {0} would be enabled.'.format(name)
     else:
-        if name not in list_(return_yaml=True):
+        _beacons = list_(return_yaml=False)
+        if name not in _beacons:
             ret['comment'] = 'Beacon {0} is not currently configured.'.format(name)
             ret['result'] = False
+            return ret
 
         try:
             eventer = salt.utils.event.get_event('minion', opts=__opts__)
@@ -446,9 +448,11 @@ def disable_beacon(name, **kwargs):
     if 'test' in kwargs and kwargs['test']:
         ret['comment'] = 'Beacons would be enabled.'
     else:
-        if name not in list_(return_yaml=True):
+        _beacons = list_(return_yaml=False)
+        if name not in _beacons:
             ret['comment'] = 'Beacon {0} is not currently configured.'.format(name)
             ret['result'] = False
+            return ret
 
         try:
             eventer = salt.utils.event.get_event('minion', opts=__opts__)


### PR DESCRIPTION
### What does this PR do?

Handle when beacon not configured and we try to enable/disable them
### What issues does this PR fix or reference?

N/A
### Previous Behavior

When enabling or disabling a beacon, if that beacon was not configured Salt would get stuck waiting for an event that would never be returned.
### New Behavior

Check to see that the beacon is configured before attempting to enabling or disabling it
### Tests written?

No
