### PR TITLE
Fix integration test_list_modules_with_arg: pass 'u*' arg correctly

### DIFF
--- a/tests/integration/modules/sysmod.py
+++ b/tests/integration/modules/sysmod.py
@@ -55,9 +55,10 @@ class SysModuleTest(integration.ModuleCase):
         '''
         sys.list_modules u*
 
-        Tests getting the list of modules looking for the "user" module
+        Tests getting the list of modules with 'u*', and looking for the
+        "user" module
         '''
-        mods = self.run_function('sys.list_modules', 'u*')
+        mods = self.run_function('sys.list_modules', ['u*'])
         self.assertIn('user', mods)
 
     def test_list_modules_with_arg_exact_match(self):


### PR DESCRIPTION
### What does this PR do?

Fix the integration test for integration.modules.sysmod.SysModuleTest.test_list_modules_with_arg: if you change `self.assertIn('user', mods)` in the test to `self.assertIn('sys', mods)`, the test still passes, when it should not. Passing 'u*' correctly fixes this.
### What issues does this PR fix or reference?

Passing the argument incorrectly.
