### PR TITLE
Detect nodegroup lists with no compound syntax as L@host1,host2,host3...

### DIFF
--- a/doc/topics/releases/carbon.rst
+++ b/doc/topics/releases/carbon.rst
@@ -133,20 +133,38 @@ for more information.
 Functionality Changes
 =====================
 
-- The ``onfail`` requisite now uses OR logic instead of AND logic. :issue:`22370`
-- The consul external pillar now strips leading and trailing whitespace. :issue:`31165`
+- The ``onfail`` requisite now uses OR logic instead of AND logic.
+  :issue:`22370`
+- The consul external pillar now strips leading and trailing whitespace.
+  :issue:`31165`
 - The win_system.py state is now case sensitive for computer names. Previously
   computer names set with a state were converted to all caps. If you have a
   state setting computer names with lower case letters in the name that has
   been applied, the computer name will be changed again to apply the case
   sensitive name.
-- The ``mac_user.list_groups`` function in the ``mac_user`` execution module now
-  lists all groups for the specified user, including groups beginning with an
-  underscore. In previous releases, groups beginning with an underscore were
+- The ``mac_user.list_groups`` function in the ``mac_user`` execution module
+  now lists all groups for the specified user, including groups beginning with
+  an underscore. In previous releases, groups beginning with an underscore were
   excluded from the list of groups.
-- A new option for minions called ``master_tries`` has been added. This specifies
-  the number of times a minion should attempt to contact a master to attempt a connection.
-  This allows better handling of occasional master downtime in a multi-master topology.
+- A new option for minions called ``master_tries`` has been added. This
+  specifies the number of times a minion should attempt to contact a master to
+  attempt a connection.  This allows better handling of occasional master
+  downtime in a multi-master topology.
+- Nodegroups consisting of a simple list of minion IDs can now also be declared
+  as a yaml list. The below two examples are equivalent:
+
+  .. code-block:: yaml
+
+      # Traditional way
+      nodegroups:
+        - group1: L@host1,host2,host3
+
+      # New way (optional)
+      nodegroups:
+        - group1:
+          - host1
+          - host2
+          - host3
 
 Deprecations
 ============

--- a/doc/topics/targeting/nodegroups.rst
+++ b/doc/topics/targeting/nodegroups.rst
@@ -68,32 +68,54 @@ nodegroup`` on the line directly following the nodegroup name.
 
 .. note::
 
-    When adding or modifying nodegroups to a master configuration file, the master must be restarted
-    for those changes to be fully recognized.
+    When adding or modifying nodegroups to a master configuration file, the
+    master must be restarted for those changes to be fully recognized.
 
-    A limited amount of functionality, such as targeting with -N from the command-line may be
-    available without a restart.
+    A limited amount of functionality, such as targeting with -N from the
+    command-line may be available without a restart.
+
+Defining Nodegroups as Lists of Minion IDs
+==========================================
+
+A simple list of minion IDs would traditionally be defined like this:
+
+.. code-block:: yaml
+
+    nodegroups:
+      - group1: L@host1,host2,host3
+
+They can now also be defined as a YAML list, like this:
+
+.. code-block:: yaml
+
+    nodegroups:
+      - group1:
+        - host1
+        - host2
+        - host3
+
+.. versionadded:: Carbon
 
 Using Nodegroups in SLS files
 =============================
 
-To use Nodegroups in Jinja logic for SLS files, the :conf_master:`pillar_opts` option in
-``/etc/salt/master`` must be set to "True". This will pass the master's configuration as
-Pillar data to each minion.
+To use Nodegroups in Jinja logic for SLS files, the :conf_master:`pillar_opts`
+option in ``/etc/salt/master`` must be set to ``True``. This will pass the
+master's configuration as Pillar data to each minion.
 
 .. note::
 
-    If the master's configuration contains any sensitive data, this will be passed to each minion.
-    Do not enable this option if you have any configuration data that you do not want to get
-    on your minions.
+    If the master's configuration contains any sensitive data, this will be
+    passed to each minion.  Do not enable this option if you have any
+    configuration data that you do not want to get on your minions.
 
     Also, if you make changes to your nodegroups, you might need to run
     ``salt '*' saltutil.refresh_pillar`` after restarting the master.
 
