### PR TITLE
Back-port #35463 to 2016.3

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1045,7 +1045,7 @@ DEFAULT_MINION_OPTS = {
     'minion_id_caching': True,
     'keysize': 2048,
     'transport': 'zeromq',
-    'auth_timeout': 60,
+    'auth_timeout': 5,
     'auth_tries': 7,
     'master_tries': _MASTER_TRIES,
     'auth_safemode': False,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -768,7 +768,7 @@ class MultiMinion(MinionBase):
         while True:
             try:
                 minion = Minion(opts,
-                                self.MINION_CONNECT_TIMEOUT,
+                                opts['auth_timeout'],
                                 False,
                                 io_loop=self.io_loop,
                                 loaded_base_name='salt.loader.{0}'.format(opts['master']),

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -714,9 +714,6 @@ class MultiMinion(MinionBase):
     defined in the master option and binds each minion object to a respective
     master.
     '''
-    # timeout for one of the minions to auth with a master
-    MINION_CONNECT_TIMEOUT = 5
-
     def __init__(self, opts):
         super(MultiMinion, self).__init__(opts)
         self.auth_wait = self.opts['acceptance_wait_time']
@@ -750,7 +747,6 @@ class MultiMinion(MinionBase):
             s_opts = copy.deepcopy(self.opts)
             s_opts['master'] = master
             s_opts['multimaster'] = True
-            s_opts['auth_timeout'] = self.MINION_CONNECT_TIMEOUT
             if self.opts.get('ipc_mode') == 'tcp':
                 # If one is a list, we can assume both are, because of check above
                 if isinstance(self.opts['tcp_pub_port'], list):


### PR DESCRIPTION
Back-port saltstack/salt#35463 to 2016.3

@cachedout Please review this back-port from @skizunov's PR to develop. There was a merge-conflict in the back-port, but I think this is the correct resolution because the `auth_timeout` option should come from through in the `s_opts = copy.deepcopy(self.opts)`, right?