### PR TITLE
win_timezone: Make timezones on Windows more compatibile with Linux

### DIFF
--- a/salt/modules/win_timezone.py
+++ b/salt/modules/win_timezone.py
@@ -251,6 +251,7 @@ LINTOWIN = {
     'Asia/Jerusalem': 'Israel Standard Time',
     'Asia/Kabul': 'Afghanistan Standard Time',
     'Asia/Karachi': 'Pakistan Standard Time',
+    'Asia/Kathmandu': 'Nepal Standard Time',
     'Asia/Katmandu': 'Nepal Standard Time',
     'Asia/Krasnoyarsk': 'North Asia Standard Time',
     'Asia/Kuala_Lumpur': 'Singapore Standard Time',


### PR DESCRIPTION
What does this PR do?
This PR makes setting timezones on Windows and Linux compatible for Nepal Standard Time. On Linux, zone.tab uses Asia/Kathmandu, which does not match the previous win_timezone value of Asia/Katmandu. Now, Asia/Kathmandu is supported on both platforms.

Previous Behavior
Setting the timezone to 'Asia/Kathmandu' on Windows would fail.

New Behavior
Setting the timezone to 'Asia/Kathmandu' on Windows successfully sets the timezone to Nepal Standard Time.

Tests written?
No