### PR TITLE
Fixed a bug in windows hostname settings when the hostname is longer …

### DIFF
--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -544,9 +544,9 @@ def get_hostname():
 
         salt 'minion-id' system.get_hostname
     '''
-    cmd = 'wmic computersystem get name'
+    cmd = 'wmic nicconfig get dnshostname'
     ret = __salt__['cmd.run'](cmd=cmd)
-    _, hostname = ret.split("\n")
+    _, _, hostname = ret.split("\n")
     return hostname
 
 

--- a/tests/unit/modules/win_system_test.py
+++ b/tests/unit/modules/win_system_test.py
@@ -291,11 +291,11 @@ class WinSystemTestCase(TestCase):
         '''
             Test setting a new hostname
         '''
-        cmd_run_mock = MagicMock(return_value="Name\nMINION")
+        cmd_run_mock = MagicMock(return_value="DNSHostName\n\nMINION")
         with patch.dict(win_system.__salt__, {'cmd.run': cmd_run_mock}):
             ret = win_system.get_hostname()
             self.assertEqual(ret, "MINION")
-        cmd_run_mock.assert_called_once_with(cmd="wmic computersystem get name")
+        cmd_run_mock.assert_called_once_with(cmd="wmic nicconfig get dnshostname")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
…than 15 chars
- The previous implementation was limited to the 15 char limit for "Computernames" which would cause the state to always fail if the hostname was longer

PR of #35722 re-submitted against develop.
