### PR TITLE
Bugfix: zypper mod repo unchanged

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -806,6 +806,7 @@ def mod_repo(repo, **kwargs):
         cmd_opt = global_cmd_opt + ['mr'] + cmd_opt + [repo]
         __zypper__.refreshable.xml.call(*cmd_opt)
 
+    comment = None
     if call_refresh:
         # when used with "zypper ar --refresh" or "zypper mr --refresh"
         # --gpg-auto-import-keys is not doing anything
@@ -813,11 +814,13 @@ def mod_repo(repo, **kwargs):
         refresh_opts = global_cmd_opt + ['refresh'] + [repo]
         __zypper__.xml.call(*refresh_opts)
     elif not added and not cmd_opt:
-        raise CommandExecutionError(
-            'Specified arguments did not result in modification of repo'
-        )
+        comment = 'Specified arguments did not result in modification of repo'
 
-    return get_repo(repo)
+    repo = get_repo(repo)
+    if comment:
+        repo['comment'] = comment
+
+    return repo
 
 
 def refresh_db():

--- a/tests/unit/modules/zypper_test.py
+++ b/tests/unit/modules/zypper_test.py
@@ -73,7 +73,7 @@ class ZypperTestCase(TestCase):
         self.zypper_patcher_config = {
             '_get_configured_repos': Mock(side_effect=side_effect),
             '__zypper__': Mock(),
-            'get_repo': Mock()
+            'get_repo': Mock(return_value={})
         }
 
     def test_list_upgrades(self):
@@ -493,17 +493,8 @@ class ZypperTestCase(TestCase):
             'salt.modules.zypper', **self.zypper_patcher_config)
 
         with zypper_patcher:
-            with self.assertRaisesRegexp(
-                Exception,
-                'Specified arguments did not result in modification of repo'
-            ):
-                zypper.mod_repo(name, **{'url': url})
-            with self.assertRaisesRegexp(
-                Exception,
-                'Specified arguments did not result in modification of repo'
-            ):
-                zypper.mod_repo(name, **{'url': url, 'gpgautoimport': 'a'})
-
+            self.assertEqual(zypper.mod_repo(name, **{'url': url}),
+                             {'comment': 'Specified arguments did not result in modification of repo'})
             zypper.__zypper__.xml.call.assert_not_called()
             zypper.__zypper__.refreshable.xml.call.assert_not_called()
 


### PR DESCRIPTION
### What does this PR do?

Bugfix
### What issues does this PR fix or reference?

`pkg.mod_repo` responds with an error, if nothing has been changed. This renders state module faulty.
### Tests written?

Yes