### PR TITLE
Use opts instead of syspaths for cloud cache

### DIFF
--- a/salt/cloud/clouds/aliyun.py
+++ b/salt/cloud/clouds/aliyun.py
@@ -603,6 +603,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -620,6 +621,7 @@ def create(vm_):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
         {'kwargs': kwargs},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -688,6 +690,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -968,6 +971,7 @@ def destroy(name, call=None):
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -983,6 +987,7 @@ def destroy(name, call=None):
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 

--- a/salt/cloud/clouds/cloudstack.py
+++ b/salt/cloud/clouds/cloudstack.py
@@ -263,6 +263,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -296,6 +297,7 @@ def create(vm_):
         {'kwargs': {'name': kwargs['name'],
                     'image': kwargs['image'].name,
                     'size': kwargs['size'].name}},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -318,6 +320,7 @@ def create(vm_):
               {'kwargs': {'name': ex_blockdevicemapping['VirtualName'],
                           'device': ex_blockdevicemapping['DeviceName'],
                           'size': ex_blockdevicemapping['VolumeSize']}},
+              opts=__opts__,
             )
             try:
                 volumes[ex_blockdevicemapping['DeviceName']] = conn.create_volume(
@@ -396,6 +399,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -417,6 +421,7 @@ def destroy(name, conn=None, call=None):
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
         {'name': name},
+        opts=__opts__,
     )
 
     if not conn:
@@ -441,6 +446,7 @@ def destroy(name, conn=None, call=None):
             'detaching volume',
             'salt/cloud/{0}/detaching'.format(volume.name),
             {'name': volume.name},
+            opts=__opts__,
         )
         if not conn.detach_volume(volume):
             log.error('Failed to Detach volume: {0}'.format(volume.name))
@@ -451,6 +457,7 @@ def destroy(name, conn=None, call=None):
             'detached volume',
             'salt/cloud/{0}/detached'.format(volume.name),
             {'name': volume.name},
+            opts=__opts__,
         )
 
         log.info('Destroying volume: {0}'.format(volume.name))
@@ -459,6 +466,7 @@ def destroy(name, conn=None, call=None):
             'destroying volume',
             'salt/cloud/{0}/destroying'.format(volume.name),
             {'name': volume.name},
+            opts=__opts__,
         )
         if not conn.destroy_volume(volume):
             log.error('Failed to Destroy volume: {0}'.format(volume.name))
@@ -469,6 +477,7 @@ def destroy(name, conn=None, call=None):
             'destroyed volume',
             'salt/cloud/{0}/destroyed'.format(volume.name),
             {'name': volume.name},
+            opts=__opts__,
         )
     log.info('Destroying VM: {0}'.format(name))
     ret = conn.destroy_node(node)
@@ -483,6 +492,7 @@ def destroy(name, conn=None, call=None):
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
         {'name': name},
+        opts=__opts__,
     )
     if __opts__['delete_sshkeys'] is True:
         salt.utils.cloud.remove_sshkey(node.public_ips[0])

--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -293,6 +293,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -371,6 +372,7 @@ def create(vm_):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
         {'kwargs': kwargs},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -442,6 +444,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -691,6 +694,7 @@ def destroy(name, call=None):
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -714,6 +718,7 @@ def destroy(name, call=None):
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1851,6 +1851,7 @@ def request_instance(vm_=None, call=None):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
         {'kwargs': params, 'location': location},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -1929,6 +1930,7 @@ def request_instance(vm_=None, call=None):
             'event',
             'waiting for spot instance',
             'salt/cloud/{0}/waiting_for_spot'.format(vm_['name']),
+            opts=__opts__,
             transport=__opts__['transport']
         )
 
@@ -1993,6 +1995,7 @@ def query_instance(vm_=None, call=None):
         'querying instance',
         'salt/cloud/{0}/querying'.format(vm_['name']),
         {'instance_id': instance_id},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -2099,6 +2102,7 @@ def query_instance(vm_=None, call=None):
             'instance queried',
             'salt/cloud/{0}/query_reactor'.format(vm_['name']),
             {'data': data},
+            opts=__opts__,
             transport=__opts__['transport']
         )
 
