### PR TITLE
Support for aws iot 'thing type'

### DIFF
--- a/salt/modules/boto_iot.py
+++ b/salt/modules/boto_iot.py
@@ -120,6 +120,8 @@ def thing_type_exists(thingTypeName,
 
         salt myminion boto_iot.thing_type_exists mythingtype
 
+    .. versionadded:: Carbon
+
     '''
 
     try:
@@ -148,6 +150,8 @@ def describe_thing_type(thingTypeName,
     .. code-block:: bash
 
         salt myminion boto_iot.describe_thing_type mythingtype
+
+    .. versionadded:: Carbon
 
     '''
     try:
@@ -186,6 +190,8 @@ def create_thing_type(thingTypeName, thingTypeDescription,
 
         salt myminion boto_iot.create_thing_type mythingtype \\
               thingtype_description_string '["searchable_attr_1", "searchable_attr_2"]'
+
+    .. versionadded:: Carbon
 
     '''
 
@@ -226,6 +232,8 @@ def deprecate_thing_type(thingTypeName, undoDeprecate=False,
 
         salt myminion boto_iot.deprecate_thing_type mythingtype
 
+    .. versionadded:: Carbon
+
     '''
 
     try:
@@ -253,6 +261,8 @@ def delete_thing_type(thingTypeName,
     .. code-block:: bash
 
         salt myminion boto_iot.delete_thing_type mythingtype
+
+    .. versionadded:: Carbon
 
     '''
 

--- a/salt/states/boto_iot.py
+++ b/salt/states/boto_iot.py
@@ -121,6 +121,9 @@ def thing_type_present(name, thingTypeName, thingTypeDescription,
     profile
         A dict with region, key, keyid, or a pillar key (string) that
         contains a dict with region, key, and keyid
+
+    .. versionadded:: Carbon
+
     '''
     ret = {
         'name': thingTypeName,
@@ -194,6 +197,9 @@ def thing_type_absent(name, thingTypeName,
     profile
         A dict with region, key and keyid, or a pillar key (string) that
         contains a dict with region, key and keyid.
+
+    .. versionadded:: Carbon
+
     '''
 
     ret = {'name': thingTypeName,

--- a/salt/states/boto_iot.py
+++ b/salt/states/boto_iot.py
@@ -72,6 +72,8 @@ from __future__ import absolute_import
 import logging
 import os
 import os.path
+import datetime
+import time
 import json
 
 # Import Salt Libs
@@ -86,6 +88,200 @@ def __virtual__():
     Only load if boto is available.
     '''
     return 'boto_iot' if 'boto_iot.policy_exists' in __salt__ else False
+
+
+def thing_type_present(name, thingTypeName, thingTypeDescription,
+    searchableAttributesList,
+    region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure thing type exists.
+
+    name
+        The name of the state definition
+
+    thingTypeName
+        Name of the thing type
+
+    thingTypeDescription
+        Description of the thing type
+
+    searchableAttributesList
+        List of string attributes that are searchable for
+        the thing type
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used
+
+    profile
+        A dict with region, key, keyid, or a pillar key (string) that
+        contains a dict with region, key, and keyid
+    '''
+    ret = {
+        'name': thingTypeName,
+        'result': True,
+        'comment': '',
+        'changes': {}
+    }
+
+    r = __salt__['boto_iot.thing_type_exists'](
+            thingTypeName=thingTypeName,
+            region=region, key=key, keyid=keyid, profile=profile
+    )
+
+    if 'error' in r:
+        ret['result'] = False
+        ret['comment'] = 'Failed to create thing type: {0}.'.format(r['error']['message'])
+        return ret
+
+    if r.get('exists'):
+        ret['result'] = True
+        ret['comment'] = 'Thing type with given name {0} already exists'.format(thingTypeName)
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'Thing type {0} is set to be created.'.format(thingTypeName)
+        ret['result'] = None
+        return ret
+
+    r = __salt__['boto_iot.create_thing_type'](
+            thingTypeName=thingTypeName,
+            thingTypeDescription=thingTypeDescription,
+            searchableAttributesList=searchableAttributesList,
+            region=region, key=key, keyid=keyid, profile=profile
+    )
+
+    if not r.get('created'):
+        ret['result'] = False
+        ret['comment'] = 'Failed to create thing type: {0}.'.format(r['error']['message'])
+        return ret
+
+    _describe = __salt__['boto_iot.describe_thing_type'](
+        thingTypeName=thingTypeName,
+        region=region, key=key, keyid=keyid, profile=profile
+    )
+    ret['changes']['old'] = {'thing_type': None}
+    ret['changes']['new'] = _describe
+    ret['comment'] = 'Thing Type {0} created.'.format(thingTypeName)
+    return ret
+
+
+def thing_type_absent(name, thingTypeName,
+                  region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure thing type with passed properties is absent.
+
+    name
+        The name of the state definition.
+
+    thingTypeName
+        Name of the thing type.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+    '''
+
+    ret = {'name': thingTypeName,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    _describe = __salt__['boto_iot.describe_thing_type'](
+        thingTypeName=thingTypeName,
+        region=region, key=key, keyid=keyid, profile=profile
+    )
+    if 'error' in _describe:
+        ret['result'] = False
+        ret['comment'] = 'Failed to delete thing type: {0}.'.format(_describe['error']['message'])
+        return ret
+
+    if _describe and not _describe['thing_type']:
+        ret['comment'] = 'Thing Type {0} does not exist.'.format(thingTypeName)
+        return ret
+
+    _existing_thing_type = _describe['thing_type']
+    _thing_type_metadata = _existing_thing_type.get('thingTypeMetadata')
+    _deprecated = _thing_type_metadata.get('deprecated', False)
+
+    if __opts__['test']:
+        if _deprecated:
+            _change_desc = 'removed'
+        else:
+            _change_desc = 'deprecated and removed'
+        ret['comment'] = 'Thing Type {0} is set to be {1}.'.format(thingTypeName, _change_desc)
+        ret['result'] = None
+        return ret
+
+    # initialize a delete_wait_timer to be 5 minutes
+    # AWS does not allow delete thing type until 5 minutes
+    # after a thing type is marked deprecated.
+    _delete_wait_timer = 300
+
+    if _deprecated is False:
+        _deprecate = __salt__['boto_iot.deprecate_thing_type'](
+            thingTypeName=thingTypeName,
+            undoDeprecate=False,
+            region=region, key=key, keyid=keyid, profile=profile
+        )
+        if 'error' in _deprecate:
+            ret['result'] = False
+            ret['comment'] = 'Failed to deprecate thing type: {0}.'.format(_deprecate['error']['message'])
+            return ret
+    else:
+        # grab the deprecation date string from _thing_type_metadata
+        _deprecation_date_str = _thing_type_metadata.get('deprecationDate')
+        if _deprecation_date_str:
+            # see if we can wait less than 5 minutes
+            _tz_index = _deprecation_date_str.find('+')
+            if _tz_index != -1:
+                _deprecation_date_str = _deprecation_date_str[:_tz_index]
+
+            _deprecation_date = datetime.datetime.strptime(
+                _deprecation_date_str,
+                "%Y-%m-%d %H:%M:%S.%f"
+            )
+
+            _elapsed_time_delta = datetime.datetime.utcnow() - _deprecation_date
+            if _elapsed_time_delta.seconds >= 300:
+                _delete_wait_timer = 0
+            else:
+                _delete_wait_timer = 300 - _elapsed_time_delta.seconds
+
+    # wait required 5 minutes since deprecation time
+    if _delete_wait_timer:
+        log.warning('wait for {0} seconds per AWS (5 minutes after deprecation time) '
+                 'before we can delete iot thing type'.format(_delete_wait_timer))
+        time.sleep(_delete_wait_timer)
+
+    # delete thing type
+    r = __salt__['boto_iot.delete_thing_type'](
+            thingTypeName=thingTypeName,
+            region=region, key=key, keyid=keyid, profile=profile
+    )
+    if not r['deleted']:
+        ret['result'] = False
+        ret['comment'] = 'Failed to delete thing type: {0}.'.format(r['error']['message'])
+        return ret
+    ret['changes']['old'] = _describe
+    ret['changes']['new'] = {'thing_type': None}
+    ret['comment'] = 'Thing Type {0} deleted.'.format(thingTypeName)
+    return ret
 
 
 def policy_present(name, policyName, policyDocument,

--- a/tests/unit/modules/boto_iot_test.py
+++ b/tests/unit/modules/boto_iot_test.py
@@ -32,6 +32,7 @@ try:
     import boto
     import boto3
     from botocore.exceptions import ClientError
+    from botocore import __version__ as found_botocore_version
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
@@ -42,6 +43,7 @@ except ImportError:
 # which was added in boto 2.8.0
 # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
 required_boto3_version = '1.2.1'
+required_botocore_version = '1.4.41'
 
 log = logging.getLogger(__name__)
 
@@ -63,8 +65,11 @@ def _has_required_boto():
         return False
     elif LooseVersion(boto3.__version__) < LooseVersion(required_boto3_version):
         return False
+    elif LooseVersion(found_botocore_version) < LooseVersion(required_botocore_version):
+        return False
     else:
         return True
+
 
 if _has_required_boto():
     region = 'us-east-1'
@@ -102,6 +107,26 @@ if _has_required_boto():
                       actions=[{'lambda': {'functionArn': 'arn:aws:::function'}}],
                       ruleDisabled=True)
 
+    thing_type_name = 'test_thing_type'
+    thing_type_desc = 'test_thing_type_desc'
+    thing_type_attr_1 = 'test_thing_type_search_attr_1'
+    thing_type_ret = dict(
+        thingTypeName=thing_type_name,
+        thingTypeProperties=dict(
+            thingTypeDescription=thing_type_desc,
+            searchableAttributes=[thing_type_attr_1],
+        ),
+        thingTypeMetadata=dict(
+            deprecated=False,
+            creationDate='test_thing_type_create_date'
+        )
+    )
+    thing_type_arn = 'test_thing_type_arn'
+    create_thing_type_ret = dict(
+        thingTypeName=thing_type_name,
+        thingTypeArn=thing_type_arn
+    )
+
 
 class BotoIoTTestCaseBase(TestCase):
     conn = None
@@ -130,8 +155,140 @@ class BotoIoTTestCaseMixin(object):
 
 @skipIf(HAS_BOTO is False, 'The boto module must be installed.')
 @skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
-                                       ' or equal to version {0}'
-        .format(required_boto3_version))
+                                       ' or equal to version {0}.  The botocore'
+                                       ' module must be greater than or equal to'
+                                       ' version {1}.'
+        .format(required_boto3_version, required_botocore_version))
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class BotoIoTThingTypeTestCase(BotoIoTTestCaseBase, BotoIoTTestCaseMixin):
+    '''
+    TestCase for salt.modules.boto_iot module
+    '''
+
+    def test_that_when_checking_if_a_thing_type_exists_and_a_thing_type_exists_the_thing_type_exists_method_returns_true(self):
+        '''
+        Tests checking iot thing type existence when the iot thing type already exists
+        '''
+        self.conn.describe_thing_type.return_value = thing_type_ret
+        result = boto_iot.thing_type_exists(thingTypeName=thing_type_name, **conn_parameters)
+
+        self.assertTrue(result['exists'])
+
+    def test_that_when_checking_if_a_thing_type_exists_and_a_thing_type_does_not_exist_the_thing_type_exists_method_returns_false(self):
+        '''
+        Tests checking iot thing type existence when the iot thing type does not exist
+        '''
+        self.conn.describe_thing_type.side_effect = not_found_error
+        result = boto_iot.thing_type_exists(thingTypeName='non existent thing type', **conn_parameters)
+
+        self.assertFalse(result['exists'])
+
+    def test_that_when_checking_if_a_thing_type_exists_and_boto3_returns_an_error_the_thing_type_exists_method_returns_error(self):
+        '''
+        Tests checking iot thing type existence when boto returns an error
+        '''
+        self.conn.describe_thing_type.side_effect = ClientError(error_content, 'describe_thing_type')
+        result = boto_iot.thing_type_exists(thingTypeName='mythingtype', **conn_parameters)
+
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('describe_thing_type'))
+
+    def test_that_when_describing_thing_type_and_thing_type_exists_the_describe_thing_type_method_returns_thing_type(self):
+        '''
+        Tests describe thing type for an existing thing type
+        '''
+        self.conn.describe_thing_type.return_value = thing_type_ret
+        result = boto_iot.describe_thing_type(thingTypeName=thing_type_name, **conn_parameters)
+
+        self.assertEqual(result.get('thing_type'), thing_type_ret)
+
+    def test_that_when_describing_thing_type_and_thing_type_does_not_exists_the_describe_thing_type_method_returns_none(self):
+        '''
+        Tests describe thing type for an non existent thing type
+        '''
+        self.conn.describe_thing_type.side_effect = not_found_error
+        result = boto_iot.describe_thing_type(thingTypeName='non existent thing type', **conn_parameters)
+
+        self.assertEqual(result.get('thing_type'), None)
+
+    def test_that_when_describing_thing_type_and_boto3_returns_error_an_error_the_describe_thing_type_method_returns_error(self):
+        self.conn.describe_thing_type.side_effect = ClientError(error_content, 'describe_thing_type')
+        result = boto_iot.describe_thing_type(thingTypeName='mythingtype', **conn_parameters)
+
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('describe_thing_type'))
+
+    def test_that_when_creating_a_thing_type_succeeds_the_create_thing_type_method_returns_true(self):
+        '''
+        tests True when thing type created
+        '''
+        self.conn.create_thing_type.return_value = create_thing_type_ret
+        result = boto_iot.create_thing_type(thingTypeName=thing_type_name,
+                                            thingTypeDescription=thing_type_desc,
+                                            searchableAttributesList=[thing_type_attr_1],
+                                            **conn_parameters)
+        self.assertTrue(result['created'])
+        self.assertTrue(result['thingTypeArn'], thing_type_arn)
+
+    def test_that_when_creating_a_thing_type_fails_the_create_thing_type_method_returns_error(self):
+        '''
+        tests False when thing type not created
+        '''
+        self.conn.create_thing_type.side_effect = ClientError(error_content, 'create_thing_type')
+        result = boto_iot.create_thing_type(thingTypeName=thing_type_name,
+                                            thingTypeDescription=thing_type_desc,
+                                            searchableAttributesList=[thing_type_attr_1],
+                                            **conn_parameters)
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('create_thing_type'))
+
+    def test_that_when_deprecating_a_thing_type_succeeds_the_deprecate_thing_type_method_returns_true(self):
+        '''
+        tests True when deprecate thing type succeeds
+        '''
+        self.conn.deprecate_thing_type.return_value = {}
+        result = boto_iot.deprecate_thing_type(thingTypeName=thing_type_name,
+                                               undoDeprecate=False,
+                                               **conn_parameters)
+
+        self.assertTrue(result.get('deprecated'))
+        self.assertEqual(result.get('error'), None)
+
+    def test_that_when_deprecating_a_thing_type_fails_the_deprecate_thing_type_method_returns_error(self):
+        '''
+        tests False when thing type fails to deprecate
+        '''
+        self.conn.deprecate_thing_type.side_effect = ClientError(error_content, 'deprecate_thing_type')
+        result = boto_iot.deprecate_thing_type(thingTypeName=thing_type_name,
+                                               undoDeprecate=False,
+                                               **conn_parameters)
+
+        self.assertFalse(result.get('deprecated'))
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('deprecate_thing_type'))
+
+    def test_that_when_deleting_a_thing_type_succeeds_the_delete_thing_type_method_returns_true(self):
+        '''
+        tests True when delete thing type succeeds
+        '''
+        self.conn.delete_thing_type.return_value = {}
+        result = boto_iot.delete_thing_type(thingTypeName=thing_type_name, **conn_parameters)
+
+        self.assertTrue(result.get('deleted'))
+        self.assertEqual(result.get('error'), None)
+
+    def test_that_when_deleting_a_thing_type_fails_the_delete_thing_type_method_returns_error(self):
+        '''
+        tests False when delete thing type fails
+        '''
+        self.conn.delete_thing_type.side_effect = ClientError(error_content, 'delete_thing_type')
+        result = boto_iot.delete_thing_type(thingTypeName=thing_type_name, **conn_parameters)
+        self.assertFalse(result.get('deleted'))
+        self.assertEqual(result.get('error', {}).get('message'), error_message.format('delete_thing_type'))
+
+
+@skipIf(HAS_BOTO is False, 'The boto module must be installed.')
+@skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
+                                       ' or equal to version {0}.  The botocore'
+                                       ' module must be greater than or equal to'
+                                       ' version {1}.'
+        .format(required_boto3_version, required_botocore_version))
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class BotoIoTPolicyTestCase(BotoIoTTestCaseBase, BotoIoTTestCaseMixin):
     '''
@@ -481,8 +638,10 @@ class BotoIoTPolicyTestCase(BotoIoTTestCaseBase, BotoIoTTestCaseMixin):
 
 @skipIf(HAS_BOTO is False, 'The boto module must be installed.')
 @skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
-                                       ' or equal to version {0}'
-        .format(required_boto3_version))
+                                       ' or equal to version {0}.  The botocore'
+                                       ' module must be greater than or equal to'
+                                       ' version {1}.'
+        .format(required_boto3_version, required_botocore_version))
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class BotoIoTTopicRuleTestCase(BotoIoTTestCaseBase, BotoIoTTestCaseMixin):
     '''

