### PR TITLE
Be more careful when processing output.

### DIFF
--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -36,14 +36,20 @@ def try_printout(data, out, opts):
     fall back to nested and then to raw
     '''
     try:
-        return get_printout(out, opts)(data).rstrip()
-    except (KeyError, AttributeError):
+        printout = get_printout(out, opts)(data)
+        if printout is not None:
+            return printout.rstrip()
+    except (KeyError, AttributeError, TypeError):
         log.debug(traceback.format_exc())
         try:
-            return get_printout('nested', opts)(data).rstrip()
-        except (KeyError, AttributeError):
+            printout = get_printout('nested', opts)(data)
+            if printout is not None:
+                return printout.rstrip()
+        except (KeyError, AttributeError, TypeError):
             log.error('Nested output failed: ', exc_info=True)
-            return get_printout('raw', opts)(data).rstrip()
+            printout = get_printout('raw', opts)(data)
+            if printout is not None:
+                return printout.rstrip()
 
 
 def get_progress(opts, out, progress):

--- a/salt/output/yaml_out.py
+++ b/salt/output/yaml_out.py
@@ -20,6 +20,7 @@ Example output::
 from __future__ import absolute_import
 
 # Import third party libs
+import logging
 import yaml
 
 # Import salt libs
@@ -27,6 +28,8 @@ from salt.utils.yamldumper import OrderedDumper
 
 # Define the module's virtual name
 __virtualname__ = 'yaml'
+
+log = logging.getLogger(__name__)
 
 
 def __virtual__():
@@ -49,4 +52,9 @@ def output(data):
     else:  # no indentation
         params.update(default_flow_style=True,
                       indent=0)
-    return yaml.dump(data, **params)
+    try:
+        return yaml.dump(data, **params)
+    except Exception as exc:
+        import pprint
+        log.exception('Exception {0} encountered when trying to serialize {1}'.format(
+            exc, pprint.pformat(data)))


### PR DESCRIPTION
This handles NoneTypes correctly as well as additional checking for failures from external serializers.