### PR TITLE
Fixed ini.options_absent. Resolves #33590.

### DIFF
--- a/salt/states/ini_manage.py
+++ b/salt/states/ini_manage.py
@@ -109,14 +109,15 @@ def options_absent(name, sections=None):
             ret['comment'] = 'No changes detected.'
         return ret
     sections = sections or {}
-    for section, key in sections.iteritems():
-        current_value = __salt__['ini.remove_option'](name, section, key)
-        if not current_value:
-            continue
-        if section not in ret['changes']:
-            ret['changes'].update({section: {}})
-        ret['changes'][section].update({key: current_value})
-        ret['comment'] = 'Changes take effect'
+    for section, keys in sections.iteritems():
+        for key in keys:
+            current_value = __salt__['ini.remove_option'](name, section, key)
+            if not current_value:
+                continue
+            if section not in ret['changes']:
+                ret['changes'].update({section: {}})
+            ret['changes'][section].update({key: current_value})
+            ret['comment'] = 'Changes take effect'
     return ret
 
 


### PR DESCRIPTION
### What does this PR do?

It fixes the bug #33590 where the state `ini.options_absent` would crash with an "unhashable type" error.
### What issues does this PR fix or reference?
#33590
### Previous Behavior

```
----------
          ID: /home/ubuntu/test.ini
    Function: ini.options_absent
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/opt/vagrant/salt/state.py", line 1703, in call
                  **cdata['kwargs'])
                File "/opt/vagrant/salt/loader.py", line 1649, in wrapper
                  return f(*args, **kwargs)
                File "/opt/vagrant/salt/states/ini_manage.py", line 114, in options_absent
                  current_value = __salt__['ini.remove_option'](name, section, key)
                File "/opt/vagrant/salt/modules/ini_manage.py", line 124, in remove_option
                  value = inifile.get(section, {}).pop(option, None)
                File "/usr/lib/python2.7/collections.py", line 155, in pop
                  if key in self:
              TypeError: unhashable type: 'list'
     Started: 02:54:06.809985
    Duration: 9.262 ms
     Changes:
```
### New Behavior

```
----------
          ID: /home/ubuntu/test.ini
    Function: ini.options_absent
      Result: True
     Comment: Changes take effect
     Started: 02:58:53.498259
    Duration: 3.88 ms
     Changes:
              ----------
              test2:
                  ----------
                  absent_opt:
                      7
                  test2_opt:
                      0
```
### Tests written?

No.

I can add test logic to the module if you think that's appropriate. I would need to add test logic to the module to bypass the normal behavior, so I'm not sure that would be a meaningful test.
