### PR TITLE
Cmd filter

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -1485,6 +1485,53 @@ this can be set to ``True``.
 
     always_verify_signature: True
 
+.. conf_minion:: cmd_blacklist_glob
+
+``cmd_blacklist_glob``
+----------------------
+
+Default: ``[]``
+
+If :conf_minion:`cmd_blacklist_glob` is enabled then any shell command called over
+remote execution or via salt-call will be checked against the glob matches found in
+the `cmd_blacklist_glob` list and any matched shell command will be blocked.
+
+.. note::
+
+    This blacklist is only applied to direct executions made by the `salt` and
+    `salt-call` commands. This does NOT blacklist commands called from states
+    or shell commands executed from other modules.
+
+.. code-block:: yaml
+
+    cmd_blacklist_glob:
+      - 'rm * '
+      - 'cat /etc/* '
+
+.. conf_minion:: cmd_whitelist_glob
+
+``cmd_whitelist_glob``
+----------------------
+
+Default: ``[]``
+
+If :conf_minion:`cmd_whitelist_glob` is enabled then any shell command called over
+remote execution or via salt-call will be checked against the glob matches found in
+the `cmd_whitelist_glob` list and any shell command NOT found in the list will be
+blocked. If `cmd_whitelist_glob` is NOT SET, then all shell commands are permitted.
+
+.. note::
+
+    This whitelist is only applied to direct executions made by the `salt` and
+    `salt-call` commands. This does NOT restrict commands called from states
+    or shell commands executed from other modules.
+
+.. code-block:: yaml
+
+    cmd_whitelist_glob:
+      - 'ls * '
+      - 'cat /etc/fstab'
+
 
 Thread Settings
 ===============

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -1502,6 +1502,8 @@ the `cmd_blacklist_glob` list and any matched shell command will be blocked.
     `salt-call` commands. This does NOT blacklist commands called from states
     or shell commands executed from other modules.
 
+.. versionadded:: Carbon
+
 .. code-block:: yaml
 
     cmd_blacklist_glob:
@@ -1525,6 +1527,8 @@ blocked. If `cmd_whitelist_glob` is NOT SET, then all shell commands are permitt
     This whitelist is only applied to direct executions made by the `salt` and
     `salt-call` commands. This does NOT restrict commands called from states
     or shell commands executed from other modules.
+
+.. versionadded:: Carbon
 
 .. code-block:: yaml
 

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -222,7 +222,7 @@ def _check_avail(cmd):
     '''
     bret = True
     wret = False
-    if __salt__['config.get']('cmd_blacklist_glob', []):
+    if __salt__['config.get']('cmd_blacklist_glob'):
         blist = __salt__['config.get']('cmd_blacklist_glob', [])
         for comp in blist:
             if fnmatch.fnmatch(cmd, comp):
@@ -271,6 +271,8 @@ def _run(cmd,
     '''
     Do the DRY thing and only call subprocess.Popen() once
     '''
+    if 'pillar' in kwargs and not pillar_override:
+        pillar_override = kwargs['pillar']
     if _is_valid_shell(shell) is False:
         log.warning(
             'Attempt to run a shell command with what may be an invalid shell! '


### PR DESCRIPTION
### What does this PR do?

Allows us to set blacklists and whitelists in the minion config (or pillar) to restrict remote execution or salt-call from running certain shell commands
### What issues does this PR fix or reference?
#22558
### Tests written?

No, this does seriously need tests
