### PR TITLE
Fix broken npm json formatting

### DIFF
--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -129,36 +129,30 @@ def install(pkg=None,
     '''
     # Protect against injection
     if pkg:
-        pkg = _cmd_quote(pkg)
-    if pkgs:
-        pkg_list = []
-        for item in pkgs:
-            pkg_list.append(_cmd_quote(item))
-        pkgs = pkg_list
+        pkgs = [_cmd_quote(pkg)]
+    elif pkgs:
+        pkgs = [_cmd_quote(v) for v in pkgs]
+    else:
+        pkgs = []
     if registry:
         registry = _cmd_quote(registry)
 
-    cmd = ['npm', 'install']
+    cmd = ['npm', 'install', '--json']
     if silent:
         cmd.append('--silent')
-    cmd.append('--json')
 
-    if dir is None:
-        cmd.append(' --global')
+    if not dir:
+        cmd.append('--global')
 
     if registry:
-        cmd.append(' --registry="{0}"'.format(registry))
+        cmd.append('--registry="{}"'.format(registry))
 
     if dry_run:
         cmd.append('--dry-run')
 
-    if pkg:
-        cmd.append(pkg)
-    elif pkgs:
-        cmd.extend(pkgs)
+    cmd.extend(pkgs)
 
-    if env is None:
-        env = {}
+    env = env or {}
 
     if runas:
         uid = salt.utils.get_uid(runas)
@@ -176,24 +170,26 @@ def install(pkg=None,
     try:
         return json.loads(npm_output)
     except ValueError:
-        # Not JSON! Try to coax the json out of it!
         pass
 
+    json_npm_output = _extract_json(npm_output)
+    return json_npm_output or npm_output
+
+
+def _extract_json(npm_output):
     lines = npm_output.splitlines()
     log.error(lines)
 
-    while lines:
-        # Strip all lines until JSON output starts
-        while not lines[0].startswith('{') and not lines[0].startswith('['):
-            lines = lines[1:]
-
-        try:
-            return json.loads(''.join(lines))
-        except ValueError:
-            lines = lines[1:]
-
-    # Still no JSON!! Return the stdout as a string
-    return npm_output
+    # Strip all lines until JSON output starts
+    while lines and not lines[0].startswith('{') and not lines[0].startswith('['):
+        lines = lines[1:]
+    while lines and not lines[-1].startswith('}') and not lines[-1].startswith(']'):
+        lines = lines[:-1]
+    try:
+        return json.loads(''.join(lines))
+    except ValueError:
+        pass
+    return None
 
 
 def uninstall(pkg,
@@ -233,20 +229,18 @@ def uninstall(pkg,
     if pkg:
         pkg = _cmd_quote(pkg)
 
-    if env is None:
-        env = {}
+    env = env or {}
 
     if runas:
         uid = salt.utils.get_uid(runas)
         if uid:
             env.update({'SUDO_UID': b'{0}'.format(uid), 'SUDO_USER': b''})
 
-    cmd = 'npm uninstall'
+    cmd = ['npm', 'uninstall', '"{0}"'.format(pkg)]
+    if not dir:
+        cmd.append('--global')
 
-    if dir is None:
-        cmd += ' --global'
-
-    cmd += ' "{0}"'.format(pkg)
+    cmd = ' '.join(cmd)
 
     result = __salt__['cmd.run_all'](cmd, python_shell=True, cwd=dir, runas=runas, env=env)
 
@@ -292,33 +286,25 @@ def list_(pkg=None,
         salt '*' npm.list
 
     '''
-    # Protect against injection
-    if pkg:
-        pkg = _cmd_quote(pkg)
-
-    if env is None:
-        env = {}
+    env = env or {}
 
     if runas:
         uid = salt.utils.get_uid(runas)
         if uid:
             env.update({'SUDO_UID': b'{0}'.format(uid), 'SUDO_USER': b''})
 
-    cmd = 'npm list --silent --json'
+    cmd = ['npm', 'list', '--json']
 
-    if dir is None:
-        cmd += ' --global'
+    if not dir:
+        cmd.append('--global')
 
     if pkg:
-        cmd += ' "{0}"'.format(pkg)
+        # Protect against injection
+        pkg = _cmd_quote(pkg)
+        cmd.append('"{0}"'.format(pkg))
 
     result = __salt__['cmd.run_all'](
-            cmd,
-            cwd=dir,
-            runas=runas,
-            env=env,
-            python_shell=True,
-            ignore_retcode=True)
+        cmd, cwd=dir, runas=runas, env=env, python_shell=True, ignore_retcode=True)
 
     # npm will return error code 1 for both no packages found and an actual
     # error. The only difference between the two cases are if stderr is empty
