### PR TITLE
Fix file.managed test=true hiding errors

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1715,7 +1715,9 @@ def managed(name,
 
     try:
         if __opts__['test']:
-            if ret['pchanges']:
+            if isinstance(ret['pchanges'], tuple):
+                ret['result'], ret['comment'] = ret['pchanges']
+            elif ret['pchanges']:
                 ret['result'] = None
                 ret['comment'] = 'The file {0} is set to be changed'.format(name)
                 if show_changes and 'diff' in ret['pchanges']:


### PR DESCRIPTION
### What does this PR do?

Today I noticed an issue where prereqs where seemingly doing the wrong thing. Initially I saw some prereq state steps executing even though nothing had changed. After digging into it more, it was actually due to a particular state failing, and then the prereq would run. A simplified example would look like:

```
# Broken
oor:
  cmd:
    - run
    - name: date
    - prereq:
      - file: /tmp/file_block

/tmp/file_block:
  file:
    - managed
    - source: http://foobar.quo
    - source_hash: sha1=7dc3e09135bb2544ec729bbad6b67b8fbe859374
```

Got an output of:

```
----------
          ID: oor
    Function: cmd.run
        Name: date
      Result: True
     Comment: Command "date" run
     Started: 16:57:42.763303
    Duration: 44.662 ms
     Changes:   
              ----------
              pid:
                  2237
              retcode:
                  0
              stderr:
              stdout:
                  Mon Jul 25 16:57:42 PDT 2016
----------
          ID: /tmp/file_block
    Function: file.managed
      Result: False
     Comment: Failed to cache http://foobar.quo: Error: [Errno -2] Name or service not known reading http://foobar.quo
     Started: 16:57:42.808861
    Duration: 14.453 ms
     Changes:   
```

In this case, I would expect oor to NOT run since the `file.managed` section failed (and will always fail since foobar.quo isn't a real domain). From looking at the log output it was apparent that the error getting the file executed before the oor state being called.

After digging in some more I found that the issue was actually with `file.managed` when called with `test=true`. A simple SLS to highlight the problem:

```
/tmp/file_block:
  file:
    - managed
    - source: http://foobar.quo
    - source_hash: sha1=7dc3e09135bb2544ec729bbad6b67b8fbe859374
```

With that, when I run `state.sls test=true` I get the following output:

```
local:
----------
          ID: /tmp/file_block
    Function: file.managed
      Result: None
     Comment: The file /tmp/file_block is set to be changed
     Started: 17:28:14.721513
    Duration: 25.294 ms
     Changes:   

Summary for local
------------
Succeeded: 1 (unchanged=1)
Failed:    0
------------
Total states run:     1
```

Which is unexpected, since that domain doesn't exist-- and it won't work. After digging some more I found the problem-- specifically that `file.check_managed_changes` wasn't being used properly in the return check. First off, `file.check_managed_changes` is a pretty terrible method-- as the return type varies (which is not generally good). The returns seem to be either a tuple of `(False, error_string)` or a dict describing the changes to be made. From looking at the file state module, it is apparent that the tuple return type isn't taken into consideration (<>>>><). This PR simply checks the return to determine if it is the failure path, and if so- to return the appropriate error.