### PR TITLE
[dockerng] remove limitation in port_binding range

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -308,7 +308,7 @@ __func_alias__ = {
 }
 
 # Minimum supported versions
-MIN_DOCKER = (1, 4, 0)
+MIN_DOCKER = (1, 6, 0)
 MIN_DOCKER_PY = (1, 4, 0)
 
 VERSION_RE = r'([\d.]+)'

--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -293,17 +293,7 @@ def _compare(actual, create_kwargs, defaults_from_image):
                 if container_port.endswith('/tcp'):
                     container_port = container_port[:-4]
                 for bind_data in bind_list:
-                    # Port range will have to be updated for future Docker
-                    # versions (see
-                    # https://github.com/docker/docker/issues/10220).  Note
-                    # that Docker 1.5.0 (released a few weeks after the fix
-                    # was merged) does not appear to have this fix in it,
-                    # so we're probably looking at 1.6.0 for this fix.
-                    if bind_data['HostPort'] == '' or \
-                            49153 <= int(bind_data['HostPort']) <= 65535:
-                        host_port = ''
-                    else:
-                        host_port = bind_data['HostPort']
+                    host_port = bind_data['HostPort']
                     if bind_data['HostIp'] in ('0.0.0.0', ''):
                         if host_port:
                             bind_def = (host_port, container_port)


### PR DESCRIPTION
### What does this PR do?

Remove a workaround of buggy docker versions prior 1.6.0
Require minimum docker version as 1.6.0
### What issues does this PR fix or reference?
#31595
### Previous Behavior

ports between 49153 and 65535 couldn't be bound.
### New Behavior

all ports are allowed.
### Tests written?

No
