### PR TITLE
Properly gate makostack

### DIFF
--- a/salt/pillar/makostack.py
+++ b/salt/pillar/makostack.py
@@ -352,11 +352,28 @@ import logging
 from functools import partial
 
 import yaml
-from mako.lookup import TemplateLookup
-from mako import exceptions
+
+try:
+    from mako.lookup import TemplateLookup
+    from mako import exceptions
+    HAS_MAKO = True
+except ImportError:
+    HAS_MAKO = False
 
 log = logging.getLogger(__name__)
 strategies = ('overwrite', 'merge-first', 'merge-last', 'remove')
+
+__virtualname__ = 'makostack'
+
+
+# Only load in this module if the EC2 configurations are in place
+def __virtual__():
+    '''
+    Set up the libcloud functions and check for EC2 configurations
+    '''
+    if HAS_MAKO is True:
+        return __virtualname__
+    return False
 
 
 def ext_pillar(minion_id, pillar, *args, **kwargs):


### PR DESCRIPTION
### What does this PR do?

Properly gate the `makostack` pillar.
### What issues does this PR fix or reference?

None known.
### Previous Behavior

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1312, in _load_module
    ), fn_, fpath, desc)
  File "/usr/lib/python2.7/site-packages/salt/utils/mako.py", line 12, in <module>
    from mako.lookup import TemplateCollection, TemplateLookup  # pylint: disable=import-error
  File "/usr/lib/python2.7/site-packages/salt/utils/mako.py", line 12, in <module>
    from mako.lookup import TemplateCollection, TemplateLookup  # pylint: disable=import-error
ImportError: No module named lookup
```
### Tests written?

No.