### PR TITLE
Handle the situation when the beacon is not configured

### DIFF
--- a/salt/modules/beacons.py
+++ b/salt/modules/beacons.py
@@ -405,14 +405,16 @@ def enable_beacon(name, **kwargs):
     if not name:
         ret['comment'] = 'Beacon name is required.'
         ret['result'] = False
+        return ret
 
     if 'test' in kwargs and kwargs['test']:
         ret['comment'] = 'Beacon {0} would be enabled.'.format(name)
     else:
-        if name not in list_(return_yaml=True):
+        _beacons = list_(return_yaml=False)
+        if name not in _beacons:
             ret['comment'] = 'Beacon {0} is not currently configured.'.format(name)
             ret['result'] = False
-
+            return ret
         try:
             eventer = salt.utils.event.get_event('minion', opts=__opts__)
             res = __salt__['event.fire']({'func': 'enable_beacon', 'name': name}, 'manage_beacons')
@@ -455,14 +457,16 @@ def disable_beacon(name, **kwargs):
     if not name:
         ret['comment'] = 'Beacon name is required.'
         ret['result'] = False
+        return ret
 
     if 'test' in kwargs and kwargs['test']:
         ret['comment'] = 'Beacons would be enabled.'
     else:
-        if name not in list_(return_yaml=True):
+        _beacons = list_(return_yaml=False)
+        if name not in _beacons:
             ret['comment'] = 'Beacon {0} is not currently configured.'.format(name)
             ret['result'] = False
-
+            return ret
         try:
             eventer = salt.utils.event.get_event('minion', opts=__opts__)
             res = __salt__['event.fire']({'func': 'disable_beacon', 'name': name}, 'manage_beacons')


### PR DESCRIPTION
### What does this PR do?

Handle the situation when the beacon is not configured and we try to enable or disable it.
### What issues does this PR fix or reference?

N/A
### Previous Behavior

Salt wouldn't return when the beacon wasn't configured.
### New Behavior

Return with an error before we attempt to fire the event to disable or enable the beacon.
### Tests written?

Yes
