### PR TITLE
Feature addition: preserve mode in file states

### DIFF
--- a/doc/topics/releases/carbon.rst
+++ b/doc/topics/releases/carbon.rst
@@ -20,6 +20,13 @@ Features
   SSL can be enabled by setting ``ssl_options`` for the returner.
   Also added support for specifying ``protocol_version`` when establishing
   cluster connection.
+- The ``mode`` parameter in the :py:mod:`file.managed
+  <salt.states.file.managed>` state, and the ``file_mode`` parameter in the
+  :py:mod:`file.managed <salt.states.file.managed>`, can both now be set to
+  ``keep`` and the minion will keep the mode of the file from the Salt
+  fileserver. This works only with files coming from sources prefixed with
+  ``salt://``, or files local to the minion (i.e. those which are absolute
+  paths, or are prefixed with ``file://``).
 
 Config Changes
 ==============

--- a/salt/client/ssh/wrapper/config.py
+++ b/salt/client/ssh/wrapper/config.py
@@ -78,12 +78,10 @@ def manage_mode(mode):
 
         salt '*' config.manage_mode
     '''
-    if mode is None:
-        return None
-    ret = str(mode).lstrip('0').zfill(4)
-    if ret[0] != '0':
-        return '0{0}'.format(ret)
-    return ret
+    # config.manage_mode should no longer be invoked from the __salt__ dunder
+    # in Salt code, this function is only being left here for backwards
+    # compatibility.
+    return salt.utils.normalize_mode(mode)
 
 
 def valid_fileproto(uri):

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -451,6 +451,7 @@ class RemoteFuncs(object):
         '''
         fs_ = salt.fileserver.Fileserver(self.opts)
         self._serve_file = fs_.serve_file
+        self._file_find = fs_._find_file
         self._file_hash = fs_.file_hash
         self._file_list = fs_.file_list
         self._file_list_emptydirs = fs_.file_list_emptydirs

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import
 # Import python libs
 import contextlib
 import logging
-import hashlib
 import os
 import shutil
 import ftplib
@@ -749,9 +748,27 @@ class LocalClient(Client):
         '''
         path = self._check_proto(path)
         fnd = self._find_file(path, saltenv)
-        if not fnd['path']:
+        fnd_path = fnd.get('path')
+        if not fnd_path:
             return ''
-        return fnd['path']
+
+        try:
+            fnd_mode = fnd.get('stat', [])[0]
+        except (IndexError, TypeError):
+            fnd_mode = None
+
+        if not salt.utils.is_windows():
+            if fnd_mode is not None:
+                try:
+                    if os.stat(dest).st_mode != fnd_mode:
+                        try:
+                            os.chmod(dest, fnd_mode)
+                        except OSError as exc:
+                            log.warning('Failed to chmod %s: %s', dest, exc)
+                except Exception:
+                    pass
+
+        return fnd_path
 
     def file_list(self, saltenv='base', prefix=''):
         '''
@@ -804,6 +821,22 @@ class LocalClient(Client):
                 ret.append(sdecode(os.path.relpath(root, path)))
         return ret
 
+    def __get_file_path(self, path, saltenv='base'):
+        '''
+        Return either a file path or the result of a remote find_file call.
+        '''
+        try:
+            path = self._check_proto(path)
+        except MinionError as err:
+            # Local file path
+            if not os.path.isfile(path):
+                msg = 'specified file {0} is not present to generate hash: {1}'
+                log.warning(msg.format(path, err))
+                return None
+            else:
+                return path
+        return self._find_file(path, saltenv)
+
     def hash_file(self, path, saltenv='base'):
         '''
         Return the hash of a file, to get the hash of a file in the file_roots
@@ -811,26 +844,51 @@ class LocalClient(Client):
         file with / for a local file.
         '''
         ret = {}
+        fnd = self.__get_file_path(path, saltenv)
+        if fnd is None:
+            return ret
+
         try:
