### PR TITLE
Improve clarity of requisite docs

### DIFF
--- a/doc/ref/states/requisites.rst
+++ b/doc/ref/states/requisites.rst
@@ -173,11 +173,11 @@ dependency logic defined above.
 require
 ~~~~~~~
 
-The use of ``require`` demands that the dependent state executes before the
-depending state. The state containing the ``require`` requisite is defined as the
-depending state. The state specified in the ``require`` statement is defined as the
-dependent state. If the dependent state's execution succeeds, the depending state
-will then execute. If the dependent state's execution fails, the depending state
+The use of ``require`` demands that the required state executes before the
+dependent state. The state containing the ``require`` requisite is defined as the
+dependent state. The state specified in the ``require`` statement is defined as the
+required state. If the required state's execution succeeds, the dependent state
+will then execute. If the required state's execution fails, the dependent state
 will not execute. In the first example above, the file ``/etc/vimrc`` will only
 execute after the vim package is installed successfully.
 


### PR DESCRIPTION
### What does this PR do?

Improves clarity of requisite docs, getting rid of "depending" vs. "dependent" confusion. Docs should stick to the terms "required" vs. "dependent", where required means the state that has to happen first, and dependent means the state that relies on the required state.
### What issues does this PR fix or reference?

N/A
### Tests written?

N/A - docs only