### PR TITLE
Fix potential infinite loop with no error when using recursive makedirs

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4609,7 +4609,14 @@ def makedirs_(path,
             break
 
         directories_to_create.append(dirname)
+        current_dirname = dirname
         dirname = os.path.dirname(dirname)
+
+        if current_dirname == dirname:
+            raise SaltInvocationError(
+                'Recursive creation for path \'{0}\' would result in an '
+                'infinite loop. Please use an absolute path.'.format(dirname)
+            )
 
     # create parent directories from the topmost to the most deeply nested one
     directories_to_create.reverse()


### PR DESCRIPTION
### What does this PR do?

Fix an infinite loop in the file.makedirs function. If you provide a relative path with a trailing `/` (e.g. : `file.makedirs mydir/`), it will result in an infinite loop since the first loop will return `"mydir"` and `os.path.dirname("mydir")` will return an empty string, which is not a directory that can exists.

I ran into this passing a relative path to archive.extracted state, which add a / to the path if it's not present, but the behavior is the same when calling the module directly
### What issues does this PR fix or reference?

Maybe #34478 ?
### Previous Behavior

Infinite loop when calling `file.makedirs` with a relative path which have a trailing path
### New Behavior

Throw an error when an infinite loop is detected
### Tests written?

No
