### PR TITLE
Remove all object.iteritems() references from the tests/ directory

### DIFF
--- a/tests/integration/cloud/helpers/virtualbox.py
+++ b/tests/integration/cloud/helpers/virtualbox.py
@@ -1,16 +1,22 @@
 # -*- coding: utf-8 -*-
+
+# Import Python libs
 from __future__ import absolute_import
-from unittest2 import skipIf
-from integration.cloud.helpers import random_name
-from salt.utils import virtualbox
 import json
 import logging
 import os
 import unittest
+
+# Import Salt Testing libs
+from salttesting import skipIf
+
+# Import Salt libs
+import salt.ext.six as six
 import integration
+from salt.utils import virtualbox
 
 # Create the cloud instance name to be used throughout the tests
-INSTANCE_NAME = random_name()
+INSTANCE_NAME = integration.cloud.helpers.random_name()
 PROVIDER_NAME = "virtualbox"
 CONFIG_NAME = PROVIDER_NAME + "-config"
 PROFILE_NAME = PROVIDER_NAME + "-test"
@@ -98,7 +104,7 @@ class VirtualboxCloudTestCase(integration.ShellCase):
         if kw_function_args:
             args = [
                 "{0}='{1}'".format(key, value)
-                for key, value in kw_function_args.iteritems()
+                for key, value in six.iteritems(kw_function_args)
                 ]
 
         output = self.run_cloud("-f {0} {1} {2}".format(function, CONFIG_NAME, " ".join(args)), **kwargs)

--- a/tests/integration/cloud/providers/virtualbox.py
+++ b/tests/integration/cloud/providers/virtualbox.py
@@ -4,8 +4,6 @@
 
 # Import Python Libs
 from __future__ import absolute_import
-from salt.ext.six.moves import range
-
 import os
 import unittest
 import logging
@@ -22,6 +20,8 @@ from integration.cloud.helpers.virtualbox import VirtualboxTestCase, VirtualboxC
 ensure_in_syspath('../../../')
 
 # Import Salt Libs
+import salt.ext.six as six
+from salt.ext.six.moves import range
 import integration
 from salt.config import cloud_providers_config, vm_profiles_config
 from utils.virtualbox import vb_xpcom_to_attribute_dict, vb_clone_vm, vb_destroy_machine, vb_create_machine, \
@@ -138,7 +138,7 @@ class VirtualboxProviderTest(VirtualboxCloudTestCase):
         expected_attributes = MINIMAL_MACHINE_ATTRIBUTES
         names = machines.keys()
         self.assertGreaterEqual(len(names), 1, "No machines found")
-        for name, machine in machines.iteritems():
+        for name, machine in six.iteritems(machines):
             self.assertItemsEqual(expected_attributes, machine.keys())
 
         self.assertIn(BASE_BOX_NAME, names)
@@ -152,7 +152,7 @@ class VirtualboxProviderTest(VirtualboxCloudTestCase):
 
         names = machines.keys()
         self.assertGreaterEqual(len(names), 1, "No machines found")
-        for name, machine in machines.iteritems():
+        for name, machine in six.iteritems(machines):
             self.assertGreaterEqual(len(machine.keys()), expected_minimal_attribute_count)
 
         self.assertIn(BASE_BOX_NAME, names)
@@ -167,7 +167,7 @@ class VirtualboxProviderTest(VirtualboxCloudTestCase):
 
         names = machines.keys()
         self.assertGreaterEqual(len(names), 1, "No machines found")
-        for name, machine in machines.iteritems():
+        for name, machine in six.iteritems(machines):
             self.assertItemsEqual(expected_attributes, machine.keys())
 
         self.assertIn(BASE_BOX_NAME, names)
@@ -399,7 +399,7 @@ class XpcomConversionTests(unittest.TestCase):
         o = XPCOM()
 
         if attributes and isinstance(attributes, dict):
-            for key, value in attributes.iteritems():
+            for key, value in six.iteritems(attributes):
                 setattr(o, key, value)
         return o
 

--- a/tests/integration/loader/interfaces.py
+++ b/tests/integration/loader/interfaces.py
@@ -16,6 +16,7 @@ from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../')
 
 # Import Salt libs
+import salt.ext.six as six
 from salt.config import minion_config
 
 import salt.loader
@@ -30,7 +31,7 @@ class RawModTest(TestCase):
     def test_basic(self):
         self.opts = minion_config(None)
         testmod = salt.loader.raw_mod(self.opts, 'test', None)
-        for k, v in testmod.iteritems():
+        for k, v in six.iteritems(testmod):
             self.assertEqual(k.split('.')[0], 'test')
 
     def test_bad_name(self):

--- a/tests/unit/modules/boto_elasticsearch_domain_test.py
+++ b/tests/unit/modules/boto_elasticsearch_domain_test.py
@@ -10,18 +10,20 @@ import string
 
 # Import Salt Testing libs
 from salttesting.unit import skipIf, TestCase