-            path = self._check_proto(path)
-        except MinionError as err:
-            if not os.path.isfile(path):
-                msg = 'specified file {0} is not present to generate hash: {1}'
-                log.warning(msg.format(path, err))
-                return ret
-            else:
-                opts_hash_type = self.opts.get('hash_type', 'md5')
-                hash_type = getattr(hashlib, opts_hash_type)
-                ret['hsum'] = salt.utils.get_hash(
-                    path, form=hash_type)
-                ret['hash_type'] = opts_hash_type
-                return ret
-        path = self._find_file(path, saltenv)['path']
-        if not path:
-            return {}
+            # Remote file path (self._find_file() invoked)
+            fnd_path = fnd['path']
+        except TypeError:
+            # Local file path
+            fnd_path = fnd
+
+        hash_type = self.opts.get('hash_type', 'md5')
+        ret['hsum'] = salt.utils.get_hash(fnd_path, form=hash_type)
+        ret['hash_type'] = hash_type
+        return ret
+
+    def hash_and_stat_file(self, path, saltenv='base'):
+        '''
+        Return the hash of a file, to get the hash of a file in the file_roots
+        prepend the path with salt://<file on server> otherwise, prepend the
+        file with / for a local file.
+
+        Additionally, return the stat result of the file, or None if no stat
+        results were found.
+        '''
         ret = {}
-        ret['hsum'] = salt.utils.get_hash(path, self.opts['hash_type'])
-        ret['hash_type'] = self.opts['hash_type']
+        fnd = self.__get_file_path(path, saltenv)
+        if fnd is None:
+            return ret, None
+
+        try:
+            # Remote file path (self._find_file() invoked)
+            fnd_path = fnd['path']
+            fnd_stat = fnd.get('stat')
+        except TypeError:
+            # Local file path
+            fnd_path = fnd
+            try:
+                fnd_stat = list(os.stat(fnd_path))
+            except Exception:
+                fnd_stat = None
+
+        hash_type = self.opts.get('hash_type', 'md5')
+        ret['hsum'] = salt.utils.get_hash(fnd_path, form=hash_type)
+        ret['hash_type'] = hash_type
         return ret
 
     def list_env(self, saltenv='base'):
@@ -906,13 +964,22 @@ class RemoteClient(Client):
         if senv:
             saltenv = senv
 
+        if not salt.utils.is_windows():
+            hash_server, stat_server = self.hash_and_stat_file(path, saltenv)
+            try:
+                mode_server = stat_server[0]
+            except (IndexError, TypeError):
+                mode_server = None
+        else:
+            hash_server = self.hash_file(path, saltenv)
+            mode_server = None
+
         # Check if file exists on server, before creating files and
         # directories
-        hash_server = self.hash_file(path, saltenv)
         if hash_server == '':
             log.debug(
-                'Could not find file from saltenv \'%s\', \'%s\'',
-                saltenv, path
+                'Could not find file \'%s\' in saltenv \'%s\'',
+                path, saltenv
             )
             return False
 
@@ -936,13 +1003,59 @@ class RemoteClient(Client):
         )
 
         if dest2check and os.path.isfile(dest2check):
-            hash_local = self.hash_file(dest2check, saltenv)
+            if not salt.utils.is_windows():
+                hash_local, stat_local = \
+                    self.hash_and_stat_file(dest2check, saltenv)
+                try:
+                    mode_local = stat_local[0]
+                except IndexError:
+                    mode_local = None
+            else:
+                hash_local = self.hash_file(dest2check, saltenv)
+                mode_local = None
+
             if hash_local == hash_server:
