### PR TITLE
Modified nlines variable in append method of file.py by updating list…

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -4020,7 +4020,7 @@ def append(name,
 
     with salt.utils.fopen(name, 'rb') as fp_:
         nlines = fp_.readlines()
-        nlines = [item.rstrip(os.linesep) for item in nlines]
+        nlines = [item.rstrip() for item in nlines]
 
     if slines != nlines:
         if not salt.utils.istextfile(name):


### PR DESCRIPTION
### What does this PR do?

Forces nlines and sliines to use the same criteria when being created.  Currently one is created used rstrip() and the other rstrip(os.pathsep)
### What issues does this PR fix or reference?
### Previous Behavior

When executing a file.append on a RHEL machine subsequent Salt runs were not idempotent because slines was always not equal to nlines.  
### New Behavior

Subsequent file.append Salt runs are idempotent.
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

… comprehension.

When executing a file.append slines is set to [item.rstrip() for item in slines] while nlines is set to [item.rstrip(os.linesep) for item in nlines].  Later if slines is not equal to nlines then it is determined that a change has occurred.  This prevents subsequent Salt runs from being idompotent.
