### PR TITLE
process_beacons: read beacon configuration from per minion opts

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -395,7 +395,7 @@ class MinionBase(object):
         the pillar or grains changed
         '''
         if 'config.merge' in functions:
-            b_conf = functions['config.merge']('beacons')
+            b_conf = functions['config.merge']('beacons', self.opts['beacons'], omit_opts=True)
             if b_conf:
                 return self.beacons.process(b_conf)  # pylint: disable=no-member
         return []


### PR DESCRIPTION
### What does this PR do?

Fixes a regression from 2016.3 where the beacon manipulation functions (enable, disable, modify) no longer work. The regression was introduced on 5821b39
### What issues does this PR fix or reference?
### Previous Behavior

Calling salt '<minion_id' beacon.disable wouldn't disable beacons.
### New Behavior

Now beacon execution module calls work as expected
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

The beacon manipulation functions, such as enable_beacons and
disable_beacons, use self.opts to enable/disable beacons. However,
process_beacons use **opts** to retrieve the becon's configuration,
which is no longer the same, due to comit 5821b39. Make process_beacon
read beacon configuration from self.opts instead.

Signed-off-by: Alejandro del Castillo alejandro.delcastillo@ni.com