### PR TITLE
update pip state and integration tests for newer pip versions

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -432,6 +432,11 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
     mirrors
         Specific mirror URL(s) to query (automatically adds --use-mirrors)
 
+        .. warning::
+
+            This option has been deprecated and removed in pip version 7.0.0.
+            Please use ``index_url`` and/or ``extra_index_url`` instead.
+
     build
         Unpack packages into ``build`` dir
 
@@ -688,6 +693,14 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
         cmd.append('--no-index')
 
     if mirrors:
+        # https://github.com/pypa/pip/pull/2641/files#diff-3ef137fb9ffdd400f117a565cd94c188L216
+        pip_version = version(pip_bin)
+        if salt.utils.compare_versions(ver1=pip_version, oper='>=', ver2='7.0.0'):
+            raise CommandExecutionError(
+                    'pip >= 7.0.0 does not support mirror argument:'
+                    ' use index_url and/or extra_index_url instead'
+            )
+
         if isinstance(mirrors, string_types):
             mirrors = [m.strip() for m in mirrors.split(',')]
 

--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -287,7 +287,7 @@ def create(path,
     # Install pip
     if pip and not os.path.exists(venv_pip):
         _ret = _install_script(
-            'https://raw.githubusercontent.com/pypa/pip/master/contrib/get-pip.py',
+            'https://bootstrap.pypa.io/get-pip.py',
             path, venv_python, user, saltenv=saltenv, use_vt=use_vt
         )
         # Let's update the return dictionary with the details from the pip

--- a/tests/integration/files/file/base/issue-1959-virtualenv-runas/init.sls
+++ b/tests/integration/files/file/base/issue-1959-virtualenv-runas/init.sls
@@ -1,4 +1,4 @@
 {{ salt['runtests_helpers.get_sys_temp_dir_for_path']('issue-1959-virtualenv-runas') }}:
-  virtualenv.manage:
+  virtualenv.managed:
     - requirements: salt://issue-1959-virtualenv-runas/requirements.txt
     - user: issue-1959

--- a/tests/integration/files/file/base/issue-2028-pip-installed.sls
+++ b/tests/integration/files/file/base/issue-2028-pip-installed.sls
@@ -7,6 +7,5 @@ supervisord-pip:
     pip.installed:
       - name: supervisor
       - bin_env: {{ salt['runtests_helpers.get_sys_temp_dir_for_path']('issue-2028-pip-installed') }}
-      - mirrors: http://testpypi.python.org/pypi
       - require:
         - virtualenv: {{ salt['runtests_helpers.get_sys_temp_dir_for_path']('issue-2028-pip-installed') }}

--- a/tests/integration/files/file/base/issue-2068-template-str-no-dot.sls
+++ b/tests/integration/files/file/base/issue-2068-template-str-no-dot.sls
@@ -9,6 +9,5 @@ pep8-pip:
     - installed
     - name: pep8
     - bin_env: {{ salt['runtests_helpers.get_sys_temp_dir_for_path']('issue-2068-template-str') }}
-    - mirrors: http://testpypi.python.org/pypi
     - require:
       - virtualenv: {{ salt['runtests_helpers.get_sys_temp_dir_for_path']('issue-2068-template-str') }}

--- a/tests/integration/files/file/base/issue-2068-template-str.sls
+++ b/tests/integration/files/file/base/issue-2068-template-str.sls
@@ -7,6 +7,5 @@ pep8-pip:
   pip.installed:
     - name: pep8
     - bin_env: {{ salt['runtests_helpers.get_sys_temp_dir_for_path']('issue-2068-template-str') }}
-    - mirrors: http://testpypi.python.org/pypi
     - require:
       - virtualenv: {{ salt['runtests_helpers.get_sys_temp_dir_for_path']('issue-2068-template-str') }}

--- a/tests/integration/files/file/base/issue-2087-missing-pip.sls
+++ b/tests/integration/files/file/base/issue-2087-missing-pip.sls
@@ -1,5 +1,4 @@
 pep8-pip:
   pip.installed:
     - name: pep8
-    - mirrors: http://testpypi.python.org/pypi
     - bin_env: {{ salt['runtests_helpers.get_sys_temp_dir_for_path']('issue-2087-missing-pip') }}

--- a/tests/integration/files/file/base/pip-installed-errors.sls
+++ b/tests/integration/files/file/base/pip-installed-errors.sls
@@ -1,5 +1,4 @@
 supervisord-pip:
     pip.installed:
       - name: supervisor
-      - mirrors: http://testpypi.python.org/pypi
       - bin_env: {{ salt['runtests_helpers.get_sys_temp_dir_for_path']('pip-installed-errors') }}

--- a/tests/integration/files/file/base/pip-installed-weird-install.sls
+++ b/tests/integration/files/file/base/pip-installed-weird-install.sls
@@ -8,6 +8,5 @@ carbon-weird-setup:
     - name: carbon
     - no_deps: True
     - bin_env: {{ salt['runtests_helpers.get_sys_temp_dir_for_path']('pip-installed-weird-install') }}
-    - mirrors: http://testpypi.python.org/pypi
     - require:
       - virtualenv: {{ salt['runtests_helpers.get_sys_temp_dir_for_path']('pip-installed-weird-install') }}

--- a/tests/unit/modules/pip_test.py
+++ b/tests/unit/modules/pip_test.py
@@ -124,7 +124,11 @@ class PipTestCase(TestCase):
                 python_shell=False,
             )
 
+    @patch.object(pip, 'version', MagicMock(return_value='1.4'))
     def test_issue5940_install_multiple_pip_mirrors(self):
+        '''
+        test multiple pip mirrors.  This test only works with pip < 7.0.0
+        '''
         mirrors = [
             'http://g.pypi.python.org',
             'http://c.pypi.python.org',


### PR DESCRIPTION
### What does this PR do?
- update integration tests to work with newer versions of pip.  @s0undt3ch, @jtand
- update the pip bootstrap URL
- add a check for pip version before using the `--mirrors` argument
### What issues does this PR fix or reference?

saltstack/salt-jenkins#158
### Tests written?

Yes
