### PR TITLE
Regression fix: minion ID generator should use FQDN first, if available

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -93,7 +93,7 @@ def _generate_minion_id():
                               '::1.*', 'ipv6-.*', 'fe00::.*', 'fe02::.*', '1.0.0.*.ip6.arpa']
 
         def append(self, p_object):
-            if p_object not in self and not self.filter(p_object):
+            if p_object and p_object not in self and not self.filter(p_object):
                 super(self.__class__, self).append(p_object)
             return self
 
@@ -111,7 +111,7 @@ def _generate_minion_id():
         def first(self):
             return self and self[0] or None
 
-    hosts = DistinctList().append(platform.node()).append(socket.gethostname()).append(socket.getfqdn())
+    hosts = DistinctList().append(socket.getfqdn()).append(platform.node()).append(socket.gethostname())
     if not hosts:
         try:
             for a_nfo in socket.getaddrinfo(hosts.first(), None, socket.AF_INET,

--- a/tests/unit/utils/network_test.py
+++ b/tests/unit/utils/network_test.py
@@ -251,7 +251,7 @@ class NetworkTestCase(TestCase):
         :return:
         '''
         self.assertEqual(network._generate_minion_id(),
-                         ['nodename', 'hostname', 'hostname.domainname.blank', '1.2.3.4', '5.6.7.8'])
+                         ['hostname.domainname.blank', 'nodename', 'hostname', '1.2.3.4', '5.6.7.8'])
 
     @patch('platform.node', MagicMock(return_value='hostname'))
     @patch('socket.gethostname', MagicMock(return_value='hostname'))
@@ -270,7 +270,7 @@ class NetworkTestCase(TestCase):
 
     @patch('platform.node', MagicMock(return_value='very.long.and.complex.domain.name'))
     @patch('socket.gethostname', MagicMock(return_value='hostname'))
-    @patch('socket.getfqdn', MagicMock(return_value='hostname'))
+    @patch('socket.getfqdn', MagicMock(return_value=''))
     @patch('socket.getaddrinfo', MagicMock(return_value=[(2, 3, 0, 'hostname', ('127.0.1.1', 0))]))
     @patch('salt.utils.fopen', MagicMock(return_value=False))
     @patch('os.path.exists', MagicMock(return_value=False))
@@ -286,7 +286,7 @@ class NetworkTestCase(TestCase):
 
     @patch('platform.node', MagicMock(return_value='localhost'))
     @patch('socket.gethostname', MagicMock(return_value='pick.me'))
-    @patch('socket.getfqdn', MagicMock(return_value='hostname'))
+    @patch('socket.getfqdn', MagicMock(return_value='hostname.domainname.blank'))
     @patch('socket.getaddrinfo', MagicMock(return_value=[(2, 3, 0, 'hostname', ('127.0.1.1', 0))]))
     @patch('salt.utils.fopen', MagicMock(return_value=False))
     @patch('os.path.exists', MagicMock(return_value=False))
@@ -297,7 +297,7 @@ class NetworkTestCase(TestCase):
 
         :return:
         '''
-        self.assertEqual(network.generate_minion_id(), 'pick.me')
+        self.assertEqual(network.generate_minion_id(), 'hostname.domainname.blank')
 
     @patch('platform.node', MagicMock(return_value='localhost'))
     @patch('socket.gethostname', MagicMock(return_value='ip6-loopback'))


### PR DESCRIPTION
### What does this PR do?

Let Minion ID uses first FQDN, if available.
### Tests written?

Yes

Addresses regression, reported: https://github.com/saltstack/salt/pull/33715#issuecomment-234502826