### PR TITLE
For #31309. If value not supplied only check for existence

### DIFF
--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -15,7 +15,7 @@ from salt.defaults import DEFAULT_TARGET_DELIM
 import re
 
 
-def present(name, value, delimiter=DEFAULT_TARGET_DELIM, force=False):
+def present(name, value=None, delimiter=DEFAULT_TARGET_DELIM, force=False):
     '''
     Ensure that a grain is set
 
@@ -25,7 +25,8 @@ def present(name, value, delimiter=DEFAULT_TARGET_DELIM, force=False):
         The grain name
 
     value
-        The value to set on the grain
+        The value to set on the grain. If not supplied the grain will only be
+        checked to see that it exists
 
     :param force: If force is True, the existing grain will be overwritten
         regardless of its existing or provided value type. Defaults to False
@@ -73,6 +74,13 @@ def present(name, value, delimiter=DEFAULT_TARGET_DELIM, force=False):
            'comment': ''}
     _non_existent = object()
     existing = __salt__['grains.get'](name, _non_existent)
+    if value is None:
+        if existing is _non_existent:
+            ret['result'] = False
+            ret['comment'] = 'Grain is not present'
+        else:
+            ret['comment'] = 'Grain is present'
+        return ret
     if existing == value:
         ret['comment'] = 'Grain is already set'
         return ret

--- a/tests/unit/states/grains_test.py
+++ b/tests/unit/states/grains_test.py
@@ -78,7 +78,26 @@ class GrainsTestCase(TestCase):
         with open(grains_file, "w+") as grf:
             grf.write(cstr)
 
-    # 'present' function tests: 12
+    # 'present' function tests: 13
+
+    def test_present_no_value(self):
+        self.setGrains({'a': 'aval', 'foo': 'bar'})
+        # Grain already set
+        ret = grains.present(
+            name='foo',
+            value=None)
+        self.assertEqual(ret['result'], True)
+        self.assertEqual(ret['comment'], 'Grain is present')
+        self.assertEqual(ret['changes'], {})
+
+        # Grain not present
+        self.setGrains({'a': 'aval'})
+        ret = grains.present(
+            name='foo',
+            value=None)
+        self.assertEqual(ret['result'], False)
+        self.assertEqual(ret['comment'], 'Grain is not present')
+        self.assertEqual(ret['changes'], {})
 
     def test_present_add(self):
         # Set a non existing grain


### PR DESCRIPTION
### What does this PR do?

Allows for grain existence check regardless of grain' value
### What issues does this PR fix or reference?
saltstack/salt#31309
### Previous Behavior

A value had to be provided and if supplied was used to set the grain
### New Behavior

A value of None can be supplied which will cause the grain to be checked for its existence only and no value to be set
### Tests written?

Yes