### PR TITLE
Fixed ACL user comparison. Resolves #33754.

### DIFF
--- a/salt/states/boto_s3_bucket.py
+++ b/salt/states/boto_s3_bucket.py
@@ -156,19 +156,39 @@ def __virtual__():
     return 'boto_s3_bucket' if 'boto_s3_bucket.exists' in __salt__ else False
 
 
+def _normalize_user(user_dict):
+    ret = deepcopy(user_dict)
+    # 'Type' is required as input to the AWS API, but not returned as output. So
+    # we ignore it everywhere.
+    if 'Type' in ret:
+        del ret['Type']
+    return ret
+
+
 def _get_canonical_id(region, key, keyid, profile):
-    return __salt__['boto_s3_bucket.list'](
+    ret = __salt__['boto_s3_bucket.list'](
         region=region, key=key, keyid=keyid, profile=profile
     ).get('Owner')
+    return _normalize_user(ret)
+
+
+def _prep_acl_for_compare(ACL):
+    '''
+    Prepares the ACL returned from the AWS API for comparison with a given one.
+    '''
+    ret = deepcopy(ACL)
+    ret['Owner'] = _normalize_user(ret['Owner'])
+    for item in ACL.get('Grants', ()):
+        item['Grantee'] = _normalize_user(item.get('Grantee'))
+    return ret
 
 
 def _acl_to_grant(ACL, owner_canonical_id):
     if 'AccessControlPolicy' in ACL:
         ret = deepcopy(ACL['AccessControlPolicy'])
-        # Type is required as input, but is not returned as output
-        for item in ret.get('Grants'):
-            if 'Type' in item.get('Grantee', ()):
-                del item['Grantee']['Type']
+        ret['Owner'] = _normalize_user(ret['Owner'])
+        for item in ACL.get('Grants', ()):
+            item['Grantee'] = _normalize_user(item.get('Grantee'))
         # If AccessControlPolicy is set, other options are not allowed
         return ret
     ret = {
@@ -281,7 +301,7 @@ def _compare_acl(current, desired, region, key, keyid, profile):
     rather than the input itself.
     '''
     ocid = _get_canonical_id(region, key, keyid, profile)
-    return json_objs_equal(current, _acl_to_grant(desired, ocid))
+    return json_objs_equal(_prep_acl_for_compare(current), _acl_to_grant(desired, ocid))
 
 
 def _compare_policy(current, desired, region, key, keyid, profile):

--- a/salt/states/boto_s3_bucket.py
+++ b/salt/states/boto_s3_bucket.py
@@ -178,7 +178,7 @@ def _prep_acl_for_compare(ACL):
     '''
     ret = deepcopy(ACL)
     ret['Owner'] = _normalize_user(ret['Owner'])
-    for item in ACL.get('Grants', ()):
+    for item in ret.get('Grants', ()):
         item['Grantee'] = _normalize_user(item.get('Grantee'))
     return ret
 

--- a/tests/unit/states/boto_s3_bucket_test.py
+++ b/tests/unit/states/boto_s3_bucket_test.py
@@ -89,6 +89,7 @@ if _has_required_boto():
             'CreationDate': None
         }],
         'Owner': {
+            'Type': 'CanonicalUser',
             'DisplayName': 'testuser',
             'ID': '111111222222'
         },


### PR DESCRIPTION
### What does this PR do?

Fixes the change detection of `states.boto_s3_bucket.present`.
### What issues does this PR fix or reference?

This PR _hopefully_ resolves #33754, but as there are other possible causes for that problem, the reporter will need to confirm. In my particular case at least, it fixes the problem described in #33754.
### Previous Behavior

`states.boto_s3_bucket.present` was idempotent with respect to actual bucket settings, but in certain cases it would detect changes when there were none. This resulted in unnecessary API requests and incorrect output.

The problem lay in bucket ACL descriptions. When specifying an ACL to the AWS API, each user description must include a `Type` key (usually set to `CanonicalUser`). But when you query the API for an ACL, it sometimes omits the `Type` key. So the comparison between expected and received ACL descriptions was failing.
### New Behavior

We normalize all user descriptions before comparison, removing the `Type` key from them.
### Tests written?

Yes (just modified the unit test `test_present_when_bucket_exists_no_mods` that was already present)
