### PR TITLE
Regex support in publisher ACL rules.

### DIFF
--- a/salt/acl/__init__.py
+++ b/salt/acl/__init__.py
@@ -10,7 +10,7 @@ found by reading the salt documentation:
 
 # Import python libraries
 from __future__ import absolute_import
-import re
+import salt.utils
 
 
 class PublisherACL(object):
@@ -26,20 +26,13 @@ class PublisherACL(object):
         Takes a username as a string and returns a boolean. True indicates that
         the provided user has been blacklisted
         '''
-        for blacklisted_user in self.blacklist.get('users', []):
-            if re.match(blacklisted_user, user):
-                return True
-        return False
+        return not salt.utils.check_whitelist_blacklist(user, blacklist=self.blacklist.get('users', []))
 
     def cmd_is_blacklisted(self, cmd):
-        for blacklisted_module in self.blacklist.get('modules', []):
-            # If this is a regular command, it is a single function
-            if isinstance(cmd, str):
-                funs_to_check = [cmd]
-            # If this is a compound function
-            else:
-                funs_to_check = cmd
-            for fun in funs_to_check:
-                if re.match(blacklisted_module, fun):
-                    return True
+        # If this is a regular command, it is a single function
+        if isinstance(cmd, str):
+            cmd = [cmd]
+        for fun in cmd:
+            if not salt.utils.check_whitelist_blacklist(fun, blacklist=self.blacklist.get('modules', [])):
+                return True
         return False

--- a/salt/master.py
+++ b/salt/master.py
@@ -2104,10 +2104,17 @@ class ClearFuncs(object):
                         'Authentication failure of type "user" occurred.'
                     )
                     return ''
-                publisher_acl = self.opts['publisher_acl'] or self.opts['client_acl']
+                publisher_acl = salt.utils.get_values_of_matching_keys(
+                            self.opts['publisher_acl'] or self.opts['client_acl'],
+                            clear_load['user'].split('_', 1)[-1])
+                if not publisher_acl:
+                    log.warning(
+                        'Authentication failure of type "user" occurred.'
+                        )
+                    return ''
                 if self.opts['sudo_acl'] and publisher_acl:
                     good = self.ckminions.auth_check(
-                                publisher_acl.get(clear_load['user'].split('_', 1)[-1]),
+                                publisher_acl,
                                 clear_load['fun'],
                                 clear_load['arg'],
                                 clear_load['tgt'],
@@ -2142,14 +2149,17 @@ class ClearFuncs(object):
                             'Authentication failure of type "user" occurred.'
                         )
                         return ''
-                    acl = self.opts['publisher_acl'] or self.opts['client_acl']
-                    if clear_load['user'] not in acl:
+                    # Build ACL matching the user name
+                    acl = salt.utils.get_values_of_matching_keys(
+                            self.opts['publisher_acl'] or self.opts['client_acl'],
+                            clear_load['user'])
+                    if not acl:
                         log.warning(
                             'Authentication failure of type "user" occurred.'
                         )
                         return ''
                     good = self.ckminions.auth_check(
-                        acl[clear_load['user']],
+                        acl,
                         clear_load['fun'],
                         clear_load['arg'],
                         clear_load['tgt'],

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1333,47 +1333,39 @@ def check_whitelist_blacklist(value, whitelist=None, blacklist=None):
     '''
     Check a whitelist and/or blacklist to see if the value matches it.
     '''
-    if not any((whitelist, blacklist)):
-        return True
-    in_whitelist = False
-    in_blacklist = False
-    if whitelist:
-        if not isinstance(whitelist, list):
-            whitelist = [whitelist]
-        try:
-            for expr in whitelist:
-                if expr_match(value, expr):
-                    in_whitelist = True
-                    break
-        except TypeError:
-            log.error('Non-iterable whitelist {0}'.format(whitelist))
-            whitelist = None
-    else:
-        whitelist = None
-
-    if blacklist:
-        if not isinstance(blacklist, list):
+    if blacklist is not None:
+        if not hasattr(blacklist, '__iter__'):
             blacklist = [blacklist]
         try:
             for expr in blacklist:
                 if expr_match(value, expr):
-                    in_blacklist = True
-                    break
+                    return False
         except TypeError:
             log.error('Non-iterable blacklist {0}'.format(whitelist))
-            blacklist = None
-    else:
-        blacklist = None
 
-    if whitelist and not blacklist:
-        ret = in_whitelist
-    elif blacklist and not whitelist:
-        ret = not in_blacklist
-    elif whitelist and blacklist:
-        ret = in_whitelist and not in_blacklist
+    if whitelist:
+        if not hasattr(whitelist, '__iter__'):
+            whitelist = [whitelist]
+        try:
+            for expr in whitelist:
+                if expr_match(value, expr):
+                    return True
+        except TypeError:
+            log.error('Non-iterable whitelist {0}'.format(whitelist))
     else:
-        ret = True
+        return True
 
+    return False
+
+
+def get_values_of_matching_keys(pattern_dict, user_name):
+    '''
+    Check a whitelist and/or blacklist to see if the value matches it.
+    '''
+    ret = []
+    for expr in pattern_dict:
+        if expr_match(user_name, expr):
+            ret.extend(pattern_dict[expr])
     return ret
 
 

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1341,7 +1341,7 @@ def check_whitelist_blacklist(value, whitelist=None, blacklist=None):
                 if expr_match(value, expr):
                     return False
         except TypeError:
-            log.error('Non-iterable blacklist {0}'.format(whitelist))
+            log.error('Non-iterable blacklist {0}'.format(blacklist))
 
     if whitelist:
         if not hasattr(whitelist, '__iter__'):

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -748,7 +748,7 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
                 # Yep, not the same user!
                 # Is the current user in ACL?
                 acl = self.config.get('publisher_acl') or self.config.get('client_acl', {})
-                if current_user in acl:
+                if salt.utils.check_whitelist_blacklist(current_user, whitelist=six.iterkeys(acl)):
                     # Yep, the user is in ACL!
                     # Let's write the logfile to its home directory instead.
                     xdg_dir = salt.utils.xdg.xdg_config_dir()

--- a/tests/unit/acl/client_test.py
+++ b/tests/unit/acl/client_test.py
@@ -24,8 +24,8 @@ class ClientACLTestCase(TestCase):
     '''
     def setUp(self):
         self.blacklist = {
-            'users': ['joker', 'penguin'],
-            'modules': ['cmd.run', 'test.fib'],
+            'users': ['joker', 'penguin', '*bad_*', 'blocked_.*', '^Homer$'],
+            'modules': ['cmd.run', 'test.fib', 'rm-rf.*'],
         }
 
     def test_user_is_blacklisted(self):
