### PR TITLE
utils/parsers.py: disable minion multiprocessing logging if only runn…

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1702,8 +1702,14 @@ class MinionOptionParser(six.with_metaclass(OptionParserMeta, MasterOptionParser
     _setup_mp_logging_listener_ = True
 
     def setup_config(self):
-        return config.minion_config(self.get_config_file_path(),  # pylint: disable=no-member
+        opts = config.minion_config(self.get_config_file_path(),  # pylint: disable=no-member
                                     cache_minion_id=True)
+        # Optimization: disable multiprocessing logging if running as a
+        #               daemon, without engines and without multiprocessing
+        if not opts.get('engines') and not opts.get('multiprocessing', True) \
+                and self.options.daemon:  # pylint: disable=no-member
+            self._setup_mp_logging_listener_ = False
+        return opts
 
 
 class ProxyMinionOptionParser(six.with_metaclass(OptionParserMeta,


### PR DESCRIPTION
### What does this PR do?

Optimization for embedded: disable mp logging if there is only one process (avoid spawning a new salt-minion process for logging)
### What issues does this PR fix or reference?
### Previous Behavior

At the very minimum the salt-minion spawns 2 processes: one for mp logging and one for the minion itself
### New Behavior

If running as a daemon, with no engines, and with multiprocessing=false, disable mp logging
### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

…ing one process

If running as a daemon, without engines and with multiprocessing
disabled, disable multiprocess logging.

Signed-off-by: Alejandro del Castillo alejandro.delcastillo@ni.com
