### PR TITLE
Back-port #33948 and #34009 to 2015.8

### DIFF
--- a/doc/topics/releases/2015.8.11.rst
+++ b/doc/topics/releases/2015.8.11.rst
@@ -1,0 +1,13 @@
+============================
+Salt 2015.8.11 Release Notes
+============================
+
+Version 2015.8.11 is a bugfix release for :doc:`2015.8.0
+</topics/releases/2015.8.0>`.
+
+Returner Changes
+================
+
+- Any returner which implements a ``save_load`` function is now required to
+  accept a ``minions`` keyword argument. All returners which ship with Salt
+  have been modified to do so.

--- a/salt/master.py
+++ b/salt/master.py
@@ -2109,7 +2109,7 @@ class ClearFuncs(object):
         if self.opts['ext_job_cache']:
             try:
                 fstr = '{0}.save_load'.format(self.opts['ext_job_cache'])
-                self.mminion.returners[fstr](clear_load['jid'], clear_load)
+                self.mminion.returners[fstr](clear_load['jid'], clear_load, minions=minions)
             except KeyError:
                 log.critical(
                     'The specified returner used for the external job cache '

--- a/salt/master.py
+++ b/salt/master.py
@@ -50,6 +50,7 @@ import salt.fileserver
 import salt.daemons.masterapi
 import salt.defaults.exitcodes
 import salt.transport.server
+import salt.utils.args
 import salt.utils.atomicfile
 import salt.utils.event
 import salt.utils.job
@@ -2107,21 +2108,40 @@ class ClearFuncs(object):
         self.event.fire_event(new_job_load, tagify([clear_load['jid'], 'new'], 'job'))
 
         if self.opts['ext_job_cache']:
+            fstr = '{0}.save_load'.format(self.opts['ext_job_cache'])
+            save_load_func = True
+
+            # Get the returner's save_load arg_spec.
             try:
-                fstr = '{0}.save_load'.format(self.opts['ext_job_cache'])
-                self.mminion.returners[fstr](clear_load['jid'], clear_load, minions=minions)
-            except KeyError:
+                arg_spec = salt.utils.args.get_function_argspec(fstr)
+
+                # Check if 'minions' is included in returner's save_load arg_spec.
+                # This may be missing in custom returners, which we should warn about.
+                if 'minions' not in arg_spec.args:
+                    log.critical(
+                        'The specified returner used for the external job cache '
+                        '\'{0}\' does not have a \'minions\' kwarg in the returner\'s '
+                        'save_load function.'.format(
+                            self.opts['ext_job_cache']
+                        )
+                    )
+            except AttributeError:
+                save_load_func = False
                 log.critical(
                     'The specified returner used for the external job cache '
                     '"{0}" does not have a save_load function!'.format(
                         self.opts['ext_job_cache']
                     )
                 )
-            except Exception:
-                log.critical(
-                    'The specified returner threw a stack trace:\n',
-                    exc_info=True
-                )
+
+            if save_load_func:
+                try:
+                    self.mminion.returners[fstr](clear_load['jid'], clear_load, minions=minions)
+                except Exception:
+                    log.critical(
+                        'The specified returner threw a stack trace:\n',
+                        exc_info=True
+                    )
 
         # always write out to the master job caches
         try:

--- a/salt/returners/cassandra_cql_return.py
+++ b/salt/returners/cassandra_cql_return.py
@@ -236,7 +236,7 @@ def event_return(events):
             raise
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load to the specified jid id
     '''

--- a/salt/returners/couchbase_return.py
+++ b/salt/returners/couchbase_return.py
@@ -184,7 +184,7 @@ def returner(load):
         return False
 
 
-def save_load(jid, clear_load):
+def save_load(jid, clear_load, minion=None):
     '''
     Save the load to the specified jid
     '''

--- a/salt/returners/django_return.py
+++ b/salt/returners/django_return.py
@@ -65,7 +65,7 @@ def returner(ret):
                   'which responded with {1}'.format(signal[0], signal[1]))
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load to the specified jid
     '''

--- a/salt/returners/elasticsearch_return.py
+++ b/salt/returners/elasticsearch_return.py
@@ -119,7 +119,7 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load to the specified jid id
 

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -102,7 +102,7 @@ def returner(ret):
         client.write(dest, json.dumps(ret[field]))
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load to the specified jid
     '''

--- a/salt/returners/influxdb_return.py
+++ b/salt/returners/influxdb_return.py
@@ -128,7 +128,7 @@ def returner(ret):
         log.critical('Failed to store return with InfluxDB returner: {0}'.format(ex))
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load to the specified jid
     '''

--- a/salt/returners/memcache_return.py
+++ b/salt/returners/memcache_return.py
@@ -130,7 +130,7 @@ def returner(ret):
             serv.add('jids', ret['jid'] + ',')
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load to the specified jid
     '''

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -190,7 +190,7 @@ def returner(ret):
         mdb.saltReturns.insert(sdata.copy())
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load for a given job id
     '''

--- a/salt/returners/multi_returner.py
+++ b/salt/returners/multi_returner.py
@@ -61,7 +61,7 @@ def returner(load):
         _mminion().returners['{0}.returner'.format(returner_)](load)
 
 
-def save_load(jid, clear_load):
+def save_load(jid, clear_load, minions=None):
     '''
     Write load to all returners in multi_returner
     '''

--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -278,7 +278,7 @@ def event_return(events):
             cur.execute(sql, (tag, json.dumps(data), __opts__['id']))
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load to the specified jid id
     '''

--- a/salt/returners/odbc.py
+++ b/salt/returners/odbc.py
@@ -205,7 +205,7 @@ def returner(ret):
     _close_conn(conn)
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load to the specified jid id
     '''

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -263,7 +263,7 @@ def event_return(events):
                               __opts__['id'], time.strftime('%Y-%m-%d %H:%M:%S %z', time.localtime())))
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load to the specified jid id
     '''

--- a/salt/returners/postgres.py
+++ b/salt/returners/postgres.py
@@ -181,7 +181,7 @@ def returner(ret):
     _close_conn(conn)
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load to the specified jid id
     '''

