### PR TITLE
Display command output when command fails with batch + failhard options

### DIFF
--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -100,7 +100,11 @@ class SaltCMD(parsers.SaltCMDOptionParser):
                         for ret in six.itervalues(res):
                             retcode = salt.utils.job.get_retcode(ret)
                             if retcode != 0:
-                                sys.stderr.write('ERROR: Minions returned with non-zero exit code\n')
+                                sys.stderr.write(
+                                    '{0}\nERROR: Minions returned with non-zero exit code.\n'.format(
+                                        ret
+                                    )
+                                )
                                 sys.exit(retcode)
 
         else:

--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -102,7 +102,7 @@ class SaltCMD(parsers.SaltCMDOptionParser):
                             if retcode != 0:
                                 sys.stderr.write(
                                     '{0}\nERROR: Minions returned with non-zero exit code.\n'.format(
-                                        ret
+                                        res
                                     )
                                 )
                                 sys.exit(retcode)


### PR DESCRIPTION
### What does this PR do?

Adds the command output to the error response when a command fails and `--failhard` and `--batch` are used together.
### What issues does this PR fix or reference?

Fixes #32452
### Previous Behavior

When a cmd.run_all fails and --failhard is set with --batch, the batch run exits and displays an error. However, no information about the failure is presented:

```
root@rallytime:~# salt rallytime cmd.run_all 'foo' -b 1 --failhard

Executing run on ['rallytime']

ERROR: Minions returned with non-zero exit code.
```
### New Behavior

Now, a data dictionary of the command output is displayed along with the ERROR message:

```
root@rallytime:~# salt rallytime cmd.run_all 'foo' -b 1 --failhard

Executing run on ['rallytime']

{'rallytime': {'retcode': 127, 'ret': {'pid': 5838, 'retcode': 127, 'stderr': '/bin/bash: foo: command not found', 'stdout': ''}}}
ERROR: Minions returned with non-zero exit code.
```
### Tests written?

No
