### PR TITLE
Update boto_ec2.find_instances() to always return values as described…

### DIFF
--- a/salt/modules/boto_ec2.py
+++ b/salt/modules/boto_ec2.py
@@ -453,8 +453,6 @@ def find_instances(instance_id=None, name=None, tags=None, region=None,
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
-    if not any((instance_id, name, tags)):
-        return []
     try:
         filter_parameters = {'filters': {}}
 


### PR DESCRIPTION
The described (and I believe reasonable and expected) behavior has the function returning all instances if no limiting filters are provided.  The code was mistakenly returning [] explicitly if no filters were passed in.
