### PR TITLE
Change iteritems() to six.iteritems in cloud, grains, and utils directories

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1434,7 +1434,7 @@ def _modify_eni_properties(eni_id, properties=None, vm_=None):
 
     params = {'Action': 'ModifyNetworkInterfaceAttribute',
               'NetworkInterfaceId': eni_id}
-    for k, v in properties.iteritems():
+    for k, v in six.iteritems(properties):
         params[k] = v
 
     retries = 5

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -1615,7 +1615,7 @@ def _get_status_descr_by_id(status_id):
     status_id
         linode VM status ID
     '''
-    for status_name, status_data in LINODE_STATUS.iteritems():
+    for status_name, status_data in six.iteritems(LINODE_STATUS):
         if status_data['code'] == int(status_id):
             return status_data['descr']
     return LINODE_STATUS.get(status_id, None)

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -669,7 +669,7 @@ def request_instance(vm_=None, call=None):
     if floating_ip_conf.get('auto_assign', False):
         pool = floating_ip_conf.get('pool', 'public')
         floating_ip = None
-        for fl_ip, opts in conn.floating_ip_list().iteritems():
+        for fl_ip, opts in six.iteritems(conn.floating_ip_list()):
             if opts['fixed_ip'] is None and opts['pool'] == pool:
                 floating_ip = fl_ip
                 break

--- a/salt/cloud/clouds/profitbricks.py
+++ b/salt/cloud/clouds/profitbricks.py
@@ -78,6 +78,7 @@ import time
 # Import salt libs
 import salt.utils
 import salt.config as config
+import salt.ext.six as six
 from salt.exceptions import (
     SaltCloudConfigError,
     SaltCloudNotFound,
@@ -317,7 +318,7 @@ def get_image(vm_):
     )
 
     images = avail_images()
-    for key, value in images.iteritems():
+    for key, value in six.iteritems(images):
         if vm_image and vm_image in (images[key]['id'], images[key]['name']):
             return images[key]
 
@@ -494,7 +495,7 @@ def create_network_interfaces(conn, datacenter_id, server_id, vm_):
     if 'private_lan' in vm_:
         lans['private_lan'] = vm_['private_lan']
 
-    for lan, lan_id in lans.iteritems():
+    for lan, lan_id in six.iteritems(lans):
         response = None
         nic = NIC(lan=lan_id, name=lan.split('_')[0])
         try:

--- a/salt/cloud/clouds/vultrpy.py
+++ b/salt/cloud/clouds/vultrpy.py
@@ -42,6 +42,7 @@ import urllib
 
 # Import salt cloud libs
 import salt.config as config
+import salt.ext.six as six
 import salt.utils.cloud
 from salt.exceptions import (
     SaltCloudConfigError,
@@ -89,15 +90,15 @@ def _cache_provider_details(conn=None):
     images = avail_images(conn)
     sizes = avail_sizes(conn)
 
-    for key, location in locations.iteritems():
+    for key, location in six.iteritems(locations):
         DETAILS['avail_locations'][location['name']] = location
         DETAILS['avail_locations'][key] = location
 
-    for key, image in images.iteritems():
+    for key, image in six.iteritems(images):
         DETAILS['avail_images'][image['name']] = image
         DETAILS['avail_images'][key] = image
 
-    for key, vm_size in sizes.iteritems():
+    for key, vm_size in six.iteritems(sizes):
         DETAILS['avail_sizes'][vm_size['name']] = vm_size
         DETAILS['avail_sizes'][key] = vm_size
 

--- a/salt/grains/junos.py
+++ b/salt/grains/junos.py
@@ -5,11 +5,18 @@ NOTE this is a little complicated--junos can only be accessed
 via salt-proxy-minion.Thus, some grains make sense to get them
 from the minion (PYTHONPATH), but others don't (ip_interfaces)
 '''
+
+# Import Python libs
 from __future__ import absolute_import
 import logging
 
+# Import Salt libs
+import salt.ext.six as six
+
 __proxyenabled__ = ['junos']
 __virtualname__ = 'junos'
+
+# Get looging started
 log = logging.getLogger(__name__)
 
 
@@ -25,7 +32,7 @@ def _remove_complex_types(dictionary):
     Linode-python is now returning some complex types that
     are not serializable by msgpack.  Kill those.
     '''
-    for k, v in dictionary.iteritems():
+    for k, v in six.iteritems(dictionary):
         if isinstance(v, dict):
             dictionary[k] = _remove_complex_types(v)
         elif hasattr(v, 'to_eng_string'):

--- a/salt/utils/configcomparer.py
+++ b/salt/utils/configcomparer.py
@@ -3,7 +3,12 @@
 Utilities for comparing and updating configurations while keeping track of
 changes in a way that can be easily reported in a state.
 """
+
+# Import Python libs
 from __future__ import absolute_import
+
+# Import Salt libs
+import salt.ext.six as six
 
 
 def compare_and_update_config(config, update_config, changes, namespace=''):
@@ -31,7 +36,7 @@ def compare_and_update_config(config, update_config, changes, namespace=''):
             # compare each key in the base config with the values in the
             # update_config, overwriting the values that are different but
             # keeping any that are not defined in config
-            for key, value in config.iteritems():
+            for key, value in six.iteritems(config):
                 _namespace = key
                 if namespace:
                     _namespace = '{0}.{1}'.format(namespace, _namespace)

--- a/salt/utils/etcd_util.py
+++ b/salt/utils/etcd_util.py
@@ -50,6 +50,7 @@ from __future__ import absolute_import
 import logging
 
 # Import salt libs
+import salt.ext.six as six
 from salt.exceptions import CommandExecutionError
 
 # Import third party libs
@@ -205,7 +206,7 @@ class EtcdClient(object):
             return {path: {}}
         path = path.strip('/')
         flat = {}
-        for k, v in data.iteritems():
+        for k, v in six.iteritems(data):
             k = k.strip('/')
             if path:
                 p = '/{0}/{1}'.format(path, k)
@@ -224,7 +225,7 @@ class EtcdClient(object):
             return None
         fields = self._flatten(fields, path)
         keys = {}
-        for k, v in fields.iteritems():
+        for k, v in six.iteritems(fields):
             is_dir = False
             if isinstance(v, dict):
                 is_dir = True

--- a/salt/utils/psutil_compat.py
+++ b/salt/utils/psutil_compat.py
@@ -10,7 +10,11 @@ Should be removed once support for psutil <2.0 is dropped. (eg RHEL 6)
 Built off of http://grodola.blogspot.com/2014/01/psutil-20-porting.html
 '''
 
+# Import Python libs
 from __future__ import absolute_import
+
+# Import Salt libs
+import salt.ext.six as six
 
 # No exception handling, as we want ImportError if psutil doesn't exist
 import psutil
@@ -103,7 +107,7 @@ else:
 
     }
 
-    for new, old in _PROCESS_FUNCTION_MAP.iteritems():
+    for new, old in six.iteritems(_PROCESS_FUNCTION_MAP):
         try:
             setattr(Process, new, psutil.Process.__dict__[old])
         except KeyError:


### PR DESCRIPTION
### What does this PR do?

Updates all of the `object.iteritems()` references to use `six.iteritems(object)` in all files using the old syntax in the `cloud/`, `grains/`, and `utils/` dirs.

This is part of the move to support running salt in Python 3.