### PR TITLE
[Don't merge] Reconnect syndic to event bus if master disappeared.

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2485,6 +2485,10 @@ class SyndicManager(MinionBase):
                 break
             master_id = masters.pop(0)
 
+    def reconnect_event_bus(self, something):
+        future = self.local.event.set_event_handler(self._process_event)
+        self.io_loop.add_future(future, self.reconnect_event_bus)
+
     # Syndic Tune In
     def tune_in(self):
         '''
@@ -2501,7 +2505,8 @@ class SyndicManager(MinionBase):
         # register the event sub to the poller
         self.job_rets = {}
         self.raw_events = []
-        self.local.event.set_event_handler(self._process_event)
+        future = self.local.event.set_event_handler(self._process_event)
+        self.io_loop.add_future(future, self.reconnect_event_bus)
 
         # forward events every syndic_event_forward_timeout
         self.forward_events = tornado.ioloop.PeriodicCallback(self._forward_events,

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -279,6 +279,9 @@ class IPCClient(object):
         if hasattr(self, '_connecting_future') and not self._connecting_future.done():  # pylint: disable=E0203
             future = self._connecting_future  # pylint: disable=E0203
         else:
+            if hasattr(self, '_connecting_future'):
+                # read previous future result to prevent the "unhandled future exception" error
+                self._connecting_future.exc_info()  # pylint: disable=E0203
             future = tornado.concurrent.Future()
             self._connecting_future = future
             self._connect(timeout=timeout)

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -773,7 +773,7 @@ class SaltEvent(object):
         if not self.cpub:
             self.connect_pub()
         # This will handle reconnects
-        self.subscriber.read_async(event_handler)
+        return self.subscriber.read_async(event_handler)
 
     def __del__(self):
         # skip exceptions in destroy-- since destroy() doesn't cover interpreter


### PR DESCRIPTION
### What does this PR do?

Fixes the syndic issue: if master is restarted syndic stops to listen the event bus thus stops forwarding job returns.
Also fixed a couple of issues related to the event bus connection errors handling.
### What issues does this PR fix or reference?
#34973
### Tests written?

No
