### PR TITLE
Dynamically support params in Consul function call

### DIFF
--- a/salt/pillar/consul_pillar.py
+++ b/salt/pillar/consul_pillar.py
@@ -247,10 +247,9 @@ def get_conn(opts, profile):
         conf = opts_merged
 
     params = {}
-    for key in ('host', 'port', 'token', 'scheme', 'consistency', 'dc', 'verify'):
-        prefixed_key = 'consul.{key}'.format(key=key)
-        if prefixed_key in conf:
-            params[key] = conf[prefixed_key]
+    for key in conf:
+        if key.startswith('consul.'):
+            params[key.split('.')[1]] = conf[key]
 
     if 'dc' in params:
         pillarenv = opts_merged.get('pillarenv') or 'base'


### PR DESCRIPTION
### What does this PR do?

Should no longer be required to maintain the arguments to `consul.Consul()`
