### PR TITLE
ZD 762

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -816,11 +816,15 @@ def run(cmd,
 
     log_callback = _check_cb(log_callback)
 
-    if 'pid' in ret and '__pub_jid' in kwargs:
+    log.debug('PRE PID')
+    log.debug('PRE PID CONTEXT: {0}'.format(__context__))
+    if 'pid' in ret and '__pub_jid' in __context__:
+        log.debug('POST PID')
         # Stuff the child pid in the JID file
         try:
             proc_dir = os.path.join(__opts__['cachedir'], 'proc')
             jid_file = os.path.join(proc_dir, kwargs['__pub_jid'])
+            log.debug('cmd.run recording to {0}'.format(jid_file))
             if os.path.isfile(jid_file):
                 serial = salt.payload.Serial(__opts__)
                 with salt.utils.fopen(jid_file, 'rb') as fn_:

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -816,31 +816,6 @@ def run(cmd,
 
     log_callback = _check_cb(log_callback)
 
-    log.debug('PRE PID')
-    log.debug('PRE PID CONTEXT: {0}'.format(__context__))
-    if 'pid' in ret and '__pub_jid' in __context__:
-        log.debug('POST PID')
-        # Stuff the child pid in the JID file
-        try:
-            proc_dir = os.path.join(__opts__['cachedir'], 'proc')
-            jid_file = os.path.join(proc_dir, kwargs['__pub_jid'])
-            log.debug('cmd.run recording to {0}'.format(jid_file))
-            if os.path.isfile(jid_file):
-                serial = salt.payload.Serial(__opts__)
-                with salt.utils.fopen(jid_file, 'rb') as fn_:
-                    jid_dict = serial.load(fn_)
-
-                if 'child_pids' in jid_dict:
-                    jid_dict['child_pids'].append(ret['pid'])
-                else:
-                    jid_dict['child_pids'] = [ret['pid']]
-                # Rewrite file
-                with salt.utils.fopen(jid_file, 'w+b') as fn_:
-                    fn_.write(serial.dumps(jid_dict))
-        except (NameError, TypeError):
-            # Avoids errors from msgpack not being loaded in salt-ssh
-            pass
-
     lvl = _check_loglevel(output_loglevel)
     if lvl is not None:
         if not ignore_retcode and ret['retcode'] != 0:

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -854,6 +854,7 @@ def signal_job(jid, sig):
         salt '*' saltutil.signal_job <job id> 15
     '''
     for data in running():
+        log.debug('FOUND RUNNING: {0}'.format(data))
         if data['jid'] == jid:
             try:
                 os.kill(int(data['pid']), sig)

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -51,6 +51,8 @@ import salt.utils.event
 import salt.utils.url
 import salt.transport
 import salt.wheel
+import salt.utils.psutil_compat as psutil
+
 from salt.exceptions import (
     SaltReqTimeoutError, SaltRenderError, CommandExecutionError, SaltInvocationError
 )
@@ -854,13 +856,11 @@ def signal_job(jid, sig):
         salt '*' saltutil.signal_job <job id> 15
     '''
     for data in running():
-        log.debug('FOUND RUNNING: {0}'.format(data))
         if data['jid'] == jid:
             try:
+                for proc in psutil.Process(pid=data['pid']).children(recursive=True):
+                    proc.send_signal(sig)
                 os.kill(int(data['pid']), sig)
-                if 'child_pids' in data:
-                    for pid in data['child_pids']:
-                        os.kill(int(pid), sig)
                 return 'Signal {0} sent to job {1} at pid {2}'.format(
                         int(sig),
                         jid,

--- a/salt/utils/minion.py
+++ b/salt/utils/minion.py
@@ -32,7 +32,6 @@ def running(opts):
             # the minion process that is executing the JID in question, so
             # we must ignore ENOENT during this process
             pass
-    print('RUNNING RET: {0}'.format(ret))
     return ret
 
 

--- a/salt/utils/minion.py
+++ b/salt/utils/minion.py
@@ -32,6 +32,7 @@ def running(opts):
             # the minion process that is executing the JID in question, so
             # we must ignore ENOENT during this process
             pass
+    print('RUNNING RET: {0}'.format(ret))
     return ret
 
 


### PR DESCRIPTION
### What does this PR do?

Replaces the old method of determining child pids with something more reliable and accurate.
### What issues does this PR fix or reference?

https://github.com/saltstack/zh/issues/742
### Previous Behavior

Child pids were not killed because we had to wait on the return of the forked proc in order to even get the child pid. Now we just look at the children of the pid using psutil.
### Tests written?

No
