### PR TITLE
Windows: salt fails to start when running in system account

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -273,7 +273,11 @@ def get_user():
     if HAS_PWD:
         return pwd.getpwuid(os.geteuid()).pw_name
     else:
-        return win32api.GetUserNameEx(win32api.NameSamCompatible)
+        user_name = win32api.GetUserNameEx(win32api.NameSamCompatible)
+        if user_name[-1] == '$' and win32api.GetUserName() == 'SYSTEM':
+            # Make the system account easier to identify.
+            user_name = 'SYSTEM'
+        return user_name
 
 
 def get_uid(user=None):


### PR DESCRIPTION
### What does this PR do?

`salt/utils/__init__.py`:
- In `get_user`, if it is the built-in system account, return the
  more recogizable 'SYSTEM' (which is the return value of
  `GetUserName`) instead of the SAM format which looks like:
  `<DOMAIN>\<HOSTNAME>$'`

`salt/utils/win_functions.py`:
- In `get_current_user` do the same change as above.
- In `is_admin`, accept the system account sid ('S-1-5-18') as
  administrator access. It technically isn't in the 'administrators'
  group but has the same access rights as administrators.
- In `get_user_groups`, if the user is 'SYSTEM', don't invoke
  `win32net.NetUserGetLocalGroups`. It will not recognize the
  'SYSTEM' username because it is a special built-in account and thus
  throw an exception. Instead, just add 'SYSTEM' to the list of groups.
  `get_sid_from_name` will still convert it correctly to 'S-1-5-18'.
### Tests written?

No

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
