### PR TITLE
Added error message if the sqs_events engine cannot be imported

### DIFF
--- a/salt/engines/sqs_events.py
+++ b/salt/engines/sqs_events.py
@@ -70,7 +70,7 @@ from salt.ext.six import string_types
 
 def __virtual__():
     if not HAS_BOTO:
-        return False
+        return (False, 'Cannot import engine sqs_events because the required boto module is missing')
     else:
         return True
 


### PR DESCRIPTION
### What does this PR do?

Adds an error message (logged to the master log) if the required boto library cannot be found on the system
### Previous Behavior

Previously only returned False to the main Engine module which made it hard to find the source of the problem
### New Behavior

A log event is recorded in salt master log.
### Tests written?

No. Behaviour is not changed, only visibility is better