### PR TITLE
[REGRESSION] salt-cloud: fix path to Salt Master socket dir

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1718,12 +1718,14 @@ def run_inline_script(host,
 def fire_event(key, msg, tag, args=None, sock_dir=None, transport='zeromq'):
     # Fire deploy action
     if sock_dir is None:
-        sock_dir = os.path.join(__opts__['sock_dir'], 'master')
+        sock_dir = __opts__['sock_dir']
+
     event = salt.utils.event.get_event(
         'master',
         sock_dir,
         transport,
         listen=False)
+
     try:
         event.fire_event(msg, tag)
     except ValueError:


### PR DESCRIPTION
### What does this PR do?

It fixes path to the Master's socket directory for Salt Cloud to be able to fire events.
### What issues does this PR fix or reference?

The regression was introduced by PR #35483.
I think this fix should be backported to `2015.8` branch as well.
### Previous Behavior

Salt Cloud probes wrong socket directory: /var/run/salt/master/**master**/

```
[DEBUG   ] MasterEvent PUB socket URI: /var/run/salt/master/master/master_event_pub.ipc
[DEBUG   ] MasterEvent PULL socket URI: /var/run/salt/master/master/master_event_pull.ipc
[DEBUG   ] Initializing new IPCClient for path: /var/run/salt/master/master/master_event_pull.ipc
```
### New Behavior

Now the path is correct:

```
[DEBUG   ] MasterEvent PUB socket URI: /var/run/salt/master/master_event_pub.ipc
[DEBUG   ] MasterEvent PULL socket URI: /var/run/salt/master/master_event_pull.ipc
[DEBUG   ] Initializing new IPCClient for path: /var/run/salt/master/master_event_pull.ipc
```
### Tests written?

No