### PR TITLE
fix salt --summary to count not responding minions correctly

### DIFF
--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -253,6 +253,8 @@ class SaltCMD(parsers.SaltCMDOptionParser):
         not_connected_minions = []
         for each_minion in ret:
             minion_ret = ret[each_minion]
+            if isinstance(minion_ret, dict) and 'ret' in minion_ret:
+                minion_ret = ret[each_minion].get('ret')
             if (
                     isinstance(minion_ret, string_types)
                     and minion_ret.startswith("Minion did not return")


### PR DESCRIPTION
### What does this PR do?

fix salt --summary .... in case a minion is not returning
### Previous Behavior

```
# salt --summary '*' test.ping
minion1:
    True
minion2:
    Minion did not return. [Not connected]
-------------------------------------------
Summary
-------------------------------------------
# of minions targeted: 2
# of minions returned: 2
# of minions that did not return: 0
-------------------------------------------
```
### New Behavior

```
# salt --summary '*' test.ping
minion1:
    True
minion2:
    Minion did not return. [Not connected]
-------------------------------------------
Summary
-------------------------------------------
# of minions targeted: 2
# of minions returned: 1
# of minions that did not return: 1
-------------------------------------------
```
### Tests written?

No
