### PR TITLE
Make `configurable_test_state` configurable in test mode

### DIFF
--- a/salt/states/test.py
+++ b/salt/states/test.py
@@ -189,6 +189,8 @@ def configurable_test_state(name, changes=True, result=True, comment=''):
         Do we return successfully or not?
         Accepts True, False, and 'Random'
         Default is True
+        If test is True and changes is True, this will be None.  If test is
+        True and and changes is False, this will be True.
     comment:
         String to fill the comment field with.
         Default is ''
@@ -242,8 +244,8 @@ def configurable_test_state(name, changes=True, result=True, comment=''):
                                   '\'Random\'')
 
     if __opts__['test']:
-        ret['result'] = None
-        ret['comment'] = 'This is a test'
+        ret['result'] = True if changes is False else None
+        ret['comment'] = 'This is a test' if not comment else comment
 
     return ret
 

--- a/salt/states/test.py
+++ b/salt/states/test.py
@@ -201,33 +201,29 @@ def configurable_test_state(name, changes=True, result=True, comment=''):
         'result': False,
         'comment': comment
     }
+    change_data = {
+        'testing': {
+            'old': 'Unchanged',
+            'new': 'Something pretended to change'
+        }
+    }
 
     if changes == 'Random':
         if random.choice([True, False]):
             # Following the docs as written here
             # http://docs.saltstack.com/ref/states/writing.html#return-data
-            ret['changes'] = {
-                'testing': {
-                    'old': 'Unchanged',
-                    'new': 'Something pretended to change'
-                }
-            }
+            ret['changes'] = change_data
     elif changes is True:
         # If changes is True we place our dummy change dictionary into it.
         # Following the docs as written here
         # http://docs.saltstack.com/ref/states/writing.html#return-data
-        ret['changes'] = {
-            'testing': {
-                'old': 'Unchanged',
-                'new': 'Something pretended to change'
-            }
-        }
+        ret['changes'] = change_data
     elif changes is False:
         ret['changes'] = {}
     else:
         err = ('You have specified the state option \'Changes\' with'
-            ' invalid arguments. It must be either '
-            ' \'True\', \'False\', or \'Random\'')
+               ' invalid arguments. It must be either '
+               ' \'True\', \'False\', or \'Random\'')
         raise SaltInvocationError(err)
 
     if result == 'Random':

