### PR TITLE
random.org checks

### DIFF
--- a/salt/modules/random_org.py
+++ b/salt/modules/random_org.py
@@ -120,7 +120,7 @@ def _query(api_version=None, data=None):
     elif result.get('status', None) == salt.ext.six.moves.http_client.NO_CONTENT:
         return False
     else:
-        ret['message'] = result.text
+        ret['message'] = result.text if hasattr(result, 'text') else ''
         return ret
 
 

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -500,6 +500,11 @@ def query(url,
             ret['status'] = exc.code
             ret['error'] = str(exc)
             return ret
+        except socket.gaierror as exc:
+            if status is True:
+                ret['status'] = 0
+            ret['error'] = str(exc)
+            return ret
 
         if stream is True or handle is True:
             return {

--- a/tests/unit/modules/random_org_test.py
+++ b/tests/unit/modules/random_org_test.py
@@ -18,11 +18,21 @@ from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../')
 
 # Import Salt Libs
+import salt.utils.http
 from salt.modules import random_org
 
 random_org.__opts__ = {}
 
 
+def check_status():
+    '''
+    Check the status of random.org
+    '''
+    ret = salt.utils.http.query('https://api.random.org/', status=True)
+    return ret['status'] == 200
+
+
+@skipIf(not check_status(), 'random.org is not available')
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class RandomOrgTestCase(TestCase):
     '''


### PR DESCRIPTION
### What does this PR do?
- Conditionally skip random.org exec module tests if random.org is unavailable.
- Except `socket.gaierror` in `salt.utils.http.query` when using tornado.
- `salt.modules.random_org._query`: return message only if it exists.
### What issues does this PR fix or reference?
### Tests written?

Yes
