### PR TITLE
beacons: update __grains__ variable on each tick

### DIFF
--- a/salt/beacons/__init__.py
+++ b/salt/beacons/__init__.py
@@ -26,7 +26,7 @@ class Beacon(object):
         self.beacons = salt.loader.beacons(opts, functions)
         self.interval_map = dict()
 
-    def process(self, config):
+    def process(self, config, grains):
         '''
         Process the configured beacons
         The config must be a list and looks like this in yaml
@@ -88,6 +88,8 @@ class Beacon(object):
                     if is_running:
                         log.info('Skipping beacon {0}. State run in progress.'.format(mod))
                         continue
+                # Update __grains__ on the beacon
+                self.beacons[fun_str].__globals__['__grains__'] = grains
                 # Fire the beacon!
                 raw = self.beacons[fun_str](b_config[mod])
                 for data in raw:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -397,7 +397,7 @@ class MinionBase(object):
         if 'config.merge' in functions:
             b_conf = functions['config.merge']('beacons', self.opts['beacons'], omit_opts=True)
             if b_conf:
-                return self.beacons.process(b_conf)  # pylint: disable=no-member
+                return self.beacons.process(b_conf, self.opts['grains'])  # pylint: disable=no-member
         return []
 
     @tornado.gen.coroutine


### PR DESCRIPTION
### What does this PR do?

Updates **grains** dunder with updated values before each beacon tick
### What issues does this PR fix or reference?
### Previous Behavior

**grains** dunder value was set once at load time, then never updated
### New Behavior

**grains** beacon variable is not in sync with grains outside the beacon
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

The beacon's **grains** variable is set at load time, then never
refreshed. This is inconvenient as it limits the scope of what can be
done in a beacon (can't rely on grain values that change).

Signed-off-by: Alejandro del Castillo alejandro.delcastillo@ni.com