### PR TITLE
Fix user.present state reporting for groups when remove_groups=false

### DIFF
--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -464,6 +464,8 @@ def present(name,
             for key, val in iteritems(changes):
                 if key == 'password':
                     val = 'XXX-REDACTED-XXX'
+                elif key == 'group' and not remove_groups:
+                    key = 'ensure groups'
                 ret['comment'] += u'{0}: {1}\n'.format(key, val)
             return ret
         # The user is present


### PR DESCRIPTION
### What does this PR do?

Right now when you test a highstate (`test=true`) for a `user.present` state which contains a value for `groups`, there is no difference between the output when `remove_groups` = true, vs when it is false. This can be quite confusing and requires you to dig into the relevant state file to be sure that you've got the correct `remove_groups` setting (or else actually run the highstate, and then check after to make sure that groups was not mangled).
### What issues does this PR fix or reference?
### Previous Behavior

`remove_groups` (true or false) did not have any effect on the output of a highstate test.
### New Behavior

Now the output gives a clearer indication of the changes to be done with regards to grouping ("ensure groups:" is used when `removed_groups` is set to false; otherwise the regular `groups:` is used when `removed_groups` is true):

```
# salt min6 state.highstate test=true

...

          ID: user-jf
    Function: user.present
        Name: jf
      Result: None
     Comment: The following user attributes are set to be changed:
              ensure groups: ['sudo', 'www-data']
     Started: 20:57:33.909938
    Duration: 1.286 ms
     Changes:
```
### Tests written?

No new tests.
