### PR TITLE
Add docs about PyYAML's 1024 character limitations for simple keys

### DIFF
--- a/doc/topics/troubleshooting/yaml_idiosyncrasies.rst
+++ b/doc/topics/troubleshooting/yaml_idiosyncrasies.rst
@@ -340,3 +340,13 @@ string with quotes:
     ValueError: month must be in 1..12
     >>> yaml.safe_load('"4017-16-20"')
     '4017-16-20'
+
+
+Keys Limited to 1024 Characters
+===============================
+
+Simple keys are limited to a single line and cannot be longer that 1024 characters.
+This is a limitation from PyYaml, as seen in a comment in `PyYAML's code`_, and
+applies to anything parsed by YAML in Salt.
+
+.. _PyYAML's code: http://pyyaml.org/browser/pyyaml/trunk/lib/yaml/scanner.py#L91


### PR DESCRIPTION
Fixes #33389
