### PR TITLE
Mocks for salt.modules.junos, salt.proxy.junos, salt.renderers.dson, …

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -124,6 +124,22 @@ MOCK_MODULES = [
     'salt.ext.six.moves.winreg',
     'win32security',
     'ntsecuritycon',
+    'napalm',
+    'dson',
+    'jnpr',
+    'json',
+    'lxml',
+    'lxml.etree',
+    'jnpr.junos',
+    'jnpr.junos.utils',
+    'jnpr.junos.utils.config',
+    'jnpr.junos.utils.sw',
+    'dns',
+    'dns.resolver',
+    'netaddr',
+    'netaddr.IPAddress',
+    'netaddr.core',
+    'netaddr.core.AddrFormatError',
 ]
 
 for mod_name in MOCK_MODULES:

--- a/doc/ref/states/all/salt.states.netntp.rst
+++ b/doc/ref/states/all/salt.states.netntp.rst
@@ -4,5 +4,4 @@ salt.states.netntp
 
 .. automodule:: salt.states.netntp
     :members:
-    :exclude-members:
 


### PR DESCRIPTION
…salt.states.netntp, salt.proxy.napalm. Refs https://github.com/saltstack/salt/pull/32947

Removes :exclude-members: from salt.states.netntp since Sphinx does not like this.
