### PR TITLE
Gate the Public IP ssh_interfaces warning a little better

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2066,8 +2066,7 @@ def query_instance(vm_=None, call=None):
 
         if ssh_interface(vm_) == 'public_ips' and 'ipAddress' in data[0]['instancesSet']['item']:
             log.error(
-                'Public IP not detected.  If private IP is meant for bootstrap you must specify '
-                '"ssh_interface: private_ips" in your profile.'
+                'Public IP not detected.'
             )
             return data
         if ssh_interface(vm_) == 'private_ips' and \

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2064,9 +2064,10 @@ def query_instance(vm_=None, call=None):
 
         log.debug('Returned query data: {0}'.format(data))
 
-        if 'ipAddress' in data[0]['instancesSet']['item']:
+        if ssh_interface(vm_) == 'public_ips' and 'ipAddress' in data[0]['instancesSet']['item']:
             log.error(
-                'Public IP not detected.  If private IP is meant for bootstrap you must specify "ssh_interface: private_ips" in your profile.'
+                'Public IP not detected.  If private IP is meant for bootstrap you must specify '
+                '"ssh_interface: private_ips" in your profile.'
             )
             return data
         if ssh_interface(vm_) == 'private_ips' and \


### PR DESCRIPTION
### What does this PR do?

Checks explicitly for the ssh_interface setting (defaults to `public_ips`) before logging the `Public IP no detected. ...` error message.
### What issues does this PR fix or reference?

Fixes saltstack/salt#34627
### Previous Behavior

Even if `ssh_interface: private_ips` was set in an ec2 cloud config, the `Public IP not detected ...` error message would show up in the logs.
### New Behavior

Error message doesn't show up in the logs if `private_ips` is set for `ssh_interface`.
### Tests written?

No