### PR TITLE
Check for version in list of installed versions

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -588,7 +588,7 @@ def install(name=None, refresh=False, pkgs=None, saltenv='base', **kwargs):
             version_num = _get_latest_pkg_version(pkginfo)
 
         # Check if the version is already installed
-        if version_num == old.get(pkg_name) \
+        if version_num in old.get(pkg_name, '').split(',') \
                 or (pkg_name in old and old[pkg_name] == 'Not Found'):
             # Desired version number already installed
             ret[pkg_name] = {'current': version_num}
@@ -874,7 +874,7 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
             ret[target] = {'current': 'not installed'}
             continue
         else:
-            if not version_num == old.get(target) \
+            if not version_num in old.get(target, '').split(',') \
                     and not old.get(target) == "Not Found" \
                     and version_num != 'latest':
                 log.error('{0} {1} not installed'.format(target, version))

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -874,7 +874,7 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
             ret[target] = {'current': 'not installed'}
             continue
         else:
-            if not version_num in old.get(target, '').split(',') \
+            if version_num not in old.get(target, '').split(',') \
                     and not old.get(target) == "Not Found" \
                     and version_num != 'latest':
                 log.error('{0} {1} not installed'.format(target, version))


### PR DESCRIPTION
### What does this PR do?

2016.3 breaks previous behavior of pkg.(install|remove) in that if multiple versions of one piece of software are installed, none are seen as installed and are not removable. Tested with w2k8/w2k12 client.
### Previous Behavior

```
w8-cl1.salt.local:
    ----------
    Java Auto Updater:
        2.8.91.15
    jre8:
        8.0.730.2,8.0.910.15
    salt-minion:
        2016.3.1

$ salt 'w8-cl1*' pkg.remove jre8 version=8.0.730.2
w8-cl1.salt.local:
    ----------
    jre8:
        ----------
        current:
            8.0.730.2 not installed

$ salt 'w8-cl1*' pkg.remove jre8
w8-cl1.salt.local:
    ----------
    jre8:
        ----------
        current:
            8.0.910.15 not installed
```
### New Behavior

```
$ salt 'w8-*' pkg.list_pkgs
w8-cl1.salt.local:
    ----------
    Java Auto Updater:
        2.8.91.15
    jre8:
        8.0.730.2,8.0.910.15
    salt-minion:
        2016.3.1

$ salt 'w8-*' pkg.remove jre8 version=8.0.730.2
w8-cl1.salt.local:
    ----------
    jre8:
        ----------
        new:
            8.0.910.15
        old:
            8.0.730.2,8.0.910.15

$ salt 'w8-*' pkg.remove jre8
w8-cl1.salt.local:
    ----------
    jre8:
        ----------
        new:
        old:
            8.0.910.15

```
### Tests written?

No