### PR TITLE
Archive extracted perms update.

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -337,7 +337,7 @@ def extracted(name,
     # Note: We do this here because we might not have access to the cachedir.
     if user or group:
         dir_result = __salt__['state.single']('file.directory',
-                                               name,
+                                               if_missing,
                                                user=user,
                                                group=group,
                                                recurse=['user', 'group'])


### PR DESCRIPTION
### What does this PR do?

As described in #32753 archived.extracted changes more permissions that they
should. Since if_missing is None, name is assigned to this variable, this
change will help not updating files/dirs permissions outside the actual extracted file.

[Here](https://github.com/saltstack/salt/blob/2016.3/salt/states/archive.py#L225-L226)  is the relevant part where if_missing gets name if it's None
### What issues does this PR fix or reference?
#32753
### Tests written?

No
