### PR TITLE
Optimize pkg integration tests and add a couple new tests

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1004,6 +1004,10 @@ def installed(
               pkg.installed:
                 - only_upgrade: True
 
+        .. note::
+            If this parameter is set to True and the package is not already
+            installed, the state will fail.
+
     :return:
         A dictionary containing the state of the software installation
     :rtype dict:
@@ -1506,6 +1510,9 @@ def latest(
           pkg.latest:
             - only_upgrade: True
 
+    .. note::
+        If this parameter is set to True and the package is not already
+        installed, the state will fail.
     '''
     rtag = __gen_rtag()
     refresh = bool(

--- a/tests/integration/files/file/base/pkg_latest_epoch.sls
+++ b/tests/integration/files/file/base/pkg_latest_epoch.sls
@@ -1,3 +1,0 @@
-nova_packages:
-  pkg.latest:
-    - name: bash-completion

--- a/tests/integration/states/pkg.py
+++ b/tests/integration/states/pkg.py
@@ -414,7 +414,7 @@ class PkgTest(integration.ModuleCase,
         if not pkgmgr_avail(self.run_function, self.run_function('grains.items')):
             self.skipTest('Package manager is not available')
 
-        ret = self.run_function('state.sls', mods='pkg_latest_epoch')
+        ret = self.run_state('pkg.installed', name='bash-completion')
         self.assertSaltTrueReturn(ret)
 
     @skipIf(salt.utils.is_windows(), 'minion is windows')

--- a/tests/integration/states/pkg.py
+++ b/tests/integration/states/pkg.py
@@ -376,7 +376,7 @@ class PkgTest(integration.ModuleCase,
 
     @skipIf(salt.utils.is_windows(), 'minion is windows')
     @requires_system_grains
-    def test_pkg_with_epoch_in_version(self, grains=None):
+    def test_pkg_008_epoch_in_version(self, grains=None):
         '''
         This tests for the regression found in the following issue:
         https://github.com/saltstack/salt/issues/8614
@@ -403,7 +403,7 @@ class PkgTest(integration.ModuleCase,
             self.assertSaltTrueReturn(ret)
 
     @skipIf(salt.utils.is_windows(), 'minion is windows')
-    def test_pkg_008_latest_with_epoch(self):
+    def test_pkg_009_latest_with_epoch(self):
         '''
         This tests for the following issue:
         https://github.com/saltstack/salt/issues/31014
@@ -417,8 +417,9 @@ class PkgTest(integration.ModuleCase,
         ret = self.run_function('state.sls', mods='pkg_latest_epoch')
         self.assertSaltTrueReturn(ret)
 
+    @skipIf(salt.utils.is_windows(), 'minion is windows')
     @requires_salt_modules('pkg.info_installed')
-    def test_pkg_009_latest_with_epoch_and_info_installed(self):
+    def test_pkg_010_latest_with_epoch_and_info_installed(self):
         '''
         Need to check to ensure the package has been
         installed after the pkg_latest_epoch sls

--- a/tests/integration/states/pkg.py
+++ b/tests/integration/states/pkg.py
@@ -402,7 +402,6 @@ class PkgTest(integration.ModuleCase,
             ret = self.run_state('pkg.removed', name=target)
             self.assertSaltTrueReturn(ret)
 
-    @destructiveTest
     @skipIf(salt.utils.is_windows(), 'minion is windows')
     def test_pkg_008_latest_with_epoch(self):
         '''


### PR DESCRIPTION
This pull request adds a couple new tests, and also keeps the pkg database from
being refreshed in every test, restricting refreshes to once per run of the
tests in the PkgTest class.

It also keeps us from unnecessarily running pkg.latest_version on a given
package when we've already done so during a test run, by storing the results in
a global-scope dictionary.
