### PR TITLE
Fix integration/cli/*.py test failures when Running in Python 3

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1299,6 +1299,10 @@ def mod_data(fsclient):
                     ret[ref] = mods_data
     if not ret:
         return {}
+
+    if six.PY3:
+        ver_base = salt.utils.to_bytes(ver_base)
+
     ver = hashlib.sha1(ver_base).hexdigest()
     ext_tar_path = os.path.join(
             fsclient.opts['cachedir'],

--- a/tests/integration/cli/batch.py
+++ b/tests/integration/cli/batch.py
@@ -5,13 +5,14 @@
 # Import Python libs
 from __future__ import absolute_import
 
-# Import Salt Libs
-import integration
-
 # Import Salt Testing Libs
 from salttesting.helpers import ensure_in_syspath
 
 ensure_in_syspath('../../')
+
+# Import Salt Libs
+import integration
+import salt.ext.six as six
 
 
 class BatchTest(integration.ShellCase):
@@ -37,9 +38,11 @@ class BatchTest(integration.ShellCase):
                'retcode:',
                '    0',
                '    batch testing']
-        ret = sorted(ret)
-        cmd = sorted(self.run_salt('\'*\' test.echo \'batch testing\' -b 50%'))
-        self.assertListEqual(cmd, ret)
+        cmd = self.run_salt('\'*\' test.echo \'batch testing\' -b 50%')
+        if six.PY3:
+            self.assertCountEqual(cmd, ret)
+        else:
+            self.assertListEqual(sorted(cmd), sorted(ret))
 
     def test_batch_run_number(self):
         '''
@@ -57,8 +60,11 @@ class BatchTest(integration.ShellCase):
                '    True',
                'retcode:',
                '    0']
-        cmd = sorted(self.run_salt('\'*\' test.ping --batch-size 2'))
-        self.assertListEqual(cmd, sorted(ret))
+        cmd = self.run_salt('\'*\' test.ping --batch-size 2')
+        if six.PY3:
+            self.assertCountEqual(cmd, ret)
+        else:
+            self.assertListEqual(sorted(cmd), sorted(ret))
 
     def test_batch_run_grains_targeting(self):
         '''
@@ -86,8 +92,11 @@ class BatchTest(integration.ShellCase):
                 os_grain = item
 
         os_grain = os_grain.strip()
-        cmd = sorted(self.run_salt('-G \'os:{0}\' -b 25% test.ping'.format(os_grain)))
-        self.assertListEqual(cmd, sorted(ret))
+        cmd = self.run_salt('-G \'os:{0}\' -b 25% test.ping'.format(os_grain))
+        if six.PY3:
+            self.assertCountEqual(cmd, ret)
+        else:
+            self.assertListEqual(sorted(cmd), sorted(ret))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Update batch integration tests to not be flaky in Python3
- Transform unicode string to bytes before hashing