### PR TITLE
Fix: Sometimes reactor does not find runner function

### DIFF
--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -305,6 +305,13 @@ class ReactWrap(object):
         '''
         if 'runner' not in self.client_cache:
             self.client_cache['runner'] = salt.runner.RunnerClient(self.opts)
+            # The len() function will cause the module functions to load if
+            # they aren't already loaded. We want to load them so that the
+            # spawned threads don't need to load them. Loading in the spawned
+            # threads creates race conditions such as sometimes not finding
+            # the required function because another thread is in the middle
+            # of loading the functions.
+            len(self.client_cache['runner'].functions)
         try:
             self.pool.fire_async(self.client_cache['runner'].low, args=(fun, kwargs))
         except SystemExit:
@@ -318,6 +325,13 @@ class ReactWrap(object):
         '''
         if 'wheel' not in self.client_cache:
             self.client_cache['wheel'] = salt.wheel.Wheel(self.opts)
+            # The len() function will cause the module functions to load if
+            # they aren't already loaded. We want to load them so that the
+            # spawned threads don't need to load them. Loading in the spawned
+            # threads creates race conditions such as sometimes not finding
+            # the required function because another thread is in the middle
+            # of loading the functions.
+            len(self.client_cache['wheel'].functions)
         try:
             self.pool.fire_async(self.client_cache['wheel'].low, args=(fun, kwargs))
         except SystemExit:


### PR DESCRIPTION
### What does this PR do?

salt/utils/reactor.py:
- The reactor currently spawns a thread for each reaction. Previously, the
  runner symbols were loaded in the spawned threads when iterated via
  `verify_fun()` in `salt.client.mixins.SyncClientMixin._low()`. This
  sometimes caused race conditions when two threads were trying to handle
  a similar reactor (eg presence events) and hence were both invoking
  `verify_fun`. The second thread sometimes would not be able to find the
  module function and fail. Now we load the module functions before
  spawning the thread.
- Do the same thing for wheel functions since it seems to have the
  exact same race condition.
### Tests written?

No

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
