### PR TITLE
Clarifies how to create aliased functions

### DIFF
--- a/doc/ref/modules/index.rst
+++ b/doc/ref/modules/index.rst
@@ -466,6 +466,26 @@ logs. The following code snippet demonstrates writing log messages:
     log.warning('You Should Not Do That')
     log.error('It Is Busted')
 
+Aliasing Functions
+==================
+
+Sometimes one wishes to use a function name that would shadow a python built-in.
+A common example would be ``set()``. To support this, append an underscore to
+the function defintion, ``def set_():``, and use the ``__func_alias__`` feature
+to provide an alias to the function.
+
+``__func_alias__`` is a dictionary where each key is the name of a function in
+the module, and each value is a string representing the alias for that function.
+When calling an aliased function from a different execution module, state
+module, or from the cli, the alias name should be used.
+
+.. code-block:: python
+
+    __func_alias__ = {
+        'set_': 'set',
+        'list_': 'list',
+    }
+
 Private Functions
 =================
 
@@ -494,12 +514,6 @@ Objects NOT Loaded into the Salt Minion
         return baz
 
     cheese = {} # Not a callable Python object
-
-.. note::
-
-    Some callable names also end with an underscore ``_``, to avoid keyword clashes
-    with Python keywords.  When using execution modules, or state modules, with these
-    in them the trailing underscore should be omitted.
 
 Useful Decorators for Modules
 =============================


### PR DESCRIPTION
Noticed that there was no explicit documentation on the `__func_alias__` feature, so I wrote up a small section.

I deleted the sort-of-related note from the Private Functions section because it wasn't all that clear and because it really isn't all that related to private functions. It seemed like it would just be confusing to try to clarify aliased functions within the private function section.

Thanks @cachedout for pointing out the feature, [in this comment](https://github.com/saltstack/salt/pull/35738#issuecomment-243367192). Also, the only other documentation I could find on the feature was in the [sdb module](https://docs.saltstack.com/en/latest/topics/sdb/#writing-sdb-modules).