### PR TITLE
fix user cron on solarish operating systems

### DIFF
--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -155,7 +155,7 @@ def _get_cron_cmdstr(path, user=None):
     '''
     cmd = 'crontab'
 
-    if __grains__.get('os_family') not in ('Solaris', 'AIX') and user:
+    if user and __grains__.get('os_family') not in ('Solaris', 'AIX'):
         cmd += ' -u {0}'.format(user)
 
     return '{0} {1}'.format(cmd, path)

--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -221,7 +221,7 @@ def _write_cron_lines(user, lines):
     path = salt.utils.mkstemp()
     if __grains__.get('os_family') in ('Solaris', 'AIX') and appUser != user:
         # on solaris/aix we change to the user before executing the commands
-        with salt.utils.fpopen(path, 'w+', uid=__salt__['file.user_to_uid'](user)) as fp_:
+        with salt.utils.fpopen(path, 'w+', uid=__salt__['file.user_to_uid'](user), mode=600) as fp_:
             fp_.writelines(lines)
         ret = __salt__['cmd.run_all'](_get_cron_cmdstr(path, user),
                                       runas=user,

--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -170,9 +170,21 @@ def write_cron_file(user, path):
     .. code-block:: bash
 
         salt '*' cron.write_cron_file root /tmp/new_cron
+
+    .. versionchanged:: 2015.8.9
+
+    .. note::
+
+        Solaris and AIX require that `path` is readable by `user`
     '''
-    return __salt__['cmd.retcode'](_get_cron_cmdstr(path, user),
-                                   python_shell=False) == 0
+    appUser = __opts__['user']
+    if __grains__.get('os_family') in ('Solaris', 'AIX') and appUser != user:
+        return __salt__['cmd.retcode'](_get_cron_cmdstr(path, user),
+                                       runas=user,
+                                       python_shell=False) == 0
+    else:
+        return __salt__['cmd.retcode'](_get_cron_cmdstr(path, user),
+                                       python_shell=False) == 0
 
 
 def write_cron_file_verbose(user, path):
@@ -184,9 +196,21 @@ def write_cron_file_verbose(user, path):
     .. code-block:: bash
 
         salt '*' cron.write_cron_file_verbose root /tmp/new_cron
+
+    .. versionchanged:: 2015.8.9
+
+    .. note::
+
+        Solaris and AIX require that `path` is readable by `user`
     '''
-    return __salt__['cmd.run_all'](_get_cron_cmdstr(path, user),
-                                   python_shell=False)
+    appUser = __opts__['user']
+    if __grains__.get('os_family') in ('Solaris', 'AIX') and appUser != user:
+        return __salt__['cmd.run_all'](_get_cron_cmdstr(path, user),
+                                       runas=user,
+                                       python_shell=False)
+    else:
+        return __salt__['cmd.run_all'](_get_cron_cmdstr(path, user),
+                                       python_shell=False)
 
 
 def _write_cron_lines(user, lines):

--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -221,13 +221,13 @@ def _write_cron_lines(user, lines):
     path = salt.utils.mkstemp()
     if __grains__.get('os_family') in ('Solaris', 'AIX') and appUser != user:
         # on solaris/aix we change to the user before executing the commands
-        with salt.utils.fpopen(path, 'w+', uid=__salt__['file.user_to_uid'](user), mode=600) as fp_:
+        with salt.utils.fpopen(path, 'w+', uid=__salt__['file.user_to_uid'](user), mode=0o600) as fp_:
             fp_.writelines(lines)
         ret = __salt__['cmd.run_all'](_get_cron_cmdstr(path, user),
                                       runas=user,
                                       python_shell=False)
     else:
-        with salt.utils.fopen(path, 'w+') as fp_:
+        with salt.utils.fpopen(path, 'w+', mode=0o600) as fp_:
             fp_.writelines(lines)
         ret = __salt__['cmd.run_all'](_get_cron_cmdstr(path, user),
                                       python_shell=False)


### PR DESCRIPTION
### What does this PR do?

Run the cron commands as the user on Solaris like operating systems.
Also switched to fpopen so the file is readable by the user.
### What issues does this PR fix or reference?
#32777
### Previous Behavior

Entries for user != root get added to root's crontab.... wiping the exiting entries.
### New Behavior

Entries get added to the correct user's crontab.
### Tests written?

No
### Affected branches
- 2015.8
- 2016.3 (tested)
- develop (tested)
