### PR TITLE
Cloud deprecations for Carbon

### DIFF
--- a/doc/topics/cloud/linode.rst
+++ b/doc/topics/cloud/linode.rst
@@ -188,10 +188,6 @@ assign_private_ip
 
 Assigns a private IP address to a Linode when set to True. Default is False.
 
-private_ip
-----------
-Deprecated in favor of `assign_private_ip`_ in Salt 2016.3.0.
-
 ssh_interface
 -------------
 .. versionadded:: 2016.3.0

--- a/doc/topics/releases/carbon.rst
+++ b/doc/topics/releases/carbon.rst
@@ -272,9 +272,6 @@ Deprecations
       # will result in refresh evaluating to True and saltenv likely not being a string at all
       fcn('add more salt', 'prod', False)
 
-- The ``vsphere`` cloud driver has been removed. Please use the ``vmware`` cloud driver
-  instead.
-
 - The ``boto_vpc`` execution module had two functions removed,
   ``boto_vpc.associate_new_dhcp_options_to_vpc`` and
   ``boto_vpc.associate_new_network_acl_to_subnet`` in favor of more concise function
@@ -402,4 +399,17 @@ Deprecations
   - The ``hyper_info`` function was removed. Use the ``host_info`` function instead.
 
 - The ``zpool_list`` function in the ``zpool`` execution module was removed. Use ``list``
+  instead.
+
+Cloud Deprecations
+------------------
+
+- The ``vsphere`` cloud driver has been removed. Please use the ``vmware`` cloud driver
+  instead.
+
+- The ``private_ip`` option in the ``linode`` cloud driver is deprecated and has been
+  removed. Use the ``assign_private_ip`` option instead.
+
+- The ``create_dns_record`` and ``delete_dns_record`` functions are deprecated and have
+  been removed from the ``digital_ocean`` driver. Use the ``post_dns_record`` function
   instead.

--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -877,34 +877,6 @@ def post_dns_record(**kwargs):
 
     return False
 
-# Delete this with create_dns_record() and delete_dns_record() for Carbon release
-__deprecated_fqdn_parsing = lambda fqdn: ('.'.join(fqdn.split('.')[-2:]), '.'.join(fqdn.split('.')[:-2]))
-
-
-def create_dns_record(hostname, ip_address):
-    salt.utils.warn_until(
-        'Carbon',
-        'create_dns_record() is deprecated and will be removed in Carbon. Please use post_dns_record() instead.'
-    )
-    return __deprecated_create_dns_record(hostname, ip_address)
-
-
-def __deprecated_create_dns_record(hostname, ip_address):
-    domainname, subdomain = __deprecated_fqdn_parsing(hostname)
-    domain = query(method='domains', droplet_id=domainname)
-
-    if domain:
-        result = query(
-            method='domains',
-            droplet_id=domainname,
-            command='records',
-            args={'type': 'A', 'name': subdomain, 'data': ip_address},
-            http_method='post'
-        )
-        return result
-
-    return False
-
 
 def destroy_dns_records(fqdn):
     '''
@@ -937,33 +909,6 @@ def destroy_dns_records(fqdn):
                 log.error('failed to delete DNS domain {0} record ID {1}.'.format(domain, hostname))
             log.debug('DNS deletion REST call returned: {0}'.format(pprint.pformat(ret)))
 
-    return False
-
-
-def delete_dns_record(hostname):
-    salt.utils.warn_until(
-        'Carbon',
-        'delete_dns_record() is deprecated and will be removed in Carbon. Please use destroy_dns_records() instead.'
-    )
-    return __deprecated_delete_dns_record(hostname)
-
-
-def __deprecated_delete_dns_record(hostname):
-    '''
-    Deletes a DNS for the given hostname if the domain is managed with DO.
-    '''
-    domainname, subdomain = __deprecated_fqdn_parsing(hostname)
-    records = query(method='domains', droplet_id=domainname, command='records')
-
-    if records:
-        for record in records['domain_records']:
-            if record['name'] == subdomain:
-                return query(
-                    method='domains',
-                    droplet_id=domainname,
-                    command='records/' + str(record['id']),
-                    http_method='delete'
-                )
     return False
 
 

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -43,7 +43,6 @@ from salt.exceptions import (
     SaltCloudNotFound,
     SaltCloudSystemExit
 )
-from salt.utils import warn_until
 
 # Import Salt-Cloud Libs
 import salt.utils.cloud

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -1031,16 +1031,6 @@ def get_private_ip(vm_):
     '''
     Return True if a private ip address is requested
     '''
-    if 'private_ip' in vm_:
-        warn_until(
-            'Carbon',
-            'The \'private_ip\' option is being deprecated in favor of the '
-            '\'assign_private_ip\' option. Please convert your Linode configuration '
-            'files to use \'assign_private_ip\'.'
-        )
-        vm_['assign_private_ip'] = vm_['private_ip']
-        vm_.pop('private_ip')
-
     return config.get_cloud_config_value(
         'assign_private_ip', vm_, __opts__, default=False
     )


### PR DESCRIPTION
### What does this PR do?

Removes some deprecated functions from the `digital_ocean` driver as well as an option from the `linode` driver. 

Also combines all of the cloud deprecations into one section to make them easy to find. I'll likely split up some of the other deprecations into larger sections for readability.
### Tests written?

No
