### PR TITLE
#32707: add an top level dir exception to recursive setting of attrib…

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1823,6 +1823,7 @@ def directory(name,
               force=False,
               backupname=None,
               allow_symlink=True,
+              children_only=False,
               **kwargs):
     '''
     Ensure that a named directory is present and has the right perms
@@ -1935,6 +1936,11 @@ def directory(name,
         argument.
 
         .. versionadded:: 2014.7.0
+
+    children_only : False
+        If children_only is True the base of a path is excluded when performing
+        a recursive operation. In case of /path/to/base, base will be ignored
+        while all of /path/to/base/* are still operated on.
     '''
     name = os.path.expanduser(name)
     ret = {'name': name,
@@ -2049,7 +2055,6 @@ def directory(name,
 
     # issue 32707: skip this __salt__['file.check_perms'] call if children_only == True
     # Check permissions
-    children_only = True
     if not children_only:
         ret, perms = __salt__['file.check_perms'](name,
                                                   ret,

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2146,8 +2146,12 @@ def directory(name,
             ret['changes']['removed'] = removed
             ret['comment'] = 'Files cleaned from directory {0}'.format(name)
 
+    # issue 32707: reflect children_only selection in comments
     if not ret['comment']:
-        ret['comment'] = 'Directory {0} updated'.format(name)
+        if children_only:
+            ret['comment'] = 'Directory {0}/* updated'.format(name)
+        else:
+            ret['comment'] = 'Directory {0} updated'.format(name)
 
     if __opts__['test']:
         ret['comment'] = 'Directory {0} not updated'.format(name)

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2047,13 +2047,16 @@ def directory(name,
     if not os.path.isdir(name):
         return _error(ret, 'Failed to create directory {0}'.format(name))
 
+    # issue 32707: skip this __salt__['file.check_perms'] call if children_only == True
     # Check permissions
-    ret, perms = __salt__['file.check_perms'](name,
-                                              ret,
-                                              user,
-                                              group,
-                                              dir_mode,
-                                              follow_symlinks)
+    children_only = True
+    if not children_only:
+        ret, perms = __salt__['file.check_perms'](name,
+                                                  ret,
+                                                  user,
+                                                  group,
+                                                  dir_mode,
+                                                  follow_symlinks)
 
     if recurse or clean:
         walk_l = list(os.walk(name))  # walk path only once and store the result


### PR DESCRIPTION
### What does this PR do?

Provides a rough POC of what the OP requested in issue 32707.
### What issues does this PR fix or reference?
#32707
### Previous Behavior

When recursively controlling / setting attributes of a hierarchy, the top level directory was included.
### New Behavior

When setting a boolean, children_only, the top level directory is excluded from the operations while all the children are still controlled / modified.
### Tests written?

No, but I did a test run in a development environment.
