### PR TITLE
Pass all data to batch.run() call when using --failhard

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -203,6 +203,11 @@ class Batch(object):
                     active.remove(minion)
                 if self.opts.get('raw'):
                     yield data
+                elif self.opts.get('failhard'):
+                    # When failhard is passed, we need to return all data to include
+                    # the retcode to use in salt/cli/salt.py later. See issue #24996.
+                    ret[minion] = data
+                    yield {minion: data}
                 else:
                     ret[minion] = data['ret']
                     yield {minion: data['ret']}


### PR DESCRIPTION
### What does this PR do?

Passes more data to batch.run when specifying `--failhard`. This allows salt.py to look for the function's retcode and stop the batch run when using `--failhard`.
### What issues does this PR fix or reference?

Fixes #24996
### Previous Behavior

Without this change, cmd_run worked as expected (because the retcode is passed automatically), but when using cmd.run, the failhard was honored and the batch run would continue instead of exiting:

```
root@rallytime:~# salt rallytime cmd.run 'foo' -b 1 --failhard

Executing run on ['rallytime']

rallytime:
    /bin/bash: foo: command not found
retcode:
    127
```
### New Behavior

With this change, the retcode of the failed cmd.run command is recognized at the process exits:

```
root@rallytime:~# salt rallytime cmd.run 'foo' -b 1 --failhard

Executing run on ['rallytime']

ERROR: Minions returned with non-zero exit code
```
### Tests written?

No
