### PR TITLE
use __utils__ in salt.cloud

### DIFF
--- a/salt/cloud/clouds/aliyun.py
+++ b/salt/cloud/clouds/aliyun.py
@@ -339,7 +339,7 @@ def list_nodes_full(call=None):
         provider = comps[0]
 
     __opts__['update_cachedir'] = True
-    salt.utils.cloud.cache_node_list(ret, provider, __opts__)
+    __utils__['cloud.cache_node_list'](ret, provider, __opts__)
 
     return ret
 
@@ -594,7 +594,7 @@ def create(vm_):
     if 'provider' in vm_:
         vm_['driver'] = vm_.pop('provider')
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'starting create',
         'salt/cloud/{0}/creating'.format(vm_['name']),
@@ -615,7 +615,7 @@ def create(vm_):
         'securitygroup_id': get_securitygroup(vm_),
     }
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
@@ -669,7 +669,7 @@ def create(vm_):
     vm_['ssh_host'] = public_ip
 
     # The instance is booted and accessible, let's Salt it!
-    ret = salt.utils.cloud.bootstrap(vm_, __opts__)
+    ret = __utils__['cloud.bootstrap'](vm_, __opts__)
     ret.update(data.__dict__)
 
     log.info('Created Cloud VM {0[name]!r}'.format(vm_))
@@ -679,7 +679,7 @@ def create(vm_):
         )
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(vm_['name']),
@@ -963,7 +963,7 @@ def destroy(name, call=None):
             '-a or --action.'
         )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
@@ -978,7 +978,7 @@ def destroy(name, call=None):
 
     node = query(params)
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),

--- a/salt/cloud/clouds/cloudstack.py
+++ b/salt/cloud/clouds/cloudstack.py
@@ -254,7 +254,7 @@ def create(vm_):
     if 'provider' in vm_:
         vm_['driver'] = vm_.pop('provider')
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'starting create',
         'salt/cloud/{0}/creating'.format(vm_['name']),
@@ -289,7 +289,7 @@ def create(vm_):
     if get_project(conn, vm_) is not False:
         kwargs['project'] = get_project(conn, vm_)
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
@@ -311,7 +311,7 @@ def create(vm_):
         for ex_blockdevicemapping in ex_blockdevicemappings:
             if 'VirtualName' not in ex_blockdevicemapping:
                 ex_blockdevicemapping['VirtualName'] = '{0}-{1}'.format(vm_['name'], len(volumes))
-            salt.utils.cloud.fire_event(
+            __utils__['cloud.fire_event'](
               'event',
               'requesting volume',
               'salt/cloud/{0}/requesting'.format(ex_blockdevicemapping['VirtualName']),
@@ -373,7 +373,7 @@ def create(vm_):
     vm_['ssh_host'] = get_ip(data)
     vm_['password'] = data.extra['password']
     vm_['key_filename'] = get_key()
-    ret = salt.utils.cloud.bootstrap(vm_, __opts__)
+    ret = __utils__['cloud.bootstrap'](vm_, __opts__)
 
     ret.update(data.__dict__)
 
@@ -387,7 +387,7 @@ def create(vm_):
         )
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(vm_['name']),
@@ -412,7 +412,7 @@ def destroy(name, conn=None, call=None):
             '-a or --action.'
         )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
@@ -436,7 +436,7 @@ def destroy(name, conn=None, call=None):
             )
             continue
         log.info('Detaching volume: {0}'.format(volume.name))
-        salt.utils.cloud.fire_event(
+        __utils__['cloud.fire_event'](
             'event',
             'detaching volume',
             'salt/cloud/{0}/detaching'.format(volume.name),
@@ -446,7 +446,7 @@ def destroy(name, conn=None, call=None):
             log.error('Failed to Detach volume: {0}'.format(volume.name))
             return False
         log.info('Detached volume: {0}'.format(volume.name))
-        salt.utils.cloud.fire_event(
+        __utils__['cloud.fire_event'](
             'event',
             'detached volume',
             'salt/cloud/{0}/detached'.format(volume.name),
@@ -454,7 +454,7 @@ def destroy(name, conn=None, call=None):
         )
 
         log.info('Destroying volume: {0}'.format(volume.name))
-        salt.utils.cloud.fire_event(
+        __utils__['cloud.fire_event'](
             'event',
             'destroying volume',
             'salt/cloud/{0}/destroying'.format(volume.name),
@@ -464,7 +464,7 @@ def destroy(name, conn=None, call=None):
             log.error('Failed to Destroy volume: {0}'.format(volume.name))
             return False
         log.info('Destroyed volume: {0}'.format(volume.name))
-        salt.utils.cloud.fire_event(
+        __utils__['cloud.fire_event'](
             'event',
             'destroyed volume',
             'salt/cloud/{0}/destroyed'.format(volume.name),
@@ -478,7 +478,7 @@ def destroy(name, conn=None, call=None):
     log.info('Destroyed VM: {0}'.format(name))
     # Fire destroy action
     event = salt.utils.event.SaltEvent('master', __opts__['sock_dir'])
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),

--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -284,7 +284,7 @@ def create(vm_):
     if 'provider' in vm_:
         vm_['driver'] = vm_.pop('provider')
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'starting create',
         'salt/cloud/{0}/creating'.format(vm_['name']),
@@ -366,7 +366,7 @@ def create(vm_):
             raise SaltCloudConfigError("'ipv6' should be a boolean value.")
         kwargs['ipv6'] = ipv6
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
@@ -423,7 +423,7 @@ def create(vm_):
             ip_address = network['ip_address']
     vm_['key_filename'] = key_filename
     vm_['ssh_host'] = ip_address
-    ret = salt.utils.cloud.bootstrap(vm_, __opts__)
+    ret = __utils__['cloud.bootstrap'](vm_, __opts__)
     ret.update(data)
 
     log.info('Created Cloud VM {0[name]!r}'.format(vm_))
@@ -433,7 +433,7 @@ def create(vm_):
         )
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(vm_['name']),
@@ -530,7 +530,7 @@ def show_instance(name, call=None):
             'The show_instance action must be called with -a or --action.'
         )
     node = _get_node(name)
-    salt.utils.cloud.cache_node(node, __active_provider_name__, __opts__)
+    __utils__['cloud.cache_node'](node, __active_provider_name__, __opts__)
     return node
 
 
@@ -686,7 +686,7 @@ def destroy(name, call=None):
             '-a or --action.'
         )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
@@ -709,7 +709,7 @@ def destroy(name, call=None):
     if delete_record:
         delete_dns_record(name)
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
@@ -718,7 +718,7 @@ def destroy(name, call=None):
     )
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
+        __utils__['cloud.delete_minion_cachedir'](name, __active_provider_name__.split(':')[0], __opts__)
 
     return node
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -94,7 +94,6 @@ import decimal
 
 # Import Salt Libs
 import salt.utils
-from salt import syspaths
 from salt._compat import ElementTree as ET
 import salt.utils.http as http
 import salt.utils.aws as aws
@@ -1846,7 +1845,7 @@ def request_instance(vm_=None, call=None):
             '\'del_all_vols_on_destroy\' should be a boolean value.'
         )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
@@ -1925,7 +1924,7 @@ def request_instance(vm_=None, call=None):
                           'Nothing else we can do here.')
                 return False
 
