### PR TITLE
Add show_template function.

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -386,7 +386,7 @@ def show_template(sls_file, **kwargs):
         return {'error': '"{0}" not found'.format(sls_file)}
 
     if not os.path.isfile(sls_file):
-        return {'error': '"{0}" must be a file'.format(sls_file)}
+        return {'error': '"{0}" not a file'.format(sls_file)}
 
     st_ = salt.state.HighState(__opts__, context=__context__)
 

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -344,6 +344,58 @@ def high(data, test=None, queue=False, **kwargs):
     return ret
 
 
+def show_template(sls_file, **kwargs):
+    '''
+    .. versionadded:: Carbon
+
+    Render yaml/jinja2 template file as a dictionary. This returns the data
+    structure that salt will use when processing the sls file. Useful to verify
+    correct syntax.
+
+    .. note::
+        This function does not ask a master for an SLS file to render but
+        instead directly processes the file at the provided path on the minion.
+
+    Args:
+        sls_file (str): The path to the file to process.
+
+    Returns:
+        dict: A dictionary containing the rendered data or any errors
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' state.show_template '<Path to template on the minion>'
+    '''
+    if 'env' in kwargs:
+        salt.utils.warn_until(
+            'Oxygen',
+            'Parameter \'env\' has been detected in the argument list.  This '
+            'parameter is no longer used and has been replaced by \'saltenv\' '
+            'as of Salt Carbon.  This warning will be removed in Salt Oxygen.'
+        )
+        kwargs.pop('env')
+
+    if 'saltenv' in kwargs:
+        saltenv = kwargs['saltenv']
+    else:
+        saltenv = ''
+
+    if not os.path.exists(sls_file):
+        return {'error': '"{0}" not found'.format(sls_file)}
+
+    if not os.path.isfile(sls_file):
+        return {'error': '"{0}" must be a file'.format(sls_file)}
+
+    st_ = salt.state.HighState(__opts__, context=__context__)
+
+    high_state, errors = st_.render_state(
+            sls_file, saltenv, '', None, local=True)
+
+    return high_state, errors
+
+
 def template(tem, queue=False, **kwargs):
     '''
     Execute the information stored in a template file on the minion.

--- a/salt/modules/win_repo.py
+++ b/salt/modules/win_repo.py
@@ -205,7 +205,7 @@ def show_sls(name, saltenv='base'):
     return config
 
 
-def show_template(name, **kwargs):
+def show_template(sls_file, **kwargs):
     '''
     .. versionadded:: Carbon
 
@@ -218,7 +218,7 @@ def show_template(name, **kwargs):
         instead directly processes the file at the provided path on the minion.
 
     Args:
-        name (str): The path to the file to process.
+        sls_file (str): The path to the file to process.
 
     Returns:
         dict: A dictionary containing the rendered data or any errors
