### PR TITLE
[WIP] Creating Docker images with pure Salt and running Salt commands inside containers

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5758,7 +5758,7 @@ def sls_build(name, base='fedora', mods=None, saltenv='base',
 
     .. code-block:: bash
 
-        salt myminion dockerng.build_image imgname mods=rails,web
+        salt myminion dockerng.sls_build imgname base=mybase mods=rails,web
 
     The base image does not need to have Salt installed, but Python
     is required.

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -255,11 +255,13 @@ import inspect as inspect_module
 import json
 import logging
 import os
+import os.path
 import pipes
 import re
 import shutil
 import string
 import sys
+import tempfile
 import time
 import base64
 import errno
@@ -270,6 +272,14 @@ from salt.ext.six.moves import map  # pylint: disable=import-error,redefined-bui
 from salt.utils.decorators \
     import identical_signature_wrapper as _mimic_signature
 import salt.utils
+import salt.utils.thin
+import salt.pillar
+import salt.exceptions
+import salt.fileclient
+
+from salt.state import HighState
+import salt.client.ssh.state
+
 
 # Import 3rd-party libs
 import salt.ext.six as six
@@ -5529,3 +5539,203 @@ def script_retcode(name,
                    ignore_retcode=ignore_retcode,
                    use_vt=use_vt,
                    keep_env=keep_env)['retcode']
+
+
+def _mk_fileclient():
+    '''
+    Create a file client and add it to the context.
+    '''
+    if 'cp.fileclient' not in __context__:
+        __context__['cp.fileclient'] = \
+                salt.fileclient.get_file_client(__opts__)
+
+
+def _prepare_trans_tar(mods=None, saltenv='base', pillar=None):
+    '''
+    Prepares a self contained tarball that has the state
+    to be applied in the container
+    '''
+    chunks = _compile_state(mods, saltenv)
+    # reuse it from salt.ssh, however this function should
+    # be somewhere else
+    refs = salt.client.ssh.state.lowstate_file_refs(chunks)
+    _mk_fileclient()
+    trans_tar = salt.client.ssh.state.prep_trans_tar(
+        __context__['cp.fileclient'],
+        chunks, refs, pillar=pillar)
+    return trans_tar
+
+
+def _compile_state(mods=None, saltenv='base'):
+    '''
+    Generates the chunks of lowdata from the list of modules
+    '''
+    st_ = HighState(__opts__)
+
+    high_data, errors = st_.render_highstate({saltenv: mods})
+    high_data, ext_errors = st_.state.reconcile_extend(high_data)
+    errors += ext_errors
+    errors += st_.state.verify_high(high_data)
+    if errors:
+        return errors
+
+    high_data, req_in_errors = st_.state.requisite_in(high_data)
+    errors += req_in_errors
+    high_data = st_.state.apply_exclude(high_data)
+    # Verify that the high data is structurally sound
+    if errors:
+        return errors
+
+    # Compile and verify the raw chunks
+    return st_.state.compile_high_data(high_data)
+
+
+def _gather_pillar(pillarenv, pillar_override, grains={}):
+    '''
+    Gathers pillar with a custom set of grains, which should
+    be first retrieved from the container
+    '''
+    pillar = salt.pillar.get_pillar(
+        __opts__,
+        grains,
+        # Not sure if these two are correct
+        __opts__['id'],
+        __opts__['environment'],
+        pillar=pillar_override,
+        pillarenv=pillarenv
+    )
+    ret = pillar.compile_pillar()
+    if pillar_override and isinstance(pillar_override, dict):
+        ret.update(pillar_override)
+    return ret
+
+
+def call(name, function=None, args=[], **kwargs):
+    '''
+    Executes a salt function inside a container
+
+    .. code-block:: bash
+
+        salt myminion dockerimage.call function=test.ping
+
+    The container does not need to have Salt installed, but Python
+    is required.
+
+    TODO: support kwargs
+    '''
+    # put_archive reqires the path to exist
+    ret = __salt__['dockerng.run_all'](name, 'mkdir -p /tmp/salt_thin')
+    if ret['retcode'] != 0:
+        return {'result': False, 'comment': ret['stderr']}
+
+    # move salt into the container
+    thin_path = salt.utils.thin.gen_thin(__opts__['cachedir'])
+    import io
+    with io.open(thin_path, 'rb') as file:
+        _client_wrapper('put_archive', name, '/tmp/salt_thin', file)
+
+    salt_argv = [
+        sys.executable,
+        '/tmp/salt_thin/salt-call',
+        '--retcode-passthrough',
+        '--local',
+        '--out', 'json',
+        '-l', 'quiet',
+        '--',
+        function
+    ] + args
+
+    ret = __salt__['dockerng.run_all'](name, ' '.join(salt_argv))
+    # python not found
+    if ret['retcode'] == 127:
+        raise CommandExecutionError(ret['stderr'])
+    elif ret['retcode'] != 0:
+        return {'result': False, 'comment': ret['stderr']}
+
+    # process "real" result in stdout
+    try:
+        data = salt.utils.find_json(ret['stdout'])
+        return data.get('local', data)
+    except ValueError:
+        return {'result': False, 'comment': ret}
+
+
+def sls(name, mods=None, saltenv='base', **kwargs):
+    '''
+    Apply the highstate defined by the specified modules.
+
+    For example, if your master defines the states ``web`` and ``rails``, you
+    can apply them to a container:
+    states by doing:
+
+    .. code-block:: bash
+
+        salt myminion dockerimage.sls compassionate_mirzakhani mods=rails,web
+
+    The container does not need to have Salt installed, but Python
+    is required.
+    '''
+    if mods is not None:
+        mods = [x.strip() for x in mods.split(',')]
+    else:
+        mods = []
+
+    # gather grains from the container
+    grains = __salt__['dockerng.call'](name, function='grains.items')
+
+    # compile pillar with container grains
+    pillar = _gather_pillar(saltenv, {}, grains)
+
+    trans_tar = _prepare_trans_tar(mods=mods, saltenv=saltenv, pillar=pillar)
+    ret = None
+    try:
+        trans_tar_sha256 = salt.utils.get_hash(trans_tar, 'sha256')
+        __salt__['dockerng.copy_to'](name, trans_tar,
+                                     '/tmp/salt_state.tgz',
+                                     exec_driver='nsenter',
+                                     overwrite=True)
+        # Now execute the state into the container
+        ret = __salt__['dockerng.call'](name, function='state.pkg',
+                                        args=['/tmp/salt_state.tgz',
+                                              trans_tar_sha256, 'sha256'])
+        # set right exit code if any state failed
+        __context__['retcode'] = 0
+        for _, state in ret.iteritems():
+            if not state['result']:
+                __context__['retcode'] = 1
+    finally:
+        os.remove(trans_tar)
+    return ret
+
+
+def sls_build(name, base='fedora', mods=None, saltenv='base',
+              **kwargs):
+    '''
+    Build a docker image using the specified sls modules and base image.
+
+    For example, if your master defines the states ``web`` and ``rails``, you
+    can build a docker image inside myminion that results of applying those
+    states by doing:
+
+    .. code-block:: bash
+
+        salt myminion dockerimage.build_image imgname mods=rails,web
+
+    The base image does not need to have Salt installed, but Python
+    is required.
+    '''
+
+    # start a new container
+    ret = __salt__['dockerng.create'](image=base,
+                                      cmd='/usr/bin/sleep infinity',
+                                      interactive=True, tty=True)
+    id = ret['Id']
+    try:
+        __salt__['dockerng.start'](id)
+
+        # Now execute the state into the container
+        __salt__['dockerng.sls'](id, mods, saltenv, **kwargs)
+    finally:
+        __salt__['dockerng.stop'](id)
+
+    return __salt__['dockerng.commit'](id, name)

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5558,7 +5558,7 @@ def _generate_tmp_path():
         'salt.dockerng.{0}'.format(uuid.uuid4().hex[:6]))
 
 
