### PR TITLE
Fix issues in execution module state ignoring explicit test=False if minion config says test=True

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -178,7 +178,7 @@ project = 'Salt'
 copyright = '2016 SaltStack, Inc.'
 
 version = salt.version.__version__
-latest_release = '2015.8.8'  # latest release
+latest_release = '2015.8.9'  # latest release
 previous_release = '2015.5.10'  # latest release from previous branch
 previous_release_dir = '2015.5'  # path on web server for previous branch
 build_type = 'previous'  # latest, previous, develop, inactive

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -707,11 +707,15 @@ Minion Module Management
 Default: ``[]`` (all modules are enabled by default)
 
 The event may occur in which the administrator desires that a minion should not
-be able to execute a certain module. The sys module is built into the minion
+be able to execute a certain module. The ``sys`` module is built into the minion
 and cannot be disabled.
 
-This setting can also tune the minion, as all modules are loaded into ram
-disabling modules will lower the minion's ram footprint.
+This setting can also tune the minion. Because all modules are loaded into system
+memory, disabling modules will lover the minion's memory footprint.
+
+Modules should be specified according to their file name on the system and not by
+their virtual name. For example, to disable ``cmd``, use the string ``cmdmod`` which
+corresponds to ``salt.modules.cmdmod``.
 
 .. code-block:: yaml
 

