### PR TITLE
Reload renderers for local pillar after gitfs

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -791,6 +791,7 @@ class Pillar(object):
         if ext:
             if self.opts.get('ext_pillar_first', False):
                 self.opts['pillar'], errors = self.ext_pillar({}, pillar_dirs)
+                self.rend = salt.loader.render(self.opts, self.functions)
                 matches = self.top_matches(top)
                 pillar, errors = self.render_pillar(matches, errors=errors)
                 pillar = merge(pillar,


### PR DESCRIPTION
### What does this PR do?

Because of the way the renderers are lazy loaded when using ext_pillar_first
and gitfs external pillar, the renderers for the local pillar object were
being set to the last loaded gitfs pillar.

This was causing the local pillar to fail to render.  This small fix
forces a reload of the renderers after all the external pillars are done
loading.

This is bit of a bandaid fix, and a longer term fix should probably
be investigated.
### What issues does this PR fix or reference?

Fixes #32810
### Previous Behavior

When using ext_pillar_first and gitfs, local pillars fail to render.
### New Behavior

Local pillars now render properly after external gitfs pillars are loaded.
### Tests written?

No
