### PR TITLE
Handle child PIDs differently depending on the availability of psutils

### DIFF
--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -51,7 +51,12 @@ import salt.utils.event
 import salt.utils.url
 import salt.transport
 import salt.wheel
-import salt.utils.psutil_compat as psutil
+
+HAS_PSUTIL = True
+try:
+    import salt.utils.psutil_compat
+except ImportError:
+    HAS_PSUTIL = False
 
 from salt.exceptions import (
     SaltReqTimeoutError, SaltRenderError, CommandExecutionError, SaltInvocationError
@@ -855,12 +860,20 @@ def signal_job(jid, sig):
 
         salt '*' saltutil.signal_job <job id> 15
     '''
+    if HAS_PSUTIL is False:
+        log.warning('saltutil.signal job called, but psutil is not installed. '
+                    'Install psutil to ensure more reliable and accurate PID '
+                    'management.')
     for data in running():
         if data['jid'] == jid:
             try:
-                for proc in psutil.Process(pid=data['pid']).children(recursive=True):
-                    proc.send_signal(sig)
+                if HAS_PSUTIL:
+                    for proc in salt.utils.psutil_compat.Process(pid=data['pid']).children(recursive=True):
+                        proc.send_signal(sig)
                 os.kill(int(data['pid']), sig)
+                if HAS_PSUTIL is False and 'child_pids' in data:
+                    for pid in data['child_pids']:
+                        os.kill(int(pid), sig)
                 return 'Signal {0} sent to job {1} at pid {2}'.format(
                         int(sig),
                         jid,


### PR DESCRIPTION
### What does this PR do?

In the change made in #33942, we are assuming that psutils is installed. This change checks if psutil is installed, and if it's not, it reverts back to the old behavior. If it is not installed, a warning is logged mentioning the missing dependency.
### What issues does this PR fix or reference?

Fixes #34043
### Previous Behavior

Stack traces would happen on calls that used and `saltutil` module function, as psutil couldn't be imported.
### New Behavior

No more stacktraces when psutils is missing, warns when psutil isn't installed, and reverts back to old PID management.
### Tests written?

No

ping @cachedout 
