### PR TITLE
File and User test fixes for 2015.5 on Fedora23

### DIFF
--- a/tests/integration/states/user.py
+++ b/tests/integration/states/user.py
@@ -69,7 +69,7 @@ class UserTest(integration.ModuleCase,
         And then destroys that user.
         Assume that it will break any system you run it on.
         '''
-        HOMEDIR = '/tmp/home_of_salt_test'
+        HOMEDIR = '/home/home_of_salt_test'
         ret = self.run_state('user.present', name='salt_test',
                              home=HOMEDIR)
         self.assertSaltTrueReturn(ret)

--- a/tests/unit/states/file_test.py
+++ b/tests/unit/states/file_test.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import
 import json
 import pprint
+import tempfile
 
 # Import Salt Testing libs
 from salttesting import skipIf, TestCase
@@ -137,8 +138,9 @@ class FileTestCase(TestCase):
         '''
         Test to create a symlink.
         '''
-        name = '/etc/grub.conf'
-        target = '/boot/grub/grub.conf'
+        name = '/tmp/testfile.txt'
+        target = tempfile.mkstemp()[1]
+        test_dir = '/tmp'
         user = 'salt'
         if salt.utils.is_windows():
             group = 'salt'
@@ -192,7 +194,7 @@ class FileTestCase(TestCase):
                                              'file.is_link': mock_f}):
             with patch.dict(filestate.__opts__, {'test': False}):
                 with patch.object(os.path, 'isdir', mock_f):
-                    comt = ('Directory /etc for symlink is not present')
+                    comt = ('Directory {0} for symlink is not present').format(test_dir)
                     ret.update({'comment': comt, 'result': False})
                     self.assertDictEqual(filestate.symlink(name, target,
                                                            user=user,


### PR DESCRIPTION
### What does this PR do?

/etc/grub.conf exists by default on Fedora 23. This uses a temp file to avoid this problem.
Fedora 23 does not allow users to create their home director in /tmp/. Changed /tmp  to /home
### What issues does this PR fix or reference?

Fixes failing tests on Fedora 23 on the 2015.5 branch
### Tests written?

Yes
