### PR TITLE
Don't lay down all available opts

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -219,6 +219,7 @@ def minion_config(opts, vm_):
     minion = {
         'master': 'salt',
         'log_level': 'info',
+        'hash_type': 'sha256',
     }
 
     # Now, let's update it to our needs

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -216,7 +216,7 @@ def minion_config(opts, vm_):
 
     # Don't start with a copy of the default minion opts; they're not always
     # what we need
-    minion = {}
+    minion = {'master': 'salt'}
     # Some default options are Null, let's set a reasonable default
     minion.update(
         log_level='info',

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -215,14 +215,11 @@ def minion_config(opts, vm_):
     '''
 
     # Don't start with a copy of the default minion opts; they're not always
-    # what we need
-    minion = {'master': 'salt'}
-    # Some default options are Null, let's set a reasonable default
-    minion.update(
-        log_level='info',
-        log_level_logfile='info',
-        hash_type='sha256'
-    )
+    # what we need. Some default options are Null, let's set a reasonable default
+    minion = {
+        'master': 'salt',
+        'log_level': 'info',
+    }
 
     # Now, let's update it to our needs
     minion['id'] = vm_['name']

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -214,8 +214,9 @@ def minion_config(opts, vm_):
     Return a minion's configuration for the provided options and VM
     '''
 
-    # Let's get a copy of the salt minion default options
-    minion = copy.deepcopy(salt.config.DEFAULT_MINION_OPTS)
+    # Don't start with a copy of the default minion opts; they're not always
+    # what we need
+    minion = {}
     # Some default options are Null, let's set a reasonable default
     minion.update(
         log_level='info',


### PR DESCRIPTION
### What does this PR do?

Keep salt cloud from laying down all available opts on the minion.
### What issues does this PR fix or reference?

None.
### Previous Behavior

Laid down all default minion opts.
### Tests written?

No
