### PR TITLE
Fix dunder virtual for runit execution module

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1185,7 +1185,7 @@ def os_data():
             os=grains['os'],
             ver=grains['osrelease'])
 
-        grains['init'] = 'windows'
+        grains['init'] = 'Windows'
 
         return grains
     elif salt.utils.is_linux():

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1185,6 +1185,8 @@ def os_data():
             os=grains['os'],
             ver=grains['osrelease'])
 
+        grains['init'] = 'windows'
+
         return grains
     elif salt.utils.is_linux():
         # Add SELinux grain, if you have it
@@ -1455,6 +1457,7 @@ def os_data():
         grains['osfullname'] = "{0} {1}".format(osname, osrelease)
         grains['osrelease'] = osrelease
         grains['osbuild'] = osbuild
+        grains['init'] = 'launchd'
         grains.update(_bsd_cpudata(grains))
         grains.update(_osx_gpudata())
         grains.update(_osx_platform_data())

--- a/salt/modules/runit.py
+++ b/salt/modules/runit.py
@@ -88,7 +88,7 @@ def __virtual__():
     Virtual service only on systems using runit as init process (PID 1).
     Otherwise, use this module with the provider mechanism.
     '''
-    if __grains__['init'] == 'runit':
+    if __grains__.get('init') == 'runit':
         if __grains__['os'] == 'Void':
             add_svc_avail_path('/etc/sv')
         return __virtualname__

--- a/salt/modules/runit.py
+++ b/salt/modules/runit.py
@@ -88,7 +88,7 @@ def __virtual__():
     Virtual service only on systems using runit as init process (PID 1).
     Otherwise, use this module with the provider mechanism.
     '''
-    if __grains__.get('init') == 'runit':
+    if __grains__['init'] == 'runit':
         if __grains__['os'] == 'Void':
             add_svc_avail_path('/etc/sv')
         return __virtualname__


### PR DESCRIPTION
### What does this PR do?

Uses 'get' to pull the 'init' grain. This was failing on os's where there is no 'init' grain.
### What issues does this PR fix or reference?

https://github.com/saltstack/zh/issues/900
### Previous Behavior

```
[ERROR   ] Exception raised when processing __virtual__ function for runit. Module will not be loaded 'init'
[WARNING ] salt.loaded.int.module.runit.__virtual__() is wrongly returning `None`. It should either return `True`, `False` or a new name. If you're the developer of the module 'runit', please fix this.
```
### New Behavior

no error
### Tests written?

NA
