### PR TITLE
Don't return bytes if py3 in salt-cloud

### DIFF
--- a/salt/cloud/libcloudfuncs.py
+++ b/salt/cloud/libcloudfuncs.py
@@ -143,7 +143,7 @@ def avail_locations(conn=None, call=None):
     locations = conn.list_locations()
     ret = {}
     for img in locations:
-        if isinstance(img.name, string_types):
+        if isinstance(img.name, string_types) and not six.PY3:
             img_name = img.name.encode('ascii', 'salt-cloud-force-ascii')
         else:
             img_name = str(img.name)
@@ -154,7 +154,7 @@ def avail_locations(conn=None, call=None):
                 continue
 
             attr_value = getattr(img, attr)
-            if isinstance(attr_value, string_types):
+            if isinstance(attr_value, string_types) and not six.PY3:
                 attr_value = attr_value.encode(
                     'ascii', 'salt-cloud-force-ascii'
                 )
@@ -180,7 +180,7 @@ def avail_images(conn=None, call=None):
     images = conn.list_images()
     ret = {}
     for img in images:
-        if isinstance(img.name, string_types):
+        if isinstance(img.name, string_types) and not six.PY3:
             img_name = img.name.encode('ascii', 'salt-cloud-force-ascii')
         else:
             img_name = str(img.name)
@@ -190,7 +190,7 @@ def avail_images(conn=None, call=None):
             if attr.startswith('_'):
                 continue
             attr_value = getattr(img, attr)
-            if isinstance(attr_value, string_types):
+            if isinstance(attr_value, string_types) and not six.PY3:
                 attr_value = attr_value.encode(
                     'ascii', 'salt-cloud-force-ascii'
                 )
@@ -215,7 +215,7 @@ def avail_sizes(conn=None, call=None):
     sizes = conn.list_sizes()
     ret = {}
     for size in sizes:
-        if isinstance(size.name, string_types):
+        if isinstance(size.name, string_types) and not six.PY3:
             size_name = size.name.encode('ascii', 'salt-cloud-force-ascii')
         else:
             size_name = str(size.name)
@@ -230,7 +230,7 @@ def avail_sizes(conn=None, call=None):
             except Exception:
                 pass
 
-            if isinstance(attr_value, string_types):
+            if isinstance(attr_value, string_types) and not six.PY3:
                 attr_value = attr_value.encode(
                     'ascii', 'salt-cloud-force-ascii'
                 )
@@ -243,17 +243,19 @@ def get_location(conn, vm_):
     Return the location object to use
     '''
     locations = conn.list_locations()
-    vm_location = config.get_cloud_config_value('location', vm_, __opts__).encode(
-        'ascii', 'salt-cloud-force-ascii'
-    )
+    vm_location = config.get_cloud_config_value('location', vm_, __opts__)
+    if not six.PY3: 
+        vm_location = vm_location.encode(
+            'ascii', 'salt-cloud-force-ascii'
+        )
 
     for img in locations:
-        if isinstance(img.id, string_types):
+        if isinstance(img.id, string_types) and not six.PY3:
             img_id = img.id.encode('ascii', 'salt-cloud-force-ascii')
         else:
             img_id = str(img.id)
 
-        if isinstance(img.name, string_types):
+        if isinstance(img.name, string_types) and not six.PY3:
             img_name = img.name.encode('ascii', 'salt-cloud-force-ascii')
         else:
             img_name = str(img.name)
@@ -274,17 +276,20 @@ def get_image(conn, vm_):
     '''
     images = conn.list_images()
 
-    vm_image = config.get_cloud_config_value('image', vm_, __opts__).encode(
-        'ascii', 'salt-cloud-force-ascii'
-    )
+    vm_image = config.get_cloud_config_value('image', vm_, __opts__)
+   
+    if not six.PY3:
+        encode(
+            'ascii', 'salt-cloud-force-ascii'
+        )
 
     for img in images:
-        if isinstance(img.id, string_types):
+        if isinstance(img.id, string_types) and not six.PY3:
             img_id = img.id.encode('ascii', 'salt-cloud-force-ascii')
         else:
             img_id = str(img.id)
 
-        if isinstance(img.name, string_types):
+        if isinstance(img.name, string_types) and not six.PY3:
             img_name = img.name.encode('ascii', 'salt-cloud-force-ascii')
         else:
             img_name = str(img.name)

--- a/salt/cloud/libcloudfuncs.py
+++ b/salt/cloud/libcloudfuncs.py
@@ -244,7 +244,7 @@ def get_location(conn, vm_):
     '''
     locations = conn.list_locations()
     vm_location = config.get_cloud_config_value('location', vm_, __opts__)
-    if not six.PY3: 
+    if not six.PY3:
         vm_location = vm_location.encode(
             'ascii', 'salt-cloud-force-ascii'
         )
@@ -276,12 +276,10 @@ def get_image(conn, vm_):
     '''
     images = conn.list_images()
 
-    vm_image = config.get_cloud_config_value('image', vm_, __opts__)
-   
     if not six.PY3:
-        encode(
-            'ascii', 'salt-cloud-force-ascii'
-        )
+        vm_image = config.get_cloud_config_value('image', vm_, __opts__).encode(
+                'ascii', 'salt-cloud-force-ascii'
+            )
 
     for img in images:
         if isinstance(img.id, string_types) and not six.PY3:

--- a/salt/cloud/libcloudfuncs.py
+++ b/salt/cloud/libcloudfuncs.py
@@ -275,11 +275,10 @@ def get_image(conn, vm_):
     Return the image object to use
     '''
     images = conn.list_images()
+    vm_image = config.get_cloud_config_value('image', vm_, __opts__)
 
     if not six.PY3:
-        vm_image = config.get_cloud_config_value('image', vm_, __opts__).encode(
-                'ascii', 'salt-cloud-force-ascii'
-            )
+        vm_image = vm_image.encode('ascii', 'salt-cloud-force-ascii')
 
     for img in images:
         if isinstance(img.id, string_types) and not six.PY3:


### PR DESCRIPTION
### What does this PR do?

We used to return bytes instead of unicode, which would make a dict with mixed bytes and unicode. This was a pain and caused tests to fail.
### What issues does this PR fix or reference?

Failing py3 compat in salt-cloud
### Previous Behavior

A dict that looked like `
..{'default': {'disk': 0, 'id': b'1', 'driver': <libcloud.compute.drivers.dimensiondata.DimensionDataNodeDriver object at 0x7f2fcbc769b0>, 'price': 0, 'get_uuid': <bound method UuidMixin.get_uuid of <NodeSize: id=1, name=default, ram=0 disk=0 bandwidth=0 price=0 driver=DimensionData ...>>, 'ram': 0, 'name': b'default', 'uuid': b'94811c79b526d5ef99518ce215d56123cc644067', 'bandwidth': 0, 'extra': {}}}
` for the test return in `unit.cloud.clouds.dimensiondata_test.DimensionDataTestCase.test_avail_sizes`

cc: @techhat @rallytime and @s0undt3ch 

@s0undt3ch This affects changes that you made specifically, so please have a quick look if you can. 
