### PR TITLE
Fix crash on unconnectable MySQL server (resolves #33582)

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -761,6 +761,8 @@ def free_slave(**connection_args):
         salt '*' mysql.free_slave
     '''
     slave_db = _connect(**connection_args)
+    if slave_db is None:
+        return ''
     slave_cur = slave_db.cursor(MySQLdb.cursors.DictCursor)
     slave_cur.execute('show slave status')
     slave_status = slave_cur.fetchone()
@@ -773,6 +775,8 @@ def free_slave(**connection_args):
         # servers here, and only overriding the host option in the connect
         # function.
         master_db = _connect(**master)
+        if master_db is None:
+            return ''
         master_cur = master_db.cursor()
         master_cur.execute('flush logs')
         master_db.close()
@@ -1807,6 +1811,8 @@ def processlist(**connection_args):
     ret = []
 
     dbc = _connect(**connection_args)
+    if dbc is None:
+        return []
     cur = dbc.cursor()
     _execute(cur, 'SHOW FULL PROCESSLIST')
     hdr = [c[0] for c in cur.description]
@@ -1887,6 +1893,8 @@ def get_master_status(**connection_args):
     mod = sys._getframe().f_code.co_name
     log.debug('{0}<--'.format(mod))
     conn = _connect(**connection_args)
+    if conn is None:
+        return []
     rtnv = __do_query_into_hash(conn, "SHOW MASTER STATUS")
     conn.close()
 
@@ -1955,6 +1963,8 @@ def get_slave_status(**connection_args):
     mod = sys._getframe().f_code.co_name
     log.debug('{0}<--'.format(mod))
     conn = _connect(**connection_args)
+    if conn is None:
+        return []
     rtnv = __do_query_into_hash(conn, "SHOW SLAVE STATUS")
     conn.close()
 
@@ -1983,6 +1993,8 @@ def showvariables(**connection_args):
     mod = sys._getframe().f_code.co_name
     log.debug('{0}<--'.format(mod))
     conn = _connect(**connection_args)
+    if conn is None:
+        return []
     rtnv = __do_query_into_hash(conn, "SHOW VARIABLES")
     conn.close()
     if len(rtnv) == 0:
@@ -2009,6 +2021,8 @@ def showglobal(**connection_args):
     mod = sys._getframe().f_code.co_name
     log.debug('{0}<--'.format(mod))
     conn = _connect(**connection_args)
+    if conn is None:
+        return []
     rtnv = __do_query_into_hash(conn, "SHOW GLOBAL VARIABLES")
     conn.close()
     if len(rtnv) == 0:

--- a/tests/unit/modules/mysql_test.py
+++ b/tests/unit/modules/mysql_test.py
@@ -269,6 +269,17 @@ class MySQLTestCase(TestCase):
         '''
         self._test_call(mysql.get_slave_status, 'SHOW SLAVE STATUS')
 
+    def test_get_slave_status_bad_server(self):
+        '''
+        Test get_slave_status in the mysql execution module, simulating a broken server
+        '''
+        connect_mock = MagicMock(return_value=None)
+        mysql._connect = connect_mock
+        with patch.dict(mysql.__salt__, {'config.option': MagicMock()}):
+            rslt = mysql.get_slave_status()
+            connect_mock.assert_has_calls([call()])
+            self.assertEqual(rslt, [])
+
     @skipIf(True, 'MySQL module claims this function is not ready for production')
     def test_free_slave(self):
         pass


### PR DESCRIPTION
### What does this PR do?

Fixes a stacktrace-inducing crash when the mysql module was used against a server to which it couldn't connect. Several of the functions in the mysql module didn't check whether the connection was successful before attempting to grab a cursor. Now they do.
### What issues does this PR fix or reference?
#33582
### Previous Behavior

```
$ sudo ./salt/scripts/salt saltdev mysql.get_slave_status
saltdev:
    The minion function caused an exception: Traceback (most recent call last):
      File "/home/ubuntu/salt/salt/minion.py", line 1078, in _thread_return
        return_data = func(*args, **kwargs)
      File "/home/ubuntu/salt/salt/modules/mysql.py", line 1959, in get_slave_status
        rtnv = __do_query_into_hash(conn, "SHOW SLAVE STATUS")
      File "/home/ubuntu/salt/salt/modules/mysql.py", line 1837, in __do_query_into_hash
        cursor = conn.cursor()
    AttributeError: 'NoneType' object has no attribute 'cursor'
```
### New Behavior

```
$ sudo ./salt/scripts/salt saltdev mysql.get_slave_status
saltdev:
```

It now returns an empty array, just like the other module functions do. The states, for their part, detect the error from `__context__` and fail if there was a problem with the connection.
### Tests written?

Yup: `unit.modules.mysql_test.MySQLTestCase.test_get_slave_status_bad_server`
