### PR TITLE
Support additional eselect parameters.

### DIFF
--- a/salt/modules/eselect.py
+++ b/salt/modules/eselect.py
@@ -99,6 +99,8 @@ def get_target_list(module, action_parameter=None):
     action_parameter
         additional params passed to the defined action
 
+        .. versionadded:: Carbon
+
     CLI Example:
 
     .. code-block:: bash

--- a/salt/modules/eselect.py
+++ b/salt/modules/eselect.py
@@ -89,12 +89,15 @@ def get_modules():
     return modules
 
 
-def get_target_list(module):
+def get_target_list(module, action_parameter=None):
     '''
     List available targets for the given module.
 
     module
         name of the module to be queried for its targets
+
+    action_parameter
+        additional params passed to the defined action
 
     CLI Example:
 
@@ -102,7 +105,7 @@ def get_target_list(module):
 
         salt '*' eselect.get_target_list kernel
     '''
-    exec_output = exec_action(module, 'list')
+    exec_output = exec_action(module, 'list', action_parameter=action_parameter)
     if not exec_output:
         return None
 

--- a/salt/states/eselect.py
+++ b/salt/states/eselect.py
@@ -56,7 +56,7 @@ def set_(name, target, module_parameter=None, action_parameter=None):
         ret['comment'] = 'Target {0!r} is already set on {1!r} module.'.format(
             target, name
         )
-    elif target not in __salt__['eselect.get_target_list'](name):
+    elif target not in __salt__['eselect.get_target_list'](name, action_parameter=action_parameter):
         ret['comment'] = (
             'Target {0!r} is not available for {1!r} module.'.format(
                 target, name


### PR DESCRIPTION
### What does this PR do?

Allows action_parameter to be passed in to get_target_list in the eselect module.
Passes the action_parameter from the set command in the eselect state to get_target_list.
### What issues does this PR fix or reference?

The PHP eselect module requires an additional parameter to be passed in to list.
e.g. eselect php list cli

Other eselect modules that require an action_parameter, like java-vm, don't require any additional parameters for list. However, they seem to ignore it, so this change doesn't hurt any modules I tested.  
### Previous Behavior

The following config would always fail because the old code couldn't get a list of targets for PHP.

``` sls
php:
  eselect.set:
    - target: php7.0
    - action_parameter: cli
```
### New Behavior

The above config now properly sets the PHP version.
### Tests written?

No
