### PR TITLE
NILinuxRT fix timezone module

### DIFF
--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -142,10 +142,10 @@ def get_zone():
         for family in ('RedHat', 'SUSE'):
             if family in os_family:
                 return _get_zone_sysconfig()
-        for family in ('Debian', 'Gentoo', 'NILinuxRT'):
+        for family in ('Debian', 'Gentoo'):
             if family in os_family:
                 return _get_zone_etc_timezone()
-        if os_family in ('FreeBSD', 'OpenBSD', 'NetBSD'):
+        if os_family in ('FreeBSD', 'OpenBSD', 'NetBSD', 'NILinuxRT'):
             return _get_zone_etc_localtime()
         elif 'Solaris' in os_family:
             return _get_zone_solaris()


### PR DESCRIPTION
### What does this PR do?

Fixes timezone.get_zone NILinuxRT uses /etc/localtime not /etc/timezone
### What issues does this PR fix or reference?

Fix mistake in commit:
57f90d2bc23e250b240a37228b3793e2b7875b18
saltstack/salt#34556
### Tests written?

No.

Sorry for the commit noise. I tested a different version of
the changes and ended up submitting the wrong code.

Signed-off-by: Collin Richards collin.richards@ni.com