### PR TITLE
2016.3 status module now works on Solaris like platforms

### DIFF
--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -838,7 +838,7 @@ def master(master=None, connected=True):
 
     Fire an event if the minion gets disconnected from its master. This
     function is meant to be run via a scheduled job from the minion. If
-    master_ip is an FQDN/Hostname, is must be resolvable to a valid IPv4
+    master_ip is an FQDN/Hostname, it must be resolvable to a valid IPv4
     address.
 
     CLI Example:
@@ -893,7 +893,8 @@ def ping_master(master):
 
     opts = copy.deepcopy(__opts__)
     opts['master'] = master
-    del opts['master_ip']  # avoid 'master ip changed' warning
+    if 'master_ip' in opts:  # avoid 'master ip changed' warning
+        del opts['master_ip']
     opts.update(salt.minion.prep_ip_port(opts))
     try:
         opts.update(salt.minion.resolve_dns(opts, fallback=False))

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -838,15 +838,19 @@ def netdev():
             # add data
             ret[dev] = {}
             for i in range(len(netstat_ipv4[0])-1):
+                if netstat_ipv4[0][i] == 'Name':
+                    continue
                 if netstat_ipv4[0][i] in ['Address', 'Net/Dest']:
                     ret[dev]['IPv4 {field}'.format(field=netstat_ipv4[0][i])] = netstat_ipv4[1][i]
                 else:
-                    ret[dev][netstat_ipv4[0][i]] = netstat_ipv4[1][i]
+                    ret[dev][netstat_ipv4[0][i]] = int(netstat_ipv4[1][i]) if netstat_ipv4[1][i].isdigit() else netstat_ipv4[1][i]
             for i in range(len(netstat_ipv6[0])-1):
+                if netstat_ipv6[0][i] == 'Name':
+                    continue
                 if netstat_ipv6[0][i] in ['Address', 'Net/Dest']:
                     ret[dev]['IPv6 {field}'.format(field=netstat_ipv6[0][i])] = netstat_ipv6[1][i]
                 else:
-                    ret[dev][netstat_ipv6[0][i]] = netstat_ipv6[1][i]
+                    ret[dev][netstat_ipv6[0][i]] = int(netstat_ipv6[1][i]) if netstat_ipv6[1][i].isdigit() else netstat_ipv6[1][i]
 
         return ret
 

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -500,14 +500,23 @@ def diskusage(*args):
             ifile = salt.utils.fopen(procf, 'r').readlines()
         elif __grains__['kernel'] == 'FreeBSD':
             ifile = __salt__['cmd.run']('mount -p').splitlines()
+        elif __grains__['kernel'] == 'SunOS':
+            ifile = __salt__['cmd.run']('mount -p').splitlines()
 
         for line in ifile:
             comps = line.split()
-            if len(comps) >= 3:
-                mntpt = comps[1]
-                fstype = comps[2]
-                if regex.match(fstype):
-                    selected.add(mntpt)
+            if __grains__['kernel'] == 'SunOS':
+                if len(comps) >= 4:
+                    mntpt = comps[2]
+                    fstype = comps[3]
+                    if regex.match(fstype):
+                        selected.add(mntpt)
+            else:
+                if len(comps) >= 3:
+                    mntpt = comps[1]
+                    fstype = comps[2]
+                    if regex.match(fstype):
+                        selected.add(mntpt)
 
     # query the filesystems disk usage
     ret = {}
@@ -674,6 +683,7 @@ def netstats():
 
 def netdev():
     '''
+    ..versionchanged:: 2016.3.2
     Return the network device stats for this minion
 
     CLI Example:

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -928,7 +928,7 @@ def all_status():
             'meminfo': meminfo(),
             'netdev': netdev(),
             'netstats': netstats(),
-            'uptime': uptime(),
+            'uptime': uptime() if not __grains__['kernel'] == 'SunOS' else _uptime(),
             'vmstats': vmstats(),
             'w': w()}
 

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -522,6 +522,7 @@ def diskusage(*args):
 
 def vmstats():
     '''
+    ..versionchanged:: 2016.3.2
     Return the virtual memory stats for this minion
 
     CLI Example:
@@ -546,9 +547,10 @@ def vmstats():
             ret[comps[0]] = _number(comps[1])
         return ret
 
-    def freebsd_vmstats():
+    def generic_vmstats():
         '''
-        freebsd specific implementation of vmstats
+        generic implementation of vmstats
+        note: works on FreeBSD, SunOS and OpenBSD (possibly others)
         '''
         ret = {}
         for line in __salt__['cmd.run']('vmstat -s').splitlines():
@@ -559,7 +561,9 @@ def vmstats():
     # dict that returns a function that does the right thing per platform
     get_version = {
         'Linux': linux_vmstats,
-        'FreeBSD': freebsd_vmstats,
+        'FreeBSD': generic_vmstats,
+        'OpenBSD': generic_vmstats,
+        'SunOS': generic_vmstats,
     }
 
     errmsg = 'This method is unsupported on the current operating system!'

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -641,10 +641,31 @@ def netstats():
                     ret[key][' '.join(comps[1:])] = comps[0]
         return ret
 
+    def sunos_netstats():
+        '''
+        sunos specific netstats implementation
+        '''
+        ret = {}
+        for line in __salt__['cmd.run']('netstat -s').splitlines():
+            line = line.replace('=', ' = ').split()
+            if len(line) > 6:
+                line.pop(0)
+            if '=' in line:
+                if len(line) >= 3:
+                    if line[2].isdigit() or line[2][0] == '-':
+                        line[2] = int(line[2])
+                    ret[line[0]] = line[2]
+                if len(line) >= 6:
+                    if line[5].isdigit() or line[5][0] == '-':
+                        line[5] = int(line[5])
+                    ret[line[3]] = line[5]
+        return ret
+
     # dict that returns a function that does the right thing per platform
     get_version = {
         'Linux': linux_netstats,
         'FreeBSD': freebsd_netstats,
+        'SunOS': sunos_netstats,
     }
 
     errmsg = 'This method is unsupported on the current operating system!'

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -393,6 +393,7 @@ def cpuinfo():
 
 def diskstats():
     '''
+    ..versionchanged:: 2016.3.2
     Return the disk stats for this minion
 
     CLI Example:
@@ -430,9 +431,10 @@ def diskstats():
                              'weighted_ms_spent_in_io': _number(comps[13])}
         return ret
 
-    def freebsd_diskstats():
+    def generic_diskstats():
         '''
-        freebsd specific implementation of diskstats
+        generic implementation of diskstats
+        note: freebsd and sunos
         '''
         ret = {}
         iostat = __salt__['cmd.run']('iostat -xzd').splitlines()
@@ -447,7 +449,8 @@ def diskstats():
     # dict that return a function that does the right thing per platform
     get_version = {
         'Linux': linux_diskstats,
-        'FreeBSD': freebsd_diskstats,
+        'FreeBSD': generic_diskstats,
+        'SunOS': generic_diskstats,
     }
 
     errmsg = 'This method is unsupported on the current operating system!'


### PR DESCRIPTION
### What does this PR do?

The salt.module.status module now mostly works on Solaris like platforms.
As a bonus a few things now also work on OpenBSD because FreeBSD/OpenBSD/SunOS have a few compatible code paths.
### What issues does this PR fix or reference?
#30493
### Previous Behavior

Most stuff did not work on Solaris like platforms.
### New Behavior

Now it works.
### Tests written?

No, but tested the current unit tests and no breakage
### Affects
- 2016.3
- develop
