### PR TITLE
Fix iptables --match-set (#23643)

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -1178,7 +1178,7 @@ def _parser():
     ## sctp
     add_arg('--chunk-types', dest='chunk-types', action='append')
     ## set
-    add_arg('--match-set', dest='match-set', action='append', nargs=2)
+    add_arg('--match-set', dest='match-set', action='append')
     add_arg('--return-nomatch', dest='return-nomatch', action='append')
     add_arg('--update-counters', dest='update-counters', action='append')
     add_arg('--update-subcounters', dest='update-subcounters', action='append')


### PR DESCRIPTION
### What does this PR do?

Function is expecting two arguments. But after processing state only one
parameter (it contain two words) is pushed into list of options.
This patch reverts the parsing of "iptables --match-set" to the behaviour
of salt v2014.*.
### What issues does this PR fix or reference?

This is a backport of https://github.com/saltstack/salt/pull/28325

Closes #23643
