### PR TITLE
Fix an error in reg.list_values and add unit tests

### DIFF
--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -285,8 +285,9 @@ def list_values(hive, key=None, use_32bit_registry=False, include_default=True):
     registry = Registry()
     hkey = registry.hkeys[local_hive]
     access_mask = registry.registry_32[use_32bit_registry]
-
+    handle = None
     values = list()
+
     try:
         handle = _winreg.OpenKey(hkey, local_key, 0, access_mask)
 

--- a/tests/unit/modules/reg_win_test.py
+++ b/tests/unit/modules/reg_win_test.py
@@ -119,6 +119,27 @@ class RegWinTestCase(TestCase):
         test = len(test_list) > 5  # Their should be a lot more than 5 items
         self.assertTrue(test)
 
+    @skipIf(not sys.platform.startswith("win"), "requires Windows OS")
+    def test_list_values_fail(self):
+        '''
+        Test - List the values under a subkey which does not exist.
+        '''
+        subkey = 'ThisIsJunkItDoesNotExistIhope'
+        test_list = win_mod_reg.list_values('HKEY_LOCAL_MACHINE', subkey)
+        # returns a tuple with first item false, and second item a reason
+        test = isinstance(test_list, tuple) and (not test_list[0])
+        self.assertTrue(test)
+
+    @skipIf(not sys.platform.startswith("win"), "requires Windows OS")
+    def test_list_values(self):
+        '''
+        Test - List the values under a subkey.
+        '''
+        subkey = r'Software\Microsoft\Windows NT\CurrentVersion'
+        test_list = win_mod_reg.list_values('HKEY_LOCAL_MACHINE', subkey)
+        test = len(test_list) > 5  # There should be a lot more than 5 items
+        self.assertTrue(test)
+
     # Not considering this destructive as its writing to a private space
     @skipIf(not sys.platform.startswith("win"), "requires Windows OS")
     def test_set_value_unicode(self):


### PR DESCRIPTION
### What does this PR do?
- Fixes an exception when passing non-existent registry key name to _reg.list_values_.
- Adds unit tests for list_values.
### What issues does this PR fix or reference?
- Passing a non-existent registry key to _reg.list_values_ causes "_UnboundLocalError: local variable 'handle' referenced before assignment_".
### Previous Behavior
- An exception would be thrown when passing a non-existent registry key to _reg.list_values_.
### New Behavior
- _reg.list_values_ no longer throws an exception when passing a non-existent registry key name.
- Adds unit tests for list_values.
### Tests written?

Yes
