### PR TITLE
Suse Useradd test fix

### DIFF
--- a/tests/integration/modules/useradd.py
+++ b/tests/integration/modules/useradd.py
@@ -67,7 +67,7 @@ class UseraddModuleTestLinux(integration.ModuleCase):
 
         try:
             uinfo = self.run_function('user.info', [uname])
-            if grains['os_family'] in ('SUSE',):
+            if grains['os_family'] in ('Suse',):
                 self.assertIn('users', uinfo['groups'])
             else:
                 self.assertIn(uname, uinfo['groups'])


### PR DESCRIPTION
### What does this PR do?

Suse os_family is 'Suse' not 'SUSE'. This fixes the test to check for the right os_family grain. 
### What issues does this PR fix or reference?

fixes failing test on jenkins. 
### Tests written?

Yes