### PR TITLE
Cache systemd unit update check per unit, closes #34927

### DIFF
--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -76,7 +76,7 @@ def _check_for_unit_changes(name):
     Check for modified/updated unit files, and run a daemon-reload if any are
     found.
     '''
-    contextkey = 'systemd._check_for_unit_changes'
+    contextkey = 'systemd._check_for_unit_changes.{0}'.format(name)
     if contextkey not in __context__:
         if _untracked_custom_unit_found(name) or _unit_file_changed(name):
             systemctl_reload()


### PR DESCRIPTION
This is a cherry-pick to ensure this one-line fix makes it in before we tag 2016.3.2, which will likely happen before the next merge-forward.
