### PR TITLE
Resolve stacktrace logged by highstate outputter if sls cannot be found

### DIFF
--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -140,6 +140,8 @@ def output(data):
         'Data passed to highstate outputter is not a valid highstate return: %s',
         data
     )
+    # We should not reach here, but if we do return empty string
+    return ''
 
 
 def _format_host(host, data):


### PR DESCRIPTION
Simply return an empty string instead of a None.

Fixes #35423
