### PR TITLE
Fixed dockerng.list_tags

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -2237,7 +2237,7 @@ def list_tags():
     '''
     ret = set()
     for item in six.itervalues(images()):
-        for repo_tag in item['RepoTags']:
+        for repo_tag in item.get('RepoTags', []):
             ret.add(repo_tag)
     return sorted(ret)
 


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in dockerng module crashing when an image doesn't have tags.
### Previous Behavior

```
$ docker pull registry/image:latest
...
# update the image in the registry
$ docker pull registry/image:latest
... # pulls new image
$ docker images
REPOSITORY                          TAG                 IMAGE ID            CREATED              SIZE
registry/image               latest              b510b2249009        About a minute ago   33.23 MB
registry/image               <none>              888075fb7fb6        About an hour ago    33.23 MB
```

```
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/var/tmp/.prod_0615df_salt/py2/salt/state.py", line 1723, in call
                  **cdata['kwargs'])
                File "/var/tmp/.prod_0615df_salt/py2/salt/loader.py", line 1650, in wrapper
                  return f(*args, **kwargs)
                File "/var/tmp/.prod_0615df_salt/py2/salt/states/dockerng.py", line 1519, in running
                  if image not in __salt__['dockerng.list_tags']():
                File "/var/tmp/.prod_0615df_salt/py2/salt/modules/dockerng.py", line 2240, in list_tags
                  for repo_tag in item.get('RepoTags', []):
              TypeError: 'NoneType' object is not iterable
```
### Tests written?

No
