### PR TITLE
Use saltstack repo in buildpackage.py on CentOS 5

### DIFF
--- a/tests/buildpackage.py
+++ b/tests/buildpackage.py
@@ -233,6 +233,8 @@ def build_centos(opts):
     if major_release == 5:
         python_bin = 'python26'
         define_opts.extend(['--define', 'dist .el5'])
+        if os.path.exists('/etc/yum.repos.d/saltstack.repo'):
+            build_reqs.extend(['--enablerepo=saltstack'])
         build_reqs.extend(['python26-devel'])
     elif major_release == 6:
         build_reqs.extend(['python-devel'])


### PR DESCRIPTION
### What does this PR do?

On CentOS 5 python26-devel will get installed from epel, which has a lower version than the python26 version we install for salt. This specifies the saltstack repo since that has the correct version of python26-devel we need. 

@terminalmage This is something you built, so I will cede to you if you have a better way of doing this. 
### What issues does this PR fix or reference?

Fixes an issue where the test run would fail on centos 5. 
### Previous Behavior

installed python26-devel from epel
### New Behavior

installs python26-devel from saltstack repo
### Tests written?

no
