### PR TITLE
Catch CommandExecutionError when the group in group_installed doesn't exist

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -2268,7 +2268,13 @@ def group_installed(name, skip=None, include=None, **kwargs):
             if not isinstance(item, six.string_types):
                 include[idx] = str(item)
 
-    diff = __salt__['pkg.group_diff'](name)
+    try:
+        diff = __salt__['pkg.group_diff'](name)
+    except CommandExecutionError as err:
+        ret['comment'] = ('An error was encountered while installing/updating '
+                          'group \'{0}\': {1}.'.format(name, err))
+        return ret
+
     mandatory = diff['mandatory']['installed'] + \
         diff['mandatory']['not installed']
 

--- a/tests/integration/states/pkg.py
+++ b/tests/integration/states/pkg.py
@@ -596,6 +596,35 @@ class PkgTest(integration.ModuleCase,
                 'Package {0} is already up-to-date'.format(target)
             )
 
+    @requires_system_grains
+    def test_group_installed_handle_missing_package_group(self):
+        '''
+        Tests that a CommandExecutionError is caught and the state returns False when
+        the package group is missing. Before this fix, the state would stacktrace.
+        See Issue #35819 for bug report.
+        '''
+        # Skip test if package manager not available
+        if not pkgmgr_avail(self.run_function, self.run_function('grains.items')):
+            self.skipTest('Package manager is not available')
+
+        # Group install not available message
+        grp_install_msg = 'pkg.group_install not available for this platform'
+
+        # Run the pkg.group_installed state with a fake package group
+        ret = self.run_state('pkg.group_installed', name='handle_missing_pkg_group',
+                             skip='foo-bar-baz')
+        ret_comment = ret['pkg_|-handle_missing_pkg_group_|-handle_missing_pkg_group_|-group_installed']['comment']
+
+        # Not all package managers support group_installed. Skip this test if not supported.
+        if ret_comment == grp_install_msg:
+            self.skipTest(grp_install_msg)
+
+        # Test state should return False and should have the right comment
+        self.assertSaltFalseReturn(ret)
+        self.assertEqual(ret_comment, 'An error was encountered while installing/updating group '
+                                      '\'handle_missing_pkg_group\': Group \'handle_missing_pkg_group\' '
+                                      'not found.')
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(PkgTest)

--- a/tests/integration/states/pkg.py
+++ b/tests/integration/states/pkg.py
@@ -597,7 +597,7 @@ class PkgTest(integration.ModuleCase,
             )
 
     @requires_system_grains
-    def test_group_installed_handle_missing_package_group(self):
+    def test_group_installed_handle_missing_package_group(self, grains=None):  # pylint: disable=unused-argument
         '''
         Tests that a CommandExecutionError is caught and the state returns False when
         the package group is missing. Before this fix, the state would stacktrace.


### PR DESCRIPTION
### What does this PR do?

Includes an integration test to make sure this doesn't regress.
### What issues does this PR fix or reference?

Fixes #35819
### Previous Behavior

When using a `pkg.group_installed` state, like this:

```
test-group-installed:
  pkg.group_installed:
    - skip:
      - admin-tools
```

and the group doesn't exist, it would stack trace:

```
ERROR   ] An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/state.py", line 1733, in call
    **cdata['kwargs'])
  File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1651, in wrapper
    return f(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/salt/states/pkg.py", line 2231, in group_installed
    diff = __salt__['pkg.group_diff'](name)
  File "/usr/lib/python2.7/site-packages/salt/modules/yumpkg.py", line 1899, in group_diff
    group_pkgs = group_info(name, expand=True)
  File "/usr/lib/python2.7/site-packages/salt/modules/yumpkg.py", line 1863, in group_info
    expanded = group_info(line, expand=True)
  File "/usr/lib/python2.7/site-packages/salt/modules/yumpkg.py", line 1839, in group_info
    raise CommandExecutionError('Group \'{0}\' not found'.format(name))
CommandExecutionError: Group 'admin-tools' not found
```
### New Behavior

The stacktrace is cleaned up and the state returns False with the error in the comment:

```
[ERROR   ] An error was encountered while installing/updating group 'test-group-installed': Group 'test-group-installed' not found
local:
----------
          ID: test-group-installed
    Function: pkg.group_installed
      Result: False
     Comment: An error was encountered while installing/updating group 'test-group-installed': Group 'test-group-installed' not found
     Started: 17:40:20.114296
    Duration: 3732.036 ms
     Changes:

Summary for local
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:   3.732 s
```
### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
