### PR TITLE
Fixes #30577 - Add log_config option

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -1819,9 +1819,9 @@ def _validate_input(kwargs,
                 'pid_mode can only be \'host\', if set'
             )
 
-    def _valid_log_config(): # pylint: disable=unused-variable
+    def _valid_log_config():  # pylint: disable=unused-variable
         '''
-        Needs to be a dictionary that might contain keys (type|Type) and (config|Config)
+        Needs to be a dictionary that might contain keys Type and Config
         '''
         try:
             _valid_dict('log_config')

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -546,6 +546,14 @@ VALID_CREATE_OPTS = {
         'min_docker': (1, 5, 0),
         'default': '',
     },
+    'log_config': {
+        'path': 'HostConfig:LogConfig',
+        'min_docker': (1, 4, 0),
+        'default': {
+            'Type': None,
+            'Config': {},
+        }
+    },
 }
 
 
@@ -1811,6 +1819,31 @@ def _validate_input(kwargs,
                 'pid_mode can only be \'host\', if set'
             )
 
+    def _valid_log_config(): # pylint: disable=unused-variable
+        '''
+        Needs to be a dictionary that might contain keys (type|Type) and (config|Config)
+        '''
+        try:
+            _valid_dict('log_config')
+        except SaltInvocationError:
+            raise SaltInvocationError(
+                'log_config must be of type \'dict\', if set'
+            )
+
+        log_config = kwargs.get('log_config')
+        log_config_type = log_config.get('Type', None)
+        if log_config_type and not isinstance(log_config_type,
+                                              six.string_types):
+            raise SaltInvocationError(
+                'log_config[\'type\'] must be of type \'str\''
+            )
+
+        log_config_config = log_config.get('Config', {})
+        if log_config_config and not isinstance(log_config_config, dict):
+            raise SaltInvocationError(
+                'log_config[\'config\'] must be of type \'dict\''
+            )
+
     def _valid_labels():  # pylint: disable=unused-variable
         '''
         Must be a dict or a list of strings
@@ -3013,6 +3046,14 @@ def create(image,
         container. Requires Docker 1.5.0 or newer.
 
         Example: ``pid_mode=host``
+
+    log_config
+        Set container's log driver and options
+
+        Example: ``log_conf:
+                     Type: json-file
+                     Config:
+                       max-file: '10'``
 
     **RETURN DATA**
 

--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -422,6 +422,17 @@ def _compare(actual, create_kwargs, defaults_from_image):
             if actual_data != data:
                 ret.update({item: {'old': actual_data, 'new': data}})
                 continue
+        elif item == 'log_config':
+            # https://github.com/saltstack/salt/issues/30577#issuecomment-238322721
+            if not data.get('Config', None) and actual_data.get('Config', None):
+                data['Config'] = {}
+                actual_data['Config'] = {}
+            if not data.get('Type', None) and actual_data.get('Type', None):
+                data['Type'] = None
+                actual_data['Type'] = None
+            if data != actual_data:
+                ret.update({item: {'old': actual_data, 'new': data}})
+            continue
         elif item in ('cmd', 'command', 'entrypoint'):
             if (actual_data is None and item not in create_kwargs and
                     _image_get(config['image_path'])):


### PR DESCRIPTION
### What does this PR do?

Add log_config option to dockerng module
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/30577
### New Behavior

Can now configure container's log driver and options
### Tests written?

No

This is a hack to get log_config working with dockerng. Currently, there is
no way to clear/override the daemon's log options. This makes _compare() not
happy, after it checks if the changes were applied correctly. _compare() will
continue to see a diff, since the container is inheriting the daemon's log
options.

The other known problem is that there is no remote API for querying the daemon's
log options. This makes detecting if there are changes difficult. If the user
specifies nothing in the state file, how will salt know if there is a diff, since
it doesn't know what the default log options should be, since they are configured
at daemon startup. This change will take no action if the state file doesn't not
reference log_config. If the operator wants to have the container use the same
log options as the daemon, they will either have to set them in the state file,
or remove the container and have salt redeploy it.

Additional reading: https://github.com/saltstack/salt/issues/30577#issuecomment-238322721