### PR TITLE
Add link to contributing guide to GitHub PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,3 +11,5 @@ Remove this section if not relevant
 ### Tests written?
 
 Yes/No
+
+Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.


### PR DESCRIPTION
Adds a mention and link to the Contributing docs to the PR template.

Refs #34096
