### PR TITLE
[dockerng] Mention that docker image names must be given with repository

### DIFF
--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -493,6 +493,8 @@ def image_present(name,
     Docker registry, built from a Dockerfile, or loaded from a saved image.
     Image names can be specified either using ``repo:tag`` notation, or just
     the repo name (in which case a tag of ``latest`` is assumed).
+    Repo identifier is mandatory, we don't assume the default repository
+    is docker hub.
 
     If neither of the ``build`` or ``load`` arguments are used, then Salt will
     pull from the :ref:`configured registries <docker-authentication>`. If the


### PR DESCRIPTION
### What does this PR do?

Address problem raised in #35581 
### What issues does this PR fix or reference?
saltstack/salt#35581 and saltstack/salt#35892
### Previous Behavior

was a security risk and faulty
### New Behavior

Document we don't assume the default docker repository is docker hub.
### Tests written?

No