### PR TITLE
Returns back missed proper grains dictionary for file module

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3431,7 +3431,7 @@ def apply_template_on_contents(
             to_str=True,
             context=context_dict,
             saltenv=saltenv,
-            grains=__grains__,
+            grains=__opts__['grains'],
             pillar=__pillar__,
             salt=__salt__,
             opts=__opts__)['data'].encode('utf-8')
@@ -3615,7 +3615,7 @@ def get_managed(
                     context=context_dict,
                     salt=__salt__,
                     pillar=__pillar__,
-                    grains=__grains__,
+                    grains=__opts__['grains'],
                     opts=__opts__,
                     **kwargs)
             else:


### PR DESCRIPTION
### What does this PR do?

Returns back missing the proper grains dictionary for file module.
Related to https://github.com/saltstack/salt/issues/33614
### What issues does this PR fix or reference?

PR fix bug reproduced by steps:

Example SLS and file for reproduce bug:

```
/tmp/graintest:
  file.managed:
   - source: salt://test/files/graintest
   - template: jinja
```

graintest:

```
{%if grains.has_key('os_family') %}
        grains.has_key works
{% else %}
        grains.has_key doesn't work
{% endif %}
{% if grains.c is defined %}
        "is defined" works
{% else %}
        "is defined" doesn't work
{% endif %}
```

And then just execute state.
### Tests written?

No
