### PR TITLE
Return cleaner error on pillar/grains rendering failure

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1226,11 +1226,11 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         '''
         if '__grains__' not in self.pack:
             self.context_dict['grains'] = opts.get('grains', {})
-            self.pack['__grains__'] = salt.utils.context.NamespacedDictWrapper(self.context_dict, 'grains')
+            self.pack['__grains__'] = salt.utils.context.NamespacedDictWrapper(self.context_dict, 'grains', override_name='grains')
 
         if '__pillar__' not in self.pack:
             self.context_dict['pillar'] = opts.get('pillar', {})
-            self.pack['__pillar__'] = salt.utils.context.NamespacedDictWrapper(self.context_dict, 'pillar')
+            self.pack['__pillar__'] = salt.utils.context.NamespacedDictWrapper(self.context_dict, 'pillar', override_name='pillar')
 
         mod_opts = {}
         for key, val in list(opts.items()):

--- a/salt/utils/context.py
+++ b/salt/utils/context.py
@@ -164,12 +164,16 @@ class NamespacedDictWrapper(collections.MutableMapping, dict):
 
     MUST inherit from dict to serialize through msgpack correctly
     '''
-    def __init__(self, d, pre_keys):  # pylint: disable=W0231
+
+    def __init__(self, d, pre_keys, override_name=None):  # pylint: disable=W0231
         self.__dict = d
         if isinstance(pre_keys, six.string_types):
             self.pre_keys = (pre_keys,)
         else:
             self.pre_keys = pre_keys
+        if override_name:
+            self.__class__.__module__ = 'salt'
+            self.__class__.__name__ = override_name
 
     def _dict(self):
         r = self.__dict
@@ -202,3 +206,4 @@ class NamespacedDictWrapper(collections.MutableMapping, dict):
 
     def __str__(self):
         return self._dict().__str__()
+    

--- a/salt/utils/context.py
+++ b/salt/utils/context.py
@@ -206,4 +206,3 @@ class NamespacedDictWrapper(collections.MutableMapping, dict):
 
     def __str__(self):
         return self._dict().__str__()
-    


### PR DESCRIPTION
### What does this PR do?

Cleans up a hard-to-read error message
### What issues does this PR fix or reference?
#35242
### Previous Behavior

```
Rendering SLS 'base:myteststate' failed: Jinja variable 'salt.utils.context.NamespacedDictWrapper object' has no attribute 'dfgjkhdfgdfgdfg'
```
### New Behavior

```
local:
    - Rendering SLS 'base:issue_35242' failed: Jinja variable 'salt.pillar object' has no attribute 'dfgjkhdfgdfgdfg'
```
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

Refs #35242
