### PR TITLE
Revert py3modernize lint changes

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -60,7 +60,7 @@ def __define_global_system_encoding_variable__():
     # than expected. See:
     #    https://github.com/saltstack/salt/issues/21036
     if sys.version_info[0] < 3:
-        import __builtin__ as builtins
+        import __builtin__ as builtins  # pylint: disable=incompatible-py3-code
     else:
         import builtins  # pylint: disable=import-error
 

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -126,7 +126,7 @@ except Exception:
 
 # Disable InsecureRequestWarning generated on python > 2.6
 try:
-    from requests.packages.urllib3 import disable_warnings
+    from requests.packages.urllib3 import disable_warnings  # pylint: disable=no-name-in-module
     disable_warnings()
 except Exception:
     pass

--- a/salt/modules/jboss7_cli.py
+++ b/salt/modules/jboss7_cli.py
@@ -342,7 +342,7 @@ def __is_long(token):
 
 def __get_long(token):
     if six.PY2:
-        return long(token[0:-1])
+        return long(token[0:-1])  # pylint: disable=incompatible-py3-code
     else:
         return int(token[0:-1])
 

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -153,7 +153,9 @@ class Serial(object):
                     for idx, entry in enumerate(obj):
                         obj[idx] = verylong_encoder(entry)
                     return obj
-                if six.PY2 and isinstance(obj, long) and long > pow(2, 64):
+                # This is a spurious lint failure as we are gating this check
+                # behind a check for six.PY2.
+                if six.PY2 and isinstance(obj, long) and long > pow(2, 64):  # pylint: disable=incompatible-py3-code
                     return str(obj)
                 elif six.PY3 and isinstance(obj, int) and int > pow(2, 64):
                     return str(obj)

--- a/salt/serializers/yamlex.py
+++ b/salt/serializers/yamlex.py
@@ -390,7 +390,7 @@ Dumper.add_multi_representer(type(None), Dumper.represent_none)
 if six.PY2:
     Dumper.add_multi_representer(six.binary_type, Dumper.represent_str)
     Dumper.add_multi_representer(six.text_type, Dumper.represent_unicode)
-    Dumper.add_multi_representer(long, Dumper.represent_long)
+    Dumper.add_multi_representer(long, Dumper.represent_long)  # pylint: disable=incompatible-py3-code
 else:
     Dumper.add_multi_representer(six.binary_type, Dumper.represent_binary)
     Dumper.add_multi_representer(six.text_type, Dumper.represent_str)

--- a/salt/states/win_servermanager.py
+++ b/salt/states/win_servermanager.py
@@ -2,6 +2,7 @@
 '''
 Manage Windows features via the ServerManager powershell module
 '''
+from __future__ import absolute_import
 
 # Import salt modules
 import salt.utils

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -2038,11 +2038,7 @@ def alias_function(fun, name, doc=None):
     if doc and isinstance(doc, six.string_types):
         alias_fun.__doc__ = doc
     else:
-        if six.PY3:
-            orig_name = fun.__name__
-        else:
-            orig_name = fun.func_name
-
+        orig_name = fun.__name__
         alias_msg = ('\nThis function is an alias of '
                      '``{0}``.\n'.format(orig_name))
         alias_fun.__doc__ = alias_msg + fun.__doc__
@@ -2820,7 +2816,7 @@ def to_str(s, encoding=None):
     else:
         if isinstance(s, bytearray):
             return str(s)
-        if isinstance(s, unicode):
+        if isinstance(s, unicode):  # pylint: disable=incompatible-py3-code
             return s.encode(encoding or __salt_system_encoding__)
         raise TypeError('expected str, bytearray, or unicode')
 
@@ -2851,7 +2847,7 @@ def to_unicode(s, encoding=None):
     else:
         if isinstance(s, str):
             return s.decode(encoding or __salt_system_encoding__)
-        return unicode(s)
+        return unicode(s)  # pylint: disable=incompatible-py3-code
 
 
 def is_list(value):

--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -27,7 +27,7 @@ def condition_input(args, kwargs):
         # XXX: We might need to revisit this code when we move to Py3
         #      since long's are int's in Py3
         if (six.PY3 and isinstance(arg, six.integer_types)) or \
-                (six.PY2 and isinstance(arg, long)):
+                (six.PY2 and isinstance(arg, long)):  # pylint: disable=incompatible-py3-code
             ret.append(str(arg))
         else:
             ret.append(arg)

