### PR TITLE
Fix localemod tests

### DIFF
--- a/tests/unit/modules/localemod_test.py
+++ b/tests/unit/modules/localemod_test.py
@@ -58,7 +58,7 @@ class LocalemodTestCase(TestCase):
                 self.assertEqual('A', localemod.get_locale())
                 localemod._parse_localectl.assert_called_once_with()
 
-        with patch.dict(localemod.__context__, {'systemd.sd_booted': False}):
+        with patch.dict(localemod.__context__, {'salt.utils.systemd.booted': False}):
             with patch.dict(localemod.__grains__, {'os_family': ['Gentoo']}):
                 with patch.dict(localemod.__salt__, {'cmd.run': MagicMock(return_value='A')}):
                     self.assertEqual(localemod.get_locale(), 'A')
@@ -78,7 +78,7 @@ class LocalemodTestCase(TestCase):
             with patch.object(localemod, '_localectl_set', return_value=True):
                 self.assertTrue(localemod.set_locale('l'))
 
-        with patch.dict(localemod.__context__, {'systemd.sd_booted': False}):
+        with patch.dict(localemod.__context__, {'salt.utils.systemd.booted': False}):
             with patch.dict(localemod.__grains__, {'os_family': ['Gentoo']}):
                 with patch.dict(localemod.__salt__, {'cmd.retcode': MagicMock(return_value='A')}):
                     self.assertFalse(localemod.set_locale('l'))


### PR DESCRIPTION
This changes the mocking for the context variables to reflect changes
made in 5b12f03.