### PR TITLE
sys.doc will skip all not connected minions

### DIFF
--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -250,8 +250,8 @@ class SaltCMD(parsers.SaltCMDOptionParser):
             print_cli('---------------------------')
             print_cli('Errors')
             print_cli('---------------------------')
-            for minion in errors:
-                print_cli(self._format_error(minion))
+            for error in errors:
+                print_cli(self._format_error(error))
 
     def _print_returns_summary(self, ret):
         '''
@@ -361,12 +361,12 @@ class SaltCMD(parsers.SaltCMDOptionParser):
         if isinstance(ret, str):
             self.exit(2, '{0}\n'.format(ret))
         for host in ret:
-            if ret[host] == 'Minion did not return. [Not connected]':
+            if isinstance(ret[host], string_types) and ret[host].startswith("Minion did not return"):
                 continue
             for fun in ret[host]:
                 if fun not in docs and ret[host][fun]:
                     docs[fun] = ret[host][fun]
-        if 'output' in self.config:
+        if self.options.output:
             for fun in sorted(docs):
                 salt.output.display_output({fun: docs[fun]}, 'nested', self.config)
         else:


### PR DESCRIPTION
### What does this PR do?

This is kind of follow up for this PR: https://github.com/saltstack/salt/pull/35286 (already merged)
where I found some more places to improve. 

Minor changes. 
Improve some code style as well.
### What issues does this PR fix or reference?
### Previous Behavior

sys.doc will only skip the minions which are not connected as return with exception 
`Minion did not return [not connected]`
### New Behavior

sys.doc will skip all the minions which do not return successfully, including exceptions with:
`Minion did not return`
`Minion did not return [not connected]`
`Minion did not return [no response]`
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