@@ -354,26 +340,20 @@ def cache_clean(path=None,
         salt '*' npm.cache_clean
 
     '''
-    if env is None:
-        env = {}
+    env = env or {}
 
     if runas:
         uid = salt.utils.get_uid(runas)
         if uid:
             env.update({'SUDO_UID': b'{0}'.format(uid), 'SUDO_USER': b''})
 
-    cmd = ['npm', 'cache clean']
+    cmd = ['npm', 'cache', 'clean']
     if path:
         cmd.append(path)
 
     cmd = ' '.join(cmd)
     result = __salt__['cmd.run_all'](
-            cmd,
-            cwd=None,
-            runas=runas,
-            env=env,
-            python_shell=True,
-            ignore_retcode=True)
+        cmd, cwd=None, runas=runas, env=env, python_shell=True, ignore_retcode=True)
 
     if result['retcode'] != 0:
         log.error(result['stderr'])
@@ -407,26 +387,20 @@ def cache_list(path=None,
         salt '*' npm.cache_clean
 
     '''
-    if env is None:
-        env = {}
+    env = env or {}
 
     if runas:
         uid = salt.utils.get_uid(runas)
         if uid:
             env.update({'SUDO_UID': b'{0}'.format(uid), 'SUDO_USER': b''})
 
-    cmd = ['npm', 'cache ls']
+    cmd = ['npm', 'cache', 'ls']
     if path:
         cmd.append(path)
 
     cmd = ' '.join(cmd)
     result = __salt__['cmd.run_all'](
-            cmd,
-            cwd=None,
-            runas=runas,
-            env=env,
-            python_shell=True,
-            ignore_retcode=True)
+        cmd, cwd=None, runas=runas, env=env, python_shell=True, ignore_retcode=True)
 
     if result['retcode'] != 0 and result['stderr']:
         raise CommandExecutionError(result['stderr'])
