### PR TITLE
fix import

### DIFF
--- a/salt/utils/dns.py
+++ b/salt/utils/dns.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
+
 import itertools  # pylint: disable=W0403
 
 import salt.utils.network


### PR DESCRIPTION
### What does this PR do?

it fixes the import of the itertools module in the `utils/dns.py`, as itertools.py does also exist in utils/ (and I think Salt shouldn't name modules the same as stdlib modules)
### Tests written?

No
