### PR TITLE
Fixed a bug in windows hostname settings when the hostname is longer …

### DIFF
--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -448,9 +448,9 @@ def get_hostname():
 
         salt 'minion-id' system.get_hostname
     '''
-    cmd = 'wmic computersystem get name'
+    cmd = 'wmic nicconfig get dnshostname'
     ret = __salt__['cmd.run'](cmd=cmd)
-    _, hostname = ret.split("\n")
+    _, _, hostname = ret.split("\n")
     return hostname
 
 

--- a/tests/unit/modules/win_system_test.py
+++ b/tests/unit/modules/win_system_test.py
@@ -291,11 +291,11 @@ class WinSystemTestCase(TestCase):
         '''
             Test setting a new hostname
         '''
-        cmd_run_mock = MagicMock(return_value="Name\nMINION")
+        cmd_run_mock = MagicMock(return_value="DNSHostName\n\nMINION")
         with patch.dict(win_system.__salt__, {'cmd.run': cmd_run_mock}):
             ret = win_system.get_hostname()
             self.assertEqual(ret, "MINION")
-        cmd_run_mock.assert_called_once_with(cmd="wmic computersystem get name")
+        cmd_run_mock.assert_called_once_with(cmd="wmic nicconfig get dnshostname")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in windows hostnames with names longer than 15 chars
### What issues does this PR fix or reference?

If you set a hostname longer than 15 chars the state would always fail
### Tests written?

Yes
