### PR TITLE
Fix win servermanager

### DIFF
--- a/salt/modules/win_servermanager.py
+++ b/salt/modules/win_servermanager.py
@@ -189,9 +189,13 @@ def remove(feature):
           '-WarningAction SilentlyContinue'.format(_cmd_quote(feature))
     out = _pshell_json(cmd)
 
-    ret = {'ExitCode': out['ExitCode'],
-           'DisplayName': out['FeatureResult'][0]['DisplayName'],
-           'RestartNeeded': out['FeatureResult'][0]['RestartNeeded'],
-           'Success': out['Success']}
-
-    return ret
+    if out['FeatureResult']:
+        return {'ExitCode': out['ExitCode'],
+                'DisplayName': out['FeatureResult'][0]['DisplayName'],
+                'RestartNeeded': out['FeatureResult'][0]['RestartNeeded'],
+                'Success': out['Success']}
+    else:
+        return {'ExitCode': out['ExitCode'],
+                'DisplayName': '{0} (not installed)'.format(feature),
+                'RestartNeeded': False,
+                'Success': out['Success']}

--- a/salt/modules/win_servermanager.py
+++ b/salt/modules/win_servermanager.py
@@ -150,12 +150,16 @@ def install(feature, recurse=False):
           '-WarningAction SilentlyContinue'.format(_cmd_quote(feature), sub)
     out = _pshell_json(cmd)
 
-    ret = {'ExitCode': out['ExitCode'],
-           'DisplayName': out['FeatureResult'][0]['DisplayName'],
-           'RestartNeeded': out['FeatureResult'][0]['RestartNeeded'],
-           'Success': out['Success']}
-
-    return ret
+    if out['FeatureResult']:
+        return {'ExitCode': out['ExitCode'],
+                'DisplayName': out['FeatureResult'][0]['DisplayName'],
+                'RestartNeeded': out['FeatureResult'][0]['RestartNeeded'],
+                'Success': out['Success']}
+    else:
+        return {'ExitCode': out['ExitCode'],
+                'DisplayName': '{0} (already installed)'.format(feature),
+                'RestartNeeded': False,
+                'Success': out['Success']}
 
 
 def remove(feature):

--- a/salt/states/win_servermanager.py
+++ b/salt/states/win_servermanager.py
@@ -3,6 +3,9 @@
 Manage Windows features via the ServerManager powershell module
 '''
 
+# Import salt modules
+import salt.utils
+
 
 def __virtual__():
     '''

--- a/salt/states/win_servermanager.py
+++ b/salt/states/win_servermanager.py
@@ -67,6 +67,9 @@ def installed(name, recurse=False, force=False):
         ret['result'] = None
         return ret
 
+    if ret['changes']['feature']:
+        ret['comment'] = ret['changes']['feature']
+
     ret['changes'] = {}
 
     # Install the features

--- a/salt/states/win_servermanager.py
+++ b/salt/states/win_servermanager.py
@@ -75,7 +75,7 @@ def installed(name, recurse=False, force=False):
     if 'already installed' not in status['DisplayName']:
         ret['changes']['feature'] = status
 
-    ret['changes']['restart_needed'] = status['RestartNeeded']
+    ret['restart_needed'] = status['RestartNeeded']
 
     new = __salt__['win_servermanager.list_installed']()
     ret['changes']['features'] = salt.utils.compare_dicts(old, new)
@@ -130,7 +130,7 @@ def removed(name):
     if not ret['result']:
         ret['comment'] = 'Failed to uninstall the feature {0}'.format(ret['changes']['feature']['ExitCode'])
 
-    ret['changes']['restart_needed'] = status['RestartNeeded']
+    ret['restart_needed'] = status['RestartNeeded']
 
     new = __salt__['win_servermanager.list_installed']()
     ret['changes']['features'] = salt.utils.compare_dicts(old, new)

--- a/salt/states/win_servermanager.py
+++ b/salt/states/win_servermanager.py
@@ -75,10 +75,12 @@ def installed(name, recurse=False, force=False):
     if 'already installed' not in status['DisplayName']:
         ret['changes']['feature'] = status
 
