### PR TITLE
Specify EBS volume tags in profile configuration in aws

### DIFF
--- a/doc/topics/cloud/aws.rst
+++ b/doc/topics/cloud/aws.rst
@@ -273,6 +273,7 @@ Set up an initial profile at ``/etc/salt/cloud.profiles``:
         - { size: 10, device: /dev/sdf }
         - { size: 10, device: /dev/sdg, type: io1, iops: 1000 }
         - { size: 10, device: /dev/sdh, type: io1, iops: 1000 }
+        - { size: 10, device: /dev/sdi, tags: {"Environment": "production"} }
       # optionally add tags to profile:
       tag: {'Environment': 'production', 'Role': 'database'}
       # force grains to sync after install

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2664,6 +2664,8 @@ def create_attach_volumes(name, kwargs, call=None, wait_to_finish=True):
                 '\'snapshot\', or \'size\''
             )
 
+        if 'tags' in volume:
+            volume_dict['tags'] = volume['tags']
         if 'type' in volume:
             volume_dict['type'] = volume['type']
         if 'iops' in volume:


### PR DESCRIPTION
### What does this PR do?

Adds ability to add tags for a volume in the cloud profile configuration file. You can now specify volume tags for aws ebs volumes in your /etc/salt/cloud.profiles.d/ like so:

```
volumes:
  - { size: 10, device: /dev/sdi, tags: {"Environment": "production"} } 
```
### What issues does this PR fix or reference?

NA
### Previous Behavior

You could not specify the tags for a volume in the profile configuration only with an execution module like so: `salt-cloud -f create_volume my-ec2-config zone=us-east-1b tags='{"tag1": "val1", "tag2", "val2"}'`
### New Behavior

Now can add the tags in your profile configuration file.
### Tests written?

No
