### PR TITLE
Test valid docs fix

### DIFF
--- a/salt/modules/ldap3.py
+++ b/salt/modules/ldap3.py
@@ -476,6 +476,7 @@ def modify(connect_spec, dn, directives):
                 'method': 'simple',
                 'password': 'secret'}
         }" dn='cn=admin,dc=example,dc=com'
+        directives="('add', 'example', ['example_val'])"
     '''
     l = connect(connect_spec)
     # convert the "iterable of values" to lists in case that's what

--- a/salt/modules/ldap3.py
+++ b/salt/modules/ldap3.py
@@ -231,6 +231,18 @@ def connect(connect_spec=None):
 
         This object should be used as a context manager.  It is safe
         to nest ``with`` statements.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' ldap3.connect "{
+            'url': 'ldaps://ldap.example.com/',
+            'bind': {
+                'method': 'simple',
+                'dn': 'cn=admin,dc=example,dc=com',
+                'password': 'secret'}
+        }"
     '''
     if isinstance(connect_spec, _connect_ctx):
         return connect_spec
@@ -357,6 +369,18 @@ def add(connect_spec, dn, attributes):
 
     :returns:
         ``True`` if successful, raises an exception otherwise.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' ldap3.add "{
+            'url': 'ldaps://ldap.example.com/',
+            'bind': {
+                'method': 'simple',
+                'password': 'secret',
+            },
+        }" "dn='dc=example,dc=com'" "attributes={'example': 'values'}"
     '''
     l = connect(connect_spec)
     # convert the "iterable of values" to lists in case that's what
@@ -386,6 +410,17 @@ def delete(connect_spec, dn):
 
     :returns:
         ``True`` if successful, raises an exception otherwise.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' ldap3.delete "{
+            'url': 'ldaps://ldap.example.com/',
+            'bind': {
+                'method': 'simple',
+                'password': 'secret'}
+        }" dn='cn=admin,dc=example,dc=com'
     '''
     l = connect(connect_spec)
     log.info('deleting entry: dn: {0}'.format(repr(dn)))
@@ -430,6 +465,17 @@ def modify(connect_spec, dn, directives):
 
     :returns:
         ``True`` if successful, raises an exception otherwise.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' ldap3.modify "{
+            'url': 'ldaps://ldap.example.com/',
+            'bind': {
+                'method': 'simple',
+                'password': 'secret'}
+        }" dn='cn=admin,dc=example,dc=com'
     '''
     l = connect(connect_spec)
     # convert the "iterable of values" to lists in case that's what
@@ -477,6 +523,19 @@ def change(connect_spec, dn, before, after):
 
     :returns:
         ``True`` if successful, raises an exception otherwise.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' ldap3.change "{
+            'url': 'ldaps://ldap.example.com/',
+            'bind': {
+                'method': 'simple',
+                'password': 'secret'}
+        }" dn='cn=admin,dc=example,dc=com'
+        before="{'example_value': 'before_val'}"
+        after="{'example_value': 'after_val'}"
     '''
     l = connect(connect_spec)
     # convert the "iterable of values" to lists in case that's what

--- a/tests/integration/modules/sysmod.py
+++ b/tests/integration/modules/sysmod.py
@@ -61,6 +61,7 @@ class SysModuleTest(integration.ModuleCase):
         allow_failure = (
                 'cp.recv',
                 'lxc.run_cmd',
+                'ipset.long_range',
                 'pkg.expand_repo_def',
                 'runtests_decorators.depends',
                 'runtests_decorators.depends_will_fallback',


### PR DESCRIPTION
### What does this PR do?

Adds doc string cli examples to ldap3 modules. It skips ipset.long_range as it does not need a docstring. 
### What issues does this PR fix or reference?

Fixes some failing tests. 
### Tests written?

Yes