### PR TITLE
Runner command

### DIFF
--- a/salt/command.py
+++ b/salt/command.py
@@ -1,0 +1,199 @@
+class Command(object):
+    '''
+    The command base class
+    '''
+    SYNC = 'runner'
+    ASYNC = 'runner_async'
+
+    def execute(self, *args, **kwargs):
+        '''
+        This will be implemented by subclasses
+        :return: None
+        '''
+        pass
+
+
+class SaltRunnerError(RuntimeError):
+    '''
+    Represent any errors
+    '''
+    pass
+
+
+class RunnerReceiver(object):
+    '''
+    The receiver for runner class
+    '''
+    def __init__(self, salt_client=None):
+        '''
+        Sets the salt client to be used.
+        Can be RunnerClient, LocalClient
+        or WheelClient depending on the operation.
+        :param salt_client: The python client that will be used
+        '''
+        self.client = salt_client
+
+    def _get_method_name_to_call(self, low):
+        '''
+        Return the String method name
+        :param client: sync or async
+        :return: String method name or the empty string
+        '''
+
+        methods = {
+            Command.SYNC: 'cmd_sync',
+            Command.ASYNC: 'cmd_async',
+        }
+        client = low['client']
+        if client not in methods:
+            return ''
+        return methods[client]
+
+    def _build_low_data(self, low, **kwargs):
+        '''
+        :param low: the low data passed in
+        :return: new dictionary of updated low data
+        that has defaults filled in for all parameters
+        and auth values. This low data should be in a
+        form accepted by RunnerClient
+        '''
+        low_data = {
+            'fun': low['fun'],
+            'arg': low.get('arg', []) or [],  # ensure arg is initialized
+            'kwarg': low.get('kwarg', {}) or {},  # ensure kwarg is initialized
+        }
+
+        if 'token' in kwargs:
+            low_data.update({
+                'token': kwargs.get('token'),
+            })
+        elif 'eauth' in kwargs:
+            low_data.update({
+                'username': kwargs.get('username', ''),
+                'password': kwargs.get('password', ''),
+                'eauth': kwargs.get('eauth'),
+            })
+        else:  # Don't have token or eauth, bail!!
+            raise SaltRunnerError(
+                'Neither token or eauth found! Please set token or eauth and try again.')
+        return low_data
+
+    def action(self, low, *args, **kwargs):
+        '''
+        Calls cmd_* on the client
+        :param low: The low data including client
+        :return: None
+        '''
+
+        def _ignore_args(*args, **kwargs):
+            '''
+            ignore all arguments
+            '''
+            pass
+
+        getattr(self.client,
+                self._get_method_name_to_call(low),  # can be either cmd_sync or cmd_async
+                _ignore_args)(self._build_low_data(low, **kwargs), timeout=10)
+
+
+class RunnerCommand(Command):
+    '''
+    Class to represent runner commands
+    '''
+    REPR_MSGS = ''.join(['RunnerCommand(fun={0}', ', arg={1}', ', kwarg={2}',
+                         ', client={3}', ', receiver={4})'])
+
+    def __init__(self,
+                 fun='job.list_jobs',
+                 arg=None,
+                 kwarg=None,
+                 receiver=None):
+        self.receiver = receiver
+        self.client = Command.SYNC
+        self.fun = fun
+        self.arg = arg
+        self.kwarg = kwarg
+
+    def make_async(self):
+        '''
+        This should execute asynchronously
+        '''
+        self.client = Command.ASYNC
+
+    def make_sync(self):
+        '''
+        This should execute synchronously
+        '''
+        self.client = Command.SYNC
+
+    def execute(self, *args, **kwargs):
+        '''
+        Calls action on the receiver
+        :return: None
+        '''
+        self.receiver.action({
+            'fun': self.fun,
+            'arg': self.arg,
+            'kwarg': self.kwarg,
+            'client': self.client,
+        }, *args, **kwargs)
+
+    def __repr__(self):
+        return self.REPR_MSGS.format(
+            repr(self.fun),
+            repr(self.arg),
+            repr(self.kwarg),
+            repr(self.client),
+            repr(self.receiver)
+        )
+
+
+def get_sync_runner_command(fun='job.list_job',
+                            arg=None,
+                            kwarg=None,
+                            client=None
+                            ):
+    '''
+    Commands need to be authenticated
+    set (username, password and eauth) as keyword args
+
+    :param fun: Runner module function (string) to call
+    :param arg: Positional argument list
+    :param kwarg: Dictionary with key value pairs
+    :param client: The salt python client to use (RunnerClient).
+    :return: RunnerCommand instance
+    '''
+    return RunnerCommand(
+        receiver=RunnerReceiver(salt_client=client),
+        fun=fun,
+        arg=arg,
+        kwarg=kwarg
+    )
+
+def get_async_runner_command(fun='job.list_job', arg=None,
+                             kwarg=None, client=None):
+    '''
+    :param fun: Runner module function (string) to call
+    :param arg: Positional argument list
+    :param kwarg: Dictionary with key value pairs
+    :param client: The salt python client to use (RunnerClient).
+    :return: RunnerCommand instance
+    '''
+    cmd = RunnerCommand(
+        receiver=RunnerReceiver(salt_client=client),
+        fun=fun,
+        arg=arg,
+        kwarg=kwarg
+    )
+    cmd.make_async()
+    return cmd
+
+
+class APIClient(object):
+
+    @staticmethod
+    def submit_runner_command(command, *args, **kwargs):
+        '''
+        Executes this command instance
+        '''
+        command.execute(*args, **kwargs)

