### PR TITLE
Use Carbon instead of Boron for new develop functions/args/kwargs

### DIFF
--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -219,7 +219,7 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
     the current VM/template\'s vCPU count is used.
 
 ``cores_per_socket``
-    .. versionadded:: Boron
+    .. versionadded:: Carbon
     Enter the number of cores per vCPU that you want the VM/template to have. If not specified,
     this will default to 1. 
     

--- a/doc/topics/netapi/writing.rst
+++ b/doc/topics/netapi/writing.rst
@@ -43,7 +43,7 @@ actually starts the service. This is started in a multiprocess.
 Multiple instances
 ==================
 
-.. versionadded:: Boron
+.. versionadded:: Carbon
 
 :py:mod:`~salt.netapi.rest_cherrypy` and :py:mod:`~salt.netapi.rest_tornado`
 support running multiple instances by copying and renaming entire directory

--- a/salt/modules/boto_cognitoidentity.py
+++ b/salt/modules/boto_cognitoidentity.py
@@ -2,7 +2,7 @@
 '''
 Connection module for Amazon CognitoIdentity
 
-.. versionadded:: Boron
+.. versionadded:: Carbon
 
 :configuration: This module accepts explicit CognitoIdentity credentials but can also
     utilize IAM roles assigned to the instance trough Instance Profiles.

--- a/salt/modules/firewalld.py
+++ b/salt/modules/firewalld.py
@@ -73,7 +73,7 @@ def reload_rules():
     Reload the firewall rules, which makes the permanent configuration the new
     runtime configuration without losing state information.
 
-    .. versionadded:: Boron
+    .. versionadded:: Carbon
 
     CLI Example:
 
@@ -438,7 +438,7 @@ def add_service_port(service, port):
     '''
     Add a new port to the specified service.
 
-    .. versionadded:: Boron
+    .. versionadded:: Carbon
 
     CLI Example:
 
@@ -457,7 +457,7 @@ def remove_service_port(service, port):
     '''
     Remove a port from the specified service.
 
-    .. versionadded:: Boron
+    .. versionadded:: Carbon
 
     CLI Example:
 
@@ -476,7 +476,7 @@ def get_service_ports(service):
     '''
     List ports of a service.
 
-    .. versionadded:: Boron
+    .. versionadded:: Carbon
 
     CLI Example:
 
@@ -492,7 +492,7 @@ def add_service_protocol(service, protocol):
     '''
     Add a new protocol to the specified service.
 
-    .. versionadded:: Boron
+    .. versionadded:: Carbon
 
     CLI Example:
 
@@ -509,7 +509,7 @@ def remove_service_protocol(service, protocol):
     '''
     Remove a protocol from the specified service.
 
-    .. versionadded:: Boron
+    .. versionadded:: Carbon
 
     CLI Example:
 
@@ -526,7 +526,7 @@ def get_service_protocols(service):
     '''
     List protocols of a service.
 
-    .. versionadded:: Boron
+    .. versionadded:: Carbon
 
     CLI Example:
 
@@ -994,7 +994,7 @@ def get_rich_rules(zone, permanent=True):
     '''
     List rich rules bound to a zone
 
-    .. versionadded:: Boron
+    .. versionadded:: Carbon
 
     CLI Example:
 
@@ -1014,7 +1014,7 @@ def add_rich_rule(zone, rule, permanent=True):
     '''
     Add a rich rule to a zone
 
-    .. versionadded:: Boron
+    .. versionadded:: Carbon
 
     CLI Example:
 
@@ -1034,7 +1034,7 @@ def remove_rich_rule(zone, rule, permanent=True):
     '''
     Add a rich rule to a zone
 
-    .. versionadded:: Boron
+    .. versionadded:: Carbon
 
     CLI Example:
 

--- a/salt/modules/smartos_nictagadm.py
+++ b/salt/modules/smartos_nictagadm.py
@@ -6,7 +6,7 @@ Module for running nictagadm command on SmartOS
 :depends:       nictagadm binary, dladm binary
 :platform:      smartos
 
-..versionadded: Boron
+..versionadded: Carbon
 
 '''
 from __future__ import absolute_import

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -250,12 +250,12 @@ def extracted(name,
     use_cmd_unzip
         When archive_format is zip, setting this flag to True will use the archive.cmd_unzip module function
 
-        .. versionadded:: Boron
+        .. versionadded:: Carbon
 
     kwargs
         kwargs to pass to the archive.unzip or archive.unrar function
 
-        .. versionadded:: Boron
+        .. versionadded:: Carbon
     '''
     ret = {'name': name, 'result': None, 'changes': {}, 'comment': ''}
     valid_archives = ('tar', 'rar', 'zip')

--- a/salt/states/boto_cognitoidentity.py
+++ b/salt/states/boto_cognitoidentity.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 '''
 Manage CognitoIdentity Functions
-=================
+================================
 
-.. versionadded:: Boron
+.. versionadded:: Carbon
 
 Create and destroy CognitoIdentity identity pools. Be aware that this interacts with
 Amazon's services, and so may incur charges.

--- a/salt/states/firewalld.py
+++ b/salt/states/firewalld.py
@@ -194,7 +194,7 @@ def service(name,
     Ensure the service exists and encompasses the specified ports and
     protocols.
 
-    .. versionadded:: Boron
+    .. versionadded:: Carbon
     '''
     ret = {'name': name,
            'result': False,


### PR DESCRIPTION
A bunch of new features have been added to develop since the `Boron` release (2016.3.0), but versionadded tags were still added with the Boron codename instead of `Carbon`. This fixes the discrepancy.
