### PR TITLE
Load UserProfile when using RunAs (2016.3)

### DIFF
--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -292,12 +292,15 @@ def runas_system(cmd, username, password):
     if '\\' in username:
         domain, username = username.split('\\')
 
-    # Get User Token
+    # Load User and Get Token
     token = win32security.LogonUser(username,
                                     domain,
                                     password,
                                     win32con.LOGON32_LOGON_INTERACTIVE,
                                     win32con.LOGON32_PROVIDER_DEFAULT)
+
+    # Load the User Profile
+    handle_reg = win32profile.LoadUserProfile(token, {'UserName': username})
 
     try:
         # Get Unrestricted Token (UAC) if this is an Admin Account
@@ -394,6 +397,9 @@ def runas_system(cmd, username, password):
 
     # Close handle to process
     win32api.CloseHandle(hProcess)
+
+    # Unload the User Profile
+    win32profile.UnloadUserProfile(token, handle_reg)
 
     return ret
 


### PR DESCRIPTION
### What does this PR do?

Loads the User Profile when using the RunAs feature in Windows. Some parts of the registry needs to be loaded for some installations to work properly.
### What issues does this PR fix or reference?

https://github.com/saltstack/zh/issues/944
### Previous Behavior

Some Installations would fail because they couldn't write to the registry because the UserProfile wasn't being loaded.
### New Behavior

UserProfile is now loaded and installations are successful
### Tests written?

No