--- a/tests/unit/command_test.py
+++ b/tests/unit/command_test.py
@@ -1,0 +1,194 @@
+import unittest
+from mock import MagicMock
+
+from command_pattern.command import Command,\
+    RunnerCommand,\
+    RunnerReceiver, \
+    get_async_runner_command, \
+    get_sync_runner_command, \
+    APIClient, \
+    SaltRunnerError
+
+
+class CommandTestCase(unittest.TestCase):
+    def test_command_has_execute_method(self):
+        self.assertEqual(hasattr(Command(), 'execute'), True)
+
+
+class RunnerCommandTestCase(unittest.TestCase):
+    def test_command_has_execute_method(self):
+        '''
+        Commands must implement execute
+        '''
+        self.assertEqual(hasattr(RunnerCommand(), 'execute'), True)
+
+    def test_repr_return_data(self):
+        '''
+        Make sure __repr__ returns
+        useful info about this command's low data
+        '''
+        fun = 'job.list_job'
+        arg = [123456]
+        kwarg = {'ext_source': 'source'}
+        receiver = RunnerReceiver()
+
+        msg = RunnerCommand.REPR_MSGS.format(fun, arg, kwarg, Command.SYNC, receiver)
+
+        self.assertTrue(Command.SYNC in msg)
+        self.assertTrue(fun in msg)
+        self.assertTrue(str(receiver) in msg)
+        self.assertTrue(str(arg) in msg)
+        self.assertTrue(str(kwarg) in msg)
+
+
+    def test_execute_calls_recievers_action_method(self):
+        '''
+        The execute method of RunnerCommand needs
+        to call action method of RunnerReceiver.
+        '''
+        mock = RunnerReceiver()
+        mock.action = MagicMock()
+
+        command = RunnerCommand(receiver=mock)
+        command.execute()
+        mock.action.assert_called()
+
+    def test_make_async_sets_async_client(self):
+        command = RunnerCommand(receiver=RunnerReceiver())
+        command.make_async()
+
+        self.assertEqual(command.client, Command.ASYNC)
+
+    def test_make_sync_sets_runner_client(self):
+        command = RunnerCommand(receiver=RunnerReceiver())
+        self.assertEqual(command.client, Command.SYNC)
+
+        command.make_async()
+        command.make_sync()
+        self.assertEqual(command.client, Command.SYNC)
+
+    def test_calls_cmd_sync_on_execute(self):
+        '''
+        RunnerCommand().execute should call cmd_sync on the client
+        '''
+        runner_client = MagicMock()
+        runner_client.cmd_sync = MagicMock()
+
+        command = get_sync_runner_command(client=runner_client)
+        command.execute(
+            username='foo',
+            password='bar',
+            eauth='ldap')
+        runner_client.cmd_sync.assert_called()
+
+    def test_calls_cmd_async_on_execute(self):
+        '''
+        RunnerCommand().execute should call cmd_sync on the client
+        '''
+        runner_client = MagicMock()
+        runner_client.cmd_async = MagicMock()
+
+        command = RunnerCommand(receiver=RunnerReceiver(salt_client=runner_client))
+        command.make_async()
+        command.execute(token='123')
+        runner_client.cmd_async.assert_called()
+
+
+class RunnerClientDummy(object):
+    '''
+    For now these are stand ins for the RunnerClient
+    '''
+    def cmd_sync(self, low, timeout=10):
+        print('Called cmd_sync with low={0} and timeout={1}'.format(low, timeout))
+
+    def cmd_async(self, low, timeout=10):
+        print('Called cmd_async with low={0} and timeout={1}'.format(low, timeout))
+
+
+class RunnerCommandsTestCase(unittest.TestCase):
+    def test_can_build_sync_runner_command(self):
+        self.assertIsNotNone(get_sync_runner_command())
+
+    def test_can_build_async_runner_command(self):
+        self.assertIsNotNone(get_async_runner_command())
+
+
+class RunnerReceiverTestCase(unittest.TestCase):
+    def test_can_set_salt_client(self):
+        salt_client = RunnerClientDummy()
+        recv = RunnerReceiver(salt_client=salt_client)
+        self.assertEqual(salt_client, recv.client)
+
+    def action_calls_cmd_sync(self):
+        salt_client = MagicMock()
+        salt_client.cmd_sync = MagicMock()
+
+        recv = RunnerReceiver(salt_client=salt_client)
+        recv.action()
+        salt_client.cmd_sync.assert_called()
+
+    def test_action_calls_cmd_async(self):
+        salt_client = MagicMock()
+        salt_client.cmd_async = MagicMock()
+        recv = RunnerReceiver(salt_client=salt_client)
+        recv.action(low={'client': 'runner_async', 'fun': 'foo.bar'}, token='1234')
+        salt_client.cmd_async.assert_called()
+
+
+class APIClientTestCase(unittest.TestCase):
+    def test_has_submit_command_method(self):
+        '''
+        Check that the submit_runner_command method is available
+        '''
+        self.assertIsNotNone(APIClient.submit_runner_command)
+
+    def test_raises_exception_when_submit_runner_command_is_called_without_auth(self):
+        '''
+        Test that cmd_sync is called on the
+        client that we set
+        '''
+        with self.assertRaises(SaltRunnerError):
+            runner_client = MagicMock()
+            runner_client.cmd_sync = MagicMock()
+            APIClient.submit_runner_command(get_sync_runner_command(
+                    fun='grains.get',
+                    arg=['osfullname'],
+                    client=runner_client))
+
+        with self.assertRaises(SaltRunnerError):
+            runner_client = MagicMock()
+            runner_client.cmd_async = MagicMock()
+            APIClient.submit_runner_command(get_async_runner_command(
+                    fun='grains.get',
+                    arg=['osfullname'],
+                    client=runner_client))
+
+    def test_it_works_when_submit_runner_command_is_called_with_token(self):
+        runner_client = MagicMock()
+        runner_client.cmd_async = MagicMock()
+        APIClient.submit_runner_command(get_async_runner_command(
+                client=runner_client), token=1234567)
+        runner_client.cmd_async.assert_called()
+
+        runner_client_sync = MagicMock()
+        runner_client_sync.cmd_sync = MagicMock()
+        APIClient.submit_runner_command(get_sync_runner_command(
+                client=runner_client_sync), token=1234567)
+        runner_client_sync.cmd_sync.assert_called()
+
+
+    def test_it_works_when_submit_runner_command_is_called_with_eauth(self):
+        runner_client = MagicMock()
+        runner_client.cmd_async = MagicMock()
+        APIClient.submit_runner_command(get_async_runner_command(
+                client=runner_client), eauth='pam')
+        runner_client.cmd_async.assert_called()
+
+        runner_client_sync = MagicMock()
+        runner_client_sync.cmd_sync = MagicMock()
+        APIClient.submit_runner_command(get_sync_runner_command(
+                client=runner_client_sync), eauth='ldap')
+        runner_client_sync.cmd_sync.assert_called()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/command_test.py
+++ b/tests/unit/command_test.py
@@ -1,21 +1,25 @@
-import unittest
-from mock import MagicMock
+# encoding: utf-8
+from __future__ import absolute_import
 
