### PR TITLE
Remove add_proxymodule_to_opts from minion.py in Carbon

### DIFF
--- a/doc/topics/proxyminion/ssh.rst
+++ b/doc/topics/proxyminion/ssh.rst
@@ -18,7 +18,6 @@ Now, configure your salt-proxy.
 .. code-block:: yaml
 
    master: localhost
-   add_proxymodule_to_opts: False
    multiprocessing: False
 
 2. On your salt-master, ensure that pillar is configured properly.  Select an ID

--- a/doc/topics/tutorials/esxi_proxy_minion.rst
+++ b/doc/topics/tutorials/esxi_proxy_minion.rst
@@ -143,17 +143,6 @@ and should be named ``proxy``. If the file is not there by default, create it.
 This file should contain the location of your Salt Master that the Salt Proxy
 will connect to.
 
-.. note::
-
-    If you're running your ESXi Proxy Minion on version of Salt that is 2015.8.2
-    or newer, you also need to set ``add_proxymodule_to_opts: False`` in your
-    proxy config file. The need to specify this configuration will be removed with
-    Salt ``2016.3.0``, the next major feature release. See the `New in 2015.8.2`_
-    section of the Proxy Minion documentation for more information.
-
-.. _New in 2015.8.2: https://docs.saltstack.com/en/latest/topics/proxyminion/index.html#new-in-2015-8-2
-
-
 Example Proxy Config File:
 
 .. code-block:: yaml
@@ -161,7 +150,6 @@ Example Proxy Config File:
     # /etc/salt/proxy
 
     master: <salt-master-location>
-    add_proxymodule_to_opts: False
 
 
 Pillar Profiles
@@ -274,7 +262,6 @@ Proxy Config File:
     # /etc/salt/proxy
 
     master: <salt-master-location>
-    add_proxymodule_to_opts: False
 
 Pillar Top File:
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2930,10 +2930,6 @@ class ProxyMinion(Minion):
         # Then load the proxy module
         self.proxy = salt.loader.proxy(self.opts)
 
-        # Check config 'add_proxymodule_to_opts'  Remove this in Carbon.
-        if self.opts['add_proxymodule_to_opts']:
-            self.opts['proxymodule'] = self.proxy
-
         # And re-load the modules so the __proxy__ variable gets injected
         self.functions, self.returners, self.function_errors, self.executors = self._load_modules()
         self.functions.pack['__proxy__'] = self.proxy


### PR DESCRIPTION
### What does this PR do?

Removes the add_proxymodule_to_opts conversion from minion.py as the comment states. This also removes relevant documentation references to add_proxymodule_to_opts - these config settings are no longer needed in Carbon.

ping @cro 
