### PR TITLE
Updated apache_module for backward compatible.

### DIFF
--- a/salt/states/apache_module.py
+++ b/salt/states/apache_module.py
@@ -9,15 +9,18 @@ Enable and disable apache modules.
 .. code-block:: yaml
 
     Enable cgi module:
-        apache_module.enable:
+        apache_module.enabled:
             - name: cgi
 
     Disable cgi module:
-        apache_module.disable:
+        apache_module.disabled:
             - name: cgi
 '''
 from __future__ import absolute_import
 from salt.ext.six import string_types
+
+# Import salt libs
+import salt.utils
 
 
 def __virtual__():
@@ -61,6 +64,22 @@ def enabled(name):
     return ret
 
 
+def enable(name):
+    '''
+    Ensure an Apache module is enabled.
+
+    name
+        Name of the Apache module
+    '''
+    salt.utils.warn_until(
+        'Carbon',
+        'This functionality has been deprecated; use "apache_module.enabled" '
+        'instead.'
+    )
+
+    return enabled(name)
+
+
 def disabled(name):
     '''
     Ensure an Apache module is disabled.
@@ -93,3 +112,19 @@ def disabled(name):
     else:
         ret['comment'] = '{0} already disabled.'.format(name)
     return ret
+
+
+def disable(name):
+    '''
+    Ensure an Apache module is disabled.
+
+    name
+        Name of the Apache module
+    '''
+    salt.utils.warn_until(
+        'Carbon',
+        'This functionality has been deprecated; use "apache_module.disabled" '
+        'instead.'
+    )
+
+    return disabled(name)


### PR DESCRIPTION
### What does this PR do?
### What issues does this PR fix or reference?

[This](https://github.com/saltstack/salt/commit/f3a2b27671459a2a323407ffea4625905e1b7f89) introduced a change of functions names that break this module when using Beryllium or older and upgrading to Boron.
Added here a deprecated warning in to order to advice users to migrate to new functions names. Also
documentation updated since was not updated in the original commit.
### Previous Behavior

State:

``` yml
Enable cgi module:
  apache_module.enable:
    - name: cgi
```

Result:

``` yml
salt '*' state.highstate
salt:
----------
          ID: Enable cgi module
    Function: apache_module.enable
        Name: cgi
      Result: False
     Comment: State 'apache_module.enable' was not found in SLS 'default'
              Reason: 'apache_module.enable' is not available.
     Started:
    Duration:
     Changes:

Summary for salt
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
```
### New Behavior

State:

``` yml
Enable cgi module:
  apache_module.enable:
    - name: cgi
```

Result

``` yml
salt:
----------
          ID: Enable cgi module
    Function: apache_module.enable
        Name: cgi
      Result: True
     Comment:
     Started: 20:27:45.885109
    Duration: 91.94 ms
     Changes:
              ----------
              new:
                  cgi
              old:
                  None

Summary for salt
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
```
### Tests written?

Tests are already in place for new named: **enabled / disabled**. Functions added are just wrappers.
