### PR TITLE
Add get/set datetime functionality - system module

### DIFF
--- a/salt/modules/system.py
+++ b/salt/modules/system.py
@@ -4,12 +4,16 @@ Support for reboot, shutdown, etc
 '''
 from __future__ import absolute_import
 
+# Import python libs
 from datetime import datetime
 import sys
 import os
 import time
 
+# Import salt libs
 import salt.utils
+from salt.exceptions import CommandExecutionError
+
 
 __virtualname__ = 'system'
 
@@ -112,7 +116,7 @@ def shutdown(at_time=None):
     return ret
 
 
-def _linux_set_datetime(new_time,utc=None):
+def _linux_set_datetime(new_time, utc=None):
     '''set the system date/time on linux'''
     # Modified version of: http://stackoverflow.com/a/12292874
     import ctypes
@@ -153,6 +157,7 @@ def _linux_set_datetime(new_time,utc=None):
 
     return result
 
+
 def _posix_set_datetime(new_date, utc=None):
     '''
     set the system date/time using the date command
@@ -174,6 +179,7 @@ def _posix_set_datetime(new_date, utc=None):
 
     return True
 
+
 def _try_parse_datetime(time_str, fmts):
     '''
     Attempts to parse the input time_str as a date.
@@ -189,7 +195,7 @@ def _try_parse_datetime(time_str, fmts):
         try:
             result = datetime.strptime(time_str, fmt)
             break
-        except ValueError,e:
+        except ValueError, e:
             pass
     return result
 
@@ -213,6 +219,7 @@ def get_system_time(utc=None):
     else:
         t = datetime.now()
     return datetime.strftime(t, "%I:%M %p")
+
 
 def set_system_time(newtime, utc=None, posix=None):
     '''
@@ -247,6 +254,7 @@ def set_system_time(newtime, utc=None, posix=None):
 
     return set_system_date_time(hours=dt_obj.hour, minutes=dt_obj.minute,
             seconds=dt_obj.second, utc=utc, posix=posix)
+
 
 def get_system_date_time(utc=None):
     '''

--- a/salt/modules/system.py
+++ b/salt/modules/system.py
@@ -251,7 +251,7 @@ def set_system_time(newtime, utc=None, posix=None):
         return False
 
     return set_system_date_time(hours=dt_obj.hour, minutes=dt_obj.minute,
-            seconds=dt_obj.second, utc=utc, posix=posix)
+                                seconds=dt_obj.second, utc=utc, posix=posix)
 
 
 def get_system_date_time(utc=None):
@@ -286,9 +286,10 @@ def set_system_date_time(years=None,
                          posix=None):
     '''
     Set the system date and time. Each argument is an element of the date, but
-    not required. If an element is not passed, the current system value for that
-    element will be used. For example, if you don't pass the year, the current
-    system year will be used. (Used by set_system_date and set_system_time)
+    not required. If an element is not passed, the current system value for
+    that element will be used. For example, if you don't pass the year, the
+    current system year will be used. (Used by set_system_date and
+    set_system_time)
 
     :param int years: Years digit, ie: 2015
     :param int months: Months digit: 1 - 12
@@ -381,7 +382,7 @@ def set_system_date(newdate, utc=None):
             '%m/%d/%Y', '%m/%d/%y', '%Y/%m/%d']
 
     # Get date/time object from newdate
-    #dt_obj = salt.utils.date_cast(newdate)
+    # dt_obj = salt.utils.date_cast(newdate)
     dt_obj = _try_parse_datetime(newdate, fmts)
     if dt_obj is None:
         return False

--- a/salt/modules/system.py
+++ b/salt/modules/system.py
@@ -6,9 +6,7 @@ from __future__ import absolute_import
 
 # Import python libs
 from datetime import datetime
-import sys
 import os
-import time
 
 # Import salt libs
 import salt.utils
@@ -124,7 +122,7 @@ def _linux_set_datetime(new_time, utc=None):
     import time
 
     # Temporarily set the TZ environment variable
-    # This must be done before loading the external library 
+    # This must be done before loading the external library
     if utc is True:
         save_timezone = os.environ.get('TZ', None)
         os.environ['TZ'] = 'UTC0'