-        salt.utils.cloud.fire_event(
+        __utils__['cloud.fire_event'](
             'event',
             'waiting for spot instance',
             'salt/cloud/{0}/waiting_for_spot'.format(vm_['name']),
@@ -1988,7 +1987,7 @@ def query_instance(vm_=None, call=None):
 
     instance_id = vm_['instance_id']
     location = vm_.get('location', get_location(vm_))
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'querying instance',
         'salt/cloud/{0}/querying'.format(vm_['name']),
@@ -2094,7 +2093,7 @@ def query_instance(vm_=None, call=None):
             raise SaltCloudSystemExit(str(exc))
 
     if 'reactor' in vm_ and vm_['reactor'] is True:
-        salt.utils.cloud.fire_event(
+        __utils__['cloud.fire_event'](
             'event',
             'instance queried',
             'salt/cloud/{0}/query_reactor'.format(vm_['name']),
@@ -2132,7 +2131,7 @@ def wait_for_instance(
         'gateway', get_ssh_gateway_config(vm_)
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'waiting for ssh',
         'salt/cloud/{0}/waiting_for_ssh'.format(vm_['name']),
@@ -2311,7 +2310,7 @@ def wait_for_instance(
         )
 
     if 'reactor' in vm_ and vm_['reactor'] is True:
-        salt.utils.cloud.fire_event(
+        __utils__['cloud.fire_event'](
             'event',
             'ssh is available',
             'salt/cloud/{0}/ssh_ready_reactor'.format(vm_['name']),
@@ -2383,7 +2382,7 @@ def create(vm_=None, call=None):
                 )
             )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'starting create',
         'salt/cloud/{0}/creating'.format(vm_['name']),
@@ -2394,7 +2393,7 @@ def create(vm_=None, call=None):
         },
         transport=__opts__['transport']
     )
-    salt.utils.cloud.cachedir_index_add(
+    __utils__['cloud.cachedir_index_add'](
         vm_['name'], vm_['profile'], 'ec2', vm_['driver']
     )
 
@@ -2484,7 +2483,7 @@ def create(vm_=None, call=None):
 
     tags['Name'] = vm_['name']
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'setting tags',
         'salt/cloud/{0}/tagging'.format(vm_['name']),
@@ -2553,7 +2552,7 @@ def create(vm_=None, call=None):
         'volumes', vm_, __opts__, search_global=True
     )
     if volumes:
-        salt.utils.cloud.fire_event(
+        __utils__['cloud.fire_event'](
             'event',
             'attaching volumes',
             'salt/cloud/{0}/attaching_volumes'.format(vm_['name']),
@@ -2574,7 +2573,7 @@ def create(vm_=None, call=None):
         )
         ret['Attached Volumes'] = created
 
-    for key, value in six.iteritems(salt.utils.cloud.bootstrap(vm_, __opts__)):
+    for key, value in six.iteritems(__utils__['cloud.bootstrap'](vm_, __opts__)):
         ret.setdefault(key, value)
 
     log.info('Created Cloud VM {0[name]!r}'.format(vm_))
@@ -2593,7 +2592,7 @@ def create(vm_=None, call=None):
     if volumes:
         event_data['volumes'] = volumes
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(vm_['name']),
@@ -2624,7 +2623,7 @@ def queue_instances(instances):
         node = _get_node(instance_id=instance_id)
         for name in node:
             if instance_id == node[name]['instanceId']:
-                salt.utils.cloud.cache_node(node[name],
+                __utils__['cloud.cache_node'](node[name],
                                             __active_provider_name__,
                                             __opts__)
 
@@ -3012,7 +3011,7 @@ def destroy(name, call=None):
         quiet=True
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
@@ -3074,7 +3073,7 @@ def destroy(name, call=None):
                            sigver='4')
         ret['spotInstance'] = result[0]
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
@@ -3082,10 +3081,10 @@ def destroy(name, call=None):
         transport=__opts__['transport']
     )
 
-    salt.utils.cloud.cachedir_index_del(name)
+    __utils__['cloud.cachedir_index_del'](name)
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
+        __utils__['cloud.delete_minion_cachedir'](name, __active_provider_name__.split(':')[0], __opts__)
 
     return ret
 
@@ -3173,7 +3172,7 @@ def show_instance(name=None, instance_id=None, call=None, kwargs=None):
 
     node = _get_node(name=name, instance_id=instance_id)
     for name in node:
-        salt.utils.cloud.cache_node(node[name],
+        __utils__['cloud.cache_node'](node[name],
                                     __active_provider_name__,
                                     __opts__)
     return node
@@ -3341,7 +3340,7 @@ def _list_nodes_full(location=None):
 
     ret = _extract_instance_info(instances)
 
-    salt.utils.cloud.cache_node_list(ret, provider, __opts__)
+    __utils__['cloud.cache_node_list'](ret, provider, __opts__)
     return ret
 
 
@@ -4493,7 +4492,7 @@ def _parse_pricing(url, name):
         regions[region['region']] = sizes
 
     outfile = os.path.join(
-        syspaths.CACHE_DIR, 'cloud', 'ec2-pricing-{0}.p'.format(name)
+        __opts__['cachedir'], 'cloud', 'ec2-pricing-{0}.p'.format(name)
     )
     with salt.utils.fopen(outfile, 'w') as fho:
         msgpack.dump(regions, fho)
@@ -4557,7 +4556,7 @@ def show_pricing(kwargs=None, call=None):
         name = 'linux'
 
     pricefile = os.path.join(
-        syspaths.CACHE_DIR, 'cloud', 'ec2-pricing-{0}.p'.format(name)
+        __opts__['cachedir'], 'cloud', 'ec2-pricing-{0}.p'.format(name)
     )
 
     if not os.path.isfile(pricefile):

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -77,7 +77,6 @@ import salt.ext.six as six
 import salt.utils.cloud
 import salt.config as config
 from salt.utils import http
-from salt import syspaths
 from salt.cloud.libcloudfuncs import *  # pylint: disable=redefined-builtin,wildcard-import,unused-wildcard-import
 from salt.exceptions import (
     SaltCloudSystemExit,
@@ -297,7 +296,7 @@ def show_instance(vm_name, call=None):
         )
     conn = get_conn()
     node = _expand_node(conn.ex_get_node(vm_name))
-    salt.utils.cloud.cache_node(node, __active_provider_name__, __opts__)
+    __utils__['cloud.cache_node'](node, __active_provider_name__, __opts__)
     return node
 
 
@@ -557,7 +556,7 @@ def create_network(kwargs=None, call=None):
     cidr = kwargs['cidr']
     conn = get_conn()
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'create network',
         'salt/cloud/net/creating',
@@ -570,7 +569,7 @@ def create_network(kwargs=None, call=None):
 
     network = conn.ex_create_network(name, cidr)
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created network',
         'salt/cloud/net/created',
@@ -607,7 +606,7 @@ def delete_network(kwargs=None, call=None):
     name = kwargs['name']
     conn = get_conn()
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'delete network',
         'salt/cloud/net/deleting',
@@ -630,7 +629,7 @@ def delete_network(kwargs=None, call=None):
         )
         return False
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'deleted network',
         'salt/cloud/net/deleted',
@@ -707,7 +706,7 @@ def create_fwrule(kwargs=None, call=None):
         dst_tags = dst_tags.split(',')
     conn = get_conn()
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'create firewall',
         'salt/cloud/firewall/creating',
@@ -727,7 +726,7 @@ def create_fwrule(kwargs=None, call=None):
         target_tags=dst_tags
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created firewall',
         'salt/cloud/firewall/created',
@@ -765,7 +764,7 @@ def delete_fwrule(kwargs=None, call=None):
     name = kwargs['name']
     conn = get_conn()
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'delete firewall',
         'salt/cloud/firewall/deleting',
@@ -788,7 +787,7 @@ def delete_fwrule(kwargs=None, call=None):
         )
         return False
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'deleted firewall',
         'salt/cloud/firewall/deleted',
@@ -856,7 +855,7 @@ def create_hc(kwargs=None, call=None):
 
     conn = get_conn()
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'create health_check',
         'salt/cloud/healthcheck/creating',
@@ -879,7 +878,7 @@ def create_hc(kwargs=None, call=None):
         healthy_threshold=healthy_threshold
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created health_check',
         'salt/cloud/healthcheck/created',
@@ -922,7 +921,7 @@ def delete_hc(kwargs=None, call=None):
     name = kwargs['name']
     conn = get_conn()
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'delete health_check',
         'salt/cloud/healthcheck/deleting',
@@ -945,7 +944,7 @@ def delete_hc(kwargs=None, call=None):
         )
         return False
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'deleted health_check',
         'salt/cloud/healthcheck/deleted',
@@ -1013,7 +1012,7 @@ def create_address(kwargs=None, call=None):
 
     conn = get_conn()
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'create address',
         'salt/cloud/address/creating',
@@ -1023,7 +1022,7 @@ def create_address(kwargs=None, call=None):
 
     addy = conn.ex_create_address(name, ex_region, ex_address)
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created address',
         'salt/cloud/address/created',
@@ -1068,7 +1067,7 @@ def delete_address(kwargs=None, call=None):
 
     conn = get_conn()
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'delete address',
         'salt/cloud/address/deleting',
@@ -1091,7 +1090,7 @@ def delete_address(kwargs=None, call=None):
         )
         return False
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'deleted address',
         'salt/cloud/address/deleted',
