### PR TITLE
rework modules.mac_brew.latest_version to work around brew version inconsistency

### DIFF
--- a/salt/modules/mac_brew.py
+++ b/salt/modules/mac_brew.py
@@ -469,3 +469,49 @@ def upgrade(refresh=True):
     ret['changes'] = salt.utils.compare_dicts(old, new)
 
     return ret
+
+
+def _info(*names):
+    '''
+    Return the information of the named package(s)
+
+    .. versionadded:: 2016.3.1
+
+    names
+        The names of the packages for which to return information.
+    '''
+    cmd = ['brew', 'info', '--json=v1']
+    cmd.extend(names)
+    res = _call_brew(cmd)
+    ret = {}
+
+    try:
+        data = json.loads(res['stdout'])
+    except ValueError as err:
+        msg = 'unable to interpret output from "brew info": {0}'.format(err)
+        log.error(msg)
+        raise CommandExecutionError(msg)
+
+    for pkg in data:
+        ret[pkg['name']] = pkg
+
+    return ret
+
+
+def info_installed(*names):
+    '''
+    Return the information of the named package(s) installed on the system.
+
+    .. versionadded:: 2016.3.1
+
+    names
+        The names of the packages for which to return information.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.info_installed <package1>
+        salt '*' pkg.info_installed <package1> <package2> <package3> ...
+    '''
+    return _info(*names)

--- a/tests/integration/modules/mac_brew.py
+++ b/tests/integration/modules/mac_brew.py
@@ -12,7 +12,6 @@ from salttesting import skipIf
 from salttesting.helpers import (
     destructiveTest,
     ensure_in_syspath,
-    requires_system_grains
 )
 ensure_in_syspath('../../')
 
@@ -27,6 +26,8 @@ ADD_PKG = 'algol68g'
 DEL_PKG = 'acme'
 
 
+@destructiveTest
+@skipIf(os.geteuid() != 0, 'You must be logged in as root to run this test')
 class BrewModuleTest(integration.ModuleCase):
     '''
     Integration tests for the brew module
@@ -51,10 +52,7 @@ class BrewModuleTest(integration.ModuleCase):
                 'You must have brew installed to run these tests'
             )
 
-    @destructiveTest
-    @skipIf(os.geteuid() != 0, 'You must be logged in as root to run this test')
-    @requires_system_grains
-    def test_brew_install(self, grains=None):
+    def test_brew_install(self):
         '''
         Tests the installation of packages
         '''
@@ -70,10 +68,7 @@ class BrewModuleTest(integration.ModuleCase):
             self.run_function('pkg.remove', [ADD_PKG])
             raise
 
-    @destructiveTest
-    @skipIf(os.geteuid() != 0, 'You must be logged in as root to run this test')
-    @requires_system_grains
-    def test_remove(self, grains=None):
+    def test_remove(self):
         '''
         Tests the removal of packages
         '''
@@ -96,10 +91,7 @@ class BrewModuleTest(integration.ModuleCase):
             self.run_function('pkg.remove', [DEL_PKG])
             raise
 
-    @destructiveTest
-    @skipIf(os.geteuid() != 0, 'You must be logged in as root to run this test')
-    @requires_system_grains
-    def test_mac_brew_pkg_version(self, grains=None):
+    def test_mac_brew_pkg_version(self):
         '''
         Test pkg.version for mac. Installs
         a package and then checks we can get
@@ -129,20 +121,14 @@ class BrewModuleTest(integration.ModuleCase):
             self.run_function('pkg.remove', [ADD_PKG])
             raise
 
-    @destructiveTest
-    @skipIf(os.geteuid() != 0, 'You must be logged in as root to run this test')
-    @requires_system_grains
-    def test_mac_brew_refresh_db(self, grains=None):
+    def test_mac_brew_refresh_db(self):
         '''
         Integration test to ensure pkg.refresh_db works with brew
         '''
         refresh_brew = self.run_function('pkg.refresh_db')
         self.assertTrue(refresh_brew)
 
-    @destructiveTest
-    @skipIf(os.geteuid() != 0, 'You must be logged in as root to run this test')
-    @requires_system_grains
-    def tearDown(self, grains=None):
+    def tearDown(self):
         '''
         Clean up after tests
         '''

--- a/tests/integration/modules/mac_brew.py
+++ b/tests/integration/modules/mac_brew.py
@@ -94,7 +94,7 @@ class BrewModuleTest(integration.ModuleCase):
             self.run_function('pkg.remove', [DEL_PKG])
             raise
 
