### PR TITLE
Make apache.configfile state handle the Options list correctly

### DIFF
--- a/salt/modules/apache.py
+++ b/salt/modules/apache.py
@@ -404,14 +404,13 @@ def _parse_config(conf, slot=None):
         else:
             print('{0}'.format(conf), file=ret, end='')
     elif isinstance(conf, list):
-        for value in conf:
-            print(_parse_config(value, str(slot)), file=ret)
+        print('{0} {1}'.format(slot, ' '.join(conf)), file=ret, end='')
     elif isinstance(conf, dict):
         print('<{0} {1}>'.format(
             slot,
             _parse_config(conf['this'])),
-            file=ret
-        )
+              file=ret
+             )
         del conf['this']
         for key, value in six.iteritems(conf):
             if isinstance(value, str):
@@ -452,6 +451,6 @@ def config(name, config, edit=True):
         configs = _parse_config(entry[key], key)
         if edit:
             with salt.utils.fopen(name, 'w') as configfile:
-                configfile.write('# This file is managed by saltstack.\n')
+                configfile.write('# This file is managed by Salt.\n')
                 configfile.write(configs)
     return configs

--- a/salt/states/apache.py
+++ b/salt/states/apache.py
@@ -33,7 +33,7 @@ the above word between angle brackets (<>).
                   - 127.0.0.1
                   - 192.168.100.0/24
                 Options:
-                  - +Indexes
+                  - Indexes
                   - FollowSymlinks
                 AllowOverride: All
 '''


### PR DESCRIPTION
### What does this PR do?
1. Fixes Apache httpd Virtualhost configuration file generation.
   
   Example SLS:
   
   ``` yaml
   Configure {{ vhost }} site:
     apache.configfile:
       - name: /etc/apache2/sites-available/{{ vhost }}.conf
       - config:
         - VirtualHost:
             this: '*:80'
             ServerName:
               - {{ vhost }}
             DocumentRoot: {{ vhost_dir }}
             Directory:
               this: {{ vhost_dir }}
               Options:
                 - Indexes
                 - FollowSymlinks
               AllowOverride: 'None'
               Require: all granted
             ErrorLog: ${APACHE_LOG_DIR}/{{ vhost }}_error.log
             CustomLog: ${APACHE_LOG_DIR}/{{ vhost }}_access.log combined
   ```
   
   It will produce a config with following `<Directory>` structure:
   
   ``` xml
   <Directory {{ vhost_dir }}>
   Options Indexes
   Options FollowSymlinks
   
   AllowOverride None
   Require all granted
   </Directory>
   ```
   
   And this is not that we really want to achieve. From Apache docs:
   https://httpd.apache.org/docs/current/mod/core.html
   
   ```
   Normally, if multiple Options could apply to a directory, then the most specific one is used and others are ignored; the options are not merged.
   ```
   
   In this particular case, the `Options Indexes` line will be ignored.
2. Fixes the example in the state docstring:
   
   ```
   Options:
     - +Indexes
     - FollowSymlinks
   ```
   
   This will not work causing the syntax error:
   
   ```
   Either all Options must start with + or -, or no Option may.
   ```
### Previous Behavior

The lists of options from SLS appeared in the file as:

```
{{ dict_key }} {{ list_item1 }}
{{ dict_key }} {{ list_item2 }}
...
{{ dict_key }} {{ list_itemN }}
```
### New Behavior

Put list of values to the single line in the config:

```
{{ dict_key }} {{ list_item1 }} {{ list_item2 }} ... {{ list_itemN }}
```

which is valid format for Apache directives with multiple options allowed.
### Tests written?

No
