### PR TITLE
Make `pkgbuild.repo` state recognize `createrepo` command return code

### DIFF
--- a/salt/modules/rpmbuild.py
+++ b/salt/modules/rpmbuild.py
@@ -466,4 +466,4 @@ def make_repo(repodir, keyid=None, env=None, use_passphrase=False, gnupghome='/e
                     proc.close(terminate=True, kill=True)
 
     cmd = 'createrepo --update {0}'.format(repodir)
-    __salt__['cmd.run'](cmd, runas=runas)
+    return __salt__['cmd.run_all'](cmd, runas=runas)

--- a/salt/states/pkgbuild.py
+++ b/salt/states/pkgbuild.py
@@ -346,7 +346,7 @@ def repo(name,
 
     if __opts__['test'] is True:
         ret['result'] = None
-        ret['comment'] = 'Package repo at {0} will be rebuilt'.format(name)
+        ret['comment'] = 'Package repo metadata at {0} will be refreshed'.format(name)
         return ret
 
     # Need the check for None here, if env is not provided then it falls back
@@ -363,6 +363,18 @@ def repo(name,
                 func = 'rpmbuild.make_repo'
                 break
 
-    __salt__[func](name, keyid, env, use_passphrase, gnupghome, runas)
-    ret['changes'] = {'refresh': True}
+    res = __salt__[func](name, keyid, env, use_passphrase, gnupghome, runas)
+
+    if res['retcode'] > 0:
+        ret['result'] = False
+    else:
+        ret['changes'] = {'refresh': True}
+
+    if res['stdout'] and res['stderr']:
+        ret['comment'] = "{0}\n{1}".format(res['stdout'], res['stderr'])
+    elif res['stdout']:
+        ret['comment'] = res['stdout']
+    elif res['stderr']:
+        ret['comment'] = res['stderr']
+
     return ret


### PR DESCRIPTION
### What does this PR do?

Makes `pkgbuild.repo` state function detect failures from execution of underlying command `createrepo` and return respective result.
### Previous Behavior

`pkgbuild.repo` state always returns `True` unless `test=True` argument provided. 
### New Behavior

`pkgbuild.repo` state will return `False` if  `createrepo` command exited with non-zero code.
### Tests written?

No
