### PR TITLE
2016.3

### DIFF
--- a/doc/ref/configuration/logging/index.rst
+++ b/doc/ref/configuration/logging/index.rst
@@ -69,8 +69,8 @@ The level of log record messages to send to the console. One of ``all``,
     log_level: warning
 
 .. note::
-    Add ``log_level: quiet```in salt configuration file to completely disable
-    logging. In case of running salt in command line use``--log-level=quiet``
+    Add ``log_level: quiet`` in salt configuration file to completely disable
+    logging. In case of running salt in command line use ``--log-level=quiet``
     instead.
 
 .. conf_log:: log_level_logfile

--- a/doc/ref/configuration/logging/index.rst
+++ b/doc/ref/configuration/logging/index.rst
@@ -10,6 +10,45 @@ system, please head over to the :doc:`logging development
 document</topics/development/logging>`, if all you're after is salt's logging
 configurations, please continue reading.
 
+
+.. conf_log:: log_levels
+
+Log Levels
+==========
+
+The log levels are ordered numerically such that setting the log level to a
+specific level will record all log statements at that level and higher.  For
+example, setting ``log_level: error`` will log statements at ``error``,
+``critical``, and ``quiet`` levels, although nothing *should* be logged at
+``quiet`` level.
+
+Most of the logging levels are defined by default in Python's logging library
+and can be found in the official `Python documentation
+<https://docs.python.org/library/logging.html#levels>`_.  Salt uses some more
+levels in addition to the standard levels.  All levels available in salt are
+shown in the table below.
+
+.. note::
+
+    Python dependencies used by salt may define and use additional logging
+    levels.  For example, the Python 2 version of the ``multiprocessing``
+    standard Python library `uses the levels
+    <https://docs.python.org/2/library/multiprocessing.html#logging>`_
+    ``subwarning``, 25 and ``subdebug``, 5.
+
+Level    Numeric value Description
+======== ============= ========================================================================
+quiet    1000          Nothing should be logged at this level
+critical   50          Critical errors
+error      40          Errors
+warning    30          Warnings
+info       20          Normal log information
+profile    15          Profiling information on salt performance
+debug      10          Information useful for debugging both salt implementations and salt code
+trace       5          More detailed code debugging information
+garbage     1          Even more debugging information
+all         0          Everything
+
 Available Configuration Settings
 ================================
 

--- a/doc/ref/configuration/logging/index.rst
+++ b/doc/ref/configuration/logging/index.rst
@@ -10,7 +10,6 @@ system, please head over to the :doc:`logging development
 document</topics/development/logging>`, if all you're after is salt's logging
 configurations, please continue reading.
 
-
 Available Configuration Settings
 ================================
 
@@ -19,29 +18,28 @@ Available Configuration Settings
 ``log_file``
 ------------
 
