### PR TITLE
Update instructions for getting master fingerprint in conf/minion

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -605,7 +605,7 @@
 
 # Fingerprint of the master public key to validate the identity of your Salt master
 # before the initial key exchange. The master fingerprint can be found by running
-# "salt-key -F master" on the Salt master.
+# "salt-key -f master.pub" on the Salt master.
 #master_finger: ''
 
 


### PR DESCRIPTION
### What does this PR do?

as per subject, update the instructions. `salt-key F master` prints all keys; what you want is `salt-key -f master.pub`
