### PR TITLE
Fixed symlinks on windows where the slashes don't match

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -900,7 +900,7 @@ def symlink(
             )
     if __salt__['file.is_link'](name):
         # The link exists, verify that it matches the target
-        if __salt__['file.readlink'](name) != target:
+        if os.path.normpath(__salt__['file.readlink'](name)) != os.path.normpath(target):
             # The target is wrong, delete the link
             os.remove(name)
         else:


### PR DESCRIPTION
### What does this PR do?

Fixed symlinks on windows where the slashes don't match
### What issues does this PR fix or reference?
### Previous Behavior

If paths had different slashes then the state would fail incorrectly 
### New Behavior

Paths are now normalised and the state will successfully pass
### Tests written?

No
- This commit fixes detecting whether a symlink is correctly setup or not, we now make sure that we are testing the normalised paths
