### PR TITLE
use aws.get_location in s3 modules

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -29,7 +29,6 @@ import salt.utils.templates
 import salt.utils.url
 import salt.utils.gzip_util
 import salt.utils.http
-import salt.utils.s3
 from salt.utils.locales import sdecode
 from salt.utils.openstack.swift import SaltSwift
 
@@ -63,6 +62,7 @@ class Client(object):
     '''
     def __init__(self, opts):
         self.opts = opts
+        self.utils = salt.loader.utils(self.opts)
         self.serial = salt.payload.Serial(self.opts)
 
     def _check_proto(self, path):
@@ -581,17 +581,17 @@ class Client(object):
                         return self.opts['pillar']['s3'][key]
                     except (KeyError, TypeError):
                         return default
-                salt.utils.s3.query(method='GET',
-                                    bucket=url_data.netloc,
-                                    path=url_data.path[1:],
-                                    return_bin=False,
-                                    local_file=dest,
-                                    action=None,
-                                    key=s3_opt('key'),
-                                    keyid=s3_opt('keyid'),
-                                    service_url=s3_opt('service_url'),
-                                    verify_ssl=s3_opt('verify_ssl', True),
-                                    location=s3_opt('location'))
+                self.utils['s3.query'](method='GET',
+                                       bucket=url_data.netloc,
+                                       path=url_data.path[1:],
+                                       return_bin=False,
+                                       local_file=dest,
+                                       action=None,
+                                       key=s3_opt('key'),
+                                       keyid=s3_opt('keyid'),
+                                       service_url=s3_opt('service_url'),
+                                       verify_ssl=s3_opt('verify_ssl', True),
+                                       location=s3_opt('location'))
                 return dest
             except Exception as exc:
                 raise MinionError(

--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -69,7 +69,6 @@ import logging
 import salt.fileserver as fs
 import salt.modules
 import salt.utils
-import salt.utils.s3 as s3
 
 # Import 3rd-party libs
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
@@ -399,7 +398,7 @@ def _refresh_buckets_cache_file(cache_file):
 
     # helper s3 query function
     def __get_s3_meta(bucket, key=key, keyid=keyid):
-        return s3.query(
+        return __utils__['s3.query'](
                 key=key,
                 keyid=keyid,
                 bucket=bucket,
@@ -632,7 +631,7 @@ def _get_file_from_s3(metadata, saltenv, bucket_name, path, cached_file_path):
                     log.debug('cached file size equal to metadata size and '
                               'cached file mtime later than metadata last '
                               'modification time.')
-                    ret = s3.query(
+                    ret = __utils__['s3.query'](
                         key=key,
                         keyid=keyid,
                         method='HEAD',
@@ -662,7 +661,7 @@ def _get_file_from_s3(metadata, saltenv, bucket_name, path, cached_file_path):
                             return
 
     # ... or get the file from S3
-    s3.query(
+    __utils__['s3.query'](
         key=key,
         keyid=keyid,
         bucket=bucket_name,

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -312,7 +312,8 @@ def pillars(opts, functions, context=None):
                      opts,
                      tag='pillar',
                      pack={'__salt__': functions,
-                           '__context__': context})
+                           '__context__': context,
+                           '__utils__': utils(opts)})
     return FilterDictWrapper(ret, '.ext_pillar')
 
 
@@ -388,7 +389,8 @@ def fileserver(opts, backends):
     return LazyLoader(_module_dirs(opts, 'fileserver', 'fileserver'),
                       opts,
                       tag='fileserver',
-                      whitelist=backends)
+                      whitelist=backends,
+                      pack={'__utils__': utils(opts)})
 
 
 def roster(opts, whitelist=None):

--- a/salt/modules/s3.py
+++ b/salt/modules/s3.py
@@ -56,10 +56,6 @@ from __future__ import absolute_import
 # Import Python libs
 import logging
 
-# Import Salt libs
-import salt.utils
-import salt.utils.s3
-
 log = logging.getLogger(__name__)
 
 
@@ -86,16 +82,16 @@ def delete(bucket, path=None, action=None, key=None, keyid=None,
     key, keyid, service_url, verify_ssl, location, role_arn = _get_key(
         key, keyid, service_url, verify_ssl, location, role_arn)
 
-    return salt.utils.s3.query(method='DELETE',
-                               bucket=bucket,
-                               path=path,
-                               action=action,
-                               key=key,
-                               keyid=keyid,
-                               service_url=service_url,
-                               verify_ssl=verify_ssl,
-                               location=location,
-                               role_arn=role_arn)
+    return __utils__['s3.query'](method='DELETE',
+                                 bucket=bucket,
+                                 path=path,
+                                 action=action,
+                                 key=key,
+                                 keyid=keyid,
+                                 service_url=service_url,
+                                 verify_ssl=verify_ssl,
+                                 location=location,
+                                 role_arn=role_arn)
 
 
 def get(bucket=None, path=None, return_bin=False, action=None,
@@ -155,18 +151,18 @@ def get(bucket=None, path=None, return_bin=False, action=None,
     key, keyid, service_url, verify_ssl, location, role_arn = _get_key(
         key, keyid, service_url, verify_ssl, location, role_arn)
 
-    return salt.utils.s3.query(method='GET',
-                               bucket=bucket,
-                               path=path,
-                               return_bin=return_bin,
-                               local_file=local_file,
-                               action=action,
-                               key=key,
-                               keyid=keyid,
-                               service_url=service_url,
-                               verify_ssl=verify_ssl,
-                               location=location,
-                               role_arn=role_arn)
+    return __utils__['s3.query'](method='GET',
+                                 bucket=bucket,
+                                 path=path,
+                                 return_bin=return_bin,
+                                 local_file=local_file,
+                                 action=action,
+                                 key=key,
+                                 keyid=keyid,
+                                 service_url=service_url,
+                                 verify_ssl=verify_ssl,
+                                 location=location,
+                                 role_arn=role_arn)
 
 
 def head(bucket, path=None, key=None, keyid=None, service_url=None,
@@ -184,16 +180,16 @@ def head(bucket, path=None, key=None, keyid=None, service_url=None,
     key, keyid, service_url, verify_ssl, location, role_arn = _get_key(
         key, keyid, service_url, verify_ssl, location, role_arn)
 
-    return salt.utils.s3.query(method='HEAD',
-                               bucket=bucket,
-                               path=path,
-                               key=key,
-                               keyid=keyid,
-                               service_url=service_url,
-                               verify_ssl=verify_ssl,
-                               location=location,
-                               full_headers=True,
-                               role_arn=role_arn)
+    return __utils__['s3.query'](method='HEAD',
+                                 bucket=bucket,
+                                 path=path,
+                                 key=key,
+                                 keyid=keyid,
+                                 service_url=service_url,
+                                 verify_ssl=verify_ssl,
+                                 location=location,
+                                 full_headers=True,
+                                 role_arn=role_arn)
 
 
 def put(bucket, path=None, return_bin=False, action=None, local_file=None,
@@ -217,18 +213,18 @@ def put(bucket, path=None, return_bin=False, action=None, local_file=None,
     key, keyid, service_url, verify_ssl, location, role_arn = _get_key(
         key, keyid, service_url, verify_ssl, location, role_arn)
 
-    return salt.utils.s3.query(method='PUT',
-                               bucket=bucket,
-                               path=path,
-                               return_bin=return_bin,
-                               local_file=local_file,
-                               action=action,
-                               key=key,
-                               keyid=keyid,
-                               service_url=service_url,
-                               verify_ssl=verify_ssl,
-                               location=location,
-                               role_arn=role_arn)
+    return __utils__['s3.query'](method='PUT',
+                                 bucket=bucket,
+                                 path=path,
+                                 return_bin=return_bin,
+                                 local_file=local_file,
+                                 action=action,
+                                 key=key,
+                                 keyid=keyid,
+                                 service_url=service_url,
+                                 verify_ssl=verify_ssl,
+                                 location=location,
+                                 role_arn=role_arn)
 
 
 def _get_key(key, keyid, service_url, verify_ssl, location, role_arn):

--- a/salt/pillar/s3.py
+++ b/salt/pillar/s3.py
@@ -94,7 +94,6 @@ from salt.ext.six.moves.urllib.parse import quote as _quote
 # Import salt libs
 from salt.pillar import Pillar
 import salt.utils
-import salt.utils.s3 as s3
 
 # Set up logging
 log = logging.getLogger(__name__)
@@ -251,7 +250,7 @@ def _refresh_buckets_cache_file(creds, cache_file, multiple_env, environment, pr
 
     # helper s3 query function
     def __get_s3_meta():
-        return s3.query(
+        return __utils__['s3.query'](
             key=creds.key,
             keyid=creds.keyid,
             bucket=creds.bucket,
@@ -392,7 +391,7 @@ def _get_file_from_s3(creds, metadata, saltenv, bucket, path,
             return
 
     # ... or get the file from S3
-    s3.query(
+    __utils__['s3.query'](
         key=creds.key,
         keyid=creds.keyid,
         bucket=bucket,

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -554,7 +554,7 @@ def get_region_from_metadata():
     return None
 
 
-def get_location(opts, provider=None):
+def get_location(opts=None, provider=None):
     '''
     Return the region to use, in this order:
         opts['location']
