### PR TITLE
Adjust target expression in state tutorial

### DIFF
--- a/doc/topics/tutorials/states_pt1.rst
+++ b/doc/topics/tutorials/states_pt1.rst
@@ -70,7 +70,7 @@ collection of minion matches is defined; for now simply specify all hosts
     .. code-block:: yaml
 
         base:
-          'G@os:Fedora':
+          'os:Fedora':
             - match: grain
             - webserver
 


### PR DESCRIPTION
### What does this PR do?

It fixes a wrong example in the states tutorial in which the grain matcher was discussed, but the example used a compound matcher. 

We either have to use 'os:Fedora' here for the grain matcher or use the
compound matcher. Given that the example discusses the grain matcher, I opted
for adjusting the target expression.
