### PR TITLE
Use full path to python.exe

### DIFF
--- a/pkg/windows/build_pkg.bat
+++ b/pkg/windows/build_pkg.bat
@@ -32,11 +32,11 @@ xcopy /S /E "%PyDir%" "%BinDir%\"
 
 :: Remove the fixed path in .exe files
 @echo Removing fixed path from .exe files
-python "%CurrDir%\portable.py" -f "%BinDir%\Scripts\easy_install.exe"
-python "%CurrDir%\portable.py" -f "%BinDir%\Scripts\easy_install-2.7.exe"
-python "%CurrDir%\portable.py" -f "%BinDir%\Scripts\pip.exe"
-python "%CurrDir%\portable.py" -f "%BinDir%\Scripts\pip2.7.exe"
-python "%CurrDir%\portable.py" -f "%BinDir%\Scripts\pip2.exe"
+%PyDir%\python "%CurrDir%\portable.py" -f "%BinDir%\Scripts\easy_install.exe"
+%PyDir%\python "%CurrDir%\portable.py" -f "%BinDir%\Scripts\easy_install-2.7.exe"
+%PyDir%\python "%CurrDir%\portable.py" -f "%BinDir%\Scripts\pip.exe"
+%PyDir%\python "%CurrDir%\portable.py" -f "%BinDir%\Scripts\pip2.7.exe"
+%PyDir%\python "%CurrDir%\portable.py" -f "%BinDir%\Scripts\pip2.exe"
 
 @ echo Cleaning up unused files and directories...
 @ echo -------------------------------------------


### PR DESCRIPTION
### What does this PR do?

Add's full path to the python executable when building the package
### What issues does this PR fix or reference?

None
### Previous Behavior

It would just launch python. If called from a shell that installed python, the environment isn't refreshed yet, so it can't find the python binary. As a result, the pip and easy_install binaries were not being modified correctly.
### New Behavior

Launches python with the full path, so it will always find it.
### Tests written?

NA
