### PR TITLE
Replace args and kwargs (plural) by arg and kwarg (singular) for ``RunnerClient``

### DIFF
--- a/doc/topics/releases/2016.3.0.rst
+++ b/doc/topics/releases/2016.3.0.rst
@@ -180,6 +180,32 @@ next.  The next release is codenamed **Carbon**, the following is **Nitrogen**.
 The example proxy minions ``rest_sample`` and ``ssh_sample`` have been updated to
 reflect these changes.
 
+RunnerClient Changes
+====================
+
+Deprecation warning:
+Salt's ``RunnerClient`` class now accepts ``arg`` and ``kwarg`` (singular)
+instead of the plural form args and kwargs in the low data. Passing plural forms for args
+and kwargs will throw a ``RuntimeException`` for Salt Oxygen (and subsequent releases).
+Until Salt Oxygen args and kwargs will also be accepted along with arg and kwarg.
+
+An example of the new low data:
+
+.. code-block:: python
+
+   opts = salt.config.master_config('/etc/salt/master')
+
+   client = salt.runner.RunnerClient(opts)
+
+   client.cmd_sync({
+       'fun': 'test.arg',
+       'client': 'runner',
+       'arg': ['an', 'argument', 'list'],
+       'kwarg': {'key': 'value'},
+   })
+
+The above example will also work with ``args`` and ``kwargs``
+until the ``Salt Oxygen`` release.
 
 Module Changes
 ==============

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -226,8 +226,8 @@ class SyncClientMixin(object):
             self.functions[fun], arglist, pub_data
         )
         low = {'fun': fun,
-               'args': args,
-               'kwargs': kwargs}
+               'arg': args,
+               'kwarg': kwargs}
         return self.low(fun, low)
 
     @property
@@ -313,23 +313,23 @@ class SyncClientMixin(object):
             # we make the transition we will load "kwargs" using format_call if
             # there are no kwargs in the low object passed in
             f_call = None
-            if 'args' not in low:
+            if 'arg' not in low:
                 f_call = salt.utils.format_call(
                     self.functions[fun],
                     low,
                     expected_extra_kws=CLIENT_INTERNAL_KEYWORDS
                 )
-                args = f_call.get('args', ())
+                args = f_call.get('arg', ())
             else:
-                args = low['args']
-            if 'kwargs' not in low:
+                args = low['arg']
+            if 'kwarg' not in low:
                 if f_call is None:
                     f_call = salt.utils.format_call(
                         self.functions[fun],
                         low,
                         expected_extra_kws=CLIENT_INTERNAL_KEYWORDS
                     )
-                kwargs = f_call.get('kwargs', {})
+                kwargs = f_call.get('kwarg', {})
 
                 # throw a warning for the badly formed low data if we found
                 # kwargs using the old mechanism
@@ -339,7 +339,7 @@ class SyncClientMixin(object):
                         'kwargs must be passed inside the low under "kwargs"'
                     )
             else:
-                kwargs = low['kwargs']
+                kwargs = low['kwarg']
 
             # Initialize a context for executing the method.
             with tornado.stack_context.StackContext(self.functions.context_dict.clone):

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -244,12 +244,10 @@ class SyncClientMixin(object):
         msg = []
         if 'args' in low:
             msg.append('call with arg instead')
-            low['arg'] = low['args']
-            del low['args']
+            low['arg'] = low.pop('args')
         if 'kwargs' in low:
             msg.append('call with kwarg instead')
-            low['kwarg'] = low['kwargs']
-            del low['kwargs']
+            low['kwarg'] = low.pop('kwargs')
 
         if msg:
             warn_until('Oxygen', ' '.join(msg))

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -63,7 +63,7 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
         reformatted_low = {'fun': fun}
         reformatted_low.update(auth_creds)
         # Support old style calls where arguments could be specified in 'low' top level
-        if not low.get('args') and not low.get('kwargs'):  # not specified or empty
+        if not low.get('arg') and not low.get('kwarg'):  # not specified or empty
             verify_fun(self.functions, fun)
             merged_args_kwargs = salt.utils.args.condition_input([], low)
             parsed_input = salt.utils.args.parse_input(merged_args_kwargs)
@@ -73,12 +73,12 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
                 self.opts,
                 ignore_invalid=True
             )
-            low['args'] = args
-            low['kwargs'] = kwargs
-        if 'kwargs' not in low:
-            low['kwargs'] = {}
-        if 'args' not in low:
-            low['args'] = []
+            low['arg'] = args
+            low['kwarg'] = kwargs
+        if 'kwarg' not in low:
+            low['kwarg'] = {}
+        if 'arg' not in low:
+            low['arg'] = []
         reformatted_low['kwarg'] = low
         return reformatted_low
 
@@ -158,8 +158,8 @@ class Runner(RunnerClient):
                     salt.utils.args.parse_input(self.opts['arg']),
                     self.opts,
                 )
-                low['args'] = args
-                low['kwargs'] = kwargs
+                low['arg'] = args
+                low['kwarg'] = kwargs
 
                 user = salt.utils.get_specific_user()
 

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -465,7 +465,7 @@ class _WithDeprecated(_DeprecationDecorator):
 
 
     In case there is a need to deprecate a function and rename it,
-    the decorator shuld be used with the 'with_name' parameter. This
+    the decorator should be used with the 'with_name' parameter. This
     parameter is pointing to the existing deprecated function. In this
     case deprecation process as follows:
 


### PR DESCRIPTION
### What does this PR do?
- Adds support for `arg` and `kwarg` to `RunnerClient`
- Removes  `args` and `kwargs` from `RunnerClient`
### What issues does this PR fix or reference?

First 2 steps of #32778 
### Previous Behavior

`RunnerClient` would be called with `args` and `kwargs`
### New Behavior

`RunnerClient` now to be called with `arg` and `kwarg`
### Tests written?

Yes
