### PR TITLE
modules.event.send(): Prevent backtrace for masterless Minions

### DIFF
--- a/salt/modules/event.py
+++ b/salt/modules/event.py
@@ -39,7 +39,7 @@ def fire_master(data, tag, preload=None):
 
         salt '*' event.fire_master '{"data":"my event data"}' 'tag'
     '''
-    if __opts__.get('local', None):
+    if (__opts__.get('local', None) or __opts__.get('file_client', None) == 'local') and not __opts__.get('use_master_when_local', False):
         #  We can't send an event if we're in masterless mode
         log.warning('Local mode detected. Event with tag {0} will NOT be sent.'.format(tag))
         return False


### PR DESCRIPTION
### What does this PR do?

It prevents a backtrace in `modules.event.send()` when running a masterless Minion with `file_client: local` in a config file, but not using `--local` on the CLI:

```
# salt-call state.single event.send name=notify/me 
[INFO    ] Loading fresh modules for state activity
[INFO    ] Running state [notify/me] at time 12:30:10.413538
[INFO    ] Executing state event.send for notify/me
[ERROR   ] An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1703, in call
    **cdata['kwargs'])
  File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1649, in wrapper
    return f(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/states/event.py", line 53, in send
    **kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/modules/event.py", line 220, in send
    return fire_master(data_dict, tag, preload=preload)
  File "/usr/lib/python2.7/dist-packages/salt/modules/event.py", line 67, in fire_master
    auth = salt.crypt.SAuth(__opts__)
  File "/usr/lib/python2.7/dist-packages/salt/crypt.py", line 944, in __new__
    new_auth.__singleton_init__(opts)
  File "/usr/lib/python2.7/dist-packages/salt/crypt.py", line 982, in __singleton_init__
    self.get_keys()
  File "/usr/lib/python2.7/dist-packages/salt/crypt.py", line 611, in get_keys
    salt.utils.verify.check_path_traversal(self.opts['pki_dir'], user)
  File "/usr/lib/python2.7/dist-packages/salt/utils/verify.py", line 403, in check_path_traversal
    raise SaltClientError(msg)
SaltClientError: Could not access /etc/salt/pki. Path does not exist.

[INFO    ] Completed state [notify/me] at time 12:30:10.417082 duration_in_ms=3.544
local:
----------
          ID: notify/me
    Function: event.send
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1703, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1649, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/states/event.py", line 53, in send
                  **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/modules/event.py", line 220, in send
                  return fire_master(data_dict, tag, preload=preload)
                File "/usr/lib/python2.7/dist-packages/salt/modules/event.py", line 67, in fire_master
                  auth = salt.crypt.SAuth(__opts__)
                File "/usr/lib/python2.7/dist-packages/salt/crypt.py", line 944, in __new__
                  new_auth.__singleton_init__(opts)
                File "/usr/lib/python2.7/dist-packages/salt/crypt.py", line 982, in __singleton_init__
                  self.get_keys()
                File "/usr/lib/python2.7/dist-packages/salt/crypt.py", line 611, in get_keys
                  salt.utils.verify.check_path_traversal(self.opts['pki_dir'], user)
                File "/usr/lib/python2.7/dist-packages/salt/utils/verify.py", line 403, in check_path_traversal
                  raise SaltClientError(msg)
              SaltClientError: Could not access /etc/salt/pki. Path does not exist.
     Started: 12:30:10.413538
    Duration: 3.544 ms
     Changes:   

Summary for local
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
```
### What issues does this PR fix or reference?

None
### Tests written?

No