### PR TITLE
Add an option to attach ENI to instance via name or id

### DIFF
--- a/salt/modules/boto_ec2.py
+++ b/salt/modules/boto_ec2.py
@@ -859,10 +859,11 @@ def run(image_id, name=None, tags=None, key_name=None, security_groups=None,
         raise SaltInvocationError('Only one of network_interface_id or '
                                   'network_interface_name may be provided.')
     if network_interface_name:
-        network_interface_id = get_network_interface_id(network_interface_name,
+        result = get_network_interface_id(network_interface_name,
                                                         region=region, key=key,
                                                         keyid=keyid,
                                                         profile=profile)
+        network_interface_id = result['result']
         if not network_interface_id:
             log.warning(
                 "Given network_interface_name '{0}' cannot be mapped to an "

--- a/salt/states/boto_ec2.py
+++ b/salt/states/boto_ec2.py
@@ -597,6 +597,8 @@ def instance_present(name, instance_name=None, instance_id=None, image_id=None,
                      additional_info=None, tenancy=None,
                      instance_profile_arn=None, instance_profile_name=None,
                      ebs_optimized=None, network_interfaces=None,
+                     network_interface_name = None,
+                     network_interface_id = None,
                      attributes=None, target_state=None, public_ip=None,
                      allocation_id=None, allocate_eip=False, region=None,
                      key=None, keyid=None, profile=None):
@@ -698,6 +700,12 @@ def instance_present(name, instance_name=None, instance_id=None, image_id=None,
         (boto.ec2.networkinterface.NetworkInterfaceCollection) – A
         NetworkInterfaceCollection data structure containing the ENI
         specifications for the instance.
+    network_interface_name
+         (string) - The name of Elastic Network Interface to attach
+    .. versionadded:: Carbon
+    network_interface_id 
+         (string) - The id of Elastic Network Interface to attach
+    .. versionadded:: Carbon
     attributes
         (dict) - Instance attributes and value to be applied to the instance.
         Available options are:
@@ -801,6 +809,8 @@ def instance_present(name, instance_name=None, instance_id=None, image_id=None,
                                      instance_profile_arn=instance_profile_arn,
                                      instance_profile_name=instance_profile_name,
                                      ebs_optimized=ebs_optimized, network_interfaces=network_interfaces,
+                                     network_interface_name = network_interface_name,
+                                     network_interface_id = network_interface_id,
                                      region=region, key=key, keyid=keyid, profile=profile)
         if not r or 'instance_id' not in r:
             ret['result'] = False

--- a/salt/states/boto_ec2.py
+++ b/salt/states/boto_ec2.py
@@ -597,8 +597,8 @@ def instance_present(name, instance_name=None, instance_id=None, image_id=None,
                      additional_info=None, tenancy=None,
                      instance_profile_arn=None, instance_profile_name=None,
                      ebs_optimized=None, network_interfaces=None,
-                     network_interface_name = None,
-                     network_interface_id = None,
+                     network_interface_name=None,
+                     network_interface_id=None,
                      attributes=None, target_state=None, public_ip=None,
                      allocation_id=None, allocate_eip=False, region=None,
                      key=None, keyid=None, profile=None):
@@ -703,7 +703,7 @@ def instance_present(name, instance_name=None, instance_id=None, image_id=None,
     network_interface_name
          (string) - The name of Elastic Network Interface to attach
     .. versionadded:: Carbon
-    network_interface_id 
+    network_interface_id
          (string) - The id of Elastic Network Interface to attach
     .. versionadded:: Carbon
     attributes
@@ -809,8 +809,8 @@ def instance_present(name, instance_name=None, instance_id=None, image_id=None,
                                      instance_profile_arn=instance_profile_arn,
                                      instance_profile_name=instance_profile_name,
                                      ebs_optimized=ebs_optimized, network_interfaces=network_interfaces,
-                                     network_interface_name = network_interface_name,
-                                     network_interface_id = network_interface_id,
+                                     network_interface_name=network_interface_name,
+                                     network_interface_id=network_interface_id,
                                      region=region, key=key, keyid=keyid, profile=profile)
         if not r or 'instance_id' not in r:
             ret['result'] = False


### PR DESCRIPTION
### What does this PR do?

Allows to attach ENI to AWS instance passing it by name or by id
### What issues does this PR fix or reference?

n/a
### Previous Behavior

It was not possible to attach ENI by name or id previously. network_interfaces wass declared but not implemented in module. 
### New Behavior

instance_present state receives network_interface_name or network_interface_id or is empty by default 
### Tests written?

No