### PR TITLE
Set the return code to 1 on salt-ssh highstate errors

### DIFF
--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -318,6 +318,7 @@ def highstate(test=None, **kwargs):
     # Check for errors
     for chunk in chunks:
         if not isinstance(chunk, dict):
+            __context__['retcode'] = 1
             return chunks
     # Create the tar containing the state pkg and relevant files.
     trans_tar = salt.client.ssh.state.prep_trans_tar(


### PR DESCRIPTION
### What does this PR do?

It makes salt-ssh highstate set a non-zero return code on error.
### What issues does this PR fix or reference?
#35964
### Previous Behavior

echo $?
0
### New Behavior

echo $?
1
### Tests written?

No
