### PR TITLE
added an optional parameter into boto_sns absent state to remove all …

### DIFF
--- a/salt/modules/boto_sns.py
+++ b/salt/modules/boto_sns.py
@@ -178,6 +178,30 @@ def subscribe(topic, protocol, endpoint, region=None, key=None, keyid=None, prof
     return True
 
 
+def unsubscribe(topic, subscription_arn, region=None, key=None, keyid=None, profile=None):
+    '''
+    Unsubscribe a specific SubscriptionArn of a topic.
+
+    CLI example to unsubscribe a subscription to a topic::
+
+        salt myminion boto_sns.unsubscribe my_topic my_subscription_arn region=us-east-1
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    if subscription_arn.startswith('arn:aws:sns:') is False:
+        return False
+
+    try:
+        conn.unsubscribe(subscription_arn)
+        log.info('Unsubscribe {0} to {1} topic'.format(subscription_arn, topic))
+    except Exception as e:
+        log.error('Unsubscribe Error: {0}'.format(e))
+        return False
+    else:
+        __context__.pop(_subscriptions_cache_key(topic), None)
+        return True
+
+
 def get_arn(name, region=None, key=None, keyid=None, profile=None):
     '''
     Returns the full ARN for a given topic name.

--- a/salt/modules/boto_sns.py
+++ b/salt/modules/boto_sns.py
@@ -182,9 +182,13 @@ def unsubscribe(topic, subscription_arn, region=None, key=None, keyid=None, prof
     '''
     Unsubscribe a specific SubscriptionArn of a topic.
 
-    CLI example to unsubscribe a subscription to a topic::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt myminion boto_sns.unsubscribe my_topic my_subscription_arn region=us-east-1
+
+    .. versionadded:: Carbon
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 

--- a/salt/states/boto_sns.py
+++ b/salt/states/boto_sns.py
@@ -233,6 +233,7 @@ def absent(
     unsubscribe
         If True, unsubscribe all subcriptions to the SNS topic before
         deleting the SNS topic
+        .. versionadded:: Carbon
     '''
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 


### PR DESCRIPTION
### What does this PR do?

adds an optional parameter into boto_sns absent state to remove subscriptions tied to the topic being removed.
### What issues does this PR fix or reference?

right now, when an SNS topic is deleted, the subscriptions for the topic is left in place.
### Previous Behavior

the absent state will only remove the SNS topic.
### New Behavior

the old behavior is retained when newly added unsubscribe parameter is False (default).

if the unsubscribe parameter is True in the absent state, all subscriptions for the topic will be removed first, prior to deleting the topic.
### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

…subscriptions tied to the topic being removed.
