### PR TITLE
Try to create the log directory when not present yet

### DIFF
--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -631,6 +631,19 @@ def setup_logfile_logger(log_path, log_level='error', log_format=None,
             shutdown_multiprocessing_logging_listener()
             sys.exit(2)
     else:
+        # make sure, the logging directory exists and attempt to create it if necessary
+        log_dir = os.path.dirname(log_path)
+        if not os.path.exists(log_dir):
+            logging.getLogger(__name__).info(
+                'Log directory not found, trying to create it: {0}'.format(log_dir)
+            )
+            try:
+                os.makedirs(log_dir, mode=0o700)
+            except OSError as ose:
+                logging.getLogger(__name__).warning(
+                    'Failed to create directory for log file: {0} ({1})'.format(log_dir, ose)
+                )
+                return
         try:
             # Logfile logging is UTF-8 on purpose.
             # Since salt uses YAML and YAML uses either UTF-8 or UTF-16, if a


### PR DESCRIPTION
### What does this PR do?

When the log directory does not exist yet, Salt will attempt to create it now.
### What issues does this PR fix or reference?

None I know of
### Previous Behavior

When the log directory (default: `/var/log/salt`) didn't exist, Salt simply failed:

```
[WARNING ] Failed to open log file, do you have permission to write to /var/log/salt/minion?
```
### New Behavior

Salt will now attempt to create the required directory in this case:

```
[INFO    ] Log directory not found, trying to create it: /var/log/salt
```
### Tests written?

No