### PR TITLE
Add yaml examples for win_iis state

### DIFF
--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -228,6 +228,10 @@ def remove_site(name):
     :return: A boolean representing whether all changes succeeded.
     :rtype: bool
 
+    .. note:
+
+        This will not remove the application pool used by the site.
+
     CLI Example:
 
     .. code-block:: bash

--- a/salt/states/win_iis.py
+++ b/salt/states/win_iis.py
@@ -482,7 +482,7 @@ def container_setting(name, container, settings=None):
         AppPools, Sites, SslBindings
     :param str settings: A dictionary of the setting names and their values.
 
-    Example of usage for the AppPools container:
+    Example of usage for the ``AppPools`` container:
 
     .. code-block:: yaml
 
@@ -496,7 +496,7 @@ def container_setting(name, container, settings=None):
                     processModel.userName: TestUser
                     processModel.password: TestPassword
 
-    Example of usage for the Sites container:
+    Example of usage for the ``Sites`` container:
 
     .. code-block:: yaml
 

--- a/salt/states/win_iis.py
+++ b/salt/states/win_iis.py
@@ -57,6 +57,30 @@ def deployed(name, sourcepath, apppool='', hostheader='', ipaddress='*', port=80
 
         If an application pool is specified, and that application pool does not already exist,
         it will be created.
+
+    Example of usage with only the required arguments. This will default to using the default application pool
+    assigned by IIS:
+
+    .. code-block:: yaml
+
+        site0-deployed:
+            win_iis.deployed:
+                - name: site0
+                - sourcepath: C:\\inetpub\\site0
+
+    Example of usage specifying all available arguments:
+
+    .. code-block:: yaml
+
+        site0-deployed:
+            win_iis.deployed:
+                - name: site0
+                - sourcepath: C:\\inetpub\\site0
+                - apppool: site0
+                - hostheader: site0.local
+                - ipaddress: '*'
+                - port: 443
+                - protocol: https
     '''
     ret = {'name': name,
            'changes': {},
@@ -87,6 +111,14 @@ def remove_site(name):
     Delete a website from IIS.
 
     :param str name: The IIS site name.
+
+    Usage:
+
+    .. code-block:: yaml
+
+        defaultwebsite-remove:
+            win_iis.remove_site:
+                - name: Default Web Site
     '''
 
     ret = {'name': name,
@@ -127,6 +159,27 @@ def create_binding(name, site, hostheader='', ipaddress='*', port=80, protocol='
     :param str port: The TCP port of the binding.
     :param str protocol: The application protocol of the binding.
     :param str sslflags: The flags representing certificate type and storage of the binding.
+
+    Example of usage with only the required arguments:
+
+    .. code-block:: yaml
+
+        site0-https-binding:
+            win_iis.create_binding:
+                - site: site0
+
+    Example of usage specifying all available arguments:
+
+    .. code-block:: yaml
+
+        site0-https-binding:
+            win_iis.create_binding:
+                - site: site0
+                - hostheader: site0.local
+                - ipaddress: '*'
+                - port: 443
+                - protocol: https
+                - sslflags: 0
     '''
     ret = {'name': name,
            'changes': {},
@@ -160,6 +213,25 @@ def remove_binding(name, site, hostheader='', ipaddress='*', port=80):
     :param str hostheader: The host header of the binding.
     :param str ipaddress: The IP address of the binding.
     :param str port: The TCP port of the binding.
+
+    Example of usage with only the required arguments:
+
+    .. code-block:: yaml
+
+        site0-https-binding-remove:
+            win_iis.remove_binding:
+                - site: site0
+
+    Example of usage specifying all available arguments:
+
+    .. code-block:: yaml
+
+        site0-https-binding-remove:
+            win_iis.remove_binding:
+                - site: site0
+                - hostheader: site0.local
+                - ipaddress: '*'
+                - port: 443
     '''
     ret = {'name': name,
            'changes': {},
@@ -199,6 +271,28 @@ def create_cert_binding(name, site, hostheader='', ipaddress='*', port=443, sslf
     :param str ipaddress: The IP address of the binding.
     :param str port: The TCP port of the binding.
     :param str sslflags: Flags representing certificate type and certificate storage of the binding.
+
+    Example of usage with only the required arguments:
+
+    .. code-block:: yaml
+
+        site0-cert-binding:
+            win_iis.create_cert_binding:
+                - name: 9988776655443322111000AAABBBCCCDDDEEEFFF
+                - site: site0
+
+    Example of usage specifying all available arguments:
+
+    .. code-block:: yaml
+
+        site0-cert-binding:
+            win_iis.create_cert_binding:
+                - name: 9988776655443322111000AAABBBCCCDDDEEEFFF
+                - site: site0
+                - hostheader: site0.local
+                - ipaddress: 192.168.1.199
+                - port: 443
+                - sslflags: 1
 
     .. versionadded:: Carbon
     '''
@@ -248,6 +342,27 @@ def remove_cert_binding(name, site, hostheader='', ipaddress='*', port=443):
     :param str ipaddress: The IP address of the binding.
     :param str port: The TCP port of the binding.
 
+    Example of usage with only the required arguments:
+
+    .. code-block:: yaml
+
+        site0-cert-binding-remove:
+            win_iis.remove_cert_binding:
+                - name: 9988776655443322111000AAABBBCCCDDDEEEFFF
+                - site: site0
+
+    Example of usage specifying all available arguments:
+
+    .. code-block:: yaml
+
+        site0-cert-binding-remove:
+            win_iis.remove_cert_binding:
+                - name: 9988776655443322111000AAABBBCCCDDDEEEFFF
+                - site: site0
+                - hostheader: site0.local
+                - ipaddress: 192.168.1.199
+                - port: 443
+
     .. versionadded:: Carbon
     '''
     ret = {'name': name,
@@ -288,6 +403,14 @@ def create_apppool(name):
         It will not modify the configuration of an existing application pool.
 
     :param str name: The name of the IIS application pool.
+
+    Usage:
+
+    .. code-block:: yaml
+
+        site0-apppool:
+            win_iis.create_apppool:
+                - name: site0
     '''
 
     ret = {'name': name,
@@ -318,6 +441,14 @@ def remove_apppool(name):
     Remove an IIS application pool.
 
     :param str name: The name of the IIS application pool.
+
+    Usage:
+
+    .. code-block:: yaml
+
+        defaultapppool-remove:
+            win_iis.remove_apppool:
+                - name: DefaultAppPool
     '''
 
     ret = {'name': name,
@@ -350,6 +481,33 @@ def container_setting(name, container, settings=None):
     :param str container: The type of IIS container. The container types are:
         AppPools, Sites, SslBindings
     :param str settings: A dictionary of the setting names and their values.
+
+    Example of usage for the AppPools container:
+
+    .. code-block:: yaml
+
+        site0-apppool-setting:
+            win_iis.container_setting:
+                - name: site0
+                - container: AppPools
+                - settings:
+                    managedPipelineMode: Integrated
+                    processModel.maxProcesses: 1
+                    processModel.userName: TestUser
+                    processModel.password: TestPassword
+
+    Example of usage for the Sites container:
+
+    .. code-block:: yaml
+
+        site0-site-setting:
+            win_iis.container_setting:
+                - name: site0
+                - container: Sites
+                - settings:
+                    logFile.logFormat: W3C
+                    logFile.period: Daily
+                    limits.maxUrlSegments: 32
     '''
     ret = {'name': name,
            'changes': {},
@@ -419,6 +577,27 @@ def create_app(name, site, sourcepath, apppool=None):
     :param str site: The IIS site name.
     :param str sourcepath: The physical path.
     :param str apppool: The name of the IIS application pool.
+
+    Example of usage with only the required arguments:
+
+    .. code-block:: yaml
+
+        site0-v1-app:
+            win_iis.create_app:
+                - name: v1
+                - site: site0
+                - sourcepath: C:\\inetpub\\site0\\v1
+
+    Example of usage specifying all available arguments:
+
+    .. code-block:: yaml
+
+        site0-v1-app:
+            win_iis.create_app:
+                - name: v1
+                - site: site0
+                - sourcepath: C:\\inetpub\\site0\\v1
+                - apppool: site0
     '''
     ret = {'name': name,
            'changes': {},
@@ -449,6 +628,15 @@ def remove_app(name, site):
 
     :param str name: The application name.
     :param str site: The IIS site name.
+
+    Usage:
+
+    .. code-block:: yaml
+
+        site0-v1-app-remove:
+            win_iis.remove_app:
+                - name: v1
+                - site: site0
     '''
     ret = {'name': name,
            'changes': {},
@@ -486,6 +674,27 @@ def create_vdir(name, site, sourcepath, app='/'):
     :param str site: The IIS site name.
     :param str sourcepath: The physical path.
     :param str app: The IIS application.
+
+    Example of usage with only the required arguments:
+
+    .. code-block:: yaml
+
+        site0-foo-vdir:
+            win_iis.create_vdir:
+                - name: foo
+                - site: site0
+                - sourcepath: C:\\inetpub\\vdirs\\foo
+
+    Example of usage specifying all available arguments:
+
+    .. code-block:: yaml
+
+        site0-foo-vdir:
+            win_iis.create_vdir:
+                - name: foo
+                - site: site0
+                - sourcepath: C:\\inetpub\\vdirs\\foo
+                - app: v1
     '''
     ret = {'name': name,
            'changes': {},
@@ -518,6 +727,25 @@ def remove_vdir(name, site, app='/'):
     :param str name: The virtual directory name.
     :param str site: The IIS site name.
     :param str app: The IIS application.
+
+    Example of usage with only the required arguments:
+
+    .. code-block:: yaml
+
+        site0-foo-vdir-remove:
+            win_iis.remove_vdir:
+                - name: foo
+                - site: site0
+
+    Example of usage specifying all available arguments:
+
+    .. code-block:: yaml
+
+        site0-foo-vdir-remove:
+            win_iis.remove_vdir:
+                - name: foo
+                - site: site0
+                - app: v1
     '''
     ret = {'name': name,
            'changes': {},


### PR DESCRIPTION
### What does this PR do?
- Adds yaml examples to the docstrings of functions of the _win_iis_ state module.
### What issues does this PR fix or reference?
- None
### Previous Behavior
- There were no yaml examples in the docstrings for functions of the _win_iis_ state module.
### New Behavior
- Adds yaml examples to the docstrings of functions of the _win_iis_ state module.
### Tests written?

No
