### PR TITLE
Fix permission rights for .gnupg gpg files

### DIFF
--- a/salt/modules/rpmbuild.py
+++ b/salt/modules/rpmbuild.py
@@ -389,6 +389,11 @@ def make_repo(repodir, keyid=None, env=None, use_passphrase=False, gnupghome='/e
                 .format(keyid)
             )
 
+        # need to ensure ownership since gpg assigns to running process - root
+        for file in os.listdir(gnupghome):
+            if file.endswith('.gpg'):
+                __salt__['cmd.run']('chown {0}:{0} {1}'.format(runas, os.path.join(gnupghome, file)))
+
         # gpg keys should have been loaded as part of setup
         # retrieve specified key and preset passphrase
         local_keys = __salt__['gpg.list_keys'](user=runas, gnupghome=gnupghome)


### PR DESCRIPTION
### What does this PR do?

Fix ownership of gpg ,gnupg files such as pubring.gpg etc.
to that for the user rather than salt's running process
### What issues does this PR fix or reference?

Ownership rights of .gnupg gpg files such as pubring.gpg
so that they are accessible by user, when signing packages.
### Previous Behavior

gpg would set the ownership to that of the running Salt process
### New Behavior

gpg would set the ownership to that of the user
### Tests written?

No
