### PR TITLE
fix 35165, salt-run jobs.exit_success jid is broken

### DIFF
--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -507,14 +507,19 @@ def exit_success(jid, ext_source=None):
     '''
     ret = dict()
 
-    data = lookup_jid(
+    data = list_job(
         jid,
         ext_source=ext_source
     )
 
-    for minion in data:
-        if "retcode" in data[minion]:
-            ret[minion] = True if not data[minion]['retcode'] else False
+    minions = data['Minions']
+    result = data['Result']
+
+    for minion in minions:
+        if minion in result and 'return' in result[minion]:
+            ret[minion] = True if result[minion]['return'] else False
+        else:
+            ret[minion] = False
 
     return ret
 


### PR DESCRIPTION
### What does this PR do?

Fix https://github.com/saltstack/salt/issues/35165
For more details about the issue, please check the issue url.

A little bit more details about the fix:
It is calling `list_job` rather than `lookup_jid` because `lookup_jid` only returns successful `'Result'` of returned minions whereas `list_job` returns more info which include failed minions as well. 
From the load perspective, calling `list_job` is same as calling `lookup_jid` because `lookup_jid` just calls `list_job` and trim the `'Result'`. 

`exit_success` will return `True` for minions that have successful returns and `False` for those that don't have returns or defunct returns. 

`retcode` is not able to be used in determining job success because all of the job management and execution codes do not have `retcode` as a field. Feel free to correct me if I am wrong
### What issues does this PR fix or reference?
### Previous Behavior

Check the issue for more details. 
In short, `salt-run jobs.exit_success jid` is broken
### New Behavior

```
salt-run jobs.exit_success jid
minion1:
    False
minion2:
    True
```
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.