### PR TITLE
Inspector: remove SQLite (entirely from here)

### DIFF
--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -328,17 +328,12 @@ class Inspector(EnvLoader):
         '''
         Get the intersection between all files and managed files.
         '''
-        def intr(src, data):
-            out = set()
-            for d_el in data:
-                if d_el not in src:
-                    out.add(d_el)
-            return out
-
         m_files, m_dirs, m_links = managed
         s_files, s_dirs, s_links = system_all
 
-        return sorted(intr(m_files, s_files)), sorted(intr(m_dirs, s_dirs)), sorted(intr(m_links, s_links))
+        return (sorted(list(set(s_files).intersection(m_files))),
+                sorted(list(set(s_dirs).intersection(m_dirs))),
+                sorted(list(set(s_links).intersection(m_links))))
 
     def _scan_payload(self):
         '''

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -175,9 +175,6 @@ class Inspector(EnvLoader):
         :param data:
         :return:
         '''
-        self.db._csv_db.create_table_from_object(Package())
-        self.db._csv_db.create_table_from_object(PackageCfgFile())
-
         pkg_id = 0
         pkg_cfg_id = 0
         for pkg_name, pkg_configs in data.items():
@@ -222,8 +219,6 @@ class Inspector(EnvLoader):
         :param links:
         :return:
         '''
-
-        self.db._csv_db.create_table_from_object(PayloadFile())
 
         idx = 0
         for p_type, p_list in (('f', files), ('d', directories), ('l', links,),):
@@ -404,11 +399,6 @@ class Inspector(EnvLoader):
         Prepare full system scan by setting up the database etc.
         '''
         self.db.purge()
-
-        # Initialize CsvDB
-        self.db._csv_db.new()
-        self.db._csv_db.create_table_from_object(AllowedDir())
-        self.db._csv_db.create_table_from_object(IgnoredDir())
 
         # Add ignored filesystems
         ignored_fs = set()

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -25,6 +25,8 @@ import logging
 from salt.modules.inspectlib.exceptions import (InspectorSnapshotException)
 from salt.modules.inspectlib import EnvLoader
 from salt.modules.inspectlib import kiwiproc
+from salt.modules.inspectlib.fsdb import CsvDBEntity
+
 import salt.utils
 from salt.utils import fsutils
 from salt.utils import reinit_crypto
@@ -36,6 +38,39 @@ except ImportError:
     kiwi = None
 
 log = logging.getLogger(__name__)
+
+
+class Package(CsvDBEntity):
+    _TABLE = 'inspector_pkg'
+
+    def __init__(self):
+        self.id = 0
+        self.name = ''
+
+
+class PackageCfgFile(CsvDBEntity):
+    _TABLE = 'inspector_pkg_cfg_files'
+
+    def __init__(self):
+        self.id = 0
+        self.pkgid = 0
+        self.path = ''
+
+
+class PayloadFile(CsvDBEntity):
+    _TABLE = 'inspector_payload'
+
+    def __init__(self):
+        self.id = 0
+        self.path = ''
+        self.p_type = ''
+        self.mode = 0
+        self.uid = 0
+        self.gid = 0
+        self.p_size = 0
+        self.atime = 0.
+        self.mtime = 0.
+        self.ctime = 0.
 
 
 class Inspector(EnvLoader):

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -222,6 +222,39 @@ class Inspector(EnvLoader):
     def _save_payload(self, files, directories, links):
         '''
         Save payload (unmanaged files)
+
+        :param files:
+        :param directories:
+        :param links:
+        :return:
+        '''
+
+        self.db._csv_db.create_table_from_object(PayloadFile())
+
+        idx = 0
+        for p_type, p_list in (('f', files), ('d', directories), ('l', links,),):
+            for p_obj in p_list:
+                stats = os.stat(p_obj)
+
+                payload = PayloadFile()
+                payload.id = idx
+                payload.path = p_obj
+                payload.p_type = p_type
+                payload.mode = stats.st_mode
+                payload.uid = stats.st_uid
+                payload.gid = stats.st_gid
+                payload.p_size = stats.st_size
+                payload.atime = stats.st_atime
+                payload.mtime = stats.st_mtime
+                payload.ctime = stats.st_ctime
+
+                idx += 1
+                self.db._csv_db.store(payload)
+
+
+    def _save_pld(self, files, directories, links):
+        '''
+        Save payload (unmanaged files)
         '''
         idx = 0
         for p_type, p_list in (('f', files), ('d', directories), ('l', links,),):

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -91,6 +91,7 @@ class Inspector(EnvLoader):
             self.db.open()
         except Exception as ex:
             log.error('Unable to [re]open db. Already opened?')
+        self.db._csv_db.open()
 
     def _syscall(self, command, input=None, env=None, *params):
         '''

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -490,8 +490,15 @@ class Inspector(EnvLoader):
         '''
         self._init_env()
 
-        self._save_cfg_pkgs(self._get_changed_cfg_pkgs(self._get_cfg_pkgs()))
-        self._save_payload(*self._scan_payload())
+        changed_cfg_pkgs = self._get_changed_cfg_pkgs(self._get_cfg_pkgs())
+        self._save_cfg_packages(changed_cfg_pkgs)
+
+        payload = self._scan_payload()
+        self._save_payload(*payload)
+
+        # Old stuff
+        self._save_cfg_pkgs(changed_cfg_pkgs)
+        self._save_pld(*payload)
 
     def request_snapshot(self, mode, priority=19, **kwargs):
         '''

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -193,23 +193,6 @@ class Inspector(EnvLoader):
 
             pkg_id += 1
 
-    def _save_cfg_pkgs(self, data):
-        '''
-        Save configuration packages.
-        '''
-        pkg_id = 0
-        pkg_cfg_id = 0
-        for pkg_name, pkg_configs in data.items():
-            self.db.cursor.execute("INSERT INTO inspector_pkg (id, name) VALUES (?, ?)",
-                                   (pkg_id, pkg_name))
-            for pkg_config in pkg_configs:
-                self.db.cursor.execute("INSERT INTO inspector_pkg_cfg_files (id, pkgid, path) VALUES (?, ?, ?)",
-                                       (pkg_cfg_id, pkg_id, pkg_config))
-                pkg_cfg_id += 1
-            pkg_id += 1
-
-        self.db.connection.commit()
-
     def _save_payload(self, files, directories, links):
         '''
         Save payload (unmanaged files)
@@ -240,23 +223,6 @@ class Inspector(EnvLoader):
                 idx += 1
                 self.db._csv_db.store(payload)
 
-
-    def _save_pld(self, files, directories, links):
-        '''
-        Save payload (unmanaged files)
-        '''
-        idx = 0
-        for p_type, p_list in (('f', files), ('d', directories), ('l', links,),):
-            for p_obj in p_list:
-                stats = os.stat(p_obj)
-                self.db.cursor.execute("INSERT INTO inspector_payload "
-                                       "(id, path, p_type, mode, uid, gid, p_size, atime, mtime, ctime)"
-                                       "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                                       (idx, p_obj, p_type, stats.st_mode, stats.st_uid, stats.st_gid, stats.st_size,
-                                        stats.st_atime, stats.st_mtime, stats.st_ctime))
-                idx += 1
-
-        self.db.connection.commit()
 
     def _get_managed_files(self):
         '''
@@ -460,10 +426,6 @@ class Inspector(EnvLoader):
 
         payload = self._scan_payload()
         self._save_payload(*payload)
-
-        # Old stuff
-        self._save_cfg_pkgs(changed_cfg_pkgs)
-        self._save_pld(*payload)
 
     def request_snapshot(self, mode, priority=19, **kwargs):
         '''

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -59,7 +59,6 @@ class Inspector(EnvLoader):
             self.db.open()
         except Exception as ex:
             log.error('Unable to [re]open db. Already opened?')
-        self.db._csv_db.open()
 
     def _syscall(self, command, input=None, env=None, *params):
         '''
@@ -181,14 +180,14 @@ class Inspector(EnvLoader):
             pkg = Package()
             pkg.id = pkg_id
             pkg.name = pkg_name
-            self.db._csv_db.store(pkg)
+            self.db.store(pkg)
 
             for pkg_config in pkg_configs:
                 cfg = PackageCfgFile()
                 cfg.id = pkg_cfg_id
                 cfg.pkgid = pkg_id
                 cfg.path = pkg_config
-                self.db._csv_db.store(cfg)
+                self.db.store(cfg)
                 pkg_cfg_id += 1
 
             pkg_id += 1
@@ -221,7 +220,7 @@ class Inspector(EnvLoader):
                 payload.ctime = stats.st_ctime
 
                 idx += 1
-                self.db._csv_db.store(payload)
+                self.db.store(payload)
 
 
     def _get_managed_files(self):
@@ -335,13 +334,13 @@ class Inspector(EnvLoader):
         '''
         # Get ignored points
         allowed = list()
-        for allowed_dir in self.db._csv_db.get(AllowedDir):
+        for allowed_dir in self.db.get(AllowedDir):
             if os.path.exists(allowed_dir.path):
                 allowed.append(allowed_dir.path)
 
         ignored = list()
         if not allowed:
-            for ignored_dir in self.db._csv_db.get(IgnoredDir):
+            for ignored_dir in self.db.get(IgnoredDir):
                 if os.path.exists(ignored_dir.path):
                     ignored.append(ignored_dir.path)
 
@@ -393,16 +392,14 @@ class Inspector(EnvLoader):
         for ignored_dir in ignored_all:
             dir_obj = IgnoredDir()
             dir_obj.path = ignored_dir
-            self.db._csv_db.store(dir_obj)
+            self.db.store(dir_obj)
 
         # Add allowed filesystems (overrides all above at full scan)
         allowed = [elm for elm in kwargs.get("filter", "").split(",") if elm]
         for allowed_dir in allowed:
             dir_obj = AllowedDir()
             dir_obj.path = allowed_dir
-            self.db._csv_db.store(dir_obj)
-
-        self.db.connection.commit()
+            self.db.store(dir_obj)
 
         return ignored_all
 

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -222,7 +222,6 @@ class Inspector(EnvLoader):
                 idx += 1
                 self.db.store(payload)
 
-
     def _get_managed_files(self):
         '''
         Build a in-memory data of all managed files.

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -25,7 +25,8 @@ import logging
 from salt.modules.inspectlib.exceptions import (InspectorSnapshotException)
 from salt.modules.inspectlib import EnvLoader
 from salt.modules.inspectlib import kiwiproc
-from salt.modules.inspectlib.fsdb import CsvDBEntity
+from salt.modules.inspectlib.entities import (AllowedDir, IgnoredDir, Package,
+                                              PayloadFile, PackageCfgFile)
 
 import salt.utils
 from salt.utils import fsutils
@@ -38,39 +39,6 @@ except ImportError:
     kiwi = None
 
 log = logging.getLogger(__name__)
-
-
-class Package(CsvDBEntity):
-    _TABLE = 'inspector_pkg'
-
-    def __init__(self):
-        self.id = 0
-        self.name = ''
-
-
-class PackageCfgFile(CsvDBEntity):
-    _TABLE = 'inspector_pkg_cfg_files'
-
-    def __init__(self):
-        self.id = 0
-        self.pkgid = 0
-        self.path = ''
-
-
-class PayloadFile(CsvDBEntity):
-    _TABLE = 'inspector_payload'
-
-    def __init__(self):
-        self.id = 0
-        self.path = ''
-        self.p_type = ''
-        self.mode = 0
-        self.uid = 0
-        self.gid = 0
-        self.p_size = 0
-        self.atime = 0.
-        self.mtime = 0.
-        self.ctime = 0.
 
 
 class Inspector(EnvLoader):

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -54,11 +54,23 @@ class Inspector(EnvLoader):
     def __init__(self, cachedir=None, piddir=None, pidfilename=None):
         EnvLoader.__init__(self, cachedir=cachedir, piddir=piddir, pidfilename=pidfilename)
 
-        # TODO: This is nasty. Need to do something with this better. ASAP!
-        try:
-            self.db.open()
-        except Exception as ex:
-            log.error('Unable to [re]open db. Already opened?')
+    def create_snapshot(self):
+        '''
+        Open new snapshot.
+
+        :return:
+        '''
+        self.db.open(new=True)
+        return self
+
+    def reuse_snapshot(self):
+        '''
+        Open an existing, latest snapshot.
+
+        :return:
+        '''
+        self.db.open()
+        return self
 
     def _syscall(self, command, input=None, env=None, *params):
         '''