-The log records can be sent to a regular file, local path name, or network location.
-Remote logging works best when configured to use rsyslogd(8) (e.g.: ``file:///dev/log``),
-with rsyslogd(8) configured for network logging.  The format for remote addresses is:
-``<file|udp|tcp>://<host|socketpath>:<port-if-required>/<log-facility>``. Where ``log-facility`` is the symbolic name of a syslog facility as defined in the :ref:`SysLogHandler documentation <python2:logging.handlers.SysLogHandler.encodePriority>` . It defaults to ``LOG_USER``.
+The log records can be sent to a regular file, local path name, or network
+location.  Remote logging works best when configured to use rsyslogd(8) (e.g.:
+``file:///dev/log``), with rsyslogd(8) configured for network logging.  The
+format for remote addresses is:
+``<file|udp|tcp>://<host|socketpath>:<port-if-required>/<log-facility>``. Where
+``log-facility`` is the symbolic name of a syslog facility as defined in the
+:ref:`SysLogHandler documentation
+<python2:logging.handlers.SysLogHandler.encodePriority>` . It defaults to
+``LOG_USER``.
 
-Default: Dependent of the binary being executed, for example, for ``salt-master``,
-``/var/log/salt/master``.
-
-
-
+Default: Dependent of the binary being executed, for example, for
+``salt-master``, ``/var/log/salt/master``.
 
 Examples:
-
 
 .. code-block:: yaml
 
     log_file: /var/log/salt/master
 
-
 .. code-block:: yaml
 
     log_file: /var/log/salt/minion
-
 
 .. code-block:: yaml
 
@@ -54,8 +52,6 @@ Examples:
 .. code-block:: yaml
 
     log_file: udp://loghost:10514
-
-
 
 .. conf_log:: log_level
 
@@ -77,7 +73,6 @@ The level of log record messages to send to the console. One of ``all``,
     logging. In case of running salt in command line use``--log-level=quiet``
     instead.
 
-
 .. conf_log:: log_level_logfile
 
 ``log_level_logfile``
@@ -93,8 +88,6 @@ The level of messages to send to the log file. One of ``all``, ``garbage``,
 
     log_level_logfile: warning
 
-
-
 .. conf_log:: log_datefmt
 
 ``log_datefmt``
@@ -109,8 +102,6 @@ formatting can be seen on :func:`time.strftime <python2:time.strftime>`.
 
     log_datefmt: '%H:%M:%S'
 
-
-
 .. conf_log:: log_datefmt_logfile
 
 ``log_datefmt_logfile``
@@ -124,8 +115,6 @@ formatting can be seen on :func:`time.strftime <python2:time.strftime>`.
 .. code-block:: yaml
 
     log_datefmt_logfile: '%Y-%m-%d %H:%M:%S'
-
-
 
 .. conf_log:: log_fmt_console
 
@@ -155,8 +144,6 @@ also provides these custom LogRecord attributes to colorize console log output:
 
     log_fmt_console: '[%(levelname)-8s] %(message)s'
 
-
-
 .. conf_log:: log_fmt_logfile
 
 ``log_fmt_logfile``
@@ -179,8 +166,6 @@ enclosing brackets ``[`` and ``]``:
 
     log_fmt_logfile: '%(asctime)s,%(msecs)03.0f [%(name)-17s][%(levelname)-8s] %(message)s'
 
-
-
 .. conf_log:: log_granular_levels
 
 ``log_granular_levels``
@@ -197,7 +182,6 @@ at the ``debug`` level:
   log_granular_levels:
     'salt': 'warning'
     'salt.modules': 'debug'
-
 
 External Logging Handlers
 -------------------------

--- a/pkg/windows/modules/get-settings.psm1
+++ b/pkg/windows/modules/get-settings.psm1
@@ -64,6 +64,10 @@ Function Get-Settings {
             "SSLeay"     = "ssleay32.dll"
             "OpenSSLLic" = "OpenSSL_License.txt"
             "libsodium"  = "libsodium.dll"
+            "concrt"     = "concrt140.dll"
+            "msvcp"      = "msvcp140.dll"
+            "vccorlib"   = "vccorlib140.dll"
+            "vcruntime"  = "vcruntime140.dll"
         }
         $ini.Add("64bitDLLs", $64bitDLLs)
 
@@ -73,6 +77,10 @@ Function Get-Settings {
             "SSLeay"     = "ssleay32.dll"
             "OpenSSLLic" = "OpenSSL_License.txt"
             "libsodium"  = "libsodium.dll"
+            "concrt"     = "concrt140.dll"
+            "msvcp"      = "msvcp140.dll"
+            "vccorlib"   = "vccorlib140.dll"
+            "vcruntime"  = "vcruntime140.dll"
         }
         $ini.Add("32bitDLLs", $32bitDLLs)
 

--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -250,8 +250,8 @@ class SaltCMD(parsers.SaltCMDOptionParser):
             print_cli('---------------------------')
             print_cli('Errors')
             print_cli('---------------------------')
-            for minion in errors:
-                print_cli(self._format_error(minion))
+            for error in errors:
+                print_cli(self._format_error(error))
 
     def _print_returns_summary(self, ret):
         '''
@@ -361,12 +361,12 @@ class SaltCMD(parsers.SaltCMDOptionParser):
         if isinstance(ret, str):
             self.exit(2, '{0}\n'.format(ret))
         for host in ret:
-            if ret[host] == 'Minion did not return. [Not connected]':
+            if isinstance(ret[host], string_types) and ret[host].startswith("Minion did not return"):
                 continue
             for fun in ret[host]:
                 if fun not in docs and ret[host][fun]:
                     docs[fun] = ret[host][fun]
-        if 'output' in self.config:
+        if self.options.output:
             for fun in sorted(docs):
                 salt.output.display_output({fun: docs[fun]}, 'nested', self.config)
         else:

--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -364,10 +364,13 @@ class SaltCMD(parsers.SaltCMDOptionParser):
             if ret[host] == 'Minion did not return. [Not connected]':
                 continue
             for fun in ret[host]:
-                if fun not in docs:
-                    if ret[host][fun]:
-                        docs[fun] = ret[host][fun]
-        for fun in sorted(docs):
-            salt.output.display_output(fun + ':', 'nested', self.config)
-            print_cli(docs[fun])
-            print_cli('')
+                if fun not in docs and ret[host][fun]:
+                    docs[fun] = ret[host][fun]
+        if 'output' in self.config:
+            for fun in sorted(docs):
+                salt.output.display_output({fun: docs[fun]}, 'nested', self.config)
+        else:
+            for fun in sorted(docs):
+                print_cli('{0}:'.format(fun))
+                print_cli(docs[fun])
+                print_cli('')

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -166,7 +166,7 @@ class SyncClientMixin(object):
 
         return ret['data']['return']
 
-    def cmd(self, fun, arg=None, pub_data=None, kwarg=None):
+    def cmd(self, fun, arg=None, pub_data=None, kwarg=None, print_event=True):
         '''
         Execute a function
 
@@ -226,7 +226,7 @@ class SyncClientMixin(object):
         low = {'fun': fun,
                'args': args,
                'kwargs': kwargs}
-        return self.low(fun, low)
+        return self.low(fun, low, print_event)
 
     @property
     def mminion(self):
@@ -234,7 +234,7 @@ class SyncClientMixin(object):
             self._mminion = salt.minion.MasterMinion(self.opts, states=False, rend=False)
         return self._mminion
 
-    def low(self, fun, low):
+    def low(self, fun, low, print_event=True):
         '''
         Execute a function from low data
         Low data includes:
@@ -266,12 +266,18 @@ class SyncClientMixin(object):
                 opts=self.opts,
                 listen=False)
 
+        if print_event:
+            print_func = self.print_async_event \
+                if hasattr(self, 'print_async_event') \
+                else None
+        else:
+            # Suppress printing of return event (this keeps us from printing
+            # runner/wheel output during orchestration).
+            print_func = None
         namespaced_event = salt.utils.event.NamespacedEvent(
             event,
             tag,
-            print_func=self.print_async_event
-                       if hasattr(self, 'print_async_event')
-                       else None
+            print_func=print_func
         )
         # TODO: document these, and test that they exist
         # TODO: Other things to inject??

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -274,7 +274,7 @@ class SSH(object):
         '''
         if not isinstance(ret[host], dict) or self.opts.get('ssh_key_deploy'):
             target = self.targets[host]
-            if 'passwd' in target or self.opts['ssh_passwd']:
+            if target.get('passwd', False) or self.opts['ssh_passwd']:
                 self._key_deploy_run(host, target, False)
             return ret
         if ret[host].get('stderr', '').count('Permission denied'):

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -792,6 +792,12 @@ class Single(object):
                 minion_opts=self.minion_opts,
                 **self.target)
             opts_pkg = pre_wrapper['test.opts_pkg']()  # pylint: disable=E1102
+            if '_error' in opts_pkg:
+                #Refresh failed
+                retcode = opts_pkg['retcode']
+                ret = json.dumps({'local': opts_pkg})
+                return ret, retcode
+
             opts_pkg['file_roots'] = self.opts['file_roots']
             opts_pkg['pillar_roots'] = self.opts['pillar_roots']
             opts_pkg['ext_pillar'] = self.opts['ext_pillar']
@@ -806,12 +812,6 @@ class Single(object):
             opts_pkg['id'] = self.id
 
             retcode = 0
-
-            if '_error' in opts_pkg:
-                #Refresh failed
-                retcode = opts_pkg['retcode']
-                ret = json.dumps({'local': opts_pkg['_error']})
-                return ret, retcode
 
             pillar = salt.pillar.Pillar(
                     opts_pkg,

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -27,7 +27,9 @@ Set up in the cloud configuration at ``/etc/salt/cloud.providers`` or
 
     my-openstack-config:
       # The OpenStack identity service url
-      identity_url: https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/
+      identity_url: https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/tokens
+      # The OpenStack Identity Version (default: 2)
+      auth_version: 2
       # The OpenStack compute region
       compute_region: region-b.geo-1
       # The OpenStack compute service name
@@ -66,6 +68,22 @@ For in-house Openstack Essex installation, libcloud needs the service_type :
     identity_url: 'http://control.openstack.example.org:5000/v2.0/'
     compute_name : Compute Service
     service_type : compute
+
+To use identity v3 for authentication, specify the `domain` and `auth_version`
+
+.. code-block:: yaml
+
+    my-openstack-config:
+      identity_url: 'http://control.openstack.example.org:5000/v3/auth/tokens'
+      auth_version: 3
+      compute_name : Compute Service
+      compute_region: East
+      service_type : compute
+      tenant: tenant
+      domain: testing
+      user: daniel
+      password: securepassword
+      driver: openstack
 
 
 Either a password or an API key must also be specified:
@@ -256,6 +274,9 @@ def get_conn():
         'ex_tenant_name': config.get_cloud_config_value(
             'tenant', vm_, __opts__, search_global=False
         ),
+        'ex_domain_name': config.get_cloud_config_value(
+            'domain', vm_, __opts__, default='Default', search_global=False
+        ),
     }
 
     service_type = config.get_cloud_config_value('service_type',
@@ -288,7 +309,10 @@ def get_conn():
     )
 
     if password is not None:
-        authinfo['ex_force_auth_version'] = '2.0_password'
+        if config.get_cloud_config_value('auth_version', vm_, __opts__, search_global=False) == 3:
+            authinfo['ex_force_auth_version'] = '3.x_password'
+        else:
+            authinfo['ex_force_auth_version'] = '2.0_password'
         log.debug('OpenStack authenticating using password')
         if password == 'USE_KEYRING':
             # retrieve password from system keyring

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1489,9 +1489,11 @@ def os_data():
                 continue
             osrelease_info[idx] = int(value)
         grains['osrelease_info'] = tuple(osrelease_info)
-        grains['osmajorrelease'] = str(grains['osrelease_info'][0])  # This will be an integer in the next release
-        os_name = 'os' if grains.get('os') in ('FreeBSD', 'OpenBSD', 'NetBSD', 'Mac', 'Raspbian') else 'osfullname'
-        grains['osfinger'] = '{0}-{1}'.format(grains[os_name], grains['osrelease_info'][0])
+        grains['osmajorrelease'] = str(grains['osrelease_info'][0])  # This will be an integer in the two releases
+        os_name = grains['os' if grains.get('os') in (
+            'FreeBSD', 'OpenBSD', 'NetBSD', 'Mac', 'Raspbian') else 'osfullname']
+        grains['osfinger'] = '{0}-{1}'.format(
+            os_name, grains['osrelease'] if os_name in ('Ubuntu',) else grains['osrelease_info'][0])
 
     return grains
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1490,6 +1490,7 @@ def os_data():
             osrelease_info[idx] = int(value)
         grains['osrelease_info'] = tuple(osrelease_info)
         grains['osmajorrelease'] = str(grains['osrelease_info'][0])  # This will be an integer in the two releases
+        salt.utils.warn_until('Nitrogen', 'The "osmajorrelease" will be a type of an integer.')
         os_name = grains['os' if grains.get('os') in (
             'FreeBSD', 'OpenBSD', 'NetBSD', 'Mac', 'Raspbian') else 'osfullname']
         grains['osfinger'] = '{0}-{1}'.format(

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1372,8 +1372,7 @@ def os_data():
                 grains.pop('lsb_distrib_release', None)
             grains['osrelease'] = \
                 grains.get('lsb_distrib_release', osrelease).strip()
-        grains['oscodename'] = grains.get('lsb_distrib_codename',
-                                          oscodename).strip()
+        grains['oscodename'] = grains.get('lsb_distrib_codename', '').strip() or oscodename
         if 'Red Hat' in grains['oscodename']:
             grains['oscodename'] = oscodename
         distroname = _REPLACE_LINUX_RE.sub('', grains['osfullname']).strip()

--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -184,7 +184,7 @@ class SaltColorLogRecord(SaltLogRecord):
                                           reset)
         self.colorlevel = '%s[%-8s]%s' % (clevel,
                                           self.levelname,
-                                          TextFormat('reset'))
+                                          reset)
         self.colorprocess = '%s[%5s]%s' % (LOG_COLORS['process'],
                                            self.process,
                                            reset)

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -502,6 +502,8 @@ class MinionBase(object):
             conn = False
             # shuffle the masters and then loop through them
             opts['local_masters'] = copy.copy(opts['master'])
