### PR TITLE
When we restart the minion we should show the error that caused it

### DIFF
--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -85,7 +85,7 @@ def minion_process():
     try:
         minion.start()
     except (SaltClientError, SaltReqTimeoutError, SaltSystemExit) as exc:
-        log.warning('Fatal functionality error caught by minion handler: ', exc_info=True)
+        log.warning('Fatal functionality error caught by minion handler:\n', exc_info=True)
         log.warning('** Restarting minion **')
         delay = 60
         if minion is not None and hasattr(minion, 'config'):

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -85,6 +85,7 @@ def minion_process():
     try:
         minion.start()
     except (SaltClientError, SaltReqTimeoutError, SaltSystemExit) as exc:
+        log.warning('Fatal functionality error caught by minion handler: ', exc_info=True)
         log.warning('** Restarting minion **')
         delay = 60
         if minion is not None and hasattr(minion, 'config'):


### PR DESCRIPTION
### What does this PR do?

Add an error handler for minion manager restarts so that bugs like #32472 are fixable
### What issues does this PR fix or reference?
### Previous Behavior

Remove this section if not relevant
### New Behavior

Remove this section if not relevant
### Tests written?

Yes/No
