### PR TITLE
Returning if value is none doesn't populate changes dictionary

### DIFF
--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -85,7 +85,6 @@ def present(name, value=None, delimiter=DEFAULT_TARGET_DELIM, force=False):
             ret['comment'] = 'Grain is not present'
         else:
             ret['comment'] = 'Grain is present'
-        return ret
     if existing == value:
         ret['comment'] = 'Grain is already set'
         return ret


### PR DESCRIPTION
### What does this PR do?

Properly populates changes dictionary. Returning too early does not populate it. 
### What issues does this PR fix or reference?

Failing test on develop
### Tests written?

Yes
