### PR TITLE
Fixup the unit.client_test.LocalClientTestCase.test_cmd_subset from #35720

### DIFF
--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -53,7 +53,7 @@ class LocalClientTestCase(TestCase,
 
     @patch('salt.client.LocalClient.cmd', return_value={'minion1': ['first.func', 'second.func'],
                                                         'minion2': ['first.func', 'second.func']})
-    def test_cmd_subset(self):
+    def test_cmd_subset(self, cmd_mock):
         with patch('salt.client.LocalClient.cmd_cli') as cmd_cli_mock:
             self.client.cmd_subset('*', 'first.func', sub=1, cli=True)
             try:

--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -53,17 +53,26 @@ class LocalClientTestCase(TestCase,
 
     @patch('salt.client.LocalClient.cmd', return_value={'minion1': ['first.func', 'second.func'],
                                                         'minion2': ['first.func', 'second.func']})
-    def test_cmd_subset(self, cmd_mock):
+    def test_cmd_subset(self):
         with patch('salt.client.LocalClient.cmd_cli') as cmd_cli_mock:
             self.client.cmd_subset('*', 'first.func', sub=1, cli=True)
-            cmd_cli_mock.assert_called_with(['minion1'], 'first.func', (), progress=False,
+            try:
+                cmd_cli_mock.assert_called_with(['minion2'], 'first.func', (), progress=False,
                                                 kwarg=None, expr_form='list',
-                                                ret=['first.func', 'second.func'])
-
+                                                ret='')
+            except AssertionError:
+                cmd_cli_mock.assert_called_with(['minion1'], 'first.func', (), progress=False,
+                                                kwarg=None, expr_form='list',
+                                                ret='')
             self.client.cmd_subset('*', 'first.func', sub=10, cli=True)
-            cmd_cli_mock.assert_called_with(['minion1', 'minion2'], 'first.func', (), progress=False,
+            try:
+                cmd_cli_mock.assert_called_with(['minion2', 'minion1'], 'first.func', (), progress=False,
                                                 kwarg=None, expr_form='list',
-                                                ret=['first.func', 'second.func'])
+                                                ret='')
+            except AssertionError:
+                cmd_cli_mock.assert_called_with(['minion1', 'minion2'], 'first.func', (), progress=False,
+                                                kwarg=None, expr_form='list',
+                                                ret='')
 
     @skipIf(NOT_ZMQ, 'This test only works with ZeroMQ')
     def test_pub(self):


### PR DESCRIPTION
### What does this PR do?

The bug fix for #20575, which is located in PR #35720, caused a test failure in the unit.client_test tests that wasn't caught until later. This PR fixes that test.

Background information on why I am fixing it this way, after confirming with @thatch45 :
- The `ret` option in this function actually stands for `returner` and should just be a pass-through and not overwritten in the `cmd_subset` function as was originally occurring in the function before the fix in #35720. Therefore, the expected return in this unit test should be `ret=''`.
- I am using a try/except on each of these tests, because now that the `cmd_subset` function actually returns a random subset of minions, sometimes the `sub=1` function operates on `minion2` and sometimes it is `minion1`. The same goes for the list of minions for `sub=10`. Since this assert is against a list, sometimes the list of minions will be called in differing orders.
### What issues does this PR fix or reference?

Refs #35720
### Previous Behavior

Test failing on 2016.3 branch.
### New Behavior

Test will pass now.
### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
