### PR TITLE
Nebula dns

### DIFF
--- a/doc/topics/cloud/opennebula.rst
+++ b/doc/topics/cloud/opennebula.rst
@@ -9,7 +9,7 @@ use of private, public, and hybrid IaaS clouds.
 Dependencies
 ============
 The driver requires Python's ``lxml`` library to be installed. It also requires an OpenNebula installation running
-version ``4.12``.
+version ``4.12`` or greater.
 
 
 Configuration
@@ -160,3 +160,21 @@ The Salt Cloud driver for OpenNebula was written using OpenNebula's native XML R
 and ``--action`` calls were added to the OpenNebula driver to enhance support for an OpenNebula infrastructure with
 additional control from Salt Cloud. See the :py:mod:`OpenNebula function definitions <salt.cloud.clouds.opennebula>`
 for more information.
+
+
+Access via DNS entry instead of IP
+==================================
+Some OpenNebula installations do not assign IP addresses to new VMs, instead they establish the new VM's hostname based
+on OpenNebula's name of the VM, and then allocate an IP out of DHCP with dynamic DNS attaching the hostname.  This driver
+supports this behavior by adding the entry `fqdn_base` to the driver configuration or the OpenNebula profile with a value
+matching the base fully-qualified domain.  For example:
+
+.. code-block:: yaml
+
+    # Note: This example is for /etc/salt/cloud.providers or any file in the
+    # /etc/salt/cloud.providers.d/ directory.
+
+    my-opennebula-provider:
+      [...]
+      fqdn_base: corp.example.com
+      [...]

--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -24,6 +24,21 @@ Set up the cloud configuration at ``/etc/salt/cloud.providers`` or
       password: JHGhgsayu32jsa
       driver: opennebula
 
+This driver supports accessing new VM instances via DNS entry instead
+of IP address.  To enable this feature, in the provider or profile file
+add `fqdn_base` with a value matching the base of your fully-qualified
+domain name.  Example:
+
+.. code-block:: yaml
+
+    my-opennebula-config:
+      [...]
+      fqdn_base: <my.basedomain.com>
+      [...]
+
+The driver will prepend the hostname to the fqdn_base and do a DNS lookup
+to find the IP of the new VM.
+
 .. note:
 
     Whenever ``data`` is provided as a kwarg to a function and the
@@ -766,7 +781,6 @@ def get_template(vm_):
         raise SaltCloudNotFound(
             'The specified template, \'{0}\', could not be found.'.format(vm_template)
         )
-
 
 
 def get_vm_id(kwargs=None, call=None):

--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -768,6 +768,7 @@ def get_template(vm_):
         )
 
 
+
 def get_vm_id(kwargs=None, call=None):
     '''
     Returns a virtual machine's ID from the given virtual machine's name.
@@ -861,11 +862,11 @@ def create(vm_):
     vcpu
         Optional - Amount of vCPUs to allocate
 
-    CLI Example:
+     CLI Example:
 
-    .. code-block:: bash
+     .. code-block:: bash
 
-        salt-cloud -p my-opennebula-profile vm_name
+         salt-cloud -p my-opennebula-profile vm_name
 
         salt-cloud -p my-opennebula-profile vm_name memory=16384 cpu=2.5 vcpu=16
 
@@ -927,6 +928,7 @@ def create(vm_):
     if vm_.get('vcpu'):
         template.append('VCPU={0}'.format(vm_.get('vcpu')))
     template_args = "\n".join(template)
+
     try:
         server, user, password = _get_xml_rpc()
         auth = ':'.join([user, password])


### PR DESCRIPTION
### What does this PR do?

Adds documentation for `fqdn_base` for the OpenNebula salt-cloud driver.  This
enables the driver to work with OpenNebula installations that don't assign IP addresses but refer to VMs by DNS entry.
### Tests written?

No