### PR TITLE
Fix develop stacktrace

### DIFF
--- a/salt/utils/s3.py
+++ b/salt/utils/s3.py
@@ -165,7 +165,7 @@ def query(key, keyid, method='GET', params=None, headers=None,
             err_data = xml.to_dict(ET.fromstring(err_text))
             err_code = err_data['Code']
             err_msg = err_data['Message']
-        except (KeyError, ET.ParseError), err:
+        except (KeyError, ET.ParseError) as err:
             log.debug('Failed to parse s3 err response. {0}: {1}'.format(
                 type(err).__name__, err))
             err_code = 'http-{0}'.format(result.status_code)


### PR DESCRIPTION
Fixes this:

```
mp@silver ...devel/salt/tests % sudo ./runtests.py -h                                                                                                             (git)-[develop] 
Traceback (most recent call last):
  File "./runtests.py", line 14, in <module>
    from integration import TestDaemon, TMP  # pylint: disable=W0403
  File "/home/mp/devel/salt/tests/integration/__init__.py", line 62, in <module>
    import salt.minion
  File "/home/mp/devel/salt/salt/minion.py", line 88, in <module>
    import salt.pillar
  File "/home/mp/devel/salt/salt/pillar/__init__.py", line 16, in <module>
    import salt.fileclient
  File "/home/mp/devel/salt/salt/fileclient.py", line 32, in <module>
    import salt.utils.s3
  File "/home/mp/devel/salt/salt/utils/s3.py", line 168
    except (KeyError, ET.ParseError), err:
```
