### PR TITLE
[bash-completion] hide timeout in salt-output

### DIFF
--- a/pkg/salt.bash
+++ b/pkg/salt.bash
@@ -16,7 +16,7 @@ _salt_get_grains(){
     if [ "$1" = 'local' ] ; then
         salt-call --out=txt -- grains.ls | sed  's/^.*\[//' | tr -d ",']" |sed 's:\([a-z0-9]\) :\1\: :g'
     else
-      salt '*' --timeout 2 --out=txt -- grains.ls | sed  's/^.*\[//' | tr -d ",']" |sed 's:\([a-z0-9]\) :\1\: :g'
+      salt '*' --timeout 2 --hide-timeout --out=txt -- grains.ls | sed  's/^.*\[//' | tr -d ",']" |sed 's:\([a-z0-9]\) :\1\: :g'
     fi
 }
 
@@ -24,7 +24,7 @@ _salt_get_grain_values(){
     if [ "$1" = 'local' ] ; then
         salt-call --out=txt -- grains.item $1 |sed 's/^\S*:\s//' |grep -v '^\s*$'
     else
-        salt '*' --timeout 2 --out=txt -- grains.item $1 |sed 's/^\S*:\s//' |grep -v '^\s*$'
+        salt '*' --timeout 2 --hide-timeout --out=txt -- grains.item $1 |sed 's/^\S*:\s//' |grep -v '^\s*$'
     fi
 }
 
@@ -116,7 +116,7 @@ _salt(){
      ;;
     esac
 
-    _salt_coms="$(salt '*' --timeout 2 --out=txt -- sys.list_functions | sed 's/^.*\[//' | tr -d ",']" )"
+    _salt_coms="$(salt '*' --timeout 2 --hide-timeout --out=txt -- sys.list_functions | sed 's/^.*\[//' | tr -d ",']" )"
     all="${opts} ${_salt_coms}"
     COMPREPLY=( $(compgen -W "${all}" -- ${cur}) )
 


### PR DESCRIPTION
### What does this PR do?

hide timeout and not corrupt the output of salt, when `show_timeout` is set in master config
### Previous Behavior

In previous versions if `show_timeout` was set, lines like 

```
<minion_id>: Minion did not return. [Not connected]
```

were processed like normal output and therefore maliciously added bad completion options.
### Tests written?

No testsuite available.