### PR TITLE
Avoid str to bytes join in test util

### DIFF
--- a/tests/integration/utils/testprogram.py
+++ b/tests/integration/utils/testprogram.py
@@ -902,8 +902,8 @@ class TestProgramCase(TestCase):
 
         ex_val = getattr(exitcodes, ex_status)
         _message = '' if not message else ' ({0})'.format(message)
-        _stdout = '' if not stdout else '\nstdout: {0}'.format('\nstdout: '.join(stdout))
-        _stderr = '' if not stderr else '\nstderr: {0}'.format('\nstderr: '.join(stderr))
+        _stdout = '' if not stdout else '\nstdout: {0}'.format(stdout)
+        _stderr = '' if not stderr else '\nstderr: {0}'.format(stderr)
         self.assertEqual(
             status,
             ex_val,


### PR DESCRIPTION
Fixes some shell.call tests.
