### PR TITLE
Add listen/listen_in support to stateconf.py

### DIFF
--- a/salt/renderers/stateconf.py
+++ b/salt/renderers/stateconf.py
@@ -363,7 +363,7 @@ def statelist(states_dict, sid_excludes=frozenset(['include', 'exclude'])):
 
 
 REQUISITES = set([
-    'require', 'require_in', 'watch', 'watch_in', 'use', 'use_in'
+    'require', 'require_in', 'watch', 'watch_in', 'use', 'use_in', 'listen', 'listen_in'
 ])
 
 
@@ -405,8 +405,8 @@ def rename_state_ids(data, sls, is_extend=False):
             del data[sid]
 
 
-REQUIRE = set(['require', 'watch'])
-REQUIRE_IN = set(['require_in', 'watch_in'])
+REQUIRE = set(['require', 'watch', 'listen'])
+REQUIRE_IN = set(['require_in', 'watch_in', 'listen_in'])
 EXTENDED_REQUIRE = {}
 EXTENDED_REQUIRE_IN = {}
 
@@ -414,8 +414,8 @@ from itertools import chain
 
 
 # To avoid cycles among states when each state requires the one before it:
-#   explicit require/watch can only contain states before it
-#   explicit require_in/watch_in can only contain states after it
+#   explicit require/watch/listen can only contain states before it
+#   explicit require_in/watch_in/listen_in can only contain states after it
 def add_implicit_requires(data):
 
     def T(sid, state):  # pylint: disable=C0103
@@ -449,7 +449,7 @@ def add_implicit_requires(data):
         for _, rstate, rsid in reqs:
             if T(rsid, rstate) in states_after:
                 raise SaltRenderError(
-                    'State({0}) can\'t require/watch a state({1}) defined '
+                    'State({0}) can\'t require/watch/listen a state({1}) defined '
                     'after it!'.format(tag, T(rsid, rstate))
                 )
 
@@ -459,7 +459,7 @@ def add_implicit_requires(data):
         for _, rstate, rsid in reqs:
             if T(rsid, rstate) in states_before:
                 raise SaltRenderError(
-                    'State({0}) can\'t require_in/watch_in a state({1}) '
+                    'State({0}) can\'t require_in/watch_in/listen_in a state({1}) '
                     'defined before it!'.format(tag, T(rsid, rstate))
                 )
 
@@ -571,7 +571,7 @@ def extract_state_confs(data, is_extend=False):
 
         if not is_extend and state_id in STATE_CONF_EXT:
             extend = STATE_CONF_EXT[state_id]
-            for requisite in 'require', 'watch':
+            for requisite in 'require', 'watch', 'listen':
                 if requisite in extend:
                     extend[requisite] += to_dict[state_id].get(requisite, [])
             to_dict[state_id].update(STATE_CONF_EXT[state_id])


### PR DESCRIPTION
Add `listen/listen_in` everywhere where `watch/watch_in` is used.
### What does this PR do?

Adds `listen/listen_in` support to `stateconf` renderer. I blindly added listen everywhere where `watch\watch_in` is used. Please don't believe me and find somebody who can either verify or reject this.

It does work for me, though. I assume `stateconf` renderer was written before `listen_in` was added:
- `stateconf` first commit was made on Oct 30, 2012https://github.com/saltstack/salt/commit/26fa7e16f8fc643c873c51f8605b0347f4da7983
- `listen_in` was added in `2014.7.0` according to docs https://docs.saltstack.com/en/latest/ref/states/requisites.html#listen-listen-in

But oh well, I'm not sure about it.
### What issues does this PR fix or reference?

`stateconf` renderer doesn't work in `listen` and `listen_in` fields. This is a naive attempt to fix it. Not sure it is done the right way, though.
### Previous Behavior

```
some/state:
  - listen_in:
    - service: .jenkins

.jenkins:
  service.running: []
```

```
----------
          ID: listen_.jenkins
    Function: Listen_Error.Listen_Error
        Name: listen_service
      Result: False
     Comment: Referenced state service: .jenkins does not exist
     Started:
    Duration:
     Changes:
```
### New Behavior

```
----------
          ID: listener_jenkins.config::jenkins
    Function: service.mod_watch
        Name: jenkins
      Result: True
     Comment: Service restarted
     Started: 17:08:20.897331
    Duration: 3024.693 ms
     Changes:
              ----------
              jenkins:
                  True
```
### Tests written?

No
