### PR TITLE
Exact matching for sys.list_x_functions

### DIFF
--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -572,7 +572,7 @@ def list_state_functions(*args, **kwargs):  # pylint: disable=unused-argument
             for func in fnmatch.filter(st_.states, module):
                 names.add(func)
         else:
-            # "sys" should just match sys, without also matching sysctl
+            # "sys" should just match sys without also matching sysctl
             module = module + '.'
             for func in st_.states:
                 if func.startswith(module):

--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -365,9 +365,9 @@ def list_functions(*args, **kwargs):  # pylint: disable=unused-argument
                 names.add(func)
         else:
             # "sys" should just match sys without also matching sysctl
-            module = module + '.'
+            moduledot = module + '.'
             for func in __salt__:
-                if func.startswith(module):
+                if func.startswith(moduledot):
                     names.add(func)
     return sorted(names)
 
@@ -573,9 +573,9 @@ def list_state_functions(*args, **kwargs):  # pylint: disable=unused-argument
                 names.add(func)
         else:
             # "sys" should just match sys without also matching sysctl
-            module = module + '.'
+            moduledot = module + '.'
             for func in st_.states:
-                if func.startswith(module):
+                if func.startswith(moduledot):
                     names.add(func)
     return sorted(names)
 
@@ -702,9 +702,9 @@ def list_runner_functions(*args, **kwargs):  # pylint: disable=unused-argument
                 names.add(func)
         else:
             # "sys" should just match sys without also matching sysctl
-            module = module + '.'
+            moduledot = module + '.'
             for func in run_.functions:
-                if func.startswith(module):
+                if func.startswith(moduledot):
                     names.add(func)
     return sorted(names)
 
@@ -789,9 +789,9 @@ def list_returner_functions(*args, **kwargs):  # pylint: disable=unused-argument
                 names.add(func)
         else:
             # "sys" should just match sys without also matching sysctl
-            module = module + '.'
+            moduledot = module + '.'
             for func in returners_:
-                if func.startswith(module):
+                if func.startswith(moduledot):
                     names.add(func)
     return sorted(names)
 

--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -344,6 +344,12 @@ def list_functions(*args, **kwargs):  # pylint: disable=unused-argument
 
         salt '*' sys.list_functions 'sys.list_*'
 
+    .. versionadded:: ?
+
+    .. code-block:: bash
+
+        salt '*' sys.list_functions 'module.specific_function'
+
     '''
     # ## NOTE: **kwargs is used here to prevent a traceback when garbage
     # ##       arguments are tacked on to the end.
@@ -354,13 +360,12 @@ def list_functions(*args, **kwargs):  # pylint: disable=unused-argument
 
     names = set()
     for module in args:
-        if '*' in module:
+        if '*' in module or '.' in module:
             for func in fnmatch.filter(__salt__, module):
                 names.add(func)
         else:
-            # allow both "sys" and "sys." to match sys, without also matching
-            # sysctl
-            module = module + '.' if not module.endswith('.') else module
+            # "sys" should just match sys without also matching sysctl
+            module = module + '.'
             for func in __salt__:
                 if func.startswith(module):
                     names.add(func)
@@ -546,6 +551,12 @@ def list_state_functions(*args, **kwargs):  # pylint: disable=unused-argument
         salt '*' sys.list_state_functions 'file.*'
         salt '*' sys.list_state_functions 'file.s*'
 
+    .. versionadded:: ?
+
+    .. code-block:: bash
+
+        salt '*' sys.list_state_functions 'module.specific_function'
+
     '''
     # NOTE: **kwargs is used here to prevent a traceback when garbage
     #       arguments are tacked on to the end.
@@ -557,18 +568,12 @@ def list_state_functions(*args, **kwargs):  # pylint: disable=unused-argument
 
     names = set()
     for module in args:
-        _use_fnmatch = False
-        if '*' in module:
-            target_mod = module
-            _use_fnmatch = True
-        elif module:
-            # allow both "sys" and "sys." to match sys, without also matching
-            # sysctl
-            module = module + '.' if not module.endswith('.') else module
-        if _use_fnmatch:
-            for func in fnmatch.filter(st_.states, target_mod):
+        if '*' in module or '.' in module:
+            for func in fnmatch.filter(st_.states, module):
                 names.add(func)
         else:
