### PR TITLE
Add fun_args to scheduled return data (part of #24237)

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -659,10 +659,12 @@ class Schedule(object):
             args = tuple()
             if 'args' in data:
                 args = data['args']
+                ret['fun_args'] = data['args']
 
             kwargs = {}
             if 'kwargs' in data:
                 kwargs = data['kwargs']
+                ret['fun_kwargs'] = data['kwargs']
 
             if func not in self.functions:
                 ret['return'] = self.functions.missing_fun_string(func)

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -582,6 +582,7 @@ class Schedule(object):
             self.returners = salt.loader.returners(self.opts, self.functions)
         ret = {'id': self.opts.get('id', 'master'),
                'fun': func,
+               'fun_args': [],
                'schedule': data['name'],
                'jid': salt.utils.jid.gen_jid()}
 
@@ -659,12 +660,12 @@ class Schedule(object):
             args = tuple()
             if 'args' in data:
                 args = data['args']
-                ret['fun_args'] = data['args']
+                ret['fun_args'].extend(data['args'])
 
             kwargs = {}
             if 'kwargs' in data:
                 kwargs = data['kwargs']
-                ret['fun_kwargs'] = data['kwargs']
+                ret['fun_args'].append(data['kwargs'])
 
             if func not in self.functions:
                 ret['return'] = self.functions.missing_fun_string(func)


### PR DESCRIPTION
### What does this PR do?

Adds the `fun_args` key to return data of scheduled jobs
### What issues does this PR fix or reference?
#24237
