### PR TITLE
Fix test example in integration testing docs

### DIFF
--- a/doc/topics/development/tests/integration.rst
+++ b/doc/topics/development/tests/integration.rst
@@ -410,13 +410,23 @@ to test states:
 
 .. code-block:: python
 
+    # Import python libs
+    from __future__ import absolute_import
     import os
     import shutil
+
+    # Import Salt Testing libs
+    from salttesting.helpers import ensure_in_syspath
+    ensure_in_syspath('../../')
+
+    # Import salt libs
     import integration
+    import salt.utils
 
     HFILE = os.path.join(integration.TMP, 'hosts')
 
-    class HostTest(integration.ModuleCase):
+
+    class HostTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
         '''
         Validate the host state
         '''
@@ -437,9 +447,8 @@ to test states:
             name = 'spam.bacon'
             ip = '10.10.10.10'
             ret = self.run_state('host.present', name=name, ip=ip)
-            result = self.state_result(ret)
-            self.assertTrue(result)
-            with open(HFILE) as fp_:
+            self.assertSaltTrueReturn(ret)
+            with salt.utils.fopen(HFILE) as fp_:
                 output = fp_.read()
                 self.assertIn('{0}\t\t{1}'.format(ip, name), output)
 


### PR DESCRIPTION
The example is out of date compared to the actual test it's modeling.

Notably, the self.state_result() function doesn't exist and it isn't using the `salt.utils.fopen` function.
