### PR TITLE
Change an exception to a warning

### DIFF
--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -1021,7 +1021,11 @@ def request_instance(call=None, kwargs=None):  # pylint: disable=unused-argument
     poller = compconn.virtual_machines.create_or_update(
         vm_['resource_group'], vm_['name'], params
     )
-    poller.wait()
+    try:
+        poller.wait()
+    except CloudError as exc:
+        log.warn('There was a cloud error: {0}'.format(exc))
+        log.warn('This may or may not indicate an actual problem')
 
     try:
         return show_instance(vm_['name'], call='action')


### PR DESCRIPTION
### What does this PR do?

There seems to be an issue where an exception is raised which stops the deployment process, when in fact the VM does spin up as expected. Errors like:

```
CloudError: Changing property 'dataDisk.vhd.uri' is not allowed.
```

...when there are no apparent issues with VM creation.
### New Behavior

Instead of allowing the exception to halt the deployment process, we catch it and log a warning.
### Tests written?

No.