### PR TITLE
Single schedule for MultiMinion, EventBus managed by MultiMinion.

### DIFF
--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -233,10 +233,7 @@ class Minion(parsers.MinionOptionParser, DaemonsMixin):  # pylint: disable=no-in
 
     def _handle_signals(self, signum, sigframe):  # pylint: disable=unused-argument
         # escalate signal to the process manager processes
-        self.minion.process_manager.stop_restarting()
-        self.minion.process_manager.send_signal_to_processes(signum)
-        # kill any remaining processes
-        self.minion.process_manager.kill_children()
+        self.minion.stop(signum)
         super(Minion, self)._handle_signals(signum, sigframe)
 
     # pylint: disable=no-member
@@ -325,13 +322,7 @@ class Minion(parsers.MinionOptionParser, DaemonsMixin):  # pylint: disable=no-in
             self.set_pidfile()
             if self.config.get('master_type') == 'func':
                 salt.minion.eval_master_func(self.config)
-            if isinstance(self.config.get('master'), list):
-                if self.config.get('master_type') == 'failover':
-                    self.minion = salt.minion.Minion(self.config)
-                else:
-                    self.minion = salt.minion.MultiMinion(self.config)
-            else:
-                self.minion = salt.minion.Minion(self.config)
+            self.minion = salt.minion.MinionManager(self.config)
         else:
             import salt.daemons.flo
             self.daemonize_if_required()

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -706,7 +706,7 @@ class MasterMinion(object):
         self.functions['sys.reload_modules'] = self.gen_modules
 
 
