### PR TITLE
Handle exception when no Slack API key was provided

### DIFF
--- a/salt/states/slack.py
+++ b/salt/states/slack.py
@@ -24,6 +24,7 @@ The api key can be specified in the master or minion configuration like below:
       api_key: peWcBiMOS9HrZG15peWcBiMOS9HrZG15
 
 '''
+from salt.exceptions import SaltInvocationError
 
 
 def __virtual__():
@@ -96,18 +97,18 @@ def post_message(name,
         ret['comment'] = 'Slack message is missing: {0}'.format(message)
         return ret
 
-    result = __salt__['slack.post_message'](
-        channel=channel,
-        message=message,
-        from_name=from_name,
-        api_key=api_key,
-        icon=icon,
-    )
-
-    if result:
+    try:
+        result = __salt__['slack.post_message'](
+            channel=channel,
+            message=message,
+            from_name=from_name,
+            api_key=api_key,
+            icon=icon,
+        )
+    except SaltInvocationError as sie:
+        ret['comment'] = 'Failed to send message: {0} ({1})'.format(name, sie)
+    else:
         ret['result'] = True
         ret['comment'] = 'Sent message: {0}'.format(name)
-    else:
-        ret['comment'] = 'Failed to send message: {0}'.format(name)
 
     return ret


### PR DESCRIPTION
When no Slack API key was provided, the state execution will fail like this:

```
          ID: hello world
    Function: slack.post_message
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1723, in call                                                                                          
                  **cdata['kwargs'])                                                                                                                                               
                File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1650, in wrapper                                                                                      
                  return f(*args, **kwargs)                                                                                                                                        
                File "/usr/lib/python2.7/dist-packages/salt/states/slack.py", line 104, in post_message                                                                            
                  icon=icon,                                                                                                                                                       
                File "/usr/lib/python2.7/dist-packages/salt/modules/slack_notify.py", line 188, in post_message                                                                    
                  api_key = _get_api_key()                                                                                                                                         
                File "/usr/lib/python2.7/dist-packages/salt/modules/slack_notify.py", line 53, in _get_api_key                                                                     
                  raise SaltInvocationError('No Slack API key found.')                                                                                                             
              SaltInvocationError: No Slack API key found.                                                                                                                         
     Started: 07:38:49.258271
    Duration: 4.542 ms
     Changes:   
```

Make it fail a bit more graceful:

```
          ID: hello world
    Function: slack.post_message
      Result: False
     Comment: Failed to send message: hello world (No Slack API key found.)
     Started: 11:34:16.072458
    Duration: 1.063 ms
     Changes:   
```