### PR TITLE
Saltnado fix for test_get_no_mid [WIP]

### DIFF
--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -1069,6 +1069,8 @@ class SaltAPIHandler(BaseSaltAPIHandler, SaltClientsMixIn):  # pylint: disable=W
                                                   'saltutil.find_job',
                                                   [jid],
                                                   expr_form=tgt_type)
+        if not ping_pub_data:
+            raise tornado.gen.Return(True)
         ping_tag = tagify([ping_pub_data['jid'], 'ret'], 'job')
 
         minion_running = False


### PR DESCRIPTION
A job is not running if it's not found by find job so just return.

This is experimental. It needs a bunch of test runs to see if the issue is resolved.