-from salttesting.mock import NO_MOCK, NO_MOCK_REASON, patch
+from salttesting.mock import (
+    NO_MOCK,
+    NO_MOCK_REASON,
+    MagicMock,
+    patch
+)
 from salttesting.helpers import ensure_in_syspath
 
 ensure_in_syspath('../../')
 
 # Import Salt libs
-import salt.config
+import salt.ext.six as six
 import salt.loader
 from salt.modules import boto_elasticsearch_domain
-
-# Import Mock libraries
-from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
 
 # Import 3rd-party libs
 
@@ -177,7 +179,7 @@ class BotoElasticsearchDomainTestCase(BotoElasticsearchDomainTestCaseBase, BotoE
         Tests describing parameters if domain exists
         '''
         domainconfig = {}
-        for k, v in domain_ret.iteritems():
+        for k, v in six.iteritems(domain_ret):
             if k == 'DomainName':
                 continue
             domainconfig[k] = {'Options': v}

--- a/tests/unit/modules/boto_s3_bucket_test.py
+++ b/tests/unit/modules/boto_s3_bucket_test.py
@@ -20,7 +20,7 @@ from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../')
 
 # Import Salt libs
-import salt.config
+import salt.ext.six as six
 import salt.loader
 from salt.modules import boto_s3_bucket
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
@@ -310,7 +310,7 @@ class BotoS3BucketTestCase(BotoS3BucketTestCaseBase, BotoS3BucketTestCaseMixin):
         '''
         Tests describing parameters if bucket exists
         '''
-        for key, value in config_ret.iteritems():
+        for key, value in six.iteritems(config_ret):
             getattr(self.conn, key).return_value = deepcopy(value)
 
         result = boto_s3_bucket.describe(Bucket='mybucket', **conn_parameters)

--- a/tests/unit/transport/ipc_test.py
+++ b/tests/unit/transport/ipc_test.py
@@ -19,11 +19,11 @@ import salt.transport.ipc
 import salt.transport.server
 import salt.transport.client
 
+import salt.ext.six as six
 from salt.ext.six.moves import range
 
 # Import Salt Testing libs
 import integration
-
 from salttesting.mock import MagicMock
 from salttesting.helpers import ensure_in_syspath
 
@@ -55,7 +55,7 @@ class BaseIPCReqCase(tornado.testing.AsyncTestCase):
         failures = []
         self.server_channel.close()
         os.unlink(self.socket_path)
-        for k, v in self.io_loop._handlers.iteritems():
+        for k, v in six.iteritems(self.io_loop._handlers):
             if self._start_handlers.get(k) != v:
                 failures.append((k, v))
         if len(failures) > 0:

--- a/tests/unit/transport/req_test.py
+++ b/tests/unit/transport/req_test.py
@@ -1,5 +1,11 @@
 # -*- coding: utf-8 -*-
 
+# Import Python libs
+from __future__ import absolute_import
+
+# Import Salt libs
+import salt.ext.six as six
+
 
 class ReqChannelMixin(object):
     def test_basic(self):
@@ -27,7 +33,7 @@ class ReqChannelMixin(object):
         ]
         for msg in msgs:
             ret = self.channel.send(msg, timeout=2, tries=1)
-            for k, v in ret['load'].iteritems():
+            for k, v in six.iteritems(ret['load']):
                 self.assertEqual(types[k], type(v))
 
     def test_badload(self):

--- a/tests/unit/transport/tcp_test.py
+++ b/tests/unit/transport/tcp_test.py
@@ -13,6 +13,7 @@ import tornado.ioloop
 from tornado.testing import AsyncTestCase
 
 import salt.config
+import salt.ext.six as six
 import salt.utils
 import salt.transport.server
 import salt.transport.client
@@ -173,7 +174,7 @@ class BaseTCPPubCase(AsyncTestCase):
     def tearDown(self):
         super(BaseTCPPubCase, self).tearDown()
         failures = []
-        for k, v in self.io_loop._handlers.iteritems():
+        for k, v in six.iteritems(self.io_loop._handlers):
             if self._start_handlers.get(k) != v:
                 failures.append((k, v))
         if len(failures) > 0:

--- a/tests/unit/transport/zeromq_test.py
+++ b/tests/unit/transport/zeromq_test.py
@@ -19,6 +19,7 @@ from tornado.testing import AsyncTestCase
 import tornado.gen
 
 import salt.config
+import salt.ext.six as six
 import salt.utils
 import salt.transport.server
 import salt.transport.client
@@ -182,7 +183,7 @@ class BaseZMQPubCase(AsyncTestCase):
     def tearDown(self):
         super(BaseZMQPubCase, self).tearDown()
         failures = []
-        for k, v in self.io_loop._handlers.iteritems():
+        for k, v in six.iteritems(self.io_loop._handlers):
             if self._start_handlers.get(k) != v:
                 failures.append((k, v))
         if len(failures) > 0:


### PR DESCRIPTION
And switch them to use `six.iteritems(object)` instead, for Python 3 compatibility.