### PR TITLE
PY3: Fix some string encoding problems in shell integration tests

### DIFF
--- a/tests/integration/shell/master.py
+++ b/tests/integration/shell/master.py
@@ -20,6 +20,7 @@ ensure_in_syspath('../../')
 
 # Import salt libs
 import integration
+import integration.utils
 from integration.utils import testprogram
 import salt.utils
 
@@ -99,7 +100,8 @@ class MasterTest(integration.ShellCase, testprogram.TestProgramCase, integration
         self.assert_exit_status(
             status, 'EX_NOUSER',
             message='unknown user not on system',
-            stdout=stdout, stderr=stderr
+            stdout=stdout,
+            stderr=integration.utils.decode_byte_list(stderr)
         )
         # master.shutdown() should be unnecessary since the start-up should fail
 
@@ -123,7 +125,8 @@ class MasterTest(integration.ShellCase, testprogram.TestProgramCase, integration
         self.assert_exit_status(
             status, 'EX_USAGE',
             message='unknown argument',
-            stdout=stdout, stderr=stderr
+            stdout=stdout,
+            stderr=integration.utils.decode_byte_list(stderr)
         )
         # master.shutdown() should be unnecessary since the start-up should fail
 
@@ -146,7 +149,8 @@ class MasterTest(integration.ShellCase, testprogram.TestProgramCase, integration
         self.assert_exit_status(
             status, 'EX_OK',
             message='correct usage',
-            stdout=stdout, stderr=stderr
+            stdout=stdout,
+            stderr=integration.utils.decode_byte_list(stderr)
         )
         master.shutdown()
 

--- a/tests/integration/shell/minion.py
+++ b/tests/integration/shell/minion.py
@@ -25,6 +25,7 @@ ensure_in_syspath('../../')
 
 # Import salt libs
 import integration
+import integration.utils
 from integration.utils import testprogram
 import salt.ext.six as six
 import salt.utils
@@ -249,7 +250,7 @@ class MinionTest(integration.ShellCase, testprogram.TestProgramCase, integration
             # Verify that PIDs match
             mpids = {}
             for line in ret[0]:
-                segs = line.split()
+                segs = line.decode(__salt_system_encoding__).split()
                 minfo = segs[0].split(':')
                 mpids[minfo[-1]] = int(segs[-1]) if segs[-1].isdigit() else None
             for minion in minions:
@@ -294,7 +295,7 @@ class MinionTest(integration.ShellCase, testprogram.TestProgramCase, integration
             status, 'EX_NOUSER',
             message='unknown user not on system',
             stdout=stdout,
-            stderr=stderr[0].decode(__salt_system_encoding__)
+            stderr=integration.utils.decode_byte_list(stderr)
         )
         # minion.shutdown() should be unnecessary since the start-up should fail
 
@@ -319,7 +320,7 @@ class MinionTest(integration.ShellCase, testprogram.TestProgramCase, integration
             status, 'EX_USAGE',
             message='unknown argument',
             stdout=stdout,
-            stderr=stderr[0].decode(__salt_system_encoding__)
+            stderr=integration.utils.decode_byte_list(stderr)
         )
         # minion.shutdown() should be unnecessary since the start-up should fail
 

--- a/tests/integration/shell/minion.py
+++ b/tests/integration/shell/minion.py
@@ -26,8 +26,8 @@ ensure_in_syspath('../../')
 # Import salt libs
 import integration
 from integration.utils import testprogram
+import salt.ext.six as six
 import salt.utils
-
 
 log = logging.getLogger(__name__)
 
@@ -125,6 +125,13 @@ class MinionTest(integration.ShellCase, testprogram.TestProgramCase, integration
             log.debug('script: salt-minion: stderr: {0}'.format(line))
         log.debug('exit status: {0}'.format(ret[2]))
 
+        if six.PY3:
+            std_out = b'\nSTDOUT:'.join(ret[0])
+            std_err = b'\nSTDERR:'.join(ret[1])
+        else:
+            std_out = '\nSTDOUT:'.join(ret[0])
+            std_err = '\nSTDERR:'.join(ret[1])
+
         # Check minion state
         for minion in minions:
             self.assertEqual(
@@ -134,8 +141,8 @@ class MinionTest(integration.ShellCase, testprogram.TestProgramCase, integration
                     action,
                     minion.name,
                     ["stopped", "running"][minion_running],
-                    '\nSTDOUT:'.join(ret[0]),
-                    '\nSTDERR:'.join(ret[1]),
+                    std_out,
+                    std_err,
                 )
             )
 
@@ -148,8 +155,8 @@ class MinionTest(integration.ShellCase, testprogram.TestProgramCase, integration
                     message,
                     ret[2],
                     exitstatus,
-                    '\nSTDOUT:'.join(ret[0]),
-                    '\nSTDERR:'.join(ret[1]),
+                    std_out,
+                    std_err,
                 )
             )
         return ret
@@ -286,7 +293,8 @@ class MinionTest(integration.ShellCase, testprogram.TestProgramCase, integration
         self.assert_exit_status(
             status, 'EX_NOUSER',
             message='unknown user not on system',
-            stdout=stdout, stderr=stderr
+            stdout=stdout,
+            stderr=stderr[0].decode(__salt_system_encoding__)
         )
         # minion.shutdown() should be unnecessary since the start-up should fail
 
@@ -310,7 +318,8 @@ class MinionTest(integration.ShellCase, testprogram.TestProgramCase, integration
         self.assert_exit_status(
             status, 'EX_USAGE',
             message='unknown argument',
-            stdout=stdout, stderr=stderr
+            stdout=stdout,
+            stderr=stderr[0].decode(__salt_system_encoding__)
         )
         # minion.shutdown() should be unnecessary since the start-up should fail
 

--- a/tests/integration/shell/proxy.py
+++ b/tests/integration/shell/proxy.py
@@ -16,6 +16,7 @@ ensure_in_syspath('../../')
 
 # Import salt libs
 import integration
+import integration.utils
 from integration.utils import testprogram
 
 log = logging.getLogger(__name__)
@@ -49,7 +50,8 @@ class ProxyTest(testprogram.TestProgramCase):
         self.assert_exit_status(
             status, 'EX_USAGE',
             message='no --proxyid specified',
-            stdout=stdout, stderr=stderr
+            stdout=stdout,
+            stderr=integration.utils.decode_byte_list(stderr)
         )
         # proxy.shutdown() should be unnecessary since the start-up should fail
 
@@ -73,7 +75,8 @@ class ProxyTest(testprogram.TestProgramCase):
         self.assert_exit_status(
             status, 'EX_NOUSER',
             message='unknown user not on system',
-            stdout=stdout, stderr=stderr
+            stdout=stdout,
+            stderr=integration.utils.decode_byte_list(stderr)
         )
         # proxy.shutdown() should be unnecessary since the start-up should fail
 
@@ -120,7 +123,8 @@ class ProxyTest(testprogram.TestProgramCase):
         self.assert_exit_status(
             status, 'EX_OK',
             message='correct usage',
-            stdout=stdout, stderr=stderr
+            stdout=stdout,
+            stderr=integration.utils.decode_byte_list(stderr)
         )
         proxy.shutdown()
 

--- a/tests/integration/utils/__init__.py
+++ b/tests/integration/utils/__init__.py
@@ -1,1 +1,16 @@
 # -*- coding: utf-8 -*-
+'''
+Some utils functions to be used throughout the integration test files.
+'''
+
+
+def decode_byte_list(byte_list):
+    '''
+    Helper function that takes a list of byte strings and decodes each item
+    according to the __salt_system_encoding__ value. Returns a list of strings.
+    '''
+    decoded_items = []
+    for item in byte_list:
+        decoded_items.append(item.decode(__salt_system_encoding__))
+
+    return decoded_items


### PR DESCRIPTION
### What does this PR do?

Fixes some byte string issues in some of the shell integration test files. This allows these tests to pass when running them with either Python 2 or 3. 

These test files rely largely on the classes defined in `tests/integration/utils/testprogram.py`, which is why all of these encoding changes take place in test files rather than non-testing salt files.