### PR TITLE
Ignore import error for pwd module in mac_shadow

### DIFF
--- a/salt/modules/mac_shadow.py
+++ b/salt/modules/mac_shadow.py
@@ -12,7 +12,11 @@ of a configuration profile.
 
 from __future__ import absolute_import
 from datetime import datetime
-import pwd
+
+try:
+    import pwd
+except ImportError:
+    pass
 
 # Import salt libs
 import salt.utils

--- a/salt/modules/mac_shadow.py
+++ b/salt/modules/mac_shadow.py
@@ -13,10 +13,12 @@ of a configuration profile.
 from __future__ import absolute_import
 from datetime import datetime
 
+
 try:
     import pwd
+    HAS_PWD = True
 except ImportError:
-    pass
+    HAS_PWD = False
 
 # Import salt libs
 import salt.utils
@@ -34,7 +36,10 @@ def __virtual__():
     if not salt.utils.is_darwin():
         return False, 'Not Darwin'
 
-    return __virtualname__
+    if HAS_PWD:
+        return __virtualname__
+    else:
+        return (False, 'The pwd module failed to load.')
 
 
 def _get_account_policy(name):


### PR DESCRIPTION
### What does this PR do?

This PR catches the ImportError exception.
The ImportError exception is raised on windows when trying to import the pwd module, as windows does not have the pwd module.

`
[DEBUG   ] output: 3
[DEBUG   ] Failed to import module mac_shadow:
Traceback (most recent call last):
  File "C:\salt\bin\lib\site-packages\salt\loader.py", line 1297, in _load_module), fn_, fpath, desc)
  File "C:\salt\bin\lib\site-packages\salt\modules\mac_shadow.py", line 15, in <module>
    import pwd
ImportError: No module named pwd
`
### Tests written?

No
