### PR TITLE
doc: add missing dot

### DIFF
--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -82,7 +82,7 @@ def _mine_get(load, opts):
 
 def update(clear=False):
     '''
-    Execute the configured functions and send the data back up to the master
+    Execute the configured functions and send the data back up to the master.
     The functions to be executed are merged from the master config, pillar and
     minion config under the option "function_cache":
 


### PR DESCRIPTION
### What issues does this PR fix or reference?

Just a small dot. Documentation reads a bit odd without it. This should/may/has to be ported on the 2016.3.1 and 2015.8.10 branch, too.
### Tests written?

No
