### PR TITLE
This needs discussion, since this breaks SUSE

### DIFF
--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -54,11 +54,6 @@ except ImportError:
     # Older jinja does not need markupsafe
     HAS_MARKUPSAFE = False
 
-try:
-    import xml
-    HAS_XML = True
-except ImportError:
-    HAS_XML = False
 # pylint: enable=import-error,no-name-in-module
 
 try:
@@ -128,10 +123,6 @@ def get_tops(extra_mods='', so_mods=''):
 
     if HAS_SSL_MATCH_HOSTNAME:
         tops.append(os.path.dirname(os.path.dirname(ssl_match_hostname.__file__)))
-
-    if HAS_XML:
-        # For openSUSE, which apparently doesn't include the whole stdlib
-        tops.append(os.path.dirname(xml.__file__))
 
     for mod in [m for m in extra_mods.split(',') if m]:
         if mod not in locals() and mod not in globals():


### PR DESCRIPTION
### What does this PR do?

This needs discussion, since this breaks salt-ssh on SUSE, it seems that there is something wrong with python-xml in the Python version shipped with OpenSUSE, or so the removed comment says. But we can't ship bins in the thin tarball since they will break on systems with an alternative version of python or alternative architecture.
### What issues does this PR fix or reference?

Fix saltstack/salt#26171

@isbm Do you know anything about this? Or know who best to consult on the SUSE side?