### PR TITLE
for options method, authorization_type should always be NONE, otherwi…

### DIFF
--- a/salt/states/boto_apigateway.py
+++ b/salt/states/boto_apigateway.py
@@ -1505,8 +1505,10 @@ class _Swagger(object):
         method = self._parse_method_data(method_name.lower(), method_data)
 
         # for options method to enable CORS, api_key_required will be set to False always.
+        # authorization_type will be set to 'NONE' always.
         if method_name.lower() == 'options':
             api_key_required = False
+            authorization_type = 'NONE'
 
         m = __salt__['boto_apigateway.create_api_method'](restApiId=self.restApiId,
                                                           resourcePath=resource_path,


### PR DESCRIPTION
### What does this PR do?

fixes an issue with when authorization_type is 'AWS_IAM' for an api being deployed, that CORS support do not work properly because options method for resources should be set to 'NONE'
### What issues does this PR fix or reference?

N/A
### Previous Behavior

CORS support for any methods with authorization_type being 'AWS_IAM' do not work properly because options method's authorization_type was also set to 'AWS_IAM'
### New Behavior

CORS work properly when authroization_type for the api being deployed is using 'AWS_IAM', as options methods do not require 'AWS_IAM' any more.
### Tests written?

No, manually tested against AWS.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

…se CORS support will not work properly when other methods are using authorization_type  AWS_IAM.
