### PR TITLE
Fix publisher leak

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -243,6 +243,14 @@
 # ZMQ high-water-mark for EventPublisher pub socket
 #event_publisher_pub_hwm: 10000
 
+# The master may allocate memory per-event and not
+# reclaim it.
+# To set a high-water mark for memory allocation, use
+# ipc_write_buffer to set a high-water mark for message
+# buffering.
+# Value: In bytes. Set to 'dynamic' to have Salt select
+# a value for you. Default is disabled.
+# ipc_write_buffer: 'dynamic'
 
 
 #####        Security settings       #####

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -969,6 +969,7 @@ DEFAULT_MINION_OPTS = {
     'mine_return_job': False,
     'mine_interval': 60,
     'ipc_mode': _DFLT_IPC_MODE,
+    'ipc_write_buffer': _DFLT_IPC_WBUFFER,
     'ipv6': False,
     'file_buffer_size': 262144,
     'tcp_pub_port': 4510,

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -84,7 +84,7 @@ def _gather_buffer_space():
         grains = salt.grains.core._memdata(os_data)
         total_mem = grains['mem_total']
     # Return the higher number between 5% of the system memory and 100MB
-    return min([total_mem * 0.05, 10 << 20])
+    return max([total_mem * 0.05, 10 << 20])
 
 # For the time being this will be a fixed calculation
 # TODO: Allow user configuration

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2979,11 +2979,11 @@ def apply_minion_config(overrides=None,
     # if there is no beacons option yet, add an empty beacons dict
     if 'beacons' not in opts:
         opts['beacons'] = {}
-    
+
     if overrides.get('ipc_write_buffer', '') == 'dynamic':
         opts['ipc_write_buffer'] = _DFLT_IPC_WBUFFER
     if 'ipc_write_buffer' not in overrides:
-        opts['ipc_write_buffer'] = 0 
+        opts['ipc_write_buffer'] = 0
 
     # if there is no schedule option yet, add an empty scheduler
     if 'schedule' not in opts:
@@ -3062,7 +3062,7 @@ def apply_master_config(overrides=None, defaults=None):
     if overrides.get('ipc_write_buffer', '') == 'dynamic':
         opts['ipc_write_buffer'] = _DFLT_IPC_WBUFFER
     if 'ipc_write_buffer' not in overrides:
-        opts['ipc_write_buffer'] = 0 
+        opts['ipc_write_buffer'] = 0
     using_ip_for_id = False
     append_master = False
     if not opts.get('id'):

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -67,6 +67,7 @@ else:
     _DFLT_IPC_MODE = 'ipc'
     _MASTER_TRIES = 1
 
+
 def _gather_buffer_space():
     '''
     Gather some system data and then calculate
@@ -1575,7 +1576,6 @@ def _read_conf_file(path):
                 # We do not want unicode settings
                 conf_opts[key] = value.encode('utf-8')
         return conf_opts
-
 
 
 def _absolute_path(path, relative_to=None):

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -83,7 +83,7 @@ def _gather_buffer_space():
         grains = salt.grains.core._memdata(os_data)
         total_mem = grains['mem_total']
     # Return the higher number between 5% of the system memory and 100MB
-    return min([total_mem * 0.05, 100 << 20])
+    return min([total_mem * 0.05, 10 << 20])
 
 # For the time being this will be a fixed calculation
 # TODO: Allow user configuration

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2979,6 +2979,11 @@ def apply_minion_config(overrides=None,
     # if there is no beacons option yet, add an empty beacons dict
     if 'beacons' not in opts:
         opts['beacons'] = {}
+    
+    if overrides.get('ipc_write_buffer', '') == 'dynamic':
+        opts['ipc_write_buffer'] = _DFLT_IPC_WBUFFER
+    if 'ipc_write_buffer' not in overrides:
+        opts['ipc_write_buffer'] = 0 
 
     # if there is no schedule option yet, add an empty scheduler
     if 'schedule' not in opts:
@@ -3054,7 +3059,10 @@ def apply_master_config(overrides=None, defaults=None):
     )
     opts['token_dir'] = os.path.join(opts['cachedir'], 'tokens')
     opts['syndic_dir'] = os.path.join(opts['cachedir'], 'syndics')
-
+    if overrides.get('ipc_write_buffer', '') == 'dynamic':
+        opts['ipc_write_buffer'] = _DFLT_IPC_WBUFFER
+    if 'ipc_write_buffer' not in overrides:
+        opts['ipc_write_buffer'] = 0 
     using_ip_for_id = False
     append_master = False
     if not opts.get('id'):

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -431,9 +431,10 @@ class IPCMessagePublisher(object):
     A Tornado IPC Publisher similar to Tornado's TCPServer class
     but using either UNIX domain sockets or TCP sockets
     '''
-    def __init__(self, socket_path, io_loop=None):
+    def __init__(self, opts, socket_path, io_loop=None):
         '''
         Create a new Tornado IPC server
+        :param dict opts: Salt options
         :param str/int socket_path: Path on the filesystem for the
                                     socket to bind to. This socket does
                                     not need to exist prior to calling
@@ -444,6 +445,7 @@ class IPCMessagePublisher(object):
                                     for a tcp localhost connection.
         :param IOLoop io_loop: A Tornado ioloop to handle scheduling
         '''
+        self.opts = opts
         self.socket_path = socket_path
         self._started = False
 
@@ -505,10 +507,12 @@ class IPCMessagePublisher(object):
 
     def handle_connection(self, connection, address):
         log.trace('IPCServer: Handling connection to address: {0}'.format(address))
+        log.debug('BUFFER SET: {0}'.format(self.opts['ipc_write_buffer']))
         try:
             stream = IOStream(
                 connection,
                 io_loop=self.io_loop,
+                max__buffer_size = self.opts['ipc_write_buffer']
             )
             self.streams.add(stream)
         except Exception as exc:

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -507,13 +507,18 @@ class IPCMessagePublisher(object):
 
     def handle_connection(self, connection, address):
         log.trace('IPCServer: Handling connection to address: {0}'.format(address))
-        log.trace('IPCPublisher write buffer set to: {0}'.format(self.opts['ipc_write_buffer']))
         try:
-            stream = IOStream(
-                connection,
-                io_loop=self.io_loop,
-                max_write_buffer_size=self.opts['ipc_write_buffer']
-            )
+            if self.opts['ipc_write_buffer']:
+                stream = IOStream(
+                    connection,
+                    io_loop=self.io_loop,
+                    max_write_buffer_size=self.opts['ipc_write_buffer']
+                )
+            else:
+                stream = IOStream(
+                    connection,
+                    io_loop=self.io_loop
+                )
             self.streams.add(stream)
         except Exception as exc:
             log.error('IPC streaming error: {0}'.format(exc))

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -512,7 +512,7 @@ class IPCMessagePublisher(object):
             stream = IOStream(
                 connection,
                 io_loop=self.io_loop,
-                max_write_buffer_size = self.opts['ipc_write_buffer']
+                max_write_buffer_size=self.opts['ipc_write_buffer']
             )
             self.streams.add(stream)
         except Exception as exc:

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -508,7 +508,8 @@ class IPCMessagePublisher(object):
     def handle_connection(self, connection, address):
         log.trace('IPCServer: Handling connection to address: {0}'.format(address))
         try:
-            if self.opts['ipc_write_buffer']:
+            if self.opts['ipc_write_buffer'] > 0:
+                log.trace('Setting IPC connection write buffer: {0}'.format((self.opts['ipc_write_buffer'])))
                 stream = IOStream(
                     connection,
                     io_loop=self.io_loop,

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -507,12 +507,12 @@ class IPCMessagePublisher(object):
 
     def handle_connection(self, connection, address):
         log.trace('IPCServer: Handling connection to address: {0}'.format(address))
-        log.debug('BUFFER SET: {0}'.format(self.opts['ipc_write_buffer']))
+        log.trace('IPCPublisher write buffer set to: {0}'.format(self.opts['ipc_write_buffer']))
         try:
             stream = IOStream(
                 connection,
                 io_loop=self.io_loop,
-                max__buffer_size = self.opts['ipc_write_buffer']
+                max_buffer_size = self.opts['ipc_write_buffer']
             )
             self.streams.add(stream)
         except Exception as exc:

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -512,7 +512,7 @@ class IPCMessagePublisher(object):
             stream = IOStream(
                 connection,
                 io_loop=self.io_loop,
-                max_buffer_size = self.opts['ipc_write_buffer']
+                max_write_buffer_size = self.opts['ipc_write_buffer']
             )
             self.streams.add(stream)
         except Exception as exc:

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -865,6 +865,7 @@ class AsyncEventPublisher(object):
                         raise
 
         self.publisher = salt.transport.ipc.IPCMessagePublisher(
+            self.opts,
             epub_uri,
             io_loop=self.io_loop
         )
@@ -953,6 +954,7 @@ class EventPublisher(salt.utils.process.SignalHandlingMultiprocessingProcess):
                 )
 
             self.publisher = salt.transport.ipc.IPCMessagePublisher(
+                self.opts,
                 epub_uri,
                 io_loop=self.io_loop
             )


### PR DESCRIPTION
This is a first pass at fixing a memory leak in the IPC publisher.

See the full description of this issue in #34215. Basically, this sets a write_buffer for the publisher.

I have _not_ yet tested this to see how this performs when the buffer is full. Messages _should_ be dropped. I'd like to at least provide notification of this condition before we merge this but the feasibility of this remains to be seen.

I also want to make the buffer size user-configurable. Right now it is selected as a function of total memory on the machine.

This does, however, definitely solve the leak. When the buffer size is reached, the size of the Publisher does not continue to grow.

cc: @thatch45 @skizunov