@@ -562,6 +562,8 @@ def get_location(opts, provider=None):
         get_region_from_metadata()
         DEFAULT_LOCATION
     '''
+    if opts is None:
+        opts = __opts__
     ret = opts.get('location', provider.get('location'))
     if ret is None:
         ret = get_region_from_metadata()

--- a/salt/utils/s3.py
+++ b/salt/utils/s3.py
@@ -92,6 +92,9 @@ def query(key, keyid, method='GET', params=None, headers=None,
     if not keyid:
         keyid = salt.utils.aws.IROLE_CODE
 
+    if not location:
+        location = __utils__['aws.get_location']()
+
     data = ''
     payload_hash = None
     if method == 'PUT':

--- a/tests/unit/modules/s3_test.py
+++ b/tests/unit/modules/s3_test.py
@@ -19,10 +19,10 @@ from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../')
 
 # Import Salt Libs
-import salt.utils.s3
 from salt.modules import s3
 
 s3.__salt__ = {}
+s3.__utils__ = {'s3.query': MagicMock(return_value='A')}
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -46,8 +46,7 @@ class S3TestCase(TestCase):
         with patch.object(s3, '_get_key',
                           return_value=('key', 'keyid', 'service_url',
                                         'verify_ssl', 'location', 'role_arn')):
-            with patch.object(salt.utils.s3, 'query', return_value='A'):
-                self.assertEqual(s3.delete('bucket'), 'A')
+            self.assertEqual(s3.delete('bucket'), 'A')
 
     def test_get(self):
         '''
