### PR TITLE
Unit file changes for 2015.8.12, 2016.3.3

### DIFF
--- a/pkg/salt-api.service
+++ b/pkg/salt-api.service
@@ -3,7 +3,7 @@ Description=The Salt API
 After=network.target
 
 [Service]
-Type=simple
+Type=notify
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-api
 TimeoutStopSec=3

--- a/pkg/salt-master.service
+++ b/pkg/salt-master.service
@@ -7,7 +7,6 @@ LimitNOFILE=16384
 Type=notify
 NotifyAccess=all
 ExecStart=/usr/bin/salt-master
-KillMode=process
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/salt-minion.service
+++ b/pkg/salt-minion.service
@@ -3,10 +3,9 @@ Description=The Salt Minion
 After=network.target
 
 [Service]
-Type=simple
+Type=notify
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-minion
-KillMode=process
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/salt-syndic.service
+++ b/pkg/salt-syndic.service
@@ -3,7 +3,7 @@ Description=The Salt Master Server
 After=network.target
 
 [Service]
-Type=simple
+Type=notify
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-syndic
 


### PR DESCRIPTION
This makes changes necessary to fully support systemd notification for all salt daemons, and disables `KillMode` to allow systemd to bring down the entire cgroup when restarting the service.