### PR TITLE
Cleanup comments in smbios.get output (fixes #33266)

### DIFF
--- a/salt/modules/smbios.py
+++ b/salt/modules/smbios.py
@@ -86,6 +86,11 @@ def get(string, clean=True):
     '''
 
     val = _dmidecoder('-s {0}'.format(string)).strip()
+
+    # Sometimes dmidecode delivers comments in strings.
+    # Don't.
+    val = '\n'.join([v for v in val.split('\n') if not v.startswith('#')])
+
     if not clean or _dmi_isclean(string, val):
         return val
 


### PR DESCRIPTION
### What does this PR do?

Sometimes `dmidecode` will output additional commentary text in strings:

```
root@n01:~# dmidecode -s system-manufacturer                                                                                                                                                                                        
# SMBIOS implementations newer than version 2.8 are not
# fully supported by this version of dmidecode.
Supermicro
```

This PR filters those out.
### What issues does this PR fix or reference?

 https://github.com/saltstack/salt/issues/33266
### Previous Behavior

Comments are inadvertently returned in the `smbios.get` returned string
### New Behavior

Comments are filtered out of the returned  `smbios.get` string
