### PR TITLE
Salt cloud esx 5 5 fixes

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -134,7 +134,7 @@ from salt.exceptions import SaltCloudSystemExit
 import salt.config as config
 
 # Attempt to import pyVim and pyVmomi libs
-ESX_5_5_NAME_PORTION = 'VMware ESXi 5.5.0'
+ESX_5_5_NAME_PORTION = 'VMware ESXi 5.5'
 SAFE_ESX_5_5_CONTROLLER_KEY_INDEX = 200
 try:
     from pyVmomi import vim
@@ -602,9 +602,9 @@ def _manage_devices(devices, vm=None, container_ref=None):
     existing_cd_drives_label = []
     ide_controllers = {}
     nics_map = []
+    cloning_from_vm = vm is not None
 
-    # this would be None when we aren't cloning a VM
-    if vm:
+    if cloning_from_vm:
         # loop through all the devices the vm/template has
         # check if the device needs to be created or configured
         for device in vm.config.hardware.device:

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2358,7 +2358,7 @@ def create(vm_):
 
     # If the hardware version is specified and if it is different from the current
     # hardware version, then schedule a hardware version upgrade
-    if hardware_version:
+    if hardware_version and object_ref is not None:
         hardware_version = "vmx-{0}".format(str(hardware_version).zfill(2))
         if hardware_version != object_ref.config.version:
             log.debug("Scheduling hardware version upgrade from {0} to {1}".format(object_ref.config.version, hardware_version))

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2246,10 +2246,9 @@ def create(vm_):
     win_user_fullname = config.get_cloud_config_value(
         'win_user_fullname', vm_, __opts__, search_global=False, default='Windows User'
     )
-
+    container_ref = None
     if 'clonefrom' in vm_:
         # If datacenter is specified, set the container reference to start search from it instead
-        container_ref = None
         if datacenter:
             datacenter_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.Datacenter, datacenter)
             container_ref = datacenter_ref if datacenter_ref else None

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2540,6 +2540,7 @@ def create(vm_):
         salt.utils.vmware.wait_for_task(task, vm_name, 'power', 5, 'info')
 
     # If it a template or if it does not need to be powered on then do not wait for the IP
+    out = None
     if not template and power:
         ip = _wait_for_ip(new_vm_ref, wait_for_ip_timeout)
         if ip:
@@ -2552,7 +2553,8 @@ def create(vm_):
                 out = salt.utils.cloud.bootstrap(vm_, __opts__)
 
     data = show_instance(vm_name, call='action')
