### PR TITLE
Add initscripts, SystemD service units and environment files for Debian

### DIFF
--- a/pkg/deb/salt-api.environment
+++ b/pkg/deb/salt-api.environment
@@ -1,0 +1,4 @@
+# Controls whether or not service is restarted automatically when it exits.
+# See the manpage for systemd.service(5) for possible values for the "Restart="
+# option.
+RESTART='no'

--- a/pkg/deb/salt-api.init
+++ b/pkg/deb/salt-api.init
@@ -1,0 +1,99 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          salt-api
+# Required-Start:    $remote_fs $network
+# Required-Stop:     $remote_fs $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: REST API for Salt
+# Description:       salt-api provides a REST interface to the Salt master
+### END INIT INFO
+
+# Author: Michael Prokop <mika@debian.org>
+
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+DESC="REST API for Salt"
+NAME=salt-api
+DAEMON=/usr/bin/salt-api
+DAEMON_ARGS="-d"
+PIDFILE=/var/run/$NAME.pid
+SCRIPTNAME=/etc/init.d/$NAME
+
+# Exit if the package is not installed
+[ -x "$DAEMON" ] || exit 0
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+. /lib/init/vars.sh
+. /lib/lsb/init-functions
+
+do_start() {
+    pid=$(pidofproc -p $PIDFILE $DAEMON)
+    if [ -n "$pid" ] ; then
+        log_begin_msg "$DESC already running."
+        log_end_msg 0
+        exit 0
+    fi
+
+    log_daemon_msg "Starting salt-api daemon: "
+    start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -- $DAEMON_ARGS
+    log_end_msg $?
+}
+
+do_stop() {
+    log_begin_msg "Stopping $DESC ..."
+    start-stop-daemon --stop --retry TERM/5 --quiet --oknodo --pidfile $PIDFILE
+    RC=$?
+    [ $RC -eq 0 ] && rm -f $PIDFILE
+    log_end_msg $RC
+}
+
+case "$1" in
+    start)
+        [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+        do_start
+        case "$?" in
+            0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+              2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+        esac
+        ;;
+    stop)
+        [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+        do_stop
+        case "$?" in
+            0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+              2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+        esac
+        ;;
+    status)
+        status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+        ;;
+    #reload)
+        # not implemented
+        #;;
+    restart|force-reload)
+        log_daemon_msg "Restarting $DESC" "$NAME"
+        do_stop
+        case "$?" in
+          0|1)
+              do_start
+              case "$?" in
+                  0) log_end_msg 0 ;;
+                  1) log_end_msg 1 ;; # Old process is still running
+                  *) log_end_msg 1 ;; # Failed to start
+              esac
+              ;;
+          *)
+              # Failed to stop
+              log_end_msg 1
+              ;;
+        esac
+        ;;
+    *)
+        echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+        exit 3
+        ;;
+esac
+
+exit 0

--- a/pkg/deb/salt-api.service
+++ b/pkg/deb/salt-api.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=REST API for Salt
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/default/salt-api
+LimitNOFILE=8192
+Type=simple
+NotifyAccess=all
+ExecStart=/usr/bin/salt-api
+KillMode=process
+Restart=$RESTART
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/deb/salt-master.environment
+++ b/pkg/deb/salt-master.environment
@@ -1,0 +1,4 @@
+# Controls whether or not service is restarted automatically when it exits.
+# See the manpage for systemd.service(5) for possible values for the "Restart="
+# option.
+RESTART='no'

