### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,7 +19,7 @@ class Mock(object):
     This allows autodoc to do its thing without having oodles of req'd
     installed libs. This doesn't work with ``import *`` imports.
 
-    http://read-the-docs.readthedocs.org/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules
+    https://read-the-docs.readthedocs.io/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules
     '''
     def __init__(self, *args, **kwargs):
         pass
@@ -405,10 +405,10 @@ linkcheck_ignore = [r'http://127.0.0.1',
                     r'http://logstash.net/docs/latest/inputs/udp',
                     r'http://logstash.net/docs/latest/inputs/zeromq',
                     r'http://www.youtube.com/saltstack',
-                    r'http://raven.readthedocs.org',
+                    r'https://raven.readthedocs.io',
                     r'https://getsentry.com',
-                    r'http://salt-cloud.readthedocs.org',
-                    r'http://salt.readthedocs.org',
+                    r'https://salt-cloud.readthedocs.io',
+                    r'https://salt.readthedocs.io',
                     r'http://www.pip-installer.org/',
                     r'http://www.windowsazure.com/',
                     r'https://github.com/watching',

--- a/doc/topics/cloud/gce.rst
+++ b/doc/topics/cloud/gce.rst
@@ -639,4 +639,4 @@ Both the instance and load-balancer must exist before using these functions.
     salt-cloud -f attach_lb gce name=lb member=w4
     salt-cloud -f detach_lb gce name=lb member=oops
 
-__ http://libcloud.readthedocs.org/en/latest/compute/drivers/gce.html#specifying-service-account-scopes
+__ https://libcloud.readthedocs.io/en/latest/compute/drivers/gce.html#specifying-service-account-scopes

--- a/doc/topics/cloud/releases/0.6.0.rst
+++ b/doc/topics/cloud/releases/0.6.0.rst
@@ -18,7 +18,7 @@ Documentation
 =============
 
 The documentation for Salt Cloud can be found on Read the Docs:
-http://salt-cloud.readthedocs.org
+https://salt-cloud.readthedocs.io
 
 Download
 ========

--- a/doc/topics/cloud/releases/0.7.0.rst
+++ b/doc/topics/cloud/releases/0.7.0.rst
@@ -15,7 +15,7 @@ Documentation
 =============
 
 The documentation for Salt Cloud can be found on Read the Docs:
-http://salt-cloud.readthedocs.org
+https://salt-cloud.readthedocs.io
 
 Download
 ========

--- a/doc/topics/cloud/releases/0.8.0.rst
+++ b/doc/topics/cloud/releases/0.8.0.rst
@@ -10,7 +10,7 @@ Documentation
 =============
 
 The documentation for Salt Cloud can be found on Read the Docs:
-http://salt-cloud.readthedocs.org
+https://salt-cloud.readthedocs.io
 
 Download
 ========

--- a/doc/topics/cloud/releases/0.8.1.rst
+++ b/doc/topics/cloud/releases/0.8.1.rst
@@ -10,7 +10,7 @@ Documentation
 =============
 
 The documentation for Salt Cloud can be found on Read the Docs:
-http://salt-cloud.readthedocs.org
+https://salt-cloud.readthedocs.io
 
 Download
 ========

--- a/doc/topics/cloud/releases/0.8.2.rst
+++ b/doc/topics/cloud/releases/0.8.2.rst
@@ -11,7 +11,7 @@ Documentation
 =============
 
 The documentation for Salt Cloud can be found on Read the Docs:
-http://salt-cloud.readthedocs.org
+https://salt-cloud.readthedocs.io
 
 Download
 ========

--- a/doc/topics/cloud/releases/0.8.3.rst
+++ b/doc/topics/cloud/releases/0.8.3.rst
@@ -9,7 +9,7 @@ Documentation
 =============
 
 The documentation for Salt Cloud can be found on Read the Docs:
-http://salt-cloud.readthedocs.org
+https://salt-cloud.readthedocs.io
 
 Download
 ========

--- a/doc/topics/cloud/releases/0.8.4.rst
+++ b/doc/topics/cloud/releases/0.8.4.rst
@@ -9,7 +9,7 @@ Documentation
 =============
 
 The documentation for Salt Cloud can be found on Read the Docs:
-http://salt-cloud.readthedocs.org
+https://salt-cloud.readthedocs.io
 
 Download
 ========

--- a/doc/topics/cloud/releases/0.8.5.rst
+++ b/doc/topics/cloud/releases/0.8.5.rst
@@ -11,7 +11,7 @@ Documentation
 =============
 
 The documentation for Salt Cloud can be found on Read the Docs:
-http://salt-cloud.readthedocs.org
+https://salt-cloud.readthedocs.io
 
 Download
 ========

--- a/doc/topics/cloud/releases/0.8.6.rst
+++ b/doc/topics/cloud/releases/0.8.6.rst
@@ -9,7 +9,7 @@ Documentation
 =============
 
 The documentation for Salt Cloud can be found on Read the Docs:
-http://salt-cloud.readthedocs.org
+https://salt-cloud.readthedocs.io
 
 Download
 ========

--- a/doc/topics/cloud/releases/0.8.7.rst
+++ b/doc/topics/cloud/releases/0.8.7.rst
@@ -28,7 +28,7 @@ Documentation
 =============
 
 The documentation for Salt Cloud can be found on Read the Docs:
-http://salt-cloud.readthedocs.org
+https://salt-cloud.readthedocs.io
 
 
 Download

--- a/doc/topics/cloud/releases/0.8.9.rst
+++ b/doc/topics/cloud/releases/0.8.9.rst
@@ -10,7 +10,7 @@ Documentation
 =============
 
 The documentation for Salt Cloud can be found on Read the Docs:
-http://salt-cloud.readthedocs.org
+https://salt-cloud.readthedocs.io
 
 
 Download

--- a/doc/topics/releases/0.9.7.rst
+++ b/doc/topics/releases/0.9.7.rst
@@ -99,7 +99,7 @@ to another environment.
 
 An external node classification can be set in the master configuration file via
 the ``external_nodes`` option:
-http://salt.readthedocs.org/en/latest/ref/configuration/master.html#external-nodes
+https://salt.readthedocs.io/en/latest/ref/configuration/master.html#external-nodes
 
 External nodes are loaded in addition to the top files. If it is intended to
 only use external nodes, do not deploy any top files.

--- a/salt/log/handlers/sentry_mod.py
+++ b/salt/log/handlers/sentry_mod.py
@@ -70,10 +70,10 @@
 
 
 
-    .. _`DSN`: http://raven.readthedocs.org/en/latest/config/index.html#the-sentry-dsn
+    .. _`DSN`: https://raven.readthedocs.io/en/latest/config/index.html#the-sentry-dsn
     .. _`Sentry`: https://getsentry.com
-    .. _`Raven`: http://raven.readthedocs.org
-    .. _`Raven client documentation`: http://raven.readthedocs.org/en/latest/config/index.html#client-arguments
+    .. _`Raven`: https://raven.readthedocs.io
+    .. _`Raven client documentation`: https://raven.readthedocs.io/en/latest/config/index.html#client-arguments
 '''
 from __future__ import absolute_import
 

