### PR TITLE
Fix #35741

### DIFF
--- a/salt/modules/modjk.py
+++ b/salt/modules/modjk.py
@@ -81,7 +81,7 @@ def _do_http(opts, profile='default'):
         raise Exception('missing url in profile {0}'.format(profile))
 
     if user and passwd:
-        auth = _auth(url, realm, user, passwd)
+        auth = _auth(url=url, realm=realm, user=user, passwd=passwd)
         _install_opener(auth)
 
     url += '?{0}'.format(_urlencode(opts))


### PR DESCRIPTION
### What does this PR do?

Correct use of HTTP credentials in modjk execution module,
### What issues does this PR fix or reference?
#35741
### Previous Behavior

Credentials fed are misused. All authentication process is broken and  any call ends in  401 traceback.
### New Behavior

Access to a password protected mod_jk web API works.
### Tests written?

No
