### PR TITLE
Properly pass in userdata as string

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1702,7 +1702,7 @@ def request_instance(vm_=None, call=None):
         blacklist = __opts__['renderer_blacklist']
         whitelist = __opts__['renderer_whitelist']
         userdata = compile_template(
-            userdata, rend, renderer, blacklist, whitelist
+            ':string:', rend, renderer, blacklist, whitelist, input_data=userdata,
         )
 
         params[spot_prefix + 'UserData'] = base64.b64encode(userdata)


### PR DESCRIPTION
### What does this PR do?

`compile_template` expects a file name, not a string. Normally we would just pass in `userdata_file`, but we want to be able to handle raw `userdata` as well. Because of situations like this, `compile_template()` was modified to accept a token to let it know that it's getting raw data.
### What issues does this PR fix or reference?
#34610
### Previous Behavior

Data was passed in improperly.
### Tests written?

No.