### PR TITLE
add /Users directory for mac minion in user present test

### DIFF
--- a/tests/integration/states/user.py
+++ b/tests/integration/states/user.py
@@ -71,7 +71,10 @@ class UserTest(integration.ModuleCase,
         And then destroys that user.
         Assume that it will break any system you run it on.
         '''
-        HOMEDIR = '/home/home_of_salt_test'
+        if salt.utils.is_darwin():
+            HOMEDIR = '/Users/home_of_salt_test'
+        else:
+            HOMEDIR = '/home/home_of_salt_test'
         ret = self.run_state('user.present', name='salt_test',
                              home=HOMEDIR)
         self.assertSaltTrueReturn(ret)


### PR DESCRIPTION
### What does this PR do?

Adds HOMEDIR for mac minions for the `def test_user_present_when_home_dir_does_not_18843` test.
### Previous Behavior

This test was failing on mac with the following error:

```
   -> integration.states.user.UserTest.test_user_present_when_home_dir_does_not_18843  .........................................................................
       Traceback (most recent call last):
         File "/opt/salt/lib/python2.7/site-packages/salttesting/helpers.py", line 68, in wrap
           return caller(cls)
         File "/testing/tests/integration/states/user.py", line 77, in test_user_present_when_home_dir_does_not_18843
           self.assertSaltTrueReturn(ret)
         File "/testing/tests/integration/__init__.py", line 1456, in assertSaltTrueReturn
           **(next(six.itervalues(ret)))
       AssertionError: False is not True. Salt Comment:
       An exception occurred in this state: Traceback (most recent call last):
         File "/testing/salt/state.py", line 1703, in call
           **cdata['kwargs'])
         File "/testing/salt/loader.py", line 1650, in wrapper
           return f(*args, **kwargs)
         File "/testing/salt/states/user.py", line 626, in present
           if __salt__['user.add'](**params):
         File "/testing/salt/modules/mac_user.py", line 126, in add
           __salt__['file.mkdir'](home, user=uid, group=gid)
         File "/testing/salt/modules/file.py", line 4518, in mkdir
           makedirs_perms(directory, user, group, mode)
         File "/testing/salt/modules/file.py", line 4606, in makedirs_perms
           os.mkdir(name)
       OSError: [Errno 45] Operation not supported: '/home/home_of_salt_test'
```
### New Behavior

Now the test is running correctly on mac minions.
