### PR TITLE
fix-35384, fix cmd.run unless

### DIFF
--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -355,10 +355,10 @@ def mod_run_check(cmd_kwargs, onlyif, unless, creates):
             for entry in unless:
                 cmd.append(__salt__['cmd.retcode'](entry, ignore_retcode=True, python_shell=True, **cmd_kwargs))
                 log.debug('Last command return code: {0}'.format(cmd))
-                if all([c == 0 for c in cmd]):
-                    return {'comment': 'unless execution succeeded',
-                            'skip_watch': True,
-                            'result': True}
+            if all([c == 0 for c in cmd]):
+                return {'comment': 'unless execution succeeded',
+                        'skip_watch': True,
+                        'result': True}
         elif not isinstance(unless, string_types):
             if unless:
                 log.debug('Command not run: unless did not evaluate to string_type')


### PR DESCRIPTION
### What does this PR do?

Fix https://github.com/saltstack/salt/issues/35384
### What issues does this PR fix or reference?
### Previous Behavior

Only one command in the `unless` list will be executed.  
### New Behavior

All commands in the `unless` list will be executed. 
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
