### PR TITLE
vmadm runner cleanup and retest

### DIFF
--- a/salt/runners/smartos_vmadm.py
+++ b/salt/runners/smartos_vmadm.py
@@ -5,8 +5,7 @@ Runner for SmartOS minions control vmadm
 from __future__ import absolute_import
 from __future__ import print_function
 # Import python libs
-#import salt.client
-import salt.key
+import salt.client
 from salt.exceptions import SaltClientError
 from salt.utils.odict import OrderedDict
 
@@ -23,29 +22,11 @@ def __virtual__():
     '''
     Provides vmadm runner
     '''
+    # NOTE: always load vmadm runner
+    #       we could check using test.ping + a grain
+    #       match, but doing this on master startup is
+    #       not acceptable
     return __virtualname__
-#    have_computenodes = False
-#
-#    ## check if there are computenode minions
-#    client = salt.client.get_local_client(__opts__['conf_file'])
-#    try:
-#        for cn in client.cmd_iter('G@virtual:physical and G@os:smartos', 'test.ping', expr_form='compound'):
-#            if not cn:
-#                continue
-#            else:
-#                have_computenodes = True
-#    except SaltClientError as client_error:
-#        pass
-#
-#    if have_computenodes:
-#        return __virtualname__
-#    else:
-#        return (
-#            False,
-#            '{0} runner can only be loaded when there are SmartOS computed nodes'.format(
-#                __virtualname__
-#            )
-#        )
 
 
 def _action(action='get', search=None, one=True, force=False):


### PR DESCRIPTION
### What does this PR do?

@cachedout  is this better?

I had to uncomment salt.client if I left it commented stuff obviously does not work.
I tried importing it in the methods that need it but that made lint unhappy.
### What issues does this PR fix or reference?
saltstack/salt#34568
### Previous Behavior

Do some dynamic detecting using test.ping in the _virtual_ function to figure out of SmartOS compute nodes are present.
### New Behavior

Always load the vmadm runner, the functions won't show any results of there are none.
### Tests written?

No