### PR TITLE
[Trivial] It's silly to use a python module path when the function is in the file.

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -1069,7 +1069,7 @@ def mine_get(tgt, fun, tgt_type='glob', opts=None):
     '''
     ret = {}
     serial = salt.payload.Serial(opts)
-    checker = salt.utils.minions.CkMinions(opts)
+    checker = CkMinions(opts)
     minions = checker.check_minions(
             tgt,
             tgt_type)


### PR DESCRIPTION
### What does this PR do?

Removes module path for local function
### What issues does this PR fix or reference?

N/A
### Tests written?

No - it's **trivial**
