### PR TITLE
Fix freebsd netstat route on fbsd 10+

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -385,13 +385,22 @@ def _netstat_route_freebsd():
     out = __salt__['cmd.run'](cmd, python_shell=True)
     for line in out.splitlines():
         comps = line.split()
-        ret.append({
-            'addr_family': 'inet',
-            'destination': comps[0],
-            'gateway': comps[1],
-            'netmask': comps[2],
-            'flags': comps[3],
-            'interface': comps[5]})
+        if __grains__['os'] == 'FreeBSD' and __grains__.get('osmajorrelease', 0) < 10:
+            ret.append({
+                'addr_family': 'inet',
+                'destination': comps[0],
+                'gateway': comps[1],
+                'netmask': comps[2],
+                'flags': comps[3],
+                'interface': comps[5]})
+        else:
+            ret.append({
+                'addr_family': 'inet',
+                'destination': comps[0],
+                'gateway': comps[1],
+                'netmask': '',
+                'flags': comps[2],
+                'interface': comps[3]})
     cmd = 'netstat -f inet6 -rn | tail -n+5'
     out = __salt__['cmd.run'](cmd, python_shell=True)
     for line in out.splitlines():


### PR DESCRIPTION
### What does this PR do?

netstat seems to have changed in fbsd 10 and up.  I don't have a fbsd 9 box to test, but the old function works on fbsd 8.  Thanks to LLNW coworker Greg Phelps for discovery and fix proposal.
### What issues does this PR fix or reference?

If we are on fbsd10, use the right column indexes
### Previous Behavior

fbsd10+ will print a backtrace when running this function
### New Behavior

fbsd10+ work with this function, fbsd8 continues to work
### Tests written?

No
