### PR TITLE
Fixed behavior for SUSE OS grains in 2016.3

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1268,6 +1268,11 @@ def os_data():
                     if 'CPE_NAME' in os_release:
                         if ":suse:" in os_release['CPE_NAME'] or ":opensuse:" in os_release['CPE_NAME']:
                             grains['os'] = "SUSE"
+                            # openSUSE `osfullname` grain normalization
+                            if grains['lsb_distrib_release'] == "42.1":
+                                grains['osfullname'] = "Leap"
+                            elif os_release.get("VERSION") == "Tumbleweed":
+                                grains['osfullname'] = os_release["VERSION"]
                 elif os.path.isfile('/etc/SuSE-release'):
                     grains['lsb_distrib_id'] = 'SUSE'
                     version = ''

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1265,6 +1265,11 @@ def os_data():
                         grains['lsb_distrib_release'] = os_release['VERSION_ID']
                     if 'PRETTY_NAME' in os_release:
                         grains['lsb_distrib_codename'] = os_release['PRETTY_NAME']
+                    if 'CPE_NAME' in os_release:
+                        if ":suse:" in os_release['CPE_NAME']:
+                            grains['os'] = "SUSE"
+                        elif ":opensuse:" in os_release['CPE_NAME']:
+                            grains['os'] = "SUSE"
                 elif os.path.isfile('/etc/SuSE-release'):
                     grains['lsb_distrib_id'] = 'SUSE'
                     version = ''
@@ -1372,7 +1377,8 @@ def os_data():
         shortname = distroname.replace(' ', '').lower()[:10]
         # this maps the long names from the /etc/DISTRO-release files to the
         # traditional short names that Salt has used.
