### PR TITLE
Fix more bugs sys.list runners,returners,renderers

### DIFF
--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -817,18 +817,18 @@ def list_renderers(*args):
         salt '*' sys.list_renderers 'yaml*'
 
     '''
-    ren_ = salt.loader.render(__opts__, [])
-    ren = set()
+    renderers_ = salt.loader.render(__opts__, [])
+    renderers = set()
 
     if not args:
-        for func in six.iterkeys(ren_):
-            ren.add(func)
-        return sorted(ren)
+        for rend in six.iterkeys(renderers_):
+            renderers.add(rend)
+        return sorted(renderers)
 
     for module in args:
-        for func in fnmatch.filter(ren_, module):
-            ren.add(func)
-    return sorted(ren)
+        for rend in fnmatch.filter(renderers_, module):
+            renderers.add(rend)
+    return sorted(renderers)
 
 
 def _argspec_to_schema(mod, spec):

--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -737,18 +737,18 @@ def list_returners(*args):
 
     if not args:
         for func in six.iterkeys(returners_):
-            comps = func.split('.')
-            if len(comps) < 2:
-                continue
-            returners.add(comps[0])
+            returners.add(func.split('.')[0])
         return sorted(returners)
 
     for module in args:
-        for func in fnmatch.filter(returners_.keys(), module):
-            comps = func.split('.')
-            if len(comps) < 2:
-                continue
-            returners.add(comps[0])
+        if '*' not in module:
+            for func in returners_:
+                comps = func.split('.')
+                if comps[0] == module:
+                    returners.add(comps[0])
+        else:
+            for func in fnmatch.filter(returners_.keys(), module):
+                returners.add(func.split('.')[0])
     return sorted(returners)
 
 

--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -314,12 +314,14 @@ def renderer_doc(*args):
         return _strip_rst(docs)
 
     for module in args:
-        if '*' in module:
+        if '*' in module or '.' in module:
             for fun in fnmatch.filter(renderers_.keys(), module):
                 docs[fun] = renderers_[fun].__doc__
         else:
+            moduledot = module + '.'
             for fun in six.iterkeys(renderers_):
-                docs[fun] = renderers_[fun].__doc__
+                if fun.startswith(moduledot):
+                    docs[fun] = renderers_[fun].__doc__
     return _strip_rst(docs)
 
 

--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -309,19 +309,19 @@ def renderer_doc(*args):
     renderers_ = salt.loader.render(__opts__, [])
     docs = {}
     if not args:
-        for fun in six.iterkeys(renderers_):
-            docs[fun] = renderers_[fun].__doc__
+        for func in six.iterkeys(renderers_):
+            docs[func] = renderers_[func].__doc__
         return _strip_rst(docs)
 
     for module in args:
         if '*' in module or '.' in module:
-            for fun in fnmatch.filter(renderers_.keys(), module):
-                docs[fun] = renderers_[fun].__doc__
+            for func in fnmatch.filter(renderers_.keys(), module):
+                docs[func] = renderers_[func].__doc__
         else:
             moduledot = module + '.'
-            for fun in six.iterkeys(renderers_):
-                if fun.startswith(moduledot):
-                    docs[fun] = renderers_[fun].__doc__
+            for func in six.iterkeys(renderers_):
+                if func.startswith(moduledot):
+                    docs[func] = renderers_[func].__doc__
     return _strip_rst(docs)
 
 

--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -400,14 +400,14 @@ def list_modules(*args):
         return sorted(modules)
 
     for module in args:
-        if '*' not in module:
+        if '*' in module:
+            for func in fnmatch.filter(__salt__, module):
+                modules.add(func.split('.')[0])
+        else:
             for func in __salt__:
                 mod_test = func.split('.')[0]
                 if mod_test == module:
                     modules.add(mod_test)
-        else:
-            for func in fnmatch.filter(__salt__, module):
-                modules.add(func.split('.')[0])
     return sorted(modules)
 
 
@@ -612,14 +612,14 @@ def list_state_modules(*args):
         return sorted(modules)
 
     for module in args:
-        if '*' not in module:
+        if '*' in module:
+            for func in fnmatch.filter(st_.states, module):
+                modules.add(func.split('.')[0])
+        else:
             for func in st_.states:
                 mod_test = func.split('.')[0]
                 if mod_test == module:
                     modules.add(mod_test)
-        else:
-            for func in fnmatch.filter(st_.states, module):
-                modules.add(func.split('.')[0])
     return sorted(modules)
 
 
@@ -652,14 +652,14 @@ def list_runners(*args):
         return sorted(runners)
 
     for module in args:
-        if '*' not in module:
+        if '*' in module:
+            for func in fnmatch.filter(run_.functions, module):
+                runners.add(func.split('.')[0])
+        else:
             for func in run_.functions:
                 mod_test = func.split('.')[0]
                 if mod_test == module:
                     runners.add(mod_test)
-        else:
-            for func in fnmatch.filter(run_.functions, module):
-                runners.add(func.split('.')[0])
     return sorted(runners)
 
 
@@ -739,14 +739,14 @@ def list_returners(*args):
         return sorted(returners)
 
     for module in args:
-        if '*' not in module:
+        if '*' in module:
+            for func in fnmatch.filter(returners_, module):
+                returners.add(func.split('.')[0])
+        else:
             for func in returners_:
                 mod_test = func.split('.')[0]
                 if mod_test == module:
                     returners.add(mod_test)
-        else:
-            for func in fnmatch.filter(returners_, module):
-                returners.add(func.split('.')[0])
     return sorted(returners)
 
 

--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -81,7 +81,7 @@ def doc(*args):
         else:
             target_mod = ''
         if _use_fnmatch:
-            for fun in fnmatch.filter(__salt__.keys(), target_mod):
+            for fun in fnmatch.filter(__salt__, target_mod):
                 docs[fun] = __salt__[fun].__doc__
         else:
 
@@ -315,7 +315,7 @@ def renderer_doc(*args):
 
     for module in args:
         if '*' in module or '.' in module:
-            for func in fnmatch.filter(renderers_.keys(), module):
+            for func in fnmatch.filter(renderers_, module):
                 docs[func] = renderers_[func].__doc__
         else:
             moduledot = module + '.'
@@ -747,7 +747,7 @@ def list_returners(*args):
                 if comps[0] == module:
                     returners.add(comps[0])
         else:
-            for func in fnmatch.filter(returners_.keys(), module):
+            for func in fnmatch.filter(returners_, module):
                 returners.add(func.split('.')[0])
     return sorted(returners)
 

--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -396,16 +396,15 @@ def list_modules(*args):
     modules = set()
     if not args:
         for func in __salt__:
-            comps = func.split('.')
-            modules.add(comps[0])
+            modules.add(func.split('.')[0])
         return sorted(modules)
 
     for module in args:
         if '*' not in module:
             for func in __salt__:
-                comps = func.split('.')
-                if comps[0] == module:
-                    modules.add(comps[0])
+                mod_test = func.split('.')[0]
+                if mod_test == module:
+                    modules.add(mod_test)
         else:
             for func in fnmatch.filter(__salt__, module):
                 modules.add(func.split('.')[0])
@@ -609,16 +608,15 @@ def list_state_modules(*args):
     if not args:
         for func in st_.states:
             log.debug('func {0}'.format(func))
-            comps = func.split('.')
-            modules.add(comps[0])
+            modules.add(func.split('.')[0])
         return sorted(modules)
 
     for module in args:
         if '*' not in module:
             for func in st_.states:
-                comps = func.split('.')
-                if comps[0] == module:
-                    modules.add(comps[0])
+                mod_test = func.split('.')[0]
+                if mod_test == module:
+                    modules.add(mod_test)
         else:
             for func in fnmatch.filter(st_.states, module):
                 modules.add(func.split('.')[0])
@@ -656,9 +654,9 @@ def list_runners(*args):
     for module in args:
         if '*' not in module:
             for func in run_.functions:
-                comps = func.split('.')
-                if comps[0] == module:
-                    runners.add(comps[0])
+                mod_test = func.split('.')[0]
+                if mod_test == module:
+                    runners.add(mod_test)
         else:
             for func in fnmatch.filter(run_.functions, module):
                 runners.add(func.split('.')[0])
@@ -743,9 +741,9 @@ def list_returners(*args):
     for module in args:
         if '*' not in module:
             for func in returners_:
-                comps = func.split('.')
-                if comps[0] == module:
-                    returners.add(comps[0])
+                mod_test = func.split('.')[0]
+                if mod_test == module:
+                    returners.add(mod_test)
         else:
             for func in fnmatch.filter(returners_, module):
                 returners.add(func.split('.')[0])

--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -650,18 +650,18 @@ def list_runners(*args):
     runners = set()
     if not args:
         for func in run_.functions:
-            comps = func.split('.')
-            if len(comps) < 2:
-                continue
-            runners.add(comps[0])
+            runners.add(func.split('.')[0])
         return sorted(runners)
 
     for module in args:
-        for func in fnmatch.filter(run_.functions, module):
-            comps = func.split('.')
-            if len(comps) < 2:
-                continue
-            runners.add(comps[0])
+        if '*' not in module:
+            for func in run_.functions:
+                comps = func.split('.')
+                if comps[0] == module:
+                    runners.add(comps[0])
+        else:
+            for func in fnmatch.filter(run_.functions, module):
+                runners.add(func.split('.')[0])
     return sorted(runners)
 
 

--- a/tests/unit/modules/sysmod_test.py
+++ b/tests/unit/modules/sysmod_test.py
@@ -325,7 +325,7 @@ class SysmodTestCase(TestCase):
         self.assertListEqual(sysmod.list_runner_functions('sys.list'), [])
         self.assertListEqual(sysmod.list_runner_functions('exist.exist'), ['exist.exist'])
 
-    # 'list_returners' function tests: 3
+    # 'list_returners' function tests: 4
 
     def test_list_returners(self):
         '''
