### PR TITLE
INFRA-1589 - add several tagging related functions to boto_ec2 exec and state modules

### DIFF
--- a/salt/modules/boto_ec2.py
+++ b/salt/modules/boto_ec2.py
@@ -1671,9 +1671,11 @@ def set_volumes_tags(tag_maps, authoritative=False, dry_run=False,
             else:
                 log.debug('No changes needed for vol.id {0}'.format(vol.id))
             if len(add):
-                log.debug('New tags for vol.id {0}: {1}'.format(vol.id, {k: tags[k] for k in add}))
+                d = dict((k, tags[k]) for k in add)
+                log.debug('New tags for vol.id {0}: {1}'.format(vol.id, d))
             if len(update):
-                log.debug('Updated tags for vol.id {0}: {1}'.format(vol.id, {k: tags[k] for k in update}))
+                d = dict((k, tags[k]) for k in update)
+                log.debug('Updated tags for vol.id {0}: {1}'.format(vol.id, d))
             if not dry_run:
                 if not create_tags(vol.id, tags, region=region, key=key, keyid=keyid, profile=profile):
                     ret['success'] = False


### PR DESCRIPTION
Add a few useful tag related funcs
modules/boto_ec2.py:
- delete_tags() - support deleting tags on resources
- set_volumes_tags() - set (with cleanup or not) tags on volumes based on fairly complex filter->tagset mappings

states/boto_ec2.py:
- volumes_tagged - new state which uses the above functions to manage tags on EC2 instance volumes