### PR TITLE
states/file.prepend: fixes #32915 define file header verbatim, in inp…

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3974,6 +3974,19 @@ def prepend(name,
               - Trust no one unless you have eaten much salt with him.
               - "Salt is born of the purest of parents: the sun and the sea."
 
+    Optionally, require the text to appear exactly as specified
+    (order and position). Combine with multi-line or multiple lines of input.
+
+    .. code-block:: yaml
+
+        /etc/motd:
+          file.prepend:
+            - header: True
+            - text:
+              - This will be the very first line in the file.
+              - The 2nd line, regardless of duplicates elsewhere in the file.
+              - These will be written anew if they do not appear verbatim.
+
     Gather text from multiple template files:
 
     .. code-block:: yaml


### PR DESCRIPTION
### What does this PR do?

It adds a new boolean to states/file.py def prepend which makes the outcome of this state arguably more intuitive.
### What issues does this PR fix or reference?

This address #32915 
### Previous Behavior

The user could define text to be prepended to a file, but lines which already occurred elsewhere in the file were not prepended. This led to predictable, but unexpected results.
### New Behavior

The user is able to use a new kwarg boolean to state that (s)he wants to have the input appear exactly as entered, at the very top of the target file.
### Tests written?

No. But developed through manual test runs.
