### PR TITLE
Fire events for orchestration jobs containing the passed arguments

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -463,12 +463,12 @@ class AsyncClientMixin(object):
         tag = salt.utils.event.tagify(jid, prefix=self.tag_prefix)
         return {'tag': tag, 'jid': jid}
 
-    def async(self, fun, low, user='UNKNOWN'):
+    def async(self, fun, low, user='UNKNOWN', pub=None):
         '''
         Execute the function in a multiprocess and return the event tag to use
         to watch for the return
         '''
-        async_pub = self._gen_async_pub()
+        async_pub = pub if pub is not None else self._gen_async_pub()
 
         proc = salt.utils.process.SignalHandlingMultiprocessingProcess(
                 target=self._proc_function,

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -1121,7 +1121,7 @@ def cmd_iter(tgt,
         yield ret
 
 
-def runner(_fun, **kwargs):
+def runner(name, **kwargs):
     '''
     Execute a runner function. This function must be run on the master,
     either by targeting a minion running on a master or by using
@@ -1129,7 +1129,7 @@ def runner(_fun, **kwargs):
 
     .. versionadded:: 2014.7.0
 
-    _fun
+    name
         The name of the function to run
 
     kwargs
@@ -1144,6 +1144,8 @@ def runner(_fun, **kwargs):
 
         salt master_minion saltutil.runner jobs.list_jobs
     '''
+    jid = kwargs.pop('__orchestration_jid__', None)
+    saltenv = kwargs.pop('__env__', 'base')
     kwargs = salt.utils.clean_kwargs(**kwargs)
 
     if 'master_job_cache' not in __opts__:
@@ -1154,10 +1156,23 @@ def runner(_fun, **kwargs):
     else:
         rclient = salt.runner.RunnerClient(__opts__)
 
-    return rclient.cmd(_fun, kwarg=kwargs, full_return=True)
+    if name in rclient.functions:
+        aspec = salt.utils.args.get_function_argspec(rclient.functions[name])
+        if 'saltenv' in aspec.args:
+            kwargs['saltenv'] = saltenv
+
+    if jid:
+        salt.utils.event.fire_args(
+            __opts__,
+            jid,
+            {'type': 'runner', 'name': name, 'args': kwargs},
+            prefix='run'
+        )
+
+    return rclient.cmd(name, kwarg=kwargs, full_return=True)
 
 
-def wheel(_fun, *args, **kwargs):
+def wheel(name, *args, **kwargs):
     '''
     Execute a wheel module and function. This function must be run against a
     minion that is local to the master.
@@ -1192,6 +1207,9 @@ def wheel(_fun, *args, **kwargs):
         their return data.
 
     '''
+    jid = kwargs.pop('__orchestration_jid__', None)
+    saltenv = kwargs.pop('__env__', 'base')
+
     if __opts__['__role'] == 'minion':
         master_config = os.path.join(os.path.dirname(__opts__['conf_file']),
                                      'master')
@@ -1211,14 +1229,31 @@ def wheel(_fun, *args, **kwargs):
             valid_kwargs[key] = val
 
     try:
-        ret = wheel_client.cmd(_fun,
+        if name in wheel_client.functions:
+            aspec = salt.utils.args.get_function_argspec(
+                wheel_client.functions[name]
+            )
+            if 'saltenv' in aspec.args:
+                valid_kwargs['saltenv'] = saltenv
+
+        if jid:
+            salt.utils.event.fire_args(
+                __opts__,
+                jid,
+                {'type': 'wheel', 'name': name, 'args': valid_kwargs},
+                prefix='run'
+            )
+
+        ret = wheel_client.cmd(name,
                                arg=args,
                                pub_data=pub_data,
                                kwarg=valid_kwargs,
                                full_return=True)
     except SaltInvocationError:
-        raise CommandExecutionError('This command can only be executed on a minion '
-                                    'that is located on the master.')
+        raise CommandExecutionError(
+            'This command can only be executed on a minion that is located on '
+            'the master.'
+        )
 
     return ret
 

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -45,6 +45,7 @@ import salt.runner
 import salt.state
 import salt.transport
 import salt.utils
+import salt.utils.args
 import salt.utils.event
 import salt.utils.extmods
 import salt.utils.minion

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -765,14 +765,15 @@ def highstate(test=None,
 
     st_.push_active()
     ret = {}
+    orchestration_jid = kwargs.get('orchestration_jid')
     try:
         ret = st_.call_highstate(
                 exclude=kwargs.get('exclude', []),
                 cache=kwargs.get('cache', None),
                 cache_name=kwargs.get('cache_name', 'highstate'),
                 force=kwargs.get('force', False),
-                whitelist=kwargs.get('whitelist')
-                )
+                whitelist=kwargs.get('whitelist'),
+                orchestration_jid=orchestration_jid)
     finally:
         st_.pop_active()
 
@@ -966,12 +967,13 @@ def sls(mods,
                                    pillar_enc=pillar_enc,
                                    mocked=kwargs.get('mock', False))
 
+    orchestration_jid = kwargs.get('orchestration_jid')
     umask = os.umask(0o77)
     if kwargs.get('cache'):
         if os.path.isfile(cfn):
             with salt.utils.fopen(cfn, 'rb') as fp_:
                 high_ = serial.load(fp_)
-                return st_.state.call_high(high_)
+                return st_.state.call_high(high_, orchestration_jid)
     os.umask(umask)
 
     if isinstance(mods, six.string_types):
@@ -993,7 +995,7 @@ def sls(mods,
                 high_['__exclude__'].extend(exclude)
             else:
                 high_['__exclude__'] = exclude
-        ret = st_.state.call_high(high_)
+        ret = st_.state.call_high(high_, orchestration_jid)
     finally:
         st_.pop_active()
     if __salt__['config.option']('state_data', '') == 'terse' or kwargs.get('terse'):
@@ -1072,14 +1074,15 @@ def top(topfn,
     st_.push_active()
     st_.opts['state_top'] = salt.utils.url.create(topfn)
     ret = {}
+    orchestration_jid = kwargs.get('orchestration_jid')
     if saltenv:
         st_.opts['state_top_saltenv'] = saltenv
     try:
         ret = st_.call_highstate(
                 exclude=kwargs.get('exclude', []),
                 cache=kwargs.get('cache', None),
-                cache_name=kwargs.get('cache_name', 'highstate')
-                )
+                cache_name=kwargs.get('cache_name', 'highstate'),
+                orchestration_jid=orchestration_jid)
     finally:
         st_.pop_active()
 

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -182,9 +182,17 @@ class Runner(RunnerClient):
 
                 user = salt.utils.get_specific_user()
 
+                # Allocate a jid
+                async_pub = self._gen_async_pub()
+                if low['fun'] == 'state.orchestrate':
+                    low['kwarg']['__pub_orchestration_jid'] = async_pub['jid']
+
                 # Run the runner!
                 if self.opts.get('async', False):
-                    async_pub = self.async(self.opts['fun'], low, user=user)
+                    async_pub = self.async(self.opts['fun'],
+                                           low,
+                                           user=user,
+                                           pub=async_pub)
                     # by default: info will be not enougth to be printed out !
                     log.warning('Running in async mode. Results of this execution may '
                              'be collected by attaching to the master event bus or '
@@ -192,8 +200,6 @@ class Runner(RunnerClient):
                              'This execution is running under tag {tag}'.format(**async_pub))
                     return async_pub['jid']  # return the jid
 
-                # otherwise run it in the main process
-                async_pub = self._gen_async_pub()
                 ret = self._proc_function(self.opts['fun'],
                                           low,
                                           user,

--- a/salt/runners/state.py
+++ b/salt/runners/state.py
@@ -20,7 +20,8 @@ def orchestrate(mods,
                 test=None,
                 exclude=None,
                 pillar=None,
-                pillarenv=None):
+                pillarenv=None,
+                **kwargs):
     '''
     .. versionadded:: 0.17.0
 
@@ -60,7 +61,8 @@ def orchestrate(mods,
             test,
             exclude,
             pillar=pillar,
-            pillarenv=pillarenv)
+            pillarenv=pillarenv,
+            orchestration_jid=kwargs.get('__pub_orchestration_jid'))
     ret = {'data': {minion.opts['id']: running}, 'outputter': 'highstate'}
     res = salt.utils.check_state_result(ret['data'])
     if res:

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -48,6 +48,18 @@ def __virtual__():
     return __virtualname__
 
 
+def _fire_args(tag_data):
+    try:
+        salt.utils.event.fire_args(__opts__,
+                                   __orchestration_jid__,
+                                   tag_data,
+                                   'run')
+    except NameError:
+        log.debug(
+            'Unable to fire args event due to missing __orchestration_jid__'
+        )
+
+
 def state(
         name,
         tgt,
@@ -67,7 +79,8 @@ def state(
         concurrent=False,
         timeout=None,
         batch=None,
-        queue=False):
+        queue=False,
+        orchestration_jid=None):
     '''
     Invoke a state run on a given target
 
@@ -233,6 +246,7 @@ def state(
     masterless = __opts__['__role'] == 'minion' and \
                  __opts__['file_client'] == 'local'
     if not masterless:
+        _fire_args({'type': 'state', 'tgt': tgt, 'name': name, 'args': cmd_kw})
         cmd_ret = __salt__['saltutil.cmd'](tgt, fun, **cmd_kw)
     else:
         if top:
@@ -421,6 +435,7 @@ def function(
         func_ret['result'] = None
         return func_ret
     try:
+        _fire_args({'type': 'function', 'tgt': tgt, 'name': name, 'args': cmd_kw})
         cmd_ret = __salt__['saltutil.cmd'](tgt, fun, **cmd_kw)
     except Exception as exc:
         func_ret['result'] = False
@@ -618,7 +633,17 @@ def runner(name, **kwargs):
             - name: manage.up
     '''
     ret = {'name': name, 'result': False, 'changes': {}, 'comment': ''}
-    out = __salt__['saltutil.runner'](name, **kwargs)
+    try:
+        jid = __orchestration_jid__
+    except NameError:
+        log.debug(
+            'Unable to fire args event due to missing __orchestration_jid__'
+        )
+        jid = None
+    out = __salt__['saltutil.runner'](name,
+                                      __orchestration_jid__=jid,
+                                      __env__=__env__,
+                                      **kwargs)
 
     ret['result'] = True
     ret['comment'] = "Runner function '{0}' executed.".format(name)
@@ -652,7 +677,17 @@ def wheel(name, **kwargs):
             - match: frank
     '''
     ret = {'name': name, 'result': False, 'changes': {}, 'comment': ''}
-    out = __salt__['saltutil.wheel'](name, **kwargs)
+    try:
+        jid = __orchestration_jid__
+    except NameError:
+        log.debug(
+            'Unable to fire args event due to missing __orchestration_jid__'
+        )
+        jid = None
+    out = __salt__['saltutil.wheel'](name,
+                                     __orchestration_jid__=jid,
+                                     __env__=__env__,
+                                     **kwargs)
 
     ret['result'] = True
     ret['comment'] = "Wheel function '{0}' executed.".format(name)

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -148,6 +148,27 @@ def get_master_event(opts, sock_dir, listen=True, io_loop=None):
         )
 
 
+def fire_args(opts, jid, tag_data, prefix=''):
+    '''
+    Fire an event containing the arguments passed to an orchestration job
+    '''
+    try:
+        tag_suffix = [jid, 'args']
+    except NameError:
+        pass
+    else:
+        try:
+            _event = get_master_event(opts, opts['sock_dir'], listen=False)
+            tag = tagify(tag_suffix, prefix)
+            _event.fire_event(tag_data, tag=tag)
+        except Exception as exc:
+            # Don't let a problem here hold up the rest of the orchestration
+            log.warning(
+                'Failed to fire args event %s with data %s: %s',
+                tag, tag_data, exc
+            )
+
+
 def tagify(suffix='', prefix='', base=SALT):
     '''
     convenience function to build a namespaced event tag string

--- a/tests/unit/modules/state_test.py
+++ b/tests/unit/modules/state_test.py
@@ -67,7 +67,7 @@ class MockState(object):
             return list
 
         @staticmethod
-        def call_high(data):
+        def call_high(data, orchestration_jid=None):
             '''
                 Mock call_high method
             '''
@@ -216,7 +216,7 @@ class MockState(object):
 
         @staticmethod
         def call_highstate(exclude, cache, cache_name, force=None,
-                           whitelist=None):
+                           whitelist=None, orchestration_jid=None):
             '''
                 Mock call_highstate method
             '''


### PR DESCRIPTION
This pull request fires additional events for orchestration jobs, containing the arguments passed to the master. These events are not written to the job cache, but exist to enable code which integrates with Salt orchestration to gather additional information orchestration jobs.

Examples of these events for state, function, runner, and wheel jobs can be found below:

```
Tag: salt/run/20160728234601815588/args
Data:
{'_stamp': '2016-07-29T04:46:02.193249',
 'args': {'arg': ['vim'],
          'expect_minions': False,
          'expr_form': 'glob',
          'kwarg': {'concurrent': False, 'queue': False, 'saltenv': 'base'},
          'ret': '',
          'ssh': False,
          'timeout': None},
 'name': 'test_orchestration',
 'tgt': '*',
 'type': 'state'}
Event fired at Thu Jul 28 23:46:02 2016
*************************
Tag: salt/run/20160728234601815588/args
Data:
{'_stamp': '2016-07-29T04:46:17.483529',
 'args': {'_cmd_meta': True,
          'arg': [],
          'expect_minions': False,
          'expr_form': 'glob',
          'kwarg': {},
          'ret': '',
          'ssh': False,
          'timeout': None},
 'name': 'test.ping',
 'tgt': '*',
 'type': 'function'}
Event fired at Thu Jul 28 23:46:17 2016
*************************
Tag: salt/run/20160728234601815588/args
Data:
{'_stamp': '2016-07-29T04:46:32.848279',
 'args': {'saltenv': 'dev'},
 'name': 'fileserver.file_list',
 'type': 'runner'}
Event fired at Thu Jul 28 23:46:32 2016
*************************
Tag: salt/run/20160728234601815588/args
Data:
{'_stamp': '2016-07-29T04:46:33.003725',
 'args': {},
 'name': 'config.values',
 'type': 'wheel'}
Event fired at Thu Jul 28 23:46:33 2016
```

Additionally, this pull request fixes a bug in Salt's orchestration which affects runner/wheel functions which accept an argument named `saltenv` (for example, `fileserver.file_list`). This argument was being stripped by `salt.utils.format_call()`, as we use this CLI argument in state/function calls to set the `__env__` value for the Salt run. This does not apply to runner/wheel functions, however.