### PR TITLE
Reset signal handling when restarting the minion.

### DIFF
--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -124,6 +124,8 @@ def salt_minion():
         os.kill(pid, signum)
 
     # keep one minion subprocess running
+    prev_sigint_handler = signal.getsignal(signal.SIGINT)
+    prev_sigterm_handler = signal.getsignal(signal.SIGTERM)
     while True:
         try:
             process = multiprocessing.Process(target=minion_process)
@@ -141,6 +143,11 @@ def salt_minion():
             break
 
         process.join()
+
+        # Process exited or was terminated. Since we're going to try to restart
+        # it, we MUST, reset signal handling to the previous handlers
+        signal.signal(signal.SIGINT, prev_sigint_handler)
+        signal.signal(signal.SIGTERM, prev_sigterm_handler)
 
         if not process.exitcode == salt.defaults.exitcodes.SALT_KEEPALIVE:
             break

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -1076,7 +1076,7 @@ class EventReturn(salt.utils.process.SignalHandlingMultiprocessingProcess):
             del self.event_queue[:]
         else:
             log.error('Could not store return for event(s) - returner '
-                '\'{1}\' not found.'.format(self.opts['event_return']))
+                      '\'%s\' not found.', self.opts['event_return'])
 
     def run(self):
         '''


### PR DESCRIPTION
### What does this PR do?

This will avoid a hang on multiple failover masters on the 2nd restart.
### What issues does this PR fix or reference?

Fixes https://github.com/saltstack/salt/issues/32750
### Previous Behavior

The minion would block if there wasn't a master running when it tried to restart(on the second iteration).
### New Behavior

Minion no longer blocks on restarts.
### Tests written?

No

_This fix was hacked at +30000 feet. Kids, don't try this at home ;)_
