### PR TITLE
Support unicode in all GECOS fields on FreeBSD

### DIFF
--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -49,6 +49,7 @@ import salt.ext.six as six
 # Import salt libs
 import salt.utils
 from salt.exceptions import CommandExecutionError
+from salt.utils import locales
 
 log = logging.getLogger(__name__)
 
@@ -81,10 +82,10 @@ def _get_gecos(name):
         # Assign empty strings for any unspecified trailing GECOS fields
         while len(gecos_field) < 4:
             gecos_field.append('')
-        return {'fullname': str(gecos_field[0]),
-                'roomnumber': str(gecos_field[1]),
-                'workphone': str(gecos_field[2]),
-                'homephone': str(gecos_field[3])}
+        return {'fullname': locales.sdecode(gecos_field[0]),
+                'roomnumber': locales.sdecode(gecos_field[1]),
+                'workphone': locales.sdecode(gecos_field[2]),
+                'homephone': locales.sdecode(gecos_field[3])}
 
 
 def _build_gecos(gecos_dict):
@@ -92,7 +93,7 @@ def _build_gecos(gecos_dict):
     Accepts a dictionary entry containing GECOS field names and their values,
     and returns a full GECOS comment string, to be used with pw usermod.
     '''
-    return '{0},{1},{2},{3}'.format(gecos_dict.get('fullname', ''),
+    return u'{0},{1},{2},{3}'.format(gecos_dict.get('fullname', ''),
                                     gecos_dict.get('roomnumber', ''),
                                     gecos_dict.get('workphone', ''),
                                     gecos_dict.get('homephone', ''))
@@ -102,8 +103,7 @@ def _update_gecos(name, key, value):
     '''
     Common code to change a user's GECOS information
     '''
-    if not isinstance(value, six.string_types):
-        value = str(value)
+    value = locales.sdecode_if_string(value)
     pre_info = _get_gecos(name)
     if not pre_info:
         return False
@@ -448,7 +448,7 @@ def get_loginclass(name):
 
     '''
 
-    userinfo = __salt__['cmd.run_stdout']('pw usershow -n {0}'.format(name))
+    userinfo = __salt__['cmd.run_stdout'](['pw', 'usershow', '-n', name])
     userinfo = userinfo.split(':')
 
     return {'loginclass': userinfo[4] if len(userinfo) == 10 else ''}

--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -103,7 +103,8 @@ def _update_gecos(name, key, value):
     '''
     Common code to change a user's GECOS information
     '''
-    value = locales.sdecode_if_string(value)
+    if not isinstance(value, six.string_types):
+        value = str(value)
     pre_info = _get_gecos(name)
     if not pre_info:
         return False

--- a/tests/unit/modules/pw_user_test.py
+++ b/tests/unit/modules/pw_user_test.py
@@ -178,6 +178,10 @@ class PwUserTestCase(TestCase):
         with patch.object(pw_user, '_get_gecos', mock):
             self.assertTrue(pw_user.chfullname('name', 'fullname'))
 
+        mock = MagicMock(return_value={'fullname': u'Unicøde name ①③②'})
+        with patch.object(pw_user, '_get_gecos', mock):
+            self.assertTrue(pw_user.chfullname('name', u'Unicøde name ①③②'))
+
         mock = MagicMock(return_value={'fullname': 'fullname'})
         with patch.object(pw_user, '_get_gecos', mock):
             mock = MagicMock(return_value=None)
@@ -201,6 +205,10 @@ class PwUserTestCase(TestCase):
         mock = MagicMock(return_value=False)
         with patch.object(pw_user, '_get_gecos', mock):
             self.assertFalse(pw_user.chroomnumber('name', 1))
+
+        mock = MagicMock(return_value={'roomnumber': u'Unicøde room ①③②'})
+        with patch.object(pw_user, '_get_gecos', mock):
+            self.assertTrue(pw_user.chroomnumber('name', u'Unicøde room ①③②'))
 
         mock = MagicMock(return_value={'roomnumber': '1'})
         with patch.object(pw_user, '_get_gecos', mock):
@@ -234,6 +242,10 @@ class PwUserTestCase(TestCase):
         with patch.object(pw_user, '_get_gecos', mock):
             self.assertTrue(pw_user.chworkphone('name', 1))
 
+        mock = MagicMock(return_value={'workphone': u'Unicøde phone number ①③②'})
+        with patch.object(pw_user, '_get_gecos', mock):
+            self.assertTrue(pw_user.chworkphone('name', u'Unicøde phone number ①③②'))
+
         mock = MagicMock(return_value={'workphone': '2'})
         with patch.object(pw_user, '_get_gecos', mock):
             mock = MagicMock(return_value=None)
@@ -261,6 +273,10 @@ class PwUserTestCase(TestCase):
         mock = MagicMock(return_value={'homephone': '1'})
         with patch.object(pw_user, '_get_gecos', mock):
             self.assertTrue(pw_user.chhomephone('name', 1))
+
+        mock = MagicMock(return_value={'homephone': u'Unicøde phone number ①③②'})
+        with patch.object(pw_user, '_get_gecos', mock):
+            self.assertTrue(pw_user.chhomephone('name', u'Unicøde phone number ①③②'))
 
         mock = MagicMock(return_value={'homephone': '2'})
         with patch.object(pw_user, '_get_gecos', mock):


### PR DESCRIPTION
### What does this PR do?

Makes the GECOS fields in user.present support Unicode when running under FreeBSD
### What issues does this PR fix or reference?

Fixes #26901 - UnicodeError when user.present fullname contains unicode
Improves on #32630 by extending the fix to also apply to FreeBSD
### Previous Behavior

state.highstate would fail on any non-ascii fullname, with the following stack trace:

```
[ERROR   ] An exception occurred in this state: Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/salt/state.py", line 1626, in call
    **cdata['kwargs'])
  File "/usr/local/lib/python2.7/site-packages/salt/loader.py", line 1492, in wrapper
    return f(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/salt/states/user.py", line 507, in present
    __salt__['user.ch{0}'.format(key)](name, val)
  File "/usr/local/lib/python2.7/site-packages/salt/modules/pw_user.py", line 285, in chfullname
    fullname = str(fullname)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe5' in position 1: ordinal not in range(128)
```
### New Behavior

user.present now supports Unicode in all fields of the GECOS when running under FreeBSD.
### Tests written?

Unit tests added. I also believe the integration test introduced in #32630 covers these changes, and would have caught the error if we had a Jenkins running on FreeBSD.
