### PR TITLE
Allow profile options to be specified in provider file when using maps

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1891,6 +1891,19 @@ class Map(Cloud):
                 continue
 
             profile_data = self.opts['profiles'].get(profile_name)
+
+            # Get associated provider data, in case something like size
+            # or image is specified in the provider file. See issue #32510.
+            alias, driver = profile_data.get('provider').split(':')
+            provider_details = self.opts['providers'][alias][driver].copy()
+            del provider_details['profiles']
+
+            # Update the provider details information with profile data
+            # Profile data should override provider data, if defined.
+            # This keeps map file data definitions consistent with -p usage.
+            provider_details.update(profile_data)
+            profile_data = provider_details
+
             for nodename, overrides in six.iteritems(nodes):
                 # Get the VM name
                 nodedata = copy.deepcopy(profile_data)


### PR DESCRIPTION
### What does this PR do?

Brings the map file inline with using a regular `-p` command with salt-cloud. When using `-p` only, the vm to be created can use important config data defined in the provider file instead of the profile. When using a map file with `-m`, any data defined in a provider file was ignored.
### What issues does this PR fix or reference?

Fixes #32510
### Previous Behavior

If you specified something like `image` or `size` in a provider config and not in the profile config, the node to be created would be missing that key information and would stack trace when calling the map. 
### New Behavior

The `dmap` data is now populated with information from the provider file and node creation works instead of stacktracing.
### Tests written?

No
