### PR TITLE
Add VirtuozzoLinux to the list of enabled distros for rpm.py

### DIFF
--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -51,7 +51,7 @@ def __virtual__():
     except Exception:
         return (False, 'The rpm execution module failed to load: failed to detect os or os_family grains.')
 
-    enabled = ('amazon', 'xcp', 'xenserver')
+    enabled = ('amazon', 'xcp', 'xenserver', 'VirtuozzoLinux')
 
     if os_family in ['redhat', 'suse'] or os_grain in enabled:
         return __virtualname__


### PR DESCRIPTION
Fixes saltstack/salt#34893