### PR TITLE
Remove string_types import from state compiler

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -51,7 +51,6 @@ import salt.utils.yamlloader as yamlloader
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 import salt.ext.six as six
 from salt.ext.six.moves import map, range
-from salt.ext.six import string_types
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
 
 log = logging.getLogger(__name__)
@@ -787,7 +786,7 @@ class State(object):
             else:
                 low_data_onlyif = low_data['onlyif']
             for entry in low_data_onlyif:
-                if not isinstance(entry, string_types):
+                if not isinstance(entry, six.string_types):
                     ret.update({'comment': 'onlyif execution failed, bad type passed', 'result': False})
                     return ret
                 cmd = self.functions['cmd.retcode'](
@@ -808,7 +807,7 @@ class State(object):
             else:
                 low_data_unless = low_data['unless']
             for entry in low_data_unless:
-                if not isinstance(entry, string_types):
+                if not isinstance(entry, six.string_types):
                     ret.update({'comment': 'unless execution failed, bad type passed', 'result': False})
                     return ret
                 cmd = self.functions['cmd.retcode'](


### PR DESCRIPTION
We have already imported salt.ext.six above - no need to do it twice.