### PR TITLE
Fix #34395 Nonfunctional default_password in states.postgres_user.present

### DIFF
--- a/salt/states/postgres_user.py
+++ b/salt/states/postgres_user.py
@@ -147,7 +147,7 @@ def present(name,
 
     if default_password is not None:
         default_password = postgres._maybe_encrypt_password(name,
-                                                            password,
+                                                            default_password,
                                                             encrypted=encrypted)
 
     db_args = {


### PR DESCRIPTION
### What does this PR do?

Makes default_password in states.postgres_user.present working.
### What issues does this PR fix or reference?

[#34395](https://github.com/saltstack/salt/issues/34395)
### Previous Behavior

setting default_password was not leading to any observable results
### New Behavior

default_password functions as intented
### Tests written?

No.