@@ -1193,7 +1192,7 @@ def create_lb(kwargs=None, call=None):
     if ex_healthchecks:
         ex_healthchecks = ex_healthchecks.split(',')
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'create load_balancer',
         'salt/cloud/loadbalancer/creating',
@@ -1207,7 +1206,7 @@ def create_lb(kwargs=None, call=None):
         ex_address=ex_address
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created load_balancer',
         'salt/cloud/loadbalancer/created',
@@ -1241,7 +1240,7 @@ def delete_lb(kwargs=None, call=None):
     name = kwargs['name']
     lb_conn = get_lb_conn(get_conn())
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'delete load_balancer',
         'salt/cloud/loadbalancer/deleting',
@@ -1264,7 +1263,7 @@ def delete_lb(kwargs=None, call=None):
         )
         return False
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'deleted load_balancer',
         'salt/cloud/loadbalancer/deleted',
@@ -1332,7 +1331,7 @@ def attach_lb(kwargs=None, call=None):
     lb_conn = get_lb_conn(conn)
     lb = lb_conn.get_balancer(kwargs['name'])
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'attach load_balancer',
         'salt/cloud/loadbalancer/attaching',
@@ -1342,7 +1341,7 @@ def attach_lb(kwargs=None, call=None):
 
     result = lb_conn.balancer_attach_compute_node(lb, node)
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'attached load_balancer',
         'salt/cloud/loadbalancer/attached',
@@ -1397,7 +1396,7 @@ def detach_lb(kwargs=None, call=None):
         )
         return False
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'detach load_balancer',
         'salt/cloud/loadbalancer/detaching',
@@ -1407,7 +1406,7 @@ def detach_lb(kwargs=None, call=None):
 
     result = lb_conn.balancer_detach_member(lb, remove_member)
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'detached load_balancer',
         'salt/cloud/loadbalancer/detached',
@@ -1441,7 +1440,7 @@ def delete_snapshot(kwargs=None, call=None):
     name = kwargs['name']
     conn = get_conn()
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'delete snapshot',
         'salt/cloud/snapshot/deleting',
@@ -1464,7 +1463,7 @@ def delete_snapshot(kwargs=None, call=None):
         )
         return False
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'deleted snapshot',
         'salt/cloud/snapshot/deleted',
@@ -1501,7 +1500,7 @@ def delete_disk(kwargs=None, call=None):
 
     disk = conn.ex_get_volume(kwargs.get('disk_name'))
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'delete disk',
         'salt/cloud/disk/deleting',
@@ -1524,7 +1523,7 @@ def delete_disk(kwargs=None, call=None):
         )
         return False
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'deleted disk',
         'salt/cloud/disk/deleted',
@@ -1588,7 +1587,7 @@ def create_disk(kwargs=None, call=None):
     location = conn.ex_get_zone(kwargs['location'])
     use_existing = True
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'create disk',
         'salt/cloud/disk/creating',
@@ -1605,7 +1604,7 @@ def create_disk(kwargs=None, call=None):
         size, name, location, snapshot, image, use_existing
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created disk',
         'salt/cloud/disk/created',
@@ -1663,7 +1662,7 @@ def create_snapshot(kwargs=None, call=None):
         )
         return False
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'create snapshot',
         'salt/cloud/snapshot/creating',
@@ -1676,7 +1675,7 @@ def create_snapshot(kwargs=None, call=None):
 
     snapshot = conn.create_volume_snapshot(disk, name)
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created snapshot',
         'salt/cloud/snapshot/created',
@@ -1767,7 +1766,7 @@ def detach_disk(name=None, kwargs=None, call=None):
     node = conn.ex_get_node(node_name)
     disk = conn.ex_get_volume(disk_name)
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'detach disk',
         'salt/cloud/disk/detaching',
@@ -1780,7 +1779,7 @@ def detach_disk(name=None, kwargs=None, call=None):
 
     result = conn.detach_volume(disk, node)
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'detached disk',
         'salt/cloud/disk/detached',
@@ -1838,7 +1837,7 @@ def attach_disk(name=None, kwargs=None, call=None):
     node = conn.ex_get_node(node_name)
     disk = conn.ex_get_volume(disk_name)
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'attach disk',
         'salt/cloud/disk/attaching',
@@ -1853,7 +1852,7 @@ def attach_disk(name=None, kwargs=None, call=None):
 
     result = conn.attach_volume(node, disk, ex_mode=mode, ex_boot=boot)
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'attached disk',
         'salt/cloud/disk/attached',
@@ -1921,7 +1920,7 @@ def destroy(vm_name, call=None):
             'Could not find instance {0}.'.format(vm_name)
         )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'delete instance',
         'salt/cloud/{0}/deleting'.format(vm_name),
@@ -1958,7 +1957,7 @@ def destroy(vm_name, call=None):
         raise SaltCloudSystemExit(
             'Could not destroy instance {0}.'.format(vm_name)
         )
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'delete instance',
         'salt/cloud/{0}/deleted'.format(vm_name),
@@ -1971,7 +1970,7 @@ def destroy(vm_name, call=None):
             'delete_boot_pd is enabled for the instance profile, '
             'attempting to delete disk'
             )
-        salt.utils.cloud.fire_event(
+        __utils__['cloud.fire_event'](
             'event',
             'delete disk',
             'salt/cloud/disk/deleting',
@@ -1992,7 +1991,7 @@ def destroy(vm_name, call=None):
                 ),
                 exc_info_on_loglevel=logging.DEBUG
             )
-        salt.utils.cloud.fire_event(
+        __utils__['cloud.fire_event'](
             'event',
             'deleted disk',
             'salt/cloud/disk/deleted',
@@ -2001,7 +2000,7 @@ def destroy(vm_name, call=None):
         )
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(vm_name, __active_provider_name__.split(':')[0], __opts__)
+        __utils__['cloud.delete_minion_cachedir'](vm_name, __active_provider_name__.split(':')[0], __opts__)
 
     return inst_deleted
 
@@ -2087,7 +2086,7 @@ def create(vm_=None, call=None):
     )
     log.debug('Create instance kwargs {0}'.format(str(kwargs)))
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'create instance',
         'salt/cloud/{0}/creating'.format(vm_['name']),
@@ -2121,7 +2120,7 @@ def create(vm_=None, call=None):
     ssh_user, ssh_key = __get_ssh_credentials(vm_)
     vm_['ssh_host'] = __get_host(node_data, vm_)
     vm_['key_filename'] = ssh_key
-    salt.utils.cloud.bootstrap(vm_, __opts__)
+    __utils__['cloud.bootstrap'](vm_, __opts__)
 
     log.info('Created Cloud VM {0[name]!r}'.format(vm_))
     log.trace(
@@ -2130,7 +2129,7 @@ def create(vm_=None, call=None):
         )
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(vm_['name']),
@@ -2161,7 +2160,7 @@ def update_pricing(kwargs=None, call=None):
     price_json = http.query(url, decode=True, decode_type='json')
 
     outfile = os.path.join(
-        syspaths.CACHE_DIR, 'cloud', 'gce-pricing.p'
+        __opts__['cachedir'], 'cloud', 'gce-pricing.p'
     )
     with salt.utils.fopen(outfile, 'w') as fho:
         msgpack.dump(price_json['dict'], fho)
@@ -2197,7 +2196,7 @@ def show_pricing(kwargs=None, call=None):
 
     size = 'CP-COMPUTEENGINE-VMIMAGE-{0}'.format(profile['size'].upper())
     pricefile = os.path.join(
-        syspaths.CACHE_DIR, 'cloud', 'gce-pricing.p'
+        __opts__['cachedir'], 'cloud', 'gce-pricing.p'
     )
     if not os.path.exists(pricefile):
         update_pricing()

--- a/salt/cloud/clouds/gogrid.py
+++ b/salt/cloud/clouds/gogrid.py
@@ -97,7 +97,7 @@ def create(vm_):
     if 'provider' in vm_:
         vm_['driver'] = vm_.pop('provider')
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'starting create',
         'salt/cloud/{0}/creating'.format(vm_['name']),
