### PR TITLE
Only allow one sync read to happen at a time.

### DIFF
--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -16,9 +16,9 @@ import tornado
 import tornado.gen
 import tornado.netutil
 import tornado.concurrent
+from tornado.locks import Semaphore
 from tornado.ioloop import IOLoop
 from tornado.iostream import IOStream
-
 # Import Salt libs
 import salt.transport.client
 import salt.transport.frame
@@ -584,9 +584,11 @@ class IPCMessageSubscriber(IPCClient):
         self._read_stream_future = None
         self._sync_ioloop_running = False
         self.saved_data = []
+        self._sync_read_in_progress = Semaphore()
 
     @tornado.gen.coroutine
     def _read_sync(self, timeout):
+        yield self._sync_read_in_progress.acquire()
         exc_to_raise = None
         ret = None
 
@@ -640,6 +642,7 @@ class IPCMessageSubscriber(IPCClient):
 
         if exc_to_raise is not None:
             raise exc_to_raise  # pylint: disable=E0702
+        self._sync_read_in_progress.release()
         raise tornado.gen.Return(ret)
 
     def read_sync(self, timeout=None):


### PR DESCRIPTION
### What does this PR do?

Makes sure that only one sync read happens at a time, thus avoiding:

``` python
Traceback (most recent call last):
  File "/var/lib/jenkins/.pyenv/versions/2.7.9/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/var/lib/jenkins/workspace/raas/pr/1275/.virtualenvs/Salt-Py2.7.9/lib/python2.7/site-packages/salt/utils/process.py", line 613, in _run
    return self._original_run()
  File "/var/lib/jenkins/workspace/raas/pr/1275/.virtualenvs/Salt-Py2.7.9/lib/python2.7/site-packages/salt/utils/event.py", line 1092, in run
    for event in events:
  File "/var/lib/jenkins/workspace/raas/pr/1275/.virtualenvs/Salt-Py2.7.9/lib/python2.7/site-packages/salt/utils/event.py", line 620, in iter_events
    data = self.get_event(tag=tag, full=full, match_type=match_type)
  File "/var/lib/jenkins/workspace/raas/pr/1275/.virtualenvs/Salt-Py2.7.9/lib/python2.7/site-packages/salt/utils/event.py", line 579, in get_event
    ret = self._get_event(wait, tag, match_func, no_block)
  File "/var/lib/jenkins/workspace/raas/pr/1275/.virtualenvs/Salt-Py2.7.9/lib/python2.7/site-packages/salt/utils/event.py", line 484, in _get_event
    raw = self.subscriber.read_sync(timeout=wait)
  File "/var/lib/jenkins/workspace/raas/pr/1275/.virtualenvs/Salt-Py2.7.9/lib/python2.7/site-packages/salt/transport/ipc.py", line 664, in read_sync
    return ret_future.result()
  File "/var/lib/jenkins/workspace/raas/pr/1275/.virtualenvs/Salt-Py2.7.9/lib/python2.7/site-packages/tornado/concurrent.py", line 237, in result
    raise_exc_info(self._exc_info)
  File "/var/lib/jenkins/workspace/raas/pr/1275/.virtualenvs/Salt-Py2.7.9/lib/python2.7/site-packages/tornado/gen.py", line 285, in wrapper
    yielded = next(result)
  File "/var/lib/jenkins/workspace/raas/pr/1275/.virtualenvs/Salt-Py2.7.9/lib/python2.7/site-packages/salt/transport/ipc.py", line 641, in _read_sync
    raise exc_to_raise  # pylint: disable=E0702
AssertionError: Already reading
Process Reactor-7:
```
### Previous Behavior

The above exception would be shown multiple times
### Tests written?

No