### PR TITLE
Document sudo policy for gitfs post-recieve hook

### DIFF
--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -767,7 +767,15 @@ steps to this process:
 
        #!/usr/bin/env sh
 
-       salt-call event.fire_master update salt/fileserver/gitfs/update
+       sudo -u root salt-call event.fire_master update salt/fileserver/gitfs/update
+
+4. On the git server, add the following policy to the sudoers file:
+
+   .. code-block::
+
+       Cmnd_Alias SALT_GIT_HOOK = /bin/salt-call event.fire_master update salt/fileserver/gitfs/update
+       Defaults!SALT_GIT_HOOK !requiretty
+       ALL ALL=(ALL) NOPASSWD: SALT_GIT_HOOK
 
 The ``update`` argument right after :mod:`event.fire_master
 <salt.modules.event.fire_master>` in this example can really be anything, as it


### PR DESCRIPTION
### What does this PR do?

Update documentation for creating a git hook to update gitfs.
### What issues does this PR fix or reference?

Because the hook is run as the user performing the push,
salt-call will typically fail.
### Previous Behavior

Git pushes not done by root would fail to run the git
post-receive hook
### New Behavior

Updates the documentation to use sudo for salt-call, and provides 
a sudo policy that permits any user to run the post-recieve hook.
### Tests written?

No
