### PR TITLE
2016.3 mount vfstab support

### DIFF
--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -418,7 +418,7 @@ def vfstab(config='/etc/vfstab'):
 
         salt '*' mount.vfstab
     '''
-    ## NOTE: vfstab is a wrapper, we share all code with fstab
+    ## NOTE: vfstab is a wrapper for fstab
     return fstab(config)
 
 
@@ -426,9 +426,6 @@ def rm_fstab(name, device, config='/etc/fstab'):
     '''
     .. versionchanged:: 2016.3.2
     Remove the mount point from the fstab
-
-    config : string
-        optional path of fstab
 
     CLI Example:
 
@@ -480,16 +477,13 @@ def rm_vfstab(name, device, config='/etc/vfstab'):
     .. versionadded:: 2016.3.2
     Remove the mount point from the vfstab
 
-    config : string
-        optional path of vfstab
-
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' mount.rm_vfstab /mnt/foo /device/c0t0d0p0
     '''
-    ## NOTE: rm_vfstab is a wrapper, we share all code with fstab
+    ## NOTE: rm_vfstab is a wrapper for rm_fstab
     return rm_fstab(name, device, config)
 
 

--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -311,7 +311,7 @@ class _vfstab_entry(object):
         '''Error raised when a line isn't parsible as an fstab entry'''
 
     vfstab_keys = ('device', 'device_fsck', 'name', 'fstype', 'pass_fsck', 'mount_at_boot', 'opts')
-    ##NOTE: weird formatting to match default spacing on Solaris
+    ## NOTE: weird formatting to match default spacing on Solaris
     vfstab_format = '{device:<11} {device_fsck:<3} {name:<19} {fstype:<8} {pass_fsck:<3} {mount_at_boot:<6} {opts}\n'
 
     @classmethod

--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -366,13 +366,10 @@ class _vfstab_entry(object):
         return True
 
 
-def fstab(config=None):
+def fstab(config='/etc/fstab'):
     '''
     .. versionchanged:: 2016.3.2
     List the contents of the fstab
-
-    config : string
-        optional path of fstab
 
     CLI Example:
 
@@ -381,11 +378,6 @@ def fstab(config=None):
         salt '*' mount.fstab
     '''
     ret = {}
-    if not config:
-        if __grains__['kernel'] == 'SunOS':
-            config = '/etc/vfstab'
-        else:
-            config = '/etc/fstab'
     if not os.path.isfile(config):
         return ret
     with salt.utils.fopen(config) as ifile:
@@ -415,7 +407,22 @@ def fstab(config=None):
     return ret
 
 
-def rm_fstab(name, device, config=None):
+def vfstab(config='/etc/vfstab'):
+    '''
+    .. versionadded:: 2016.3.2
+    List the contents of the vfstab
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' mount.vfstab
+    '''
+    ## NOTE: vfstab is a wrapper, we share all code with fstab
+    return fstab(config)
+
+
+def rm_fstab(name, device, config='/etc/fstab'):
     '''
     .. versionchanged:: 2016.3.2
     Remove the mount point from the fstab
@@ -430,12 +437,6 @@ def rm_fstab(name, device, config=None):
         salt '*' mount.rm_fstab /mnt/foo /dev/sdg
     '''
     modified = False
-
-    if not config:
-        if __grains__['kernel'] == 'SunOS':
-            config = '/etc/vfstab'
-        else:
-            config = '/etc/fstab'
 
     if __grains__['kernel'] == 'SunOS':
         criteria = _vfstab_entry(name=name, device=device)
@@ -472,6 +473,24 @@ def rm_fstab(name, device, config=None):
     # Note: not clear why we always return 'True'
     # --just copying previous behavior at this point...
     return True
