### PR TITLE
If we get an error from the Linode API, return it

### DIFF
--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -438,7 +438,7 @@ def create(vm_):
             )
             return False
 
-    if 'ERRORARRAY' in result and len(result['ERRORARRAY']) > 0:
+    if 'ERRORARRAY' in result:
         for error_data in result['ERRORARRAY']:
             log.error('Error creating {0} on Linode\n\n'
                     'The Linode API returned the following: {1}\n'.format(

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -438,6 +438,16 @@ def create(vm_):
             )
             return False
 
+    if 'ERRORARRAY' in result and len(result['ERRORARRAY']) > 0:
+        for error_data in result['ERRORARRAY']:
+            log.error('Error creating {0} on Linode\n\n'
+                    'The Linode API returned the following: {1}\n'.format(
+                        name,
+                        error_data['ERRORMESSAGE']
+                        )
+                    )
+            return False
+
     __utils__['cloud.fire_event'](
         'event',
         'requesting instance',
@@ -446,7 +456,6 @@ def create(vm_):
         sock_dir=__opts__['sock_dir'],
         transport=__opts__['transport']
     )
-
     node_id = _clean_data(result)['LinodeID']
     data['id'] = node_id
 


### PR DESCRIPTION
If Linode returned an error when attempting to provision a VM, we did not attempt to detect it and instead continued until we eventually stacktraced. This prevented the use from actually seeing the problem.

This now returns a clean error to the user and returns instead of continuing.