### PR TITLE
Make --gpg-auto-import-keys a global param when calling zypper

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -766,6 +766,7 @@ def mod_repo(repo, **kwargs):
 
     # Modify added or existing repo according to the options
     cmd_opt = []
+    global_cmd_opt = []
 
     if 'enabled' in kwargs:
         cmd_opt.append(kwargs['enabled'] and '--enable' or '--disable')
@@ -779,18 +780,18 @@ def mod_repo(repo, **kwargs):
     if 'gpgcheck' in kwargs:
         cmd_opt.append(kwargs['gpgcheck'] and '--gpgcheck' or '--no-gpgcheck')
 
-    if kwargs.get('gpgautoimport') is True:
-        cmd_opt.append('--gpg-auto-import-keys')
-
     if 'priority' in kwargs:
         cmd_opt.append("--priority={0}".format(kwargs.get('priority', DEFAULT_PRIORITY)))
 
     if 'humanname' in kwargs:
         cmd_opt.append("--name='{0}'".format(kwargs.get('humanname')))
 
+    if kwargs.get('gpgautoimport') is True:
+        global_cmd_opt.append('--gpg-auto-import-keys')
+
     if cmd_opt:
-        cmd_opt.append(repo)
-        __zypper__.refreshable.xml.call('mr', *cmd_opt)
+        cmd_opt = global_cmd_opt + ['mr'] + cmd_opt + [repo]
+        __zypper__.refreshable.xml.call(*cmd_opt)
 
     # If repo nor added neither modified, error should be thrown
     if not added and not cmd_opt:


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug in modules.zypper.mod_repo.
Without this fix, zypper.mod_repo calls zypper like this:

`zypper mr --gpg-auto-import-keys --refresh <repo-name>`

while it should call it like this:

`zypper --gpg-auto-import-keys mr --refresh <repo-name>`
### What issues does this PR fix or reference?

This is related to pkgrepo.managed. With this fix, this would work as expected:

``` yaml
systemsmanagement_saltstack:
  pkgrepo.managed:
    - url: http://repo.url/path
    - enabled: True
    - refresh: True
    - gpgkey: http://repo.key
    - gpgautoimport: True
```

At the moment the key is rejected and on subsequent `zypper refresh`  it asks the user to accept/reject the key.

From zypper man pages:

```
       --gpg-auto-import-keys
           If new repository signing key is found, do not ask what to do; trust and import it automatically. This
           option causes that the new key is imported also in non-interactive mode, where it would otherwise got
           rejected.
```
### Tests written?

Yes
