### PR TITLE
Revert "Decode byte strings when running tests in Python 3"

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -566,7 +566,7 @@ class SaltDaemonScriptBase(SaltScriptBase, ShellTestCase):
                     del sock
                 elif isinstance(port, str):
                     joined = self.run_run('manage.joined', config_dir=self.config_dir)
-                    joined = [x.decode().lstrip('- ') for x in joined]
+                    joined = [x.lstrip('- ') for x in joined]
                     if port in joined:
                         check_ports.remove(port)
             yield gen.sleep(0.125)


### PR DESCRIPTION
Reverts saltstack/salt#34990

This is unnecessary (and breaks things) with the change in https://github.com/saltstack/salt-testing/pull/72, so let's revert it.