### PR TITLE
Deep merge with file.serialize merge_if_exists=True

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -248,6 +248,7 @@ from collections import Iterable, Mapping
 import salt.loader
 import salt.payload
 import salt.utils
+import salt.utils.dictupdate
 import salt.utils.templates
 import salt.utils.url
 from salt.utils.locales import sdecode
@@ -4601,8 +4602,7 @@ def serialize(name,
                 existing_data = __serializers__[deserializer_name](fhr)
 
             if existing_data is not None:
-                merged_data = existing_data.copy()
-                merged_data.update(dataset)
+                merged_data = salt.utils.dictupdate.merge_recurse(existing_data, dataset)
                 if existing_data == merged_data:
                     ret['result'] = True
                     ret['comment'] = 'The file {0} is in the correct state'.format(name)


### PR DESCRIPTION
Deep merge data in the `file.serialize` state when `merge_if_exists` is True.

Should this be togglable? And maybe with a `merge_lists` argument as well?

Technically this is a breaking feature but I can't see why you _wouldn't_ want this behaviour.
