### PR TITLE
rewrite win_service.py

### DIFF
--- a/pkg/windows/req.txt
+++ b/pkg/windows/req.txt
@@ -30,7 +30,7 @@ requests==2.9.1
 singledispatch==3.4.0.3
 six==1.10.0
 smmap==0.9.0
-timelib==0.2.5
+timelib==0.2.4
 tornado==4.3
 wheel==0.26.0
 WMI==1.4.9

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -604,7 +604,7 @@ def disable(name, **kwargs):
 
         salt '*' service.disable <service name>
     '''
-    modify(name, start_type='Auto')
+    modify(name, start_type='Disabled')
     return info(name)['StartType'] == 'Disabled'
 
 

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -194,6 +194,10 @@ def info(name):
     ret['Dependencies'] = config_info[6]
     ret['ServiceAccount'] = config_info[7]
     ret['DisplayName'] = config_info[8]
+    ret['Description'] = win32service.QueryServiceConfig2(handle_svc, 1)
+
+    handle_svc.Close()
+    handle_scm.Close()
 
     return ret
 

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 '''
 Windows Service module.
+
+.. versionadded:: Carbon
+    Rewritten to use PyWin32
 '''
 
 # Import python libs
@@ -36,7 +39,13 @@ SERVICE_TYPE = {1: 'Kernel Driver',
                 8: 'Recognizer Driver',
                 16: 'Win32 Own Process',
                 32: 'Win32 Share Process',
-                256: 'Interactive'}
+                256: 'Interactive',
+                'kernel': 1,
+                'filesystem': 2,
+                'adapter': 4,
+                'recognizer': 8,
+                'own': 16,
+                'share': 32}
 
 SERVICE_CONTROLS = {1: 'Stop',
                     2: 'Pause/Continue',
@@ -61,7 +70,9 @@ SERVICE_STATE = {1: 'Stopped',
 SERVICE_ERRORS = {0: 'No Error',
                   1066: 'Service Specific Error'}
 
-SERVICE_START_TYPE = {'auto': 2,
+SERVICE_START_TYPE = {'boot': 0,
+                      'system': 1,
+                      'auto': 2,
                       'manual': 3,
                       'disabled': 4,
                       0: 'Boot',
@@ -79,13 +90,12 @@ SERVICE_ERROR_CONTROL = {0: 'Ignore',
                          'severe': 2,
                          'critical': 3}
 
-BUFFSIZE = 5000
-SERVICE_START_STOP_ATTEMPTS = 90
+RETRY_ATTEMPTS = 90
 
 
 def __virtual__():
     '''
-    Only works on Windows systems
+    Only works on Windows systems with PyWin32 installed
     '''
     if not salt.utils.is_windows():
         return (False, 'Module win_service: module only works on Windows.')
@@ -96,7 +106,11 @@ def __virtual__():
 
 def get_enabled():
     '''
-    Return the enabled services
+    Return a list of enabled services. Enabled is defined as a service that is
+    marked to Auto Start.
+
+    Returns:
+        list: A list of enabled services
 
     CLI Example:
 
@@ -115,7 +129,11 @@ def get_enabled():
 
 def get_disabled():
     '''
-    Return the disabled services
+    Return a list of disabled services. Disabled is defined as a service that is
+    marked 'Disabled' or 'Manual'.
+
+    Returns:
+        list: A list of disabled services.
 
     CLI Example:
 
@@ -134,8 +152,13 @@ def get_disabled():
 
 def available(name):
     '''
-    Returns ``True`` if the specified service is available, otherwise returns
-    ``False``.
+    Check if a service is available on the system.
+
+    Args:
+        name (str): The name of the service to check
+
+    Returns:
+        bool: ``True`` if the service is available, ``False`` otherwise
 
     CLI Example:
 
@@ -149,8 +172,12 @@ def available(name):
 def missing(name):
     '''
     The inverse of service.available.
-    Returns ``True`` if the specified service is not available, otherwise returns
-    ``False``.
+
+    Args:
+        name (str): The name of the service to check
+
+    Returns:
+        bool: ``True`` if the service is missing, ``False`` otherwise
 
     CLI Example:
 
@@ -162,6 +189,9 @@ def missing(name):
 
 
 def _get_services():
+    '''
+    Returns a list of all services on the system.
+    '''
     handle_scm = win32service.OpenSCManager(
         None, None, win32service.SC_MANAGER_ENUMERATE_SERVICE)
 
@@ -178,6 +208,9 @@ def _get_services():
 def get_all():
     '''
     Return all installed services
+
+    Returns:
+        list: Returns a list of all services on the system.
 
     CLI Example:
 
@@ -207,7 +240,7 @@ def get_service_name(*args):
 
     If arguments are passed, create a dict of Display Names and Service Names
 
-    CLI Example:
+    CLI Examples:
 
     .. code-block:: bash
 
@@ -219,7 +252,9 @@ def get_service_name(*args):
     services = dict()
     for raw_service in raw_services:
         if args:
-            if raw_service['DisplayName'] in args:
+            if raw_service['DisplayName'] in args or \
+                    raw_service['ServiceName'] in args or \
+                    raw_service['ServiceName'].lower() in args:
                 services[raw_service['DisplayName']] = raw_service['ServiceName']
         else:
             services[raw_service['DisplayName']] = raw_service['ServiceName']
@@ -227,29 +262,35 @@ def get_service_name(*args):
     return services
 
 
-def _open_service_handles(name):
+def info(name):
+    '''
+    Get information about a service on the system
+
+    Args:
+        name (str): The name of the service. This is not the display name. Use
+        ``get_service_name`` to find the service name.
+
+    Returns:
+        dict: A dictionary containing information about the service.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.info spooler
+    '''
     handle_scm = win32service.OpenSCManager(
         None, None, win32service.SC_MANAGER_CONNECT)
 
     try:
         handle_svc = win32service.OpenService(
-            handle_scm, name, win32service.SERVICE_ENUMERATE_DEPENDENTS |
+            handle_scm, name,
+            win32service.SERVICE_ENUMERATE_DEPENDENTS |
             win32service.SERVICE_INTERROGATE |
             win32service.SERVICE_QUERY_CONFIG |
             win32service.SERVICE_QUERY_STATUS)
     except pywintypes.error as exc:
         raise CommandExecutionError('Failed Open {0}: {1}'.format(name, exc[2]))
-
-    return handle_scm, handle_svc
-
-
-def _close_service_handles(handle_scm, handle_svc):
-    win32service.CloseServiceHandle(handle_scm)
-    win32service.CloseServiceHandle(handle_svc)
-
-
-def info(name):
-    handle_scm, handle_svc = _open_service_handles(name)
 
     try:
         config_info = win32service.QueryServiceConfig(handle_svc)
@@ -259,7 +300,8 @@ def info(name):
         delayed_start = win32service.QueryServiceConfig2(
             handle_svc, win32service.SERVICE_CONFIG_DELAYED_AUTO_START_INFO)
     finally:
-        _close_service_handles(handle_scm, handle_svc)
+        win32service.CloseServiceHandle(handle_scm)
+        win32service.CloseServiceHandle(handle_svc)
 
     sid = win32security.LookupAccountName('', 'NT Service\\{0}'.format(name))[0]
 
@@ -279,8 +321,9 @@ def info(name):
 
     flags = list()
     for bit in SERVICE_TYPE:
-        if config_info[0] & bit:
-            flags.append(SERVICE_TYPE[bit])
+        if isinstance(bit, int):
+            if config_info[0] & bit:
+                flags.append(SERVICE_TYPE[bit])
 
     ret['ServiceType'] = flags if flags else config_info[0]
 
