### PR TITLE
Add versionadded for new cache_valid_time option in aptpkg

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -237,7 +237,10 @@ def latest_version(*names, **kwargs):
     A specific repo can be requested using the ``fromrepo`` keyword argument.
 
     cache_valid_time
-        skip refresh the package database if refresh has already occur within
+
+        .. versionadded:: Carbon
+
+        Skip refreshing the package database if refresh has already occurred within
         <value> seconds
 
     CLI Example:
@@ -361,7 +364,10 @@ def refresh_db(cache_valid_time=0):
     - ``None``: Database already up-to-date
 
     cache_valid_time
-        skip refresh the package database if refresh has already occur within
+
+        .. versionadded:: Carbon
+
+        Skip refreshing the package database if refresh has already occurred within
         <value> seconds
 
     CLI Example:
@@ -448,7 +454,10 @@ def install(name=None,
         Whether or not to refresh the package database before installing.
 
     cache_valid_time
-        skip refresh the package database if refresh has already occur within
+
+        .. versionadded:: Carbon
+
+        Skip refreshing the package database if refresh has already occurred within
         <value> seconds
 
     fromrepo
@@ -948,7 +957,10 @@ def upgrade(refresh=True, dist_upgrade=False, **kwargs):
         .. versionadded:: 2014.7.0
 
     cache_valid_time
-        skip refresh the package database if refresh has already occur within
+
+        .. versionadded:: Carbon
+
+        Skip refreshing the package database if refresh has already occurred within
         <value> seconds
 
     force_conf_new
@@ -1338,7 +1350,10 @@ def list_upgrades(refresh=True, dist_upgrade=True, **kwargs):
         Default: True.
 
     cache_valid_time
-        skip refresh the package database if refresh has already occur within
+
+        .. versionadded:: Carbon
+
+        Skip refreshing the package database if refresh has already occurred within
         <value> seconds
 
     dist_upgrade

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -752,9 +752,12 @@ def installed(
         from slowing down the Salt run.
 
     :param str cache_valid_time:
-        This parameter sets the value in seconds after which cache marked as invalid,
-        and cache update is necessary. This overwrite ``refresh`` parameter
-        default behavior.
+
+        .. versionadded:: Carbon
+
+        This parameter sets the value in seconds after which the cache is
+        marked as invalid, and a cache update is necessary. This overwrites
+        the ``refresh`` parameter's default behavior.
 
         Example:
 
@@ -771,13 +774,13 @@ def installed(
                 - allow_updates: True
                 - hold: False
 
-        In this case refresh will not take place for 5 minutes since last
-        ``apt-get update`` executed on the system.
+        In this case, a refresh will not take place for 5 minutes since the last
+        ``apt-get update`` was executed on the system.
 
         .. note::
 
-            This parameter available only on Debian based distributions, and
-            have no effect on the rest.
+            This parameter is available only on Debian based distributions and
+            has no effect on the rest.
 
     :param str fromrepo:
         Specify a repository from which to install
@@ -1659,9 +1662,12 @@ def latest(
         from slowing down the Salt run.
 
     :param str cache_valid_time:
-        This parameter sets the value in seconds after which cache marked as invalid,
-        and cache update is necessary. This overwrite ``refresh`` parameter
-        default behavior.
+
+        .. versionadded:: Carbon
+
+        This parameter sets the value in seconds after which the cache is
+        marked as invalid, and a cache update is necessary. This overwrites
+        the ``refresh`` parameter's default behavior.
 
         Example:
 
@@ -1672,13 +1678,13 @@ def latest(
                 - refresh: True
                 - cache_valid_time: 300
 
-        In this case refresh will not take place for 5 minutes since last
-        ``apt-get update`` executed on the system.
+        In this case, a refresh will not take place for 5 minutes since the last
+        ``apt-get update`` was executed on the system.
 
         .. note::
 
-            This parameter available only on Debian based distributions, and
-            have no effect on the rest.
+            This parameter is available only on Debian based distributions and
+            has no effect on the rest.
 
 
     Multiple Package Installation Options:


### PR DESCRIPTION
Also includes some various and small doc changes from the new docs.

Refs saltstack/salt#34914