### PR TITLE
Fix bug plus logic in sys.renderer_doc

### DIFF
--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -314,12 +314,14 @@ def renderer_doc(*args):
         return _strip_rst(docs)
 
     for module in args:
-        if '*' in module:
+        if '*' in module or '.' in module:
             for fun in fnmatch.filter(renderers_.keys(), module):
                 docs[fun] = renderers_[fun].__doc__
         else:
+            moduledot = module + '.'
             for fun in six.iterkeys(renderers_):
-                docs[fun] = renderers_[fun].__doc__
+                if fun.startswith(moduledot):
+                    docs[fun] = renderers_[fun].__doc__
     return _strip_rst(docs)
 
 

--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -309,19 +309,19 @@ def renderer_doc(*args):
     renderers_ = salt.loader.render(__opts__, [])
     docs = {}
     if not args:
-        for fun in six.iterkeys(renderers_):
-            docs[fun] = renderers_[fun].__doc__
+        for func in six.iterkeys(renderers_):
+            docs[func] = renderers_[func].__doc__
         return _strip_rst(docs)
 
     for module in args:
         if '*' in module or '.' in module:
-            for fun in fnmatch.filter(renderers_.keys(), module):
-                docs[fun] = renderers_[fun].__doc__
+            for func in fnmatch.filter(renderers_.keys(), module):
+                docs[func] = renderers_[func].__doc__
         else:
             moduledot = module + '.'
-            for fun in six.iterkeys(renderers_):
-                if fun.startswith(moduledot):
-                    docs[fun] = renderers_[fun].__doc__
+            for func in six.iterkeys(renderers_):
+                if func.startswith(moduledot):
+                    docs[func] = renderers_[func].__doc__
     return _strip_rst(docs)
 
 


### PR DESCRIPTION
### What does this PR do?

Fix bug in sys.renderer_doc: any non-glob argument returns docstrings for all functions
Fix logic: arguments in the form of exact module, module with glob, exact function, function with glob all work now

_(Note: I did the s/fun/func in order to help track where I am in terms of my looking at the code)_

Up for discussion:

[1] I would like to remove the use of `six.iterkeys`. Don't really see a need for it. I mean, the `for key in dict:` form works both in python2, and python3?

These are the relevant lines in six for iterkeys:

```
if PY3:
    def iterkeys(d, **kw):
        return iter(d.keys(**kw))
...
else:
    def iterkeys(d, **kw):
        return iter(d.iterkeys(**kw))
```

Update: does http://stackoverflow.com/a/3295295 (which references PEP 234) have any relevance? For Python2, `d.iterkeys()` returns an iterator already. What's with wrapping another `iter()` around it?

[2] ~~likewise the use of `.keys()` in `fnmatch.filter(renderers_.keys(), module)`. Is there a need for this?~~ Ok interestingly, pylint flags the use of `.keys()` on another line (84), but not this one:

`for fun in fnmatch.filter(__salt__.keys(), target_mod):`
(https://github.com/jf/salt/blob/fc66053be4500d301c91b9a5137a422324254b87/salt/modules/sysmod.py#L84)

with a

`C0201(consider-iterating-dictionary)` `Consider iterating the dictionary directly instead of calling .keys()`

I know that `renderers_` is a dictionary too... So I'm just going to call this a "yes", and go ahead and remove these `.keys()` instances.
### What issues does this PR fix or reference?

None. Filing as a `(issue, PR which fixes it)` tuple
### Previous Behavior

`sys.renderer_doc` does not behave as expected
### New Behavior

`sys.renderer_doc` behaves as expected
### Tests written?

No new tests (unit tests are being reworked and will be PR-ed separately).
