### PR TITLE
Fix for groupadd execution module failures in SLES11 systems

### DIFF
--- a/salt/modules/groupadd.py
+++ b/salt/modules/groupadd.py
@@ -233,8 +233,7 @@ def members(name, members_list):
             cmd = 'gpasswd -M {0} {1}'.format(members_list, name)
         elif on_suse_11:
             for old_member in __salt__['group.info'](name).get('members'):
-                __salt__['cmd.run']('groupmod -R {0} {1}'.format(old_member, name),
-                                    python_shell=False)
+                __salt__['cmd.run']('groupmod -R {0} {1}'.format(old_member, name), python_shell=False)
             cmd = 'groupmod -A {0} {1}'.format(members_list, name)
         else:
             cmd = 'gpasswd --members {0} {1}'.format(members_list, name)

--- a/salt/modules/groupadd.py
+++ b/salt/modules/groupadd.py
@@ -153,10 +153,13 @@ def adduser(name, username):
     if not then adds it.
     '''
     on_redhat_5 = __grains__.get('os_family') == 'RedHat' and __grains__.get('osmajorrelease') == '5'
+    on_suse_11 = __grains__.get('os_family') == 'Suse' and __grains__.get('osrelease_info')[0] == 11
 
     if __grains__['kernel'] == 'Linux':
         if on_redhat_5:
             cmd = 'gpasswd -a {0} {1}'.format(username, name)
+        elif on_suse_11:
+            cmd = 'usermod -A {0} {1}'.format(name, username)
         else:
             cmd = 'gpasswd --add {0} {1}'.format(username, name)
     else:
@@ -181,6 +184,7 @@ def deluser(name, username):
     then returns True.
     '''
     on_redhat_5 = __grains__.get('os_family') == 'RedHat' and __grains__.get('osmajorrelease') == '5'
+    on_suse_11 = __grains__.get('os_family') == 'Suse' and __grains__.get('osrelease_info')[0] == 11
 
     grp_info = __salt__['group.info'](name)
     try:
@@ -188,6 +192,8 @@ def deluser(name, username):
             if __grains__['kernel'] == 'Linux':
                 if on_redhat_5:
                     cmd = 'gpasswd -d {0} {1}'.format(username, name)
+                elif on_suse_11:
+                    cmd = 'usermod -R {0} {1}'.format(name, username)
                 else:
                     cmd = 'gpasswd --del {0} {1}'.format(username, name)
                 retcode = __salt__['cmd.retcode'](cmd, python_shell=False)
