### PR TITLE
pacman.py: Fix incorrect return in pkg.latest_version

### DIFF
--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -89,14 +89,6 @@ def latest_version(*names, **kwargs):
         except (ValueError, IndexError):
             pass
 
-    pkgs = {}
-
-    for name in names:
-        if not ret[name]:
-            if not pkgs:
-                pkgs = list_pkgs()
-            if name in pkgs:
-                ret[name] = pkgs[name]
     # Return a string if only one package name passed
     if len(names) == 1:
         return ret[names[0]]


### PR DESCRIPTION
This was initially broken in 75fd92f. The documented behavior of this
function is to return an empty string for the package when the package
is up-to-date. Changing that behavior negatively affects the pkg.latest
state, which relies on the documented behavior.

This happened not to cause a problem with `pkg.latest` until I removed
the version check that was hiding this problem, in 667f31a several weeks
ago.