### PR TITLE
Bump the deprecation warnings in glance module to Nitrogen

### DIFF
--- a/salt/modules/glance.py
+++ b/salt/modules/glance.py
@@ -250,9 +250,9 @@ def image_create(name, location=None, profile=None, visibility=None,
                'raw', 'qcow2', 'vdi', 'iso']
     # 'location' and 'visibility' are the parameters used in
     # Glance API v2. For now we have to use v1 for now (see below)
-    # but this modules interface will change in Carbon.
+    # but this modules interface will change in Nitrogen.
     if copy_from is not None or is_public is not None:
-        warn_until('Carbon', 'The parameters \'copy_from\' and '
+        warn_until('Nitrogen', 'The parameters \'copy_from\' and '
             '\'is_public\' are deprecated and will be removed. '
             'Use \'location\' and \'visibility\' instead.')
     if is_public is not None and visibility is not None:
@@ -381,8 +381,8 @@ def image_show(id=None, name=None, profile=None):  # pylint: disable=C0103
     ret_details = {}
     # I may want to use this code on Beryllium
     # until we got 2016.3.0 packages for Ubuntu
-    # so please keep this code until Carbon!
-    warn_until('Carbon', 'Starting with \'2016.3.0\' image_show() '
+    # so please keep this code until Nitrogen!
+    warn_until('Nitrogen', 'Starting with \'2016.3.0\' image_show() '
             'will stop wrapping the returned image in another '
             'dictionary.')
     if CUR_VER < BORON:
@@ -415,8 +415,8 @@ def image_list(id=None, profile=None, name=None):  # pylint: disable=C0103
     #
     # I may want to use this code on Beryllium
     # until we got 2016.3.0 packages for Ubuntu
-    # so please keep this code until Carbon!
-    warn_until('Carbon', 'Starting in \'2016.3.0\' image_list() '
+    # so please keep this code until Nitrogen!
+    warn_until('Nitrogen', 'Starting in \'2016.3.0\' image_list() '
         'will return a list of images instead of a dictionary '
         'keyed with the images\' names.')
     if CUR_VER < BORON:
@@ -509,8 +509,8 @@ def image_update(id=None, name=None, profile=None, **kwargs):  # pylint: disable
     updated = g_client.images.update(image['id'], **to_update)
     # I may want to use this code on Beryllium
     # until we got 2016.3.0 packages for Ubuntu
-    # so please keep this code until Carbon!
-    warn_until('Carbon', 'Starting with \'2016.3.0\' image_update() '
+    # so please keep this code until Nitrogen!
+    warn_until('Nitrogen', 'Starting with \'2016.3.0\' image_update() '
             'will stop wrapping the returned, updated image in '
             'another dictionary.')
     if CUR_VER < BORON:


### PR DESCRIPTION
### What does this PR do?

We're bumping the deprecation warnings until we've heard back from the module maintainer. This is being tracked in #35502.