-from command_pattern.command import Command,\
+from salttesting import TestCase
+from salttesting.mock import MagicMock
+
+from salt.command import Command,\
     RunnerCommand,\
     RunnerReceiver, \
     get_async_runner_command, \
     get_sync_runner_command, \
     APIClient, \
-    SaltRunnerError
+    SaltCommandError, \
+    get_command_for_low_data
 
 
-class CommandTestCase(unittest.TestCase):
+class CommandTestCase(TestCase):
     def test_command_has_execute_method(self):
         self.assertEqual(hasattr(Command(), 'execute'), True)
 
 
-class RunnerCommandTestCase(unittest.TestCase):
+class RunnerCommandTestCase(TestCase):
     def test_command_has_execute_method(self):
         '''
         Commands must implement execute
@@ -39,7 +43,6 @@ class RunnerCommandTestCase(unittest.TestCase):
         self.assertTrue(str(receiver) in msg)
         self.assertTrue(str(arg) in msg)
         self.assertTrue(str(kwarg) in msg)
-
 
     def test_execute_calls_recievers_action_method(self):
         '''
@@ -75,10 +78,7 @@ class RunnerCommandTestCase(unittest.TestCase):
         runner_client.cmd_sync = MagicMock()
 
         command = get_sync_runner_command(client=runner_client)
