### PR TITLE
Added rawfile_json returner, writes directly to local file

### DIFF
--- a/doc/ref/returners/all/index.rst
+++ b/doc/ref/returners/all/index.rst
@@ -34,6 +34,7 @@ returner modules
     postgres
     postgres_local_cache
     pushover_returner
+    rawfile_json
     redis_return
     sentry_return
     slack_returner

--- a/salt/returners/rawfile_json.py
+++ b/salt/returners/rawfile_json.py
@@ -22,10 +22,7 @@ import logging
 import json
 
 import salt.returners
-<<<<<<< HEAD
 import salt.utils
-=======
->>>>>>> Added rawfile_json returner
 
 log = logging.getLogger(__name__)
 

--- a/salt/returners/rawfile_json.py
+++ b/salt/returners/rawfile_json.py
@@ -22,6 +22,7 @@ import logging
 import json
 
 import salt.returners
+import salt.utils
 
 log = logging.getLogger(__name__)
 
@@ -35,7 +36,7 @@ def __virtual__():
 
 def _get_options(ret):
     '''
-    Returns options used for the carbon returner.
+    Returns options used for the rawfile_json returner.
     '''
     defaults = {'filename': '/var/log/salt/events'}
     attrs = {'filename': 'filename'}
@@ -55,7 +56,7 @@ def returner(ret):
     '''
     opts = _get_options({})  # Pass in empty ret, since this is a list of events
     try:
-        with open(opts['filename'], 'a') as logfile:
+        with salt.utils.flopen(opts['filename'], 'a') as logfile:
             logfile.write(str(ret)+'\n')
     except:
         log.error('Could not write to rawdata_json file {0}'.format(opts['filename']))
@@ -68,7 +69,7 @@ def event_return(event):
     '''
     opts = _get_options({})  # Pass in empty ret, since this is a list of events
     try:
-        with open(opts['filename'], 'a') as logfile:
+        with salt.utils.flopen(opts['filename'], 'a') as logfile:
             for e in event:
                 logfile.write(str(json.dumps(e))+'\n')
     except:

--- a/salt/returners/rawfile_json.py
+++ b/salt/returners/rawfile_json.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+'''
+Take data from salt and "return" it into a raw file containing the json, with one line per event.
+
+Add the following to the minion or master configuration file.
+
+... code-block: yaml
+
+    rawfile_json.filename: <path_to_output_file>
+
+Default is /var/log/salt/events.
+
+Common use is to log all events on the master. This can generate a lot of
+noise, so you may wish to configure batch processing and/or configure the
+event_return_whitelist or event_return_blacklist to restrict the events
+that are written.
+'''
+
+# Import python libs
+from __future__ import absolute_import, print_function, with_statement
+import logging
+import json
+
+import salt.returners
+
+log = logging.getLogger(__name__)
+
+# Define the module's virtual name
+__virtualname__ = 'rawfile_json'
+
+
+def __virtual__():
+    return __virtualname__
+
+
+def _get_options(ret):
+    '''
+    Returns options used for the carbon returner.
+    '''
+    defaults = {'filename': '/var/log/salt/events'}
+    attrs = {'filename': 'filename'}
+    _options = salt.returners.get_returner_options(__virtualname__,
+                                                   ret,
+                                                   attrs,
+                                                   __salt__=__salt__,
+                                                   __opts__=__opts__,
+                                                   defaults=defaults)
+
+    return _options
+
+
+def returner(ret):
+    '''
+    Write the return data to a file on the minion.
+    '''
+    opts = _get_options({})  # Pass in empty ret, since this is a list of events
+    try:
+        with open(opts['filename'], 'a') as logfile:
+            logfile.write(str(ret)+'\n')
+    except:
+        log.error('Could not write to rawdata_json file {0}'.format(opts['filename']))
+        raise
+
+
+def event_return(event):
+    '''
+    Write event return data to a file on the master.
+    '''
+    opts = _get_options({})  # Pass in empty ret, since this is a list of events
+    try:
+        with open(opts['filename'], 'a') as logfile:
+            for e in event:
+                logfile.write(str(json.dumps(e))+'\n')
+    except:
+        log.error('Could not write to rawdata_json file {0}'.format(opts['rawfile']))
+        raise

--- a/salt/returners/rawfile_json.py
+++ b/salt/returners/rawfile_json.py
@@ -22,7 +22,10 @@ import logging
 import json
 
 import salt.returners
+<<<<<<< HEAD
 import salt.utils
+=======
+>>>>>>> Added rawfile_json returner
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
### What does this PR do?

Adds a simple returner that dumps the json for returned events to a file on the local filesystem for easy parsing by other software. This returner writes to a file on the local filesystem of either the minion (in the event of --return) or of the master (when using event_return).
### What issues does this PR fix or reference?

None
### New Behavior

Filename can be specified by custom variable. If configured as a returner, will output event data in JSON format to a raw file.
### Tests written?

No