### PR TITLE
Fix file.recurse with clean: True  on Windows (2016.3)

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -416,7 +416,7 @@ def _clean_dir(root, keep, exclude_pat):
             while True:
                 fn_ = os.path.dirname(fn_)
                 real_keep.add(fn_)
-                if fn_ in ['/', ''.join([os.path.splitdrive(fn_)[0], '\\'])]:
+                if fn_ in ['/', ''.join([os.path.splitdrive(fn_)[0], '\\\\'])]:
                     break
 
     def _delete_not_kept(nfn):
@@ -2458,7 +2458,7 @@ def recurse(name,
                 merge_ret(path, _ret)
                 return
             else:
-                os.remove(path)
+                __salt__['file.remove'](path)
                 _ret['changes'] = {'diff': 'Replaced file with a directory'}
                 merge_ret(path, _ret)
 


### PR DESCRIPTION
### What does this PR do?

Fixes an endless loop condition when clean = True. It was looking for `C:\\` in a list containing `['/', 'C:\']`. Uses the file module to remove a directory instead of os.remove. os.remove has issues in windows when there are symlinks in the directory.
### What issues does this PR fix or reference?

https://github.com/saltstack/zh/issues/879
### Previous Behavior

Windows would hang if clean: True
### New Behavior

Windows now returns back successfully
### Tests written?

No
