### PR TITLE
cloud.query needs to define mapper.opts

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -279,6 +279,7 @@ class CloudClient(object):
         Query basic instance information
         '''
         mapper = salt.cloud.Map(self._opts_defaults())
+        mapper.opts['selected_query_option'] = 'list_nodes'
         return mapper.map_providers_parallel(query_type)
 
     def full_query(self, query_type='list_nodes_full'):


### PR DESCRIPTION
### What does this PR do?

fix cloud.query. I think @techhat missed a line. in 70847f21b4efc5ce89433446c2faea7983879c8d
### What issues does this PR fix or reference?
### Previous Behavior

salt-call cloud.query for digital_ocean works correctly. Fails for ec2 and linode.
### New Behavior

works for ec2 and linode
### Tests written?

No - sorry.
