### PR TITLE
Fix os_family check in zypper module

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -54,7 +54,7 @@ def __virtual__():
     '''
     Set the virtual pkg module if the os is openSUSE
     '''
-    if __grains__.get('os_family', '') != 'SUSE':
+    if __grains__.get('os_family', '') != 'Suse':
         return (False, "Module zypper: non SUSE OS not suppored by zypper package manager")
     # Not all versions of SUSE use zypper, check that it is available
     if not salt.utils.which('zypper'):


### PR DESCRIPTION
### What does this PR do?

as per https://github.com/saltstack/salt/pull/35415, it fixes os_family
### What issues does this PR fix or reference?

it allows zypper module to provide `pkg` again
### Tests written?

No