### PR TITLE
salt.module.mdata should be able to retreive sdc:* properties

### DIFF
--- a/salt/modules/mdata.py
+++ b/salt/modules/mdata.py
@@ -103,7 +103,7 @@ def get_(*keyname):
 
     .. note::
 
-        If no keynames are specified, we get all properties
+        If no keynames are specified, we get all (public) properties
 
     CLI Example:
 
@@ -113,16 +113,16 @@ def get_(*keyname):
         salt '*' mdata.get user-script salt:role
     '''
     mdata = _check_mdata_get()
-    valid_keynames = list_()
     ret = {}
 
     if len(keyname) == 0:
-        keyname = valid_keynames
+        keyname = list_()
 
     for k in keyname:
-        if mdata and k in valid_keynames:
+        if mdata:
             cmd = '{0} {1}'.format(mdata, k)
-            ret[k] = __salt__['cmd.run'](cmd)
+            res = __salt__['cmd.run_all'](cmd)
+            ret[k] = res['stdout'] if res['retcode'] == 0 else ''
         else:
             ret[k] = ''
 


### PR DESCRIPTION
### What does this PR do?

Some properties are not listed by mdata-list but exist anyway.

mdata.get will now use the retcode to check if the property exists or not.
### What issues does this PR fix or reference?

N/A
### Previous Behavior

Properties not listed could not be retrieved.
### New Behavior

Properties that are not listed can now be retrieved.
### Tests written?

No
### Affected Branches:
- 2016.3
- develop
