### PR TITLE
Fix functionality of unless in states.cmd, when unless condition give…

### DIFF
--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -352,10 +352,10 @@ def mod_run_check(cmd_kwargs, onlyif, unless, creates):
             for entry in unless:
                 cmd.append(__salt__['cmd.retcode'](entry, ignore_retcode=True, python_shell=True, **cmd_kwargs))
                 log.debug('Last command return code: {0}'.format(cmd))
-                if all([c == 0 for c in cmd]):
-                    return {'comment': 'unless execution succeeded',
-                            'skip_watch': True,
-                            'result': True}
+            if all([c == 0 for c in cmd]):
+                return {'comment': 'unless execution succeeded',
+                        'skip_watch': True,
+                        'result': True}
         elif not isinstance(unless, string_types):
             if unless:
                 log.debug('Command not run: unless did not evaluate to string_type')


### PR DESCRIPTION
### What does this PR do?

This PR fixes the functionality of `unless`'s  buggy behavior when unless conditions are given as a list in functions of salt.states.cmd.
### What issues does this PR fix or reference?

As stated in the docs of [Requisites section unless](https://docs.saltstack.com/en/latest/ref/states/requisites.html#unless), the unless will not succeed if any of the commands given in unless not run successfully.
But the current behavior of it is not in accordance of that. Currently, the unless execution gets succeeded if only first command runs successfully and it doesn't check for later commands.
### Tests written?

No

Please fix this in all major version too. We use 2015.8 (Beryllium)
