### PR TITLE
INFRA-3927 - compare SQS policies as json rather than strings

### DIFF
--- a/salt/states/boto_sqs.py
+++ b/salt/states/boto_sqs.py
@@ -64,6 +64,7 @@ import json
 
 log = logging.getLogger(__name__)
 
+
 def __virtual__():
     '''
     Only load if boto is available.

--- a/salt/states/boto_sqs.py
+++ b/salt/states/boto_sqs.py
@@ -136,7 +136,7 @@ def present(
                     val = json.loads(val)
                 if _val != val:
                     log.debug('Policies differ:\n{0}\n{1}'.format(_val, val))
-                    attrs_to_set[attr] = val
+                    attrs_to_set[attr] = json.dumps(val, sort_keys=True)
             elif str(_val) != str(val):
                 log.debug('Attributes differ:\n{0}\n{1}'.format(_val, val))
                 attrs_to_set[attr] = val

--- a/salt/states/boto_sqs.py
+++ b/salt/states/boto_sqs.py
@@ -59,7 +59,10 @@ passed in as a dict, or as a string to pull from pillars or minion config:
 '''
 from __future__ import absolute_import
 import salt.ext.six as six
+import logging
+import json
 
+log = logging.getLogger(__name__)
 
 def __virtual__():
     '''
@@ -124,7 +127,17 @@ def present(
     if attributes:
         for attr, val in six.iteritems(attributes):
             _val = _attributes.get(attr, None)
-            if str(_val) != str(val):
+            if attr == 'Policy':
+                # Normalize these guys by brute force..
+                if isinstance(_val, six.string_types):
+                    _val = json.loads(_val)
+                if isinstance(val, six.string_types):
+                    val = json.loads(val)
+                if _val != val:
+                    log.debug('Policies differ:\n{0}\n{1}'.format(_val, val))
+                    attrs_to_set[attr] = val
+            elif str(_val) != str(val):
+                log.debug('Attributes differ:\n{0}\n{1}'.format(_val, val))
                 attrs_to_set[attr] = val
     attr_names = ','.join(attrs_to_set)
     if attrs_to_set:


### PR DESCRIPTION
boto_sqs module currently compares policies as strings, even though internally they're json docs.  This leads to unnecessary updates in many situations where AWS itself considers the policies identical.

Fix this by loading any policy docs passed as strings to json first, and then comparing.