### PR TITLE
Save an entire minion cache traversal on each master pub

### DIFF
--- a/doc/topics/releases/carbon.rst
+++ b/doc/topics/releases/carbon.rst
@@ -39,6 +39,13 @@ Beacons Changes
 - The ``loadavg`` beacon now outputs averages as integers instead of strings.
   (Via :issuse:`31124`.)
 
+Returner Changes
+================
+
+- Any returner which implements a `save_load` function is now required to
+  accept a `minions` keyword argument. All returners which ship with Salt
+  have been modified to do so.
+
 External Module Packaging
 =========================
 

--- a/salt/master.py
+++ b/salt/master.py
@@ -2266,7 +2266,7 @@ class ClearFuncs(object):
         if self.opts['ext_job_cache']:
             try:
                 fstr = '{0}.save_load'.format(self.opts['ext_job_cache'])
-                self.mminion.returners[fstr](clear_load['jid'], clear_load)
+                self.mminion.returners[fstr](clear_load['jid'], clear_load, minions=minions)
             except KeyError:
                 log.critical(
                     'The specified returner used for the external job cache '

--- a/salt/returners/cassandra_cql_return.py
+++ b/salt/returners/cassandra_cql_return.py
@@ -236,7 +236,7 @@ def event_return(events):
             raise
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load to the specified jid id
     '''

--- a/salt/returners/couchbase_return.py
+++ b/salt/returners/couchbase_return.py
@@ -184,7 +184,7 @@ def returner(load):
         return False
 
 
-def save_load(jid, clear_load):
+def save_load(jid, clear_load, minion=None):
     '''
     Save the load to the specified jid
     '''

--- a/salt/returners/django_return.py
+++ b/salt/returners/django_return.py
@@ -65,7 +65,7 @@ def returner(ret):
                   'which responded with {1}'.format(signal[0], signal[1]))
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load to the specified jid
     '''

--- a/salt/returners/elasticsearch_return.py
+++ b/salt/returners/elasticsearch_return.py
@@ -164,7 +164,7 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load to the specified jid id
 

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -133,7 +133,7 @@ def returner(ret):
         client.set(dest, json.dumps(ret[field]), ttl=ttl)
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load to the specified jid
     '''

--- a/salt/returners/influxdb_return.py
+++ b/salt/returners/influxdb_return.py
@@ -189,7 +189,7 @@ def returner(ret):
         log.critical('Failed to store return with InfluxDB returner: {0}'.format(ex))
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load to the specified jid
     '''

--- a/salt/returners/memcache_return.py
+++ b/salt/returners/memcache_return.py
@@ -154,7 +154,7 @@ def returner(ret):
     _append_list(serv, 'jids', jid)
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load to the specified jid
     '''

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -199,7 +199,7 @@ def returner(ret):
         mdb.saltReturns.insert(sdata.copy())
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load for a given job id
     '''

--- a/salt/returners/multi_returner.py
+++ b/salt/returners/multi_returner.py
@@ -61,7 +61,7 @@ def returner(load):
         _mminion().returners['{0}.returner'.format(returner_)](load)
 
 
-def save_load(jid, clear_load):
+def save_load(jid, clear_load, minions=None):
     '''
     Write load to all returners in multi_returner
     '''

--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -287,7 +287,7 @@ def event_return(events):
             cur.execute(sql, (tag, json.dumps(data), __opts__['id']))
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load to the specified jid id
     '''

--- a/salt/returners/odbc.py
+++ b/salt/returners/odbc.py
@@ -214,7 +214,7 @@ def returner(ret):
     _close_conn(conn)
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load to the specified jid id
     '''

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -272,7 +272,7 @@ def event_return(events):
                               __opts__['id'], time.strftime('%Y-%m-%d %H:%M:%S %z', time.localtime())))
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load to the specified jid id
     '''

--- a/salt/returners/postgres.py
+++ b/salt/returners/postgres.py
@@ -189,7 +189,7 @@ def returner(ret):
     _close_conn(conn)
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load to the specified jid id
     '''

--- a/salt/returners/postgres_local_cache.py
+++ b/salt/returners/postgres_local_cache.py
@@ -264,7 +264,7 @@ def event_return(events):
     _close_conn(conn)
 
 
-def save_load(jid, clear_load):
+def save_load(jid, clear_load, minions=None):
     '''
     Save the load to the specified jid id
     '''

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -128,7 +128,7 @@ def returner(ret):
     pipeline.execute()
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load to the specified jid
     '''

--- a/salt/returners/sqlite3_return.py
+++ b/salt/returners/sqlite3_return.py
@@ -178,7 +178,7 @@ def returner(ret):
     _close_conn(conn)
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load to the specified jid
     '''

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -654,13 +654,14 @@ class CkMinions(object):
 
         return set(self.check_minions(v_expr, v_matcher))
 
-    def validate_tgt(self, valid, expr, expr_form):
+    def validate_tgt(self, valid, expr, expr_form, minions=None):
         '''
         Return a Bool. This function returns if the expression sent in is
         within the scope of the valid expression
         '''
         v_minions = self._expand_matching(valid)
-        minions = set(self.check_minions(expr, expr_form))
+        if minions is None:
+            minions = set(self.check_minions(expr, expr_form))
         d_bool = not bool(minions.difference(v_minions))
         if len(v_minions) == len(minions) and d_bool:
             return True
@@ -818,7 +819,8 @@ class CkMinions(object):
                    tgt,
                    tgt_type='glob',
                    groups=None,
-                   publish_validate=False):
+                   publish_validate=False,
+                   minions=None):
         '''
         Returns a bool which defines if the requested function is authorized.
         Used to evaluate the standard structure under external master
@@ -860,7 +862,8 @@ class CkMinions(object):
                         if self.validate_tgt(
                             valid,
                             tgt,
-                            tgt_type):
+                            tgt_type,
+                            minions=minions):
                             # Minions are allowed, verify function in allowed list
                             if isinstance(ind[valid], six.string_types):
                                 if self.match_check(ind[valid], fun):


### PR DESCRIPTION
We were doing an extra and unecessary full traversal of the minion
cache. This refactors all returners and the master to reduce this
to a single call. More work will be forthcoming to reduce this even
further, especially in the context of auth lookups.