--- a/salt/modules/boto_cloudwatch.py
+++ b/salt/modules/boto_cloudwatch.py
@@ -191,7 +191,7 @@ def create_or_update_alarm(
     Create or update a cloudwatch alarm.
 
     Params are the same as:
-        http://boto.readthedocs.org/en/latest/ref/cloudwatch.html#boto.ec2.cloudwatch.alarm.MetricAlarm.
+        https://boto.readthedocs.io/en/latest/ref/cloudwatch.html#boto.ec2.cloudwatch.alarm.MetricAlarm.
 
     Dimensions must be a dict. If the value of Dimensions is a string, it will
     be json decoded to produce a dict. alarm_actions, insufficient_data_actions,

--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -616,7 +616,7 @@ def create_container(image,
 
         This dictionary is suitable for feeding directly into the Docker API, and all
         keys are required.
-        (see http://docker-py.readthedocs.org/en/latest/volumes/)
+        (see https://docker-py.readthedocs.io/en/latest/volumes/)
     tty
         attach ttys, Default is ``False``
     stdin_open

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -1292,7 +1292,7 @@ def _validate_input(kwargs,
     def _valid_ports():  # pylint: disable=unused-variable
         '''
         Format ports in the documented way:
-        http://docker-py.readthedocs.org/en/stable/port-bindings/
+        https://docker-py.readthedocs.io/en/stable/port-bindings/
 
         It's possible to pass this as a dict, and indeed it is returned as such
         in the inspect output. Passing port configurations as a dict will work

--- a/salt/modules/elasticsearch.py
+++ b/salt/modules/elasticsearch.py
@@ -7,7 +7,7 @@ Module to provide Elasticsearch compatibility to Salt
 
 .. versionadded:: 2015.8.0
 
-:depends:       `elasticsearch-py <http://elasticsearch-py.readthedocs.org/en/latest/>`_
+:depends:       `elasticsearch-py <https://elasticsearch-py.readthedocs.io/en/latest/>`_
 
 :configuration: This module accepts connection configuration details either as
     parameters or as configuration settings in /etc/salt/minion on the relevant

--- a/salt/modules/uwsgi.py
+++ b/salt/modules/uwsgi.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-uWSGI stats server http://uwsgi-docs.readthedocs.org/en/latest/StatsServer.html
+uWSGI stats server https://uwsgi-docs.readthedocs.io/en/latest/StatsServer.html
 
 :maintainer: Peter Baumgartner <pete@lincolnloop.com>
 :maturity:   new

--- a/salt/netapi/rest_tornado/saltnado_websockets.py
+++ b/salt/netapi/rest_tornado/saltnado_websockets.py
@@ -91,7 +91,7 @@ The event stream can be easily consumed via JavaScript:
 Or via Python, using the Python module
 `websocket-client <https://pypi.python.org/pypi/websocket-client/>`_ for example.
 Or the tornado
-`client <http://tornado.readthedocs.org/en/latest/websocket.html#client-side-support>`_.
+`client <https://tornado.readthedocs.io/en/latest/websocket.html#client-side-support>`_.
 
 .. code-block:: python
 
@@ -201,7 +201,7 @@ The event stream can be easily consumed via JavaScript:
 Or via Python, using the Python module
 `websocket-client <https://pypi.python.org/pypi/websocket-client/>`_ for example.
 Or the tornado
-`client <http://tornado.readthedocs.org/en/latest/websocket.html#client-side-support>`_.
+`client <https://tornado.readthedocs.io/en/latest/websocket.html#client-side-support>`_.
 
 .. code-block:: python
 

--- a/salt/proxy/napalm.py
+++ b/salt/proxy/napalm.py
@@ -5,7 +5,7 @@ NAPALM
 
 Proxy minion for managing network devices via NAPALM_ library.
 
-.. _NAPALM: http://napalm.readthedocs.org
+.. _NAPALM: https://napalm.readthedocs.io
 
 :codeauthor: Mircea Ulinic <mircea@cloudflare.com> & Jerome Fleury <jf@cloudflare.com>
 :maturity:   new
@@ -33,7 +33,7 @@ please refer to the `NAPALM Read the Docs page`_.
 * username: username to be used when connecting to the device
 * passwd: the password needed to establish the connection
 
-.. _`NAPALM Read the Docs page`: http://napalm.readthedocs.org/en/latest/#supported-network-operating-systems
+.. _`NAPALM Read the Docs page`: https://napalm.readthedocs.io/en/latest/#supported-network-operating-systems
 
 Example:
 
@@ -180,7 +180,7 @@ def call(method, **params):
     Calls a specific method from the network driver instance.
     Please check the readthedocs_ page for the updated list of getters.
 
-    .. _readthedocs: http://napalm.readthedocs.org/en/latest/support/index.html#getters-support-matrix
+    .. _readthedocs: https://napalm.readthedocs.io/en/latest/support/index.html#getters-support-matrix
 
     :param method: specifies the name of the method to be called
     :param params: contains the mapping between the name and the values of the parameters needed to call the method

--- a/salt/returners/elasticsearch_return.py
+++ b/salt/returners/elasticsearch_return.py
@@ -4,7 +4,7 @@ Return data to an elasticsearch server for indexing.
 
 :maintainer:    Jurnell Cockhren <jurnell.cockhren@sophicware.com>, Arnold Bechtoldt <mail@arnoldbechtoldt.com>
 :maturity:      New
-:depends:       `elasticsearch-py <http://elasticsearch-py.readthedocs.org/en/latest/>`_
+:depends:       `elasticsearch-py <https://elasticsearch-py.readthedocs.io/en/latest/>`_
 :platform:      all
 
 To enable this returner the elasticsearch python client must be installed

--- a/salt/sdb/consul.py
+++ b/salt/sdb/consul.py
@@ -24,7 +24,7 @@ requires very little. For example:
       verify: True
 
 The ``driver`` refers to the Consul module, all other options are optional.
-For option details see: http://python-consul.readthedocs.org/en/latest/#consul
+For option details see: https://python-consul.readthedocs.io/en/latest/#consul
 '''
 from __future__ import absolute_import
 

--- a/salt/states/boto_asg.py
+++ b/salt/states/boto_asg.py
@@ -326,7 +326,7 @@ def present(
 
     scaling_policies
         List of scaling policies.  Each policy is a dict of key-values described by
-        http://boto.readthedocs.org/en/latest/ref/autoscale.html#boto.ec2.autoscale.policy.ScalingPolicy
+        https://boto.readthedocs.io/en/latest/ref/autoscale.html#boto.ec2.autoscale.policy.ScalingPolicy
 
     scaling_policies_from_pillar:
         name of pillar dict that contains scaling policy settings.   Scaling policies defined for

--- a/salt/states/boto_elasticache.py
+++ b/salt/states/boto_elasticache.py
@@ -120,7 +120,7 @@ def present(
 
     cache_node_type
         The compute and memory capacity of the nodes in the cache cluster.
-        cache.t1.micro, cache.m1.small, etc. See: http://boto.readthedocs.org/en/latest/ref/elasticache.html#boto.elasticache.layer1.ElastiCacheConnection.create_cache_cluster
+        cache.t1.micro, cache.m1.small, etc. See: https://boto.readthedocs.io/en/latest/ref/elasticache.html#boto.elasticache.layer1.ElastiCacheConnection.create_cache_cluster
 
     num_cache_nodes
         The number of cache nodes that the cache cluster will have.

--- a/salt/states/boto_iam_role.py
+++ b/salt/states/boto_iam_role.py
@@ -121,10 +121,10 @@ def present(
         Name of the IAM role.
 
     policy_document
-        The policy that grants an entity permission to assume the role. (See http://boto.readthedocs.org/en/latest/ref/iam.html#boto.iam.connection.IAMConnection.create_role)
+        The policy that grants an entity permission to assume the role. (See https://boto.readthedocs.io/en/latest/ref/iam.html#boto.iam.connection.IAMConnection.create_role)
 
     path
-        The path to the role/instance profile. (See http://boto.readthedocs.org/en/latest/ref/iam.html#boto.iam.connection.IAMConnection.create_role)
+        The path to the role/instance profile. (See https://boto.readthedocs.io/en/latest/ref/iam.html#boto.iam.connection.IAMConnection.create_role)
 
     policies
         A dict of IAM role policies.

--- a/salt/states/boto_rds.py
+++ b/salt/states/boto_rds.py
@@ -239,7 +239,7 @@ def present(name,
         A dict with region, key and keyid, or a pillar key (string) that
         contains a dict with region, key and keyid.
 
-    .. _create_dbinstance: http://boto.readthedocs.org/en/latest/ref/rds.html#boto.rds.RDSConnection.create_dbinstance
+    .. _create_dbinstance: https://boto.readthedocs.io/en/latest/ref/rds.html#boto.rds.RDSConnection.create_dbinstance
     '''
     ret = {'name': name,
            'result': True,
@@ -500,7 +500,7 @@ def absent(name, skip_final_snapshot=None, final_db_snapshot_identifier=None,
         A dict with region, key and keyid, or a pillar key (string) that
         contains a dict with region, key and keyid.
 
-    .. _create_dbinstance: http://boto.readthedocs.org/en/latest/ref/rds.html#boto.rds.RDSConnection.create_dbinstance
+    .. _create_dbinstance: https://boto.readthedocs.io/en/latest/ref/rds.html#boto.rds.RDSConnection.create_dbinstance
 
     wait_for_deletion (bool)
         Wait for the RDS instance to be deleted completely before finishing

--- a/salt/states/etcd_mod.py
+++ b/salt/states/etcd_mod.py
@@ -237,7 +237,7 @@ def wait_rm(name, recurse=False, profile=None):
         The etcd key name to remove, for example ``/foo/bar/baz``.
     recurse
         Optional, defaults to ``False``. If ``True`` performs a recursive
-        delete, see: https://python-etcd.readthedocs.org/en/latest/#delete-a-key.
+        delete, see: https://python-etcd.readthedocs.io/en/latest/#delete-a-key.
     profile
         Optional, defaults to ``None``. Sets the etcd profile to use which has
         been defined in the Salt Master config.

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -142,7 +142,7 @@ class IPCServer(object):
 
         :param IOStream stream: An IOStream for processing
 
-        See http://tornado.readthedocs.org/en/latest/iostream.html#tornado.iostream.IOStream
+        See https://tornado.readthedocs.io/en/latest/iostream.html#tornado.iostream.IOStream
         for additional details.
         '''
         @tornado.gen.coroutine

--- a/salt/utils/schema.py
+++ b/salt/utils/schema.py
@@ -12,7 +12,7 @@
     This code was inspired by `jsl`__, "A Python DSL for describing JSON
     schemas".
 
-    .. __: http://jsl.readthedocs.org/
+    .. __: https://jsl.readthedocs.io/
 
 
     A configuration document or configuration document section is defined using

--- a/tests/unit/states/dockerng_test.py
+++ b/tests/unit/states/dockerng_test.py
@@ -207,7 +207,7 @@ class DockerngTestCase(TestCase):
         protocol declaration passed as tuple. As stated by docker-py
         documentation
 
-        https://docker-py.readthedocs.org/en/latest/port-bindings/
+        https://docker-py.readthedocs.io/en/latest/port-bindings/
 
         In sls:
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
