### PR TITLE
Don't discard running beacons config when listing becaons

### DIFF
--- a/salt/beacons/__init__.py
+++ b/salt/beacons/__init__.py
@@ -189,7 +189,8 @@ class Beacon(object):
         # Fire the complete event back along with the list of beacons
         evt = salt.utils.event.get_event('minion', opts=self.opts)
         b_conf = self.functions['config.merge']('beacons')
-        evt.fire_event({'complete': True, 'beacons': b_conf},
+        self.opts['beacons'].update(b_conf)
+        evt.fire_event({'complete': True, 'beacons': self.opts['beacons']},
                        tag='/salt/minion/minion_beacons_list_complete')
 
         return True


### PR DESCRIPTION
Refs saltstack/salt#34827 

Fixes all broken beacon tests on develop