### PR TITLE
Added some more docs for master and minion config settings

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -64,6 +64,9 @@
 # key_logfile, pidfile:
 #root_dir: /
 
+# The path to the master's configuration file.
+#conf_file: /etc/salt/master
+
 # Directory used to store public key data:
 #pki_dir: /etc/salt/pki/master
 
@@ -87,6 +90,10 @@
 
 # Set the number of hours to keep old job information in the job cache:
 #keep_jobs: 24
+
+# The number of seconds to wait when the client is requesting information
+# about running jobs.
+#gather_job_timeout: 10
 
 # Set the default timeout for the salt command and api. The default is 5
 # seconds.

--- a/conf/minion
+++ b/conf/minion
@@ -67,6 +67,9 @@
 # sock_dir, pidfile.
 #root_dir: /
 
+# The path to the minion's configuration file.
+#conf_file: /etc/salt/minion
+
 # The directory to store the pki information in
 #pki_dir: /etc/salt/pki/minion
 

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -198,6 +198,19 @@ an alternative root.
     :conf_master:`log_file`, :conf_master:`autosign_file`,
     :conf_master:`autoreject_file`, :conf_master:`pidfile`.
 
+.. conf_master:: conf_file
+
+``conf_file``
+-------------
+
+Default: ``/etc/salt/master``
+
+The path to the master's configuration file.
+
+.. code-block:: yaml
+
+    conf_file: /etc/salt/master
+
 .. conf_master:: pki_dir
 
 ``pki_dir``
@@ -278,6 +291,22 @@ Set the number of hours to keep old job information.
 .. code-block:: yaml
 
     keep_jobs: 24
+
+.. conf_master:: gather_job_timeout
+
+``gather_job_timeout``
+----------------------
+
+.. versionadded:: 2014.7.0
+
+Default: ``10``
+
+The number of seconds to wait when the client is requesting information
+about running jobs.
+
+.. code-block:: yaml
+
+    gather_job_timeout: 10
 
 .. conf_master:: timeout
 
@@ -480,6 +509,23 @@ Store all event returns _except_ the tags in a blacklist.
     event_return_blacklist:
       - salt/master/not_this_tag
       - salt/master/or_this_one
+
+.. conf_master:: max_event_size
+
+``max_event_size``
+------------------
+
+.. versionadded:: 2014.7.0
+
+Default: ``1048576``
+
+Passing very large events can cause the minion to consume large amounts of
+memory. This value tunes the maximum size of a message allowed onto the
+master event bus. The value is expressed in bytes.
+
+.. code-block:: yaml
+
+    max_event_size: 1048576
 
 .. conf_master:: master_job_cache
 
@@ -950,6 +996,40 @@ The renderer to use on the minions to render the state data.
 .. code-block:: yaml
 
     renderer: yaml_jinja
+
+.. conf_master:: jinja_trim_blocks
+
+``jinja_trim_blocks``
+---------------------
+
+.. versionadded:: 2014.1.0
+
+Default: ``False``
+
+If this is set to ``True``, the first newline after a Jinja block is
+removed (block, not variable tag!). Defaults to ``False`` and corresponds
+to the Jinja environment init variable ``trim_blocks``.
+
+.. code-block:: yaml
+
+    jinja_trim_blocks: False
+
+.. conf_master:: jinja_lstrip_blocks
+
+``jinja_lstrip_blocks``
+-----------------------
+
+.. versionadded:: 2014.1.0
+
+Default: ``False``
+
+If this is set to ``True``, leading spaces and tabs are stripped from the
+start of a line to a block. Defaults to ``False`` and corresponds to the
+Jinja environment init variable ``lstrip_blocks``.
+
+.. code-block:: yaml
+
+    jinja_lstrip_blocks: False
 
 .. conf_master:: failhard
 

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -107,6 +107,25 @@ to manage the minion's master setting from an execution module. By simply
 changing the algorithm in the module to return a new master ip/fqdn, restart
 the minion and it will connect to the new master.
 