-class MultiMinion(MinionBase):
+class MinionManager(MinionBase):
     '''
     Create a multi minion interface, this creates as many minions as are
     defined in the master option and binds each minion object to a respective
@@ -716,76 +716,71 @@ class MultiMinion(MinionBase):
     MINION_CONNECT_TIMEOUT = 5
 
     def __init__(self, opts):
-        super(MultiMinion, self).__init__(opts)
+        super(MinionManager, self).__init__(opts)
         self.auth_wait = self.opts['acceptance_wait_time']
         self.max_auth_wait = self.opts['acceptance_wait_time_max']
+        self.minions = []
 
         if HAS_ZMQ:
             zmq.eventloop.ioloop.install()
         self.io_loop = LOOP_CLASS.current()
 
+    def _bind(self):
+        # start up the event publisher, so we can see events during startup
+        self.event_publisher = salt.utils.event.AsyncEventPublisher(
+            self.opts,
+            io_loop=self.io_loop,
+        )
+        self.event = salt.utils.event.get_event('minion', opts=self.opts, io_loop=self.io_loop)
+        self.event.subscribe('')
+        self.event.set_event_handler(self.handle_event)
+
+    @tornado.gen.coroutine
+    def handle_event(self, package):
+        yield [minion.handle_event(package) for minion in self.minions]
+
     def _spawn_minions(self):
         '''
         Spawn all the coroutines which will sign in to masters
         '''
-        if not isinstance(self.opts['master'], list):
-            log.error(
-                'Attempting to start a multimaster system with one master')
-            sys.exit(salt.defaults.exitcodes.EX_GENERIC)
-        # Check that for tcp ipc_mode that we have either default ports or
-        # lists of ports
-        if self.opts.get('ipc_mode') == 'tcp' and (
-                    (not isinstance(self.opts['tcp_pub_port'], list) and
-                    self.opts['tcp_pub_port'] != 4510) or
-                    (not isinstance(self.opts['tcp_pull_port'], list) and
-                    self.opts['tcp_pull_port'] != 4511)
-                ):
-            raise SaltException('For multi-master, tcp_(pub/pull)_port '
-                                'settings must be lists of ports, or the '
-                                'default 4510 and 4511')
-        masternumber = 0
-        for master in set(self.opts['master']):
+        masters = self.opts['master']
+        if self.opts['master_type'] == 'failover' or not isinstance(self.opts['master'], list):
+            masters = [masters]
+
+        for master in masters:
             s_opts = copy.deepcopy(self.opts)
             s_opts['master'] = master
             s_opts['multimaster'] = True
             s_opts['auth_timeout'] = self.MINION_CONNECT_TIMEOUT
-            if self.opts.get('ipc_mode') == 'tcp':
-                # If one is a list, we can assume both are, because of check above
-                if isinstance(self.opts['tcp_pub_port'], list):
-                    s_opts['tcp_pub_port'] = self.opts['tcp_pub_port'][masternumber]
-                    s_opts['tcp_pull_port'] = self.opts['tcp_pull_port'][masternumber]
-                else:
-                    s_opts['tcp_pub_port'] = self.opts['tcp_pub_port'] + (masternumber * 2)
-                    s_opts['tcp_pull_port'] = self.opts['tcp_pull_port'] + (masternumber * 2)
-            self.io_loop.spawn_callback(self._connect_minion, s_opts)
-            masternumber += 1
+            minion = Minion(s_opts,
+                            self.MINION_CONNECT_TIMEOUT,
+                            False,
+                            io_loop=self.io_loop,
+                            loaded_base_name='salt.loader.{0}'.format(s_opts['master']),
+                            )
+            self.minions.append(minion)
+            self.io_loop.spawn_callback(self._connect_minion, minion)
 
     @tornado.gen.coroutine
-    def _connect_minion(self, opts):
+    def _connect_minion(self, minion):
         '''
         Create a minion, and asynchronously connect it to a master
         '''
         last = 0  # never have we signed in
-        auth_wait = opts['acceptance_wait_time']
+        auth_wait = minion.opts['acceptance_wait_time']
         while True:
             try:
-                minion = Minion(opts,
-                                self.MINION_CONNECT_TIMEOUT,
-                                False,
-                                io_loop=self.io_loop,
-                                loaded_base_name='salt.loader.{0}'.format(opts['master']),
-                                )
                 yield minion.connect_master()
                 minion.tune_in(start=False)
                 break
             except SaltClientError as exc:
-                log.error('Error while bringing up minion for multi-master. Is master at {0} responding?'.format(opts['master']))
+                log.error('Error while bringing up minion for multi-master. Is master at {0} responding?'.format(minion.opts['master']))
                 last = time.time()
                 if auth_wait < self.max_auth_wait:
                     auth_wait += self.auth_wait
                 yield tornado.gen.sleep(auth_wait)  # TODO: log?
             except Exception as e:
-                log.critical('Unexpected error while connecting to {0}'.format(opts['master']), exc_info=True)
+                log.critical('Unexpected error while connecting to {0}'.format(minion.opts['master']), exc_info=True)
 
     # Multi Master Tune In
     def tune_in(self):
@@ -796,11 +791,32 @@ class MultiMinion(MinionBase):
         to yet, but once the initial connection is made it is up to ZMQ to do the
         reconnect (don't know of an API to get the state here in salt)
         '''
+        self._bind()
+
         # Fire off all the minion coroutines
-        self.minions = self._spawn_minions()
+        self._spawn_minions()
 
         # serve forever!
         self.io_loop.start()
+
+    @property
+    def restart(self):
+        for minion in self.minions:
+            if minion.restart:
+                return True
+        return False
+
+    def stop(self, signum):
+        for minion in self.minions:
+            minion.process_manager.stop_restarting()
+            minion.process_manager.send_signal_to_processes(signum)
+            # kill any remaining processes
+            minion.process_manager.kill_children()
+            minion.destroy()
+
+    def destroy(self):
+        for minion in self.minions:
+            minion.destroy()
 
 
 class Minion(MinionBase):
@@ -822,6 +838,9 @@ class Minion(MinionBase):
         self.loaded_base_name = loaded_base_name
         self.connected = False
         self.restart = False
+        # Flag meaning minion has finished initialization including first connect to the master.
+        # True means the Minion is fully functional and ready to handle events.
+        self.ready = False
 
         if io_loop is None:
             if HAS_ZMQ:
