### PR TITLE
Return full pending computer name (develop)

### DIFF
--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -344,10 +344,10 @@ def get_pending_computer_name():
 
         salt 'minion-id' system.get_pending_computer_name
     '''
-    current = get_computer_name().upper()
+    current = get_computer_name()
     pending = read_value('HKLM',
-                         r'SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName',
-                         'ComputerName')['vdata']
+                         r'SYSTEM\CurrentControlSet\Services\Tcpip\Parameters',
+                         'NV Hostname')['vdata']
     if pending:
         return pending if pending != current else None
     return False

--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -318,10 +318,7 @@ def set_computer_name(name):
         ret = {'Computer Name': {'Current': get_computer_name()}}
         pending = get_pending_computer_name()
         if pending not in (None, False):
-            if pending == name.upper():
-                ret['Computer Name']['Pending'] = name
-            else:
-                ret['Computer Name']['Pending'] = pending
+            ret['Computer Name']['Pending'] = pending
         return ret
     return False
 


### PR DESCRIPTION
### What does this PR do?

Returns the full pending computer name when longer than 15 characters
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/33422
### Previous Behavior

Only the first 15 characters of the pending computer name was being returned
### New Behavior

Return the full pending computer name (63 characters)
### Tests written?

No