+.. conf_minion:: max_event_size
+
+``max_event_size``
+------------------
+
+.. versionadded:: 2014.7.0
+
+Default: ``1048576``
+
+Passing very large events can cause the minion to consume large amounts of
+memory. This value tunes the maximum size of a message allowed onto the
+minion event bus. The value is expressed in bytes.
+
+.. code-block:: yaml
+
+    max_event_size: 1048576
+
+.. conf_minion:: master_alive_interval
+
 ``master_alive_interval``
 -------------------------
 
@@ -119,6 +138,8 @@ to the next master in the list if it finds the existing one is dead.
 .. code-block:: yaml
 
     master_alive_interval: 30
+
+.. conf_minion:: master_shuffle
 
 ``master_shuffle``
 ------------------
@@ -134,6 +155,8 @@ Python's :func:`random.shuffle <python2:random.shuffle>` method.
 .. code-block:: yaml
 
     master_shuffle: True
+
+.. conf_minion:: random_master
 
 ``random_master``
 -----------------
@@ -233,6 +256,19 @@ This directory is prepended to the following options: :conf_minion:`pki_dir`,
 .. code-block:: yaml
 
     root_dir: /
+
+.. conf_minion:: conf_file
+
+``conf_file``
+-------------
+
+Default: ``/etc/salt/minion``
+
+The path to the minion's configuration file.
+
+.. code-block:: yaml
+
+    conf_file: /etc/salt/minion
 
 .. conf_minion:: pki_dir
 
@@ -433,6 +469,21 @@ master.
 
     acceptance_wait_time: 10
 
+.. conf_minion:: acceptance_wait_time_max
+
+``acceptance_wait_time_max``
+----------------------------
+
+Default: ``0``
+
+The maximum number of seconds to wait until attempting to re-authenticate
+with the master. If set, the wait will increase by :conf_minion:`acceptance_wait_time`
+seconds each iteration.
+
+.. code-block:: yaml
+
+    acceptance_wait_time_max: 0
+
 .. conf_minion:: random_reauth_delay
 
 ``random_reauth_delay``
@@ -468,20 +519,42 @@ when trying to authenticate to the master.
 
     auth_tries: 7
 
-.. conf_minion:: acceptance_wait_time_max
+.. conf_minion:: auth_timeout
 
-``acceptance_wait_time_max``
-----------------------------
+``auth_timeout``
+----------------
 
-Default: ``0``
+.. versionadded:: 2014.7.0
 
-The maximum number of seconds to wait until attempting to re\-authenticate
-with the master. If set, the wait will increase by acceptance_wait_time
-seconds each iteration.
+Default: ``60``
+
+When waiting for a master to accept the minion's public key, salt will
+continuously attempt to reconnect until successful. This is the timeout value,
+in seconds, for each individual attempt. After this timeout expires, the minion
+will wait for :conf_minion:`acceptance_wait_time` seconds before trying again.
+Unless your master is under unusually heavy load, this should be left at the
+default.
 
 .. code-block:: yaml
 
-    acceptance_wait_time_max: 0
+    auth_timeout: 60
+
+.. conf_minion:: auth_safemode
+
+``auth_safemode``
+-----------------
+
+.. versionadded:: 2014.7.0
+
+Default: ``False``
+
+If authentication fails due to SaltReqTimeoutError during a ping_interval,
+this setting, when set to ``True``, will cause a sub minion process to
+restart.
+
+.. code-block:: yaml
+
+    auth_safemode: False
 
 .. conf_minion:: recon_default
 

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -549,7 +549,7 @@ default.
 Default: ``False``
 
 If authentication fails due to SaltReqTimeoutError during a ping_interval,
-this setting, when set to ``True``, will cause a sub minion process to
+this setting, when set to ``True``, will cause a sub-minion process to
 restart.
 
 .. code-block:: yaml


### PR DESCRIPTION
Configs addressed:
- auth_safemode
- auth_timeout
- conf_file
- gather_job_timeout
- jinja_lstrip_blocks
- jinja_trim_blocks
- max_event_size

Refs #32400
