### PR TITLE
Add has_ipv6 grains

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1620,6 +1620,16 @@ def fqdn_ip4():
     return {'fqdn_ip4': addrs}
 
 
+def has_ipv6():
+    '''
+    Check whether IPv6 is supported on this platform.
+
+    .. versionadded:: Carbon
+    '''
+
+    return {'has_ipv6': socket.has_ipv6}
+
+
 def ip6():
     '''
     Return a list of ipv6 addrs


### PR DESCRIPTION
### What does this PR do?
- Add a `has_ipv6` grains to check whether ipv6 is supported on the host
### What issues does this PR fix or reference?

None
### Tests written?

No
