### PR TITLE
Avoid UnboundLocalError in beacons module

### DIFF
--- a/salt/modules/beacons.py
+++ b/salt/modules/beacons.py
@@ -9,13 +9,16 @@ Module for managing the Salt beacons on a minion
 # Import Python libs
 from __future__ import absolute_import
 import difflib
+import logging
 import os
 import yaml
 
+# Import Salt libs
 import salt.utils
+import salt.utils.event
 from salt.ext.six.moves import map
 
-import logging
+# Get logging started
 log = logging.getLogger(__name__)
 
 __func_alias__ = {
@@ -38,6 +41,7 @@ def list_(return_yaml=True):
         salt '*' beacons.list
 
     '''
+    beacons = None
 
     try:
         eventer = salt.utils.event.get_event('minion', opts=__opts__)


### PR DESCRIPTION
### What does this PR do?

If something goes wrong with the event response call, we'll hit an `UnboundLocalError` stack trace during the `if beacons` check below. This avoids that stacktrace by instantiating `beacons` as `None` before trying the event call.

This imports the correct salt.utils.event lib (not just salt.utils - event.py is it's own file and there isn't an event reference in `salt.utils.__init__.py`).
### What issues does this PR fix or reference?

None that I know of - found during the testing of the 
### Previous Behavior

When trying to perform a `salt-call --local beacons.list` function, the stacktrace happens when no beacons are configured:

```
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    salt_call()
  File "/root/SaltStack/salt/salt/scripts.py", line 338, in salt_call
    client.run()
  File "/root/SaltStack/salt/salt/cli/call.py", line 53, in run
    caller.run()
  File "/root/SaltStack/salt/salt/cli/caller.py", line 134, in run
    ret = self.call()
  File "/root/SaltStack/salt/salt/cli/caller.py", line 197, in call
    ret['return'] = func(*args, **kwargs)
  File "/root/SaltStack/salt/salt/modules/beacons.py", line 56, in list_
    if beacons:
UnboundLocalError: local variable 'beacons' referenced before assignment
```
### New Behavior

No more stacktrace:

```
root@rallytime:~# salt-call --local beacons.list
local:
    ----------
    beacons:
        ----------
```
### Tests written?

No - there are already integration tests covering this feature in general. That's how this bug was found. Those tests started failing during the merge-forward in #34894.