### PR TITLE
don't deprecate openstack until Nitrogen

### DIFF
--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -207,9 +207,9 @@ def __virtual__():
         return False
 
     salt.utils.warn_until(
-        'Carbon',
+        'Nitrogen',
         'This driver has been deprecated and will be removed in the '
-        'Carbon release of Salt. Please use the nova driver instead.'
+        'Nitrogen release of Salt. Please use the nova driver instead.'
     )
 
     return __virtualname__


### PR DESCRIPTION
### What does this PR do?

Novaclient driver is not where we want it yet, need to push back removing openstack till at least neutron.