### PR TITLE
added extention for tmp file when using check_cmd in file.managed state

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1770,7 +1770,7 @@ def managed(name,
     tmp_filename = None
 
     if check_cmd:
-        tmp_filename = salt.utils.mkstemp()+'.'+tmp_ext
+        tmp_filename = salt.utils.mkstemp()+tmp_ext
 
         # if exists copy existing file to tmp to compare
         if __salt__['file.file_exists'](name):

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1468,9 +1468,9 @@ def managed(name,
 
     tmp_ext
         provide extention for temp file created by check_cmd
-	usefull for checkers dependant on config file extention
-	for example it should be usefull for init-checkconf upstart config checker
-	by default it is empty
+        usefull for checkers dependant on config file extention
+        for example it should be usefull for init-checkconf upstart config checker
+        by default it is empty
 
     skip_verify : False
         If ``True``, hash verification of remote file sources (``http://``,

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1471,6 +1471,21 @@ def managed(name,
         usefull for checkers dependant on config file extention
         for example it should be usefull for init-checkconf upstart config checker
         by default it is empty
+        .. code-block:: yaml
+
+            /etc/init/test.conf:
+              file.managed:
+                - user: root
+                - group: root
+                - mode: 0440
+                - tmp_ext: '.conf'
+                - contents:
+                  - 'description "Salt Minion"''
+                  - 'start on started mountall'
+                  - 'stop on shutdown'
+                  - 'respawn'
+                  - 'exec salt-minion'
+                - check_cmd: init-checkconf -f
 
     skip_verify : False
         If ``True``, hash verification of remote file sources (``http://``,

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1468,8 +1468,8 @@ def managed(name,
 
     tmp_ext
         provide extention for temp file created by check_cmd
-        usefull for checkers dependant on config file extention
-        for example it should be usefull for init-checkconf upstart config checker
+        useful for checkers dependant on config file extention
+        for example it should be useful for init-checkconf upstart config checker
         by default it is empty
         .. code-block:: yaml
 

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1117,6 +1117,7 @@ def managed(name,
             show_changes=True,
             create=True,
             contents=None,
+            tmp_ext='',
             contents_pillar=None,
             contents_grains=None,
             contents_newline=True,
@@ -1465,6 +1466,12 @@ def managed(name,
         **NOTE**: This ``check_cmd`` functions differently than the requisite
         ``check_cmd``.
 
+    tmp_ext
+        provide extention for temp file created by check_cmd
+	usefull for checkers dependant on config file extention
+	for example it should be usefull for init-checkconf upstart config checker
+	by default it is empty
+
     skip_verify : False
         If ``True``, hash verification of remote file sources (``http://``,
         ``https://``, ``ftp://``) will be skipped, and the ``source_hash``
@@ -1763,7 +1770,7 @@ def managed(name,
     tmp_filename = None
 
     if check_cmd:
-        tmp_filename = salt.utils.mkstemp()
+        tmp_filename = salt.utils.mkstemp()+'.'+tmp_ext
 
         # if exists copy existing file to tmp to compare
         if __salt__['file.file_exists'](name):


### PR DESCRIPTION
### What does this PR do?

add new tmp_ext options to file.managed state
### What issues does this PR fix or reference?

check_cmd does not work for init-checkconf because it needs file with .conf extention
### Tests written?

No