### PR TITLE
Add docs and tests to disk state

### DIFF
--- a/salt/states/disk.py
+++ b/salt/states/disk.py
@@ -53,6 +53,27 @@ __monitor__ = [
         ]
 
 
+def _validate_int(name, value, limits=(), strip='%'):
+    '''
+    Validate the named integer within the supplied limits inclusive and
+    strip supplied unit characters
+    '''
+    comment = ''
+    # Must be integral
+    try:
+        if isinstance(value, string_types):
+            value = value.strip(' ' + strip)
+        value = int(value)
+    except (TypeError, ValueError):
+        comment += '{0} must be an integer '.format(name)
+    # Must be in range
+    else:
+        if len(limits) == 2:
+            if value < limits[0] or value > limits[1]:
+                comment += '{0} must be in the range [{1[0]}, {1[1]}] '.format(name, limits)
+    return value, comment
+
+
 def status(name, maximum=None, minimum=None, absolute=False):
     '''
     Return the current disk usage stats for the named mount point
@@ -80,45 +101,55 @@ def status(name, maximum=None, minimum=None, absolute=False):
            'data': {}}  # Data field for monitoring state
 
     data = __salt__['disk.usage']()
+
+    # Validate name
     if name not in data:
         ret['result'] = False
         ret['comment'] += 'Named disk mount not present '
         return ret
-    if maximum and not absolute:
-        try:
-            if isinstance(maximum, string_types):
-                maximum = int(maximum.strip('%'))
-        except Exception:
-            ret['comment'] += 'Max argument must be an integer '
-    if minimum and not absolute:
-        try:
-            if isinstance(minimum, string_types):
-                minimum = int(minimum.strip('%'))
-        except Exception:
-            ret['comment'] += 'Min argument must be an integer '
-    if minimum and maximum:
+    # Validate extrema
+    if maximum is not None:
+        if not absolute:
+            maximum, comment = _validate_int('maximum', maximum, [0, 100])
+        else:
+            maximum, comment = _validate_int('maximum', maximum, strip='KB')
+        ret['comment'] += comment
+    if minimum is not None:
+        if not absolute:
+            minimum, comment = _validate_int('minimum', minimum, [0, 100])
+        else:
+            minimum, comment = _validate_int('minimum', minimum, strip='KB')
+        ret['comment'] += comment
+    if minimum is not None and maximum is not None:
         if minimum >= maximum:
-            ret['comment'] += 'Min must be less than max'
+            ret['comment'] += 'minimum must be less than maximum '
     if ret['comment']:
         return ret
-    minimum = int(minimum)
-    maximum = int(maximum)
+
+    # Get used space
     if absolute:
         used = int(data[name]['used'])
     else:
         # POSIX-compliant df output reports percent used as 'capacity'
         used = int(data[name]['capacity'].strip('%'))
+
+    # Collect return information
     ret['data'] = data[name]
-    if minimum:
+    unit = 'KB' if absolute else '%'
+    if minimum is not None:
         if used < minimum:
-            ret['comment'] = 'Disk used space is below minimum of {0} at {1}'.format(
-                    minimum, used)
+            ret['comment'] = ('Disk used space is below minimum'
+                              ' of {0} {2} at {1} {2}'
+                              ''.format(minimum, used, unit)
+                             )
             return ret
-    if maximum:
+    if maximum is not None:
         if used > maximum:
-            ret['comment'] = 'Disk used space is above maximum of {0} at {1}'.format(
-                    maximum, used)
+            ret['comment'] = ('Disk used space is above maximum'
+                              ' of {0} {2} at {1} {2}'
+                              ''.format(maximum, used, unit)
+                             )
             return ret
-    ret['comment'] = 'Disk in acceptable range'
+    ret['comment'] = 'Disk used space in acceptable range'
     ret['result'] = True
     return ret

--- a/tests/unit/states/disk_test.py
+++ b/tests/unit/states/disk_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-    :codeauthor: :email:`Jayesh Kariya <jayeshk@saltstack.com>`
+Tests for disk state
 '''
 # Import Python libs
 from __future__ import absolute_import
