### PR TITLE
Migrate StringIO imports to use the six library for Python2/3 compatibility

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -1413,10 +1413,10 @@ class Keys(LowDataAdapter):
         priv_key_file = tarfile.TarInfo('minion.pem')
         priv_key_file.size = len(priv_key)
 
-        fileobj = six.StringIO.StringIO()
+        fileobj = six.moves.StringIO()
         tarball = tarfile.open(fileobj=fileobj, mode='w')
-        tarball.addfile(pub_key_file, six.StringIO.StringIO(pub_key))
-        tarball.addfile(priv_key_file, six.StringIO.StringIO(priv_key))
+        tarball.addfile(pub_key_file, six.moves.StringIO(pub_key))
+        tarball.addfile(priv_key_file, six.moves.StringIO(priv_key))
         tarball.close()
 
         headers = cherrypy.response.headers

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -310,7 +310,6 @@ import itertools
 import functools
 import logging
 import json
-import StringIO
 import tarfile
 import time
 from multiprocessing import Process, Pipe
@@ -1414,10 +1413,10 @@ class Keys(LowDataAdapter):
         priv_key_file = tarfile.TarInfo('minion.pem')
         priv_key_file.size = len(priv_key)
 
-        fileobj = StringIO.StringIO()
+        fileobj = six.StringIO.StringIO()
         tarball = tarfile.open(fileobj=fileobj, mode='w')
-        tarball.addfile(pub_key_file, StringIO.StringIO(pub_key))
-        tarball.addfile(priv_key_file, StringIO.StringIO(priv_key))
+        tarball.addfile(pub_key_file, six.StringIO.StringIO(pub_key))
+        tarball.addfile(priv_key_file, six.StringIO.StringIO(priv_key))
         tarball.close()
 
         headers = cherrypy.response.headers

