### PR TITLE
Older versions of psutil may not have the 'children' attribute for processes

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -494,12 +494,15 @@ class SaltDaemonScriptBase(SaltScriptBase, ShellTestCase):
         Terminate the started daemon
         '''
         log.info('Terminating %s %s DAEMON', self.display_name, self.__class__.__name__)
+
+        children = []
         if HAS_PSUTIL:
             try:
                 parent = psutil.Process(self._process.pid)
-                children = parent.children(recursive=True)
+                if hasattr(parent, 'children'):
+                    children = parent.children(recursive=True)
             except psutil.NoSuchProcess:
-                children = []
+                pass
         self._running.clear()
         self._connectable.clear()
         time.sleep(0.0125)


### PR DESCRIPTION
### What does this PR do?

It checks for the 'children' process attribute before using it to set the `children` list variable.
We also should make sure the 'children' variable is instantiated before calling it lower in the function (line 510/513).

Fixes saltstack/salt#34967