### PR TITLE
Adds support for multiple server-side event_returners.

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -476,8 +476,9 @@ local job cache on the master.
 
 Default: ``''``
 
-Specify the returner to use to log events. A returner may have installation and
-configuration requirements. Read the returner's documentation.
+Specify the returner(s) to use to log events. Each returner may have
+installation and configuration requirements. Read the returner's 
+documentation.
 
 .. note::
 
@@ -486,7 +487,9 @@ configuration requirements. Read the returner's documentation.
 
 .. code-block:: yaml
 
-    event_return: cassandra_cql
+    event_return: 
+      - syslog
+      - splunk
 
 .. conf_master:: event_return_queue
 

--- a/doc/ref/returners/index.rst
+++ b/doc/ref/returners/index.rst
@@ -345,11 +345,12 @@ Event Returners
 ===============
 
 For maximimum visibility into the history of events across a Salt
-infrastructure, all events seen by a salt master may be logged to a returner.
+infrastructure, all events seen by a salt master may be logged to one or
+more returners.
 
 To enable event logging, set the ``event_return`` configuration option in the
-master config to returner which should be designated as the handler for event
-returns.
+master config to the returner(s) which should be designated as the handler 
+for event returns.
 
 .. note::
     Not all returners support event returns. Verify a returner has an

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -395,9 +395,9 @@ VALID_OPTS = {
     'return_retry_timer': int,
     'return_retry_timer_max': int,
 
-    # Specify a returner in which all events will be sent to. Requires that the returner in question
-    # have an event_return(event) function!
-    'event_return': str,
+    # Specify one or more returners in which all events will be sent to. Requires that the returners
+    # in question have an event_return(event) function!
+    'event_return': list,
 
     # The number of events to queue up in memory before pushing them down the pipe to an event returner
     # specified by 'event_return'

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -395,9 +395,9 @@ VALID_OPTS = {
     'return_retry_timer': int,
     'return_retry_timer_max': int,
 
-    # Specify a returner in which all events will be sent to. Requires that the returner in question
-    # have an event_return(event) function!
-    'event_return': str,
+    # Specify one or more returners in which all events will be sent to. Requires that the returners
+    # in question have an event_return(event) function!
+    'event_return': (list, string_types),
 
     # The number of events to queue up in memory before pushing them down the pipe to an event returner
     # specified by 'event_return'

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -1078,15 +1078,13 @@ class EventReturn(salt.utils.process.SignalHandlingMultiprocessingProcess):
         if isinstance(self.opts['event_return'], list):
             # Multiple event returners
             for r in self.opts['event_return']:
-                if log.level <= logging.DEBUG:
-                    log.debug('Calling event returner {0}, one of many.'.format(r))
+                log.debug('Calling event returner {0}, one of many.'.format(r))
                 event_return = '{0}.event_return'.format(r)
                 self._flush_event_single(event_return)
         else:
             # Only a single event returner
-            if log.level <= logging.DEBUG:
-                log.debug('Calling event returner {0}, only one '
-                          'configured.'.format(self.opts['event_return']))
+            log.debug('Calling event returner {0}, only one '
+                      'configured.'.format(self.opts['event_return']))
             event_return = '{0}.event_return'.format(
                 self.opts['event_return']
                 )

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -1075,24 +1075,39 @@ class EventReturn(salt.utils.process.SignalHandlingMultiprocessingProcess):
         super(EventReturn, self)._handle_signals(signum, sigframe)
 
     def flush_events(self):
-        event_return = '{0}.event_return'.format(
-            self.opts['event_return']
-        )
+        if isinstance(self.opts['event_return'], list):
+            # Multiple event returners
+            for r in self.opts['event_return']:
+                if log.level <= logging.DEBUG:
+                    log.debug('Calling event returner {0}, one of many.'.format(r))
+                event_return = '{0}.event_return'.format(r)
+                self._flush_event_single(event_return)
+        else:
+            # Only a single event returner
+            if log.level <= logging.DEBUG:
+                log.debug('Calling event returner {0}, only one '
+                          'configured.'.format(self.opts['event_return']))
+            event_return = '{0}.event_return'.format(
+                self.opts['event_return']
+                )
+            self._flush_event_single(event_return)
+        del self.event_queue[:]
+
+    def _flush_event_single(self, event_return):
         if event_return in self.minion.returners:
             try:
                 self.minion.returners[event_return](self.event_queue)
             except Exception as exc:
                 log.error('Could not store events - returner \'{0}\' raised '
-                    'exception: {1}'.format(self.opts['event_return'], exc))
+                          'exception: {1}'.format(event_return, exc))
                 # don't waste processing power unnecessarily on converting a
                 # potentially huge dataset to a string
                 if log.level <= logging.DEBUG:
                     log.debug('Event data that caused an exception: {0}'.format(
                         self.event_queue))
-            del self.event_queue[:]
         else:
             log.error('Could not store return for event(s) - returner '
-                      '\'%s\' not found.', self.opts['event_return'])
+                      '\'%s\' not found.', event_return)
 
     def run(self):
         '''

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -1075,24 +1075,39 @@ class EventReturn(salt.utils.process.SignalHandlingMultiprocessingProcess):
         super(EventReturn, self)._handle_signals(signum, sigframe)
 
     def flush_events(self):
-        event_return = '{0}.event_return'.format(
-            self.opts['event_return']
-        )
+        if type(self.opts['event_return']) is list:
+            # Multiple event returners
+            for r in self.opts['event_return']:
+                if log.level <= logging.DEBUG:
+                    log.debug('Calling event returner {0}, one of many.'.format(r))
+                event_return = '{0}.event_return'.format(r)
+                self._flush_event_single(event_return)
+        else:
+            # Only a single event returner
+            if log.level <= logging.DEBUG:
+                log.debug('Calling event returner {0}, only one '
+                          'configured.'.format(self.opts['event_return']))
+            event_return = '{0}.event_return'.format(
+                self.opts['event_return']
+                )
+            self._flush_event_single(event_return)
+        del self.event_queue[:]
+
+    def _flush_event_single(self, event_return):
         if event_return in self.minion.returners:
             try:
                 self.minion.returners[event_return](self.event_queue)
             except Exception as exc:
                 log.error('Could not store events - returner \'{0}\' raised '
-                    'exception: {1}'.format(self.opts['event_return'], exc))
+                          'exception: {1}'.format(event_return, exc))
                 # don't waste processing power unnecessarily on converting a
                 # potentially huge dataset to a string
                 if log.level <= logging.DEBUG:
                     log.debug('Event data that caused an exception: {0}'.format(
                         self.event_queue))
-            del self.event_queue[:]
         else:
             log.error('Could not store return for event(s) - returner '
-                      '\'%s\' not found.', self.opts['event_return'])
+                      '\'%s\' not found.', event_return)
 
     def run(self):
         '''


### PR DESCRIPTION
### What does this PR do?

Adds support for specifying and calling multiple returners from the master side 'event_return'.
### Previous Behavior

Only a single returner could be specified. This configuration format continues to be supported.
### New Behavior

Multiple returners can be specified, and each is called in turn on every event_flush.
### Tests written?

No