### PR TITLE
Update auth data on reauth.

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1659,6 +1659,12 @@ class Minion(MinionBase):
             tag, data = salt.utils.event.MinionEvent.unpack(package)
             log.debug('Forwarding salt error event tag={tag}'.format(tag=tag))
             self._fire_master(data, tag)
+        elif package.startswith('salt/auth/creds'):
+            tag, data = salt.utils.event.MinionEvent.unpack(package)
+            key = tuple(data['key'])
+            log.debug('Updating auth data for {0}: {1} -> {2}'.format(
+                    key, salt.crypt.AsyncAuth.creds_map.get(key), data['creds']))
+            salt.crypt.AsyncAuth.creds_map[tuple(data['key'])] = data['creds']
 
     def _fallback_cleanups(self):
         '''

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -581,7 +581,7 @@ class SaltEvent(object):
             self.opts['max_event_size'],
             is_msgpacked=True,
         )
-        log.debug('Sending event - data = {0}'.format(data))
+        log.debug('Sending event: tag = {0}; data = {1}'.format(tag, data))
         event = '{0}{1}{2}'.format(tag, tagend, serialized_data)
         try:
             self.push.send(salt.utils.to_bytes(event, 'utf-8'))


### PR DESCRIPTION
### What does this PR do?

If minion reauth in a subprocess, like scheduler jobs, update the auth
data in the main process by sending and handling a local event.

### What issues does this PR fix or reference?
saltstack/salt#28462

### Tests written?
No