### PR TITLE
Skip version checking for targeted packages in pkg.latest state

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1578,31 +1578,18 @@ def latest(
 
     targets = {}
     problems = []
-    cmp_func = __salt__.get('pkg.version_cmp')
-    minion_os = __salt__['grains.item']('os')['os']
-
-    if minion_os == 'Gentoo' and watch_flags:
-        for pkg in desired_pkgs:
-            if not avail[pkg] and not cur[pkg]:
-                msg = 'No information found for {0!r}.'.format(pkg)
+    for pkg in desired_pkgs:
+        if not avail[pkg]:
+            if not cur[pkg]:
+                msg = 'No information found for \'{0}\'.'.format(pkg)
                 log.error(msg)
                 problems.append(msg)
-            else:
-                if salt.utils.compare_versions(ver1=cur[pkg], oper='!=', ver2=avail[pkg], cmp_func=cmp_func):
-                    targets[pkg] = avail[pkg]
-                else:
-                    if not cur[pkg] or __salt__['portage_config.is_changed_uses'](pkg):
-                        targets[pkg] = avail[pkg]
-    else:
-        for pkg in desired_pkgs:
-            if pkg not in avail:
-                if not cur.get(pkg):
-                    msg = 'No information found for \'{0}\'.'.format(pkg)
-                    log.error(msg)
-                    problems.append(msg)
-            elif not cur.get(pkg) \
-                    or salt.utils.compare_versions(ver1=cur[pkg], oper='<', ver2=avail[pkg], cmp_func=cmp_func):
+            elif watch_flags \
+                    and __grains__.get('os') == 'Gentoo' \
+                    and __salt__['portage_config.is_changed_uses'](pkg):
                 targets[pkg] = avail[pkg]
+        else:
+            targets[pkg] = avail[pkg]
 
     if problems:
         return {


### PR DESCRIPTION
The mere fact that we have run pkg.latest_version will tell us if an
upgrade is available, by the value for that package name being a
non-empty string. So, performing version-checking here is overkill.
