### PR TITLE
Handle ipv6 error as an exception

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -619,6 +619,9 @@ def wait_for_port(host, port=22, timeout=900, gateway=None):
                 sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
             else:
                 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        except socket.error:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
             sock.settimeout(30)
             sock.connect((test_ssh_host, int(test_ssh_port)))
             # Stop any remaining reads/writes on the socket


### PR DESCRIPTION
### What does this PR do?

Catch exceptions from inet_pton.
### What issues does this PR fix or reference?
#33243
### Previous Behavior

inet_pton was being treated as if it would return a falsy response, when in fact it raised an exception instead.
### New Behavior

Catch the exception.
### Tests written?

Nay.
