### PR TITLE
check for bucket creation before returning on it

### DIFF
--- a/salt/modules/boto_s3_bucket.py
+++ b/salt/modules/boto_s3_bucket.py
@@ -168,6 +168,7 @@ def create(Bucket,
             kwargs['CreateBucketConfiguration'] = {'LocationConstraint': LocationConstraint}
         location = conn.create_bucket(Bucket=Bucket,
                                   **kwargs)
+        conn.get_waiter("bucket_exists").wait(Bucket=Bucket)
         if location:
             log.info('The newly created bucket name is located at {0}'.format(location['Location']))
 


### PR DESCRIPTION
### What does this PR do?

waits on bucket creation before returning on create method
### What issues does this PR fix or reference?

Consistency issues when you describe the bucket immediately after it's creation.
### Previous Behavior

It returned immediately after create_bucket not waiting for it's complete creation 
### Tests written?

Not necessary
