### PR TITLE
Prevent salt-cloud from hanging when spinning up new Vultr instances

### DIFF
--- a/salt/cloud/clouds/vultrpy.py
+++ b/salt/cloud/clouds/vultrpy.py
@@ -152,7 +152,11 @@ def destroy(name):
     '''
     node = show_instance(name, call='action')
     params = {'SUBID': node['SUBID']}
-    return _query('server/destroy', method='POST', decode=False, data=params)
+    result = _query('server/destroy', method='POST', decode=False, data=params)
+    if result['body'] == '' and result['text'] == '':
+        return True
+    return result
+
 
 
 def stop(*args, **kwargs):
@@ -391,7 +395,6 @@ def _query(path, method='GET', data=None, params=None, header_dict=None, decode=
         hide_fields=['api_key'],
         opts=__opts__,
     )
-
     if 'dict' in result:
         return result['dict']
 

--- a/salt/cloud/clouds/vultrpy.py
+++ b/salt/cloud/clouds/vultrpy.py
@@ -39,6 +39,7 @@ __virtualname__ = 'vultr'
 
 DETAILS = {}
 
+
 def __virtual__():
     '''
     Set up the Vultr functions and check for configurations
@@ -59,8 +60,12 @@ def get_configured_provider():
         ('api_key',)
     )
 
-def _cache_provider_details(conn=None):
 
+def _cache_provider_details(conn=None):
+    '''
+    Provide a place to hang onto results of --list-[locations|sizes|images]
+    so we don't have to go out to the API and get them every time.
+    '''
     DETAILS['avail_locations'] = {}
     DETAILS['avail_sizes'] = {}
     DETAILS['avail_images'] = {}
@@ -158,7 +163,6 @@ def destroy(name):
     return result
 
 
-
 def stop(*args, **kwargs):
     '''
     Execute a "stop" action on a VM
@@ -199,6 +203,7 @@ def _lookup_vultrid(which_key, availkey, keyname):
         return DETAILS[availkey][which_key][keyname]
     except KeyError:
         return False
+
 
 def create(vm_):
     '''

