### PR TITLE
Fix traceback in salt-cloud logging for Azure

### DIFF
--- a/salt/utils/nb_popen.py
+++ b/salt/utils/nb_popen.py
@@ -93,7 +93,7 @@ class NonBlockingPopen(subprocess.Popen):
         log.info(
             'Running command under pid %s: \'%s\'',
             self.pid,
-            *args if logging_command is None else logging_command
+            args if logging_command is None else logging_command
         )
 
     def recv(self, maxsize=None):


### PR DESCRIPTION
This regressed in develop only, because of 20ed2c6
