### PR TITLE
exportdb command for udev module and tests

### DIFF
--- a/tests/unit/modules/udev_test.py
+++ b/tests/unit/modules/udev_test.py
@@ -61,7 +61,12 @@ class UdevTestCase(TestCase):
 
         mock = MagicMock(return_value=cmd_out)
         with patch.dict(udev.__salt__, {'cmd.run_all': mock}):
-            self.assertDictEqual(udev.info("/dev/vcsa7"), ret)
+            data = udev.info("/dev/vcsa7")
+
+            assert ret['P'] == data['P']
+            assert ret.get('N') == data.get('N')
+            for key, value in data['E'].items():
+                assert ret['E'][key] == value
 
 
     # 'exportdb' function tests: 1
@@ -70,39 +75,108 @@ class UdevTestCase(TestCase):
         '''
         Test if it returns the all the udev database into a dict
         '''
-        cmd_out = {
-            'retcode': 0,
-            'stdout': "P: /devices/virtual/vc/vcsa7\n" \
-                      "N: vcsa7\n" \
-                      "E: DEVNAME=/dev/vcsa7\n" \
-                      "E: DEVPATH=/devices/virtual/vc/vcsa7\n" \
-                      "E: MAJOR=7\n" \
-                      "E: MINOR=135\n" \
-                      "E: SUBSYSTEM=vc\n" \
-                      "\n" \
-                      "P: /devices/virtual/workqueue/writeback\n" \
-                      "E: DEVPATH=/devices/virtual/workqueue/writeback\n" \
-                      "E: SUBSYSTEM=workqueue\n" \
-                      "\n",
-            'stderr': ''
-        }
+        udev_data = """
+P: /devices/LNXSYSTM:00/LNXPWRBN:00
+E: DEVPATH=/devices/LNXSYSTM:00/LNXPWRBN:00
+E: DRIVER=button
+E: MODALIAS=acpi:LNXPWRBN:
+E: SUBSYSTEM=acpi
 
-        ret = [
-            {"E": {"DEVNAME": "/dev/vcsa7",
-                   "DEVPATH": "/devices/virtual/vc/vcsa7",
-                   "MAJOR": 7,
-                   "MINOR": 135,
-                   "SUBSYSTEM": "vc"},
-             "N": "vcsa7",
-             "P": "/devices/virtual/vc/vcsa7"},
-            {"E": {"DEVPATH": "/devices/virtual/workqueue/writeback",
-                   "SUBSYSTEM": "workqueue"},
-             "P": "/devices/virtual/workqueue/writeback"}
-        ]
+P: /devices/LNXSYSTM:00/LNXPWRBN:00/input/input2
+E: DEVPATH=/devices/LNXSYSTM:00/LNXPWRBN:00/input/input2
+E: EV=3
+E: ID_FOR_SEAT=input-acpi-LNXPWRBN_00
+E: ID_INPUT=1
+E: ID_INPUT_KEY=1
+E: ID_PATH=acpi-LNXPWRBN:00
+E: ID_PATH_TAG=acpi-LNXPWRBN_00
+E: KEY=10000000000000 0
+E: MODALIAS=input:b0019v0000p0001e0000-e0,1,k74,ramlsfw
+E: NAME="Power Button"
+E: PHYS="LNXPWRBN/button/input0"
+E: PRODUCT=19/0/1/0
+E: PROP=0
+E: SUBSYSTEM=input
+E: TAGS=:seat:
+E: USEC_INITIALIZED=2010022
 
-        mock = MagicMock(return_value=cmd_out)
+P: /devices/LNXSYSTM:00/LNXPWRBN:00/input/input2/event2
+N: input/event2
+E: BACKSPACE=guess
+E: DEVNAME=/dev/input/event2
+E: DEVPATH=/devices/LNXSYSTM:00/LNXPWRBN:00/input/input2/event2
+E: ID_INPUT=1
+E: ID_INPUT_KEY=1
+E: ID_PATH=acpi-LNXPWRBN:00
+E: ID_PATH_TAG=acpi-LNXPWRBN_00
+E: MAJOR=13
+E: MINOR=66
+E: SUBSYSTEM=input
+E: TAGS=:power-switch:
+E: USEC_INITIALIZED=2076101
+E: XKBLAYOUT=us
+E: XKBMODEL=pc105
+    """
+
+        out = [{'P': '/devices/LNXSYSTM:00/LNXPWRBN:00',
+                'E': {'MODALIAS': 'acpi:LNXPWRBN:',
+                      'SUBSYSTEM': 'acpi',
+                      'DRIVER': 'button',
+                      'DEVPATH': '/devices/LNXSYSTM:00/LNXPWRBN:00'}},
+               {'P': '/devices/LNXSYSTM:00/LNXPWRBN:00/input/input2',
+                'E': {'SUBSYSTEM': 'input',
+                      'PRODUCT': '19/0/1/0',
+                      'PHYS': '"LNXPWRBN/button/input0"',
+                      'NAME': '"Power Button"',
+                      'ID_INPUT': 1,
+                      'DEVPATH': '/devices/LNXSYSTM:00/LNXPWRBN:00/input/input2',
+                      'MODALIAS': 'input:b0019v0000p0001e0000-e0,1,k74,ramlsfw',
+                      'ID_PATH_TAG': 'acpi-LNXPWRBN_00',
+                      'TAGS': ':seat:',
+                      'PROP': 0,
+                      'ID_FOR_SEAT': 'input-acpi-LNXPWRBN_00',
+                      'KEY': '10000000000000 0',
+                      'USEC_INITIALIZED': 2010022,
+                      'ID_PATH': 'acpi-LNXPWRBN:00',
+                      'EV': 3,
+                      'ID_INPUT_KEY': 1}},
+               {'P': '/devices/LNXSYSTM:00/LNXPWRBN:00/input/input2/event2',
+                'E': {'SUBSYSTEM': 'input',
+                      'XKBLAYOUT': 'us',
+                      'MAJOR': 13,
+                      'ID_INPUT': 1,
+                      'DEVPATH': '/devices/LNXSYSTM:00/LNXPWRBN:00/input/input2/event2',
+                      'ID_PATH_TAG': 'acpi-LNXPWRBN_00',
+                      'DEVNAME': '/dev/input/event2',
+                      'TAGS': ':power-switch:',
+                      'BACKSPACE': 'guess',
+                      'MINOR': 66,
+                      'USEC_INITIALIZED': 2076101,
+                      'ID_PATH': 'acpi-LNXPWRBN:00',
+                      'XKBMODEL': 'pc105',
+                      'ID_INPUT_KEY': 1},
+                'N': 'input/event2'}]
+
+        mock = MagicMock(return_value={'retcode': 0, 'stdout': udev_data})
         with patch.dict(udev.__salt__, {'cmd.run_all': mock}):
