### PR TITLE
Unit tests in place of integration tests for sys.list_{functions,modules}

### DIFF
--- a/tests/integration/modules/sysmod.py
+++ b/tests/integration/modules/sysmod.py
@@ -19,60 +19,6 @@ class SysModuleTest(integration.ModuleCase):
     '''
     Validate the sys module
     '''
-    def test_list_functions(self):
-        '''
-        sys.list_functions
-        '''
-        # Get all functions
-        funcs = self.run_function('sys.list_functions')
-        self.assertIn('hosts.list_hosts', funcs)
-        self.assertIn('pkg.install', funcs)
-
-        # Just sysctl
-        funcs = self.run_function('sys.list_functions', ('sysctl',))
-        self.assertNotIn('sys.doc', funcs)
-        self.assertIn('sysctl.get', funcs)
-
-        # Just sys
-        funcs = self.run_function('sys.list_functions', ('sys.',))
-        self.assertNotIn('sysctl.get', funcs)
-        self.assertIn('sys.doc', funcs)
-
-        # Staring with sys
-        funcs = self.run_function('sys.list_functions', ('sys',))
-        self.assertNotIn('sysctl.get', funcs)
-        self.assertIn('sys.doc', funcs)
-
-    def test_list_modules(self):
-        '''
-        sys.list_modules
-        '''
-        mods = self.run_function('sys.list_modules')
-        self.assertTrue('hosts' in mods)
-        self.assertTrue('pkg' in mods)
-
-    def test_list_modules_with_arg_glob(self):
-        '''
-        sys.list_modules u*
-
-        Tests getting the list of modules with 'u*', and looking for the
-        "user" module
-        '''
-        mods = self.run_function('sys.list_modules', ['u*'])
-        self.assertNotIn('bigip', mods)
-        self.assertIn('user', mods)
-
-    def test_list_modules_with_arg_exact_match(self):
-        '''
-        sys.list_modules user
-
-        Tests getting the list of modules looking for the "user" module with
-        an exact match of 'user' being passed at the CLI instead of something
-        with '*'.
-        '''
-        mods = self.run_function('sys.list_modules', ['user'])
-        self.assertEqual(mods, ['user'])
-
     def test_valid_docs(self):
         '''
         Make sure no functions are exposed that don't have valid docstrings

--- a/tests/unit/modules/sysmod_test.py
+++ b/tests/unit/modules/sysmod_test.py
@@ -21,8 +21,23 @@ ensure_in_syspath('../../')
 # Import Salt Libs
 from salt.modules import sysmod
 
+modules = set()
+functions = [
+    'sys.doc',     'sys.list_functions', 'sys.list_modules',
+    'sysctl.get',  'sysctl.show',
+    'system.halt', 'system.reboot',
+
+    'udev.name',   'udev.path',
+    'user.add',    'user.info',          'user.rename',
+]
+
 sysmod.__salt__ = {}
 sysmod.__opts__ = {}
+
+for func in functions:
+    sysmod.__salt__[func] = None
+    modules.add(func.split('.')[0])
+modules = sorted(list(modules))
 
 
 class Mockstate(object):
@@ -97,7 +112,7 @@ class SysmodTestCase(TestCase):
         '''
         Test if it return the docstrings for all modules.
         '''
-        self.assertDictEqual(sysmod.doc(), {})
+        self.assertDictEqual(sysmod.doc(), sysmod.__salt__)
 
     # 'state_doc' function tests: 1
 
@@ -145,9 +160,9 @@ class SysmodTestCase(TestCase):
         '''
         Test if it list the functions for all modules.
         '''
-        self.assertListEqual(sysmod.list_functions(), [])
+        self.assertListEqual(sysmod.list_functions(), functions)
 
-        self.assertListEqual(sysmod.list_functions('sys'), [])
+        self.assertListEqual(sysmod.list_functions('sys'), ['sys.doc', 'sys.list_functions', 'sys.list_modules'])
 
     # 'list_modules' function tests: 1
 
@@ -155,9 +170,11 @@ class SysmodTestCase(TestCase):
         '''
         Test if it list the modules loaded on the minion
         '''
-        self.assertListEqual(sysmod.list_modules(), [])
+        self.assertListEqual(sysmod.list_modules(), modules)
 
-        self.assertListEqual(sysmod.list_modules('s*'), [])
+        self.assertListEqual(sysmod.list_modules('s*'), ['sys', 'sysctl', 'system'])
+
+        self.assertListEqual(sysmod.list_modules('user'), ['user'])
 
     # 'reload_modules' function tests: 1
 

--- a/tests/unit/modules/sysmod_test.py
+++ b/tests/unit/modules/sysmod_test.py
@@ -162,8 +162,17 @@ class SysmodTestCase(TestCase):
         '''
         self.assertListEqual(sysmod.list_functions(), functions)
 
