### PR TITLE
Add versionadded tag for show_low_sls function in salt-ssh state wrapper

### DIFF
--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -533,7 +533,9 @@ def show_sls(mods, saltenv='base', test=None, env=None, **kwargs):
 def show_low_sls(mods, saltenv='base', test=None, env=None, **kwargs):
     '''
     Display the low state data from a specific sls or list of sls files on the
-    master
+    master.
+
+    .. versionadded:: 2016.3.2
 
     CLI Example:
 


### PR DESCRIPTION
### What does this PR do?

The show_low_sls function was added to the salt-ssh state wrapper in saltstack/salt#34840 for version 2016.3.2 to fix #32525. This adds the versionadded tag to help people who are looking at the 2016.3 docs for this function.