### PR TITLE
WIP: Report changes after updating refs in bare repos

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -1320,6 +1320,8 @@ def latest(name,
                                 else ''
                         )
                     )
+                    if fetch_changes:
+                        ret['changes']['bare'] = 'Refs updated'
             try:
                 new_rev = __salt__['git.revision'](
                     cwd=target,


### PR DESCRIPTION
### What does this PR do?

It fixes a bug, where updates to a bare repo aren't reported and thereby render `onchanges` requisites useless.
### What issues does this PR fix or reference?

None filed
### Tests written?

No
