### PR TITLE
Add ability to set server state for HAProxy

### DIFF
--- a/salt/modules/haproxyconn.py
+++ b/salt/modules/haproxyconn.py
@@ -188,6 +188,42 @@ def set_weight(name, backend, weight=0, socket='/var/run/haproxy.sock'):
     return get_weight(name, backend, socket=socket)
 
 
+def set_state(name, backend, state, socket='/var/run/haproxy.sock'):
+    '''
+    Force a server's administrative state to a new state. This can be useful to
+    disable load balancing and/or any traffic to a server. Setting the state to
+    "ready" puts the server in normal mode, and the command is the equivalent of
+    the "enable server" command. Setting the state to "maint" disables any traffic
+    to the server as well as any health checks. This is the equivalent of the
+    "disable server" command. Setting the mode to "drain" only removes the server
+    from load balancing but still allows it to be checked and to accept new
+    persistent connections. Changes are propagated to tracking servers if any.
+
+    name
+        Server name
+
+    backend
+        haproxy backend
+
+    state
+        A string of the state to set. Must be 'ready', 'drain', or 'maint'
+        
+    '''
+
+
+    # Pulling this in from the latest 0.5 release which is not yet in PyPi.
+    # https://github.com/neurogeek/haproxyctl
+    class setServerState(haproxy.cmds.Cmd):
+        """Set server state command."""
+        cmdTxt = "set server %(backend)s/%(server)s state %(value)s\r\n"
+        p_args = ['backend', 'server', 'value']
+        helpTxt = "Force a server's administrative state to a new state."
+
+    ha_conn = _get_conn(socket)
+    ha_cmd = setServerState(server=name, backend=backend, value=state)
+    return ha_conn.sendCmd(ha_cmd)
+
+
 def show_frontends(socket='/var/run/haproxy.sock'):
     '''
     Show HaProxy frontends


### PR DESCRIPTION
### What does this PR do?

Allows the user to set the server state using Salt. See following URL for details

https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#9.2-set%20server
### What issues does this PR fix or reference?

None AFAIK. Doing part of sprint in Saltconf.
### Tests written?

No
