### PR TITLE
Remote port forwarding with salt-ssh

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -280,6 +280,9 @@ class SSH(object):
                 'ssh_identities_only',
                 salt.config.DEFAULT_MASTER_OPTS['ssh_identities_only']
             ),
+            'remote_port_forwards': self.opts.get(
+                'ssh_remote_port_forwards'
+            ),
         }
         if self.opts.get('rand_thin_dir'):
             self.defaults['thin_dir'] = os.path.join(
@@ -666,6 +669,7 @@ class Single(object):
             mine=False,
             minion_opts=None,
             identities_only=False,
+            remote_port_forwards=None,
             **kwargs):
         # Get mine setting and mine_functions if defined in kwargs (from roster)
         self.mine = mine
@@ -720,7 +724,8 @@ class Single(object):
                 'sudo': sudo,
                 'tty': tty,
                 'mods': self.mods,
-                'identities_only': identities_only}
+                'identities_only': identities_only,
+                'remote_port_forwards': remote_port_forwards}
         # Pre apply changeable defaults
         self.minion_opts = {
                     'grains_cache': True,

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -62,7 +62,8 @@ class Shell(object):
             sudo=False,
             tty=False,
             mods=None,
-            identities_only=False):
+            identities_only=False,
+            remote_port_forwards=None):
         self.opts = opts
         self.host = host
         self.user = user
@@ -74,6 +75,7 @@ class Shell(object):
         self.tty = tty
         self.mods = mods
         self.identities_only = identities_only
+        self.remote_port_forwards = remote_port_forwards
 
     def get_error(self, errstr):
         '''
@@ -223,11 +225,18 @@ class Shell(object):
             opts = self._passwd_opts()
         if self.priv:
             opts = self._key_opts()
-        return "{0} {1} {2} {3} {4}".format(
+
+        ports = ''
+        if self.remote_port_forwards:
+            port_forwards = self.remote_port_forwards.split(',')
+            ports = ' '.join(map(lambda x: '-R {0}'.format(x), port_forwards))
+
+        return "{0} {1} {2} {3} {4} {5}".format(
                 ssh,
                 '' if ssh == 'scp' else self.host,
                 '-t -t' if tty else '',
                 opts,
+                '' if ssh == 'scp' else ports,
                 cmd)
 
     def _old_run_cmd(self, cmd):

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2791,6 +2791,20 @@ class SaltSSHOptionParser(six.with_metaclass(OptionParserMeta,
             help='Pass a JID to be used instead of generating one.'
         )
 
+        ports_group = optparse.OptionGroup(
+            self, 'Port Forwarding Options',
+            'Parameters for setting up SSH port forwarding.'
+        )
+        ports_group.add_option(
+            '--remote-port-forwards',
+            dest='ssh_remote_port_forwards',
+            help='Setup remote port forwarding using the same syntax as with '
+                 'the -R parameter of ssh. A comma separated list of port '
+                 'forwarding definitions will be translated into multiple '
+                 '-R parameters.'
+        )
+        self.add_option_group(ports_group)
+
         auth_group = optparse.OptionGroup(
             self, 'Authentication Options',
             'Parameters affecting authentication.'


### PR DESCRIPTION
### What does this PR do?

This patch adds support for setting up remote port forwarding with the salt SSH client and command. Such port forwardings can be useful when managing systems that are located outside of an organization's firewall but there is still a need to access resources in the internal network like for instance a company internal repository server to install packages from.
### What issues does this PR fix or reference?
- #21252 (local port forwardings could easily be added in the same way)
### New Behavior

The patch introduces a new parameter to `salt-ssh` for specifying remote port forwardings for the duration of a state application or a synchronous call to an execution module:

```
salt-ssh --remote-port-forwards=8888:my.company.server:443 pkg.install salt
```

Multiple remote port forwardings can be defined by using a comma separated list. These will then be translated into one `-R` parameter to the ssh call each:

```
salt-ssh --remote-port-forwards=8888:my.company.server:443,9999:my.company.server:80 state.highstate
```
### Tests written?

No
