### PR TITLE
Add loader.utils() example to calling minion_mods

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -144,7 +144,8 @@ def minion_mods(
         __opts__ = salt.config.minion_config('/etc/salt/minion')
         __grains__ = salt.loader.grains(__opts__)
         __opts__['grains'] = __grains__
-        __salt__ = salt.loader.minion_mods(__opts__)
+        __utils__ = salt.loader.utils(__opts__)
+        __salt__ = salt.loader.minion_mods(__opts__, utils=__utils__)
         __salt__['test.ping']()
     '''
     if context is None:


### PR DESCRIPTION
### What does this PR do?

Add docs for including the utils modules when instantiating minion_mods().