--- a/salt/modules/system.py
+++ b/salt/modules/system.py
@@ -4,6 +4,11 @@ Support for reboot, shutdown, etc
 '''
 from __future__ import absolute_import
 
+from datetime import datetime
+import sys
+import os
+import time
+
 import salt.utils
 
 __virtualname__ = 'system'
@@ -22,10 +27,6 @@ def __virtual__():
 
     if salt.utils.is_sunos():
         return (False, 'This module is not available on SunOS')
-
-    if not salt.utils.which('shutdown'):
-        return (False, 'The system execution module failed to load: '
-                'only available on Linux systems with shutdown command.')
 
     return __virtualname__
 
@@ -109,3 +110,258 @@ def shutdown(at_time=None):
     cmd = ['shutdown', '-h', ('{0}'.format(at_time) if at_time else 'now')]
     ret = __salt__['cmd.run'](cmd, python_shell=False)
     return ret
+
+
+def _linux_set_datetime(new_time,utc=None):
+    '''set the system date/time on linux'''
+    # Modified version of: http://stackoverflow.com/a/12292874
+    import ctypes
+    import ctypes.util
+    import time
+
+    # Temporarily set the TZ environment variable
+    # This must be done before loading the external library 
+    if utc is True:
+        save_timezone = os.environ.get('TZ', None)
+        os.environ['TZ'] = 'UTC0'
+
+    class timespec(ctypes.Structure):
+        _fields_ = [("tv_sec", ctypes.c_long),
+                    ("tv_nsec", ctypes.c_long)]
+
+    CLOCK_REALTIME = 0
+    nano_per_micro = 1000
+    librt = ctypes.CDLL(ctypes.util.find_library("rt"))
+
+    # seperate the microseconds part from the seconds part
+    secs_part = datetime(*new_time.timetuple()[:6]).timetuple()
+    micro_part = new_time.timetuple()[6]
+
+    ts = timespec()
+    ts.tv_sec = int(time.mktime(secs_part))
+    ts.tv_nsec = micro_part * nano_per_micro
+
+    # Attempt to set the clock
+    result = not bool(librt.clock_settime(CLOCK_REALTIME, ctypes.byref(ts)))
+
+    # Reset TZ environment variable
+    if utc is True:
+        if save_timezone is not None:
+            os.environ['TZ'] = save_timezone
+        else:
+            del os.environ['TZ']
+
+    return result
+
+def _posix_set_datetime(new_date, utc=None):
+    '''
+    set the system date/time using the date command
+
+    Note using a posix date binary we can only set the date up to the minute
+    '''
+    cmd = 'date'
+    if utc is True:
+        cmd += ' -u'
+    # the date can be set in the following format:
+    # date mmddhhmm[[cc]yy]
+    cmd += " {1:02}{2:02}{3:02}{4:02}{0:04}".format(*new_date.timetuple())
+
+    ret = __salt__['cmd.run_all'](cmd, python_shell=False)
+
+    if ret['retcode'] != 0:
+        msg = 'date failed: {0}'.format(ret['stderr'])
+        raise CommandExecutionError(msg)
+
+    return True
+
+def _try_parse_datetime(time_str, fmts):
+    '''
+    Attempts to parse the input time_str as a date.
+
+    :param str time_str: A string representing the time
+    :param list fmts: A list of date format strings.
+
+    :return: Returns a datetime object if parsed properly. Otherwise None
+    :rtype datetime:
+    '''
+    result = None
+    for fmt in fmts:
+        try:
+            result = datetime.strptime(time_str, fmt)
+            break
+        except ValueError,e:
+            pass
+    return result
+
+
+def get_system_time(utc=None):
+    '''
+    Get the system time.
+
+    :param bool utc: A Boolean that indicates if the output timezone is UTC.
+    :return: Returns the system time in HH:MM AM/PM format.
+    :rtype: str
+    '''
+    if utc is True:
+        t = datetime.utcnow()
+    else:
+        t = datetime.now()
+    return datetime.strftime(t, "%I:%M %p")
+
+def set_system_time(newtime, utc=None, posix=None):
+    '''
+    Set the system time.
+
+    :param str newtime:
+        The time to set. Can be any of the following formats.
+        - HH:MM:SS AM/PM
+        - HH:MM AM/PM
+        - HH:MM:SS (24 hour)
+        - HH:MM (24 hour)
+
+        Note that the salt command line parser parses the date/time
+        before we obtain the argument (preventing us from doing utc)
+        Therefore the argument must be passed in as a string.
+        Meaning you may have to quote the text twice from the command line.
+
+    :return: Returns True if successful. Otherwise False.
+    :rtype: bool
+    '''
+
+    fmts = ['%I:%M:%S %p', '%I:%M %p', '%H:%M:%S', '%H:%M']
+    dt_obj = _try_parse_datetime(newtime, fmts)
+    if dt_obj is None:
+        return False
+
+    return set_system_date_time(hours=dt_obj.hour, minutes=dt_obj.minute,
+            seconds=dt_obj.second, utc=utc, posix=posix)
+
+def get_system_date_time(utc=None):
+    '''
+    Get the system date/time.
+
+    :param bool utc: A Boolean that indicates if the output timezone is UTC.
+    :return: Returns the system time in YYYY-MM-DD hh:mm:ss format.
+    :rtype: str
+    '''
+    if utc is True:
+        t = datetime.utcnow()
+    else:
+        t = datetime.now()
+
+    return datetime.strftime(t, "%Y-%m-%d %H:%M:%S")
+
+
+def set_system_date_time(years=None,
+                         months=None,
+                         days=None,
+                         hours=None,
+                         minutes=None,
+                         seconds=None,
+                         utc=None,
+                         posix=None):
+    '''
+    Set the system date and time. Each argument is an element of the date, but
+    not required. If an element is not passed, the current system value for that
+    element will be used. For example, if you don't pass the year, the current
+    system year will be used. (Used by set_system_date and set_system_time)
+
+    :param int years: Years digit, ie: 2015
+    :param int months: Months digit: 1 - 12
+    :param int days: Days digit: 1 - 31
+    :param int hours: Hours digit: 0 - 23
+    :param int minutes: Minutes digit: 0 - 59
+    :param int seconds: Seconds digit: 0 - 59
+    :param bool utc: A Boolean to specify input time is UTC.
+    :param bool posix: A Boolean to specify to use the posix date backend
+
+    :return: True if successful. Otherwise False.
+    :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' system.set_system_date_time 2015 5 12 11 37 53
+    '''
+    # Get the current date/time
+    if utc is True:
+        date_time = datetime.utcnow()
+    else:
+        date_time = datetime.now()
+
+    # Check for passed values. If not passed, use current values
+    if years is None:
+        years = date_time.year
+    if months is None:
+        months = date_time.month
+    if days is None:
+        days = date_time.day
+    if hours is None:
+        hours = date_time.hour
+    if minutes is None:
+        minutes = date_time.minute
+    if seconds is None:
+        seconds = date_time.second
+
+    dt = datetime(years, months, days, hours, minutes, seconds)
+    if posix is True:
+        return _posix_set_datetime(dt, utc=utc)
+    else:
+        return _linux_set_datetime(dt, utc=utc)
+
+
+def get_system_date(utc=None):
+    '''
+    Get the system date
+
+    :param bool utc: A Boolean that indicates if the output timezone is UTC.
+    :return: Returns the system date.
+    :rtype: str
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' system.get_system_date
+    '''
+
+    if utc is True:
+        t = datetime.utcnow()
+    else:
+        t = datetime.now()
+    return datetime.strftime(t, "%a %m/%d/%Y")
+
+
+def set_system_date(newdate, utc=None):
+    '''
+    Set the Windows system date. Use <mm-dd-yy> format for the date.
+
+    :param str newdate:
+        The date to set. Can be any of the following formats
+        - YYYY-MM-DD
+        - MM-DD-YYYY
+        - MM-DD-YY
+        - MM/DD/YYYY
+        - MM/DD/YY
+        - YYYY/MM/DD
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' system.set_system_date '03-28-13'
+    '''
+
+    fmts = ['%Y-%m-%d', '%m-%d-%Y', '%m-%d-%y',
+            '%m/%d/%Y', '%m/%d/%y', '%Y/%m/%d']
+
+    # Get date/time object from newdate
+    #dt_obj = salt.utils.date_cast(newdate)
+    dt_obj = _try_parse_datetime(newdate, fmts)
+    if dt_obj is None:
+        return False
+
+    # Set time using set_system_date_time()
+    return set_system_date_time(years=dt_obj.year, months=dt_obj.month,
+                                days=dt_obj.day, utc=utc)

--- a/salt/modules/system.py
+++ b/salt/modules/system.py
@@ -201,6 +201,12 @@ def get_system_time(utc=None):
     :param bool utc: A Boolean that indicates if the output timezone is UTC.
     :return: Returns the system time in HH:MM AM/PM format.
     :rtype: str
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' system.get_system_time
     '''
     if utc is True:
         t = datetime.utcnow()
