### PR TITLE
Refactor sys.list_functions

### DIFF
--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -354,18 +354,13 @@ def list_functions(*args, **kwargs):  # pylint: disable=unused-argument
 
     names = set()
     for module in args:
-        _use_fnmatch = False
         if '*' in module:
-            target_mod = module
-            _use_fnmatch = True
-        elif module:
+            for func in fnmatch.filter(__salt__, module):
+                names.add(func)
+        else:
             # allow both "sys" and "sys." to match sys, without also matching
             # sysctl
             module = module + '.' if not module.endswith('.') else module
-        if _use_fnmatch:
-            for func in fnmatch.filter(__salt__, target_mod):
-                names.add(func)
-        else:
             for func in __salt__:
                 if func.startswith(module):
                     names.add(func)

--- a/tests/unit/modules/sysmod_test.py
+++ b/tests/unit/modules/sysmod_test.py
@@ -164,15 +164,15 @@ class SysmodTestCase(TestCase):
 
         self.assertListEqual(sysmod.list_modules('nonexist'), [])
 
+        # these all really do the same thing (*the '.' at the end is an internal implementation trick)
         self.assertListEqual(sysmod.list_functions('sys'), ['sys.doc', 'sys.list_functions', 'sys.list_modules'])
-
         self.assertListEqual(sysmod.list_functions('sys.'), ['sys.doc', 'sys.list_functions', 'sys.list_modules'])
 
-        self.assertListEqual(sysmod.list_functions('sys.l'), [])
-
+        # globs can be used for both module names and function names:
+        self.assertListEqual(sysmod.list_functions('sys*'), ['sys.doc', 'sys.list_functions', 'sys.list_modules', 'sysctl.get', 'sysctl.show', 'system.halt', 'system.reboot'])
         self.assertListEqual(sysmod.list_functions('sys.list*'), ['sys.list_functions', 'sys.list_modules'])
 
-        self.assertListEqual(sysmod.list_functions('sys*'), ['sys.doc', 'sys.list_functions', 'sys.list_modules', 'sysctl.get', 'sysctl.show', 'system.halt', 'system.reboot'])
+        self.assertListEqual(sysmod.list_functions('sys.list'), [])
 
     # 'list_modules' function tests: 1
 


### PR DESCRIPTION
### What does this PR do?

Refactor the code in sys.list_functions to be much more straightforward and readable.

As a side note, I drop the `elif module:` test (as if we need to care?), and simply make that an `else:`. As a side effect, this changes the behaviour for the case (should we care? do we even need to bother or worry about this case?) when `sys.list_functions` is called with an empty string (`''`). See the sections on behaviour below for more details.
### What issues does this PR fix or reference?
### Previous Behavior

calling `sys.list_functions ''` (passing an empty string) would return all functions
### New Behavior

Now calling `sys.list_functions ''` will return an empty list.
### Tests written?

Not for the "empty string" behaviour. I really doubt we want to care about the particular behaviour for this case.