### PR TITLE
fix redis_return's clean_old_jobs.

### DIFF
--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -212,6 +212,11 @@ def get_minions():
 def clean_old_jobs():
     '''
     Clean out minions's return data for old jobs.
+
+    Normally, hset 'ret:<jid>' are saved with a TTL, and will eventually
+    get cleaned by redis.But for jobs with some very late minion return, the
+    corresponding hset's TTL will be refreshed to a too late timestamp, we'll
+    do manually cleaning here.
     '''
     serv = _get_serv(ret=None)
     living_jids = set(serv.keys('load:*'))
@@ -220,7 +225,7 @@ def clean_old_jobs():
         load_key = ret_key.replace('ret:', 'load:', 1)
         if load_key not in living_jids:
             to_remove.append(ret_key)
-    serv.delete(**to_remove)  # pylint: disable=E1134
+    serv.delete(*to_remove)
 
 
 def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument


### PR DESCRIPTION
### What does this PR do?

fix a type mismatch in a call to redis.delete in redis returner's clean_old_jobs.
### What issues does this PR fix or reference?

Refs #33969 
### Tests written?

No, since this is a bug fix and no new cases introduced in
