### PR TITLE
Windows: salt fails to start when running as domain user

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -169,6 +169,10 @@ class LocalClient(object):
                 key_user = self.opts.get('user', 'root')
         if key_user.startswith('sudo_'):
             key_user = self.opts.get('user', 'root')
+        if salt.utils.is_windows():
+            # The username may contain '\' if it is in Windows
+            # 'DOMAIN\username' format. Fix this for the keyfile path.
+            key_user = key_user.replace('\\', '_')
         keyfile = os.path.join(self.opts['cachedir'],
                                '.{0}_key'.format(key_user))
         # Make sure all key parent directories are accessible

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -223,9 +223,17 @@ def access_keys(opts):
                 except KeyError:
                     log.error('ACL user {0} is not available'.format(user))
                     continue
-        keyfile = os.path.join(
-            opts['cachedir'], '.{0}_key'.format(user)
-        )
+
+        if salt.utils.is_windows():
+            # The username may contain '\' if it is in Windows
+            # 'DOMAIN\username' format. Fix this for the keyfile path.
+            keyfile = os.path.join(
+                opts['cachedir'], '.{0}_key'.format(user.replace('\\', '_'))
+            )
+        else:
+            keyfile = os.path.join(
+                opts['cachedir'], '.{0}_key'.format(user)
+            )
 
         if os.path.exists(keyfile):
             log.debug('Removing stale keyfile: {0}'.format(keyfile))

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -273,7 +273,7 @@ def get_user():
     if HAS_PWD:
         return pwd.getpwuid(os.geteuid()).pw_name
     else:
-        return win32api.GetUserName()
+        return win32api.GetUserNameEx(win32api.NameSamCompatible)
 
 
 def get_uid(user=None):

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -136,7 +136,7 @@ def get_current_user():
         str: The user name
     '''
     try:
-        user_name = win32api.GetUserName()
+        user_name = win32api.GetUserNameEx(win32api.NameSamCompatible)
     except pywintypes.error as exc:
         raise CommandExecutionError(
             'Failed to get current user: {0}'.format(exc[2]))


### PR DESCRIPTION
### What does this PR do?

The following error occurs when running salt-master or salt-minion
under a domain user account:

  File "...\lib\site-packages\
  salt\utils\win_functions.py", line 79, in get_user_groups
      groups = win32net.NetUserGetLocalGroups(None, name)
      pywintypes.error: (2221, 'NetUserGetLocalGroups',
      'The user name could not be found.')

`salt/utils/__init__.py`:
- Change `get_user` to use:
  `win32api.GetUserNameEx(win32api.NameSamCompatible)`. This will return
  the username in the format 'DOMAIN\username'.

`salt/utils/win_functions.py`:
- Change `get_current_user` to also use
  `win32api.GetUserNameEx(win32api.NameSamCompatible)`. This will fix the
  problem when it passes the username to `win32net.NetUserGetLocalGroups`.

`salt/client/__init__.py`:
- In `LocalClient.__read_master_key`, on Windows replace the username
  portion of the keyfile path so that '\' is converted to '_'. This will
  allow a valid filename.

`salt/daemons/masterapi.py`:
- In `access_keys`, on Windows replace the username
  portion of the keyfile path so that '\' is converted to '_'. This will
  allow a valid filename.
### Tests written?

No

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
