### PR TITLE
Copypath prepend filename

### DIFF
--- a/doc/_themes/saltstack2/layout.html
+++ b/doc/_themes/saltstack2/layout.html
@@ -143,9 +143,9 @@
                     <!-- Collect the nav links, forms, and other content for toggling -->
                     <div class="collapse navbar-collapse" id="navbarCollapse">
                         <ul class="nav navbar-nav">
-                <li><a href="/en/latest/">Documentation</a></li>
+                <li><a href="/en/latest/">Overview</a></li>
                 <li><a href="/en/getstarted/">Tutorials</a></li>
-                <li><a href="/en/latest/contents.html">Reference Guide</a></li>
+                <li><a href="/en/latest/contents.html">Documentation</a></li>
                 <li><a href="https://repo.saltstack.com">Downloads</a></li>
                 <li><a href="/en/latest/topics/development/">Develop</a></li>
                             <!--<li><a href="/en/2016.3/faq/">FAQ</a></li>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -214,8 +214,8 @@ project = 'Salt'
 copyright = '2016 SaltStack, Inc.'
 
 version = salt.version.__version__
-latest_release = '2016.3.1'  # latest release
-previous_release = '2015.8.10'  # latest release from previous branch
+latest_release = '2016.3.2'  # latest release
+previous_release = '2015.8.11'  # latest release from previous branch
 previous_release_dir = '2015.8'  # path on web server for previous branch
 next_release = ''  # next release
 next_release_dir = ''  # path on web server for next release branch

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -198,8 +198,8 @@ project = 'Salt'
 copyright = '2016 SaltStack, Inc.'
 
 version = salt.version.__version__
-latest_release = '2016.3.1'  # latest release
-previous_release = '2015.8.10'  # latest release from previous branch
+latest_release = '2016.3.2'  # latest release
+previous_release = '2015.8.11'  # latest release from previous branch
 previous_release_dir = '2015.8'  # path on web server for previous branch
 next_release = ''  # next release
 next_release_dir = ''  # path on web server for next release branch

--- a/doc/topics/releases/2015.8.10.rst
+++ b/doc/topics/releases/2015.8.10.rst
@@ -5,6 +5,12 @@ Salt 2015.8.10 Release Notes
 Version 2015.8.10 is a bugfix release for :doc:`2015.8.0
 </topics/releases/2015.8.0>`.
 
+**Final Release of Debian 7 Packages**
+
+Regular security support for Debian 7 ended on April 25th 2016. As a result,
+2016.3.1 and 2015.8.10 will be the last Salt releases for which Debian
+7 packages are created.
+
 .. admonition:: Mint Linux: Important Post-Upgrade Instructions
 
     As a result of some upstream changes, the ``os`` grain on Mint Linux is now

--- a/doc/topics/releases/2015.8.11.rst
+++ b/doc/topics/releases/2015.8.11.rst
@@ -12,6 +12,12 @@ Returner Changes
   accept a ``minions`` keyword argument. All returners which ship with Salt
   have been modified to do so.
 
+Ubuntu 16.04 Packages
+=====================
+
+SaltStack is now providing official Salt 2015.8 `packages
+<http://repo.saltstack.com/2015.8.html#ubuntu>`_ for Ubuntu 16.04.
+
 Changes for v2015.8.10..v2015.8.11
 ----------------------------------
 

