### PR TITLE
fixes computenode_* grains on SmartOS compute nodes

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1391,8 +1391,8 @@ def os_data():
             uname_v = os.uname()[3]
             grains['os'] = grains['osfullname'] = 'SmartOS'
             grains['osrelease'] = uname_v[uname_v.index('_')+1:]
-        elif salt.utils.is_smartos_globalzone():
-            grains.update(_smartos_computenode_data())
+            if salt.utils.is_smartos_globalzone():
+                grains.update(_smartos_computenode_data())
         elif os.path.isfile('/etc/release'):
             with salt.utils.fopen('/etc/release', 'r') as fp_:
                 rel_data = fp_.read()


### PR DESCRIPTION
### What does this PR do?

Fixes the computenode_\* grains for SmartOS, somewhere before release they got broken.
I only noticed now because I try to consume them in the runner I am working on. Oops!
### What issues does this PR fix or reference?

N/a
### Previous Behavior

is_smartos is always true if is_smartos_global is true, so the section was never hit for inclusion.
### New Behavior

Change elif to if, so now the grains do get added
### Tests written?

No
### Affected branches
- 2016.3
- develop
