### PR TITLE
Add Nitrogen release notes 

### DIFF
--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -1,0 +1,12 @@
+:orphan:
+
+======================================
+Salt Release Notes - Codename Nitrogen
+======================================
+
+Grains Changes
+==============
+
+- The ``os_release`` grain has been changed from a string to an integer.
+  State files, especially those using a templating language like Jinja
+  may need to be adjusted to account for this change.

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1520,7 +1520,6 @@ def os_data():
             osrelease_info[idx] = int(value)
         grains['osrelease_info'] = tuple(osrelease_info)
         grains['osmajorrelease'] = str(grains['osrelease_info'][0])  # This will be an integer in the two releases
-        salt.utils.warn_until('Nitrogen', 'The "osmajorrelease" will be a type of an integer.')
         os_name = grains['os' if grains.get('os') in (
             'FreeBSD', 'OpenBSD', 'NetBSD', 'Mac', 'Raspbian') else 'osfullname']
         grains['osfinger'] = '{0}-{1}'.format(


### PR DESCRIPTION
Remove deprecation warning for core grains. We can't have a deprecation warning thrown for grains on every single salt-call. That's just too much. Documenting in the release notes will be fine.

cc: @isbm 