--- a/doc/topics/releases/2015.5.11.rst
+++ b/doc/topics/releases/2015.5.11.rst
@@ -10,11 +10,37 @@ Changes for v2015.5.10..v2015.5.11
 
 Extended changelog courtesy of Todd Stansell (https://github.com/tjstansell/salt-changelogs):
 
-*Generated at: 2016-05-13T14:26:40Z*
+*Generated at: 2016-05-20T21:02:38Z*
 
-Total Merges: **99**
+Total Merges: **101**
 
 Changes:
+
+* dc8ce2d Fix traceback in logging for config validation (`#33386`_) (`#33405`_)
+
+- **PR** `#33383`_: (*thatch45*) maintain the fallabck because I am totally sick of this crap
+
+* 755acfb Improve doc clarity for disable_modules documentation (`#33379`_)
+
+* 2b5ad12 Better YAML syntax error handling (`#33375`_)
+
+- **PR** `#33372`_: (*jacobhammons*) revved 2015.8 branch to .9 in version selector
+
+* 55be0ab Expanded documentation for boto_elb state and module (`#33341`_)
+
+* 9b42a05 Added some more docs for master and minion config settings (`#33292`_)
+
+* 8acee5e Fix iptables --match-set (`#23643`_) (`#33301`_)
+
+* 757ef20 fix "loose" typo (`#33290`_)
+
+* b7d98da Add auth_tries config option to minion.rst docs (`#33287`_)
+
+* 061851b Document minion_id_caching config value (`#33282`_)
+
+* 8fa72f6 Clarify file.replace MULTILINE flag interaction with regex anchors (`#33137`_)
+
+* 4b1f460 update 2015.5.11 release notes (`#33236`_)
 
 - **PR** `#33211`_: (*cachedout*) Don't try to kill a parent proc if we can't
 
@@ -404,6 +430,7 @@ Changes:
 .. _`#33078`: https://github.com/saltstack/salt/pull/33078
 .. _`#33080`: https://github.com/saltstack/salt/pull/33080
 .. _`#33132`: https://github.com/saltstack/salt/pull/33132
+.. _`#33137`: https://github.com/saltstack/salt/pull/33137
 .. _`#33141`: https://github.com/saltstack/salt/pull/33141
 .. _`#33155`: https://github.com/saltstack/salt/pull/33155
 .. _`#33160`: https://github.com/saltstack/salt/pull/33160
@@ -414,3 +441,17 @@ Changes:
 .. _`#33197`: https://github.com/saltstack/salt/pull/33197
 .. _`#33205`: https://github.com/saltstack/salt/pull/33205
 .. _`#33211`: https://github.com/saltstack/salt/pull/33211
+.. _`#33236`: https://github.com/saltstack/salt/pull/33236
+.. _`#33282`: https://github.com/saltstack/salt/pull/33282
+.. _`#33286`: https://github.com/saltstack/salt/pull/33286
+.. _`#33287`: https://github.com/saltstack/salt/pull/33287
+.. _`#33290`: https://github.com/saltstack/salt/pull/33290
+.. _`#33292`: https://github.com/saltstack/salt/pull/33292
+.. _`#33301`: https://github.com/saltstack/salt/pull/33301
+.. _`#33341`: https://github.com/saltstack/salt/pull/33341
+.. _`#33372`: https://github.com/saltstack/salt/pull/33372
+.. _`#33375`: https://github.com/saltstack/salt/pull/33375
+.. _`#33379`: https://github.com/saltstack/salt/pull/33379
+.. _`#33383`: https://github.com/saltstack/salt/pull/33383
+.. _`#33386`: https://github.com/saltstack/salt/pull/33386
+.. _`#33405`: https://github.com/saltstack/salt/pull/33405

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -98,6 +98,7 @@ def _wait(jid):
         time.sleep(1)
         states = _prior_running_states(jid)
 
+
 def running(concurrent=False):
     '''
     Return a list of strings that contain state return data if a state function
@@ -801,12 +802,12 @@ def sls(mods,
     opts = _get_opts(kwargs.get('localconfig'))
 
     if test is None:
-      if salt.utils.test_mode(test=test, **kwargs):
-        opts['test'] = True
-      else:
-        opts['test'] = __opts__.get('test', None)
+        if salt.utils.test_mode(test=test, **kwargs):
+            opts['test'] = True
+        else:
+            opts['test'] = __opts__.get('test', None)
     else:
-      opts['test'] = test
+        opts['test'] = test
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -910,12 +911,12 @@ def top(topfn,
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
     if test is None:
-      if salt.utils.test_mode(test=test, **kwargs):
-        opts['test'] = True
-      else:
-        opts['test'] = __opts__.get('test', None)
+        if salt.utils.test_mode(test=test, **kwargs):
+            opts['test'] = True
+        else:
+            opts['test'] = __opts__.get('test', None)
     else:
-      opts['test'] = test
+        opts['test'] = test
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -1089,12 +1090,12 @@ def show_low_sls(mods,
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
     if test is None:
-      if salt.utils.test_mode(test=test, **kwargs):
-        opts['test'] = True
-      else:
-        opts['test'] = __opts__.get('test', None)
+        if salt.utils.test_mode(test=test, **kwargs):
+            opts['test'] = True
+        else:
+            opts['test'] = __opts__.get('test', None)
     else:
-      opts['test'] = test
+        opts['test'] = test
     if 'pillarenv' in kwargs:
         opts['pillarenv'] = kwargs['pillarenv']
     st_ = salt.state.HighState(opts)
@@ -1148,12 +1149,12 @@ def show_sls(mods, saltenv='base', test=None, queue=False, env=None, **kwargs):
     opts = _get_opts(kwargs.get('localconfig'))
 
     if test is None:
-      if salt.utils.test_mode(test=test, **kwargs):
-        opts['test'] = True
-      else:
-        opts['test'] = __opts__.get('test', None)
+        if salt.utils.test_mode(test=test, **kwargs):
+            opts['test'] = True
+        else:
+            opts['test'] = __opts__.get('test', None)
     else:
-      opts['test'] = test
+        opts['test'] = test
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -1237,12 +1238,12 @@ def single(fun, name, test=None, queue=False, **kwargs):
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
     if test is None:
-      if salt.utils.test_mode(test=test, **kwargs):
-        opts['test'] = True
-      else:
-        opts['test'] = __opts__.get('test', None)
+        if salt.utils.test_mode(test=test, **kwargs):
+            opts['test'] = True
+        else:
+            opts['test'] = __opts__.get('test', None)
     else:
-      opts['test'] = test
+        opts['test'] = test
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -1335,13 +1336,12 @@ def pkg(pkg_path, pkg_sum, hash_type, test=None, **kwargs):
     popts = _get_opts(kwargs.get('localconfig'))
     popts['fileclient'] = 'local'
     popts['file_roots'] = {}
-    if test is None:
-      if salt.utils.test_mode(test=test, **kwargs):
-        opts['test'] = True
-      else:
-        opts['test'] = __opts__.get('test', None)
+    if salt.utils.test_mode(test=test, **kwargs):
+            popts['test'] = True
+        else:
+            popts['test'] = __opts__.get('test', None)
     else:
-      opts['test'] = test
+        popts['test'] = test
     envs = os.listdir(root)
     for fn_ in envs:
         full = os.path.join(root, fn_)

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -229,7 +229,7 @@ def high(data, test=None, queue=False, **kwargs):
         return conflict
     opts = _get_opts(kwargs.get('localconfig'))
 
-    opts['test'] = _get_test_value()
+    opts['test'] = _get_test_value(test, kwargs)
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -632,7 +632,7 @@ def highstate(test=None,
 
     opts = _get_opts(kwargs.get('localconfig'))
 
-    opts['test'] = _get_test_value()
+    opts['test'] = _get_test_value(test, kwargs)
 
     if 'env' in kwargs:
         salt.utils.warn_until(
@@ -805,7 +805,7 @@ def sls(mods,
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
 
-    opts['test'] = _get_test_value()
+    opts['test'] = _get_test_value(test, kwargs)
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -908,7 +908,7 @@ def top(topfn,
         return err
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
-    opts['test'] = _get_test_value()
+    opts['test'] = _get_test_value(test, kwargs)
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -1014,7 +1014,7 @@ def sls_id(
         return conflict
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
-    opts['test'] = _get_test_value()
+    opts['test'] = _get_test_value(test, kwargs)
     if 'pillarenv' in kwargs:
         opts['pillarenv'] = kwargs['pillarenv']
     st_ = salt.state.HighState(opts)
@@ -1075,7 +1075,7 @@ def show_low_sls(mods,
         return conflict
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
-    opts['test'] = _get_test_value()
+    opts['test'] = _get_test_value(test, kwargs)
     if 'pillarenv' in kwargs:
         opts['pillarenv'] = kwargs['pillarenv']
     st_ = salt.state.HighState(opts)
@@ -1128,7 +1128,7 @@ def show_sls(mods, saltenv='base', test=None, queue=False, env=None, **kwargs):
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
 
-    opts['test'] = _get_test_value()
+    opts['test'] = _get_test_value(test, kwargs)
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -1211,7 +1211,7 @@ def single(fun, name, test=None, queue=False, **kwargs):
                    'name': name})
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
-    opts['test'] = _get_test_value()
+    opts['test'] = _get_test_value(test, kwargs)
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -1304,7 +1304,7 @@ def pkg(pkg_path, pkg_sum, hash_type, test=None, **kwargs):
     popts = _get_opts(kwargs.get('localconfig'))
     popts['fileclient'] = 'local'
     popts['file_roots'] = {}
-    popts['test'] = _get_test_value()
+    popts['test'] = _get_test_value(test, kwargs)
     envs = os.listdir(root)
     for fn_ in envs:
         full = os.path.join(root, fn_)

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -1336,7 +1336,8 @@ def pkg(pkg_path, pkg_sum, hash_type, test=None, **kwargs):
     popts = _get_opts(kwargs.get('localconfig'))
     popts['fileclient'] = 'local'
     popts['file_roots'] = {}
-    if salt.utils.test_mode(test=test, **kwargs):
+    if test is None:
+        if salt.utils.test_mode(test=test, **kwargs):
             popts['test'] = True
         else:
             popts['test'] = __opts__.get('test', None)

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -98,7 +98,6 @@ def _wait(jid):
         time.sleep(1)
         states = _prior_running_states(jid)
 
-
 def running(concurrent=False):
     '''
     Return a list of strings that contain state return data if a state function
@@ -801,12 +800,13 @@ def sls(mods,
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
 
-    if salt.utils.test_mode(test=test, **kwargs):
+    if test is None:
+      if salt.utils.test_mode(test=test, **kwargs):
         opts['test'] = True
-    elif test is not None:
-        opts['test'] = test
-    else:
+      else:
         opts['test'] = __opts__.get('test', None)
+    else:
+      opts['test'] = test
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -909,10 +909,13 @@ def top(topfn,
         return err
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
-    if salt.utils.test_mode(test=test, **kwargs):
+    if test is None:
+      if salt.utils.test_mode(test=test, **kwargs):
         opts['test'] = True
-    else:
+      else:
         opts['test'] = __opts__.get('test', None)
+    else:
+      opts['test'] = test
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -1018,10 +1021,13 @@ def sls_id(
         return conflict
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
-    if salt.utils.test_mode(test=test, **kwargs):
+    if test is None:
+      if salt.utils.test_mode(test=test, **kwargs):
         opts['test'] = True
-    else:
+      else:
         opts['test'] = __opts__.get('test', None)
+    else:
+      opts['test'] = test
     if 'pillarenv' in kwargs:
         opts['pillarenv'] = kwargs['pillarenv']
     st_ = salt.state.HighState(opts)
@@ -1082,10 +1088,13 @@ def show_low_sls(mods,
         return conflict
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
-    if salt.utils.test_mode(test=test, **kwargs):
+    if test is None:
+      if salt.utils.test_mode(test=test, **kwargs):
         opts['test'] = True
-    else:
+      else:
         opts['test'] = __opts__.get('test', None)
+    else:
+      opts['test'] = test
     if 'pillarenv' in kwargs:
         opts['pillarenv'] = kwargs['pillarenv']
     st_ = salt.state.HighState(opts)
@@ -1138,10 +1147,13 @@ def show_sls(mods, saltenv='base', test=None, queue=False, env=None, **kwargs):
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
 
-    if salt.utils.test_mode(test=test, **kwargs):
+    if test is None:
+      if salt.utils.test_mode(test=test, **kwargs):
         opts['test'] = True
-    else:
+      else:
         opts['test'] = __opts__.get('test', None)
+    else:
+      opts['test'] = test
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -1224,10 +1236,13 @@ def single(fun, name, test=None, queue=False, **kwargs):
                    'name': name})
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
-    if salt.utils.test_mode(test=test, **kwargs):
+    if test is None:
+      if salt.utils.test_mode(test=test, **kwargs):
         opts['test'] = True
-    else:
+      else:
         opts['test'] = __opts__.get('test', None)
+    else:
+      opts['test'] = test
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -1321,9 +1336,11 @@ def pkg(pkg_path, pkg_sum, hash_type, test=False, **kwargs):
     popts['fileclient'] = 'local'
     popts['file_roots'] = {}
     if salt.utils.test_mode(test=test, **kwargs):
-        popts['test'] = True
+      opts['test'] = True
+    elif test is not None:
+      opts['test'] = test
     else:
-        popts['test'] = __opts__.get('test', None)
+      opts['test'] = __opts__.get('test', None)
     envs = os.listdir(root)
     for fn_ in envs:
         full = os.path.join(root, fn_)

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -210,6 +210,7 @@ def _get_test_value(test=None, **kwargs):
         ret = test
     return ret
 
+
 def high(data, test=None, queue=False, **kwargs):
     '''
     Execute the compound calls stored in a single set of high data

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -1291,7 +1291,7 @@ def clear_cache():
     return ret
 
 
-def pkg(pkg_path, pkg_sum, hash_type, test=False, **kwargs):
+def pkg(pkg_path, pkg_sum, hash_type, test=None, **kwargs):
     '''
     Execute a packaged state run, the packaged state run will exist in a
     tarball available locally. This packaged state
@@ -1335,12 +1335,13 @@ def pkg(pkg_path, pkg_sum, hash_type, test=False, **kwargs):
     popts = _get_opts(kwargs.get('localconfig'))
     popts['fileclient'] = 'local'
     popts['file_roots'] = {}
-    if salt.utils.test_mode(test=test, **kwargs):
-      opts['test'] = True
-    elif test is not None:
-      opts['test'] = test
+    if test is None:
+      if salt.utils.test_mode(test=test, **kwargs):
+        opts['test'] = True
+      else:
+        opts['test'] = __opts__.get('test', None)
     else:
-      opts['test'] = __opts__.get('test', None)
+      opts['test'] = test
     envs = os.listdir(root)
     for fn_ in envs:
         full = os.path.join(root, fn_)

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -1023,12 +1023,12 @@ def sls_id(
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
     if test is None:
-      if salt.utils.test_mode(test=test, **kwargs):
-        opts['test'] = True
-      else:
-        opts['test'] = __opts__.get('test', None)
+        if salt.utils.test_mode(test=test, **kwargs):
+            opts['test'] = True
+        else:
+            opts['test'] = __opts__.get('test', None)
     else:
-      opts['test'] = test
+        opts['test'] = test
     if 'pillarenv' in kwargs:
         opts['pillarenv'] = kwargs['pillarenv']
     st_ = salt.state.HighState(opts)

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -229,7 +229,7 @@ def high(data, test=None, queue=False, **kwargs):
         return conflict
     opts = _get_opts(kwargs.get('localconfig'))
 
-    opts['test'] = _get_test_value(test, kwargs)
+    opts['test'] = _get_test_value(test, **kwargs)
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -632,7 +632,7 @@ def highstate(test=None,
 
     opts = _get_opts(kwargs.get('localconfig'))
 
-    opts['test'] = _get_test_value(test, kwargs)
+    opts['test'] = _get_test_value(test, **kwargs)
 
     if 'env' in kwargs:
         salt.utils.warn_until(
@@ -805,7 +805,7 @@ def sls(mods,
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
 
-    opts['test'] = _get_test_value(test, kwargs)
+    opts['test'] = _get_test_value(test, **kwargs)
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -908,7 +908,7 @@ def top(topfn,
         return err
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
-    opts['test'] = _get_test_value(test, kwargs)
+    opts['test'] = _get_test_value(test, **kwargs)
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -1014,7 +1014,7 @@ def sls_id(
         return conflict
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
-    opts['test'] = _get_test_value(test, kwargs)
+    opts['test'] = _get_test_value(test, **kwargs)
     if 'pillarenv' in kwargs:
         opts['pillarenv'] = kwargs['pillarenv']
     st_ = salt.state.HighState(opts)
@@ -1075,7 +1075,7 @@ def show_low_sls(mods,
         return conflict
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
-    opts['test'] = _get_test_value(test, kwargs)
+    opts['test'] = _get_test_value(test, **kwargs)
     if 'pillarenv' in kwargs:
         opts['pillarenv'] = kwargs['pillarenv']
     st_ = salt.state.HighState(opts)
@@ -1128,7 +1128,7 @@ def show_sls(mods, saltenv='base', test=None, queue=False, env=None, **kwargs):
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
 
-    opts['test'] = _get_test_value(test, kwargs)
+    opts['test'] = _get_test_value(test, **kwargs)
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -1211,7 +1211,7 @@ def single(fun, name, test=None, queue=False, **kwargs):
                    'name': name})
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
-    opts['test'] = _get_test_value(test, kwargs)
+    opts['test'] = _get_test_value(test, **kwargs)
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -1304,7 +1304,7 @@ def pkg(pkg_path, pkg_sum, hash_type, test=None, **kwargs):
     popts = _get_opts(kwargs.get('localconfig'))
     popts['fileclient'] = 'local'
     popts['file_roots'] = {}
-    popts['test'] = _get_test_value(test, kwargs)
+    popts['test'] = _get_test_value(test, **kwargs)
     envs = os.listdir(root)
     for fn_ in envs:
         full = os.path.join(root, fn_)

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -196,7 +196,21 @@ def low(data, queue=False, **kwargs):
     return ret
 
 
-def high(data, test=False, queue=False, **kwargs):
+def _get_test_value(test=None, **kwargs):
+    '''
+    Determine the correct value for the test flag.
+    '''
+    ret = True
+    if test is None:
+        if salt.utils.test_mode(test=test, **kwargs):
+            ret = True
+        else:
+            ret = __opts__.get('test', None)
+    else:
+        ret = test
+    return ret
+
+def high(data, test=None, queue=False, **kwargs):
     '''
     Execute the compound calls stored in a single set of high data
 
@@ -214,12 +228,7 @@ def high(data, test=False, queue=False, **kwargs):
         return conflict
     opts = _get_opts(kwargs.get('localconfig'))
 
-    if salt.utils.test_mode(test=test, **kwargs):
-        opts['test'] = True
-    elif test is not None:
-        opts['test'] = test
-    else:
-        opts['test'] = __opts__.get('test', None)
+    opts['test'] = _get_test_value()
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -622,13 +631,7 @@ def highstate(test=None,
 
     opts = _get_opts(kwargs.get('localconfig'))
 
-    if test is None:
-        if salt.utils.test_mode(test=test, **kwargs):
-            opts['test'] = True
-        else:
-            opts['test'] = __opts__.get('test', None)
-    else:
-        opts['test'] = test
+    opts['test'] = _get_test_value()
 
     if 'env' in kwargs:
         salt.utils.warn_until(
@@ -801,13 +804,7 @@ def sls(mods,
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
 
-    if test is None:
-        if salt.utils.test_mode(test=test, **kwargs):
-            opts['test'] = True
-        else:
-            opts['test'] = __opts__.get('test', None)
-    else:
-        opts['test'] = test
+    opts['test'] = _get_test_value()
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -910,13 +907,7 @@ def top(topfn,
         return err
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
-    if test is None:
-        if salt.utils.test_mode(test=test, **kwargs):
-            opts['test'] = True
-        else:
-            opts['test'] = __opts__.get('test', None)
-    else:
-        opts['test'] = test
+    opts['test'] = _get_test_value()
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -1022,13 +1013,7 @@ def sls_id(
         return conflict
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
-    if test is None:
-        if salt.utils.test_mode(test=test, **kwargs):
-            opts['test'] = True
-        else:
-            opts['test'] = __opts__.get('test', None)
-    else:
-        opts['test'] = test
+    opts['test'] = _get_test_value()
     if 'pillarenv' in kwargs:
         opts['pillarenv'] = kwargs['pillarenv']
     st_ = salt.state.HighState(opts)
@@ -1089,13 +1074,7 @@ def show_low_sls(mods,
         return conflict
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
-    if test is None:
-        if salt.utils.test_mode(test=test, **kwargs):
-            opts['test'] = True
-        else:
-            opts['test'] = __opts__.get('test', None)
-    else:
-        opts['test'] = test
+    opts['test'] = _get_test_value()
     if 'pillarenv' in kwargs:
         opts['pillarenv'] = kwargs['pillarenv']
     st_ = salt.state.HighState(opts)
@@ -1148,13 +1127,7 @@ def show_sls(mods, saltenv='base', test=None, queue=False, env=None, **kwargs):
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
 
-    if test is None:
-        if salt.utils.test_mode(test=test, **kwargs):
-            opts['test'] = True
-        else:
-            opts['test'] = __opts__.get('test', None)
-    else:
-        opts['test'] = test
+    opts['test'] = _get_test_value()
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -1237,13 +1210,7 @@ def single(fun, name, test=None, queue=False, **kwargs):
                    'name': name})
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
-    if test is None:
-        if salt.utils.test_mode(test=test, **kwargs):
-            opts['test'] = True
-        else:
-            opts['test'] = __opts__.get('test', None)
-    else:
-        opts['test'] = test
+    opts['test'] = _get_test_value()
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -1336,13 +1303,7 @@ def pkg(pkg_path, pkg_sum, hash_type, test=None, **kwargs):
     popts = _get_opts(kwargs.get('localconfig'))
     popts['fileclient'] = 'local'
     popts['file_roots'] = {}
-    if test is None:
-        if salt.utils.test_mode(test=test, **kwargs):
-            popts['test'] = True
-        else:
-            popts['test'] = __opts__.get('test', None)
-    else:
-        popts['test'] = test
+    popts['test'] = _get_test_value()
     envs = os.listdir(root)
     for fn_ in envs:
         full = os.path.join(root, fn_)

--- a/salt/renderers/yaml.py
+++ b/salt/renderers/yaml.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import
 import logging
 import warnings
 from yaml.scanner import ScannerError
+from yaml.parser import ParserError
 from yaml.constructor import ConstructorError
 
 # Import salt libs
@@ -52,7 +53,7 @@ def render(yaml_data, saltenv='base', sls='', argline='', **kws):
             err_type = _ERROR_MAP.get(exc.problem, exc.problem)
             line_num = exc.problem_mark.line + 1
             raise SaltRenderError(err_type, line_num, exc.problem_mark.buffer)
-        except ConstructorError as exc:
+        except (ParserError, ConstructorError) as exc:
             raise SaltRenderError(exc)
         if len(warn_list) > 0:
             for item in warn_list:

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -155,6 +155,7 @@ def _check_pkg_version_format(pkg):
             )
         )
         return ret
+
     if install_req.req is None:
         # This is most likely an url and there's no way to know what will
         # be installed before actually installing it.

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -155,21 +155,24 @@ def _check_pkg_version_format(pkg):
             )
         )
         return ret
-
-    if install_req.req is None:
-        # This is most likely an url and there's no way to know what will
-        # be installed before actually installing it.
-        ret['result'] = True
-        ret['prefix'] = ''
-        ret['version_spec'] = []
-    else:
-        ret['result'] = True
-        ret['prefix'] = re.sub('[^A-Za-z0-9.]+', '-', install_req.name)
-        if hasattr(install_req, "specifier"):
-            specifier = install_req.specifier
+    try:
+        ret['prefix'] = install_req.req.project_name
+        ret['version_spec'] = install_req.req.specs
+    except Exception:
+        if install_req.req is None:
+            # This is most likely an url and there's no way to know what will
+            # be installed before actually installing it.
+            ret['result'] = True
+            ret['prefix'] = ''
+            ret['version_spec'] = []
         else:
-            specifier = install_req.req.specifier
-        ret['version_spec'] = [(spec.operator, spec.version) for spec in specifier]
+            ret['result'] = True
+            ret['prefix'] = re.sub('[^A-Za-z0-9.]+', '-', install_req.name)
+            if hasattr(install_req, "specifier"):
+                specifier = install_req.specifier
+            else:
+                specifier = install_req.req.specifier
+            ret['version_spec'] = [(spec.operator, spec.version) for spec in specifier]
 
     return ret
 

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -155,18 +155,18 @@ def _check_pkg_version_format(pkg):
             )
         )
         return ret
-    try:
-        ret['prefix'] = install_req.req.project_name
-        ret['version_spec'] = install_req.req.specs
-    except Exception:
-        if install_req.req is None:
-            # This is most likely an url and there's no way to know what will
-            # be installed before actually installing it.
-            ret['result'] = True
-            ret['prefix'] = ''
-            ret['version_spec'] = []
-        else:
-            ret['result'] = True
+    if install_req.req is None:
+        # This is most likely an url and there's no way to know what will
+        # be installed before actually installing it.
+        ret['result'] = True
+        ret['prefix'] = ''
+        ret['version_spec'] = []
+    else:
+        ret['result'] = True
+        try:
+            ret['prefix'] = install_req.req.project_name
+            ret['version_spec'] = install_req.req.specs
+        except Exception:
             ret['prefix'] = re.sub('[^A-Za-z0-9.]+', '-', install_req.name)
             if hasattr(install_req, "specifier"):
                 specifier = install_req.specifier


### PR DESCRIPTION
### What does this PR do?

Makes the determination of the correct test value consistent and correct in the state execution module.
### What issues does this PR fix or reference?
#33363
### Previous Behavior

There were 3 different patterns for determining the final value of test.  Most (if not all) would override the explicit test argument's value with the value from the minion config if the minion config says test=True (not the default).
### New Behavior

Single pattern used by all functions in this module that take an explicit test argument.

Minion config will never be used to override and explicit test=True argument when the functions are invoked.
### Tests written?

No
