### PR TITLE
System date module change interface

### DIFF
--- a/salt/modules/system.py
+++ b/salt/modules/system.py
@@ -219,7 +219,7 @@ def get_system_time(utc=None):
     return datetime.strftime(t, "%I:%M %p")
 
 
-def set_system_time(newtime, utc=None, posix=None):
+def set_system_time(newtime, utc=None):
     '''
     Set the system time.
 
@@ -251,7 +251,7 @@ def set_system_time(newtime, utc=None, posix=None):
         return False
 
     return set_system_date_time(hours=dt_obj.hour, minutes=dt_obj.minute,
-                                seconds=dt_obj.second, utc=utc, posix=posix)
+                                seconds=dt_obj.second, utc=utc)
 
 
 def get_system_date_time(utc=None):
@@ -282,8 +282,7 @@ def set_system_date_time(years=None,
                          hours=None,
                          minutes=None,
                          seconds=None,
-                         utc=None,
-                         posix=None):
+                         utc=None):
     '''
     Set the system date and time. Each argument is an element of the date, but
     not required. If an element is not passed, the current system value for
@@ -298,7 +297,6 @@ def set_system_date_time(years=None,
     :param int minutes: Minutes digit: 0 - 59
     :param int seconds: Seconds digit: 0 - 59
     :param bool utc: A Boolean to specify input time is UTC.
-    :param bool posix: A Boolean to specify to use the posix date backend
 
     :return: True if successful. Otherwise False.
     :rtype: bool
@@ -330,10 +328,10 @@ def set_system_date_time(years=None,
         seconds = date_time.second
 
     dt = datetime(years, months, days, hours, minutes, seconds)
-    if posix is True:
-        return _posix_set_datetime(dt, utc=utc)
-    else:
+    if salt.utils.is_linux():
         return _linux_set_datetime(dt, utc=utc)
+    else:
+        return _posix_set_datetime(dt, utc=utc)
 
 
 def get_system_date(utc=None):

--- a/salt/modules/system.py
+++ b/salt/modules/system.py
@@ -346,7 +346,7 @@ def set_system_date_time(years=None,
     try:
         new_datetime = datetime(years, months, days, hours, minutes, seconds, 0,
                                 date_time.tzinfo)
-    except ValueError, err:
+    except ValueError as err:
         raise SaltInvocationError(err.message)
 
     return _date_bin_set_datetime(new_datetime)

--- a/tests/integration/modules/system.py
+++ b/tests/integration/modules/system.py
@@ -108,50 +108,6 @@ class SystemModuleTest(integration.ModuleCase):
 
     @destructiveTest
     @skipIf(os.geteuid() != 0, 'you must be root to run this test')
-    def test_set_system_date_time_posix(self):
-        '''
-        Test changing the system clock. We are only able to set it up to a
-        resolution of a second so this test may appear to run in negative time.
-        '''
-        self._fake_time = datetime.datetime.strptime("1981-02-03 04:05:06",
-                                                     self.fmt_str)
-
-        self._save_time()
-        result = self._set_time(self._fake_time)
-
-        time_now = datetime.datetime.now()
-        msg = ("Difference in times is too large. Now: {0} Fake: {1}"
-               .format(time_now, self._fake_time))
-        # posix only enables setting to minute
-        self.assertTrue(result and self._same_times(time_now, self._fake_time,
-                        seconds_diff=60), msg=msg)
-
-        self._restore_time()
-
-    @destructiveTest
-    @skipIf(os.geteuid() != 0, 'you must be root to run this test')
-    def test_set_system_date_time_posix_utc(self):
-        '''
-        Test changing the system clock. We are only able to set it up to a
-        resolution of a second so this test may appear to run in negative time.
-        '''
-        self._fake_time = datetime.datetime.strptime("1981-02-03 04:05:06",
-                                                     self.fmt_str)
-
-        self._save_time()
-        result = self._set_time(self._fake_time, utc=True)
-
-        time_now = datetime.datetime.utcnow()
-        msg = ("Difference in times is too large. Now: {0} Fake: {1}"
-               .format(time_now, self._fake_time))
-        # posix only enables setting to minute
-        self.assertTrue(result and self._same_times(time_now, self._fake_time,
-                        seconds_diff=60), msg=msg)
-
-        self._restore_time(utc=True)
-
-    @destructiveTest
-    @skipIf(os.geteuid() != 0, 'you must be root to run this test')
     def test_set_system_time(self):
         '''
         Test setting the system time without adjusting the date.

--- a/tests/integration/modules/system.py
+++ b/tests/integration/modules/system.py
@@ -27,10 +27,9 @@ class SystemModuleTest(integration.ModuleCase):
     def _save_time(self):
         self._orig_time = datetime.datetime.now()
 
-    def _set_time(self, new_time, posix=None, utc=None):
+    def _set_time(self, new_time, utc=None):
         t = new_time.timetuple()[:6]
-        return self.run_function('system.set_system_date_time', t,
-                                 posix=posix, utc=utc)
+        return self.run_function('system.set_system_date_time', t, utc=utc)
 
     def _restore_time(self, utc=None):
         if utc is True:
@@ -118,7 +117,7 @@ class SystemModuleTest(integration.ModuleCase):
                                                      self.fmt_str)
 
         self._save_time()
-        result = self._set_time(self._fake_time, posix=True)
+        result = self._set_time(self._fake_time)
 
         time_now = datetime.datetime.now()
         msg = ("Difference in times is too large. Now: {0} Fake: {1}"
@@ -140,7 +139,7 @@ class SystemModuleTest(integration.ModuleCase):
                                                      self.fmt_str)
 
         self._save_time()
-        result = self._set_time(self._fake_time, posix=True, utc=True)
+        result = self._set_time(self._fake_time, utc=True)
 
         time_now = datetime.datetime.utcnow()
         msg = ("Difference in times is too large. Now: {0} Fake: {1}"

--- a/tests/integration/modules/system.py
+++ b/tests/integration/modules/system.py
@@ -16,31 +16,51 @@ ensure_in_syspath('../../')
 
 # Import salt libs
 import integration
+import salt.utils
 
-
+@skipIf(not salt.utils.is_linux(), 'These tests can only be run on linux')
 class SystemModuleTest(integration.ModuleCase):
     '''
     Validate the date/time functions in the system module
     '''
     fmt_str = "%Y-%m-%d %H:%M:%S"
 
+    def __init__(self, arg):
+        super(self.__class__, self).__init__(arg)
+        self._orig_time = None
+
+    def setUp(self):
+        super(SystemModuleTest, self).setUp()
+        os_grain = self.run_function('grains.item', ['kernel'])
+        if os_grain['kernel'] not in ('Linux'):
+            self.skipTest(
+                'Test not applicable to \'{kernel}\' kernel'.format(
+                    **os_grain
+                )
+            )
+
+    def tearDown(self):
+        if self._orig_time is not None:
+            self._restore_time()
+        self._orig_time = None
+
     def _save_time(self):
-        self._orig_time = datetime.datetime.now()
+        self._orig_time = datetime.datetime.utcnow()
 
-    def _set_time(self, new_time, utc=None):
+    def _set_time(self, new_time, offset=None):
         t = new_time.timetuple()[:6]
-        return self.run_function('system.set_system_date_time', t, utc=utc)
+        t += (offset,)
+        return self.run_function('system.set_system_date_time', t)
 
-    def _restore_time(self, utc=None):
-        if utc is True:
-            t = datetime.datetime.utcnow()
-        else:
-            t = datetime.datetime.now()
-        test_timediff = t - self._fake_time
-        now = test_timediff + self._orig_time
-        self._set_time(now)
+    def _restore_time(self):
+        result = self._set_time(self._orig_time, "+0000")
+        self.assertTrue(result, msg="Unable to restore time properly")
 
-    def _same_times(self, t1, t2, seconds_diff=1):
+    def _same_times(self, t1, t2, seconds_diff=2):
+        '''
+        Helper function to check if two datetime objects
+        are close enough to the same time.
+        '''
         return abs(t1 - t2) < datetime.timedelta(seconds=seconds_diff)
 
     def test_get_system_date_time(self):
@@ -59,7 +79,8 @@ class SystemModuleTest(integration.ModuleCase):
         Test we are able to get the correct time with utc
         '''
         t1 = datetime.datetime.utcnow()
-        res = self.run_function('system.get_system_date_time', utc=True)
+        res = self.run_function('system.get_system_date_time',
+                                utc_offset="+0000")
         t2 = datetime.datetime.strptime(res, self.fmt_str)
         msg = ("Difference in times is too large. Now: {0} Fake: {1}"
                .format(t1, t2))
@@ -72,18 +93,17 @@ class SystemModuleTest(integration.ModuleCase):
         Test changing the system clock. We are only able to set it up to a
         resolution of a second so this test may appear to run in negative time.
         '''
-        self._fake_time = datetime.datetime.strptime("1981-02-03 04:05:06",
-                                                     self.fmt_str)
+        cmp_time = datetime.datetime.strptime("1981-02-03 04:05:06",
+                                              self.fmt_str)
 
         self._save_time()
-        self._set_time(self._fake_time)
+        result = self._set_time(cmp_time)
 
         time_now = datetime.datetime.now()
         msg = ("Difference in times is too large. Now: {0} Fake: {1}"
-               .format(time_now, self._fake_time))
-        self.assertTrue(self._same_times(time_now, self._fake_time), msg=msg)
-
-        self._restore_time()
+               .format(time_now, cmp_time))
+        self.assertTrue(result and self._same_times(time_now, cmp_time),
+                        msg=msg)
 
     @destructiveTest
     @skipIf(os.geteuid() != 0, 'you must be root to run this test')
@@ -92,19 +112,61 @@ class SystemModuleTest(integration.ModuleCase):
         Test changing the system clock. We are only able to set it up to a
         resolution of a second so this test may appear to run in negative time.
         '''
-        self._fake_time = datetime.datetime.strptime("1981-02-03 04:05:06",
-                                                     self.fmt_str)
+        cmp_time = datetime.datetime.strptime("1981-02-03 04:05:06", self.fmt_str)
 
         self._save_time()
-        result = self._set_time(self._fake_time, utc=True)
+        result = self._set_time(cmp_time, offset="+0000")
 
         time_now = datetime.datetime.utcnow()
         msg = ("Difference in times is too large. Now: {0} Fake: {1}"
-               .format(time_now, self._fake_time))
-        self.assertTrue(result and self._same_times(time_now, self._fake_time),
-                        msg=msg)
+               .format(time_now, cmp_time))
+        self.assertTrue(result)
+        self.assertTrue(self._same_times(time_now, cmp_time), msg=msg)
 
-        self._restore_time(utc=True)
+    @destructiveTest
+    @skipIf(os.geteuid() != 0, 'you must be root to run this test')
+    def test_set_system_date_time_utcoffset_east(self):
+        '''
+        Test changing the system clock. We are only able to set it up to a
+        resolution of a second so this test may appear to run in negative time.
+        '''
+        cmp_time = datetime.datetime.strptime("1981-02-03 11:05:06",
+                                              self.fmt_str)
+        offset_str = "-0700"
+        time_to_set = datetime.datetime.strptime("1981-02-03 04:05:06",
+                                                 self.fmt_str)
+
+        self._save_time()
+
+        result = self._set_time(time_to_set, offset=offset_str)
+
+        time_now = datetime.datetime.utcnow()
+        msg = ("Difference in times is too large. Now: {0} Fake: {1}"
+               .format(time_now, cmp_time))
+        self.assertTrue(result)
+        self.assertTrue(self._same_times(time_now, cmp_time), msg=msg)
+
+    @destructiveTest
+    @skipIf(os.geteuid() != 0, 'you must be root to run this test')
+    def test_set_system_date_time_utcoffset_west(self):
+        '''
+        Test changing the system clock. We are only able to set it up to a
+        resolution of a second so this test may appear to run in negative time.
+        '''
+        cmp_time = datetime.datetime.strptime("1981-02-03 02:05:06",
+                                                     self.fmt_str)
+        offset_str = "+0200"
+        time_to_set = datetime.datetime.strptime("1981-02-03 04:05:06",
+                                                 self.fmt_str)
+
+        self._save_time()
+        result = self._set_time(time_to_set, offset=offset_str)
+
+        time_now = datetime.datetime.utcnow()
+        msg = ("Difference in times is too large. Now: {0} Fake: {1}"
+               .format(time_now, cmp_time))
+        self.assertTrue(result)
+        self.assertTrue(self._same_times(time_now, cmp_time), msg=msg)
 
     @destructiveTest
     @skipIf(os.geteuid() != 0, 'you must be root to run this test')
@@ -112,23 +174,17 @@ class SystemModuleTest(integration.ModuleCase):
         '''
         Test setting the system time without adjusting the date.
         '''
-        self._fake_time = datetime.datetime.combine(datetime.date.today(),
-                                                    datetime.time(4, 5, 0))
-
+        cmp_time = datetime.datetime.now().replace(hour=10, minute=5, second=0)
         self._save_time()
 
-        result = self.run_function('system.set_system_time', ["04:05:00"])
+        result = self.run_function('system.set_system_time', ["10:05:00"])
 
         time_now = datetime.datetime.now()
         msg = ("Difference in times is too large. Now: {0} Fake: {1}"
-               .format(time_now, self._fake_time))
+               .format(time_now, cmp_time))
 
         self.assertTrue(result)
-        self.assertTrue(time_now.hour == 4 and
-                        time_now.minute == 5 and
-                        (time_now.second < 10), msg=msg)
-
-        self._restore_time()
+        self.assertTrue(self._same_times(time_now, cmp_time), msg=msg)
 
     @destructiveTest
     @skipIf(os.geteuid() != 0, 'you must be root to run this test')
@@ -136,28 +192,17 @@ class SystemModuleTest(integration.ModuleCase):
         '''
         Test setting the system date without adjusting the time.
         '''
-        self._fake_time = datetime.datetime.combine(
-                datetime.datetime(2000, 12, 25),
-                datetime.datetime.now().time()
-        )
+        cmp_time = datetime.datetime.now().replace(year=2000, month=12, day=25)
 
         self._save_time()
-
         result = self.run_function('system.set_system_date', ["2000-12-25"])
 
         time_now = datetime.datetime.now()
         msg = ("Difference in times is too large. Now: {0} Fake: {1}"
-               .format(time_now, self._fake_time))
+               .format(time_now, cmp_time))
 
         self.assertTrue(result)
