### PR TITLE
Salt Cloud: add `centos` default user for official CentOS AMIs

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2418,7 +2418,12 @@ def create(vm_=None, call=None):
         vm_,
         __opts__,
         default_users=(
-            'ec2-user', 'ubuntu', 'fedora', 'admin', 'bitnami', 'root'
+            'ec2-user',  # Amazon Linux, Fedora, RHEL; FreeBSD
+            'centos',    # CentOS AMIs from AWS Marketplace
+            'ubuntu',    # Ubuntu
+            'admin',     # Debian GNU/Linux
+            'bitnami',   # BitNami AMIs
+            'root'       # Last resort, default user on RHEL 5, SUSE
         )
     )
 
@@ -3262,6 +3267,7 @@ def list_nodes_full(location=None, call=None):
             get_location(vm_) for vm_ in six.itervalues(__opts__['profiles'])
             if _vm_provider_driver(vm_)
         )
+
         # If there aren't any profiles defined for EC2, check
         # the provider config file, or use the default location.
         if not locations:


### PR DESCRIPTION
### What does this PR do?

It adds `centos` user to the default users list for common EC2 images.
Official CentOS AMIs from AWS Marketplace have the `centos` account configured to perform administrative tasks. SSH login with `root` user is possible, but SFTP file transfers are _not_.
### Previous Behavior

Salt Cloud failed to bootstrap CentOS instances in AWS EC2, it just can't copy files to the host, i.e. generated Minion keys.
### New Behavior

Salt Cloud is able to completely bootstrap CentOS machines in EC2.
### Tests written?

No