### PR TITLE
check rabbitmq version and use different api to validate a users pass…

### DIFF
--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -308,8 +308,10 @@ def check_password(name, password, runas=None):
     '''
     # try to get the rabbitmq-version - adapted from _get_rabbitmq_plugin
     try:
-        version = map(int, __salt__['pkg.version']('rabbitmq-server').split('-')[0].split('.'))
-    except:
+        version = [int(i) for i in __salt__['pkg.version']('rabbitmq-server').split('-')[0].split('.')]
+    except ValueError:
+        version = (0, 0, 0)
+    if len(version) < 3:
         version = (0, 0, 0)
 
     if runas is None:

--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -306,8 +306,24 @@ def check_password(name, password, runas=None):
 
         salt '*' rabbitmq.check_password rabbit_user password
     '''
+    # try to get the rabbitmq-version - adapted from _get_rabbitmq_plugin
+    try:
+        version = map(int, __salt__['pkg.version']('rabbitmq-server').split('-')[0].split('.'))
+    except:
+        version = (0, 0, 0)
+
     if runas is None:
         runas = salt.utils.get_user()
+
+    # rabbitmq introduced a native api to check a username and password in version 3.5.7.
+    if version[0] >= 3 and version[1] >= 5 and version[2] >= 7:
+        res = __salt__['cmd.run'](
+            ['rabbitmqctl', 'authenticate_user', name, password],
+            runas=runas,
+            output_loglevel='quiet',
+            python_shell=False)
+        msg = 'password-check'
+        return _format_response(res, msg)
 
     cmd = ('rabbit_auth_backend_internal:check_user_login'
         '(<<"{0}">>, [{{password, <<"{1}">>}}]).').format(


### PR DESCRIPTION
### What does this PR do?

Rabbitmq added in version 3.5.7 a cli command to check users credentials. The command executed by `modules/rabbitmq.py` to check the user credentials seems to an internal api, which was renamed or removed from rabbitmq.

This PR introduces a version check (code adapted from line 58) and use the public API to validate the user credentials if rabbitmq >= 3.5.7. is detected - solving #33588
### What issues does this PR fix or reference?
#33588
### Tests written?

No
