### PR TITLE
Call zypper refresh after adding/modifying a repository

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -765,9 +765,9 @@ def mod_repo(repo, **kwargs):
         added = True
 
     # Modify added or existing repo according to the options
-    trigger_refresh = False
     cmd_opt = []
     global_cmd_opt = []
+    call_refresh = False
 
     if 'enabled' in kwargs:
         cmd_opt.append(kwargs['enabled'] and '--enable' or '--disable')
@@ -789,23 +789,22 @@ def mod_repo(repo, **kwargs):
 
     if kwargs.get('gpgautoimport') is True:
         global_cmd_opt.append('--gpg-auto-import-keys')
-        trigger_refresh = True
+        call_refresh = True
 
     if cmd_opt:
         cmd_opt = global_cmd_opt + ['mr'] + cmd_opt + [repo]
         __zypper__.refreshable.xml.call(*cmd_opt)
 
-    # If repo nor added neither modified, error should be thrown
-    if not added and not cmd_opt and not trigger_refresh:
-        raise CommandExecutionError(
-            'Specified arguments did not result in modification of repo'
-        )
-    elif trigger_refresh:
+    if call_refresh:
         # when used with "zypper ar --refresh" or "zypper mr --refresh"
         # --gpg-auto-import-keys is not doing anything
         # so we need to specifically refresh here with --gpg-auto-import-keys
         refresh_opts = global_cmd_opt + ['refresh'] + [repo]
         __zypper__.xml.call(*refresh_opts)
+    elif not added and not cmd_opt:
+        raise CommandExecutionError(
+            'Specified arguments did not result in modification of repo'
+        )
 
     return get_repo(repo)
 

--- a/tests/unit/modules/zypper_test.py
+++ b/tests/unit/modules/zypper_test.py
@@ -471,15 +471,12 @@ class ZypperTestCase(TestCase):
                 'Specified arguments did not result in modification of repo'
             ):
                 zypper.mod_repo(name, **{'url': url})
-            zypper.__zypper__.xml.call.assert_not_called()
-            zypper.__zypper__.refreshable.xml.call.assert_not_called()
-
-        with zypper_patcher:
             with self.assertRaisesRegexp(
                 Exception,
                 'Specified arguments did not result in modification of repo'
             ):
                 zypper.mod_repo(name, **{'url': url, 'gpgautoimport': 'a'})
+
             zypper.__zypper__.xml.call.assert_not_called()
             zypper.__zypper__.refreshable.xml.call.assert_not_called()
 

