### PR TITLE
backport PR #32732 for issue #23714

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -4024,7 +4024,8 @@ def copy(
             hash1 = salt.utils.get_hash(name)
             hash2 = salt.utils.get_hash(source)
             if hash1 == hash2:
-                changed = False
+                changed = True
+                ret['comment'] = ' '.join([ret['comment'], '- files are identical but force flag is set'])
         if not force:
             changed = False
         elif not __opts__['test'] and changed:


### PR DESCRIPTION
### What does this PR do?

backport of #32732 to fix issue #23714 -- when force=True, copy the file even if it already exists
### What issues does this PR fix or reference?
#23714
### Previous Behavior

if force=True, file.copy state did not copy the file if the file existed and the hashes matched
### New Behavior

If force=True and the dest file exists and hash matches the source, still copy the file
### Tests written?

No
