### PR TITLE
Remove unnecessarily-disabled sanity check

### DIFF
--- a/tests/integration/states/pkg.py
+++ b/tests/integration/states/pkg.py
@@ -214,7 +214,7 @@ class PkgTest(integration.ModuleCase,
         # If this assert fails, we need to find new targets, this test needs to
         # be able to test successful installation of packages, so these
         # packages need to not be installed before we run the states below
-        #self.assertFalse(any(version.values()))
+        self.assertFalse(any(version.values()))
 
         ret = self.run_state('pkg.installed', name=None, pkgs=pkg_targets)
         self.assertSaltTrueReturn(ret)


### PR DESCRIPTION
This was commented out for reasons having nothing to do with anything
else going on in 0c069dd. Uncommenting this sanity check so that we are
notified if we need to update our targets in the future.
