### PR TITLE
Don't escape source before calling managed

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2355,7 +2355,6 @@ def recurse(name,
             ret['changes'][path] = _ret['changes']
 
     def manage_file(path, source):
-        source = salt.utils.url.escape(source)
         if clean and os.path.exists(path) and os.path.isdir(path):
             _ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
             if __opts__['test']:


### PR DESCRIPTION
### What does this PR do?

Does not escape the salt source url before calling file.managed from file.recurse. file.recurse is designed to be called from states directly so it should not need an escaped source url.
### What issues does this PR fix or reference?
#34273
### Previous Behavior

File caching for file.recurse was failing because the minion was attempting to cache to a directory with a prepended `|` character.
### New Behavior

Minion caches files correctly.
### Tests written?

No
