### PR TITLE
Fixes Type error in jboss state module when concatenating comments

### DIFF
--- a/salt/states/jboss7.py
+++ b/salt/states/jboss7.py
@@ -530,6 +530,12 @@ def __check_dict_contains(dct, dict_name, keys, comment='', result=True):
 
 
 def __append_comment(new_comment, current_comment=''):
+    if current_comment is None and new_comment is None:
+        return ''
+    if current_comment is None:
+        return new_comment
+    if new_comment is None:
+        return current_comment
     return current_comment+'\n'+new_comment
 
 


### PR DESCRIPTION
### What does this PR do?

Fixes Type error in jboss state module when concatenating comments
### What issues does this PR fix or reference?

Deploy to jboss TypeError at boss7.py:469 #33187
### Previous Behavior

Breaks when concatenating a string to a message defined as NoneType
### Tests written?

No
