### PR TITLE
fix for mod_aggregate in pkg.py (state module), if fromrepo is used

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -2493,6 +2493,9 @@ def mod_aggregate(low, chunks, running):
             # Check for the same function
             if chunk.get('fun') != low.get('fun'):
                 continue
+            # Check for the same repo
+            if chunk.get('fromrepo') != low.get('fromrepo'):
+                continue
             # Pull out the pkg names!
             if 'pkgs' in chunk:
                 pkgs.extend(chunk['pkgs'])


### PR DESCRIPTION
### What does this PR do?

Fix the problem that pkgs from different repos are aggregated.
### What issues does this PR fix or reference?
#16986
### Tests written?

No

Fix saltstack/salt#16986