### PR TITLE
Use list for iter in keys iteration in state compiler for py3

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -3041,7 +3041,7 @@ class BaseHighState(object):
                 )
                 continue
             skeys = set()
-            for key in state[name]:
+            for key in list(state[name]):
                 if key.startswith('_'):
                     continue
                 if not isinstance(state[name][key], list):


### PR DESCRIPTION
Refs the test integration.states.compiler.CompileTest.test_multi_state

In Py3, this dict changes during iteration and stacktraces. Migrating by iterating a list is best practice per PEP 0469.

cc: @thatch45 
