### PR TITLE
#33536 pkgrepo.managed does not disable a yum repo with "disabled: True"

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2165,7 +2165,7 @@ def mod_repo(repo, basedir=None, **kwargs):
         )
 
     # Build a list of keys to be deleted
-    todelete = []
+    todelete = ['disabled']
     for key in repo_opts:
         if repo_opts[key] != 0 and not repo_opts[key]:
             del repo_opts[key]
@@ -2174,6 +2174,8 @@ def mod_repo(repo, basedir=None, **kwargs):
     # convert disabled to enabled respectively from pkgrepo state
     if 'enabled' not in repo_opts:
         repo_opts['enabled'] = int(str(repo_opts.pop('disabled', False)).lower() != 'true')
+    else:
+        repo_opts.pop('disabled', False)
 
     # Add baseurl or mirrorlist to the 'todelete' list if the other was
     # specified in the repo_opts
@@ -2302,6 +2304,7 @@ def _parse_repo_file(filename):
                         'Failed to parse line in %s, offending line was '
                         '\'%s\'', filename, line.rstrip()
                     )
+                # YUM uses enabled field - create the disabled field so that comparisons works correctly in state
                 if comps[0].strip() == 'enabled':
                     repos[repo]['disabled'] = comps[1] != "1"
 

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -281,6 +281,13 @@ def managed(name, ppa=None, **kwargs):
                           'intended.')
         return ret
 
+    if 'enabled' in kwargs:
+        salt.utils.warn_until(
+            'Carbon',
+            'The `enabled` argument has been deprecated in favor of '
+            '`disabled`.'
+        )
+
     repo = name
     if __grains__['os'] in ('Ubuntu', 'Mint'):
         if ppa is not None:
@@ -308,13 +315,9 @@ def managed(name, ppa=None, **kwargs):
             # Fall back to the repo name if humanname not provided
             kwargs['name'] = repo
 
-    if kwargs.pop('enabled', None):
-        kwargs['disabled'] = False
-        salt.utils.warn_until(
-            'Carbon',
-            'The `enabled` argument has been deprecated in favor of '
-            '`disabled`.'
-        )
+    # Replace 'enabled' from kwargs with 'disabled'
+    enabled = kwargs.pop('enabled', True)
+    kwargs['disabled'] = not salt.utils.is_true(enabled)
 
     for kwarg in _STATE_INTERNAL_KEYWORDS:
         kwargs.pop(kwarg, None)


### PR DESCRIPTION
### What does this PR do?
- This fixes the pkgrepo state and yumpkg module for EL systems. The state was not working with enabled neither with disabled fields.
- Fixes the situation when the "disabled" was saved into the repo file. Internally works with "disabled" but saves "enabled".
- Fixes the warning message about _enabled_ being deprecated.
### What issues does this PR fix or reference?
saltstack/salt#33536
### Tests written?

No