### PR TITLE
Archive unzip permissions

### DIFF
--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -465,7 +465,7 @@ def cmd_unzip(zip_file, dest, excludes=None,
 
 
 def unzip(zip_file, dest, excludes=None, options=None, template=None,
-          runas=None, trim_output=False, password=None, extract_perms = False):
+          runas=None, trim_output=False, password=None, extract_perms=False):
     '''
     Uses the ``zipfile`` Python module to unpack zip files
 

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -524,6 +524,9 @@ def unzip(zip_file, dest, excludes=None, options=None, template=None,
         Setting this flag will attempt to apply the file permision attributes to the
         extracted files/folders.
 
+        On Windows, only the read-only flag will be extracted as set within the zip file,
+        other attributes (i.e. user/group permissions) are ignored.
+
         .. versionadded:: Carbon
 
     CLI Example:

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -520,8 +520,9 @@ def unzip(zip_file, dest, excludes=None, options=None, template=None,
         .. versionadded:: 2016.3.0
 
     extract_perms: False
-        Set the permissions of the extracted files to match those stored in the
-        attributes of the file within the archive.
+        The python zipfile module does not extract file/directory attributes by default.
+        Setting this flag will attempt to apply the file permision attributes to the
+        extracted files/folders.
 
         .. versionadded:: Carbon
 

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -465,7 +465,7 @@ def cmd_unzip(zip_file, dest, excludes=None,
 
 
 def unzip(zip_file, dest, excludes=None, options=None, template=None,
-          runas=None, trim_output=False, password=None):
+          runas=None, trim_output=False, password=None, extract_perms = False):
     '''
     Uses the ``zipfile`` Python module to unpack zip files
 
@@ -519,6 +519,12 @@ def unzip(zip_file, dest, excludes=None, options=None, template=None,
 
         .. versionadded:: 2016.3.0
 
+    extract_perms: False
+        Set the permissions of the extracted files to match those stored in the
+        attributes of the file within the archive.
+
+        .. versionadded:: Carbon
+
     CLI Example:
 
     .. code-block:: bash
@@ -571,6 +577,8 @@ def unzip(zip_file, dest, excludes=None, options=None, template=None,
                             os.symlink(source, os.path.join(dest, target))
                             continue
                     zfile.extract(target, dest, password)
+                    if extract_perms:
+                        os.chmod(os.path.join(dest, target), zfile.getinfo(target).external_attr >> 16)
     except Exception as exc:
         pass
     finally:

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -78,6 +78,7 @@ def extracted(name,
               keep=False,
               trim_output=False,
               source_hash_update=None,
+              use_cmd_unzip=False,
               **kwargs):
     '''
     .. versionadded:: 2014.1.0
@@ -213,6 +214,11 @@ def extracted(name,
 
         .. versionadded:: 2016.3.0
 
+    use_cmd_unzip
+        When archive_format is zip, setting this flag to True will use the archive.cmd_unzip module function
+
+        .. versionadded:: Boron
+
     kwargs
         kwargs to pass to the archive.unzip or archive.unrar function
 
@@ -320,7 +326,10 @@ def extracted(name,
 
     log.debug('Extracting {0} to {1}'.format(filename, name))
     if archive_format == 'zip':
-        files = __salt__['archive.unzip'](filename, name, options=zip_options, trim_output=trim_output, password=password, **kwargs)
+        if use_cmd_unzip:
+            files = __salt__['archive.cmd_unzip'](filename, name, options=zip_options, trim_output=trim_output, **kwargs)
+        else:
+            files = __salt__['archive.unzip'](filename, name, options=zip_options, trim_output=trim_output, password=password, **kwargs)
     elif archive_format == 'rar':
         files = __salt__['archive.unrar'](filename, name, trim_output=trim_output, **kwargs)
     else:

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -77,7 +77,8 @@ def extracted(name,
               if_missing=None,
               keep=False,
               trim_output=False,
-              source_hash_update=None):
+              source_hash_update=None,
+              **kwargs):
     '''
     .. versionadded:: 2014.1.0
 
@@ -211,6 +212,11 @@ def extracted(name,
         trimmed, if this is set to True then it will default to 100
 
         .. versionadded:: 2016.3.0
+
+    kwargs
+        kwargs to pass to the archive.unzip or archive.unrar function
+
+        .. versionadded:: Boron
     '''
     ret = {'name': name, 'result': None, 'changes': {}, 'comment': ''}
     valid_archives = ('tar', 'rar', 'zip')
@@ -314,9 +320,9 @@ def extracted(name,
 
     log.debug('Extracting {0} to {1}'.format(filename, name))
     if archive_format == 'zip':
-        files = __salt__['archive.unzip'](filename, name, options=zip_options, trim_output=trim_output, password=password)
+        files = __salt__['archive.unzip'](filename, name, options=zip_options, trim_output=trim_output, password=password, **kwargs)
     elif archive_format == 'rar':
-        files = __salt__['archive.unrar'](filename, name, trim_output=trim_output)
+        files = __salt__['archive.unrar'](filename, name, trim_output=trim_output, **kwargs)
     else:
         if tar_options is None:
             with closing(tarfile.open(filename, 'r')) as tar:


### PR DESCRIPTION
### What does this PR do?

Add two methods for preserving file/directory permissions of files/folders in a ZIP file when extracted by the archive.extracted state and ability to preserver permissions when using the archive.unzip execution module
### What issues does this PR fix or reference?
#27207
### Previous Behavior

The archive.extracted state and archive.unzip execution module did not preserve permissions of the files/folders in the zip file when extracted
### New Behavior

File permissions can be extracted/preserved:
When using the archive.unzip execution module, the extract_perms parameter can be set to True to set the file permission attributes.
When using the archive.extracted state:
The extract_perms parameter can be set to True to set the file permissions.
Alternatively, the use_cmd_unzip parameter can be set to True to use the archive.cmd_unzip function (the unzip command will preserve permission attributes by default)
### Tests written?

No
