### PR TITLE
Use skipTest for network state integration test

### DIFF
--- a/tests/integration/states/network.py
+++ b/tests/integration/states/network.py
@@ -12,7 +12,6 @@ from __future__ import absolute_import
 import integration
 
 # Salttesting libs
-from salttesting import skipIf
 from salttesting.helpers import destructiveTest, ensure_in_syspath
 
 ensure_in_syspath('../../')

--- a/tests/integration/states/network.py
+++ b/tests/integration/states/network.py
@@ -10,7 +10,6 @@ from __future__ import absolute_import
 
 # Salt libs
 import integration
-import salt.utils
 
 # Salttesting libs
 from salttesting import skipIf
@@ -19,20 +18,16 @@ from salttesting.helpers import destructiveTest, ensure_in_syspath
 ensure_in_syspath('../../')
 
 
-def _check_arch_linux():
-    with salt.utils.fopen('/etc/os-release', 'r') as f:
-        release = f.readline()
-        r = release.split('=')[1].strip().strip('"')
-        return r
-
-
 @destructiveTest
-@skipIf(_check_arch_linux() == 'Arch Linux', 'Network state not supported on Arch')
 class NetworkTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
     '''
     Validate network state module
     '''
     def setUp(self):
+        os_family = self.run_function('grains.get', ['os_family'])
+        if os_family not in ('RedHat', 'Debian'):
+            self.skipTest('Network state only supported on RedHat and Debian based systems')
+
         self.run_function('cmd.run', ['ip link add name dummy0 type dummy'])
 
     def tearDown(self):


### PR DESCRIPTION
### What does this PR do?

Skips the network state tests if the os is not RedHat or Debian based. 
### What issues does this PR fix or reference?

Addresses failing tests on OpenSuse due to it not being supported, and addresses a failing test on CentOS 5/6 as those os's do not have `/etc/os-release`. 
### Tests written?

Yes
