### PR TITLE
Remove read_key function from reg.py execution module

### DIFF
--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -368,51 +368,6 @@ def list_values(hive, key=None, use_32bit_registry=False, include_default=True):
     return values
 
 
-def read_key(hkey, path, key=None, use_32bit_registry=False):
-    '''
-    .. important::
-        The name of this function is misleading and will be changed to reflect
-        proper usage in the Carbon release of Salt. The path option will be removed
-        and the key will be the actual key. See the following issue:
-
-        https://github.com/saltstack/salt/issues/25618
-
-        In order to not break existing state files this function will call the
-        read_value function if a key is passed. Key will be passed as the value
-        name. If key is not passed, this function will return the default value for
-        the key.
-
-        In the Carbon release this function will be removed in favor of read_value.
-
-    Read registry key value
-
-    Returns the first unnamed value (Default) as a string.
-    Returns none if first unnamed value is empty.
-    Returns False if key not found.
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' reg.read_key HKEY_LOCAL_MACHINE 'SOFTWARE\\Salt' 'version'
-    '''
-
-    if key:  # This if statement will be removed in Carbon
-        salt.utils.warn_until(
-            'Carbon',
-            'Use reg.read_value to read a registry value. This functionality '
-            'will be removed in Salt Carbon'
-            )
-        return read_value(hive=hkey,
-                          key=path,
-                          vname=key,
-                          use_32bit_registry=use_32bit_registry)
-
-    return read_value(hive=hkey,
-                      key=path,
-                      use_32bit_registry=use_32bit_registry)
-
-
 def read_value(hive, key, vname=None, use_32bit_registry=False):
     r'''
     Reads a registry value entry or the default value for a key.


### PR DESCRIPTION
This change has already been added to the carbon release notes.
