### PR TITLE
Eliminate dry-run false positives for files in /tmp

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3882,6 +3882,11 @@ def check_managed(
             return False, comments
     changes = check_file_meta(name, sfn, source, source_sum, user,
                               group, mode, saltenv, contents)
+    # Ignore permission for files written temporary directories
+    # Files in any path will still be set correctly using get_managed()
+    if name.startswith(tempfile.gettempdir()):
+        for key in ['user', 'group', 'mode']:
+            changes.pop(key, None)
     __clean_tmp(sfn)
     if changes:
         log.info(changes)


### PR DESCRIPTION
### What does this PR do?

Eliminates false positives for crontab ownership when running `state.highstate`
with `test=True`
### What issues does this PR fix or reference?
### Previous Behavior

```
vm:
----------
          ID: system_tasks
    Function: cron.file
        Name: salt://vm/root.cron
      Result: None
     Comment: The following values are set to be changed:
              group: crontab
     Started: 14:46:49.708843
    Duration: 101.032 ms
     Changes:   

Summary for vm
-------------
Succeeded: 22 (unchanged=1)
Failed:     0
-------------
```
### New Behavior

```
vm:

Summary for vm
-------------
Succeeded: 22
Failed:     0
-------------
```
### Tests written?

No
