### PR TITLE
Remove tests that don't test anything

### DIFF
--- a/tests/unit/cloud/clouds/dimensiondata_test.py
+++ b/tests/unit/cloud/clouds/dimensiondata_test.py
@@ -149,22 +149,6 @@ class DimensionDataTestCase(ExtendedTestCase):
             'default'
         )
 
-    @patch('libcloud.compute.drivers.dimensiondata.DimensionDataNodeDriver.list_nodes', MagicMock(return_value=[]))
-    def test_list_nodes(self):
-        nodes = dimensiondata.list_nodes()
-        self.assertEqual(
-            nodes,
-            {}
-        )
-
-    @patch('libcloud.compute.drivers.dimensiondata.DimensionDataNodeDriver.list_locations', MagicMock(return_value=[]))
-    def test_list_locations(self):
-        locations = dimensiondata.avail_locations()
-        self.assertEqual(
-            locations,
-            {}
-        )
-
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
These tests are mocked so heavily that they're essentially asserting that the functions return an empty list/dict when we can't connect to the service - no other logic is tested, so I am removing them.