### PR TITLE
Call `sys.exit()` instead of `exit()`

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -865,7 +865,7 @@ class Minion(MinionBase):
         self.process_manager.send_signal_to_processes(signum)
         # kill any remaining processes
         self.process_manager.kill_children()
-        exit(0)
+        sys.exit(0)
 
     def sync_connect_master(self, timeout=None):
         '''

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -92,7 +92,7 @@ def minion_process():
         delay = randint(1, delay)
         log.info('waiting random_reauth_delay {0}s'.format(delay))
         time.sleep(delay)
-        exit(salt.defaults.exitcodes.SALT_KEEPALIVE)
+        sys.exit(salt.defaults.exitcodes.SALT_KEEPALIVE)
 
 
 def salt_minion():

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -6,6 +6,7 @@ Zeromq transport classes
 # Import Python Libs
 from __future__ import absolute_import
 import os
+import sys
 import copy
 import errno
 import signal
@@ -636,7 +637,7 @@ class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.
             msg += 'SIGTERM'
         msg += '. Exiting'
         log.debug(msg)
-        exit(salt.defaults.exitcodes.EX_OK)
+        sys.exit(salt.defaults.exitcodes.EX_OK)
 
 
 class ZeroMQPubServerChannel(salt.transport.server.PubServerChannel):

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -652,7 +652,7 @@ class SignalHandlingMultiprocessingProcess(MultiprocessingProcess):
             msg += 'SIGTERM'
         msg += '. Exiting'
         log.debug(msg)
-        exit(salt.defaults.exitcodes.EX_OK)
+        sys.exit(salt.defaults.exitcodes.EX_OK)
 
     def start(self):
         with default_signals(signal.SIGINT, signal.SIGTERM):

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -256,6 +256,7 @@ dictionary, othewise it will be ignored.
 # Import python libs
 from __future__ import absolute_import, with_statement
 import os
+import sys
 import time
 import signal
 import datetime
@@ -788,7 +789,7 @@ class Schedule(object):
             finally:
                 if multiprocessing_enabled:
                     # Let's make sure we exit the process!
-                    exit(salt.defaults.exitcodes.EX_GENERIC)
+                    sys.exit(salt.defaults.exitcodes.EX_GENERIC)
 
     def eval(self):
         '''


### PR DESCRIPTION
### What does this PR do?

Calls `sys.exit()` instead of `exit()`

This will prevent an error with running a frozen(Using PyInstaller) version of salt:

``` python
Process SignalHandlingMultiprocessingProcess-1:3:
Traceback (most recent call last):
  File "multiprocessing/process.py", line 258, in _bootstrap
  File "site-packages/salt/utils/process.py", line 613, in _run
  File "multiprocessing/process.py", line 114, in run
  File "site-packages/salt/utils/schedule.py", line 791, in handle_func
NameError: global name 'exit' is not defined
```
