### PR TITLE
Don't run the same job twice on the same minion.

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -890,6 +890,8 @@ VALID_OPTS = {
     'proxy_password': str,
     'proxy_port': int,
 
+    # Minion de-dup jid cache max size
+    'minion_jid_queue_hwm': int,
 }
 
 # default configurations
@@ -1125,6 +1127,7 @@ DEFAULT_MINION_OPTS = {
     'proxy_username': '',
     'proxy_password': '',
     'proxy_port': 0,
+    'minion_jid_queue_hwm': 100,
 }
 
 DEFAULT_MASTER_OPTS = {


### PR DESCRIPTION
### What does this PR do?
- Adds new config option `minion_jid_queue_hwm: int`.
- Keep no more than `minion_jid_queue_hwm` of last jids in an in-memory list.
- Look up a new job in the list and do not run it if the jid already exists in the list.
### What issues does this PR fix or reference?
#28785
### Previous Behavior

Multimaster minion connected to a number of syndics all of which are connected to one MoM was receiving and executing duplicated jobs.
### New Behavior

Minions executes the only one of the duplicated jobs.
### Tests written?

No