--- a/tests/unit/modules/zypper_test.py
+++ b/tests/unit/modules/zypper_test.py
@@ -11,6 +11,7 @@ from salttesting import TestCase, skipIf
 from salttesting.mock import (
     Mock,
     MagicMock,
+    call,
     patch,
     NO_MOCK,
     NO_MOCK_REASON
@@ -58,6 +59,28 @@ class ZypperTestCase(TestCase):
     '''
     Test cases for salt.modules.zypper
     '''
+
+    def setUp(self):
+        self.new_repo_config = dict(
+            name='mock-repo-name',
+            url='http://repo.url/some/path'
+        )
+        self.zypper_patcher_config = {
+            '_get_configured_repos': Mock(
+                side_effect=[
+                    Mock(**{'sections.return_value': []}),
+                    Mock(
+                        **{
+                            'sections.return_value': [
+                                self.new_repo_config['name']
+                            ]
+                        }
+                    ),
+                ],
+            ),
+            '__zypper__': Mock(),
+            'get_repo': Mock()
+        }
 
     def test_list_upgrades(self):
         '''
@@ -414,37 +437,233 @@ class ZypperTestCase(TestCase):
             self.assertEqual(r_info['enabled'], alias == 'SLE12-SP1-x86_64-Update')
             self.assertEqual(r_info['autorefresh'], alias == 'SLE12-SP1-x86_64-Update')
 
-    def test_modify_repo_gpg_auto_import_keys_parameter_position(self):
+    def test_add_repo_and_do_not_refresh_repo(self):
         '''
-        Tests if when modifying a repo, --gpg-auto-import-keys is a global option
+        Test mod_repo adds the new repo and nothing else
 
         :return:
         '''
         zypper_patcher = patch.multiple(
-            'salt.modules.zypper',
-            **{
-                '_get_configured_repos': Mock(
-                    **{
-                        'return_value.sections.return_value': ['mock-repo-name']
-                    }
-                ),
-                '__zypper__': Mock(),
-                'get_repo': Mock()
-            }
+            'salt.modules.zypper', **self.zypper_patcher_config)
+
+        url = self.new_repo_config['url']
+        name = self.new_repo_config['name']
+        with zypper_patcher:
+            zypper.mod_repo(name, **{'url': url})
+            self.assertEqual(
+                zypper.__zypper__.xml.call.call_args_list,
+                [call('ar', url, name)]
+            )
+            zypper.__zypper__.refreshable.xml.call.assert_not_called()
+
+    def test_repo_exists_nothing_to_change_do_not_refresh(self):
+        '''
+        Test mod_repo detects the repo already exists,
+        no modification was requested and no refresh requested either
+
+        :return:
+        '''
+        url = self.new_repo_config['url']
+        name = self.new_repo_config['name']
+        self.zypper_patcher_config['_get_configured_repos'] = Mock(
+            **{'return_value.sections.return_value': [name]}
         )
+        zypper_patcher = patch.multiple(
+            'salt.modules.zypper', **self.zypper_patcher_config)
+
+        with zypper_patcher:
+            with self.assertRaisesRegexp(
+                Exception,
+                'Specified arguments did not result in modification of repo'
+            ):
+                zypper.mod_repo(name, **{'url': url})
+            zypper.__zypper__.xml.call.assert_not_called()
+
+    def test_add_repo_modify_repo_do_not_refresh(self):
+        '''
+        Test mod_repo adds the new repo and call modify to update autorefresh
+
+        :return:
+        '''
+        zypper_patcher = patch.multiple(
+            'salt.modules.zypper', **self.zypper_patcher_config)
+
+        url = self.new_repo_config['url']
+        name = self.new_repo_config['name']
         with zypper_patcher:
             zypper.mod_repo(
-                'mock-repo-name',
+                name,
                 **{
-                    'disabled': False,
-                    'url': 'http://repo.url/some/path',
-                    'gpgkey': 'http://repo.key',
+                    'url': url,
+                    'refresh': True
+                }
+            )
+            self.assertEqual(
+                zypper.__zypper__.xml.call.call_args_list,
+                [
+                    call('ar', url, name)
+                ]
+            )
+            zypper.__zypper__.refreshable.xml.call.assert_called_once_with(
+                'mr', '--refresh', name
+            )
+
+    def test_modify_repo_do_not_refresh(self):
+        '''
+        Test mod_repo detects the repository exists,
+        calls modify to update 'autorefresh' but does not call refresh
+
+        :return:
+        '''
+        url = self.new_repo_config['url']
+        name = self.new_repo_config['name']
+        self.zypper_patcher_config['_get_configured_repos'] = Mock(
+            **{'return_value.sections.return_value': [name]}
+        )
+        zypper_patcher = patch.multiple(
+            'salt.modules.zypper', **self.zypper_patcher_config)
+        with zypper_patcher:
+            zypper.mod_repo(
+                name,
+                **{
+                    'url': url,
+                    'refresh': True
+                }
+            )
+            zypper.__zypper__.xml.call.assert_not_called()
+            zypper.__zypper__.refreshable.xml.call.assert_called_once_with(
+                'mr', '--refresh', name
+            )
+
+    def test_add_repo_and_refresh_repo_with_gpgautoimport(self):
+        '''
+        Test mod_repo adds the new repo and refreshes the repo with
+            `zypper --gpg-auto-import-keys refresh <repo-name>`
+
+        :return:
+        '''
+        zypper_patcher = patch.multiple(
+            'salt.modules.zypper', **self.zypper_patcher_config)
+
+        url = self.new_repo_config['url']
+        name = self.new_repo_config['name']
+        with zypper_patcher:
+            zypper.mod_repo(
+                name,
+                **{
+                    'url': url,
+                    'gpgautoimport': True
+                }
+            )
+            self.assertEqual(
+                zypper.__zypper__.xml.call.call_args_list,
+                [
+                    call('ar', url, name),
+                    call('--gpg-auto-import-keys', 'refresh', name)
+                ]
+            )
+            zypper.__zypper__.refreshable.xml.call.assert_not_called()
+
+    def test_nothing_to_modify_and_refresh_repo_with_gpgautoimport(self):
+        '''
+        Test mod_repo detects the repo already exists,
+        has nothing to modify and refreshes the repo with
+            `zypper --gpg-auto-import-keys refresh <repo-name>`
+
+        :return:
+        '''
+        url = self.new_repo_config['url']
+        name = self.new_repo_config['name']
+        self.zypper_patcher_config['_get_configured_repos'] = Mock(
+            **{'return_value.sections.return_value': [name]}
+        )
+        zypper_patcher = patch.multiple(
+            'salt.modules.zypper', **self.zypper_patcher_config)
+
+        with zypper_patcher:
+            zypper.mod_repo(
+                name,
+                **{
+                    'url': url,
+                    'gpgautoimport': True
+                }
+            )
+            self.assertEqual(
+                zypper.__zypper__.xml.call.call_args_list,
+                [
+                    call('--gpg-auto-import-keys', 'refresh', name)
+                ]
+            )
+            zypper.__zypper__.refreshable.xml.call.assert_not_called()
+
+    def test_add_repo_modify_repo_and_refresh_repo_with_gpgautoimport(self):
+        '''
+        Test mod_repo adds the new repo,
+        modifies the new repo when refresh is True and
+        refreshes the repo with
+            `zypper --gpg-auto-import-keys refresh <repo-name>`
+
+        :return:
+        '''
+        zypper_patcher = patch.multiple(
+            'salt.modules.zypper', **self.zypper_patcher_config)
+
+        url = self.new_repo_config['url']
+        name = self.new_repo_config['name']
+        with zypper_patcher:
+            zypper.mod_repo(
+                name,
+                **{
+                    'url': url,
                     'refresh': True,
                     'gpgautoimport': True
                 }
             )
+            self.assertEqual(
+                zypper.__zypper__.xml.call.call_args_list,
+                [
+                    call('ar', url, name),
+                    call('--gpg-auto-import-keys', 'refresh', name)
+                ]
+            )
             zypper.__zypper__.refreshable.xml.call.assert_called_once_with(
-                '--gpg-auto-import-keys', 'mr', '--refresh', 'mock-repo-name'
+                '--gpg-auto-import-keys', 'mr', '--refresh', name
+            )
+
+    def test_modify_existing_repo_and_refresh_repo_with_gpgautoimport(self):
+        '''
+        Test mod_repo detects the repo already exists,
+        modifies the existing repo when refresh is True and
+        refreshes the repo with
+            `zypper --gpg-auto-import-keys refresh <repo-name>`
+
+        :return:
+        '''
+        url = self.new_repo_config['url']
+        name = self.new_repo_config['name']
+        self.zypper_patcher_config['_get_configured_repos'] = Mock(
+            **{'return_value.sections.return_value': [name]}
+        )
+        zypper_patcher = patch.multiple(
+            'salt.modules.zypper', **self.zypper_patcher_config)
+
+        with zypper_patcher:
+            zypper.mod_repo(
+                name,
+                **{
+                    'url': url,
+                    'refresh': True,
+                    'gpgautoimport': True
+                }
+            )
+            self.assertEqual(
+                zypper.__zypper__.xml.call.call_args_list,
+                [
+                    call('--gpg-auto-import-keys', 'refresh', name)
+                ]
+            )
+            zypper.__zypper__.refreshable.xml.call.assert_called_once_with(
+                '--gpg-auto-import-keys', 'mr', '--refresh', name
             )
 
 if __name__ == '__main__':

--- a/tests/unit/modules/zypper_test.py
+++ b/tests/unit/modules/zypper_test.py
@@ -66,19 +66,12 @@ class ZypperTestCase(TestCase):
             name='mock-repo-name',
             url='http://repo.url/some/path'
         )
+        side_effect = [
+            Mock(**{'sections.return_value': []}),
+            Mock(**{'sections.return_value': [self.new_repo_config['name']]})
+        ]
         self.zypper_patcher_config = {
-            '_get_configured_repos': Mock(
-                side_effect=[
-                    Mock(**{'sections.return_value': []}),
-                    Mock(
-                        **{
-                            'sections.return_value': [
-                                self.new_repo_config['name']
-                            ]
-                        }
-                    ),
-                ],
-            ),
+            '_get_configured_repos': Mock(side_effect=side_effect),
             '__zypper__': Mock(),
             'get_repo': Mock()
         }

--- a/tests/unit/modules/zypper_test.py
+++ b/tests/unit/modules/zypper_test.py
@@ -56,6 +56,7 @@ zypper.rpm = None
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class ZypperTestCase(TestCase):
+
     '''
     Test cases for salt.modules.zypper
     '''
@@ -491,18 +492,10 @@ class ZypperTestCase(TestCase):
         url = self.new_repo_config['url']
         name = self.new_repo_config['name']
         with zypper_patcher:
-            zypper.mod_repo(
-                name,
-                **{
-                    'url': url,
-                    'refresh': True
-                }
-            )
+            zypper.mod_repo(name, **{'url': url, 'refresh': True})
             self.assertEqual(
                 zypper.__zypper__.xml.call.call_args_list,
-                [
-                    call('ar', url, name)
-                ]
+                [call('ar', url, name)]
             )
             zypper.__zypper__.refreshable.xml.call.assert_called_once_with(
                 'mr', '--refresh', name
@@ -518,18 +511,11 @@ class ZypperTestCase(TestCase):
         url = self.new_repo_config['url']
         name = self.new_repo_config['name']
         self.zypper_patcher_config['_get_configured_repos'] = Mock(
-            **{'return_value.sections.return_value': [name]}
-        )
+            **{'return_value.sections.return_value': [name]})
         zypper_patcher = patch.multiple(
             'salt.modules.zypper', **self.zypper_patcher_config)
         with zypper_patcher:
-            zypper.mod_repo(
-                name,
-                **{
-                    'url': url,
-                    'refresh': True
-                }
-            )
+            zypper.mod_repo(name, **{'url': url, 'refresh': True})
             zypper.__zypper__.xml.call.assert_not_called()
             zypper.__zypper__.refreshable.xml.call.assert_called_once_with(
                 'mr', '--refresh', name
@@ -548,13 +534,7 @@ class ZypperTestCase(TestCase):
         url = self.new_repo_config['url']
         name = self.new_repo_config['name']
         with zypper_patcher:
-            zypper.mod_repo(
-                name,
-                **{
-                    'url': url,
-                    'gpgautoimport': True
-                }
-            )
+            zypper.mod_repo(name, **{'url': url, 'gpgautoimport': True})
             self.assertEqual(
                 zypper.__zypper__.xml.call.call_args_list,
                 [
@@ -581,18 +561,10 @@ class ZypperTestCase(TestCase):
             'salt.modules.zypper', **self.zypper_patcher_config)
 
         with zypper_patcher:
-            zypper.mod_repo(
-                name,
-                **{
-                    'url': url,
-                    'gpgautoimport': True
-                }
-            )
+            zypper.mod_repo(name, **{'url': url, 'gpgautoimport': True})
             self.assertEqual(
                 zypper.__zypper__.xml.call.call_args_list,
-                [
-                    call('--gpg-auto-import-keys', 'refresh', name)
-                ]
+                [call('--gpg-auto-import-keys', 'refresh', name)]
             )
             zypper.__zypper__.refreshable.xml.call.assert_not_called()
 
@@ -612,11 +584,7 @@ class ZypperTestCase(TestCase):
         with zypper_patcher:
             zypper.mod_repo(
                 name,
-                **{
-                    'url': url,
-                    'refresh': True,
-                    'gpgautoimport': True
-                }
+                **{'url': url, 'refresh': True, 'gpgautoimport': True}
             )
             self.assertEqual(
                 zypper.__zypper__.xml.call.call_args_list,
@@ -648,17 +616,11 @@ class ZypperTestCase(TestCase):
         with zypper_patcher:
             zypper.mod_repo(
                 name,
-                **{
-                    'url': url,
-                    'refresh': True,
-                    'gpgautoimport': True
-                }
+                **{'url': url, 'refresh': True, 'gpgautoimport': True}
             )
             self.assertEqual(
                 zypper.__zypper__.xml.call.call_args_list,
-                [
-                    call('--gpg-auto-import-keys', 'refresh', name)
-                ]
+                [call('--gpg-auto-import-keys', 'refresh', name)]
             )
             zypper.__zypper__.refreshable.xml.call.assert_called_once_with(
                 '--gpg-auto-import-keys', 'mr', '--refresh', name

--- a/tests/unit/modules/zypper_test.py
+++ b/tests/unit/modules/zypper_test.py
@@ -437,7 +437,7 @@ class ZypperTestCase(TestCase):
             self.assertEqual(r_info['enabled'], alias == 'SLE12-SP1-x86_64-Update')
             self.assertEqual(r_info['autorefresh'], alias == 'SLE12-SP1-x86_64-Update')
 
-    def test_add_repo_and_do_not_refresh_repo(self):
+    def test_repo_add_nomod_noref(self):
         '''
         Test mod_repo adds the new repo and nothing else
 
@@ -456,7 +456,7 @@ class ZypperTestCase(TestCase):
             )
             zypper.__zypper__.refreshable.xml.call.assert_not_called()
 
