### PR TITLE
Update the blockdev state to reference the disk execution module.

### DIFF
--- a/salt/modules/blockdev.py
+++ b/salt/modules/blockdev.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+'''
+Module for managing block devices
+
+.. versionadded:: 2014.7.0
+.. deprecated:: Carbon
+   Merged to `disk` module
+
+'''
+from __future__ import absolute_import
+
+# Import python libs
+import logging
+
+# Import salt libs
+import salt.utils
+
+log = logging.getLogger(__name__)
+
+__func_alias__ = {
+    'format_': 'format'
+}
+
+__virtualname__ = 'blockdev'
+
+
+def __virtual__():
+    '''
+    Only load this module if the blockdev utility is available
+    '''
+    if salt.utils.is_windows():
+        return (False, ('The {0} execution module '
+                        'is not supported on windows'.format(__virtualname__)))
+    elif not salt.utils.which('blockdev'):
+        return (False, ('Cannot load the {0} execution module: '
+                        'blockdev utility not found'.format(__virtualname__)))
+    return __virtualname__
+
+
+def format_(device, fs_type='ext4',
+            inode_size=None, lazy_itable_init=None, force=False):
+    '''
+    Format a filesystem onto a block device
+
+    .. versionadded:: 2015.8.2
+
+    .. deprecated:: Carbon
+
+    device
+        The block device in which to create the new filesystem
+
+    fs_type
+        The type of filesystem to create
+
+    inode_size
+        Size of the inodes
+
+        This option is only enabled for ext and xfs filesystems
+
+    lazy_itable_init
+        If enabled and the uninit_bg feature is enabled, the inode table will
+        not be fully initialized by mke2fs.  This speeds up filesystem
+        initialization noticeably, but it requires the kernel to finish
+        initializing the filesystem  in  the  background  when  the filesystem
+        is first mounted.  If the option value is omitted, it defaults to 1 to
+        enable lazy inode table zeroing.
+
+        This option is only enabled for ext filesystems
+
+    force
+        Force mke2fs to create a filesystem, even if the specified device is
+        not a partition on a block special device. This option is only enabled
+        for ext and xfs filesystems
+
+        This option is dangerous, use it with caution.
+
+        .. versionadded:: Carbon
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' blockdev.format /dev/sdX1
+    '''
+    salt.utils.warn_until(
+        'Oxygen',
+        'The blockdev module has been merged with the disk module,'
+        'and will disappear in Oxygen. Use the disk.format_ function instead.'
+    )
+    return __salt__['disk.format_'](device,
+                                    fs_type=fs_type,
+                                    inode_size=inode_size,
+                                    lazy_itable_init=lazy_itable_init,
+                                    force=force)
+
+
+def fstype(device):
+    '''
+    Return the filesystem name of a block device
+
+    .. versionadded:: 2015.8.2
+
+    .. deprecated:: Carbon
+
+    device
+        The name of the block device
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' blockdev.fstype /dev/sdX1
+    '''
+    salt.utils.warn_until(
+        'Oxygen',
+        'The blockdev module has been merged with the disk module,'
+        'and will disappear in Oxygen. Use the disk.fstype function instead.'
+    )
+    return __salt__['disk.fstype'](device)
+

--- a/salt/modules/blockdev.py
+++ b/salt/modules/blockdev.py
@@ -117,4 +117,3 @@ def fstype(device):
         'and will disappear in Oxygen. Use the disk.fstype function instead.'
     )
     return __salt__['disk.fstype'](device)
-

--- a/salt/states/blockdev.py
+++ b/salt/states/blockdev.py
@@ -40,12 +40,12 @@ log = logging.getLogger(__name__)
 
 def __virtual__():
     '''
-    Only load this module if the blockdev execution module is available
+    Only load this module if the disk execution module is available
     '''
-    if 'blockdev.tune' in __salt__:
+    if 'disk.tune' in __salt__:
         return __virtualname__
     return (False, ('Cannot load the {0} state module: '
-                    'blockdev execution module not found'.format(__virtualname__)))
+                    'disk execution module not found'.format(__virtualname__)))
 
 
 def tuned(name, **kwargs):
@@ -87,8 +87,8 @@ def tuned(name, **kwargs):
         ret['result'] = None
         return ret
     else:
-        current = __salt__['blockdev.dump'](name)
-        changes = __salt__['blockdev.tune'](name, **kwargs)
+        current = __salt__['disk.dump'](name)
+        changes = __salt__['disk.tune'](name, **kwargs)
         changeset = {}
         for key in kwargs:
             if key in kwarg_map:
@@ -159,8 +159,8 @@ def formatted(name, fs_type='ext4', force=False, **kwargs):
         ret['result'] = None
         return ret
 
-    __salt__['blockdev.format'](name, fs_type, force=force, **kwargs)
-    current_fs = __salt__['blockdev.fstype'](name)
+    __salt__['disk.format_'](name, fs_type, force=force, **kwargs)
+    current_fs = __salt__['disk.fstype'](name)
 
     # Repeat lsblk check up to 10 times with 3s sleeping between each
     # to avoid lsblk failing although mkfs has succeeded

--- a/tests/unit/states/blockdev_test.py
+++ b/tests/unit/states/blockdev_test.py
@@ -80,8 +80,8 @@ class BlockdevTestCase(TestCase):
             mock_t = MagicMock(return_value=True)
             mock_e = MagicMock(return_value='')
             with patch.dict(blockdev.__salt__, {'cmd.run': mock_ext4,
-                                                'blockdev.format': mock_t,
-                                                'blockdev.fstype': mock_e}):
+                                                'disk.format_': mock_t,
+                                                'disk.fstype': mock_e}):
                 comt = ('{0} already formatted with '.format(name))
                 ret.update({'comment': comt, 'result': True})
                 self.assertDictEqual(blockdev.formatted(name, fs_type=''), ret)


### PR DESCRIPTION
### What does this PR do?

Add blockdev.py module back in to develop. This was inadvertently removed in a merge-forward due to the confusing nature of the way the original deprecation was made. I've restored the correct blockdev.py module which should include two functions that are now properly marked for deprecation. My apologies for this mistake.

This change also updates the `blockdev.function` calls in the blockdev state to use the `disk` module. These updates were missed in the original deprecation path in #25267.
### What issues does this PR fix or reference?

Refs saltstack/salt#35361 and saltstack/salt#35424
### Tests written?

No - the tests for the blockdev module have been moved to the test files for the disk.py execution module since those functions now live there.