### PR TITLE
adds missing versionadded

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -211,7 +211,7 @@ def extracted(name,
         trimmed, if this is set to True then it will default to 100
 
         .. versionadded:: 2016.3.0
-'''
+    '''
     ret = {'name': name, 'result': None, 'changes': {}, 'comment': ''}
     valid_archives = ('tar', 'rar', 'zip')
 

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -155,6 +155,8 @@ def extracted(name,
         Set this to ``True`` if archive should be extracted if source_hash has
         changed. This would extract regardless of the ``if_missing`` parameter.
 
+        .. versionadded:: 2016.3.0
+
     archive_format
         ``tar``, ``zip`` or ``rar``
 
@@ -207,7 +209,9 @@ def extracted(name,
     trim_output
         The number of files we should output on success before the rest are
         trimmed, if this is set to True then it will default to 100
-    '''
+
+        .. versionadded:: 2016.3.0
+'''
     ret = {'name': name, 'result': None, 'changes': {}, 'comment': ''}
     valid_archives = ('tar', 'rar', 'zip')
 


### PR DESCRIPTION
### What does this PR do?

updates doc string
adds missing  versionadded to states.archive.extracted:
trim_outpout and source_hash_changed appeared in v2016.3
