### PR TITLE
Properly detect newer Linux Mint distros

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -930,6 +930,7 @@ _OS_NAME_MAP = {
     'synology': 'Synology',
     'manjaro': 'Manjaro',
     'sles': 'SUSE',
+    'linuxmint': 'Mint',
 }
 
 # Map the 'os' grain to the 'os_family' grain

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -89,7 +89,7 @@ def __virtual__():
     '''
     Confirm this module is on a Debian based system
     '''
-    if __grains__.get('os_family') in ('Kali', 'Debian', 'LinuxMint'):
+    if __grains__.get('os_family') in ('Kali', 'Debian'):
         return __virtualname__
     return False
 


### PR DESCRIPTION
LMDE 2 and Linux Mint 17.3 changed the DISTRIB_ID in /etc/lsb-release to
`LinuxMint`, breaking OS detection for these distros.

This pull request fixes that by adding an entry to the OS_NAME_MAP in the core
grains.

Resolves #33295.
