### PR TITLE
Add pyvmomi version warning to Getting Started with VMware docs

### DIFF
--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -23,6 +23,18 @@ This package can be installed using `pip` or `easy_install`:
     pip install pyvmomi
     easy_install pyvmomi
 
+.. note::
+
+    Version 6.0 of pyVmomi has some problems with SSL error handling on certain
+    versions of Python. If using version 6.0 of pyVmomi, the machine that you
+    are running the proxy minion process from must have either Python 2.7.9 or
+    newer This is due to an upstream dependency in pyVmomi 6.0 that is not supported
+    in Python version 2.6 to 2.7.8. If the version of Python running the salt-cloud
+    command is not in the supported range, you will need to install an earlier version
+    of pyVmomi. See `Issue #29537`_ for more information.
+
+.. _Issue #29537: https://github.com/saltstack/salt/issues/29537
+
 
 Configuration
 =============


### PR DESCRIPTION
### What does this PR do?

Adds the pyvmomi version warning to the Getting Started with VMware docs. Same warning is on regular vmware docs and esxi tutorial.
### What issues does this PR fix or reference?

Fixes #32824