-    def test_mac_brew_pkg_version(self):
+    def test_version(self):
         '''
         Test pkg.version for mac. Installs
         a package and then checks we can get
@@ -124,7 +124,32 @@ class BrewModuleTest(integration.ModuleCase):
             self.run_function('pkg.remove', [ADD_PKG])
             raise
 
-    def test_mac_brew_refresh_db(self):
+    def test_latest_version(self):
+        '''
+        Test pkg.latest_version:
+          - get the latest version available
+          - install the package
+          - get the latest version available
+          - check that the latest version is empty after installing it
+        '''
+        try:
+            self.run_function('pkg.remove', [ADD_PKG])
+            uninstalled_latest = self.run_function('pkg.latest_version', [ADD_PKG])
+
+            self.run_function('pkg.install', [ADD_PKG])
+            installed_latest = self.run_function('pkg.latest_version', [ADD_PKG])
+            version = self.run_function('pkg.version', [ADD_PKG])
+            try:
+                self.assertTrue(isinstance(uninstalled_latest, six.string_types))
+                self.assertEqual(installed_latest, '')
+            except AssertionError:
+                self.run_function('pkg.remove', [ADD_PKG])
+                raise
+        except CommandExecutionError:
+            self.run_function('pkg.remove', [ADD_PKG])
+            raise
+
+    def test_refresh_db(self):
         '''
         Integration test to ensure pkg.refresh_db works with brew
         '''

--- a/tests/unit/modules/mac_brew_test.py
+++ b/tests/unit/modules/mac_brew_test.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 
 # Import Salt Libs
 from salt.modules import mac_brew
+from salt.exceptions import CommandExecutionError
 
 # Import Salt Testing Libs
 from salttesting import skipIf, TestCase
@@ -38,7 +39,8 @@ class BrewTestCase(TestCase):
         '''
         Tests the return of the list of taps
         '''
-        mock_taps = MagicMock(return_value={'stdout': TAPS_STRING})
+        mock_taps = MagicMock(return_value={'stdout': TAPS_STRING,
+                                            'retcode': 0})
         mock_user = MagicMock(return_value='foo')
         mock_cmd = MagicMock(return_value='')
         with patch.dict(mac_brew.__salt__, {'file.get_user': mock_user,
@@ -60,7 +62,9 @@ class BrewTestCase(TestCase):
         '''
         Tests if the tap installation failed
         '''
-        mock_failure = MagicMock(return_value={'retcode': 1})
+        mock_failure = MagicMock(return_value={'stdout': '',
+                                               'stderr': '',
+                                               'retcode': 1})
         mock_user = MagicMock(return_value='foo')
         mock_cmd = MagicMock(return_value='')
         with patch.dict(mac_brew.__salt__, {'cmd.run_all': mock_failure,
@@ -147,10 +151,12 @@ class BrewTestCase(TestCase):
         Tests an update of homebrew package repository failure
         '''
         mock_user = MagicMock(return_value='foo')
-        mock_failure = MagicMock(return_value={'retcode': 1})
+        mock_failure = MagicMock(return_value={'stdout': '',
+                                               'stderr': '',
+                                               'retcode': 1})
         with patch.dict(mac_brew.__salt__, {'file.get_user': mock_user,
                                         'cmd.run_all': mock_failure}):
-            self.assertFalse(mac_brew.refresh_db())
+            self.assertRaises(CommandExecutionError, mac_brew.refresh_db)
 
     @patch('salt.modules.mac_brew._homebrew_bin',
            MagicMock(return_value=HOMEBREW_BIN))


### PR DESCRIPTION
### What does this PR do?

Brew lists package versions differently for packages that are not installed vs installed if the version includes a package revision.
### What issues does this PR fix or reference?
### Previous Behavior

``` py
   -> integration.states.pkg.PkgTest.test_pkg_008_latest_with_epoch  ................................
       Traceback (most recent call last):
         File "/opt/salt/lib/python2.7/site-packages/salttesting/helpers.py", line 68, in wrap
           return caller(cls)
         File "/testing/tests/integration/states/pkg.py", line 328, in test_pkg_008_latest_with_epoch
           self.assertSaltTrueReturn(ret)
         File "/testing/tests/integration/__init__.py", line 1456, in assertSaltTrueReturn
           **(next(six.itervalues(ret)))
       AssertionError: False is not True. Salt Comment:
       The following packages failed to update: bash-completion
```
### New Behavior

```
test_pkg_008_latest_with_epoch (integration.states.pkg.PkgTest)
[CPU:48.2%|MEM:49.1%|Z:0]  ... ok
```
### Tests written?

Yes
