### PR TITLE
set record_type to lowercase as api is case sensitive

### DIFF
--- a/salt/modules/infoblox.py
+++ b/salt/modules/infoblox.py
@@ -115,6 +115,7 @@ def delete_record(name,
         _throw_no_creds()
         return None
 
+    record_type = record_type.lower()
     currentRecords = get_record(name,
                                 record_type,
                                 infoblox_server,
@@ -193,6 +194,7 @@ def update_record(name,
         _throw_no_creds()
         return None
 
+    record_type = record_type.lower()
     currentRecords = get_record(name,
                                 record_type,
                                 infoblox_server,
@@ -443,6 +445,7 @@ def get_record(record_name,
                                                                          infoblox_user,
                                                                          infoblox_password)
 
+    record_type = record_type.lower()
     if infoblox_server is None and infoblox_user is None and infoblox_password is None:
         _throw_no_creds()
         return None


### PR DESCRIPTION
### What does this PR do?

sets record_type to always be lowercase, as wapi is case sensitive
### What issues does this PR fix or reference?

None
### Previous Behavior

Not all functions set record_type to lowercase, giving user ability to ruin themselves with case
### New Behavior

All functions with record_type will set record_type to lowercase
### Tests written?

No
