### PR TITLE
Increase timeout for siging to 10 seconds when signing rpm packages

### DIFF
--- a/salt/modules/rpmbuild.py
+++ b/salt/modules/rpmbuild.py
@@ -425,7 +425,7 @@ def make_repo(repodir, keyid=None, env=None, use_passphrase=False, gnupghome='/e
         for file in os.listdir(repodir):
             if file.endswith('.rpm'):
                 abs_file = os.path.join(repodir, file)
-                number_retries = 5
+                number_retries = 20
                 times_looped = 0
                 error_msg = 'Failed to sign file {0}'.format(abs_file)
                 cmd = 'rpm {0} --addsign {1}'.format(define_gpg_name, abs_file)


### PR DESCRIPTION
### What does this PR do?

Increase time out loop from 2.5 to 10 seconds when signing packages
### What issues does this PR fix or reference?

none
### Previous Behavior

On some infrastructures, for example, OpenNebula, 2.5 seconds was insufficient time allowance causing timeout errors.
### New Behavior

10 seconds is sufficient time allowance to not  cause timeout errors when signing packages.
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