-def _prepare_trans_tar(mods=None, saltenv='base', pillar=None):
+def _prepare_trans_tar(name, mods=None, saltenv='base', pillar=None):
     '''
     Prepares a self contained tarball that has the state
     to be applied in the container
@@ -5570,7 +5570,7 @@ def _prepare_trans_tar(mods=None, saltenv='base', pillar=None):
     _mk_fileclient()
     trans_tar = salt.client.ssh.state.prep_trans_tar(
         __context__['cp.fileclient'],
-        chunks, refs, pillar=pillar)
+        chunks, refs, pillar=pillar, id_=name)
     return trans_tar
 
 
@@ -5710,7 +5710,7 @@ def sls(name, mods=None, saltenv='base', **kwargs):
     # compile pillar with container grains
     pillar = _gather_pillar(saltenv, {}, **grains)
 
-    trans_tar = _prepare_trans_tar(mods=mods, saltenv=saltenv, pillar=pillar)
+    trans_tar = _prepare_trans_tar(name, mods=mods, saltenv=saltenv, pillar=pillar)
 
     # where to put the salt trans tar
     trans_dest_path = _generate_tmp_path()
@@ -5790,3 +5790,4 @@ def sls_build(name, base='fedora', mods=None, saltenv='base',
         __salt__['dockerng.stop'](id_)
 
     return __salt__['dockerng.commit'](id_, name)
+

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5612,18 +5612,19 @@ def _gather_pillar(pillarenv, pillar_override, grains={}):
     return ret
 
 
-def call(name, function=None, args=[], **kwargs):
+def call(name, function, *args, **kwargs):
     '''
     Executes a salt function inside a container
 
     .. code-block:: bash
 
