### PR TITLE
Use correct deprecated notation instead of a warning for apache_module.enable state function.

### DIFF
--- a/salt/states/apache_module.py
+++ b/salt/states/apache_module.py
@@ -16,6 +16,8 @@ Enable and disable apache modules.
       apache_module.disabled:
         - name: cgi
 '''
+
+# Import Python libs
 from __future__ import absolute_import
 from salt.ext.six import string_types
 
@@ -66,11 +68,10 @@ def enabled(name):
 
 def enable(name):
     '''
-    Ensure an Apache module is enabled.
+    Ensure an Apache module is enabled. This function is deprecated and will be
+    removed in Salt Nitrogen. Please use the ``enabled`` state function instead.
 
-    .. warning::
-
-        This function is deprecated and will be removed in Salt Nitrogen.
+    .. deprecated:: 2016.3.0
 
     name
         Name of the Apache module


### PR DESCRIPTION
### What does this PR do?

This should help make the documentation more clear to fix #35458.
### What issues does this PR fix or reference?

Fixes #35458
