### PR TITLE
Add apt key proxy support

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1072,9 +1072,9 @@ DEFAULT_MINION_OPTS = {
     'event_match_type': 'startswith',
     'minion_restart_command': [],
     'pub_ret': True,
-    'proxy_host': None,
-    'proxy_username': None,
-    'proxy_password': None,
+    'proxy_host': '',
+    'proxy_username': '',
+    'proxy_password': '',
     'proxy_port': None,
 }
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -835,6 +835,13 @@ VALID_OPTS = {
     # Whether or not a minion should send the results of a command back to the master
     # Useful when a returner is the source of truth for a job result
     'pub_ret': bool,
+
+    # HTTP proxy settings. Used in tornado fetch functions, apt-key etc
+    'proxy_host': str,
+    'proxy_username': str,
+    'proxy_password': str,
+    'proxy_port': int,
+
 }
 
 # default configurations
@@ -1065,6 +1072,10 @@ DEFAULT_MINION_OPTS = {
     'event_match_type': 'startswith',
     'minion_restart_command': [],
     'pub_ret': True,
+    'proxy_host': None,
+    'proxy_username': None,
+    'proxy_password': None,
+    'proxy_port': None,
 }
 
 DEFAULT_MASTER_OPTS = {

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -47,6 +47,7 @@ config = salt.config.minion_config(
         os.path.join(salt.syspaths.CONFIG_DIR, 'minion')
 )
 
+# Set HTTP_PROXY_URL for use in various internet facing actions...eg apt-key adv
 if config['proxy_host'] and config['proxy_port']:
     if config['proxy_username'] and config['proxy_password']:
         HTTP_PROXY_URL = 'http://{0}:{1}@{2}:{3}'.format(

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -60,7 +60,7 @@ if config['proxy_host'] and config['proxy_port']:
             config['proxy_host'],
             config['proxy_port'])
 else:
-  HTTP_PROXY_URL = None
+    HTTP_PROXY_URL = None
 
 # pylint: disable=import-error
 try:


### PR DESCRIPTION
### What does this PR do?

Adds support for http proxy in aptpkg
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/34360
### Previous Behavior

If you enabled proxy_host/proxy_port in minion config adding a pkgrepo for apt with a gpg key url would fail
### New Behavior

It now works
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
