### PR TITLE
Log err msg when failed to hash a file

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -813,10 +813,10 @@ class LocalClient(Client):
         ret = {}
         try:
             path = self._check_proto(path)
-        except MinionError:
+        except MinionError, err:
             if not os.path.isfile(path):
-                err = 'Specified file {0} is not present to generate hash'
-                log.warning(err.format(path))
+                msg = 'specified file {0} is not present to generate hash: {1}'
+                log.warning(msg.format(path, err))
                 return ret
             else:
                 opts_hash_type = self.opts.get('hash_type', 'md5')
@@ -1097,10 +1097,10 @@ class RemoteClient(Client):
         '''
         try:
             path = self._check_proto(path)
-        except MinionError:
+        except MinionError, err:
             if not os.path.isfile(path):
-                err = 'Specified file {0} is not present to generate hash'
-                log.warning(err.format(path))
+                msg = 'specified file {0} is not present to generate hash: {1}'
+                log.warning(msg.format(path, err))
                 return {}
             else:
                 ret = {}

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -813,7 +813,7 @@ class LocalClient(Client):
         ret = {}
         try:
             path = self._check_proto(path)
-        except MinionError, err:
+        except MinionError as err:
             if not os.path.isfile(path):
                 msg = 'specified file {0} is not present to generate hash: {1}'
                 log.warning(msg.format(path, err))
@@ -1097,7 +1097,7 @@ class RemoteClient(Client):
         '''
         try:
             path = self._check_proto(path)
-        except MinionError, err:
+        except MinionError as err:
             if not os.path.isfile(path):
                 msg = 'specified file {0} is not present to generate hash: {1}'
                 log.warning(msg.format(path, err))


### PR DESCRIPTION
### What does this PR do?

Adds the error message that caused the fileclient to fail to hash a file, so that the user can diagnose the issue.
### Previous Behavior

The warning in the logs is misleading, making it sound like no attempt was made to get the file, and it just doesn't exist for some unknown reason.

```
$ salt-call cp.get_file s3://bucket/file-path /tmp/local-path
[WARNING ] specified file s3://bucket/file-path is not present to generate hash
```
### New Behavior

Now it indicates the reason that it's unable to hash the file. In this case, it's that s3 urls aren't supported (but it's helpful to know the reason whatever else it may be).

```
$ salt-call cp.get_file s3://bucket/file-path /tmp/local-path
[WARNING ] specified file s3://bucket/file-path is not present to generate hash: Unsupported path: s3://bucket/file-path
```
