### PR TITLE
[dockerng] RepoTags can be also be None with docker 1.12

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -2065,9 +2065,11 @@ def images(verbose=False, **kwargs):
             if img_id is None:
                 continue
             for item in img:
-                img_state = 'untagged' \
-                    if img['RepoTags'] == ['<none>:<none>'] \
-                    else 'tagged'
+                img_state = ('untagged' if
+                             img['RepoTags'] in (
+                               ['<none>:<none>'],  # docker API <1.24
+                               None,  # docker API >=1.24
+                             ) else 'tagged')
                 bucket = __context__.setdefault('docker.images', {})
                 bucket = bucket.setdefault(img_state, {})
                 img_key = key_map.get(item, item)
@@ -2250,8 +2252,7 @@ def list_tags():
     '''
     ret = set()
     for item in six.itervalues(images()):
-        for repo_tag in item.get('RepoTags', []):
-            ret.add(repo_tag)
+        ret.update(set(item['RepoTags']))
     return sorted(ret)
 
 

--- a/tests/unit/modules/dockerng_test.py
+++ b/tests/unit/modules/dockerng_test.py
@@ -620,6 +620,25 @@ class DockerngTestCase(TestCase):
                                   'state': {'new': 'stopped',
                                             'old': 'stopped'}})
 
+    def test_images_with_empty_tags(self):
+        """
+        docker 1.12 reports also images without tags with `null`.
+        """
+        client = Mock()
+        client.api_version = '1.24'
+        client.images = Mock(
+            return_value=[{'Id': 'sha256:abcde',
+                           'RepoTags': None},
+                          {'Id': 'sha256:abcdef'},
+                          {'Id': 'sha256:abcdefg',
+                           'RepoTags': ['image:latest']}])
+        with patch.dict(dockerng_mod.__context__,
+                        {'docker.client': client}):
+            dockerng_mod._clear_context()
+            result = dockerng_mod.images()
+        self.assertEqual(result,
+                         {'sha256:abcdefg': {'RepoTags': ['image:latest']}})
+
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
### What does this PR do?

Add support for images response when `RepoTags` entry is None

``` python
{u'Created': 1471252564,
 u'Id': u'sha256:fffffffffffffffffffffffffffffffff',
 u'Labels': {},
 u'ParentId': u'',
 u'RepoDigests': [u'repo/image@sha256:ffffffffffffffffffffffffffffffffff'],
 u'RepoTags': None,  # <--- HERE 
 u'Size': 281902218,
 u'VirtualSize': 281902218}
```
### What issues does this PR fix or reference?
saltstack/salt#35308 saltstack/salt#34702
### Previous Behavior

Was not fixed at the right place.
### New Behavior

Provide a fix, I believe to be correct.
### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.