### PR TITLE
Fix user present tests

### DIFF
--- a/tests/integration/states/user.py
+++ b/tests/integration/states/user.py
@@ -250,6 +250,8 @@ class UserTest(integration.ModuleCase,
         ret = self.run_state('user.absent', name='salt_test')
         self.assertSaltTrueReturn(ret)
 
+    @destructiveTest
+    @skipIf(os.geteuid() != 0, 'you must be root to run this test')
     def tearDown(self):
         if salt.utils.is_darwin():
             check_user = self.run_function('user.list_users')

--- a/tests/integration/states/user.py
+++ b/tests/integration/states/user.py
@@ -42,20 +42,28 @@ class UserTest(integration.ModuleCase,
     '''
     test for user absent
     '''
+    @destructiveTest
+    @skipIf(os.geteuid() != 0, 'you must be root to run this test')
     def setUp(self):
         if salt.utils.is_darwin():
             #on mac we need to add user, because there is
             #no creationtime for nobody user.
             add_user = self.run_function('user.add', [USER], gid=GID)
 
+    @destructiveTest
+    @skipIf(os.geteuid() != 0, 'you must be root to run this test')
     def test_user_absent(self):
         ret = self.run_state('user.absent', name='unpossible')
         self.assertSaltTrueReturn(ret)
 
+    @destructiveTest
+    @skipIf(os.geteuid() != 0, 'you must be root to run this test')
     def test_user_if_present(self):
         ret = self.run_state('user.present', name=USER)
         self.assertSaltTrueReturn(ret)
 
+    @destructiveTest
+    @skipIf(os.geteuid() != 0, 'you must be root to run this test')
     def test_user_if_present_with_gid(self):
         if self.run_function('group.info', [USER]):
             ret = self.run_state('user.present', name=USER, gid=GID)

--- a/tests/integration/states/user.py
+++ b/tests/integration/states/user.py
@@ -29,13 +29,14 @@ import integration
 if salt.utils.is_darwin():
     USER = 'macuser'
     GROUP = 'macuser'
-    GID = randint(400,500)
-    NOGROUPGID = randint(400,500)
+    GID = randint(400, 500)
+    NOGROUPGID = randint(400, 500)
 else:
     USER = 'nobody'
     GROUP = 'nobody'
     GID = 'nobody'
     NOGROUPGID = 'nogroup'
+
 
 class UserTest(integration.ModuleCase,
                integration.SaltReturnAssertsMixIn):


### PR DESCRIPTION
### What does this PR do?

Fixes user present tests for MACOSX.
### Previous Behavior

Was receiving errors on the following tests:
- integration.states.user.UserTest.test_user_if_present
- integration.states.user.UserTest.test_user_if_present_with_gid
### New Behavior

The tests are now passing. I had to create a separate user 'macuser' instead of using the default nobody user in the test, because with mac_user when calling user.present it also calls user.info which checks for the key creationtime when running the dscl command. Because nobody is a default user that is added when installing MacOSX it does not include the creationtime key which is the cause of the previous failures. 
