### PR TITLE
Fix minor docstring issues

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -1002,7 +1002,7 @@ def get_bufsize(iface):
 
     .. code-block:: bash
 
-        salt '*' network.getbufsize
+        salt '*' network.get_bufsize eth0
     '''
     if __grains__['kernel'] == 'Linux':
         if os.path.exists('/sbin/ethtool'):


### PR DESCRIPTION
The network.get_bufsize function requires an interface for arg. In the
example, the argument is missing and the function name is a little bit
off. Add arbitrary 'eth0' for argument and correct the name.
