### PR TITLE
This fixes a regression in the file state

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2868,7 +2868,7 @@ def retention_schedule(name, retain, strptime_format=None, timezone=None):
     def get_file_time_from_strptime(f):
         try:
             ts = datetime.strptime(f, strptime_format)
-            ts_epoch = (ts - beginning_of_unix_time).total_seconds()
+            ts_epoch = salt.utils.total_seconds(ts - beginning_of_unix_time)
             return (ts, ts_epoch)
         except ValueError:
             # Files which don't match the pattern are not relevant files.


### PR DESCRIPTION
This was introduced in 6fedd7f68d963c6865127bcab9684966aa653313

This is not supported in 2.6. Changed to use Salt's total_seconds wrapper.
