### PR TITLE
event runner

### DIFF
--- a/salt/runners/event.py
+++ b/salt/runners/event.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+'''
+Module for sending events using the runner system.
+
+.. versionadded:: TBD
+'''
+from __future__ import absolute_import
+
+import logging
+
+import salt.utils.event
+
+
+log = logging.getLogger(__name__)
+
+
+def send(tag, data=None):
+    '''
+    Send an event with the given tag and data.
+
+    .. versionadded:: TBD
+
+    This is useful for sending events directly to the master from the shell
+    with salt-run. It is also quite useful for sending events in orchestration
+    states where the ``fire_event`` requisite isn't sufficient because it does
+    not support sending custom data with the event.
+
+    Note that event tags will *not* be namespaced like events sent with the
+    ``fire_event`` requisite! Whereas events produced from ``fire_event`` are
+    prefixed with ``salt/state_result/<jid>/<minion_id>/<name>``, events sent
+    using this runner module will have no such prefix. Make sure your reactors
+    don't expect a prefix!
+
+    :param tag: the tag to send with the event
+    :param data: an optional dictionary of data to send with the event
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run event.send my/custom/event '{"foo": "bar"}'
+
+    Orchestration Example:
+
+    .. code-block:: yaml
+
+        # orch/command.sls
+
+        run_a_command:
+          salt.function:
+            - name: cmd.run
+            - tgt: my_minion
+            - arg:
+              - exit {{ pillar['exit_code'] }}
+
+        send_success_event:
+          salt.runner:
+            - name: event.send
+            - tag: my_event/success
+            - data:
+                foo: bar
+            - require:
+              - salt: run_a_command
+
+        send_failure_event:
+          salt.runner:
+            - name: event.send
+            - tag: my_event/failure
+            - data:
+                baz: qux
+            - onfail:
+              - salt: run_a_command
+
+    .. code-block:: bash
+
+        salt-run state.orchestrate orch.command pillar='{"exit_code": 0}'
+        salt-run state.orchestrate orch.command pillar='{"exit_code": 1}'
+    '''
+    data = data or {}
+    event = salt.utils.event.get_master_event(__opts__, __opts__['sock_dir'],
+                                              listen=False)
+    return event.fire_event(data, tag)


### PR DESCRIPTION
### What does this PR do?

Adds an event runner, which can be used to:
- fire events directly into the master from the command line
- fire events in conjunction with orchestration where the `fire_event` requisite isn't sufficient (i.e., you need to fire an event with data)
### What issues does this PR fix or reference?

None, this is new code. It is somewhat related to the fix I submitted for the `fire_event` requisite (#34256). I wrote this runner after finding a few cases where `fire_event` was insufficient for my purposes because I needed to send a payload with the event.
### Tests written?

No
