### PR TITLE
salt.log.setup: process user args before format

### DIFF
--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -144,8 +144,8 @@ class SaltLogRecord(logging.LogRecord):
 class SaltColorLogRecord(logging.LogRecord):
     def __init__(self, *args, **kwargs):
         logging.LogRecord.__init__(self, *args, **kwargs)
-        reset = TextFormat('reset')
 
+        reset = TextFormat('reset')
         clevel = LOG_COLORS['levels'].get(self.levelname, reset)
         cmsg = LOG_COLORS['msgs'].get(self.levelname, reset)
 
@@ -159,7 +159,7 @@ class SaltColorLogRecord(logging.LogRecord):
         self.colorprocess = '%s[%5s]%s' % (LOG_COLORS['process'],
                                            self.process,
                                            reset)
-        self.colormsg = '%s%s%s' % (cmsg, self.msg, reset)
+        self.colormsg = '%s%s%s' % (cmsg, self.getMessage(), reset)
         # pylint: enable=E1321
 
 

--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -141,9 +141,9 @@ class SaltLogRecord(logging.LogRecord):
         # pylint: enable=E1321
 
 
-class SaltColorLogRecord(logging.LogRecord):
+class SaltColorLogRecord(SaltLogRecord):
     def __init__(self, *args, **kwargs):
-        logging.LogRecord.__init__(self, *args, **kwargs)
+        SaltLogRecord.__init__(self, *args, **kwargs)
 
         reset = TextFormat('reset')
         clevel = LOG_COLORS['levels'].get(self.levelname, reset)


### PR DESCRIPTION
### What does this PR do?

Process log message arguments in colorized console messages.

``` py
def secret_handler(sec, num):
    if num > 1337:
        log.debug('too many %s', 'secrets')
```
### Previous Behavior

```
[DEBUG   ] too many %s
```
### New Behavior

```
[DEBUG   ] too many secrets
```
### Tests written?

No
