### PR TITLE
Prevent backtrace in `salt.states.network`

### DIFF
--- a/salt/states/network.py
+++ b/salt/states/network.py
@@ -536,6 +536,10 @@ def system(name, **kwargs):
         ret['result'] = False
         ret['comment'] = str(error)
         return ret
+    except KeyError as error:
+        ret['result'] = False
+        ret['comment'] = str(error)
+        return ret
 
     # Apply global network settings
     if apply_net_settings:


### PR DESCRIPTION
Prevents this backtrace:

```
  File "/usr/lib64/python2.7/site-packages/salt/state.py", line 1723, in call
    **cdata['kwargs'])
  File "/usr/lib64/python2.7/site-packages/salt/loader.py", line 1650, in wrapper
    return f(*args, **kwargs)
  File "/usr/lib64/python2.7/site-packages/salt/states/network.py", line 513, in system
    old = __salt__['ip.get_network_settings']()
  File "/usr/lib64/python2.7/site-packages/salt/loader.py", line 1053, in __getitem__
    func = super(LazyLoader, self).__getitem__(item)
  File "/usr/lib64/python2.7/site-packages/salt/utils/lazy.py", line 93, in __getitem__
    raise KeyError(key)
KeyError: 'ip.get_network_settings'
```