### PR TITLE
Update mac_assistive module for El Capitan (10.11)

### DIFF
--- a/salt/modules/mac_assistive.py
+++ b/salt/modules/mac_assistive.py
@@ -51,11 +51,12 @@ def install(app_id, enable=True):
         salt '*' assistive.install /usr/bin/osascript
         salt '*' assistive.install com.smileonmymac.textexpander
     '''
+    ge_el_capitan = True if LooseVersion(__grains__['osrelease']) >= '10.11' else False
     client_type = _client_type(app_id)
     enable_str = '1' if enable else '0'
     cmd = 'sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" ' \
-          '"INSERT or REPLACE INTO access VALUES(\'kTCCServiceAccessibility\',\'{0}\',{1},{2},1,NULL)"'.\
-        format(app_id, client_type, enable_str)
+          '"INSERT or REPLACE INTO access VALUES(\'kTCCServiceAccessibility\',\'{0}\',{1},{2},1,NULL{3})"'.\
+        format(app_id, client_type, enable_str, ',NULL' if ge_el_capitan else '')
 
     call = __salt__['cmd.run_all'](
         cmd,

--- a/salt/modules/mac_assistive.py
+++ b/salt/modules/mac_assistive.py
@@ -28,7 +28,7 @@ def __virtual__():
     '''
     Only work on Mac OS
     '''
-    if salt.utils.is_darwin() and LooseVersion(__grains__['osrelease']) >= LooseVersion('10.9'):
+    if salt.utils.is_darwin() and LooseVersion(__grains__['osrelease']) >= '10.9':
         return True
     return False, 'The assistive module cannot be loaded: must be run on OSX 10.9 or newer.'
 

--- a/tests/integration/modules/mac_assistive.py
+++ b/tests/integration/modules/mac_assistive.py
@@ -49,14 +49,14 @@ class MacAssistiveTest(integration.ModuleCase):
         Clean up after tests
         '''
         # Delete any bundles that were installed
-        osa_script = self.run_function('assistive.installed', OSA_SCRIPT)
+        osa_script = self.run_function('assistive.installed', [OSA_SCRIPT])
         if osa_script:
-            self.run_function('assistive.remove', OSA_SCRIPT)
+            self.run_function('assistive.remove', [OSA_SCRIPT])
 
         smile_bundle = 'com.smileonmymac.textexpander'
-        smile_bundle_present = self.run_function('assistive.installed', smile_bundle)
+        smile_bundle_present = self.run_function('assistive.installed', [smile_bundle])
         if smile_bundle_present:
-            self.run_function('assistive.remove', smile_bundle)
+            self.run_function('assistive.remove', [smile_bundle])
 
     @requires_system_grains
     def test_install_and_remove(self, grains=None):
@@ -65,10 +65,10 @@ class MacAssistiveTest(integration.ModuleCase):
         '''
         new_bundle = 'com.smileonmymac.textexpander'
         self.assertTrue(
-            self.run_function('assistive.install', new_bundle)
+            self.run_function('assistive.install', [new_bundle])
         )
         self.assertTrue(
-            self.run_function('assistive.remove', new_bundle)
+            self.run_function('assistive.remove', [new_bundle])
         )
 
     @requires_system_grains
@@ -78,7 +78,7 @@ class MacAssistiveTest(integration.ModuleCase):
         '''
         # OSA script should have been installed in setUp function
         self.assertTrue(
-            self.run_function('assistive.installed', OSA_SCRIPT)
+            self.run_function('assistive.installed', [OSA_SCRIPT])
         )
         # Clean up install
         self.run_function('assistive.remove', [OSA_SCRIPT])
@@ -103,11 +103,11 @@ class MacAssistiveTest(integration.ModuleCase):
         )
         # Now re-enable
         self.assertTrue(
-            self.run_function('assistive.enable', OSA_SCRIPT)
+            self.run_function('assistive.enable', [OSA_SCRIPT])
         )
         # Double check the script was enabled, as intended.
         self.assertTrue(
-            self.run_function('assistive.enabled', OSA_SCRIPT)
+            self.run_function('assistive.enabled', [OSA_SCRIPT])
         )
 
     @requires_system_grains
@@ -118,7 +118,7 @@ class MacAssistiveTest(integration.ModuleCase):
         # OSA script should have been installed in setUp function, which sets
         # enabled to True by default.
         self.assertTrue(
-            self.run_function('assistive.enabled', OSA_SCRIPT)
+            self.run_function('assistive.enabled', [OSA_SCRIPT])
         )
         # Disable OSA Script
         self.run_function('assistive.enable', [OSA_SCRIPT, False])

--- a/tests/unit/modules/mac_assistive_test.py
+++ b/tests/unit/modules/mac_assistive_test.py
@@ -18,6 +18,7 @@ from salt.exceptions import CommandExecutionError
 from salt.modules import mac_assistive as assistive
 
 assistive.__salt__ = {}
+assistive.__grains__ = {}
 
 
 class AssistiveTestCase(TestCase):
@@ -28,7 +29,8 @@ class AssistiveTestCase(TestCase):
         '''
         mock_ret = MagicMock(return_value={'retcode': 0})
         with patch.dict(assistive.__salt__, {'cmd.run_all': mock_ret}):
-            self.assertTrue(assistive.install('foo'))
+            with patch.dict(assistive.__grains__, {'osrelease': '10.11.3'}):
+                self.assertTrue(assistive.install('foo'))
 
     def test_install_assistive_error(self):
         '''
@@ -36,7 +38,8 @@ class AssistiveTestCase(TestCase):
         '''
         mock_ret = MagicMock(return_value={'retcode': 1})
         with patch.dict(assistive.__salt__, {'cmd.run_all': mock_ret}):
-            self.assertRaises(CommandExecutionError, assistive.install, 'foo')
+            with patch.dict(assistive.__grains__, {'osrelease': '10.11.3'}):
+                self.assertRaises(CommandExecutionError, assistive.install, 'foo')
 
     @patch('salt.modules.mac_assistive._get_assistive_access', MagicMock(return_value=[('foo', 0)]))
     def test_installed_bundle(self):


### PR DESCRIPTION
### What does this PR do?

Fix `assistive.install` for MacOS 10.11.  Ping @rallytime, @opdude.
### Previous Behavior

`integration.modules.mac_assistive.MacAssistiveTest.test_enable` failed on MacOS 10.11 because `assistive.install` was trying to insert data into `TCC.db` that didn't match the schema.
### New Behavior

Insert data with the correct number of columns on MacOS 10.11.
### Tests written?

Yes
