### PR TITLE
`states.postgres_privileges` expects a real list, not a comma-separated string

### DIFF
--- a/salt/states/postgres_privileges.py
+++ b/salt/states/postgres_privileges.py
@@ -107,7 +107,7 @@ def present(name,
        - group
 
     privileges
-       Comma separated list of privileges to grant, from the list below:
+       List of privileges to grant, from the list below:
 
        - INSERT
        - CREATE


### PR DESCRIPTION
### What does this PR do?

It fixes the documentation of `states.postgres_privileges` which claims the value of the `privileges` attributes has to be a comma-separated list (string), while it actually expects a real list/array.
