### PR TITLE
Lazy init for cache lazyloader to prevent serialization on fork.

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -930,6 +930,18 @@ def executors(opts, functions=None, context=None):
     )
 
 
+def cache(opts, serial):
+    '''
+    Returns the returner modules
+    '''
+    return LazyLoader(
+        _module_dirs(opts, 'cache', 'cache'),
+        opts,
+        tag='cache',
+        pack={'__opts__': opts, '__context__': {'serial': serial}},
+    )
+
+
 def _generate_module(name):
     if name in sys.modules:
         return


### PR DESCRIPTION
### What does this PR do?

Fix a Windows related minion data cache issue: when master initializes it's channels on windows it fails on pickling `salt.cache.Cache` object. I've updated the cache to initialize cache drivers `LazyLoader` on demand.
### What issues does this PR fix or reference?

Related to #27446 
### Tests written?

No
