### PR TITLE
fixes , causing lots of mayham (onchange) with 2016.3.2 for me

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3519,7 +3519,7 @@ def append(name,
 
     with salt.utils.fopen(name, 'rb') as fp_:
         slines = fp_.readlines()
-        slines = [item.rstrip() for item in slines]
+        slines = [item.rstrip(os.linesep) for item in slines]
 
     append_lines = []
     try:

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3518,8 +3518,7 @@ def append(name,
     text = _validate_str_list(text)
 
     with salt.utils.fopen(name, 'rb') as fp_:
-        slines = fp_.readlines()
-        slines = [item.rstrip(os.linesep) for item in slines]
+        slines = fp_.read().splitlines()
 
     append_lines = []
     try:
@@ -3567,8 +3566,7 @@ def append(name,
         ret['comment'] = 'File {0} is in correct state'.format(name)
 
     with salt.utils.fopen(name, 'rb') as fp_:
-        nlines = fp_.readlines()
-        nlines = [item.rstrip(os.linesep) for item in nlines]
+        nlines = fp_.read().splitlines()
 
     if slines != nlines:
         if not salt.utils.istextfile(name):


### PR DESCRIPTION
### What does this PR do?

nlines and slines were handled differently, handle them the same.

This causes changes to be present if a line ended with a whitespace. In turn causing mayham in my environment due to using onchange resulting in mutliple unneeded service restarts on every state.apply.
### What issues does this PR fix or reference?
saltstack/salt#35121
### Previous Behavior

always changes if a file contained a line that had a whitespace at the end.
### New Behavior

only have changes on well actualy changes
### Tests written?

No
### Affected
- 2015.8 (untested but assumed)
- 2016.3 (.2 and up)
- develop

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.