### PR TITLE
Lower the retry timer for waiting for a server to come in

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -654,7 +654,7 @@ def wait_for_port(host, port=22, timeout=900, gateway=None):
         except socket.error:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
-            sock.settimeout(2)
+            sock.settimeout(5)
             sock.connect((test_ssh_host, int(test_ssh_port)))
             # Stop any remaining reads/writes on the socket
             sock.shutdown(socket.SHUT_RDWR)

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -654,7 +654,7 @@ def wait_for_port(host, port=22, timeout=900, gateway=None):
         except socket.error:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
-            sock.settimeout(30)
+            sock.settimeout(2)
             sock.connect((test_ssh_host, int(test_ssh_port)))
             # Stop any remaining reads/writes on the socket
             sock.shutdown(socket.SHUT_RDWR)


### PR DESCRIPTION
Since all we're doing is waiting on a socket, it's a little crazy
to wait 30s between tries. This makes salt-cloud really slow.
