### PR TITLE
Add license information for pip modules

### DIFF
--- a/pkg/windows/readme.md
+++ b/pkg/windows/readme.md
@@ -22,7 +22,8 @@ salt for Windows with their corresponding licenses:
 | Mako | MIT |
 | MarkupSafe | BSD |
 | msgpack-python | --- |
-| psutil | OSI Approved + BSD |
+| pip | MIT |
+| psutil | BSD |
 | pyasn1 | BSD |
 | pycparser | BSD |
 | pycurl | LGPL + MIT |
@@ -33,6 +34,7 @@ salt for Windows with their corresponding licenses:
 | PyYAML | MIT |
 | pyzmq | LGPL + BSD |
 | requests | Apache 2.0 |
+| setuptools | MIT |
 | singledispatch | MIT |
 | six | MIT |
 | smmap | BSD |

--- a/pkg/windows/readme.md
+++ b/pkg/windows/readme.md
@@ -1,0 +1,42 @@
+### Packaged Plugin Licenses
+The following dependencies are packaged with
+salt for Windows with their corresponding licenses:
+
+| Module    | License |
+|-----------|---------|
+| backports-abc | --- |
+| backports.ssl-match-hostname | PSF |
+| certifi | ISC |
+| cffi | MIT |
+| CherryPy | BSD |
+| enum34 | BSD |
+| futures | BSD |
+| gitdb | BSD |
+| GitPython | BSD |
+| idna | BSD-like |
+| ioflo | Apache 2.0 |
+| ioloop | MIT |
+| ipaddress | PSF |
+| Jinja2 | BSD |
+| libnacl | --- |
+| Mako | MIT |
+| MarkupSafe | BSD |
+| msgpack-python | --- |
+| psutil | OSI Approved + BSD |
+| pyasn1 | BSD |
+| pycparser | BSD |
+| pycurl | LGPL + MIT |
+| PyMySQL | MIT |
+| pypiwin32 | PSF |
+| python-dateutil | Simplified BSD |
+| python-gnupg | BSD |
+| PyYAML | MIT |
+| pyzmq | LGPL + BSD |
+| requests | Apache 2.0 |
+| singledispatch | MIT |
+| six | MIT |
+| smmap | BSD |
+| timelib | ZLIB/PHP |
+| tornado | Apache 2.0 |
+| wheel | MIT |
+| WMI | MIT |


### PR DESCRIPTION
### What does this PR do?

Adds a readme file that contains the license information for pip modules that are packaged with windows.
### What issues does this PR fix or reference?

Related to #32717 
### Previous Behavior

License information not documented
### New Behavior

Documents license information
### Tests written?

NA
