### PR TITLE
Openstack keystone V3 API support in keystone

### DIFF
--- a/salt/modules/keystone.py
+++ b/salt/modules/keystone.py
@@ -55,6 +55,7 @@ import logging
 
 # Import Salt Libs
 import salt.ext.six as six
+import salt.utils.http
 
 # Import third party libs
 HAS_KEYSTONE = False
@@ -62,10 +63,14 @@ try:
     # pylint: disable=import-error
     from keystoneclient.v2_0 import client
     import keystoneclient.exceptions
-    # pylint: enable=import-error
     HAS_KEYSTONE = True
+    from keystoneclient.v3 import client as client3
+    # pylint: enable=import-error
 except ImportError:
     pass
+
+_OS_IDENTITY_API_VERSION = 2
+_TENANTS = 'tenants'
 
 log = logging.getLogger(__name__)
 
@@ -80,6 +85,26 @@ def __virtual__():
     return (False, 'keystone execution module cannot be loaded: keystoneclient python library not available.')
 
 __opts__ = {}
+
+
+def api_version():
+    '''
+    Returns the API version derived from endpoint's response.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' keystone.api_version
+    '''
+    auth_url = __salt__['config.get']('keystone.auth_url', None)
+    if not auth_url:
+        auth_url = __salt__['config.get']('keystone.endpoint', None)
+    try:
+        return salt.utils.http.query(auth_url, decode=True, decode_type='json',
+                                     verify_ssl=False)['dict']['version']['id']
+    except KeyError:
+        return None
 
 
 def auth(profile=None, **connection_args):
@@ -98,10 +123,12 @@ def auth(profile=None, **connection_args):
     else:
         prefix = "keystone."
 
-    # look in connection_args first, then default to config file
     def get(key, default=None):
+        '''
+        look in connection_args first, then default to config file
+        '''
         return connection_args.get('connection_' + key,
-            __salt__['config.get'](prefix + key, default))
+                                   __salt__['config.get'](prefix + key, default))
 
     user = get('user', 'admin')
     password = get('password', 'ADMIN')
@@ -126,7 +153,14 @@ def auth(profile=None, **connection_args):
         if insecure:
             kwargs['insecure'] = True
 
