### PR TITLE
Isbm osfinger ubuntu fix

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1489,9 +1489,11 @@ def os_data():
                 continue
             osrelease_info[idx] = int(value)
         grains['osrelease_info'] = tuple(osrelease_info)
-        grains['osmajorrelease'] = str(grains['osrelease_info'][0])  # This will be an integer in the next release
-        os_name = 'os' if grains.get('os') in ('FreeBSD', 'OpenBSD', 'NetBSD', 'Mac', 'Raspbian') else 'osfullname'
-        grains['osfinger'] = '{0}-{1}'.format(grains[os_name], grains['osrelease_info'][0])
+        grains['osmajorrelease'] = str(grains['osrelease_info'][0])  # This will be an integer in the two releases
+        os_name = grains['os' if grains.get('os') in (
+            'FreeBSD', 'OpenBSD', 'NetBSD', 'Mac', 'Raspbian') else 'osfullname']
+        grains['osfinger'] = '{0}-{1}'.format(
+            os_name, grains['osrelease'] if os_name in ('Ubuntu',) else grains['osrelease_info'][0])
 
     return grains
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1490,6 +1490,7 @@ def os_data():
             osrelease_info[idx] = int(value)
         grains['osrelease_info'] = tuple(osrelease_info)
         grains['osmajorrelease'] = str(grains['osrelease_info'][0])  # This will be an integer in the two releases
+        salt.utils.warn_until('Nitrogen', 'The "osmajorrelease" will be a type of an integer.')
         os_name = grains['os' if grains.get('os') in (
             'FreeBSD', 'OpenBSD', 'NetBSD', 'Mac', 'Raspbian') else 'osfullname']
         grains['osfinger'] = '{0}-{1}'.format(

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1372,8 +1372,7 @@ def os_data():
                 grains.pop('lsb_distrib_release', None)
             grains['osrelease'] = \
                 grains.get('lsb_distrib_release', osrelease).strip()
-        grains['oscodename'] = grains.get('lsb_distrib_codename',
-                                          oscodename).strip()
+        grains['oscodename'] = grains.get('lsb_distrib_codename', '').strip() or oscodename
         if 'Red Hat' in grains['oscodename']:
             grains['oscodename'] = oscodename
         distroname = _REPLACE_LINUX_RE.sub('', grains['osfullname']).strip()

--- a/tests/unit/grains/core_test.py
+++ b/tests/unit/grains/core_test.py
@@ -376,6 +376,79 @@ PATCHLEVEL = 3
         self._run_suse_os_grains_tests(_os_release_map)
 
 
+    @skipIf(not salt.utils.is_linux(), 'System is not Linux')
+    def test_suse_os_grains_ubuntu(self):
+        '''
+        Test if OS grains are parsed correctly in Ubuntu Xenial Xerus
+        '''
+        _os_release_map = {
+            'os_release_file': {
+                'NAME': 'Ubuntu',
+                'VERSION': '16.04.1 LTS (Xenial Xerus)',
+                'VERSION_ID': '16.04',
+                'PRETTY_NAME': '',
+                'ID': 'ubuntu',
+            },
+            'oscodename': 'xenial',
+            'osfullname': 'Ubuntu',
+            'osrelease': '16.04',
+            'osrelease_info': [16, 4],
+            'osmajorrelease': '16',
+            'osfinger': 'Ubuntu-16.04',
+        }
+        self._run_ubuntu_os_grains_tests(_os_release_map)
+
+
+    def _run_ubuntu_os_grains_tests(self, os_release_map):
+        path_isfile_mock = MagicMock(side_effect=lambda x: x in ['/etc/os-release'])
+        empty_mock = MagicMock(return_value={})
+        osarch_mock = MagicMock(return_value="amd64")
+        os_release_mock = MagicMock(return_value=os_release_map.get('os_release_file'))
+
+        orig_import = __import__
+
+        def _import_mock(name, *args):
+            if name == 'lsb_release':
+                raise ImportError('No module named lsb_release')
+            return orig_import(name, *args)
+
+        # Skip the first if statement
+        with patch.object(salt.utils, 'is_proxy',
+                          MagicMock(return_value=False)):
+            # Skip the selinux/systemd stuff (not pertinent)
+            with patch.object(core, '_linux_bin_exists',
+                              MagicMock(return_value=False)):
+                # Skip the init grain compilation (not pertinent)
+                with patch.object(os.path, 'exists', path_isfile_mock):
+                    # Ensure that lsb_release fails to import
+                    with patch('__builtin__.__import__',
+                               side_effect=_import_mock):
+                        # Skip all the /etc/*-release stuff (not pertinent)
+                        with patch.object(os.path, 'isfile', path_isfile_mock):
+                            with patch.object(core, '_parse_os_release', os_release_mock):
+                                # Mock platform.linux_distribution to give us the
+                                # OS name that we want.
+                                distro_mock = MagicMock(return_value=('Ubuntu', '16.04', 'xenial'))
+                                with patch("salt.utils.fopen", mock_open()) as suse_release_file:
+                                    suse_release_file.return_value.__iter__.return_value = os_release_map.get(
+                                        'suse_release_file', '').splitlines()
+                                    with patch.object(platform, 'linux_distribution', distro_mock):
+                                        with patch.object(core, '_linux_gpu_data', empty_mock):
+                                            with patch.object(core, '_linux_cpudata', empty_mock):
+                                                with patch.object(core, '_virtual', empty_mock):
+                                                    # Mock the osarch
+                                                    with patch.dict(core.__salt__, {'cmd.run': osarch_mock}):
+                                                        os_grains = core.os_data()
+
+        self.assertEqual(os_grains.get('os'), 'Ubuntu')
+        self.assertEqual(os_grains.get('os_family'), 'Debian')
+        self.assertEqual(os_grains.get('osfullname'), os_release_map['osfullname'])
+        self.assertEqual(os_grains.get('oscodename'), os_release_map['oscodename'])
+        self.assertEqual(os_grains.get('osrelease'), os_release_map['osrelease'])
+        self.assertListEqual(list(os_grains.get('osrelease_info')), os_release_map['osrelease_info'])
+        self.assertEqual(os_grains.get('osmajorrelease'), os_release_map['osmajorrelease'])
+
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(CoreGrainsTestCase, needs_daemon=False)

--- a/tests/unit/grains/core_test.py
+++ b/tests/unit/grains/core_test.py
@@ -375,7 +375,6 @@ PATCHLEVEL = 3
         }
         self._run_suse_os_grains_tests(_os_release_map)
 
