### PR TITLE
Pass makedirs from cp.get_url through to fileclient

### DIFF
--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -278,7 +278,7 @@ def get_dir(path, dest, saltenv='base', template=None, gzip=None, **kwargs):
     return _client().get_dir(path, dest, saltenv, gzip)
 
 
-def get_url(path, dest, saltenv='base'):
+def get_url(path, dest, saltenv='base', makedirs=False):
     '''
     Used to get a single file from a URL.
 
@@ -294,9 +294,9 @@ def get_url(path, dest, saltenv='base'):
         salt '*' cp.get_url http://www.slashdot.org /tmp/index.html
     '''
     if dest:
-        return _client().get_url(path, dest, False, saltenv)
+        return _client().get_url(path, dest, makedirs, saltenv)
     else:
-        return _client().get_url(path, None, False, saltenv, no_cache=True)
+        return _client().get_url(path, None, makedirs, saltenv, no_cache=True)
 
 
 def get_file_str(path, saltenv='base'):

--- a/tests/integration/modules/cp.py
+++ b/tests/integration/modules/cp.py
@@ -164,6 +164,24 @@ class CPModuleTest(integration.ModuleCase):
             self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
             self.assertNotIn('bacon', data)
 
+    def test_get_url_makedirs(self):
+        '''
+        cp.get_url
+        '''
+        tgt = os.path.join(integration.TMP, 'make/dirs/scene33')
+        self.run_function(
+               'cp.get_url',
+                [
+                    'salt://grail/scene33',
+                    tgt,
+                ],
+                makedirs=True
+            )
+        with salt.utils.fopen(tgt, 'r') as scene:
+            data = scene.read()
+            self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
+            self.assertNotIn('bacon', data)
+
     def test_get_url_https(self):
         '''
         cp.get_url with https:// source


### PR DESCRIPTION
### What does this PR do?

Pass makedirs=X down to fileclient in keeping with other methods that offer it. Is currently hard set to False.
### Previous Behavior

```
salt 'w12*' cp.get_url 'http://slashdot.org/' C:\\TEST\\index.html makedirs=True
w12-cl1.salt.local:
    ERROR executing 'cp.get_url': The following keyword arguments are not valid: makedirs=True
```
### New Behavior

```
salt 'w12*' cp.get_url 'http://slashdot.org/' C:\\TEST\\index.html makedirs=True
w12-cl1.salt.local:
    C:\TEST\index.html
```
### Tests written?

Yes