@@ -129,7 +129,7 @@ def create(vm_):
         'ip': host_ip,
     }
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
@@ -174,7 +174,7 @@ def create(vm_):
     )
 
     vm_['ssh_host'] = host_ip
-    ret = salt.utils.cloud.bootstrap(vm_, __opts__)
+    ret = __utils__['cloud.bootstrap'](vm_, __opts__)
     ret.update(data)
 
     log.info('Created Cloud VM {0[name]!r}'.format(vm_))
@@ -184,7 +184,7 @@ def create(vm_):
         )
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(vm_['name']),
@@ -407,7 +407,7 @@ def destroy(name, call=None):
             '-a or --action.'
         )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
@@ -417,7 +417,7 @@ def destroy(name, call=None):
 
     response = _query('grid', 'server/delete', args={'name': name})
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
@@ -426,7 +426,7 @@ def destroy(name, call=None):
     )
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
+        __utils__['cloud.delete_minion_cachedir'](name, __active_provider_name__.split(':')[0], __opts__)
 
     return response
 

--- a/salt/cloud/clouds/joyent.py
+++ b/salt/cloud/clouds/joyent.py
@@ -178,7 +178,7 @@ def query_instance(vm_=None, call=None):
             'The query_instance action must be called with -a or --action.'
         )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'querying instance',
         'salt/cloud/{0}/querying'.format(vm_['name']),
@@ -259,7 +259,7 @@ def create(vm_):
         'private_key', vm_, __opts__, search_global=False, default=None
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'starting create',
         'salt/cloud/{0}/creating'.format(vm_['name']),
@@ -288,7 +288,7 @@ def create(vm_):
 
     }
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
@@ -316,9 +316,9 @@ def create(vm_):
     vm_['key_filename'] = key_filename
     vm_['ssh_host'] = data[1]['primaryIp']
 
-    salt.utils.cloud.bootstrap(vm_, __opts__)
+    __utils__['cloud.bootstrap'](vm_, __opts__)
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(vm_['name']),
@@ -383,7 +383,7 @@ def destroy(name, call=None):
             '-a or --action.'
         )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
@@ -395,7 +395,7 @@ def destroy(name, call=None):
     ret = query(command='my/machines/{0}'.format(node['id']),
                  location=node['location'], method='DELETE')
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
@@ -404,7 +404,7 @@ def destroy(name, call=None):
     )
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
+        __utils__['cloud.delete_minion_cachedir'](name, __active_provider_name__.split(':')[0], __opts__)
 
     return ret[0] in VALID_RESPONSE_CODES
 

--- a/salt/cloud/clouds/libcloud_aws.py
+++ b/salt/cloud/clouds/libcloud_aws.py
@@ -556,9 +556,9 @@ def create(vm_):
 
         deployed = False
         if win_installer:
-            deployed = salt.utils.cloud.deploy_windows(**deploy_kwargs)
+            deployed = __utils__['cloud.deploy_windows'](**deploy_kwargs)
         else:
-            deployed = salt.utils.cloud.deploy_script(**deploy_kwargs)
+            deployed = __utils__['cloud.deploy_script'](**deploy_kwargs)
 
         if deployed:
             log.info('Salt installed on {name}'.format(**vm_))
@@ -827,6 +827,6 @@ def destroy(name):
         )
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
+        __utils__['cloud.delete_minion_cachedir'](name, __active_provider_name__.split(':')[0], __opts__)
 
     return ret

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -356,7 +356,7 @@ def create(vm_):
     if _validate_name(name) is False:
         return False
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'starting create',
         'salt/cloud/{0}/creating'.format(name),
@@ -447,7 +447,7 @@ def create(vm_):
             )
             return False
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(name),
@@ -509,7 +509,7 @@ def create(vm_):
     vm_['password'] = get_password(vm_)
 
     # Bootstrap!
-    ret = salt.utils.cloud.bootstrap(vm_, __opts__)
+    ret = __utils__['cloud.bootstrap'](vm_, __opts__)
 
     ret.update(data)
 
@@ -520,7 +520,7 @@ def create(vm_):
         )
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(name),
@@ -696,7 +696,7 @@ def destroy(name, call=None):
             '-a or --action.'
         )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
@@ -708,7 +708,7 @@ def destroy(name, call=None):
 
     response = _query('linode', 'delete', args={'LinodeID': linode_id, 'skipChecks': True})
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
@@ -717,7 +717,7 @@ def destroy(name, call=None):
     )
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
+        __utils__['cloud.delete_minion_cachedir'](name, __active_provider_name__.split(':')[0], __opts__)
 
     return response
 

--- a/salt/cloud/clouds/lxc.py
+++ b/salt/cloud/clouds/lxc.py
@@ -27,7 +27,6 @@ from salt.exceptions import SaltCloudSystemExit
 
 import salt.client
 import salt.runner
-import salt.syspaths
 
 
 # Import 3rd-party libs
@@ -69,7 +68,7 @@ def _minion_opts(cfg='minion'):
     if 'conf_file' in __opts__:
         default_dir = os.path.dirname(__opts__['conf_file'])
     else:
-        default_dir = salt.syspaths.CONFIG_DIR,
+        default_dir = __opts__['config_dir'],
     cfg = os.environ.get(
         'SALT_MINION_CONFIG', os.path.join(default_dir, cfg))
     opts = config.minion_config(cfg)
@@ -80,7 +79,7 @@ def _master_opts(cfg='master'):
     cfg = os.environ.get(
         'SALT_MASTER_CONFIG',
         __opts__.get('conf_file',
-                     os.path.join(salt.syspaths.CONFIG_DIR, cfg)))
+                     os.path.join(__opts__['config_dir'], cfg)))
     opts = config.master_config(cfg)
     return opts
 
@@ -332,7 +331,7 @@ def show_instance(name, call=None):
     if not call:
         call = 'action'
     nodes = list_nodes_full(call=call)
-    salt.utils.cloud.cache_node(nodes[name], __active_provider_name__, __opts__)
+    __utils__['cloud.cache_node'](nodes[name], __active_provider_name__, __opts__)
     return nodes[name]
 
 
@@ -393,7 +392,7 @@ def destroy(vm_, call=None):
     ret = {'comment': '{0} was not found'.format(vm_),
            'result': False}
     if _salt('lxc.info', vm_, path=path):
