### PR TITLE
Python3 support for versions-report

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -664,7 +664,7 @@ def versions_report(include_salt_cloud=False):
     for ver_type in ('Salt Version', 'Dependency Versions', 'System Versions'):
         info.append('{0}:'.format(ver_type))
         # List dependencies in alphabetical, case insensitive order
-        for name in sorted(ver_info[ver_type], cmp=lambda x, y: cmp(x.lower(), y.lower())):
+        for name in sorted(ver_info[ver_type], key=lambda x: x.lower()):
             ver = fmt.format(name,
                              ver_info[ver_type][name] or 'Not Installed',
                              pad=padding)


### PR DESCRIPTION
### What does this PR do?

cmp() is not in python3. This allows versions-report to work with python3 and not stacktrace. 
### What issues does this PR fix or reference?
### Tests written?

Yes
