### PR TITLE
Don't append a newline when creating new content with blockreplace

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2155,7 +2155,7 @@ def blockreplace(path,
         if prepend_if_not_found:
             # add the markers and content at the beginning of file
             new_file.insert(0, marker_end + '\n')
-            new_file.insert(0, content + '\n')
+            new_file.insert(0, content)
             new_file.insert(0, marker_start + '\n')
             done = True
         elif append_if_not_found:
@@ -2165,7 +2165,7 @@ def blockreplace(path,
                     new_file[-1] += '\n'
             # add the markers and content at the end of file
             new_file.append(marker_start + '\n')
-            new_file.append(content + '\n')
+            new_file.append(content)
             new_file.append(marker_end + '\n')
             done = True
         else:


### PR DESCRIPTION
### What does this PR do?

removed the additional newline which was specific to file creation in file.blockreplace
### What issues does this PR fix or reference?

fix #12422
### Tests written?

No
