### PR TITLE
Proposal: Add a new which module

### DIFF
--- a/salt/modules/which.py
+++ b/salt/modules/which.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+'''
+Look for binaries in the default $PATH
+======================================
+
+This module searches the $PATH as seen by the minion process for a binary.
+
+'''
+from __future__ import absolute_import
+
+import salt.utils
+
+def find(binary_name):
+    '''
+    Try to find the specified binary in $PATH
+
+    CLI Example::
+
+        salt '*' which.find dig
+    '''
+    return salt.utils.which(binary_name)
+
+def missing(binary_name):
+   '''
+   Try to prove that the specified binary is _not_ in $PATH
+
+   CLI Example::
+
+       salt '*' which.missing brew
+   '''
+   return not bool(salt.utils.which(binary_name))
+


### PR DESCRIPTION
This adds a new execution module that wraps `salt.utils.which`. I was thinking about a way to portably and quietly simplify https://github.com/saltstack-formulas/openssh-formula/blob/master/openssh/known_hosts.sls#L3-L5. Currently, it will run and report the output of `which dig` in every run. I feel like that's unncessary and noisy, so instead I wanted to quiet it.

However, simply ignoring the output could be problematic and also considering the general use-case, this seemed appropriate. My imagined use-case is wrapping this in a `module.run` state and an onfail/onsuccess requisite.

And for use as a sysadmin, it is a nice tool to query wether a binary can be found on any given system. Not a super common task, but I can think of a few instances where it would have been appreciated.

No tests written, not sure how to really test this, it's so simple.
