### PR TITLE
Forgot reference to inotify

### DIFF
--- a/doc/topics/beacons/index.rst
+++ b/doc/topics/beacons/index.rst
@@ -44,6 +44,10 @@ minion configuration file:
 The beacon system, like many others in Salt, can also be configured via the
 minion pillar, grains, or local config file.
 
+.. note::
+    The `inotify` beacon only works on OSes that have `inotify` kernel support.
+    Currently this excludes FreeBSD, Mac OS X, and Windows.
+
 Beacon Monitoring Interval
 --------------------------
 


### PR DESCRIPTION
### What does this PR do?

Adds 'inotify only works on Linux' note to Beacon index as well.
