### PR TITLE
Adds a "Generated on <timestamp>" line to the html footer

### DIFF
--- a/doc/_themes/saltstack2/layout.html
+++ b/doc/_themes/saltstack2/layout.html
@@ -191,10 +191,11 @@
                     <div class="footer">
                         <hr />
 
-                        {% if on_saltstack %}
                         <div class="row">
 
+                            {% if on_saltstack %}
                             <div class="col-sm-6">
+                            <p><i>Generated on {{today}}.</i></p>
 
                                 {% if build_type == "latest" %}
                                 <p>You are viewing docs for the latest stable release, {{ latest_release }}. Switch to docs for the previous stable release, <a data-container="body" data-toggle="tooltip" data-placement="bottom" title="Docs for the previous stable release" href="/en/{{ previous_release_dir }}/">{{ previous_release }}</a>, or to a recent doc build from the <a data-container="body" data-toggle="tooltip" data-placement="bottom" title="Latest docs from the develop branch" href="/en/develop/">develop</a> branch.</p>
@@ -220,8 +221,8 @@
 
 
                             </div>
+                            {% endif %}
                         </div>
-                        {% endif %}
                     </div> <!--end footer-->
                     {%- endblock %}
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -7,6 +7,7 @@ import functools
 import sys
 import os
 import types
+import time
 
 from sphinx.directives import TocTree
 
@@ -198,6 +199,8 @@ previous_release_dir = '2015.8'  # path on web server for previous branch
 next_release = ''  # next release
 next_release_dir = ''  # path on web server for next release branch
 
+today = time.strftime("%B %d, %Y") + " at " + time.strftime("%X %Z")
+
 # < --- START do not merge these settings to other branches START ---> #
 build_type = 'previous'  # latest, previous, develop, next
 release = previous_release  # version, latest_release, previous_release
@@ -341,6 +344,7 @@ html_context = {
     'previous_release_dir': previous_release_dir,
     'search_cx': search_cx,
     'build_type': build_type,
+    'today': today,
 }
 
 html_use_index = True


### PR DESCRIPTION
This should make it easier to tell when commits are on the doc site.
