### PR TITLE
Fix iptables.flush state: Do not force 'filter' table when flushing

### DIFF
--- a/salt/states/iptables.py
+++ b/salt/states/iptables.py
@@ -774,9 +774,6 @@ def flush(name, table='filter', family='ipv4', **kwargs):
         if ignore in kwargs:
             del kwargs[ignore]
 
-    if 'table' not in kwargs:
-        table = 'filter'
-
     if 'chain' not in kwargs:
         kwargs['chain'] = ''
     if __opts__['test']:

--- a/tests/unit/states/iptables_test.py
+++ b/tests/unit/states/iptables_test.py
@@ -353,8 +353,8 @@ class IptablesTestCase(TestCase):
                 with patch.dict(iptables.__salt__,
                                 {'iptables.flush': mock}):
                     ret.update({'changes': {'locale': 'salt'},
-                                'comment': 'Flush iptables rules in '
-                                'filter table  chain ipv4 family',
+                                'comment': 'Flush iptables rules in  '
+                                'table  chain ipv4 family',
                                 'result': True})
                     self.assertDictEqual(iptables.flush('salt',
                                                         table='', chain=''),


### PR DESCRIPTION
### What does this PR do?

Makes `table` argument of `iptables.flush` state work.

The "table" argument is already part of the function signature, this means
that flush() will always force the "filter" table even when the user sets
a different one.
### Previous Behavior

`table` was always set to `filter`.
### New Behavior

`table` is set to whatever the user passes (or `filter` if the user doesn't set anything).
### Tests written?

No
