### PR TITLE
removes `:exclude-members:` from automodule

### DIFF
--- a/doc/ref/states/all/salt.states.probes.rst
+++ b/doc/ref/states/all/salt.states.probes.rst
@@ -4,5 +4,4 @@ salt.states.probes
 
 .. automodule:: salt.states.probes
     :members:
-    :exclude-members:
 


### PR DESCRIPTION
Refs https://github.com/saltstack/salt/pull/32947
