### PR TITLE
Raise the correct exception when gitfs lockfile is empty

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -442,7 +442,7 @@ class GitProvider(object):
                                     'by another master.')
                     log.warning(msg)
                     if failhard:
-                        raise
+                        raise exc
                     return
                 elif pid and pid_exists(pid):
                     log.warning('Process %d has a %s %s lock (%s)',


### PR DESCRIPTION
Catching the ValueError around line 416 means that when we re-raise
the exception below, we raise the wrong exception. This commit
explicitly raises the outer-scope exception that we caught above the
block where we attempt to read from the lock file.

Resolves #34114.