-    def test_repo_exists_nothing_to_change_do_not_refresh(self):
+    def test_repo_noadd_nomod_noref(self):
         '''
         Test mod_repo detects the repo already exists,
         no modification was requested and no refresh requested either
@@ -479,7 +479,7 @@ class ZypperTestCase(TestCase):
                 zypper.mod_repo(name, **{'url': url})
             zypper.__zypper__.xml.call.assert_not_called()
 
-    def test_add_repo_modify_repo_do_not_refresh(self):
+    def test_repo_add_mod_noref(self):
         '''
         Test mod_repo adds the new repo and call modify to update autorefresh
 
@@ -508,7 +508,7 @@ class ZypperTestCase(TestCase):
                 'mr', '--refresh', name
             )
 
-    def test_modify_repo_do_not_refresh(self):
+    def test_repo_noadd_mod_noref(self):
         '''
         Test mod_repo detects the repository exists,
         calls modify to update 'autorefresh' but does not call refresh
@@ -535,7 +535,7 @@ class ZypperTestCase(TestCase):
                 'mr', '--refresh', name
             )
 
-    def test_add_repo_and_refresh_repo_with_gpgautoimport(self):
+    def test_repo_add_nomod_ref(self):
         '''
         Test mod_repo adds the new repo and refreshes the repo with
             `zypper --gpg-auto-import-keys refresh <repo-name>`
