### PR TITLE
If cache_jobs: True is set, populate the local job cache when running salt-call

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -23,6 +23,7 @@ import salt.payload
 import salt.transport
 import salt.utils.args
 import salt.utils.jid
+import salt.utils.minion
 import salt.defaults.exitcodes
 from salt.log import LOG_LEVELS
 from salt.utils import is_windows
@@ -256,16 +257,7 @@ class BaseCaller(object):
                 pass
         elif self.opts['cache_jobs']:
             # Local job cache has been enabled
-            fn_ = os.path.join(
-                self.opts['cachedir'],
-                'minion_jobs',
-                ret['jid'],
-                'return.p')
-            jdir = os.path.dirname(fn_)
-
-            if not os.path.isdir(jdir):
-                os.makedirs(jdir)
-                salt.utils.fopen(fn_, 'w+b').write(self.serial.dumps(ret))
+            salt.utils.minion.cache_jobs(self.opts, ret['jid'], ret)
 
         # close raet channel here
         return ret

--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -254,6 +254,19 @@ class BaseCaller(object):
                 self.return_pub(mret)
             except Exception:
                 pass
+        elif self.opts['cache_jobs']:
+            # Local job cache has been enabled
+            fn_ = os.path.join(
+                self.opts['cachedir'],
+                'minion_jobs',
+                ret['jid'],
+                'return.p')
+            jdir = os.path.dirname(fn_)
+
+            if not os.path.isdir(jdir):
+                os.makedirs(jdir)
+                salt.utils.fopen(fn_, 'w+b').write(self.serial.dumps(ret))
+
         # close raet channel here
         return ret
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -84,6 +84,7 @@ import salt.utils.jid
 import salt.pillar
 import salt.utils.args
 import salt.utils.event
+import salt.utils.minion
 import salt.utils.minions
 import salt.utils.schedule
 import salt.utils.error
@@ -1298,15 +1299,8 @@ class Minion(MinionBase):
                     load['out'] = oput
         if self.opts['cache_jobs']:
             # Local job cache has been enabled
-            fn_ = os.path.join(
-                self.opts['cachedir'],
-                'minion_jobs',
-                load['jid'],
-                'return.p')
-            jdir = os.path.dirname(fn_)
-            if not os.path.isdir(jdir):
-                os.makedirs(jdir)
-            salt.utils.fopen(fn_, 'w+b').write(self.serial.dumps(ret))
+            salt.utils.minion.cache_jobs(self.opts, load['jid'], ret)
+
         try:
             ret_val = channel.send(load, timeout=timeout)
         except SaltReqTimeoutError:

--- a/salt/utils/minion.py
+++ b/salt/utils/minion.py
@@ -2,11 +2,13 @@
 '''
 Utility functions for minions
 '''
-# Import python libs
+
+# Import Python Libs
 from __future__ import absolute_import
 import os
 import threading
-# Import salt libs
+
+# Import Salt Libs
 import salt.utils
 import salt.payload
 
@@ -31,6 +33,20 @@ def running(opts):
             # we must ignore ENOENT during this process
             pass
     return ret
+
+
+def cache_jobs(opts, jid, ret):
+    serial = salt.payload.Serial(opts=opts)
+
+    fn_ = os.path.join(
+        opts['cachedir'],
+        'minion_jobs',
+        jid,
+        'return.p')
+    jdir = os.path.dirname(fn_)
+    if not os.path.isdir(jdir):
+        os.makedirs(jdir)
+    salt.utils.fopen(fn_, 'w+b').write(serial.dumps(ret))
 
 
 def _read_proc_file(path, opts):


### PR DESCRIPTION
### What does this PR do?

Allows a masterless minion to query the job cache when the following settings are configured on the minion:

```
file_client: local
cache_jobs: True
```
### What issues does this PR fix or reference?

Fixes #32834
### Previous Behavior

Could not use the `saltutil.find_cached_job` function when running `salt-call` because `salt-call` jobs we not getting populated in the minion jobs cache.
### New Behavior

The minion job cached is now populated with salt-call jobs, so `saltutil.find_cached_job` function ca now query for cached jobs created in masterless mode.
### Tests written?

No