@@ -26,79 +26,227 @@ disk.__salt__ = {}
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class DiskTestCase(TestCase):
     '''
-    Test cases for salt.states.disk
+    Test disk state
     '''
-    # 'status' function tests: 1
+    def setUp(self):
+        '''
+        setup common test info
+        '''
+        self.mock_data = {
+            '/': {
+                '1K-blocks': '41147472',
+                'available': '37087976',
+                'capacity': '6%',
+                'filesystem': '/dev/xvda1',
+                'used': '2172880'},
+            '/dev': {
+                '1K-blocks': '10240',
+                'available': '10240',
+                'capacity': '0%',
+                'filesystem': 'udev',
+                'used': '0'},
+            '/run': {
+                '1K-blocks': '410624',
+                'available': '379460',
+                'capacity': '8%',
+                'filesystem': 'tmpfs',
+                'used': '31164'},
+            '/sys/fs/cgroup': {
+                '1K-blocks': '1026556',
+                'available': '1026556',
+                'capacity': '0%',
+                'filesystem': 'tmpfs',
+                'used': '0'}
+        }
+        self.__salt__ = {
+            'disk.usage': MagicMock(return_value=self.mock_data),
+        }
+
+    def test_status_missing(self):
+        '''
+        Test disk.status when name not found
+        '''
+        mock_fs = '/mnt/cheese'
+        mock_ret = {'name': mock_fs,
+                    'result': False,
+                    'comment': 'Named disk mount not present ',
+                    'changes': {},
+                    'data': {}}
+
+        with patch.dict(disk.__salt__, self.__salt__):
+            ret = disk.status(mock_fs)
+            self.assertEqual(ret, mock_ret)
+
+    def test_status_type_error(self):
+        '''
+        Test disk.status with incorrectly formatted arguments
+        '''
+        mock_fs = '/'
+        mock_ret = {'name': mock_fs,
+                    'result': False,
+                    'comment': '',
+                    'changes': {},
+                    'data': {}}
+
+        with patch.dict(disk.__salt__, self.__salt__):
+            mock_ret['comment'] = 'maximum must be an integer '
+            ret = disk.status(mock_fs, maximum=r'e^{i\pi}')
+            self.assertEqual(ret, mock_ret)
+
+        with patch.dict(disk.__salt__, self.__salt__):
+            mock_ret['comment'] = 'minimum must be an integer '
+            ret = disk.status(mock_fs, minimum=r'\cos\pi + i\sin\pi')
+            self.assertEqual(ret, mock_ret)
+
+    def test_status_range_error(self):
+        '''
+        Test disk.status with excessive extrema
+        '''
+        mock_fs = '/'
+        mock_ret = {'name': mock_fs,
+                    'result': False,
+                    'comment': '',
+                    'changes': {},
+                    'data': {}}
+
+        with patch.dict(disk.__salt__, self.__salt__):
+            mock_ret['comment'] = 'maximum must be in the range [0, 100] '
+            ret = disk.status(mock_fs, maximum='-1')
+            self.assertEqual(ret, mock_ret)
+
+        with patch.dict(disk.__salt__, self.__salt__):
+            mock_ret['comment'] = 'minimum must be in the range [0, 100] '
+            ret = disk.status(mock_fs, minimum='101')
+            self.assertEqual(ret, mock_ret)
+
+    def test_status_inverted_range(self):
+        '''
+        Test disk.status when minimum > maximum
+        '''
+        mock_fs = '/'
+        mock_ret = {'name': mock_fs,
+                    'result': False,
+                    'comment': 'minimum must be less than maximum ',
+                    'changes': {},
+                    'data': {}}
+
+        with patch.dict(disk.__salt__, self.__salt__):
+            ret = disk.status(mock_fs, maximum='0', minimum='1')
+            self.assertEqual(ret, mock_ret)
+
+    def test_status_threshold(self):
+        '''
+        Test disk.status when filesystem triggers thresholds
+        '''
+        mock_min = 100
+        mock_max = 0
+        mock_fs = '/'
+        mock_used = int(self.mock_data[mock_fs]['capacity'].strip('%'))
+        mock_ret = {'name': mock_fs,
+                    'result': False,
+                    'comment': '',
+                    'changes': {},
+                    'data': self.mock_data[mock_fs]}
+
+        with patch.dict(disk.__salt__, self.__salt__):
+            mock_ret['comment'] = 'Disk used space is below minimum of {0} % at {1} %'.format(
+                                       mock_min,
+                                       mock_used
+                                   )
+            ret = disk.status(mock_fs, minimum=mock_min)
+            self.assertEqual(ret, mock_ret)
+
+        with patch.dict(disk.__salt__, self.__salt__):
+            mock_ret['comment'] = 'Disk used space is above maximum of {0} % at {1} %'.format(
+                                       mock_max,
+                                       mock_used
+                                   )
+            ret = disk.status(mock_fs, maximum=mock_max)
+            self.assertEqual(ret, mock_ret)
+
+    def test_status_strip(self):
+        '''
+        Test disk.status appropriately strips unit info from numbers
+        '''
+        mock_fs = '/'
+        mock_ret = {'name': mock_fs,
+                    'result': True,
+                    'comment': 'Disk used space in acceptable range',
+                    'changes': {},
+                    'data': self.mock_data[mock_fs]}
+
+        with patch.dict(disk.__salt__, self.__salt__):
+            ret = disk.status(mock_fs, minimum='0%')
+            self.assertEqual(ret, mock_ret)
+
+            ret = disk.status(mock_fs, minimum='0 %')
+            self.assertEqual(ret, mock_ret)
+
+            ret = disk.status(mock_fs, maximum='100%')
+            self.assertEqual(ret, mock_ret)
+
+            ret = disk.status(mock_fs, minimum='1024K', absolute=True)
+            self.assertEqual(ret, mock_ret)
+
+            ret = disk.status(mock_fs, minimum='1024KB', absolute=True)
+            self.assertEqual(ret, mock_ret)
+
+            ret = disk.status(mock_fs, maximum='4194304 KB', absolute=True)
+            self.assertEqual(ret, mock_ret)
 
     def test_status(self):
         '''
-        Test to return the current disk usage stats for the named mount point
+        Test disk.status when filesystem meets thresholds
         '''
