### PR TITLE
pillar.stack: allow yaml files to reference previous yml file values

### DIFF
--- a/salt/pillar/stack.py
+++ b/salt/pillar/stack.py
@@ -107,7 +107,8 @@ The following variables are available in jinja2 templating of PillarStack
 configuration files:
 
 - ``pillar``: the pillar data (as passed by Salt to our ``ext_pillar``
-  function)
+  function). NOTE: If all pillar data is managed by this external pillar,
+  stack ``yaml`` files can refer to previously parsed stack ``yaml`` files.
 - ``minion_id``: the minion id ;-)
 - ``__opts__``: a dictionary of mostly Salt configuration options
 - ``__grains__``: a dictionary of the grains of the minion making this pillar
@@ -405,6 +406,14 @@ def ext_pillar(minion_id, pillar, *args, **kwargs):
 def _process_stack_cfg(cfg, stack, minion_id, pillar):
     basedir, filename = os.path.split(cfg)
     jenv = Environment(loader=FileSystemLoader(basedir))
+    if not pillar:
+        # Allow yaml files to refer to previous file values.
+        # We can't do this if there are other pillar values, since
+        # those pillar values would have to be merged according to
+        # Salt's pillar merging strategy, which would complicate the
+        # code. This feature is for configurations managed completely
+        # by pillar stack.
+        pillar = stack
     jenv.globals.update({
         "__opts__": __opts__,
         "__salt__": __salt__,


### PR DESCRIPTION
### What does this PR do?

Enables previously parsed pillar.stack YAML file values to be referenced by subsequent YAML files.
### What issues does this PR fix or reference?

One of the features of pillar.stack is that it allows you to reference pillars in a pillar. This fix allows you to reference pillars as well as the pillar values of previous files in the pillar.stack. 

There is one caveat: you can only do this if you have not defined any other pillar values before pillar.stack executes. This means that pillar/top.sls is empty. This feature is useful if you switch all your pillar config to pillar.stack. 

The reason this restriction is in place is that in order to merge previously defined, non-pillar.stack values, you have to use the salt merging strategy that would be in place once pillar.stack returns its values. This behavior is tricky to replicate, and it conflicts with the code that merges the pillar stack strategies. If there are no previously defined pillar values, then there is no merging necessary before pillar.stack executes in a semantically consistent manner.
### Tests written?

No.
