### PR TITLE
glance.warn_until shouldn't be checked for a doc string

### DIFF
--- a/tests/integration/modules/sysmod.py
+++ b/tests/integration/modules/sysmod.py
@@ -63,6 +63,7 @@ class SysModuleTest(integration.ModuleCase):
                 'runtests_decorators.missing_depends',
                 'runtests_decorators.missing_depends_will_fallback',
                 'swift.head',
+                'glance.warn_until',
                 'yumpkg.expand_repo_def',
                 'yumpkg5.expand_repo_def',
                 'container_resource.run',


### PR DESCRIPTION
### What does this PR do?

Skips the doc string test on glance.warn_until, since that isn't actually a function within the glance module. 
### What issues does this PR fix or reference?

It wont fail when glance gets loaded in the test suite.
### Tests written?

Yes
