### PR TITLE
Tests run py3

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -1240,6 +1240,4 @@ class Crypticle(object):
         if not data.startswith(self.PICKLE_PAD):
             return {}
         load = self.serial.loads(data[len(self.PICKLE_PAD):], raw=raw)
-        if six.PY3 and not raw:
-            load = salt.transport.frame.decode_embedded_strs(load)
         return load

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -1231,7 +1231,7 @@ class Crypticle(object):
         '''
         return self.encrypt(self.PICKLE_PAD + self.serial.dumps(obj))
 
-    def loads(self, data):
+    def loads(self, data, raw=False):
         '''
         Decrypt and un-serialize a python object
         '''
@@ -1239,7 +1239,7 @@ class Crypticle(object):
         # simple integrity check to verify that we got meaningful data
         if not data.startswith(self.PICKLE_PAD):
             return {}
-        load = self.serial.loads(data[len(self.PICKLE_PAD):])
-        if six.PY3:
+        load = self.serial.loads(data[len(self.PICKLE_PAD):], raw=raw)
+        if six.PY3 and not raw:
             load = salt.transport.frame.decode_embedded_strs(load)
         return load

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -11,6 +11,7 @@ import time
 
 # Import Salt libs
 import salt.defaults.exitcodes
+import salt.ext.six as six
 
 log = logging.getLogger(__name__)
 
@@ -39,6 +40,8 @@ class SaltException(Exception):
         Pack this exception into a serializable dictionary that is safe for
         transport via msgpack
         '''
+        if six.PY3:
+            return {'message': str(self), 'args': self.args}
         return dict(message=self.__unicode__(), args=self.args)
 
 

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -956,31 +956,31 @@ class RemoteClient(Client):
                 load['loc'] = 0
             else:
                 load['loc'] = fn_.tell()
-            data = self.channel.send(load)
+            data = self.channel.send(load, raw=True)
             try:
-                if not data['data']:
-                    if not fn_ and data['dest']:
+                if not data[b'data']:
+                    if not fn_ and data[b'dest']:
                         # This is a 0 byte file on the master
                         with self._cache_loc(
-                                data['dest'],
+                                data[b'dest'],
                                 saltenv,
                                 cachedir=cachedir) as cache_dest:
                             dest = cache_dest
                             with salt.utils.fopen(cache_dest, 'wb+') as ofile:
-                                ofile.write(data['data'])
-                    if 'hsum' in data and d_tries < 3:
+                                ofile.write(data[b'data'])
+                    if b'hsum' in data and d_tries < 3:
                         # Master has prompted a file verification, if the
                         # verification fails, re-download the file. Try 3 times
                         d_tries += 1
-                        hsum = salt.utils.get_hash(dest, data.get('hash_type', 'md5'))
-                        if hsum != data['hsum']:
+                        hsum = salt.utils.get_hash(dest, data.get(b'hash_type', 'md5'))
+                        if hsum != data[b'hsum']:
                             log.warning('Bad download of file {0}, attempt {1} '
                                      'of 3'.format(path, d_tries))
                             continue
                     break
                 if not fn_:
                     with self._cache_loc(
-                            data['dest'],
+                            data[b'dest'],
                             saltenv,
                             cachedir=cachedir) as cache_dest:
                         dest = cache_dest
@@ -989,10 +989,10 @@ class RemoteClient(Client):
                         if os.path.isdir(dest):
                             salt.utils.rm_rf(dest)
                         fn_ = salt.utils.fopen(dest, 'wb+')
-                if data.get('gzip', None):
-                    data = salt.utils.gzip_util.uncompress(data['data'])
+                if data.get(b'gzip', None):
+                    data = salt.utils.gzip_util.uncompress(data[b'data'])
                 else:
-                    data = data['data']
+                    data = data[b'data']
                 fn_.write(data)
             except (TypeError, KeyError) as e:
                 transport_tries += 1

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -729,7 +729,7 @@ class FSChan(object):
         self.fs.update()
         self.cmd_stub = {'ext_nodes': {}}
 
-    def send(self, load, tries=None, timeout=None):
+    def send(self, load, tries=None, timeout=None, raw=False):  # pylint: disable=unused-argument
         '''
         Emulate the channel send method, the tries and timeout are not used
         '''

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -15,6 +15,7 @@ import datetime
 # Import salt libs
 import salt.log
 import salt.crypt
+import salt.transport.frame
 from salt.exceptions import SaltReqTimeoutError
 
 # Import third party libs
@@ -108,7 +109,7 @@ class Serial(object):
         else:
             self.serial = 'msgpack'
 
-    def loads(self, msg, encoding=None):
+    def loads(self, msg, encoding=None, raw=False):
         '''
         Run the correct loads serialization format
 
@@ -132,9 +133,11 @@ class Serial(object):
                 # Due to this, if we don't need it, don't pass it at all so
                 # that under Python 2 we can still work with older versions
                 # of msgpack.
-                return msgpack.loads(msg, use_list=True, encoding=encoding)
+                ret = msgpack.loads(msg, use_list=True, encoding=encoding)
             else:
-                return msgpack.loads(msg, use_list=True)
+                ret = msgpack.loads(msg, use_list=True)
+            if six.PY3 and not raw:
+                ret = salt.transport.frame.decode_embedded_strs(ret)
         except Exception as exc:
             log.critical('Could not deserialize msgpack message: {0}'
                          'This often happens when trying to read a file not in binary mode.'
@@ -142,6 +145,7 @@ class Serial(object):
             raise
         finally:
             gc.enable()
+        return ret
 
     def load(self, fn_):
         '''

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -136,7 +136,7 @@ class Serial(object):
                 ret = msgpack.loads(msg, use_list=True, encoding=encoding)
             else:
                 ret = msgpack.loads(msg, use_list=True)
