### PR TITLE
If the thin does not match, then redeploy, don't error

### DIFF
--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -131,11 +131,7 @@ def main(argv):  # pylint: disable=W0613
     thin_path = os.path.join(OPTIONS.saltdir, THIN_ARCHIVE)
     if os.path.isfile(thin_path):
         if OPTIONS.checksum != get_hash(thin_path, OPTIONS.hashfunc):
-            sys.stderr.write('{0}\n'.format(OPTIONS.checksum))
-            sys.stderr.write('{0}\n'.format(get_hash(thin_path, OPTIONS.hashfunc)))
-            os.unlink(thin_path)
-            sys.stderr.write('WARNING: checksum mismatch for "{0}"\n'.format(thin_path))
-            sys.exit(EX_THIN_CHECKSUM)
+            need_deployment()
         unpack_thin(thin_path)
         # Salt thin now is available to use
     else:


### PR DESCRIPTION
### What does this PR do?

@plastikos is there any reason not to do this? If the thin is bad we can just redeploy right?
### What issues does this PR fix or reference?
#34509
### Previous Behavior

Threw an error
### New Behavior

Silently recovers
