### PR TITLE
Fix incorrect deprecation notice

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -102,8 +102,8 @@ def extracted(name,
     archive_user
         The user to own each extracted file.
 
-        .. deprecated:: Boron
-            replaced by standardized `user` parameter.
+        .. deprecated:: 2014.7.2
+            Replaced by ``user`` parameter
 
     user
         The user to own each extracted file.


### PR DESCRIPTION
The "deprecated" entry refers to when the deprecation path started, not
when the option will be removed.

FYI @rallytime
