### PR TITLE
Add docstring examples to glance.py and nova.py [2015.8]

### DIFF
--- a/salt/modules/glance.py
+++ b/salt/modules/glance.py
@@ -448,6 +448,12 @@ def image_schema(profile=None):
     '''
     Returns names and descriptions of the schema "image"'s
     properties for this profile's instance of glance
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' glance.image_schema
     '''
     return schema_get('image', profile)
 
@@ -459,6 +465,13 @@ def image_update(id=None, name=None, profile=None, **kwargs):  # pylint: disable
     - min_ram (in MB)
     - protected (bool)
     - visibility ('public' or 'private')
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' glance.image_update id=c2eb2eb0-53e1-4a80-b990-8ec887eae7df
+        salt '*' glance.image_update name=f16-jeos
     '''
     if id:
         image = image_show(id=id, profile=profile)
@@ -512,6 +525,12 @@ def schema_get(name, profile=None):
       - images
       - member
       - members
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' glance.schema_get name=f16-jeos
     '''
     g_client = _auth(profile)
     pformat = pprint.PrettyPrinter(indent=4).pformat

--- a/salt/modules/nova.py
+++ b/salt/modules/nova.py
@@ -559,6 +559,12 @@ def list_(profile=None):
     '''
     To maintain the feel of the nova command line, this function simply calls
     the server_list function.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' nova.list
     '''
     return server_list(profile=profile)
 

--- a/tests/integration/modules/sysmod.py
+++ b/tests/integration/modules/sysmod.py
@@ -66,6 +66,7 @@ class SysModuleTest(integration.ModuleCase):
                 'runtests_decorators.depends_will_fallback',
                 'runtests_decorators.missing_depends',
                 'runtests_decorators.missing_depends_will_fallback',
+                'swift.head',
                 'yumpkg.expand_repo_def',
                 'yumpkg5.expand_repo_def',
                 'container_resource.run',


### PR DESCRIPTION
### What does this PR do?

Fixes docstring issues that saltstack/salt-jenkins#175 exposes. Dependencies get installed that previously weren't, which loads this module. 

The swift.head function does not have a body, so I've skipped it from being checked for a docstring. 

This adds the new functions that https://github.com/saltstack/salt/pull/33486 did not have. 

@gtmanfred Can you make sure these example look correct?
### What issues does this PR fix or reference?

references saltstack/salt-jenkins#175
### Tests written?

No
