### PR TITLE
Fix runas function for System Account

### DIFF
--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -298,6 +298,10 @@ def runas_system(cmd, username, password):
                                     win32con.LOGON32_LOGON_INTERACTIVE,
                                     win32con.LOGON32_PROVIDER_DEFAULT)
 
+    # Get Unrestricted Token (UAC) if this is an Admin Account
+    elevated_token = win32security.GetTokenInformation(
+        token, win32security.TokenLinkedToken)
+
     # Get Security Attributes
     security_attributes = win32security.SECURITY_ATTRIBUTES()
     security_attributes.bInheritHandle = 1
@@ -337,8 +341,8 @@ def runas_system(cmd, username, password):
                 None,
                 startup_info)
 
-    hProcess, hThread, PId, TId = win32process.CreateProcessAsUser(token,
-                                                                   *procArgs)
+    hProcess, hThread, PId, TId = \
+        win32process.CreateProcessAsUser(elevated_token, *procArgs)
 
     if stdin_read is not None:
         stdin_read.Close()

--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -303,6 +303,19 @@ def runas_system(cmd, username, password):
         # Get Unrestricted Token (UAC) if this is an Admin Account
         elevated_token = win32security.GetTokenInformation(
             token, win32security.TokenLinkedToken)
+
+        # Get list of privileges this token contains
+        privileges = win32security.GetTokenInformation(
+            elevated_token, win32security.TokenPrivileges)
+
+        # Create a set of all privileges to be enabled
+        enable_privs = set()
+        for luid, flags in privileges:
+            enable_privs.add((luid, win32con.SE_PRIVILEGE_ENABLED))
+
+        # Enable the privileges
+        win32security.AdjustTokenPrivileges(elevated_token, 0, enable_privs)
+
     except win32security.error as exc:
         # User doesn't have admin, use existing token
         if exc[0] == winerror.ERROR_NO_SUCH_LOGON_SESSION \


### PR DESCRIPTION
### What does this PR do?

Use the elevated token if present when passing runas with an admin account. Only fixes when Salt is running under the LocalSystem account. Need to fix for debug mode under an admin account.
### What issues does this PR fix or reference?

https://github.com/saltstack/zh/issues/766
### Previous Behavior

When admin credentials were passed to Runas the restricted token was used instead of the full elevated privileges of the user.
### New Behavior

Uses the elevated token.
### Tests written?

No
