### PR TITLE
Revert refresh logic in pkg to to do it once per run

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1111,9 +1111,9 @@ def installed(
 
     kwargs['saltenv'] = __env__
     rtag = __gen_rtag()
-    refresh = bool(salt.utils.is_true(refresh) or
-                   (os.path.isfile(rtag) and salt.utils.is_true(refresh))
-                   )
+    refresh = bool(
+        salt.utils.is_true(refresh) or (os.path.isfile(rtag) and refresh is not False)
+    )
     if not isinstance(pkg_verify, list):
         pkg_verify = pkg_verify is True
     if (pkg_verify or isinstance(pkg_verify, list)) \
@@ -1634,9 +1634,9 @@ def latest(
 
     '''
     rtag = __gen_rtag()
-    refresh = bool(salt.utils.is_true(refresh) or
-                   (os.path.isfile(rtag) and salt.utils.is_true(refresh))
-                   )
+    refresh = bool(
+        salt.utils.is_true(refresh) or (os.path.isfile(rtag) and refresh is not False)
+    )
 
     if kwargs.get('sources'):
         return {'name': name,


### PR DESCRIPTION
The change happened in aa29744c285451e9ea066fd076ab4a39cb2490e1. Previously package db refresh happened once per run, but after the change it does not happen anymore if you don't specify refresh=True explicitly.

Closes #32862.

Here's how to verify:
- 2015.8.10 (one `apt-get update`):

```
$ docker build -t salt -q --build-arg SALT_VERSION=2015.8 2>/dev/null https://gist.githubusercontent.com/bobrik/e018ce44a67b3d3274f6b6af131c6412/raw/bbd199d3b271e1fbf33e8ab91cf080cf903be9d8/Dockerfile && docker run --rm -it salt salt-call -l info --local state.sls test | fgrep apt-get
sha256:cffe99452c37af98e450c95d4c3431a24fc1d38e6261ef10f1cef4eb6b7021be
[INFO    ] Executing command 'apt-get -q update' in directory '/root'
[INFO    ] Executing command ['apt-get', '-q', '-y', '-o', 'DPkg::Options::=--force-confold', '-o', 'DPkg::Options::=--force-confdef', 'install', 'htop'] in directory '/root'
[INFO    ] Executing command ['apt-get', '-q', '-y', '-o', 'DPkg::Options::=--force-confold', '-o', 'DPkg::Options::=--force-confdef', 'install', 'strace'] in directory '/root'
```
- 2016.3.1 (no `apt-get update`):

```
$ docker build -t salt -q --build-arg SALT_VERSION=2016.3 2>/dev/null https://gist.githubusercontent.com/bobrik/e018ce44a67b3d3274f6b6af131c6412/raw/bbd199d3b271e1fbf33e8ab91cf080cf903be9d8/Dockerfile && docker run --rm -it salt salt-call -l info --local state.sls test | fgrep apt-get
sha256:9e578157578c83ba91529013885656a55122a4da444163c1b5dba166a51f61d3
[INFO    ] Executing command ['apt-get', '-q', '-y', '-o', 'DPkg::Options::=--force-confold', '-o', 'DPkg::Options::=--force-confdef', 'install', 'htop'] in directory '/root'
[INFO    ] Executing command ['apt-get', '-q', '-y', '-o', 'DPkg::Options::=--force-confold', '-o', 'DPkg::Options::=--force-confdef', 'install', 'strace'] in directory '/root'
```

I also found out that docs for v2015.8.10 are much better:

<img width="694" alt="screen shot 2016-06-20 at 20 25 20" src="https://cloud.githubusercontent.com/assets/89186/16207477/2ba6fea4-3725-11e6-89c1-bfb42d9d3ce6.png">
- https://docs.saltstack.com/en/2015.8/ref/states/all/salt.states.pkg.html#salt.states.pkg.latest

The problem is: I can't find these docs in 2016.3.1 or in develop. I can't even see them in v2015.8.10 in git. How did that happen?

cc @secumod, @twangboy, @hrumph, @DenisBY, @jfindlay.