-        salt.utils.cloud.fire_event(
+        __utils__['cloud.fire_event'](
             'event',
             'destroying instance',
             'salt/cloud/{0}/destroying'.format(vm_),
@@ -404,7 +403,7 @@ def destroy(vm_, call=None):
         ret['result'] = cret['result']
         if ret['result']:
             ret['comment'] = '{0} was destroyed'.format(vm_)
-            salt.utils.cloud.fire_event(
+            __utils__['cloud.fire_event'](
                 'event',
                 'destroyed instance',
                 'salt/cloud/{0}/destroyed'.format(vm_),
@@ -412,7 +411,7 @@ def destroy(vm_, call=None):
                 transport=__opts__['transport']
             )
             if __opts__.get('update_cachedir', False) is True:
-                salt.utils.cloud.delete_minion_cachedir(vm_, __active_provider_name__.split(':')[0], __opts__)
+                __utils__['cloud.delete_minion_cachedir'](vm_, __active_provider_name__.split(':')[0], __opts__)
     return ret
 
 
@@ -438,7 +437,7 @@ def create(vm_, call=None):
     if 'provider' in vm_:
         vm_['driver'] = vm_.pop('provider')
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event', 'starting create',
         'salt/cloud/{0}/creating'.format(vm_['name']),
         {'name': vm_['name'], 'profile': profile,
@@ -473,7 +472,7 @@ def create(vm_, call=None):
         __opts__['internal_lxc_profile'] = __opts__['profile']
         del __opts__['profile']
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(vm_['name']),

--- a/salt/cloud/clouds/msazure.py
+++ b/salt/cloud/clouds/msazure.py
@@ -399,7 +399,7 @@ def show_instance(name, call=None):
     # Find under which cloud service the name is listed, if any
     if name not in nodes:
         return {}
-    salt.utils.cloud.cache_node(nodes[name], __active_provider_name__, __opts__)
+    __utils__['cloud.cache_node'](nodes[name], __active_provider_name__, __opts__)
     return nodes[name]
 
 
@@ -422,7 +422,7 @@ def create(vm_):
     if 'provider' in vm_:
         vm_['driver'] = vm_.pop('provider')
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'starting create',
         'salt/cloud/{0}/creating'.format(vm_['name']),
@@ -522,7 +522,7 @@ def create(vm_):
     del event_kwargs['vm_kwargs']['system_config']
     del event_kwargs['vm_kwargs']['os_virtual_hard_disk']
     del event_kwargs['vm_kwargs']['network_config']
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
@@ -631,14 +631,14 @@ def create(vm_):
     vm_['password'] = config.get_cloud_config_value(
         'ssh_password', vm_, __opts__
     )
-    ret = salt.utils.cloud.bootstrap(vm_, __opts__)
+    ret = __utils__['cloud.bootstrap'](vm_, __opts__)
 
     # Attaching volumes
     volumes = config.get_cloud_config_value(
         'volumes', vm_, __opts__, search_global=True
     )
     if volumes:
-        salt.utils.cloud.fire_event(
+        __utils__['cloud.fire_event'](
             'event',
             'attaching volumes',
             'salt/cloud/{0}/attaching_volumes'.format(vm_['name']),
@@ -671,7 +671,7 @@ def create(vm_):
 
     ret.update(data)
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(vm_['name']),
@@ -939,7 +939,7 @@ def destroy(name, conn=None, call=None, kwargs=None):
         delete_type: {'request_id': result.request_id},
     }
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
+        __utils__['cloud.delete_minion_cachedir'](name, __active_provider_name__.split(':')[0], __opts__)
 
     cleanup_disks = config.get_cloud_config_value(
         'cleanup_disks',

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -347,7 +347,7 @@ def show_instance(name, call=None):
 
     conn = get_conn()
     node = conn.show_instance(name).__dict__
-    salt.utils.cloud.cache_node(node, __active_provider_name__, __opts__)
+    __utils__['cloud.cache_node'](node, __active_provider_name__, __opts__)
     return node
 
 
@@ -474,7 +474,7 @@ def destroy(name, conn=None, call=None):
             '-a or --action.'
         )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
@@ -511,7 +511,7 @@ def destroy(name, conn=None, call=None):
     if ret:
         log.info('Destroyed VM: {0}'.format(name))
         # Fire destroy action
-        salt.utils.cloud.fire_event(
+        __utils__['cloud.fire_event'](
             'event',
             'destroyed instance',
             'salt/cloud/{0}/destroyed'.format(name),
@@ -521,7 +521,7 @@ def destroy(name, conn=None, call=None):
         if __opts__.get('delete_sshkeys', False) is True:
             salt.utils.cloud.remove_sshkey(getattr(node, __opts__.get('ssh_interface', 'public_ips'))[0])
         if __opts__.get('update_cachedir', False) is True:
-            salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
+            __utils__['cloud.delete_minion_cachedir'](name, __active_provider_name__.split(':')[0], __opts__)
         return True
 
     log.error('Failed to Destroy VM: {0}'.format(name))
@@ -624,7 +624,7 @@ def request_instance(vm_=None, call=None):
 
     kwargs.update(get_block_mapping_opts(vm_))
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
@@ -684,7 +684,7 @@ def create(vm_):
     if 'provider' in vm_:
         vm_['driver'] = vm_.pop('provider')
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'starting create',
         'salt/cloud/{0}/creating'.format(vm_['name']),
@@ -887,7 +887,7 @@ def create(vm_):
     vm_['ssh_host'] = ip_address
     vm_['salt_host'] = salt_ip_address
 
-    ret = salt.utils.cloud.bootstrap(vm_, __opts__)
+    ret = __utils__['cloud.bootstrap'](vm_, __opts__)
 
     ret.update(data.__dict__)
 
@@ -901,7 +901,7 @@ def create(vm_):
         )
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(vm_['name']),
@@ -1012,7 +1012,7 @@ def list_nodes_full(call=None, **kwargs):
         except IndexError as exc:
             ret = {}
 
-    salt.utils.cloud.cache_node_list(ret, __active_provider_name__.split(':')[0], __opts__)
+    __utils__['cloud.cache_node_list'](ret, __active_provider_name__.split(':')[0], __opts__)
     return ret
 
 

--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -316,7 +316,7 @@ def create(vm_):
     if 'provider' in vm_:
         vm_['driver'] = vm_.pop('provider')
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'starting create',
         'salt/cloud/{0}/creating'.format(vm_['name']),
@@ -339,7 +339,7 @@ def create(vm_):
     )
     kwargs['private_networking'] = 'true' if private_networking else 'false'
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
@@ -421,7 +421,7 @@ def create(vm_):
     vm_['key_filename'] = key_filename
     vm_['ssh_host'] = private_ip
 
-    ret = salt.utils.cloud.bootstrap(vm_, __opts__)
+    ret = __utils__['cloud.bootstrap'](vm_, __opts__)
 
     ret['id'] = data['id']
     ret['image'] = vm_['image']
@@ -438,7 +438,7 @@ def create(vm_):
         )
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(vm_['name']),
@@ -476,7 +476,7 @@ def show_instance(name, call=None):
             'The show_instance action must be called with -a or --action.'
         )
     node = _get_node(name)
-    salt.utils.cloud.cache_node(node, __active_provider_name__, __opts__)
+    __utils__['cloud.cache_node'](node, __active_provider_name__, __opts__)
     return node
 
 
@@ -514,7 +514,7 @@ def destroy(name, call=None):
             '-a or --action.'
         )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
@@ -526,7 +526,7 @@ def destroy(name, call=None):
     data = show_instance(name, call='action')
     node = server.one.vm.action(user+':'+password, 'delete', int(data['id']))[1]
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
@@ -534,6 +534,6 @@ def destroy(name, call=None):
     )
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
+        __utils__['cloud.delete_minion_cachedir'](name, __active_provider_name__.split(':')[0], __opts__)
 
     return node

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -512,7 +512,7 @@ def request_instance(vm_=None, call=None):
     if config_drive is not None:
         kwargs['ex_config_drive'] = config_drive
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
@@ -582,7 +582,7 @@ def create(vm_):
 
     vm_['key_filename'] = key_filename
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'starting create',
         'salt/cloud/{0}/creating'.format(vm_['name']),
@@ -771,7 +771,7 @@ def create(vm_):
 
     vm_['salt_host'] = salt_ip_address
     vm_['ssh_host'] = ip_address
-    ret = salt.utils.cloud.bootstrap(vm_, __opts__)
+    ret = __utils__['cloud.bootstrap'](vm_, __opts__)
     ret.update(data.__dict__)
 
     if hasattr(data, 'extra') and 'password' in data.extra:
@@ -784,7 +784,7 @@ def create(vm_):
         )
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(vm_['name']),

--- a/salt/cloud/clouds/parallels.py
+++ b/salt/cloud/clouds/parallels.py
@@ -253,7 +253,7 @@ def create_node(vm_):
 
     data = ET.tostring(content, encoding='UTF-8')
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
@@ -284,7 +284,7 @@ def create(vm_):
     if 'provider' in vm_:
         vm_['driver'] = vm_.pop('provider')
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'starting create',
         'salt/cloud/{0}/creating'.format(vm_['name']),
@@ -349,7 +349,7 @@ def create(vm_):
     public_ip = comps[0]
 
     vm_['ssh_host'] = public_ip
-    ret = salt.utils.cloud.bootstrap(vm_, __opts__)
+    ret = __utils__['cloud.bootstrap'](vm_, __opts__)
 
     log.info('Created Cloud VM {0[name]!r}'.format(vm_))
     log.debug(
@@ -358,7 +358,7 @@ def create(vm_):
         )
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(vm_['name']),
@@ -507,7 +507,7 @@ def show_instance(name, call=None):
             for child in children:
                 ret[item.tag][child.tag] = child.attrib
 
-    salt.utils.cloud.cache_node(ret, __active_provider_name__, __opts__)
+    __utils__['cloud.cache_node'](ret, __active_provider_name__, __opts__)
     return ret
 
 
@@ -542,7 +542,7 @@ def destroy(name, call=None):
             '-a or --action.'
         )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
