### PR TITLE
ssh: keep original permissions, when hashing known_hosts

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -1175,8 +1175,10 @@ def hash_known_hosts(user=None, config=None):
     if not os.path.isfile(full):
         return {'status': 'error',
                 'error': 'Known hosts file {0} does not exist'.format(full)}
+    origmode = os.stat(full).st_mode
     cmd = ['ssh-keygen', '-H', '-f', full]
     cmd_result = __salt__['cmd.run'](cmd, python_shell=False)
+    os.stat(full, origmode)
     # ssh-keygen creates a new file, thus a chown is required.
     if os.geteuid() == 0 and user:
         uinfo = __salt__['user.info'](user)


### PR DESCRIPTION
### What does this PR do?

sets the original file permission on ssh known_hosts files after hashing them with ssh-keygen
### What issues does this PR fix or reference?
#33932
### Previous Behavior

Adding public keys to the global SSH known_hosts file (/etc/ssh/ssh_known_hosts) with hashing (default) resulted in an ssh_known_hosts file, which was only readable by root, because ssh-keygen, which does the hashing sets it's umask to 077 prior creating the new, hashed known_hosts file.
### New Behavior

hash_known_hosts() in module ssh gets the original permissions of the known_hosts file prior to hashing, and re-sets them after ssh-keygen invocation.
### Tests written?

No

ssh-keygen sets the newly created known_hosts file's permissions to
0600. It's good for user's personal files, but bad idea for the global
ones, like /etc/ssh/ssh_known_hosts. This patch record's the original
file's permissions, and sets them on the hashed one after hashing.
