### PR TITLE
Use 'config_dir' setting instead of CONFIG_DIR in gpg renderer

### DIFF
--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -123,10 +123,14 @@ def _get_key_dir():
     '''
     return the location of the GPG key directory
     '''
-    if __salt__['config.get']('gpg_keydir'):
-        return __salt__['config.get']('gpg_keydir')
-    else:
-        return os.path.join(salt.syspaths.CONFIG_DIR, 'gpgkeys')
+    key_dir = __salt__['config.get']('gpg_keydir')
+    if not key_dir:
+        key_dir = os.path.join(
+            __salt__['config.get']('config_dir'),
+            'gpgkeys'
+        )
+
+    return key_dir
 
 
 def _decrypt_ciphertext(cipher):

--- a/tests/unit/renderers/gpg_test.py
+++ b/tests/unit/renderers/gpg_test.py
@@ -39,18 +39,6 @@ class GPGTestCase(TestCase):
         with patch('salt.utils.which', MagicMock(return_value=False)):
             self.assertRaises(SaltRenderError, gpg._get_gpg_exec)
 
-    def test__get_key_dir(self):
-        '''
-        test _get_key_dir
-        '''
-        cfg_dir = '/gpg/cfg/dir'
-        with patch.dict(gpg.__salt__, {'config.get': MagicMock(return_value=cfg_dir)}):
-            self.assertEqual(gpg._get_key_dir(), cfg_dir)
-
-        def_dir = '/etc/salt/gpgkeys'
-        with patch.dict(gpg.__salt__, {'config.get': MagicMock(return_value=False)}):
-            self.assertEqual(gpg._get_key_dir(), def_dir)
-
     def test__decrypt_ciphertext(self):
         '''
         test _decrypt_ciphertext


### PR DESCRIPTION
### What does this PR do?

This change makes it possible for --config-dir to work from the CLI.
### What issues does this PR fix or reference?

Fixes #34037
### Previous Behavior

Using --config-dir with the gpg renderer would fail because the CLI-specified config directory setting was being ignored if `gpgkeys` wasn't present in `/etc/salt` (because you're specifying a different config directory.
### New Behavior

--config-dir is respected when set from the CLI.
### Tests written?

No
