### PR TITLE
beacons: fix pyroute2 import statement

### DIFF
--- a/salt/beacons/network_settings.py
+++ b/salt/beacons/network_settings.py
@@ -8,7 +8,7 @@ Beacon to monitor network adapter setting changes on Linux
 from __future__ import absolute_import
 # Import third party libs
 try:
-    from pyroute2.ipdb import IPDB
+    from pyroute2 import IPDB
     IP = IPDB()
     HAS_PYROUTE2 = True
 except ImportError:


### PR DESCRIPTION
### What does this PR do?

Fixes the import statement so the beacons code uses the public pyroute2 API
### What issues does this PR fix or reference?
saltstack/salt#34978
### Tests written?

Not needed (this API is being tested in the pyroute2 CI)

Bug-Url: https://github.com/saltstack/salt/issues/34978