### PR TITLE
Make tornado raise error configurable

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -132,6 +132,7 @@ def query(url,
           handle=False,
           agent=USERAGENT,
           hide_fields=None,
+          raise_error=True,
           **kwargs):
     '''
     Query a resource, and decode the return data
@@ -479,6 +480,7 @@ def query(url,
                     proxy_port=proxy_port,
                     proxy_username=proxy_username,
                     proxy_password=proxy_password,
+                    raise_error=raise_error,
                     **req_kwargs
                 )
             else:
@@ -498,6 +500,7 @@ def query(url,
                     proxy_port=proxy_port,
                     proxy_username=proxy_username,
                     proxy_password=proxy_password,
+                    raise_error=raise_error,
                     **req_kwargs
                 )
         except tornado.httpclient.HTTPError as exc:


### PR DESCRIPTION
### What does this PR do?

Let us disable "default" tornado behavior upon request in case non 200 response is returned. By default it raise an error without checking for body of the error. 
### What issues does this PR fix or reference?

Systems like kubernetes provide description of error message while returning non 200 status code. Example of this message is:

```
status: 400
body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"asafdlakj in version \"v1\" cannot be handled as a ReplicationController: no kind \"asafdlakj\" is registered for version \"v1\"","reason":"BadRequest","code":400}
```

while with default raising error for the same POST query, I can got only:

```
        error:
            HTTP 400: Bad Request
        status:
            400
```

which makes impossible to create human friendly error messaging. This blocks me to push complete k8s module, as one moths of usage on our environment proved that it is impossible to manage production systems without proper logging of errors. 
