### PR TITLE
Moved _finger_fail method to parent class.

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -890,6 +890,20 @@ class AsyncAuth(object):
                     salt.utils.fopen(m_pub_fn, 'wb+').write(payload['pub_key'])
                 return self.extract_aes(payload, master_pub=False)
 
+    def _finger_fail(self, finger, master_key):
+        log.critical(
+            'The specified fingerprint in the master configuration '
+            'file:\n{0}\nDoes not match the authenticating master\'s '
+            'key:\n{1}\nVerify that the configured fingerprint '
+            'matches the fingerprint of the correct master and that '
+            'this minion is not subject to a man-in-the-middle attack.'
+            .format(
+                finger,
+                salt.utils.pem_finger(master_key, sum_type=self.opts['hash_type'])
+            )
+        )
+        sys.exit(42)
+
 
 # TODO: remove, we should just return a sync wrapper of AsyncAuth
 class SAuth(AsyncAuth):
@@ -1098,20 +1112,6 @@ class SAuth(AsyncAuth):
                     self._finger_fail(self.opts['master_finger'], m_pub_fn)
         auth['publish_port'] = payload['publish_port']
         return auth
-
-    def _finger_fail(self, finger, master_key):
-        log.critical(
-            'The specified fingerprint in the master configuration '
-            'file:\n{0}\nDoes not match the authenticating master\'s '
-            'key:\n{1}\nVerify that the configured fingerprint '
-            'matches the fingerprint of the correct master and that '
-            'this minion is not subject to a man-in-the-middle attack.'
-            .format(
-                finger,
-                salt.utils.pem_finger(master_key, sum_type=self.opts['hash_type'])
-            )
-        )
-        sys.exit(42)
 
 
 class Crypticle(object):


### PR DESCRIPTION
### What does this PR do?

Method _finger_fail method from SAuth to AsyncAuth class to make method available
in both class and fix an issue where _finger_Fail is called inside AsyncAuth.
### What issues does this PR fix or reference?
#32999
### Previous Behavior

``` python
[ERROR   ] Exception in callback <functools.partial object at 0x7fbb68467158>
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/tornado/ioloop.py", line 600, in _run_callback
    ret = callback()
  File "/usr/local/lib/python2.7/dist-packages/tornado/stack_context.py", line 275, in null_wrapper
    return fn(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/tornado/ioloop.py", line 615, in <lambda>
    self.add_future(ret, lambda f: f.result())
  File "/usr/local/lib/python2.7/dist-packages/tornado/concurrent.py", line 232, in result
    raise_exc_info(self._exc_info)
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 1014, in run
    yielded = self.gen.throw(*exc_info)
  File "/usr/lib/python2.7/dist-packages/salt/crypt.py", line 433, in _authenticate
    creds = yield self.sign_in()
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 1008, in run
    value = future.result()
  File "/usr/local/lib/python2.7/dist-packages/tornado/concurrent.py", line 232, in result
    raise_exc_info(self._exc_info)
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 1017, in run
    yielded = self.gen.send(value)
  File "/usr/lib/python2.7/dist-packages/salt/crypt.py", line 563, in sign_in
    self._finger_fail(self.opts['master_finger'], m_pub_fn)
AttributeError: 'AsyncAuth' object has no attribute '_finger_fail'
```
### New Behavior

``` bash
[CRITICAL] The specified fingerprint in the master configuration file:
40:ea:b2:3e:7d:0c:70:ca:ee:3d:94:8c:da:6f:09:e6XXXXXX
Does not match the authenticating master's key:
40:ea:b2:3e:7d:0c:70:ca:ee:3d:94:8c:da:6f:09:e6
Verify that the configured fingerprint matches the fingerprint of the correct master and that this minion is not subject to a man-in-the-middle attack.
root@ubuntu:~# salt-minion -l error
[CRITICAL] The specified fingerprint in the master configuration file:
40:ea:b2:3e:7d:0c:70:ca:ee:3d:94:8c:da:6f:09:e6XXXXXX
Does not match the authenticating master's key:
40:ea:b2:3e:7d:0c:70:ca:ee:3d:94:8c:da:6f:09:e6
Verify that the configured fingerprint matches the fingerprint of the correct master and that this minion is not subject to a man-in-the-middle attack.
```
### Tests written?

No
