### PR TITLE
Add load_reg and save_reg for Thorium

### DIFF
--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -23,6 +23,7 @@ import salt.utils.jid
 import salt.exceptions
 
 # Import 3rd-party libs
+import msgpack
 import salt.ext.six as six
 
 
@@ -502,7 +503,7 @@ def save_reg(data):
         else:
             raise
     try:
-        with salt.utils.flopen(regfile, 'a') as fh_:
+        with salt.utils.fopen(regfile, 'a') as fh_:
             msgpack.dump(data, fh_)
         fh_.close()
     except:
@@ -517,7 +518,7 @@ def load_reg():
     reg_dir = _reg_dir()
     regfile = os.path.join(reg_dir, 'register')
     try:
-        with salt.utils.flopen(regfile, 'a') as fh_:
+        with salt.utils.fopen(regfile, 'r') as fh_:
             return msgpack.load(fh_)
     except:
         log.error('Could not write to msgpack file {0}'.format(opts['outdir']))

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -507,7 +507,7 @@ def save_reg(data):
             msgpack.dump(data, fh_)
         fh_.close()
     except:
-        log.error('Could not write to msgpack file {0}'.format(opts['outdir']))
+        log.error('Could not write to msgpack file {0}'.format(__opts__['outdir']))
         raise
 
 
@@ -521,5 +521,5 @@ def load_reg():
         with salt.utils.fopen(regfile, 'r') as fh_:
             return msgpack.load(fh_)
     except:
-        log.error('Could not write to msgpack file {0}'.format(opts['outdir']))
+        log.error('Could not write to msgpack file {0}'.format(__opts__['outdir']))
         raise

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -478,3 +478,47 @@ def get_endtime(jid):
     with salt.utils.fopen(etpath, 'r') as etfile:
         endtime = etfile.read().strip('\n')
     return endtime
+
+
+def _reg_dir():
+    '''
+    Return the reg_dir for the given job id
+    '''
+    return os.path.join(__opts__['cachedir'], 'thorium')
+
+
+def save_reg(data):
+    '''
+    Save the register to msgpack files
+    '''
+    reg_dir = _reg_dir()
+    regfile = os.path.join(reg_dir, 'register')
+    try:
+        if not os.path.exists():
+            os.makedirs(reg_dir)
+    except OSError as exc:
+        if exc.errno == errno.EEXIST:
+            pass
+        else:
+            raise
+    try:
+        with salt.utils.flopen(regfile, 'a') as fh_:
+            msgpack.dump(data, fh_)
+        fh_.close()
+    except:
+        log.error('Could not write to msgpack file {0}'.format(opts['outdir']))
+        raise
+
+
+def load_reg():
+    '''
+    Load the register from msgpack files
+    '''
+    reg_dir = _reg_dir()
+    regfile = os.path.join(reg_dir, 'register')
+    try:
+        with salt.utils.flopen(regfile, 'a') as fh_:
+            return msgpack.load(fh_)
+    except:
+        log.error('Could not write to msgpack file {0}'.format(opts['outdir']))
+        raise

--- a/salt/thorium/__init__.py
+++ b/salt/thorium/__init__.py
@@ -46,12 +46,13 @@ class ThorState(salt.state.HighState):
         salt.state.HighState.__init__(self, self.opts, loader='thorium')
 
         self.returners = salt.loader.returners(self.opts, {})
-        self.reg_ret = self.opts.get('register_returner', 'local_cache')
-        try:
-            regdata = self.returners['{0}.load_reg'.format(self.reg_ret)]()
-        except Exception as exc:
-            log.error(exc)
-            regdata = {}
+        self.reg_ret = self.opts.get('register_returner', None)
+        if self.reg_ret is not None:
+            try:
+                regdata = self.returners['{0}.load_reg'.format(self.reg_ret)]()
+            except Exception as exc:
+                log.error(exc)
+                regdata = {}
 
         self.state.inject_globals = {'__reg__': regdata}
         self.event = salt.utils.event.get_master_event(
@@ -184,5 +185,6 @@ class ThorState(salt.state.HighState):
             if (start - r_start) > recompile:
                 cache = self.gather_cache()
                 chunks = self.get_chunks()
-                self.returners['{0}.save_reg'.format(self.reg_ret)](chunks)
+                if self.reg_ret is not None:
+                    self.returners['{0}.save_reg'.format(self.reg_ret)](chunks)
                 r_start = time.time()

--- a/salt/thorium/__init__.py
+++ b/salt/thorium/__init__.py
@@ -18,6 +18,7 @@ import traceback
 
 # Import Salt libs
 import salt.state
+import salt.loader
 import salt.payload
 from salt.exceptions import SaltRenderError
 
@@ -43,7 +44,16 @@ class ThorState(salt.state.HighState):
         opts['file_client'] = 'local'
         self.opts = opts
         salt.state.HighState.__init__(self, self.opts, loader='thorium')
-        self.state.inject_globals = {'__reg__': {}}
+
+        self.returners = salt.loader.returners(self.opts, {})
+        self.reg_ret = self.opts.get('register_returner', 'local_cache')
+        try:
+            regdata = self.returners['{0}.load_reg'.format(self.reg_ret)]()
+        except Exception as exc:
+            log.error(exc)
+            regdata = {}
+
+        self.state.inject_globals = {'__reg__': regdata}
         self.event = salt.utils.event.get_master_event(
                 self.opts,
                 self.opts['sock_dir'])
@@ -174,4 +184,5 @@ class ThorState(salt.state.HighState):
             if (start - r_start) > recompile:
                 cache = self.gather_cache()
                 chunks = self.get_chunks()
+                self.returners['{0}.save_reg'.format(self.reg_ret)](chunks)
                 r_start = time.time()


### PR DESCRIPTION
### What does this PR do?

This adds the ability for Thorium to persist its register using the returner system. The `load_reg()` function is used to load the register when starting up the master, and the `save_reg()` function is used to persist the register every `thorium_recompile` seconds.
### Tests written?

No.