-        salt myminion dockerimage.call function=test.ping
+        salt myminion dockerng.call test.ping
+
+        salt myminion test.arg arg1 arg2 key1=val1
 
     The container does not need to have Salt installed, but Python
     is required.
 
-    TODO: support kwargs
     '''
     # put_archive reqires the path to exist
     ret = __salt__['dockerng.run_all'](name, 'mkdir -p /tmp/salt_thin')
@@ -5647,7 +5648,7 @@ def call(name, function=None, args=[], **kwargs):
         '-l', 'quiet',
         '--',
         function
-    ] + args
+    ] + list(args) + ['{0}={1}'.format(key, value) for (key, value) in kwargs.items() if not key.startswith('__')]
 
     ret = __salt__['dockerng.run_all'](name,
                                        list2cmdline(map(str, salt_argv)))
@@ -5676,7 +5677,7 @@ def sls(name, mods=None, saltenv='base', **kwargs):
 
     .. code-block:: bash
 
-        salt myminion dockerimage.sls compassionate_mirzakhani mods=rails,web
+        salt myminion dockerng.sls compassionate_mirzakhani mods=rails,web
 
     The container does not need to have Salt installed, but Python
     is required.
@@ -5727,7 +5728,7 @@ def sls_build(name, base='fedora', mods=None, saltenv='base',
 
     .. code-block:: bash
 
-        salt myminion dockerimage.build_image imgname mods=rails,web
+        salt myminion dockerng.build_image imgname mods=rails,web
 
     The base image does not need to have Salt installed, but Python
     is required.

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5706,7 +5706,7 @@ def sls(name, mods=None, saltenv='base', **kwargs):
         mods = []
 
     # gather grains from the container
-    grains = __salt__['dockerng.call'](name, function='grains.items')
+    grains = __salt__['dockerng.call'](name, 'grains.items')
 
     # compile pillar with container grains
     pillar = _gather_pillar(saltenv, {}, **grains)
@@ -5721,9 +5721,8 @@ def sls(name, mods=None, saltenv='base', **kwargs):
                                      overwrite=True)
 
         # Now execute the state into the container
-        ret = __salt__['dockerng.call'](name, function='state.pkg',
-                                        args=['/tmp/salt_state.tgz',
-                                              trans_tar_sha256, 'sha256'])
+        ret = __salt__['dockerng.call'](name, 'state.pkg', '/tmp/salt_state.tgz',
+                                        trans_tar_sha256, 'sha256')
 
         # set right exit code if any state failed
         __context__['retcode'] = 0

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5624,6 +5624,8 @@ def call(name, function, *args, **kwargs):
     The container does not need to have Salt installed, but Python
     is required.
 
+    .. versionadded:: Carbon
+
     '''
     # put_archive reqires the path to exist
     ret = __salt__['dockerng.run_all'](name, 'mkdir -p /tmp/salt_thin')
