### PR TITLE
change osmajorrelease check to string to fix pkgrepo test

### DIFF
--- a/tests/integration/files/file/base/pkgrepo/managed.sls
+++ b/tests/integration/files/file/base/pkgrepo/managed.sls
@@ -1,7 +1,7 @@
 {% if grains['os'] == 'CentOS' %}
 
 # START CentOS pkgrepo tests
-{% if grains['osmajorrelease'] == 7 %}
+{% if grains['osmajorrelease'] == '7' %}
 epel-salttest:
   pkgrepo.managed:
     - humanname: Extra Packages for Enterprise Linux 7 - $basearch (salttest)


### PR DESCRIPTION
### What does this PR do?

Change osmajorrelease check back to a string. The grain still returns a string until a later release. 
### What issues does this PR fix or reference?

Fixes failing test
### Tests written?

Yes