### PR TITLE
Typo in dockerio doc

### DIFF
--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -75,7 +75,7 @@ Available Functions
         docker.running:
           - container: mysuperdocker
           - image: corp/mysuperdocker_img
-          - port_bindings:
+          - ports:
             - "5000/tcp":
                   HostIp: ""
                   HostPort: "5000"


### PR DESCRIPTION
### What does this PR do?

Fix a typo in dockerio doc: The key to bind port is `ports` and not `port_binding` , based on https://docs.saltstack.com/en/latest/ref/states/all/salt.states.dockerio.html#salt.states.dockerio.running
### What issues does this PR fix or reference?

Don't now :P
### Tests written?

No
