### PR TITLE
pkg.uptodate: Pass kwargs to pkg.list_upgrades

### DIFF
--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -332,7 +332,7 @@ def install(name=None, pkgs=None, taps=None, options=None, **kwargs):
     return salt.utils.compare_dicts(old, new)
 
 
-def list_upgrades(refresh=True):
+def list_upgrades(refresh=True, **kwargs):  # pylint: disable=W0613
     '''
     Check whether or not an upgrade is available for all packages
 
@@ -348,14 +348,12 @@ def list_upgrades(refresh=True):
     cmd = 'brew outdated'
     call = _call_brew(cmd)
     if call['retcode'] != 0:
-        comment = ''
-        if 'stderr' in call:
-            comment += call['stderr']
-        if 'stdout' in call:
-            comment += call['stdout']
-        raise CommandExecutionError(
-            '{0}'.format(comment)
-        )
+        msg = 'Failed to get upgrades'
+        for key in ('stderr', 'stdout'):
+            if call[key]:
+                msg += ': ' + call[key]
+                break
+        raise CommandExecutionError(msg)
     else:
         out = call['stdout']
     return out.splitlines()

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -266,14 +266,12 @@ def _get_upgradable():
     call = __salt__['cmd.run_all'](cmd, output_loglevel='trace')
 
     if call['retcode'] != 0:
-        comment = ''
-        if 'stderr' in call:
-            comment += call['stderr']
-        if 'stdout' in call:
-            comment += call['stdout']
-        raise CommandExecutionError(
-            '{0}'.format(comment)
-        )
+        msg = 'Failed to get upgrades'
+        for key in ('stderr', 'stdout'):
+            if call[key]:
+                msg += ': ' + call[key]
+                break
+        raise CommandExecutionError(msg)
     else:
         out = call['stdout']
 
@@ -296,7 +294,7 @@ def _get_upgradable():
     return ret
 
 
-def list_upgrades(refresh=True):
+def list_upgrades(refresh=True, **kwargs):  # pylint: disable=W0613
     '''
     List all available package upgrades.
 

--- a/salt/modules/macports.py
+++ b/salt/modules/macports.py
@@ -329,7 +329,7 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
     return salt.utils.compare_dicts(old, new)
 
 
-def list_upgrades(refresh=True):
+def list_upgrades(refresh=True, **kwargs):  # pylint: disable=W0613
     '''
     Check whether or not an upgrade is available for all packages
 

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -116,7 +116,7 @@ def upgrade_available(name):
     return latest_version(name) != ''
 
 
-def list_upgrades(refresh=False):
+def list_upgrades(refresh=False, **kwargs):  # pylint: disable=W0613
     '''
     List all available package upgrades on this system
 
@@ -127,14 +127,14 @@ def list_upgrades(refresh=False):
         salt '*' pkg.list_upgrades
     '''
     upgrades = {}
-    options = ['-S', '-p', '-u', '--print-format "%n %v"']
+    cmd = ['pacman', '-S', '-p', '-u', '--print-format', '%n %v']
 
     if refresh:
-        options.append('-y')
+        cmd.append('-y')
 
-    cmd = ('pacman {0}').format(' '.join(options))
-
-    call = __salt__['cmd.run_all'](cmd, output_loglevel='trace')
+    call = __salt__['cmd.run_all'](cmd,
+                                   python_shell=False,
+                                   output_loglevel='trace')
 
     if call['retcode'] != 0:
         comment = ''
@@ -148,7 +148,7 @@ def list_upgrades(refresh=False):
     else:
         out = call['stdout']
 
-    for line in iter(out.splitlines()):
+    for line in out.splitlines():
         comps = line.split(' ')
         if len(comps) != 2:
             continue

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -65,7 +65,7 @@ def upgrade_available(name):
     return ''
 
 
-def list_upgrades(refresh=True):
+def list_upgrades(refresh=True, **kwargs):  # pylint: disable=W0613
     '''
     List all available package upgrades on this system
 

--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -122,12 +122,19 @@ def upgrade_available(name):
     return ret
 
 
-def list_upgrades(refresh=False):
+def list_upgrades(refresh=False, **kwargs):  # pylint: disable=W0613
     '''
     Lists all packages available for update.
-    When run in global zone, it reports only upgradable packages for the global zone.
-    When run in non-global zone, it can report more upgradable packages than "pkg update -vn" because "pkg update" hides packages that require newer version of pkg://solaris/entire (which means that they can be upgraded only from global zone). Simply said: if you see pkg://solaris/entire in the list of upgrades, you should upgrade the global zone to get all possible updates.
-    You can force full pkg DB refresh before listing.
+
+    When run in global zone, it reports only upgradable packages for the global
+    zone.
+
+    When run in non-global zone, it can report more upgradable packages than
+    ``pkg update -vn``, because ``pkg update`` hides packages that require
+    newer version of ``pkg://solaris/entire`` (which means that they can be
+    upgraded only from the global zone). If ``pkg://solaris/entire`` is found
+    in the list of upgrades, then the global zone should be updated to get all
+    possible updates. Use ``refresh=True`` to refresh the package database.
 
     CLI Example::
 

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -133,7 +133,7 @@ def upgrade_available(name):
     return latest_version(name) != ''
 
 
-def list_upgrades(refresh=True):
+def list_upgrades(refresh=True, **kwargs):  # pylint: disable=W0613
     '''
     List all available package upgrades on this system
 

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1637,14 +1637,19 @@ def uptodate(name, refresh=False, **kwargs):
         ret['comment'] = 'State pkg.uptodate is not available'
         return ret
 
+    # emerge --update doesn't appear to support repo notation
+    if 'fromrepo' in kwargs and __grains__['os'] == 'Gentoo':
+        ret['comment'] = '\'fromrepo\' argument not supported on this platform'
+        return ret
+
     if isinstance(refresh, bool):
         try:
-            packages = __salt__['pkg.list_upgrades'](refresh=refresh)
+            packages = __salt__['pkg.list_upgrades'](refresh=refresh, **kwargs)
         except Exception as e:
             ret['comment'] = str(e)
             return ret
     else:
-        ret['comment'] = 'refresh must be a boolean.'
+        ret['comment'] = 'refresh must be either True or False'
         return ret
 
     if not packages:


### PR DESCRIPTION
This resolves an edge case in which the "fromrepo" argument is passed to
the pkg.uptodate state. We pass through the kwargs to pkg.upgrade, but do
not pass the same kwargs to list_upgrades, resulting in inconsistent
results.
