### PR TITLE
Add pending reboot check to win_system

### DIFF
--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -102,9 +102,9 @@ def init(runlevel):
 
         salt '*' system.init 3
     '''
-    #cmd = ['init', runlevel]
-    #ret = __salt__['cmd.run'](cmd, python_shell=False)
-    #return ret
+    # cmd = ['init', runlevel]
+    # ret = __salt__['cmd.run'](cmd, python_shell=False)
+    # return ret
 
     # TODO: Create a mapping of runlevels to
     #       corresponding Windows actions
@@ -422,8 +422,8 @@ def get_system_info():
     :rtype: dict
     '''
     os_type = {1: 'Work Station',
-              2: 'Domain Controller',
-              3: 'Server'}
+               2: 'Domain Controller',
+               3: 'Server'}
     pythoncom.CoInitialize()
     c = wmi.WMI()
     system = c.Win32_OperatingSystem()[0]
@@ -445,10 +445,10 @@ def get_system_info():
            'windows_directory': system.WindowsDirectory}
     system = c.Win32_ComputerSystem()[0]
     ret.update({'hardware_manufacturer': system.Manufacturer,
-               'hardware_model': system.Model,
-               'processors': system.NumberOfProcessors,
-               'processors_logical': system.NumberOfLogicalProcessors,
-               'system_type': system.SystemType})
+                'hardware_model': system.Model,
+                'processors': system.NumberOfProcessors,
+                'processors_logical': system.NumberOfLogicalProcessors,
+                'system_type': system.SystemType})
     system = c.Win32_BIOS()[0]
     ret.update({'hardware_serial': system.SerialNumber,
                 'bios_manufacturer': system.Manufacturer,
@@ -966,3 +966,201 @@ def stop_time_service():
         salt '*' system.stop_time_service
     '''
     return __salt__['service.stop']('w32time')
+
+
+def get_pending_component_servicing():
+    '''
+    Determine whether there are pending Component Based Servicing tasks that require a reboot.
+
+    :return: A boolean representing whether there are pending Component Based Servicing tasks.
+    :rtype: bool
+
+    .. versionadded:: Carbon
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' system.get_pending_component_servicing
+    '''
+    vname = '(Default)'
+    key = r'SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending'
+
+    reg_ret = read_value('HKLM', key, vname)
+
+    # So long as the registry key exists, a reboot is pending.
+    if reg_ret['success']:
+        log.debug('Found key: %s', key)
+        return True
+    else:
+        log.debug('Unable to access key: %s', key)
+    return False
+
+
+def get_pending_domain_join():
+    '''
+    Determine whether there is a pending domain join action that requires a reboot.
+
+    :return: A boolean representing whether there is a pending domain join action.
+    :rtype: bool
+
+    .. versionadded:: Carbon
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' system.get_pending_domain_join
+    '''
+    vname = '(Default)'
+    base_key = r'SYSTEM\CurrentControlSet\Services\Netlogon'
+    avoid_key = r'{0}\AvoidSpnSet'.format(base_key)
+    join_key = r'{0}\JoinDomain'.format(base_key)
+
+    # If either the avoid_key or join_key is present,
+    # then there is a reboot pending.
+
+    avoid_reg_ret = read_value('HKLM', avoid_key, vname)
+
+    if avoid_reg_ret['success']:
+        log.debug('Found key: %s', avoid_key)
+        return True
+    else:
+        log.debug('Unable to access key: %s', avoid_key)
+
+    join_reg_ret = read_value('HKLM', join_key, vname)
+
+    if join_reg_ret['success']:
+        log.debug('Found key: %s', join_key)
+        return True
+    else:
+        log.debug('Unable to access key: %s', join_key)
+    return False
+
+
+def get_pending_file_rename():
+    '''
+    Determine whether there are pending file rename operations that require a reboot.
+
+    :return: A boolean representing whether there are pending file rename operations.
+    :rtype: bool
+
+    .. versionadded:: Carbon
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' system.get_pending_file_rename
+    '''
+    vnames = ('PendingFileRenameOperations', 'PendingFileRenameOperations2')
+    key = r'SYSTEM\CurrentControlSet\Control\Session Manager'
+
+    # If any of the value names exist and have value data set,
+    # then a reboot is pending.
+
+    for vname in vnames:
+        reg_ret = read_value('HKLM', key, vname)
+
+        if reg_ret['success']:
+            log.debug('Found key: %s', key)
+
+            if reg_ret['vdata'] and (reg_ret['vdata'] != '(value not set)'):
+                return True
+        else:
+            log.debug('Unable to access key: %s', key)
+    return False
+
+
+def get_pending_servermanager():
+    '''
+    Determine whether there are pending Server Manager tasks that require a reboot.
+
+    :return: A boolean representing whether there are pending Server Manager tasks.
+    :rtype: bool
+
+    .. versionadded:: Carbon
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' system.get_pending_servermanager
+    '''
+    vname = 'CurrentRebootAttempts'
+    key = r'SOFTWARE\Microsoft\ServerManager'
+
+    # There are situations where it's possible to have '(value not set)' as
+    # the value data, and since an actual reboot wont be pending in that
+    # instance, just catch instances where we try unsuccessfully to cast as int.
+
+    reg_ret = read_value('HKLM', key, vname)
+
+    if reg_ret['success']:
+        log.debug('Found key: %s', key)
+
+        try:
+            if int(reg_ret['vdata']) > 0:
+                return True
+        except ValueError:
+            pass
+    else:
+        log.debug('Unable to access key: %s', key)
+    return False
+
+
+def get_pending_update():
+    '''
+    Determine whether there are pending updates that require a reboot.
+
+    :return: A boolean representing whether there are pending updates.
+    :rtype: bool
+
+    .. versionadded:: Carbon
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' system.get_pending_update
+    '''
+    vname = '(Default)'
+    key = r'SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired'
+
+    reg_ret = read_value('HKLM', key, vname)
+
+    # So long as the registry key exists, a reboot is pending.
+    if reg_ret['success']:
+        log.debug('Found key: %s', key)
+        return True
+    else:
+        log.debug('Unable to access key: %s', key)
+    return False
+
+
+def get_pending_reboot():
+    '''
+    Determine whether there is a reboot pending.
+
+    :return: A boolean representing whether reboots are pending.
+    :rtype: bool
+
+    .. versionadded:: Carbon
+    
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' system.get_pending_reboot
+    '''
+
+    # Order the checks for reboot pending in most to least likely.
+    checks = (get_pending_update, get_pending_file_rename, get_pending_servermanager,
+              get_pending_component_servicing, get_pending_computer_name,
+              get_pending_domain_join)
+
+    for check in checks:
+        if check():
+            return True
+
+    return False

--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -1146,7 +1146,7 @@ def get_pending_reboot():
     :rtype: bool
 
     .. versionadded:: Carbon
-    
+
     CLI Example:
 
     .. code-block:: bash


### PR DESCRIPTION
### What does this PR do?
- Adds functions for checking conditions which indicate a pending reboot to the win_system execution module (NOTE: if this functionality makes more sense being broken out as a separate module rather than being part of win_system, I'm happy to do so).
- Minor pylint fix for code alignment in some of the existing functions.
### What issues does this PR fix or reference?
- None.
### Previous Behavior
- The functionality only existed to check for possible pending reboots due to a computer rename via _win_system.get_pending_computer_name_, but not in other instances which may indicate whether a reboot may be pending.
### New Behavior
- Adds functions for checking conditions which indicate a pending reboot to the win_system execution module.
- Minor pylint fix for code alignment in some of the existing functions.
### Tests written?

No
