### PR TITLE
Use cmd_async instead of cmd when calling saltutil.revoke_auth

### DIFF
--- a/salt/key.py
+++ b/salt/key.py
@@ -856,7 +856,7 @@ class Key(object):
                         else:
                             try:
                                 client = salt.client.get_local_client(mopts=self.opts)
-                                client.cmd(key, 'saltutil.revoke_auth')
+                                client.cmd_async(key, 'saltutil.revoke_auth')
                             except salt.exceptions.SaltClientError:
                                 print('Cannot contact Salt master. '
                                       'Connection for {0} will remain up until '
@@ -1318,7 +1318,7 @@ class RaetKey(Key):
                     else:
                         try:
                             client = salt.client.get_local_client(mopts=self.opts)
-                            client.cmd(key, 'saltutil.revoke_auth')
+                            client.cmd_async(key, 'saltutil.revoke_auth')
                         except salt.exceptions.SaltClientError:
                             print('Cannot contact Salt master. '
                                   'Connection for {0} will remain up until '


### PR DESCRIPTION
### What does this PR do?

Allow the CLI to continue instead of blocking while waiting for authentication to be revoked when using `salt-key -d`.
### What issues does this PR fix or reference?

Fixes #32896
### Previous Behavior

When authentication revocation was added to all `salt-key -d` calls in #26918, this caused the CLI to block until all authentication had been revoked for all minions in the list of keys to delete. This made it look like salt-key was spinning and never returning. With a single minion:

```
root@rallytime:~# time salt-key -d ms-02
The following keys are going to be deleted:
Accepted Keys:
ms-02
Proceed? [N/y] y
Key for minion ms-02 deleted.

real    0m16.952s
user    0m0.447s
sys 0m0.183s
```
### New Behavior

Uses `cmd_async` instead of `cmd` so the CLI won't block while waiting for auth revocation and restores a reasonable expected return time for `salt-key -d`:

```
root@rallytime:~# time salt-key -d nt-1
The following keys are going to be deleted:
Accepted Keys:
nt-1
Proceed? [N/y] y
Key for minion nt-1 deleted.

real    0m1.996s
user    0m0.253s
sys 0m0.167s
```
### Tests written?

No

@cachedout Please review. Also ping @thatch45.
