### PR TITLE
2016.3 zpool cleanup and fixes

### DIFF
--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -646,7 +646,6 @@ def create(zpool, *vdevs, **kwargs):
             salt '*' zpool.create myzpool /path/to/vdev1 [...] properties="{'property1': 'value1', 'property2': 'value2'}"
     '''
     ret = {}
-    dlist = []
 
     # Check if the pool_name is already being used
     if exists(zpool):
@@ -657,23 +656,7 @@ def create(zpool, *vdevs, **kwargs):
         ret[zpool] = 'no devices specified'
         return ret
 
-    # make sure files are present on filesystem
-    ret[zpool] = {}
-    for vdev in vdevs:
-        if vdev not in ['mirror', 'log', 'cache', 'raidz1', 'raidz2', 'raidz3', 'spare']:
-            if not os.path.exists(vdev):
-                ret[zpool][vdev] = 'not present on filesystem'
-                continue
-            mode = os.stat(vdev).st_mode
-            if not stat.S_ISBLK(mode) and not stat.S_ISREG(mode) and not stat.S_ISCHR(mode):
-                ret[zpool][vdev] = 'not a block device, a file vdev or character special device'
-                continue
-        dlist.append(vdev)
-
-    if len(ret[zpool]) > 0:
-        return ret
-
-    devs = ' '.join(dlist)
+    devs = ' '.join(vdevs)
     zpool_cmd = _check_zpool()
     force = kwargs.get('force', False)
     altroot = kwargs.get('altroot', None)
@@ -718,7 +701,7 @@ def create(zpool, *vdevs, **kwargs):
     if res['retcode'] != 0:
         ret[zpool] = res['stderr'] if 'stderr' in res else res['stdout']
     else:
-        ret[zpool] = 'created'
+        ret[zpool] = 'created with {0}'.format(devs)
 
     return ret
 
@@ -743,7 +726,6 @@ def add(zpool, *vdevs, **kwargs):
         salt '*' zpool.add myzpool /path/to/vdev1 /path/to/vdev2 [...]
     '''
     ret = {}
-    dlist = []
 
     # check for pool
     if not exists(zpool):
@@ -755,24 +737,7 @@ def add(zpool, *vdevs, **kwargs):
         return ret
 
     force = kwargs.get('force', False)
-
-    # make sure files are present on filesystem
-    ret[zpool] = {}
-    for vdev in vdevs:
-        if vdev not in ['mirror', 'log', 'cache', 'raidz1', 'raidz2', 'raidz3', 'spare']:
-            if not os.path.exists(vdev):
-                ret[zpool][vdev] = 'not present on filesystem'
-                continue
-            mode = os.stat(vdev).st_mode
-            if not stat.S_ISBLK(mode) and not stat.S_ISREG(mode):
-                ret[zpool][vdev] = 'not a block device, a file vdev or character special device'
-                continue
-        dlist.append(vdev)
-
-    if len(ret[zpool]) > 0:
-        return ret
-
-    devs = ' '.join(dlist)
+    devs = ' '.join(vdevs)
 
     # try and add watch out for mismatched replication levels
     zpool_cmd = _check_zpool()
@@ -786,10 +751,7 @@ def add(zpool, *vdevs, **kwargs):
     if res['retcode'] != 0:
         ret[zpool] = res['stderr'] if 'stderr' in res else res['stdout']
     else:
-        ret[zpool] = {}
-        for device in dlist:
-            if device not in ['mirror', 'log', 'cache', 'raidz1', 'raidz2', 'raidz3', 'spare']:
-                ret[zpool][device] = 'added'
+        ret[zpool] = 'added {0}'.format(devs)
 
     return ret
 
@@ -970,8 +932,7 @@ def replace(zpool, old_device, new_device=None, force=False):
     if res['retcode'] != 0:
         ret[zpool] = res['stderr'] if 'stderr' in res else res['stdout']
     else:
-        ret[zpool] = {}
-        ret[zpool][old_device] = 'replaced with {0}'.format(new_device)
+        ret[zpool] = 'replaced {0} with {1}'.format(old_device, new_device)
 
     return ret
 
@@ -1207,22 +1168,7 @@ def online(zpool, *vdevs, **kwargs):
     # get expand option
     expand = kwargs.get('expand', False)
 
