### PR TITLE
HipChat State & Returner to use api_url param

### DIFF
--- a/salt/returners/hipchat_return.py
+++ b/salt/returners/hipchat_return.py
@@ -9,6 +9,7 @@ The following fields can be set in the minion conf file::
     hipchat.room_id (required)
     hipchat.api_key (required)
     hipchat.api_version (required)
+    hipchat.api_url (optional)
     hipchat.from_name (required)
     hipchat.color (optional)
     hipchat.notify (optional)
@@ -22,6 +23,7 @@ the default location::
     hipchat.room_id
     hipchat.api_key
     hipchat.api_version
+    hipchat.api_url
     hipchat.from_name
 
 Hipchat settings may also be configured as:
@@ -30,6 +32,7 @@ Hipchat settings may also be configured as:
 
     hipchat:
       room_id: RoomName
+      api_url: https://hipchat.myteam.con
       api_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       api_version: v1
       from_name: user@email.com
@@ -161,6 +164,7 @@ def _query(function,
     '''
     HipChat object method function to construct and execute on the API URL.
 
+    :param api_url:     The HipChat API URL.
     :param api_key:     The HipChat api key.
     :param function:    The HipChat api function to perform.
     :param api_version: The HipChat api version (v1 or v2).
@@ -273,6 +277,7 @@ def _send_message(room_id,
     :param room_id:     The room id or room name, either will work.
     :param message:     The message to send to the HipChat room.
     :param from_name:   Specify who the message is from.
+    :param api_url:     The HipChat API URL, if not specified in the configuration.
     :param api_key:     The HipChat api key, if not specified in the configuration.
     :param api_version: The HipChat api version, if not specified in the configuration.
     :param color:       The color for the message, default: yellow.
@@ -354,14 +359,14 @@ def returner(ret):
     else:
         color = 'red'
 
-    hipchat = _send_message(_options.get('room_id'),
-                            message,
-                            _options.get('from_name'),
-                            _options.get('api_key'),
-                            _options.get('api_version'),
-                            _options.get('api_url'),
-                            color,
-                            _options.get('notify'))
+    hipchat = _send_message(_options.get('room_id'),  # room_id
+                            message,  # message
+                            _options.get('from_name'),  # from_name
+                            api_key=_options.get('api_key'),
+                            api_version=_options.get('api_version'),
+                            api_url=_options.get('api_url'),
+                            color=color,
+                            notify=_options.get('notify'))
 
     return hipchat
 
@@ -377,11 +382,11 @@ def event_return(events):
         # Pre-process messages to apply individualized colors for various
         # event types.
         log.trace('Hipchat returner received event: {0}'.format(event))
-        _send_message(_options.get('room_id'),
-                      event['data'],
-                      _options.get('from_name'),
-                      _options.get('api_key'),
-                      _options.get('api_version'),
-                      _options.get('api_url'),
-                      _options.get('color'),
-                      _options.get('notify'))
+        _send_message(_options.get('room_id'),  # room_id
+                      event['data'],  # message
+                      _options.get('from_name'),  # from_name
+                      api_key=_options.get('api_key'),
+                      api_version=_options.get('api_version'),
+                      api_url=_options.get('api_url'),
+                      color=_options.get('color'),
+                      notify=_options.get('notify'))

--- a/salt/states/hipchat.py
+++ b/salt/states/hipchat.py
@@ -5,6 +5,8 @@ Send a message to Hipchat
 
 This state is useful for sending messages to Hipchat during state runs.
 
+The property api_url is optional. By defaul will use the public HipChat API at https://api.hipchat.com
+
 .. versionadded:: 2015.5.0
 
 .. code-block:: yaml
@@ -14,6 +16,7 @@ This state is useful for sending messages to Hipchat during state runs.
         - room_id: 123456
         - from_name: SuperAdmin
         - message: 'This state was executed successfully.'
+        - api_url: https://hipchat.myteam.com
         - api_key: peWcBiMOS9HrZG15peWcBiMOS9HrZG15
         - api_version: v1
 
@@ -39,6 +42,7 @@ def send_message(name,
                  room_id,
                  from_name,
                  message,
+                 api_url=None,
                  api_key=None,
                  api_version=None,
                  message_color='yellow',
@@ -53,6 +57,7 @@ def send_message(name,
             - room_id: 123456
             - from_name: SuperAdmin
             - message: 'This state was executed successfully.'
+            - api_url: https://hipchat.myteam.com
             - api_key: peWcBiMOS9HrZG15peWcBiMOS9HrZG15
             - api_version: v1
             - color: green
@@ -74,6 +79,11 @@ def send_message(name,
         The message that is to be sent to the Hipchat room.
 
     The following parameters are optional:
+
+    api_url
+        The API URl to be used.
+        If not specified here or in the configuration options of master or minion,
+        will use the public HipChat API: https://api.hipchat.com
 
     api_key
         The api key for Hipchat to use for authentication,
@@ -116,6 +126,7 @@ def send_message(name,
         room_id=room_id,
         message=message,
         from_name=from_name,
+        api_url=api_url,
         api_key=api_key,
         api_version=api_version,
         color=message_color,


### PR DESCRIPTION
### What does this PR do?

Following #32708, I adapted the HipChat State and Returner to make use of the optional parameter _api_url_. As in my pervious PR, if _api_url_ is not specified, will use the public API.
### What issues does this PR fix or reference?

Adds one more config option.
### Tests written?

No
