### PR TITLE
Allow filtering in Thorium file.save

### DIFF
--- a/salt/thorium/file.py
+++ b/salt/thorium/file.py
@@ -1,6 +1,37 @@
 # -*- coding: utf-8 -*-
 '''
 Writes matches to disk to verify activity, helpful when testing
+
+Normally this is used by giving the name of the file (without a path) that the
+data will be saved to. If for instance you use ``foo`` as the name:
+
+.. code-block: yaml
+
+    foo:
+      file.save
+
+Then the file will be saved to:
+
+.. code-block: bash
+
+    <salt cachedir>/thorium/saves/foo
+
+You may also provide an absolute path for the file to be saved to:
+
+    /tmp/foo.save:
+        file.save
+
+Files will be saved in JSON format. However, JSON does not support ``set()``s.
+If you are saving a register entry that contains a ``set()``, then it will fail
+to save to JSON format. However, you may pass data through a filter which makes
+it JSON compliant:
+
+    foo:
+      file.save:
+        filter: True
+
+Be warned that if you do this, then the file will be saved, but not in a format
+that can be re-imported into Python.
 '''
 
 # import python libs
@@ -10,9 +41,10 @@ import json
 
 # Import salt libs
 import salt.utils
+from salt.utils import simple_types_filter
 
 
-def save(name):
+def save(name, filter=False):
     '''
     Save the register to <salt cachedir>/thorium/saves/<name>
     '''
@@ -20,10 +52,16 @@ def save(name):
            'changes': {},
            'comment': '',
            'result': True}
-    tgt_dir = os.path.join(__opts__['cachedir'], 'thorium', 'saves')
+    if name.startswith('/'):
+        tgt_dir = name
+    else:
+        tgt_dir = os.path.join(__opts__['cachedir'], 'thorium', 'saves')
     fn_ = os.path.join(tgt_dir, name)
     if not os.path.isdir(tgt_dir):
         os.makedirs(tgt_dir)
     with salt.utils.fopen(fn_, 'w+') as fp_:
-        fp_.write(json.dumps(__reg__))
+        if filter is True:
+            fp_.write(json.dumps(simple_types_filter(__reg__)))
+        else:
+            fp_.write(json.dumps(__reg__))
     return ret


### PR DESCRIPTION
### What does this PR do?

This extends `file.save` to be able to filter data before saving it to a file. However, since this produces a JSON file that will not accurately translate back into something Python-readable, you must explicitly turn that feature on.

Also, you may now specify a full path for the file instead of keeping it in the `cachedir`.

Documentation also added.
### Tests written?

No.