### PR TITLE
Properly handle minion failback failure.

### DIFF
--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -50,7 +50,7 @@ try:
 except ImportError as exc:
     if exc.args[0] != 'No module named _msgpack':
         raise
-from salt.exceptions import SaltSystemExit, get_error_message
+from salt.exceptions import SaltSystemExit, SaltClientError, get_error_message
 
 
 # Let's instantiate logger using salt.log.setup.logging.getLogger() so pylint
@@ -318,6 +318,8 @@ class Minion(parsers.MinionOptionParser, DaemonsMixin):  # pylint: disable=no-in
                 self.verify_hash_type()
                 self.start_log_info()
                 self.minion.tune_in()
+                if self.minion.restart:
+                    raise SaltClientError('Minion could not connect to Master')
         finally:
             self.shutdown()
 

--- a/tests/unit/daemons_test.py
+++ b/tests/unit/daemons_test.py
@@ -113,8 +113,9 @@ class DaemonsStarterTestCase(TestCase, integration.SaltClientTestCaseMixIn):
             '''
             obj = daemons.Minion()
             obj.config = {'user': 'dummy', 'hash_type': alg}
-            for attr in ['minion', 'start_log_info', 'prepare', 'shutdown']:
+            for attr in ['start_log_info', 'prepare', 'shutdown']:
                 setattr(obj, attr, MagicMock())
+            setattr(obj, 'minion', MagicMock(restart=False))
 
             return obj
 


### PR DESCRIPTION
### What does this PR do?

Initiate minion restart if all masters down on __master_disconnect like
minion does on the initial master connect on start.
### What issues does this PR fix or reference?
#32609
### Previous Behavior

If all masters down on `__master_disconnect` event the event handler just raises an exception. After that minion continues to work disconnected and there is no any routine handling this state. Minion continues to run scheduled `master_alive` job but this job could only detect if there are already connected master because it looks up the existing tcp connections. So minion still to be disconnected forever.
### New Behavior

If minion fails to failover to any master it restart itself like it does on the initial connect on start.
### Tests written?

No
