### PR TITLE
Resolve Zypper locks on asynchronous calls

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -121,6 +121,8 @@ class _Zypper(object):
             self.__no_raise = True
         elif item == 'refreshable':
             self.__refresh = True
+        elif item == 'call':
+            return self.__call
         else:
             return self.__dict__[item]
 
@@ -210,7 +212,7 @@ class _Zypper(object):
             self.error_msg = _error_msg
         return True
 
-    def call(self, *args, **kwargs):
+    def __call(self, *args, **kwargs):
         '''
         Call Zypper.
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -71,7 +71,7 @@ class _Zypper(object):
     SUCCESS_EXIT_CODES = [0, 100, 101, 102, 103]
     LOCK_EXIT_CODE = 7
     XML_DIRECTIVES = ['-x', '--xmlout']
-    ZYPPER_LOCK = '/run/zypp.pid'
+    ZYPPER_LOCK = '/var/run/zypp.pid'
     TAG_RELEASED = 'zypper/released'
     TAG_BLOCKED = 'zypper/blocked'
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -75,10 +75,9 @@ class _Zypper(object):
     TAG_RELEASED = 'zypper/released'
     TAG_BLOCKED = 'zypper/blocked'
 
-    def __init__(self, no_refresh=True):
+    def __init__(self):
         '''
         Constructor
-        :param no_refresh:
         '''
         self.__called = False
         self._reset()

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -403,6 +403,11 @@ def latest_version(*names, **kwargs):
     If the latest version of a given package is already installed, an empty
     dict will be returned for that package.
 
+    refresh
+        force a refresh if set to True (default).
+        If set to False it depends on zypper if a refresh is
+        executed or not.
+
     CLI example:
 
     .. code-block:: bash
@@ -437,6 +442,11 @@ available_version = salt.utils.alias_function(latest_version, 'available_version
 def upgrade_available(name, **kwargs):
     '''
     Check whether or not an upgrade is available for a given package
+
+    refresh
+        force a refresh if set to True (default).
+        If set to False it depends on zypper if a refresh is
+        executed or not.
 
     CLI Example:
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -434,7 +434,7 @@ def latest_version(*names, **kwargs):
 available_version = salt.utils.alias_function(latest_version, 'available_version')
 
 
-def upgrade_available(name):
+def upgrade_available(name, **kwargs):
     '''
     Check whether or not an upgrade is available for a given package
 
@@ -445,7 +445,7 @@ def upgrade_available(name):
         salt '*' pkg.upgrade_available <package name>
     '''
     # The "not not" tactic is intended here as it forces the return to be False.
-    return not not latest_version(name)  # pylint: disable=C0113
+    return not not latest_version(name, **kwargs)  # pylint: disable=C0113
 
 
 def version(*names, **kwargs):

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1248,12 +1248,11 @@ def search(criteria, refresh=False):
         raise CommandExecutionError('No packages found by criteria "{0}".'.format(criteria))
 
     out = {}
-    for solvable in [s for s in solvables
-                     if s.getAttribute('status') == 'not-installed' and
-                        s.getAttribute('kind') == 'package']:
-        out[solvable.getAttribute('name')] = {
-            'summary': solvable.getAttribute('summary')
-        }
+    for solvable in [slv for slv in solvables
+                     if slv.getAttribute('status') == 'not-installed'
+                         and slv.getAttribute('kind') == 'package']:
+        out[solvable.getAttribute('name')] = {'summary': solvable.getAttribute('summary')}
+
     return out
 
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -125,6 +125,10 @@ class _Zypper(object):
         else:
             return self.__dict__[item]
 
+        # Prevent the use of "refreshable" together with "nolock".
+        if self.__no_lock:
+            self.__no_lock = not self.__refresh
+
         return self
 
     @property

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -440,7 +440,7 @@ def _get_repo_info(alias, repos_cfg=None):
             if val == 'NONE':
                 ret[key] = None
         return ret