@@ -335,7 +335,7 @@ class SysmodTestCase(TestCase):
 
         self.assertListEqual(sysmod.list_returners('nonexist'), [])
 
-        #TODO self.assertListEqual(sysmod.list_returners('user'), ['user'])
+        self.assertListEqual(sysmod.list_returners('user'), ['user'])
 
         self.assertListEqual(sysmod.list_returners('s*'), ['sys', 'sysctl', 'system'])
 

--- a/tests/unit/modules/sysmod_test.py
+++ b/tests/unit/modules/sysmod_test.py
@@ -290,7 +290,7 @@ class SysmodTestCase(TestCase):
 
         self.assertListEqual(sysmod.list_state_modules('s*'), ['sys', 'sysctl', 'system'])
 
-    # 'list_runners' function tests: 1
+    # 'list_runners' function tests: 4
 
     def test_list_runners(self):
         '''
@@ -298,7 +298,11 @@ class SysmodTestCase(TestCase):
         '''
         self.assertListEqual(sysmod.list_runners(), _modules)
 
-        self.assertListEqual(sysmod.list_runners('m*'), [])
+        self.assertListEqual(sysmod.list_runners('nonexist'), [])
+
+        self.assertListEqual(sysmod.list_runners('user'), ['user'])
+
+        self.assertListEqual(sysmod.list_runners('s*'), ['sys', 'sysctl', 'system'])
 
     # 'list_runner_functions' function tests: 7
 

