### PR TITLE
Add team-related functionality to github module/state

### DIFF
--- a/salt/modules/github.py
+++ b/salt/modules/github.py
@@ -204,7 +204,7 @@ def get_user(name, profile='github', user_details=False):
     try:
         user = client.get_user(name)
     except UnknownObjectException as e:
-        logging.exception("Resource not found {0}: ".format(str(e)))
+        log.exception("Resource not found {0}: ".format(str(e)))
         return False
 
     response['company'] = user.company
@@ -258,7 +258,7 @@ def add_user(name, profile='github'):
     try:
         github_named_user = client.get_user(name)
     except UnknownObjectException as e:
-        logging.exception("Resource not found {0}: ".format(str(e)))
+        log.exception("Resource not found {0}: ".format(str(e)))
         return False
 
     org_team = organization.get_team(
@@ -273,7 +273,7 @@ def add_user(name, profile='github'):
             parameters={'role': 'member'}
         )
     except github.GithubException as e:
-        logging.error(str(e))
+        log.error("Unable to add user", exc_info=True)
         return True
 
     headers, data = organization._requester.requestJsonAndCheck(
@@ -309,7 +309,7 @@ def remove_user(name, profile='github'):
     try:
         git_user = client.get_user(name)
     except UnknownObjectException as e:
-        logging.exception("Resource not found: {0}".format(str(e)))
+        log.exception("Resource not found: {0}".format(str(e)))
         return False
 
     if organization.has_in_members(git_user):
@@ -924,7 +924,7 @@ def add_team(name,
         list_teams(ignore_cache=True)  # Refresh cache
         return True
     except github.GithubException as e:
-        logging.exception('Error creating a team: {0}'.format(str(e)))
+        log.exception('Error creating a team: {0}'.format(str(e)))
         return False
 
 
@@ -962,7 +962,7 @@ def edit_team(name,
     '''
     team = get_team(name, profile=profile)
     if not team:
-        logging.error('Team {0} does not exist'.format(name))
+        log.error('Team {0} does not exist'.format(name))
         return False
     try:
         client = _get_client(profile)
@@ -988,7 +988,7 @@ def edit_team(name,
         )
         return True
     except UnknownObjectException as e:
-        logging.exception('Resource not found: {0}'.format(team['id']))
+        log.exception('Resource not found: {0}'.format(team['id']))
         return False
 
 
@@ -1012,7 +1012,7 @@ def remove_team(name, profile="github"):
     '''
     team_info = get_team(name, profile=profile)
     if not team_info:
-        logging.error('Team {0} to be removed does not exist.'.format(name))
+        log.error('Team {0} to be removed does not exist.'.format(name))
         return False
     try:
         client = _get_client(profile)
@@ -1023,7 +1023,7 @@ def remove_team(name, profile="github"):
         team.delete()
         return list_teams(ignore_cache=True, profile=profile).get(name) is None
     except github.GithubException as e:
-        logging.exception('Error deleting a team: {0}'.format(str(e)))
+        log.exception('Error deleting a team: {0}'.format(str(e)))
         return False
 
 
@@ -1050,7 +1050,7 @@ def list_team_repos(team_name, profile="github", ignore_cache=False):
     '''
     cached_team = get_team(team_name, profile=profile)
     if not cached_team:
-        logging.error('Team {0} does not exist.'.format(team_name))
+        log.error('Team {0} does not exist.'.format(team_name))
         return False
 
     # Return from cache if available
@@ -1064,12 +1064,12 @@ def list_team_repos(team_name, profile="github", ignore_cache=False):
         )
         team = organization.get_team(cached_team['id'])
     except UnknownObjectException as e:
-        logging.exception('Resource not found: {0}'.format(cached_team['id']))
+        log.exception('Resource not found: {0}'.format(cached_team['id']))
     try:
         cached_team['repos'] = [repo.name.lower() for repo in team.get_repos()]
         return cached_team['repos']
     except UnknownObjectException as e:
-        logging.exception('Resource not found: {0}'.format(cached_team['id']))
+        log.exception('Resource not found: {0}'.format(cached_team['id']))
         return []
 
 
@@ -1096,7 +1096,7 @@ def add_team_repo(repo_name, team_name, profile="github"):
     '''
     team = get_team(team_name, profile=profile)
     if not team:
-        logging.error('Team {0} does not exist'.format(team_name))
+        log.error('Team {0} does not exist'.format(team_name))
         return False
     try:
         client = _get_client(profile)
@@ -1106,7 +1106,7 @@ def add_team_repo(repo_name, team_name, profile="github"):
         team = organization.get_team(team['id'])
         repo = organization.get_repo(repo_name)
     except UnknownObjectException as e:
-        logging.exception('Resource not found: {0}'.format(team['id']))
+        log.exception('Resource not found: {0}'.format(team['id']))
         return False
     team.add_to_repos(repo)
     return repo_name in list_team_repos(team_name, profile=profile, ignore_cache=True)
@@ -1135,7 +1135,7 @@ def remove_team_repo(repo_name, team_name, profile="github"):
     '''
     team = get_team(team_name, profile=profile)
     if not team:
-        logging.error('Team {0} does not exist'.format(team_name))
+        log.error('Team {0} does not exist'.format(team_name))
         return False
     try:
         client = _get_client(profile)
@@ -1145,7 +1145,7 @@ def remove_team_repo(repo_name, team_name, profile="github"):
         team = organization.get_team(team['id'])
         repo = organization.get_repo(repo_name)
     except UnknownObjectException as e:
-        logging.exception('Resource not found: {0}'.format(team['id']))
+        log.exception('Resource not found: {0}'.format(team['id']))
         return False
     team.remove_from_repos(repo)
     return repo_name not in list_team_repos(team_name, profile=profile, ignore_cache=True)
@@ -1174,7 +1174,7 @@ def list_team_members(team_name, profile="github", ignore_cache=False):
     '''
     cached_team = get_team(team_name, profile=profile)
     if not cached_team:
-        logging.error('Team {0} does not exist.'.format(team_name))
+        log.error('Team {0} does not exist.'.format(team_name))
         return False
     # Return from cache if available
     if cached_team.get('members') and not ignore_cache:
@@ -1187,13 +1187,13 @@ def list_team_members(team_name, profile="github", ignore_cache=False):
         )
         team = organization.get_team(cached_team['id'])
     except UnknownObjectException as e:
-        logging.exception('Resource not found: {0}'.format(cached_team['id']))
+        log.exception('Resource not found: {0}'.format(cached_team['id']))
     try:
         cached_team['members'] = [member.login.lower()
                                   for member in team.get_members()]
         return cached_team['members']
     except UnknownObjectException as e:
-        logging.exception('Resource not found: {0}'.format(cached_team['id']))
+        log.exception('Resource not found: {0}'.format(cached_team['id']))
         return []
 
 
@@ -1277,7 +1277,7 @@ def add_team_member(name, team_name, profile="github"):
     '''
     team = get_team(team_name, profile=profile)
     if not team:
-        logging.error('Team {0} does not exist'.format(team_name))
+        log.error('Team {0} does not exist'.format(team_name))
         return False
     try:
         client = _get_client(profile)
@@ -1287,7 +1287,7 @@ def add_team_member(name, team_name, profile="github"):
         team = organization.get_team(team['id'])
         member = client.get_user(name)
     except UnknownObjectException as e:
-        logging.exception('Resource not found: {0}'.format(team['id']))
+        log.exception('Resource not found: {0}'.format(team['id']))
         return False
 
     if not hasattr(team, 'add_membership'):
@@ -1303,7 +1303,7 @@ def add_team_member(name, team_name, profile="github"):
             parameters={'role': 'member'}
         )
     except github.GithubException as e:
-        logging.exception('Error in adding a member to a team: {0}'.format(str(e)))
+        log.exception('Error in adding a member to a team: {0}'.format(str(e)))
         return False
     return team.has_in_members(member)
 
@@ -1331,7 +1331,7 @@ def remove_team_member(name, team_name, profile="github"):
     '''
     team = get_team(team_name, profile=profile)
     if not team:
-        logging.error('Team {0} does not exist'.format(team_name))
+        log.error('Team {0} does not exist'.format(team_name))
         return False
     try:
         client = _get_client(profile)
@@ -1342,7 +1342,7 @@ def remove_team_member(name, team_name, profile="github"):
         member = client.get_user(name)
 
     except UnknownObjectException as e:
-        logging.exception('Resource not found: {0}'.format(team['id']))
+        log.exception('Resource not found: {0}'.format(team['id']))
         return False
 
     if not hasattr(team, 'remove_from_members'):

--- a/salt/modules/github.py
+++ b/salt/modules/github.py
@@ -146,6 +146,8 @@ def list_users(profile="github", ignore_cache=False):
     ignore_cache
         Bypasses the use of cached users.
 
+        .. versionadded:: Carbon
+
     CLI Example:
 
     .. code-block:: bash
@@ -894,6 +896,8 @@ def add_team(name,
     .. code-block:: bash
 
         salt myminion github.add_team 'team_name'
+
+    .. versionadded:: Carbon
     '''
     try:
         client = _get_client(profile)
@@ -953,6 +957,8 @@ def edit_team(name,
     .. code-block:: bash
 
         salt myminion github.edit_team 'team_name' description='Team description'
+
+    .. versionadded:: Carbon
     '''
     team = get_team(name, profile=profile)
     if not team:
@@ -1001,6 +1007,8 @@ def remove_team(name, profile="github"):
     .. code-block:: bash
 
         salt myminion github.remove_team 'team_name'
+
+    .. versionadded:: Carbon
     '''
     team_info = get_team(name, profile=profile)
     if not team_info:
@@ -1037,6 +1045,8 @@ def list_team_repos(team_name, profile="github", ignore_cache=False):
     .. code-block:: bash
 
         salt myminion github.list_team_repos 'team_name'
+
+    .. versionadded:: Carbon
     '''
     cached_team = get_team(team_name, profile=profile)
     if not cached_team:
@@ -1081,6 +1091,8 @@ def add_team_repo(repo_name, team_name, profile="github"):
     .. code-block:: bash
 
         salt myminion github.add_team_repo 'my_repo' 'team_name'
+
+    .. versionadded:: Carbon
     '''
     team = get_team(team_name, profile=profile)
     if not team:
@@ -1118,6 +1130,8 @@ def remove_team_repo(repo_name, team_name, profile="github"):
     .. code-block:: bash
 
         salt myminion github.remove_team_repo 'my_repo' 'team_name'
+
+    .. versionadded:: Carbon
     '''
     team = get_team(team_name, profile=profile)
     if not team:
@@ -1155,6 +1169,8 @@ def list_team_members(team_name, profile="github", ignore_cache=False):
     .. code-block:: bash
 
         salt myminion github.list_team_members 'team_name'
+
+    .. versionadded:: Carbon
     '''
     cached_team = get_team(team_name, profile=profile)
     if not cached_team:
@@ -1196,6 +1212,8 @@ def list_members_without_mfa(profile="github", ignore_cache=False):
     .. code-block:: bash
 
         salt myminion github.list_members_without_mfa
+
+    .. versionadded:: Carbon
     '''
     key = "github.{0}:non_mfa_users".format(
         _get_config_value(profile, 'org_name')
@@ -1230,6 +1248,8 @@ def is_team_member(name, team_name, profile="github"):
     .. code-block:: bash
 
         salt myminion github.is_team_member 'user_name' 'team_name'
+
+    .. versionadded:: Carbon
     '''
     return name.lower() in list_team_members(team_name, profile=profile)
 
@@ -1252,6 +1272,8 @@ def add_team_member(name, team_name, profile="github"):
     .. code-block:: bash
 
         salt myminion github.add_team_member 'user_name' 'team_name'
+
+    .. versionadded:: Carbon
     '''
     team = get_team(team_name, profile=profile)
     if not team:
@@ -1304,6 +1326,8 @@ def remove_team_member(name, team_name, profile="github"):
     .. code-block:: bash
 
         salt myminion github.remove_team_member 'user_name' 'team_name'
+
+    .. versionadded:: Carbon
     '''
     team = get_team(team_name, profile=profile)
     if not team:
@@ -1344,6 +1368,8 @@ def list_teams(profile="github", ignore_cache=False):
     .. code-block:: bash
 
         salt myminion github.list_teams
+
+    .. versionadded:: Carbon
     '''
     key = 'github.{0}:teams'.format(
         _get_config_value(profile, 'org_name')

--- a/salt/states/github.py
+++ b/salt/states/github.py
@@ -222,6 +222,8 @@ def team_present(
                     user1:
                         enforce_mfa_from: 2016/06/15
                 - enforce_mfa: True
+
+    .. versionadded:: Carbon
     '''
     ret = {
         'name': name,
@@ -437,6 +439,7 @@ def team_absent(name, profile="github", **kwargs):
     name
         This is the name of the team in the organization.
 
+    .. versionadded:: Carbon
     '''
     ret = {
         'name': name,


### PR DESCRIPTION
### What does this PR do?

Adds `team_present` and `team_absent` states along with related module implementations.
### What issues does this PR fix or reference?

N/A
### New Behavior

Allows for managing teams in the github state as well as optionally enforcing MFA requirements on team members.
### Tests written?

Not yet. Open to feedback on where they'd be most useful.
