### PR TITLE
Removed `!`-password check for salt-cloud vultr provider

### DIFF
--- a/salt/cloud/clouds/vultrpy.py
+++ b/salt/cloud/clouds/vultrpy.py
@@ -341,9 +341,6 @@ def create(vm_):
         if str(data.get('default_password', '')) == '':
             time.sleep(1)
             return False
-        if '!' not in data['default_password']:
-            time.sleep(1)
-            return False
         return data['default_password']
 
     vm_['ssh_host'] = salt.utils.cloud.wait_for_fun(


### PR DESCRIPTION
### What does this PR do?

Fixes a problem with vultr provider for salt-cloud. The current `!` check in password field caused the bootstrapping process to fail as vultr no longer follows `!` in every password policy. ;)

Additionally, verifying auto-generated password by checking if it contains an exclamation mark seem like a very unreliable and issue-prone idea.
### What issues does this PR fix or reference?

There was no issue reported.
### Previous Behavior

Before bootstrapping a node it is waiting for the API response with a `default_password` field. It assumes though that if the field does not contain `!` then it is not a password. 
### New Behavior

Before bootstrapping a node it is waiting for the API response with a `default_password` field. If the field has content then use it as a password.
### Tests written?

No
