### PR TITLE
Add additional logging to Linode salt-cloud driver

### DIFF
--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -868,9 +868,11 @@ def get_distribution_id(vm_):
     if not distro_id:
         raise SaltCloudNotFound(
             'The DistributionID for the \'{0}\' profile could not be found.\n'
-            'The \'{1}\' instance could not be provisioned.'.format(
+            'The \'{1}\' instance could not be provisioned. The following distributions '
+            'are available:\n{2}'.format(
                 vm_image_name,
-                vm_['name']
+                vm_['name'],
+                pprint.pprint([distro['LABEL'].encode(__salt_system_encoding__) for distro in distributions])
             )
         )
 

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -872,7 +872,7 @@ def get_distribution_id(vm_):
             'are available:\n{2}'.format(
                 vm_image_name,
                 vm_['name'],
-                pprint.pprint([distro['LABEL'].encode(__salt_system_encoding__) for distro in distributions])
+                pprint.pprint(sorted([distro['LABEL'].encode(__salt_system_encoding__) for distro in distributions]))
             )
         )
 


### PR DESCRIPTION
Now displays the following when a profile can't be resolved:

```
Usage: salt-cloud

salt-cloud: error: There was a profile error: The DistributionID for the 'Ubuntu 16.04' profile could not be found.
The 'zjenkins-ubuntu16-a302b4' instance could not be provisioned. The following distributions are available:
['Arch 2016.06.01',
 'CentOS 5.6',
 'CentOS 6.5',
 'CentOS 7',
 'Debian 7',
 'Debian 8',
 'Fedora 23',
 'Fedora 24',
 'Gentoo 2013-11-26',
 'Gentoo 2014.12',
 'Slackware 13.37',
 'Slackware 13.37 32bit',
 'Slackware 14.1',
 'Ubuntu 12.04 LTS',
 'Ubuntu 14.04 LTS',
 'Ubuntu 16.04 LTS',
 'openSUSE 13.1',
 'openSUSE 13.2',
 'openSUSE Leap 42.1']
```
