### PR TITLE
Issue 34880 cloud vmware image not working

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2852,7 +2852,7 @@ def is_profile_configured(opts, provider, profile_name, vm_=None):
         non_size_drivers.append('linode')
 
     # If cloning on VMware, specifying image is not necessary.
-    if driver == 'vmware' and profile_key.get('image', True):
+    if driver == 'vmware' and profile_key.get('clonefrom', False):
         non_image_drivers.append('vmware')
 
     if driver not in non_image_drivers:

--- a/tests/unit/cloud/clouds/vmware_test.py
+++ b/tests/unit/cloud/clouds/vmware_test.py
@@ -14,6 +14,7 @@ from copy import deepcopy
 from salttesting import TestCase, skipIf
 from salttesting.mock import MagicMock, NO_MOCK, NO_MOCK_REASON, patch
 from salttesting.helpers import ensure_in_syspath
+from salt import config
 
 ensure_in_syspath('../../../')
 
@@ -43,6 +44,14 @@ PROVIDER_CONFIG = {
   }
 }
 VM_NAME = 'test-vm'
+PROFILE = {
+  'base-gold': {
+    'provider': 'vcenter01:vmware',
+    'datastore': 'Datastore1',
+    'resourcepool': 'Resources',
+    'folder': 'vm'
+  }
+}
 
 
 class ExtendedTestCase(TestCase):
@@ -797,54 +806,67 @@ class VMwareTestCase(ExtendedTestCase):
         Tests that a SaltCloudSystemExit is raised when esxi_host_password is not
         specified in the cloud provider configuration when calling add_host.
         '''
-        import salt.config as config
 
-        profile = {
-            'base-gold': {
-                'provider': 'vcenter01:vmware',
-                'datastore': 'Datastore1',
-                'resourcepool': 'Resources',
-                'folder': 'vm',
-                'image': 'test-image'
-            }
-
+        profile_additions = {
+            'image': 'some-image.iso'
         }
+
+        provider_config = deepcopy(PROVIDER_CONFIG)
+        profile = deepcopy(PROFILE)
+        profile['base-gold'].update(profile_additions)
+
         provider_config_additions = {
             'profiles': profile
         }
-        provider_config = deepcopy(PROVIDER_CONFIG)
         provider_config['vcenter01']['vmware'].update(provider_config_additions)
         vm_ = {'profile': profile}
         with patch.dict(vmware.__opts__, {'providers': provider_config}, clean=True):
             self.assertEqual(config.is_profile_configured(vmware.__opts__, 'vcenter01:vmware',
-                                         'base-gold', vm_=vm_), True)
+                                                          'base-gold', vm_=vm_), True)
 
     def test_just_clonefrom(self):
         '''
         Tests that a SaltCloudSystemExit is raised when esxi_host_password is not
         specified in the cloud provider configuration when calling add_host.
         '''
-        import salt.config as config
 
-        profile = {
-            'base-gold': {
-                'provider': 'vcenter01:vmware',
-                'datastore': 'Datastore1',
-                'resourcepool': 'Resources',
-                'folder': 'vm',
-                'clonefrom': 'test-template'
-            }
-
+        profile_additions = {
+            'clonefrom': 'test-template'
         }
+
+        provider_config = deepcopy(PROVIDER_CONFIG)
+        profile = deepcopy(PROFILE)
+        profile['base-gold'].update(profile_additions)
+
         provider_config_additions = {
             'profiles': profile
         }
-        provider_config = deepcopy(PROVIDER_CONFIG)
         provider_config['vcenter01']['vmware'].update(provider_config_additions)
         vm_ = {'profile': profile}
         with patch.dict(vmware.__opts__, {'providers': provider_config}, clean=True):
             self.assertEqual(config.is_profile_configured(vmware.__opts__, 'vcenter01:vmware',
                                                           'base-gold', vm_=vm_), True)
+
+    def test_no_clonefrom_expect_fail(self):
+        '''
+        Tests that a SaltCloudSystemExit is raised when esxi_host_password is not
+        specified in the cloud provider configuration when calling add_host.
+        '''
+
+        profile_additions = {}
+
+        provider_config = deepcopy(PROVIDER_CONFIG)
+        profile = deepcopy(PROFILE)
+        profile['base-gold'].update(profile_additions)
+
+        provider_config_additions = {
+            'profiles': profile
+        }
+        provider_config['vcenter01']['vmware'].update(provider_config_additions)
+        vm_ = {'profile': profile}
+        with patch.dict(vmware.__opts__, {'providers': provider_config}, clean=True):
+            self.assertEqual(config.is_profile_configured(vmware.__opts__, 'vcenter01:vmware',
+                                                          'base-gold', vm_=vm_), False)
 
     def test_add_host_no_host_in_kwargs(self):
         '''

