### PR TITLE
Correct (and make consistent) determination of the test flag.

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -196,7 +196,22 @@ def low(data, queue=False, **kwargs):
     return ret
 
 
-def high(data, test=False, queue=False, **kwargs):
+def _get_test_value(test=None, **kwargs):
+    '''
+    Determine the correct value for the test flag.
+    '''
+    ret = True
+    if test is None:
+        if salt.utils.test_mode(test=test, **kwargs):
+            ret = True
+        else:
+            ret = __opts__.get('test', None)
+    else:
+        ret = test
+    return ret
+
+
+def high(data, test=None, queue=False, **kwargs):
     '''
     Execute the compound calls stored in a single set of high data
 
@@ -214,12 +229,7 @@ def high(data, test=False, queue=False, **kwargs):
         return conflict
     opts = _get_opts(kwargs.get('localconfig'))
 
-    if salt.utils.test_mode(test=test, **kwargs):
-        opts['test'] = True
-    elif test is not None:
-        opts['test'] = test
-    else:
-        opts['test'] = __opts__.get('test', None)
+    opts['test'] = _get_test_value(test, **kwargs)
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -622,13 +632,7 @@ def highstate(test=None,
 
     opts = _get_opts(kwargs.get('localconfig'))
 
-    if test is None:
-        if salt.utils.test_mode(test=test, **kwargs):
-            opts['test'] = True
-        else:
-            opts['test'] = __opts__.get('test', None)
-    else:
-        opts['test'] = test
+    opts['test'] = _get_test_value(test, **kwargs)
 
     if 'env' in kwargs:
         salt.utils.warn_until(
@@ -801,12 +805,7 @@ def sls(mods,
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
 
-    if salt.utils.test_mode(test=test, **kwargs):
-        opts['test'] = True
-    elif test is not None:
-        opts['test'] = test
-    else:
-        opts['test'] = __opts__.get('test', None)
+    opts['test'] = _get_test_value(test, **kwargs)
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -909,10 +908,7 @@ def top(topfn,
         return err
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
-    if salt.utils.test_mode(test=test, **kwargs):
-        opts['test'] = True
-    else:
-        opts['test'] = __opts__.get('test', None)
+    opts['test'] = _get_test_value(test, **kwargs)
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -1018,10 +1014,7 @@ def sls_id(
         return conflict
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
-    if salt.utils.test_mode(test=test, **kwargs):
-        opts['test'] = True
-    else:
-        opts['test'] = __opts__.get('test', None)
+    opts['test'] = _get_test_value(test, **kwargs)
     if 'pillarenv' in kwargs:
         opts['pillarenv'] = kwargs['pillarenv']
     st_ = salt.state.HighState(opts)
@@ -1082,10 +1075,7 @@ def show_low_sls(mods,
         return conflict
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
-    if salt.utils.test_mode(test=test, **kwargs):
-        opts['test'] = True
-    else:
-        opts['test'] = __opts__.get('test', None)
+    opts['test'] = _get_test_value(test, **kwargs)
     if 'pillarenv' in kwargs:
         opts['pillarenv'] = kwargs['pillarenv']
     st_ = salt.state.HighState(opts)
@@ -1138,10 +1128,7 @@ def show_sls(mods, saltenv='base', test=None, queue=False, env=None, **kwargs):
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
 
-    if salt.utils.test_mode(test=test, **kwargs):
-        opts['test'] = True
-    else:
-        opts['test'] = __opts__.get('test', None)
+    opts['test'] = _get_test_value(test, **kwargs)
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -1224,10 +1211,7 @@ def single(fun, name, test=None, queue=False, **kwargs):
                    'name': name})
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
-    if salt.utils.test_mode(test=test, **kwargs):
-        opts['test'] = True
-    else:
-        opts['test'] = __opts__.get('test', None)
+    opts['test'] = _get_test_value(test, **kwargs)
 
     pillar = kwargs.get('pillar')
     if pillar is not None and not isinstance(pillar, dict):
@@ -1276,7 +1260,7 @@ def clear_cache():
     return ret
 
 
-def pkg(pkg_path, pkg_sum, hash_type, test=False, **kwargs):
+def pkg(pkg_path, pkg_sum, hash_type, test=None, **kwargs):
     '''
     Execute a packaged state run, the packaged state run will exist in a
     tarball available locally. This packaged state
@@ -1320,10 +1304,7 @@ def pkg(pkg_path, pkg_sum, hash_type, test=False, **kwargs):
     popts = _get_opts(kwargs.get('localconfig'))
     popts['fileclient'] = 'local'
     popts['file_roots'] = {}
-    if salt.utils.test_mode(test=test, **kwargs):
-        popts['test'] = True
-    else:
-        popts['test'] = __opts__.get('test', None)
+    popts['test'] = _get_test_value(test, **kwargs)
     envs = os.listdir(root)
     for fn_ in envs:
         full = os.path.join(root, fn_)


### PR DESCRIPTION
### What does this PR do?

Makes the determination of the correct test value consistent and correct in the state execution module.
### What issues does this PR fix or reference?

Fixes: #33363
### Previous Behavior

There were 3 different patterns for determining the final value of test. Most (if not all) would override the explicit test argument's value with the value from the minion config if the minion config says test=True (not the default).
### New Behavior

Single pattern used by all functions in this module that take an explicit test argument.

Minion config will never be used to override and explicit test=True argument when the functions are invoked.
### Tests written?

No
