### PR TITLE
fix error in using alternate hash in py3

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -972,7 +972,7 @@ class RemoteClient(Client):
                         # Master has prompted a file verification, if the
                         # verification fails, re-download the file. Try 3 times
                         d_tries += 1
-                        hsum = salt.utils.get_hash(dest, data.get(b'hash_type', 'md5'))
+                        hsum = salt.utils.get_hash(dest, salt.utils.to_str(data.get(b'hash_type', b'md5')))
                         if hsum != data[b'hsum']:
                             log.warning('Bad download of file {0}, attempt {1} '
                                      'of 3'.format(path, d_tries))


### PR DESCRIPTION
### What does this PR do?

prevents a stack trace in the minion when running py3 and a checksum other than the default is set
### What issues does this PR fix or reference?
### Previous Behavior

Remove this section if not relevant
### New Behavior

Remove this section if not relevant
### Tests written?

Yes/No
