### PR TITLE
Fix crash in git.detached when ref is a commit ID

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -1372,7 +1372,7 @@ def describe(cwd, rev='HEAD', user=None, ignore_retcode=False):
     cwd = _expand_path(cwd, user)
     if not isinstance(rev, six.string_types):
         rev = str(rev)
-    command = ['git', 'describe', rev]
+    command = ['git', 'describe', '--always', rev]
     return _git_run(command,
                     cwd=cwd,
                     runas=user,

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -1946,7 +1946,7 @@ def detached(name,
 
         local_commit_id = _get_local_rev_and_branch(target, user)[0]
 
-        if remote_ref_type is 'hash' and __salt__['git.describe'](ref):
+        if remote_ref_type is 'hash' and __salt__['git.describe'](target, ref):
             # The ref is a hash and it exists locally so skip to checkout
             hash_exists_locally = True
         else:
@@ -2110,7 +2110,7 @@ def detached(name,
     #get refs and checkout
     checkout_commit_id = ''
     if remote_ref_type is 'hash':
-        if __salt__['git.describe'](ref):
+        if __salt__['git.describe'](target, ref):
             checkout_commit_id = ref
         else:
             return _fail(


### PR DESCRIPTION
### What does this PR do?

Fix `git.detached` crash due to missing `cwd` parameter for `git.describe`, and subsequent failure due to missing `--always` parameter in `git.describe`. I'm not sure if the `--always` parameter will break any unrelated code.
### What issues does this PR fix or reference?

See #34371 for details.
### Tests written?

No
