### PR TITLE
External auth can return dynamically generated ACL from auth call.

### DIFF
--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -159,8 +159,10 @@ class LoadAuth(object):
         '''
         Run time_auth and create a token. Return False or the token
         '''
-        ret = self.time_auth(load)
-        if ret is False:
+        auth_ret = self.time_auth(load)
+        if not isinstance(auth_ret, list) and not isinstance(auth_ret, bool):
+            auth_ret = False
+        if auth_ret is False:
             return {}
         fstr = '{0}.auth'.format(load['eauth'])
         hash_type = getattr(hashlib, self.opts.get('hash_type', 'md5'))
@@ -184,6 +186,9 @@ class LoadAuth(object):
                  'name': fcall['args'][0],
                  'eauth': load['eauth'],
                  'token': tok}
+
+        if auth_ret is not True:
+            tdata['auth_list'] = auth_ret
 
         if 'groups' in load:
             tdata['groups'] = load['groups']

--- a/salt/auth/django.py
+++ b/salt/auth/django.py
@@ -117,7 +117,7 @@ def auth(username, password):
 
             auth_dict_from_db = retrieve_auth_entries(username)[username]
             if auth_dict_from_db is not None:
-                __opts__['external_auth']['django'][username] = auth_dict_from_db
+                return auth_dict_from_db
 
             return True
         else:

--- a/salt/auth/rest.py
+++ b/salt/auth/rest.py
@@ -2,7 +2,7 @@
 '''
 Provide authentication using a REST call
 
-Django auth can be defined like any other eauth module:
+REST auth can be defined like any other eauth module:
 
 .. code-block:: yaml
 
@@ -32,7 +32,7 @@ import salt.utils.http
 
 log = logging.getLogger(__name__)
 
-__virtualname__ = 'django'
+__virtualname__ = 'rest'
 
 
 def __virtual__():
@@ -56,12 +56,13 @@ def auth(username, password):
 
     data = {'username': username, 'password': password}
 
-    # Post to the API endpoint.  If 200 is returned then the result will be the ACLs
+    # Post to the API endpoint. If 200 is returned then the result will be the ACLs
     # for this user
     result = salt.utils.http.query(url, method='POST', data=data)
     if result['status'] == 200:
         log.debug('eauth REST call returned 200: {0}'.format(result))
-        __opts__['external_auth']['rest'][username] = result['dict']
+        if result['dict'] is not None:
+            return result['dict']
         return True
     else:
         log.debug('eauth REST call failed: {0}'.format(result))

--- a/tests/unit/auth_test.py
+++ b/tests/unit/auth_test.py
@@ -65,6 +65,7 @@ class LoadAuthTestCase(TestCase):
             self.lauth.get_groups(valid_eauth_load)
             format_call_mock.assert_has_calls((expected_ret,), any_order=True)
 
+
 @patch('zmq.Context', MagicMock())
 @patch('salt.payload.Serial.dumps', MagicMock())
 @patch('salt.master.tagify', MagicMock())

--- a/tests/unit/auth_test.py
+++ b/tests/unit/auth_test.py
@@ -65,7 +65,6 @@ class LoadAuthTestCase(TestCase):
             self.lauth.get_groups(valid_eauth_load)
             format_call_mock.assert_has_calls((expected_ret,), any_order=True)
 
-
 @patch('zmq.Context', MagicMock())
 @patch('salt.payload.Serial.dumps', MagicMock())
 @patch('salt.master.tagify', MagicMock())
@@ -495,6 +494,64 @@ class MasterACLTestCase(integration.ModuleCase):
                                          '__kwarg__': True}]
         self.clear.publish(self.valid_clear_load)
         self.assertEqual(fire_event_mock.mock_calls, [])
+
+
+class AuthACLTestCase(integration.ModuleCase):
+    '''
+    A class to check various aspects of the publisher ACL system
+    '''
+    @patch('salt.minion.MasterMinion', MagicMock())
+    @patch('salt.utils.verify.check_path_traversal', MagicMock())
+    def setUp(self):
+        opts = self.get_config('minion', from_scratch=True)
+        opts['client_acl'] = {}
+        opts['publisher_acl'] = {}
+        opts['client_acl_blacklist'] = {}
+        opts['publisher_acl_blacklist'] = {}
+        opts['master_job_cache'] = ''
+        opts['sign_pub_messages'] = False
+        opts['con_cache'] = ''
+        opts['external_auth'] = {}
+        opts['external_auth']['pam'] = {'test_user': [{'alpha_minion': ['test.ping']}]}
+
+        self.clear = salt.master.ClearFuncs(opts, MagicMock())
+
+        # overwrite the _send_pub method so we don't have to serialize MagicMock
+        self.clear._send_pub = lambda payload: True
+
+        # make sure to return a JID, instead of a mock
+        self.clear.mminion.returners = {'.prep_jid': lambda x: 1}
+
+        self.valid_clear_load = {'tgt_type': 'glob',
+                                 'jid': '',
+                                 'cmd': 'publish',
+                                 'tgt': 'test_minion',
+                                 'kwargs':
+                                     {'username': 'test_user',
+                                      'password': 'test_password',
+                                      'show_timeout': False,
+                                      'eauth': 'pam',
+                                      'show_jid': False},
+                                 'ret': '',
+                                 'user': 'test_user',
+                                 'key': '',
+                                 'arg': '',
+                                 'fun': 'test.ping',
+                                 }
+
+    @patch('salt.auth.LoadAuth.time_auth', MagicMock(return_value=True))
+    @patch('salt.utils.minions.CkMinions.auth_check', return_value=True)
+    def test_acl_simple_allow(self, auth_check_mock):
+        self.clear.publish(self.valid_clear_load)
+        self.assertEqual(auth_check_mock.call_args[0][0],
+                         [{'alpha_minion': ['test.ping']}])
+
+    @patch('salt.auth.LoadAuth.time_auth', MagicMock(return_value=[{'beta_minion': ['test.ping']}]))
+    @patch('salt.utils.minions.CkMinions.auth_check', return_value=True)
+    def test_acl_simple_deny(self, auth_check_mock):
+        self.clear.publish(self.valid_clear_load)
+        self.assertEqual(auth_check_mock.call_args[0][0],
+                         [{'beta_minion': ['test.ping']}])
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
### What does this PR do?

Adds an ability to return ACL from external auth module. The ACL could be dynamically generated or fetched from an external data source by the module and returned from auth call. The returned data will be used as ACL for the authenticated user.
The format is the same as the external auth ACL. For example:
`[{'test_minion': ['test.ping']}]`
The old behavior is kept. I.e. auth() also can return True or False.
### What issues does this PR fix or reference?
#30762
### Tests written?

Yes
