### PR TITLE
Gentoo/OpenRC service management enhancements

### DIFF
--- a/salt/modules/gentoo_service.py
+++ b/salt/modules/gentoo_service.py
@@ -17,8 +17,6 @@ import collections
 import logging
 
 # Import salt libs
-from collections import Iterable
-
 import salt.utils.systemd
 
 # Set up logging

--- a/salt/modules/gentoo_service.py
+++ b/salt/modules/gentoo_service.py
@@ -261,7 +261,8 @@ def enable(name, **kwargs):
 
     .. code-block:: bash
 
-        salt '*' service.enable <service name> <runlevels=[runlevel]>
+        salt '*' service.enable <service name> <runlevels=single-runlevel>
+        salt '*' service.enable <service name> <runlevels=[runlevel1,runlevel2]>
     '''
     if 'runlevels' in kwargs:
         requested_levels = set(kwargs['runlevels'] if isinstance(kwargs['runlevels'],
@@ -290,7 +291,8 @@ def disable(name, **kwargs):
 
     .. code-block:: bash
 
-        salt '*' service.disable <service name>
+        salt '*' service.disable <service name> <runlevels=single-runlevel>
+        salt '*' service.disable <service name> <runlevels=[runlevel1,runlevel2]>
     '''
     levels = []
     if 'runlevels' in kwargs:
@@ -311,11 +313,17 @@ def enabled(name, **kwargs):
 
     .. code-block:: bash
 
-        salt '*' service.enabled <service name> <runlevels=[runlevel]>
+        salt '*' service.enabled <service name> <runlevels=single-runlevel>
+        salt '*' service.enabled <service name> <runlevels=[runlevel1,runlevel2]>
     '''
     enabled_services = get_enabled()
-    return (name in enabled_services and
-            ('runlevels' not in kwargs or kwargs['runlevels'] in enabled_services[name]))
+    if name not in enabled_services:
+        return False
+    if 'runlevels' not in kwargs:
+        return True
+    requested_levels = set(kwargs['runlevels'] if isinstance(kwargs['runlevels'],
+                                                             list) else [kwargs['runlevels']])
+    return len(requested_levels - set(enabled_services[name])) == 0
 
 
 def disabled(name):
@@ -326,6 +334,6 @@ def disabled(name):
 
     .. code-block:: bash
 
-        salt '*' service.disabled <service name>
+        salt '*' service.disabled <service name> <runlevels=[runlevel]>
     '''
     return name in get_disabled()

--- a/salt/modules/gentoo_service.py
+++ b/salt/modules/gentoo_service.py
@@ -13,11 +13,11 @@ to the correct service manager
 from __future__ import absolute_import
 
 # Import Python libs
-import collections
 import logging
 
 # Import salt libs
 import salt.utils.systemd
+import salt.utils.odict as odict
 
 # Set up logging
 log = logging.getLogger(__name__)
