### PR TITLE
salt/state.py: set `chunk['order'] = 0' with `order: first'; fixes #24744

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -512,6 +512,8 @@ class Compiler(object):
             if not isinstance(chunk['order'], (int, float)):
                 if chunk['order'] == 'last':
                     chunk['order'] = cap + 1000000
+                elif chunk['order'] == 'first':
+                    chunk['order'] = 0
                 else:
                     chunk['order'] = cap
             if 'name_order' in chunk:
@@ -1140,6 +1142,8 @@ class State(object):
             if not isinstance(chunk['order'], (int, float)):
                 if chunk['order'] == 'last':
                     chunk['order'] = cap + 1000000
+                elif chunk['order'] == 'first':
+                    chunk['order'] = 0
                 else:
                     chunk['order'] = cap
             if 'name_order' in chunk:


### PR DESCRIPTION
### What does this PR do?

Fixes behavior of 'order: first' (explain in further detail in the commit message and below)
### What issues does this PR fix or reference?
#24744 and the later (closed) saltstack/salt#26278
### Previous Behavior

Explained in commit message.
### New Behavior

First goes first :)
### Tests written?

No. Tested manually before removing the debug logging and committing.
### Commit Message

salt/state.py: set chunk['order'] = 0' withorder: first'; fixes saltstack/salt#24744

Currently the `order: first' keyword executes later states without order
options. Consider a test case such as:

``` SaltStack
sleep 1:
  cmd.run:
    - order: first
sleep 2:
  cmd.run
sleep 3:
  cmd.run
sleep 4:
  cmd.run:
    - order: last
```

The contents of each chunk dictionary at runtime show that the 'first' state
is not evaluated to 'first'.

{'name': 'sleep 4', 'state': 'cmd', '**id**': 'sleep 4', 'fun': 'run', '**env**': 'base', '**sls**': u'test', 'order': 1010100}
{'name': 'sleep 2', 'state': 'cmd', '**id**': 'sleep 2', 'fun': 'run', '**env**': 'base', '**sls**': u'test', 'order': 10000}
{'name': 'sleep 3', 'state': 'cmd', '**id**': 'sleep 3', 'fun': 'run', '**env**': 'base', '**sls**': u'test', 'order': 10001}
{'name': 'sleep 1', 'state': 'cmd', '**id**': 'sleep 1', 'fun': 'run', '**env**': 'base', '**sls**': u'test', 'order': 10100}