### PR TITLE
Update external auth documentation to list supported matcher.

### DIFF
--- a/doc/topics/eauth/access_control.rst
+++ b/doc/topics/eauth/access_control.rst
@@ -33,7 +33,7 @@ The access controls are manifested using matchers in these configurations:
 
 In the above example, fred is able to send commands only to minions which match
 the specified glob target. This can be expanded to include other functions for
-other minions based on standard targets.
+other minions based on standard targets (all matchers are supported except the compound one).
 
 .. code-block:: yaml
 
@@ -58,4 +58,3 @@ unrestricted access to salt commands.
 
 .. note::
     Functions are matched using regular expressions.
-


### PR DESCRIPTION
### What does this PR do?

Update external auth documentation to list supported matcher.
### What issues does this PR fix or reference?
#21303
### Tests written?

No

---

Thanks to #31598, all matchers are supported for eauth configuration.
But we still have no way to use compound matchers in eauth configuration.
Update the documentation to explicitly express this limitation.
