### PR TITLE
remove unnecessary block parsing ip addrs for nova

### DIFF
--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -804,14 +804,6 @@ def create(vm_):
            'access_ip' in node.get('extra', {}):
             result = [node['extra']['access_ip']]
 
-        if not result:
-            temp_dd = node.get('addresses', {})
-            for k, addr_ll in temp_dd.iteritems():
-                for addr_dd in addr_ll:
-                    addr = addr_dd.get('addr', None)
-                    if addr is not None:
-                        result.append(addr.strip())
-
         private = node.get('private_ips', [])
         public = node.get('public_ips', [])
         if private and not public:


### PR DESCRIPTION
### What does this PR do?

This block shouldn't be necessary, we correctly parse the ipaddrs in the
NovaServer class now.  This was added in commit https://github.com/saltstack/salt/commit/47ecb7a150f88c77e082cf6541a40388acd8ea93
### What issues does this PR fix or reference?

closes #34224
### Previous Behavior

see #34224 
### New Behavior

see #34224 
### Tests written?

No
