### PR TITLE
beacons: add run_once config option

### DIFF
--- a/salt/beacons/__init__.py
+++ b/salt/beacons/__init__.py
@@ -70,6 +70,7 @@ class Beacon(object):
             log.trace('Beacon processing: {0}'.format(mod))
             fun_str = '{0}.beacon'.format(mod)
             if fun_str in self.beacons:
+                runonce = self._determine_beacon_config(current_beacon_config, 'run_once')
                 interval = self._determine_beacon_config(current_beacon_config, 'interval')
                 if interval:
                     b_config = self._trim_config(b_config, mod, 'interval')
@@ -96,6 +97,8 @@ class Beacon(object):
                     if 'id' not in data:
                         data['id'] = self.opts['id']
                     ret.append({'tag': tag, 'data': data})
+                if runonce:
+                    self.disable_beacon(mod)
             else:
                 log.debug('Unable to process beacon {0}'.format(mod))
         return ret


### PR DESCRIPTION
### What does this PR do?

Adds run_once beacon option to enable the use case where a process needs to run just once and stays in memory. This is the case for the avahi_announce (zeroconf) beacon that I will submit shortly.
### What issues does this PR fix or reference?

new feature
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

Useful for code that needs to run once and stay in memory, but that
doesn't need polling.

Signed-off-by: Alejandro del Castillo alejandro.delcastillo@ni.com