### PR TITLE
Allow for specifying not using the random module

### DIFF
--- a/salt/utils/pycrypto.py
+++ b/salt/utils/pycrypto.py
@@ -28,14 +28,14 @@ except ImportError:
 from salt.exceptions import SaltInvocationError
 
 
-def secure_password(length=20):
+def secure_password(length=20, use_random=True):
     '''
     Generate a secure password.
     '''
     length = int(length)
     pw = ''
     while len(pw) < length:
-        if HAS_RANDOM:
+        if HAS_RANDOM and use_random:
             pw += re.sub(r'\W', '', Crypto.Random.get_random_bytes(1))
         else:
             pw += random.SystemRandom().choice(string.ascii_letters + string.digits)


### PR DESCRIPTION
### What does this PR do?

backport this to 2016.3 so that they nxos proxy minion can be used as a drop in.
### Tests written?

No

The Random module can lead to non alpha numeric characters in the
password.  Since we also use this for creating the salt, some devices
cannot have these extra characters in their salts, so allow to turn this
feature off as needed.
