### PR TITLE
Fix ldap auth for function matches

### DIFF
--- a/salt/auth/ldap.py
+++ b/salt/auth/ldap.py
@@ -391,6 +391,8 @@ def expand_ldap_entries(entries, opts=None):
     bind = _bind_for_search(opts=opts)
     acl_tree = []
     for user_or_group_dict in entries:
+        if not isinstance(user_or_group_dict, dict):
+            acl_tree.append(user_or_group_dict)
         for minion_or_ou, matchers in six.iteritems(user_or_group_dict):
             permissions = matchers
             retrieved_minion_ids = []


### PR DESCRIPTION
### What does this PR do?

The expand_ldap_entries doesn't take into account that certain entries
may not actually be dicts, such as @runner, @wheel, @jobs, or even .*
### What issues does this PR fix or reference?

When trying to use ldap auth with @runner or such, it will bomb with an exception: ExtraData: unpack(b) received extra data.
### Tests written?

No