### PR TITLE
Add jid to orchestration returns

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -933,6 +933,8 @@ class LocalClient(object):
                         ret[raw['data']['id']]['out'] = raw['data']['out']
                     if 'retcode' in raw['data']:
                         ret[raw['data']['id']]['retcode'] = raw['data']['retcode']
+                    if 'jid' in raw['data']:
+                        ret[raw['data']['id']]['jid'] = raw['data']['jid']
                     if kwargs.get('_cmd_meta', False):
                         ret[raw['data']['id']].update(raw['data'])
                     log.debug('jid {0} return from {1}'.format(jid, raw['data']['id']))

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -246,6 +246,11 @@ def state(
                 isinstance(tmp_ret, dict) else 'highstate'
         }}
 
+    try:
+        state_ret['__jid__'] = cmd_ret[next(iter(cmd_ret))]['jid']
+    except (StopIteration, KeyError):
+        pass
+
     changes = {}
     fail = set()
     failures = {}

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -427,6 +427,11 @@ def function(
         func_ret['comment'] = str(exc)
         return func_ret
 
+    try:
+        func_ret['__jid__'] = cmd_ret[next(iter(cmd_ret))]['jid']
+    except (StopIteration, KeyError):
+        pass
+
     changes = {}
     fail = set()
     failures = {}


### PR DESCRIPTION
This will make it easier to track the jids of jobs spawned by the
state.orchestrate runner.