### PR TITLE
Checksum validation for zypper pkg.download in 2016.3 and develop

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1595,14 +1595,17 @@ def download(*packages, **kwargs):
     pkg_ret = {}
     for dld_result in __zypper__.xml.call('download', *packages).getElementsByTagName("download-result"):
         repo = dld_result.getElementsByTagName("repository")[0]
+        path = dld_result.getElementsByTagName("localfile")[0].getAttribute("path")
         pkg_info = {
             'repository-name': repo.getAttribute('name'),
             'repository-alias': repo.getAttribute('alias'),
+            'path': path,
         }
         key = _get_first_aggregate_text(
             dld_result.getElementsByTagName('name')
         )
-        pkg_ret[key] = pkg_info
+        if __salt__['lowpkg.checksum'](pkg_info['path']):
+            pkg_ret[key] = pkg_info
 
     if pkg_ret:
         failed = [pkg for pkg in packages if pkg not in pkg_ret]

--- a/tests/unit/modules/zypper_test.py
+++ b/tests/unit/modules/zypper_test.py
@@ -387,6 +387,7 @@ class ZypperTestCase(TestCase):
 
         test_out = {
             'nmap': {
+                'path': u'/var/cache/zypp/packages/SLE-12-x86_64-Pool/x86_64/nmap-6.46-1.72.x86_64.rpm',
                 'repository-alias': u'SLE-12-x86_64-Pool',
                 'repository-name': u'SLE-12-x86_64-Pool'
             }


### PR DESCRIPTION
### What does this PR do?

This PR brings some missing changes related with PRs https://github.com/saltstack/salt/pull/33469 and https://github.com/saltstack/salt/pull/33501 to the `2016.3` and `develop` branches.

Seems PRs were merged in `2015.8` but for some conflicts (https://github.com/saltstack/salt/pull/33508/commits/a5e0141eda812d7a3d22d2e3cabc6c631e0c639a) not all changes were merged forward to `2016.3` and `develop`. I don't know if there was a reason to avoid some of the changes, so I create this PR.

This PR enables checksum validation for `pkg.download` in zypper execution module.
### Tests written?

Yes

Could you please take a look?
Thanks!

/cc @isbm 
