### PR TITLE
Rsync synchronized updates.

### DIFF
--- a/tests/unit/modules/rsync_test.py
+++ b/tests/unit/modules/rsync_test.py
@@ -40,7 +40,7 @@ class RsyncTestCase(TestCase):
 
         with patch.dict(rsync.__salt__,
                         {'config.option': MagicMock(return_value='A'),
-                         'cmd.run': MagicMock(side_effect=[IOError('f'),
+                         'cmd.run_all': MagicMock(side_effect=[IOError('f'),
                                                                'A'])}):
             with patch.object(rsync, '_check', return_value=['A']):
                 self.assertRaises(CommandExecutionError, rsync.rsync, 'a', 'b')


### PR DESCRIPTION
### What does this PR do?

Also added --dry-run option which is also used for test mode taking advantage of this option in rsync.
Finally synchronized was not working, See #32478. Changes cmd.run to cmd.run_all make this works.
### Previous Behavior

``` yml
ubuntu:
----------
          ID: /opt/user-backups
    Function: rsync.synchronized
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/root/salt/salt/state.py", line 1703, in call
                  **cdata['kwargs'])
                File "/root/salt/salt/loader.py", line 1661, in wrapper
                  return f(*args, **kwargs)
                File "/root/salt/salt/states/rsync.py", line 117, in synchronized
                  if result.get('retcode'):
              AttributeError: 'str' object has no attribute 'get'
     Started: 01:00:28.262860
    Duration: 557.255 ms
     Changes:
```
### New Behavior

``` yml
ubuntu:
----------
          ID: /tmp
    Function: rsync.synchronized
      Result: True
     Comment: - sent 3,444 bytes
              - received 203 bytes
              - 7,294.00 bytes/sec
              - total size is 7,495
              - speedup is 2.06
     Started: 01:41:57.791846
    Duration: 61.9 ms
     Changes:
              ----------
              copied:
                  ubuntu/
                  ubuntu/.bash_logout
                  ubuntu/.bashrc
                  ubuntu/.profile
                  ubuntu/.ssh/
                  ubuntu/.ssh/authorized_keys
                  ubuntu/a
                  ubuntu/b
                  ubuntu/c
                  ubuntu/tmp/
                  ubuntu/tmp/.ICE-unix/
                  ubuntu/tmp/.X11-unix/
                  ubuntu/tmp/salt-runtests.log
                  ubuntu/tmp/tmux-0/
                  ubuntu/tmp/tmux-0/default
              deleted:
                  N/A

Summary for ubuntu
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
```
### Tests written?

No
