### PR TITLE
modules.pkg int tests: skip refresh_db upon error

### DIFF
--- a/tests/integration/modules/pkg.py
+++ b/tests/integration/modules/pkg.py
@@ -193,6 +193,8 @@ class PkgModuleTest(integration.ModuleCase,
             self.assertIn(ret, (True, None))
         elif os_family == 'Debian':
             ret = self.run_function(func)
+            if not isinstance(ret, dict):
+                self.skipTest('{0} encountered an error: {1}'.format(func, ret))
             self.assertNotEqual(ret, {})
             for source, state in ret.items():
                 self.assertIn(state, (True, False, None))


### PR DESCRIPTION
### What does this PR do?

Skip the test when there is an error:

``` py
Error Message

'str' object has no attribute 'items'

Stacktrace

Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/salttesting/helpers.py", line 547, in wrapper
    return func(cls)
  File "/usr/local/lib/python2.7/dist-packages/salttesting/helpers.py", line 68, in wrap
    return caller(cls)
  File "/testing/tests/integration/modules/pkg.py", line 197, in test_refresh_db
    for source, state in ret.items():
AttributeError: 'str' object has no attribute 'items'

Standard Output

Standard Error
```
### What issues does this PR fix or reference?
### Tests written?

Yes