@@ -226,6 +232,12 @@ def set_system_time(newtime, utc=None, posix=None):
 
     :return: Returns True if successful. Otherwise False.
     :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' system.set_system_time "'11:20'"
     '''
 
     fmts = ['%I:%M:%S %p', '%I:%M %p', '%H:%M:%S', '%H:%M']
@@ -243,6 +255,12 @@ def get_system_date_time(utc=None):
     :param bool utc: A Boolean that indicates if the output timezone is UTC.
     :return: Returns the system time in YYYY-MM-DD hh:mm:ss format.
     :rtype: str
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' system.get_system_date_time utc=True
     '''
     if utc is True:
         t = datetime.utcnow()

--- a/tests/integration/modules/system.py
+++ b/tests/integration/modules/system.py
@@ -1,0 +1,208 @@
+# -*- coding: utf-8 -*-
+
+# Import python libs
+from __future__ import absolute_import
+import os
+import hashlib
+
+# Import Salt Testing libs
+from salttesting import skipIf
+from salttesting.helpers import (
+    destructiveTest,
+    ensure_in_syspath,
+    requires_system_grains
+)
+
+ensure_in_syspath('../../')
+
+# Import salt libs
+import integration
+import salt.utils
+import time
+import datetime
+
+class SystemModuleTest(integration.ModuleCase):
+    '''
+    Validate the date/time functions in the system module
+    '''
+    fmt_str = "%Y-%m-%d %H:%M:%S"
+
+    def _save_time(self):
+        self._orig_time = datetime.datetime.now()
+
+    def _set_time(self, new_time, posix=None, utc=None):
+        t = new_time.timetuple()[:6]
+        return self.run_function('system.set_system_date_time', t,
+                posix=posix, utc=utc)
+
+    def _restore_time(self, utc=None):
+        if utc is True:
+            t = datetime.datetime.utcnow()
+        else:
+            t = datetime.datetime.now()
+        test_timediff = t - self._fake_time
+        now = test_timediff + self._orig_time
+        self._set_time(now)
+
+    def _same_times(self, t1, t2, seconds_diff=1):
+        return abs(t1 - t2) < datetime.timedelta(seconds=seconds_diff)
+
+    def test_get_system_date_time(self):
+        '''
+        Test we are able to get the correct time
+        '''
+        t1 = datetime.datetime.now()
+        res = self.run_function('system.get_system_date_time')
+        t2 = datetime.datetime.strptime(res, self.fmt_str)
+        msg = ("Difference in times is too large. Now: {} Fake: {}"
+                .format(t1, t2))
+        self.assertTrue(self._same_times(t1, t2),msg=msg)
+
+    def test_get_system_date_time_utc(self):
+        '''
+        Test we are able to get the correct time with utc
+        '''
+        t1 = datetime.datetime.utcnow()
+        res = self.run_function('system.get_system_date_time', utc=True)
+        t2 = datetime.datetime.strptime(res, self.fmt_str)
+        msg = ("Difference in times is too large. Now: {} Fake: {}"
+                .format(t1, t2))
+        self.assertTrue(self._same_times(t1, t2), msg=msg)
+
+    @destructiveTest
+    @skipIf(os.geteuid() != 0, 'you must be root to run this test')
+    def test_set_system_date_time(self):
+        '''
+        Test changing the system clock. We are only able to set it up to a
+        resolution of a second so this test may appear to run in negative time.
+        '''
+        self._fake_time = datetime.datetime.strptime("1981-02-03 04:05:06",
+                self.fmt_str)
+
+        self._save_time()
+        self._set_time(self._fake_time)
+
+        time_now = datetime.datetime.now()
+        msg = ("Difference in times is too large. Now: {} Fake: {}"
+                .format(time_now, self._fake_time))
+        self.assertTrue(self._same_times(time_now, self._fake_time), msg=msg)
+
+        self._restore_time()
+
+    @destructiveTest
+    @skipIf(os.geteuid() != 0, 'you must be root to run this test')
+    def test_set_system_date_time_utc(self):
+        '''
+        Test changing the system clock. We are only able to set it up to a
+        resolution of a second so this test may appear to run in negative time.
+        '''
+        self._fake_time = datetime.datetime.strptime("1981-02-03 04:05:06",
+                self.fmt_str)
+
+        self._save_time()
+        result = self._set_time(self._fake_time, utc=True)
+
+        time_now = datetime.datetime.utcnow()
+        msg = ("Difference in times is too large. Now: {} Fake: {}"
+                .format(time_now, self._fake_time))
+        self.assertTrue(result and self._same_times(time_now,self._fake_time),
+                msg=msg)
+
+        self._restore_time(utc=True)
+
+    @destructiveTest
+    @skipIf(os.geteuid() != 0, 'you must be root to run this test')
+    def test_set_system_date_time_posix(self):
+        '''
+        Test changing the system clock. We are only able to set it up to a
+        resolution of a second so this test may appear to run in negative time.
+        '''
+        self._fake_time = datetime.datetime.strptime("1981-02-03 04:05:06",
+                self.fmt_str)
+
+        self._save_time()
+        result = self._set_time(self._fake_time, posix=True)
+
+        time_now = datetime.datetime.now()
+        msg = ("Difference in times is too large. Now: {} Fake: {}"
+                .format(time_now, self._fake_time))
+        self.assertTrue(result and self._same_times(time_now, self._fake_time,
+            seconds_diff=60), msg=msg) # posix only enables setting to minute
+
+        self._restore_time()
+
+    @destructiveTest
+    @skipIf(os.geteuid() != 0, 'you must be root to run this test')
+    def test_set_system_date_time_posix_utc(self):
+        '''
+        Test changing the system clock. We are only able to set it up to a
+        resolution of a second so this test may appear to run in negative time.
+        '''
+        self._fake_time = datetime.datetime.strptime("1981-02-03 04:05:06",
+                self.fmt_str)
+
+        self._save_time()
+        result = self._set_time(self._fake_time, posix=True, utc=True)
+
+        time_now = datetime.datetime.utcnow()
+        msg = ("Difference in times is too large. Now: {} Fake: {}"
+                .format(time_now, self._fake_time))
+        self.assertTrue(result and self._same_times(time_now, self._fake_time,
+            seconds_diff=60), msg=msg) # posix only enables setting to minute
+
+        self._restore_time(utc=True)
+
+    @destructiveTest
+    @skipIf(os.geteuid() != 0, 'you must be root to run this test')
+    def test_set_system_time(self):
+        '''
+        Test setting the system time without adjusting the date.
+        '''
+        self._fake_time = datetime.datetime.combine(datetime.date.today(),
+                datetime.time(4,5,0))
+
+        self._save_time()
+
+        result = self.run_function('system.set_system_time', ["04:05:00"])
+
+        time_now = datetime.datetime.now()
+        msg = ("Difference in times is too large. Now: {} Fake: {}"
+                .format(time_now, self._fake_time))
+
+        self.assertTrue(result)
+        self.assertTrue(time_now.hour == 4 and
+                time_now.minute == 5 and
+                (time_now.second < 10), msg=msg)
+
+        self._restore_time()
+
+    @destructiveTest
+    @skipIf(os.geteuid() != 0, 'you must be root to run this test')
+    def test_set_system_date(self):
+        '''
+        Test setting the system date without adjusting the time.
+        '''
+        self._fake_time = datetime.datetime.combine(
+                datetime.datetime(2000, 12, 25), datetime.datetime.now().time())
+
+        self._save_time()
+
+        result = self.run_function('system.set_system_date', ["2000-12-25"])
+
+        time_now = datetime.datetime.now()
+        msg = ("Difference in times is too large. Now: {} Fake: {}"
+                .format(time_now, self._fake_time))
+
+        self.assertTrue(result)
+        self.assertTrue(time_now.year == 2000 and
+                time_now.day == 25 and
+                time_now.month == 12 and
+                time_now.hour == self._orig_time.hour and
+                time_now.minute == self._orig_time.minute
+                , msg=msg)
+
+        self._restore_time()
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(SystemModuleTest)

