### PR TITLE
added missing non-keyword argument skip_verify to __get_artifact func…

### DIFF
--- a/salt/states/jboss7.py
+++ b/salt/states/jboss7.py
@@ -418,6 +418,7 @@ def __get_artifact(salt_source):
                     saltenv=__env__,
                     context=None,
                     defaults=None,
+                    skip_verify=False,
                     kwargs=None)
 
                 manage_result = __salt__['file.manage_file'](


### PR DESCRIPTION
### What does this PR do?

Fixes "TypeError: get_managed() takes exactly 11 non-keyword arguments (10 given)" in
 jboss7.deployed when using the http(s) source protocol.
### What issues does this PR fix or reference?

None
### Previous Behavior

TypeError: get_managed() takes exactly 11 non-keyword arguments (10 given) when deploying using the http(s) source protocol.
### New Behavior

No error message. Deploy using http(s) source protocol completes successfully.
### Tests written?

No