### PR TITLE
NamespacedDictWrapper: implement human readable representation

### DIFF
--- a/salt/utils/context.py
+++ b/salt/utils/context.py
@@ -199,3 +199,6 @@ class NamespacedDictWrapper(collections.MutableMapping, dict):
     def __deepcopy__(self, memo):
         return type(self)(copy.deepcopy(self.__dict, memo),
                           copy.deepcopy(self.pre_keys, memo))
+
+    def __str__(self):
+        return self._dict().__str__()


### PR DESCRIPTION
### What does this PR do?

Fixes a regression from 2015.8  where dunder variables injected during loading (using class NamespaceDictWrapper) can't be printed.
### What issues does this PR fix or reference?

Printing dunder variables, such as **grains**, from entities loaded via the LazyLoader (such as beacons) now correctly print.
### Previous Behavior

Previously printing a dunder like **grains** from a becon will return an empty dictionary,
### New Behavior

Now it correctly prints the internal dictionary.
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

NamespacedDictWrapper wraps an internal dictionary with a set of key(s).
Since 2016.3, it is used for dunder dictionaries, such as **grains** and
**pillar**. However, the class doesn't provide a human readable output,
which ofuscates debugging (printing the dunder variable returns an empty
dictionary).

Signed-off-by: Alejandro del Castillo alejandro.delcastillo@ni.com
