### PR TITLE
Use --always when available to git describe

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -1350,7 +1350,10 @@ def describe(cwd, rev='HEAD', user=None, ignore_retcode=False):
     cwd = _expand_path(cwd, user)
     if not isinstance(rev, six.string_types):
         rev = str(rev)
-    command = ['git', 'describe', '--always', rev]
+    command = ['git', 'describe']
+    if _LooseVersion(version(versioninfo=False)) >= _LooseVersion('1.5.6'):
+        command.append('--always')
+    command.append(rev)
     return _git_run(command,
                     cwd=cwd,
                     runas=user,

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -1350,7 +1350,7 @@ def describe(cwd, rev='HEAD', user=None, ignore_retcode=False):
     cwd = _expand_path(cwd, user)
     if not isinstance(rev, six.string_types):
         rev = str(rev)
-    command = ['git', 'describe', rev]
+    command = ['git', 'describe', '--always', rev]
     return _git_run(command,
                     cwd=cwd,
                     runas=user,


### PR DESCRIPTION
This adds the use of `--always` to the `git describe` command, on git 1.5.6 and newer.
