### PR TITLE
salt.states.slack: check correct result attribute

### DIFF
--- a/salt/states/slack.py
+++ b/salt/states/slack.py
@@ -111,7 +111,7 @@ def post_message(name,
             icon=icon,
         )
     except SaltInvocationError as sie:
-        ret['comment'] = 'Failed to send message: {0} ({1})'.format(name, sie)
+        ret['comment'] = 'Failed to send message ({0}): {1}'.format(sie, name)
     else:
         if isinstance(result, bool) and result:
             ret['result'] = True

--- a/salt/states/slack.py
+++ b/salt/states/slack.py
@@ -113,7 +113,10 @@ def post_message(name,
     except SaltInvocationError as sie:
         ret['comment'] = 'Failed to send message: {0} ({1})'.format(name, sie)
     else:
-        ret['result'] = True
-        ret['comment'] = 'Sent message: {0}'.format(name)
+        if isinstance(result, bool) and result:
+            ret['result'] = True
+            ret['comment'] = 'Sent message: {0}'.format(name)
+        else:
+            ret['comment'] = 'Failed to send message ({0}): {1}'.format(result['message'], name)
 
     return ret


### PR DESCRIPTION
### What does this PR do?

It makes the state `salt.post_message` fail properly in cases when the underlying execution module doesn't succeed.
### What issues does this PR fix or reference?
### Previous Behavior

A failed execution resulted in the state module indicating success, as only the existence of the `result` dict was checked, but not the value of its `res` attribute.
### New Behavior

The state execution fails now properly.
### Tests written?

No