+            # "sys" should just match sys, without also matching sysctl
+            module = module + '.'
             for func in st_.states:
                 if func.startswith(module):
                     names.add(func)

--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -784,20 +784,13 @@ def list_returner_functions(*args, **kwargs):  # pylint: disable=unused-argument
 
     names = set()
     for module in args:
-        _use_fnmatch = False
-        if '*' in module:
-            target_mod = module
-            _use_fnmatch = True
-        elif module:
-            # allow both "sys" and "sys." to match sys, without also matching
-            # sysctl
-            module = module + '.' if not module.endswith('.') else module
-        if _use_fnmatch:
-            for func in returners_:
-                if func.startswith(module):
-                    names.add(func)
+        if '*' in module or '.' in module:
+            for func in fnmatch.filter(returners_, module):
+                names.add(func)
         else:
-            for func in six.iterkeys(returners_):
+            # "sys" should just match sys without also matching sysctl
+            module = module + '.'
+            for func in returners_:
                 if func.startswith(module):
                     names.add(func)
     return sorted(names)

--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -697,18 +697,12 @@ def list_runner_functions(*args, **kwargs):  # pylint: disable=unused-argument
 
     names = set()
     for module in args:
-        _use_fnmatch = False
-        if '*' in module:
-            target_mod = module
-            _use_fnmatch = True
-        elif module:
-            # allow both "sys" and "sys." to match sys, without also matching
-            # sysctl
-            module = module + '.' if not module.endswith('.') else module
-        if _use_fnmatch:
-            for func in fnmatch.filter(run_.functions, target_mod):
+        if '*' in module or '.' in module:
+            for func in fnmatch.filter(run_.functions, module):
                 names.add(func)
         else:
+            # "sys" should just match sys without also matching sysctl
+            module = module + '.'
             for func in run_.functions:
                 if func.startswith(module):
                     names.add(func)

--- a/tests/unit/modules/sysmod_test.py
+++ b/tests/unit/modules/sysmod_test.py
@@ -79,7 +79,7 @@ class Mockloader(object):
     Mock of loader
     """
     flag = None
-    functions = []
+    functions = []	# ? does not have any effect on existing tests
 
     def __init__(self):
         self.opts = None
@@ -93,7 +93,7 @@ class Mockloader(object):
         self.lst = lst
         if self.flag:
             return {}
-        return []
+        return sysmod.__salt__
 
     def render(self, opts, lst):
         """
