### PR TITLE
modules/ebuild: Add handling for InvalidAtom exception

### DIFF
--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -1064,7 +1064,11 @@ def check_extra_requirements(pkgname, pkgver):
     else:
         return True
 
-    cpv = _porttree().dbapi.xmatch('bestmatch-visible', atom)
+    try:
+        cpv = _porttree().dbapi.xmatch('bestmatch-visible', atom)
+    except portage.exception.InvalidAtom as iae:
+        log.error('Unable to find a matching package for {0}: ({1})'.format(atom, iae))
+        return False
 
     if cpv == '':
         return False


### PR DESCRIPTION
Otherwise, an invalid pkg atom such as generated by the following state:

``` SaltStack
sys-apps/systemd:
  pkg.installed:
    - pkgs:
      - sys-apps/systemd: '[curl, importd, nat]'
```

…would lead to this backtrace:

```
          ID: sys-apps/systemd
    Function: pkg.installed
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib64/python2.7/site-packages/salt/state.py", line 1723, in call
                  **cdata['kwargs'])
                File "/usr/lib64/python2.7/site-packages/salt/loader.py", line 1650, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib64/python2.7/site-packages/salt/states/pkg.py", line 1062, in installed
                  **kwargs)
                File "/usr/lib64/python2.7/site-packages/salt/states/pkg.py", line 454, in _find_install_targets
                  if not __salt__['pkg_resource.check_extra_requirements'](key, val):
                File "/usr/lib64/python2.7/site-packages/salt/modules/pkg_resource.py", line 290, in check_extra_requirements
                  return __salt__['pkg.check_extra_requirements'](pkgname, pkgver)
                File "/usr/lib64/python2.7/site-packages/salt/modules/ebuild.py", line 1059, in check_extra_requirements
                  cpv = _porttree().dbapi.xmatch('bestmatch-visible', atom)
                File "/usr/lib64/python2.7/site-packages/portage/dbapi/porttree.py", line 835, in xmatch
                  mydep = dep_expand(origdep, mydb=self, settings=self.settings)
                File "/usr/lib64/python2.7/site-packages/portage/proxy/objectproxy.py", line 31, in __call__
                  return result(*args, **kwargs)
                File "/usr/lib64/python2.7/site-packages/portage/dbapi/dep_expand.py", line 35, in dep_expand
                  mydep = Atom(mydep, allow_repo=True)
                File "/usr/lib64/python2.7/site-packages/portage/dep/__init__.py", line 1366, in __init__
                  use = _use_dep(use_str[1:-1].split(","), eapi_attrs)
                File "/usr/lib64/python2.7/site-packages/portage/dep/__init__.py", line 855, in __init__
                  raise InvalidAtom(_("Invalid use dep: '%s'") % (x,))
              InvalidAtom: Invalid use dep: ' importd'
     Started: 21:53:35.925124
    Duration: 999.249 ms
     Changes:
```