### PR TITLE
ddns: Add support for user defined nameserver port/TSIG key algorithm

### DIFF
--- a/salt/modules/ddns.py
+++ b/salt/modules/ddns.py
@@ -198,7 +198,7 @@ def update(zone, name, ttl, rdtype, data, nameserver='127.0.0.1', port=53,
 
 
 def delete(zone, name, rdtype=None, data=None, nameserver='127.0.0.1',
-           port='53', timeout=5, **kwargs):
+           port=53, timeout=5, **kwargs):
     '''
     Delete a DNS record.
 

--- a/salt/modules/ddns.py
+++ b/salt/modules/ddns.py
@@ -75,8 +75,8 @@ def _get_keyring(keyfile):
     return keyring
 
 
-def add_host(zone, name, ttl, ip, nameserver='127.0.0.1', replace=True,
-             timeout=5, **kwargs):
+def add_host(zone, name, ttl, ip, nameserver='127.0.0.1', port=53,
+             replace=True, timeout=5, **kwargs):
     '''
     Add, replace, or update the A and PTR (reverse) records for a host.
 
@@ -86,7 +86,7 @@ def add_host(zone, name, ttl, ip, nameserver='127.0.0.1', replace=True,
 
         salt ns1 ddns.add_host example.com host1 60 10.1.1.1
     '''
-    res = update(zone, name, ttl, 'A', ip, nameserver, timeout, replace,
+    res = update(zone, name, ttl, 'A', ip, nameserver, port, timeout, replace,
                  **kwargs)
     if res is False:
         return False
@@ -101,14 +101,15 @@ def add_host(zone, name, ttl, ip, nameserver='127.0.0.1', replace=True,
         popped.append(p)
         zone = '{0}.{1}'.format('.'.join(parts), 'in-addr.arpa.')
         name = '.'.join(popped)
-        ptr = update(zone, name, ttl, 'PTR', fqdn, nameserver, timeout,
+        ptr = update(zone, name, ttl, 'PTR', fqdn, nameserver, port, timeout,
                      replace, **kwargs)
         if ptr:
             return True
     return res
 
 
-def delete_host(zone, name, nameserver='127.0.0.1', timeout=5, **kwargs):
+def delete_host(zone, name, nameserver='127.0.0.1', port=53, timeout=5,
+                **kwargs):
     '''
     Delete the forward and reverse records for a host.
 
@@ -122,13 +123,14 @@ def delete_host(zone, name, nameserver='127.0.0.1', timeout=5, **kwargs):
     '''
     fqdn = '{0}.{1}'.format(name, zone)
     request = dns.message.make_query(fqdn, 'A')
-    answer = dns.query.udp(request, nameserver, timeout)
+    answer = dns.query.udp(request, nameserver, timeout, port)
     try:
         ips = [i.address for i in answer.answer[0].items]
     except IndexError:
         ips = []
 
-    res = delete(zone, name, nameserver=nameserver, timeout=timeout, **kwargs)
+    res = delete(zone, name, nameserver=nameserver, port=port, timeout=timeout,
+                 **kwargs)
 
     fqdn = fqdn + '.'
     for ip in ips:
@@ -142,13 +144,13 @@ def delete_host(zone, name, nameserver='127.0.0.1', timeout=5, **kwargs):
             zone = '{0}.{1}'.format('.'.join(parts), 'in-addr.arpa.')
             name = '.'.join(popped)
             ptr = delete(zone, name, 'PTR', fqdn, nameserver=nameserver,
-                         timeout=timeout, **kwargs)
+                         port=port, timeout=timeout, **kwargs)
         if ptr:
             res = True
     return res
 
 
-def update(zone, name, ttl, rdtype, data, nameserver='127.0.0.1',
+def update(zone, name, ttl, rdtype, data, nameserver='127.0.0.1', port=53,
            timeout=5, replace=False, **kwargs):
     '''
     Add, replace, or update a DNS record.
@@ -165,7 +167,7 @@ def update(zone, name, ttl, rdtype, data, nameserver='127.0.0.1',
     name = str(name)
     fqdn = '{0}.{1}'.format(name, zone)
     request = dns.message.make_query(fqdn, rdtype)
-    answer = dns.query.udp(request, nameserver, timeout)
+    answer = dns.query.udp(request, nameserver, timeout, port)
 
     rdtype = dns.rdatatype.from_text(rdtype)
     rdata = dns.rdata.from_text(dns.rdataclass.IN, rdtype, data)
@@ -189,14 +191,14 @@ def update(zone, name, ttl, rdtype, data, nameserver='127.0.0.1',
         dns_update.replace(name, ttl, rdata)
     elif not is_exist:
         dns_update.add(name, ttl, rdata)
-    answer = dns.query.udp(dns_update, nameserver, timeout)
+    answer = dns.query.udp(dns_update, nameserver, timeout, port)
     if answer.rcode() > 0:
         return False
     return True
 
 
 def delete(zone, name, rdtype=None, data=None, nameserver='127.0.0.1',
-           timeout=5, **kwargs):
+           port='53', timeout=5, **kwargs):
     '''
     Delete a DNS record.
 
@@ -210,7 +212,7 @@ def delete(zone, name, rdtype=None, data=None, nameserver='127.0.0.1',
     fqdn = '{0}.{1}'.format(name, zone)
     request = dns.message.make_query(fqdn, (rdtype or 'ANY'))
 
-    answer = dns.query.udp(request, nameserver, timeout)
+    answer = dns.query.udp(request, nameserver, timeout, port)
     if not answer.answer:
         return None
 
@@ -232,7 +234,7 @@ def delete(zone, name, rdtype=None, data=None, nameserver='127.0.0.1',
     else:
         dns_update.delete(name)
 
-    answer = dns.query.udp(dns_update, nameserver, timeout)
+    answer = dns.query.udp(dns_update, nameserver, timeout, port)
     if answer.rcode() > 0:
         return False
     return True

--- a/salt/modules/ddns.py
+++ b/salt/modules/ddns.py
@@ -76,7 +76,7 @@ def _get_keyring(keyfile):
 
 
 def add_host(zone, name, ttl, ip, nameserver='127.0.0.1', replace=True,
-             timeout=5, **kwargs, port=53):
+             timeout=5, port=53, **kwargs):
     '''
     Add, replace, or update the A and PTR (reverse) records for a host.
 
@@ -86,8 +86,8 @@ def add_host(zone, name, ttl, ip, nameserver='127.0.0.1', replace=True,
 
         salt ns1 ddns.add_host example.com host1 60 10.1.1.1
     '''
-    res = update(zone, name, ttl, 'A', ip, nameserver, timeout, replace,
-                 **kwargs, port)
+    res = update(zone, name, ttl, 'A', ip, nameserver, timeout, replace, port,
+                 **kwargs)
     if res is False:
         return False
 
@@ -102,14 +102,14 @@ def add_host(zone, name, ttl, ip, nameserver='127.0.0.1', replace=True,
         zone = '{0}.{1}'.format('.'.join(parts), 'in-addr.arpa.')
         name = '.'.join(popped)
         ptr = update(zone, name, ttl, 'PTR', fqdn, nameserver, timeout,
-                     replace, **kwargs, port)
+                     replace, port, **kwargs)
         if ptr:
             return True
     return res
 
 
-def delete_host(zone, name, nameserver='127.0.0.1', timeout=5, **kwargs,
-               port=53):
+def delete_host(zone, name, nameserver='127.0.0.1', timeout=5, port=53,
+                **kwargs):
     '''
     Delete the forward and reverse records for a host.
 
@@ -129,8 +129,8 @@ def delete_host(zone, name, nameserver='127.0.0.1', timeout=5, **kwargs,
     except IndexError:
         ips = []
 
-    res = delete(zone, name, nameserver=nameserver, timeout=timeout, **kwargs,
-                 port=port)
+    res = delete(zone, name, nameserver=nameserver, timeout=timeout, port=port,
+                 **kwargs)
 
     fqdn = fqdn + '.'
     for ip in ips:
@@ -144,14 +144,14 @@ def delete_host(zone, name, nameserver='127.0.0.1', timeout=5, **kwargs,
             zone = '{0}.{1}'.format('.'.join(parts), 'in-addr.arpa.')
             name = '.'.join(popped)
             ptr = delete(zone, name, 'PTR', fqdn, nameserver=nameserver,
-                         timeout=timeout, **kwargs, port=port)
+                         timeout=timeout, port=port, **kwargs)
         if ptr:
             res = True
     return res
 
 
 def update(zone, name, ttl, rdtype, data, nameserver='127.0.0.1', timeout=5,
-           replace=False, **kwargs, port=53):
+           replace=False, port=53, **kwargs):
     '''
     Add, replace, or update a DNS record.
     nameserver must be an IP address and the minion running this module
@@ -198,7 +198,7 @@ def update(zone, name, ttl, rdtype, data, nameserver='127.0.0.1', timeout=5,
 
 
 def delete(zone, name, rdtype=None, data=None, nameserver='127.0.0.1',
-           timeout=5, **kwargs, port=53):
+           timeout=5, port=53, **kwargs):
     '''
     Delete a DNS record.
 

--- a/salt/modules/ddns.py
+++ b/salt/modules/ddns.py
@@ -75,8 +75,8 @@ def _get_keyring(keyfile):
     return keyring
 
 
-def add_host(zone, name, ttl, ip, nameserver='127.0.0.1', port=53,
-             replace=True, timeout=5, **kwargs):
+def add_host(zone, name, ttl, ip, nameserver='127.0.0.1', replace=True,
+             timeout=5, **kwargs, port=53):
     '''
     Add, replace, or update the A and PTR (reverse) records for a host.
 
@@ -86,8 +86,8 @@ def add_host(zone, name, ttl, ip, nameserver='127.0.0.1', port=53,
 
         salt ns1 ddns.add_host example.com host1 60 10.1.1.1
     '''
-    res = update(zone, name, ttl, 'A', ip, nameserver, port, timeout, replace,
-                 **kwargs)
+    res = update(zone, name, ttl, 'A', ip, nameserver, timeout, replace,
+                 **kwargs, port)
     if res is False:
         return False
 
@@ -101,15 +101,15 @@ def add_host(zone, name, ttl, ip, nameserver='127.0.0.1', port=53,
         popped.append(p)
         zone = '{0}.{1}'.format('.'.join(parts), 'in-addr.arpa.')
         name = '.'.join(popped)
-        ptr = update(zone, name, ttl, 'PTR', fqdn, nameserver, port, timeout,
-                     replace, **kwargs)
+        ptr = update(zone, name, ttl, 'PTR', fqdn, nameserver, timeout,
+                     replace, **kwargs, port)
         if ptr:
             return True
     return res
 
 
-def delete_host(zone, name, nameserver='127.0.0.1', port=53, timeout=5,
-                **kwargs):
+def delete_host(zone, name, nameserver='127.0.0.1', timeout=5, **kwargs,
+               port=53):
     '''
     Delete the forward and reverse records for a host.
 
@@ -129,8 +129,8 @@ def delete_host(zone, name, nameserver='127.0.0.1', port=53, timeout=5,
     except IndexError:
         ips = []
 
-    res = delete(zone, name, nameserver=nameserver, port=port, timeout=timeout,
-                 **kwargs)
+    res = delete(zone, name, nameserver=nameserver, timeout=timeout, **kwargs,
+                 port=port)
 
     fqdn = fqdn + '.'
     for ip in ips:
@@ -144,14 +144,14 @@ def delete_host(zone, name, nameserver='127.0.0.1', port=53, timeout=5,
             zone = '{0}.{1}'.format('.'.join(parts), 'in-addr.arpa.')
             name = '.'.join(popped)
             ptr = delete(zone, name, 'PTR', fqdn, nameserver=nameserver,
-                         port=port, timeout=timeout, **kwargs)
+                         timeout=timeout, **kwargs, port=port)
         if ptr:
             res = True
     return res
 
 
-def update(zone, name, ttl, rdtype, data, nameserver='127.0.0.1', port=53,
-           timeout=5, replace=False, **kwargs):
+def update(zone, name, ttl, rdtype, data, nameserver='127.0.0.1', timeout=5,
+           replace=False, **kwargs, port=53):
     '''
     Add, replace, or update a DNS record.
     nameserver must be an IP address and the minion running this module
@@ -198,7 +198,7 @@ def update(zone, name, ttl, rdtype, data, nameserver='127.0.0.1', port=53,
 
 
 def delete(zone, name, rdtype=None, data=None, nameserver='127.0.0.1',
-           port=53, timeout=5, **kwargs):
+           timeout=5, **kwargs, port=53):
     '''
     Delete a DNS record.
 

--- a/salt/runners/ddns.py
+++ b/salt/runners/ddns.py
@@ -53,7 +53,8 @@ def _get_keyring(keyfile):
     return keyring
 
 
-def create(zone, name, ttl, rdtype, data, keyname, keyfile, nameserver, timeout):
+def create(zone, name, ttl, rdtype, data, keyname, keyfile, nameserver,
+           timeout, port=53, keyalgorithm='hmac-md5'):
     '''
     Create a DNS record. The nameserver must be an IP address and the master running
     this runner must have create privileges on that server.
@@ -62,13 +63,13 @@ def create(zone, name, ttl, rdtype, data, keyname, keyfile, nameserver, timeout)
 
     .. code-block:: bash
 
-        salt-run ddns.create domain.com my-test-vm 3600 A 10.20.30.40 5 my-tsig-key /etc/salt/tsig.keyring 10.0.0.1
+        salt-run ddns.create domain.com my-test-vm 3600 A 10.20.30.40 my-tsig-key /etc/salt/tsig.keyring 10.0.0.1 5
     '''
     if zone in name:
         name = name.replace(zone, '').rstrip('.')
     fqdn = '{0}.{1}'.format(name, zone)
     request = dns.message.make_query(fqdn, rdtype)
-    answer = dns.query.udp(request, nameserver, timeout)
+    answer = dns.query.udp(request, nameserver, timeout, port)
 
     rdata_value = dns.rdatatype.from_text(rdtype)
     rdata = dns.rdata.from_text(dns.rdataclass.IN, rdata_value, data)
@@ -79,17 +80,19 @@ def create(zone, name, ttl, rdtype, data, keyname, keyfile, nameserver, timeout)
 
     keyring = _get_keyring(keyfile)
 
-    dns_update = dns.update.Update(zone, keyring=keyring, keyname=keyname)
+    dns_update = dns.update.Update(zone, keyring=keyring, keyname=keyname,
+                                   keyalgorithm=keyalgorithm)
     dns_update.add(name, ttl, rdata)
 
-    answer = dns.query.udp(dns_update, nameserver, timeout)
+    answer = dns.query.udp(dns_update, nameserver, timeout, port)
     if answer.rcode() > 0:
         return {fqdn: 'Failed to create record of type \'{0}\''.format(rdtype)}
 
     return {fqdn: 'Created record of type \'{0}\': {1} -> {2}'.format(rdtype, fqdn, data)}
 
 
-def update(zone, name, ttl, rdtype, data, keyname, keyfile, nameserver, timeout, replace=False):
+def update(zone, name, ttl, rdtype, data, keyname, keyfile, nameserver,
+           timeout, replace=False, port=53, keyalgorithm='hmac-md5'):
     '''
     Replace, or update a DNS record. The nameserver must be an IP address and the master running
     this runner must have update privileges on that server.
@@ -103,13 +106,13 @@ def update(zone, name, ttl, rdtype, data, keyname, keyfile, nameserver, timeout,
 
     .. code-block:: bash
 
-        salt-run ddns.update domain.com my-test-vm 3600 A 10.20.30.40 5 my-tsig-key /etc/salt/tsig.keyring 10.0.0.1
+        salt-run ddns.update domain.com my-test-vm 3600 A 10.20.30.40 my-tsig-key /etc/salt/tsig.keyring 10.0.0.1 5
     '''
     if zone in name:
         name = name.replace(zone, '').rstrip('.')
     fqdn = '{0}.{1}'.format(name, zone)
     request = dns.message.make_query(fqdn, rdtype)
-    answer = dns.query.udp(request, nameserver, timeout)
+    answer = dns.query.udp(request, nameserver, timeout, port)
     if not answer.answer:
         return {fqdn: 'No matching DNS record(s) found'}
 
@@ -128,17 +131,19 @@ def update(zone, name, ttl, rdtype, data, keyname, keyfile, nameserver, timeout,
 
     keyring = _get_keyring(keyfile)
 
-    dns_update = dns.update.Update(zone, keyring=keyring, keyname=keyname)
+    dns_update = dns.update.Update(zone, keyring=keyring, keyname=keyname,
+                                   keyalgorithm=keyalgorithm)
     dns_update.replace(name, ttl, rdata)
 
-    answer = dns.query.udp(dns_update, nameserver, timeout)
+    answer = dns.query.udp(dns_update, nameserver, timeout, port)
     if answer.rcode() > 0:
         return {fqdn: 'Failed to update record of type \'{0}\''.format(rdtype)}
 
     return {fqdn: 'Updated record of type \'{0}\''.format(rdtype)}
 
 
-def delete(zone, name, keyname, keyfile, nameserver, timeout, rdtype=None, data=None):
+def delete(zone, name, keyname, keyfile, nameserver, timeout, rdtype=None,
+           data=None, port=53, keyalgorithm='hmac-md5'):
     '''
     Delete a DNS record.
 
@@ -146,20 +151,21 @@ def delete(zone, name, keyname, keyfile, nameserver, timeout, rdtype=None, data=
 
     .. code-block:: bash
 
-        salt-run ddns.delete domain.com my-test-vm my-tsig-key /etc/salt/tsig.keyring 10.0.0.1 A
+        salt-run ddns.delete domain.com my-test-vm my-tsig-key /etc/salt/tsig.keyring 10.0.0.1 5 A
     '''
     if zone in name:
         name = name.replace(zone, '').rstrip('.')
     fqdn = '{0}.{1}'.format(name, zone)
     request = dns.message.make_query(fqdn, (rdtype or 'ANY'))
 
-    answer = dns.query.udp(request, nameserver, timeout)
+    answer = dns.query.udp(request, nameserver, timeout, port)
     if not answer.answer:
         return {fqdn: 'No matching DNS record(s) found'}
 
     keyring = _get_keyring(keyfile)
 
-    dns_update = dns.update.Update(zone, keyring=keyring, keyname=keyname)
+    dns_update = dns.update.Update(zone, keyring=keyring, keyname=keyname,
+                                   keyalgorithm=keyalgorithm)
 
     if rdtype:
         rdata_value = dns.rdatatype.from_text(rdtype)
@@ -171,14 +177,15 @@ def delete(zone, name, keyname, keyfile, nameserver, timeout, rdtype=None, data=
     else:
         dns_update.delete(name)
 
-    answer = dns.query.udp(dns_update, nameserver, timeout)
+    answer = dns.query.udp(dns_update, nameserver, timeout, port)
     if answer.rcode() > 0:
         return {fqdn: 'Failed to delete DNS record(s)'}
 
     return {fqdn: 'Deleted DNS record(s)'}
 
 
-def add_host(zone, name, ttl, ip, keyname, keyfile, nameserver, timeout):
+def add_host(zone, name, ttl, ip, keyname, keyfile, nameserver, timeout,
+             port=53, keyalgorithm='hmac-md5'):
     '''
     Create both A and PTR (reverse) records for a host.
 
@@ -186,14 +193,15 @@ def add_host(zone, name, ttl, ip, keyname, keyfile, nameserver, timeout):
 
     .. code-block:: bash
 
-        salt-run ddns.add_host domain.com my-test-vm 3600 10.20.30.40 5 my-tsig-key /etc/salt/tsig.keyring 10.0.0.1
+        salt-run ddns.add_host domain.com my-test-vm 3600 10.20.30.40 my-tsig-key /etc/salt/tsig.keyring 10.0.0.1 5
     '''
     res = []
     if zone in name:
         name = name.replace(zone, '').rstrip('.')
     fqdn = '{0}.{1}'.format(name, zone)
 
-    ret = create(zone, name, ttl, 'A', ip, keyname, keyfile, nameserver, timeout)
+    ret = create(zone, name, ttl, 'A', ip, keyname, keyfile, nameserver,
+                 timeout, port, keyalgorithm)
     res.append(ret[fqdn])
 
     parts = ip.split('.')[::-1]
@@ -209,7 +217,8 @@ def add_host(zone, name, ttl, ip, keyname, keyfile, nameserver, timeout):
         zone = '{0}.{1}'.format('.'.join(parts), 'in-addr.arpa.')
         name = '.'.join(popped)
         rev_fqdn = '{0}.{1}'.format(name, zone)
-        ret = create(zone, name, ttl, 'PTR', "{0}.".format(fqdn), keyname, keyfile, nameserver, timeout)
+        ret = create(zone, name, ttl, 'PTR', "{0}.".format(fqdn), keyname,
+                     keyfile, nameserver, timeout, port, keyalgorithm)
 
         if "Created" in ret[rev_fqdn]:
             res.append(ret[rev_fqdn])
@@ -220,7 +229,8 @@ def add_host(zone, name, ttl, ip, keyname, keyfile, nameserver, timeout):
     return {fqdn: res}
 
 
-def delete_host(zone, name, keyname, keyfile, nameserver, timeout):
+def delete_host(zone, name, keyname, keyfile, nameserver, timeout, port=53,
+                keyalgorithm='hmac-md5'):
     '''
     Delete both forward (A) and reverse (PTR) records for a host only if the
     forward (A) record exists.
@@ -229,21 +239,22 @@ def delete_host(zone, name, keyname, keyfile, nameserver, timeout):
 
     .. code-block:: bash
 
-        salt-run ddns.delete_host domain.com my-test-vm my-tsig-key /etc/salt/tsig.keyring 10.0.0.1
+        salt-run ddns.delete_host domain.com my-test-vm my-tsig-key /etc/salt/tsig.keyring 10.0.0.1 5
     '''
     res = []
     if zone in name:
         name = name.replace(zone, '').rstrip('.')
     fqdn = '{0}.{1}'.format(name, zone)
     request = dns.message.make_query(fqdn, 'A')
-    answer = dns.query.udp(request, nameserver, timeout)
+    answer = dns.query.udp(request, nameserver, timeout, port)
 
     try:
         ips = [i.address for i in answer.answer[0].items]
     except IndexError:
         ips = []
 
-    ret = delete(zone, name, keyname, keyfile, nameserver, timeout)
+    ret = delete(zone, name, keyname, keyfile, nameserver, timeout, port=port,
+                 keyalgorithm=keyalgorithm)
     res.append("{0} of type \'A\'".format(ret[fqdn]))
 
     for ip in ips:
@@ -259,7 +270,8 @@ def delete_host(zone, name, keyname, keyfile, nameserver, timeout):
             zone = '{0}.{1}'.format('.'.join(parts), 'in-addr.arpa.')
             name = '.'.join(popped)
             rev_fqdn = '{0}.{1}'.format(name, zone)
-            ret = delete(zone, name, keyname, keyfile, nameserver, timeout, 'PTR', "{0}.".format(fqdn))
+            ret = delete(zone, name, keyname, keyfile, nameserver, timeout,
+                         'PTR', "{0}.".format(fqdn), port, keyalgorithm)
 
             if "Deleted" in ret[rev_fqdn]:
                 res.append("{0} of type \'PTR\'".format(ret[rev_fqdn]))


### PR DESCRIPTION
### What does this PR do?

Adds a port argument to the ddns module and ddns runner to support non-standard nameserver ports.
Allows the ddns runner to support all dnspython TSIG key algorithms through an additional argument.
### What issues does this PR fix or reference?

Did not find any, fixes own use case.
### Previous Behavior

End user was unable to select a nameserver running on a non-standard port.
ddns runner could not use any TSIG key except for hmac-md5.
### Tests written?

No