### PR TITLE
Check that mysqladmin exists before running mysql integration tests

### DIFF
--- a/tests/integration/modules/mysql.py
+++ b/tests/integration/modules/mysql.py
@@ -14,6 +14,7 @@ ensure_in_syspath('../../')
 
 # Import salt libs
 import integration
+import salt.utils
 from salt.modules import mysql as mysqlmod
 
 # Import 3rd-party libs
@@ -26,6 +27,9 @@ NO_MYSQL = False
 try:
     import MySQLdb  # pylint: disable=import-error,unused-import
 except Exception:
+    NO_MYSQL = True
+
+if not salt.utils.which('mysqladmin'):
     NO_MYSQL = True
 
 


### PR DESCRIPTION
### What does this PR do?

Checks that mysqladmin bin exists before the tests are run. If it doesn't, skip the tests. 
### What issues does this PR fix or reference?

Cleans up unecessary errors from test log. 
### Tests written?

Yes