@@ -363,8 +375,7 @@ class Inspector(EnvLoader):
         '''
         Prepare full system scan by setting up the database etc.
         '''
-        self.db.purge()
-
+        self.db.open(new=True)
         # Add ignored filesystems
         ignored_fs = set()
         ignored_fs |= set(self.IGNORE_PATHS)
@@ -484,7 +495,7 @@ def main(dbfile, pidfile, mode):
     '''
     Main analyzer routine.
     '''
-    Inspector(dbfile, pidfile).snapshot(mode)
+    Inspector(dbfile, pidfile).reuse_snapshot().snapshot(mode)
 
 
 if __name__ == '__main__':

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -374,16 +374,15 @@ class Inspector(EnvLoader):
         '''
         # Get ignored points
         allowed = list()
-        self.db.cursor.execute("SELECT path FROM inspector_allowed")
-        for alwd_path in self.db.cursor.fetchall():
-            if os.path.exists(alwd_path[0]):
-                allowed.append(alwd_path[0])
+        for allowed_dir in self.db._csv_db.get(AllowedDir):
+            if os.path.exists(allowed_dir.path):
+                allowed.append(allowed_dir.path)
 
         ignored = list()
         if not allowed:
-            self.db.cursor.execute("SELECT path FROM inspector_ignored")
-            for ign_path in self.db.cursor.fetchall():
-                ignored.append(ign_path[0])
+            for ignored_dir in self.db._csv_db.get(IgnoredDir):
+                if os.path.exists(ignored_dir.path):
+                    ignored.append(ignored_dir.path)
 
         all_files = list()
         all_dirs = list()

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -289,25 +289,26 @@ class Inspector(EnvLoader):
         dirs = list()
         links = list()
 
-        for obj in os.listdir(path):
-            obj = os.path.join(path, obj)
-            valid = True
-            for ex_obj in exclude:
-                if obj.startswith(str(ex_obj)):
-                    valid = False
+        if os.access(path, os.R_OK):
+            for obj in os.listdir(path):
+                obj = os.path.join(path, obj)
+                valid = True
+                for ex_obj in exclude:
+                    if obj.startswith(str(ex_obj)):
+                        valid = False
+                        continue
+                if not valid or not os.path.exists(obj) or not os.access(obj, os.R_OK):
                     continue
-            if not valid or not os.path.exists(obj):
-                continue
-            if os.path.islink(obj):
-                links.append(obj)
-            elif os.path.isdir(obj):
-                dirs.append(obj)
-                f_obj, d_obj, l_obj = self._get_all_files(obj, *exclude)
-                files.extend(f_obj)
-                dirs.extend(d_obj)
-                links.extend(l_obj)
-            elif os.path.isfile(obj):
-                files.append(obj)
+                if os.path.islink(obj):
+                    links.append(obj)
+                elif os.path.isdir(obj):
+                    dirs.append(obj)
+                    f_obj, d_obj, l_obj = self._get_all_files(obj, *exclude)
+                    files.extend(f_obj)
+                    dirs.extend(d_obj)
+                    links.extend(l_obj)
+                elif os.path.isfile(obj):
+                    files.append(obj)
 
         return sorted(files), sorted(dirs), sorted(links)
 

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -232,9 +232,6 @@ class Inspector(EnvLoader):
         '''
         Save configuration packages.
         '''
-        for table in ["inspector_pkg", "inspector_pkg_cfg_files"]:
-            self.db.flush(table)
-
         pkg_id = 0
         pkg_cfg_id = 0
         for pkg_name, pkg_configs in data.items():

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -200,6 +200,34 @@ class Inspector(EnvLoader):
 
         return f_data
 
+    def _save_cfg_packages(self, data):
+        '''
+        Save configuration packages. (NG)
+
+        :param data:
+        :return:
+        '''
+        self.db._csv_db.create_table_from_object(Package())
+        self.db._csv_db.create_table_from_object(PackageCfgFile())
+
+        pkg_id = 0
+        pkg_cfg_id = 0
+        for pkg_name, pkg_configs in data.items():
+            pkg = Package()
+            pkg.id = pkg_id
+            pkg.name = pkg_name
+            self.db._csv_db.store(pkg)
+
+            for pkg_config in pkg_configs:
+                cfg = PackageCfgFile()
+                cfg.id = pkg_cfg_id
+                cfg.pkgid = pkg_id
+                cfg.path = pkg_config
+                self.db._csv_db.store(cfg)
+                pkg_cfg_id += 1
+
+            pkg_id += 1
+
     def _save_cfg_pkgs(self, data):
         '''
         Save configuration packages.

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -331,9 +331,9 @@ class Inspector(EnvLoader):
         m_files, m_dirs, m_links = managed
         s_files, s_dirs, s_links = system_all
 
-        return (sorted(list(set(s_files).intersection(m_files))),
-                sorted(list(set(s_dirs).intersection(m_dirs))),
-                sorted(list(set(s_links).intersection(m_links))))
+        return (sorted(list(set(s_files).difference(m_files))),
+                sorted(list(set(s_dirs).difference(m_dirs))),
+                sorted(list(set(s_links).difference(m_links))))
 
     def _scan_payload(self):
         '''
@@ -424,11 +424,8 @@ class Inspector(EnvLoader):
         '''
         self._init_env()
 
-        changed_cfg_pkgs = self._get_changed_cfg_pkgs(self._get_cfg_pkgs())
-        self._save_cfg_packages(changed_cfg_pkgs)
-
-        payload = self._scan_payload()
-        self._save_payload(*payload)
+        self._save_cfg_packages(self._get_changed_cfg_pkgs(self._get_cfg_pkgs()))
+        self._save_payload(*self._scan_payload())
 
     def request_snapshot(self, mode, priority=19, **kwargs):
         '''

--- a/salt/modules/inspectlib/dbhandle.py
+++ b/salt/modules/inspectlib/dbhandle.py
@@ -16,11 +16,11 @@
 
 # Import Python LIbs
 from __future__ import absolute_import
-import sqlite3
 import os
 from salt.modules.inspectlib.fsdb import CsvDB
 from salt.modules.inspectlib.entities import (Package, PackageCfgFile,
                                               PayloadFile, IgnoredDir, AllowedDir)
+
 
 class DBHandleBase(object):
     '''
@@ -34,60 +34,36 @@ class DBHandleBase(object):
         Constructor.
         '''
         self._path = path
-        self.connection = None
-        self.cursor = None
         self.init_queries = list()
-        self._csv_db = CsvDB("/tmp/salt.fsdb")  ## Replace with the self._path afterwards
+        self._db = CsvDB("/tmp/salt.fsdb")  ## Replace with the self._path afterwards
 
     def open(self, new=False):
         '''
         Init the database, if required.
         '''
-        if self.connection and self.cursor:
-            return
-
         if new and os.path.exists(self._path):
             os.unlink(self._path)  # As simple as that
 
-        self.connection = sqlite3.connect(self._path)
-        self.connection.text_factory = str
-        self.cursor = self.connection.cursor()
-
-        self.cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
-        if self.cursor.fetchall():
-            return
-
-
         if new:
-            self._csv_db.new()
+            self._db.new()
         else:
-            self._csv_db.open()
+            self._db.open()
 
         self._run_init_queries()
-        self.connection.commit()
 
     def _run_init_queries(self):
         '''
         Initialization queries
         '''
         for obj in (Package, PackageCfgFile, PayloadFile, IgnoredDir, AllowedDir):
-            self._csv_db.create_table_from_object(obj())
-
-        for query in self.init_queries:
-            self.cursor.execute(query)
+            self._db.create_table_from_object(obj())
 
     def purge(self):
         '''
         Purge whole database.
         '''
-        if self.connection and self.cursor:
-            self.cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
-            for table_name in self.cursor.fetchall():
-                self.cursor.execute("DROP TABLE {0}".format(table_name[0]))
-            self.connection.commit()
-
-        for table_name in self._csv_db.list_tables():
-            self._csv_db.flush(table_name)
+        for table_name in self._db.list_tables():
+            self._db.flush(table_name)
 
         self._run_init_queries()
 
@@ -95,18 +71,22 @@ class DBHandleBase(object):
         '''
         Flush the table.
         '''
-        self.cursor.execute("DELETE FROM " + table)
-        self.connection.commit()
-        self._csv_db.flush(table)
+        self._db.flush(table)
 
     def close(self):
         '''
         Close the database connection.
         '''
-        if self.cursor is not None and self.connection is not None:
-            self.connection.close()
-            self.cursor = self.connection = None
-            self._csv_db.close()
+        self._db.close()
+
+    def __getattr__(self, item):
+        '''
+        Proxy methods from the Database instance.
+
+        :param item:
+        :return:
+        '''
+        return getattr(self._db, item)
 
 
 class DBHandle(DBHandleBase):
@@ -128,19 +108,3 @@ class DBHandle(DBHandleBase):
         :return:
         '''
         DBHandleBase.__init__(self, path)
-
-        self.init_queries.append("CREATE TABLE inspector_pkg "
-                                 "(id INTEGER PRIMARY KEY, name CHAR(255))")
-        self.init_queries.append("CREATE TABLE inspector_pkg_cfg_files "
-                                 "(id INTEGER PRIMARY KEY, pkgid INTEGER, path CHAR(4096))")
-        self.init_queries.append("CREATE TABLE inspector_pkg_cfg_diffs "
-                                 "(id INTEGER PRIMARY KEY, cfgid INTEGER, diff TEXT)")
-        self.init_queries.append("CREATE TABLE inspector_payload "
-                                 "(id INTEGER PRIMARY KEY, path CHAR(4096), "
-                                 "p_type char(1), mode INTEGER, uid INTEGER, gid INTEGER, p_size INTEGER, "
-                                 "atime FLOAT, mtime FLOAT, ctime FLOAT)")
-
-        # inspector_allowed overrides inspector_ignored.
-        # I.e. if allowed is not empty, then inspector_ignored is completely omitted.
-        self.init_queries.append("CREATE TABLE inspector_ignored (path CHAR(4096))")
-        self.init_queries.append("CREATE TABLE inspector_allowed (path CHAR(4096))")

--- a/salt/modules/inspectlib/dbhandle.py
+++ b/salt/modules/inspectlib/dbhandle.py
@@ -80,12 +80,16 @@ class DBHandleBase(object):
             self.connection.commit()
         self._run_init_queries()
 
+        for db_id in self._csv_db.list():
+            self._csv_db.purge(db_id)
+
     def flush(self, table):
         '''
         Flush the table.
         '''
         self.cursor.execute("DELETE FROM " + table)
         self.connection.commit()
