### PR TITLE
Use traffic_ctl in the trafficserver state and module.

### DIFF
--- a/salt/modules/trafficserver.py
+++ b/salt/modules/trafficserver.py
@@ -4,7 +4,7 @@ Apache Traffic Server execution module.
 
 .. versionadded:: 2015.8.0
 
-``traffic_line`` is used to execute individual Traffic Server commands and to
+``traffic_ctl`` is used to execute individual Traffic Server commands and to
 script multiple commands in a shell.
 '''
 from __future__ import absolute_import
@@ -22,13 +22,32 @@ log = logging.getLogger(__name__)
 
 
 def __virtual__():
-    if utils.which('traffic_line'):
+    if utils.which('traffic_ctl') or utils.which('traffic_line'):
         return __virtualname__
     return (False, 'trafficserver execution module not loaded: '
-            'traffic_line command not found.')
+            'neither traffic_ctl nor traffic_line was found.')
 
 
 _TRAFFICLINE = utils.which('traffic_line')
+_TRAFFICCTL = utils.which('traffic_ctl')
+
+
+def _traffic_ctl(*args):
+    return ' '.join([_TRAFFICCTL] + args)
+
+
+def _traffic_line(*args):
+    return ' '.join([_TRAFFICLINE] + args)
+
+
+def _statuscmd():
+    if _TRAFFICCTL:
+        cmd = _traffic_ctl('server', 'status')
+    else:
+        cmd = _traffic_line('--status')
+
+    log.debug('Running: %s', cmd)
+    return _subprocess(cmd)
 
 
 def _subprocess(cmd):
@@ -62,7 +81,10 @@ def bounce_cluster():
         salt '*' trafficserver.bounce_cluster
     '''
 
-    cmd = '{0} {1}'.format(_TRAFFICLINE, '-B')
+    if _TRAFFICCTL:
+        cmd = _traffic_ctl('cluster', 'restart')
+    else:
+        cmd = _traffic_line('-B')
     log.debug('Running: %s', cmd)
     return _subprocess(cmd)
 
@@ -72,20 +94,26 @@ def bounce_local(drain=False):
     Bounce Traffic Server on the local node. Bouncing Traffic Server shuts down
     and immediately restarts the Traffic Server node.
 
-    This option modifies the behavior of traffic_line -b and traffic_line -L
-    such that traffic_server is not shut down until the number of active client
-    connections drops to the number given by the
-    proxy.config.restart.active_client_threshold configuration variable.
+    drain
+        This option modifies the restart behavior such that traffic_server
+        is not shut down until the number of active client connections
+        drops to the number given by the
+        proxy.config.restart.active_client_threshold configuration
+        variable.
 
     .. code-block:: bash
 
         salt '*' trafficserver.bounce_local
         salt '*' trafficserver.bounce_local drain=True
     '''
-    if drain:
-        cmd = '{0} {1} {2}'.format(_TRAFFICLINE, '-b', '--drain')
+    if _TRAFFICCTL:
+        cmd = _traffic_ctl('server', 'restart')
     else:
-        cmd = '{0} {1}'.format(_TRAFFICLINE, '-b')
+        cmd = _traffic_line('-b')
+
+    if drain:
+        cmd = '{0} {1}'.format(cmd, '--drain')
+
     log.debug('Running: %s', cmd)
     return _subprocess(cmd)
 
@@ -99,7 +127,11 @@ def clear_cluster():
         salt '*' trafficserver.clear_cluster
     '''
 
-    cmd = '{0} {1}'.format(_TRAFFICLINE, '-C')
+    if _TRAFFICCTL:
+        cmd = _traffic_ctl('metric', 'clear', '--cluster')
+    else:
+        cmd = _traffic_line('-C')
+
     log.debug('Running: %s', cmd)
     return _subprocess(cmd)
 
@@ -113,7 +145,11 @@ def clear_node():
         salt '*' trafficserver.clear_node
     '''
 
-    cmd = '{0} {1}'.format(_TRAFFICLINE, '-c')
+    if _TRAFFICCTL:
+        cmd = _traffic_ctl('metric', 'clear')
+    else:
+        cmd = _traffic_line('-c')
+
     log.debug('Running: %s', cmd)
     return _subprocess(cmd)
 
@@ -128,7 +164,11 @@ def restart_cluster():
         salt '*' trafficserver.restart_cluster
     '''
 
