### PR TITLE
Add support for stop_signal, fixes #32858

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -448,9 +448,9 @@ VALID_CREATE_OPTS = {
         'default': '',
     },
     'labels': {
-      'path': 'Config:Labels',
-      'image_path': 'Config:Labels',
-      'default': {},
+        'path': 'Config:Labels',
+        'image_path': 'Config:Labels',
+        'default': {},
     },
     'binds': {
         'path': 'HostConfig:Binds',
@@ -551,15 +551,15 @@ def __virtual__():
                 return __virtualname__
             else:
                 return (False,
-                    'Insufficient Docker version for dockerng (required: '
-                    '{0}, installed: {1})'.format(
-                        '.'.join(map(str, MIN_DOCKER)),
-                        '.'.join(map(str, docker_versioninfo))))
+                        'Insufficient Docker version for dockerng (required: '
+                        '{0}, installed: {1})'.format(
+                            '.'.join(map(str, MIN_DOCKER)),
+                            '.'.join(map(str, docker_versioninfo))))
         return (False,
-            'Insufficient docker-py version for dockerng (required: '
-            '{0}, installed: {1})'.format(
-                '.'.join(map(str, MIN_DOCKER_PY)),
-                '.'.join(map(str, docker_py_versioninfo))))
+                'Insufficient docker-py version for dockerng (required: '
+                '{0}, installed: {1})'.format(
+                    '.'.join(map(str, MIN_DOCKER_PY)),
+                    '.'.join(map(str, docker_py_versioninfo))))
     return (False, 'Docker module could not get imported')
 
 
@@ -620,8 +620,8 @@ class _client_version(object):
                 minion_conf = __salt__['config.get']('docker.version', NOTSET)
                 if minion_conf is not NOTSET:
                     error_message += (
-                      ' Hint: Your minion configuration specified'
-                      ' `docker.version` = "{0}"'.format(minion_conf))
+                        ' Hint: Your minion configuration specified'
+                        ' `docker.version` = "{0}"'.format(minion_conf))
                 raise CommandExecutionError(error_message)
             return func(*args, **salt.utils.clean_kwargs(**kwargs))
         return _mimic_signature(func, wrapper)
@@ -1456,8 +1456,8 @@ def _validate_input(kwargs,
                         .format(container_path, bind)
                     )
                 log.warning('Host path {0} in bind {1} is not absolute,'
-                         ' assuming it is a docker volume.'.format(host_path,
-                                                                   bind))
+                            ' assuming it is a docker volume.'
+                            .format(host_path, bind))
             if not os.path.isabs(container_path):
                 raise SaltInvocationError(
                     'Container path {0} in bind {1} is not absolute'
@@ -1645,7 +1645,7 @@ def _validate_input(kwargs,
                 # just a name assume it is a network
                 log.info(
                     'Assuming network_mode \'{0}\' is a network.'.format(
-                      kwargs['network_mode'])
+                        kwargs['network_mode'])
                 )
         except SaltInvocationError:
             raise SaltInvocationError(

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -432,6 +432,13 @@ VALID_CREATE_OPTS = {
         'path': 'Config:Volumes',
         'image_path': 'Config:Volumes',
     },
+    'stop_signal': {
+        'validator': 'string',
+        'path': 'Config:StopSignal',
+        'min_docker': (1, 9, 0),
+        'min_docker_py': (1, 7, 0),
+        'default': '',
+    },
     'cpu_shares': {
         'validator': 'number',
         'path': 'HostConfig:CpuShares',

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -436,7 +436,6 @@ VALID_CREATE_OPTS = {
         'validator': 'string',
         'path': 'Config:StopSignal',
         'min_docker': (1, 9, 0),
-        'min_docker_py': (1, 7, 0),
         'default': '',
     },
     'cpu_shares': {

--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -1521,6 +1521,22 @@ def running(name,
         such as the django ``migrate`` and ``collectstatic`` commands. In
         instances such as this, the container only needs to be started the
         first time.
+
+    stop_signal
+        Specify the signal docker will send to the container when stopping.
+        Useful when running systemd as PID 1 inside the container.
+
+        .. code-block:: yaml
+
+            foo:
+              dockerng.running:
+                - image: bar/baz:latest
+                - stop_signal: SIGRTMIN+3
+
+        .. note::
+
+            This option requires Docker 1.9.0 or newer and
+            docker-py 1.7.0 or newer.
     '''
     ret = {'name': name,
            'changes': {},

--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -1537,6 +1537,8 @@ def running(name,
 
             This option requires Docker 1.9.0 or newer and
             docker-py 1.7.0 or newer.
+
+        .. versionadded:: carbon
     '''
     ret = {'name': name,
            'changes': {},

--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -194,7 +194,7 @@ def _compare(actual, create_kwargs, defaults_from_image):
                 else:
                     actual_env[key] = val
             log.trace('dockerng.running ({0}): munged actual value: {1}'
-                        .format(item, actual_env))
+                      .format(item, actual_env))
             env_diff = {}
             for key in data:
                 actual_val = actual_env.get(key)
@@ -354,12 +354,12 @@ def _compare(actual, create_kwargs, defaults_from_image):
             actual_binds.sort()
             desired_binds.sort()
             log.trace('dockerng.running ({0}): munged actual value: {1}'
-                        .format(item, actual_binds))
+                      .format(item, actual_binds))
             log.trace('dockerng.running ({0}): munged desired value: {1}'
-                        .format(item, desired_binds))
+                      .format(item, desired_binds))
             if actual_binds != desired_binds:
                 ret.update({item: {'old': actual_binds,
-                                    'new': desired_binds}})
+                                   'new': desired_binds}})
                 continue
 
         elif item == 'links':