@@ -2137,6 +2141,7 @@ def wait_for_instance(
         'waiting for ssh',
         'salt/cloud/{0}/waiting_for_ssh'.format(vm_['name']),
         {'ip_address': ip_address},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -2316,6 +2321,7 @@ def wait_for_instance(
             'ssh is available',
             'salt/cloud/{0}/ssh_ready_reactor'.format(vm_['name']),
             {'ip_address': ip_address},
+            opts=__opts__,
             transport=__opts__['transport']
         )
 
@@ -2392,6 +2398,7 @@ def create(vm_=None, call=None):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
     salt.utils.cloud.cachedir_index_add(
@@ -2489,6 +2496,7 @@ def create(vm_=None, call=None):
         'setting tags',
         'salt/cloud/{0}/tagging'.format(vm_['name']),
         {'tags': tags},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -2558,6 +2566,7 @@ def create(vm_=None, call=None):
             'attaching volumes',
             'salt/cloud/{0}/attaching_volumes'.format(vm_['name']),
             {'volumes': volumes},
+            opts=__opts__,
             transport=__opts__['transport']
         )
 
@@ -2598,6 +2607,7 @@ def create(vm_=None, call=None):
         'created instance',
         'salt/cloud/{0}/created'.format(vm_['name']),
         event_data,
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -3017,6 +3027,7 @@ def destroy(name, call=None):
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
         {'name': name, 'instance_id': instance_id},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -3079,6 +3090,7 @@ def destroy(name, call=None):
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
         {'name': name, 'instance_id': instance_id},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2395,7 +2395,7 @@ def create(vm_=None, call=None):
         transport=__opts__['transport']
     )
     salt.utils.cloud.cachedir_index_add(
-        vm_['name'], vm_['profile'], 'ec2', vm_['driver']
+        vm_['name'], vm_['profile'], 'ec2', vm_['driver'], opts=__opts__,
     )
 
     vm_['key_filename'] = key_filename
@@ -3082,7 +3082,7 @@ def destroy(name, call=None):
         transport=__opts__['transport']
     )
 
-    salt.utils.cloud.cachedir_index_del(name)
+    salt.utils.cloud.cachedir_index_del(name, opts=__opts__)
 
     if __opts__.get('update_cachedir', False) is True:
         salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -565,6 +565,7 @@ def create_network(kwargs=None, call=None):
             'name': name,
             'cidr': cidr,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -578,6 +579,7 @@ def create_network(kwargs=None, call=None):
             'name': name,
             'cidr': cidr,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
     return _expand_item(network)
