### PR TITLE
Pip fix

### DIFF
--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -168,7 +168,11 @@ def _check_pkg_version_format(pkg):
             ret['prefix'] = install_req.req.project_name
         else:
             ret['prefix'] = re.sub('[^A-Za-z0-9.]+', '-', install_req.req.name)
-        ret['version_spec'] = [(spec.operator, spec.version) for spec in install_req.req.specifier]
+        if hasattr(install_req, "specifier"):
+            specifier = install_req.specifier
+        else:
+            specifier = install_req.req.specifier
+        ret['version_spec'] = [(spec.operator, spec.version) for spec in specifier]
 
     return ret
 

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -21,6 +21,7 @@ requisite to a pkg.installed state for the package which provides pip
 
 # Import python libs
 from __future__ import absolute_import
+import re
 import logging
 
 # Import salt libs
@@ -163,8 +164,8 @@ def _check_pkg_version_format(pkg):
         ret['version_spec'] = []
     else:
         ret['result'] = True
-        ret['prefix'] = install_req.req.project_name
-        ret['version_spec'] = install_req.req.specs
+        ret['prefix'] = re.sub('[^A-Za-z0-9.]+', '-', install_req.req.name)
+        ret['version_spec'] = [(spec.operator, spec.version) for spec in install_req.req.specifier]
 
     return ret
 

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -164,10 +164,7 @@ def _check_pkg_version_format(pkg):
         ret['version_spec'] = []
     else:
         ret['result'] = True
-        if hasattr(install_req.req, 'project_name'):
-            ret['prefix'] = install_req.req.project_name
-        else:
-            ret['prefix'] = re.sub('[^A-Za-z0-9.]+', '-', install_req.req.name)
+        ret['prefix'] = re.sub('[^A-Za-z0-9.]+', '-', install_req.name)
         if hasattr(install_req, "specifier"):
             specifier = install_req.specifier
         else:

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -164,7 +164,10 @@ def _check_pkg_version_format(pkg):
         ret['version_spec'] = []
     else:
         ret['result'] = True
-        ret['prefix'] = re.sub('[^A-Za-z0-9.]+', '-', install_req.req.name)
+        if hasattr(install_req.req, 'project_name'):
+            ret['prefix'] = install_req.req.project_name
+        else:
+            ret['prefix'] = re.sub('[^A-Za-z0-9.]+', '-', install_req.req.name)
         ret['version_spec'] = [(spec.operator, spec.version) for spec in install_req.req.specifier]
 
     return ret


### PR DESCRIPTION
### What does this PR do?

Fix #33163, this makes the pip requirements object duck typed, so that we can use pip before 8.1.2 as well as post 8.1.2
### What issues does this PR fix or reference?
### Previous Behavior

Remove this section if not relevant
### New Behavior

Remove this section if not relevant
### Tests written?

Yes/No
