### PR TITLE
Backport #33244 to 2015.8

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -716,7 +716,7 @@ class GitPython(GitProvider):
             try:
                 self.repo = git.Repo(self.cachedir)
             except git.exc.InvalidGitRepositoryError:
-                log.error(_INVALID_REPO.format(self.cachedir, self.url))
+                log.error(_INVALID_REPO.format(self.cachedir, self.url, self.role))
                 return new
 
         self.gitdir = os.path.join(self.repo.working_dir, '.git')
@@ -1194,7 +1194,7 @@ class Pygit2(GitProvider):
                     pygit2.settings.search_path[pygit2.GIT_CONFIG_LEVEL_GLOBAL] = home
                     self.repo = pygit2.Repository(self.cachedir)
             except KeyError:
-                log.error(_INVALID_REPO.format(self.cachedir, self.url))
+                log.error(_INVALID_REPO.format(self.cachedir, self.url, self.role))
                 return new
 
         self.gitdir = os.path.join(self.repo.workdir, '.git')
@@ -1893,7 +1893,7 @@ class Dulwich(GitProvider):  # pylint: disable=abstract-method
             try:
                 self.repo = dulwich.repo.Repo(self.cachedir)
             except dulwich.repo.NotGitRepository:
-                log.error(_INVALID_REPO.format(self.cachedir, self.url))
+                log.error(_INVALID_REPO.format(self.cachedir, self.url, self.role))
                 return new
 
         self.gitdir = os.path.join(self.repo.path, '.git')


### PR DESCRIPTION
To avoid leaving develop in a broken state, #33244 was opened to fix what was
broken by #32238. This pull request backports the logging fix to the earliest
branch where it needed to go (2015.8).
