### PR TITLE
Don't allow a "repo" kwarg for pkgrepo.managed

### DIFF
--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -270,6 +270,13 @@ def managed(name, ppa=None, **kwargs):
         ret['comment'] = 'Repo management not implemented on this platform'
         return ret
 
+    if 'repo' in kwargs:
+        ret['result'] = False
+        ret['comment'] = ('\'repo\' is not a supported argument for this '
+                          'state. The \'name\' argument is probably what was '
+                          'intended.')
+        return ret
+
     repo = name
     if __grains__['os'] == 'Ubuntu':
         if ppa is not None:


### PR DESCRIPTION
This is not a valid argument for any of the supported pkgrepo platforms,
and having it pass through to pkg.expand_repo_def results in a
traceback.
