### PR TITLE
Skip mysql state test if mysqladmin is not available

### DIFF
--- a/tests/integration/states/mysql.py
+++ b/tests/integration/states/mysql.py
@@ -17,6 +17,7 @@ ensure_in_syspath('../../')
 
 # Import salt libs
 import integration
+import salt.utils
 import salt.ext.six as six
 from salt.modules import mysql as mysqlmod
 
@@ -26,6 +27,9 @@ NO_MYSQL = False
 try:
     import MySQLdb  # pylint: disable=import-error,unused-import
 except ImportError:
+    NO_MYSQL = True
+
+if not salt.utils.which('mysqladmin'):
     NO_MYSQL = True
 
 


### PR DESCRIPTION
### What does this PR do?

Cleans up errors in test log when mysqladmin bin doesn't exist. Like saltstack/salt#34642 but for the state test.

@cachedout 
### What issues does this PR fix or reference?

None.
### Tests written?

n/a