### PR TITLE
Enable transport fallback

### DIFF
--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -311,7 +311,7 @@ class Minion(parsers.MinionOptionParser, DaemonsMixin):  # pylint: disable=no-in
             self.shutdown(1)
 
         # TODO: AIO core is separate from transport
-        if self.config['transport'].lower() in ('zeromq', 'tcp'):
+        if self.config['transport'].lower() in ('zeromq', 'tcp', 'detect'):
             # Late import so logging works correctly
             import salt.minion
             # If the minion key has not been accepted, then Salt enters a loop

--- a/salt/transport/client.py
+++ b/salt/transport/client.py
@@ -147,6 +147,13 @@ class AsyncPubChannel(AsyncChannel):
             ttype = opts['transport']
         elif 'transport' in opts.get('pillar', {}).get('master', {}):
             ttype = opts['pillar']['master']['transport']
+        if ttype == 'detect':
+            opts['__last_transport'] = 'tcp'
+            opts['transport'] = 'tcp'
+            ttype = opts['transport']
+        elif '__last_transport' in opts:
+            opts['transport'] = 'zeromq' if opts['transport'] == 'tcp' else 'tcp'
+            ttype = opts['transport']
 
         # switch on available ttypes
         if ttype == 'zeromq':

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -878,6 +878,9 @@ class SaltMessageClient(object):
                 if self._connecting_future.done():
                     self._connecting_future = self.connect()
                 yield self._connecting_future
+            except TypeError:
+                # This is an invalid transport
+                raise SaltClientError
             except Exception as e:
                 log.error('Exception parsing response', exc_info=True)
                 for future in six.itervalues(self.send_future_map):


### PR DESCRIPTION
### What does this PR do?

Adds the new option to transport "detect", which will make the minion toggle between tcp and zeromq until it connects
### What issues does this PR fix or reference?
#33881
### Previous Behavior

just searched for the named transport
### New Behavior

AWESOME
### Tests written?

No

We could easily add tests by setting the default minion in the test suite to "detect" and keep the master at zeroMQ, since the detect tries tcp first
