### PR TITLE
RFC: proposed fix for multiple fileserver updates in masterless runs

### DIFF
--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -723,7 +723,12 @@ class FSChan(object):
         self.kwargs = kwargs
         self.fs = Fileserver(self.opts)
         self.fs.init()
-        self.fs.update()
+        if self.opts.get('file_client', 'remote') == 'local':
+            if '__fs_update' not in self.opts:
+                self.fs.update()
+                self.opts['__fs_update'] = True
+        else:
+            self.fs.update()
         self.cmd_stub = {'ext_nodes': {}}
 
     def send(self, load, tries=None, timeout=None):


### PR DESCRIPTION
Resolves #30100.

`salt.fileclient.get_file_client()` creates a new fileclient each time it is invoked. When the `LocalClient` is being used (as happens in masterless runs), the instantiation of a new FSChan results in a fileserver update being performed.

After investigating, I noticed that this problem has been in place as far back as the 2014.1 branch, so this is not new.

We use `salt.fileclient.get_file_client()` in a number of places, and most of them are deeper than the execution module layer, so we can't rely on the `__context__` dunder to store a fileclient object for later reuse. The compromise in this PR is to drop a key into the minion opts if it is detected that we are using a local fileclient.

If/when we decide to allow masterless Salt to run as a daemon, this code will need to be revisited, as it would prevent more than one fileserver update from being performed. We'd likely need to address this anyway however, since if we had a minion daemon running in masterless mode we would likely need a maintenance loop like we do in the traditional master/minion paradigm.
