### PR TITLE
set HAS_PSUTIL=False for old versions of psutils

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -43,9 +43,10 @@ import salt.defaults.exitcodes
 
 try:
     import psutil
-    psutil.virtual_memory
+    if not hasattr(psutil, 'virtual_memory'):
+        raise ImportError('Version of psutil too old.')
     HAS_PSUTIL = True
-except (ImportError, AttributeError):
+except ImportError:
     HAS_PSUTIL = False
     import platform
     import salt.grains.core

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -43,8 +43,9 @@ import salt.defaults.exitcodes
 
 try:
     import psutil
+    psutil.virtual_memory
     HAS_PSUTIL = True
-except ImportError:
+except (ImportError, AttributeError):
     HAS_PSUTIL = False
     import platform
     import salt.grains.core


### PR DESCRIPTION
### What does this PR do?

Avoid uncaught exception if psutil is a old version:

```
        Traceback (most recent call last):
          File "/var/tmp/.root_dcdf8c_salt/salt-call", line 15, in <module>
            salt_call()
          File "/var/tmp/.root_dcdf8c_salt/py2/salt/scripts.py", line 339, in salt_call
            import salt.cli.call
          File "/var/tmp/.root_dcdf8c_salt/py2/salt/cli/call.py", line 6, in <module>
            from salt.utils import parsers
          File "/var/tmp/.root_dcdf8c_salt/py2/salt/utils/parsers.py", line 28, in <module>
            import salt.config as config
          File "/var/tmp/.root_dcdf8c_salt/py2/salt/config/__init__.py", line 93, in <module>
            _DFLT_IPC_WBUFFER = _gather_buffer_space() * .5
          File "/var/tmp/.root_dcdf8c_salt/py2/salt/config/__init__.py", line 82, in _gather_buffer_space
            total_mem = psutil.virtual_memory().total
        AttributeError: 'module' object has no attribute 'virtual_memory'

```
### What issues does this PR fix or reference?

Part of https://github.com/saltstack/salt/issues/34419#issuecomment-241021598
