### PR TITLE
Fix rabbitmq_user state test to check for correct string

### DIFF
--- a/tests/integration/states/rabbitmq_user.py
+++ b/tests/integration/states/rabbitmq_user.py
@@ -36,7 +36,7 @@ class RabbitUserTestCase(integration.ModuleCase,
             'rabbitmq_user.present', name='null_name', test=True
         )
         self.assertSaltFalseReturn(ret)
-        self.assertInSaltComment('User null_name is set to be created', ret)
+        self.assertInSaltComment('User \'null_name\' is set to be created', ret)
 
     def absent(self):
         '''


### PR DESCRIPTION
This test was failing when I ran it locally - I'm not sure why the error isn't showing up in Jenkins, but I double checked the string in the state and there should be single-quotes around the user name.