### PR TITLE
grains.core.os_data: add windows osfinger, osrelease_info

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1156,6 +1156,23 @@ def os_data():
         grains.update(_windows_cpudata())
         grains.update(_windows_virtual(grains))
         grains.update(_ps(grains))
+
+        if 'Server' in grains['osrelease']:
+            osrelease_info = grains['osrelease'].split('Server', 1)
+            osrelease_info[1] = osrelease_info[1].lstrip('R')
+        else:
+            osrelease_info = grains['osrelease'].split('.')
+
+        for idx, value in enumerate(osrelease_info):
+            if not value.isdigit():
+                continue
+            osrelease_info[idx] = int(value)
+        grains['osrelease_info'] = tuple(osrelease_info)
+
+        grains['osfinger'] = '{os}-{ver}'.format(
+            os=grains['os'],
+            ver=grains['osrelease'])
+
         return grains
     elif salt.utils.is_linux():
         # Add SELinux grain, if you have it


### PR DESCRIPTION
### What does this PR do?

grains.core.os_data: add windows osfinger, osrelease_info
#### Windows 2008

``` diff
--- 2008.grains.old     2016-05-27 16:41:50.436000000 -0400
+++ 2008.grains.new     2016-05-27 16:40:14.472000000 -0400
@@ -82,18 +82,23 @@
         Windows
     os_family:
         Windows
+    osfinger:
+        Windows-2008ServerR2
     osfullname:
         Microsoft Windows Server 2008 R2 Datacenter
     osmanufacturer:
         Microsoft Corporation
     osrelease:
         2008ServerR2
+    osrelease_info:
+        - 2008
+        - 2
     osversion:
         6.1.7601
     path:
```
#### Windows 2012

``` diff
--- 2012.grains.old     2016-05-18 10:08:32.284000000 -0600
+++ 2012.grains.new     2016-05-18 10:30:33.484000000 -0600
@@ -92,12 +92,21 @@
         Windows
     os_family:
         Windows
+    osfinger:
+        Windows-2012ServerR2
     osfullname:
         Microsoft Windows Server 2012 R2 Standard
     osmanufacturer:
         Microsoft Corporation
     osrelease:
         2012ServerR2
+    osrelease_info:
+        - 2012
+        - 2
     osversion:
         6.3.9600
     path:
```
#### Windows 10

``` diff
--- 10.grains.old  2016-05-18 13:34:54.250168000 -0400
+++ 10.grains.new  2016-05-18 13:36:57.186168000 -0400
@@ -76,18 +76,26 @@
         Windows
     os_family:
         Windows
+    osfinger:
+        Windows-10
     osfullname:
         Microsoft Windows 10 Pro
     osmanufacturer:
         Microsoft Corporation
     osrelease:
         10
+    osrelease_info:
+        - 10
     osversion:
         10.0.10240
     path:
```

Ping @cedwards.
### Tests written?

No
