### PR TITLE
fix augeas module so shlex doesn't strip quotes

### DIFF
--- a/salt/modules/augeas_cfg.py
+++ b/salt/modules/augeas_cfg.py
@@ -199,7 +199,7 @@ def execute(context=None, lens=None, commands=(), load_path=None):
             method = METHOD_MAP[cmd]
             nargs = arg_map[method]
 
-            parts = salt.utils.shlex_split(arg)
+            parts = salt.utils.shlex_split(arg, posix=False)
 
             if len(parts) not in nargs:
                 err = '{0} takes {1} args: {2}'.format(method, nargs, parts)


### PR DESCRIPTION
### What does this PR do?

This change make it so shlex for the augeas module does not use posix and there for does not strip quotes for arguments
### What issues does this PR fix or reference?

saltstack/salt#34640 
### Previous Behavior

With some additional logging added the issue is apparent that the double quotes have been stripped from the path.
`{'path': '/files/etc/fstab/*[file=/tmp]/opt[last()]', 'before': False, 'label': 'opt'}`
### New Behavior

With some additional logging added the issue is apparent that the double quotes have been stripped from the path.
`{'path': '/files/etc/fstab/*[file="/tmp"]/opt[last()]', 'before': False, 'label': 'opt'}`
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.