### PR TITLE
Fix more tmp paths on MacOS

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -81,7 +81,7 @@ SYS_TMP_DIR = os.path.realpath(
     # Avoid ${TMPDIR} and gettempdir() on MacOS as they yield a base path too long
     # for unix sockets: ``error: AF_UNIX path too long``
     # Gentoo Portage prefers ebuild tests are rooted in ${TMPDIR}
-    os.environ.get('TMPDIR', tempfile.gettempdir()) if salt.utils.is_darwin() else '/tmp'
+    os.environ.get('TMPDIR', tempfile.gettempdir()) if not salt.utils.is_darwin() else '/tmp'
 )
 TMP = os.path.join(SYS_TMP_DIR, 'salt-tests-tmpdir')
 FILES = os.path.join(INTEGRATION_TEST_DIR, 'files')

--- a/tests/integration/files/file/base/_modules/runtests_helpers.py
+++ b/tests/integration/files/file/base/_modules/runtests_helpers.py
@@ -20,7 +20,7 @@ SYS_TMP_DIR = os.path.realpath(
     # Avoid ${TMPDIR} and gettempdir() on MacOS as they yield a base path too long
     # for unix sockets: ``error: AF_UNIX path too long``
     # Gentoo Portage prefers ebuild tests are rooted in ${TMPDIR}
-    os.environ.get('TMPDIR', tempfile.gettempdir()) if salt.utils.is_darwin() else '/tmp'
+    os.environ.get('TMPDIR', tempfile.gettempdir()) if not salt.utils.is_darwin() else '/tmp'
 )
 # This tempdir path is defined on tests.integration.__init__
 TMP = os.path.join(SYS_TMP_DIR, 'salt-tests-tmpdir')

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -8,12 +8,11 @@ Discover all instances of unittest.TestCase in this directory.
 # Import python libs
 from __future__ import absolute_import, print_function
 import os
-import tempfile
 import time
 
 # Import salt libs
 from integration import TestDaemon, TMP  # pylint: disable=W0403
-from integration import INTEGRATION_TEST_DIR
+from integration import SYS_TMP_DIR, INTEGRATION_TEST_DIR
 from integration import CODE_DIR as SALT_ROOT
 import salt.utils
 
@@ -536,7 +535,7 @@ def main():
         parser = SaltTestsuiteParser(
             TEST_DIR,
             xml_output_dir=XML_OUTPUT_DIR,
-            tests_logfile=os.path.join(tempfile.gettempdir(), 'salt-runtests.log')
+            tests_logfile=os.path.join(SYS_TMP_DIR, 'salt-runtests.log')
         )
         parser.parse_args()
 


### PR DESCRIPTION
### What does this PR do?

Fix three temp paths on MacOS systems.  The mac jenkins runs successfully with this patch: all uses of `tempfile.gettempdir()` and `$TMPDIR` are now bypassed on that platform.
### What issues does this PR fix or reference?
### Tests written?

No
