### PR TITLE
salt-cloud: fix ipv6-only virtual machines

### DIFF
--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -794,7 +794,7 @@ def create(vm_):
         #         If this is True, then we should have an access_ip at this point set to the ip on the cloud
         #         network.  If that network does not exist in the 'addresses' dictionary, then SaltCloud will
         #         use the initial access_ip, and not overwrite anything.
-        if any((cloudnetwork(vm_), rackconnect(vm_))) and (ssh_interface(vm_) != 'private_ips' or rcv3):
+        if any((cloudnetwork(vm_), rackconnect(vm_))) and (ssh_interface(vm_) != 'private_ips' or rcv3) and access_ip != '':
             data.public_ips = [access_ip, ]
             return data
 

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1845,7 +1845,7 @@ def scp_file(dest_path, contents=None, kwargs=None, local_file=None):
     cmd = (
         'scp {0} {1} {2[username]}@{4}:{3} || '
         'echo "put {1} {3}" | sftp {0} {2[username]}@{4} || '
-        'rsync -avz -e "ssh {0}" {1} {2[username]}@{4}:{3}'.format(
+        'rsync -avz -e "ssh {0}" {1} {2[username]}@{2[hostname]}:{3}'.format(
             ' '.join(ssh_args), tmppath, kwargs, dest_path, ipaddr
         )
     )

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -590,10 +590,6 @@ def wait_for_port(host, port=22, timeout=900, gateway=None):
     test_ssh_host = host
     test_ssh_port = port
 
-    if socket.inet_pton(socket.AF_INET6, host):
-        global ipv6
-        ipv6 = True
-
     if gateway:
         ssh_gateway = gateway['ssh_gateway']
         ssh_gateway_port = 22
@@ -619,7 +615,7 @@ def wait_for_port(host, port=22, timeout=900, gateway=None):
     while True:
         trycount += 1
         try:
-            if ipv6:
+            if socket.inet_pton(socket.AF_INET6, host):
                 sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
             else:
                 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -1837,7 +1833,7 @@ def scp_file(dest_path, contents=None, kwargs=None, local_file=None):
             )
         )
 
-    if ipv6:
+    if socket.inet_pton(socket.AF_INET6, kwargs['hostname']):
         ipaddr = '[{0}]'.format(kwargs['hostname'])
     else:
         ipaddr = kwargs['hostname']
@@ -1944,7 +1940,7 @@ def sftp_file(dest_path, contents=None, kwargs=None, local_file=None):
             )
         )
 
-    if ipv6:
+    if socket.inet_pton(socket.AF_INET6, kwargs['hostname']):
         ipaddr = '[{0}]'.format(kwargs['hostname'])
     else:
         ipaddr = kwargs['hostname']

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -589,6 +589,11 @@ def wait_for_port(host, port=22, timeout=900, gateway=None):
     # we first want to test the gateway before the host.
     test_ssh_host = host
     test_ssh_port = port
+
+    if socket.inet_pton(socket.AF_INET6, host):
+      global ipv6
+      ipv6 = True
+
     if gateway:
         ssh_gateway = gateway['ssh_gateway']
         ssh_gateway_port = 22
@@ -614,7 +619,10 @@ def wait_for_port(host, port=22, timeout=900, gateway=None):
     while True:
         trycount += 1
         try:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            if ipv6:
+              sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+            else:
+              sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.settimeout(30)
             sock.connect((test_ssh_host, int(test_ssh_port)))
             # Stop any remaining reads/writes on the socket
@@ -1828,11 +1836,17 @@ def scp_file(dest_path, contents=None, kwargs=None, local_file=None):
                 ssh_gateway_port
             )
         )
