### PR TITLE
Update bootstrap-salt.sh to correctly handle Ubuntu 16.04 VMs

### DIFF
--- a/salt/cloud/deploy/bootstrap-salt.sh
+++ b/salt/cloud/deploy/bootstrap-salt.sh
@@ -1185,6 +1185,13 @@ __ubuntu_codename_translation() {
                 DISTRO_CODENAME="wily"
             fi
             ;;
+        "16")
+            if [ -n "$_april" ]; then
+                DISTRO_CODENAME="xenial"
+            else
+                DISTRO_CODENAME="yakkety"
+            fi
+            ;;
         *)
             DISTRO_CODENAME="trusty"
             ;;


### PR DESCRIPTION
### What does this PR do?

Adds support to bootstrap-salt.sh for Ubuntu 16.04 Xenial and Yakkety VMs.

With current salt-cloud deploying Ubuntu 16.04 VMs fails with error:

```
W: The repository 'https://repo.saltstack.com/apt/ubuntu/16.04/amd64/latest trusty Release' does not have a Release file.
E: Failed to fetch https://repo.saltstack.com/apt/ubuntu/16.04/amd64/latest/dists/trusty/main/binary-amd64/Packages  404  Not Found
E: Some index files failed to download. They have been ignored, or old ones used instead.
 * ERROR: Failed to run install_ubuntu_stable_deps()!!!
```

This happens because bootstrap-salt.sh incorrectly guesses release name to be 'trusty' when it should be 'xenial'.  This patch also adds support for upcoming 'yakkety' release of Ubuntu.
### What issues does this PR fix or reference?

Fixes #34084.
### Tests written?

No
