### PR TITLE
Joining sys.path is redundant and causes the string result to be split and re-joined.

### DIFF
--- a/tests/integration/utils/testprogram.py
+++ b/tests/integration/utils/testprogram.py
@@ -378,7 +378,7 @@ class TestProgram(six.with_metaclass(TestProgramMeta, object)):
         if not verbatim_env:
             env_pypath = env_delta.get('PYTHONPATH', os.environ.get('PYTHONPATH'))
             if not env_pypath:
-                env_pypath = ':'.join(sys.path)
+                env_pypath = sys.path
             else:
                 env_pypath = env_pypath.split(':')
                 for path in sys.path:


### PR DESCRIPTION
### What does this PR do?

Bugfix for `tests.integration.utils.testprogram.TestProgram` setting up `PYTHONPATH`
### What issues does this PR fix or reference?

None logged
### Previous Behavior

`PYTHONPATH` was redundantly `join()`ed which caused the string to be treated as an array and re-`join()`ed with the separator character every-other character.
### New Behavior

`PYTHONPATH` is now correctly `join()`ed
### Tests written?

No
