### PR TITLE
Add clarifying comments to the pkg.latest state, fix USE flag condition

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1626,15 +1626,21 @@ def latest(
     problems = []
     for pkg in desired_pkgs:
         if not avail[pkg]:
+            # Package either a) is up-to-date, or b) does not exist
             if not cur[pkg]:
+                # Package does not exist
                 msg = 'No information found for \'{0}\'.'.format(pkg)
                 log.error(msg)
                 problems.append(msg)
             elif watch_flags \
                     and __grains__.get('os') == 'Gentoo' \
                     and __salt__['portage_config.is_changed_uses'](pkg):
+                # Package is up-to-date, but Gentoo USE flags are changing so
+                # we need to add it to the targets
                 targets[pkg] = avail[pkg]
         else:
+            # Package either a) is not installed, or b) is installed and has an
+            # upgrade available
             targets[pkg] = avail[pkg]
 
     if problems:

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1637,7 +1637,7 @@ def latest(
                     and __salt__['portage_config.is_changed_uses'](pkg):
                 # Package is up-to-date, but Gentoo USE flags are changing so
                 # we need to add it to the targets
-                targets[pkg] = avail[pkg]
+                targets[pkg] = cur[pkg]
         else:
             # Package either a) is not installed, or b) is installed and has an
             # upgrade available


### PR DESCRIPTION
These comments explain what is being done as we evaluate which packages
need to be added to the install targets and which do not.

Additionally, the condition which determines what value we add to the targets
when a Gentoo package needs to be rebuilt with new USE flags has been
corrected.
