### PR TITLE
verify_env function for windows

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -912,8 +912,7 @@ class DaemonMixIn(six.with_metaclass(MixInMeta, object)):
         a running process.
         '''
         # There is no os.getppid method for windows
-        from salt.utils import is_windows
-        if is_windows():
+        if salt.utils.is_windows():
             from salt.utils.win_functions import get_parent_pid
             ppid = get_parent_pid()
         else:

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -911,9 +911,17 @@ class DaemonMixIn(six.with_metaclass(MixInMeta, object)):
         Check if a pid file exists and if it is associated with
         a running process.
         '''
+        # There is no os.getppid method for windows
+        from salt.utils import is_windows
+        if is_windows():
+            from salt.utils.win_functions import get_parent_pid
+            ppid = get_parent_pid()
+        else:
+            ppid = os.getppid()
+
         if self.check_pidfile():
             pid = self.get_pidfile()
-            if self.check_pidfile() and self.is_daemonized(pid) and not os.getppid() == pid:
+            if self.check_pidfile() and self.is_daemonized(pid) and not ppid == pid:
                 return True
         return False
 

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -533,7 +533,7 @@ def win_verify_env(dirs, user, permissive=False, pki_dir='', skip_extra=False):
 
     # Get the root path directory where salt is installed
     path = dirs[0]
-    while os.path.basename(path) not in ['salt']:
+    while os.path.basename(path) not in ['salt', 'salt-tests-tmpdir']:
         path, base = os.path.split(path)
 
     # Create the root path directory if missing

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -558,7 +558,7 @@ def win_verify_env(dirs, user, permissive=False, pki_dir='', skip_extra=False):
                 salt.utils.win_functions.set_path_permissions(path)
             except CommandExecutionError:
                 msg = 'Unable to securely set the permissions of "{0}".'
-                msg = msg.format(dir_)
+                msg = msg.format(path)
                 if is_console_configured():
                     log.critical(msg)
                 else:

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -531,8 +531,6 @@ def win_verify_env(dirs, user, permissive=False, pki_dir='', skip_extra=False):
     '''
     import salt.utils.win_functions
 
-
-
     # Get the root path directory where salt is installed
     path = dirs[0]
     while os.path.basename(path) not in ['salt']:
@@ -549,7 +547,7 @@ def win_verify_env(dirs, user, permissive=False, pki_dir='', skip_extra=False):
             salt.utils.win_functions.set_path_owner(path)
         except CommandExecutionError:
             msg = 'Unable to securely set the owner of "{0}".'
-            msg = msg.format(dir_)
+            msg = msg.format(path)
             if is_console_configured():
                 log.critical(msg)
             else:

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -548,13 +548,23 @@ def win_verify_env(dirs, user, permissive=False, pki_dir='', skip_extra=False):
         try:
             salt.utils.win_functions.set_path_owner(path)
         except CommandExecutionError:
-            pass
+            msg = 'Unable to securely set the owner of "{0}".'
+            msg = msg.format(dir_)
+            if is_console_configured():
+                log.critical(msg)
+            else:
+                sys.stderr.write("CRITICAL: {0}\n".format(msg))
 
         if not permissive:
             try:
                 salt.utils.win_functions.set_path_permissions(path)
             except CommandExecutionError:
-                pass
+                msg = 'Unable to securely set the permissions of "{0}".'
+                msg = msg.format(dir_)
+                if is_console_configured():
+                    log.critical(msg)
+                else:
+                    sys.stderr.write("CRITICAL: {0}\n".format(msg))
 
     # Create the directories
     for dir_ in dirs:
@@ -567,18 +577,11 @@ def win_verify_env(dirs, user, permissive=False, pki_dir='', skip_extra=False):
                 msg = 'Failed to create directory path "{0}" - {1}\n'
                 sys.stderr.write(msg.format(dir_, err))
                 sys.exit(err.errno)
-        log.error('*' * 68)
-        log.error(pki_dir)
-        log.error(dir_)
-        log.error('*' * 68)
 
         if dir_ == pki_dir:
             try:
-                salt.utils.win_functions.set_path_owner(path)
-                salt.utils.win_functions.set_path_permissions(path)
-                log.error('*' * 68)
-                log.error(salt.utils.win_functions.get_current_user())
-                log.error('*' * 68)
+                salt.utils.win_functions.set_path_owner(dir_)
+                salt.utils.win_functions.set_path_permissions(dir_)
             except CommandExecutionError:
                 msg = 'Unable to securely set the permissions of "{0}".'
                 msg = msg.format(dir_)

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -23,7 +23,8 @@ else:
 
 # Import salt libs
 from salt.log import is_console_configured
-from salt.exceptions import SaltClientError, SaltSystemExit
+from salt.exceptions import SaltClientError, SaltSystemExit, \
+    CommandExecutionError
 import salt.defaults.exitcodes
 import salt.utils
 
@@ -200,7 +201,9 @@ def verify_env(dirs, user, permissive=False, pki_dir='', skip_extra=False):
     can shake the salt
     '''
     if salt.utils.is_windows():
