### PR TITLE
pv_present should execute pvcreate with -y if existing filesystem sig…

### DIFF
--- a/salt/modules/linux_lvm.py
+++ b/salt/modules/linux_lvm.py
@@ -219,7 +219,7 @@ def pvcreate(devices, override=True, **kwargs):
     if isinstance(devices, six.string_types):
         devices = devices.split(',')
 
-    cmd = ['pvcreate']
+    cmd = ['pvcreate', '-y']
     for device in devices:
         if not os.path.exists(device):
             raise CommandExecutionError('{0} does not exist'.format(device))


### PR DESCRIPTION
### What does this PR do?

pv_present should execute pvcreate with -y if existing filesystem signature detected
### What issues does this PR fix or reference?
#34924
### Previous Behavior

hangs the script when pvcreate /dev/xxxx with existing filesystem signature detected
### Tests written?

No