### PR TITLE
Fix grains to be backwards compatible

### DIFF
--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -85,7 +85,6 @@ def present(name, value=None, delimiter=DEFAULT_TARGET_DELIM, force=False):
             ret['comment'] = 'Grain is not present'
         else:
             ret['comment'] = 'Grain is present'
-        return ret
     if existing == value:
         ret['comment'] = 'Grain is already set'
         return ret

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -80,11 +80,13 @@ def present(name, value=None, delimiter=DEFAULT_TARGET_DELIM, force=False):
     _non_existent = object()
     existing = __salt__['grains.get'](name, _non_existent)
     if value is None:
+        ret = __salt__['grains.set'](name, value, force=force)
         if existing is _non_existent:
             ret['result'] = False
             ret['comment'] = 'Grain is not present'
         else:
-            ret['comment'] = 'Grain is present'
+            if not ret['comment']:
+                ret['comment'] = 'Grain is present'
     if existing == value:
         ret['comment'] = 'Grain is already set'
         return ret

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -87,6 +87,7 @@ def present(name, value=None, delimiter=DEFAULT_TARGET_DELIM, force=False):
         else:
             if not ret['comment']:
                 ret['comment'] = 'Grain is present'
+        return ret
     if existing == value:
         ret['comment'] = 'Grain is already set'
         return ret

--- a/tests/unit/states/grains_test.py
+++ b/tests/unit/states/grains_test.py
@@ -88,7 +88,7 @@ class GrainsTestCase(TestCase):
             value=None)
         self.assertEqual(ret['result'], True)
         self.assertEqual(ret['comment'], 'Grain is present')
-        self.assertEqual(ret['changes'], {})
+        self.assertEqual(ret['changes'], {'foo': None})
 
         # Grain not present
         self.setGrains({'a': 'aval'})
@@ -97,7 +97,7 @@ class GrainsTestCase(TestCase):
             value=None)
         self.assertEqual(ret['result'], False)
         self.assertEqual(ret['comment'], 'Grain is not present')
-        self.assertEqual(ret['changes'], {})
+        self.assertEqual(ret['changes'], {'foo': None})
 
     def test_present_add(self):
         # Set a non existing grain


### PR DESCRIPTION
### What does this PR do?

Fixes failing tests and allows the changes made to the grains state in #33010 to be backwards compatible. 
### What issues does this PR fix or reference?

Failing tests. 
### Tests written?

Yes
