### PR TITLE
Adding intermediate certificate support to rest_cherrypy

### DIFF
--- a/salt/netapi/rest_cherrypy/__init__.py
+++ b/salt/netapi/rest_cherrypy/__init__.py
@@ -92,5 +92,7 @@ def start():
         cherrypy.server.ssl_module = 'builtin'
         cherrypy.server.ssl_certificate = apiopts['ssl_crt']
         cherrypy.server.ssl_private_key = apiopts['ssl_key']
+        if 'ssl_chain' in apiopts.keys():
+            cherrypy.server.ssl_certificate_chain = apiopts['ssl_chain']
 
     cherrypy.quickstart(root, apiopts.get('root_prefix', '/'), conf)


### PR DESCRIPTION
### What does this PR do?

This change configures cherrypy to use an intermediate certificate, if configured in the master conf.
### What issues does this PR fix or reference?

N/A
### Previous Behavior

Wasn't possible to configure cherrypy to use an intermediate certificate, forcing users to proxy with Apache, Nginx, etc. 
### Tests written?

No... I did some manual testing to make sure it works... self-signed
certs (with no intermediate configured in the master conf) still work...
and I tested with a valid GoDaddy cert and their intermediate too.
