### PR TITLE
Correct handling of min/maxdepth during file.find (#34217)

### DIFF
--- a/salt/utils/find.py
+++ b/salt/utils/find.py
@@ -143,6 +143,8 @@ _INTERVAL_REGEX = re.compile(r'''
                              ''',
                              flags=re.VERBOSE)
 
+_PATH_DEPTH_IGNORED = (os.path.sep, os.path.curdir, os.path.pardir)
+
 
 def _parse_interval(value):
     '''
@@ -675,8 +677,6 @@ class Finder(object):
             if result is not None:
                 yield result
 
-
-_PATH_DEPTH_IGNORED = (os.path.sep, os.path.curdir, os.path.pardir)
 
 def path_depth(path):
     depth = 0

--- a/salt/utils/find.py
+++ b/salt/utils/find.py
@@ -670,14 +670,16 @@ class Finder(object):
                 dirs[:] = []
 
 
+_PATH_DEPTH_IGNORED = (os.path.sep, os.path.curdir, os.path.pardir)
+
 def path_depth(path):
     depth = 0
     head = path
     while True:
         head, tail = os.path.split(head)
-        if not tail and (not head or head in (os.path.sep, os.path.curdir)):
+        if not tail and (not head or head in _PATH_DEPTH_IGNORED):
             break
-        if tail and tail != os.path.curdir:
+        if tail and tail not in _PATH_DEPTH_IGNORED:
             depth += 1
     return depth
 

--- a/salt/utils/find.py
+++ b/salt/utils/find.py
@@ -675,9 +675,9 @@ def path_depth(path):
     head = path
     while True:
         head, tail = os.path.split(head)
-        if not tail:
+        if not tail and (not head or head in (os.path.sep, os.path.curdir)):
             break
-        if tail != '.':
+        if tail and tail != os.path.curdir:
             depth += 1
     return depth
 

--- a/salt/utils/find.py
+++ b/salt/utils/find.py
@@ -630,9 +630,13 @@ class Finder(object):
         This method is a generator and should be repeatedly called
         until there are no more results.
         '''
+        if self.mindepth < 1:
+            yield path
+
         for dirpath, dirs, files in os.walk(path):
-            depth = dirpath[len(path) + len(os.path.sep):].count(os.path.sep)
-            if depth >= self.mindepth:
+            relpath = os.path.relpath(dirpath, path)
+            depth = path_depth(relpath) + 1
+            if depth >= self.mindepth and (self.maxdepth is None or self.maxdepth >= depth):
                 for name in dirs + files:
                     fstat = None
                     matches = True
@@ -662,8 +666,20 @@ class Finder(object):
                             if result is not None:
                                 yield result
 
-            if depth == self.maxdepth:
+            if self.maxdepth is not None and depth > self.maxdepth:
                 dirs[:] = []
+
+
+def path_depth(path):
+    depth = 0
+    head = path
+    while True:
+        head, tail = os.path.split(head)
+        if not tail:
+            break
+        if tail != '.':
+            depth += 1
+    return depth
 
 
 def find(path, options):

--- a/tests/unit/utils/find_test.py
+++ b/tests/unit/utils/find_test.py
@@ -560,15 +560,20 @@ class TestFinder(TestCase):
         fd.write("foo")
         fd.close()
 
-        finder = salt.utils.find.Finder({'name': 'test_name'})
-        self.assertEqual(list(finder.find('')), [])
+        finder = salt.utils.find.Finder({})
+        self.assertEqual(list(finder.find(self.tmpdir)), [self.tmpdir, hello_file])
+
+        finder = salt.utils.find.Finder({'mindepth': 1})
+        self.assertEqual(list(finder.find(self.tmpdir)), [hello_file])
+
+        finder = salt.utils.find.Finder({'maxdepth': 0})
+        self.assertEqual(list(finder.find(self.tmpdir)), [self.tmpdir])
 
         finder = salt.utils.find.Finder({'name': 'hello.txt'})
         self.assertEqual(list(finder.find(self.tmpdir)), [hello_file])
 
         finder = salt.utils.find.Finder({'type': 'f', 'print': 'path'})
-        self.assertEqual(list(finder.find(self.tmpdir)),
-            [os.path.join(self.tmpdir, 'hello.txt')])
+        self.assertEqual(list(finder.find(self.tmpdir)), [hello_file])
 
         finder = salt.utils.find.Finder({'size': '+1G', 'print': 'path'})
         self.assertEqual(list(finder.find(self.tmpdir)), [])
@@ -579,6 +584,9 @@ class TestFinder(TestCase):
         self.assertEqual(
             list(finder.find(self.tmpdir)), [[hello_file, 'hello.txt']]
         )
+
+        finder = salt.utils.find.Finder({'name': 'test_name'})
+        self.assertEqual(list(finder.find('')), [])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?

Fixes handling of min/maxdepth during `file.find`
### What issues does this PR fix or reference?
#34217
### Previous Behavior

Specifying min/maxdepth during `file.find` included and excluded the incorrect paths.
### New Behavior

Specifying min/maxdepth during `file.find` includes and excludes the same paths that unix find would.
### Tests written?

Yes.
