### PR TITLE
add test for installing package while using salt-call --local

### DIFF
--- a/tests/integration/shell/call.py
+++ b/tests/integration/shell/call.py
@@ -38,6 +38,7 @@ _PKG_TARGETS = {
     'Suse': ['aalib', 'python-pssh']
 }
 
+
 class CallTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
 
     _call_binary_ = 'salt-call'

--- a/tests/integration/shell/call.py
+++ b/tests/integration/shell/call.py
@@ -14,6 +14,7 @@ import re
 import shutil
 import yaml
 from datetime import datetime
+import logging
 
 # Import Salt Testing libs
 from salttesting import skipIf
@@ -23,7 +24,19 @@ ensure_in_syspath('../../')
 # Import salt libs
 import integration
 import salt.utils
+from salttesting.helpers import (
+    destructiveTest
+)
 
+log = logging.getLogger(__name__)
+
+_PKG_TARGETS = {
+    'Arch': ['python2-django', 'libpng'],
+    'Debian': ['python-plist', 'apg'],
+    'RedHat': ['xz-devel', 'zsh-html'],
+    'FreeBSD': ['aalib', 'pth'],
+    'Suse': ['aalib', 'python-pssh']
+}
 
 class CallTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
 
@@ -69,6 +82,25 @@ class CallTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
         self.assertIn('Result: True', ''.join(out))
         self.assertIn('hello', ''.join(out))
         self.assertIn('Succeeded: 1', ''.join(out))
+
+    @destructiveTest
+    @skipIf(sys.platform.startswith('win'), 'This test does not apply on Win')
+    def test_local_pkg_install(self):
+        '''
+        Test to ensure correct output when installing package
+        '''
+        get_os_family = self.run_call('--local grains.get os_family')
+        pkg_targets = _PKG_TARGETS.get(get_os_family[1].strip(), [])
+        check_pkg = self.run_call('--local pkg.list_pkgs')
+        for pkg in pkg_targets:
+            if pkg not in str(check_pkg):
+                out = self.run_call('--local pkg.install {0}'.format(pkg))
+                self.assertIn('local:    ----------', ''.join(out))
+                self.assertIn('{0}:        ----------'.format(pkg), ''.join(out))
+                self.assertIn('new:', ''.join(out))
+                self.assertIn('old:', ''.join(out))
+            else:
+                log.debug('The pkg: {0} is already installed on the machine'.format(pkg))
 
     @skipIf(sys.platform.startswith('win'), 'This test does not apply on Win')
     def test_user_delete_kw_output(self):
@@ -393,6 +425,17 @@ class CallTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
             # Restore umask
             os.umask(current_umask)
 
+    def tearDown(self):
+        '''
+        Teardown method to remove installed packages
+        '''
+        check_pkg = self.run_call('--local pkg.list_pkgs')
+        get_os_family = self.run_call('--local grains.get os_family')
+        pkg_targets = _PKG_TARGETS.get(get_os_family[1].strip(), [])
+        check_pkg = self.run_call('--local pkg.list_pkgs')
+        for pkg in pkg_targets:
+            if pkg in str(check_pkg):
+                out = self.run_call('--local pkg.remove {0}'.format(pkg))
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
### What does this PR do?

Test for testing the output when installing a package with `salt-call --local pkg.install`
### What issues does this PR fix or reference?

NA
### Tests written?

Yes
