### PR TITLE
Updated user.py to redact password when test=true

### DIFF
--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -475,7 +475,7 @@ def present(name,
             ret['comment'] = ('The following user attributes are set to be '
                               'changed:\n')
             for key, val in iteritems(changes):
-                if key == 'password':
+                if key == 'passwd':
                     val = 'XXX-REDACTED-XXX'
                 ret['comment'] += u'{0}: {1}\n'.format(key, val)
             return ret


### PR DESCRIPTION
### What does this PR do?

Hides the password when using the Salt user state and setting test=true by testing if the value of a key is equal to 'passwd'.
### What issues does this PR fix or reference?

Showing a users password in plaintext when running salt with test=true
### Previous Behavior

The password was displayed in plaintext on the screen when running with test=true

apache-user:
  user.present:
     - name: apache
     - system: True
     - password: PLAINTEXTPASSWORD
     - home: /var/www

[root@84bd62911587 /]# salt-call state.highstate test=true
...
          ID: apache-user
    Function: user.present
        Name: apache
      Result: None
     Comment: The following user attributes are set to be changed:
              passwd: PLAINTEXTPASSWORD
     Started: 15:24:09.868957
    Duration: 2.901 ms
     Changes:
### New Behavior

The password is not displayed when running with test=true

Same state as above.

[root@84bd62911587 /]# salt-call state.highstate test=true
...
          ID: apache-user
    Function: user.present
        Name: apache
      Result: None
     Comment: The following user attributes are set to be changed:
              passwd: XXX-REDACTED-XXX
     Started: 15:26:32.891816
    Duration: 2.035 ms
     Changes:
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
