### PR TITLE
Treat python XML as an optdep

### DIFF
--- a/salt/_compat.py
+++ b/salt/_compat.py
@@ -14,6 +14,7 @@ import subprocess
 from salt.ext.six import binary_type, string_types, text_type
 from salt.ext.six.moves import cStringIO, StringIO
 
+HAS_XML = True
 try:
     # Python >2.5
     import xml.etree.cElementTree as ElementTree
@@ -30,7 +31,8 @@ except Exception:
                 # normal ElementTree install
                 import elementtree.ElementTree as ElementTree
             except Exception:
-                raise
+                ElementTree = None
+                HAS_XML = False
 
 
 # True if we are running on Python 3.
@@ -44,14 +46,15 @@ else:
     import exceptions
 
 
-if not hasattr(ElementTree, 'ParseError'):
-    class ParseError(Exception):
-        '''
-        older versions of ElementTree do not have ParseError
-        '''
-        pass
+if HAS_XML:
+    if not hasattr(ElementTree, 'ParseError'):
+        class ParseError(Exception):
+            '''
+            older versions of ElementTree do not have ParseError
+            '''
+            pass
 
-    ElementTree.ParseError = ParseError
+        ElementTree.ParseError = ParseError
 
 
 def text_(s, encoding='latin-1', errors='strict'):


### PR DESCRIPTION
This is due to the fact that some distros (I am looking at YOU SUSE) strip the xml code out pf python and into another library. This fixes a bug where on SUSE systems the python-xml package needs to be installed for salt-ssh as well as our docker introspection.
