### PR TITLE
Bump fire_event deprecation warning version from Nitrogen to Oxygen

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1729,7 +1729,7 @@ def fire_event(key, msg, tag, args=None, sock_dir=None, transport='zeromq'):
     # Fire deploy action
     if sock_dir is None:
         salt.utils.warn_until(
-            'Nitrogen',
+            'Oxygen',
             '`salt.utils.cloud.fire_event` requires that the `sock_dir`'
             'parameter be passed in when calling the function.'
         )


### PR DESCRIPTION
This deprecated was made only a month or two ago in develop. We need at least 2 feature release versions for deprecations.

Refs #34870
