### PR TITLE
fix rabbitmq version detection using a package-agnostic version

### DIFF
--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -307,17 +307,23 @@ def check_password(name, password, runas=None):
         salt '*' rabbitmq.check_password rabbit_user password
     '''
     # try to get the rabbitmq-version - adapted from _get_rabbitmq_plugin
+
+    if runas is None:
+        runas = salt.utils.get_user()
+
     try:
 	res = __salt__['cmd.run'](['rabbitmqctl', 'status'], runas=runas, python_shell=False)
-	server_version = re.search(r'\{rabbit,"RabbitMQ","(.+)"\}',res).group(1)
+	server_version = re.search(r'\{rabbit,"RabbitMQ","(.+)"\}',res)
+
+        if server_version is None:
+            raise ValueError("")
+
+        server_version = server_version.group(1)
         version = [int(i) for i in server_version.split('.')]
     except ValueError:
         version = (0, 0, 0)
     if len(version) < 3:
         version = (0, 0, 0)
-
-    if runas is None:
-        runas = salt.utils.get_user()
 
     # rabbitmq introduced a native api to check a username and password in version 3.5.7.
     if tuple(version) >= (3, 5, 7):
@@ -326,8 +332,8 @@ def check_password(name, password, runas=None):
             runas=runas,
             output_loglevel='quiet',
             python_shell=False)
-        msg = 'password-check'
-        return _format_response(res, msg)
+
+        return not 'Error:' in res
 
     cmd = ('rabbit_auth_backend_internal:check_user_login'
         '(<<"{0}">>, [{{password, <<"{1}">>}}]).').format(

--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 
 # Import python libs
 import json
+import re
 import logging
 import random
 import string
@@ -307,7 +308,9 @@ def check_password(name, password, runas=None):
     '''
     # try to get the rabbitmq-version - adapted from _get_rabbitmq_plugin
     try:
-        version = [int(i) for i in __salt__['pkg.version']('rabbitmq-server').split('-')[0].split('.')]
+	res = __salt__['cmd.run'](['rabbitmqctl', 'status'], runas=runas, python_shell=False)
+	server_version = re.search(r'\{rabbit,"RabbitMQ","(.+)"\}',res).group(1)
+        version = [int(i) for i in server_version.split('.')]
     except ValueError:
         version = (0, 0, 0)
     if len(version) < 3:


### PR DESCRIPTION
### What does this PR do?

Fix rabbitmq version detection using a package-agnostic version. The package is not used anymore, so even if rabbitMQ wasn't installed with a package, the version can be determined. This is also useful on system where the package name isn't `rabbitmq-server`

I had to modify the `>3.5.7` check-password code since it was raising an error when the password has to be changed where the old code return a `bool`
### What issues does this PR fix or reference?

Fixes #34481
Fixes #35003
Fixes #33588
### Previous Behavior

Use package version with hardcoded package name `rabbitmq-server`
### New Behavior

Parse `rabbitmqctl status` stdout to determine the version
### Tests written?

No
