### PR TITLE
Expose CherryPy option to write access and error logs

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -72,6 +72,14 @@ A REST API for Salt
     debug : ``False``
         Starts the web server in development mode. It will reload itself when
         the underlying code is changed and will output more debugging info.
+    log_access_file
+        Path to a file to write HTTP access logs.
+
+        .. versionaddedd:: Carbon
+    log_error_file
+        Path to a file to write HTTP error logs.
+
+        .. versionaddedd:: Carbon
     ssl_crt
         The path to a SSL certificate. (See below)
     ssl_key
@@ -2391,6 +2399,8 @@ class API(object):
                 'max_request_body_size': self.apiopts.get(
                     'max_request_body_size', 1048576),
                 'debug': self.apiopts.get('debug', False),
+                'log.access_file': self.apiopts.get('log_access_file', ''),
+                'log.error_file': self.apiopts.get('log_error_file', ''),
             },
             '/': {
                 'request.dispatch': cherrypy.dispatch.MethodDispatcher(),


### PR DESCRIPTION
### What does this PR do?

Add new new config options to rest_cherrypy to specify where to write access and error logs.
