### PR TITLE
Check dependencies type before appling str operations

### DIFF
--- a/salt/spm/__init__.py
+++ b/salt/spm/__init__.py
@@ -247,6 +247,8 @@ class SPMClient(object):
 
         can_has = {}
         cant_has = []
+        if 'dependencies' in formula_def and formula_def['dependencies'] is None:
+            formula_def['dependencies'] = ''
         for dep in formula_def.get('dependencies', '').split(','):
             dep = dep.strip()
             if not dep:


### PR DESCRIPTION
### What does this PR do?

The `dependencies` field sometimes shows up as `None`. This looks for that and changes it to an empty string.
### What issues does this PR fix or reference?

None that I know of.
### Tests written?

No
