### PR TITLE
Gate jnpr imports in salt.proxy.junos.py

### DIFF
--- a/salt/proxy/junos.py
+++ b/salt/proxy/junos.py
@@ -4,23 +4,39 @@ Interface with a Junos device via proxy-minion.
 '''
 
 # Import python libs
-from __future__ import print_function
 from __future__ import absolute_import
-
+from __future__ import print_function
 import logging
+import json
 
 # Import 3rd-party libs
-import jnpr.junos
-import jnpr.junos.utils
-import jnpr.junos.utils.config
-import json
-HAS_JUNOS = True
+try:
+    HAS_JUNOS = True
+    import jnpr.junos
+    import jnpr.junos.utils
+    import jnpr.junos.utils.config
+except ImportError:
+    HAS_JUNOS = False
 
 __proxyenabled__ = ['junos']
 
 thisproxy = {}
 
 log = logging.getLogger(__name__)
+
+# Define the module's virtual name
+__virtualname__ = 'junos'
+
+
+def __virtual__():
+    '''
+    Only return if all the modules are available
+    '''
+    if not HAS_JUNOS:
+        log.critical('fx2 proxy minion needs "racadm" to be installed.')
+        return False, 'Missing dependency: The junos proxy minion requires the \'jnpr\' Python module.'
+
+    return __virtualname__
 
 
 def init(opts):

--- a/salt/proxy/junos.py
+++ b/salt/proxy/junos.py
@@ -33,7 +33,6 @@ def __virtual__():
     Only return if all the modules are available
     '''
     if not HAS_JUNOS:
-        log.critical('fx2 proxy minion needs "racadm" to be installed.')
         return False, 'Missing dependency: The junos proxy minion requires the \'jnpr\' Python module.'
 
     return __virtualname__


### PR DESCRIPTION
### What does this PR do?

The doc build fails when these are not gated because jnpr raises an ImportError.
### What issues does this PR fix or reference?

Fixes #31975
### Previous Behavior

The doc builder couldn't find any references to ref/proxy/all/salt.proxy.junos, so these docs couldn't be displayed.
### New Behavior

References can now be found and page displays correctly.
### Tests written?

No
