### PR TITLE
Update linux_sysctl tests to reflect new context key

### DIFF
--- a/salt/utils/systemd.py
+++ b/salt/utils/systemd.py
@@ -17,9 +17,10 @@ log = logging.getLogger(__name__)
 
 def booted(context=None):
     '''
-    Return True if the system was booted with systemd, False otherwise.
-    Pass in the loader context "__context__", this function will set the
-    systemd.sd_booted key to represent if systemd is running
+    Return True if the system was booted with systemd, False otherwise.  If the
+    loader context dict ``__context__`` is passed, this function will set the
+    ``salt.utils.systemd.booted`` key to represent if systemd is running and
+    keep the logic below from needing to be run again during the same salt run.
     '''
     contextkey = 'salt.utils.systemd.booted'
     if isinstance(context, dict):

--- a/tests/unit/modules/linux_sysctl_test.py
+++ b/tests/unit/modules/linux_sysctl_test.py
@@ -113,7 +113,7 @@ class LinuxSysctlTestCase(TestCase):
                             {'cmd.run_stdout': mock_sys_cmd,
                              'cmd.run_all': mock_asn_cmd}):
                 with patch.dict(systemd.__context__,
-                                {'systemd.sd_booted': True}):
+                                {'salt.utils.systemd.booted': True}):
                     linux_sysctl.persist('net.ipv4.ip_forward', 1)
                     helper_open = m_open()
                     helper_open.write.assert_called_once_with(
@@ -136,7 +136,7 @@ class LinuxSysctlTestCase(TestCase):
                             {'cmd.run_stdout': mock_sys_cmd,
                              'cmd.run_all': mock_asn_cmd}):
                 with patch.dict(systemd.__context__,
-                                {'systemd.sd_booted': True}):
+                                {'salt.utils.systemd.booted': True}):
                     self.assertEqual(linux_sysctl.persist(
                                      'net.ipv4.ip_forward', 1), 'Updated')
 


### PR DESCRIPTION
This key was changed in 5b12f03, this updates the tests to reflect the
change.