### PR TITLE
Fix Salt Cloud cache directory path

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -4593,7 +4593,7 @@ def _parse_pricing(url, name):
         regions[region['region']] = sizes
 
     outfile = os.path.join(
-        __opts__['cachedir'], 'cloud', 'ec2-pricing-{0}.p'.format(name)
+        __opts__['cachedir'], 'ec2-pricing-{0}.p'.format(name)
     )
     with salt.utils.fopen(outfile, 'w') as fho:
         msgpack.dump(regions, fho)
@@ -4657,7 +4657,7 @@ def show_pricing(kwargs=None, call=None):
         name = 'linux'
 
     pricefile = os.path.join(
-        __opts__['cachedir'], 'cloud', 'ec2-pricing-{0}.p'.format(name)
+        __opts__['cachedir'], 'ec2-pricing-{0}.p'.format(name)
     )
 
     if not os.path.isfile(pricefile):

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -2166,7 +2166,7 @@ def update_pricing(kwargs=None, call=None):
     price_json = http.query(url, decode=True, decode_type='json')
 
     outfile = os.path.join(
-        __opts__['cachedir'], 'cloud', 'gce-pricing.p'
+        __opts__['cachedir'], 'gce-pricing.p'
     )
     with salt.utils.fopen(outfile, 'w') as fho:
         msgpack.dump(price_json['dict'], fho)
@@ -2202,7 +2202,7 @@ def show_pricing(kwargs=None, call=None):
 
     size = 'CP-COMPUTEENGINE-VMIMAGE-{0}'.format(profile['size'].upper())
     pricefile = os.path.join(
-        __opts__['cachedir'], 'cloud', 'gce-pricing.p'
+        __opts__['cachedir'], 'gce-pricing.p'
     )
     if not os.path.exists(pricefile):
         update_pricing()

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -2525,7 +2525,8 @@ def init_cachedir(base=None):
     Initialize the cachedir needed for Salt Cloud to keep track of minions
     '''
     if base is None:
-        base = os.path.join(__opts__['cachedir'], 'cloud')
+        base = __opts__['cachedir']
+
     needed_dirs = (base,
                    os.path.join(base, 'requested'),
                    os.path.join(base, 'active'))
@@ -2555,7 +2556,7 @@ def request_minion_cachedir(
     will be set to None.
     '''
     if base is None:
-        base = os.path.join(__opts__['cachedir'], 'cloud')
+        base = __opts__['cachedir']
 
     if not fingerprint and pubkey is not None:
         fingerprint = salt.utils.pem_finger(key=pubkey, sum_type=(opts and opts.get('hash_type') or 'sha256'))
@@ -2597,7 +2598,7 @@ def change_minion_cachedir(
         return False
 
     if base is None:
-        base = os.path.join(__opts__['cachedir'], 'cloud')
+        base = __opts__['cachedir']
 
     fname = '{0}.p'.format(minion_id)
     path = os.path.join(base, cachedir, fname)
@@ -2618,7 +2619,7 @@ def activate_minion_cachedir(minion_id, base=None):
     exists, and should be expected to exist from here on out.
     '''
     if base is None:
-        base = os.path.join(__opts__['cachedir'], 'cloud')
+        base = __opts__['cachedir']
 
     fname = '{0}.p'.format(minion_id)
     src = os.path.join(base, 'requested', fname)
@@ -2636,7 +2637,7 @@ def delete_minion_cachedir(minion_id, provider, opts, base=None):
         return
 
     if base is None:
-        base = os.path.join(__opts__['cachedir'], 'cloud')
+        base = __opts__['cachedir']
 
     driver = next(six.iterkeys(opts['providers'][provider]))
     fname = '{0}.p'.format(minion_id)
@@ -2656,7 +2657,7 @@ def list_cache_nodes_full(opts, provider=None, base=None):
         return
 
     if base is None:
-        base = os.path.join(__opts__['cachedir'], 'cloud', 'active')
+        base = os.path.join(__opts__['cachedir'], 'active')
 
     minions = {}
     # First, get a list of all drivers in use
@@ -2687,7 +2688,7 @@ def cache_nodes_ip(opts, base=None):
     addresses. Returns a dict.
     '''
     if base is None:
-        base = os.path.join(__opts__['cachedir'], 'cloud')
+        base = __opts__['cachedir']
 
     minions = list_cache_nodes_full(opts, base=base)
 
@@ -2867,7 +2868,7 @@ def cache_node(node, provider, opts):
     if 'update_cachedir' not in opts or not opts['update_cachedir']:
         return
 
-    base = os.path.join(__opts__['cachedir'], 'cloud', 'active')
+    base = os.path.join(__opts__['cachedir'], 'active')
     if not os.path.exists(base):
         init_cachedir()
 


### PR DESCRIPTION
### What does this PR do?

Subj. Details are below.
### What issues does this PR fix or reference?

This PR came up after discussion in PR  #35893. So it removes the root cause of the regression.

It also conflicts with PR #35897, differences are:
- this PR takes care about EC2 and GCE cloud modules by updating paths where too
- loads Salt Cloud default config options dict and overrides them from the config file (as it should be implemented AFAIU)
- reads `cloud` configuration file from provided path instead of always using default configuration directory