-    cmd = '{0} {1}'.format(_TRAFFICLINE, '-M')
+    if _TRAFFICCTL:
+        cmd = _traffic_ctl('cluster', 'restart', '--manager')
+    else:
+        cmd = _traffic_line('-M')
+
     log.debug('Running: %s', cmd)
     return _subprocess(cmd)
 
@@ -137,20 +177,26 @@ def restart_local(drain=False):
     '''
     Restart the traffic_manager and traffic_server processes on the local node.
 
-    This option modifies the behavior of traffic_line -b and traffic_line -L
-    such that traffic_server is not shut down until the number of active client
-    connections drops to the number given by the
-    proxy.config.restart.active_client_threshold configuration variable.
+    drain
+        This option modifies the restart behavior such that
+        ``traffic_server`` is not shut down until the number of
+        active client connections drops to the number given by the
+        ``proxy.config.restart.active_client_threshold`` configuration
+        variable.
 
     .. code-block:: bash
 
         salt '*' trafficserver.restart_local
         salt '*' trafficserver.restart_local drain=True
     '''
-    if drain:
-        cmd = '{0} {1} {2}'.format(_TRAFFICLINE, '-L', '--drain')
+    if _TRAFFICCTL:
+        cmd = _traffic_ctl('server', 'restart', '--manager')
     else:
-        cmd = '{0} {1}'.format(_TRAFFICLINE, '-L')
+        cmd = _traffic_line('-L')
+
+    if drain:
+        cmd = '{0} {1}'.format(cmd, '--drain')
+
     log.debug('Running: %s', cmd)
     return _subprocess(cmd)
 
@@ -160,20 +206,145 @@ def match_var(regex):
     Display the current values of all performance statistics or configuration
     variables whose names match the given regular expression.
 
+    .. deprecated:: Oxygen
+        Use ``match_metric`` or ``match_config`` instead.
+
     .. code-block:: bash
 
         salt '*' trafficserver.match_var regex
     '''
-    cmd = '{0} {1} {2}'.format(_TRAFFICLINE, '-m', regex)
+    cmd = _traffic_line('-m', regex)
     log.debug('Running: %s', cmd)
+    return _subprocess(cmd)
+
+
+def match_metric(regex):
+    '''
+    Display the current values of all metrics whose names match the
+    given regular expression.
+
+    .. versionadded:: Carbon
+
+    .. code-block:: bash
+
+        salt '*' trafficserver.match_metric regex
+    '''
+    if _TRAFFICCTL:
+        cmd = _traffic_ctl('metric', 'match', regex)
+    else:
+        cmd = _traffic_ctl('-m', regex)
+
+    log.debug('Running: %s', cmd)
+    return _subprocess(cmd)
+
+
+def match_config(regex):
+    '''
+    Display the current values of all configuration variables whose
+    names match the given regular expression.
+
+    .. versionadded:: Carbon
+
+    .. code-block:: bash
+
+        salt '*' trafficserver.match_config regex
+    '''
+    if _TRAFFICCTL:
+        cmd = _traffic_ctl('config', 'match', regex)
+    else:
+        cmd = _traffic_line('-m', regex)
+
+    log.debug('Running: %s', cmd)
+    return _subprocess(cmd)
+
+
+def read_config(*args):
+    '''
+    Read Traffic Server configuration variable definitions.
+
+    .. versionadded:: Carbon
+
+    .. code-block:: bash
+
+        salt '*' trafficserver.read_config proxy.config.http.keep_alive_post_out
+    '''
+
+    ret = {}
+    if _TRAFFICCTL:
+        cmd = _traffic_ctl('config', 'get')
+    else:
+        cmd = _traffic_line('-r')
+
+    try:
+        for arg in args:
+            log.debug('Querying: %s', arg)
+            ret[arg] = _subprocess('{0} {1}'.format(cmd, arg))
+    except KeyError:
+        pass
+
+    return ret
+
+
+def read_metric(*args):
+    '''
+    Read Traffic Server one or more metrics.
+
+    .. versionadded:: Carbon
+
+    .. code-block:: bash
+
+        salt '*' trafficserver.read_metric proxy.process.http.tcp_hit_count_stat
+    '''
+
+    ret = {}
+    if _TRAFFICCTL:
+        cmd = _traffic_ctl('metric', 'get')
+    else:
+        cmd = _traffic_line('-r')
+
+    try:
+        for arg in args:
+            log.debug('Querying: %s', arg)
+            ret[arg] = _subprocess('{0} {1}'.format(cmd, arg))
+    except KeyError:
+        pass
+
+    return ret
+
+
+def set_config(variable, value):
+    '''
+    Set the value of a Traffic Server configuration variable.
+
+    variable
+        Name of a Traffic Server configuration variable.
+
+    value
+        The new value to set.
+
+    .. versionadded:: Carbon
+
+    .. code-block:: bash
+
+        salt '*' trafficserver.set_config proxy.config.http.keep_alive_post_out 0
+    '''
+
+    if _TRAFFICCTL:
+        cmd = _traffic_ctl('config', 'set', variable, value)
+    else:
+        cmd = _traffic_line('-s', variable, '-v', value)
+
+    log.debug('Setting %s to %s', variable, value)
     return _subprocess(cmd)
 
 
 def read_var(*args):
     '''
