### PR TITLE
list_nodes_min should return a minimum dictionary

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -1261,7 +1261,7 @@ def list_nodes_min(kwargs=None, call=None):
     vm_list = salt.utils.vmware.get_mors_with_properties(_get_si(), vim.VirtualMachine, vm_properties)
 
     for vm in vm_list:
-        ret[vm["name"]] = True
+        ret[vm['name']] = {'state': 'Running', 'id': vm['name']}
 
     return ret
 


### PR DESCRIPTION
### What does this PR do?

vmware list_nodes_min used to return a bool True, instead of a dictionary with minimum information about vms.
### Tests written?

No