### PR TITLE
Send traps to Zabbix when there is a comment and name in result.

### DIFF
--- a/salt/returners/zabbix_return.py
+++ b/salt/returners/zabbix_return.py
@@ -55,10 +55,10 @@ def returner(ret):
 
     if type(ret['return']) is dict:
         for state, item in ret['return'].iteritems():
-            if not item['result']:
+            if 'comment' in item and 'name' in item and not item['result']:
                 errors = True
                 zabbix_send("salt.trap.high", host, 'SALT:\nname: {0}\ncomment: {1}'.format(item['name'], item['comment']))
-            if item['changes']:
+            if 'comment' in item and 'name' in item and item['changes']:
                 changes = True
                 zabbix_send("salt.trap.warning", host, 'SALT:\nname: {0}\ncomment: {1}'.format(item['name'], item['comment']))
 


### PR DESCRIPTION
### What does this PR do?

Check for 'comment' and 'name' in ret.
### What issues does this PR fix or reference?

Fix breaking the returner when there are now keys called 'comment' and 'name' in ret['result']
### Tests written?

No

ret['return'] not always contain 'comment', and 'name' values, Check is added.