@@ -454,8 +428,7 @@ def cache_path(runas=None,
         salt '*' npm.cache_path
 
     '''
-    if env is None:
-        env = {}
+    env = env or {}
 
     if runas:
         uid = salt.utils.get_uid(runas)
@@ -465,11 +438,6 @@ def cache_path(runas=None,
     cmd = 'npm config get cache'
 
     result = __salt__['cmd.run_all'](
-            cmd,
-            cwd=None,
-            runas=runas,
-            env=env,
-            python_shell=True,
-            ignore_retcode=True)
+        cmd, cwd=None, runas=runas, env=env, python_shell=True, ignore_retcode=True)
 
     return result.get('stdout') or result.get('stderr')

--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -192,10 +192,7 @@ def _extract_json(npm_output):
     return None
 
 
-def uninstall(pkg,
-              dir=None,
-              runas=None,
-              env=None):
+def uninstall(pkg, dir=None, runas=None, env=None):
     '''
     Uninstall an NPM package.
 
@@ -250,10 +247,7 @@ def uninstall(pkg,
     return True
 
 
-def list_(pkg=None,
-          dir=None,
-          runas=None,
-          env=None):
+def list_(pkg=None, dir=None, runas=None, env=None):
     '''
     List installed NPM packages.
 
@@ -293,7 +287,7 @@ def list_(pkg=None,
         if uid:
             env.update({'SUDO_UID': b'{0}'.format(uid), 'SUDO_USER': b''})
 
-    cmd = ['npm', 'list', '--json']
+    cmd = ['npm', 'list', '--json', '--silent']
 
     if not dir:
         cmd.append('--global')
@@ -302,6 +296,7 @@ def list_(pkg=None,
         # Protect against injection
         pkg = _cmd_quote(pkg)
         cmd.append('"{0}"'.format(pkg))
+    cmd = ' '.join(cmd)
 
     result = __salt__['cmd.run_all'](
         cmd, cwd=dir, runas=runas, env=env, python_shell=True, ignore_retcode=True)
@@ -314,9 +309,7 @@ def list_(pkg=None,
     return json.loads(result['stdout']).get('dependencies', {})
 
 
-def cache_clean(path=None,
-                runas=None,
-                env=None):
+def cache_clean(path=None, runas=None, env=None):
     '''
     Clean cached NPM packages.
 
@@ -361,9 +354,7 @@ def cache_clean(path=None,
     return True
 
 
-def cache_list(path=None,
-               runas=None,
-               env=None):
+def cache_list(path=None, runas=None, env=None):
     '''
     List NPM cached packages.
 
@@ -408,8 +399,7 @@ def cache_list(path=None,
     return result['stdout']
 
 
-def cache_path(runas=None,
-               env=None):
+def cache_path(runas=None, env=None):
     '''
     List path of the NPM cache directory.
 

--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -145,7 +145,7 @@ def install(pkg=None,
         cmd.append('--global')
 
     if registry:
-        cmd.append('--registry="{}"'.format(registry))
+        cmd.append('--registry="{0}"'.format(registry))
 
     if dry_run:
         cmd.append('--dry-run')

--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -93,10 +93,7 @@ def installed(name,
     '''
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
 
-    if pkgs is not None:
-        pkg_list = pkgs
-    else:
-        pkg_list = [name]
+    pkg_list = pkgs if pkgs else [name]
 
     try:
         installed_pkgs = __salt__['npm.list'](dir=dir, runas=user, env=env)
@@ -215,9 +212,7 @@ def installed(name,
     return ret
 
 
-def removed(name,
-            dir=None,
-            user=None):
+def removed(name, dir=None, user=None):
     '''
     Verify that the given package is not installed.
 
@@ -260,9 +255,7 @@ def removed(name,
     return ret
 
 
-def bootstrap(name,
-              user=None,
-              silent=True):
+def bootstrap(name, user=None, silent=True):
     '''
     Bootstraps a node.js application.
 
@@ -278,13 +271,12 @@ def bootstrap(name,
     if __opts__['test']:
         try:
             call = __salt__['npm.install'](dir=name, runas=user, pkg=None, silent=silent, dry_run=True)
+            ret['result'] = None
+            ret['changes'] = {'old': [], 'new': call}
+            ret['comment'] = '{0} is set to be bootstrapped'.format(name)
         except (CommandNotFoundError, CommandExecutionError) as err:
             ret['result'] = False
             ret['comment'] = 'Error Bootstrapping \'{0}\': {1}'.format(name, err)
-            return ret
-        ret['result'] = None
-        ret['changes'] = {'old': [], 'new': call}
-        ret['comment'] = '{0} is set to be bootstrapped'.format(name)
         return ret
 
     try:


### PR DESCRIPTION
### What does this PR do?

Fixes an issue with parsing non-json responses and general cleanup in the npm module
### What issues does this PR fix or reference?

None
### Previous Behavior

``` bash
[ERROR   ] ['npm WARN optional Skipping failed optional dependency /karma/chokidar/fsevents:', 'npm WARN notsup Not compatible with your operating system or architecture: fsevents@1.0.14', 'npm WARN optional Skipping failed optional dependency /chokidar/fsevents:', 'npm WARN notsup Not compatible with your operating system or architecture: fsevents@1.0.14']
[ERROR   ] An exception occurred in this state: Traceback (most recent call last):
  File "/code/salt/salt/state.py", line 1737, in call
    **cdata['kwargs'])
  File "/code/salt/salt/loader.py", line 1683, in wrapper
    return f(*args, **kwargs)
  File "/code/salt/salt/states/npm.py", line 291, in bootstrap
    call = __salt__['npm.install'](dir=name, runas=user, pkg=None, silent=silent)
  File "/code/salt/salt/modules/npm.py", line 187, in install
    while not lines[0].startswith('{') and not lines[0].startswith('['):
IndexError: list index out of range

[INFO    ] Completed state [/srv/service_npm_modules] at time 05:26:09.064303 duration_in_ms=37195.508
local:
  Name: npm@3.x - Function: npm.installed - Result: Changed
----------
          ID: Ensure modules are bootstrapped
    Function: npm.bootstrap
        Name: /srv/service_npm_modules
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/code/salt/salt/state.py", line 1737, in call
                  **cdata['kwargs'])
                File "/code/salt/salt/loader.py", line 1683, in wrapper
                  return f(*args, **kwargs)
                File "/code/salt/salt/states/npm.py", line 291, in bootstrap
                  call = __salt__['npm.install'](dir=name, runas=user, pkg=None, silent=silent)
                File "/code/salt/salt/modules/npm.py", line 187, in install
                  while not lines[0].startswith('{') and not lines[0].startswith('['):
              IndexError: list index out of range
     Started: 05:25:31.868795
    Duration: 37195.508 ms
     Changes:   

Summary for local
------------
Succeeded: 3 (changed=1)
Failed:    1
------------
Total states run:     4
```

Remove this section if not relevant
### New Behavior

``` bash
[ERROR   ] ['npm WARN optional Skipping failed optional dependency /karma/chokidar/fsevents:', 'npm WARN notsup Not compatible with your operating system or architecture: fsevents@1.0.14', 'npm WARN optional Skipping failed optional dependency /chokidar/fsevents:', 'npm WARN notsup Not compatible with your operating system or architecture: fsevents@1.0.14']
[ERROR   ] npm WARN optional Skipping failed optional dependency /karma/chokidar/fsevents:
npm WARN notsup Not compatible with your operating system or architecture: fsevents@1.0.14
npm WARN optional Skipping failed optional dependency /chokidar/fsevents:
npm WARN notsup Not compatible with your operating system or architecture: fsevents@1.0.14
[INFO    ] Completed state [/srv/service_npm_modules] at time 05:28:25.418920 duration_in_ms=37136.295
local:
  Name: npm@3.x - Function: npm.installed - Result: Changed
----------
          ID: Ensure modules are bootstrapped
    Function: npm.bootstrap
        Name: /srv/service_npm_modules
      Result: False
     Comment: Could not bootstrap directory
     Started: 05:27:48.282625
    Duration: 37136.295 ms
     Changes:   Invalid Changes data: npm WARN optional Skipping failed optional dependency /karma/chokidar/fsevents:
npm WARN notsup Not compatible with your operating system or architecture: fsevents@1.0.14
npm WARN optional Skipping failed optional dependency /chokidar/fsevents:
npm WARN notsup Not compatible with your operating system or architecture: fsevents@1.0.14

Summary for local
------------
Succeeded: 3 (changed=2)
Failed:    1
------------
Total states run:     4
```
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.