### PR TITLE
Port boto_rds to Boto3 version 1.3.1

### DIFF
--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -39,39 +39,63 @@ Connection module for Amazon RDS
             key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
             region: us-east-1
 
-:depends: boto
+:depends: boto3
 '''
 # keep lint from choking on _get_conn and _cache_id
 #pylint: disable=E0602
 
-from __future__ import absolute_import
 
 # Import Python libs
+from __future__ import absolute_import
 import logging
 from salt.exceptions import SaltInvocationError
+from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
 from time import time, sleep
+
+# Import Salt libs
+import salt.utils.boto3
+import salt.utils.compat
+import salt.utils
+import salt.ext.six as six
 
 log = logging.getLogger(__name__)
 
 # Import third party libs
-import salt.ext.six as six
+# pylint: disable=import-error
 try:
+    #pylint: disable=unused-import
     import boto
-    import boto.rds2
+    import boto3
+    #pylint: enable=unused-import
+    from botocore.exceptions import ClientError
     logging.getLogger('boto').setLevel(logging.CRITICAL)
+    logging.getLogger('boto3').setLevel(logging.CRITICAL)
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
+# pylint: enable=import-error
 
 
 def __virtual__():
     '''
-    Only load if boto libraries exist.
+    Only load if boto libraries exist and if boto libraries are greater than
+    a given version.
     '''
+    required_boto3_version = '1.3.1'
     if not HAS_BOTO:
-        return (False, 'The boto_rds module could not be loaded: boto libraries not found')
-    __utils__['boto.assign_funcs'](__name__, 'rds', module='rds2', pack=__salt__)
-    return True
+        return (False, 'The boto_rds module could not be loaded: '
+                'boto libraries not found')
+    elif _LooseVersion(boto3.__version__) < _LooseVersion(required_boto3_version):
+        return (False, 'The boto_rds module could not be loaded: '
+                'boto version {0} or later must be installed.'.format(required_boto3_version))
+    else:
+        return True
+
+
+def __init__(opts):
+    salt.utils.compat.pack_dunder(__name__)
+    if HAS_BOTO:
+        __utils__['boto3.assign_funcs'](__name__, 'rds')
 
 
 def exists(name, tags=None, region=None, key=None, keyid=None, profile=None):
@@ -85,15 +109,10 @@ def exists(name, tags=None, region=None, key=None, keyid=None, profile=None):
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
     try:
-        rds = conn.describe_db_instances(db_instance_identifier=name)
-        if not rds:
-            msg = 'Rds instance does not exist in region {0}'.format(region)
-            log.debug(msg)
-            return False
-        return True
-    except boto.exception.BotoServerError as e:
-        log.debug(e)
-        return False
+        rds = conn.describe_db_instances(DBInstanceIdentifier=name)
+        return {'exists': bool(rds)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
 
 
 def option_group_exists(name, tags=None, region=None, key=None, keyid=None,
@@ -108,17 +127,10 @@ def option_group_exists(name, tags=None, region=None, key=None, keyid=None,
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
     try:
-        rds = conn.describe_option_groups(option_group_name=name)
-        if not rds:
-            msg = ('Rds option group does not exist in region '
-                   '{0}'.format(region)
-                   )
-            log.debug(msg)
-            return False
-        return True
-    except boto.exception.BotoServerError as e:
-        log.debug(e)
-        return False
+        rds = conn.describe_option_groups(OptionGroupName=name)
+        return {'exists': bool(rds)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
 
 
 def parameter_group_exists(name, tags=None, region=None, key=None, keyid=None,
@@ -134,16 +146,10 @@ def parameter_group_exists(name, tags=None, region=None, key=None, keyid=None,
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
     try:
-        rds = conn.describe_db_parameter_groups(db_parameter_group_name=name)
-        if not rds:
-            msg = ('Rds parameter group does not exist in'
-                   'region {0}'.format(region))
-            log.debug(msg)
-            return False
-        return True
-    except boto.exception.BotoServerError as e:
-        log.debug(e)
-        return False
+        rds = conn.describe_db_parameter_groups(DBParameterGroupName=name)
+        return {'exists': bool(rds)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
 
 
 def subnet_group_exists(name, tags=None, region=None, key=None, keyid=None,
@@ -156,32 +162,33 @@ def subnet_group_exists(name, tags=None, region=None, key=None, keyid=None,
         salt myminion boto_rds.subnet_group_exists my-param-group \
                 region=us-east-1
     '''
-    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-
     try:
-        rds = conn.describe_db_subnet_groups(db_subnet_group_name=name)
-        if not rds:
-            msg = ('Rds subnet group does not exist in'
-                   'region {0}'.format(region))
-            log.debug(msg)
-            return False
-        return True
-    except boto.exception.BotoServerError as e:
-        log.debug(e)
-        return False
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'exists': bool(conn)}
+
+        rds = conn.describe_db_subnet_groups(DBSubnetGroupName=name)
+        return {'exists': bool(rds)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
 
 
 def create(name, allocated_storage, db_instance_class, engine,
-           master_username, master_user_password, db_name=None,
+           master_username, master_user_password, DBname=None,
            db_security_groups=None, vpc_security_group_ids=None,
            availability_zone=None, db_subnet_group_name=None,
            preferred_maintenance_window=None, db_parameter_group_name=None,
            backup_retention_period=None, preferred_backup_window=None,
-           port=None, multi_az=None, engine_version=None,
-           auto_minor_version_upgrade=None, license_model=None, iops=None,
-           option_group_name=None, character_set_name=None,
-           publicly_accessible=None, wait_status=None, tags=None, region=None,
-           key=None, keyid=None, profile=None):
+           Port=None, MultiAZ=None, EngineVersion=None,
+           AutoMinorVersionUpgrade=None, LicenseModel=None, Iops=None,
+           OptionGroupName=None, CharacterSetName=None,
+           PubliclyAccessible=None, wait_status=None, tags=None,
+           DBClusterIdentifier=None, storage_type=None,
+           TdeCredentialArn=None, TdeCredentialPassword=None,
+           StorageEncrypted=None, KmsKeyId=None, Domain=None,
+           CopyTagsToSnapshot=None, MonitoringInterval=None,
+           MonitoringRoleArn=None, DomainIAMRoleName=None, region=None,
+           PromotionTier=None, key=None, keyid=None, profile=None):
     '''
     Create an RDS
 
@@ -189,11 +196,6 @@ def create(name, allocated_storage, db_instance_class, engine,
 
         salt myminion boto_rds.create myrds 10 db.t2.micro MySQL sqlusr sqlpassw
     '''
-    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-
-    if __salt__['boto_rds.exists'](name, tags, region, key, keyid, profile):
-        return True
-
     if not allocated_storage:
         raise SaltInvocationError('allocated_storage is required')
     if not db_instance_class:
