### PR TITLE
During minion verification, read directly from public key file

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -955,21 +955,14 @@ class AESFuncs(object):
         if not salt.utils.verify.valid_id(self.opts, id_):
             return False
         pub_path = os.path.join(self.opts['pki_dir'], 'minions', id_)
-        with salt.utils.fopen(pub_path, 'r') as fp_:
-            minion_pub = fp_.read()
-        tmp_pub = salt.utils.mkstemp()
-        with salt.utils.fopen(tmp_pub, 'w+') as fp_:
-            fp_.write(minion_pub)
 
-        pub = None
         try:
-            with salt.utils.fopen(tmp_pub) as fp_:
+            with salt.utils.fopen(pub_path, 'r') as fp_:
                 pub = RSA.importKey(fp_.read())
         except (ValueError, IndexError, TypeError) as err:
-            log.error('Unable to load temporary public key "{0}": {1}'
-                      .format(tmp_pub, err))
+            log.error('Unable to load public key "{0}": {1}'
+                      .format(pub_path, err))
         try:
-            os.remove(tmp_pub)
             if salt.crypt.public_decrypt(pub, token) == b'salt':
                 return True
         except ValueError as err:


### PR DESCRIPTION
### What does this PR do?

Simplifies salt-master's public key loading process during minion verification.
### What issues does this PR fix or reference?

This reduces the I/O load generated by salt-master in dense deployments (dozens to hundreds of masters per host).
### Previous Behavior

To verify a minion, salt-master:
1. read /etc/salt/pki/master/minions/minion_id (or other configured location)
2. writes the content to a new temporary file
3. reads the temporary file
4. loads the public key from the read data
5. removes the temporary file
### New Behavior
1. read /etc/salt/pki/master/minions/minion_id
2. load the public key from the read data
