### PR TITLE
Missing trailing whitespace after cmd

### DIFF
--- a/salt/modules/win_servermanager.py
+++ b/salt/modules/win_servermanager.py
@@ -182,7 +182,7 @@ def install(feature, recurse=False, restart=False, source=None, exclude=None):
     if source is not None:
         src = '-Source {0}'.format(source)
 
-    cmd = '{0} -Name {1} {2} {3} {4} {5}' \
+    cmd = '{0} -Name {1} {2} {3} {4} {5} ' \
           '-ErrorAction SilentlyContinue ' \
           '-WarningAction SilentlyContinue'.format(command,
                                                    _cmd_quote(feature),


### PR DESCRIPTION
### What does this PR do?

Add whitespace to cmd to create valid powershell command
### What issues does this PR fix or reference?

win_servermanager.install would error out
### Previous Behavior

```
[DEBUG   ] PowerShell: Import-Module ServerManager; Install-WindowsFeature -Name
 TFTP-Client    -IncludeManagementTools-ErrorAction SilentlyContinue -WarningAct
ion SilentlyContinue | ConvertTo-Json
[INFO    ] Executing command 'Powershell -NonInteractive "Import-Module ServerMa
nager; Install-WindowsFeature -Name TFTP-Client    -IncludeManagementTools-Error
Action SilentlyContinue -WarningAction SilentlyContinue | ConvertTo-Json"' in di
rectory 'C:\Users\Administrator'
[ERROR   ] Command 'Import-Module ServerManager; Install-WindowsFeature -Name TF
TP-Client    -IncludeManagementTools-ErrorAction SilentlyContinue -WarningAction
 SilentlyContinue | ConvertTo-Json' failed with return code: 1
[ERROR   ] output: Install-WindowsFeature : A parameter cannot be found that mat
ches parameter
name 'IncludeManagementTools-ErrorAction'.
At line:1 char:74
+ Import-Module ServerManager; Install-WindowsFeature -Name TFTP-Client
-Includ ...
+
    + CategoryInfo          : InvalidArgument: (:) [Install-WindowsFeature], P
   arameterBindingException
    + FullyQualifiedErrorId : NamedParameterNotFound,Microsoft.Windows.ServerM
   anager.Commands.AddWindowsFeatureCommand
[DEBUG   ] Json not returned
[WARNING ] Passed invalid arguments to win_servermanager.install: string indices
 must be integers, not str
```
### New Behavior

```
[DEBUG   ] PowerShell: Import-Module ServerManager; Install-WindowsFeature -Name
 TFTP-Client    -IncludeManagementTools -ErrorAction SilentlyContinue -WarningAc
tion SilentlyContinue | ConvertTo-Json
[INFO    ] Executing command 'Powershell -NonInteractive "Import-Module ServerMa
nager; Install-WindowsFeature -Name TFTP-Client    -IncludeManagementTools -Erro
rAction SilentlyContinue -WarningAction SilentlyContinue | ConvertTo-Json"' in d
irectory 'C:\Users\Administrator'
[INFO    ] User root Executing command saltutil.find_job with jid 20160723223358
299867
== cut job processing ==
[DEBUG   ] output: {
    "Success":  true,
    "RestartNeeded":  1,
    "FeatureResult":  [
                          {
                              "Id":  58,
                              "Name":  "TFTP-Client",
                              "DisplayName":  "TFTP Client",
                              "Success":  true,
                              "RestartNeeded":  false,
                              "Message":  "",
                              "SkipReason":  0
                          }
                      ],
    "ExitCode":  0
}
```
### Tests written?

No