### PR TITLE
Change merge-if-exists logic to properly report changes

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -4394,45 +4394,6 @@ def accumulated(name, filename, text, **kwargs):
     _persist_accummulators(accum_data, accum_deps)
     return ret
 
-
-def _merge_dict(obj, k, v):
-    changes = {}
-    if k in obj:
-        if isinstance(obj[k], list):
-            if isinstance(v, list):
-                for a in v:
-                    if a not in obj[k]:
-                        changes[k] = a
-                        obj[k].append(a)
-            else:
-                if obj[k] != v:
-                    changes[k] = v
-                    obj[k] = v
-        elif isinstance(obj[k], dict):
-            if isinstance(v, dict):
-                for a, b in six.iteritems(v):
-                    if isinstance(b, dict) or isinstance(b, list):
-                        updates = _merge_dict(obj[k], a, b)
-                        for x, y in six.iteritems(updates):
-                            changes[k + "." + x] = y
-                    else:
-                        if a not in obj[k] or obj[k][a] != b:
-                            changes[k + "." + a] = b
-                            obj[k][a] = b
-            else:
-                if obj[k] != v:
-                    changes[k] = v
-                    obj[k] = v
-        else:
-            if obj[k] != v:
-                changes[k] = v
-                obj[k] = v
-    else:
-        changes[k] = v
-        obj[k] = v
-    return changes
-
-
 def serialize(name,
               dataset=None,
               dataset_pillar=None,
@@ -4587,37 +4548,37 @@ def serialize(name,
 
     serializer_name = '{0}.serialize'.format(formatter)
     deserializer_name = '{0}.deserialize'.format(formatter)
-    if serializer_name in __serializers__:
-        serializer = __serializers__[serializer_name]
-        if merge_if_exists:
-            if os.path.isfile(name):
-                if '{0}.deserialize'.format(formatter) in __serializers__:
-                    with salt.utils.fopen(name, 'r') as fhr:
-                        existing_data = __serializers__[deserializer_name](fhr)
-                else:
-                    return {'changes': {},
-                            'comment': ('{0} format is not supported for merging'
-                                        .format(formatter.capitalize())),
-                            'name': name,
-                            'result': False}
 
-                if existing_data is not None:
-                    for k, v in six.iteritems(dataset):
-                        if k in existing_data:
-                            ret['changes'].update(_merge_dict(existing_data, k, v))
-                        else:
-                            ret['changes'][k] = v
-                            existing_data[k] = v
-                    dataset = existing_data
-
-        contents = __serializers__[serializer_name](dataset)
-    else:
+    if serializer_name not in __serializers__:
         return {'changes': {},
                 'comment': '{0} format is not supported'.format(
                     formatter.capitalize()),
                 'name': name,
                 'result': False
                 }
+
+    if merge_if_exists:
+        if os.path.isfile(name):
+            if '{0}.deserialize'.format(formatter) not in __serializers__:
+                return {'changes': {},
+                        'comment': ('{0} format is not supported for merging'
+                                    .format(formatter.capitalize())),
+                        'name': name,
+                        'result': False}
+
+            with salt.utils.fopen(name, 'r') as fhr:
+                existing_data = __serializers__[deserializer_name](fhr)
+
+            if existing_data is not None:
+                merged_data = existing_data.copy()
+                merged_data.update(dataset)
+                if existing_data == merged_data:
+                    ret['result'] = True
+                    ret['comment'] = 'The file {0} is in the correct state'.format(name)
+                    return ret
+                dataset = merged_data
+
+    contents = __serializers__[serializer_name](dataset)
 
     contents += '\n'
 


### PR DESCRIPTION
### What does this PR do?

Changes the merge-if-exists logic to use a simple dict.update() and properly reports no changes if the content does not need to be changed.
### Previous Behavior

merge-if-exists would report changes on every run, whether or not changes were necessary.
### New Behavior

Uses a simple dict.update to compare the serialized data before and after applying the changes and only reports changes and writes to the file if the dicts are not equal.
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
