### PR TITLE
fix dockercompose version check

### DIFF
--- a/salt/modules/dockercompose.py
+++ b/salt/modules/dockercompose.py
@@ -118,6 +118,7 @@ except ImportError:
     HAS_DOCKERCOMPOSE = False
 
 MIN_DOCKERCOMPOSE = (1, 5, 0)
+MAX_DOCKERCOMPOSE = (1, 6, 2)
 VERSION_RE = r'([\d.]+)'
 
 log = logging.getLogger(__name__)
@@ -132,7 +133,7 @@ def __virtual__():
         match = re.match(VERSION_RE, str(compose.__version__))
         if match:
             version = tuple([int(x) for x in match.group(1).split('.')])
-            if MIN_DOCKERCOMPOSE >= version:
+            if version >= MIN_DOCKERCOMPOSE and version <= MAX_DOCKERCOMPOSE:
                 return __virtualname__
         else:
             log.critical('Minimum version of docker-compose>=1.5.0')

--- a/salt/modules/dockercompose.py
+++ b/salt/modules/dockercompose.py
@@ -135,8 +135,6 @@ def __virtual__():
             version = tuple([int(x) for x in match.group(1).split('.')])
             if version >= MIN_DOCKERCOMPOSE and version <= MAX_DOCKERCOMPOSE:
                 return __virtualname__
-        else:
-            log.critical('Minimum version of docker-compose>=1.5.0')
     return (False, 'The dockercompose execution module not loaded: '
             'compose python library not available.')
 


### PR DESCRIPTION
### What does this PR do?

Fix the version check for the dockercompose module.
### What issues does this PR fix or reference?
### Previous Behavior

Will not accept a version above the minimun version (check inverted)
### New Behavior

Will not accept a version under the minimum one or more than the maximum. 

For now we still do not support docker-compose 1.7, I will work on it soonish.
### Tests written?

No
