### PR TITLE
Fixes to git module & state module related to identity file

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -146,7 +146,7 @@ def _format_opts(opts):
 
 def _git_run(command, cwd=None, runas=None, identity=None,
              ignore_retcode=False, failhard=True, redirect_stderr=False,
-             **kwargs):
+             saltenv='base', **kwargs):
     '''
     simple, throw an exception with the error message on an error return code.
 
@@ -171,7 +171,7 @@ def _git_run(command, cwd=None, runas=None, identity=None,
         for id_file in identity:
             if 'salt://' in id_file:
                 _id_file = id_file
-                id_file = __salt__['cp.cache_file'](id_file)
+                id_file = __salt__['cp.cache_file'](id_file, saltenv)
                 if not id_file:
                     log.error('identity {0} does not exist.'.format(_id_file))
                     continue
@@ -684,7 +684,8 @@ def clone(cwd,
           https_user=None,
           https_pass=None,
           ignore_retcode=False,
-          repository=None):
+          repository=None,
+          saltenv='base'):
     '''
     Interface to `git-clone(1)`_
 
@@ -755,6 +756,11 @@ def clone(cwd,
 
         .. versionadded:: 2015.8.0
 
+    saltenv
+        The default salt environment to pull sls files from
+
+        .. versionadded:: 2016.3.1
+
     .. _`git-clone(1)`: http://git-scm.com/docs/git-clone
 
     CLI Example:
@@ -806,7 +812,8 @@ def clone(cwd,
              cwd=clone_cwd,
              runas=user,
              identity=identity,
-             ignore_retcode=ignore_retcode)
+             ignore_retcode=ignore_retcode,
+             saltenv=saltenv)
     return True
 
 
@@ -1379,7 +1386,8 @@ def fetch(cwd,
           opts='',
           user=None,
           identity=None,
-          ignore_retcode=False):
+          ignore_retcode=False,
+          saltenv='base'):
     '''
     .. versionchanged:: 2015.8.2
         Return data is now a dictionary containing information on branches and
@@ -1448,6 +1456,11 @@ def fetch(cwd,
 
         .. versionadded:: 2015.8.0
 
+    saltenv
+        The default salt environment to pull sls files from
+
+        .. versionadded:: 2016.3.1
+
     .. _`git-fetch(1)`: http://git-scm.com/docs/git-fetch
 
 
@@ -1487,7 +1500,8 @@ def fetch(cwd,
                       runas=user,
                       identity=identity,
                       ignore_retcode=ignore_retcode,
-                      redirect_stderr=True)['stdout']
+                      redirect_stderr=True,
+                      saltenv=saltenv)['stdout']
 
     update_re = re.compile(
         r'[\s*]*(?:([0-9a-f]+)\.\.([0-9a-f]+)|'
@@ -2020,7 +2034,8 @@ def ls_remote(cwd=None,
               identity=None,
               https_user=None,
               https_pass=None,
-              ignore_retcode=False):
+              ignore_retcode=False,
+              saltenv='base'):
     '''
     Interface to `git-ls-remote(1)`_. Returns the upstream hash for a remote
     reference.
@@ -2097,6 +2112,11 @@ def ls_remote(cwd=None,
 
         .. versionadded:: 2015.8.0
 
+    saltenv
+        The default salt environment to pull sls files from
+
+        .. versionadded:: 2016.3.1
+
     .. _`git-ls-remote(1)`: http://git-scm.com/docs/git-ls-remote
 
 
@@ -2129,7 +2149,8 @@ def ls_remote(cwd=None,
                       cwd=cwd,
                       runas=user,
                       identity=identity,
-                      ignore_retcode=ignore_retcode)['stdout']
+                      ignore_retcode=ignore_retcode,
+                      saltenv=saltenv)['stdout']
     ret = {}
     for line in output.splitlines():
         try:
@@ -2468,7 +2489,7 @@ def merge_tree(cwd,
                     ignore_retcode=ignore_retcode)['stdout']
 
 
-def pull(cwd, opts='', user=None, identity=None, ignore_retcode=False):
+def pull(cwd, opts='', user=None, identity=None, ignore_retcode=False, saltenv='base'):
     '''
     Interface to `git-pull(1)`_
 
@@ -2516,6 +2537,11 @@ def pull(cwd, opts='', user=None, identity=None, ignore_retcode=False):
 
         .. versionadded:: 2015.8.0
 
+    saltenv
+        The default salt environment to pull sls files from
+
+        .. versionadded:: 2016.3.1
+
     .. _`git-pull(1)`: http://git-scm.com/docs/git-pull
 
     CLI Example:
@@ -2531,7 +2557,8 @@ def pull(cwd, opts='', user=None, identity=None, ignore_retcode=False):
                     cwd=cwd,
                     runas=user,
                     identity=identity,
-                    ignore_retcode=ignore_retcode)['stdout']
+                    ignore_retcode=ignore_retcode,
+                    saltenv=saltenv)['stdout']
 
 
 def push(cwd,
@@ -2541,6 +2568,7 @@ def push(cwd,
          user=None,
          identity=None,
          ignore_retcode=False,
+         saltenv='base',
          **kwargs):
     '''
     Interface to `git-push(1)`_
