### PR TITLE
file.find module: fix handling of broken symlinks

### DIFF
--- a/salt/utils/find.py
+++ b/salt/utils/find.py
@@ -640,17 +640,24 @@ class Finder(object):
                     for criterion in self.criteria:
                         if fstat is None and criterion.requires() & _REQUIRES_STAT:
                             fullpath = os.path.join(dirpath, name)
-                            fstat = os.stat(fullpath)
+                            try:
+                                fstat = os.stat(fullpath)
+                            except OSError:
+                                fstat = os.lstat(fullpath)
                         if not criterion.match(dirpath, name, fstat):
                             matches = False
                             break
+
                     if matches:
                         if fullpath is None:
                             fullpath = os.path.join(dirpath, name)
                         for action in self.actions:
                             if (fstat is None and
                                     action.requires() & _REQUIRES_STAT):
-                                fstat = os.stat(fullpath)
+                                try:
+                                    fstat = os.stat(fullpath)
+                                except OSError:
+                                    fstat = os.lstat(fullpath)
                             result = action.execute(fullpath, fstat, test=self.test)
                             if result is not None:
                                 yield result


### PR DESCRIPTION
### What does this PR do?

Fixes `salt.modules.file.find` function to handle broken symlinks.
### Use Case

I would like get all symlinks in the directory, some of them are eventually broken (point to non-existent files).

Setup is very simple: standalone Salt Minion 2016.3.1 and following directory layout with broken symlink:

``` sh
cd /root
rm -f test*
ln -sf test test2
```

If I query the files just by name it works:

``` sh
salt-call --local file.find /root name='test*'
local:
    - /root/test2

```

But...
### Previous Behavior

If I would like to get only symlinks among all the files it fails:

``` sh
salt-call --local file.find /root name='test*' type=l 
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
OSError: [Errno 2] No such file or directory: '/root/test2'
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    salt_call()
  File "/usr/lib/python2.7/dist-packages/salt/scripts.py", line 345, in salt_call
    client.run()
  File "/usr/lib/python2.7/dist-packages/salt/cli/call.py", line 58, in run
    caller.run()
  File "/usr/lib/python2.7/dist-packages/salt/cli/caller.py", line 134, in run
    ret = self.call()
  File "/usr/lib/python2.7/dist-packages/salt/cli/caller.py", line 197, in call
    ret['return'] = func(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/modules/file.py", line 694, in find
    ret = [item for i in [finder.find(p) for p in glob.glob(os.path.expanduser(path))] for item in i]
  File "/usr/lib/python2.7/dist-packages/salt/utils/find.py", line 643, in find
    fstat = os.stat(fullpath)
OSError: [Errno 2] No such file or directory: '/root/test2'
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    salt_call()
  File "/usr/lib/python2.7/dist-packages/salt/scripts.py", line 345, in salt_call
    client.run()
  File "/usr/lib/python2.7/dist-packages/salt/cli/call.py", line 58, in run
    caller.run()
  File "/usr/lib/python2.7/dist-packages/salt/cli/caller.py", line 134, in run
    ret = self.call()
  File "/usr/lib/python2.7/dist-packages/salt/cli/caller.py", line 197, in call
    ret['return'] = func(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/modules/file.py", line 694, in find
    ret = [item for i in [finder.find(p) for p in glob.glob(os.path.expanduser(path))] for item in i]
  File "/usr/lib/python2.7/dist-packages/salt/utils/find.py", line 643, in find
    fstat = os.stat(fullpath)
OSError: [Errno 2] No such file or directory: '/root/test2'
```
### New Behavior

My PR fixes this and allows to delete such files:

``` sh
salt-call --local file.find /root name='test*' type=l
local:
    - /root/test2
salt-call --local file.find /root name='test*' delete=l
local:
    - /root/test2
```
### Tests written?

No
