### PR TITLE
document log levels and warn on all logging below info

### DIFF
--- a/doc/ref/configuration/logging/index.rst
+++ b/doc/ref/configuration/logging/index.rst
@@ -69,8 +69,8 @@ The level of log record messages to send to the console. One of ``all``,
     log_level: warning
 
 .. note::
-    Add ``log_level: quiet```in salt configuration file to completely disable
-    logging. In case of running salt in command line use``--log-level=quiet``
+    Add ``log_level: quiet`` in salt configuration file to completely disable
+    logging. In case of running salt in command line use ``--log-level=quiet``
     instead.
 
 .. conf_log:: log_level_logfile

--- a/doc/ref/configuration/logging/index.rst
+++ b/doc/ref/configuration/logging/index.rst
@@ -10,6 +10,45 @@ system, please head over to the :doc:`logging development
 document</topics/development/logging>`, if all you're after is salt's logging
 configurations, please continue reading.
 
+
+.. conf_log:: log_levels
+
+Log Levels
+==========
+
+The log levels are ordered numerically such that setting the log level to a
+specific level will record all log statements at that level and higher.  For
+example, setting ``log_level: error`` will log statements at ``error``,
+``critical``, and ``quiet`` levels, although nothing *should* be logged at
+``quiet`` level.
+
+Most of the logging levels are defined by default in Python's logging library
+and can be found in the official `Python documentation
+<https://docs.python.org/library/logging.html#levels>`_.  Salt uses some more
+levels in addition to the standard levels.  All levels available in salt are
+shown in the table below.
+
+.. note::
+
+    Python dependencies used by salt may define and use additional logging
+    levels.  For example, the Python 2 version of the ``multiprocessing``
+    standard Python library `uses the levels
+    <https://docs.python.org/2/library/multiprocessing.html#logging>`_
+    ``subwarning``, 25 and ``subdebug``, 5.
+
+Level    Numeric value Description
+======== ============= ========================================================================
+quiet    1000          Nothing should be logged at this level
+critical   50          Critical errors
+error      40          Errors
+warning    30          Warnings
+info       20          Normal log information
+profile    15          Profiling information on salt performance
+debug      10          Information useful for debugging both salt implementations and salt code
+trace       5          More detailed code debugging information
+garbage     1          Even more debugging information
+all         0          Everything
+
 Available Configuration Settings
 ================================
 

--- a/doc/ref/configuration/logging/index.rst
+++ b/doc/ref/configuration/logging/index.rst
@@ -10,7 +10,6 @@ system, please head over to the :doc:`logging development
 document</topics/development/logging>`, if all you're after is salt's logging
 configurations, please continue reading.
 
-
 Available Configuration Settings
 ================================
 
@@ -19,29 +18,28 @@ Available Configuration Settings
 ``log_file``
 ------------
 
