### PR TITLE
`salt-cloud -u` downloads stable version from bootstrap.saltstack.com by default

### DIFF
--- a/doc/ref/cli/salt-cloud.rst
+++ b/doc/ref/cli/salt-cloud.rst
@@ -89,7 +89,7 @@ Execution Options
 
 .. option:: -u, --update-bootstrap
 
-    Update salt-bootstrap to the latest develop version on GitHub.
+    Update salt-bootstrap to the latest stable bootstrap release.
 
 .. option:: -y, --assume-yes
 

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -2407,17 +2407,14 @@ def cache_nodes_ip(opts, base=None):
 
 
 def update_bootstrap(config, url=None):
-
     '''
     Update the salt-bootstrap script
 
-        url can be either:
+    url can be one of:
 
-            - The URL to fetch the bootstrap script from
-            - The absolute path to the bootstrap
-            - The content of the bootstrap script
-
-
+        - The URL to fetch the bootstrap script from
+        - The absolute path to the bootstrap
+        - The content of the bootstrap script
     '''
     default_url = config.get('bootstrap_script_url',
                              'https://bootstrap.saltstack.com')

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1173,8 +1173,7 @@ class ExecutionOptionsMixIn(object):
             '-u', '--update-bootstrap',
             default=False,
             action='store_true',
-            help='Update salt-bootstrap to the latest develop version on '
-                 'GitHub.'
+            help='Update salt-bootstrap to the latest stable bootstrap release.'
         )
         group.add_option(
             '-y', '--assume-yes',


### PR DESCRIPTION
### What does this PR do?

Fix incorrect help documentation on `salt-cloud -u`.  The download location can be configured with `bootstrap_script_url:  https://bootstrap.saltstack.com/develop`, etc.
### Tests written?

No
