### PR TITLE
Fix a pair of gitfs bugs

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -153,6 +153,17 @@ def is_empty(filename):
         return False
 
 
+def is_hex(value):
+    '''
+    Returns True if value is a hexidecimal string, otherwise returns False
+    '''
+    try:
+        int(value, 16)
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
 def get_color_theme(theme):
     '''
     Return the color theme to use

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -1835,9 +1835,7 @@ class Dulwich(GitProvider):  # pylint: disable=abstract-method
         # SHA-1 hashes.
         if not self.env_is_exposed(tgt_env):
             return None
-        try:
-            int(tgt_ref, 16)
-        except ValueError:
+        elif not salt.utils.is_hex(tgt_ref):
             # Not hexidecimal, likely just a non-matching environment
             return None
 

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -1440,7 +1440,7 @@ class Pygit2(GitProvider):
             return None
         try:
             commit = self.repo.revparse_single(tgt_ref)
-        except (KeyError, TypeError):
+        except (KeyError, TypeError, ValueError):
             # Not a valid commit, likely not a commit SHA
             pass
         else:

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -2535,7 +2535,8 @@ class GitFS(GitBase):
         '''
         fnd = {'path': '',
                'rel': ''}
-        if os.path.isabs(path) or tgt_env not in self.envs():
+        if os.path.isabs(path) or \
+                (not salt.utils.is_hex(tgt_env) and tgt_env not in self.envs()):
             return fnd
 
         dest = os.path.join(self.cache_root, 'refs', tgt_env, path)
@@ -2715,7 +2716,8 @@ class GitFS(GitBase):
             return cache_match
         if refresh_cache:
             ret = {'files': set(), 'symlinks': {}, 'dirs': set()}
-            if load['saltenv'] in self.envs():
+            if salt.utils.is_hex(load['saltenv']) \
+                    or load['saltenv'] in self.envs():
                 for repo in self.remotes:
                     repo_files, repo_symlinks = repo.file_list(load['saltenv'])
                     ret['files'].update(repo_files)
@@ -2761,7 +2763,8 @@ class GitFS(GitBase):
             )
             load['saltenv'] = load.pop('env')
 
-        if load['saltenv'] not in self.envs():
+        if not salt.utils.is_hex(load['saltenv']) \
+                and load['saltenv'] not in self.envs():
             return {}
         if 'prefix' in load:
             prefix = load['prefix'].strip('/')


### PR DESCRIPTION
This fixes a regression in which git SHAs were not being honored as fileserver environments, and also resolves a pygit2 corner-case.

Resolves #34212.
Resolves #34213.
