### PR TITLE
[Bug] minion exit status

### DIFF
--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -156,7 +156,7 @@ def salt_minion():
         signal.signal(signal.SIGTERM, prev_sigterm_handler)
 
         if not process.exitcode == salt.defaults.exitcodes.SALT_KEEPALIVE:
-            break
+            sys.exit(process.exitcode)
         # ontop of the random_reauth_delay already preformed
         # delay extra to reduce flooding and free resources
         # NOTE: values are static but should be fine.

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -262,6 +262,15 @@ class OptionParser(optparse.OptionParser, object):
             log.shutdown_multiprocessing_logging_listener()
         optparse.OptionParser.exit(self, status, msg)
 
+    def error(self, msg):
+        """error(msg : string)
+
+        Print a usage message incorporating 'msg' to stderr and exit.
+        This keeps option parsing exit status uniform for all parsing errors.
+        """
+        self.print_usage(sys.stderr)
+        self.exit(salt.defaults.exitcodes.EX_USAGE, '{0}: error: {1}\n'.format(self.get_prog_name(), msg))
+
 
 class MergeConfigMixIn(six.with_metaclass(MixInMeta, object)):
     '''
@@ -2071,7 +2080,7 @@ class SaltCPOptionParser(six.with_metaclass(OptionParserMeta,
         # salt-cp needs arguments
         if len(self.args) <= 1:
             self.print_help()
-            self.exit(salt.defaults.exitcodes.EX_USAGE)
+            self.error('Insufficient arguments')
 
         if self.options.list:
             if ',' in self.args[0]:
@@ -2523,7 +2532,7 @@ class SaltCallOptionParser(six.with_metaclass(OptionParserMeta,
     def _mixin_after_parsed(self):
         if not self.args and not self.options.grains_run and not self.options.doc:
             self.print_help()
-            self.exit(salt.defaults.exitcodes.EX_USAGE)
+            self.error('Requires function, --grains or --doc')
 
         elif len(self.args) >= 1:
             if self.options.grains_run:
@@ -2870,7 +2879,7 @@ class SaltSSHOptionParser(six.with_metaclass(OptionParserMeta,
     def _mixin_after_parsed(self):
         if not self.args:
             self.print_help()
-            self.exit(salt.defaults.exitcodes.EX_USAGE)
+            self.error('Insufficient arguments')
 
         if self.options.list:
             if ',' in self.args[0]:
@@ -2883,7 +2892,7 @@ class SaltSSHOptionParser(six.with_metaclass(OptionParserMeta,
         self.config['argv'] = self.args[1:]
         if not self.config['argv'] or not self.config['tgt']:
             self.print_help()
-            self.exit(salt.defaults.exitcodes.EX_USAGE)
+            self.error('Insufficient arguments')
 
         if self.options.ssh_askpass:
             self.options.ssh_passwd = getpass.getpass('Password: ')
@@ -2994,7 +3003,7 @@ class SPMParser(six.with_metaclass(OptionParserMeta,
         if len(self.args) <= 1:
             if not self.args or self.args[0] not in ('update_repo',):
                 self.print_help()
-                self.exit(salt.defaults.exitcodes.EX_USAGE)
+                self.error('Insufficient arguments')
 
     def setup_config(self):
         return salt.config.spm_config(self.get_config_file_path())

--- a/tests/integration/shell/minion.py
+++ b/tests/integration/shell/minion.py
@@ -331,6 +331,32 @@ class MinionTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
         )
         self._assert_exit_status(status, 'EX_USAGE', message='unknown argument', stdout=stdout, stderr=stderr)
 
+    def test_exit_status_correct_usage(self):
+        '''
+        Ensure correct exit status when salt-minion starts correctly.
+        '''
+
+        user = getpass.getuser()
+
+        minion = testprogram.TestDaemonSaltMinion(
+            name='correct_usage',
+            program=os.path.join(integration.CODE_DIR, 'scripts', 'salt-minion'),
+            config={'user': user},
+            parent_dir=self._test_dir,
+            env={
+                'PYTHONPATH': ':'.join(sys.path),
+            },
+        )
+        # Call setup here to ensure config and script exist
+        minion.setup()
+        stdout, stderr, status = minion.run(
+            args=['-d'],
+            catch_stderr=True,
+            with_retcode=True,
+        )
+        self._assert_exit_status(status, 'EX_OK', message='correct usage', stdout=stdout, stderr=stderr)
+        minion.shutdown()
+
 
 if __name__ == '__main__':
     integration.run_tests(MinionTest)

--- a/tests/integration/shell/minion.py
+++ b/tests/integration/shell/minion.py
@@ -305,6 +305,32 @@ class MinionTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
             stderr=stderr
         )
 
+    # pylint: disable=invalid-name
+    def test_exit_status_unknown_argument(self):
+        '''
+        Ensure correct exit status when an unknown argument is passed to salt-minion.
+        '''
+
+        user = getpass.getuser()
+
+        minion = testprogram.TestDaemonSaltMinion(
+            name='unknown_argument',
+            program=os.path.join(integration.CODE_DIR, 'scripts', 'salt-minion'),
+            config={'user': user},
+            parent_dir=self._test_dir,
+            env={
+                'PYTHONPATH': ':'.join(sys.path),
+            },
+        )
+        # Call setup here to ensure config and script exist
+        minion.setup()
+        stdout, stderr, status = minion.run(
+            args=['-d', '--unknown-argument'],
+            catch_stderr=True,
+            with_retcode=True,
+        )
+        self._assert_exit_status(status, 'EX_USAGE', message='unknown argument', stdout=stdout, stderr=stderr)
+
 
 if __name__ == '__main__':
     integration.run_tests(MinionTest)

--- a/tests/integration/shell/minion.py
+++ b/tests/integration/shell/minion.py
@@ -254,6 +254,57 @@ class MinionTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
             for minion in minions:
                 minion.shutdown()
 
+    def _assert_exit_status(self, status, ex_status, message=None, stdout=None, stderr=None):
+        '''
+        Helper function to verify exit status and emit failure information.
+        '''
+
+        ex_val = getattr(salt.defaults.exitcodes, ex_status)
+        _message = '' if not message else ' ({0})'.format(message)
+        _stdout = '' if not stdout else '\nstdout: {0}'.format('\nstdout: '.join(stdout))
+        _stderr = '' if not stderr else '\nstderr: {0}'.format('\nstderr: '.join(stderr))
+        self.assertEqual(
+            status,
+            ex_val,
+            'Exit status was {0}, must be {1} (salt.default.exitcodes.{2}){3}{4}{5}'.format(
+                status,
+                ex_val,
+                ex_status,
+                _message,
+                _stderr,
+                _stderr,
+            )
+        )
+
+    def test_exit_status_unknown_user(self):
+        '''
+        Ensure correct exit status when the minion is configured to run as an unknown user.
+        '''
+
+        minion = testprogram.TestDaemonSaltMinion(
+            name='unknown_user',
+            program=os.path.join(integration.CODE_DIR, 'scripts', 'salt-minion'),
+            config={'user': 'unknown'},
+            parent_dir=self._test_dir,
+            env={
+                'PYTHONPATH': ':'.join(sys.path),
+            },
+        )
+        # Call setup here to ensure config and script exist
+        minion.setup()
+        stdout, stderr, status = minion.run(
+            args=['-d'],
+            catch_stderr=True,
+            with_retcode=True,
+        )
+        self._assert_exit_status(
+            status,
+            'EX_NOUSER',
+            message='unknown user not on system',
+            stdout=stdout,
+            stderr=stderr
+        )
+
 
 if __name__ == '__main__':
     integration.run_tests(MinionTest)


### PR DESCRIPTION
### What does this PR do?

Propagate `salt-minion` exit status rather than quash it to `0`
### What issues does this PR fix or reference?

None logged.
### Previous Behavior

`salt-minion` always exited with status `0` even when it would fail starting.
### New Behavior

Status values for errors are propagated.
### Tests written?

Yes
- Put the sleep in the same conditional branch as the prep_jid() recursion.
- Specifically check for errno.EEXIST for the makedirs() call - all other OSErrors are raised
- Don't check for the existence of jid_dir_, just call makedirs() and catch exceptions
