### PR TITLE
Making salt-ssh pass proper return codes for jinja rendering errors

### DIFF
--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -200,6 +200,7 @@ def main(argv):  # pylint: disable=W0613
     salt_argv = [
         sys.executable,
         salt_call_path,
+        '--retcode-passthrough',
         '--local',
         '--metadata',
         '--out', 'json',

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -1502,6 +1502,7 @@ def pkg(pkg_path, pkg_sum, hash_type, test=None, **kwargs):
         shutil.rmtree(root)
     except (IOError, OSError):
         pass
+    _set_retcode(ret)
     return ret
 
 


### PR DESCRIPTION
### What does this PR do?

It adds --retcode-passthrough to the salt-call command used by salt-ssh. It also changes the module state.pkg to return a return code.

This fixes a whole class of bugs in salt-ssh about return codes.
### What issues does this PR fix or reference?

Fixes #33674
Maybe  #28300
### Previous Behavior

salt-ssh's return code would be zero on jinja rendering errors
### New Behavior

salt-ssh's return code will be 20 on jinja rendering errors
### Tests written?

No