-    ret['restart_needed'] = status['RestartNeeded']
-
     new = __salt__['win_servermanager.list_installed']()
-    ret['changes']['features'] = salt.utils.compare_dicts(old, new)
+    changes = salt.utils.compare_dicts(old, new)
+
+    if changes:
+        ret['changes']['features'] = changes
+        ret['changes']['restart_needed'] = status['RestartNeeded']
 
     return ret
 
@@ -130,9 +132,11 @@ def removed(name):
     if not ret['result']:
         ret['comment'] = 'Failed to uninstall the feature {0}'.format(ret['changes']['feature']['ExitCode'])
 
-    ret['restart_needed'] = status['RestartNeeded']
-
     new = __salt__['win_servermanager.list_installed']()
-    ret['changes']['features'] = salt.utils.compare_dicts(old, new)
+    changes = salt.utils.compare_dicts(old, new)
+
+    if changes:
+        ret['changes']['features'] = changes
+        ret['changes']['restart_needed'] = status['RestartNeeded']
 
     return ret

--- a/salt/states/win_servermanager.py
+++ b/salt/states/win_servermanager.py
@@ -71,11 +71,14 @@ def installed(name, recurse=False, force=False):
     ret['result'] = status['Success']
     if not ret['result']:
         ret['comment'] = 'Failed to install {0}: {1}'.format(name, ret['changes']['feature']['ExitCode'])
+
     if 'already installed' not in status['DisplayName']:
         ret['changes']['feature'] = status
 
+    ret['changes']['restart_needed'] = status['RestartNeeded']
+
     new = __salt__['win_servermanager.list_installed']()
-    ret['changes'] = salt.utils.compare_dicts(old, new)
+    ret['changes']['features'] = salt.utils.compare_dicts(old, new)
 
     return ret
 
@@ -127,7 +130,9 @@ def removed(name):
     if not ret['result']:
         ret['comment'] = 'Failed to uninstall the feature {0}'.format(ret['changes']['feature']['ExitCode'])
 
+    ret['changes']['restart_needed'] = status['RestartNeeded']
+
     new = __salt__['win_servermanager.list_installed']()
-    ret['changes'] = salt.utils.compare_dicts(old, new)
+    ret['changes']['features'] = salt.utils.compare_dicts(old, new)
 
     return ret

--- a/tests/unit/states/win_servermanager_test.py
+++ b/tests/unit/states/win_servermanager_test.py
@@ -35,58 +35,92 @@ class WinServermanagerTestCase(TestCase):
         '''
             Test to install the windows feature
         '''
-        ret = {'name': 'salt',
-               'changes': {},
-               'result': True,
-               'comment': ''}
-        mock = MagicMock(side_effect=['salt', 'stack', 'stack'])
-        mock1 = MagicMock(return_value={'Success': True})
+        mock_list = MagicMock(
+            side_effect=[{'spongebob': 'squarepants'},
+                         {'squidward': 'patrick'},
+                         {'spongebob': 'squarepants'},
+                         {'spongebob': 'squarepants',
+                          'squidward': 'patrick'}])
+        mock_install = MagicMock(
+            return_value={'Success': True,
+                          'RestartNeeded': False,
+                          'ExitCode': 1234})
         with patch.dict(win_servermanager.__salt__,
-                        {"win_servermanager.list_installed": mock,
-                         "win_servermanager.install": mock1}):
-            ret.update({'comment': 'The feature salt is already installed'})
-            self.assertDictEqual(win_servermanager.installed('salt'), ret)
+                        {"win_servermanager.list_installed": mock_list,
+                         "win_servermanager.install": mock_install}):
+            ret = {'name': 'spongebob',
+                   'changes': {},
+                   'result': True,
+                   'comment': 'The feature spongebob is already installed'}
+            self.assertDictEqual(win_servermanager.installed('spongebob'), ret)
 
             with patch.dict(win_servermanager.__opts__, {"test": True}):
