### PR TITLE
fix 34425, a bug that sys.doc cannot output format

### DIFF
--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -364,10 +364,13 @@ class SaltCMD(parsers.SaltCMDOptionParser):
             if ret[host] == 'Minion did not return. [Not connected]':
                 continue
             for fun in ret[host]:
-                if fun not in docs:
-                    if ret[host][fun]:
-                        docs[fun] = ret[host][fun]
-        for fun in sorted(docs):
-            salt.output.display_output(fun + ':', 'nested', self.config)
-            print_cli(docs[fun])
-            print_cli('')
+                if fun not in docs and ret[host][fun]:
+                    docs[fun] = ret[host][fun]
+        if 'output' in self.config:
+            for fun in sorted(docs):
+                salt.output.display_output({fun: docs[fun]}, 'nested', self.config)
+        else:
+            for fun in sorted(docs):
+                print_cli('{0}:'.format(fun))
+                print_cli(docs[fun])
+                print_cli('')


### PR DESCRIPTION
### What does this PR do?

Fix https://github.com/saltstack/salt/issues/34425
### What issues does this PR fix or reference?
### Previous Behavior

For more details, please check https://github.com/saltstack/salt/issues/34425
In short, `salt minion1 sys.doc test.ping --out json` cannot output as the format configured.
### New Behavior

```
salt minion1 sys.doc test.ping --out json
{
    "test.ping": "\n    Used to make sure the minion is up and responding. Not an ICMP ping.\n\n    Returns ``True``.\n\n    CLI Example:\n\n        salt '*' test.ping\n    "
}
```

```
salt minion1 sys.doc test.ping
test.ping:

    Used to make sure the minion is up and responding. Not an ICMP ping.

    Returns ``True``.

    CLI Example:

        salt '*' test.ping

```
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
