### PR TITLE
Always update minion ID on restart, by default.

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -957,7 +957,7 @@ DEFAULT_MINION_OPTS = {
     'tcp_keepalive_intvl': -1,
     'modules_max_memory': -1,
     'grains_refresh_every': 0,
-    'minion_id_caching': True,
+    'minion_id_caching': False,
     'keysize': 2048,
     'transport': 'zeromq',
     'auth_timeout': 60,


### PR DESCRIPTION
### What does this PR do?

By default, minion is using ID from the cache. Just minion restart on the changed hostname brings to the confusion and issues that are classified high priority of bugs, while they aren't.
### New behaviour

Now minion will be always reconcile its ID on the minion restart, unless explicitly specified in the config to get it from the cache.
