### PR TITLE
The '_handle_event_socket_recv' function in Salt Api is missing first data of stream.

### DIFF
--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -272,13 +272,14 @@ class IPCClient(object):
         else:
             future = tornado.concurrent.Future()
             self._connecting_future = future
-            self.io_loop.add_callback(self._connect, timeout=timeout)
+            self._connect(timeout=timeout)
 
         if callback is not None:
             def handle_future(future):
                 response = future.result()
                 self.io_loop.add_callback(callback, response)
             future.add_done_callback(handle_future)
+
         return future
 
     @tornado.gen.coroutine
@@ -665,14 +666,6 @@ class IPCMessageSubscriber(IPCClient):
 
     @tornado.gen.coroutine
     def _read_async(self, callback):
-        while not self.connected():
-            try:
-                yield self.connect()
-            except tornado.iostream.StreamClosedError:
-                log.trace('Subscriber closed stream on IPC {0} before connect'.format(self.socket_path))
-            except Exception as exc:
-                log.error('Exception occurred while Subscriber connecting: {0}'.format(exc))
-
         while not self.stream.closed():
             try:
                 self._read_stream_future = self.stream.read_bytes(4096, partial=True)
@@ -694,6 +687,14 @@ class IPCMessageSubscriber(IPCClient):
 
         :param callback: A callback with the received data
         '''
+        while not self.connected():
+            try:
+                self.connect()
+            except tornado.iostream.StreamClosedError:
+                log.trace('Subscriber closed stream on IPC {0} before connect'.format(self.socket_path))
+            except Exception as exc:
+                log.error('Exception occurred while Subscriber connecting: {0}'.format(exc))
+
         self.io_loop.spawn_callback(self._read_async, callback)
 
     def close(self):


### PR DESCRIPTION
### What does this PR do?

We fixed a bug that the function `_handle_event_socket_recv` in Salt Api is always missing first data in IOStream of socket. This bug is related with [`read_async` function in `transport/ipc.py`](https://github.com/saltstack/salt/blob/v2016.3.1/salt/transport/ipc.py#L656-L687) and [`_handle_event_socket_recv` in tornado version of Salt Api's `EventListener`](https://github.com/saltstack/salt/blob/v2016.3.1/salt/netapi/rest_tornado/saltnado.py#L314).

A function `read_async` in `transport/ipc.py` is called by a function `set_event_handler` in `utils/event.py` to attach some callback functions, like `_handle_event_socket_recv`, to help handlin Salt data stream. After calling `set_event_handler` to attach the callback functions, the `_read_async` function should subscribe stream and call the callback function.
However, a function [`connect`](https://github.com/saltstack/salt/blob/v2016.3.1/salt/transport/ipc.py#L266-L282) which is called at [`_read_async`](https://github.com/saltstack/salt/blob/v2016.3.1/salt/transport/ipc.py#L660), does not call [`_connect` immediately](https://github.com/saltstack/salt/blob/v2016.3.1/salt/transport/ipc.py#L275). Functions, which are passed to a function `add_callback` in `ioloop` of tornado, will be called at '[next I/O loop iteration](http://www.tornadoweb.org/en/stable/ioloop.html#tornado.ioloop.IOLoop.add_callback)', thus it will triggered after first HTTP request in case of Salt Api.
Because of above call sequences, `_read_async` actually read a stream after first HTTP request. While connecting `IOStream` [in `_read_async`](https://github.com/saltstack/salt/blob/v2016.3.1/salt/transport/ipc.py#L658-L664), the `_read_async` misses a first stream data at least, and it also causes missing a first stream data at `_handle_event_socket_recv`.
Other callback functions, which are attached by calling `read_async`, also potentially have a same problem, but we doesn't analyse the every callback functions. 

After found it, we modified `connect` function to call `_connect` immediately, instead of using `add_callback`, also we modified `read_async` function to call `connect` explicitly before attaching callback functions, instead of waiting tornado's next I/O iteration. And this our modification works very well without missing first data stream. Also we wrote a test case for this issue, and it will fail when run the test case in original Salt (for specifically, version of 2016.3).

However, we are careful about this pull request, because the `connect` function and `read_async` function have been used for other components. Our modification might be a cause of some bad side effects. So after reviewing this pull request, let me know is this a reasonable pull request or not. We are always open to discuss about it.

P.S.
The function `test_simple` and `test_timeout` in `tests/unit/netapi/rest_tornado/test_utils.py` did not work with some exceptions, so I fixed it to work well.
### What issues does this PR fix or reference?
### Previous Behavior

`_handle_event_socket_recv` always had missed first data of stream.
### New Behavior

`_handle_event_socket_recv` doesn't miss first data of stream.
### Tests written?

Yes