### PR TITLE
Add test for non-ascii pkg.info_installed

### DIFF
--- a/tests/unit/modules/zypper_test.py
+++ b/tests/unit/modules/zypper_test.py
@@ -297,6 +297,17 @@ class ZypperTestCase(TestCase):
                     continue
                 self.assertEqual(installed['virgo-dummy'][pn_key], pn_val)
 
+    def test_info_installed_with_non_ascii_char(self):
+        '''
+        Test the return information of the named package(s), installed on the system whith non-ascii chars
+
+        :return:
+        '''
+        run_out = {'vīrgô': {'description': 'vīrgô d€šçripţiǫñ'}}
+        with patch.dict(zypper.__salt__, {'lowpkg.info': MagicMock(return_value=run_out)}):
+            installed = zypper.info_installed()
+            self.assertEqual(installed['vīrgô']['description'], 'vīrgô d€šçripţiǫñ')
+
     def test_info_available(self):
         '''
         Test return the information of the named package available for the system.


### PR DESCRIPTION
### What does this PR do?

adds a test for pkg.info_installed with non-ascii chars
### What issues does this PR fix or reference?
### Previous Behavior
### Tests written?

Yes