### PR TITLE
modules.lxc: make clone work with lxc >= 2.0

### DIFF
--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -2088,12 +2088,19 @@ def clone(name,
     size = select('size', '1G')
     if backing in ('dir', 'overlayfs', 'btrfs'):
         size = None
-    cmd = 'lxc-clone'
+    # LXC commands and options changed in 2.0 - CF issue #34086 for details
+    if version() >= distutils.version.LooseVersion('2.0'):
+        # https://linuxcontainers.org/lxc/manpages//man1/lxc-copy.1.html
+        cmd = 'lxc-copy'
+        cmd += ' {0} -n {1} -N {2}'.format(snapshot, orig, name)
+    else:
+        # https://linuxcontainers.org/lxc/manpages//man1/lxc-clone.1.html
+        cmd = 'lxc-clone'
+        cmd += ' {0} -o {1} -n {2}'.format(snapshot, orig, name)
     if path:
         cmd += ' -P {0}'.format(pipes.quote(path))
         if not os.path.exists(path):
             os.makedirs(path)
-    cmd += ' {0} -o {1} -n {2}'.format(snapshot, orig, name)
     if backing:
         backing = backing.lower()
         cmd += ' -B {0}'.format(backing)


### PR DESCRIPTION
### What does this PR do?

Make the lxc module able to clone for LXC versions >= 2.0.
### What issues does this PR fix or reference?

Fixes #34086
### Previous Behavior

Failed totally (CF issue details)
### New Behavior

Clone working fine
### Tests written?

No supplementary ones
