### PR TITLE
Refresh pillar only if minion is connected to master

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1675,19 +1675,20 @@ class Minion(MinionBase):
         '''
         Refresh the pillar
         '''
-        log.debug('Refreshing pillar')
-        try:
-            self.opts['pillar'] = yield salt.pillar.get_async_pillar(
-                self.opts,
-                self.opts['grains'],
-                self.opts['id'],
-                self.opts['environment'],
-                pillarenv=self.opts.get('pillarenv'),
-            ).compile_pillar()
-        except SaltClientError:
-            # Do not exit if a pillar refresh fails.
-            log.error('Pillar data could not be refreshed. '
-                      'One or more masters may be down!')
+        if self.connected:
+            log.debug('Refreshing pillar')
+            try:
+                self.opts['pillar'] = yield salt.pillar.get_async_pillar(
+                    self.opts,
+                    self.opts['grains'],
+                    self.opts['id'],
+                    self.opts['environment'],
+                    pillarenv=self.opts.get('pillarenv'),
+                ).compile_pillar()
+            except SaltClientError:
+                # Do not exit if a pillar refresh fails.
+                log.error('Pillar data could not be refreshed. '
+                          'One or more masters may be down!')
         self.module_refresh(force_refresh)
 
     def manage_schedule(self, tag, data):


### PR DESCRIPTION
### What does this PR do?

Added logic to refresh the pillar only if the minion is connected
to the master in `Minion.pillar_refresh()`. This matches the existing
logic in `Minion._post_master_init()`. This allows `pillar_refresh`
and `grains_refresh` events to be handled without throwing an exception
if the minion is not connected to the master (eg when `master_type` is
`disable`).
### Tests written?

No
