### PR TITLE
Fix 'present' option when used without 'key_type'

### DIFF
--- a/salt/states/test.py
+++ b/salt/states/test.py
@@ -335,7 +335,7 @@ def _check_key_type(key_str, key_type=None):
     value = __salt__['pillar.get'](key_str, None)
     if value is None:
         return None
-    elif type(value) is not key_type:
+    elif type(value) is not key_type and key_type is not None:
         return False
     else:
         return True

--- a/tests/unit/states/test_test.py
+++ b/tests/unit/states/test_test.py
@@ -11,6 +11,7 @@ from salttesting import TestCase, skipIf
 from salttesting.helpers import ensure_in_syspath
 from salttesting.mock import (
     patch,
+    MagicMock,
     NO_MOCK,
     NO_MOCK_REASON
 )
@@ -114,6 +115,39 @@ class TestTestCase(TestCase):
                     'comment': 'Watch statement fired.'})
         self.assertDictEqual(test.mod_watch('salt'), ret)
 
+    def test_check_pillar_present(self):
+        '''
+            Test to ensure the check_pillar function
+            works properly with the 'present' keyword in
+            the absence of a 'type' keyword.
+        '''
+        ret = {
+            'name': 'salt',
+            'changes': {},
+            'result': True,
+            'comment': ''
+        }
+        pillar_return = 'I am a pillar.'
+        pillar_mock = MagicMock(return_value=pillar_return)
+        with patch.dict(test.__salt__, {'pillar.get': pillar_mock}):
+            self.assertEqual(test.check_pillar('salt', present='my_pillar'), ret)
+
+    def test_check_pillar_dictionary(self):
+        '''
+            Test to ensure the check_pillar function
+            works properly with the 'key_type' checks,
+            using the dictionary key_type.
+        '''
+        ret = {
+            'name': 'salt',
+            'changes': {},
+            'result': True,
+            'comment': ''
+        }
+        pillar_return = {'this': 'dictionary'}
+        pillar_mock = MagicMock(return_value=pillar_return)
+        with patch.dict(test.__salt__, {'pillar.get': pillar_mock}):
+            self.assertEqual(test.check_pillar('salt', dictionary='my_pillar'), ret)
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
### What does this PR do?

It fixes the issue of passing the present option, since in that case, the key_type isn't checked.  Since `None` is passed to  `_check_key_type()` the `present` option will always return False.
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/32964
### Tests written?

Yes.  There were actually no tests for this function previously so I also included a test for one of the "type checks."  Just looking at the code, I doubt more than one "type" check test is needed.  They should all work if one of them does.
