### PR TITLE
Add pip3 support to pip module

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -118,7 +118,7 @@ def _get_pip_bin(bin_env):
     executable itself, or from searching conventional filesystem locations
     '''
     if not bin_env:
-        which_result = __salt__['cmd.which_bin'](['pip', 'pip2', 'pip-python'])
+        which_result = __salt__['cmd.which_bin'](['pip', 'pip2', 'pip3', 'pip-python'])
         if which_result is None:
             raise CommandNotFoundError('Could not find a `pip` binary')
         if salt.utils.is_windows():


### PR DESCRIPTION
### What does this PR do?

This allows the pip module to use the pip3 binary when python3 is being used. 
### What issues does this PR fix or reference?

https://github.com/saltstack/salt-testing/pull/56
https://github.com/saltstack/salt-jenkins/pull/159
### New Behavior

pip3 binary can be used now. 
### Tests written?

No
