### PR TITLE
Vsphere fixes

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2422,11 +2422,6 @@ def create(vm_):
 
     new_vm_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.VirtualMachine, vm_name, container_ref=container_ref)
 
-    # Re-configure to make sure all info is correct, without this new network settings specifically
-    # ip settings and connect on startup may not apply
-    task = new_vm_ref.ReconfigVM_Task(spec=config_spec)
-    salt.utils.vmware.wait_for_task(task, vm_name, 'reconfig', 5, 'info')
-
     # Find how to power on in CreateVM_Task (if possible), for now this will do
     if not clone_type and power:
         task = new_vm_ref.PowerOn()

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2422,6 +2422,11 @@ def create(vm_):
 
     new_vm_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.VirtualMachine, vm_name, container_ref=container_ref)
 
+    # Re-configure to make sure all info is correct, without this new network settings specifically
+    # ip settings and connect on startup may not apply
+    task = new_vm_ref.ReconfigVM_Task(spec=config_spec)
+    salt.utils.vmware.wait_for_task(task, vm_name, 'reconfig', 5, 'info')
+
     # Find how to power on in CreateVM_Task (if possible), for now this will do
     if not clone_type and power:
         task = new_vm_ref.PowerOn()

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -187,7 +187,6 @@ def get_service_instance(host, username, password, protocol=None, port=None):
     service_instance = GetSi()
     if service_instance:
         if service_instance._GetStub().host == ':'.join([host, str(port)]):
-            service_instance._GetStub().GetConnection()
             return service_instance
         Disconnect(service_instance)
 

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -187,6 +187,8 @@ def get_service_instance(host, username, password, protocol=None, port=None):
     service_instance = GetSi()
     if service_instance:
         if service_instance._GetStub().host == ':'.join([host, str(port)]):
+            if salt.utils.is_proxy():
+                service_instance._GetStub().GetConnection()
             return service_instance
         Disconnect(service_instance)
 


### PR DESCRIPTION
### What does this PR do?

Fixes creating VMs on vSphere
### What issues does this PR fix or reference?

N/A
### Previous Behavior
- When getting the cached SI object any connections using a self signed certificate would then receive the CERTIFICATE_VERIFY_FAILED error
- When creating a new VM, with network info changed, the VM would start with "startOnConnected" being false and the VM would never receive a connected network card
### New Behavior
- After a VM is created the VM is configured with the same settings which correctly sets the networking info
### Tests written?

No
