### PR TITLE
Boto lambda test fix

### DIFF
--- a/tests/unit/state_test.py
+++ b/tests/unit/state_test.py
@@ -59,7 +59,7 @@ class StateCompilerTestCase(TestCase):
             minion_opts['pillar'] = {'git': OrderedDict([('test1', 'test')])}
             state_obj = salt.state.State(minion_opts)
             with self.assertRaises(salt.exceptions.SaltRenderError):
-            state_obj.call_high(high_data)
+                state_obj.call_high(high_data)
 
 
 if __name__ == '__main__':

--- a/tests/unit/state_test.py
+++ b/tests/unit/state_test.py
@@ -48,7 +48,7 @@ class StateCompilerTestCase(TestCase):
         salt.state.format_log(ret)
 
     @skipIf(sys.version_info < (2, 7), 'Context manager in assertEquals only available in > Py2.7')
-    def test_render_error_on_invalid_requisite(self, state_patch):
+    def test_render_error_on_invalid_requisite(self):
         '''
         Test that the state compiler correctly deliver a rendering
         exception when a requisite cannot be resolved

--- a/tests/unit/state_test.py
+++ b/tests/unit/state_test.py
@@ -48,17 +48,17 @@ class StateCompilerTestCase(TestCase):
         salt.state.format_log(ret)
 
     @skipIf(sys.version_info < (2, 7), 'Context manager in assertEquals only available in > Py2.7')
-    @patch('salt.state.State._gather_pillar')
     def test_render_error_on_invalid_requisite(self, state_patch):
         '''
         Test that the state compiler correctly deliver a rendering
         exception when a requisite cannot be resolved
         '''
-        high_data = {'git': OrderedDict([('pkg', [OrderedDict([('require', [OrderedDict([('file', OrderedDict([('test1', 'test')]))])])]), 'installed', {'order': 10000}]), ('__sls__', u'issue_35226'), ('__env__', 'base')])}
-        minion_opts = salt.config.minion_config(os.path.join(TMP_CONF_DIR, 'minion'))
-        minion_opts['pillar'] = {'git': OrderedDict([('test1', 'test')])}
-        state_obj = salt.state.State(minion_opts)
-        with self.assertRaises(salt.exceptions.SaltRenderError):
+        with patch('salt.state.State._gather_pillar'):
+            high_data = {'git': OrderedDict([('pkg', [OrderedDict([('require', [OrderedDict([('file', OrderedDict([('test1', 'test')]))])])]), 'installed', {'order': 10000}]), ('__sls__', u'issue_35226'), ('__env__', 'base')])}
+            minion_opts = salt.config.minion_config(os.path.join(TMP_CONF_DIR, 'minion'))
+            minion_opts['pillar'] = {'git': OrderedDict([('test1', 'test')])}
+            state_obj = salt.state.State(minion_opts)
+            with self.assertRaises(salt.exceptions.SaltRenderError):
             state_obj.call_high(high_data)
 
 


### PR DESCRIPTION
### What does this PR do?

the patch decorator in unit/state_test.py was interfering with boto_lambda_test.py and causing a test failure. I moved the patch to be a context manager instead so it no longer interferes. 

I honestly don't know why it was interfering so if this is the wrong approach, let me know. 
### What issues does this PR fix or reference?

Fixes test failure on jenkins
### Tests written?

Yes
