### PR TITLE
2015.5

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1275,7 +1275,7 @@ class AESFuncs(object):
         try:
             salt.utils.job.store_job(
                 self.opts, load, event=self.event, mminion=self.mminion)
-        except salt.exception.SaltCacheError:
+        except salt.exceptions.SaltCacheError:
             log.error('Could not store job information for load: {0}'.format(load))
 
     def _syndic_return(self, load):

--- a/salt/returners/sqlite3_return.py
+++ b/salt/returners/sqlite3_return.py
@@ -197,7 +197,7 @@ def get_load(jid):
                 {'jid': jid})
     data = cur.fetchone()
     if data:
-        return json.loads(data)
+        return json.loads(data[0].encode())
     _close_conn(conn)
     return {}
 


### PR DESCRIPTION
This PR solves 2 issues that appeared while initiating sqlite3 returner usage:
- Type in master,py regarding base.exceptions (solved in master already)
- A TypeError exception resulting from sqlite3 returner passing improper data

We're succesfully using these patches in our production salt environment.