--- a/salt/renderers/mako.py
+++ b/salt/renderers/mako.py
@@ -32,4 +32,4 @@ def render(template_file, saltenv='base', sls='', context=None, tmplpath=None, *
     if not tmp_data.get('result', False):
         raise SaltRenderError(tmp_data.get('data',
             'Unknown render error in mako renderer'))
-    return six.StringIO.StringIO(tmp_data['data'])
+    return six.moves.StringIO(tmp_data['data'])

--- a/salt/renderers/mako.py
+++ b/salt/renderers/mako.py
@@ -3,12 +3,11 @@
 Mako Renderer for Salt
 '''
 
+# Import python libs
 from __future__ import absolute_import
 
-# Import python libs
-from StringIO import StringIO
-
 # Import salt libs
+import salt.ext.six as six
 import salt.utils.templates
 from salt.exceptions import SaltRenderError
 
@@ -33,4 +32,4 @@ def render(template_file, saltenv='base', sls='', context=None, tmplpath=None, *
     if not tmp_data.get('result', False):
         raise SaltRenderError(tmp_data.get('data',
             'Unknown render error in mako renderer'))
-    return StringIO(tmp_data['data'])
+    return six.StringIO.StringIO(tmp_data['data'])

--- a/salt/renderers/wempy.py
+++ b/salt/renderers/wempy.py
@@ -32,4 +32,4 @@ def render(template_file,
     if not tmp_data.get('result', False):
         raise SaltRenderError(tmp_data.get('data',
             'Unknown render error in the wempy renderer'))
-    return six.StringIO.StringIO(tmp_data['data'])
+    return six.moves.StringIO(tmp_data['data'])

--- a/salt/renderers/wempy.py
+++ b/salt/renderers/wempy.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 
+# Import python libs
 from __future__ import absolute_import
 
-# Import python libs
-from StringIO import StringIO
-
 # Import salt libs
+import salt.ext.six as six
 from salt.exceptions import SaltRenderError
 import salt.utils.templates
 
@@ -33,4 +32,4 @@ def render(template_file,
     if not tmp_data.get('result', False):
         raise SaltRenderError(tmp_data.get('data',
             'Unknown render error in the wempy renderer'))
-    return StringIO(tmp_data['data'])
+    return six.StringIO.StringIO(tmp_data['data'])

--- a/salt/returners/smtp_return.py
+++ b/salt/returners/smtp_return.py
@@ -159,7 +159,7 @@ def returner(ret):
         if field in ret:
             subject += ' {0}'.format(ret[field])
     subject = compile_template(':string:', rend, renderer, blacklist, whitelist, input_data=subject, **ret)
-    if isinstance(subject, six.StringIO.StringIO):
+    if isinstance(subject, six.moves.StringIO):
         subject = subject.read()
 
     log.debug("smtp_return: Subject is '{0}'".format(subject))
@@ -187,7 +187,7 @@ def returner(ret):
             content = 'Encryption failed, the return data was not sent.\r\n\r\n{0}\r\n{1}'.format(
                     encrypted_data.status, encrypted_data.stderr)
 
-    if isinstance(content, six.StringIO.StringIO):
+    if isinstance(content, six.moves.StringIO):
         content = content.read()
 
     message = ('From: {0}\r\n'

--- a/salt/returners/smtp_return.py
+++ b/salt/returners/smtp_return.py
@@ -74,16 +74,16 @@ that prints any email it receives to the console.
 
     python -m smtpd -n -c DebuggingServer localhost:1025
 '''
-from __future__ import absolute_import
 
 # Import python libs
+from __future__ import absolute_import
 import os
 import logging
 import smtplib
-import StringIO
 from email.utils import formatdate
 
 # Import Salt libs
+import salt.ext.six as six
 import salt.utils.jid
 import salt.returners
 import salt.loader
@@ -159,7 +159,7 @@ def returner(ret):
         if field in ret:
             subject += ' {0}'.format(ret[field])
     subject = compile_template(':string:', rend, renderer, blacklist, whitelist, input_data=subject, **ret)
-    if isinstance(subject, StringIO.StringIO):
+    if isinstance(subject, six.StringIO.StringIO):
         subject = subject.read()
 
     log.debug("smtp_return: Subject is '{0}'".format(subject))
@@ -187,7 +187,7 @@ def returner(ret):
             content = 'Encryption failed, the return data was not sent.\r\n\r\n{0}\r\n{1}'.format(
                     encrypted_data.status, encrypted_data.stderr)
 
-    if isinstance(content, StringIO.StringIO):
+    if isinstance(content, six.StringIO.StringIO):
         content = content.read()
 
     message = ('From: {0}\r\n'

--- a/salt/serializers/configparser.py
+++ b/salt/serializers/configparser.py
@@ -8,12 +8,12 @@
     Implements a configparser serializer.
 '''
 
+# Import Python libs
 from __future__ import absolute_import
 
-import StringIO
+# Import Salt Libs
+import salt.ext.six as six
 import salt.ext.six.moves.configparser as configparser  # pylint: disable=E0611
-
-from salt.ext.six import string_types
 from salt.serializers import DeserializationError, SerializationError
 
 __all__ = ['deserialize', 'serialize', 'available']
@@ -32,11 +32,11 @@ def deserialize(stream_or_string, **options):
     cp = configparser.SafeConfigParser(**options)
 
     try:
-        if not isinstance(stream_or_string, (bytes, string_types)):
+        if not isinstance(stream_or_string, (bytes, six.string_types)):
             cp.readfp(stream_or_string)
         else:
             # python2's ConfigParser cannot parse a config from a string
-            cp.readfp(StringIO.StringIO(stream_or_string))
+            cp.readfp(six.StringIO.StringIO(stream_or_string))
         data = {}
         for section_name in cp.sections():
             section = {}
@@ -66,7 +66,7 @@ def serialize(obj, **options):
         if fp:
             return cp.write(fp)
         else:
-            s = StringIO.StringIO()
+            s = six.StringIO.StringIO()
             cp.write(s)
             return s.getvalue()
     except Exception as error:

--- a/salt/serializers/configparser.py
+++ b/salt/serializers/configparser.py
@@ -36,7 +36,7 @@ def deserialize(stream_or_string, **options):
             cp.readfp(stream_or_string)
         else:
             # python2's ConfigParser cannot parse a config from a string
-            cp.readfp(six.StringIO.StringIO(stream_or_string))
+            cp.readfp(six.moves.StringIO(stream_or_string))
         data = {}
         for section_name in cp.sections():
             section = {}
@@ -66,7 +66,7 @@ def serialize(obj, **options):
         if fp:
             return cp.write(fp)
         else:
-            s = six.StringIO.StringIO()
+            s = six.moves.StringIO()
             cp.write(s)
             return s.getvalue()
     except Exception as error:

--- a/salt/states/jenkins.py
+++ b/salt/states/jenkins.py
@@ -1,20 +1,21 @@
 # -*- coding: utf-8 -*-
 '''
 Management of Jenkins
-==============================
+=====================
 
 .. versionadded:: 2016.3.0
 
 '''
 
-
+# Import Python libs
 from __future__ import absolute_import
-
 import difflib
-import salt.utils
-import StringIO
-
 import logging
+
+# Import Salt libs
+import salt.ext.six as six
+import salt.utils
+
 log = logging.getLogger(__name__)
 
 
@@ -42,7 +43,7 @@ def present(name,
 
     if _job_exists:
         _current_job_config = __salt__['jenkins.get_job_config'](name)
-        buf = StringIO.StringIO(_current_job_config)
+        buf = six.StringIO.StringIO(_current_job_config)
         _current_job_config = buf.readlines()
 
         cached_source_path = __salt__['cp.cache_file'](config, __env__)
@@ -62,7 +63,7 @@ def present(name,
 
         __salt__['jenkins.create_job'](name, config, __env__)
 
-        buf = StringIO.StringIO(new_config_xml)
+        buf = six.StringIO.StringIO(new_config_xml)
         _current_job_config = buf.readlines()
 
         diff = difflib.unified_diff('', buf, lineterm='')

--- a/salt/states/jenkins.py
+++ b/salt/states/jenkins.py
@@ -43,7 +43,7 @@ def present(name,
 
     if _job_exists:
         _current_job_config = __salt__['jenkins.get_job_config'](name)
-        buf = six.StringIO.StringIO(_current_job_config)
+        buf = six.moves.StringIO(_current_job_config)
         _current_job_config = buf.readlines()
 
         cached_source_path = __salt__['cp.cache_file'](config, __env__)
@@ -63,7 +63,7 @@ def present(name,
 
         __salt__['jenkins.create_job'](name, config, __env__)
 
-        buf = six.StringIO.StringIO(new_config_xml)
+        buf = six.moves.StringIO(new_config_xml)
         _current_job_config = buf.readlines()
 
         diff = difflib.unified_diff('', buf, lineterm='')

--- a/tests/unit/modules/zypper_test.py
+++ b/tests/unit/modules/zypper_test.py
@@ -5,9 +5,11 @@
 
 # Import Python Libs
 from __future__ import absolute_import
+import os
 
 # Import Salt Testing Libs
 from salttesting import TestCase, skipIf
+from salttesting.helpers import ensure_in_syspath
 from salttesting.mock import (
     Mock,
     MagicMock,
@@ -16,15 +18,13 @@ from salttesting.mock import (
     NO_MOCK,
     NO_MOCK_REASON
 )
-from salt.exceptions import CommandExecutionError
-
-import os
-from salt.ext.six.moves import configparser
-import StringIO
-
-from salttesting.helpers import ensure_in_syspath
 
 ensure_in_syspath('../../')
+
+# Import Salt libs
+from salt.exceptions import CommandExecutionError
+from salt.ext.six.moves import configparser
+import salt.ext.six as six
 
 
 class ZyppCallMock(object):
@@ -443,7 +443,7 @@ class ZypperTestCase(TestCase):
         '''
         repos_cfg = configparser.ConfigParser()
         for cfg in ['zypper-repo-1.cfg', 'zypper-repo-2.cfg']:
-            repos_cfg.readfp(StringIO.StringIO(get_test_data(cfg)))
+            repos_cfg.readfp(six.StringIO.StringIO(get_test_data(cfg)))
 
         for alias in repos_cfg.sections():
             r_info = zypper._get_repo_info(alias, repos_cfg=repos_cfg)

--- a/tests/unit/modules/zypper_test.py
+++ b/tests/unit/modules/zypper_test.py
@@ -443,7 +443,7 @@ class ZypperTestCase(TestCase):
         '''
         repos_cfg = configparser.ConfigParser()
         for cfg in ['zypper-repo-1.cfg', 'zypper-repo-2.cfg']:
-            repos_cfg.readfp(six.StringIO.StringIO(get_test_data(cfg)))
+            repos_cfg.readfp(six.moves.StringIO(get_test_data(cfg)))
 
         for alias in repos_cfg.sections():
             r_info = zypper._get_repo_info(alias, repos_cfg=repos_cfg)


### PR DESCRIPTION
Also cleans up some of the import blocks for these files. Some of them are getting a little scattered.