### PR TITLE
If windows pkg db hasn't been created yet, refresh the db instead of stacktracing

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -16,7 +16,6 @@ A module to manage software on Windows
 
 # Import python libs
 from __future__ import absolute_import
-import errno
 import os
 import locale
 import logging
@@ -40,7 +39,7 @@ except ImportError:
 import shlex
 
 # Import salt libs
-from salt.exceptions import CommandExecutionError, SaltRenderError
+from salt.exceptions import SaltRenderError
 import salt.utils
 import salt.syspaths
 from salt.exceptions import MinionError

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1061,6 +1061,7 @@ def get_repo_data(saltenv='base'):
     repocache_dir = _get_local_repo_dir(saltenv=saltenv)
     winrepo = 'winrepo.p'
     if not os.path.exists(os.path.join(repocache_dir, winrepo)):
+        log.debug('No winrepo.p cache file. Refresh pkg db now.')
         refresh_db(saltenv=saltenv)
     try:
         with salt.utils.fopen(

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1070,12 +1070,6 @@ def get_repo_data(saltenv='base'):
                 log.exception(exc)
                 return {}
     except IOError as exc:
-        if exc.errno == errno.ENOENT:
-            # File doesn't exist
-            raise CommandExecutionError(
-                'Windows repo cache doesn\'t exist, pkg.refresh_db likely '
-                'needed'
-            )
         log.error('Not able to read repo file')
         log.exception(exc)
         return {}

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1060,6 +1060,8 @@ def get_repo_data(saltenv='base'):
     #    return __context__['winrepo.data']
     repocache_dir = _get_local_repo_dir(saltenv=saltenv)
     winrepo = 'winrepo.p'
+    if not os.path.exists(os.path.join(repocache_dir, winrepo)):
+        refresh_db(saltenv=saltenv)
     try:
         with salt.utils.fopen(
                 os.path.join(repocache_dir, winrepo), 'rb') as repofile:


### PR DESCRIPTION
### What does this PR do?

If the windows pkg db hasn't been created yet, let's refresh the db and keep going instead of stacktracing.
### What issues does this PR fix or reference?

ZD932
### Previous Behavior

If the windows pkg db hadn't been created yet, then the minion would stacktrace
### New Behavior

refresh the db and attempt to install the pkg instead of stacktracing
### Tests written?

No