--- a/tests/unit/states/boto_iot_test.py
+++ b/tests/unit/states/boto_iot_test.py
@@ -32,6 +32,7 @@ try:
     import boto
     import boto3
     from botocore.exceptions import ClientError
+    from botocore import __version__ as found_botocore_version
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
@@ -42,6 +43,7 @@ except ImportError:
 # which was added in boto 2.8.0
 # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
 required_boto3_version = '1.2.1'
+required_botocore_version = '1.4.41'
 
 log = logging.getLogger(__name__)
 
@@ -61,6 +63,8 @@ def _has_required_boto():
     if not HAS_BOTO:
         return False
     elif LooseVersion(boto3.__version__) < LooseVersion(required_boto3_version):
+        return False
+    elif LooseVersion(found_botocore_version) < LooseVersion(required_botocore_version):
         return False
     else:
         return True
@@ -102,6 +106,38 @@ if _has_required_boto():
                       ruleDisabled=True)
     principal = 'arn:aws:iot:us-east-1:1234:cert/21fc104aaaf6043f5756c1b57bda84ea8395904c43f28517799b19e4c42514'
 
+    thing_type_name = 'test_thing_type'
+    thing_type_desc = 'test_thing_type_desc'
+    thing_type_attr_1 = 'test_thing_type_search_attr_1'
+    thing_type_ret = dict(
+        thingTypeName=thing_type_name,
+        thingTypeProperties=dict(
+            thingTypeDescription=thing_type_desc,
+            searchableAttributes=[thing_type_attr_1],
+        ),
+        thingTypeMetadata=dict(
+            deprecated=False,
+            creationDate='2010-08-01 15:54:49.699000+00:00'
+        )
+    )
+    deprecated_thing_type_ret = dict(
+        thingTypeName=thing_type_name,
+        thingTypeProperties=dict(
+            thingTypeDescription=thing_type_desc,
+            searchableAttributes=[thing_type_attr_1],
+        ),
+        thingTypeMetadata=dict(
+            deprecated=True,
+            creationDate='2010-08-01 15:54:49.699000+00:00',
+            deprecationDate='2010-08-02 15:54:49.699000+00:00'
+        )
+    )
+    thing_type_arn = 'test_thing_type_arn'
+    create_thing_type_ret = dict(
+        thingTypeName=thing_type_name,
+        thingTypeArn=thing_type_arn
+    )
+
 
 class BotoIoTStateTestCaseBase(TestCase):
     conn = None