--- a/pkg/deb/salt-master.init
+++ b/pkg/deb/salt-master.init
@@ -1,0 +1,112 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          salt-master
+# Required-Start:    $remote_fs $network
+# Required-Stop:     $remote_fs $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: The Salt Master daemon
+# Description:       The Salt Master is the central server (management
+#                    component) to which all Salt Minions connect
+### END INIT INFO
+
+# Author: Michael Prokop <mika@debian.org>
+
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+DESC="The Salt Master daemon"
+NAME=salt-master
+DAEMON=/usr/bin/salt-master
+DAEMON_ARGS="-d"
+PIDFILE=/var/run/$NAME.pid
+SCRIPTNAME=/etc/init.d/$NAME
+
+# Exit if the package is not installed
+[ -x "$DAEMON" ] || exit 0
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+. /lib/lsb/init-functions
+
+do_start() {
+    # Return
+    #   0 if daemon has been started
+    #   1 if daemon was already running
+    #   2 if daemon could not be started
+    pid=$(pidofproc -p $PIDFILE $DAEMON)
+    if [ -n "$pid" ] ; then
+        return 1
+    fi
+
+    start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \
+            $DAEMON_ARGS \
+            || return 2
+}
+
+do_stop() {
+    # Return
+    #   0 if daemon has been stopped
+    #   1 if daemon was already stopped
+    #   2 if daemon could not be stopped
+    #   other if a failure occurred
+    pids=$(pidof -x $DAEMON)
+    if [ $? -eq 0 ] ; then
+       echo $pids | xargs kill 2&1> /dev/null
+       RETVAL=0
+    else
+       RETVAL=1
+    fi
+
+    [ "$RETVAL" = 2 ] && return 2
+    rm -f $PIDFILE
+    return "$RETVAL"
+}
+
+case "$1" in
+    start)
+        [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+        do_start
+        case "$?" in
+            0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+              2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+        esac
+        ;;
+    stop)
+        [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+        do_stop
+        case "$?" in
+            0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+              2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+        esac
+        ;;
+    status)
+        status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+        ;;
+    #reload)
+        # not implemented
+        #;;
+    restart|force-reload)
+        log_daemon_msg "Restarting $DESC" "$NAME"
+        do_stop
+        case "$?" in
+          0|1)
+              do_start
+              case "$?" in
+                  0) log_end_msg 0 ;;
+                  1) log_end_msg 1 ;; # Old process is still running
+                  *) log_end_msg 1 ;; # Failed to start
+              esac
+              ;;
+          *)
+              # Failed to stop
+              log_end_msg 1
+              ;;
+        esac
+        ;;
+    *)
+        echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+        exit 3
+        ;;
+esac
+
+exit 0

--- a/pkg/deb/salt-master.service
+++ b/pkg/deb/salt-master.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=The Salt Master daemon
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/default/salt-master
+LimitNOFILE=16384
+Type=simple
+NotifyAccess=all
+ExecStart=/usr/bin/salt-master
+KillMode=process
+Restart=$RESTART
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/deb/salt-minion.environment
+++ b/pkg/deb/salt-minion.environment
@@ -1,0 +1,4 @@
+# Controls whether or not service is restarted automatically when it exits.
+# See the manpage for systemd.service(5) for possible values for the "Restart="
+# option.
+RESTART='no'

--- a/pkg/deb/salt-minion.init
+++ b/pkg/deb/salt-minion.init
@@ -1,0 +1,107 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          salt-minion
+# Required-Start:    $remote_fs $network
+# Required-Stop:     $remote_fs $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: The Salt Minion daemon
+# Description:       The Salt Minion is the agent component of Salt. It listens
+#                    for instructions from the Master, runs jobs, and returns
+#                    results back to the Salt Master
+### END INIT INFO
+
+# Author: Michael Prokop <mika@debian.org>
+
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+DESC="The Salt Minion daemon"
+NAME=salt-minion
+DAEMON=/usr/bin/salt-minion
+DAEMON_ARGS="-d"
+PIDFILE=/var/run/$NAME.pid
+SCRIPTNAME=/etc/init.d/$NAME
+
+# Exit if the package is not installed
+[ -x "$DAEMON" ] || exit 0
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+. /lib/lsb/init-functions
+
+do_start() {
+    # Return
+    #   0 if daemon has been started
+    #   1 if daemon was already running
+    #   2 if daemon could not be started
+    pid=$(pidofproc -p $PIDFILE $DAEMON)
+    if [ -n "$pid" ] ; then
+        return 1
+    fi
+
+    start-stop-daemon --start --quiet --background --pidfile $PIDFILE --exec $DAEMON -- \
+            $DAEMON_ARGS \
+            || return 2
+}
+
+do_stop() {
+    # Return
+    #   0 if daemon has been stopped
+    #   1 if daemon was already stopped
+    #   2 if daemon could not be stopped
+    #   other if a failure occurred
+    start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --name $NAME
+    RETVAL="$?"
+    [ "$RETVAL" = 2 ] && return 2
+    rm -f $PIDFILE
+    return "$RETVAL"
+}
+
+case "$1" in
+    start)
+        [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+        do_start
+        case "$?" in
+            0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+              2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+        esac
+        ;;
+    stop)
+        [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+        do_stop
+        case "$?" in
+            0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+              2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+        esac
+        ;;
+    status)
+        status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+        ;;
+    #reload)
+        # not implemented
+        #;;
+    restart|force-reload)
+        log_daemon_msg "Restarting $DESC" "$NAME"
+        do_stop
+        case "$?" in
+          0|1)
+              do_start
+              case "$?" in
+                  0) log_end_msg 0 ;;
+                  1) log_end_msg 1 ;; # Old process is still running
+                  *) log_end_msg 1 ;; # Failed to start
+              esac
+              ;;
+          *)
+              # Failed to stop
+              log_end_msg 1
+              ;;
+        esac
+        ;;
+    *)
+        echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+        exit 3
+        ;;
+esac
+
+exit 0

