### PR TITLE
result gets set to True only when Force==false

### DIFF
--- a/tests/unit/states/dockerng_test.py
+++ b/tests/unit/states/dockerng_test.py
@@ -340,7 +340,7 @@ class DockerngTestCase(TestCase):
             ret = dockerng_state.image_present('image:latest', force=True)
             self.assertEqual(ret,
                              {'changes': {},
-                              'result': True,
+                              'result': False,
                               'comment': "Image 'image:latest' was pulled, "
                               "but there were no changes",
                               'name': 'image:latest',


### PR DESCRIPTION
### What does this PR do?

Dockerng.image_present sets result as True when force==True. 
### What issues does this PR fix or reference?

Fixes failing test on jenkins
### Tests written?

Yes
