### PR TITLE
Enable pillarenv usage on state module 'state' and change git_pillar to ignore other environments

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -362,20 +362,24 @@ class Pillar(object):
         # Gather initial top files
         try:
             if self.opts['pillarenv']:
-                tops[self.opts['pillarenv']] = [
-                        compile_template(
-                            self.client.cache_file(
-                                self.opts['state_top'],
-                                self.opts['pillarenv']
-                                ),
-                            self.rend,
-                            self.opts['renderer'],
-                            self.opts['renderer_blacklist'],
-                            self.opts['renderer_whitelist'],
-                            self.opts['pillarenv'],
-                            _pillar_rend=True,
-                            )
-                        ]
+                # If file roots environment for the pillar does not match pillarenv, dont look for top file
+                if self.opts['pillarenv'] not in self.opts['file_roots']:
+                    log.debug("Pillarenv NOT equal to file_roots")
+                else:
+                    tops[self.opts['pillarenv']] = [
+                            compile_template(
+                                self.client.cache_file(
+                                    self.opts['state_top'],
+                                    self.opts['pillarenv']
+                                    ),
+                                self.rend,
+                                self.opts['renderer'],
+                                self.opts['renderer_blacklist'],
+                                self.opts['renderer_whitelist'],
+                                self.opts['pillarenv'],
+                                _pillar_rend=True,
+                                )
+                            ]
             else:
                 for saltenv in self._get_envs():
                     top = self.client.cache_file(

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -364,7 +364,7 @@ class Pillar(object):
             if self.opts['pillarenv']:
                 # If file roots environment for the pillar does not match pillarenv, dont look for top file
                 if self.opts['pillarenv'] not in self.opts['file_roots']:
-                    log.debug("Pillarenv NOT equal to file_roots")
+                    log.debug('pillarenv (%s) not present in pillar_roots', self.opts['pillarenv'])
                 else:
                     tops[self.opts['pillarenv']] = [
                             compile_template(

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -318,7 +318,7 @@ def ext_pillar(minion_id, repo, pillar_dirs):
             # If pillarenv is set, only grab pillars with that match pillarenv
             if opts['pillarenv'] and env != opts['pillarenv']:
                 log.debug(
-                    "Env '{0}' does not match pillarenv '{1}' - skipping pillar".format(env,opts['pillarenv'])
+                    "Env '{0}' does not match pillarenv '{1}' - skipping pillar".format(env, opts['pillarenv'])
                 )
                 continue
             log.debug(

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -290,6 +290,12 @@ def ext_pillar(minion_id, repo, pillar_dirs):
             False
         )
         for pillar_dir, env in six.iteritems(pillar.pillar_dirs):
+            # If pillarenv is set, only grab pillars with that match pillarenv
+            if opts['pillarenv'] and env != opts['pillarenv']:
+                log.debug(
+                    'Env \'{0}\' does not match pillarenv \'{1}\', skipping pillar'.format(env,opts['pillarenv'])
+                )
+                continue
             log.debug(
                 'git_pillar is processing pillar SLS from {0} for pillar '
                 'env \'{1}\''.format(pillar_dir, env)

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -318,7 +318,7 @@ def ext_pillar(minion_id, repo, pillar_dirs):
             # If pillarenv is set, only grab pillars with that match pillarenv
             if opts['pillarenv'] and env != opts['pillarenv']:
                 log.debug(
-                    'Env \'{0}\' does not match pillarenv \'{1}\', skipping pillar'.format(env,opts['pillarenv'])
+                    "Env '{0}' does not match pillarenv '{1}' - skipping pillar".format(env,opts['pillarenv'])
                 )
                 continue
             log.debug(

--- a/salt/runners/pillar.py
+++ b/salt/runners/pillar.py
@@ -41,6 +41,7 @@ def show_pillar(minion='*', **kwargs):
     Returns the compiled pillar either of a specific minion
     or just the global available pillars. This function assumes
     that no minion has the id ``*``.
+    Function also accepts pillarenv as attribute in order to limit to a specific pillar branch of git
 
     CLI Example:
 
@@ -62,6 +63,12 @@ def show_pillar(minion='*', **kwargs):
 
         salt-run pillar.show_pillar 'saltenv=dev'
 
+    shows global pillar for 'dev' pillar environment and specific pillarenv = dev:
+
+    .. code-block:: bash
+
+        salt-run pillar.show_pillar 'saltenv=dev' 'pillarenv=dev'
+
     API Example:
 
     .. code-block:: python
@@ -80,6 +87,8 @@ def show_pillar(minion='*', **kwargs):
         grains = {'fqdn': minion}
 
     for key in kwargs:
+        if key == 'pillarenv':
+            __opts__['pillarenv'] = kwargs[key]
         if key == 'saltenv':
             saltenv = kwargs[key]
         else:

--- a/salt/runners/state.py
+++ b/salt/runners/state.py
@@ -15,7 +15,7 @@ from salt.exceptions import SaltInvocationError
 LOGGER = logging.getLogger(__name__)
 
 
-def orchestrate(mods, saltenv='base', test=None, exclude=None, pillar=None):
+def orchestrate(mods, saltenv='base', test=None, exclude=None, pillar=None, pillarenv=None):
     '''
     .. versionadded:: 0.17.0
 
@@ -53,7 +53,8 @@ def orchestrate(mods, saltenv='base', test=None, exclude=None, pillar=None):
             saltenv,
             test,
             exclude,
-            pillar=pillar)
+            pillar=pillar,
+            pillarenv=pillarenv)
     ret = {'data': {minion.opts['id']: running}, 'outputter': 'highstate'}
     res = salt.utils.check_state_result(ret['data'])
     if res:

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -52,6 +52,7 @@ def state(
         env=None,
         test=False,
         pillar=None,
+        pillarenv=None,
         expect_minions=False,
         fail_minions=None,
         allow_fail=0,
@@ -92,6 +93,9 @@ def state(
 
     pillar
         Pass the ``pillar`` kwarg through to the state function
+
+    pillarenv
+        The pillar environment to grab pillars from
 
     saltenv
         The default salt environment to pull sls files from
@@ -213,6 +217,13 @@ def state(
 
     if pillar:
         cmd_kw['kwarg']['pillar'] = pillar
+
+    # If pillarenv is directly defined, use it
+    if pillarenv:
+        cmd_kw['kwarg']['pillarenv'] = pillarenv
+    # Use pillarenv if it's passed from __opts__ (via state.orchestrate for example)
+    elif __opts__.get('pillarenv'):
+        cmd_kw['kwarg']['pillarenv'] = __opts__['pillarenv']
 
     cmd_kw['kwarg']['saltenv'] = __env__
     cmd_kw['kwarg']['queue'] = queue

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -124,6 +124,8 @@ def state(
     pillarenv
         The pillar environment to grab pillars from
 
+        .. versionadded:: Nitrogen
+
     saltenv
         The default salt environment to pull sls files from
 


### PR DESCRIPTION
### What does this PR do?

This PR complements https://github.com/saltstack/salt/pull/31908 into enabling the usage of pillarenv in more cases as it should. 
Now pillarenv can be used on state.orchestrate (fixed on the above PR) and is accepted on 'salt.state' inside state files. In addition git_pillar accepts this change
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/pull/31908
### Previous Behavior

Executing something like the below in a state file failed

```
test_orch:
  salt.state:
    - tgt: '*'
    - pillarenv: release_1
    - sls:
      - default
```
### New Behavior

We can execute an orchestation:
`salt-run state.orchestrate orch_simple pillarenv=release_1`

while orch_simple.sls is:

```
test_orch:
  salt.state:
    - tgt: '*'
    - sls:
      - default
```

and state 'default' will use pillarenv=release_1

In addition we can also do (without passing pillarenv from orchestrate, or even overwriting it):

```
test_orch:
  salt.state:
    - tgt: '*'
    - pillarenv: release_1
    - sls:
      - default
```

This also supports having external git pillars like:

```
ext_pillar:
  - git:
    - dev git@bitbucket.org:something.git
      - env: dev
    - release_1 git@bitbucket.org:something.git
      - env: release_1
```

In this case, git_pillar will not throw "[ERROR   ] Template does not exist:" trying to find top.sls for the git environments that do not mach pillarenv value. It will skip them.

(FIXED) **However**, "[ERROR   ] Template does not exist:" is thrown once before git_pillar is invoked and I would like some help into fixing it
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
