### PR TITLE
Update hold packages in yum.

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1159,7 +1159,19 @@ def install(name=None,
 
     errors = []
 
+    hold_pkgs = list_holds(full=False)
+    log.error(hold_pkgs)
+    to_hold = []
     if targets:
+        if len(targets) == 1:
+            to_hold.append(pkgname)
+        else:
+            for _pkg in targets:
+                if _pkg in hold_pkgs:
+                    to_hold.append(_pkg)
+        if to_hold:
+            log.info('Removing lock for package(s) %s', to_hold)
+            unhold(pkgs=to_hold)
         cmd = [_yum(), '-y']
         if _yum() == 'dnf':
             cmd.extend(['--best', '--allowerasing'])
@@ -1174,6 +1186,10 @@ def install(name=None,
         )
         if out['retcode'] != 0:
             errors.append(out['stdout'])
+
+        if to_hold:
+            log.info('Adding lock for package(s) %s', to_hold)
+            hold(pkgs=to_hold)
 
     if downgrade:
         cmd = [_yum(), '-y']

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1039,7 +1039,6 @@ def install(name=None,
     # information already in __context__ from the previous call to list_pkgs()
     old_as_list = list_pkgs(versions_as_list=True)
 
-
     to_install = []
     to_downgrade = []
     to_reinstall = []

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1275,6 +1275,7 @@ def installed(
                                               sources=sources,
                                               reinstall=bool(to_reinstall),
                                               normalize=normalize,
+                                              update_holds=update_holds,
                                               **kwargs)
 
             if os.path.isfile(rtag) and refresh:

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -637,6 +637,7 @@ def installed(
         normalize=True,
         ignore_epoch=False,
         reinstall=False,
+        update_holds=False,
         **kwargs):
     '''
     Ensure that the package is installed, and that it is the correct version
@@ -1017,9 +1018,20 @@ def installed(
 
     :param bool hold:
         Force the package to be held at the current installed version.
-        Currently works with YUM & APT based systems.
+        Currently works with YUM/DNF & APT based systems.
 
         .. versionadded:: 2014.7.0
+
+    :param bool update_holds:
+        If ``True``, and this function would update the package version, any
+        packages which are being held will be temporarily unheld so that they
+        can be updated. Otherwise, if this function attempts to update a held
+        package, the held package(s) will be skipped and the state will fail.
+        By default, this parameter is set to ``False``.
+
+        This option is currently supported only for YUM/DNF.
+
+        .. versionadded:: Carbon
 
     :param list names:
         A list of packages to install from a software repository. Each package
@@ -1161,18 +1173,18 @@ def installed(
 
                     if modified_hold:
                         for i in modified_hold:
-                            result['comment'] += ' {0}'.format(i['comment'])
+                            result['comment'] += '.\n{0}'.format(i['comment'])
                             result['result'] = i['result']
                             result['changes'][i['name']] = i['changes']
 
                     if not_modified_hold:
                         for i in not_modified_hold:
-                            result['comment'] += ' {0}'.format(i['comment'])
+                            result['comment'] += '.\n{0}'.format(i['comment'])
                             result['result'] = i['result']
 
                     if failed_hold:
                         for i in failed_hold:
-                            result['comment'] += ' {0}'.format(i['comment'])
+                            result['comment'] += '.\n{0}'.format(i['comment'])
                             result['result'] = i['result']
         return result
 


### PR DESCRIPTION
### What does this PR do?

Similar to #30777, now using yum salt will update/upgraded held packages.
### What issues does this PR fix or reference?
#31566
### Previous Behavior

``` bash
[root@salt ~]# yum versionlock list
Loaded plugins: fastestmirror, versionlock
0:epel-release-7-6.*
0:python-perf-3.10.0-327.18.2.el7.*
versionlock list done
```

``` bash
[root@salt ~]# yum list updates
Loaded plugins: fastestmirror, versionlock
Loading mirror speeds from cached hostfile
 * base: mirrors.dcarsat.com.ar
 * centosplus: centos.zeotec.cl
 * epel: mirror.globo.com
 * epel-debuginfo: epel.gtdinternet.com
 * epel-source: mirror.globo.com
 * epel-testing: mirror.globo.com
 * epel-testing-debuginfo: epel.gtdinternet.com
 * epel-testing-source: mirror.globo.com
 * extras: mirror.globo.com
 * fasttrack: mirrors.dcarsat.com.ar
 * updates: mirror.globo.com
```

``` yml
[root@salt ~]# cat /srv/salt/source.sls
epel-release:
  pkg.installed:
    - hold: True
    - version: 7-7

python-perf:
  pkg.installed:
    - hold: True
    - version: 3.10.0-327.18.2.el7.centos.plus
```

``` yml
[root@salt ~]# salt '*' state.apply source
salt:
----------
          ID: epel-release
    Function: pkg.installed
      Result: False
     Comment: Error occurred installing package(s). Additional info follows:

              errors:
                  - Loaded plugins: fastestmirror, versionlock
                    Loading mirror speeds from cached hostfile
                     * base: mirrors.dcarsat.com.ar
                     * centosplus: centos.zeotec.cl
                     * epel: mirror.globo.com
                     * epel-debuginfo: epel.gtdinternet.com
                     * epel-source: mirror.globo.com
                     * epel-testing: mirror.globo.com
                     * epel-testing-debuginfo: epel.gtdinternet.com
                     * epel-testing-source: mirror.globo.com
                     * extras: mirror.globo.com
                     * fasttrack: mirrors.dcarsat.com.ar
                     * updates: mirror.globo.com
                    No package epel-release-7-7 available.
                    Error: Nothing to do
     Started: 07:17:13.723757
    Duration: 2127.424 ms
     Changes:
----------
          ID: python-perf
    Function: pkg.installed
      Result: False
     Comment: Error occurred installing package(s). Additional info follows:

              errors:
                  - Loaded plugins: fastestmirror, versionlock
                    Loading mirror speeds from cached hostfile
                     * base: mirrors.dcarsat.com.ar
                     * centosplus: centos.zeotec.cl
                     * epel: mirror.globo.com
                     * epel-debuginfo: epel.gtdinternet.com
                     * epel-source: mirror.globo.com
                     * epel-testing: mirror.globo.com
                     * epel-testing-debuginfo: epel.gtdinternet.com
                     * epel-testing-source: mirror.globo.com
                     * extras: mirror.globo.com
                     * fasttrack: mirrors.dcarsat.com.ar
                     * updates: mirror.globo.com
                    No package python-perf-3.10.0-327.18.2.el7.centos.plus available.
                    Error: Nothing to do
     Started: 07:17:15.851417
    Duration: 1640.429 ms
     Changes:

Summary for salt
------------
Succeeded: 0
Failed:    2
------------
Total states run:     2
ERROR: Minions returned with non-zero exit code
```
### New Behavior

``` bash
[root@salt ~]# yum versionlock list
Loaded plugins: fastestmirror, versionlock
0:python-perf-3.10.0-327.13.1.el7.*
0:epel-release-7-5.*
versionlock list done
```

``` bash
[root@salt ~]# yum list updates
Loaded plugins: fastestmirror, versionlock
Loading mirror speeds from cached hostfile
 * base: mirrors.dcarsat.com.ar
 * centosplus: centos.zeotec.cl
 * epel: mirror.globo.com
 * epel-debuginfo: epel.gtdinternet.com
 * epel-source: mirror.globo.com
 * epel-testing: mirror.globo.com
 * epel-testing-debuginfo: epel.gtdinternet.com
 * epel-testing-source: mirror.globo.com
 * extras: mirror.globo.com
 * fasttrack: mirrors.dcarsat.com.ar
 * updates: mirror.globo.com
```

``` yml
[root@salt ~]# cat /srv/salt/source.sls
epel-release:
  pkg.installed:
    - hold: True
    - version: 7-7

python-perf:
  pkg.installed:
    - hold: True
    - version: 3.10.0-327.18.2.el7.centos.plus
```

```
[root@salt ~]# salt '*' state.apply source
salt:
----------
          ID: epel-release
    Function: pkg.installed
      Result: True
     Comment: The following packages were installed/updated: epel-release=7-7
              Package epel-release is already set to be held.
     Started: 07:10:04.251636
    Duration: 6363.53 ms
     Changes:
              ----------
              epel-release:
                  ----------
                  new:
                      7-7
                  old:
                      7-5
----------
          ID: python-perf
    Function: pkg.installed
      Result: True
     Comment: 1 targeted package was installed/updated.
              Package python-perf is already set to be held.
     Started: 07:10:10.636655
    Duration: 10925.828 ms
     Changes:
              ----------
              python-perf:
                  ----------
                  new:
                      3.10.0-327.18.2.el7.centos.plus
                  old:
                      3.10.0-327.13.1.el7

Summary for salt
------------
Succeeded: 2 (changed=2)
Failed:    0
------------
Total states run:     2
```
### Tests written?

No

@terminalmage sorry to bother, what probably you want to review this. Mostly because is not easy to handle lheld packages in yu, since in _targets_ when updating a single package,  package name contains version number to install and that didn't work  with versionlock.

Thanks.
