### PR TITLE
Fix console and file logging on Windows

### DIFF
--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -46,7 +46,6 @@ from salt.utils import kinds
 try:
     from salt.utils import parsers, ip_bracket
     from salt.utils.verify import check_user, verify_env, verify_socket
-    from salt.utils.verify import verify_files
 except ImportError as exc:
     if exc.args[0] != 'No module named _msgpack':
         raise
@@ -162,12 +161,6 @@ class Master(parsers.MasterOptionParser, DaemonsMixin):  # pylint: disable=no-in
                     permissive=self.config['permissive_pki_access'],
                     pki_dir=self.config['pki_dir'],
                 )
-                logfile = self.config['log_file']
-                if logfile is not None and not logfile.startswith(('tcp://', 'udp://', 'file://')):
-                    # Logfile is not using Syslog, verify
-                    current_umask = os.umask(0o027)
-                    verify_files([logfile], self.config['user'])
-                    os.umask(current_umask)
                 # Clear out syndics from cachedir
                 for syndic_file in os.listdir(self.config['syndic_dir']):
                     os.remove(os.path.join(self.config['syndic_dir'], syndic_file))
@@ -288,12 +281,6 @@ class Minion(parsers.MinionOptionParser, DaemonsMixin):  # pylint: disable=no-in
                     permissive=self.config['permissive_pki_access'],
                     pki_dir=self.config['pki_dir'],
                 )
-                logfile = self.config['log_file']
-                if logfile is not None and not logfile.startswith(('tcp://', 'udp://', 'file://')):
-                    # Logfile is not using Syslog, verify
-                    current_umask = os.umask(0o027)
-                    verify_files([logfile], self.config['user'])
-                    os.umask(current_umask)
         except OSError as error:
             self.environment_failure(error)
 
@@ -464,14 +451,6 @@ class ProxyMinion(parsers.ProxyMinionOptionParser, DaemonsMixin):  # pylint: dis
                     permissive=self.config['permissive_pki_access'],
                     pki_dir=self.config['pki_dir'],
                 )
-
-                logfile = self.config.get('proxy_log') or self.config['log_file']
-                if logfile is not None and not logfile.startswith(('tcp://', 'udp://', 'file://')):
-                    # Logfile is not using Syslog, verify
-                    current_umask = os.umask(0o027)
-                    verify_files([logfile], self.config['user'])
-                    os.umask(current_umask)
-
         except OSError as error:
             self.environment_failure(error)
 
@@ -569,12 +548,6 @@ class Syndic(parsers.SyndicOptionParser, DaemonsMixin):  # pylint: disable=no-in
                     permissive=self.config['permissive_pki_access'],
                     pki_dir=self.config['pki_dir'],
                 )
-                logfile = self.config['log_file']
-                if logfile is not None and not logfile.startswith(('tcp://', 'udp://', 'file://')):
-                    # Logfile is not using Syslog, verify
-                    current_umask = os.umask(0o027)
-                    verify_files([logfile], self.config['user'])
-                    os.umask(current_umask)
         except OSError as error:
             self.environment_failure(error)
 

--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -920,9 +920,20 @@ def __process_multiprocessing_logging_queue(opts, queue):
     salt.utils.appendproctitle('MultiprocessingLoggingQueue')
     if salt.utils.is_windows():
         # On Windows, creating a new process doesn't fork (copy the parent
-        # process image). Due to this, we need to setup extended logging
+        # process image). Due to this, we need to setup all of our logging
         # inside this process.
         setup_temp_logger()
+        setup_console_logger(
+            log_level=opts.get('log_level'),
+            log_format=opts.get('log_fmt_console'),
+            date_format=opts.get('log_datefmt_console')
+        )
+        setup_logfile_logger(
+            opts.get('log_file'),
+            log_level=opts.get('log_level_logfile'),
+            log_format=opts.get('log_fmt_logfile'),
+            date_format=opts.get('log_datefmt_logfile')
+        )
         setup_extended_logging(opts)
     while True:
         try:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1270,15 +1270,6 @@ class Minion(MinionBase):
         This method should be used as a threading target, start the actual
         minion side execution.
         '''
-        # this seems awkward at first, but it's a workaround for Windows
-        # multiprocessing communication.
-        if sys.platform.startswith('win') and \
-                opts['multiprocessing'] and \
-                not salt.log.setup.is_logging_configured():
-            # We have to re-init the logging system for Windows
-            salt.log.setup.setup_console_logger(log_level=opts.get('log_level', 'info'))
-            if opts.get('log_file'):
-                salt.log.setup.setup_logfile_logger(opts['log_file'], opts.get('log_level_logfile', 'info'))
         fn_ = os.path.join(minion_instance.proc_dir, data['jid'])
 
         if opts['multiprocessing'] and not salt.utils.is_windows():
@@ -1457,15 +1448,6 @@ class Minion(MinionBase):
         minion side execution.
         '''
         salt.utils.appendproctitle('{0}._thread_multi_return {1}'.format(cls.__name__, data['jid']))
-        # this seems awkward at first, but it's a workaround for Windows
-        # multiprocessing communication.
-        if sys.platform.startswith('win') and \
-                opts['multiprocessing'] and \
-                not salt.log.is_logging_configured():
-            # We have to re-init the logging system for Windows
-            salt.log.setup_console_logger(log_level=opts.get('log_level', 'info'))
-            if opts.get('log_file'):
-                salt.log.setup_logfile_logger(opts['log_file'], opts.get('log_level_logfile', 'info'))
         ret = {
             'return': {},
             'success': {},


### PR DESCRIPTION
### What does this PR do?

On Windows, only the main process properly logged to console and to
file. Things worked on other OSes due to the logging configuration
being propagated via fork, something that won't work on Windows.

The new strategy for Windows is if multiprocessing mode is used,
all console and file logging will be performed through the
Multiprocessing Logging Listener except for the main process. The
main process does not send stuff to the Multiprocessing Logging Listener.
Hence the main process will still configure file and console logging
separately from the MP Logging Listener.
If multiprocessing mode is off, then logging will be done as before
(which should be ok since there is only one process).

salt/utils/parsers.py:
- Broke apart the logic that figures out the input options for
  `log.setup_logfile_logger` and `log.setup_console_logger`. This
  functionality is run before `self._setup_mp_logging_listener` so that
  the options passed to the MP Logging Listener are appropriate for direct
  use in the functions that setup the console and file logging in the
  MP Logging Listener process.
- Moved the logic that verifies the path for the log file from
  `cli/daemons.py` to be able to run it before creating the MP Logging
  Listener. Its original place in `cli/daemons.py` would run after the
  MP Logging Listener is created.

salt/log/setup.py:
- Invoke `setup_console_logger` and `setup_logfile_logger` using the
  appropriate options if running on Windows.

salt/minion.py:
- No longer need to invoke the functions to setup the console and file
  logging on Windows multiprocessing mode due to the MP Logging
  Listener taking care of that on Windows.

salt/cli/daemons.py:
- Moved the logic that verifies the path for the log file to
  `utils/parsers.py`.
### Tests created?

No

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com