### PR TITLE
Add docstring examples to glance.py [2015.5]

### DIFF
--- a/salt/modules/glance.py
+++ b/salt/modules/glance.py
@@ -296,6 +296,12 @@ def image_schema(profile=None):
     '''
     Returns names and descriptions of the schema "image"'s
     properties for this profile's instance of glance
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' glance.image_schema
     '''
     return schema_get('image', profile)
 
@@ -307,6 +313,12 @@ def schema_get(name, profile=None):
       - images
       - member
       - members
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' glance.schema_get name=f16-jeos
     '''
     g_client = _auth(profile)
     pformat = pprint.PrettyPrinter(indent=4).pformat

--- a/tests/integration/modules/sysmod.py
+++ b/tests/integration/modules/sysmod.py
@@ -62,6 +62,7 @@ class SysModuleTest(integration.ModuleCase):
                 'runtests_decorators.depends_will_fallback',
                 'runtests_decorators.missing_depends',
                 'runtests_decorators.missing_depends_will_fallback',
+                'swift.head',
                 'yumpkg.expand_repo_def',
                 'yumpkg5.expand_repo_def',
                 'container_resource.run',


### PR DESCRIPTION
### What does this PR do?

Fixes docstring issues that https://github.com/saltstack/salt-jenkins/pull/175 exposes. Dependencies get installed that previously weren't, which loads this module.  

The swift.head function does not have a body, so I've skipped it from being checked for a docstring.

@gtmanfred Can you make sure these example look correct? 
### What issues does this PR fix or reference?

references https://github.com/saltstack/salt-jenkins/pull/175 
### Tests written?

No
