### PR TITLE
reg: Change access mask to read by default

### DIFF
--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -165,8 +165,8 @@ class Registry(object):  # pylint: disable=R0903
         }
 
         self.registry_32 = {
-            True: _winreg.KEY_ALL_ACCESS | _winreg.KEY_WOW64_32KEY,
-            False: _winreg.KEY_ALL_ACCESS,
+            True: _winreg.KEY_READ | _winreg.KEY_WOW64_32KEY,
+            False: _winreg.KEY_READ,
             }
 
     def __getattr__(self, k):
@@ -613,7 +613,7 @@ def set_value(hive,
     registry = Registry()
     hkey = registry.hkeys[local_hive]
     vtype_value = registry.vtype[local_vtype]
-    access_mask = registry.registry_32[use_32bit_registry]
+    access_mask = registry.registry_32[use_32bit_registry] | _winreg.KEY_ALL_ACCESS
     if volatile:
         create_options = registry.opttype['REG_OPTION_VOLATILE']
     else:
@@ -674,7 +674,7 @@ def delete_key_recursive(hive, key, use_32bit_registry=False):
     registry = Registry()
     hkey = registry.hkeys[local_hive]
     key_path = local_key
-    access_mask = registry.registry_32[use_32bit_registry]
+    access_mask = registry.registry_32[use_32bit_registry] | _winreg.KEY_ALL_ACCESS
 
     if not _key_exists(local_hive, local_key, use_32bit_registry):
         return False
@@ -771,7 +771,7 @@ def delete_value(hive, key, vname=None, use_32bit_registry=False):
 
     registry = Registry()
     hkey = registry.hkeys[local_hive]
-    access_mask = registry.registry_32[use_32bit_registry]
+    access_mask = registry.registry_32[use_32bit_registry] | _winreg.KEY_ALL_ACCESS
 
     try:
         handle = _winreg.OpenKey(hkey, local_key, 0, access_mask)


### PR DESCRIPTION
### What does this PR do?

This changes KEY_ALL_ACCESS to KEY_READ in Registry class. At least one registry key cannot be read with 'reg.read_value' because of READONLY permissions on the key (SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing). set_value, delete_\* request ALL_ACCESS when they need to set/delete.
### Previous Behavior

Before patch:

```
# salt 'w12-*' reg.read_value HKLM 'SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending'
w12-cl1.salt.local:
    ----------
    comment:
        Cannot find key: HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending
    hive:
        HKLM
    key:
        SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending
    success:
        False
    vdata:
        None
    vname:
        (Default)
```
### New Behavior

After patch:

```
# salt 'w12-*' reg.read_value HKLM 'SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending'
w12-cl1.salt.local:
    ----------
    hive:
        HKLM
    key:
        SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending
    success:
        True
    vdata:
        (value not set)
    vname:
        (Default)
    vtype:
        REG_SZ
```
### Tests written?

No