### PR TITLE
Bugfix: prevent snapper module crash on load if no DBus is available in the system

### DIFF
--- a/salt/modules/snapper.py
+++ b/salt/modules/snapper.py
@@ -68,6 +68,8 @@ if HAS_DBUS:
             except (dbus.DBusException, ValueError) as exc:
                 log.error(exc)
                 snapper_error = exc
+        else:
+            snapper_error = 'snapper is missing'
 
 
 def __virtual__():

--- a/salt/modules/snapper.py
+++ b/salt/modules/snapper.py
@@ -46,23 +46,24 @@ SNAPPER_DBUS_OBJECT = 'org.opensuse.Snapper'
 SNAPPER_DBUS_PATH = '/org/opensuse/Snapper'
 SNAPPER_DBUS_INTERFACE = 'org.opensuse.Snapper'
 
-log = logging.getLogger(__name__)  # pylint: disable=invalid-name
+# pylint: disable=invalid-name
+log = logging.getLogger(__name__)
 
-bus = None  # pylint: disable=invalid-name
-system_bus_error = None  # pylint: disable=invalid-name
-snapper = None  # pylint: disable=invalid-name
-snapper_error = None  # pylint: disable=invalid-name
+bus = None
+system_bus_error = None
+snapper = None
+snapper_error = None
 
 if HAS_DBUS:
     try:
-        bus = dbus.SystemBus()  # pylint: disable=invalid-name
+        bus = dbus.SystemBus()
     except dbus.DBusException as exc:
         log.error(exc)
         system_bus_error = exc
     else:
         if SNAPPER_DBUS_OBJECT in bus.list_activatable_names():
             try:
-                snapper = dbus.Interface(bus.get_object(SNAPPER_DBUS_OBJECT,  # pylint: disable=invalid-name
+                snapper = dbus.Interface(bus.get_object(SNAPPER_DBUS_OBJECT,
                                                         SNAPPER_DBUS_PATH),
                                          dbus_interface=SNAPPER_DBUS_INTERFACE)
             except (dbus.DBusException, ValueError) as exc:
@@ -70,6 +71,7 @@ if HAS_DBUS:
                 snapper_error = exc
         else:
             snapper_error = 'snapper is missing'
+# pylint: enable=invalid-name
 
 
 def __virtual__():

--- a/salt/modules/snapper.py
+++ b/salt/modules/snapper.py
@@ -49,9 +49,9 @@ SNAPPER_DBUS_INTERFACE = 'org.opensuse.Snapper'
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 bus = None  # pylint: disable=invalid-name
-system_bus_error = None
+system_bus_error = None  # pylint: disable=invalid-name
 snapper = None  # pylint: disable=invalid-name
-snapper_error = None
+snapper_error = None  # pylint: disable=invalid-name
 
 if HAS_DBUS:
     try:


### PR DESCRIPTION
### What does this PR do?

Bugfix
### What issues does this PR fix or reference?

If an OS has no DBus installed but does have python bindings to it installed, then the module crashes, while loading.
### Previous Behavior

`salt.modules.snapper` crashes if no DBus installed.
### New Behavior

`salt.module.snapper` shows the following error in the log instead:

```
[ERROR   ] org.freedesktop.DBus.Error.NoServer: Failed to connect to socket /var/run/dbus/system_bus_socket: Connection refused
```
### Tests written?

No