### PR TITLE
removed method that doesn't exist

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -832,6 +832,8 @@ def wait_for_winrm(host, port, username, password, timeout=900):
         trycount += 1
         try:
             s = winrm.Session(host, auth=(username, password), transport='ssl')
+            if hasattr(s.protocol, 'set_timeout'):
+                s.protocol.set_timeout(15)
             log.trace('WinRM endpoint url: {0}'.format(s.url))
             r = s.run_cmd('sc query winrm')
             if r.status_code == 0:

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -832,7 +832,6 @@ def wait_for_winrm(host, port, username, password, timeout=900):
         trycount += 1
         try:
             s = winrm.Session(host, auth=(username, password), transport='ssl')
-            s.protocol.set_timeout(15)
             log.trace('WinRM endpoint url: {0}'.format(s.url))
             r = s.run_cmd('sc query winrm')
             if r.status_code == 0:


### PR DESCRIPTION
### What does this PR do?

This PR removes a line of code that doesn't exist.

``` py
s.protocol.set_timeout(15)
```

`winrm.Session.protocol` has no `set_timeout` method. There are two properties that are set to sane defaults.

``` py
DEFAULT_READ_TIMEOUT_SEC = 30
DEFAULT_OPERATION_TIMEOUT_SEC = 20
read_timeout_sec=DEFAULT_READ_TIMEOUT_SEC, 
operation_timeout_sec=DEFAULT_OPERATION_TIMEOUT_SEC, 
```
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/34008
### Tests written?

No
