### PR TITLE
Repair and sort orchestrate runner output

### DIFF
--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -122,6 +122,14 @@ def output(data):
     The HighState Outputter is only meant to be used with the state.highstate
     function, or a function that returns highstate return data.
     '''
+
+    # Discard retcode in dictionary as present in orchestrate data
+    local_masters = [key for key in data.keys() if key.endswith('.local_master')]
+    orchestrator_output = 'retcode' in data.keys() and len(local_masters) == 1
+
+    if orchestrator_output:
+        del data['retcode']
+
     # If additional information is passed through via the "data" dictionary to
     # the highstate outputter, such as "outputter" or "retcode", discard it.
     # We only want the state data that was passed through, if it is wrapped up
@@ -169,7 +177,7 @@ def _format_host(host, data):
         # Verify that the needed data is present
         data_tmp = {}
         for tname, info in six.iteritems(data):
-            if isinstance(info, dict) and '__run_num__' not in info:
+            if isinstance(info, dict) and tname is not 'changes' and '__run_num__' not in info:
                 err = (u'The State execution failed to record the order '
                        'in which all states were executed. The state '
                        'return missing data is:')


### PR DESCRIPTION
The orchestrate output is currently broken, only returns the retcode and does not order the state output when changes returned are a dictionary.
