### PR TITLE
Feature/issue 15749

### DIFF
--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -235,6 +235,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
         __salt__['pkg_resource.stringify'](ret)
     return ret
 
+
 def group_list():
     '''
     .. versionadded:: ?
@@ -311,6 +312,7 @@ def group_list():
 
     return ret
 
+
 def group_info(name):
 
     pkgtypes = ('mandatory', 'optional', 'default', 'conditional')
@@ -346,7 +348,7 @@ def group_diff(name):
     Lists which of a group's packages are installed and which are not
     installed
 
-    Compatible with yumpkg.group_diff for easy support of group_installed
+    Compatible with yumpkg.group_diff for easy support of state.pkg.group_installed
 
     CLI Example:
 
@@ -373,7 +375,6 @@ def group_diff(name):
             else:
                 ret[pkgtype]['not installed'].append(member)
     return ret
-
 
 
 def refresh_db(root=None):

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -289,9 +289,6 @@ def group_list():
 
     # move installed and partially-installed items from available to appropriate other places
 
-    log.warn('Available: {0}'.format(available))
-    log.warn('Installed: {0}'.format(installed))
-
     for group in installed:
         if group not in available:
             log.error('Pacman reports group {0} installed, but it is not in the available list ({1})!'.format(group, available))

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -311,6 +311,32 @@ def group_list():
 
     return ret
 
+def group_info(name):
+
+    pkgtypes = ('mandatory', 'optional', 'default', 'conditional')
+    ret = {}
+    for pkgtype in pkgtypes:
+        ret[pkgtype] = set()
+
+
+    cmd = ['pacman', '-Sgg', name]
+    out = __salt__['cmd.run'](cmd, output_loglevel='trace', python_shell=False)
+
+    packages = {}
+
+    for line in salt.utils.itertools.split(out, '\n'):
+        if not line:
+            continue
+        try:
+            pkg = line.split()[1]
+        except ValueError:
+            log.error('Problem parsing pacman -Sgg: Unexpected formatting in '
+                      'line: \'{0}\''.format(line))
+        else:
+            ret['default'].add(pkg)
+
+    return ret
+
 
 
 def refresh_db(root=None):

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -238,7 +238,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
 
 def group_list():
     '''
-    .. versionadded:: ?
+    .. versionadded:: Carbon
 
     Lists all groups known by pacman on this system
 
@@ -315,7 +315,7 @@ def group_list():
 
 def group_info(name):
     '''
-    .. versionadded:: ?
+    .. versionadded:: Carbon
 
     Lists all packages in the specified group
 
@@ -354,7 +354,7 @@ def group_info(name):
 def group_diff(name):
 
     '''
-    .. versionadded:: ?
+    .. versionadded:: Carbon
 
     Lists which of a group's packages are installed and which are not
     installed

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -293,7 +293,7 @@ def group_list():
     log.warn('Installed: {0}'.format(installed))
 
     for group in installed:
-        if not available.has_key(group):
+        if not group in available:
             log.error('Pacman reports group {0} installed, but it is not in the available list ({1})!'.format(group, available))
             continue
         if len(installed[group]) == len(available[group]):
@@ -306,9 +306,9 @@ def group_list():
 
     ret['available'] = available.keys()
 
-    ret['installed'].sort();
-    ret['partially_installed'].sort();
-    ret['available'].sort();
+    ret['installed'].sort()
+    ret['partially_installed'].sort()
+    ret['available'].sort()
 
     return ret
 
@@ -319,7 +319,6 @@ def group_info(name):
     ret = {}
     for pkgtype in pkgtypes:
         ret[pkgtype] = set()
-
 
     cmd = ['pacman', '-Sgg', name]
     out = __salt__['cmd.run'](cmd, output_loglevel='trace', python_shell=False)
@@ -339,7 +338,7 @@ def group_info(name):
 
     for pkgtype in pkgtypes:
         ret[pkgtype] = sorted(ret[pkgtype])
-        
+
     return ret
 
 

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -338,6 +338,43 @@ def group_info(name):
     return ret
 
 