-        grains['os'] = _OS_NAME_MAP.get(shortname, distroname)
+        if 'os' not in grains:
+            grains['os'] = _OS_NAME_MAP.get(shortname, distroname)
         grains.update(_linux_cpudata())
         grains.update(_linux_gpu_data())
     elif grains['kernel'] == 'SunOS':

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1037,6 +1037,7 @@ _OS_FAMILY_MAP = {
     'SUSE': 'Suse',
     'openSUSE Leap': 'Suse',
     'openSUSE Tumbleweed': 'Suse',
+    'SLES_SAP': 'Suse',
     'Solaris': 'Solaris',
     'SmartOS': 'Solaris',
     'OpenIndiana Development': 'Solaris',

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1266,9 +1266,7 @@ def os_data():
                     if 'PRETTY_NAME' in os_release:
                         grains['lsb_distrib_codename'] = os_release['PRETTY_NAME']
                     if 'CPE_NAME' in os_release:
-                        if ":suse:" in os_release['CPE_NAME']:
-                            grains['os'] = "SUSE"
-                        elif ":opensuse:" in os_release['CPE_NAME']:
+                        if ":suse:" in os_release['CPE_NAME'] or ":opensuse:" in os_release['CPE_NAME']:
                             grains['os'] = "SUSE"
                 elif os.path.isfile('/etc/SuSE-release'):
                     grains['lsb_distrib_id'] = 'SUSE'

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1269,7 +1269,7 @@ def os_data():
                         if ":suse:" in os_release['CPE_NAME'] or ":opensuse:" in os_release['CPE_NAME']:
                             grains['os'] = "SUSE"
                             # openSUSE `osfullname` grain normalization
-                            if grains['lsb_distrib_release'] == "42.1":
+                            if os_release.get("NAME") == "openSUSE Leap":
                                 grains['osfullname'] = "Leap"
                             elif os_release.get("VERSION") == "Tumbleweed":
                                 grains['osfullname'] = os_release["VERSION"]

--- a/tests/unit/grains/core_test.py
+++ b/tests/unit/grains/core_test.py
@@ -119,7 +119,6 @@ class CoreGrainsTestCase(TestCase):
 
         self.assertEqual(os_grains.get('os_family'), 'Debian')
 
-
     @skipIf(not salt.utils.is_linux(), 'System is not Linux')
     def test_suse_os_from_cpe_data(self):
         '''

--- a/tests/unit/grains/core_test.py
+++ b/tests/unit/grains/core_test.py
@@ -165,7 +165,9 @@ class CoreGrainsTestCase(TestCase):
                             with patch.object(platform, 'linux_distribution', distro_mock):
                                 with patch.object(core, '_linux_gpu_data', empty_mock):
                                     with patch.object(core, '_virtual', empty_mock):
-                                        os_grains = core.os_data()
+                                        # Mock the osarch
+                                        with patch.dict(core.__salt__, {'cmd.run': "amd64"}):
+                                            os_grains = core.os_data()
 
         self.assertEqual(os_grains.get('os_family'), 'SUSE')
         self.assertEqual(os_grains.get('os'), 'SUSE')

--- a/tests/unit/grains/core_test.py
+++ b/tests/unit/grains/core_test.py
@@ -14,6 +14,7 @@ from salttesting.helpers import ensure_in_syspath
 from salttesting.mock import (
     MagicMock,
     patch,
+    mock_open,
     NO_MOCK,
     NO_MOCK_REASON
 )
@@ -217,7 +218,8 @@ class CoreGrainsTestCase(TestCase):
                                 distro_mock = MagicMock(
                                     return_value=('SUSE Linux Enterprise Server ', '12', 'x86_64')
                                 )
-                                with patch.object(salt.utils, "fopen", MagicMock(return_value=os_release_map.get('suse_release_files'))):
+                                with patch("salt.utils.fopen", mock_open()) as suse_release_file:
+                                    suse_release_file.return_value.__iter__.return_value = os_release_map.get('suse_release_file', '').splitlines()
                                     with patch.object(platform, 'linux_distribution', distro_mock):
                                         with patch.object(core, '_linux_gpu_data', empty_mock):
                                             with patch.object(core, '_linux_cpudata', empty_mock):
@@ -242,15 +244,14 @@ class CoreGrainsTestCase(TestCase):
             '/proc/1/cmdline': False
         }
         _os_release_map = {
-            'suse_release_file': [
-                'SUSE Linux Enterprise Server 11 (x86_64)'
-                'VERSION = 11',
-                'PATCHLEVEL = 3',
-            ],
-            'oscodename': 'SUSE Linux Enterprise Server 12',
+            'suse_release_file': '''SUSE Linux Enterprise Server 11 (x86_64)
+VERSION = 11
+PATCHLEVEL = 3
+''',
+            'oscodename': 'SUSE Linux Enterprise Server 11 SP3',
             'osfullname': "SLES",
-            'osrelease': '12',
-            'osrelease_info': [12],
+            'osrelease': '11.3',
+            'osrelease_info': [11, 3],
             'files': ["/etc/SuSE-release", _path_exists_map],
         }
         self._run_os_grains_tests(_os_release_map)

--- a/tests/unit/grains/core_test.py
+++ b/tests/unit/grains/core_test.py
@@ -216,7 +216,7 @@ class CoreGrainsTestCase(TestCase):
                                 # Mock platform.linux_distribution to give us the
                                 # OS name that we want.
                                 distro_mock = MagicMock(
-                                    return_value=('SUSE Linux Enterprise Server ', '12', 'x86_64')
+                                    return_value=('SUSE test', 'version', 'arch')
                                 )
                                 with patch("salt.utils.fopen", mock_open()) as suse_release_file:
                                     suse_release_file.return_value.__iter__.return_value = os_release_map.get('suse_release_file', '').splitlines()
@@ -378,7 +378,7 @@ PATCHLEVEL = 3
                 'ANSI_COLOR': '0;32',
                 'CPE_NAME': 'cpe:/o:opensuse:opensuse:20160504'
             },
-            'oscodename': 'openSUSE Tumbleweed (20160504)',
+            'oscodename': 'openSUSE Tumbleweed (20160504) (x86_64)',
             'osfullname': "Tumbleweed",
             'osrelease': '20160504',
             'osrelease_info': [20160504],

--- a/tests/unit/grains/core_test.py
+++ b/tests/unit/grains/core_test.py
@@ -182,8 +182,208 @@ class CoreGrainsTestCase(TestCase):
                                                 with patch.dict(core.__salt__, {'cmd.run': osarch_mock}):
                                                     os_grains = core.os_data()
 
-        self.assertEqual(os_grains.get('os_family'), 'SUSE')
+        self.assertEqual(os_grains.get('os_family'), 'Suse')
         self.assertEqual(os_grains.get('os'), 'SUSE')
+
+    def _run_os_grains_tests(self, os_release_map):
+        path_isfile_mock = MagicMock(side_effect=lambda x: x in os_release_map['files'])
+        empty_mock = MagicMock(return_value={})
+        osarch_mock = MagicMock(return_value="amd64")
+        os_release_mock = MagicMock(return_value=os_release_map.get('os_release_file'))
+
+        orig_import = __import__
+
+        def _import_mock(name, *args):
+            if name == 'lsb_release':
+                raise ImportError('No module named lsb_release')
+            return orig_import(name, *args)
+
+        # Skip the first if statement
+        with patch.object(salt.utils, 'is_proxy',
+                          MagicMock(return_value=False)):
+            # Skip the selinux/systemd stuff (not pertinent)
+            with patch.object(core, '_linux_bin_exists',
+                              MagicMock(return_value=False)):
+                # Skip the init grain compilation (not pertinent)
+                with patch.object(os.path, 'exists', path_isfile_mock):
+                    # Ensure that lsb_release fails to import
+                    with patch('__builtin__.__import__',
+                               side_effect=_import_mock):
+                        # Skip all the /etc/*-release stuff (not pertinent)
+                        with patch.object(os.path, 'isfile', path_isfile_mock):
+                            with patch.object(core, '_parse_os_release', os_release_mock):
+                                # Mock platform.linux_distribution to give us the
+                                # OS name that we want.
+                                distro_mock = MagicMock(
+                                    return_value=('SUSE Linux Enterprise Server ', '12', 'x86_64')
+                                )
+                                with patch.object(salt.utils, "fopen", MagicMock(return_value=os_release_map.get('suse_release_files'))):
+                                    with patch.object(platform, 'linux_distribution', distro_mock):
+                                        with patch.object(core, '_linux_gpu_data', empty_mock):
+                                            with patch.object(core, '_linux_cpudata', empty_mock):
+                                                with patch.object(core, '_virtual', empty_mock):
+                                                    # Mock the osarch
+                                                    with patch.dict(core.__salt__, {'cmd.run': osarch_mock}):
+                                                        os_grains = core.os_data()
+
+        self.assertEqual(os_grains.get('os'), 'SUSE')
+        self.assertEqual(os_grains.get('os_family'), 'Suse')
+        self.assertEqual(os_grains.get('osfullname'), os_release_map['osfullname'])
+        self.assertEqual(os_grains.get('oscodename'), os_release_map['oscodename'])
+        self.assertEqual(os_grains.get('osrelease'), os_release_map['osrelease'])
+        self.assertListEqual(list(os_grains.get('osrelease_info')), os_release_map['osrelease_info'])
+
+    @skipIf(not salt.utils.is_linux(), 'System is not Linux')
+    def test_suse_os_grains_sles11sp3(self):
+        '''
+        Test if OS grains are parsed correctly in SLES 11 SP3
+        '''
+        _path_exists_map = {
+            '/proc/1/cmdline': False
+        }
+        _os_release_map = {
+            'suse_release_file': [
+                'SUSE Linux Enterprise Server 11 (x86_64)'
+                'VERSION = 11',
+                'PATCHLEVEL = 3',
+            ],
+            'oscodename': 'SUSE Linux Enterprise Server 12',
+            'osfullname': "SLES",
+            'osrelease': '12',
+            'osrelease_info': [12],
+            'files': ["/etc/SuSE-release", _path_exists_map],
+        }
+        self._run_os_grains_tests(_os_release_map)
+
+    @skipIf(not salt.utils.is_linux(), 'System is not Linux')
+    def test_suse_os_grains_sles11sp4(self):
+        '''
+        Test if OS grains are parsed correctly in SLES 11 SP4
+        '''
+        _path_exists_map = {
+            '/proc/1/cmdline': False
+        }
+        _os_release_map = {
+            'os_release_file': {
+                'NAME': 'SLES',
+                'VERSION': '11.4',
+                'VERSION_ID': '11.4',
+                'PRETTY_NAME': 'SUSE Linux Enterprise Server 11 SP4',
+                'ID': 'sles',
+                'ANSI_COLOR': '0;32',
+                'CPE_NAME': 'cpe:/o:suse:sles:11:4'
+            },
+            'oscodename': 'SUSE Linux Enterprise Server 11 SP4',
+            'osfullname': "SLES",
+            'osrelease': '11.4',
+            'osrelease_info': [11, 4],
+            'files': ["/etc/os-release", _path_exists_map],
+        }
+        self._run_os_grains_tests(_os_release_map)
+
+    @skipIf(not salt.utils.is_linux(), 'System is not Linux')
+    def test_suse_os_grains_sles12(self):
+        '''
+        Test if OS grains are parsed correctly in SLES 12
+        '''
+        _path_exists_map = {
+            '/proc/1/cmdline': False
+        }
+        _os_release_map = {
+            'os_release_file': {
+                'NAME': 'SLES',
+                'VERSION': '12',
+                'VERSION_ID': '12',
+                'PRETTY_NAME': 'SUSE Linux Enterprise Server 12',
+                'ID': 'sles',
+                'ANSI_COLOR': '0;32',
+                'CPE_NAME': 'cpe:/o:suse:sles:12'
+            },
+            'oscodename': 'SUSE Linux Enterprise Server 12',
+            'osfullname': "SLES",
+            'osrelease': '12',
+            'osrelease_info': [12],
+            'files': ["/etc/os-release", _path_exists_map],
+        }
+        self._run_os_grains_tests(_os_release_map)
+
+    @skipIf(not salt.utils.is_linux(), 'System is not Linux')
+    def test_suse_os_grains_sles12sp1(self):
+        '''
+        Test if OS grains are parsed correctly in SLES 12 SP1
+        '''
+        _path_exists_map = {
+            '/proc/1/cmdline': False
+        }
+        _os_release_map = {
+            'os_release_file': {
+                'NAME': 'SLES',
+                'VERSION': '12-SP1',
+                'VERSION_ID': '12.1',
+                'PRETTY_NAME': 'SUSE Linux Enterprise Server 12 SP1',
+                'ID': 'sles',
+                'ANSI_COLOR': '0;32',
+                'CPE_NAME': 'cpe:/o:suse:sles:12:sp1'
+            },
+            'oscodename': 'SUSE Linux Enterprise Server 12 SP1',
+            'osfullname': "SLES",
+            'osrelease': '12.1',
+            'osrelease_info': [12, 1],
+            'files': ["/etc/os-release", _path_exists_map],
+        }
+        self._run_os_grains_tests(_os_release_map)
+
+    @skipIf(not salt.utils.is_linux(), 'System is not Linux')
+    def test_suse_os_grains_opensuse_leap_42_1(self):
+        '''
+        Test if OS grains are parsed correctly in openSUSE Leap 42.1
+        '''
+        _path_exists_map = {
+            '/proc/1/cmdline': False
+        }
+        _os_release_map = {
+            'os_release_file': {
+                'NAME': 'openSUSE Leap',
+                'VERSION': '42.1',
+                'VERSION_ID': '42.1',
+                'PRETTY_NAME': 'openSUSE Leap 42.1 (x86_64)',
+                'ID': 'opensuse',
+                'ANSI_COLOR': '0;32',
+                'CPE_NAME': 'cpe:/o:opensuse:opensuse:42.1'
+            },
+            'oscodename': 'openSUSE Leap 42.1 (x86_64)',
+            'osfullname': "Leap",
+            'osrelease': '42.1',
+            'osrelease_info': [42, 1],
+            'files': ["/etc/os-release", _path_exists_map],
+        }
+        self._run_os_grains_tests(_os_release_map)
+
+    @skipIf(not salt.utils.is_linux(), 'System is not Linux')
+    def test_suse_os_grains_tumbleweed(self):
+        '''
+        Test if OS grains are parsed correctly in openSUSE Tumbleweed
+        '''
+        _path_exists_map = {
+            '/proc/1/cmdline': False
+        }
+        _os_release_map = {
+            'os_release_file': {
+                'NAME': 'openSUSE',
+                'VERSION': 'Tumbleweed',
+                'VERSION_ID': '20160504',
+                'PRETTY_NAME': 'openSUSE Tumbleweed (20160504) (x86_64)',
+                'ID': 'opensuse',
+                'ANSI_COLOR': '0;32',
+                'CPE_NAME': 'cpe:/o:opensuse:opensuse:20160504'
+            },
+            'oscodename': 'openSUSE Tumbleweed (20160504)',
+            'osfullname': "Tumbleweed",
+            'osrelease': '20160504',
+            'osrelease_info': [20160504],
+            'files': ["/etc/os-release", _path_exists_map],
+        }
+        self._run_os_grains_tests(_os_release_map)
 
 
 if __name__ == '__main__':

--- a/tests/unit/grains/core_test.py
+++ b/tests/unit/grains/core_test.py
@@ -136,6 +136,7 @@ class CoreGrainsTestCase(TestCase):
             side_effect=lambda x: _path_isfile_map.get(x, False)
         )
         empty_mock = MagicMock(return_value={})
+        osarch_mock = MagicMock(return_value="amd64")
 
         orig_import = __import__
 
@@ -166,7 +167,7 @@ class CoreGrainsTestCase(TestCase):
                                 with patch.object(core, '_linux_gpu_data', empty_mock):
                                     with patch.object(core, '_virtual', empty_mock):
                                         # Mock the osarch
-                                        with patch.dict(core.__salt__, {'cmd.run': "amd64"}):
+                                        with patch.dict(core.__salt__, {'cmd.run': osarch_mock}):
                                             os_grains = core.os_data()
 
         self.assertEqual(os_grains.get('os_family'), 'SUSE')

--- a/tests/unit/grains/core_test.py
+++ b/tests/unit/grains/core_test.py
@@ -186,7 +186,7 @@ class CoreGrainsTestCase(TestCase):
         self.assertEqual(os_grains.get('os_family'), 'Suse')
         self.assertEqual(os_grains.get('os'), 'SUSE')
 
-    def _run_os_grains_tests(self, os_release_map):
+    def _run_suse_os_grains_tests(self, os_release_map):
         path_isfile_mock = MagicMock(side_effect=lambda x: x in os_release_map['files'])
         empty_mock = MagicMock(return_value={})
         osarch_mock = MagicMock(return_value="amd64")
@@ -240,9 +240,6 @@ class CoreGrainsTestCase(TestCase):
         '''
         Test if OS grains are parsed correctly in SLES 11 SP3
         '''
-        _path_exists_map = {
-            '/proc/1/cmdline': False
-        }
         _os_release_map = {
             'suse_release_file': '''SUSE Linux Enterprise Server 11 (x86_64)
 VERSION = 11
@@ -252,18 +249,15 @@ PATCHLEVEL = 3
             'osfullname': "SLES",
             'osrelease': '11.3',
             'osrelease_info': [11, 3],
-            'files': ["/etc/SuSE-release", _path_exists_map],
+            'files': ["/etc/SuSE-release"],
         }
