### PR TITLE
Win firewall remote ip

### DIFF
--- a/salt/modules/win_firewall.py
+++ b/salt/modules/win_firewall.py
@@ -125,7 +125,7 @@ def add_rule(name, localport, protocol='tcp', action='allow', dir='in', remote_i
            'protocol={0}'.format(protocol),
            'dir={0}'.format(dir),
            'action={0}'.format(action),
-           'remote_ip={0}'.format(remote_ip)]
+           'remoteip={0}'.format(remote_ip)]
 
     if 'icmpv4' not in protocol and 'icmpv6' not in protocol:
         cmd.append('localport={0}'.format(localport))
@@ -155,7 +155,7 @@ def delete_rule(name, localport, protocol='tcp', dir='in', remote_ip='any'):
            'name={0}'.format(name),
            'protocol={0}'.format(protocol),
            'dir={0}'.format(dir),
-           'remote_ip={0}'.format(remote_ip)]
+           'remoteip={0}'.format(remote_ip)]
 
     if 'icmpv4' not in protocol and 'icmpv6' not in protocol:
         cmd.append('localport={0}'.format(localport))

--- a/salt/modules/win_firewall.py
+++ b/salt/modules/win_firewall.py
@@ -105,7 +105,7 @@ def get_rule(name='all'):
     return ret
 
 
-def add_rule(name, localport, protocol='tcp', action='allow', dir='in'):
+def add_rule(name, localport, protocol='tcp', action='allow', dir='in', remote_ip='any'):
     '''
     .. versionadded:: 2015.5.0
 
@@ -117,13 +117,15 @@ def add_rule(name, localport, protocol='tcp', action='allow', dir='in'):
 
         salt '*' firewall.add_rule 'test' '8080' 'tcp'
         salt '*' firewall.add_rule 'test' '1' 'icmpv4'
+        salt '*' firewall.add_rule 'test_remote_ip' '8000' 'tcp' 'allow' 'in' '192.168.0.1'
 
     '''
     cmd = ['netsh', 'advfirewall', 'firewall', 'add', 'rule',
            'name={0}'.format(name),
            'protocol={0}'.format(protocol),
            'dir={0}'.format(dir),
-           'action={0}'.format(action)]
+           'action={0}'.format(action),
+           'remote_ip={0}'.format(remote_ip)]
 
     if 'icmpv4' not in protocol and 'icmpv6' not in protocol:
         cmd.append('localport={0}'.format(localport))
@@ -136,7 +138,7 @@ def add_rule(name, localport, protocol='tcp', action='allow', dir='in'):
         return False
 
 
-def delete_rule(name, localport, protocol='tcp', dir='in'):
+def delete_rule(name, localport, protocol='tcp', dir='in', remote_ip='any'):
     '''
     .. versionadded:: 2015.8.0
 
@@ -147,11 +149,13 @@ def delete_rule(name, localport, protocol='tcp', dir='in'):
     .. code-block:: bash
 
         salt '*' firewall.delete_rule 'test' '8080' 'tcp' 'in'
+        salt '*' firewall.delete_rule 'test_remote_ip' '8000' 'tcp' 'in' '192.168.0.1'
     '''
     cmd = ['netsh', 'advfirewall', 'firewall', 'delete', 'rule',
            'name={0}'.format(name),
            'protocol={0}'.format(protocol),
-           'dir={0}'.format(dir)]
+           'dir={0}'.format(dir),
+           'remote_ip={0}'.format(remote_ip)]
 
     if 'icmpv4' not in protocol and 'icmpv6' not in protocol:
         cmd.append('localport={0}'.format(localport))


### PR DESCRIPTION
### Enhancement to the windows firewall execution module
### Adds the ability to target remote ip address
### Previous Behavior

Feature was missing
### New Behavior

A new option appears where you can specify the ip address.
### Tests written?

No (let me know if you need one)

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