+            if opts['random_master']:
+                shuffle(opts['local_masters'])
             last_exc = None
 
             while True:
@@ -555,6 +557,8 @@ class MinionBase(object):
 
         # single master sign in
         else:
+            if opts['random_master']:
+                log.warning('random_master is True but there is only one master specified. Ignoring.')
             while True:
                 attempts += 1
                 if tries > 0:

--- a/salt/modules/blockdev.py
+++ b/salt/modules/blockdev.py
@@ -42,7 +42,7 @@ def tune(device, **kwargs):
     '''
     Set attributes for the specified device
 
-    .. deprecated:: Carbon
+    .. deprecated:: 2016.3.0
        Use `disk.tune`
 
     CLI Example:
@@ -59,7 +59,7 @@ def tune(device, **kwargs):
     '''
     salt.utils.warn_until(
         'Carbon',
-        'The blockdev module has been merged with the disk module, and will disappear in Carbon'
+        'The tune function has been moved to the disk module, and will disappear in Carbon'
     )
     return __salt__['disk.tune'](device, **kwargs)
 
@@ -69,7 +69,7 @@ def wipe(device):
     '''
     Remove the filesystem information
 
-    .. deprecated:: Carbon
+    .. deprecated:: 2016.3.0
        Use `disk.tune`
 
     CLI Example:
@@ -80,7 +80,7 @@ def wipe(device):
     '''
     salt.utils.warn_until(
         'Carbon',
-        'The blockdev module has been merged with the disk module, and will disappear in Carbon'
+        'The wipe function has been moved to the disk module, and will disappear in Carbon'
     )
     return __salt__['disk.wipe'](device)
 
