### PR TITLE
Don't deep copy context dict values.

### DIFF
--- a/salt/utils/context.py
+++ b/salt/utils/context.py
@@ -134,7 +134,7 @@ class ChildContextDict(collections.MutableMapping):
         # merge self.global_data into self._data
         for k, v in self.parent.global_data.iteritems():
             if k not in self._data:
-                self._data[k] = copy.deepcopy(v)
+                self._data[k] = v
 
     def __setitem__(self, key, val):
         self._data[key] = val


### PR DESCRIPTION
### What does this PR do?

This highly speeds up the salt minion.

I'm not sure this is safe but in the same time I found no reason to deep copy context dict values that could be not the only generic python objects but also salt objects like cached connections.

If this will break something, we should reimplement the fix #31164 to find another way to  keep returns through state execution, for instance keep the only needed values ('return').
### What issues does this PR fix or reference?
#33575
### Tests written?

No