--- a/tests/unit/states/test_test.py
+++ b/tests/unit/states/test_test.py
@@ -18,6 +18,7 @@ from salttesting.mock import (
 ensure_in_syspath('../../')
 
 # Import Salt Libs
+from salt.exceptions import SaltInvocationError
 from salt.states import test
 
 # Globals
@@ -88,19 +89,200 @@ class TestTestCase(TestCase):
 
     def test_configurable_test_state(self):
         '''
-            Test of a configurable test state which
-            determines its output based on the inputs.
+        Test test.configurable_test_state with and without comment
         '''
-        ret = {'name': 'salt',
-               'changes': {},
-               'result': True,
-               'comment': ''}
-        with patch.dict(test.__opts__, {"test": False}):
-            ret.update({'changes': {'testing': {'new': 'Something pretended'
-                                                ' to change',
-                                                'old': 'Unchanged'}},
-                        'comment': 'Success!'})
-            self.assertDictEqual(test.succeed_with_changes('salt'), ret)
+        # Configure mock parameters
+        mock_name = 'cheese_shop'
+        mock_comment = "I'm afraid we're fresh out of Red Leicester sir."
+        mock_changes = {
+            'testing': {
+                'old': 'Unchanged',
+                'new': 'Something pretended to change'
+            }
+        }
+
+        # Test default state with comment
+        with patch.dict(test.__opts__, {'test': False}):
+            mock_ret = {'name': mock_name,
+                        'changes': mock_changes,
+                        'result': True,
+                        'comment': ''}
+            ret = test.configurable_test_state(mock_name)
+            self.assertDictEqual(ret, mock_ret)
+
+        # Test default state without comment
+        with patch.dict(test.__opts__, {'test': False}):
+            mock_ret = {'name': mock_name,
+                        'changes': mock_changes,
+                        'result': True,
+                        'comment': mock_comment}
+            ret = test.configurable_test_state(mock_name,
+                                               comment=mock_comment)
+            self.assertDictEqual(ret, mock_ret)
+
+    def test_configurable_test_state_changes(self):
+        '''
+        Test test.configurable_test_state with permutations of changes and with
+        comment
+        '''
+        # Configure mock parameters
+        mock_name = 'cheese_shop'
+        mock_comment = "I'm afraid we're fresh out of Red Leicester sir."
+        mock_changes = {
+            'testing': {
+                'old': 'Unchanged',
+                'new': 'Something pretended to change'
+            }
+        }
+
+        # Test changes=Random and comment
+        with patch.dict(test.__opts__, {'test': False}):
+            ret = test.configurable_test_state(mock_name,
+                                               changes='Random',
+                                               comment=mock_comment)
+            self.assertEqual(ret['name'], mock_name)
+            self.assertIn(ret['changes'], [mock_changes, {}])
+            self.assertEqual(ret['result'], True)
+            self.assertEqual(ret['comment'], mock_comment)
+
+        # Test changes=True and comment
+        with patch.dict(test.__opts__, {'test': False}):
+            mock_ret = {'name': mock_name,
+                        'changes': mock_changes,
+                        'result': True,
+                        'comment': mock_comment}
+            ret = test.configurable_test_state(mock_name,
+                                               changes=True,
+                                               comment=mock_comment)
+            self.assertDictEqual(ret, mock_ret)
+
+        # Test changes=False and comment
+        with patch.dict(test.__opts__, {'test': False}):
+            mock_ret = {'name': mock_name,
+                        'changes': {},
+                        'result': True,
+                        'comment': mock_comment}
+            ret = test.configurable_test_state(mock_name,
+                                               changes=False,
+                                               comment=mock_comment)
+            self.assertDictEqual(ret, mock_ret)
+
+        # Test changes=Cheese
+        with patch.dict(test.__opts__, {'test': False}):
+            self.assertRaises(SaltInvocationError,
+                              test.configurable_test_state,
+                              mock_name,
+                              changes='Cheese')
+
+    def test_configurable_test_state_result(self):
+        '''
+        Test test.configurable_test_state with permutations of result and with
+        comment
+        '''
+        # Configure mock parameters
+        mock_name = 'cheese_shop'
+        mock_comment = "I'm afraid we're fresh out of Red Leicester sir."
+        mock_changes = {
+            'testing': {
+                'old': 'Unchanged',
+                'new': 'Something pretended to change'
+            }
+        }
+
+        # Test result=Random and comment
+        with patch.dict(test.__opts__, {'test': False}):
+            ret = test.configurable_test_state(mock_name,
+                                               result='Random',
+                                               comment=mock_comment)
+            self.assertEqual(ret['name'], mock_name)
+            self.assertEqual(ret['changes'], mock_changes)
+            self.assertIn(ret['result'], [True, False])
+            self.assertEqual(ret['comment'], mock_comment)
+
+        # Test result=True and comment
+        with patch.dict(test.__opts__, {'test': False}):
+            mock_ret = {'name': mock_name,
+                        'changes': mock_changes,
+                        'result': True,
+                        'comment': mock_comment}
+            ret = test.configurable_test_state(mock_name,
+                                               result=True,
+                                               comment=mock_comment)
+            self.assertDictEqual(ret, mock_ret)
+
+        # Test result=False and comment
+        with patch.dict(test.__opts__, {'test': False}):
+            mock_ret = {'name': mock_name,
+                        'changes': mock_changes,
+                        'result': False,
+                        'comment': mock_comment}
+            ret = test.configurable_test_state(mock_name,
+                                               result=False,
+                                               comment=mock_comment)
+            self.assertDictEqual(ret, mock_ret)
+
+        # Test result=Cheese
+        with patch.dict(test.__opts__, {'test': False}):
+            self.assertRaises(SaltInvocationError,
+                              test.configurable_test_state,
+                              mock_name,
+                              result='Cheese')
+
+    def test_configurable_test_state_test(self):
+        '''
+        Test test.configurable_test_state with test=True with and without
+        comment
+        '''
+        # Configure mock parameters
+        mock_name = 'cheese_shop'
+        mock_comment = "I'm afraid we're fresh out of Red Leicester sir."
+        mock_changes = {
+            'testing': {
+                'old': 'Unchanged',
+                'new': 'Something pretended to change'
+            }
+        }
+
+        # Test test=True without comment
+        with patch.dict(test.__opts__, {'test': True}):
+            mock_ret = {'name': mock_name,
+                        'changes': mock_changes,
+                        'result': None,
+                        'comment': 'This is a test'}
+            ret = test.configurable_test_state(mock_name)
+            self.assertDictEqual(ret, mock_ret)
+
+        # Test test=True with comment
+        with patch.dict(test.__opts__, {'test': True}):
+            mock_ret = {'name': mock_name,
+                        'changes': mock_changes,
+                        'result': None,
+                        'comment': mock_comment}
+            ret = test.configurable_test_state(mock_name,
+                                               comment=mock_comment)
+            self.assertDictEqual(ret, mock_ret)
+
+        # Test test=True and changes=True with comment
+        with patch.dict(test.__opts__, {'test': True}):
+            mock_ret = {'name': mock_name,
+                        'changes': mock_changes,
+                        'result': None,
+                        'comment': mock_comment}
+            ret = test.configurable_test_state(mock_name,
+                                               changes=True,
+                                               comment=mock_comment)
+            self.assertDictEqual(ret, mock_ret)
+
+        # Test test=True and changes=False with comment
+        with patch.dict(test.__opts__, {'test': True}):
+            mock_ret = {'name': mock_name,
+                        'changes': {},
+                        'result': True,
+                        'comment': mock_comment}
+            ret = test.configurable_test_state(mock_name,
+                                               changes=False,
+                                               comment=mock_comment)
+            self.assertDictEqual(ret, mock_ret)
 
     def test_mod_watch(self):
         '''


### PR DESCRIPTION
### What does this PR do?

Make `test.configurable_test_state` configurable even in test mode and return the correct result in test mode as per [the state docs](https://docs.saltstack.com/en/latest/ref/states/writing.html#return-data).
### What issues does this PR fix or reference?

ZD-752
### Tests written?

Yes
