### PR TITLE
Fix incorrectly written test

### DIFF
--- a/tests/integration/output/output.py
+++ b/tests/integration/output/output.py
@@ -10,11 +10,13 @@ import copy
 
 # Import Salt Testing Libs
 from salttesting.helpers import ensure_in_syspath
+from salttesting.mixins import RUNTIME_VARS
 
 ensure_in_syspath('../../')
 
 # Import Salt libs
 import integration
+import salt.config
 from salt.output import display_output
 
 
@@ -85,15 +87,15 @@ class OutputReturnTest(integration.ShellCase):
         '''
         Tests outputter reliability with utf8
         '''
-        opts = copy.deepcopy(self.minion_opts)
+        opts = salt.config.minion_config(os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'minion'))
         opts['output_file'] = os.path.join(
-            self.minion_opts['root_dir'], 'outputtest')
+            opts['root_dir'], 'outputtest')
         data = {'foo': {'result': False,
                         'aaa': 'azerzaeréééé',
                         'comment': u'ééééàààà'}}
         try:
             # this should not raises UnicodeEncodeError
-            display_output(data, opts=self.minion_opts)
+            display_output(data, opts=opts)
             self.assertTrue(True)
         except Exception:
             # display trace in error message for debugging on jenkins


### PR DESCRIPTION
Modified to use the correct method for generating a new copy of opts inside an integration test.