-    # make sure files are present on filesystem
-    ret[zpool] = {}
-    for vdev in vdevs:
-        if not os.path.exists(vdev):
-            ret[zpool][vdev] = 'not present on filesystem'
-            continue
-        mode = os.stat(vdev).st_mode
-        if not stat.S_ISBLK(mode) and not stat.S_ISREG(mode):
-            ret[zpool][vdev] = 'not a block device, a file vdev or character special device'
-            continue
-        dlist.append(vdev)
-
-    if len(ret[zpool]) > 0:
-        return ret
-
-    devs = ' '.join(dlist)
+    devs = ' '.join(vdevs)
     zpool_cmd = _check_zpool()
     cmd = '{zpool_cmd} online {expand}{zpool} {devs}'.format(
         zpool_cmd=zpool_cmd,
@@ -1235,10 +1181,7 @@ def online(zpool, *vdevs, **kwargs):
     if res['retcode'] != 0:
         ret[zpool] = res['stderr'] if 'stderr' in res else res['stdout']
     else:
-        ret[zpool] = {}
-        for device in dlist:
-            if device not in ['mirror', 'log', 'cache', 'raidz1', 'raidz2', 'raidz3', 'spare']:
-                ret[zpool][device] = 'onlined'
+        ret[zpool] = 'onlined {0}'.format(devs)
     return ret
 
 
@@ -1294,10 +1237,7 @@ def offline(zpool, *vdevs, **kwargs):
     if res['retcode'] != 0:
         ret[zpool] = res['stderr'] if 'stderr' in res else res['stdout']
     else:
-        ret[zpool] = {}
-        for device in vdevs:
-            if device not in ['mirror', 'log', 'cache', 'raidz1', 'raidz2', 'raidz3', 'spare']:
-                ret[zpool][device] = 'offlined'
+        ret[zpool] = 'offlined {0}'.format(devs)
     return ret
 
 

--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -671,10 +671,13 @@ def create(zpool, *vdevs, **kwargs):
     if properties:  # create "-o property=value" pairs
         optlist = []
         for prop in properties:
-            if ' ' in properties[prop]:
-                value = "'{0}'".format(properties[prop])
+            if isinstance(properties[prop], bool):
+                value = 'on' if properties[prop] else 'off'
             else:
-                value = properties[prop]
+                if ' ' in properties[prop]:
+                    value = "'{0}'".format(properties[prop])
+                else:
+                    value = properties[prop]
             optlist.append('-o {0}={1}'.format(prop, value))
         opts = ' '.join(optlist)
         cmd = '{0} {1}'.format(cmd, opts)

--- a/salt/states/zpool.py
+++ b/salt/states/zpool.py
@@ -295,11 +295,11 @@ def present(name, properties=None, filesystem_properties=None, layout=None, conf
 
                     # execute zpool.create
                     ret['result'] = __salt__['zpool.create'](*params, force=config['force'], properties=properties, filesystem_properties=filesystem_properties)
-                    if ret['result'].get(name) == 'created':
+                    if ret['result'].get(name).startswith('created'):
                         ret['result'] = True
                     else:
                         if ret['result'].get(name):
-                            ret['comment'] = ret['result'][name]
+                            ret['comment'] = ret['result'].get(name)
                         ret['result'] = False
 
                 if ret['result']:

--- a/salt/states/zpool.py
+++ b/salt/states/zpool.py
@@ -281,13 +281,12 @@ def present(name, properties=None, filesystem_properties=None, layout=None, conf
                     for root_dev in layout:
                         if '-' in root_dev:  # special device
                             # NOTE: accomidate non existing 'disk' vdev
-                            if root_dev.split('-')[0] in ['mirror', 'log', 'cache', 'raidz1', 'raidz2', 'raidz3', 'spare', 'disk']:
-                                if root_dev.split('-')[0] != 'disk':
-                                    params.append(root_dev.split('-')[0])  # add the type by stripping the ID
-                                for sub_dev in layout[root_dev]:  # add all sub devices
-                                    if '/' not in sub_dev and config['device_dir'] and os.path.exists(config['device_dir']):
-                                        sub_dev = os.path.join(config['device_dir'], sub_dev)
-                                    params.append(sub_dev)
+                            if root_dev.split('-')[0] != 'disk':
+                                params.append(root_dev.split('-')[0])  # add the type by stripping the ID
+                            for sub_dev in layout[root_dev]:  # add all sub devices
+                                if '/' not in sub_dev and config['device_dir'] and os.path.exists(config['device_dir']):
+                                    sub_dev = os.path.join(config['device_dir'], sub_dev)
+                                params.append(sub_dev)
                         else:  # normal device
                             if '/' not in root_dev and config['device_dir'] and os.path.exists(config['device_dir']):
                                 root_dev = os.path.join(config['device_dir'], root_dev)

--- a/salt/states/zpool.py
+++ b/salt/states/zpool.py
@@ -53,7 +53,6 @@ from __future__ import absolute_import
 
 # Import Python libs
 import os
-import stat
 import logging
 
 # Import Salt libs
@@ -78,23 +77,6 @@ def __virtual__():
                 __virtualname__
             )
         )
-
-
-def _check_device(device, config):
-    '''
-    Check if device is present
-    '''
-    if '/' not in device and config['device_dir'] and os.path.exists(config['device_dir']):
-        device = os.path.join(config['device_dir'], device)
-
-    if not os.path.exists(device):
-        return False, 'not present on filesystem'
-    else:
-        mode = os.stat(device).st_mode
-        if not stat.S_ISBLK(mode) and not stat.S_ISREG(mode) and not stat.S_ISCHR(mode):
-            return False, 'not a block device, a file vdev or character special device'
-
-    return True, ''
 
 
 def present(name, properties=None, filesystem_properties=None, layout=None, config=None):
@@ -170,41 +152,22 @@ def present(name, properties=None, filesystem_properties=None, layout=None, conf
     config = {
         'import': True,
         'import_dirs': None,
-        'device_dir': None if __grains__['kernel'] != 'SunOS' else '/dev/rdsk',
+        'device_dir': None,
         'force': False
     }
+    if __grains__['kernel'] == 'SunOS':
+        config['device_dir'] = '/dev/rdsk'
+    elif __grains__['kernel'] == 'Linux':
+        config['device_dir'] = '/dev'
     config.update(state_config)
     log.debug('zpool.present::{0}::config - {1}'.format(name, config))
 
-    # validate layout
+    # parse layout
     if layout:
-        layout_valid = True
-        layout_result = {}
         for root_dev in layout:
-            if '-' in root_dev:
-                # NOTE: people seem to be confused a lot and want to use the 'disk' vdev which does not exist
-                #       we try to accomidate them in the state module by faking it.
-                if root_dev.split('-')[0] not in ['mirror', 'log', 'cache', 'raidz1', 'raidz2', 'raidz3', 'spare', 'disk']:
-                    layout_valid = False
-                    layout_result[root_dev] = 'not a valid vdev type'
-                layout[root_dev] = layout[root_dev].keys() if isinstance(layout[root_dev], OrderedDict) else layout[root_dev].split(' ')
-
-                for dev in layout[root_dev]:
-                    dev_info = _check_device(dev, config)
-                    if not dev_info[0]:
-                        layout_valid = False
-                        layout_result[root_dev] = {}
-                        layout_result[root_dev][dev] = dev_info[1]
-            else:
-                dev_info = _check_device(root_dev, config)
-                if not dev_info[0]:
-                    layout_valid = False
-                    layout_result[root_dev] = dev_info[1]
-
-        if not layout_valid:
-            ret['result'] = False
-            ret['comment'] = "{0}".format(layout_result)
-            return ret
+            if '-' not in root_dev:
+                continue
+            layout[root_dev] = layout[root_dev].keys() if isinstance(layout[root_dev], OrderedDict) else layout[root_dev].split(' ')
 
         log.debug('zpool.present::{0}::layout - {1}'.format(name, layout))
 


### PR DESCRIPTION
### What does this PR do?

As pointed out in #34770 the zpool exec module is not very robust in regard to vdev type.

This PR skips all the fancy parsing and falls back to the zpool cli's error messages, allowing the hardcoded list of vdev types to be removed.

There is also one small fix for a bug when passing on/off values via the zpool state + tweaks to make the zpool state module work with the updated exec module.
### What issues does this PR fix or reference?
#34770
### Previous Behavior

Hardcoded list of vdev types
### New Behavior

Removed the hardcoded list from the exec module and state module
### Tests written?

No