### PR TITLE
Fix legacy git_pillar tests

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -465,13 +465,20 @@ def _legacy_git_pillar(minion_id, repo_string, pillar_dirs):
         # Support multiple key=val attributes as custom parameters.
         DELIM = '='
         if DELIM not in extraopt:
-            log.error('Incorrectly formatted extra parameter. '
-                      'Missing \'{0}\': {1}'.format(DELIM, extraopt))
+            log.error(
+                'Legacy git_pillar: Incorrectly formatted extra parameter '
+                '\'%s\' within \'%s\' missing \'%s\')',
+                extraopt, repo_string, DELIM
+            )
         key, val = _extract_key_val(extraopt, DELIM)
         if key == 'root':
             root = val
         else:
-            log.warning('Unrecognized extra parameter: {0}'.format(key))
+            log.error(
+                'Legacy git_pillar: Unrecognized extra parameter \'%s\' '
+                'in \'%s\'',
+                key, repo_string
+            )
 
     # environment is "different" from the branch
     cfg_branch, _, environment = branch_env.partition(':')
@@ -487,12 +494,24 @@ def _legacy_git_pillar(minion_id, repo_string, pillar_dirs):
 
     # normpath is needed to remove appended '/' if root is empty string.
     pillar_dir = os.path.normpath(os.path.join(gitpil.working_dir, root))
+    log.debug(
+        'Legacy git_pillar: pillar_dir for \'%s\' is \'%s\'',
+        repo_string, pillar_dir
+    )
+    log.debug(
+        'Legacy git_pillar: branch for \'%s\' is \'%s\'',
+        repo_string, branch
+    )
 
     pillar_dirs.setdefault(pillar_dir, {})
 
     if cfg_branch == '__env__' and branch not in ['master', 'base']:
         gitpil.update()
     elif pillar_dirs[pillar_dir].get(branch, False):
+        log.debug(
+            'Already processed pillar_dir \'%s\' for \'%s\'',
+            pillar_dir, repo_string
+        )
         return {}  # we've already seen this combo
 
     pillar_dirs[pillar_dir].setdefault(branch, True)

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -355,7 +355,7 @@ class _LegacyGitPillar(object):
         self.working_dir = ''
         self.repo = None
 
-        hash_type = getattr(hashlib, opts.get('hash_type', 'md5'))
+        hash_type = getattr(hashlib, opts['hash_type'])
         hash_str = '{0} {1}'.format(self.branch, self.rp_location)
         repo_hash = hash_type(salt.utils.to_bytes(hash_str)).hexdigest()
         rp_ = os.path.join(self.opts['cachedir'], 'pillar_gitfs', repo_hash)

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -413,7 +413,7 @@ class _LegacyGitPillar(object):
         Return boolean whether it worked
         '''
         try:
-            log.debug('Updating fileserver for git_pillar module')
+            log.debug('Legacy git_pillar: Updating \'%s\'', self.rp_location)
             self.repo.git.fetch()
         except git.exc.GitCommandError as exc:
             log.error('Unable to fetch the latest changes from remote '
@@ -421,10 +421,15 @@ class _LegacyGitPillar(object):
             return False
 
         try:
-            self.repo.git.checkout('origin/{0}'.format(self.branch))
+            checkout_ref = 'origin/{0}'.format(self.branch)
+            log.debug('Legacy git_pillar: Checking out %s for \'%s\'',
+                      checkout_ref, self.rp_location)
+            self.repo.git.checkout(checkout_ref)
         except git.exc.GitCommandError as exc:
-            log.error('Unable to checkout branch '
-                      '{0}: {1}'.format(self.branch, exc))
+            log.error(
+                'Legacy git_pillar: Failed to checkout %s for \'%s\': %s',
+                checkout_ref, self.rp_location, exc
+            )
             return False
 
         return True

--- a/tests/unit/pillar/git_test.py
+++ b/tests/unit/pillar/git_test.py
@@ -111,7 +111,7 @@ class GitPillarTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn)
         ]
         pil = Pillar(git_pillar.__opts__,
                      git_pillar.__grains__,
-                     'myminon', None)
+                     'myminion', None)
         self.assertEqual(PILLAR_CONTENT, pil.compile_pillar(pillar_dirs={}))
 
     def test_no_loop(self):
@@ -152,7 +152,7 @@ class GitPillarTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn)
 
         pil = Pillar(git_pillar.__opts__,
                      git_pillar.__grains__,
-                     'myminon', 'base')
+                     'myminion', 'base')
 
         orig_ext_pillar = pil.ext_pillars['git']
         orig_ext_pillar.count = 0

--- a/tests/unit/pillar/git_test.py
+++ b/tests/unit/pillar/git_test.py
@@ -51,6 +51,7 @@ class GitPillarTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn)
         git_pillar.__opts__ = {
                 'cachedir': cachedir,
                 'pillar_roots': {},
+                'hash_type': 'sha256',
                 'file_roots': {},
                 'state_top': 'top.sls',
                 'extension_modules': '',

--- a/tests/unit/pillar/git_test.py
+++ b/tests/unit/pillar/git_test.py
@@ -172,10 +172,13 @@ class GitPillarTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn)
             if key == 'git.ext_pillar':
                 return ext_pillar_count_calls
             return orig_getitem(self, key)
-        LazyLoader.__getitem__ = __getitem__
 
-        self.assertEqual(PILLAR_CONTENT, pil.compile_pillar(pillar_dirs={}))
-        self.assertTrue(orig_ext_pillar.count < 7)
+        try:
+            LazyLoader.__getitem__ = __getitem__
+            self.assertEqual(PILLAR_CONTENT, pil.compile_pillar(pillar_dirs={}))
+            self.assertTrue(orig_ext_pillar.count < 7)
+        finally:
+            LazyLoader.__getitem__ = orig_getitem
 
 
 if __name__ == '__main__':

--- a/tests/unit/pillar/git_test.py
+++ b/tests/unit/pillar/git_test.py
@@ -149,6 +149,7 @@ class GitPillarTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn)
             dict(git=self.conf_line),
             dict(git=conf_line2),
         ]
+        git_pillar._update(*conf_line2.split(None, 1))
 
         pil = Pillar(git_pillar.__opts__,
                      git_pillar.__grains__,


### PR DESCRIPTION
This is to aid in troubleshooting some failures on the branch builds

EDIT: After adding the debug logging I discovered this was caused by a combination of three things:
1. b0f0b4e changed the default hash type to `sha256`.
2. When legacy git_pillar checks the `hash_type` config option, it falls back to `md5` when no such key is present.
3. The unit tests did not specify a `hash_type` param, causing it to fall back to `md5` due to thing number 2.

These are now corrected, and the pull request has been rebased with the unnecessary extra logging removed.