@@ -89,7 +89,7 @@ def dump(device, args=None):
     '''
     Return all contents of dumpe2fs for a specified device
 
-    .. deprecated:: Carbon
+    .. deprecated:: 2016.3.0
        Use `disk.dump`
 
     args
@@ -103,7 +103,7 @@ def dump(device, args=None):
     '''
     salt.utils.warn_until(
         'Carbon',
-        'The blockdev module has been merged with the disk module, and will disappear in Carbon'
+        'The dump function has been moved to the disk module, and will disappear in Carbon'
     )
     return __salt__['disk.dump'](device, args)
 
@@ -200,7 +200,7 @@ def resize2fs(device):
     '''
     Resizes the filesystem.
 
-    .. deprecated:: Carbon
+    .. deprecated:: 2016.3.0
        Use `disk.resize2fs`
 
     CLI Example:
@@ -210,6 +210,6 @@ def resize2fs(device):
     '''
     salt.utils.warn_until(
         'Carbon',
-        'The blockdev module has been merged with the disk module, and will disappear in Carbon'
+        'The resizefs function has been moved to the disk module, and will disappear in Carbon'
     )
     return __salt__['disk.resize2fs'](device)

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3431,7 +3431,7 @@ def apply_template_on_contents(
             to_str=True,
             context=context_dict,
             saltenv=saltenv,
-            grains=__grains__,
+            grains=__opts__['grains'],
             pillar=__pillar__,
             salt=__salt__,
             opts=__opts__)['data'].encode('utf-8')
