### PR TITLE
Fix naive fileserver map diff algorithm

### DIFF
--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -198,11 +198,15 @@ def diff_mtime_map(map1, map2):
     '''
     # check if the mtimes are the same
     if sorted(map1) != sorted(map2):
-        #log.debug('diff_mtime_map: the maps are different')
         return True
 
+    # map1 and map2 are guaranteed to have same keys,
+    # so compare mtimes
+    for filename, mtime in map1.iteritems():
+        if map2[filename] != mtime:
+            return True
+
     # we made it, that means we have no changes
-    #log.debug('diff_mtime_map: the maps are the same')
     return False
 
 

--- a/tests/unit/fileserver/map.py
+++ b/tests/unit/fileserver/map.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Joao Mesquita <jmesquita@sangoma.com>`
+'''
+
+# Import pytohn libs
+from __future__ import absolute_import
+
+# Import Salt Testing libs
+from salttesting import TestCase
+
+from salt import fileserver
+
+
+class MapDiffTestCase(TestCase):
+    def test_diff_with_diffent_keys(self):
+        '''
+        Test that different maps are indeed reported different
+        '''
+        map1 = {'file1': 1234}
+        map2 = {'file2': 1234}
+        assert fileserver.diff_mtime_map(map1, map2) is True
+
+    def test_diff_with_diffent_values(self):
+        '''
+        Test that different maps are indeed reported different
+        '''
+        map1 = {'file1': 12345}
+        map2 = {'file1': 1234}
+        assert fileserver.diff_mtime_map(map1, map2) is True


### PR DESCRIPTION
### What does this PR do?

Fixes fileserver map diffing algorithm
### Previous Behavior

Fired fileserver event  would say changed is False in case a file was modified and none was addded/removed.
### New Behavior

Changed flag is now correct on the event
### Tests written?

Yes

Naively comparing sorted dict keys does not guarantee that maps are equal. We
must compare mtimes for filenames in case keys are the same to make sure there
isnt a modified file.