### PR TITLE
[Trivial] Ensure that option parser messages have a newline.

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -260,6 +260,8 @@ class OptionParser(optparse.OptionParser, object):
         if self._setup_mp_logging_listener_ is True:
             # Stop the logging queue listener process
             log.shutdown_multiprocessing_logging_listener()
+        if isinstance(msg, six.string_types) and msg and msg[-1] != '\n':
+            msg = '{0}\n'.format(msg)
         optparse.OptionParser.exit(self, status, msg)
 
     def error(self, msg):


### PR DESCRIPTION
### What does this PR do?

Ensures that option parser messages have newlines.
### What issues does this PR fix or reference?

None.
### Previous Behavior

Daemon shutdown messages were not newline terminated.
### New Behavior

Daemon shutdown messages are pretty.
### Tests written?

No

It's possible that this might add newlines where they aren't desired.  If this
is the case then all of the shutdown messages for the classes in
salt/cli/daemons.py require an explicit '\n'.
