### PR TITLE
Fix cpu_model grain on Windows to actual CPU model

### DIFF
--- a/doc/topics/releases/carbon.rst
+++ b/doc/topics/releases/carbon.rst
@@ -64,6 +64,31 @@ Grains Changes
 
       {% set on_vmware = grains['virtual'].lower() == 'vmware' %}
 
+
+- On Windows the ``cpu_model`` grain has been changed to provide the actual cpu
+  model name and not the cpu family.
+
+  Old behavior:
+
+  .. code-block:: bash
+
+      root@master:~# salt 'testwin200' grains.item cpu_model
+      testwin200:
+          ----------
+          cpu_model:
+              Intel64 Family 6 Model 58 Stepping 9, GenuineIntel
+
+  New behavior:
+
+  .. code-block:: bash
+
+      root@master:~# salt 'testwin200' grains.item cpu_model
+      testwin200:
+          ----------
+          cpu_model:
+              Intel(R) Core(TM) i7-3520M CPU @ 2.90GHz
+
+
 Beacons Changes
 ===============
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -62,7 +62,9 @@ if salt.utils.is_windows():
         import wmi  # pylint: disable=import-error
         import salt.utils.winapi
         import win32api
+        import salt.modules.reg
         HAS_WMI = True
+        __salt__['reg.read_value'] = salt.modules.reg.read_value
     except ImportError:
         log.exception(
             'Unable to import Python wmi module, some core grains '
@@ -87,7 +89,10 @@ def _windows_cpudata():
             grains['num_cpus'] = int(os.environ['NUMBER_OF_PROCESSORS'])
         except ValueError:
             grains['num_cpus'] = 1
-    grains['cpu_model'] = platform.processor()
+    grains['cpu_model'] = __salt__['reg.read_value'](
+                       "HKEY_LOCAL_MACHINE",
+                       "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0",
+                       "ProcessorNameString").get('vdata')
     return grains
 
 


### PR DESCRIPTION
### What does this PR do?

On Windows the `cpu_model` grain gave cpu family info, not the cpu model
### What issues does this PR fix or reference?

Fixes saltstack/salt#35027
### Previous Behavior

```
root@bouchamaster:~# salt 'test*' grains.item cpu_model
testwin200:
    ----------
    cpu_model:
        Intel64 Family 6 Model 58 Stepping 9, GenuineIntel
```
### New Behavior

```
root@bouchamaster:~# salt 'test*' grains.item cpu_model
testwin200:
    ----------
    cpu_model:
        Intel(R) Core(TM) i7-3520M CPU @ 2.90GHz
```
### Tests written?

No