### PR TITLE
Fixed boto_vpc_test failure

### DIFF
--- a/tests/unit/modules/boto_vpc_test.py
+++ b/tests/unit/modules/boto_vpc_test.py
@@ -436,14 +436,20 @@ class BotoVpcTestCase(BotoVpcTestCaseBase):
         '''
         Tests describing parameters via vpc id if vpc exist
         '''
+        # With moto 0.4.25 is_default is set to True. 0.4.24 and older, is_default is False
+        if LooseVersion(moto.__version__) >= LooseVersion('0.4.25'):
+            is_default = True
+        else:
+            is_default = False
+
         vpc = self._create_vpc(name='test', tags={'test': 'testvalue'})
 
         describe_vpc = boto_vpc.describe(vpc_id=vpc.id, **conn_parameters)
 
         vpc_properties = dict(cidr_block=unicode(cidr_block),
-                              is_default=False,
+                              is_default=is_default,
                               state=u'available',
-                              tags={'Name': 'test', 'test': 'testvalue'},
+                              tags={u'Name': u'test', u'test': u'testvalue'},
                               dhcp_options_id=u'dopt-7a8b9c2d',
                               instance_tenancy=u'default')
 

--- a/tests/unit/modules/boto_vpc_test.py
+++ b/tests/unit/modules/boto_vpc_test.py
@@ -73,6 +73,21 @@ def _has_required_boto():
         return True
 
 
+def _get_moto_version():
+    '''
+    Returns the moto version
+    '''
+    try:
+        return LooseVersion(moto.__version__)
+    except AttributeError:
+        import pkg_resources
+        from pkg_resources import DistributionNotFound
+        try:
+            return LooseVersion(pkg_resources.get_distribution('moto').version)
+        except DistributionNotFound:
+            return False
+
+
 def _has_required_moto():
     '''
     Returns True/False boolean depending on if Moto is installed and correct
@@ -81,17 +96,8 @@ def _has_required_moto():
     if not HAS_MOTO:
         return False
     else:
-        try:
-            if LooseVersion(moto.__version__) < LooseVersion(required_moto_version):
-                return False
-        except AttributeError:
-            import pkg_resources
-            from pkg_resources import DistributionNotFound
-            try:
-                if LooseVersion(pkg_resources.get_distribution('moto').version) < LooseVersion(required_moto_version):
-                    return False
-            except DistributionNotFound:
-                return False
+        if _get_moto_version() < LooseVersion(required_moto_version):
+            return False
         return True
 
 
@@ -437,7 +443,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase):
         Tests describing parameters via vpc id if vpc exist
         '''
         # With moto 0.4.25 is_default is set to True. 0.4.24 and older, is_default is False
-        if LooseVersion(moto.__version__) >= LooseVersion('0.4.25'):
+        if _get_moto_version() >= LooseVersion('0.4.25'):
             is_default = True
         else:
             is_default = False

--- a/tests/unit/modules/boto_vpc_test.py
+++ b/tests/unit/modules/boto_vpc_test.py
@@ -2,6 +2,8 @@
 
 # Import Python Libs
 from distutils.version import LooseVersion  # pylint: disable=no-name-in-module
+import pkg_resources
+from pkg_resources import DistributionNotFound
 
 # Import Salt Testing Libs
 from salttesting import skipIf, TestCase
@@ -80,8 +82,6 @@ def _get_moto_version():
     try:
         return LooseVersion(moto.__version__)
     except AttributeError:
-        import pkg_resources
-        from pkg_resources import DistributionNotFound
         try:
             return LooseVersion(pkg_resources.get_distribution('moto').version)
         except DistributionNotFound:


### PR DESCRIPTION
### What does this PR do?

With new moto version 0.4.25, is_default is set to True, while on older versions it is False. This lets this test be backwards compatible with older versions of moto. 

It also changes the tags to be unicode strings. 
### What issues does this PR fix or reference?

Failing test on jenkins, across all branches. 
### Tests written?

Yes
