### PR TITLE
Proxies don't handle reusing the SmartConnect instances very well.  D…

### DIFF
--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -311,7 +311,7 @@ def get_service_instance(host, username=None, password=None, protocol=None,
 
     service_instance = GetSi()
     if service_instance:
-        if salt.utils.is_proxy() or GetStub().host <> ':'.join([host, str(port)]):
+        if salt.utils.is_proxy() or GetStub().host != ':'.join([host, str(port)]):
             # Proxies will fork and mess up the cached service instance.
             # If this is a proxy or we are connecting to a different host
             # invalidate the service instance to avoid a potential memory leak

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -309,7 +309,8 @@ def get_service_instance(host, username=None, password=None, protocol=None,
 
     service_instance = GetSi()
     if service_instance:
-        if salt.utils.is_proxy() or GetStub().host != ':'.join([host, str(port)]):
+        stub = GetStub()
+        if salt.utils.is_proxy() or (hasattr(stub, 'host') and stub.host != ':'.join([host, str(port)])):
             # Proxies will fork and mess up the cached service instance.
             # If this is a proxy or we are connecting to a different host
             # invalidate the service instance to avoid a potential memory leak

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -172,6 +172,8 @@ def _get_service_instance(host, username, password, protocol,
     Internal method to authenticate with a vCenter server or ESX/ESXi host
     and return the service instance object.
     '''
+    import pydevd
+    pydevd.settrace('172.16.207.1', port=65500, stdoutToServer=True, stderrToServer=True)
     log.trace('Retrieving new service instance')
     token = None
     if mechanism == 'userpass':
@@ -207,9 +209,16 @@ def _get_service_instance(host, username, password, protocol,
             port=port,
             b64token=token,
             mechanism=mechanism)
-    except Exception as exc:
+    except TypeError as exc:
+        if 'unexpected keyword argument' in exc.message:
+            log.error('Initial connect to the VMware endpoint failed with {0}'.format(exc.message))
+            log.error('This may mean that a version of PyVmomi EARLIER than 6.0.0.2016.6 is installed.')
+            log.error('We recommend updating to that version or later.')
+            raise
+
         default_msg = 'Could not connect to host \'{0}\'. ' \
                       'Please check the debug log for more information.'.format(host)
+
         try:
             if (isinstance(exc, vim.fault.HostConnectFault) and
                 '[SSL: CERTIFICATE_VERIFY_FAILED]' in exc.msg) or \

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -302,10 +302,10 @@ def get_service_instance(host, username=None, password=None, protocol=None,
 
     service_instance = GetSi()
     if service_instance:
-        if service_instance._GetStub().host == ':'.join([host, str(port)]):
-            log.trace('Using cached service instance')
-            if salt.utils.is_proxy():
-                service_instance._GetStub().GetConnection()
+        if not salt.utils.is_proxy():
+            stub = GetStub()
+            if stub.host == ':'.join([host, str(port)]):
+                return service_instance
         else:
             # Invalidate service instance
             Disconnect(service_instance)

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -87,7 +87,7 @@ import salt.utils
 
 # Import Third Party Libs
 try:
-    from pyVim.connect import GetSi, SmartConnect, Disconnect
+    from pyVim.connect import GetSi, SmartConnect, Disconnect, GetStub
     from pyVmomi import vim, vmodl
     HAS_PYVMOMI = True
 except ImportError:

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -302,14 +302,15 @@ def get_service_instance(host, username=None, password=None, protocol=None,
 
     service_instance = GetSi()
     if service_instance:
-        if not salt.utils.is_proxy():
-            stub = GetStub()
-            if stub.host == ':'.join([host, str(port)]):
-                return service_instance
-        else:
-            # Invalidate service instance
+        if salt.utils.is_proxy() or GetStub().host <> ':'.join([host, str(port)]):
+            # Proxies will fork and mess up the cached service instance.
+            # If this is a proxy or we are connecting to a different host
+            # invalidate the service instance to avoid a potential memory leak
+            # and reconnect
             Disconnect(service_instance)
             service_instance = None
+        else:
+            return service_instance
 
     if not service_instance:
         service_instance = _get_service_instance(host,

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -213,6 +213,7 @@ def _get_service_instance(host, username, password, protocol,
             log.error('This may mean that a version of PyVmomi EARLIER than 6.0.0.2016.6 is installed.')
             log.error('We recommend updating to that version or later.')
             raise
+    except Exception as exc:
 
         default_msg = 'Could not connect to host \'{0}\'. ' \
                       'Please check the debug log for more information.'.format(host)

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -172,8 +172,6 @@ def _get_service_instance(host, username, password, protocol,
     Internal method to authenticate with a vCenter server or ESX/ESXi host
     and return the service instance object.
     '''
-    import pydevd
-    pydevd.settrace('172.16.207.1', port=65500, stdoutToServer=True, stderrToServer=True)
     log.trace('Retrieving new service instance')
     token = None
     if mechanism == 'userpass':


### PR DESCRIPTION
### What does this PR do?

Prevents proxy minions from re-using cached SmartConnect instances.
### Previous Behavior

Proxies would hang or throw confusing stacktraces but only after the first time they talk to the VMware endpoints.
### New Behavior

Calls to the proxy after the first one continue to work.
