### PR TITLE
Fix wheel test to call correct wheel function

### DIFF
--- a/tests/integration/wheel/client.py
+++ b/tests/integration/wheel/client.py
@@ -65,7 +65,7 @@ class WheelModuleTest(integration.TestCase, integration.AdaptedConfigurationTest
     def test_cmd_sync(self):
         low = {
             'client': 'wheel',
-            'fun': 'key.list_keys',
+            'fun': 'key.list_all',
         }
         low.update(self.eauth_creds)
 
@@ -74,7 +74,7 @@ class WheelModuleTest(integration.TestCase, integration.AdaptedConfigurationTest
     def test_cmd_async(self):
         low = {
             'client': 'wheel_async',
-            'fun': 'key.list_keys',
+            'fun': 'key.list_all',
         }
         low.update(self.eauth_creds)
 


### PR DESCRIPTION
This was not causing a test failure because no asserts were being
made but it was throwing exceptions in the logs. This cleans that up.
