### PR TITLE
Allow socket closes when the socket is disconnected

### DIFF
--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -435,7 +435,7 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
             try:
                 self._socket.shutdown(socket.SHUT_RDWR)
             except socket.error as exc:
-                if socket.errno.ENOTCONN == 107:
+                if exc.errno == 107:
                     # We may try to shutdown a socket which is already disconnected.
                     # Ignore this condition and continue.
                     pass

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -432,7 +432,15 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
 
     def close(self):
         if self._socket is not None:
-            self._socket.shutdown(socket.SHUT_RDWR)
+            try:
+                self._socket.shutdown(socket.SHUT_RDWR)
+            except socket.error as exc:
+                if socket.errno.ENOTCONN == 107:
+                    # We may try to shutdown a socket which is already disconnected.
+                    # Ignore this condition and continue.
+                    pass
+                else:
+                    raise exc
             self._socket.close()
             self._socket = None
 

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -17,6 +17,7 @@ import weakref
 import urlparse  # TODO: remove
 import time
 import traceback
+import errno
 
 # Import Salt Libs
 import salt.crypt
@@ -435,7 +436,7 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
             try:
                 self._socket.shutdown(socket.SHUT_RDWR)
             except socket.error as exc:
-                if exc.errno == 107:
+                if exc.errno == errno.ENOTCONN:
                     # We may try to shutdown a socket which is already disconnected.
                     # Ignore this condition and continue.
                     pass


### PR DESCRIPTION
This prevents stacktraces when the master is signaled for a shutdown
but the sockets are already disconnected.

cc: @skizunov 

Closes #33843
