### PR TITLE
Fix broken reactor function calls

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -337,7 +337,7 @@ class SyncClientMixin(object):
                     low,
                     expected_extra_kws=CLIENT_INTERNAL_KEYWORDS
                 )
-                args = f_call.get('arg', ())
+                args = f_call.get('args', ())
             else:
                 args = low['arg']
             if 'kwarg' not in low:
@@ -347,7 +347,7 @@ class SyncClientMixin(object):
                         low,
                         expected_extra_kws=CLIENT_INTERNAL_KEYWORDS
                     )
-                kwargs = f_call.get('kwarg', {})
+                kwargs = f_call.get('kwargs', {})
 
                 # throw a warning for the badly formed low data if we found
                 # kwargs using the old mechanism


### PR DESCRIPTION
### What does this PR do?

Broken by PR #32938

salt/client/mixins.py:
- In `SyncClientMixin._low`, `salt.utils.format_call` is invoked. The
  `salt.utils.format_call` function will return a dict containing
  'args' and 'kwargs', not 'arg' and 'kwarg' as was changed by
  PR #32938.
### Tests written?

No

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
