### PR TITLE
Don't use binary mode for cmdmod.exec_code

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2272,7 +2272,7 @@ def exec_code_all(lang, code, cwd=None):
         salt '*' cmd.exec_code_all ruby 'puts "cheese"'
     '''
     codefile = salt.utils.mkstemp()
-    with salt.utils.fopen(codefile, 'w+t') as fp_:
+    with salt.utils.fopen(codefile, 'w+t', binary=False) as fp_:
         fp_.write(code)
     cmd = [lang, codefile]
     ret = run_all(cmd, cwd=cwd, python_shell=False)


### PR DESCRIPTION
### What does this PR do?

Fixes cmdmod.exec_code on Windows machines due to invalid file mode.
### What issues does this PR fix or reference?

Fixes #34196
### Previous Behavior

``` python
 The minion function caused an exception: Traceback (most recent call last):
      File "c:\salt\bin\lib\site-packages\salt\minion.py", line 1318, in _thread_return
        return_data = executor.execute()
      File "c:\salt\bin\lib\site-packages\salt\executors\direct_call.py", line 28, in execute
        return self.func(*self.args, **self.kwargs)
      File "c:\salt\bin\lib\site-packages\salt\modules\cmdmod.py", line 2296, in exec_code_all
        with salt.utils.fopen(codefile, 'w+t') as fp_:
      File "c:\salt\bin\lib\site-packages\salt\utils\__init__.py", line 1209, in fopen
        fhandle = open(*args, **kwargs)
    ValueError: Invalid mode ('w+tb')
```
### New Behavior

Successfully executed
### Tests written?

Not required
