### PR TITLE
aptpkg will specify --install-recommends if enabled by the SLS

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -559,8 +559,11 @@ def install(name=None,
         else:
             cmd_prefix += ['-o', 'DPkg::Options::=--force-confold']
         cmd_prefix += ['-o', 'DPkg::Options::=--force-confdef']
-        if 'install_recommends' in kwargs and not kwargs['install_recommends']:
-            cmd_prefix.append('--no-install-recommends')
+        if 'install_recommends' in kwargs:
+            if not kwargs['install_recommends']:
+                cmd_prefix.append('--no-install-recommends')
+            else:
+                cmd_prefix.append('--install-recommends')
         if 'only_upgrade' in kwargs and kwargs['only_upgrade']:
             cmd_prefix.append('--only-upgrade')
         if skip_verify:


### PR DESCRIPTION
This changes the behaviour of the "install_recommends" flag for the "pkg" state slightly. It explicitly passes "--install-recommends" to the apt call, if the user sets the flag to True in the state.
### What issues does this PR fix or reference?

This fixes #35422.
### Previous Behavior

Previously the aptpkg module would only provide the "--no-install-recommends" argument if the user set the "install_recommends" flag to False. The command line arguments would not be manipulated if the user set it to True, or did not specify the flag at all.
### New Behavior

With the changes in this pull, if the user sets "install_recommends" to True in the state, then the module will provide the "--install-recommends" argument. If the user sets "install_recommends" to False in the state, then the module will provide the "--no-install-recommends" flag as before. And if the user doesn't specify either way, then the module will not add any argument, as it did before.
