### PR TITLE
Only compile the template contents if they evaluate to True

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2399,14 +2399,14 @@ class BaseHighState(object):
             )
             if contents:
                 found = 1
-            tops[self.opts['environment']] = [
-                compile_template(
-                    contents,
-                    self.state.rend,
-                    self.state.opts['renderer'],
-                    saltenv=self.opts['environment']
-                )
-            ]
+                tops[self.opts['environment']] = [
+                    compile_template(
+                        contents,
+                        self.state.rend,
+                        self.state.opts['renderer'],
+                        saltenv=self.opts['environment']
+                    )
+                ]
         elif self.opts['top_file_merging_strategy'] == 'merge':
             found = 0
             if self.opts.get('state_top_saltenv', False):
@@ -2417,28 +2417,6 @@ class BaseHighState(object):
                 )
                 if contents:
                     found = found + 1
-                else:
-                    log.debug('No contents loaded for env: {0}'.format(saltenv))
-
-                tops[saltenv].append(
-                    compile_template(
-                        contents,
-                        self.state.rend,
-                        self.state.opts['renderer'],
-                        saltenv=saltenv
-                    )
-                )
-            else:
-                for saltenv in self._get_envs():
-                    contents = self.client.cache_file(
-                        self.opts['state_top'],
-                        saltenv
-                    )
-                    if contents:
-                        found = found + 1
-                    else:
-                        log.debug('No contents loaded for env: {0}'.format(saltenv))
-
                     tops[saltenv].append(
                         compile_template(
                             contents,
@@ -2447,6 +2425,26 @@ class BaseHighState(object):
                             saltenv=saltenv
                         )
                     )
+                else:
+                    log.debug('No contents loaded for env: {0}'.format(saltenv))
+            else:
+                for saltenv in self._get_envs():
+                    contents = self.client.cache_file(
+                        self.opts['state_top'],
+                        saltenv
+                    )
+                    if contents:
+                        found = found + 1
+                        tops[saltenv].append(
+                            compile_template(
+                                contents,
+                                self.state.rend,
+                                self.state.opts['renderer'],
+                                saltenv=saltenv
+                            )
+                        )
+                    else:
+                        log.debug('No contents loaded for env: {0}'.format(saltenv))
             if found > 1:
                 log.warning('Top file merge strategy set to \'merge\' and multiple top files found. '
                             'Top file merging order is undefined; '

--- a/salt/state.py
+++ b/salt/state.py
@@ -2407,6 +2407,8 @@ class BaseHighState(object):
                         saltenv=self.opts['environment']
                     )
                 ]
+            else:
+                tops[self.opts['environment']] = [{}]
         elif self.opts['top_file_merging_strategy'] == 'merge':
             found = 0
             if self.opts.get('state_top_saltenv', False):
@@ -2426,6 +2428,7 @@ class BaseHighState(object):
                         )
                     )
                 else:
+                    tops[saltenv].append({})
                     log.debug('No contents loaded for env: {0}'.format(saltenv))
             else:
                 for saltenv in self._get_envs():
@@ -2444,6 +2447,7 @@ class BaseHighState(object):
                             )
                         )
                     else:
+                        tops[saltenv].append({})
                         log.debug('No contents loaded for env: {0}'.format(saltenv))
             if found > 1:
                 log.warning('Top file merge strategy set to \'merge\' and multiple top files found. '


### PR DESCRIPTION
When getting all the top files for the various environments, those
environments without a top file will return `False` when we attempt to
cache the file. Passing a boolean to `compile_template()` will result
in an error being logged, since we are invoking the function incorrectly
(it expects the template data to be a string).

Since a `False` return from caching the file means that it does not
exist, this commit will only run `compile_template()` when the
contents evaluate to `True`.

Resolves #33424.

@thatch45 Is this a sane fix? Is there any potential breakage that could occur
by leaving environments lacking a top file (or I guess, those with top files of
zero length) out of the return data from `get_tops()`? I can't see any.