-        name = 'mydisk'
+        mock_min = 0
+        mock_max = 100
+        mock_fs = '/'
+        mock_ret = {'name': mock_fs,
+                    'result': True,
+                    'comment': 'Disk used space in acceptable range',
+                    'changes': {},
+                    'data': self.mock_data[mock_fs]}
 
-        ret = {'name': name,
-               'result': False,
-               'comment': '',
-               'changes': {},
-               'data': {}}
+        with patch.dict(disk.__salt__, self.__salt__):
+            ret = disk.status(mock_fs, minimum=mock_min)
+            self.assertEqual(ret, mock_ret)
 
-        mock = MagicMock(side_effect=[[], [name], {name: {'capacity': '8 %'}},
-                                      {name: {'capacity': '22 %'}},
-                                      {name: {'capacity': '15 %'}}])
-        with patch.dict(disk.__salt__, {'disk.usage': mock}):
-            comt = ('Named disk mount not present ')
-            ret.update({'comment': comt})
-            self.assertDictEqual(disk.status(name), ret)
-
-            comt = ('Min must be less than max')
-            ret.update({'comment': comt})
-            self.assertDictEqual(disk.status(name, '10 %', '20 %'), ret)
-
-            comt = ('Disk is below minimum of 10 at 8')
-            ret.update({'comment': comt, 'data': {'capacity': '8 %'}})
-            self.assertDictEqual(disk.status(name, '20 %', '10 %'), ret)
-
-            comt = ('Disk is above maximum of 20 at 22')
-            ret.update({'comment': comt, 'data': {'capacity': '22 %'}})
-            self.assertDictEqual(disk.status(name, '20 %', '10 %'), ret)
-
-            comt = ('Disk in acceptable range')
-            ret.update({'comment': comt, 'result': True,
-                        'data': {'capacity': '15 %'}})
-            self.assertDictEqual(disk.status(name, '20 %', '10 %'), ret)
+        with patch.dict(disk.__salt__, self.__salt__):
+            ret = disk.status(mock_fs, maximum=mock_max)
+            self.assertEqual(ret, mock_ret)
 
         # Reset mock because it's an iterator to run the tests with the
         # absolute flag
