### PR TITLE
Fix for salt issue #33445

### DIFF
--- a/salt/modules/mongodb.py
+++ b/salt/modules/mongodb.py
@@ -233,7 +233,7 @@ def user_create(name, passwd, user=None, password=None, host=None, port=None,
 
         salt '*' mongodb.user_create <name> <user> <password> <host> <port> <database>
     '''
-    conn = _connect(user, password, host, port, authdb=authdb)
+    conn = _connect(user, password, host, port, database, authdb=authdb)
     if not conn:
         return 'Failed to connect to mongo database'
 

--- a/salt/modules/mongodb.py
+++ b/salt/modules/mongodb.py
@@ -165,7 +165,7 @@ def user_list(user=None, password=None, host=None, port=None, database='admin', 
 
         salt '*' mongodb.user_list <user> <password> <host> <port> <database>
     '''
-    conn = _connect(user, password, host, port, authdb=authdb)
+    conn = _connect(user, password, host, port, database, authdb=authdb)
     if not conn:
         return 'Failed to connect to mongo database'
 
@@ -262,7 +262,7 @@ def user_remove(name, user=None, password=None, host=None, port=None,
 
         salt '*' mongodb.user_remove <name> <user> <password> <host> <port> <database>
     '''
-    conn = _connect(user, password, host, port)
+    conn = _connect(user, password, host, port, database, authdb=authdb)
     if not conn:
         return 'Failed to connect to mongo database'
 


### PR DESCRIPTION
### What does this PR do?

Passes the database from mongodb user_create to _connect
### What issues does this PR fix or reference?
#33445
### Previous Behavior

In _connect database always equals admin
### New Behavior

In _connect database equals the passed database or defaults to admin
### Tests written?

No

Passing the database to the conn function so that it will connect to something other than admin.
