### PR TITLE
fix formulas map.jinja example when using default values

### DIFF
--- a/doc/topics/development/conventions/formulas.rst
+++ b/doc/topics/development/conventions/formulas.rst
@@ -798,7 +798,7 @@ Collecting common values
 Common values can be collected into a *base* dictionary.  This
 minimizes repetition of identical values in each of the
 ``lookup_dict`` sub-dictionaries.  Now only the values that are
-different from the base must be specified of the alternates:
+different from the base must be specified by the alternates:
 
 :file:`map.jinja`:
 
@@ -826,7 +826,7 @@ different from the base must be specified of the alternates:
             'python': 'dev-python/mysql-python',
         },
     },
-    merge=salt['pillar.get']('mysql:lookup', default='default') %}
+    merge=salt['pillar.get']('mysql:lookup'), base='default') %}
 
 
 Overriding values in the lookup table


### PR DESCRIPTION
### What does this PR do?

Fix `map.jinja` example in formulas conventions - [collecting-common-values](https://github.com/saltstack/salt/blob/e9da85ba91ed84c37df050f73d7d766f57504521/doc/topics/development/conventions/formulas.rst#collecting-common-values).

The previous example had a syntax error and didn't accomplish what it set out to do: under e.g. RedHat it would lead to `Rendering SLS '...' failed: Jinja variable 'dict object' has no attribute 'server'`.
### What issues does this PR fix or reference?

None
### Tests written?

No