@@ -564,7 +564,7 @@ class ZypperTestCase(TestCase):
             )
             zypper.__zypper__.refreshable.xml.call.assert_not_called()
 
-    def test_nothing_to_modify_and_refresh_repo_with_gpgautoimport(self):
+    def test_repo_noadd_nomod_ref(self):
         '''
         Test mod_repo detects the repo already exists,
         has nothing to modify and refreshes the repo with
@@ -596,11 +596,10 @@ class ZypperTestCase(TestCase):
             )
             zypper.__zypper__.refreshable.xml.call.assert_not_called()
 
-    def test_add_repo_modify_repo_and_refresh_repo_with_gpgautoimport(self):
+    def test_repo_add_mod_ref(self):
         '''
         Test mod_repo adds the new repo,
-        modifies the new repo when refresh is True and
-        refreshes the repo with
+        calls modify to update 'autorefresh' and refreshes the repo with
             `zypper --gpg-auto-import-keys refresh <repo-name>`
 
         :return:
@@ -630,11 +629,10 @@ class ZypperTestCase(TestCase):
                 '--gpg-auto-import-keys', 'mr', '--refresh', name
             )
 
-    def test_modify_existing_repo_and_refresh_repo_with_gpgautoimport(self):
+    def test_repo_noadd_mod_ref(self):
         '''
         Test mod_repo detects the repo already exists,
-        modifies the existing repo when refresh is True and
-        refreshes the repo with
+        calls modify to update 'autorefresh' and refreshes the repo with
             `zypper --gpg-auto-import-keys refresh <repo-name>`
 
         :return:

--- a/tests/unit/modules/zypper_test.py
+++ b/tests/unit/modules/zypper_test.py
@@ -479,6 +479,16 @@ class ZypperTestCase(TestCase):
             ):
                 zypper.mod_repo(name, **{'url': url})
             zypper.__zypper__.xml.call.assert_not_called()
+            zypper.__zypper__.refreshable.xml.call.assert_not_called()
+
+        with zypper_patcher:
+            with self.assertRaisesRegexp(
+                Exception,
+                'Specified arguments did not result in modification of repo'
+            ):
+                zypper.mod_repo(name, **{'url': url, 'gpgautoimport': 'a'})
+            zypper.__zypper__.xml.call.assert_not_called()
+            zypper.__zypper__.refreshable.xml.call.assert_not_called()
 
     def test_repo_add_mod_noref(self):
         '''


