### PR TITLE
Fixed spelling of "through"

### DIFF
--- a/salt/modules/boto_asg.py
+++ b/salt/modules/boto_asg.py
@@ -5,7 +5,7 @@ Connection module for Amazon Autoscale Groups
 .. versionadded:: 2014.7.0
 
 :configuration: This module accepts explicit autoscale credentials but can also
-    utilize IAM roles assigned to the instance trough Instance Profiles.
+    utilize IAM roles assigned to the instance through Instance Profiles.
     Dynamic credentials are then automatically obtained from AWS API and no
     further configuration is necessary. More Information available at:
 

--- a/salt/modules/boto_cfn.py
+++ b/salt/modules/boto_cfn.py
@@ -5,7 +5,7 @@ Connection module for Amazon Cloud Formation
 .. versionadded:: 2015.5.0
 
 :configuration: This module accepts explicit AWS credentials but can also utilize
-    IAM roles assigned to the instance trough Instance Profiles. Dynamic
+    IAM roles assigned to the instance through Instance Profiles. Dynamic
     credentials are then automatically obtained from AWS API and no further
     configuration is necessary. More Information available at:
 

--- a/salt/modules/boto_cloudtrail.py
+++ b/salt/modules/boto_cloudtrail.py
@@ -5,7 +5,7 @@ Connection module for Amazon CloudTrail
 .. versionadded:: 2016.3.0
 
 :configuration: This module accepts explicit Lambda credentials but can also
-    utilize IAM roles assigned to the instance trough Instance Profiles.
+    utilize IAM roles assigned to the instance through Instance Profiles.
     Dynamic credentials are then automatically obtained from AWS API and no
     further configuration is necessary. More Information available at:
 

--- a/salt/modules/boto_cloudwatch.py
+++ b/salt/modules/boto_cloudwatch.py
@@ -5,7 +5,7 @@ Connection module for Amazon CloudWatch
 .. versionadded:: 2014.7.0
 
 :configuration: This module accepts explicit credentials but can also utilize
-    IAM roles assigned to the instance trough Instance Profiles. Dynamic
+    IAM roles assigned to the instance through Instance Profiles. Dynamic
     credentials are then automatically obtained from AWS API and no further
     configuration is necessary. More Information available at:
 

--- a/salt/modules/boto_dynamodb.py
+++ b/salt/modules/boto_dynamodb.py
@@ -5,7 +5,7 @@ Connection module for Amazon DynamoDB
 .. versionadded:: 2015.5.0
 
 :configuration: This module accepts explicit DynamoDB credentials but can also
-    utilize IAM roles assigned to the instance trough Instance Profiles.
+    utilize IAM roles assigned to the instance through Instance Profiles.
     Dynamic credentials are then automatically obtained from AWS API and no
     further configuration is necessary. More Information available at:
 

--- a/salt/modules/boto_elasticache.py
+++ b/salt/modules/boto_elasticache.py
@@ -5,7 +5,7 @@ Connection module for Amazon Elasticache
 .. versionadded:: 2014.7.0
 
 :configuration: This module accepts explicit elasticache credentials but can
-    also utilize IAM roles assigned to the instance trough Instance Profiles.
+    also utilize IAM roles assigned to the instance through Instance Profiles.
     Dynamic credentials are then automatically obtained from AWS API and no
     further configuration is necessary. More Information available at:
 

--- a/salt/modules/boto_elb.py
+++ b/salt/modules/boto_elb.py
@@ -5,7 +5,7 @@ Connection module for Amazon ELB
 .. versionadded:: 2014.7.0
 
 :configuration: This module accepts explicit elb credentials but can also utilize
-    IAM roles assigned to the instance trough Instance Profiles. Dynamic
+    IAM roles assigned to the instance through Instance Profiles. Dynamic
     credentials are then automatically obtained from AWS API and no further
     configuration is necessary. More Information available at:
 

--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -5,7 +5,7 @@ Connection module for Amazon IAM
 .. versionadded:: 2014.7.0
 
 :configuration: This module accepts explicit iam credentials but can also utilize
-    IAM roles assigned to the instance trough Instance Profiles. Dynamic
+    IAM roles assigned to the instance through Instance Profiles. Dynamic
     credentials are then automatically obtained from AWS API and no further
     configuration is necessary. More Information available at:
 

--- a/salt/modules/boto_iot.py
+++ b/salt/modules/boto_iot.py
@@ -5,7 +5,7 @@ Connection module for Amazon IoT
 .. versionadded:: 2016.3.0
 
 :configuration: This module accepts explicit Lambda credentials but can also
-    utilize IAM roles assigned to the instance trough Instance Profiles.
+    utilize IAM roles assigned to the instance through Instance Profiles.
     Dynamic credentials are then automatically obtained from AWS API and no
     further configuration is necessary. More Information available at:
 

--- a/salt/modules/boto_kms.py
+++ b/salt/modules/boto_kms.py
@@ -5,7 +5,7 @@ Connection module for Amazon KMS
 .. versionadded:: 2015.8.0
 
 :configuration: This module accepts explicit kms credentials but can also utilize
-    IAM roles assigned to the instance trough Instance Profiles. Dynamic
+    IAM roles assigned to the instance through Instance Profiles. Dynamic
     credentials are then automatically obtained from AWS API and no further
     configuration is necessary. More Information available at::
 

--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -5,7 +5,7 @@ Connection module for Amazon Lambda
 .. versionadded:: 2016.3.0
 
 :configuration: This module accepts explicit Lambda credentials but can also
