### PR TITLE
conf/minion: minion supports sha1 hashing as well, so add that in the note as well

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -540,8 +540,8 @@
 #fileserver_limit_traversal: False
 
 # The hash_type is the hash to use when discovering the hash of a file on
-# the local fileserver. The default is md5, but sha224, sha256, sha384 and sha512 are
-# also supported.
+# the local fileserver. The default is md5, but sha1, sha224, sha256, sha384
+# and sha512 are also supported.
 #
 # WARNING: While md5 and sha1 are also supported, do not use it due to the high chance
 # of possible collisions and thus security breach.


### PR DESCRIPTION
### What does this PR do?

Update hash algorithm list in conf/minion, after confirming that sha1 is accepted as well
