### PR TITLE
cloud.clouds.ec2: cache each named node

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2622,7 +2622,11 @@ def queue_instances(instances):
     '''
     for instance_id in instances:
         node = _get_node(instance_id=instance_id)
-        salt.utils.cloud.cache_node(node, __active_provider_name__, __opts__)
+        for name in node:
+            if instance_id == node[name]['instanceId']:
+                salt.utils.cloud.cache_node(node[name],
+                                            __active_provider_name__,
+                                            __opts__)
 
 
 def create_attach_volumes(name, kwargs, call=None, wait_to_finish=True):
@@ -3168,7 +3172,10 @@ def show_instance(name=None, instance_id=None, call=None, kwargs=None):
         )
 
     node = _get_node(name=name, instance_id=instance_id)
-    salt.utils.cloud.cache_node(node, __active_provider_name__, __opts__)
+    for name in node:
+        salt.utils.cloud.cache_node(node[name],
+                                    __active_provider_name__,
+                                    __opts__)
     return node
 
 


### PR DESCRIPTION
### What does this PR do?

fix node caching for EC2, ping @techhat
### What issues does this PR fix or reference?
#33162
### Previous Behavior

stack trace (see issue)
### New Behavior

``` yaml
# salt-call --local cloud.has_instance jmoney-git-ec2-amazon-6
[INFO    ] Determining pillar cache
[INFO    ] Starting new HTTPS connection (1): api.digitalocean.com
[INFO    ] Starting new HTTPS connection (1): ec2.us-east-1.amazonaws.com
[INFO    ] Starting new HTTPS connection (1): identity.api.rackspacecloud.com
[INFO    ] Starting new HTTPS connection (1): ec2.us-east-1.amazonaws.com
local:
    True
```
### Tests written?

No
