### PR TITLE
Suffix temp file with .sr1 and add mandatory argument when executing PowerShell script

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2271,10 +2271,21 @@ def exec_code_all(lang, code, cwd=None):
 
         salt '*' cmd.exec_code_all ruby 'puts "cheese"'
     '''
-    codefile = salt.utils.mkstemp()
+    powershell = lang.lower().startswith("powershell")
+
+    if powershell:
+        codefile = salt.utils.mkstemp(suffix=".ps1")
+    else:
+        codefile = salt.utils.mkstemp()
+
     with salt.utils.fopen(codefile, 'w+t', binary=False) as fp_:
         fp_.write(code)
-    cmd = [lang, codefile]
+
+    if powershell:
+        cmd = [lang, "-File", codefile]
+    else:
+        cmd = [lang, codefile]
+
     ret = run_all(cmd, cwd=cwd, python_shell=False)
     os.remove(codefile)
     return ret

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2272,7 +2272,7 @@ def exec_code_all(lang, code, cwd=None):
         salt '*' cmd.exec_code_all ruby 'puts "cheese"'
     '''
     codefile = salt.utils.mkstemp()
-    with salt.utils.fopen(codefile, 'w+t') as fp_:
+    with salt.utils.fopen(codefile, 'w+t', binary=False) as fp_:
         fp_.write(code)
     cmd = [lang, codefile]
     ret = run_all(cmd, cwd=cwd, python_shell=False)


### PR DESCRIPTION
### What does this PR do?

Suffixes created temp file .sr1 and adds -File argument when executing PowerShell script via cmdmod.exec_code / exec_code_all
### What issues does this PR fix or reference?

Fixes #34199  and requires #34198 for proper work.
### Previous Behavior

PowerShell script could not be executed due to restrictions on end system (script has to end with extension sr1 and full command for executing is 'powershell -File script.sr1'
### New Behavior

Execution works properly
### Tests written?

No
