### PR TITLE
Use salt.utils.normalize_mode() instead of coercing int modes to octal

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2437,8 +2437,8 @@ def create(vm_=None, call=None):
                 )
             )
 
-        key_mode = str(
-            oct(stat.S_IMODE(os.stat(key_filename).st_mode))
+        key_mode = salt.utils.normalize_mode(
+            stat.S_IMODE(os.stat(key_filename).st_mode)
         )
         if key_mode not in ('0400', '0600'):
             raise SaltCloudSystemExit(

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -1043,8 +1043,8 @@ class RemoteClient(Client):
                                     '\'%s\', mode updated from %s to %s',
                                     saltenv,
                                     path,
-                                    salt.utils.st_mode_to_octal(mode_local),
-                                    salt.utils.st_mode_to_octal(mode_server)
+                                    salt.utils.normalize_mode(mode_local),
+                                    salt.utils.normalize_mode(mode_server)
                                 )
                             except OSError as exc:
                                 log.warning(
@@ -1183,7 +1183,7 @@ class RemoteClient(Client):
                                 '** done ** \'%s\', mode set to %s',
                                 saltenv,
                                 path,
-                                salt.utils.st_mode_to_octal(mode_server)
+                                salt.utils.normalize_mode(mode_server)
                             )
                         except OSError:
                             log.warning('Failed to chmod %s: %s', dest, exc)

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3110,7 +3110,7 @@ def stats(path, hash_type=None, follow_symlinks=True):
     ret['mtime'] = pstat.st_mtime
     ret['ctime'] = pstat.st_ctime
     ret['size'] = pstat.st_size
-    ret['mode'] = str(oct(stat.S_IMODE(pstat.st_mode)))
+    ret['mode'] = salt.utils.normalize_mode(stat.S_IMODE(pstat.st_mode))
     if hash_type:
         ret['sum'] = get_hash(path, hash_type)
     ret['type'] = 'file'
@@ -3968,7 +3968,7 @@ def check_managed_changes(
             if _urlparse(source).scheme in ('salt', 'file') \
                     or source.startswith('/'):
                 try:
-                    mode = salt.utils.st_mode_to_octal(os.stat(sfn).st_mode)
+                    mode = salt.utils.normalize_mode(os.stat(sfn).st_mode)
                 except Exception as exc:
                     log.warning('Unable to stat %s: %s', sfn, exc)
     changes = check_file_meta(name, sfn, source, source_sum, user,
@@ -4258,7 +4258,7 @@ def manage_file(name,
             if _urlparse(source).scheme in ('salt', 'file') \
                     or source.startswith('/'):
                 try:
-                    mode = salt.utils.st_mode_to_octal(os.stat(sfn).st_mode)
+                    mode = salt.utils.normalize_mode(os.stat(sfn).st_mode)
                 except Exception as exc:
                     log.warning('Unable to stat %s: %s', sfn, exc)
 

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -482,7 +482,7 @@ class Query(EnvLoader):
                     'uid': self._id_resolv(pld_data.uid, named=(owners == "id")),
                     'gid': self._id_resolv(pld_data.gid, named=(owners == "id"), uid=False),
                     'size': _size_format(pld_data.p_size, fmt=size_fmt),
-                    'mode': oct(pld_data.mode),
+                    'mode': salt.utils.normalize_mode(pld_data.mode),
                     'accessed': tfmt(pld_data.atime),
                     'modified': tfmt(pld_data.mtime),
                     'created': tfmt(pld_data.ctime),

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -882,7 +882,7 @@ def stats(path, hash_type='sha256', follow_symlinks=True):
     ret['mtime'] = pstat.st_mtime
     ret['ctime'] = pstat.st_ctime
     ret['size'] = pstat.st_size
-    ret['mode'] = str(oct(stat.S_IMODE(pstat.st_mode)))
+    ret['mode'] = salt.utils.normalize_mode(stat.S_IMODE(pstat.st_mode))
     if hash_type:
         ret['sum'] = get_sum(path, hash_type)
     ret['type'] = 'file'

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1831,17 +1831,6 @@ def check_state_result(running, recurse=False):
     return ret
 
 
-def st_mode_to_octal(mode):
-    '''
-    Convert the st_mode value from a stat(2) call (as returned from os.stat())
-    to an octal mode.
-    '''
-    try:
-        return oct(mode)[-4:]
-    except (TypeError, IndexError):
-        return ''
-
-
 def normalize_mode(mode):
     '''
     Return a mode value, normalized to a string and containing a leading zero
@@ -1852,11 +1841,13 @@ def normalize_mode(mode):
     '''
     if mode is None:
         return None
-    if not isinstance(mode, six.string_types):
+    if isinstance(mode, six.integer_types):
+        mode = oct(mode)
+    elif not isinstance(mode, six.string_types):
         mode = str(mode)
-    # Strip any quotes any initial zeroes, then though zero-pad it up to 4.
-    # This ensures that somethign like '00644' is normalized to '0644'
-    return mode.strip('"').strip('\'').lstrip('0').zfill(4)
+    # Strip any quotes, initial zeroes, and Python 3's octal specifier "o",
+    # then zero-pad it up to 4. This ensures that we get a 4-digit octal mode.
+    return mode.strip('"').strip('\'').lstrip('0o').zfill(4)
 
 
 def test_mode(**kwargs):

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -3139,7 +3139,7 @@ def check_key_path_and_mode(provider, key_path):
         )
         return False
 
-    key_mode = str(oct(stat.S_IMODE(os.stat(key_path).st_mode)))
+    key_mode = salt.utils.normalize_mode(stat.S_IMODE(os.stat(key_path).st_mode))
     if key_mode not in ('0400', '0600'):
         log.error(
             'The key file \'{0}\' used in the \'{1}\' provider configuration '


### PR DESCRIPTION
This function was written by me a few weeks ago in the process of implementing mode preservation in `file.managed` and `file.recurse` states. However, upon discovering how much we were manually using `oct()` in Salt code to obtain octal mode strings, I realized that these instances would be negatively impacted when run in Python 3.

This pull request consolidates `salt.utils.st_mode_to_octal()` into `salt.utils.normalize_mode()`, and makes a change to normalize_mode which strips the Python 3 octal string specifier (i.e. the `0o` in `0o2775`).

This helps us in two ways:
1. Provides a single interface in Salt for returning a 4-character octal mode string, even when an integer mode is passed in.
2. Corrects for differences in the output of `oct()` between Python 2 and 3. For example:
#### Python 2

``` python
Python 2.7.12 (default, Jun 28 2016, 08:31:05)
[GCC 6.1.1 20160602] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> oct(420)
'0644'
>>> import salt.utils
>>> salt.utils.normalize_mode(420)
'0644'
>>>
>>> salt.utils.normalize_mode('644')
'0644'
>>> salt.utils.normalize_mode('0644')
'0644'
```
#### Python 3

``` python
Python 3.5.2 (default, Jun 28 2016, 08:46:01)
[GCC 6.1.1 20160602] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> oct(420)
'0o644'
>>>
>>> import salt.utils
>>> salt.utils.normalize_mode(420)
'0644'
>>> salt.utils.normalize_mode('644')
'0644'
>>> salt.utils.normalize_mode('0o644')
'0644'
```
