### PR TITLE
quick patch: s/list_modules/list_functions in sysmod_test.py

### DIFF
--- a/tests/unit/modules/sysmod_test.py
+++ b/tests/unit/modules/sysmod_test.py
@@ -162,7 +162,7 @@ class SysmodTestCase(TestCase):
         '''
         self.assertListEqual(sysmod.list_functions(), functions)
 
-        self.assertListEqual(sysmod.list_modules('nonexist'), [])
+        self.assertListEqual(sysmod.list_functions('nonexist'), [])
 
         # these all really do the same thing (*the '.' at the end is an internal implementation trick)
         self.assertListEqual(sysmod.list_functions('sys'), ['sys.doc', 'sys.list_functions', 'sys.list_modules'])


### PR DESCRIPTION
### What does this PR do?

Fix a whoopsie from copy-pasting in #35081 (calling `list_modules` instead of `list_functions` in the `list_functions` test). As per subject.
### What issues does this PR fix or reference?
### Tests written?

This is a correction of a test
