### PR TITLE
Fixing the Tomcat state's indifference to a lack of versions and incorrect file paths

### DIFF
--- a/salt/modules/tomcat.py
+++ b/salt/modules/tomcat.py
@@ -74,11 +74,11 @@ import logging
 # pylint: disable=no-name-in-module,import-error
 from salt.ext.six.moves.urllib.parse import urlencode as _urlencode
 from salt.ext.six.moves.urllib.request import (
-        urlopen as _urlopen,
-        HTTPBasicAuthHandler as _HTTPBasicAuthHandler,
-        HTTPDigestAuthHandler as _HTTPDigestAuthHandler,
-        build_opener as _build_opener,
-        install_opener as _install_opener
+    urlopen as _urlopen,
+    HTTPBasicAuthHandler as _HTTPBasicAuthHandler,
+    HTTPDigestAuthHandler as _HTTPDigestAuthHandler,
+    build_opener as _build_opener,
+    install_opener as _install_opener
 )
 # pylint: enable=no-name-in-module,import-error
 
@@ -111,7 +111,8 @@ def __virtual__():
     '''
     if __catalina_home() or _auth('dummy'):
         return 'tomcat'
-    return (False, 'Tomcat execution module not loaded: neither Tomcat installed locally nor tomcat-manager credentials set in grains/pillar/config.')
+    return (False,
+            'Tomcat execution module not loaded: neither Tomcat installed locally nor tomcat-manager credentials set in grains/pillar/config.')
 
 
 def __catalina_home():
@@ -168,10 +169,10 @@ def _auth(uri):
 
     basic = _HTTPBasicAuthHandler()
     basic.add_password(realm='Tomcat Manager Application', uri=uri,
-            user=user, passwd=password)
+                       user=user, passwd=password)
     digest = _HTTPDigestAuthHandler()
     digest.add_password(realm='Tomcat Manager Application', uri=uri,
-            user=user, passwd=password)
+                        user=user, passwd=password)
     return _build_opener(basic, digest)
 
 
@@ -191,7 +192,7 @@ def _extract_war_version(war):
     basename = os.path.basename(war)
     war_package = os.path.splitext(basename)[0]  # remove '.war'
     version = re.findall("-([\\d.-]+)$", war_package)  # try semver
-    return version[0] if version and len(version) == 1 else None # default to none
+    return version[0] if version and len(version) == 1 else None  # default to none
 
 
 def _wget(cmd, opts=None, url='http://localhost:8080/manager', timeout=180):
@@ -291,7 +292,7 @@ def leaks(url='http://localhost:8080/manager', timeout=180):
     '''
 
     return _wget('findleaks', {'statusLine': 'true'},
-        url, timeout=timeout)['msg']
+                 url, timeout=timeout)['msg']
 
 
 def status(url='http://localhost:8080/manager', timeout=180):
@@ -604,9 +605,9 @@ def deploy_war(war,
         'war': 'file:{0}'.format(tfile),
         'path': context,
     }
-    
+
     # If parallel versions are desired or not disabled
-    if version != False:
+    if version is True:
         # Set it to defined version or attempt extract
         version = version or _extract_war_version(war)
 
