### PR TITLE
Fix docstring for code-block of rst

### DIFF
--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -37,7 +37,7 @@ def attr_call():
     '''
     Call grains.items via the attribute
 
-    CLI Example::
+    CLI Example:
 
     .. code-block:: bash
 
@@ -51,7 +51,7 @@ def module_report():
     Return a dict containing all of the execution modules with a report on
     the overall availability via different references
 
-    CLI Example::
+    CLI Example:
 
     .. code-block:: bash
 


### PR DESCRIPTION
### What does this PR do?

Documentation fixes invalid rst directive. (No app changes)

https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.test.html

currently like this:

![2016-07-28 15 45 32](https://cloud.githubusercontent.com/assets/928692/17203417/5b4078a2-54da-11e6-824d-1021bbbb5ba2.png)
### What issues does this PR fix or reference?

Nothing cause it's so minor changes.
### Tests written?

No that's docs only.