### PR TITLE
Files without pkg.owner are not skipped

### DIFF
--- a/salt/modules/restartcheck.py
+++ b/salt/modules/restartcheck.py
@@ -377,6 +377,8 @@ def restartcheck(ignorelist=None, blacklist=None, excludepid=None, verbose=True)
             packagename = owners_cache[readlink]
         except KeyError:
             packagename = __salt__['pkg.owner'](readlink)
+            if not packagename:
+                packagename = name
             owners_cache[readlink] = packagename
         if packagename and packagename not in ignorelist:
             program = '\t' + str(pid) + ' ' + readlink + ' (file: ' + str(path) + ')'


### PR DESCRIPTION
### What does this PR do?

We found some false negative reports on our machines with qemu.
### What issues does this PR fix or reference?

In rare situations dpkg -S was not able to find the owner of deleted file, but it was still used by some process. Use process name instead of packagename.
### Previous Behavior

False negative qemu, libtasn1 (and maybe other) deleted files.
### New Behavior

Better reporting
### Tests written?

No
