### PR TITLE
Remove loader test for pam module

### DIFF
--- a/salt/modules/pam.py
+++ b/salt/modules/pam.py
@@ -6,18 +6,22 @@ from __future__ import absolute_import
 
 # Import python libs
 import os
+import logging
 
 # Import salt libs
 import salt.utils
 
+log = logging.getLogger(__name__)
+
+# Define the module's virtual name
+__virtualname__ = 'pam'
+
 
 def __virtual__():
     '''
-    Only load the module if iptables is installed
+    Set the virtual name for the module
     '''
-    if os.path.exists('/usr/lib/libpam.so'):
-        return 'pam'
-    return False
+    return __virtualname__
 
 
 def _parse(contents=None, file_name=None):
@@ -30,6 +34,7 @@ def _parse(contents=None, file_name=None):
         with salt.utils.fopen(file_name, 'r') as ifile:
             contents = ifile.read()
     else:
+        log.error('File "{0}" does not exist'.format(file_name))
         return False
 
     rules = []


### PR DESCRIPTION
### What does this PR do?

Remove the test in the `__virtual__` function for the `pam` module. The test in the virtual function was unnecessary. The pam module does not itself rely on any external python or pam libraries. The
only function present, pam.read_file(), accepts a file name as a parameter, checks if it exists, and parses the file. There is no reason to avoid loading the module.
### What issues does this PR fix or reference?

Fixes #20809
### Previous Behavior

The `pam` module would load only if `/usr/lib/libpam.so` existed.
### New Behavior

The `pam` module will always load, as there is no inherent python or pam library dependency.
### Tests written?

No