-                ret.update({'changes': {'feature':
-                                        'salt will be installed'
-                                        ' recurse=False'}, 'result': None,
-                            'comment': ''})
-                self.assertDictEqual(win_servermanager.installed('salt'), ret)
+                ret = {'name': 'spongebob',
+                       'result': None,
+                       'comment': '',
+                       'changes': {
+                           'feature': 'spongebob will be installed '
+                                      'recurse=False'}}
+                self.assertDictEqual(
+                    win_servermanager.installed('spongebob'), ret)
 
-                with patch.dict(win_servermanager.__opts__, {"test": False}):
-                    ret.update({'changes': {'feature': {'Success': True}},
-                                'result': True, 'comment': 'Installed salt'})
-                    self.assertDictEqual(win_servermanager.installed('salt'),
-                                         ret)
+            with patch.dict(win_servermanager.__opts__, {"test": False}):
+                ret = {'name': 'squidward',
+                       'result': True,
+                       'comment': 'Installed squidward',
+                       'changes': {
+                           'Success': True,
+                           'RestartNeeded': False,
+                           'ExitCode': 1234,
+                           'feature': {'squidward': {'new': 'patrick',
+                                                     'old': ''}}}}
+                self.assertDictEqual(
+                    win_servermanager.installed('squidward'), ret)
 
     def test_removed(self):
         '''
             Test to remove the windows feature
         '''
-        ret = {'name': 'salt',
-               'changes': {},
-               'result': True,
-               'comment': ''}
-        mock = MagicMock(side_effect=['stack', 'salt', 'salt'])
-        mock1 = MagicMock(return_value={'Success': True})
+        mock_list = MagicMock(
+            side_effect=[{'spongebob': 'squarepants'},
+                         {'squidward': 'patrick'},
+                         {'spongebob': 'squarepants',
+                          'squidward': 'patrick'},
+                         {'spongebob': 'squarepants'}])
+        mock_remove = MagicMock(
+            return_value={'Success': True,
+                          'RestartNeeded': False,
+                          'ExitCode': 1234})
         with patch.dict(win_servermanager.__salt__,
-                        {"win_servermanager.list_installed": mock,
-                         "win_servermanager.remove": mock1}):
-            ret.update({'comment': 'The feature salt is not installed'})
-            self.assertDictEqual(win_servermanager.removed('salt'), ret)
+                        {"win_servermanager.list_installed": mock_list,
+                         "win_servermanager.remove": mock_remove}):
+            ret = {'name': 'squidward',
+                   'changes': {},
+                   'result': True,
+                   'comment': 'The feature squidward is not installed'}
+            self.assertDictEqual(
+                win_servermanager.removed('squidward'), ret)
 
             with patch.dict(win_servermanager.__opts__, {"test": True}):
-                ret.update({'changes': {'feature':
-                                        'salt will be removed'},
-                            'result': None, 'comment': ''})
-                self.assertDictEqual(win_servermanager.removed('salt'), ret)
+                ret = {'name': 'squidward',
+                       'result': None,
+                       'comment': '',
+                       'changes': {'feature': 'squidward will be removed'}}
+                self.assertDictEqual(
+                    win_servermanager.removed('squidward'), ret)
 
-                with patch.dict(win_servermanager.__opts__, {"test": False}):
-                    ret.update({'changes': {'feature': {'Success': True}},
-                                'result': True})
-                    self.assertDictEqual(win_servermanager.removed('salt'),
-                                         ret)
+            with patch.dict(win_servermanager.__opts__, {"test": False}):
+                ret = {'name': 'squidward',
+                       'result': True,
+                       'comment': 'Removed squidward',
+                       'changes': {
+                           'Success': True,
+                           'RestartNeeded': False,
+                           'ExitCode': 1234,
+                           'feature': {'squidward': {'new': '',
+                                                     'old': 'patrick'}}}}
+                self.assertDictEqual(
+                    win_servermanager.removed('squidward'), ret)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?

Fixes problem with where win_servermanager state would fail if run when already installed with the force option. Was returning an empty dictionary.

Also returns more detailed information about what was installed.
### What issues does this PR fix or reference?

An issue Rob H was having.
### Previous Behavior

win_servermanager state would fail if the item was already installed and force was set to True
### New Behavior

win_servermanager state no longer fails. More detailed information is returned.
### Tests written?

Yes
