### PR TITLE
add missing glob import

### DIFF
--- a/salt/modules/consul.py
+++ b/salt/modules/consul.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import
 # Import 3rd-party libs
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 from salt.ext.six.moves.urllib.parse import urljoin as _urljoin
-import salt.ext.six 
+import salt.ext.six
 import salt.ext.six.moves.http_client
 # pylint: enable=import-error,no-name-in-module
 

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -31,7 +31,7 @@ import sys  # do not remove, used in imported file.py functions
 import fileinput  # do not remove, used in imported file.py functions
 import fnmatch  # do not remove, used in imported file.py functions
 import mmap  # do not remove, used in imported file.py functions
-import glob # do not remove, used in imported file.py functions
+import glob  # do not remove, used in imported file.py functions
 # do not remove, used in imported file.py functions
 import salt.ext.six as six  # pylint: disable=import-error,no-name-in-module
 from salt.ext.six.moves.urllib.parse import urlparse as _urlparse  # pylint: disable=import-error,no-name-in-module

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -10,7 +10,6 @@ data
 from __future__ import absolute_import
 
 # Import python libs
-import glob
 import os
 import stat
 import os.path
@@ -32,6 +31,7 @@ import sys  # do not remove, used in imported file.py functions
 import fileinput  # do not remove, used in imported file.py functions
 import fnmatch  # do not remove, used in imported file.py functions
 import mmap  # do not remove, used in imported file.py functions
+import glob # do not remove, used in imported file.py functions
 # do not remove, used in imported file.py functions
 import salt.ext.six as six  # pylint: disable=import-error,no-name-in-module
 from salt.ext.six.moves.urllib.parse import urlparse as _urlparse  # pylint: disable=import-error,no-name-in-module

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -10,6 +10,7 @@ data
 from __future__ import absolute_import
 
 # Import python libs
+import glob
 import os
 import stat
 import os.path


### PR DESCRIPTION
### What does this PR do?

Adds missing glob import in modules/win_file.py

modules/win_file.py imports file.path_exists_glob from modules/file.py and file.path_exists_glob needs glob imported to work
### What issues does this PR fix or reference?

Fixes ZD 903
### Previous Behavior

Stacktrace if using file.path_exists_glob
### New Behavior

Actually work
### Tests written?

No