### PR TITLE
Add 'os_family' grain mapping for FedBerry

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1025,6 +1025,7 @@ _OS_FAMILY_MAP = {
     'Fedora': 'RedHat',
     'Chapeau': 'RedHat',
     'Korora': 'RedHat',
+    'FedBerry': 'RedHat',
     'CentOS': 'RedHat',
     'GoOSe': 'RedHat',
     'Scientific': 'RedHat',


### PR DESCRIPTION
### What does this PR do?

This PR adds mapping from `os` grain '[FedBerry](http://fedberry.org)' (Fedora remix for Raspberry Pi) to `os_family` grain 'RedHat'. 
### What issues does this PR fix or reference?

Without this mapping, `yumpkg` does not get loaded to provide `pkg`.
### Tests written?

No