### PR TITLE
Be more careful when making the SMinion

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -585,9 +585,10 @@ class SMinion(MinionBase):
         # Clean out the proc directory (default /var/cache/salt/minion/proc)
         if (self.opts.get('file_client', 'remote') == 'remote'
                 or self.opts.get('use_master_when_local', False)):
-            if HAS_ZMQ:
-                zmq.eventloop.ioloop.install()
-            io_loop = LOOP_CLASS.current()
+            if self.opts['transport'] == 'zeromq' and HAS_ZMQ:
+                io_loop = zmq.eventloop.ioloop.ZMQIOLoop()
+            else:
+                io_loop = LOOP_CLASS.current()
             io_loop.run_sync(
                 lambda: self.eval_master(self.opts, failed=True)
             )


### PR DESCRIPTION
### What does this PR do?

When we create the initial loop then the previous code was correct, but if we are running a salt client instance from within an existing loop like from runners, from salt api etc, then we need to not install the zmq interface but rely entirely on pyzmq to create the loop if it does not exist or attach to the loop if it does.
### What issues does this PR fix or reference?

Proposed fix for #33697
### Tests written?

No
We need to get tests in if this fix does indeed solve the issue
