### PR TITLE
detect running from master in State.event method

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1936,7 +1936,13 @@ class State(object):
         chunk is evaluated an event will be set up to the master with the
         results.
         '''
-        if not self.opts.get('local') and (self.opts.get('state_events', True) or fire_event) and self.opts.get('master_uri'):
+        if not self.opts.get('local') and (self.opts.get('state_events', True) or fire_event):
+            if not self.opts.get('master_uri'):
+                ev_func = lambda ret, tag, preload=None: salt.utils.event.get_master_event(
+                    self.opts, self.opts['sock_dir'], listen=False).fire_event(ret, tag)
+            else:
+                ev_func = self.functions['event.fire_master']
+            
             ret = {'ret': chunk_ret}
             if fire_event is True:
                 tag = salt.utils.event.tagify(
@@ -1952,7 +1958,8 @@ class State(object):
                         )
                 ret['len'] = length
             preload = {'jid': self.jid}
-            self.functions['event.fire_master'](ret, tag, preload=preload)
+            ev_func(ret, tag, preload=preload)
+
 
     def call_chunk(self, low, running, chunks):
         '''

--- a/salt/state.py
+++ b/salt/state.py
@@ -1942,7 +1942,7 @@ class State(object):
                     self.opts, self.opts['sock_dir'], listen=False).fire_event(ret, tag)
             else:
                 ev_func = self.functions['event.fire_master']
-            
+
             ret = {'ret': chunk_ret}
             if fire_event is True:
                 tag = salt.utils.event.tagify(
@@ -1959,7 +1959,6 @@ class State(object):
                 ret['len'] = length
             preload = {'jid': self.jid}
             ev_func(ret, tag, preload=preload)
-
 
     def call_chunk(self, low, running, chunks):
         '''


### PR DESCRIPTION
### What does this PR do?

Fixes (I hope) `State.event` to work correctly when running on the master. This will enable firing events using the `fire_event`requisite in orchestration states.

I've tested this with the test case I provided on #34255 and it works as I expect; it produces the following event:

```
salt/state_result/my.master_master/my/event    {
    "_stamp": "2016-06-23T21:00:08.733246",
    "ret": {
        "__id__": "testing",
        "__run_num__": 0,
        "changes": {},
        "comment": "Success!",
        "duration": 0.328,
        "name": "test.ping",
        "result": true,
        "start_time": "21:00:08.731032"
    }
}
```
### What issues does this PR fix or reference?
#34255
### Previous Behavior

`fire_event` requisite did not work with orchestration.
### New Behavior

`fire_event` requisite works with orchestration. Does not appear to utterly destroy everything else that depends on `State.fire_event`.
### Tests written?

No -- looking for guidance.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

This changes `State.event` to detect whether the state that invoked `fire_event` is running on the master. This fixes an issue where the `fire_event` requisite doesn't work when being used in orchestration states.
