### PR TITLE
Support verify_options for pkg.verify

### DIFF
--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -168,14 +168,34 @@ def verify(*packages, **kwargs):
               'g': 'ghost',
               'l': 'license',
               'r': 'readme'}
+    options_map = {
+        'nocaps': '--nocaps',
+        'nodeps': '--nodeps',
+        'nodigest': '--nodigest',
+        'nofiledigest': '--nofiledigest',
+        'nofiles': '--nofiles',
+        'nogroup': '--nogroup',
+        'nolinkto': '--nolinkto',
+        'nomode': '--nomode',
+        'nomtime': '--nomtime',
+        'nordev': '--nordev',
+        'noscripts': '--noscripts',
+        'nosignature': '--nosignature',
+        'nosize': '--nosize',
+        'nouser': '--nouser'
+    }
     ret = {}
     ignore_types = kwargs.get('ignore_types', [])
+    verify_options = kwargs.get('verify_options', [])
+    cmd = ['rpm']
+    for option in verify_options:
+        cmd.append(options_map.get(option, ''))
     if packages:
-        cmd = ['rpm', '-V']
+        cmd.append('-V')
         # Can't concatenate a tuple, must do a list.extend()
         cmd.extend(packages)
     else:
-        cmd = ['rpm', '-Va']
+        cmd.append('-Va')
     out = __salt__['cmd.run'](cmd,
                               output_loglevel='trace',
                               ignore_retcode=True,

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1691,6 +1691,9 @@ def verify(*names, **kwargs):
 
     Runs an rpm -Va on a system, and returns the results in a dict
 
+    Pass options to modify rpm verify behavior using the ``verify_options``
+    keyword argument
+
     Files with an attribute of config, doc, ghost, license or readme in the
     package header can be ignored using the ``ignore_types`` keyword argument
 
@@ -1702,6 +1705,7 @@ def verify(*names, **kwargs):
         salt '*' pkg.verify httpd
         salt '*' pkg.verify 'httpd postfix'
         salt '*' pkg.verify 'httpd postfix' ignore_types=['config','doc']
+        salt '*' pkg.verify 'httpd postfix' verify_options=['nodeps','nosize']
     '''
     return __salt__['lowpkg.verify'](*names, **kwargs)
 


### PR DESCRIPTION
### What does this PR do?

This patch adds support to `pkg.verify` for a list of `verify_options` that modify how `rpm -V` is executed. In addition, the new parameter is exposed through the `pkg.installed` state module so that it may be specified via an sls state definition.
### What issues does this PR fix or reference?

Fixes #33145
### Tests written?

No
