### PR TITLE
Do not use KillMode=process for salt-master

### DIFF
--- a/pkg/deb/salt-master.service
+++ b/pkg/deb/salt-master.service
@@ -8,7 +8,6 @@ LimitNOFILE=16384
 Type=simple
 NotifyAccess=all
 ExecStart=/usr/bin/salt-master
-KillMode=process
 Restart=$RESTART
 
 [Install]

--- a/pkg/salt-master.service
+++ b/pkg/salt-master.service
@@ -7,7 +7,6 @@ LimitNOFILE=16384
 Type=notify
 NotifyAccess=all
 ExecStart=/usr/bin/salt-master
-KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### What does this PR do?

It removes `KillMode=process` from the salt-master systemd unit file and will thereby fallback to the systemd default of `KillMode=control-group`.

https://www.freedesktop.org/software/systemd/man/systemd.kill.html discusses these options as:

```
KillMode=
Specifies how processes of this unit shall be killed. One of control-group, 
process, mixed, none.

If set to control-group, all remaining processes in the control group of 
this unit will bekilled on unit stop (for services: after the stop command
is executed, as configured with ExecStop=). If set to process, only the 
main process itself is killed. If set to mixed, the SIGTERM signal (see 
below) is sent to the main process while the subsequent SIGKILL signal
(see below) is sent to all remaining processes of the unit's control group.
If set to none, no process is killed. In this case, only the stop command
will be executed on unit stop, but no process be killed otherwise. 
Processes remaining alive after stop are left in their control group and the
control group continues to exist after stop unless it is empty.

Processes will first be terminated via SIGTERM (unless the signal 
to send is changed via KillSignal=). Optionally, this is immediately
followed by a SIGHUP (if enabled with SendSIGHUP=). Ifthen, after
a delay (configured via the TimeoutStopSec= option), processes still 
remain, thetermination request is repeated with the SIGKILL signal 
(unless this is disabled via the SendSIGKILL= option).

See kill(2) for more information.

Defaults to control-group.
```
### What issues does this PR fix or reference?

`KillMode=process` for salt-master was introduced in d288539 to fix #29295. That issue discusses the need to include 'KillMode=process' for the **salt-minion** on Debian systems.

The reason this was included for salt-minion in the first place was to ensure that it can upgrade itself and the approach taken was to _not_ terminate salt-minion child processes when the service is restarted. That way the salt-minion process that actually performs the upgrade can continue working, while the parent process has been "upgraded". This relies on the fact that salt-minion child processes are rather short lived.

The salt-master will never upgrade itself and you would typically want to terminate its child processes also when you stop the service. I am not sure why it was introduced to begin with as the referenced bug clearly discusses `salt-minion`.

It would be good to hear some opinions concerning `salt-api` where `KillMode=process` seems to have been adopted without discussion too. Unfortunately I am not yet too familiar with the salt-api codebase, so I can't decide which behaviour would be most appropriate.