@@ -649,7 +650,7 @@ def passwd(passwd,
     digest = hasattr(hashlib, alg) and getattr(hashlib, alg) or None
     if digest:
         if realm:
-            digest.update('{0}:{1}:{2}'.format(user, realm, passwd,))
+            digest.update('{0}:{1}:{2}'.format(user, realm, passwd, ))
         else:
             digest.update(passwd)
 

--- a/salt/modules/tomcat.py
+++ b/salt/modules/tomcat.py
@@ -186,12 +186,12 @@ def _extract_war_version(war):
     .. code-block::
 
         /path/salt-2015.8.6.war -> 2015.8.6
-        /path/V6R2013xD5.war -> V6R2013xD5
+        /path/V6R2013xD5.war -> None
     '''
     basename = os.path.basename(war)
     war_package = os.path.splitext(basename)[0]  # remove '.war'
     version = re.findall("-([\\d.-]+)$", war_package)  # try semver
-    return version[0] if version and len(version) == 1 else war_package  # default to whole name
+    return version[0] if version and len(version) == 1 else None # default to none
 
 
 def _wget(cmd, opts=None, url='http://localhost:8080/manager', timeout=180):
@@ -603,8 +603,17 @@ def deploy_war(war,
     opts = {
         'war': 'file:{0}'.format(tfile),
         'path': context,
-        'version': version or _extract_war_version(war),
     }
+    
+    # If parallel versions are desired or not disabled
+    if version != False:
+        # Set it to defined version or attempt extract
+        version = version or _extract_war_version(war)
+
+        if version != ('' or None):
+            # Only pass version to Tomcat if not undefined
+            opts['version'] = version
+
     if force == 'yes':
         opts['update'] = 'true'
 

--- a/salt/states/tomcat.py
+++ b/salt/states/tomcat.py
@@ -27,7 +27,7 @@ a valid user in the file ``conf/tomcat-users.xml``.
     <?xml version='1.0' encoding='utf-8'?>
     <tomcat-users>
         <role rolename="manager-script"/>
-        <user username="tomcat" password="tomcat" roles="manager-script"/>
+        <user username="tomcat-manager" password="Passw0rd" roles="manager-script"/>
     </tomcat-users>
 
 Notes

--- a/salt/states/tomcat.py
+++ b/salt/states/tomcat.py
@@ -1,14 +1,28 @@
 # -*- coding: utf-8 -*-
 '''
-This state uses the manager webapp to manage Apache tomcat webapps
-This state requires the manager webapp to be enabled
+Manage Apache Tomcat web applications
+=====================================
 
-The following grains/pillar should be set::
+.. note::
+    This state requires the Tomcat Manager webapp to be installed and running.
 
-    tomcat-manager:user: admin user name
-    tomcat-manager:passwd: password
+The following grains/pillars must be set for communication with Tomcat Manager
+to work:
 
-and also configure a user in the conf/tomcat-users.xml file::
+.. code-block:: yaml
+
+    tomcat-manager:
+        user: 'tomcat-manager'
+        passwd: 'Passw0rd'
+
+
+Configuring Tomcat Manager
+--------------------------
+To manage webapps via the Tomcat Manager, you'll need to configure
+a valid user in the file ``conf/tomcat-users.xml``.
+
+.. code-block:: xml
+   :caption: conf/tomcat-users.xml
 
     <?xml version='1.0' encoding='utf-8'?>
     <tomcat-users>
@@ -16,28 +30,29 @@ and also configure a user in the conf/tomcat-users.xml file::
         <user username="tomcat" password="tomcat" roles="manager-script"/>
     </tomcat-users>
 
-Notes:
+Notes
+-----
 
-- Not supported multiple version on the same context path
-- More information about tomcat manager:
-    http://tomcat.apache.org/tomcat-7.0-doc/manager-howto.html
-- if you use only this module for deployments you might want to restrict
-    access to the manager so its only accessible via localhost
-    for more info: http://tomcat.apache.org/tomcat-7.0-doc/manager-howto.html#Configuring_Manager_Application_Access
-- Tested on:
-
-  JVM Vendor:
-      Sun Microsystems Inc.
-  JVM Version:
-      1.6.0_43-b01
-  OS Architecture:
+- Using multiple versions (aka. parallel deployments) on the same context
+  path is not supported.
+- More information about the Tomcat Manager:
+  http://tomcat.apache.org/tomcat-7.0-doc/manager-howto.html
+- If you use only this module for deployments you might want to restrict
+  access to the manager so it's only accessible via localhost.
+  For more info: http://tomcat.apache.org/tomcat-7.0-doc/manager-howto.html#Configuring_Manager_Application_Access
+- Last tested on:
+    Tomcat Version:
+      Apache Tomcat/7.0.54
+    JVM Vendor:
+      Oracle Corporation
+    JVM Version:
+      1.8.0_101-b13
+    OS Architecture:
       amd64
-  OS Name:
+    OS Name:
       Linux
-  OS Version:
-      2.6.32-358.el6.x86_64
-  Tomcat Version:
-      Apache Tomcat/7.0.37
+    OS Version:
+      3.10.0-327.22.2.el7.x86_64
 '''
 
 from __future__ import absolute_import
@@ -64,31 +79,38 @@ def war_deployed(name,
                  temp_war_location=None,
                  version=''):
     '''
-    Enforce that the WAR will be deployed and started in the context path
-    it will make use of WAR versions
+    Enforce that the WAR will be deployed and started in the context path,
+    while making use of WAR versions in the filename.
 
-    for more info:
+    .. note::
+
+        For more info about Tomcats file paths and context naming, please see
         http://tomcat.apache.org/tomcat-7.0-doc/config/context.html#Naming
 
     name
-        the context path to deploy
+        The context path to deploy (incl. forward slash) the WAR to.
     war
-        absolute path to WAR file (should be accessible by the user running
-        tomcat) or a path supported by the salt.modules.cp.get_url function
-    force
-        force deploy even if version strings are the same, False by default.
+        Absolute path to WAR file (should be accessible by the user running
+        Tomcat) or a path supported by the ``salt.modules.cp.get_url`` function.
+    force : False
+        Force deployment even if the version strings are the same.
+        Disabled by default.
     url : http://localhost:8080/manager
-        the URL of the server manager webapp
+        The URL of the Tomcat Web Application Manager.
     timeout : 180
-        timeout for HTTP request to the tomcat manager
+        Timeout for HTTP requests to the Tomcat Manager.
     temp_war_location : None
-        use another location to temporarily copy to war file
-        by default the system's temp directory is used
+        Use another location to temporarily copy the WAR file to.
+        By default the system's temp directory is used.
     version : ''
-        Specify the war version.  If this argument is provided, it overrides
-        the version encoded in the war file name, if one is present.
+        Specify the WAR version.  If this argument is provided, it overrides
+        the version encoded in the WAR file name, if one is present.
 
         .. versionadded:: 2015.8.6
+
+        Use ``False`` to prevent guessing the version and keeping it blank.
+
+        .. versionadded:: 2016.PLEASE_LET_ME_KNOW
 
     Example:
 
@@ -100,34 +122,55 @@ def war_deployed(name,
             - war: salt://jenkins-1.2.4.war
             - require:
               - service: application-service
+
+    .. note::
+
+        Be aware that in the above example the WAR ``jenkins-1.2.4.war`` will
+        be deployed to the context path ``jenkins##1.2.4``. To avoid this
+        either specify a version yourself, or set version to ``False``.
+
     '''
     # Prepare
     ret = {'name': name,
-       'result': True,
-       'changes': {},
-       'comment': ''}
+           'result': True,
+           'changes': {},
+           'comment': ''}
 
-    if not version:
-        version = _extract_war_version(war)
+    # if version is defined or False, we don't want to overwrite
+    if version == '':
+        version = _extract_war_version(war) or ""
+    elif not version:
+        version = ''
+    else:
+        version = str(version)
 
     webapps = __salt__['tomcat.ls'](url, timeout)
     deploy = False
     undeploy = False
     status = True
 
+    # Gathered/specified new WAR version string
+    specified_ver = 'version ' + version if version else 'no version'
+
     # Determine what to do
     try:
-        if not webapps[name]['version'].endswith(version) or force:
+        # Printed version strings, here to throw exception if no webapps[name]
+        current_ver = 'version ' + webapps[name]['version'] \
+            if webapps[name]['version'] else 'no version'
+        # `endswith` on the supposed string will cause Exception if empty
+        if (not webapps[name]['version'].endswith(version)
+            or (version == '' and webapps[name]['version'] != version)
+            or force):
             deploy = True
             undeploy = True
-            ret['changes']['undeploy'] = ('undeployed {0} in version {1}'.
-                    format(name, webapps[name]['version']))
-            ret['changes']['deploy'] = ('will deploy {0} in version {1}'.
-                    format(name, version))
+            ret['changes']['undeploy'] = ('undeployed {0} with {1}'.
+                                          format(name, current_ver))
+            ret['changes']['deploy'] = ('will deploy {0} with {1}'.
+                                        format(name, specified_ver))
         else:
             deploy = False
-            ret['comment'] = ('{0} in version {1} is already deployed'.
-                    format(name, version))
+            ret['comment'] = ('{0} with {1} is already deployed'.
+                              format(name, specified_ver))
             if webapps[name]['mode'] != 'running':
                 ret['changes']['start'] = 'starting {0}'.format(name)
                 status = False
@@ -135,8 +178,8 @@ def war_deployed(name,
                 return ret
     except Exception:
         deploy = True
-        ret['changes']['deploy'] = ('deployed {0} in version {1}'.format(name,
-            version))
+        ret['changes']['deploy'] = ('deployed {0} with {1}'.
+                                    format(name, specified_ver))
 
     # Test
     if __opts__['test']:
@@ -147,7 +190,7 @@ def war_deployed(name,
     if deploy is False:
         if status is False:
             ret['comment'] = __salt__['tomcat.start'](name, url,
-                    timeout=timeout)
+                                                      timeout=timeout)
             ret['result'] = ret['comment'].startswith('OK')
         return ret
 
@@ -166,14 +209,15 @@ def war_deployed(name,
                                                url,
                                                __env__,
                                                timeout,
-                                               temp_war_location=temp_war_location)
+                                               temp_war_location=temp_war_location,
+                                               version=version)
 
     # Return
     if deploy_res.startswith('OK'):
         ret['result'] = True
         ret['comment'] = str(__salt__['tomcat.ls'](url, timeout)[name])
-        ret['changes']['deploy'] = 'deployed {0} in version {1}'.format(name,
-                version)
+        ret['changes']['deploy'] = ('deployed {0} with {1}'.
+                                    format(name, specified_ver))
     else:
         ret['result'] = False
         ret['comment'] = deploy_res
@@ -183,17 +227,17 @@ def war_deployed(name,
 
 def wait(name, url='http://localhost:8080/manager', timeout=180):
     '''
-    Wait for the tomcat manager to load
+    Wait for the Tomcat Manager to load.
 
     Notice that if tomcat is not running we won't wait for it start and the
     state will fail. This state can be required in the tomcat.war_deployed
     state to make sure tomcat is running and that the manager is running as
-    well and ready for deployment
+    well and ready for deployment.
 
     url : http://localhost:8080/manager
-        the URL of the server manager webapp
+        The URL of the server with the Tomcat Manager webapp.
     timeout : 180
-        timeout for HTTP request to the tomcat manager
+        Timeout for HTTP request to the Tomcat Manager.
 
     Example:
 
@@ -220,11 +264,11 @@ def wait(name, url='http://localhost:8080/manager', timeout=180):
 
     result = __salt__['tomcat.status'](url, timeout)
     ret = {'name': name,
-       'result': result,
-       'changes': {},
-       'comment': ('tomcat manager is ready' if result
-               else 'tomcat manager is not ready')
-       }
+           'result': result,
+           'changes': {},
+           'comment': ('tomcat manager is ready' if result
+                       else 'tomcat manager is not ready')
+           }
 
     return ret
 
@@ -239,26 +283,26 @@ def mod_watch(name, url='http://localhost:8080/manager', timeout=180):
     result = msg.startswith('OK')
 
     ret = {'name': name,
-       'result': result,
-       'changes': {name: result},
-       'comment': msg
-       }
+           'result': result,
+           'changes': {name: result},
+           'comment': msg
+           }
 
     return ret
 
 
 def undeployed(name,
-                 url='http://localhost:8080/manager',
-                 timeout=180):
+               url='http://localhost:8080/manager',
+               timeout=180):
     '''
-    Enforce that the WAR will be un-deployed from the server
+    Enforce that the WAR will be undeployed from the server
 
     name
-        the context path to deploy
+        The context path to undeploy.
     url : http://localhost:8080/manager
-        the URL of the server manager webapp
+        The URL of the server with the Tomcat Manager webapp.
     timeout : 180
-        timeout for HTTP request to the tomcat manager
+        Timeout for HTTP request to the Tomcat Manager.
 
     Example:
 
@@ -273,12 +317,12 @@ def undeployed(name,
 
     # Prepare
     ret = {'name': name,
-       'result': True,
-       'changes': {},
-       'comment': ''}
+           'result': True,
+           'changes': {},
+           'comment': ''}
 
     if not __salt__['tomcat.status'](url, timeout):
-        ret['comment'] = 'Tomcat Manager does not response'
+        ret['comment'] = 'Tomcat Manager does not respond'
         ret['result'] = False
         return ret
 

--- a/tests/unit/states/tomcat_test.py
+++ b/tests/unit/states/tomcat_test.py
@@ -6,6 +6,9 @@
 # Import Python Libs
 from __future__ import absolute_import
 
+# Import Salt Libs
+from salt.states import tomcat
+
 # Import Salt Testing Libs
 from salttesting import TestCase, skipIf
 from salttesting.helpers import ensure_in_syspath
@@ -18,9 +21,6 @@ from salttesting.mock import (
 
 ensure_in_syspath('../../')
 
-# Import Salt Libs
-from salt.states import tomcat
-
 # Globals
 tomcat.__salt__ = {}
 tomcat.__opts__ = {}
@@ -30,42 +30,44 @@ tomcat.__env__ = {}
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class TomcatTestCase(TestCase):
     '''
