### PR TITLE
Fix proposal for the module ini_manage

### DIFF
--- a/salt/modules/ini_manage.py
+++ b/salt/modules/ini_manage.py
@@ -77,9 +77,6 @@ def set_option(file_name, sections=None, separator='='):
     sections = sections or {}
     changes = {}
     inifile = _Ini.get_ini_file(file_name, separator=separator)
-    if not inifile:
-        changes.update({'error': 'ini file not found'})
-        return changes
     changes = inifile.update(sections)
     inifile.flush()
     return changes

--- a/salt/states/ini_manage.py
+++ b/salt/states/ini_manage.py
@@ -55,7 +55,12 @@ def options_present(name, sections=None, separator='='):
         ret['comment'] = ''
         for section in sections or {}:
             section_name = ' in section ' + section if section != 'DEFAULT_IMPLICIT' else ''
-            cur_section = __salt__['ini.get_section'](name, section, separator)
+            try:
+                cur_section = __salt__['ini.get_section'](name, section, separator)
+            except IOError as err:
+                ret['comment'] = "{0}".format(err)
+                ret['result'] = False
+                return ret
             for key in sections[section]:
                 cur_value = cur_section.get(key)
                 if cur_value == str(sections[section][key]):
@@ -66,7 +71,12 @@ def options_present(name, sections=None, separator='='):
         if ret['comment'] == '':
             ret['comment'] = 'No changes detected.'
         return ret
-    changes = __salt__['ini.set_option'](name, sections, separator)
+    try:
+        changes = __salt__['ini.set_option'](name, sections, separator)
+    except IOError as err:
+        ret['comment'] = "{0}".format(err)
+        ret['result'] = False
+        return ret
     if 'error' in changes:
         ret['result'] = False
         ret['comment'] = 'Errors encountered. {0}'.format(changes['error'])
@@ -106,7 +116,12 @@ def options_absent(name, sections=None, separator='='):
         ret['comment'] = ''
         for section in sections or {}:
             section_name = ' in section ' + section if section != 'DEFAULT_IMPLICIT' else ''
-            cur_section = __salt__['ini.get_section'](name, section, separator)
+            try:
+                cur_section = __salt__['ini.get_section'](name, section, separator)
+            except IOError as err:
+                ret['comment'] = "{0}".format(err)
+                ret['result'] = False
+                return ret
             for key in sections[section]:
                 cur_value = cur_section.get(key)
                 if not cur_value:
@@ -120,7 +135,12 @@ def options_absent(name, sections=None, separator='='):
     sections = sections or {}
     for section, keys in six.iteritems(sections):
         for key in keys:
-            current_value = __salt__['ini.remove_option'](name, section, key, separator)
+            try:
+                current_value = __salt__['ini.remove_option'](name, section, key, separator)
+            except IOError as err:
+                ret['comment'] = "{0}".format(err)
+                ret['result'] = False
+                return ret
             if not current_value:
                 continue
             if section not in ret['changes']:
@@ -156,7 +176,12 @@ def sections_present(name, sections=None, separator='='):
         ret['result'] = True
         ret['comment'] = ''
         for section in sections or {}:
-            cur_section = __salt__['ini.get_section'](name, section, separator)
+            try:
+                cur_section = __salt__['ini.get_section'](name, section, separator)
+            except IOError as err:
+                ret['result'] = False
+                ret['comment'] = "{0}".format(err)
+                return ret
             if cmp(dict(sections[section]), cur_section) == 0:
                 ret['comment'] += 'Section unchanged {0}.\n'.format(section)
                 continue
@@ -171,7 +196,12 @@ def sections_present(name, sections=None, separator='='):
     section_to_update = {}
     for section_name in sections or []:
         section_to_update.update({section_name: {}})
-    changes = __salt__['ini.set_option'](name, section_to_update, separator)
+    try:
+        changes = __salt__['ini.set_option'](name, section_to_update, separator)
+    except IOError as err:
+        ret['result'] = False
+        ret['comment'] = "{0}".format(err)
+        return ret
     if 'error' in changes:
         ret['result'] = False
         ret['changes'] = 'Errors encountered {0}'.format(changes['error'])
@@ -204,7 +234,12 @@ def sections_absent(name, sections=None, separator='='):
         ret['result'] = True
         ret['comment'] = ''
         for section in sections or []:
-            cur_section = __salt__['ini.get_section'](name, section, separator)
+            try:
+                cur_section = __salt__['ini.get_section'](name, section, separator)
+            except IOError as err:
+                ret['result'] = False
+                ret['comment'] = "{0}".format(err)
+                return ret
             if not cur_section:
                 ret['comment'] += 'Section {0} does not exist.\n'.format(section)
                 continue
@@ -214,7 +249,12 @@ def sections_absent(name, sections=None, separator='='):
             ret['comment'] = 'No changes detected.'
         return ret
     for section in sections or []:
-        cur_section = __salt__['ini.remove_section'](name, section, separator)
+        try:
+            cur_section = __salt__['ini.remove_section'](name, section, separator)
+        except IOError as err:
+            ret['result'] = False
+            ret['comment'] = "{0}".format(err)
+            return ret
         if not cur_section:
             continue
         ret['changes'][section] = cur_section


### PR DESCRIPTION
### What does this PR do?
- Catch the IOError exception when a file is not found in the state module
- let empty file to be modified by the module (currently return an error: "ini file not found")
### What issues does this PR fix or reference?

No particular issue
### Previous Behavior

```
local:
----------
          ID: /tmp/notfound.conf
    Function: ini.sections_present
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1723, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1650, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/states/ini_manage.py", line 164, in sections_present
                  changes = __salt__['ini.set_option'](name, section_to_update)
                File "/usr/lib/python2.7/dist-packages/salt/modules/ini_manage.py", line 70, in set_option
                  inifile = _Ini.get_ini_file(file_name)
                File "/usr/lib/python2.7/dist-packages/salt/modules/ini_manage.py", line 350, in get_ini_file
                  inifile.refresh()
                File "/usr/lib/python2.7/dist-packages/salt/modules/ini_manage.py", line 328, in refresh
                  inicontents = inicontents or _fopen(self.name).read()
                File "/usr/lib/python2.7/dist-packages/salt/utils/__init__.py", line 1209, in fopen
                  fhandle = open(*args, **kwargs)
              IOError: [Errno 2] No such file or directory: '/tmp/notfound.conf'
     Started: 20:12:06.261635
    Duration: 2.917 ms
     Changes:   
----------
          ID: /tmp/empty.conf
    Function: ini.options_present
      Result: False
     Comment: Errors encountered. ini file not found
     Started: 20:12:06.264710
    Duration: 0.467 ms
     Changes:   

Summary for local
------------
Succeeded: 0
Failed:    2
------------
Total states run:     2
```
### New Behavior

```
local:
----------
          ID: /tmp/notfound.conf
    Function: ini.sections_present
      Result: False
     Comment: [Errno 2] No such file or directory: '/tmp/notfound.conf'
     Started: 20:15:53.970112
    Duration: 0.665 ms
     Changes:   
----------
          ID: /tmp/empty.conf
    Function: ini.options_present
      Result: True
     Comment: Changes take effect
     Started: 20:15:53.970879
    Duration: 0.572 ms
     Changes:   
              ----------
              test:
                  ----------
                  after:
                      ----------
                      opt1:
                          val1
                      opt2:
                          val2
                  before:
                      None

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    1
------------
Total states run:     2
```
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
