### PR TITLE
Join domain with new name

### DIFF
--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -615,10 +615,12 @@ def join_domain(domain,
     NETSETUP_JOIN_DOMAIN = 0x1
     NETSETUP_ACCOUNT_CREATE = 0x2
     NETSETUP_DOMAIN_JOIN_IF_JOINED = 0x20
+    NETSETUP_JOIN_WITH_NEW_NAME = 0x400
 
     join_options = 0x0
     join_options |= NETSETUP_JOIN_DOMAIN
     join_options |= NETSETUP_DOMAIN_JOIN_IF_JOINED
+    join_options |= NETSETUP_JOIN_WITH_NEW_NAME
     if not account_exists:
         join_options |= NETSETUP_ACCOUNT_CREATE
 


### PR DESCRIPTION
### What does this PR do?

This patch will use a new, "pending" computer name when joining a
Windows system to an Active Directory domain. This allows a user
to rename a computer, then join a domain, and the new computer
name will be used for the computer account. Without this patch,
the old computer name would be used for the domain computer account.

This flag has been tested to work even if the computer name is not
changing.

See https://msdn.microsoft.com/en-us/library/windows/desktop/aa370433(v=vs.85).aspx.
### Tests written?

No
