### PR TITLE
check status of random.org for tests

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -500,6 +500,11 @@ def query(url,
             ret['status'] = exc.code
             ret['error'] = str(exc)
             return ret
+        except socket.gaierror as exc:
+            if status is True:
+                ret['status'] = 0
+            ret['error'] = str(exc)
+            return ret
 
         if stream is True or handle is True:
             return {

--- a/tests/unit/modules/random_org_test.py
+++ b/tests/unit/modules/random_org_test.py
@@ -18,11 +18,21 @@ from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../')
 
 # Import Salt Libs
+import salt.utils.http
 from salt.modules import random_org
 
 random_org.__opts__ = {}
 
 
+def check_status():
+    '''
+    Check the status of random.org
+    '''
+    ret = salt.utils.http.query('https://api.random.org/', status=True)
+    return ret['status'] == 200
+
+
+@skipIf(not check_status(), 'random.org is not available')
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class RandomOrgTestCase(TestCase):
     '''


### PR DESCRIPTION
### What does this PR do?

Check status of random.org for tests.  Also except `socket.gaierror` in `salt.utils.http.query` when using tornado.
### What issues does this PR fix or reference?
### Previous Behavior

``` py
Traceback (most recent call last):
  File "/testing/tests/unit/modules/random_org_test.py", line 203, in test_generatedecimalfractions
    decimalPlaces=4, replacement=True), ret5)
  File "/testing/salt/modules/random_org.py", line 554, in generateDecimalFractions
    result = _query(api_version=api_version, data=data)
  File "/testing/salt/modules/random_org.py", line 110, in _query
    opts=__opts__,
  File "/testing/salt/utils/http.py", line 478, in query
    **req_kwargs
  File "/usr/lib64/python2.7/site-packages/tornado/httpclient.py", line 102, in fetch
    self._async_client.fetch, request, **kwargs))
  File "/usr/lib64/python2.7/site-packages/tornado/ioloop.py", line 453, in run_sync
    return future_cell[0].result()
  File "/usr/lib64/python2.7/site-packages/tornado/concurrent.py", line 232, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 3, in raise_exc_info
gaierror: [Errno -2] Name or service not known
```
### Tests written?

Yes
