### PR TITLE
Check for single quote before splitting on single quote

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -874,11 +874,11 @@ def refresh_db():
     for line in out.splitlines():
         if not line:
             continue
-        if line.strip().startswith('Repository'):
+        if line.strip().startswith('Repository') and '\'' in line:
             key = line.split('\'')[1].strip()
             if 'is up to date' in line:
                 ret[key] = False
-        elif line.strip().startswith('Building'):
+        elif line.strip().startswith('Building')  and '\'' in line:
             key = line.split('\'')[1].strip()
             if 'done' in line:
                 ret[key] = True


### PR DESCRIPTION
### What does this PR do?

Prevents an IndexError when zypper outputs warnings on expired keys.  For example,

Retrieving repository 'OpenAttic' metadata ----------------------------------[]
Warning: The gpg key signing file 'repomd.xml' has expired.
  Repository:       OpenAttic  
  Key Name:         filesystems OBS Project filesystems@build.opensuse.org  
  Key Fingerprint:  B1FB5374 87204722 05FA6019 98C97FE7 324E6311  
  Key Created:      Mon 12 May 2014 02:34:19 PM UTC  
  Key Expires:      Wed 20 Jul 2016 02:34:19 PM UTC (EXPIRED)  
  Rpm Name:         gpg-pubkey-324e6311-5370dbeb  
Retrieving repository 'OpenAttic' metadata ...............................[done]
### What issues does this PR fix or reference?

None submitted
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

Signed-off-by: Eric Jackson ejackson@suse.com