### PR TITLE
Fix integration.output tests for PY3

### DIFF
--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -99,7 +99,7 @@ def display_output(data, out=None, opts=None):
                         # try to let the stream write
                         # even if we didn't encode it
                         pass
-                ofh.write(fdata)
+                ofh.write(fdata.decode())
                 ofh.write('\n')
             return
         if display_data:

--- a/tests/integration/output/output.py
+++ b/tests/integration/output/output.py
@@ -90,7 +90,10 @@ class OutputReturnTest(integration.ShellCase):
         '''
         opts = salt.config.minion_config(os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'minion'))
         opts['output_file'] = os.path.join(
-            opts['root_dir'], 'outputtest')
+            integration.SYS_TMP_DIR,
+            'salt-tests-tmpdir',
+            'outputtest'
+        )
         data = {'foo': {'result': False,
                         'aaa': 'azerzaeréééé',
                         'comment': u'ééééàààà'}}


### PR DESCRIPTION
This also makes a PY3 compatibility fix with `salt/output/__init__.py`, decoding a bytestring before writing it.