### PR TITLE
Remove proxy check and additional GetConnection--this makes the proxy…

### DIFF
--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -187,8 +187,6 @@ def get_service_instance(host, username, password, protocol=None, port=None):
     service_instance = GetSi()
     if service_instance:
         if service_instance._GetStub().host == ':'.join([host, str(port)]):
-            if salt.utils.is_proxy():
-                service_instance._GetStub().GetConnection()
             return service_instance
         Disconnect(service_instance)
 


### PR DESCRIPTION
… fail to start.  Need to check to see if proxy memory leak is back.
### What does this PR do?

Removes the extra GetConnection and check for salt-proxy.  This check causes the proxy to fail to start.
### Previous Behavior

ESXi proxy minion fails to start with error messages indicating the SSL certificate failed to verify.
### New Behavior

ESXi proxy starts successfully.
### Tests written?

No
