### PR TITLE
Skip some netapi tests on MacOS

### DIFF
--- a/tests/integration/netapi/rest_cherrypy/app_pam_test.py
+++ b/tests/integration/netapi/rest_cherrypy/app_pam_test.py
@@ -17,6 +17,7 @@ ensure_in_syspath('../../../')
 from tests.utils import BaseRestCherryPyTest
 
 # Import Salt Libs
+import salt.utils
 from tests import integration
 
 # Import 3rd-party libs
@@ -39,6 +40,7 @@ AUTH_CREDS = {
     'eauth': 'pam'}
 
 
+@skipIf(salt.utils.is_darwin(), 'Skip until user passwords can be automated on MacOS')
 @skipIf(HAS_CHERRYPY is False, 'CherryPy not installed')
 class TestAuthPAM(BaseRestCherryPyTest, integration.ModuleCase):
     '''


### PR DESCRIPTION
### What does this PR do?

User passwords cannot be automatically added/updated on MacOS, which is necessary for the tests that are skipped.
### Tests written?

No
