### PR TITLE
When building Windows installer, setup.py install will not print each file

### DIFF
--- a/pkg/windows/build.bat
+++ b/pkg/windows/build.bat
@@ -36,7 +36,7 @@ if not %errorLevel%==0 (
 :: Install Current Version of salt
 @echo  %0 :: Install Current Version of salt...
 @echo ---------------------
-"%PyDir%\python.exe" "%SrcDir%\setup.py" install --force
+"%PyDir%\python.exe" "%SrcDir%\setup.py" --quiet install --force
 
 :: Build the Salt Package
 @echo  %0 :: Build the Salt Package...


### PR DESCRIPTION
### What does this PR do?

adds `--quiet` to `setup.py install` for the Windows installer build script.
### What issues does this PR fix or reference?

Issue https://github.com/saltstack/salt/issues/34495
Issue https://github.com/saltstack/salt/issues/34500
### Previous Behavior

setup.py install prints 2,500 file names to the console.
### New Behavior

setup.py install does not print 2,500 file names to the console.
### Tests written?

Yes