### PR TITLE
Add timeout to ddns execution module and runner

### DIFF
--- a/salt/modules/ddns.py
+++ b/salt/modules/ddns.py
@@ -128,7 +128,7 @@ def delete_host(zone, name, nameserver='127.0.0.1', timeout=5, **kwargs):
     except IndexError:
         ips = []
 
-    res = delete(zone, name, nameserver=nameserver, timeout, **kwargs)
+    res = delete(zone, name, nameserver=nameserver, timeout=timeout, **kwargs)
 
     fqdn = fqdn + '.'
     for ip in ips:

--- a/salt/modules/ddns.py
+++ b/salt/modules/ddns.py
@@ -76,7 +76,7 @@ def _get_keyring(keyfile):
 
 
 def add_host(zone, name, ttl, ip, nameserver='127.0.0.1', replace=True,
-             **kwargs):
+             timeout=5, **kwargs):
     '''
     Add, replace, or update the A and PTR (reverse) records for a host.
 
@@ -86,7 +86,8 @@ def add_host(zone, name, ttl, ip, nameserver='127.0.0.1', replace=True,
 
         salt ns1 ddns.add_host example.com host1 60 10.1.1.1
     '''
-    res = update(zone, name, ttl, 'A', ip, nameserver, replace, **kwargs)
+    res = update(zone, name, ttl, 'A', ip, nameserver, timeout, replace,
+                 **kwargs)
     if res is False:
         return False
 
@@ -100,14 +101,14 @@ def add_host(zone, name, ttl, ip, nameserver='127.0.0.1', replace=True,
         popped.append(p)
         zone = '{0}.{1}'.format('.'.join(parts), 'in-addr.arpa.')
         name = '.'.join(popped)
-        ptr = update(zone, name, ttl, 'PTR', fqdn, nameserver, replace,
-                     **kwargs)
+        ptr = update(zone, name, ttl, 'PTR', fqdn, nameserver, timeout,
+                     replace, **kwargs)
         if ptr:
             return True
     return res
 
 
-def delete_host(zone, name, nameserver='127.0.0.1', **kwargs):
+def delete_host(zone, name, nameserver='127.0.0.1', timeout=5, **kwargs):
     '''
     Delete the forward and reverse records for a host.
 
@@ -121,13 +122,13 @@ def delete_host(zone, name, nameserver='127.0.0.1', **kwargs):
     '''
     fqdn = '{0}.{1}'.format(name, zone)
     request = dns.message.make_query(fqdn, 'A')
-    answer = dns.query.udp(request, nameserver)
+    answer = dns.query.udp(request, nameserver, timeout)
     try:
         ips = [i.address for i in answer.answer[0].items]
     except IndexError:
         ips = []
 
-    res = delete(zone, name, nameserver=nameserver, **kwargs)
+    res = delete(zone, name, nameserver=nameserver, timeout, **kwargs)
 
     fqdn = fqdn + '.'
     for ip in ips:
@@ -141,14 +142,14 @@ def delete_host(zone, name, nameserver='127.0.0.1', **kwargs):
             zone = '{0}.{1}'.format('.'.join(parts), 'in-addr.arpa.')
             name = '.'.join(popped)
             ptr = delete(zone, name, 'PTR', fqdn, nameserver=nameserver,
-                         **kwargs)
+                         timeout, **kwargs)
         if ptr:
             res = True
     return res
 
 
 def update(zone, name, ttl, rdtype, data, nameserver='127.0.0.1',
-           replace=False, **kwargs):
+           timeout=5, replace=False, **kwargs):
     '''
     Add, replace, or update a DNS record.
     nameserver must be an IP address and the minion running this module
@@ -164,7 +165,7 @@ def update(zone, name, ttl, rdtype, data, nameserver='127.0.0.1',
     name = str(name)
     fqdn = '{0}.{1}'.format(name, zone)
     request = dns.message.make_query(fqdn, rdtype)
-    answer = dns.query.udp(request, nameserver)
+    answer = dns.query.udp(request, nameserver, timeout)
 
     rdtype = dns.rdatatype.from_text(rdtype)
     rdata = dns.rdata.from_text(dns.rdataclass.IN, rdtype, data)
@@ -188,14 +189,14 @@ def update(zone, name, ttl, rdtype, data, nameserver='127.0.0.1',
         dns_update.replace(name, ttl, rdata)
     elif not is_exist:
         dns_update.add(name, ttl, rdata)
-    answer = dns.query.udp(dns_update, nameserver)
+    answer = dns.query.udp(dns_update, nameserver, timeout)
     if answer.rcode() > 0:
         return False
     return True
 
 
 def delete(zone, name, rdtype=None, data=None, nameserver='127.0.0.1',
-           **kwargs):
+           timeout=5, **kwargs):
     '''
     Delete a DNS record.
 
