### PR TITLE
Expanded documentation for boto_elb state and module

### DIFF
--- a/salt/modules/boto_elb.py
+++ b/salt/modules/boto_elb.py
@@ -415,6 +415,37 @@ def set_attributes(name, attributes, region=None, key=None, keyid=None,
     '''
     Set attributes on an ELB.
 
+    name (string)
+        Name of the ELB instance to set attributes for
+
+    attributes
+        A dict of attributes to set.
+
+        Valid attributes are:
+
+        access_log (dict)
+            enabled (bool)
+                Enable storage of access logs.
+            s3_bucket_name (string)
+                The name of the S3 bucket to place logs.
+            s3_bucket_prefix (string)
+                Prefix for the log file name.
+            emit_interval (int)
+                Interval for storing logs in S3 in minutes. Valid values are
+                5 and 60.
+
+        connection_draining (dict)
+            enabled (bool)
+                Enable connection draining.
+            timeout (int)
+                Maximum allowed time in seconds for sending existing
+                connections to an instance that is deregistering or unhealthy.
+                Default is 300.
+
+        cross_zone_load_balancing (dict)
+            enabled (bool)
+                Enable cross-zone load balancing.
+
     CLI example to set attributes on an ELB::
 
         salt myminion boto_elb.set_attributes myelb '{"access_log": {"enabled": "true", "s3_bucket_name": "mybucket", "s3_bucket_prefix": "mylogs/", "emit_interval": "5"}}' region=us-east-1

--- a/salt/states/boto_elb.py
+++ b/salt/states/boto_elb.py
@@ -257,6 +257,10 @@ def present(
 
     attributes
         A dict defining the attributes to set on this ELB.
+        Unknown keys will be silently ignored.
+
+        See the :mod:`salt.modules.boto_elb.set_attributes` function for
+        recognized attributes.
 
     attributes_from_pillar
         name of pillar dict that contains attributes.   Attributes defined for this specific

--- a/salt/states/boto_elb.py
+++ b/salt/states/boto_elb.py
@@ -263,7 +263,10 @@ def present(
         state will override those from pillar.
 
     cnames
-        A list of cname dicts with attributes: name, zone, ttl, and identifier.
+        An optional list of cname dicts with attributes: name, zone, ttl, and
+        identifier. If specified, a CNAME record will be created referencing
+        this ELB's public FQDN.
+
         See the boto_route53 state for information about these attributes.
 
     alarms:


### PR DESCRIPTION
### What does this PR do?

Expands the function docstrings for both the boto_elb state and module.
- Adds parameter documentation to `salt.modules.boto_elb.set_attributes` function.
- Adds a link in `salt.states.boto_elb.present` function to to the above `set_attributes` function for a list of valid ELB attributes
- Describes with a little more detail the action of the `cnames` parameter in the above `present` function.
