### PR TITLE
Better YAML syntax error handling

### DIFF
--- a/salt/renderers/yaml.py
+++ b/salt/renderers/yaml.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import
 import logging
 import warnings
 from yaml.scanner import ScannerError
+from yaml.parser import ParserError
 from yaml.constructor import ConstructorError
 
 # Import salt libs
@@ -52,7 +53,7 @@ def render(yaml_data, saltenv='base', sls='', argline='', **kws):
             err_type = _ERROR_MAP.get(exc.problem, exc.problem)
             line_num = exc.problem_mark.line + 1
             raise SaltRenderError(err_type, line_num, exc.problem_mark.buffer)
-        except ConstructorError as exc:
+        except (ParserError, ConstructorError) as exc:
             raise SaltRenderError(exc)
         if len(warn_list) > 0:
             for item in warn_list:


### PR DESCRIPTION
### What does this PR do?

Cleans up stacktrace on invalid yaml in top files
### What issues does this PR fix or reference?
#26574
### Previous Behavior

```
he minion function caused an exception: Traceback (most recent call last):
      File "/root/salt/salt/minion.py", line 1173, in _thread_return
        return_data = func(*args, **kwargs)
      File "/root/salt/salt/modules/state.py", line 1045, in show_top
        top_ = st_.get_top()
      File "/root/salt/salt/state.py", line 2436, in get_top
        tops = self.get_tops()
      File "/root/salt/salt/state.py", line 2313, in get_tops
        saltenv=saltenv
      File "/root/salt/salt/template.py", line 79, in compile_template
        ret = render(input_data, saltenv, sls, **render_kwargs)
      File "/root/salt/salt/renderers/yaml.py", line 50, in render
        data = load(yaml_data, Loader=get_yaml_loader(argline))
      File "/usr/lib/python2.7/dist-packages/yaml/__init__.py", line 71, in load
        return loader.get_single_data()
      File "/usr/lib/python2.7/dist-packages/yaml/constructor.py", line 37, in get_single_data
        node = self.get_single_node()
      File "/usr/lib/python2.7/dist-packages/yaml/composer.py", line 36, in get_single_node
        document = self.compose_document()
      File "/usr/lib/python2.7/dist-packages/yaml/composer.py", line 55, in compose_document
        node = self.compose_node(None, None)
      File "/usr/lib/python2.7/dist-packages/yaml/composer.py", line 84, in compose_node
        node = self.compose_mapping_node(anchor)
      File "/usr/lib/python2.7/dist-packages/yaml/composer.py", line 127, in compose_mapping_node
        while not self.check_event(MappingEndEvent):
      File "/usr/lib/python2.7/dist-packages/yaml/parser.py", line 98, in check_event
        self.current_event = self.state()
      File "/usr/lib/python2.7/dist-packages/yaml/parser.py", line 439, in parse_block_mapping_key
        "expected <block end>, but found %r" % token.id, token.start_mark)
    ParserError: while parsing a block mapping
      in "<unicode string>", line 1, column 1:
        base:
        ^
    expected <block end>, but found '<block sequence start>'
      in "<unicode string>", line 3, column 5:
            - state1
            ^
```
### New Behavior

```
mp@silver ...devel/salt/salt % sudo salt-call --local state.show_top                                                                                                                                                   (git)-[2015.5] 
14:23:48,751 [salt.state                               ][INFO    ] Loading fresh modules for state activity
14:23:48,760 [salt.fileclient                          ][INFO    ] Fetching file from saltenv 'base', ** skipped ** latest already in cache 'salt://top.sls'
14:23:48,762 [salt.state                               ][ERROR   ] Unable to render top file: while parsing a block mapping
  in "<unicode string>", line 1, column 1:
    base:
    ^
expected <block end>, but found '<block sequence start>'
  in "<unicode string>", line 4, column 5:
        - issue_32591
        ^
local:
    ----------
```
### Tests written?

No

Closes #26574
