### PR TITLE
Several new boto_* functions and a couple of bugfixes

### DIFF
--- a/salt/modules/boto_elb.py
+++ b/salt/modules/boto_elb.py
@@ -111,7 +111,7 @@ def exists(name, region=None, key=None, keyid=None, profile=None):
             log.debug(msg)
             return False
     except boto.exception.BotoServerError as error:
-        log.debug(error)
+        log.warning(error)
         return False
 
 
@@ -130,7 +130,7 @@ def get_all_elbs(region=None, key=None, keyid=None, profile=None):
     try:
         return [e for e in conn.get_all_load_balancers()]
     except boto.exception.BotoServerError as error:
-        log.debug(error)
+        log.warning(error)
         return []
 
 
@@ -145,7 +145,8 @@ def list_elbs(region=None, key=None, keyid=None, profile=None):
         salt myminion boto_elb.list_elbs region=us-east-1
     '''
 
-    return [e.name for e in get_all_elbs(region=region, key=key, keyid=keyid, profile=profile)]
+    return [e.name for e in get_all_elbs(region=region, key=key, keyid=keyid,
+                                         profile=profile)]
 
 
 def get_elb_config(name, region=None, key=None, keyid=None, profile=None):

--- a/salt/modules/boto_elb.py
+++ b/salt/modules/boto_elb.py
@@ -801,10 +801,10 @@ def set_instances(name, instances, test=False, region=None, key=None, keyid=None
     if test:
         return bool(add or remove)
     if len(remove):
-        if deregister_instances(name, list(remove), region, key, keyid, profile) == False:
+        if deregister_instances(name, list(remove), region, key, keyid, profile) is False:
             ret = False
     if len(add):
-        if register_instances(name, list(add), region, key, keyid, profile) == False:
+        if register_instances(name, list(add), region, key, keyid, profile) is False:
             ret = False
     return ret
 

--- a/salt/modules/boto_elb.py
+++ b/salt/modules/boto_elb.py
@@ -115,6 +115,39 @@ def exists(name, region=None, key=None, keyid=None, profile=None):
         return False
 
 
+def get_all_elbs(region=None, key=None, keyid=None, profile=None):
+    '''
+    Return all load balancers associated with an account
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt myminion boto_elb.get_all_elbs region=us-east-1
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    try:
+        return [e for e in conn.get_all_load_balancers()]
+    except boto.exception.BotoServerError as error:
+        log.debug(error)
+        return []
+
+
+def list_elbs(region=None, key=None, keyid=None, profile=None):
+    '''
+    Return names of all load balancers associated with an account
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt myminion boto_elb.list_elbs region=us-east-1
+    '''
+
+    return [e.name for e in get_all_elbs(region=region, key=key, keyid=keyid, profile=profile)]
+
+
 def get_elb_config(name, region=None, key=None, keyid=None, profile=None):
     '''
     Get an ELB configuration.
@@ -219,10 +252,11 @@ def create(name, availability_zones, listeners, subnets=None,
     _complex_listeners = []
     for listener in listeners:
         _complex_listeners.append(listener_dict_to_tuple(listener))
+
     try:
-        lb = conn.create_load_balancer(name, availability_zones, [],
-                                       subnets, security_groups, scheme,
-                                       _complex_listeners)
+        lb = conn.create_load_balancer(name=name, zones=availability_zones, subnets=subnets,
+                                       security_groups=security_groups, scheme=scheme,
+                                       complex_listeners=_complex_listeners)
         if lb:
             log.info('Created ELB {0}'.format(name))
             return True
@@ -746,6 +780,33 @@ def deregister_instances(name, instances, region=None, key=None, keyid=None,
     else:
         deregister_result = True
     return deregister_result
+
+
+def set_instances(name, instances, test=False, region=None, key=None, keyid=None,
+                         profile=None):
+    '''
+    Set the instances assigned to an ELB to exactly the list given
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt myminion boto_elb.set_instances myelb region=us-east-1 instances="[instance_id,instance_id]"
+    '''
+    ret = True
+    current = set([i['instance_id'] for i in get_instance_health(name, region, key, keyid, profile)])
+    desired = set(instances)
+    add = desired - current
+    remove = current - desired
+    if test:
+        return bool(add or remove)
+    if len(remove):
+        if deregister_instances(name, list(remove), region, key, keyid, profile) == False:
+            ret = False
+    if len(add):
+        if register_instances(name, list(add), region, key, keyid, profile) == False:
+            ret = False
+    return ret
 
 
 def get_instance_health(name, region=None, key=None, keyid=None, profile=None, instances=None):

--- a/salt/modules/boto_secgroup.py
+++ b/salt/modules/boto_secgroup.py
@@ -324,7 +324,7 @@ def get_group_id(name, vpc_id=None, vpc_name=None, region=None, key=None,
         return False
 
 
-def convert_to_group_ids(groups, vpc_id, vpc_name=None, region=None, key=None,
+def convert_to_group_ids(groups, vpc_id=None, vpc_name=None, region=None, key=None,
                          keyid=None, profile=None):
     '''
     Given a list of security groups and a vpc_id, convert_to_group_ids will
