### PR TITLE
Windows minion fix (broken on PR #33011)

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1447,7 +1447,7 @@ class Minion(MinionBase):
         for ind in range(0, len(data['fun'])):
             ret['success'][data['fun'][ind]] = False
             try:
-                if minion_instance.opts['pillar'].get('minion_blackout', False):
+                if minion_instance.connected and minion_instance.opts['pillar'].get('minion_blackout', False):
                     # this minion is blacked out. Only allow saltutil.refresh_pillar
                     if data['fun'][ind] != 'saltutil.refresh_pillar' and \
                             data['fun'][ind] not in minion_instance.opts['pillar'].get('minion_blackout_whitelist', []):
@@ -1474,10 +1474,11 @@ class Minion(MinionBase):
             ret['fun_args'] = data['arg']
         if 'metadata' in data:
             ret['metadata'] = data['metadata']
-        minion_instance._return_pub(
-            ret,
-            timeout=minion_instance._return_retry_timer()
-        )
+        if minion_instance.connected:
+            minion_instance._return_pub(
+                ret,
+                timeout=minion_instance._return_retry_timer()
+            )
         if data['ret']:
             if 'ret_config' in data:
                 ret['ret_config'] = data['ret_config']

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1171,12 +1171,12 @@ class Minion(MinionBase):
                 # running on windows
                 instance = None
             process = SignalHandlingMultiprocessingProcess(
-                target=self._target, args=(instance, self.opts, data)
+                target=self._target, args=(instance, self.opts, data, self.connected)
             )
         else:
             process = threading.Thread(
                 target=self._target,
-                args=(instance, self.opts, data),
+                args=(instance, self.opts, data, self.connected),
                 name=data['jid']
             )
 
@@ -1212,9 +1212,10 @@ class Minion(MinionBase):
             return exitstack
 
     @classmethod
-    def _target(cls, minion_instance, opts, data):
+    def _target(cls, minion_instance, opts, data, connected):
         if not minion_instance:
             minion_instance = cls(opts)
+            minion_instance.connected = connected
             if not hasattr(minion_instance, 'functions'):
                 functions, returners, function_errors, executors = (
                     minion_instance._load_modules()


### PR DESCRIPTION
### What does this PR do?

Fixes the Windows minion, since PR #33011 (standalone minion fix) submission exposed a problem with the state of minion_instance. It also adds a fix to the standalone minion to make the same change on #33011 for the multifunc case.
### What issues does this PR fix or reference?

3301
### Previous Behavior

Remove this section if not relevant
Windows minion will not return data via the PUB channel back to the master
### Tests written?

No