+        self._csv_db.flush(table)
 
     def close(self):
         '''
@@ -94,6 +98,7 @@ class DBHandleBase(object):
         if self.cursor is not None and self.connection is not None:
             self.connection.close()
             self.cursor = self.connection = None
+            self._csv_db.close()
 
 
 class DBHandle(DBHandleBase):

--- a/salt/modules/inspectlib/dbhandle.py
+++ b/salt/modules/inspectlib/dbhandle.py
@@ -35,7 +35,7 @@ class DBHandleBase(object):
         '''
         self._path = path
         self.init_queries = list()
-        self._db = CsvDB("/tmp/salt.fsdb")  ## Replace with the self._path afterwards
+        self._db = CsvDB(self._path)
 
     def open(self, new=False):
         '''

--- a/salt/modules/inspectlib/dbhandle.py
+++ b/salt/modules/inspectlib/dbhandle.py
@@ -18,6 +18,7 @@
 from __future__ import absolute_import
 import sqlite3
 import os
+from salt.modules.inspectlib.fsdb import CsvDB
 
 
 class DBHandleBase(object):
@@ -35,6 +36,7 @@ class DBHandleBase(object):
         self.connection = None
         self.cursor = None
         self.init_queries = list()
+        self._csv_db = CsvDB("/tmp/salt.fsdb")  ## Replace with the self._path afterwards
 
     def open(self, new=False):
         '''

--- a/salt/modules/inspectlib/dbhandle.py
+++ b/salt/modules/inspectlib/dbhandle.py
@@ -16,7 +16,6 @@
 
 # Import Python LIbs
 from __future__ import absolute_import
-import os
 from salt.modules.inspectlib.fsdb import CsvDB
 from salt.modules.inspectlib.entities import (Package, PackageCfgFile,
                                               PayloadFile, IgnoredDir, AllowedDir)
@@ -41,7 +40,7 @@ class DBHandleBase(object):
         '''
         Init the database, if required.
         '''
-        self._db.new() if new else self._db.open()
+        self._db.new() if new else self._db.open()  # pylint: disable=W0106
         self._run_init_queries()
 
     def _run_init_queries(self):

--- a/salt/modules/inspectlib/dbhandle.py
+++ b/salt/modules/inspectlib/dbhandle.py
@@ -57,6 +57,11 @@ class DBHandleBase(object):
         self._run_init_queries()
         self.connection.commit()
 
+        if new:
+            self._csv_db.new()
+        else:
+            self._csv_db.open()
+
     def _run_init_queries(self):
         '''
         Initialization queries

--- a/salt/modules/inspectlib/dbhandle.py
+++ b/salt/modules/inspectlib/dbhandle.py
@@ -41,14 +41,7 @@ class DBHandleBase(object):
         '''
         Init the database, if required.
         '''
-        if new and os.path.exists(self._path):
-            os.unlink(self._path)  # As simple as that
-
-        if new:
-            self._db.new()
-        else:
-            self._db.open()
-
+        self._db.new() if new else self._db.open()
         self._run_init_queries()
 
     def _run_init_queries(self):

--- a/salt/modules/inspectlib/entities.py
+++ b/salt/modules/inspectlib/entities.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2016 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from salt.modules.inspectlib.fsdb import CsvDBEntity
+
+
+class IgnoredDir(CsvDBEntity):
+    '''
+    Ignored directories
+    '''
+    _TABLE = 'inspector_ignored'
+
+    def __init__(self):
+        self.path = ''
+
+
+class AllowedDir(CsvDBEntity):
+    '''
+    Allowed directories
+    '''
+    _TABLE = 'inspector_allowed'
+
+    def __init__(self):
+        self.path = ''
+
+
+class Package(CsvDBEntity):
+    '''
+    Package.
+    '''
+    _TABLE = 'inspector_pkg'
+
+    def __init__(self):
+        self.id = 0
+        self.name = ''
+
+
+class PackageCfgFile(CsvDBEntity):
+    '''
+    Config file, belongs to the package
+    '''
+    _TABLE = 'inspector_pkg_cfg_files'
+
+    def __init__(self):
+        self.id = 0
+        self.pkgid = 0
+        self.path = ''
+
+
+class PayloadFile(CsvDBEntity):
+    '''
+    Payload file.
+    '''
+    _TABLE = 'inspector_payload'
+
+    def __init__(self):
+        self.id = 0
+        self.path = ''
+        self.p_type = ''
+        self.mode = 0
+        self.uid = 0
+        self.gid = 0
+        self.p_size = 0
+        self.atime = 0.
+        self.mtime = 0.
+        self.ctime = 0.

--- a/salt/modules/inspectlib/entities.py
+++ b/salt/modules/inspectlib/entities.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from salt.modules.inspectlib.fsdb import CsvDBEntity
 
 

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -159,7 +159,7 @@ class CsvDB(object):
         '''
         return not self._opened
 
-    def table_from_object(self, obj):
+    def create_table_from_object(self, obj):
         '''
         Create a table from the object.
         NOTE: This method doesn't stores anything.
@@ -172,6 +172,7 @@ class CsvDB(object):
             with gzip.open(os.path.join(self.db_path, obj._TABLE), 'wb') as table_file:
                 csv.writer(table_file).writerow(['{col}:{type}'.format(col=elm[0], type=get_type(elm[1]))
                                                  for elm in tuple(obj.__dict__.items())])
+            self._tables[obj._TABLE] = self._load_table(obj._TABLE)
 
     def store(self, obj):
         '''

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -105,6 +105,7 @@ class CsvDB(object):
     def open(self, dbname=None):
         '''
         Open database from the path with the name or latest.
+        If there are no yet databases, create a new implicitly.
 
         :return:
         '''

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -185,6 +185,27 @@ class CsvDB(object):
         with gzip.open(os.path.join(self.db_path, obj._TABLE), 'a') as table:
             csv.writer(table).writerow(self._validate_object(obj))
 
+    def delete(self, obj, matches=None, mt=None, lt=None, eq=None):
+        '''
+        Delete object from the database.
+
+        :param obj:
+        :param matches:
+        :param mt:
+        :param lt:
+        :param eq:
+        :return:
+        '''
+        objects = list()
+        for obj in self.get(obj):
+            if not self.__criteria(obj, matches=matches, mt=mt, lt=lt, eq=eq):
+                objects.append(obj)
+        self.flush(obj._TABLE)
+        self.create_table_from_object(obj)
+        for obj in objects:
+            self.store(obj)
+
+
     def _validate_object(self, obj):
         descr = self._tables.get(obj._TABLE)
         if descr is None:

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -95,6 +95,8 @@ class CsvDB(object):
         db_path = os.path.join(self.path, dbid)
         if os.path.exists(db_path):
             shutil.rmtree(db_path, ignore_errors=True)
+            return True
+        return False
 
     def flush(self, table):
         '''

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import os
+import re
 import csv
 import datetime
 import gzip
@@ -189,6 +190,39 @@ class CsvDB(object):
         if descr is None:
             raise Exception('Table {0} not found.'.format(obj._TABLE))
         return obj._serialize(self._tables[obj._TABLE])
+
+    def __criteria(self, obj, matches=None, mt=None, lt=None, eq=None):
+        '''
+        Returns True if object is aligned to the criteria.
+
+        :param obj:
+        :param matches:
+        :param mt:
+        :param lt:
+        :param eq:
+        :return: Boolean
+        '''
+        # Fail matcher if "less than"
+        for field, value in (mt or {}).items():
+            if getattr(obj, field) < value:
+                return False
+
+        # Fail matcher if "more than"
+        for field, value in (lt or {}).items():
+            if getattr(obj, field) > value:
+                return False
+
+        # Fail matcher if "not equal"
+        for field, value in (eq or {}).items():
+            if getattr(obj, field) != value:
+                return False
+
+        # Fail matcher if "doesn't match"
+        for field, value in (matches or {}).items():
+            if not re.search(value, str(getattr(obj, field))):
+                return False
+
+        return True
 
     def get(self, obj, matches=None, mt=None, lt=None, eq=None):
         '''

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -193,6 +193,29 @@ class CsvDB(object):
         with gzip.open(os.path.join(self.db_path, obj._TABLE), 'a') as table:
             csv.writer(table).writerow(self._validate_object(obj))
 
+    def update(self, obj, matches=None, mt=None, lt=None, eq=None):
+        '''
+        Update object(s) in the database.
+
+        :param obj:
+        :param matches:
+        :param mt:
+        :param lt:
+        :param eq:
+        :return:
+        '''
+        updated = False
+        objects = list()
+        for _obj in self.get(obj.__class__):
+            objects.append(not self.__criteria(_obj, matches=matches, mt=mt, lt=lt, eq=eq) and _obj or obj)
+        self.flush(obj._TABLE)
+        self.create_table_from_object(obj)
+        for obj in objects:
+            self.store(obj)
+
+        return updated
+
+
     def delete(self, obj, matches=None, mt=None, lt=None, eq=None):
         '''
         Delete object from the database.

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -175,14 +175,13 @@ class CsvDB(object):
                                                  for elm in tuple(obj.__dict__.items())])
             self._tables[obj._TABLE] = self._load_table(obj._TABLE)
 
-    def store(self, obj, distinct=False, update=None):
+    def store(self, obj, distinct=False):
         '''
         Store an object in the table.
 
         :param obj: An object to store
         :param distinct: Store object only if there is none identical of such.
                           If at least one field is different, store it.
-        :param update: Update an object by the following keys. Parameter should be an array of keys.
         :return:
         '''
         if distinct:

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import os
+import csv
 import datetime
 
 
@@ -132,10 +133,16 @@ class CsvDB(object):
     def table_from_object(self, obj):
         '''
         Create a table from the object.
+        NOTE: This method doesn't stores anything.
 
         :param obj:
         :return:
         '''
+        get_type = lambda item: str(type(item)).split("'")[1]
+        if not os.path.exists(os.path.join(self.db_path, obj._TABLE)):
+            with open(os.path.join(self.db_path, obj._TABLE), 'wb') as table_file:
+                csv.writer(table_file).writerow(['{col}:{type}'.format(col=elm[0], type=get_type(elm[1]))
+                                                 for elm in tuple(obj.__dict__.items())])
 
     def store(self, obj):
         '''

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -49,6 +49,7 @@ class CsvDB(object):
         self._opened = False
         self.db_path = None
         self._opened = False
+        self._tables = {}
 
     def _prepare(self, path):
         self.path = path
@@ -103,6 +104,22 @@ class CsvDB(object):
             databases.append(dbname)
         return list(reversed(sorted(databases)))
 
+    def list_tables(self):
+        '''
+        Load existing tables and their descriptions.
+
+        :return:
+        '''
+        if not self._tables:
+            for table_name in os.listdir(self.db_path):
+                self._tables[table_name] = self._load_table(table_name)
+
+        return self._tables.keys()
+
+    def _load_table(self, table_name):
+        with open(os.path.join(self.db_path, table_name), 'rb') as table:
+            return dict([tuple(elm.split(':')) for elm in csv.reader(table).next()])
+
     def open(self, dbname=None):
         '''
         Open database from the path with the name or latest.
@@ -113,6 +130,7 @@ class CsvDB(object):
         databases = self.list()
         if self.is_closed():
             self.db_path = os.path.join(self.path, dbname or (databases and databases[0] or self.new()))
+            self._opened = True
 
     def close(self):
         '''

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+'''
+    :codeauthor: :email:`Bo Maryniuk <bo@suse.de>`
+'''
+
 import os
 import re
 import csv

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -276,7 +276,8 @@ class CsvDB(object):
                 for t_attr, t_data in zip(header, data):
                     t_attr, t_type = t_attr.split(':')
                     setattr(_obj, t_attr, self._to_type(t_data, t_type))
