### PR TITLE
Clean up some of the warnings during a doc build

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -68,6 +68,7 @@ MOCK_MODULES = [
     'yaml',
     'yaml.constructor',
     'yaml.nodes',
+    'yaml.parser',
     'yaml.scanner',
     'zmq',
     'zmq.eventloop',

--- a/doc/ref/engines/all/index.rst
+++ b/doc/ref/engines/all/index.rst
@@ -11,9 +11,9 @@ engine modules
     :template: autosummary.rst.tmpl
 
     docker_events
+    http_logstash
     logentries
     logstash
-    logstash_http
     reactor
     redis_sentinel
     slack

--- a/doc/ref/engines/all/salt.engines.http_logstash.rst
+++ b/doc/ref/engines/all/salt.engines.http_logstash.rst
@@ -1,0 +1,6 @@
+==========================
+salt.engines.http_logstash
+==========================
+
+.. automodule:: salt.engines.http_logstash
+    :members:

--- a/doc/ref/engines/all/salt.engines.logstash_http.rst
+++ b/doc/ref/engines/all/salt.engines.logstash_http.rst
@@ -1,6 +1,0 @@
-==========================
-salt.engines.logstash_http
-==========================
-
-.. automodule:: salt.engines.logstash_http
-    :members:

--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -236,7 +236,6 @@ execution modules
     nfs3
     nftables
     nginx
-    node
     nova
     npm
     nspawn

--- a/doc/ref/modules/all/salt.modules.node.rst
+++ b/doc/ref/modules/all/salt.modules.node.rst
@@ -1,6 +1,0 @@
-=================
-salt.modules.node
-=================
-
-.. automodule:: salt.modules.node
-    :members:

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -91,8 +91,6 @@ from __future__ import absolute_import
 import sys
 
 # Import salt libs
-import salt.utils
-
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 from salt.modules.aptpkg import _strip_uri
 from salt.state import STATE_INTERNAL_KEYWORDS as _STATE_INTERNAL_KEYWORDS


### PR DESCRIPTION
- Remove references to logstash_http engine: should be http_logstash.
- Remove node refernce in execution module docs: doesn't exist.
- Add yaml.parser to doc build mocks
- Don't import salt.utils twice in the pkgrepo state