@@ -5680,6 +5682,8 @@ def sls(name, mods=None, saltenv='base', **kwargs):
 
     The container does not need to have Salt installed, but Python
     is required.
+
+    .. versionadded:: Carbon
     '''
     if mods is not None:
         mods = [x.strip() for x in mods.split(',')]
@@ -5731,6 +5735,8 @@ def sls_build(name, base='fedora', mods=None, saltenv='base',
 
     The base image does not need to have Salt installed, but Python
     is required.
+
+    .. versionadded:: Carbon
     '''
 
     # start a new container

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5770,13 +5770,13 @@ def sls_build(name, base='fedora', mods=None, saltenv='base',
     ret = __salt__['dockerng.create'](image=base,
                                       cmd='/usr/bin/sleep infinity',
                                       interactive=True, tty=True)
-    id = ret['Id']
+    id_ = ret['Id']
     try:
-        __salt__['dockerng.start'](id)
+        __salt__['dockerng.start'](id_)
 
         # Now execute the state into the container
-        __salt__['dockerng.sls'](id, mods, saltenv, **kwargs)
+        __salt__['dockerng.sls'](id_, mods, saltenv, **kwargs)
     finally:
-        __salt__['dockerng.stop'](id)
+        __salt__['dockerng.stop'](id_)
 
-    return __salt__['dockerng.commit'](id, name)
+    return __salt__['dockerng.commit'](id_, name)

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5730,7 +5730,7 @@ def sls(name, mods=None, saltenv='base', **kwargs):
                                      overwrite=True)
 
         # Now execute the state into the container
-        ret = __salt__['dockerng.call'](name, 'state.pkg', os.path.join('salt_state.tgz'),
+        ret = __salt__['dockerng.call'](name, 'state.pkg', os.path.join(trans_dest_path, 'salt_state.tgz'),
                                         trans_tar_sha256, 'sha256')
 
         # set right exit code if any state failed

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5734,10 +5734,7 @@ def sls(name, mods=None, saltenv='base', **kwargs):
                                         trans_tar_sha256, 'sha256')
 
         # set right exit code if any state failed
-        __context__['retcode'] = 0
-        for _, state in ret.iteritems():
-            if not state['result']:
-                __context__['retcode'] = 1
+        __context__['retcode'] = 1 if any(not state['result'] for state in six.itervalues(ret)) else 0
     finally:
         # delete the trans dir so that it does not end in the image
         rm_trans_argv = ['rm', '-rf', trans_dest_path]

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5591,7 +5591,7 @@ def _compile_state(mods=None, saltenv='base'):
     return st_.state.compile_high_data(high_data)
 
 
-def _gather_pillar(pillarenv, pillar_override, grains={}):
+def _gather_pillar(pillarenv, pillar_override, **grains):
     '''
     Gathers pillar with a custom set of grains, which should
     be first retrieved from the container

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5700,10 +5700,7 @@ def sls(name, mods=None, saltenv='base', **kwargs):
 
     .. versionadded:: Carbon
     '''
