### PR TITLE
Sphinx crash: documentation config fix

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,31 +15,40 @@ from sphinx.directives import TocTree
 # pylint: disable=R0903
 class Mock(object):
     '''
-    Mock out specified imports
+    Mock out specified imports.
 
     This allows autodoc to do its thing without having oodles of req'd
     installed libs. This doesn't work with ``import *`` imports.
 
+    This Mock class can be configured to return a specific values at specific names, if required.
+
     http://read-the-docs.readthedocs.org/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules
     '''
-    def __init__(self, *args, **kwargs):
-        pass
+    def __init__(self, mapping=None, *args, **kwargs):
+        """
+        Mapping allows to bypass the Mock object, but actually assign
+        a specific value, expected by a specific attribute returned.
+        """
+        self.__mapping = mapping or {}
 
     __all__ = []
 
     def __call__(self, *args, **kwargs):
-        ret = Mock()
         # If mocked function is used as a decorator, expose decorated function.
         # if args and callable(args[-1]):
         #     functools.update_wrapper(ret, args[0])
-        return ret
+        return Mock(mapping=self.__mapping)
 
-    @classmethod
-    def __getattr__(cls, name):
-        if name in ('__file__', '__path__'):
-            return '/dev/null'
+    def __getattr__(self, name):
+        #__mapping = {'total': 0}
+        data = None
+        if name in self.__mapping:
+            data = self.__mapping.get(name)
+        elif name in ('__file__', '__path__'):
+            data = '/dev/null'
         else:
-            return Mock()
+            data = Mock(mapping=self.__mapping)
+        return data
 # pylint: enable=R0903
 
 MOCK_MODULES = [

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -141,7 +141,11 @@ MOCK_MODULES = [
 ]
 
 for mod_name in MOCK_MODULES:
-    sys.modules[mod_name] = Mock()
+    if mod_name == 'psutil':
+        mock = Mock(mapping={'total': 0})  # Otherwise it will crash Sphinx
+    else:
+        mock = Mock()
+    sys.modules[mod_name] = mock
 
 def mock_decorator_with_params(*oargs, **okwargs):
     '''

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -120,6 +120,7 @@ MOCK_MODULES = [
     'MySQLdb',
     'MySQLdb.cursors',
     'nagios_json',
+    'psutil',
     'pycassa',
     'pymongo',
     'rabbitmq_server',


### PR DESCRIPTION
### What does this PR do?

Fixes sphinx doc generator on mocked imports.
### What issues does this PR fix or reference?
### Previous Behavior

```
No need to update translations. Skipping...
sphinx-build -b html -d _build/doctrees    . _build/html
Running Sphinx v1.4.6
making output directory...
loading translations [en]... done
loading pickled environment... not yet created
[autosummary] generating autosummary for: contents.rst, faq.rst, glossary.rst,
ref/auth/all/index.rst, ref/auth/all/salt.auth.auto.rst, ref/auth/all/salt.auth.django.rst,
ref/auth/all/salt.auth.keystone.rst, ref/auth/all/salt.auth.ldap.rst, 
ref/auth/all/salt.auth.mysql.rst, ref/auth/all/salt.auth.pam.rst, ...,
topics/tutorials/walkthrough_macosx.rst, topics/tutorials/writing_tests.rst,
topics/using_salt.rst, topics/virt/disk.rst, topics/virt/index.rst, topics/virt/nic.rst,
topics/windows/index.rst, topics/windows/windows-package-manager.rst,
topics/windows/windows-specific-behavior.rst, topics/yaml/index.rst

Exception occurred:
  File "/builds/salt-2016.3.2/salt/config/__init__.py", line 89, in _gather_buffer_space
    return max([total_mem * 0.05, 10 << 20])
TypeError: unsupported operand type(s) for *: 'Mock' and 'float'
The full traceback has been saved in /tmp/sphinx-err-MhWC7u.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
Makefile:73: recipe for target 'html' failed
make: *** [html] Error 1
```
### New Behavior

Problem gone.
### Tests written?

No
