### PR TITLE
Issue 19313 / Add support of lvm thinpools

### DIFF
--- a/salt/modules/linux_lvm.py
+++ b/salt/modules/linux_lvm.py
@@ -370,14 +370,14 @@ def lvcreate(lvname,
     .. versionadded:: to_complete
 
     Support for thin pools and thin volumes
-    
+
     CLI Examples:
 
     .. code-block:: bash
 
         salt '*' lvm.lvcreate new_thinpool_name   vg_name               size=20G thinpool=True
         salt '*' lvm.lvcreate new_thinvolume_name vg_name/thinpool_name size=10G thinvolume=True
-    
+
     '''
     if size and extents:
         return 'Error: Please specify only one of size or extents'

--- a/salt/modules/linux_lvm.py
+++ b/salt/modules/linux_lvm.py
@@ -347,7 +347,15 @@ def vgextend(vgname, devices):
     return vgdata
 
 
-def lvcreate(lvname, vgname, size=None, extents=None, snapshot=None, pv=None, **kwargs):
+def lvcreate(lvname,
+        vgname,
+        size=None,
+        extents=None,
+        snapshot=None,
+        pv=None,
+        thinvolume=False,
+        thinpool=False,
+        **kwargs):
     '''
     Create a new logical volume, with option for which physical volume to be used
 
@@ -355,17 +363,31 @@ def lvcreate(lvname, vgname, size=None, extents=None, snapshot=None, pv=None, **
 
     .. code-block:: bash
 
-        salt '*' lvm.lvcreate new_volume_name vg_name size=10G
-        salt '*' lvm.lvcreate new_volume_name vg_name extents=100 pv=/dev/sdb
-        salt '*' lvm.lvcreate new_snapshot    vg_name snapshot=volume_name size=3G
+        salt '*' lvm.lvcreate new_volume_name     vg_name size=10G
+        salt '*' lvm.lvcreate new_volume_name     vg_name extents=100 pv=/dev/sdb
+        salt '*' lvm.lvcreate new_snapshot        vg_name snapshot=volume_name size=3G
+
+    .. versionadded:: to_complete
+
+    Support for thin pools and thin volumes
+    
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' lvm.lvcreate new_thinpool_name   vg_name               size=20G thinpool=True
+        salt '*' lvm.lvcreate new_thinvolume_name vg_name/thinpool_name size=10G thinvolume=True
+    
     '''
     if size and extents:
         return 'Error: Please specify only one of size or extents'
+    if thinvolume and thinpool:
+        return 'Error: Please set only one of thinvolume or thinpool to True'
 
     valid = ('activate', 'chunksize', 'contiguous', 'discards', 'stripes',
              'stripesize', 'minor', 'persistent', 'mirrors', 'noudevsync',
              'monitor', 'ignoremonitoring', 'permission', 'poolmetadatasize',
-             'readahead', 'regionsize', 'thin', 'thinpool', 'type',
+             'readahead', 'regionsize', 'type',
              'virtualsize', 'zero')
     no_parameter = ('noudevsync', 'ignoremonitoring', )
 
@@ -377,14 +399,25 @@ def lvcreate(lvname, vgname, size=None, extents=None, snapshot=None, pv=None, **
             elif k in valid:
                 extra_arguments.extend(['--{0}'.format(k), '{0}'.format(v)])
 
-    cmd = [salt.utils.which('lvcreate'), '-n', lvname]
+    cmd = [salt.utils.which('lvcreate')]
+
+    if thinvolume:
+        cmd.extend(['--thin', '-n', lvname])
+    elif thinpool:
+        cmd.extend(['--thinpool', lvname])
+    else:
+        cmd.extend(['-n', lvname])
 
     if snapshot:
         cmd.extend(['-s', '{0}/{1}'.format(vgname, snapshot)])
     else:
         cmd.append(vgname)
 
-    if size:
+    if size and thinvolume:
+        cmd.extend(['-V', '{0}'.format(size)])
+    elif extents and thinvolume:
+        return 'Error: Thin volume size cannot be specified as extents'
+    elif size:
         cmd.extend(['-L', '{0}'.format(size)])
     elif extents:
         cmd.extend(['-l', '{0}'.format(extents)])

--- a/salt/modules/linux_lvm.py
+++ b/salt/modules/linux_lvm.py
@@ -348,14 +348,14 @@ def vgextend(vgname, devices):
 
 
 def lvcreate(lvname,
-        vgname,
-        size=None,
-        extents=None,
-        snapshot=None,
-        pv=None,
-        thinvolume=False,
-        thinpool=False,
-        **kwargs):
+             vgname,
+             size=None,
+             extents=None,
+             snapshot=None,
+             pv=None,
+             thinvolume=False,
+             thinpool=False,
+             **kwargs):
     '''
     Create a new logical volume, with option for which physical volume to be used
 

--- a/salt/states/lvm.py
+++ b/salt/states/lvm.py
@@ -209,6 +209,8 @@ def lv_present(name,
                extents=None,
                snapshot=None,
                pv='',
+               thinvolume=False,
+               thinpool=False,
                **kwargs):
     '''
     Create a new logical volume
@@ -234,6 +236,14 @@ def lv_present(name,
     kwargs
         Any supported options to lvcreate. See
         :mod:`linux_lvm <salt.modules.linux_lvm>` for more details.
+
+    .. versionadded:: to_complete
+
+    thinvolume
+        Logical volume is thinly provisioned
+
+    thinpool
+        Logical volume is a thin pool
     '''
     ret = {'changes': {},
            'comment': '',
@@ -246,7 +256,10 @@ def lv_present(name,
         _snapshot = name
         name = snapshot
 
-    lvpath = '/dev/{0}/{1}'.format(vgname, name)
+    if thinvolume:
+        lvpath = '/dev/{0}/{1}'.format(vgname.split('/')[0], name)
+    else:
+        lvpath = '/dev/{0}/{1}'.format(vgname, name)
 
     if __salt__['lvm.lvdisplay'](lvpath):
         ret['comment'] = 'Logical Volume {0} already present'.format(name)
@@ -261,6 +274,8 @@ def lv_present(name,
                                            extents=extents,
                                            snapshot=_snapshot,
                                            pv=pv,
+                                           thinvolume=thinvolume,
+                                           thinpool=thinpool,
                                            **kwargs)
 
         if __salt__['lvm.lvdisplay'](lvpath):

--- a/tests/unit/modules/linux_lvm_test.py
+++ b/tests/unit/modules/linux_lvm_test.py
@@ -214,6 +214,12 @@ class LinuxLVMTestCase(TestCase):
         self.assertEqual(linux_lvm.lvcreate(None, None, None, None),
                          'Error: Either size or extents must be specified')
 
+        self.assertEqual(linux_lvm.lvcreate(None, None, thinvolume=True, thinpool=True),
+                        'Error: Please set only one of thinvolume or thinpool to True')
+
+        self.assertEqual(linux_lvm.lvcreate(None, None, thinvolume=True, extents=1),
+                        'Error: Thin volume size cannot be specified as extents')
+
         mock = MagicMock(return_value='A\nB')
         with patch.dict(linux_lvm.__salt__, {'cmd.run': mock}):
             with patch.object(linux_lvm, 'lvdisplay', return_value={}):


### PR DESCRIPTION
### What does this PR do?

Add support of LVM thin pools and thin volumes. Add two new paramaters to lvm.lvcreate module function and to lvm.lv_present state function : 
- _thinvolume_ (default to _False_)
- _thinpool_ (default to _False_)
### What issues does this PR fix or reference?
saltstack/salt#19313
### Previous Behavior

_lvm.lvcreate_ and _lvm.lv_present_ can only create "normal" lvm volume or snapshot.
### New Behavior

If _thinpool_ parameter is _True_, _lvm.lvcreate_ will create a new LVM thin pool. If _thinvolume_ parameter is True, _lvm.lvcreate_ will create a new LVM thinly provisioned volume in thin pool passed with volume group name.
### Tests written?

Yes (tests errors in lvm module)

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.