### PR TITLE
New module: openstack_mng

### DIFF
--- a/salt/modules/openstack_mng.py
+++ b/salt/modules/openstack_mng.py
@@ -44,11 +44,9 @@ def start_service(service_name):
     .. code-block:: bash
         salt '*' openstack_mng.start_service neutron
     '''
-
-    if __salt__['cmd.retcode'](['/usr/bin/openstack-service', 'start', service_name]) == 0:
-        return True
-
-    return False
+    
+    os_cmd = ['/usr/bin/openstack-service', 'start', service_name]
+    return __salt__['cmd.retcode'](os_cmd) == 0
 
 
 def stop_service(service_name):
@@ -61,10 +59,8 @@ def stop_service(service_name):
         salt '*' openstack_mng.stop_service neutron
     '''
 
-    if __salt__['cmd.retcode'](['/usr/bin/openstack-service', 'stop', service_name]) == 0:
-        return True
-
-    return False
+    os_cmd = ['/usr/bin/openstack-service', 'stop', service_name]
+    return __salt__['cmd.retcode'](os_cmd) == 0
 
 
 def restart_service(service_name, minimum_running_time=None):
@@ -101,7 +97,5 @@ def restart_service(service_name, minimum_running_time=None):
         return ret_code
     else:
         # just restart
-        if __salt__['cmd.retcode'](['/usr/bin/openstack-service', 'restart', service_name]) == 0:
-            return True
-
-    return False
+        os_cmd = ['/usr/bin/openstack-service', 'restart', service_name]
+        return __salt__['cmd.retcode'](os_cmd) == 0

--- a/salt/modules/openstack_mng.py
+++ b/salt/modules/openstack_mng.py
@@ -91,7 +91,7 @@ def restart_service(service_name, minimum_running_time=None):
             boot_time = float(open('/proc/uptime').read().split(' ')[0])
 
             expr_time = int(service_info.get('ExecMainStartTimestampMonotonic', 0)) / 1000000 < boot_time - minimum_running_time
-            expr_active = True if service_info.get('ActiveState') == "active" else False
+            expr_active = service_info.get('ActiveState') == "active"
 
             if expr_time or not expr_active:
                 # restart specific system service

--- a/salt/modules/openstack_mng.py
+++ b/salt/modules/openstack_mng.py
@@ -12,7 +12,6 @@ from __future__ import absolute_import
 
 # Import python libs
 import logging
-import time
 
 # Import salt libs
 

--- a/salt/modules/openstack_mng.py
+++ b/salt/modules/openstack_mng.py
@@ -45,8 +45,7 @@ def start_service(service_name):
         salt '*' openstack_mng.start_service neutron
     '''
 
-    ret = __salt__['cmd.run_all'](['/usr/bin/openstack-service', 'start', service_name])
-    if ret.get('retcode', 0) == 0:
+    if __salt__['cmd.retcode'](['/usr/bin/openstack-service', 'start', service_name]) == 0:
         return True
 
     return False
@@ -62,8 +61,7 @@ def stop_service(service_name):
         salt '*' openstack_mng.stop_service neutron
     '''
 
-    ret = __salt__['cmd.run_all'](['/usr/bin/openstack-service', 'stop', service_name])
-    if ret.get('retcode', 0) == 0:
+    if __salt__['cmd.retcode'](['/usr/bin/openstack-service', 'stop', service_name]) == 0:
         return True
 
     return False
@@ -103,8 +101,7 @@ def restart_service(service_name, minimum_running_time=None):
         return ret_code
     else:
         # just restart
-        ret = __salt__['cmd.run_all'](['/usr/bin/openstack-service', 'restart', service_name])
-        if ret.get('retcode', 0) == 0:
+        if __salt__['cmd.retcode'](['/usr/bin/openstack-service', 'restart', service_name]) == 0:
             return True
 
     return False

--- a/salt/modules/openstack_mng.py
+++ b/salt/modules/openstack_mng.py
@@ -17,10 +17,6 @@ import logging
 
 # Import third party libs
 import os.path
-if os.path.isfile('/usr/bin/openstack-service'):
-    HAS_OPENSTACK = True
-else:
-    HAS_OPENSTACK = False
 
 log = logging.getLogger(__name__)
 
@@ -32,7 +28,7 @@ def __virtual__():
     '''
     Only load this module if openstack-service is installed
     '''
-    if HAS_OPENSTACK:
+    if os.path.isfile('/usr/bin/openstack-service'):
         return __virtualname__
     else:
         return (False, 'The openstack-service binary could not be found.')

--- a/salt/modules/openstack_mng.py
+++ b/salt/modules/openstack_mng.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import
 import logging
 
 # Import salt libs
