### PR TITLE
fix some shell tests for MacOS

### DIFF
--- a/salt/modules/mac_user.py
+++ b/salt/modules/mac_user.py
@@ -140,7 +140,7 @@ def delete(name, remove=False, force=False):
 
     .. code-block:: bash
 
-        salt '*' user.delete foo
+        salt '*' user.delete name remove=True force=True
     '''
     if salt.utils.contains_whitespace(name):
         raise SaltInvocationError('Username cannot contain whitespace')

--- a/tests/integration/shell/enabled.py
+++ b/tests/integration/shell/enabled.py
@@ -33,7 +33,7 @@ class EnabledTest(integration.ModuleCase):
         '''
         enabled_ret = '3\nsaltines'  # the result of running self.cmd in a shell
         ret = self.run_function('cmd.run', [self.cmd])
-        self.assertEqual(ret, enabled_ret)
+        self.assertEqual(ret.strip(), enabled_ret)
 
     def test_shell_disabled(self):
         '''


### PR DESCRIPTION
### What does this PR do?
- auth.pam integration test: use unhashed pw for MacOS
- shell tests: strip whitespace from shell return
- modules.mac_user.delete: update example for integration test
### What issues does this PR fix or reference?
#31690
### Tests written?

Yes
