### PR TITLE
Allow exact arg matches to work in sys.list_modules func

### DIFF
--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -401,6 +401,8 @@ def list_modules(*args):
         return sorted(modules)
 
     for module in args:
+        if '*' not in module:
+            module += '*'
         for func in fnmatch.filter(__salt__, module):
             comps = func.split('.')
             if len(comps) < 2:

--- a/tests/integration/modules/sysmod.py
+++ b/tests/integration/modules/sysmod.py
@@ -45,11 +45,31 @@ class SysModuleTest(integration.ModuleCase):
 
     def test_list_modules(self):
         '''
-        sys.list_moduels
+        sys.list_modules
         '''
         mods = self.run_function('sys.list_modules')
         self.assertTrue('hosts' in mods)
         self.assertTrue('pkg' in mods)
+
+    def test_list_modules_with_arg(self):
+        '''
+        sys.list_modules u*
+
+        Tests getting the list of modules looking for the "user" module
+        '''
+        mods = self.run_function('sys.list_modules', 'u*')
+        self.assertIn('user', mods)
+
+    def test_list_modules_with_arg_exact_match(self):
+        '''
+        sys.list_modules user
+
+        Tests getting the list of modules looking for the "user" module with
+        an exact match of 'user' being passed at the CLI instead of something
+        with '*'.
+        '''
+        mods = self.run_function('sys.list_modules', 'user')
+        self.assertIn('user', mods)
 
     def test_valid_docs(self):
         '''


### PR DESCRIPTION
### What does this PR do?

Allows an exact module name to be passed in to `sys.list_modules` instead of requiring a `*`.
### What issues does this PR fix or reference?

Fixes #33500
### Previous Behavior

```
root@rallytime:~# salt-call --local sys.list_modules user
local:
```
### New Behavior

```
root@rallytime:~# salt-call --local sys.list_modules user
local:
    - user
```
### Tests written?

Yes
