### PR TITLE
smtp_return: allow specifying multiple recipients

### DIFF
--- a/salt/returners/smtp_return.py
+++ b/salt/returners/smtp_return.py
@@ -245,13 +245,14 @@ def returner(ret):
 
     log.debug('smtp_return: Connecting to the server...')
     server = smtplib.SMTP(host, int(port))
-    server.set_debuglevel(1)  # enable logging SMTP session
     if smtp_tls is True:
         server.starttls()
         log.debug('smtp_return: TLS enabled')
     if user and passwd:
         server.login(user, passwd)
         log.debug('smtp_return: Authenticated')
+    # enable logging SMTP session after the login credentials were passed
+    server.set_debuglevel(1)
     server.sendmail(from_addr, to_addrs, message)
     log.debug('smtp_return: Message sent.')
     server.quit()

--- a/salt/returners/smtp_return.py
+++ b/salt/returners/smtp_return.py
@@ -189,7 +189,13 @@ def returner(ret):
     for field in fields:
         if field in ret:
             subject += ' {0}'.format(ret[field])
-    subject = compile_template(':string:', rend, renderer, blacklist, whitelist, input_data=subject, **ret)
+    subject = compile_template(':string:',
+                               rend,
+                               renderer,
+                               blacklist,
+                               whitelist,
+                               input_data=subject,
+                               **ret)
     if isinstance(subject, six.moves.StringIO):
         subject = subject.read()
     log.debug("smtp_return: Subject is '{0}'".format(subject))
@@ -203,7 +209,13 @@ def returner(ret):
                     'function args: {{fun_args}}\r\n'
                     'jid: {{jid}}\r\n'
                     'return: {{return}}\r\n')
-        content = compile_template(':string:', rend, renderer, blacklist, whitelist, input_data=template, **ret)
+        content = compile_template(':string:',
+                                   rend,
+                                   renderer,
+                                   blacklist,
+                                   whitelist,
+                                   input_data=template,
+                                   **ret)
 
     if HAS_GNUPG and gpgowner:
         gpg = gnupg.GPG(gnupghome=os.path.expanduser('~{0}/.gnupg'.format(gpgowner)),
@@ -215,7 +227,7 @@ def returner(ret):
         else:
             log.error('smtp_return: Encryption failed, only an error message will be sent')
             content = 'Encryption failed, the return data was not sent.\r\n\r\n{0}\r\n{1}'.format(
-                    encrypted_data.status, encrypted_data.stderr)
+                encrypted_data.status, encrypted_data.stderr)
 
     if isinstance(content, six.moves.StringIO):
         content = content.read()
@@ -233,7 +245,7 @@ def returner(ret):
 
     log.debug('smtp_return: Connecting to the server...')
     server = smtplib.SMTP(host, int(port))
-    server.set_debuglevel(1) # enable logging SMTP session
+    server.set_debuglevel(1)  # enable logging SMTP session
     if smtp_tls is True:
         server.starttls()
         log.debug('smtp_return: TLS enabled')


### PR DESCRIPTION
### What does this PR do?

It supports specifying more than one recipient address in the `smtp.to` configuration option for the `smtp` returner.
Also fixed setting SMTP session debugging level by calling the method with correct numeric argument.
### Previous Behavior

You're able to configure only one address in `smtp.to` option.
### New Behavior

Multiple comma-separated recipient addresses are allowed in `smtp.to` option in Master/Minion config file.
### Tests written?

No