@@ -2607,6 +2635,11 @@ def push(cwd,
 
         .. versionadded:: 2015.8.0
 
+    saltenv
+        The default salt environment to pull sls files from
+
+        .. versionadded:: 2016.3.1
+
     .. _`git-push(1)`: http://git-scm.com/docs/git-push
     .. _refspec: http://git-scm.com/book/en/v2/Git-Internals-The-Refspec
 
@@ -2645,7 +2678,8 @@ def push(cwd,
                     cwd=cwd,
                     runas=user,
                     identity=identity,
-                    ignore_retcode=ignore_retcode)['stdout']
+                    ignore_retcode=ignore_retcode,
+                    saltenv=saltenv)['stdout']
 
 
 def rebase(cwd, rev='master', opts='', user=None, ignore_retcode=False):
@@ -2766,7 +2800,8 @@ def remote_refs(url,
                 identity=None,
                 https_user=None,
                 https_pass=None,
-                ignore_retcode=False):
+                ignore_retcode=False,
+                saltenv='base'):
     '''
     .. versionadded:: 2015.8.0
 
@@ -2818,6 +2853,11 @@ def remote_refs(url,
         If ``True``, do not log an error to the minion log if the git command
         returns a nonzero exit status.
 
+    saltenv
+        The default salt environment to pull sls files from
+
+        .. versionadded:: 2016.3.1
+
     CLI Example:
 
     .. code-block:: bash
@@ -2839,7 +2879,8 @@ def remote_refs(url,
     output = _git_run(command,
                       runas=user,
                       identity=identity,
-                      ignore_retcode=ignore_retcode)['stdout']
+                      ignore_retcode=ignore_retcode,
+                      saltenv=saltenv)['stdout']
     ret = {}
     for line in salt.utils.itertools.split(output, '\n'):
         try:
@@ -3328,6 +3369,7 @@ def submodule(cwd,
               user=None,
               identity=None,
               ignore_retcode=False,
+              saltenv='base',
               **kwargs):
     '''
     .. versionchanged:: 2015.8.0
@@ -3397,6 +3439,11 @@ def submodule(cwd,
 
         .. versionadded:: 2015.8.0
 
+    saltenv
+        The default salt environment to pull sls files from
+
+        .. versionadded:: 2016.3.1
+
     .. _`git-submodule(1)`: http://git-scm.com/docs/git-submodule
 
     CLI Example:
@@ -3437,7 +3484,8 @@ def submodule(cwd,
                     cwd=cwd,
                     runas=user,
                     identity=identity,
-                    ignore_retcode=ignore_retcode)['stdout']
+                    ignore_retcode=ignore_retcode,
+                    saltenv=saltenv)['stdout']
 
 
 def symbolic_ref(cwd,

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -506,7 +506,7 @@ def latest(name,
         for ident_path in identity:
             if 'salt://' in ident_path:
                 try:
-                    ident_path = __salt__['cp.cache_file'](ident_path)
+                    ident_path = __salt__['cp.cache_file'](ident_path, __env__)
                 except IOError as exc:
                     log.error(
                         'Failed to cache {0}: {1}'.format(ident_path, exc)
@@ -584,7 +584,8 @@ def latest(name,
             identity=identity,
             https_user=https_user,
             https_pass=https_pass,
-            ignore_retcode=False)
+            ignore_retcode=False,
+            saltenv=__env__)
     except CommandExecutionError as exc:
         return _fail(
             ret,
@@ -1097,7 +1098,8 @@ def latest(name,
                             force=force_fetch,
                             refspecs=refspecs,
                             user=user,
-                            identity=identity)
+                            identity=identity,
+                            saltenv=__env__)
                     except CommandExecutionError as exc:
                         return _failed_fetch(ret, exc, comments)
                     else:
@@ -1284,7 +1286,8 @@ def latest(name,
                             'update',
                             opts=['--init', '--recursive'],
                             user=user,
-                            identity=identity)
+                            identity=identity,
+                            saltenv=__env__)
                     except CommandExecutionError as exc:
                         return _failed_submodule_update(ret, exc, comments)
             elif bare:
@@ -1304,7 +1307,8 @@ def latest(name,
                         force=force_fetch,
                         refspecs=refspecs,
                         user=user,
-                        identity=identity)
+                        identity=identity,
+                        saltenv=__env__)
                 except CommandExecutionError as exc:
                     return _failed_fetch(ret, exc, comments)
                 else:
@@ -1421,7 +1425,8 @@ def latest(name,
                                       opts=clone_opts,
                                       identity=identity,
                                       https_user=https_user,
-                                      https_pass=https_pass)
+                                      https_pass=https_pass,
+                                      saltenv=__env__)
             except CommandExecutionError as exc:
                 msg = 'Clone failed: {0}'.format(_strip_exc(exc))
                 return _fail(ret, msg, comments)
@@ -2046,7 +2051,8 @@ def detached(name,
                                   opts=clone_opts,
                                   identity=identity,
                                   https_user=https_user,
-                                  https_pass=https_pass)
+                                  https_pass=https_pass,
+                                  saltenv=__env__)
             comments.append(
                 '{0} cloned to {1}'.format(
                     name,
@@ -2088,7 +2094,8 @@ def detached(name,
                 force=True,
                 refspecs=refspecs,
                 user=user,
-                identity=identity)
+                identity=identity,
+                saltenv=__env__)
         except CommandExecutionError as exc:
             msg = 'Fetch failed'
             msg += ':\n\n' + str(exc)


### PR DESCRIPTION
### What does this PR do?

Fixes to git module & state module related to using an identity file from a Salt URL.
### What issues does this PR fix or reference?

N/A
### Previous Behavior

If you specified an identity file via a Salt URL, eg. salt://files/identity and if that file is in a different environment than the default `base` then the file can't be found.
### New Behavior

New behavior, adding the ability to specify the saltenv for those functions where it makes sense.  The functions in the state module that use an identify file the environment is passed along where applicable.
### Tests written?

/No
