### PR TITLE
add osmajorrelease grain for raspbian

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1489,6 +1489,8 @@ def os_data():
             os=grains['osfullname'],
             ver=grains['osrelease'].partition('.')[0])
     elif grains.get('osfullname') == 'Ubuntu':
+        grains['osmajorrelease'] = grains['osrelease'].split('.', 1)[0]
+
         grains['osfinger'] = '{os}-{ver}'.format(
             os=grains['osfullname'],
             ver=grains['osrelease'])

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1498,7 +1498,7 @@ def os_data():
         grains['osfinger'] = '{os}-{ver}'.format(
             os=grains['osfullname'],
             ver=grains['osrelease'].partition('.')[0])
-    elif grains.get('os') in ('FreeBSD', 'OpenBSD', 'NetBSD', 'Mac'):
+    elif grains.get('os') in ('FreeBSD', 'OpenBSD', 'NetBSD', 'Mac', 'Raspbian'):
         grains['osmajorrelease'] = grains['osrelease'].split('.', 1)[0]
 
         grains['osfinger'] = '{os}-{ver}'.format(

--- a/tests/integration/modules/grains.py
+++ b/tests/integration/modules/grains.py
@@ -105,6 +105,14 @@ class TestModulesGrains(integration.ModuleCase):
                     'grains.get',
                     ['level1:level2']),
                 'foo')
+    def test_get_core_grains(self):
+        '''
+        test to ensure some core grains are returned
+        '''
+        grains = ['os', 'os_family', 'osmajorrelease', 'osrelease', 'osfullname', 'id']
+        for grain in grains:
+            get_grain = self.run_function('grains.get', [grain])
+            self.assertTrue(get_grain, grain + "is not available")
 
 
 class GrainsAppendTestCase(integration.ModuleCase):

--- a/tests/integration/modules/grains.py
+++ b/tests/integration/modules/grains.py
@@ -105,6 +105,7 @@ class TestModulesGrains(integration.ModuleCase):
                     'grains.get',
                     ['level1:level2']),
                 'foo')
+
     def test_get_core_grains(self):
         '''
         test to ensure some core grains are returned


### PR DESCRIPTION
### What does this PR do?

Adds the osmajorrelease grains for raspberry pi boxes.
### What issues does this PR fix or reference?

Fixes #34321 
### Previous Behavior

```
salt '*' grains.item osmajorrelease

raspberrypi:
    ----------
    osmajorrelease
```
### New Behavior

```
root@raspberrypi:/etc# salt '*' grains.item osmajorrelease
raspberrypi:
    ----------
    osmajorrelease:
        8
```
### Tests written?

Yes
