### PR TITLE
Fix utils_test failure caused by change in #35712

### DIFF
--- a/tests/unit/utils/utils_test.py
+++ b/tests/unit/utils/utils_test.py
@@ -157,9 +157,8 @@ class UtilsTestCase(TestCase):
         # Make sure we raise an error if we don't pass in the requisite number of arguments
         self.assertRaises(SaltInvocationError, utils.format_call, dummy_func, {'1': 2})
 
-        # Make sure we warn on invalid kwargs
-        ret = utils.format_call(dummy_func, {'first': 2, 'second': 2, 'third': 3})
-        self.assertGreaterEqual(len(ret['warnings']), 1)
+        # Make sure we raise an error on invalid kwargs
+        self.assertRaises(SaltInvocationError, utils.format_call, dummy_func, {'first': 2, 'second': 2, 'third': 3})
 
         ret = utils.format_call(dummy_func, {'first': 2, 'second': 2, 'third': 3},
                                 expected_extra_kws=('first', 'second', 'third'))


### PR DESCRIPTION
### What does this PR do?

A test failure snuck in when #35712 was merged and tests didn't run. This PR fixes that test failure.

We need to change this test to assert that an error is raised when passing in invalid kwargs instead of a warning. Error raising vs. warning was changed for the Carbon release with #35712.
### What issues does this PR fix or reference?

Refs #35712
### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
