### PR TITLE
Properly gate pythoncom

### DIFF
--- a/salt/utils/winapi.py
+++ b/salt/utils/winapi.py
@@ -15,8 +15,6 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
-__salt__ = None
-
 
 def __virtual__():
     '''
@@ -25,9 +23,6 @@ def __virtual__():
     if not HAS_LIBS:
         return False
     else:
-        global __salt__
-        if not __salt__:
-            __salt__ = minion_mods(__opts__)
         return True
 
 

--- a/salt/utils/winapi.py
+++ b/salt/utils/winapi.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 # Import python libs
 import logging
 import threading
-from salt.loader import minion_mods
 
 try:
     import pythoncom

--- a/salt/utils/winapi.py
+++ b/salt/utils/winapi.py
@@ -4,10 +4,31 @@ from __future__ import absolute_import
 
 # Import python libs
 import logging
-import pythoncom
 import threading
+from salt.loader import minion_mods
+
+try:
+    import pythoncom
+    HAS_LIBS = True
+except ImportError:
+    HAS_LIBS = False
 
 log = logging.getLogger(__name__)
+
+__salt__ = None
+
+
+def __virtual__():
+    '''
+    Only load if required libraries exist
+    '''
+    if not HAS_LIBS:
+        return False
+    else:
+        global __salt__
+        if not __salt__:
+            __salt__ = minion_mods(__opts__)
+        return True
 
 
 class Com(object):


### PR DESCRIPTION
### What does this PR do?

Properly gate `remcom` in the `winapi` module. Ping @UtahDave @twangboy. This is largely unfamiliar territory to me, so would one of you please verify this?
### What issues does this PR fix or reference?

Ref #34614, which resolves a similar issue.
### Previous Behavior

```
[DEBUG   ] Failed to import utils winapi:
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1312, in _load_module
    ), fn_, fpath, desc)
  File "/usr/lib/python2.7/site-packages/salt/utils/winapi.py", line 7, in <module>
    import pythoncom
ImportError: No module named pythoncom
[DEBUG   ] Failed to import utils winservice:
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1312, in _load_module
    ), fn_, fpath, desc)
  File "/usr/lib/python2.7/site-packages/salt/utils/winservice.py", line 11, in <module>
    import win32serviceutil
ImportError: No module named win32serviceutil
```
### Tests written?

No.