-    except (ValueError, configparser.NoSectionError) as error:
+    except (ValueError, configparser.NoSectionError):
         return {}
 
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -362,7 +362,7 @@ def version_cmp(ver1, ver2):
 
         salt '*' pkg.version_cmp '0.2-001' '0.2.0.1-002'
     '''
-    return __salt__['lowpkg.version_cmp'](ver1, ver2)
+    return __salt__['lowpkg.version_cmp'](str(ver1), str(ver2))
 
 
 def list_pkgs(versions_as_list=False, **kwargs):

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -60,7 +60,6 @@ def __virtual__():
 
 
 class Zypper(object):
-def _is_zypper_error(retcode):
     '''
     Zypper parallel caller.
     Validates the result and either raises an exception or reports an error.
@@ -88,46 +87,6 @@ def _is_zypper_error(retcode):
             self.__env['ZYPP_READONLY_HACK'] = "1"
         elif item == 'noraise':
             self.__no_raise = False
-    Return True in case the exist code indicate a zypper errror.
-    Otherwise False
-    '''
-    # see man zypper for existing exit codes
-    return int(retcode) not in [0, 100, 101, 102, 103]
-
-
-def _zypper(*args, **kwargs):
-    '''
-    __salt__['cmd.run_all'] with the different environment
-
-    :return:
-    '''
-    cmd = ['zypper', '--non-interactive']
-    cmd.extend(args)
-
-    kwargs['output_loglevel'] = 'trace'
-    kwargs['env'] = {'SALT_RUNNING': "1"}
-
-    return __salt__['cmd.run_all'](cmd, **kwargs)
-
-
-def _zypper_check_result(result, xml=False):
-    '''
-    Check the result of a zypper command. In case of an error, it raise
-    a CommandExecutionError. Otherwise it returns stdout string of the
-    command.
-
-    result
-        The result of a zypper command called with cmd.run_all
-
-    xml
-        Set to True if zypper command was called with --xmlout.
-        In this case it try to read an error message out of the XML
-        stream. Default is False.
-    '''
-    if _is_zypper_error(result['retcode']):
-        msg = list()
-        if not xml:
-            msg.append(result['stderr'] and result['stderr'] or "")
         else:
             return self.__dict__[item]
 
@@ -243,23 +202,6 @@ def _zypper_check_result(result, xml=False):
             raise CommandExecutionError('Zypper command failure: {0}'.format(self.error_msg))
 
         return self.__call_result['stdout']
-            try:
-                doc = dom.parseString(result['stdout'])
-            except ExpatError as err:
-                log.error(err)
-                doc = None
-            if doc:
-                msg_nodes = doc.getElementsByTagName('message')
-                for node in msg_nodes:
-                    if node.getAttribute('type') == 'error':
-                        msg.append(node.childNodes[0].nodeValue)
-            elif result['stderr'].strip():
-                msg.append(result['stderr'].strip())
-
-        raise CommandExecutionError("zypper command failed: {0}".format(
-            msg and os.linesep.join(msg) or "Check zypper logs"))
-
-    return result['stdout']
 
 
 def list_upgrades(refresh=True):

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -197,7 +197,6 @@ def info_installed(*names, **kwargs):
                 t_nfo['source'] = value
             else:
                 t_nfo[key] = value
-
         ret[pkg_name] = t_nfo
 
     return ret

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -98,7 +98,7 @@ class _Zypper(object):
         # Call config
         self.__xml = False
         self.__no_lock = False
-        self.__no_raise = True
+        self.__no_raise = False
         self.__refresh = False
 
     def __getattr__(self, item):
@@ -118,7 +118,7 @@ class _Zypper(object):
         elif item == 'nolock':
             self.__no_lock = True
         elif item == 'noraise':
-            self.__no_raise = False
+            self.__no_raise = True
         elif item == 'refreshable':
             self.__refresh = True
         else:

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -72,6 +72,8 @@ class Zypper(object):
     LOCK_EXIT_CODE = 7
     XML_DIRECTIVES = ['-x', '--xmlout']
     ZYPPER_LOCK = '/run/zypp.pid'
+    TAG_RELEASED = '__zypper_released'
+    TAG_BLOCKED = '__zypper_blocked'
 
     def __init__(self, no_refresh=True):
         self.__exit_code = 0
@@ -219,7 +221,7 @@ class Zypper(object):
             else:
                 log.debug("Collected data about blocking process.")
 
-            __salt__['event.fire_master'](data, '__zypper_blocked')
+            __salt__['event.fire_master'](data, self.TAG_BLOCKED)
             log.debug("Fired a Zypper blocked event to the master with the data: {0}".format(str(data)))
             time.sleep(5)
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -71,6 +71,7 @@ class Zypper(object):
     SUCCESS_EXIT_CODES = [0, 100, 101, 102, 103]
     LOCK_EXIT_CODE = 7
     XML_DIRECTIVES = ['-x', '--xmlout']
+    ZYPPER_LOCK = '/run/zypp.pid'
 
     def __init__(self, no_refresh=True):
         self.__exit_code = 0

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -404,12 +404,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
 
     cmd = ['rpm', '-qa', '--queryformat', '%{NAME}_|-%{VERSION}_|-%{RELEASE}_|-%|EPOCH?{%{EPOCH}}:{}|\\n']
     ret = {}
-    out = __salt__['cmd.run'](
-        cmd,
-        output_loglevel='trace',
-        python_shell=False
-    )
-    for line in out.splitlines():
+    for line in __salt__['cmd.run'](cmd, output_loglevel='trace', python_shell=False).splitlines():
         name, pkgver, rel, epoch = line.split('_|-')
         if epoch:
             pkgver = '{0}:{1}'.format(epoch, pkgver)

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -240,7 +240,6 @@ class _Zypper(object):
             self.__call_result = __salt__['cmd.run_all'](self.__cmd, **kwargs)
             if self._check_result():
                 break
-            log.debug("Zypper locked. Trying again in 5 seconds.")
 
             if os.path.exists(self.ZYPPER_LOCK):
                 try:
@@ -263,6 +262,7 @@ class _Zypper(object):
 
             __salt__['event.fire_master'](data, self.TAG_BLOCKED)
             log.debug("Fired a Zypper blocked event to the master with the data: {0}".format(str(data)))
+            log.debug("Waiting 5 seconds for Zypper gets released...")
             time.sleep(5)
             if not was_blocked:
                 was_blocked = True

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -72,8 +72,8 @@ class _Zypper(object):
     LOCK_EXIT_CODE = 7
     XML_DIRECTIVES = ['-x', '--xmlout']
     ZYPPER_LOCK = '/run/zypp.pid'
-    TAG_RELEASED = '__zypper_released'
-    TAG_BLOCKED = '__zypper_blocked'
+    TAG_RELEASED = 'zypper/released'
+    TAG_BLOCKED = 'zypper/blocked'
 
     def __init__(self, no_refresh=True):
         '''

