### PR TITLE
for options method, always create it with api_key_required parameter …

### DIFF
--- a/salt/states/boto_apigateway.py
+++ b/salt/states/boto_apigateway.py
@@ -1504,7 +1504,10 @@ class _Swagger(object):
         '''
         method = self._parse_method_data(method_name.lower(), method_data)
 
-        # authorizationType is hard coded to 'NONE' for now.
+        # for options method to enable CORS, api_key_required will be set to False always.
+        if method_name.lower() == 'options':
+            api_key_required = False
+
         m = __salt__['boto_apigateway.create_api_method'](restApiId=self.restApiId,
                                                           resourcePath=resource_path,
                                                           httpMethod=method_name.upper(),


### PR DESCRIPTION
### What does this PR do?

when deploying a service with api key access enabled, we need to make sure the options method is not enabling the api key access to facilitate CORS support.
### What issues does this PR fix or reference?

NA
### Previous Behavior

the service after deployed to AWS apigateway, would yield 403 forbidden when trying to test a post method on a resource endpoint from the swagger online editor (mainly due to options method is not able to return the CORS headers due to the api key restriction)
### New Behavior

This is now fixed.
### Tests written?

No, manually tested against a live deployment to AWS apigateway.

…equaling False, otherwise CORS support will not work properly.