@@ -3615,7 +3615,7 @@ def get_managed(
                     context=context_dict,
                     salt=__salt__,
                     pillar=__pillar__,
-                    grains=__grains__,
+                    grains=__opts__['grains'],
                     opts=__opts__,
                     **kwargs)
             else:

--- a/salt/modules/mac_shadow.py
+++ b/salt/modules/mac_shadow.py
@@ -12,7 +12,11 @@ of a configuration profile.
 
 from __future__ import absolute_import
 from datetime import datetime
-import pwd
+
+try:
+    import pwd
+except ImportError:
+    pass
 
 # Import salt libs
 import salt.utils

--- a/salt/modules/mac_shadow.py
+++ b/salt/modules/mac_shadow.py
@@ -13,10 +13,12 @@ of a configuration profile.
 from __future__ import absolute_import
 from datetime import datetime
 
+
 try:
     import pwd
+    HAS_PWD = True
 except ImportError:
-    pass
+    HAS_PWD = False
 
 # Import salt libs
 import salt.utils
@@ -34,7 +36,10 @@ def __virtual__():
     if not salt.utils.is_darwin():
         return False, 'Not Darwin'
 
-    return __virtualname__
+    if HAS_PWD:
+        return __virtualname__
+    else:
+        return (False, 'The pwd module failed to load.')
 
 
 def _get_account_policy(name):

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -385,13 +385,22 @@ def _netstat_route_freebsd():
     out = __salt__['cmd.run'](cmd, python_shell=True)
     for line in out.splitlines():
         comps = line.split()
-        ret.append({
-            'addr_family': 'inet',
-            'destination': comps[0],
-            'gateway': comps[1],
-            'netmask': comps[2],
-            'flags': comps[3],
-            'interface': comps[5]})
+        if __grains__['os'] == 'FreeBSD' and __grains__.get('osmajorrelease', 0) < 10:
+            ret.append({
+                'addr_family': 'inet',
+                'destination': comps[0],
+                'gateway': comps[1],
+                'netmask': comps[2],
+                'flags': comps[3],
+                'interface': comps[5]})
+        else:
+            ret.append({
+                'addr_family': 'inet',
+                'destination': comps[0],
+                'gateway': comps[1],
+                'netmask': '',
+                'flags': comps[2],
+                'interface': comps[3]})
     cmd = 'netstat -f inet6 -rn | tail -n+5'
     out = __salt__['cmd.run'](cmd, python_shell=True)
     for line in out.splitlines():

--- a/salt/modules/rpmbuild.py
+++ b/salt/modules/rpmbuild.py
@@ -425,7 +425,7 @@ def make_repo(repodir, keyid=None, env=None, use_passphrase=False, gnupghome='/e
         for file in os.listdir(repodir):
             if file.endswith('.rpm'):
                 abs_file = os.path.join(repodir, file)
-                number_retries = 5
+                number_retries = 20
                 times_looped = 0
                 error_msg = 'Failed to sign file {0}'.format(abs_file)
                 cmd = 'rpm {0} --addsign {1}'.format(define_gpg_name, abs_file)

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -1094,7 +1094,7 @@ def runner(name, **kwargs):
         if 'saltenv' in aspec.args:
             kwargs['saltenv'] = saltenv
 
-    return rclient.cmd(name, kwarg=kwargs)
+    return rclient.cmd(name, kwarg=kwargs, print_event=False)
 
 
 def wheel(name, *args, **kwargs):
@@ -1152,7 +1152,8 @@ def wheel(name, *args, **kwargs):
         ret = wheel_client.cmd(name,
                                arg=args,
                                pub_data=pub_data,
-                               kwarg=valid_kwargs)
+                               kwarg=valid_kwargs,
+                               print_event=False)
     except SaltInvocationError:
         raise CommandExecutionError(
             'This command can only be executed on a minion that is located on '

--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -188,7 +188,8 @@ def _format_host(host, data):
                               .format(ret.get('duration', 0)))
 
             tcolor = colors['GREEN']
-            schanged, ctext = _format_changes(ret['changes'])
+            orchestration = ret.get('__orchestration__', False)
+            schanged, ctext = _format_changes(ret['changes'], orchestration)
             nchanges += 1 if schanged else 0
 
             # Skip this state if it was successful & diff output was requested
@@ -441,14 +442,36 @@ def _format_host(host, data):
     return u'\n'.join(hstrs), nchanges > 0
 
 
-def _format_changes(changes):
+def _nested_changes(changes):
     '''
-    Format the changes dict based on what the data is
+    Print the changes data using the nested outputter
     '''
     global __opts__  # pylint: disable=W0601
 
+    opts = __opts__.copy()
+    # Pass the __opts__ dict. The loader will splat this modules __opts__ dict
+    # anyway so have to restore it after the other outputter is done
+    if __opts__['color']:
+        __opts__['color'] = u'CYAN'
+    __opts__['nested_indent'] = 14
+    ret = u'\n'
+    ret += salt.output.out_format(
+            changes,
+            'nested',
+            __opts__)
+    __opts__ = opts
+    return ret
+
+
+def _format_changes(changes, orchestration=False):
+    '''
+    Format the changes dict based on what the data is
+    '''
     if not changes:
         return False, u''
