### PR TITLE
Update package dep note to systemd-python for RHEL7 install

### DIFF
--- a/doc/topics/installation/rhel.rst
+++ b/doc/topics/installation/rhel.rst
@@ -42,7 +42,7 @@ the SaltStack Repository.
               https://repo.saltstack.com/yum/redhat/$releasever/$basearch/latest/base/RPM-GPG-KEY-CentOS-7
 
 .. note::
-    ``systemd`` and ``python-systemd`` are required by Salt, but are not
+    ``systemd`` and ``systemd-python`` are required by Salt, but are not
     installed by the Red Hat 7 ``@base`` installation or by the Salt
     installation. These dependencies might need to be installed before Salt.
 


### PR DESCRIPTION
The package name in [this install note](https://docs.saltstack.com/en/2015.8/topics/installation/rhel.html) should be systemd-python.

Fixes #34120

Refs #31402
