### PR TITLE
mode should default to 'text'

### DIFF
--- a/salt/returners/carbon_return.py
+++ b/salt/returners/carbon_return.py
@@ -230,8 +230,7 @@ def _send(saltdata, metric_base, opts):
     port = opts.get('port')
     skip = opts.get('skip')
     metric_base_pattern = opts.get('carbon.metric_base_pattern')
-    if 'mode' in opts:
-        mode = opts.get('mode').lower()
+    mode = opts.get('mode').lower() if 'mode' in opts else 'text'
 
     log.debug('Carbon minion configured with host: {0}:{1}'.format(host, port))
     log.debug('Using carbon protocol: {0}'.format(mode))


### PR DESCRIPTION
### What does this PR do?

Assign carbon.mode a default value.
### What issues does this PR fix or reference?
#32882
### Previous Behavior

```
Traceback (most recent call last):
  File "salt/utils/schedule.py", line 734, in handle_func
  File "salt/returners/carbon_return.py", line 300, in returner
  File "salt/returners/carbon_return.py", line 237, in _send
UnboundLocalError: local variable 'mode' referenced before assignment
```
### New Behavior

```
[INFO    ] Returning information for job: req
```
### Tests written?

No