-
     @skipIf(not salt.utils.is_linux(), 'System is not Linux')
     def test_suse_os_grains_ubuntu(self):
         '''
@@ -397,7 +396,6 @@ PATCHLEVEL = 3
             'osfinger': 'Ubuntu-16.04',
         }
         self._run_ubuntu_os_grains_tests(_os_release_map)
-
 
     def _run_ubuntu_os_grains_tests(self, os_release_map):
         path_isfile_mock = MagicMock(side_effect=lambda x: x in ['/etc/os-release'])


### PR DESCRIPTION
### What does this PR do?

Bugfix PR.
### What issues does this PR fix or reference?
- Fixes the regression for Ubuntu systems, mentioned in https://github.com/saltstack/salt/issues/35167
- Fixes a bug, when `oscodename` has not been taken properly from the platform module
### Previous Behavior

The `osfinger` grain for Ubuntu systems has been returning only name and major release included, resulting to e.g. `Ubuntu-16` instead of expected `Ubuntu-16.04` or `Ubuntu-16.10`.
### New Behavior

The `osfinger` grain for Ubuntu is now reported with a minor version included. Example:

```
$ cat /etc/os-release | grep 'VERSION='
VERSION="16.04.1 LTS (Xenial Xerus)"

$ salt \* grains.get osfinger
saltdevel:
    Ubuntu-16.04
```
### Tests written?

Yes

Cc: @nmadhok please take a look
