### PR TITLE
Update service_rh provider to exclude XenServer >= 7.

### DIFF
--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -65,8 +65,6 @@ def __virtual__():
         'VirtuozzoLinux'
     ))
     if __grains__['os'] in enable:
-        if __grains__['os'] == 'XenServer':
-            return __virtualname__
 
         if __grains__['os'] == 'SUSE':
             if str(__grains__['osrelease']).startswith('11'):
@@ -75,6 +73,15 @@ def __virtual__():
                 return (False, 'Cannot load rh_service module on SUSE > 11')
 
         osrelease_major = __grains__.get('osrelease_info', [0])[0]
+
+        if __grains__['os'] == 'XenServer':
+            if osrelease_major >= 7:
+                return (
+                    False,
+                    'XenServer >= 7 uses systemd, will not load rh_service.py '
+                    'as virtual \'service\''
+                )
+            return __virtualname__
 
         if __grains__['os'] == 'Fedora':
             if osrelease_major >= 15:


### PR DESCRIPTION
### What does this PR do?

XenServer 7 now used systemd to handle services.
### What issues does this PR fix or reference?
#34760
### Previous Behavior

``` yaml
ensure service is running:
  service.running:
    - name: salt-minion
    - enable: True
```

``` yaml
          ID: ensure service is running
    Function: service.running
        Name: salt-minion
      Result: False
     Comment: The named service salt-minion is not available
     Started: 16:45:10.268587
    Duration: 136.407 ms
     Changes:   
```
### New Behavior

Now salt will not load rh_service as provider and system provider should be detected and used.
### Tests written?

No

_NOTE_ This patch was not tested since I don't have a XenServer install to test it there.