### PR TITLE
Add ignore_repo_failure option to suppress zypper's exit code 106 on …

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -99,6 +99,18 @@ class _Zypper(object):
         self.__no_lock = False
         self.__no_raise = False
         self.__refresh = False
+        self.__ignore_repo_failure = False
+
+    def __call__(self, *args, **kwargs):
+        '''
+        :param args:
+        :param kwargs:
+        :return:
+        '''
+        # Ignore exit code for 106 (repo is not available)
+        if 'no_repo_failure' in kwargs:
+            self.__ignore_repo_failure = kwargs['no_repo_failure']
+        return self
 
     def __getattr__(self, item):
         '''
@@ -274,7 +286,7 @@ class _Zypper(object):
             __salt__['event.fire_master']({'success': not len(self.error_msg),
                                            'info': self.error_msg or 'Zypper has been released'},
                                           self.TAG_RELEASED)
-        if self.error_msg and not self.__no_raise:
+        if self.error_msg and not self.__no_raise and not self.__ignore_repo_failure:
             raise CommandExecutionError('Zypper command failure: {0}'.format(self.error_msg))
 
         return self._is_xml_mode() and dom.parseString(self.__call_result['stdout']) or self.__call_result['stdout']
@@ -856,6 +868,7 @@ def install(name=None,
             sources=None,
             downloadonly=None,
             version=None,
+            ignore_repo_failure=False,
             **kwargs):
     '''
     Install the passed package(s), add refresh=True to force a 'zypper refresh'
@@ -918,6 +931,10 @@ def install(name=None,
         .. code-block:: bash
 
             salt '*' pkg.install sources='[{"foo": "salt://foo.rpm"},{"bar": "salt://bar.rpm"}]'
+
+    ignore_repo_failure
+        Zypper returns error code 106 if one of the repositories are not available for various reasons.
+        In case to set strict check, this parameter needs to be set to True. Default: False.
 
 
     Returns a dict containing the new package names and versions::
@@ -983,7 +1000,7 @@ def install(name=None,
     while targets:
         cmd = cmd_install + targets[:500]
         targets = targets[500:]
-        for line in __zypper__.call(*cmd).splitlines():
+        for line in __zypper__(no_repo_failure=ignore_repo_failure).call(*cmd).splitlines():
             match = re.match(r"^The selected package '([^']+)'.+has lower version", line)
             if match:
                 downgrades.append(match.group(1))
@@ -991,7 +1008,7 @@ def install(name=None,
     while downgrades:
         cmd = cmd_install + ['--force'] + downgrades[:500]
         downgrades = downgrades[500:]
-        __zypper__.call(*cmd)
+        __zypper__(no_repo_failure=ignore_repo_failure).call(*cmd)
 
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()


### PR DESCRIPTION
### What does this PR do?

Sync with the latest Zypper changes.
### What issues does this PR fix or reference?

If Zypper finds at least one wrong repository (not available, empty etc) it stops everything, which is a correct behaviour. However, sometimes it is needed to "ignore" this kind of setup, as long as package is anyway available. For this `ignore_repo_failure=False` has been added. In order to let this start working, `ignore_repo_failure` needs to be set to `True` explicitly. The error message is still included for further references.
### Tests written?

No