### PR TITLE
Regen the thin tarball option

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -206,6 +206,8 @@ class SSH(object):
         else:
             self.event = None
         self.opts = opts
+        if self.opts['regen_thin']:
+            self.opts['ssh_wipe'] = True
         if not salt.utils.which('ssh'):
             raise salt.exceptions.SaltSystemExit('No ssh binary found in path -- ssh must be installed for salt-ssh to run. Exiting.')
         self.opts['_ssh_version'] = ssh_version()

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -293,6 +293,7 @@ class SSH(object):
         self.returners = salt.loader.returners(self.opts, {})
         self.fsclient = salt.fileclient.FSClient(self.opts)
         self.thin = salt.utils.thin.gen_thin(self.opts['cachedir'],
+                                             overwrite=self.opts['regen_thin'],
                                              python2_bin=self.opts['python2_bin'],
                                              python3_bin=self.opts['python3_bin'])
         self.mods = mod_data(self.fsclient)

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2819,6 +2819,13 @@ class SaltSSHOptionParser(six.with_metaclass(OptionParserMeta,
             help=('Select a random temp dir to deploy on the remote system. '
                   'The dir will be cleaned after the execution.'))
         self.add_option(
+            '-t', '--regen-thin', '--thin',
+            dest='regen_thin',
+            default=False,
+            action='store_true',
+            help=('Trigger a thin tarball regeneration. This is needed if',
+                  'custom grains/modules/states have been added or updated.'))
+        self.add_option(
             '--python2-bin',
             default='python2',
             help='Path to a python2 binary which has salt installed.'


### PR DESCRIPTION
### What does this PR do?

This adds an option to regen the thin tarball, this option forces a new thin tarball to be generated and forces an upgrade on the thin on the targets.

This enables an option to force a thin regen without manually deleting it, this will make it a lot easier for people to update custom grains/modues/states
### What issues does this PR fix or reference?
saltstack/salt#33629