### PR TITLE
Return full pending computer name (2015.8)

### DIFF
--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -287,7 +287,7 @@ def set_computer_name(name):
 
     if windll.kernel32.SetComputerNameExW(win32con.ComputerNamePhysicalDnsHostname,
                                           name):
-        ret = {'Computer Name': {'Current': get_system_info()['name']}}
+        ret = {'Computer Name': {'Current': get_computer_name()}}
         pending = get_pending_computer_name()
         if pending not in (None, False):
             ret['Computer Name']['Pending'] = pending
@@ -315,8 +315,8 @@ def get_pending_computer_name():
     '''
     current = get_computer_name()
     pending = read_value('HKLM',
-                         r'SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName',
-                         'ComputerName')['vdata']
+                         r'SYSTEM\CurrentControlSet\Services\Tcpip\Parameters',
+                         'NV Hostname')['vdata']
     if pending:
         return pending if pending != current else None
     return False
@@ -335,7 +335,7 @@ def get_computer_name():
 
         salt 'minion-id' system.get_computer_name
     '''
-    name = get_system_info()['name']
+    name = win32api.GetComputerNameEx(win32con.ComputerNamePhysicalDnsHostname)
     return name if name else False
 
 


### PR DESCRIPTION
### What does this PR do?

Returns the full pending computer name when longer than 15 characters
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/33422
### Previous Behavior

Only the first 15 characters of the pending computer name was being returned
### New Behavior

Return the full pending computer name (63 characters)
### Tests written?

No
