### PR TITLE
Make the log level back to warning for unclassified exc

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1389,7 +1389,7 @@ class Minion(MinionBase):
                 ret['out'] = 'nested'
             except Exception:
                 msg = 'The minion function caused an exception'
-                log.warning(msg, exc_info_on_loglevel=logging.DEBUG)
+                log.warning(msg, exc_info_on_loglevel=True)
                 salt.utils.error.fire_exception(salt.exceptions.MinionError(msg), opts, job=data)
                 ret['return'] = '{0}: {1}'.format(msg, traceback.format_exc())
                 ret['out'] = 'nested'


### PR DESCRIPTION
### What does this PR do?

Make the log level back to warning for unclassified exceptions. 
The issue was made in this [commit](https://github.com/saltstack/salt/commit/c6790a1ec7dd0b4975897ed18ccc2568bf0e6a02)

There are three reasons why we need to change the log level back:
1. It was at warning level, but the commit above make it to debug without explanation. 
2. It is helpful to make unclassified exceptions to warning as these exceptions would be critical.
3. We don't need to set the log level back to debug, restart minion, rerun/reproduce the module calls, etc. , troubleshoot the issue, make the log level back to what it was again and restart salt-minion again. 
4. Especially for salt-api calls, the salt service owner may not be able to reproduce the salt-api call easily with confidence. 
5. Back to warning level will be consistent with [line](https://github.com/saltstack/salt/blob/develop/salt/minion.py#L1503)
### What issues does this PR fix or reference?
### Previous Behavior

When I see "The minion function caused an exception" in the log and I want to debug on, I have to do the following:
1. set the log level back to debug
2. restart minion
3. rerun/reproduce the module calls, etc.
4. troubleshoot the issue
5. set the log level back to what it was
6. restart minion
### New Behavior

I just need to do one step: troubleshoot the issue. 
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
