### PR TITLE
Catch exception raised from invalid verify_options

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -426,6 +426,7 @@ def _find_install_targets(name=None,
     to_reinstall = {}
     problems = []
     warnings = []
+    failed_verify = False
     for key, val in six.iteritems(desired):
         cver = cur_pkgs.get(key, [])
         # Package not yet installed, so add to targets
@@ -475,8 +476,8 @@ def _find_install_targets(name=None,
                             ignore_types=ignore_types,
                             verify_options=verify_options
                         )
-                    except SaltInvocationError as exc:
-                        problems.append(exc.strerror)
+                    except (CommandExecutionError, SaltInvocationError) as exc:
+                        failed_verify = exc.strerror
                         continue
                     if verify_result:
                         to_reinstall[key] = val
@@ -503,8 +504,8 @@ def _find_install_targets(name=None,
                         key,
                         ignore_types=ignore_types,
                         verify_options=verify_options)
-                except SaltInvocationError as exc:
-                    problems.append(exc.strerror)
+                except (CommandExecutionError, SaltInvocationError) as exc:
+                    failed_verify = exc.strerror
                     continue
                 if verify_result:
                     to_reinstall[key] = val
@@ -516,6 +517,9 @@ def _find_install_targets(name=None,
                     .format(cver, val)
                 )
                 targets[key] = val
+
+    if failed_verify:
+        problems.append(failed_verify)
 
     if problems:
         return {'name': name,

--- a/tests/unit/modules/rpm_test.py
+++ b/tests/unit/modules/rpm_test.py
@@ -48,8 +48,11 @@ class RpmTestCase(TestCase):
         Test if it runs an rpm -Va on a system,
         and returns the results in a dict
         '''
-        mock = MagicMock(return_value='')
-        with patch.dict(rpm.__salt__, {'cmd.run': mock}):
+        mock = MagicMock(return_value={'stdout': '',
+                                       'stderr': '',
+                                       'retcode': 0,
+                                       'pid': 12345})
+        with patch.dict(rpm.__salt__, {'cmd.run_all': mock}):
             self.assertDictEqual(rpm.verify('httpd'), {})
 
     # 'file_list' function tests: 1


### PR DESCRIPTION
This fails the state gracefully in these cases.

Refs: https://github.com/saltstack/salt/pull/33147/files/6b97161293aefcb2a7f932057ccd416c7989ab94#r63577507
