### PR TITLE
Run self.close only if GC did not delete the class before the instance

### DIFF
--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -726,4 +726,5 @@ class IPCMessageSubscriber(IPCClient):
                 self._read_stream_future.exc_info()
 
     def __del__(self):
-        self.close()
+        if IPCMessageSubscriber in globals():
+            self.close()


### PR DESCRIPTION
### What does this PR do?

In PY2, when calling `salt` with `--output=json` the returned json is invalid because the ignored exception message is also included:

``` bash
bash-4.2# salt "id_ajHMb" test.ping --output="json"                                                                   
{
    "id_ajHMb": true
}
Exception AttributeError: "'NoneType' object has no attribute 'close'" in <bound method IPCMessageSubscriber.__del__ of <salt.transport.ipc.IPCMessageSubscriber object at 0x7fb142511290>> ignored

bash-4.2# salt "id_ajHMb" grains.get "os" --output="json"                                                             
{
    "id_ajHMb": "SUSE"
}
Exception AttributeError: "'NoneType' object has no attribute 'close'" in <bound method IPCMessageSubscriber.__del__ of <salt.transport.ipc.IPCMessageSubscriber object at 0x7fe3d9620290>> ignored
```

It seems that this issue was eliminated in PY3.4:
https://docs.python.org/3/whatsnew/3.4.html#whatsnew-pep-442
### What issues does this PR fix or reference?

python docs: https://docs.python.org/2/reference/datamodel.html#object.__del__
explanation: http://stackoverflow.com/questions/18058730/python-attributeerror-on-del#18058854
example: http://grokbase.com/t/python/python-list/051zyj1rne/a-python-bug-in-processing-del-method#20050131apuulmh57og6i76bhkw53kgb54
### New Behavior

It would call self.close() only if the class of self was not garbage-collected before the object itself.
If it was deleted, the GC sets the class of self to `NoneType` and when self.close is called we get that Exception which somehow is included in the command output.
### Tests written?

No
### Question

Is `__del__` reliable for freeing the resources given it's possible that the class can be garbage-collected before the instance itself?