### PR TITLE
Revert "For #31309. If value not supplied only check for existence"

### DIFF
--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -18,7 +18,7 @@ import re
 from salt.defaults import DEFAULT_TARGET_DELIM
 
 
-def present(name, value=None, delimiter=DEFAULT_TARGET_DELIM, force=False):
+def present(name, value, delimiter=DEFAULT_TARGET_DELIM, force=False):
     '''
     Ensure that a grain is set
 
@@ -28,8 +28,7 @@ def present(name, value=None, delimiter=DEFAULT_TARGET_DELIM, force=False):
         The grain name
 
     value
-        The value to set on the grain. If not supplied the grain will only be
-        checked to see that it exists
+        The value to set on the grain
 
     force
         If force is True, the existing grain will be overwritten
@@ -79,13 +78,6 @@ def present(name, value=None, delimiter=DEFAULT_TARGET_DELIM, force=False):
            'comment': ''}
     _non_existent = object()
     existing = __salt__['grains.get'](name, _non_existent)
-    if value is None:
-        if existing is _non_existent:
-            ret['result'] = False
-            ret['comment'] = 'Grain is not present'
-        else:
-            ret['comment'] = 'Grain is present'
-        return ret
     if existing == value:
         ret['comment'] = 'Grain is already set'
         return ret

--- a/tests/unit/states/grains_test.py
+++ b/tests/unit/states/grains_test.py
@@ -78,26 +78,7 @@ class GrainsTestCase(TestCase):
         with open(grains_file, "w+") as grf:
             grf.write(cstr)
 
-    # 'present' function tests: 13
-
-    def test_present_no_value(self):
-        self.setGrains({'a': 'aval', 'foo': 'bar'})
-        # Grain already set
-        ret = grains.present(
-            name='foo',
-            value=None)
-        self.assertEqual(ret['result'], True)
-        self.assertEqual(ret['comment'], 'Grain is present')
-        self.assertEqual(ret['changes'], {})
-
-        # Grain not present
-        self.setGrains({'a': 'aval'})
-        ret = grains.present(
-            name='foo',
-            value=None)
-        self.assertEqual(ret['result'], False)
-        self.assertEqual(ret['comment'], 'Grain is not present')
-        self.assertEqual(ret['changes'], {})
+    # 'present' function tests: 12
 
     def test_present_add(self):
         # Set a non existing grain


### PR DESCRIPTION
After seeing the tests that ended up failing here, I'm still not quite convinced this is ready to go. I'm really concerned that this behavior is going to bite a lot of people and that the net benefit isn't as large in comparison to the potential disruption. 

Reverts saltstack/salt#33010