### PR TITLE
Add default proxy config directories /etc/salt/proxy.d & config in opts

### DIFF
--- a/doc/topics/proxyminion/index.rst
+++ b/doc/topics/proxyminion/index.rst
@@ -36,6 +36,16 @@ or more minions.
 See :doc:`Proxyminion Beacon </topics/proxyminion/beacon>` to help
 with easy configuration and management of ``salt-proxy`` processes.
 
+New in Carbon
+-------------
+
+Proxy minions now support configuration files with names ending in '*.conf'
+and placed in /etc/salt/proxy.d.
+
+Proxy minions can now be configured in /etc/salt/proxy or /etc/salt/proxy.d
+instead of just pillar.  Configuration format is the same as it would be in pillar.
+
+
 New in 2016.3
 -------------
 
@@ -179,7 +189,8 @@ Configuration parameters
 
 Proxy minions require no configuration parameters in /etc/salt/master.
 
-Salt's Pillar system is ideally suited for configuring proxy-minions.  Proxies
+Salt's Pillar system is ideally suited for configuring proxy-minions
+(though they can be configured in /etc/salt/proxy as well).  Proxies
 can either be designated via a pillar file in pillar_roots, or through an
 external pillar.  External pillars afford the opportunity for interfacing with
 a configuration management system, database, or other knowledgeable system that
@@ -298,6 +309,9 @@ In the above example
 Because of the way pillar works, each of the salt-proxy processes that fork off the
 proxy minions will only see the keys specific to the proxies it will be
 handling.
+
+Proxies can be configured in /etc/salt/proxy or with files in /etc/salt/proxy.d as of
+Salt's Carbon release.
 
 Also, in general, proxy-minions are lightweight, so the machines that run them
 could conceivably control a large number of devices.  To run more than one proxy from

--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -440,7 +440,7 @@ class ProxyMinion(parsers.ProxyMinionOptionParser, DaemonsMixin):  # pylint: dis
                         )
                 else:
                     confd = os.path.join(
-                        os.path.dirname(self.config['conf_file']), 'minion.d'
+                        os.path.dirname(self.config['conf_file']), 'proxy.d'
                     )
 
                 v_dirs = [

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1342,6 +1342,7 @@ DEFAULT_PROXY_MINION_OPTS = {
     'log_file': os.path.join(salt.syspaths.LOGS_DIR, 'proxy'),
     'add_proxymodule_to_opts': False,
     'proxy_merge_grains_in_module': False,
+    'default_include': 'proxy.d/*.conf',
 }
 
 # ----- Salt Cloud Configuration Defaults ----------------------------------->

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2981,14 +2981,16 @@ class ProxyMinion(Minion):
             pillarenv=self.opts.get('pillarenv'),
         ).compile_pillar()
 
-        if 'proxy' not in self.opts['pillar']:
-            log.error('No proxy key found in pillar for id '+self.opts['id']+'.')
+        if 'proxy' not in self.opts['pillar'] and 'proxy' not in self.opts:
+            log.error('No proxy key found in pillar or opts for id '+self.opts['id']+'.')
             log.error('Check your pillar configuration and contents.  Salt-proxy aborted.')
             self._running = False
             raise SaltSystemExit(code=-1)
 
-        fq_proxyname = self.opts['pillar']['proxy']['proxytype']
-        self.opts['proxy'] = self.opts['pillar']['proxy']
+        if 'proxy' not in self.opts:
+            self.opts['proxy'] = self.opts['pillar']['proxy']
+
+        fq_proxyname = self.opts['proxy']['proxytype']
 
         # Need to load the modules so they get all the dunder variables
         self.functions, self.returners, self.function_errors, self.executors = self._load_modules()


### PR DESCRIPTION
### What does this PR do?

Adds support for /etc/salt/proxy.d configuration files and the ability for proxies to be configured by `__opts__` in addition to pillar.
### What issues does this PR fix or reference?

None currently
### Tests written?

No
