### PR TITLE
Add salt.utils import to wheel.key.py

### DIFF
--- a/salt/key.py
+++ b/salt/key.py
@@ -17,19 +17,19 @@ import logging
 
 # Import salt libs
 import salt.crypt
-import salt.utils
 import salt.client
 import salt.exceptions
-import salt.utils.event
 import salt.daemons.masterapi
-from salt.utils import kinds
-from salt.utils.event import tagify
+import salt.utils
+import salt.utils.event
+import salt.utils.kinds
 
-# Import third party libs
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 import salt.ext.six as six
 from salt.ext.six.moves import input
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
+
+# Import third party libs
 try:
     import msgpack
 except ImportError:
@@ -536,7 +536,7 @@ class Key(object):
     def __init__(self, opts):
         self.opts = opts
         kind = self.opts.get('__role', '')  # application kind
-        if kind not in kinds.APPL_KINDS:
+        if kind not in salt.utils.kinds.APPL_KINDS:
             emsg = ("Invalid application kind = '{0}'.".format(kind))
             log.error(emsg + '\n')
             raise ValueError(emsg)
@@ -811,7 +811,8 @@ class Key(object):
                     eload = {'result': True,
                              'act': 'accept',
                              'id': key}
-                    self.event.fire_event(eload, tagify(prefix='key'))
+                    self.event.fire_event(eload,
+                                          salt.utils.event.tagify(prefix='key'))
                 except (IOError, OSError):
                     pass
         return (
@@ -839,7 +840,8 @@ class Key(object):
                 eload = {'result': True,
                          'act': 'accept',
                          'id': key}
-                self.event.fire_event(eload, tagify(prefix='key'))
+                self.event.fire_event(eload,
+                                      salt.utils.event.tagify(prefix='key'))
             except (IOError, OSError):
                 pass
         return self.list_keys()
@@ -881,7 +883,8 @@ class Key(object):
                     eload = {'result': True,
                              'act': 'delete',
                              'id': key}
-                    self.event.fire_event(eload, tagify(prefix='key'))
+                    self.event.fire_event(eload,
+                                          salt.utils.event.tagify(prefix='key'))
                 except (OSError, IOError):
                     pass
         if preserve_minions:
@@ -908,7 +911,8 @@ class Key(object):
                     eload = {'result': True,
                                  'act': 'delete',
                                  'id': key}
-                    self.event.fire_event(eload, tagify(prefix='key'))
+                    self.event.fire_event(eload,
+                                          salt.utils.event.tagify(prefix='key'))
                 except (OSError, IOError):
                     pass
         self.check_minion_cache()
@@ -925,7 +929,8 @@ class Key(object):
                     eload = {'result': True,
                              'act': 'delete',
                              'id': key}
-                    self.event.fire_event(eload, tagify(prefix='key'))
+                    self.event.fire_event(eload,
+                                          salt.utils.event.tagify(prefix='key'))
                 except (OSError, IOError):
                     pass
         self.check_minion_cache()
@@ -965,7 +970,8 @@ class Key(object):
                     eload = {'result': True,
                             'act': 'reject',
                             'id': key}
-                    self.event.fire_event(eload, tagify(prefix='key'))
+                    self.event.fire_event(eload,
+                                          salt.utils.event.tagify(prefix='key'))
                 except (IOError, OSError):
                     pass
         self.check_minion_cache()
@@ -996,7 +1002,8 @@ class Key(object):
                 eload = {'result': True,
                          'act': 'reject',
                          'id': key}
-                self.event.fire_event(eload, tagify(prefix='key'))
+                self.event.fire_event(eload,
+                                      salt.utils.event.tagify(prefix='key'))
             except (IOError, OSError):
                 pass
         self.check_minion_cache()
@@ -1075,7 +1082,7 @@ class RaetKey(Key):
                     shutil.rmtree(os.path.join(m_cache, minion))
 
         kind = self.opts.get('__role', '')  # application kind
-        if kind not in kinds.APPL_KINDS:
+        if kind not in salt.utils.kinds.APPL_KINDS:
             emsg = ("Invalid application kind = '{0}'.".format(kind))
             log.error(emsg + '\n')
             raise ValueError(emsg)

--- a/salt/utils/job.py
+++ b/salt/utils/job.py
@@ -6,10 +6,9 @@ import logging
 
 # Import Salt libs
 import salt.minion
-import salt.utils.verify
 import salt.utils.jid
-from salt.utils.event import tagify
-
+import salt.utils.event
+import salt.utils.verify
 
 log = logging.getLogger(__name__)
 
@@ -64,7 +63,8 @@ def store_job(opts, load, event=None, mminion=None):
     if event:
         # If the return data is invalid, just ignore it
         log.info('Got return from {id} for job {jid}'.format(**load))
-        event.fire_event(load, tagify([load['jid'], 'ret', load['id']], 'job'))
+        event.fire_event(load,
+                         salt.utils.event.tagify([load['jid'], 'ret', load['id']], 'job'))
         event.fire_ret_load(load)
 
     # if you have a job_cache, or an ext_job_cache, don't write to

--- a/salt/wheel/__init__.py
+++ b/salt/wheel/__init__.py
@@ -2,20 +2,22 @@
 '''
 Modules used to control the master itself
 '''
+
+# Import Python libs
 from __future__ import absolute_import
-#import python libs
-import os
 import collections
 
 # Import salt libs
-from salt import syspaths
+import salt.client.mixins
 import salt.config
 import salt.loader
-from salt.client import mixins
-from salt.utils.error import raise_error
+import salt.transport
+import salt.utils
+import salt.utils.error
 
 
-class WheelClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
+class WheelClient(salt.client.mixins.SyncClientMixin,
+                  salt.client.mixins.AsyncClientMixin, object):
     '''
     An interface to Salt's wheel modules
 
@@ -66,7 +68,7 @@ class WheelClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
         ret = channel.send(load)
         if isinstance(ret, collections.Mapping):
             if 'error' in ret:
-                raise_error(**ret['error'])
+                salt.utils.error.raise_error(**ret['error'])
         return ret
 
     def cmd_sync(self, low, timeout=None):

--- a/salt/wheel/key.py
+++ b/salt/wheel/key.py
@@ -11,6 +11,7 @@ import hashlib
 # Import salt libs
 import salt.key
 import salt.crypt
+import salt.utils
 
 __func_alias__ = {
     'list_': 'list'

--- a/salt/wheel/key.py
+++ b/salt/wheel/key.py
@@ -2,9 +2,9 @@
 '''
 Wheel system wrapper for key system
 '''
-from __future__ import absolute_import
 
 # Import python libs
+from __future__ import absolute_import
 import os
 import hashlib
 

--- a/tests/integration/wheel/client.py
+++ b/tests/integration/wheel/client.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
-# Import Salt Testing libs
+# Import Python libs
 from __future__ import absolute_import
+
+# Import Salt Testing libs
 import integration
 
 # Import Salt libs


### PR DESCRIPTION
### What does this PR do?

Adds a handy import to allow wheel tests to pass in Python3.
### Previous Behavior

All tests run with `-w` would fail.
### New Behavior

`-w` tests pass.
### Tests written?

No
