### PR TITLE
Suse Leap doesn't have 'man'

### DIFF
--- a/tests/unit/modules/zfs_test.py
+++ b/tests/unit/modules/zfs_test.py
@@ -359,6 +359,7 @@ class ZfsTestCase(TestCase):
             self.assertEqual(zfs.promote('myzpool/yesterday'), res)
 
     @patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
+    @patch('salt.utils.which', MagicMock(return_value='/usr/bin/man'))
     def test_bookmark_success(self):
         '''
         Tests zfs bookmark success


### PR DESCRIPTION
### What does this PR do?

ZFS.bookmark unit test is failing because OpenSuse doesn't have `man`. 

``` bash
opensuse: % man ls
-bash: man: command not found
```

This mocks salt.utils.which() to give it a path so the test can run. 
### What issues does this PR fix or reference?

No open issues. fixes failing test. 
### Tests written?

Yes