### PR TITLE
Remove explicit PW column default from mysql_user

### DIFF
--- a/salt/states/mysql_user.py
+++ b/salt/states/mysql_user.py
@@ -72,7 +72,7 @@ def present(name,
             password_hash=None,
             allow_passwordless=False,
             unix_socket=False,
-            password_column='Password',
+            password_column=None,
             **connection_args):
     '''
     Ensure that the named user is present with the specified properties. A


### PR DESCRIPTION
Followup to issue #29265 and PR #32440.
#32440 improved the mysql module to automatically choose the password column name as appropriate for the MySQL version, but neglected to update the mysql_user state, which was still supplying a value for password_column that overrode the automatic detection in the module.

This change corrects that oversight and passes None by default, allowing the module to choose an appropriate default when the state is called without parameters.
### Tests written?

No
