### PR TITLE
Add wait_for_successful_query to module and state

### DIFF
--- a/salt/modules/http.py
+++ b/salt/modules/http.py
@@ -7,6 +7,9 @@ like, but also useful for basic http testing.
 '''
 from __future__ import absolute_import
 
+# Import system libs
+import time
+
 # Import salt libs
 import salt.utils.http
 
@@ -28,6 +31,36 @@ def query(url, **kwargs):
             data='<xml>somecontent</xml>'
     '''
     return salt.utils.http.query(url=url, opts=__opts__, **kwargs)
+
+
+def wait_for_successful_query(url, wait_for=300, **kwargs):
+    '''
+    Query a resource until a successful response, and decode the return data
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' http.wait_for_successful_query http://somelink.com/ wait_for=160
+    '''
+
+    starttime = time.time()
+
+    while True:
+        caught_exception = None
+        result = None
+        try:
+            result = query(url=url, **kwargs)
+            if not result.get('Error') and not result.get('error'):
+                return result
+        except Exception as exc:
+            caught_exception = exc
+
+        if time.time() > starttime + wait_for:
+            if not result and caught_exception:
+                raise caught_exception
+
+            return result
 
 
 def update_ca_bundle(target=None, source=None, merge_files=None):

--- a/salt/modules/http.py
+++ b/salt/modules/http.py
@@ -58,7 +58,8 @@ def wait_for_successful_query(url, wait_for=300, **kwargs):
 
         if time.time() > starttime + wait_for:
             if not result and caught_exception:
-                raise caught_exception
+                # workaround pylint bug https://www.logilab.org/ticket/3207
+                raise caught_exception  # pylint: disable=E0702
 
             return result
 

--- a/salt/states/http.py
+++ b/salt/states/http.py
@@ -11,12 +11,14 @@ Perform an HTTP query and statefully return the result
 from __future__ import absolute_import
 import re
 
+import time
+
 __monitor__ = [
         'query',
         ]
 
 
-def query(name, match=None, match_type='string', status=None, **kwargs):
+def query(name, match=None, match_type='string', status=None, wait_for=None, **kwargs):
     '''
     Perform an HTTP query and statefully return the result
 
@@ -82,7 +84,10 @@ def query(name, match=None, match_type='string', status=None, **kwargs):
     if __opts__['test']:
         kwargs['test'] = True
 
-    data = __salt__['http.query'](name, **kwargs)
+    if wait_for:
+        data = __salt__['http.wait_for_successful_query'](name, wait_for=wait_for, **kwargs)
+    else:
+        data = __salt__['http.query'](name, **kwargs)
 
     if match is not None:
         if match_type == 'string':
@@ -118,3 +123,27 @@ def query(name, match=None, match_type='string', status=None, **kwargs):
 
     ret['data'] = data
     return ret
+
+
+def wait_for_successful_query(name, wait_for=300, **kwargs):
+    '''
+    Like query but, repeat and wait until match/match_type or status is fulfilled. State returns result from last
+    query state in case of success or if no successful query was made within wait_for timeout.
+    '''
+    starttime = time.time()
+
+    while True:
+        caught_exception = None
+        ret = None
+        try:
+            ret = query(name, wait_for=wait_for, **kwargs)
+            if ret['result']:
+                return ret
+        except Exception as exc:
+            caught_exception = exc
+
+        if time.time() > starttime + wait_for:
+            if not ret and caught_exception:
+                raise caught_exception
+
+            return ret

--- a/salt/states/http.py
+++ b/salt/states/http.py
@@ -144,6 +144,7 @@ def wait_for_successful_query(name, wait_for=300, **kwargs):
 
         if time.time() > starttime + wait_for:
             if not ret and caught_exception:
-                raise caught_exception
+                # workaround pylint bug https://www.logilab.org/ticket/3207
+                raise caught_exception  # pylint: disable=E0702
 
             return ret


### PR DESCRIPTION
### What does this PR do?

Add a module state that ignores exceptions like timeouts and retries for a certain timespan to succeed.
This is useful to ensure that a rest API, e.g. from Elasticsearch, is reachable up after the server has been started.
### What issues does this PR fix or reference?

n/a
### Tests written?

No
