### PR TITLE
Speed up /jobs for salt-api when run under cherrypy.

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -1221,10 +1221,14 @@ class Jobs(LowDataAdapter):
         ret = {}
         if jid:
             ret['info'] = [job_ret_info[0]]
-            try:
-                ret['return'] = [dict((k, job_ret_info[0]['Result'][k]['return']) for k in job_ret_info[0]['Result'])]
-            except (TypeError, KeyError):
-                ret['return'] = [{}]
+            minion_ret = {}
+            returns = job_ret_info[0].get('Result')
+            for minion in returns.keys():
+                if u'return' in returns[minion]:
+                    minion_ret[minion] = returns[minion].get(u'return')
+                else:
+                    minion_ret[minion] = returns[minion].get('return')
+            ret['return'] = [minion_ret]
         else:
             ret['return'] = [job_ret_info[0]]
 

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -1220,10 +1220,13 @@ class Jobs(LowDataAdapter):
 
         ret = {}
         if jid:
-            ret['info'] = job_ret_info[0]
-            ret['return'] = [dict((k, job_ret_info[0]['Result'][k]['return']) for k in job_ret_info[0]['Result'])]
+            ret['info'] = [job_ret_info[0]]
+            try:
+                ret['return'] = [dict((k, job_ret_info[0]['Result'][k]['return']) for k in job_ret_info[0]['Result'])]
+            except (TypeError, KeyError):
+                ret['return'] = [{}]
         else:
-            ret['return'] = job_ret_info[0]
+            ret['return'] = [job_ret_info[0]]
 
         return ret
 

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -1210,16 +1210,9 @@ class Jobs(LowDataAdapter):
         '''
         lowstate = [{
             'client': 'runner',
-            'fun': 'jobs.lookup_jid' if jid else 'jobs.list_jobs',
+            'fun': 'jobs.list_job' if jid else 'jobs.list_jobs',
             'jid': jid,
         }]
-
-        if jid:
-            lowstate.append({
-                'client': 'runner',
-                'fun': 'jobs.list_job',
-                'jid': jid,
-            })
 
         cherrypy.request.lowstate = lowstate
         job_ret_info = list(self.exec_lowstate(
@@ -1227,12 +1220,11 @@ class Jobs(LowDataAdapter):
 
         ret = {}
         if jid:
-            job_ret, job_info = job_ret_info
-            ret['info'] = [job_info]
+            ret['info'] = job_ret_info[0]
+            ret['return'] = [dict((k, job_ret_info[0]['Result'][k]['return']) for k in job_ret_info[0]['Result'])]
         else:
-            job_ret = job_ret_info[0]
+            ret['return'] = job_ret_info[0]
 
-        ret['return'] = [job_ret]
         return ret
 
 


### PR DESCRIPTION
### What does this PR do?

This PR increases performance of the /jobs endpoint of rest_cherrypy by eliminating a case where 2 salt runners are executed where only one is necessary.
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

Currently, if a jid is supplied, two runners are run (both
jobs.lookup_jid and jobs.list_job). This is unnecessary because
the return from jobs.list_job contains all of the information
from jobs.lookup_jid as well.

This change runs only jobs.list_job in this case and builds an
appropriate return from the output, netting an ~ 40% decrease
in response time for this endpoint when a jid is supplied.
