### PR TITLE
Preserve existing, unspecified network settings

### DIFF
--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -776,7 +776,7 @@ def _parse_network_settings(opts, current):
     # Normalize keys
     opts = dict((k.lower(), v) for (k, v) in six.iteritems(opts))
     current = dict((k.lower(), v) for (k, v) in six.iteritems(current))
-    result = {}
+    result = current
 
     valid = _CONFIG_TRUE + _CONFIG_FALSE
     if 'enabled' not in opts:

--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -776,7 +776,10 @@ def _parse_network_settings(opts, current):
     # Normalize keys
     opts = dict((k.lower(), v) for (k, v) in six.iteritems(opts))
     current = dict((k.lower(), v) for (k, v) in six.iteritems(current))
-    result = current
+
+    # Check for supported parameters
+    retain_settings = opts.get('retain_settings', False)
+    result = current if retain_settings else {}
 
     valid = _CONFIG_TRUE + _CONFIG_FALSE
     if 'enabled' not in opts:

--- a/salt/states/network.py
+++ b/salt/states/network.py
@@ -234,6 +234,20 @@ all interfaces are ignored unless specified.
 
     .. versionadded:: 2015.5.0
 
+    system:
+      network.system:
+        - hostname: server2.example.com
+        - apply_hostname: True
+        - retain_settings: True
+
+    .. note::
+        Use `retain_settings` to retain current network settings that are not
+        otherwise specified in the state. Particularly useful if only setting
+        the hostname. Default behavior is to delete unspecified network
+        settings.
+
+    .. versionadded:: Carbon
+
 .. note::
 
     When managing bridged interfaces on a Debian or Ubuntu based system, the

--- a/salt/templates/rh_ip/network.jinja
+++ b/salt/templates/rh_ip/network.jinja
@@ -1,4 +1,5 @@
 {% if networking %}NETWORKING={{networking}}
+{%endif%}{% if networking_ipv6 %}NETWORKING_IPV6={{networking_ipv6}}
 {%endif%}{% if hostname %}HOSTNAME={{hostname}}
 {%endif%}{% if gateway %}GATEWAY={{gateway}}
 {%endif%}{% if gatewaydev %}GATEWAYDEV={{gatewaydev}}


### PR DESCRIPTION
### What does this PR do?
- When building the network configuration, retain any existing settings that are not explicitly specified by the user.
- Also adds support to the network template for the NETWORKING_IPV6 configuration setting.
### What issues does this PR fix or reference?

Fixes #33006
### Previous Behavior

Previously, unspecified network settings would be removed from the network configuration file.
### New Behavior

Adds a parameter, `retain_settings`, with a default `False` value. This default preserves prior behavior. If the user passes `retain_settings = True`, then existing network settings that are not otherwise specified in the state will be retained.
### Tests written?

No