-            if six.PY3 and not raw:
+            if six.PY3 and encoding is None and not raw:
                 ret = salt.transport.frame.decode_embedded_strs(ret)
         except Exception as exc:
             log.critical('Could not deserialize msgpack message: {0}'

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -718,7 +718,7 @@ class Pillar(object):
                 errors.append('The "ext_pillar" option is malformed')
                 log.critical(errors[-1])
                 return {}, errors
-            if run.keys()[0] in self.opts.get('exclude_ext_pillar', []):
+            if next(six.iterkeys(run)) in self.opts.get('exclude_ext_pillar', []):
                 continue
             for key, val in six.iteritems(run):
                 if key not in self.ext_pillars:

--- a/salt/renderers/yaml.py
+++ b/salt/renderers/yaml.py
@@ -80,6 +80,8 @@ def _yaml_result_unicode_to_utf8(data):
 
     This is a recursive function
     '''
+    if six.PY3:
+        return data
     if isinstance(data, OrderedDict):
         for key, elt in six.iteritems(data):
             data[key] = _yaml_result_unicode_to_utf8(elt)

--- a/salt/transport/client.py
+++ b/salt/transport/client.py
@@ -22,7 +22,7 @@ class ReqChannel(object):
         sync = SyncWrapper(AsyncReqChannel.factory, (opts,), kwargs)
         return sync
 
-    def send(self, load, tries=3, timeout=60):
+    def send(self, load, tries=3, timeout=60, raw=False):
         '''
         Send "load" to the master.
         '''
@@ -119,7 +119,7 @@ class AsyncReqChannel(AsyncChannel):
             raise Exception('Channels are only defined for ZeroMQ and raet')
             # return NewKindOfChannel(opts, **kwargs)
 
-    def send(self, load, tries=3, timeout=60):
+    def send(self, load, tries=3, timeout=60, raw=False):
         '''
         Send "load" to the master.
         '''

--- a/salt/transport/local.py
+++ b/salt/transport/local.py
@@ -20,7 +20,7 @@ class LocalChannel(ReqChannel):
         self.kwargs = kwargs
         self.tries = 0
 
-    def send(self, load, tries=3, timeout=60):
+    def send(self, load, tries=3, timeout=60, raw=False):
 
         if self.tries == 0:
             log.debug('LocalChannel load: {0}').format(load)

--- a/salt/transport/raet.py
+++ b/salt/transport/raet.py
@@ -127,7 +127,7 @@ class RAETReqChannel(ReqChannel):
         '''
         return self.send(load, tries, timeout)
 
-    def send(self, load, tries=3, timeout=60):
+    def send(self, load, tries=3, timeout=60, raw=False):
         '''
         Send a message load and wait for a relative reply
         One shot wonder

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -249,7 +249,7 @@ class AsyncTCPReqChannel(salt.transport.client.ReqChannel):
         raise tornado.gen.Return(ret)
 
     @tornado.gen.coroutine
-    def send(self, load, tries=3, timeout=60):
+    def send(self, load, tries=3, timeout=60, raw=False):
         '''
         Send a request, return a future which will complete when we send the message
         '''

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -823,7 +823,7 @@ class SaltMessageClient(object):
                 SaltReqTimeoutError('Message timed out')
             )
 
-    def send(self, msg, timeout=None, callback=None):
+    def send(self, msg, timeout=None, callback=None, raw=False):
         '''
         Send given message, and return a future
         '''

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -946,7 +946,7 @@ class AsyncReqMessageClient(object):
             else:
                 future.set_exception(SaltReqTimeoutError('Message timed out'))
 
-    def send(self, message, timeout=None, tries=3, future=None, callback=None):
+    def send(self, message, timeout=None, tries=3, future=None, callback=None, raw=False):
         '''
         Return a future which will be completed when the message has a response
         '''

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -841,6 +841,11 @@ def path_join(*parts):
     See tests/unit/utils/path_join_test.py for some examples on what's being
     talked about here.
     '''
+    if six.PY3:
+        new_parts = []
+        for part in parts:
+            new_parts.append(to_str(part))
+        parts = new_parts
     # Normalize path converting any os.sep as needed
     parts = [os.path.normpath(p) for p in parts]
 


### PR DESCRIPTION
### What does this PR do?

This extends #32366 which gets salt running on python3 for the zeromq transport, these fixes get the salt test suite to start and run under python3!

Only merge after merging #32366

It has a lot of failures, but it runs surprisingly well!
### What issues does this PR fix or reference?
### Previous Behavior

Remove this section if not relevant
### New Behavior

Remove this section if not relevant
### Tests written?

Yes/No