-            self.assertListEqual(udev.exportdb(), ret)
+            data = udev.exportdb()
+            assert data == filter(None, data)
+
+            for d_idx, d_section in enumerate(data):
+                assert out[d_idx]['P'] == d_section['P']
+                assert out[d_idx].get('N') == d_section.get('N')
+                for key, value in d_section['E'].items():
+                    assert out[d_idx]['E'][key] == value
+
+
+    def test_normalize_info(self):
+        '''
+        Test if udevdb._normalize_info does not returns nested lists that contains only one item.
+
+        :return:
+        '''
+        data = {'key': ['value', 'here'], 'foo': ['bar'], 'some': 'data'}
+        assert udev._normalize_info(data) == {'foo': 'bar', 'some': 'data', 'key': ['value', 'here']}
 
 
 if __name__ == '__main__':

--- a/tests/unit/modules/udev_test.py
+++ b/tests/unit/modules/udev_test.py
@@ -159,7 +159,7 @@ E: XKBMODEL=pc105
         mock = MagicMock(return_value={'retcode': 0, 'stdout': udev_data})
         with patch.dict(udev.__salt__, {'cmd.run_all': mock}):
             data = udev.exportdb()
-            assert data == filter(None, data)
+            assert data == [x for x in data if x]
 
             for d_idx, d_section in enumerate(data):
                 assert out[d_idx]['P'] == d_section['P']