--- a/tests/integration/cloud/providers/vultr.py
+++ b/tests/integration/cloud/providers/vultr.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+'''
+Integration tests for Vultr
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+import os
+import random
+import string
+
+# Import Salt Testing Libs
+from salttesting import skipIf
+from salttesting.helpers import ensure_in_syspath, expensiveTest
+
+ensure_in_syspath('../../../')
+
+# Import Salt Libs
+import integration
+from salt.config import cloud_providers_config
+
+# Import 3rd-party libs
+from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
+
+
+def __random_name(size=6):
+    '''
+    Generates a random cloud instance name
+    '''
+    return 'CLOUD-TEST-' + ''.join(
+        random.choice(string.ascii_uppercase + string.digits)
+        for x in range(size)
+    )
+
+# Create the cloud instance name to be used throughout the tests
+INSTANCE_NAME = __random_name()
+PROVIDER_NAME = 'digital_ocean'
+
+
+@skipIf(True, 'Valid provider configs are not available for the DigitalOcean v1 API '
+              'in conjunction with the configs needed for v2 API.')
+class VultrTest(integration.ShellCase):
+    '''
+    Integration tests for the DigitalOcean cloud provider in Salt-Cloud
+    '''
+
+    @expensiveTest
+    def setUp(self):
+        '''
+        Sets up the test requirements
+        '''
+        super(VultrTest, self).setUp()
+
+        # check if appropriate cloud provider and profile files are present
+        profile_str = 'digitalocean-config'
+        providers = self.run_cloud('--list-providers')
+        if profile_str + ':' not in providers:
+            self.skipTest(
+                'Configuration file for {0} was not found. Check {0}.conf files '
+                'in tests/integration/files/conf/cloud.*.d/ to run these tests.'
+                .format(PROVIDER_NAME)
+            )
+
+        # check if api_key, ssh_key_file, and ssh_key_names are present
+        config = cloud_providers_config(
+            os.path.join(
+                integration.FILES,
+                'conf',
+                'cloud.providers.d',
+                PROVIDER_NAME + '.conf'
+            )
+        )
+
+        api_key = config[profile_str][PROVIDER_NAME]['api_key']
+        ssh_file = config[profile_str][PROVIDER_NAME]['ssh_key_file']
+        ssh_name = config[profile_str][PROVIDER_NAME]['ssh_key_name']
+
+        if api_key == '' or ssh_file == '' or ssh_name == '':
+            self.skipTest(
+                'An API key, an ssh key file, and an ssh key name '
+                'must be provided to run these tests. Check '
+                'tests/integration/files/conf/cloud.providers.d/{0}.conf'
+                .format(PROVIDER_NAME)
+            )
+
+    def test_list_images(self):
+        '''
+        Tests the return of running the --list-images command for digital ocean
+        '''
+        image_list = self.run_cloud('--list-images {0}'.format(PROVIDER_NAME))
+        self.assertIn(
+            '14.04 x64',
+            [i.strip() for i in image_list]
+        )
+
+    def test_list_locations(self):
+        '''
+        Tests the return of running the --list-locations command for digital ocean
+        '''
+        _list_locations = self.run_cloud('--list-locations {0}'.format(PROVIDER_NAME))
+        self.assertIn(
+            'New Jersey',
+            [i.strip() for i in _list_locations]
+        )
+
+    def test_list_sizes(self):
+        '''
+        Tests the return of running the --list-sizes command for digital ocean
+        '''
+        _list_sizes = self.run_cloud('--list-sizes {0}'.format(PROVIDER_NAME))
+        self.assertIn(
+            '32768 MB RAM',
+            [i.strip() for i in _list_sizes]
+        )
+
+    def test_key_management(self):
+        '''
+        Test key management
+        '''
+        pub = 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAQQDDHr/jh2Jy4yALcK4JyWbVkPRaWmhck3IgCoeOO3z1e2dBowLh64QAM+Qb72pxekALga2oi4GvT+TlWNhzPH4V example'
+        finger_print = '3b:16:bf:e4:8b:00:8b:b8:59:8c:a9:d3:f0:19:45:fa'
+
+        _key = self.run_cloud('-f create_key {0} name="MyPubKey" public_key="{1}"'.format(PROVIDER_NAME, pub))
+
+        # Upload public key
+        self.assertIn(
+            finger_print,
+            [i.strip() for i in _key]
+        )
+
+        try:
+            # List all keys
+            list_keypairs = self.run_cloud('-f list_keypairs {0}'.format(PROVIDER_NAME))
+
+            self.assertIn(
+                finger_print,
+                [i.strip() for i in list_keypairs]
+            )
+
+            # List key
+            show_keypair = self.run_cloud('-f show_keypair {0} keyname={1}'.format(PROVIDER_NAME, 'MyPubKey'))
+
+            self.assertIn(
+                finger_print,
+                [i.strip() for i in show_keypair]
+            )
+        except AssertionError:
+            # Delete the public key if the above assertions fail
+            self.run_cloud('-f remove_key {0} id={1}'.format(PROVIDER_NAME, finger_print))
+            raise
+
+        # Delete public key
+        self.assertTrue(self.run_cloud('-f remove_key {0} id={1}'.format(PROVIDER_NAME, finger_print)))
+
+    def test_instance(self):
+        '''
+        Test creating an instance on Vultr
+        '''
+        # check if instance with salt installed returned
+        try:
+            self.assertIn(
+                INSTANCE_NAME,
+                [i.strip() for i in self.run_cloud('-p vultr-test {0}'.format(INSTANCE_NAME))]
+            )
+        except AssertionError:
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
+            raise
+
+        # delete the instance
+        try:
+            self.assertIn(
+                'True',
+                [i.strip() for i in self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))]
+            )
+        except AssertionError:
+            raise
+
+        # Final clean-up of created instance, in case something went wrong.
+        # This was originally in a tearDown function, but that didn't make sense
+        # To run this for each test when not all tests create instances.
+        if INSTANCE_NAME in [i.strip() for i in self.run_cloud('--query')]:
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(VultrTest)

--- a/tests/integration/cloud/providers/vultr.py
+++ b/tests/integration/cloud/providers/vultr.py
@@ -11,7 +11,6 @@ import string
 import time
 
 # Import Salt Testing Libs
-from salttesting import skipIf
 from salttesting.helpers import ensure_in_syspath, expensiveTest
 
 ensure_in_syspath('../../../')
@@ -84,7 +83,7 @@ class VultrTest(integration.ShellCase):
 
     def test_list_images(self):
         '''
-        Tests the return of running the --list-images command for Vultr 
+        Tests the return of running the --list-images command for Vultr
         '''
         image_list = self.run_cloud('--list-images {0}'.format(PROVIDER_NAME))
 

--- a/tests/integration/files/conf/cloud.providers.d/vultr.conf
+++ b/tests/integration/files/conf/cloud.providers.d/vultr.conf
@@ -1,0 +1,6 @@
+vultr-config:
+  provider: vultr
+  api_key: asdfhlkasdjfklsdfj;slkdfjas;dlkj
+  ssh_key_file: '/root/.ssh/vultr_test.pub'
+  ssh_key_name: 'vultr_test'
+  location: New Jersey


### PR DESCRIPTION
### What does this PR do?

Returns better result codes so salt-cloud won't hang waiting forever for Vultr
### What issues does this PR fix or reference?
#31388
### Previous Behavior

Salt-cloud would hang waiting for Vultr because the vultrpy.py driver was returning an empty dictionary in some places instead of 'False'
### New Behavior

I haven't been able to make salt-cloud hang since adding these fixes.

In addition, I added the ability for the driver to accept names for sizes, images, and locations instead of just IDs.
### Tests written?

YES!  Woohoo, we now have basic integration tests for Vultr
