### PR TITLE
Change iteritems() to six.iteritems in modules, states, returners, etc.

### DIFF
--- a/salt/log/handlers/log4mongo_mod.py
+++ b/salt/log/handlers/log4mongo_mod.py
@@ -40,6 +40,7 @@ import socket
 import logging
 
 # Import salt libs
+import salt.ext.six as six
 from salt.log.mixins import NewStyleClassMixIn
 from salt.log.setup import LOG_LEVELS
 
@@ -81,7 +82,7 @@ def setup_handlers():
         }
 
         config_opts = {}
-        for config_opt, arg_name in config_fields.iteritems():
+        for config_opt, arg_name in six.iteritems(config_fields):
             config_opts[arg_name] = __opts__[handler_id].get(config_opt)
 
         config_opts['level'] = LOG_LEVELS[

--- a/salt/modules/boto_asg.py
+++ b/salt/modules/boto_asg.py
@@ -398,7 +398,7 @@ def _create_scheduled_actions(conn, as_name, scheduled_actions):
     Helper function to create scheduled actions
     '''
     if scheduled_actions:
-        for name, action in scheduled_actions.iteritems():
+        for name, action in six.iteritems(scheduled_actions):
             if 'start_time' in action and isinstance(action['start_time'], six.string_types):
                 action['start_time'] = datetime.datetime.strptime(
                     action['start_time'], DATE_FORMAT

--- a/salt/modules/boto_ec2.py
+++ b/salt/modules/boto_ec2.py
@@ -686,7 +686,7 @@ def _to_blockdev_map(thing):
         return None
 
     bdm = BlockDeviceMapping()
-    for d, t in thing.iteritems():
+    for d, t in six.iteritems(thing):
         bdt = BlockDeviceType(ephemeral_name=t.get('ephemeral_name'),
                               no_device=t.get('no_device', False),
                               volume_id=t.get('volume_id'),

--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -44,13 +44,13 @@ import json
 import yaml
 
 # Import salt libs
+import salt.ext.six as six
 import salt.utils.compat
 import salt.utils.odict as odict
 import salt.utils.boto
 
 # Import third party libs
 # pylint: disable=unused-import
-from salt.ext.six import string_types
 from salt.ext.six.moves.urllib.parse import unquote as _unquote  # pylint: disable=no-name-in-module
 try:
     import boto
@@ -559,7 +559,7 @@ def put_group_policy(group_name, policy_name, policy_json, region=None, key=None
         return False
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     try:
-        if not isinstance(policy_json, string_types):
+        if not isinstance(policy_json, six.string_types):
             policy_json = json.dumps(policy_json)
         created = conn.put_group_policy(group_name, policy_name,
                                         policy_json)
@@ -1168,7 +1168,7 @@ def create_role_policy(role_name, policy_name, policy, region=None, key=None,
         if _policy == policy:
             return True
         mode = 'modify'
-    if isinstance(policy, string_types):
+    if isinstance(policy, six.string_types):
         policy = json.loads(policy, object_pairs_hook=odict.OrderedDict)
     try:
         _policy = json.dumps(policy)
@@ -1229,7 +1229,7 @@ def update_assume_role_policy(role_name, policy_document, region=None,
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
-    if isinstance(policy_document, string_types):
+    if isinstance(policy_document, six.string_types):
         policy_document = json.loads(policy_document,
                                      object_pairs_hook=odict.OrderedDict)
     try:
@@ -1448,7 +1448,7 @@ def put_user_policy(user_name, policy_name, policy_json, region=None, key=None, 
         return False
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     try:
-        if not isinstance(policy_json, string_types):
+        if not isinstance(policy_json, six.string_types):
             policy_json = json.dumps(policy_json)
         created = conn.put_user_policy(user_name, policy_name,
                                        policy_json)
@@ -1697,7 +1697,7 @@ def create_policy(policy_name, policy_document, path=None, description=None,
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
-    if not isinstance(policy_document, string_types):
+    if not isinstance(policy_document, six.string_types):
         policy_document = json.dumps(policy_document)
     params = {}
     for arg in 'path', 'description':
@@ -1825,7 +1825,7 @@ def create_policy_version(policy_name, policy_document, set_as_default=None,
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
-    if not isinstance(policy_document, string_types):
+    if not isinstance(policy_document, six.string_types):
         policy_document = json.dumps(policy_document)
     params = {}
     for arg in ('set_as_default',):
@@ -2098,7 +2098,7 @@ def list_entities_for_policy(policy_name, path_prefix=None, entity_filter=None,
           'policy_roles': [],
         }
         for ret in salt.utils.boto.paged_call(conn.list_entities_for_policy, policy_arn=policy_arn, **params):
-            for k, v in allret.iteritems():
+            for k, v in six.iteritems(allret):
                 v.extend(ret.get('list_entities_for_policy_response', {}).get('list_entities_for_policy_result', {}).get(k))
         return allret
     except boto.exception.BotoServerError as e:

--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -880,7 +880,7 @@ def modify_db_instance(name,
 def _tag_doc(tags):
     taglist = []
     if tags is not None:
-        for k, v in tags.iteritems():
+        for k, v in six.iteritems(tags):
             if str(k).startswith('__'):
                 continue
             taglist.append({'Key': str(k), 'Value': str(v)})

--- a/salt/modules/github.py
+++ b/salt/modules/github.py
@@ -36,6 +36,7 @@ import logging
 
 # Import Salt Libs
 from salt.exceptions import CommandExecutionError
+import salt.ext.six as six
 import salt.utils.http
 
 # Import third party libs
@@ -705,7 +706,7 @@ def get_milestone(number=None,
 
     else:
         milestones = get_milestones(repo_name=repo_name, profile=profile, output=output)
-        for key, val in milestones.iteritems():
+        for key, val in six.iteritems(milestones):
             if val.get('title') == name:
                 ret[key] = val
                 return ret

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -2,11 +2,14 @@
 '''
 Module for interfacing to Junos devices.
 '''
-from __future__ import absolute_import
 
 # Import python libraries
+from __future__ import absolute_import
 import logging
 import json
+
+# Import Salt libs
+import salt.ext.six as six
 
 try:
     from lxml import etree
@@ -124,7 +127,7 @@ def call_rpc(cmd=None, *args, **kwargs):
     else:
         op.update(kwargs)
 
-    for k, v in op.iteritems():
+    for k, v in six.iteritems(op):
         op[k] = str(v)
     op['format'] = 'json'
 

--- a/salt/modules/k8s.py
+++ b/salt/modules/k8s.py
@@ -551,12 +551,12 @@ def _decode_secrets(secrets):
     if items:
         for i, secret in enumerate(items):
             log.trace(i, secret)
-            for k, v in secret.get("data", {}).iteritems():
+            for k, v in six.iteritems(secret.get("data", {})):
                 items[i]['data'][k] = base64.b64decode(v)
         secrets["items"] = items
         return secrets
     else:
-        for k, v in secrets.get("data", {}).iteritems():
+        for k, v in six.iteritems(secrets.get("data", {})):
             secrets['data'][k] = base64.b64decode(v)
         return secrets
 
@@ -729,7 +729,7 @@ def create_secret(namespace, name, sources, apiserver_url=None, force=False, upd
             # format is array of dictionaries:
             # [{public_auth: salt://public_key}, {test: "/tmp/test"}]
             log.trace("source is dictionary: {0}".format(source))
-            for k, v in source.iteritems():
+            for k, v in six.iteritems(source):
                 sname, encoded = _source_encode(v, saltenv)
                 if sname == encoded == "":
                     ret['comment'] += "Source file {0} is missing or name is incorrect\n".format(v)

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -1472,7 +1472,7 @@ def ifacestartswith(cidr):
     intfnames = []
     pattern = str(cidr)
     size = len(pattern)
-    for ifname, ifval in net_list.iteritems():
+    for ifname, ifval in six.iteritems(net_list):
         if 'inet' in ifval:
             for inet in ifval['inet']:
                 if inet['address'][0:size] == pattern:

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -996,7 +996,7 @@ def remove(name=None,
         # FreeBSD pkg supports `openjdk` and `java/openjdk7` package names
         if pkg[0].find("/") > 0:
             origin = pkg[0]
-            pkg = [k for k, v in old.iteritems() if v['origin'] == origin][0]
+            pkg = [k for k, v in six.iteritems(old) if v['origin'] == origin][0]
 
         if pkg[0] in old:
             targets.append(pkg[0])

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -526,7 +526,7 @@ def info(*packages, **attr):
             attr.append('edition')
             query.append(attr_map['edition'])
     else:
-        for attr_k, attr_v in attr_map.iteritems():
+        for attr_k, attr_v in six.iteritems(attr_map):
             if attr_k != 'description':
                 query.append(attr_v)
     if attr and 'description' in attr or not attr:

--- a/salt/modules/smartos_vmadm.py
+++ b/salt/modules/smartos_vmadm.py
@@ -14,6 +14,7 @@ except ImportError:
     from pipes import quote as _quote_args
 
 # Import Salt libs
+import salt.ext.six as six
 import salt.utils
 import salt.utils.decorators as decorators
 from salt.utils.odict import OrderedDict
@@ -783,7 +784,7 @@ def create(from_file=None, **kwargs):
     # prepare vmcfg
     vmcfg = {}
     kwargs = salt.utils.clean_kwargs(**kwargs)
-    for k, v in kwargs.iteritems():
+    for k, v in six.iteritems(kwargs):
         vmcfg[k] = v
 
     if from_file:
@@ -818,7 +819,7 @@ def update(vm, from_file=None, key='uuid', **kwargs):
     # prepare vmcfg
     vmcfg = {}
     kwargs = salt.utils.clean_kwargs(**kwargs)
-    for k, v in kwargs.iteritems():
+    for k, v in six.iteritems(kwargs):
         vmcfg[k] = v
 
     if key not in ['uuid', 'alias', 'hostname']:

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -1616,7 +1616,7 @@ def get_vsan_eligible_disks(host, username, password, protocol=None, port=None, 
     response = _get_vsan_eligible_disks(service_instance, host, host_names)
 
     ret = {}
-    for host_name, value in response.iteritems():
+    for host_name, value in six.iteritems(response):
         error = value.get('Error')
         if error:
             ret.update({host_name: {'Error': error}})
@@ -3013,7 +3013,7 @@ def vsan_add_disks(host, username, password, protocol=None, port=None, host_name
     response = _get_vsan_eligible_disks(service_instance, host, host_names)
 
     ret = {}
-    for host_name, value in response.iteritems():
+    for host_name, value in six.iteritems(response):
         host_ref = _get_host_ref(service_instance, host, host_name=host_name)
         vsan_system = host_ref.configManager.vsanSystem
 

--- a/salt/pillar/http_json.py
+++ b/salt/pillar/http_json.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
+'''
 A module that adds data to the Pillar structure retrieved by an http request
 
 
@@ -19,23 +19,26 @@ Set the following Salt config to setup Foreman as external pillar source:
 
 Module Documentation
 ====================
-"""
-from __future__ import absolute_import
+'''
 
 # Import python libs
+from __future__ import absolute_import
 import logging
+
+# Import Salt libs
+import salt.ext.six as six
 
 
 def ext_pillar(minion_id,
                pillar,  # pylint: disable=W0613
                url=None):
-    """
+    '''
     Read pillar data from HTTP response.
 
     :param url String to make request
     :returns dict with pillar data to add
     :returns empty if error
-    """
+    '''
     # Set up logging
     log = logging.getLogger(__name__)
 
@@ -46,7 +49,7 @@ def ext_pillar(minion_id,
 
     log.error('Error caught on query to' + url + '\nMore Info:\n')
 
-    for k, v in data.iteritems():
+    for k, v in six.iteritems(data):
         log.error(k + ' : ' + v)
 
     return {}

--- a/salt/pillar/http_yaml.py
+++ b/salt/pillar/http_yaml.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
+'''
 A module that adds data to the Pillar structure retrieved by an http request
 
 
@@ -19,11 +19,14 @@ Set the following Salt config to setup an http endpoint as the external pillar s
 
 Module Documentation
 ====================
-"""
-from __future__ import absolute_import
+'''
 
 # Import python libs
+from __future__ import absolute_import
 import logging
+
+# Import Salt libs
+import salt.ext.six as six
 
 
 def ext_pillar(minion_id,
@@ -46,7 +49,7 @@ def ext_pillar(minion_id,
 
     log.error('Error caught on query to' + url + '\nMore Info:\n')
 
-    for k, v in data.iteritems():
+    for k, v in six.iteritems(data):
         log.error(k + ' : ' + v)
 
     return {}

--- a/salt/pillar/makostack.py
+++ b/salt/pillar/makostack.py
@@ -371,12 +371,15 @@ You can also select a custom merging strategy using a ``__`` object in a list:
 +----------------+-------------------------+-------------------------+
 '''
 
+# Import Python libs
 from __future__ import absolute_import
 import os
 import logging
 from functools import partial
-
 import yaml
+
+# Import Salt libs
+import salt.ext.six as six
 
 try:
     from mako.lookup import TemplateLookup
@@ -410,7 +413,7 @@ def ext_pillar(minion_id, pillar, *args, **kwargs):
         'grains': partial(salt.utils.traverse_dict_and_list, __grains__),
         'opts': partial(salt.utils.traverse_dict_and_list, __opts__),
         }
-    for matcher, matchs in kwargs.iteritems():
+    for matcher, matchs in six.iteritems(kwargs):
         t, matcher = matcher.split(':', 1)
         if t not in traverse:
             raise Exception('Unknown traverse option "{0}", '
@@ -470,7 +473,7 @@ def _cleanup(obj):
     if obj:
         if isinstance(obj, dict):
             obj.pop('__', None)
-            for k, v in obj.iteritems():
+            for k, v in six.iteritems(obj):
                 obj[k] = _cleanup(v)
         elif isinstance(obj, list) and isinstance(obj[0], dict) \
                 and '__' in obj[0]:
@@ -486,7 +489,7 @@ def _merge_dict(stack, obj):
     if strategy == 'overwrite':
         return _cleanup(obj)
     else:
-        for k, v in obj.iteritems():
+        for k, v in six.iteritems(obj):
             if strategy == 'remove':
                 stack.pop(k, None)
                 continue

--- a/salt/pillar/stack.py
+++ b/salt/pillar/stack.py
@@ -366,13 +366,16 @@ You can also select a custom merging strategy using a ``__`` object in a list:
 +----------------+-------------------------+-------------------------+
 '''
 
+# Import Python libs
 from __future__ import absolute_import
 import os
 import logging
 from functools import partial
-
 import yaml
 from jinja2 import FileSystemLoader, Environment, TemplateNotFound
+
+# Import Salt libs
+import salt.ext.six as six
 
 
 log = logging.getLogger(__name__)
@@ -388,7 +391,7 @@ def ext_pillar(minion_id, pillar, *args, **kwargs):
         'grains': partial(salt.utils.traverse_dict_and_list, __grains__),
         'opts': partial(salt.utils.traverse_dict_and_list, __opts__),
         }
-    for matcher, matchs in kwargs.iteritems():
+    for matcher, matchs in six.iteritems(kwargs):
         t, matcher = matcher.split(':', 1)
         if t not in traverse:
             raise Exception('Unknown traverse option "{0}", '
@@ -443,7 +446,7 @@ def _cleanup(obj):
     if obj:
         if isinstance(obj, dict):
             obj.pop('__', None)
-            for k, v in obj.iteritems():
+            for k, v in six.iteritems(obj):
                 obj[k] = _cleanup(v)
         elif isinstance(obj, list) and isinstance(obj[0], dict) \
                 and '__' in obj[0]:
@@ -459,7 +462,7 @@ def _merge_dict(stack, obj):
     if strategy == 'overwrite':
         return _cleanup(obj)
     else:
-        for k, v in obj.iteritems():
+        for k, v in six.iteritems(obj):
             if strategy == 'remove':
                 stack.pop(k, None)
                 continue

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -45,12 +45,13 @@ To override individual configuration items, append --return_kwargs '{"key:": "va
     salt '*' test.ping --return redis --return_kwargs '{"db": "another-salt"}'
 
 '''
-from __future__ import absolute_import
 
 # Import python libs
+from __future__ import absolute_import
 import json
 
 # Import Salt libs
+import salt.ext.six as six
 import salt.utils
 import salt.utils.jid
 import salt.returners
@@ -160,7 +161,7 @@ def get_jid(jid):
     '''
     serv = _get_serv(ret=None)
     ret = {}
-    for minion, data in serv.hgetall('ret:{0}'.format(jid)).iteritems():
+    for minion, data in six.iteritems(serv.hgetall('ret:{0}'.format(jid))):
         if data:
             ret[minion] = json.loads(data)
     return ret

--- a/salt/returners/zabbix_return.py
+++ b/salt/returners/zabbix_return.py
@@ -13,9 +13,16 @@ Key: salt.trap.disaster
   .. code-block:: bash
     salt '*' test.ping --return zabbix
 '''
+
+# Import Python libs
 from __future__ import absolute_import
 import logging
 import os
+
+# Import Salt libs
+import salt.ext.six as six
+
+# Get logging started
 log = logging.getLogger(__name__)
 
 
@@ -54,7 +61,7 @@ def returner(ret):
     host = job_minion_id.split('.')[0]
 
     if type(ret['return']) is dict:
-        for state, item in ret['return'].iteritems():
+        for state, item in six.iteritems(ret['return']):
             if 'comment' in item and 'name' in item and not item['result']:
                 errors = True
                 zabbix_send("salt.trap.high", host, 'SALT:\nname: {0}\ncomment: {1}'.format(item['name'], item['comment']))

--- a/salt/state.py
+++ b/salt/state.py
@@ -185,7 +185,7 @@ def find_name(name, state, high):
         ext_id.append((name, state))
     # if we are requiring an entire SLS, then we need to add ourselves to everything in that SLS
     elif state == 'sls':
-        for nid, item in high.iteritems():
+        for nid, item in six.iteritems(high):
             if item['__sls__'] == name:
                 ext_id.append((nid, next(iter(item))))
     # otherwise we are requiring a single state, lets find it

--- a/salt/states/boto_datapipeline.py
+++ b/salt/states/boto_datapipeline.py
@@ -48,12 +48,16 @@ config:
       - parameter_values:
           myDDBTableName: my-dynamo-table
 '''
-from __future__ import absolute_import
 
+# Import Python libs
+from __future__ import absolute_import
 import copy
 import datetime
 import difflib
 import json
+
+# Import Salt lobs
+import salt.ext.six as six
 from salt.ext.six.moves import zip
 
 
@@ -416,7 +420,7 @@ def _standardize(structure):
                 mutating_helper(each)
         elif isinstance(structure, dict):
             structure = dict(structure)
-            for k, v in structure.iteritems():
+            for k, v in six.iteritems(structure):
                 mutating_helper(k)
                 mutating_helper(v)
 
@@ -484,7 +488,7 @@ def _dict_to_list_ids(objects):
     while still satisfying the boto api.
     '''
     list_with_ids = []
-    for key, value in objects.iteritems():
+    for key, value in six.iteritems(objects):
         element = {'id': key}
         element.update(value)
         list_with_ids.append(element)
@@ -518,7 +522,7 @@ def _properties_from_dict(d, key_name='key'):
         ]
     '''
     fields = []
-    for key, value in d.iteritems():
+    for key, value in six.iteritems(d):
         if isinstance(value, dict):
             fields.append({
                 key_name: key,

--- a/salt/states/boto_ec2.py
+++ b/salt/states/boto_ec2.py
@@ -57,8 +57,9 @@ import logging
 from time import time, sleep
 
 # Import salt libs
+import salt.ext.six as six
+import salt.utils
 import salt.utils.dictupdate as dictupdate
-from salt.utils import exactly_one
 from salt.exceptions import SaltInvocationError, CommandExecutionError
 
 log = logging.getLogger(__name__)
@@ -235,7 +236,7 @@ def eni_present(
         A dict with region, key and keyid, or a pillar key (string)
         that contains a dict with region, key and keyid.
     '''
-    if not exactly_one((subnet_id, subnet_name)):
+    if not salt.utils.exactly_one((subnet_id, subnet_name)):
         raise SaltInvocationError('One (but not both) of subnet_id or '
                                   'subnet_name must be provided.')
     if not groups:
@@ -751,10 +752,10 @@ def instance_present(name, instance_name=None, instance_id=None, image_id=None,
     running_states = ('pending', 'rebooting', 'running', 'stopping', 'stopped')
     changed_attrs = {}
 
-    if not exactly_one((image_id, image_name)):
+    if not salt.utils.exactly_one((image_id, image_name)):
         raise SaltInvocationError('Exactly one of image_id OR '
                                   'image_name must be provided.')
-    if (public_ip or allocation_id or allocate_eip) and not exactly_one((public_ip, allocation_id, allocate_eip)):
+    if (public_ip or allocation_id or allocate_eip) and not salt.utils.exactly_one((public_ip, allocation_id, allocate_eip)):
         raise SaltInvocationError('At most one of public_ip, allocation_id OR '
                                   'allocate_eip may be provided.')
 
@@ -869,7 +870,7 @@ def instance_present(name, instance_name=None, instance_id=None, image_id=None,
                 return ret
 
     if attributes:
-        for k, v in attributes.iteritems():
+        for k, v in six.iteritems(attributes):
             curr = __salt__['boto_ec2.get_attribute'](k, instance_id=instance_id, region=region, key=key,
                                                       keyid=keyid, profile=profile)
             if not isinstance(curr, dict):
@@ -1055,7 +1056,7 @@ def volume_absent(name, volume_name=None, volume_id=None, instance_name=None,
     filters = {}
     running_states = ('pending', 'rebooting', 'running', 'stopping', 'stopped')
 
-    if not exactly_one((volume_name, volume_id, instance_name, instance_id)):
+    if not salt.utils.exactly_one((volume_name, volume_id, instance_name, instance_id)):
         raise SaltInvocationError("Exactly one of 'volume_name', 'volume_id', "
                                   "'instance_name', or 'instance_id' must be provided.")
     if (instance_name or instance_id) and not device:

--- a/salt/states/dellchassis.py
+++ b/salt/states/dellchassis.py
@@ -159,9 +159,12 @@ from __future__ import absolute_import
 import logging
 import os
 
-log = logging.getLogger(__name__)
-
+# Import Salt lobs
+import salt.ext.six as six
 from salt.exceptions import CommandExecutionError
+
+# Get logging started
+log = logging.getLogger(__name__)
 
 
 def __virtual__():
@@ -468,7 +471,7 @@ def chassis(name, chassis_name=None, password=None, datacenter=None,
                     target_power_states[key] = 'powerup'
                 if current_power_states[key] != -1 and current_power_states[key]:
                     target_power_states[key] = 'powercycle'
-        for k, v in target_power_states.iteritems():
+        for k, v in six.iteritems(target_power_states):
             old = {k: current_power_states[k]}
             new = {k: v}
             if ret['changes'].get('Blade Power States') is None:
@@ -528,7 +531,7 @@ def chassis(name, chassis_name=None, password=None, datacenter=None,
             slot_names = True
 
     powerchange_all_ok = True
-    for k, v in target_power_states.iteritems():
+    for k, v in six.iteritems(target_power_states):
         powerchange_ok = __salt__[chassis_cmd]('server_power', v, module=k)
         if not powerchange_ok:
             powerchange_all_ok = False

--- a/salt/states/esxi.py
+++ b/salt/states/esxi.py
@@ -97,6 +97,7 @@ from __future__ import absolute_import
 import logging
 
 # Import Salt Libs
+import salt.ext.six as six
 import salt.utils
 from salt.exceptions import CommandExecutionError
 
@@ -913,7 +914,7 @@ def syslog_configured(name,
         if not __opts__['test']:
             reset = __salt__[esxi_cmd]('reset_syslog_config',
                                        syslog_config=reset_configs).get(host)
-            for key, val in reset.iteritems():
+            for key, val in six.iteritems(reset):
                 if isinstance(val, bool):
                     continue
                 if not val.get('success'):
@@ -952,7 +953,7 @@ def syslog_configured(name,
                                'new': firewall}})
 
     current_syslog_config = __salt__[esxi_cmd]('get_syslog_config').get(host)
-    for key, val in syslog_configs.iteritems():
+    for key, val in six.iteritems(syslog_configs):
         # The output of get_syslog_config has different keys than the keys
         # Used to set syslog_config values. We need to look them up first.
         try:

--- a/salt/states/grafana_dashboard.py
+++ b/salt/states/grafana_dashboard.py
@@ -38,14 +38,14 @@ they exist in dashboards. The module will not manage rows that are not defined,
 allowing users to manage their own custom rows.
 '''
 
+# Import Python libs
 from __future__ import absolute_import
-
 import copy
 import json
-
 import requests
 
-from salt.ext.six import string_types
+# Import Salt libs
+import salt.ext.six as six
 from salt.utils.dictdiffer import DictDiffer
 
 
@@ -94,7 +94,7 @@ def present(name,
     base_rows_from_pillar = base_rows_from_pillar or []
     dashboard = dashboard or {}
 
-    if isinstance(profile, string_types):
+    if isinstance(profile, six.string_types):
         profile = __salt__['config.option'](profile)
 
     # Add pillar keys for default configuration
@@ -200,7 +200,7 @@ def absent(name, profile='grafana'):
     '''
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
-    if isinstance(profile, string_types):
+    if isinstance(profile, six.string_types):
         profile = __salt__['config.option'](profile)
 
     url = 'db/{0}'.format(name)
@@ -538,7 +538,7 @@ def _dashboard_diff(_new_dashboard, _old_dashboard):
 def _stripped(d):
     '''Strip falsey entries.'''
     ret = {}
-    for k, v in d.iteritems():
+    for k, v in six.iteritems(d):
         if v:
             ret[k] = v
     return ret

--- a/salt/states/probes.py
+++ b/salt/states/probes.py
@@ -94,7 +94,7 @@ def _expand_probes(probes, defaults):
         if probe_name not in expected_probes.keys():
             expected_probes[probe_name] = dict()
         probe_defaults = probe_test.pop('defaults', {})
-        for test_name, test_details in probe_test.iteritems():
+        for test_name, test_details in six.iteritems(probe_test):
             test_defaults = test_details.pop('defaults', {})
             expected_test_details = deepcopy(defaults)  # copy first the general defaults
             expected_test_details.update(probe_defaults)  # update with more specific defaults if any
@@ -118,7 +118,7 @@ def _clean_probes(probes):
         if not probe_tests:
             probes.pop(probe_name)
             continue
-        for test_name, test_params in probe_tests.iteritems():
+        for test_name, test_params in six.iteritems(probe_tests):
             if not test_params:
                 probes[probe_name].pop(test_name)
             if not probes.get(probe_name):
@@ -163,7 +163,7 @@ def _compare_probes(configured_probes, expected_probes):
         remove_probes[probe_name] = configured_probes.pop(probe_name)
 
     # common probes
-    for probe_name, probe_tests in expected_probes.iteritems():
+    for probe_name, probe_tests in six.iteritems(expected_probes):
         configured_probe_tests = configured_probes.get(probe_name, {})
         configured_tests_keys_set = set(configured_probe_tests.keys())
         expected_tests_keys_set = set(probe_tests.keys())
@@ -185,7 +185,7 @@ def _compare_probes(configured_probes, expected_probes):
                 test_name: configured_probe_tests.pop(test_name)
             })
         # common tests for common probes
-        for test_name, test_params in probe_tests.iteritems():
+        for test_name, test_params in six.iteritems(probe_tests):
             configured_test_params = configured_probe_tests.get(test_name, {})
             # if test params are different, probe goes to update probes dict!
             if test_params != configured_test_params:

--- a/salt/states/rabbitmq_user.py
+++ b/salt/states/rabbitmq_user.py
@@ -57,7 +57,7 @@ def _check_perms_changes(name, newperms, runas=None, existing=None):
 
     perm_need_change = False
     for vhost_perms in newperms:
-        for vhost, perms in vhost_perms.iteritems():
+        for vhost, perms in six.iteritems(vhost_perms):
             if vhost in existing:
                 existing_vhost = existing[vhost]
                 if perms != existing_vhost:

--- a/salt/states/sqlite3.py
+++ b/salt/states/sqlite3.py
@@ -79,7 +79,11 @@ Here is an example of removing a row from a table:
           - sqlite3: users
 """
 
+# Import Python libs
 from __future__ import absolute_import
+
+# Import Salt libs
+import salt.ext.six as six
 
 try:
     import sqlite3
@@ -229,7 +233,7 @@ def row_present(name,
             changes['result'] = False
             changes['comment'] = 'More than one row matched the specified query'
         elif len(rows) == 1:
-            for key, value in data.iteritems():
+            for key, value in six.iteritems(data):
                 if key in rows[0] and rows[0][key] != value:
                     if update:
                         if __opts__['test']:
@@ -239,7 +243,7 @@ def row_present(name,
                         else:
                             columns = []
                             params = []
-                            for key, value in data.iteritems():
+                            for key, value in six.iteritems(data):
                                 columns.append("`" + key + "`=?")
                                 params.append(value)
 
@@ -278,7 +282,7 @@ def row_present(name,
                 columns = []
                 value_stmt = []
                 values = []
-                for key, value in data.iteritems():
+                for key, value in six.iteritems(data):
                     value_stmt.append('?')
                     values.append(value)
                     columns.append("`" + key + "`")


### PR DESCRIPTION
### What does this PR do?

Changes a bunch of `object.iteritems()` references to use the `six.iteritems(object)` syntax for Python 3 compatibility.

There are some references left to tackle in the `tests/` directory, but this PR handles the remaining references in the `salt/` directory.