-    if mods is not None:
-        mods = [x.strip() for x in mods.split(',')]
-    else:
-        mods = []
+    mods = [item.strip() for item in mods.split(',')] if mods else []
 
     # gather grains from the container
     grains = __salt__['dockerng.call'](name, 'grains.items')

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -262,7 +262,6 @@ import re
 import shutil
 import string
 import sys
-import tempfile
 import time
 import base64
 import errno

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5629,6 +5629,9 @@ def call(name, function=None, args=[], **kwargs):
     if ret['retcode'] != 0:
         return {'result': False, 'comment': ret['stderr']}
 
+    if function is None:
+        raise CommandExecutionError('Missing function parameter')
+
     # move salt into the container
     thin_path = salt.utils.thin.gen_thin(__opts__['cachedir'])
     import io

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5747,7 +5747,3 @@ def sls_build(name, base='fedora', mods=None, saltenv='base',
         __salt__['dockerng.stop'](id)
 
     return __salt__['dockerng.commit'](id, name)
-
-
-
-

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5548,8 +5548,7 @@ def _mk_fileclient():
     Create a file client and add it to the context.
     '''
     if 'cp.fileclient' not in __context__:
-        __context__['cp.fileclient'] = \
-                salt.fileclient.get_file_client(__opts__)
+        __context__['cp.fileclient'] = salt.fileclient.get_file_client(__opts__)
 
 
 def _generate_tmp_path():

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -265,6 +265,7 @@ import tempfile
 import time
 import base64
 import errno
+from subprocess import list2cmdline
 
 # Import Salt libs
 from salt.exceptions import CommandExecutionError, SaltInvocationError
@@ -5646,7 +5647,7 @@ def call(name, function=None, args=[], **kwargs):
     ] + args
 
     ret = __salt__['dockerng.run_all'](name,
-                                       ' '.join(map(str, salt_argv)))
+                                       list2cmdline(map(str, salt_argv)))
     # python not found
     if ret['retcode'] == 127:
         raise CommandExecutionError(ret['stderr'])

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -252,6 +252,7 @@ import fnmatch
 import functools
 import gzip
 import inspect as inspect_module
+import io
 import json
 import logging
 import os
@@ -5634,7 +5635,6 @@ def call(name, function=None, args=[], **kwargs):
 
     # move salt into the container
     thin_path = salt.utils.thin.gen_thin(__opts__['cachedir'])
-    import io
     with io.open(thin_path, 'rb') as file:
         _client_wrapper('put_archive', name, '/tmp/salt_thin', file)
 

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5694,7 +5694,7 @@ def sls(name, mods=None, saltenv='base', **kwargs):
     grains = __salt__['dockerng.call'](name, function='grains.items')
 
     # compile pillar with container grains
-    pillar = _gather_pillar(saltenv, {}, grains)
+    pillar = _gather_pillar(saltenv, {}, **grains)
 
     trans_tar = _prepare_trans_tar(mods=mods, saltenv=saltenv, pillar=pillar)
     ret = None

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5740,7 +5740,15 @@ def sls(name, mods=None, saltenv='base', **kwargs):
         rm_trans_argv = ['rm', '-rf', trans_dest_path]
         __salt__['dockerng.run_all'](name, list2cmdline(rm_trans_argv))
         # delete the local version of the trans tar
-        os.remove(trans_tar)
+        try:
+            os.remove(trans_tar)
+        except (IOError, OSError) as exc:
+            log.error(
+                'dockerng.sls: Unable to remove state tarball \'{0}\': {1}'.format(
+                    trans_tar,
+                    exc
+                )
+            )
     return ret
 
 

--- a/tests/unit/modules/dockerng_test.py
+++ b/tests/unit/modules/dockerng_test.py
@@ -17,6 +17,7 @@ from salttesting.mock import (
     patch
 )
 from contextlib import nested
+from salt.ext.six.moves import range
 
 ensure_in_syspath('../../')
 

--- a/tests/unit/modules/dockerng_test.py
+++ b/tests/unit/modules/dockerng_test.py
@@ -732,8 +732,8 @@ class DockerngTestCase(TestCase):
         # check directory cleanup
         self.assertIn('rm -rf', docker_run_all_mock.mock_calls[2][1][1])
         self.assertIn('rm -rf', docker_run_all_mock.mock_calls[5][1][1])
-        self.assertNotEqual(docker_run_all_mock.mock_calls[1][1][1],
-                            docker_run_all_mock.mock_calls[4][1][1])
+        self.assertNotEqual(docker_run_all_mock.mock_calls[2][1][1],
+                            docker_run_all_mock.mock_calls[5][1][1])
 
         self.assertEqual(
             {"retcode": 0, "comment": "container cmd"}, ret)

--- a/tests/unit/modules/dockerng_test.py
+++ b/tests/unit/modules/dockerng_test.py
@@ -711,15 +711,14 @@ class DockerngTestCase(TestCase):
         ):
             ret = dockerng_mod.call(
                 'ID',
-                function='test.arg',
-                args=[1, 2],
-                kwargs={'arg1': 'val1'}
-            )
+                'test.arg',
+                1, 2,
+                arg1='val1')
         docker_run_all_mock.assert_called_with(
             'ID',
             "python /tmp/salt_thin/salt-call"
             " --retcode-passthrough --local "
-            "--out json -l quiet -- test.arg 1 2")
+            "--out json -l quiet -- test.arg 1 2 arg1=val1")
         self.assertEqual(
             {"retcode": 0, "comment": "container cmd"}, ret)
 

--- a/tests/unit/modules/dockerng_test.py
+++ b/tests/unit/modules/dockerng_test.py
@@ -655,13 +655,14 @@ class DockerngTestCase(TestCase):
                 }
             })
 
+        ret = None
         with patch.dict(dockerng_mod.__salt__, {
                 'dockerng.start': docker_start_mock,
                 'dockerng.create': docker_create_mock,
                 'dockerng.stop': docker_stop_mock,
                 'dockerng.commit': docker_commit_mock,
                 'dockerng.sls': docker_sls_mock}):
-            dockerng_mod.sls_build(
+            ret = dockerng_mod.sls_build(
                 'foo',
                 mods='foo',
             )
@@ -672,8 +673,8 @@ class DockerngTestCase(TestCase):
         docker_sls_mock.assert_called_once_with('ID', 'foo', 'base')
         docker_stop_mock.assert_called_once_with('ID')
         docker_commit_mock.assert_called_once_with('ID', 'foo')
-
-
+        self.assertEqual(
+            {'Id': 'ID2', 'Image': 'foo', 'Time_Elapsed': 42}, ret)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?
- It implements creating Docker images from sls states (Salt on the image not required, base image only needs python)

![screenshot from 2016-07-05 23-16-16](https://cloud.githubusercontent.com/assets/15332/16617553/9c8dad00-4384-11e6-8641-cf520c345b9f.png)

![cmds_bvwyaairc-](https://cloud.githubusercontent.com/assets/15332/16617533/7bfb53bc-4384-11e6-8110-87f1e9792546.jpg)
- Allows to run arbitrary Salt modules inside a container without needing Salt in the container (uses salt-thin).

![cmrl4paviaemgly](https://cloud.githubusercontent.com/assets/15332/16617549/8e29c4ba-4384-11e6-98cb-ff6a33e24548.jpg)
- It was a [Hackweek 14 Project](https://hackweek.suse.com/14/projects/1756) at [SUSE](http://www.suse.com).
- Lightning talk: [![default](https://cloud.githubusercontent.com/assets/15332/16732477/b6ea7aaa-477d-11e6-9fd6-3b697e7a87a5.jpg)](https://www.youtube.com/watch?v=2znjgf9Q7J0)
### What issues does this PR fix or reference?
- https://www.redhat.com/en/about/press-releases/red-hat-launches-ansible-native-container-workflow-project
### Tests written?

Yes. (dockerng.sls pending)

cc @meaksh @isbm @dincamihai 
