### PR TITLE
Fix incorrect args passed to timezone.set_hwclock

### DIFF
--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -410,6 +410,12 @@ def set_hwclock(clock):
         elif clock == 'localtime':
             __salt__['file.sed']('/etc/default/rcS', '^UTC=.*', 'UTC=no')
     elif 'Gentoo' in __grains__['os_family']:
+        if clock not in ('UTC', 'localtime'):
+            raise SaltInvocationError(
+                'Only \'UTC\' and \'localtime\' are allowed'
+            )
+        if clock.__eq__('localtime'):
+            clock = 'local'
         __salt__['file.sed'](
             '/etc/conf.d/hwclock', '^clock=.*', 'clock="{0}"'.format(clock))
 

--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -414,7 +414,7 @@ def set_hwclock(clock):
             raise SaltInvocationError(
                 'Only \'UTC\' and \'localtime\' are allowed'
             )
-        if clock.__eq__('localtime'):
+        if clock == 'localtime':
             clock = 'local'
         __salt__['file.sed'](
             '/etc/conf.d/hwclock', '^clock=.*', 'clock="{0}"'.format(clock))


### PR DESCRIPTION
On Gentoo, we should check the value passed in to timezone.set_hwclock
and only allow 'UTC' or 'localtime' for argument. If incorrect value is
passed in, it could subsequently fry the important config file.

There is another closely related issue on Gentoo. The value to set
'clock' variable in the config file is either 'UTC' or 'local'. In case
of localtime arg, we should convert the value of 'localtime' to 'local'
when setting that 'clock' variable.
