### PR TITLE
Ensure max recursion in gitfs results in no blob object being returned.

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -1417,6 +1417,7 @@ class Pygit2(GitProvider):
                 else:
                     oid = tree[path].oid
                     blob = self.repo[oid]
+                    break
             except KeyError:
                 blob = None
                 break

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -857,6 +857,7 @@ class GitPython(GitProvider):
         while True:
             depth += 1
             if depth > SYMLINK_RECURSE_DEPTH:
+                blob = None
                 break
             try:
                 file_blob = tree / path
@@ -878,6 +879,7 @@ class GitPython(GitProvider):
                     break
             except KeyError:
                 # File not found or repo_path points to a directory
+                blob = None
                 break
         return blob, blob.hexsha if blob is not None else blob
 
@@ -1400,6 +1402,7 @@ class Pygit2(GitProvider):
         while True:
             depth += 1
             if depth > SYMLINK_RECURSE_DEPTH:
+                blob = None
                 break
             try:
                 if stat.S_ISLNK(tree[path].filemode):
@@ -1415,6 +1418,7 @@ class Pygit2(GitProvider):
                     oid = tree[path].oid
                     blob = self.repo[oid]
             except KeyError:
+                blob = None
                 break
         return blob, blob.hex if blob is not None else blob
 
@@ -1750,6 +1754,7 @@ class Dulwich(GitProvider):  # pylint: disable=abstract-method
         while True:
             depth += 1
             if depth > SYMLINK_RECURSE_DEPTH:
+                blob = None
                 break
             prefix_dirs, _, filename = path.rpartition(os.path.sep)
             tree = self.walk_tree(tree, prefix_dirs)
@@ -1771,6 +1776,7 @@ class Dulwich(GitProvider):  # pylint: disable=abstract-method
                     blob = self.repo.get_object(oid)
                     break
             except KeyError:
+                blob = None
                 break
         return blob, blob.sha().hexdigest() if blob is not None else blob
 


### PR DESCRIPTION
We should be returning `None` here to denote that we did not find the file, but we would instead be returning the last blob object inspected. This pull request fixes that behavior.
