### PR TITLE
backport PR #32732 to 2015.5 fixes #23714

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3626,7 +3626,8 @@ def copy(
             hash1 = salt.utils.get_hash(name)
             hash2 = salt.utils.get_hash(source)
             if hash1 == hash2:
-                changed = False
+                changed = True
+                ret['comment'] = ' '.join([ret['comment'], '- files are identical but force flag is set'])
         if not force:
             changed = False
         elif not __opts__['test'] and changed:


### PR DESCRIPTION
### What does this PR do?

backport of PR #32732 to 2015.5 to fix #23714 
### What issues does this PR fix or reference?
#23714
### Previous Behavior

If force=True, file.copy would not copy the file if the destination file existed and hash matched the source
### New Behavior

If force=True and destination file exists, file will be copied even if hashes match
### Tests written?

No
