### PR TITLE
Trivial documentation spelling fix

### DIFF
--- a/doc/ref/states/writing.rst
+++ b/doc/ref/states/writing.rst
@@ -151,7 +151,7 @@ A State Module must return a dict containing the following keys/values:
 
 - **comment:** A string containing a summary of the result.
 
-The return data can also, include the **pchanges** key, this statnds for
+The return data can also, include the **pchanges** key, this stands for
 `predictive changes`. The **pchanges** key informs the State system what
 changes are predicted to occur.
 


### PR DESCRIPTION
### What does this PR do?

Make a single spelling fix in the documentation.
### What issues does this PR fix or reference?

None found
### Tests written?

No

---
- Change `statnds` to `stands` in State Writing documentation.
