### PR TITLE
salt-cloud - vultr - Change hard_timeout value to avoid use of timeout command

### DIFF
--- a/salt/cloud/clouds/vultrpy.py
+++ b/salt/cloud/clouds/vultrpy.py
@@ -284,7 +284,7 @@ def create(vm_):
         get_configured_provider(),
         __opts__,
         search_global=False,
-        default=15,
+        default=None,
     )
 
     # Bootstrap


### PR DESCRIPTION
Vultr images seem to have an issue utilizing the timeout command line
util. So change this to not default to using it.

The symptom is that salt-cloud hangs forever in the ssh command that has
timeout set.

I've been using this change locally for some time now. I've spun up
multiple instances of varying size in that time without issue.

Fixes #31388

@cro @techhat
