### PR TITLE
Fix broken parsing of usermgmt.conf on OpenBSD

### DIFF
--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -147,10 +147,9 @@ def add(name,
                         if 'group' not in line[:5]:
                             continue
 
-                        for val in line.split(' '):
-                            cmd.extend([
-                                '-g', str(val[1])
-                            ])
+                        cmd.extend([
+                            '-g', str(line.split()[-1])
+                        ])
 
                         # We found what we wanted, let's break out of the loop
                         break


### PR DESCRIPTION
### What does this PR do?

Fixes parsing of usermgmt.conf on OpenBSD in the useradd module
### What issues does this PR fix or reference?

None?
### Previous Behavior

/etc/usermgmt.conf:

```
group           =uid
base_dir        /home
skel_dir        /etc/skel
shell           /bin/ksh
class
inactive        Null (unset)
expire          Null (unset)
preserve        false
```

Given the above, **useradd.add** would incorrectly parse the group line argument as "r" instead of "=uid".
### New Behavior

Correctly parses usermgmt.conf file
### Tests written?

No

When creating a new user, if a group of the same name already exists,
the usermgmt.conf file is consulted to determine the primary group.
It's in these cases that the parsing bug is triggered.

This code change addresses several of the existing issues:
- The previous split statement explicitly specified a single space.
  Since a config line may have any number of spaces and/or tabs
  surrounding the entries, the resulting array's elements may be
  incorrect.
- According to the man pages for usermgmt.conf, the "group" config
  entry accpets a single parameter -- so we shouldn't iterate.
- The "val[1]" was returning the 2nd letter of each word and not the
  second word on the config line as intended.
