### PR TITLE
Unbreak passwd change/expire reading on OpenBSD

### DIFF
--- a/salt/modules/bsd_shadow.py
+++ b/salt/modules/bsd_shadow.py
@@ -79,7 +79,7 @@ def info(name):
             with salt.utils.fopen('/etc/master.passwd', 'r') as fp_:
                 for line in fp_:
                     if line.startswith('{0}:'.format(name)):
-                        change, expire = line.rstrip('\n')[5:7]
+                        change, expire = line.split(':')[5:7]
                         break
         except IOError:
             change = expire = None


### PR DESCRIPTION
### What does this PR do?

Correctly read the change / expire timestamps in /etc/master.passwd on OpenBSD and NetBSD. Tested on OpenBSD 5.9
### Previous Behavior

ValueError: invalid literal for int() with base 10: 'a'
