### PR TITLE
Remove duplicate inet line for inet6 interfaces

### DIFF
--- a/salt/templates/debian_ip/debian_eth.jinja
+++ b/salt/templates/debian_ip/debian_eth.jinja
@@ -2,7 +2,8 @@
 {%endif%}{% if data.hotplug %}allow-hotplug {{name}}
 {%endif%}{%- if data.data['inet'] -%}
 {%- set interface = data.data['inet'] -%}
-{% if interface.proto %}iface {{name}} {{interface.addrfam}} {{interface.proto}}
+{% if interface.proto and interface.address %}iface {{name}} {{interface.addrfam}} {{interface.proto}}
+{%endif%}{% if interface.proto == 'dhcp' %}iface {{name}} {{interface.addrfam}} {{interface.proto}}
 {%endif %}{% if interface.hwaddress %}    hwaddress {{interface.hwaddress}}
 {%endif%}{% if interface.vlan_raw_device %}    vlan-raw-device {{interface.vlan_raw_device}}
 {%endif%}{% if interface.address %}    address {{interface.address}}
@@ -90,5 +91,4 @@ iface {{name}} {{interface.addrfam}} {{interface.proto}}
 {%endif%}{% if interface.pre_down_cmds %}{% for cmd in interface.pre_down_cmds %}    pre-down {{ cmd }}
 {%endfor-%}
 {%endif%}{% if interface.post_down_cmds %}{% for cmd in interface.post_down_cmds %}    post-down {{ cmd }}
-{%endfor-%}{%endif%}
-{%endif%}
+{%endfor-%}{%endif%}{%endif%}


### PR DESCRIPTION
### What does this PR do?

Currently the template debian_eth.jinja checks if "interface.proto" exists. This is not sufficient since it will always be "inet" and therefore the additional inet line will be present in the generated configuration, even though it is an IPv6 only interface. In case of a static IP address configuration, it also needs to be checked if "interface.address" exists. In case of an interface configured via DHCP, it needs to be checked if "interface.proto" is "dhcp".
### What issues does this PR fix or reference?

Relates #28114 
Closes: #28114 
### Previous Behavior

Salt created an additional "inet" line for an "inet6" only interface
### New Behavior

Salt now creates the correct "inet6" configuration line
### Tests written?

No
