### PR TITLE
Properly handle failed git commands when redirect_stderr=True

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -449,6 +449,10 @@ def _run(cmd,
             return ret
 
         out, err = proc.stdout, proc.stderr
+        if err is None:
+            # Will happen if redirect_stderr is True, since stderr was sent to
+            # stdout.
+            err = ''
 
         if rstrip:
             if out is not None:

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -238,9 +238,9 @@ def _git_run(command, cwd=None, runas=None, identity=None,
             if result['retcode'] == 0:
                 return result
             else:
-                stderr = \
-                    salt.utils.url.redact_http_basic_auth(result['stderr'])
-                errors.append(stderr)
+                err = result['stdout' if redirect_stderr else 'stderr']
+                if err:
+                    errors.append(salt.utils.url.redact_http_basic_auth(err))
 
         # We've tried all IDs and still haven't passed, so error out
         if failhard:
@@ -281,9 +281,10 @@ def _git_run(command, cwd=None, runas=None, identity=None,
                 msg = 'Command \'{0}\' failed'.format(
                     salt.utils.url.redact_http_basic_auth(gitcommand)
                 )
-                if result['stderr']:
+                err = result['stdout' if redirect_stderr else 'stderr']
+                if err:
                     msg += ': {0}'.format(
-                        salt.utils.url.redact_http_basic_auth(result['stderr'])
+                        salt.utils.url.redact_http_basic_auth(err)
                     )
                 raise CommandExecutionError(msg)
             return result


### PR DESCRIPTION
When running `subprocess.Popen.communicate()` on a command run with stderr
redirected to `subprocess.STDOUT`, the 2nd element of the return tuple
(representing the stderr) will be None, since all of the standard error wa
sent to stdout.

Functions interpreting the return data from `cmd.run_all` will be expecting
the `stderr` key in the return dict to contain a string, not a NoneType,
so this pull request forces the stderr to be set to an empty string when
redirect_stderr is True.

Additionally, when reporting on failed git commands, the stdout will be
inspected in these cases, since stderr will be an empty string and will not
contain the useful error message.

Resolves #32385.
