### PR TITLE
exportdb command for udev module and tests

### DIFF
--- a/tests/unit/modules/udev_test.py
+++ b/tests/unit/modules/udev_test.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Pablo Suárez Hdez. <psuarezhernandez@suse.de>`
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+
+# Import Salt Testing Libs
+from salttesting import TestCase, skipIf
+from salttesting.mock import (
+    MagicMock,
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+# Import Salt Libs
+from salt.modules import udev
+
+# Globals
+udev.__salt__ = {}
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class UdevTestCase(TestCase):
+    '''
+    Test cases for salt.modules.udev
+    '''
+    # 'info' function tests: 1
+
+    def test_info(self):
+        '''
+        Test if it returns the info of udev-created node in a dict
+        '''
+        cmd_out = {
+            'retcode': 0,
+            'stdout': "P: /devices/virtual/vc/vcsa7\n" \
+                      "N: vcsa7\n" \
+                      "E: DEVNAME=/dev/vcsa7\n" \
+                      "E: DEVPATH=/devices/virtual/vc/vcsa7\n" \
+                      "E: MAJOR=7\n" \
+                      "E: MINOR=135\n" \
+                      "E: SUBSYSTEM=vc\n" \
+                      "\n",
+            'stderr': ''
+        }
+
+        ret = {
+            "E": {"DEVNAME": "/dev/vcsa7",
+                  "DEVPATH": "/devices/virtual/vc/vcsa7",
+                  "MAJOR": 7,
+                  "MINOR": 135,
+                  "SUBSYSTEM": "vc"},
+            "N": "vcsa7",
+            "P": "/devices/virtual/vc/vcsa7"}
+
+        mock = MagicMock(return_value=cmd_out)
+        with patch.dict(udev.__salt__, {'cmd.run_all': mock}):
+            self.assertDictEqual(udev.info("/dev/vcsa7"), ret)
+
+
+    # 'exportdb' function tests: 1
+
+    def test_exportdb(self):
+        '''
+        Test if it returns the all the udev database into a dict
+        '''
+        cmd_out = {
+            'retcode': 0,
+            'stdout': "P: /devices/virtual/vc/vcsa7\n" \
+                      "N: vcsa7\n" \
+                      "E: DEVNAME=/dev/vcsa7\n" \
+                      "E: DEVPATH=/devices/virtual/vc/vcsa7\n" \
+                      "E: MAJOR=7\n" \
+                      "E: MINOR=135\n" \
+                      "E: SUBSYSTEM=vc\n" \
+                      "\n" \
+                      "P: /devices/virtual/workqueue/writeback\n" \
+                      "E: DEVPATH=/devices/virtual/workqueue/writeback\n" \
+                      "E: SUBSYSTEM=workqueue\n" \
+                      "\n",
+            'stderr': ''
+        }
+
+        ret = [
+            {"E": {"DEVNAME": "/dev/vcsa7",
+                   "DEVPATH": "/devices/virtual/vc/vcsa7",
+                   "MAJOR": 7,
+                   "MINOR": 135,
+                   "SUBSYSTEM": "vc"},
+             "N": "vcsa7",
+             "P": "/devices/virtual/vc/vcsa7"},
+            {"E": {"DEVPATH": "/devices/virtual/workqueue/writeback",
+                   "SUBSYSTEM": "workqueue"},
+             "P": "/devices/virtual/workqueue/writeback"}
+        ]
+
+        mock = MagicMock(return_value=cmd_out)
+        with patch.dict(udev.__salt__, {'cmd.run_all': mock}):
+            self.assertListEqual(udev.exportdb(), ret)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(UdevTestCase, needs_daemon=False)


### PR DESCRIPTION
### What does this PR do?

This PR adds the new method `exportdb` to the `udev` module of Salt.

Currently Salt allow us to know the information for a `udev` node but we cannot get the entire `udev` database.

This method executes `udevadm info --export-db` in the minion and returns a list with the information of each node.

```
# salt '*' udev.exportdb
minionsles12-suma3pg.vagrant.local:
    |_
      ----------
      E:
          ----------
          DEVPATH:
              /devices/LNXSYSTM:00
          MODALIAS:
              acpi:LNXSYSTM:
          SUBSYSTEM:
              acpi
      P:
          /devices/LNXSYSTM:00
    |_
      ----------
      E:
          ----------
          DEVPATH:
              /devices/LNXSYSTM:00/LNXPWRBN:00
          DRIVER:
              button
          MODALIAS:
              acpi:LNXPWRBN:
          SUBSYSTEM:
              acpi
      P:
          /devices/LNXSYSTM:00/LNXPWRBN:00

[...]
```

Additionally, this PR does some refactoring and creates the method `_parse_udevadm_info` and `_normalize_info` which are used to parse the `udevadm` command response for both `udev.info` and the new `udev.exportdb`.
### Tests written?

Yes

/cc @isbm @mateiw
