### PR TITLE
[RFC] Only check minions that are missing

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -965,7 +965,7 @@ class LocalClient(object):
             # re-do the ping
             if time.time() > timeout_at and minions_running:
                 # since this is a new ping, no one has responded yet
-                jinfo = self.gather_job_info(jid, tgt, tgt_type, **kwargs)
+                jinfo = self.gather_job_info(jid, list(minions - found), 'list', **kwargs)
                 minions_running = False
                 # if we weren't assigned any jid that means the master thinks
                 # we have nothing to send


### PR DESCRIPTION
Right now, we all ask minions for a job, regardless of whether or not
we expected them to return a job. This changes that behavior so that
we now only ask the minions that we expected to return but did not.

Questions: Will this have bad side-effects for syndics or multi-master?

Or, are the valid use cases for a minion returning a result that we weren't expecting?