### PR TITLE
Automated test for saltutil.kill_job

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1091,7 +1091,7 @@ class ModuleCase(TestCase, SaltClientTestCaseMixIn):
         return self.run_function(_function, args, **kw)
 
     def run_function(self, function, arg=(), minion_tgt='minion', timeout=25,
-                     **kwargs):
+                     async=False, **kwargs):
         '''
         Run a single salt function and condition the return down to match the
         behavior of the raw function call
@@ -1099,9 +1099,15 @@ class ModuleCase(TestCase, SaltClientTestCaseMixIn):
         know_to_return_none = (
             'file.chown', 'file.chgrp', 'ssh.recv_known_host'
         )
-        orig = self.client.cmd(
-            minion_tgt, function, arg, timeout=timeout, kwarg=kwargs
-        )
+        if async:
+            orig = self.client.cmd_async(
+                minion_tgt, function, arg, timeout=timeout, kwarg=kwargs
+            )
+            return orig
+        else:
+            orig = self.client.cmd(
+                minion_tgt, function, arg, timeout=timeout, kwarg=kwargs
+            )
 
         if minion_tgt not in orig:
             self.skipTest(

--- a/tests/integration/files/conf/sub_minion
+++ b/tests/integration/files/conf/sub_minion
@@ -4,7 +4,7 @@ master_port: 64506
 root_dir: /tmp/subsalttest
 pki_dir: pki
 id: sub_minion
-cachedir: cachedir
+cachedir: sub_cachedir
 sock_dir: sub_minion_sock
 #acceptance_wait_time: 1
 open_mode: True

--- a/tests/integration/modules/saltutil.py
+++ b/tests/integration/modules/saltutil.py
@@ -5,6 +5,7 @@ Integration tests for the saltutil module.
 
 # Import Python libs
 from __future__ import absolute_import
+import time
 
 # Import Salt Testing libs
 from salttesting.helpers import ensure_in_syspath
@@ -59,12 +60,15 @@ class SaltUtilModuleTest(integration.ModuleCase):
         '''
         # Run job as async
         job_jid = self.run_function('test.sleep', arg=['30'], async=True)
+        # Allow for a little time so we don't race the pub
+        time.sleep(1) 
         # Execute runner to get job status
         job_status = self.run_function('saltutil.find_job', arg=[job_jid])
         # TODO migrate to assertDictContainsSubset once 2.6 is gone
         self.assertIn('jid', job_status)
         # Kill the job
         job_kill_ret = self.run_function('saltutil.kill_job', arg=[job_jid])
+        time.sleep(1)
         # Check again to see if the job is running. It should be gone
         job_kill_status = self.run_function('saltutil.find_job', arg=[job_jid])
         self.assertEqual({}, job_kill_status)

--- a/tests/integration/modules/saltutil.py
+++ b/tests/integration/modules/saltutil.py
@@ -61,7 +61,7 @@ class SaltUtilModuleTest(integration.ModuleCase):
         # Run job as async
         job_jid = self.run_function('test.sleep', arg=['30'], async=True)
         # Allow for a little time so we don't race the pub
-        time.sleep(1) 
+        time.sleep(1)
         # Execute runner to get job status
         job_status = self.run_function('saltutil.find_job', arg=[job_jid])
         # TODO migrate to assertDictContainsSubset once 2.6 is gone

--- a/tests/integration/modules/saltutil.py
+++ b/tests/integration/modules/saltutil.py
@@ -53,6 +53,21 @@ class SaltUtilModuleTest(integration.ModuleCase):
         self.assertIn('pub', ret)
         self.assertIn('priv', ret)
 
+    def test_kill_job(self):
+        '''
+        Test to ensure that a long-running job can be killed.
+        '''
+        # Run job as async
+        job_jid = self.run_function('test.sleep', arg=['30'], async=True)
+        # Execute runner to get job status
+        job_status = self.run_function('saltutil.find_job', arg=[job_jid])
+        # TODO migrate to assertDictContainsSubset once 2.6 is gone
+        self.assertIn('jid', job_status)
+        # Kill the job
+        job_kill_ret = self.run_function('saltutil.kill_job', arg=[job_jid])
+        # Check again to see if the job is running. It should be gone
+        job_kill_status = self.run_function('saltutil.find_job', arg=[job_jid])
+        self.assertEqual({}, job_kill_status)
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
This adds an automated test for `saltutil.kill job`
that starts a job in async mode, then tests to see if
it is running and then kills it and ensures it is not running.

Also adds the ability for salt modules to be called asynchronously
from the test suite.

Closes #34143
