### PR TITLE
Always loop over updated keys in non recursive update

### DIFF
--- a/salt/utils/dictupdate.py
+++ b/salt/utils/dictupdate.py
@@ -58,7 +58,8 @@ def update(dest, upd, recursive_update=True, merge_lists=False):
         return dest
     else:
         try:
-            dest.update(upd)
+            for k in upd.keys():
+                dest[k] = upd[k]
         except AttributeError:
             # this mapping is not a dict
             for k in upd:


### PR DESCRIPTION
### What does this PR do?

Remove dict.update and always use loop because this is failing for NamespacedDictWrapper
### What issues does this PR fix or reference?
saltstack/salt#34678
### Tests written?

No