### PR TITLE
Including name per-remote config option in example

### DIFF
--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -313,7 +313,12 @@ tremendous amount of customization. Here's some example usage:
       - https://foo.com/foo.git
       - https://foo.com/bar.git:
         - root: salt
-        - mountpoint: salt://foo/bar/baz
+        - mountpoint: salt://bar
+        - base: salt-base
+      - https://foo.com/bar.git:
+        - name: second_bar_repo
+        - root: other/salt
+        - mountpoint: salt://other/bar
         - base: salt-base
       - http://foo.com/baz.git:
         - root: salt/states
@@ -330,26 +335,32 @@ tremendous amount of customization. Here's some example usage:
        with a colon.
 
     2. Per-remote configuration parameters are named like the global versions,
-       with the ``gitfs_`` removed from the beginning.
+       with the ``gitfs_`` removed from the beginning. The exception being the
+       ``name`` parameter which is only available to Per-remote configurations.
 
 In the example configuration above, the following is true:
 
-1. The first and third gitfs remotes will use the ``develop`` branch/tag as the
-   ``base`` environment, while the second one will use the ``salt-base``
+1. The first and fourth gitfs remotes will use the ``develop`` branch/tag as the
+   ``base`` environment, while the second and third will use the ``salt-base``
    branch/tag as the ``base`` environment.
 
 2. The first remote will serve all files in the repository. The second
    remote will only serve files from the ``salt`` directory (and its
-   subdirectories), while the third remote will only serve files from the
-   ``salt/states`` directory (and its subdirectories).
+   subdirectories). The third remote will only server files from the
+   ``other/salt`` directory (and its subdirectorys), while the fourth remote
+   will only serve files from the ``salt/states`` directory (and its
+   subdirectories).
 
-3. The files from the second remote will be located under
-   ``salt://foo/bar/baz``, while the files from the first and third remotes
-   will be located under the root of the Salt fileserver namespace
-   (``salt://``).
+3. The first and fourth remotes will have files located under the root of the
+   Salt fileserver namespace (``salt://``). The files from the second remote
+   will be located under ``salt://bar``, while the files from the third remote
+   will be located under ``salt://other/bar``.
 
-4. The third remote overrides the default behavior of :ref:`not authenticating to
-   insecure (non-HTTPS) remotes <gitfs-insecure-auth>`.
+4. The second and third remotes reference the same repository and unique names
+   need to be declared for duplicate gitfs remotes.
+
+5. The fourth remote overrides the default behavior of :ref:`not authenticating
+   to insecure (non-HTTPS) remotes <gitfs-insecure-auth>`.
 
 Serving from a Subdirectory
 ===========================


### PR DESCRIPTION
### What does this PR do?

Add documentation and update example to include gitfs per-remote parameter `name`.
### What issues does this PR fix or reference?

NA
### Previous Behavior

I was adding `gitfs` remotes in the saltmaster config and needed to reference the same repository in two different directory paths. I received the following error from master after restart which led me to discover the `name` parameter for per-remote configurations:

``` bash
[salt.utils.gitfs ][CRITICAL][32481] The following gitfs remotes have conflicting cachedirs: ssh://github.com/somerepo/salt, ssh://github.com/somerepo/salt. Resolve this using a per-remote parameter called 'name'.
[salt.master      ][CRITICAL][32481] Failed to load gitfs
```
### New Behavior

Documentation now shows that you can use the `name` parameter for duplicate `gitfs` remotes.
### Tests written?

No
