### PR TITLE
Provide useful hints for error "No contents found"

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2606,7 +2606,10 @@ class BaseHighState(object):
                 )
 
         if found == 0:
-            log.error('No contents found in top file')
+            log.error('No contents found in top file. Please verify '
+                'that the \'file_roots\' specified in \'etc/master\' are '
+                'accessible: {0}'.format(repr(self.state.opts['file_roots']))
+            )
 
         # Search initial top files for includes
         for saltenv, ctops in six.iteritems(tops):


### PR DESCRIPTION
### What does this PR do?

Improve the error message produced by `salt-ssh` or `salt` when a `file_root` path is not inaccessible.
### What issues does this PR fix or reference?
### Previous Behavior

```
[ERROR   ] No contents found in top file.
```
### New Behavior

```
[ERROR   ] No contents found in top file. Please verify that the 'file_roots' specified in 'etc/master' are accessible: {'base': ['/home/eradman/hg/salT']}
```
