### PR TITLE
Correctly check if image is in current tags

### DIFF
--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -572,7 +572,13 @@ def image_present(name,
     image = ':'.join(_get_repo_tag(name))
     all_tags = __salt__['dockerng.list_tags']()
 
-    if image in all_tags:
+    image_in_tags = False
+    for tag in __salt__['dockerng.list_tags']():
+        if tag.endswith(image):
+            image_in_tags = True
+            break
+
+    if image_in_tags:
         if not force:
             ret['result'] = True
             ret['comment'] = 'Image \'{0}\' already present'.format(name)
@@ -596,7 +602,7 @@ def image_present(name,
 
     if __opts__['test']:
         ret['result'] = None
-        if (image in all_tags and force) or image not in all_tags:
+        if (image_in_tags and force) or image not in all_tags:
             ret['comment'] = 'Image \'{0}\' will be {1}'.format(name, action)
             return ret
 
@@ -649,9 +655,7 @@ def image_present(name,
             # Only add to the changes dict if layers were pulled
             ret['changes'] = image_update
 
-    ret['result'] = image in __salt__['dockerng.list_tags']()
-
-    if not ret['result']:
+    if not image_in_tags:
         # This shouldn't happen, failure to pull should be caught above
         ret['comment'] = 'Image \'{0}\' could not be {1}'.format(name, action)
     elif not ret['changes']:


### PR DESCRIPTION
### What does this PR do?

According to Docker conventions, if you are using the official Docker Hub, you can leave the repository url out of a valid image name. While all the docker commands still work with salt if you do this, checks to confirm successful commands will fail
### Previous Behavior

Salt previously required exact image name matches, including registry url
### New Behavior

Salt now only requires you to match a suffix of the tag, since repository url is optional for docker hub
### Tests written?

No(t yet)

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
