### PR TITLE
check the RPM signature of zypper pkg.download packages and report errors

### DIFF
--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -604,7 +604,7 @@ def version_cmp(ver1, ver2):
     return salt.utils.version_cmp(ver1, ver2)
 
 
-def check_sig(*paths):
+def checksum(*paths):
     '''
     Return if the signature of a RPM file is valid.
 
@@ -612,8 +612,8 @@ def check_sig(*paths):
 
     .. code-block:: bash
 
-        salt '*' lowpkg.check_sig /path/to/package1.rpm
-        salt '*' lowpkg.check_sig /path/to/package1.rpm /path/to/package2.rpm
+        salt '*' lowpkg.checksum /path/to/package1.rpm
+        salt '*' lowpkg.checksum /path/to/package1.rpm /path/to/package2.rpm
     '''
     ret = {}
 
@@ -626,13 +626,7 @@ def check_sig(*paths):
         if not __salt__['file.file_exists'](package_file):
             continue
 
-        check_cmd = ["rpm", "-K", "--quiet", package_file]
-        check_args = {
-            'ignore_retcode': True,
-            'output_loglevel': 'trace',
-            'python_shell': False,
-        }
-        if __salt__['cmd.retcode'](check_cmd, **check_args) == 0:
+        if not __salt__['cmd.retcode'](["rpm", "-K", "--quiet", package_file], ignore_retcode=True, output_loglevel='trace', python_shell=False):
             ret[package_file] = True
 
     return ret

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -602,3 +602,37 @@ def version_cmp(ver1, ver2):
         log.warning("Failed to compare version '{0}' to '{1}' using RPM: {2}".format(ver1, ver2, exc))
 
     return salt.utils.version_cmp(ver1, ver2)
+
+
+def check_sig(*paths):
+    '''
+    Return if the signature of a RPM file is valid.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' lowpkg.check_sig /path/to/package1.rpm
+        salt '*' lowpkg.check_sig /path/to/package1.rpm /path/to/package2.rpm
+    '''
+    ret = {}
+
+    if not paths:
+        raise CommandExecutionError("No RPM files has been specified.")
+
+    for package_file in paths:
+        ret[package_file] = False
+
+        if not __salt__['file.file_exists'](package_file):
+            continue
+
+        check_cmd = ["rpm", "-K", "--quiet", package_file]
+        check_args = {
+            'ignore_retcode': True,
+            'output_loglevel': 'trace',
+            'python_shell': False,
+        }
+        if __salt__['cmd.retcode'](check_cmd, **check_args) == 0:
+            ret[package_file] = True
+
+    return ret

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -615,18 +615,16 @@ def checksum(*paths):
         salt '*' lowpkg.checksum /path/to/package1.rpm
         salt '*' lowpkg.checksum /path/to/package1.rpm /path/to/package2.rpm
     '''
-    ret = {}
+    ret = dict()
 
     if not paths:
-        raise CommandExecutionError("No RPM files has been specified.")
+        raise CommandExecutionError("No package files has been specified.")
 
     for package_file in paths:
-        ret[package_file] = False
-
-        if not __salt__['file.file_exists'](package_file):
-            continue
-
-        if not __salt__['cmd.retcode'](["rpm", "-K", "--quiet", package_file], ignore_retcode=True, output_loglevel='trace', python_shell=False):
-            ret[package_file] = True
+        ret[package_file] = (bool(__salt__['file.file_exists'](package_file)) and
+                            not __salt__['cmd.retcode'](["rpm", "-K", "--quiet", package_file],
+                                                        ignore_retcode=True,
+                                                        output_loglevel='trace',
+                                                        python_shell=False))
 
     return ret

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1534,15 +1534,13 @@ def download(*packages, **kwargs):
             'repository-alias': repo.getAttribute("alias"),
             'path': dld_result.getElementsByTagName("localfile")[0].getAttribute("path"),
         }
-        if not __salt__['lowpkg.check_sig'](pkg_info['path']):
-            continue
-        pkg_ret[_get_first_aggregate_text(dld_result.getElementsByTagName("name"))] = pkg_info
+        if __salt__['lowpkg.checksum'](pkg_info['path']):
+            pkg_ret[_get_first_aggregate_text(dld_result.getElementsByTagName("name"))] = pkg_info
 
     if pkg_ret:
         failed = [pkg for pkg in packages if pkg not in pkg_ret]
         if failed:
-            pkg_ret['_error'] = ('The following package(s) failed to download: {0}'
-                                 .format(', '.join(failed)))
+            pkg_ret['_error'] = ('The following package(s) failed to download: {0}'.format(', '.join(failed)))
         return pkg_ret
 
     raise CommandExecutionError("Unable to download packages: {0}.".format(', '.join(packages)))

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1534,6 +1534,8 @@ def download(*packages, **kwargs):
             'repository-alias': repo.getAttribute("alias"),
             'path': dld_result.getElementsByTagName("localfile")[0].getAttribute("path"),
         }
+        if not __salt__['lowpkg.check_sig'](pkg_info['path']):
+            continue
         pkg_ret[_get_first_aggregate_text(dld_result.getElementsByTagName("name"))] = pkg_info
 
     if pkg_ret:

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1539,6 +1539,10 @@ def download(*packages, **kwargs):
         pkg_ret[_get_first_aggregate_text(dld_result.getElementsByTagName("name"))] = pkg_info
 
     if pkg_ret:
+        failed = [pkg for pkg in packages if pkg not in pkg_ret]
+        if failed:
+            pkg_ret['_error'] = ('The following package(s) failed to download: {0}'
+                                 .format(', '.join(failed)))
         return pkg_ret
 
     raise CommandExecutionError("Unable to download packages: {0}.".format(', '.join(packages)))


### PR DESCRIPTION
### What does this PR do?
- Create new method in rpm module which allow you to check if the signature of a RPM file is correct or not:

```
# salt '*' lowpkg.checksum /var/cache/zypp/packages/SLE-12-SP1-x86_64-Pool/x86_64/nmap-6.46-1.72.x86_64.rpm
minionsles12sp1-suma3pg.vagrant.local:
    ----------
    /var/cache/zypp/packages/SLE-12-SP1-x86_64-Pool/x86_64/nmap-6.46-1.72.x86_64.rpm:
        True
```
- Now zypper `pkg.download` checks if the packages are successfully downloaded and reports errors when some packages fail.
### What issues does this PR fix or reference?

This PR fixes inconsistent behavior of zypper pkg.download as it currently doesn't report errors correctly and it doesn't check if the downloaded may be corrupted. 

Before fix:

```
# salt '*' pkg.download nmap foo
minionsles12-suma3pg.vagrant.local:
    ----------
    nmap:
        ----------
        path:
            /var/cache/zypp/packages/SLE-12-x86_64-Pool/x86_64/nmap-6.46-1.72.x86_64.rpm
        repository-alias:
            SLE-12-x86_64-Pool
        repository-name:
            SLE-12-x86_64-Pool
```

After fix:

```
# salt '*' pkg.download nmap foo
minionsles12sp1-suma3pg.vagrant.local:
    ----------
    _error:
        The following package(s) failed to download: foo
    nmap:
        ----------
        path:
            /var/cache/zypp/packages/SLE-12-SP1-x86_64-Pool/x86_64/nmap-6.46-1.72.x86_64.rpm
        repository-alias:
            SLE-12-SP1-x86_64-Pool
        repository-name:
            SLE-12-SP1-x86_64-Pool
```
### Tests written?

No
