### PR TITLE
Support cp.get_file|url to download files to a directory

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -466,6 +466,18 @@ class Client(object):
         url_path = os.path.join(
                 url_data.netloc, url_data.path).rstrip(os.sep)
 
+        # If dest is a directory, rewrite dest with filename
+        if os.path.isdir(dest) or dest.endswith(('/', '\\')):
+            if url_data.query or len(url_data.path) > 1 and not url_data.path.endswith('/'):
+                strpath = url.split('/')[-1]
+            else:
+                strpath = 'index.html'
+
+            if salt.utils.is_windows():
+                strpath = salt.utils.sanitize_win_path_string(strpath)
+
+            dest = os.path.join(dest, strpath)
+
         if url_scheme and url_scheme.lower() in string.ascii_lowercase:
             url_path = ':'.join((url_scheme, url_path))
             url_scheme = 'file'
@@ -996,6 +1008,13 @@ class RemoteClient(Client):
                 path, saltenv
             )
             return False
+
+        # If dest is a directory, rewrite dest with filename
+        if os.path.isdir(dest) or dest.endswith(('/', '\\')):
+            dest = os.path.join(dest, os.path.basename(path))
+            log.debug(
+                'In saltenv \'%s\', \'%s\' is a directory. Changing dest to '
+                '\'%s\'', saltenv, os.path.dirname(dest), dest)
 
         # Hash compare local copy with master and skip download
         # if no difference found.

--- a/tests/integration/modules/cp.py
+++ b/tests/integration/modules/cp.py
@@ -37,6 +37,22 @@ class CPModuleTest(integration.ModuleCase):
             self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
             self.assertNotIn('bacon', data)
 
+    def test_get_file_to_dir(self):
+        '''
+        cp.get_file
+        '''
+        tgt = os.path.join(integration.TMP, '')
+        self.run_function(
+                'cp.get_file',
+                [
+                    'salt://grail/scene33',
+                    tgt,
+                ])
+        with salt.utils.fopen(tgt + 'scene33', 'r') as scene:
+            data = scene.read()
+            self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
+            self.assertNotIn('bacon', data)
+
     def test_get_file_templated_paths(self):
         '''
         cp.get_file
@@ -179,6 +195,22 @@ class CPModuleTest(integration.ModuleCase):
                 makedirs=True
             )
         with salt.utils.fopen(tgt, 'r') as scene:
+            data = scene.read()
+            self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
+            self.assertNotIn('bacon', data)
+
+    def test_get_url_to_dir(self):
+        '''
+        cp.get_url with salt:// source
+        '''
+        tgt = os.path.join(integration.TMP, '')
+        self.run_function(
+                'cp.get_url',
+                [
+                    'salt://grail/scene33',
+                    tgt,
+                ])
+        with salt.utils.fopen(tgt + 'scene33', 'r') as scene:
             data = scene.read()
             self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
             self.assertNotIn('bacon', data)


### PR DESCRIPTION
### What does this PR do?

Allow cp.get_file / cp.get_url to dump files to destination directory instead of having to specify full destination name.
### What issues does this PR fix or reference?

Issue #34747
### Previous Behavior

See Issue
### New Behavior

File will be downloaded to destination directory.
Url name will be pull from end of URL or 'index.html' if there is no path/query

`salt minion cp.get_file salt://file.txt /tmp`
`salt windowsmin cp.get_url 'http://www.google.com/' C:\\`  (saved as index.html)
### Tests written?

Yes
