### PR TITLE
Write test for multiple unless commands where 1st cmd passes and 2nd fails

### DIFF
--- a/tests/integration/files/file/base/issue-35384.sls
+++ b/tests/integration/files/file/base/issue-35384.sls
@@ -1,0 +1,6 @@
+cmd_run_unless_multiple:
+  cmd.run:
+    - name: echo "hello"
+    - unless:
+      - /bin/true
+      - /bin/false

--- a/tests/integration/states/cmd.py
+++ b/tests/integration/states/cmd.py
@@ -87,6 +87,22 @@ class CMDTest(integration.ModuleCase,
             os.remove(state_file)
             os.remove(unless_file)
 
+    def test_run_unless_multiple_cmds(self):
+        '''
+        test cmd.run using multiple unless options where the first cmd in the
+        list will pass, but the second will fail. This tests the fix for issue
+        #35384. (The fix is in PR #35545.)
+        '''
+        sls = self.run_function('state.sls', mods='issue-35384')
+        self.assertSaltTrueReturn(sls)
+        # We must assert against the comment here to make sure the comment reads that the
+        # command "echo "hello"" was run. This ensures that we made it to the last unless
+        # command in the state. If the comment reads "unless execution succeeded", or similar,
+        # then the unless state run bailed out after the first unless command succeeded,
+        # which is the bug we're regression testing for.
+        self.assertEqual(sls['cmd_|-cmd_run_unless_multiple_|-echo "hello"_|-run']['comment'],
+                         'Command "echo "hello"" run')
+
     def test_run_creates_exists(self):
         '''
         test cmd.run creates already there


### PR DESCRIPTION
### What does this PR do?

This is a regression integration test for #35384, which was fixed by #35545, and back-ported to the 2015.8 branch in #35566.
### What issues does this PR fix or reference?
#35384, #35545, and #35566.
### Tests written?

Yes!

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.