### PR TITLE
Avoid a syntax error by using " instead of escaped '

### DIFF
--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -652,7 +652,7 @@ def bootstrap(version='develop',
                         ('root@' if root_user else '') + host,
                         'python -c \'import urllib; '
                         'print urllib.urlopen('
-                        '\'' + script + '\''
+                        '"' + script + '"'
                         ').read()\' | sh -s -- git ' + version])
 
 


### PR DESCRIPTION
### What does this PR do?

Fixes a syntax error in the `manage.bootstrap` runner.
### What issues does this PR fix or reference?

Fixes #26913
### Previous Behavior

Runner function would exit with a syntax error:

```
  File "<string>", line 1
    import urllib; print urllib.urlopen(https://bootstrap.saltstack.com).read()
```
### New Behavior

There is no longer a syntax error and the bootstrap script runs.
### Tests written?

No
