### PR TITLE
Update job_cache and keep_jobs docs to be more specific to their behavior

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -287,7 +287,8 @@ Verify and set permissions on configuration directories at startup.
 
 Default: ``24``
 
-Set the number of hours to keep old job information.
+Set the number of hours to keep old job information. Note that setting this option
+to ``0`` disables the cache cleaner.
 
 .. code-block:: yaml
 
@@ -399,12 +400,32 @@ grains for the master.
 
 Default: ``True``
 
-The master maintains a job cache. While this is a great addition, it can be
-a burden on the master for larger deployments (over 5000 minions).
+The master maintains a temporary job cache. While this is a great addition, it
+can be a burden on the master for larger deployments (over 5000 minions).
 Disabling the job cache will make previously executed jobs unavailable to
 the jobs system and is not generally recommended. Normally it is wise to make
 sure the master has access to a faster IO system or a tmpfs is mounted to the
 jobs dir.
+
+.. code-block:: yaml
+
+    job_cache: True
+
+.. note::
+
+    Setting the ``job_cache`` to ``False`` will not cache minion returns, but
+    the JID directory for each job is still created. The creation of the JID
+    directories is necessary because Salt uses those directories to check for
+    JID collisions. By setting this option to ``False``, the job cache
+    directory, which is ``/var/cache/salt/master/jobs/`` by default, will be
+    smaller, but the JID directories will still be present.
+
+    Note that the :conf_master:`keep_jobs` option can be set to a lower value,
+    such as ``1``, to limit the number of hours jobs are stored in the job
+    cache. (The default is 24 hours.)
+
+    Please see the :ref:`Managing the Job Cache <managing_the_job_cache>`
+    documentation for more information.
 
 .. conf_master:: minion_data_cache
 

--- a/doc/topics/jobs/job_cache.rst
+++ b/doc/topics/jobs/job_cache.rst
@@ -1,3 +1,5 @@
+.. _managing_the_job_cache:
+
 ======================
 Managing the Job Cache
 ======================
@@ -26,6 +28,37 @@ Salt Master configuration file. The value passed in is measured via hours:
 .. code-block:: yaml
 
     keep_jobs: 24
