### PR TITLE
Add `fun_args` field to events generated by execution of Master modules

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -256,10 +256,14 @@ class SyncClientMixin(object):
         jid = low.get('__jid__', salt.utils.jid.gen_jid())
         tag = low.get('__tag__', tagify(jid, prefix=self.tag_prefix))
 
+        # This avoids including kwargs dict as args list in low data.
+        # We only need to update event data.
+        fun_args = low.get('args', [])
         data = {'fun': '{0}.{1}'.format(self.client, fun),
+                'fun_args': fun_args + ([low['kwargs']] if low.get('kwargs', False) else []),
                 'jid': jid,
                 'user': low.get('__user__', 'UNKNOWN'),
-                }
+               }
 
         event = salt.utils.event.get_event(
                 'master',


### PR DESCRIPTION
### What does this PR do?

It allows to see function arguments for Master-side modules (such as `runners` and `wheels`) in the event bus flow. The `fun_args` event attribute contains a list of positional and keyword arguments in exactly the same way as it appears for Minion execution modules.
### Previous Behavior

Only Minion jobs events have `fun_args` filed, for example:

``` json
salt/job/20160729124148005586/ret/salt  {
    "_stamp": "2016-07-29T12:41:48.186326", 
    "cmd": "_return", 
    "fun": "saltutil.sync_all", 
    "fun_args": [
        {
            "refresh": false
        }
    ], 
    "id": "salt", 
    "jid": "20160729124148005586", 
    "retcode": 0, 
    "return": {
        "beacons": [], 
        "engines": [], 
        "grains": [], 
        "log_handlers": [], 
        "modules": [], 
        "output": [], 
        "proxymodules": [], 
        "renderers": [], 
        "returners": [], 
        "sdb": [], 
        "states": [], 
        "utils": []
    }, 
    "success": true
```

But not Master jobs:

``` json
salt/run/20160729124402702295/new   {
    "_stamp": "2016-07-29T12:44:04.928547", 
    "fun": "runner.state.event", 
    "jid": "20160729124402702295", 
    "user": "root"
}
```
### New Behavior

For the sake of consistency, events generated by modules executed on Master are also have arguments list, e.g:

``` json
salt/run/20160729134632623337/new   {
    "_stamp": "2016-07-29T13:46:34.831869", 
    "fun": "runner.state.event", 
    "fun_args": [
        "*", 
        {
            "pretty": true
        }
    ], 
    "jid": "20160729134632623337", 
    "user": "root"
```

``` json
salt/run/20160729152134990954/ret   {
    "_stamp": "2016-07-29T15:21:37.366272", 
    "fun": "runner.saltutil.sync_all", 
    "fun_args": [], 
    "jid": "20160729152134990954", 
    "return": {
        "engines": [], 
        "grains": [], 
        "modules": [], 
        "output": [], 
        "pillar": [], 
        "proxymodules": [], 
        "queues": [], 
        "renderers": [], 
        "returners": [], 
        "runners": [], 
        "states": [], 
        "wheel": []
    }, 
    "success": true, 
    "user": "root"
}
```
### Tests written?

No