### PR TITLE
fix 34922, StopIteration should not throw exception out

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -53,15 +53,17 @@ class Batch(object):
 
         ping_gen = self.local.cmd_iter(*args, **self.eauth)
 
+        # Broadcast to targets
         fret = set()
         try:
             for ret in ping_gen:
                 m = next(six.iterkeys(ret))
                 if m is not None:
                     fret.add(m)
-            return (list(fret), ping_gen)
         except StopIteration:
-            raise salt.exceptions.SaltClientError('No minions matched the target.')
+            if not self.quiet:
+                print_cli('No minions matched the target.')
+        return list(fret), ping_gen
 
     def get_bnum(self):
         '''
@@ -101,6 +103,9 @@ class Batch(object):
                 'list',
                 ]
         bnum = self.get_bnum()
+        # No targets to run
+        if not self.minions:
+            return
         to_run = copy.deepcopy(self.minions)
         active = []
         ret = {}


### PR DESCRIPTION
### What does this PR do?

This is part of fixing https://github.com/saltstack/salt/issues/34922. 

More importantly, although it takes me a while to understand the case whether it is needed to raise an exception when no minion match the target, after go through the code base and careful consideration, I think it doesn't make sense to throw an exception and do not catch it till cmd interface when no minion match the target. Here are the reasons:
1. No other cases in the entire code base that throw another exception when catch `StopIteration`
2. Stop throwing exception `No minions matched the target.` can address the concerns in https://github.com/saltstack/salt/issues/34922 or similar. 
3. In general, no minion match the target need logic in code to take care of, which may end up with noop, but definitely not to throw an exception
4. This issue is introduced in https://github.com/saltstack/salt/commit/1600f3eccdc8a02f85dcfe4aea12d3e7ee15bc62 to fix https://github.com/saltstack/salt/issues/26343, where code itself should handle the scenario rather than fail the users. 
5. Uncaught exception in initialization phase (`__gather_minions`) is not a good practice.  

Please take a look and feel free to challenge me or provide a feedback. I am glad to learn and help;)
### What issues does this PR fix or reference?
### Previous Behavior

Batch run such as `salt 'no_match*' -b 20 test.ping` will exit with `No minions matched the target. No command was sent, no jid was assigned.` and code 1.

As the https://github.com/saltstack/salt/issues/34922 reports, `Comment` field will be filled with stacktrace and `Result: False`
### New Behavior

Batch run such as `salt 'no_match*' -b 20 test.ping` will exit with `No minions matched the target. No command was sent, no jid was assigned.` and code 0.

For https://github.com/saltstack/salt/issues/34922, no stacktrace in `Comment` and `Result: True`
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
