### PR TITLE
Properly remove minion_test_issue_2731 key.

### DIFF
--- a/tests/integration/shell/call.py
+++ b/tests/integration/shell/call.py
@@ -183,7 +183,7 @@ class CallTest(integration.ShellCase, testprogram.TestProgramCase, integration.S
 
         master_root_dir = master_config['root_dir']
         this_minion_key = os.path.join(
-            master_root_dir, 'pki', 'minions', 'minion_test_issue_2731'
+            master_root_dir, 'pki', 'master', 'minions', 'minion_test_issue_2731'
         )
 
         minion_config = {


### PR DESCRIPTION
### What does this PR do?

Corrected the minion key path to remove the key properly after the test pass.
### What issues does this PR fix or reference?

Related to #2731.
Fixes a number of integration tests.
### Tests written?

No