### PR TITLE
verify_socket: print interface:port in error msg

### DIFF
--- a/salt/pillar/stack.py
+++ b/salt/pillar/stack.py
@@ -412,7 +412,7 @@ def _process_stack_cfg(cfg, stack, minion_id, pillar):
         "minion_id": minion_id,
         "pillar": pillar,
         })
-    for path in jenv.get_template(filename).render(stack=stack).splitlines():
+    for path in _parse_top_cfg(jenv.get_template(filename).render(stack=stack)):
         try:
             obj = yaml.safe_load(jenv.get_template(path).render(stack=stack))
             if not isinstance(obj, dict):
@@ -489,3 +489,14 @@ def _merge_list(stack, obj):
         return obj + stack
     else:
         return stack + obj
+
+
+def _parse_top_cfg(content):
+    """Allow top_cfg to be YAML"""
+    try:
+        obj = yaml.safe_load(content)
+        if isinstance(obj, list):
+            return obj
+    except Exception as e:
+        pass
+    return content.splitlines()

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -117,32 +117,27 @@ def verify_socket(interface, pub_port, ret_port):
     '''
 
     addr_family = lookup_family(interface)
-    pubsock = socket.socket(addr_family, socket.SOCK_STREAM)
-    retsock = socket.socket(addr_family, socket.SOCK_STREAM)
-    try:
-        pubsock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        pubsock.bind((interface, int(pub_port)))
-        pubsock.close()
-        retsock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        retsock.bind((interface, int(ret_port)))
-        retsock.close()
-        result = True
-    except Exception as exc:
-        if exc.args:
-            msg = ('Unable to bind socket, error: {0}'.format(str(exc)))
-        else:
-            msg = ('Unable to bind socket, this might not be a problem.'
-                   ' Is there another salt-master running?')
-        if is_console_configured():
-            log.warning(msg)
-        else:
-            sys.stderr.write('WARNING: {0}\n'.format(msg))
-        result = False
-    finally:
-        pubsock.close()
-        retsock.close()
+    for port in pub_port, ret_port:
+        sock = socket.socket(addr_family, socket.SOCK_STREAM)
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind((interface, int(port)))
+        except Exception as exc:
+            msg = 'Unable to bind socket {}:{}'.format(interface, port)
+            if exc.args:
+                msg = '{}, error: {}'.format(msg, str(exc))
+            else:
+                msg = '{}, this might not be a problem.'.format(msg)
+            msg += ' Is there another salt-master running?'
+            if is_console_configured():
+                log.warning(msg)
+            else:
+                sys.stderr.write('WARNING: {0}\n'.format(msg))
+            return False
+        finally:
+            sock.close()
 
-    return result
+    return True
 
 
 def verify_files(files, user):


### PR DESCRIPTION
### What does this PR do?

Improves error message when salt master can't bind to an interface:port
### What issues does this PR fix or reference?

If you know what port it is, makes it easier to find the process. It could be 4505, but might be 4506. Printing the port allows you to run `lsof -i <interface>:<port>` to get the process id.
### Previous Behavior

```
Unable to bind socket, error: [Errno 98] Address already in use
```
### New Behavior

```
Unable to bind socket 0.0.0.0:4505, error: [Errno 98] Address already in use Is there another salt-master running?
```
### Tests written?

No
