### PR TITLE
OpenBSD: skip unit tests that rely on PAM

### DIFF
--- a/tests/unit/auth_test.py
+++ b/tests/unit/auth_test.py
@@ -5,6 +5,7 @@
 
 # Import pytohn libs
 from __future__ import absolute_import
+import sys
 
 # Import Salt Testing libs
 from salttesting import TestCase, skipIf
@@ -66,6 +67,7 @@ class LoadAuthTestCase(TestCase):
             format_call_mock.assert_has_calls((expected_ret,), any_order=True)
 
 
+@skipIf(sys.platform.startswith('openbsd'), 'OpenBSD does not use PAM')
 @patch('zmq.Context', MagicMock())
 @patch('salt.payload.Serial.dumps', MagicMock())
 @patch('salt.master.tagify', MagicMock())
@@ -497,6 +499,7 @@ class MasterACLTestCase(integration.ModuleCase):
         self.assertEqual(fire_event_mock.mock_calls, [])
 
 
+@skipIf(sys.platform.startswith('openbsd'), 'OpenBSD does not use PAM')
 class AuthACLTestCase(integration.ModuleCase):
     '''
     A class to check various aspects of the publisher ACL system

--- a/tests/unit/modules/localemod_test.py
+++ b/tests/unit/modules/localemod_test.py
@@ -157,6 +157,7 @@ class LocalemodTestCase(TestCase):
             with patch.dict(localemod.__grains__, {'os': 'Ubuntu'}):
                 self.assertTrue(localemod.gen_locale('en_US.UTF-8'))
 
+    @patch('salt.utils.which', MagicMock(return_value='/some/dir/path'))
     @patch('os.listdir', MagicMock(return_value=['en_US.UTF-8']))
     def test_gen_locale_gentoo(self):
         '''
@@ -170,6 +171,7 @@ class LocalemodTestCase(TestCase):
                              'cmd.run_all': MagicMock(return_value=ret)}):
                 self.assertTrue(localemod.gen_locale('en_US.UTF-8 UTF-8'))
 
+    @patch('salt.utils.which', MagicMock(return_value='/some/dir/path'))
     @patch('os.listdir', MagicMock(return_value=['en_US.UTF-8']))
     def test_gen_locale_gentoo_no_charmap(self):
         '''

--- a/tests/unit/modules/pam_test.py
+++ b/tests/unit/modules/pam_test.py
@@ -27,7 +27,7 @@ MOCK_FILE = 'ok ok ignore '
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
-@skipIf(sys.platform.startswith('OpenBSD'), 'OpenBSD does not use PAM')
+@skipIf(sys.platform.startswith('openbsd'), 'OpenBSD does not use PAM')
 class PamTestCase(TestCase):
     '''
     Test cases for salt.modules.pam


### PR DESCRIPTION
### What does this PR do?

Eliminate a series of errors that result from trying to load the pam module
### Details

Importing the pam module on OpenBSD raises "AttributeError: Unable to resolve symbol". Also, fix incorrect skipIf case: `sys.platform` returns a string in lower case.
