### PR TITLE
force dism to always output english text

### DIFF
--- a/salt/modules/win_dism.py
+++ b/salt/modules/win_dism.py
@@ -30,7 +30,7 @@ def __virtual__():
 
 def _get_components(type_regex, plural_type, install_value, image=None):
     cmd = ['DISM',
-           '/English'
+           '/English',
            '/Image:{0}'.format(image) if image else '/Online',
            '/Get-{0}'.format(plural_type)]
     out = __salt__['cmd.run'](cmd)
@@ -163,7 +163,7 @@ def get_capabilities(image=None):
             'Windows: {0}'.format(__grains__['osversion']))
 
     cmd = ['DISM',
-           '/English'
+           '/English',
            '/Image:{0}'.format(image) if image else '/Online',
            '/Get-Capabilities']
     out = __salt__['cmd.run'](cmd)

--- a/salt/modules/win_dism.py
+++ b/salt/modules/win_dism.py
@@ -30,6 +30,7 @@ def __virtual__():
 
 def _get_components(type_regex, plural_type, install_value, image=None):
     cmd = ['DISM',
+           '/English'
            '/Image:{0}'.format(image) if image else '/Online',
            '/Get-{0}'.format(plural_type)]
     out = __salt__['cmd.run'](cmd)
@@ -162,6 +163,7 @@ def get_capabilities(image=None):
             'Windows: {0}'.format(__grains__['osversion']))
 
     cmd = ['DISM',
+           '/English'
            '/Image:{0}'.format(image) if image else '/Online',
            '/Get-Capabilities']
     out = __salt__['cmd.run'](cmd)
@@ -354,6 +356,7 @@ def get_features(package=None, image=None):
             salt '*' dism.get_features Microsoft.Windows.Calc.Demo~6595b6144ccf1df~x86~en~1.0.0.0
     '''
     cmd = ['DISM',
+           '/English',
            '/Image:{0}'.format(image) if image else '/Online',
            '/Get-Features']
 
@@ -546,6 +549,7 @@ def package_info(package, image=None):
         salt '*' dism. package_info C:\\packages\\package.cab
     '''
     cmd = ['DISM',
+           '/English',
            '/Image:{0}'.format(image) if image else '/Online',
            '/Get-PackageInfo']
 

--- a/tests/unit/modules/win_dism_test.py
+++ b/tests/unit/modules/win_dism_test.py
@@ -71,7 +71,7 @@ class WinDismTestCase(TestCase):
             with patch.dict(dism.__grains__, {'osversion': 10}):
                 out = dism.get_capabilities()
                 mock.assert_called_once_with(
-                    ['DISM', '/Online', '/Get-Capabilities'])
+                    ['DISM', '/English', '/Online', '/Get-Capabilities'])
                 self.assertEqual(out, ['Capa1', 'Capa2'])
 
     def test_installed_capabilities(self):
@@ -86,7 +86,7 @@ class WinDismTestCase(TestCase):
             with patch.dict(dism.__grains__, {'osversion': 10}):
                 out = dism.installed_capabilities()
                 mock.assert_called_once_with(
-                    ['DISM', '/Online', '/Get-Capabilities'])
+                    ['DISM', '/English', '/Online', '/Get-Capabilities'])
                 self.assertEqual(out, ["Capa1"])
 
     def test_available_capabilities(self):
@@ -101,7 +101,7 @@ class WinDismTestCase(TestCase):
             with patch.dict(dism.__grains__, {'osversion': 10}):
                 out = dism.available_capabilities()
                 mock.assert_called_once_with(
-                    ['DISM', '/Online', '/Get-Capabilities'])
+                    ['DISM', '/English', '/Online', '/Get-Capabilities'])
                 self.assertEqual(out, ["Capa2"])
 
     def test_add_feature(self):
@@ -159,7 +159,7 @@ class WinDismTestCase(TestCase):
         mock = MagicMock(return_value=features)
         with patch.dict(dism.__salt__, {'cmd.run': mock}):
             out = dism.get_features()
-            mock.assert_called_once_with(['DISM', '/Online', '/Get-Features'])
+            mock.assert_called_once_with(['DISM', '/English', '/Online', '/Get-Features'])
             self.assertEqual(out, ['Capa1', 'Capa2'])
 
     def test_installed_features(self):
@@ -172,7 +172,7 @@ class WinDismTestCase(TestCase):
         mock = MagicMock(return_value=features)
         with patch.dict(dism.__salt__, {'cmd.run': mock}):
             out = dism.installed_features()
-            mock.assert_called_once_with(['DISM', '/Online', '/Get-Features'])
+            mock.assert_called_once_with(['DISM', '/English', '/Online', '/Get-Features'])
             self.assertEqual(out, ["Capa1"])
 
     def test_available_features(self):
@@ -185,7 +185,7 @@ class WinDismTestCase(TestCase):
         mock = MagicMock(return_value=features)
         with patch.dict(dism.__salt__, {'cmd.run': mock}):
             out = dism.available_features()
-            mock.assert_called_once_with(['DISM', '/Online', '/Get-Features'])
+            mock.assert_called_once_with(['DISM', '/English', '/Online', '/Get-Features'])
             self.assertEqual(out, ["Capa2"])
 
     def test_add_package(self):
@@ -232,7 +232,7 @@ class WinDismTestCase(TestCase):
         mock = MagicMock(return_value=features)
         with patch.dict(dism.__salt__, {'cmd.run': mock}):
             out = dism.installed_packages()
-            mock.assert_called_once_with(['DISM', '/Online', '/Get-Packages'])
+            mock.assert_called_once_with(['DISM', '/English', '/Online', '/Get-Packages'])
             self.assertEqual(out, ['Capa1', 'Capa2'])
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?

This pull requests add the /English switch to all the relevant calls to DISM.
### Previous Behavior

Previously, DISM text output was not displayed in English on localized systems which breaks the DISM module on non English systems.
### Tests written?

No