-The log records can be sent to a regular file, local path name, or network location.
-Remote logging works best when configured to use rsyslogd(8) (e.g.: ``file:///dev/log``),
-with rsyslogd(8) configured for network logging.  The format for remote addresses is:
-``<file|udp|tcp>://<host|socketpath>:<port-if-required>/<log-facility>``. Where ``log-facility`` is the symbolic name of a syslog facility as defined in the :ref:`SysLogHandler documentation <python2:logging.handlers.SysLogHandler.encodePriority>` . It defaults to ``LOG_USER``.
+The log records can be sent to a regular file, local path name, or network
+location.  Remote logging works best when configured to use rsyslogd(8) (e.g.:
+``file:///dev/log``), with rsyslogd(8) configured for network logging.  The
+format for remote addresses is:
+``<file|udp|tcp>://<host|socketpath>:<port-if-required>/<log-facility>``. Where
+``log-facility`` is the symbolic name of a syslog facility as defined in the
+:ref:`SysLogHandler documentation
+<python2:logging.handlers.SysLogHandler.encodePriority>` . It defaults to
+``LOG_USER``.
 
-Default: Dependent of the binary being executed, for example, for ``salt-master``,
-``/var/log/salt/master``.
-
-
-
+Default: Dependent of the binary being executed, for example, for
+``salt-master``, ``/var/log/salt/master``.
 
 Examples:
-
 
 .. code-block:: yaml
 
     log_file: /var/log/salt/master
 
-
 .. code-block:: yaml
 
     log_file: /var/log/salt/minion
-
 
 .. code-block:: yaml
 
@@ -54,8 +52,6 @@ Examples:
 .. code-block:: yaml
 
     log_file: udp://loghost:10514
-
-
 
 .. conf_log:: log_level
 
@@ -77,7 +73,6 @@ The level of log record messages to send to the console. One of ``all``,
     logging. In case of running salt in command line use``--log-level=quiet``
     instead.
 
-
 .. conf_log:: log_level_logfile
 
 ``log_level_logfile``
@@ -93,8 +88,6 @@ The level of messages to send to the log file. One of ``all``, ``garbage``,
 
     log_level_logfile: warning
 
-
-
 .. conf_log:: log_datefmt
 
 ``log_datefmt``
@@ -109,8 +102,6 @@ formatting can be seen on :func:`time.strftime <python2:time.strftime>`.
 
     log_datefmt: '%H:%M:%S'
 
-
-
 .. conf_log:: log_datefmt_logfile
 
 ``log_datefmt_logfile``
@@ -124,8 +115,6 @@ formatting can be seen on :func:`time.strftime <python2:time.strftime>`.
 .. code-block:: yaml
 
     log_datefmt_logfile: '%Y-%m-%d %H:%M:%S'
-
-
 
 .. conf_log:: log_fmt_console
 
@@ -155,8 +144,6 @@ also provides these custom LogRecord attributes to colorize console log output:
 
     log_fmt_console: '[%(levelname)-8s] %(message)s'
 
-
-
 .. conf_log:: log_fmt_logfile
 
 ``log_fmt_logfile``
@@ -179,8 +166,6 @@ enclosing brackets ``[`` and ``]``:
 
     log_fmt_logfile: '%(asctime)s,%(msecs)03.0f [%(name)-17s][%(levelname)-8s] %(message)s'
 
-
-
 .. conf_log:: log_granular_levels
 
 ``log_granular_levels``
@@ -197,7 +182,6 @@ at the ``debug`` level:
   log_granular_levels:
     'salt': 'warning'
     'salt.modules': 'debug'
-
 
 External Logging Handlers
 -------------------------

--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -184,7 +184,7 @@ class SaltColorLogRecord(SaltLogRecord):
                                           reset)
         self.colorlevel = '%s[%-8s]%s' % (clevel,
                                           self.levelname,
-                                          TextFormat('reset'))
+                                          reset)
         self.colorprocess = '%s[%5s]%s' % (LOG_COLORS['process'],
                                            self.process,
                                            reset)

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -23,6 +23,7 @@ else:
 
 # Import salt libs
 from salt.log import is_console_configured
+from salt.log.setup import LOG_LEVELS
 from salt.exceptions import SaltClientError, SaltSystemExit
 import salt.defaults.exitcodes
 import salt.utils
@@ -519,5 +520,7 @@ def verify_log(opts):
     '''
     If an insecre logging configuration is found, show a warning
     '''
-    if opts.get('log_level') in ('garbage', 'trace', 'debug'):
+    level = LOG_LEVELS.get(opts.get('log_level').lower(), logging.NOTSET)
+
+    if level < logging.INFO:
         log.warn('Insecure logging configuration detected! Sensitive data may be logged.')


### PR DESCRIPTION
### What does this PR do?

Document log levels and warn about sensitive data on all logging below info

I also wanted to warn on insecure levels of `log_level_logfile`, but this is not possible at present because of the following complications:

Running a check in `salt.utils.verify.verify_log` against `log_level_logfile` results in that config being set to `None` because that is what it is in `salt.config`.

`salt.minion` and `salt.utils.cloud` both set `log_level_logfile` to `info` as advertised by [the logging docs](https://docs.saltstack.com/en/latest/ref/configuration/logging/index.html#log-level-logfile) and [the minion config docs](https://docs.saltstack.com/en/latest/ref/configuration/minion.html#log-level-logfile), but these are all incorrect and preempted by [`salt.utils.parsers`](https://github.com/saltstack/salt/blob/v2016.3.2/salt/utils/parsers.py#L558-L567), which sets `log_level_logfile` indiscriminately to `warning`.  I have also verified this with a 2016.3.2 install.

If advised, I will submit another pull request against develop unifying these contradictory defaults to `warning` or `info` and update the release notes.  I think `warning` would be better since that is what effectively happens and we should change `salt.minion` and `salt.utils.cloud` and the docs to that.

In my opinion, `salt.config` should be considered the authority on option defaults so that, for example, `salt.utils.parsers` can source its defaults from there rather than provide duplicate or contradictory defaults.  What do you think, @s0undt3ch?
### What issues does this PR fix or reference?

none
### Tests written?

Yes