### PR TITLE
Add sortlist and options to parse_resolv() in utils/dns.py + pylint issues + refactoring

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1749,11 +1749,16 @@ def dns():
 
      .. versionadded:: 2016.3.0
     '''
-
+    # Provides:
+    #   dns
     if salt.utils.is_windows() or 'proxyminion' in __opts__:
         return {}
 
     resolv = salt.utils.dns.parse_resolv()
+    for key in ('nameservers', 'ip4_nameservers', 'ip6_nameservers',
+                'sortlist'):
+        if key in resolv:
+            resolv[key] = [str(i) for i in resolv[key]]
 
     return {'dns': resolv} if resolv else {}
 

--- a/salt/utils/dns.py
+++ b/salt/utils/dns.py
@@ -1,48 +1,114 @@
 # -*- coding: utf-8 -*-
+'''
+Define some generic functions for dns modules
+'''
 
 # Import python libs
 from __future__ import absolute_import
 import itertools
+import logging
 
 # Import salt libs
 import salt.utils.network
+from salt._compat import ipaddress
+
+log = logging.getLogger(__name__)
 
 
-def parse_resolv(fp='/etc/resolv.conf'):
-    ns4 = []
-    ns6 = []
+def parse_resolv(src='/etc/resolv.conf'):
+    '''
+    Parse a resolver configuration file (traditionally /etc/resolv.conf)
+    '''
+
+    nameservers = []
     search = []
+    sortlist = []
     domain = ''
+    options = []
 
     try:
-        with salt.utils.fopen(fp) as f:
-            for line in f:
+        with salt.utils.fopen(src) as src_file:
+            # pylint: disable=too-many-nested-blocks
+            for line in src_file:
                 line = line.strip().split()
 
                 try:
                     (directive, arg) = (line[0].lower(), line[1:])
+                    # Drop everything after # or ; (comments)
+                    arg = list(itertools.takewhile(
+                        lambda x: x[0] not in ('#', ';'), arg))
+
                     if directive == 'nameserver':
-                        ip_addr = arg[0]
-                        if (salt.utils.network.is_ipv4(ip_addr) and
-                                ip_addr not in ns4):
-                            ns4.append(ip_addr)
-                        elif (salt.utils.network.is_ipv6(ip_addr) and
-                                ip_addr not in ns6):
-                            ns6.append(ip_addr)
+                        try:
+                            ip_addr = ipaddress.ip_address(arg[0])
+                            if ip_addr not in nameservers:
+                                nameservers.append(ip_addr)
+                        except ValueError as exc:
+                            log.error('{0}: {1}'.format(src, exc))
                     elif directive == 'domain':
                         domain = arg[0]
                     elif directive == 'search':
-                        search = list(itertools.takewhile(
-                            lambda x: x[0] not in ('#', ';'), arg))
-                except (IndexError, RuntimeError):
+                        search = arg
+                    elif directive == 'sortlist':
+                        # A sortlist is specified by IP address netmask pairs.
+                        # The netmask is optional and defaults to the natural
+                        # netmask of the net. The IP address and optional
+                        # network pairs are separated by slashes.
+                        for ip_raw in arg:
+                            try:
+                                ip_net = ipaddress.ip_network(ip_raw)
+                            except ValueError as exc:
+                                log.error('{0}: {1}'.format(src, exc))
+                            else:
+                                if '/' not in ip_raw:
+                                    # No netmask has been provided, guess
+                                    # the "natural" one
+                                    if ip_net.version == 4:
+                                        ip_addr = str(ip_net.network_address)
+                                        # pylint: disable=protected-access
+                                        ip_bits = salt.utils.network.\
+                                            _ipv4_to_bits(ip_addr)
+
+                                        if ip_bits.startswith('11'):
+                                            mask = '/24'
+                                        elif ip_bits.startswith('1'):
+                                            mask = '/16'
+                                        else:
+                                            mask = '/8'
+
+                                        ip_net = ipaddress.ip_network(
+                                            '{0}{1}'.format(ip_addr, mask),
+                                            strict=False
+                                        )
+                                    if ip_net.version == 6:
+                                        # TODO
+                                        pass
+
+                                if ip_net not in sortlist:
+                                    sortlist.append(ip_net)
+                    elif directive == 'options':
+                        # Options allows certain internal resolver variables to
+                        # be modified.
+                        if arg[0] not in options:
+                            options.append(arg[0])
+                except IndexError:
                     continue
 
+        if domain and search:
+            # The domain and search keywords are mutually exclusive.  If more
+            # than one instance of these keywords is present, the last instance
+            # will override.
+            log.warning('{0}: The domain and search keywords are mutually '
+                        'exclusive.'.format(src))
+
         return {
-            'nameservers': ns4 + ns6,
-            'ip4_nameservers': ns4,
-            'ip6_nameservers': ns6,
+            'nameservers': nameservers,
+            'ip4_nameservers': [ip for ip in nameservers if ip.version == 4],
+            'ip6_nameservers': [ip for ip in nameservers if ip.version == 6],
+            'sortlist': [ip.with_netmask for ip in sortlist],
             'domain': domain,
-            'search': search
+            'search': search,
+            'options': options
         }
     except IOError:
         return {}


### PR DESCRIPTION
### What does this PR do?
- use the ipaddress module for the handling of the IP addresses (more safe when INET6 has been disabled on the host)
- refactoring (`ns4 + ns6` don't preserve the order)
- fixes some pylint issues
- add support for `sortlist`
- add support for `options`

Example:

``` sh
(saltdev) mage@mordor:/home/mage/venvs/saltdev % cat /etc/resolv.conf
nameserver 127.0.0.1
options edns0

options 
options timeout:1


nameserver 5800:10c3:e3c3:f1aa:48e3:d923:d494:aaff
nameserver 8.8.8.8
nameserver fd30:0000:0000:0001:ff4e:003e:0009:000e

domain fdp

search lan prod.lan

sortlist 10.209.1.0/24 192.168.0.1 173.25.3.6 fd30:0000:0000:0001:ff4e:003e:0009:000e
```

returns:

``` salt
(saltdev) mage@mordor:/home/mage/venvs/saltdev % salt -c ./etc/salt '*' grains.get dns
saltdev:
    ----------
    domain:
        fdp
    ip4_nameservers:
        - 127.0.0.1
        - 8.8.8.8
    ip6_nameservers:
        - 5800:10c3:e3c3:f1aa:48e3:d923:d494:aaff
        - fd30::1:ff4e:3e:9:e
    nameservers:
        - 127.0.0.1
        - 5800:10c3:e3c3:f1aa:48e3:d923:d494:aaff
        - 8.8.8.8
        - fd30::1:ff4e:3e:9:e
    options:
        - edns0
        - timeout:1
    search:
        - lan
        - prod.lan
    sortlist:
        - 10.209.1.0/255.255.255.0
        - 192.168.0.0/255.255.255.0
        - 173.25.0.0/255.255.0.0
        - fd30::1:ff4e:3e:9:e/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
```
### Tests written?

No.. but planned :)