--- a/tests/integration/modules/system.py
+++ b/tests/integration/modules/system.py
@@ -123,7 +123,7 @@ class SystemModuleTest(integration.ModuleCase):
         msg = ("Difference in times is too large. Now: {0} Fake: {1}"
                 .format(time_now, self._fake_time))
         self.assertTrue(result and self._same_times(time_now, self._fake_time,
-            seconds_diff=60), msg=msg) # posix only enables setting to minute
+            seconds_diff=60), msg=msg)  # posix only enables setting to minute
 
         self._restore_time()
 
@@ -144,7 +144,7 @@ class SystemModuleTest(integration.ModuleCase):
         msg = ("Difference in times is too large. Now: {0} Fake: {1}"
                 .format(time_now, self._fake_time))
         self.assertTrue(result and self._same_times(time_now, self._fake_time,
-            seconds_diff=60), msg=msg) # posix only enables setting to minute
+            seconds_diff=60), msg=msg)  # posix only enables setting to minute
 
         self._restore_time(utc=True)
 

--- a/tests/integration/modules/system.py
+++ b/tests/integration/modules/system.py
@@ -2,24 +2,20 @@
 
 # Import python libs
 from __future__ import absolute_import
+import datetime
 import os
-import hashlib
 
 # Import Salt Testing libs
 from salttesting import skipIf
 from salttesting.helpers import (
     destructiveTest,
-    ensure_in_syspath,
-    requires_system_grains
+    ensure_in_syspath
 )
 
 ensure_in_syspath('../../')
 
 # Import salt libs
 import integration
