### PR TITLE
Don't assume we have a file to remove in tearDown

### DIFF
--- a/tests/integration/states/cmd.py
+++ b/tests/integration/states/cmd.py
@@ -54,8 +54,14 @@ class CMDRunRedirectTest(integration.ModuleCase,
         super(CMDRunRedirectTest, self).setUp()
 
     def tearDown(self):
-        os.remove(self.state_file)
-        os.remove(self.test_file)
+        try:
+            os.remove(self.state_file)
+            os.remove(self.test_file)
+        except OSError:
+            # Not all of the tests leave files around that we want to remove
+            # As some of the tests create the sls files in the test itself,
+            # And some are using files in the integration test file state tree.
+            pass
         super(CMDRunRedirectTest, self).tearDown()
 
     def test_run_unless(self):


### PR DESCRIPTION
Some tests build the state file in the test itself and need to be removed. However, some tests rely on sls files inside of the integration file state tree. Therefore, in those tests, we have nothing to remove.

This fixes a test failure introduced during the merge-forward in #35702. The test that was newly failing is new in the develop branch. 