--- a/salt/returners/postgres_local_cache.py
+++ b/salt/returners/postgres_local_cache.py
@@ -224,7 +224,7 @@ def returner(load):
     _close_conn(conn)
 
 
-def save_load(jid, clear_load):
+def save_load(jid, clear_load, minions=None):
     '''
     Save the load to the specified jid id
     '''

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -106,7 +106,7 @@ def returner(ret):
     pipe.execute()
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load to the specified jid
     '''

--- a/salt/returners/sqlite3_return.py
+++ b/salt/returners/sqlite3_return.py
@@ -170,7 +170,7 @@ def returner(ret):
     _close_conn(conn)
 
 
-def save_load(jid, load):
+def save_load(jid, load, minions=None):
     '''
     Save the load to the specified jid
     '''

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -632,7 +632,7 @@ class CkMinions(object):
             minions = []
         return minions
 
-    def validate_tgt(self, valid, expr, expr_form):
+    def validate_tgt(self, valid, expr, expr_form, minions=None):
         '''
         Return a Bool. This function returns if the expression sent in is
         within the scope of the valid expression
@@ -655,7 +655,8 @@ class CkMinions(object):
         v_expr = target_info['pattern']
 
         v_minions = set(self.check_minions(v_expr, v_matcher))
-        minions = set(self.check_minions(expr, expr_form))
+        if minions is None:
+            minions = set(self.check_minions(expr, expr_form))
         d_bool = not bool(minions.difference(v_minions))
         if len(v_minions) == len(minions) and d_bool:
             return True
@@ -701,7 +702,8 @@ class CkMinions(object):
                    tgt,
                    tgt_type='glob',
                    groups=None,
-                   publish_validate=False):
+                   publish_validate=False,
+                   minions=None):
         '''
         Returns a bool which defines if the requested function is authorized.
         Used to evaluate the standard structure under external master
@@ -740,7 +742,8 @@ class CkMinions(object):
                         if self.validate_tgt(
                                 valid,
                                 tgt,
-                                tgt_type):
+                                tgt_type,
+                                minions=minions):
                             # Minions are allowed, verify function in allowed list
                             if isinstance(ind[valid], six.string_types):
                                 if self.match_check(ind[valid], fun):


### PR DESCRIPTION
### What does this PR do?

Back-ports #33948 to the 2015.8 branch, along with the additions in #34009 in order to have the logic to detect if a returner does not have the minions kwarg present in it's save_load function, which can happen when users are using custom returners.

Instead of updating the release notes for Carbon as in the original PR, this adds a note to the 2015.8.11 release notes.

ping @thatch45 and @cachedout 
