### PR TITLE
Fix 35420,  add run_on_start in build_schedule_item

### DIFF
--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -359,14 +359,9 @@ def build_schedule_item(name, **kwargs):
             schedule[name]['splay'] = kwargs['splay']
 
     for item in ['range', 'when', 'once', 'once_fmt', 'cron', 'returner',
-                 'return_config', 'return_kwargs', 'until', 'enabled']:
+                 'return_config', 'return_kwargs', 'until', 'run_on_start']:
         if item in kwargs:
             schedule[name][item] = kwargs[item]
-
-    # if enabled is not included in the job,
-    # assume job is enabled.
-    if 'enabled' not in kwargs:
-        schedule[name]['enabled'] = True
 
     return schedule[name]
 

--- a/salt/states/schedule.py
+++ b/salt/states/schedule.py
@@ -117,6 +117,10 @@ def present(name,
         using the crontab format.
         Requires python-croniter.
 
+    run_on_start
+        Whether the job will run when Salt minion start.  Value should be
+        a boolean.
+
     function
         The function that should be executed by the scheduled job.
 


### PR DESCRIPTION
### What does this PR do?

Fix https://github.com/saltstack/salt/issues/35420
more than that, remove redundant code on setting `enabled` as it is already set in line 344.
### What issues does this PR fix or reference?
### Previous Behavior

As https://github.com/saltstack/salt/issues/35420 described
### New Behavior

run_on_start will be effective when it is set `False` (by default, it is `True`)
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