-                objects.append(_obj)
+                if self.__criteria(_obj, matches=matches, mt=mt, lt=lt, eq=eq):
+                    objects.append(_obj)
         return objects
 
     def _to_type(self, data, type):

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -26,12 +26,13 @@ class CsvDBEntity(object):
     def bind_table(self, table):
         self.__table = table
 
-    def serialize(self):
+    def serialize(self, description):
         '''
-        Serialize the object to a row for CSV.
+        Serialize the object to a row for CSV according to the table description.
 
         :return:
         '''
+        return [getattr(self, attr) for attr in description]
 
 
 class CsvDB(object):

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -175,13 +175,22 @@ class CsvDB(object):
                                                  for elm in tuple(obj.__dict__.items())])
             self._tables[obj._TABLE] = self._load_table(obj._TABLE)
 
-    def store(self, obj):
+    def store(self, obj, distinct=False, update=None):
         '''
         Store an object in the table.
 
-        :param obj:
+        :param obj: An object to store
+        :param distinct: Store object only if there is none identical of such.
+                          If at least one field is different, store it.
+        :param update: Update an object by the following keys. Parameter should be an array of keys.
         :return:
         '''
+        if distinct:
+            fields = dict(zip(self._tables[obj._TABLE].keys(), obj._serialize(self._tables[obj._TABLE])))
+            db_obj = self.get(obj.__class__, eq=fields)
+            if db_obj and distinct:
+                raise Exception("Object already in the database.")
+
         with gzip.open(os.path.join(self.db_path, obj._TABLE), 'a') as table:
             csv.writer(table).writerow(self._validate_object(obj))
 

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -91,6 +91,16 @@ class CsvDB(object):
         if os.path.exists(db_path):
             shutil.rmtree(db_path, ignore_errors=True)
 
+    def flush(self, table):
+        '''
+        Flush table.
+
+        :param table:
+        :return:
+        '''
+        table_path = os.path.join(self.db_path, table)
+        if os.path.exists(table_path):
+            os.unlink(table_path)
 
     def list(self):
         '''

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -53,8 +53,23 @@ class CsvDB(object):
 
     def new(self):
         '''
-        Create a new database.
+        Create a new database and opens it.
 
+        :return:
+        '''
+
+    def get_tables(self):
+        '''
+        Get a list of existin tables in this database.
+
+        :return:
+        '''
+
+    def add_table(self, table):
+        '''
+        Add table.
+
+        :param table:
         :return:
         '''
 
@@ -68,14 +83,14 @@ class CsvDB(object):
 
     def list(self):
         '''
-        List all the databases.
+        List all the databases on the given path.
 
         :return:
         '''
 
-    def open(self):
+    def open(self, dbname):
         '''
-        Open database.
+        Open database from the path with the name.
 
         :return:
         '''
@@ -93,3 +108,33 @@ class CsvDB(object):
 
         :return:
         '''
+
+    def table_from_object(self, obj):
+        '''
+        Create a table from the object.
+
+        :param obj:
+        :return:
+        '''
+
+    def store(self, obj):
+        '''
+        Store an object in the table.
+
+        :param obj:
+        :return:
+        '''
+
+    def get(self, table_name, matches=None, mt=None, lt=None, eq=None):
+        '''
+        Get objects from the table.
+
+        :param table_name:
+        :param matches: Regexp.
+        :param mt: More than.
+        :param lt: Less than.
+        :param eq: Equals.
+        :return:
+        '''
+        objects = []
+        return objects

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -18,7 +18,7 @@
     :codeauthor: :email:`Bo Maryniuk <bo@suse.de>`
 '''
 
-from __future__ import absolute_import
+from __future__ import absolute_import, with_statement
 import os
 import sys
 import re
@@ -27,6 +27,7 @@ import datetime
 import gzip
 import shutil
 from salt.utils.odict import OrderedDict
+from salt.ext.six.moves import zip
 
 
 class CsvDBEntity(object):
@@ -136,7 +137,7 @@ class CsvDB(object):
 
     def _load_table(self, table_name):
         with gzip.open(os.path.join(self.db_path, table_name), 'rb') as table:
-            return OrderedDict([tuple(elm.split(':')) for elm in csv.reader(table).next()])
+            return OrderedDict([tuple(elm.split(':')) for elm in next(csv.reader(table))])
 
     def open(self, dbname=None):
         '''
@@ -193,10 +194,8 @@ class CsvDB(object):
         :return:
         '''
         if distinct:
-            # pylint: disable=W1699
             fields = dict(zip(self._tables[obj._TABLE].keys(),
                               obj._serialize(self._tables[obj._TABLE])))
-            # pylint: enable=W1699
             db_obj = self.get(obj.__class__, eq=fields)
             if db_obj and distinct:
                 raise Exception("Object already in the database.")

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -24,8 +24,6 @@ class CsvDBEntity(object):
     '''
     Serializable object for the table.
     '''
-    def bind_table(self, table):
-        self.__table = table
 
     def serialize(self, description):
         '''

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -211,7 +211,11 @@ class CsvDB(object):
         updated = False
         objects = list()
         for _obj in self.get(obj.__class__):
-            objects.append(not self.__criteria(_obj, matches=matches, mt=mt, lt=lt, eq=eq) and _obj or obj)
+            if self.__criteria(_obj, matches=matches, mt=mt, lt=lt, eq=eq):
+                objects.append(obj)
+                updated = True
+            else:
+                objects.append(_obj)
         self.flush(obj._TABLE)
         self.create_table_from_object(obj)
         for obj in objects:

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -39,7 +39,7 @@ class CsvDBEntity(object):
 class CsvDB(object):
     '''
     File-based CSV database.
-    This database is in-memory operating plain text csv files.
+    This database is in-memory operating relatively small plain text csv files.
     '''
     def __init__(self, path):
         '''

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -17,6 +17,7 @@
 import os
 import csv
 import datetime
+import gzip
 from salt.utils.odict import OrderedDict
 
 
@@ -110,7 +111,7 @@ class CsvDB(object):
         return self._tables.keys()
 
     def _load_table(self, table_name):
-        with open(os.path.join(self.db_path, table_name), 'rb') as table:
+        with gzip.open(os.path.join(self.db_path, table_name), 'rb') as table:
             return OrderedDict([tuple(elm.split(':')) for elm in csv.reader(table).next()])
 
     def open(self, dbname=None):
@@ -153,7 +154,7 @@ class CsvDB(object):
         '''
         get_type = lambda item: str(type(item)).split("'")[1]
         if not os.path.exists(os.path.join(self.db_path, obj._TABLE)):
-            with open(os.path.join(self.db_path, obj._TABLE), 'wb') as table_file:
+            with gzip.open(os.path.join(self.db_path, obj._TABLE), 'wb') as table_file:
                 csv.writer(table_file).writerow(['{col}:{type}'.format(col=elm[0], type=get_type(elm[1]))
                                                  for elm in tuple(obj.__dict__.items())])
 
@@ -164,7 +165,7 @@ class CsvDB(object):
         :param obj:
         :return:
         '''
-        with open(os.path.join(self.db_path, obj._TABLE), 'a') as table:
+        with gzip.open(os.path.join(self.db_path, obj._TABLE), 'a') as table:
             csv.writer(table).writerow(self._validate_object(obj))
 
     def _validate_object(self, obj):
@@ -185,7 +186,7 @@ class CsvDB(object):
         :return:
         '''
         objects = []
-        with open(os.path.join(self.db_path, obj._TABLE), 'rb') as table:
+        with gzip.open(os.path.join(self.db_path, obj._TABLE), 'rb') as table:
             header = None
             for data in csv.reader(table):
                 if not header:

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -264,12 +264,12 @@ class CsvDB(object):
         '''
         # Fail matcher if "less than"
         for field, value in (mt or {}).items():
-            if getattr(obj, field) < value:
+            if getattr(obj, field) <= value:
                 return False
 
         # Fail matcher if "more than"
         for field, value in (lt or {}).items():
-            if getattr(obj, field) > value:
+            if getattr(obj, field) >= value:
                 return False
 
         # Fail matcher if "not equal"

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import datetime
 
 
@@ -43,6 +44,13 @@ class CsvDB(object):
 
         :param path:
         '''
+        self._prepare(path)
+        self._opened = False
+
+    def _prepare(self, path):
+        self.path = path
+        if not os.path.exists(self.path):
+            os.makedirs(self.path)
 
     def _label(self):
         '''
@@ -50,6 +58,7 @@ class CsvDB(object):
 
         :return:
         '''
+        return datetime.datetime.utcnow().strftime('%Y%m%d.%H%M%S')
 
     def new(self):
         '''
@@ -57,6 +66,10 @@ class CsvDB(object):
 
         :return:
         '''
+        self.db_path = os.path.join(self.path, self._label())
+        if not os.path.exists(self.db_path):
+            os.makedirs(self.db_path)
+        self._opened = True
 
     def get_tables(self):
         '''
@@ -79,8 +92,12 @@ class CsvDB(object):
 
         :return:
         '''
+        databases = []
+        for dbname in os.listdir(self.path):
+            databases.append(dbname)
+        return reversed(sorted(databases))
 
-    def open(self, dbname):
+    def open(self, dbname=None):
         '''
         Open database from the path with the name or latest.
 

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -205,14 +205,19 @@ class CsvDB(object):
         :param eq:
         :return:
         '''
+        deleted = False
         objects = list()
         for obj in self.get(obj):
             if not self.__criteria(obj, matches=matches, mt=mt, lt=lt, eq=eq):
                 objects.append(obj)
+            else:
+                deleted = True
         self.flush(obj._TABLE)
         self.create_table_from_object(obj)
         for obj in objects:
             self.store(obj)
+
+        return deleted
 
 
     def _validate_object(self, obj):

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -82,7 +82,7 @@ class CsvDB(object):
 
     def open(self, dbname):
         '''
-        Open database from the path with the name.
+        Open database from the path with the name or latest.
 
         :return:
         '''

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -17,6 +17,21 @@
 import datetime
 
 
+class CsvDBEntity(object):
+    '''
+    Serializable object for the table.
+    '''
+    def bind_table(self, table):
+        self.__table = table
+
+    def serialize(self):
+        '''
+        Serialize the object to a row for CSV.
+
+        :return:
+        '''
+
+
 class CsvDB(object):
     '''
     File-based CSV database.

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -18,6 +18,7 @@ import os
 import csv
 import datetime
 import gzip
+import shutil
 from salt.utils.odict import OrderedDict
 
 
@@ -86,6 +87,10 @@ class CsvDB(object):
         :param dbid:
         :return:
         '''
+        db_path = os.path.join(self.path, dbid)
+        if os.path.exists(db_path):
+            shutil.rmtree(db_path, ignore_errors=True)
+
 
     def list(self):
         '''

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2016 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+
+
+class CsvDB(object):
+    '''
+    File-based CSV database.
+    This database is in-memory operating plain text csv files.
+    '''
+    def __init__(self, path):
+        '''
+        Constructor to store the database files.
+
+        :param path:
+        '''
+
+    def _label(self):
+        '''
+        Create label of the database, based on the date-time.
+
+        :return:
+        '''
+
+    def new(self):
+        '''
+        Create a new database.
+
+        :return:
+        '''
+
+    def purge(self, dbid):
+        '''
+        Purge the database.
+
+        :param dbid:
+        :return:
+        '''
+
+    def list(self):
+        '''
+        List all the databases.
+
+        :return:
+        '''
+
+    def open(self):
+        '''
+        Open database.
+
+        :return:
+        '''
+
+    def close(self):
+        '''
+        Close the database.
+
+        :return:
+        '''
+
+    def is_closed(self):
+        '''
+        Return if the database is closed.
+
+        :return:
+        '''

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -68,7 +68,7 @@ class CsvDB(object):
 
         :return:
         '''