-import salt.utils
-import time
-import datetime
 
 class SystemModuleTest(integration.ModuleCase):
     '''
@@ -54,9 +50,9 @@ class SystemModuleTest(integration.ModuleCase):
         t1 = datetime.datetime.now()
         res = self.run_function('system.get_system_date_time')
         t2 = datetime.datetime.strptime(res, self.fmt_str)
-        msg = ("Difference in times is too large. Now: {} Fake: {}"
+        msg = ("Difference in times is too large. Now: {0} Fake: {1}"
                 .format(t1, t2))
-        self.assertTrue(self._same_times(t1, t2),msg=msg)
+        self.assertTrue(self._same_times(t1, t2), msg=msg)
 
     def test_get_system_date_time_utc(self):
         '''
@@ -65,7 +61,7 @@ class SystemModuleTest(integration.ModuleCase):
         t1 = datetime.datetime.utcnow()
         res = self.run_function('system.get_system_date_time', utc=True)
         t2 = datetime.datetime.strptime(res, self.fmt_str)
-        msg = ("Difference in times is too large. Now: {} Fake: {}"
+        msg = ("Difference in times is too large. Now: {0} Fake: {1}"
                 .format(t1, t2))
         self.assertTrue(self._same_times(t1, t2), msg=msg)
 
@@ -83,7 +79,7 @@ class SystemModuleTest(integration.ModuleCase):
         self._set_time(self._fake_time)
 
         time_now = datetime.datetime.now()
-        msg = ("Difference in times is too large. Now: {} Fake: {}"
+        msg = ("Difference in times is too large. Now: {0} Fake: {1}"
                 .format(time_now, self._fake_time))
         self.assertTrue(self._same_times(time_now, self._fake_time), msg=msg)
 
@@ -103,9 +99,9 @@ class SystemModuleTest(integration.ModuleCase):
         result = self._set_time(self._fake_time, utc=True)
 
         time_now = datetime.datetime.utcnow()
-        msg = ("Difference in times is too large. Now: {} Fake: {}"
+        msg = ("Difference in times is too large. Now: {0} Fake: {1}"
                 .format(time_now, self._fake_time))
-        self.assertTrue(result and self._same_times(time_now,self._fake_time),
+        self.assertTrue(result and self._same_times(time_now, self._fake_time),
                 msg=msg)
 
         self._restore_time(utc=True)
@@ -124,7 +120,7 @@ class SystemModuleTest(integration.ModuleCase):
         result = self._set_time(self._fake_time, posix=True)
 
         time_now = datetime.datetime.now()
-        msg = ("Difference in times is too large. Now: {} Fake: {}"
+        msg = ("Difference in times is too large. Now: {0} Fake: {1}"
                 .format(time_now, self._fake_time))
         self.assertTrue(result and self._same_times(time_now, self._fake_time,
             seconds_diff=60), msg=msg) # posix only enables setting to minute
@@ -145,7 +141,7 @@ class SystemModuleTest(integration.ModuleCase):
         result = self._set_time(self._fake_time, posix=True, utc=True)
 
         time_now = datetime.datetime.utcnow()
-        msg = ("Difference in times is too large. Now: {} Fake: {}"
+        msg = ("Difference in times is too large. Now: {0} Fake: {1}"
                 .format(time_now, self._fake_time))
         self.assertTrue(result and self._same_times(time_now, self._fake_time,
             seconds_diff=60), msg=msg) # posix only enables setting to minute
@@ -159,14 +155,14 @@ class SystemModuleTest(integration.ModuleCase):
         Test setting the system time without adjusting the date.
         '''
         self._fake_time = datetime.datetime.combine(datetime.date.today(),
-                datetime.time(4,5,0))
+                datetime.time(4, 5, 0))
 
         self._save_time()
 
         result = self.run_function('system.set_system_time', ["04:05:00"])
 
         time_now = datetime.datetime.now()
-        msg = ("Difference in times is too large. Now: {} Fake: {}"
+        msg = ("Difference in times is too large. Now: {0} Fake: {1}"
                 .format(time_now, self._fake_time))
 
         self.assertTrue(result)
@@ -190,7 +186,7 @@ class SystemModuleTest(integration.ModuleCase):
         result = self.run_function('system.set_system_date', ["2000-12-25"])
 
         time_now = datetime.datetime.now()
-        msg = ("Difference in times is too large. Now: {} Fake: {}"
+        msg = ("Difference in times is too large. Now: {0} Fake: {1}"
                 .format(time_now, self._fake_time))
 
         self.assertTrue(result)

--- a/tests/integration/modules/system.py
+++ b/tests/integration/modules/system.py
@@ -17,6 +17,7 @@ ensure_in_syspath('../../')
 # Import salt libs
 import integration
 
+
 class SystemModuleTest(integration.ModuleCase):
     '''
     Validate the date/time functions in the system module
@@ -29,7 +30,7 @@ class SystemModuleTest(integration.ModuleCase):
     def _set_time(self, new_time, posix=None, utc=None):
         t = new_time.timetuple()[:6]
         return self.run_function('system.set_system_date_time', t,
-                posix=posix, utc=utc)
+                                 posix=posix, utc=utc)
 
     def _restore_time(self, utc=None):
         if utc is True:
@@ -51,7 +52,7 @@ class SystemModuleTest(integration.ModuleCase):
         res = self.run_function('system.get_system_date_time')
         t2 = datetime.datetime.strptime(res, self.fmt_str)
         msg = ("Difference in times is too large. Now: {0} Fake: {1}"
-                .format(t1, t2))
+               .format(t1, t2))
         self.assertTrue(self._same_times(t1, t2), msg=msg)
 
     def test_get_system_date_time_utc(self):
@@ -62,7 +63,7 @@ class SystemModuleTest(integration.ModuleCase):
         res = self.run_function('system.get_system_date_time', utc=True)
         t2 = datetime.datetime.strptime(res, self.fmt_str)
         msg = ("Difference in times is too large. Now: {0} Fake: {1}"
-                .format(t1, t2))
+               .format(t1, t2))
         self.assertTrue(self._same_times(t1, t2), msg=msg)
 
     @destructiveTest
@@ -73,14 +74,14 @@ class SystemModuleTest(integration.ModuleCase):
         resolution of a second so this test may appear to run in negative time.
         '''
         self._fake_time = datetime.datetime.strptime("1981-02-03 04:05:06",
-                self.fmt_str)
+                                                     self.fmt_str)
 
         self._save_time()
         self._set_time(self._fake_time)
 
         time_now = datetime.datetime.now()
         msg = ("Difference in times is too large. Now: {0} Fake: {1}"
-                .format(time_now, self._fake_time))
+               .format(time_now, self._fake_time))
         self.assertTrue(self._same_times(time_now, self._fake_time), msg=msg)
 
         self._restore_time()
@@ -93,16 +94,16 @@ class SystemModuleTest(integration.ModuleCase):
         resolution of a second so this test may appear to run in negative time.
         '''
         self._fake_time = datetime.datetime.strptime("1981-02-03 04:05:06",
-                self.fmt_str)
+                                                     self.fmt_str)
 
         self._save_time()
         result = self._set_time(self._fake_time, utc=True)
 
         time_now = datetime.datetime.utcnow()
         msg = ("Difference in times is too large. Now: {0} Fake: {1}"
-                .format(time_now, self._fake_time))
+               .format(time_now, self._fake_time))
         self.assertTrue(result and self._same_times(time_now, self._fake_time),
-                msg=msg)
+                        msg=msg)
 
         self._restore_time(utc=True)
 
