### PR TITLE
Fetching grains['os'] from /etc/os-release on SUSE systems if it is possible

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1285,9 +1285,7 @@ def os_data():
                     if 'PRETTY_NAME' in os_release:
                         grains['lsb_distrib_codename'] = os_release['PRETTY_NAME']
                     if 'CPE_NAME' in os_release:
-                        if ":suse:" in os_release['CPE_NAME']:
-                            grains['os'] = "SUSE"
-                        elif ":opensuse:" in os_release['CPE_NAME']:
+                        if ":suse:" in os_release['CPE_NAME'] or ":opensuse:" in os_release['CPE_NAME']:
                             grains['os'] = "SUSE"
                 elif os.path.isfile('/etc/SuSE-release'):
                     grains['lsb_distrib_id'] = 'SUSE'

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1284,6 +1284,11 @@ def os_data():
                         grains['lsb_distrib_release'] = os_release['VERSION_ID']
                     if 'PRETTY_NAME' in os_release:
                         grains['lsb_distrib_codename'] = os_release['PRETTY_NAME']
+                    if 'CPE_NAME' in os_release:
+                        if ":suse:" in os_release['CPE_NAME']:
+                            grains['os'] = "SUSE"
+                        elif ":opensuse:" in os_release['CPE_NAME']:
+                            grains['os'] = "SUSE"
                 elif os.path.isfile('/etc/SuSE-release'):
                     grains['lsb_distrib_id'] = 'SUSE'
                     version = ''
@@ -1391,7 +1396,8 @@ def os_data():
         shortname = distroname.replace(' ', '').lower()[:10]
         # this maps the long names from the /etc/DISTRO-release files to the
         # traditional short names that Salt has used.
-        grains['os'] = _OS_NAME_MAP.get(shortname, distroname)
+        if 'os' not in grains:
+            grains['os'] = _OS_NAME_MAP.get(shortname, distroname)
         grains.update(_linux_cpudata())
         grains.update(_linux_gpu_data())
     elif grains['kernel'] == 'SunOS':

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1038,6 +1038,7 @@ _OS_FAMILY_MAP = {
     'SUSE': 'SUSE',
     'openSUSE Leap': 'SUSE',
     'openSUSE Tumbleweed': 'SUSE',
+    'SLES_SAP': 'SUSE',
     'Solaris': 'Solaris',
     'SmartOS': 'Solaris',
     'OpenIndiana Development': 'Solaris',

--- a/tests/unit/grains/core_test.py
+++ b/tests/unit/grains/core_test.py
@@ -119,7 +119,6 @@ class CoreGrainsTestCase(TestCase):
 
         self.assertEqual(os_grains.get('os_family'), 'Debian')
 
-
     @skipIf(not salt.utils.is_linux(), 'System is not Linux')
     def test_suse_os_from_cpe_data(self):
         '''

--- a/tests/unit/grains/core_test.py
+++ b/tests/unit/grains/core_test.py
@@ -165,7 +165,9 @@ class CoreGrainsTestCase(TestCase):
                             with patch.object(platform, 'linux_distribution', distro_mock):
                                 with patch.object(core, '_linux_gpu_data', empty_mock):
                                     with patch.object(core, '_virtual', empty_mock):
-                                        os_grains = core.os_data()
+                                        # Mock the osarch
+                                        with patch.dict(core.__salt__, {'cmd.run': "amd64"}):
+                                            os_grains = core.os_data()
 
         self.assertEqual(os_grains.get('os_family'), 'SUSE')
         self.assertEqual(os_grains.get('os'), 'SUSE')

--- a/tests/unit/grains/core_test.py
+++ b/tests/unit/grains/core_test.py
@@ -136,6 +136,7 @@ class CoreGrainsTestCase(TestCase):
             side_effect=lambda x: _path_isfile_map.get(x, False)
         )
         empty_mock = MagicMock(return_value={})
+        osarch_mock = MagicMock(return_value="amd64")
 
         orig_import = __import__
 
@@ -166,7 +167,7 @@ class CoreGrainsTestCase(TestCase):
                                 with patch.object(core, '_linux_gpu_data', empty_mock):
                                     with patch.object(core, '_virtual', empty_mock):
                                         # Mock the osarch
-                                        with patch.dict(core.__salt__, {'cmd.run': "amd64"}):
+                                        with patch.dict(core.__salt__, {'cmd.run': osarch_mock}):
                                             os_grains = core.os_data()
 
         self.assertEqual(os_grains.get('os_family'), 'SUSE')


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug solved for one of our customers which uses `SUSE SLES SAP` systems. It also defines a new rule to get the `grains['os']` in SUSE family systems.

Currently, Salt uses the `_OS_FAMILY_MAP` to get the `grains['os_family']` based on `grains['os']` grain, but it implies that we have to keep the map updated for all the possible `osname` for SUSE products.

So we propose to try to use the `CPE_NAME` information contained in `/etc/os-release` in order to know if it's a SUSE product and also to set the `grains['os'] == "SUSE"`
### Tests written?

Yes

/cc @isbm
