### PR TITLE
Introduce cache_valid_time parameter

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -751,6 +751,34 @@ def installed(
         ``refresh`` to ``True``. This prevents needless additional refreshes
         from slowing down the Salt run.
 
+    :param str cache_valid_time:
+        This parameter sets the value in seconds after which cache marked as invalid,
+        and cache update is necessary. This overwrite ``refresh`` parameter
+        default behavior.
+
+        Example:
+
+        .. code-block:: yaml
+
+            httpd:
+              pkg.installed:
+                - fromrepo: mycustomrepo
+                - skip_verify: True
+                - skip_suggestions: True
+                - version: 2.0.6~ubuntu3
+                - refresh: True
+                - cache_valid_time: 300
+                - allow_updates: True
+                - hold: False
+
+        In this case refresh will not take place for 5 minutes since last
+        ``apt-get update`` executed on the system.
+
+        .. note::
+
+            This parameter available only on Debian based distributions, and
+            have no effect on the rest.
+
     :param str fromrepo:
         Specify a repository from which to install
 
@@ -1630,6 +1658,28 @@ def latest(
         ``refresh`` to ``True``. This prevents needless additional refreshes
         from slowing down the Salt run.
 
+    :param str cache_valid_time:
+        This parameter sets the value in seconds after which cache marked as invalid,
+        and cache update is necessary. This overwrite ``refresh`` parameter
+        default behavior.
+
+        Example:
+
+        .. code-block:: yaml
+
+            httpd:
+              pkg.latest:
+                - refresh: True
+                - cache_valid_time: 300
+
+        In this case refresh will not take place for 5 minutes since last
+        ``apt-get update`` executed on the system.
+
+        .. note::
+
+            This parameter available only on Debian based distributions, and
+            have no effect on the rest.
+
 
     Multiple Package Installation Options:
 
@@ -2232,6 +2282,19 @@ def uptodate(name, refresh=False, **kwargs):
 
     refresh
         refresh the package database before checking for new upgrades
+
+    :param str cache_valid_time:
+        This parameter sets the value in seconds after which cache marked as invalid,
+        and cache update is necessary. This overwrite ``refresh`` parameter
+        default behavior.
+
+        In this case cache_valid_time is set, refresh will not take place for
+        amount in seconds since last ``apt-get update`` executed on the system.
+
+        .. note::
+
+            This parameter available only on Debian based distributions, and
+            have no effect on the rest.
 
     kwargs
         Any keyword arguments to pass through to ``pkg.upgrade``.


### PR DESCRIPTION
### What does this PR do?

It introduces new parameter: `cache_valid_time` which represents amount of seconds to wait before the next `apt-get update` on Debian based machines will be executed. 
### What issues does this PR fix or reference?

it might be considered as one of the possible solutions for https://github.com/saltstack/salt/issues/32862
### Previous Behavior

Currently, if you have state similar to this one:

```
vim:
  pkg.latest:
  - refresh: True

bash:
  pkg.latest:
  - refresh: True
```

execution will be something like:

```
root@master:/home/vagrant# time salt-call state.sls obsolete.test
[INFO    ] Loading fresh modules for state activity
[INFO    ] Fetching file from saltenv 'base', ** skipped ** latest already in cache 'salt://obsolete/test.sls'
[INFO    ] Running state [vim] at time 11:34:19.274541
[INFO    ] Executing state pkg.latest for vim
[INFO    ] Executing command ['dpkg-query', '--showformat', '${Status} ${Package} ${Version} ${Architecture}\n', '-W'] in directory '/root'
[INFO    ] Executing command ['apt-get', '-q', 'update'] in directory '/root'
[INFO    ] Executing command ['apt-cache', '-q', 'policy', 'vim'] in directory '/root'
[INFO    ] Package vim is already up-to-date
[INFO    ] Completed state [vim] at time 11:34:57.543289 duration_in_ms=38268.748
[INFO    ] Running state [bash] at time 11:34:57.547911
[INFO    ] Executing state pkg.latest for bash
[INFO    ] Executing command ['apt-get', '-q', 'update'] in directory '/root'
[INFO    ] Executing command ['apt-cache', '-q', 'policy', 'bash'] in directory '/root'
[INFO    ] Package bash is already up-to-date
[INFO    ] Completed state [bash] at time 11:35:27.605897 duration_in_ms=30057.986
local:
----------
          ID: vim
    Function: pkg.latest
      Result: True
     Comment: Package vim is already up-to-date
     Started: 11:34:19.274541
    Duration: 38268.748 ms
     Changes:   
----------
          ID: bash
    Function: pkg.latest
      Result: True
     Comment: Package bash is already up-to-date
     Started: 11:34:57.547911
    Duration: 30057.986 ms
     Changes:   

Summary for local
------------
Succeeded: 2
Failed:    0
------------
Total states run:     2

real    1m13.629s
user    0m8.936s
sys 0m4.784s
```

Which is far away from optimal. 
### New Behavior

In case you have state similar to this one:

```
vim:
  pkg.latest:
  - cache_valid_time: 60
  - refresh: True

bash:
  pkg.latest:
  - cache_valid_time: 60
  - refresh: True
```

and try to execute it within 60 seconds after the `apt-get update` you will get result:

```
root@master:/home/vagrant# time salt-call state.sls obsolete.test
[INFO    ] Loading fresh modules for state activity
[INFO    ] Fetching file from saltenv 'base', ** done ** 'obsolete/test.sls'
[INFO    ] Running state [vim] at time 11:35:37.363041
[INFO    ] Executing state pkg.latest for vim
[INFO    ] Executing command ['dpkg-query', '--showformat', '${Status} ${Package} ${Version} ${Architecture}\n', '-W'] in directory '/root'
[INFO    ] Executing command ['apt-cache', '-q', 'policy', 'vim'] in directory '/root'
[INFO    ] Package vim is already up-to-date
[INFO    ] Completed state [vim] at time 11:35:37.919114 duration_in_ms=556.073
[INFO    ] Running state [bash] at time 11:35:37.919778
[INFO    ] Executing state pkg.latest for bash
[INFO    ] Executing command ['apt-cache', '-q', 'policy', 'bash'] in directory '/root'
[INFO    ] Package bash is already up-to-date
[INFO    ] Completed state [bash] at time 11:35:37.942775 duration_in_ms=22.997
local:
----------
          ID: vim
    Function: pkg.latest
      Result: True
     Comment: Package vim is already up-to-date
     Started: 11:35:37.363041
    Duration: 556.073 ms
     Changes:   
----------
          ID: bash
    Function: pkg.latest
      Result: True
     Comment: Package bash is already up-to-date
     Started: 11:35:37.919778
    Duration: 22.997 ms
     Changes:   

Summary for local
------------
Succeeded: 2
Failed:    0
------------
Total states run:     2

real    0m5.471s
user    0m1.068s
sys 0m0.328s
```

In case you execute it on fresh machine, result will be:

```
root@master:/home/vagrant# time salt-call state.sls obsolete.test
[INFO    ] Loading fresh modules for state activity
[INFO    ] Fetching file from saltenv 'base', ** skipped ** latest already in cache 'salt://obsolete/test.sls'
[INFO    ] Running state [vim] at time 11:42:02.050746
[INFO    ] Executing state pkg.latest for vim
[INFO    ] Executing command ['dpkg-query', '--showformat', '${Status} ${Package} ${Version} ${Architecture}\n', '-W'] in directory '/root'
[INFO    ] Executing command ['apt-get', '-q', 'update'] in directory '/root'
[INFO    ] Executing command ['apt-cache', '-q', 'policy', 'vim'] in directory '/root'
[INFO    ] Package vim is already up-to-date
[INFO    ] Completed state [vim] at time 11:42:22.067842 duration_in_ms=20017.096
[INFO    ] Running state [bash] at time 11:42:22.069378
[INFO    ] Executing state pkg.latest for bash
[INFO    ] Executing command ['apt-cache', '-q', 'policy', 'bash'] in directory '/root'
[INFO    ] Package bash is already up-to-date
[INFO    ] Completed state [bash] at time 11:42:22.142588 duration_in_ms=73.21
local:
----------
          ID: vim
    Function: pkg.latest
      Result: True
     Comment: Package vim is already up-to-date
     Started: 11:42:02.050746
    Duration: 20017.096 ms
     Changes:   
----------
          ID: bash
    Function: pkg.latest
      Result: True
     Comment: Package bash is already up-to-date
     Started: 11:42:22.069378
    Duration: 73.21 ms
     Changes:   

Summary for local
------------
Succeeded: 2
Failed:    0
------------
Total states run:     2

real    0m24.697s
user    0m3.848s
sys 0m1.748s
```

which is way better than original behaviour. 
### Tests written?

No, it keeps previous behaviour. If `cache_valid_time` is not set, it will fall back to previous non optimized behaviour.