### PR TITLE
states.pip: upgrade pip upgrade test versions

### DIFF
--- a/tests/integration/states/pip.py
+++ b/tests/integration/states/pip.py
@@ -360,7 +360,7 @@ class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
             # Let's install a fixed version pip over whatever pip was
             # previously installed
             ret = self.run_function(
-                'pip.install', ['pip==6.0'], upgrade=True,
+                'pip.install', ['pip==8.0.0'], upgrade=True,
                 ignore_installed=True,
                 bin_env=venv_dir
             )
@@ -375,15 +375,15 @@ class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
                 pprint.pprint(ret)
                 raise
 
-            # Le't make sure we have pip 6.0 installed
+            # Le't make sure we have pip 8.0.0 installed
             self.assertEqual(
                 self.run_function('pip.list', ['pip'], bin_env=venv_dir),
-                {'pip': '6.0'}
+                {'pip': '8.0.0'}
             )
 
             # Now the actual pip upgrade pip test
             ret = self.run_state(
-                'pip.installed', name='pip==6.0.7', upgrade=True,
+                'pip.installed', name='pip==8.0.3', upgrade=True,
                 bin_env=venv_dir
             )
             try:
@@ -391,7 +391,7 @@ class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
                 self.assertInSaltReturn(
                     'Installed',
                     ret,
-                    ['changes', 'pip==6.0.7']
+                    ['changes', 'pip==8.0.3']
                 )
             except AssertionError:
                 import pprint


### PR DESCRIPTION
### What does this PR do?

Upgrade the pip versions used in the pip state module integration test for pip upgrade testing to avoid stack trace coming from pip 6.0 code.
### What issues does this PR fix or reference?
### Previous Behavior

``` py
ERROR: Traceback (most recent call last):
  File "/private/tmp/salt-tests-tmpdir/6833-pip-upgrade-pip/bin/pip", line 7, in <module>
    from pip import main
  File "/private/tmp/salt-tests-tmpdir/6833-pip-upgrade-pip/lib/python2.7/site-packages/pip/__init__.py", line 13, in <module>
    from pip.utils import get_installed_distributions, get_prog
  File "/private/tmp/salt-tests-tmpdir/6833-pip-upgrade-pip/lib/python2.7/site-packages/pip/utils/__init__.py", line 22, in <module>
    from pip._vendor import pkg_resources, six
  File "/private/tmp/salt-tests-tmpdir/6833-pip-upgrade-pip/lib/python2.7/site-packages/pip/_vendor/__init__.py", line 61, in load_module
    __import__(name)
  File "/private/tmp/salt-tests-tmpdir/6833-pip-upgrade-pip/lib/python2.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 71, in <module>
    __import__('pip._vendor.packaging.requirements')
  File "/private/tmp/salt-tests-tmpdir/6833-pip-upgrade-pip/lib/python2.7/site-packages/pip/_vendor/packaging/requirements.py", line 49, in <module>
    VERSION_PEP440 = Regex(Specifier._regex_str, re.VERBOSE | re.IGNORECASE)
AttributeError: type object 'Specifier' has no attribute '_regex_str'
```
### New Behavior

```
test_issue_6833_pip_upgrade_pip (integration.states.pip.PipStateTest)
[CPU:44.9%|MEM:43.5%|Z:0]  ... ok
```
### Tests written?

No