-        self.assertTrue(time_now.year == 2000 and
-                        time_now.day == 25 and
-                        time_now.month == 12 and
-                        time_now.hour == self._orig_time.hour and
-                        time_now.minute == self._orig_time.minute,
-                        msg=msg)
-
-        self._restore_time()
+        self.assertTrue(self._same_times(time_now, cmp_time), msg=msg)
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/integration/modules/system.py
+++ b/tests/integration/modules/system.py
@@ -18,6 +18,7 @@ ensure_in_syspath('../../')
 import integration
 import salt.utils
 
+
 @skipIf(not salt.utils.is_linux(), 'These tests can only be run on linux')
 class SystemModuleTest(integration.ModuleCase):
     '''
@@ -32,7 +33,7 @@ class SystemModuleTest(integration.ModuleCase):
     def setUp(self):
         super(SystemModuleTest, self).setUp()
         os_grain = self.run_function('grains.item', ['kernel'])
-        if os_grain['kernel'] not in ('Linux'):
+        if os_grain['kernel'] not in 'Linux':
             self.skipTest(
                 'Test not applicable to \'{kernel}\' kernel'.format(
                     **os_grain


### PR DESCRIPTION
### What does this PR do?
- Modifies the system.{set,get}_datetime interface to support arbitrary utc offsets.
- Changes the backend to only use the date binary instead of using
  a linux specific system call.
### Previous Behavior

Previously the interface took in a boolean.

I really intend #34024 to be an RFC but neglected to add that to the header.
There has since been a couple changes to the interface and implementation.
### Tests written?

Yes
