### PR TITLE
Add advanced settings config to win_iis

### DIFF
--- a/salt/states/win_iis.py
+++ b/salt/states/win_iis.py
@@ -342,6 +342,69 @@ def remove_apppool(name):
     return ret
 
 
+def container_setting(name, container, settings=None):
+    '''
+    Set the value of the setting for an IIS container.
+
+    :param str name: The name of the IIS container.
+    :param str container: The type of IIS container. The container types are:
+        AppPools, Sites, SslBindings
+    :param str settings: A dictionary of the setting names and their values.
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'comment': str(),
+           'result': None}
+
+    if not settings:
+        ret['comment'] = 'No settings to change provided.'
+        ret['result'] = True
+        return ret
+
+    ret_settings = {
+        'changes': {},
+        'failures': {},
+    }
+
+    current_settings = __salt__['win_iis.get_container_setting'](name=name,
+                                                                 container=container,
+                                                                 settings=settings.keys())
+    for setting in settings:
+        if str(settings[setting]) != str(current_settings[setting]):
+            ret_settings['changes'][setting] = {'old': current_settings[setting],
+                                                'new': settings[setting]}
+    if not ret_settings['changes']:
+        ret['comment'] = 'Settings already contain the provided values.'
+        ret['result'] = True
+        return ret
+    elif __opts__['test']:
+        ret['comment'] = 'Settings will be changed.'
+        ret['changes'] = ret_settings
+        return ret
+
+    __salt__['win_iis.set_container_setting'](name=name, container=container,
+                                              settings=settings)
+    new_settings = __salt__['win_iis.get_container_setting'](name=name,
+                                                             container=container,
+                                                             settings=settings.keys())
+    for setting in settings:
+        if str(settings[setting]) != str(new_settings[setting]):
+            ret_settings['failures'][setting] = {'old': current_settings[setting],
+                                                 'new': new_settings[setting]}
+            ret_settings['changes'].pop(setting, None)
+
+    if ret_settings['failures']:
+        ret['comment'] = 'Some settings failed to change.'
+        ret['changes'] = ret_settings
+        ret['result'] = False
+    else:
+        ret['comment'] = 'Set settings to contain the provided values.'
+        ret['changes'] = ret_settings['changes']
+        ret['result'] = True
+
+    return ret
+
+
 def create_app(name, site, sourcepath, apppool=None):
     '''
     Create an IIS application.


### PR DESCRIPTION
### What does this PR do?
- Adds the ability to get and set any advanced configuration parameters (App Pool identity, max worker processes, managed pipline mode, etc) for IIS Sites and AppPools.
### What issues does this PR fix or reference?
- None
### Previous Behavior
- The ability to get and set advanced configuration parameters for IIS was limited to the parameters exposed in the list__/create__/remove_\* win_iis functions.
### New Behavior
- Adds the ability to get and set any advanced configuration parameters for IIS Sites and AppPools.
### Tests written?

No