@@ -565,7 +565,7 @@ def destroy(name, call=None):
     if 'error' in data:
         return data['error']
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
@@ -574,7 +574,7 @@ def destroy(name, call=None):
     )
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
+        __utils__['cloud.delete_minion_cachedir'](name, __active_provider_name__.split(':')[0], __opts__)
 
     return {'Destroyed': '{0} was destroyed.'.format(name)}
 

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -516,7 +516,7 @@ def create(vm_):
 
     ret = {}
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'starting create',
         'salt/cloud/{0}/creating'.format(vm_['name']),
@@ -589,7 +589,7 @@ def create(vm_):
 
     vm_['ssh_host'] = ip_address
     vm_['password'] = ssh_password
-    ret = salt.utils.cloud.bootstrap(vm_, __opts__)
+    ret = __utils__['cloud.bootstrap'](vm_, __opts__)
 
     # Report success!
     log.info('Created Cloud VM {0[name]!r}'.format(vm_))
@@ -599,7 +599,7 @@ def create(vm_):
         )
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(vm_['name']),
@@ -661,7 +661,7 @@ def create_node(vm_):
                 newnode[prop] = vm_[prop]
 
     # The node is ready. Lets request it to be added
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
@@ -684,7 +684,7 @@ def show_instance(name, call=None):
         )
 
     nodes = list_nodes_full()
-    salt.utils.cloud.cache_node(nodes[name], __active_provider_name__, __opts__)
+    __utils__['cloud.cache_node'](nodes[name], __active_provider_name__, __opts__)
     return nodes[name]
 
 
@@ -769,7 +769,7 @@ def destroy(name, call=None):
             '-a or --action.'
         )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
@@ -790,7 +790,7 @@ def destroy(name, call=None):
         query('delete', 'nodes/{0}/{1}'.format(
             vmobj['node'], vmobj['id']
         ))
-        salt.utils.cloud.fire_event(
+        __utils__['cloud.fire_event'](
             'event',
             'destroyed instance',
             'salt/cloud/{0}/destroyed'.format(name),
@@ -798,7 +798,7 @@ def destroy(name, call=None):
             transport=__opts__['transport']
         )
         if __opts__.get('update_cachedir', False) is True:
-            salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
+            __utils__['cloud.delete_minion_cachedir'](name, __active_provider_name__.split(':')[0], __opts__)
 
         return {'Destroyed': '{0} was destroyed.'.format(name)}
 

--- a/salt/cloud/clouds/qingcloud.py
+++ b/salt/cloud/clouds/qingcloud.py
@@ -517,7 +517,7 @@ def list_nodes_full(call=None):
         provider = comps[0]
 
     __opts__['update_cachedir'] = True
-    salt.utils.cloud.cache_node_list(result, provider, __opts__)
+    __utils__['cloud.cache_node_list'](result, provider, __opts__)
 
     return result
 
@@ -671,7 +671,7 @@ def create(vm_):
     if 'provider' in vm_:
         vm_['driver'] = vm_.pop('provider')
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'starting create',
         'salt/cloud/{0}/creating'.format(vm_['name']),
@@ -697,7 +697,7 @@ def create(vm_):
         'login_keypair': vm_['login_keypair'],
     }
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
@@ -735,7 +735,7 @@ def create(vm_):
     vm_['ssh_host'] = private_ip
 
     # The instance is booted and accessible, let's Salt it!
-    salt.utils.cloud.bootstrap(vm_, __opts__)
+    __utils__['cloud.bootstrap'](vm_, __opts__)
 
     log.info('Created Cloud VM {0[name]!r}'.format(vm_))
 
@@ -745,7 +745,7 @@ def create(vm_):
         )
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(vm_['name']),
@@ -879,7 +879,7 @@ def destroy(instance_id, call=None):
     instance_data = show_instance(instance_id, call='action')
     name = instance_data['instance_name']
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
@@ -894,7 +894,7 @@ def destroy(instance_id, call=None):
     }
     result = query(params)
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),

--- a/salt/cloud/clouds/rackspace.py
+++ b/salt/cloud/clouds/rackspace.py
@@ -202,7 +202,7 @@ def create(vm_):
         pass
 
     deploy = config.get_cloud_config_value('deploy', vm_, __opts__)
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'starting create',
         'salt/cloud/{0}/creating'.format(vm_['name']),
@@ -222,7 +222,7 @@ def create(vm_):
         'size': get_size(conn, vm_)
     }
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
@@ -429,7 +429,7 @@ def create(vm_):
             del event_kwargs['password']
         ret['deploy_kwargs'] = event_kwargs
 
-        salt.utils.cloud.fire_event(
+        __utils__['cloud.fire_event'](
             'event',
             'executing deploy script',
             'salt/cloud/{0}/deploying'.format(vm_['name']),
@@ -438,9 +438,9 @@ def create(vm_):
         )
 
         if win_installer:
-            deployed = salt.utils.cloud.deploy_windows(**deploy_kwargs)
+            deployed = __utils__['cloud.deploy_windows'](**deploy_kwargs)
         else:
-            deployed = salt.utils.cloud.deploy_script(**deploy_kwargs)
+            deployed = __utils__['cloud.deploy_script'](**deploy_kwargs)
 
         if deployed:
             log.info('Salt installed on {0}'.format(vm_['name']))
@@ -463,7 +463,7 @@ def create(vm_):
         )
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(vm_['name']),

--- a/salt/cloud/clouds/saltify.py
+++ b/salt/cloud/clouds/saltify.py
@@ -17,10 +17,6 @@ from __future__ import absolute_import
 import logging
 
 # Import salt libs
-import salt.utils
-
-# Import salt cloud libs
-import salt.utils.cloud
 import salt.config as config
 
 # Get logging started
