### PR TITLE
Remove check_or_die for venv_bin

### DIFF
--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -129,8 +129,6 @@ def create(path,
     '''
     if venv_bin is None:
         venv_bin = __opts__.get('venv_bin') or __pillar__.get('venv_bin')
-    # raise CommandNotFoundError if venv_bin is missing
-    salt.utils.check_or_die(venv_bin)
 
     cmd = [venv_bin]
 


### PR DESCRIPTION
While it sounds a good idea to check wether the venv_bin exists or not, due to
the implementation of salt.utils.which it fails if the command contains
arguments, for example "/usr/local/bin/python3.4 -m venv":

```
2016-04-20 12:56:46,564 [salt.state
][ERROR   ][45709] An exception occurred in this state: Traceback (most recent
call last):
  File "/usr/local/lib/python2.7/site-packages/salt/state.py", line 1594, in
call
    **cdata['kwargs'])
  File "/usr/local/lib/python2.7/site-packages/salt/loader.py", line 1491, in
wrapper
    return f(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/salt/states/virtualenv_mod.py",
line 169, in managed
    use_vt=use_vt,
  File "/usr/local/lib/python2.7/site-packages/salt/modules/virtualenv_mod.py",
line 117, in create
    salt.utils.check_or_die(venv_bin)
  File "/usr/local/lib/python2.7/site-packages/salt/utils/__init__.py", line
804, in check_or_die
    raise CommandNotFoundError(command)
CommandNotFoundError: /usr/local/bin/python3.4 -m venv
```
