### PR TITLE
Add regex support to event_return_whitelist and event_return_blacklist

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -515,7 +515,7 @@ By default, events are not queued.
 
 Default: ``[]``
 
-Only return events matching tags in a whitelist.
+Only return events where the tag matches a regex in the whitelist.
 
 .. code-block:: yaml
 
@@ -532,7 +532,7 @@ Only return events matching tags in a whitelist.
 
 Default: ``[]``
 
-Store all event returns _except_ the tags in a blacklist.
+Return events where the tag does not match a regex in blacklist.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
### What does this PR do?

Added regex support to the event_return_whitelist and event_return_blacklist, and fixes the logic of whitelisting to standard whitelisting logic. (i.e. if a whitelist exists, assume all others are blacklisted). Includes documentation updates to clarify that the values should be regexes.
### What issues does this PR fix or reference?

Fixes #34153 
### Previous Behavior

Used exact string match, and defaulted to whitelisted unless events were specifically blacklisted.
### New Behavior

Uses a regex match, and defaults to blacklisted iff a whitelist is set.
### Tests written?

No
