### PR TITLE
Fixes #34181 no more newlines in long yaml encodes

### DIFF
--- a/salt/utils/yamlencoding.py
+++ b/salt/utils/yamlencoding.py
@@ -16,7 +16,7 @@ def yaml_dquote(text):
     quote characters.
     '''
     with io.StringIO() as ostream:
-        yemitter = yaml.emitter.Emitter(ostream)
+        yemitter = yaml.emitter.Emitter(ostream, width=six.MAXSIZE)
         yemitter.write_double_quoted(six.text_type(text))
         return ostream.getvalue()
 
@@ -28,7 +28,7 @@ def yaml_squote(text):
     quote characters.
     '''
     with io.StringIO() as ostream:
-        yemitter = yaml.emitter.Emitter(ostream)
+        yemitter = yaml.emitter.Emitter(ostream, width=six.MAXSIZE)
         yemitter.write_single_quoted(six.text_type(text))
         return ostream.getvalue()
 

--- a/tests/unit/utils/utils_test.py
+++ b/tests/unit/utils/utils_test.py
@@ -547,9 +547,17 @@ class UtilsTestCase(TestCase):
         for teststr in (r'"\ []{}"',):
             self.assertEqual(teststr, yaml.safe_load(utils.yamlencoding.yaml_dquote(teststr)))
 
+    def test_yaml_dquote_doesNotAddNewLines(self):
+        teststr = '"' * 100
+        self.assertNotIn('\n', utils.yamlencoding.yaml_dquote(teststr))
+
     def test_yaml_squote(self):
         ret = utils.yamlencoding.yaml_squote(r'"')
         self.assertEqual(ret, r"""'"'""")
+
+    def test_yaml_squote_doesNotAddNewLines(self):
+        teststr = "'" * 100
+        self.assertNotIn('\n', utils.yamlencoding.yaml_squote(teststr))
 
     def test_yaml_encode(self):
         for testobj in (None, True, False, '[7, 5]', '"monkey"', 5, 7.5, "2014-06-02 15:30:29.7"):


### PR DESCRIPTION
### What does this PR do?

Allows for longer strings to be yaml encoded
### What issues does this PR fix or reference?
#34181
### Previous Behavior

New lines were inserted into the string being encoded
### Tests written?

Yes