@@ -951,7 +970,8 @@ class Minion(MinionBase):
         self.schedule = salt.utils.schedule.Schedule(
             self.opts,
             self.functions,
-            self.returners)
+            self.returners,
+            cleanup=['__master_alive'])
 
         # add default scheduling jobs to the minions scheduler
         if self.opts['mine_enabled'] and 'mine.update' in self.functions:
@@ -974,7 +994,7 @@ class Minion(MinionBase):
                 self.opts['master_alive_interval'] > 0 and
                 self.connected):
             self.schedule.add_job({
-                '__master_alive':
+                '__master_alive_{0}'.format(self.opts['master']):
                 {
                     'function': 'status.master',
                     'seconds': self.opts['master_alive_interval'],
@@ -1000,10 +1020,11 @@ class Minion(MinionBase):
             else:
                 self.schedule.delete_job('__master_failback', persist=True)
         else:
-            self.schedule.delete_job('__master_alive', persist=True)
+            self.schedule.delete_job('__master_alive_{0}'.format(self.opts['master']), persist=True)
             self.schedule.delete_job('__master_failback', persist=True)
 
         self.grains_cache = self.opts['grains']
+        self.ready = True
 
     def _return_retry_timer(self):
         '''
@@ -1796,8 +1817,10 @@ class Minion(MinionBase):
         '''
         Handle an event from the epull_sock (all local minion events)
         '''
+        if not self.ready:
+            raise tornado.gen.Return()
         tag, data = salt.utils.event.SaltEvent.unpack(package)
-        log.debug('Handling event tag \'{0}\''.format(tag))
+        log.debug('Minion of "{0}" is handling event tag \'{1}\''.format(self.opts['master'], tag))
         if tag.startswith('module_refresh'):
             self.module_refresh(notify=data.get('notify', False))
         elif tag.startswith('pillar_refresh'):
@@ -1820,8 +1843,8 @@ class Minion(MinionBase):
         elif tag.startswith('__master_disconnected') or tag.startswith('__master_failback'):
             # if the master disconnect event is for a different master, raise an exception
             if tag.startswith('__master_disconnected') and data['master'] != self.opts['master']:
-                raise SaltException('Bad master disconnected \'{0}\' when mine one is \'{1}\''.format(
-                    data['master'], self.opts['master']))
+                # not mine master, ignore
+                return
             if tag.startswith('__master_failback'):
                 # if the master failback event is not for the top master, raise an exception
                 if data['master'] != self.opts['master_list'][0]:
@@ -1844,7 +1867,7 @@ class Minion(MinionBase):
                        'kwargs': {'master': self.opts['master'],
                                   'connected': False}
                     }
-                    self.schedule.modify_job(name='__master_alive',
+                    self.schedule.modify_job(name='__master_alive_{0}'.format(self.opts['master']),
                                              schedule=schedule)
 
                 log.info('Connection to master {0} lost'.format(self.opts['master']))
@@ -1890,7 +1913,7 @@ class Minion(MinionBase):
                                'kwargs': {'master': self.opts['master'],
                                           'connected': True}
                             }
-                            self.schedule.modify_job(name='__master_alive',
+                            self.schedule.modify_job(name='__master_alive_{0}'.format(self.opts['master']),
                                                      schedule=schedule)
 
                             if self.opts['master_failback'] and 'master_list' in self.opts:
@@ -1927,7 +1950,7 @@ class Minion(MinionBase):
                                   'connected': True}
                     }
 
-                    self.schedule.modify_job(name='__master_alive',
+                    self.schedule.modify_job(name='__master_alive_{0}'.format(self.opts['master']),
                                              schedule=schedule)
         elif tag.startswith('__schedule_return'):
             self._return_pub(data, ret_cmd='_return', sync=False)
@@ -1962,13 +1985,6 @@ class Minion(MinionBase):
         :rtype : None
         '''
         self._pre_tune()
-
-        # start up the event publisher, so we can see events during startup
-        self.event_publisher = salt.utils.event.AsyncEventPublisher(
-            self.opts,
-            self.handle_event,
-            io_loop=self.io_loop,
-        )
 
         log.debug('Minion \'{0}\' trying to tune in'.format(self.opts['id']))
 
@@ -3046,7 +3062,7 @@ class ProxyMinion(Minion):
         if (self.opts['transport'] != 'tcp' and
                 self.opts['master_alive_interval'] > 0):
             self.schedule.add_job({
-                '__master_alive':
+                '__master_alive_{0}'.format(self.opts['master']):
                     {
                         'function': 'status.master',
                         'seconds': self.opts['master_alive_interval'],
@@ -3072,7 +3088,7 @@ class ProxyMinion(Minion):
             else:
                 self.schedule.delete_job('__master_failback', persist=True)
         else:
-            self.schedule.delete_job('__master_alive', persist=True)
+            self.schedule.delete_job('__master_alive_{0}'.format(self.opts['master']), persist=True)
             self.schedule.delete_job('__master_failback', persist=True)
 
         #  Sync the grains here so the proxy can communicate them to the master

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -817,12 +817,10 @@ class AsyncEventPublisher(object):
 
     TODO: remove references to "minion_event" whenever we need to use this for other things
     '''
-    def __init__(self, opts, publish_handler, io_loop=None):
+    def __init__(self, opts, io_loop=None):
         self.opts = salt.config.DEFAULT_MINION_OPTS.copy()
         default_minion_sock_dir = self.opts['sock_dir']
         self.opts.update(opts)
-
-        self.publish_handler = publish_handler
 
         self.io_loop = io_loop or tornado.ioloop.IOLoop.current()
         self._closing = False
@@ -909,7 +907,6 @@ class AsyncEventPublisher(object):
         '''
         try:
             self.publisher.publish(package)
-            self.io_loop.spawn_callback(self.publish_handler, package)
             return package
         # Add an extra fallback in case a forked process leeks through
         except Exception:

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -619,17 +619,12 @@ class Schedule(object):
         '''
         Reload the schedule from saved schedule file.
         '''
-
         # Remove all jobs from self.intervals
         self.intervals = {}
 
-        if 'schedule' in self.opts:
-            if 'schedule' in schedule:
-                self.opts['schedule'].update(schedule['schedule'])
-            else:
-                self.opts['schedule'].update(schedule)
-        else:
-            self.opts['schedule'] = schedule
+        if 'schedule' in schedule:
+            schedule = schedule['schedule']
+        self.opts.setdefault('schedule', {}).update(schedule)
 
     def list(self, where):
         '''

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -308,7 +308,29 @@ class Schedule(object):
     '''
     Create a Schedule object, pass in the opts and the functions dict to use
     '''
-    def __init__(self, opts, functions, returners=None, intervals=None):
+    instance = None
+
+    def __new__(cls, opts, functions, returners=None, intervals=None, cleanup=None):
+        '''
+        Only create one instance of Schedule
+        '''
+        if cls.instance is None:
+            log.debug('Initializing new Schedule')
+            # we need to make a local variable for this, as we are going to store
+            # it in a WeakValueDictionary-- which will remove the item if no one
+            # references it-- this forces a reference while we return to the caller
+            cls.instance = object.__new__(cls)
+            cls.instance.__singleton_init__(opts, functions, returners, intervals, cleanup)
+        else:
+            log.debug('Re-using Schedule')
+        return cls.instance
+
+    # has to remain empty for singletons, since __init__ will *always* be called
+    def __init__(self, opts, functions, returners=None, intervals=None, cleanup=None):
+        pass
+
+    # an init for the singleton instance to call
+    def __singleton_init__(self, opts, functions, returners=None, intervals=None, cleanup=None):
         self.opts = opts
         self.functions = functions
         if isinstance(intervals, dict):
@@ -324,6 +346,9 @@ class Schedule(object):
         # Keep track of the lowest loop interval needed in this variable
         self.loop_interval = six.MAXSIZE
         clean_proc_dir(opts)
+        if cleanup:
+            for prefix in cleanup:
+                self.delete_job_prefix(prefix)
 
     def option(self, opt):
         '''
@@ -389,6 +414,38 @@ class Schedule(object):
         # remove from self.intervals
         if name in self.intervals:
             del self.intervals[name]
+
+        if persist:
+            self.persist()
+
+    def delete_job_prefix(self, name, persist=True, where=None):
+        '''
+        Deletes a job from the scheduler.
+        '''
+        if where is None or where != 'pillar':
+            # ensure job exists, then delete it
+            for job in list(self.opts['schedule'].keys()):
+                if job.startswith(name):
+                    del self.opts['schedule'][job]
+            schedule = self.opts['schedule']
+        else:
+            # If job is in pillar, delete it there too
+            if 'schedule' in self.opts['pillar']:
+                for job in list(self.opts['pillar']['schedule'].keys()):
+                    if job.startswith(name):
+                        del self.opts['pillar']['schedule'][job]
+            schedule = self.opts['pillar']['schedule']
+            log.warning('Pillar schedule deleted. Pillar refresh recommended. Run saltutil.refresh_pillar.')
+
+        # Fire the complete event back along with updated list of schedule
+        evt = salt.utils.event.get_event('minion', opts=self.opts, listen=False)
+        evt.fire_event({'complete': True, 'schedule': schedule},
+                       tag='/salt/minion/minion_schedule_delete_complete')
+
+        # remove from self.intervals
+        for job in list(self.intervals.keys()):
+            if job.startswith(name):
+                del self.intervals[job]
 
         if persist:
             self.persist()

--- a/tests/unit/minion_test.py
+++ b/tests/unit/minion_test.py
@@ -46,7 +46,7 @@ class MinionTestCase(TestCase):
         }
         with patch.dict(__opts__, opts):
             try:
-                event_publisher = event.AsyncEventPublisher(__opts__, lambda x: True)
+                event_publisher = event.AsyncEventPublisher(__opts__)
                 result = True
             except SaltSystemExit:
                 result = False

--- a/tests/unit/utils/event_test.py
+++ b/tests/unit/utils/event_test.py
@@ -346,11 +346,14 @@ class TestAsyncEventPublisher(AsyncTestCase):
 
     def setUp(self):
         super(TestAsyncEventPublisher, self).setUp()
+        self.opts = {'sock_dir': SOCK_DIR}
         self.publisher = event.AsyncEventPublisher(
-            {'sock_dir': SOCK_DIR},
-            self._handle_publish,
+            self.opts,
             self.io_loop,
         )
+        self.event = event.get_event('minion', opts=self.opts, io_loop=self.io_loop)
+        self.event.subscribe('')
+        self.event.set_event_handler(self._handle_publish)
 
     def _handle_publish(self, raw):
         self.tag, self.data = event.SaltEvent.unpack(raw)
@@ -358,7 +361,7 @@ class TestAsyncEventPublisher(AsyncTestCase):
 
     def test_event_subscription(self):
         '''Test a single event is received'''
-        me = event.MinionEvent({'sock_dir': SOCK_DIR}, listen=True)
+        me = event.MinionEvent(self.opts, listen=True)
         me.fire_event({'data': 'foo1'}, 'evt1')
         self.wait()
         evt1 = me.get_event(tag='evt1')


### PR DESCRIPTION
### What does this PR do?

Reworked the schedule and MultiMinion design:
1. MultiMinion renamed to MinionManager
2. MinionManager manages:
        a) Minions
        b) EventBus
3. Minions are subscribed to events with MinionEvent
4. Single Minion is now a multiminion with multiplicity of 1
5. Schedule is now a singleton
6. Own master alive schedule job for each master
(__master_alive_<master-id>)
7. All previously persisted __master_alive\* jobs are cleared up on Minion start.
### What issues does this PR fix or reference?
#26311
### Tests written?

No
