### PR TITLE
Fix epoch handling for rpm. If epoch is given it is also required in …

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1074,13 +1074,19 @@ def install(name=None,
             # not None, since the only way version_num is not None is if RPM
             # metadata parsing was successful.
             if pkg_type == 'repository':
+
+                # do not overwrite version_num
+                pkg_version = version_num
+
                 if _yum() == 'yum':
                     # yum install does not support epoch without the arch, and
                     # we won't know what the arch will be when it's not
                     # provided. It could either be the OS architecture, or
                     # 'noarch', and we don't make that distinction in the
                     # pkg.list_pkgs return data.
-                    version_num = version_num.split(':', 1)[-1]
+
+                    pkg_version = version_num.split(':', 1)[-1]
+
                 arch = ''
                 try:
                     namepart, archpart = pkgname.rsplit('.', 1)
@@ -1091,11 +1097,12 @@ def install(name=None,
                         arch = '.' + archpart
                         pkgname = namepart
 
-                pkgstr = '{0}-{1}{2}'.format(pkgname, version_num, arch)
+                pkgstr = '{0}-{1}{2}'.format(pkgname, pkg_version, arch)
             else:
                 pkgstr = pkgpath
 
             cver = old.get(pkgname, '')
+
             if reinstall and cver \
                     and salt.utils.compare_versions(ver1=version_num,
                                                     oper='==',


### PR DESCRIPTION
…version checks. The previous behaviour extracted the epoch, so that version checks with installed epoch versions led to invalid yum downgrades.
### What does this PR do?

Fixing a problem with rpm/yum.
When pkg.install is used with version and epoch number, the epoch number is stripped of the version string to build the package string for yum. This leads to a misleading version comparison afterwards, since the installed version contains the epoch number and the version to install not anymore.
### What issues does this PR fix or reference?

Did not create an issue
### Previous Behavior

e.g. yelp:
installed version = 2:3.17.2-3.fc23 
pkg.install yelp version=2:3.18.0-1 would result in yum downgrade call instead of yum install 
### New Behavior

e.g. yelp:
installed version = 2:3.17.2-3.fc23 
pkg.install yelp version=2:3.18.0-1 would results in yum install 
### Tests written?

No