--- a/tests/unit/modules/sysmod_test.py
+++ b/tests/unit/modules/sysmod_test.py
@@ -360,7 +360,7 @@ class SysmodTestCase(TestCase):
         self.assertListEqual(sysmod.list_returner_functions('sys.list'), [])
         self.assertListEqual(sysmod.list_returner_functions('exist.exist'), ['exist.exist'])
 
-    # 'list_renderers' function tests: 1
+    # 'list_renderers' function tests: 4
 
     def test_list_renderers(self):
         '''
@@ -368,7 +368,11 @@ class SysmodTestCase(TestCase):
         '''
         self.assertListEqual(sysmod.list_renderers(), _functions)
 
-        self.assertListEqual(sysmod.list_renderers('sqlite3.get_*'), [])
+        self.assertListEqual(sysmod.list_renderers('nonexist'), [])
+
+        self.assertListEqual(sysmod.list_renderers('user.info'), ['user.info'])
+
+        self.assertListEqual(sysmod.list_renderers('syst*'), ['system.halt', 'system.reboot'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?

Fix bugs with sys.list_{runners,returners}, and write unit tests for sys.list_renderers

Note: this builds on top of #35315 
### What issues does this PR fix or reference?
### Previous Behavior

`sys.list_runners` and `sys.list_returners` bugged out when given any sort of non-glob argument, and will return nothing, even if there should be a match. e.g. `sys.list_returners couchdb`, `sys.list_runners cloud`
### New Behavior

`sys.list_runners` and `sys.list_returners` work now with non-glob arguments
### Tests written?

Yes
