### PR TITLE
correct use of force flag in file.copy #23714

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -4142,15 +4142,14 @@ def copy(
 
     if os.path.lexists(source) and os.path.lexists(name):
         # if this is a file which did not change, do not update
-        if os.path.isfile(name):
+        if force and os.path.isfile(name):
             hash1 = salt.utils.get_hash(name)
             hash2 = salt.utils.get_hash(source)
             if hash1 == hash2:
-                if force:
-                    changed = True
-                    ret['comment'] = ' '.join([ret['comment'], '- files are identical but force flag is set'])
-                else:
-                    changed = False
+                changed = True
+                ret['comment'] = ' '.join([ret['comment'], '- files are identical but force flag is set'])
+        if not force:
+            changed = False
         elif not __opts__['test'] and changed:
             # Remove the destination to prevent problems later
             try:

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -4142,13 +4142,15 @@ def copy(
 
     if os.path.lexists(source) and os.path.lexists(name):
         # if this is a file which did not change, do not update
-        if force and os.path.isfile(name):
+        if os.path.isfile(name):
             hash1 = salt.utils.get_hash(name)
             hash2 = salt.utils.get_hash(source)
             if hash1 == hash2:
-                changed = False
-        if not force:
-            changed = False
+                if force:
+                    changed = True
+                    ret['comment'] = ' '.join([ret['comment'], '- files are identical but force flag is set'])
+                else:
+                    changed = False
         elif not __opts__['test'] and changed:
             # Remove the destination to prevent problems later
             try:


### PR DESCRIPTION
### What does this PR do?

fixes use of force in file.copy state.  To be specific it was ambiguous whether or not `force` would overwrite a file if the file already existed and had the same hash as the source file.  Since there may be some reason why the file needs to be overwritten even if it appears identical, this PR clarifies the semantics that `force` really signifies  `I SAID FORCE AND I MEAN IT, DANGIT!`  The comment is updated to indicate when the file is overwritten when the hashes match.
### What issues does this PR fix or reference?
#23714
### Previous Behavior

force flag was ignored when the source and target file hashes matched.
### New Behavior

force flag indicates to overwrite the file in all situations, even if it exists and the hash is identical to the source.
### Tests written?

No
