### PR TITLE
AsyncClientMixin should not daemonize on Windows

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -425,7 +425,7 @@ class AsyncClientMixin(object):
         Run this method in a multiprocess target to execute the function in a
         multiprocess and fire the return data on the event bus
         '''
-        if daemonize:
+        if daemonize and not salt.utils.is_windows():
             # Shutdown the multiprocessing before daemonizing
             salt.log.setup.shutdown_multiprocessing_logging()
 


### PR DESCRIPTION
### What does this PR do?

If `AsyncClientMixin` daemonizes on Windows, an exception is thrown
since `daemonize` calls `os.fork()` which isn't supported on Windows.
No longer daemonize on Windows.

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
### Tests written?

No