--- a/tests/unit/cloud/clouds/vmware_test.py
+++ b/tests/unit/cloud/clouds/vmware_test.py
@@ -792,6 +792,60 @@ class VMwareTestCase(ExtendedTestCase):
                 kwargs=None,
                 call='function')
 
+    def test_no_clonefrom_just_image(self):
+        '''
+        Tests that a SaltCloudSystemExit is raised when esxi_host_password is not
+        specified in the cloud provider configuration when calling add_host.
+        '''
+        import salt.config as config
+
+        profile = {
+            'base-gold': {
+                'provider': 'vcenter01:vmware',
+                'datastore': 'Datastore1',
+                'resourcepool': 'Resources',
+                'folder': 'vm',
+                'image': 'test-image'
+            }
+
+        }
+        provider_config_additions = {
+            'profiles': profile
+        }
+        provider_config = deepcopy(PROVIDER_CONFIG)
+        provider_config['vcenter01']['vmware'].update(provider_config_additions)
+        vm_ = {'profile': profile}
+        with patch.dict(vmware.__opts__, {'providers': provider_config}, clean=True):
+            self.assertEqual(config.is_profile_configured(vmware.__opts__, 'vcenter01:vmware',
+                                         'base-gold', vm_=vm_), True)
+
+    def test_just_clonefrom(self):
+        '''
+        Tests that a SaltCloudSystemExit is raised when esxi_host_password is not
+        specified in the cloud provider configuration when calling add_host.
+        '''
+        import salt.config as config
+
+        profile = {
+            'base-gold': {
+                'provider': 'vcenter01:vmware',
+                'datastore': 'Datastore1',
+                'resourcepool': 'Resources',
+                'folder': 'vm',
+                'clonefrom': 'test-template'
+            }
+
+        }
+        provider_config_additions = {
+            'profiles': profile
+        }
+        provider_config = deepcopy(PROVIDER_CONFIG)
+        provider_config['vcenter01']['vmware'].update(provider_config_additions)
+        vm_ = {'profile': profile}
+        with patch.dict(vmware.__opts__, {'providers': provider_config}, clean=True):
+            self.assertEqual(config.is_profile_configured(vmware.__opts__, 'vcenter01:vmware',
+                                                          'base-gold', vm_=vm_), True)
+
     def test_add_host_no_host_in_kwargs(self):
         '''
         Tests that a SaltCloudSystemExit is raised when host is not present in


### PR DESCRIPTION
### What does this PR do?

Resolves issue #34880 in salt-cloud vmware driver where specifying the `image` property for an ESX host was not working as salt-cloud was requiring `clonefrom` to be present, which is only valid for vCenter and not ESX.
### What issues does this PR fix or reference?

Resolves issue #34880 
### Previous Behavior

Would report that `clonefrom` property was required even if the `image` property was provided.
### New Behavior

If `clonefrom` provided: validation passes.
If `image` provided: validation passes
If neither `clonefrom` nor `image`: validation does not pass
### Tests written?

Yes... but I'm not sure I like them that much.
