### PR TITLE
Fix unbound local variable error

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -475,7 +475,8 @@ class AsyncAuth(object):
         while True:
             try:
                 creds = yield self.sign_in(channel=channel)
-            except SaltClientError as error:
+            except SaltClientError as exc:
+                error = exc
                 break
             if creds == 'retry':
                 if self.opts.get('caller'):


### PR DESCRIPTION
### What does this PR do?

I have occasionally come across this error while running a salt-minion on
Windows using Python 3.5.1 and the TCP transport:

```
  File "...\salt\crypt.py", line 498, in _authenticate
    if not error:
UnboundLocalError: local variable 'error' referenced before assignment
[WARNING ] Minion received a SIGINT. Exiting.
```

It seems like there is an overloaded use of the local variable called
`error`, each use with a different lifespan. Changed it so that `error`
is no longer overloaded. This has fixed the issue.
### Tests written?

No

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com