### PR TITLE
Accept both user accounts and SID's in the win_dacl module.

### DIFF
--- a/salt/modules/win_dacl.py
+++ b/salt/modules/win_dacl.py
@@ -308,7 +308,7 @@ def _getUserSid(user):
     '''
     ret = {}
 
-    sid_pattern = '^S-1(-\d+){1,}$'
+    sid_pattern = r'^S-1(-\d+){1,}$'
 
     if user and re.match(sid_pattern, user, re.I):
         try:

--- a/salt/modules/win_dacl.py
+++ b/salt/modules/win_dacl.py
@@ -9,6 +9,7 @@ Manage DACLs on Windows
 from __future__ import absolute_import
 import os
 import logging
+import re
 
 # TODO: Figure out the exceptions that could be raised and properly catch
 #       them instead of a bare except that catches any exception at all
@@ -306,14 +307,34 @@ def _getUserSid(user):
     if user is None, sid will also be None
     '''
     ret = {}
-    try:
-        sid = win32security.LookupAccountName('', user)[0] if user else None
-        ret['result'] = True
-        ret['sid'] = sid
-    except Exception as e:
-        ret['result'] = False
-        ret['comment'] = 'Unable to obtain the security identifier for {0}.  The exception was {1}.'.format(
-            user, e)
+
+    sid_pattern = '^S-1(-\d+){1,}$'
+
+    if user and re.match(sid_pattern, user, re.I):
+        try:
+            sid = win32security.GetBinarySid(user)
+        except Exception as e:
+            ret['result'] = False
+            ret['comment'] = 'Unable to obtain the binary security identifier for {0}.  The exception was {1}.'.format(
+                user, e)
+        else:
+            try:
+                win32security.LookupAccountSid('', sid)
+                ret['result'] = True
+                ret['sid'] = sid
+            except Exception as e:
+                ret['result'] = False
+                ret['comment'] = 'Unable to lookup the account for the security identifier {0}.  The exception was {1}.'.format(
+                    user, e)
+    else:
+        try:
+            sid = win32security.LookupAccountName('', user)[0] if user else None
+            ret['result'] = True
+            ret['sid'] = sid
+        except Exception as e:
+            ret['result'] = False
+            ret['comment'] = 'Unable to obtain the security identifier for {0}.  The exception was {1}.'.format(
+                user, e)
     return ret
 
 

--- a/salt/states/win_dacl.py
+++ b/salt/states/win_dacl.py
@@ -6,7 +6,7 @@ Ensure an ACL is present
     parameters:
         name - the path of the object
         objectType - Registry/File/Directory
-        user - user account for the ace
+        user - user account or SID for the ace
         permission - permission for the ace (see module win_acl for available permissions for each objectType)
         acetype -  Allow/Deny
         propagation - how the ACL should apply to child objects (see module win_acl for available propagation types)
@@ -26,7 +26,7 @@ Ensure an ACL does not exist
     parameters:
         name - the path of the object
         objectType - Registry/File/Directory
-        user - user account for the ace
+        user - user account or SID for the ace
         permission - permission for the ace (see module win_acl for available permissions for each objectType)
         acetype -  Allow/Deny
         propagation - how the ACL should apply to child objects (see module win_acl for available propagation types)


### PR DESCRIPTION
### What does this PR do?

This pull requests lets one use SID's as security principals in the win_dacl module where previously only user accounts/groups were accepted.
### Previous Behavior

Only user accounts/groups were accepted as security principal.
### New Behavior

Both SID's and user accounts/groups can be used as security principal.
### Tests written?

No
### Motivation

Accounts with well known SID's (administrator, everyone, etc) are localised on non English Windows versions ("everyone" on English systems is named "Jeder" on German systems, and "tout le monde" on French systems).

The SID's for those well known accounts are the same across all versions of Windows, which makes handling ACL's on localised Windows releases easier, as one can just reference the well known SID's.

Well known SID's: https://support.microsoft.com/en-us/kb/243330