@@ -614,6 +616,7 @@ def delete_network(kwargs=None, call=None):
         {
             'name': name,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -637,6 +640,7 @@ def delete_network(kwargs=None, call=None):
         {
             'name': name,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
     return result
@@ -716,6 +720,7 @@ def create_fwrule(kwargs=None, call=None):
             'network': network_name,
             'allow': kwargs['allow'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -736,6 +741,7 @@ def create_fwrule(kwargs=None, call=None):
             'network': network_name,
             'allow': kwargs['allow'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
     return _expand_item(fwrule)
@@ -772,6 +778,7 @@ def delete_fwrule(kwargs=None, call=None):
         {
             'name': name,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -795,6 +802,7 @@ def delete_fwrule(kwargs=None, call=None):
         {
             'name': name,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
     return result
@@ -870,6 +878,7 @@ def create_hc(kwargs=None, call=None):
             'unhealthy_threshold': unhealthy_threshold,
             'healthy_threshold': healthy_threshold,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -893,6 +902,7 @@ def create_hc(kwargs=None, call=None):
             'unhealthy_threshold': unhealthy_threshold,
             'healthy_threshold': healthy_threshold,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
     return _expand_item(hc)
@@ -929,6 +939,7 @@ def delete_hc(kwargs=None, call=None):
         {
             'name': name,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -952,6 +963,7 @@ def delete_hc(kwargs=None, call=None):
         {
             'name': name,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
     return result
@@ -1018,6 +1030,7 @@ def create_address(kwargs=None, call=None):
         'create address',
         'salt/cloud/address/creating',
         kwargs,
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -1028,6 +1041,7 @@ def create_address(kwargs=None, call=None):
         'created address',
         'salt/cloud/address/created',
         kwargs,
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -1075,6 +1089,7 @@ def delete_address(kwargs=None, call=None):
         {
             'name': name,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -1098,6 +1113,7 @@ def delete_address(kwargs=None, call=None):
         {
             'name': name,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -1198,6 +1214,7 @@ def create_lb(kwargs=None, call=None):
         'create load_balancer',
         'salt/cloud/loadbalancer/creating',
         kwargs,
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -1212,6 +1229,7 @@ def create_lb(kwargs=None, call=None):
         'created load_balancer',
         'salt/cloud/loadbalancer/created',
         kwargs,
+        opts=__opts__,
         transport=__opts__['transport']
     )
     return _expand_balancer(lb)
@@ -1248,6 +1266,7 @@ def delete_lb(kwargs=None, call=None):
         {
             'name': name,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -1271,6 +1290,7 @@ def delete_lb(kwargs=None, call=None):
         {
             'name': name,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
     return result
@@ -1337,6 +1357,7 @@ def attach_lb(kwargs=None, call=None):
         'attach load_balancer',
         'salt/cloud/loadbalancer/attaching',
         kwargs,
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -1347,6 +1368,7 @@ def attach_lb(kwargs=None, call=None):
         'attached load_balancer',
         'salt/cloud/loadbalancer/attached',
         kwargs,
+        opts=__opts__,
         transport=__opts__['transport']
     )
     return _expand_item(result)
@@ -1402,6 +1424,7 @@ def detach_lb(kwargs=None, call=None):
         'detach load_balancer',
         'salt/cloud/loadbalancer/detaching',
         kwargs,
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -1412,6 +1435,7 @@ def detach_lb(kwargs=None, call=None):
         'detached load_balancer',
         'salt/cloud/loadbalancer/detached',
         kwargs,
+        opts=__opts__,
         transport=__opts__['transport']
     )
     return result
@@ -1448,6 +1472,7 @@ def delete_snapshot(kwargs=None, call=None):
         {
             'name': name,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -1471,6 +1496,7 @@ def delete_snapshot(kwargs=None, call=None):
         {
             'name': name,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
     return result
@@ -1510,6 +1536,7 @@ def delete_disk(kwargs=None, call=None):
             'location': disk.extra['zone'].name,
             'size': disk.size,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -1533,6 +1560,7 @@ def delete_disk(kwargs=None, call=None):
             'location': disk.extra['zone'].name,
             'size': disk.size,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
     return result
@@ -1598,6 +1626,7 @@ def create_disk(kwargs=None, call=None):
             'image': image,
             'snapshot': snapshot,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -1615,6 +1644,7 @@ def create_disk(kwargs=None, call=None):
             'image': image,
             'snapshot': snapshot,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
     return _expand_disk(disk)
@@ -1671,6 +1701,7 @@ def create_snapshot(kwargs=None, call=None):
             'name': name,
             'disk_name': disk_name,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -1684,6 +1715,7 @@ def create_snapshot(kwargs=None, call=None):
             'name': name,
             'disk_name': disk_name,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
     return _expand_item(snapshot)
@@ -1775,6 +1807,7 @@ def detach_disk(name=None, kwargs=None, call=None):
             'name': node_name,
             'disk_name': disk_name,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -1788,6 +1821,7 @@ def detach_disk(name=None, kwargs=None, call=None):
             'name': node_name,
             'disk_name': disk_name,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
     return result
@@ -1848,6 +1882,7 @@ def attach_disk(name=None, kwargs=None, call=None):
             'mode': mode,
             'boot': boot,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -1863,6 +1898,7 @@ def attach_disk(name=None, kwargs=None, call=None):
             'mode': mode,
             'boot': boot,
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
     return result
@@ -1926,6 +1962,7 @@ def destroy(vm_name, call=None):
         'delete instance',
         'salt/cloud/{0}/deleting'.format(vm_name),
         {'name': vm_name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -1963,6 +2000,7 @@ def destroy(vm_name, call=None):
         'delete instance',
         'salt/cloud/{0}/deleted'.format(vm_name),
         {'name': vm_name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -1976,6 +2014,7 @@ def destroy(vm_name, call=None):
             'delete disk',
             'salt/cloud/disk/deleting',
             {'name': vm_name},
+            opts=__opts__,
             transport=__opts__['transport']
         )
         try:
@@ -1997,6 +2036,7 @@ def destroy(vm_name, call=None):
             'deleted disk',
             'salt/cloud/disk/deleted',
             {'name': vm_name},
+            opts=__opts__,
             transport=__opts__['transport']
         )
 
@@ -2096,6 +2136,7 @@ def create(vm_=None, call=None):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -2139,6 +2180,7 @@ def create(vm_=None, call=None):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 

--- a/salt/cloud/clouds/gogrid.py
+++ b/salt/cloud/clouds/gogrid.py
@@ -106,6 +106,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -134,6 +135,7 @@ def create(vm_):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
         {'kwargs': create_kwargs},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -193,6 +195,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -412,6 +415,7 @@ def destroy(name, call=None):
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -422,6 +426,7 @@ def destroy(name, call=None):
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 

--- a/salt/cloud/clouds/joyent.py
+++ b/salt/cloud/clouds/joyent.py
@@ -182,6 +182,7 @@ def query_instance(vm_=None, call=None):
         'event',
         'querying instance',
         'salt/cloud/{0}/querying'.format(vm_['name']),
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -268,6 +269,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -293,6 +295,7 @@ def create(vm_):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
         {'kwargs': kwargs},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -327,6 +330,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -388,6 +392,7 @@ def destroy(name, call=None):
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -400,6 +405,7 @@ def destroy(name, call=None):
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -365,6 +365,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -452,6 +453,7 @@ def create(vm_):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(name),
         {'kwargs': kwargs},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -529,6 +531,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -701,6 +704,7 @@ def destroy(name, call=None):
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -713,6 +717,7 @@ def destroy(name, call=None):
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 

--- a/salt/cloud/clouds/lxc.py
+++ b/salt/cloud/clouds/lxc.py
@@ -398,6 +398,7 @@ def destroy(vm_, call=None):
             'destroying instance',
             'salt/cloud/{0}/destroying'.format(vm_),
             {'name': vm_, 'instance_id': vm_},
+            opts=__opts__,
             transport=__opts__['transport']
         )
         cret = _salt('lxc.destroy', vm_, stop=True, path=path)
@@ -409,6 +410,7 @@ def destroy(vm_, call=None):
                 'destroyed instance',
                 'salt/cloud/{0}/destroyed'.format(vm_),
                 {'name': vm_, 'instance_id': vm_},
+                opts=__opts__,
                 transport=__opts__['transport']
             )
             if __opts__.get('update_cachedir', False) is True:
@@ -443,6 +445,7 @@ def create(vm_, call=None):
         'salt/cloud/{0}/creating'.format(vm_['name']),
         {'name': vm_['name'], 'profile': profile,
          'provider': vm_['driver'], },
+        opts=__opts__,
         transport=__opts__['transport'])
     ret = {'name': vm_['name'], 'changes': {}, 'result': True, 'comment': ''}
     if 'pub_key' not in vm_ and 'priv_key' not in vm_:
@@ -482,6 +485,7 @@ def create(vm_, call=None):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 

--- a/salt/cloud/clouds/msazure.py
+++ b/salt/cloud/clouds/msazure.py
@@ -431,6 +431,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -527,6 +528,7 @@ def create(vm_):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
         event_kwargs,
+        opts=__opts__,
         transport=__opts__['transport']
     )
     log.debug('vm_kwargs: {0}'.format(vm_kwargs))
@@ -643,6 +645,7 @@ def create(vm_):
             'attaching volumes',
             'salt/cloud/{0}/attaching_volumes'.format(vm_['name']),
             {'volumes': volumes},
+            opts=__opts__,
             transport=__opts__['transport']
         )
 
@@ -680,6 +683,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -479,6 +479,7 @@ def destroy(name, conn=None, call=None):
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -516,6 +517,7 @@ def destroy(name, conn=None, call=None):
             'destroyed instance',
             'salt/cloud/{0}/destroyed'.format(name),
             {'name': name},
+            opts=__opts__,
             transport=__opts__['transport']
         )
         if __opts__.get('delete_sshkeys', False) is True:
@@ -631,6 +633,7 @@ def request_instance(vm_=None, call=None):
         {'kwargs': {'name': kwargs['name'],
                     'image': kwargs.get('image_id', 'Boot From Volume'),
                     'size': kwargs['flavor_id']}},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -693,6 +696,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
     conn = get_conn()
@@ -910,6 +914,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 

--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -325,6 +325,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
     )
 
     log.info('Creating Cloud VM {0}'.format(vm_['name']))
@@ -344,6 +345,7 @@ def create(vm_):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
         {'kwargs': kwargs},
+        opts=__opts__,
     )
 
     region = ''
@@ -447,6 +449,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
     )
 
     return ret
@@ -519,6 +522,7 @@ def destroy(name, call=None):
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
         {'name': name},
+        opts=__opts__,
     )
 
     server, user, password = _get_xml_rpc()
@@ -531,6 +535,7 @@ def destroy(name, call=None):
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
         {'name': name},
+        opts=__opts__,
     )
 
     if __opts__.get('update_cachedir', False) is True:

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -520,6 +520,7 @@ def request_instance(vm_=None, call=None):
                     'image': kwargs['image'].name,
                     'size': kwargs['size'].name,
                     'profile': vm_['profile']}},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -591,6 +592,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -793,6 +795,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 

