### PR TITLE
Py3 fixes for running unit tests in the unit/states/ directory.

### DIFF
--- a/salt/modules/boto_apigateway.py
+++ b/salt/modules/boto_apigateway.py
@@ -78,7 +78,6 @@ Connection module for Amazon APIGateway
 # Import Python libs
 from __future__ import absolute_import
 import logging
-import string
 import json
 import datetime
 from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module

--- a/salt/modules/boto_apigateway.py
+++ b/salt/modules/boto_apigateway.py
@@ -350,7 +350,7 @@ def create_api_resources(restApiId, path,
         salt myminion boto_apigateway.create_api_resources myapi_id resource_path
 
     '''
-    path_parts = string.split(path, '/')
+    path_parts = str.split(path, '/')
     created = []
     current_path = ''
     try:

--- a/salt/modules/boto_apigateway.py
+++ b/salt/modules/boto_apigateway.py
@@ -84,6 +84,7 @@ import datetime
 from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
 
 # Import Salt libs
+import salt.ext.six as six
 import salt.utils.boto3
 import salt.utils.compat
 
@@ -140,7 +141,7 @@ def _convert_datetime_str(response):
     modify any key-value pair where value is a datetime object to a string.
     '''
     if response:
-        return dict([(k, '{0}'.format(v)) if isinstance(v, datetime.date) else (k, v) for k, v in response.iteritems()])
+        return dict([(k, '{0}'.format(v)) if isinstance(v, datetime.date) else (k, v) for k, v in six.iteritems(response)])
     return None
 
 
@@ -805,7 +806,7 @@ def overwrite_api_stage_variables(restApiId, stageName, variables, region=None, 
                 patch_ops.append(dict(op='remove',
                                       path='/variables/{0}'.format(old_var),
                                       value=''))
-        for var, val in variables.iteritems():
+        for var, val in six.iteritems(variables):
             if var not in old_vars or old_vars[var] != val:
                 patch_ops.append(dict(op='replace',
                                       path='/variables/{0}'.format(var),

--- a/salt/modules/boto_cloudtrail.py
+++ b/salt/modules/boto_cloudtrail.py
@@ -51,6 +51,7 @@ import logging
 from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
 
 # Import Salt libs
+import salt.ext.six as six
 import salt.utils.boto3
 import salt.utils.compat
 import salt.utils
@@ -425,7 +426,7 @@ def add_tags(Name,
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         tagslist = []
-        for k, v in kwargs.iteritems():
+        for k, v in six.iteritems(kwargs):
             if str(k).startswith('__'):
                 continue
             tagslist.append({'Key': str(k), 'Value': str(v)})
@@ -456,7 +457,7 @@ def remove_tags(Name,
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         tagslist = []
-        for k, v in kwargs.iteritems():
+        for k, v in six.iteritems(kwargs):
             if str(k).startswith('__'):
                 continue
             tagslist.append({'Key': str(k), 'Value': str(v)})

--- a/salt/modules/boto_elasticsearch_domain.py
+++ b/salt/modules/boto_elasticsearch_domain.py
@@ -81,11 +81,11 @@ import json
 from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
 
 # Import Salt libs
+import salt.ext.six as six
 import salt.utils.boto3
 import salt.utils.compat
 import salt.utils
 from salt.exceptions import SaltInvocationError
-from salt.ext.six import string_types
 
 log = logging.getLogger(__name__)
 
@@ -252,7 +252,7 @@ def create(DomainName, ElasticsearchClusterConfig=None, EBSOptions=None,
                     'AccessPolicies', 'SnapshotOptions', 'AdvancedOptions'):
             if locals()[k] is not None:
                 val = locals()[k]
-                if isinstance(val, string_types):
+                if isinstance(val, six.string_types):
                     try:
                         val = json.loads(val)
                     except ValueError as e:
@@ -324,7 +324,7 @@ def update(DomainName, ElasticsearchClusterConfig=None, EBSOptions=None,
                 'AccessPolicies', 'SnapshotOptions', 'AdvancedOptions'):
         if locals()[k] is not None:
             val = locals()[k]
-            if isinstance(val, string_types):
+            if isinstance(val, six.string_types):
                 try:
                     val = json.loads(val)
                 except ValueError as e:
@@ -362,7 +362,7 @@ def add_tags(DomainName=None, ARN=None,
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         tagslist = []
-        for k, v in kwargs.iteritems():
+        for k, v in six.iteritems(kwargs):
             if str(k).startswith('__'):
                 continue
             tagslist.append({'Key': str(k), 'Value': str(v)})

--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -84,11 +84,11 @@ import time
 import random
 
 # Import Salt libs
+import salt.ext.six as six
 import salt.utils.boto3
 import salt.utils.compat
 import salt.utils
 from salt.exceptions import SaltInvocationError
-from salt.ext.six import string_types
 from salt.ext.six.moves import range  # pylint: disable=import-error
 
 log = logging.getLogger(__name__)
@@ -343,13 +343,13 @@ def update_function_config(FunctionName, Role=None, Handler=None,
     '''
 
     args = dict(FunctionName=FunctionName)
-    for val, var in {
-        'Handler': Handler,
-        'Description': Description,
-        'Timeout': Timeout,
-        'MemorySize': MemorySize,
-        'VpcConfig': VpcConfig,
-    }.iteritems():
+    options = {'Handler': Handler,
+               'Description': Description,
+               'Timeout': Timeout,
+               'MemorySize': MemorySize,
+               'VpcConfig': VpcConfig}
+
+    for val, var in six.iteritems(options):
         if var:
             args[val] = var
     if Role:
@@ -523,7 +523,7 @@ def get_permissions(FunctionName, Qualifier=None,
         policy = conn.get_policy(FunctionName=FunctionName,
                                    **kwargs)
         policy = policy.get('Policy', {})
-        if isinstance(policy, string_types):
+        if isinstance(policy, six.string_types):
             policy = json.loads(policy)
         if policy is None:
             policy = {}

--- a/salt/modules/boto_s3_bucket.py
+++ b/salt/modules/boto_s3_bucket.py
@@ -583,7 +583,7 @@ def put_logging(Bucket,
         logstate = {}
         targets = {'TargetBucket': TargetBucket,
                    'TargetGrants': TargetGrants,
-                   'TargetPrefix': TargetPrefix,}
+                   'TargetPrefix': TargetPrefix}
         for key, val in six.iteritems(targets):
             if val is not None:
                 logstate[key] = val

--- a/salt/modules/boto_s3_bucket.py
+++ b/salt/modules/boto_s3_bucket.py
@@ -269,18 +269,19 @@ def describe(Bucket,
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         result = {}
-        for key, query in {
-                'ACL': conn.get_bucket_acl,
-                'CORS': conn.get_bucket_cors,
-                'LifecycleConfiguration': conn.get_bucket_lifecycle_configuration,
-                'Location': conn.get_bucket_location,
-                'Logging': conn.get_bucket_logging,
-                'NotificationConfiguration': conn.get_bucket_notification_configuration,
-                'Policy': conn.get_bucket_policy,
-                'Replication': conn.get_bucket_replication,
-                'RequestPayment': conn.get_bucket_request_payment,
-                'Versioning': conn.get_bucket_versioning,
-                'Website': conn.get_bucket_website}.iteritems():
+        conn_dict = {'ACL': conn.get_bucket_acl,
+                     'CORS': conn.get_bucket_cors,
+                     'LifecycleConfiguration': conn.get_bucket_lifecycle_configuration,
+                     'Location': conn.get_bucket_location,
+                     'Logging': conn.get_bucket_logging,
+                     'NotificationConfiguration': conn.get_bucket_notification_configuration,
+                     'Policy': conn.get_bucket_policy,
+                     'Replication': conn.get_bucket_replication,
+                     'RequestPayment': conn.get_bucket_request_payment,
+                     'Versioning': conn.get_bucket_versioning,
+                     'Website': conn.get_bucket_website}
+
+        for key, query in six.iteritems(conn_dict):
             try:
                 data = query(Bucket=Bucket)
             except ClientError as e:
@@ -340,7 +341,8 @@ def empty(Bucket, MFA=None, RequestPayer=None, region=None, key=None,
     if len(Delete['Objects']):
         ret = delete_objects(Bucket, Delete, MFA=MFA, RequestPayer=RequestPayer,
                              region=region, key=key, keyid=keyid, profile=profile)
-        if len(ret.get('failed', [])):
+        failed = ret.get('failed', [])
+        if len(failed):
             return {'deleted': False, 'failed': ret[failed]}
     return {'deleted': True}
 
@@ -579,11 +581,10 @@ def put_logging(Bucket,
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         logstate = {}
-        for key, val in {
-                'TargetBucket': TargetBucket,
-                'TargetGrants': TargetGrants,
-                'TargetPrefix': TargetPrefix,
-        }.iteritems():
+        targets = {'TargetBucket': TargetBucket,
+                   'TargetGrants': TargetGrants,
+                   'TargetPrefix': TargetPrefix,}
+        for key, val in six.iteritems(targets):
             if val is not None:
                 logstate[key] = val
         if logstate:
@@ -764,7 +765,7 @@ def put_tagging(Bucket,
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         tagslist = []
-        for k, v in kwargs.iteritems():
+        for k, v in six.iteritems(kwargs):
             if str(k).startswith('__'):
                 continue
             tagslist.append({'Key': str(k), 'Value': str(v)})

--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -2462,7 +2462,7 @@ def describe_route_tables(route_table_id=None, route_table_name=None,
                       }
         for item in route_tables:
             route_table = {}
-            for outkey, inkey in keys.iteritems():
+            for outkey, inkey in six.iteritems(keys):
                 if inkey in item:
                     if outkey == 'routes':
                         route_table[outkey] = _key_remap(inkey, route_keys, item)
@@ -2546,7 +2546,7 @@ def _key_remap(key, keys, item):
     elements_list = []
     for r_item in item.get(key, []):
         element = {}
-        for r_outkey, r_inkey in keys.iteritems():
+        for r_outkey, r_inkey in six.iteritems(keys):
             if r_inkey in r_item:
                 element[r_outkey] = r_item.get(r_inkey)
         elements_list.append(element)

--- a/salt/states/boto_apigateway.py
+++ b/salt/states/boto_apigateway.py
@@ -1593,7 +1593,7 @@ class _Swagger(object):
 
         lambda_integration_role
             name of the IAM role or IAM role arn that Api Gateway will assume when executing
-            the associated lambda function`
+            the associated lambda function
 
         lambda_region
             the region for the lambda function that Api Gateway will integrate to.

--- a/salt/states/boto_apigateway.py
+++ b/salt/states/boto_apigateway.py
@@ -57,10 +57,8 @@ import json
 import yaml
 
 # Import Salt Libs
+import salt.ext.six as six
 import salt.utils
-from salt.ext.six import string_types
-
-# Import 3rd Party Libs
 
 log = logging.getLogger(__name__)
 
@@ -300,7 +298,7 @@ def _get_stage_variables(stage_variables):
     if stage_variables is None:
         return ret
 
-    if isinstance(stage_variables, string_types):
+    if isinstance(stage_variables, six.string_types):
         if stage_variables in __opts__:
             ret = __opts__[stage_variables]
         master_opts = __pillar__.get('master', {})
@@ -439,7 +437,7 @@ def _object_reducer(o, names=('id', 'name', 'path', 'httpMethod',
     '''
     result = {}
     if isinstance(o, dict):
-        for k, v in o.iteritems():
+        for k, v in six.iteritems(o):
             if isinstance(v, dict):
                 reduced = v if k == 'variables' else _object_reducer(v, names)
                 if reduced or _name_matches(k, names):
@@ -701,13 +699,13 @@ class _Swagger(object):
         to handle response code mapping/integration
         '''
         for path, ops in paths:
-            for opname, opobj in ops.iteritems():
+            for opname, opobj in six.iteritems(ops):
                 if opname not in _Swagger.SWAGGER_OPERATION_NAMES:
                     continue
 
                 if 'responses' not in opobj:
                     raise ValueError('missing mandatory responses field in path item object')
-                for rescode, resobj in opobj.get('responses').iteritems():
+                for rescode, resobj in six.iteritems(opobj.get('responses')):
                     if not self._is_http_error_rescode(str(rescode)):
                         continue
 
@@ -857,7 +855,7 @@ class _Swagger(object):
         for path in paths:
             if not path.startswith('/'):
                 raise ValueError('Path object {0} should start with /. Please fix it'.format(path))
-        return paths.iteritems()
+        return six.iteritems(paths)
 
     @property
     def basePath(self):
@@ -1258,7 +1256,7 @@ class _Swagger(object):
                 # need to walk each property object
                 properties = obj_schema.get('properties')
                 if properties:
-                    for _, prop_obj_schema in properties.iteritems():
+                    for _, prop_obj_schema in six.iteritems(properties):
                         dep_models_list.extend(self._build_dependent_model_list(prop_obj_schema))
         return list(set(dep_models_list))
 
@@ -1267,7 +1265,7 @@ class _Swagger(object):
         Helper function to build a map of model to their list of model reference dependencies
         '''
         ret = {}
-        for model, schema in self._models().iteritems():
+        for model, schema in six.iteritems(self._models()):
             dep_list = self._build_dependent_model_list(schema)
             ret[model] = dep_list
         return ret
@@ -1280,7 +1278,7 @@ class _Swagger(object):
         if not models_dict:
             return next_model
 
-        for model, dependencies in models_dict.iteritems():
+        for model, dependencies in six.iteritems(models_dict):
             if dependencies == []:
                 next_model = model
                 break
@@ -1291,7 +1289,7 @@ class _Swagger(object):
 
         # remove the model from other depednencies before returning
         models_dict.pop(next_model)
-        for model, dep_list in models_dict.iteritems():
+        for model, dep_list in six.iteritems(models_dict):
             if next_model in dep_list:
                 dep_list.remove(next_model)
 
@@ -1421,7 +1419,7 @@ class _Swagger(object):
     def _find_patterns(self, o):
         result = []
         if isinstance(o, dict):
-            for k, v in o.iteritems():
+            for k, v in six.iteritems(o):
                 if isinstance(v, dict):
                     result.extend(self._find_patterns(v))
                 else:
@@ -1547,7 +1545,7 @@ class _Swagger(object):
         ret = _log_changes(ret, '_deploy_method.create_api_integration', integration)
 
         if 'responses' in method_data:
-            for response, response_data in method_data['responses'].iteritems():
+            for response, response_data in six.iteritems(method_data['responses']):
                 httpStatus = str(response)
                 method_response = self._parse_method_response(method_name.lower(),
                                                               _Swagger.SwaggerMethodResponse(response_data), httpStatus)
@@ -1612,7 +1610,7 @@ class _Swagger(object):
                 ret = _log_error_and_abort(ret, resource)
                 return ret
             ret = _log_changes(ret, 'deploy_resources', resource)
-            for method, method_data in pathData.iteritems():
+            for method, method_data in six.iteritems(pathData):
                 if method in _Swagger.SWAGGER_OPERATION_NAMES:
                     ret = self._deploy_method(ret, path, method, method_data, api_key_required,
                                               lambda_integration_role, lambda_region, authorization_type)

--- a/salt/states/boto_apigateway.py
+++ b/salt/states/boto_apigateway.py
@@ -1593,7 +1593,7 @@ class _Swagger(object):
 
         lambda_integration_role
             name of the IAM role or IAM role arn that Api Gateway will assume when executing
-            the associated lambda function
+            the associated lambda function`
 
         lambda_region
             the region for the lambda function that Api Gateway will integrate to.

--- a/salt/states/boto_asg.py
+++ b/salt/states/boto_asg.py
@@ -200,8 +200,6 @@ import copy
 
 # Import Salt libs
 import salt.utils.dictupdate as dictupdate
-
-# Import 3rd-party libs
 import salt.ext.six as six
 from salt.ext.six.moves import zip  # pylint: disable=import-error,redefined-builtin
 
@@ -530,7 +528,7 @@ def present(
                 if 'min_adjustment_step' not in policy:
                     policy['min_adjustment_step'] = None
         if scheduled_actions:
-            for s_name, action in scheduled_actions.iteritems():
+            for s_name, action in six.iteritems(scheduled_actions):
                 if 'end_time' not in action:
                     action['end_time'] = None
         config = {
@@ -558,7 +556,7 @@ def present(
         if scheduled_actions is None:
             config['scheduled_actions'] = {}
         # allow defaults on start_time
-        for s_name, action in scheduled_actions.iteritems():
+        for s_name, action in six.iteritems(scheduled_actions):
             if 'start_time' not in action:
                 asg_action = asg['scheduled_actions'].get(s_name, {})
                 if 'start_time' in asg_action:

--- a/salt/states/boto_cloudtrail.py
+++ b/salt/states/boto_cloudtrail.py
@@ -55,6 +55,7 @@ import os
 import os.path
 
 # Import Salt Libs
+import salt.ext.six as six
 import salt.utils
 
 log = logging.getLogger(__name__)
@@ -222,16 +223,18 @@ def present(name, Name,
     _describe['LoggingEnabled'] = r.get('trail', {}).get('IsLogging', False)
 
     need_update = False
-    for invar, outvar in {'S3BucketName': 'S3BucketName',
-                'S3KeyPrefix': 'S3KeyPrefix',
-                'SnsTopicName': 'SnsTopicName',
-                'IncludeGlobalServiceEvents': 'IncludeGlobalServiceEvents',
-                'IsMultiRegionTrail': 'IsMultiRegionTrail',
-                'EnableLogFileValidation': 'LogFileValidationEnabled',
-                'CloudWatchLogsLogGroupArn': 'CloudWatchLogsLogGroupArn',
-                'CloudWatchLogsRoleArn': 'CloudWatchLogsRoleArn',
-                'KmsKeyId': 'KmsKeyId',
-                'LoggingEnabled': 'LoggingEnabled'}.iteritems():
+    bucket_vars = {'S3BucketName': 'S3BucketName',
+                   'S3KeyPrefix': 'S3KeyPrefix',
+                   'SnsTopicName': 'SnsTopicName',
+                   'IncludeGlobalServiceEvents': 'IncludeGlobalServiceEvents',
+                   'IsMultiRegionTrail': 'IsMultiRegionTrail',
+                   'EnableLogFileValidation': 'LogFileValidationEnabled',
+                   'CloudWatchLogsLogGroupArn': 'CloudWatchLogsLogGroupArn',
+                   'CloudWatchLogsRoleArn': 'CloudWatchLogsRoleArn',
+                   'KmsKeyId': 'KmsKeyId',
+                   'LoggingEnabled': 'LoggingEnabled'}
+
+    for invar, outvar in six.iteritems(bucket_vars):
         if _describe[outvar] != locals()[invar]:
             need_update = True
             ret['changes'].setdefault('new', {})[invar] = locals()[invar]
@@ -291,7 +294,7 @@ def present(name, Name,
         if bool(tagchange):
             adds = {}
             removes = {}
-            for k, diff in tagchange.iteritems():
+            for k, diff in six.iteritems(tagchange):
                 if diff.get('new', '') != '':
                     # there's an update for this key
                     adds[k] = Tags[k]

--- a/salt/states/boto_elasticsearch_domain.py
+++ b/salt/states/boto_elasticsearch_domain.py
@@ -85,7 +85,7 @@ import os.path
 import json
 
 # Import Salt Libs
-from salt.ext.six import string_types
+import salt.ext.six as six
 
 log = logging.getLogger(__name__)
 
@@ -216,7 +216,7 @@ def present(name, DomainName,
         }
     if Tags is None:
         Tags = {}
-    if AccessPolicies is not None and isinstance(AccessPolicies, string_types):
+    if AccessPolicies is not None and isinstance(AccessPolicies, six.string_types):
         try:
             AccessPolicies = json.loads(AccessPolicies)
         except ValueError as e:
@@ -271,13 +271,13 @@ def present(name, DomainName,
 
     comm_args = {}
     need_update = False
-    for k, v in {
-        'ElasticsearchClusterConfig': ElasticsearchClusterConfig,
-        'EBSOptions': EBSOptions,
-        'AccessPolicies': AccessPolicies,
-        'SnapshotOptions': SnapshotOptions,
-        'AdvancedOptions': AdvancedOptions
-    }.iteritems():
+    es_opts = {'ElasticsearchClusterConfig': ElasticsearchClusterConfig,
+               'EBSOptions': EBSOptions,
+               'AccessPolicies': AccessPolicies,
+               'SnapshotOptions': SnapshotOptions,
+               'AdvancedOptions': AdvancedOptions}
+
+    for k, v in six.iteritems(es_opts):
         if not _compare_json(v, _describe[k]):
             need_update = True
             comm_args[k] = v

--- a/salt/states/boto_elb.py
+++ b/salt/states/boto_elb.py
@@ -757,10 +757,10 @@ def _listeners_present(
     to_delete = []
     to_create = []
 
-    for t, l in expected_listeners_by_tuple.iteritems():
+    for t, l in six.iteritems(expected_listeners_by_tuple):
         if t not in actual_listeners_by_tuple:
             to_create.append(l)
-    for t, l in actual_listeners_by_tuple.iteritems():
+    for t, l in six.iteritems(actual_listeners_by_tuple):
         if t not in expected_listeners_by_tuple:
             to_delete.append(l)
 
@@ -1260,18 +1260,18 @@ def _policies_present(
                 to_delete.append(policy_name)
 
     listeners_to_update = set()
-    for port, policies in expected_policies_by_listener.iteritems():
+    for port, policies in six.iteritems(expected_policies_by_listener):
         if policies != actual_policies_by_listener.get(port, set()):
             listeners_to_update.add(port)
-    for port, policies in actual_policies_by_listener.iteritems():
+    for port, policies in six.iteritems(actual_policies_by_listener):
         if policies != expected_policies_by_listener.get(port, set()):
             listeners_to_update.add(port)
 
     backends_to_update = set()
-    for port, policies in expected_policies_by_backend.iteritems():
+    for port, policies in six.iteritems(expected_policies_by_backend):
         if policies != actual_policies_by_backend.get(port, set()):
             backends_to_update.add(port)
-    for port, policies in actual_policies_by_backend.iteritems():
+    for port, policies in six.iteritems(actual_policies_by_backend):
         if policies != expected_policies_by_backend.get(port, set()):
             backends_to_update.add(port)
 
@@ -1387,7 +1387,7 @@ def _policy_cname(policy_dict):
     policy_name = policy_dict['policy_name']
     policy_type = policy_dict['policy_type']
     policy = policy_dict['policy']
-    canonical_policy_repr = str(sorted(list(policy.iteritems()), key=lambda x: str(x[0])))
+    canonical_policy_repr = str(sorted(list(six.iteritems(policy)), key=lambda x: str(x[0])))
     policy_hash = hashlib.md5(str(canonical_policy_repr)).hexdigest()
     if policy_type.endswith('Type'):
         policy_type = policy_type[:-4]

--- a/salt/states/boto_iot.py
+++ b/salt/states/boto_iot.py
@@ -504,7 +504,8 @@ def topic_rule_present(name, ruleName, sql, actions, description='',
         actions = json.loads(actions)
 
     need_update = False
-    r = cmp(_describe['actions'], actions)
+    # cmp() function is deprecated in Python 3: use the following as a substitute for 'r'.
+    r = (_describe['actions'] > actions) - (_describe['actions'] < actions)
     if bool(r):
         need_update = True
         ret['changes'].setdefault('new', {})['actions'] = actions

--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -65,10 +65,10 @@ import hashlib
 import json
 
 # Import Salt Libs
+import salt.ext.six as six
 import salt.utils.dictupdate as dictupdate
 import salt.utils
 from salt.exceptions import SaltInvocationError
-from salt.ext.six import string_types
 
 log = logging.getLogger(__name__)
 
@@ -177,11 +177,11 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S
            }
 
     if Permissions is not None:
-        if isinstance(Permissions, string_types):
+        if isinstance(Permissions, six.string_types):
             Permissions = json.loads(Permissions)
         required_keys = set(('Action', 'Principal'))
         optional_keys = set(('SourceArn', 'SourceAccount'))
-        for sid, permission in Permissions.iteritems():
+        for sid, permission in six.iteritems(Permissions):
             keyset = set(permission.keys())
             if not keyset.issuperset(required_keys):
                 raise SaltInvocationError('{0} are required for each permission '
@@ -222,7 +222,7 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S
             return ret
 
         if Permissions:
-            for sid, permission in Permissions.iteritems():
+            for sid, permission in six.iteritems(Permissions):
                 r = __salt__['boto_lambda.add_permission'](FunctionName=FunctionName,
                                                        StatementId=sid,
                                                        region=region, key=key,
@@ -291,13 +291,13 @@ def _function_config_present(FunctionName, Role, Handler, Description, Timeout,
            region=region, key=key, keyid=keyid, profile=profile)['function']
     role_arn = _get_role_arn(Role, region, key, keyid, profile)
     need_update = False
-    for val, var in {
-        'Role': 'role_arn',
-        'Handler': 'Handler',
-        'Description': 'Description',
-        'Timeout': 'Timeout',
-        'MemorySize': 'MemorySize',
-    }.iteritems():
+    options = {'Role': 'role_arn',
+               'Handler': 'Handler',
+               'Description': 'Description',
+               'Timeout': 'Timeout',
+               'MemorySize': 'MemorySize'}
+
+    for val, var in six.iteritems(options):
         if func[val] != locals()[var]:
             need_update = True
             ret['changes'].setdefault('new', {})[var] = locals()[var]
@@ -400,7 +400,7 @@ def _function_permissions_present(FunctionName, Permissions,
             ret['comment'] = msg
             ret['result'] = None
             return ret
-        for sid, diff in diffs.iteritems():
+        for sid, diff in six.iteritems(diffs):
             if diff.get('old', '') != '':
                 # There's a permssion that needs to be removed
                 _r = __salt__['boto_lambda.remove_permission'](FunctionName=FunctionName,
@@ -563,10 +563,10 @@ def alias_present(name, FunctionName, Name, FunctionVersion, Description='',
                                                   profile=profile)['alias']
 
     need_update = False
-    for val, var in {
-        'FunctionVersion': 'FunctionVersion',
-        'Description': 'Description',
-    }.iteritems():
+    options = {'FunctionVersion': 'FunctionVersion',
+               'Description': 'Description'}
+
+    for val, var in six.iteritems(options):
         if _describe[val] != locals()[var]:
             need_update = True
             ret['changes'].setdefault('new', {})[var] = locals()[var]
@@ -762,9 +762,9 @@ def event_source_mapping_present(name, EventSourceArn, FunctionName, StartingPos
                                  region=region, key=key, keyid=keyid, profile=profile)['event_source_mapping']
 
     need_update = False
-    for val, var in {
-        'BatchSize': 'BatchSize',
-    }.iteritems():
+    options = {'BatchSize': 'BatchSize'}
+
+    for val, var in six.iteritems(options):
         if _describe[val] != locals()[var]:
             need_update = True
             ret['changes'].setdefault('new', {})[var] = locals()[var]

--- a/salt/states/boto_vpc.py
+++ b/salt/states/boto_vpc.py
@@ -92,6 +92,7 @@ from __future__ import absolute_import
 import logging
 
 # Import Salt Libs
+import salt.ext.six as six
 import salt.utils.dictupdate as dictupdate
 
 log = logging.getLogger(__name__)
@@ -981,7 +982,7 @@ def _routes_present(route_table_name, routes, tags=None, region=None, key=None, 
         for i in routes:
             #_r = {k:i[k] for k in i if k in route_keys}
             _r = {}
-            for k, v in i.iteritems():
+            for k, v in six.iteritems(i):
                 if k in route_keys:
                     _r[k] = i[k]
             if i.get('internet_gateway_name'):

--- a/salt/states/ini_manage.py
+++ b/salt/states/ini_manage.py
@@ -10,6 +10,11 @@ Manage ini files
 
 '''
 
+# Import Python libs
+from __future__ import absolute_import
+
+# Import Salt libs
+import salt.ext.six as six
 
 __virtualname__ = 'ini'
 
@@ -113,7 +118,7 @@ def options_absent(name, sections=None, separator='='):
             ret['comment'] = 'No changes detected.'
         return ret
     sections = sections or {}
-    for section, keys in sections.iteritems():
+    for section, keys in six.iteritems(sections):
         for key in keys:
             current_value = __salt__['ini.remove_option'](name, section, key, separator)
             if not current_value:

--- a/salt/utils/boto3.py
+++ b/salt/utils/boto3.py
@@ -46,6 +46,7 @@ from functools import partial
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 from salt.exceptions import SaltInvocationError
 from salt.ext import six
+import salt.utils
 
 # Import third party libs
 # pylint: disable=import-error
@@ -128,7 +129,10 @@ def _get_profile(service, region, key, keyid, profile):
 
     label = 'boto_{0}:'.format(service)
     if keyid:
-        cxkey = label + hashlib.md5(region + keyid + key).hexdigest()
+        hash_string = region + keyid + key
+        if six.PY3:
+            hash_string = salt.utils.to_bytes(hash_string)
+        cxkey = label + hashlib.md5(hash_string).hexdigest()
     else:
         cxkey = label + region
 

--- a/salt/utils/boto3.py
+++ b/salt/utils/boto3.py
@@ -253,23 +253,27 @@ def get_error(e):
     # The returns from boto modules vary greatly between modules. We need to
     # assume that none of the data we're looking for exists.
     aws = {}
-    if hasattr(e, 'status'):
-        aws['status'] = e.status
-    if hasattr(e, 'reason'):
-        aws['reason'] = e.reason
-    if hasattr(e, 'message') and e.message != '':
-        aws['message'] = e.message
-    if hasattr(e, 'error_code') and e.error_code is not None:
-        aws['code'] = e.error_code
 
-    if 'message' in aws and 'reason' in aws:
-        message = '{0}: {1}'.format(aws['reason'], aws['message'])
-    elif 'message' in aws:
-        message = aws['message']
-    elif 'reason' in aws:
-        message = aws['reason']
-    else:
-        message = ''
+    message = ''
+    if six.PY2:
+        if hasattr(e, 'status'):
+            aws['status'] = e.status
+        if hasattr(e, 'reason'):
+            aws['reason'] = e.reason
+        if hasattr(e, 'message') and e.message != '':
+            aws['message'] = e.message
+        if hasattr(e, 'error_code') and e.error_code is not None:
+            aws['code'] = e.error_code
+
+        if 'message' in aws and 'reason' in aws:
+            message = '{0}: {1}'.format(aws['reason'], aws['message'])
+        elif 'message' in aws:
+            message = aws['message']
+        elif 'reason' in aws:
+            message = aws['reason']
+    elif six.PY3:
+        message = e.args[0]
+
     r = {'message': message}
     if aws:
         r['aws'] = aws

--- a/tests/unit/modules/boto_apigateway_test.py
+++ b/tests/unit/modules/boto_apigateway_test.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module
 import datetime
 import logging
-from itertools import izip
 import random
 import string
 
@@ -17,7 +16,6 @@ from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../')
 
 # Import Salt libs
-import salt.config
 import salt.loader
 from salt.modules import boto_apigateway
 
@@ -31,7 +29,7 @@ try:
 except ImportError:
     HAS_BOTO = False
 
-from salt.ext.six.moves import range
+from salt.ext.six.moves import range, zip
 
 # pylint: enable=import-error,no-name-in-module
 
@@ -148,7 +146,7 @@ class BotoApiGatewayTestCaseMixin(object):
 
         listdict1_sorted = sorted(listdict1, key=lambda x: x[sortkey])
         listdict2_sorted = sorted(listdict2, key=lambda x: x[sortkey])
-        for item1, item2 in izip(listdict1_sorted, listdict2_sorted):
+        for item1, item2 in zip(listdict1_sorted, listdict2_sorted):
             if len(set(item1) & set(item2)) != len(set(item2)):
                 return True
         return False

--- a/tests/unit/modules/boto_lambda_test.py
+++ b/tests/unit/modules/boto_lambda_test.py
@@ -21,10 +21,12 @@ ensure_in_syspath('../../')
 
 # Import Salt libs
 import salt.config
+import salt.ext.six as six
 import salt.loader
 from salt.modules import boto_lambda
 from salt.exceptions import SaltInvocationError
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
+import salt.utils
 
 # Import 3rd-party libs
 from tempfile import NamedTemporaryFile
@@ -134,7 +136,10 @@ class BotoLambdaTestCaseBase(TestCase):
 class TempZipFile(object):
     def __enter__(self):
         with NamedTemporaryFile(suffix='.zip', prefix='salt_test_', delete=False) as tmp:
-            tmp.write('###\n')
+            to_write = '###\n'
+            if six.PY3:
+                to_write = salt.utils.to_bytes(to_write)
+            tmp.write(to_write)
             self.zipfile = tmp.name
         return self.zipfile
 

--- a/tests/unit/states/boto_elasticsearch_domain_test.py
+++ b/tests/unit/states/boto_elasticsearch_domain_test.py
@@ -9,17 +9,20 @@ import string
 
 # Import Salt Testing libs
 from salttesting.unit import skipIf, TestCase
-from salttesting.mock import NO_MOCK, NO_MOCK_REASON, patch
+from salttesting.mock import (
+    MagicMock,
+    NO_MOCK,
+    NO_MOCK_REASON,
+    patch
+)
 from salttesting.helpers import ensure_in_syspath
 
 ensure_in_syspath('../../')
 
 # Import Salt libs
-import salt.config
+import salt.ext.six as six
 import salt.loader
-
-# Import Mock libraries
-from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
+from salt.ext.six.moves import range
 
 # pylint: disable=import-error,no-name-in-module,unused-import
 from unit.modules.boto_elasticsearch_domain_test import BotoElasticsearchDomainTestCaseMixin
@@ -32,8 +35,6 @@ try:
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
-
-from salt.ext.six.moves import range
 
 # pylint: enable=import-error,no-name-in-module,unused-import
 
@@ -137,7 +138,7 @@ class BotoElasticsearchDomainTestCase(BotoElasticsearchDomainStateTestCaseBase, 
     def test_present_when_domain_exists(self):
         self.conn.describe_elasticsearch_domain.return_value = {'DomainStatus': domain_ret}
         cfg = {}
-        for k, v in domain_ret.iteritems():
+        for k, v in six.iteritems(domain_ret):
             cfg[k] = {'Options': v}
         cfg['AccessPolicies'] = {'Options': '{"a": "b"}'}
         self.conn.describe_elasticsearch_domain_config.return_value = {'DomainConfig': cfg}

--- a/tests/unit/states/boto_elasticsearch_domain_test.py
+++ b/tests/unit/states/boto_elasticsearch_domain_test.py
@@ -22,7 +22,7 @@ ensure_in_syspath('../../')
 # Import Salt libs
 import salt.ext.six as six
 import salt.loader
-from salt.ext.six.moves import range
+from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 
 # pylint: disable=import-error,no-name-in-module,unused-import
 from unit.modules.boto_elasticsearch_domain_test import BotoElasticsearchDomainTestCaseMixin

--- a/tests/unit/states/boto_s3_bucket_test.py
+++ b/tests/unit/states/boto_s3_bucket_test.py
@@ -21,7 +21,7 @@ from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../')
 
 # Import Salt libs
-import salt.config
+import salt.ext.six as six
 import salt.loader
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 
@@ -309,7 +309,7 @@ class BotoS3BucketTestCase(BotoS3BucketStateTestCaseBase, BotoS3BucketTestCaseMi
         self.conn.head_bucket.side_effect = [not_found_error, None]
         self.conn.list_buckets.return_value = deepcopy(list_ret)
         self.conn.create_bucket.return_value = bucket_ret
-        for key, value in config_ret.iteritems():
+        for key, value in six.iteritems(config_ret):
             getattr(self.conn, key).return_value = deepcopy(value)
         with patch.dict(funcs, {'boto_iam.get_account_id': MagicMock(return_value='111111222222')}):
             result = salt_states['boto_s3_bucket.present'](
@@ -323,7 +323,7 @@ class BotoS3BucketTestCase(BotoS3BucketStateTestCaseBase, BotoS3BucketTestCaseMi
 
     def test_present_when_bucket_exists_no_mods(self):
         self.conn.list_buckets.return_value = deepcopy(list_ret)
-        for key, value in config_ret.iteritems():
+        for key, value in six.iteritems(config_ret):
             getattr(self.conn, key).return_value = deepcopy(value)
         with patch.dict(funcs, {'boto_iam.get_account_id': MagicMock(return_value='111111222222')}):
             result = salt_states['boto_s3_bucket.present'](
@@ -337,7 +337,7 @@ class BotoS3BucketTestCase(BotoS3BucketStateTestCaseBase, BotoS3BucketTestCaseMi
 
     def test_present_when_bucket_exists_all_mods(self):
         self.conn.list_buckets.return_value = deepcopy(list_ret)
-        for key, value in config_ret.iteritems():
+        for key, value in six.iteritems(config_ret):
             getattr(self.conn, key).return_value = deepcopy(value)
         with patch.dict(funcs, {'boto_iam.get_account_id': MagicMock(return_value='111111222222')}):
             result = salt_states['boto_s3_bucket.present'](
@@ -360,7 +360,7 @@ class BotoS3BucketTestCase(BotoS3BucketStateTestCaseBase, BotoS3BucketTestCaseMi
                          **config_in
                      )
         self.assertFalse(result['result'])
-        self.assertTrue('An error occurred' in result['comment'])
+        self.assertTrue('Failed to create bucket' in result['comment'])
 
     def test_absent_when_bucket_does_not_exist(self):
         '''
@@ -380,4 +380,4 @@ class BotoS3BucketTestCase(BotoS3BucketStateTestCaseBase, BotoS3BucketTestCaseMi
         self.conn.delete_bucket.side_effect = ClientError(error_content, 'delete_bucket')
         result = salt_states['boto_s3_bucket.absent']('test', 'testbucket')
         self.assertFalse(result['result'])
-        self.assertTrue('An error occurred' in result['comment'])
+        self.assertTrue('Failed to delete bucket' in result['comment'])

--- a/tests/unit/states/dockerio_test.py
+++ b/tests/unit/states/dockerio_test.py
@@ -20,6 +20,7 @@ def provision_state(module, fixture):
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(True, 'Skipped: This module has been deprecated.')
 class DockerStateTestCase(TestCase):
     def test_docker_run_success(self):
         from salt.states import dockerio

--- a/tests/unit/states/kmod_test.py
+++ b/tests/unit/states/kmod_test.py
@@ -158,7 +158,7 @@ class KmodTestCase(TestCase):
         mock_mod_list = MagicMock(return_value=mods)
         with patch.dict(kmod.__salt__, {'kmod.mod_list': mock_mod_list}):
             with patch.dict(kmod.__opts__, {'test': True}):
-                comment = 'Kernel modules {0} are set to be removed'.format(', '.join(mods))
+                comment = 'Kernel modules {0} are set to be removed'.format(', '.join(sorted(mods)))
                 ret.update({'comment': comment, 'result': None})
                 self.assertDictEqual(kmod.absent(name, mods=mods), ret)
 


### PR DESCRIPTION
### What does this PR do?

Most of the changes center around moving `object.iteritems()` calls to `six.iteritems(object)` calls. 

There are still about 7 files in the `unit/states/` directory that need to be addressed for running tests in Python 3, but I wanted to get this in and get tests running on these changes now.