### PR TITLE
this was supposed to be only temporary

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5785,7 +5785,7 @@ def sls(name, mods=None, saltenv='base', **kwargs):
     return ret
 
 
-def sls_build(name, base='fedora', mods=None, saltenv='base',
+def sls_build(name, base='opensuse/python', mods=None, saltenv='base',
               **kwargs):
     '''
     Build a docker image using the specified sls modules and base image.


### PR DESCRIPTION
### What does this PR do?

It adds the original intended default base image referred as "leapy" (Leap on Python) so that containers can be built with Salt. Of course this is a sane default: the user can specify any base image that is python enabled.
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/pull/35062
### Tests written?

No