### PR TITLE
Pass kwargs to cmd.run

### DIFF
--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -808,14 +808,15 @@ def run(name,
         if 'user' in kwargs and kwargs['user'] is not None and runas is None:
             runas = kwargs.pop('user')
 
-    cmd_kwargs = {'cwd': cwd,
-                  'runas': runas,
-                  'use_vt': use_vt,
-                  'shell': shell or __grains__['shell'],
-                  'env': env,
-                  'umask': umask,
-                  'output_loglevel': output_loglevel,
-                  'quiet': quiet}
+    cmd_kwargs = copy.deepcopy(kwargs)
+    cmd_kwargs.update({'cwd': cwd,
+                       'runas': runas,
+                       'use_vt': use_vt,
+                       'shell': shell or __grains__['shell'],
+                       'env': env,
+                       'umask': umask,
+                       'output_loglevel': output_loglevel,
+                       'quiet': quiet})
 
     cret = mod_run_check(cmd_kwargs, onlyif, unless, creates)
     if isinstance(cret, dict):


### PR DESCRIPTION
### What does this PR do?

Passes kwargs to cmd.run
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/33676
### Previous Behavior

password wasn't being passed as a kwarg to cmd.run
### New Behavior

password is now passed as a part of kwargs
### Tests written?

No
