### PR TITLE
Handle trigger the same way as slack engine

### DIFF
--- a/salt/engines/hipchat.py
+++ b/salt/engines/hipchat.py
@@ -51,7 +51,6 @@ def __virtual__():
     return HAS_HYPCHAT
 
 
-COMMAND_NAME = 'salt'
 log = logging.getLogger(__name__)
 
 
@@ -133,9 +132,9 @@ def start(token,
         ''' yield partner message '''
         for message in all_messages:
             message_text = message['message']
-            if message_text.startswith(trigger + COMMAND_NAME + ' '):
+            if message_text.startswith(trigger):
                 fire(tag, message)
-                text = message_text.replace(trigger + COMMAND_NAME + ' ', '').strip()
+                text = message_text.replace(trigger, '').strip()
                 yield message['from']['mention_name'], text
 
     if not token:


### PR DESCRIPTION
### What does this PR do?

Treats the hipchat trigger the same as as the slack engine. 
### Previous Behavior

Assumed user definable trigger followed by "salt". This limited options to something like "!salt" or "/salt". 
### New Behavior

Use the entirety of the configured trigger. By default the trigger is "!" allowing for a command syntax of `!test.ping`. Now you can specify trigger in the config allowing for `!salt test.ping` or `!saltbot test.ping` should that be preferred. 
### Tests written?

No

@garethgreenaway Normalized with slack
