### PR TITLE
Fix git_pillar edge case for remote repos without a master branch

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -1045,11 +1045,14 @@ class Pygit2(GitProvider):
                             return None
                         remote_head = 'refs/remotes/origin/' + branch_name
                         if remote_head not in refs:
-                            log.error(
-                                'Unable to find remote ref \'{0}\' in {1} remote '
-                                '\'{2}\''.format(head_ref, self.role, self.id)
-                            )
-                            return None
+                            # No remote ref for HEAD exists. This can happen in
+                            # the first-time git_pillar checkout when when the
+                            # remote repo does not have a master branch. Since
+                            # we need a HEAD reference to keep pygit2 from
+                            # throwing an error, and none exists in
+                            # refs/remotes/origin, we'll just point HEAD at the
+                            # remote_ref.
+                            remote_head = remote_ref
                         self.repo.create_reference(
                             head_ref,
                             self.repo.lookup_reference(remote_head).target


### PR DESCRIPTION
When the remote repository does not have a master branch, on the initial
checkout there will be no ref in refs/remotes/origin for this branch,
leading to an error being logged and the checkout failing.

Instead of failing the checkout, in these cases we'll create the initial
local HEAD based on the ref we will eventually check out, since we know
for a fact that this ref exists.

Resolves #33725.