-                log.info(
-                    'Fetching file from saltenv \'%s\', ** skipped ** '
-                    'latest already in cache \'%s\'', saltenv, path
-                )
-                return dest2check
+                if not salt.utils.is_windows():
+                    if mode_server is None:
+                        log.debug('No file mode available for \'%s\'', path)
+                    elif mode_local is None:
+                        log.debug(
+                            'No file mode available for \'%s\'',
+                            dest2check
+                        )
+                    else:
+                        if mode_server == mode_local:
+                            log.info(
+                                'Fetching file from saltenv \'%s\', '
+                                '** skipped ** latest already in cache '
+                                '\'%s\', mode up-to-date', saltenv, path
+                            )
+                        else:
+                            try:
+                                os.chmod(dest2check, mode_server)
+                                log.info(
+                                    'Fetching file from saltenv \'%s\', '
+                                    '** updated ** latest already in cache, '
+                                    '\'%s\', mode updated from %s to %s',
+                                    saltenv,
+                                    path,
+                                    salt.utils.st_mode_to_octal(mode_local),
+                                    salt.utils.st_mode_to_octal(mode_server)
+                                )
+                            except OSError as exc:
+                                log.warning(
+                                    'Failed to chmod %s: %s', dest2check, exc
+                                )
+                    # We may not have been able to check/set the mode, but we
+                    # don't want to re-download the file because of a failure
+                    # in mode checking. Return the cached path.
+                    return dest2check
+                else:
+                    log.info(
+                        'Fetching file from saltenv \'%s\', ** skipped ** '
+                        'latest already in cache \'%s\'', saltenv, path
+                    )
+                    return dest2check
 
         log.debug(
             'Fetching file from saltenv \'%s\', ** attempting ** \'%s\'',
@@ -968,7 +1081,7 @@ class RemoteClient(Client):
                     return False
             fn_ = salt.utils.fopen(dest, 'wb+')
         else:
-            log.debug('Dest file \'%s\' not found', dest)
+            log.debug('No dest file found')
 
         while True:
             if not fn_:
@@ -1055,6 +1168,23 @@ class RemoteClient(Client):
                 saltenv, path
             )
 
+        if not salt.utils.is_windows():
+            if mode_server is not None:
+                try:
+                    if os.stat(dest).st_mode != mode_server:
+                        try:
+                            os.chmod(dest, mode_server)
+                            log.info(
+                                'Fetching file from saltenv \'%s\', '
+                                '** done ** \'%s\', mode set to %s',
+                                saltenv,
+                                path,
+                                salt.utils.st_mode_to_octal(mode_server)
+                            )
+                        except OSError:
+                            log.warning('Failed to chmod %s: %s', dest, exc)
+                except OSError:
+                    pass
         return dest
 
     def file_list(self, saltenv='base', prefix=''):
@@ -1094,11 +1224,9 @@ class RemoteClient(Client):
                 'cmd': '_symlink_list'}
         return self.channel.send(load)
 
-    def hash_file(self, path, saltenv='base'):
+    def __hash_and_stat_file(self, path, saltenv='base'):
         '''
-        Return the hash of a file, to get the hash of a file on the salt
-        master file server prepend the path with salt://<file on server>
-        otherwise, prepend the file with / for a local file.
+        Common code for hashing and stating files
         '''
         try:
             path = self._check_proto(path)
@@ -1110,14 +1238,44 @@ class RemoteClient(Client):
             else:
                 ret = {}
                 hash_type = self.opts.get('hash_type', 'md5')
-                ret['hsum'] = salt.utils.get_hash(
-                    path, form=hash_type)
+                ret['hsum'] = salt.utils.get_hash(path, form=hash_type)
                 ret['hash_type'] = hash_type
                 return ret
         load = {'path': path,
                 'saltenv': saltenv,
                 'cmd': '_file_hash'}
         return self.channel.send(load)