--- a/salt/modules/cyg.py
+++ b/salt/modules/cyg.py
@@ -95,7 +95,22 @@ def _get_all_packages(mirror=DEFAULT_MIRROR,
 def check_valid_package(package,
                         cyg_arch='x86_64',
                         mirrors=None):
-    """Check if the package is valid on the given mirrors."""
+    '''
+    Check if the package is valid on the given mirrors.
+
+    Args:
+        package: The name of the package
+        cyg_arch: The cygwin architecture
+        mirrors: any mirrors to check
+
+    Returns (bool): True if Valid, otherwise False
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cyg.check_valid_package <package name>
+    '''
     if mirrors is None:
         mirrors = [{DEFAULT_MIRROR: DEFAULT_MIRROR_KEY}]
 

--- a/salt/modules/ipset.py
+++ b/salt/modules/ipset.py
@@ -427,73 +427,23 @@ def check(set=None, entry=None, family='ipv4'):
     if not settype:
         return 'Error: Set {0} does not exist'.format(set)
 
+    current_members = _parse_members(settype, _find_set_members(set))
+
+    if not len(current_members):
+        return False
+
     if isinstance(entry, list):
-        entries = entry
+        entries = _parse_members(settype, entry)
     else:
-        _entry = entry.split()[0]
-        _entry_extra = entry.split()[1:]
-        if _entry.find('-') != -1 and _entry.count('-') == 1:
-            start, end = _entry.split('-')
+        entries = [_parse_member(settype, entry)]
 
-            if settype == 'hash:ip':
-                if _entry_extra:
-                    entries = [' '.join([str(ipaddress.ip_address(ip)), ' '.join(_entry_extra)]) for ip in long_range(
-                        ipaddress.ip_address(start),
-                        ipaddress.ip_address(end) + 1
-                    )]
-                else:
-                    entries = [' '.join([str(ipaddress.ip_address(ip))]) for ip in long_range(
-                        ipaddress.ip_address(start),
-                        ipaddress.ip_address(end) + 1
-                    )]
+    for current_member in current_members:
+        for entry in entries:
+            if _member_contains(current_member, entry):
+                # print "{0} contains {1}".format(current_member, entry)
+                return True
 
-            elif settype == 'hash:net':
-                networks = ipaddress.summarize_address_range(ipaddress.ip_address(start),
-                                                             ipaddress.ip_address(end))
-                entries = []
-                for network in networks:
-                    _network = [str(ip) for ip in ipaddress.ip_network(network)]
-                    if len(_network) == 1:
-                        if _entry_extra:
-                            __network = ' '.join([str(_network[0]), ' '.join(_entry_extra)])
-                        else:
-                            __network = ' '.join([str(_network[0])])
-                    else:
-                        if _entry_extra:
-                            __network = ' '.join([str(network), ' '.join(_entry_extra)])
-                        else:
-                            __network = ' '.join([str(network)])
-                    entries.append(__network)
-            else:
-                entries = [entry]
-
-        elif _entry.find('/') != -1 and _entry.count('/') == 1:
-            if settype == 'hash:ip':
-                if _entry_extra:
-                    entries = [' '.join([str(ip), ' '.join(_entry_extra)]) for ip in ipaddress.ip_network(_entry)]
-                else:
-                    entries = [' '.join([str(ip)]) for ip in ipaddress.ip_network(_entry)]
-            elif settype == 'hash:net':
-                _entries = [str(ip) for ip in ipaddress.ip_network(_entry)]
-                if len(_entries) == 1:
-                    if _entry_extra:
-                        entries = [' '.join([_entries[0], ' '.join(_entry_extra)])]
-                    else:
-                        entries = [' '.join([_entries[0]])]
-                else:
-                    entries = [entry]
-            else:
-                entries = [entry]
-        else:
-            entries = [entry]
-
-    current_members = _find_set_members(set)
-    for entry in entries:
-        if entry not in current_members:
-            return False
-
-    return True
-
+    return False
 
 def test(set=None, entry=None, family='ipv4', **kwargs):
     '''
@@ -587,7 +537,6 @@ def _find_set_members(set):
             startMembers = True
     return members
 
-
 def _find_set_info(set):
     '''
     Return information about the set
@@ -620,3 +569,97 @@ def _find_set_type(set):
         return setinfo['Type']
     else:
         return False
+
+def _parse_members(settype, members):
+    if isinstance(members, six.string_types):
+
+        return [_parse_member(settype, members)]
+
+    return [_parse_member(settype, member) for member in members]
+
+def _parse_member(settype, member, strict=False):
+    subtypes = settype.split(':')[1].split(',')
+
+    parts = member.split(' ')
+
+    parsed_member = []
+    for i in range(len(subtypes)):
+        subtype = subtypes[i]
+        part = parts[i]
+
+        if subtype in ['ip', 'net']:
+            try:
+                if '/' in part:
+                    part = ipaddress.ip_network(part, strict=strict)
+                elif '-' in part:
+                    start,end = map(ipaddress.ip_address, part.split('-'))
+
+                    part = list(ipaddress.summarize_address_range(start, end))
+                else:
+                    part = ipaddress.ip_address(part)
+            except ValueError:
+                pass
+
+        elif subtype == 'port':
+            part = int(part)
+
+        parsed_member.append(part)
+
+    if len(parts) > len(subtypes):
+        parsed_member.append(' '.join(parts[len(subtypes):]))
+
+    return parsed_member
+
+def _members_contain(members, entry):
+    pass
+
+def _member_contains(member, entry):
+    if len(member) < len(entry):
+        return False
+
+    for i in range(len(entry)):
+        if not _compare_member_parts(member[i], entry[i]):
+            return False
+
+    return True
+
+def _compare_member_parts(member_part, entry_part):
+    if member_part == entry_part:
+        # this covers int, string, and equal ip and net
+        return True
+
+    # for ip ranges parsed with summarize_address_range
+    if isinstance(entry_part, list):
+        for entry_part_item in entry_part:
+            if not _compare_member_parts(member_part, entry_part_item):
+                return False
+
+        return True
+
+    # below we only deal with ip and net objects
+    if _is_address(member_part):
+        if _is_network(entry_part):
+            return member_part in entry_part
+
+    elif _is_network(member_part):
+        if _is_address(entry_part):
+            return entry_part in member_part
+
+        # both are networks, and == was false
+        return False
+
+        # This could be changed to support things like
+        # 192.168.0.4/30 contains 192.168.0.4/31
+        #
+        # return entry_part.network_address in member_part \
+        #    and entry_part.broadcast_address in member_part
+
+    return False
+
+def _is_network(o):
+    return isinstance(o, ipaddress.IPv4Network) \
+        or isinstance(o, ipaddress.IPv6Network)
+
+def _is_address(o):
+    return isinstance(o, ipaddress.IPv4Address) \
+        or isinstance(o, ipaddress.IPv6Address)

--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -212,6 +212,14 @@ def _key_exists(hive, key, use_32bit_registry=False):
 def broadcast_change():
     '''
     Refresh the windows environment.
+
+    Returns (bool): True if successful, otherwise False
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' reg.broadcast_change
     '''
     # https://msdn.microsoft.com/en-us/library/windows/desktop/ms644952(v=vs.85).aspx
     _, res = SendMessageTimeout(HWND_BROADCAST, WM_SETTINGCHANGE, 0, 0,

--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -354,18 +354,13 @@ def list_functions(*args, **kwargs):  # pylint: disable=unused-argument
 
     names = set()
     for module in args:
-        _use_fnmatch = False
         if '*' in module:
-            target_mod = module
-            _use_fnmatch = True
-        elif module:
+            for func in fnmatch.filter(__salt__, module):
+                names.add(func)
+        else:
             # allow both "sys" and "sys." to match sys, without also matching
             # sysctl
             module = module + '.' if not module.endswith('.') else module
-        if _use_fnmatch:
-            for func in fnmatch.filter(__salt__, target_mod):
-                names.add(func)
-        else:
             for func in __salt__:
                 if func.startswith(module):
                     names.add(func)

--- a/salt/modules/win_certutil.py
+++ b/salt/modules/win_certutil.py
@@ -36,6 +36,11 @@ def get_cert_serial(cert_file):
     cert_file
         The certificate file to find the serial for
 
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' certutil.get_cert_serial <certificate name>
     '''
     cmd = "certutil.exe -verify {0}".format(cert_file)
     out = __salt__['cmd.run'](cmd)
@@ -53,6 +58,11 @@ def get_stored_cert_serials(store):
     store
         The store to get all the certificate serials from
 
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' certutil.get_stored_cert_serials <store>
     '''
     cmd = "certutil.exe -store {0}".format(store)
     out = __salt__['cmd.run'](cmd)

--- a/salt/modules/win_dacl.py
+++ b/salt/modules/win_dacl.py
@@ -39,7 +39,7 @@ __virtualname__ = 'win_dacl'
 
 class daclConstants(object):
     '''
-    dacl constants used throughout the module
+    DACL constants used throughout the module
     '''
     # Definition in ntsecuritycon is incorrect (does not match winnt.h). The version
     # in ntsecuritycon has the extra bits 0x200 enabled.
@@ -349,7 +349,7 @@ def __virtual__():
 
 def _get_dacl(path, objectType):
     '''
-    gets the dacl of a path
+    Gets the DACL of a path
     '''
     try:
         dacl = win32security.GetNamedSecurityInfo(
@@ -362,14 +362,14 @@ def _get_dacl(path, objectType):
 
 def get(path, objectType, user=None):
     '''
-    Get the acl ef an object. Will filter by user if one is provided.
+    Get the ACL of an object. Will filter by user if one is provided.
 
     Args:
         path: The path to the object
         objectType: The type of object (FILE, DIRECTORY, REGISTRY)
         user: A user name to filter by
 
-    Returns (dict): A dictionary containing the acl
+    Returns (dict): A dictionary containing the ACL
 
     CLI Example:
 

--- a/salt/modules/win_dacl.py
+++ b/salt/modules/win_dacl.py
@@ -362,7 +362,20 @@ def _get_dacl(path, objectType):
 
 def get(path, objectType, user=None):
     '''
-    Get the acl of an object. Will filter by user if one is provided.
+    Get the acl ef an object. Will filter by user if one is provided.
+
+    Args:
+        path: The path to the object
+        objectType: The type of object (FILE, DIRECTORY, REGISTRY)
+        user: A user name to filter by
+
+    Returns (dict): A dictionary containing the acl
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' win_dacl.get c:\temp directory
     '''
     ret = {'Path': path,
            'ACLs': []}
@@ -629,7 +642,18 @@ def enable_inheritance(path, objectType, clear=False):
     '''
     enable/disable inheritance on an object
 
-    clear = True will remove non-Inherited ACEs from the ACL
+    Args:
+        path: The path to the object
+        objectType: The type of object (FILE, DIRECTORY, REGISTRY)
+        clear: True will remove non-Inherited ACEs from the ACL
+
+    Returns (dict): A dictionary containing the results
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' win_dacl.enable_inheritance c:\temp directory
     '''
     dc = daclConstants()
     objectType = dc.getObjectTypeBit(objectType)
@@ -640,9 +664,20 @@ def enable_inheritance(path, objectType, clear=False):
 
 def disable_inheritance(path, objectType, copy=True):
     '''
-    disable inheritance on an object
+    Disable inheritance on an object
 
-    copy = True will copy the Inerhited ACEs to the DACL before disabling inheritance
+    Args:
+        path: The path to the object
+        objectType: The type of object (FILE, DIRECTORY, REGISTRY)
+        copy: True will copy the Inherited ACEs to the DACL before disabling inheritance
+
+    Returns (dict): A dictionary containing the results
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' win_dacl.disable_inheritance c:\temp directory
     '''
     dc = daclConstants()
     objectType = dc.getObjectTypeBit(objectType)
@@ -653,11 +688,20 @@ def disable_inheritance(path, objectType, copy=True):
 
 def check_inheritance(path, objectType, user=None):
     '''
-    check a specified path to verify if inheritance is enabled
-    returns 'Inheritance' of True/False
+    Check a specified path to verify if inheritance is enabled
 
-    path: path of the registry key or file system object to check
-    user: if provided, will consider only the ACEs for that user
+    Args:
+        path: path of the registry key or file system object to check
+        objectType: The type of object (FILE, DIRECTORY, REGISTRY)
+        user: if provided, will consider only the ACEs for that user
+
+    Returns (bool): 'Inheritance' of True/False
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' win_dacl.check_inheritance c:\temp directory <username>
     '''
 
     ret = {'result': False,
@@ -691,16 +735,24 @@ def check_inheritance(path, objectType, user=None):
 
 def check_ace(path, objectType, user, permission=None, acetype=None, propagation=None, exactPermissionMatch=False):
     '''
-    checks a path to verify the ACE (access control entry) specified exists
-    returns 'Exists' true if the ACE exists, false if it does not
+    Checks a path to verify the ACE (access control entry) specified exists
 
-    path:  path to the file/reg key
-    user:  user that the ACL is for
-    permission:  permission to test for (READ, FULLCONTROl, etc)
-    acetype:  the type of ACE (ALLOW or DENY)
-    propagation:  the propagation type of the ACE (FILES, FOLDERS, KEY, KEY&SUBKEYS, SUBKEYS, etc)
-    exactPermissionMatch:  the ACL must match exactly, IE if READ is specified, the user must have READ exactly and not FULLCONTROL (which also has the READ permission obviously)
+    Args:
+        path:  path to the file/reg key
+        objectType: The type of object (FILE, DIRECTORY, REGISTRY)
+        user:  user that the ACL is for
+        permission:  permission to test for (READ, FULLCONTROL, etc)
+        acetype:  the type of ACE (ALLOW or DENY)
+        propagation:  the propagation type of the ACE (FILES, FOLDERS, KEY, KEY&SUBKEYS, SUBKEYS, etc)
+        exactPermissionMatch:  the ACL must match exactly, IE if READ is specified, the user must have READ exactly and not FULLCONTROL (which also has the READ permission obviously)
 
+    Returns (dict): 'Exists' true if the ACE exists, false if it does not
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' win_dacl.check_ace c:\temp directory <username> fullcontrol
     '''
     ret = {'result': False,
            'Exists': False,

--- a/salt/modules/win_dsc.py
+++ b/salt/modules/win_dsc.py
@@ -237,7 +237,7 @@ def run_config(path, source=None, config=None, salt_env='base'):
     :return: True if successfully compiled and applied, False if not
     :rtype: bool
 
-    CLI Example
+    CLI Example:
 
     To compile a config from a script that already exists on the system:
 
@@ -577,8 +577,13 @@ def set_lcm_config(config_mode=None,
     :param int status_retention_days: Number of days to keep status of the
     current config.
 
-    Returns:
+    Returns (bool): True if successful, otherwise False
 
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' dsc.set_lcm_config ApplyOnly
     '''
     cmd = 'Configuration SaltConfig {'
     cmd += '    Node localhost {'

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1239,5 +1239,18 @@ def _get_latest_pkg_version(pkginfo):
 def compare_versions(ver1='', oper='==', ver2=''):
     '''
     Compare software package versions
+
+    Args:
+        ver1 (str): A software version to compare
+        oper (str): The operand to use to compare
+        ver2 (str): A software version to compare
+
+    Returns (bool): True if the comparison is valid, otherwise False
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.compare_versions 1.2 >= 1.3
     '''
     return salt.utils.compare_versions(ver1, oper, ver2)

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1182,6 +1182,21 @@ def get_repo_data(saltenv='base'):
 
 
 def get_name_map(saltenv='base'):
+    '''
+    Return a reverse map of full pkg names to the names recognized by winrepo.
+
+    Args:
+        saltenv: The environment to pull use
+
+    Returns: A dictionary of the name map
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.get_name_map
+
+    '''
     return _get_name_map(saltenv)
 
 

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -617,6 +617,14 @@ def modify(name,
         run_interactive (bool): If this setting is True, the service will be
         allowed to interact with the user. Not recommended for services that run
         with elevated privileges.
+
+    Returns (dict): A dictionary of changes made
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.modify spooler start_type=disabled
     '''
     # https://msdn.microsoft.com/en-us/library/windows/desktop/ms681987(v=vs.85).aspx
     # https://msdn.microsoft.com/en-us/library/windows/desktop/ms681988(v-vs.85).aspx

--- a/salt/modules/win_shadow.py
+++ b/salt/modules/win_shadow.py
@@ -72,6 +72,12 @@ def set_expire(name, expire):
 
     :return: True if successful. False if unsuccessful.
     :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' shadow.set_expire <username> 2016/7/1
     '''
     return __salt__['user.update'](name, expiration_date=expire)
 
@@ -84,6 +90,12 @@ def require_password_change(name):
 
     :return: True if successful. False if unsuccessful.
     :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' shadow.require_password_change <username>
     '''
     return __salt__['user.update'](name, expired=True)
 
@@ -96,6 +108,12 @@ def unlock_account(name):
 
     :return: True if successful. False if unsuccessful.
     :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' shadow.unlock_account <username>
     '''
     return __salt__['user.update'](name, unlock_account=True)
 

--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -301,7 +301,7 @@ def shutdown_abort():
     displayed to the user. Once the shutdown has initiated, it cannot be aborted
 
     :return: True if successful
-    :rtype: boo
+    :rtype: bool
 
     CLI Example:
 

--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -301,7 +301,13 @@ def shutdown_abort():
     displayed to the user. Once the shutdown has initiated, it cannot be aborted
 
     :return: True if successful
-    :rtype: bool
+    :rtype: boo
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' system.shutdown_abort
     '''
     try:
         win32api.AbortSystemShutdown('127.0.0.1')
@@ -321,6 +327,12 @@ def lock():
 
     :return: True if successful
     :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' system.lock
     '''
     return windll.user32.LockWorkStation()
 
@@ -450,6 +462,12 @@ def get_system_info():
         Returns a Dictionary containing information about the system to include
         name, description, version, etc...
     :rtype: dict
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' system.get_info
     '''
     os_type = {1: 'Work Station',
                2: 'Domain Controller',
@@ -783,6 +801,12 @@ def get_domain_workgroup():
     :return: The name of the domain or workgroup
     :rtype: str
 
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' system.get_domain_workgroup
+
     '''
     pythoncom.CoInitialize()
     conn = wmi.WMI()
@@ -819,6 +843,12 @@ def get_system_time():
 
     :return: Returns the system time in HH:MM:SS AM/PM format.
     :rtype: str
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' system.get_system_time
     '''
     now = win32api.GetLocalTime()
     meridian = 'AM'
@@ -846,6 +876,12 @@ def set_system_time(newtime):
 
     :return: Returns True if successful. Otherwise False.
     :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' system.set_system_time 12:01
     '''
     # Get date/time object from newtime
     fmts = ['%I:%M:%S %p', '%I:%M %p', '%H:%M:%S', '%H:%M']

--- a/salt/modules/win_task.py
+++ b/salt/modules/win_task.py
@@ -323,6 +323,12 @@ def list_tasks(location='\\'):
 
     :return: Returns a list of tasks.
     :rtype: list
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' task.list_tasks
     '''
     # Create the task service object
     pythoncom.CoInitialize()
@@ -350,6 +356,12 @@ def list_folders(location='\\'):
 
     :return: Returns a list of folders.
     :rtype: list
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' task.list_folders
     '''
     # Create the task service object
     pythoncom.CoInitialize()
@@ -379,6 +391,12 @@ def list_triggers(name, location='\\'):
 
     :return: Returns a list of triggers.
     :rtype: list
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' task.list_triggers <task_name>
     '''
     # Create the task service object
     pythoncom.CoInitialize()
@@ -409,6 +427,12 @@ def list_actions(name, location='\\'):
 
     :return: Returns a list of actions.
     :rtype: list
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' task.list_actions <task_name>
     '''
     # Create the task service object
     pythoncom.CoInitialize()
@@ -459,6 +483,12 @@ def create_task(name,
 
     :return: True if successful, False if unsuccessful
     :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' task.create_task <task_name> user_name=System force=True action_type=Execute cmd='del /Q /S C:\\Temp' trigger_type=Once start_date=2016-12-1 start_time=01:00
     '''
     # Check for existing task
     if name in list_tasks(location) and not force:
@@ -534,6 +564,12 @@ def create_task_from_xml(name,
 
     :return: True if successful, False if unsuccessful
     :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' task.create_task_from_xml <task_name> xml_path=C:\task.xml
     '''
     # Check for existing task
     if name in list_tasks(location):
@@ -611,6 +647,12 @@ def create_folder(name, location='\\'):
 
     :return: True if successful, False if unsuccessful
     :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' task.create_folder <folder_name>
     '''
     # Check for existing folder
     if name in list_folders(location):
@@ -800,7 +842,13 @@ def edit_task(name=None,
     - Stop Existing
 
     :return: True if successful, False if unsuccessful
-    :rtype: bool
+    :rtype: boo
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' task.edit_task <task_name> description='This task is awesome'
     '''
     # TODO: Add more detailed return for items changed
 
@@ -974,6 +1022,12 @@ def delete_task(name, location='\\'):
 
     :return: True if successful, False if unsuccessful
     :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' task.delete_task <task_name>
     '''
     # Check for existing task
     if name not in list_tasks(location):
@@ -1008,6 +1062,12 @@ def delete_folder(name, location='\\'):
 
     :return: True if successful, False if unsuccessful
     :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' task.delete_folder <folder_name>
     '''
     # Check for existing folder
     if name not in list_folders(location):
@@ -1043,6 +1103,12 @@ def run(name, location='\\'):
 
     :return: True if successful, False if unsuccessful
     :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' task.list_run <task_name>
     '''
     # Check for existing folder
     if name not in list_tasks(location):
@@ -1076,6 +1142,12 @@ def run_wait(name, location='\\'):
 
     :return: True if successful, False if unsuccessful
     :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' task.list_run_wait <task_name>
     '''
     # Check for existing folder
     if name not in list_tasks(location):
@@ -1127,6 +1199,12 @@ def stop(name, location='\\'):
 
     :return: True if successful, False if unsuccessful
     :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' task.list_stop <task_name>
     '''
     # Check for existing folder
     if name not in list_tasks(location):
@@ -1165,6 +1243,12 @@ def status(name, location='\\'):
     - Ready
     - Running
     :rtype: string
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' task.list_status <task_name>
     '''
     # Check for existing folder
     if name not in list_tasks(location):
@@ -1194,6 +1278,12 @@ def info(name, location='\\'):
 
     :return:
     :rtype: dict
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' task.info <task_name>
     '''
     # Check for existing folder
     if name not in list_tasks(location):
@@ -1372,6 +1462,12 @@ def add_action(name=None,
 
     :return: True if successful, False if unsuccessful
     :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' task.add_action <task_name> cmd='del /Q /S C:\\Temp'
     '''
     save_definition = False
     if kwargs.get('task_definition', False):
@@ -1723,6 +1819,12 @@ def add_trigger(name=None,
 
     :return: True if successful, False if unsuccessful
     :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' task.add_trigger <task_name> trigger_type=Once trigger_enabled=True start_date=2016/12/1 start_time=12:01
     '''
     if not trigger_type:
         return 'Required parameter "trigger_type" not specified'
@@ -2017,6 +2119,12 @@ def clear_triggers(name, location='\\'):
 
     :return: True if successful, False if unsuccessful
     :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' task.clear_trigger <task_name>
     '''
     # Check for existing task
     if name not in list_tasks(location):

--- a/salt/modules/win_task.py
+++ b/salt/modules/win_task.py
@@ -842,7 +842,7 @@ def edit_task(name=None,
     - Stop Existing
 
     :return: True if successful, False if unsuccessful
-    :rtype: boo
+    :rtype: bool
 
     CLI Example:
 

--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -1034,6 +1034,12 @@ def create_certificate(path=None, text=False, ca_server=None, **kwargs):
         An additional path to copy the resulting certificate to. Can be used to maintain a copy
         of all certificates issued for revocation purposes.
 
+    prepend_cn:
+        If set to True, the CN and a dash will be prepended to the copypath's filename.
+
+        Example:
+            /etc/pki/issued_certs/www.example.com-DE:CA:FB:AD:00:00:00:00.crt
+
     signing_policy:
         A signing policy that should be used to create this certificate. Signing policies should be defined
         in the minion configuration, or in a minion pillar. It should be a yaml formatted list of arguments
@@ -1203,8 +1209,13 @@ def create_certificate(path=None, text=False, ca_server=None, **kwargs):
         raise salt.exceptions.SaltInvocationError('failed to verify certificate signature')
 
     if 'copypath' in kwargs:
-        write_pem(text=cert.as_pem(), path=os.path.join(kwargs['copypath'], kwargs['serial_number']+'.crt'),
-                pem_type='CERTIFICATE')
+        if 'prepend_cn' in kwargs and kwargs['prepend_cn'] is True:
+            prepend = str(kwargs['CN']) + '-'
+        else:
+            prepend = ''
+        write_pem(text=cert.as_pem(), path=os.path.join(kwargs['copypath'], 
+                  prepend + kwargs['serial_number']+'.crt'), 
+                  pem_type='CERTIFICATE')
 
     if path:
         return write_pem(text=cert.as_pem(), path=path,

--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -1207,6 +1207,12 @@ def create_certificate(
         An additional path to copy the resulting certificate to. Can be used
         to maintain a copy of all certificates issued for revocation purposes.
 
+    prepend_cn:
+        If set to True, the CN and a dash will be prepended to the copypath's filename.
+
+        Example:
+            /etc/pki/issued_certs/www.example.com-DE:CA:FB:AD:00:00:00:00.crt
+
     signing_policy:
         A signing policy that should be used to create this certificate.
         Signing policies should be defined in the minion configuration, or in
@@ -1412,13 +1418,13 @@ def create_certificate(
             'failed to verify certificate signature')
 
     if 'copypath' in kwargs:
-        write_pem(
-            text=cert.as_pem(),
-            path=os.path.join(
-                kwargs['copypath'], kwargs['serial_number'] + '.crt'),
-            overwrite=overwrite,
-            pem_type='CERTIFICATE'
-        )
+        if 'prepend_cn' in kwargs and kwargs['prepend_cn'] is True:
+            prepend = str(kwargs['CN']) + '-'
+        else:
+            prepend = ''
+        write_pem(text=cert.as_pem(), path=os.path.join(kwargs['copypath'], 
+                  prepend + kwargs['serial_number']+'.crt'), 
+                  pem_type='CERTIFICATE')
 
     if path:
         return write_pem(

--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -99,7 +99,7 @@ def display_output(data, out=None, opts=None):
                         # try to let the stream write
                         # even if we didn't encode it
                         pass
-                ofh.write(fdata)
+                ofh.write(fdata.decode())
                 ofh.write('\n')
             return
         if display_data:

--- a/tests/integration/modules/sysmod.py
+++ b/tests/integration/modules/sysmod.py
@@ -100,6 +100,7 @@ class SysModuleTest(integration.ModuleCase):
                 'lowpkg.bin_pkg_info',
                 'state.apply',
                 'cmd.win_runas',
+                'status.list2cmdline'
         )
 
         for fun in docs:

--- a/tests/integration/modules/sysmod.py
+++ b/tests/integration/modules/sysmod.py
@@ -19,6 +19,60 @@ class SysModuleTest(integration.ModuleCase):
     '''
     Validate the sys module
     '''
+    def test_list_functions(self):
+        '''
+        sys.list_functions
+        '''
+        # Get all functions
+        funcs = self.run_function('sys.list_functions')
+        self.assertIn('hosts.list_hosts', funcs)
+        self.assertIn('pkg.install', funcs)
+
+        # Just pkg
+        funcs = self.run_function('sys.list_functions', ('pkg.',))
+        self.assertNotIn('sys.doc', funcs)
+        self.assertIn('pkg.install', funcs)
+
+        # Just sys
+        funcs = self.run_function('sys.list_functions', ('sys.',))
+        self.assertNotIn('pkg.install', funcs)
+        self.assertIn('sys.doc', funcs)
+
+        # Starting with sys
+        funcs = self.run_function('sys.list_functions', ('sys',))
+        self.assertNotIn('sysctl.get', funcs)
+        self.assertIn('sys.doc', funcs)
+
+    def test_list_modules(self):
+        '''
+        sys.list_modules
+        '''
+        mods = self.run_function('sys.list_modules')
+        self.assertTrue('hosts' in mods)
+        self.assertTrue('pkg' in mods)
+
+    def test_list_modules_with_arg_glob(self):
+        '''
+        sys.list_modules u*
+
+        Tests getting the list of modules with 'u*', and looking for the
+        "user" module
+        '''
+        mods = self.run_function('sys.list_modules', ['u*'])
+        self.assertNotIn('bigip', mods)
+        self.assertIn('user', mods)
+
+    def test_list_modules_with_arg_exact_match(self):
+        '''
+        sys.list_modules user
+
+        Tests getting the list of modules looking for the "user" module with
+        an exact match of 'user' being passed at the CLI instead of something
+        with '*'.
+        '''
+        mods = self.run_function('sys.list_modules', ['user'])
+        self.assertEqual(mods, ['user'])
+
     def test_valid_docs(self):
         '''
         Make sure no functions are exposed that don't have valid docstrings
@@ -45,6 +99,7 @@ class SysModuleTest(integration.ModuleCase):
                 'nspawn.restart',
                 'lowpkg.bin_pkg_info',
                 'state.apply',
+                'cmd.win_runas',
         )
 
         for fun in docs:

--- a/tests/integration/output/output.py
+++ b/tests/integration/output/output.py
@@ -90,7 +90,10 @@ class OutputReturnTest(integration.ShellCase):
         '''
         opts = salt.config.minion_config(os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'minion'))
         opts['output_file'] = os.path.join(
-            opts['root_dir'], 'outputtest')
+            integration.SYS_TMP_DIR,
+            'salt-tests-tmpdir',
+            'outputtest'
+        )
         data = {'foo': {'result': False,
                         'aaa': 'azerzaeréééé',
                         'comment': u'ééééàààà'}}

--- a/tests/unit/modules/sysmod_test.py
+++ b/tests/unit/modules/sysmod_test.py
@@ -164,15 +164,15 @@ class SysmodTestCase(TestCase):
 
         self.assertListEqual(sysmod.list_modules('nonexist'), [])
 
+        # these all really do the same thing (*the '.' at the end is an internal implementation trick)
         self.assertListEqual(sysmod.list_functions('sys'), ['sys.doc', 'sys.list_functions', 'sys.list_modules'])
-
         self.assertListEqual(sysmod.list_functions('sys.'), ['sys.doc', 'sys.list_functions', 'sys.list_modules'])
 
-        self.assertListEqual(sysmod.list_functions('sys.l'), [])
-
+        # globs can be used for both module names and function names:
+        self.assertListEqual(sysmod.list_functions('sys*'), ['sys.doc', 'sys.list_functions', 'sys.list_modules', 'sysctl.get', 'sysctl.show', 'system.halt', 'system.reboot'])
         self.assertListEqual(sysmod.list_functions('sys.list*'), ['sys.list_functions', 'sys.list_modules'])
 
-        self.assertListEqual(sysmod.list_functions('sys*'), ['sys.doc', 'sys.list_functions', 'sys.list_modules', 'sysctl.get', 'sysctl.show', 'system.halt', 'system.reboot'])
+        self.assertListEqual(sysmod.list_functions('sys.list'), [])
 
     # 'list_modules' function tests: 1
 


### PR DESCRIPTION
### What does this PR do?

This PR adds a feature to x509's copypath option that places the CN name in front of the serial in the file name.
### What issues does this PR fix or reference?

When using Salt as a CA for many servers, the copypath directory becomes filled with non-human readable file names like aa:bb:cc:dd.crt .  This patch adds a toggle to prepend those file names with the CN.  So now you have a directory with filenames such as web01-aa:bb:cc:dd.crt.  This makes it easier for a human to deduce which server/CN a file is a backup copy for.

A more elegant solution would be to allow templating inside the signing_policy file, but this particular patch works for our use-case.
### Tests written?

No.

Please review [Salt's Contributing Guide]
I have run this through Salt's pylint file and do not see any obvious errors or pep8 issues.
