### PR TITLE
Fix master hanging after a request from minion with removed key.

### DIFF
--- a/salt/transport/mixins/auth.py
+++ b/salt/transport/mixins/auth.py
@@ -101,6 +101,9 @@ class AESReqServerMixin(object):
                 pub = RSA.importKey(f.read())
         except (ValueError, IndexError, TypeError):
             return self.crypticle.dumps({})
+        except IOError:
+            log.error('AES key not found')
+            return 'AES key not found'
 
         pret = {}
         cipher = PKCS1_OAEP.new(pub)

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -457,6 +457,9 @@ class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.
         if hasattr(self, '_monitor') and self._monitor is not None:
             self._monitor.stop()
             self._monitor = None
+        if hasattr(self, '_w_monitor') and self._w_monitor is not None:
+            self._w_monitor.stop()
+            self._w_monitor = None
         if hasattr(self, 'clients'):
             self.clients.close()
         self.stream.close()
@@ -484,6 +487,13 @@ class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.
 
         self.context = zmq.Context(1)
         self._socket = self.context.socket(zmq.REP)
+        if HAS_ZMQ_MONITOR and self.opts['zmq_monitor']:
+            # Socket monitor shall be used the only for debug  purposes so using threading doesn't look too bad here
+            import threading
+            self._w_monitor = ZeroMQSocketMonitor(self._socket)
+            t = threading.Thread(target=self._w_monitor.start_poll)
+            t.start()
+
         if self.opts.get('ipc_mode', '') == 'tcp':
             self.w_uri = 'tcp://127.0.0.1:{0}'.format(
                 self.opts.get('tcp_master_workers', 4515)


### PR DESCRIPTION
### What does this PR do?

If a minion key is removed on a master and the master gets a message from the minion MWorker stops responding. The PR fixes this issue.
This happens because an exception occurs when master crypts the response for the minion and the message wasn't sent as a result. MWorker uses ZMQ.REP socket that doesn't receive anything until a reply is sent.
### What issues does this PR fix or reference?
#29674
### Tests written?

No