+def group_diff(name):
+
+    '''
+    .. versionadded:: ?
+
+    Lists which of a group's packages are installed and which are not
+    installed
+
+    Compatible with yumpkg.group_diff for easy support of group_installed
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.group_diff 'xorg'
+    '''
+
+    # Use a compatible structure with yum, so we can leverage the existing state.group_installed
+    # In pacmanworld, everything is the default, but nothing is mandatory
+
+    pkgtypes = ('mandatory', 'optional', 'default', 'conditional')
+    ret = {}
+    for pkgtype in pkgtypes:
+        ret[pkgtype] = {'installed': [], 'not installed': []}
+
+    # use indirect references to simplify unit testing
+    pkgs = __salt__['pkg.list_pkgs']()
+    group_pkgs = __salt__['pkg.group_info'](name)
+    for pkgtype in pkgtypes:
+        for member in group_pkgs.get(pkgtype, []):
+            if member in pkgs:
+                ret[pkgtype]['installed'].append(member)
+            else:
+                ret[pkgtype]['not installed'].append(member)
+    return ret
+
+
 
 def refresh_db(root=None):
     '''

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -337,6 +337,9 @@ def group_info(name):
         else:
             ret['default'].add(pkg)
 
+    for pkgtype in pkgtypes:
+        ret[pkgtype] = sorted(ret[pkgtype])
+        
     return ret
 
 

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -253,7 +253,7 @@ def group_list():
         'partially_installed': [],
         'available': []}
 
-    #find out what's available
+    # find out what's available
 
     cmd = ['pacman', '-Sgg']
     out = __salt__['cmd.run'](cmd, output_loglevel='trace', python_shell=False)
@@ -293,7 +293,7 @@ def group_list():
     log.warn('Installed: {0}'.format(installed))
 
     for group in installed:
-        if not group in available:
+        if group not in available:
             log.error('Pacman reports group {0} installed, but it is not in the available list ({1})!'.format(group, available))
             continue
         if len(installed[group]) == len(available[group]):
@@ -314,6 +314,17 @@ def group_list():
 
 
 def group_info(name):
+    '''
+    .. versionadded:: ?
+
+    Lists all packages in the specified group
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.group_info 'xorg'
+    '''
 
     pkgtypes = ('mandatory', 'optional', 'default', 'conditional')
     ret = {}
@@ -322,8 +333,6 @@ def group_info(name):
 
     cmd = ['pacman', '-Sgg', name]
     out = __salt__['cmd.run'](cmd, output_loglevel='trace', python_shell=False)
-
-    packages = {}
 
     for line in salt.utils.itertools.split(out, '\n'):
         if not line:

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -2186,8 +2186,12 @@ def group_installed(name, skip=None, include=None, **kwargs):
     '''
     .. versionadded:: 2015.8.0
 
+    ..versionchanged:: ?
+        Added support in :mod:`pacman <salt.modules.pacman>`
+
     Ensure that an entire package group is installed. This state is currently
