### PR TITLE
do not crash on "make" package description.

### DIFF
--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -288,9 +288,9 @@ def _get_pkg_info(*packages):
     if call['retcode']:
         raise CommandExecutionError("Error getting packages information: {0}".format(call['stderr']))
 
-    for pkg_info in [elm for elm in re.split(r"----*", call['stdout']) if elm.strip()]:
+    for pkg_info in [elm for elm in re.split(r"------", call['stdout']) if elm.strip()]:
         pkg_data = {}
-        pkg_info, pkg_descr = re.split(r"====*", pkg_info)
+        pkg_info, pkg_descr = re.split(r"======", pkg_info)
         for pkg_info_line in [el.strip() for el in pkg_info.split(os.linesep) if el.strip()]:
             key, value = pkg_info_line.split(":", 1)
             if value:


### PR DESCRIPTION
### What does this PR do?

Fixes pkg.info_installed and other modules that use it on Debian.

Package info is retrieved calling dpkg using a custom format/separator. However the code that parses the output for some reason does not use THAT separator (six '-' or '='), but a regexp with a different meaning (three or more '-' or '=') that chokes on the description of make (https://packages.debian.org/jessie/make) which contains three '-''s., crashing as:

```
    for pkg_name, pkg_nfo in __salt__['lowpkg.info'](*names).items():
  File "/usr/lib/python2.7/dist-packages/salt/modules/dpkg.py", line 392, in info
    for pkg in _get_pkg_info(*packages):
  File "/usr/lib/python2.7/dist-packages/salt/modules/dpkg.py", line 293, in _get_pkg_info
    pkg_info, pkg_descr = re.split(r"====*", pkg_info)
ValueError: need more than 1 value to unpack
```
### What issues does this PR fix or reference?

Could not find a specific one.

There are other issues that are related to the design of building custom output and try to parse it. Like https://github.com/saltstack/salt/issues/34514 but it is a different issue, but probably enough to think about a different approach. I ignore if python-apt can do also dpkg queries.
### Previous Behavior

``` console
docker pull debian
# Follow https://repo.saltstack.com/#debian intructions
salt-call --local pkg.info_installed # works
apt-get install make
salt-call --local pkg.info_installed # crashes
```
### New Behavior

``` console
docker pull debian
# Follow https://repo.saltstack.com/#debian intructions
salt-call --local pkg.info_installed # works
apt-get install make
salt-call --local pkg.info_installed # works
```
### Tests written?

No

@isbm 
@meaksh 
@dincamihai