### PR TITLE
Add NILinuxRT mod_hostname support

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -984,7 +984,8 @@ def mod_hostname(hostname):
             if 'Static hostname' in line[0]:
                 o_hostname = line[1].strip()
     elif not salt.utils.is_sunos():
-        o_hostname = __salt__['cmd.run']('{0} -f'.format(hostname_cmd))
+        # don't run hostname -f because -f is not supported on all platforms
+        o_hostname = socket.getfqdn()
     else:
         # output: Hostname core OK: fully qualified as core.acheron.be
         o_hostname = __salt__['cmd.run'](check_hostname_cmd).split(' ')[-1]
@@ -1025,7 +1026,7 @@ def mod_hostname(hostname):
                     fh_.write('HOSTNAME={0}\n'.format(hostname))
                 else:
                     fh_.write(net)
-    elif __grains__['os_family'] == 'Debian':
+    elif __grains__['os_family'] in ('Debian', 'NILinuxRT'):
         with salt.utils.fopen('/etc/hostname', 'w') as fh_:
             fh_.write(hostname + '\n')
     elif __grains__['os_family'] == 'OpenBSD':


### PR DESCRIPTION
- Coreutils hostname does not support a -f flag so an error message was
  printed whenever attempting to set the hostname. Switch to using more
  pythonic solution that does not have this issue.

Signed-off-by: Collin Richards collin.richards@ni.com