### PR TITLE
Use correct config setting in cloud syndic docs

### DIFF
--- a/doc/topics/cloud/misc.rst
+++ b/doc/topics/cloud/misc.rst
@@ -105,7 +105,7 @@ defined either in a profile config file or in a map file:
     make_master: True
 
 To install the Salt Syndic, the only other specification that needs to be
-configured is the ``master_syndic`` key to specify the location of the master
+configured is the ``syndic_master`` key to specify the location of the master
 that the syndic will be reporting to. This modification needs to be placed
 in the ``master`` setting, which can be configured either in the profile,
 provider, or ``/etc/salt/cloud`` config file:
@@ -113,7 +113,7 @@ provider, or ``/etc/salt/cloud`` config file:
 .. code-block:: yaml
 
     master:
-      master_syndic: 123.456.789  # may be either an IP address or a hostname
+      syndic_master: 123.456.789  # may be either an IP address or a hostname
 
 Many other Salt Syndic configuration settings and specifications can be passed
 through to the new syndic machine via the ``master`` configuration setting.


### PR DESCRIPTION
### What does this PR do?

Switches the `master_syndic` references in the salt-cloud miscellaneous settings doc to the correct reference of `syndic_master`.
### What issues does this PR fix or reference?

Fixes #32861
### Tests written?

N/A