-        Validate the tomcat state
+    Validate the tomcat state
     '''
+
     def test_war_deployed(self):
         '''
-            Test to enforce that the WAR will be deployed and
-            started in the context path it will make use of WAR versions
+        Test to enforce that the WAR will be deployed and
+        started in the context path it will make use of WAR versions
         '''
         ret = {'name': 'salt',
                'changes': {},
                'result': True,
                'comment': ''}
-        mock1 = MagicMock(return_value='saltstack')
-        mock2 = MagicMock(side_effect=['FAIL', 'saltstack'])
-        mock3 = MagicMock(return_value='deploy')
-        mock = MagicMock(side_effect=[{'salt': {'version': 'jenkins-1.20.4',
-                                                'mode': 'running'}},
-                                      {'salt': {'version': '1'}},
-                                      {'salt': {'version': 'jenkins-1.2.4',
-                                                'mode': 'run'}},
-                                      {'salt': {'version': '1'}},
-                                      {'salt': {'version': '1'}}])
-        with patch.dict(tomcat.__salt__, {"tomcat.ls": mock,
-                                          'tomcat.start': mock1,
-                                          'tomcat.undeploy': mock2,
-                                          'tomcat.deploy_war': mock3}):
-            ret.update({'comment': 'salt in version 1.20.4'
-                        ' is already deployed'})
+        mock_start = MagicMock(return_value='saltstack')
+        mock_undeploy = MagicMock(side_effect=['FAIL', 'saltstack'])
+        mock_deploy = MagicMock(return_value='deploy')
+        mock_ls = MagicMock(side_effect=[{'salt': {'version': 'jenkins-1.20.4',
+                                                   'mode': 'running'}},
+                                         {'salt': {'version': '1'}},
+                                         {'salt': {'version': 'jenkins-1.2.4',
+                                                   'mode': 'run'}},
+                                         {'salt': {'version': '1'}},
+                                         {'salt': {'version': '1'}},
+                                         {'salt': {'version': '1'}}])
+        with patch.dict(tomcat.__salt__, {"tomcat.ls": mock_ls,
+                                          'tomcat.start': mock_start,
+                                          'tomcat.undeploy': mock_undeploy,
+                                          'tomcat.deploy_war': mock_deploy}):
+            ret.update({'comment': 'salt with version 1.20.4'
+                                   ' is already deployed'})
             self.assertDictEqual(tomcat.war_deployed('salt',
                                                      'salt://jenkins'
                                                      '-1.20.4.war'), ret)
 
             with patch.dict(tomcat.__opts__, {"test": True}):
                 ret.update({'changes': {'deploy': 'will deploy salt'
-                                        ' in version 1.2.4',
+                                                  ' with version 1.2.4',
                                         'undeploy': 'undeployed salt'
-                                        ' in version 1'},
+                                                    ' with version 1'},
                             'result': None, 'comment': ''})
                 self.assertDictEqual(tomcat.war_deployed('salt',
                                                          'salt://jenkins'
@@ -78,25 +80,89 @@ class TomcatTestCase(TestCase):
                                                          'salt://jenkins'
                                                          '-1.2.4.war'), ret)
 
-                ret.update({'changes': {'deploy': 'will deploy salt in'
-                                        ' version 1.2.4',
-                                        'undeploy': 'undeployed salt in'
-                                        ' version 1'},
+                ret.update({'changes': {'deploy': 'will deploy salt with'
+                                                  ' version 1.2.4',
+                                        'undeploy': 'undeployed salt with'
+                                                    ' version 1'},
                             'comment': 'FAIL'})
                 self.assertDictEqual(tomcat.war_deployed('salt',
                                                          'salt://jenkins'
                                                          '-1.2.4.war'), ret)
 
                 ret.update({'changes': {'undeploy': 'undeployed salt'
-                                        ' in version 1'},
+                                                    ' with version 1'},
                             'comment': 'deploy'})
                 self.assertDictEqual(tomcat.war_deployed('salt',
                                                          'salt://jenkins'
                                                          '-1.2.4.war'), ret)
 
+    def test_war_deployed_no_version(self):
+        '''
+        Tests that going from versions to no versions and back work, as well
+        as not overwriting a WAR without version with another without version.
+        '''
+        ret = {'name': 'salt',
+               'changes': {},
+               'result': None,
+               'comment': ''}
+
+        mock_deploy = MagicMock(return_value='deploy')
+        mock_undeploy = MagicMock(return_value='SUCCESS')
+        mock_ls_version = MagicMock(return_value={'salt': {'version': '1.2.4',
+                                                       'mode': 'running'}})
+        mock_ls_no_version = MagicMock(return_value={'salt': {'version': '',
+                                                        'mode': 'running'}})
+
+        # We're just checking what it *would* do.
+        with patch.dict(tomcat.__opts__, {"test": True}):
+            with patch.dict(tomcat.__salt__,
+                            {"tomcat.ls": mock_ls_version,
+                             "tomcat.deploy_war": mock_deploy,
+                             "tomcat.undeploy": mock_undeploy}):
+                # We deploy from version to no version
+                ret.update({'changes':
+                                {'deploy': 'will deploy salt with no version',
+                                 'undeploy': 'undeployed salt with version 1.2.4'},
+                            })
+                self.assertDictEqual(tomcat.war_deployed('salt',
+                                                         'salt://jenkins.war'),
+                                     ret)
+
+            with patch.dict(tomcat.__salt__,
+                            {"tomcat.ls": mock_ls_no_version,
+                             "tomcat.deploy_war": mock_deploy,
+                             "tomcat.undeploy": mock_undeploy}):
+                # Deploy from none to specified version
+                ret.update({'changes':
+                                {'deploy': 'will deploy salt with version 1.2.4',
+                                 'undeploy': 'undeployed salt with no version'},
+                            })
+                self.assertDictEqual(tomcat.war_deployed('salt',
+                                                         'salt://jenkins.war',
+                                                         version='1.2.4'),
+                                     ret)
+                # Deploy from none to extracted version
+                self.assertDictEqual(tomcat.war_deployed('salt',
+                                                         'salt://jenkins-1.2.4.war'),
+                                     ret)
+                # Don't deploy from no version to no version
+                ret.update({'changes': {},
+                            'comment': 'salt with no version is already deployed',
+                            'result': True
+                            })
+                # Don't deploy from blank to blank version
+                self.assertDictEqual(tomcat.war_deployed('salt',
+                                                         'salt://jenkins.war'),
+                                     ret)
+                # Don't deploy from blank to false version
+                self.assertDictEqual(tomcat.war_deployed('salt',
+                                                         'salt://jenkins-1.2.4.war',
+                                                         version=False),
+                                     ret)
+
     def test_wait(self):
         '''
