### PR TITLE
linux_acl: Allow '-' as a separation character in ACL permissions. Fi…

### DIFF
--- a/salt/states/linux_acl.py
+++ b/salt/states/linux_acl.py
@@ -56,7 +56,7 @@ def present(name, acl_type, acl_name='', perms='', recurse=False):
            'changes': {},
            'comment': ''}
 
-    _octal = {'r': 4, 'w': 2, 'x': 1}
+    _octal = {'r': 4, 'w': 2, 'x': 1, '-': 0}
 
     __current_perms = __salt__['acl.getfacl'](name)
 


### PR DESCRIPTION
### What does this PR do?

Allow '-' as a separation character in ACL permissions.  

This allows using acl states with things like '- perms: r-x' or '- perms: r--', which also works when manually setting ACL's using setfacl.
### What issues does this PR fix or reference?

Fixes #31270
### Previous Behavior

ACL states defined as follows would fail with the error below. One would have to remove the '-' from the state for it to work correctly:

State:

```
/tmp/testdir/:
  acl.present:
    - acl_type: user
    - acl_name: root
    - perms: r-x
```

Error:

```
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1624, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1491, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/states/linux_acl.py", line 77, in present
                  if user[acl_name]['octal'] == sum([_octal.get(i, i) for i in perms]):
              TypeError: unsupported operand type(s) for +: 'int' and 'str'
```
### New Behavior

The above ACL state works as expected, giving read and execute permissions on `/tmp/testdir/` to the user root.
### Tests written?

No