@@ -57,8 +56,7 @@ class S3TestCase(TestCase):
         with patch.object(s3, '_get_key',
                           return_value=('key', 'keyid', 'service_url',
                                         'verify_ssl', 'location', 'role_arn')):
-            with patch.object(salt.utils.s3, 'query', return_value='A'):
-                self.assertEqual(s3.get(), 'A')
+            self.assertEqual(s3.get(), 'A')
 
     def test_head(self):
         '''
@@ -67,8 +65,7 @@ class S3TestCase(TestCase):
         with patch.object(s3, '_get_key',
                           return_value=('key', 'keyid', 'service_url',
                                         'verify_ssl', 'location', 'role_arn')):
-            with patch.object(salt.utils.s3, 'query', return_value='A'):
-                self.assertEqual(s3.head('bucket'), 'A')
+            self.assertEqual(s3.head('bucket'), 'A')
 
     def test_put(self):
         '''
@@ -77,8 +74,7 @@ class S3TestCase(TestCase):
         with patch.object(s3, '_get_key',
                           return_value=('key', 'keyid', 'service_url',
                                         'verify_ssl', 'location', 'role_arn')):
-            with patch.object(salt.utils.s3, 'query', return_value='A'):
-                self.assertEqual(s3.put('bucket'), 'A')
+            self.assertEqual(s3.put('bucket'), 'A')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?

Use `aws.get_location` in s3 modules

Also load the `__utils__` into pillar and fileserver and fileclient so
that this function can be used there with `__opts__`.

Also sets the default for s3 to 'us-east-1' like it is documented.
### What issues does this PR fix or reference?

Closes #30976
Closes #28913 
### Tests written?

No
