### PR TITLE
Fix integration tests for timezone on Windows

### DIFF
--- a/tests/integration/modules/timezone.py
+++ b/tests/integration/modules/timezone.py
@@ -48,6 +48,24 @@ class TimezoneSolarisModuleTest(integration.ModuleCase):
         self.assertIn(ret, timescale)
 
 
+class TimezoneWindowsModuleTest(integration.ModuleCase):
+    def setUp(self):
+        '''
+        Set up Solaris test environment
+        '''
+        ret_grain = self.run_function('grains.item', ['os_family'])
+        if 'Windows' not in ret_grain['os_family']:
+            self.skipTest('For Windows only')
+        super(TimezoneSolarisModuleTest, self).setUp()
+
+    def test_get_hwclock(self):
+        timescale = ['UTC', 'localtime']
+        ret = self.run_function('timezone.get_hwclock')
+        self.assertIn(ret, timescale)
+
+
 if __name__ == '__main__':
     from integration import run_tests
-    run_tests([TimezoneLinuxModuleTest, TimezoneSolarisModuleTest])
+    run_tests([TimezoneLinuxModuleTest,
+               TimezoneSolarisModuleTest,
+               TimezoneWindowsModuleTest])

--- a/tests/integration/modules/timezone.py
+++ b/tests/integration/modules/timezone.py
@@ -56,7 +56,7 @@ class TimezoneWindowsModuleTest(integration.ModuleCase):
         ret_grain = self.run_function('grains.item', ['os_family'])
         if 'Windows' not in ret_grain['os_family']:
             self.skipTest('For Windows only')
-        super(TimezoneSolarisModuleTest, self).setUp()
+        super(TimezoneWindowsModuleTest, self).setUp()
 
     def test_get_hwclock(self):
         timescale = ['UTC', 'localtime']


### PR DESCRIPTION
### What does this PR do?

Adds integration tests for timezone on Windows

https://github.com/saltstack/zh/issues/853