### PR DESCRIPTION
### What does this PR do?

completes this previous PR https://github.com/saltstack/salt/pull/33432
and it attempts to fix this issue https://github.com/saltstack/salt/issues/27155
### What issues does this PR fix or reference?

In my previous attempt to fix this I was tricked by zypper's caching mechanism which saves the gpg key once accepted and it made me believe that just fixing the `--gpg-auto-import-keys` position fixes the issue.
I talked today with the maintainer of 'zypper' and it seems that an additional call like this

``` bash
zypper --gpg-auto-import-keys refresh
```

is necessary after adding the repository.
At the moment, this is the only way to prevent subsequent `zypper refresh` from asking for confirmation of the gpg key.
I didn't revert the previous commit introduced with https://github.com/saltstack/salt/pull/33432 because it still fixes the related issue with using `--gpg-auto-import-keys` in the wrong position when calling zypper.
### Tests written?

Yes.
Meanwhile I learned more about zypper and _modules/zypper.py::mod_repo_ so I added more tests to capture the behavior of mod_repo when passing different parameters to it and to make sure the repository is refreshed only when specifically requested in the sls file with **gpgautoimport: True**

Possible scenarios:
- _url_ only
  
  ``` yaml
  repo_with_gpg:
    pkgrepo.managed:
      - url: {{ REPO_URL }}
  ```
  - when the repository is new:
    - this only adds the new repository and does not call modify nor refresh
  - when the repository already exist:
    - raises _CommandExecutionError: Specified arguments did not result in modification of repo_
