### PR TITLE
fix pillar/pillar-pcre pillar/top targetting

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -19,6 +19,7 @@ import salt.crypt
 import salt.transport
 import salt.utils.url
 import salt.utils.cache
+from salt.utils.master import MasterPillarUtil
 from salt.exceptions import SaltClientError
 from salt.template import compile_template
 from salt.utils.dictupdate import merge
@@ -348,6 +349,10 @@ class Pillar(object):
             opts['environment'] = saltenv
         if 'pillarenv' not in opts:
             opts['pillarenv'] = pillarenv
+        if 'pillar' not in opts:
+            mpu = MasterPillarUtil(id_, opts=opts, saltenv=pillarenv)
+            mp_ret = mpu.get_minion_pillar()
+            opts['pillar'] = mp_ret.get(id_, {})
         if opts['state_top'].startswith('salt://'):
             opts['state_top'] = opts['state_top']
         elif opts['state_top'].startswith('/'):


### PR DESCRIPTION
### What does this PR do?

Fix pillar/pillar-pcre pillar targetting
### What issues does this PR fix or reference?
#26727
### Previous Behavior

When `pillar`, `pillar_pcre` or if the `I@` or `J@` prefixes are used within a compound match within `/srv/pillar/top.sls`, an exception is raised from  [`salt.minion.Matcher.pillar_(pcre_)?match()`](https://github.com/saltstack/salt/blob/2015.8/salt/minion.py#L2393)

This is due to [`salt.pillar.Pillar()`](https://github.com/saltstack/salt/blob/develop/salt/pillar/__init__.py#L316) instantiating its Matcher instance with an opts dict that does not contain a `pillar` key.  
### New Behavior

Since  [`salt.pillar.Pillar__gen_opts()`](https://github.com/saltstack/salt/blob/develop/salt/pillar/__init__.py#L316) already exists and is responsible for seeding the minion opts dict with bits and pieces necessary to interact with `Pillar`, it made sense to add a check for `opts['pillar']`, populating it using [`salt.utils.master.MasterPillarUtil()'](https://github.com/saltstack/salt/blob/develop/salt/utils/master.py#L42)
### Tests written?

No :see_no_evil:
