### PR TITLE
keep safteychek, we still need it for older configs

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2911,7 +2911,12 @@ def apply_minion_config(overrides=None,
     # Enabling open mode requires that the value be set to True, and
     # nothing else!
     opts['open_mode'] = opts['open_mode'] is True
-
+    # Make sure ext_mods gets set if it is an untrue value
+    # (here to catch older bad configs)
+    opts['extension_modules'] = (
+        opts.get('extension_modules') or
+        os.path.join(opts['cachedir'], 'extmods')
+    )
     # Set up the utils_dirs location from the extension_modules location
     opts['utils_dirs'] = (
         opts.get('utils_dirs') or


### PR DESCRIPTION
### What does this PR do?

When we fixed the default config values we removed a safety check, this check does not matter on a fresh install of 2016.3, but on an upgrade where you have a bad config it still prevents catastrophe 
