### PR TITLE
fix launch config creation params

### DIFF
--- a/salt/states/boto_lc.py
+++ b/salt/states/boto_lc.py
@@ -240,11 +240,24 @@ def present(
         # TODO: Ensure image_id, key_name, security_groups and instance_profile
         # exist, or throw an invocation error.
         created = __salt__['boto_asg.create_launch_configuration'](
-            name, image_id, key_name, security_groups, user_data,
-            instance_type, kernel_id, ramdisk_id, block_device_mappings,
-            instance_monitoring, spot_price, instance_profile_name,
-            ebs_optimized, associate_public_ip_address,
-            region, key, keyid, profile)
+            name,
+            image_id,
+            key_name=key_name,
+            security_groups=security_groups,
+            user_data=user_data,
+            instance_type=instance_type,
+            kernel_id=kernel_id,
+            ramdisk_id=ramdisk_id,
+            block_device_mappings=block_device_mappings,
+            instance_monitoring=instance_monitoring,
+            spot_price=spot_price,
+            instance_profile_name=instance_profile_name,
+            ebs_optimized=ebs_optimized,
+            associate_public_ip_address=associate_public_ip_address,
+            region=region,
+            key=key,
+            keyid=keyid,
+            profile=profile)
         if created:
             ret['changes']['old'] = None
             ret['changes']['new'] = name


### PR DESCRIPTION
### What does this PR do?

This fixes an issue where the launch configuration could not be created because it was connecting to the default region instead of the specified region.
### What issues does this PR fix or reference?

There was no submitted issue for this. It was an issue that was hit this morning for us and we debugged until it was fixed.
### Previous Behavior

Given:

``` yaml
    Ensure mylc exists:
      boto_lc.present:
        - name: mylc
        - region: sa-east-1
        - image_id: ami-0b9c9f62
        - profile: myprofile
```

the state will fail with due to connecting to the wrong region:

``` xml
<ErrorResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
  <Error>
    <Type>Sender</Type>
    <Code>ValidationError</Code>
    <Message>AMI ami-0b9c9f62 is invalid: The image id '[ami-0b9c9f62]' does not exist</Message>
  </Error>
  <RequestId>b60ae124-3269-11e6-9c98-016ce5ab63a5</RequestId>
</ErrorResponse>
```

The arguments to `boto_asg.create_launch_configuration` were taken as positional instead of named, and there were additional arguments to `boto_asg.create_launch_configuration`. This created an inconsistency between argument lists and therefore the specified `region` was getting passed into the `volume_type` argument and consequently the local `region` variable was always `None` for the actual creation of the launch configuration.
### New Behavior

All parameters have been named to prevent this error.
### Tests written?

No
