### PR TITLE
Fix tests for file.blockplace to remove newline

### DIFF
--- a/tests/integration/states/file.py
+++ b/tests/integration/states/file.py
@@ -1563,12 +1563,10 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
             self.assertEqual(
                 ['#-- start salt managed zonestart -- PLEASE, DO NOT EDIT',
                  'foo',
-                 '',
                  '#-- end salt managed zonestart --',
                  '#',
                  '#-- start salt managed zoneend -- PLEASE, DO NOT EDIT',
                  'bar',
-                 '',
                  '#-- end salt managed zoneend --',
                  ''],
                 contents
@@ -1633,7 +1631,6 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
                  'bar',
                  '',
                  'baz',
-                 '',
                  '#-- end managed zone',
                  ''],
                 contents

--- a/tests/unit/modules/file_test.py
+++ b/tests/unit/modules/file_test.py
@@ -257,7 +257,7 @@ class FileBlockReplaceTestCase(TestCase):
         )
         with salt.utils.fopen(self.tfile.name, 'r') as fp:
             self.assertNotIn('#-- START BLOCK 2'
-                             + "\n" + new_content + "\n"
+                             + "\n" + new_content
                              + '#-- END BLOCK 2', fp.read())
 
         filemod.blockreplace(self.tfile.name,
@@ -270,7 +270,7 @@ class FileBlockReplaceTestCase(TestCase):
         with salt.utils.fopen(self.tfile.name, 'r') as fp:
             self.assertIn('#-- START BLOCK 2'
                           + "\n" + new_content
-                          + "\n" + '#-- END BLOCK 2', fp.read())
+                          + '#-- END BLOCK 2', fp.read())
 
     def test_replace_append_newline_at_eof(self):
         '''
@@ -284,7 +284,7 @@ class FileBlockReplaceTestCase(TestCase):
                 'content': 'baz',
                 'append_if_not_found': True,
         }
-        block = '{marker_start}\n{content}\n{marker_end}\n'.format(**args)
+        block = '{marker_start}\n{content}{marker_end}\n'.format(**args)
         expected = base + '\n' + block
         # File ending with a newline
         with tempfile.NamedTemporaryFile(mode='w+') as tfile:
@@ -322,7 +322,7 @@ class FileBlockReplaceTestCase(TestCase):
         with salt.utils.fopen(self.tfile.name, 'r') as fp:
             self.assertNotIn(
                 '#-- START BLOCK 2' + "\n"
-                + new_content + "\n" + '#-- END BLOCK 2',
+                + new_content + '#-- END BLOCK 2',
                 fp.read())
 
         filemod.blockreplace(self.tfile.name,
@@ -336,7 +336,7 @@ class FileBlockReplaceTestCase(TestCase):
                 fp.read().startswith(
                     '#-- START BLOCK 2'
                     + "\n" + new_content
-                    + "\n" + '#-- END BLOCK 2'))
+                    + '#-- END BLOCK 2'))
 
     def test_replace_partial_marked_lines(self):
         filemod.blockreplace(self.tfile.name,


### PR DESCRIPTION
### What does this PR do?

Fixes the expected output for `file.blockreplace` tests. 
### What issues does this PR fix or reference?

This fixes the tests which where failing due to the PR change here: #33049
These changes will remove the appending newline when creating new content with `file.blockreplace` in the expected output for the tests in this PR.
### Previous Behavior

Getting Failures on the following tests:
- integration.states.file.FileTest.test_issue_11003_immutable_lazy_proxy_sum
- integration.states.file.FileTest.test_issue_8343_accumulated_require_in
- unit.modules.file_test.FileBlockReplaceTestCase.test_replace_append
- unit.modules.file_test.FileBlockReplaceTestCase.test_replace_append_newline_at_eof
- unit.modules.file_test.FileBlockReplaceTestCase.test_replace_prepend
### New Behavior

Tests are passing
### Tests written?

Yes
