### PR TITLE
Support the supression of prints in the wheel module

### DIFF
--- a/salt/wheel/__init__.py
+++ b/salt/wheel/__init__.py
@@ -50,7 +50,7 @@ class WheelClient(salt.client.mixins.SyncClientMixin,
         '''
         Backwards compatibility
         '''
-        return self.low(fun, kwargs)
+        return self.low(fun, kwargs, print_event=low.get('print_event', True), full_return=low.get('full_return', False))
 
     # TODO: Inconsistent with runner client-- the runner client's master_call gives
     # an async return, unlike this

--- a/tests/integration/wheel/client.py
+++ b/tests/integration/wheel/client.py
@@ -35,6 +35,7 @@ class WheelModuleTest(integration.TestCase, integration.AdaptedConfigurationTest
         low = {
             'client': 'wheel',
             'fun': 'key.list_all',
+            'print_event': False
         }
         low.update(self.eauth_creds)
 
@@ -60,12 +61,14 @@ class WheelModuleTest(integration.TestCase, integration.AdaptedConfigurationTest
             'client': 'wheel',
             'fun': 'key.list_all',
             'token': token['token'],
+            'print_event': False,
         })
 
     def test_cmd_sync(self):
         low = {
             'client': 'wheel',
             'fun': 'key.list_all',
+            'print_event': False,
         }
         low.update(self.eauth_creds)
 

--- a/tests/integration/wheel/key.py
+++ b/tests/integration/wheel/key.py
@@ -13,12 +13,12 @@ class KeyWheelModuleTest(integration.TestCase, integration.AdaptedConfigurationT
         self.wheel = salt.wheel.Wheel(dict(self.get_config('client_config')))
 
     def test_list_all(self):
-        ret = self.wheel.call_func('key.list_all')
+        ret = self.wheel.cmd('key.list_all', print_event=False)
         for host in ['minion', 'sub_minion']:
             self.assertIn(host, ret['minions'])
 
     def test_gen(self):
-        ret = self.wheel.call_func('key.gen', id_='soundtechniciansrock')
+        ret = self.wheel.cmd('key.gen', id_='soundtechniciansrock', print_event=False)
 
         self.assertIn('pub', ret)
         self.assertIn('priv', ret)


### PR DESCRIPTION
This will clean up all those pesky key output issues in the wheel tests.