-    only supported for the :mod:`yum <salt.modules.yumpkg>` package manager.
+    only supported for the :mod:`yum <salt.modules.yumpkg>` and :mod:`pacman <salt.modules.pacman>`
+    package managers.
 
     skip
         Packages that would normally be installed by the package group

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -2186,7 +2186,7 @@ def group_installed(name, skip=None, include=None, **kwargs):
     '''
     .. versionadded:: 2015.8.0
 
-    ..versionchanged:: ?
+    .. versionchanged:: Carbon
         Added support in :mod:`pacman <salt.modules.pacman>`
 
     Ensure that an entire package group is installed. This state is currently

--- a/tests/unit/modules/pacman_test.py
+++ b/tests/unit/modules/pacman_test.py
@@ -91,6 +91,23 @@ class PacmanTestCase(TestCase):
                 }):
             self.assertDictEqual(pacman.group_list(), {'available': ['group-c', 'group-f'], 'installed': ['group-b'], 'partially_installed': ['group-a']})
 
+    def test_group_info(self):
+
+        def cmdlist(cmd, **kwargs):
+            if cmd ==  ['pacman', '-Sgg', 'testgroup']:
+                return 'testgroup pkg1\ntestgroup pkg2'
+            else:
+                return 'Untested command!'
+
+        cmdmock = MagicMock(side_effect = cmdlist)
+
+        sortmock = MagicMock()
+        with patch.dict(pacman.__salt__, {
+                'cmd.run': cmdmock, 
+                'pkg_resource.sort_pkglist': sortmock
+                }):
+            self.assertEqual(pacman.group_info('testgroup')['default'], set(['pkg1','pkg2']))
+
 
 
 

--- a/tests/unit/modules/pacman_test.py
+++ b/tests/unit/modules/pacman_test.py
@@ -44,7 +44,8 @@ class PacmanTestCase(TestCase):
         with patch.dict(pacman.__salt__, {
                 'cmd.run': cmdmock, 
                 'pkg_resource.add_pkg': lambda pkgs, name, version: pkgs.setdefault(name, []).append(version), 
-                'pkg_resource.sort_pkglist': sortmock, 'pkg_resource.stringify': stringifymock
+                'pkg_resource.sort_pkglist': sortmock, 
+                'pkg_resource.stringify': stringifymock
                 }):
             self.assertDictEqual(pacman.list_pkgs(), {'A': ['1.0'], 'B': ['2.0']})
 
@@ -62,13 +63,34 @@ class PacmanTestCase(TestCase):
         with patch.dict(pacman.__salt__, {
                 'cmd.run': cmdmock, 
                 'pkg_resource.add_pkg': lambda pkgs, name, version: pkgs.setdefault(name, []).append(version), 
-                'pkg_resource.sort_pkglist': sortmock, 'pkg_resource.stringify': stringifymock
+                'pkg_resource.sort_pkglist': sortmock, 
+                'pkg_resource.stringify': stringifymock
                 }):
             self.assertDictEqual(pacman.list_pkgs(True), {'A': ['1.0'], 'B': ['2.0']})
 
         sortmock.assert_called_once()
         stringifymock.assert_not_called()
         
+
+    def test_group_list(self):
+
+        def cmdlist(cmd, **kwargs):
+            if cmd ==  ['pacman', '-Sgg']:
+                return 'group-a pkg1\ngroup-a pkg2\ngroup-f pkg9\ngroup-c pkg3\ngroup-b pkg4'
+            elif cmd ==  ['pacman', '-Qg']:
+                return 'group-a pkg1\ngroup-b pkg4'
+            else:
+                return 'Untested command!'
+
+        cmdmock = MagicMock(side_effect = cmdlist)
+
+        sortmock = MagicMock()
+        with patch.dict(pacman.__salt__, {
+                'cmd.run': cmdmock, 
+                'pkg_resource.sort_pkglist': sortmock
+                }):
+            self.assertDictEqual(pacman.group_list(), {'available': ['group-c', 'group-f'], 'installed': ['group-b'], 'partially_installed': ['group-a']})
+
 
 
 

--- a/tests/unit/modules/pacman_test.py
+++ b/tests/unit/modules/pacman_test.py
@@ -109,6 +109,16 @@ class PacmanTestCase(TestCase):
             self.assertEqual(pacman.group_info('testgroup')['default'], set(['pkg1','pkg2']))
 
 
+    def test_group_diff(self):
+
+        listmock = MagicMock(return_value={'A': ['1.0'], 'B': ['2.0']})
+        groupmock = MagicMock(return_value={'mandatory': set(), 'optional':set(), 'default': set(['A', 'C']), 'conditional': set()})
+        with patch.dict(pacman.__salt__, {
+                'pkg.list_pkgs': listmock, 
+                'pkg.group_info': groupmock
+                }):
+            results = pacman.group_diff('testgroup')
+            self.assertEqual(results['default'], {'installed': ['A'], 'not installed': ['C']})
 
 
 if __name__ == '__main__':

--- a/tests/unit/modules/pacman_test.py
+++ b/tests/unit/modules/pacman_test.py
@@ -106,13 +106,13 @@ class PacmanTestCase(TestCase):
                 'cmd.run': cmdmock, 
                 'pkg_resource.sort_pkglist': sortmock
                 }):
-            self.assertEqual(pacman.group_info('testgroup')['default'], set(['pkg1','pkg2']))
+            self.assertEqual(pacman.group_info('testgroup')['default'], ['pkg1','pkg2'])
 
 
     def test_group_diff(self):
 
         listmock = MagicMock(return_value={'A': ['1.0'], 'B': ['2.0']})
-        groupmock = MagicMock(return_value={'mandatory': set(), 'optional':set(), 'default': set(['A', 'C']), 'conditional': set()})
+        groupmock = MagicMock(return_value={'mandatory': [], 'optional':[], 'default': ['A', 'C'], 'conditional': []})
         with patch.dict(pacman.__salt__, {
                 'pkg.list_pkgs': listmock, 
                 'pkg.group_info': groupmock

--- a/tests/unit/modules/pacman_test.py
+++ b/tests/unit/modules/pacman_test.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Eric Vz <eric@base10.org>`
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+
+# Import Salt Testing Libs
+from salttesting import TestCase, skipIf
+from salttesting.mock import (
+    MagicMock,
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+# Import Salt Libs
+from salt.modules import pacman
+from salt.exceptions import CommandExecutionError
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class PacmanTestCase(TestCase):
+    '''
+    Test cases for salt.modules.pacman
+    '''
+
+    def setUp(self):
+        pacman.__salt__ = {}
+        pacman.__context__ = {}
+
+
+    def test_list_pkgs(self):
+        '''
+        Test if it list the packages currently installed in a dict
+        '''
+        cmdmock = MagicMock(return_value='A 1.0\nB 2.0')
+        sortmock = MagicMock()
+        stringifymock = MagicMock()
+        with patch.dict(pacman.__salt__, {'cmd.run': cmdmock, 'pkg_resource.add_pkg': self._add_pkg, 'pkg_resource.sort_pkglist': sortmock, 'pkg_resource.stringify': stringifymock}):
+            self.assertDictEqual(pacman.list_pkgs(), {'A': ['1.0'], 'B': ['2.0']})
+        sortmock.assert_called_once()
+        stringifymock.assert_called_once()
+
+
+    def test_list_pkgs_as_list(self):
+        '''
+        Test if it list the packages currently installed in a dict
+        '''
+        cmdmock = MagicMock(return_value='A 1.0\nB 2.0')
+        sortmock = MagicMock()
+        stringifymock = MagicMock()
+        with patch.dict(pacman.__salt__, {'cmd.run': cmdmock, 'pkg_resource.add_pkg': self._add_pkg, 'pkg_resource.sort_pkglist': sortmock, 'pkg_resource.stringify': stringifymock}):
+            self.assertDictEqual(pacman.list_pkgs(True), {'A': ['1.0'], 'B': ['2.0']})
+        sortmock.assert_called_once()
+        stringifymock.assert_not_called()
+        
+
+
+    ''' 
+    Helper methods for test cases
+    '''
+    def _add_pkg(self, pkgs, name, version):
+        pkgs.setdefault(name, []).append(version)
+
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(PacmanTestCase, needs_daemon=False)

--- a/tests/unit/modules/pacman_test.py
+++ b/tests/unit/modules/pacman_test.py
@@ -126,7 +126,7 @@ class PacmanTestCase(TestCase):
         groupmock = MagicMock(return_value={
                 'mandatory': [],
                 'optional': [],
-                'default': ['A', 'C'], 
+                'default': ['A', 'C'],
                 'conditional': []})
         with patch.dict(pacman.__salt__, {
                 'pkg.list_pkgs': listmock,

--- a/tests/unit/modules/pacman_test.py
+++ b/tests/unit/modules/pacman_test.py
@@ -74,7 +74,7 @@ class PacmanTestCase(TestCase):
         Test if it lists the available groups
         '''
 