-    if deploy:
+    # out is only assigned when  it has an ip, deploy and power but not template
+    if deploy and out is not None:
         data['deploy_kwargs'] = out['deploy_kwargs']
 
     salt.utils.cloud.fire_event(

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -477,7 +477,7 @@ def _add_new_ide_controller_helper(ide_controller_label, properties, bus_number)
 
     .. versionadded:: 2016.3.0
     '''
-    random_key = randint(-200, -250)
+    random_key = randint(-200, 250)
 
     ide_spec = vim.vm.device.VirtualDeviceSpec()
     ide_spec.device = vim.vm.device.VirtualIDEController()

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2268,6 +2268,7 @@ def create(vm_):
     win_user_fullname = config.get_cloud_config_value(
         'win_user_fullname', vm_, __opts__, search_global=False, default='Windows User'
     )
+
     container_ref = None
     if 'clonefrom' in vm_:
         # If datacenter is specified, set the container reference to start search from it instead
@@ -2553,7 +2554,7 @@ def create(vm_):
                 out = salt.utils.cloud.bootstrap(vm_, __opts__)
 
     data = show_instance(vm_name, call='action')
-    # out is only assigned when  it has an ip, deploy and power but not template
+
     if deploy and out is not None:
         data['deploy_kwargs'] = out['deploy_kwargs']
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2835,7 +2835,7 @@ def is_profile_configured(opts, provider, profile_name, vm_=None):
     alias, driver = provider.split(':')
 
     # Most drivers need an image to be specified, but some do not.
-    non_image_drivers = ['nova', 'virtualbox']
+    drivers_requiring_an_image = ['nova', 'virtualbox']
 
     # Most drivers need a size, but some do not.
     non_size_drivers = ['opennebula', 'parallels', 'proxmox', 'scaleway',
@@ -2848,14 +2848,14 @@ def is_profile_configured(opts, provider, profile_name, vm_=None):
     # If cloning on Linode, size and image are not necessary.
     # They are obtained from the to-be-cloned VM.
     if driver == 'linode' and profile_key.get('clonefrom', False):
-        non_image_drivers.append('linode')
+        drivers_requiring_an_image.append('linode')
         non_size_drivers.append('linode')
 
     # If cloning on VMware, specifying image is not necessary.
-    if driver == 'vmware' and profile_key.get('clonefrom', False):
-        non_image_drivers.append('vmware')
+    if driver == 'vmware' and profile_key.get('clonefrom') is None:
+        drivers_requiring_an_image.append('vmware')
 
-    if driver not in non_image_drivers:
+    if driver in drivers_requiring_an_image:
         required_keys.append('image')
         if driver == 'vmware':
             required_keys.append('datastore')

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2835,7 +2835,7 @@ def is_profile_configured(opts, provider, profile_name, vm_=None):
     alias, driver = provider.split(':')
 
     # Most drivers need an image to be specified, but some do not.
-    drivers_requiring_an_image = ['nova', 'virtualbox']
+    non_image_drivers = ['nova', 'virtualbox']
 
     # Most drivers need a size, but some do not.
     non_size_drivers = ['opennebula', 'parallels', 'proxmox', 'scaleway',
@@ -2848,14 +2848,14 @@ def is_profile_configured(opts, provider, profile_name, vm_=None):
     # If cloning on Linode, size and image are not necessary.
     # They are obtained from the to-be-cloned VM.
     if driver == 'linode' and profile_key.get('clonefrom', False):
-        drivers_requiring_an_image.append('linode')
+        non_image_drivers.append('linode')
         non_size_drivers.append('linode')
 
     # If cloning on VMware, specifying image is not necessary.
-    if driver == 'vmware' and profile_key.get('clonefrom') is None:
-        drivers_requiring_an_image.append('vmware')
+    if driver == 'vmware' and 'image' not in list(profile_key.keys()) and 'clonefrom' in list(profile_key.keys()):
+        non_image_drivers.append('vmware')
 
-    if driver in drivers_requiring_an_image:
+    if driver not in non_image_drivers:
         required_keys.append('image')
         if driver == 'vmware':
             required_keys.append('datastore')

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2852,7 +2852,7 @@ def is_profile_configured(opts, provider, profile_name, vm_=None):
         non_size_drivers.append('linode')
 
     # If cloning on VMware, specifying image is not necessary.
-    if driver == 'vmware' and profile_key.get('image', True):
+    if driver == 'vmware' and profile_key.get('clonefrom', False):
         non_image_drivers.append('vmware')
 
     if driver not in non_image_drivers:

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2852,7 +2852,7 @@ def is_profile_configured(opts, provider, profile_name, vm_=None):
         non_size_drivers.append('linode')
 
     # If cloning on VMware, specifying image is not necessary.
-    if driver == 'vmware' and 'image' not in list(profile_key.keys()) and 'clonefrom' in list(profile_key.keys()):
+    if driver == 'vmware' and 'image' not in list(profile_key.keys()):
         non_image_drivers.append('vmware')
 
     if driver not in non_image_drivers:

--- a/tests/unit/cloud/clouds/vmware_test.py
+++ b/tests/unit/cloud/clouds/vmware_test.py
@@ -868,6 +868,45 @@ class VMwareTestCase(ExtendedTestCase):
             self.assertEqual(config.is_profile_configured(vmware.__opts__, 'vcenter01:vmware',
                                                           'base-gold', vm_=vm_), False)
 
+    @patch('salt.cloud.clouds.vmware.randint', return_value=101)
+    def test_add_new_ide_controller_helper(self, randint_mock):
+        controller_label = 'Some label'
+        bus_number = 1
+        spec = vmware._add_new_ide_controller_helper(controller_label, None, bus_number)
+        self.assertEqual(spec.device.key, randint_mock.return_value)
+
+        spec = vmware._add_new_ide_controller_helper(controller_label, 200, bus_number)
+        self.assertEqual(spec.device.key, 200)
+
+        self.assertEqual(spec.device.busNumber, bus_number)
+        self.assertEqual(spec.device.deviceInfo.label, controller_label)
+        self.assertEqual(spec.device.deviceInfo.summary, controller_label)
+
+
+    def test_manage_devices_just_cd(self):
+        device_map = {
+            'ide': {
+                'IDE 0': {},
+                'IDE 1': {}
+            },
+            'cd': {
+                'CD/DVD Drive 1': {'controller': 'IDE 0'}
+            }
+        }
+        with patch('salt.cloud.clouds.vmware.get_vcenter_version', return_value='VMware ESXi 5.5.0'):
+            specs = vmware._manage_devices(device_map, vm=None)['device_specs']
+
+            self.assertEqual(specs[0].device.key, vmware.SAFE_ESX_5_5_CONTROLLER_KEY_INDEX)
+            self.assertEqual(specs[1].device.key, vmware.SAFE_ESX_5_5_CONTROLLER_KEY_INDEX+1)
+            self.assertEqual(specs[2].device.controllerKey, vmware.SAFE_ESX_5_5_CONTROLLER_KEY_INDEX)
+
+        with patch('salt.cloud.clouds.vmware.get_vcenter_version', return_value='VMware ESXi 6'),\
+             patch('salt.cloud.clouds.vmware.randint', return_value=100) as first_key:
+            specs = vmware._manage_devices(device_map, vm=None)['device_specs']
+
+            self.assertEqual(specs[0].device.key, first_key.return_value)
+            self.assertEqual(specs[2].device.controllerKey, first_key.return_value)
+
     def test_add_host_no_host_in_kwargs(self):
         '''
         Tests that a SaltCloudSystemExit is raised when host is not present in

--- a/tests/unit/cloud/clouds/vmware_test.py
+++ b/tests/unit/cloud/clouds/vmware_test.py
@@ -803,8 +803,7 @@ class VMwareTestCase(ExtendedTestCase):
 
     def test_no_clonefrom_just_image(self):
         '''
-        Tests that a SaltCloudSystemExit is raised when esxi_host_password is not
-        specified in the cloud provider configuration when calling add_host.
+        Tests that the profile is configured correctly when deploying using an image
         '''
 
         profile_additions = {
@@ -826,8 +825,7 @@ class VMwareTestCase(ExtendedTestCase):
 
     def test_just_clonefrom(self):
         '''
-        Tests that a SaltCloudSystemExit is raised when esxi_host_password is not
-        specified in the cloud provider configuration when calling add_host.
+        Tests that the profile is configured correctly when deploying by cloning from a template
         '''
 
         profile_additions = {
@@ -849,8 +847,7 @@ class VMwareTestCase(ExtendedTestCase):
 
     def test_no_clonefrom_expect_fail(self):
         '''
-        Tests that a SaltCloudSystemExit is raised when esxi_host_password is not
-        specified in the cloud provider configuration when calling add_host.
+        Tests that not including the clonefrom property will result in an invalid profile
         '''
 
         profile_additions = {}
@@ -870,6 +867,10 @@ class VMwareTestCase(ExtendedTestCase):
 
     @patch('salt.cloud.clouds.vmware.randint', return_value=101)
     def test_add_new_ide_controller_helper(self, randint_mock):
+        '''
+        Tests that creating a new controller, ensuring that it will generate a controller key
+        if one is not provided
+        '''
         controller_label = 'Some label'
         bus_number = 1
         spec = vmware._add_new_ide_controller_helper(controller_label, None, bus_number)
@@ -884,6 +885,10 @@ class VMwareTestCase(ExtendedTestCase):
 
 
     def test_manage_devices_just_cd(self):
+        '''
+        Tests that when adding IDE/CD drives, controller keys will be in the apparent
+        safe-range on ESX 5.5 but randomly generated on other versions (i.e. 6)
+        '''
         device_map = {
             'ide': {
                 'IDE 0': {},

--- a/tests/unit/cloud/clouds/vmware_test.py
+++ b/tests/unit/cloud/clouds/vmware_test.py
@@ -14,6 +14,7 @@ from copy import deepcopy
 from salttesting import TestCase, skipIf
 from salttesting.mock import MagicMock, NO_MOCK, NO_MOCK_REASON, patch
 from salttesting.helpers import ensure_in_syspath
+from salt import config
 
 ensure_in_syspath('../../../')
 
@@ -43,6 +44,14 @@ PROVIDER_CONFIG = {
   }
 }
 VM_NAME = 'test-vm'
+PROFILE = {
+  'base-gold': {
+    'provider': 'vcenter01:vmware',
+    'datastore': 'Datastore1',
+    'resourcepool': 'Resources',
+    'folder': 'vm'
+  }
+}
 
 
 class ExtendedTestCase(TestCase):
@@ -797,54 +806,67 @@ class VMwareTestCase(ExtendedTestCase):
         Tests that a SaltCloudSystemExit is raised when esxi_host_password is not
         specified in the cloud provider configuration when calling add_host.
         '''
-        import salt.config as config
 
-        profile = {
-            'base-gold': {
-                'provider': 'vcenter01:vmware',
-                'datastore': 'Datastore1',
-                'resourcepool': 'Resources',
-                'folder': 'vm',
-                'image': 'test-image'
-            }
-
+        profile_additions = {
+            'image': 'some-image.iso'
         }
+
+        provider_config = deepcopy(PROVIDER_CONFIG)
+        profile = deepcopy(PROFILE)
+        profile['base-gold'].update(profile_additions)
+
         provider_config_additions = {
             'profiles': profile
         }
-        provider_config = deepcopy(PROVIDER_CONFIG)
         provider_config['vcenter01']['vmware'].update(provider_config_additions)
         vm_ = {'profile': profile}
         with patch.dict(vmware.__opts__, {'providers': provider_config}, clean=True):
             self.assertEqual(config.is_profile_configured(vmware.__opts__, 'vcenter01:vmware',
-                                         'base-gold', vm_=vm_), True)
+                                                          'base-gold', vm_=vm_), True)
 
     def test_just_clonefrom(self):
         '''
         Tests that a SaltCloudSystemExit is raised when esxi_host_password is not
         specified in the cloud provider configuration when calling add_host.
         '''
-        import salt.config as config
 
-        profile = {
-            'base-gold': {
-                'provider': 'vcenter01:vmware',
-                'datastore': 'Datastore1',
-                'resourcepool': 'Resources',
-                'folder': 'vm',
-                'clonefrom': 'test-template'
-            }
-
+        profile_additions = {
+            'clonefrom': 'test-template'
         }
+
+        provider_config = deepcopy(PROVIDER_CONFIG)
+        profile = deepcopy(PROFILE)
+        profile['base-gold'].update(profile_additions)
+
         provider_config_additions = {
             'profiles': profile
         }
-        provider_config = deepcopy(PROVIDER_CONFIG)
         provider_config['vcenter01']['vmware'].update(provider_config_additions)
         vm_ = {'profile': profile}
         with patch.dict(vmware.__opts__, {'providers': provider_config}, clean=True):
             self.assertEqual(config.is_profile_configured(vmware.__opts__, 'vcenter01:vmware',
                                                           'base-gold', vm_=vm_), True)
+
+    def test_no_clonefrom_expect_fail(self):
+        '''
+        Tests that a SaltCloudSystemExit is raised when esxi_host_password is not
+        specified in the cloud provider configuration when calling add_host.
+        '''
+
+        profile_additions = {}
+
+        provider_config = deepcopy(PROVIDER_CONFIG)
+        profile = deepcopy(PROFILE)
+        profile['base-gold'].update(profile_additions)
+
+        provider_config_additions = {
+            'profiles': profile
+        }
+        provider_config['vcenter01']['vmware'].update(provider_config_additions)
+        vm_ = {'profile': profile}
+        with patch.dict(vmware.__opts__, {'providers': provider_config}, clean=True):
+            self.assertEqual(config.is_profile_configured(vmware.__opts__, 'vcenter01:vmware',
+                                                          'base-gold', vm_=vm_), False)
 
     def test_add_host_no_host_in_kwargs(self):
         '''

--- a/tests/unit/cloud/clouds/vmware_test.py
+++ b/tests/unit/cloud/clouds/vmware_test.py
@@ -792,6 +792,60 @@ class VMwareTestCase(ExtendedTestCase):
                 kwargs=None,
                 call='function')
 
+    def test_no_clonefrom_just_image(self):
+        '''
+        Tests that a SaltCloudSystemExit is raised when esxi_host_password is not
+        specified in the cloud provider configuration when calling add_host.
+        '''
+        import salt.config as config
+
+        profile = {
+            'base-gold': {
+                'provider': 'vcenter01:vmware',
+                'datastore': 'Datastore1',
+                'resourcepool': 'Resources',
+                'folder': 'vm',
+                'image': 'test-image'
+            }
+
+        }
+        provider_config_additions = {
+            'profiles': profile
+        }
+        provider_config = deepcopy(PROVIDER_CONFIG)
+        provider_config['vcenter01']['vmware'].update(provider_config_additions)
+        vm_ = {'profile': profile}
+        with patch.dict(vmware.__opts__, {'providers': provider_config}, clean=True):
+            self.assertEqual(config.is_profile_configured(vmware.__opts__, 'vcenter01:vmware',
+                                         'base-gold', vm_=vm_), True)
+
+    def test_just_clonefrom(self):
+        '''
+        Tests that a SaltCloudSystemExit is raised when esxi_host_password is not
+        specified in the cloud provider configuration when calling add_host.
+        '''
+        import salt.config as config
+
+        profile = {
+            'base-gold': {
+                'provider': 'vcenter01:vmware',
+                'datastore': 'Datastore1',
+                'resourcepool': 'Resources',
+                'folder': 'vm',
+                'clonefrom': 'test-template'
+            }
+
+        }
+        provider_config_additions = {
+            'profiles': profile
+        }
+        provider_config = deepcopy(PROVIDER_CONFIG)
+        provider_config['vcenter01']['vmware'].update(provider_config_additions)
+        vm_ = {'profile': profile}
+        with patch.dict(vmware.__opts__, {'providers': provider_config}, clean=True):
+            self.assertEqual(config.is_profile_configured(vmware.__opts__, 'vcenter01:vmware',
+                                                          'base-gold', vm_=vm_), True)
+
     def test_add_host_no_host_in_kwargs(self):
         '''
         Tests that a SaltCloudSystemExit is raised when host is not present in


### PR DESCRIPTION
### What does this PR do?

Fixes a number of issues relating to the VMWare salt-cloud driver, specifically ESX 5.5 and ESX 6 and deploying from an image (ISO) rather than vCenter and cloning from templates.
### What issues does this PR fix or reference?

Resolves 
- Issue #35052 "salt-cloud (non templated) VM deploy to an ESXi Host returns a profile error 'container_ref' referenced before assignment "
- Issue #34880 "salt-cloud (non templated) VM deploy to an ESXi Host appears to require a "clonefrom" parameter"
- Issue where image deploy would not work on ESX 5.5 (not tested on earlier versions - no access)
### Tests written?

Yes. 
