### PR TITLE
Libcloud DNS module fix

### DIFF
--- a/salt/modules/libcloud_dns.py
+++ b/salt/modules/libcloud_dns.py
@@ -73,7 +73,7 @@ def _get_driver(profile):
     key = config.get('key')
     secret = config.get('secret', None)
     secure = config.get('secure', True)
-    host = config.get('jost', None)
+    host = config.get('host', None)
     port = config.get('port', None)
     return cls(key, secret, secure, host, port)
 

--- a/salt/modules/libcloud_dns.py
+++ b/salt/modules/libcloud_dns.py
@@ -63,8 +63,6 @@ def __virtual__():
 
 def __init__(opts):
     salt.utils.compat.pack_dunder(__name__)
-    if HAS_LIBCLOUD:
-        __utils__['libcloud.assign_funcs'](__name__, 'dns', pack=__salt__)
 
 
 def _get_driver(profile):

--- a/tests/unit/modules/libcloud_dns_test.py
+++ b/tests/unit/modules/libcloud_dns_test.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Anthony Shaw <anthonyshaw@apache.org>`
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+
+# Import Salt Testing Libs
+from salttesting import skipIf
+from tests.unit import ModuleTestCase, hasDependency
+from salttesting.mock import (
+    patch,
+    MagicMock,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+from salttesting.helpers import ensure_in_syspath
+from salt.modules import libcloud_dns
+
+ensure_in_syspath('../../')
+
+SERVICE_NAME = 'libcloud_dns'
+libcloud_dns.__salt__ = {}
+
+
+class MockDNSDriver(object):
+    def __init__(self):
+        pass
+
+
+def get_mock_driver():
+    return MockDNSDriver()
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@patch('salt.modules.libcloud_dns._get_driver',
+       MagicMock(return_value=MockDNSDriver()))
+class LibcloudDnsModuleTestCase(ModuleTestCase):
+    def setUp(self):
+        hasDependency('libcloud')
+
+        def get_config(service):
+            if service == SERVICE_NAME:
+                return {
+                    'test': {
+                        'driver': 'test',
+                        'key': '2orgk34kgk34g'
+                    }
+                }
+            else:
+                raise KeyError("service name invalid")
+
+        self.setup_loader()
+        self.loader.set_result(libcloud_dns, 'config.option', get_config)
+
+    def test_module_creation(self, *args):
+        client = libcloud_dns._get_driver('test')
+        self.assertFalse(client is None)
+
+
+if __name__ == '__main__':
+    from unit import run_tests
+    run_tests(LibcloudDnsModuleTestCase)

--- a/tests/unit/modules/libcloud_dns_test.py
+++ b/tests/unit/modules/libcloud_dns_test.py
@@ -62,7 +62,7 @@ class LibcloudDnsModuleTestCase(ModuleTestCase):
     def test_init(self):
         with patch('salt.utils.compat.pack_dunder', return_value=False) as dunder:
             libcloud_dns.__init__(None)
-            dunder.assert_called_with()
+            dunder.assert_called_with('salt.modules.libcloud_dns')
 
 
 if __name__ == '__main__':

--- a/tests/unit/modules/libcloud_dns_test.py
+++ b/tests/unit/modules/libcloud_dns_test.py
@@ -22,6 +22,7 @@ ensure_in_syspath('../../')
 
 SERVICE_NAME = 'libcloud_dns'
 libcloud_dns.__salt__ = {}
+libcloud_dns.__utils__ = {}
 
 
 class MockDNSDriver(object):
@@ -57,6 +58,11 @@ class LibcloudDnsModuleTestCase(ModuleTestCase):
     def test_module_creation(self, *args):
         client = libcloud_dns._get_driver('test')
         self.assertFalse(client is None)
+
+    def test_init(self):
+        with patch('salt.utils.compat.pack_dunder', return_value=False) as dunder:
+            libcloud_dns.__init__(None)
+            dunder.assert_called_with()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?

Fixes a call to `__util__` for a module which does not exist. Also fixes a typo in the configuration dictionary.
### What issues does this PR fix or reference?

Fixes saltstack/salt#34613 
### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.