### PR TITLE
Ignore retcode when checking service's status

### DIFF
--- a/salt/modules/debian_service.py
+++ b/salt/modules/debian_service.py
@@ -234,7 +234,7 @@ def status(name, sig=None):
     if sig:
         return bool(__salt__['status.pid'](sig))
     cmd = _service_cmd(name, 'status')
-    return not __salt__['cmd.retcode'](cmd)
+    return not __salt__['cmd.retcode'](cmd, ignore_retcode=True)
 
 
 def _osrel():

--- a/salt/modules/freebsdservice.py
+++ b/salt/modules/freebsdservice.py
@@ -46,7 +46,7 @@ def _cmd():
     '''
     service = salt.utils.which('service')
     if not service:
-        raise CommandNotFoundError
+        raise CommandNotFoundError('\'service\' command not found')
     return service
 
 

--- a/salt/modules/freebsdservice.py
+++ b/salt/modules/freebsdservice.py
@@ -376,4 +376,6 @@ def status(name, sig=None):
     if sig:
         return bool(__salt__['status.pid'](sig))
     cmd = '{0} {1} onestatus'.format(_cmd(), name)
-    return not __salt__['cmd.retcode'](cmd, python_shell=False)
+    return not __salt__['cmd.retcode'](cmd,
+                                       python_shell=False,
+                                       ignore_retcode=True)

--- a/salt/modules/netbsdservice.py
+++ b/salt/modules/netbsdservice.py
@@ -115,7 +115,7 @@ def status(name, sig=None):
     if sig:
         return bool(__salt__['status.pid'](sig))
     cmd = '/etc/rc.d/{0} onestatus'.format(name)
-    return not __salt__['cmd.retcode'](cmd)
+    return not __salt__['cmd.retcode'](cmd, ignore_retcode=True)
 
 
 def _get_svc(rcd, service_status):

--- a/salt/modules/openbsdservice.py
+++ b/salt/modules/openbsdservice.py
@@ -104,7 +104,7 @@ def status(name, sig=None):
     if sig:
         return bool(__salt__['status.pid'](sig))
     cmd = '/etc/rc.d/{0} -f check'.format(name)
-    return not __salt__['cmd.retcode'](cmd)
+    return not __salt__['cmd.retcode'](cmd, ignore_retcode=True)
 
 
 def reload_(name):


### PR DESCRIPTION
This prevents spurious errors from being logged when a nonexistant service is
polled, or if the service is not running.

Fixes #23435.
Fixes #26062.
