### PR TITLE
Fixed a TypeError in local_cache

### DIFF
--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -254,6 +254,7 @@ def save_minions(jid, minions, syndic_id=None):
         ' from syndic master \'{0}\''.format(syndic_id) if syndic_id else '',
         minions
     )
+    minions = list(minions)
     serial = salt.payload.Serial(__opts__)
 
     jid_dir = _jid_dir(jid)


### PR DESCRIPTION
### What does this PR do?

It fixes a bug in local_cache.py that is broken on python 3.5:

```
$ python --version
Python 3.5.1
$ salt-ssh -l debug vm test.ping
[DEBUG   ] LazyLoaded roots.envs
[DEBUG   ] Could not LazyLoad roots.init
[DEBUG   ] Updating roots fileserver cache
[DEBUG   ] LazyLoaded local_cache.prep_jid
[DEBUG   ] Adding minions for job 20160712220022612666: dict_keys(['vm'])
[ERROR   ] can't serialize dict_keys(['vm'])
Traceback (most recent call last):
  File "/Users/farcaller/src/salt/salt/client/ssh/__init__.py", line 572, in run
    self.returners['{0}.save_load'.format(self.opts['master_job_cache'])](jid, job_load, minions=self.targets.keys())
  File "/Users/farcaller/src/salt/salt/returners/local_cache.py", line 244, in save_load
    save_minions(jid, minions)
  File "/Users/farcaller/src/salt/salt/returners/local_cache.py", line 274, in save_minions
    serial.dump(minions, salt.utils.fopen(minions_path, 'w+b'))
  File "/Users/farcaller/src/salt/salt/payload.py", line 224, in dump
    fn_.write(self.dumps(msg))
  File "/Users/farcaller/src/salt/salt/payload.py", line 141, in dumps
    return msgpack.dumps(msg)
  File "/Users/farcaller/src/salt/.venv/lib/python3.5/site-packages/msgpack/__init__.py", line 47, in packb
    return Packer(**kwargs).pack(o)
  File "msgpack/_packer.pyx", line 231, in msgpack._packer.Packer.pack (msgpack/_packer.cpp:231)
  File "msgpack/_packer.pyx", line 233, in msgpack._packer.Packer.pack (msgpack/_packer.cpp:233)
  File "msgpack/_packer.pyx", line 228, in msgpack._packer.Packer._pack (msgpack/_packer.cpp:228)
TypeError: can't serialize dict_keys(['vm'])
[ERROR   ] Could not save load with returner local_cache: can't serialize dict_keys(['vm'])
[DEBUG   ] Could not LazyLoad test.ping
```
### Tests written?

No
