### PR TITLE
Fixed version comparison for packages with epoch

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1089,13 +1089,6 @@ def install(name=None,
             # not None, since the only way version_num is not None is if RPM
             # metadata parsing was successful.
             if pkg_type == 'repository':
-                if _yum() == 'yum':
-                    # yum install does not support epoch without the arch, and
-                    # we won't know what the arch will be when it's not
-                    # provided. It could either be the OS architecture, or
-                    # 'noarch', and we don't make that distinction in the
-                    # pkg.list_pkgs return data.
-                    version_num = version_num.split(':', 1)[-1]
                 arch = ''
                 try:
                     namepart, archpart = pkgname.rsplit('.', 1)
@@ -1105,8 +1098,16 @@ def install(name=None,
                     if archpart in salt.utils.pkg.rpm.ARCHES:
                         arch = '.' + archpart
                         pkgname = namepart
-
-                pkgstr = '{0}-{1}{2}'.format(pkgname, version_num, arch)
+                if _yum() == 'yum':
+                    # yum install does not support epoch without the arch, and
+                    # we won't know what the arch will be when it's not
+                    # provided. It could either be the OS architecture, or
+                    # 'noarch', and we don't make that distinction in the
+                    # pkg.list_pkgs return data.
+                    version_num = version_num.split(':', 1)[-1]
+                    pkgstr = '{0}-{1}{2}'.format(pkgname, version_num.split(':', 1)[-1], arch)
+                else:
+                    pkgstr = '{0}-{1}{2}'.format(pkgname, version_num, arch)
             else:
                 pkgstr = pkgpath
 

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1104,7 +1104,6 @@ def install(name=None,
                     # provided. It could either be the OS architecture, or
                     # 'noarch', and we don't make that distinction in the
                     # pkg.list_pkgs return data.
-                    version_num = version_num.split(':', 1)[-1]
                     pkgstr = '{0}-{1}{2}'.format(pkgname, version_num.split(':', 1)[-1], arch)
                 else:
                     pkgstr = '{0}-{1}{2}'.format(pkgname, version_num, arch)


### PR DESCRIPTION
### What does this PR do?

Since the epoch is removed from `version_num` before doing version comparison (`salt.utils.compare_versions`), it was always trying to downgrade packages with epoch in version.
### What issues does this PR fix or reference?
### Previous Behavior

Packages with epoch in version will fail to upgrade, because it was trying to downgrade them.
### New Behavior

Packages with epoch in version will upgrade.
### Tests written?

No