+import salt.utils
 
 # Import third party libs
 import os.path
@@ -88,7 +89,7 @@ def restart_service(service_name, minimum_running_time=None):
         for service in services:
             service_info = __salt__['service.show'](service)
 
-            boot_time = float(open('/proc/uptime').read().split(' ')[0])
+            boot_time = float(salt.utils.fopen('/proc/uptime').read().split(' ')[0])
 
             expr_time = int(service_info.get('ExecMainStartTimestampMonotonic', 0)) / 1000000 < boot_time - minimum_running_time
             expr_active = service_info.get('ActiveState') == "active"

--- a/salt/modules/openstack_mng.py
+++ b/salt/modules/openstack_mng.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+'''
+Module for OpenStack Management
+
+:codeauthor:    Konrad Mosoń <mosonkonrad@gmail.com>
+:maturity:      new
+:depends:       openstack-utils
+:platform:      linux
+'''
+
+from __future__ import absolute_import
+
+# Import python libs
+import logging
+import time
+
+# Import salt libs
+
+# Import third party libs
+import os.path
+if os.path.isfile('/usr/bin/openstack-service'):
+    HAS_OPENSTACK = True
+else:
+    HAS_OPENSTACK = False
+
+log = logging.getLogger(__name__)
+
+# Define the module's virtual name
+__virtualname__ = 'openstack_mng'
+
+
+def __virtual__():
+    '''
+    Only load this module if openstack-service is installed
+    '''
+    if HAS_OPENSTACK:
+        return __virtualname__
+    else:
+        return (False, 'The openstack-service binary could not be found.')
+
+
+def start_service(service_name):
+    '''
+    Start OpenStack service immiedately
+
+    CLI Example:
+
+    .. code-block:: bash
+        salt '*' openstack_mng.start_service neutron
+    '''
+
+    ret = __salt__['cmd.run_all'](['/usr/bin/openstack-service', 'start', service_name])
+    if ret.get('retcode', 0) == 0:
+        return True
+
+    return False
+
+
+def stop_service(service_name):
+    '''
+    Stop OpenStack service immiedately
+
+    CLI Example:
+
+    .. code-block:: bash
+        salt '*' openstack_mng.stop_service neutron
+    '''
+
+    ret = __salt__['cmd.run_all'](['/usr/bin/openstack-service', 'stop', service_name])
+    if ret.get('retcode', 0) == 0:
+        return True
+
+    return False
+
+
+def restart_service(service_name, minimum_running_time=None):
+    '''
+    Restart OpenStack service immiedately, or only if it's running longer than
+    specified value
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' openstack_mng.restart_service neutron
+        salt '*' openstack_mng.restart_service neutron minimum_running_time=600
+    '''
+
+    if minimum_running_time:
+        ret_code = False
+        # get system services list for interesting openstack service
+        services = __salt__['cmd.run'](['/usr/bin/openstack-service', 'list', service_name]).split('\n')
+        for service in services:
+            service_info = __salt__['service.show'](service)
+
+            boot_time = float(open('/proc/uptime').read().split(' ')[0])
+
+            expr_time = int(service_info.get('ExecMainStartTimestampMonotonic', 0)) / 1000000 < boot_time - minimum_running_time
+            expr_active = True if service_info.get('ActiveState') == "active" else False
+
+            if expr_time or not expr_active:
+                # restart specific system service
+                ret = __salt__['service.restart'](service)
+                if ret:
+                    ret_code = True
+
+        return ret_code
+    else:
+        # just restart
+        ret = __salt__['cmd.run_all'](['/usr/bin/openstack-service', 'restart', service_name])
+        if ret.get('retcode', 0) == 0:
+            return True
+
+    return False


### PR DESCRIPTION
### What does this PR do?

Adds new module.
### Tests written?

No
### Module info

This module allows management of OpenStack services (using `openstack-service` command).

Additionally, it allows to restart service only when it's running longer than specified time (depends on systemd; if systemd is not used on system, it'll be restarted immediately). This can be useful when you use this with Salt Reactor and more than 1 script/daemon/whatever would try to restart the same service in case of some self-healing.
#### Why such module?

`service.restart` allows to restart service by name (like `service.restart openstack-nova-compute`). But `openstack-service` command can restart all OpenStack services that works on specific host.

For example:
`openstack-service restart nova` will restart `nova-compute` if it's Compute Node, or `nova-conductor`, `nova-scheduler`, `nova-conductor` and others if it's Controller Node.

Name for module is chosen on existing pattern (there is already `openstack_config`), and it can be used later for other management stuff.