--- a/salt/cloud/clouds/parallels.py
+++ b/salt/cloud/clouds/parallels.py
@@ -258,6 +258,7 @@ def create_node(vm_):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
         {'kwargs': data},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -293,6 +294,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -367,6 +369,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -547,6 +550,7 @@ def destroy(name, call=None):
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -570,6 +574,7 @@ def destroy(name, call=None):
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -525,6 +525,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -608,6 +609,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
     )
 
     return ret
@@ -666,6 +668,7 @@ def create_node(vm_):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
         {'kwargs': newnode},
+        opts=__opts__,
     )
 
     log.debug('Preparing to generate a node using these parameters: {0} '.format(
@@ -774,6 +777,7 @@ def destroy(name, call=None):
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -795,6 +799,7 @@ def destroy(name, call=None):
             'destroyed instance',
             'salt/cloud/{0}/destroyed'.format(name),
             {'name': name},
+            opts=__opts__,
             transport=__opts__['transport']
         )
         if __opts__.get('update_cachedir', False) is True:

--- a/salt/cloud/clouds/qingcloud.py
+++ b/salt/cloud/clouds/qingcloud.py
@@ -680,6 +680,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -702,6 +703,7 @@ def create(vm_):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
         {'kwargs': params},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -754,6 +756,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -884,6 +887,7 @@ def destroy(instance_id, call=None):
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -899,6 +903,7 @@ def destroy(instance_id, call=None):
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 

--- a/salt/cloud/clouds/rackspace.py
+++ b/salt/cloud/clouds/rackspace.py
@@ -211,6 +211,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['provider'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -229,6 +230,7 @@ def create(vm_):
         {'kwargs': {'name': kwargs['name'],
                     'image': kwargs['image'].name,
                     'size': kwargs['size'].name}},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -434,6 +436,7 @@ def create(vm_):
             'executing deploy script',
             'salt/cloud/{0}/deploying'.format(vm_['name']),
             {'kwargs': event_kwargs},
+            opts=__opts__,
             transport=__opts__['transport']
         )
 
@@ -472,6 +475,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['provider'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 

--- a/salt/cloud/clouds/scaleway.py
+++ b/salt/cloud/clouds/scaleway.py
@@ -228,6 +228,7 @@ def create(server_):
             'profile': server_['profile'],
             'provider': server_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -253,6 +254,7 @@ def create(server_):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(server_['name']),
         {'kwargs': kwargs},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -321,6 +323,7 @@ def create(server_):
             'profile': server_['profile'],
             'provider': server_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -438,6 +441,7 @@ def destroy(name, call=None):
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -452,6 +456,7 @@ def destroy(name, call=None):
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 

--- a/salt/cloud/clouds/softlayer.py
+++ b/salt/cloud/clouds/softlayer.py
@@ -266,6 +266,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -367,6 +368,7 @@ def create(vm_):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
         {'kwargs': kwargs},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -483,6 +485,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -583,6 +586,7 @@ def destroy(name, call=None):
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -595,6 +599,7 @@ def destroy(name, call=None):
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
     if __opts__.get('update_cachedir', False) is True:

--- a/salt/cloud/clouds/softlayer_hw.py
+++ b/salt/cloud/clouds/softlayer_hw.py
@@ -237,6 +237,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -319,6 +320,7 @@ def create(vm_):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
         {'kwargs': kwargs},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -413,6 +415,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -514,6 +517,7 @@ def destroy(name, call=None):
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -534,6 +538,7 @@ def destroy(name, call=None):
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
     if __opts__.get('update_cachedir', False) is True:

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -1933,6 +1933,7 @@ def destroy(name, call=None):
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -1981,6 +1982,7 @@ def destroy(name, call=None):
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
     if __opts__.get('update_cachedir', False) is True:
@@ -2026,6 +2028,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -2258,6 +2261,7 @@ def create(vm_):
                 'requesting instance',
                 'salt/cloud/{0}/requesting'.format(vm_['name']),
                 {'kwargs': vm_},
+                opts=__opts__,
                 transport=__opts__['transport']
             )
 
@@ -2321,6 +2325,7 @@ def create(vm_):
                 'profile': vm_['profile'],
                 'provider': vm_['driver'],
             },
