### PR TITLE
win_pkg: Allow minion upgrade on batteries and report launch failure

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -698,7 +698,10 @@ def install(name=None, refresh=False, pkgs=None, saltenv='base', **kwargs):
                                          ac_only=False,
                                          stop_if_on_batteries=False)
             # Run Scheduled Task
-            __salt__['task.run_wait'](name='update-salt-software')
+            if not __salt__['task.run_wait'](name='update-salt-software'):
+                log.error('Failed to install {0}'.format(pkg_name))
+                log.error('Scheduled Task failed to run')
+                ret[pkg_name] = {'install status': 'failed'}
         else:
             # Build the install command
             cmd = []
@@ -959,7 +962,10 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
                                          ac_only=False,
                                          stop_if_on_batteries=False)
             # Run Scheduled Task
-            __salt__['task.run_wait'](name='update-salt-software')
+            if not __salt__['task.run_wait'](name='update-salt-software'):
+                log.error('Failed to remove {0}'.format(target))
+                log.error('Scheduled Task failed to run')
+                ret[target] = {'uninstall status': 'failed'}
         else:
             # Build the install command
             cmd = []

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -694,7 +694,9 @@ def install(name=None, refresh=False, pkgs=None, saltenv='base', **kwargs):
                                          start_in=cache_path,
                                          trigger_type='Once',
                                          start_date='1975-01-01',
-                                         start_time='01:00')
+                                         start_time='01:00',
+                                         ac_only=False,
+                                         stop_if_on_batteries=False)
             # Run Scheduled Task
             __salt__['task.run_wait'](name='update-salt-software')
         else:
@@ -953,7 +955,9 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
                                          start_in=cache_path,
                                          trigger_type='Once',
                                          start_date='1975-01-01',
-                                         start_time='01:00')
+                                         start_time='01:00',
+                                         ac_only=False,
+                                         stop_if_on_batteries=False)
             # Run Scheduled Task
             __salt__['task.run_wait'](name='update-salt-software')
         else:


### PR DESCRIPTION
### What does this PR do?
- Modifies the Scheduled Task that launches the minion installer on Windows, so that the running of the install / uninstall action is not blocked when the computer isn't connected to mains power.
- Reports and logs a failure if the Scheduled Task fails to launch (for some other reason)

I've not checked for successful launch of the Scheduled Task, since it only reports it's own success (not the return code of the action it ran). Also, since only the minion service is installed or removed by this method, success will never be reported as the service will have been stopped.
### What issues does this PR fix or reference?
#35943
### Previous Behavior
- Minion cannot be upgraded, downgraded, or uninstalled when running on batteries
- No error or package result is returned
### New Behavior
- Minion can be upgraded, downgraded, or uninstalled when running on batteries
- Report a failure from the module and log that the Scheduled Task didn't launch
### Tests written?

No