--- a/tests/unit/modules/zypper_test.py
+++ b/tests/unit/modules/zypper_test.py
@@ -90,11 +90,12 @@ class ZypperTestCase(TestCase):
  <message type="error">Another zypper internal error</message>
 </stream>
             ''',
-            'retcode': 1
+            'stderr': '',
+            'retcode': 1,
         }
-        with patch.dict(zypper.__salt__, {'cmd.run_all': MagicMock(return_value=ref_out)}):
+        with patch.dict('salt.modules.zypper.__salt__', {'cmd.run_all': MagicMock(return_value=ref_out)}):
             with self.assertRaisesRegexp(CommandExecutionError,
-                    "^zypper command failed: Some handled zypper internal error\nAnother zypper internal error$"):
+                    "^Zypper command failure: Some handled zypper internal error\nAnother zypper internal error$"):
                 zypper.list_upgrades(refresh=False)
 
         # Test unhandled error
@@ -103,8 +104,8 @@ class ZypperTestCase(TestCase):
             'stdout': '',
             'stderr': ''
         }
-        with patch.dict(zypper.__salt__, {'cmd.run_all': MagicMock(return_value=ref_out)}):
-            with self.assertRaisesRegexp(CommandExecutionError, '^zypper command failed: Check zypper logs$'):
+        with patch.dict('salt.modules.zypper.__salt__', {'cmd.run_all': MagicMock(return_value=ref_out)}):
+            with self.assertRaisesRegexp(CommandExecutionError, "^Zypper command failure: Check Zypper's logs.$"):
                 zypper.list_upgrades(refresh=False)
 
     def test_list_products(self):
@@ -221,8 +222,7 @@ class ZypperTestCase(TestCase):
         :return:
         '''
         test_pkgs = ['vim', 'emacs', 'python']
