### PR TITLE
Support for building with local packages on Debian and Ubuntu

### DIFF
--- a/salt/modules/debbuild.py
+++ b/salt/modules/debbuild.py
@@ -15,13 +15,8 @@ from __future__ import absolute_import, print_function
 import errno
 import logging
 import os
-import sys
 import tempfile
 import shutil
-import time
-import re
-import traceback
-## import functools
 
 # Import salt libs
 import salt.utils
@@ -624,4 +619,3 @@ def make_repo(repodir, keyid=None, env=None, use_passphrase=False, gnupghome='/e
     if use_passphrase and local_keyid is not None:
         cmd = '/usr/lib/gnupg2/gpg-preset-passphrase --forget {0}'.format(local_fingerprint)
         __salt__['cmd.run'](cmd, runas=runas)
-


### PR DESCRIPTION
### What does this PR do?

Allows for building packages with previously locally build dependencies on Debian and Ubuntu
### What issues does this PR fix or reference?

https://github.com/saltstack/salt-pack/issues/78
https://github.com/saltstack/salt-pack/issues/71
### New Behavior

Will now build packages using previously built local packages
### Tests written?

No, ability to build with previously built was sufficient test

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
