### PR TITLE
Remove KillMode=process from salt-api unit file

### DIFF
--- a/pkg/deb/salt-api.service
+++ b/pkg/deb/salt-api.service
@@ -8,7 +8,6 @@ LimitNOFILE=8192
 Type=simple
 NotifyAccess=all
 ExecStart=/usr/bin/salt-api
-KillMode=process
 Restart=$RESTART
 
 [Install]


### PR DESCRIPTION
### What does this PR do?

It removes `KillMode=process` from salt-api unit files as well. Please see #33792 for a discussion of this feature and background to this change.