--- a/tests/unit/modules/udev_test.py
+++ b/tests/unit/modules/udev_test.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Pablo Suárez Hdez. <psuarezhernandez@suse.de>`
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+
+# Import Salt Testing Libs
+from salttesting import TestCase, skipIf
+from salttesting.mock import (
+    MagicMock,
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+# Import Salt Libs
+from salt.modules import udev
+
+# Globals
+udev.__salt__ = {}
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class UdevTestCase(TestCase):
+    '''
+    Test cases for salt.modules.udev
+    '''
+    # 'info' function tests: 1
+
+    def test_info(self):
+        '''
+        Test if it returns the info of udev-created node in a dict
+        '''
+        cmd_out = {
+            'retcode': 0,
+            'stdout': "P: /devices/virtual/vc/vcsa7\n" \
+                      "N: vcsa7\n" \
+                      "E: DEVNAME=/dev/vcsa7\n" \
+                      "E: DEVPATH=/devices/virtual/vc/vcsa7\n" \
+                      "E: MAJOR=7\n" \
+                      "E: MINOR=135\n" \
+                      "E: SUBSYSTEM=vc\n" \
+                      "\n",
+            'stderr': ''
+        }
+
+        ret = {
+            "E": {"DEVNAME": "/dev/vcsa7",
+                  "DEVPATH": "/devices/virtual/vc/vcsa7",
+                  "MAJOR": 7,
+                  "MINOR": 135,
+                  "SUBSYSTEM": "vc"},
+            "N": "vcsa7",
+            "P": "/devices/virtual/vc/vcsa7"}
+
+        mock = MagicMock(return_value=cmd_out)
+        with patch.dict(udev.__salt__, {'cmd.run_all': mock}):
+            self.assertDictEqual(udev.info("/dev/vcsa7"), ret)
+
+
+    # 'exportdb' function tests: 1
+
+    def test_exportdb(self):
+        '''
+        Test if it returns the all the udev database into a dict
+        '''
+        cmd_out = {
+            'retcode': 0,
+            'stdout': "P: /devices/virtual/vc/vcsa7\n" \
+                      "N: vcsa7\n" \
+                      "E: DEVNAME=/dev/vcsa7\n" \
+                      "E: DEVPATH=/devices/virtual/vc/vcsa7\n" \
+                      "E: MAJOR=7\n" \
+                      "E: MINOR=135\n" \
+                      "E: SUBSYSTEM=vc\n" \
+                      "\n" \
+                      "P: /devices/virtual/workqueue/writeback\n" \
+                      "E: DEVPATH=/devices/virtual/workqueue/writeback\n" \
+                      "E: SUBSYSTEM=workqueue\n" \
+                      "\n",
+            'stderr': ''
+        }
+
+        ret = [
+            {"E": {"DEVNAME": "/dev/vcsa7",
+                   "DEVPATH": "/devices/virtual/vc/vcsa7",
+                   "MAJOR": 7,
+                   "MINOR": 135,
+                   "SUBSYSTEM": "vc"},
+             "N": "vcsa7",
+             "P": "/devices/virtual/vc/vcsa7"},
+            {"E": {"DEVPATH": "/devices/virtual/workqueue/writeback",
+                   "SUBSYSTEM": "workqueue"},
+             "P": "/devices/virtual/workqueue/writeback"}
+        ]
+
+        mock = MagicMock(return_value=cmd_out)
+        with patch.dict(udev.__salt__, {'cmd.run_all': mock}):
+            self.assertListEqual(udev.exportdb(), ret)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(UdevTestCase, needs_daemon=False)

--- a/tests/unit/modules/udev_test.py
+++ b/tests/unit/modules/udev_test.py
@@ -39,13 +39,13 @@ class UdevTestCase(TestCase):
         '''
         cmd_out = {
             'retcode': 0,
-            'stdout': "P: /devices/virtual/vc/vcsa7\n" \
-                      "N: vcsa7\n" \
-                      "E: DEVNAME=/dev/vcsa7\n" \
-                      "E: DEVPATH=/devices/virtual/vc/vcsa7\n" \
-                      "E: MAJOR=7\n" \
-                      "E: MINOR=135\n" \
-                      "E: SUBSYSTEM=vc\n" \
+            'stdout': "P: /devices/virtual/vc/vcsa7\n"
+                      "N: vcsa7\n"
+                      "E: DEVNAME=/dev/vcsa7\n"
+                      "E: DEVPATH=/devices/virtual/vc/vcsa7\n"
+                      "E: MAJOR=7\n"
+                      "E: MINOR=135\n"
+                      "E: SUBSYSTEM=vc\n"
                       "\n",
             'stderr': ''
         }
@@ -67,7 +67,6 @@ class UdevTestCase(TestCase):
             assert ret.get('N') == data.get('N')
             for key, value in data['E'].items():
                 assert ret['E'][key] == value
-
 
     # 'exportdb' function tests: 1
 
@@ -167,7 +166,6 @@ E: XKBMODEL=pc105
                 assert out[d_idx].get('N') == d_section.get('N')
                 for key, value in d_section['E'].items():
                     assert out[d_idx]['E'][key] == value
-
 
     def test_normalize_info(self):
         '''


### PR DESCRIPTION
### What does this PR do?

This PR adds the new method `exportdb` to the `udev` module of Salt.

Currently Salt allow us to know the information for a `udev` node but we cannot get the entire `udev` database.

This method executes `udevadm info --export-db` in the minion and returns a list with the information of each node.

```
# salt '*' udev.exportdb
minionsles12-suma3pg.vagrant.local:
    |_
      ----------
      E:
          ----------
          DEVPATH:
              /devices/LNXSYSTM:00
          MODALIAS:
              acpi:LNXSYSTM:
          SUBSYSTEM:
              acpi
      P:
          /devices/LNXSYSTM:00
    |_
      ----------
      E:
          ----------
          DEVPATH:
              /devices/LNXSYSTM:00/LNXPWRBN:00
          DRIVER:
              button
          MODALIAS:
              acpi:LNXPWRBN:
          SUBSYSTEM:
              acpi
      P:
          /devices/LNXSYSTM:00/LNXPWRBN:00

[...]
```

Additionally, this PR does some refactoring and creates the method `_parse_udevadm_info` and `_normalize_info` which are used to parse the `udevadm` command response for both `udev.info` and the new `udev.exportdb`.
### Tests written?

Yes

Thanks @isbm for the refactor ;)

/cc @mateiw
