### PR TITLE
Fix: `salt-key -f master.pub`

### DIFF
--- a/salt/key.py
+++ b/salt/key.py
@@ -165,7 +165,8 @@ class KeyCLI(object):
         ret = self.client.cmd_sync(low)
 
         ret = ret['data']['return']
-        if isinstance(ret, dict) and 'local' in ret:
+        if (isinstance(ret, dict) and 'local' in ret and
+                cmd not in ('finger', 'finger_all')):
             ret.pop('local', None)
 
         return ret


### PR DESCRIPTION
### What does this PR do?

The command `salt-key -f master.pub` was broken by PR #35015. This is
because it now requests the keys from the master via
`salt.wheel.WheelClient` and always filters out `local` in the return
value. Change it so that `local` is not filtered out in the case of the
`finger` and `finger_all` commands. These commands require all keys
including the local ones.
### Tests written?

No
