### PR TITLE
return list of nodes for lxc driver when called directly

### DIFF
--- a/salt/cloud/clouds/lxc.py
+++ b/salt/cloud/clouds/lxc.py
@@ -279,27 +279,22 @@ def list_nodes(conn=None, call=None):
     nodes = {}
     for state, lxcs in lxclist.items():
         for lxcc, linfos in lxcs.items():
-            info = {
-                'id': lxcc,
-                'name': lxcc,  # required for cloud cache
-                'image': None,
-                'size': linfos['size'],
-                'state': state.lower(),
-                'public_ips': linfos['public_ips'],
-                'private_ips': linfos['private_ips'],
-            }
             # in creation mode, we need to go inside the create method
             # so we hide the running vm from being seen as already installed
             # do not also mask half configured nodes which are explicitly asked
             # to be acted on, on the command line
-            if (
-                (call in ['full'] or not hide)
-                and (
-                    (lxcc in names and call in ['action'])
-                    or (call in ['full'])
-                )
-            ):
-                nodes[lxcc] = info
+            if (call in ['full'] or not hide) and ((lxcc in names and call in ['action']) or call in ['full']):
+                nodes[lxcc] = {
+                    'id': lxcc,
+                    'name': lxcc,  # required for cloud cache
+                    'image': None,
+                    'size': linfos['size'],
+                    'state': state.lower(),
+                    'public_ips': linfos['public_ips'],
+                    'private_ips': linfos['private_ips'],
+                }
+            else:
+                nodes[lxcc] = {'id': lxcc, 'state': state.lower()}
     return nodes
 
 


### PR DESCRIPTION
### What does this PR do?

This is required so that salt-cloud sees a dictionary list of lxc
containers that exist so that they do not attempt to recreate the
container.

The downside to this is that if the container is stopped, it is not
started.
### What issues does this PR fix or reference?

Fixes #33633
### Tests written?

No
