### PR TITLE
fix 34241, webutil.useradd_all is deprecated

### DIFF
--- a/salt/states/htpasswd.py
+++ b/salt/states/htpasswd.py
@@ -68,9 +68,9 @@ def user_exists(name, password=None, htpasswd_file=None, options='',
             ret['changes'] = {name: True}
             return ret
 
-        useradd_ret = __salt__['webutil.useradd_all'](htpasswd_file, name,
-                                                      password, opts=options,
-                                                      runas=runas)
+        useradd_ret = __salt__['webutil.useradd'](htpasswd_file, name,
+                                                  password, opts=options,
+                                                  runas=runas)
         if useradd_ret['retcode'] == 0:
             ret['result'] = True
             ret['comment'] = useradd_ret['stderr']

--- a/tests/unit/states/htpasswd_test.py
+++ b/tests/unit/states/htpasswd_test.py
@@ -60,7 +60,7 @@ class HtpasswdTestCase(TestCase):
 
         with patch.dict(htpasswd.__salt__,
                         {'file.grep': mock_grep,
-                         'webutil.useradd_all': mock_useradd}):
+                         'webutil.useradd': mock_useradd}):
             ret = htpasswd.user_exists('larry', 'badpass',
                                        '/etc/httpd/htpasswd')
             expected = {'name': 'larry',
@@ -80,7 +80,7 @@ class HtpasswdTestCase(TestCase):
 
         with patch.dict(htpasswd.__salt__,
                         {'file.grep': mock_grep,
-                         'webutil.useradd_all': mock_useradd}):
+                         'webutil.useradd': mock_useradd}):
             ret = htpasswd.user_exists('larry', 'badpass',
                                        '/etc/httpd/htpasswd')
             expected = {'name': 'larry',


### PR DESCRIPTION
### What does this PR do?

Fix https://github.com/saltstack/salt/issues/34241

`webutil.useradd_all`is deprecated. Replace it with `webutil.useradd`
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
