### PR TITLE
Add persist option to chhome in mac_user.py

### DIFF
--- a/salt/modules/mac_user.py
+++ b/salt/modules/mac_user.py
@@ -268,7 +268,7 @@ def chhome(name, home, persist=False):
     Args:
         name (str): The name of the user to change
         home (str): The new location of the home directory
-        persist (bool): True to copy files from the old to the new directory
+        persist (bool): True to move files from the old to the new directory
 
     Returns:
         bool: True for success, False otherwise
@@ -295,7 +295,7 @@ def chhome(name, home, persist=False):
 
     # If persist, move the home directory contents to the new location
     if persist:
-        __salt__['cmd.run'](['mv', pre_info['home'], home])
+        __salt__['cmd.run'](['mv', '{0}\*'.format(pre_info['home']), home])
 
     return info(name).get('home') == home
 

--- a/salt/modules/mac_user.py
+++ b/salt/modules/mac_user.py
@@ -296,7 +296,9 @@ def chhome(name, home, persist=False):
 
     # If persist, move the home directory contents to the new location
     if persist:
-        if os.path.isdir(pre_info['home']):
+        if os.path.isdir(home):
+            __salt__['cmd.run'](['mv', '{0}/*'.format(pre_info['home']), home])
+        elif not os.path.isfile(home) and os.path.isdir(pre_info['home']):
             __salt__['cmd.run'](['mv', pre_info['home'], home])
 
     return info(name).get('home') == home

--- a/salt/modules/mac_user.py
+++ b/salt/modules/mac_user.py
@@ -294,10 +294,10 @@ def chhome(name, home, persist=False):
             moved = True
 
     # If the change fails and the file was moved, move it back
-    if not _dscl(['/Users/{0}'.format(name),
-                  'NFSHomeDirectory',
-                  pre_info['home'],
-                  home], ctype='change')['retcode'] and moved:
+    if _dscl(['/Users/{0}'.format(name),
+              'NFSHomeDirectory',
+              pre_info['home'],
+              home], ctype='change')['retcode'] and moved:
         __salt__['cmd.run_stderr'](['mv', home, pre_info['home']])
 
     # dscl buffers changes, sleep 1 second before checking if new value

--- a/salt/modules/mac_user.py
+++ b/salt/modules/mac_user.py
@@ -295,7 +295,7 @@ def chhome(name, home, persist=False):
 
     # If persist, move the home directory contents to the new location
     if persist:
-        __salt__['cmd.run'](['mv', '{0}\*'.format(pre_info['home']), home])
+        __salt__['cmd.run'](['mv', pre_info['home'], home])
 
     return info(name).get('home') == home
 

--- a/salt/modules/mac_user.py
+++ b/salt/modules/mac_user.py
@@ -296,7 +296,7 @@ def chhome(name, home, persist=False):
 
     # If persist, move the home directory contents to the new location
     if persist:
-        if os.path.isdir(home):
+        if os.path.isdir(home) and not os.listdir(home):
             __salt__['cmd.run'](['mv', '{0}/*'.format(pre_info['home']), home])
         elif not os.path.isfile(home) and os.path.isdir(pre_info['home']):
             __salt__['cmd.run'](['mv', pre_info['home'], home])

--- a/salt/modules/mac_user.py
+++ b/salt/modules/mac_user.py
@@ -17,6 +17,7 @@ except ImportError:
     pass
 import logging
 import time
+import os
 
 # Import 3rdp-party libs
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
@@ -295,7 +296,8 @@ def chhome(name, home, persist=False):
 
     # If persist, move the home directory contents to the new location
     if persist:
-        __salt__['cmd.run'](['mv', pre_info['home'], home])
+        if os.path.isdir(pre_info['home']):
+            __salt__['cmd.run'](['mv', pre_info['home'], home])
 
     return info(name).get('home') == home
 

--- a/salt/modules/mac_user.py
+++ b/salt/modules/mac_user.py
@@ -269,7 +269,13 @@ def chhome(name, home, persist=False):
     Args:
         name (str): The name of the user to change
         home (str): The new location of the home directory
+
+        .. versionadded:: 2016.3.4
         persist (bool): True to move files from the old to the new directory
+
+    .. note::
+        If persist is True and the new home directory already exists on the
+        system the home directory will not be moved.
 
     Returns:
         bool: True for success, False otherwise

--- a/salt/modules/mac_user.py
+++ b/salt/modules/mac_user.py
@@ -261,9 +261,17 @@ def chshell(name, shell):
     return info(name).get('shell') == shell
 
 
-def chhome(name, home):
+def chhome(name, home, persist=False):
     '''
     Change the home directory of the user
+
+    Args:
+        name (str): The name of the user to change
+        home (str): The new location of the home directory
+        persist (bool): True to copy files from the old to the new directory
+
+    Returns:
+        bool: True for success, False otherwise
 
     CLI Example:
 
@@ -284,6 +292,11 @@ def chhome(name, home):
     # dscl buffers changes, sleep 1 second before checking if new value
     # matches desired value
     time.sleep(1)
+
+    # If persist, move the home directory contents to the new location
+    if persist:
+        __salt__['cmd.run'](['mv', pre_info['home'], home])
+
     return info(name).get('home') == home
 
 


### PR DESCRIPTION
### What does this PR do?

Adds persist parameter to the chhome function in mac_user.py
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/31409
### Previous Behavior

States would fail if they passed the persist parameter
### New Behavior

States will no longer fail when they pass the persist parameter
### Tests written?

No
