### PR TITLE
Use six.string_types instead of type(x) == str for consistency/compatibility

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -357,7 +357,7 @@ def info_installed(*names, **kwargs):
         t_nfo = dict()
         # Translate dpkg-specific keys to a common structure
         for key, value in pkg_nfo.items():
-            if type(value) == str:
+            if isinstance(value, six.string_types):
                 # Check, if string is encoded in a proper UTF-8
                 if six.PY3:
                     value_ = value.encode('UTF-8', 'ignore').decode('UTF-8', 'ignore')


### PR DESCRIPTION
Refs #35117 and [this comment](https://github.com/saltstack/salt/pull/35117/files/e723110e0dda07ab2b95ad3246678ae634705a2c#r73118669)
