### PR TITLE
Fix override of ec2 volumetype

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1888,8 +1888,8 @@ def request_instance(vm_=None, call=None):
             termination_key = '{0}BlockDeviceMapping.{1}.Ebs.DeleteOnTermination'.format(spot_prefix, dev_index)
             params[termination_key] = str(set_del_root_vol_on_destroy).lower()
 
-            # Preserve the volume type if specified
-            if rd_type is not None:
+            # Use default volume type if not specified
+            if rd_type is None:
                 type_key = '{0}BlockDeviceMapping.{1}.Ebs.VolumeType'.format(spot_prefix, dev_index)
                 params[type_key] = rd_type
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1889,7 +1889,7 @@ def request_instance(vm_=None, call=None):
             params[termination_key] = str(set_del_root_vol_on_destroy).lower()
 
             # Use default volume type if not specified
-            if rd_type is None:
+            if 'Ebs.VolumeType' not in ex_blockdevicemappings[dev_index]:
                 type_key = '{0}BlockDeviceMapping.{1}.Ebs.VolumeType'.format(spot_prefix, dev_index)
                 params[type_key] = rd_type
 


### PR DESCRIPTION
### What does this PR do?

Fixes volumetype override for the root volume when creating instances.
### What issues does this PR fix or reference?
### Previous Behavior

Always used the default that get's pulled in [here](https://github.com/saltstack/salt/blob/develop/salt/cloud/clouds/ec2.py#L1863)
### New Behavior

Now respects the value specified in the cloud.profile

```
block_device_mappings:
  - DeviceName: /dev/sda1
    Ebs.VolumeType: gp2
```
### Tests written?

No