@@ -318,6 +361,12 @@ def start(name):
     '''
     Start the specified service
 
+    Args:
+        name (str): The name of the service to start
+
+    Returns:
+        bool: True if successful, False otherwise
+
     CLI Example:
 
     .. code-block:: bash
@@ -330,9 +379,10 @@ def start(name):
     win32serviceutil.StartService(name)
 
     attempts = 0
-    while info(name)['Status'] in ['Start Pending'] \
-            and attempts <= SERVICE_START_STOP_ATTEMPTS:
+    while info(name)['Status'] in ['Start Pending', 'Stopped'] \
+            and attempts <= RETRY_ATTEMPTS:
         time.sleep(1)
+        attempts += 1
 
     return status(name)
 
@@ -340,6 +390,12 @@ def start(name):
 def stop(name):
     '''
     Stop the specified service
+
+    Args:
+        name (str): The name of the service to stop
+
+    Returns:
+        bool: True if successful, False otherwise
 
     CLI Example:
 
@@ -353,16 +409,27 @@ def stop(name):
     win32serviceutil.StopService(name)
 
     attempts = 0
-    while info(name)['Status'] in ['Stop Pending'] \
-            and attempts <= SERVICE_START_STOP_ATTEMPTS:
+    while info(name)['Status'] in ['Running', 'Stop Pending'] \
+            and attempts <= RETRY_ATTEMPTS:
         time.sleep(1)
+        attempts += 1
 
     return not status(name)
 
 
 def restart(name):
     '''
-    Restart the named service
+    Restart the named service. This issues a stop command followed by a start.
+
+    Args:
+        name: The name of the service to restart.
+
+    .. note::
+        If the name passed is ``salt-minion`` a scheduled task is created and
+        executed to restart the salt-minion service.
+
+    Returns:
+        bool: ``True`` if successful, ``False`` otherwise
 
     CLI Example:
 
@@ -388,7 +455,8 @@ def create_win_salt_restart_task():
         salt '*' service.create_win_salt_restart_task()
     '''
     cmd = 'cmd'
-    args = '/c ping -n 3 127.0.0.1 && net stop salt-minion && net start salt-minion'
+    args = '/c ping -n 3 127.0.0.1 && net stop salt-minion && net start ' \
+           'salt-minion'
     return __salt__['task.create_task'](name='restart-salt-minion',
                                         user_name='System',
                                         force=True,
@@ -415,9 +483,14 @@ def execute_salt_restart_task():
 
 def status(name, sig=None):
     '''
-    Return the status for a service, returns the PID or an empty string if the
-    service is running or not, pass a signature to use to find the service via
-    ps
+    Return the status for a service
+
+    Args:
+        name (str): The name of the service to check
+        sig (str): Not supported on Windows
+
+    Returns:
+        bool: True if running, False otherwise
 
     CLI Example:
 
@@ -433,7 +506,13 @@ def status(name, sig=None):
 
 def getsid(name):
     '''
-    Return the sid for this windows service
+    Return the SID for this windows service
+
+    Args:
+        name (str): The name of the service for which to return the SID
+
+    Returns:
+        str: A string representing the SID for the service
 
     CLI Example:
 
@@ -445,19 +524,92 @@ def getsid(name):
 
 
 def modify(name,
-           bin_path=None,  # str
-           exe_args=None,  # str
-           display_name=None,  # str
-           description=None,  # str
-           service_type=None,  # ????
-           start_type=None,  # auto, manual, disabled
-           start_delayed=None,  # bool
-           error_control=None,  # ignore, normal, severe, critical
-           load_order_group=None,  # str, ''
-           dependencies=None,  # list, ''
-           account_name=None,  # NT Service\<service name>, <domain>\<service name>, LocalSystem, LocalService, NetworkService
-           account_password=None,  # str, '' for ^
-           run_interactive=None):  # Bool
+           bin_path=None,
+           exe_args=None,
+           display_name=None,
+           description=None,
+           service_type=None,
+           start_type=None,
+           start_delayed=None,
+           error_control=None,
+           load_order_group=None,
+           dependencies=None,
+           account_name=None,
+           account_password=None,
+           run_interactive=None):
+    '''
+    Modify a service's parameters. Changes will not be made for parameters that
+    are not passed.
+
+    .. versionadded:: Carbon
+
+    Args:
+        name (str): The name of the service. Can be found using the
+        ``service.get_service_name`` function
+
+        bin_path (str): The path to the service executable. Backslashes must be
+        escaped, eg: C:\\path\\to\\binary.exe
+
+        exe_args (str): Any arguments required by the service executable
+
+        display_name (str): The name to display in the service manager
+
+        description (str): The description to display for the service
+
+        service_type (str): Specifies the service type. Default is ``own``.
+        Valid options are as follows:
+            - kernel: Driver service
+            - filesystem: File system driver service
+            - adapter: Adapter driver service (reserved)
+            - recognizer: Recognizer driver service (reserved)
+            - own (default): Service runs in its own process
+            - share: Service shares a process with one or more other services
+
+        start_type (str): Specifies the service start type. Valid options are as
+            follows:
+            - boot: Device driver that is loaded by the boot loader
+            - system: Device driver that is started during kernel initialization
+            - auto: Service that automatically starts
+            - manual: Service must be started manually
+            - disabled: Service cannot be started
+
+        start_delayed (bool): Set the service to Auto(Delayed Start). Only valid
+        if the start_type is set to ``Auto``. If service_type is not passed, but
+        the service is already set to ``Auto``, then the flag will be set.
+
+        error_control (str): The severity of the error, and action taken, if
+        this service fails to start. Valid options are as follows:
+            - normal: Error is logged and a message box is displayed
+            - severe: Error is logged and computer attempts a restart with the
+              last known good configuration
+            - critical: Error is logged, computer attempts to restart with the
+              last known good configuration, system halts on failure
+            - ignore: Error is logged and startup continues, no notification is
+              given to the user
+
+        load_order_group: The name of the load order group to which this service
+            belongs
+
+        dependencies (list): A list of services or load ordering groups that
+        must start before this service
+
+        account_name (str): The name of the account under which the service
+        should run. For ``own`` type services this should be in the
+        ``domain\username`` format. The following are examples of valid built-in
+        service accounts:
+            - NT Authority\\LocalService
+            - NT Authority\\NetworkService
+            - NT Authority\\LocalSystem
+            - .\LocalSystem
+
+        account_password (str): The password for the account name specified in
+        ``account_name``. For the above built-in accounts, this can be None.
+        Otherwise a password must be specified.
+
+        run_interactive (bool): If this setting is True, the service will be
+        allowed to interact with the user. Not recommended for services that run
+        with elevated privileges.
+    '''
     # https://msdn.microsoft.com/en-us/library/windows/desktop/ms681987(v=vs.85).aspx
     # https://msdn.microsoft.com/en-us/library/windows/desktop/ms681988(v-vs.85).aspx
 
