### PR TITLE
Strip ldap fqdn

### DIFF
--- a/doc/topics/eauth/index.rst
+++ b/doc/topics/eauth/index.rst
@@ -172,6 +172,8 @@ Server configuration values and their defaults:
     auth.ldap.activedirectory: False
     auth.ldap.persontype: 'person'
 
+    auth.ldap.minion_stripdomains: []
+
 There are two phases to LDAP authentication.  First, Salt authenticates to search for a users' Distinguished Name
 and group membership.  The user it authenticates as in this phase is often a special LDAP system user with
 read-only access to the LDAP directory.  After Salt searches the directory to determine the actual user's DN
@@ -210,6 +212,16 @@ the results are filtered against ``auth.ldap.groupclass``, default
 .. code-block:: yaml
 
     auth.ldap.groupou: Groups
+
+When using the `ldap('DC=domain,DC=com')` eauth operator, sometimes the records returned
+from LDAP or Active Directory have fully-qualified domain names attached, while minion IDs
+instead are simple hostnames.  The parameter below allows the administrator to strip
+off a certain set of domain names so the hostnames looked up in the directory service
+can match the minion IDs.
+               
+.. code-block:: yaml
+
+   auth.ldap.minion_stripdomains: ['.external.bigcorp.com', '.internal.bigcorp.com']
 
 Active Directory
 ----------------
@@ -265,3 +277,17 @@ To configure a LDAP group, append a ``%`` to the ID:
         test_ldap_group%:
           - '*':
             - test.echo
+
+In addition, if there are a set of computers in the directory service that should
+be part of the eAuth definition, they can be specified like this:
+
+.. code-block:: yaml
+
+    external_auth:
+      ldap:
+        test_ldap_group%:
+          - ldap('DC=corp,DC=example,DC=com'):
+            - test.echo
+
+The string inside `ldap()` above is any valid LDAP/AD tree limiter.  `OU=` in
+particular is permitted as long as it would return a list of computer objects.

--- a/salt/auth/ldap.py
+++ b/salt/auth/ldap.py
@@ -410,8 +410,8 @@ def expand_ldap_entries(entries, opts=None):
                             # in their computer lists.  auth.minion_stripdomains
                             # lets a user strip off configured domain names
                             # and arrive at the basic minion_id
-                            if opts.get('auth.minion_stripdomains', None):
-                                for domain in opts['auth.minion_stripdomains']:
+                            if opts.get('auth.ldap.minion_stripdomains', None):
+                                for domain in opts['auth.ldap.minion_stripdomains']:
                                     if minion_id.endswith(domain):
                                         minion_id = minion_id[:-len(domain)]
                                         break

--- a/salt/auth/ldap.py
+++ b/salt/auth/ldap.py
@@ -363,7 +363,6 @@ def groups(username, **kwargs):
                 return []
     else:
         log.error('ldap bind to determine group membership FAILED!')
-        return group_list
 
     return group_list
 
@@ -411,7 +410,7 @@ def expand_ldap_entries(entries, opts=None):
                             # in their computer lists.  auth.minion_stripdomains
                             # lets a user strip off configured domain names
                             # and arrive at the basic minion_id
-                            if opts['auth.minion_stripdomains']:
+                            if opts.get('auth.minion_stripdomains', None):
                                 for domain in opts['auth.minion_stripdomains']:
                                     if minion_id.endswith(domain):
                                         minion_id = minion_id[:-len(domain)]

--- a/salt/auth/ldap.py
+++ b/salt/auth/ldap.py
@@ -39,6 +39,7 @@ __defopts__ = {'auth.ldap.basedn': '',
                'auth.ldap.persontype': 'person',
                'auth.ldap.groupclass': 'posixGroup',
                'auth.ldap.activedirectory': False,
+               'auth.ldap.minion_stripdomains': [],
                }
 
 
@@ -406,6 +407,15 @@ def expand_ldap_entries(entries, opts=None):
                     for ldap_match in search_results:
                         try:
                             minion_id = ldap_match[1]['cn'][0].lower()
+                            # Some LDAP/AD trees only have the FQDN of machines
+                            # in their computer lists.  auth.minion_stripdomains
+                            # lets a user strip off configured domain names
+                            # and arrive at the basic minion_id
+                            if opts['auth.minion_stripdomains']:
+                                for domain in opts['auth.minion_stripdomains']:
+                                    if minion_id.endswith(domain):
+                                        minion_id = minion_id[:-len(domain)]
+                                        break
                             retrieved_minion_ids.append(minion_id)
                         except TypeError:
                             # TypeError here just means that one of the returned
@@ -415,6 +425,7 @@ def expand_ldap_entries(entries, opts=None):
 
                     for minion_id in retrieved_minion_ids:
                         acl_tree.append({minion_id: permissions})
+                    log.trace('Expanded acl_tree is: {0}'.format(acl_tree))
                 except ldap.NO_SUCH_OBJECT:
                     pass
             else:


### PR DESCRIPTION
### What does this PR do?

Adds an additional LDAP-related option:

auth.minion_stripdomains:
- .lop.off.this.domain.com
- .lop.off.this.one.too.com

Any substring in the auth.minion_stripdomains list will be removed from the end of computer names coming from LDAP.  Note the leading '.'s in the list items, the routine blindly removes whatever is in each list entry (for maximum flexibility, there's no "magic" that tries to reformat the minion_id to be canonical or anything).

This is to support the use case where the list of computers that comes from LDAP/AD are FQDNs, but minion_ids are simple hostnames.
### Tests written?

Manual test plan forthcoming.
