### PR TITLE
Fix wrong order of retention_policy_exists.

### DIFF
--- a/salt/modules/influx.py
+++ b/salt/modules/influx.py
@@ -490,7 +490,7 @@ def retention_policy_exists(database,
 
         salt '*' influxdb.retention_policy_exists metrics default
     '''
-    policy = retention_policy_get(name, database, user, password, host, port)
+    policy = retention_policy_get(database, name, user, password, host, port)
     return policy is not None
 
 


### PR DESCRIPTION
### What does this PR do?

Fix wrong order of retention_policy_exists in InfluxDB module.
### What issues does this PR fix or reference?

The name of retention policy and database were reversed:
Based on [InfluxDB module documentation](https://docs.saltstack.com/en/2015.8/ref/modules/all/salt.modules.influx.html#salt.modules.influx.retention_policy_exists) It should be:
- database: The database to operate on.
- name: Name of the policy to modify. 

But SaltStack was using rp name as database, so it returns "database does not exist".
