### PR TITLE
win_network.ping: add timeout and return_boolean

### DIFF
--- a/salt/modules/win_network.py
+++ b/salt/modules/win_network.py
@@ -37,7 +37,7 @@ def __virtual__():
     return (False, "Module win_network: module only works on Windows systems")
 
 
-def ping(host):
+def ping(host, timeout=False, return_boolean=False):
     '''
     Performs a ping to a host
 
@@ -46,9 +46,29 @@ def ping(host):
     .. code-block:: bash
 
         salt '*' network.ping archlinux.org
+
+    .. versionadded:: Carbon
+
+    Return a True or False instead of ping output.
+
+        salt '*' network.ping windows.com return_boolean=True
+
+    Set the time to wait for a response in seconds.
+
+        salt '*' network.ping windows.com timeout=3
     '''
-    cmd = ['ping', '-n', '4', salt.utils.network.sanitize_host(host)]
-    return __salt__['cmd.run'](cmd, python_shell=False)
+    if timeout:
+        cmd = ['ping', '-n', '4', '-w', str(timeout * 1000), salt.utils.network.sanitize_host(host)]
+    else:
+        cmd = ['ping', '-n', '4', salt.utils.network.sanitize_host(host)]
+    if return_boolean:
+        ret = __salt__['cmd.run_all'](cmd, python_shell=False)
+        if ret['retcode'] != 0:
+            return False
+        else:
+            return True
+    else:
+        return __salt__['cmd.run'](cmd, python_shell=False)
 
 
 def netstat():

--- a/salt/modules/win_network.py
+++ b/salt/modules/win_network.py
@@ -51,14 +51,18 @@ def ping(host, timeout=False, return_boolean=False):
 
     Return a True or False instead of ping output.
 
-        salt '*' network.ping windows.com return_boolean=True
+    .. code-block:: bash
+
+        salt '*' network.ping archlinux.org return_boolean=True
 
     Set the time to wait for a response in seconds.
 
-        salt '*' network.ping windows.com timeout=3
+    .. code-block:: bash
+
+        salt '*' network.ping archlinux.org timeout=3
     '''
     if timeout:
-        # Windows differs by having timeout be for individual echo requests.'
+        # Windows ping differs by having timeout be for individual echo requests.'
         # Divide timeout by tries to mimic BSD behaviour.
         timeout = int(timeout) * 1000 // 4
         cmd = ['ping', '-n', '4', '-w', str(timeout), salt.utils.network.sanitize_host(host)]

--- a/salt/modules/win_network.py
+++ b/salt/modules/win_network.py
@@ -58,7 +58,10 @@ def ping(host, timeout=False, return_boolean=False):
         salt '*' network.ping windows.com timeout=3
     '''
     if timeout:
-        cmd = ['ping', '-n', '4', '-w', str(timeout * 1000), salt.utils.network.sanitize_host(host)]
+        # Windows differs by having timeout be for individual echo requests.'
+        # Divide timeout by tries to mimic BSD behaviour.
+        timeout = int(timeout) * 1000 // 4
+        cmd = ['ping', '-n', '4', '-w', str(timeout), salt.utils.network.sanitize_host(host)]
     else:
         cmd = ['ping', '-n', '4', salt.utils.network.sanitize_host(host)]
     if return_boolean:


### PR DESCRIPTION
### What does this PR do?

This makes the ping function in the win_network module accept the same flags that the generic network does.
### What issues does this PR fix or reference?

Fixes #33009 
### Previous Behavior

Previously the win_network module generated an ERROR that the arguments timeout or return_boolean were not valid.
### New Behavior

win_network.ping now accepts the timeout and return_boolean flags and acts accordingly.
### Tests written?

No, request how it should be tested and I'll write it. 
