### PR TITLE
only call compute_scope if it exists

### DIFF
--- a/salt/log/handlers/sentry_mod.py
+++ b/salt/log/handlers/sentry_mod.py
@@ -124,8 +124,10 @@ def setup_handlers():
             if not transport_registry.supported_scheme(url.scheme):
                 raise ValueError('Unsupported Sentry DSN scheme: {0}'.format(url.scheme))
             dsn_config = {}
-            conf_extras = transport_registry.compute_scope(url, dsn_config)
-            dsn_config.update(conf_extras)
+            if (hasattr(transport_registry, 'compute_scope') and
+                    callable(transport_registry.compute_scope)):
+                conf_extras = transport_registry.compute_scope(url, dsn_config)
+                dsn_config.update(conf_extras)
             options.update({
                 'project': dsn_config['SENTRY_PROJECT'],
                 'servers': dsn_config['SENTRY_SERVERS'],


### PR DESCRIPTION
### What does this PR do?

Fixes `AttributeError` on starting Salt >= 2016.3.1 with Sentry logging handler
### What issues does this PR fix or reference?
#34152
### Previous Behavior

Master failed to start with AttributeError in the Sentry logging handler.
### New Behavior

Works correctly.
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

Fixes #34152
