### PR TITLE
Deprecate status.uptime one version later

### DIFF
--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -132,7 +132,7 @@ def custom():
     return ret
 
 
-@with_deprecated(globals(), "Boron")
+@with_deprecated(globals(), "Carbon")
 def uptime():
     '''
     Return the uptime for this system.


### PR DESCRIPTION
### What does this PR do?

Versions probably were misunderstood and it results that this function dies entirely in 2016.3. Hence allow to use deprecated version `uptime` in Carbon (in case somebody still needs it). To use a deprecated version, add in the `/etc/salt/minion` config the following:

``` yaml
use_deprecated:
  - status.uptime
```
