### PR TITLE
Handle exceptions in `_get_virtual()` and in `_get_virtual()` consumers

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -171,7 +171,12 @@ def _get_virtual():
     except KeyError:
         __context__['pkg._get_virtual'] = {}
         if HAS_APT:
-            apt_cache = apt.cache.Cache()
+            try:
+                apt_cache = apt.cache.Cache()
+            except SystemError as se:
+                msg = 'Failed to get virtual package information ({0})'.format(se)
+                log.error(msg)
+                raise CommandExecutionError(msg)
             pkgs = getattr(apt_cache._cache, 'packages', [])
             for pkg in pkgs:
                 for item in getattr(pkg, 'provides_list', []):
@@ -249,7 +254,10 @@ def latest_version(*names, **kwargs):
     if refresh:
         refresh_db()
 
-    virtpkgs = _get_virtual()
+    try:
+        virtpkgs = _get_virtual()
+    except CommandExecutionError as cee:
+        raise CommandExecutionError(cee)
     all_virt = set()
     for provides in six.itervalues(virtpkgs):
         all_virt.update(provides)
@@ -1179,7 +1187,10 @@ def list_pkgs(versions_as_list=False,
 
     # Check for virtual packages. We need dctrl-tools for this.
     if not removed:
-        virtpkgs_all = _get_virtual()
+        try:
+            virtpkgs_all = _get_virtual()
+        except CommandExecutionError as cee:
+            raise CommandExecutionError(cee)
         virtpkgs = set()
         for realpkg, provides in six.iteritems(virtpkgs_all):
             # grep-available returns info on all virtual packages. Ignore any


### PR DESCRIPTION
### What does this PR do?

It makes the execution of `_get_virtual()` in `modules.aptpkg` a bit more deterministic by handling `SystemError`/`CommandExecutionError` exceptions and thereby shortens this backtrace:

```
          ID: git-binary-icons
    Function: pkg.installed
        Name: git
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1703, in call                                            
                  **cdata['kwargs'])                                                                                                 
                File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1649, in wrapper                                        
                  return f(*args, **kwargs)                                                                                          
                File "/usr/lib/python2.7/dist-packages/salt/states/pkg.py", line 1062, in installed                                  
                  **kwargs)                                                                                                          
                File "/usr/lib/python2.7/dist-packages/salt/states/pkg.py", line 300, in _find_install_targets                       
                  cur_pkgs = __salt__['pkg.list_pkgs'](versions_as_list=True, **kwargs)                                              
                File "/usr/lib/python2.7/dist-packages/salt/modules/aptpkg.py", line 1182, in list_pkgs                              
                  virtpkgs_all = _get_virtual()                                                                                      
                File "/usr/lib/python2.7/dist-packages/salt/modules/aptpkg.py", line 174, in _get_virtual                            
                  apt_cache = apt.cache.Cache()                                                                                      
                File "/usr/lib/python2.7/dist-packages/apt/cache.py", line 113, in __init__                                          
                  self.open(progress)                                                                                                
                File "/usr/lib/python2.7/dist-packages/apt/cache.py", line 164, in open                                              
                  self._cache = apt_pkg.Cache(progress)                                                                              
              SystemError: E:Malformed line 2 in source list /etc/apt/sources.list (type), E:The list of sources could not be read.  
     Started: 19:37:06.154266
    Duration: 24.353 ms
     Changes: 
```

at least by a few lines to this one:

```
          ID: git-binary-icons
    Function: pkg.installed
        Name: git
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1703, in call                                            
                  **cdata['kwargs'])                                                                                                 
                File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1649, in wrapper                                        
                  return f(*args, **kwargs)                                                                                          
                File "/usr/lib/python2.7/dist-packages/salt/states/pkg.py", line 1062, in installed                                  
                  **kwargs)                                                                                                          
                File "/usr/lib/python2.7/dist-packages/salt/states/pkg.py", line 300, in _find_install_targets                       
                  cur_pkgs = __salt__['pkg.list_pkgs'](versions_as_list=True, **kwargs)                                              
                File "/var/cache/salt/minion/extmods/modules/aptpkg.py", line 1193, in list_pkgs                                     
                  raise CommandExecutionError(cee)                                                                                   
              CommandExecutionError: Failed to get virtual package information (E:Malformed line 2 in source list /etc/apt/sources.list (type), E:The list of sources could not be read.)                                                                                 
     Started: 20:01:10.665930
    Duration: 30.483 ms
     Changes:
```
### What issues does this PR fix or reference?

None
### Tests written?

No
