### PR TITLE
fix second run problems with pkg.installed using sources

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -431,7 +431,7 @@ def _find_install_targets(name=None,
             # package's name and version
             err = 'Unable to cache {0}: {1}'
             try:
-                cached_path = __salt__['cp.cache_file'](val)
+                cached_path = __salt__['cp.cache_file'](val, saltenv=kwargs['saltenv'])
             except CommandExecutionError as exc:
                 problems.append(err.format(val, exc))
                 continue


### PR DESCRIPTION
### What does this PR do?

Fix second run problems with pkg.installed using sources.
It used saltenv when the sources file cached.
### What issues does this PR fix or reference?
saltstack/salt#32276
### Tests written?

No