### PR TITLE
Fixed glusterfs.peered output

### DIFF
--- a/salt/states/glusterfs.py
+++ b/salt/states/glusterfs.py
@@ -89,7 +89,7 @@ def peered(name):
 
     newpeers = __salt__['glusterfs.list_peers']()
     # if newpeers was null, we know something didn't work.
-    if newpeers and name in newpeers or any([name in newpeers[x] for x in newpeers]):
+    if newpeers and name in newpeers or newpeers and any([name in newpeers[x] for x in newpeers]):
         ret['result'] = True
         ret['changes'] = {'new': newpeers, 'old': peers}
     # In case the hostname doesn't have any periods in it


### PR DESCRIPTION
### What does this PR do?

Fixes 'NoneType' object is not iterable issue and removes existing peers from newpeers list
### What issues does this PR fix or reference?

Issue #32954
### Previous Behavior

```
----------
          ID: glusterfs_peers
    Function: glusterfs.peered
        Name: 172.16.20.101
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1626, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1492, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/states/glusterfs.py", line 92, in peered
                  if newpeers and name in newpeers or any([name in newpeers[x] for x in newpeers]):
              TypeError: 'NoneType' object is not iterable
     Started: 19:25:36.955326
    Duration: 268.857 ms
     Changes:   
```
### New Behavior

```
----------
          ID: glusterfs_peers
    Function: glusterfs.peered
        Name: 172.16.20.101
      Result: True
     Comment: Peering with localhost is not needed
     Started: 20:05:16.446194
    Duration: 271.019 ms
     Changes:   
```
### Tests written?

No
