### PR TITLE
Remove env references in salt-ssh state wrapper

### DIFF
--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -49,15 +49,6 @@ def sls(mods, saltenv='base', test=None, exclude=None, **kwargs):
     '''
     st_kwargs = __salt__.kwargs
     __opts__['grains'] = __grains__
-    if 'env' in kwargs:
-        salt.utils.warn_until(
-            'Oxygen',
-            'Parameter \'env\' has been detected in the argument list.  This '
-            'parameter is no longer used and has been replaced by \'saltenv\' '
-            'as of Salt Carbon.  This warning will be removed in Salt Oxygen.'
-            )
-        kwargs.pop('env')
-
     __pillar__.update(kwargs.get('pillar', {}))
     st_ = salt.client.ssh.state.SSHHighState(
             __opts__,
@@ -494,15 +485,6 @@ def show_sls(mods, saltenv='base', test=None, **kwargs):
     '''
     __pillar__.update(kwargs.get('pillar', {}))
     __opts__['grains'] = __grains__
-    if 'env' in kwargs:
-        salt.utils.warn_until(
-            'Oxygen',
-            'Parameter \'env\' has been detected in the argument list.  This '
-            'parameter is no longer used and has been replaced by \'saltenv\' '
-            'as of Salt Carbon.  This warning will be removed in Salt Oxygen.'
-            )
-        kwargs.pop('env')
-
     opts = copy.copy(__opts__)
     if salt.utils.test_mode(test=test, **kwargs):
         opts['test'] = True
@@ -530,7 +512,7 @@ def show_sls(mods, saltenv='base', test=None, **kwargs):
     return high_data
 
 
-def show_low_sls(mods, saltenv='base', test=None, env=None, **kwargs):
+def show_low_sls(mods, saltenv='base', test=None, **kwargs):
     '''
     Display the low state data from a specific sls or list of sls files on the
     master
@@ -543,14 +525,6 @@ def show_low_sls(mods, saltenv='base', test=None, env=None, **kwargs):
     '''
     __pillar__.update(kwargs.get('pillar', {}))
     __opts__['grains'] = __grains__
-    if env is not None:
-        salt.utils.warn_until(
-            'Carbon',
-            'Passing a salt environment should be done using \'saltenv\' '
-            'not \'env\'. This functionality will be removed in Salt Carbon.'
-        )
-        # Backwards compatibility
-        saltenv = env
 
     opts = copy.copy(__opts__)
     if salt.utils.test_mode(test=test, **kwargs):


### PR DESCRIPTION
`env` has been deprecated and removed in the Carbon release. `saltenv` must be used instead. This is already documented in the deprecations section of the Carbon release notes.
