### PR TITLE
Ensure that output for salt-ssh gets back

### DIFF
--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -230,7 +230,7 @@ def main(argv):  # pylint: disable=W0613
         subprocess.call(salt_argv)
         shutil.rmtree(OPTIONS.saltdir)
     else:
-        os.execv(sys.executable, salt_argv)
+        subprocess.call(salt_argv)
     if OPTIONS.cmd_umask is not None:
         os.umask(old_umask)
 


### PR DESCRIPTION
We ran into a rare case where the os.execv did not send the command output back up to ssh, this resolved said issue.