### PR TITLE
Protect the vboxapi import more carefully

### DIFF
--- a/salt/cloud/clouds/virtualbox.py
+++ b/salt/cloud/clouds/virtualbox.py
@@ -28,7 +28,7 @@ import salt.utils.cloud as cloud
 
 # Import Third Party Libs
 try:
-    import vboxapi
+    import vboxapi  # pylint: disable=unused-import
     from salt.utils.virtualbox import (
         vb_list_machines,
         vb_clone_vm,

--- a/salt/cloud/clouds/virtualbox.py
+++ b/salt/cloud/clouds/virtualbox.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
-"""
+'''
 A salt cloud provider that lets you use virtualbox on your machine
 and act as a cloud.
+
+:depends: vboxapi
 
 For now this will only clone existing VMs. It's best to create a template
 from which we will clone.
@@ -13,29 +15,43 @@ to create this.
 Dicts provided by salt:
     __opts__ : contains the options used to run Salt Cloud,
         as well as a set of configuration and environment variables
-"""
-from __future__ import absolute_import
+'''
+
 # Import python libs
+from __future__ import absolute_import
 import logging
 
 # Import salt libs
-
 from salt.exceptions import SaltCloudSystemExit
 import salt.config as config
 import salt.utils.cloud as cloud
-from salt.utils.virtualbox import vb_list_machines, vb_clone_vm, HAS_LIBS, vb_machine_exists, vb_destroy_machine, \
-    vb_get_machine, vb_stop_vm, treat_machine_dict, vb_start_vm, vb_wait_for_network_address
+
+# Import Third Party Libs
+try:
+    import vboxapi
+    from salt.utils.virtualbox import (
+        vb_list_machines,
+        vb_clone_vm,
+        vb_machine_exists,
+        vb_destroy_machine,
+        vb_get_machine,
+        vb_stop_vm,
+        treat_machine_dict,
+        vb_start_vm,
+        vb_wait_for_network_address
+    )
+    HAS_VBOX = True
+except ImportError:
+    HAS_VBOX = False
 
 log = logging.getLogger(__name__)
 
-"""
-The name salt will identify the lib by
-"""
+# The name salt will identify the lib by
 __virtualname__ = 'virtualbox'
 
 
 def __virtual__():
-    """
+    '''
     This function determines whether or not
     to make this cloud module available upon execution.
     Most often, it uses get_configured_provider() to determine
@@ -46,18 +62,16 @@ def __virtual__():
      then that name should be returned instead of True.
 
     @return True|False|str
-    """
-
-    if not HAS_LIBS:
-        return False
+    '''
+    if not HAS_VBOX:
+        return False, 'The virtualbox driver cannot be loaded: \'vboxapi\' is not installed.'
 
     if get_configured_provider() is False:
-        return False
+        return False, 'The virtualbox driver cannot be loaded: \'virtualbox\' provider is not configured.'
 
     # If the name of the driver used does not match the filename,
     #  then that name should be returned instead of True.
-    # return __virtualname__
-    return True
+    return __virtualname__
 
 
 def get_configured_provider():


### PR DESCRIPTION
### What does this PR do?

Fixes the `__virtual__` function to work with the loader correctly by protecting the various imports in a try/except block. Also added some helpful messages when the virtualbox driver is called to help users know why the module might not have been loaded.t
### What issues does this PR fix or reference?

Fixes #33720
### Previous Behavior

Any salt-cloud command would stack trace with an import error:

```
root@rallytime:~# salt-cloud -f list_nodes linode
[INFO    ] salt-cloud starting
[ERROR   ] Couldn't import VirtualBox API
Traceback (most recent call last):
  File "/root/SaltStack/salt/salt/utils/virtualbox.py", line 25, in <module>
    import vboxapi
ImportError: No module named vboxapi
```
### New Behavior

Module doesn't load if the vboxapi dependency isn't installed and the stack trace is gone.

```
root@rallytime:~# salt-cloud -f list_nodes linode
[INFO    ] salt-cloud starting
linode-config:
    ----------
    linode:
        ----------
<snipped>
```
### Tests written?

No
