### PR TITLE
Test a fix for the wheel test [WIP]

### DIFF
--- a/tests/integration/modules/saltutil.py
+++ b/tests/integration/modules/saltutil.py
@@ -22,7 +22,7 @@ class SaltUtilModuleTest(integration.ModuleCase):
     '''
 
     def setUp(self):
-        self.run_function('saltutil.refresh_pillar') 
+        self.run_function('saltutil.refresh_pillar')
 
     # Tests for the wheel function
 
@@ -31,7 +31,7 @@ class SaltUtilModuleTest(integration.ModuleCase):
         Tests using the saltutil.wheel function when passing only a function.
         '''
         # Wait for the pillar refresh to kick in, so that grains are ready to go
-        time.sleep(3) 
+        time.sleep(3)
         ret = self.run_function('saltutil.wheel', ['minions.connected'])
         self.assertIn('minion', ret['return'])
         self.assertIn('sub_minion', ret['return'])

--- a/tests/integration/modules/saltutil.py
+++ b/tests/integration/modules/saltutil.py
@@ -5,6 +5,7 @@ Integration tests for the saltutil module.
 
 # Import Python libs
 from __future__ import absolute_import
+import time
 
 # Import Salt Testing libs
 from salttesting.helpers import ensure_in_syspath
@@ -20,12 +21,17 @@ class SaltUtilModuleTest(integration.ModuleCase):
     Testcase for the saltutil execution module
     '''
 
+    def setUp(self):
+        self.run_function('saltutil.refresh_pillar') 
+
     # Tests for the wheel function
 
     def test_wheel_just_function(self):
         '''
         Tests using the saltutil.wheel function when passing only a function.
         '''
+        # Wait for the pillar refresh to kick in, so that grains are ready to go
+        time.sleep(3) 
         ret = self.run_function('saltutil.wheel', ['minions.connected'])
         self.assertIn('minion', ret['return'])
         self.assertIn('sub_minion', ret['return'])


### PR DESCRIPTION
I think that what is happening here is that we're using stale grains from a previous test. This should hopefully refresh them and allow this test to succeed.

Please don't merge this unless this test passes: `integration.modules.saltutil.SaltUtilModuleTest.test_wheel_just_function`
