### PR TITLE
Glob matching patterns in `event_return_whitelist` and `event_return_blacklist`

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -131,15 +131,15 @@
 # By default, events are not queued.
 #event_return_queue: 0
 
-# Only return events matching tags in a whitelist,
-# event_return_whitelist:
-#   - salt/master/a_tag
-#   - salt/master/another_tag
+# Only return events matching tags in a whitelist, supports glob matches.
+#event_return_whitelist:
+#  - salt/master/a_tag
+#  - salt/run/*/ret
 
-# Store all event returns _except_ the tags in a blacklist.
-# event_return_blacklist:
-#   - salt/master/not_this_tag
-#   - salt/master/or_this_one
+# Store all event returns **except** the tags in a blacklist, supports globs.
+#event_return_blacklist:
+#  - salt/master/not_this_tag
+#  - salt/wheel/*/ret
 
 # Passing very large events can cause the minion to consume large amounts of
 # memory. This value tunes the maximum size of a message allowed onto the

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -229,6 +229,7 @@ The directory to store the pki authentication keys.
 ---------------------
 
 .. versionchanged:: 2016.3.0
+
     The default location for this directory has been moved. Prior to this
     version, the location was a directory named ``extmods`` in the Salt
     cachedir (on most platforms, ``/var/cache/salt/extmods``). It has been
@@ -517,11 +518,15 @@ Default: ``[]``
 
 Only return events matching tags in a whitelist.
 
+.. versionchanged:: 2016.3.2
+
+    Supports glob matching patterns.
+
 .. code-block:: yaml
 
     event_return_whitelist:
       - salt/master/a_tag
-      - salt/master/another_tag
+      - salt/run/*/ret
 
 .. conf_master:: event_return_blacklist
 
@@ -534,11 +539,15 @@ Default: ``[]``
 
 Store all event returns _except_ the tags in a blacklist.
 
+.. versionchanged:: 2016.3.2
+
+    Supports glob matching patterns.
+
 .. code-block:: yaml
 
     event_return_blacklist:
       - salt/master/not_this_tag
-      - salt/master/or_this_one
+      - salt/wheel/*/ret
 
 .. conf_master:: max_event_size
 
@@ -1537,6 +1546,7 @@ Defines which branch/tag should be used as the ``base`` environment.
     gitfs_base: salt
 
 .. versionchanged:: 2014.7.0
+
     Ability to specify the base on a per-remote basis was added. See :ref:`here
     <gitfs-per-remote-config>` for more info.
 
@@ -3265,6 +3275,7 @@ used.
 ---------------
 
 .. versionchanged:: 2015.8.0
+
     Renamed from ``win_repo`` to ``winrepo_dir``.
 
 Default: ``/srv/salt/win/repo``
@@ -3301,9 +3312,11 @@ out for 2015.8.0 and later minions.
 ---------------------
 
 .. versionchanged:: 2015.8.0
+
     Renamed from ``win_repo_mastercachefile`` to ``winrepo_cachefile``
 
 .. note::
+
     2015.8.0 and later minions do not use this setting since the cachefile
     is now located on the minion.
 
@@ -3323,6 +3336,7 @@ created.
 -------------------
 
 .. versionchanged:: 2015.8.0
+
     Renamed from ``win_gitrepos`` to ``winrepo_remotes``.
 
 Default: ``['https://github.com/saltstack/salt-winrepo.git']``

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -1107,14 +1107,19 @@ class EventReturn(salt.utils.process.SignalHandlingMultiprocessingProcess):
         Returns True if event should be stored, else False
         '''
         tag = event['tag']
-        if tag in self.opts['event_return_whitelist']:
-            if tag not in self.opts['event_return_blacklist']:
-                return True
-            else:
-                return False  # Event was whitelisted and blacklisted
-        elif tag in self.opts['event_return_blacklist']:
-            return False
-        return True
+        if self.opts['event_return_whitelist']:
+            ret = False
+        else:
+            ret = True
+        for whitelist_match in self.opts['event_return_whitelist']:
+            if fnmatch.fnmatch(tag, whitelist_match):
+                ret = True
+                break
+        for blacklist_match in self.opts['event_return_blacklist']:
+            if fnmatch.fnmatch(tag, blacklist_match):
+                ret = False
+                break
+        return ret
 
 
 class StateFire(object):


### PR DESCRIPTION
### What does this PR do?

Allows to specify glob patterns to match event tags in `event_return_whitelist` and `event_return_blacklist` Master config options the similar way like you do it in Reactor SLS files.
It would become possible to select events passed to the module configured in `event_return` option more flexibly.
### Previous Behavior

`event_return_whitelist` and `event_return_blacklist` options only support exact match for the event tags.
### New Behavior

The both options support glob matching patterns, i.e.:

``` yaml
event_return_whitelist:
  - salt/run/*/ret
```

Salt Master configuration file example and documentation have been updated accordingly.
### Tests written?

No
