### PR TITLE
boto_elasticsearch_domain: avoid unnecessary changes to the Elasticse…

### DIFF
--- a/salt/states/boto_elasticsearch_domain.py
+++ b/salt/states/boto_elasticsearch_domain.py
@@ -97,6 +97,10 @@ def __virtual__():
     return 'boto_elasticsearch_domain' if 'boto_elasticsearch_domain.exists' in __salt__ else False
 
 
+def _compare_json(current, desired):
+    return __utils__['boto3.json_objs_equal'](current, desired)
+
+
 def present(name, DomainName,
             ElasticsearchClusterConfig=None,
             EBSOptions=None,
@@ -274,7 +278,7 @@ def present(name, DomainName,
         'SnapshotOptions': SnapshotOptions,
         'AdvancedOptions': AdvancedOptions
     }.iteritems():
-        if v != _describe[k]:
+        if not _compare_json(v, _describe[k]):
             need_update = True
             comm_args[k] = v
             ret['changes'].setdefault('new', {})[k] = v


### PR DESCRIPTION
### What does this PR do?

There is an issue where boto_elasticsearch_domain state module may request updates when there is actually no change. This can be expensive, since AWS may migrate to a new cluster in order to accomplish the "change".

This change addresses this by forcing a predictable order on fields where order is not guaranteed, before making the comparison.