-        command.execute(
-            username='foo',
-            password='bar',
-            eauth='ldap')
+        command.execute()
         runner_client.cmd_sync.assert_called()
 
     def test_calls_cmd_async_on_execute(self):
@@ -90,22 +90,11 @@ class RunnerCommandTestCase(unittest.TestCase):
 
         command = RunnerCommand(receiver=RunnerReceiver(salt_client=runner_client))
         command.make_async()
-        command.execute(token='123')
+        command.execute()
         runner_client.cmd_async.assert_called()
 
 
-class RunnerClientDummy(object):
-    '''
-    For now these are stand ins for the RunnerClient
-    '''
-    def cmd_sync(self, low, timeout=10):
-        print('Called cmd_sync with low={0} and timeout={1}'.format(low, timeout))
-
-    def cmd_async(self, low, timeout=10):
-        print('Called cmd_async with low={0} and timeout={1}'.format(low, timeout))
-
-
-class RunnerCommandsTestCase(unittest.TestCase):
+class RunnerCommandsTestCase(TestCase):
     def test_can_build_sync_runner_command(self):
         self.assertIsNotNone(get_sync_runner_command())
 
@@ -113,9 +102,9 @@ class RunnerCommandsTestCase(unittest.TestCase):
         self.assertIsNotNone(get_async_runner_command())
 
 
-class RunnerReceiverTestCase(unittest.TestCase):
+class RunnerReceiverTestCase(TestCase):
     def test_can_set_salt_client(self):
-        salt_client = RunnerClientDummy()
+        salt_client = {}
         recv = RunnerReceiver(salt_client=salt_client)
         self.assertEqual(salt_client, recv.client)
 
@@ -131,64 +120,49 @@ class RunnerReceiverTestCase(unittest.TestCase):
         salt_client = MagicMock()
         salt_client.cmd_async = MagicMock()
         recv = RunnerReceiver(salt_client=salt_client)
-        recv.action(low={'client': 'runner_async', 'fun': 'foo.bar'}, token='1234')
+        recv.action(low={'client': 'runner_async', 'fun': 'foo.bar'})
         salt_client.cmd_async.assert_called()
 
 
-class APIClientTestCase(unittest.TestCase):
+class APIClientTestCase(TestCase):
     def test_has_submit_command_method(self):
         '''
         Check that the submit_runner_command method is available
         '''
         self.assertIsNotNone(APIClient.submit_runner_command)
 