-    utilize IAM roles assigned to the instance trough Instance Profiles.
+    utilize IAM roles assigned to the instance through Instance Profiles.
     Dynamic credentials are then automatically obtained from AWS API and no
     further configuration is necessary. More Information available at:
 

--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -5,7 +5,7 @@ Connection module for Amazon RDS
 .. versionadded:: 2015.8.0
 
 :configuration: This module accepts explicit rds credentials but can also
-    utilize IAM roles assigned to the instance trough Instance Profiles.
+    utilize IAM roles assigned to the instance through Instance Profiles.
     Dynamic credentials are then automatically obtained from AWS API and no
     further configuration is necessary. More Information available at:
 

--- a/salt/modules/boto_route53.py
+++ b/salt/modules/boto_route53.py
@@ -5,7 +5,7 @@ Connection module for Amazon Route53
 .. versionadded:: 2014.7.0
 
 :configuration: This module accepts explicit route53 credentials but can also
-    utilize IAM roles assigned to the instance trough Instance Profiles.
+    utilize IAM roles assigned to the instance through Instance Profiles.
     Dynamic credentials are then automatically obtained from AWS API and no
     further configuration is necessary. More Information available at:
 

--- a/salt/modules/boto_s3_bucket.py
+++ b/salt/modules/boto_s3_bucket.py
@@ -5,7 +5,7 @@ Connection module for Amazon S3 Buckets
 .. versionadded:: 2016.3.0
 
 :configuration: This module accepts explicit Lambda credentials but can also
-    utilize IAM roles assigned to the instance trough Instance Profiles.
+    utilize IAM roles assigned to the instance through Instance Profiles.
     Dynamic credentials are then automatically obtained from AWS API and no
     further configuration is necessary. More Information available at:
 

--- a/salt/modules/boto_secgroup.py
+++ b/salt/modules/boto_secgroup.py
@@ -5,7 +5,7 @@ Connection module for Amazon Security Groups
 .. versionadded:: 2014.7.0
 
 :configuration: This module accepts explicit ec2 credentials but can
-    also utilize IAM roles assigned to the instance trough Instance Profiles.
+    also utilize IAM roles assigned to the instance through Instance Profiles.
     Dynamic credentials are then automatically obtained from AWS API and no
     further configuration is necessary. More Information available at:
 

--- a/salt/modules/boto_sns.py
+++ b/salt/modules/boto_sns.py
@@ -3,7 +3,7 @@
 Connection module for Amazon SNS
 
 :configuration: This module accepts explicit sns credentials but can also
-    utilize IAM roles assigned to the instance trough Instance Profiles. Dynamic
+    utilize IAM roles assigned to the instance through Instance Profiles. Dynamic
     credentials are then automatically obtained from AWS API and no further
     configuration is necessary. More Information available at:
 

--- a/salt/modules/boto_sqs.py
+++ b/salt/modules/boto_sqs.py
@@ -5,7 +5,7 @@ Connection module for Amazon SQS
 .. versionadded:: 2014.7.0
 
 :configuration: This module accepts explicit sqs credentials but can also utilize
-    IAM roles assigned to the instance trough Instance Profiles. Dynamic
+    IAM roles assigned to the instance through Instance Profiles. Dynamic
     credentials are then automatically obtained from AWS API and no further
     configuration is necessary. More Information available at:
 

--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -5,7 +5,7 @@ Connection module for Amazon VPC
 .. versionadded:: 2014.7.0
 
 :configuration: This module accepts explicit VPC credentials but can also
-    utilize IAM roles assigned to the instance trough Instance Profiles.
+    utilize IAM roles assigned to the instance through Instance Profiles.
     Dynamic credentials are then automatically obtained from AWS API and no
     further configuration is necessary. More Information available at:
 

--- a/salt/modules/s3.py
+++ b/salt/modules/s3.py
@@ -3,7 +3,7 @@
 Connection module for Amazon S3
 
 :configuration: This module accepts explicit s3 credentials but can also utilize
-    IAM roles assigned to the instance trough Instance Profiles. Dynamic
+    IAM roles assigned to the instance through Instance Profiles. Dynamic
     credentials are then automatically obtained from AWS API and no further
     configuration is necessary. More Information available at::
 

--- a/salt/states/boto_asg.py
+++ b/salt/states/boto_asg.py
@@ -11,7 +11,7 @@ services, and so may incur charges.
 This module uses boto, which can be installed via package, or pip.
 
 This module accepts explicit autoscale credentials but can also utilize
-IAM roles assigned to the instance trough Instance Profiles. Dynamic
+IAM roles assigned to the instance through Instance Profiles. Dynamic
 credentials are then automatically obtained from AWS API and no further
 configuration is necessary. More Information available at:
 

--- a/salt/states/boto_cloudwatch_alarm.py
+++ b/salt/states/boto_cloudwatch_alarm.py
@@ -10,7 +10,7 @@ Amazon's services, and so may incur charges.
 This module uses boto, which can be installed via package, or pip.
 
 This module accepts explicit credentials but can also utilize
-IAM roles assigned to the instance trough Instance Profiles. Dynamic
+IAM roles assigned to the instance through Instance Profiles. Dynamic
 credentials are then automatically obtained from AWS API and no further
 configuration is necessary. More Information available at:
 


### PR DESCRIPTION
### What does this PR do?

Fixes the consistent typo of "through" as "trough" throughout S3 module and state documentation.
