### PR TITLE
Windows installer build scripts will exit on error

### DIFF
--- a/pkg/windows/build.bat
+++ b/pkg/windows/build.bat
@@ -36,7 +36,7 @@ if not %errorLevel%==0 (
 :: Install Current Version of salt
 @echo  %0 :: Install Current Version of salt...
 @echo ---------------------
-"%PyDir%\python.exe" "%SrcDir%\setup.py" install --force
+"%PyDir%\python.exe" "%SrcDir%\setup.py" --quiet install --force
 
 :: Build the Salt Package
 @echo  %0 :: Build the Salt Package...

--- a/pkg/windows/build.bat
+++ b/pkg/windows/build.bat
@@ -13,7 +13,7 @@ if %errorLevel%==0 (
 )
 
 :: Define Variables
-@echo Defining Variables...
+@echo %0 :: Defining Variables...
 @echo ---------------------
 Set "PyDir=C:\Python27"
 Set "CurDir=%~dp0"
@@ -28,10 +28,22 @@ if [%1]==[] (
 :: Create Build Environment
 PowerShell.exe -ExecutionPolicy RemoteSigned -File "%CurDir%build_env.ps1" -Silent
 
+if not %errorLevel%==0 (
+    echo "%CurDir%build_env.ps1" returned errorlevel %errorLevel%. Aborting %0
+    goto eof
+)
+
 :: Install Current Version of salt
+@echo  %0 :: Install Current Version of salt...
+@echo ---------------------
 "%PyDir%\python.exe" "%SrcDir%\setup.py" install --force
 
 :: Build the Salt Package
+@echo  %0 :: Build the Salt Package...
+@echo ---------------------
 call "%CurDir%build_pkg.bat" "%Version%"
 
 :eof
+
+@echo  End of %0
+@echo ---------------------

--- a/pkg/windows/build_env.ps1
+++ b/pkg/windows/build_env.ps1
@@ -52,7 +52,7 @@ Import-Module $script_path\Modules\download-module.psm1
 Import-Module $script_path\Modules\get-settings.psm1
 Import-Module $script_path\Modules\uac-module.psm1
 Import-Module $script_path\Modules\zip-module.psm1
-
+Import-Module $script_path\Modules\start-process-and-test-exitcode.psm1
 #==============================================================================
 # Check for Elevated Privileges
 #==============================================================================
@@ -208,7 +208,7 @@ If (!($Path.ToLower().Contains("$($ini['Settings']['ScriptsDir'])".ToLower()))) 
 Write-Output " ----------------------------------------------------------------"
 Write-Output " - Updating PIP and SetupTools . . ."
 Write-Output " ----------------------------------------------------------------"
-$p = Start-Process "$($ini['Settings']['PythonDir'])\python.exe" -ArgumentList "-m pip --no-cache-dir install -r $($script_path)\req_pip.txt" -Wait -NoNewWindow -PassThru
+Start_Process_and_test_exitcode "$($ini['Settings']['PythonDir'])\python.exe" "-m pip --no-cache-dir install -r $($script_path)\req_pip.txt" "python pip"
 
 #==============================================================================
 # Install pypi resources using pip
@@ -216,7 +216,7 @@ $p = Start-Process "$($ini['Settings']['PythonDir'])\python.exe" -ArgumentList "
 Write-Output " ----------------------------------------------------------------"
 Write-Output " - Installing pypi resources using pip . . ."
 Write-Output " ----------------------------------------------------------------"
-$p = Start-Process "$($ini['Settings']['ScriptsDir'])\pip.exe" -ArgumentList "--no-cache-dir install -r $($script_path)\req.txt" -Wait -NoNewWindow -PassThru
+Start_Process_and_test_exitcode "$($ini['Settings']['ScriptsDir'])\pip.exe"  "--no-cache-dir install -r $($script_path)\req.txt" "pip install"
 
 #==============================================================================
 # Install PyYAML with CLoader
@@ -233,7 +233,7 @@ DownloadFileWithProgress $url $file
 
 # Install
 $file = "$($ini['Settings']['DownloadDir'])\$($ini[$bitPrograms]['PyYAML'])"
-$p = Start-Process "$($ini['Settings']['ScriptsDir'])\easy_install.exe" -ArgumentList "-Z $file " -Wait -NoNewWindow -PassThru
+Start_Process_and_test_exitcode "$($ini['Settings']['ScriptsDir'])\easy_install.exe" "-Z $file " "easy_install PyYAML"
 
 #==============================================================================
 # Install PyCrypto from wheel file
@@ -249,7 +249,7 @@ DownloadFileWithProgress $url $file
 
 # Install
 $file = "$($ini['Settings']['DownloadDir'])\$($ini[$bitPrograms]['PyCrypto'])"
-$p = Start-Process "$($ini['Settings']['ScriptsDir'])\pip.exe" -ArgumentList "install --no-index --find-links=$($ini['Settings']['DownloadDir']) $file " -Wait -NoNewWindow -PassThru
+Start_Process_and_test_exitcode  "$($ini['Settings']['ScriptsDir'])\pip.exe" "install --no-index --find-links=$($ini['Settings']['DownloadDir']) $file " "pip install PyCrypto"
 
 #==============================================================================
 # Copy DLLs to Python Directory

--- a/pkg/windows/modules/download-module.psm1
+++ b/pkg/windows/modules/download-module.psm1
@@ -48,5 +48,11 @@ Function DownloadFileWithProgress {
         Remove-Variable eventDataComplete
         Remove-Variable eventDataProgress
         [GC]::Collect()
+        # 2016-07-06  mkr  Errorchecking added. nice-to-have: integration into the above code.
+        If (!((Test-Path "$localfile") -and ((Get-Item "$localfile").length -gt 0kb))) {
+            Write-Error "Exiting because download missing or zero-length:    $localfile"
+            exit 2
+        }
+
     }
 }

--- a/pkg/windows/modules/start-process-and-test-exitcode.psm1
+++ b/pkg/windows/modules/start-process-and-test-exitcode.psm1
@@ -1,0 +1,22 @@
+Function Start_Process_and_test_exitcode {
+
+    # This function is a wrapper for Start-Process that checks the exitcode
+    # It receives 3 parameters:
+    #    $fun   - the process that shall be started
+    #    $args  - the the arguments of $fun
+    #    $descr - the short description shown in the case of an error
+
+    param(
+        [Parameter(Mandatory=$true)] [String] $fun,
+        [Parameter(Mandatory=$true)] [String] $args,
+        [Parameter(Mandatory=$true)] [String] $descr
+    )
+
+    begin {
+        $p = Start-Process "$fun" -ArgumentList "$args" -Wait -NoNewWindow -PassThru
+        If ( $($p.ExitCode) -ne 0) {
+            Write-Error "$descr returned exitcode $($p.ExitCode). "
+            exit $($p.ExitCode)
+        }
+    }
+}

--- a/pkg/windows/uninstall-and-wipe-Python.cmd
+++ b/pkg/windows/uninstall-and-wipe-Python.cmd
@@ -1,0 +1,9 @@
+@echo off
+
+:: uninstall Python 2.7 64bit
+MsiExec.exe /X {16E52445-1392-469F-9ADB-FC03AF00CD62} /QN
+
+:: wipe the Python directory
+::  DOS hack first create dir because Windows cannot test not existing without error message
+md c:\Python27  1>nul 2>nul
+rd /s /q c:\Python27 || echo Failure: c:\Python27 still exists, please find out why and repeat.


### PR DESCRIPTION
### What does this PR do?

Building the Windows environment and building the Nullsoft installer stops on first error.
### What issues does this PR fix or reference?

Building the environment and building the installer continued on errors. 
This makes it hard to find errors or compare the console log, especially because setup.py creates 2,500 lines of filenames.
Part of issue https://github.com/saltstack/salt/issues/34495
Related to issue https://github.com/saltstack/salt/issues/34500
### Tests written?

No, but executed build.bat successfully and provoked some errors.
