### PR TITLE
move routine call out of try/except block

### DIFF
--- a/salt/roster/ansible.py
+++ b/salt/roster/ansible.py
@@ -139,9 +139,10 @@ class Target(object):
         Execute the correct tgt_type routine and return
         '''
         try:
-            return getattr(self, 'get_{0}'.format(self.tgt_type))()
+            routine = getattr(self, 'get_{0}'.format(self.tgt_type))
         except AttributeError:
             return {}
+        return routine()
 
     def get_glob(self):
         '''


### PR DESCRIPTION
### What does this PR do?

The try/except block is indented to handle AttributeErrors if the routine `get_<tgt_type>` is not available. But since the actual function call is also wrapped in the block if the routine is actually implemented but raises an AttributeError that one is catched too (which I think is unintentional).

This patch moves the function call out of the try/except block to not mask AttributeErrors happening within the called routine.
### What issues does this PR fix or reference?

If a `get_*` routine is written in a way that it raises an AttributeError (likely by accident) the resulting exception is not silently ignored anymore but raises and makes the problem visible.
### Previous Behavior

If the routine exists but raises an AttributeError internally that exception was catched and an empty dict was returned.
### New Behavior

If the routine exists and raises an AttributeError internally that exception is not being catched anymore but reported up the stack (up to aborting the current script).
### Tests written?

No