### PR TITLE
Don't traverse directories that match file_ignore_regex and file_ignore_glob

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -766,6 +766,8 @@ class LocalClient(Client):
             for root, dirs, files in os.walk(
                 os.path.join(path, prefix), followlinks=True
             ):
+                # Don't walk any directories that match file_ignore_regex or glob
+                dirs[:] = [d for d in dirs if not salt.fileserver.is_file_ignored(self.opts, d)]
                 for fname in files:
                     relpath = os.path.relpath(os.path.join(root, fname), path)
                     ret.append(sdecode(relpath))
@@ -784,6 +786,8 @@ class LocalClient(Client):
             for root, dirs, files in os.walk(
                 os.path.join(path, prefix), followlinks=True
             ):
+                # Don't walk any directories that match file_ignore_regex or glob
+                dirs[:] = [d for d in dirs if not salt.fileserver.is_file_ignored(self.opts, d)]
                 if len(dirs) == 0 and len(files) == 0:
                     ret.append(sdecode(os.path.relpath(root, path)))
         return ret

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -171,7 +171,7 @@ def check_env_cache(opts, env_cache):
     return None
 
 
-def generate_mtime_map(path_map):
+def generate_mtime_map(opts, path_map):
     '''
     Generate a dict of filename -> mtime
     '''
@@ -179,6 +179,8 @@ def generate_mtime_map(path_map):
     for saltenv, path_list in six.iteritems(path_map):
         for path in path_list:
             for directory, dirnames, filenames in os.walk(path):
+                # Don't walk any directories that match file_ignore_regex or glob
+                dirnames[:] = [d for d in dirnames if not is_file_ignored(opts, d)]
                 for item in filenames:
                     try:
                         file_path = os.path.join(directory, item)

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -134,7 +134,7 @@ def update():
             'backend': 'roots'}
 
     # generate the new map
-    new_mtime_map = salt.fileserver.generate_mtime_map(__opts__['file_roots'])
+    new_mtime_map = salt.fileserver.generate_mtime_map(__opts__, __opts__['file_roots'])
 
     old_mtime_map = {}
     # if you have an old map, load that
@@ -302,6 +302,9 @@ def _file_lists(load, form):
             for root, dirs, files in os.walk(
                     path,
                     followlinks=__opts__['fileserver_followsymlinks']):
+                # Don't walk any directories that match file_ignore_regex or glob
+                dirs[:] = [d for d in dirs if not salt.fileserver.is_file_ignored(__opts__, d)]
+
                 dir_rel_fn = os.path.relpath(root, path)
                 if __opts__.get('file_client', 'remote') == 'local' and os.path.sep == "\\":
                     dir_rel_fn = dir_rel_fn.replace('\\', '/')
@@ -381,6 +384,8 @@ def symlink_list(load):
             prefix = ''
         # Adopting rsync functionality here and stopping at any encounter of a symlink
         for root, dirs, files in os.walk(os.path.join(path, prefix), followlinks=False):
+            # Don't walk any directories that match file_ignore_regex or glob
+            dirs[:] = [d for d in dirs if not salt.fileserver.is_file_ignored(__opts__, d)]
             for fname in files:
                 if not os.path.islink(os.path.join(root, fname)):
                     continue


### PR DESCRIPTION
### What does this PR do?

This PR allows salt to ignore directories that match regex or globs in file_ignore_regex or file_ignore_glob settings. This is helpful if you have a large directory you want ignored so that salt does not waste time learning about files in that directory. One such example is the .git directory which can be very large. When file roots is on a network drive or vagrant share, learning of all these files severely degrades salt-master and salt-call state.highstate performance due to os.stat calls that are called on each file. (benchmarks below)
### What issues does this PR fix or reference?

This PR fixes https://github.com/saltstack/salt/issues/33907
### Previous Behavior

Salt roots fileserver periodically generates a list/cache of files that it can serve. Doing so ends up calling os.stat on each file, which is can be slow over a network or vagrant share. If a file matches file_ignore_regex or file_ignore_glob, then the file is excluded from the list. If the directory name matches file_ignore_regex or glob, salt still goes into directory and adds all those files to its file cache.
### New Behavior

As salt generates file list, if it encounters a directory whose name matches file_ignore_regex or glob, it is skipped and all files within that directory are ignored and not cached.
### Benchmarks

Two benchmarks below show state.highstate now completes in 2 minutes instead of 10 minutes when I ignore the .git directory and file roots is on a vagrant share. strace -c shows the reduction in stat syscalls from 582314 calls  to 140998. Both of these highstates were done after an initial highstate was already completed, so all states with side-effects had already been completed.

strace -c of salt-call state.highstate and file_ignore_regex contain '.git':