@@ -204,7 +206,7 @@ def create(name, allocated_storage, db_instance_class, engine,
         raise SaltInvocationError('master_username is required')
     if not master_user_password:
         raise SaltInvocationError('master_user_password is required')
-    if availability_zone and multi_az:
+    if availability_zone and MultiAZ:
         raise SaltInvocationError('availability_zone and multi_az are mutually'
                                   ' exclusive arguments.')
     if wait_status:
@@ -212,53 +214,83 @@ def create(name, allocated_storage, db_instance_class, engine,
         if wait_status not in wait_statuses:
             raise SaltInvocationError('wait_status can be one of: '
                                       '{0}'.format(wait_statuses))
+
     try:
-        rds = conn.create_db_instance(name, allocated_storage,
-                                      db_instance_class, engine,
-                                      master_username, master_user_password,
-                                      db_name, db_security_groups,
-                                      vpc_security_group_ids,
-                                      availability_zone, db_subnet_group_name,
-                                      preferred_maintenance_window,
-                                      db_parameter_group_name,
-                                      backup_retention_period,
-                                      preferred_backup_window, port, multi_az,
-                                      engine_version,
-                                      auto_minor_version_upgrade,
-                                      license_model, iops,
-                                      option_group_name, character_set_name,
-                                      publicly_accessible, tags)
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'results': bool(conn)}
+
+        kwargs = {}
+        for key in ('DomainIAMRoleName', 'LicenseModel',
+                    'TdeCredentialArn',
+                    'TdeCredentialPassword', 'DBname', 'Domain',
+                    'EngineVersion', 'OptionGroupName',
+                    'CharacterSetName', 'MonitoringRoleArn',
+                    'DBClusterIdentifier', 'KmsKeyId'):
+            if locals()[key] is not None:
+                kwargs[key] = str(locals()[key])
+
+        for key in ('MonitoringInterval', 'PromotionTier',
+                    'Iops', 'Port'):
+            if locals()[key] is not None:
+                kwargs[key] = int(locals()[key])
+
+        for key in ('CopyTagsToSnapshot', 'MultiAZ',
+                    'AutoMinorVersionUpgrade', 'StorageEncrypted',
+                    'PubliclyAccessible'):
+            if locals()[key] is not None:
+                kwargs[key] = bool(locals()[key])
+
+        taglist = _tag_doc(tags)
+
+        rds = conn.create_db_instance(DBInstanceIdentifier=name,
+                                      AllocatedStorage=allocated_storage,
+                                      DBInstanceClass=db_instance_class,
+                                      DBSecurityGroups=db_security_groups,
+                                      Engine=engine,
+                                      MasterUsername=master_username,
+                                      MasterUserPassword=master_user_password,
+                                      VpcSecurityGroupIds=vpc_security_group_ids,
+                                      AvailabilityZone=availability_zone,
+                                      DBSubnetGroupName=db_subnet_group_name,
+                                      PreferredMaintenanceWindow=preferred_maintenance_window,
+                                      DBParameterGroupName=db_parameter_group_name,
+                                      BackupRetentionPeriod=backup_retention_period,
+                                      PreferredBackupWindow=preferred_backup_window,
+                                      StorageType=storage_type, Tags=taglist,
+                                      **kwargs)
+
         if not rds:
-            msg = 'Failed to create RDS {0}'.format(name)
-            log.error(msg)
-            return False
+            return {'created': False}
         if not wait_status:
-            log.info('Created RDS {0}'.format(name))
-            return True
+            return {'created': True, 'message':
+                    'Created RDS instance {0}.'.format(name)}
+
         while True:
             log.info('Waiting 10 secs...')
             sleep(10)
-            _describe = describe(name, tags, region, key, keyid, profile)
+            _describe = describe(name=name, tags=tags, region=region, key=key,
+                                 keyid=keyid, profile=profile)
             if not _describe:
-                return True
+                return {'created': True}
             if _describe['db_instance_status'] == wait_status:
-                log.info('Created RDS {0} with current status '
-                         '{1}'.format(name, _describe['db_instance_status']))
-                return True
+                return {'created': True, 'message':
+                        'Created RDS {0} with current status '
+                        '{1}'.format(name, _describe['db_instance_status'])}
+
             log.info('Current status: {0}'.format(_describe['db_instance_status']))
 
-    except boto.exception.BotoServerError as e:
-        log.debug(e)
-        msg = 'Failed to create RDS {0}, reason: {1}'.format(name, e.body)
-        log.error(msg)
-        return False
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
 
 
 def create_read_replica(name, source_name, db_instance_class=None,
                         availability_zone=None, port=None,
                         auto_minor_version_upgrade=None, iops=None,
                         option_group_name=None, publicly_accessible=None,
-                        tags=None,
+                        tags=None, db_subnet_group_name=None,
+                        storage_type=None, copy_tags_to_snapshot=None,
+                        monitoring_interval=None, monitoring_role_arn=None,
                         region=None, key=None, keyid=None, profile=None):
     '''
     Create an RDS read replica
@@ -267,33 +299,53 @@ def create_read_replica(name, source_name, db_instance_class=None,
 
         salt myminion boto_rds.create_read_replica replicaname source_name
     '''
-    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    if not backup_retention_period:
+        raise SaltInvocationError('backup_retention_period is required')
+    res = __salt__['boto_rds.exists'](source_name, tags, region, key, keyid, profile)
+    if not res.get('exists'):
+        return {'exists': bool(res), 'message':
+                'RDS instance source {0} does not exists.'.format(source_name)}
 
-    if not __salt__['boto_rds.exists'](source_name, tags, region, key, keyid, profile):
-        return False
-    if __salt__['boto_rds.exists'](name, tags, region, key, keyid, profile):
-        return True
+    res = __salt__['boto_rds.exists'](name, tags, region, key, keyid, profile)
+    if res.get('exists'):
+        return {'exists': bool(res), 'message':
+                'RDS replica instance {0} already exists.'.format(name)}
+
     try:
-        rds_replica = conn.create_db_instance_read_replica(name, source_name,
-                                                           db_instance_class,
-                                                           availability_zone,
-                                                           port,
-                                                           auto_minor_version_upgrade,
-                                                           iops, option_group_name,
-                                                           publicly_accessible,
-                                                           tags)
-        if rds_replica:
-            log.info('Created replica {0} from {1}'.format(name, source_name))
-            return True
-        else:
-            msg = 'Failed to create RDS replica {0}'.format(name)
-            log.error(msg)
-            return False
-    except boto.exception.BotoServerError as e:
-        log.debug(e)
-        msg = 'Failed to create RDS replica {0}'.format(name)
-        log.error(msg)
-        return False
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        kwargs = {}
+        for key in ('OptionGroupName', 'MonitoringRoleArn'):
+            if locals()[key] is not None:
+                kwargs[key] = str(locals()[key])
+
+        for key in ('MonitoringInterval', 'Iops', 'Port'):
+            if locals()[key] is not None:
+                kwargs[key] = int(locals()[key])
+
+        for key in ('CopyTagsToSnapshot', 'AutoMinorVersionUpgrade'):
+            if locals()[key] is not None:
+                kwargs[key] = bool(locals()[key])
+
+        taglist = _tag_doc(tags)
+
+        rds_replica = conn.create_db_instance_read_replica(DBInstanceIdentifier=name,
+                                                           SourceDBInstanceIdentifier=source_name,
+                                                           DBInstanceClass=db_instance_class,
+                                                           AvailabilityZone=availability_zone,
+                                                           Port=port,
+                                                           AutoMinorVersionUpgrade=auto_minor_version_upgrade,
+                                                           Iops=iops, OptionGroupName=option_group_name,
+                                                           PubliclyAccessible=publicly_accessible,
+                                                           Tags=taglist, DBSubnetGroupName=db_subnet_group_name,
+                                                           StorageType=storage_type,
+                                                           CopyTagsToSnapshot=copy_tags_to_snapshot,
+                                                           MonitoringInterval=monitoring_interval,
+                                                           MonitoringRoleArn=monitoring_role_arn)
+
+
+        return {'exists': bool(rds_replica)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
 
 
 def create_option_group(name, engine_name, major_engine_version,
@@ -307,26 +359,26 @@ def create_option_group(name, engine_name, major_engine_version,
         salt myminion boto_rds.create_option_group my-opt-group mysql 5.6 \
                 "group description"
     '''
-    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    res = __salt__['boto_rds.option_group_exists'](name, tags, region, key, keyid,
+                                                   profile)
+    if res.get('exists'):
+        return {'exists': bool(res)}
 
-    if __salt__['boto_rds.option_group_exists'](name, tags, region, key, keyid,
-                                                profile):
-        return True
     try:
-        rds = conn.create_option_group(name, engine_name,
-                                       major_engine_version,
-                                       option_group_description, tags)
-        if not rds:
-            msg = 'Failed to create RDS option group {0}'.format(name)
-            log.error(msg)
-            return False
-        log.info('Created RDS option group {0}'.format(name))
-        return True
-    except boto.exception.BotoServerError as e:
-        log.debug(e)
-        msg = 'Failed to create RDS option group {0}'.format(name)
-        log.error(msg)
-        return False
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'results': bool(conn)}
+
+        taglist = _tag_doc(tags)
+        rds = conn.create_option_group(OptionGroupName=name,
+                                       EngineName=engine_name,
+                                       MajorEngineVersion=major_engine_version,
+                                       OptionGroupDescription=option_group_description,
+                                       Tags=taglist)
+
+        return {'exists': bool(rds)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
 
 
 def create_parameter_group(name, db_parameter_group_family, description,
@@ -340,28 +392,33 @@ def create_parameter_group(name, db_parameter_group_family, description,
         salt myminion boto_rds.create_parameter_group my-param-group mysql5.6 \
                 "group description"
     '''
-    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    res = __salt__['boto_rds.parameter_group_exists'](name, tags, region, key,
+                                                      keyid, profile)
+    if res.get('exists'):
+        return {'exists': bool(res)}
 
-    if __salt__['boto_rds.parameter_group_exists'](name, tags, region, key,
-                                                   keyid, profile):
-        return True
     try:
-        rds = conn.create_db_parameter_group(name, db_parameter_group_family,
-                                             description, tags)
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'results': bool(conn)}
+
+        taglist = _tag_doc(tags)
+        rds = conn.create_db_parameter_group(DBParameterGroupName=name,
+                                             DBParameterGroupFamily=db_parameter_group_family,
+                                             Description=description,
+                                             Tags=taglist)
         if not rds:
-            msg = 'Failed to create RDS parameter group {0}'.format(name)
-            log.error(msg)
-            return False
-        log.info('Created RDS parameter group {0}'.format(name))
-        return True
-    except boto.exception.BotoServerError as e:
-        log.debug(e)
-        msg = 'Failed to create RDS parameter group {0}'.format(name)
-        log.error(msg)
-        return False
+            return {'created': False, 'message':
+                    'Failed to create RDS parameter group {0}'.format(name)}
+
+        return {'exists': bool(rds), 'message':
+                'Created RDS parameter group {0}'.format(name)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
 
 
-def create_subnet_group(name, description, subnet_ids, tags=None, region=None, key=None, keyid=None, profile=None):
+def create_subnet_group(name, description, subnet_ids, tags=None,
+                        region=None, key=None, keyid=None, profile=None):
     '''
     Create an RDS subnet group
 
@@ -371,24 +428,24 @@ def create_subnet_group(name, description, subnet_ids, tags=None, region=None, k
             "group description" '[subnet-12345678, subnet-87654321]' \
             region=us-east-1
     '''
-    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    res = __salt__['boto_rds.subnet_group_exists'](name, tags, region, key,
+                                                 keyid, profile)
+    if res.get('exists'):
+        return {'exists': bool(res)}
 
-    if __salt__['boto_rds.subnet_group_exists'](name, tags, region, key, keyid,
-                                                profile):
-        return True
     try:
-        rds = conn.create_db_subnet_group(name, description, subnet_ids, tags)
-        if not rds:
-            msg = 'Failed to create RDS subnet group {0}'.format(name)
-            log.error(msg)
-            return False
-        log.info('Created RDS subnet group {0}'.format(name))
-        return True
-    except boto.exception.BotoServerError as e:
-        log.debug(e)
-        msg = 'Failed to create RDS subnet group {0}'.format(name)
-        log.error(msg)
-        return False
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'results': bool(conn)}
+
+        taglist = _tag_doc(tags)
+        rds = conn.create_db_subnet_group(DBSubnetGroupName=name,
+                                          DBSubnetGroupDescription=description,
+                                          SubnetIds=subnet_ids, Tags=taglist)
+
+        return {'created': bool(rds)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
 
 
 def update_parameter_group(name, parameters, apply_method="pending-reboot",
@@ -404,25 +461,28 @@ def update_parameter_group(name, parameters, apply_method="pending-reboot",
                 region=us-east-1
     '''
 
-    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    res = __salt__['boto_rds.parameter_group_exists'](name, tags, region, key,
+                                                      keyid, profile)
+    if res.get('exists'):
+        return {'exists': bool(res)}
 
-    if not __salt__['boto_rds.parameter_group_exists'](name, tags, region, key,
-                                                       keyid, profile):
-        return False
     param_list = []
     for key, value in six.iteritems(parameters):
         item = (key, value, apply_method)
         param_list.append(item)
         if not len(param_list):
-            return False
+            return {'results': False}
+
     try:
-        conn.modify_db_parameter_group(name, param_list)
-        return True
-    except boto.exception.BotoServerError as e:
-        log.debug(e)
-        msg = 'Failed to update RDS parameter group {0}'.format(name)
-        log.error(msg)
-        return False
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'results': bool(conn)}
+
+        res = conn.modify_db_parameter_group(DBParameterGroupName=name,
+                                             Parameters=param_list)
+        return {'results': bool(res)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
 
 
 def describe(name, tags=None, region=None, key=None, keyid=None,
@@ -435,54 +495,69 @@ def describe(name, tags=None, region=None, key=None, keyid=None,
         salt myminion boto_rds.describe myrds
 
     '''
-    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    res = __salt__['boto_rds.exists'](name, tags, region, key, keyid,
+                                      profile):
+        return {'exists': bool(res)}
 
-    if not __salt__['boto_rds.exists'](name, tags, region, key, keyid,
-                                       profile):
-        return False
     try:
-        rds = conn.describe_db_instances(db_instance_identifier=name)
-    except boto.exception.BotoServerError as e:
-        log.debug(e)
-        return False
-    _rds = rds['DescribeDBInstancesResponse']['DescribeDBInstancesResult']['DBInstances'][0]
-    return _pythonize_dict(_rds)
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'results': bool(conn)}
+
+        rds = conn.describe_db_instances(DBInstanceIdentifier=name)
+
+        if rds:
+            keys = ('DBInstanceIdentifier', 'DBInstanceClass', 'Engine',
+                    'DBInstanceStatus', 'DBName', 'AllocatedStorage',
+                    'PreferredBackupWindow', 'BackupRetentionPeriod',
+                    'AvailabilityZone', 'PreferredMaintenanceWindow',
+                    'LatestRestorableTime', 'EngineVersion',
+                    'AutoMinorVersionUpgrade', 'LicenseModel',
+                    'Iops', 'CharacterSetName', 'PubliclyAccessible',
+                    'StorageType', 'TdeCredentialArn', 'DBInstancePort',
+                    'DBClusterIdentifier', 'StorageEncrypted', 'KmsKeyId',
+                    'DbiResourceId', 'CACertificateIdentifier',
+                    'CopyTagsToSnapshot', 'MonitoringInterval',
+                    'MonitoringRoleArn', 'PromotionTier',
+                    'DomainMemberships')
+            return {'rds': dict([(k, rds.get(k)) for k in keys])}
+        else:
+            return {'rds': None}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
 
 
 def get_endpoint(name, tags=None, region=None, key=None, keyid=None,
                  profile=None):
     '''
-    Return the enpoint of an RDS instance.
+    Return the endpoint of an RDS instance.
 
     CLI example::
 
         salt myminion boto_rds.get_endpoint myrds
 
     '''
-    ret = False
+    endpoint = 'None'
+    res = __salt__['boto_rds.exists'](name, tags, region, key, keyid,
+                                      profile)
+    if not res:
+        return {'exists': bool(res), 'message':
+                'RDS instance {0} does not exist.'.format(name)}
 
-    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-
-    if not __salt__['boto_rds.exists'](name, tags, region, key, keyid,
-                                       profile):
-        return False
     try:
-        rds = conn.describe_db_instances(db_instance_identifier=name)
-    except boto.exception.BotoServerError as e:
-        log.debug(e)
-        return False
-    insts = rds['DescribeDBInstancesResponse']['DescribeDBInstancesResult']
-    found = False
-    endpoints = []
-    for instance in insts['DBInstances']:
-        if 'Endpoint' in instance and instance['Endpoint'] is not None and 'Address' in instance['Endpoint']:
-            found = True
-            endpoints.append(instance['Endpoint']['Address'])
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'results': bool(conn)}
 
-    if found:
-        ret = endpoints[0]
+        rds = conn.describe_db_instances(DBInstanceIdentifier=name)
 
-    return ret
+        if rds:
+            inst = rds['DBInstances'][0]['Endpoint']
+            endpoint = '{0}:{1}'.format(inst.get('Address'), inst.get('Port'))
+            return endpoint
+
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
 
 
 def delete(name, skip_final_snapshot=None, final_db_snapshot_identifier=None,
@@ -499,35 +574,40 @@ def delete(name, skip_final_snapshot=None, final_db_snapshot_identifier=None,
     if timeout == 180 and not skip_final_snapshot:
         timeout = 420
 
-    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-
     if not skip_final_snapshot and not final_db_snapshot_identifier:
         raise SaltInvocationError('At least one of the following must'
                                   ' be specified: skip_final_snapshot'
                                   ' final_db_snapshot_identifier')
+
     try:
-        conn.delete_db_instance(name, skip_final_snapshot,
-                                final_db_snapshot_identifier)
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'deleted': bool(conn)}
+
+        res = conn.delete_db_instance(DBInstanceIdentifier=name,
+                                      SkipFinalSnapshot=skip_final_snapshot,
+                                      FinalDBSnapshotIdentifier=final_db_snapshot_identifier)
+
         if not wait_for_deletion:
-            log.info('Deleted RDS instance {0}.'.format(name))
-            return True
+            return {'deleted': bool(res), 'message':
+                    'Deleted RDS instance {0}.'.format(name)}
+
         start_time = time()
         while True:
             if not __salt__['boto_rds.exists'](name=name, region=region,
                                                key=key, keyid=keyid,
                                                profile=profile):
-                log.info('Deleted RDS instance {0} completely.'.format(name))
-                return True
+
+                return {'deleted': bool(res), 'message':
+                        'Deleted RDS instance {0} completely.'.format(name)}
+
             if time() - start_time > timeout:
                 raise SaltInvocationError('RDS instance {0} has not been '
                                           'deleted completely after {1} '
                                           'seconds'.format(name, timeout))
             sleep(10)
-    except boto.exception.BotoServerError as e:
-        log.debug(e)
-        msg = 'Failed to delete RDS instance {0}'.format(name)
-        log.error(msg)
-        return False
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
 
 
 def delete_option_group(name, region=None, key=None, keyid=None, profile=None):
@@ -539,18 +619,20 @@ def delete_option_group(name, region=None, key=None, keyid=None, profile=None):
         salt myminion boto_rds.delete_option_group my-opt-group \
                 region=us-east-1
     '''
-    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-
     try:
-        conn.delete_option_group(name)
-        msg = 'Deleted RDS option group {0}.'.format(name)
-        log.info(msg)
-        return True
-    except boto.exception.BotoServerError as e:
-        log.debug(e)
-        msg = 'Failed to delete RDS option group {0}'.format(name)
-        log.error(msg)
-        return False
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'deleted': bool(conn)}
+
+        res = conn.delete_option_group(OptionGroupName=name)
+        if not res:
+            return {'deleted': bool(res), 'message':
+                    'Failed to delete RDS option group {0}.'.format(name)}
+
+        return {'deleted': bool(res), 'message':
+                'Deleted RDS option group {0}.'.format(name)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
 
 
 def delete_parameter_group(name, region=None, key=None, keyid=None,
@@ -563,18 +645,16 @@ def delete_parameter_group(name, region=None, key=None, keyid=None,
         salt myminion boto_rds.delete_parameter_group my-param-group \
                 region=us-east-1
     '''
-    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-
     try:
-        conn.delete_db_parameter_group(name)
-        msg = 'Deleted RDS parameter group {0}.'.format(name)
-        log.info(msg)
-        return True
-    except boto.exception.BotoServerError as e:
-        log.debug(e)
-        msg = 'Failed to delete RDS parameter group {0}'.format(name)
-        log.error(msg)
-        return False
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'results': bool(conn)}
+
+        r = conn.delete_db_parameter_group(DBParameterGroupName=name)
+        return {'deleted': bool(r), 'message':
+                'Deleted RDS parameter group {0}.'.format(name)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
 
 
 def delete_subnet_group(name, region=None, key=None, keyid=None,
@@ -587,27 +667,20 @@ def delete_subnet_group(name, region=None, key=None, keyid=None,
         salt myminion boto_rds.delete_subnet_group my-subnet-group \
                 region=us-east-1
     '''
-    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-
     try:
-        conn.delete_db_subnet_group(name)
-        msg = 'Deleted RDS subnet group {0}.'.format(name)
-        log.info(msg)
-        return True
-    except boto.exception.BotoServerError as e:
-        log.debug(e)
-        msg = 'Failed to delete RDS subnet group {0}'.format(name)
-        log.error(msg)
-        return False
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'results': bool(conn)}
+
+        r = conn.delete_db_subnet_group(DBSubnetGroupName=name)
+        return {'deleted': bool(r), 'message':
+                'Deleted RDS subnet group {0}.'.format(name)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
 
 
-def _pythonize_dict(dictionary):
-    _ret = dict((boto.utils.pythonize_name(k), _pythonize_dict(v) if
-                 hasattr(v, 'keys') else v) for k, v in dictionary.items())
-    return _ret
-
-
-def describe_parameter_group(name, filters=None, max_records=None, marker=None, region=None, key=None, keyid=None, profile=None):
+def describe_parameter_group(name, filters=None, max_records=None, marker=None,
+                             region=None, key=None, keyid=None, profile=None):
     '''
     Returns a list of `DBParameterGroup` descriptions.
     CLI example to description of parameter group::
@@ -615,27 +688,35 @@ def describe_parameter_group(name, filters=None, max_records=None, marker=None, 
         salt myminion boto_rds.describe_parameter_group parametergroupname\
             region=us-east-1
     '''
-    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-    if not conn:
-        return False
-    if not __salt__['boto_rds.parameter_group_exists'](name, tags=None, region=region, key=key, keyid=keyid, profile=profile):
-        return False
+    res = __salt__['boto_rds.parameter_group_exists'](name, tags=None,
+                                                      region=region, key=key,
+                                                      keyid=keyid,
+                                                      profile=profile)
+    if not res:
+        return {'exists': bool(res)}
+
     try:
-        info = conn.describe_db_parameter_groups(name, filters, max_records, marker)
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'results': bool(conn)}
+
+        info = conn.describe_db_parameter_groups(DBParameterGroupName=name,
+                                                 Filters=filters,
+                                                 MaxRecords=max_records,
+                                                 Marker=marker)
+
         if not info:
-            msg = 'Failed to get RDS description for group {0}.'.format(name)
-            log.error(msg)
-            return False
-        log.info('Got RDS descrition for group {0}.'.format(name))
-        return info
-    except boto.exception.BotoServerError as e:
-        log.debug(e)
-        msg = 'Failed to get RDS description for group {0}.'.format(name)
-        log.error(msg)
-        return False
+            return {'results': bool(info), 'message':
+                    'Failed to get RDS description for group {0}.'.format(name)}
+
+        return {'results': bool (info), 'message':
+                'Got RDS descrition for group {0}.'.format(name)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
 
 
-def describe_parameters(name, source=None, max_records=None, marker=None, region=None, key=None, keyid=None, profile=None):
+def describe_parameters(name, source=None, max_records=None, marker=None,
+                        region=None, key=None, keyid=None, profile=None):
     '''
     Returns a list of `DBParameterGroup` parameters.
     CLI example to description of parameters ::
@@ -643,59 +724,133 @@ def describe_parameters(name, source=None, max_records=None, marker=None, region
         salt myminion boto_rds.describe_parameters parametergroupname\
             region=us-east-1
     '''
-    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-    if not conn:
-        return False
-    if not __salt__['boto_rds.parameter_group_exists'](name, tags=None, region=region, key=key, keyid=keyid, profile=profile):
-        return False
+    res = __salt__['boto_rds.parameter_group_exists'](name, tags=None,
+                                                      region=region, key=key,
+                                                      keyid=keyid,
+                                                      profile=profile)
+    if not res:
+        return {'exists': bool(res)}
+
     try:
-        info = conn.describe_db_parameters(name, source, max_records, marker)
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'results': bool(conn)}
+
+        info = conn.describe_db_parameters(DBParameterGroupName=name,
+                                           Source=source,
+                                           MaxRecords=max_records,
+                                           Marker=marker)
+
         if not info:
-            msg = 'Failed to get RDS parameters for group {0}.'.format(name)
-            log.error(msg)
-            return False
-        log.info('Got RDS parameters for group {0}.'.format(name))
-        return info
-    except boto.exception.BotoServerError as e:
-        log.debug(e)
-        msg = 'Failed to get RDS parameters {0}.'.format(name)
-        log.error(msg)
-        return False
+            return {'results': bool(info), 'message':
+                    'Failed to get RDS parameters for group {0}.'.format(name)}
+
+        return {'results': bool(info), 'message':
+                'Got RDS parameters for group {0}.'.format(name)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
 
 
-def modify_db_instance(name, allocated_storage=None, db_instance_class=None, db_security_groups=None, vpc_security_group_ids=None,
-                       apply_immediately=None, master_user_password=None, db_parameter_group_name=None, backup_retention_period=None,
-                       preferred_backup_window=None, preferred_maintenance_window=None, multi_az=None, engine_version=None,
-                       allow_major_version_upgrade=None, auto_minor_version_upgrade=None, storage_type=None, iops=None,
-                       option_group_name=None, new_db_instance_identifier=None, region=None, key=None, keyid=None, profile=None):
+def modify_db_instance(name,
+                       allocated_storage=None,
+                       db_instance_class=None,
+                       db_security_groups=None,
+                       vpc_security_group_ids=None,
+                       ApplyImmediately=None,
+                       master_user_password=None,
+                       db_parameter_group_name=None,
+                       backup_retention_period=None,
+                       preferred_backup_window=None,
+                       preferred_maintenance_window=None,
+                       storage_type=None,
+                       MultiAZ=None,
+                       EngineVersion=None,
+                       AllowMajorVersionUpgrade=None,
+                       AutoMinorVersionUpgrade=None,
+                       Iops=None,
+                       OptionGroupName=None,
+                       NewDBInstanceIdentifier=None,
+                       TdeCredentialArn=None,
+                       TdeCredentialPassword=None,
+                       CACertificateIdentifier=None,
+                       Domain=None,
+                       CopyTagsToSnapshot=None,
+                       MonitoringInterval=None,
+                       DBPortNumber=None,
+                       PubliclyAccessible=None,
+                       MonitoringRoleArn=None,
+                       DomainIAMRoleName=None,
+                       PromotionTier=None,
+                       region=None, key=None, keyid=None, profile=None):
     '''
     Modify settings for a DB instance.
     CLI example to description of parameters ::
 
-        salt myminion boto_rds.modify_db_instance dbname db_parameter_group_name=myparamgroup\
-            region=us-east-1
+        salt myminion boto_rds.modify_db_instance db_instance_identifier region=us-east-1
     '''
-    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-    if not conn:
-        return False
-    if not __salt__['boto_rds.exists'](name, tags=None, region=region, key=key, keyid=keyid, profile=profile):
-        log.debug('RDS db instnance {0} does not exist.'.format(name))
-        return False
+    res = __salt__['boto_rds.exists'](name, tags=None, region=region, key=key, keyid=keyid, profile=profile)
+    if not res.get('exists'):
+        return {'modified': False, 'message':
+                'RDS db instance {0} does not exist.'.format(name)}
+
     try:
-        info = conn.modify_db_instance(name, allocated_storage, db_instance_class, db_security_groups,
-                                       vpc_security_group_ids, apply_immediately, master_user_password,
-                                       db_parameter_group_name, backup_retention_period, preferred_backup_window,
-                                       preferred_maintenance_window, multi_az, engine_version,
-                                       allow_major_version_upgrade, auto_minor_version_upgrade, storage_type,
-                                       iops, option_group_name, new_db_instance_identifier)
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'modified': False}
+
+        kwargs = {}
+        for key in ('DomainIAMRoleName', 'LicenseModel',
+                    'TdeCredentialArn',
+                    'TdeCredentialPassword', 'DBname', 'Domain',
+                    'EngineVersion', 'OptionGroupName',
+                    'CharacterSetName', 'MonitoringRoleArn',
+                    'DBClusterIdentifier', 'KmsKeyId',
+                    'NewDBInstanceIdentifier',
+                    'CACertificateIdentifier',
+                    'Domain', ):
+            if locals()[key] is not None:
+                kwargs[key] = str(locals()[key])
+
+        for key in ('MonitoringInterval', 'PromotionTier',
+                    'Iops', 'DBPortNumber'):
+            if locals()[key] is not None:
+                kwargs[key] = int(locals()[key])
+
+        for key in ('CopyTagsToSnapshot', 'MultiAZ',
+                    'AutoMinorVersionUpgrade',
+                    'AllowMajorVersionUpgrade', 'StorageEncrypted',
+                    'ApplyImmediately', 'PubliclyAccessible'):
+            if locals()[key] is not None:
+                kwargs[key] = bool(locals()[key])
+
+        info = conn.modify_db_instance(DBInstanceIdentifier=name,
+                                       AllocatedStorage=allocated_storage,
+                                       DBInstanceClass=db_instance_class,
+                                       DBSecurityGroups=db_security_groups,
+                                       VpcSecurityGroupIds=vpc_security_group_ids,
+                                       MasterUserPassword=master_user_password,
+                                       DBParameterGroupName=db_parameter_group_name,
+                                       BackupRetentionPeriod=backup_retention_period,
+                                       PreferredBackupWindow=preferred_backup_window,
+                                       PreferredMaintenanceWindow=preferred_maintenance_window,
+                                       StorageType=storage_type, Tags=taglist,
+                                       **kwargs)
+
         if not info:
-            msg = 'Failed to modify RDS db instance {0}.'.format(name)
-            log.error(msg)
-            return False
-        log.info('Modified RDS db instance {0}.'.format(info))
-        return info
-    except boto.exception.BotoServerError as e:
-        log.debug(e)
-        msg = 'Failed to modify RDS db instance {0}.'.format(name)
-        log.error(msg)
-        return False
+            return {'modified': bool(info), 'message':
+                    'Failed to modify RDS db instance {0}.'.format(name)}
+
+        return {'modified': bool(info), 'message':
+                'Modified RDS db instance {0}.'.format(info)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def _tag_doc(tags):
+    taglist = []
+    if tags is not None:
+        for k, v in tags.iteritems():
+            if str(k).startswith('__'):
+                continue
+            taglist.append({'Key': str(k), 'Value': str(v)})
+    return taglist

--- a/salt/states/boto_rds.py
+++ b/salt/states/boto_rds.py
@@ -41,6 +41,7 @@ config:
       boto_rds.present:
         - name: myrds
         - allocated_storage: 5
+        - storage_type: standard
         - db_instance_class: db.t2.micro
         - engine: MySQL
         - master_username: myuser
@@ -70,24 +71,19 @@ config:
             - region: eu-west-1
 .. note::
 
-    This state module uses ``boto.rds2``, which requires a different tagging syntax than
-    some of the other boto states. The ``tags`` key and value set noted in the example
-    above is the required yaml notation that ``rds2`` depends upon to function properly.
-    For more information, please see `Issue #28715`_.
-
-.. _Issue #28715: https://github.com/saltstack/salt/issues/28715
-
+:depends: boto3
 
 '''
 
 # Import Python Libs
 from __future__ import absolute_import
 import logging
-import os
 
 # Import Salt Libs
 from salt.exceptions import SaltInvocationError
-from salt.utils import exactly_one
+import salt.utils
+
+log = logging.getLogger(__name__)
 
 
 def __virtual__():
@@ -106,12 +102,18 @@ def present(name,
             master_username,
             master_user_password,
             db_name=None,
+            storage_type=None,
             db_security_groups=None,
             vpc_security_group_ids=None,
             availability_zone=None,
             db_subnet_group_name=None,
             preferred_maintenance_window=None,
             db_parameter_group_name=None,
+            db_cluster_identifier=None,
+            tde_credential_arn=None,
+            tde_credential_password=None,
+            storage_encrypted=None,
+            kms_keyid=None,
             backup_retention_period=None,
             preferred_backup_window=None,
             port=None,
@@ -125,15 +127,21 @@ def present(name,
             publicly_accessible=None,
             wait_status=None,
             tags=None,
+            copy_tags_to_snapshot=None,
             region=None,
+            domain=None,
             key=None,
             keyid=None,
+            monitoring_interval=None,
+            monitoring_role_arn=None,
+            domain_iam_role_name=None,
+            promotion_tier=None,
             profile=None):
     '''
     Ensure RDS instance exists.
 
     name
-        Name of the RDS instance.
+        Name of the RDS state definition.
 
     allocated_storage
         The amount of storage (in gigabytes) to be initially allocated for the
@@ -144,10 +152,10 @@ def present(name,
 
     engine
         The name of the database engine to be used for this instance. Supported
-        engine types are: MySQL, oracle-se1, oracle-se, oracle-ee, sqlserver-ee,
-        sqlserver-se, sqlserver-ex, sqlserver-web, and postgres. For more
-        information, please see the ``engine`` argument in the boto_rds
-        `create_dbinstance`_ documentation.
+        engine types are: MySQL, mariadb, oracle-se1, oracle-se, oracle-ee, sqlserver-ee,
+        sqlserver-se, sqlserver-ex, sqlserver-web, postgres and aurora. For more
+        information, please see the ``engine`` argument in the Boto3 RDS
+        `create_db_instance`_ documentation.
 
     master_username
         The name of master user for the client DB instance.
@@ -157,7 +165,14 @@ def present(name,
         character except "/", '"', or "@".
 
     db_name
-        The database name for the restored DB instance.
+        The meaning of this parameter differs according to the database engine you use.
+        See the Boto3 RDS documentation to determine the appropriate value for your configuration.
+        https://boto3.readthedocs.io/en/latest/reference/services/rds.html#RDS.Client.create_db_instance
+
+    storage_type
+        Specifies the storage type to be associated with the DB instance.
+        Options are standard, gp2 and io1. If you specify io1, you must also include
+        a value for the Iops parameter.
 
     db_security_groups
         A list of DB security groups to associate with this DB instance.
@@ -175,6 +190,27 @@ def present(name,
     preferred_maintenance_window
         The weekly time range (in UTC) during which system maintenance can
         occur.
+
+    db_parameter_group_name
+        A DB parameter group to associate with this DB instance.
+
+    db_cluster_identifier
+        If the DB instance is a member of a DB cluster, contains the name of
+        the DB cluster that the DB instance is a member of.
+
+    tde_credential_arn
+        The ARN from the Key Store with which the instance is associated for
+        TDE encryption.
+
+    tde_credential_password
+        The password to use for TDE encryption if an encryption key is not used.
+
+    storage_encrypted
+        Specifies whether the DB instance is encrypted.
+
+    kms_keyid
+        If storage_encrypted is true, the KMS key identifier for the encrypted
+        DB instance.
 
     backup_retention_period
         The number of days for which automated backups are retained.
@@ -226,106 +262,107 @@ def present(name,
     tags
         A list of tags.
 
+    copy_tags_to_snapshot
+        Specifies whether tags are copied from the DB instance to snapshots of
+        the DB instance.
+
     region
         Region to connect to.
 
+    domain
+        The identifier of the Active Directory Domain.
+
     key
-        Secret key to be used.
+        AWS secret key to be used.
 
     keyid
-        Access key to be used.
+        AWS access key to be used.
+
+    monitoring_interval
+        The interval, in seconds, between points when Enhanced Monitoring
+        metrics are collected for the DB instance.
+
+    monitoring_role_arn
+        The ARN for the IAM role that permits RDS to send Enhanced Monitoring
+        metrics to CloudWatch Logs.
+
+    domain_iam_role_name
+        Specify the name of the IAM role to be used when making API calls to
+        the Directory Service.
+
+    promotion_tier
+        A value that specifies the order in which an Aurora Replica is
+        promoted to the primary instance after a failure of the existing
+        primary instance. For more information, see Fault Tolerance for an
+        Aurora DB Cluster .
 
     profile
         A dict with region, key and keyid, or a pillar key (string) that
         contains a dict with region, key and keyid.
 
-    .. _create_dbinstance: https://boto.readthedocs.io/en/latest/ref/rds.html#boto.rds.RDSConnection.create_dbinstance
+    .. _create_dbinstance: https://boto3.readthedocs.io/en/latest/reference/services/rds.html#RDS.Client.create_db_instance
     '''
     ret = {'name': name,
            'result': True,
            'comment': '',
            'changes': {}
            }
-    _ret = _rds_present(name, allocated_storage,
-                        db_instance_class, engine,
-                        master_username, master_user_password, db_name,
-                        db_security_groups, vpc_security_group_ids,
-                        availability_zone, db_subnet_group_name,
-                        preferred_maintenance_window, db_parameter_group_name,
-                        backup_retention_period, preferred_backup_window, port,
-                        multi_az, engine_version, auto_minor_version_upgrade,
-                        license_model, iops, option_group_name,
-                        character_set_name, publicly_accessible, wait_status,
-                        tags, region, key, keyid, profile)
-    ret['changes'] = _ret['changes']
-    ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
-    if not _ret['result']:
-        ret['result'] = _ret['result']
-        if ret['result'] is False:
-            return ret
-    return ret
 
+    r = __salt__['boto_rds.exists'](name, region, key, keyid, profile)
 
-def _rds_present(name, allocated_storage, db_instance_class,
-                 engine, master_username, master_user_password, db_name=None,
-                 db_security_groups=None, vpc_security_group_ids=None,
-                 availability_zone=None, db_subnet_group_name=None,
-                 preferred_maintenance_window=None,
-                 db_parameter_group_name=None, backup_retention_period=None,
-                 preferred_backup_window=None, port=None, multi_az=None,
-                 engine_version=None, auto_minor_version_upgrade=None,
-                 license_model=None, iops=None, option_group_name=None,
-                 character_set_name=None, publicly_accessible=None,
-                 wait_status=None, tags=None, region=None, key=None,
-                 keyid=None, profile=None):
-    ret = {'result': True,
-           'comment': '',
-           'changes': {}
-           }
-    exists = __salt__['boto_rds.exists'](name, tags, region, key, keyid,
-                                         profile)
-    if not exists:
+    if not r.get('exists'):
         if __opts__['test']:
-            ret['comment'] = 'RDS {0} is set to be created.'.format(name)
+            ret['comment'] = 'RDS instance {0} is set to be created.'.format(name)
             ret['result'] = None
             return ret
-        created = __salt__['boto_rds.create'](name, allocated_storage,
-                                              db_instance_class,
-                                              engine, master_username,
-                                              master_user_password, db_name,
-                                              db_security_groups,
-                                              vpc_security_group_ids,
-                                              availability_zone,
-                                              db_subnet_group_name,
-                                              preferred_maintenance_window,
-                                              db_parameter_group_name,
-                                              backup_retention_period,
-                                              preferred_backup_window, port,
-                                              multi_az, engine_version,
-                                              auto_minor_version_upgrade,
-                                              license_model, iops,
-                                              option_group_name,
-                                              character_set_name,
-                                              publicly_accessible,
-                                              wait_status, tags, region, key,
-                                              keyid, profile)
-        if not created:
+
+        r = __salt__['boto_rds.create'](name, allocated_storage,
+                                        db_instance_class, engine,
+                                        master_username,
+                                        master_user_password,
+                                        db_name, db_security_groups,
+                                        vpc_security_group_ids,
+                                        availability_zone,
+                                        db_subnet_group_name,
+                                        preferred_maintenance_window,
+                                        db_parameter_group_name,
+                                        backup_retention_period,
+                                        preferred_backup_window,
+                                        port, multi_az, engine_version,
+                                        auto_minor_version_upgrade,
+                                        license_model, iops,
+                                        option_group_name,
+                                        character_set_name,
+                                        publicly_accessible, wait_status,
+                                        tags, db_cluster_identifier,
+                                        storage_type, tde_credential_arn,
+                                        tde_credential_password,
+                                        storage_encrypted, kms_keyid,
+                                        domain, copy_tags_to_snapshot,
+                                        monitoring_interval,
+                                        monitoring_role_arn,
+                                        domain_iam_role_name, region,
+                                        promotion_tier, key, keyid, profile)
+
+        if not r.get('created'):
             ret['result'] = False
-            ret['comment'] = 'Failed to create {0} RDS.'.format(name)
+            ret['comment'] = 'Failed to create RDS instance {0}.'.format(r['error']['message'])
             return ret
-        _describe = __salt__['boto_rds.describe'](name, tags, region, key,
-                                                  keyid, profile)
-        ret['changes']['old'] = {'rds': None}
-        ret['changes']['new'] = {'rds': _describe}
-        ret['comment'] = 'RDS {0} created.'.format(name)
+
+        _describe = __salt__['boto_rds.describe'](name, region, key, keyid, profile)
+        ret['changes']['old'] = {'instance': None}
+        ret['changes']['new'] = _describe
+        ret['comment'] = 'RDS instance {0} created.'.format(name)
     else:
-        ret['comment'] = 'RDS replica {0} exists.'.format(name)
+        ret['comment'] = 'RDS instance {0} exists.'.format(name)
     return ret
 
 
-def replica_present(name, source, db_instance_class=None, availability_zone=None, port=None,
-                    auto_minor_version_upgrade=None, iops=None, option_group_name=None,
-                    publicly_accessible=None, tags=None, region=None, key=None, keyid=None,
+def replica_present(name, source, db_instance_class=None,
+                    availability_zone=None, port=None,
+                    auto_minor_version_upgrade=None, iops=None,
+                    option_group_name=None, publicly_accessible=None,
+                    tags=None, region=None, key=None, keyid=None,
                     profile=None):
     '''
     Ensure RDS replica exists.
@@ -409,7 +446,7 @@ def subnet_group_present(name, description, subnet_ids=None, subnet_names=None,
         A dict with region, key and keyid, or a pillar key (string) that
         contains a dict with region, key and keyid.
     '''
-    if not exactly_one((subnet_ids, subnet_names)):
+    if not salt.utils.exactly_one((subnet_ids, subnet_names)):
         raise SaltInvocationError('One (but not both) of subnet_ids or '
                                   'subnet_names must be provided.')
 
@@ -424,46 +461,54 @@ def subnet_group_present(name, description, subnet_ids=None, subnet_names=None,
 
     if subnet_names:
         for i in subnet_names:
-            r = __salt__['boto_vpc.get_resource_id']('subnet',
-                                                     name=i,
+            r = __salt__['boto_vpc.get_resource_id']('subnet', name=i,
                                                      region=region,
-                                                     key=key,
-                                                     keyid=keyid,
+                                                     key=key, keyid=keyid,
                                                      profile=profile)
 
             if 'error' in r:
-                msg = 'Error looking up subnet ids: {0}'.format(
+                ret['comment'] = 'Error looking up subnet ids: {0}'.format(
                     r['error']['message'])
-                ret['comment'] = msg
                 ret['result'] = False
                 return ret
             if r['id'] is None:
-                msg = 'Subnet {0} does not exist.'.format(i)
-                ret['comment'] = msg
+                ret['comment'] = 'Subnet {0} does not exist.'.format(i)
                 ret['result'] = False
                 return ret
             subnet_ids.append(r['id'])
 
-    exists = __salt__['boto_rds.subnet_group_exists'](name=name, tags=tags, region=region, key=key,
-                                                      keyid=keyid, profile=profile)
-    if not exists:
-        if __opts__['test']:
-            ret['comment'] = 'Subnet group {0} is set to be created.'.format(name)
-            ret['result'] = None
-            return ret
-        created = __salt__['boto_rds.create_subnet_group'](name=name, subnet_ids=subnet_ids,
-                                                           description=description, tags=tags, region=region,
-                                                           key=key, keyid=keyid, profile=profile)
-        if not created:
-            ret['result'] = False
-            ret['comment'] = 'Failed to create {0} subnet group.'.format(name)
-            return ret
-        ret['changes']['old'] = None
-        ret['changes']['new'] = name
-        ret['comment'] = 'Subnet {0} created.'.format(name)
+    for i in subnet_ids:
+        r = __salt__['boto_rds.create_subnet_group'](name=name,
+                                                     description=description,
+                                                     subnet_ids=subnet_ids,
+                                                     tags=tags, region=region,
+                                                     key=key, keyid=keyid,
+                                                     profile=profile)
+
+        if not r.get('exists'):
+            if __opts__['test']:
+                ret['comment'] = 'Subnet group {0} is set to be created.'.format(name)
+                ret['result'] = None
+                return ret
+            if not r.get('created'):
+                ret['result'] = False
+                ret['comment'] = 'Failed to create {0} subnet group.'.format(r['error']['message'])
+                return ret
+
+            _describe = __salt__['boto_rds.describe']('subnet',
+                                                      name=i,
+                                                      region=region,
+                                                      key=key,
+                                                      keyid=keyid,
+                                                      profile=profile)
+
+            ret['changes']['old'] = None
+            ret['changes']['new'] = _describe
+            ret['comment'] = 'Subnet {0} created.'.format(name)
+        else:
+            ret['comment'] = 'Subnet {0} present.'.format(name)
+
         return ret
-    ret['comment'] = 'Subnet present.'
-    return ret
 
 
 def absent(name, skip_final_snapshot=None, final_db_snapshot_identifier=None,
@@ -500,7 +545,7 @@ def absent(name, skip_final_snapshot=None, final_db_snapshot_identifier=None,
         A dict with region, key and keyid, or a pillar key (string) that
         contains a dict with region, key and keyid.
 
-    .. _create_dbinstance: https://boto.readthedocs.io/en/latest/ref/rds.html#boto.rds.RDSConnection.create_dbinstance
+    .. _create_db_instance: https://boto3.readthedocs.io/en/latest/reference/services/rds.html#RDS.Client.create_db_instance
 
     wait_for_deletion (bool)
         Wait for the RDS instance to be deleted completely before finishing


### PR DESCRIPTION
### What does this PR do?

Migrates boto_rds states and modules to boto3 and enables support for things like StorageType.
### What issues does this PR fix or reference?
#26784

Possibly #23607
### New Behavior

Support for setting StorageType as well as many other AWS RDS features found in newer API.
### Tests written?

No

This started off being an attempt to add support for StorageType and ended up being a full helping of Boto3 and Salt. I am sure there is some more work to do here but would like to offer this in hopes that I can take away some feedback to make it an acceptable PR. Green on Python and Salt module/state development.

@cachedout New PR against develop as requested. https://github.com/saltstack/salt/pull/33867

@lorengordon @ryan-lane 