-    Read variable definitions from the traffic_line command
+    Read variable definitions from the traffic_line command.
 
-    This allows reading arbitrary key=value pairs from within trafficserver
+    .. deprecated:: Oxygen
+        Use ``read_metric`` or ``read_config`` instead. Note that this
+        function does not work for Traffic Server versions >= 7.0.
 
     .. code-block:: bash
 
@@ -197,10 +368,14 @@ def set_var(variable, value):
     '''
     .. code-block:: bash
 
+    .. deprecated:: Oxygen
+        Use ``set_config`` instead. Note that this function does
+        not work for Traffic Server versions >= 7.0.
+
         salt '*' trafficserver.set_var proxy.config.http.server_ports
     '''
 
-    cmd = '{0} {1} {2} {3} {4}'.format(_TRAFFICLINE, '-s', variable, '-v', value)
+    cmd = _traffic_line('-s', variable, '-v', value)
     log.debug('Setting %s to %s', variable, value)
     return _subprocess(cmd)
 
@@ -214,11 +389,16 @@ def shutdown():
         salt '*' trafficserver.shutdown
     '''
 
-    cmd = '{0} {1}'.format(_TRAFFICLINE, '-S')
-    status_cmd = '{0} {1}'.format(_TRAFFICLINE, '--status')
+    # Earlier versions of traffic_ctl do not support
+    # "server stop", so we prefer traffic_line here.
+    if _TRAFFICLINE:
+        cmd = _traffic_line('-S')
+    else:
+        cmd = _traffic_ctl('server', 'stop')
+
     log.debug('Running: %s', cmd)
     _subprocess(cmd)
-    return _subprocess(status_cmd)
+    return _statuscmd()
 
 
 def startup():
@@ -230,11 +410,16 @@ def startup():
         salt '*' trafficserver.start
     '''
 
-    cmd = '{0} {1}'.format(_TRAFFICLINE, '-U')
-    status_cmd = '{0} {1}'.format(_TRAFFICLINE, '--status')
+    # Earlier versions of traffic_ctl do not support
+    # "server start", so we prefer traffic_line here.
+    if _TRAFFICLINE:
+        cmd = _traffic_line('-U')
+    else:
+        cmd = _traffic_ctl('server', 'start')
+
     log.debug('Running: %s', cmd)
     _subprocess(cmd)
-    return _subprocess(status_cmd)
+    return _statuscmd()
 
 
 def refresh():
@@ -250,7 +435,11 @@ def refresh():
         salt '*' trafficserver.refresh
     '''
 
-    cmd = '{0} {1}'.format(_TRAFFICLINE, '-x')
+    if _TRAFFICCTL:
+        cmd = _traffic_ctl('config', 'reload')
+    else:
+        cmd = _traffic_line('-x')
+
     log.debug('Running: %s', cmd)
     return _subprocess(cmd)
 
@@ -263,7 +452,11 @@ def zero_cluster():
 
         salt '*' trafficserver.zero_cluster
     '''
-    cmd = '{0} {1}'.format(_TRAFFICLINE, '-Z')
+    if _TRAFFICCTL:
+        cmd = _traffic_ctl('metric', 'clear', '--cluster')
+    else:
+        cmd = _traffic_line('-Z')
+
     log.debug('Running: %s', cmd)
     return _subprocess(cmd)
 
@@ -276,7 +469,11 @@ def zero_node():
 
         salt '*' trafficserver.zero_cluster
     '''
-    cmd = '{0} {1}'.format(_TRAFFICLINE, '-z')
+    if _TRAFFICCTL:
+        cmd = _traffic_ctl('metric', 'clear')
+    else:
+        cmd = _traffic_line('-z')
+
     log.debug('Running: %s', cmd)
     return _subprocess(cmd)
 
@@ -295,7 +492,11 @@ def offline(path):
         salt '*' trafficserver.offline /path/to/cache
     '''
 
