### PR TITLE
Change deprecation tag from Oxygen to Carbon

### DIFF
--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -663,7 +663,7 @@ def bootstrap(version='develop',
 
         .. versionchanged:: Carbon
 
-        .. deprecated:: Oxygen
+        .. deprecated:: Carbon
 
     script_args
         Any additional arguments that you want to pass to the script.


### PR DESCRIPTION
Deprecation tags should denote when an option goes on the deprecation
path and a warn_until is issued, not when the option is removed completely.
