### PR TITLE
FreeBSD Service module fix.

### DIFF
--- a/salt/modules/freebsdservice.py
+++ b/salt/modules/freebsdservice.py
@@ -376,4 +376,4 @@ def status(name, sig=None):
     if sig:
         return bool(__salt__['status.pid'](sig))
     cmd = '{0} {1} onestatus'.format(_cmd(), name)
-    return not __salt__['cmd.retcode'](cmd, python_shell=False)
+    return not __salt__['cmd.retcode'](cmd, python_shell=False, ignore_retcode=True)


### PR DESCRIPTION
### What does this PR do?

Now, before trying to start or stop a service we run an status, since FreeBSD will return
an error if you want to start a service that is already running. The same happens with
stopping a service when is not running. For the same reason in status method added
_ignore_retcode=True_ to avoid logging an error when there is no such thing.
### What issues does this PR fix or reference?
#26062 /  #23435
### Previous Behavior

When starting a service already running,
- Salt output

``` yml
salt freebsd service.start sshd
freebsd:
    True
ERROR: Minions returned with non-zero exit code
```
- Minion log

``` bash
2016-05-08 21:45:48,727 [salt.loaded.int.module.cmdmod][ERROR   ][3385] Command '/usr/sbin/service sshd onestart' failed with return code: 1
2016-05-08 21:45:48,729 [salt.loaded.int.module.cmdmod][ERROR   ][3385] output: sshd already running?  (pid=2657).
```

When stopping a service not running.
- Salt output

``` yml
salt freebsd service.start foooo
freebsd:
    False
ERROR: Minions returned with non-zero exit code
```
- Minion Log

``` bash
2016-05-08 23:50:43,521 [salt.loaded.int.module.cmdmod][ERROR   ][5205] Command '/usr/sbin/service sshd onestatus' failed with return code: 1
2016-05-08 23:50:43,522 [salt.loaded.int.module.cmdmod][ERROR   ][5205] output: sshd is not running.
```
### New Behavior

``` yml
[root@freebsd ~]# salt freebsd service.start sshd
freebsd:
    True
[root@freebsd ~]# salt freebsd service.start sshd
freebsd:
    True
```

``` yml
[root@freebsd ~]# salt freebsd service.stop sshd
freebsd:
    True
[root@freebsd ~]# salt freebsd service.stop sshd
freebsd:
    True
```

 There is no more errors in salt logs
### Tests written?

No