@@ -114,16 +115,17 @@ class SystemModuleTest(integration.ModuleCase):
         resolution of a second so this test may appear to run in negative time.
         '''
         self._fake_time = datetime.datetime.strptime("1981-02-03 04:05:06",
-                self.fmt_str)
+                                                     self.fmt_str)
 
         self._save_time()
         result = self._set_time(self._fake_time, posix=True)
 
         time_now = datetime.datetime.now()
         msg = ("Difference in times is too large. Now: {0} Fake: {1}"
-                .format(time_now, self._fake_time))
+               .format(time_now, self._fake_time))
+        # posix only enables setting to minute
         self.assertTrue(result and self._same_times(time_now, self._fake_time,
-            seconds_diff=60), msg=msg)  # posix only enables setting to minute
+                        seconds_diff=60), msg=msg)
 
         self._restore_time()
 
@@ -135,16 +137,17 @@ class SystemModuleTest(integration.ModuleCase):
         resolution of a second so this test may appear to run in negative time.
         '''
         self._fake_time = datetime.datetime.strptime("1981-02-03 04:05:06",
-                self.fmt_str)
+                                                     self.fmt_str)
 
         self._save_time()
         result = self._set_time(self._fake_time, posix=True, utc=True)
 
         time_now = datetime.datetime.utcnow()
         msg = ("Difference in times is too large. Now: {0} Fake: {1}"
-                .format(time_now, self._fake_time))
+               .format(time_now, self._fake_time))
+        # posix only enables setting to minute
         self.assertTrue(result and self._same_times(time_now, self._fake_time,
-            seconds_diff=60), msg=msg)  # posix only enables setting to minute
+                        seconds_diff=60), msg=msg)
 
         self._restore_time(utc=True)
 
