### PR TITLE
Ensure network config file has trainling newline

### DIFF
--- a/salt/templates/rh_ip/network.jinja
+++ b/salt/templates/rh_ip/network.jinja
@@ -4,4 +4,5 @@
 {%endif%}{% if gateway %}GATEWAY={{gateway}}
 {%endif%}{% if gatewaydev %}GATEWAYDEV={{gatewaydev}}
 {%endif%}{% if nisdomain %}NISDOMAIN={{nisdomain}}
-{%endif%}{% if nozeroconf %}NOZEROCONF={{nozeroconf}}{%endif%}
+{%endif%}{% if nozeroconf %}NOZEROCONF={{nozeroconf}}
+{%endif%}


### PR DESCRIPTION
### What does this PR do?

This PR reformats the template for /etc/sysconfig/network to make sure the file will always
end with a \n newline.
### What issues does this PR fix or reference?

Cosmetic change.
### Previous Behavior

The /etc/sysconfig/network file on RH type machines is currently created
without a trailing newline only if the NOZEROCONF option is set.
In all other cases, the file will end with a newline.
### New Behavior

File will always end with a trailing newline.
### Tests written?

No