@@ -389,7 +389,7 @@ def _compare(actual, create_kwargs, defaults_from_image):
             desired_links = sorted(data)
             if actual_links != desired_links:
                 ret.update({item: {'old': actual_links,
-                                    'new': desired_links}})
+                                   'new': desired_links}})
                 continue
 
         elif item == 'extra_hosts':
@@ -444,12 +444,12 @@ def _compare(actual, create_kwargs, defaults_from_image):
             actual_data = sorted(actual_data)
             desired_data = sorted(data)
             log.trace('dockerng.running ({0}): munged actual value: {1}'
-                        .format(item, actual_data))
+                      .format(item, actual_data))
             log.trace('dockerng.running ({0}): munged desired value: {1}'
-                        .format(item, desired_data))
+                      .format(item, desired_data))
             if actual_data != desired_data:
                 ret.update({item: {'old': actual_data,
-                                    'new': desired_data}})
+                                   'new': desired_data}})
             continue
 
         else:
@@ -2040,8 +2040,8 @@ def stopped(name=None,
     stop_errors = []
     for target in to_stop:
         changes = __salt__['dockerng.stop'](target,
-                                             timeout=stop_timeout,
-                                             unpause=unpause)
+                                            timeout=stop_timeout,
+                                            unpause=unpause)
         if changes['result'] is True:
             ret['changes'][target] = changes
         else:
@@ -2344,7 +2344,7 @@ def volume_present(name, driver=None, driver_opts=None, force=False):
                     name, driver=driver, driver_opts=driver_opts)
             except Exception as exc:
                 ret['comment'] = ('Failed to create volume \'{0}\': {1}'
-                                .format(name, exc))
+                                  .format(name, exc))
                 return ret
             else:
                 result = True


### PR DESCRIPTION
### What does this PR do?

Adds stop_signal to VALID_CREATE_OPTS. This adds support for already existing functionality in docker-py.
docker-py support since 1.7.0: https://github.com/docker/docker-py/blob/master/docs/change_log.md#170
docker support since 1.9.0: https://github.com/docker/docker/releases/tag/v1.9.0
### What issues does this PR fix or reference?
#32858
### Tests written?

No
### Use case

Running systemd inside a container requires the signal SIGRTMIN+3 to shutdown gracefully, this fix makes it possible to specify the signal.
