### PR TITLE
Pass through "greedy" parameter rather than hard-coded "True"

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -527,7 +527,7 @@ class CkMinions(object):
                     engine_args = [target_info['pattern']]
                     if target_info['engine'] in ('G', 'P', 'I', 'J'):
                         engine_args.append(target_info['delimiter'] or ':')
-                    engine_args.append(True)
+                    engine_args.append(greedy)
 
                     results.append(str(set(engine(*engine_args))))
                     if unmatched and unmatched[-1] == '-':


### PR DESCRIPTION
### What does this PR do?

Propagates `greedy` parameter to `CkMinions._check_compound_minions()`
### What issues does this PR fix or reference?
#33730
### Previous Behavior

`greedy` parameter passed to matching engine was always hard-coded as `True`
### New Behavior

`greedy` is propagated from `CkMinions._check_compound_minions()` to the matching engines.
### Tests written?

No
