### PR TITLE
Check for all success return codes in win_dism state

### DIFF
--- a/salt/states/win_dism.py
+++ b/salt/states/win_dism.py
@@ -83,7 +83,7 @@ def capability_installed(name,
     status = __salt__['dism.add_capability'](
         name, source, limit_access, image, restart)
 
-    if status['retcode'] != 0:
+    if status['retcode'] not in [0, 1641, 3010]:
         ret['comment'] = 'Failed to install {0}: {1}'\
             .format(name, status['stdout'])
         ret['result'] = False
@@ -139,7 +139,7 @@ def capability_removed(name, image=None, restart=False):
     # Remove the capability
     status = __salt__['dism.remove_capability'](name, image, restart)
 
-    if status['retcode'] != 0:
+    if status['retcode'] not in [0, 1641, 3010]:
         ret['comment'] = 'Failed to remove {0}: {1}' \
             .format(name, status['stdout'])
         ret['result'] = False
@@ -210,7 +210,7 @@ def feature_installed(name,
     status = __salt__['dism.add_feature'](
         name, package, source, limit_access, enable_parent, image, restart)
 
-    if status['retcode'] != 0:
+    if status['retcode'] not in [0, 1641, 3010]:
         ret['comment'] = 'Failed to install {0}: {1}' \
             .format(name, status['stdout'])
         ret['result'] = False
@@ -270,7 +270,7 @@ def feature_removed(name, remove_payload=False, image=None, restart=False):
     status = __salt__['dism.remove_feature'](
         name, remove_payload, image, restart)
 
-    if status['retcode'] != 0:
+    if status['retcode'] not in [0, 1641, 3010]:
         ret['comment'] = 'Failed to remove {0}: {1}' \
             .format(name, status['stdout'])
         ret['result'] = False
@@ -338,7 +338,7 @@ def package_installed(name,
     status = __salt__['dism.add_package'](
         name, ignore_check, prevent_pending, image, restart)
 
-    if status['retcode'] != 0:
+    if status['retcode'] not in [0, 1641, 3010]:
         ret['comment'] = 'Failed to install {0}: {1}' \
             .format(name, status['stdout'])
         ret['result'] = False
@@ -407,7 +407,7 @@ def package_removed(name, image=None, restart=False):
     # Remove the package
     status = __salt__['dism.remove_package'](name, image, restart)
 
-    if status['retcode'] != 0:
+    if status['retcode'] not in [0, 1641, 3010]:
         ret['comment'] = 'Failed to remove {0}: {1}' \
             .format(name, status['stdout'])
         ret['result'] = False


### PR DESCRIPTION
### What does this PR do?

The win_dism state module gives an incorrect failure message when the dism return code is not 0. These changes will report success where dism indicates a reboot was initiated or required.

i.e. these return codes now indicate success

1641 (ERROR_SUCCESS_REBOOT_INITIATED)
3010 (ERROR_SUCCESS_REBOOT_REQUIRED)

I've checked the codes [here](https://support.microsoft.com/en-us/kb/304888) and checked that at least one "Windows Feature" and one "Windows Package" requests a reboot in this fashion.
### What issues does this PR fix or reference?
#35519 is fixed with this.

<pre>          ID: install_KB2888049
    Function: dism.package_installed
        Name: C:\Windows\TEMP\KB2888049\Windows6.1-KB2888049-x64.cab
      Result: True
     Comment: 
     Started: 16:13:07.704000
    Duration: 15208.0 ms
     Changes:</pre>

### Previous Behavior

Return code must be 0 to indicate that the dism action was successful
### New Behavior

Return code must be 0, 1641, or 3010 to indicate that the dism action was successful
### Tests written?

No
