### PR TITLE
Make the mine and publish combine minion and master opts in salt-ssh

### DIFF
--- a/salt/client/ssh/wrapper/mine.py
+++ b/salt/client/ssh/wrapper/mine.py
@@ -36,7 +36,9 @@ def get(tgt, fun, expr_form='glob', roster='flat'):
         salt-ssh '*' mine.get '192.168.5.0' network.ipaddrs roster=scan
     '''
     # Set up opts for the SSH object
-    opts = copy.deepcopy(__opts__)
+    opts = copy.deepcopy(__context__['master_opts'])
+    minopts = copy.deepcopy(__opts__)
+    opts.update(minopts)
     if roster:
         opts['roster'] = roster
     opts['argv'] = [fun]

--- a/salt/client/ssh/wrapper/publish.py
+++ b/salt/client/ssh/wrapper/publish.py
@@ -72,7 +72,9 @@ def _publish(tgt,
         arg = []
 
     # Set up opts for the SSH object
-    opts = copy.deepcopy(__opts__)
+    opts = copy.deepcopy(__context__['master_opts'])
+    minopts = copy.deepcopy(__opts__)
+    opts.update(minopts)
     if roster:
         opts['roster'] = roster
     if timeout:


### PR DESCRIPTION
### What does this PR do?

The minion opts used to pass into the SSH object need to be defaulted with the master opts so that the general global ssh needed opts are available
### What issues does this PR fix or reference?
saltstack/salt#34526
### Previous Behavior

Stack traces!