+
+    def hash_file(self, path, saltenv='base'):
+        '''
+        Return the hash of a file, to get the hash of a file on the salt
+        master file server prepend the path with salt://<file on server>
+        otherwise, prepend the file with / for a local file.
+        '''
+        return self.__hash_and_stat_file(path, saltenv)
+
+    def hash_and_stat_file(self, path, saltenv='base'):
+        '''
+        The same as hash_file, but also return the file's mode, or None if no
+        mode data is present.
+        '''
+        hash_result = self.hash_file(path, saltenv)
+        try:
+            path = self._check_proto(path)
+        except MinionError as err:
+            if not os.path.isfile(path):
+                return hash_result, None
+            else:
+                try:
+                    return hash_result, list(os.stat(path))
+                except Exception:
+                    return hash_result, None
+        load = {'path': path,
+                'saltenv': saltenv,
+                'cmd': '_file_find'}
+        fnd = self.channel.send(load)
+        stat_result = fnd.get('stat')
+        return hash_result, stat_result
 
     def list_env(self, saltenv='base'):
         '''

--- a/salt/fileserver/azurefs.py
+++ b/salt/fileserver/azurefs.py
@@ -86,11 +86,8 @@ def find_file(path, saltenv='base', **kwargs):
            'rel': ''}
     try:
         root = os.path.join(salt.syspaths.CACHE_DIR, 'azure')
-    except IndexError:
-        # An invalid index was passed
-        return fnd
-    except ValueError:
-        # An invalid index option was passed
+    except (IndexError, ValueError):
+        # An invalid index or index option was passed
         return fnd
     full = os.path.join(root, path)
     if os.path.isfile(full) and not salt.fileserver.is_file_ignored(

--- a/salt/fileserver/azurefs.py
+++ b/salt/fileserver/azurefs.py
@@ -97,7 +97,22 @@ def find_file(path, saltenv='base', **kwargs):
                                                             __opts__, full):
         fnd['path'] = full
         fnd['rel'] = path
-        fnd['stat'] = list(os.stat(full))
+        try:
+            # Converting the stat result to a list, the elements of the
+            # list correspond to the following stat_result params:
+            # 0 => st_mode=33188
+            # 1 => st_ino=10227377
+            # 2 => st_dev=65026
+            # 3 => st_nlink=1
+            # 4 => st_uid=1000
+            # 5 => st_gid=1000
+            # 6 => st_size=1056233
+            # 7 => st_atime=1468284229
+            # 8 => st_mtime=1456338235
+            # 9 => st_ctime=1456338235
+            fnd['stat'] = list(os.stat(full))
+        except Exception:
+            pass
     return fnd
 
 

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -687,7 +687,22 @@ def find_file(path, tgt_env='base', **kwargs):  # pylint: disable=W0613
             pass
         fnd['rel'] = path
         fnd['path'] = dest
-        fnd['stat'] = list(os.stat(dest))
+        try:
+            # Converting the stat result to a list, the elements of the
+            # list correspond to the following stat_result params:
+            # 0 => st_mode=33188
+            # 1 => st_ino=10227377
+            # 2 => st_dev=65026
+            # 3 => st_nlink=1
+            # 4 => st_uid=1000
+            # 5 => st_gid=1000
+            # 6 => st_size=1056233
+            # 7 => st_atime=1468284229
+            # 8 => st_mtime=1456338235
+            # 9 => st_ctime=1456338235
+            fnd['stat'] = list(os.stat(dest))
+        except Exception:
+            pass
         repo['repo'].close()
         return fnd
     return fnd

--- a/salt/fileserver/svnfs.py
+++ b/salt/fileserver/svnfs.py
@@ -583,6 +583,22 @@ def find_file(path, tgt_env='base', **kwargs):  # pylint: disable=W0613
         if os.path.isfile(full):
             fnd['rel'] = path
             fnd['path'] = full
+            try:
+                # Converting the stat result to a list, the elements of the
+                # list correspond to the following stat_result params:
+                # 0 => st_mode=33188
+                # 1 => st_ino=10227377
+                # 2 => st_dev=65026
+                # 3 => st_nlink=1
+                # 4 => st_uid=1000
+                # 5 => st_gid=1000
+                # 6 => st_size=1056233
+                # 7 => st_atime=1468284229
+                # 8 => st_mtime=1456338235
+                # 9 => st_ctime=1456338235
+                fnd['stat'] = list(os.stat(full))
+            except Exception:
+                pass
             return fnd
     return fnd
 

--- a/salt/master.py
+++ b/salt/master.py
@@ -936,6 +936,7 @@ class AESFuncs(object):
         '''
         self.fs_ = salt.fileserver.Fileserver(self.opts)
         self._serve_file = self.fs_.serve_file
