### PR TITLE
salt/grains/core.py: restore bsd_cpudata grains update on FreeBSD; fi…

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1432,6 +1432,7 @@ def os_data():
     else:
         grains['os'] = grains['kernel']
     if grains['kernel'] == 'FreeBSD':
+        grains.update(_bsd_cpudata(grains))
         try:
             grains['osrelease'] = __salt__['cmd.run']('freebsd-version -u').split('-')[0]
         except salt.exceptions.CommandExecutionError:


### PR DESCRIPTION
### What does this PR do?

After addressing #29882 in de5661725 the call for grains.update(_bsd_cpudata(grains)) was omitted for FreeBSD and only called on NetBSD and OpenBSD.
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/33608
### Previous Behavior

grains.update skipped
### New Behavior

grains.update called
### Tests written?

No. Testing by the submitter noted in the issue and patched for the FreeBSD port in https://github.com/freebsd/freebsd-ports/commit/02145140146049128f322fe093835cffec47334c. I'd like to get that in 2016.3.2 so we can remove patching the port.