-    def test_raises_exception_when_submit_runner_command_is_called_without_auth(self):
-        '''
-        Test that cmd_sync is called on the
-        client that we set
-        '''
-        with self.assertRaises(SaltRunnerError):
-            runner_client = MagicMock()
-            runner_client.cmd_sync = MagicMock()
-            APIClient.submit_runner_command(get_sync_runner_command(
-                    fun='grains.get',
-                    arg=['osfullname'],
-                    client=runner_client))
-
-        with self.assertRaises(SaltRunnerError):
-            runner_client = MagicMock()
-            runner_client.cmd_async = MagicMock()
-            APIClient.submit_runner_command(get_async_runner_command(
-                    fun='grains.get',
-                    arg=['osfullname'],
-                    client=runner_client))
-
-    def test_it_works_when_submit_runner_command_is_called_with_token(self):
-        runner_client = MagicMock()
-        runner_client.cmd_async = MagicMock()
-        APIClient.submit_runner_command(get_async_runner_command(
-                client=runner_client), token=1234567)
-        runner_client.cmd_async.assert_called()
-
-        runner_client_sync = MagicMock()
-        runner_client_sync.cmd_sync = MagicMock()
-        APIClient.submit_runner_command(get_sync_runner_command(
-                client=runner_client_sync), token=1234567)
-        runner_client_sync.cmd_sync.assert_called()
+    def test_it_calls_execute_on_command(self):
+        command = MagicMock()
+        command.execute = MagicMock()
+        APIClient.submit_runner_command(command)
+        command.execute.assert_called()
 
 
-    def test_it_works_when_submit_runner_command_is_called_with_eauth(self):
-        runner_client = MagicMock()
-        runner_client.cmd_async = MagicMock()
-        APIClient.submit_runner_command(get_async_runner_command(
-                client=runner_client), eauth='pam')
-        runner_client.cmd_async.assert_called()
+class CommandForLowDataTestCase(TestCase):
+    def test_returns_command_for_low_data(self):
+        low = {
+            'client': 'runner',
+            'fun': 'foo.bar',
+            'arg': [],
+            'kwarg': {}
+        }
+        self.assertIsInstance(get_command_for_low_data(low), Command)
 
-        runner_client_sync = MagicMock()
-        runner_client_sync.cmd_sync = MagicMock()
-        APIClient.submit_runner_command(get_sync_runner_command(
-                client=runner_client_sync), eauth='ldap')
-        runner_client_sync.cmd_sync.assert_called()
+    def test_raises_error_if_client_not_specified(self):
+        low = {
+            'fun': 'foo.bar',
+            'arg': [],
+            'kwarg': {}
+        }
+        with self.assertRaises(SaltCommandError):
+            get_command_for_low_data(low)
+
 
 if __name__ == '__main__':
-    unittest.main()
+    from integration import run_tests
+    run_tests(CommandTestCase, needs_daemon=False)
+    run_tests(RunnerCommandTestCase, needs_daemon=False)
+    run_tests(RunnerCommandsTestCase, needs_daemon=False)
+    run_tests(RunnerReceiverTestCase, needs_daemon=False)
+    run_tests(APIClientTestCase, needs_daemon=False)
+    run_tests(CommandForLowDataTestCase, needs_daemon=False)


### PR DESCRIPTION
### What does this PR do?

Adds code to encapsulate invocations to salt's python clients. This only covers the `RunnerClient` for now. Will add support for others (depending on how this goes).

Example usage:

``` python
from salt.command import get_command_for_low_data, APIClient

low = {
 ...snip
}
command = get_command_for_low_data(low)  # low is the dictionary with salt's low data
APIClient.submit(command)  # calls runner client
```
### What issues does this PR fix or reference?

This references the feature #32778
### Previous Behavior

``` python
from salt.runner import RunnerClient

low = {
 ...snip
}

opts = ...

client = RunnerClient(opts)  # could be WheelClient or LocalClient as well

client.cmd_sync(low)  # cmd_async is also an option
```
### New Behavior

``` python
from salt.command import get_command_for_low_data, APIClient

# low is the dictionary with salt's low data
low = {
 ...snip
}

command = get_command_for_low_data(low)  # let the code figure out what client to instantiate
APIClient.submit(command)  # calls runner client's cmd_sync (or cmd_async) method, depending on what low data was passed in. No need to be aware of the internal implementation.
```
### Tests written?

Yes, there are unit tests for the code.
Look at notes for info about integration tests.
### Notes:

This isn't yet integrated into the code base (there are no places in the code that make use of this functionality). 

The reasons are
- This is still experimental. (Feedback is appreciated!). Let's check if this is useful before integrating this with the code base.
- Some efforts might still be required to make sure that `WheelClient` class can be called with args and kwargs. Once that is in place I'll write the `Receiver` and concrete command for `WheelClient`.
- Need to write the `Receiver` and concrete command for Local Client.
  Once the above are satisfied we can start to integrate this.
