### PR TITLE
Check rendered YAML for invalid keys

### DIFF
--- a/tests/unit/returners/smtp_return_test.py
+++ b/tests/unit/returners/smtp_return_test.py
@@ -43,19 +43,18 @@ class SMTPReturnerTestCase(TestCase):
                'fun': 'mytest.func',
                'fun_args': 'myfunc args',
                'jid': '54321',
-               'return': 'The room is on fire as shes fixing her hair'
-               }
+               'return': 'The room is on fire as shes fixing her hair'}
         options = {'username': '',
-                  'tls': '',
-                  'from': '',
-                  'fields': 'id,fun,fun_args,jid,return',
-                  'to': '',
-                  'host': '',
-                  'renderer': 'yaml',
-                  'template': '',
-                  'password': '',
-                  'gpgowner': '',
-                  'subject': ''}
+                   'tls': '',
+                   'from': '',
+                   'fields': 'id,fun,fun_args,jid,return',
+                   'to': '',
+                   'host': '',
+                   'renderer': 'jinja|yaml',
+                   'template': '',
+                   'password': '',
+                   'gpgowner': '',
+                   'subject': ''}
 
         with patch('salt.returners.smtp_return._get_options', MagicMock(return_value=options)):
             smtp.returner(ret)
@@ -66,14 +65,20 @@ if HAS_GNUPG:
     @patch('salt.returners.smtp_return.smtplib.SMTP')
     def test_returner(self, mocked_smtplib, *args):
         with patch.dict(smtp.__opts__, {'extension_modules': '',
-                                        'renderer': 'yaml'}):
+                                        'renderer': 'jinja|yaml',
+                                        'file_roots': [],
+                                        'pillar_roots': [],
+                                        'cachedir': '/'}):
             self._test_returner(mocked_smtplib, *args)
 
 else:
     @patch('salt.returners.smtp_return.smtplib.SMTP')
     def test_returner(self, mocked_smtplib, *args):
         with patch.dict(smtp.__opts__, {'extension_modules': '',
-                                        'renderer': 'yaml'}):
+                                        'renderer': 'jinja|yaml',
+                                        'file_roots': [],
+                                        'pillar_roots': [],
+                                        'cachedir': '/'}):
             self._test_returner(mocked_smtplib, *args)
 
 SMTPReturnerTestCase.test_returner = test_returner


### PR DESCRIPTION
PyYAML will for some reason allow improper YAML, specifically double
curly-braces like `{{ }}`, to be formed into an unhashable dict (that
is, one with a dict as a key). This commit will change the YAML renderer
such that the rendered data is recursively checked for keys that are
dicts, and raises an SaltRenderError if such a key is encountered.

Resolves #33073.