+
+
+def rm_vfstab(name, device, config='/etc/vfstab'):
+    '''
+    .. versionadded:: 2016.3.2
+    Remove the mount point from the vfstab
+
+    config : string
+        optional path of vfstab
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' mount.rm_vfstab /mnt/foo /device/c0t0d0p0
+    '''
+    ## NOTE: rm_vfstab is a wrapper, we share all code with fstab
+    return rm_fstab(name, device, config)
 
 
 def set_fstab(

--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -468,7 +468,6 @@ def rm_fstab(name, device, config=None):
         except (IOError, OSError) as exc:
             msg = "Couldn't write to {0}: {1}"
             raise CommandExecutionError(msg.format(config, str(exc)))
-            return False
 
     # Note: not clear why we always return 'True'
     # --just copying previous behavior at this point...
@@ -496,6 +495,9 @@ def set_fstab(
 
         salt '*' mount.set_fstab /mnt/foo /dev/sdz1 ext4
     '''
+
+    if __grains__['kernel'] == 'SunOS':
+        return {'Error': 'set_fstab not support on Solaris like platforms, use set_vfstab.'}
 
     # Fix the opts type if it is a list
     if isinstance(opts, list):

--- a/tests/unit/modules/mount_test.py
+++ b/tests/unit/modules/mount_test.py
@@ -103,6 +103,30 @@ class MountTestCase(TestCase):
                                                            'opts': ['D', 'E', 'F'],
                                                            'pass': 'H'}})
 
+    def test_vfstab(self):
+        '''
+        List the content of the vfstab
+        '''
+        mock = MagicMock(return_value=False)
+        with patch.object(os.path, 'isfile', mock):
+            self.assertEqual(mount.vfstab(), {})
+
+        mock = MagicMock(return_value=True)
+        with patch.dict(mount.__grains__, {'kernel': 'SunOS'}):
+            with patch.object(os.path, 'isfile', mock):
+                file_data = '\n'.join(['#',
+                                       'swap        -   /tmp                tmpfs    -   yes    size=2048m'])
+                with patch('salt.utils.fopen',
+                           mock_open(read_data=file_data),
+                           create=True) as m:
+                    m.return_value.__iter__.return_value = file_data.splitlines()
+                    self.assertEqual(mount.fstab(), {'/tmp': {'device': 'swap',
+                                                              'device_fsck': '-',
+                                                              'fstype': 'tmpfs',
+                                                              'mount_at_boot': 'yes',
+                                                              'opts': ['size=2048m'],
+                                                              'pass_fsck': '-'}})
+
     def test_rm_fstab(self):
         '''
         Remove the mount point from the fstab

--- a/tests/unit/modules/mount_test.py
+++ b/tests/unit/modules/mount_test.py
@@ -132,17 +132,19 @@ class MountTestCase(TestCase):
         Remove the mount point from the fstab
         '''
         mock_fstab = MagicMock(return_value={})
-        with patch.object(mount, 'fstab', mock_fstab):
-            with patch('salt.utils.fopen', mock_open()):
-                self.assertTrue(mount.rm_fstab('name', 'device'))
+        with patch.dict(mount.__grains__, {'kernel': ''}):
+            with patch.object(mount, 'fstab', mock_fstab):
+                with patch('salt.utils.fopen', mock_open()):
+                    self.assertTrue(mount.rm_fstab('name', 'device'))
 
         mock_fstab = MagicMock(return_value={'name': 'name'})
-        with patch.object(mount, 'fstab', mock_fstab):
-            with patch('salt.utils.fopen', mock_open()) as m_open:
-                helper_open = m_open()
-                helper_open.write.assertRaises(CommandExecutionError,
-                                               mount.rm_fstab,
-                                               config=None)
+        with patch.dict(mount.__grains__, {'kernel': ''}):
+            with patch.object(mount, 'fstab', mock_fstab):
+                with patch('salt.utils.fopen', mock_open()) as m_open:
+                    helper_open = m_open()
+                    helper_open.write.assertRaises(CommandExecutionError,
+                                                   mount.rm_fstab,
+                                                   config=None)
 
     def test_set_fstab(self):
         '''

--- a/tests/unit/modules/mount_test.py
+++ b/tests/unit/modules/mount_test.py
@@ -89,18 +89,19 @@ class MountTestCase(TestCase):
             self.assertEqual(mount.fstab(), {})
 
         mock = MagicMock(return_value=True)
-        with patch.object(os.path, 'isfile', mock):
-            file_data = '\n'.join(['#',
-                                   'A B C D,E,F G H'])
-            with patch('salt.utils.fopen',
-                       mock_open(read_data=file_data),
-                       create=True) as m:
-                m.return_value.__iter__.return_value = file_data.splitlines()
-                self.assertEqual(mount.fstab(), {'B': {'device': 'A',
-                                                       'dump': 'G',
-                                                       'fstype': 'C',
-                                                       'opts': ['D', 'E', 'F'],
-                                                       'pass': 'H'}})
+        with patch.dict(mount.__grains__, {'kernel': ''}):
+            with patch.object(os.path, 'isfile', mock):
+                file_data = '\n'.join(['#',
+                                       'A B C D,E,F G H'])
+                with patch('salt.utils.fopen',
+                           mock_open(read_data=file_data),
+                           create=True) as m:
+                    m.return_value.__iter__.return_value = file_data.splitlines()
+                    self.assertEqual(mount.fstab(), {'B': {'device': 'A',
+                                                           'dump': 'G',
+                                                           'fstype': 'C',
+                                                           'opts': ['D', 'E', 'F'],
+                                                           'pass': 'H'}})
 
     def test_rm_fstab(self):
         '''


### PR DESCRIPTION
### What does this PR do?

Add vfstab support (Solaris like platform fstab format)

It bugged me the entire day I didn't fix the fstab parsing for Solaris like platforms, so I added support for vfstab.

New functions
mount.vfstab (wrapper for mount.fstab)
mount.rm_vfstab (wrapper for mount.rm_fstab)
mount.set_vfstab

The wrapper pass the correct file path (/etc/vfstab) to there parent function, the parent functions know how to parse the vfstab format by creating a _vfstab_entry class.
### What issues does this PR fix or reference?

N/A
### Previous Behavior

fstab returned nothing, rm_fstab and set_fstab did not work either.
### New Behavior

vfstab, rm_vfstab en set_vfstab are now working.
### Tests written?

Yes (mount.vfstab)
### Affected version
- 2016.3
- develop
