### PR TITLE
Update chkconfig for xinetd based services

### DIFF
--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -184,7 +184,7 @@ def _chkconfig_is_enabled(name, runlevel=None):
             if '{0}:on'.format(runlevel) in row:
                 if row.split()[0] == name:
                     return True
-            elif row.split() == [name + ':', 'on']:
+            elif row.split() == [name, 'on']:
                 return True
     return False
 


### PR DESCRIPTION
### What does this PR do?

Fixes chkconfig check for Redhat 6 xinetd based services
### What issues does this PR fix or reference?

The existing module doesn't detected enabled/disabled chkconfig services
### Previous Behavior

Always returns False for xinetd services
### New Behavior

Correctly returns True for enabled xinetd services
### Tests written?

Yes - modified the existing rh_service.py test

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

Enabled xinetd based services report as <service> on but the existing code is looking for <service>: on
