### PR TITLE
Fix issue where pyVmomi 6.0.0 raises SSL errors on Debian 8.3

### DIFF
--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -215,6 +215,18 @@ def get_service_instance(host, username, password, protocol=None, port=None):
                     port=port
                 )
                 ssl._create_default_https_context = default_context
+            elif (isinstance(exc, vim.fault.HostConnectFault) and 'SSL3_GET_SERVER_CERTIFICATE\', \'certificate verify failed' in exc.msg) or 'SSL3_GET_SERVER_CERTIFICATE\', \'certificate verify failed' in str(exc):
+                import ssl
+                default_context = ssl._create_default_https_context
+                ssl._create_default_https_context = ssl._create_unverified_context
+                service_instance = SmartConnect(
+                    host=host,
+                    user=username,
+                    pwd=password,
+                    protocol=protocol,
+                    port=port
+                )
+                ssl._create_default_https_context = default_context
             else:
                 err_msg = exc.msg if hasattr(exc, 'msg') else default_msg
                 log.debug(exc)


### PR DESCRIPTION
### What does this PR do?

The error message for a bad handshake due to a private certificate has changed slightly in PyVmomi 6.0.0. This additional if statement fixes this issue and allows connectivity with a self-signed certificate for pyVmomi 6.0.0.
### What issues does this PR fix or reference?

Relates: #29537
Closes: #29537
### Previous Behavior

The error messages in the output did not match the pattern in the if statement, therefore SaltSystemExit was raised and the program exited.
### Tests written?

No