-            Test to wait for the tomcat manager to load
+        Test to wait for the tomcat manager to load
         '''
         ret = {'name': 'salt',
                'changes': {},
@@ -108,7 +174,7 @@ class TomcatTestCase(TestCase):
 
     def test_mod_watch(self):
         '''
-            Test to the tomcat watcher function.
+        Test to the tomcat watcher function.
         '''
         ret = {'name': 'salt',
                'changes': {},
@@ -121,7 +187,7 @@ class TomcatTestCase(TestCase):
 
     def test_undeployed(self):
         '''
-            Test to enforce that the WAR will be un-deployed from the server
+        Test to enforce that the WAR will be un-deployed from the server
         '''
         ret = {'name': 'salt',
                'changes': {},
@@ -158,4 +224,5 @@ class TomcatTestCase(TestCase):
 
 if __name__ == '__main__':
     from integration import run_tests
+
     run_tests(TomcatTestCase, needs_daemon=False)

--- a/tests/unit/states/tomcat_test.py
+++ b/tests/unit/states/tomcat_test.py
@@ -109,9 +109,9 @@ class TomcatTestCase(TestCase):
         mock_deploy = MagicMock(return_value='deploy')
         mock_undeploy = MagicMock(return_value='SUCCESS')
         mock_ls_version = MagicMock(return_value={'salt': {'version': '1.2.4',
-                                                       'mode': 'running'}})
+                                                           'mode': 'running'}})
         mock_ls_no_version = MagicMock(return_value={'salt': {'version': '',
-                                                        'mode': 'running'}})
+                                                              'mode': 'running'}})
 
         # We're just checking what it *would* do.
         with patch.dict(tomcat.__opts__, {"test": True}):
@@ -202,7 +202,7 @@ class TomcatTestCase(TestCase):
         with patch.dict(tomcat.__salt__, {"tomcat.status": mock,
                                           "tomcat.ls": mock1,
                                           "tomcat.undeploy": mock2}):
-            ret.update({'comment': 'Tomcat Manager does not response'})
+            ret.update({'comment': 'Tomcat Manager does not respond'})
             self.assertDictEqual(tomcat.undeployed('salt'), ret)
 
             ret.update({'comment': '', 'result': True})


### PR DESCRIPTION
### What does this PR do?

This pull request aims to solve and allow for deployed applications to context paths _without_ having a blank version number, and allows you to disable extracting the version out of the filename.
### What issues does this PR fix or reference?

Per the commit it aims to fix #24990.
### Previous Behavior

The main issue previously were that deploying a file named `jenkins.war` would result in a deployment with a _empty_ version, and as such it would be deployed to `jenkins##`. The same behaviour would be present if you deployed `jenkins-1.2.4.war` and you manually specified `version: ''` for in the state `tomcat.war_deployed`.
### New Behavior

The main _backwards affecting_ change is that now WARs without a version in them--or specified--will have a correct file path and be without a version string in Tomcat's eyes. For instance, in this case deploying `jenkins.war` will be deployed to `jenkins` inside the Tomcat webapps folder (e.g. `/usr/lib/tomcat/webapps/` on CentOS 7 at least).

However, this means that if you have `jenkins.war` deployed to `jenkins##` at the moment, **this change will redeploy `jenkins.war` from `jenkins##` to `jenkins`**.

Furthermore, if you're deploying a file like `jenkins-1.2.4.war`, you can now disable extracting the version from the filename by specifying `version: False`. (You _must_ use `version: False`, as the `version` parameter is an empty string by default.)

My question would be, could this be **released in a bugfix update or is it too backwards incompatible?** I'm slightly torn: on one hand it never should've deployed to `blah##` in the first place, and WAR-files usually don't much to configuration in them you do manually (and you'd think that'd be controlled with states anyway), _but_ it could cause someone to go "huh". Thoughts?
### Tests written?

Yes, the current tests were slightly updated and some new ones to deal specifically with _no version_ to _version_ and _version_ to _no version_, as well as _no version_ to _blank version_ and such.

From the commit:

> Ensure that lack of version does not result in blank version being used,
> as to avoid certain Java EE applications from having issues with paths
> when parallell execution is not "supported".
> 
> This fixes saltstack/salt#24990 by both not adding a blank version if there is no
> version to exract, but also by allowing you to overwrite that there
> should be _no_ version whether or not your WAR-file ends with `-1.2.3`.
> 
> Tests added for specifically dealing with no-to-version scenarios,
> as well as several minor documentation tweaks that hopefully aren't too
> interruptive!