-        def cmdlist(cmd):
+        def cmdlist(cmd, **kwargs):
             '''
             Handle several different commands being run
             '''
@@ -83,7 +83,7 @@ class PacmanTestCase(TestCase):
             elif cmd == ['pacman', '-Qg']:
                 return 'group-a pkg1\ngroup-b pkg4'
             else:
-                return 'Untested command!'
+                return 'Untested command ({0}, {1})!'.format(cmd, kwargs)
 
         cmdmock = MagicMock(side_effect=cmdlist)
 
@@ -99,14 +99,14 @@ class PacmanTestCase(TestCase):
         Test if it shows the packages in a group
         '''
 
-        def cmdlist(cmd):
+        def cmdlist(cmd, **kwargs):
             '''
             Handle several different commands being run
             '''
             if cmd == ['pacman', '-Sgg', 'testgroup']:
                 return 'testgroup pkg1\ntestgroup pkg2'
             else:
-                return 'Untested command!'
+                return 'Untested command ({0}, {1})!'.format(cmd, kwargs)
 
         cmdmock = MagicMock(side_effect=cmdlist)
 

--- a/tests/unit/modules/pacman_test.py
+++ b/tests/unit/modules/pacman_test.py
@@ -41,8 +41,12 @@ class PacmanTestCase(TestCase):
         cmdmock = MagicMock(return_value='A 1.0\nB 2.0')
         sortmock = MagicMock()
         stringifymock = MagicMock()
-        with patch.dict(pacman.__salt__, {'cmd.run': cmdmock, 'pkg_resource.add_pkg': self._add_pkg, 'pkg_resource.sort_pkglist': sortmock, 'pkg_resource.stringify': stringifymock}):
+        with patch.dict(pacman.__salt__, {'cmd.run': cmdmock, 
+                'pkg_resource.add_pkg': lambda pkgs, name, version: pkgs.setdefault(name, []).append(version), 
+                'pkg_resource.sort_pkglist': sortmock, 'pkg_resource.stringify': stringifymock
+                }):
             self.assertDictEqual(pacman.list_pkgs(), {'A': ['1.0'], 'B': ['2.0']})
+            
         sortmock.assert_called_once()
         stringifymock.assert_called_once()
 
@@ -54,18 +58,15 @@ class PacmanTestCase(TestCase):
         cmdmock = MagicMock(return_value='A 1.0\nB 2.0')
         sortmock = MagicMock()
         stringifymock = MagicMock()
-        with patch.dict(pacman.__salt__, {'cmd.run': cmdmock, 'pkg_resource.add_pkg': self._add_pkg, 'pkg_resource.sort_pkglist': sortmock, 'pkg_resource.stringify': stringifymock}):
+        with patch.dict(pacman.__salt__, {'cmd.run': cmdmock, 
+                'pkg_resource.add_pkg': lambda pkgs, name, version: pkgs.setdefault(name, []).append(version), 
+                'pkg_resource.sort_pkglist': sortmock, 'pkg_resource.stringify': stringifymock
+                }):
             self.assertDictEqual(pacman.list_pkgs(True), {'A': ['1.0'], 'B': ['2.0']})
+
         sortmock.assert_called_once()
         stringifymock.assert_not_called()
         
-
-
-    ''' 
-    Helper methods for test cases
-    '''
-    def _add_pkg(self, pkgs, name, version):
-        pkgs.setdefault(name, []).append(version)
 
 
 

--- a/tests/unit/modules/pacman_test.py
+++ b/tests/unit/modules/pacman_test.py
@@ -41,11 +41,11 @@ class PacmanTestCase(TestCase):
         sortmock = MagicMock()
         stringifymock = MagicMock()
         with patch.dict(pacman.__salt__, {
-            'cmd.run': cmdmock,
-            'pkg_resource.add_pkg': lambda pkgs, name, version: pkgs.setdefault(name, []).append(version),
-            'pkg_resource.sort_pkglist': sortmock,
-            'pkg_resource.stringify': stringifymock
-            }):
+                'cmd.run': cmdmock,
+                'pkg_resource.add_pkg': lambda pkgs, name, version: pkgs.setdefault(name, []).append(version),
+                'pkg_resource.sort_pkglist': sortmock,
+                'pkg_resource.stringify': stringifymock
+                }):
             self.assertDictEqual(pacman.list_pkgs(), {'A': ['1.0'], 'B': ['2.0']})
 
         sortmock.assert_called_once()
@@ -59,11 +59,11 @@ class PacmanTestCase(TestCase):
         sortmock = MagicMock()
         stringifymock = MagicMock()
         with patch.dict(pacman.__salt__, {
-            'cmd.run': cmdmock,
-            'pkg_resource.add_pkg': lambda pkgs, name, version: pkgs.setdefault(name, []).append(version),
-            'pkg_resource.sort_pkglist': sortmock,
-            'pkg_resource.stringify': stringifymock
-            }):
+                'cmd.run': cmdmock,
+                'pkg_resource.add_pkg': lambda pkgs, name, version: pkgs.setdefault(name, []).append(version),
+                'pkg_resource.sort_pkglist': sortmock,
+                'pkg_resource.stringify': stringifymock
+                }):
             self.assertDictEqual(pacman.list_pkgs(True), {'A': ['1.0'], 'B': ['2.0']})
 
         sortmock.assert_called_once()
@@ -74,7 +74,10 @@ class PacmanTestCase(TestCase):
         Test if it lists the available groups
         '''
 
