### PR TITLE
Add NILinuxRT support to timezone execution module

### DIFF
--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -142,7 +142,7 @@ def get_zone():
         for family in ('RedHat', 'SUSE'):
             if family in os_family:
                 return _get_zone_sysconfig()
-        for family in ('Debian', 'Gentoo'):
+        for family in ('Debian', 'Gentoo', 'NILinuxRT'):
             if family in os_family:
                 return _get_zone_etc_timezone()
         if os_family in ('FreeBSD', 'OpenBSD', 'NetBSD'):


### PR DESCRIPTION
### What does this PR do?

Add NILinuxRT support to timezone execution module

get_zone function in the timezone module would not work properly for
NILinuxRT due to OS sniffing. Add NILinuxRT as one of the OSes checked.
### Tests written?

No