### PR TITLE
Make ddns_test happy with py3 and py26

### DIFF
--- a/tests/unit/modules/ddns_test.py
+++ b/tests/unit/modules/ddns_test.py
@@ -4,7 +4,7 @@
 '''
 # Import Python libs
 from __future__ import absolute_import
-import contextlib
+import textwrap
 import json
 try:
     import dns.query

--- a/tests/unit/modules/ddns_test.py
+++ b/tests/unit/modules/ddns_test.py
@@ -99,14 +99,12 @@ class DDNSTestCase(TestCase):
         def mock_udp_query(*args, **kwargs):
             return MockAnswer
 
-        # pylint: disable=E0598
         with patch.object(dns.message, 'make_query', MagicMock(return_value=mock_request)):
             with patch.object(dns.query, 'udp', mock_udp_query()):
                 with patch.object(dns.rdatatype, 'from_text', MagicMock(return_value=mock_rdtype)):
                     with patch.object(ddns, '_get_keyring', return_value=None):
                         with patch.object(ddns, '_config', return_value=None):
                             self.assertTrue(ddns.update('zone', 'name', 1, 'AAAA', '::1'))
-        # pylint: enable=E0598
 
     def test_delete(self):
         '''
@@ -124,14 +122,12 @@ class DDNSTestCase(TestCase):
         def mock_udp_query(*args, **kwargs):
             return MockAnswer
 
-        # pylint: disable=E0598
         with patch.object(dns.query, 'udp', mock_udp_query()):
             with patch('salt.utils.fopen', mock_open(read_data=file_data), create=True):
                 with patch.object(dns.tsigkeyring, 'from_text', return_value=True):
                     with patch.object(ddns, '_get_keyring', return_value=None):
                         with patch.object(ddns, '_config', return_value=None):
                             self.assertTrue(ddns.delete(zone='A', name='B'))
-        # pylint: enable=E0598
 
 
 if __name__ == '__main__':

--- a/tests/unit/modules/ddns_test.py
+++ b/tests/unit/modules/ddns_test.py
@@ -5,7 +5,6 @@
 # Import Python libs
 from __future__ import absolute_import
 import contextlib
-import textwrap
 import json
 try:
     import dns.query
@@ -26,7 +25,6 @@ from salttesting.mock import (
 )
 
 # Import Salt Libs
-import salt.ext.six as six
 from salt.modules import ddns
 
 # Globals

--- a/tests/unit/modules/ddns_test.py
+++ b/tests/unit/modules/ddns_test.py
@@ -99,23 +99,14 @@ class DDNSTestCase(TestCase):
         def mock_udp_query(*args, **kwargs):
             return MockAnswer
 
