### PR TITLE
Improve top file merging documentation

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -1033,9 +1033,73 @@ environments is to isolate via the top file.
 
 .. code-block:: yaml
 
-    environment: None
+    environment: dev
 
+.. conf_minion:: top_file_merging_strategy
 
+``top_file_merging_strategy``
+-----------------------------
+
+Default: ``merge``
+
+When no specific fileserver environment (a.k.a. ``saltenv``) has been specified
+for a :ref:`highstate <running-highstate>`, all environments' top files are
+inspected. This config option determines how the SLS targets in those top files
+are handled.
+
+When set to ``merge``, the targets for all SLS files in all environments are
+merged together. A given environment's SLS targets for the highstate will
+consist of the collective SLS targets specified for that environment in all top
+files. The environments will be merged in no specific order, for greater
+control over the order in which the environments are merged use
+:conf_minion:`env_order`.
+
+When set to ``same``, then for each environment, only that environment's top
+file is processed, with the others being ignored. For example, only the ``dev``
+environment's top file will be processed for the ``dev`` environment, and any
+SLS targets defined for ``dev`` in the ``base`` environment's (or any other
+environment's) top file will be ignored. If an environment does not have a top
+file, then the top file from the :conf_minion:`default_top` config parameter
+will be used as a fallback.
+
+.. code-block:: yaml
+
+    top_file_merging_strategy: same
+
+.. conf_minion:: env_order
+
+``env_order``
+-------------
+
+Default: ``[]``
+
+When :conf_minion:`top_file_merging_strategy` is set to ``merge``, and no
+environment is specified for a :ref:`highstate <running-highstate>`, this
+config option allows for the order in which top files are merged to be
+explicitly defined.
+
+.. code-block:: yaml
+
+    env_order:
+      - base
+      - dev
+      - qa
+
+.. conf_minion:: default_top
+
+``default_top``
+---------------
+
+Default: ``base``
+
+When :conf_minion:`top_file_merging_strategy` is set to ``same``, and no
+environment is specified for a :ref:`highstate <running-highstate>`, this
+config option specifies a fallback environment in which to look for a top file
+if an environment lacks one.
+
+.. code-block:: yaml
+
+    default_top: dev
 
 File Directory Settings
 =======================

--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -15,6 +15,11 @@ configuring one or more repositories in :conf_master:`gitfs_remotes`.
 
 Branches and tags become Salt fileserver environments.
 
+.. note::
+    Branching and tagging can result in a lot of potentially-conflicting
+    :ref:`top files <states-top>`, for this reason it may be useful to set
+    :conf_minion:`top_file_merging_strategy` to ``same`` in the minions' config
+    files if the top files are being managed in a GitFS repo.
 
 .. _gitfs-dependencies:
 

--- a/salt/state.py
+++ b/salt/state.py
@@ -2450,9 +2450,14 @@ class BaseHighState(object):
                         tops[saltenv].append({})
                         log.debug('No contents loaded for env: {0}'.format(saltenv))
             if found > 1:
-                log.warning('Top file merge strategy set to \'merge\' and multiple top files found. '
-                            'Top file merging order is undefined; '
-                            'for better results use \'same\' option')
+                log.warning(
+                    'top_file_merging_strategy is set to \'merge\' and '
+                    'multiple top files were found. Merging order is not '
+                    'deterministic, it may be desirable to either set '
+                    'top_file_merging_strategy to \'same\' or use the '
+                    '\'env_order\' configuration parameter to specify the '
+                    'merging order.'
+                )
 
         if found == 0:
             log.error('No contents found in top file')


### PR DESCRIPTION
Also add a recommendation to set the merging strategy to "same" when using
GitFS, and improve usefulness of the warning logged when more than one top file
is found.

Resolves #34302.
