### PR TITLE
Fix getting total available memory without `psutil` installed

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -86,7 +86,7 @@
 
 # Set the default output file used by the salt command. Default is to output
 # to the CLI and not to a file. Functions the same way as the "--out-file"
-CLI option, only sets this to a single file for all salt commands.
+# CLI option, only sets this to a single file for all salt commands.
 #output_file: None
 
 # Return minions that timeout when running commands like test.ping

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -47,6 +47,7 @@ try:
     HAS_PSUTIL = True
 except ImportError:
     HAS_PSUTIL = False
+    import platform
     import salt.grains.core
 
 log = logging.getLogger(__name__)
@@ -80,8 +81,8 @@ def _gather_buffer_space():
         # Oh good, we have psutil. This will be quick.
         total_mem = psutil.virtual_memory().total
     else:
-        # We need to load up some grains. This will be slow.
-        os_data = salt.grains.core.os_data()
+        # We need to load up ``mem_total`` grain. Let's mimic required OS data.
+        os_data = {'kernel': platform.system()}
         grains = salt.grains.core._memdata(os_data)
         total_mem = grains['mem_total']
     # Return the higher number between 5% of the system memory and 100MB


### PR DESCRIPTION
### What does this PR do?

Fixes Salt crash on Linux without `psutil` Python module installed.
### What issues does this PR fix or reference?

The issue was introduced by this PR: #34683
### Previous Behavior

```
[root@salt /]# salt --version
Traceback (most recent call last):
  File "/usr/bin/salt", line 10, in <module>
    salt_main()
  File "/usr/lib/python2.7/site-packages/salt/scripts.py", line 462, in salt_main
    import salt.cli.salt
  File "/usr/lib/python2.7/site-packages/salt/cli/salt.py", line 9, in <module>
    import salt.utils.job
  File "/usr/lib/python2.7/site-packages/salt/utils/job.py", line 8, in <module>
    import salt.minion
  File "/usr/lib/python2.7/site-packages/salt/minion.py", line 78, in <module>
    import salt.client
  File "/usr/lib/python2.7/site-packages/salt/client/__init__.py", line 29, in <module>
    import salt.config
  File "/usr/lib/python2.7/site-packages/salt/config/__init__.py", line 92, in <module>
    _DFLT_IPC_WBUFFER = _gather_buffer_space() * .5
  File "/usr/lib/python2.7/site-packages/salt/config/__init__.py", line 84, in _gather_buffer_space
    os_data = salt.grains.core.os_data()
  File "/usr/lib/python2.7/site-packages/salt/grains/core.py", line 1386, in os_data
    grains.update(_linux_gpu_data())
  File "/usr/lib/python2.7/site-packages/salt/grains/core.py", line 154, in _linux_gpu_data
    if __opts__.get('enable_lspci', True) is False:
NameError: global name '__opts__' is not defined
```

`__opts__` dictionary is not available because you're loading configuration right now, "chicken and the egg" problem appears.

But just for getting `mem_total`Grain value you don't need full blown OS data, only to know what's the OS kernel (see `_memdata` function). This should be safe on all supported platforms.
### New Behavior

Salt works.
### Tests written?

No