--- a/pkg/deb/salt-minion.service
+++ b/pkg/deb/salt-minion.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=The Salt Minion daemon
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/default/salt-minion
+Type=simple
+LimitNOFILE=8192
+ExecStart=/usr/bin/salt-minion
+KillMode=process
+Restart=$RESTART
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/deb/salt-syndic.environment
+++ b/pkg/deb/salt-syndic.environment
@@ -1,0 +1,4 @@
+# Controls whether or not service is restarted automatically when it exits.
+# See the manpage for systemd.service(5) for possible values for the "Restart="
+# option.
+RESTART='no'

--- a/pkg/deb/salt-syndic.init
+++ b/pkg/deb/salt-syndic.init
@@ -1,0 +1,107 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          salt-syndic
+# Required-Start:    $remote_fs $network
+# Required-Stop:     $remote_fs $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: The Salt Syndic daemon
+# Description:       The Salt Syndic is a master daemon which can receive
+#                    instructions from a higher-level Salt Master, allowing
+#                    for tiered organization of your Salt infrastructure
+### END INIT INFO
+
+# Author: Michael Prokop <mika@debian.org>
+
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+DESC="The Salt Syndic daemon"
+NAME=salt-syndic
+DAEMON=/usr/bin/salt-syndic
+DAEMON_ARGS="-d"
+PIDFILE=/var/run/$NAME.pid
+SCRIPTNAME=/etc/init.d/$NAME
+
+# Exit if the package is not installed
+[ -x "$DAEMON" ] || exit 0
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+. /lib/lsb/init-functions
+
+do_start() {
+    # Return
+    #   0 if daemon has been started
+    #   1 if daemon was already running
+    #   2 if daemon could not be started
+    pid=$(pidofproc -p $PIDFILE $DAEMON)
+    if [ -n "$pid" ] ; then
+        return 1
+    fi
+
+    start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \
+            $DAEMON_ARGS \
+            || return 2
+}
+
+do_stop() {
+    # Return
+    #   0 if daemon has been stopped
+    #   1 if daemon was already stopped
+    #   2 if daemon could not be stopped
+    #   other if a failure occurred
+    start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --name $NAME
+    RETVAL="$?"
+    [ "$RETVAL" = 2 ] && return 2
+    rm -f $PIDFILE
+    return "$RETVAL"
+}
+
+case "$1" in
+    start)
+        [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+        do_start
+        case "$?" in
+            0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+              2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+        esac
+        ;;
+    stop)
+        [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+        do_stop
+        case "$?" in
+            0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+              2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+        esac
+        ;;
+    status)
+        status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+        ;;
+    #reload)
+        # not implemented
+        #;;
+    restart|force-reload)
+        log_daemon_msg "Restarting $DESC" "$NAME"
+        do_stop
+        case "$?" in
+          0|1)
+              do_start
+              case "$?" in
+                  0) log_end_msg 0 ;;
+                  1) log_end_msg 1 ;; # Old process is still running
+                  *) log_end_msg 1 ;; # Failed to start
+              esac
+              ;;
+          *)
+              # Failed to stop
+              log_end_msg 1
+              ;;
+        esac
+        ;;
+    *)
+        echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+        exit 3
+        ;;
+esac
+
+exit 0

--- a/pkg/deb/salt-syndic.service
+++ b/pkg/deb/salt-syndic.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=The Salt Syndic daemon
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/default/salt-syndic
+Type=simple
+LimitNOFILE=8192
+ExecStart=/usr/bin/salt-syndic
+Restart=$RESTART
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
### What does this PR do?

Adds necessary files for complete bootstrapping (via [bootstrap-salt.sh](https://github.com/saltstack/salt-bootstrap)) Salt components on Debian GNU/Linux from Git without downloading from external repos and sources. 

This PR is required for replacing workarounds in the bootstrap script which set up Salt services.
It will complement PR saltstack/salt-bootstrap#828 for better support of git installations on Debian.
