### PR TITLE
Fix iptables target options with no arguments

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -405,7 +405,9 @@ def build_rule(table='filter', chain=None, command=None, position='', full=None,
     for after_jump_argument in after_jump_arguments:
         if after_jump_argument in kwargs:
             value = kwargs[after_jump_argument]
-            if any(ws_char in str(value) for ws_char in string.whitespace):
+            if value in (None, ''):  # options without arguments
+                after_jump.append('--{0}'.format(after_jump_argument))
+            elif any(ws_char in str(value) for ws_char in string.whitespace):
                 after_jump.append('--{0} "{1}"'.format(after_jump_argument, value))
             else:
                 after_jump.append('--{0} {1}'.format(after_jump_argument, value))

--- a/tests/unit/modules/iptables_test.py
+++ b/tests/unit/modules/iptables_test.py
@@ -128,7 +128,12 @@ class IptablesTestCase(TestCase):
         # Should allow no-arg jump options
         self.assertEqual(iptables.build_rule(jump='CLUSTERIP',
                                              **{'new': ''}),
-                         '--jump CLUSTERIP --new ')
+                         '--jump CLUSTERIP --new')
+
+        # Should allow no-arg jump options as None
+        self.assertEqual(iptables.build_rule(jump='CT',
+                                             **{'notrack': None}),
+                         '--jump CT --notrack')
 
         # should build match-sets with single string
         self.assertEqual(iptables.build_rule(**{'match-set': 'src flag1,flag2'}),


### PR DESCRIPTION
Fix iptables `build_rule` when the target's option has no argument。

Link to my previous MR https://github.com/saltstack/salt/pull/24595 , which was reverted in the end.

I tried to change my iptables yaml data to compatible with salt's iptables structure, for example:

``` yaml
  - name: test
    jump: CT
    notrack: ''
    ...
```

In my previous written syntax, it just like `jump: CT --notrack`, but this will cause problem as I described in the previous MR.

But if I use the salt expected syntax, I found the target's option, such as in above example, `--notrack` option of target `CT`, has no argument, so I defined it with empty string, and salt parse it with `None`, so I add this bugfix, otherwise it will parsed with error format:

``` bash
iptables -A INPUT ... --jump CT --notrack None
```