### PR TITLE
Gracefully handle non-XML output in GlusterFS execution module.

### DIFF
--- a/salt/modules/glusterfs.py
+++ b/salt/modules/glusterfs.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import
 import logging
 import sys
 import xml.etree.ElementTree as ET
-from xml.etree.ElementTree import ParseError
 
 # Import salt libs
 import salt.utils
@@ -80,7 +79,7 @@ def _gluster_xml(cmd):
 
     try:
         root = ET.fromstring(_gluster_output_cleanup(result))
-    except ParseError as e:
+    except ET.ParseError:
         raise CommandExecutionError('\n'.join(result.splitlines()[:-1]))
 
     if int(root.find('opRet').text) != 0:

--- a/salt/modules/glusterfs.py
+++ b/salt/modules/glusterfs.py
@@ -81,7 +81,7 @@ def _gluster_xml(cmd):
     try:
         root = ET.fromstring(_gluster_output_cleanup(result))
     except ParseError as e:
-        raise CommandExecutionError(result)
+        raise CommandExecutionError('\n'.join(result.splitlines()[:-1]))
 
     if int(root.find('opRet').text) != 0:
         raise CommandExecutionError(root.find('opErrstr').text)

--- a/salt/modules/glusterfs.py
+++ b/salt/modules/glusterfs.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 import logging
 import sys
 import xml.etree.ElementTree as ET
+from xml.etree.ElementTree import ParseError
 
 # Import salt libs
 import salt.utils
@@ -76,7 +77,11 @@ def _gluster_xml(cmd):
         result = __salt__['cmd.run'](
             'gluster --xml --mode=script', stdin="{0}\n".format(cmd)
         )
-    root = ET.fromstring(_gluster_output_cleanup(result))
+
+    try:
+        root = ET.fromstring(_gluster_output_cleanup(result))
+    except ParseError as e:
+        raise CommandExecutionError(result)
 
     if int(root.find('opRet').text) != 0:
         raise CommandExecutionError(root.find('opErrstr').text)


### PR DESCRIPTION
This PR gracefully handles non-XML `gluster` command output. An example would be to attempt to list an inappropriate amount of bricks compared to what `stripe` and `replica` options define, resulting in a non-descriptive ParseError.

Example execution module run before PR:

```
# salt 'gluster1' glusterfs.create gluster '["10.0.0.2:/mnt","10.0.0.3:/mnt","10.0.0.4:/mnt"]' stripe=2
gluster1:
    The minion function caused an exception: Traceback (most recent call last):
      File "/usr/lib/python2.7/dist-packages/salt/minion.py", line 1318, in _thread_return
        return_data = executor.execute()
      File "/usr/lib/python2.7/dist-packages/salt/executors/direct_call.py", line 28, in execute
        return self.func(*self.args, **self.kwargs)
      File "/usr/lib/python2.7/dist-packages/salt/modules/glusterfs.py", line 271, in create
        _gluster_xml(cmd)
      File "/usr/lib/python2.7/dist-packages/salt/modules/glusterfs.py", line 79, in _gluster_xml
        root = ET.fromstring(_gluster_output_cleanup(result))
      File "/usr/lib/python2.7/xml/etree/ElementTree.py", line 1300, in XML
        parser.feed(text)
      File "/usr/lib/python2.7/xml/etree/ElementTree.py", line 1642, in feed
        self._raiseerror(v)
      File "/usr/lib/python2.7/xml/etree/ElementTree.py", line 1506, in _raiseerror
        raise err
    ParseError: syntax error: line 1, column 0
```

Example regular command output:

```
# gluster --xml --mode=script volume create gluster stripe 2 10.0.0.2:/mnt 10.0.0.3:/mnt 10.0.0.4:/mnt
number of bricks is not a multiple of stripe count
```

Example execution module run after PR:

```
# salt 'gluster1' glusterfs.create gluster '["10.0.0.2:/mnt","10.0.0.3:/mnt","10.0.0.4:/mnt"]' stripe=2
gluster1:
    ERROR: number of bricks is not a multiple of stripe count
```
