### PR TITLE
Update docs version to 2015.8.9

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -192,7 +192,7 @@ project = 'Salt'
 copyright = '2016 SaltStack, Inc.'
 
 version = salt.version.__version__
-latest_release = '2015.8.8'  # latest release
+latest_release = '2015.8.9'  # latest release
 previous_release = '2015.5.10'  # latest release from previous branch
 previous_release_dir = '2015.5'  # path on web server for previous branch
 build_type = 'latest'  # latest, previous, develop, inactive

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -358,3 +358,22 @@ When possible, you should target sensitive operations and data using the Minion
 ID. If the Minion ID of a system changes, the Salt Minion's public key must be
 re-accepted by an administrator on the Salt Master, making it less vulnerable
 to impersonation attacks.
+
+Why Did the Value for a Grain Change on Its Own?
+------------------------------------------------
+
+This is usually the result of an upstream change in an OS distribution that
+replaces or removes something that Salt was using to detect the grain.
+Fortunately, when this occurs, you can use Salt to fix it with a command
+similar to the following:
+
+.. code-block:: bash
+
+    salt -G 'grain:ChangedValue' grains.setvals "{'grain': 'OldValue'}"
+
+(Replacing *grain*, *ChangedValue*, and *OldValue* with
+the grain and values that you want to change / set.)
+
+You should also `file an issue <https://github.com/saltstack/salt/issues>`_
+describing the change so it can be fixed in Salt.
+

--- a/doc/topics/releases/2015.8.9.rst
+++ b/doc/topics/releases/2015.8.9.rst
@@ -5,6 +5,18 @@ Salt 2015.8.9 Release Notes
 Version 2015.8.9 is a bugfix release for :doc:`2015.8.0
 </topics/releases/2015.8.0>`.
 
+.. admonition:: Mint Linux: Important Post-Upgrade Instructions
+
+    As a result of some upstream changes, the ``os`` grain on Mint Linux is now
+    being detected as ``LinuxMint`` (:issue:`33295`). Run the following command
+    **after you upgrade to 2015.8.9** to reset the ``os`` grain to ``Mint`` and
+    the ``os_family`` grain to ``Debian``:
+
+    .. code-block:: bash
+
+        salt -G 'os:LinuxMint' grains.setvals "{'os': 'Mint', 'os_family': 'Debian'}"
+
+
 Changes for v2015.8.8..v2015.8.9
 --------------------------------
 


### PR DESCRIPTION
### What does this PR do?

Updates docs version to 2015.8.9
Adds note regarding the os grain on Mint Linux
Adds an FAQ regarding grains that change due to upstream changes