-        if six.PY3:
-            # pylint: disable=E0598
-            with patch.object(dns.message, 'make_query', MagicMock(return_value=mock_request)):
-                with patch.object(dns.query, 'udp', mock_udp_query()):
-                    with patch.object(dns.rdatatype, 'from_text', MagicMock(return_value=mock_rdtype)):
-                        with patch.object(ddns, '_get_keyring', return_value=None):
-                            with patch.object(ddns, '_config', return_value=None):
-                                self.assertTrue(ddns.update('zone', 'name', 1, 'AAAA', '::1'))
-            # pylint: enable=E0598
-        else:
-            with contextlib.nested(
-                    patch.object(dns.message, 'make_query', MagicMock(return_value=mock_request)),
-                    patch.object(dns.query, 'udp', mock_udp_query()),
-                    patch.object(dns.rdatatype, 'from_text', MagicMock(return_value=mock_rdtype)),
-                    patch.object(ddns, '_get_keyring', return_value=None),
-                    patch.object(ddns, '_config', return_value=None)):
-                self.assertTrue(ddns.update('zone', 'name', 1, 'AAAA', '::1'))
+        # pylint: disable=E0598
+        with patch.object(dns.message, 'make_query', MagicMock(return_value=mock_request)):
+            with patch.object(dns.query, 'udp', mock_udp_query()):
+                with patch.object(dns.rdatatype, 'from_text', MagicMock(return_value=mock_rdtype)):
+                    with patch.object(ddns, '_get_keyring', return_value=None):
+                        with patch.object(ddns, '_config', return_value=None):
+                            self.assertTrue(ddns.update('zone', 'name', 1, 'AAAA', '::1'))
+        # pylint: enable=E0598
 
     def test_delete(self):
         '''
@@ -133,23 +124,14 @@ class DDNSTestCase(TestCase):
         def mock_udp_query(*args, **kwargs):
             return MockAnswer
 
-        if six.PY3:
-            # pylint: disable=E0598
-            with patch.object(dns.query, 'udp', mock_udp_query()):
-                with patch('salt.utils.fopen', mock_open(read_data=file_data), create=True):
-                    with patch.object(dns.tsigkeyring, 'from_text', return_value=True):
-                        with patch.object(ddns, '_get_keyring', return_value=None):
-                            with patch.object(ddns, '_config', return_value=None):
-                                self.assertTrue(ddns.delete(zone='A', name='B'))
-            # pylint: enable=E0598
-        else:
-            with contextlib.nested(
-                    patch.object(dns.query, 'udp', mock_udp_query()),
-                    patch('salt.utils.fopen', mock_open(read_data=file_data), create=True),
-                    patch.object(dns.tsigkeyring, 'from_text', return_value=True),
-                    patch.object(ddns, '_get_keyring', return_value=None),
-                    patch.object(ddns, '_config', return_value=None)):
-                self.assertTrue(ddns.delete(zone='A', name='B'))
+        # pylint: disable=E0598
+        with patch.object(dns.query, 'udp', mock_udp_query()):
+            with patch('salt.utils.fopen', mock_open(read_data=file_data), create=True):
+                with patch.object(dns.tsigkeyring, 'from_text', return_value=True):
+                    with patch.object(ddns, '_get_keyring', return_value=None):
+                        with patch.object(ddns, '_config', return_value=None):
+                            self.assertTrue(ddns.delete(zone='A', name='B'))
+        # pylint: enable=E0598
 
 
 if __name__ == '__main__':

--- a/tests/unit/modules/ddns_test.py
+++ b/tests/unit/modules/ddns_test.py
@@ -101,12 +101,12 @@ class DDNSTestCase(TestCase):
 
         if six.PY3:
             # pylint: disable=E0598
-            with patch.object(dns.message, 'make_query', MagicMock(return_value=mock_request)), \
-                    patch.object(dns.query, 'udp', mock_udp_query()), \
-                    patch.object(dns.rdatatype, 'from_text', MagicMock(return_value=mock_rdtype)), \
-                    patch.object(ddns, '_get_keyring', return_value=None), \
-                    patch.object(ddns, '_config', return_value=None):
-                self.assertTrue(ddns.update('zone', 'name', 1, 'AAAA', '::1'))
+            with patch.object(dns.message, 'make_query', MagicMock(return_value=mock_request)):
+                with patch.object(dns.query, 'udp', mock_udp_query()):
+                    with patch.object(dns.rdatatype, 'from_text', MagicMock(return_value=mock_rdtype)):
+                        with patch.object(ddns, '_get_keyring', return_value=None):
+                            with patch.object(ddns, '_config', return_value=None):
+                                self.assertTrue(ddns.update('zone', 'name', 1, 'AAAA', '::1'))
             # pylint: enable=E0598
         else:
             with contextlib.nested(
@@ -135,12 +135,12 @@ class DDNSTestCase(TestCase):
 
         if six.PY3:
             # pylint: disable=E0598
-            with patch.object(dns.query, 'udp', mock_udp_query()), \
-                    patch('salt.utils.fopen', mock_open(read_data=file_data), create=True), \
-                    patch.object(dns.tsigkeyring, 'from_text', return_value=True), \
-                    patch.object(ddns, '_get_keyring', return_value=None), \
-                    patch.object(ddns, '_config', return_value=None):
-                self.assertTrue(ddns.delete(zone='A', name='B'))
+            with patch.object(dns.query, 'udp', mock_udp_query()):
+                with patch('salt.utils.fopen', mock_open(read_data=file_data), create=True):
+                    with patch.object(dns.tsigkeyring, 'from_text', return_value=True):
+                        with patch.object(ddns, '_get_keyring', return_value=None):
+                            with patch.object(ddns, '_config', return_value=None):
+                                self.assertTrue(ddns.delete(zone='A', name='B'))
             # pylint: enable=E0598
         else:
             with contextlib.nested(


### PR DESCRIPTION
### What does this PR do?

Makes python26 and python3 happy when we have multiple with statements. python26 doesn't let you break up lines with `, \` and this way of nesting with statements makes both 2.6 and 3 happy. 

If there is a better way to do this, I'm all ears. 

@rallytime 
### What issues does this PR fix or reference?
### Tests written?

Yes
