### PR TITLE
Revert to vcredist 12 (2013)

### DIFF
--- a/pkg/windows/modules/get-settings.psm1
+++ b/pkg/windows/modules/get-settings.psm1
@@ -65,10 +65,7 @@ Function Get-Settings {
             "SSLeay"     = "ssleay32.dll"
             "OpenSSLLic" = "OpenSSL_License.txt"
             "libsodium"  = "libsodium.dll"
-            "concrt"     = "concrt140.dll"
-            "msvcp"      = "msvcp140.dll"
-            "vccorlib"   = "vccorlib140.dll"
-            "vcruntime"  = "vcruntime140.dll"
+            "msvcr"      = "msvcr120.dll"
         }
         $ini.Add("64bitDLLs", $64bitDLLs)
 
@@ -78,10 +75,7 @@ Function Get-Settings {
             "SSLeay"     = "ssleay32.dll"
             "OpenSSLLic" = "OpenSSL_License.txt"
             "libsodium"  = "libsodium.dll"
-            "concrt"     = "concrt140.dll"
-            "msvcp"      = "msvcp140.dll"
-            "vccorlib"   = "vccorlib140.dll"
-            "vcruntime"  = "vcruntime140.dll"
+            "msvcr"      = "msvcr120.dll"
         }
         $ini.Add("32bitDLLs", $32bitDLLs)
 


### PR DESCRIPTION
### What does this PR do?

Rolls back to VCRedist 12 (2013) for Windows Packages
