### PR TITLE
Allow batch mode to use verbose option, as well as show_jid.

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -99,8 +99,10 @@ class Batch(object):
 
         if self.options:
             show_jid = self.options.show_jid
+            show_verbose = self.options.verbose
         else:
             show_jid = False
+            show_verbose = False
 
         # the minion tracker keeps track of responses and iterators
         # - it removes finished iterators from iters[]
@@ -138,6 +140,7 @@ class Batch(object):
                                 raw=self.opts.get('raw', False),
                                 ret=self.opts.get('return', ''),
                                 show_jid=show_jid,
+                                verbose=show_verbose,
                                 **self.eauth)
                 # add it to our iterators and to the minion_tracker
                 iters.append(new_iter)

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -672,6 +672,7 @@ class LocalClient(object):
             ret='',
             kwarg=None,
             show_jid=False,
+            verbose=False,
             **kwargs):
         '''
         Yields the individual minion returns as they come in, or None
@@ -715,7 +716,7 @@ class LocalClient(object):
                                                 tgt_type=expr_form,
                                                 block=False,
                                                 **kwargs):
-                if fn_ret and show_jid:
+                if fn_ret and any([show_jid, verbose]):
                     for minion in fn_ret.keys():
                         fn_ret[minion]['jid'] = pub_data['jid']
                 yield fn_ret


### PR DESCRIPTION
### What does this PR do?

Allows `--verbose` to be passed in along with `--batch`.
### What issues does this PR fix or reference?

Fixes #32856
Refs #32450
### Previous Behavior

Without this change, the jid (which is shown with `--verbose`) is not passed through:

```
root@rallytime:~# salt '*' test.ping -b 50% --verbose

Executing run on ['rallytime', 'ms-0', 'ms-1']

ms-1:
    True
retcode:
    0
rallytime:
    True
retcode:
    0
ms-0:
    True
retcode:
    0

Executing run on ['ms-2', 'ms-3', 'ms-4']

ms-4:
    True
retcode:
    0
ms-3:
    True
retcode:
    0
ms-2:
    True
retcode:
    0
```
### New Behavior

JID is displayed:

```
root@rallytime:~# salt '*' test.ping -b 50% --verbose

Executing run on ['rallytime', 'ms-0', 'ms-1']

jid:
    20160502220059839202
rallytime:
    True
retcode:
    0
jid:
    20160502220059839202
ms-1:
    True
retcode:
    0
jid:
    20160502220059839202
ms-0:
    True
retcode:
    0

Executing run on ['ms-2', 'ms-3', 'ms-4']

jid:
    20160502220100191554
ms-4:
    True
retcode:
    0
jid:
    20160502220100191554
ms-3:
    True
retcode:
    0
jid:
    20160502220100191554
ms-2:
    True
retcode:
    0
```
### Tests written?

No