-        def cmdlist(cmd, **kwargs):
+        def cmdlist(cmd):
+            '''
+            Handle several different commands being run
+            '''
             if cmd == ['pacman', '-Sgg']:
                 return 'group-a pkg1\ngroup-a pkg2\ngroup-f pkg9\ngroup-c pkg3\ngroup-b pkg4'
             elif cmd == ['pacman', '-Qg']:
@@ -96,7 +99,10 @@ class PacmanTestCase(TestCase):
         Test if it shows the packages in a group
         '''
 
-        def cmdlist(cmd, **kwargs):
+        def cmdlist(cmd):
+            '''
+            Handle several different commands being run
+            '''
             if cmd == ['pacman', '-Sgg', 'testgroup']:
                 return 'testgroup pkg1\ntestgroup pkg2'
             else:
@@ -117,7 +123,11 @@ class PacmanTestCase(TestCase):
         '''
 
         listmock = MagicMock(return_value={'A': ['1.0'], 'B': ['2.0']})
-        groupmock = MagicMock(return_value={'mandatory': [], 'optional':[], 'default': ['A', 'C'], 'conditional': []})
+        groupmock = MagicMock(return_value={
+                'mandatory': [],
+                'optional': [],
+                'default': ['A', 'C'], 
+                'conditional': []})
         with patch.dict(pacman.__salt__, {
                 'pkg.list_pkgs': listmock,
                 'pkg.group_info': groupmock

--- a/tests/unit/modules/pacman_test.py
+++ b/tests/unit/modules/pacman_test.py
@@ -41,12 +41,13 @@ class PacmanTestCase(TestCase):
         cmdmock = MagicMock(return_value='A 1.0\nB 2.0')
         sortmock = MagicMock()
         stringifymock = MagicMock()
-        with patch.dict(pacman.__salt__, {'cmd.run': cmdmock, 
+        with patch.dict(pacman.__salt__, {
+                'cmd.run': cmdmock, 
                 'pkg_resource.add_pkg': lambda pkgs, name, version: pkgs.setdefault(name, []).append(version), 
                 'pkg_resource.sort_pkglist': sortmock, 'pkg_resource.stringify': stringifymock
                 }):
             self.assertDictEqual(pacman.list_pkgs(), {'A': ['1.0'], 'B': ['2.0']})
-            
+
         sortmock.assert_called_once()
         stringifymock.assert_called_once()
 
@@ -58,7 +59,8 @@ class PacmanTestCase(TestCase):
         cmdmock = MagicMock(return_value='A 1.0\nB 2.0')
         sortmock = MagicMock()
         stringifymock = MagicMock()
-        with patch.dict(pacman.__salt__, {'cmd.run': cmdmock, 
+        with patch.dict(pacman.__salt__, {
+                'cmd.run': cmdmock, 
                 'pkg_resource.add_pkg': lambda pkgs, name, version: pkgs.setdefault(name, []).append(version), 
                 'pkg_resource.sort_pkglist': sortmock, 'pkg_resource.stringify': stringifymock
                 }):


### PR DESCRIPTION
### What does this PR do?

Adds support for pkg.group_list, pkg.group_info, and pkg.group_diff to modules.pacman.  Includes unit tests.
### What issues does this PR fix or reference?

Issue #15749
### Previous Behavior

Groups (when configured for pkg.installed) would always reinstall, no matter the current state, when running state.pkg.installed.
### New Behavior

Introduces a new toolset, similar to yumpkg, allowing Arch users to use pkg.group_list, pkg.group_info, and pkg.group_diff, and states.pkg.group_installed.
### Tests written?

Yes
