### PR TITLE
Renable the pam execution module unit test

### DIFF
--- a/tests/unit/modules/pam_test.py
+++ b/tests/unit/modules/pam_test.py
@@ -27,7 +27,7 @@ MOCK_FILE = 'ok ok ignore '
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
-@skipIf(not sys.platform.startswith('OpenBSD'), 'OpenBSD does not use PAM')
+@skipIf(sys.platform.startswith('OpenBSD'), 'OpenBSD does not use PAM')
 class PamTestCase(TestCase):
     '''
     Test cases for salt.modules.pam


### PR DESCRIPTION
The logic wasn't correct on the skipIF. We want these test to run when `sys.platform.startswith('OpenBSD')` is False.