### PR TITLE
Allow sys.list modules to list exact match

### DIFF
--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -395,19 +395,18 @@ def list_modules(*args):
     if not args:
         for func in __salt__:
             comps = func.split('.')
-            if len(comps) < 2:
-                continue
             modules.add(comps[0])
         return sorted(modules)
 
     for module in args:
         if '*' not in module:
-            module += '*'
-        for func in fnmatch.filter(__salt__, module):
-            comps = func.split('.')
-            if len(comps) < 2:
-                continue
-            modules.add(comps[0])
+            for func in __salt__:
+                comps = func.split('.')
+                if comps[0] == module:
+                    modules.add(comps[0])
+        else:
+            for func in fnmatch.filter(__salt__, module):
+                modules.add(func.split('.')[0])
     return sorted(modules)
 
 

--- a/tests/integration/modules/sysmod.py
+++ b/tests/integration/modules/sysmod.py
@@ -55,9 +55,10 @@ class SysModuleTest(integration.ModuleCase):
         '''
         sys.list_modules u*
 
-        Tests getting the list of modules looking for the "user" module
+        Tests getting the list of modules with 'u*', and looking for the
+        "user" module
         '''
-        mods = self.run_function('sys.list_modules', 'u*')
+        mods = self.run_function('sys.list_modules', ['u*'])
         self.assertIn('user', mods)
 
     def test_list_modules_with_arg_exact_match(self):

--- a/tests/integration/modules/sysmod.py
+++ b/tests/integration/modules/sysmod.py
@@ -51,7 +51,7 @@ class SysModuleTest(integration.ModuleCase):
         self.assertTrue('hosts' in mods)
         self.assertTrue('pkg' in mods)
 
-    def test_list_modules_with_arg(self):
+    def test_list_modules_with_arg_glob(self):
         '''
         sys.list_modules u*
 
@@ -69,8 +69,8 @@ class SysModuleTest(integration.ModuleCase):
         an exact match of 'user' being passed at the CLI instead of something
         with '*'.
         '''
-        mods = self.run_function('sys.list_modules', 'user')
-        self.assertIn('user', mods)
+        mods = self.run_function('sys.list_modules', ['user'])
+        self.assertEqual(mods, ['user'])
 
     def test_valid_docs(self):
         '''


### PR DESCRIPTION
*NOTE: this builds on https://github.com/saltstack/salt/pull/33774; that should be merged first.

*Take note that I've taken some "liberties" with the code (it's not a real liberty, because according to the docs, they're safe) in order to make it simpler: I've removed the check for `if len(comps) < 2`, because the values in `__salt__` will always contain a '.' anyway (so the check was redundant, and unnecessary)
### What does this PR do?

Fixes #33500 
### What issues does this PR fix or reference?
#33500
### Tests written?

Yes
