### PR TITLE
Remove legacy compat docs in mysql pillar since the code was removed already

### DIFF
--- a/salt/pillar/mysql.py
+++ b/salt/pillar/mysql.py
@@ -11,17 +11,6 @@ This module is a concrete implementation of the sql_base ext_pillar for MySQL.
 :depends: python-mysqldb
 :platform: all
 
-Legacy compatibility
-=====================================
-
-This module has an extra addition for backward compatibility.
-
-If there's a keyword arg of mysql_query, that'll go first before other args.
-This legacy compatibility translates to depth 1.
-
-We do this so that it's backward compatible with older configs.
-This is deprecated and slated to be removed in Carbon.
-
 Configuring the mysql ext_pillar
 =====================================
 


### PR DESCRIPTION
Refs #30913, and more specifically this commit: 4fd6bdeaf24b9478cf4d4bf9f8fd3f8c19ba78cf 
