### PR TITLE
Add more helpful return messages for drac runner

### DIFF
--- a/salt/runners/drac.py
+++ b/salt/runners/drac.py
@@ -5,11 +5,12 @@ Manage Dell DRAC from the Master
 The login credentials need to be configured in the Salt master
 configuration file.
 
-  .. code-block: yaml
+.. code-block: yaml
 
-      drac:
-        username: admin
-        password: secret
+    drac:
+      username: admin
+      password: secret
+
 '''
 
 # Import python libs
@@ -38,17 +39,18 @@ def __connect(hostname, timeout=20, username=None, password=None):
     Connect to the DRAC
     '''
     drac_cred = __opts__.get('drac')
+    err_msg = 'No drac login credentials found. Please add the \'username\' and \'password\' ' \
+              'fields beneath a \'drac\' key in the master configuration file. Or you can ' \
+              'pass in a username and password as kwargs at the CLI.'
 
     if not username:
         if drac_cred is None:
-            log.error('No drac login credentials found. Please add a drac username and password'
-                      'in the master configuration file or pass in a username at the CLI.')
+            log.error(err_msg)
             return False
         username = drac_cred.get('username', None)
     if not password:
         if drac_cred is None:
-            log.error('No drac login credentials found. Please add a drac username and password'
-                      'in the master configuration file or pass in a password at the CLI.')
+            log.error(err_msg)
             return False
         password = drac_cred.get('password', None)
 

--- a/salt/runners/drac.py
+++ b/salt/runners/drac.py
@@ -30,18 +30,27 @@ def __virtual__():
     if HAS_PARAMIKO:
         return True
 
-    return False
+    return False, 'The drac runner module cannot be loaded: paramiko package is not installed.'
 
 
 def __connect(hostname, timeout=20, username=None, password=None):
     '''
     Connect to the DRAC
     '''
+    drac_cred = __opts__.get('drac')
 
     if not username:
-        username = __opts__['drac'].get('username', None)
+        if drac_cred is None:
+            log.error('No drac login credentials found. Please add a drac username and password'
+                      'in the master configuration file or pass in a username at the CLI.')
+            return False
+        username = drac_cred.get('username', None)
     if not password:
-        password = __opts__['drac'].get('password', None)
+        if drac_cred is None:
+            log.error('No drac login credentials found. Please add a drac username and password'
+                      'in the master configuration file or pass in a password at the CLI.')
+            return False
+        password = drac_cred.get('password', None)
 
     client = paramiko.SSHClient()
     client.set_missing_host_key_policy(paramiko.AutoAddPolicy())


### PR DESCRIPTION
We should also be more helpful and protect against a KeyError and stacktrace when the "drac" username and password are not in the master config file or passed in at the CLI.

Fixes #35825