### PR TITLE
Skip utils_test if timelib is not installed

### DIFF
--- a/tests/unit/utils/utils_test.py
+++ b/tests/unit/utils/utils_test.py
@@ -516,14 +516,9 @@ class UtilsTestCase(TestCase):
             ret = utils.date_cast('Mon Dec 23 10:19:15 MST 2013')
             expected_ret = datetime.datetime(2013, 12, 23, 10, 19, 15)
             self.assertEqual(ret, expected_ret)
-        except ImportError:
-            try:
-                ret = utils.date_cast('Mon Dec 23 10:19:15 MST 2013')
-                expected_ret = datetime.datetime(2013, 12, 23, 10, 19, 15)
-                self.assertEqual(ret, expected_ret)
-            except RuntimeError:
-                # Unparseable without timelib installed
-                self.skipTest('\'timelib\' is not installed')
+        except RuntimeError:
+            # Unparseable without timelib installed
+            self.skipTest('\'timelib\' is not installed')
 
     @skipIf(not HAS_TIMELIB, '\'timelib\' is not installed')
     def test_date_format(self):


### PR DESCRIPTION
### What does this PR do?

Skips a test if timelib is not installed instead of throwing an error
### Previous Behavior

```
============================  Overall Tests Report  ============================
*** unit.utils.utils_test.UtilsTestCase.test_date_cast Tests  ******************
 --------  Tests with Errors  --------------------------------------------------
   -> unit.utils.utils_test.UtilsTestCase.test_date_cast  ......................
       Traceback (most recent call last):
         File "/home/eradman/git/salt/tests/unit/utils/utils_test.py", line 516, in test_date_cast
           ret = utils.date_cast('Mon Dec 23 10:19:15 MST 2013')
         File "/home/eradman/git/salt/salt/utils/__init__.py", line 2117, in date_cast
           ' Consider installing timelib'.format(date))
       RuntimeError: Unable to parse Mon Dec 23 10:19:15 MST 2013. Consider installing timelib
```
### New Behavior

```
============================  Overall Tests Report  ============================
*** unit.utils.utils_test.UtilsTestCase.test_date_cast Tests  ******************
 --------  Skipped Tests  ------------------------------------------------------
   -> unit.utils.utils_test.UtilsTestCase.test_date_cast  ->  'timelib' is not installed
 -------------------------------------------------------------------------------
================================================================================
OK (total=1, skipped=1, passed=0, failures=0, errors=0) 
```
