### PR TITLE
Avoid second grains load on windows multiprocessing

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -837,7 +837,7 @@ class Minion(MinionBase):
         # module.  If this is a proxy, however, we need to init the proxymodule
         # before we can get the grains.  We do this for proxies in the
         # post_master_init
-        if not salt.utils.is_proxy():
+        if not salt.utils.is_proxy() and not self.opts.get('grains'):
             self.opts['grains'] = salt.loader.grains(opts)
 
         log.info('Creating minion process manager')
@@ -1050,7 +1050,7 @@ class Minion(MinionBase):
                 )
                 self.event_publisher.handle_publish(event, None)
 
-    def _load_modules(self, force_refresh=False, notify=False):
+    def _load_modules(self, force_refresh=False, notify=False, grains=None):
         '''
         Return the functions and the returners loaded up from the loader
         module
@@ -1078,7 +1078,8 @@ class Minion(MinionBase):
         else:
             proxy = None
 
-        self.opts['grains'] = salt.loader.grains(self.opts, force_refresh, proxy=proxy)
+       if grains is None:
+            self.opts['grains'] = salt.loader.grains(self.opts, force_refresh, proxy=proxy)
         self.utils = salt.loader.utils(self.opts)
 
         if self.opts.get('multimaster', False):
@@ -1219,7 +1220,7 @@ class Minion(MinionBase):
             minion_instance = cls(opts)
             if not hasattr(minion_instance, 'functions'):
                 functions, returners, function_errors, executors = (
-                    minion_instance._load_modules()
+                    minion_instance._load_modules(grains=opts['grains'])
                     )
                 minion_instance.functions = functions
                 minion_instance.returners = returners

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1078,9 +1078,9 @@ class Minion(MinionBase):
         else:
             proxy = None
 
-       if grains is None:
+        if grains is None:
             self.opts['grains'] = salt.loader.grains(self.opts, force_refresh, proxy=proxy)
-        self.utils = salt.loader.utils(self.opts)
+            self.utils = salt.loader.utils(self.opts)
 
         if self.opts.get('multimaster', False):
             s_opts = copy.deepcopy(self.opts)


### PR DESCRIPTION
This drops the load time of any Windows call by about 1.5s
