### PR TITLE
Only fail user lookup is the user parameter is required

### DIFF
--- a/salt/modules/win_dacl.py
+++ b/salt/modules/win_dacl.py
@@ -347,8 +347,7 @@ def get(path, objectType, user=None):
            'ACLs': []}
 
     sidRet = _getUserSid(user)
-    if not sidRet['result']:
-        return sidRet
+
     if path and objectType:
         dc = daclConstants()
         objectTypeBit = dc.getObjectTypeBit(objectType)
@@ -645,8 +644,6 @@ def check_inheritance(path, objectType, user=None):
            'comment': ''}
 
     sidRet = _getUserSid(user)
-    if not sidRet['result']:
-        return sidRet
 
     dc = daclConstants()
     objectType = dc.getObjectTypeBit(objectType)
@@ -665,7 +662,8 @@ def check_inheritance(path, objectType, user=None):
         if (ace[0][1] & win32security.INHERITED_ACE) == win32security.INHERITED_ACE:
             if not sidRet['sid'] or ace[2] == sidRet['sid']:
                 ret['Inheritance'] = True
-                return ret
+                break
+
     ret['result'] = True
     return ret
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes two functions that broke win_dacl.disableinheritance and win_dacl.enableinheritance.
### Previous Behavior

win_dacl.disableinheritance and win_dacl.enableinheritance always failed, because check_inheritance() always returned false when called without the user parameter.
### New Behavior

win_dacl.disableinheritance and win_dacl.enableinheritance succeed.
### Tests written?

No
### Summary

get() and check_inheritance() have an optional user parameter.
While said parameter is optional, the functions in questions
do not treat it as such, which at the very least breaks
disable_inheritance() (used by win_dacl.disableinheritance) and
enable_inheritance (used by win_dacl.enableinheritance), as those
functions call check_inheritance() without the user parameter.