### PR TITLE
Remove repr formatting flag in places where it is used solely for quoting

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1206,7 +1206,7 @@ class Cloud(object):
         if deploy:
             if not make_master and 'master' not in minion_dict:
                 log.warning(
-                    'There\'s no master defined on the {0!r} VM settings.'.format(
+                    'There\'s no master defined on the \'{0}\' VM settings.'.format(
                         vm_['name']
                     )
                 )

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -1468,7 +1468,7 @@ def pages_to_list(items):
     objs = []
     while True:
         try:
-            page = items.next()
+            page = items.next()  # pylint: disable=incompatible-py3-code
             for item in page:
                 objs.append(item)
         except GeneratorExit:

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -1087,9 +1087,9 @@ def create(vm_):
     ret = salt.utils.cloud.bootstrap(vm_, __opts__)
 
     data = show_instance(vm_['name'], call='action')
-    log.info('Created Cloud VM {0[name]!r}'.format(vm_))
+    log.info('Created Cloud VM \'{0[name]}\''.format(vm_))
     log.debug(
-        '{0[name]!r} VM creation details:\n{1}'.format(
+        '\'{0[name]}\' VM creation details:\n{1}'.format(
             vm_, pprint.pformat(data)
         )
     )

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2426,7 +2426,7 @@ def create(vm_=None, call=None):
 
         if not os.path.exists(key_filename):
             raise SaltCloudSystemExit(
-                'The EC2 key file {0!r} does not exist.\n'.format(
+                'The EC2 key file \'{0}\' does not exist.\n'.format(
                     key_filename
                 )
             )
@@ -2436,7 +2436,7 @@ def create(vm_=None, call=None):
         )
         if key_mode not in ('0400', '0600'):
             raise SaltCloudSystemExit(
-                'The EC2 key file {0!r} needs to be set to mode 0400 or 0600.\n'.format(
+                'The EC2 key file \'{0}\' needs to be set to mode 0400 or 0600.\n'.format(
                     key_filename
                 )
             )

--- a/salt/cloud/clouds/profitbricks.py
+++ b/salt/cloud/clouds/profitbricks.py
@@ -706,9 +706,9 @@ def create(vm_):
             raise SaltCloudSystemExit(str(exc.message))
 
     log.debug('VM is now running')
-    log.info('Created Cloud VM {0[name]!r}'.format(vm_))
+    log.info('Created Cloud VM \'{0[name]}\''.format(vm_))
     log.debug(
-        '{0[name]!r} VM creation details:\n{1}'.format(
+        '\'{0[name]}\' VM creation details:\n{1}'.format(
             vm_, pprint.pformat(data)
         )
     )

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1186,9 +1186,11 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                         curr_ext = self.file_mapping[f_noext][1]
                         #log.debug("****** curr_ext={0} ext={1} suffix_order={2}".format(curr_ext, ext, suffix_order))
                         if '' in (curr_ext, ext) and curr_ext != ext:
-                            log.error('Module/package collision: {0!r} and {1!r}'.format(
-                                fpath, self.file_mapping[f_noext][0]
-                            ))
+                            log.error(
+                                'Module/package collision: \'%s\' and \'%s\'',
+                                fpath,
+                                self.file_mapping[f_noext][0]
+                            )
                         if not curr_ext or suffix_order.index(ext) >= suffix_order.index(curr_ext):
                             continue  # Next filename
 

--- a/salt/modules/boto_s3_bucket.py
+++ b/salt/modules/boto_s3_bucket.py
@@ -54,9 +54,10 @@ from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=i
 import json
 
 # Import Salt libs
+from salt.ext import six
+from salt.ext.six.moves import range  # pylint: disable=import-error
 import salt.utils.compat
 import salt.utils
-from salt.ext.six import string_types
 from salt.exceptions import SaltInvocationError
 
 log = logging.getLogger(__name__)
@@ -221,7 +222,7 @@ def delete_objects(Bucket, Delete, MFA=None, RequestPayer=None,
 
     '''
 
-    if isinstance(Delete, string_types):
+    if isinstance(Delete, six.string_types):
         Delete = json.loads(Delete)
     if not isinstance(Delete, dict):
         raise SaltInvocationError("Malformed Delete request.")
@@ -230,7 +231,7 @@ def delete_objects(Bucket, Delete, MFA=None, RequestPayer=None,
 
     failed = []
     objs = Delete['Objects']
-    for i in xrange(0, len(objs), 1000):
+    for i in range(0, len(objs), 1000):
         chunk = objs[i:i+1000]
         subset = {'Objects': chunk, 'Quiet': True}
         try:
@@ -475,7 +476,7 @@ def put_acl(Bucket,
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         kwargs = {}
         if AccessControlPolicy is not None:
-            if isinstance(AccessControlPolicy, string_types):
+            if isinstance(AccessControlPolicy, six.string_types):
                 AccessControlPolicy = json.loads(AccessControlPolicy)
             kwargs['AccessControlPolicy'] = AccessControlPolicy
         for arg in ('ACL',
@@ -515,7 +516,7 @@ def put_cors(Bucket,
 
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-        if CORSRules is not None and isinstance(CORSRules, string_types):
+        if CORSRules is not None and isinstance(CORSRules, six.string_types):
             CORSRules = json.loads(CORSRules)
         conn.put_bucket_cors(Bucket=Bucket, CORSConfiguration={'CORSRules': CORSRules})
         return {'updated': True, 'name': Bucket}
@@ -550,7 +551,7 @@ def put_lifecycle_configuration(Bucket,
 
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-        if Rules is not None and isinstance(Rules, string_types):
+        if Rules is not None and isinstance(Rules, six.string_types):
             Rules = json.loads(Rules)
         conn.put_bucket_lifecycle_configuration(Bucket=Bucket, LifecycleConfiguration={'Rules': Rules})
         return {'updated': True, 'name': Bucket}
@@ -589,7 +590,7 @@ def put_logging(Bucket,
             logstatus = {'LoggingEnabled': logstate}
         else:
             logstatus = {}
-        if TargetGrants is not None and isinstance(TargetGrants, string_types):
+        if TargetGrants is not None and isinstance(TargetGrants, six.string_types):
             TargetGrants = json.loads(TargetGrants)
         conn.put_bucket_logging(Bucket=Bucket, BucketLoggingStatus=logstatus)
         return {'updated': True, 'name': Bucket}
@@ -622,15 +623,15 @@ def put_notification_configuration(Bucket,
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         if TopicConfigurations is None:
             TopicConfigurations = []
-        elif isinstance(TopicConfigurations, string_types):
+        elif isinstance(TopicConfigurations, six.string_types):
             TopicConfigurations = json.loads(TopicConfigurations)
         if QueueConfigurations is None:
             QueueConfigurations = []
-        elif isinstance(QueueConfigurations, string_types):
+        elif isinstance(QueueConfigurations, six.string_types):
             QueueConfigurations = json.loads(QueueConfigurations)
         if LambdaFunctionConfigurations is None:
             LambdaFunctionConfigurations = []
-        elif isinstance(LambdaFunctionConfigurations, string_types):
+        elif isinstance(LambdaFunctionConfigurations, six.string_types):
             LambdaFunctionConfigurations = json.loads(LambdaFunctionConfigurations)
         # TODO allow the user to use simple names & substitute ARNs for those names
         conn.put_bucket_notification_configuration(Bucket=Bucket, NotificationConfiguration={
@@ -663,7 +664,7 @@ def put_policy(Bucket, Policy,
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         if Policy is None:
             Policy = '{}'
-        elif not isinstance(Policy, string_types):
+        elif not isinstance(Policy, six.string_types):
             Policy = json.dumps(Policy)
         conn.put_bucket_policy(Bucket=Bucket, Policy=Policy)
         return {'updated': True, 'name': Bucket}
@@ -707,7 +708,7 @@ def put_replication(Bucket, Role, Rules,
                              region=region, key=key, keyid=keyid, profile=profile)
         if Rules is None:
             Rules = []
-        elif isinstance(Rules, string_types):
+        elif isinstance(Rules, six.string_types):
             Rules = json.loads(Rules)
         conn.put_bucket_replication(Bucket=Bucket, ReplicationConfiguration={
                 'Role': Role,
@@ -831,7 +832,7 @@ def put_website(Bucket, ErrorDocument=None, IndexDocument=None,
                     'RedirectAllRequestsTo', 'RoutingRules'):
             val = locals()[key]
             if val is not None:
-                if isinstance(val, string_types):
+                if isinstance(val, six.string_types):
                     WebsiteConfiguration[key] = json.loads(val)
                 else:
                     WebsiteConfiguration[key] = val

--- a/salt/modules/minion.py
+++ b/salt/modules/minion.py
@@ -15,6 +15,7 @@ import salt.key
 
 # Import third party libs
 import salt.ext.six as six
+from salt.ext.six.moves import range
 
 # Don't shadow built-ins.
 __func_alias__ = {

--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -35,7 +35,8 @@ from __future__ import unicode_literals
 import sys
 import logging
 from salt.ext.six.moves import range  # pylint: disable=W0622,import-error
-import salt.ext.six as six
+from salt.ext import six
+
 # Import third party libs
 try:
     from salt.ext.six.moves import winreg as _winreg  # pylint: disable=import-error,no-name-in-module
@@ -99,7 +100,7 @@ def _mbcs_to_unicode(instr):
     if instr is None or isinstance(instr, six.text_type):
         return instr
     else:
-        return unicode(instr, 'mbcs')
+        return six.text_type(instr, 'mbcs')
 
 
 def _mbcs_to_unicode_wrap(obj, vtype):

--- a/salt/modules/testinframod.py
+++ b/salt/modules/testinframod.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
-"""
+'''
 This module exposes the functionality of the TestInfra library
 for use with SaltStack in order to verify the state of your minions.
 In order to allow for the addition of new resource types in TestInfra this
 module dynamically generates wrappers for the various resources by iterating
 over the values in the ``__all__`` variable exposed by the testinfra.modules
 namespace.
-"""
+'''
+from __future__ import absolute_import
 import inspect
 import logging
 import operator

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -1101,7 +1101,7 @@ def remove(path, force=False):
             # Reset attributes to the original if delete fails.
             win32api.SetFileAttributes(path, file_attributes)
         raise CommandExecutionError(
-            'Could not remove {0!r}: {1}'.format(path, exc)
+            'Could not remove \'{0}\': {1}'.format(path, exc)
         )
 
     return True

--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -15,6 +15,7 @@ import logging
 import os
 
 # Import salt libs
+from salt.ext.six.moves import range
 from salt.exceptions import SaltInvocationError
 import salt.utils
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -961,7 +961,7 @@ def install(name=None,
                     targets.append('{0}{1}{2}'.format(param, ((gt_lt or '') + (equal or '')) or '=', verstr))
                     log.debug(targets)
                 else:
-                    msg = ('Invalid version string {0!r} for package {1!r}'.format(version_num, name))
+                    msg = ('Invalid version string \'{0}\' for package \'{1}\''.format(version_num, name))
                     problems.append(msg)
         if problems:
             for problem in problems:

--- a/salt/pillar/consul_pillar.py
+++ b/salt/pillar/consul_pillar.py
@@ -169,8 +169,7 @@ def ext_pillar(minion_id,
     try:
         pillar = fetch_tree(client, path)
     except KeyError:
-        log.error('No such key in consul profile {0}: {1}'
-                  .format(profile, path))
+        log.error('No such key in consul profile %s: %s', profile, path)
         pillar = {}
 
     return pillar
@@ -199,8 +198,8 @@ def fetch_tree(client, path):
         return ret
     for item in reversed(items):
         key = re.sub(r'^' + path + '/?', '', item['Key'])
-        if key != "":
-            log.debug('key/path - {0}: {1}'.format(path, key))
+        if key != '':
+            log.debug('key/path - %s: %s', path, key)
             log.debug('has_children? %r', format(has_children.search(key)))
         if has_children.search(key) is None:
             ret = pillar_format(ret, key.split('/'), item['Value'])
@@ -282,20 +281,16 @@ def _resolve_datacenter(dc, pillarenv):
     If none patterns matched return ``None`` which meanse us datacenter of
     conencted Consul agent.
     '''
-    log.debug("Resolving Consul datacenter based on: {dc}".format(dc=dc))
+    log.debug('Resolving Consul datacenter based on: %s', dc)
 
     try:
         mappings = dc.items()  # is it a dict?
     except AttributeError:
-        log.debug('Using pre-defined DC: {dc!r}'.format(dc=dc))
+        log.debug('Using pre-defined DC: \'%s\'', dc)
         return dc
 
-    log.debug(
-        'Selecting DC based on pillarenv using {num} pattern(s)'.format(
-            num=len(mappings)
-        )
-    )
-    log.debug('Pillarenv set to {env!r}'.format(env=pillarenv))
+    log.debug('Selecting DC based on pillarenv using %d pattern(s)', len(mappings))
+    log.debug('Pillarenv set to \'%s\'', pillarenv)
 
     # sort in reverse based on pattern length
     # but use alphabetic order within groups of patterns of same length
@@ -304,13 +299,12 @@ def _resolve_datacenter(dc, pillarenv):
     for pattern, target in sorted_mappings:
         match = re.match(pattern, pillarenv)
         if match:
-            log.debug('Matched pattern: {pattern!r}'.format(pattern=pattern))
+            log.debug('Matched pattern: \'%s\'', pattern)
             result = target.format(**match.groupdict())
-            log.debug('Resolved datacenter: {result!r}'.format(result=result))
+            log.debug('Resolved datacenter: \'%s\'', result)
             return result
 
     log.debug(
-        'None of following patterns matched pillarenv={env}: {lst}'.format(
-            env=pillarenv, lst=', '.join(repr(x) for x in mappings)
-        )
+        'None of following patterns matched pillarenv=%s: %s',
+        pillarenv, ', '.join(repr(x) for x in mappings)
     )

--- a/salt/pillar/csvpillar.py
+++ b/salt/pillar/csvpillar.py
@@ -45,6 +45,7 @@ Will produce the following Pillar values for a minion named "jerry":
         'env': 'prod',
     }
 '''
+from __future__ import absolute_import
 import csv
 
 import salt.utils

--- a/salt/renderers/pyobjects.py
+++ b/salt/renderers/pyobjects.py
@@ -416,7 +416,9 @@ def render(template, saltenv='base', sls='', salt_data=True, **kwargs):
 
                 state_file = client.cache_file(import_file, saltenv)
                 if not state_file:
-                    raise ImportError("Could not find the file {0!r}".format(import_file))
+                    raise ImportError(
+                        'Could not find the file \'{0}\''.format(import_file)
+                    )
 
                 state_locals = {}
                 with salt.utils.fopen(state_file) as state_fh:
@@ -439,10 +441,12 @@ def render(template, saltenv='base', sls='', salt_data=True, **kwargs):
                             alias = matches.group(2).strip()
 
                         if name not in state_locals:
-                            raise ImportError("{0!r} was not found in {1!r}".format(
-                                name,
-                                import_file
-                            ))
+                            raise ImportError(
+                                '\'{0}\' was not found in \'{1}\''.format(
+                                    name,
+                                    import_file
+                                )
+                            )
                         state_globals[alias] = state_locals[name]
 
                 matched = True

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -287,12 +287,13 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     '''
     return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
 
+
 def event_return(events):
-    """
+    '''
     Return events to Mongodb server
-    """
+    '''
     conn, mdb = _get_conn(ret=None)
-    
+
     if isinstance(events, list):
         events = events[0]
 

--- a/salt/returners/sentry_return.py
+++ b/salt/returners/sentry_return.py
@@ -144,9 +144,8 @@ def returner(ret):
                 )
             except KeyError as missing_key:
                 logger.error(
-                    'Sentry returner need config {0!r} in pillar'.format(
-                        missing_key
-                    )
+                    'Sentry returner needs key \'%s\' in pillar',
+                    missing_key
                 )
                 return
 

--- a/salt/states/bower.py
+++ b/salt/states/bower.py
@@ -96,7 +96,7 @@ def installed(name,
         installed_pkgs = __salt__['bower.list'](dir=dir, runas=user, env=env)
     except (CommandNotFoundError, CommandExecutionError) as err:
         ret['result'] = False
-        ret['comment'] = 'Error looking up {0!r}: {1}'.format(name, err)
+        ret['comment'] = 'Error looking up \'{0}\': {1}'.format(name, err)
         return ret
     else:
         installed_pkgs = dict((p, info) for p, info in
@@ -137,14 +137,14 @@ def installed(name,
         comment_msg = []
         if pkgs_to_install:
             comment_msg.append(
-                'Bower package(s) {0!r} are set to be installed'.format(
+                'Bower package(s) \'{0}\' are set to be installed'.format(
                     ', '.join(pkgs_to_install)))
 
             ret['changes'] = {'old': [], 'new': pkgs_to_install}
 
         if pkgs_satisfied:
             comment_msg.append(
-                'Package(s) {0!r} satisfied by {1}'.format(
+                'Package(s) \'{0}\' satisfied by {1}'.format(
                     ', '.join(pkg_list), ', '.join(pkgs_satisfied)))
 
         ret['comment'] = '. '.join(comment_msg)
@@ -152,7 +152,7 @@ def installed(name,
 
     if not pkgs_to_install:
         ret['result'] = True
-        ret['comment'] = ('Package(s) {0!r} satisfied by {1}'.format(
+        ret['comment'] = ('Package(s) \'{0}\' satisfied by {1}'.format(
             ', '.join(pkg_list), ', '.join(pkgs_satisfied)))
         return ret
 
@@ -173,18 +173,18 @@ def installed(name,
         call = __salt__['bower.install'](**cmd_args)
     except (CommandNotFoundError, CommandExecutionError) as err:
         ret['result'] = False
-        ret['comment'] = 'Error installing {0!r}: {1}'.format(
+        ret['comment'] = 'Error installing \'{0}\': {1}'.format(
                 ', '.join(pkg_list), err)
         return ret
 
     if call:
         ret['result'] = True
         ret['changes'] = {'old': [], 'new': pkgs_to_install}
-        ret['comment'] = 'Package(s) {0!r} successfully installed'.format(
+        ret['comment'] = 'Package(s) \'{0}\' successfully installed'.format(
                 ', '.join(pkgs_to_install))
     else:
         ret['result'] = False
-        ret['comment'] = 'Could not install package(s) {0!r}'.format(
+        ret['comment'] = 'Could not install package(s) \'{0}\''.format(
                 ', '.join(pkg_list))
 
     return ret
@@ -207,31 +207,31 @@ def removed(name, dir, user=None):
         installed_pkgs = __salt__['bower.list'](dir=dir, runas=user)
     except (CommandExecutionError, CommandNotFoundError) as err:
         ret['result'] = False
-        ret['comment'] = 'Error removing {0!r}: {1}'.format(name, err)
+        ret['comment'] = 'Error removing \'{0}\': {1}'.format(name, err)
         return ret
 
     if name not in installed_pkgs:
         ret['result'] = True
-        ret['comment'] = 'Package {0!r} is not installed'.format(name)
+        ret['comment'] = 'Package \'{0}\' is not installed'.format(name)
         return ret
 
     if __opts__['test']:
         ret['result'] = None
-        ret['comment'] = 'Package {0!r} is set to be removed!'.format(name)
+        ret['comment'] = 'Package \'{0}\' is set to be removed'.format(name)
         return ret
 
     try:
         if __salt__['bower.uninstall'](pkg=name, dir=dir, runas=user):
             ret['result'] = True
             ret['changes'] = {name: 'Removed'}
-            ret['comment'] = 'Package {0!r} was successfully removed'.format(
+            ret['comment'] = 'Package \'{0}\' was successfully removed'.format(
                 name)
         else:
             ret['result'] = False
-            ret['comment'] = 'Error removing {0!r}'.format(name)
+            ret['comment'] = 'Error removing \'{0}\''.format(name)
     except (CommandExecutionError, CommandNotFoundError) as err:
         ret['result'] = False
-        ret['comment'] = 'Error removing {0!r}: {1}'.format(name, err)
+        ret['comment'] = 'Error removing \'{0}\': {1}'.format(name, err)
 
     return ret
 
@@ -250,7 +250,7 @@ def bootstrap(name, user=None):
 
     if __opts__['test']:
         ret['result'] = None
-        ret['comment'] = 'Directory {0!r} is set to be bootstrapped'.format(
+        ret['comment'] = 'Directory \'{0}\' is set to be bootstrapped'.format(
             name)
         return ret
 
@@ -258,7 +258,7 @@ def bootstrap(name, user=None):
         call = __salt__['bower.install'](pkg=None, dir=name, runas=user)
     except (CommandNotFoundError, CommandExecutionError) as err:
         ret['result'] = False
-        ret['comment'] = 'Error bootstrapping {0!r}: {1}'.format(name, err)
+        ret['comment'] = 'Error bootstrapping \'{0}\': {1}'.format(name, err)
         return ret
 
     if not call:

--- a/salt/states/cabal.py
+++ b/salt/states/cabal.py
@@ -100,7 +100,7 @@ def installed(name,
             user=user, installed=True, env=env)
     except (CommandNotFoundError, CommandExecutionError) as err:
         ret['result'] = False
-        ret['comment'] = 'Error looking up  {0!r}: {1}'.format(name, err)
+        ret['comment'] = 'Error looking up \'{0}\': {1}'.format(name, err)
         return ret
 
     pkgs_satisfied = []
@@ -127,12 +127,12 @@ def installed(name,
 
         if pkgs_to_install:
             comment_msg.append(
-                'Packages(s) {0!r} are set to be installed'.format(
+                'Packages(s) \'{0}\' are set to be installed'.format(
                     ', '.join(pkgs_to_install)))
 
         if pkgs_satisfied:
             comment_msg.append(
-                'Packages(s) {0!r} satisfied by {1}'.format(
+                'Packages(s) \'{0}\' satisfied by {1}'.format(
                     ', '.join(pkg_list), ', '.join(pkgs_satisfied)))
 
         ret['comment'] = '. '.join(comment_msg)
@@ -140,7 +140,7 @@ def installed(name,
 
     if not pkgs_to_install:
         ret['result'] = True
-        ret['comment'] = ('Packages(s) {0!r} satisfied by {1}'.format(
+        ret['comment'] = ('Packages(s) \'{0}\' satisfied by {1}'.format(
             ', '.join(pkg_list), ', '.join(pkgs_satisfied)))
 
         return ret
@@ -152,18 +152,18 @@ def installed(name,
                                          env=env)
     except (CommandNotFoundError, CommandExecutionError) as err:
         ret['result'] = False
-        ret['comment'] = 'Error installing {0!r}: {1}'.format(
+        ret['comment'] = 'Error installing \'{0}\': {1}'.format(
             ', '.join(pkg_list), err)
         return ret
 
     if call and isinstance(call, dict):
         ret['result'] = True
         ret['changes'] = {'old': [], 'new': pkgs_to_install}
-        ret['comment'] = 'Packages(s) {0!r} successfully installed'.format(
+        ret['comment'] = 'Packages(s) \'{0}\' successfully installed'.format(
             ', '.join(pkgs_to_install))
     else:
         ret['result'] = False
-        ret['comment'] = 'Could not install packages(s) {0!r}'.format(
+        ret['comment'] = 'Could not install packages(s) \'{0}\''.format(
             ', '.join(pkg_list))
 
     return ret
@@ -183,24 +183,24 @@ def removed(name,
             user=user, installed=True, env=env)
     except (CommandNotFoundError, CommandExecutionError) as err:
         ret['result'] = False
-        ret['comment'] = 'Error looking up  {0!r}: {1}'.format(name, err)
+        ret['comment'] = 'Error looking up \'{0}\': {1}'.format(name, err)
 
     if name not in installed_pkgs:
         ret['result'] = True
-        ret['comment'] = 'Package {0!r} is not installed'.format(name)
+        ret['comment'] = 'Package \'{0}\' is not installed'.format(name)
         return ret
 
     if __opts__['test']:
         ret['result'] = None
-        ret['comment'] = 'Package {0!r} is set to be removed'.format(name)
+        ret['comment'] = 'Package \'{0}\' is set to be removed'.format(name)
         return ret
 
     if __salt__['cabal.uninstall'](pkg=name, user=user, env=env):
         ret['result'] = True
         ret['changes'][name] = 'Removed'
-        ret['comment'] = 'Package {0!r} was successfully removed'.format(name)
+        ret['comment'] = 'Package \'{0}\' was successfully removed'.format(name)
     else:
         ret['result'] = False
-        ret['comment'] = 'Error removing package {0!r}'.format(name)
+        ret['comment'] = 'Error removing package \'{0}\''.format(name)
 
     return ret

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -1090,7 +1090,7 @@ def script(name,
 
     if __opts__['test'] and not test_name:
         ret['result'] = None
-        ret['comment'] = 'Command {0!r} would have been ' \
+        ret['comment'] = 'Command \'{0}\' would have been ' \
                          'executed'.format(name)
         return _reinterpreted_state(ret) if stateful else ret
 
@@ -1115,9 +1115,9 @@ def script(name,
         ret['result'] = not bool(cmd_all['retcode'])
     if ret.get('changes', {}).get('cache_error'):
         ret['comment'] = 'Unable to cache script {0} from saltenv ' \
-                         '{1!r}'.format(source, __env__)
+                         '\'{1}\''.format(source, __env__)
     else:
-        ret['comment'] = 'Command {0!r} run'.format(name)
+        ret['comment'] = 'Command \'{0}\' run'.format(name)
     if stateful:
         ret = _reinterpreted_state(ret)
     if __opts__['test'] and cmd_all['retcode'] == 0 and ret['changes']:

--- a/salt/states/composer.py
+++ b/salt/states/composer.py
@@ -157,7 +157,7 @@ def installed(name,
         )
     except (SaltException) as err:
         ret['result'] = False
-        ret['comment'] = 'Error executing composer in \'{0!r}\': {1!r}'.format(name, err)
+        ret['comment'] = 'Error executing composer in \'{0}\': {1}'.format(name, err)
         return ret
 
     # If composer retcode != 0 then an exception was thrown and we dealt with it.
@@ -271,7 +271,7 @@ def update(name,
         )
     except (SaltException) as err:
         ret['result'] = False
-        ret['comment'] = 'Error executing composer in \'{0!r}\': {1!r}'.format(name, err)
+        ret['comment'] = 'Error executing composer in \'{0}\': {1}'.format(name, err)
         return ret
 
     # If composer retcode != 0 then an exception was thrown and we dealt with it.

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -657,11 +657,11 @@ def installed(name,
     already_exists = cinfos['status']
     # if container exists but is not started, try to start it
     if already_exists:
-        return _valid(comment='Container {0!r} already exists'.format(name))
+        return _valid(comment='Container \'{0}\' already exists'.format(name))
     dports, denvironment = {}, {}
 
     if __opts__['test']:
-        comment = 'Container {0!r} will be created'.format(name)
+        comment = 'Container \'{0}\' will be created'.format(name)
         return _ret_status(name=name, comment=comment)
 
     if not ports:
@@ -737,7 +737,7 @@ def absent(name):
         is_running = __salt__['docker.is_running'](cid)
 
         if __opts__['test']:
-            comment = 'Container {0!r} will be stopped and destroyed'.format(cid)
+            comment = 'Container \'{0}\' will be stopped and destroyed'.format(cid)
             return _ret_status(name=name, comment=comment)
 
         # Stop container gracefully, if running
@@ -746,32 +746,32 @@ def absent(name):
             __salt__['docker.stop'](cid)
             is_running = __salt__['docker.is_running'](cid)
             if is_running:
-                return _invalid(comment=("Container {0!r} could not be stopped"
+                return _invalid(comment=('Container \'{0}\' could not be stopped'
                                          .format(cid)))
             else:
                 __salt__['docker.remove_container'](cid)
                 is_gone = __salt__['docker.exists'](cid)
                 if is_gone:
-                    return _valid(comment=('Container {0!r}'
+                    return _valid(comment=('Container \'{0}\''
                                   ' was stopped and destroyed, '.format(cid)),
                                   changes={name: True})
                 else:
-                    return _valid(comment=('Container {0!r}'
+                    return _valid(comment=('Container \'{0}\''
                                   ' was stopped but could not be destroyed,'.format(cid)),
                                   changes={name: True})
         else:
             __salt__['docker.remove_container'](cid)
             is_gone = __salt__['docker.exists'](cid)
             if is_gone:
-                return _valid(comment=('Container {0!r}'
+                return _valid(comment=('Container \'{0}\''
                               'is stopped and was destroyed, '.format(cid)),
                               changes={name: True})
             else:
-                return _valid(comment=('Container {0!r}'
+                return _valid(comment=('Container \'{0}\''
                               ' is stopped but could not be destroyed,'.format(cid)),
                               changes={name: True})
     else:
-        return _valid(comment="Container {0!r} not found".format(name))
+        return _valid(comment='Container \'{0}\' not found'.format(name))
 
 
 def present(name, image=None, tag='latest', is_latest=False):
@@ -886,7 +886,7 @@ def run(name,
                 return valid(comment='docked_unless execution succeeded')
 
     if __opts__['test']:
-        comment = 'Command {0!r} will be executed on container {1}'.format(name, cid)
+        comment = 'Command \'{0}\' will be executed on container {1}'.format(name, cid)
         return _ret_status(name=name, comment=comment)
 
     result = drun_all(cid, name)
@@ -1129,27 +1129,27 @@ def running(name,
 
     # if container exists but is not started, try to start it
     if already_exists_with_same_image and (is_running or not start):
-        return _valid(comment='container {0!r} already exists'.format(name))
+        return _valid(comment='container \'{0}\' already exists'.format(name))
     if not already_exists_with_same_image and already_exists:
         # Outdated container: It means it runs against an old image.
         # We're gonna have to stop and remove the old container, to let
         # the name available for the new one.
         if __opts__['test']:
-            comment = 'Will replace outdated container {0!r}'.format(name)
+            comment = 'Will replace outdated container \'{0}\''.format(name)
             return _ret_status(name=name, comment=comment)
         if is_running:
             stop_status = __salt__['docker.stop'](name)
             if not stop_status['status']:
-                return _invalid(comment='Failed to stop outdated container {0!r}'.format(name))
+                return _invalid(comment='Failed to stop outdated container \'{0}\''.format(name))
 
         remove_status = __salt__['docker.remove_container'](name)
         if not remove_status['status']:
-            return _invalid(comment='Failed to remove outdated container {0!r}'.format(name))
+            return _invalid(comment='Failed to remove outdated container \'{0}\''.format(name))
         already_exists = False
         # now it's clear, the name is available for the new container
 
     if __opts__['test']:
-        comment = 'Will create container {0!r}'.format(name)
+        comment = 'Will create container \'{0}\''.format(name)
         return _ret_status(name=name, comment=comment)
 
     # parse input data
@@ -1260,10 +1260,10 @@ def running(name,
             log.debug("Docker-io running:" + str(started))
             log.debug("Docker-io running:" + str(is_running))
             if is_running:
-                changes.append('Container {0!r} started.\n'.format(name))
+                changes.append('Container \'{0}\' started.\n'.format(name))
             else:
-                return _invalid(comment=('Container {0!r} cannot be started\n{1!s}'
+                return _invalid(comment=('Container \'{0}\' cannot be started\n{1!s}'
                                          .format(name, started['out'],)))
         else:
-            changes.append('Container {0!r} started.\n'.format(name))
+            changes.append('Container \'{0}\' started.\n'.format(name))
     return _valid(comment='\n'.join(changes), changes={name: True})

--- a/salt/states/eselect.py
+++ b/salt/states/eselect.py
@@ -53,18 +53,18 @@ def set_(name, target, module_parameter=None, action_parameter=None):
     old_target = __salt__['eselect.get_current_target'](name, module_parameter=module_parameter, action_parameter=action_parameter)
 
     if target == old_target:
-        ret['comment'] = 'Target {0!r} is already set on {1!r} module.'.format(
+        ret['comment'] = 'Target \'{0}\' is already set on \'{1}\' module.'.format(
             target, name
         )
     elif target not in __salt__['eselect.get_target_list'](name, action_parameter=action_parameter):
         ret['comment'] = (
-            'Target {0!r} is not available for {1!r} module.'.format(
+            'Target \'{0}\' is not available for \'{1}\' module.'.format(
                 target, name
             )
         )
         ret['result'] = False
     elif __opts__['test']:
-        ret['comment'] = 'Target {0!r} will be set on {1!r} module.'.format(
+        ret['comment'] = 'Target \'{0}\' will be set on \'{1}\' module.'.format(
             target, name
         )
         ret['result'] = None
@@ -72,12 +72,12 @@ def set_(name, target, module_parameter=None, action_parameter=None):
         result = __salt__['eselect.set_target'](name, target, module_parameter=module_parameter, action_parameter=action_parameter)
         if result:
             ret['changes'][name] = {'old': old_target, 'new': target}
-            ret['comment'] = 'Target {0!r} set on {1!r} module.'.format(
+            ret['comment'] = 'Target \'{0}\' set on \'{1}\' module.'.format(
                 target, name
             )
         else:
             ret['comment'] = (
-                'Target {0!r} failed to be set on {1!r} module.'.format(
+                'Target \'{0}\' failed to be set on \'{1}\' module.'.format(
                     target, name
                 )
             )

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2428,7 +2428,7 @@ def recurse(name,
 
     for precheck in source_list:
         if not precheck.startswith('salt://'):
-            return _error(ret, ('Invalid source {0!r} '
+            return _error(ret, ('Invalid source \'{0}\' '
                                 '(must be a salt:// URI)'.format(precheck)))
 
     # Select the first source in source_list that exists
@@ -2448,8 +2448,8 @@ def recurse(name,
                          if x.startswith(source_rel + '/'))):
         ret['result'] = False
         ret['comment'] = (
-            'The directory {0!r} does not exist on the salt fileserver '
-            'in saltenv {1!r}'.format(source, __env__)
+            'The directory \'{0}\' does not exist on the salt fileserver '
+            'in saltenv \'{1}\''.format(source, __env__)
         )
         return ret
 
@@ -4239,7 +4239,7 @@ def patch(name,
     # get cached file or copy it to cache
     cached_source_path = __salt__['cp.cache_file'](source, __env__)
     if not cached_source_path:
-        ret['comment'] = ('Unable to cache {0} from saltenv {1!r}'
+        ret['comment'] = ('Unable to cache {0} from saltenv \'{1}\''
                           .format(source, __env__))
         return ret
 
@@ -5167,7 +5167,7 @@ def mknod(name, ntype, major=0, minor=0, user=None, group=None, mode='0600'):
 
     else:
         ret['comment'] = (
-            'Node type unavailable: {0!r}. Available node types are '
+            'Node type unavailable: \'{0}\'. Available node types are '
             'character (\'c\'), block (\'b\'), and pipe (\'p\')'.format(ntype)
         )
 

--- a/salt/states/htpasswd.py
+++ b/salt/states/htpasswd.py
@@ -63,7 +63,7 @@ def user_exists(name, password=None, htpasswd_file=None, options='',
     if grep_ret['retcode'] != 0 or force:
         if __opts__['test']:
             ret['result'] = None
-            ret['comment'] = ('User {0!r} is set to be added to htpasswd '
+            ret['comment'] = ('User \'{0}\' is set to be added to htpasswd '
                               'file').format(name)
             ret['changes'] = {name: True}
             return ret

--- a/salt/states/memcached.py
+++ b/salt/states/memcached.py
@@ -67,15 +67,15 @@ def managed(name,
 
     if cur == value:
         ret['result'] = True
-        ret['comment'] = 'Key {0!r} does not need to be updated'.format(name)
+        ret['comment'] = 'Key \'{0}\' does not need to be updated'.format(name)
         return ret
 
     if __opts__['test']:
         ret['result'] = None
         if cur is None:
-            ret['comment'] = 'Key {0!r} would be added'.format(name)
+            ret['comment'] = 'Key \'{0}\' would be added'.format(name)
         else:
-            ret['comment'] = 'Value of key {0!r} would be changed'.format(name)
+            ret['comment'] = 'Value of key \'{0}\' would be changed'.format(name)
         return ret
 
     try:
@@ -86,13 +86,13 @@ def managed(name,
         ret['comment'] = str(exc)
     else:
         if ret['result']:
-            ret['comment'] = 'Successfully set key {0!r}'.format(name)
+            ret['comment'] = 'Successfully set key \'{0}\''.format(name)
             if cur is not None:
                 ret['changes'] = {'old': cur, 'new': value}
             else:
                 ret['changes'] = {'key added': name, 'value': value}
         else:
-            ret['comment'] = 'Failed to set key {0!r}'.format(name)
+            ret['comment'] = 'Failed to set key \'{0}\''.format(name)
     return ret
 
 
@@ -142,18 +142,18 @@ def absent(name,
         if cur is not None and cur != value:
             ret['result'] = True
             ret['comment'] = (
-                'Value of key {0!r} ({1!r}) is not {2!r}'
+                'Value of key \'{0}\' (\'{1}\') is not \'{2}\''
                 .format(name, cur, value)
             )
             return ret
     if cur is None:
         ret['result'] = True
-        ret['comment'] = 'Key {0!r} does not exist'.format(name)
+        ret['comment'] = 'Key \'{0}\' does not exist'.format(name)
         return ret
 
     if __opts__['test']:
         ret['result'] = None
-        ret['comment'] = 'Key {0!r} would be deleted'.format(name)
+        ret['comment'] = 'Key \'{0}\' would be deleted'.format(name)
         return ret
 
     try:
@@ -162,8 +162,8 @@ def absent(name,
         ret['comment'] = str(exc)
     else:
         if ret['result']:
-            ret['comment'] = 'Successfully deleted key {0!r}'.format(name)
+            ret['comment'] = 'Successfully deleted key \'{0}\''.format(name)
             ret['changes'] = {'key deleted': name, 'value': cur}
         else:
-            ret['comment'] = 'Failed to delete key {0!r}'.format(name)
+            ret['comment'] = 'Failed to delete key \'{0}\''.format(name)
     return ret

--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -102,7 +102,7 @@ def installed(name,
         installed_pkgs = __salt__['npm.list'](dir=dir, runas=user, env=env)
     except (CommandNotFoundError, CommandExecutionError) as err:
         ret['result'] = False
-        ret['comment'] = 'Error looking up {0!r}: {1}'.format(name, err)
+        ret['comment'] = 'Error looking up \'{0}\': {1}'.format(name, err)
         return ret
     else:
         installed_pkgs = dict((p, info)
@@ -167,13 +167,13 @@ def installed(name,
 
         comment_msg = []
         if pkgs_to_install:
-            comment_msg.append('NPM package(s) {0!r} are set to be installed'
+            comment_msg.append('NPM package(s) \'{0}\' are set to be installed'
                 .format(', '.join(pkgs_to_install)))
 
             ret['changes'] = {'old': [], 'new': pkgs_to_install}
 
         if pkgs_satisfied:
-            comment_msg.append('Package(s) {0!r} satisfied by {1}'
+            comment_msg.append('Package(s) \'{0}\' satisfied by {1}'
                 .format(', '.join(pkg_list), ', '.join(pkgs_satisfied)))
             ret['result'] = True
 
@@ -182,7 +182,7 @@ def installed(name,
 
     if not pkgs_to_install:
         ret['result'] = True
-        ret['comment'] = ('Package(s) {0!r} satisfied by {1}'
+        ret['comment'] = ('Package(s) \'{0}\' satisfied by {1}'
                 .format(', '.join(pkg_list), ', '.join(pkgs_satisfied)))
         return ret
 
@@ -198,18 +198,18 @@ def installed(name,
         call = __salt__['npm.install'](**cmd_args)
     except (CommandNotFoundError, CommandExecutionError) as err:
         ret['result'] = False
-        ret['comment'] = 'Error installing {0!r}: {1}'.format(
+        ret['comment'] = 'Error installing \'{0}\': {1}'.format(
                 ', '.join(pkg_list), err)
         return ret
 
     if call and (isinstance(call, list) or isinstance(call, dict)):
         ret['result'] = True
         ret['changes'] = {'old': [], 'new': pkgs_to_install}
-        ret['comment'] = 'Package(s) {0!r} successfully installed'.format(
+        ret['comment'] = 'Package(s) \'{0}\' successfully installed'.format(
                 ', '.join(pkgs_to_install))
     else:
         ret['result'] = False
-        ret['comment'] = 'Could not install package(s) {0!r}'.format(
+        ret['comment'] = 'Could not install package(s) \'{0}\''.format(
                 ', '.join(pkg_list))
 
     return ret
@@ -236,26 +236,26 @@ def removed(name,
         installed_pkgs = __salt__['npm.list'](dir=dir)
     except (CommandExecutionError, CommandNotFoundError) as err:
         ret['result'] = False
-        ret['comment'] = 'Error uninstalling {0!r}: {1}'.format(name, err)
+        ret['comment'] = 'Error uninstalling \'{0}\': {1}'.format(name, err)
         return ret
 
     if name not in installed_pkgs:
         ret['result'] = True
-        ret['comment'] = 'Package {0!r} is not installed'.format(name)
+        ret['comment'] = 'Package \'{0}\' is not installed'.format(name)
         return ret
 
     if __opts__['test']:
         ret['result'] = None
-        ret['comment'] = 'Package {0!r} is set to be removed'.format(name)
+        ret['comment'] = 'Package \'{0}\' is set to be removed'.format(name)
         return ret
 
     if __salt__['npm.uninstall'](pkg=name, dir=dir, runas=user):
         ret['result'] = True
         ret['changes'][name] = 'Removed'
-        ret['comment'] = 'Package {0!r} was successfully removed'.format(name)
+        ret['comment'] = 'Package \'{0}\' was successfully removed'.format(name)
     else:
         ret['result'] = False
-        ret['comment'] = 'Error removing package {0!r}'.format(name)
+        ret['comment'] = 'Error removing package \'{0}\''.format(name)
 
     return ret
 
@@ -280,7 +280,7 @@ def bootstrap(name,
             call = __salt__['npm.install'](dir=name, runas=user, pkg=None, silent=silent, dry_run=True)
         except (CommandNotFoundError, CommandExecutionError) as err:
             ret['result'] = False
-            ret['comment'] = 'Error Bootstrapping {0!r}: {1}'.format(name, err)
+            ret['comment'] = 'Error Bootstrapping \'{0}\': {1}'.format(name, err)
             return ret
         ret['result'] = None
         ret['changes'] = {'old': [], 'new': call}
@@ -291,7 +291,7 @@ def bootstrap(name,
         call = __salt__['npm.install'](dir=name, runas=user, pkg=None, silent=silent)
     except (CommandNotFoundError, CommandExecutionError) as err:
         ret['result'] = False
-        ret['comment'] = 'Error Bootstrapping {0!r}: {1}'.format(name, err)
+        ret['comment'] = 'Error Bootstrapping \'{0}\': {1}'.format(name, err)
         return ret
 
     if not call:

--- a/salt/states/nxos.py
+++ b/salt/states/nxos.py
@@ -7,6 +7,7 @@ State module for Cisco NX OS Switches Proxy minions
 For documentation on setting up the nxos proxy minion look in the documentation
 for :doc:`salt.proxy.nxos</ref/proxy/all/salt.proxy.nxos>`.
 '''
+from __future__ import absolute_import
 import re
 
 

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -151,7 +151,7 @@ def _check_pkg_version_format(pkg):
             )
             return ret
         ret['comment'] = (
-            'pip raised an exception while parsing {0!r}: {1}'.format(
+            'pip raised an exception while parsing \'{0}\': {1}'.format(
                 pkg, exc
             )
         )
@@ -195,8 +195,7 @@ def _check_if_installed(prefix, state_pkg_name, version_spec,
         prefix_realname = _find_key(prefix, pip_list)
     except (CommandNotFoundError, CommandExecutionError) as err:
         ret['result'] = None
-        ret['comment'] = 'Error installing {0!r}: {1}'.format(state_pkg_name,
-                                                              err)
+        ret['comment'] = 'Error installing \'{0}\': {1}'.format(state_pkg_name, err)
         return ret
 
     # If the package was already installed, check
@@ -577,8 +576,8 @@ def installed(name,
     if repo is not None:
         msg = ('The \'repo\' argument to pip.installed is deprecated and will '
                'be removed in Salt {version}. Please use \'name\' instead. '
-               'The current value for name, {0!r} will be replaced by the '
-               'value of repo, {1!r}'.format(
+               'The current value for name, \'{0}\' will be replaced by the '
+               'value of repo, \'{1}\''.format(
                    name,
                    repo,
                    version=_SaltStackVersion.from_name('Lithium').formatted_version
@@ -617,7 +616,7 @@ def installed(name,
             if requirements:
                 # TODO: Check requirements file against currently-installed
                 # packages to provide more accurate state output.
-                comments.append('Requirements file {0!r} will be '
+                comments.append('Requirements file \'{0}\' will be '
                                 'processed.'.format(requirements))
             if editable:
                 comments.append(

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1761,7 +1761,7 @@ def latest(
     if minion_os == 'Gentoo' and watch_flags:
         for pkg in desired_pkgs:
             if not avail[pkg] and not cur[pkg]:
-                msg = 'No information found for {0!r}.'.format(pkg)
+                msg = 'No information found for \'{0}\'.'.format(pkg)
                 log.error(msg)
                 problems.append(msg)
             else:

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -428,7 +428,7 @@ def managed(name, ppa=None, **kwargs):
     except Exception as exc:
         ret['result'] = False
         ret['comment'] = \
-            'Failed to confirm config of repo {0!r}: {1}'.format(name, exc)
+            'Failed to confirm config of repo \'{0}\': {1}'.format(name, exc)
 
     # Clear cache of available packages, if present, since changes to the
     # repositories may change the packages that are available.
@@ -513,7 +513,7 @@ def absent(name, **kwargs):
     except CommandExecutionError as exc:
         ret['result'] = False
         ret['comment'] = \
-            'Failed to configure repo {0!r}: {1}'.format(name, exc)
+            'Failed to configure repo \'{0}\': {1}'.format(name, exc)
         return ret
 
     if not repo:
@@ -522,7 +522,7 @@ def absent(name, **kwargs):
         return ret
 
     if __opts__['test']:
-        ret['comment'] = ('Package repo {0!r} will be removed. This may '
+        ret['comment'] = ('Package repo \'{0}\' will be removed. This may '
                           'cause pkg states to behave differently than stated '
                           'if this action is repeated without test=True, due '
                           'to the differences in the configured repositories.'

--- a/salt/states/supervisord.py
+++ b/salt/states/supervisord.py
@@ -121,7 +121,7 @@ def running(name,
                     # Process group
                     if len(to_start) == len(matches):
                         ret['comment'] = (
-                            'All services in group {0!r} will be started'
+                            'All services in group \'{0}\' will be started'
                             .format(name)
                         )
                     else:
@@ -136,7 +136,7 @@ def running(name,
                 if name.endswith(':'):
                     # Process group
                     ret['comment'] = (
-                        'All services in group {0!r} are already running'
+                        'All services in group \'{0}\' are already running'
                         .format(name)
                     )
                 else:
@@ -146,7 +146,7 @@ def running(name,
             ret['result'] = None
             # Process/group needs to be added
             if name.endswith(':'):
-                _type = 'Group {0!r}'.format(name)
+                _type = 'Group \'{0}\''.format(name)
             else:
                 _type = 'Service {0}'.format(name)
             ret['comment'] = '{0} will be added and started'.format(_type)

--- a/salt/states/timezone.py
+++ b/salt/states/timezone.py
@@ -63,7 +63,7 @@ def system(name, utc=True):
     except (SaltInvocationError, CommandExecutionError) as exc:
         ret['result'] = False
         ret['comment'] = (
-            'Unable to compare desired timezone {0!r} to system timezone: {1}'
+            'Unable to compare desired timezone \'{0}\' to system timezone: {1}'
             .format(name, exc)
         )
         return ret

--- a/salt/states/virtualenv_mod.py
+++ b/salt/states/virtualenv_mod.py
@@ -144,7 +144,7 @@ def managed(name,
         if not cached_requirements:
             ret.update({
                 'result': False,
-                'comment': 'pip requirements file {0!r} not found'.format(
+                'comment': 'pip requirements file \'{0}\' not found'.format(
                     requirements
                 )
             })

--- a/salt/states/win_network.py
+++ b/salt/states/win_network.py
@@ -244,7 +244,7 @@ def managed(name,
         'name': name,
         'changes': {},
         'result': True,
-        'comment': 'Interface {0!r} is up to date.'.format(name)
+        'comment': 'Interface \'{0}\' is up to date.'.format(name)
     }
 
     dns_proto = str(dns_proto).lower()
@@ -269,12 +269,12 @@ def managed(name,
         if __salt__['ip.is_enabled'](name):
             if __opts__['test']:
                 ret['result'] = None
-                ret['comment'] = ('Interface {0!r} will be disabled'
+                ret['comment'] = ('Interface \'{0}\' will be disabled'
                                   .format(name))
             else:
                 ret['result'] = __salt__['ip.disable'](name)
                 if not ret['result']:
-                    ret['comment'] = ('Failed to disable interface {0!r}'
+                    ret['comment'] = ('Failed to disable interface \'{0}\''
                                       .format(name))
         else:
             ret['comment'] += ' (already disabled)'
@@ -287,13 +287,13 @@ def managed(name,
         if not currently_enabled:
             if __opts__['test']:
                 ret['result'] = None
-                ret['comment'] = ('Interface {0!r} will be enabled'
+                ret['comment'] = ('Interface \'{0}\' will be enabled'
                                   .format(name))
             else:
                 result = __salt__['ip.enable'](name)
                 if not result:
                     ret['result'] = False
-                    ret['comment'] = ('Failed to enable interface {0!r} to '
+                    ret['comment'] = ('Failed to enable interface \'{0}\' to '
                                       'make changes'.format(name))
                     return ret
 
@@ -308,7 +308,7 @@ def managed(name,
         if not old:
             ret['result'] = False
             ret['comment'] = ('Unable to get current configuration for '
-                              'interface {0!r}'.format(name))
+                              'interface \'{0}\''.format(name))
             return ret
 
         changes = _changes(old,
@@ -350,7 +350,7 @@ def managed(name,
 
             ret['result'] = None
             ret['comment'] = ('The following changes will be made to '
-                              'interface {0!r}: {1}'
+                              'interface \'{0}\': {1}'
                               .format(name, ' '.join(comments)))
             return ret
 
@@ -389,8 +389,8 @@ def managed(name,
         if _changes(new, dns_proto, dns_servers, ip_proto, ip_addrs, gateway):
             ret['result'] = False
             ret['comment'] = ('Failed to set desired configuration settings '
-                              'for interface {0!r}'.format(name))
+                              'for interface \'{0}\''.format(name))
         else:
             ret['comment'] = ('Successfully updated configuration for '
-                              'interface {0!r}'.format(name))
+                              'interface \'{0}\''.format(name))
         return ret

--- a/salt/states/win_system.py
+++ b/salt/states/win_system.py
@@ -53,7 +53,7 @@ def computer_desc(name):
     ret = {'name': name,
            'changes': {},
            'result': True,
-           'comment': 'Computer description already set to {0!r}'.format(name)}
+           'comment': 'Computer description already set to \'{0}\''.format(name)}
 
     before_desc = __salt__['system.get_computer_desc']()
 
@@ -62,19 +62,19 @@ def computer_desc(name):
 
     if __opts__['test']:
         ret['result'] = None
-        ret['comment'] = ('Computer description will be changed to {0!r}'
+        ret['comment'] = ('Computer description will be changed to \'{0}\''
                           .format(name))
         return ret
 
     result = __salt__['system.set_computer_desc'](name)
     if result['Computer Description'] == name:
-        ret['comment'] = ('Computer description successfully changed to {0!r}'
+        ret['comment'] = ('Computer description successfully changed to \'{0}\''
                           .format(name))
         ret['changes'] = {'old': before_desc, 'new': name}
     else:
         ret['result'] = False
         ret['comment'] = ('Unable to set computer description to '
-                          '{0!r}'.format(name))
+                          '\'{0}\''.format(name))
     return ret
 
 computer_description = salt.utils.alias_function(computer_desc, 'computer_description')
@@ -93,7 +93,7 @@ def computer_name(name):
     ret = {'name': name,
            'changes': {},
            'result': True,
-           'comment': 'Computer name already set to {0!r}'.format(name)}
+           'comment': 'Computer name already set to \'{0}\''.format(name)}
 
     before_name = __salt__['system.get_computer_name']()
     pending_name = __salt__['system.get_pending_computer_name']()
@@ -101,14 +101,14 @@ def computer_name(name):
     if before_name == name and pending_name is None:
         return ret
     elif pending_name == name.upper():
-        ret['comment'] = ('The current computer name is {0!r}, but will be '
-                          'changed to {1!r} on the next reboot'
+        ret['comment'] = ('The current computer name is \'{0}\', but will be '
+                          'changed to \'{1}\' on the next reboot'
                           .format(before_name, name))
         return ret
 
     if __opts__['test']:
         ret['result'] = None
-        ret['comment'] = 'Computer name will be changed to {0!r}'.format(name)
+        ret['comment'] = 'Computer name will be changed to \'{0}\''.format(name)
         return ret
 
     result = __salt__['system.set_computer_name'](name)
@@ -117,13 +117,13 @@ def computer_name(name):
         after_pending = result['Computer Name'].get('Pending')
         if ((after_pending is not None and after_pending == name) or
                 (after_pending is None and after_name == name)):
-            ret['comment'] = 'Computer name successfully set to {0!r}'.format(name)
+            ret['comment'] = 'Computer name successfully set to \'{0}\''.format(name)
             if after_pending is not None:
                 ret['comment'] += ' (reboot required for change to take effect)'
         ret['changes'] = {'old': before_name, 'new': name}
     else:
         ret['result'] = False
-        ret['comment'] = 'Unable to set computer name to {0!r}'.format(name)
+        ret['comment'] = 'Unable to set computer name to \'{0}\''.format(name)
     return ret
 
 
@@ -203,7 +203,7 @@ def join_domain(name, username=None, password=None, account_ou=None,
     ret = {'name': name,
            'changes': {},
            'result': True,
-           'comment': 'Computer already added to {0!r}'.format(name)}
+           'comment': 'Computer already added to \'{0}\''.format(name)}
 
     # Set name to domain, needed for the add to domain module.
     domain = name
@@ -217,20 +217,20 @@ def join_domain(name, username=None, password=None, account_ou=None,
         current_domain = None
 
     if domain == current_domain:
-        ret['comment'] = 'Computer already added to {0!r}'.format(name)
+        ret['comment'] = 'Computer already added to \'{0}\''.format(name)
         return ret
 
     if __opts__['test']:
         ret['result'] = None
-        ret['comment'] = 'Computer will be added to {0!r}'.format(name)
+        ret['comment'] = 'Computer will be added to \'{0}\''.format(name)
         return ret
 
     result = __salt__['system.join_domain'](domain, username, password,
                                             account_ou, account_exists,
                                             restart)
     if result is not False:
-        ret['comment'] = 'Computer added to {0!r}'.format(name)
+        ret['comment'] = 'Computer added to \'{0}\''.format(name)
     else:
-        ret['comment'] = 'Computer failed to join {0!r}'.format(name)
+        ret['comment'] = 'Computer failed to join \'{0}\''.format(name)
         ret['result'] = False
     return ret

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -2018,17 +2018,13 @@ def win_cmd(command, **kwargs):
 
         if logging_command is None:
             log.debug(
-                'Executing command(PID {0}): {1!r}'.format(
-                    proc.pid,
-                    command
-                )
+                'Executing command(PID %s): \'%s\'',
+                proc.pid, command
             )
         else:
             log.debug(
-                'Executing command(PID {0}): {1!r}'.format(
-                    proc.pid,
-                    logging_command
-                )
+                'Executing command(PID %s): \'%s\'',
+                proc.pid, logging_command
             )
 
         proc.poll_and_read_until_finish()
@@ -2036,7 +2032,7 @@ def win_cmd(command, **kwargs):
         return proc.returncode
     except Exception as err:
         log.error(
-            'Failed to execute command {0!r}: {1}\n'.format(
+            'Failed to execute command \'{0}\': {1}\n'.format(
                 logging_command,
                 err
             ),

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -154,10 +154,10 @@ class PrintableDict(OrderedDict):
         for key, value in six.iteritems(self):
             if isinstance(value, six.string_types):
                 # keeps quotes around strings
-                output.append('{0!r}: {1!r}'.format(key, value))
+                output.append('{0!r}: {1!r}'.format(key, value))  # pylint: disable=repr-flag-used-in-string
             else:
                 # let default output
-                output.append('{0!r}: {1!s}'.format(key, value))
+                output.append('{0!r}: {1!s}'.format(key, value))  # pylint: disable=repr-flag-used-in-string
         return '{' + ', '.join(output) + '}'
 
     def __repr__(self):  # pylint: disable=W0221
@@ -165,7 +165,7 @@ class PrintableDict(OrderedDict):
         for key, value in six.iteritems(self):
             # Raw string formatter required here because this is a repr
             # function.
-            output.append('{0!r}: {1!r}'.format(key, value))
+            output.append('{0!r}: {1!r}'.format(key, value))  # pylint: disable=repr-flag-used-in-string
         return '{' + ', '.join(output) + '}'
 
 

--- a/salt/utils/nb_popen.py
+++ b/salt/utils/nb_popen.py
@@ -90,20 +90,11 @@ class NonBlockingPopen(subprocess.Popen):
             self._stderr_logger_name_.format(pid=self.pid)
         )
 
-        if logging_command is None:
-            log.info(
-                'Running command under pid {0}: {1!r}'.format(
-                    self.pid,
-                    *args
-                )
-            )
-        else:
-            log.info(
-                'Running command under pid {0}: {1!r}'.format(
-                    self.pid,
-                    logging_command
-                )
-            )
+        log.info(
+            'Running command under pid %s: \'%s\'',
+            self.pid,
+            *args if logging_command is None else logging_command
+        )
 
     def recv(self, maxsize=None):
         return self._recv('stdout', maxsize)

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -3,6 +3,7 @@
 Various functions to be used by windows during start up and to monkey patch
 missing functions in other modules
 '''
+from __future__ import absolute_import
 from salt.exceptions import CommandExecutionError
 
 # Import Salt Libs

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -31,10 +31,6 @@ try:
     import pwd
 except ImportError:
     pass
-try:
-    import SocketServer as socketserver
-except ImportError:
-    import socketserver
 
 STATE_FUNCTION_RUNNING_RE = re.compile(
     r'''The function (?:"|')(?P<state_func>.*)(?:"|') is running as PID '''
@@ -83,6 +79,8 @@ except ImportError:
 import yaml
 import msgpack
 import salt.ext.six as six
+import salt.ext.six.moves.socketserver as socketserver  # pylint: disable=no-name-in-module
+
 if salt.utils.is_windows():
     import win32api
 

--- a/tests/integration/shell/minion.py
+++ b/tests/integration/shell/minion.py
@@ -22,10 +22,14 @@ import logging
 from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../')
 
+
 # Import salt libs
 import integration
 from integration.utils import testprogram
 import salt.utils
+
+# Import ext libs
+from salt.ext.six.moves import zip
 
 log = logging.getLogger(__name__)
 

--- a/tests/integration/states/file.py
+++ b/tests/integration/states/file.py
@@ -417,7 +417,7 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
             '''
             Return a string octal representation of the permissions for name
             '''
-            return oct(os.stat(name).st_mode & 0777)
+            return oct(os.stat(name).st_mode & 0o777)
 
         top = os.path.join(integration.TMP, 'top_dir')
         sub = os.path.join(top, 'sub_dir')

--- a/tests/integration/utils/test_reactor.py
+++ b/tests/integration/utils/test_reactor.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
 import time
 import shutil
 import tempfile

--- a/tests/integration/utils/testprogram.py
+++ b/tests/integration/utils/testprogram.py
@@ -4,6 +4,7 @@ Classes for starting/stopping/status salt daemons, auxiliary
 scripts, generic commands.
 '''
 
+from __future__ import absolute_import
 import atexit
 import copy
 from datetime import datetime, timedelta
@@ -20,10 +21,10 @@ import time
 
 import yaml
 
-import salt.ext.six as six
 import salt.utils.process
 import salt.utils.psutil_compat as psutils
 from salt.defaults import exitcodes
+from salt.ext import six
 
 from salttesting import TestCase
 
@@ -343,14 +344,11 @@ class TestSaltProgramMeta(type):
         return super(TestSaltProgramMeta, mcs).__new__(mcs, name, bases, attrs)
 
 
-class TestSaltProgram(TestProgram):
+class TestSaltProgram(six.with_metaclass(TestSaltProgramMeta, TestProgram)):
     '''
     This is like TestProgram but with some functions to run a salt-specific
     auxiliary program.
     '''
-
-    __metaclass__ = TestSaltProgramMeta
-
     script = ''
 
     def __init__(self, *args, **kwargs):
@@ -391,7 +389,7 @@ class TestSaltProgram(TestProgram):
             sdo.write(''.join(lines))
             sdo.flush()
 
-        os.chmod(self.script_path, 0755)
+        os.chmod(self.script_path, 0o755)
 
 
 class TestProgramSaltCall(TestSaltProgram):
@@ -573,13 +571,10 @@ class TestSaltDaemonMeta(TestSaltProgramMeta, type):
         return super(TestSaltDaemonMeta, mcs).__new__(mcs, name, bases, attrs)
 
 
-class TestSaltDaemon(TestDaemon, TestSaltProgram):
+class TestSaltDaemon(six.with_metaclass(TestSaltDaemonMeta, TestDaemon, TestSaltProgram)):
     '''
     A class to run arbitrary salt daemons (master, minion, syndic, etc.)
     '''
-
-    __metaclass__ = TestSaltDaemonMeta
-
     config_types = (dict,)
     config_attrs = {
         'root_dir': None,

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -4,6 +4,7 @@ A lightweight version of tests.integration for testing of unit tests
 
 This test class will not import the salt minion, runner and config modules.
 '''
+from __future__ import absolute_import
 from salttesting.case import TestCase
 from salttesting.parser import SaltTestcaseParser
 

--- a/tests/unit/context_test.py
+++ b/tests/unit/context_test.py
@@ -104,7 +104,7 @@ class ContextDictTests(AsyncTestCase):
 
         wait_iterator = tornado.gen.WaitIterator(*futures)
         while not wait_iterator.done():
-            r = yield wait_iterator.next()
+            r = yield wait_iterator.next()  # pylint: disable=incompatible-py3-code
             self.assertEqual(r[0], r[1])  # verify that the global value remails
             self.assertEqual(r[2], r[3])  # verify that the override sticks locally
             self.assertEqual(r[3], r[4])  # verify that the override sticks across coroutines

--- a/tests/unit/modules/boto_apigateway_test.py
+++ b/tests/unit/modules/boto_apigateway_test.py
@@ -31,6 +31,8 @@ try:
 except ImportError:
     HAS_BOTO = False
 
+from salt.ext.six.moves import range
+
 # pylint: enable=import-error,no-name-in-module
 
 # the boto_lambda module relies on the connect_to_region() method

--- a/tests/unit/modules/boto_cognitoidentity_test.py
+++ b/tests/unit/modules/boto_cognitoidentity_test.py
@@ -3,6 +3,7 @@
 # Import Python libs
 from __future__ import absolute_import
 from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module
+import logging
 import random
 import string
 
@@ -18,11 +19,10 @@ import salt.config
 import salt.loader
 from salt.modules import boto_cognitoidentity
 
-# Import 3rd-party libs
-import logging
-
 # Import Mock libraries
 from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
+
+# Import 3rd-party libs
 
 # pylint: disable=import-error,no-name-in-module
 try:
@@ -31,6 +31,8 @@ try:
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
+
+from salt.ext.six.moves import range  # pylint: disable=import-error
 
 # pylint: enable=import-error,no-name-in-module
 

--- a/tests/unit/modules/boto_elasticsearch_domain_test.py
+++ b/tests/unit/modules/boto_elasticsearch_domain_test.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import
 from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module
 import copy
+import logging
 import random
 import string
 
@@ -19,11 +20,10 @@ import salt.config
 import salt.loader
 from salt.modules import boto_elasticsearch_domain
 
-# Import 3rd-party libs
-import logging
-
 # Import Mock libraries
 from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
+
+# Import 3rd-party libs
 
 # pylint: disable=import-error,no-name-in-module
 try:
@@ -32,6 +32,8 @@ try:
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
+
+from salt.ext.six.moves import range
 
 # pylint: enable=import-error,no-name-in-module
 

--- a/tests/unit/modules/k8s_test.py
+++ b/tests/unit/modules/k8s_test.py
@@ -20,6 +20,8 @@ ensure_in_syspath('../../')
 # Import Salt libs
 import salt.modules.k8s as k8s
 
+# Import 3rd-party libs
+from salt.ext.six.moves import range  # pylint: disable=import-error
 
 TestCase.maxDiff = None
 

--- a/tests/unit/modules/reg_win_test.py
+++ b/tests/unit/modules/reg_win_test.py
@@ -17,6 +17,7 @@ from salttesting import TestCase, skipIf
 from salttesting.helpers import destructiveTest
 # Import Salt Libs
 from salt.modules import reg as win_mod_reg
+from salt.ext import six
 try:
     from salt.ext.six.moves import winreg as _winreg  # pylint: disable=import-error,no-name-in-module
     NO_WINDOWS_MODULES = False
@@ -30,7 +31,7 @@ PY2 = sys.version_info[0] == 2
 TIMEINT = int(time.time())
 
 if PY2:
-    TIME_INT_UNICODE = unicode(TIMEINT)
+    TIME_INT_UNICODE = six.text_type(TIMEINT)
     TIMESTR = time.strftime('%X %x %Z').decode('utf-8')
 else:
     TIMESTR = time.strftime('%X %x %Z')

--- a/tests/unit/states/boto_apigateway_test.py
+++ b/tests/unit/states/boto_apigateway_test.py
@@ -34,6 +34,8 @@ try:
 except ImportError:
     HAS_BOTO = False
 
+from salt.ext.six.moves import range
+
 # pylint: enable=import-error,no-name-in-module
 
 # the boto_apigateway module relies on the connect_to_region() method

--- a/tests/unit/states/boto_cognitoidentity_test.py
+++ b/tests/unit/states/boto_cognitoidentity_test.py
@@ -34,6 +34,8 @@ try:
 except ImportError:
     HAS_BOTO = False
 
+from salt.ext.six.moves import range
+
 # pylint: enable=import-error,no-name-in-module
 
 # the boto_cognitoidentity module relies on the connect_to_region() method

--- a/tests/unit/states/boto_elasticsearch_domain_test.py
+++ b/tests/unit/states/boto_elasticsearch_domain_test.py
@@ -3,6 +3,7 @@
 # Import Python libs
 from __future__ import absolute_import
 from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module
+import logging
 import random
 import string
 
@@ -16,9 +17,6 @@ ensure_in_syspath('../../')
 # Import Salt libs
 import salt.config
 import salt.loader
-
-# Import 3rd-party libs
-import logging
 
 # Import Mock libraries
 from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
@@ -34,6 +32,8 @@ try:
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
+
+from salt.ext.six.moves import range
 
 # pylint: enable=import-error,no-name-in-module,unused-import
 

--- a/tests/unit/states/composer_test.py
+++ b/tests/unit/states/composer_test.py
@@ -61,7 +61,7 @@ class ComposerTestCase(TestCase):
                 mock = MagicMock(side_effect=[SaltException, {}])
                 with patch.dict(composer.__salt__, {'composer.install': mock}):
                     comt = ("Error executing composer in "
-                            "''CURL'': SaltException('',)")
+                            "'CURL': ")
                     ret.update({'comment': comt, 'result': False,
                                 'changes': {}})
                     self.assertDictEqual(composer.installed(name), ret)
@@ -99,7 +99,7 @@ class ComposerTestCase(TestCase):
                 mock = MagicMock(side_effect=[SaltException, {}])
                 with patch.dict(composer.__salt__, {'composer.update': mock}):
                     comt = ("Error executing composer in "
-                            "''CURL'': SaltException('',)")
+                            "'CURL': ")
                     ret.update({'comment': comt, 'result': False,
                                 'changes': {}})
                     self.assertDictEqual(composer.update(name), ret)


### PR DESCRIPTION
Using repr will insert a `u` before the string in Python 2.

``` python
>>> u'something something {0!r}'.format(u'foo')
u"something something u'foo'"
```
