### PR TITLE
Fix build script where pip didn't work

### DIFF
--- a/pkg/windows/build.bat
+++ b/pkg/windows/build.bat
@@ -26,10 +26,10 @@ if [%1]==[] (
 )
 
 :: Create Build Environment
-cmd /c powershell -ExecutionPolicy RemoteSigned -File "%CurDir%build_env.ps1" -Silent
+PowerShell.exe -ExecutionPolicy RemoteSigned -File "%CurDir%build_env.ps1" -Silent
 
 :: Install Current Version of salt
-cmd /c "%PyDir%\python.exe %SrcDir%\setup.py" install --force
+"%PyDir%\python.exe" "%SrcDir%\setup.py" install --force
 
 :: Build the Salt Package
 call "%CurDir%build_pkg.bat" "%Version%"

--- a/pkg/windows/req_pip.txt
+++ b/pkg/windows/req_pip.txt
@@ -1,2 +1,2 @@
-pip==8.1.1
-setuptools==21.0.0
+pip==8.1.2
+setuptools==21.2.1


### PR DESCRIPTION
### What does this PR do?

Fixes pip when built using the build script. For some reason it wasn't putting the right paths in the .exe.
### Previous Behavior

the pip.exe's had an incorrect path in the .exe causing it not to run. This was often hidden if python was installed on the system. Pip would revert to the installed pip instead of salt's pip.
### New Behavior

Salt's pip functions as expected.
### Tests written?

No
