### PR TITLE
Allow security_groups kwarg for boto_elb.present to be string or list

### DIFF
--- a/salt/states/boto_elb.py
+++ b/salt/states/boto_elb.py
@@ -70,6 +70,8 @@ passed in as a dict, or as a string to pull from pillars or minion config:
                   ttl: 60
                 - name: myothercname.example.com.
                   zone: example.com.
+            - security_groups:
+                - my-security-group
 
     # Using a profile from pillars
     Ensure myelb ELB exists:
@@ -249,7 +251,22 @@ def present(
         A list of subnet IDs in your VPC to attach to your LoadBalancer.
 
     security_groups
-        The security groups assigned to your LoadBalancer within your VPC.
+        The security groups assigned to your LoadBalancer within your VPC. Must
+        be passed either as a list or a comma-separated string.
+
+        For example, a list:
+
+        .. code-block:: yaml
+
+            - security_groups:
+              - secgroup-one
+              - secgroup-two
+
+        Or as a comma-separated string:
+
+        .. code-block:: yaml
+
+            - security_groups: secgroup-one,secgroup-two
 
     scheme
         The type of a LoadBalancer, ``internet-facing`` or ``internal``. Once
@@ -308,6 +325,16 @@ def present(
         attributes = tmp
 
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
+
+    if security_groups:
+        if isinstance(security_groups, six.string_types):
+            security_groups = security_groups.split(',')
+        elif not isinstance(security_groups, list):
+            ret['result'] = False
+            ret['comment'] = 'The \'security_group\' parameter must either be a list or ' \
+                             'a comma-separated string.'
+            return ret
+
     _ret = _elb_present(name, availability_zones, listeners, subnets,
                         security_groups, scheme, region, key, keyid, profile)
     ret['changes'] = _ret['changes']


### PR DESCRIPTION
### What does this PR do?

Allows the security_groups option to be either a list or a comma-separated string. If neither are used, then the state fails and warns the user. Also added documentation for examples on how to use it.
### What issues does this PR fix or reference?

Fixes #33041
### Tests written?

No
