### PR TITLE
fixes issue #32748

### DIFF
--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -329,7 +329,7 @@ def mounted(name,
                     # convert uid/gid to numeric value from user/group name
                     name_id_opts = {'uid': 'user.info',
                                     'gid': 'group.info'}
-                    if opt.split('=')[0] in name_id_opts:
+                    if opt.split('=')[0] in name_id_opts and len(opt.split('=')) > 1:
                         _givenid = opt.split('=')[1]
                         _param = opt.split('=')[0]
                         _id = _givenid


### PR DESCRIPTION
### What does this PR do?

This PR fixes #32748 
### What issues does this PR fix or reference?
### Previous Behavior

uid=xxx
uid

Both of these string split at '=' will have chunk 0 match 'uid', it was assumed that there always was a chunk 1 which is not the case if using mount_invisible_keys.
### New Behavior

Don't make the assumption and check if len() is bigger than 1
### Tests written?

No
