### PR TITLE
Bugfix: Startup states on minions are not being written to mysql returner

### DIFF
--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -246,6 +246,11 @@ def returner(ret):
     '''
     Return data to a mysql server
     '''
+    # if a minion is returning a standalone job, get a jobid
+    if ret['jid'] == 'req':
+        ret['jid'] = prep_jid(nocache=ret.get('nocache', False))
+        save_load(ret['jid'], ret)
+
     try:
         with _get_serv(ret, commit=True) as cur:
             sql = '''INSERT INTO `salt_returns`


### PR DESCRIPTION
### What does this PR do?

Allows salt-run jobs.list_jobs etc. to work correctly with a minion triggered mysql returner.
Sets a proper jid for minion based mysql returner, similar to local_cache returner.
### What issues does this PR fix or reference?

If a startup state is specified and 'ext_job_cache' is set to 'mysql' on a minion. The mysql returner does not correctly write the state run to Mysql.
### New Behavior

Minion will write the startup state to mysql.
Master runners have visibility of the startup state run.
### Tests written?

No