### PR TITLE
archive.extracted: unbreak on OpenBSD

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -455,6 +455,9 @@ def extracted(name,
                         append_opt = append_opt.replace('x', '').replace('f', '')
                         tar_shortopts = tar_shortopts + append_opt
 
+            if __grains__['os'] == 'OpenBSD':
+                tar_shortopts = '-' + tar_shortopts
+
             tar_cmd.append(tar_shortopts)
             tar_cmd.extend(tar_longopts)
             tar_cmd.extend(['-f', filename])


### PR DESCRIPTION
### What does this PR do?

Fix archive.extracted on OpenBSD.
### What issues does this PR fix or reference?

None.
### Previous Behavior

Could not extract tar files on OpenBSD.
### New Behavior

Extracting a tar file (as well as tgz) is now working on OpenBSD.
### Tests written?

No

On OpenBSD, using tar in "legacy" mode, all option flags except for -C and -I
must be contained within the first argument to tar and must not be prefixed by a
hyphen. Since the state automatically adds '-f', we are not running in legacy
mode and as such, all options must be prefixed by a hyphen.
- before
  [INFO    ] Executing command ['tar', 'xz', '-f', '/path/to/file.tgz'] in directory '/path/to/extractdir'
  [ERROR   ] Command '['tar', 'xz', '-f', '/path/to/file.tgz']' failed with return code: 1
  [ERROR   ] stderr: tar: Failed open to read on /dev/rst0: Device not configured
  <snip>
  Failed:    1
- after
  [INFO    ] Executing command ['tar', '-xz', '-f', '/path/to/file.tgz'] in directory '/path/to/extractdir'
  <snip>
  Succeeded: 1 (changed=1)