### PR TITLE
Fix invalid syntax error in system.py module exception handling

### DIFF
--- a/salt/modules/system.py
+++ b/salt/modules/system.py
@@ -193,7 +193,7 @@ def _try_parse_datetime(time_str, fmts):
         try:
             result = datetime.strptime(time_str, fmt)
             break
-        except ValueError, e:
+        except ValueError:
             pass
     return result
 


### PR DESCRIPTION
### What does this PR do?

Fixes a syntax error when running runner tests in Python 3.
