### PR TITLE
Feature to add passphrase protection for master keys.

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -267,6 +267,22 @@
 
 #####        Security settings       #####
 ##########################################
+# Enable passphrase protection of Master private key.  Although a string value
+# is acceptable; passwords should be stored in an external vaulting mechanism
+# and retrieved via sdb. See https://docs.saltstack.com/en/latest/topics/sdb/.
+# Passphrase protection is off by default but an example of an sdb profile and
+# query is as follows.
+# masterkeyring:
+#  driver: keyring
+#  service: system
+#
+# key_pass: sdb://masterkeyring/key_pass
+
+# Enable passphrase protection of the Master signing_key. This only applies if
+# master_sign_pubkey is set to True.  This is disabled by default.
+# master_sign_pubkey: True
+# signing_key_pass: sdb://masterkeyring/signing_pass
+
 # Enable "open mode", this mode still maintains encryption, but turns off
 # authentication, this is only intended for highly secure environments or for
 # the situation where your keys end up in a bad state. If you run in open mode

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1350,7 +1350,7 @@ DEFAULT_MASTER_OPTS = {
     'verify_env': True,
     'permissive_pki_access': False,
     'key_pass': '',
-    'signing_key_pass': '',    
+    'signing_key_pass': '',
     'default_include': 'master.d/*.conf',
     'winrepo_dir': os.path.join(salt.syspaths.BASE_FILE_ROOTS_DIR, 'win', 'repo'),
     'winrepo_dir_ng': os.path.join(salt.syspaths.BASE_FILE_ROOTS_DIR, 'win', 'repo-ng'),

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -415,6 +415,12 @@ VALID_OPTS = {
     # Allow a daemon to function even if the key directories are not secured
     'permissive_pki_access': bool,
 
+    # The passphrase of the master's private key
+    'key_pass': str,
+
+    # The passphrase of the master's private signing key
+    'signing_key_pass': str,
+
     # The path to a directory to pull in configuration file includes
     'default_include': str,
 
@@ -1343,6 +1349,8 @@ DEFAULT_MASTER_OPTS = {
     'key_logfile': os.path.join(salt.syspaths.LOGS_DIR, 'key'),
     'verify_env': True,
     'permissive_pki_access': False,
+    'key_pass': '',
+    'signing_key_pass': '',    
     'default_include': 'master.d/*.conf',
     'winrepo_dir': os.path.join(salt.syspaths.BASE_FILE_ROOTS_DIR, 'win', 'repo'),
     'winrepo_dir_ng': os.path.join(salt.syspaths.BASE_FILE_ROOTS_DIR, 'win', 'repo-ng'),

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -250,7 +250,6 @@ class MasterKeys(dict):
             # create a new signing key-pair to sign the masters
             # auth-replies when a minion tries to connect
             else:
-
                 key_pass = salt.utils.sdb.sdb_get(self.opts['signing_key_pass'], self.opts)
 
                 self.pub_sign_path = os.path.join(self.opts['pki_dir'],

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -250,6 +250,7 @@ class MasterKeys(dict):
             # create a new signing key-pair to sign the masters
             # auth-replies when a minion tries to connect
             else:
+
                 key_pass = salt.utils.sdb.sdb_get(self.opts['signing_key_pass'], self.opts)
 
                 self.pub_sign_path = os.path.join(self.opts['pki_dir'],

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -130,7 +130,7 @@ def gen_keys(keydir, keyname, keysize, user=None, passphrase=None):
     return priv
 
 
-def sign_message(privkey_path, message):
+def sign_message(privkey_path, message, passphrase=None):
     '''
     Use Crypto.Signature.PKCS1_v1_5 to sign a message. Returns the signature.
     '''
@@ -250,9 +250,9 @@ class MasterKeys(dict):
             # create a new signing key-pair to sign the masters
             # auth-replies when a minion tries to connect
             else:
-                
+
                 key_pass = salt.utils.sdb.sdb_get(self.opts['signing_key_pass'], self.opts)
-                
+
                 self.pub_sign_path = os.path.join(self.opts['pki_dir'],
                                                   opts['master_sign_key_name'] + '.pub')
                 self.rsa_sign_path = os.path.join(self.opts['pki_dir'],

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -41,10 +41,11 @@ import salt.payload
 import salt.transport.client
 import salt.transport.frame
 import salt.utils.rsax931
+import salt.utils.sdb
 import salt.utils.verify
 import salt.version
 from salt.exceptions import (
-    AuthenticationError, SaltClientError, SaltReqTimeoutError
+    AuthenticationError, SaltClientError, SaltReqTimeoutError, MasterExit
 )
 
 import tornado.gen
@@ -81,7 +82,7 @@ def dropfile(cachedir, user=None):
         os.umask(mask)  # restore original umask
 
 
-def gen_keys(keydir, keyname, keysize, user=None):
+def gen_keys(keydir, keyname, keysize, user=None, passphrase=None):
     '''
     Generate a RSA public keypair for use with salt
 
@@ -89,6 +90,7 @@ def gen_keys(keydir, keyname, keysize, user=None):
     :param str keyname: The type of salt server for whom this key should be written. (i.e. 'master' or 'minion')
     :param int keysize: The number of bits in the key
     :param str user: The user on the system who should own this keypair
+    :param str passphrase: The passphrase which should be used to encrypt the private key
 
     :rtype: str
     :return: Path on the filesystem to the RSA private key
@@ -110,7 +112,7 @@ def gen_keys(keydir, keyname, keysize, user=None):
 
     cumask = os.umask(191)
     with salt.utils.fopen(priv, 'wb+') as f:
-        f.write(gen.exportKey('PEM'))
+        f.write(gen.exportKey('PEM', passphrase))
     os.umask(cumask)
     with salt.utils.fopen(pub, 'wb+') as f:
         f.write(gen.publickey().exportKey('PEM'))
@@ -134,7 +136,7 @@ def sign_message(privkey_path, message):
     '''
     log.debug('salt.crypt.sign_message: Loading private key')
     with salt.utils.fopen(privkey_path) as f:
-        key = RSA.importKey(f.read())
+        key = RSA.importKey(f.read(), passphrase)
     log.debug('salt.crypt.sign_message: Signing message.')
     signer = PKCS1_v1_5.new(key)
     return signer.sign(SHA.new(message))
@@ -153,7 +155,7 @@ def verify_signature(pubkey_path, message, signature):
     return verifier.verify(SHA.new(message), signature)
 
 
-def gen_signature(priv_path, pub_path, sign_path):
+def gen_signature(priv_path, pub_path, sign_path, passphrase=None):
     '''
     creates a signature for the given public-key with
     the given private key and writes it to sign_path
@@ -162,7 +164,7 @@ def gen_signature(priv_path, pub_path, sign_path):
     with salt.utils.fopen(pub_path) as fp_:
         mpub_64 = fp_.read()
 
-    mpub_sig = sign_message(priv_path, mpub_64)
+    mpub_sig = sign_message(priv_path, mpub_64, passphrase)
     mpub_sig_64 = binascii.b2a_base64(mpub_sig)
     if os.path.isfile(sign_path):
         return False
@@ -220,7 +222,8 @@ class MasterKeys(dict):
         self.pub_path = os.path.join(self.opts['pki_dir'], 'master.pub')
         self.rsa_path = os.path.join(self.opts['pki_dir'], 'master.pem')
 
-        self.key = self.__get_keys()
+        key_pass = salt.utils.sdb.sdb_get(self.opts['key_pass'], self.opts)
+        self.key = self.__get_keys(passphrase=key_pass)
         self.pub_signature = None
 
         # set names for the signing key-pairs
@@ -247,11 +250,15 @@ class MasterKeys(dict):
             # create a new signing key-pair to sign the masters
             # auth-replies when a minion tries to connect
             else:
+                
+                key_pass = salt.utils.sdb.sdb_get(self.opts['signing_key_pass'], self.opts)
+                
                 self.pub_sign_path = os.path.join(self.opts['pki_dir'],
                                                   opts['master_sign_key_name'] + '.pub')
                 self.rsa_sign_path = os.path.join(self.opts['pki_dir'],
                                                   opts['master_sign_key_name'] + '.pem')
-                self.sign_key = self.__get_keys(name=opts['master_sign_key_name'])
+                self.sign_key = self.__get_keys(name=opts['master_sign_key_name'],
+                                                passphrase=key_pass)
 
     # We need __setstate__ and __getstate__ to avoid pickling errors since
     # some of the member variables correspond to Cython objects which are
@@ -264,7 +271,7 @@ class MasterKeys(dict):
     def __getstate__(self):
         return {'opts': self.opts}
 
-    def __get_keys(self, name='master'):
+    def __get_keys(self, name='master', passphrase=None):
         '''
         Returns a key object for a key in the pki-dir
         '''
@@ -272,16 +279,22 @@ class MasterKeys(dict):
                             name + '.pem')
         if os.path.exists(path):
             with salt.utils.fopen(path) as f:
-                key = RSA.importKey(f.read())
+                try:
+                    key = RSA.importKey(f.read(), passphrase)
+                except ValueError as e:
+                    message = 'Unable to read key: {0}; passphrase may be incorrect'.format(path)
+                    log.error(message)
+                    raise MasterExit(message)
             log.debug('Loaded {0} key: {1}'.format(name, path))
         else:
             log.info('Generating {0} keys: {1}'.format(name, self.opts['pki_dir']))
             gen_keys(self.opts['pki_dir'],
                      name,
                      self.opts['keysize'],
-                     self.opts.get('user'))
-            with salt.utils.fopen(self.rsa_path) as f:
-                key = RSA.importKey(f.read())
+                     self.opts.get('user'),
+                     passphrase)
+            with salt.utils.fopen(path) as f:
+                key = RSA.importKey(f.read(), passphrase)
         return key
 
     def get_pub_str(self, name='master'):

--- a/salt/key.py
+++ b/salt/key.py
@@ -25,6 +25,7 @@ import salt.minion
 import salt.utils
 import salt.utils.event
 import salt.utils.kinds
+import salt.utils.sdb
 
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 import salt.ext.six as six
@@ -354,6 +355,8 @@ class Key(object):
                 opts=opts,
                 listen=False)
 
+        self.passphrase = salt.utils.sdb.sdb_get(self.opts['signing_key_pass'], self.opts)
+
     def _check_minions_directories(self):
         '''
         Return the minion keys directory paths
@@ -389,7 +392,7 @@ class Key(object):
         '''
         keydir, keyname, keysize, user = self._get_key_attrs(keydir, keyname,
                                                              keysize, user)
-        salt.crypt.gen_keys(keydir, keyname, keysize, user)
+        salt.crypt.gen_keys(keydir, keyname, keysize, user, self.passphrase)
         return salt.utils.pem_finger(os.path.join(keydir, keyname + '.pub'))
 
     def gen_signature(self, privkey, pubkey, sig_path):
@@ -398,7 +401,8 @@ class Key(object):
         '''
         return salt.crypt.gen_signature(privkey,
                                         pubkey,
-                                        sig_path)
+                                        sig_path,
+                                        self.passphrase)
 
     def gen_keys_signature(self, priv, pub, signature_path, auto_create=False, keysize=None):
         '''

--- a/salt/key.py
+++ b/salt/key.py
@@ -436,7 +436,8 @@ class Key(object):
                 salt.crypt.gen_keys(self.opts['pki_dir'],
                                     self.opts['master_sign_key_name'],
                                     keysize or self.opts['keysize'],
-                                    self.opts.get('user'))
+                                    self.opts.get('user'),
+                                    self.passphrase)
 
                 priv = self.opts['pki_dir'] + '/' + self.opts['master_sign_key_name'] + '.pem'
             else:

--- a/salt/transport/mixins/auth.py
+++ b/salt/transport/mixins/auth.py
@@ -431,9 +431,13 @@ class AESReqServerMixin(object):
             else:
                 # the master has its own signing-keypair, compute the master.pub's
                 # signature and append that to the auth-reply
+                
+                # get the key_pass for the signing key
+                key_pass = salt.utils.sdb.sdb_get(self.opts['signing_key_pass'], self.opts)
+                
                 log.debug("Signing master public key before sending")
                 pub_sign = salt.crypt.sign_message(self.master_key.get_sign_paths()[1],
-                                                   ret['pub_key'])
+                                                   ret['pub_key'], key_pass)
                 ret.update({'pub_sig': binascii.b2a_base64(pub_sign)})
 
         mcipher = PKCS1_OAEP.new(self.master_key.key)

--- a/salt/transport/mixins/auth.py
+++ b/salt/transport/mixins/auth.py
@@ -431,10 +431,10 @@ class AESReqServerMixin(object):
             else:
                 # the master has its own signing-keypair, compute the master.pub's
                 # signature and append that to the auth-reply
-                
+
                 # get the key_pass for the signing key
                 key_pass = salt.utils.sdb.sdb_get(self.opts['signing_key_pass'], self.opts)
-                
+
                 log.debug("Signing master public key before sending")
                 pub_sign = salt.crypt.sign_message(self.master_key.get_sign_paths()[1],
                                                    ret['pub_key'], key_pass)

--- a/tests/unit/crypt_test.py
+++ b/tests/unit/crypt_test.py
@@ -100,9 +100,32 @@ class CryptTestCase(TestCase):
                     crypt.gen_keys('/keydir', 'keyname', 2048)
                     salt.utils.fopen.assert_has_calls([open_priv_wb, open_pub_wb], any_order=True)
 
+
+    @patch('os.umask', MagicMock())
+    @patch('os.chmod', MagicMock())
+    @patch('os.chown', MagicMock())
+    @patch('os.access', MagicMock(return_value=True))
+    def test_gen_keys_with_passphrase(self):
+        with patch('salt.utils.fopen', mock_open()):
+            open_priv_wb = call('/keydir/keyname.pem', 'wb+')
+            open_pub_wb = call('/keydir/keyname.pub', 'wb+')
+            with patch('os.path.isfile', return_value=True):
+                self.assertEqual(crypt.gen_keys('/keydir', 'keyname', 2048, passphrase='password'), '/keydir/keyname.pem')
+                self.assertNotIn(open_priv_wb, salt.utils.fopen.mock_calls)
+                self.assertNotIn(open_pub_wb, salt.utils.fopen.mock_calls)
+            with patch('os.path.isfile', return_value=False):
+                with patch('salt.utils.fopen', mock_open()):
+                    crypt.gen_keys('/keydir', 'keyname', 2048)
+                    salt.utils.fopen.assert_has_calls([open_priv_wb, open_pub_wb], any_order=True)
+
     def test_sign_message(self):
         with patch('salt.utils.fopen', mock_open(read_data=PRIVKEY_DATA)):
             self.assertEqual(SIG, crypt.sign_message('/keydir/keyname.pem', MSG))
+
+    def test_sign_message_with_passphrase(self):
+        with patch('salt.utils.fopen', mock_open(read_data=PRIVKEY_DATA)):
+            self.assertEqual(SIG, crypt.sign_message('/keydir/keyname.pem', MSG, passphrase='password'))
+
 
     def test_verify_signature(self):
         with patch('salt.utils.fopen', mock_open(read_data=PUBKEY_DATA)):

--- a/tests/unit/crypt_test.py
+++ b/tests/unit/crypt_test.py
@@ -100,7 +100,6 @@ class CryptTestCase(TestCase):
                     crypt.gen_keys('/keydir', 'keyname', 2048)
                     salt.utils.fopen.assert_has_calls([open_priv_wb, open_pub_wb], any_order=True)
 
-
     @patch('os.umask', MagicMock())
     @patch('os.chmod', MagicMock())
     @patch('os.chown', MagicMock())
@@ -125,7 +124,6 @@ class CryptTestCase(TestCase):
     def test_sign_message_with_passphrase(self):
         with patch('salt.utils.fopen', mock_open(read_data=PRIVKEY_DATA)):
             self.assertEqual(SIG, crypt.sign_message('/keydir/keyname.pem', MSG, passphrase='password'))
-
 
     def test_verify_signature(self):
         with patch('salt.utils.fopen', mock_open(read_data=PUBKEY_DATA)):


### PR DESCRIPTION
### What does this PR do?

This feature adds the ability to passphrase protect the master private key and/or the master signing key.  This is more or less an initial stab at this and I'd like to get some eyes on it etc. as my gut is telling me I'm missing something.
### What issues does this PR fix or reference?

Background for this PR can be found [salt/issues/35303](https://github.com/saltstack/salt/issues/35303)
### Previous Behavior

Previous behavior is as follows:
- salt-master creates a private key without passphrase
- salt-master loads a private key without passphrase
- salt-master creates signing key without passphrase
- salt-master loads signing key without passphrase
- salt-key generates signature without passphrase needed for existing signing key
- salt-key creates new signing key without a passphrase (--auto-create on)
### New Behavior
- salt-master creates a private key with a passphrase
- salt-master loads a private key with passphrase
- salt-master creates signing key with passphrase
- salt-master loads signing key with passphrase
- salt-key generates signature with passphrase needed for existing signing key
- salt-key creates new signing key with a passphrase (--auto-create on)

passphrases are configured within the master config.  Best pracitces is to utilize external vaulting mechanism but if a string is used as the passphrase values, it will be accepted.  (this is due to sdb passing the string along if it can't resolve the query).

The private key and the signing key both can have their own unique passphrase and one is not dependent on the other.  If the user would like to manage one password I figured they can use the same sdb query to retrieve the same password for both.  It is also possible to set a passphrase for the private key but not the signing key and vice versa.

The following configuration options being proposed are as followed.

``` yaml
#####        Security settings       #####
##########################################
# Enable passphrase protection of Master private key.  Although a string value
# is acceptable; passwords should be stored in an external vaulting mechanism
# and retrieved via sdb. See https://docs.saltstack.com/en/latest/topics/sdb/.
# Passphrase protection is off by default but an example of an sdb profile and
# query is as follows.
# masterkeyring:
#  driver: keyring
#  service: system
#
# key_pass: sdb://masterkeyring/key_pass

# Enable passphrase protection of the Master signing_key. This only applies if
# master_sign_pubkey is set to True.  This is disabled by default.
# master_sign_pubkey: True
# signing_key_pass: sdb://masterkeyring/signing_pass
```
### Tests written?

Yes/**No**
The biggest challenge is in regards to testing and how best to approach this.  I wrote a quick unit test where it passes in a passphrase alongside the other salt.crypt tests which are already there but I know this is not enough.  If possible some direction on how to approach this would be greatly appreciated.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