@@ -155,7 +158,7 @@ class SystemModuleTest(integration.ModuleCase):
         Test setting the system time without adjusting the date.
         '''
         self._fake_time = datetime.datetime.combine(datetime.date.today(),
-                datetime.time(4, 5, 0))
+                                                    datetime.time(4, 5, 0))
 
         self._save_time()
 
@@ -163,12 +166,12 @@ class SystemModuleTest(integration.ModuleCase):
 
         time_now = datetime.datetime.now()
         msg = ("Difference in times is too large. Now: {0} Fake: {1}"
-                .format(time_now, self._fake_time))
+               .format(time_now, self._fake_time))
 
         self.assertTrue(result)
         self.assertTrue(time_now.hour == 4 and
-                time_now.minute == 5 and
-                (time_now.second < 10), msg=msg)
+                        time_now.minute == 5 and
+                        (time_now.second < 10), msg=msg)
 
         self._restore_time()
 
@@ -179,7 +182,9 @@ class SystemModuleTest(integration.ModuleCase):
         Test setting the system date without adjusting the time.
         '''
         self._fake_time = datetime.datetime.combine(
-                datetime.datetime(2000, 12, 25), datetime.datetime.now().time())
+                datetime.datetime(2000, 12, 25),
+                datetime.datetime.now().time()
+        )
 
         self._save_time()
 