-        return datetime.datetime.utcnow().strftime('%Y%m%d.%H%M%S')
+        return datetime.datetime.utcnow().strftime('%Y%m%d-%H%M%S')
 
     def new(self):
         '''

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -65,14 +65,6 @@ class CsvDB(object):
         :return:
         '''
 
-    def add_table(self, table):
-        '''
-        Add table.
-
-        :param table:
-        :return:
-        '''
-
     def purge(self, dbid):
         '''
         Purge the database.

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -18,7 +18,9 @@
     :codeauthor: :email:`Bo Maryniuk <bo@suse.de>`
 '''
 
+from __future__ import absolute_import
 import os
+import sys
 import re
 import csv
 import datetime
@@ -191,11 +193,13 @@ class CsvDB(object):
         :return:
         '''
         if distinct:
-            fields = dict(zip(self._tables[obj._TABLE].keys(), obj._serialize(self._tables[obj._TABLE])))
+            # pylint: disable=W1699
+            fields = dict(zip(self._tables[obj._TABLE].keys(),
+                              obj._serialize(self._tables[obj._TABLE])))
+            # pylint: enable=W1699
             db_obj = self.get(obj.__class__, eq=fields)
             if db_obj and distinct:
                 raise Exception("Object already in the database.")
-
         with gzip.open(os.path.join(self.db_path, obj._TABLE), 'a') as table:
             csv.writer(table).writerow(self._validate_object(obj))
 
@@ -322,7 +326,7 @@ class CsvDB(object):
         elif type == 'float':
             data = float(data)
         elif type == 'long':
-            data = long(data)
+            data = sys.version_info[0] == 2 and long(data) or int(data)  # pylint: disable=W1699
         else:
             data = str(data)
         return data

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -215,7 +215,6 @@ class CsvDB(object):
 
         return updated
 
-
     def delete(self, obj, matches=None, mt=None, lt=None, eq=None):
         '''
         Delete object from the database.

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -229,18 +229,18 @@ class CsvDB(object):
         '''
         deleted = False
         objects = list()
-        for obj in self.get(obj):
-            if not self.__criteria(obj, matches=matches, mt=mt, lt=lt, eq=eq):
-                objects.append(obj)
+        for _obj in self.get(obj):
+            if not self.__criteria(_obj, matches=matches, mt=mt, lt=lt, eq=eq):
+                objects.append(_obj)
             else:
                 deleted = True
+
         self.flush(obj._TABLE)
-        self.create_table_from_object(obj)
-        for obj in objects:
-            self.store(obj)
+        self.create_table_from_object(obj())
+        for _obj in objects:
+            self.store(_obj)
 
         return deleted
-
 
     def _validate_object(self, obj):
         descr = self._tables.get(obj._TABLE)

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -24,8 +24,7 @@ class CsvDBEntity(object):
     '''
     Serializable object for the table.
     '''
-
-    def serialize(self, description):
+    def _serialize(self, description):
         '''
         Serialize the object to a row for CSV according to the table description.
 
@@ -172,7 +171,7 @@ class CsvDB(object):
         descr = self._tables.get(obj._TABLE)
         if descr is None:
             raise Exception('Table {0} not found.'.format(obj._TABLE))
-        return obj.serialize(self._tables[obj._TABLE])
+        return obj._serialize(self._tables[obj._TABLE])
 
     def get(self, table_name, matches=None, mt=None, lt=None, eq=None):
         '''

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -46,6 +46,8 @@ class CsvDB(object):
         '''
         self._prepare(path)
         self._opened = False
+        self.db_path = None
+        self._opened = False
 
     def _prepare(self, path):
         self.path = path
@@ -66,10 +68,13 @@ class CsvDB(object):
 
         :return:
         '''
-        self.db_path = os.path.join(self.path, self._label())
+        dbname = self._label()
+        self.db_path = os.path.join(self.path, dbname)
         if not os.path.exists(self.db_path):
             os.makedirs(self.db_path)
         self._opened = True
+
+        return dbname
 
     def get_tables(self):
         '''
@@ -95,7 +100,7 @@ class CsvDB(object):
         databases = []
         for dbname in os.listdir(self.path):
             databases.append(dbname)
-        return reversed(sorted(databases))
+        return list(reversed(sorted(databases)))
 
     def open(self, dbname=None):
         '''
@@ -103,6 +108,9 @@ class CsvDB(object):
 
         :return:
         '''
+        databases = self.list()
+        if self.is_closed():
+            self.db_path = os.path.join(self.path, dbname or (databases and databases[0] or self.new()))
 
     def close(self):
         '''
@@ -110,6 +118,7 @@ class CsvDB(object):
 
         :return:
         '''
+        self._opened = False
 
     def is_closed(self):
         '''
@@ -117,6 +126,7 @@ class CsvDB(object):
 
         :return:
         '''
+        return not self._opened
 
     def table_from_object(self, obj):
         '''

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -173,7 +173,7 @@ class CsvDB(object):
             raise Exception('Table {0} not found.'.format(obj._TABLE))
         return obj._serialize(self._tables[obj._TABLE])
 
-    def get(self, table_name, matches=None, mt=None, lt=None, eq=None):
+    def get(self, obj, matches=None, mt=None, lt=None, eq=None):
         '''
         Get objects from the table.
 
@@ -185,4 +185,26 @@ class CsvDB(object):
         :return:
         '''
         objects = []
+        with open(os.path.join(self.db_path, obj._TABLE), 'rb') as table:
+            header = None
+            for data in csv.reader(table):
+                if not header:
+                    header = data
+                    continue
+                _obj = obj()
+                for t_attr, t_data in zip(header, data):
+                    t_attr, t_type = t_attr.split(':')
+                    setattr(_obj, t_attr, self._to_type(t_data, t_type))
+                objects.append(_obj)
         return objects
+
+    def _to_type(self, data, type):
+        if type == 'int':
+            data = int(data)
+        elif type == 'float':
+            data = float(data)
+        elif type == 'long':
+            data = long(data)
+        else:
+            data = str(data)
+        return data

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -407,7 +407,7 @@ class Query(EnvLoader):
 
     def _payload(self, *args, **kwargs):
         '''
-        Find all unmanaged files.
+        Find all unmanaged files. Returns maximum 1000 values.
 
         Parameters:
 
@@ -419,6 +419,11 @@ class Query(EnvLoader):
                       Values: name (default), id
         * **type**: Comma-separated type of included payload: dir (or directory), link and/or file.
         * **brief**: Return just a list of matches, if True. Default: False
+        * **offset**: Offset of the files
+
+        Options:
+
+        * **total**: Return a total amount of found payload files
         '''
         def _size_format(size, fmt):
             if fmt is None:

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -420,6 +420,7 @@ class Query(EnvLoader):
         * **type**: Comma-separated type of included payload: dir (or directory), link and/or file.
         * **brief**: Return just a list of matches, if True. Default: False
         * **offset**: Offset of the files
+        * **max**: Maximum returned values. Default 1000.
 
         Options:
 
@@ -473,7 +474,7 @@ class Query(EnvLoader):
 
         brief = kwargs.get("brief")
         pld_files = list() if brief else dict()
-        for pld_data in self.db.get(PayloadFile)[offset:offset + 1000]:
+        for pld_data in self.db.get(PayloadFile)[offset:offset + kwargs.get('max', 1000)]:
             if brief:
                 pld_files.append(pld_data.path)
             else:

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -191,10 +191,10 @@ class Query(EnvLoader):
         '''
 
         data = dict()
-        self.db._csv_db.open()
-        for pkg in self.db._csv_db.get(Package):
+        self.db.open()
+        for pkg in self.db.get(Package):
             configs = list()
-            for pkg_cfg in self.db._csv_db.get(PackageCfgFile, eq={'pkgid': pkg.id}):
+            for pkg_cfg in self.db.get(PackageCfgFile, eq={'pkgid': pkg.id}):
                 configs.append(pkg_cfg.path)
             data[pkg.name] = configs
 
@@ -456,11 +456,10 @@ class Query(EnvLoader):
                                               'Should be comma separated one or more of '
                                               'dir, file and/or link.'.format(", ".join(incl_type)))
         self.db.open()
-        self.db._csv_db.open()
 
         brief = kwargs.get("brief")
         pld_files = list() if brief else dict()
-        for pld_data in self.db._csv_db.get(PayloadFile):
+        for pld_data in self.db.get(PayloadFile):
             if brief:
                 pld_files.append(pld_data.path)
             else:

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -440,6 +440,7 @@ class Query(EnvLoader):
                 return "{0} Gb".format(round((float(size) / 0x400 / 0x400 / 0x400), 2))
 
         filter = kwargs.get('filter')
+        offset = kwargs.get('offset', 0)
 
         timeformat = kwargs.get("time", "tz")
         if timeformat not in ["ticks", "tz"]:
@@ -467,9 +468,12 @@ class Query(EnvLoader):
                                               'dir, file and/or link.'.format(", ".join(incl_type)))
         self.db.open()
 
+        if "total" in args:
+            return {'total': len(self.db.get(PayloadFile))}
+
         brief = kwargs.get("brief")
         pld_files = list() if brief else dict()
-        for pld_data in self.db.get(PayloadFile):
+        for pld_data in self.db.get(PayloadFile)[offset:offset + 1000]:
             if brief:
                 pld_files.append(pld_data.path)
             else:

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -167,7 +167,7 @@ class Query(EnvLoader):
             )
         elif not scope:
             raise InspectorQueryException(
-                "Scope cannot be empty. Must be one of: {0}".format(repr(scope), ", ".join(self.SCOPES))
+                "Scope cannot be empty. Must be one of: {0}".format(", ".join(self.SCOPES))
             )
         EnvLoader.__init__(self, cachedir=cachedir)
         self.scope = '_' + scope

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -161,9 +161,14 @@ class Query(EnvLoader):
         :param scope:
         :return:
         '''
-        if scope not in self.SCOPES:
+        if scope and scope not in self.SCOPES:
             raise InspectorQueryException(
-                "Unknown scope: {0}. Must be one of: {1}".format(repr(scope), ", ".join(self.SCOPES)))
+                "Unknown scope: {0}. Must be one of: {1}".format(repr(scope), ", ".join(self.SCOPES))
+            )
+        elif not scope:
+            raise InspectorQueryException(
+                "Scope cannot be empty. Must be one of: {0}".format(repr(scope), ", ".join(self.SCOPES))
+            )
         EnvLoader.__init__(self, cachedir=cachedir)
         self.scope = '_' + scope
         self.local_identity = dict()

--- a/salt/modules/inspector.py
+++ b/salt/modules/inspector.py
@@ -244,3 +244,29 @@ def snapshots():
         log.error(_get_error_message(err))
         raise Exception(err)
 
+
+def delete(*databases):
+    '''
+    Remove description snapshots from the system.
+
+    CLI example:
+
+    .. code-block:: bash:
+
+        salt myminion inspector.delete <ID> <ID1> <ID2>..
+
+    '''
+    if not databases:
+        raise CommandExecutionError('At least one database ID required.')
+
+    try:
+        ret = dict()
+        inspector = _("collector").Inspector()
+        for dbid in databases:
+            ret[dbid] = inspector.db.purge(dbid)
+        return ret
+    except InspectorSnapshotException as err:
+        raise CommandExecutionError(err)
+    except Exception as err:
+        log.error(_get_error_message(err))
+        raise Exception(err)

--- a/salt/modules/inspector.py
+++ b/salt/modules/inspector.py
@@ -102,7 +102,7 @@ def inspect(mode='all', priority=19, **kwargs):
         raise Exception(ex)
 
 
-def query(scope, **kwargs):
+def query(*args, **kwargs):
     '''
     Query the node for specific information.
 
