### PR TITLE
Bash-completion cache output and improve behavior

### DIFF
--- a/pkg/salt.bash
+++ b/pkg/salt.bash
@@ -8,7 +8,6 @@
 # TODO: --compound[tab] -- how?
 # TODO: use history to extract some words, esp. if ${cur} is empty
 # TODO: TEST EVERYTHING a lot
-# TODO: cache results of some functions?  where? how long?
 # TODO: is it ok to use '--timeout 2' ?
 
 

--- a/pkg/salt.bash
+++ b/pkg/salt.bash
@@ -140,7 +140,11 @@ _salt(){
           > "${_salt_cache_functions}"
     fi
 
-    _salt_coms="$(cat "${_salt_cache_functions}")"
+    # filter results, to only print the part to next dot (or end of function)
+    _salt_coms="$(sed 's/^\('${cur}'\(\.\|[^.]*\)\)\?.*/\1/' "${_salt_cache_functions}" | sort -u)"
+
+    # If there are still dots in the suggestion, do not append space
+    grep "^${cur}.*\." "${_salt_cache_functions}" &>/dev/null && compopt -o nospace
 
     all="${opts} ${_salt_coms}"
     COMPREPLY=( $(compgen -W "${all}" -- ${cur}) )


### PR DESCRIPTION
### What does this PR do?
### What issues does this PR fix or reference?

Similar problem, but on different shell: saltstack/salt#15321
Actual implementation on fish: saltstack/salt#15310
### Previous Behavior
1. If some minions are not up, the shell freezes during completion, until the salt-command times out.
   - Additionally, if you hit tab during running completion, it'll queue another completion run. If you do this as a reflex of your frozen shell, it's often so bad, closing the window might be the best solution.
2. After hitting tab for completion, all modules including functions were displayed. This is overload.
### New Behavior
1. The functions are now cached in the user's home directory. If the cache is available, it'll query the cache instead of an extra execution of salt.
2. The completion will now only complete until the next dot or until word-end: [![asciicast](https://asciinema.org/a/0ucb6o9ntmaxefrwbc7twncow.png)](https://asciinema.org/a/0ucb6o9ntmaxefrwbc7twncow)
### Tests written?

No testsuite available