### PR TITLE
_active_mounts_openbsd: unbreak output for special filesystems

### DIFF
--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -140,10 +140,10 @@ def _active_mounts_openbsd(ret):
     '''
     for line in __salt__['cmd.run_stdout']('mount -v').split('\n'):
         comps = re.sub(r"\s+", " ", line).split()
-        nod = __salt__['cmd.run_stdout']('ls -l {0}'.format(comps[0]))
-        nod = ' '.join(nod.split()).split(" ")
         parens = re.findall(r'\((.*?)\)', line, re.DOTALL)
         if len(parens) > 1:
+            nod = __salt__['cmd.run_stdout']('ls -l {0}'.format(comps[0]))
+            nod = ' '.join(nod.split()).split(" ")
             ret[comps[3]] = {'device': comps[0],
                          'fstype': comps[5],
                          'opts': _resolve_user_group_names(parens[1].split(", ")),
@@ -153,7 +153,7 @@ def _active_mounts_openbsd(ret):
         else:
             ret[comps[2]] = {'device': comps[0],
                             'fstype': comps[4],
-                            'opts': _resolve_user_group_names(parens[1].split(", "))}
+                            'opts': _resolve_user_group_names(parens[0].split(", "))}
     return ret
 
 


### PR DESCRIPTION
### What does this PR do?

mount(8) output is a little bit different on OpenBSD between local and special
or remote filesystems (e.g. tmpfs or nfs). These do not use a UUID nor a device.
This PR fixes mount.active.
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/34012
### Previous Behavior

salt-call -l debug --local mount.active 
<snip>
  File "/usr/local/lib/python2.7/site-packages/salt/modules/mount.py", line 156, in _active_mounts_openbsd
    'opts': _resolve_user_group_names(parens[1].split(", "))}
IndexError: list index out of range
### New Behavior

Output is properly displayed for local, remote and special FS.