-Once pillar_opts is enabled, you can find the nodegroups under the "master" pillar.
-To make sure that only the correct minions are targeted,
-you should use each matcher for the nodegroup definition.
-For example, to check if a minion is in the 'webserver' nodegroup:
+Once :conf_master:`pillar_opts` is set to ``True``, you can find the nodegroups
+under the "master" pillar.  To make sure that only the correct minions are
+targeted, you should use each matcher for the nodegroup definition.  For
+example, to check if a minion is in the 'webserver' nodegroup:
 
 .. code-block:: yaml
 

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -127,16 +127,16 @@ def nodegroup_comp(nodegroup, nodegroups, skip=None, first_call=True):
     elif isinstance(nglookup, (list, tuple)):
         words = nglookup
     else:
-        log.error(
-            'Nodgroup is neither a string, list'
-            ' nor tuple: {0} = {1}'.format(nodegroup, nglookup)
-        )
+        log.error('Nodegroup \'%s\' (%s) is neither a string, list nor tuple',
+                  nodegroup, nglookup)
         return ''
 
     skip.add(nodegroup)
     ret = []
     opers = ['and', 'or', 'not', '(', ')']
     for word in words:
+        if not isinstance(word, six.string_types):
+            word = str(word)
         if word in opers:
             ret.append(word)
         elif len(word) >= 3 and word.startswith('N@'):
@@ -157,10 +157,30 @@ def nodegroup_comp(nodegroup, nodegroups, skip=None, first_call=True):
     if expanded_nodegroup or not first_call:
         return ret
     else:
-        log.debug('No nested nodegroups detected. '
-                  'Using original nodegroup definition: {0}'
-                  .format(nodegroups[nodegroup]))
-        return nodegroups[nodegroup]
+        opers_set = set(opers)
+        ret = words
+        if (set(ret) - opers_set) == set(ret):
+            # No compound operators found in nodegroup definition. Check for
+            # group type specifiers
+            group_type_re = re.compile('^[A-Z]@')
+            if not [x for x in ret if '*' in x or group_type_re.match(x)]:
+                # No group type specifiers and no wildcards. Treat this as a
+                # list of nodenames.
+                joined = 'L@' + ','.join(ret)
+                log.debug(
+                    'Nodegroup \'%s\' (%s) detected as list of nodenames. '
+                    'Assuming compound matching syntax of \'%s\'',
+                    nodegroup, ret, joined
+                )
+                # Return data must be a list of compound matching components
+                # to be fed into compound matcher. Enclose return data in list.
+                return [joined]
+
+        log.debug(
+            'No nested nodegroups detected. Using original nodegroup '
+            'definition: %s', nodegroups[nodegroup]
+        )
+        return ret
 
 
 class CkMinions(object):

--- a/tests/unit/utils/minions_test.py
+++ b/tests/unit/utils/minions_test.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+# Import python libs
+from __future__ import absolute_import
+
+# Import Salt Libs
+from salt.utils import minions
+
+# Import Salt Testing Libs
+from salttesting import TestCase
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+NODEGROUPS = {
+    'group1': 'L@host1,host2,host3',
+    'group2': ['G@foo:bar', 'or', 'web1*'],
+    'group3': ['N@group1', 'or', 'N@group2'],
+    'group4': ['host4', 'host5', 'host6'],
+}
+
+EXPECTED = {
+    'group1': ['L@host1,host2,host3'],
+    'group2': ['G@foo:bar', 'or', 'web1*'],
+    'group3': ['(', '(', 'L@host1,host2,host3', ')', 'or', '(', 'G@foo:bar', 'or', 'web1*', ')', ')'],
+    'group4': ['L@host4,host5,host6'],
+}
+
+
+class MinionsTestCase(TestCase):
+    '''
+    TestCase for salt.utils.minions module functions
+    '''
+    def test_nodegroup_comp(self):
+        '''
+        Test a simple string nodegroup
+        '''
+        for nodegroup in NODEGROUPS:
+            expected = EXPECTED[nodegroup]
+            ret = minions.nodegroup_comp(nodegroup, NODEGROUPS)
+            self.assertEqual(ret, expected)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(MinionsTestCase, needs_daemon=False)


### PR DESCRIPTION
Resolves #35065.

Tests included. I also realized that we didn't have tests for any of the other potential input scenarios, so I wrote tests for them too. TEST ALL THE THINGS!