### PR TITLE
Remove htpasswd unit test for deprecated function that doesn't test anything

### DIFF
--- a/tests/unit/modules/htpasswd_test.py
+++ b/tests/unit/modules/htpasswd_test.py
@@ -27,17 +27,6 @@ class HtpasswdTestCase(TestCase):
     '''
     Test cases for salt.modules.htpasswd
     '''
-    # 'useradd_all' function tests: 1
-
-    @patch('os.path.exists', MagicMock(return_value=True))
-    def test_useradd_all(self):
-        '''
-        Test if it adds an HTTP user using the htpasswd command
-        '''
-        mock = MagicMock(return_value=True)
-        with patch.dict(htpasswd.__salt__, {'cmd.run_all': mock}):
-            self.assertTrue(htpasswd.useradd_all('/etc/httpd/htpasswd',
-                                                 'larry', 'badpassword'))
 
     # 'useradd' function tests: 1
 


### PR DESCRIPTION
### What does this PR do?

The test suite is displaying a deprecation warning saying that `useradd` should be used instead of `useradd_all`. This PR removes this test because a) the function is deprecation, and, b) the test isn't actually testing anything.