-        ref_out = get_test_data('zypper-available.txt')
-        with patch.dict(zypper.__salt__, {'cmd.run_stdout': MagicMock(return_value=ref_out)}):
+        with patch('salt.modules.zypper.__zypper__', ZyppCallMock(return_value=get_test_data('zypper-available.txt'))):
             available = zypper.info_available(*test_pkgs, refresh=False)
             self.assertEqual(len(available), 3)
             for pkg_name, pkg_info in available.items():
@@ -247,8 +247,7 @@ class ZypperTestCase(TestCase):
 
         :return:
         '''
-        ref_out = get_test_data('zypper-available.txt')
-        with patch.dict(zypper.__salt__, {'cmd.run_stdout': MagicMock(return_value=ref_out)}):
+        with patch('salt.modules.zypper.__zypper__', ZyppCallMock(return_value=get_test_data('zypper-available.txt'))):
             self.assertEqual(zypper.latest_version('vim'), '7.4.326-2.62')
 
     @patch('salt.modules.zypper.refresh_db', MagicMock(return_value=True))
@@ -259,7 +258,7 @@ class ZypperTestCase(TestCase):
         :return:
         '''
         ref_out = get_test_data('zypper-available.txt')
-        with patch.dict(zypper.__salt__, {'cmd.run_stdout': MagicMock(return_value=ref_out)}):
+        with patch('salt.modules.zypper.__zypper__', ZyppCallMock(return_value=get_test_data('zypper-available.txt'))):
             for pkg_name in ['emacs', 'python']:
                 self.assertFalse(zypper.upgrade_available(pkg_name))
             self.assertTrue(zypper.upgrade_available('vim'))

--- a/tests/unit/modules/zypper_test.py
+++ b/tests/unit/modules/zypper_test.py
@@ -93,9 +93,10 @@ class ZypperTestCase(TestCase):
                         'stderr': self._stderr,
                         'retcode': self._retcode}
 
-        sniffer = RunSniffer(stdout='standard out', stderr='error out')
+        stdout_xml_snippet = '<?xml version="1.0"?><test foo="bar"/>'
+        sniffer = RunSniffer(stdout=stdout_xml_snippet)
         with patch.dict('salt.modules.zypper.__salt__', {'cmd.run_all': sniffer}):
-            self.assertEqual(zypper.__zypper__.call('foo'), 'standard out')
+            self.assertEqual(zypper.__zypper__.call('foo'), stdout_xml_snippet)
             self.assertEqual(len(sniffer.calls), 1)
 
             zypper.__zypper__.call('bar')
@@ -103,9 +104,11 @@ class ZypperTestCase(TestCase):
             self.assertEqual(sniffer.calls[0]['args'][0], ['zypper', '--non-interactive', '--no-refresh', 'foo'])
             self.assertEqual(sniffer.calls[1]['args'][0], ['zypper', '--non-interactive', '--no-refresh', 'bar'])
 
