### PR TITLE
Fixed a bug in the consul.py module that was preventing services

### DIFF
--- a/salt/modules/consul.py
+++ b/salt/modules/consul.py
@@ -84,7 +84,7 @@ def _query(function,
     )
 
     if result.get('status', None) == salt.ext.six.moves.http_client.OK:
-        ret['data'] = result['dict']
+        ret['data'] = result.get('dict', result)
         ret['res'] = True
     elif result.get('status', None) == salt.ext.six.moves.http_client.NO_CONTENT:
         ret['res'] = False


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in consul.py module that was preventing services from registering in consul.agent_service_register.
### What issues does this PR fix or reference?

Fixes a bug in consul.py module that was preventing services from registering in consul.agent_service_register.
### Previous Behavior

A nonexistent dict key was being referenced, causing an Excepetion and failure to register the service. This fix required only changing the offending line to use the "get" method and supplying a default value.
### New Behavior

Services are now able to register with consul.
### Tests written?

No
