### PR TITLE
Bugfix: Restore boolean values from the repo configuration

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -608,12 +608,14 @@ def _get_repo_info(alias, repos_cfg=None):
     Get one repo meta-data.
     '''
     try:
-        ret = dict((repos_cfg or _get_configured_repos()).items(alias))
-        ret['alias'] = alias
-        for key, val in six.iteritems(ret):
-            if val == 'NONE':
-                ret[key] = None
-        return ret
+        meta = dict((repos_cfg or _get_configured_repos()).items(alias))
+        meta['alias'] = alias
+        for key, val in six.iteritems(meta):
+            if val in ['0', '1']:
+                meta[key] = int(meta[key]) == 1
+            elif val == 'NONE':
+                meta[key] = None
+        return meta
     except (ValueError, configparser.NoSectionError):
         return {}
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -783,7 +783,7 @@ def mod_repo(repo, **kwargs):
         cmd_opt.append('--gpg-auto-import-keys')
 
     if 'priority' in kwargs:
-        cmd_opt.append("--priority='{0}'".format(kwargs.get('priority', DEFAULT_PRIORITY)))
+        cmd_opt.append("--priority={0}".format(kwargs.get('priority', DEFAULT_PRIORITY)))
 
     if 'humanname' in kwargs:
         cmd_opt.append("--name='{0}'".format(kwargs.get('humanname')))

--- a/tests/unit/modules/zypp/zypper-repo-1.cfg
+++ b/tests/unit/modules/zypp/zypper-repo-1.cfg
@@ -1,0 +1,5 @@
+[SLE12-SP1-x86_64-Update]
+enabled=1
+autorefresh=1
+baseurl=http://somehost.com/SUSE/Updates/SLE-SERVER/12-SP1/x86_64/update/
+type=NONE

--- a/tests/unit/modules/zypp/zypper-repo-2.cfg
+++ b/tests/unit/modules/zypp/zypper-repo-2.cfg
@@ -1,0 +1,5 @@
+[SLE12-SP1-x86_64-Update-disabled]
+enabled=0
+autorefresh=0
+baseurl=http://somehost.com/SUSE/Updates/SLE-SERVER/12-SP1/x86_64/update/
+type=NONE

--- a/tests/unit/modules/zypper_test.py
+++ b/tests/unit/modules/zypper_test.py
@@ -17,6 +17,8 @@ from salttesting.mock import (
 from salt.exceptions import CommandExecutionError
 
 import os
+from salt.ext.six.moves import configparser
+import StringIO
 
 from salttesting.helpers import ensure_in_syspath
 
@@ -391,6 +393,25 @@ class ZypperTestCase(TestCase):
                             self.assertTrue(diff[pkg_name]['old'])
                             self.assertFalse(diff[pkg_name]['new'])
 
+    def test_repo_value_info(self):
+        '''
+        Tests if repo info is properly parsed.
+
+        :return:
+        '''
+        repos_cfg = configparser.ConfigParser()
+        for cfg in ['zypper-repo-1.cfg', 'zypper-repo-2.cfg']:
+            repos_cfg.readfp(StringIO.StringIO(get_test_data(cfg)))
+
+        for alias in repos_cfg.sections():
+            r_info = zypper._get_repo_info(alias, repos_cfg=repos_cfg)
+            self.assertEqual(type(r_info['type']), type(None))
+            self.assertEqual(type(r_info['enabled']), bool)
+            self.assertEqual(type(r_info['autorefresh']), bool)
+            self.assertEqual(type(r_info['baseurl']), str)
+            self.assertEqual(r_info['type'], None)
+            self.assertEqual(r_info['enabled'], alias == 'SLE12-SP1-x86_64-Update')
+            self.assertEqual(r_info['autorefresh'], alias == 'SLE12-SP1-x86_64-Update')
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
### What does this PR do?

Restores broken behaviour by https://github.com/saltstack/salt/commit/add2111fecdbfd94367f330bf57104f085007c29
### What issues does this PR fix or reference?

`0` and `1` values should be `False` and `True` respectively.
### Previous Behavior

Boolean values from the Zypper's repository configuration were returned as an integer types.
### New Behavior

Boolean values from the Zypper's repository configuration are returned as a boolean types.
### ➡ _Bonus!_

Bugfix: setting repo priority was failing with the following error: 

```
Failed to configure repo 'NON_Public:Infrastructure': zypper command failed:
Invalid priority ''102''. Use a positive integer number. 
The greater the number, the lower the priority.
```
### Tests written?

Yes
