### PR TITLE
Add encryption support to etcd

### DIFF
--- a/salt/utils/etcd_util.py
+++ b/salt/utils/etcd_util.py
@@ -17,6 +17,9 @@ may be passed in. The following configurations are both valid:
     etcd.port: 4001
     etcd.username: larry  # Optional; requires etcd.password to be set
     etcd.password: 123pass  # Optional; requires etcd.username to be set
+    etcd.ca: /path/to/your/ca_cert/ca.pem # Optional
+    etcd.client_key: /path/to/your/client_key/client-key.pem # Optional; requires etcd.ca and etcd.client_cert to be set
+    etcd.client_cert: /path/to/your/client_cert/client.pem # Optional; requires etcd.ca and etcd.client_key to be set
 
     # One or more profiles defined
     my_etcd_config:
@@ -24,6 +27,9 @@ may be passed in. The following configurations are both valid:
       etcd.port: 4001
       etcd.username: larry  # Optional; requires etcd.password to be set
       etcd.password: 123pass  # Optional; requires etcd.username to be set
+      etcd.ca: /path/to/your/ca_cert/ca.pem # Optional
+      etcd.client_key: /path/to/your/client_key/client-key.pem # Optional; requires etcd.ca and etcd.client_cert to be set
+      etcd.client_cert: /path/to/your/client_cert/client.pem # Optional; requires etcd.ca and etcd.client_key to be set
 
 Once configured, the client() function is passed a set of opts, and optionally,
 the name of a profile to be used.
@@ -91,6 +97,9 @@ class EtcdClient(object):
         port = self.conf.get('etcd.port', 4001)
         username = self.conf.get('etcd.username')
         password = self.conf.get('etcd.password')
+        ca_cert = self.conf.get('etcd.ca')
+        cli_key = self.conf.get('etcd.client_key')
+        cli_cert = self.conf.get('etcd.client_cert')
 
         auth = {}
         if username and password:
@@ -99,8 +108,26 @@ class EtcdClient(object):
                 'password': str(password)
             }
 
+        certs = {}
+        if ca_cert and not (cli_cert or cli_key):
+            certs = {
+                'ca_cert': str(ca_cert),
+                'protocol': 'https'
+            }
+
+        if ca_cert and cli_cert and cli_key:
+            cert = (cli_cert, cli_key);
+            certs = {
+                'ca_cert': str(ca_cert),
+                'cert': cert,
+                'protocol': 'https'
+            }
+
+        xargs = auth.copy()
+        xargs.update(certs)
+
         if HAS_LIBS:
-            self.client = etcd.Client(host, port, **auth)
+            self.client = etcd.Client(host, port, **xargs)
         else:
             raise CommandExecutionError(
                 '(unable to import etcd, '

--- a/salt/utils/etcd_util.py
+++ b/salt/utils/etcd_util.py
@@ -116,7 +116,7 @@ class EtcdClient(object):
             }
 
         if ca_cert and cli_cert and cli_key:
-            cert = (cli_cert, cli_key);
+            cert = (cli_cert, cli_key)
             certs = {
                 'ca_cert': str(ca_cert),
                 'cert': cert,


### PR DESCRIPTION
### What does this PR do?

Adds encryption support to the etcd_util using a CA certificate or a CA certificate with a client certificate and key
### What issues does this PR fix or reference?

[Feature] Add etcd encryption support saltstack/salt#35009 
### Tests written?

No