+
+    if ipv6:
+      ipaddr = '[{0}]'.format(kwargs['hostname'])
+    else:
+      ipaddr = kwargs['hostname']
+
     cmd = (
-        'scp {0} {1} {2[username]}@{2[hostname]}:{3} || '
-        'echo "put {1} {3}" | sftp {0} {2[username]}@{2[hostname]} || '
-        'rsync -avz -e "ssh {0}" {1} {2[username]}@{2[hostname]}:{3}'.format(
-            ' '.join(ssh_args), tmppath, kwargs, dest_path
+        'scp {0} {1} {2[username]}@{4}:{3} || '
+        'echo "put {1} {3}" | sftp {0} {2[username]}@{4} || '
+        'rsync -avz -e "ssh {0}" {1} {2[username]}@{4}:{3}'.format(
+            ' '.join(ssh_args), tmppath, kwargs, dest_path, ipaddr
         )
     )
 
@@ -1930,8 +1944,14 @@ def sftp_file(dest_path, contents=None, kwargs=None, local_file=None):
             )
         )
 
-    cmd = 'echo "put {0} {1} {2}" | sftp {3} {4[username]}@{4[hostname]}'.format(
-        ' '.join(put_args), tmppath, dest_path, ' '.join(ssh_args), kwargs
+
+    if ipv6:
+      ipaddr = '[{0}]'.format(kwargs['hostname'])
+    else:
+      ipaddr = kwargs['hostname']
+
+    cmd = 'echo "put {0} {1} {2}" | sftp {3} {4[username]}@{5}'.format(
+        ' '.join(put_args), tmppath, dest_path, ' '.join(ssh_args), kwargs, ipaddr
     )
     log.debug('SFTP command: {0!r}'.format(cmd))
     retcode = _exec_ssh_cmd(cmd,

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -591,8 +591,8 @@ def wait_for_port(host, port=22, timeout=900, gateway=None):
     test_ssh_port = port
 
     if socket.inet_pton(socket.AF_INET6, host):
-      global ipv6
-      ipv6 = True
+        global ipv6
+        ipv6 = True
 
     if gateway:
         ssh_gateway = gateway['ssh_gateway']
@@ -620,9 +620,9 @@ def wait_for_port(host, port=22, timeout=900, gateway=None):
         trycount += 1
         try:
             if ipv6:
-              sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+                sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
             else:
-              sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.settimeout(30)
             sock.connect((test_ssh_host, int(test_ssh_port)))
             # Stop any remaining reads/writes on the socket
@@ -1838,9 +1838,9 @@ def scp_file(dest_path, contents=None, kwargs=None, local_file=None):
         )
 
     if ipv6:
-      ipaddr = '[{0}]'.format(kwargs['hostname'])
+        ipaddr = '[{0}]'.format(kwargs['hostname'])
     else:
-      ipaddr = kwargs['hostname']
+        ipaddr = kwargs['hostname']
 
     cmd = (
         'scp {0} {1} {2[username]}@{4}:{3} || '
@@ -1944,11 +1944,10 @@ def sftp_file(dest_path, contents=None, kwargs=None, local_file=None):
             )
         )
 
-
     if ipv6:
-      ipaddr = '[{0}]'.format(kwargs['hostname'])
+        ipaddr = '[{0}]'.format(kwargs['hostname'])
     else:
-      ipaddr = kwargs['hostname']
+        ipaddr = kwargs['hostname']
 
     cmd = 'echo "put {0} {1} {2}" | sftp {3} {4[username]}@{5}'.format(
         ' '.join(put_args), tmppath, dest_path, ' '.join(ssh_args), kwargs, ipaddr


### PR DESCRIPTION
### What does this PR do?

If **host** is IPv6 addr, add brackets around **host** in **scp_file** and **sftp_file** functions; Fix IPv6 in **wait_for_port** function
### What issues does this PR fix or reference?

One moar bugfix like https://github.com/saltstack/salt/pull/31120
### Previous Behavior

Can't upload files to created VM
### New Behavior

Can upload files to created VM
### Tests written?

No
### Disclaimer

Tested with dual-stack and ipv6-only hosts. Can't test with non-public IPv4 addresses, because i didn't have that cloud provider
