### PR TITLE
Update pkg integration test to match #35415

### DIFF
--- a/tests/integration/states/pkg.py
+++ b/tests/integration/states/pkg.py
@@ -35,7 +35,7 @@ _PKG_TARGETS = {
     'Debian': ['python-plist', 'apg'],
     'RedHat': ['xz-devel', 'zsh-html'],
     'FreeBSD': ['aalib', 'pth'],
-    'SUSE': ['aalib', 'python-pssh'],
+    'Suse': ['aalib', 'python-pssh'],
     'MacOS': ['libpng', 'jpeg'],
     'Windows': ['firefox', '7zip'],
 }


### PR DESCRIPTION
### What does this PR do?
#35415 Changed suse's os family from SUSE to Suse. This updates the pkg test to get the right packages for the tests.
### What issues does this PR fix or reference?
#35415
### Tests written?

Yes
