### PR TITLE
modules.slack.post_message: Allow sending messages to direct-message …

### DIFF
--- a/salt/modules/slack_notify.py
+++ b/salt/modules/slack_notify.py
@@ -190,8 +190,9 @@ def post_message(channel,
     if not channel:
         log.error('channel is a required option.')
 
-    # channel must start with a hash
-    if not channel.startswith('#'):
+    # channel must start with a hash or an @ (direct-message channels)
+    if not channel.startswith('#') and not channel.startswith('@'):
+        log.warning('Channel name must start with a hash or @. Prepending a hash and using "#{0}" as channel name instead of {1}'.format(channel, channel))
         channel = '#{0}'.format(channel)
 
     if not from_name:


### PR DESCRIPTION
### What does this PR do?

It enables `salt.modules.slack.post_message` to also send messages to personal/direct-message channels whose name doesn't start with `#` but `@` instead.
### What issues does this PR fix or reference?

none
### Previous Behavior

The message never arrived in the desired channel, although the module reported success (which is another issue I'm going to fix) as it converted a channel name like `@eliasp` to `#@eliasp`.
### New Behavior

It accepts now a channel name like `@eliasp` and only prepends a `#` as a fallback in case the channel name neither starts with `@` nor `#`.
### Tests written?

No