### PR TITLE
Fix case where the printer functions would modify the event system

### DIFF
--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -814,9 +814,9 @@ class NamespacedEvent(object):
         self.print_func = print_func
 
     def fire_event(self, data, tag):
+        self.event.fire_event(data, tagify(tag, base=self.base))
         if self.print_func is not None:
             self.print_func(tag, data)
-        self.event.fire_event(data, tagify(tag, base=self.base))
 
 
 class MinionEvent(SaltEvent):


### PR DESCRIPTION
There was a case where the printer func passed into NamespacedEvent
could modify the data which was then passed onto the event bus. This,
in turn, would do things like converting ints to strings. This,
in turn, would then break when the master picked up the data on the
other end of the event bus and did things like pass that data to the
outputter system which was (in this case) expecting an int.

Resolves this test case: integration.runners.state.StateRunnerTest.test_orchestrate_output
