### PR TITLE
Fix libsodium for 32bit windows

### DIFF
--- a/pkg/windows/build_env.ps1
+++ b/pkg/windows/build_env.ps1
@@ -257,16 +257,6 @@ $p = Start-Process "$($ini['Settings']['ScriptsDir'])\pip.exe" -ArgumentList "in
 Write-Output " ----------------------------------------------------------------"
 Write-Output "   - Copying DLLs . . ."
 Write-Output " ----------------------------------------------------------------"
-ForEach ($key in $ini['CommonDLLs'].Keys) {
-    If ($arrInstalled -notcontains $key) {
-        Write-Output "   - $key . . ."
-        $file = "$($ini['CommonDLLs'][$key])"
-        $url  = "$($ini['Settings']['SaltRepo'])/$file"
-        $file = "$($ini['Settings']['PythonDir'])\$file"
-        DownloadFileWithProgress $url $file
-    }
-}
-
 # Architecture Specific DLL's
 ForEach($key in $ini[$bitDLLs].Keys) {
     If ($arrInstalled -notcontains $key) {

--- a/pkg/windows/modules/get-settings.psm1
+++ b/pkg/windows/modules/get-settings.psm1
@@ -58,17 +58,12 @@ Function Get-Settings {
         }
         $ini.Add("32bitPrograms", $32bitPrograms)
 
-        # CPU Architecture Independent DLL's
-        $CommonDLLs = @{
-            "libsodium" = "libsodium-13.dll"
-        }
-        $ini.Add("CommonDLLs", $CommonDLLs)
-
         # DLL's for 64 bit Windows
         $64bitDLLs = @{
             "Libeay"     = "libeay32.dll"
             "SSLeay"     = "ssleay32.dll"
             "OpenSSLLic" = "OpenSSL_License.txt"
+            "libsodium"  = "libsodium.dll"
         }
         $ini.Add("64bitDLLs", $64bitDLLs)
 
@@ -77,6 +72,7 @@ Function Get-Settings {
             "Libeay"     = "libeay32.dll"
             "SSLeay"     = "ssleay32.dll"
             "OpenSSLLic" = "OpenSSL_License.txt"
+            "libsodium"  = "libsodium.dll"
         }
         $ini.Add("32bitDLLs", $32bitDLLs)
 

--- a/pkg/windows/req.txt
+++ b/pkg/windows/req.txt
@@ -12,7 +12,7 @@ ioflo==1.5.3
 ioloop==0.1a0
 ipaddress==1.0.16
 Jinja2==2.8
-libnacl==1.4.4
+libnacl==1.4.5
 Mako==1.0.4
 MarkupSafe==0.23
 msgpack-python==0.4.7


### PR DESCRIPTION
### What does this PR do?

Adds platform specific dll's for windows. It seems only the 64bit version of libsodium was being put in the salt environment
### Previous Behavior

Launching 32bit salt caused an error message to pop up when launching salt. The message box said the libsodium dll was poss corrupt.
### New Behavior

Salt now uses the correct dll for each windows platform
### Tests written?

NA