@@ -229,4 +229,4 @@ def show_template(name, **kwargs):
 
         salt '*' state.show_template '<Path to template on the minion>'
     '''
-    return __salt__['state.show_template'](name, **kwargs)
+    return __salt__['state.show_template'](sls_file, **kwargs)

--- a/salt/modules/win_repo.py
+++ b/salt/modules/win_repo.py
@@ -203,3 +203,30 @@ def show_sls(name, saltenv='base'):
         config['Error'] = '{0}'.format(exc)
 
     return config
+
+
+def show_template(name, **kwargs):
+    '''
+    .. versionadded:: Carbon
+
+    Render yaml/jinja2 template file as a dictionary. This returns the data
+    structure that salt will use when processing the sls file. Useful to verify
+    correct syntax.
+
+    .. note::
+        This function does not ask a master for an SLS file to render but
+        instead directly processes the file at the provided path on the minion.
+
+    Args:
+        name (str): The path to the file to process.
+
+    Returns:
+        dict: A dictionary containing the rendered data or any errors
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' state.show_template '<Path to template on the minion>'
+    '''
+    return __salt__['state.show_template'](name, **kwargs)

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -1152,8 +1152,10 @@ class StateModuleTest(integration.ModuleCase,
         # Parse the file
         ret = self.run_function('state.show_template', [sls_file])
 
+        self.assertIn('spongebob', ret[0]['bikini-bottom'])
+        self.assertIn('patrick', ret[0]['bikini-bottom'])
         self.assertEqual(
-            ret['bikini-bottom']['patrick']['full_name'], 'patrick star')
+            ret[0]['bikini-bottom']['patrick']['full_name'], 'patrick star')
 
 
 if __name__ == '__main__':

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -1133,14 +1133,13 @@ class StateModuleTest(integration.ModuleCase,
         fd_, sls_file = tempfile.mkstemp()
 
         # Create the content of the yaml/jinja file to test
-        with salt.utils.fopen(state_file, 'w') as fp_:
-            fp_.write(textwrap.dedent('''\
-                bikini-bottom:
-                  {% for first_name, last_name in [('spongebob', 'squarepants'), ('patrick', 'star')] %}
-                  '{{ first_name }}':
-                    full_name: '{{ first_name }} {{ last_name }}'
-                  {% endfor %}
-                '''))
+        fd_.write(textwrap.dedent('''\
+            bikini-bottom:
+              {% for first_name, last_name in [('spongebob', 'squarepants'), ('patrick', 'star')] %}
+              '{{ first_name }}':
+                full_name: '{{ first_name }} {{ last_name }}'
+              {% endfor %}
+            '''))
 
         # Release the handle so it can be removed in Windows
         try:

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 import os
 import shutil
 import textwrap
+import tempfile
 
 # Import Salt Testing libs
 from salttesting import skipIf
@@ -1133,7 +1134,7 @@ class StateModuleTest(integration.ModuleCase,
 
         # Create the content of the yaml/jinja file to test
         with salt.utils.fopen(state_file, 'w') as fp_:
-            fp_.write(textwrap.dedent('''\
+            t
                 bikini-bottom:
                   {% for first_name, last_name in [('spongebob', 'squarepants'), ('patrick', 'star')] %}
                   '{{ first_name }}':

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -1152,7 +1152,7 @@ class StateModuleTest(integration.ModuleCase,
         # Parse the file
         ret = self.run_function('state.show_template', [sls_file])
 
-        self.assertIn(ret['bikini-bottom'], 'spongebob')
+        self.assertIn('spongebob', ret['bikini-bottom'])
         self.assertIn(ret['bikini-bottom'], 'patrick')
         self.assertEqual(
             ret['bikini-bottom']['patrick']['full_name'], 'patrick star')

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -1134,7 +1134,7 @@ class StateModuleTest(integration.ModuleCase,
 
         # Create the content of the yaml/jinja file to test
         with salt.utils.fopen(state_file, 'w') as fp_:
-            t
+            fp_.write(textwrap.dedent('''\
                 bikini-bottom:
                   {% for first_name, last_name in [('spongebob', 'squarepants'), ('patrick', 'star')] %}
                   '{{ first_name }}':

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -1132,21 +1132,22 @@ class StateModuleTest(integration.ModuleCase,
         '''
         fd_, sls_file = tempfile.mkstemp()
 
-        # Create the content of the yaml/jinja file to test
-        fd_.write(textwrap.dedent('''\
-            bikini-bottom:
-              {% for first_name, last_name in [('spongebob', 'squarepants'), ('patrick', 'star')] %}
-              '{{ first_name }}':
-                full_name: '{{ first_name }} {{ last_name }}'
-              {% endfor %}
-            '''))
-
         # Release the handle so it can be removed in Windows
         try:
             os.close(fd_)
         except OSError as exc:
             if exc.errno != errno.EBADF:
                 raise exc
+
+        # Create the content of the yaml/jinja file to test
+        with salt.utils.fopen(sls_file, 'w') as fp_:
+            fp_.write(textwrap.dedent('''\
+                bikini-bottom:
+                  {% for first_name, last_name in [('spongebob', 'squarepants'), ('patrick', 'star')] %}
+                  '{{ first_name }}':
+                    full_name: '{{ first_name }} {{ last_name }}'
+                  {% endfor %}
+                '''))
 
         # Parse the file
         ret = self.run_function('state.show_template', [sls_file])

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -1152,8 +1152,6 @@ class StateModuleTest(integration.ModuleCase,
         # Parse the file
         ret = self.run_function('state.show_template', [sls_file])
 
-        self.assertIn('spongebob', ret['bikini-bottom'])
-        self.assertIn(ret['bikini-bottom'], 'patrick')
         self.assertEqual(
             ret['bikini-bottom']['patrick']['full_name'], 'patrick star')
 


### PR DESCRIPTION
### What does this PR do?

Adds a function that will render the yaml/jinja2 from sls files and display the high data. Can be any file on the minion. It doesn't have to reside in the minion cache.

Function found in execution module `state.show_template`
Created an alias for it in execution module `winrepo.show_template`
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/28898
### Tests written?

Yes

Unable to test because integration tests are broke right now... on Windows
