### PR TITLE
Assume two EVRs are equal if E and V are equal but one R is missing.

### DIFF
--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -688,29 +688,28 @@ def version_cmp(ver1, ver2, ignore_epoch=False):
                     'more accurate version comparisons'
                 )
         else:
-            else:
-                # If one EVR is missing a release but not the other and they
-                # otherwise would be equal, assume they are equal. This can
-                # happen if e.g. you are checking if a package version 3.2 is
-                # satisfied by a 3.2-1.
-                (ver1_e, ver1_v, ver1_r) = salt.utils.str_version_to_evr(ver1)
-                (ver2_e, ver2_v, ver2_r) = salt.utils.str_version_to_evr(ver2)
-                if not ver1_r or not ver2_r:
-                    tmp_cmp = cmp_func((ver1_e, ver1_v, ''), (ver2_e, ver2_v, ''))
-                    if tmp_cmp not in (-1, 0, 1):
-                        raise CommandExecutionError(
-                            'Comparison result \'{0}\' is invalid'.format(tmp_cmp)
-                        )
-                    if tmp_cmp == 0:
-                        return 0
-
-                cmp_result = cmp_func((ver1_e, ver1_v, ver1_r),
-                                      (ver2_e, ver2_v, ver2_r))
-                if cmp_result not in (-1, 0, 1):
+            # If one EVR is missing a release but not the other and they
+            # otherwise would be equal, assume they are equal. This can
+            # happen if e.g. you are checking if a package version 3.2 is
+            # satisfied by a 3.2-1.
+            (ver1_e, ver1_v, ver1_r) = salt.utils.str_version_to_evr(ver1)
+            (ver2_e, ver2_v, ver2_r) = salt.utils.str_version_to_evr(ver2)
+            if not ver1_r or not ver2_r:
+                tmp_cmp = cmp_func((ver1_e, ver1_v, ''), (ver2_e, ver2_v, ''))
+                if tmp_cmp not in (-1, 0, 1):
                     raise CommandExecutionError(
-                        'Comparison result \'{0}\' is invalid'.format(cmp_result)
+                        'Comparison result \'{0}\' is invalid'.format(tmp_cmp)
                     )
-                return cmp_result
+                if tmp_cmp == 0:
+                    return 0
+
+            cmp_result = cmp_func((ver1_e, ver1_v, ver1_r),
+                                  (ver2_e, ver2_v, ver2_r))
+            if cmp_result not in (-1, 0, 1):
+                raise CommandExecutionError(
+                    'Comparison result \'{0}\' is invalid'.format(cmp_result)
+                )
+            return cmp_result
 
     except Exception as exc:
         log.warning(

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -688,14 +688,29 @@ def version_cmp(ver1, ver2, ignore_epoch=False):
                     'more accurate version comparisons'
                 )
         else:
-            cmp_result = cmp_func(salt.utils.str_version_to_evr(ver1),
-                                  salt.utils.str_version_to_evr(ver2))
-            if cmp_result not in (-1, 0, 1):
-                raise CommandExecutionError(
-                    'Comparison result \'{0}\' is invalid'.format(cmp_result)
-                )
+            else:
+                # If one EVR is missing a release but not the other and they
+                # otherwise would be equal, assume they are equal. This can
+                # happen if e.g. you are checking if a package version 3.2 is
+                # satisfied by a 3.2-1.
+                (ver1_e, ver1_v, ver1_r) = salt.utils.str_version_to_evr(ver1)
+                (ver2_e, ver2_v, ver2_r) = salt.utils.str_version_to_evr(ver2)
+                if not ver1_r or not ver2_r:
+                    tmp_cmp = cmp_func((ver1_e, ver1_v, ''), (ver2_e, ver2_v, ''))
+                    if tmp_cmp not in (-1, 0, 1):
+                        raise CommandExecutionError(
+                            'Comparison result \'{0}\' is invalid'.format(tmp_cmp)
+                        )
+                    if tmp_cmp == 0:
+                        return 0
 
-            return cmp_result
+                cmp_result = cmp_func((ver1_e, ver1_v, ver1_r),
+                                      (ver2_e, ver2_v, ver2_r))
+                if cmp_result not in (-1, 0, 1):
+                    raise CommandExecutionError(
+                        'Comparison result \'{0}\' is invalid'.format(cmp_result)
+                    )
+                return cmp_result
 
     except Exception as exc:
         log.warning(

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -689,19 +689,13 @@ def version_cmp(ver1, ver2, ignore_epoch=False):
                 )
         else:
             # If one EVR is missing a release but not the other and they
-            # otherwise would be equal, assume they are equal. This can
-            # happen if e.g. you are checking if a package version 3.2 is
-            # satisfied by a 3.2-1.
+            # otherwise would be equal, ignore the release. This can happen if
+            # e.g. you are checking if a package version 3.2 is satisfied by
+            # 3.2-1.
             (ver1_e, ver1_v, ver1_r) = salt.utils.str_version_to_evr(ver1)
             (ver2_e, ver2_v, ver2_r) = salt.utils.str_version_to_evr(ver2)
             if not ver1_r or not ver2_r:
-                tmp_cmp = cmp_func((ver1_e, ver1_v, ''), (ver2_e, ver2_v, ''))
-                if tmp_cmp not in (-1, 0, 1):
-                    raise CommandExecutionError(
-                        'Comparison result \'{0}\' is invalid'.format(tmp_cmp)
-                    )
-                if tmp_cmp == 0:
-                    return 0
+                ver1_r = ver2_r = ''
 
             cmp_result = cmp_func((ver1_e, ver1_v, ver1_r),
                                   (ver2_e, ver2_v, ver2_r))


### PR DESCRIPTION
### What does this PR do?

Changes the behavior of RPM version checking such that if one release is missing but they are otherwise equal, assume they are equal. Installed packages will always have a release, but a desired version specification may not, and in that case we should assume the installed version matches the desired version, as yum does.
### What issues does this PR fix or reference?
saltstack/salt#34861
### Previous Behavior

Assume `somepkg-3.2-1` is installed and you want installed `somepkg-3.2`. Previously, `somepkg-3.2-1` would not satisfy `somepkg-3.2` and `3.2` would be slated for install. This would fail because yum considers `3.2` to already satisfy `3.2-1`, and since no changes have been made, the state would fail entirely.
### New Behavior

`somepkg-3.2-1` will satisfy `somepkg-3.2`.
### Tests written?

No