### PR TITLE
Fix type error in network module for fbsd osmajorrelease compare

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -385,7 +385,7 @@ def _netstat_route_freebsd():
     out = __salt__['cmd.run'](cmd, python_shell=True)
     for line in out.splitlines():
         comps = line.split()
-        if __grains__['os'] == 'FreeBSD' and __grains__.get('osmajorrelease', 0) < 10:
+        if __grains__['os'] == 'FreeBSD' and int(__grains__.get('osmajorrelease', 0)) < 10:
             ret.append({
                 'addr_family': 'inet',
                 'destination': comps[0],


### PR DESCRIPTION
### What does this PR do?

Add type conversion so we can do a valid integer compare
### What issues does this PR fix or reference?

Fixes PR saltstack/salt#35325 
### Previous Behavior

The code compared a String from the osmajorrelease grain to an int.  This will always return false, which means fbsd > 10 is now happy, but the older releases are not.
### New Behavior

The logic does the right thing and uses the 'if' codepath on fbsd < 10
### Tests written?

No