@@ -36,9 +36,21 @@ class ClientACLTestCase(TestCase):
 
         self.assertTrue(client_acl.user_is_blacklisted('joker'))
         self.assertTrue(client_acl.user_is_blacklisted('penguin'))
+        self.assertTrue(client_acl.user_is_blacklisted('bad_'))
+        self.assertTrue(client_acl.user_is_blacklisted('bad_user'))
+        self.assertTrue(client_acl.user_is_blacklisted('bad_*'))
+        self.assertTrue(client_acl.user_is_blacklisted('user_bad_'))
+        self.assertTrue(client_acl.user_is_blacklisted('blocked_'))
+        self.assertTrue(client_acl.user_is_blacklisted('blocked_user'))
+        self.assertTrue(client_acl.user_is_blacklisted('blocked_.*'))
+        self.assertTrue(client_acl.user_is_blacklisted('Homer'))
 
         self.assertFalse(client_acl.user_is_blacklisted('batman'))
         self.assertFalse(client_acl.user_is_blacklisted('robin'))
+        self.assertFalse(client_acl.user_is_blacklisted('bad'))
+        self.assertFalse(client_acl.user_is_blacklisted('blocked'))
+        self.assertFalse(client_acl.user_is_blacklisted('NotHomer'))
+        self.assertFalse(client_acl.user_is_blacklisted('HomerSimpson'))
 
     def test_cmd_is_blacklisted(self):
         '''
@@ -48,9 +60,11 @@ class ClientACLTestCase(TestCase):
 
         self.assertTrue(client_acl.cmd_is_blacklisted('cmd.run'))
         self.assertTrue(client_acl.cmd_is_blacklisted('test.fib'))
+        self.assertTrue(client_acl.cmd_is_blacklisted('rm-rf.root'))
 
         self.assertFalse(client_acl.cmd_is_blacklisted('cmd.shell'))
         self.assertFalse(client_acl.cmd_is_blacklisted('test.versions'))
+        self.assertFalse(client_acl.cmd_is_blacklisted('arm-rf.root'))
 
         self.assertTrue(client_acl.cmd_is_blacklisted(['cmd.run', 'state.sls']))
         self.assertFalse(client_acl.cmd_is_blacklisted(['state.highstate', 'state.sls']))


### PR DESCRIPTION
### What does this PR do?

Users in publisher ACL and users and functions in the publisher ACL
blacklist now have matched in the following order:
1. Equality
2. Glob
3. Regex

Users in publisher ACL still not supported in systems without pwd python
module (Windows, any else?)
### What issues does this PR fix or reference?
saltstack/salt#23194
### Tests written?

Partially.

Please don't merge for now, I've to test it and write some tests.