### PR TITLE
Fix slack engine to run on python2.6

### DIFF
--- a/salt/engines/slack.py
+++ b/salt/engines/slack.py
@@ -31,10 +31,12 @@ prefaced with a ``!``.
 # Import python libraries
 from __future__ import absolute_import
 import datetime
-import json
 import logging
 import pprint
 import time
+import string
+import re
+import collections
 try:
     import slackclient
     HAS_SLACKCLIENT = True
@@ -72,10 +74,22 @@ def _get_users(token):
     users = {}
     if 'message' in ret:
         for item in ret['message']:
-            if not item['is_bot']:
-                users[item['name']] = item['id']
-                users[item['id']] = item['name']
+            if 'is_bot' in item:
+                if not item['is_bot']:
+                    users[item['name']] = item['id']
+                    users[item['id']] = item['name']
     return users
+
+
+def _convert(data):
+    if isinstance(data, basestring):
+        return ''.join(str(data).splitlines())
+    elif isinstance(data, collections.Mapping):
+        return dict(map(_convert, data.iteritems()))
+    elif isinstance(data, collections.Iterable):
+        return type(data)(map(_convert, data))
+    else:
+        return data
 
 
 def start(token,
@@ -135,6 +149,27 @@ def start(token,
                                 # Trim the ! from the front
                                 # cmdline = _text[1:].split(' ', 1)
                                 cmdline = salt.utils.shlex_split(_text[len(trigger):])
+
+                                cmdlist = []
+                                #remove \X00 from strings
+                                for cmditem  in cmdline:
+                                    cmdlist.append(filter(lambda x: x in string.printable, str(cmditem)))
+                                cmdline = cmdlist
+
+                                cmdlist = []
+                                #remove slack url parsing
+                                # take input target=<http://host.domain.net|host.domain.net>
+                                # convert to target=host.domain.net
+                                for cmditem  in cmdline:
+                                    pattern = r'(?P<begin>.*)(<.*\|)(?P<url>.*)(>)(?P<remainder>.*)'
+                                    m = re.match(pattern, cmditem)
+                                    if m:
+                                        origtext = m.group('begin') + m.group('url') + m.group('remainder')
+                                        cmdlist.append(origtext)
+                                    else:
+                                        cmdlist.append(cmditem)
+                                cmdline = cmdlist
+
                                 cmd = cmdline[0]
                                 args = []
                                 kwargs = {}
@@ -190,9 +225,10 @@ def start(token,
                                         "files.upload", channels=_m['channel'], filename=filename,
                                         content=return_text
                                     )
-                                    _result = json.loads(result)
-                                    if 'ok' in _result and _result['ok'] is False:
-                                        channel.send_message('Error: {0}'.format(_result['error']))
+                                    #handle unicode return
+                                    result = _convert(result)
+                                    if 'ok' in result and result['ok'] is False:
+                                        channel.send_message('Error: {0}'.format(result['error']))
                             else:
                                 # Fire event to event bus
                                 fire('{0}/{1}'.format(tag, _m['type']), _m)

--- a/salt/engines/slack.py
+++ b/salt/engines/slack.py
@@ -147,10 +147,6 @@ def start(token,
                                 # cmdline = _text[1:].split(' ', 1)
                                 cmdline = salt.utils.shlex_split(_text[len(trigger):])
 
-                                # Remove inital salt item from list
-                                if cmdline[0] == 'salt':
-                                    del cmdline[0]
-
                                 # Remove slack url parsing
                                 #  Translate target=<http://host.domain.net|host.domain.net>
                                 #  to target=host.domain.net

--- a/salt/engines/slack.py
+++ b/salt/engines/slack.py
@@ -20,10 +20,13 @@ prefaced with a ``!``.
                valid_commands:
                    - test.ping
                    - cmd.run
+                   - list_jobs
+                   - list_commands
                aliases:
                    list_jobs:
-                       type: runner
                        cmd: jobs.list_jobs
+                   list_commands:
+                       cmd: pillar.get salt:engines:slack:valid_commands target=saltmaster
 
 :depends: slackclient
 '''
@@ -32,11 +35,11 @@ prefaced with a ``!``.
 from __future__ import absolute_import
 import datetime
 import logging
-import pprint
 import time
-import string
 import re
-import collections
+import json
+import yaml
+
 try:
     import slackclient
     HAS_SLACKCLIENT = True
@@ -54,10 +57,7 @@ import salt.utils.slack
 
 
 def __virtual__():
-    if not HAS_SLACKCLIENT:
-        return False
-    else:
-        return True
+    return HAS_SLACKCLIENT
 
 log = logging.getLogger(__name__)
 
@@ -67,7 +67,6 @@ def _get_users(token):
     Get all users from Slack
     '''
 
-    log.debug('running _get_users')
     ret = salt.utils.slack.query(function='users',
                                  api_key=token,
                                  opts=__opts__)
@@ -79,17 +78,6 @@ def _get_users(token):
                     users[item['name']] = item['id']
                     users[item['id']] = item['name']
     return users
-
-
-def _convert(data):
-    if isinstance(data, basestring):
-        return ''.join(str(data).splitlines())
-    elif isinstance(data, collections.Mapping):
-        return dict(map(_convert, data.iteritems()))
-    elif isinstance(data, collections.Iterable):
-        return type(data)(map(_convert, data))
-    else:
-        return data
 
 
 def start(token,
@@ -110,18 +98,22 @@ def start(token,
         fire_master = None
 
     def fire(tag, msg):
+        '''
+        Fire event to salt bus
+        '''
         if fire_master:
             fire_master(msg, tag)
         else:
             __salt__['event.send'](tag, msg)
 
     if not token:
-        log.debug('Slack Bot token not found')
-        return
+        raise UserWarning('Slack Bot token not found')
+
     all_users = _get_users(token)
 
     sc = slackclient.SlackClient(token)
     slack_connect = sc.rtm_connect()
+    log.debug('connected to slack')
 
     runner_functions = sorted(salt.runner.Runner(__opts__).functions)
 
@@ -136,6 +128,11 @@ def start(token,
 
                         # Edited messages have text in message
                         _text = _m.get('text', None) or _m.get('message', {}).get('text', None)
+
+                        # Convert UTF to string
+                        _text = json.dumps(_text)
+                        _text = yaml.safe_load(_text)
+
                         if _text:
                             if _text.startswith(trigger) and control:
 
@@ -150,16 +147,14 @@ def start(token,
                                 # cmdline = _text[1:].split(' ', 1)
                                 cmdline = salt.utils.shlex_split(_text[len(trigger):])
 
-                                cmdlist = []
-                                #remove \X00 from strings
-                                for cmditem  in cmdline:
-                                    cmdlist.append(filter(lambda x: x in string.printable, str(cmditem)))
-                                cmdline = cmdlist
+                                # Remove inital salt item from list
+                                if cmdline[0] == 'salt':
+                                    del cmdline[0]
 
+                                # Remove slack url parsing
+                                #  Translate target=<http://host.domain.net|host.domain.net>
+                                #  to target=host.domain.net
                                 cmdlist = []
-                                #remove slack url parsing
-                                # take input target=<http://host.domain.net|host.domain.net>
-                                # convert to target=host.domain.net
                                 for cmditem  in cmdline:
                                     pattern = r'(?P<begin>.*)(<.*\|)(?P<url>.*)(>)(?P<remainder>.*)'
                                     m = re.match(pattern, cmditem)
@@ -180,6 +175,13 @@ def start(token,
                                         channel.send_message('Using {0} is not allowed.'.format(cmd))
                                         return
 
+                                # Evaluate aliases
+                                if aliases and isinstance(aliases, dict) and cmd in aliases.keys():
+                                    cmdline = aliases[cmd].get('cmd')
+                                    cmdline = salt.utils.shlex_split(cmdline)
+                                    cmd = cmdline[0]
+
+                                # Parse args and kwargs
                                 if len(cmdline) > 1:
                                     for item in cmdline[1:]:
                                         if '=' in item:
@@ -188,6 +190,7 @@ def start(token,
                                         else:
                                             args.append(item)
 
+                                # Check for target. Otherwise assume *
                                 if 'target' not in kwargs:
                                     target = '*'
                                 else:
@@ -195,29 +198,18 @@ def start(token,
                                     del kwargs['target']
 
                                 ret = {}
-                                if aliases and isinstance(aliases, dict) and cmd in aliases.keys():
-                                    salt_cmd = aliases[cmd].get('cmd')
 
-                                    if 'type' in aliases[cmd]:
-                                        if aliases[cmd]['type'] == 'runner':
-                                            runner = salt.runner.RunnerClient(__opts__)
-                                            ret = runner.cmd(salt_cmd, arg=args, kwarg=kwargs)
-                                    else:
-                                        local = salt.client.LocalClient()
-                                        ret = local.cmd('{0}'.format(target), salt_cmd, args, kwargs)
-
-                                elif cmd in runner_functions:
+                                if cmd in runner_functions:
                                     runner = salt.runner.RunnerClient(__opts__)
                                     ret = runner.cmd(cmd, arg=args, kwarg=kwargs)
 
-                                # default to trying to run as a client module.
+                                # Default to trying to run as a client module.
                                 else:
                                     local = salt.client.LocalClient()
                                     ret = local.cmd('{0}'.format(target), cmd, args, kwargs)
 
                                 if ret:
-                                    pp = pprint.PrettyPrinter(width=1)
-                                    return_text = pp.pformat(ret)
+                                    return_text = json.dumps(ret, sort_keys=True, indent=1)
                                     ts = time.time()
                                     st = datetime.datetime.fromtimestamp(ts).strftime('%Y%m%d%H%M%S%f')
                                     filename = 'salt-results-{0}.yaml'.format(st)
@@ -225,8 +217,9 @@ def start(token,
                                         "files.upload", channels=_m['channel'], filename=filename,
                                         content=return_text
                                     )
-                                    #handle unicode return
-                                    result = _convert(result)
+                                    # Handle unicode return
+                                    result = json.dumps(result)
+                                    result = yaml.safe_load(result)
                                     if 'ok' in result and result['ok'] is False:
                                         channel.send_message('Error: {0}'.format(result['error']))
                             else:
@@ -235,3 +228,5 @@ def start(token,
                     else:
                         # Fire event to event bus
                         fire('{0}/{1}'.format(tag, _m['type']), _m)
+    else:
+        raise UserWarning("Could not connect to slack")

--- a/salt/engines/slack.py
+++ b/salt/engines/slack.py
@@ -155,7 +155,7 @@ def start(token,
                                 #  Translate target=<http://host.domain.net|host.domain.net>
                                 #  to target=host.domain.net
                                 cmdlist = []
-                                for cmditem  in cmdline:
+                                for cmditem in cmdline:
                                     pattern = r'(?P<begin>.*)(<.*\|)(?P<url>.*)(>)(?P<remainder>.*)'
                                     m = re.match(pattern, cmditem)
                                     if m:


### PR DESCRIPTION
### What does this PR do?

Fixes issue where slack user doesn't have an is_bot key
Allows engine to run on rhel6 with python 2.6 with unicode conversion
Corrects for slack's autoparsing of url looking text. Commands like:
`!salt test.ping target=hostname.domain.com` should now be handled properly.
### Tests written?

No

I am not a python unicode wizard, so please don't take my word for it. While this fixes the engine for my python2.6 environment, there might be better ways of handling something maybe with python 3 in mind. So this works for me and likely corrects it for others, but please review.
