### PR TITLE
Typo in states/virtualenv_mod.py

### DIFF
--- a/salt/states/virtualenv_mod.py
+++ b/salt/states/virtualenv_mod.py
@@ -189,7 +189,7 @@ def managed(name,
             )
         except CommandNotFoundError as err:
             ret['result'] = False
-            ret['comment'] = 'Failed to create virtualenv: {0}'.formar(err)
+            ret['comment'] = 'Failed to create virtualenv: {0}'.format(err)
             return ret
 
         if _ret['retcode'] != 0:


### PR DESCRIPTION
'str' object has no attribute 'formar'
