### PR TITLE
Detect System Architecture for Mac Build

### DIFF
--- a/pkg/osx/build_pkg.sh
+++ b/pkg/osx/build_pkg.sh
@@ -52,6 +52,8 @@ else
     PKGDIR=$2
 fi
 
+CPUARCH=`uname -m`
+
 ############################################################################
 # Additional Parameters Required for the script to function properly
 ############################################################################
@@ -140,13 +142,17 @@ cp $SRCDIR/conf/minion $PKGDIR/etc/salt/minion.dist
 cp $SRCDIR/conf/master $PKGDIR/etc/salt/master.dist
 
 ############################################################################
-# Add Version to distribution.xml
+# Add Version and CPU Arch to distribution.xml
 ############################################################################
 echo -n -e "\033]0;Build_Pkg: Add Version to .xml\007"
 
 cd $PKGRESOURCES
 cp distribution.xml.dist distribution.xml
 SEDSTR="s/@VERSION@/$VERSION/"
+echo $SEDSTR
+sed -i '' $SEDSTR distribution.xml
+
+SEDSTR="s/@CPUARCH@/$CPUARCH/"
 echo $SEDSTR
 sed -i '' $SEDSTR distribution.xml
 
@@ -159,10 +165,10 @@ pkgbuild --root $PKGDIR \
          --scripts $PKGDIR/scripts \
          --identifier=com.saltstack.salt \
          --version=$VERSION \
-         --ownership=recommended salt-src-$VERSION.pkg
+         --ownership=recommended salt-src-$VERSION-$CPUARCH.pkg
 
 productbuild --resources=$PKGDIR/resources \
              --distribution=distribution.xml  \
-             --package-path=salt-src-$VERSION.pkg \
-             --version=$VERSION salt-$VERSION.pkg
+             --package-path=salt-src-$VERSION-$CPUARCH.pkg \
+             --version=$VERSION salt-$VERSION-$CPUARCH.pkg
 

--- a/pkg/osx/distribution.xml.dist
+++ b/pkg/osx/distribution.xml.dist
@@ -9,7 +9,7 @@
         </allowed-os-versions>
     </volume-check>
     <options rootVolumeOnly="true"
-             hostArchitectures="x86_64" />
+             hostArchitectures="@CPUARCH@" />
     <domains enable_localSystem="true" />
     <!-- Define background image -->
     <background file="saltstack.png"
@@ -25,7 +25,7 @@
     <!-- List all component packages -->
     <pkg-ref id="com.saltstack.salt"
              version="@VERSION@"
-             auth="root">salt-src-@VERSION@.pkg</pkg-ref>
+             auth="root">salt-src-@VERSION@-@CPUARCH@.pkg</pkg-ref>
     <!-- List them again here. They can now be organized
          as a hierarchy if you want. -->
     <choices-outline>


### PR DESCRIPTION
### What does this PR do?

Detects System Architecture on Mac for the build process. We are now adding the architecture to the file name when we build.
### What issues does this PR fix or reference?

None
### Previous Behavior

Architecture was hardcoded in distribution.xml but not added to the filename
### New Behavior

System Architecture is now detected and added to distribution.xml dynamically. File name contains the system architecture.
### Tests written?

No
