### PR TITLE
Remove deprecated version of status.uptime module function

### DIFF
--- a/doc/topics/releases/carbon.rst
+++ b/doc/topics/releases/carbon.rst
@@ -375,6 +375,12 @@ Execution Module Deprecations
 - The ``hash_hostname`` option was removed from the ``salt.modules.ssh`` execution
   module. The ``hash_known_hosts`` option should be used instead.
 
+- The ``human_readable`` option was removed from the ``uptime`` function in the
+  ``status`` execution module. The function was also updated in 2015.8.9 to return
+  a more complete offering of uptime information, formatted as an easy-to-read
+  dictionary. This updated function replaces the need for the ``human_readable``
+  option.
+
 - The ``zpool_list`` function in the ``zpool`` execution module was removed. Use ``list``
   instead.
 

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -132,10 +132,14 @@ def custom():
     return ret
 
 
-@with_deprecated(globals(), "Carbon")
 def uptime():
     '''
     Return the uptime for this system.
+
+    .. versionchanged:: 2015.8.9
+        The uptime function was changed to return a dictionary of easy-to-read
+        key/value pairs containing uptime information, instead of the output
+        from a ``cmd.run`` call.
 
     CLI Example:
 
@@ -161,34 +165,6 @@ def uptime():
     ut_ret['users'] = len(__salt__['cmd.run']("who -s").split(os.linesep))
 
     return ut_ret
-
-
-def _uptime(human_readable=True):
-    '''
-    Return the uptime for this minion
-
-    human_readable: True
-        If ``True`` return the output provided by the system.  If ``False``
-        return the output in seconds.
-
-        .. versionadded:: 2015.8.4
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' status.uptime
-    '''
-    if human_readable:
-        return __salt__['cmd.run']('uptime')
-    else:
-        if os.path.exists('/proc/uptime'):
-            out = __salt__['cmd.run']('cat /proc/uptime').split()
-            if len(out):
-                return out[0]
-            else:
-                return 'unexpected format in /proc/uptime'
-        return 'cannot find /proc/uptime'
 
 
 def loadavg():

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -27,7 +27,6 @@ import salt.utils.event
 from salt.utils.network import host_to_ip as _host_to_ip
 from salt.utils.network import remote_port_tcp as _remote_port_tcp
 from salt.ext.six.moves import zip
-from salt.utils.decorators import with_deprecated
 from salt.exceptions import CommandExecutionError
 
 __virtualname__ = 'status'
@@ -921,7 +920,7 @@ def all_status():
             'meminfo': meminfo(),
             'netdev': netdev(),
             'netstats': netstats(),
-            'uptime': uptime() if not __grains__['kernel'] == 'SunOS' else _uptime(),
+            'uptime': uptime(),
             'vmstats': vmstats(),
             'w': w()}
 

--- a/tests/unit/modules/status_test.py
+++ b/tests/unit/modules/status_test.py
@@ -57,32 +57,6 @@ class StatusTestCase(TestCase):
             with self.assertRaises(CommandExecutionError):
                 status.uptime()
 
-    def test_deprecated_uptime(self):
-        '''
-        test modules.status.uptime function, deprecated version
-        '''
-        mock_uptime = 'very often'
-        mock_run = MagicMock(return_value=mock_uptime)
-        with patch.dict(status.__salt__, {'cmd.run': mock_run}):
-            self.assertEqual(status._uptime(), mock_uptime)
-
-        mock_uptime = 'very idle'
-        mock_run = MagicMock(return_value=mock_uptime)
-        with patch.dict(status.__salt__, {'cmd.run': mock_run}):
-            with patch('os.path.exists', MagicMock(return_value=True)):
-                self.assertEqual(status._uptime(human_readable=False), mock_uptime.split()[0])
-
-        mock_uptime = ''
-        mock_return = 'unexpected format in /proc/uptime'
-        mock_run = MagicMock(return_value=mock_uptime)
-        with patch.dict(status.__salt__, {'cmd.run': mock_run}):
-            with patch('os.path.exists', MagicMock(return_value=True)):
-                self.assertEqual(status._uptime(human_readable=False), mock_return)
-
-        mock_return = 'cannot find /proc/uptime'
-        with patch('os.path.exists', MagicMock(return_value=False)):
-            self.assertEqual(status._uptime(human_readable=False), mock_return)
-
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
### What does this PR do?
- Removes the deprecated version of the status.uptime function. The deprecated version of the function was set to be removed in Carbon.
- Updates the Carbon release notes with this removal
- Removes the test_deprecated_uptime unit test. The deprecated version of uptime no longer exists.

Refs #35196
### Tests written?

No - This just removes an old function, so let's see how the current tests do now that this code has been removed.

@isbm - This is your code, and I haven't handled anything with your new deprecation decorators yet. Did I do this correctly?
