### PR TITLE
Don't require 'domain' to be present before checking fqdn_ip* grains

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1603,9 +1603,8 @@ def fqdn_ip4():
     addrs = []
     try:
         hostname_grains = hostname()
-        if hostname_grains['domain']:
-            info = socket.getaddrinfo(hostname_grains['fqdn'], None, socket.AF_INET)
-            addrs = list(set(item[4][0] for item in info))
+        info = socket.getaddrinfo(hostname_grains['fqdn'], None, socket.AF_INET)
+        addrs = list(set(item[4][0] for item in info))
     except socket.error:
         pass
     return {'fqdn_ip4': addrs}
@@ -1633,9 +1632,8 @@ def fqdn_ip6():
     addrs = []
     try:
         hostname_grains = hostname()
-        if hostname_grains['domain']:
-            info = socket.getaddrinfo(hostname_grains['fqdn'], None, socket.AF_INET6)
-            addrs = list(set(item[4][0] for item in info))
+        info = socket.getaddrinfo(hostname_grains['fqdn'], None, socket.AF_INET6)
+        addrs = list(set(item[4][0] for item in info))
     except socket.error:
         pass
     return {'fqdn_ip6': addrs}


### PR DESCRIPTION
### What does this PR do?

Fixes a regression found in #34129 where `fqdn_ip4` or `fqdn_ip6` grains were empty if the `domain` grain wasn't set. This removes the check to require the `domain` name before running the appropriate `socket.getaddrinfo` calls on the `fqdn` grain value.
### What issues does this PR fix or reference?

Fixes #34129
### Previous Behavior

```
# salt-call grains.item fqdn_ip4
local:
    ----------
    fqdn_ip4:
```
### New Behavior

```
# salt-call grains.item fqdn_ip4 
local:
    ----------
    fqdn_ip4:
        - 172.16.236.1
```
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