-    return client.Client(**kwargs)
+    if api_version() >= 'v3':
+        global _OS_IDENTITY_API_VERSION
+        global _TENANTS
+        _OS_IDENTITY_API_VERSION = 3
+        _TENANTS = 'projects'
+        return client3.Client(**kwargs)
+    else:
+        return client.Client(**kwargs)
 
 
 def ec2_credentials_create(user_id=None, name=None,
@@ -140,9 +174,10 @@ def ec2_credentials_create(user_id=None, name=None,
     .. code-block:: bash
 
         salt '*' keystone.ec2_credentials_create name=admin tenant=admin
+
         salt '*' keystone.ec2_credentials_create \
-user_id=c965f79c4f864eaaa9c3b41904e67082 \
-tenant_id=722787eb540849158668370dc627ec5f
+        user_id=c965f79c4f864eaaa9c3b41904e67082 \
+        tenant_id=722787eb540849158668370dc627ec5f
     '''
     kstone = auth(profile, **connection_args)
 
@@ -175,9 +210,10 @@ def ec2_credentials_delete(user_id=None, name=None, access_key=None,
     .. code-block:: bash
 
         salt '*' keystone.ec2_credentials_delete \
-860f8c2c38ca4fab989f9bc56a061a64 access_key=5f66d2f24f604b8bb9cd28886106f442
+        860f8c2c38ca4fab989f9bc56a061a64 access_key=5f66d2f24f604b8bb9cd28886106f442
+
         salt '*' keystone.ec2_credentials_delete name=admin \
-access_key=5f66d2f24f604b8bb9cd28886106f442
+        access_key=5f66d2f24f604b8bb9cd28886106f442
     '''
     kstone = auth(profile, **connection_args)
 
@@ -199,8 +235,8 @@ def ec2_credentials_get(user_id=None, name=None, access=None,
 
     .. code-block:: bash
 
-        salt '*' keystone.ec2_credentials_get c965f79c4f864eaaa9c3b41904e67082 access=722787eb540849158668370dc627ec5f
-        salt '*' keystone.ec2_credentials_get user_id=c965f79c4f864eaaa9c3b41904e67082 access=722787eb540849158668370dc627ec5f
+        salt '*' keystone.ec2_credentials_get c965f79c4f864eaaa9c3b41904e67082 access=722787eb540849158668370
+        salt '*' keystone.ec2_credentials_get user_id=c965f79c4f864eaaa9c3b41904e67082 access=722787eb540849158668370
         salt '*' keystone.ec2_credentials_get name=nova access=722787eb540849158668370dc627ec5f
     '''
     kstone = auth(profile, **connection_args)
@@ -263,7 +299,7 @@ def endpoint_get(service, profile=None, **connection_args):
 
         salt '*' keystone.endpoint_get nova
     '''
-    kstone = auth(profile, **connection_args)
+    auth(profile, **connection_args)
     services = service_list(profile, **connection_args)
     if service not in services:
         return {'Error': 'Could not find the specified service'}
@@ -287,18 +323,16 @@ def endpoint_list(profile=None, **connection_args):
     '''
     kstone = auth(profile, **connection_args)
     ret = {}
+
     for endpoint in kstone.endpoints.list():
-        ret[endpoint.id] = {'id': endpoint.id,
-                            'region': endpoint.region,
-                            'adminurl': endpoint.adminurl,
-                            'internalurl': endpoint.internalurl,
-                            'publicurl': endpoint.publicurl,
-                            'service_id': endpoint.service_id}
+        ret[endpoint.id] = dict((value, getattr(endpoint, value)) for value in dir(endpoint)
+                                if not value.startswith('_') and
+                                isinstance(getattr(endpoint, value), (unicode, dict, bool)))
     return ret
 
 
 def endpoint_create(service, publicurl=None, internalurl=None, adminurl=None,
-                    region=None, profile=None, **connection_args):
+                    region=None, profile=None, url=None, interface=None, **connection_args):
     '''
     Create an endpoint for an Openstack service
 
@@ -306,19 +340,27 @@ def endpoint_create(service, publicurl=None, internalurl=None, adminurl=None,
 
     .. code-block:: bash
 
-        salt '*' keystone.endpoint_create nova 'http://public/url'
-            'http://internal/url' 'http://adminurl/url' region
+        salt 'v2' keystone.endpoint_create nova 'http://public/url' 'http://internal/url' 'http://adminurl/url' region
+
+        salt 'v3' keystone.endpoint_create nova url='http://public/url' interface='public'
     '''
     kstone = auth(profile, **connection_args)
     keystone_service = service_get(name=service, profile=profile,
                                    **connection_args)
     if not keystone_service or 'Error' in keystone_service:
         return {'Error': 'Could not find the specified service'}
-    kstone.endpoints.create(region=region,
-                            service_id=keystone_service[service]['id'],
-                            publicurl=publicurl,
-                            adminurl=adminurl,
-                            internalurl=internalurl)
+
+    if _OS_IDENTITY_API_VERSION > 2:
+        kstone.endpoints.create(service=keystone_service[service]['id'],
+                                region_id=region,
+                                url=url,
+                                interface=interface)
+    else:
+        kstone.endpoints.create(region=region,
+                                service_id=keystone_service[service]['id'],
+                                publicurl=publicurl,
+                                adminurl=adminurl,
+                                internalurl=internalurl)
     return endpoint_get(service, profile, **connection_args)
 
 
@@ -356,7 +398,7 @@ def role_create(name, profile=None, **connection_args):
     kstone = auth(profile, **connection_args)
     if 'Error' not in role_get(name=name, profile=profile, **connection_args):
         return {'Error': 'Role "{0}" already exists'.format(name)}
-    role = kstone.roles.create(name)
+    kstone.roles.create(name)
     return role_get(name=name, profile=profile, **connection_args)
 
 
@@ -382,8 +424,10 @@ def role_delete(role_id=None, name=None, profile=None,
                 break
     if not role_id:
         return {'Error': 'Unable to resolve role id'}
-    role = role_get(role_id, profile=profile, **connection_args)
+
+    role = kstone.roles.get(role_id)
     kstone.roles.delete(role)
+
     ret = 'Role ID {0} deleted'.format(role_id)
     if name:
         ret += ' ({0})'.format(name)
@@ -412,6 +456,7 @@ def role_get(role_id=None, name=None, profile=None, **connection_args):
     if not role_id:
         return {'Error': 'Unable to resolve role id'}
     role = kstone.roles.get(role_id)
+
     ret[role.name] = {'id': role.id,
                       'name': role.name}
     return ret
@@ -430,8 +475,9 @@ def role_list(profile=None, **connection_args):
     kstone = auth(profile, **connection_args)
     ret = {}
     for role in kstone.roles.list():
-        ret[role.name] = {'id': role.id,
-                          'name': role.name}
+        ret[role.name] = dict((value, getattr(role, value)) for value in dir(role)
+                              if not value.startswith('_') and
+                              isinstance(getattr(role, value), (unicode, dict, bool)))
     return ret
 
 
@@ -448,7 +494,7 @@ def service_create(name, service_type, description=None, profile=None,
 'OpenStack Compute Service'
     '''
     kstone = auth(profile, **connection_args)
-    service = kstone.services.create(name, service_type, description)
+    service = kstone.services.create(name, service_type, description=description)
     return service_get(service.id, profile=profile, **connection_args)
 
 
@@ -467,7 +513,7 @@ def service_delete(service_id=None, name=None, profile=None, **connection_args):
     if name:
         service_id = service_get(name=name, profile=profile,
                                  **connection_args)[name]['id']
-    service = kstone.services.delete(service_id)
+    kstone.services.delete(service_id)
     return 'Keystone service ID "{0}" deleted'.format(service_id)
 
 
@@ -493,10 +539,9 @@ def service_get(service_id=None, name=None, profile=None, **connection_args):
     if not service_id:
         return {'Error': 'Unable to resolve service id'}
     service = kstone.services.get(service_id)
-    ret[service.name] = {'id': service.id,
-                         'name': service.name,
-                         'type': service.type,
-                         'description': service.description}
+    ret[service.name] = dict((value, getattr(service, value)) for value in dir(service)
+                             if not value.startswith('_') and
+                             isinstance(getattr(service, value), (unicode, dict, bool)))
     return ret
 
 
@@ -513,10 +558,9 @@ def service_list(profile=None, **connection_args):
     kstone = auth(profile, **connection_args)
     ret = {}
     for service in kstone.services.list():
-        ret[service.name] = {'id': service.id,
-                             'name': service.name,
-                             'description': service.description,
-                             'type': service.type}
+        ret[service.name] = dict((value, getattr(service, value)) for value in dir(service)
+                                 if not value.startswith('_') and
+                                 isinstance(getattr(service, value), (unicode, dict, bool)))
     return ret
 
 
@@ -533,7 +577,41 @@ def tenant_create(name, description=None, enabled=True, profile=None,
         salt '*' keystone.tenant_create test enabled=False
     '''
     kstone = auth(profile, **connection_args)
-    new = kstone.tenants.create(name, description, enabled)
+    new = getattr(kstone, _TENANTS, None).create(name, description, enabled)
+    return tenant_get(new.id, profile=profile, **connection_args)
+
+
+def project_create(name, domain, description=None, enabled=True, profile=None,
+                   **connection_args):
+    '''
+    Create a keystone project.
+    Overrides keystone tenant_create form api V2. For keystone api V3.
+
+    name
+        The project name, which must be unique within the owning domain.
+
+    domain
+        The domain name.
+
+    description
+        The project description.
+
+    enabled
+        Enables or disables the project.
+
+    profile
+        Configuration profile - if configuration for multiple openstack accounts required.
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' keystone.project_create nova default description='Nova Compute Project'
+        salt '*' keystone.project_create test default enabled=False
+    '''
+    kstone = auth(profile, **connection_args)
+    new = getattr(kstone, _TENANTS, None).create(name=name, domain=domain,
+                                                 description=description, enabled=enabled)
     return tenant_get(new.id, profile=profile, **connection_args)
 
 
@@ -551,18 +629,48 @@ def tenant_delete(tenant_id=None, name=None, profile=None, **connection_args):
     '''
     kstone = auth(profile, **connection_args)
     if name:
-        for tenant in kstone.tenants.list():
+        for tenant in getattr(kstone, _TENANTS, None).list():
             if tenant.name == name:
                 tenant_id = tenant.id
                 break
     if not tenant_id:
         return {'Error': 'Unable to resolve tenant id'}
-    kstone.tenants.delete(tenant_id)
+    getattr(kstone, _TENANTS, None).delete(tenant_id)
     ret = 'Tenant ID {0} deleted'.format(tenant_id)
     if name:
 
         ret += ' ({0})'.format(name)
     return ret
+
+
+def project_delete(project_id=None, name=None, profile=None, **connection_args):
+    '''
+    Delete a project (keystone project-delete).
+    Overrides keystone tenant-delete form api V2. For keystone api V3 only.
+
+    project_id
+        The project id.
+
+    name
+        The project name.
+
+    profile
+        Configuration profile - if configuration for multiple openstack accounts required.
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' keystone.project_delete c965f79c4f864eaaa9c3b41904e67082
+        salt '*' keystone.project_delete project_id=c965f79c4f864eaaa9c3b41904e67082
+        salt '*' keystone.project_delete name=demo
+    '''
+    auth(profile, **connection_args)
+
+    if _OS_IDENTITY_API_VERSION > 2:
+        return tenant_delete(tenant_id=project_id, name=name, profile=None, **connection_args)
+    else:
+        return False
 
 
 def tenant_get(tenant_id=None, name=None, profile=None,
@@ -580,19 +688,50 @@ def tenant_get(tenant_id=None, name=None, profile=None,
     '''
     kstone = auth(profile, **connection_args)
     ret = {}
+
     if name:
-        for tenant in kstone.tenants.list():
+        for tenant in getattr(kstone, _TENANTS, None).list():
             if tenant.name == name:
                 tenant_id = tenant.id
                 break
     if not tenant_id:
         return {'Error': 'Unable to resolve tenant id'}
-    tenant = kstone.tenants.get(tenant_id)
-    ret[tenant.name] = {'id': tenant.id,
-                        'name': tenant.name,
-                        'description': tenant.description,
-                        'enabled': tenant.enabled}
+    tenant = getattr(kstone, _TENANTS, None).get(tenant_id)
+    ret[tenant.name] = dict((value, getattr(tenant, value)) for value in dir(tenant)
+                            if not value.startswith('_') and
+                            isinstance(getattr(tenant, value), (unicode, dict, bool)))
     return ret
+
+
+def project_get(project_id=None, name=None, profile=None, **connection_args):
+    '''
+    Return a specific projects (keystone project-get)
+    Overrides keystone tenant-get form api V2.
+    For keystone api V3 only.
+
+    project_id
+        The project id.
+
+    name
+        The project name.
+
+    profile
+        Configuration profile - if configuration for multiple openstack accounts required.
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' keystone.project_get c965f79c4f864eaaa9c3b41904e67082
+        salt '*' keystone.project_get project_id=c965f79c4f864eaaa9c3b41904e67082
+        salt '*' keystone.project_get name=nova
+    '''
+    auth(profile, **connection_args)
+
+    if _OS_IDENTITY_API_VERSION > 2:
+        return tenant_get(tenant_id=project_id, name=name, profile=None, **connection_args)
+    else:
+        return False
 
 
 def tenant_list(profile=None, **connection_args):
@@ -607,19 +746,42 @@ def tenant_list(profile=None, **connection_args):
     '''
     kstone = auth(profile, **connection_args)
     ret = {}
-    for tenant in kstone.tenants.list():
-        ret[tenant.name] = {'id': tenant.id,
-                            'name': tenant.name,
-                            'description': tenant.description,
-                            'enabled': tenant.enabled}
+
+    for tenant in getattr(kstone, _TENANTS, None).list():
+        ret[tenant.name] = dict((value, getattr(tenant, value)) for value in dir(tenant)
+                                if not value.startswith('_') and
+                                isinstance(getattr(tenant, value), (unicode, dict, bool)))
     return ret
+
+
+def project_list(profile=None, **connection_args):
+    '''
+    Return a list of available projects (keystone projects-list).
+    Overrides keystone tenants-list form api V2.
+    For keystone api V3 only.
+
+    profile
+        Configuration profile - if configuration for multiple openstack accounts required.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' keystone.project_list
+    '''
+    auth(profile, **connection_args)
+
+    if _OS_IDENTITY_API_VERSION > 2:
+        return tenant_list(profile, **connection_args)
+    else:
+        return False
 
 
 def tenant_update(tenant_id=None, name=None, description=None,
                   enabled=None, profile=None, **connection_args):
     '''
     Update a tenant's information (keystone tenant-update)
-    The following fields may be updated: name, email, enabled.
+    The following fields may be updated: name, description, enabled.
     Can only update name if targeting by ID
 
     CLI Examples:
@@ -630,22 +792,68 @@ def tenant_update(tenant_id=None, name=None, description=None,
         salt '*' keystone.tenant_update c965f79c4f864eaaa9c3b41904e67082 name=admin email=admin@domain.com
     '''
     kstone = auth(profile, **connection_args)
+
     if not tenant_id:
-        for tenant in kstone.tenants.list():
+        for tenant in getattr(kstone, _TENANTS, None).list():
             if tenant.name == name:
                 tenant_id = tenant.id
                 break
     if not tenant_id:
         return {'Error': 'Unable to resolve tenant id'}
 
-    tenant = kstone.tenants.get(tenant_id)
+    tenant = getattr(kstone, _TENANTS, None).get(tenant_id)
     if not name:
         name = tenant.name
     if not description:
         description = tenant.description
     if enabled is None:
         enabled = tenant.enabled
-    kstone.tenants.update(tenant_id, name, description, enabled)
+    updated = getattr(kstone, _TENANTS, None).update(tenant_id, name=name, description=description, enabled=enabled)
+
+    return dict((value, getattr(updated, value)) for value in dir(updated)
+                if not value.startswith('_') and
+                isinstance(getattr(updated, value), (unicode, dict, bool)))
+
+
+def project_update(project_id=None, name=None, description=None,
+                   enabled=None, profile=None, **connection_args):
+    '''
+    Update a tenant's information (keystone project-update)
+    The following fields may be updated: name, description, enabled.
+    Can only update name if targeting by ID
+
+    Overrides keystone tenant_update form api V2.
+    For keystone api V3 only.
+
+    project_id
+        The project id.
+
+    name
+        The project name, which must be unique within the owning domain.
+
+    description
+        The project description.
+
+    enabled
+        Enables or disables the project.
+
+    profile
+        Configuration profile - if configuration for multiple openstack accounts required.
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' keystone.project_update name=admin enabled=True
+        salt '*' keystone.project_update c965f79c4f864eaaa9c3b41904e67082 name=admin email=admin@domain.com
+    '''
+    auth(profile, **connection_args)
+
+    if _OS_IDENTITY_API_VERSION > 2:
+        return tenant_update(tenant_id=project_id, name=name, description=description,
+                             enabled=enabled, profile=profile, **connection_args)
+    else:
+        return False
 
 
 def token_get(profile=None, **connection_args):
@@ -679,10 +887,9 @@ def user_list(profile=None, **connection_args):
     kstone = auth(profile, **connection_args)
     ret = {}
     for user in kstone.users.list():
-        ret[user.name] = {'id': user.id,
-                          'name': user.name,
-                          'email': user.email,
-                          'enabled': user.enabled}
+        ret[user.name] = dict((value, getattr(user, value, None)) for value in dir(user)
+                              if not value.startswith('_') and
+                              isinstance(getattr(user, value, None), (unicode, dict, bool)))
         tenant_id = getattr(user, 'tenantId', None)
         if tenant_id:
             ret[user.name]['tenant_id'] = tenant_id
@@ -717,10 +924,10 @@ def user_get(user_id=None, name=None, profile=None, **connection_args):
         log.error(msg)
         return {'Error': msg}
 
-    ret[user.name] = {'id': user.id,
-                      'name': user.name,
-                      'email': user.email,
-                      'enabled': user.enabled}
+    ret[user.name] = dict((value, getattr(user, value, None)) for value in dir(user)
+                          if not value.startswith('_') and
+                          isinstance(getattr(user, value, None), (unicode, dict, bool)))
+
     tenant_id = getattr(user, 'tenantId', None)
     if tenant_id:
         ret[user.name]['tenant_id'] = tenant_id
@@ -728,7 +935,7 @@ def user_get(user_id=None, name=None, profile=None, **connection_args):
 
 
 def user_create(name, password, email, tenant_id=None,
-                enabled=True, profile=None, **connection_args):
+                enabled=True, profile=None, project_id=None, description=None, **connection_args):
     '''
     Create a user (keystone user-create)
 
@@ -736,14 +943,26 @@ def user_create(name, password, email, tenant_id=None,
 
     .. code-block:: bash
 
-        salt '*' keystone.user_create name=jack password=zero email=jack@halloweentown.org tenant_id=a28a7b5a999a455f84b1f5210264375e enabled=True
+        salt '*' keystone.user_create name=jack password=zero email=jack@halloweentown.org \
+        tenant_id=a28a7b5a999a455f84b1f5210264375e enabled=True
     '''
     kstone = auth(profile, **connection_args)
-    item = kstone.users.create(name=name,
-                               password=password,
-                               email=email,
-                               tenant_id=tenant_id,
-                               enabled=enabled)
+
+    if _OS_IDENTITY_API_VERSION > 2:
+        if tenant_id and not project_id:
+            project_id = tenant_id
+        item = kstone.users.create(name=name,
+                                   password=password,
+                                   email=email,
+                                   project_id=project_id,
+                                   enabled=enabled,
+                                   description=description)
+    else:
+        item = kstone.users.create(name=name,
+                                   password=password,
+                                   email=email,
+                                   tenant_id=tenant_id,
+                                   enabled=enabled)
     return user_get(item.id, profile=profile, **connection_args)
 
 
@@ -776,7 +995,7 @@ def user_delete(user_id=None, name=None, profile=None, **connection_args):
 
 
 def user_update(user_id=None, name=None, email=None, enabled=None,
-                tenant=None, profile=None, **connection_args):
+                tenant=None, profile=None, project=None, description=None, **connection_args):
     '''
     Update a user's information (keystone user-update)
     The following fields may be updated: name, email, enabled, tenant.
@@ -805,13 +1024,36 @@ def user_update(user_id=None, name=None, email=None, enabled=None,
         email = user.email
     if enabled is None:
         enabled = user.enabled
-    kstone.users.update(user=user_id, name=name, email=email, enabled=enabled)
-    if tenant:
-        for tnt in kstone.tenants.list():
-            if tnt.name == tenant:
-                tenant_id = tnt.id
-                break
-        kstone.users.update_tenant(user_id, tenant_id)
+
+    if _OS_IDENTITY_API_VERSION > 2:
+        if description is None:
+            description = getattr(user, 'description', None)
+        else:
+            description = str(description)
+
+        project_id = None
+        if project:
+            for proj in kstone.projects.list():
+                if proj.name == project:
+                    project_id = proj.id
+                    break
+        if not project_id:
+            project_id = getattr(user, 'project_id', None)
+
+        kstone.users.update(user=user_id, name=name, email=email, enabled=enabled, description=description,
+                            project_id=project_id)
+    else:
+        kstone.users.update(user=user_id, name=name, email=email, enabled=enabled)
+
+        tenant_id = None
+        if tenant:
+            for tnt in kstone.tenants.list():
+                if tnt.name == tenant:
+                    tenant_id = tnt.id
+                    break
+            if tenant_id:
+                kstone.users.update_tenant(user_id, tenant_id)
+
     ret = 'Info updated for user ID {0}'.format(user_id)
     return ret
 
@@ -832,8 +1074,12 @@ def user_verify_password(user_id=None, name=None, password=None,
     if 'connection_endpoint' in connection_args:
         auth_url = connection_args.get('connection_endpoint')
     else:
-        auth_url = __salt__['config.option']('keystone.endpoint',
-                                         'http://127.0.0.1:35357/v2.0')
+        if _OS_IDENTITY_API_VERSION > 2:
+            auth_url = __salt__['config.option']('keystone.endpoint',
+                                                 'http://127.0.0.1:35357/v3')
+        else:
+            auth_url = __salt__['config.option']('keystone.endpoint',
+                                                 'http://127.0.0.1:35357/v2.0')
 
     if user_id:
         for user in kstone.users.list():
@@ -846,7 +1092,10 @@ def user_verify_password(user_id=None, name=None, password=None,
               'password': password,
               'auth_url': auth_url}
     try:
-        userauth = client.Client(**kwargs)
+        if _OS_IDENTITY_API_VERSION > 2:
+            client3.Client(**kwargs)
+        else:
+            client.Client(**kwargs)
     except (keystoneclient.exceptions.Unauthorized,
             keystoneclient.exceptions.AuthorizationFailure):
         return False
@@ -874,7 +1123,11 @@ def user_password_update(user_id=None, name=None, password=None,
                 break
     if not user_id:
         return {'Error': 'Unable to resolve user id'}
-    kstone.users.update_password(user=user_id, password=password)
+
+    if _OS_IDENTITY_API_VERSION > 2:
+        kstone.users.update(user=user_id, password=password)
+    else:
+        kstone.users.update_password(user=user_id, password=password)
     ret = 'Password updated for user ID {0}'.format(user_id)
     if name:
         ret += ' ({0})'.format(name)
@@ -883,7 +1136,7 @@ def user_password_update(user_id=None, name=None, password=None,
 
 def user_role_add(user_id=None, user=None, tenant_id=None,
                   tenant=None, role_id=None, role=None, profile=None,
-                  **connection_args):
+                  project_id=None, project_name=None, **connection_args):
     '''
     Add role for user in tenant (keystone user-role-add)
 
@@ -898,6 +1151,12 @@ role_id=ce377245c4ec9b70e1c639c89e8cead4
         salt '*' keystone.user_role_add user=admin tenant=admin role=admin
     '''
     kstone = auth(profile, **connection_args)
+
+    if project_id and not tenant_id:
+        tenant_id = project_id
+    elif project_name and not tenant:
+        tenant = project_name
+
     if user:
         user_id = user_get(name=user, profile=profile,
                            **connection_args)[user]['id']
@@ -914,7 +1173,7 @@ role_id=ce377245c4ec9b70e1c639c89e8cead4
         tenant = next(six.iterkeys(tenant_get(tenant_id, profile=profile,
                                               **connection_args)))['name']
     if not tenant_id:
-        return {'Error': 'Unable to resolve tenant id'}
+        return {'Error': 'Unable to resolve tenant/project id'}
 
     if role:
         role_id = role_get(name=role, profile=profile,
@@ -925,14 +1184,17 @@ role_id=ce377245c4ec9b70e1c639c89e8cead4
     if not role_id:
         return {'Error': 'Unable to resolve role id'}
 
-    kstone.roles.add_user_role(user_id, role_id, tenant_id)
-    ret_msg = '"{0}" role added for user "{1}" for "{2}" tenant'
+    if _OS_IDENTITY_API_VERSION > 2:
+        kstone.roles.grant(role_id, user=user_id, project=tenant_id)
+    else:
+        kstone.roles.add_user_role(user_id, role_id, tenant_id)
+    ret_msg = '"{0}" role added for user "{1}" for "{2}" tenant/project'
     return ret_msg.format(role, user, tenant)
 
 
 def user_role_remove(user_id=None, user=None, tenant_id=None,
                      tenant=None, role_id=None, role=None,
-                     profile=None, **connection_args):
+                     profile=None, project_id=None, project_name=None, **connection_args):
     '''
     Remove role for user in tenant (keystone user-role-remove)
 
@@ -947,6 +1209,12 @@ role_id=ce377245c4ec9b70e1c639c89e8cead4
         salt '*' keystone.user_role_remove user=admin tenant=admin role=admin
     '''
     kstone = auth(profile, **connection_args)
+
+    if project_id and not tenant_id:
+        tenant_id = project_id
+    elif project_name and not tenant:
+        tenant = project_name
+
     if user:
         user_id = user_get(name=user, profile=profile,
                            **connection_args)[user]['id']
@@ -963,7 +1231,7 @@ role_id=ce377245c4ec9b70e1c639c89e8cead4
         tenant = next(six.iterkeys(tenant_get(tenant_id, profile=profile,
                                               **connection_args)))['name']
     if not tenant_id:
-        return {'Error': 'Unable to resolve tenant id'}
+        return {'Error': 'Unable to resolve tenant/project id'}
 
     if role:
         role_id = role_get(name=role, profile=profile,
@@ -973,13 +1241,16 @@ role_id=ce377245c4ec9b70e1c639c89e8cead4
     if not role_id:
         return {'Error': 'Unable to resolve role id'}
 
-    kstone.roles.remove_user_role(user_id, role_id, tenant_id)
+    if _OS_IDENTITY_API_VERSION > 2:
+        kstone.roles.revoke(role_id, user=user_id, project=tenant_id)
+    else:
+        kstone.roles.remove_user_role(user_id, role_id, tenant_id)
     ret_msg = '"{0}" role removed for user "{1}" under "{2}" tenant'
     return ret_msg.format(role, user, tenant)
 
 
 def user_role_list(user_id=None, tenant_id=None, user_name=None,
-                   tenant_name=None, profile=None, **connection_args):
+                   tenant_name=None, profile=None, project_id=None, project_name=None, **connection_args):
     '''
     Return a list of available user_roles (keystone user-roles-list)
 
@@ -994,23 +1265,36 @@ tenant_id=7167a092ece84bae8cead4bf9d15bb3b
     '''
     kstone = auth(profile, **connection_args)
     ret = {}
+
+    if project_id and not tenant_id:
+        tenant_id = project_id
+    elif project_name and not tenant_name:
+        tenant_name = project_name
+
     if user_name:
         for user in kstone.users.list():
             if user.name == user_name:
                 user_id = user.id
                 break
     if tenant_name:
-        for tenant in kstone.tenants.list():
+        for tenant in getattr(kstone, _TENANTS, None).list():
             if tenant.name == tenant_name:
                 tenant_id = tenant.id
                 break
     if not user_id or not tenant_id:
-        return {'Error': 'Unable to resolve user or tenant id'}
-    for role in kstone.roles.roles_for_user(user=user_id, tenant=tenant_id):
-        ret[role.name] = {'id': role.id,
-                          'name': role.name,
-                          'user_id': user_id,
-                          'tenant_id': tenant_id}
+        return {'Error': 'Unable to resolve user or tenant/project id'}
+
+    if _OS_IDENTITY_API_VERSION > 2:
+        for role in kstone.roles.list(user=user_id, project=tenant_id):
+            ret[role.name] = dict((value, getattr(role, value)) for value in dir(role)
+                                  if not value.startswith('_') and
+                                  isinstance(getattr(role, value), (unicode, dict, bool)))
+    else:
+        for role in kstone.roles.roles_for_user(user=user_id, tenant=tenant_id):
+            ret[role.name] = {'id': role.id,
+                              'name': role.name,
+                              'user_id': user_id,
+                              'tenant_id': tenant_id}
     return ret
 
 
@@ -1029,10 +1313,10 @@ def _item_list(profile=None, **connection_args):
     ret = []
     for item in kstone.items.list():
         ret.append(item.__dict__)
-        #ret[item.name] = {
-        #        'id': item.id,
-        #        'name': item.name,
-        #        }
+        # ret[item.name] = {
+        #         'id': item.id,
+        #         'name': item.name,
+        #         }
     return ret
 
     # The following is a list of functions that need to be incorporated in the

--- a/salt/modules/keystone.py
+++ b/salt/modules/keystone.py
@@ -56,6 +56,7 @@ import logging
 # Import Salt Libs
 import salt.ext.six as six
 import salt.utils.http
+from salt.ext import six
 
 # Import third party libs
 HAS_KEYSTONE = False
@@ -327,7 +328,7 @@ def endpoint_list(profile=None, **connection_args):
     for endpoint in kstone.endpoints.list():
         ret[endpoint.id] = dict((value, getattr(endpoint, value)) for value in dir(endpoint)
                                 if not value.startswith('_') and
-                                isinstance(getattr(endpoint, value), (unicode, dict, bool)))
+                                isinstance(getattr(endpoint, value), (six.text_type, dict, bool)))
     return ret
 
 
@@ -477,7 +478,7 @@ def role_list(profile=None, **connection_args):
     for role in kstone.roles.list():
         ret[role.name] = dict((value, getattr(role, value)) for value in dir(role)
                               if not value.startswith('_') and
-                              isinstance(getattr(role, value), (unicode, dict, bool)))
+                              isinstance(getattr(role, value), (six.text_type, dict, bool)))
     return ret
 
 
@@ -541,7 +542,7 @@ def service_get(service_id=None, name=None, profile=None, **connection_args):
     service = kstone.services.get(service_id)
     ret[service.name] = dict((value, getattr(service, value)) for value in dir(service)
                              if not value.startswith('_') and
-                             isinstance(getattr(service, value), (unicode, dict, bool)))
+                             isinstance(getattr(service, value), (six.text_type, dict, bool)))
     return ret
 
 
@@ -560,7 +561,7 @@ def service_list(profile=None, **connection_args):
     for service in kstone.services.list():
         ret[service.name] = dict((value, getattr(service, value)) for value in dir(service)
                                  if not value.startswith('_') and
-                                 isinstance(getattr(service, value), (unicode, dict, bool)))
+                                 isinstance(getattr(service, value), (six.text_type, dict, bool)))
     return ret
 
 
@@ -699,7 +700,7 @@ def tenant_get(tenant_id=None, name=None, profile=None,
     tenant = getattr(kstone, _TENANTS, None).get(tenant_id)
     ret[tenant.name] = dict((value, getattr(tenant, value)) for value in dir(tenant)
                             if not value.startswith('_') and
-                            isinstance(getattr(tenant, value), (unicode, dict, bool)))
+                            isinstance(getattr(tenant, value), (six.text_type, dict, bool)))
     return ret
 
 
@@ -750,7 +751,7 @@ def tenant_list(profile=None, **connection_args):
     for tenant in getattr(kstone, _TENANTS, None).list():
         ret[tenant.name] = dict((value, getattr(tenant, value)) for value in dir(tenant)
                                 if not value.startswith('_') and
-                                isinstance(getattr(tenant, value), (unicode, dict, bool)))
+                                isinstance(getattr(tenant, value), (six.text_type, dict, bool)))
     return ret
 
 
@@ -812,7 +813,7 @@ def tenant_update(tenant_id=None, name=None, description=None,
 
     return dict((value, getattr(updated, value)) for value in dir(updated)
                 if not value.startswith('_') and
-                isinstance(getattr(updated, value), (unicode, dict, bool)))
+                isinstance(getattr(updated, value), (six.text_type, dict, bool)))
 
 
 def project_update(project_id=None, name=None, description=None,
@@ -889,7 +890,7 @@ def user_list(profile=None, **connection_args):
     for user in kstone.users.list():
         ret[user.name] = dict((value, getattr(user, value, None)) for value in dir(user)
                               if not value.startswith('_') and
-                              isinstance(getattr(user, value, None), (unicode, dict, bool)))
+                              isinstance(getattr(user, value, None), (six.text_type, dict, bool)))
         tenant_id = getattr(user, 'tenantId', None)
         if tenant_id:
             ret[user.name]['tenant_id'] = tenant_id
@@ -926,7 +927,7 @@ def user_get(user_id=None, name=None, profile=None, **connection_args):
 
     ret[user.name] = dict((value, getattr(user, value, None)) for value in dir(user)
                           if not value.startswith('_') and
-                          isinstance(getattr(user, value, None), (unicode, dict, bool)))
+                          isinstance(getattr(user, value, None), (six.text_type, dict, bool)))
 
     tenant_id = getattr(user, 'tenantId', None)
     if tenant_id:
@@ -1288,7 +1289,7 @@ tenant_id=7167a092ece84bae8cead4bf9d15bb3b
         for role in kstone.roles.list(user=user_id, project=tenant_id):
             ret[role.name] = dict((value, getattr(role, value)) for value in dir(role)
                                   if not value.startswith('_') and
-                                  isinstance(getattr(role, value), (unicode, dict, bool)))
+                                  isinstance(getattr(role, value), (six.text_type, dict, bool)))
     else:
         for role in kstone.roles.roles_for_user(user=user_id, tenant=tenant_id):
             ret[role.name] = {'id': role.id,

--- a/salt/modules/keystone.py
+++ b/salt/modules/keystone.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-Module for handling openstack keystone calls.
+Module for handling openstack keystone calls
 
 :optdepends:    - keystoneclient Python adapter
 :configuration: This module is not usable until the following are specified

--- a/salt/modules/keystone.py
+++ b/salt/modules/keystone.py
@@ -328,7 +328,7 @@ def endpoint_list(profile=None, **connection_args):
     for endpoint in kstone.endpoints.list():
         ret[endpoint.id] = dict((value, getattr(endpoint, value)) for value in dir(endpoint)
                                 if not value.startswith('_') and
-                                isinstance(getattr(endpoint, value), (six.text_type, dict, bool)))
+                                isinstance(getattr(endpoint, value), (six.text_type, dict, bool, str)))
     return ret
 
 
@@ -478,7 +478,7 @@ def role_list(profile=None, **connection_args):
     for role in kstone.roles.list():
         ret[role.name] = dict((value, getattr(role, value)) for value in dir(role)
                               if not value.startswith('_') and
-                              isinstance(getattr(role, value), (six.text_type, dict, bool)))
+                              isinstance(getattr(role, value), (six.text_type, dict, bool, str)))
     return ret
 
 
@@ -542,7 +542,7 @@ def service_get(service_id=None, name=None, profile=None, **connection_args):
     service = kstone.services.get(service_id)
     ret[service.name] = dict((value, getattr(service, value)) for value in dir(service)
                              if not value.startswith('_') and
-                             isinstance(getattr(service, value), (six.text_type, dict, bool)))
+                             isinstance(getattr(service, value), (six.text_type, dict, bool, str)))
     return ret
 
 
@@ -561,7 +561,7 @@ def service_list(profile=None, **connection_args):
     for service in kstone.services.list():
         ret[service.name] = dict((value, getattr(service, value)) for value in dir(service)
                                  if not value.startswith('_') and
-                                 isinstance(getattr(service, value), (six.text_type, dict, bool)))
+                                 isinstance(getattr(service, value), (six.text_type, dict, bool, str)))
     return ret
 
 
@@ -700,7 +700,7 @@ def tenant_get(tenant_id=None, name=None, profile=None,
     tenant = getattr(kstone, _TENANTS, None).get(tenant_id)
     ret[tenant.name] = dict((value, getattr(tenant, value)) for value in dir(tenant)
                             if not value.startswith('_') and
-                            isinstance(getattr(tenant, value), (six.text_type, dict, bool)))
+                            isinstance(getattr(tenant, value), (six.text_type, dict, bool, str)))
     return ret
 
 
@@ -751,7 +751,7 @@ def tenant_list(profile=None, **connection_args):
     for tenant in getattr(kstone, _TENANTS, None).list():
         ret[tenant.name] = dict((value, getattr(tenant, value)) for value in dir(tenant)
                                 if not value.startswith('_') and
-                                isinstance(getattr(tenant, value), (six.text_type, dict, bool)))
+                                isinstance(getattr(tenant, value), (six.text_type, dict, bool, str)))
     return ret
 
 
@@ -813,7 +813,7 @@ def tenant_update(tenant_id=None, name=None, description=None,
 
     return dict((value, getattr(updated, value)) for value in dir(updated)
                 if not value.startswith('_') and
-                isinstance(getattr(updated, value), (six.text_type, dict, bool)))
+                isinstance(getattr(updated, value), (six.text_type, dict, bool, str)))
 
 
 def project_update(project_id=None, name=None, description=None,
@@ -890,7 +890,7 @@ def user_list(profile=None, **connection_args):
     for user in kstone.users.list():
         ret[user.name] = dict((value, getattr(user, value, None)) for value in dir(user)
                               if not value.startswith('_') and
-                              isinstance(getattr(user, value, None), (six.text_type, dict, bool)))
+                              isinstance(getattr(user, value, None), (six.text_type, dict, bool, str)))
         tenant_id = getattr(user, 'tenantId', None)
         if tenant_id:
             ret[user.name]['tenant_id'] = tenant_id
@@ -927,7 +927,7 @@ def user_get(user_id=None, name=None, profile=None, **connection_args):
 
     ret[user.name] = dict((value, getattr(user, value, None)) for value in dir(user)
                           if not value.startswith('_') and
-                          isinstance(getattr(user, value, None), (six.text_type, dict, bool)))
+                          isinstance(getattr(user, value, None), (six.text_type, dict, bool, str)))
 
     tenant_id = getattr(user, 'tenantId', None)
     if tenant_id:
@@ -1289,7 +1289,7 @@ tenant_id=7167a092ece84bae8cead4bf9d15bb3b
         for role in kstone.roles.list(user=user_id, project=tenant_id):
             ret[role.name] = dict((value, getattr(role, value)) for value in dir(role)
                                   if not value.startswith('_') and
-                                  isinstance(getattr(role, value), (six.text_type, dict, bool)))
+                                  isinstance(getattr(role, value), (six.text_type, dict, bool, str)))
     else:
         for role in kstone.roles.roles_for_user(user=user_id, tenant=tenant_id):
             ret[role.name] = {'id': role.id,

--- a/salt/states/keystone.py
+++ b/salt/states/keystone.py
@@ -75,6 +75,22 @@ def __virtual__():
     return 'keystone' if 'keystone.auth' in __salt__ else False
 
 
+_OS_IDENTITY_API_VERSION = 2
+_TENANT_ID = 'tenant_id'
+
+
+def _api_version(**connection_args):
+    '''
+    Sets global variables _OS_IDENTITY_API_VERSION and _TENANT_ID
+    depending on API version.
+    '''
+    global _TENANT_ID
+    global _OS_IDENTITY_API_VERSION
+    if __salt__['keystone.api_version'](**connection_args) >= 'v3':
+        _TENANT_ID = 'project_id'
+        _OS_IDENTITY_API_VERSION = 3
+
+
 def user_present(name,
                  password,
                  email,
@@ -83,6 +99,7 @@ def user_present(name,
                  roles=None,
                  profile=None,
                  password_reset=True,
+                 project=None,
                  **connection_args):
     '''
     Ensure that the keystone user is present with the specified properties.
@@ -100,7 +117,10 @@ def user_present(name,
         The email address for this user
 
     tenant
-        The tenant for this user
+        The tenant (name) for this user
+
+    project
+        The project (name) for this user (overrides tenant in api v3)
 
     enabled
         Availability state for this user
@@ -122,6 +142,11 @@ def user_present(name,
            'result': True,
            'comment': 'User "{0}" will be updated'.format(name)}
 
+    _api_version(**connection_args)
+
+    if project and not tenant:
+        tenant = project
+
     # Validate tenant if set
     if tenant is not None:
         tenantdata = __salt__['keystone.tenant_get'](name=tenant,
@@ -139,53 +164,57 @@ def user_present(name,
     user = __salt__['keystone.user_get'](name=name, profile=profile,
                                          **connection_args)
     if 'Error' not in user:
+
+        change_email = False
+        change_enabled = False
+        change_tenant = False
+        change_password = False
+
+        if user[name].get('email', None) != email:
+            change_email = True
+
+        if user[name].get('enabled', None) != enabled:
+            change_enabled = True
+
+        if tenant and (_TENANT_ID not in user[name] or
+                       user[name].get(_TENANT_ID, None) != tenant_id):
+            change_tenant = True
+
+        if (password_reset is True and
+            not __salt__['keystone.user_verify_password'](name=name,
+                                                          password=password,
+                                                          profile=profile,
+                                                          **connection_args)):
+            change_password = True
+
+        if __opts__['test'] and (change_email or change_enabled or change_tenant or change_password):
+            ret['result'] = None
+            ret['comment'] = 'User "{0}" will been updated'.format(name)
+            return ret
+
         ret['comment'] = 'User "{0}" is already present'.format(name)
-        if user[name]['email'] != email:
-            if __opts__['test']:
-                ret['result'] = None
-                ret['changes']['Email'] = 'Will be updated'
-                return ret
-            __salt__['keystone.user_update'](name=name, email=email,
-                                             profile=profile, **connection_args)
+
+        if change_email:
+            __salt__['keystone.user_update'](name=name, email=email, profile=profile, **connection_args)
             ret['comment'] = 'User "{0}" has been updated'.format(name)
             ret['changes']['Email'] = 'Updated'
-        if user[name]['enabled'] != enabled:
-            if __opts__['test']:
-                ret['result'] = None
-                ret['changes']['Enabled'] = 'Will be {0}'.format(enabled)
-                return ret
-            __salt__['keystone.user_update'](name=name,
-                                             enabled=enabled,
-                                             profile=profile,
-                                             **connection_args)
+
+        if change_enabled:
+            __salt__['keystone.user_update'](name=name, enabled=enabled, profile=profile, **connection_args)
             ret['comment'] = 'User "{0}" has been updated'.format(name)
             ret['changes']['Enabled'] = 'Now {0}'.format(enabled)
-        if tenant and ('tenant_id' not in user[name] or
-                       user[name]['tenant_id'] != tenant_id):
-            if __opts__['test']:
-                ret['result'] = None
-                ret['changes']['Tenant'] = 'Will be added to "{0}" tenant'.format(tenant)
-                return ret
-            __salt__['keystone.user_update'](name=name, tenant=tenant,
-                                             profile=profile,
-                                             **connection_args)
+
+        if change_tenant:
+            __salt__['keystone.user_update'](name=name, tenant=tenant, profile=profile, **connection_args)
             ret['comment'] = 'User "{0}" has been updated'.format(name)
             ret['changes']['Tenant'] = 'Added to "{0}" tenant'.format(tenant)
-        if (password_reset is True and
-              not __salt__['keystone.user_verify_password'](name=name,
-                                                            password=password,
-                                                            profile=profile,
-                                                            **connection_args)):
-            if __opts__['test']:
-                ret['result'] = None
-                ret['changes']['Password'] = 'Will be updated'
-                return ret
-            __salt__['keystone.user_password_update'](name=name,
-                                                      password=password,
-                                                      profile=profile,
+
+        if change_password:
+            __salt__['keystone.user_password_update'](name=name, password=password, profile=profile,
                                                       **connection_args)
             ret['comment'] = 'User "{0}" has been updated'.format(name)
             ret['changes']['Password'] = 'Updated'
+
         if roles:
             for tenant in roles.keys():
                 args = dict({'user_name': name, 'tenant_name':
@@ -195,11 +224,8 @@ def user_present(name,
                     if role not in tenant_roles:
                         if __opts__['test']:
                             ret['result'] = None
-                            if 'roles' in ret['changes']:
-                                ret['changes']['roles'].append(role)
-                            else:
-                                ret['changes']['roles'] = [role]
-                            continue
+                            ret['comment'] = 'User roles "{0}" will been updated'.format(name)
+                            return ret
                         addargs = dict({'user': name, 'role': role,
                                         'tenant': tenant,
                                         'profile': profile},
@@ -213,11 +239,8 @@ def user_present(name,
                 for role in roles_to_remove:
                     if __opts__['test']:
                         ret['result'] = None
-                        if 'roles' in ret['changes']:
-                            ret['changes']['roles'].append(role)
-                        else:
-                            ret['changes']['roles'] = [role]
-                        continue
+                        ret['comment'] = 'User roles "{0}" will been updated'.format(name)
+                        return ret
                     addargs = dict({'user': name, 'role': role,
                                     'tenant': tenant,
                                     'profile': profile},
@@ -232,7 +255,6 @@ def user_present(name,
         if __opts__['test']:
             ret['result'] = None
             ret['comment'] = 'Keystone user "{0}" will be added'.format(name)
-            ret['changes']['User'] = 'Will be created'
             return ret
         __salt__['keystone.user_create'](name=name,
                                          password=password,
@@ -274,7 +296,6 @@ def user_absent(name, profile=None, **connection_args):
         if __opts__['test']:
             ret['result'] = None
             ret['comment'] = 'User "{0}" will be deleted'.format(name)
-            ret['changes']['User'] = 'Will be deleted'
             return ret
         # Delete that user!
         __salt__['keystone.user_delete'](name=name, profile=profile,
@@ -304,50 +325,51 @@ def tenant_present(name, description=None, enabled=True, profile=None,
            'result': True,
            'comment': 'Tenant "{0}" already exists'.format(name)}
 
+    _api_version(**connection_args)
+
     # Check if tenant is already present
     tenant = __salt__['keystone.tenant_get'](name=name,
                                              profile=profile,
                                              **connection_args)
 
     if 'Error' not in tenant:
-        if tenant[name]['description'] != description:
+        if tenant[name].get('description', None) != description:
             if __opts__['test']:
                 ret['result'] = None
-                ret['comment'] = 'Tenant "{0}" will be updated'.format(name)
-                ret['changes']['Description'] = 'Will be updated'
+                ret['comment'] = 'Tenant / project "{0}" will be updated'.format(name)
                 return ret
             __salt__['keystone.tenant_update'](name=name,
                                                description=description,
                                                enabled=enabled,
                                                profile=profile,
                                                **connection_args)
-            ret['comment'] = 'Tenant "{0}" has been updated'.format(name)
+            ret['comment'] = 'Tenant / project "{0}" has been updated'.format(name)
             ret['changes']['Description'] = 'Updated'
-        if tenant[name]['enabled'] != enabled:
+        if tenant[name].get('enabled', None) != enabled:
             if __opts__['test']:
                 ret['result'] = None
-                ret['comment'] = 'Tenant "{0}" will be updated'.format(name)
-                ret['changes']['Enabled'] = 'Will be {0}'.format(enabled)
+                ret['comment'] = 'Tenant / project "{0}" will be updated'.format(name)
                 return ret
             __salt__['keystone.tenant_update'](name=name,
                                                description=description,
                                                enabled=enabled,
                                                profile=profile,
                                                **connection_args)
-            ret['comment'] = 'Tenant "{0}" has been updated'.format(name)
+            ret['comment'] = 'Tenant / project "{0}" has been updated'.format(name)
             ret['changes']['Enabled'] = 'Now {0}'.format(enabled)
     else:
         if __opts__['test']:
             ret['result'] = None
-            ret['comment'] = 'Tenant "{0}" will be added'.format(name)
-            ret['changes']['Tenant'] = 'Will be created'
+            ret['comment'] = 'Tenant / project "{0}" will be added'.format(name)
             return ret
         # Create tenant
-        __salt__['keystone.tenant_create'](name, description, enabled,
-                                           profile=profile,
-                                           **connection_args)
-        ret['comment'] = 'Tenant "{0}" has been added'.format(name)
-        ret['changes']['Tenant'] = 'Created'
+        if _OS_IDENTITY_API_VERSION > 2:
+            ret['changes'] = __salt__['keystone.project_create'](name=name, domain='default', description=description,
+                                                                 enabled=enabled, profile=profile, **connection_args)
+        else:
+            ret['changes'] = __salt__['keystone.tenant_create'](name=name, description=description, enabled=enabled,
+                                                                profile=profile, **connection_args)
+        ret['comment'] = 'Tenant / project "{0}" has been added'.format(name)
     return ret
 
 
@@ -361,7 +383,7 @@ def tenant_absent(name, profile=None, **connection_args):
     ret = {'name': name,
            'changes': {},
            'result': True,
-           'comment': 'Tenant "{0}" is already absent'.format(name)}
+           'comment': 'Tenant / project "{0}" is already absent'.format(name)}
 
     # Check if tenant is present
     tenant = __salt__['keystone.tenant_get'](name=name,
@@ -370,16 +392,63 @@ def tenant_absent(name, profile=None, **connection_args):
     if 'Error' not in tenant:
         if __opts__['test']:
             ret['result'] = None
-            ret['comment'] = 'Tenant "{0}" will be deleted'.format(name)
-            ret['changes']['Tenant'] = 'Will be deleted'
+            ret['comment'] = 'Tenant / project "{0}" will be deleted'.format(name)
             return ret
         # Delete tenant
         __salt__['keystone.tenant_delete'](name=name, profile=profile,
                                            **connection_args)
-        ret['comment'] = 'Tenant "{0}" has been deleted'.format(name)
-        ret['changes']['Tenant'] = 'Deleted'
+        ret['comment'] = 'Tenant / project "{0}" has been deleted'.format(name)
+        ret['changes']['Tenant/Project'] = 'Deleted'
 
     return ret
+
+
+def project_present(name, description=None, enabled=True, profile=None,
+                    **connection_args):
+    '''
+    Ensures that the keystone project exists
+    Alias for tenant_present from V2 API to fulfil
+    V3 API naming convention.
+
+    name
+        The name of the project to manage
+
+    description
+        The description to use for this project
+
+    enabled
+        Availability state for this project
+
+    .. code-block:: yaml
+
+        nova:
+            keystone.project_present:
+                - enabled: True
+                - description: 'Nova Compute Service'
+
+    '''
+
+    return tenant_present(name, description=description, enabled=enabled, profile=profile,
+                          **connection_args)
+
+
+def project_absent(name, profile=None, **connection_args):
+    '''
+    Ensure that the keystone project is absent.
+    Alias for tenant_absent from V2 API to fulfil
+    V3 API naming convention.
+
+    name
+        The name of the project that should not exist
+
+    .. code-block:: yaml
+
+        delete_nova:
+            keystone.project_absent:
+                - name: nova
+    '''
+
+    return tenant_absent(name, profile=profile, **connection_args)
 
 
 def role_present(name, profile=None, **connection_args):
@@ -404,7 +473,6 @@ def role_present(name, profile=None, **connection_args):
         if __opts__['test']:
             ret['result'] = None
             ret['comment'] = 'Role "{0}" will be added'.format(name)
-            ret['changes']['Role'] = 'Will be created'
             return ret
         # Create role
         __salt__['keystone.role_create'](name, profile=profile,
@@ -433,7 +501,6 @@ def role_absent(name, profile=None, **connection_args):
         if __opts__['test']:
             ret['result'] = None
             ret['comment'] = 'Role "{0}" will be deleted'.format(name)
-            ret['changes']['Role'] = 'Will be deleted'
             return ret
         # Delete role
         __salt__['keystone.role_delete'](name=name, profile=profile,
@@ -474,7 +541,6 @@ def service_present(name, service_type, description=None,
         if __opts__['test']:
             ret['result'] = None
             ret['comment'] = 'Service "{0}" will be added'.format(name)
-            ret['changes']['Service'] = 'Will be created'
             return ret
         # Create service
         __salt__['keystone.service_create'](name, service_type,
@@ -483,6 +549,7 @@ def service_present(name, service_type, description=None,
                                             **connection_args)
         ret['comment'] = 'Service "{0}" has been added'.format(name)
         ret['changes']['Service'] = 'Created'
+
     return ret
 
 
@@ -506,7 +573,6 @@ def service_absent(name, profile=None, **connection_args):
         if __opts__['test']:
             ret['result'] = None
             ret['comment'] = 'Service "{0}" will be deleted'.format(name)
-            ret['changes']['Service'] = 'Will be deleted'
             return ret
         # Delete service
         __salt__['keystone.service_delete'](name=name,
@@ -522,68 +588,143 @@ def endpoint_present(name,
                      publicurl=None,
                      internalurl=None,
                      adminurl=None,
-                     region='RegionOne', profile=None, **connection_args):
+                     region='RegionOne',
+                     profile=None,
+                     url=None,
+                     interface=None, **connection_args):
     '''
     Ensure the specified endpoints exists for service
 
     name
         The Service name
 
-    public url
-        The public url of service endpoint
+    publicurl
+        The public url of service endpoint (for V2 API)
 
-    internal url
-        The internal url of service endpoint
+    internalurl
+        The internal url of service endpoint (for V2 API)
 
-    admin url
-        The admin url of the service endpoint
+    adminurl
+        The admin url of the service endpoint (for V2 API)
 
     region
         The region of the endpoint
+
+    url
+        The endpoint URL (for V3 API)
+
+    interface
+        The interface type, which describes the visibility
+        of the endpoint. (for V3 API)
+
     '''
     ret = {'name': name,
            'changes': {},
            'result': True,
-           'comment': 'endpoint for service "{0}" already exists'.format(name)}
+           'comment': 'Endpoint for service "{0}" already exists'.format(name)}
+
+    _api_version(**connection_args)
+
     endpoint = __salt__['keystone.endpoint_get'](name,
                                                  profile=profile,
                                                  **connection_args)
-    cur_endpoint = dict(region=region,
-                        publicurl=publicurl,
-                        adminurl=adminurl,
-                        internalurl=internalurl)
+
     if endpoint and 'Error' not in endpoint:
-        endpoint.pop('id')
-        endpoint.pop('service_id')
-        if endpoint == cur_endpoint:
-            return ret
-        else:
+
+        if endpoint.get('region', None) != region:
             if __opts__['test']:
                 ret['result'] = None
                 ret['comment'] = 'Endpoint for service "{0}" will be updated'.format(name)
-                ret['changes']['endpoint'] = 'Will be updated'
                 return ret
+            ret['comment'] = 'Endpoint for service "{0}" will be updated'.format(name)
+            ret['changes']['Region'] = region
+
+        if _OS_IDENTITY_API_VERSION > 2:
+
+            change_url = False
+            change_interface = False
+
+            if endpoint.get('url', None) != url:
+                change_url = True
+
+            if endpoint.get('interface', None) != interface:
+                change_interface = True
+
+            if __opts__['test'] and (change_url or change_interface):
+                ret['result'] = None
+                ret['comment'] = 'Endpoint for service "{0}" will be updated'.format(name)
+                return ret
+
+            if change_url:
+                ret['comment'] = 'Endpoint for service "{0}" will be updated'.format(name)
+                ret['changes']['url'] = url
+
+            if change_interface:
+                ret['comment'] = 'Endpoint for service "{0}" will be updated'.format(name)
+                ret['changes']['interface'] = interface
+
+        else:
+            change_publicurl = False
+            change_adminurl = False
+            change_internalurl = False
+
+            if endpoint.get('publicurl', None) != publicurl:
+                change_publicurl = True
+
+            if endpoint.get('adminurl', None) != adminurl:
+                change_adminurl = True
+
+            if endpoint.get('internalurl', None) != internalurl:
+                change_internalurl = True
+
+            if __opts__['test'] and (change_publicurl or change_adminurl or change_internalurl):
+                ret['result'] = None
+                ret['comment'] = 'Endpoint for service "{0}" will be updated'.format(name)
+                return ret
+
+            if endpoint.get('publicurl', None) != publicurl:
+                ret['comment'] = 'Endpoint for service "{0}" will be updated'.format(name)
+                ret['changes']['publicurl'] = publicurl
+
+            if endpoint.get('adminurl', None) != adminurl:
+                ret['comment'] = 'Endpoint for service "{0}" will be updated'.format(name)
+                ret['changes']['adminurl'] = adminurl
+
+            if endpoint.get('internalurl', None) != internalurl:
+                ret['comment'] = 'Endpoint for service "{0}" will be updated'.format(name)
+                ret['changes']['internalurl'] = internalurl
+
+        if ret['comment'].endswith('already exists'):
+            return ret
+        else:
             __salt__['keystone.endpoint_delete'](name,
                                                  profile=profile,
                                                  **connection_args)
             ret['comment'] = 'Endpoint for service "{0}" has been updated'.format(name)
+
     else:
         if __opts__['test']:
             ret['result'] = None
             ret['comment'] = 'Endpoint for service "{0}" will be added'.format(name)
-            ret['changes']['endpoint'] = 'Will be created'
             return ret
-        ret['comment'] = 'Endpoint for service "{0}" has been added'.format(name)
 
-    if not __opts__['test']:
-        ret['changes'] = __salt__['keystone.endpoint_create'](
-            name,
-            region=region,
-            publicurl=publicurl,
-            adminurl=adminurl,
-            internalurl=internalurl,
-            profile=profile,
-            **connection_args)
+        elif _OS_IDENTITY_API_VERSION > 2:
+            ret['changes'] = __salt__['keystone.endpoint_create'](
+                name,
+                region=region,
+                url=url,
+                interface=interface,
+                **connection_args)
+        else:
+            ret['changes'] = __salt__['keystone.endpoint_create'](
+                name,
+                region=region,
+                publicurl=publicurl,
+                adminurl=adminurl,
+                internalurl=internalurl,
+                profile=profile,
+                **connection_args)
+        ret['comment'] = 'Endpoint for service "{0}" has been added'.format(name)
     return ret
 
 
@@ -609,7 +750,6 @@ def endpoint_absent(name, profile=None, **connection_args):
         if __opts__['test']:
             ret['result'] = None
             ret['comment'] = 'Endpoint for service "{0}" will be deleted'.format(name)
-            ret['changes']['endpoint'] = 'Will be deleted'
             return ret
         # Delete service
         __salt__['keystone.endpoint_delete'](name,

--- a/salt/states/keystone.py
+++ b/salt/states/keystone.py
@@ -86,10 +86,12 @@ def _api_version(**connection_args):
     '''
     global _TENANT_ID
     global _OS_IDENTITY_API_VERSION
-    if __salt__['keystone.api_version'](**connection_args) >= 'v3':
-        _TENANT_ID = 'project_id'
-        _OS_IDENTITY_API_VERSION = 3
-
+    try:
+        if __salt__['keystone.api_version'](**connection_args) >= 'v3':
+            _TENANT_ID = 'project_id'
+            _OS_IDENTITY_API_VERSION = 3
+    except KeyError:
+        pass
 
 def user_present(name,
                  password,

--- a/tests/unit/modules/keystone_test.py
+++ b/tests/unit/modules/keystone_test.py
@@ -611,7 +611,8 @@ class KeystoneTestCase(TestCase):
         Test if it return a list of available roles (keystone role-list)
         '''
         self.assertDictEqual(keystone.role_list(),
-                             {'nova': {'id': '113', 'name': 'nova'}})
+                             {'nova': {'id': '113', 'name': 'nova', 'tenant_id':
+                              'a1a1', 'user_id': '446'}})
 
     # 'service_create' function tests: 1
 
@@ -740,9 +741,12 @@ class KeystoneTestCase(TestCase):
         Test if it return a list of available users (keystone user-list)
         '''
         self.assertDictEqual(keystone.user_list(),
-                             {'nova': {'email': 'salt@saltstack.com',
-                                       'id': '446', 'name': 'nova',
-                                       'enabled': 'True'}})
+                             {'nova': {'name': 'nova',
+                                       'tenant_id': 'a1a1',
+                                       'enabled': 'True',
+                                       'id': '446',
+                                       'password': 'salt',
+                                       'email': 'salt@saltstack.com'}})
 
     # 'user_get' function tests: 1
 
@@ -754,9 +758,10 @@ class KeystoneTestCase(TestCase):
                              {'Error': 'Unable to resolve user id'})
 
         self.assertDictEqual(keystone.user_get(user_id='446'),
-                             {'nova': {'email': 'salt@saltstack.com',
-                                       'id': '446', 'name': 'nova',
-                                       'enabled': 'True'}})
+                             {'nova': {'name': 'nova', 'tenant_id': 'a1a1',
+                                       'enabled': 'True', 'id': '446',
+                                       'password': 'salt',
+                                       'email': 'salt@saltstack.com'}})
     # 'user_create' function tests: 1
 
     def test_user_create(self, mock):
@@ -766,9 +771,10 @@ class KeystoneTestCase(TestCase):
         self.assertDictEqual(keystone.user_create(name='nova', password='salt',
                                                   email='salt@saltstack.com',
                                                   tenant_id='a1a1'),
-                             {'nova': {'email': 'salt@saltstack.com',
-                                       'id': '446', 'name': 'nova',
-                                       'enabled': 'True'}})
+                             {'nova': {'name': 'nova', 'tenant_id': 'a1a1',
+                                       'enabled': 'True', 'id': '446',
+                                       'password': 'salt',
+                                       'email': 'salt@saltstack.com'}})
 
     # 'user_delete' function tests: 1
 
@@ -832,7 +838,7 @@ class KeystoneTestCase(TestCase):
         '''
         self.assertEqual(keystone.user_role_add(user='nova', tenant='nova',
                                                 role='nova'),
-                         '"nova" role added for user "nova" for "nova" tenant')
+                         '"nova" role added for user "nova" for "nova" tenant/project')
 
         MockRoles.flag = 1
         self.assertDictEqual(keystone.user_role_add(user='nova', tenant='nova',
@@ -883,7 +889,7 @@ class KeystoneTestCase(TestCase):
         (keystone user-roles-list)
         '''
         self.assertDictEqual(keystone.user_role_list(user='nova'),
-                             {'Error': 'Unable to resolve user or tenant id'})
+                             {'Error': 'Unable to resolve user or tenant/project id'})
 
         self.assertDictEqual(keystone.user_role_list(user_name='nova',
                                                      tenant_name='nova'),

--- a/tests/unit/states/keystone_test.py
+++ b/tests/unit/states/keystone_test.py
@@ -214,8 +214,7 @@ class KeystoneTestCase(TestCase):
 
             with patch.dict(keystone.__opts__, {'test': True}):
                 comt = ('Role "{0}" will be added'.format(name))
-                ret.update({'comment': comt, 'result': None,
-                            'changes': {'Role': 'Will be created'}})
+                ret.update({'comment': comt, 'result': None})
                 self.assertDictEqual(keystone.role_present(name), ret)
 
     # 'role_absent' function tests: 1
@@ -261,8 +260,7 @@ class KeystoneTestCase(TestCase):
 
             with patch.dict(keystone.__opts__, {'test': True}):
                 comt = ('Service "{0}" will be added'.format(name))
-                ret.update({'comment': comt, 'result': None,
-                            'changes': {'Service': 'Will be created'}})
+                ret.update({'comment': comt, 'result': None})
                 self.assertDictEqual(keystone.service_present(name,
                                                               service_type),
                                      ret)

--- a/tests/unit/states/keystone_test.py
+++ b/tests/unit/states/keystone_test.py
@@ -124,9 +124,8 @@ class KeystoneTestCase(TestCase):
             self.assertDictEqual(keystone.user_absent(name), ret)
 
             with patch.dict(keystone.__opts__, {'test': True}):
-                comt = ('User "{0}" will be deleted'.format(name))
-                ret.update({'comment': comt, 'result': None,
-                            'changes': {'User': 'Will be deleted'}})
+                comt = 'User "{0}" will be deleted'.format(name)
+                ret.update({'comment': comt, 'result': None})
                 self.assertDictEqual(keystone.user_absent(name), ret)
 
     # 'tenant_present' function tests: 1
@@ -185,16 +184,15 @@ class KeystoneTestCase(TestCase):
         ret = {'name': name,
                'changes': {},
                'result': True,
-               'comment': 'Tenant "{0}" is already absent'.format(name)}
+               'comment': 'Tenant / project "{0}" is already absent'.format(name)}
 
         mock_lst = MagicMock(side_effect=[['Error'], []])
         with patch.dict(keystone.__salt__, {'keystone.tenant_get': mock_lst}):
             self.assertDictEqual(keystone.tenant_absent(name), ret)
 
             with patch.dict(keystone.__opts__, {'test': True}):
-                comt = ('Tenant "{0}" will be deleted'.format(name))
-                ret.update({'comment': comt, 'result': None,
-                            'changes': {'Tenant': 'Will be deleted'}})
+                comt = 'Tenant / project "{0}" will be deleted'.format(name)
+                ret.update({'comment': comt, 'result': None})
                 self.assertDictEqual(keystone.tenant_absent(name), ret)
 
     # 'role_present' function tests: 1
@@ -238,9 +236,8 @@ class KeystoneTestCase(TestCase):
             self.assertDictEqual(keystone.role_absent(name), ret)
 
             with patch.dict(keystone.__opts__, {'test': True}):
-                comt = ('Role "{0}" will be deleted'.format(name))
-                ret.update({'comment': comt, 'result': None,
-                            'changes': {'Role': 'Will be deleted'}})
+                comt = 'Role "{0}" will be deleted'.format(name)
+                ret.update({'comment': comt, 'result': None})
                 self.assertDictEqual(keystone.role_absent(name), ret)
 
     # 'service_present' function tests: 1
@@ -288,9 +285,8 @@ class KeystoneTestCase(TestCase):
             self.assertDictEqual(keystone.service_absent(name), ret)
 
             with patch.dict(keystone.__opts__, {'test': True}):
-                comt = ('Service "{0}" will be deleted'.format(name))
-                ret.update({'comment': comt, 'result': None,
-                            'changes': {'Service': 'Will be deleted'}})
+                comt = 'Service "{0}" will be deleted'.format(name)
+                ret.update({'comment': comt, 'result': None})
                 self.assertDictEqual(keystone.service_absent(name), ret)
 
     # 'endpoint_present' function tests: 1
@@ -360,8 +356,7 @@ class KeystoneTestCase(TestCase):
             with patch.dict(keystone.__opts__, {'test': True}):
                 comt = ('Endpoint for service "{0}" will be deleted'
                         .format(name))
-                ret.update({'comment': comt, 'result': None,
-                            'changes': {'endpoint': 'Will be deleted'}})
+                ret.update({'comment': comt, 'result': None})
                 self.assertDictEqual(keystone.endpoint_absent(name), ret)
 
 


### PR DESCRIPTION
### What does this PR do?

Modified openstack keystone state and execution module to be both usable with new V3 API.
### Previous Behavior

Keystone V2 API support only.
### New Behavior

Supports both openstack keystone V2 and V3 API.
### Tests written?

No
### Previous PR:
#32017
