### PR TITLE
grains.filter_by: lookup_dict key could be a globing pattern

### DIFF
--- a/tests/unit/modules/grains_test.py
+++ b/tests/unit/modules/grains_test.py
@@ -153,6 +153,15 @@ class GrainsModuleTestCase(TestCase):
         res = grainsmod.filter_by(dict1, grain='roles', default='C')
         self.assertEqual(res, {'D': {'E': 'F', 'G': 'H'}})
 
+        # Test with wildcard pattern in the lookup_dict keys
+        dict1 = {'*OS': 'B', 'C': {'D': {'E': 'F', 'G': 'H'}}}
+        res = grainsmod.filter_by(dict1)
+        self.assertEqual(res, 'B')
+        # Test with sequence pattern with roles
+        dict1 = {'Z': 'B', '[BC]': {'D': {'E': 'F', 'G': 'H'}}}
+        res = grainsmod.filter_by(dict1, grain='roles', default='Z')
+        self.assertEqual(res, {'D': {'E': 'F', 'G': 'H'}})
+
         # Base tests
         # NOTE: these may fail to detect errors if dictupdate.update() is broken
         # but then the unit test for dictupdate.update() should fail and expose


### PR DESCRIPTION
### What does this PR do?

It allows to specify wildcard globbing pattern as lookup dictionary keys. The function will return lookup dict value which matches a pattern. See example below.
### What issues does this PR fix or reference?

This feature also works with the one in PR #35379. Logic remains the same: first value matching a pattern wins.
### Previous Behavior

Only exact match between grain value and lookup dict key gives a lookup value.
### New Behavior

Now it is possible to match grain value by the pattern in lookup dict. For example:

``` sh
salt '*.example.com' grains.filter_by '{salt*: got some salt, default: salt is not here}' id
salt.example.com:
    got some salt
other.example.com:
    salt is not here
```

Here we have '_got some salt_' string for the Minion which ID starts from '_salt_' (by setting`salt*` pattern).
### Tests written?

Added two test cases to `unit.modules.grains_test.GrainsModuleTestCase.test_filter_by` unit test.
