### PR TITLE
Fix hosts integration tests for Windows

### DIFF
--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -31,7 +31,7 @@ if salt.utils.is_windows():
     _HOSTS_FILE = os.path.join(
         os.environ['SystemRoot'], 'System32', 'drivers', 'etc', 'hosts')
 else:
-    _HOSTS_FILE = os.path.join('etc', 'hosts')
+    _HOSTS_FILE = os.path.join('/', 'etc', 'hosts')
 
 log = logging.getLogger(__name__)
 

--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -31,7 +31,7 @@ if salt.utils.is_windows():
     _HOSTS_FILE = os.path.join(
         os.environ['SystemRoot'], 'System32', 'drivers', 'etc', 'hosts')
 else:
-    _HOSTS_FILE = os.path.join('/', 'etc', 'hosts')
+    _HOSTS_FILE = os.path.join(os.sep, 'etc', 'hosts')
 
 log = logging.getLogger(__name__)
 

--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -27,6 +27,12 @@ import salt.utils.sdb as sdb
 # Import 3rd-party libs
 import salt.ext.six as six
 
+if salt.utils.is_windows():
+    _HOSTS_FILE = os.path.join(
+        os.environ['SystemRoot'], 'System32', 'drivers', 'etc', 'hosts')
+else:
+    _HOSTS_FILE = os.path.join('etc', 'hosts')
+
 log = logging.getLogger(__name__)
 
 __proxyenabled__ = ['*']
@@ -65,7 +71,7 @@ DEFAULTS = {'mongo.db': 'salt',
             'ldap.attrs': None,
             'ldap.binddn': '',
             'ldap.bindpw': '',
-            'hosts.file': '/etc/hosts',
+            'hosts.file': _HOSTS_FILE,
             'aliases.file': '/etc/aliases',
             'virt.images': os.path.join(syspaths.SRV_ROOT_DIR, 'salt-images'),
             'virt.tunnel': False,

--- a/salt/modules/hosts.py
+++ b/salt/modules/hosts.py
@@ -21,10 +21,6 @@ def __get_hosts_filename():
     '''
     Return the path to the appropriate hosts file
     '''
-    # TODO: Investigate using  "%SystemRoot%\system32" for this
-    if salt.utils.is_windows():
-        return 'C:\\Windows\\System32\\drivers\\etc\\hosts'
-
     return __salt__['config.option']('hosts.file')
 
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1018,6 +1018,8 @@ class TestDaemon(object):
         minion_opts['config_dir'] = TMP_CONF_DIR
         minion_opts['root_dir'] = os.path.join(TMP, 'rootdir')
         minion_opts['pki_dir'] = os.path.join(TMP, 'rootdir', 'pki')
+        minion_opts['hosts.file'] = os.path.join(TMP, 'rootdir', 'hosts')
+        minion_opts['aliases.file'] = os.path.join(TMP, 'rootdir', 'aliases')
 
         # This sub_minion also connects to master
         sub_minion_opts = salt.config._read_conf_file(os.path.join(CONF_DIR, 'sub_minion'))
@@ -1026,6 +1028,8 @@ class TestDaemon(object):
         sub_minion_opts['config_dir'] = TMP_SUB_MINION_CONF_DIR
         sub_minion_opts['root_dir'] = os.path.join(TMP, 'rootdir-sub-minion')
         sub_minion_opts['pki_dir'] = os.path.join(TMP, 'rootdir-sub-minion', 'pki', 'minion')
+        sub_minion_opts['hosts.file'] = os.path.join(TMP, 'rootdir', 'hosts')
+        sub_minion_opts['aliases.file'] = os.path.join(TMP, 'rootdir', 'aliases')
 
         # This is the master of masters
         syndic_master_opts = salt.config._read_conf_file(os.path.join(CONF_DIR, 'syndic_master'))

--- a/tests/integration/files/conf/minion
+++ b/tests/integration/files/conf/minion
@@ -14,8 +14,6 @@ pidfile: minion.pid
 
 # module extension
 test.foo: baz
-hosts.file: /tmp/salt-tests-tmpdir/hosts
-aliases.file: /tmp/salt-tests-tmpdir/aliases
 integration.test: True
 
 # Grains addons

--- a/tests/integration/files/conf/sub_minion
+++ b/tests/integration/files/conf/sub_minion
@@ -14,8 +14,6 @@ pidfile: sub_minion.pid
 
 # module extension
 test.foo: baz
-hosts.file: /tmp/salt-tests-tmpdir/hosts
-aliases.file: /tmp/salt-tests-tmpdir/aliases
 integration.test: True
 
 # Grains addons


### PR DESCRIPTION
### What does this PR do?

This fixes the hosts integration test for windows.
### Previous Behavior

The config files for minion and sub_minion contained an absolute path to the hosts file and the aliases file.
Additionally, the path to the windows hosts file was hard-coded in the module so the test was editing the actual hosts file.
### New Behavior

The `hosts.file` and `aliases.file` parameters are defined in `integrations/__init__.py` so they are configured according to the OS.
A default value for `hosts.file` is defined for the minion in the config module.

https://github.com/saltstack/zh/issues/853