@@ -209,7 +210,7 @@ def delete(zone, name, rdtype=None, data=None, nameserver='127.0.0.1',
     fqdn = '{0}.{1}'.format(name, zone)
     request = dns.message.make_query(fqdn, (rdtype or 'ANY'))
 
-    answer = dns.query.udp(request, nameserver)
+    answer = dns.query.udp(request, nameserver, timeout)
     if not answer.answer:
         return None
 
@@ -231,7 +232,7 @@ def delete(zone, name, rdtype=None, data=None, nameserver='127.0.0.1',
     else:
         dns_update.delete(name)
 
-    answer = dns.query.udp(dns_update, nameserver)
+    answer = dns.query.udp(dns_update, nameserver, timeout)
     if answer.rcode() > 0:
         return False
     return True

--- a/salt/modules/ddns.py
+++ b/salt/modules/ddns.py
@@ -142,7 +142,7 @@ def delete_host(zone, name, nameserver='127.0.0.1', timeout=5, **kwargs):
             zone = '{0}.{1}'.format('.'.join(parts), 'in-addr.arpa.')
             name = '.'.join(popped)
             ptr = delete(zone, name, 'PTR', fqdn, nameserver=nameserver,
-                         timeout, **kwargs)
+                         timeout=timeout, **kwargs)
         if ptr:
             res = True
     return res

--- a/salt/runners/ddns.py
+++ b/salt/runners/ddns.py
@@ -131,7 +131,7 @@ def update(zone, name, ttl, rdtype, data, keyname, keyfile, nameserver, timeout,
     dns_update = dns.update.Update(zone, keyring=keyring, keyname=keyname)
     dns_update.replace(name, ttl, rdata)
 
-    answer = dns.query.udp(dns_update, nameserver, timout)
+    answer = dns.query.udp(dns_update, nameserver, timeout)
     if answer.rcode() > 0:
         return {fqdn: 'Failed to update record of type \'{0}\''.format(rdtype)}
 

--- a/salt/runners/ddns.py
+++ b/salt/runners/ddns.py
@@ -53,7 +53,7 @@ def _get_keyring(keyfile):
     return keyring
 
 
-def create(zone, name, ttl, rdtype, data, keyname, keyfile, nameserver):
+def create(zone, name, ttl, rdtype, data, keyname, keyfile, nameserver, timeout):
     '''
     Create a DNS record. The nameserver must be an IP address and the master running
     this runner must have create privileges on that server.
@@ -62,13 +62,13 @@ def create(zone, name, ttl, rdtype, data, keyname, keyfile, nameserver):
 
     .. code-block:: bash
 
-        salt-run ddns.create domain.com my-test-vm 3600 A 10.20.30.40 my-tsig-key /etc/salt/tsig.keyring 10.0.0.1
+        salt-run ddns.create domain.com my-test-vm 3600 A 10.20.30.40 5 my-tsig-key /etc/salt/tsig.keyring 10.0.0.1
     '''
     if zone in name:
         name = name.replace(zone, '').rstrip('.')
     fqdn = '{0}.{1}'.format(name, zone)
     request = dns.message.make_query(fqdn, rdtype)
-    answer = dns.query.udp(request, nameserver)
+    answer = dns.query.udp(request, nameserver, timeout)
 
     rdata_value = dns.rdatatype.from_text(rdtype)
     rdata = dns.rdata.from_text(dns.rdataclass.IN, rdata_value, data)
@@ -82,14 +82,14 @@ def create(zone, name, ttl, rdtype, data, keyname, keyfile, nameserver):
     dns_update = dns.update.Update(zone, keyring=keyring, keyname=keyname)
     dns_update.add(name, ttl, rdata)
 
-    answer = dns.query.udp(dns_update, nameserver)
+    answer = dns.query.udp(dns_update, nameserver, timeout)
     if answer.rcode() > 0:
         return {fqdn: 'Failed to create record of type \'{0}\''.format(rdtype)}
 
     return {fqdn: 'Created record of type \'{0}\': {1} -> {2}'.format(rdtype, fqdn, data)}
 
 
-def update(zone, name, ttl, rdtype, data, keyname, keyfile, nameserver, replace=False):
+def update(zone, name, ttl, rdtype, data, keyname, keyfile, nameserver, timeout, replace=False):
     '''
     Replace, or update a DNS record. The nameserver must be an IP address and the master running
     this runner must have update privileges on that server.
@@ -103,13 +103,13 @@ def update(zone, name, ttl, rdtype, data, keyname, keyfile, nameserver, replace=
 
     .. code-block:: bash
 
-        salt-run ddns.update domain.com my-test-vm 3600 A 10.20.30.40 my-tsig-key /etc/salt/tsig.keyring 10.0.0.1
+        salt-run ddns.update domain.com my-test-vm 3600 A 10.20.30.40 5 my-tsig-key /etc/salt/tsig.keyring 10.0.0.1
     '''
     if zone in name:
         name = name.replace(zone, '').rstrip('.')
     fqdn = '{0}.{1}'.format(name, zone)
     request = dns.message.make_query(fqdn, rdtype)
-    answer = dns.query.udp(request, nameserver)
+    answer = dns.query.udp(request, nameserver, timeout)
     if not answer.answer:
         return {fqdn: 'No matching DNS record(s) found'}
 
@@ -131,14 +131,14 @@ def update(zone, name, ttl, rdtype, data, keyname, keyfile, nameserver, replace=
     dns_update = dns.update.Update(zone, keyring=keyring, keyname=keyname)
     dns_update.replace(name, ttl, rdata)
 
-    answer = dns.query.udp(dns_update, nameserver)
+    answer = dns.query.udp(dns_update, nameserver, timout)
     if answer.rcode() > 0:
         return {fqdn: 'Failed to update record of type \'{0}\''.format(rdtype)}
 
     return {fqdn: 'Updated record of type \'{0}\''.format(rdtype)}
 
 
-def delete(zone, name, keyname, keyfile, nameserver, rdtype=None, data=None):
+def delete(zone, name, keyname, keyfile, nameserver, timeout, rdtype=None, data=None):
     '''
     Delete a DNS record.
 
@@ -153,7 +153,7 @@ def delete(zone, name, keyname, keyfile, nameserver, rdtype=None, data=None):
     fqdn = '{0}.{1}'.format(name, zone)
     request = dns.message.make_query(fqdn, (rdtype or 'ANY'))
 
-    answer = dns.query.udp(request, nameserver)
+    answer = dns.query.udp(request, nameserver, timeout)
     if not answer.answer:
         return {fqdn: 'No matching DNS record(s) found'}
 
@@ -171,14 +171,14 @@ def delete(zone, name, keyname, keyfile, nameserver, rdtype=None, data=None):
     else:
         dns_update.delete(name)
 
-    answer = dns.query.udp(dns_update, nameserver)
+    answer = dns.query.udp(dns_update, nameserver, timeout)
     if answer.rcode() > 0:
         return {fqdn: 'Failed to delete DNS record(s)'}
 
     return {fqdn: 'Deleted DNS record(s)'}
 
 
-def add_host(zone, name, ttl, ip, keyname, keyfile, nameserver):
+def add_host(zone, name, ttl, ip, keyname, keyfile, nameserver, timeout):
     '''
     Create both A and PTR (reverse) records for a host.
 
@@ -186,14 +186,14 @@ def add_host(zone, name, ttl, ip, keyname, keyfile, nameserver):
 
     .. code-block:: bash
 
-        salt-run ddns.add_host domain.com my-test-vm 3600 10.20.30.40 my-tsig-key /etc/salt/tsig.keyring 10.0.0.1
+        salt-run ddns.add_host domain.com my-test-vm 3600 10.20.30.40 5 my-tsig-key /etc/salt/tsig.keyring 10.0.0.1
     '''
     res = []
     if zone in name:
         name = name.replace(zone, '').rstrip('.')
     fqdn = '{0}.{1}'.format(name, zone)
 
-    ret = create(zone, name, ttl, 'A', ip, keyname, keyfile, nameserver)
+    ret = create(zone, name, ttl, 'A', ip, keyname, keyfile, nameserver, timeout)
     res.append(ret[fqdn])
 
     parts = ip.split('.')[::-1]
@@ -209,7 +209,7 @@ def add_host(zone, name, ttl, ip, keyname, keyfile, nameserver):
         zone = '{0}.{1}'.format('.'.join(parts), 'in-addr.arpa.')
         name = '.'.join(popped)
         rev_fqdn = '{0}.{1}'.format(name, zone)
-        ret = create(zone, name, ttl, 'PTR', "{0}.".format(fqdn), keyname, keyfile, nameserver)
+        ret = create(zone, name, ttl, 'PTR', "{0}.".format(fqdn), keyname, keyfile, nameserver, timeout)
 
         if "Created" in ret[rev_fqdn]:
             res.append(ret[rev_fqdn])
@@ -220,7 +220,7 @@ def add_host(zone, name, ttl, ip, keyname, keyfile, nameserver):
     return {fqdn: res}
 
 
-def delete_host(zone, name, keyname, keyfile, nameserver):
+def delete_host(zone, name, keyname, keyfile, nameserver, timeout):
     '''
     Delete both forward (A) and reverse (PTR) records for a host only if the
     forward (A) record exists.
@@ -236,14 +236,14 @@ def delete_host(zone, name, keyname, keyfile, nameserver):
         name = name.replace(zone, '').rstrip('.')
     fqdn = '{0}.{1}'.format(name, zone)
     request = dns.message.make_query(fqdn, 'A')
-    answer = dns.query.udp(request, nameserver)
+    answer = dns.query.udp(request, nameserver, timeout)
 
     try:
         ips = [i.address for i in answer.answer[0].items]
     except IndexError:
         ips = []
 
-    ret = delete(zone, name, keyname, keyfile, nameserver)
+    ret = delete(zone, name, keyname, keyfile, nameserver, timeout)
     res.append("{0} of type \'A\'".format(ret[fqdn]))
 
     for ip in ips:
@@ -259,7 +259,7 @@ def delete_host(zone, name, keyname, keyfile, nameserver):
             zone = '{0}.{1}'.format('.'.join(parts), 'in-addr.arpa.')
             name = '.'.join(popped)
             rev_fqdn = '{0}.{1}'.format(name, zone)
-            ret = delete(zone, name, keyname, keyfile, nameserver, 'PTR', "{0}.".format(fqdn))
+            ret = delete(zone, name, keyname, keyfile, nameserver, timeout, 'PTR', "{0}.".format(fqdn))
 
             if "Deleted" in ret[rev_fqdn]:
                 res.append("{0} of type \'PTR\'".format(ret[rev_fqdn]))


### PR DESCRIPTION
### What does this PR do?

Fix a bug in the ddns execution module. 
### What issues does this PR fix or reference?

Current implementation has no timeout value set for dns.query.udp. By default the value is None (no timeout). This can potentially result in the ddns execution module to wait forever for the DNS response.
### Previous Behavior

If no DNS response returns, the execution module waits/hangs forever.
### New Behavior

Use default timeout of 5 seconds, throws exception if timeout has exceeded.
### Tests written?

No
