### PR TITLE
useradd: correctly handle a user without a loginclass on openbsd

### DIFF
--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -544,7 +544,7 @@ def get_loginclass(name):
             try:
                 ret = line.split(None, 1)[1]
                 break
-            except ValueError:
+            except (ValueError, IndexError):
                 continue
     else:
         ret = ''


### PR DESCRIPTION
### What does this PR do?

Catch the IndexError exception in get_loginclass()
### What issues does this PR fix or reference?

When a existing user lacks a login class, the useradd module fails to run successfully.
### Tests written?

No
