### PR TITLE
Fix `force` lock for zk_concurrency

### DIFF
--- a/salt/modules/zk_concurrency.py
+++ b/salt/modules/zk_concurrency.py
@@ -10,6 +10,7 @@ also be used to coordinate between masters.
 from __future__ import absolute_import
 
 import logging
+import sys
 
 try:
     from kazoo.client import KazooClient
@@ -213,6 +214,7 @@ def lock(path,
     # forcibly get the lock regardless of max_concurrency
     if force:
         SEMAPHORE_MAP[path].assured_path = True
+        SEMAPHORE_MAP[path].max_leases = sys.maxint
 
     # block waiting for lock acquisition
     if timeout:


### PR DESCRIPTION
### What does this PR do?

fix bug in zk_concurrency.lock with force=true

If all leases where currently held force would not work. This works around the issue by setting the local max leases to maxint-- to let you grab the lock always
