### PR TITLE
fix pkg.latest_version for mac_brew.py

### DIFF
--- a/salt/modules/mac_brew.py
+++ b/salt/modules/mac_brew.py
@@ -162,13 +162,27 @@ def latest_version(*names, **kwargs):
     if refresh:
         refresh_db()
 
-    if len(names) <= 1:
+    if len(names) <= 0:
         return ''
     else:
         ret = {}
+        pkg_upgrades = 'brew outdated --verbose'
+        pkg_installed = list_pkgs()
+        call = _call_brew(pkg_upgrades)
+
         for name in names:
             ret[name] = ''
-        return ret
+            if name in pkg_installed:
+                if name in call['stdout']:
+                    updates = call['stdout'].split()[-1].strip(")")
+                    ret[name] = updates
+            else:
+                new_version = __salt__['cmd.run']('brew info {0}'.format(name))
+                to_install = new_version.split("\n")[0].split()[2]
+                ret[name] = ''.join(to_install)
+    if len(names) == 1:
+        return ret[names[0]]
+    return ret
 
 # available_version is being deprecated
 available_version = salt.utils.alias_function(latest_version, 'available_version')


### PR DESCRIPTION
### What does this PR do?

Fixes the functionality for pkg.latest_version for mac_brew.py
### What issues does this PR fix or reference?

The following automated tests were failing due to pkg.latest_version not working properly on mac_brew.py:
- integration.states.pkg.PkgTest.test_pkg_002_installed_with_version
- integration.states.pkg.PkgTest.test_pkg_004_installed_multipkg_with_version
- integration.states.pkg.PkgTest.test_pkg_008_latest_with_epoch
### Previous Behavior

When running `salt-call pkg.latest_version ossp-uuid` it would not return anything on a mac minion. Even if the package had an update available or was not even installed. 
### New Behavior

Now `salt-call pkg.latest_version ossp-uuid` will return the version number available if there is an update available for a package installed on the mac minion AND return the version number if it is not installed and can be installed.
### Tests written?

Yes, there are currently already tests written for this. This will fix those tests that run on mac.
