### PR TITLE
use default docker auth file as prior auth system

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -938,10 +938,14 @@ def _image_wrapper(attr, *args, **kwargs):
         try:
             home = os.path.expanduser("~")
             docker_auth_file = os.path.join(home, '.docker', 'config.json')
-            if os.path.isfile(docker_auth_file):
-                with salt.utils.fopen(docker_auth_file) as fp:
+            with salt.utils.fopen(docker_auth_file) as fp:
+                try:
                     docker_auth = json.load(fp)
                     fp.close()
+                except (OSError, IOError) as exc:
+                    if exc.errno != errno.ENOENT:
+                        log.error('Failed to read docker auth file %s: %s', docker_auth_file, exc)
+                        docker_auth = {}
                 if isinstance(docker_auth, dict):
                     if 'auths' in docker_auth and isinstance(docker_auth['auths'], dict):
                         for key, data in six.iteritems(docker_auth['auths']):

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -262,6 +262,7 @@ import string
 import sys
 import time
 import base64
+import errno
 
 # Import Salt libs
 from salt.exceptions import CommandExecutionError, SaltInvocationError

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -44,9 +44,14 @@ Docker_. docker-py can easily be installed using :py:func:`pip.install
 Authentication
 --------------
 
-To push or pull images, credentials must be configured. Because a password must
-be used, it is recommended to place this configuration in :ref:`Pillar
-<pillar>` data. The configuration schema is as follows:
+To push or pull images, credentials must be configured. By default dockerng will
+try to get the credentials from the default docker auth file, located under the
+home directory of the user running the salt-minion (HOME/.docker/config.json).
+Because a password must be used, it is recommended to place this configuration
+in :ref:`Pillar <pillar>` data. If pillar data specifies a registry already
+present in the default docker auth file, it will override.
+
+The configuration schema is as follows:
 
 .. code-block:: yaml
 
@@ -256,6 +261,7 @@ import shutil
 import string
 import sys
 import time
+import base64
 
 # Import Salt libs
 from salt.exceptions import CommandExecutionError, SaltInvocationError
@@ -926,8 +932,34 @@ def _image_wrapper(attr, *args, **kwargs):
     catch_api_errors = kwargs.pop('catch_api_errors', True)
 
     if kwargs.pop('client_auth', False):
-        # Set credentials
-        registry_auth_config = __pillar__.get('docker-registries', {})
+        # Get credential from the home directory of the user running
+        # salt-minion, default auth file for docker (~/.docker/config.json)
+        registry_auth_config = {}
+        try:
+            home = os.path.expanduser("~")
+            docker_auth_file = os.path.join(home, '.docker', 'config.json')
+            if os.path.isfile(docker_auth_file):
+                with salt.utils.fopen(docker_auth_file) as fp:
+                    docker_auth = json.load(fp)
+                    fp.close()
+                if isinstance(docker_auth, dict):
+                    if 'auths' in docker_auth and isinstance(docker_auth['auths'], dict):
+                        for key, data in six.iteritems(docker_auth['auths']):
+                            if isinstance(data, dict):
+                                email = str(data.get('email', ''))
+                                b64_auth = base64.b64decode(data.get('auth', ''))
+                                username, password = b64_auth.split(':')
+                                registry = 'https://{registry}'.format(registry=key)
+                                registry_auth_config.update({registry: {
+                                    'username': username,
+                                    'password': password,
+                                    'email': email
+                                }})
+        except Exception as e:
+            log.debug('dockerng was unable to load credential from ~/.docker/config.json'
+                      ' trying with pillar now ({0})'.format(e))
+        # Set credentials from pillar - Overwrite auth from config.json
+        registry_auth_config.update(__pillar__.get('docker-registries', {}))
         for key, data in six.iteritems(__pillar__):
             if key.endswith('-docker-registries'):
                 registry_auth_config.update(data)


### PR DESCRIPTION
@jfindlay  as discussed this morning on IRC here is a PR for the docker registry authenticatin.
### What does this PR do?

At the moment the only way to use authenticated registry with dockerng is to specify pillar information for each registry. This is a good way and we should keep it as a default behaviour, but sometimes if you have your pillar in git or multiple salt-masters it can be a bit heavy.

Also it happens quite regularly that people use the docker cli tool directly and this latter stores its credentials in ~/.docker/config.json. It makes sense that the dockerng plugin is able to go and read that file to try and see if it has some credentials for a repo. 

So in the end if a credential is present in the default auth file and no pillar info is specified we go ahead and use them. If the same registry is specified in both the default auth file and pillar, the pillar data will be used.
### What issues does this PR fix or reference?
## 
### Previous Behavior

Docker registry credential are read only from pillar.
### New Behavior

Docker registry credential are read from pillar and the default docker auth file.
### Tests written?

No
