### PR TITLE
Add comments as an option for apt in pkgrepo.managed.

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1697,6 +1697,13 @@ def mod_repo(repo, saltenv='base', **kwargs):
         consolidate
             if ``True``, will attempt to de-dup and consolidate sources
 
+        comments
+            Sometimes you want to supply additional information, but not as
+            enabled configuration. Anything supplied for this list will be saved
+            in the repo configuration with a comment marker (#) in front.
+
+            .. versionadded:: 2016.3.1
+
         .. note:: Due to the way keys are stored for APT, there is a known issue
                 where the key won't be updated unless another change is made
                 at the same time.  Keys should be properly added on initial
@@ -1923,6 +1930,8 @@ def mod_repo(repo, saltenv='base', **kwargs):
         if 'comments' in kwargs:
             mod_source.comment = " ".join(str(c) for c in kwargs['comments'])
         sources.list.append(mod_source)
+    elif 'comments' in kwargs:
+        mod_source.comment = " ".join(str(c) for c in kwargs['comments'])
 
     for key in kwargs:
         if key in _MODIFY_OK and hasattr(mod_source, key):

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -364,6 +364,10 @@ def managed(name, ppa=None, **kwargs):
                 reposplit[3:] = sorted(reposplit[3:])
                 if sanitizedsplit != reposplit:
                     needs_update = True
+                if 'comments' in kwargs:
+                    _line = pre[kwarg].split('#')
+                    if str(kwargs['comments']) not in _line:
+                        needs_update = True
             else:
                 if str(sanitizedkwargs[kwarg]) != str(pre[kwarg]):
                     needs_update = True


### PR DESCRIPTION
### What does this PR do?

Adds comments as an option when setting an apt repo file.
### What issues does this PR fix or reference?
#32605
### Previous Behavior

**state**

``` yml
{% set codename = grains.get('lsb_distrib_codename')|lower %}

repository_pgdg:
  pkgrepo.managed:
    - humanname: {{ codename }}-backports
    - file: /etc/apt/sources.list.d/pgdg.list
    - refresh_db: True
    - clean_file: True
    - name: deb http://apt.postgresql.org/pub/repos/apt/ {{ codename }}-pgdg main
    - key_url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
    - comments:
      - 'This is a comment'
```

**repo file**

``` bash
deb http://apt.postgresql.org/pub/repos/apt trusty-pgdg main
deb http://foo.bar.org/pub/repos/apt trusty-pgdg main #This is a comment
```

**result**

``` yml
ubuntu:
----------
          ID: repository_pgdg
    Function: pkgrepo.managed
        Name: deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main
      Result: True
     Comment: Package repo 'deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main' already configured
     Started: 13:52:48.847907
    Duration: 54.242 ms
     Changes:

Summary for ubuntu
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1
```

**repo file**

``` bash
deb http://apt.postgresql.org/pub/repos/apt trusty-pgdg main
deb http://foo.bar.org/pub/repos/apt trusty-pgdg main #This is a comment
```

Note that the file remains unchanged
### New Behavior

``` yml
ubuntu:
----------
          ID: repository_pgdg
    Function: pkgrepo.managed
        Name: deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main
      Result: True
     Comment: Configured package repo 'deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main'
     Started: 13:54:36.299121
    Duration: 18389.816 ms
     Changes:
              ----------
              line:
                  ----------
                  new:
                      deb http://apt.postgresql.org/pub/repos/apt trusty-pgdg main #This is a comment
                  old:
                      deb http://apt.postgresql.org/pub/repos/apt trusty-pgdg main

Summary for ubuntu
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
```

**repo file**

``` bash
deb http://apt.postgresql.org/pub/repos/apt trusty-pgdg main #This is a comment
```

Note that here we are using  `- clean_file: True`. Setting `- clean_file: False` results are:

``` yml
ubuntu:
----------
          ID: repository_pgdg
    Function: pkgrepo.managed
        Name: deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main
      Result: True
     Comment: Configured package repo 'deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main'
     Started: 17:16:07.281609
    Duration: 18201.019 ms
     Changes:
              ----------
              line:
                  ----------
                  new:
                      deb http://apt.postgresql.org/pub/repos/apt trusty-pgdg main #This is a comment
                  old:
                      deb http://apt.postgresql.org/pub/repos/apt trusty-pgdg main

Summary for ubuntu
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
```

**repo file**

``` bash
deb http://apt.postgresql.org/pub/repos/apt trusty-pgdg main #This is a comment
deb http://archive.canonical.com/ubuntu trusty partner #This is a comment
```
### Tests written?

No
