### PR TITLE
Fix iptables.flush() state

### DIFF
--- a/salt/states/iptables.py
+++ b/salt/states/iptables.py
@@ -774,9 +774,6 @@ def flush(name, table='filter', family='ipv4', **kwargs):
         if ignore in kwargs:
             del kwargs[ignore]
 
-    if 'table' not in kwargs:
-        table = 'filter'
-
     if 'chain' not in kwargs:
         kwargs['chain'] = ''
     if __opts__['test']:


### PR DESCRIPTION
### What does this PR do?

Makes `table` argument of `iptables.flush` state work.

The "table" argument is already part of the function signature, this means
that flush() will always force the "filter" table even when the user sets
a different one.
### Previous Behavior

`table` was always set to `filter`.
### New Behavior

`table` is set to whatever the user passes (or `filter` if the user doesn't set anything).
### Tests written?

No
