### PR TITLE
Ensure ssh keys are decodable before inserting

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -645,6 +645,15 @@ def set_auth_key(
     uinfo = __salt__['user.info'](user)
     if not uinfo:
         return 'fail'
+
+    # A 'valid key' to us pretty much means 'decodable as base64', which is
+    # the same filtering done when reading the authorized_keys file. Apply
+    # the same check to ensure we don't insert anything that will not
+    # subsequently be read)
+    key_is_valid = _fingerprint(key) is not None
+    if not key_is_valid:
+        return 'Invalid public key'
+
     status = check_key(user, key, enc, comment, options, config, cache_keys)
     if status == 'update':
         _replace_auth_key(user, key, enc, comment, options or [], config)

--- a/tests/unit/modules/ssh_test.py
+++ b/tests/unit/modules/ssh_test.py
@@ -19,6 +19,12 @@ from salt.exceptions import CommandExecutionError
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class SSHAuthKeyTestCase(TestCase):
+
+    def setUp(self):
+        ssh.__salt__ = {
+            'user.info': lambda u: getattr(self, 'user_info_mock', None),
+        }
+
     '''
     TestCase for salt.modules.ssh
     '''
@@ -49,6 +55,13 @@ class SSHAuthKeyTestCase(TestCase):
 
         path = '/home/%dude'
         self.assertRaises(CommandExecutionError, ssh._expand_authorized_keys_path, path, user, home)
+
+
+    def test_set_auth_key_invalid(self):
+        self.user_info_mock = {'home': '/dev/null'}
+        # Inserting invalid public key should be rejected
+        invalid_key = 'AAAAB3NzaC1kc3MAAACBAL0sQ9fJ5bYTEyY' # missing padding
+        self.assertEqual(ssh.set_auth_key('user', invalid_key), 'Invalid public key')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?

Prevent invalid keys from being written to the `authorized_keys` file. Without this the key would be written, but not read, causing it to be written again on next run.
### What issues does this PR fix or reference?
saltstack/salt#35631
### Tests written?

Yes. Although pretty poor coverage from earlier.