### PR TITLE
When configuring master using salt cloud set 'hash_type: sha256' as a defau…

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -263,7 +263,8 @@ def master_config(opts, vm_):
     # Some default options are Null, let's set a reasonable default
     master.update(
         log_level='info',
-        log_level_logfile='info'
+        log_level_logfile='info',
+        hash_type='sha256'
     )
 
     # Get ANY defined master setting, merging data, in the following order


### PR DESCRIPTION
### What does this PR do?

By default salt minion is configured to use `hash_type: sha256` hash when using salt cloud and master should use the same value.
### Tests written?

No