- _url_ and _refresh_
  
  ``` yaml
  repo_with_gpg:
    pkgrepo.managed:
      - url: {{ REPO_URL }}
      - refresh: True,
  ```
  - when the repository is new:
    - this adds the repository, then modifies it by updating its _autorefresh_ option but doesn't call `zypper refresh`
  - when the repository already exist:
    - modifies the repository by updating its _autorefresh_ option but doesn't call `zypper refresh`
- _url_ and _gpgautoimport_
  
  ``` yaml
  repo_with_gpg:
    pkgrepo.managed:
      - url: {{ REPO_URL }}
      - gpgautoimport: True
  ```
  - when the repository is new:
    - this adds the repository and refreshes with `zypper --gpg-auto-import-keys refresh <repo-name>` but does not call modify
  - when the repository already exist:
    - this only calls `zypper --gpg-auto-import-keys refresh <repo-name>` on the existing repository
- _url_, _refresh_ and _gpgautoimport_
  
  ``` yaml
  repo_with_gpg:
    pkgrepo.managed:
      - url: {{ REPO_URL }}
      - refresh: True,
      - gpgautoimport: True
  ```
  - when the repository is new:
    - this adds the repository, then modifies it by updating its _autorefresh_ option and then refreshes with `zypper --gpg-auto-import-keys refresh <repo-name>`
  - when the repository already exist:
    - modifies the repository by updating its _autorefresh_ option and calls refresh