@@ -159,7 +159,7 @@ def query(scope, **kwargs):
     '''
     query = _("query")
     try:
-        return query.Query(scope, cachedir=__opts__['cachedir'])(**kwargs)
+        return query.Query(kwargs.get('scope'), cachedir=__opts__['cachedir'])(*args, **kwargs)
     except InspectorQueryException as ex:
         raise CommandExecutionError(ex)
     except Exception as ex:

--- a/salt/modules/inspector.py
+++ b/salt/modules/inspector.py
@@ -189,7 +189,7 @@ def build(format='qcow2', path='/tmp/'):
     try:
         _("collector").Inspector(cachedir=__opts__['cachedir'],
                                  piddir=os.path.dirname(__opts__['pidfile']),
-                                 pidfilename='').build(format=format, path=path)
+                                 pidfilename='').reuse_snapshot().build(format=format, path=path)
     except InspectorKiwiProcessorException as ex:
         raise CommandExecutionError(ex)
     except Exception as ex:
@@ -218,7 +218,7 @@ def export(local=False, path="/tmp", format='qcow2'):
         raise CommandExecutionError('In order to export system, the minion should run as "root".')
     try:
         description = _("query").Query('all', cachedir=__opts__['cachedir'])()
-        return _("collector").Inspector().export(description, local=local, path=path, format=format)
+        return _("collector").Inspector().reuse_snapshot().export(description, local=local, path=path, format=format)
     except InspectorKiwiProcessorException as ex:
         raise CommandExecutionError(ex)
     except Exception as ex:

--- a/salt/modules/inspector.py
+++ b/salt/modules/inspector.py
@@ -246,25 +246,27 @@ def snapshots():
        raise Exception(err)
 
 
-def delete(*databases):
+def delete(all=False, *databases):
     '''
     Remove description snapshots from the system.
+
+    ::parameter: all. Default: False. Remove all snapshots, if set to True.
 
     CLI example:
 
     .. code-block:: bash:
 
         salt myminion inspector.delete <ID> <ID1> <ID2>..
-
+        salt myminion inspector.delete all=True
     '''
-    if not databases:
+    if not all and not databases:
         raise CommandExecutionError('At least one database ID required.')
 
     try:
         ret = dict()
         inspector = _("collector").Inspector(cachedir=__opts__['cachedir'],
                                              piddir=os.path.dirname(__opts__['pidfile']))
-        for dbid in databases:
+        for dbid in (all and inspector.db.list() or databases):
             ret[dbid] = inspector.db._db.purge(str(dbid))
         return ret
     except InspectorSnapshotException as err:

--- a/salt/modules/inspector.py
+++ b/salt/modules/inspector.py
@@ -224,3 +224,23 @@ def export(local=False, path="/tmp", format='qcow2'):
     except Exception as ex:
         log.error(_get_error_message(ex))
         raise Exception(ex)
+
+
+def snapshots():
+    '''
+    List current description snapshots.
+
+    CLI Example:
+
+    .. code-block:: bash:
+
+        salt myminion inspector.snapshots
+    '''
+    try:
+        return _("collector").Inspector().db.list()
+    except InspectorSnapshotException as err:
+        raise CommandExecutionError(err)
+    except Exception as err:
+        log.error(_get_error_message(err))
+        raise Exception(err)
+

--- a/salt/modules/inspector.py
+++ b/salt/modules/inspector.py
@@ -154,8 +154,8 @@ def query(scope, **kwargs):
 
     .. code-block:: bash
 
-        salt '*' inspector.query scope=os
-        salt '*' inspector.query payload type=file,link filter=/etc size=Kb brief=False
+        salt '*' inspector.query scope=system
+        salt '*' inspector.query scope=payload type=file,link filter=/etc size=Kb brief=False
     '''
     query = _("query")
     try:

--- a/salt/modules/inspector.py
+++ b/salt/modules/inspector.py
@@ -240,10 +240,10 @@ def snapshots():
         return _("collector").Inspector(cachedir=__opts__['cachedir'],
                                         piddir=os.path.dirname(__opts__['pidfile'])).db.list()
     except InspectorSnapshotException as err:
-       raise CommandExecutionError(err)
+        raise CommandExecutionError(err)
     except Exception as err:
-       log.error(_get_error_message(err))
-       raise Exception(err)
+        log.error(_get_error_message(err))
+        raise Exception(err)
 
 
 def delete(all=False, *databases):
@@ -266,7 +266,7 @@ def delete(all=False, *databases):
         ret = dict()
         inspector = _("collector").Inspector(cachedir=__opts__['cachedir'],
                                              piddir=os.path.dirname(__opts__['pidfile']))
-        for dbid in (all and inspector.db.list() or databases):
+        for dbid in all and inspector.db.list() or databases:
             ret[dbid] = inspector.db._db.purge(str(dbid))
         return ret
     except InspectorSnapshotException as err:

--- a/salt/modules/inspector.py
+++ b/salt/modules/inspector.py
@@ -38,7 +38,7 @@ def __virtual__():
     '''
     Only work on POSIX-like systems
     '''
-    return not salt.utils.is_windows()
+    return not salt.utils.is_windows() and 'inspector'
 
 
 def _(module):
@@ -86,9 +86,9 @@ def inspect(mode='all', priority=19, **kwargs):
 
     .. code-block:: bash
 
-        salt '*' node.inspect
-        salt '*' node.inspect configuration
-        salt '*' node.inspect payload filter=/opt,/ext/oracle
+        salt '*' inspector.inspect
+        salt '*' inspector.inspect configuration
+        salt '*' inspector.inspect payload filter=/opt,/ext/oracle
     '''
     collector = _("collector")
     try:
@@ -154,8 +154,8 @@ def query(scope, **kwargs):
 
     .. code-block:: bash
 
-        salt '*' node.query scope=os
-        salt '*' node.query payload type=file,link filter=/etc size=Kb brief=False
+        salt '*' inspector.query scope=os
+        salt '*' inspector.query payload type=file,link filter=/etc size=Kb brief=False
     '''
     query = _("query")
     try:
@@ -183,8 +183,8 @@ def build(format='qcow2', path='/tmp/'):
 
     .. code-block:: bash:
 
-        salt myminion node.build
-        salt myminion node.build format=iso path=/opt/builds/
+        salt myminion inspector.build
+        salt myminion inspector.build format=iso path=/opt/builds/
     '''
     try:
         _("collector").Inspector(cachedir=__opts__['cachedir'],
@@ -211,8 +211,8 @@ def export(local=False, path="/tmp", format='qcow2'):
 
     .. code-block:: bash:
 
-        salt myminion node.export
-        salt myminion node.export format=iso path=/opt/builds/
+        salt myminion inspector.export
+        salt myminion inspector.export format=iso path=/opt/builds/
     '''
     if getpass.getuser() != 'root':
         raise CommandExecutionError('In order to export system, the minion should run as "root".')

--- a/salt/modules/inspector.py
+++ b/salt/modules/inspector.py
@@ -237,12 +237,13 @@ def snapshots():
         salt myminion inspector.snapshots
     '''
     try:
-        return _("collector").Inspector().db.list()
+        return _("collector").Inspector(cachedir=__opts__['cachedir'],
+                                        piddir=os.path.dirname(__opts__['pidfile'])).db.list()
     except InspectorSnapshotException as err:
-        raise CommandExecutionError(err)
+       raise CommandExecutionError(err)
     except Exception as err:
-        log.error(_get_error_message(err))
-        raise Exception(err)
+       log.error(_get_error_message(err))
+       raise Exception(err)
 
 
 def delete(*databases):
@@ -261,9 +262,10 @@ def delete(*databases):
 
     try:
         ret = dict()
-        inspector = _("collector").Inspector()
+        inspector = _("collector").Inspector(cachedir=__opts__['cachedir'],
+                                             piddir=os.path.dirname(__opts__['pidfile']))
         for dbid in databases:
-            ret[dbid] = inspector.db.purge(dbid)
+            ret[dbid] = inspector.db._db.purge(str(dbid))
         return ret
     except InspectorSnapshotException as err:
         raise CommandExecutionError(err)

--- a/tests/unit/modules/inspect_collector_test.py
+++ b/tests/unit/modules/inspect_collector_test.py
@@ -40,6 +40,7 @@ class InspectorCollectorTestCase(TestCase):
     '''
     Test inspectlib:collector:Inspector
     '''
+    @patch("os.mkdir", MagicMock())
     def test_env_loader(self):
         '''
         Get packages on the different distros.
@@ -50,6 +51,7 @@ class InspectorCollectorTestCase(TestCase):
         self.assertEqual(inspector.dbfile, '/foo/cache/_minion_collector.db')
         self.assertEqual(inspector.pidfile, '/foo/pid/bar.pid')
 
+    @patch("os.mkdir", MagicMock())
     def test_file_tree(self):
         '''
         Test file tree.
@@ -72,6 +74,7 @@ class InspectorCollectorTestCase(TestCase):
         tree_result = tuple(tree_result)
         self.assertEqual(expected_tree, tree_result)
 
+    @patch("os.mkdir", MagicMock())
     def test_get_unmanaged_files(self):
         '''
         Test get_unmanaged_files.
@@ -92,6 +95,7 @@ class InspectorCollectorTestCase(TestCase):
         self.assertEqual(inspector._get_unmanaged_files(managed=managed, system_all=system_all),
                          ([], ['E'], ['G', 'H']))
 
+    @patch("os.mkdir", MagicMock())
     def test_pkg_get(self):
         '''
         Test if grains switching the pkg get method.

--- a/tests/unit/modules/inspect_collector_test.py
+++ b/tests/unit/modules/inspect_collector_test.py
@@ -1,4 +1,18 @@
 # -*- coding: utf-8 -*-
+#
+# Copyright 2016 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 '''
     :codeauthor: :email:`Bo Maryniuk <bo@suse.de>`
 '''

--- a/tests/unit/modules/inspect_fsdb_test.py
+++ b/tests/unit/modules/inspect_fsdb_test.py
@@ -30,8 +30,7 @@ from salt.modules.inspectlib.fsdb import CsvDB
 from salt.modules.inspectlib.entities import CsvDBEntity
 from salt.utils.odict import OrderedDict
 
-
-from StringIO import StringIO
+from salt.ext.six.moves import StringIO
 
 ensure_in_syspath('../../')
 

--- a/tests/unit/modules/inspect_fsdb_test.py
+++ b/tests/unit/modules/inspect_fsdb_test.py
@@ -203,6 +203,28 @@ class InspectorFSDBTestCase(TestCase):
 
     @patch("os.makedirs", MagicMock())
     @patch("os.listdir", MagicMock(return_value=['test_db']))
+    def test_get_obj_equals(self):
+        '''
+        Getting an object from the store with conditions
+        :return:
+        '''
+        with patch("gzip.open", MagicMock()):
+            with patch("csv.reader", MagicMock(return_value=iter([[], ['foo:int', 'bar:str', 'spam:float'],
+                                                                  ['123', 'test', '0.123'],
+                                                                  ['234', 'another', '0.456']]))):
+                csvdb = CsvDB('/foobar')
+                csvdb.open()
+
+                entities = csvdb.get(FoobarEntity, eq={'foo': 123})
+                assert list == type(entities)
+                assert len(entities) == 1
+
+                assert entities[0].foo == 123
+                assert entities[0].bar == 'test'
+                assert entities[0].spam == 0.123
+
+    @patch("os.makedirs", MagicMock())
+    @patch("os.listdir", MagicMock(return_value=['test_db']))
     def test_get_obj_more_than(self):
         '''
         Getting an object from the store with conditions

