### PR TITLE
Fix file.managed for Windows

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -35,7 +35,7 @@ import mmap
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 # This string_types import needs to be here for windows as six.string_types
 # does not work from this module...
-import salt.ext.six as six
+from salt.ext.six import string_types
 from salt.ext.six.moves import range, reduce, zip
 from salt.ext.six.moves.urllib.parse import urlparse as _urlparse
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
@@ -2887,7 +2887,7 @@ def source_list(source, source_hash, saltenv):
                 elif single_src.startswith('/') and os.path.exists(single_src):
                     ret = (single_src, single_hash)
                     break
-            elif isinstance(single, six.string_types):
+            elif isinstance(single, string_types):
                 path, senv = salt.utils.url.parse(single)
                 if not senv:
                     senv = saltenv
@@ -3242,7 +3242,7 @@ def check_perms(name, ret, user, group, mode, follow_symlinks=False):
         elif 'cgroup' in perms and user != '':
             ret['changes']['group'] = group
 
-    if isinstance(orig_comment, six.string_types):
+    if isinstance(orig_comment, string_types):
         if orig_comment:
             ret['comment'].insert(0, orig_comment)
         ret['comment'] = '; '.join(ret['comment'])
@@ -3499,7 +3499,7 @@ def get_diff(
 
     ret = ''
 
-    if isinstance(env, six.string_types):
+    if isinstance(env, string_types):
         salt.utils.warn_until(
             'Boron',
             'Passing a salt environment should be done using \'saltenv\' not '

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -35,6 +35,7 @@ import mmap
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 # This string_types import needs to be here for windows as six.string_types
 # does not work from this module...
+from salt.ext import six
 from salt.ext.six import string_types
 from salt.ext.six.moves import range, reduce, zip
 from salt.ext.six.moves.urllib.parse import urlparse as _urlparse

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -35,7 +35,6 @@ import mmap
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 # This string_types import needs to be here for windows as six.string_types
 # does not work from this module...
-from salt.ext import six
 from salt.ext.six import string_types
 from salt.ext.six.moves import range, reduce, zip
 from salt.ext.six.moves.urllib.parse import urlparse as _urlparse

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -34,7 +34,8 @@ import mmap
 
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 # This string_types import needs to be here for windows as six.string_types
-# does not work from this module...
+# does not work from this module... This only applies to the 2015.5 branch.
+# Do not merge forward
 from salt.ext.six import string_types
 from salt.ext.six.moves import range, reduce, zip
 from salt.ext.six.moves.urllib.parse import urlparse as _urlparse

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -35,7 +35,7 @@ import mmap
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 # This string_types import needs to be here for windows as six.string_types
 # does not work from this module...
-from salt.ext.six import string_types
+import salt.ext.six as six
 from salt.ext.six.moves import range, reduce, zip
 from salt.ext.six.moves.urllib.parse import urlparse as _urlparse
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
@@ -2887,7 +2887,7 @@ def source_list(source, source_hash, saltenv):
                 elif single_src.startswith('/') and os.path.exists(single_src):
                     ret = (single_src, single_hash)
                     break
-            elif isinstance(single, string_types):
+            elif isinstance(single, six.string_types):
                 path, senv = salt.utils.url.parse(single)
                 if not senv:
                     senv = saltenv
@@ -3242,7 +3242,7 @@ def check_perms(name, ret, user, group, mode, follow_symlinks=False):
         elif 'cgroup' in perms and user != '':
             ret['changes']['group'] = group
 
-    if isinstance(orig_comment, string_types):
+    if isinstance(orig_comment, six.string_types):
         if orig_comment:
             ret['comment'].insert(0, orig_comment)
         ret['comment'] = '; '.join(ret['comment'])
@@ -3499,7 +3499,7 @@ def get_diff(
 
     ret = ''
 
-    if isinstance(env, string_types):
+    if isinstance(env, six.string_types):
         salt.utils.warn_until(
             'Boron',
             'Passing a salt environment should be done using \'saltenv\' not '

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -33,7 +33,9 @@ import glob
 import mmap
 
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
-from salt.ext import six
+# This string_types import needs to be here for windows as six.string_types
+# does not work from this module...
+from salt.ext.six import string_types
 from salt.ext.six.moves import range, reduce, zip
 from salt.ext.six.moves.urllib.parse import urlparse as _urlparse
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
@@ -2885,7 +2887,7 @@ def source_list(source, source_hash, saltenv):
                 elif single_src.startswith('/') and os.path.exists(single_src):
                     ret = (single_src, single_hash)
                     break
-            elif isinstance(single, six.string_types):
+            elif isinstance(single, string_types):
                 path, senv = salt.utils.url.parse(single)
                 if not senv:
                     senv = saltenv
@@ -3240,7 +3242,7 @@ def check_perms(name, ret, user, group, mode, follow_symlinks=False):
         elif 'cgroup' in perms and user != '':
             ret['changes']['group'] = group
 
-    if isinstance(orig_comment, six.string_types):
+    if isinstance(orig_comment, string_types):
         if orig_comment:
             ret['comment'].insert(0, orig_comment)
         ret['comment'] = '; '.join(ret['comment'])
@@ -3497,7 +3499,7 @@ def get_diff(
 
     ret = ''
 
-    if isinstance(env, six.string_types):
+    if isinstance(env, string_types):
         salt.utils.warn_until(
             'Boron',
             'Passing a salt environment should be done using \'saltenv\' not '

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -33,10 +33,7 @@ import glob
 import mmap
 
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
-# This string_types import needs to be here for windows as six.string_types
-# does not work from this module... This only applies to the 2015.5 branch.
-# Do not merge forward
-from salt.ext.six import string_types
+import salt.ext.six as six
 from salt.ext.six.moves import range, reduce, zip
 from salt.ext.six.moves.urllib.parse import urlparse as _urlparse
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
@@ -2888,7 +2885,7 @@ def source_list(source, source_hash, saltenv):
                 elif single_src.startswith('/') and os.path.exists(single_src):
                     ret = (single_src, single_hash)
                     break
-            elif isinstance(single, string_types):
+            elif isinstance(single, six.string_types):
                 path, senv = salt.utils.url.parse(single)
                 if not senv:
                     senv = saltenv
@@ -3243,7 +3240,7 @@ def check_perms(name, ret, user, group, mode, follow_symlinks=False):
         elif 'cgroup' in perms and user != '':
             ret['changes']['group'] = group
 
-    if isinstance(orig_comment, string_types):
+    if isinstance(orig_comment, six.string_types):
         if orig_comment:
             ret['comment'].insert(0, orig_comment)
         ret['comment'] = '; '.join(ret['comment'])
@@ -3500,7 +3497,7 @@ def get_diff(
 
     ret = ''
 
-    if isinstance(env, string_types):
+    if isinstance(env, six.string_types):
         salt.utils.warn_until(
             'Boron',
             'Passing a salt environment should be done using \'saltenv\' not '

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -29,8 +29,8 @@ import sys  # do not remove, used in imported file.py functions
 import fileinput  # do not remove, used in imported file.py functions
 import fnmatch  # do not remove, used in imported file.py functions
 import mmap  # do not remove, used in imported file.py functions
-import salt.ext.six as six  # pylint: disable=import-error,no-name-in-module
 # do not remove, used in imported file.py functions
+import salt.ext.six as six  # pylint: disable=import-error,no-name-in-module
 from salt.ext.six.moves.urllib.parse import urlparse as _urlparse  # pylint: disable=import-error,no-name-in-module
 import salt.utils.atomicfile  # do not remove, used in imported file.py functions
 from salt.exceptions import CommandExecutionError, SaltInvocationError

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -29,7 +29,7 @@ import sys  # do not remove, used in imported file.py functions
 import fileinput  # do not remove, used in imported file.py functions
 import fnmatch  # do not remove, used in imported file.py functions
 import mmap  # do not remove, used in imported file.py functions
-from salt.ext.six import string_types  # do not remove, used in imported file.py functions
+import salt.ext.six as six  # pylint: disable=import-error,no-name-in-module
 # do not remove, used in imported file.py functions
 from salt.ext.six.moves.urllib.parse import urlparse as _urlparse  # pylint: disable=import-error,no-name-in-module
 import salt.utils.atomicfile  # do not remove, used in imported file.py functions


### PR DESCRIPTION
### What does this PR do?

Fixes file.managed for windows
### What issues does this PR fix or reference?

https://github.com/saltstack/zh/issues/697
For some reason, there is a problem with the following code when run from the file.py module:

```
from salt.ext import six
comment = 'This is a string'
isinstance(comment, six.string_types)
```

When run from within the python shell it works fine. Had to revert back to the old import:

```
from salt.ext.six import string_types
```
### Previous Behavior

file.managed would fail with the following error:

```
Unable to manage file: global name 'six' is not defined
```
### New Behavior

`file.managed` works as expected
### Tests written?

No
