### PR TITLE
[BUG] proxy exit status

### DIFF
--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -9,6 +9,7 @@ import os
 import warnings
 from salt.utils.verify import verify_log
 
+
 # All salt related deprecation warnings should be shown once each!
 warnings.filterwarnings(
     'once',                 # Show once
@@ -417,7 +418,7 @@ class ProxyMinion(parsers.ProxyMinionOptionParser, DaemonsMixin):  # pylint: dis
         super(ProxyMinion, self).prepare()
 
         if not self.values.proxyid:
-            raise SaltSystemExit('salt-proxy requires --proxyid')
+            self.error('salt-proxy requires --proxyid')
 
         # Proxies get their ID from the command line.  This may need to change in
         # the future.

--- a/tests/integration/shell/minion.py
+++ b/tests/integration/shell/minion.py
@@ -26,7 +26,6 @@ ensure_in_syspath('../../')
 import integration
 from integration.utils import testprogram
 import salt.utils
-import salt.defaults.exitcodes
 
 log = logging.getLogger(__name__)
 

--- a/tests/integration/shell/proxy.py
+++ b/tests/integration/shell/proxy.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Thayne Harbaugh (tharbaug@adobe.com)`
+
+    tests.integration.shell.proxy
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+'''
+
+# Import python libs
+from __future__ import absolute_import
+import logging
+
+# Import Salt Testing libs
+from salttesting.helpers import ensure_in_syspath
+ensure_in_syspath('../../')
+
+# Import salt libs
+import integration
+from integration.utils import testprogram
+
+log = logging.getLogger(__name__)
+
+
+class ProxyTest(testprogram.TestProgramCase):
+    '''
+    Various integration tests for the salt-proxy executable.
+    '''
+
+    def test_exit_status_no_proxyid(self):
+        '''
+        Ensure correct exit status when --proxyid argument is missing.
+        '''
+
+        proxy = testprogram.TestDaemonSaltProxy(
+            name='proxy-no_proxyid',
+            parent_dir=self._test_dir,
+        )
+        # Call setup here to ensure config and script exist
+        proxy.setup()
+        stdout, stderr, status = proxy.run(
+            args=['-d'],
+            verbatim_args=True,   # prevents --proxyid from being added automatically
+            catch_stderr=True,
+            with_retcode=True,
+        )
+        self.assert_exit_status(
+            status, 'EX_USAGE',
+            message='no --proxyid specified',
+            stdout=stdout, stderr=stderr
+        )
+        # proxy.shutdown() should be unnecessary since the start-up should fail
+
+    def test_exit_status_unknown_user(self):
+        '''
+        Ensure correct exit status when the proxy is configured to run as an unknown user.
+        '''
+
+        proxy = testprogram.TestDaemonSaltProxy(
+            name='proxy-unknown_user',
+            config={'user': 'unknown'},
+            parent_dir=self._test_dir,
+        )
+        # Call setup here to ensure config and script exist
+        proxy.setup()
+        stdout, stderr, status = proxy.run(
+            args=['-d'],
+            catch_stderr=True,
+            with_retcode=True,
+        )
+        self.assert_exit_status(
+            status, 'EX_NOUSER',
+            message='unknown user not on system',
+            stdout=stdout, stderr=stderr
+        )
+        # proxy.shutdown() should be unnecessary since the start-up should fail
+
+    # pylint: disable=invalid-name
+    def test_exit_status_unknown_argument(self):
+        '''
+        Ensure correct exit status when an unknown argument is passed to salt-proxy.
+        '''
+
+        proxy = testprogram.TestDaemonSaltProxy(
+            name='proxy-unknown_argument',
+            parent_dir=self._test_dir,
+        )
+        # Call setup here to ensure config and script exist
+        proxy.setup()
+        stdout, stderr, status = proxy.run(
+            args=['-d', '--unknown-argument'],
+            catch_stderr=True,
+            with_retcode=True,
+        )
+        self.assert_exit_status(
+            status, 'EX_USAGE',
+            message='unknown argument',
+            stdout=stdout, stderr=stderr
+        )
+        # proxy.shutdown() should be unnecessary since the start-up should fail
+
+    def test_exit_status_correct_usage(self):
+        '''
+        Ensure correct exit status when salt-proxy starts correctly.
+        '''
+
+        proxy = testprogram.TestDaemonSaltProxy(
+            name='proxy-correct_usage',
+            parent_dir=self._test_dir,
+        )
+        # Call setup here to ensure config and script exist
+        proxy.setup()
+        stdout, stderr, status = proxy.run(
+            args=['-d'],
+            catch_stderr=True,
+            with_retcode=True,
+        )
+        self.assert_exit_status(
+            status, 'EX_OK',
+            message='correct usage',
+            stdout=stdout, stderr=stderr
+        )
+        proxy.shutdown()
+
+
+if __name__ == '__main__':
+    integration.run_tests(ProxyTest)

--- a/tests/integration/utils/testprogram.py
+++ b/tests/integration/utils/testprogram.py
@@ -165,12 +165,16 @@ class TestProgram(object):
         env_delta.update(env)
 
         if not verbatim_env:
-            env_pypath = env_delta.get('PYTHONPATH', os.environ['PYTHONPATH']).split(':')
-            for path in sys.path:
-                if path not in env_pypath:
-                    env_pypath.append(path)
-            if integration.CODE_DIR not in env_pypath:
-                env_pypath.append(integration.CODE_DIR)
+            env_pypath = env_delta.get('PYTHONPATH', os.environ.get('PYTHONPATH'))
+            if not env_pypath:
+                env_pypath = ':'.join(sys.path)
+            else:
+                env_pypath = env_pypath.split(':')
+                for path in sys.path:
+                    if path not in env_pypath:
+                        env_pypath.append(path)
+                if integration.CODE_DIR not in env_pypath:
+                    env_pypath.append(integration.CODE_DIR)
             env_delta['PYTHONPATH'] = ':'.join(env_pypath)
 
         cmd_env = dict(os.environ)


### PR DESCRIPTION
### What does this PR do?

`salt-proxy` fixes and integration tests.
### What issues does this PR fix or reference?

Corrects `salt-proxy` exit status as well as prevents infinite looping when `--proxyid` is not specified.
### Previous Behavior
- Exit status for unknown arguments was `0`.
- When `--proxyid` was not specified an error message was printed but it would continue to try to start.
### New Behavior
- Corrects exit status to return `EX_USAGE` when an unknown argument is passed or a necessary argument (such as `--proxyid`) is missing.
- Does not loop infinitely.
### Tests written?

Yes
