### PR TITLE
Fix LVM parameter devices as a pure list. Comma seperated lists are c…

### DIFF
--- a/salt/modules/linux_lvm.py
+++ b/salt/modules/linux_lvm.py
@@ -216,7 +216,7 @@ def pvcreate(devices, override=True, **kwargs):
     '''
     if not devices:
         return 'Error: at least one device is required'
-    if isinstance(devices, str):
+    if isinstance(devices, six.string_types):
         devices = devices.split(',')
 
     cmd = ['pvcreate']
@@ -266,7 +266,7 @@ def pvremove(devices, override=True):
 
         salt mymachine lvm.pvremove /dev/sdb1,/dev/sdb2
     '''
-    if isinstance(devices, str):
+    if isinstance(devices, six.string_types):
         devices = devices.split(',')
 
     cmd = ['pvremove', '-y']
@@ -305,7 +305,7 @@ def vgcreate(vgname, devices, **kwargs):
     '''
     if not vgname or not devices:
         return 'Error: vgname and device(s) are both required'
-    if isinstance(devices, str):
+    if isinstance(devices, six.string_types):
         devices = devices.split(',')
 
     cmd = ['vgcreate', vgname]
@@ -336,7 +336,7 @@ def vgextend(vgname, devices):
     '''
     if not vgname or not devices:
         return 'Error: vgname and device(s) are both required'
-    if isinstance(devices, str):
+    if isinstance(devices, six.string_types):
         devices = devices.split(',')
 
     cmd = ['vgextend', vgname]

--- a/salt/modules/linux_lvm.py
+++ b/salt/modules/linux_lvm.py
@@ -216,9 +216,11 @@ def pvcreate(devices, override=True, **kwargs):
     '''
     if not devices:
         return 'Error: at least one device is required'
+    if isinstance(devices, str):
+        devices = devices.split(',')
 
     cmd = ['pvcreate']
-    for device in devices.split(','):
+    for device in devices:
         if not os.path.exists(device):
             raise CommandExecutionError('{0} does not exist'.format(device))
         # Verify pvcreate was successful
@@ -244,7 +246,7 @@ def pvcreate(devices, override=True, **kwargs):
         raise CommandExecutionError(out.get('stderr'))
 
     # Verify pvcreate was successful
-    for device in devices.split(','):
+    for device in devices:
         if not pvdisplay(device):
             raise CommandExecutionError('Device "{0}" was not affected.'.format(device))
 
@@ -264,8 +266,11 @@ def pvremove(devices, override=True):
 
         salt mymachine lvm.pvremove /dev/sdb1,/dev/sdb2
     '''
+    if isinstance(devices, str):
+        devices = devices.split(',')
+
     cmd = ['pvremove', '-y']
-    for device in devices.split(','):
+    for device in devices:
         if pvdisplay(device):
             cmd.append(device)
         elif not override:
@@ -280,7 +285,7 @@ def pvremove(devices, override=True):
         raise CommandExecutionError(out.get('stderr'))
 
     # Verify pvcremove was successful
-    for device in devices.split(','):
+    for device in devices:
         if pvdisplay(device):
             raise CommandExecutionError('Device "{0}" was not affected.'.format(device))
 
@@ -300,9 +305,11 @@ def vgcreate(vgname, devices, **kwargs):
     '''
     if not vgname or not devices:
         return 'Error: vgname and device(s) are both required'
+    if isinstance(devices, str):
+        devices = devices.split(',')
 
     cmd = ['vgcreate', vgname]
-    for device in devices.split(','):
+    for device in devices:
         cmd.append(device)
     valid = ('clustered', 'maxlogicalvolumes', 'maxphysicalvolumes',
              'vgmetadatacopies', 'metadatacopies', 'physicalextentsize')
@@ -329,9 +336,11 @@ def vgextend(vgname, devices):
     '''
     if not vgname or not devices:
         return 'Error: vgname and device(s) are both required'
+    if isinstance(devices, str):
+        devices = devices.split(',')
 
     cmd = ['vgextend', vgname]
-    for device in devices.split(','):
+    for device in devices:
         cmd.append(device)
     out = __salt__['cmd.run'](cmd, python_shell=False).splitlines()
     vgdata = {'Output from vgextend': out[0].strip()}

--- a/salt/states/lvm.py
+++ b/salt/states/lvm.py
@@ -28,7 +28,7 @@ import os
 
 # Import salt libs
 import salt.utils
-
+mport salt.ext.six as six
 
 def __virtual__():
     '''
@@ -121,7 +121,7 @@ def vg_present(name, devices=None, **kwargs):
            'comment': '',
            'name': name,
            'result': True}
-    if isinstance(devices, str):
+    if isinstance(devices, six.string_types):
         devices = devices.split(',')
 
     if __salt__['lvm.vgdisplay'](name):

--- a/salt/states/lvm.py
+++ b/salt/states/lvm.py
@@ -30,6 +30,7 @@ import os
 import salt.utils
 import salt.ext.six as six
 
+
 def __virtual__():
     '''
     Only load the module if lvm is installed

--- a/salt/states/lvm.py
+++ b/salt/states/lvm.py
@@ -121,10 +121,12 @@ def vg_present(name, devices=None, **kwargs):
            'comment': '',
            'name': name,
            'result': True}
+    if isinstance(devices, str):
+        devices = devices.split(',')
 
     if __salt__['lvm.vgdisplay'](name):
         ret['comment'] = 'Volume Group {0} already present'.format(name)
-        for device in devices.split(','):
+        for device in devices:
             realdev = os.path.realpath(device)
             pvs = __salt__['lvm.pvdisplay'](realdev, real=True)
             if pvs and pvs.get(realdev, None):

--- a/salt/states/lvm.py
+++ b/salt/states/lvm.py
@@ -28,7 +28,7 @@ import os
 
 # Import salt libs
 import salt.utils
-mport salt.ext.six as six
+import salt.ext.six as six
 
 def __virtual__():
     '''


### PR DESCRIPTION
### What does this PR do?

Provide LVM devicelist as a pure list:

```
vg_test:
  lvm.vg_present:
    - devices:
      - /dev/vdb
      - /dev/vdc

```

Old syntax is still posible:

```
vg_test:
  lvm.vg_present:
    - devices: /dev/vdb,/dev/vdc

```
### What issues does this PR fix or reference?

none
### Previous Behavior

Error on a pure list input:

```
Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/site-packages/salt/state.py", line 1626, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1492, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python2.7/site-packages/salt/states/lvm.py", line 162, in vg_present
                  changes = __salt__['lvm.vgcreate'](name, devices, **kwargs)
                File "/usr/lib/python2.7/site-packages/salt/modules/linux_lvm.py", line 305, in vgcreate
                  for device in devices.split(','):
              AttributeError: 'list' object has no attribute 'split'

```
### New Behavior

Works now with list input
### Tests written?

No