+            opts=__opts__,
             transport=__opts__['transport']
         )
         return data

--- a/salt/cloud/clouds/vsphere.py
+++ b/salt/cloud/clouds/vsphere.py
@@ -265,6 +265,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -276,6 +277,7 @@ def create(vm_):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
         {'kwargs': vm_},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -350,6 +352,7 @@ def create(vm_):
             'profile': vm_['profile'],
             'provider': vm_['driver'],
         },
+        opts=__opts__,
         transport=__opts__['transport']
     )
     return ret
@@ -479,6 +482,7 @@ def _deploy(vm_):
         'executing deploy script',
         'salt/cloud/{0}/deploying'.format(vm_['name']),
         {'kwargs': deploy_kwargs},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -647,6 +651,7 @@ def destroy(name, call=None):  # pylint: disable=W0613
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -664,6 +669,7 @@ def destroy(name, call=None):  # pylint: disable=W0613
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
     if __opts__.get('update_cachedir', False) is True:

--- a/salt/cloud/libcloudfuncs.py
+++ b/salt/cloud/libcloudfuncs.py
@@ -330,6 +330,7 @@ def destroy(name, conn=None, call=None):
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
         {'name': name},
+        opts=__opts__,
         transport=__opts__['transport']
     )
 
@@ -370,6 +371,7 @@ def destroy(name, conn=None, call=None):
             'destroyed instance',
             'salt/cloud/{0}/destroyed'.format(name),
             {'name': name},
