### PR TITLE
fix maximum recursion depth bug

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -249,8 +249,9 @@ class OptionParser(optparse.OptionParser, object):
             try:
                 mixin_before_exit_func(self)
             except Exception as err:  # pylint: disable=broad-except
-                logging.getLogger(__name__).exception(err)
-                self.error(
+                logger = logging.getLogger(__name__)
+                logger.exception(err)
+                logger.error(
                     'Error while processing {0}: {1}'.format(
                         mixin_before_exit_func, traceback.format_exc(err)
                     )
@@ -872,7 +873,7 @@ class DaemonMixIn(six.with_metaclass(MixInMeta, object)):
         )
 
     def _mixin_before_exit(self):
-        if hasattr(self, 'config'):
+        if hasattr(self, 'config') and self.config.get('pidfile', ''):
             # We've loaded and merged options into the configuration, it's safe
             # to query about the pidfile
             if self.check_pidfile():


### PR DESCRIPTION
### What does this PR do?

fix maximum recursion depth bug
### What issues does this PR fix or reference?

In "optparse.OptionParser", "self.error" will call "self.exit". 
So if some Exception occurs in mixin_before_exit_func, 
it will raise "RuntimeError: maximum recursion depth exceeded while calling a Python object"
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