@@ -98,7 +98,7 @@ def get_enabled():
         salt '*' service.get_enabled
     '''
     (enabled_services, disabled_services) = _get_service_list()
-    return collections.OrderedDict(enabled_services)
+    return odict.OrderedDict(enabled_services)
 
 
 def get_disabled():
@@ -160,7 +160,7 @@ def get_all():
     (enabled_services, disabled_services) = _get_service_list(include_enabled=True,
                                                               include_disabled=True)
     enabled_services.update(dict([(s, []) for s in disabled_services]))
-    return collections.OrderedDict(enabled_services)
+    return odict.OrderedDict(enabled_services)
 
 
 def start(name):

--- a/tests/unit/modules/gentoo_service_test.py
+++ b/tests/unit/modules/gentoo_service_test.py
@@ -436,7 +436,7 @@ class GentooServicesTestCase(TestCase):
         '''
         Test for Return True if the named service is disabled, false otherwise
         '''
-        mock = MagicMock(return_value={'name'})
+        mock = MagicMock(return_value=['name'])
         with patch.object(gentoo_service, 'get_disabled', mock):
             self.assertTrue(gentoo_service.disabled('name'))
 

--- a/tests/unit/modules/gentoo_service_test.py
+++ b/tests/unit/modules/gentoo_service_test.py
@@ -1,0 +1,436 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+from __future__ import absolute_import
+
+# Import Salt Testing Libs
+from mock import call
+
+from salttesting import TestCase, skipIf
+from salttesting.mock import (
+    MagicMock,
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+# Import Salt Libs
+from salt.modules import gentoo_service
+
+
+# Globals
+gentoo_service.__grains__ = {}
+gentoo_service.__salt__ = {}
+gentoo_service.__context__ = {}
+gentoo_service.__opts__ = {}
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class GentooServicesTestCase(TestCase):
+    """
+    Test cases for salt.modules.gentoo_service
+    """
+
+    def test_service_list_parser(self):
+        """
+        Test for parser of rc-status results
+        """
+        # no services is enabled
+        mock = MagicMock(return_value='')
+        with patch.dict(gentoo_service.__salt__, {'cmd.run': mock}):
+            self.assertFalse(gentoo_service.get_enabled())
+        mock.assert_called_once_with('rc-update -v show')
+
+    def test_get_enabled_single_runlevel(self):
+        """
+        Test for Return a list of service that are enabled on boot
+        """
+        service_name = 'name'
+        runlevels = ['default']
+        mock = MagicMock(return_value=self.__services({service_name: runlevels}))
+        with patch.dict(gentoo_service.__salt__, {'cmd.run': mock}):
+            enabled_services = gentoo_service.get_enabled()
+            self.assertTrue(service_name in enabled_services)
+            self.assertEqual(enabled_services[service_name], runlevels)
+
+    def test_get_enabled_filters_out_disabled_services(self):
+        """
+        Test for Return a list of service that are enabled on boot
+        """
+        service_name = 'name'
+        runlevels = ['default']
+        disabled_service = 'disabled'
+        service_list = self.__services({service_name: runlevels, disabled_service: []})
+
+        mock = MagicMock(return_value=service_list)
+        with patch.dict(gentoo_service.__salt__, {'cmd.run': mock}):
+            enabled_services = gentoo_service.get_enabled()
+            self.assertEqual(len(enabled_services), 1)
+            self.assertTrue(service_name in enabled_services)
+            self.assertEqual(enabled_services[service_name], runlevels)
+
+    def test_get_enabled_with_multiple_runlevels(self):
+        """
+        Test for Return a list of service that are enabled on boot at more than one runlevel
+        """
+        service_name = 'name'
+        runlevels = ['non-default', 'default']
+        mock = MagicMock(return_value=self.__services({service_name: runlevels}))
+        with patch.dict(gentoo_service.__salt__, {'cmd.run': mock}):
+            enabled_services = gentoo_service.get_enabled()
+            self.assertTrue(service_name in enabled_services)
+            self.assertEqual(enabled_services[service_name][0], runlevels[1])
+            self.assertEqual(enabled_services[service_name][1], runlevels[0])
+
+    def test_get_disabled(self):
+        """
+        Test for Return a list of service that are installed but disabled
+        """
+        disabled_service = 'disabled'
+        enabled_service = 'enabled'
+        service_list = self.__services({disabled_service: [],
+                                        enabled_service: ['default']})
+        mock = MagicMock(return_value=service_list)
+        with patch.dict(gentoo_service.__salt__, {'cmd.run': mock}):
+            disabled_services = gentoo_service.get_disabled()
+            self.assertTrue(len(disabled_services), 1)
+            self.assertTrue(disabled_service in disabled_services)
+
+    def test_available(self):
+        """
+        Test for Returns ``True`` if the specified service is
+        available, otherwise returns
+        ``False``.
+        """
+        disabled_service = 'disabled'
+        enabled_service = 'enabled'
+        multilevel_service = 'multilevel'
+        missing_service = 'missing'
+        shutdown_service = 'shutdown'
+        service_list = self.__services({disabled_service: [],
+                                        enabled_service: ['default'],
+                                        multilevel_service: ['default', 'shutdown'],
+                                        shutdown_service: ['shutdown']})
+        mock = MagicMock(return_value=service_list)
+        with patch.dict(gentoo_service.__salt__, {'cmd.run': mock}):
+            self.assertTrue(gentoo_service.available(enabled_service))
+            self.assertTrue(gentoo_service.available(multilevel_service))
+            self.assertTrue(gentoo_service.available(disabled_service))
+            self.assertTrue(gentoo_service.available(shutdown_service))
+            self.assertFalse(gentoo_service.available(missing_service))
+
+    def test_missing(self):
+        """
+        Test for The inverse of service.available.
+        """
+        disabled_service = 'disabled'
+        enabled_service = 'enabled'
+        service_list = self.__services({disabled_service: [],
+                                        enabled_service: ['default']})
+        mock = MagicMock(return_value=service_list)
+        with patch.dict(gentoo_service.__salt__, {'cmd.run': mock}):
+            self.assertFalse(gentoo_service.missing(enabled_service))
+            self.assertFalse(gentoo_service.missing(disabled_service))
+            self.assertTrue(gentoo_service.missing('missing'))
+
+    def test_getall(self):
+        """
+        Test for Return all available boot services
+        """
+        disabled_service = 'disabled'
+        enabled_service = 'enabled'
+        service_list = self.__services({disabled_service: [],
+                                        enabled_service: ['default']})
+        mock = MagicMock(return_value=service_list)
+        with patch.dict(gentoo_service.__salt__, {'cmd.run': mock}):
+            all_services = gentoo_service.get_all()
+            self.assertEqual(len(all_services), 2)
+            self.assertTrue(disabled_service in all_services)
+            self.assertTrue(enabled_service in all_services)
+
+    def test_start(self):
+        """
+        Test for Start the specified service
+        """
+        mock = MagicMock(return_value=True)
+        with patch.dict(gentoo_service.__salt__, {'cmd.retcode': mock}):
+            self.assertFalse(gentoo_service.start('name'))
+        mock.assert_called_once_with('/etc/init.d/name start', python_shell=False)
+
+    def test_stop(self):
+        """
+        Test for Stop the specified service
+        """
+        mock = MagicMock(return_value=True)
+        with patch.dict(gentoo_service.__salt__, {'cmd.retcode': mock}):
+            self.assertFalse(gentoo_service.stop('name'))
+        mock.assert_called_once_with('/etc/init.d/name stop', python_shell=False)
+
+    def test_restart(self):
+        """
+        Test for Restart the named service
+        """
+        mock = MagicMock(return_value=True)
+        with patch.dict(gentoo_service.__salt__, {'cmd.retcode': mock}):
+            self.assertFalse(gentoo_service.restart('name'))
+        mock.assert_called_once_with('/etc/init.d/name restart', python_shell=False)
+
+    def test_reload_(self):
+        """
+        Test for Reload the named service
+        """
+        mock = MagicMock(return_value=True)
+        with patch.dict(gentoo_service.__salt__, {'cmd.retcode': mock}):
+            self.assertFalse(gentoo_service.reload_('name'))
+        mock.assert_called_once_with('/etc/init.d/name reload', python_shell=False)
+
+    def test_zap(self):
+        """
+        Test for Reload the named service
+        """
+        mock = MagicMock(return_value=True)
+        with patch.dict(gentoo_service.__salt__, {'cmd.retcode': mock}):
+            self.assertFalse(gentoo_service.zap('name'))
+        mock.assert_called_once_with('/etc/init.d/name zap', python_shell=False)
+
+    def test_status(self):
+        """
+        Test for Return the status for a service
+        """
+        mock = MagicMock(return_value=True)
+        with patch.dict(gentoo_service.__salt__, {'status.pid': mock}):
+            self.assertTrue(gentoo_service.status('name', 1))
+
+        # service is running
+        mock = MagicMock(return_value=0)
+        with patch.dict(gentoo_service.__salt__, {'cmd.retcode': mock}):
+            self.assertTrue(gentoo_service.status('name'))
+        mock.assert_called_once_with('/etc/init.d/name status', python_shell=False)
+
+        # service is not running
+        mock = MagicMock(return_value=1)
+        with patch.dict(gentoo_service.__salt__, {'cmd.retcode': mock}):
+            self.assertFalse(gentoo_service.status('name'))
+        mock.assert_called_once_with('/etc/init.d/name status', python_shell=False)
+
+        # service is stopped
+        mock = MagicMock(return_value=3)
+        with patch.dict(gentoo_service.__salt__, {'cmd.retcode': mock}):
+            self.assertFalse(gentoo_service.status('name'))
+        mock.assert_called_once_with('/etc/init.d/name status', python_shell=False)
+
+        # service has crashed
+        mock = MagicMock(return_value=32)
+        with patch.dict(gentoo_service.__salt__, {'cmd.retcode': mock}):
+            self.assertFalse(gentoo_service.status('name'))
+        mock.assert_called_once_with('/etc/init.d/name status', python_shell=False)
+
+    def test_enable(self):
+        """
+        Test for Enable the named service to start at boot
+        """
+        rc_update_mock = MagicMock(return_value=0)
+        with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
+            self.assertTrue(gentoo_service.enable('name'))
+        rc_update_mock.assert_called_once_with('rc-update add name', python_shell=False)
+        rc_update_mock.reset_mock()
+
+        # move service from 'l1' to 'l2' runlevel
+        service_name = 'name'
+        runlevels = ['l1']
+        level_list_mock = MagicMock(return_value=self.__services({service_name: runlevels}))
+        with patch.dict(gentoo_service.__salt__, {'cmd.run': level_list_mock}):
+            with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
+                self.assertTrue(gentoo_service.enable('name', runlevels='l2'))
+        rc_update_mock.assert_has_calls([call('rc-update delete name l1', python_shell=False),
+                                         call('rc-update add name l2', python_shell=False)])
+        rc_update_mock.reset_mock()
+
+        # requested levels are the same as the current ones
+        with patch.dict(gentoo_service.__salt__, {'cmd.run': level_list_mock}):
+            with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
+                self.assertTrue(gentoo_service.enable('name', runlevels='l1'))
+        rc_update_mock.assert_not_called()
+        rc_update_mock.reset_mock()
+
+        # same as above with the list instead of the string
+        with patch.dict(gentoo_service.__salt__, {'cmd.run': level_list_mock}):
+            with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
+                self.assertTrue(gentoo_service.enable('name', runlevels=['l1']))
+        rc_update_mock.assert_not_called()
+        rc_update_mock.reset_mock()
+
+        # add service to 'l2' runlevel
+        with patch.dict(gentoo_service.__salt__, {'cmd.run': level_list_mock}):
+            with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
+                self.assertTrue(gentoo_service.enable('name', runlevels=['l2', 'l1']))
+        rc_update_mock.assert_called_once_with('rc-update add name l2', python_shell=False)
+        rc_update_mock.reset_mock()
+
+        # remove service from 'l1' runlevel
+        runlevels = ['l1', 'l2']
+        level_list_mock = MagicMock(return_value=self.__services({service_name: runlevels}))
+        with patch.dict(gentoo_service.__salt__, {'cmd.run': level_list_mock}):
+            with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
+                self.assertTrue(gentoo_service.enable('name', runlevels=['l2']))
+        rc_update_mock.assert_called_once_with('rc-update delete name l1', python_shell=False)
+        rc_update_mock.reset_mock()
+
+        # move service from 'l2' add to 'l3', leaving at l1
+        with patch.dict(gentoo_service.__salt__, {'cmd.run': level_list_mock}):
+            with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
+                self.assertTrue(gentoo_service.enable('name', runlevels=['l1', 'l3']))
+        rc_update_mock.assert_has_calls([call('rc-update delete name l2', python_shell=False),
+                                         call('rc-update add name l3', python_shell=False)])
+        rc_update_mock.reset_mock()
+
+        # remove from l1, l3, and add to l2, l4, and leave at l5
+        runlevels = ['l1', 'l3', 'l5']
+        level_list_mock = MagicMock(return_value=self.__services({service_name: runlevels}))
+        with patch.dict(gentoo_service.__salt__, {'cmd.run': level_list_mock}):
+            with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
+                self.assertTrue(gentoo_service.enable('name', runlevels=['l2', 'l4', 'l5']))
+        rc_update_mock.assert_has_calls([call('rc-update delete name l1 l3', python_shell=False),
+                                         call('rc-update add name l2 l4', python_shell=False)])
+        rc_update_mock.reset_mock()
+
+        # rc-update failed
+        rc_update_mock = MagicMock(return_value=1)
+        with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
+            self.assertFalse(gentoo_service.enable('name'))
+        rc_update_mock.assert_called_once_with('rc-update add name', python_shell=False)
+        rc_update_mock.reset_mock()
+
+        # move service delete failed
+        runlevels = ['l1']
+        level_list_mock = MagicMock(return_value=self.__services({service_name: runlevels}))
+        with patch.dict(gentoo_service.__salt__, {'cmd.run': level_list_mock}):
+            with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
+                self.assertFalse(gentoo_service.enable('name', runlevels='l2'))
+        rc_update_mock.assert_called_once_with('rc-update delete name l1', python_shell=False)
+        rc_update_mock.reset_mock()
+
+        # move service delete succeeds. add fails
+        rc_update_mock = MagicMock()
+        rc_update_mock.side_effect = [0, 1]
+        with patch.dict(gentoo_service.__salt__, {'cmd.run': level_list_mock}):
+            with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
+                self.assertFalse(gentoo_service.enable('name', runlevels='l2'))
+        rc_update_mock.assert_has_calls([call('rc-update delete name l1', python_shell=False),
+                                         call('rc-update add name l2', python_shell=False)])
+        rc_update_mock.reset_mock()
+
+    def test_disable(self):
+        """
+        Test for Disable the named service to start at boot
+        """
+        rc_update_mock = MagicMock(return_value=0)
+        with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
+            self.assertTrue(gentoo_service.disable('name'))
+        rc_update_mock.assert_called_once_with('rc-update delete name', python_shell=False)
+        rc_update_mock.reset_mock()
+
+        # disable service
+        service_name = 'name'
+        runlevels = ['l1']
+        level_list_mock = MagicMock(return_value=self.__services({service_name: runlevels}))
+        with patch.dict(gentoo_service.__salt__, {'cmd.run': level_list_mock}):
+            with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
+                self.assertTrue(gentoo_service.disable('name', runlevels='l1'))
+        rc_update_mock.assert_called_once_with('rc-update delete name l1',
+                                               python_shell=False)
+        rc_update_mock.reset_mock()
+
+        # same as above with list
+        runlevels = ['l1']
+        level_list_mock = MagicMock(return_value=self.__services({service_name: runlevels}))
+        with patch.dict(gentoo_service.__salt__, {'cmd.run': level_list_mock}):
+            with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
+                self.assertTrue(gentoo_service.disable('name', runlevels=['l1']))
+        rc_update_mock.assert_called_once_with('rc-update delete name l1',
+                                               python_shell=False)
+        rc_update_mock.reset_mock()
+
+        # remove from 'l1', and leave at 'l2'
+        runlevels = ['l1', 'l2']
+        level_list_mock = MagicMock(return_value=self.__services({service_name: runlevels}))
+        with patch.dict(gentoo_service.__salt__, {'cmd.run': level_list_mock}):
+            with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
+                self.assertTrue(gentoo_service.disable('name', runlevels=['l1']))
+        rc_update_mock.assert_called_once_with('rc-update delete name l1',
+                                               python_shell=False)
+        rc_update_mock.reset_mock()
+
+        # remove from non-enabled level
+        runlevels = ['l2']
+        level_list_mock = MagicMock(return_value=self.__services({service_name: runlevels}))
+        with patch.dict(gentoo_service.__salt__, {'cmd.run': level_list_mock}):
+            with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
+                self.assertTrue(gentoo_service.disable('name', runlevels=['l1']))
+        rc_update_mock.assert_not_called()
+        rc_update_mock.reset_mock()
+
+        # remove from 'l1' and 'l3', leave at 'l2'
+        runlevels = ['l1', 'l2', 'l3']
+        level_list_mock = MagicMock(return_value=self.__services({service_name: runlevels}))
+        with patch.dict(gentoo_service.__salt__, {'cmd.run': level_list_mock}):
+            with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
+                self.assertTrue(gentoo_service.disable('name', runlevels=['l1', 'l3']))
+        rc_update_mock.assert_called_once_with('rc-update delete name l1 l3',
+                                               python_shell=False)
+        rc_update_mock.reset_mock()
+
+        # rc-update failed
+        rc_update_mock = MagicMock(return_value=1)
+        with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
+            self.assertFalse(gentoo_service.disable('name'))
+        rc_update_mock.assert_called_once_with('rc-update delete name', python_shell=False)
+        rc_update_mock.reset_mock()
+
+        # move service delete failed
+        runlevels = ['l1']
+        level_list_mock = MagicMock(return_value=self.__services({service_name: runlevels}))
+        with patch.dict(gentoo_service.__salt__, {'cmd.run': level_list_mock}):
+            with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
+                self.assertFalse(gentoo_service.disable('name', runlevels='l1'))
+        rc_update_mock.assert_called_once_with('rc-update delete name l1', python_shell=False)
+        rc_update_mock.reset_mock()
+
+        # move service delete succeeds. add fails
+        runlevels = ['l1', 'l2', 'l3']
+        level_list_mock = MagicMock(return_value=self.__services({service_name: runlevels}))
+        with patch.dict(gentoo_service.__salt__, {'cmd.run': level_list_mock}):
+            with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
+                self.assertFalse(gentoo_service.disable('name', runlevels=['l1', 'l3']))
+        rc_update_mock.assert_called_once_with('rc-update delete name l1 l3',
+                                               python_shell=False)
+        rc_update_mock.reset_mock()
+
+    def test_enabled(self):
+        """
+        Test for Return True if the named service is enabled, false otherwise
+        """
+        mock = MagicMock(return_value={'name': ['default']})
+        with patch.object(gentoo_service, 'get_enabled', mock):
+            # service is enabled at any level
+            self.assertTrue(gentoo_service.enabled('name'))
+            # service is enabled at the requested runlevels
+            self.assertTrue(gentoo_service.enabled('name', runlevels='default'))
+            # service is enabled at a different runlevels
+            self.assertFalse(gentoo_service.enabled('name', runlevels='boot'))
+
+    def test_disabled(self):
+        '''
+        Test for Return True if the named service is disabled, false otherwise
+        '''
+        mock = MagicMock(return_value={'name'})
+        with patch.object(gentoo_service, 'get_disabled', mock):
+            self.assertTrue(gentoo_service.disabled('name'))
+
+    def __services(self, services):
+        return '\n'.join([' | '.join([svc, ' '.join(services[svc])]) for svc in services])
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(GentooServicesTestCase, needs_daemon=False)

--- a/tests/unit/modules/gentoo_service_test.py
+++ b/tests/unit/modules/gentoo_service_test.py
@@ -419,6 +419,19 @@ class GentooServicesTestCase(TestCase):
             # service is enabled at a different runlevels
             self.assertFalse(gentoo_service.enabled('name', runlevels='boot'))
 
+        mock = MagicMock(return_value={'name': ['boot', 'default']})
+        with patch.object(gentoo_service, 'get_enabled', mock):
+            # service is enabled at any level
+            self.assertTrue(gentoo_service.enabled('name'))
+            # service is enabled at the requested runlevels
+            self.assertTrue(gentoo_service.enabled('name', runlevels='default'))
+            # service is enabled at all levels
+            self.assertTrue(gentoo_service.enabled('name', runlevels=['boot', 'default']))
+            # service is enabled at a different runlevels
+            self.assertFalse(gentoo_service.enabled('name', runlevels='some-other-level'))
+            # service is enabled at a different runlevels
+            self.assertFalse(gentoo_service.enabled('name', runlevels=['boot', 'some-other-level']))
+
     def test_disabled(self):
         '''
         Test for Return True if the named service is disabled, false otherwise


