### PR TITLE
Add fetching number of sessions on web backends to haproxy module

### DIFF
--- a/salt/beacons/haproxy.py
+++ b/salt/beacons/haproxy.py
@@ -15,6 +15,7 @@ log = logging.getLogger(__name__)
 
 __virtualname__ = 'haproxy'
 
+
 def __virtual__():
     '''
     Only load the module if haproxyctl module is installed
@@ -24,21 +25,22 @@ def __virtual__():
     else:
         return False
 
+
 def validate(config):
     '''
     Validate the beacon configuration
     '''
-    # Configuration for pkg beacon should be a list
     if not isinstance(config, dict):
         return False, ('Configuration for haproxy beacon must be a dictionary.')
     if 'haproxy' not in config:
         return False, ('Configuration for haproxy beacon requires a list of backends and servers')
     return True, 'Valid beacon configuration'
 
+
 def beacon(config):
     '''
     Check if current number of sessions of a server for a specific haproxy backend
-    is over a defined threshold. 
+    is over a defined threshold.
     .. code-block:: yaml
         beacons:
           haproxy:
@@ -68,4 +70,3 @@ def beacon(config):
                     log.debug('Emit because {0} > {1} for {2} in {3}'.format(scur, threshold, server, backend))
                     ret.append(_server)
     return ret
-

--- a/salt/beacons/haproxy.py
+++ b/salt/beacons/haproxy.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+'''
+Watch current connections of haproxy server backends.
+Fire an event when over a specified threshold.
+
+.. versionadded:: 2016.9.0
+'''
+
+# Import Python libs
+from __future__ import absolute_import
+import logging
+
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = 'haproxy'
+
+def __virtual__():
+    '''
+    Only load the module if haproxyctl module is installed
+    '''
+    if 'haproxy.get_sessions' in __salt__:
+        return __virtualname__
+    else:
+        return False
+
+def validate(config):
+    '''
+    Validate the beacon configuration
+    '''
+    # Configuration for pkg beacon should be a list
+    if not isinstance(config, dict):
+        return False, ('Configuration for haproxy beacon must be a dictionary.')
+    if 'haproxy' not in config:
+        return False, ('Configuration for haproxy beacon requires a list of backends and servers')
+    return True, 'Valid beacon configuration'
+
+def beacon(config):
+    '''
+    Check if current number of sessions of a server for a specific haproxy backend
+    is over a defined threshold. 
+    .. code-block:: yaml
+        beacons:
+          haproxy:
+            - www-backend:
+                threshold: 45
+                servers:
+                  - web1
+                  - web2
+            - interval: 120
+    '''
+    log.debug('haproxy beacon starting')
+    ret = []
+    _validate = validate(config)
+    if not _validate:
+        log.debug('haproxy beacon unable to validate')
+        return ret
+    for backend in config:
+        threshold = config[backend]['threshold']
+        for server in config[backend]['servers']:
+            scur = __salt__['haproxy.get_sessions'](server, backend)
+            if scur:
+                if int(scur) > int(threshold):
+                    _server = {'server': server,
+                               'scur': scur,
+                               'threshold': threshold,
+                               }
+                    log.debug('Emit because {0} > {1} for {2} in {3}'.format(scur, threshold, server, backend))
+                    ret.append(_server)
+    return ret
+

--- a/salt/beacons/haproxy.py
+++ b/salt/beacons/haproxy.py
@@ -3,7 +3,7 @@
 Watch current connections of haproxy server backends.
 Fire an event when over a specified threshold.
 
-.. versionadded:: 2016.9.0
+.. versionadded:: Carbon
 '''
 
 # Import Python libs

--- a/salt/modules/haproxyconn.py
+++ b/salt/modules/haproxyconn.py
@@ -256,3 +256,36 @@ def show_backends(socket='/var/run/haproxy.sock'):
     ha_conn = _get_conn(socket)
     ha_cmd = haproxy.cmds.showBackends()
     return ha_conn.sendCmd(ha_cmd)
+
+def get_sessions(name, backend, socket='/var/run/haproxy.sock'):
+    '''
+    Get number of current session on server in backend (scurr)
+
+    name
+        Server name
+
+    backend
+        haproxy backend
+
+    socket
+        haproxy stats socket
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' haproxy.get_sessions web1.example.com www
+    '''
+    class getStats(haproxy.cmds.Cmd):
+        p_args = ["backend", "server"]
+        cmdTxt = "show stat\r\n"
+        helpText = "Fetch all statistics"
+
+    ha_conn = _get_conn(socket)
+    ha_cmd = getStats(server=name, backend=backend)
+    result = ha_conn.sendCmd(ha_cmd)
+    for line in result.split('\n'):
+        if line.startswith(backend):
+            outCols = line.split(',')
+            if outCols[1] == name:
+                return outCols[4]

--- a/salt/modules/haproxyconn.py
+++ b/salt/modules/haproxyconn.py
@@ -257,9 +257,12 @@ def show_backends(socket='/var/run/haproxy.sock'):
     ha_cmd = haproxy.cmds.showBackends()
     return ha_conn.sendCmd(ha_cmd)
 
+
 def get_sessions(name, backend, socket='/var/run/haproxy.sock'):
     '''
-    Get number of current session on server in backend (scurr)
+    .. versionadded:: Carbon
+
+    Get number of current sessions on server in backend (scur)
 
     name
         Server name


### PR DESCRIPTION
### What does this PR do?

Adds fetching the number of current sessions (scur) for web backends to the haproxy module
Also adds a haproxy beacon allowing for triggering events when scur is over a specified threshold
### Tests written?

No