+            opts=__opts__,
             transport=__opts__['transport']
         )
         if __opts__['delete_sshkeys'] is True:
@@ -410,6 +412,7 @@ def reboot(name, conn=None):
             '{0} has been rebooted'.format(name), 'salt-cloud'
             'salt/cloud/{0}/rebooting'.format(name),
             {'name': name},
+            opts=__opts__,
             transport=__opts__['transport']
         )
         return True

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1684,10 +1684,12 @@ def run_inline_script(host,
     return True
 
 
-def fire_event(key, msg, tag, args=None, sock_dir=None, transport='zeromq'):
+def fire_event(key, msg, tag, args=None, sock_dir=None, opts=None, transport='zeromq'):
     # Fire deploy action
     if sock_dir is None:
-        sock_dir = os.path.join(syspaths.SOCK_DIR, 'master')
+        if opts is None:
+            opts = {}
+        sock_dir = os.path.join(opts.get('sock_dir', syspaths.SOCK_DIR), 'master')
     event = salt.utils.event.get_event(
         'master',
         sock_dir,


### PR DESCRIPTION
### What does this PR do?

opts uses syspaths already, so we should be just passing through opts to
make sure that these things follow the configurations like `root_dir`
### What issues does this PR fix or reference?

Closes #18419 
### Tests written?

No
