### PR TITLE
Arch linux does not have osrelease or osmajorrelease grains

### DIFF
--- a/tests/integration/modules/grains.py
+++ b/tests/integration/modules/grains.py
@@ -111,9 +111,14 @@ class TestModulesGrains(integration.ModuleCase):
         test to ensure some core grains are returned
         '''
         grains = ['os', 'os_family', 'osmajorrelease', 'osrelease', 'osfullname', 'id']
+        os = self.run_function('grains.get', ['os'])
+
         for grain in grains:
             get_grain = self.run_function('grains.get', [grain])
-            self.assertTrue(get_grain, grain + "is not available")
+            if os == 'Arch' and grain in ['osmajorrelease', 'osrelease']:
+                self.assertEqual(get_grain, '')
+                continue
+            self.assertTrue(get_grain)
 
 
 class GrainsAppendTestCase(integration.ModuleCase):


### PR DESCRIPTION
### What does this PR do?

Arch linux does not have release versions, so it does not have the osrelease/osmajorrelease grains for it. This change accounts for the release grains not existing.
### What issues does this PR fix or reference?

Fixes failing tests on Arch. 
### Tests written?

Yes
