### PR TITLE
fix salt-api's default opts were covered by salt-master

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3273,10 +3273,10 @@ def api_config(path):
     '''
     # Let's grab a copy of salt's master default opts
     defaults = DEFAULT_MASTER_OPTS
-    opts = client_config(path, defaults=defaults)
     # Let's override them with salt-api's required defaults
-    opts.update(DEFAULT_API_OPTS)
-    return opts
+    defaults.update(DEFAULT_API_OPTS)
+    
+    return client_config(path, defaults=defaults)
 
 
 def spm_config(path):

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3275,7 +3275,6 @@ def api_config(path):
     defaults = DEFAULT_MASTER_OPTS
     # Let's override them with salt-api's required defaults
     defaults.update(DEFAULT_API_OPTS)
-    
     return client_config(path, defaults=defaults)
 
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3275,6 +3275,7 @@ def api_config(path):
     defaults = DEFAULT_MASTER_OPTS
     # Let's override them with salt-api's required defaults
     defaults.update(DEFAULT_API_OPTS)
+
     return client_config(path, defaults=defaults)
 
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1383,8 +1383,8 @@ CLOUD_CONFIG_DEFAULTS = {
 
 DEFAULT_API_OPTS = {
     # ----- Salt master settings overridden by Salt-API --------------------->
-    'pidfile': '/var/run/salt-api.pid',
-    'logfile': '/var/log/salt/api',
+    'pidfile': os.path.join(salt.syspaths.PIDFILE_DIR, 'salt-api.pid'),
+    'log_file': os.path.join(salt.syspaths.LOGS_DIR, 'api'),
     'rest_timeout': 300,
     # <---- Salt master settings overridden by Salt-API ----------------------
 }
@@ -3273,10 +3273,11 @@ def api_config(path):
     '''
     # Let's grab a copy of salt's master default opts
     defaults = DEFAULT_MASTER_OPTS
+    opts = client_config(path, defaults=defaults)
     # Let's override them with salt-api's required defaults
-    defaults.update(DEFAULT_API_OPTS)
+    opts.update(DEFAULT_API_OPTS)
+    return opts
 
-    return client_config(path, defaults=defaults)
 
 
 def spm_config(path):

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3279,7 +3279,6 @@ def api_config(path):
     return opts
 
 
-
 def spm_config(path):
     '''
     Read in the salt master config file and add additional configs that


### PR DESCRIPTION
### What does this PR do?

salt-api default pidfile : salt-api.pid ; log_file: log/api were covered by salt-master's salt-master.pid and log/master
### What issues does this PR fix or reference?
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