@@ -519,19 +671,18 @@ def modify(name,
         start_type = win32service.SERVICE_NO_CHANGE
 
     if error_control is not None:
-        if error_control.lower() in SERVICE_START_TYPE:
-            error_control = SERVICE_START_TYPE[error_control.lower()]
+        if error_control.lower() in SERVICE_ERROR_CONTROL:
+            error_control = SERVICE_ERROR_CONTROL[error_control.lower()]
         else:
             raise CommandExecutionError(
                 'Invalid Error Control: {0}'.format(error_control))
         changes['ErrorControl'] = SERVICE_ERROR_CONTROL[error_control]
-
     else:
         error_control = win32service.SERVICE_NO_CHANGE
 
     if account_name is not None:
         changes['ServiceAccount'] = account_name
-    if account_name in ['LocalSystem', 'NetworkService', 'LocalSystem']:
+    if account_name in ['LocalSystem', 'LocalService', 'NetworkService']:
         account_password = ''
 
     if account_password is not None:
@@ -575,7 +726,8 @@ def modify(name,
         else:
             changes['Warning'] = 'start_delayed: Requires start_type "auto"'
 
-    _close_service_handles(handle_scm, handle_svc)
+    win32service.CloseServiceHandle(handle_scm)
+    win32service.CloseServiceHandle(handle_svc)
 
     return changes
 
@@ -583,6 +735,12 @@ def modify(name,
 def enable(name, **kwargs):
     '''
     Enable the named service to start at boot
+
+    Args:
+        name (str): The name of the service to enable.
+
+    Returns:
+        bool: ``True`` if successful, ``False`` otherwise
 
     CLI Example:
 
@@ -598,6 +756,12 @@ def disable(name, **kwargs):
     '''
     Disable the named service to start at boot
 
+    Args:
+        name (str): The name of the service to disable
+
+    Returns:
+        bool: ``True`` if disabled, ``False`` otherwise
+
     CLI Example:
 
     .. code-block:: bash
@@ -612,6 +776,12 @@ def enabled(name, **kwargs):
     '''
     Check to see if the named service is enabled to start on boot
 
+    Args:
+        name (str): The name of the service to check
+
+    Returns:
+        bool: True if the service is set to start
+
     CLI Example:
 
     .. code-block:: bash
@@ -625,6 +795,12 @@ def disabled(name):
     '''
     Check to see if the named service is disabled to start on boot
 
+    Args:
+        name (str): The name of the service to check
+
+    Returns:
+        bool: True if the service is disabled
+
     CLI Example:
 
     .. code-block:: bash
@@ -635,65 +811,95 @@ def disabled(name):
 
 
 def create(name,
-           binpath,
-           DisplayName=None,
-           type='own',
-           start='demand',
-           error='normal',
-           group=None,
-           tag='no',
-           depend=None,
-           obj=None,
-           password=None,
+           bin_path,
+           exe_args=None,
+           display_name=None,
+           description=None,
+           service_type='own',
+           start_type='manual',
+           start_delayed=False,
+           error_control='normal',
+           load_order_group=None,
+           dependencies=None,
+           account_name='.\\LocalSystem',
+           account_password=None,
+           run_interactive=False,
            **kwargs):
     r'''
     Create the named service.
 
     .. versionadded:: 2015.8.0
 
-    Required parameters:
+    Args:
 
-    :param name: Specifies the service name returned by the getkeyname operation
+        name (str): Specifies the service name. This is not the display_name
 
-    :param binpath: Specifies the path to the service binary file, backslashes must be escaped
-      - eg: C:\\path\\to\\binary.exe
+        bin_path (str): Specifies the path to the service binary file.
+        Backslashes must be escaped, eg: C:\\path\\to\\binary.exe
 
-    Optional parameters:
+        exe_args (str): Any additional arguments required by the service binary.
 
-    :param DisplayName: the name to be displayed in the service manager
+        display_name (str): the name to be displayed in the service manager
 
-    :param type: Specifies the service type, default is own
-      - own (default): Service runs in its own process
-      - share: Service runs as a shared process
-      - interact: Service can interact with the desktop
-      - kernel: Service is a driver
-      - filesys: Service is a system driver
-      - rec: Service is a file system-recognized driver that identifies filesystems on the computer
+        description (str): A description of the service
 
-    :param start: Specifies the start type for the service
-      - boot: Device driver that is loaded by the boot loader
-      - system: Device driver that is started during kernel initialization
-      - auto: Service that automatically starts
-      - demand (default): Service must be started manually
-      - disabled: Service cannot be started
-      - delayed-auto: Service starts automatically after other auto-services start
+        service_type (str): Specifies the service type. Default is ``own``.
+        Valid options are as follows:
+            - kernel: Driver service
+            - filesystem: File system driver service
+            - adapter: Adapter driver service (reserved)
+            - recognizer: Recognizer driver service (reserved)
+            - own (default): Service runs in its own process
+            - share: Service shares a process with one or more other services
 
-    :param error: Specifies the severity of the error
-      - normal (default): Error is logged and a message box is displayed
-      - severe: Error is logged and computer attempts a restart with last known good configuration
-      - critical: Error is logged, computer attempts to restart with last known good configuration, system halts on failure
-      - ignore: Error is logged and startup continues, no notification is given to the user
+        start_type (str): Specifies the service start type. Valid options are as
+        follows:
+            - boot: Device driver that is loaded by the boot loader
+            - system: Device driver that is started during kernel initialization
+            - auto: Service that automatically starts
+            - manual (default): Service must be started manually
+            - disabled: Service cannot be started
 
-    :param group: Specifies the name of the group of which this service is a member
+        start_delayed (bool): Set the service to Auto(Delayed Start). Only valid
+        if the start_type is set to ``Auto``. If service_type is not passed, but
+        the service is already set to ``Auto``, then the flag will be set.
+        Default is ``False``
 
-    :param tag: Specifies whether or not to obtain a TagID from the CreateService call. For boot-start and system-start drivers
-      - yes/no
+        error_control (str): The severity of the error, and action taken, if
+        this service fails to start. Valid options are as follows:
+            - normal (normal): Error is logged and a message box is displayed
+            - severe: Error is logged and computer attempts a restart with the
+              last known good configuration
+            - critical: Error is logged, computer attempts to restart with the
+              last known good configuration, system halts on failure
+            - ignore: Error is logged and startup continues, no notification is
+              given to the user
 
-    :param depend: Specifies the names of services or groups that myust start before this service. The names are separated by forward slashes.
+        load_order_group: The name of the load order group to which this service
+            belongs
 
-    :param obj: Specifies the name of an account in which a service will run. Default is LocalSystem
+        dependencies (list): A list of services or load ordering groups that
+        must start before this service
 
-    :param password: Specifies a password. Required if other than LocalSystem account is used.
+        account_name (str): The name of the account under which the service
+        should run. For ``own`` type services this should be in the
+        ``domain\username`` format. The following are examples of valid built-in
+        service accounts:
+            - NT Authority\\LocalService
+            - NT Authority\\NetworkService
+            - NT Authority\\LocalSystem
+            - .\\LocalSystem
+
+        account_password (str): The password for the account name specified in
+        ``account_name``. For the above built-in accounts, this can be None.
+        Otherwise a password must be specified.
+
+        run_interactive (bool): If this setting is True, the service will be
+        allowed to interact with the user. Not recommended for services that run
+        with elevated privileges.
+
+    Returns:
+        dict: A dictionary containing information about the new service
 
     CLI Example:
 
@@ -701,28 +907,182 @@ def create(name,
 
         salt '*' service.create <service name> <path to exe> display_name='<display name>'
     '''
+    # Deprecations
+    if 'binpath' in kwargs:
+        salt.utils.warn_until(
+            'Nitrogen',
+            'The \'binpath\' argument to service.create is deprecated, and '
+            'will be removed in Salt {version}. Please use \'bin_path\' '
+            'instead.'
+        )
+        if bin_path is None:
+            bin_path = kwargs.pop('binpath')
 
-    cmd = [
-           'sc',
-           'create',
-           name,
-           'binpath=', binpath,
-           'type=', type,
-           'start=', start,
-           'error=', error,
-           ]
-    if DisplayName is not None:
-        cmd.extend(['DisplayName=', DisplayName])
-    if group is not None:
-        cmd.extend(['group=', group])
-    if depend is not None:
-        cmd.extend(['depend=', depend])
-    if obj is not None:
-        cmd.extend(['obj=', obj])
-    if password is not None:
-        cmd.extend(['password=', password])
+    if 'DisplayName' in kwargs:
+        salt.utils.warn_until(
+            'Nitrogen',
+            'The \'DisplayName\' argument to service.create is deprecated, and '
+            'will be removed in Salt {version}. Please use \'display_name\' '
+            'instead.'
+        )
+        if display_name is None:
+            display_name = kwargs.pop('DisplayName')
 
-    return not __salt__['cmd.retcode'](cmd, python_shell=False)
+    if 'type' in kwargs:
+        salt.utils.warn_until(
+            'Nitrogen',
+            'The \'type\' argument to service.create is deprecated, and '
+            'will be removed in Salt {version}. Please use \'service_type\' '
+            'instead.'
+        )
+        if service_type is None:
+            service_type = kwargs.pop('type')
+
+    if 'start' in kwargs:
+        salt.utils.warn_until(
+            'Nitrogen',
+            'The \'start\' argument to service.create is deprecated, and '
+            'will be removed in Salt {version}. Please use \'start_type\' '
+            'instead.'
+        )
+        if start_type is None:
+            start_type = kwargs.pop('start')
+
+    if 'error' in kwargs:
+        salt.utils.warn_until(
+            'Nitrogen',
+            'The \'error\' argument to service.create is deprecated, and '
+            'will be removed in Salt {version}. Please use \'error_control\' '
+            'instead.'
+        )
+        if error_control is None:
+            error_control = kwargs.pop('error')
+
+    if 'group' in kwargs:
+        salt.utils.warn_until(
+            'Nitrogen',
+            'The \'group\' argument to service.create is deprecated, and '
+            'will be removed in Salt {version}. Please use '
+            '\'load_order_group\' instead.'
+        )
+        if load_order_group is None:
+            load_order_group = kwargs.pop('group')
+
+    if 'depend' in kwargs:
+        salt.utils.warn_until(
+            'Nitrogen',
+            'The \'depend\' argument to service.create is deprecated, and '
+            'will be removed in Salt {version}. Please use \'dependencies\' '
+            'instead.'
+        )
+        if dependencies is None:
+            dependencies = kwargs.pop('depend')
+
+    if 'obj' in kwargs:
+        salt.utils.warn_until(
+            'Nitrogen',
+            'The \'obj\' argument to service.create is deprecated, and '
+            'will be removed in Salt {version}. Please use \'account_name\' '
+            'instead.'
+        )
+        if account_name is None:
+            account_name = kwargs.pop('obj')
+
+    if 'password' in kwargs:
+        salt.utils.warn_until(
+            'Nitrogen',
+            'The \'password\' argument to service.create is deprecated, and '
+            'will be removed in Salt {version}. Please use '
+            '\'account_password\' instead.'
+        )
+        if account_password is None:
+            account_password = kwargs.pop('password')
+
+    # Test if the service already exists
+    if name in get_all():
+        raise CommandExecutionError('Service Already Exists: {0}'.format(name))
+
+    # Input validation
+    bin_path = bin_path.strip('"')
+    if exe_args is not None:
+        bin_path = '{0} {1}'.format(bin_path, exe_args)
+
+    if service_type.lower() in SERVICE_TYPE:
+        service_type = SERVICE_TYPE[service_type.lower()]
+        if run_interactive:
+            service_type = service_type | \
+                           win32service.SERVICE_INTERACTIVE_PROCESS
+    else:
+        raise CommandExecutionError(
+            'Invalid Service Type: {0}'.format(service_type))
+
+    if start_type.lower() in SERVICE_START_TYPE:
+        start_type = SERVICE_START_TYPE[start_type.lower()]
+    else:
+        raise CommandExecutionError(
+            'Invalid Start Type: {0}'.format(start_type))
+
+    if error_control.lower() in SERVICE_ERROR_CONTROL:
+        error_control = SERVICE_ERROR_CONTROL[error_control.lower()]
+    else:
+        raise CommandExecutionError(
+            'Invalid Error Control: {0}'.format(error_control))
+
+    if start_delayed:
+        if start_type != 2:
+            raise CommandExecutionError(
+                'Invalid Parameter: start_delayed requires start_type "auto"')
+
+    if account_name in ['LocalSystem', 'LocalService', 'NetworkService']:
+        account_password = ''
+
+    # Connect to Service Control Manager
+    handle_scm = win32service.OpenSCManager(
+        None, None, win32service.SC_MANAGER_ALL_ACCESS)
+
+    # return {'handle': 'handle',
+    #         'name:': name,
+    #         'display_name': display_name,
+    #         'service_type': service_type,
+    #         'start_type': start_type,
+    #         'error_control': error_control,
+    #         'bin_path': bin_path,
+    #         'load_order_group': load_order_group,
+    #         'dependencies': dependencies,
+    #         'account_name': account_name,
+    #         'account_password': account_password}
+
+    # Create the service
+    handle_svc = win32service.CreateService(handle_scm,
+                                            name,
+                                            display_name,
+                                            win32service.SERVICE_ALL_ACCESS,
+                                            service_type,
+                                            start_type,
+                                            error_control,
+                                            bin_path,
+                                            load_order_group,
+                                            0,
+                                            dependencies,
+                                            account_name,
+                                            account_password)
+
+    if description is not None:
+        win32service.ChangeServiceConfig2(
+            handle_svc, win32service.SERVICE_CONFIG_DESCRIPTION, description)
+
+    if start_delayed is not None:
+        # You can only set delayed start for services that are set to auto start
+        # Start type 2 is Auto
+        if start_type == 2:
+            win32service.ChangeServiceConfig2(
+                handle_svc, win32service.SERVICE_CONFIG_DELAYED_AUTO_START_INFO,
+                start_delayed)
+
+    win32service.CloseServiceHandle(handle_scm)
+    win32service.CloseServiceHandle(handle_svc)
+
+    return info(name)
 
 
 def config(name,
@@ -738,79 +1098,68 @@ def config(name,
            password=None,
            **kwargs):
     r'''
-    Modify the named service.
+    .. deprecated:: Carbon
+        Use ``service.modify`` instead
 
-    .. versionadded:: 2015.8.8
+    Modify the named service. Because this is deprecated it will use the passed
+    parameters to run ``service.modify`` instead.
 
-    Required parameters:
+    Args:
 
-    :param str name: Specifies the service name returned by the getkeyname
-    operation
+        name (str): Specifies the service name. This is not the display_name
+
+        bin_path (str): Specifies the path to the service binary file.
+        Backslashes must be escaped, eg: C:\\path\\to\\binary.exe
+
+        display_name (str): the name to be displayed in the service manager
+
+        svc_type (str): Specifies the service type. Default is ``own``.
+        Valid options are as follows:
+            - kernel: Driver service
+            - filesystem: File system driver service
+            - adapter: Adapter driver service (reserved)
+            - recognizer: Recognizer driver service (reserved)
+            - own (default): Service runs in its own process
+            - share: Service shares a process with one or more other services
+
+        start_type (str): Specifies the service start type. Valid options are as
+            follows:
+            - boot: Device driver that is loaded by the boot loader
+            - system: Device driver that is started during kernel initialization
+            - auto: Service that automatically starts
+            - manual (default): Service must be started manually
+            - disabled: Service cannot be started
+
+        error (str): The severity of the error, and action taken, if this
+        service fails to start. Valid options are as follows:
+            - normal (normal): Error is logged and a message box is displayed
+            - severe: Error is logged and computer attempts a restart with the
+              last known good configuration
+            - critical: Error is logged, computer attempts to restart with the
+              last known good configuration, system halts on failure
+            - ignore: Error is logged and startup continues, no notification is
+              given to the user
+
+        group: The name of the load order group to which this service
+            belongs
+
+        depend (list): A list of services or load ordering groups that
+        must start before this service
+
+        obj (str): The name of the account under which the service
+        should run. For ``own`` type services this should be in the
+        ``domain\username`` format. The following are examples of valid built-in
+        service accounts:
+            - NT Authority\\LocalService
+            - NT Authority\\NetworkService
+            - NT Authority\\LocalSystem
+            - .\\LocalSystem
+
+        password (str): The password for the account name specified in
+        ``account_name``. For the above built-in accounts, this can be None.
+        Otherwise a password must be specified.
 
 
-    Optional parameters:
-
-    :param str bin_path: Specifies the path to the service binary file,
-    backslashes must be escaped
-    - eg: C:\\path\\to\\binary.exe
-
-    :param str display_name: the name to be displayed in the service manager
-    Specifies a more descriptive name for identifying the service in user
-    interface programs.
-
-    :param str svc_type: Specifies the service type. Acceptable values are:
-      - own (default): Service runs in its own process
-      - share: Service runs as a shared process
-      - interact: Service can interact with the desktop
-      - kernel: Service is a driver
-      - filesys: Service is a system driver
-      - rec: Service is a file system-recognized driver that identifies
-        filesystems on the computer
-      - adapt: Service is an adapter driver that identifies hardware such as
-        keyboards, mice and disk drives
-
-    :param str start_type: Specifies the start type for the service.
-    Acceptable values are:
-      - boot: Device driver that is loaded by the boot loader
-      - system: Device driver that is started during kernel initialization
-      - auto: Service that automatically starts
-      - demand (default): Service must be started manually
-      - disabled: Service cannot be started
-      - delayed-auto: Service starts automatically after other auto-services
-        start
-
-    :param str error: Specifies the severity of the error if the service
-    fails to start. Acceptable values are:
-      - normal (default): Error is logged and a message box is displayed
-      - severe: Error is logged and computer attempts a restart with last known
-        good configuration
-      - critical: Error is logged, computer attempts to restart with last known
-        good configuration, system halts on failure
-      - ignore: Error is logged and startup continues, no notification is given
-        to the user
-
-    :param str group: Specifies the name of the group of which this service is a
-    member. The list of groups is stored in the registry, in the
-    HKLM\System\CurrentControlSet\Control\ServiceGroupOrder subkey. The default
-    is null.
-
-    :param str tag: Specifies whether or not to obtain a TagID from the
-    CreateService call. For boot-start and system-start drivers only.
-    Acceptable values are:
-      - yes/no
-
-    :param str depend: Specifies the names of services or groups that must start
-    before this service. The names are separated by forward slashes.
-
-    :param str obj: Specifies the name of an account in which a service will run
-    or specifies a name of the Windows driver object in which the driver will
-    run. Default is LocalSystem
-
-    :param str password: Specifies a password. Required if other than
-    LocalSystem account is used.
-
-    :return: True if successful, False if not
-    :rtype: bool
 
     CLI Example:
 
@@ -818,35 +1167,32 @@ def config(name,
 
         salt '*' service.config <service name> <path to exe> display_name='<display name>'
     '''
+    salt.utils.warn_until(
+        'Nitrogen',
+        'The \'service.change\' function is deprecated, and will be removed in '
+        'Salt {version}. Please use \'service.modify\' instead.')
 
-    cmd = ['sc', 'config', name]
-    if bin_path is not None:
-        cmd.extend(['binpath=', bin_path])
-    if svc_type is not None:
-        cmd.extend(['type=', svc_type])
-    if start_type is not None:
-        cmd.extend(['start=', start_type])
-    if error is not None:
-        cmd.extend(['error=', error])
-    if display_name is not None:
-        cmd.extend(['DisplayName=', display_name])
-    if group is not None:
-        cmd.extend(['group=', group])
-    if tag is not None:
-        cmd.extend(['tag=', tag])
-    if depend is not None:
-        cmd.extend(['depend=', depend])
-    if obj is not None:
-        cmd.extend(['obj=', obj])
-    if password is not None:
-        cmd.extend(['password=', password])
-
-    return not __salt__['cmd.retcode'](cmd, python_shell=False)
+    return modify(name=name,
+                  bin_path=bin_path,
+                  display_name=display_name,
+                  service_type=svc_type,
+                  start_type=start_type,
+                  error_control=error,
+                  load_order_group=group,
+                  dependencies=depend,
+                  account_name=obj,
+                  account_password=password)
 
 
 def delete(name):
     '''
     Delete the named service
+
+    Args:
+        name (str): The name of the service to delete
+
+    Returns:
+        bool: True if successful, False otherwise
 
     CLI Example:
 
@@ -854,5 +1200,23 @@ def delete(name):
 
         salt '*' service.delete <service name>
     '''
-    cmd = ['sc', 'delete', name]
-    return not __salt__['cmd.retcode'](cmd, python_shell=False)
+    handle_scm = win32service.OpenSCManager(
+        None, None, win32service.SC_MANAGER_CONNECT)
+
+    try:
+        handle_svc = win32service.OpenService(
+            handle_scm, name, win32service.SERVICE_ALL_ACCESS)
+    except pywintypes.error as exc:
+        raise CommandExecutionError('Failed Open {0}: {1}'.format(name, exc[2]))
+
+    win32service.DeleteService(handle_svc)
+
+    win32service.CloseServiceHandle(handle_scm)
+    win32service.CloseServiceHandle(handle_svc)
+
+    attempts = 0
+    while name in get_all() and attempts <= RETRY_ATTEMPTS:
+        time.sleep(1)
+        attempts += 1
+
+    return name not in get_all()

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -8,18 +8,13 @@ Windows Service module.
 
 # Import python libs
 from __future__ import absolute_import
-import os
 import salt.utils
 import time
 import logging
-from salt.ext.six.moves import zip
-from salt.ext.six.moves import range
 from salt.exceptions import CommandExecutionError
 
 # Import 3rd party libs
 try:
-    import win32api
-    import win32con
     import win32security
     import win32service
     import win32serviceutil
@@ -546,7 +541,7 @@ def modify(name,
            account_name=None,
            account_password=None,
            run_interactive=None):
-    '''
+    r'''
     Modify a service's parameters. Changes will not be made for parameters that
     are not passed.
 

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -410,7 +410,11 @@ def stop(name):
     if not status(name):
         return True
 
-    win32serviceutil.StopService(name)
+    try:
+        win32serviceutil.StopService(name)
+    except pywintypes.error as exc:
+        raise CommandExecutionError(
+            'Failed To Stop {0}: {1}'.format(name, exc[2]))
 
     attempts = 0
     while info(name)['Status'] in ['Running', 'Stop Pending'] \
@@ -524,7 +528,7 @@ def getsid(name):
 
         salt '*' service.getsid <service name>
     '''
-    return info['sid']
+    return info(name)['sid']
 
 
 def modify(name,
@@ -1044,18 +1048,6 @@ def create(name,
     # Connect to Service Control Manager
     handle_scm = win32service.OpenSCManager(
         None, None, win32service.SC_MANAGER_ALL_ACCESS)
-
-    # return {'handle': 'handle',
-    #         'name:': name,
-    #         'display_name': display_name,
-    #         'service_type': service_type,
-    #         'start_type': start_type,
-    #         'error_control': error_control,
-    #         'bin_path': bin_path,
-    #         'load_order_group': load_order_group,
-    #         'dependencies': dependencies,
-    #         'account_name': account_name,
-    #         'account_password': account_password}
 
     # Create the service
     handle_svc = win32service.CreateService(handle_scm,

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -31,6 +31,15 @@ SERVICE_TYPE = {1: 'SERVICE_KERNEL_DRIVER',
                 32: 'SERVICE_WIN32_SHARE_PROCESS',
                 272: 'SERVICE_WIN32_OWN_INTERACTIVE',
                 280: 'SERVICE_WIN32_SHARE_INTERACTIVE'}
+SERVICE_STATE = {1: 'SERVICE_STOPPED',
+                 2: 'SERVICE_START_PENDING',
+                 3: 'SERVICE_STOP_PENDING',
+                 4: 'SERVICE_RUNNING',
+                 5: 'SERVICE_CONTINUE_PENDING',
+                 6: 'SERVICE_PAUSE_PENDING',
+                 7: 'SERVICE_PAUSED'}
+SERVICE_ERRORS = {0: 'NO_ERROR',
+                  1066: 'SERVICE_SPECIFIC_ERROR'}
 SERVICE_START_TYPE = {0: 'SERVICE_BOOT_START',
                       1: 'SERVICE_SYSTEM_START',
                       2: 'SERVICE_AUTO_START',
@@ -183,6 +192,7 @@ def info(name):
         raise CommandExecutionError(exc[2])
 
     config_info = win32service.QueryServiceConfig(handle_svc)
+    status_info = win32service.QueryServiceStatusEx(handle_svc)
 
     ret = dict()
     ret['ServiceType'] = SERVICE_TYPE[config_info[0]]
@@ -195,6 +205,11 @@ def info(name):
     ret['ServiceAccount'] = config_info[7]
     ret['DisplayName'] = config_info[8]
     ret['Description'] = win32service.QueryServiceConfig2(handle_svc, 1)
+    ret['Status'] = SERVICE_STATE[status_info['CurrentState']]
+    ret['Status_ExitCode'] = SERVICE_ERRORS[status_info['Win32ExitCode']]
+    ret['Status_ServiceCode'] = status_info['ServiceSpecificExitCode']
+    ret['Status_CheckPoint'] = status_info['CheckPoint']
+    ret['Status_WaitHint'] = status_info['WaitHint']
 
     handle_svc.Close()
     handle_scm.Close()

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -25,6 +25,22 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'service'
 
+SERVICE_TYPE = {1, 'SERVICE_KERNEL_DRIVER',
+                2, 'SERVICE_FILE_SYSTEM_DRIVER',
+                16, 'SERVICE_WIN32_OWN_PROCESS',
+                32, 'SERVICE_WIN32_SHARE_PROCESS',
+                272, 'SERVICE_WIN32_OWN_INTERACTIVE',
+                280, 'SERVICE_WIN32_SHARE_INTERACTIVE'}
+SERVICE_START_TYPE = {0, 'SERVICE_BOOT_START',
+                      1, 'SERVICE_SYSTEM_START',
+                      2, 'SERVICE_AUTO_START',
+                      3, 'SERVICE_DEMAND_START',
+                      4, 'SERVICE_DISABLED'}
+SERVICE_ERROR_CONTROL = {0, 'SERVICE_ERROR_IGNORE',
+                         1, 'SERVICE_ERROR_NORMAL',
+                         2, 'SERVICE_ERROR_SEVERE',
+                         3, 'SERVICE_ERROR_CRITICAL'}
+
 BUFFSIZE = 5000
 SERVICE_STOP_DELAY_SECONDS = 15
 SERVICE_STOP_POLL_MAX_ATTEMPTS = 5
@@ -169,9 +185,9 @@ def info(name):
     config_info = win32service.QueryServiceConfig(handle_svc)
 
     ret = dict()
-    ret['ServiceType'] = config_info[0]
-    ret['StartType'] = config_info[1]
-    ret['ErrorControl'] = config_info[2]
+    ret['ServiceType'] = SERVICE_TYPE[config_info[0]]
+    ret['StartType'] = SERVICE_START_TYPE[config_info[1]]
+    ret['ErrorControl'] = SERVICE_ERROR_CONTROL[config_info[2]]
     ret['BinaryPath'] = config_info[3]
     ret['LoadOrderGroup'] = config_info[4]
     ret['TagID'] = config_info[5]

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -590,8 +590,8 @@ def enable(name, **kwargs):
 
         salt '*' service.enable <service name>
     '''
-    cmd = ['sc', 'config', name, 'start=', 'auto']
-    return not __salt__['cmd.retcode'](cmd, python_shell=False)
+    modify(name, start_type='Auto')
+    return info(name)['StartType'] == 'Auto'
 
 
 def disable(name, **kwargs):
@@ -604,8 +604,8 @@ def disable(name, **kwargs):
 
         salt '*' service.disable <service name>
     '''
-    cmd = ['sc', 'config', name, 'start=', 'disabled']
-    return not __salt__['cmd.retcode'](cmd, python_shell=False)
+    modify(name, start_type='Auto')
+    return info(name)['StartType'] == 'Disabled'
 
 
 def enabled(name, **kwargs):
@@ -618,12 +618,7 @@ def enabled(name, **kwargs):
 
         salt '*' service.enabled <service name>
     '''
-    cmd = ['sc', 'qc', name]
-    lines = __salt__['cmd.run'](cmd, python_shell=False).splitlines()
-    for line in lines:
-        if 'AUTO_START' in line:
-            return True
-    return False
+    return info(name)['StartType'] == 'Auto'
 
 
 def disabled(name):
@@ -636,14 +631,7 @@ def disabled(name):
 
         salt '*' service.disabled <service name>
     '''
-    cmd = ['sc', 'qc', name]
-    lines = __salt__['cmd.run'](cmd, python_shell=False).splitlines()
-    for line in lines:
-        if 'DEMAND_START' in line:
-            return True
-        elif 'DISABLED' in line:
-            return True
-    return False
+    return not enabled(name)
 
 
 def create(name,

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -166,7 +166,11 @@ def available(name):
 
         salt '*' service.available <service name>
     '''
-    return name in get_all()
+    for service in get_all():
+        if name.lower() == service.lower():
+            return True
+
+    return False
 
 
 def missing(name):
@@ -290,7 +294,8 @@ def info(name):
             win32service.SERVICE_QUERY_CONFIG |
             win32service.SERVICE_QUERY_STATUS)
     except pywintypes.error as exc:
-        raise CommandExecutionError('Failed Open {0}: {1}'.format(name, exc[2]))
+        raise CommandExecutionError(
+            'Failed To Open {0}: {1}'.format(name, exc[2]))
 
     try:
         config_info = win32service.QueryServiceConfig(handle_svc)
@@ -376,7 +381,11 @@ def start(name):
     if status(name):
         return True
 
-    win32serviceutil.StartService(name)
+    try:
+        win32serviceutil.StartService(name)
+    except pywintypes.error as exc:
+        raise CommandExecutionError(
+            'Failed To Start {0}: {1}'.format(name, exc[2]))
 
     attempts = 0
     while info(name)['Status'] in ['Start Pending', 'Stopped'] \
@@ -620,7 +629,8 @@ def modify(name,
         handle_svc = win32service.OpenService(
             handle_scm, name, win32service.SERVICE_ALL_ACCESS)
     except pywintypes.error as exc:
-        raise CommandExecutionError('Failed Open {0}: {1}'.format(name, exc[2]))
+        raise CommandExecutionError(
+            'Failed To Open {0}: {1}'.format(name, exc[2]))
 
     config_info = win32service.QueryServiceConfig(handle_svc)
 
@@ -1207,7 +1217,8 @@ def delete(name):
         handle_svc = win32service.OpenService(
             handle_scm, name, win32service.SERVICE_ALL_ACCESS)
     except pywintypes.error as exc:
-        raise CommandExecutionError('Failed Open {0}: {1}'.format(name, exc[2]))
+        raise CommandExecutionError(
+            'Failed To Open {0}: {1}'.format(name, exc[2]))
 
     win32service.DeleteService(handle_svc)
 

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -164,10 +164,7 @@ def info(name):
         handle_svc = win32service.OpenService(
             handle_scm, name, win32service.SERVICE_ALL_ACCESS)
     except pywintypes.error as exc:
-        # Service not found
-        if 'does not exist' in exc[2]:
-            raise CommandExecutionError('Service Not Found')
-        raise CommandExecutionError('Unknown Error: {0}'.format(exc[2]))
+        raise CommandExecutionError(exc[2])
 
     config_info = win32service.QueryServiceConfig(handle_svc)
 

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -25,21 +25,21 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'service'
 
-SERVICE_TYPE = {1, 'SERVICE_KERNEL_DRIVER',
-                2, 'SERVICE_FILE_SYSTEM_DRIVER',
-                16, 'SERVICE_WIN32_OWN_PROCESS',
-                32, 'SERVICE_WIN32_SHARE_PROCESS',
-                272, 'SERVICE_WIN32_OWN_INTERACTIVE',
-                280, 'SERVICE_WIN32_SHARE_INTERACTIVE'}
-SERVICE_START_TYPE = {0, 'SERVICE_BOOT_START',
-                      1, 'SERVICE_SYSTEM_START',
-                      2, 'SERVICE_AUTO_START',
-                      3, 'SERVICE_DEMAND_START',
-                      4, 'SERVICE_DISABLED'}
-SERVICE_ERROR_CONTROL = {0, 'SERVICE_ERROR_IGNORE',
-                         1, 'SERVICE_ERROR_NORMAL',
-                         2, 'SERVICE_ERROR_SEVERE',
-                         3, 'SERVICE_ERROR_CRITICAL'}
+SERVICE_TYPE = {1: 'SERVICE_KERNEL_DRIVER',
+                2: 'SERVICE_FILE_SYSTEM_DRIVER',
+                16: 'SERVICE_WIN32_OWN_PROCESS',
+                32: 'SERVICE_WIN32_SHARE_PROCESS',
+                272: 'SERVICE_WIN32_OWN_INTERACTIVE',
+                280: 'SERVICE_WIN32_SHARE_INTERACTIVE'}
+SERVICE_START_TYPE = {0: 'SERVICE_BOOT_START',
+                      1: 'SERVICE_SYSTEM_START',
+                      2: 'SERVICE_AUTO_START',
+                      3: 'SERVICE_DEMAND_START',
+                      4: 'SERVICE_DISABLED'}
+SERVICE_ERROR_CONTROL = {0: 'SERVICE_ERROR_IGNORE',
+                         1: 'SERVICE_ERROR_NORMAL',
+                         2: 'SERVICE_ERROR_SEVERE',
+                         3: 'SERVICE_ERROR_CRITICAL'}
 
 BUFFSIZE = 5000
 SERVICE_STOP_DELAY_SECONDS = 15

--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -50,6 +50,7 @@ import time
 
 # Import Salt libs
 from salt.exceptions import CommandExecutionError
+import salt.utils
 
 
 def __virtual__():
@@ -336,6 +337,10 @@ def running(name, enable=None, sig=None, init_delay=None, **kwargs):
         ret['result'] = None
         ret['comment'] = 'Service {0} is set to start'.format(name)
         return ret
+
+    if salt.utils.is_windows():
+        if enable is True:
+            ret.update(_enable(name, False, result=False, **kwargs))
 
     func_ret = __salt__['service.start'](name)
 

--- a/tests/unit/modules/win_service_test.py
+++ b/tests/unit/modules/win_service_test.py
@@ -89,7 +89,6 @@ class WinServiceTestCase(TestCase):
             self.assertListEqual(win_service.get_all(),
                                  ['patrick', 'spongebob', 'squarepants'])
 
-
     def test_get_service_name(self):
         '''
             Test to the Display Name is what is displayed

--- a/tests/unit/modules/win_service_test.py
+++ b/tests/unit/modules/win_service_test.py
@@ -21,7 +21,11 @@ ensure_in_syspath('../../')
 from salt.modules import win_service
 
 # Import 3rd Party Libs
-import win32serviceutil
+try:
+    WINAPI = True
+    import win32serviceutil
+except ImportError:
+    WINAPI = False
 
 win_service.__salt__ = {}
 
@@ -108,6 +112,7 @@ class WinServiceTestCase(TestCase):
             self.assertDictEqual(win_service.get_service_name('patrick'),
                                  {'Patrick the Starfish': 'patrick'})
 
+    @skipIf(not WINAPI, 'win32serviceutil not available')
     def test_start(self):
         '''
             Test to start the specified service
@@ -127,6 +132,7 @@ class WinServiceTestCase(TestCase):
                     with patch.object(win_service, 'status', mock_true):
                         self.assertTrue(win_service.start('spongebob'))
 
+    @skipIf(not WINAPI, 'win32serviceutil not available')
     def test_stop(self):
         '''
             Test to stop the specified service

--- a/tests/unit/modules/win_service_test.py
+++ b/tests/unit/modules/win_service_test.py
@@ -20,6 +20,9 @@ ensure_in_syspath('../../')
 # Import Salt Libs
 from salt.modules import win_service
 
+# Import 3rd Party Libs
+import win32serviceutil
+
 win_service.__salt__ = {}
 
 
@@ -32,21 +35,31 @@ class WinServiceTestCase(TestCase):
         '''
             Test to return the enabled services
         '''
-        mock = MagicMock(return_value=['c', 'a', 'b'])
-        with patch.object(win_service, 'get_all', mock):
-            mock = MagicMock(side_effect=[True, False, True])
-            with patch.object(win_service, 'enabled', mock):
-                self.assertListEqual(win_service.get_enabled(), ['b', 'c'])
+        mock = MagicMock(return_value=[{'ServiceName': 'spongebob'},
+                                       {'ServiceName': 'squarepants'},
+                                       {'ServiceName': 'patrick'}])
+        with patch.object(win_service, '_get_services', mock):
+            mock_info = MagicMock(side_effect=[{'StartType': 'Auto'},
+                                               {'StartType': 'Manual'},
+                                               {'StartType': 'Disabled'}])
+            with patch.object(win_service, 'info', mock_info):
+                self.assertListEqual(win_service.get_enabled(),
+                                     ['spongebob'])
 
     def test_get_disabled(self):
         '''
             Test to return the disabled services
         '''
-        mock = MagicMock(return_value=['c', 'a', 'b'])
-        with patch.object(win_service, 'get_all', mock):
-            mock = MagicMock(side_effect=[True, False, True])
-            with patch.object(win_service, 'disabled', mock):
-                self.assertListEqual(win_service.get_disabled(), ['b', 'c'])
+        mock = MagicMock(return_value=[{'ServiceName': 'spongebob'},
+                                       {'ServiceName': 'squarepants'},
+                                       {'ServiceName': 'patrick'}])
+        with patch.object(win_service, '_get_services', mock):
+            mock_info = MagicMock(side_effect=[{'StartType': 'Auto'},
+                                               {'StartType': 'Manual'},
+                                               {'StartType': 'Disabled'}])
+            with patch.object(win_service, 'info', mock_info):
+                self.assertListEqual(win_service.get_disabled(),
+                                     ['patrick', 'squarepants'])
 
     def test_available(self):
         '''
@@ -69,51 +82,70 @@ class WinServiceTestCase(TestCase):
         '''
             Test to return all installed services
         '''
-        mock = MagicMock(return_value="")
-        with patch.dict(win_service.__salt__, {'cmd.run': mock}):
-            self.assertListEqual(win_service.get_all(), [])
+        mock = MagicMock(return_value=[{'ServiceName': 'spongebob'},
+                                       {'ServiceName': 'squarepants'},
+                                       {'ServiceName': 'patrick'}])
+        with patch.object(win_service, '_get_services', mock):
+            self.assertListEqual(win_service.get_all(),
+                                 ['patrick', 'spongebob', 'squarepants'])
+
 
     def test_get_service_name(self):
         '''
             Test to the Display Name is what is displayed
             in Windows when services.msc is executed.
         '''
-        ret = ['Service Names and Display Names mismatch',
-               {'salt DISPLAY_NAME:salt': 'salt DISPLAY_NAME:salt'}]
-        mock = MagicMock(side_effect=['SERVICE_NAME:salt',
-                                      'SERVICE_NAME:salt DISPLAY_NAME:salt',
-                                      'SERVICE_NAME:salt DISPLAY_NAME:salt'])
-        with patch.dict(win_service.__salt__, {'cmd.run': mock}):
-            self.assertEqual(win_service.get_service_name(), ret[0])
-
-            self.assertDictEqual(win_service.get_service_name(), ret[1])
-
-            self.assertDictEqual(win_service.get_service_name("salt"), {})
+        mock = MagicMock(return_value=[{'ServiceName': 'spongebob',
+                                        'DisplayName': 'Sponge Bob'},
+                                       {'ServiceName': 'squarepants',
+                                        'DisplayName': 'Square Pants'},
+                                       {'ServiceName': 'patrick',
+                                        'DisplayName': 'Patrick the Starfish'}])
+        with patch.object(win_service, '_get_services', mock):
+            self.assertDictEqual(win_service.get_service_name(),
+                                 {'Patrick the Starfish': 'patrick',
+                                  'Sponge Bob': 'spongebob',
+                                  'Square Pants': 'squarepants'})
+            self.assertDictEqual(win_service.get_service_name('patrick'),
+                                 {'Patrick the Starfish': 'patrick'})
 
     def test_start(self):
         '''
             Test to start the specified service
         '''
-        mock = MagicMock(return_value=False)
-        with patch.dict(win_service.__salt__, {'cmd.retcode': mock}):
-            self.assertTrue(win_service.start("salt"))
+        mock_true = MagicMock(return_value=True)
+        mock_false = MagicMock(return_value=False)
+        mock_info = MagicMock(side_effect=[{'Status': 'Stopped'},
+                                           {'Status': 'Start Pending'},
+                                           {'Status': 'Running'}])
+
+        with patch.object(win_service, 'status', mock_true):
+            self.assertTrue(win_service.start('spongebob'))
+
+        with patch.object(win_service, 'status', mock_false):
+            with patch.object(win32serviceutil, 'StartService', mock_true):
+                with patch.object(win_service, 'info', mock_info):
+                    with patch.object(win_service, 'status', mock_true):
+                        self.assertTrue(win_service.start('spongebob'))
 
     def test_stop(self):
         '''
             Test to stop the specified service
         '''
-        win_service.SERVICE_STOP_POLL_MAX_ATTEMPTS = 1
-        win_service.SERVICE_STOP_DELAY_SECONDS = 1
-        mock = MagicMock(side_effect=[['service was stopped'], ["salt"],
-                                      ["salt"]])
-        with patch.dict(win_service.__salt__, {'cmd.run': mock}):
-            self.assertTrue(win_service.stop("salt"))
+        mock_true = MagicMock(return_value=True)
+        mock_false = MagicMock(return_value=False)
+        mock_info = MagicMock(side_effect=[{'Status': 'Running'},
+                                           {'Status': 'Stop Pending'},
+                                           {'Status': 'Stopped'}])
 
-            mock = MagicMock(side_effect=[False, True])
-            with patch.object(win_service, 'status', mock):
-                self.assertTrue(win_service.stop("salt"))
+        with patch.object(win_service, 'status', mock_false):
+            self.assertTrue(win_service.stop('spongebob'))
 
-                self.assertFalse(win_service.stop("salt"))
+        with patch.object(win_service, 'status', mock_true):
+            with patch.object(win32serviceutil, 'StopService', mock_true):
+                with patch.object(win_service, 'info', mock_info):
+                    with patch.object(win_service, 'status', mock_false):
+                        self.assertTrue(win_service.stop('spongebob'))
 
     def test_restart(self):
         '''
@@ -151,63 +183,66 @@ class WinServiceTestCase(TestCase):
         '''
             Test to return the status for a service
         '''
-        mock = MagicMock(side_effect=["RUNNING", "STOP_PENDING", ""])
-        with patch.dict(win_service.__salt__, {'cmd.run': mock}):
-            self.assertTrue(win_service.status("salt"))
+        mock_info = MagicMock(side_effect=[{'Status': 'Running'},
+                                           {'Status': 'Stop Pending'},
+                                           {'Status': 'Stopped'}])
 
-            self.assertTrue(win_service.status("salt"))
-
-            self.assertFalse(win_service.status("salt"))
+        with patch.object(win_service, 'info', mock_info):
+            self.assertTrue(win_service.status('spongebob'))
+            self.assertTrue(win_service.status('patrick'))
+            self.assertFalse(win_service.status('squidward'))
 
     def test_getsid(self):
         '''
             Test to return the sid for this windows service
         '''
-        mock = MagicMock(side_effect=["SERVICE SID:S-1-5-80-1956725871-603941828-2318551034-3950094706-3826225633", "SERVICE SID"])
-        with patch.dict(win_service.__salt__, {'cmd.run': mock}):
-            self.assertEqual(win_service.getsid("salt"), 'S-1-5-80-1956725871-603941828-2318551034-3950094706-3826225633')
-
-            self.assertEqual(win_service.getsid("salt"), None)
+        mock_info = MagicMock(side_effect=[{'sid': 'S-1-5-80-1956725871...'},
+                                           {'sid': None}])
+        with patch.object(win_service, 'info', mock_info):
+            self.assertEqual(win_service.getsid('spongebob'),
+                             'S-1-5-80-1956725871...')
+            self.assertEqual(win_service.getsid('plankton'), None)
 
     def test_enable(self):
         '''
             Test to enable the named service to start at boot
         '''
-        mock = MagicMock(return_value=False)
-        with patch.dict(win_service.__salt__, {'cmd.retcode': mock}):
-            self.assertTrue(win_service.enable("salt"))
+        mock_modify = MagicMock(return_value=True)
+        mock_info = MagicMock(return_value={'StartType': 'Auto'})
+        with patch.object(win_service, 'modify', mock_modify):
+            with patch.object(win_service, 'info', mock_info):
+                self.assertTrue(win_service.enable('spongebob'))
 
     def test_disable(self):
         '''
             Test to disable the named service to start at boot
         '''
-        mock = MagicMock(return_value=False)
-        with patch.dict(win_service.__salt__, {'cmd.retcode': mock}):
-            self.assertTrue(win_service.disable("salt"))
+        mock_modify = MagicMock(return_value=True)
+        mock_info = MagicMock(return_value={'StartType': 'Disabled'})
+        with patch.object(win_service, 'modify', mock_modify):
+            with patch.object(win_service, 'info', mock_info):
+                self.assertTrue(win_service.disable('spongebob'))
 
     def test_enabled(self):
         '''
             Test to check to see if the named
             service is enabled to start on boot
         '''
-        mock = MagicMock(side_effect=["AUTO_START", ""])
-        with patch.dict(win_service.__salt__, {'cmd.run': mock}):
-            self.assertTrue(win_service.enabled("salt"))
-
-            self.assertFalse(win_service.enabled("salt"))
+        mock = MagicMock(side_effect=[{'StartType': 'Auto'},
+                                      {'StartType': 'Disabled'}])
+        with patch.object(win_service, 'info', mock):
+            self.assertTrue(win_service.enabled('spongebob'))
+            self.assertFalse(win_service.enabled('squarepants'))
 
     def test_disabled(self):
         '''
             Test to check to see if the named
             service is disabled to start on boot
         '''
-        mock = MagicMock(side_effect=["DEMAND_START", "DISABLED", ""])
-        with patch.dict(win_service.__salt__, {'cmd.run': mock}):
-            self.assertTrue(win_service.disabled("salt"))
-
-            self.assertTrue(win_service.disabled("salt"))
-
-            self.assertFalse(win_service.disabled("salt"))
+        mock = MagicMock(side_effect=[False, True])
+        with patch.object(win_service, 'enabled', mock):
+            self.assertTrue(win_service.disabled('spongebob'))
+            self.assertFalse(win_service.disabled('squarepants'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?

Rewrites win_service.py to use windows api's instead of shelling out to the command line. Fixes `service.running` state for windows.
https://github.com/saltstack/zh/issues/12
### What issues does this PR fix or reference?
#31323
#29383
#32647
#29891
#13791
#15065
#10455
### Previous Behavior

Used to shell out to the command line for service operations.
Couldn't find services that didn't have the exact upper and lower case characters.
`service.running` with `enabled: True` would fail in windows if the service was disabled
### New Behavior

Uses windows api
Finds service names regardless of the case
Enables the service before trying to start it if `enable: True` for `service.running`
### Tests written?

No