+
+    if orchestration:
+        return True, _nested_changes(changes)
 
     if not isinstance(changes, dict):
         return True, u'Invalid Changes data: {0}'.format(changes)
@@ -463,18 +486,7 @@ def _format_changes(changes):
             changed = changed or c
     else:
         changed = True
-        opts = __opts__.copy()
-        # Pass the __opts__ dict. The loader will splat this modules __opts__ dict
-        # anyway so have to restore it after the other outputter is done
-        if __opts__['color']:
-            __opts__['color'] = u'CYAN'
-        __opts__['nested_indent'] = 14
-        ctext = u'\n'
-        ctext += salt.output.out_format(
-                changes,
-                'nested',
-                __opts__)
-        __opts__ = opts
+        ctext = _nested_changes(changes)
     return changed, ctext
 
 

--- a/salt/pillar/mysql.py
+++ b/salt/pillar/mysql.py
@@ -11,17 +11,6 @@ This module is a concrete implementation of the sql_base ext_pillar for MySQL.
 :depends: python-mysqldb
 :platform: all
 
-Legacy compatibility
-=====================================
-
-This module has an extra addition for backward compatibility.
-
-If there's a keyword arg of mysql_query, that'll go first before other args.
-This legacy compatibility translates to depth 1.
-
-We do this so that it's backward compatible with older configs.
-This is deprecated and slated to be removed in Carbon.
-
 Configuring the mysql ext_pillar
 =====================================
 

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -119,6 +119,16 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
         reformatted_low = self._reformat_low(low)
         return mixins.SyncClientMixin.cmd_sync(self, reformatted_low, timeout)
 
+    def cmd(self, fun, arg=None, pub_data=None, kwarg=None, print_event=True):
+        '''
+        Execute a function
+        '''
+        return super(RunnerClient, self).cmd(fun,
+                                             arg,
+                                             pub_data,
+                                             kwarg,
+                                             print_event)
+
 
 class Runner(RunnerClient):
     '''

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -507,14 +507,19 @@ def exit_success(jid, ext_source=None):
     '''
     ret = dict()
 
