### PR TITLE
Properly mock localemod unit tests

### DIFF
--- a/tests/unit/modules/localemod_test.py
+++ b/tests/unit/modules/localemod_test.py
@@ -157,6 +157,7 @@ class LocalemodTestCase(TestCase):
             with patch.dict(localemod.__grains__, {'os': 'Ubuntu'}):
                 self.assertTrue(localemod.gen_locale('en_US.UTF-8'))
 
+    @patch('salt.utils.which', MagicMock(return_value='/some/dir/path'))
     @patch('os.listdir', MagicMock(return_value=['en_US.UTF-8']))
     def test_gen_locale_gentoo(self):
         '''
@@ -170,6 +171,7 @@ class LocalemodTestCase(TestCase):
                              'cmd.run_all': MagicMock(return_value=ret)}):
                 self.assertTrue(localemod.gen_locale('en_US.UTF-8 UTF-8'))
 
+    @patch('salt.utils.which', MagicMock(return_value='/some/dir/path'))
     @patch('os.listdir', MagicMock(return_value=['en_US.UTF-8']))
     def test_gen_locale_gentoo_no_charmap(self):
         '''


### PR DESCRIPTION
### What does this PR do?

Unbreak localemod unit tests on non-Linux systems
### Previous Behavior

```
unit.modules.localemod_test.LocalemodTestCase.test_gen_locale_gentoo_no_charmap

   -> unit.modules.localemod_test.LocalemodTestCase.test_gen_locale_gentoo  ....
       Traceback (most recent call last):
         File "/home/eradman/local/saltenv/lib/python2.7/site-packages/mock/mock.py", line 13
05, in patched
           return func(*args, **keywargs)
         File "/home/eradman/git/salt/tests/unit/modules/localemod_test.py", line 171, in tes
t_gen_locale_gentoo
           self.assertTrue(localemod.gen_locale('en_US.UTF-8 UTF-8'))
         File "/home/eradman/git/salt/salt/modules/localemod.py", line 337, in gen_locale
           'Command "locale-gen" or "localedef" was not found on this system.')
       CommandExecutionError: Command "locale-gen" or "localedef" was not found on this syste
m.
```