### PR TITLE
Update correct default value for spm_build_dir

### DIFF
--- a/doc/topics/spm/config.rst
+++ b/doc/topics/spm/config.rst
@@ -41,7 +41,7 @@ and the metadata for those files.
 
 spm_build_dir
 -------------
-Default: ``/srv/spm``
+Default: ``/srv/spm_build``
 
 When packages are built, they will be placed in this directory.
 


### PR DESCRIPTION
### What does this PR do?

Fixes typo in docs (right?)
### What issues does this PR fix or reference?

Looks like docs have wrong default directory for `spm_build_dir` config option. It is actually `/srv/spm_build`.

See this line for reference:
https://github.com/saltstack/salt/blob/945b21b70dbe708716d7b009a2005ef0acf76e6b/salt/config/__init__.py#L1388
