### PR TITLE
Add Minion Only Installer Script

### DIFF
--- a/pkg/windows/build_pkg.bat
+++ b/pkg/windows/build_pkg.bat
@@ -81,6 +81,7 @@ If Exist "%BinDir%\README.txt" del /q "%BinDir%\README.txt" 1>nul
 @echo Building the installer...
 @echo ----------------------------------------------------------------------
 makensis.exe /DSaltVersion=%Version% "%InsDir%\Salt-Minion-Setup.nsi"
+makensis.exe /DSaltVersion=%Version% "%InsDir%\Salt-Setup.nsi"
 @echo.
 
 @echo.


### PR DESCRIPTION
### What does this PR do?

Creates another Nullsoft Installer Script that will create an installer for the Minion Only.
Adds the new Nullsoft Installer Script to the build.bat file so that both are built
### What issues does this PR fix or reference?

https://github.com/saltstack/zh/issues/915
### Previous Behavior

Built an installer for Master and Minion only.
### New Behavior

Adds an additional installer for just the minion
### Tests written?

NA
