### PR TITLE
Make dockerng.absent state honor test=true

### DIFF
--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -2056,6 +2056,11 @@ def absent(name, force=False):
                           'forcibly remove it')
         return ret
 
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = ('Container \'{0}\' will be removed'.format(name))
+        return ret
+
     try:
         ret['changes']['removed'] = __salt__['dockerng.rm'](name, force=force)
     except Exception as exc:


### PR DESCRIPTION
### What does this PR do?

Fix `dockerng.absent` when passing in `test=true`
### Previous Behavior

With the following state `/srv/state/docker_test.sls`:

``` bash
delete_container:
  dockerng.absent:
    - name: test
    - force: True
```

``` bash
(salt) root@jessie:/srv/salt# docker ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
8caecab07a9b        ubuntu:14.04        "/bin/bash"         13 minutes ago      Up 13 minutes                           test

(salt) root@jessie:~/salt# salt '*' state.sls docker_test test=true

jessie:
----------
          ID: delete_container
    Function: dockerng.absent
        Name: test
      Result: True
     Comment: Forcibly removed container 'test'
     Started: 20:59:58.159183
    Duration: 842.916 ms
     Changes:   
              ----------
              removed:
                  - 8caecab07a9b8c44cabb1b7130222227611f582e6a100967569d734c3339a258

Summary for jessie
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1

(salt) root@jessie:~/salt# docker ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
```
### New Behavior

Same state as above and the fix:

``` bash
(salt) root@jessie:~/salt# salt '*' state.sls docker_test test=true

jessie:
----------
          ID: delete_container
    Function: dockerng.absent
        Name: test
      Result: None
     Comment: Container 'test' will be removed
     Started: 22:04:53.411383
    Duration: 4.884 ms
     Changes:   

Summary for jessie
------------
Succeeded: 1 (unchanged=1)
Failed:    0
------------
Total states run:     1
(salt) root@jessie:~/salt# docker ps -a

CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
6f332874952d        ubuntu:14.04        "/bin/bash"         2 minutes ago       Up 2 minutes                            test
```

And actually running the state works as expect still:

``` bash
(salt) root@jessie:~/salt# salt '*' state.sls docker_test
jessie:
----------
          ID: delete_container
    Function: dockerng.absent
        Name: test
      Result: True
     Comment: Forcibly removed container 'test'
     Started: 22:28:42.605469
    Duration: 621.064 ms
     Changes:   
              ----------
              removed:
                  - 6f332874952d2e2887833e46740631396b56f4b3aad8b15f2dda3674b4bf4e49

Summary for jessie
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
(salt) root@jessie:~/salt# docker ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
```
### Tests written?

No

Version output:

``` bash
root@jessie:~/salt# salt --versions
Salt Version:
           Salt: 2016.3.1-31-gf9667ba

Dependency Versions:
           cffi: Not Installed
       cherrypy: Not Installed
       dateutil: Not Installed
          gitdb: Not Installed
      gitpython: Not Installed
          ioflo: Not Installed
         Jinja2: 2.8
        libgit2: Not Installed
        libnacl: Not Installed
       M2Crypto: Not Installed
           Mako: Not Installed
   msgpack-pure: Not Installed
 msgpack-python: 0.4.7
   mysql-python: Not Installed
      pycparser: Not Installed
       pycrypto: 2.6.1
         pygit2: Not Installed
         Python: 2.7.9 (default, Mar  1 2015, 12:57:24)
   python-gnupg: Not Installed
         PyYAML: 3.11
          PyZMQ: 15.2.0
           RAET: Not Installed
          smmap: Not Installed
        timelib: Not Installed
        Tornado: 4.3
            ZMQ: 4.1.4

System Versions:
           dist: debian 8.2
        machine: x86_64
        release: 3.16.0-4-amd64
         system: Linux
        version: debian 8.2
```
