### PR TITLE
Make example top file match templated version

### DIFF
--- a/doc/topics/grains/index.rst
+++ b/doc/topics/grains/index.rst
@@ -88,13 +88,13 @@ the following configuration:
 
 .. code-block:: yaml
 
-    'node_type:web':
+    'node_type:webserver':
       - match: grain
       - webserver
 
     'node_type:postgres':
       - match: grain
-      - database
+      - postgres
 
     'node_type:redis':
       - match: grain


### PR DESCRIPTION
### What does this PR do?

Updates some content in the saltstack documentation.
### What issues does this PR fix or reference?

Currently the example top file under "Matching Grains in the Top File" has
node_type grains whose values do not match the names of the states which
they specify.  (e.g. the `webserver` node_type specifies the `web` state).  
Later these values are templated using jinja templates as if they are identical.

This commit adjusts the values in the example to be identical, so that the 
template example follows naturally.
### Tests written?

No
