### PR TITLE
OpenSSL.crypto.X509Extension object is not serializable

### DIFF
--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -1574,7 +1574,7 @@ def cert_info(cert_path, digest='sha256'):
         ret['extensions'] = {}
         for i in _range(cert.get_extension_count()):
             ext = cert.get_extension(i)
-            ret['extensions'][ext.get_short_name()] = ext
+            ret['extensions'][ext.get_short_name()] = str(ext)
 
     if 'subjectAltName' in ret.get('extensions', {}):
         valid_names = set()


### PR DESCRIPTION
### What issues does this PR fix or reference?

Function `cert_info` in tls module fails if certificate has additional info because OpenSSL.crypto.X509Extension object is not serializable:

`salt '*' tls.cert_info /path/to/cert.pem`
`Minion did not return. [No response]`

Log from minion:
`TypeError: can't serialize <OpenSSL.crypto.X509Extension object at 0x7fc80d70c350>`
### Tests written?

No
