### PR TITLE
Remove the env and activate kwargs from pip install/ed functions

### DIFF
--- a/doc/topics/releases/carbon.rst
+++ b/doc/topics/releases/carbon.rst
@@ -343,6 +343,10 @@ Execution Module Deprecations
   - The old style of defining lxc containers has been removed. Please use keys under which
     LXC profiles should be configured such as ``lxc.container_profile.profile_name``.
 
+- The ``env`` and ``activate`` keyword arguments have been removed from the ``install``
+  function in the ``pip`` execution module. The use of ``bin_env`` replaces both of these
+  options.
+
 - ``reg`` execution module
 
   Functions in the ``reg`` execution module had misleading and confusing names
@@ -395,6 +399,10 @@ Runner Module Deprecations
 
 State Module Deprecations
 -------------------------
+
+- The ``env`` and ``activate`` keyword arguments were removed from the ``installed``
+  function in the ``pip`` state module. The use of ``bin_env`` replaces both of these
+  options.
 
 - ``reg`` state module
 

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -328,7 +328,6 @@ def _process_requirements(requirements, cmd, cwd, saltenv, user):
 
 def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
             requirements=None,
-            env=None,
             bin_env=None,
             use_wheel=False,
             no_use_wheel=False,
@@ -358,7 +357,6 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
             user=None,
             no_chown=False,
             cwd=None,
-            activate=False,
             pre_releases=False,
             cert=None,
             allow_all_external=False,
@@ -390,9 +388,6 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
         .. note::
             If installing into a virtualenv, just use the path to the
             virtualenv (e.g. ``/home/code/path/to/virtualenv/``)
-
-    env
-        Deprecated, use bin_env now
 
     use_wheel
         Prefer wheel archives (requires pip>=1.4)
@@ -496,14 +491,6 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
     cwd
         Current working directory to run pip from
 
-    activate
-        Activates the virtual environment, if given via bin_env, before running
-        install.
-
-        .. deprecated:: 2014.7.2
-            If `bin_env` is given, pip will already be sourced from that
-            virtualenv, making `activate` effectively a noop.
-
     pre_releases
         Include pre-releases in the available versions
 
@@ -561,28 +548,6 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
                 editable=git+https://github.com/worldcompany/djangoembed.git#egg=djangoembed upgrade=True no_deps=True
 
     '''
-    # Switching from using `pip_bin` and `env` to just `bin_env`
-    # cause using an env and a pip bin that's not in the env could
-    # be problematic.
-    # Still using the `env` variable, for backwards compatibility's sake
-    # but going fwd you should specify either a pip bin or an env with
-    # the `bin_env` argument and we'll take care of the rest.
-    if env and not bin_env:
-        salt.utils.warn_until(
-            'Carbon',
-            'Passing \'env\' to the pip module is deprecated. Use bin_env instead. '
-            'This functionality will be removed in Salt Carbon.'
-        )
-        bin_env = env
-
-    if activate:
-        salt.utils.warn_until(
-            'Carbon',
-            'Passing \'activate\' to the pip module is deprecated. If '
-            'bin_env refers to a virtualenv, there is no need to activate '
-            'that virtualenv before using pip to install packages in it.'
-        )
-
     pip_bin = _get_pip_bin(bin_env)
 
     cmd = [pip_bin, 'install']

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -220,7 +220,6 @@ def installed(name,
               pkgs=None,
               pip_bin=None,
               requirements=None,
-              env=None,
               bin_env=None,
               use_wheel=False,
               no_use_wheel=False,
@@ -251,7 +250,6 @@ def installed(name,
               user=None,
               no_chown=False,
               cwd=None,
-              activate=False,
               pre_releases=False,
               cert=None,
               allow_all_external=False,
@@ -374,14 +372,6 @@ def installed(name,
     cwd
         Current working directory to run pip from
 
-    activate
-        Activates the virtual environment, if given via bin_env,
-        before running install.
-
-        .. deprecated:: 2014.7.2
-            If `bin_env` is given, pip will already be sourced from that
-            virtualenv, making `activate` effectively a noop.
-
     pre_releases
         Include pre-releases in the available versions
 
@@ -459,9 +449,6 @@ def installed(name,
     pip_bin : None
         Deprecated, use ``bin_env``
 
-    env : None
-        Deprecated, use ``bin_env``
-
     .. versionchanged:: 0.17.0
         ``use_wheel`` option added.
 
@@ -524,8 +511,6 @@ def installed(name,
 
     if pip_bin and not bin_env:
         bin_env = pip_bin
-    elif env and not bin_env:
-        bin_env = env
 
     # If pkgs is present, ignore name
     if pkgs:
@@ -709,7 +694,6 @@ def installed(name,
         user=user,
         no_chown=no_chown,
         cwd=cwd,
-        activate=activate,
         pre_releases=pre_releases,
         cert=cert,
         allow_all_external=allow_all_external,


### PR DESCRIPTION
### What does this PR do?

These options have been marked for deprecation in Carbon. The bin_env option replaces both of these keyword args in the pip execution module as well as the pip state.