@@ -119,6 +119,8 @@ class SysmodTestCase(TestCase):
         Test if it return the docstrings for all modules.
         '''
         self.assertDictEqual(sysmod.doc(), sysmod.__salt__)
+
+        self.assertDictEqual(sysmod.doc('sys.doc'), {'sys.doc': None})
 
     # 'state_doc' function tests: 1
 
@@ -322,10 +324,20 @@ class SysmodTestCase(TestCase):
         '''
         Test if it list the functions for all returner modules.
         '''
-        self.assertListEqual(sysmod.list_returner_functions(), [])
+        self.assertListEqual(sysmod.list_returner_functions(), _functions)
 
-        self.assertListEqual(sysmod.list_returner_functions('sqlite3.get_*'),
-                             [])
+        self.assertListEqual(sysmod.list_returner_functions('nonexist'), [])
+
+        # list all functions in/given a specific module
+        self.assertListEqual(sysmod.list_returner_functions('sys'), ['sys.doc', 'sys.list_functions', 'sys.list_modules'])
+
+        # globs can be used for both module names and function names:
+        self.assertListEqual(sysmod.list_returner_functions('sys*'), ['sys.doc', 'sys.list_functions', 'sys.list_modules', 'sysctl.get', 'sysctl.show', 'system.halt', 'system.reboot'])
+        self.assertListEqual(sysmod.list_returner_functions('sys.list*'), ['sys.list_functions', 'sys.list_modules'])
+
+        # "list", or check for a specific function:
+        self.assertListEqual(sysmod.list_returner_functions('sys.list'), [])
+        self.assertListEqual(sysmod.list_returner_functions('exist.exist'), ['exist.exist'])
 
     # 'list_renderers' function tests: 1
 

--- a/tests/unit/modules/sysmod_test.py
+++ b/tests/unit/modules/sysmod_test.py
@@ -168,15 +168,16 @@ class SysmodTestCase(TestCase):
 
         self.assertListEqual(sysmod.list_functions('nonexist'), [])
 
-        # these all really do the same thing (*the '.' at the end is an internal implementation trick)
+        # list all functions in/given a specific module
         self.assertListEqual(sysmod.list_functions('sys'), ['sys.doc', 'sys.list_functions', 'sys.list_modules'])
-        self.assertListEqual(sysmod.list_functions('sys.'), ['sys.doc', 'sys.list_functions', 'sys.list_modules'])
 
         # globs can be used for both module names and function names:
         self.assertListEqual(sysmod.list_functions('sys*'), ['sys.doc', 'sys.list_functions', 'sys.list_modules', 'sysctl.get', 'sysctl.show', 'system.halt', 'system.reboot'])
         self.assertListEqual(sysmod.list_functions('sys.list*'), ['sys.list_functions', 'sys.list_modules'])
 
+        # "list", or check for a specific function:
         self.assertListEqual(sysmod.list_functions('sys.list'), [])
+        self.assertListEqual(sysmod.list_functions('exist.exist'), ['exist.exist'])
 
     # 'list_modules' function tests: 1
 
@@ -244,7 +245,18 @@ class SysmodTestCase(TestCase):
         '''
         self.assertListEqual(sysmod.list_state_functions(), functions)
 
-        self.assertListEqual(sysmod.list_state_functions('file.s*'), [])
+        self.assertListEqual(sysmod.list_state_functions('nonexist'), [])
+
+        # list all functions in/given a specific module
+        self.assertListEqual(sysmod.list_state_functions('sys'), ['sys.doc', 'sys.list_functions', 'sys.list_modules'])
+
+        # globs can be used for both module names and function names:
+        self.assertListEqual(sysmod.list_state_functions('sys*'), ['sys.doc', 'sys.list_functions', 'sys.list_modules', 'sysctl.get', 'sysctl.show', 'system.halt', 'system.reboot'])
+        self.assertListEqual(sysmod.list_state_functions('sys.list*'), ['sys.list_functions', 'sys.list_modules'])
+
+        # "list", or check for a specific function:
+        self.assertListEqual(sysmod.list_state_functions('sys.list'), [])
+        self.assertListEqual(sysmod.list_state_functions('exist.exist'), ['exist.exist'])
 
     # 'list_state_modules' function tests: 1
 

--- a/tests/unit/modules/sysmod_test.py
+++ b/tests/unit/modules/sysmod_test.py
@@ -79,7 +79,7 @@ class Mockloader(object):
     Mock of loader
     """
     flag = None
-    functions = []	# ? does not have any effect on existing tests
+    functions = []  # ? does not have any effect on existing tests
 
     def __init__(self):
         self.opts = None


### PR DESCRIPTION
### What does this PR do?

This is the last of the "exact name matching for sys.list_x_functions" stuff. Now all "list_functions" won't fail with exact function name matches.

Couple of things to take note:
- if you were matching for (all functions from) a module _using the "dot" form specifically_ (even if this was not the usage shown in the documentation), this will no longer work. i.e. `sys.list_functions user.` as opposed to just `sys.list_functions user` (no `.` at the end of `user`). I dont think this is a big deal because (a) this is probably arcane knowledge (the official doc uses the "non dot"), and (b) even if you knew, why would you bother to type the extra dot if the "non dot" worked? 
- this goes a way towards removing the ugliness with the `_use_fnmatch` stuff I mention at https://github.com/saltstack/salt/pull/35161#issuecomment-237174224
### What issues does this PR fix or reference?

Fixes #35255 
### Previous Behavior

for various listing functions, if you gave a function name which matched, it would not return anything.

`sys.list_functions cmd.call`

would not return `cmd.call`
### New Behavior

Exact matches work now.
### Tests written?

Yes