+
+Reducing the Size of the Default Job Cache
+------------------------------------------
+
+The Default Job Cache can sometimes be a burden on larger deployments (over 5000
+minions). Disabling the job cache will make previously executed jobs unavailable
+to the jobs system and is not generally recommended. Normally it is wise to make
+sure the master has access to a faster IO system or a tmpfs is mounted to the
+jobs dir.
+
+However, you can disable the :conf_master:`job_cache` by setting it to ``False``
+in the Salt Master configuration file. Setting this value to ``False`` means that
+the Salt Master will no longer cache minion returns, but a JID directory and ``jid``
+file for each job will still be created. This JID directory is necessary for
+checking for and preventing JID collisions.
+
+The default location for the job cache is in the ``/var/cache/salt/master/jobs/``
+directory.
+
+Setting the :conf_master:`job_cache`` to ``False`` in addition to setting
+the :conf_master:`keep_jobs` option to a smaller value, such as ``1``, in the Salt
+Master configuration file will reduce the size of the Default Job Cache, and thus
+the burden on the Salt Master.
+
+.. note::
+
+    Changing the ``keep_jobs`` option sets the number of hours to keep old job
+    information and defaults to ``24`` hours. Do not set this value to ``0`` when
+    trying to make the cache cleaner run more frequently, as this means the cache
+    cleaner will never run.
+
 
 Additional Job Cache Options
 ============================

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -379,19 +379,44 @@ def clean_old_jobs():
         if not os.path.exists(jid_root):
             return
 
+        # Keep track of any empty t_path dirs that need to be removed later
+        dirs_to_remove = set()
+
         for top in os.listdir(jid_root):
             t_path = os.path.join(jid_root, top)
-            for final in os.listdir(t_path):
+
+            # Check if there are any stray/empty JID t_path dirs
+            t_path_dirs = os.listdir(t_path)
+            if not t_path_dirs and t_path not in dirs_to_remove:
+                dirs_to_remove.add(t_path)
+                continue
+
+            for final in t_path_dirs:
                 f_path = os.path.join(t_path, final)
                 jid_file = os.path.join(f_path, 'jid')
                 if not os.path.isfile(jid_file):
                     # No jid file means corrupted cache entry, scrub it
-                    shutil.rmtree(f_path)
+                    # by removing the entire t_path directory
+                    shutil.rmtree(t_path)
                 else:
                     jid_ctime = os.stat(jid_file).st_ctime
                     hours_difference = (cur - jid_ctime) / 3600.0
                     if hours_difference > __opts__['keep_jobs']:
-                        shutil.rmtree(f_path)
+                        # Remove the entire t_path from the original JID dir
+                        shutil.rmtree(t_path)
+
+        # Remove empty JID dirs from job cache, if they're old enough.
+        # JID dirs may be empty either from a previous cache-clean with the bug
+        # Listed in #29286 still present, or the JID dir was only recently made
+        # And the jid file hasn't been created yet.
+        if dirs_to_remove:
+            for t_path in dirs_to_remove:
+                # Checking the time again prevents a possible race condition where
+                # t_path JID dirs were created, but not yet populated by a jid file.
+                t_path_ctime = os.stat(t_path).st_ctime
+                hours_difference = (cur - t_path_ctime) / 3600.0
+                if hours_difference > __opts__['keep_jobs']:
+                    shutil.rmtree(t_path)
 
 
 def update_endtime(jid, time):

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -14,7 +14,6 @@ import shutil
 import time
 import hashlib
 import bisect
-import time
 
 # Import salt libs
 import salt.payload

--- a/tests/unit/returners/local_cache_test.py
+++ b/tests/unit/returners/local_cache_test.py
@@ -36,6 +36,7 @@ local_cache.__opts__ = {'cachedir': TMP_CACHE_DIR,
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+@destructiveTest
 class LocalCacheCleanOldJobsTestCase(TestCase):
     '''
     Tests for the local_cache.clean_old_jobs function.
@@ -136,7 +137,6 @@ class LocalCacheCleanOldJobsTestCase(TestCase):
         # Assert that the JID dir was removed
         self.assertEqual([], os.listdir(TMP_JID_DIR))
 
-    @destructiveTest
     def _make_tmp_jid_dirs(self, create_files=True):
         '''
         Helper function to set up temporary directories and files used for

--- a/tests/unit/returners/local_cache_test.py
+++ b/tests/unit/returners/local_cache_test.py
@@ -14,7 +14,7 @@ import tempfile
 
 # Import Salt Testing libs
 from salttesting import TestCase, skipIf
-from salttesting.helpers import ensure_in_syspath
+from salttesting.helpers import destructiveTest, ensure_in_syspath
 from salttesting.mock import (
     MagicMock,
     NO_MOCK,
@@ -136,6 +136,7 @@ class LocalCacheCleanOldJobsTestCase(TestCase):
         # Assert that the JID dir was removed
         self.assertEqual([], os.listdir(TMP_JID_DIR))
 
+    @destructiveTest
     def _make_tmp_jid_dirs(self, create_files=True):
         '''
         Helper function to set up temporary directories and files used for

--- a/tests/unit/returners/local_cache_test.py
+++ b/tests/unit/returners/local_cache_test.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+'''
+tests.unit.returners.local_cache_test
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unit tests for the Default Job Cache (local_cache).
+'''
+
+# Import Python libs
+from __future__ import absolute_import
+import os
+import shutil
+import tempfile
+
+# Import Salt Testing libs
+from salttesting import TestCase, skipIf
+from salttesting.helpers import ensure_in_syspath
+from salttesting.mock import (
+    MagicMock,
+    NO_MOCK,
+    NO_MOCK_REASON,
+    patch
+)
+
+ensure_in_syspath('../../')
+
+# Import Salt libs
+import salt.utils
+from salt.returners import local_cache
+
+TMP_CACHE_DIR = '/tmp/salt_test_job_cache/'
+TMP_JID_DIR = '/tmp/salt_test_job_cache/jobs/'
+
+local_cache.__opts__ = {'cachedir': TMP_CACHE_DIR,
+                        'keep_jobs': 1}
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class LocalCacheCleanOldJobsTestCase(TestCase):
+    '''
+    Tests for the local_cache.clean_old_jobs function.
+    '''
+
+    def tearDown(self):
+        '''
+        Clean up after tests.
+
+        Note that a setUp function is not used in this TestCase because the
+        _make_tmp_jid_dirs replaces it.
+        '''
+        if os.path.exists(TMP_CACHE_DIR):
+            shutil.rmtree(TMP_CACHE_DIR)
+
+    @patch('os.path.exists', MagicMock(return_value=False))
+    def test_clean_old_jobs_no_jid_root(self):
+        '''
+        Tests that the function returns None when no jid_root is found.
+        '''
+        self.assertEqual(local_cache.clean_old_jobs(), None)
+
+    def test_clean_old_jobs_empty_jid_dir_removed(self):
+        '''
+        Tests that an empty JID dir is removed when it is old enough to be deleted.
+        '''
+        # Create temp job cache dir without files in it.
+        jid_dir, jid_file = self._make_tmp_jid_dirs(create_files=False)
+
+        # Make sure there are no files in the directory before continuing
+        self.assertEqual(jid_file, None)
+
+        # Call clean_old_jobs function, patching the keep_jobs value with a
+        # very small value to force the call to clean the job.
+        with patch.dict(local_cache.__opts__, {'keep_jobs': 0.00000001}):
+            local_cache.clean_old_jobs()
+
+        # Assert that the JID dir was removed
+        self.assertEqual([], os.listdir(TMP_JID_DIR))
+
+    def test_clean_old_jobs_empty_jid_dir_remains(self):
+        '''
+        Tests that an empty JID dir is NOT removed because it was created within
+        the keep_jobs time frame.
+        '''
+        # Create temp job cache dir without files in it.
+        jid_dir, jid_file = self._make_tmp_jid_dirs(create_files=False)
+
+        # Make sure there are no files in the directory
+        self.assertEqual(jid_file, None)
+
+        # Call clean_old_jobs function
+        local_cache.clean_old_jobs()
+
+        # Get the name of the JID directory that was created to test against
+        jid_dir_name = jid_dir.rpartition('/')[2]
+
+        # Assert the JID directory is still present to be cleaned after keep_jobs interval
+        self.assertEqual([jid_dir_name], os.listdir(TMP_JID_DIR))
+
+    def test_clean_old_jobs_jid_file_corrupted(self):
+        '''
+        Tests that the entire JID dir is removed when the jid_file is not a file.
+        This scenario indicates a corrupted cache entry, so the entire dir is scrubbed.
+        '''
+        # Create temp job cache dir and jid file
+        jid_dir, jid_file = self._make_tmp_jid_dirs()
+
+        # Make sure there is a jid file in a new job cache director
+        jid_dir_name = jid_file.rpartition('/')[2]
+        self.assertEqual(jid_dir_name, 'jid')
+
+        # Even though we created a valid jid file in the _make_tmp_jid_dirs call to get
+        # into the correct loop, we need to mock the 'os.path.isfile' check to force the
+        # "corrupted file" check in the clean_old_jobs call.
+        with patch('os.path.isfile', MagicMock(return_value=False)) as mock:
+            local_cache.clean_old_jobs()
+
+        # Assert that the JID dir was removed
+        self.assertEqual([], os.listdir(TMP_JID_DIR))
+
+    def test_clean_old_jobs_jid_file_is_cleaned(self):
+        '''
+        Test that the entire JID dir is removed when a job is old enough to be removed.
+        '''
+        # Create temp job cache dir and jid file
+        jid_dir, jid_file = self._make_tmp_jid_dirs()
+
+        # Make sure there is a jid directory
+        jid_dir_name = jid_file.rpartition('/')[2]
+        self.assertEqual(jid_dir_name, 'jid')
+
+        # Call clean_old_jobs function, patching the keep_jobs value with a
+        # very small value to force the call to clean the job.
+        with patch.dict(local_cache.__opts__, {'keep_jobs': 0.00000001}):
+            local_cache.clean_old_jobs()
+
+        # Assert that the JID dir was removed
+        self.assertEqual([], os.listdir(TMP_JID_DIR))
+
+    def _make_tmp_jid_dirs(self, create_files=True):
+        '''
+        Helper function to set up temporary directories and files used for
+        testing the clean_old_jobs function.
+
+        Returns a temp_dir name and a jid_file_path. If create_files is False,
+        the jid_file_path will be None.
+        '''
+        # First, create the /tmp/salt_test_job_cache/jobs/ directory to hold jid dirs
+        if not os.path.exists(TMP_JID_DIR):
+            os.makedirs(TMP_JID_DIR)
+
+        # Then create a JID temp file in "/tmp/salt_test_job_cache/"
+        temp_dir = tempfile.mkdtemp(dir=TMP_JID_DIR)
+
+        jid_file_path = None
+        if create_files:
+            dir_name = '/'.join([temp_dir, 'jid'])
+            os.mkdir(dir_name)
+            jid_file_path = '/'.join([dir_name, 'jid'])
+            with salt.utils.fopen(jid_file_path, 'w') as jid_file:
+                jid_file.write('this is a jid file')
+
+        return temp_dir, jid_file_path
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(LocalCacheCleanOldJobsTestCase, needs_daemon=False)


### PR DESCRIPTION
### What does this PR do?

Updates the job_cache and keep_jobs docs to be more accurate about their behavior, especially the `job_cache` setting. When this is set to `False`, it doesn't completely "disable" the job cache. It just makes the corresponding JID collision detection dirs less heavy by disregarding the minion return data.

Also fixed a bug discovered when investigating job_cache/keep_jobs functionality where the jid directory and files were removed by the cache cleaner, but not the original jid clash detection directory created in `/var/cache/salt/master/jobs/`.
### What issues does this PR fix or reference?

Fixes #29286
### Previous Behavior

The cache cleaner removes the jid files and directories from the original top jid directory (which is originally created to hold the jid file and jid/minion dirs) but it doesn't remove the original directory that was created in /var/cache/salt/master/jobs/.

For example, jid dir 30 has been cleaned, but the newest job, 19, has not been cleaned yet. This leaves around a lot of empty directories, causing the job cache to bloat over time:

```
root@rallytime:~# ls /var/cache/salt/master/jobs/
19  30
root@rallytime:~# ls /var/cache/salt/master/jobs/30/
root@rallytime:~# ls /var/cache/salt/master/jobs/19/
f1cca89613752b2fb9a65b1450bec7
```
### New Behavior

The cache cleaner removes the entire jid top directory from `/var/cache/salt/master/jobs`:

```
root@rallytime:~# ls /var/cache/salt/master/jobs/
19
```
### Tests written?

Yes!
