### PR TITLE
PY3: Fixup jinja template unit tests

### DIFF
--- a/tests/unit/templates/jinja_test.py
+++ b/tests/unit/templates/jinja_test.py
@@ -16,6 +16,8 @@ from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../')
 
 # Import salt libs
+import salt.config
+import salt.ext.six as six
 import salt.loader
 import salt.utils
 from salt.exceptions import SaltRenderError
@@ -341,7 +343,9 @@ class TestGetTemplate(TestCase):
         fn = os.path.join(TEMPLATES_DIR, 'files', 'test', 'non_ascii')
         out = JINJA(fn, opts=self.local_opts, saltenv='test')
         with salt.utils.fopen(out['data']) as fp:
-            result = fp.read().decode('utf-8')
+            result = fp.read()
+            if six.PY2:
+                result = result.decode('utf-8')
             self.assertEqual(u'Assunção\n', result)
 
     def test_get_context_has_enough_context(self):
@@ -385,6 +389,7 @@ class TestGetTemplate(TestCase):
             dict(opts=self.local_opts, saltenv='test')
         )
 
+    @skipIf(six.PY3, 'Not applicable to Python 3: skipping.')
     def test_render_with_unicode_syntax_error(self):
         encoding = builtins.__salt_system_encoding__
         builtins.__salt_system_encoding__ = 'utf-8'


### PR DESCRIPTION
- Added explicit import for `salt.config` (was missing and passing in Python 2, but not 3)
- Removed `decode` call on file read for Python 3
- Skipped a test that doesn't apply to Python 3 - that test is trying to force a failure based on a "bad" unicode option. This scenario doesn't exist in Python 3, as that character actually renders instead of raising an exception.
