### PR TITLE
Fix reference error in adb module

### DIFF
--- a/salt/beacons/adb.py
+++ b/salt/beacons/adb.py
@@ -81,7 +81,7 @@ def beacon(config):
     out = __salt__['cmd.run']('adb devices', runas=config.get('user', None))
 
     lines = out.split('\n')[1:]
-    last_state_devices = last_state.keys()
+    last_state_devices = list(last_state.keys())
     found_devices = []
 
     for line in lines:


### PR DESCRIPTION
### What does this PR do?

The Py3 transition exposed a subtle bug in the adb becaon. We need
a unique list object for the last_state keys, or we'll be referencing
a dict that we'll modify inside some of the function loops in certain cases.
