### PR TITLE
network_settings.py: fix documentation

### DIFF
--- a/salt/beacons/network_settings.py
+++ b/salt/beacons/network_settings.py
@@ -96,12 +96,13 @@ def beacon(config):
     .. code-block:: yaml
 
         beacons:
-          eth0:
-            ipaddr:
-            promiscuity:
-              onvalue: 1
-          eth1:
-            linkmode:
+          network_settings:
+            eth0:
+              ipaddr:
+              promiscuity:
+                onvalue: 1
+            eth1:
+              linkmode:
 
     The config above will check for value changes on eth0 ipaddr and eth1 linkmode. It will also
     emit if the promiscuity value changes to 1.
@@ -115,10 +116,11 @@ def beacon(config):
     .. code-block:: yaml
 
         beacons:
-          coalesce: True
-          eth0:
-            ipaddr:
-            promiscuity:
+          network_settings:
+            coalesce: True
+            eth0:
+              ipaddr:
+              promiscuity:
 
     '''
     ret = []


### PR DESCRIPTION
### What does this PR do?

Documentation fix
### What issues does this PR fix or reference?
### Tests written?

/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

Module documentation is showing an incorrect config example since it's
omitting the network_settings identifier.

Signed-off-by: Alejandro del Castillo alejandro.delcastillo@ni.com
