### PR TITLE
Allow validation of bundled certificates

### DIFF
--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -60,6 +60,7 @@ EXT_NAME_MAPPINGS = OrderedDict([
                     ])
 
 CERT_DEFAULTS = {'days_valid': 365, 'version': 3, 'serial_bits': 64, 'algorithm': 'sha256'}
+PEM_RE = re.compile(r"(-----BEGIN CERTIFICATE-----\s?.+?\s?-----END CERTIFICATE-----)\s?", re.DOTALL)
 
 
 def __virtual__():
@@ -359,6 +360,11 @@ def get_pem_entry(text, pem_type=None):
     else:
         pem_header = '-----BEGIN {0}-----'.format(pem_type)
         pem_footer = '-----END {0}-----'.format(pem_type)
+        if pem_type == 'CERTIFICATE':
+            for _match in PEM_RE.finditer(text):
+                # get the first certificate
+                text = _match.group(0)
+                break
         # Split based on defined headers
         if (len(text.split(pem_header)) is not 2 or
                 len(text.split(pem_footer)) is not 2):


### PR DESCRIPTION
### Adds the ability to validate bundled certificates using the x509 module

Using the command.

`salt-call x509.verify_signature /etc/pki/baruwa/certs/scanner.lab.topdog-software.com.pem signing_pub_key=/etc/pki/certbot/certs/certbot-staging-ca.pem`

`/etc/pki/baruwa/certs/scanner.lab.topdog-software.com.pem`  contains the certificate and the CA certificate appended for use with Nginx
### Previous Behavior

It was not possible to validate a bundled certificate, you would get the error

`Passed invalid arguments: PEM does not contain a single entry of type`
### New Behavior

It is now possible to validate a bundled certificate, the first certificate in
the bundle is extracted and used in the check.
### Tests written?

No

Currently it is not possible to validate bundled
certificates as the get_pem_entry function expects
only one certificate in the file.

This change allows for the first certificate in the
file to be extracted and validated.
