### PR TITLE
Add eq to check thorium state

### DIFF
--- a/salt/thorium/check.py
+++ b/salt/thorium/check.py
@@ -45,6 +45,24 @@ def lt(name, value):
     return ret
 
 
+def eq(name, value):
+    '''
+    Only succeed if the value in the given register location is equal to
+    the given value
+    '''
+    ret = {'name': name,
+           'result': False,
+           'comment': '',
+           'changes': {}}
+    if name not in __reg__:
+        ret['result'] = None
+        ret['comment'] = 'Value {0} not in register'.format(name)
+        return ret
+    if __reg__[name]['val'] == value:
+        ret['result'] = True
+    return ret
+
+
 def contains(name, value):
     '''
     Only succeed if the value in the given register location is greater than


### PR DESCRIPTION
### What does this PR do?

Extend the check thorium state with an _equals to_ evaluation.
### What issues does this PR fix or reference?

None that I am aware of. (Checked through GitHub with a _thorium_ search in open issues.)
### New Behavior

Ability to perform _equals to_ checks with thorium.
### Tests written?

No
