### PR TITLE
Fix salt.states.boto_secgroup message printing

### DIFF
--- a/salt/states/boto_secgroup.py
+++ b/salt/states/boto_secgroup.py
@@ -419,9 +419,9 @@ def _rules_present(name, rules, vpc_id=None, vpc_name=None,
     to_delete, to_create = _get_rule_changes(rules, sg['rules'])
     if to_create or to_delete:
         if __opts__['test']:
-            msg = ('Security group {0} set to have rules modified.',
-                   '\nTo be created: {1}.\nTo be deleted: {2}').format(
-                       name, pprint.pformat(to_create), pprint.pformat(to_delete))
+            msg = """Security group {0} set to have rules modified.
+            To be created: {1}
+            To be deleted: {2}""".format(name, pprint.pformat(to_create), pprint.pformat(to_delete))
             ret['comment'] = msg
             ret['result'] = None
             return ret
@@ -502,9 +502,9 @@ def _rules_egress_present(name, rules_egress, vpc_id=None, vpc_name=None,
     )
     if to_create_egress or to_delete_egress:
         if __opts__['test']:
-            msg = ('Security group {0} set to have rules modified.'
-                   '\nTo be created: {1}.\nTo be deleted: {2}').format(
-                       name, pprint.pformat(to_create_egress), pprint.pformat(to_delete_egress))
+            msg = """Security group {0} set to have rules modified.
+            To be created: {1}
+            To be deleted: {2}""".format(name, pprint.pformat(to_create_egress), pprint.pformat(to_delete_egress))
             ret['comment'] = msg
             ret['result'] = None
             return ret


### PR DESCRIPTION
saltstack/salt#35089 is broken as I sent the wrong commit, my bad. Here is a fix.

For reference, the error message is

```
2016-08-01 12:40:19,233 [salt.state       ][ERROR   ][7909] An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1723, in call
    **cdata['kwargs'])
  File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1650, in wrapper
    return f(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/states/boto_secgroup.py", line 189, in present
    profile=profile)
  File "/usr/lib/python2.7/dist-packages/salt/states/boto_secgroup.py", line 421, in _rules_present
    '\nTo be created: {1}.\nTo be deleted: {2}').format(
AttributeError: 'tuple' object has no attribute 'format'
```