### PR TITLE
Add runner return data to job cache

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -1010,3 +1010,5 @@
 ############################################
 # Default match type for filtering events tags: startswith, endswith, find, regex, fnmatch
 #event_match_type: startswith
+# Save runner returns to the job cache
+#runner_returns: False

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -493,7 +493,7 @@ local job cache on the master.
 Default: ``''``
 
 Specify the returner(s) to use to log events. Each returner may have
-installation and configuration requirements. Read the returner's 
+installation and configuration requirements. Read the returner's
 documentation.
 
 .. note::
@@ -503,7 +503,7 @@ documentation.
 
 .. code-block:: yaml
 
-    event_return: 
+    event_return:
       - syslog
       - splunk
 
@@ -1265,6 +1265,20 @@ or just post what changes are going to be made.
 .. code-block:: yaml
 
     test: False
+
+.. conf_master:: runner_returns
+
+``runner_returns``
+------------------
+
+Default: ``False``
+
+If set to ``True``, runner jobs will be saved to job cache (defined by
+:conf_master:`master_job_cache`).
+
+.. code-block:: yaml
+
+    runner_returns: True
 
 Master File Server Settings
 ===========================

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -674,6 +674,9 @@ VALID_OPTS = {
     # Defines engines. See https://docs.saltstack.com/en/latest/topics/engines/
     'engines': list,
 
+    # Whether or not to store runner returns in the job cache
+    'runner_returns': bool,
+
     'serial': str,
     'search': str,
 
@@ -1289,6 +1292,7 @@ DEFAULT_MASTER_OPTS = {
     'event_return_whitelist': [],
     'event_return_blacklist': [],
     'event_match_type': 'startswith',
+    'runner_returns': False,
     'serial': 'msgpack',
     'state_verbose': True,
     'state_output': 'full',

--- a/salt/returners/couchbase_return.py
+++ b/salt/returners/couchbase_return.py
@@ -200,7 +200,7 @@ def save_load(jid, clear_load, minion=None):
     cb_.replace(str(jid), jid_doc.value, cas=jid_doc.cas, ttl=_get_ttl())
 
     # if you have a tgt, save that for the UI etc
-    if 'tgt' in clear_load:
+    if 'tgt' in clear_load and clear_load['tgt'] != '':
         ckminions = salt.utils.minions.CkMinions(__opts__)
         # Retrieve the minions list
         minions = ckminions.check_minions(

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -233,7 +233,7 @@ def save_load(jid, clear_load, minions=None, recurse_count=0):
                          recurse_count=recurse_count+1)
 
     # if you have a tgt, save that for the UI etc
-    if 'tgt' in clear_load:
+    if 'tgt' in clear_load and clear_load['tgt'] != '':
         if minions is None:
             ckminions = salt.utils.minions.CkMinions(__opts__)
             # Retrieve the minions list


### PR DESCRIPTION
Resolves #34561.

@thatch45 Since I included documentation for `runner_returns` in the master config docs, and also added to the master config file template, then if we decide to default this option to `True` we will need to modify the documentation and config file template to reflect the change in `salt/config/__init__.py`.