### PR TITLE
Update Git Policy docs to match Contribution guide

### DIFF
--- a/doc/topics/development/git/index.rst
+++ b/doc/topics/development/git/index.rst
@@ -16,19 +16,20 @@ contributors and developers to send in code. Simplicity is always a goal!
 New Code Entry
 ==============
 
-All new SaltStack code is posted to the `develop` branch, which is the single
-point of entry. The only exception is when a bugfix to develop cannot be
-cleanly merged into a release branch and the bugfix needs to be rewritten for
-the release branch.
+All new SaltStack code should be submitted against either the ``develop`` branch
+or a point release branch, depending on the nature of the submission. Please see
+the :ref:`Which Salt Branch? <which-salt-branch>` section of Salt's
+:ref:`Contributing <contributing>` documentation or the Release Branching section
+section below for more information.
 
 Release Branching
 =================
 
-SaltStack maintains two types of releases, `Feature Releases` and
-`Point Releases`. A feature release is managed by incrementing the first or
-second release point number, so 0.10.5 -> 0.11.0 signifies a feature release
-and 0.11.0 -> 0.11.1 signifies a point release, also a hypothetical
-0.42.7 -> 1.0.0 would also signify a feature release.
+SaltStack maintains two types of releases, ``Feature Releases`` and
+``Point Releases`` (also commonly referred to as ``Bugfix Releases``. A
+feature release is managed by incrementing the first or second release point
+number, so 2015.5.5 -> 2015.8.0 signifies a feature release
+and 2015.8.0 -> 2015.8.1 signifies a point release.
 
 Feature Release Branching
 -------------------------
@@ -38,41 +39,40 @@ last applicable release commit on develop. All file changes relevant to the
 feature release will be completed in the develop branch prior to the creation
 of the feature release branch. The feature release branch will be named after
 the relevant numbers to the feature release, which constitute the first two
-numbers. This means that the release branch for the 0.11.0 series is named
-0.11.
+numbers. This means that the release branch for the 2015.8.0 series is named
+2015.8.
 
 A feature release branch is created with the following command:
 
 .. code-block:: bash
 
-    # git checkout -b 0.11 # From the develop branch
-    # git push origin 0.11
+    # git checkout -b 2015.8 # From the develop branch
+    # git push origin 2015.8
 
 Point Releases
 --------------
 
 Each point release is derived from its parent release branch. Constructing point
 releases is a critical aspect of Salt development and is managed by members of
-the core development team. Point releases comprise bug and security fixes which
-are cherry picked from develop onto the aforementioned release branch. At the
-time when a core developer accepts a pull request a determination needs to be
-made if the commits in the pull request need to be backported to the release
-branch. Some simple criteria are used to make this determination:
+the core development team. Point releases comprise bug and security fixes. Bug
+fixes can be made against a point release branch in one of two ways: the bug
+fix can be submitted directly against the point release branch, or an attempt
+can be made to back-port the fix to the point release branch.
 
-* Is this commit fixing a bug?
-  Backport
-* Does this commit change or add new features in any way?
-  Don't backport
-* Is this a PEP8 or code cleanup commit?
-  Don't backport
-* Does this commit fix a security issue?
-  Backport
+Bug fixes should be made against the earliest supported release branch on which
+the bug is present. The Salt development team regularly merges older point
+release branches forward into newer point release branches. That way, the bug
+fixes that are submitted to older release branches can cascade up through all
+related release branches.
+
+For more information, please see the :ref:`Which Salt Branch? <which-salt-branch>`
+section of Salt's :ref:`Contributing <contributing>` documentation.
 
 Determining when a point release is going to be made is up to the project
-leader (Thomas Hatch). Generally point releases are made every 1-2 weeks or
+leader (Thomas Hatch). Generally point releases are made every 2-4 weeks or
 if there is a security fix they can be made sooner.
 
 The point release is only designated by tagging the commit on the release
-branch with release number using the existing convention (version 0.11.1 is
-tagged with v0.11.1). From the tag point a new source tarball is generated
+branch with a release number using the existing convention (version 2015.8.1
+is tagged with v2015.8.1). From the tag point a new source tarball is generated
 and published to PyPI, and a release announcement is made.


### PR DESCRIPTION
The SaltStack Git Policy documentation needed to be updated to match the contributing docs around where code should be submitted. Before this fix the docs had the old method of submitting everything to develop. This update changes the docs to submit bugfixes to point release branches.

Fixes #30946
