### PR TITLE
Always deploy the thin to /var/tmp

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -288,7 +288,7 @@ class SSH(object):
         }
         if self.opts.get('rand_thin_dir'):
             self.defaults['thin_dir'] = os.path.join(
-                    '/tmp',
+                    '/var/tmp',
                     '.{0}'.format(uuid.uuid4().hex[:6]))
             self.opts['ssh_wipe'] = 'True'
         self.serial = salt.payload.Serial(opts)


### PR DESCRIPTION
### What does this PR do?

makes salt-ssh -W deploy the thin to /var/tmp instead of /tmp to match the update made in 2016.3.0