### PR TITLE
salt-cloud will use list_floating_ips for Openstack

### DIFF
--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -844,7 +844,7 @@ def _assign_floating_ips(vm_, conn, kwargs):
                 pool = OpenStack_1_1_FloatingIpPool(
                     '', conn.connection
                 )
-                for idx in [pool.create_floating_ip()]:
+                for idx in pool.list_floating_ips():
                     if idx.node_id is None:
                         floating.append(idx)
                 if not floating:


### PR DESCRIPTION
### What does this PR do?

When using salt-cloud on an Openstack installation, attempting to provision a machine with public_ips while a project has maxed out the quota for floating-ips but has unassigned IP's in the pool results in a HTTP 413 error. It appears the code calls get create_floating_ips instead of using unassigned IP's in the pool. This changes the behavior to use IP's from the pool and errors if none are assigned.
### What issues does this PR fix or reference?

N/A
### Previous Behavior

salt-cloud would call create_floating_ips to get a floating IP to assign to an instance when provisioning
### New Behavior

salt-cloud will call list_floating_ips and use any unassigned IP currently in the pool for provisioing
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

This changes salt-cloud for Openstack to list_floating_ips when
nodes are provisioned. This prevents quota errors whe attempting
to allocate IPs to a project when the quota is maxed out but there
are unassigned IPs.
