### PR TITLE
Fix pkg.latest integration test for non-LTS ubuntu

### DIFF
--- a/tests/integration/states/pkg.py
+++ b/tests/integration/states/pkg.py
@@ -566,16 +566,23 @@ class PkgTest(integration.ModuleCase,
 
         # Now look for updates and try to run the state on a package which is
         # already up-to-date.
+        installed_pkgs = self.run_function('pkg.list_pkgs')
         updates = self.run_function('pkg.list_upgrades', refresh=False)
-        try:
-            target = next(iter(updates))
-        except StopIteration:
-            log.warning(
-                'No available upgrades, skipping only_upgrade=True test with '
-                'already-installed package. For best results run this test '
-                'on a machine with upgrades available.'
-            )
+
+        for pkgname in updates:
+            if pkgname in installed_pkgs:
+                target = pkgname
+                break
         else:
+            target = ''
+            log.warning(
+                'No available upgrades to installed packages, skipping '
+                'only_upgrade=True test with already-installed package. For '
+                'best results run this test on a machine with upgrades '
+                'available.'
+            )
+
+        if target:
             ret = self.run_state('pkg.latest', name=target, refresh=False,
                                  only_upgrade=True)
             self.assertSaltTrueReturn(ret)


### PR DESCRIPTION
This test uses `pkg.list_upgrades` to find a package which it assumes is
installed, to test `pkg.installed` with `only_upgrade=True`. The
problem with that approach is that `pkg.list_upgrades` uses a dry-run
of an `apt-get dist-upgrade` to find the upgrades. On non-LTS Ubuntu
releases, a `dist-upgrade` results in upgrading to an entirely new
Ubuntu release, and new packages which would be installed by the
dist-upgrade (but are not currently installed) will be included in the
return data. This causes the test to fail when we attempt to run
`pkg.latest` with `only_upgrade=True` on a package which is not
already installed.

This commit fixes the test by ensuring that our target package is
already installed, and continuing to iterate through the return data
from `pkg.list_upgrades` until a currently-installed package is found.
