### PR TITLE
Support salt.state orchestration in masterless mode

### DIFF
--- a/doc/topics/orchestrate/orchestrate_runner.rst
+++ b/doc/topics/orchestrate/orchestrate_runner.rst
@@ -69,6 +69,26 @@ apply the states defined in that file.
     with the :mod:`state.sls <salt.modules.state.sls>` execution function. In
     versions 0.17.0 through 2014.1.0, ``state.sls`` must be used.
 
+Masterless Orchestration
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: Carbon
+
+To support salt orchestration on masterless minions, the Orchestrate Runner is
+available as an execution module. The syntax for masterless orchestration is
+exactly the same, but it uses the ``salt-call`` command and the minion
+configuration must contain the ``file_mode: local`` option. Alternatively,
+use ``salt-call --local`` on the command line.
+
+.. code-block:: bash
+
+    salt-call --local state.orchestrate orch.webserver
+
+.. note::
+
+    Masterless orchestration supports only the ``salt.state`` command in an
+    sls file; it does not (currently) support the ``salt.function`` command.
+
 Examples
 ~~~~~~~~
 

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -67,8 +67,10 @@ def __virtual__():
     '''
     Set the virtualname
     '''
+    # Update global namespace with functions that are cloned in this module
     global _orchestrate
     _orchestrate = salt.utils.namespaced_function(_orchestrate, globals())
+
     return __virtualname__
 
 
@@ -127,7 +129,22 @@ def orchestrate(mods,
                 pillar=None,
                 pillarenv=None):
     '''
-    Execute the orchestrate runner
+    .. versionadded:: Carbon
+
+    Execute the orchestrate runner from a masterless minion.
+
+    .. seealso:: More Orchestrate documentation
+
+        * :ref:`Full Orchestrate Tutorial <orchestrate-runner>`
+        * :py:mod:`Docs for the ``salt`` state module <salt.states.saltmod>`
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt-call --local state.orchestrate webserver
+        salt-call --local state.orchestrate webserver saltenv=dev test=True
+        salt-call --local state.orchestrate webserver saltenv=dev pillarenv=aws
     '''
     return _orchestrate(mods=mods,
                         saltenv=saltenv,

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -32,6 +32,7 @@ import salt.utils
 import salt.utils.jid
 import salt.utils.url
 from salt.exceptions import SaltInvocationError
+from salt.runners.state import orchestrate as _orchestrate
 
 # Import 3rd-party libs
 import salt.ext.six as six
@@ -57,6 +58,18 @@ __func_alias__ = {
     'apply_': 'apply'
 }
 log = logging.getLogger(__name__)
+
+# Define the module's virtual name
+__virtualname__ = 'state'
+
+
+def __virtual__():
+    '''
+    Set the virtualname
+    '''
+    global _orchestrate
+    _orchestrate = salt.utils.namespaced_function(_orchestrate, globals())
+    return __virtualname__
 
 
 def _filter_running(runnings):
@@ -105,6 +118,23 @@ def _wait(jid):
     while states:
         time.sleep(1)
         states = _prior_running_states(jid)
+
+
+def orchestrate(mods,
+                saltenv='base',
+                test=None,
+                exclude=None,
+                pillar=None,
+                pillarenv=None):
+    '''
+    Execute the orchestrate runner
+    '''
+    return _orchestrate(mods=mods,
+                        saltenv=saltenv,
+                        test=test,
+                        exclude=exclude,
+                        pillar=pillar,
+                        pillarenv=pillarenv)
 
 
 def running(concurrent=False):

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -7,6 +7,15 @@ This state is intended for use from the Salt Master. It provides access to
 sending commands down to minions as well as access to executing master-side
 modules. These state functions wrap Salt's :ref:`Python API <python-api>`.
 
+    .. versionadded: Carbon
+
+    Support for masterless minions was added to the ``salt.state`` function,
+    so they can run orchestration sls files. This is particularly useful when
+    the rendering of a state is dependent on the execution of another state.
+    Orchestration will render and execute each orchestration block
+    independently, while honoring requisites to ensure the states are applied
+    in the correct order.
+
 .. seealso:: More Orchestrate documentation
 
     * :ref:`Full Orchestrate Tutorial <orchestrate-runner>`
@@ -67,6 +76,11 @@ def state(
 
     tgt
         The target specification for the state run.
+
+        .. versionadded: Carbon
+
+        Masterless support: When running on a masterless minion, the ``tgt``
+        is ignored and will always be the local minion.
 
     tgt_type | expr_form
         The target type to resolve, defaults to glob

--- a/tests/unit/states/saltmod_test.py
+++ b/tests/unit/states/saltmod_test.py
@@ -23,7 +23,7 @@ ensure_in_syspath('../../')
 # Import Salt Libs
 from salt.states import saltmod
 
-saltmod.__opts__ = {}
+saltmod.__opts__ = {'__role': 'master', 'file_client': 'remote'}
 saltmod.__salt__ = {'saltutil.cmd': MagicMock()}
 saltmod.__env__ = {}
 


### PR DESCRIPTION
### What does this PR do?
- Import the orchestrate runner as an execution module so it is available to masterless minions
- Add logic to the `salt.state` state function so that masterless minions are able to execute orchestration state files
### What issues does this PR fix or reference?

Fixes #33356
### Tests written?

No
