### PR TITLE
Correct setting typo in conf/master: 'pulisher_acl' -> 'publisher_acl'

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -285,7 +285,7 @@
 # This setting should be treated with care since it opens up execution
 # capabilities to non root users. By default this capability is completely
 # disabled.
-#pulisher_acl:
+#publisher_acl:
 #  larry:
 #    - test.ping
 #    - network.*


### PR DESCRIPTION
As per subject: correct typo of setting name in conf/master
