### PR TITLE
Avoid traceback in mac_user.py when user.chhome is invoked from a user state

### DIFF
--- a/salt/modules/mac_user.py
+++ b/salt/modules/mac_user.py
@@ -272,7 +272,7 @@ def chshell(name, shell):
     return info(name).get('shell') == shell
 
 
-def chhome(name, home):
+def chhome(name, home, **kwargs):
     '''
     Change the home directory of the user
 
@@ -282,6 +282,13 @@ def chhome(name, home):
 
         salt '*' user.chhome foo /Users/foo
     '''
+    kwargs = salt.utils.clean_kwargs(**kwargs)
+    persist = kwargs.pop('persist', False)
+    if kwargs:
+        salt.utils.invalid_kwargs(kwargs)
+    if persist:
+        log.info('Ignoring unsupported \'persist\' argument to user.chhome')
+
     pre_info = info(name)
     if not pre_info:
         raise CommandExecutionError('User {0!r} does not exist'.format(name))

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -259,10 +259,15 @@ def present(name,
         This also the location of the home directory to create if createhome is
         set to True.
 
-    createhome
-        If False, the home directory will not be created if it doesn't exist.
-        Please note that directories leading up to the home directory
-        will NOT be created, Default is ``True``.
+    createhome : True
+        If set to ``False``, the home directory will not be created if it
+        doesn't already exist.
+
+        .. warning::
+            Not supported on Windows or Mac OS.
+
+            Additionally, parent directories will *not* be created. The parent
+            directory for ``home`` must already exist.
 
     password
         A password hash to set for the user. This field is only supported on


### PR DESCRIPTION
`persist`-like behavior is not supported in MacOS, so just log that the argument is being skipped. Raise an exception when a kwarg other than persist is passed. This method keeps the `persist` arg out of the function definition and thus out of the documentation, so that a user doesn't get the idea that this is a supported option.

This pull request also removes our attempt to manually implement `persist` behavior in Windows. This ~~feature~~ argument is supported as part of user management on UNIX/Linux, so we support it there, but we should not be manually moving around people's files trying to implement behavior that is not natural to Windows/MacOS.