### PR DESCRIPTION
### What does this PR do?

Full support for Gentoo/OpenRC service management
### What issues does this PR fix or reference?

The changes provide full service management support for Gentoo with OpenRC
### Previous Behavior
- module implemented OpenRC service management but was loaded on any Gentoo system (systemd/OpenRC).
- `service.get_enabled` returned a set of enabled services
- `service.get_enabled` filtered out services enabled at `shutdown` runlevel
- `service.get_all` required two `rc-update` commands
- `service.reload_` was not implemented
- `service.zap` was not implemented
- `service.status` used `status.pid` with and without `signature` argument
- `service.enabled` returned `False` for services enabled at `shutdow` level
- `service.disabled` returned `False` for services enabled at `shutdow` level
- `service.enable` always explicitly enabled a service at `default` runlevel
- `service.disable` always explicitly disabled a service at `default` runlevel
### New Behavior
- module will be load only on Gentoo with OpenRC.
- `service.get_enabled` returns service to runlevel map
- `service.get_enabled` includes services enabled at `shutdown` runlevel
- `service.get_all` requires a single `rc-update` commands
- new `service.reload_` command for the services that support it
- new `service.zap` command
- `service.status` without signature uses `rc-status` (identical to debian implementation)
- `service.enabled` returns `True` for any enabled service
- `service.enabled` supports optional `runlevels` argument. With out the argument it returns `True`
  if service is enabled at runlevel. With the argument it returns `True` when and only when the
  service is enabled that the specified runlevel and `False` otherwise
- `service.disabled` returns `False` for the services enabled at `shutdown` level
  when and only when service is disabled at the specified runlevel.
- `service.enable` supports optional `runlvels` argument. Without the argument runlevel selection
  is deferred to the system with the argument the service will be enabled only at the specified `runlevels`.
  `runlevels` can be specified at command line and sls files:

``` sh
salt '*' service.enable foo runlevels=bar
salt '*' service.enable foo runlevels=[bar,baz]
```

``` yaml
my.enabled.service:
  service.enabled:
    - name: foo
    - runlevels: bar

my.service.enabled.at.multiple.levels:
  service.enabled:
    - name: foo
    - runlevels:
      - bar
      - baz
```
- `service.disable` supports optional `runlevels` argument. Without the argument runlevel selection deferred to the system.
  With the argument a service will be disabled only at the runlevels specified.
### Tests written?

Yes tests/unit/modules/getoo_serivce_test.py
