### PR TITLE
[boto_lambda] handle ommitted Permissions parameter

### DIFF
--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -477,7 +477,7 @@ def remove_permission(FunctionName, StatementId, Qualifier=None,
 
 
 def get_permissions(FunctionName, Qualifier=None,
-                   region=None, key=None, keyid=None, profile=None):
+                    region=None, key=None, keyid=None, profile=None):
     '''
     Get resource permissions for the given lambda function
 

--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -369,7 +369,7 @@ def _function_permissions_present(FunctionName, Permissions,
     curr_permissions = __salt__['boto_lambda.get_permissions'](FunctionName,
            region=region, key=key, keyid=keyid, profile=profile)['permissions']
     need_update = False
-    diffs = salt.utils.compare_dicts(curr_permissions, Permissions)
+    diffs = salt.utils.compare_dicts(curr_permissions, Permissions or {})
     if bool(diffs):
         ret['comment'] = os.linesep.join([ret['comment'], 'Function permissions to be modified'])
         if __opts__['test']:

--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -184,7 +184,7 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S
                 raise SaltInvocationError('Invalid permission value {0}'.format(', '.join(keyset)))
 
     r = __salt__['boto_lambda.function_exists'](FunctionName=FunctionName, region=region,
-                                    key=key, keyid=keyid, profile=profile)
+                                                key=key, keyid=keyid, profile=profile)
 
     if 'error' in r:
         ret['result'] = False
@@ -234,7 +234,7 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S
     ret['changes'] = {}
     # function exists, ensure config matches
     _ret = _function_config_present(FunctionName, Role, Handler, Description, Timeout,
-                                  MemorySize, region, key, keyid, profile)
+                                    MemorySize, region, key, keyid, profile)
     if not _ret.get('result'):
         ret['result'] = False
         ret['comment'] = _ret['comment']
@@ -243,7 +243,7 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S
     ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
     _ret = _function_code_present(FunctionName, ZipFile, S3Bucket, S3Key, S3ObjectVersion,
-                                 region, key, keyid, profile)
+                                  region, key, keyid, profile)
     if not _ret.get('result'):
         ret['result'] = False
         ret['comment'] = _ret['comment']
@@ -252,7 +252,7 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S
     ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
     _ret = _function_permissions_present(FunctionName, Permissions,
-                                 region, key, keyid, profile)
+                                         region, key, keyid, profile)
     if not _ret.get('result'):
         ret['result'] = False
         ret['comment'] = _ret['comment']
@@ -364,7 +364,7 @@ def _function_code_present(FunctionName, ZipFile, S3Bucket, S3Key, S3ObjectVersi
 
 
 def _function_permissions_present(FunctionName, Permissions,
-                           region, key, keyid, profile):
+                                  region, key, keyid, profile):
     ret = {'result': True, 'comment': '', 'changes': {}}
     curr_permissions = __salt__['boto_lambda.get_permissions'](FunctionName,
            region=region, key=key, keyid=keyid, profile=profile)['permissions']


### PR DESCRIPTION
### What does this PR do?

If `Permissions` parameter was ommited but actual lambda function defines `Permissions`,
the state would fail attempting to compare old and new values.

```
An exception occurred in this state: Traceback (most recent call last):
File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1703, in call
    **cdata['kwargs'])
File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1649, in wrapper
    return f(*args, **kwargs)
File "/usr/lib/python2.7/dist-packages/salt/states/boto_lambda.py", line 255, in function_present
    region, key, keyid, profile)
File "/usr/lib/python2.7/dist-packages/salt/states/boto_lambda.py", line 372, in _function_permissions_present
    diffs = salt.utils.compare_dicts(curr_permissions, Permissions)
File "/usr/lib/python2.7/dist-packages/salt/utils/__init__.py", line 2355, in compare_dicts
    elif key not in new:
TypeError: argument of type 'NoneType' is not iterable
```
### What issues does this PR fix or reference?

none
### Tests written?

Yes
