### PR TITLE
Raise a warning to a user if using Py2 byte-compiled files in Py3

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1295,7 +1295,10 @@ class LazyLoader(salt.utils.lazy.LazyDict):
 
         except IOError:
             raise
-        except ImportError:
+        except ImportError as exc:
+            if 'magic number' in str(exc):
+                log.warning('Failed to import {0} {1}. Bad magic number. If migrating '
+                        'from Python2 to Python3, remove all .pyc files and try again.'.format(self.tag, name))
             log.debug(
                 'Failed to import {0} {1}:\n'.format(
                     self.tag, name


### PR DESCRIPTION
### What does this PR do?

Raises a warning to the user if the loader encounters a Py2 byte-compiled module in Py3.
### What issues does this PR fix or reference?

None
### Previous Behavior

The LazyLoader would be empty.
### New Behavior

The lazyloader is still empty but you are filled with knowledge and delight.
### Tests written?

No
