### PR TITLE
Ensure 'data' remains a dictionary if conf file is empty or missing

### DIFF
--- a/tests/minionswarm.py
+++ b/tests/minionswarm.py
@@ -267,7 +267,7 @@ class MinionSwarm(Swarm):
         if self.opts['config_dir']:
             spath = os.path.join(self.opts['config_dir'], 'minion')
             with open(spath) as conf:
-                data = yaml.load(conf)
+                data = yaml.load(conf) or {}
         minion_id = '{0}-{1}'.format(
                 self.opts['name'],
                 str(idx).zfill(self.zfill)


### PR DESCRIPTION
### What does this PR do?

`data` is initialized as a dict but if `conf` produces `None` (like loading malformed yaml) this will traceback.