@@ -64,7 +60,7 @@ def create(vm_):
     '''
     log.info('Provisioning existing machine {0}'.format(vm_['name']))
 
-    ret = salt.utils.cloud.bootstrap(vm_, __opts__)
+    ret = __utils__['cloud.bootstrap'](vm_, __opts__)
 
     return ret
 

--- a/salt/cloud/clouds/scaleway.py
+++ b/salt/cloud/clouds/scaleway.py
@@ -219,7 +219,7 @@ def create(server_):
     if 'provider' in server_:
         server_['driver'] = server_.pop('provider')
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'starting create',
         'salt/cloud/{0}/creating'.format(server_['name']),
@@ -248,7 +248,7 @@ def create(server_):
         'commercial_type': commercial_type,
     }
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(server_['name']),
@@ -301,7 +301,7 @@ def create(server_):
     server_['ssh_password'] = config.get_cloud_config_value(
         'ssh_password', server_, __opts__
     )
-    ret = salt.utils.cloud.bootstrap(server_, __opts__)
+    ret = __utils__['cloud.bootstrap'](server_, __opts__)
 
     ret.update(data)
 
@@ -312,7 +312,7 @@ def create(server_):
         )
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(server_['name']),
@@ -400,7 +400,7 @@ def show_instance(name, call=None):
             'The show_instance action must be called with -a or --action.'
         )
     node = _get_node(name)
-    salt.utils.cloud.cache_node(node, __active_provider_name__, __opts__)
+    __utils__['cloud.cache_node'](node, __active_provider_name__, __opts__)
     return node
 
 
@@ -433,7 +433,7 @@ def destroy(name, call=None):
             '-a or --action.'
         )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
@@ -447,7 +447,7 @@ def destroy(name, call=None):
         args={'action': 'terminate'}, http_method='post'
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
@@ -456,7 +456,7 @@ def destroy(name, call=None):
     )
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(
+        __utils__['cloud.delete_minion_cachedir'](
             name, __active_provider_name__.split(':')[0], __opts__
         )
 

--- a/salt/cloud/clouds/softlayer.py
+++ b/salt/cloud/clouds/softlayer.py
@@ -257,7 +257,7 @@ def create(vm_):
     if 'provider' in vm_:
         vm_['driver'] = vm_.pop('provider')
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'starting create',
         'salt/cloud/{0}/creating'.format(vm_['name']),
@@ -362,7 +362,7 @@ def create(vm_):
     if post_uri:
         kwargs['postInstallScriptUri'] = post_uri
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
@@ -470,11 +470,11 @@ def create(vm_):
 
     vm_['ssh_host'] = ip_address
     vm_['password'] = passwd
-    ret = salt.utils.cloud.bootstrap(vm_, __opts__)
+    ret = __utils__['cloud.bootstrap'](vm_, __opts__)
 
     ret.update(response)
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(vm_['name']),
@@ -503,7 +503,7 @@ def list_nodes_full(mask='mask[id]', call=None):
     response = conn.getVirtualGuests()
     for node_id in response:
         ret[node_id['hostname']] = node_id
-    salt.utils.cloud.cache_node_list(ret, __active_provider_name__.split(':')[0], __opts__)
+    __utils__['cloud.cache_node_list'](ret, __active_provider_name__.split(':')[0], __opts__)
     return ret
 
 
@@ -558,7 +558,7 @@ def show_instance(name, call=None):
         )
 
     nodes = list_nodes_full()
-    salt.utils.cloud.cache_node(nodes[name], __active_provider_name__, __opts__)
+    __utils__['cloud.cache_node'](nodes[name], __active_provider_name__, __opts__)
     return nodes[name]
 
 
@@ -578,7 +578,7 @@ def destroy(name, call=None):
             '-a or --action.'
         )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
@@ -590,7 +590,7 @@ def destroy(name, call=None):
     conn = get_conn()
     response = conn.deleteObject(id=node['id'])
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
@@ -598,7 +598,7 @@ def destroy(name, call=None):
         transport=__opts__['transport']
     )
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
+        __utils__['cloud.delete_minion_cachedir'](name, __active_provider_name__.split(':')[0], __opts__)
 
     return response
 

--- a/salt/cloud/clouds/softlayer_hw.py
+++ b/salt/cloud/clouds/softlayer_hw.py
@@ -228,7 +228,7 @@ def create(vm_):
     if 'provider' in vm_:
         vm_['driver'] = vm_.pop('provider')
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'starting create',
         'salt/cloud/{0}/creating'.format(vm_['name']),
@@ -314,7 +314,7 @@ def create(vm_):
     if location:
         kwargs['location'] = location
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
@@ -400,11 +400,11 @@ def create(vm_):
 
     vm_['ssh_host'] = ip_address
     vm_['password'] = passwd
-    ret = salt.utils.cloud.bootstrap(vm_, __opts__)
+    ret = __utils__['cloud.bootstrap'](vm_, __opts__)
 
     ret.update(response)
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(vm_['name']),
@@ -436,7 +436,7 @@ def list_nodes_full(mask='mask[id, hostname, primaryIpAddress, \
 
     for node in response:
         ret[node['hostname']] = node
-    salt.utils.cloud.cache_node_list(ret, __active_provider_name__.split(':')[0], __opts__)
+    __utils__['cloud.cache_node_list'](ret, __active_provider_name__.split(':')[0], __opts__)
     return ret
 
 
@@ -489,7 +489,7 @@ def show_instance(name, call=None):
         )
 
     nodes = list_nodes_full()
-    salt.utils.cloud.cache_node(nodes[name], __active_provider_name__, __opts__)
+    __utils__['cloud.cache_node'](nodes[name], __active_provider_name__, __opts__)
     return nodes[name]
 
 
@@ -509,7 +509,7 @@ def destroy(name, call=None):
             '-a or --action.'
         )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
@@ -529,7 +529,7 @@ def destroy(name, call=None):
         }
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
@@ -537,7 +537,7 @@ def destroy(name, call=None):
         transport=__opts__['transport']
     )
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
+        __utils__['cloud.delete_minion_cachedir'](name, __active_provider_name__.split(':')[0], __opts__)
 
     return response
 

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -1928,7 +1928,7 @@ def destroy(name, call=None):
             '-a or --action.'
         )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
@@ -1976,7 +1976,7 @@ def destroy(name, call=None):
                 )
                 return 'failed to destroy'
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
@@ -1984,7 +1984,7 @@ def destroy(name, call=None):
         transport=__opts__['transport']
     )
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
+        __utils__['cloud.delete_minion_cachedir'](name, __active_provider_name__.split(':')[0], __opts__)
 
     return True
 
@@ -2017,7 +2017,7 @@ def create(vm_):
     if 'provider' in vm_:
         vm_['driver'] = vm_.pop('provider')
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'starting create',
         'salt/cloud/{0}/creating'.format(vm_['name']),
@@ -2253,7 +2253,7 @@ def create(vm_):
 
         try:
             log.info("Creating {0} from {1}({2})".format(vm_['name'], clone_type, vm_['clonefrom']))
-            salt.utils.cloud.fire_event(
+            __utils__['cloud.fire_event'](
                 'event',
                 'requesting instance',
                 'salt/cloud/{0}/requesting'.format(vm_['name']),
@@ -2308,11 +2308,11 @@ def create(vm_):
                     vm_['key_filename'] = key_filename
                     vm_['ssh_host'] = ip
 
-                    salt.utils.cloud.bootstrap(vm_, __opts__)
+                    __utils__['cloud.bootstrap'](vm_, __opts__)
 
         data = show_instance(vm_name, call='action')
 
-        salt.utils.cloud.fire_event(
+        __utils__['cloud.fire_event'](
             'event',
             'created instance',
             'salt/cloud/{0}/created'.format(vm_['name']),

--- a/salt/cloud/clouds/vsphere.py
+++ b/salt/cloud/clouds/vsphere.py
@@ -256,7 +256,7 @@ def create(vm_):
     if 'provider' in vm_:
         vm_['driver'] = vm_.pop('provider')
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'starting create',
         'salt/cloud/{0}/creating'.format(vm_['name']),
@@ -271,7 +271,7 @@ def create(vm_):
     log.info('Creating Cloud VM {0}'.format(vm_['name']))
     conn = get_conn()
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
@@ -341,7 +341,7 @@ def create(vm_):
         )
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(vm_['name']),
@@ -385,7 +385,7 @@ def _deploy(vm_):
     '''
     run bootstrap script
     '''
-    # TODO: review salt.utils.cloud.bootstrap(vm_, __opts__)
+    # TODO: review __utils__['cloud.bootstrap'](vm_, __opts__)
     # TODO: review salt.utils.cloud.wait_for_ip
     ip_address = wait_for_ip(vm_)
 
@@ -474,7 +474,7 @@ def _deploy(vm_):
             'win_password', vm_, __opts__, default=''
         )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'executing deploy script',
         'salt/cloud/{0}/deploying'.format(vm_['name']),
@@ -484,9 +484,9 @@ def _deploy(vm_):
 
     deployed = False
     if win_installer:
-        deployed = salt.utils.cloud.deploy_windows(**deploy_kwargs)
+        deployed = __utils__['cloud.deploy_windows'](**deploy_kwargs)
     else:
-        deployed = salt.utils.cloud.deploy_script(**deploy_kwargs)
+        deployed = __utils__['cloud.deploy_script'](**deploy_kwargs)
 
     if deployed:
         log.info('Salt installed on {0}'.format(vm_['name']))
@@ -628,7 +628,7 @@ def show_instance(name, call=None):
     conn = get_conn()
     instance = conn.get_vm_by_name(name, )
     ret = _get_instance_properties(instance)
-    salt.utils.cloud.cache_node(ret, __active_provider_name__, __opts__)
+    __utils__['cloud.cache_node'](ret, __active_provider_name__, __opts__)
     return ret
 
 
@@ -642,7 +642,7 @@ def destroy(name, call=None):  # pylint: disable=W0613
 
         salt-cloud --destroy mymachine
     '''
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
@@ -659,7 +659,7 @@ def destroy(name, call=None):  # pylint: disable=W0613
     except Exception as exc:  # pylint: disable=W0703
         return exc
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
@@ -667,7 +667,7 @@ def destroy(name, call=None):  # pylint: disable=W0613
         transport=__opts__['transport']
     )
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
+        __utils__['cloud.delete_minion_cachedir'](name, __active_provider_name__.split(':')[0], __opts__)
 
     return True
 

--- a/salt/cloud/libcloudfuncs.py
+++ b/salt/cloud/libcloudfuncs.py
@@ -107,7 +107,7 @@ def get_node(conn, name):
     nodes = conn.list_nodes()
     for node in nodes:
         if node.name == name:
-            salt.utils.cloud.cache_node(salt.utils.cloud.simple_types_filter(node.__dict__), __active_provider_name__, __opts__)
+            __utils__['cloud.cache_node'](salt.utils.cloud.simple_types_filter(node.__dict__), __active_provider_name__, __opts__)
             return node
 
 
@@ -325,7 +325,7 @@ def destroy(name, conn=None, call=None):
             '-a or --action.'
         )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
@@ -365,7 +365,7 @@ def destroy(name, conn=None, call=None):
     if ret:
         log.info('Destroyed VM: {0}'.format(name))
         # Fire destroy action
-        salt.utils.cloud.fire_event(
+        __utils__['cloud.fire_event'](
             'event',
             'destroyed instance',
             'salt/cloud/{0}/destroyed'.format(name),
@@ -382,7 +382,7 @@ def destroy(name, conn=None, call=None):
                 salt.utils.cloud.remove_sshkey(private_ips[0])
 
         if __opts__.get('update_cachedir', False) is True:
-            salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
+            __utils__['cloud.delete_minion_cachedir'](name, __active_provider_name__.split(':')[0], __opts__)
 
         return True
 
@@ -405,7 +405,7 @@ def reboot(name, conn=None):
     if ret:
         log.info('Rebooted VM: {0}'.format(name))
         # Fire reboot action
-        salt.utils.cloud.fire_event(
+        __utils__['cloud.fire_event'](
             'event',
             '{0} has been rebooted'.format(name), 'salt-cloud'
             'salt/cloud/{0}/rebooting'.format(name),
@@ -466,7 +466,7 @@ def list_nodes_full(conn=None, call=None):
         ret[node.name] = pairs
         del ret[node.name]['driver']
 
-    salt.utils.cloud.cache_node_list(ret, __active_provider_name__.split(':')[0], __opts__)
+    __utils__['cloud.cache_node_list'](ret, __active_provider_name__.split(':')[0], __opts__)
     return ret
 
 
@@ -492,7 +492,7 @@ def show_instance(name, call=None):
         )
 
     nodes = list_nodes_full()
-    salt.utils.cloud.cache_node(nodes[name], __active_provider_name__, __opts__)
+    __utils__['cloud.cache_node'](nodes[name], __active_provider_name__, __opts__)
     return nodes[name]
 
 

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -770,7 +770,8 @@ def clouds(opts):
                                            int_type='clouds'),
                               opts,
                               tag='clouds',
-                              pack={'__active_provider_name__': None},
+                              pack={'__utils__': salt.loader.utils(opts),
+                                    '__active_provider_name__': None},
                               )
     for funcname in LIBCLOUD_FUNCS_NOT_SUPPORTED:
         log.trace(

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -56,7 +56,6 @@ import salt.client
 import salt.config
 import salt.utils
 import salt.utils.event
-from salt import syspaths
 from salt.utils import vt
 from salt.utils.nb_popen import NonBlockingPopen
 from salt.utils.yamldumper import SafeOrderedDumper
@@ -1687,7 +1686,7 @@ def run_inline_script(host,
 def fire_event(key, msg, tag, args=None, sock_dir=None, transport='zeromq'):
     # Fire deploy action
     if sock_dir is None:
-        sock_dir = os.path.join(syspaths.SOCK_DIR, 'master')
+        sock_dir = os.path.join(__opts__['sock_dir'], 'master')
     event = salt.utils.event.get_event(
         'master',
         sock_dir,
@@ -2477,7 +2476,7 @@ def init_cachedir(base=None):
     Initialize the cachedir needed for Salt Cloud to keep track of minions
     '''
     if base is None:
-        base = os.path.join(syspaths.CACHE_DIR, 'cloud')
+        base = os.path.join(__opts__['cachedir'], 'cloud')
     needed_dirs = (base,
                    os.path.join(base, 'requested'),
                    os.path.join(base, 'active'))
@@ -2507,7 +2506,7 @@ def request_minion_cachedir(
     will be set to None.
     '''
     if base is None:
-        base = os.path.join(syspaths.CACHE_DIR, 'cloud')
+        base = os.path.join(__opts__['cachedir'], 'cloud')
 
     if not fingerprint:
         if pubkey is not None:
@@ -2550,7 +2549,7 @@ def change_minion_cachedir(
         return False
 
     if base is None:
-        base = os.path.join(syspaths.CACHE_DIR, 'cloud')
+        base = os.path.join(__opts__['cachedir'], 'cloud')
 
     fname = '{0}.p'.format(minion_id)
     path = os.path.join(base, cachedir, fname)
@@ -2571,7 +2570,7 @@ def activate_minion_cachedir(minion_id, base=None):
     exists, and should be expected to exist from here on out.
     '''
     if base is None:
-        base = os.path.join(syspaths.CACHE_DIR, 'cloud')
+        base = os.path.join(__opts__['cachedir'], 'cloud')
 
     fname = '{0}.p'.format(minion_id)
     src = os.path.join(base, 'requested', fname)
@@ -2589,7 +2588,7 @@ def delete_minion_cachedir(minion_id, provider, opts, base=None):
         return
 
     if base is None:
-        base = os.path.join(syspaths.CACHE_DIR, 'cloud')
+        base = os.path.join(__opts__['cachedir'], 'cloud')
 
     driver = next(six.iterkeys(opts['providers'][provider]))
     fname = '{0}.p'.format(minion_id)
@@ -2609,7 +2608,7 @@ def list_cache_nodes_full(opts, provider=None, base=None):
         return
 
     if base is None:
-        base = os.path.join(syspaths.CACHE_DIR, 'cloud', 'active')
+        base = os.path.join(__opts__['cachedir'], 'cloud', 'active')
 
     minions = {}
     # First, get a list of all drivers in use
@@ -2640,7 +2639,7 @@ def cache_nodes_ip(opts, base=None):
     addresses. Returns a dict.
     '''
     if base is None:
-        base = os.path.join(syspaths.CACHE_DIR, 'cloud')
+        base = os.path.join(__opts__['cachedir'], 'cloud')
 
     minions = list_cache_nodes_full(opts, base=base)
 
@@ -2714,7 +2713,7 @@ def update_bootstrap(config, url=None):
     # Compute the search path using the install time defined
     # syspaths.CONF_DIR
     deploy_d_from_syspaths = os.path.join(
-        syspaths.CONFIG_DIR,
+        config['config_dir'],
         'cloud.deploy.d'
     )
 
@@ -2820,10 +2819,10 @@ def cache_node(node, provider, opts):
     if 'update_cachedir' not in opts or not opts['update_cachedir']:
         return
 
-    if not os.path.exists(os.path.join(syspaths.CACHE_DIR, 'cloud', 'active')):
+    if not os.path.exists(os.path.join(__opts__['cachedir'], 'cloud', 'active')):
         init_cachedir()
 
-    base = os.path.join(syspaths.CACHE_DIR, 'cloud', 'active')
+    base = os.path.join(__opts__['cachedir'], 'cloud', 'active')
     provider, driver = provider.split(':')
     prov_dir = os.path.join(base, driver, provider)
     if not os.path.exists(prov_dir):

--- a/tests/unit/cloud/clouds/saltify_test.py
+++ b/tests/unit/cloud/clouds/saltify_test.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 
 # Import Salt Testing Libs
 from salttesting import TestCase
+from salttesting.mock import MagicMock
 
 # Import Salt Libs
 from salt.cloud.clouds import saltify
@@ -15,6 +16,8 @@ from salt.cloud.clouds import saltify
 # Globals
 saltify.__opts__ = {}
 saltify.__opts__['providers'] = {}
+saltify.__utils__ = {}
+saltify.__utils__['cloud.bootstrap'] = MagicMock()
 
 
 class SaltifyTestCase(TestCase):


### PR DESCRIPTION
### What does this PR do?

Use `__utils__` in salt.cloud instead of importing salt.utils

Use this for `sock_dir` and `cachedir` instead of using `syspaths`
### What issues does this PR fix or reference?

Closes saltstack/salt#18419 and #34806

Should also revert https://github.com/saltstack/salt/pull/34870 when this is merged to develop, because it is not needed now that we will have **opts** available in the cloud utils.
### Tests written?

No