### PR TITLE
No need to run ddns update every time

### DIFF
--- a/salt/modules/ddns.py
+++ b/salt/modules/ddns.py
@@ -188,6 +188,8 @@ def update(zone, name, ttl, rdtype, data, nameserver='127.0.0.1',
         dns_update.replace(name, ttl, rdata)
     elif not is_exist:
         dns_update.add(name, ttl, rdata)
+    else:
+        return None
     answer = dns.query.udp(dns_update, nameserver)
     if answer.rcode() > 0:
         return False


### PR DESCRIPTION
... - only if we're replacing record and record not exists.
After applying https://github.com/saltstack/salt/commit/f0dbbd5d6c80e462c61ad91a9f2ba806dac3bb5d update() in ddns execute module never returns `None`. 
(Compare with old code - https://github.com/saltstack/salt/blob/2015.5/salt/modules/ddns.py#L162-L173)
But `None` is still used in the corresponding state for change detection - https://github.com/saltstack/salt/blob/develop/salt/states/ddns.py#L73-L89
This PR makes update() return None if no updates are needed.
### What does this PR do?

Fixing issue https://github.com/saltstack/salt/issues/35350 - now Salt emits ddns updates only when needed.
### What issues do this PR fix or reference?

https://github.com/saltstack/salt/issues/35350
### Previous Behavior

DDNS record was updated every Salt run.
### New Behavior

DDNS record is updating if needed.
### Tests written?

No
