### PR TITLE
Add runner for execution modules

### DIFF
--- a/doc/ref/modules/index.rst
+++ b/doc/ref/modules/index.rst
@@ -144,6 +144,14 @@ This code will call the `run` function in the :mod:`cmd <salt.modules.cmdmod>`
 module and pass the argument ``bar`` to it.
 
 
+Calling Execution Modules on the Salt Master
+============================================
+
+.. versionadded:: Carbon
+Execution modules can now also be called via the :command:`salt-run` command
+using the :ref:`salt runner <salt_salt_runner>`.
+
+
 Preloaded Execution Module Data
 ===============================
 

--- a/doc/ref/runners/all/index.rst
+++ b/doc/ref/runners/all/index.rst
@@ -33,6 +33,7 @@ Full list of runner modules
     pkg
     queue
     reactor
+    salt
     saltutil
     sdb
     search

--- a/doc/ref/runners/all/salt.runners.salt.rst
+++ b/doc/ref/runners/all/salt.runners.salt.rst
@@ -1,0 +1,6 @@
+=================
+salt.runners.salt
+=================
+
+.. automodule:: salt.runners.salt
+    :members:

--- a/doc/topics/releases/carbon.rst
+++ b/doc/topics/releases/carbon.rst
@@ -14,7 +14,8 @@ Features
     .. code-block:: bash
 
         salt-run salt.cmd test.ping
-        salt-run salt.cmd test.arg args='[1, 2, 3]', kwargs='{"a": 1}'
+        # call functions with arguments and keyword arguments
+        salt-run salt.cmd test.arg 1 2 3 a=1
 
 Config Changes
 ==============

--- a/doc/topics/releases/carbon.rst
+++ b/doc/topics/releases/carbon.rst
@@ -9,6 +9,12 @@ Features
 
 - Minions can run in stand-alone mode to use beacons and engines without
   having to connect to a master. (Thanks @adelcast!)
+- Added a ``salt`` runner to allow running salt modules via salt-run.
+
+    .. code-block:: bash
+
+        salt-run salt.cmd test.ping
+        salt-run salt.cmd test.arg args='[1, 2, 3]', kwargs='{"a": 1}'
 
 Config Changes
 ==============

--- a/salt/runners/salt.py
+++ b/salt/runners/salt.py
@@ -1,8 +1,33 @@
 # -*- coding: utf-8 -*-
 '''
-Runner to call execution modules
-
 .. versionadded:: Carbon
+
+This runner makes Salt's
+execution modules available
+on the salt master.
+
+.. _salt_salt_runner:
+Salt's execution modules are normally available
+on the salt minion. Use this runner to call
+execution modules on the salt master.
+Salt :ref:`execution modules <writing-execution-modules>`
+are the functions called by the ``salt`` command.
+
+Execution modules can be
+called with ``salt-run``:
+
+.. code-block:: bash
+
+    salt-run salt.cmd test.ping
+    # call functions with arguments and keyword arguments
+    salt-run salt.cmd test.arg 1 2 3 key=value a=1
+
+Execution modules are also available to salt runners:
+
+.. code-block:: python
+
+    __salt__['salt.cmd'](fun=fun, args=args, kwargs=kwargs)
+
 '''
 # import python libs
 from __future__ import absolute_import
@@ -17,8 +42,12 @@ log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 def cmd(fun, *args, **kwargs):
     '''
-    Execute fun with the given args and kwargs
-    Parameter fun should be a Salt module function name.
+    Execute ``fun`` with the given ``args`` and ``kwargs``.
+    Parameter ``fun`` should be the string :ref:`name <all-salt_modules>`
+    of the execution module to call.
+
+    Note that execution modules will be *loaded every time*
+    this function is called.
 
     CLI example:
 

--- a/salt/runners/salt.py
+++ b/salt/runners/salt.py
@@ -10,12 +10,12 @@ from __future__ import print_function
 import logging
 
 # import salt libs
-from salt.loader import minion_mods
+from salt.loader import minion_mods, utils
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
-def cmd(fun, args=None, kwargs=None):
+def cmd(fun, *args, **kwargs):
     '''
     Execute fun with the given args and kwargs
     Parameter fun should be a Salt module function name.
@@ -25,11 +25,15 @@ def cmd(fun, args=None, kwargs=None):
     .. code-block:: bash
 
         salt-run salt.cmd test.ping
-        salt-run salt.cmd test.arg args='[1, 2, 3]', kwargs='{"a": 1}'
+        # call functions with arguments and keyword arguments
+        salt-run salt.cmd test.arg 1 2 3 a=1
     '''
     log.debug('Called salt.cmd runner with minion function %s', fun)
 
-    args = args or []
-    kwargs = kwargs or {}
+    kws = {key: val for key, val in kwargs.iteritems()
+           if not key.startswith('__')}
 
-    return minion_mods(__opts__).get(fun)(*args, **kwargs)  # pylint: disable=undefined-variable
+    # pylint: disable=undefined-variable
+    return minion_mods(
+        __opts__,
+        utils=utils(__opts__)).get(fun)(*args, **kws)

--- a/salt/runners/salt.py
+++ b/salt/runners/salt.py
@@ -30,8 +30,7 @@ def cmd(fun, *args, **kwargs):
     '''
     log.debug('Called salt.cmd runner with minion function %s', fun)
 
-    kws = {key: val for key, val in kwargs.iteritems()
-           if not key.startswith('__')}
+    kws = dict((k, v) for k, v in kwargs.items() if not k.startswith('__'))
 
     # pylint: disable=undefined-variable
     return minion_mods(

--- a/salt/runners/salt.py
+++ b/salt/runners/salt.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+'''
+Runner to call execution modules
+
+.. versionadded:: Carbon
+'''
+# import python libs
+from __future__ import absolute_import
+from __future__ import print_function
+import logging
+
+# import salt libs
+from salt.loader import minion_mods
+
+log = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+def cmd(fun, args=None, kwargs=None):
+    '''
+    Execute fun with the given args and kwargs
+    Parameter fun should be a Salt module function name.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt-run salt.cmd test.ping
+        salt-run salt.cmd test.arg args='[1, 2, 3]', kwargs='{"a": 1}'
+    '''
+    log.debug('Called salt.cmd runner with minion function %s', fun)
+
+    args = args or []
+    kwargs = kwargs or {}
+
+    return minion_mods(__opts__).get(fun)(*args, **kwargs)  # pylint: disable=undefined-variable

--- a/tests/integration/runners/salt.py
+++ b/tests/integration/runners/salt.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+'''
+Tests for the salt runner
+
+.. versionadded:: Carbon
+'''
+# Import Python libs
+from __future__ import absolute_import
+
+# Import Salt Testing libs
+from salttesting.helpers import ensure_in_syspath
+ensure_in_syspath('../../')
+
+# Import salt libs
+import integration
+
+
+class SaltRunnerTest(integration.ShellCase):
+    '''
+    Test the salt runner
+    '''
+    def test_salt_cmd(self):
+        '''
+        salt.cmd
+        '''
+        ret = self.run_run_plus('salt.cmd', 'test.ping')
+        self.assertTrue(ret.get('out')[0])
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(SaltRunnerTest)


### PR DESCRIPTION
### What does this PR do?

Adds a runner to execute execution modules
### What issues does this PR fix or reference?

N/A
### New Behavior

`salt-run salt.cmd test.ping`
`salt-run salt.cmd test.arg 1 2 3 foo=bar`
Edit: Updated example
### Tests written?

Yes
