### PR TITLE
Option to allow scheduled jobs to return the result but not being cached on the master side.

### DIFF
--- a/salt/utils/job.py
+++ b/salt/utils/job.py
@@ -72,6 +72,11 @@ def store_job(opts, load, event=None, mminion=None):
     if not opts['job_cache'] or opts.get('ext_job_cache'):
         return
 
+    # do not cache job results if explicitly requested
+    if load.get('jid') == 'nocache':
+        log.debug('Ignoring job return with jid for caching {jid} from {id}'.format(**load))
+        return
+
     # otherwise, write to the master cache
     savefstr = '{0}.save_load'.format(job_cache)
     getfstr = '{0}.get_load'.format(job_cache)

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -236,6 +236,10 @@ from being sent back to the Salt master.
           function: scheduled_job_function
           return_job: False
 
+Setting the ``return_job`` parameter to 'nocache' prevents the salt master
+from storing the job in the master cache. Still, an event is fired on the
+master event bus in the form 'salt/job/nocache/ret/myminion'.
+
 It can be useful to include specific data to differentiate a job from other
 jobs.  Using the metadata parameter special values can be associated with
 a scheduled job.  These values are not used in the execution of the job,
@@ -771,6 +775,9 @@ class Schedule(object):
                         # Send back to master so the job is included in the job list
                         mret = ret.copy()
                         mret['jid'] = 'req'
+                        if data.get('return_job') == 'nocache':
+                            # overwrite 'req' to signal to master that this job shouldn't be stored
+                            mret['jid'] = 'nocache'
                         event = salt.utils.event.get_event('minion', opts=self.opts, listen=False)
                         load = {'cmd': '_return', 'id': self.opts['id']}
                         for key, value in six.iteritems(mret):


### PR DESCRIPTION
Extends the return_job option to a setting (nocache) that prevents the master from storing the job result.
This is particularly useful for scheduled jobs that do return information, where an immediate reaction is 
the only useful action and not cluttering the master job cache.
