### PR TITLE
Fix disk.wipe missing option.

### DIFF
--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -310,13 +310,16 @@ def wipe(device):
         salt '*' disk.wipe /dev/sda1
     '''
 
-    cmd = 'wipefs {0}'.format(device)
+    cmd = 'wipefs -a {0}'.format(device)
     try:
         out = __salt__['cmd.run_all'](cmd, python_shell=False)
     except subprocess.CalledProcessError as err:
         return False
     if out['retcode'] == 0:
         return True
+    else:
+        log.error('Error wiping device {0}: {1}'.format(device, out['stderr']))
+        return False
 
 
 def dump(device, args=None):


### PR DESCRIPTION
### What does this PR do?

Added -a option to wipefs in disk.,wipe to actually wipe partition.
### What issues does this PR fix or reference?
#35234
### Previous Behavior

When using disk.wipe salt don'r really remove that partition, just shows it

```
----------------------------------------------------------------
0x438                ext4   [filesystem]
                     UUID:  4ad1a0ff-4784-4301-84b7-0cec92b6fa3b
```
### New Behavior

Partition is removed.
### Tests written?

No

Also added en else  clause in case the cmd retcode is not 0. This can be the case when trying to wipe a non-existant partition.
