### PR TITLE
Beacon network docs

### DIFF
--- a/doc/ref/beacons/all/index.rst
+++ b/doc/ref/beacons/all/index.rst
@@ -19,6 +19,7 @@ beacon modules
     load
     memusage
     network_info
+    network_settings
     pkg
     proxy_example
     ps

--- a/doc/ref/beacons/all/salt.beacons.network_settings.rst
+++ b/doc/ref/beacons/all/salt.beacons.network_settings.rst
@@ -1,0 +1,6 @@
+=============================
+salt.beacons.network_settings
+=============================
+
+.. automodule:: salt.beacons.network_settings
+    :members:

--- a/salt/beacons/network_settings.py
+++ b/salt/beacons/network_settings.py
@@ -2,6 +2,8 @@
 '''
 Beacon to monitor network adapter setting changes on Linux
 
+.. versionadded:: 2016.3.0
+
 '''
 from __future__ import absolute_import
 # Import third party libs


### PR DESCRIPTION
Add beacons/network_settings to doc build and a versionadded tag to the beacons.network_settings.py module.
