### PR TITLE
Allow extra opts to be passed when creating nodes

### DIFF
--- a/salt/modules/cloud.py
+++ b/salt/modules/cloud.py
@@ -183,7 +183,7 @@ def get_instance(name, provider=None):
     return info
 
 
-def profile_(profile, names, vm_overrides=None, **kwargs):
+def profile_(profile, names, vm_overrides=None, opts=None, **kwargs):
     '''
     Spin up an instance using Salt Cloud
 
@@ -194,6 +194,8 @@ def profile_(profile, names, vm_overrides=None, **kwargs):
         salt '*' cloud.profile my-gce-config myinstance
     '''
     client = _get_client()
+    if isinstance(opts, dict):
+        client.opts.update(opts)
     info = client.profile(profile, names, vm_overrides=vm_overrides, **kwargs)
     return info
 
@@ -236,7 +238,7 @@ def action(
     return info
 
 
-def create(provider, names, **kwargs):
+def create(provider, names, opts=None, **kwargs):
     '''
     Create an instance using Salt Cloud
 
@@ -247,6 +249,8 @@ def create(provider, names, **kwargs):
         salt minionname cloud.create my-ec2-config myinstance image=ami-1624987f size='t1.micro' ssh_username=ec2-user securitygroup=default delvol_on_destroy=True
     '''
     client = _get_client()
+    if isinstance(opts, dict):
+        client.opts.update(opts)
     info = client.create(provider, names, **kwargs)
     return info
 

--- a/salt/runners/cloud.py
+++ b/salt/runners/cloud.py
@@ -83,7 +83,7 @@ def select_query(query_type='list_nodes_select'):
     return info
 
 
-def profile(prof=None, instances=None, **kwargs):
+def profile(prof=None, instances=None, opts=None, **kwargs):
     '''
     Create a cloud vm with the given profile and instances, instances can be a
     list or comma-delimited string
@@ -107,6 +107,8 @@ def profile(prof=None, instances=None, **kwargs):
         return {'Error': 'One or more instances (comma-delimited) must be set'}
 
     client = _get_client()
+    if isinstance(opts, dict):
+        client.opts.update(opts)
     info = client.profile(prof, instances, **kwargs)
     return info
 
@@ -149,7 +151,7 @@ def action(func=None,
     return info
 
 
-def create(provider, instances, **kwargs):
+def create(provider, instances, opts=None, **kwargs):
     '''
     Create an instance using Salt Cloud
 
@@ -166,5 +168,7 @@ def create(provider, instances, **kwargs):
         if not kwarg.startswith('__'):
             create_kwargs[kwarg] = kwargs[kwarg]
     client = _get_client()
+    if isinstance(opts, dict):
+        client.opts.update(opts)
     info = client.create(provider, instances, **create_kwargs)
     return info

--- a/salt/states/cloud.py
+++ b/salt/states/cloud.py
@@ -64,7 +64,7 @@ def _get_instance(names):
     return instance
 
 
-def present(name, cloud_provider, onlyif=None, unless=None, **kwargs):
+def present(name, cloud_provider, onlyif=None, unless=None, opts=None, **kwargs):
     '''
     Spin up a single instance on a cloud provider, using salt-cloud. This state
     does not take a profile argument; rather, it takes the arguments that would
@@ -87,6 +87,9 @@ def present(name, cloud_provider, onlyif=None, unless=None, **kwargs):
 
     unless
         Do not run the state at least unless succeed
+
+    opts
+        Any extra opts that need to be used
     '''
     ret = {'name': name,
            'changes': {},
@@ -120,7 +123,7 @@ def present(name, cloud_provider, onlyif=None, unless=None, **kwargs):
         ret['comment'] = 'Instance {0} needs to be created'.format(name)
         return ret
 
-    info = __salt__['cloud.create'](cloud_provider, name, **kwargs)
+    info = __salt__['cloud.create'](cloud_provider, name, opts=opts, **kwargs)
     if info and 'Error' not in info:
         ret['changes'] = info
         ret['result'] = True
@@ -214,7 +217,7 @@ def absent(name, onlyif=None, unless=None):
     return ret
 
 
-def profile(name, profile, onlyif=None, unless=None, **kwargs):
+def profile(name, profile, onlyif=None, unless=None, opts=None, **kwargs):
     '''
     Create a single instance on a cloud provider, using a salt-cloud profile.
 
@@ -239,6 +242,8 @@ def profile(name, profile, onlyif=None, unless=None, **kwargs):
     kwargs
         Any profile override or addition
 
+    opts
+        Any extra opts that need to be used
     '''
     ret = {'name': name,
            'changes': {},
@@ -269,7 +274,7 @@ def profile(name, profile, onlyif=None, unless=None, **kwargs):
         ret['comment'] = 'Instance {0} needs to be created'.format(name)
         return ret
 
-    info = __salt__['cloud.profile'](profile, name, vm_overrides=kwargs)
+    info = __salt__['cloud.profile'](profile, name, vm_overrides=kwargs, opts=opts)
 
     # get either {Error: ''} or {namestring: {Error: ''}}
     # which is what we can get from providers returns


### PR DESCRIPTION
### What does this PR do?

When using `cloud` modules to create new nodes, allow the `opts` dictionary to be updated with extra configuration.
### Tests written?

No.