### PR TITLE
grains.filter_by: allow grain value to be a list

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -493,16 +493,25 @@ def filter_by(lookup_dict, grain='os_family', merge=None, default='default', bas
         values relevant to systems matching that grain. For example, a key
         could be the grain for an OS and the value could the name of a package
         on that particular OS.
+
     :param grain: The name of a grain to match with the current system's
         grains. For example, the value of the "os_family" grain for the current
         system could be used to pull values from the ``lookup_dict``
         dictionary.
+
+        .. versionchanged:: Carbon
+
+            The grain value could be a list. The function will return the
+            ``lookup_dict`` value for a first found item in the list matching
+            one of the ``lookup_dict`` keys.
+
     :param merge: A dictionary to merge with the results of the grain selection
         from ``lookup_dict``. This allows Pillar to override the values in the
         ``lookup_dict``. This could be useful, for example, to override the
         values for non-standard package names such as when using a different
         Python version from the default Python version provided by the OS
         (e.g., ``python26-mysql`` instead of ``python-mysql``).
+
     :param default: default lookup_dict's key used if the grain does not exists
         or if the grain value has no match on lookup_dict.  If unspecified
         the value is "default".
@@ -529,10 +538,20 @@ def filter_by(lookup_dict, grain='os_family', merge=None, default='default', bas
         # next same as above when default='H' instead of 'F' renders {A: {B: C}, D: J}
     '''
 
-    ret = lookup_dict.get(
-            salt.utils.traverse_dict_and_list(__grains__, grain, None),
-            lookup_dict.get(
-                default, None)
+    ret = None
+    val = salt.utils.traverse_dict_and_list(__grains__, grain, None)
+
+    if isinstance(val, list):
+        for each in val:
+            if each in lookup_dict:
+                ret = lookup_dict[each]
+                break
+        if ret is None:
+            ret = lookup_dict.get(default, None)
+    else:
+        ret = lookup_dict.get(
+            val,
+            lookup_dict.get(default, None)
             )
 
     if base and base in lookup_dict:
@@ -542,7 +561,8 @@ def filter_by(lookup_dict, grain='os_family', merge=None, default='default', bas
 
         elif isinstance(base_values, collections.Mapping):
             if not isinstance(ret, collections.Mapping):
-                raise SaltException('filter_by default and look-up values must both be dictionaries.')
+                raise SaltException(
+                    'filter_by default and look-up values must both be dictionaries.')
             ret = salt.utils.dictupdate.update(copy.deepcopy(base_values), ret)
 
     if merge:

--- a/tests/unit/modules/grains_test.py
+++ b/tests/unit/modules/grains_test.py
@@ -38,9 +38,10 @@ class GrainsModuleTestCase(TestCase):
 
     def test_filter_by(self):
         grainsmod.__grains__ = {
-          'os_family': 'MockedOS',
-          '1': '1',
-          '2': '2',
+            'os_family': 'MockedOS',
+            '1': '1',
+            '2': '2',
+            'roles': ['A', 'B'],
         }
 
         dict1 = {'A': 'B', 'C': {'D': {'E': 'F', 'G': 'H'}}}
@@ -141,6 +142,15 @@ class GrainsModuleTestCase(TestCase):
         # dict1 was altered, reestablish
         dict1 = {'A': 'B', 'MockedOS': {'D': {'E': 'F', 'G': 'H'}}}
         res = grainsmod.filter_by(dict1, default='Z')
+        self.assertEqual(res, {'D': {'E': 'F', 'G': 'H'}})
+
+        # Test when grain value is a list
+        dict1 = {'A': 'B', 'C': {'D': {'E': 'F', 'G': 'H'}}}
+        res = grainsmod.filter_by(dict1, grain='roles', default='C')
+        self.assertEqual(res, 'B')
+        # Test default when grain value is a list
+        dict1 = {'Z': 'B', 'C': {'D': {'E': 'F', 'G': 'H'}}}
+        res = grainsmod.filter_by(dict1, grain='roles', default='C')
         self.assertEqual(res, {'D': {'E': 'F', 'G': 'H'}})
 
         # Base tests


### PR DESCRIPTION
### What does this PR do?

It allows `grain` argument for `grains.filter_by` function to be a list and match against a `lookup_dict` keys. The case is explained below.
### What issues does this PR fix or reference?

Partially covers feature request #15061
### Previous Behavior

It wasn't possible to filter `lookup_dict` with `roles` grain (or any grain which contain a list value).
For example:

``` yaml
# salt-call grains.append roles myrole
local:
    ----------
    roles:
        - myrole
# salt-call grains.append roles otherrole
local:
    ----------
    roles:
        - myrole
        - otherrole
# salt-call grains.filter_by "{'myrole': {'success': True}, 'default': {'success': None}}" roles

Passed invalid arguments: unhashable type: 'list'.

...
```
### New Behavior

Now it's working:

``` yaml
# salt-call grains.filter_by "{'myrole': {'success': True}, 'default': {'success': None}}" roles
local:
    ----------
    success:
        True
```

The main idea is that if your grain has a list value, `grains.filter_by` function will iterate over the list items, and return the `lookup_dict` value under the key matching that item when found. First match wins.
### Tests written?

Yes! Added a couple of test cases.
