### PR TITLE
Add support for systemd in latest XenServer 7.0 release which is now …

### DIFF
--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -44,7 +44,8 @@ def __virtual__():
         'McAfee  OS Server',
         'Void',
         'Mint',
-        'Raspbian'
+        'Raspbian',
+        'XenServer'
     ))
     if __grains__.get('os', '') in disable:
         return (False, 'Your OS is on the disabled list')


### PR DESCRIPTION
### What does this PR do?

Makes systemd working on latest Xenserver 7.0 release which now is based on CentOS7 instead of CentOS5
### Previous Behavior

Cannot manage services on XenServer 7.0
### New Behavior

Can manage services on XenServer 7.0
### Tests written?

No

It would be nice if this could be downported to 2015.5 and 2015.8.
