### PR TITLE
Ignore IndexError in refresh_db() for zypper.py. Fixing #33963

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -875,9 +875,12 @@ def refresh_db():
         if not line:
             continue
         if line.strip().startswith('Repository') and '\'' in line:
-            key = line.split('\'')[1].strip()
-            if 'is up to date' in line:
-                ret[key] = False
+            try:
+                key = line.split('\'')[1].strip()
+                if 'is up to date' in line:
+                    ret[key] = False
+            except IndexError:
+                continue
         elif line.strip().startswith('Building') and '\'' in line:
             key = line.split('\'')[1].strip()
             if 'done' in line:


### PR DESCRIPTION
### What does this PR do?

Fixes #33963
### What issues does this PR fix or reference?
#33963
### New Behavior

Ignores lines that start with Repository but not contain the character '.
### Tests written?

No

From the openSUSE machines i have access to, zypper refresh --force only outputs lines that start with the word Repository when an gpg key is about to expire.

```
Forcing raw metadata refresh
Retrieving repository 'monitoring' metadata ..................................................................................................................................................................[done]
Forcing building of repository cache
Building repository 'monitoring' cache .......................................................................................................................................................................[done]
Forcing raw metadata refresh
Retrieving repository 'repo-non-oss' metadata ................................................................................................................................................................[done]
Forcing building of repository cache
Building repository 'repo-non-oss' cache .....................................................................................................................................................................[done]
Forcing raw metadata refresh
Retrieving repository 'repo-oss' metadata ....................................................................................................................................................................[done]
Forcing building of repository cache
Building repository 'repo-oss' cache .........................................................................................................................................................................[done]
Forcing raw metadata refresh
Retrieving repository 'oss-updates' metadata .................................................................................................................................................................[done]
Forcing building of repository cache
Building repository 'oss-updates' cache ......................................................................................................................................................................[done]
Forcing raw metadata refresh
Retrieving repository 'non-oss-update' metadata ..............................................................................................................................................................[done]
Forcing building of repository cache
Building repository 'non-oss-update' cache ...................................................................................................................................................................[done]
Forcing raw metadata refresh
Retrieving repository 'Shell Implementations (openSUSE_Leap_42.1)' metadata -------------------------------------------------------------------------------------------------------------------------------------[\]
The gpg key signing file 'repomd.xml' will expire in 14 days.
  Repository:       Shell Implementations (openSUSE_Leap_42.1)
  Key Name:         shells OBS Project <shells@build.opensuse.org>
  Key Fingerprint:  91A1391C 69563409 D2CD5B34 85CFE451 B91E1E8B
  Key Created:      Tue 08 Jul 2014 12:24:53 PM EDT
  Key Expires:      Thu 15 Sep 2016 12:24:53 PM EDT (expires in 14 days)
  Rpm Name:         gpg-pubkey-b91e1e8b-53bc1b55
Retrieving repository 'Shell Implementations (openSUSE_Leap_42.1)' metadata ..................................................................................................................................[done]
Forcing building of repository cache
Building repository 'Shell Implementations (openSUSE_Leap_42.1)' cache .......................................................................................................................................[done]
Forcing raw metadata refresh
Retrieving repository 'Machinery systems management toolkit (openSUSE_Leap_42.1)' metadata ...................................................................................................................[done]
Forcing building of repository cache
Building repository 'Machinery systems management toolkit (openSUSE_Leap_42.1)' cache ........................................................................................................................[done]
Forcing raw metadata refresh
Retrieving repository 'SaltStack, dependencies, and addons' metadata .........................................................................................................................................[done]
Forcing building of repository cache
Building repository 'SaltStack, dependencies, and addons' cache ..............................................................................................................................................[done]
All repositories have been refreshed.
```

So when the initial test succeeds, it will then fail to extract the repository name.
I am pretty sure the test itself isn't needed since we are forcing the rebuild  of the cache, but maybe an older zypper(8) does output it.