+        self._file_find = self.fs_._find_file
         self._file_hash = self.fs_.file_hash
         self._file_list = self.fs_.file_list
         self._file_list_emptydirs = self.fs_.file_list_emptydirs

--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -97,17 +97,10 @@ def manage_mode(mode):
 
         salt '*' config.manage_mode
     '''
-    if mode is None:
-        return None
-    if not isinstance(mode, six.string_types):
-        # Make it a string in case it's not
-        mode = str(mode)
-    # Strip any quotes and initial 0, though zero-pad it up to 4
-    ret = mode.strip('"').strip('\'').lstrip('0').zfill(4)
-    if ret[0] != '0':
-        # Always include a leading zero
-        return '0{0}'.format(ret)
-    return ret
+    # config.manage_mode should no longer be invoked from the __salt__ dunder
+    # in Salt code, this function is only being left here for backwards
+    # compatibility.
+    return salt.utils.normalize_mode(mode)
 
 
 def valid_fileproto(uri):

--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -469,7 +469,7 @@ def file(name,
         Overrides the default backup mode for the user's crontab.
     '''
     # Initial set up
-    mode = __salt__['config.manage_mode']('0600')
+    mode = salt.utils.normalize_mode('0600')
     owner, group, crontab_dir = _get_cron_info()
 
     cron_path = salt.utils.mkstemp()

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1805,6 +1805,34 @@ def check_state_result(running, recurse=False):
     return ret
 
 
+def st_mode_to_octal(mode):
+    '''
+    Convert the st_mode value from a stat(2) call (as returned from os.stat())
+    to an octal mode.
+    '''
+    try:
+        return oct(mode)[-4:]
+    except (TypeError, IndexError):
+        return ''
+
+
+def normalize_mode(mode):
+    '''
+    Return a mode value, normalized to a string and containing a leading zero
+    if it does not have one.
+
+    Allow "keep" as a valid mode (used by file state/module to preserve mode
+    from the Salt fileserver in file states).
+    '''
+    if mode is None:
+        return None
+    if not isinstance(mode, six.string_types):
+        mode = str(mode)
+    # Strip any quotes any initial zeroes, then though zero-pad it up to 4.
+    # This ensures that somethign like '00644' is normalized to '0644'
+    return mode.strip('"').strip('\'').lstrip('0').zfill(4)
+
+
 def test_mode(**kwargs):
     '''
     Examines the kwargs passed and returns True if any kwarg which matching

--- a/tests/integration/modules/config.py
+++ b/tests/integration/modules/config.py
@@ -50,17 +50,17 @@ class ConfigTest(integration.ModuleCase):
         self.assertEqual(
             self.run_function('config.manage_mode', ['"775"']), '0775')
         self.assertEqual(
-            self.run_function('config.manage_mode', ['"1775"']), '01775')
+            self.run_function('config.manage_mode', ['"1775"']), '1775')
         self.assertEqual(
             self.run_function('config.manage_mode', ['"0775"']), '0775')
         self.assertEqual(
-            self.run_function('config.manage_mode', ['"01775"']), '01775')
+            self.run_function('config.manage_mode', ['"01775"']), '1775')
         self.assertEqual(
             self.run_function('config.manage_mode', ['"0"']), '0000')
         self.assertEqual(
             self.run_function('config.manage_mode', ['775']), '0775')
         self.assertEqual(
-            self.run_function('config.manage_mode', ['1775']), '01775')
+            self.run_function('config.manage_mode', ['1775']), '1775')
         self.assertEqual(
             self.run_function('config.manage_mode', ['0']), '0000')
 


### PR DESCRIPTION
This allows both the `mode` param in the `file.managed` state, and the
`file_mode` param in the `file.recurse` state, to be set to `keep`. If
this is done, and the file comes from a path local to the minion, or from the
salt fileserver (i.e. prefixed by `salt://`), then the minion will honor the
mode from that source.

This works best with the `roots` and `git` fileserver backends, the other
remote backends simply stat the file in the server-side cache to determine
what mode to enforce on the minion.

Resolves #2707.