### PR TITLE
Fix master crash on ctl-c for long-running job

### DIFF
--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -486,9 +486,9 @@ class SaltEvent(object):
                     break
                 mtag, data = self.unpack(raw, self.serial)
                 ret = {'data': data, 'tag': mtag}
-            except (KeyboardInterrupt, RuntimeError):
+            except (KeyboardInterrupt):
                 return {'tag': 'salt/event/exit', 'data': {}}
-            except tornado.iostream.StreamClosedError:
+            except (tornado.iostream.StreamClosedError, RuntimeError):
                 return None
 
             if not match_func(ret['tag'], tag):

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -486,7 +486,7 @@ class SaltEvent(object):
                     break
                 mtag, data = self.unpack(raw, self.serial)
                 ret = {'data': data, 'tag': mtag}
-            except (KeyboardInterrupt):
+            except KeyboardInterrupt:
                 return {'tag': 'salt/event/exit', 'data': {}}
             except (tornado.iostream.StreamClosedError, RuntimeError):
                 return None


### PR DESCRIPTION
This was causing events to loop into the reactor, spiking CPU and leaking memory.

Fixes #34439 