-        self._run_os_grains_tests(_os_release_map)
+        self._run_suse_os_grains_tests(_os_release_map)
 
     @skipIf(not salt.utils.is_linux(), 'System is not Linux')
     def test_suse_os_grains_sles11sp4(self):
         '''
         Test if OS grains are parsed correctly in SLES 11 SP4
         '''
-        _path_exists_map = {
-            '/proc/1/cmdline': False
-        }
         _os_release_map = {
             'os_release_file': {
                 'NAME': 'SLES',
@@ -278,18 +272,15 @@ PATCHLEVEL = 3
             'osfullname': "SLES",
             'osrelease': '11.4',
             'osrelease_info': [11, 4],
-            'files': ["/etc/os-release", _path_exists_map],
+            'files': ["/etc/os-release"],
         }
-        self._run_os_grains_tests(_os_release_map)
+        self._run_suse_os_grains_tests(_os_release_map)
 
     @skipIf(not salt.utils.is_linux(), 'System is not Linux')
     def test_suse_os_grains_sles12(self):
         '''
         Test if OS grains are parsed correctly in SLES 12
         '''
-        _path_exists_map = {
-            '/proc/1/cmdline': False
-        }
         _os_release_map = {
             'os_release_file': {
                 'NAME': 'SLES',
@@ -304,18 +295,15 @@ PATCHLEVEL = 3
             'osfullname': "SLES",
             'osrelease': '12',
             'osrelease_info': [12],
-            'files': ["/etc/os-release", _path_exists_map],
+            'files': ["/etc/os-release"],
         }
-        self._run_os_grains_tests(_os_release_map)
+        self._run_suse_os_grains_tests(_os_release_map)
 
     @skipIf(not salt.utils.is_linux(), 'System is not Linux')
     def test_suse_os_grains_sles12sp1(self):
         '''
         Test if OS grains are parsed correctly in SLES 12 SP1
         '''
-        _path_exists_map = {
-            '/proc/1/cmdline': False
-        }
         _os_release_map = {
             'os_release_file': {
                 'NAME': 'SLES',
@@ -330,18 +318,15 @@ PATCHLEVEL = 3
             'osfullname': "SLES",
             'osrelease': '12.1',
             'osrelease_info': [12, 1],
-            'files': ["/etc/os-release", _path_exists_map],
+            'files': ["/etc/os-release"],
         }
-        self._run_os_grains_tests(_os_release_map)
+        self._run_suse_os_grains_tests(_os_release_map)
 
     @skipIf(not salt.utils.is_linux(), 'System is not Linux')
     def test_suse_os_grains_opensuse_leap_42_1(self):
         '''
         Test if OS grains are parsed correctly in openSUSE Leap 42.1
         '''
-        _path_exists_map = {
-            '/proc/1/cmdline': False
-        }
         _os_release_map = {
             'os_release_file': {
                 'NAME': 'openSUSE Leap',
@@ -356,18 +341,15 @@ PATCHLEVEL = 3
             'osfullname': "Leap",
             'osrelease': '42.1',
             'osrelease_info': [42, 1],
-            'files': ["/etc/os-release", _path_exists_map],
+            'files': ["/etc/os-release"],
         }
-        self._run_os_grains_tests(_os_release_map)
+        self._run_suse_os_grains_tests(_os_release_map)
 
     @skipIf(not salt.utils.is_linux(), 'System is not Linux')
     def test_suse_os_grains_tumbleweed(self):
         '''
         Test if OS grains are parsed correctly in openSUSE Tumbleweed
         '''
-        _path_exists_map = {
-            '/proc/1/cmdline': False
-        }
         _os_release_map = {
             'os_release_file': {
                 'NAME': 'openSUSE',
@@ -382,9 +364,9 @@ PATCHLEVEL = 3
             'osfullname': "Tumbleweed",
             'osrelease': '20160504',
             'osrelease_info': [20160504],
-            'files': ["/etc/os-release", _path_exists_map],
+            'files': ["/etc/os-release"],
         }
-        self._run_os_grains_tests(_os_release_map)
+        self._run_suse_os_grains_tests(_os_release_map)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?

This PR brings changes discussed in #33903 to `2016.3` branch.

Also includes other fixes in order to fix the behavior of OS-related grains for the different SUSE versions:
- openSUSE Leap: `grains['osfullname'] = "Leap"`
- openSUSE Tumbleweed: `grains['osfullname'] = "Tumbleweed"`

Unit tests are included in order to check OS grains for the different SUSE versions.

These new changes expect to be also promoted to `develop` branch if it's possible.
### Tests written?

Yes

/cc @isbm 
