### PR TITLE
Added check for presence of Testinfra library

### DIFF
--- a/salt/modules/testinframod.py
+++ b/salt/modules/testinframod.py
@@ -292,4 +292,5 @@ def _register_functions():
         globals()[mod_name] = mod_func
 
 
-_register_functions()
+if TESTINFRA_PRESENT:
+    _register_functions()

--- a/salt/states/testinframod.py
+++ b/salt/states/testinframod.py
@@ -61,4 +61,5 @@ def _generate_functions():
         globals()[module_name] = _wrap_module_function(func_name)
 
 
-_generate_functions()
+if TESTINFRA_PRESENT:
+    _generate_functions()


### PR DESCRIPTION
### What does this PR do?

Fix build failures when Testinfra is not installed
### What issues does this PR fix or reference?
#33944
### Previous Behavior

During the build for Python 3 a stacktrace was generated when the module was imported due to the `_register_functions` method being called unconditionally.
### New Behavior

No stacktrace is generated because the `_register_functions` method is only run if Testinfra is installed.
### Tests written?

No

Added a check for the presence of the Testinfra library before trying to
register the generated functions in the execution and state modules.