-        ret = {'name': name,
+        ret = {'name': mock_fs,
                'result': False,
                'comment': '',
                'changes': {},
                'data': {}}
 
-        mock = MagicMock(side_effect=[[], [name], {name: {'capacity': '8 %', 'available': '8'}},
-            {name: {'capacity': '22 %', 'available': '22'}},
-            {name: {'capacity': '15 %', 'available': '15'}}])
+        mock = MagicMock(side_effect=[[], [mock_fs], {mock_fs: {'capacity': '8 %', 'used': '8'}},
+            {mock_fs: {'capacity': '22 %', 'used': '22'}},
+            {mock_fs: {'capacity': '15 %', 'used': '15'}}])
         with patch.dict(disk.__salt__, {'disk.usage': mock}):
             comt = ('Named disk mount not present ')
             ret.update({'comment': comt})
-            self.assertDictEqual(disk.status(name), ret)
+            self.assertDictEqual(disk.status(mock_fs), ret)
 
-            comt = ('Min must be less than max')
+            comt = ('minimum must be less than maximum ')
             ret.update({'comment': comt})
-            self.assertDictEqual(disk.status(name, '10', '20', absolute=True), ret)
+            self.assertDictEqual(disk.status(mock_fs, '10', '20', absolute=True), ret)
 
-            comt = ('Disk is below minimum of 10 at 8')
-            ret.update({'comment': comt, 'data': {'capacity': '8 %', 'available': '8'}})
-            self.assertDictEqual(disk.status(name, '20', '10', absolute=True), ret)
+            comt = ('Disk used space is below minimum of 10 KB at 8 KB')
+            ret.update({'comment': comt, 'data': {'capacity': '8 %', 'used': '8'}})
+            self.assertDictEqual(disk.status(mock_fs, '20', '10', absolute=True), ret)
 
-            comt = ('Disk is above maximum of 20 at 22')
-            ret.update({'comment': comt, 'data': {'capacity': '22 %', 'available': '22'}})
-            self.assertDictEqual(disk.status(name, '20', '10', absolute=True), ret)
+            comt = ('Disk used space is above maximum of 20 KB at 22 KB')
+            ret.update({'comment': comt, 'data': {'capacity': '22 %', 'used': '22'}})
+            self.assertDictEqual(disk.status(mock_fs, '20', '10', absolute=True), ret)
 
-            comt = ('Disk in acceptable range')
+            comt = ('Disk used space in acceptable range')
             ret.update({'comment': comt, 'result': True,
-                'data': {'capacity': '15 %', 'available': '15'}})
-            self.assertDictEqual(disk.status(name, '20', '10', absolute=True), ret)
+                'data': {'capacity': '15 %', 'used': '15'}})
+            self.assertDictEqual(disk.status(mock_fs, '20', '10', absolute=True), ret)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?

Add docs and tests to disk state to remove ambiguity about what 'capacity' means and reinforce correct behavior.  Port of #33984 to develop branch.  Also fixes an error in #33918 where using `absolute: True` switched the meaning of `minimum` and `maximum`.  Ping, @cachedout.
### What issues does this PR fix or reference?

ZD-754
### Tests written?

Yes