@@ -187,15 +192,15 @@ class SystemModuleTest(integration.ModuleCase):
 
         time_now = datetime.datetime.now()
         msg = ("Difference in times is too large. Now: {0} Fake: {1}"
-                .format(time_now, self._fake_time))
+               .format(time_now, self._fake_time))
 
         self.assertTrue(result)
         self.assertTrue(time_now.year == 2000 and
-                time_now.day == 25 and
-                time_now.month == 12 and
-                time_now.hour == self._orig_time.hour and
-                time_now.minute == self._orig_time.minute
-                , msg=msg)
+                        time_now.day == 25 and
+                        time_now.month == 12 and
+                        time_now.hour == self._orig_time.hour and
+                        time_now.minute == self._orig_time.minute,
+                        msg=msg)
 
         self._restore_time()
 


### PR DESCRIPTION
### What does this PR do?

Adds posix/linux support for getting and setting the date/time.
### What issues does this PR fix or reference?

None.
### New Behavior

Implement {get,set}_system_{time,date_time,date} functions
in system module for posix/linux machines. These functions
already exist in the win_system module, however there isn't
currently a way to set the date/time on linux/posix systems.

Includes two methods for setting the date/time.
    - Using the date program (posix)
    - Using the linux function clock_settime function (linux)

Adds UTC functionality that isn't currently included in the windows
date/time module.
### Tests written?

Yes.
### Review Questions

I'd like some input on the placement of this code. Windows has it's
datetime functions in win_system. Mac some datetime functions in
mac_timezone. Would having a separate date module make sense?
Or does adding it to the system module make sense?

Currently these changes only support posix/linux because support
already exists for windows in win_system. Does it make sense to
consolidate the functionality into a single module?

I'm happy to fix any errors you may find and am open to suggestions.
