### PR TITLE
fix proposal for #34438

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -217,6 +217,14 @@ def _fulfills_version_spec(versions, oper, desired_version,
     '''
     cmp_func = __salt__.get('pkg.version_cmp')
     for ver in versions:
+        if oper == '==':
+            # support wildcards in desired version
+            limit = desired_version.find('*')
+            if limit == -1:
+                limit = None
+            ver =  ver[:limit]
+            desired_version = desired_version[:limit]
+
         if salt.utils.compare_versions(ver1=ver,
                                        oper=oper,
                                        ver2=desired_version,


### PR DESCRIPTION
### What does this PR do?

Add wildcard '*' support to pkg version comparison
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/34438
### Previous Behavior

during comparison of installed version `1.11.2-0~wily` with desired version `1.11.2*` it will get unsuccessful result and try to install docker once again:

```
[DEBUG   ] Current version (['1.11.2-0~wily']) did not match desired version specification (1.11.2*), adding to installation targets
```
### New Behavior

Compare version until the `*` if any, which means, it will compare `1.11.2` with `1.11.2` and will get a successful result.
### Tests written?

No
it should behave the same way as before, with asterisk support only in case it was provided.

P.S. should I make a PR over 2016.3 version as well? 