@@ -338,8 +338,7 @@ def convert_to_group_ids(groups, vpc_id, vpc_name=None, region=None, key=None,
     group_ids = []
     for group in groups:
         if re.match('sg-.*', group):
-            log.debug('group {0} is a group id. get_group_id not called.'
-                      .format(group))
+            log.debug('group {0} is a group id. get_group_id not called.'.format(group))
             group_ids.append(group)
         else:
             log.debug('calling boto_secgroup.get_group_id for'
@@ -347,10 +346,12 @@ def convert_to_group_ids(groups, vpc_id, vpc_name=None, region=None, key=None,
             group_id = get_group_id(name=group, vpc_id=vpc_id,
                                     vpc_name=vpc_name, region=region,
                                     key=key, keyid=keyid, profile=profile)
-            log.debug('group name {0} has group id {1}'.format(
-                group, group_id)
-            )
-            group_ids.append(str(group_id))
+            if not group_id:
+                log.warning('group name {0} did not resolve to a group ID'.format(group))
+            else:
+                log.debug('group name {0} has group id {1}'.format(group, group_id))
+                group_ids.append(str(group_id))
+
     log.debug('security group contents {0} post-conversion'.format(group_ids))
     return group_ids
 

--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -485,7 +485,7 @@ def _get_id(vpc_name=None, cidr=None, tags=None, region=None, key=None,
     vpc_ids = _find_vpcs(vpc_name=vpc_name, cidr=cidr, tags=tags, region=region,
                          key=key, keyid=keyid, profile=profile)
     if vpc_ids:
-        log.info("Matching VPC: {0}".format(" ".join(vpc_ids)))
+        log.debug("Matching VPC: {0}".format(" ".join(vpc_ids)))
         if len(vpc_ids) == 1:
             vpc_id = vpc_ids[0]
             if vpc_name:

--- a/salt/states/boto_asg.py
+++ b/salt/states/boto_asg.py
@@ -438,6 +438,7 @@ def present(
         }
 
         if 'image_name' in launch_config:
+            image_name = launch_config['image_name']
             args = {'ami_name': image_name, 'region': region, 'key': key,
                     'keyid': keyid, 'profile': profile}
             image_ids = __salt__['boto_ec2.find_images'](**args)

--- a/salt/states/boto_asg.py
+++ b/salt/states/boto_asg.py
@@ -437,6 +437,16 @@ def present(
             'profile': profile
         }
 
+        if 'image_name' in launch_config:
+            args = {'ami_name': image_name, 'region': region, 'key': key,
+                    'keyid': keyid, 'profile': profile}
+            image_ids = __salt__['boto_ec2.find_images'](**args)
+            if len(image_ids):
+                launch_config['image_id'] = image_ids[0]
+            else:
+                launch_config['image_id'] = image_name
+            del launch_config['image_name']
+
         if vpc_id:
             log.debug('Auto Scaling Group {0} is a associated with a vpc')
             # locate the security groups attribute of a launch config

--- a/salt/states/boto_elb.py
+++ b/salt/states/boto_elb.py
@@ -247,8 +247,8 @@ from salt.utils import exactly_one
 from salt.exceptions import SaltInvocationError
 import salt.ext.six as six
 
-
 log = logging.getLogger(__name__)
+
 
 def __virtual__():
     '''

--- a/salt/states/boto_elb.py
+++ b/salt/states/boto_elb.py
@@ -653,6 +653,7 @@ def _elb_present(
                 return ret
             subnets.append(r['id'])
 
+    _security_groups = None
     if subnets:
         vpc_id = __salt__['boto_vpc.get_subnet_association'](subnets, region, key, keyid, profile)
         vpc_id = vpc_id.get('vpc_id')


### PR DESCRIPTION
- modules/boto_elb: new functions get_all_elbs(), list_elbs(), set_instances()
- modules/boto_secgroup: make vpc_id param to convert_to_group_ids)_ optional as it is just passed through, fix bug where [False] is returned when [] is intended
- modules/boto_vpc: change loglevel of one line from 'info' to 'debug' to avoid zillions of duplicate lines in salt-call output :)
- states/boto_asg: add support for 'image_name' item in launch_config param to present()
- states/boto_elb: add support for 'subnet_names', 'instance_ids', and 'instance_names' to present(), return False instead of raising error in a couple of cases, fixup "Failed" return of test=True case when ELB does not exist, present() can now add and remove instances as needed, if requested.
