### PR TITLE
propagate opts to salt.util.http call

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -603,6 +603,7 @@ class Client(object):
                 header_callback=on_header,
                 username=url_data.username,
                 password=url_data.password,
+                opts=self.opts,
                 **get_kwargs
             )
             if 'handle' not in query:


### PR DESCRIPTION
### What does this PR do?

Correctly propagate opts variable to salt.util.http.query call
### What issues does this PR fix or reference?

This PR enables correct behavior inside salt.util.http.query ; without this PR, as no opts variable is passed, http.query tries to load configuration from default path (/etc/salt/minion for minion configuration) instead to use current configuration.

i.e. any `-c <custom path>` provided on command line is ignored as no opts variable is passed and http.query is unaware of any context configuration.

Code from http.py (not modified in this PR) that loads configuration from default path if opts is not provided / empty :

``` python
if opts is None:
        if node == 'master':
            opts = salt.config.master_config(
                os.path.join(syspaths.CONFIG_DIR, 'master')
            )
        elif node == 'minion':
            opts = salt.config.minion_config(
                os.path.join(syspaths.CONFIG_DIR, 'minion')
            )
        else:
            opts = {}
```
### Previous Behavior

On `salt-call --local -c <custom path> command`, custom configurations loaded from `<custom path>` and related to http.py are ignored (like proxy_host / proxy_port for example). Instead, configuration is (re)loaded from default configuration path (/etc/salt/minion, /etc/salt/master)
### New Behavior

Any custom configuration path and http.py related options are loaded and not ignored
### Tests written?

No
