### PR TITLE
Allow concurrent runs for state single

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -159,7 +159,7 @@ def _check_queue(queue, kwargs):
     if queue:
         _wait(kwargs.get('__pub_jid'))
     else:
-        conflict = running()
+        conflict = running(concurrent=kwargs.get('concurrent', False))
         if conflict:
             __context__['retcode'] = 1
             return conflict


### PR DESCRIPTION
### What does this PR do?

Enables usage of state.single and state.highstate with concurrent=True
### What issues does this PR fix or reference?

None
### Previous Behavior

The parameter was not used - this is somewhat surprising, since state.apply respects the concurrent param.
### New Behavior

Do not check for other jobs if concurrent is set to true
### Tests written?

No
