### PR TITLE
Remove "_use_fnmatch" logic: salt/utils/__init__.py

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -2485,18 +2485,8 @@ def argspec_report(functions, module=''):
     # TODO: cp.get_file will also match cp.get_file_str. this is the
     # same logic as sys.doc, and it is not working as expected, see
     # issue #3614
-    _use_fnmatch = False
     if '*' in module:
-        target_mod = module
-        _use_fnmatch = True
-    elif module:
-        # allow both "sys" and "sys." to match sys, without also matching
-        # sysctl
-        target_module = module + '.' if not module.endswith('.') else module
-    else:
-        target_module = ''
-    if _use_fnmatch:
-        for fun in fnmatch.filter(functions, target_mod):
+        for fun in fnmatch.filter(functions, module):
             try:
                 aspec = salt.utils.args.get_function_argspec(functions[fun])
             except TypeError:
@@ -2512,8 +2502,12 @@ def argspec_report(functions, module=''):
             ret[fun]['kwargs'] = True if kwargs else None
 
     else:
+        # allow both "sys" and "sys." to match sys, without also matching
+        # sysctl
+        moduledot_or_empty = module + '.' if module and not module.endswith('.') else module
+
         for fun in functions:
-            if fun == module or fun.startswith(target_module):
+            if fun == module or fun.startswith(moduledot_or_empty):
                 try:
                     aspec = salt.utils.args.get_function_argspec(functions[fun])
                 except TypeError:

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -2504,10 +2504,10 @@ def argspec_report(functions, module=''):
     else:
         # allow both "sys" and "sys." to match sys, without also matching
         # sysctl
-        moduledot_or_empty = module + '.' if module and not module.endswith('.') else module
+        moduledot = module + '.' if module and not module.endswith('.') else module
 
         for fun in functions:
-            if fun == module or fun.startswith(moduledot_or_empty):
+            if fun == module or fun.startswith(moduledot):
                 try:
                     aspec = salt.utils.args.get_function_argspec(functions[fun])
                 except TypeError:


### PR DESCRIPTION
### What does this PR do?

As per subject, this removes and cleans up the code introduced by the "_use_fnmatch" logic.

Please review and comment:

Specific questions I have:
1. I was tempted to rename the `argspec_report()` function parameter `module` to `module_function_spec` (or even `module_function`; `module_or_function_spec` is getting reaally long) because that's more accurate. The parameter could be a module "spec"... (like say `user`), or a function "spec" (`user.add`). What are your thoughts? Rename or not? **Update**: on the other hand, renaming `module` would necessitate renaming `moduledot_or_empty` as well in order to be coherent. Oh boy!
2. Does anybody have any problem with that one liner

```
moduledot_or_empty = module + '.' if module and not module.endswith('.') else module
```

? Admittedly the long variable name doesn't help; but it is descriptive! The alternative would be an if-else block:

```
if module and not module.endswith('.'):
    moduledot_or_empty = module + '.'
else:
    moduledot_or_empty = module
```
### What issues does this PR fix or reference?

On the positive side, this produces more readable/maintainable/understandable code.
### Tests written?

No new tests; existing tests remain.
