### PR TITLE
Fix #33578 disks grain

### DIFF
--- a/salt/grains/disks.py
+++ b/salt/grains/disks.py
@@ -106,6 +106,8 @@ def _freebsd_geom():
                         tmp[_geomconsts._aliases[attrib]] = value
 
         name = tmp.pop(_geomconsts.GEOMNAME)
+        if name.startswith('cd'):
+            return
 
         ret['disks'][name] = tmp
         if tmp[_geomconsts.ROTATIONRATE] == 0:

--- a/salt/grains/disks.py
+++ b/salt/grains/disks.py
@@ -57,18 +57,27 @@ class _geomconsts(object):
 
     _datatypes = {
         MEDIASIZE: ('re_int', r'(\d+)'),
-        SECTORSIZE: 'int',
-        STRIPESIZE: 'int',
-        STRIPEOFFSET: 'int',
-        ROTATIONRATE: 'int',
+        SECTORSIZE: 'try_int',
+        STRIPESIZE: 'try_int',
+        STRIPEOFFSET: 'try_int',
+        ROTATIONRATE: 'try_int',
     }
 
 
 def _datavalue(datatype, data):
-    if datatype == 'int':
-        return int(data)
-    elif datatype and datatype[0] == 're_int':
-        return int(re.search(datatype[1], data).group(1))
+    if datatype == 'try_int':
+        try:
+            return int(data)
+        except ValueError:
+            return None
+    elif datatype is tuple and datatype[0] == 're_int':
+        search = re.search(datatype[1], data)
+        if search:
+            try:
+                return int(search.group(1))
+            except ValueError:
+                return None
+        return None
     else:
         return data
 


### PR DESCRIPTION
### What does this PR do?

Some fixes for the disks grain changes in 2016.3.0.
### What issues does this PR fix or reference?
#33578
### Previous Behavior

The disks grain would throw a ValueError exception if `rotationrate` returned `(unknown)` in `geom disk list` because it tries to cast the data to an integer.

The grain would include cd-rom drives.
### New Behavior

The datatype parsing is more resilient and will return None if the expected data type is not present.

The grain will not include cd-roms.
### Tests written?

No