-        return True
+        from salt.utils.win_functions import get_current_user
+        return win_verify_env(
+            dirs, get_current_user(), permissive, pki_dir, skip_extra)
     import pwd  # after confirming not running Windows
     try:
         pwnam = pwd.getpwnam(user)
@@ -276,7 +279,7 @@ def verify_env(dirs, user, permissive=False, pki_dir='', skip_extra=False):
         #
         # If the permissions aren't correct, default to the more secure 700.
         # If acls are enabled, the pki_dir needs to remain readable, this
-        # is still secure because the private keys are still only readbale
+        # is still secure because the private keys are still only readable
         # by the user running the master
         if dir_ == pki_dir:
             smode = stat.S_IMODE(mode.st_mode)
@@ -519,3 +522,71 @@ def verify_log(opts):
     '''
     if opts.get('log_level') in ('garbage', 'trace', 'debug'):
         log.warning('Insecure logging configuration detected! Sensitive data may be logged.')
+
+
+def win_verify_env(dirs, user, permissive=False, pki_dir='', skip_extra=False):
+    '''
+    Verify that the named directories are in place and that the environment
+    can shake the salt
+    '''
+    import salt.utils.win_functions
+
+
+
+    # Get the root path directory where salt is installed
+    path = dirs[0]
+    while os.path.basename(path) not in ['salt']:
+        path, base = os.path.split(path)
+
+    # Create the root path directory if missing
+    if not os.path.isdir(path):
+        os.makedirs(path)
+
+    # Set permissions to the root path directory
+    current_user = salt.utils.win_functions.get_current_user()
+    if salt.utils.win_functions.is_admin(current_user):
+        try:
+            salt.utils.win_functions.set_path_owner(path)
+        except CommandExecutionError:
+            pass
+
+        if not permissive:
+            try:
+                salt.utils.win_functions.set_path_permissions(path)
+            except CommandExecutionError:
+                pass
+
+    # Create the directories
+    for dir_ in dirs:
+        if not dir_:
+            continue
+        if not os.path.isdir(dir_):
+            try:
+                os.makedirs(dir_)
+            except OSError as err:
+                msg = 'Failed to create directory path "{0}" - {1}\n'
+                sys.stderr.write(msg.format(dir_, err))
+                sys.exit(err.errno)
+        log.error('*' * 68)
+        log.error(pki_dir)
+        log.error(dir_)
+        log.error('*' * 68)
+
+        if dir_ == pki_dir:
+            try:
+                salt.utils.win_functions.set_path_owner(path)
+                salt.utils.win_functions.set_path_permissions(path)
+                log.error('*' * 68)
+                log.error(salt.utils.win_functions.get_current_user())
+                log.error('*' * 68)
+            except CommandExecutionError:
+                msg = 'Unable to securely set the permissions of "{0}".'
+                msg = msg.format(dir_)
+                if is_console_configured():
+                    log.critical(msg)
+                else:
+                    sys.stderr.write("CRITICAL: {0}\n".format(msg))
+
+    if skip_extra is False:
+        # Run the extra verification checks
+        zmq_version()

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -203,7 +203,9 @@ def set_path_permissions(path):
     Returns:
         bool: True if successful, Otherwise CommandExecutionError
     '''
