### PR TITLE
modules.inspectlib.kiwiproc: import gate lxml

### DIFF
--- a/salt/modules/inspectlib/kiwiproc.py
+++ b/salt/modules/inspectlib/kiwiproc.py
@@ -14,14 +14,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Import python libs
+from __future__ import absolute_import
 import os
 import grp
 import pwd
-from lxml import etree
 from xml.dom import minidom
 import platform
 import socket
+
+# Import salt libs
 from salt.modules.inspectlib.exceptions import InspectorKiwiProcessorException
+
+# Import third party libs
+try:
+    from lxml import etree
+except ImportError:
+    from salt._compat import ElementTree as etree
 
 
 class KiwiExporter(object):


### PR DESCRIPTION
### What does this PR do?

Fix this failing test:

``` py
unittest2.loader._FailedTest.inspect_collector_test (from unittest2.loader._FailedTest-20160616214205)

Error Message

...

Stacktrace

Traceback (most recent call last):
ImportError: Failed to import test module: unit.modules.inspect_collector_test
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/unittest2/loader.py", line 456, in _find_test_path
    module = self._get_module_from_name(name)
  File "/usr/lib/python2.6/site-packages/unittest2/loader.py", line 395, in _get_module_from_name
    __import__(name)
  File "/testing/tests/unit/modules/inspect_collector_test.py", line 18, in <module>
    from salt.modules.inspectlib.collector import Inspector
  File "/testing/salt/modules/inspectlib/collector.py", line 27, in <module>
    from salt.modules.inspectlib import kiwiproc
  File "/testing/salt/modules/inspectlib/kiwiproc.py", line 20, in <module>
    from lxml import etree
ImportError: No module named lxml

Standard Output

Standard Error
```
### What issues does this PR fix or reference?
### Tests written?

No
