### PR TITLE
Fix 'virt' state names in cloud controller tutorial

### DIFF
--- a/doc/topics/tutorials/cloud_controller.rst
+++ b/doc/topics/tutorials/cloud_controller.rst
@@ -59,7 +59,7 @@ to set up the libvirt pki keys.
         - contents: 'LIBVIRTD_ARGS="--listen"'
         - require:
           - pkg: libvirt
-      libvirt.keys:
+      virt.keys:
         - require:
           - pkg: libvirt
       service.running:
@@ -139,7 +139,7 @@ date:
 .. code-block:: yaml
 
     libvirt_keys:
-      libvirt.keys
+      virt.keys
 
 Getting Virtual Machine Images Ready
 ====================================


### PR DESCRIPTION
### What does this PR do?

It fixes erroneous references to "libvirt" states that have been renamed to "virt" in 2016.3 or, specifically, in 34972124727c62095b7a623936ed9861eff4f849
