### PR TITLE
Remove extraneous params from github user present state

### DIFF
--- a/salt/states/github.py
+++ b/salt/states/github.py
@@ -43,8 +43,6 @@ def present(name, profile="github", **kwargs):
 
         ensure user test is present in github:
             github.present:
-                - fullname: 'Example TestUser1'
-                - email: 'example@domain.com'
                 - name: 'gitexample'
 
     The following parameters are required:
@@ -52,9 +50,6 @@ def present(name, profile="github", **kwargs):
     name
         This is the github handle of the user in the organization
     '''
-
-    email = kwargs.get('email')
-    full_name = kwargs.get('fullname')
 
     ret = {
         'name': name,


### PR DESCRIPTION
### What does this PR do?

Removes some extraneous params we were using internally from the state docs. Sorry about that!
### Tests written?

No