### PR TITLE
ProfitBricks cloud provider improvements

### DIFF
--- a/doc/topics/cloud/profitbricks.rst
+++ b/doc/topics/cloud/profitbricks.rst
@@ -83,6 +83,7 @@ Here is an example of a profile:
       size: Micro Instance
       image: 2f98b678-6e7e-11e5-b680-52540066fee9
       disk_size: 10
+      disk_type: SSD
       cores: 2
       ram: 4096
       public_lan: 1
@@ -110,6 +111,10 @@ image
 disk_size
     This option allows you to override the size of the disk as defined by the
     size. The disk size is set in gigabytes (GB).
+
+disk_type
+    This option allow the disk type to be set to HDD or SSD. The default is
+    HDD.
 
 cores
     This option allows you to override the number of CPU cores as defined by
@@ -143,6 +148,10 @@ ssh_interface
 
 deploy
     Set to False if Salt should not be installed on the node.
+
+wait_for_timeout
+    The timeout to wait in seconds for provisioning resources such as servers.
+    The default wait_for_timeout is 15 minutes.
 
 For more information concerning cloud profiles, see :doc:`here
 </topics/cloud/profiles>`.

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2773,7 +2773,8 @@ def is_profile_configured(opts, provider, profile_name, vm_=None):
 
     # Most drivers need a size, but some do not.
     non_size_drivers = ['opennebula', 'parallels', 'proxmox', 'scaleway',
-                        'softlayer', 'softlayer_hw', 'vmware', 'vsphere', 'virtualbox']
+                        'softlayer', 'softlayer_hw', 'vmware', 'vsphere',
+                        'virtualbox', 'profitbricks']
 
     provider_key = opts['providers'][alias][driver]
     profile_key = opts['providers'][alias][driver]['profiles'][profile_name]


### PR DESCRIPTION
This PR provides a couple of improvements to the ProfitBricks cloud provider. 
- Added `disk_type` property to allow HDD or SSD disks and updated documentation.
- Added a `wait_for_timeout`property for ProfitBricks API requests, incremented default wait timeout to 15 minutes, and updated documentation.
- Refactored image selection by image name.
- Print API request ID in debug log output.
- Made the  `size` property optional; allow predefined size or custom cores/ram/disk. The ProfitBricks driver has been added to the `non_size_drivers` list
