### PR TITLE
Fix minor docstring issue of arg being missing

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -1195,7 +1195,7 @@ def get_bufsize(iface):
 
     .. code-block:: bash
 
-        salt '*' network.get_bufsize
+        salt '*' network.get_bufsize eth0
     '''
     if __grains__['kernel'] == 'Linux':
         if os.path.exists('/sbin/ethtool'):


### PR DESCRIPTION
The network.get_bufsize function requires an interface for arg. In the
example that part is missing. Add arbitrary 'eth0' for clarity.
