### PR TITLE
Add example in the docs for varstack as a master_tops

### DIFF
--- a/doc/topics/master_tops/index.rst
+++ b/doc/topics/master_tops/index.rst
@@ -29,6 +29,13 @@ for :doc:`Cobbler <../../ref/tops/all/salt.tops.cobbler>` or:
 
 for :doc:`Reclass <../../ref/tops/all/salt.tops.reclass_adapter>`.
 
+.. code-block:: yaml
+
+    master_tops:
+      varstack: /path/to/the/config/file/varstack.yaml
+
+for :doc:`Varstack <../../ref/tops/all/salt.tops.varstack>`.
+
 It's also possible to create custom master_tops modules. These modules must go
 in a subdirectory called `tops` in the `extension_modules` directory.
 The `extension_modules` directory is not defined by default (the


### PR DESCRIPTION
### What does this PR do?

Adds a missing example for using varstack as a master top
### What issues does this PR fix or reference?

Master tops' doc page was missing a reference
