### PR TITLE
handle jboss cli expression type in the parsing of output

### DIFF
--- a/salt/modules/jboss7_cli.py
+++ b/salt/modules/jboss7_cli.py
@@ -298,6 +298,9 @@ def __process_tokens_internal(tokens, start_at=0):
         elif __is_assignment(token):
             log.debug("    TYPE: ASSIGNMENT")
             is_assignment = True
+        elif __is_expression(token):
+            log.debug("    TYPE: EXPRESSION")
+            is_expression = True
         else:
             raise CommandExecutionError('Unknown token! Token: {0}'.format(token))
 
@@ -372,3 +375,7 @@ def __get_quoted_string(token):
 
 def __is_assignment(token):
     return token == '=>'
+
+
+def __is_expression(token):
+    return token == 'expression'


### PR DESCRIPTION
### What does this PR do?

updates jboss7_cli.py to handle jboss cli expression type in the parsing of output 
ex. "password"`=> expression "${VAULT`::`one`::`two`::1}"
### What issues does this PR fix or reference?

none
### Tests written?

No