### PR TITLE
Add append_minionid_config_dirs option

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -127,6 +127,13 @@
 # This data may contain sensitive data and should be protected accordingly.
 #cachedir: /var/cache/salt/minion
 
+# Append minion_id to these directories.  Helps with
+# multiple proxies and minions running on the same machine.
+# Allowed elements in the list: pki_dir, cachedir, extension_modules
+# Normally not needed unless running several proxies and/or minions on the same machine
+# Defaults to ['cachedir'] for proxies, [] (empty list) for regular minions
+#append_minionid_config_dirs:
+
 # Verify and set permissions on configuration directories at startup.
 #verify_env: True
 

--- a/conf/proxy
+++ b/conf/proxy
@@ -84,6 +84,16 @@
 # This data may contain sensitive data and should be protected accordingly.
 #cachedir: /var/cache/salt/minion
 
+# Append minion_id to these directories.  Helps with
+# multiple proxies and minions running on the same machine.
+# Allowed elements in the list: pki_dir, cachedir, extension_modules
+# Normally not needed unless running several proxies and/or minions on the same machine
+# Defaults to ['cachedir'] for proxies, [] (empty list) for regular minions
+# append_minionid_config_dirs:
+#   - cachedir
+
+
+
 # Verify and set permissions on configuration directories at startup.
 #verify_env: True
 

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -395,7 +395,24 @@ This directory may contain sensitive data and should be protected accordingly.
 
     cachedir: /var/cache/salt/minion
 
-.. conf_minion:: verify_env
+.. conf_minion:: append_minionid_config_dirs
+
+``append_minionid_config_dirs``
+-------------------------------
+
+Default: ``[]`` (the empty list) for regular minions, ``['cachedir']`` for proxy minions.
+
+Append minion_id to these configuration directories.  Helps with multiple proxies
+and minions running on the same machine. Allowed elements in the list:
+``pki_dir``, ``cachedir``, ``extension_modules``.
+Normally not needed unless running several proxies and/or minions on the same machine.
+
+.. code-block:: yaml
+
+    append_minionid_config_dirs:
+      - pki_dir
+      - cachedir
+
 
 ``verify_env``
 --------------

--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -424,7 +424,9 @@ class ProxyMinion(parsers.ProxyMinionOptionParser, DaemonsMixin):  # pylint: dis
 
         # Proxies get their ID from the command line.  This may need to change in
         # the future.
-        self.config['id'] = self.values.proxyid
+        # We used to set this here.  Now it is set in ProxyMinionOptionParser
+        # by passing it via setup_config to config.minion_config
+        # self.config['id'] = self.values.proxyid
 
         try:
             if self.config['verify_env']:

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1693,13 +1693,13 @@ class MinionOptionParser(six.with_metaclass(OptionParserMeta, MasterOptionParser
 
 class ProxyMinionOptionParser(six.with_metaclass(OptionParserMeta,
                                                  OptionParser,
+                                                 ProxyIdMixIn,
                                                  ConfigDirMixIn,
                                                  MergeConfigMixIn,
                                                  LogLevelMixIn,
                                                  RunUserMixin,
                                                  DaemonMixIn,
-                                                 SaltfileMixIn,
-                                                 ProxyIdMixIn)):  # pylint: disable=no-init
+                                                 SaltfileMixIn)):  # pylint: disable=no-init
 
     description = (
         'The Salt proxy minion, connects to and controls devices not able to run a minion.  '
@@ -1712,8 +1712,13 @@ class ProxyMinionOptionParser(six.with_metaclass(OptionParserMeta,
     _default_logging_logfile_ = os.path.join(syspaths.LOGS_DIR, 'proxy')
 
     def setup_config(self):
+        try:
+            minion_id = self.values.proxyid
+        except AttributeError:
+            minion_id = None
+
         return config.minion_config(self.get_config_file_path(),
-                                   cache_minion_id=False)
+                                   cache_minion_id=False, minion_id=minion_id)
 
 
 class SyndicOptionParser(six.with_metaclass(OptionParserMeta,


### PR DESCRIPTION
### What does this PR do?

Adds an option to append the minion_id to some configuration directories, thereby namespacing them and preventing multiple minions or proxy minions from clobbering each others cache, pki, or extension module directories.
### What issues does this PR fix or reference?
#34446
### Previous Behavior

A minion and a proxy minion, or multiple proxy minions could overwrite each others cache directory contents.
### New Behavior

When this option is set, cache directories are namespaced by minion_id.
### Tests written?

No
