### PR TITLE
Fix reactor engine not being loaded.

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -541,7 +541,7 @@ class Master(SMaster):
             if self.opts.get('reactor'):
                 if isinstance(self.opts['engines'], list):
                     rine = False
-                    for item in self.opts:
+                    for item in self.opts['engines']:
                         if 'reactor' in item:
                             rine = True
                             break


### PR DESCRIPTION
The reactor engine was not loaded when it was not explicitly defined
in the configuraiton file. See #33090

Closes #33090
