### PR TITLE
Lower the log level for failed auths

### DIFF
--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -532,7 +532,16 @@ class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.
             payload = self.serial.loads(payload[0])
             payload = self._decode_payload(payload)
         except Exception as exc:
-            log.error('Bad load from minion: %s: %s', type(exc).__name__, exc)
+            exc_type = type(exc).__name__
+            if exc_type == 'AuthenticationError':
+                log.debug(
+                    'Minion failed to auth to master. Since the payload is '
+                    'encrypted, it is not known which minion failed to '
+                    'authenticate. It is likely that this is a transient '
+                    'failure due to the master rotating its public key.'
+                )
+            else:
+                log.error('Bad load from minion: %s: %s', exc_type, exc)
             stream.send(self.serial.dumps('bad load'))
             raise tornado.gen.Return()
 


### PR DESCRIPTION
Since failed auths are most often due to key rotation, they should be
logged as debug messages rather than errors.
