### PR TITLE
add onfail multiple test

### DIFF
--- a/tests/integration/files/file/base/requisites/onfail_multiple.sls
+++ b/tests/integration/files/file/base/requisites/onfail_multiple.sls
@@ -1,0 +1,14 @@
+a:
+  cmd.run:
+    - name: exit 0
+
+b:
+  cmd.run:
+    - name: exit 1
+
+c:
+  cmd.run:
+    - name: echo itworked
+    - onfail:
+      - cmd: a
+      - cmd: b

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -1030,6 +1030,21 @@ class StateModuleTest(integration.ModuleCase,
         expected_result = 'State was not run because onfail req did not change'
         self.assertIn(expected_result, test_data)
 
+    def test_multiple_onfail_requisite(self):
+        '''
+        test to ensure state is run even if only one
+        of the onfails fails. This is a test for the issue:
+        https://github.com/saltstack/salt/issues/22370
+        '''
+
+        state_run = self.run_function('state.sls', mods='requisites.onfail_multiple')
+
+        retcode = state_run['cmd_|-c_|-echo itworked_|-run']['changes']['retcode']
+        self.assertEqual(retcode, 0)
+
+        stdout = state_run['cmd_|-c_|-echo itworked_|-run']['changes']['stdout']
+        self.assertEqual(stdout, 'itworked')
+
     def test_onfail_in_requisite(self):
         '''
         Tests a simple state using the onfail_in requisite


### PR DESCRIPTION
### What does this PR do?

Adds a test for this issue: https://github.com/saltstack/salt/issues/22370

This test ensures when using multiple onfail requisites the state runs even if only one requisite fails
### What issues does this PR fix or reference?
saltstack/salt#22370
### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.