### PR TITLE
Boto iam extras

### DIFF
--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -2216,8 +2216,9 @@ def create_saml_provider(name, saml_metadata_document, region=None, key=None, ke
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     try:
-        saml_provider_arn = get_saml_provider_arn(name, region=region, key=key, keyid=keyid, profile=profile)
-        response = conn.create_saml_provider(saml_metadata_document, name)
+        conn.create_saml_provider(saml_metadata_document, name)
+        msg = 'Successfully created {0} SAML provider.'
+        log.info(msg.format(name))
         return True
     except boto.exception.BotoServerError as e:
         aws = salt.utils.boto.get_error(e)
@@ -2265,12 +2266,10 @@ def delete_saml_provider(name, region=None, key=None, keyid=None, profile=None):
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     try:
         saml_provider_arn = get_saml_provider_arn(name, region=region, key=key, keyid=keyid, profile=profile)
-        # The work is done if we the SAML provider is not present anymore.
         if not saml_provider_arn:
             msg = 'SAML provider {0} not found.'
             log.info(msg.format(name))
             return True
-        # Delete the SAML provider found before.
         conn.delete_saml_provider(saml_provider_arn)
         msg = 'Successfully deleted {0} SAML provider.'
         log.info(msg.format(name))

--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -2297,7 +2297,7 @@ def list_saml_providers(region=None, key=None, keyid=None, profile=None):
         providers = []
         info = conn.list_saml_providers()
         for arn in info['list_saml_providers_response']['list_saml_providers_result']['saml_provider_list']:
-          providers.append(arn['arn'].rsplit('/', 1)[1])
+            providers.append(arn['arn'].rsplit('/', 1)[1])
         return providers
     except boto.exception.BotoServerError as e:
         aws = salt.utils.boto.get_error(e)
@@ -2347,7 +2347,7 @@ def update_saml_provider(name, saml_metadata_document, region=None, key=None, ke
             log.info(msg.format(name))
             return False
         if conn.update_saml_provider(name, saml_metadata_document):
-          return True
+            return True
         return False
     except boto.exception.BotoServerError as e:
         aws = salt.utils.boto.get_error(e)

--- a/salt/states/boto_iam.py
+++ b/salt/states/boto_iam.py
@@ -1504,7 +1504,7 @@ def policy_absent(name,
 def saml_provider_present(name, saml_metadata_document, region=None, key=None, keyid=None, profile=None):
     '''
 
-    .. versionadded:: 
+    .. versionadded::
 
     Ensure the SAML provider with the specified name is present.
 
@@ -1562,7 +1562,7 @@ def saml_provider_present(name, saml_metadata_document, region=None, key=None, k
 def saml_provider_absent(name, region=None, key=None, keyid=None, profile=None):
     '''
 
-    .. versionadded:: 
+    .. versionadded::
 
     Ensure the SAML provider with the specified name is absent.
 


### PR DESCRIPTION
### What does this PR do?

adds functionality to key_present to have save_format for keys.
adds functionality to saml_provider_present to load documents from salt base directory
removes functionality to update saml provider since it would always give changes.
### What issues does this PR fix or reference?
#35201
### Previous Behavior

could only load xml document from string in saml_provider_present
did not have the option to save keys in a specific format ( yaml )
### Tests written?

No

The state saml_provider_present does not check if the document provided is different in case that the provider already exists. In order to do this I would have to compare xml documents which I wouldn't want to do since I would either has to have another python library loaded or do it in some boto utils library. Please advise if something like that already exists in saltstack.

Also, please advise what should I put on the 

```
.. versionadded::
```
