### PR TITLE
Updated puppet module paths for agents >= 4.0.0

### DIFF
--- a/salt/modules/puppet.py
+++ b/salt/modules/puppet.py
@@ -5,6 +5,7 @@ Execute puppet routines
 
 # Import python libs
 from __future__ import absolute_import
+from distutils import version
 import logging
 import os
 import datetime
@@ -67,9 +68,14 @@ class _Puppet(object):
             self.useshell = True
         else:
             self.useshell = False
-            if 'Enterprise' in __salt__['cmd.run']('puppet --version'):
+            self.puppet_version = __salt__['cmd.run']('puppet --version')
+            if 'Enterprise' in self.puppet_version:
                 self.vardir = '/var/opt/lib/pe-puppet'
                 self.rundir = '/var/opt/run/pe-puppet'
+                self.confdir = '/etc/puppetlabs/puppet'
+            elif self.puppet_version != [] and version.StrictVersion(self.puppet_version) >= version.StrictVersion('4.0.0'):
+                self.vardir = '/opt/puppetlabs/puppet/cache'
+                self.rundir = '/var/run/puppetlabs'
                 self.confdir = '/etc/puppetlabs/puppet'
             else:
                 self.vardir = '/var/lib/puppet'


### PR DESCRIPTION
### What does this PR do?

Resubmit of https://github.com/saltstack/salt/pull/33798, this time with (hopefully) passing unit tests!

Open-source puppet (> v4.0) has a different directory structure.  This patch is meant to catch newer agents and reference proper config directories.

https://docs.puppet.com/puppet/4.0/reference/whered_it_go.html
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/33797
### Previous Behavior

Defaulted to 3.x directory paths
### New Behavior

Detects 4.x puppet agents and uses new default paths
### Tests written?

No