-    data = lookup_jid(
+    data = list_job(
         jid,
         ext_source=ext_source
     )
 
-    for minion in data:
-        if "retcode" in data[minion]:
-            ret[minion] = True if not data[minion]['retcode'] else False
+    minions = data['Minions']
+    result = data['Result']
+
+    for minion in minions:
+        if minion in result and 'return' in result[minion]:
+            ret[minion] = True if result[minion]['return'] else False
+        else:
+            ret[minion] = False
 
     return ret
 

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1238,9 +1238,9 @@ def managed(name,
         on Windows
 
     template
-        If this setting is applied then the named templating engine will be
-        used to render the downloaded file, currently jinja, mako, and wempy
-        are supported
+        If this setting is applied, then the named templating engine will be
+        used to render the downloaded file. Currently jinja, mako, py, genshi,
+        cheetah, and wempy are supported.
 
     makedirs : False
         If set to ``True``, then the parent directories will be created to

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -416,7 +416,7 @@ def _clean_dir(root, keep, exclude_pat):
             while True:
                 fn_ = os.path.dirname(fn_)
                 real_keep.add(fn_)
-                if fn_ in ['/', ''.join([os.path.splitdrive(fn_)[0], '\\'])]:
+                if fn_ in ['/', ''.join([os.path.splitdrive(fn_)[0], '\\\\'])]:
                     break
 
     def _delete_not_kept(nfn):
@@ -2458,7 +2458,7 @@ def recurse(name,
                 merge_ret(path, _ret)
                 return
             else:
-                os.remove(path)
+                __salt__['file.remove'](path)
                 _ret['changes'] = {'diff': 'Replaced file with a directory'}
                 merge_ret(path, _ret)
 

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2335,8 +2335,7 @@ def recurse(name,
             return _error(
                 ret, 'The path {0} exists and is not a directory'.format(name))
         if not __opts__['test']:
-            __salt__['file.makedirs_perms'](
-                name, user, group, int(str(dir_mode), 8) if dir_mode else None)
+            __salt__['file.makedirs_perms'](name, user, group, dir_mode)
 
     def add_comment(path, comment):
         comments = ret['comment'].setdefault(path, [])

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -584,6 +584,7 @@ def runner(name, **kwargs):
     ret['result'] = True
     ret['comment'] = "Runner function '{0}' executed.".format(name)
 
+    ret['__orchestration__'] = True
     if out:
         ret['changes'] = out
 
@@ -616,6 +617,7 @@ def wheel(name, **kwargs):
     ret['result'] = True
     ret['comment'] = "Wheel function '{0}' executed.".format(name)
 
+    ret['__orchestration__'] = True
     if out:
         ret['changes'] = out
 

--- a/salt/states/ssh_known_hosts.py
+++ b/salt/states/ssh_known_hosts.py
@@ -120,7 +120,8 @@ def present(
             result = __salt__['ssh.check_known_host'](user, name,
                                                       key=key,
                                                       fingerprint=fingerprint,
-                                                      config=config)
+                                                      config=config,
+                                                      port=port)
         except CommandNotFoundError as err:
             ret['result'] = False
             ret['comment'] = 'ssh.check_known_host error: {0}'.format(err)

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -23,6 +23,7 @@ else:
 
 # Import salt libs
 from salt.log import is_console_configured
+from salt.log.setup import LOG_LEVELS
 from salt.exceptions import SaltClientError, SaltSystemExit
 import salt.defaults.exitcodes
 import salt.utils
@@ -519,5 +520,7 @@ def verify_log(opts):
     '''
     If an insecre logging configuration is found, show a warning
     '''
-    if opts.get('log_level') in ('garbage', 'trace', 'debug'):
+    level = LOG_LEVELS.get(opts.get('log_level').lower(), logging.NOTSET)
+
+    if level < logging.INFO:
         log.warn('Insecure logging configuration detected! Sensitive data may be logged.')

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -116,10 +116,9 @@ class Terminal(object):
         # Let's avoid Zombies!!!
         _cleanup()
 
-        if not args and not executable and not shell:
+        if not args and not executable:
             raise TerminalException(
-                'You need to pass at least one of \'args\', \'executable\' '
-                'or \'shell=True\''
+                'You need to pass at least one of "args", "executable" '
             )
 
         self.args = args

--- a/salt/wheel/__init__.py
+++ b/salt/wheel/__init__.py
@@ -112,7 +112,7 @@ class WheelClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
         fun = low.pop('fun')
         return self.async(fun, low)
 
-    def cmd(self, fun, arg=None, pub_data=None, kwarg=None):
+    def cmd(self, fun, arg=None, pub_data=None, kwarg=None, print_event=True):
         '''
         Execute a function
 
@@ -121,7 +121,11 @@ class WheelClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
             >>> wheel.cmd('key.finger', ['jerry'])
             {'minions': {'jerry': '5d:f6:79:43:5e:d4:42:3f:57:b8:45:a8:7e:a4:6e:ca'}}
         '''
-        return super(WheelClient, self).cmd(fun, arg, pub_data, kwarg)
+        return super(WheelClient, self).cmd(fun,
+                                            arg,
+                                            pub_data,
+                                            kwarg,
+                                            print_event)
 
 
 Wheel = WheelClient  # for backward-compat

--- a/tests/integration/files/file/base/issue-34945/foo/bar/baz/test_file
+++ b/tests/integration/files/file/base/issue-34945/foo/bar/baz/test_file
@@ -1,0 +1,1 @@
+Hello world!

--- a/tests/integration/states/file.py
+++ b/tests/integration/states/file.py
@@ -767,6 +767,36 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
         finally:
             shutil.rmtree(name, ignore_errors=True)
 
+    def test_recurse_issue_34945(self):
+        '''
+        This tests the case where the source dir for the file.recurse state
+        does not contain any files (only subdirectories), and the dir_mode is
+        being managed. For a long time, this corner case resulted in the top
+        level of the destination directory being created with the wrong initial
+        permissions, a problem that would be corrected later on in the
+        file.recurse state via running state.directory. However, the
+        file.directory state only gets called when there are files to be
+        managed in that directory, and when the source directory contains only
+        subdirectories, the incorrectly-set initial perms would not be
+        repaired.
+
+        This was fixed in https://github.com/saltstack/salt/pull/35309
+        '''
+        dir_mode = '2775'
+        issue_dir = 'issue-34945'
+        name = os.path.join(integration.TMP, issue_dir)
+
+        try:
+            ret = self.run_state('file.recurse',
+                                 name=name,
+                                 source='salt://' + issue_dir,
+                                 dir_mode=dir_mode)
+            self.assertSaltTrueReturn(ret)
+            actual_dir_mode = oct(stat.S_IMODE(os.stat(name).st_mode))[-4:]
+            self.assertEqual(dir_mode, actual_dir_mode)
+        finally:
+            shutil.rmtree(name, ignore_errors=True)
+
     def test_replace(self):
         '''
         file.replace

--- a/tests/unit/grains/core_test.py
+++ b/tests/unit/grains/core_test.py
@@ -376,6 +376,79 @@ PATCHLEVEL = 3
         self._run_suse_os_grains_tests(_os_release_map)
 
 
+    @skipIf(not salt.utils.is_linux(), 'System is not Linux')
+    def test_suse_os_grains_ubuntu(self):
+        '''
+        Test if OS grains are parsed correctly in Ubuntu Xenial Xerus
+        '''
+        _os_release_map = {
+            'os_release_file': {
+                'NAME': 'Ubuntu',
+                'VERSION': '16.04.1 LTS (Xenial Xerus)',
+                'VERSION_ID': '16.04',
+                'PRETTY_NAME': '',
+                'ID': 'ubuntu',
+            },
+            'oscodename': 'xenial',
+            'osfullname': 'Ubuntu',
+            'osrelease': '16.04',
+            'osrelease_info': [16, 4],
+            'osmajorrelease': '16',
+            'osfinger': 'Ubuntu-16.04',
+        }
+        self._run_ubuntu_os_grains_tests(_os_release_map)
+
+
+    def _run_ubuntu_os_grains_tests(self, os_release_map):
+        path_isfile_mock = MagicMock(side_effect=lambda x: x in ['/etc/os-release'])
+        empty_mock = MagicMock(return_value={})
+        osarch_mock = MagicMock(return_value="amd64")
+        os_release_mock = MagicMock(return_value=os_release_map.get('os_release_file'))
+
+        orig_import = __import__
+
+        def _import_mock(name, *args):
+            if name == 'lsb_release':
+                raise ImportError('No module named lsb_release')
+            return orig_import(name, *args)
+
+        # Skip the first if statement
+        with patch.object(salt.utils, 'is_proxy',
+                          MagicMock(return_value=False)):
+            # Skip the selinux/systemd stuff (not pertinent)
+            with patch.object(core, '_linux_bin_exists',
+                              MagicMock(return_value=False)):
+                # Skip the init grain compilation (not pertinent)
+                with patch.object(os.path, 'exists', path_isfile_mock):
+                    # Ensure that lsb_release fails to import
+                    with patch('__builtin__.__import__',
+                               side_effect=_import_mock):
+                        # Skip all the /etc/*-release stuff (not pertinent)
+                        with patch.object(os.path, 'isfile', path_isfile_mock):
+                            with patch.object(core, '_parse_os_release', os_release_mock):
+                                # Mock platform.linux_distribution to give us the
+                                # OS name that we want.
+                                distro_mock = MagicMock(return_value=('Ubuntu', '16.04', 'xenial'))
+                                with patch("salt.utils.fopen", mock_open()) as suse_release_file:
+                                    suse_release_file.return_value.__iter__.return_value = os_release_map.get(
+                                        'suse_release_file', '').splitlines()
+                                    with patch.object(platform, 'linux_distribution', distro_mock):
+                                        with patch.object(core, '_linux_gpu_data', empty_mock):
+                                            with patch.object(core, '_linux_cpudata', empty_mock):
+                                                with patch.object(core, '_virtual', empty_mock):
+                                                    # Mock the osarch
+                                                    with patch.dict(core.__salt__, {'cmd.run': osarch_mock}):
+                                                        os_grains = core.os_data()
+
+        self.assertEqual(os_grains.get('os'), 'Ubuntu')
+        self.assertEqual(os_grains.get('os_family'), 'Debian')
+        self.assertEqual(os_grains.get('osfullname'), os_release_map['osfullname'])
+        self.assertEqual(os_grains.get('oscodename'), os_release_map['oscodename'])
+        self.assertEqual(os_grains.get('osrelease'), os_release_map['osrelease'])
+        self.assertListEqual(list(os_grains.get('osrelease_info')), os_release_map['osrelease_info'])
+        self.assertEqual(os_grains.get('osmajorrelease'), os_release_map['osmajorrelease'])
+
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(CoreGrainsTestCase, needs_daemon=False)

--- a/tests/unit/grains/core_test.py
+++ b/tests/unit/grains/core_test.py
@@ -375,7 +375,6 @@ PATCHLEVEL = 3
         }
         self._run_suse_os_grains_tests(_os_release_map)
 
-
     @skipIf(not salt.utils.is_linux(), 'System is not Linux')
     def test_suse_os_grains_ubuntu(self):
         '''
@@ -397,7 +396,6 @@ PATCHLEVEL = 3
             'osfinger': 'Ubuntu-16.04',
         }
         self._run_ubuntu_os_grains_tests(_os_release_map)
-
 
     def _run_ubuntu_os_grains_tests(self, os_release_map):
         path_isfile_mock = MagicMock(side_effect=lambda x: x in ['/etc/os-release'])

--- a/tests/unit/states/saltmod_test.py
+++ b/tests/unit/states/saltmod_test.py
@@ -171,7 +171,8 @@ class SaltmodTestCase(TestCase):
         name = 'state'
 
         ret = {'changes': True, 'name': 'state', 'result': True,
-               'comment': "Runner function 'state' executed."}
+               'comment': 'Runner function \'state\' executed.',
+               '__orchestration__': True}
 
         with patch.dict(saltmod.__salt__, {'saltutil.runner':
                                            MagicMock(return_value=True)}):
@@ -186,7 +187,8 @@ class SaltmodTestCase(TestCase):
         name = 'state'
 
         ret = {'changes': True, 'name': 'state', 'result': True,
-               'comment': "Wheel function 'state' executed."}
+               'comment': 'Wheel function \'state\' executed.',
+               '__orchestration__': True}
 
         with patch.dict(saltmod.__salt__, {'saltutil.wheel':
                                            MagicMock(return_value=True)}):


### PR DESCRIPTION
### What does this PR do?

Returns back missing the proper grains dictionary for file module.
Related to https://github.com/saltstack/salt/issues/33614
### What issues does this PR fix or reference?

PR fix bug reproduced by steps:

Example SLS and file for reproduce bug:

```
/tmp/graintest:
  file.managed:
   - source: salt://test/files/graintest
   - template: jinja
```

graintest:

```
{%if grains.has_key('c') %}
        grains.has_key works
{% else %}
        grains.has_key doesn't work
{% endif %}
{% if grains.c is defined %}
        "is defined" works
{% else %}
        "is defined" doesn't work
{% endif %}
```

And then just execute state.
### Tests written?

No
