### PR TITLE
modules/rabbitmq.py version checking had a logical error

### DIFF
--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -318,7 +318,7 @@ def check_password(name, password, runas=None):
         runas = salt.utils.get_user()
 
     # rabbitmq introduced a native api to check a username and password in version 3.5.7.
-    if version[0] >= 3 and version[1] >= 5 and version[2] >= 7:
+    if tuple(version) >= (3, 5, 7):
         res = __salt__['cmd.run'](
             ['rabbitmqctl', 'authenticate_user', name, password],
             runas=runas,


### PR DESCRIPTION
### What does this PR do?

I recently contributed to an issue and created a PR. The code I committed had a logical error when checking the version number - version `3.6.X`with `X<7` were not matched (and so on).

This PR solves this.

Related issue https://github.com/saltstack/salt/issues/33588 and PR https://github.com/saltstack/salt/pull/33641
