### PR TITLE
fixed incorrect change status for the old role policy document for bo…

### DIFF
--- a/salt/states/boto_iam_role.py
+++ b/salt/states/boto_iam_role.py
@@ -266,7 +266,7 @@ def _role_present(
             if updated:
                 msg = 'Assume role policy document updated.'
                 ret['comment'] = '{0} {1}'.format(ret['comment'], msg)
-                ret['changes']['old'] = {'policy_document': policy_document}
+                ret['changes']['old'] = {'policy_document': role['assume_role_policy_document']}
                 ret['changes']['new'] = {'policy_document': _policy_document}
             else:
                 ret['result'] = False


### PR DESCRIPTION
### What does this PR do?

iam_role present state was reporting incorrect old configuration for the role's policy document.
### What issues does this PR fix or reference?

NA
### Previous Behavior

it was always showing the old config as the eventual new config that is set.
### New Behavior

it now shows the old config as reported by aws before changes were applied.
### Tests written?

No, tested manually vs. AWS.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

…to_iam_role.
