### PR TITLE
feature mongodb return events

### DIFF
--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -289,8 +289,16 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
 
 def event_return(events):
     """
+    Return events to Mongodb server
+    """
+    conn, mdb = _get_conn(ret=None)
+    
+    if isinstance(events, list):
+        events = events[0]
+
     if isinstance(events, dict):
         log.debug(events)
+
         if float(version) > 2.3:
             mdb.events.insert_one(events.copy())
         else:

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -157,10 +157,12 @@ def _get_conn(ret):
             mdb.saltReturns.create_index('minion')
             mdb.saltReturns.create_index('jid')
             mdb.jobs.create_index('jid')
+            mdb.events.create_index('tag')
         else:
             mdb.saltReturns.ensure_index('minion')
             mdb.saltReturns.ensure_index('jid')
             mdb.jobs.ensure_index('jid')
+            mdb.events.ensure_index('tag')
 
     return conn, mdb
 
@@ -284,3 +286,12 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     Do any work necessary to prepare a JID, including sending a custom id
     '''
     return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
+
+def event_return(events):
+    """
+    if isinstance(events, dict):
+        log.debug(events)
+        if float(version) > 2.3:
+            mdb.events.insert_one(events.copy())
+        else:
+            mdb.events.insert(events.copy())


### PR DESCRIPTION
### What does this PR do?

Adds events to the mongodb returner
### What issues does this PR fix or reference?

None
### New Behavior

Sends events to mongodb server
and indexes on `tag`
### Tests written?

No
### Tested with

Mongodb server 3.2.7
pymongo 3.2
### usage

``` yaml
#/etc/salt/master
event_return: mongo
```

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
