### PR TITLE
Key cache

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -45,6 +45,10 @@
 # Directory used to store public key data:
 #pki_dir: /etc/salt/pki/master
 
+# Key cache. Increases master speed for large numbers of accepted
+# keys. Available options: 'sched'. (Updates on a fixed schedule.)
+#key_cache: ''
+
 # Directory to store job and cache data:
 # This directory may contain sensitive data and should be protected accordingly.
 #

--- a/conf/master
+++ b/conf/master
@@ -47,6 +47,9 @@
 
 # Key cache. Increases master speed for large numbers of accepted
 # keys. Available options: 'sched'. (Updates on a fixed schedule.)
+# Note that enabling this feature means that minions will not be
+# available to target for up to the length of the maintanence loop
+# which by default is 60s.
 #key_cache: ''
 
 # Directory to store job and cache data:

--- a/doc/topics/tutorials/intro_scale.rst
+++ b/doc/topics/tutorials/intro_scale.rst
@@ -271,3 +271,17 @@ If the job cache is necessary there are (currently) 2 options:
   into a returner (not sent through the Master)
 - master_job_cache (New in `2014.7.0`): this will make the Master store the job
   data using a returner (instead of the local job cache on disk).
+
+If a master has many accepted keys, it may take a long time to publish a job
+because the master much first determine the matching minions and deliver
+that information back to the waiting client before the job can be published.
+
+To mitigate this, a key cache may be enabled. This will reduce the load
+on the master to a single file open instead of thousands or tens of thousands.
+
+This cache is updated by the maintanence process, however, which means that
+minions with keys that are accepted may not be targeted by the master
+for up to sixty seconds by default.
+
+To enable the master key cache, set `key_cache: 'sched'` in the master
+configuration file.

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -159,6 +159,12 @@ VALID_OPTS = {
     # master
     'syndic_finger': str,
 
+    # The caching mechanism to use for the PKI key store. Can substantially decrease master publish
+    # times. Available types:
+    # 'maint': Runs on a schedule as a part of the maintanence process.
+    # '': Disable the key cache [default]
+    'key_cache': str,
+
     # The user under which the daemon should run
     'user': str,
 
@@ -1134,6 +1140,7 @@ DEFAULT_MASTER_OPTS = {
     'keep_jobs': 24,
     'root_dir': salt.syspaths.ROOT_DIR,
     'pki_dir': os.path.join(salt.syspaths.CONFIG_DIR, 'pki', 'master'),
+    'key_cache': '',
     'cachedir': os.path.join(salt.syspaths.CACHE_DIR, 'master'),
     'file_roots': {
         'base': [salt.syspaths.BASE_FILE_ROOTS_DIR,

--- a/salt/master.py
+++ b/salt/master.py
@@ -260,7 +260,7 @@ class Maintenance(SignalHandlingMultiprocessingProcess):
         Evaluate accepted keys and create a msgpack file
         which contains a list
         '''
-        if self.opts['key_cache'] == 'maint':
+        if self.opts['key_cache'] == 'sched':
             keys = []
             #TODO DRY from CKMinions
             if self.opts['transport'] in ('zeromq', 'tcp'):

--- a/salt/master.py
+++ b/salt/master.py
@@ -254,7 +254,7 @@ class Maintenance(SignalHandlingMultiprocessingProcess):
         if self.opts.get('search'):
             if now - last >= self.opts['search_index_interval']:
                 self.search.index()
-    
+
     def handle_key_cache(self):
         '''
         Evaluate accepted keys and create a msgpack file

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -221,6 +221,12 @@ class CkMinions(object):
         except OSError:
             return []
 
+    def _pki_cache_minions(self):
+        '''
+        Retreive complete minion list from PKI cache
+        '''
+        pki_cache_fn = os.path.join(self.opts['pki_dir'], self.acc)
+
     def _check_cache_minions(self,
                              expr,
                              delimiter,

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -200,7 +200,7 @@ class CkMinions(object):
         Return the minions found by looking via regular expressions
         '''
         reg = re.compile(expr)
-        return [m for m in self._pki_minions if reg.match(m)]
+        return [m for m in self._pki_minions() if reg.match(m)]
 
     def _pki_minions(self):
         '''
@@ -215,7 +215,7 @@ class CkMinions(object):
                 with salt.utils.fopen(pki_cache_fn) as fn_:
                     return self.serial.load(fn_)
             else:
-                for fn_ in salt.utils.isorted(os.listdir(os.path.join(self.opts['pki_dir'], elf.acc))):
+                for fn_ in salt.utils.isorted(os.listdir(os.path.join(self.opts['pki_dir'], self.acc))):
                     if not fn_.startswith('.') and os.path.isfile(os.path.join(self.opts['pki_dir'], self.acc, fn_)):
                         minions.append(fn_)
             return minions

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -193,26 +193,14 @@ class CkMinions(object):
         '''
         if isinstance(expr, six.string_types):
             expr = [m for m in expr.split(',') if m]
-        ret = []
         return [x for x in expr if x in self._pki_minions()]
-#        for minion in expr:
-#            if os.path.isfile(os.path.join(self.opts['pki_dir'], self.acc, minion)):
-#                ret.append(minion)
-#        return ret
 
     def _check_pcre_minions(self, expr, greedy):  # pylint: disable=unused-argument
         '''
         Return the minions found by looking via regular expressions
         '''
-        try:
-            minions = []
-            for fn_ in salt.utils.isorted(os.listdir(os.path.join(self.opts['pki_dir'], self.acc))):
-                if not fn_.startswith('.') and os.path.isfile(os.path.join(self.opts['pki_dir'], self.acc, fn_)):
-                    minions.append(fn_)
-            reg = re.compile(expr)
-            return [m for m in minions if reg.match(m)]
-        except OSError:
-            return []
+        reg = re.compile(expr)
+        return [m for m in self._pki_minions if reg.match(m)]
 
     def _pki_minions(self):
         '''
@@ -330,11 +318,7 @@ class CkMinions(object):
         cache_enabled = self.opts.get('minion_data_cache', False)
 
         if greedy:
-            mlist = []
-            for fn_ in salt.utils.isorted(os.listdir(os.path.join(self.opts['pki_dir'], self.acc))):
-                if not fn_.startswith('.') and os.path.isfile(os.path.join(self.opts['pki_dir'], self.acc, fn_)):
-                    mlist.append(fn_)
-            minions = set(mlist)
+            minions = set(self._pki_minions())
         elif cache_enabled:
             minions = os.listdir(os.path.join(self.opts['cachedir'], 'minions'))
         else:
@@ -436,11 +420,7 @@ class CkMinions(object):
         if not isinstance(expr, six.string_types) and not isinstance(expr, (list, tuple)):
             log.error('Compound target that is neither string, list nor tuple')
             return []
-        mlist = []
-        for fn_ in salt.utils.isorted(os.listdir(os.path.join(self.opts['pki_dir'], self.acc))):
-            if not fn_.startswith('.') and os.path.isfile(os.path.join(self.opts['pki_dir'], self.acc, fn_)):
-                mlist.append(fn_)
-        minions = set(mlist)
+        minions = set(self._pki_minions())
         log.debug('minions: {0}'.format(minions))
 
         if self.opts.get('minion_data_cache', False):


### PR DESCRIPTION
### What does this PR do?

Implements an optional master-side metadata cache for keys
### What issues does this PR fix or reference?

None
### Previous Behavior

The master would have to open O(n) files for the number of accepted keys.
### New Behavior

Much closer to O(1). This should be a substantial increase for masters with tens of thousand or hundreds of thousands of accepted keys.