### PR TITLE
Check for non-existant keys when updating PagerDuty escalation policies

### DIFF
--- a/salt/states/pagerduty_escalation_policy.py
+++ b/salt/states/pagerduty_escalation_policy.py
@@ -134,7 +134,10 @@ def _diff(state_data, resource_object):
             v = _escalation_rules_to_string(v)
             resource_value = _escalation_rules_to_string(resource_object[k])
         else:
-            resource_value = resource_object[k]
+            if k not in resource_object.keys():
+                objects_differ = True
+            else:
+                resource_value = resource_object[k]
         if v != resource_value:
             objects_differ = '{0} {1} {2}'.format(k, v, resource_value)
             break


### PR DESCRIPTION
### What does this PR do?

Allows repeat_enabled and num_loops to be passed to pagerduty_escalation_policy.present.  Those fields are supported by the PagerDuty UI, but weren't supported by the pagerduty_escalation_policy state until now.
### Previous Behavior

Trying to pass those fields in would cause an exception.
### New Behavior

Sets those fields on new/update escalation polcies.
### Tests written?

No

Following the existing code, perhaps I should have done something like
this:

```
objects_differ = '{0} {1} {2}'.format(k, v, '')
```

But I don't see the value of objects_differ used as a string, only as
as a bool... so I set it as a bool.

By the way, salt/modules/pagerduty_util.py doesn't return 'changes'..
I'll open a separate issue for that.