### PR TITLE
When move a function to a new namespace, allow to keep original context.

### DIFF
--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -70,7 +70,7 @@ def __virtual__():
     if 'dockerng.version' in __salt__:
         global _validate_input  # pylint: disable=global-statement
         _validate_input = salt.utils.namespaced_function(
-            _validate_input, globals()
+            _validate_input, globals(), preserve_context=True,
         )
         return __virtualname__
     return (False, __salt__.missing_fun_string('dockerng.version'))

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -2030,13 +2030,22 @@ def get_hash(path, form='sha256', chunk_size=65536):
         return hash_obj.hexdigest()
 
 
-def namespaced_function(function, global_dict, defaults=None):
+def namespaced_function(function, global_dict, defaults=None, preserve_context=False):
     '''
     Redefine (clone) a function under a different globals() namespace scope
+
+        preserve_context:
+            Allow to keep the context taken from orignal namespace,
+            and extend it with globals() taken from
+            new targetted namespace.
     '''
     if defaults is None:
         defaults = function.__defaults__
 
+    if preserve_context:
+        _global_dict = function.__globals__.copy()
+        _global_dict.update(global_dict)
+        global_dict = _global_dict
     new_namespaced_function = types.FunctionType(
         function.__code__,
         global_dict,

--- a/tests/unit/states/dockerng_test.py
+++ b/tests/unit/states/dockerng_test.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 
 # Import Salt Testing Libs
 from salttesting import skipIf, TestCase
+from salt.exceptions import SaltInvocationError
 from salttesting.helpers import ensure_in_syspath
 from salttesting.mock import (
     MagicMock,
@@ -1082,6 +1083,21 @@ class DockerngTestCase(TestCase):
                                            validate_input=False,
                                            name='cont',
                                            client_timeout=60)
+
+    def test_validate_input_min_docker_py(self):
+        docker_mock = Mock()
+        docker_mock.version_info = (1, 0, 0)
+        dockerng_mod.docker = None
+        with patch.dict(dockerng_mod.VALID_CREATE_OPTS['command'],
+                        {'path': 'Config:Cmd',
+                         'image_path': 'Config:Cmd',
+                         'min_docker_py': (999, 0, 0)}):
+            with patch.object(dockerng_mod, 'docker', docker_mock):
+                self.assertRaisesRegexp(SaltInvocationError,
+                                        "The 'command' parameter requires at"
+                                        " least docker-py 999.0.0.*$",
+                                        dockerng_state._validate_input,
+                                        {'command': 'echo boom'})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?

Attempt to extend `salt.utils.namespaced_function()` by preserving available context
of function before recreated in new module.
### What issues does this PR fix or reference?

 #32887
### Previous Behavior

When moved function refers to a resource only available in original namespace, `NameError` was raised
### New Behavior

New function keeps references to resources existing in original context.
### Tests written?

Yes
