### PR TITLE
Don't stacktrace when using --out=highstate at CLI during state run.

### DIFF
--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -117,8 +117,9 @@ def get_printout(out, opts=None, **kwargs):
     if opts is None:
         opts = {}
 
-    if 'output' in opts:
-        # new --out option
+    if 'output' in opts and opts['output'] != 'highstate':
+        # new --out option, but don't choke when using --out=highstate at CLI
+        # See Issue #29796 for more information.
         out = opts['output']
 
     if out == 'text':


### PR DESCRIPTION
### What does this PR do?

Fixes the stacktrace that occurs when passing `--out=highstate` at the CLI during a state run.
### What issues does this PR fix or reference?

Fixes #29796
### Previous Behavior

When calling `--out=highstate` on a state command and there are changes in the state, there is a nasty stacktrace:

```
root@rallytime:~# salt-call --local state.sls always-changes-and-succeeds --out=highstate
[ERROR   ] Nested output failed: 
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/output/__init__.py", line 43, in try_printout
    return get_printout('nested', opts)(data).rstrip()
  File "/usr/lib/python2.7/site-packages/salt/output/highstate.py", line 85, in output
    return _format_host(host, hostdata)[0]
  File "/usr/lib/python2.7/site-packages/salt/output/highstate.py", line 131, in _format_host
    key=lambda k: data[k].get('__run_num__', 0)):
  File "/usr/lib/python2.7/site-packages/salt/output/highstate.py", line 131, in <lambda>
    key=lambda k: data[k].get('__run_num__', 0)):
AttributeError: 'str' object has no attribute 'get'
[ERROR   ] Nested output failed: 
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/output/__init__.py", line 43, in try_printout
    return get_printout('nested', opts)(data).rstrip()
  File "/usr/lib/python2.7/site-packages/salt/output/highstate.py", line 85, in output
    return _format_host(host, hostdata)[0]
  File "/usr/lib/python2.7/site-packages/salt/output/highstate.py", line 131, in _format_host
    key=lambda k: data[k].get('__run_num__', 0)):
  File "/usr/lib/python2.7/site-packages/salt/output/highstate.py", line 131, in <lambda>
    key=lambda k: data[k].get('__run_num__', 0)):
AttributeError: 'str' object has no attribute 'get'
<snipped>
  File "/usr/lib/python2.7/site-packages/salt/output/__init__.py", line 164, in out_format
    return try_printout(data, out, opts)
  File "/usr/lib/python2.7/site-packages/salt/output/__init__.py", line 46, in try_printout
    return get_printout('raw', opts)(data).rstrip()
  File "/usr/lib/python2.7/site-packages/salt/output/highstate.py", line 85, in output
    return _format_host(host, hostdata)[0]
  File "/usr/lib/python2.7/site-packages/salt/output/highstate.py", line 131, in _format_host
    key=lambda k: data[k].get('__run_num__', 0)):
  File "/usr/lib/python2.7/site-packages/salt/output/highstate.py", line 131, in <lambda>
    key=lambda k: data[k].get('__run_num__', 0)):
AttributeError: 'str' object has no attribute 'get'
```
### New Behavior

No longer stacktraces when there are changes in the state file and `--out=highstate` is passed at the CLI:

```
root@rallytime:~# salt-call --local state.sls always-changes-and-succeeds --out=highstate
<snipped>
local:
----------
          ID: always-changes-and-succeeds
    Function: test.succeed_with_changes
        Name: foo
      Result: True
     Comment: Success!
     Started: 20:11:54.442256
    Duration: 0.836 ms
     Changes:
              ----------
              testing:
                  ----------
                  new:
                      Something pretended to change
                  old:
                      Unchanged

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
```

I also tested this to make sure no other behavior was affected, but it all is working as expected. (Note that I have `out: json` set in my minion config to debug this issue:

```
root@rallytime:~# salt-call --local test.ping
{
    "local": true
}
root@rallytime:~# salt-call --local test.ping --out=nested
local:
    True
root@rallytime:~# salt-call --local test.ping --out=highstate
local:
    True
root@rallytime:~# salt-call --local state.sls always-changes-and-succeeds
{
    "local": {
        "test_|-always-changes-and-succeeds_|-foo_|-succeed_with_changes": {
            "comment": "Success!",
            "name": "foo",
            "start_time": "21:31:20.040920",
            "result": true,
            "duration": 0.765,
            "__run_num__": 0,
            "changes": {
                "testing": {
                    "new": "Something pretended to change",
                    "old": "Unchanged"
                }
            }
        }
    }
}
```
