### PR TITLE
add num_cpus grain to freebsd

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1438,6 +1438,7 @@ def os_data():
             # freebsd-version was introduced in 10.0.
             # derive osrelease from kernelversion prior to that
             grains['osrelease'] = grains['kernelrelease'].split('-')[0]
+        grains.update(_bsd_cpudata(grains))
     if grains['kernel'] in ('OpenBSD', 'NetBSD'):
         grains.update(_bsd_cpudata(grains))
         grains['osrelease'] = grains['kernelrelease'].split('-')[0]

--- a/tests/integration/modules/grains.py
+++ b/tests/integration/modules/grains.py
@@ -132,6 +132,7 @@ class TestModulesGrains(integration.ModuleCase):
             self.assertIsInstance(get_grain, int,
                                   msg='grain: {0} is not an int or empty'.format(grain))
 
+
 class GrainsAppendTestCase(integration.ModuleCase):
     '''
     Tests written specifically for the grains.append function.

--- a/tests/integration/modules/grains.py
+++ b/tests/integration/modules/grains.py
@@ -120,6 +120,17 @@ class TestModulesGrains(integration.ModuleCase):
                 continue
             self.assertTrue(get_grain)
 
+    def test_get_grains_int(self):
+        '''
+        test to ensure int grains
+        are returned as integers
+        '''
+        grains = ['num_cpus', 'mem_total', 'num_gpus', 'uid']
+        for grain in grains:
+            get_grain = self.run_function('grains.get', [grain])
+
+            self.assertIsInstance(get_grain, int,
+                                  msg='grain: {0} is not an int or empty'.format(grain))
 
 class GrainsAppendTestCase(integration.ModuleCase):
     '''


### PR DESCRIPTION
### What does this PR do?

Adds the num_cpus grain to freebsd which was removed in commit: de5661725c3ff81a080917dca8f876c628909cb2
### What issues does this PR fix or reference?
saltstack/salt#34382 and #34554
### Previous Behavior

```
root@ch3ll-freebsd10-2:~ # salt-call --local grains.item num_cpus
local:
    ----------
    num_cpus:
```
### New Behavior

```
root@ch3ll-freebsd10-2:~ # salt-call --local grains.item num_cpus
local:
    ----------
    num_cpus:
        2
```
### Tests written?

Yes