### PR TITLE
Add ssh_agent support to digital_ocean provider

### DIFF
--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -336,7 +336,7 @@ def create(vm_):
             )
         )
 
-    if key_filename is None:
+    if not __opts__.get('ssh_agent', False) and key_filename is None:
         raise SaltCloudConfigError(
             'The DigitalOcean driver requires an ssh_key_file and an ssh_key_name '
             'because it does not supply a root password upon building the server.'


### PR DESCRIPTION
### What does this PR do?

Allows `ssh_key_file` to be undefined if `ssh_agent` is true.
### What issues does this PR fix or reference?

I don't believe this issue was previously reported.
### Previous Behavior

`ssh_key_file` was previously required unconditionally.
### New Behavior

`ssh_key_file` is only needed if `ssh_agent` isn't `True`.
### Tests written?

No. However, I did manually test it.

---

Note: I understand this PR is lacking. Ideally, there'd be documentation changes here and error message improvements. Plus, `has_ssh_agent` is only actually true if the environment is configured correctly.

I don't really have the time to implement a more fleshed out PR, so kind of a half-bug-report, half-PR. I understand if you don't want to merge this as-is.
