### PR TITLE
zpool state module needs support for disk vdev #34762

### DIFF
--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -660,7 +660,7 @@ def create(zpool, *vdevs, **kwargs):
     # make sure files are present on filesystem
     ret[zpool] = {}
     for vdev in vdevs:
-        if vdev not in ['mirror', 'log', 'cache', 'raidz1', 'raidz2', 'raidz3', 'spare']:
+        if vdev not in ['disk', 'mirror', 'log', 'cache', 'raidz1', 'raidz2', 'raidz3', 'spare']:
             if not os.path.exists(vdev):
                 ret[zpool][vdev] = 'not present on filesystem'
                 continue

--- a/salt/states/zpool.py
+++ b/salt/states/zpool.py
@@ -171,7 +171,7 @@ def present(name, properties=None, filesystem_properties=None, layout=None, conf
         layout_result = {}
         for root_dev in layout:
             if '-' in root_dev:
-                if root_dev.split('-')[0] not in ['mirror', 'log', 'cache', 'raidz1', 'raidz2', 'raidz3', 'spare']:
+                if root_dev.split('-')[0] not in ['disk', 'mirror', 'log', 'cache', 'raidz1', 'raidz2', 'raidz3', 'spare']:
                     layout_valid = False
                     layout_result[root_dev] = 'not a valid vdev type'
                 layout[root_dev] = layout[root_dev].keys() if isinstance(layout[root_dev], OrderedDict) else layout[root_dev].split(' ')

--- a/salt/states/zpool.py
+++ b/salt/states/zpool.py
@@ -171,7 +171,7 @@ def present(name, properties=None, filesystem_properties=None, layout=None, conf
         layout_result = {}
         for root_dev in layout:
             if '-' in root_dev:
-                if root_dev.split('-')[0] not in ['mirror', 'log', 'cache', 'raidz1', 'raidz2', 'raidz3', 'spare']:
+                if root_dev.split('-')[0] not in ['disk', 'mirror', 'log', 'cache', 'raidz1', 'raidz2', 'raidz3', 'spare']:
                     layout_valid = False
                     layout_result[root_dev] = 'not a valid vdev type'
                 layout[root_dev] = layout[root_dev].keys() if isinstance(layout[root_dev], OrderedDict) else layout[root_dev].split(' ')
@@ -267,9 +267,12 @@ def present(name, properties=None, filesystem_properties=None, layout=None, conf
                     params.append(name)
                     for root_dev in layout:
                         if '-' in root_dev:  # special device
-                            params.append(root_dev.split('-')[0])  # add the type by stripping the ID
-                            if root_dev.split('-')[0] in ['mirror', 'log', 'cache', 'raidz1', 'raidz2', 'raidz3', 'spare']:
-                                for sub_dev in layout[root_dev]:  # add all sub devices
+                            sub_devs = layout[root_dev]
+                            root_dev = root_dev.split('-')[0]
+                            if root_dev in ['disk', 'mirror', 'log', 'cache', 'raidz1', 'raidz2', 'raidz3', 'spare']:
+                                if root_dev not in ('disk', 'file'):
+                                    params.append(root_dev)
+                                for sub_dev in sub_devs:  # add all sub devices
                                     if '/' not in sub_dev and config['device_dir'] and os.path.exists(config['device_dir']):
                                         sub_dev = os.path.join(config['device_dir'], sub_dev)
                                     params.append(sub_dev)

--- a/salt/states/zpool.py
+++ b/salt/states/zpool.py
@@ -267,9 +267,12 @@ def present(name, properties=None, filesystem_properties=None, layout=None, conf
                     params.append(name)
                     for root_dev in layout:
                         if '-' in root_dev:  # special device
-                            params.append(root_dev.split('-')[0])  # add the type by stripping the ID
-                            if root_dev.split('-')[0] in ['mirror', 'log', 'cache', 'raidz1', 'raidz2', 'raidz3', 'spare']:
-                                for sub_dev in layout[root_dev]:  # add all sub devices
+                            sub_devs = layout[root_dev]
+                            root_dev = root_dev.split('-')[0]
+                            if root_dev in ['disk', 'mirror', 'log', 'cache', 'raidz1', 'raidz2', 'raidz3', 'spare']:
+                                if root_dev not in ('disk', 'file'):
+                                    params.append(root_dev)
+                                for sub_dev in sub_devs:  # add all sub devices
                                     if '/' not in sub_dev and config['device_dir'] and os.path.exists(config['device_dir']):
                                         sub_dev = os.path.join(config['device_dir'], sub_dev)
                                     params.append(sub_dev)


### PR DESCRIPTION
Support zpool "disk" vdevs with explicit syntax, conforming to the same convention for specifying other vdev types.
### Previous Behavior

to make a mirror vdev zpool:

```
mirrorpool:
  zpool.present:
    - config:
        import: false
        force: true
    - properties:
        comment: salty storage pool
    - layout:
        mirror-0:
          /dev/disk0
          /dev/disk1
```

to make a simple disk vpool

```
newpool:
  zpool.present:
    - config:
        import: false
        force: true
    - properties:
        comment: quick and dirty
    - layout: /dev/disk0
```

to make a striped disk zpool

```
newpool:
  zpool.present:
    - config:
        import: false
        force: true
    - properties:
        comment: quicker and dirtier
    - layout: /dev/disk0 /dev/disk1
```
### New Behavior

old behavior still works

to make a simple disk vpool

```
newpool:
  zpool.present:
    - config:
        import: false
        force: true
    - properties:
        comment: quick and dirty
    - layout:
        disk-0:
          /dev/disk0
```

to make a striped disk zpool

```
newpool:
  zpool.present:
    - config:
        import: false
        force: true
    - properties:
        comment: quicker and dirtier
    - layout:
        disk-0:
          /dev/disk0
          /dev/disk1
```
### Tests written?

No, but these examples are a good start!
### Documentation changes?

Let's see 
