### PR TITLE
Make `auth_timeout` user configurable again

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1091,7 +1091,7 @@ DEFAULT_MINION_OPTS = {
     'minion_id_caching': True,
     'keysize': 2048,
     'transport': 'zeromq',
-    'auth_timeout': 60,
+    'auth_timeout': 5,
     'auth_tries': 7,
     'master_tries': _MASTER_TRIES,
     'auth_safemode': False,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -731,9 +731,6 @@ class MinionManager(MinionBase):
     defined in the master option and binds each minion object to a respective
     master.
     '''
-    # timeout for one of the minions to auth with a master
-    MINION_CONNECT_TIMEOUT = 5
-
     def __init__(self, opts):
         super(MinionManager, self).__init__(opts)
         self.auth_wait = self.opts['acceptance_wait_time']
@@ -771,9 +768,8 @@ class MinionManager(MinionBase):
             s_opts = copy.deepcopy(self.opts)
             s_opts['master'] = master
             s_opts['multimaster'] = True
-            s_opts['auth_timeout'] = self.MINION_CONNECT_TIMEOUT
             minion = Minion(s_opts,
-                            self.MINION_CONNECT_TIMEOUT,
+                            s_opts['auth_timeout'],
                             False,
                             io_loop=self.io_loop,
                             loaded_base_name='salt.loader.{0}'.format(s_opts['master']),


### PR DESCRIPTION
### What does this PR do?

There was code that was overriding the value of `auth_timeout` regardless
of what was set in the configuration. It was overriding it to be 5
seconds. Although 5 seconds is sufficient for most cases, in testing, I
have found it insufficient for the following use case (running both
Windows master and minions):

1) Start salt-master
2) Start salt-minion
3) Stop salt-master
4) Start salt-master

The minion reconnect will timeout after step 4. Due to this, we set the
`auth_timeout` to be 15 seconds in our own configuration file. However,
due to this issue, that configuration value was ignored and thus we
fail on reconnects.

`salt/minion.py`:
- Don't hard-code the `auth_timeout` to 5 seconds. Use the user configured
  value (or the default value if the user didn't configure a value).

`salt/config/__init__.py`:
- Made the default be 5 seconds for `auth_timeout` instead of 60. Chose 5
  seconds because this is the current hard-coded behavior.
### Tests written?

No