### PR TITLE
grafana_datasource: fix missing name in state return

### DIFF
--- a/salt/states/grafana_datasource.py
+++ b/salt/states/grafana_datasource.py
@@ -83,7 +83,7 @@ def present(name,
     if isinstance(profile, string_types):
         profile = __salt__['config.option'](profile)
 
-    ret = {'result': None, 'comment': None, 'changes': None}
+    ret = {'name': name, 'result': None, 'comment': None, 'changes': None}
     datasource = _get_datasource(profile, name)
     data = _get_json_data(name, type, url, access, user, password, database,
         basic_auth, basic_auth_user, basic_auth_password, is_default, json_data)


### PR DESCRIPTION
Fixes "SaltException: The following keys were not present in the state return: name"