### PR TITLE
Preserve ownership for blockreplace backup files

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2187,15 +2187,22 @@ def blockreplace(path,
         has_changes = diff is not ''
         if has_changes and not dry_run:
             # changes detected
-            # backup old content
-            if backup is not False:
-                shutil.copy2(path, '{0}{1}'.format(path, backup))
-
             # backup file attrs
             perms = {}
             perms['user'] = get_user(path)
             perms['group'] = get_group(path)
             perms['mode'] = __salt__['config.manage_mode'](get_mode(path))
+
+            # backup old content
+            if backup is not False:
+                backup_path = '{0}{1}'.format(path, backup)
+                shutil.copy2(path, backup_path)
+                # copy2 does not preserve ownership
+                check_perms(backup_path,
+                        None,
+                        perms['user'],
+                        perms['group'],
+                        perms['mode'])
 
             # write new content in the file while avoiding partial reads
             try:


### PR DESCRIPTION
### What does this PR do?

Ensure that backup file ownership matches the source file
### Previous Behavior

`.bak` ownership was set to `root:root` by default
### Explanation

shutil.copy2 does not attempt to preserve file ownership, which means that backup files on local disk will normally be owned by `root`. This creates a hazard for unprivileged utilities such as `rsync` or `pg_basebackup` which may fail when operating on directories where these backup files were created.