--- a/tests/unit/modules/inspect_fsdb_test.py
+++ b/tests/unit/modules/inspect_fsdb_test.py
@@ -178,6 +178,37 @@ class InspectorFSDBTestCase(TestCase):
 
     @patch("os.makedirs", MagicMock())
     @patch("os.listdir", MagicMock(return_value=['test_db']))
+    def test_delete_object(self):
+        '''
+        Deleting an object from the store.
+        :return:
+        '''
+        with patch("gzip.open", MagicMock()):
+            with patch("csv.reader", MagicMock(return_value=iter([[], ['foo:int', 'bar:str', 'spam:float'],
+                                                                  ['123', 'test', '0.123'],
+                                                                  ['234', 'another', '0.456']]))):
+                class InterceptedCsvDB(CsvDB):
+                    def __init__(self, path):
+                        CsvDB.__init__(self, path)
+                        self._remained = list()
+
+                    def store(self, obj, distinct=False):
+                        self._remained.append(obj)
+
+                csvdb = InterceptedCsvDB('/foobar')
+                csvdb.open()
+                csvdb.create_table_from_object = MagicMock()
+                csvdb.flush = MagicMock()
+
+                assert csvdb.delete(FoobarEntity, eq={'foo': 123}) == True
+                assert len(csvdb._remained) == 1
+
+                assert csvdb._remained[0].foo == 234
+                assert csvdb._remained[0].bar == 'another'
+                assert csvdb._remained[0].spam == 0.456
+
+    @patch("os.makedirs", MagicMock())
+    @patch("os.listdir", MagicMock(return_value=['test_db']))
     def test_get_object(self):
         '''
         Getting an object from the store.

--- a/tests/unit/modules/inspect_fsdb_test.py
+++ b/tests/unit/modules/inspect_fsdb_test.py
@@ -60,7 +60,9 @@ def mock_open(data=None):
 
 
 class Writable(StringIO):
-    data = []
+    def __init__(self):
+        StringIO.__init__(self)
+        self.data = []
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         return self

--- a/tests/unit/modules/inspect_fsdb_test.py
+++ b/tests/unit/modules/inspect_fsdb_test.py
@@ -34,6 +34,8 @@ from salttesting.mock import (
 from salttesting.helpers import ensure_in_syspath
 from salt.modules.inspectlib.fsdb import CsvDB
 from salt.modules.inspectlib.entities import CsvDBEntity
+from salt.utils.odict import OrderedDict
+
 
 from StringIO import StringIO
 
@@ -146,6 +148,19 @@ class InspectorFSDBTestCase(TestCase):
     def test_list_databases(self):
         '''
         Test storing object into the database.
+
+    def test_obj_serialization(self):
+        '''
+        Test object serialization.
+        :return:
+        '''
+        obj = FoobarEntity()
+        obj.foo = 123
+        obj.bar = 'test entity'
+        obj.spam = 0.123
+
+        descr = OrderedDict([tuple(elm.split(':')) for elm in ["foo:int", "bar:str", "spam:float"]])
+        assert obj._serialize(descr) == [123, 'test entity', 0.123]
 
         :return:
         '''

--- a/tests/unit/modules/inspect_fsdb_test.py
+++ b/tests/unit/modules/inspect_fsdb_test.py
@@ -57,7 +57,8 @@ def mock_open(data=None):
     return mock
 
 
-class TestEntity(CsvDBEntity):
+
+class FoobarEntity(CsvDBEntity):
     '''
     Entity for test purposes.
     '''
@@ -131,7 +132,7 @@ class InspectorFSDBTestCase(TestCase):
         with patch("gzip.open", MagicMock(return_value=writer)):
             csvdb = CsvDB('/foobar')
             csvdb.open()
-            csvdb.create_table_from_object(TestEntity())
+            csvdb.create_table_from_object(FoobarEntity())
 
         assert writer.data[0].strip() == "foo:int,bar:str,spam:float"
 

--- a/tests/unit/modules/inspect_fsdb_test.py
+++ b/tests/unit/modules/inspect_fsdb_test.py
@@ -162,7 +162,21 @@ class InspectorFSDBTestCase(TestCase):
         descr = OrderedDict([tuple(elm.split(':')) for elm in ["foo:int", "bar:str", "spam:float"]])
         assert obj._serialize(descr) == [123, 'test entity', 0.123]
 
+    @patch("os.makedirs", MagicMock())
+    @patch("os.path.exists", MagicMock(return_value=False))
+    @patch("os.listdir", MagicMock(return_value=['some_table']))
+    def test_obj_validation(self):
+        '''
+        Test object validation.
+
         :return:
         '''
+        obj = FoobarEntity()
+        obj.foo = 123
+        obj.bar = 'test entity'
+        obj.spam = 0.123
+
         csvdb = CsvDB('/foobar')
-        assert csvdb.list() == ['test_db']
+        csvdb._tables = {'some_table': OrderedDict([tuple(elm.split(':'))
+                                                    for elm in ["foo:int", "bar:str", "spam:float"]])}
+        assert csvdb._validate_object(obj) == [123, 'test entity', 0.123]

--- a/tests/unit/modules/inspect_fsdb_test.py
+++ b/tests/unit/modules/inspect_fsdb_test.py
@@ -79,6 +79,20 @@ class InspectorFSDBTestCase(TestCase):
         csvdb = CsvDB('/foobar')
         csvdb.open()
         assert csvdb.list_tables() == ['test_db']
+        assert csvdb.is_closed() == False
+
+    @patch("os.makedirs", MagicMock())
+    @patch("os.listdir", MagicMock(return_value=['test_db']))
+    @patch("gzip.open", mock_open("foo:int,bar:str"))
+    def test_close(self):
+        '''
+        Test opening the database.
+        :return:
+        '''
+        csvdb = CsvDB('/foobar')
+        csvdb.open()
+        csvdb.close()
+        assert csvdb.is_closed() == True
 
 
     @patch("os.makedirs", MagicMock())

--- a/tests/unit/modules/inspect_fsdb_test.py
+++ b/tests/unit/modules/inspect_fsdb_test.py
@@ -60,8 +60,11 @@ def mock_open(data=None):
 
 
 class Writable(StringIO):
-    def __init__(self):
-        StringIO.__init__(self)
+    def __init__(self, data=None):
+        if data:
+            StringIO.__init__(self, data)
+        else:
+            StringIO.__init__(self)
         self.data = []
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -69,9 +72,6 @@ class Writable(StringIO):
 
     def __enter__(self):
         return self
-
-    def read(self, n=-1):
-        return ""
 
     def write(self, s):
         self.data.append(s)

--- a/tests/unit/modules/inspect_fsdb_test.py
+++ b/tests/unit/modules/inspect_fsdb_test.py
@@ -176,6 +176,31 @@ class InspectorFSDBTestCase(TestCase):
             csvdb.store(obj)
             assert writable.data[0].strip() == '123,test entity,0.123'
 
+    @patch("os.makedirs", MagicMock())
+    @patch("os.listdir", MagicMock(return_value=['test_db']))
+    def test_get_object(self):
+        '''
+        Getting an object from the store.
+        :return:
+        '''
+        with patch("gzip.open", MagicMock()):
+            with patch("csv.reader", MagicMock(return_value=iter([[], ['foo:int', 'bar:str', 'spam:float'],
+                                                                  ['123', 'test', '0.123'],
+                                                                  ['234', 'another', '0.456']]))):
+                csvdb = CsvDB('/foobar')
+                csvdb.open()
+                entities = csvdb.get(FoobarEntity)
+                assert list == type(entities)
+                assert len(entities) == 2
+
+                assert entities[0].foo == 123
+                assert entities[0].bar == 'test'
+                assert entities[0].spam == 0.123
+
+                assert entities[1].foo == 234
+                assert entities[1].bar == 'another'
+                assert entities[1].spam == 0.456
+
     def test_obj_serialization(self):
         '''
         Test object serialization.

--- a/tests/unit/modules/inspect_fsdb_test.py
+++ b/tests/unit/modules/inspect_fsdb_test.py
@@ -267,6 +267,28 @@ class InspectorFSDBTestCase(TestCase):
                 assert entities[0].bar == 'test'
                 assert entities[0].spam == 0.123
 
+    @patch("os.makedirs", MagicMock())
+    @patch("os.listdir", MagicMock(return_value=['test_db']))
+    def test_get_obj_matching(self):
+        '''
+        Getting an object from the store with conditions
+        :return:
+        '''
+        with patch("gzip.open", MagicMock()):
+            with patch("csv.reader", MagicMock(return_value=iter([[], ['foo:int', 'bar:str', 'spam:float'],
+                                                                  ['123', 'this is test of something', '0.123'],
+                                                                  ['234', 'another test of stuff', '0.456']]))):
+                csvdb = CsvDB('/foobar')
+                csvdb.open()
+
+                entities = csvdb.get(FoobarEntity, matches={'bar': 'is\stest'})
+                assert list == type(entities)
+                assert len(entities) == 1
+
+                assert entities[0].foo == 123
+                assert entities[0].bar == 'this is test of something'
+                assert entities[0].spam == 0.123
+
     def test_obj_serialization(self):
         '''
         Test object serialization.

--- a/tests/unit/modules/inspect_fsdb_test.py
+++ b/tests/unit/modules/inspect_fsdb_test.py
@@ -147,6 +147,11 @@ class InspectorFSDBTestCase(TestCase):
     @patch("os.listdir", MagicMock(return_value=['test_db']))
     def test_list_databases(self):
         '''
+        Test list databases.
+        :return:
+        '''
+        csvdb = CsvDB('/foobar')
+        assert csvdb.list() == ['test_db']
         Test storing object into the database.
 
     def test_obj_serialization(self):

--- a/tests/unit/modules/inspect_fsdb_test.py
+++ b/tests/unit/modules/inspect_fsdb_test.py
@@ -245,6 +245,28 @@ class InspectorFSDBTestCase(TestCase):
                 assert entities[0].bar == 'another'
                 assert entities[0].spam == 0.456
 
+    @patch("os.makedirs", MagicMock())
+    @patch("os.listdir", MagicMock(return_value=['test_db']))
+    def test_get_obj_less_than(self):
+        '''
+        Getting an object from the store with conditions
+        :return:
+        '''
+        with patch("gzip.open", MagicMock()):
+            with patch("csv.reader", MagicMock(return_value=iter([[], ['foo:int', 'bar:str', 'spam:float'],
+                                                                  ['123', 'test', '0.123'],
+                                                                  ['234', 'another', '0.456']]))):
+                csvdb = CsvDB('/foobar')
+                csvdb.open()
+
+                entities = csvdb.get(FoobarEntity, lt={'foo': 234})
+                assert list == type(entities)
+                assert len(entities) == 1
+
+                assert entities[0].foo == 123
+                assert entities[0].bar == 'test'
+                assert entities[0].spam == 0.123
+
     def test_obj_serialization(self):
         '''
         Test object serialization.

