### PR TITLE
Typo (`privilages` → `privileges`)

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -2670,7 +2670,7 @@ def has_privileges(name,
         SELECT,INSERT maintenance_db=db_name
 
     name
-       Name of the role whose privilages should be checked on object_type
+       Name of the role whose privileges should be checked on object_type
 
     object_name
        Name of the object on which the check is to be performed
@@ -2687,7 +2687,7 @@ def has_privileges(name,
        - group
 
     privileges
-       Comma separated list of privilages to check, from the list below:
+       Comma separated list of privileges to check, from the list below:
 
        - INSERT
        - CREATE
@@ -2792,7 +2792,7 @@ def privileges_grant(name,
         SELECT,UPDATE maintenance_db=db_name
 
     name
-       Name of the role to which privilages should be granted
+       Name of the role to which privileges should be granted
 
     object_name
        Name of the object on which the grant is to be performed
@@ -2809,7 +2809,7 @@ def privileges_grant(name,
        - group
 
     privileges
-       Comma separated list of privilages to grant, from the list below:
+       Comma separated list of privileges to grant, from the list below:
 
        - INSERT
        - CREATE
@@ -2918,7 +2918,7 @@ def privileges_revoke(name,
         SELECT,UPDATE maintenance_db=db_name
 
     name
-       Name of the role whose privilages should be revoked
+       Name of the role whose privileges should be revoked
 
     object_name
        Name of the object on which the revoke is to be performed
@@ -2935,7 +2935,7 @@ def privileges_revoke(name,
        - group
 
     privileges
-       Comma separated list of privilages to revoke, from the list below:
+       Comma separated list of privileges to revoke, from the list below:
 
        - INSERT
        - CREATE

--- a/salt/states/postgres_privileges.py
+++ b/salt/states/postgres_privileges.py
@@ -90,7 +90,7 @@ def present(name,
     Grant the requested privilege(s) on the specified object to a role
 
     name
-        Name of the role to which privilages should be granted
+        Name of the role to which privileges should be granted
 
     object_name
        Name of the object on which the grant is to be performed
@@ -107,7 +107,7 @@ def present(name,
        - group
 
     privileges
-       Comma separated list of privilages to grant, from the list below:
+       Comma separated list of privileges to grant, from the list below:
 
        - INSERT
        - CREATE
@@ -210,7 +210,7 @@ def absent(name,
     Revoke the requested privilege(s) on the specificed object(s)
 
     name
-        Name of the role whose privilages should be revoked
+        Name of the role whose privileges should be revoked
 
     object_name
        Name of the object on which the revoke is to be performed
@@ -227,7 +227,7 @@ def absent(name,
        - group
 
     privileges
-       Comma separated list of privilages to revoke, from the list below:
+       Comma separated list of privileges to revoke, from the list below:
 
        - INSERT
        - CREATE


### PR DESCRIPTION
### What does this PR do?

It fixes a widespread typo (`privilages` → `privileges`) in PostgreSQL related docs, exec modules and state modules.