-    cmd = '{0} {1} {2}'.format(_TRAFFICLINE, '--offline', path)
+    if _TRAFFICCTL:
+        cmd = _traffic_ctl('storage', 'offline', path)
+    else:
+        cmd = _traffic_line('--offline', path)
+
     log.debug('Running: %s', cmd)
     return _subprocess(cmd)
 
@@ -309,7 +510,11 @@ def alarms():
         salt '*' trafficserver.alarms
     '''
 
-    cmd = '{0} {1}'.format(_TRAFFICLINE, '--alarms')
+    if _TRAFFICCTL:
+        cmd = _traffic_ctl('alarm', 'list')
+    else:
+        cmd = _traffic_line('--alarms')
+
     log.debug('Running: %s', cmd)
     return _subprocess(cmd)
 
@@ -325,7 +530,11 @@ def clear_alarms(alarm):
         salt '*' trafficserver.clear_alarms [all | #event | name]
     '''
 
-    cmd = '{0} {1} {2}'.format(_TRAFFICLINE, '--clear_alarms', alarm)
+    if _TRAFFICCTL:
+        cmd = _traffic_ctl('alarm', 'clear', alarm)
+    else:
+        cmd = _traffic_line('--clear_alarms', alarm)
+
     log.debug('Running: %s', cmd)
     return _subprocess(cmd)
 
@@ -339,6 +548,4 @@ def status():
         salt '*' trafficserver.status
     '''
 
-    cmd = '{0} {1}'.format(_TRAFFICLINE, '--status')
-    log.debug('Running: %s', cmd)
-    return _subprocess(cmd)
+    return _statuscmd()

--- a/salt/states/trafficserver.py
+++ b/salt/states/trafficserver.py
@@ -11,7 +11,7 @@ def __virtual__():
     '''
     Only load if the Traffic Server module is available in __salt__
     '''
-    return 'trafficserver' if 'trafficserver.set_var' in __salt__ else False
+    return 'trafficserver' if 'trafficserver.set_config' in __salt__ else False
 
 
 def bounce_cluster(name):
@@ -196,20 +196,20 @@ def restart_local(name, drain=False):
         return ret
 
 
-def set_var(name, value):
+def config(name, value):
     '''
-    Set Traffic Server variable values
+    Set Traffic Server configuration variable values.
 
     .. code-block:: yaml
 
         proxy.config.proxy_name:
-          trafficserver.set_var:
+          trafficserver.config:
             - value: cdn.site.domain.tld
 
         OR
 
         traffic_server_setting:
-          trafficserver.set_var:
+          trafficserver.config:
             - name: proxy.config.proxy_name
             - value: cdn.site.domain.tld
 
@@ -226,11 +226,35 @@ def set_var(name, value):
         )
         return ret
 
-    __salt__['trafficserver.set_var'](name, value)
+    __salt__['trafficserver.set_config'](name, value)
 
     ret['result'] = True
     ret['comment'] = 'Configured {0} to {1}'.format(name, value)
     return ret
+
+
+def set_var(name, value):
+    '''
+    Set Traffic Server configuration variable values.
+
+    .. deprecated:: Oxygen
+        Use ``trafficserver.config`` instead.
+
+    .. code-block:: yaml
+
+        proxy.config.proxy_name:
+          trafficserver.set_var:
+            - value: cdn.site.domain.tld
+
+        OR
+
+        traffic_server_setting:
+          trafficserver.set_var:
+            - name: proxy.config.proxy_name
+            - value: cdn.site.domain.tld
+
+    '''
+    return config(name, value)
 
 
 def shutdown(name):


### PR DESCRIPTION
### What does this PR do?

This is an RFC branch for updating the `trafficserver` state and module. It is completely untested; I'm pushing this early to solicit reviews and feedback.

Ping @jacksontj and @cedwards.
### What issues does this PR fix or reference?
#32752
### New Behavior

The `trafficserver` state and module will be compatible with upstream Traffic Server >= 7.0. 
### Tests written?

No. Tests are still TBD.

Traffic Server has deprecated traffic_line some time ago and subsumed
almost all of its functionality into traffic_ctl. This change checks whether
traffic_ctl is available and uses that in preference to traffic_line.

The only missing functionality from traffic_ctl is that of stopping
and starting the traffic_server process.