--- a/salt/utils/compat.py
+++ b/salt/utils/compat.py
@@ -38,7 +38,7 @@ def deepcopy_bound(name):
 
     '''
     def _deepcopy_method(x, memo):
-        return type(x)(x.im_func, copy.deepcopy(x.im_self, memo), x.im_class)
+        return type(x)(x.im_func, copy.deepcopy(x.im_self, memo), x.im_class)  # pylint: disable=incompatible-py3-code
     try:
         pre_dispatch = copy._deepcopy_dispatch
         copy._deepcopy_dispatch[types.MethodType] = _deepcopy_method

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -303,13 +303,13 @@ class _DeprecationDecorator(object):
             try:
                 return self._function(*args, **kwargs)
             except TypeError as error:
-                error = str(error).replace(self._function.func_name, self._orig_f_name)  # Hide hidden functions
+                error = str(error).replace(self._function.__name__, self._orig_f_name)  # Hide hidden functions
                 log.error('Function "{f_name}" was not properly called: {error}'.format(f_name=self._orig_f_name,
                                                                                         error=error))
                 return self._function.__doc__
             except Exception as error:
                 log.error('Unhandled exception occurred in '
-                          'function "{f_name}: {error}'.format(f_name=self._function.func_name,
+                          'function "{f_name}: {error}'.format(f_name=self._function.__name__,
                                                                error=error))
                 raise error
         else:
@@ -324,7 +324,7 @@ class _DeprecationDecorator(object):
         :return:
         '''
         self._function = function
-        self._orig_f_name = self._function.func_name
+        self._orig_f_name = self._function.__name__
 
 
 class _IsDeprecated(_DeprecationDecorator):
@@ -405,13 +405,13 @@ class _IsDeprecated(_DeprecationDecorator):
             '''
             if self._curr_version < self._exp_version:
                 msg = ['The function "{f_name}" is deprecated and will '
-                       'expire in version "{version_name}".'.format(f_name=self._function.func_name,
+                       'expire in version "{version_name}".'.format(f_name=self._function.__name__,
                                                                     version_name=self._exp_version_name)]
                 if self._successor:
                     msg.append('Use successor "{successor}" instead.'.format(successor=self._successor))
                 log.warning(' '.join(msg))
             else:
-                msg = ['The lifetime of the function "{f_name}" expired.'.format(f_name=self._function.func_name)]
+                msg = ['The lifetime of the function "{f_name}" expired.'.format(f_name=self._function.__name__)]
                 if self._successor:
                     msg.append('Please use its successor "{successor}" instead.'.format(successor=self._successor))
                 log.warning(' '.join(msg))
@@ -513,13 +513,13 @@ class _WithDeprecated(_DeprecationDecorator):
         :return:
         '''
         full_name = "{m_name}.{f_name}".format(m_name=self._globals.get(self.MODULE_NAME, ''),
-                                               f_name=function.func_name)
+                                               f_name=function.__name__)
         if full_name.startswith("."):
             self._raise_later = CommandExecutionError('Module not found for function "{f_name}"'.format(
-                f_name=function.func_name))
+                f_name=function.__name__))
 
         if full_name in self._options.get(self.CFG_KEY, list()):
-            self._function = self._globals.get(self._with_name or "_{0}".format(function.func_name))
+            self._function = self._globals.get(self._with_name or "_{0}".format(function.__name__))
 
     def _is_used_deprecated(self):
         '''
@@ -565,7 +565,7 @@ class _WithDeprecated(_DeprecationDecorator):
                     log.warning(' '.join(msg))
                 else:
                     msg_patt = 'The lifetime of the function "{f_name}" expired.'
-                    if '_' + self._orig_f_name == self._function.func_name:
+                    if '_' + self._orig_f_name == self._function.__name__:
                         msg = [msg_patt.format(f_name=self._orig_f_name),
                                'Please turn off its deprecated version in the configuration']
                     else:

--- a/salt/version.py
+++ b/salt/version.py
@@ -9,15 +9,18 @@ import re
 import sys
 import platform
 
-# Don't rely on external packages in this module since it's used at install time
 # pylint: disable=invalid-name,redefined-builtin
+# Import 3rd-party libs
+from salt.ext import six
+from salt.ext.six.moves import map
+
+# Don't rely on external packages in this module since it's used at install time
 if sys.version_info[0] == 3:
     MAX_SIZE = sys.maxsize
     string_types = (str,)
 else:
     MAX_SIZE = sys.maxint
-    string_types = (basestring,)
-    from itertools import imap as map
+    string_types = (six.string_types,)
 # pylint: enable=invalid-name,redefined-builtin
 
 # ----- ATTENTION --------------------------------------------------------------------------------------------------->

--- a/tests/salt-tcpdump.py
+++ b/tests/salt-tcpdump.py
@@ -124,7 +124,7 @@ class PCAPParser(object):
                            'tcp': {}
                           }
 
-            (header, packet) = cap.next()
+            (header, packet) = cap.next()  # pylint: disable=incompatible-py3-code
 
             eth_length, eth_protocol = self.parse_ether(packet)
 


### PR DESCRIPTION
These were legitimate uses of disabling the `incompatible-py3-code check`, which
due to some idiosyncrasy on the jenkins server were causing an error and most
of the pylint disables here were removed in 35b2076 to satisfy the linter.
After a recent change to the PR lint jenkins job, these now fail as expected
without the disable.

This pull request resolves failing `incompatible-py3-code` and fixes a couple
legit failures of this check.