+        self.assertListEqual(sysmod.list_modules('nonexist'), [])
+
         self.assertListEqual(sysmod.list_functions('sys'), ['sys.doc', 'sys.list_functions', 'sys.list_modules'])
+
         self.assertListEqual(sysmod.list_functions('sys.'), ['sys.doc', 'sys.list_functions', 'sys.list_modules'])
+
+        self.assertListEqual(sysmod.list_functions('sys.l'), [])
+
+        self.assertListEqual(sysmod.list_functions('sys.list*'), ['sys.list_functions', 'sys.list_modules'])
+
+        self.assertListEqual(sysmod.list_functions('sys*'), ['sys.doc', 'sys.list_functions', 'sys.list_modules', 'sysctl.get', 'sysctl.show', 'system.halt', 'system.reboot'])
 
     # 'list_modules' function tests: 1
 
@@ -173,9 +182,11 @@ class SysmodTestCase(TestCase):
         '''
         self.assertListEqual(sysmod.list_modules(), modules)
 
-        self.assertListEqual(sysmod.list_modules('s*'), ['sys', 'sysctl', 'system'])
+        self.assertListEqual(sysmod.list_modules('nonexist'), [])
 
         self.assertListEqual(sysmod.list_modules('user'), ['user'])
+
+        self.assertListEqual(sysmod.list_modules('s*'), ['sys', 'sysctl', 'system'])
 
     # 'reload_modules' function tests: 1
 

--- a/tests/unit/modules/sysmod_test.py
+++ b/tests/unit/modules/sysmod_test.py
@@ -23,12 +23,12 @@ from salt.modules import sysmod
 
 modules = set()
 functions = [
-    'sys.doc',     'sys.list_functions', 'sys.list_modules',
-    'sysctl.get',  'sysctl.show',
+    'sys.doc', 'sys.list_functions', 'sys.list_modules',
+    'sysctl.get', 'sysctl.show',
     'system.halt', 'system.reboot',
 
-    'udev.name',   'udev.path',
-    'user.add',    'user.info',          'user.rename',
+    'udev.name', 'udev.path',
+    'user.add', 'user.info', 'user.rename',
 ]
 
 sysmod.__salt__ = {}
@@ -162,7 +162,7 @@ class SysmodTestCase(TestCase):
         '''
         self.assertListEqual(sysmod.list_functions(), functions)
 
-        self.assertListEqual(sysmod.list_functions('sys'),  ['sys.doc', 'sys.list_functions', 'sys.list_modules'])
+        self.assertListEqual(sysmod.list_functions('sys'), ['sys.doc', 'sys.list_functions', 'sys.list_modules'])
         self.assertListEqual(sysmod.list_functions('sys.'), ['sys.doc', 'sys.list_functions', 'sys.list_modules'])
 
     # 'list_modules' function tests: 1

--- a/tests/unit/modules/sysmod_test.py
+++ b/tests/unit/modules/sysmod_test.py
@@ -162,7 +162,8 @@ class SysmodTestCase(TestCase):
         '''
         self.assertListEqual(sysmod.list_functions(), functions)
 
-        self.assertListEqual(sysmod.list_functions('sys'), ['sys.doc', 'sys.list_functions', 'sys.list_modules'])
+        self.assertListEqual(sysmod.list_functions('sys'),  ['sys.doc', 'sys.list_functions', 'sys.list_modules'])
+        self.assertListEqual(sysmod.list_functions('sys.'), ['sys.doc', 'sys.list_functions', 'sys.list_modules'])
 
     # 'list_modules' function tests: 1
 


### PR DESCRIPTION
(Why unit tests? Because these make more sense over integration tests)
### What does this PR do?

Use unit tests in place of integration tests for sys.list_{functions,modules}
### What issues does this PR fix or reference?

Old PRs written using integration tests: #33774, #33775
*NOTE if this PR is accepted, pls ignore #35077
### Tests written?

duh
