### PR TITLE
Fixes to schedule.list in 2015.8

### DIFF
--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -112,7 +112,16 @@ def list_(show_all=False, where=None, return_yaml=True):
                 schedule[job][item] = False
 
         if '_seconds' in schedule[job]:
-            schedule[job]['seconds'] = schedule[job]['_seconds']
+            # if _seconds is greater than zero
+            # then include the original back in seconds.
+            # otherwise remove seconds from the listing as the
+            # original item didn't include it.
+            if schedule[job]['_seconds'] > 0:
+                schedule[job]['seconds'] = schedule[job]['_seconds']
+            else:
+                del schedule[job]['seconds']
+
+            # remove _seconds from the listing
             del schedule[job]['_seconds']
 
     if schedule:


### PR DESCRIPTION
### What does this PR do?

Backporting a fix from develop where the use of splay would result in seconds=0 in the schedule.list when there was no seconds specified in the original schedule
### What issues does this PR fix or reference?

N/A
### Previous Behavior

Unnecessary seconds=0 in results from schedule.list
### New Behavior

Unnecessary seconds=0 removed from schedule.list
### Tests written?

No
