### PR TITLE
INFRA-1931 - support (present/absent) for hosted zones in states/boto_route53

### DIFF
--- a/salt/modules/boto_route53.py
+++ b/salt/modules/boto_route53.py
@@ -123,6 +123,25 @@ def describe_hosted_zones(zone_id=None, domain_name=None, region=None,
     domain_name
         The FQDN of the Hosted Zone (including final period)
 
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_route53.describe_hosted_zones domain_name=foo.bar.com. \
+                profile='{"region": "us-east-1", "keyd": "A12345678AB", "key": "xblahblahblah"}'
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     if zone_id and domain_name:
@@ -162,6 +181,25 @@ def describe_hosted_zones(zone_id=None, domain_name=None, region=None,
 def list_all_zones_by_name(region=None, key=None, keyid=None, profile=None):
     '''
     List, by their FQDNs, all hosted zones in the bound account.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_route53.list_all_zones_by_name
     '''
     ret = describe_hosted_zones(region=region, key=key, keyid=keyid,
                                 profile=profile)
@@ -171,6 +209,25 @@ def list_all_zones_by_name(region=None, key=None, keyid=None, profile=None):
 def list_all_zones_by_id(region=None, key=None, keyid=None, profile=None):
     '''
     List, by their IDs, all hosted zones in the bound account.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_route53.list_all_zones_by_id
     '''
     ret = describe_hosted_zones(region=region, key=key, keyid=keyid,
                                 profile=profile)

--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -73,12 +73,9 @@ Connection module for Amazon VPC
 
 .. versionadded:: Carbon
 
-Functions to request, accept, delete and describe
-VPC peering connections.
-Named VPC peering connections can be requested using these
-modules.
-VPC owner accounts can accept VPC peering connections (named
-or otherwise).
+Functions to request, accept, delete and describe VPC peering connections.
+Named VPC peering connections can be requested using these modules.
+VPC owner accounts can accept VPC peering connections (named or otherwise).
 
 Examples showing creation of VPC peering connection
 
@@ -731,7 +728,9 @@ def describe(vpc_id=None, vpc_name=None, region=None, key=None,
 
             keys = ('id', 'cidr_block', 'is_default', 'state', 'tags',
                     'dhcp_options_id', 'instance_tenancy')
-            return {'vpc': dict([(k, getattr(vpc, k)) for k in keys])}
+            _r = dict([(k, getattr(vpc, k)) for k in keys])
+            _r.update({'region': getattr(vpc, 'region').name})
+            return {'vpc': _r}
         else:
             return {'vpc': None}
 
@@ -786,10 +785,12 @@ def describe_vpcs(vpc_id=None, name=None, cidr=None, tags=None,
         if vpcs:
             ret = []
             for vpc in vpcs:
-                ret.append(dict((k, getattr(vpc, k)) for k in keys))
+                _r = dict([(k, getattr(vpc, k)) for k in keys])
+                _r.update({'region': getattr(vpc, 'region').name})
+                ret.append(_r)
             return {'vpcs': ret}
         else:
-            return {'vpcs': None}
+            return {'vpcs': []}
 
     except BotoServerError as e:
         return {'error': salt.utils.boto.get_error(e)}

--- a/salt/states/boto_route53.py
+++ b/salt/states/boto_route53.py
@@ -73,9 +73,10 @@ passed in as a dict, or as a string to pull from pillars or minion config:
 
 # Import Python Libs
 from __future__ import absolute_import
+import json
 
 # Import Salt Libs
-from salt.utils import SaltInvocationError
+from salt.utils import SaltInvocationError, exactly_one
 import logging
 log = logging.getLogger(__name__)
 
@@ -85,6 +86,10 @@ def __virtual__():
     Only load if boto is available.
     '''
     return 'boto_route53' if 'boto_route53.get_record' in __salt__ else False
+
+
+def rr_present(*args, **kwargs):
+    return present(*args, **kwargs)
 
 
 def present(
@@ -267,6 +272,10 @@ def present(
     return ret
 
 
+def rr_absent(*args, **kwargs):
+    return absent(*args, **kwargs)
+
+
 def absent(
         name,
         zone,
@@ -347,4 +356,186 @@ def absent(
             ret['comment'] = msg
     else:
         ret['comment'] = '{0} does not exist.'.format(name)
+    return ret
+
+
+def hosted_zone_present(name, domain_name=None, private_zone=False, comment='',
+                        vpc_id=None, vpc_name=None, vpc_region=None,
+                        region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure a hosted zone exists with the given attributes.  Note that most
+    things cannot be modified once a zone is created - it must be deleted and
+    re-spun to update these attributes:
+        - private_zone (AWS API limitation).
+        - comment (the appropriate call exists in the AWS API and in boto3, but
+                   has not, as of this writing, been added to boto2).
+        - vpc_id (same story - we really need to rewrite this module with boto3)
+        - vpc_name (really just a pointer to vpc_id anyway).
+        - vpc_region (again, supported in boto3 but not boto2).
+
+    name
+        The name of the state definition.  This will be used as the 'caller_ref'
+        param if/when creating the hosted zone.
+
+    domain_name
+        The name of the domain. This should be a fully-specified domain, and
+        should terminate with a period. This is the name you have registered
+        with your DNS registrar. It is also the name you will delegate from your
+        registrar to the Amazon Route 53 delegation servers returned in response
+        to this request.  Defaults to the value of name if not provided.
+
+    comment
+        Any comments you want to include about the hosted zone.
+
+    private_zone
+        Set True if creating a private hosted zone.
+
+    vpc_id
+        When creating a private hosted zone, either the VPC ID or VPC Name to
+        associate with is required.  Exclusive with vpe_name.  Ignored if passed
+        for a non-private zone.
+
+    vpc_name
+        When creating a private hosted zone, either the VPC ID or VPC Name to
+        associate with is required.  Exclusive with vpe_id.  Ignored if passed
+        for a non-private zone.
+
+    vpc_region
+        When creating a private hosted zone, the region of the associated VPC is
+        required.  If not provided, an effort will be made to determine it from
+        vpc_id or vpc_name, if possible.  If this fails, you'll need to provide
+        an explicit value for this option.  Ignored if passed for a non-private
+        zone.
+    '''
+    domain_name = domain_name if domain_name else name
+
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
+
+    # First translaste vpc_name into a vpc_id if possible
+    if private_zone:
+        if not exactly_one((vpc_name, vpc_id)):
+            raise SaltInvocationError('Either vpc_name or vpc_id is required '
+                                      'when creating a private zone.')
+        vpcs = __salt__['boto_vpc.describe_vpcs'](
+                vpc_id=vpc_id, name=vpc_name, region=region, key=key,
+                keyid=keyid, profile=profile).get('vpcs', [])
+        if vpc_region and vpcs:
+            vpcs = [v for v in vpcs if v['region'] == vpc_region]
+        if not vpcs:
+            msg = ('Private zone requested but a VPC matching given criteria '
+                    'not found.')
+            log.error(msg)
+            ret['result'] = False
+            ret['comment'] = msg
+            return ret
+        if len(vpcs) > 1:
+            msg = ('Private zone requested but multiple VPCs matching given '
+                   'criteria found: {0}.'.format([v['id'] for v in vpcs]))
+            log.error(msg)
+            return None
+        vpc = vpcs[0]
+        if vpc_name:
+            vpc_id = vpc['id']
+        if not vpc_region:
+            vpc_region = vpc['region']
+
+    # Next, see if it (or they) exist at all, anywhere?
+    deets = __salt__['boto_route53.describe_hosted_zones'](
+          domain_name=domain_name, region=region, key=key, keyid=keyid,
+          profile=profile)
+
+    create = False
+    if not deets:
+        create = True
+    else:  # Something exists - now does it match our criteria?
+        if (json.loads(deets['HostedZone']['Config']['PrivateZone']) !=
+                private_zone):
+            create = True
+        else:
+            if private_zone:
+                for v, d in deets.get('VPCs', {}).items():
+                    if (d['VPCId'] == vpc_id
+                            and d['VPCRegion'] == vpc_region):
+                        create = False
+                        break
+                    else:
+                        create = True
+        if not create:
+            ret['comment'] = 'Hostd Zone {0} already in desired state'.format(
+                    domain_name)
+        else:
+            # Until we get modifies in place with boto3, the best option is to
+            # attempt creation and let route53 tell us if we're stepping on
+            # toes.  We can't just fail, because some scenarios (think split
+            # horizon DNS) require zones with identical names but different
+            # settings...
+            log.info('A Hosted Zone with name {0} already exists, but with '
+                     'different settings.  Will attempt to create the one '
+                     'requested on the assumption this is what is desired.  '
+                     'This may fail...'.format(domain_name))
+
+    if create:
+        if __opts__['test']:
+            ret['comment'] = 'Route53 Hosted Zone {0} set to be added.'.format(
+                    domain_name)
+            ret['result'] = None
+            return ret
+        res = __salt__['boto_route53.create_hosted_zone'](domain_name=domain_name,
+                caller_ref=name, comment=comment, private_zone=private_zone,
+                vpc_id=vpc_id, vpc_region=vpc_region, region=region, key=key,
+                keyid=keyid, profile=profile)
+        if res:
+            msg = 'Hosted Zone {0} successfully created'.format(domain_name)
+            log.info(msg)
+            ret['comment'] = msg
+            ret['changes']['old'] = None
+            ret['changes']['new'] = res
+        else:
+            ret['comment'] = 'Creating Hosted Zone {0} failed'.format(
+                    domain_name)
+            ret['result'] = False
+
+    return ret
+
+
+def hosted_zone_absent(name, domain_name=None, region=None, key=None,
+                       keyid=None, profile=None):
+    '''
+    Ensure the Route53 Hostes Zone described is absent
+
+    name
+        The name of the state definition.
+
+    domain_name
+        The FQDN (including final period) of the zone you wish absent.  If not
+        provided, the value of name will be used.
+
+    '''
+    domain_name = domain_name if domain_name else name
+
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
+
+    deets = __salt__['boto_route53.describe_hosted_zones'](
+          domain_name=domain_name, region=region, key=key, keyid=keyid,
+          profile=profile)
+    if not deets:
+        ret['comment'] = 'Hosted Zone {0} already absent'.format(domain_name)
+        log.info(ret['comment'])
+        return ret
+    if __opts__['test']:
+        ret['comment'] = 'Route53 Hosted Zone {0} set to be deleted.'.format(
+                domain_name)
+        ret['result'] = None
+        return ret
+    # Not entirely comfortable with this - no safety checks around pub/priv, VPCs
+    # or anything else.  But this is all the module function exposes, so hmph.
+    # Inclined to put it on the "wait 'til we port to boto3" pile in any case :)
+    if __salt__['boto_route53.delete_zone'](
+            zone=domain_name, region=region, key=key, keyid=keyid,
+            profile=profile):
+        ret['comment'] = 'Route53 Hosted Zone {0} deleted'.format(domain_name)
+        log.info(ret['comment'])
+        ret['changes']['old'] = deets
+        ret['changes']['new'] = None
+
     return ret

--- a/tests/unit/modules/boto_vpc_test.py
+++ b/tests/unit/modules/boto_vpc_test.py
@@ -533,6 +533,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                               state=u'available',
                               tags={u'Name': u'test', u'test': u'testvalue'},
                               dhcp_options_id=u'dopt-7a8b9c2d',
+                              region=u'us-east-1',
                               instance_tenancy=u'default')
 
         self.assertEqual(describe_vpc, {'vpc': vpc_properties})


### PR DESCRIPTION
New:
states/boto_route53
- hosted_zone_present()
- hosted_zone_absent()
- rr_present()  - alias for present()
- rr_absent()  - alias for absent()

modules/boto_route53
- describe_hosted_zones()
- list_all_zones_by_name()
- list_all_zones_by_id()
- create_hosted_zone()

Changed:
modules/boto_vpc
- describe()  - add 'region' as another interesting field to return.  Needed for route53 bits to work.
- describe_vpcs()  - ditto
