### PR TITLE
Add the option to silence output from the X509 create_private_key function

### DIFF
--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -330,6 +330,14 @@ def _get_pubkey_hash(cert):
     return _pretty_hex(sha_hash)
 
 
+def _keygen_callback():
+    '''
+    Replacement keygen callback function which silences the output
+    sent to stdout by the default keygen function
+    '''
+    return
+
+
 def get_pem_entry(text, pem_type=None):
     '''
     Returns a properly formatted PEM string from the input text fixing
@@ -637,7 +645,7 @@ def write_pem(text, path, pem_type=None):
     return 'PEM written to {0}'.format(path)
 
 
-def create_private_key(path=None, text=False, bits=2048):
+def create_private_key(path=None, text=False, bits=2048, verbose=False):
     '''
     Creates a private key in PEM format.
 
@@ -650,6 +658,9 @@ def create_private_key(path=None, text=False, bits=2048):
     bits:
         Length of the private key in bits. Default 2048
 
+    verbose:
+        Provide visual feedback on stdout. Default False
+
     CLI Example:
 
     .. code-block:: bash
@@ -661,7 +672,12 @@ def create_private_key(path=None, text=False, bits=2048):
     if path and text:
         raise salt.exceptions.SaltInvocationError('Either path or text must be specified, not both.')
 
-    rsa = M2Crypto.RSA.gen_key(bits, M2Crypto.m2.RSA_F4)            # pylint: disable=no-member
+    if verbose:
+        _callback_func = M2Crypto.RSA.keygen_callback
+    else:
+        _callback_func = _keygen_callback
+
+    rsa = M2Crypto.RSA.gen_key(bits, M2Crypto.m2.RSA_F4, _callback_func)  # pylint: disable=no-member
     bio = M2Crypto.BIO.MemoryBuffer()
     rsa.save_key_bio(bio, cipher=None)
 

--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -645,7 +645,7 @@ def write_pem(text, path, pem_type=None):
     return 'PEM written to {0}'.format(path)
 
 
-def create_private_key(path=None, text=False, bits=2048, verbose=False):
+def create_private_key(path=None, text=False, bits=2048, verbose=True):
     '''
     Creates a private key in PEM format.
 
@@ -659,7 +659,9 @@ def create_private_key(path=None, text=False, bits=2048, verbose=False):
         Length of the private key in bits. Default 2048
 
     verbose:
-        Provide visual feedback on stdout. Default False
+        Provide visual feedback on stdout. Default True
+
+        .. versionadded:: Carbon
 
     CLI Example:
 

--- a/salt/states/x509.py
+++ b/salt/states/x509.py
@@ -204,7 +204,7 @@ def private_key_managed(name,
                         bits=2048,
                         new=False,
                         backup=False,
-                        verbose=False,):
+                        verbose=True,):
     '''
     Manage a private key's existence.
 
@@ -225,7 +225,9 @@ def private_key_managed(name,
 
     verbose:
         Provide visual feedback on stdout, dots while key is generated.
-        Default is False.
+        Default is True.
+
+        .. versionadded:: Carbon
 
     Example:
 

--- a/salt/states/x509.py
+++ b/salt/states/x509.py
@@ -203,7 +203,8 @@ def _revoked_to_list(revs):
 def private_key_managed(name,
                         bits=2048,
                         new=False,
-                        backup=False):
+                        backup=False,
+                        verbose=False,):
     '''
     Manage a private key's existence.
 
@@ -220,6 +221,10 @@ def private_key_managed(name,
 
     backup:
         When replacing an existing file, backup the old file onthe minion.
+        Default is False.
+
+    verbose:
+        Provide visual feedback on stdout, dots while key is generated.
         Default is False.
 
     Example:
@@ -268,7 +273,8 @@ def private_key_managed(name,
         bkroot = os.path.join(__opts__['cachedir'], 'file_backup')
         salt.utils.backup_minion(name, bkroot)
 
-    ret['comment'] = __salt__['x509.create_private_key'](path=name, bits=bits)
+    ret['comment'] = __salt__['x509.create_private_key'](
+        path=name, bits=bits, verbose=verbose)
     ret['result'] = True
 
     return ret


### PR DESCRIPTION
### Adds the ability to silence the verbose output of the the X509 create_private_key function
### The verbose output on stdout messes up the screen in some cases
### Previous Behavior

Output was verbose with dots indicating the process of the key generation
### New Behavior

It is now possible to silence the verbose output
### Tests written?

Yes/No

progress status output to stdout, in some cases this
is not convenient as it mixes into the current stdout.

This is due to the underlying M2Crypto's modules
keygen_callback function which writes dots as
progress feedback to stdout

This change adds the ability to silence the output from
the function if you do now what it.
