### PR TITLE
Fix mongo get_load to return full mongo record instead of non-existant 'load' key

### DIFF
--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -223,8 +223,7 @@ def get_load(jid):
     Return the load associated with a given job id
     '''
     conn, mdb = _get_conn(ret=None)
-    ret = mdb.jobs.find_one({'jid': jid}, {'_id': 0})
-    return ret['load']
+    return mdb.jobs.find_one({'jid': jid}, {'_id': 0})
 
 
 def get_jid(jid):


### PR DESCRIPTION
### What does this PR do?

Returns mongo record for jid without attempting to access non-existing 'load' key
### What issues does this PR fix or reference?

Eliminate error for mongo returner that states "could not get load"
### Previous Behavior

Returner gets jid load record and attempts to return non-existing 'load' key instead of the full record.
### New Behavior

Return full load record from mongo
### Tests written?

No

The jid load comes in directly, not as 'load' key. Should return the mongo record directly without accessing keys
