### PR TITLE
Check for (non-)duplicate data dicts

### DIFF
--- a/salt/thorium/reg.py
+++ b/salt/thorium/reg.py
@@ -27,7 +27,10 @@ def set_(name, add, match):
         __reg__[name]['val'] = set()
     for event in __events__:
         if salt.utils.expr_match(event['tag'], match):
-            val = event['data']['data'].get(add)
+            try:
+                val = event['data']['data'].get(add)
+            except KeyError:
+                val = event['data'].get(add)
             if val is None:
                 val = 'None'
             ret['changes'][add] = val
@@ -63,11 +66,15 @@ def list_(name, add, match, stamp=False, prune=0):
         __reg__[name] = {}
         __reg__[name]['val'] = []
     for event in __events__:
+        try:
+            event_data = event['data']['data']
+        except KeyError:
+            event_data = event['data']
         if salt.utils.expr_match(event['tag'], match):
             item = {}
             for key in add:
-                if key in event['data']['data']:
-                    item[key] = event['data']['data'][key]
+                if key in event_data:
+                    item[key] = event_data[key]
                     if stamp is True:
                         item['time'] = event['data']['_stamp']
             __reg__[name]['val'].append(item)


### PR DESCRIPTION
### What does this PR do?

Normally event data is found inside another dict called `data` (`event['data']['data']`). However, you may need to reference information in a field that isn't in that dict.
### Previous Behavior

Referencing data in a field that wasn't in the `data` dict would result in an error.
### New Behavior

Allow the register to search through either `event['data']` or `event['data']['data']`. 
### Tests written?

No.