-            zypper.__zypper__.xml.call('xml-test')
+            dom = zypper.__zypper__.xml.call('xml-test')
             self.assertEqual(sniffer.calls[2]['args'][0], ['zypper', '--non-interactive', '--xmlout',
                                                            '--no-refresh', 'xml-test'])
+            self.assertEqual(dom.getElementsByTagName('test')[0].getAttribute('foo'), 'bar')
+
             zypper.__zypper__.refreshable.call('refresh-test')
             self.assertEqual(sniffer.calls[3]['args'][0], ['zypper', '--non-interactive', 'refresh-test'])
 

--- a/tests/unit/modules/zypper_test.py
+++ b/tests/unit/modules/zypper_test.py
@@ -23,6 +23,17 @@ from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../')
 
 
+class ZyppCallMock(object):
+    def __init__(self, return_value=None):
+        self.__return_value = return_value
+
+    def __getattr__(self, item):
+        return self
+
+    def __call__(self, *args, **kwargs):
+        return MagicMock(return_value=self.__return_value)()
+
+
 def get_test_data(filename):
     '''
     Return static test data

--- a/tests/unit/modules/zypper_test.py
+++ b/tests/unit/modules/zypper_test.py
@@ -75,56 +75,6 @@ class ZypperTestCase(TestCase):
                 self.assertIn(pkg, upgrades)
                 self.assertEqual(upgrades[pkg], version)
 
-    def test_zypper_check_result(self):
-        '''
-        Test zypper check result function
-        '''
-        cmd_out = {
-                'retcode': 1,
-                'stdout': '',
-                'stderr': 'This is an error'
-        }
-        with self.assertRaisesRegexp(CommandExecutionError, "^zypper command failed: This is an error$"):
-            zypper._zypper_check_result(cmd_out)
-
-        cmd_out = {
-                'retcode': 0,
-                'stdout': 'result',
-                'stderr': ''
-        }
-        out = zypper._zypper_check_result(cmd_out)
-        self.assertEqual(out, "result")
-
-        cmd_out = {
-                'retcode': 1,
-                'stdout': '',
-                'stderr': 'This is an error'
-        }
-        with self.assertRaisesRegexp(CommandExecutionError, "^zypper command failed: This is an error$"):
-            zypper._zypper_check_result(cmd_out, xml=True)
-
-        cmd_out = {
-                'retcode': 1,
-                'stdout': '',
-                'stderr': ''
-        }
-        with self.assertRaisesRegexp(CommandExecutionError, "^zypper command failed: Check zypper logs$"):
-            zypper._zypper_check_result(cmd_out, xml=True)
-
-        cmd_out = {
-            'stdout': '''<?xml version='1.0'?>
-<stream>
- <message type="info">Refreshing service &apos;container-suseconnect&apos;.</message>
- <message type="error">Some handled zypper internal error</message>
- <message type="error">Another zypper internal error</message>
-</stream>
-            ''',
-            'stderr': '',
-            'retcode': 1
-        }
-        with self.assertRaisesRegexp(CommandExecutionError,
-                "^zypper command failed: Some handled zypper internal error\nAnother zypper internal error$"):
-            zypper._zypper_check_result(cmd_out, xml=True)
 
     def test_list_upgrades_error_handling(self):
         '''


### PR DESCRIPTION
### What does this PR do?
1. Allows call Zypper unlimited times
2. Fixes minor bugs
### Previous Behavior

If there are multiple calls to the Zypper module, only first wins and other fails. This affects patch updates from the SUSE Manager, where every patch schedule will definitely fail unresolved, if there is anything that blocks Zypper (Zypper itself or any other package-management-related components, e.g. YaST).
### New Behavior

When Zypper is locked, all other next calls will wait in cycle and fire "Zypper blocked" events. Once Zypper is released, an appropriate event will be fired to the Master.
### Tests written?

Yes
