### PR TITLE
Fix documentation typo in salt.modules.state.high

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -211,7 +211,7 @@ def high(data, test=False, queue=False, **kwargs):
     '''
     Execute the compound calls stored in a single set of high data
 
-    This function is mostly intended for testing the state system andis not
+    This function is mostly intended for testing the state system and is not
     likely to be needed in everyday usage.
 
     CLI Example:


### PR DESCRIPTION
salt.modules.state.high documentation has typo "andis" instead of "and is".
