### PR TITLE
Back-port #33734 to 2016.3

### DIFF
--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -317,7 +317,7 @@ def check_password(name, password, runas=None):
         runas = salt.utils.get_user()
 
     # rabbitmq introduced a native api to check a username and password in version 3.5.7.
-    if version[0] >= 3 and version[1] >= 5 and version[2] >= 7:
+    if tuple(version) >= (3, 5, 7):
         res = __salt__['cmd.run'](
             ['rabbitmqctl', 'authenticate_user', name, password],
             runas=runas,


### PR DESCRIPTION
Back-port #33734 to 2016.3

I submitted the original backport (#34304) against the develop branch accidentally. This PR is against the 2016.3 branch.

Refs #33588
