### PR TITLE
Correct errant call to argspec from master. Fix ext_job_cache.

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -2275,7 +2275,7 @@ class ClearFuncs(object):
 
             # Get the returner's save_load arg_spec.
             try:
-                arg_spec = salt.utils.args.get_function_argspec(fstr)
+                arg_spec = salt.utils.args.get_function_argspec(self.mminion.returners[fstr])
 
                 # Check if 'minions' is included in returner's save_load arg_spec.
                 # This may be missing in custom returners, which we should warn about.


### PR DESCRIPTION
We were passing a string to the argpsec checker when it expects the actual func.

Closes saltstack/salt#35403