### PR TITLE
Backport #35225 to 2015.8

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -689,6 +689,9 @@ def installed(
                   - dos2unix
                   - salt-minion: 2015.8.5-1.el6
 
+        If the version given is the string ``latest``, the latest available
+        package version will be installed à la ``pkg.latest``.
+
     :param bool refresh:
         This parameter controls whether or not the packge repo database is
         updated prior to installing the requested package(s).


### PR DESCRIPTION
Backport #35225 to 2015.8

This is necessary because the missing documentation that #35225 adds is for the feature mentioned in #29785, which was added in 2015.8
