### PR TITLE
rsync state: Removed source existance check

### DIFF
--- a/salt/states/rsync.py
+++ b/salt/states/rsync.py
@@ -116,10 +116,7 @@ def synchronized(name, source,
 
     ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
 
-    if not os.path.exists(source):
-        ret['result'] = False
-        ret['comment'] = "Source directory {src} was not found.".format(src=source)
-    elif not os.path.exists(name) and not force and not prepare:
+    if not os.path.exists(name) and not force and not prepare:
         ret['result'] = False
         ret['comment'] = "Destination directory {dest} was not found.".format(dest=name)
     else:


### PR DESCRIPTION
### What does this PR do?

Rsync state bugfix
### What issues does this PR fix or reference?
#25251
### Previous Behavior

rsync.synchronized was failing if source has `rsync://` schema
### New Behavior

Local path existence check removed, so state will be executed
### Tests written?

No