+    # TODO: Need to make this more generic, maybe a win_dacl utility
     admins = win32security.ConvertStringSidToSid('S-1-5-32-544')
+    user = win32security.ConvertStringSidToSid('S-1-5-32-545')
     system = win32security.ConvertStringSidToSid('S-1-5-18')
     owner = win32security.ConvertStringSidToSid('S-1-3-4')
 
@@ -212,11 +214,15 @@ def set_path_permissions(path):
     revision = win32security.ACL_REVISION_DS
     inheritance = win32security.CONTAINER_INHERIT_ACE |\
         win32security.OBJECT_INHERIT_ACE
-    access = ntsecuritycon.FILE_ALL_ACCESS
+    full_access = ntsecuritycon.GENERIC_ALL
+    user_access = ntsecuritycon.GENERIC_READ | \
+        ntsecuritycon.GENERIC_EXECUTE
 
-    dacl.AddAccessAllowedAceEx(revision, inheritance, access, admins)
-    dacl.AddAccessAllowedAceEx(revision, inheritance, access, system)
-    dacl.AddAccessAllowedAceEx(revision, inheritance, access, owner)
+    dacl.AddAccessAllowedAceEx(revision, inheritance, full_access, admins)
+    dacl.AddAccessAllowedAceEx(revision, inheritance, full_access, system)
+    dacl.AddAccessAllowedAceEx(revision, inheritance, full_access, owner)
+    if 'pki' not in path:
+        dacl.AddAccessAllowedAceEx(revision, inheritance, user_access, user)
 
     try:
         win32security.SetNamedSecurityInfo(

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -1,0 +1,239 @@
+# -*- coding: utf-8 -*-
+'''
+Various functions to be used by windows during start up and to monkey patch
+missing functions in other modules
+'''
+from salt.exceptions import CommandExecutionError
+
+try:
+    import ntsecuritycon
+    import psutil
+    import pywintypes
+    import win32api
+    import win32net
+    import win32security
+    HAS_WIN32 = True
+except ImportError:
+    HAS_WIN32 = False
+
+
+def __virtual__():
+    '''
+    Load only on Windows with necessary modules
+    '''
+    if not salt.utils.is_windows():
+        return False, 'This utility only works on Windows'
+    if not HAS_WIN32:
+        return False, 'This utility requires pywin32'
+
+    return 'win_runas'
+
+
+def get_parent_pid():
+    '''
+    This is a monkey patch for os.getppid. Used in:
+    - salt.utils.parsers
+
+    Returns:
+        int: The parent process id
+    '''
+    return psutil.Process().ppid()
+
+
+def is_admin(name):
+    '''
+    Is the passed user a member of the Administrators group
+
+    Args:
+        name (str): The name to check
+
+    Returns:
+        bool: True if user is a member of the Administrators group, False
+        otherwise
+    '''
+    groups = get_user_groups(name, True)
+
+    for group in groups:
+        if group == 'S-1-5-32-544':
+            return True
+
+    return False
+
+
+def get_user_groups(name, sid=False):
+    '''
+    Get the groups to which a user belongs
+
+    Args:
+        name (str): The user name to query
+        sid (bool): True will return a list of SIDs, False will return a list of
+        group names
+
+    Returns:
+        list: A list of group names or sids
+    '''
+    groups = win32net.NetUserGetLocalGroups(None, name)
+
+    if not sid:
+        return groups
+
+    ret_groups = set()
+    for group in groups:
+        ret_groups.add(get_sid_from_name(group))
+
+    return ret_groups
+
+
+def get_sid_from_name(name):
+    '''
+    This is a tool for getting a sid from a name. The name can be any object.
+    Usually a user or a group
+
+    Args:
+        name (str): The name of the user or group for which to get the sid
+
+    Returns:
+        str: The corresponding SID
+    '''
+    try:
+        sid = win32security.LookupAccountName(None, name)[0]
+    except pywintypes.error as exc:
+        raise CommandExecutionError(
+            'User {0} found: {1}'.format(name, exc[2]))
+
+    return win32security.ConvertSidToStringSid(sid)
+
+
+def get_name_from_sid(sid):
+    '''
+    This gets the name from the specified SID. Opposite of get_sid_from_name
+
+    Args:
+        sid (str): The SID for which to find the name
+
+    Returns:
+        str: The name that corresponds to the passed SID
+    '''
+    try:
+        sid_obj = win32security.ConvertStringSidToSid(sid)
+        name = win32security.LookupAccountSid(None, sid_obj)[0]
+    except pywintypes.error as exc:
+        raise CommandExecutionError(
+            'User {0} found: {1}'.format(sid, exc[2]))
+
+    return name
+
+
+def get_current_user():
+    '''
+    Gets the user executing the process
+
+    Returns:
+        str: The user name
+    '''
+    try:
+        user_name = win32api.GetUserName()
+    except pywintypes.error as exc:
+        raise CommandExecutionError(
+            'Failed to get current user: {0}'.format(exc[2]))
+
+    if not user_name:
+        return False
+
+    return user_name
+
+
+def get_path_owner(path):
+    '''
+    Gets the owner of the file or directory passed
+
+    Args:
+        path (str): The path for which to obtain owner information
+
+    Returns:
+        str: The owner (group or user)
+    '''
+    # Return owner
+    security_descriptor = win32security.GetFileSecurity(
+        path, win32security.OWNER_SECURITY_INFORMATION)
+    owner_sid = security_descriptor.GetSecurityDescriptorOwner()
+
+    return get_name(win32security.ConvertSidToStringSid(owner_sid))
+
+
+def set_path_owner(path):
+    '''
+    Sets the owner of a file or directory to be Administrator
+
+    Args:
+        path (str): The path to the file or directory
+
+    Returns:
+        bool: True if successful, Otherwise CommandExecutionError
+    '''
+    # Must use the SID here to be locale agnostic
+    admins = win32security.ConvertStringSidToSid('S-1-5-32-544')
+    try:
+        win32security.SetNamedSecurityInfo(
+            path,
+            win32security.SE_FILE_OBJECT,
+            win32security.OWNER_SECURITY_INFORMATION,
+            admins,
+            None, None, None)
+    except pywintypes.error as exc:
+        raise CommandExecutionError(
+            'Failed to set owner: {0}'.format(exc[2]))
+
+    return True
+
+
+def set_path_permissions(path):
+    '''
+    Gives Administrators, System, and Owner full control over the specified
+    directory
+
+    Args:
+        path (str): The path to the file or directory
+
+    Returns:
+        bool: True if successful, Otherwise CommandExecutionError
+    '''
+    admins = win32security.ConvertStringSidToSid('S-1-5-32-544')
+    system = win32security.ConvertStringSidToSid('S-1-5-18')
+    owner = win32security.ConvertStringSidToSid('S-1-3-4')
+
+    dacl = win32security.ACL()
+
+    dacl.AddAccessAllowedAceEx(
+        win32security.ACL_REVISION,
+        win32security.CONTAINER_INHERIT_ACE |
+        win32security.OBJECT_INHERIT_ACE,
+        ntsecuritycon.FILE_ALL_ACCESS,
+        admins)
+
+    dacl.AddAccessAllowedAceEx(
+        win32security.ACL_REVISION,
+        win32security.CONTAINER_INHERIT_ACE |
+        win32security.OBJECT_INHERIT_ACE,
+        ntsecuritycon.FILE_ALL_ACCESS,
+        system)
+
+    dacl.AddAccessAllowedAceEx(
+        win32security.ACL_REVISION,
+        win32security.CONTAINER_INHERIT_ACE |
+        win32security.OBJECT_INHERIT_ACE,
+        ntsecuritycon.FILE_ALL_ACCESS,
+        owner)
+
+    try:
+        win32security.SetNamedSecurityInfo(
+            path,
+            win32security.SE_FILE_OBJECT,
+            win32security.DACL_SECURITY_INFORMATION &
+            win32security.PROTECTED_DACL_SECURITY_INFORMATION,
+            None, None, dacl, None)
+    except pywintypes.error as exc:
+        raise CommandExecutionError(
+            'Failed to set permissions: {0}'.format(exc[2]))
+
+    return True

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -30,7 +30,7 @@ def __virtual__():
     if not HAS_WIN32:
         return False, 'This utility requires pywin32'
 
-    return 'win_runas'
+    return 'win_functions'
 
 
 def get_parent_pid():

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -177,7 +177,8 @@ def set_path_owner(path):
         win32security.SetNamedSecurityInfo(
             path,
             win32security.SE_FILE_OBJECT,
-            win32security.OWNER_SECURITY_INFORMATION,
+            win32security.OWNER_SECURITY_INFORMATION |
+            win32security.PROTECTED_DACL_SECURITY_INFORMATION,
             admins,
             None, None, None)
     except pywintypes.error as exc:
@@ -204,32 +205,20 @@ def set_path_permissions(path):
 
     dacl = win32security.ACL()
 
-    dacl.AddAccessAllowedAceEx(
-        win32security.ACL_REVISION,
-        win32security.CONTAINER_INHERIT_ACE |
-        win32security.OBJECT_INHERIT_ACE,
-        ntsecuritycon.FILE_ALL_ACCESS,
-        admins)
+    revision = win32security.ACL_REVISION_DS
+    inheritance = win32security.CONTAINER_INHERIT_ACE |\
+        win32security.OBJECT_INHERIT_ACE
+    access = ntsecuritycon.FILE_ALL_ACCESS
 
-    dacl.AddAccessAllowedAceEx(
-        win32security.ACL_REVISION,
-        win32security.CONTAINER_INHERIT_ACE |
-        win32security.OBJECT_INHERIT_ACE,
-        ntsecuritycon.FILE_ALL_ACCESS,
-        system)
-
-    dacl.AddAccessAllowedAceEx(
-        win32security.ACL_REVISION,
-        win32security.CONTAINER_INHERIT_ACE |
-        win32security.OBJECT_INHERIT_ACE,
-        ntsecuritycon.FILE_ALL_ACCESS,
-        owner)
+    dacl.AddAccessAllowedAceEx(revision, inheritance, access, admins)
+    dacl.AddAccessAllowedAceEx(revision, inheritance, access, system)
+    dacl.AddAccessAllowedAceEx(revision, inheritance, access, owner)
 
     try:
         win32security.SetNamedSecurityInfo(
             path,
             win32security.SE_FILE_OBJECT,
-            win32security.DACL_SECURITY_INFORMATION &
+            win32security.DACL_SECURITY_INFORMATION |
             win32security.PROTECTED_DACL_SECURITY_INFORMATION,
             None, None, dacl, None)
     except pywintypes.error as exc:

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -5,6 +5,10 @@ missing functions in other modules
 '''
 from salt.exceptions import CommandExecutionError
 
+# Import Salt Libs
+import salt.utils
+
+# Import 3rd Party Libs
 try:
     import ntsecuritycon
     import psutil
@@ -158,7 +162,7 @@ def get_path_owner(path):
         path, win32security.OWNER_SECURITY_INFORMATION)
     owner_sid = security_descriptor.GetSecurityDescriptorOwner()
 
-    return get_name(win32security.ConvertSidToStringSid(owner_sid))
+    return get_name_from_sid(win32security.ConvertSidToStringSid(owner_sid))
 
 
 def set_path_owner(path):


### PR DESCRIPTION
### What does this PR do?

Creates `win_verify_env` to handle folder creation and permissions for windows
Fixes problem with missing `os.getppid` method in windows
Creates win_functions util
### What issues does this PR fix or reference?

https://github.com/saltstack/zh/issues/674
https://github.com/saltstack/zh/issues/675
### Previous Behavior

Folders were not being created on minion/master start in windows
Stacktrace when launching minion/master when minion/master is running
### New Behavior

Creates missing folders and adds permissions
Gracefully exits when instance is already running
### Tests written?

No
