### PR TITLE
remove redundant, incorrect sudo_runas config documentation

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -60,11 +60,15 @@
 # The user to run salt.
 #user: root
 
-# Setting sudo_user will cause salt to run all execution modules under an sudo
-# to the user given in sudo_user.  The user under which the salt minion process
-# itself runs will still be that provided in the user config above, but all
-# execution modules run by the minion will be rerouted through sudo.
-#sudo_user: saltdev
+# The user to run salt remote execution commands as via sudo. If this option is
+# enabled then sudo will be used to change the active user executing the remote
+# command. If enabled the user will need to be allowed access via the sudoers
+# file for the user that the salt minion is configured to run as. The most
+# common option would be to use the root user. If this option is set the user
+# option should also be set to a non-root user. If migrating from a root minion
+# to a non root minion the minion cache should be cleared and the minion pki
+# directory will need to be changed to the ownership of the new user.
+#sudo_user: root
 
 # Specify the location of the daemon process ID file.
 #pidfile: /var/run/salt-minion.pid

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -196,12 +196,12 @@ The user to run the Salt processes
 
     user: root
 
-.. conf_minion:: sudo_runas
+.. conf_minion:: sudo_user
 
-``sudo_runas``
+``sudo_user``
 --------------
 
-Default: None
+Default: ``''``
 
 The user to run salt remote execution commands as via sudo. If this option is
 enabled then sudo will be used to change the active user executing the remote
@@ -215,24 +215,6 @@ need to be changed to the ownership of the new user.
 .. code-block:: yaml
 
     sudo_user: root
-
-.. conf_minion:: sudo_user
-
-``sudo_user``
--------------
-
-Default: ``''``
-
-Setting ``sudo_user`` will cause salt to run all execution modules under a
-sudo to the user given in ``sudo_user``.  The user under which the salt minion
-process itself runs will still be that provided in :conf_minion:`user` above,
-but all execution modules run by the minion will be rerouted through sudo.
-
-.. code-block:: yaml
-
-    sudo_user: saltadm
-
-.. conf_minion:: pidfile
 
 
 ``pidfile``


### PR DESCRIPTION
### What does this PR do?

`sudo_runas` was renamed to `sudo_user` but the old documentation was not removed.
### What issues does this PR fix or reference?
#20226, #22480, #25089
### Tests written?

No
