### PR TITLE
Add missing CLI Examples to aws_sqs module funcs

### DIFF
--- a/salt/modules/aws_sqs.py
+++ b/salt/modules/aws_sqs.py
@@ -2,6 +2,8 @@
 '''
 Support for the Amazon Simple Queue Service.
 '''
+
+# Import Python libs
 from __future__ import absolute_import
 import logging
 import json
@@ -162,6 +164,11 @@ def list_queues(region, opts=None, user=None):
 
     user : None
         Run hg as a user other than what the minion runs as
+
+    CLI Example:
+
+        salt '*' aws_sqs.list_queues <region>
+
     '''
     out = _run_aws('list-queues', region, opts, user)
 
@@ -187,6 +194,11 @@ def create_queue(name, region, opts=None, user=None):
 
     user : None
         Run hg as a user other than what the minion runs as
+
+    CLI Example:
+
+        salt '*' aws_sqs.create_queue <sqs queue> <region>
+
     '''
 
     create = {'queue-name': name}
@@ -216,6 +228,11 @@ def delete_queue(name, region, opts=None, user=None):
 
     user : None
         Run hg as a user other than what the minion runs as
+
+    CLI Example:
+
+        salt '*' aws_sqs.delete_queue <sqs queue> <region>
+
     '''
     queues = list_queues(region, opts, user)
     url_map = _parse_queue_list(queues)
@@ -263,6 +280,11 @@ def queue_exists(name, region, opts=None, user=None):
 
     user : None
         Run hg as a user other than what the minion runs as
+
+    CLI Example:
+
+        salt '*' aws_sqs.queue_exists <sqs queue> <region>
+
     '''
     output = list_queues(region, opts, user)
 


### PR DESCRIPTION
### What does this PR do?

While running the test suite manually with `-m`, these functions popped up as missing CLI examples and failed the `integration.modules.sysmod.SysModuleTest.test_valid_docs` test. This fixes that test failure.
### What issues does this PR fix or reference?

None.

I will back-port this to 2015.8, too, as these functions were added when the original module was created in 2013. I'm not sure why that test hasn't failed before now for those functions.