### PR TITLE
Remove _get_date_time_format function

### DIFF
--- a/pkg/windows/req.txt
+++ b/pkg/windows/req.txt
@@ -30,7 +30,7 @@ requests==2.9.1
 singledispatch==3.4.0.3
 six==1.10.0
 smmap==0.9.0
-timelib==0.2.5
+timelib==0.2.4
 tornado==4.3
 wheel==0.26.0
 WMI==1.4.9

--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -710,37 +710,6 @@ def get_domain_workgroup():
             return {'Workgroup': computer.Domain}
 
 
-def _get_date_time_format(dt_string):
-    '''
-    Function that detects the date/time format for the string passed.
-
-    :param str dt_string:
-        A date/time string
-
-    :return: The format of the passed dt_string
-    :rtype: str
-    '''
-    valid_formats = [
-        '%I:%M:%S %p',
-        '%I:%M %p',
-        '%H:%M:%S',
-        '%H:%M',
-        '%Y-%m-%d',
-        '%m-%d-%y',
-        '%m-%d-%Y',
-        '%m/%d/%y',
-        '%m/%d/%Y',
-        '%Y/%m/%d'
-    ]
-    for dt_format in valid_formats:
-        try:
-            datetime.strptime(dt_string, dt_format)
-            return dt_format
-        except ValueError:
-            continue
-    return False
-
-
 def get_system_time():
     '''
     Get the system time.
@@ -765,9 +734,8 @@ def set_system_time(newtime):
     :return: Returns True if successful. Otherwise False.
     :rtype: bool
     '''
-    # Parse time values from new time
-    time_format = _get_date_time_format(newtime)
-    dt_obj = datetime.strptime(newtime, time_format)
+    # Get date/time object from newtime
+    dt_obj = salt.utils.date_cast(newtime)
 
     # Set time using set_system_date_time()
     return set_system_date_time(hours=int(dt_obj.strftime('%H')),
@@ -879,9 +847,8 @@ def set_system_date(newdate):
 
         salt '*' system.set_system_date '03-28-13'
     '''
-    # Parse time values from new time
-    date_format = _get_date_time_format(newdate)
-    dt_obj = datetime.strptime(newdate, date_format)
+    # Get date/time object from newdate
+    dt_obj = salt.utils.date_cast(newdate)
 
     # Set time using set_system_date_time()
     return set_system_date_time(years=int(dt_obj.strftime('%Y')),


### PR DESCRIPTION
### What does this PR do?

Removes `_get_date_time_format` function in favor of `salt.utils.date_cast`
Also fixes a problem with an incorrect version of timelib needed for `salt.utils.date_cast`
### What issues does this PR fix or reference?

https://github.com/saltstack/zh/issues/278
### Previous Behavior

Previous modules used _get_date_time_format to determine the date/time format and then create a DT object. I was unaware of the function `salt.utils.date_cast` that did pretty much the same thing... cleaner. This had already been done for `win_useradd.py`.
### New Behavior

Uses `salt.utils.date_cast()` instead of my own home cooked version.
### Tests written?

No
