### PR TITLE
backport #32732 to 2016.3

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -4109,7 +4109,8 @@ def copy(
             hash1 = salt.utils.get_hash(name)
             hash2 = salt.utils.get_hash(source)
             if hash1 == hash2:
-                changed = False
+                changed = True
+                ret['comment'] = ' '.join([ret['comment'], '- files are identical but force flag is set'])
         if not force:
             changed = False
         elif not __opts__['test'] and changed:


### PR DESCRIPTION
### What does this PR do?

backport of #32732 to 2016.3
### What issues does this PR fix or reference?
#23714 -- force flag not being respected
### Previous Behavior

if force=true and destination file existed and file hash matched source, file was not copied
### New Behavior

source file is copied to destination even if it already exists and hashes match
### Tests written?

No