```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 74.87    8.855751          63    140998      3708 stat
 13.25    1.567275          38     40854     15411 open
 10.66    1.261491          40     31720        13 lstat
  0.47    0.055037           2     30559           fstat
  0.43    0.051170         391       131           clone
  0.12    0.014648           0     39136           getdents
  0.08    0.009545           0     26064           close
  0.07    0.008091          62       131           wait4
  0.02    0.002637           0      9225         2 read
  0.02    0.002008           0      4695           write
  0.00    0.000564           0      5333       935 lseek
  0.00    0.000135           1       111           poll
  0.00    0.000114           1       224           umask
  0.00    0.000111           0      5515           fcntl
  0.00    0.000099           0      2225           mmap
  0.00    0.000082           0      1794           munmap
  0.00    0.000055           1        55           setresgid
  0.00    0.000052           0       116           getcwd
  0.00    0.000000           0       252           mprotect
  0.00    0.000000           0       228           brk
  0.00    0.000000           0        69           rt_sigaction
  0.00    0.000000           0         3           rt_sigprocmask
  0.00    0.000000           0         9         2 ioctl
  0.00    0.000000           0       922       694 access
  0.00    0.000000           0       295           pipe
  0.00    0.000000           0         1           msync
  0.00    0.000000           0         3           dup
  0.00    0.000000           0        21           socket
  0.00    0.000000           0        21        19 connect
  0.00    0.000000           0         2           sendto
  0.00    0.000000           0         2           recvfrom
  0.00    0.000000           0         1           execve
  0.00    0.000000           0         1           kill
  0.00    0.000000           0        16           uname
  0.00    0.000000           0       474           flock
  0.00    0.000000           0         1           rename
  0.00    0.000000           0        18           mkdir
  0.00    0.000000           0        15           rmdir
  0.00    0.000000           0        64         1 unlink
  0.00    0.000000           0        13         2 readlink
  0.00    0.000000           0         1           chmod
  0.00    0.000000           0         1           chown
  0.00    0.000000           0         2           getrlimit
  0.00    0.000000           0         1           getrusage
  0.00    0.000000           0         3           sysinfo
  0.00    0.000000           0         3           getuid
  0.00    0.000000           0         2           getgid
  0.00    0.000000           0         2           geteuid
  0.00    0.000000           0        37           getegid
  0.00    0.000000           0         1         1 statfs
  0.00    0.000000           0         1           arch_prctl
  0.00    0.000000           0         1           gettid
  0.00    0.000000           0        10           futex
  0.00    0.000000           0         1           set_tid_address
  0.00    0.000000           0         1           set_robust_list
  0.00    0.000000           0         4           pipe2
------ ----------- ----------- --------- --------- ----------------
100.00   11.828865                341388     20788 total

real    2m37.927s
user    0m16.064s
sys     1m6.400s
```

timed strace -c of salt-call state.highstate (not ignoring .git directory):

```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 70.21   30.634259          53    582314      3693 stat
 18.42    8.035836          68    118804     15410 open
 10.60    4.625255          39    118224        13 lstat
  0.47    0.205072           2    108526           fstat
  0.16    0.069499           0    195026           getdents
  0.10    0.042764           0    104015           close
  0.01    0.006235           1      8789           write
  0.01    0.006036          46       131           wait4
  0.01    0.003156          24       131           clone
  0.00    0.001183           0     11602         2 read
  0.00    0.000436           0      2060           munmap
  0.00    0.000392           0      2506           mmap
  0.00    0.000165           0      5529           fcntl
  0.00    0.000161           0      5357       935 lseek
  0.00    0.000112           0       915       687 access
  0.00    0.000000           0       111           poll
  0.00    0.000000           0       252           mprotect
  0.00    0.000000           0       230           brk
  0.00    0.000000           0        69           rt_sigaction
  0.00    0.000000           0         3           rt_sigprocmask
  0.00    0.000000           0         9         2 ioctl
  0.00    0.000000           0       295           pipe
  0.00    0.000000           0         1           msync
  0.00    0.000000           0         3           dup
  0.00    0.000000           0        21           socket
  0.00    0.000000           0        21        19 connect
  0.00    0.000000           0         2           sendto
  0.00    0.000000           0         2           recvfrom
  0.00    0.000000           0         1           execve
  0.00    0.000000           0         1           kill
  0.00    0.000000           0        16           uname
  0.00    0.000000           0       476           flock
  0.00    0.000000           0       118           getcwd
  0.00    0.000000           0        13           mkdir
  0.00    0.000000           0        13           rmdir
  0.00    0.000000           0        64         1 unlink
  0.00    0.000000           0        13         2 readlink
  0.00    0.000000           0       224           umask
  0.00    0.000000           0         2           getrlimit
  0.00    0.000000           0         1           getrusage
  0.00    0.000000           0         3           sysinfo
  0.00    0.000000           0         3           getuid
  0.00    0.000000           0         2           getgid
  0.00    0.000000           0         2           geteuid
  0.00    0.000000           0        37           getegid
  0.00    0.000000           0        55           setresgid
  0.00    0.000000           0         1         1 statfs
  0.00    0.000000           0         1           arch_prctl
  0.00    0.000000           0         1           gettid
  0.00    0.000000           0        10           futex
  0.00    0.000000           0         1           set_tid_address
  0.00    0.000000           0         1           set_robust_list
  0.00    0.000000           0         4           pipe2
------ ----------- ----------- --------- --------- ----------------
100.00   43.630561               1266011     20765 total

real    10m28.216s
user    0m29.580s
sys     4m41.004s
```