### PR TITLE
Wrap the test in a try/finally to ensure that the keys get cleaned up.

### DIFF
--- a/tests/integration/shell/call.py
+++ b/tests/integration/shell/call.py
@@ -305,7 +305,6 @@ class CallTest(integration.ShellCase, testprogram.TestProgramCase, integration.S
             if os.path.isfile(this_minion_key):
                 os.unlink(this_minion_key)
 
-
     def test_issue_7754(self):
         old_cwd = os.getcwd()
         config_dir = os.path.join(integration.TMP, 'issue-7754')


### PR DESCRIPTION
We're seeing the keys appear later on in some tests, such as here:

integration.modules.saltutil.SaltUtilModuleTest.test_wheel_just_function