@@ -220,10 +226,16 @@ def members(name, members_list):
         foo:x:1234:user1,user2,user3,...
     '''
     on_redhat_5 = __grains__.get('os_family') == 'RedHat' and __grains__.get('osmajorrelease') == '5'
+    on_suse_11 = __grains__.get('os_family') == 'Suse' and __grains__.get('osrelease_info')[0] == 11
 
     if __grains__['kernel'] == 'Linux':
         if on_redhat_5:
             cmd = 'gpasswd -M {0} {1}'.format(members_list, name)
+        elif on_suse_11:
+            for old_member in __salt__['group.info'](name).get('members'):
+                __salt__['cmd.run']('groupmod -R {0} {1}'.format(old_member, name),
+                                    python_shell=False)
+            cmd = 'groupmod -A {0} {1}'.format(members_list, name)
         else:
             cmd = 'gpasswd --members {0} {1}'.format(members_list, name)
         retcode = __salt__['cmd.retcode'](cmd, python_shell=False)

--- a/tests/unit/modules/groupadd_test.py
+++ b/tests/unit/modules/groupadd_test.py
@@ -28,7 +28,6 @@ class GroupAddTestCase(TestCase):
     mock_group = {'passwd': '*', 'gid': 0, 'name': 'test', 'members': ['root']}
     mock_getgrnam = grp.struct_group(('foo', '*', 20, ['test']))
 
-
     # 'add' function tests: 1
 
     def test_add(self):
@@ -117,7 +116,7 @@ class GroupAddTestCase(TestCase):
             {'grains': {'kernel': 'Linux', 'os_family': 'RedHat', 'osmajorrelease': '5'},
              'cmd': 'gpasswd -a root test'},
 
-            {'grains': {'kernel': 'Linux', 'os_family': 'Suse', 'osrelease_info': [11,2]},
+            {'grains': {'kernel': 'Linux', 'os_family': 'Suse', 'osrelease_info': [11, 2]},
              'cmd': 'usermod -A test root'},
 
             {'grains': {'kernel': 'Linux'},
@@ -144,7 +143,7 @@ class GroupAddTestCase(TestCase):
             {'grains': {'kernel': 'Linux', 'os_family': 'RedHat', 'osmajorrelease': '5'},
              'cmd': 'gpasswd -d root test'},
 
-            {'grains': {'kernel': 'Linux', 'os_family': 'Suse', 'osrelease_info': [11,2]},
+            {'grains': {'kernel': 'Linux', 'os_family': 'Suse', 'osrelease_info': [11, 2]},
              'cmd': 'usermod -R test root'},
 
             {'grains': {'kernel': 'Linux'},
@@ -179,7 +178,7 @@ class GroupAddTestCase(TestCase):
             {'grains': {'kernel': 'Linux', 'os_family': 'RedHat', 'osmajorrelease': '5'},
              'cmd': "gpasswd -M foo test"},
 
-            {'grains': {'kernel': 'Linux', 'os_family': 'Suse', 'osrelease_info': [11,2]},
+            {'grains': {'kernel': 'Linux', 'os_family': 'Suse', 'osrelease_info': [11, 2]},
              'cmd': 'groupmod -A foo test'},
 
             {'grains': {'kernel': 'Linux'},

--- a/tests/unit/modules/groupadd_test.py
+++ b/tests/unit/modules/groupadd_test.py
@@ -184,10 +184,14 @@ class GroupAddTestCase(TestCase):
 
             {'grains': {'kernel': 'Linux'},
              'cmd': 'gpasswd --members foo test'},
+
+            {'grains': {'kernel': 'OpenBSD'},
+             'cmd': 'usermod -G test foo'},
         ]
 
         for os_version in os_version_list:
             mock_ret = MagicMock(return_value={'retcode': 0})
+            mock_stdout = MagicMock(return_value={'cmd.run_stdout': 1})
             mock_info = MagicMock(return_value={'passwd': '*',
                                                 'gid': 0,
                                                 'name': 'test',
@@ -197,18 +201,10 @@ class GroupAddTestCase(TestCase):
             with patch.dict(groupadd.__grains__, os_version['grains']):
                 with patch.dict(groupadd.__salt__, {'cmd.retcode': mock_ret,
                                                     'group.info': mock_info,
+                                                    'cmd.run_stdout': mock_stdout,
                                                     'cmd.run': mock}):
                     self.assertFalse(groupadd.members('test', 'foo'))
                     groupadd.__salt__['cmd.retcode'].assert_called_once_with(os_version['cmd'], python_shell=False)
-
-        mock_stdout = MagicMock(return_value={'cmd.run_stdout': 1})
-        mock = MagicMock()
-        with patch.dict(groupadd.__grains__, {'kernel': 'OpenBSD'}):
-            with patch.dict(groupadd.__salt__, {'cmd.retcode': mock_ret,
-                                                'group.info': mock_info,
-                                                 'cmd.run_stdout': mock_stdout,
-                                                 'cmd.run': mock}):
-                self.assertFalse(groupadd.members('foo', ['root']))
 
 
 if __name__ == '__main__':

--- a/tests/unit/modules/groupadd_test.py
+++ b/tests/unit/modules/groupadd_test.py
@@ -28,6 +28,7 @@ class GroupAddTestCase(TestCase):
     mock_group = {'passwd': '*', 'gid': 0, 'name': 'test', 'members': ['root']}
     mock_getgrnam = grp.struct_group(('foo', '*', 20, ['test']))
 
+
     # 'add' function tests: 1
 
     def test_add(self):
@@ -112,14 +113,26 @@ class GroupAddTestCase(TestCase):
         '''
         Tests if specified user gets added in the group.
         '''
-        mock = MagicMock(return_value={'retcode': 0})
-        with patch.dict(groupadd.__grains__, {'kernel': 'Linux'}):
-            with patch.dict(groupadd.__salt__, {'cmd.retcode': mock}):
-                self.assertFalse(groupadd.adduser('test', 'root'))
+        os_version_list = [
+            {'grains': {'kernel': 'Linux', 'os_family': 'RedHat', 'osmajorrelease': '5'},
+             'cmd': 'gpasswd -a root test'},
 
-        with patch.dict(groupadd.__grains__, {'kernel': ''}):
-            with patch.dict(groupadd.__salt__, {'cmd.retcode': mock}):
-                self.assertFalse(groupadd.adduser('test', 'root'))
+            {'grains': {'kernel': 'Linux', 'os_family': 'Suse', 'osrelease_info': [11,2]},
+             'cmd': 'usermod -A test root'},
+
+            {'grains': {'kernel': 'Linux'},
+             'cmd': 'gpasswd --add root test'},
+
+            {'grains': {'kernel': 'OTHERKERNEL'},
+             'cmd': 'usermod -G test root'},
+        ]
+
+        for os_version in os_version_list:
+            mock = MagicMock(return_value={'retcode': 0})
+            with patch.dict(groupadd.__grains__, os_version['grains']):
+                with patch.dict(groupadd.__salt__, {'cmd.retcode': mock}):
+                    self.assertFalse(groupadd.adduser('test', 'root'))
+                    groupadd.__salt__['cmd.retcode'].assert_called_once_with(os_version['cmd'], python_shell=False)
 
     # 'deluser' function tests: 1
 
@@ -127,22 +140,34 @@ class GroupAddTestCase(TestCase):
         '''
         Tests if specified user gets deleted from the group.
         '''
-        mock_ret = MagicMock(return_value={'retcode': 0})
-        mock_info = MagicMock(return_value={'passwd': '*',
-                                              'gid': 0,
-                                              'name': 'test',
-                                              'members': ['root']})
-        with patch.dict(groupadd.__grains__, {'kernel': 'Linux'}):
-            with patch.dict(groupadd.__salt__, {'cmd.retcode': mock_ret,
-                                                'group.info': mock_info}):
-                self.assertFalse(groupadd.deluser('test', 'root'))
+        os_version_list = [
+            {'grains': {'kernel': 'Linux', 'os_family': 'RedHat', 'osmajorrelease': '5'},
+             'cmd': 'gpasswd -d root test'},
 
-        mock_stdout = MagicMock(return_value={'cmd.run_stdout': 1})
-        with patch.dict(groupadd.__grains__, {'kernel': 'OpenBSD'}):
-            with patch.dict(groupadd.__salt__, {'cmd.retcode': mock_ret,
-                                                'group.info': mock_info,
-                                                'cmd.run_stdout': mock_stdout}):
-                self.assertTrue(groupadd.deluser('foo', 'root'))
+            {'grains': {'kernel': 'Linux', 'os_family': 'Suse', 'osrelease_info': [11,2]},
+             'cmd': 'usermod -R test root'},
+
+            {'grains': {'kernel': 'Linux'},
+             'cmd': 'gpasswd --del root test'},
+
+            {'grains': {'kernel': 'OpenBSD'},
+             'cmd': 'usermod -S foo root'},
+        ]
+
+        for os_version in os_version_list:
+            mock_ret = MagicMock(return_value={'retcode': 0})
+            mock_stdout = MagicMock(return_value='test foo')
+            mock_info = MagicMock(return_value={'passwd': '*',
+                                                'gid': 0,
+                                                'name': 'test',
+                                                'members': ['root']})
+
+            with patch.dict(groupadd.__grains__, os_version['grains']):
+                with patch.dict(groupadd.__salt__, {'cmd.retcode': mock_ret,
+                                                    'group.info': mock_info,
+                                                    'cmd.run_stdout': mock_stdout}):
+                    self.assertFalse(groupadd.deluser('test', 'root'))
+                    groupadd.__salt__['cmd.retcode'].assert_called_once_with(os_version['cmd'], python_shell=False)
 
     # 'deluser' function tests: 1
 
@@ -150,15 +175,31 @@ class GroupAddTestCase(TestCase):
         '''
         Tests if members of the group, get replaced with a provided list.
         '''
-        mock_ret = MagicMock(return_value={'retcode': 0})
-        mock_info = MagicMock(return_value={'passwd': '*',
-                                              'gid': 0,
-                                              'name': 'test',
-                                              'members': ['root']})
-        with patch.dict(groupadd.__grains__, {'kernel': 'Linux'}):
-            with patch.dict(groupadd.__salt__, {'cmd.retcode': mock_ret,
-                                                'group.info': mock_info}):
-                self.assertFalse(groupadd.members('test', ['foo']))
+        os_version_list = [
+            {'grains': {'kernel': 'Linux', 'os_family': 'RedHat', 'osmajorrelease': '5'},
+             'cmd': "gpasswd -M foo test"},
+
+            {'grains': {'kernel': 'Linux', 'os_family': 'Suse', 'osrelease_info': [11,2]},
+             'cmd': 'groupmod -A foo test'},
+
+            {'grains': {'kernel': 'Linux'},
+             'cmd': 'gpasswd --members foo test'},
+        ]
+
+        for os_version in os_version_list:
+            mock_ret = MagicMock(return_value={'retcode': 0})
+            mock_info = MagicMock(return_value={'passwd': '*',
+                                                'gid': 0,
+                                                'name': 'test',
+                                                'members': ['root']})
+            mock = MagicMock(return_value=True)
+
+            with patch.dict(groupadd.__grains__, os_version['grains']):
+                with patch.dict(groupadd.__salt__, {'cmd.retcode': mock_ret,
+                                                    'group.info': mock_info,
+                                                    'cmd.run': mock}):
+                    self.assertFalse(groupadd.members('test', 'foo'))
+                    groupadd.__salt__['cmd.retcode'].assert_called_once_with(os_version['cmd'], python_shell=False)
 
         mock_stdout = MagicMock(return_value={'cmd.run_stdout': 1})
         mock = MagicMock()


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug in `group` execution module when we're using `SLES11 SPX` and also `openSUSE 11.X` systems.

`gpasswd` version for `SLES11 SPX` and `openSUSE 11.X` does not support the arguments passed by Salt when calling `adduser`, `deluser` or `members` functions of `group` execution module.

This PR uses `usermod` and `groupmod` instead of `gpasswd` to manage the groups when using these systems.
### Previous Behavior

```
clisles11sp3-suma3pg:~ # salt-call group.adduser www root
[INFO    ] Executing command 'gpasswd --add root www' in directory '/root'
[ERROR   ] Command 'gpasswd --add root www' failed with return code: 6
[ERROR   ] output: gpasswd: unrecognized option '--add'
Try `gpasswd --help' or `gpasswd --usage' for more information.
local:
    False
```
### New Behavior

```
clisles11sp3-suma3pg:~ # salt-call group.adduser www root
[INFO    ] Executing command 'usermod -A www root' in directory '/root'
local:
    True
```
### Tests written?

No

Thanks!

/cc @isbm @kkaempf 
