### PR TITLE
Make `module.ssh.recv_known_host()` more resilient against hosts not returning a key

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -839,7 +839,11 @@ def recv_known_host(hostname,
         cmd.append('-H')
     cmd.extend(['-T', str(timeout)])
     cmd.append(hostname)
-    lines = __salt__['cmd.run'](cmd, python_shell=False).splitlines()
+    lines = None
+    attempts = 5
+    while not lines and attempts > 0:
+        attempts = attempts - 1
+        lines = __salt__['cmd.run'](cmd, python_shell=False).splitlines()
     known_hosts = list(_parse_openssh_output(lines))
     return known_hosts[0] if known_hosts else None
 


### PR DESCRIPTION
Some providers (esp. Bitbucket) have faulty git/SSH endpoints which
often simply return empty results. A previous attempt in Salt to improve
this by adding an optional timeout value didn't change much here, as it
just increased the time it took to return: nothing.

Repeating the request a few times until the host returns a value works
around this issue far more reliable.

Signed-off-by: Elias Probst mail@eliasprobst.eu