--- a/tests/unit/modules/inspect_fsdb_test.py
+++ b/tests/unit/modules/inspect_fsdb_test.py
@@ -201,6 +201,28 @@ class InspectorFSDBTestCase(TestCase):
                 assert entities[1].bar == 'another'
                 assert entities[1].spam == 0.456
 
+    @patch("os.makedirs", MagicMock())
+    @patch("os.listdir", MagicMock(return_value=['test_db']))
+    def test_get_obj_more_than(self):
+        '''
+        Getting an object from the store with conditions
+        :return:
+        '''
+        with patch("gzip.open", MagicMock()):
+            with patch("csv.reader", MagicMock(return_value=iter([[], ['foo:int', 'bar:str', 'spam:float'],
+                                                                  ['123', 'test', '0.123'],
+                                                                  ['234', 'another', '0.456']]))):
+                csvdb = CsvDB('/foobar')
+                csvdb.open()
+
+                entities = csvdb.get(FoobarEntity, mt={'foo': 123})
+                assert list == type(entities)
+                assert len(entities) == 1
+
+                assert entities[0].foo == 234
+                assert entities[0].bar == 'another'
+                assert entities[0].spam == 0.456
+
     def test_obj_serialization(self):
         '''
         Test object serialization.

--- a/tests/unit/modules/inspect_fsdb_test.py
+++ b/tests/unit/modules/inspect_fsdb_test.py
@@ -136,7 +136,6 @@ class InspectorFSDBTestCase(TestCase):
 
         assert writable.data[0].strip() == "foo:int,bar:str,spam:float"
 
-
     @patch("os.makedirs", MagicMock())
     @patch("os.listdir", MagicMock(return_value=['test_db']))
     def test_list_databases(self):
@@ -345,7 +344,7 @@ class InspectorFSDBTestCase(TestCase):
                 csvdb = CsvDB('/foobar')
                 csvdb.open()
 
-                entities = csvdb.get(FoobarEntity, matches={'bar': 'is\stest'})
+                entities = csvdb.get(FoobarEntity, matches={'bar': r'is\stest'})
                 assert list == type(entities)
                 assert len(entities) == 1
 
@@ -429,4 +428,3 @@ class InspectorFSDBTestCase(TestCase):
         assert cmp(obj, matches={'bar': r'^test.*?y$'}, mt={'foo': 122}, lt={'spam': 0.124}, eq={'pi': 3.14}) is True
         assert cmp(obj, matches={'bar': r'^ent'}, mt={'foo': 122}, lt={'spam': 0.124}, eq={'pi': 3.14}) is False
         assert cmp(obj, matches={'bar': r'^test.*?y$'}, mt={'foo': 123}, lt={'spam': 0.124}, eq={'pi': 3.14}) is False
-

--- a/tests/unit/modules/inspect_fsdb_test.py
+++ b/tests/unit/modules/inspect_fsdb_test.py
@@ -100,7 +100,7 @@ class InspectorFSDBTestCase(TestCase):
     @patch("gzip.open", mock_open("foo:int,bar:str"))
     def test_close(self):
         '''
-        Test opening the database.
+        Test closing the database.
         :return:
         '''
         csvdb = CsvDB('/foobar')

--- a/tests/unit/modules/inspect_fsdb_test.py
+++ b/tests/unit/modules/inspect_fsdb_test.py
@@ -20,16 +20,10 @@
 
 # Import Python Libs
 from __future__ import absolute_import
-import os
 
 # Import Salt Testing Libs
-from salttesting import TestCase, skipIf
-from salttesting.mock import (
-    MagicMock,
-    patch,
-    NO_MOCK,
-    NO_MOCK_REASON
-)
+from salttesting import TestCase
+from salttesting.mock import MagicMock, patch
 
 from salttesting.helpers import ensure_in_syspath
 from salt.modules.inspectlib.fsdb import CsvDB

--- a/tests/unit/modules/inspect_fsdb_test.py
+++ b/tests/unit/modules/inspect_fsdb_test.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2016 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+    :codeauthor: :email:`Bo Maryniuk <bo@suse.de>`
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+import os
+
+# Import Salt Testing Libs
+from salttesting import TestCase, skipIf
+from salttesting.mock import (
+    MagicMock,
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+from salttesting.helpers import ensure_in_syspath
+from salt.modules.inspectlib.fsdb import CsvDB
+from StringIO import StringIO
+
+ensure_in_syspath('../../')
+
+
+def mock_open(data=None):
+    '''
+    Mock "open" function in a simple way.
+
+    :param data:
+    :return:
+    '''
+    data = StringIO(data)
+    mock = MagicMock(spec=file)
+    handle = MagicMock(spec=file)
+    handle.write.return_value = None
+    handle.__enter__.return_value = data or handle
+    mock.return_value = handle
+
+    return mock
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class InspectorFSDBTestCase(TestCase):
+    '''
+    Test case for the FSDB: FileSystem Database.
+
+    FSDB is a very simple object-to-CSV storage with a very inefficient
+    update/delete operations (nice to have at some point) and efficient
+    storing/reading the objects (what is exactly needed for the functionality).
+
+    Main advantage of FSDB is to store Python objects in just a CSV files,
+    and have a very small code base.
+    '''
+
+    @patch("os.makedirs", MagicMock())
+    @patch("os.listdir", MagicMock(return_value=['test_db']))
+    @patch("gzip.open", mock_open("foo:int,bar:str"))
+    def test_open(self):
+        '''
+        Test opening the database.
+        :return:
+        '''
+        csvdb = CsvDB('/foobar')
+        csvdb.open()
+        assert csvdb.list_tables() == ['test_db']
+
+
+    @patch("os.makedirs", MagicMock())
+    @patch("os.listdir", MagicMock(return_value=['test_db']))
+    def test_list_databases(self):
+        '''
+        Test storing object into the database.
+
+        :return:
+        '''
+        csvdb = CsvDB('/foobar')
+        assert csvdb.list() == ['test_db']

--- a/tests/unit/modules/inspect_fsdb_test.py
+++ b/tests/unit/modules/inspect_fsdb_test.py
@@ -106,7 +106,7 @@ class InspectorFSDBTestCase(TestCase):
         csvdb = CsvDB('/foobar')
         csvdb.open()
         assert csvdb.list_tables() == ['test_db']
-        assert csvdb.is_closed() == False
+        assert csvdb.is_closed() is False
 
     @patch("os.makedirs", MagicMock())
     @patch("os.listdir", MagicMock(return_value=['test_db']))
@@ -119,7 +119,7 @@ class InspectorFSDBTestCase(TestCase):
         csvdb = CsvDB('/foobar')
         csvdb.open()
         csvdb.close()
-        assert csvdb.is_closed() == True
+        assert csvdb.is_closed() is True
 
     @patch("os.makedirs", MagicMock())
     @patch("os.path.exists", MagicMock(return_value=False))
@@ -194,7 +194,7 @@ class InspectorFSDBTestCase(TestCase):
                 csvdb.create_table_from_object = MagicMock()
                 csvdb.flush = MagicMock()
 
-                assert csvdb.delete(FoobarEntity, eq={'foo': 123}) == True
+                assert csvdb.delete(FoobarEntity, eq={'foo': 123}) is True
                 assert len(csvdb._remained) == 1
 
                 assert csvdb._remained[0].foo == 234
@@ -230,7 +230,7 @@ class InspectorFSDBTestCase(TestCase):
                 csvdb.create_table_from_object = MagicMock()
                 csvdb.flush = MagicMock()
 
-                assert csvdb.update(obj, eq={'foo': 123}) == True
+                assert csvdb.update(obj, eq={'foo': 123}) is True
                 assert len(csvdb._remained) == 2
 
                 assert csvdb._remained[0].foo == 123
@@ -404,30 +404,30 @@ class InspectorFSDBTestCase(TestCase):
         cmp = CsvDB('/foobar')._CsvDB__criteria
 
         # Single
-        assert cmp(obj, eq={'foo': 123}) == True
-        assert cmp(obj, lt={'foo': 124}) == True
-        assert cmp(obj, mt={'foo': 122}) == True
+        assert cmp(obj, eq={'foo': 123}) is True
+        assert cmp(obj, lt={'foo': 124}) is True
+        assert cmp(obj, mt={'foo': 122}) is True
 
-        assert cmp(obj, eq={'foo': 0}) == False
-        assert cmp(obj, lt={'foo': 123}) == False
-        assert cmp(obj, mt={'foo': 123}) == False
+        assert cmp(obj, eq={'foo': 0}) is False
+        assert cmp(obj, lt={'foo': 123}) is False
+        assert cmp(obj, mt={'foo': 123}) is False
 
-        assert cmp(obj, matches={'bar': r't\se.*?'}) == True
-        assert cmp(obj, matches={'bar': r'\s\sentity'}) == False
+        assert cmp(obj, matches={'bar': r't\se.*?'}) is True
+        assert cmp(obj, matches={'bar': r'\s\sentity'}) is False
 
         # Combined
-        assert cmp(obj, eq={'foo': 123, 'bar': r'test entity', 'spam': 0.123}) == True
-        assert cmp(obj, eq={'foo': 123, 'bar': r'test', 'spam': 0.123}) == False
+        assert cmp(obj, eq={'foo': 123, 'bar': r'test entity', 'spam': 0.123}) is True
+        assert cmp(obj, eq={'foo': 123, 'bar': r'test', 'spam': 0.123}) is False
 
-        assert cmp(obj, lt={'foo': 124, 'spam': 0.124}) == True
-        assert cmp(obj, lt={'foo': 124, 'spam': 0.123}) == False
+        assert cmp(obj, lt={'foo': 124, 'spam': 0.124}) is True
+        assert cmp(obj, lt={'foo': 124, 'spam': 0.123}) is False
 
-        assert cmp(obj, mt={'foo': 122, 'spam': 0.122}) == True
-        assert cmp(obj, mt={'foo': 122, 'spam': 0.123}) == False
+        assert cmp(obj, mt={'foo': 122, 'spam': 0.122}) is True
+        assert cmp(obj, mt={'foo': 122, 'spam': 0.123}) is False
 
-        assert cmp(obj, matches={'bar': r'test'}, mt={'foo': 122}, lt={'spam': 0.124}, eq={'pi': 3.14}) == True
+        assert cmp(obj, matches={'bar': r'test'}, mt={'foo': 122}, lt={'spam': 0.124}, eq={'pi': 3.14}) is True
 
-        assert cmp(obj, matches={'bar': r'^test.*?y$'}, mt={'foo': 122}, lt={'spam': 0.124}, eq={'pi': 3.14}) == True
-        assert cmp(obj, matches={'bar': r'^ent'}, mt={'foo': 122}, lt={'spam': 0.124}, eq={'pi': 3.14}) == False
-        assert cmp(obj, matches={'bar': r'^test.*?y$'}, mt={'foo': 123}, lt={'spam': 0.124}, eq={'pi': 3.14}) == False
+        assert cmp(obj, matches={'bar': r'^test.*?y$'}, mt={'foo': 122}, lt={'spam': 0.124}, eq={'pi': 3.14}) is True
+        assert cmp(obj, matches={'bar': r'^ent'}, mt={'foo': 122}, lt={'spam': 0.124}, eq={'pi': 3.14}) is False
+        assert cmp(obj, matches={'bar': r'^test.*?y$'}, mt={'foo': 123}, lt={'spam': 0.124}, eq={'pi': 3.14}) is False
 


### PR DESCRIPTION
### What does this PR do?

SQLite was a back-end cache for the `inspectlib`. It is simply replaced by a simple compressed CSV (comma separated values) storage that allows much more reliable (and actually faster) operation.
### Tests written?

Yes
