### PR TITLE
tests/integration: wait for test children to terminate

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -507,6 +507,7 @@ class SaltDaemonScriptBase(SaltScriptBase, ShellTestCase):
         self._connectable.clear()
         time.sleep(0.0125)
         self._process.terminate()
+        self._process.join()
 
         if HAS_PSUTIL:
             # Lets log and kill any child processes which salt left behind


### PR DESCRIPTION
### What does this PR do?

Fix a race condition inside the salt integration test suite.
### What issues does this PR fix or reference?

issue #35028.
### Previous Behavior

Test suite errors as described in the opened github issue.
### New Behavior

Tests finish as expected, no tmpdir / log errors.
### Tests written?

No

This is a fix for salt github issue #35028.

Commit b02926f41c188 ("Immediate shutdown") removed the join() call
when stopping the daemon process, thus triggering a race between the
tmpdir cleanup logic and running children who still have data to
write. By re-adding the join() call we ensure all children finish
before the tmpdir gets removed. Children should normally be dead when
the call from join() returns, the SIGKILL logic after join() is for
cleaning up hanged processes.

Signed-off-by: Ioan-Adrian Ratiu adrian.ratiu@ni.com