@@ -125,8 +161,103 @@ class BotoIoTStateTestCaseBase(TestCase):
 
 @skipIf(HAS_BOTO is False, 'The boto module must be installed.')
 @skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
-                                       ' or equal to version {0}'
-        .format(required_boto3_version))
+                                       ' or equal to version {0}.  The botocore'
+                                       ' module must be greater than or equal to'
+                                       ' version {1}.'
+        .format(required_boto3_version, required_botocore_version))
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class BotoIoTThingTypeTestCase(BotoIoTStateTestCaseBase, BotoIoTTestCaseMixin):
+    '''
+    TestCase for salt.modules.boto_iot state.module
+    '''
+
+    def test_present_when_thing_type_does_not_exist(self):
+        '''
+        tests present on a thing type that does not exist.
+        '''
+        self.conn.describe_thing_type.side_effect = [not_found_error, thing_type_ret]
+        self.conn.create_thing_type.return_value = create_thing_type_ret
+        result = salt_states['boto_iot.thing_type_present'](
+            'thing type present',
+            thingTypeName=thing_type_name,
+            thingTypeDescription=thing_type_desc,
+            searchableAttributesList=[thing_type_attr_1],
+            **conn_parameters
+        )
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes']['new']['thing_type']['thingTypeName'],
+                         thing_type_name)
+
+    def test_present_when_thing_type_exists(self):
+        self.conn.describe_thing_type.return_value = thing_type_ret
+        result = salt_states['boto_iot.thing_type_present'](
+            'thing type present',
+            thingTypeName=thing_type_name,
+            thingTypeDescription=thing_type_desc,
+            searchableAttributesList=[thing_type_attr_1],
+            **conn_parameters
+        )
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes'], {})
+        self.conn.create_thing_type.assert_not_called()
+
+    def test_present_with_failure(self):
+        self.conn.describe_thing_type.side_effect = [not_found_error, thing_type_ret]
+        self.conn.create_thing_type.side_effect = ClientError(error_content, 'create_thing_type')
+        result = salt_states['boto_iot.thing_type_present'](
+            'thing type present',
+            thingTypeName=thing_type_name,
+            thingTypeDescription=thing_type_desc,
+            searchableAttributesList=[thing_type_attr_1],
+            **conn_parameters
+        )
+        self.assertFalse(result['result'])
+        self.assertTrue('An error occurred' in result['comment'])
+
+    def test_absent_when_thing_type_does_not_exist(self):
+        '''
+        Tests absent on a thing type does not exist
+        '''
+        self.conn.describe_thing_type.side_effect = not_found_error
+        result = salt_states['boto_iot.thing_type_absent']('test', 'mythingtype', **conn_parameters)
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes'], {})
+
+    def test_absent_when_thing_type_exists(self):
+        '''
+        Tests absent on a thing type
+        '''
+        self.conn.describe_thing_type.return_value = deprecated_thing_type_ret
+        result = salt_states['boto_iot.thing_type_absent']('test', thing_type_name, **conn_parameters)
+        self.assertTrue(result['result'])
+        self.assertEqual(result['changes']['new']['thing_type'], None)
+        self.conn.deprecate_thing_type.assert_not_called()
+
+    def test_absent_with_deprecate_failure(self):
+        self.conn.describe_thing_type.return_value = thing_type_ret
+        self.conn.deprecate_thing_type.side_effect = ClientError(error_content, 'deprecate_thing_type')
+        result = salt_states['boto_iot.thing_type_absent']('test', thing_type_name, **conn_parameters)
+        self.assertFalse(result['result'])
+        self.assertTrue('An error occurred' in result['comment'])
+        self.assertTrue('deprecate_thing_type' in result['comment'])
+        self.conn.delete_thing_type.assert_not_called()
+
+    def test_absent_with_delete_failure(self):
+        self.conn.describe_thing_type.return_value = deprecated_thing_type_ret
+        self.conn.delete_thing_type.side_effect = ClientError(error_content, 'delete_thing_type')
+        result = salt_states['boto_iot.thing_type_absent']('test', thing_type_name, **conn_parameters)
+        self.assertFalse(result['result'])
+        self.assertTrue('An error occurred' in result['comment'])
+        self.assertTrue('delete_thing_type' in result['comment'])
+        self.conn.deprecate_thing_type.assert_not_called()
+
+
+@skipIf(HAS_BOTO is False, 'The boto module must be installed.')
+@skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
+                                       ' or equal to version {0}.  The botocore'
+                                       ' module must be greater than or equal to'
+                                       ' version {1}.'
+        .format(required_boto3_version, required_botocore_version))
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class BotoIoTPolicyTestCase(BotoIoTStateTestCaseBase, BotoIoTTestCaseMixin):
     '''
@@ -252,8 +383,10 @@ class BotoIoTPolicyTestCase(BotoIoTStateTestCaseBase, BotoIoTTestCaseMixin):
 
 @skipIf(HAS_BOTO is False, 'The boto module must be installed.')
 @skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
-                                       ' or equal to version {0}'
-        .format(required_boto3_version))
+                                       ' or equal to version {0}.  The botocore'
+                                       ' module must be greater than or equal to'
+                                       ' version {1}.'
+        .format(required_boto3_version, required_botocore_version))
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class BotoIoTTopicRuleTestCase(BotoIoTStateTestCaseBase, BotoIoTTestCaseMixin):
     '''


### PR DESCRIPTION
### What does this PR do?

added supporting execution and state module functions to deal with aws iot thing types, which was introduced in botocore 1.4.41.
### What issues does this PR fix or reference?

see title, it is an enhancement to something new that AWS introduced in botocore 1.4.41 wrt aws iot.
### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.