### PR TITLE
Fix json encoding parameters

### DIFF
--- a/salt/states/serverdensity_device.py
+++ b/salt/states/serverdensity_device.py
@@ -85,8 +85,8 @@ def _get_salt_params():
         params['cpuCores'] = all_stats['cpuinfo']['cpu cores']
         params['installedRAM'] = str(int(all_stats['meminfo']['MemTotal']['value']) / 1024)
         params['swapSpace'] = str(int(all_stats['meminfo']['SwapTotal']['value']) / 1024)
-        params['privateIPs'] = all_grains['fqdn_ip4']
-        params['privateDNS'] = all_grains['fqdn']
+        params['privateIPs'] = json.dumps(all_grains['fqdn_ip4'])
+        params['privateDNS'] = json.dumps(all_grains['fqdn'])
     except KeyError:
         pass
 


### PR DESCRIPTION
### What does this PR do?

Fixes the privateIPs and privateDNS fields on the serverdensity_device state to be json encoded strings as expected by Server Density's API endpoint.
### What issues does this PR fix or reference?

None
### Previous Behavior

privateIPs and privateDNS fields were causing an HTTP 400 code error on device creation.
### New Behavior

The device creation works.
### Tests written?

No
