### PR TITLE
jobs.exit_success allow to check if a job has executed and exit successfully

### DIFF
--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -488,6 +488,48 @@ def print_job(jid, ext_source=None, outputter=None):
         return ret
 
 
+def exit_success(jid, ext_source=None):
+    '''
+    Check if a job has been executed and exit successfully
+
+    jid
+        The jid to look up.
+    ext_source
+        The external job cache to use. Default: `None`.
+
+    CLI Example:
+    .. code-block:: bash
+        salt-run jobs.exit_success 20160520145827701627
+    '''
+    ret = {}
+    mminion = salt.minion.MasterMinion(__opts__)
+    returner = _get_returner((
+        __opts__['ext_job_cache'],
+        ext_source,
+        __opts__['master_job_cache']
+    ))
+
+    try:
+        data = list_job(
+            jid,
+            ext_source=ext_source
+        )
+    except TypeError:
+        return ('Requested returner could not be loaded. '
+                'No JIDs could be retrieved.')
+
+    returns = data.get('Result', {})
+
+    for minion in returns:
+        minion_ret = returns[minion].get('return', {})
+        if minion_ret['retcode'] == 0:
+            ret[minion] = True
+        else:
+            ret[minion] = False
+
+    return ret
+
+
 def last_run(ext_source=None,
              outputter=None,
              metadata=None,

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -501,31 +501,16 @@ def exit_success(jid, ext_source=None):
     .. code-block:: bash
         salt-run jobs.exit_success 20160520145827701627
     '''
-    ret = {}
-    mminion = salt.minion.MasterMinion(__opts__)
-    returner = _get_returner((
-        __opts__['ext_job_cache'],
-        ext_source,
-        __opts__['master_job_cache']
-    ))
+    ret = dict()
 
-    try:
-        data = list_job(
-            jid,
-            ext_source=ext_source
-        )
-    except TypeError:
-        return ('Requested returner could not be loaded. '
-                'No JIDs could be retrieved.')
+    data = lookup_jid(
+        jid,
+        ext_source=ext_source
+    )
 
-    returns = data.get('Result', {})
-
-    for minion in returns:
-        minion_ret = returns[minion].get('return', {})
-        if minion_ret['retcode'] == 0:
-            ret[minion] = True
-        else:
-            ret[minion] = False
+    for minion in data:
+        if "retcode" in data[minion]:
+            ret[minion] = True if not data[minion]['retcode'] else False
 
     return ret
 


### PR DESCRIPTION
### What does this PR do?

This PR create a new method for runners.jobs which easy allow you to check if a job has been executed and it has returned successfully.

Currently salt lets you check the results of a job using:

```
# salt-run jobs.lookup_jid 20160520173111930120
minionsles12sp1-suma3pg.vagrant.local:
    ----------
    pid:
        15124
    retcode:
        0
    stderr:
    stdout:
```

If what we want is to check if a job has executed and returned successfully or not, I propose `jobs.exit_success` on this PR:

```
# salt-run jobs.exit_success 20160520173111930120
minionsles12sp1-suma3pg.vagrant.local:
    True
```

What do you think?
### Tests written?

No
