### PR TITLE
Remove stray debug print statements

### DIFF
--- a/salt/modules/cpan.py
+++ b/salt/modules/cpan.py
@@ -51,9 +51,6 @@ def install(module):
     cmd = 'cpan -i {0}'.format(module)
     out = __salt__['cmd.run'](cmd)
 
-    import pprint
-    pprint.pprint(out)
-
     if "don't know what it is" in out:
         ret['error'] = 'CPAN cannot identify this package'
         return ret

--- a/tests/unit/states/boto_elb_test.py
+++ b/tests/unit/states/boto_elb_test.py
@@ -110,8 +110,6 @@ class BotoElbTestCase(TestCase):
                         boto_elb.__salt__['boto_elb.get_health_check'].called
                     )
                     self.assertIn('ELB myelb created.', ret['comment'])
-                    import pprint
-                    pprint.pprint(ret)
                     self.assertTrue(ret['result'])
 
         mock = MagicMock(return_value={})


### PR DESCRIPTION
### What does this PR do?

Removes stray output while running `tests/runtests.py --unit-tests`